### PR TITLE
fix(editor): destroy BlockNote editors on unmount; stop remounting the note and journal editors per external update

### DIFF
--- a/apps/desktop/src/renderer/src/components/inbox-detail/inbox-content-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/inbox-content-editor.tsx
@@ -6,6 +6,7 @@
 
 import { memo, useCallback, useEffect, useRef } from 'react'
 import { useCreateBlockNote } from '@blocknote/react'
+import { useEditorTeardown } from '@/hooks/use-editor-teardown'
 import { BlockNoteView } from '@blocknote/shadcn'
 import { useTheme } from 'next-themes'
 
@@ -73,6 +74,9 @@ export const InboxContentEditor = memo(function InboxContentEditor({
       checkListItem: 'To-do item'
     }
   })
+
+  // `useCreateBlockNote` never disposes what it builds.
+  useEditorTeardown(editor)
 
   // Parse and load initial content
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -328,7 +328,10 @@ function resetEditor(): void {
     insertBlocks: vi.fn(),
     getTextCursorPosition: vi.fn(() => ({ block: urlBlock })),
     prosemirrorView: { focus: vi.fn(), dom: { blur: vi.fn() } },
-    _tiptapEditor: { state: { selection: { empty: true, $from: { parentOffset: 0 } } } }
+    _tiptapEditor: {
+      state: { selection: { empty: true, $from: { parentOffset: 0 } } },
+      destroy: vi.fn()
+    }
   }
 }
 
@@ -391,6 +394,88 @@ describe('ContentArea', () => {
       path: 'attachments/file.png'
     })
     resetEditor()
+  })
+
+  it('destroys the editor and releases the window handle when it unmounts', () => {
+    const editor = contentAreaMocks.editor
+    const win = window as unknown as { ProseMirror?: unknown }
+    // `useCreateBlockNote` parks the newest instance here; nothing ever clears it.
+    win.ProseMirror = editor._tiptapEditor
+
+    const { unmount } = render(<ContentArea noteId="note-1" />)
+    expect(editor._tiptapEditor.destroy).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(editor._tiptapEditor.destroy).toHaveBeenCalledTimes(1)
+    expect(win.ProseMirror).toBeUndefined()
+  })
+
+  it('leaves no DOM listener or animation frame behind after unmount', () => {
+    const addEventListener = EventTarget.prototype.addEventListener
+    const removeEventListener = EventTarget.prototype.removeEventListener
+    const requestAnimationFrame = window.requestAnimationFrame
+    const cancelAnimationFrame = window.cancelAnimationFrame
+
+    const live = new Set<string>()
+    const key = (target: EventTarget, type: string, listener: unknown, options: unknown): string =>
+      `${(target as { tagName?: string }).tagName ?? target.constructor.name}:${type}:${
+        (listener as { name?: string })?.name ?? 'anon'
+      }:${typeof options === 'object' ? JSON.stringify(options) : String(options)}`
+
+    // React 19 installs its delegated root listeners on the test container and
+    // deliberately keeps them past unmount — they are the runtime's, not ours.
+    const isReactRootListener = (listener: unknown): boolean =>
+      typeof listener === 'function' && /^bound dispatch/.test(listener.name)
+
+    EventTarget.prototype.addEventListener = function (
+      this: EventTarget,
+      type: string,
+      listener: never,
+      options?: never
+    ) {
+      if (!isReactRootListener(listener)) live.add(key(this, type, listener, options))
+      return addEventListener.call(this, type, listener, options)
+    }
+    EventTarget.prototype.removeEventListener = function (
+      this: EventTarget,
+      type: string,
+      listener: never,
+      options?: never
+    ) {
+      live.delete(key(this, type, listener, options))
+      return removeEventListener.call(this, type, listener, options)
+    }
+
+    const liveFrames = new Set<number>()
+    window.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+      const handle = requestAnimationFrame(callback)
+      liveFrames.add(handle)
+      return handle
+    }
+    window.cancelAnimationFrame = (handle: number): void => {
+      liveFrames.delete(handle)
+      cancelAnimationFrame(handle)
+    }
+
+    try {
+      const { unmount } = render(<ContentArea noteId="note-1" />)
+      live.clear()
+      liveFrames.clear()
+      const { unmount: unmountTracked } = render(<ContentArea noteId="note-2" />)
+      expect(live.size).toBeGreaterThan(0)
+
+      unmountTracked()
+      unmount()
+
+      expect([...live]).toEqual([])
+      expect([...liveFrames]).toEqual([])
+    } finally {
+      EventTarget.prototype.addEventListener = addEventListener
+      EventTarget.prototype.removeEventListener = removeEventListener
+      window.requestAnimationFrame = requestAnimationFrame
+      window.cancelAnimationFrame = cancelAnimationFrame
+    }
   })
 
   it('shows the collaboration loading skeleton while a synced note is not ready', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -52,6 +52,7 @@ import { formatDateKey } from '@/lib/task-utils'
 import { editorSchema } from './editor-schema'
 import { analyzeTaskIntents } from './scan-task-intents'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
+import { useEditorTeardown } from '@/hooks/use-editor-teardown'
 import { useFeatureFlags } from '@/hooks/use-feature-flags'
 import { vaultService } from '@/services/vault-service'
 import { createNoteFileUrlResolver } from '@/lib/create-note-file-url-resolver'
@@ -135,6 +136,7 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
   notePath,
   initialContent,
   contentType = 'html',
+  externalContentRevision,
   placeholder,
   editable = true,
   stickyToolbar = false,
@@ -265,12 +267,13 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
   })
 
   // Hook #2: Content sync (initial load + debounced change handler)
-  const { handleChange } = useEditorSync({
+  const { handleChange, flushPendingMarkdown } = useEditorSync({
     editor,
     noteId,
     notePath,
     initialContent,
     contentType,
+    externalContentRevision,
     yjsFragment,
     isRemoteUpdateRef,
     noteTags,
@@ -283,6 +286,11 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     onHeadingsChange,
     onInlineTagsChange
   })
+
+  // Hook #2b: Explicit teardown. `useCreateBlockNote` never disposes what it
+  // builds, so the editor is destroyed here — after the pending markdown save
+  // has been flushed, since serializing needs a live editor.
+  useEditorTeardown(editor, flushPendingMarkdown)
 
   useEffect(() => {
     onReviewEditorReady?.(editor)

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useEditorSync } from './use-editor-sync'
+import { useEditorTeardown } from '@/hooks/use-editor-teardown'
 import { fetchLinkPreview } from '@/lib/url-metadata'
 
 const blockNoteMocks = vi.hoisted(() => ({
@@ -65,7 +66,8 @@ function createEditor(parsedBlocks: any[] = []) {
       if ('props' in update) block.props = { ...block.props, ...update.props }
     }),
     _tiptapEditor: {
-      state: {}
+      state: {},
+      destroy: vi.fn()
     }
   }
 }
@@ -332,6 +334,123 @@ describe('useEditorSync', () => {
     })
     expect(onInlineTagsChange).toHaveBeenCalledWith(['Build', 'Focus'])
     expect(result.current.prevInlineTagsRef.current).toEqual(['Build', 'Focus'])
+  })
+
+  it('re-applies external content in place when the external revision changes', async () => {
+    const editor = createEditor([
+      { id: 'paragraph-1', type: 'paragraph', props: {}, content: ['Body'], children: [] }
+    ])
+
+    const { rerender } = renderHook(
+      ({ initialContent, externalContentRevision }) =>
+        useEditorSync({
+          editor,
+          initialContent,
+          contentType: 'markdown',
+          externalContentRevision
+        }),
+      { initialProps: { initialContent: 'Body', externalContentRevision: 0 } }
+    )
+
+    await waitFor(() => expect(blockNoteMocks.removeAndInsertBlocks).toHaveBeenCalledTimes(1))
+
+    editor.tryParseMarkdownToBlocks.mockResolvedValue([
+      {
+        id: 'paragraph-2',
+        type: 'paragraph',
+        props: {},
+        content: ['Edited elsewhere'],
+        children: []
+      }
+    ])
+    rerender({ initialContent: 'Edited elsewhere', externalContentRevision: 1 })
+
+    await waitFor(() => expect(blockNoteMocks.removeAndInsertBlocks).toHaveBeenCalledTimes(2))
+    expect(editor.document).toEqual([
+      {
+        id: 'paragraph-2',
+        type: 'paragraph',
+        props: {},
+        content: ['Edited elsewhere'],
+        children: []
+      }
+    ])
+  })
+
+  it('leaves an external revision to the Y.Doc when collaboration is active', async () => {
+    const editor = createEditor([
+      { id: 'paragraph-1', type: 'paragraph', props: {}, content: ['Body'], children: [] }
+    ])
+
+    const { result, rerender } = renderHook(
+      ({ externalContentRevision }) =>
+        useEditorSync({
+          editor,
+          initialContent: 'Body',
+          contentType: 'markdown',
+          yjsFragment: {} as never,
+          externalContentRevision
+        }),
+      { initialProps: { externalContentRevision: 0 } }
+    )
+
+    await waitFor(() => expect(result.current.isContentReadyRef.current).toBe(true))
+
+    rerender({ externalContentRevision: 1 })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // The main process feeds the external edit into the shared Y.Doc, which the
+    // IPC provider merges into this editor. Re-parsing here would clobber that
+    // merge (and any concurrent local edit riding on the same doc).
+    expect(blockNoteMocks.removeAndInsertBlocks).not.toHaveBeenCalled()
+    expect(editor.replaceBlocks).not.toHaveBeenCalled()
+    expect(editor.document).toEqual([
+      { id: 'initial', type: 'paragraph', props: {}, content: [], children: [] }
+    ])
+  })
+
+  it('flushes a pending markdown save before the editor is torn down', async () => {
+    const onMarkdownChange = vi.fn()
+    const editor = createEditor()
+    editor.blocksToMarkdownLossy.mockResolvedValue('Typed just before closing')
+    const typed = [
+      {
+        id: 'paragraph-1',
+        type: 'paragraph',
+        props: {},
+        content: [{ type: 'text', text: 'Typed just before closing', styles: {} }],
+        children: []
+      }
+    ]
+
+    const { result, unmount } = renderHook(() => {
+      const sync = useEditorSync({
+        editor,
+        initialContent: typed as never,
+        contentType: 'blocks',
+        onMarkdownChange
+      })
+      useEditorTeardown(editor, sync.flushPendingMarkdown)
+      return sync
+    })
+
+    await waitFor(() => expect(result.current.isContentReadyRef.current).toBe(true))
+
+    // Type, then close the tab inside the 150ms debounce window.
+    act(() => {
+      result.current.handleChange()
+    })
+    unmount()
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalledTimes(1))
+    expect(onMarkdownChange.mock.calls[0][0]).toContain('Typed just before closing')
+    expect(editor._tiptapEditor.destroy).toHaveBeenCalledTimes(1)
+    expect(onMarkdownChange.mock.invocationCallOrder[0]).toBeLessThan(
+      editor._tiptapEditor.destroy.mock.invocationCallOrder[0]
+    )
   })
 
   it('skips markdown persistence for remote updates and Yjs-backed documents', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
@@ -110,6 +110,13 @@ interface EditorSyncParams {
   initialContent?: Block[] | string
   contentType?: 'html' | 'markdown' | 'blocks'
   yjsFragment?: Y.XmlFragment
+  /**
+   * Bumped by the owner when `initialContent` was replaced by an edit that did
+   * NOT come from this editor (device sync, an on-disk edit, an agent write).
+   * The editor is an uncontrolled component, so without this the content only
+   * loads once per instance and the owner has to remount the whole editor.
+   */
+  externalContentRevision?: number
   isRemoteUpdateRef?: React.RefObject<boolean>
   noteTags?: string[]
   tagColorMap?: Map<string, string>
@@ -122,6 +129,12 @@ interface EditorSyncParams {
 
 interface EditorSyncResult {
   handleChange: () => void
+  /**
+   * Run the debounced markdown save right now instead of waiting for its timer.
+   * Used at teardown so an edit made inside the debounce window still persists
+   * before the editor is destroyed. Resolves once `onMarkdownChange` has run.
+   */
+  flushPendingMarkdown: () => Promise<void>
   isContentReadyRef: React.RefObject<boolean>
   prevInlineTagsRef: React.MutableRefObject<string[]>
   lastNormalizedTagsRef: React.MutableRefObject<string>
@@ -134,6 +147,7 @@ export function useEditorSync({
   initialContent,
   contentType = 'html',
   yjsFragment,
+  externalContentRevision,
   isRemoteUpdateRef,
   noteTags,
   tagColorMap,
@@ -143,7 +157,7 @@ export function useEditorSync({
   onHeadingsChange,
   onInlineTagsChange
 }: EditorSyncParams): EditorSyncResult {
-  const initialContentLoadedRef = useRef(false)
+  const loadedContentRevisionRef = useRef<number | null>(null)
   const isContentReadyRef = useRef(false)
   const prevInlineTagsRef = useRef<string[]>([])
   const lastNormalizedTagsRef = useRef<string>('')
@@ -151,6 +165,8 @@ export function useEditorSync({
   const markdownDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const headingsDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const inlineTagsDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The debounced markdown save, kept callable so teardown can run it early.
+  const pendingMarkdownSaveRef = useRef<(() => Promise<void>) | null>(null)
 
   // Cleanup debounce timers on unmount
   useEffect(() => {
@@ -170,16 +186,31 @@ export function useEditorSync({
     }
   }, [editor, noteId])
 
-  // Parse content on initial mount (uncontrolled component pattern).
+  // Parse content on initial mount (uncontrolled component pattern), and again
+  // whenever the owner reports that `initialContent` was replaced from outside
+  // this editor (`externalContentRevision`). Re-parsing in place is what lets
+  // the owner keep one editor instance alive across external updates instead of
+  // remounting a brand-new one.
   // Cancellation flag + cleanup return mark this as a synchronization effect
   // so the unnecessary-effect lints recognize it as legitimate.
   useEffect(() => {
-    if (initialContentLoadedRef.current) {
+    const revision = externalContentRevision ?? 0
+    if (loadedContentRevisionRef.current === revision) {
       return
     }
-    initialContentLoadedRef.current = true
+    const isExternalReload = loadedContentRevisionRef.current !== null
+    loadedContentRevisionRef.current = revision
 
     let cancelled = false
+
+    // Collaboration owns the document: the main process feeds an external edit
+    // into the shared Y.Doc (`feedExternalEditToCrdt`), the IPC provider applies
+    // it here, and y-prosemirror merges it into this editor in place. Replacing
+    // the blocks from `initialContent` would clobber that merge — including any
+    // edit the user is making concurrently.
+    if (isExternalReload && yjsFragment) {
+      return
+    }
 
     if (yjsFragment) {
       clearYjsUndoHistory(editor)
@@ -278,7 +309,7 @@ export function useEditorSync({
       cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor])
+  }, [editor, externalContentRevision])
 
   // Debounced change handler
   const handleChange = useCallback(() => {
@@ -301,21 +332,22 @@ export function useEditorSync({
       if (markdownDebounceRef.current) {
         clearTimeout(markdownDebounceRef.current)
       }
-      markdownDebounceRef.current = setTimeout(() => {
-        void (async () => {
-          try {
-            const markdown = await serializeBlocksPreservingBlanks(
-              editor,
-              editor.document as Block[]
-            )
+      const save = async (): Promise<void> => {
+        pendingMarkdownSaveRef.current = null
+        try {
+          const markdown = await serializeBlocksPreservingBlanks(editor, editor.document as Block[])
 
-            onMarkdownChange(markdown)
-          } catch (error) {
-            // The debounced save silently stops while the user keeps typing.
-            log.error('Failed to convert blocks to markdown', error)
-            trackRendererError('editor_serialize_save', error)
-          }
-        })()
+          onMarkdownChange(markdown)
+        } catch (error) {
+          // The debounced save silently stops while the user keeps typing.
+          log.error('Failed to convert blocks to markdown', error)
+          trackRendererError('editor_serialize_save', error)
+        }
+      }
+      pendingMarkdownSaveRef.current = save
+      markdownDebounceRef.current = setTimeout(() => {
+        markdownDebounceRef.current = null
+        void save()
       }, 150)
     }
 
@@ -352,5 +384,22 @@ export function useEditorSync({
     onInlineTagsChange
   ])
 
-  return { handleChange, isContentReadyRef, prevInlineTagsRef, lastNormalizedTagsRef }
+  // Teardown hook: run the debounced save now. The unmount cleanup above only
+  // clears the timer, so without this an edit made in the last 150ms before the
+  // tab/journal date closed would never reach `onMarkdownChange`.
+  const flushPendingMarkdown = useCallback(async (): Promise<void> => {
+    if (markdownDebounceRef.current) {
+      clearTimeout(markdownDebounceRef.current)
+      markdownDebounceRef.current = null
+    }
+    await pendingMarkdownSaveRef.current?.()
+  }, [])
+
+  return {
+    handleChange,
+    flushPendingMarkdown,
+    isContentReadyRef,
+    prevInlineTagsRef,
+    lastNormalizedTagsRef
+  }
 }

--- a/apps/desktop/src/renderer/src/components/note/content-area/types.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/types.ts
@@ -96,6 +96,14 @@ export interface ContentAreaProps {
   initialContent?: Block[] | string
   /** Type of content being passed: 'html', 'markdown', or 'blocks' */
   contentType?: 'html' | 'markdown' | 'blocks'
+  /**
+   * Bump this when `initialContent` was replaced by an edit that did not come
+   * from this editor (device sync, an on-disk edit, an agent write). The editor
+   * re-reads `initialContent` in place, so the caller never has to remount it.
+   * Ignored while collaboration is active — the shared Y.Doc already merges the
+   * update into the live editor.
+   */
+  externalContentRevision?: number
   /** Placeholder text when editor is empty */
   placeholder?: string
   /** Whether the editor is read-only */

--- a/apps/desktop/src/renderer/src/components/tasks/task-description-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-description-editor.tsx
@@ -8,6 +8,7 @@
 
 import { memo, useCallback, useEffect, useRef } from 'react'
 import { useCreateBlockNote } from '@blocknote/react'
+import { useEditorTeardown } from '@/hooks/use-editor-teardown'
 import { BlockNoteView } from '@blocknote/shadcn'
 import { useTheme } from 'next-themes'
 
@@ -56,6 +57,9 @@ export const TaskDescriptionEditor = memo(function TaskDescriptionEditor({
       checkListItem: 'To-do item'
     }
   })
+
+  // `useCreateBlockNote` never disposes what it builds.
+  useEditorTeardown(editor)
 
   // Parse and load initial markdown once.
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/hooks/use-editor-teardown.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-editor-teardown.test.ts
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useEditorTeardown } from './use-editor-teardown'
+
+function createEditor() {
+  const listeners = new Map<string, Set<() => void>>()
+  const tiptap = {
+    isDestroyed: false,
+    on(event: string, handler: () => void) {
+      const set = listeners.get(event) ?? new Set()
+      set.add(handler)
+      listeners.set(event, set)
+    },
+    destroy: vi.fn(() => {
+      tiptap.isDestroyed = true
+      listeners.clear()
+    })
+  }
+  return { editor: { _tiptapEditor: tiptap }, tiptap, listeners }
+}
+
+afterEach(() => {
+  delete (window as unknown as { ProseMirror?: unknown }).ProseMirror
+})
+
+describe('useEditorTeardown', () => {
+  it('destroys the editor on unmount and drops its registered listeners', () => {
+    const { editor, tiptap, listeners } = createEditor()
+    tiptap.on('update', () => {})
+    const win = window as unknown as { ProseMirror?: unknown }
+    win.ProseMirror = tiptap
+
+    const { unmount } = renderHook(() => useEditorTeardown(editor))
+    expect(tiptap.destroy).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(tiptap.destroy).toHaveBeenCalledTimes(1)
+    expect(tiptap.isDestroyed).toBe(true)
+    expect(listeners.size).toBe(0)
+    expect(win.ProseMirror).toBeUndefined()
+  })
+
+  it('keeps a window handle that belongs to a different editor', () => {
+    const { editor } = createEditor()
+    const other = createEditor()
+    const win = window as unknown as { ProseMirror?: unknown }
+    win.ProseMirror = other.tiptap
+
+    const { unmount } = renderHook(() => useEditorTeardown(editor))
+    unmount()
+
+    expect(win.ProseMirror).toBe(other.tiptap)
+  })
+
+  it('waits for an async flush before destroying, and destroys even if it rejects', async () => {
+    const { editor, tiptap } = createEditor()
+    const order: string[] = []
+    let resolveFlush: (() => void) | null = null
+    const flush = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = () => {
+            order.push('flush')
+            resolve()
+          }
+        })
+    )
+
+    const { unmount } = renderHook(() => useEditorTeardown(editor, flush))
+    unmount()
+
+    expect(flush).toHaveBeenCalledTimes(1)
+    expect(tiptap.destroy).not.toHaveBeenCalled()
+
+    resolveFlush!()
+    await vi.waitFor(() => expect(tiptap.destroy).toHaveBeenCalledTimes(1))
+    order.push('destroy')
+    expect(order).toEqual(['flush', 'destroy'])
+
+    const rejecting = createEditor()
+    const { unmount: unmountRejecting } = renderHook(() =>
+      useEditorTeardown(rejecting.editor, () => Promise.reject(new Error('save failed')))
+    )
+    unmountRejecting()
+    await vi.waitFor(() => expect(rejecting.tiptap.destroy).toHaveBeenCalledTimes(1))
+  })
+
+  it('does nothing when there is no editor', () => {
+    const { unmount } = renderHook(() => useEditorTeardown(null))
+    expect(() => unmount()).not.toThrow()
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-editor-teardown.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-editor-teardown.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('Hook:EditorTeardown')
+
+interface TiptapHost {
+  _tiptapEditor?: { destroy?: () => void }
+}
+
+/**
+ * Explicitly tear a BlockNote editor down when its owner unmounts.
+ *
+ * `useCreateBlockNote` is a bare `useMemo` with no cleanup: it builds a
+ * `BlockNoteEditor` and parks the underlying Tiptap instance on
+ * `window.ProseMirror`, and nothing ever releases either. `BlockNoteView`'s ref
+ * callback calls `editor.unmount()`, which destroys the ProseMirror *view* but
+ * deliberately keeps the Tiptap editor reusable — every listener registered on
+ * it stays attached. `_tiptapEditor.destroy()` is `unmount()` +
+ * `removeAllListeners()`, and its `unmount()` is guarded on `editorView`, so
+ * calling it after BlockNoteView already unmounted the view is a no-op there.
+ *
+ * `beforeDestroy` runs first and may return a promise: teardown waits for it so
+ * a pending save can still read the document while the editor is intact. It is
+ * awaited even when it rejects — a failed save must not strand the editor.
+ */
+export function useEditorTeardown(
+  editor: unknown,
+  beforeDestroy?: () => void | Promise<void>
+): void {
+  const beforeDestroyRef = useRef(beforeDestroy)
+  useEffect(() => {
+    beforeDestroyRef.current = beforeDestroy
+  })
+
+  useEffect(() => {
+    return () => {
+      const tiptap = (editor as TiptapHost | null)?._tiptapEditor
+      const destroy = (): void => {
+        try {
+          tiptap?.destroy?.()
+        } catch (error) {
+          log.warn('Failed to destroy editor on unmount', error)
+        }
+        const globalHandle = window as unknown as { ProseMirror?: unknown }
+        if (tiptap && globalHandle.ProseMirror === tiptap) {
+          delete globalHandle.ProseMirror
+        }
+      }
+
+      let pending: void | Promise<void> = undefined
+      try {
+        pending = beforeDestroyRef.current?.()
+      } catch (error) {
+        log.warn('Editor teardown flush threw', error)
+      }
+
+      if (pending && typeof pending.then === 'function') {
+        void pending.then(destroy, (error: unknown) => {
+          log.warn('Editor teardown flush rejected', error)
+          destroy()
+        })
+        return
+      }
+      destroy()
+    }
+  }, [editor])
+}

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-note-body.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-note-body.tsx
@@ -19,6 +19,7 @@
  */
 import React, { memo, useEffect } from 'react'
 import { useCreateBlockNote } from '@blocknote/react'
+import { useEditorTeardown } from '@/hooks/use-editor-teardown'
 import { BlockNoteView } from '@blocknote/shadcn'
 import { useTheme } from 'next-themes'
 
@@ -49,6 +50,9 @@ export const CanvasNoteBody = memo(function CanvasNoteBody({
 }: CanvasNoteBodyProps): React.JSX.Element {
   const { resolvedTheme } = useTheme()
   const editor = useCreateBlockNote({ schema: editorSchema })
+
+  // `useCreateBlockNote` never disposes what it builds.
+  useEditorTeardown(editor)
 
   useEffect(() => {
     let cancelled = false

--- a/apps/desktop/src/renderer/src/pages/journal.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { JournalPage } from './journal'
-import type React from 'react'
+import React from 'react'
 
 const mocks = vi.hoisted(() => ({
   openTab: vi.fn(),
@@ -26,6 +26,8 @@ const mocks = vi.hoisted(() => ({
   togglePropertiesCollapsed: vi.fn(),
   saveError: null as string | null,
   entryError: null as string | null,
+  externalUpdateCount: 0,
+  contentAreaMounts: 0,
   entry: {
     id: 'j2026-01-15',
     date: '2026-01-15',
@@ -81,7 +83,7 @@ vi.mock('@/hooks/use-journal', () => ({
     loadedForDate: mocks.activeTab.viewState?.date ?? '2026-01-15',
     error: mocks.entryError,
     saveError: mocks.saveError,
-    externalUpdateCount: 0,
+    externalUpdateCount: mocks.externalUpdateCount,
     updateContent: mocks.updateContent,
     updateTags: mocks.updateTags,
     forceReload: mocks.forceReload,
@@ -256,6 +258,7 @@ vi.mock('@/components/note', () => ({
   ContentArea: ({
     initialContent,
     placeholder,
+    externalContentRevision,
     onMarkdownChange,
     onLinkClick,
     onInternalLinkClick,
@@ -263,8 +266,16 @@ vi.mock('@/components/note', () => ({
     focusAtEndRef
   }: any) => {
     focusAtEndRef.current = vi.fn()
+    // Counting mounts (not renders) is the whole point: an external update must
+    // reach the live editor as a prop, never as a fresh editor instance.
+    React.useEffect(() => {
+      mocks.contentAreaMounts += 1
+    }, [])
     return (
-      <div data-testid="content-area">
+      <div
+        data-testid="content-area"
+        data-external-revision={String(externalContentRevision ?? 'none')}
+      >
         {initialContent}:{placeholder}
         <div
           data-testid="blocknote-editor"
@@ -369,7 +380,9 @@ describe('JournalPage', () => {
     mocks.activeTab = { type: 'journal', viewState: { date: '2026-01-15' } }
     mocks.saveError = null
     mocks.entryError = null
-    mocks.entry = { ...mocks.entry, id: 'j2026-01-15', date: '2026-01-15' }
+    mocks.externalUpdateCount = 0
+    mocks.contentAreaMounts = 0
+    mocks.entry = { ...mocks.entry, id: 'j2026-01-15', date: '2026-01-15', content: '# Today' }
     mocks.resolveWikiLink.mockResolvedValue({ type: 'note', id: 'note-2', title: 'Linked Note' })
     vi.stubGlobal('localStorage', {
       getItem: vi.fn(() => 'false'),
@@ -377,6 +390,25 @@ describe('JournalPage', () => {
     })
     document.body.innerHTML = '<div data-id="h1"></div>'
     Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  it('hands an external update to the live editor instead of remounting it', () => {
+    const { rerender } = render(<JournalPage />)
+
+    expect(screen.getByTestId('content-area')).toHaveTextContent('# Today')
+    expect(mocks.contentAreaMounts).toBe(1)
+
+    // A sync/agent/on-disk edit lands: useJournalEntry swaps the entry and bumps
+    // externalUpdateCount.
+    mocks.entry = { ...mocks.entry, content: '# Edited elsewhere' }
+    mocks.externalUpdateCount = 1
+    rerender(<JournalPage />)
+
+    // The new content must be visible...
+    expect(screen.getByTestId('content-area')).toHaveTextContent('# Edited elsewhere')
+    expect(screen.getByTestId('content-area')).toHaveAttribute('data-external-revision', '1')
+    // ...without throwing away the editor instance.
+    expect(mocks.contentAreaMounts).toBe(1)
   })
 
   it('renders the day editor and drives tags, properties, backlinks, and links', async () => {

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -217,12 +217,18 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
   const [editorRevision, setEditorRevision] = useState(0)
 
   const editorLoadState = loadedForDate === selectedDate ? 'loaded' : 'pending'
+  // `externalUpdateCount` is deliberately NOT part of the key: an external
+  // update (device sync, an on-disk edit, an agent write) is handed to the live
+  // editor via `externalContentRevision` instead of throwing the editor away and
+  // building a new one for every remote change. `editorRevision` stays in the
+  // key — it is the error-boundary recovery path, where a fresh editor is the
+  // point.
   const editorState = useMemo(
     () => ({
-      key: `${selectedDate}-${editorLoadState}-${externalUpdateCount}-${editorRevision}`,
+      key: `${selectedDate}-${editorLoadState}-${editorRevision}`,
       content: editorLoadState === 'loaded' ? (entry?.content ?? '') : ''
     }),
-    [selectedDate, editorLoadState, externalUpdateCount, editorRevision, entry?.content]
+    [selectedDate, editorLoadState, editorRevision, entry?.content]
   )
 
   const isDataPending = isEntryLoading || loadedForDate !== selectedDate
@@ -949,6 +955,7 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
                               noteId={entry?.id}
                               initialContent={review.editorInitialContent}
                               contentType="markdown"
+                              externalContentRevision={externalUpdateCount}
                               placeholder={
                                 selectedDate > today
                                   ? t('editor.placeholder.future')

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@tests/utils/render'
 import { NotePage } from './note'
 import { toast } from 'sonner'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type React from 'react'
 
 const mocks = vi.hoisted(() => ({
@@ -44,6 +44,7 @@ const mocks = vi.hoisted(() => ({
   registerPendingSave: vi.fn(),
   unregisterPendingSave: vi.fn(),
   pickerOnValueChange: null as ((value: string) => void) | null,
+  contentAreaMounts: 0,
   onDeleted: vi.fn(),
   onUpdated: vi.fn(),
   onRenamed: vi.fn(),
@@ -291,6 +292,7 @@ vi.mock('@/components/note', () => ({
   ),
   ContentArea: ({
     initialContent,
+    externalContentRevision,
     onMarkdownChange,
     onHeadingsChange,
     onLinkClick,
@@ -299,6 +301,7 @@ vi.mock('@/components/note', () => ({
     focusAtEndRef
   }: {
     initialContent: string
+    externalContentRevision?: number
     onMarkdownChange: (markdown: string) => void
     onHeadingsChange: (
       headings: Array<{ id: string; level: number; text: string; position: number }>
@@ -310,9 +313,20 @@ vi.mock('@/components/note', () => ({
   }) => {
     const [content] = useState(initialContent)
     focusAtEndRef.current = mocks.refetchNote
+    // Counting mounts (not renders) is the point: an update from elsewhere must
+    // reach the live editor as a prop, never as a fresh editor instance.
+    useEffect(() => {
+      mocks.contentAreaMounts += 1
+    }, [])
     return (
       <div>
+        {/* frozen at mount — changes only when the editor is rebuilt */}
         <div data-testid="editor-content">{content}</div>
+        {/* the live prop the editor re-reads when the revision moves */}
+        <div data-testid="editor-live-content">{initialContent}</div>
+        <div data-testid="editor-external-revision">
+          {String(externalContentRevision ?? 'none')}
+        </div>
         <div data-id="heading-1" />
         <button type="button" onClick={() => onMarkdownChange('# Changed')}>
           Change markdown
@@ -666,6 +680,7 @@ describe('NotePage', () => {
     mocks.notesUpdate.mockResolvedValue({ success: true })
     mocks.pickerOnValueChange = null
     mocks.propertyOnBlocked = null
+    mocks.contentAreaMounts = 0
     Element.prototype.scrollIntoView = vi.fn()
     mocks.resolveWikiLink.mockImplementation((target: string) => {
       if (target === 'Existing Note')
@@ -922,9 +937,14 @@ describe('NotePage', () => {
     expect(mocks.findInPage.close).toHaveBeenCalled()
   })
 
-  it('remounts the editor for agent-driven note content updates', async () => {
+  // Was "remounts the editor for agent-driven note content updates". The update
+  // still has to become visible; it must now do so through the live editor
+  // instead of destroying and rebuilding it. `editor-content` is frozen at mount,
+  // so it staying stale while `editor-live-content` moves is exactly the proof.
+  it('hands an agent-driven content update to the live editor instead of remounting it', async () => {
     renderWithProviders(<NotePage noteId="note-1" />)
     expect(await screen.findByTestId('editor-content')).toHaveTextContent('Original body')
+    expect(mocks.contentAreaMounts).toBe(1)
 
     act(() => {
       mocks.updatedHandler?.({
@@ -934,7 +954,55 @@ describe('NotePage', () => {
       })
     })
 
-    expect(screen.getByTestId('editor-content')).toHaveTextContent('Agent edited body')
+    expect(screen.getByTestId('editor-live-content')).toHaveTextContent('Agent edited body')
+    expect(screen.getByTestId('editor-external-revision')).toHaveTextContent('1')
+    expect(mocks.contentAreaMounts).toBe(1)
+  })
+
+  it('hands an on-disk external content update to the live editor without remounting', async () => {
+    renderWithProviders(<NotePage noteId="note-1" />)
+    expect(await screen.findByTestId('editor-content')).toHaveTextContent('Original body')
+    expect(mocks.contentAreaMounts).toBe(1)
+
+    act(() => {
+      mocks.updatedHandler?.({
+        id: 'note-1',
+        source: 'external',
+        changes: { content: 'Edited on disk' }
+      })
+    })
+
+    expect(screen.getByTestId('editor-live-content')).toHaveTextContent('Edited on disk')
+    expect(screen.getByTestId('editor-external-revision')).toHaveTextContent('1')
+    expect(mocks.contentAreaMounts).toBe(1)
+  })
+
+  // The other direction: a local edit round-tripping through the save path must
+  // not look like an external update. `handleMarkdownChange` stamps
+  // `lastSavedContent`, so the echoed event is dropped — no revision bump, no
+  // reload, nothing to clobber what the user is typing.
+  it('does not bump the editor revision for a note update echoing a local save', async () => {
+    renderWithProviders(<NotePage noteId="note-1" />)
+    await screen.findByTestId('editor-content')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change markdown' }))
+    // handleMarkdownChange debounces the save by a real 1000ms before it stamps
+    // lastSavedContent, which is what makes the echo recognisable.
+    await waitFor(() => expect(mocks.updateNote).toHaveBeenCalled(), { timeout: 3000 })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    act(() => {
+      mocks.updatedHandler?.({
+        id: 'note-1',
+        source: 'internal',
+        changes: { content: '# Changed' }
+      })
+    })
+
+    expect(screen.getByTestId('editor-external-revision')).toHaveTextContent('0')
+    expect(mocks.contentAreaMounts).toBe(1)
   })
 
   // The CRDT write-back fires 500ms after any Y.Doc change — including local
@@ -954,6 +1022,8 @@ describe('NotePage', () => {
     })
 
     expect(screen.getByTestId('editor-content')).toHaveTextContent('Original body')
+    expect(screen.getByTestId('editor-external-revision')).toHaveTextContent('0')
+    expect(mocks.contentAreaMounts).toBe(1)
   })
 
   it('blocks mutations after the note is deleted', async () => {

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -1401,12 +1401,18 @@ export function NotePage({ noteId }: NotePageProps) {
             onRecover={refetchNote}
             onError={(error) => log.error('Editor error:', error)}
           >
+            {/* `externalUpdateCount` is deliberately NOT part of the key: an
+                update that did not originate here is handed to the live editor
+                via `externalContentRevision` instead of destroying and
+                rebuilding the editor for every remote change. `noteId` stays —
+                a different note in this tab is a genuinely different document. */}
             <ContentArea
-              key={`${noteId}-${externalUpdateCount}`}
+              key={noteId}
               noteId={noteId}
               notePath={note.path}
               initialContent={review.editorInitialContent}
               contentType="markdown"
+              externalContentRevision={externalUpdateCount}
               placeholder={t('editor.content.placeholder')}
               stickyToolbar={editorSettings.toolbarMode === 'sticky'}
               spellCheck={editorSettings.spellCheck}


### PR DESCRIPTION
Fixes #1017

## The headline: this fixes real keystroke loss, not just a leak

`useEditorSync` **cleared** its 150ms markdown debounce on unmount without running it. On the journal that debounce is the *only* save path — `onContentChange` there is a no-op (`journal.tsx:596`), so `onMarkdownChange` is the sole route to `updateContent` → `pendingContentRef` → disk. Anything typed in the last 150ms before a journal date switch or a tab close never reached it and was silently gone. `useJournalEntry`'s unmount flush could not help: `pendingContentRef` was still `null`, because the serialization that fills it never ran.

That is fixed first (`flushPendingMarkdown`), and it is also the precondition for everything else here — teardown waits for the flush before destroying, because serializing needs a live editor.

Three defects, fixed and tested separately.

---

## 1. Editors are never destroyed *(the issue's headline)*

**Verified still real.** `useCreateBlockNote` in `@blocknote/react@0.47.1` is a bare `useMemo` with no cleanup — `node_modules/@blocknote/react/dist/blocknote-react.js:4562`:

```js
const Ke = (e = {}, t = []) => V(() => {
  const n = Un.create(e);
  return window && (window.ProseMirror = n._tiptapEditor), n;
}, t)
```

It also parks the newest instance on `window.ProseMirror` and never clears it. `BlockNoteView`'s ref callback (`blocknote-react.js:3769`) does `i ? n.mount(i) : n.unmount()`, and `editor.unmount()` is `this._tiptapEditor.unmount()` (`@blocknote/core/dist/blocknote.js:3312`). Tiptap's `unmount()` destroys the ProseMirror view but deliberately keeps the editor reusable — only `destroy()` also calls `removeAllListeners()` (`@tiptap/core@3.19.0/dist/index.js:4618` and `:5041`). Repo-wide grep of `apps/desktop/src/renderer/src` still finds no `editor.destroy()` / `_tiptapEditor.destroy()`.

**Fix** — `renderer/src/hooks/use-editor-teardown.ts` (new). On unmount: run an optional `beforeDestroy` flush (awaited, and awaited even when it rejects — a failed save must not strand the editor), then `_tiptapEditor.destroy()`, then release `window.ProseMirror` when it still points at this editor. Its `unmount()` is guarded on `editorView`, so calling it after BlockNoteView already unmounted the view is a safe no-op. Wired into all four `useCreateBlockNote` sites: `ContentArea`, `task-description-editor`, `inbox-content-editor`, `canvas-note-body`.

Flushing before destroying is safe because Tiptap's `state` getter falls back to the retained `editorState` once the view is gone (`@tiptap/core/dist/index.js:4750`), and `serializeBlocksPreservingBlanks` only needs `blocksToMarkdownLossy`.

## 2. The journal remounted an editor per external update

`journal.tsx:222` keyed `ContentArea` on `${selectedDate}-${editorLoadState}-${externalUpdateCount}-${editorRevision}`, and `useJournalEntry` bumps `externalUpdateCount` on every `source: 'external'` entry update (`use-journal-entry.ts:438`). The key change unmounted the editor, dropped the Y.Doc registry refcount to 0 (`provider.destroy()` + `doc.destroy()`) and reconnected — one editor per remote change.

**Fix** — `externalUpdateCount` moves out of the key into a new `externalContentRevision` prop. In `useEditorSync` the initial-load effect's "run once" guard becomes "run once per revision", so the live editor re-reads `initialContent` instead of being rebuilt. **Skipped when a `yjsFragment` is present**: the main process feeds the external edit into the shared Y.Doc via `feedExternalEditToCrdt` (`main/vault/watcher.ts:619`), `YjsIpcProvider` applies it, and y-prosemirror merges it in place. Replacing blocks there would clobber that merge and any concurrent local edit. `editorRevision` stays in the key — that is the error-boundary recovery path, where a fresh editor is the point.

## 3. The note page had the identical defect

`note.tsx:1405` keyed on `${noteId}-${externalUpdateCount}`. Same fix, same prop. `noteId` stays in the key: a different note in the tab is a genuinely different document.

**The collaboration precondition was checked here, not assumed — and it holds for a different reason than the journal:**

- `note.tsx:515` already drops `source: 'sync'`, so CRDT write-back never bumped the count.
- The remaining bumps are `source: 'internal'` (`notes-crud.ts:638`, `notes-versions.ts:232`) and `source: 'external'` (`watcher.ts:606`). Neither `notes-crud` nor `notes-versions` calls into the CRDT, so "the Y.Doc already merged it" is **not** available as the argument the way it is for the journal.
- The argument that does hold: `useEditorSync`'s load branch returns early under `yjsFragment` **without reading `initialContent` at all**. So a remount under active collaboration never surfaced `eventContentOverride` either — content only ever arrived through the Y.Doc. Skipping the reload there is behaviour-preserving.
- And the note page **can** render without a fragment (sync off, free plan, offline, or `useYjsCollaboration`'s fail-open `fallback` path). In that state the revision-triggered reload runs and does exactly what the remount did. The guard lives in `useEditorSync` keyed on `yjsFragment`, not on the page, so both surfaces get the correct branch by construction.

No new dependency. No IPC / contract / schema / sync-protocol / vault-format change.

---

## Tests

Red → green, each mutation-checked (revert the fix ⇒ the test fails again).

| Test | Red before |
|---|---|
| `use-editor-sync.test.tsx` › flushes a pending markdown save before the editor is torn down | `onMarkdownChange` never called; also asserts flush-before-destroy via `invocationCallOrder` |
| `ContentArea.test.tsx` › destroys the editor and releases the window handle when it unmounts | `expected "vi.fn()" to be called 1 times, but got 0 times` |
| `ContentArea.test.tsx` › leaves no DOM listener or animation frame behind after unmount | `expected [ …(138) ] to deeply equal []` |
| `use-editor-sync.test.tsx` › re-applies external content in place when the external revision changes | second `removeAndInsertBlocks` never happens |
| `use-editor-sync.test.tsx` › leaves an external revision to the Y.Doc when collaboration is active | the shared no-clobber guard for both surfaces |
| `journal.test.tsx` › hands an external update to the live editor instead of remounting it | `data-external-revision="none"`, mount count 2 |
| `note.test.tsx` › hands an agent-driven content update to the live editor instead of remounting it | rewritten from "remounts the editor…" — see below |
| `note.test.tsx` › hands an on-disk external content update to the live editor without remounting | mount count 2 |
| `note.test.tsx` › does not bump the editor revision for a note update echoing a local save | the local-edit direction |
| `note.test.tsx` › does not remount the editor for CRDT write-back updates | existing test, now also asserts revision 0 + mount count 1 |
| `hooks/use-editor-teardown.test.ts` (new, 4 cases) | file did not exist |

**One existing test changed contract.** `note.test.tsx` › `remounts the editor for agent-driven note content updates` asserted the old remount behaviour by name. It is rewritten as `hands an agent-driven content update to the live editor instead of remounting it`: the update must still become visible, now via the live editor. The mock's `editor-content` is frozen at mount (`useState(initialContent)`), so it staying stale while `editor-live-content` moves is precisely the proof that no remount happened. All page tests assert the **mount count**, not just content.

Mutation results — each reverted fix turns only its own tests red:

```
M1 remove useEditorTeardown from ContentArea      Tests 1 failed | 9 passed (10)
M2 drop externalContentRevision from deps         Tests 1 failed | 9 passed (10)
M3 make flushPendingMarkdown a no-op              Tests 1 failed | 9 passed (10)
M4 put externalUpdateCount back in journal key    Tests 1 failed | 6 passed (7)
M5 put externalUpdateCount back in note key       Tests 2 failed | 25 passed (27)
M6 drop externalContentRevision from note page    Tests 4 failed | 23 passed (27)
```

## Checks

```
pnpm --filter @memry/desktop typecheck                       pass
pnpm lint                                                    0 errors, 14 warnings (all pre-existing, untouched files)
eslint --no-cache --max-warnings=0 <9 changed sources>       exit 0
vitest renderer (note, tasks, inbox-detail, canvas,
  gap-surfaces, journal, note page, hooks)                   219 files, 2100 passed | 6 skipped
npx react-doctor@latest .                                    32 findings / exit 1 — finding set diffs IDENTICAL
                                                             to the origin/main baseline captured via git stash
```

## Out of scope

#1047–#1051 (date-pill MutationObserver, scroll re-renders, active-heading tracking, marquee selection, find-in-page) and #1104 (split-view link handler) are separate editor issues owned elsewhere.
