### PR TITLE
perf(graph): patch the live graph in place instead of rebuilding sigma on every save

### DIFF
--- a/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
@@ -489,5 +489,155 @@ describe('GraphCanvas', () => {
 
       expect(graph.getNodeAttribute('note-a', 'x')).toBe(before)
     })
+
+    it('leaves no graph listeners behind on unmount', () => {
+      const { graph, unmount } = renderLive()
+      unmount()
+
+      for (const event of ['nodeAdded', 'nodeDropped', 'edgeAdded', 'edgeDropped']) {
+        expect(graph.listenerCount(event)).toBe(0)
+      }
+    })
+  })
+
+  describe('incremental data updates', () => {
+    const noteC: GraphDataResponse['nodes'][number] = {
+      id: 'note-c',
+      type: 'note',
+      label: 'Gamma',
+      tags: [],
+      wordCount: 10,
+      connectionCount: 1,
+      emoji: null,
+      color: '#555555',
+      isOrphan: false,
+      isUnresolved: false
+    }
+
+    function renderWith(
+      next: GraphDataResponse,
+      graphSettings: GraphSettings = settings
+    ): { rerender: (data: GraphDataResponse) => void; unmount: () => void } {
+      const { rerender, unmount } = render(
+        <GraphCanvas
+          data={next}
+          filterState={filters}
+          graphSettings={graphSettings}
+          onFocusNode={vi.fn()}
+        />
+      )
+      return {
+        rerender: (updated) =>
+          rerender(
+            <GraphCanvas
+              data={updated}
+              filterState={filters}
+              graphSettings={graphSettings}
+              onFocusNode={vi.fn()}
+            />
+          ),
+        unmount
+      }
+    }
+
+    function liveGraph(): any {
+      return graphCanvasMocks.sigmaContainerProps?.graph
+    }
+
+    it('keeps the same graph instance so sigma is never recreated', () => {
+      const { rerender } = renderWith(data)
+      const graph = liveGraph()
+
+      rerender({ nodes: [...data.nodes, noteC], edges: data.edges })
+
+      expect(liveGraph()).toBe(graph)
+      expect(graph.hasNode('note-c')).toBe(true)
+    })
+
+    it('removes a deleted note and its edges from the live graph', () => {
+      const { rerender } = renderWith(data)
+      const graph = liveGraph()
+      expect(graph.hasEdge('note-a-task-1-task-note')).toBe(true)
+
+      rerender({
+        nodes: data.nodes.filter((node) => node.id !== 'task-1'),
+        edges: data.edges.filter((edge) => edge.target !== 'task-1')
+      })
+
+      expect(liveGraph()).toBe(graph)
+      expect(graph.hasNode('task-1')).toBe(false)
+      expect(graph.hasEdge('note-a-task-1-task-note')).toBe(false)
+    })
+
+    it('renames a node in the live graph', () => {
+      const { rerender } = renderWith(data)
+      const graph = liveGraph()
+
+      rerender({
+        nodes: data.nodes.map((node) =>
+          node.id === 'note-a' ? { ...node, label: 'Renamed' } : node
+        ),
+        edges: data.edges
+      })
+
+      expect(liveGraph()).toBe(graph)
+      expect(graph.getNodeAttribute('note-a', 'label')).toBe('Renamed')
+    })
+
+    it('adds and removes links in the live graph', () => {
+      const { rerender } = renderWith(data)
+      const graph = liveGraph()
+
+      rerender({
+        nodes: data.nodes,
+        edges: [
+          ...data.edges,
+          { id: 'edge-b-ghost', source: 'note-b', target: 'ghost', type: 'wikilink', weight: 1 }
+        ]
+      })
+      expect(graph.hasEdge('note-b-ghost-wikilink')).toBe(true)
+
+      rerender({ nodes: data.nodes, edges: data.edges })
+      expect(graph.hasEdge('note-b-ghost-wikilink')).toBe(false)
+      expect(liveGraph()).toBe(graph)
+    })
+
+    it('does not re-simulate when a save changes nothing structural', () => {
+      const live: GraphSettings = { ...settings, layout: 'forceatlas2', animateLayout: true }
+      const { rerender } = renderWith(data, live)
+      for (let i = 0; i < 400; i++) vi.advanceTimersToNextFrame()
+      const settledX = liveGraph().getNodeAttribute('note-a', 'x')
+
+      rerender({
+        nodes: data.nodes.map((node) => ({ ...node, tags: [...node.tags] })),
+        edges: data.edges.map((edge) => ({ ...edge }))
+      })
+      for (let i = 0; i < 5; i++) vi.advanceTimersToNextFrame()
+
+      expect(liveGraph().getNodeAttribute('note-a', 'x')).toBe(settledX)
+    })
+
+    it('reheats the settled simulation when a node appears', () => {
+      const live: GraphSettings = { ...settings, layout: 'forceatlas2', animateLayout: true }
+      const { rerender } = renderWith(data, live)
+      for (let i = 0; i < 400; i++) vi.advanceTimersToNextFrame()
+      const graph = liveGraph()
+      const settledX = graph.getNodeAttribute('note-a', 'x')
+
+      rerender({
+        nodes: [...data.nodes, noteC],
+        edges: [
+          ...data.edges,
+          { id: 'edge-a-c', source: 'note-a', target: 'note-c', type: 'wikilink', weight: 1 }
+        ]
+      })
+      vi.advanceTimersToNextFrame()
+      const afterFirstFrame = graph.getNodeAttribute('note-a', 'x')
+      for (let i = 0; i < 20; i++) vi.advanceTimersToNextFrame()
+
+      expect(afterFirstFrame).not.toBe(settledX)
+      // Without the reheat the loop parks itself again after that single tick.
+      expect(graph.getNodeAttribute('note-a', 'x')).not.toBe(afterFirstFrame)
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/components/graph/graph-canvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-canvas.tsx
@@ -5,7 +5,12 @@ import '@react-sigma/core/lib/style.css'
 import type Graph from 'graphology'
 import type { GraphDataResponse } from '@memry/contracts/graph-api'
 import type { NodeDisplayData, EdgeDisplayData } from 'sigma/types'
-import { buildGraphologyGraph, computeFocusSet, type BuildGraphOptions } from '@/lib/graph-builder'
+import {
+  buildGraphologyGraph,
+  computeFocusSet,
+  syncGraphologyGraph,
+  type BuildGraphOptions
+} from '@/lib/graph-builder'
 import { LivePhysics, SettledPhysics, type PhysicsHandle } from './physics-layout'
 import type { GraphFilterState } from '@/hooks/use-graph-filters'
 import type { GraphSettings } from '@memry/contracts/graph-api'
@@ -98,16 +103,15 @@ export function GraphCanvas({
     [graphSettings.showTagEdges]
   )
 
-  const graph = useMemo(
-    () => buildGraphologyGraph(data, graphBuildOptions),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [data, graphBuildOptions, resolvedTheme]
-  )
+  const { graph, revision } = useLiveGraph(data, graphBuildOptions, resolvedTheme)
 
   const focusVisibleSet = useMemo(() => {
     if (!filterState.focusNodeId) return null
     return computeFocusSet(graph, filterState.focusNodeId, filterState.focusDepth)
-  }, [graph, filterState.focusNodeId, filterState.focusDepth])
+    // `revision` is not read here — it marks the patch that changed the topology
+    // this focus neighbourhood is derived from.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [graph, revision, filterState.focusNodeId, filterState.focusDepth])
 
   const searchLower = useMemo(
     () => filterState.searchQuery.toLowerCase(),
@@ -267,6 +271,7 @@ export function GraphCanvas({
           layout={graphSettings.layout}
           animate={graphSettings.animateLayout}
           graph={graph}
+          revision={revision}
           physicsHandleRef={physicsHandleRef}
         />
         <GraphEvents
@@ -292,6 +297,51 @@ export function GraphCanvas({
       )}
     </div>
   )
+}
+
+/**
+ * One graphology instance for the lifetime of the canvas, patched in place as
+ * data arrives.
+ *
+ * `SigmaContainer` recreates Sigma — and with it the WebGL context — whenever the
+ * `graph` prop changes identity, and the layout restarts from a cold alpha. Every
+ * note or task save invalidates the graph query, so rebuilding here meant a
+ * renderer teardown and a full re-simulation per keystroke-debounce. Only a
+ * remount (vault switch, tab close, reload) builds a fresh graph now.
+ */
+function useLiveGraph(
+  data: GraphDataResponse,
+  options: BuildGraphOptions,
+  themeKey: string | undefined
+): { graph: Graph; revision: number } {
+  const [graph] = useState(() => buildGraphologyGraph(data, options))
+  const [revision, setRevision] = useState(0)
+  const appliedRef = useRef({ data, options, themeKey })
+
+  /* eslint-disable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change,
+     react-you-might-not-need-an-effect/no-event-handler,
+     react-you-might-not-need-an-effect/no-chain-state-updates -- genuine external sync: the
+     graphology instance sigma is bound to is mutated here, and the counter only records that it
+     happened so the layout and the focus set can react. Patching during render would fire
+     graphology's change events mid-render. */
+  useEffect(() => {
+    const applied = appliedRef.current
+    // Nothing has arrived since the graph was built or last patched. `themeKey`
+    // takes part because a theme flip re-resolves the CSS colour variables the
+    // node and edge attributes were built from.
+    if (applied.data === data && applied.options === options && applied.themeKey === themeKey) {
+      return
+    }
+    appliedRef.current = { data, options, themeKey }
+    if (syncGraphologyGraph(graph, data, options).changed) {
+      setRevision((current) => current + 1)
+    }
+  }, [graph, data, options, themeKey])
+  /* eslint-enable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change,
+     react-you-might-not-need-an-effect/no-event-handler,
+     react-you-might-not-need-an-effect/no-chain-state-updates */
+
+  return { graph, revision }
 }
 
 function ContextMenuWithTabAction({
@@ -484,11 +534,13 @@ function LayoutManager({
   layout,
   animate,
   graph,
+  revision,
   physicsHandleRef
 }: {
   layout: GraphSettings['layout']
   animate: boolean
   graph: Graph
+  revision: number
   physicsHandleRef: React.MutableRefObject<PhysicsHandle | null>
 }): React.JSX.Element | null {
   useEffect(() => {
@@ -497,14 +549,15 @@ function LayoutManager({
     } else if (layout === 'random') {
       applyRandomLayout(graph)
     }
-  }, [layout, graph])
+    // A patch can add nodes the static layouts have never placed.
+  }, [layout, graph, revision])
 
   if (layout !== 'forceatlas2') return null
 
   return animate ? (
-    <LivePhysics graph={graph} handleRef={physicsHandleRef} />
+    <LivePhysics graph={graph} handleRef={physicsHandleRef} revision={revision} />
   ) : (
-    <SettledPhysics graph={graph} />
+    <SettledPhysics graph={graph} revision={revision} />
   )
 }
 

--- a/apps/desktop/src/renderer/src/components/graph/physics-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/physics-layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useSigma } from '@react-sigma/core'
 import type Graph from 'graphology'
 import { GraphPhysics, type GraphPhysicsOptions } from '@/lib/graph-physics'
@@ -19,16 +19,22 @@ export interface PhysicsHandle {
 export function LivePhysics({
   graph,
   handleRef,
+  revision = 0,
   options
 }: {
   graph: Graph
   handleRef: React.MutableRefObject<PhysicsHandle | null>
+  /** Bumped whenever the graph was patched in place; never remounts the simulation. */
+  revision?: number
   options?: GraphPhysicsOptions
 }): null {
   const sigma = useSigma()
+  const physicsRef = useRef<GraphPhysics | null>(null)
+  const wakeRef = useRef<() => void>(() => {})
 
   useEffect(() => {
     const physics = new GraphPhysics(graph, options)
+    physicsRef.current = physics
     let frame: number | null = null
 
     const step = (): void => {
@@ -43,6 +49,7 @@ export function LivePhysics({
     const wake = (): void => {
       if (frame === null) frame = requestAnimationFrame(step)
     }
+    wakeRef.current = wake
 
     handleRef.current = {
       grab: (nodeId) => {
@@ -64,6 +71,8 @@ export function LivePhysics({
     return () => {
       if (frame !== null) cancelAnimationFrame(frame)
       handleRef.current = null
+      wakeRef.current = () => {}
+      physicsRef.current = null
       physics.destroy()
     }
     // `options` is a static per-call-site literal; re-running on identity would
@@ -71,28 +80,61 @@ export function LivePhysics({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [graph, sigma, handleRef])
 
+  // A save patched the graph while it stayed mounted. Fold the new nodes and
+  // edges into the running simulation and give it just enough energy to absorb
+  // them, instead of throwing the layout away and starting over at alpha 1.
+  useEffect(() => {
+    const physics = physicsRef.current
+    if (!physics?.sync()) return
+    physics.reheat()
+    wakeRef.current()
+  }, [revision])
+
   return null
 }
 
 /** Same forces, run to rest in one pass — the static arrangement when live motion is off. */
 export function SettledPhysics({
   graph,
+  revision = 0,
   options
 }: {
   graph: Graph
+  /** Bumped whenever the graph was patched in place; never remounts the simulation. */
+  revision?: number
   options?: GraphPhysicsOptions
 }): null {
   const sigma = useSigma()
+  const physicsRef = useRef<GraphPhysics | null>(null)
 
   useEffect(() => {
     const physics = new GraphPhysics(graph, options)
-    for (let i = 0; i < SETTLE_TICK_LIMIT && !physics.isSettled; i++) {
-      physics.tick()
-    }
-    physics.destroy()
+    physicsRef.current = physics
+    settle(physics)
     if (sigma.getGraph() === graph) sigma.refresh()
+
+    return () => {
+      physicsRef.current = null
+      physics.destroy()
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [graph, sigma])
 
+  // Structural change on a patched graph: relax from where the nodes already sit
+  // rather than re-deriving the whole arrangement from a cold start.
+  useEffect(() => {
+    const physics = physicsRef.current
+    if (!physics?.sync()) return
+    physics.reheat()
+    settle(physics)
+    if (sigma.getGraph() === graph) sigma.refresh()
+  }, [revision, graph, sigma])
+
   return null
+}
+
+function settle(physics: GraphPhysics): void {
+  for (let i = 0; i < SETTLE_TICK_LIMIT && !physics.isSettled; i++) {
+    physics.tick()
+  }
 }

--- a/apps/desktop/src/renderer/src/hooks/missing-hooks.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/missing-hooks.test.tsx
@@ -689,7 +689,9 @@ describe('state and settings hooks', () => {
       mocks.notesListeners.created()
       mocks.taskListeners.updated()
     })
-    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['graph'] })
+    // The graph refetch is debounced so one save cannot fan out into several.
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ['graph'] })
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: ['graph'] }))
 
     const graphSettings = renderHook(() => useGraphSettings(), { wrapper })
     await waitFor(() => expect(graphSettings.result.current.settings.layout).toBe('force'))

--- a/apps/desktop/src/renderer/src/hooks/use-graph-data.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-graph-data.ts
@@ -27,12 +27,24 @@ export function useLocalGraphData(noteId: string | undefined) {
   })
 }
 
+/**
+ * One save can fire several of these events (the note plus each task it owns),
+ * and each refetch rebuilds the whole graph in the main process. Coalesce them.
+ */
+const GRAPH_INVALIDATE_DEBOUNCE_MS = 250
+
 export function useGraphReactivity(): void {
   const queryClient = useQueryClient()
 
   useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null
+
     const invalidateAll = () => {
-      void queryClient.invalidateQueries({ queryKey: graphKeys.all })
+      if (timer !== null) clearTimeout(timer)
+      timer = setTimeout(() => {
+        timer = null
+        void queryClient.invalidateQueries({ queryKey: graphKeys.all })
+      }, GRAPH_INVALIDATE_DEBOUNCE_MS)
     }
 
     const unsubs = [
@@ -45,6 +57,7 @@ export function useGraphReactivity(): void {
     ]
 
     return () => {
+      if (timer !== null) clearTimeout(timer)
       for (const unsub of unsubs) unsub()
     }
   }, [queryClient])

--- a/apps/desktop/src/renderer/src/lib/graph-builder.test.ts
+++ b/apps/desktop/src/renderer/src/lib/graph-builder.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GraphDataResponse } from '@memry/contracts/graph-api'
 
-import { buildGraphologyGraph, computeFocusSet } from './graph-builder'
+import { buildGraphologyGraph, computeFocusSet, syncGraphologyGraph } from './graph-builder'
 
 const mocks = vi.hoisted(() => ({
   assign: vi.fn()
@@ -143,6 +143,101 @@ describe('graph-builder', () => {
     expect(graph.hasEdge('note-a-tag:shared-entity-tag')).toBe(false)
     expect(graph.getNodeAttribute('note-a', 'color')).toBe('#8c8c8c')
     expect(graph.getEdgeAttribute('note-a-note-b-wikilink', 'color')).toBe('#8c8c8c')
+  })
+
+  describe('syncGraphologyGraph', () => {
+    const gamma: GraphDataResponse['nodes'][number] = {
+      id: 'note-c',
+      type: 'note',
+      label: 'Gamma',
+      tags: [],
+      wordCount: 10,
+      connectionCount: 1,
+      emoji: null,
+      isOrphan: false,
+      isUnresolved: false
+    }
+
+    it('adds new nodes and edges while leaving settled positions alone', () => {
+      const graph = buildGraphologyGraph(graphData)
+      graph.setNodeAttribute('note-a', 'x', 123)
+      graph.setNodeAttribute('note-a', 'y', -45)
+
+      const result = syncGraphologyGraph(graph, {
+        nodes: [...graphData.nodes, gamma],
+        edges: [...graphData.edges, { source: 'note-a', target: 'note-c', type: 'wikilink' }]
+      })
+
+      expect(result).toEqual({ changed: true, structureChanged: true })
+      expect(graph.hasNode('note-c')).toBe(true)
+      expect(graph.hasEdge('note-a-note-c-wikilink')).toBe(true)
+      expect(graph.getNodeAttribute('note-a', 'x')).toBe(123)
+      expect(graph.getNodeAttribute('note-a', 'y')).toBe(-45)
+    })
+
+    it('drops nodes and their edges when they leave the data', () => {
+      const graph = buildGraphologyGraph(graphData)
+
+      const result = syncGraphologyGraph(graph, {
+        nodes: graphData.nodes.filter((node) => node.id !== 'task-1'),
+        edges: graphData.edges
+      })
+
+      expect(result.structureChanged).toBe(true)
+      expect(graph.hasNode('task-1')).toBe(false)
+      expect(graph.hasEdge('note-a-task-1-task-note')).toBe(false)
+      expect(graph.hasNode('note-a')).toBe(true)
+    })
+
+    it('drops an unlinked edge but keeps both endpoints', () => {
+      const graph = buildGraphologyGraph(graphData)
+
+      const result = syncGraphologyGraph(graph, {
+        nodes: graphData.nodes,
+        edges: graphData.edges.filter((edge) => edge.type !== 'task-note')
+      })
+
+      expect(result.structureChanged).toBe(true)
+      expect(graph.hasEdge('note-a-task-1-task-note')).toBe(false)
+      expect(graph.hasNode('task-1')).toBe(true)
+    })
+
+    it('renames a node in place without disturbing the layout', () => {
+      const graph = buildGraphologyGraph(graphData)
+      graph.setNodeAttribute('note-a', 'x', 77)
+
+      const result = syncGraphologyGraph(graph, {
+        nodes: graphData.nodes.map((node) =>
+          node.id === 'note-a' ? { ...node, label: 'Renamed' } : node
+        ),
+        edges: graphData.edges
+      })
+
+      expect(result).toEqual({ changed: true, structureChanged: false })
+      expect(graph.getNodeAttribute('note-a', 'label')).toBe('Renamed')
+      expect(graph.getNodeAttribute('note-a', 'x')).toBe(77)
+    })
+
+    it('reports nothing changed when an identical payload arrives', () => {
+      const graph = buildGraphologyGraph(graphData)
+
+      const result = syncGraphologyGraph(graph, {
+        nodes: graphData.nodes.map((node) => ({ ...node, tags: [...node.tags] })),
+        edges: graphData.edges.map((edge) => ({ ...edge }))
+      })
+
+      expect(result).toEqual({ changed: false, structureChanged: false })
+    })
+
+    it('honours the tag toggle when patching', () => {
+      const graph = buildGraphologyGraph(graphData)
+      expect(graph.hasNode('tag:shared')).toBe(true)
+
+      const result = syncGraphologyGraph(graph, graphData, { showTags: false })
+
+      expect(result.structureChanged).toBe(true)
+      expect(graph.hasNode('tag:shared')).toBe(false)
+    })
   })
 
   it('computes focus neighborhoods by graph distance', () => {

--- a/apps/desktop/src/renderer/src/lib/graph-builder.ts
+++ b/apps/desktop/src/renderer/src/lib/graph-builder.ts
@@ -33,12 +33,27 @@ export interface BuildGraphOptions {
   showTags?: boolean
 }
 
-export function buildGraphologyGraph(
-  data: GraphDataResponse,
-  options: BuildGraphOptions = {}
-): Graph {
+type GraphAttributes = Record<string, unknown>
+
+interface SpecEdge {
+  source: string
+  target: string
+  attributes: GraphAttributes
+}
+
+interface GraphSpec {
+  nodes: Map<string, GraphAttributes>
+  edges: Map<string, SpecEdge>
+}
+
+/** Owned by the force simulation, so a data refresh must never write over them. */
+const LAYOUT_ATTRIBUTES = new Set(['x', 'y'])
+
+/** The shape `data` should have on screen, independent of any existing graph. */
+function buildGraphSpec(data: GraphDataResponse, options: BuildGraphOptions): GraphSpec {
   const { showTags = true } = options
-  const graph = new Graph({ multi: true, type: 'undirected' })
+  const nodes = new Map<string, GraphAttributes>()
+  const edges = new Map<string, SpecEdge>()
 
   const ghostColor = resolveVar('--graph-ghost-node', '#c4c2bc')
 
@@ -63,7 +78,7 @@ export function buildGraphologyGraph(
       ? ghostColor
       : (resolvedNodeColors[node.type] ?? resolvedNodeColors.note)
 
-    graph.addNode(node.id, {
+    nodes.set(node.id, {
       x: Math.cos(angle) * radius,
       y: Math.sin(angle) * radius,
       size: computeNodeSize(node.connectionCount, node.isUnresolved),
@@ -82,33 +97,33 @@ export function buildGraphologyGraph(
   const defaultEdgeColor = resolvedEdgeColors.wikilink
   for (const edge of data.edges) {
     if (edge.type === 'tag-cooccurrence') continue
-    if (graph.hasNode(edge.source) && graph.hasNode(edge.target)) {
-      const edgeKey = `${edge.source}-${edge.target}-${edge.type}`
-      if (!graph.hasEdge(edgeKey)) {
-        graph.addEdgeWithKey(edgeKey, edge.source, edge.target, {
-          size: EDGE_SIZES[edge.type] ?? 1,
-          color: resolvedEdgeColors[edge.type] ?? defaultEdgeColor,
-          edgeType: edge.type,
-          weight: edge.weight
-        })
+    if (!nodes.has(edge.source) || !nodes.has(edge.target)) continue
+    const edgeKey = `${edge.source}-${edge.target}-${edge.type}`
+    if (edges.has(edgeKey)) continue
+    edges.set(edgeKey, {
+      source: edge.source,
+      target: edge.target,
+      attributes: {
+        size: EDGE_SIZES[edge.type] ?? 1,
+        color: resolvedEdgeColors[edge.type] ?? defaultEdgeColor,
+        edgeType: edge.type,
+        weight: edge.weight
       }
-    }
+    })
   }
 
   if (showTags) {
     const tagColor = resolvedNodeColors.tag
     const tagEdgeColor = resolvedEdgeColors['entity-tag']
-    const tagNodeIds = new Map<string, string>()
+    const tagDegrees = new Map<string, number>()
 
     for (const node of data.nodes) {
       for (const tag of node.tags) {
-        let tagNodeId = tagNodeIds.get(tag)
-        if (!tagNodeId) {
-          tagNodeId = `tag:${tag}`
-          tagNodeIds.set(tag, tagNodeId)
+        const tagNodeId = `tag:${tag}`
+        if (!nodes.has(tagNodeId)) {
           const angle = Math.random() * 2 * Math.PI
           const radius = spread * 0.3 + Math.random() * spread * 0.7
-          graph.addNode(tagNodeId, {
+          nodes.set(tagNodeId, {
             x: Math.cos(angle) * radius,
             y: Math.sin(angle) * radius,
             size: 3,
@@ -122,29 +137,140 @@ export function buildGraphologyGraph(
             isOrphan: false,
             isUnresolved: false
           })
+          tagDegrees.set(tagNodeId, 0)
         }
 
         const edgeKey = `${node.id}-${tagNodeId}-entity-tag`
-        if (!graph.hasEdge(edgeKey)) {
-          graph.addEdgeWithKey(edgeKey, node.id, tagNodeId, {
+        if (edges.has(edgeKey)) continue
+        edges.set(edgeKey, {
+          source: node.id,
+          target: tagNodeId,
+          attributes: {
             size: EDGE_SIZES['entity-tag'],
             color: tagEdgeColor,
             edgeType: 'entity-tag',
             weight: 1
-          })
-        }
+          }
+        })
+        tagDegrees.set(tagNodeId, (tagDegrees.get(tagNodeId) ?? 0) + 1)
       }
     }
 
-    for (const [, tagNodeId] of tagNodeIds) {
-      const degree = graph.degree(tagNodeId)
-      const tagSize = degree <= 1 ? 3 : 3 + Math.log2(degree) * 2
-      graph.setNodeAttribute(tagNodeId, 'size', tagSize)
-      graph.setNodeAttribute(tagNodeId, 'connectionCount', degree)
+    for (const [tagNodeId, degree] of tagDegrees) {
+      const attributes = nodes.get(tagNodeId)
+      if (!attributes) continue
+      attributes.size = degree <= 1 ? 3 : 3 + Math.log2(degree) * 2
+      attributes.connectionCount = degree
     }
   }
 
+  return { nodes, edges }
+}
+
+export function buildGraphologyGraph(
+  data: GraphDataResponse,
+  options: BuildGraphOptions = {}
+): Graph {
+  const graph = new Graph({ multi: true, type: 'undirected' })
+  const spec = buildGraphSpec(data, options)
+
+  for (const [id, attributes] of spec.nodes) graph.addNode(id, attributes)
+  for (const [key, edge] of spec.edges) {
+    graph.addEdgeWithKey(key, edge.source, edge.target, edge.attributes)
+  }
+
   return graph
+}
+
+export interface GraphSyncResult {
+  /** Anything at all moved — nodes, edges, or their attributes. */
+  changed: boolean
+  /** Nodes or edges were added or removed, so the layout has to react. */
+  structureChanged: boolean
+}
+
+/**
+ * Fold a fresh `data` payload into a graph that is already on screen.
+ *
+ * Rebuilding the graph would hand `SigmaContainer` a new instance, which kills
+ * the renderer and its WebGL context and restarts the layout from scratch —
+ * once per note save. Patching keeps the same instance (and the same settled
+ * positions) and lets sigma repaint from graphology's own change events.
+ */
+export function syncGraphologyGraph(
+  graph: Graph,
+  data: GraphDataResponse,
+  options: BuildGraphOptions = {}
+): GraphSyncResult {
+  const spec = buildGraphSpec(data, options)
+  let changed = false
+  let structureChanged = false
+
+  for (const key of graph.edges()) {
+    if (spec.edges.has(key)) continue
+    graph.dropEdge(key)
+    structureChanged = true
+  }
+
+  for (const id of graph.nodes()) {
+    if (spec.nodes.has(id)) continue
+    graph.dropNode(id)
+    structureChanged = true
+  }
+
+  for (const [id, attributes] of spec.nodes) {
+    if (!graph.hasNode(id)) {
+      graph.addNode(id, attributes)
+      structureChanged = true
+      continue
+    }
+    const patch = diffAttributes(graph.getNodeAttributes(id), attributes, LAYOUT_ATTRIBUTES)
+    if (patch) {
+      graph.mergeNodeAttributes(id, patch)
+      changed = true
+    }
+  }
+
+  for (const [key, edge] of spec.edges) {
+    if (!graph.hasEdge(key)) {
+      graph.addEdgeWithKey(key, edge.source, edge.target, edge.attributes)
+      structureChanged = true
+      continue
+    }
+    const patch = diffAttributes(graph.getEdgeAttributes(key), edge.attributes)
+    if (patch) {
+      graph.mergeEdgeAttributes(key, patch)
+      changed = true
+    }
+  }
+
+  return { changed: changed || structureChanged, structureChanged }
+}
+
+/** Only the attributes that actually differ, so sigma is not woken for a no-op. */
+function diffAttributes(
+  current: GraphAttributes,
+  next: GraphAttributes,
+  skip?: Set<string>
+): GraphAttributes | null {
+  let patch: GraphAttributes | null = null
+
+  for (const key of Object.keys(next)) {
+    if (skip?.has(key)) continue
+    if (isSameAttribute(current[key], next[key])) continue
+    patch ??= {}
+    patch[key] = next[key]
+  }
+
+  return patch
+}
+
+function isSameAttribute(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, index) => Object.is(item, b[index]))
+  }
+  return false
 }
 
 function computeNodeSize(connectionCount: number, isUnresolved: boolean): number {

--- a/apps/desktop/src/renderer/src/lib/graph-physics.test.ts
+++ b/apps/desktop/src/renderer/src/lib/graph-physics.test.ts
@@ -215,6 +215,94 @@ describe('GraphPhysics', () => {
     expect(graph.getNodeAttribute('a', 'x')).toBe(x)
   })
 
+  describe('sync', () => {
+    it('reports no work when the graph is untouched', () => {
+      const physics = new GraphPhysics(
+        makeGraph([
+          ['a', 0, 0],
+          ['b', 40, 0]
+        ])
+      )
+
+      expect(physics.sync()).toBe(false)
+    })
+
+    it('folds a node added to the graph into the running simulation', () => {
+      const graph = makeGraph([
+        ['a', 0, 0],
+        ['b', 40, 0]
+      ])
+      const physics = new GraphPhysics(graph)
+      settle(physics)
+      graph.addNode('c', { x: 4, y: 4, size: 5 })
+
+      expect(physics.sync()).toBe(true)
+
+      physics.reheat()
+      for (let i = 0; i < 60; i++) physics.tick()
+
+      expect(graph.getNodeAttribute('c', 'x')).not.toBe(4)
+    })
+
+    it('keeps the positions of the nodes that survive a sync', () => {
+      const graph = makeGraph([
+        ['a', 0, 0],
+        ['b', 40, 0]
+      ])
+      const physics = new GraphPhysics(graph)
+      settle(physics)
+      const x = graph.getNodeAttribute('a', 'x') as number
+      const y = graph.getNodeAttribute('a', 'y') as number
+
+      graph.addNode('c', { x: 300, y: 300, size: 5 })
+      physics.sync()
+      physics.tick()
+
+      expect(graph.getNodeAttribute('a', 'x')).toBeCloseTo(x, 6)
+      expect(graph.getNodeAttribute('a', 'y')).toBeCloseTo(y, 6)
+    })
+
+    it('forgets nodes and edges dropped from the graph', () => {
+      const graph = makeGraph(
+        [
+          ['a', 0, 0],
+          ['b', 40, 0]
+        ],
+        [['a', 'b']]
+      )
+      const physics = new GraphPhysics(graph)
+      graph.dropNode('b')
+
+      expect(physics.sync()).toBe(true)
+      expect(() => physics.tick()).not.toThrow()
+    })
+
+    it('picks up a link added between existing nodes', () => {
+      const graph = makeGraph([
+        ['a', -900, 0],
+        ['b', 900, 0]
+      ])
+      const physics = new GraphPhysics(graph)
+      graph.addEdgeWithKey('later', 'a', 'b', { weight: 1 })
+
+      expect(physics.sync()).toBe(true)
+
+      const before = distance(graph, 'a', 'b')
+      for (let i = 0; i < 60; i++) physics.tick()
+
+      expect(distance(graph, 'a', 'b')).toBeLessThan(before)
+    })
+
+    it('does nothing after destroy', () => {
+      const graph = makeGraph([['a', 0, 0]])
+      const physics = new GraphPhysics(graph)
+      physics.destroy()
+      graph.addNode('b', { x: 5, y: 5, size: 5 })
+
+      expect(physics.sync()).toBe(false)
+    })
+  })
+
   it('handles an empty graph without throwing', () => {
     const physics = new GraphPhysics(new Graph())
 

--- a/apps/desktop/src/renderer/src/lib/graph-physics.ts
+++ b/apps/desktop/src/renderer/src/lib/graph-physics.ts
@@ -74,6 +74,8 @@ export class GraphPhysics {
   private readonly nodes: PhysicsNode[] = []
   private readonly nodesById = new Map<string, PhysicsNode>()
   private readonly links: PhysicsLink[] = []
+  /** Edge keys currently modelled, so `sync` can tell a rewire from a no-op. */
+  private linkKeys = new Set<string>()
   private readonly cutoff: number
   private alphaValue = 1
   private alphaTarget = 0
@@ -100,23 +102,7 @@ export class GraphPhysics {
       this.nodesById.set(id, node)
     })
 
-    graph.forEachEdge((edge) => {
-      const [sourceId, targetId] = graph.extremities(edge)
-      // Self-loops collapse to a zero-length spring and blow the solver up.
-      if (sourceId === targetId) return
-      const source = this.nodesById.get(sourceId)
-      const target = this.nodesById.get(targetId)
-      if (!source || !target) return
-      source.degree++
-      target.degree++
-      this.links.push({ source, target, strength: 0, bias: 0 })
-    })
-
-    for (const link of this.links) {
-      const total = link.source.degree + link.target.degree
-      link.strength = 1 / Math.min(link.source.degree, link.target.degree)
-      link.bias = total === 0 ? 0.5 : link.source.degree / total
-    }
+    this.rebuildLinks()
   }
 
   get alpha(): number {
@@ -141,6 +127,61 @@ export class GraphPhysics {
     for (let i = 0; i < COLLIDE_ITERATIONS; i++) this.applyCollision()
 
     this.syncPositions()
+  }
+
+  /**
+   * Reconcile with a graph that was patched in place: nodes that survived keep
+   * their position and velocity, new ones join where the builder seeded them,
+   * dropped ones are forgotten. Returns whether the node or link set actually
+   * moved — an attribute-only refresh is not a reason to reheat.
+   */
+  sync(): boolean {
+    if (this.destroyed) return false
+
+    let structureChanged = false
+    const surviving: PhysicsNode[] = []
+    const present = new Set<string>()
+
+    this.graph.forEachNode((id, attrs) => {
+      present.add(id)
+      let node = this.nodesById.get(id)
+      if (!node) {
+        node = {
+          id,
+          x: (attrs.x as number) ?? 0,
+          y: (attrs.y as number) ?? 0,
+          vx: 0,
+          vy: 0,
+          fx: null,
+          fy: null,
+          radius: 0,
+          degree: 0
+        }
+        this.nodesById.set(id, node)
+        structureChanged = true
+      }
+      node.radius = ((attrs.size as number) ?? 4) * 1.2 + this.settings.collidePadding
+      surviving.push(node)
+    })
+
+    for (const id of this.nodesById.keys()) {
+      if (present.has(id)) continue
+      this.nodesById.delete(id)
+      structureChanged = true
+    }
+
+    this.nodes.length = 0
+    for (const node of surviving) this.nodes.push(node)
+
+    const previousLinkKeys = this.linkKeys
+    this.rebuildLinks()
+
+    if (this.linkKeys.size !== previousLinkKeys.size) return true
+    if (structureChanged) return true
+    for (const key of this.linkKeys) {
+      if (!previousLinkKeys.has(key)) return true
+    }
+    return false
   }
 
   reheat(alpha: number = REHEAT_ALPHA): void {
@@ -178,7 +219,34 @@ export class GraphPhysics {
     this.destroyed = true
     this.nodes.length = 0
     this.links.length = 0
+    this.linkKeys.clear()
     this.nodesById.clear()
+  }
+
+  /** Rederive every spring from the graph's current edges. */
+  private rebuildLinks(): void {
+    this.links.length = 0
+    this.linkKeys = new Set<string>()
+    for (const node of this.nodes) node.degree = 0
+
+    this.graph.forEachEdge((edge) => {
+      const [sourceId, targetId] = this.graph.extremities(edge)
+      // Self-loops collapse to a zero-length spring and blow the solver up.
+      if (sourceId === targetId) return
+      const source = this.nodesById.get(sourceId)
+      const target = this.nodesById.get(targetId)
+      if (!source || !target) return
+      source.degree++
+      target.degree++
+      this.linkKeys.add(edge)
+      this.links.push({ source, target, strength: 0, bias: 0 })
+    })
+
+    for (const link of this.links) {
+      const total = link.source.degree + link.target.degree
+      link.strength = 1 / Math.min(link.source.degree, link.target.degree)
+      link.bias = total === 0 ? 0.5 : link.source.degree / total
+    }
   }
 
   /** Springs pulling each linked pair toward `linkDistance`. */

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -68,6 +68,10 @@ The layout is a live simulation: it arranges itself when the view opens, comes t
 its own, and wakes up again whenever you drag something. Node positions are not saved, so
 each time you open the graph it settles into a fresh arrangement.
 
+Edits made while the graph is open are folded into the arrangement you are looking at. A
+new note or link slides into place and the neighbours shift to make room; nothing else
+moves, and the graph does not rebuild itself from scratch on every save.
+
 Turn the motion off with **Live motion** under the gear icon → **Display** if you prefer a
 still graph — the same forces then run once and stop, which is also the lighter option on
 very large vaults.


### PR DESCRIPTION
Fixes #1015

## Verification (the issue was still real)

`apps/desktop/src/renderer/src/components/graph/graph-canvas.tsx:101-105` on `origin/main`
built a new graphology instance for every `data` identity:

```ts
const graph = useMemo(
  () => buildGraphologyGraph(data, graphBuildOptions),
  [data, graphBuildOptions, resolvedTheme]
)
```

`@react-sigma/core@5.0.6` `SigmaContainer.tsx:92-114` keys its create effect on that prop and
kills the renderer on cleanup:

```ts
useEffect(() => {
  instance = new Sigma(sigGraph, containerRef.current, sigmaSettings)
  ...
  return () => { if (instance) instance.kill() }
}, [containerRef, graph, sigmaSettings])
```

`use-graph-data.ts:33-45` invalidated `graphKeys.all` from six IPC listeners with no debounce, and
`physics-layout.tsx` keyed `new GraphPhysics(graph)` on the same prop, so each save also restarted
the simulation at `alpha = 1` (~300 frames at the default `alphaDecay`). One note save = one WebGL
context destroyed and recreated plus a full re-layout.

## Change

- **`lib/graph-builder.ts`** — the build logic is factored into `buildGraphSpec()` (the shape the
  data *should* have). `buildGraphologyGraph()` applies it to a fresh graph as before; the new
  `syncGraphologyGraph()` reconciles it against a graph that is already on screen: drop what left,
  add what arrived, merge only the attributes that actually differ. `x`/`y` are excluded — the
  simulation owns them. Returns `{ changed, structureChanged }`.
- **`components/graph/graph-canvas.tsx`** — `useLiveGraph()` holds one graphology instance for the
  canvas's lifetime and patches it in an effect, exposing a `revision` counter. `SigmaContainer`
  therefore never sees a new `graph` prop, so Sigma and its WebGL context are created once.
- **`lib/graph-physics.ts`** — new `sync()` reconciles the simulation with a patched graph: surviving
  nodes keep position and velocity, new ones join at their seed, dropped ones are forgotten, springs
  are rederived. Returns whether the node/link set actually moved, so an attribute-only refresh does
  not reheat.
- **`components/graph/physics-layout.tsx`** — `LivePhysics`/`SettledPhysics` take `revision` and, on a
  structural change, `sync()` + `reheat(REHEAT_ALPHA)` instead of restarting from a cold alpha.
- **`hooks/use-graph-data.ts`** — graph query invalidation is debounced 250 ms, so one save (note +
  each task it owns) cannot fan out into several full-graph refetches.
- **`apps/docs/src/user-guide/notes/wiki-links.md`** — one paragraph in *Graph View*.

No new dependencies. The physics stays dependency-free.

### What still forces a real rebuild, and why that is correct

A fresh graph (and therefore a fresh Sigma) is built only when `GraphCanvas` mounts — vault switch,
tab close, route change, full reload. Those are exactly the cases where the previous arrangement is
meaningless, and node positions were never persisted anyway. `LocalGraphPanel` is untouched
(that is #1046).

### Leak check

- `SigmaContainer`'s cleanup still calls `instance.kill()` on unmount; the change only stops the
  effect from re-running, it does not keep an instance past unmount.
- This change adds **zero** listeners. Repaints after a patch come from graphology's own
  `nodeAdded`/`nodeDropped`/`edgeAdded`/`edgeDropped`/`*AttributesUpdated` events, which Sigma binds
  itself in `bindGraphHandlers()` and unbinds in `kill()`. A regression test asserts the graph has no
  leftover listeners after unmount.
- `LivePhysics` still cancels its `requestAnimationFrame` and destroys the simulation on cleanup, and
  now also clears `wakeRef`/`physicsRef` so nothing can reschedule a frame post-unmount. The existing
  "stops the animation loop on unmount" test still passes.
- `SettledPhysics` now keeps its `GraphPhysics` until unmount (it used to `destroy()` inline after the
  first settle) so a structural change can relax from the current positions. That is O(nodes + edges)
  of retained plain objects for a mounted graph, freed in the effect cleanup — traded against a
  400-tick re-settle per save.

## Tests

`apps/desktop/src/renderer/src/lib/graph-builder.test.ts` (+6), `lib/graph-physics.test.ts` (+6),
`components/graph/graph-canvas.test.tsx` (+7). The canvas tests cover create, rename, link, unlink and
delete against the live instance, not just "it did not remount".

Red first, on `origin/main` + tests only — 18 failures, all for the right reason:

```
FAIL: graph-builder syncGraphologyGraph adds new nodes and edges while leaving settled positions alone
    TypeError: __vi_import_0__.syncGraphologyGraph is not a function
FAIL: GraphPhysics sync folds a node added to the graph into the running simulation
    TypeError: physics.sync is not a function
FAIL: GraphCanvas incremental data updates keeps the same graph instance so sigma is never recreated
    AssertionError: expected { order: 7, size: 4, …(13) } to be { order: 6, size: 4, …(13) } // Object.is equality
FAIL: GraphCanvas incremental data updates removes a deleted note and its edges from the live graph
    AssertionError: expected { order: 5, size: 3, …(13) } to be { order: 6, size: 4, …(13) } // Object.is equality
FAIL: GraphCanvas incremental data updates renames a node in the live graph
    AssertionError: expected { order: 6, size: 4, …(13) } to be { order: 6, size: 4, …(13) } // Object.is equality
FAIL: GraphCanvas incremental data updates adds and removes links in the live graph
    AssertionError: expected false to be true // Object.is equality
FAIL: GraphCanvas incremental data updates does not re-simulate when a save changes nothing structural
    AssertionError: expected 54.29931045833721 to be 20.14887346866264 // Object.is equality
FAIL: GraphCanvas incremental data updates reheats the settled simulation when a node appears
    AssertionError: expected 1.7413430500231537 not to be 1.7413430500231537 // Object.is equality
```

Green after the fix: `PASS (83) FAIL (0)` across `components/graph`, `lib/graph-builder.test.ts`,
`lib/graph-physics.test.ts` and `hooks/missing-hooks.test.tsx`.

Mutation-checked, because mocked-Sigma tests are easy to fool:

- Disable `syncGraphologyGraph` in `useLiveGraph` → 5 of the 7 incremental tests fail.
- Drop the `physics.reheat()` in `LivePhysics` → the reheat test *survived* the first version, because
  collision separation is alpha-independent and still nudges nodes for one tick. The test was rewritten
  to assert motion continues past that first frame, and now fails
  (`expected 51.46342657267719 not to be 51.46342657267719`).

`hooks/missing-hooks.test.tsx` was updated for the debounce: it now asserts the invalidation is *not*
synchronous, then waits for it.

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass
- `pnpm lint` — pass, 0 errors / 14 warnings, all pre-existing in files this branch does not touch
  (`tags-hub/*`, `use-folder-view.ts`, `use-tab-keyboard-shortcuts.ts`); `eslint --no-cache` on the
  touched files reports 0 problems
- targeted vitest — `PASS (83) FAIL (0)`, plus `pages/note.test.tsx` `PASS (25) FAIL (0)`
- `npx react-doctor@latest .` — bug-level errors 41 → 40; the only remaining graph findings are the
  pre-existing `effect-raf-loop-needs-cancel` trio (all three do cancel; `local-graph-panel.tsx` is
  untouched and reports the same)
- `pnpm docs:impact --base origin/main --strict` — covered; `pnpm docs:build` — pass
