### PR TITLE
fix(export): destroy the hidden PDF window when rendering fails

### DIFF
--- a/apps/desktop/src/main/ipc/notes-handlers-extra.test.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers-extra.test.ts
@@ -11,7 +11,8 @@ const mocks = vi.hoisted(() => {
   const windowInstance = {
     loadURL: vi.fn().mockResolvedValue(undefined),
     webContents,
-    destroy: vi.fn()
+    destroy: vi.fn(),
+    isDestroyed: vi.fn(() => false)
   }
   const BrowserWindow = Object.assign(
     vi.fn(function BrowserWindowMock() {
@@ -224,6 +225,7 @@ describe('notes-handlers extra coverage', () => {
     mocks.handlers.clear()
     mocks.webContents.printToPDF.mockResolvedValue(Buffer.from('pdf'))
     mocks.windowInstance.loadURL.mockResolvedValue(undefined)
+    mocks.windowInstance.isDestroyed.mockReturnValue(false)
     mocks.fsWriteFile.mockResolvedValue(undefined)
     mocks.fromMemryFileUrl.mockReturnValue('/vault/.memry/attachments/note-a/file.png')
     mocks.service.get.mockReturnValue(null)
@@ -527,6 +529,57 @@ describe('notes-handlers extra coverage', () => {
       '<html><body>note</body></html>',
       'utf-8'
     )
+  })
+
+  it('destroys the hidden PDF window when rendering fails', async () => {
+    const note = {
+      id: 'note-a',
+      title: 'Daily note',
+      content: '# Today',
+      emoji: null,
+      tags: ['work'],
+      created: new Date('2026-05-10T00:00:00.000Z'),
+      modified: new Date('2026-05-10T00:00:00.000Z')
+    }
+    mocks.getNoteById.mockResolvedValue(note)
+
+    mocks.webContents.printToPDF.mockRejectedValueOnce(new Error('printToPDF crashed'))
+    expect(
+      await invoke(NotesChannels.invoke.EXPORT_PDF, {
+        noteId: 'note-a',
+        outputPath: '/tmp/Daily_note.pdf',
+        includeMetadata: false,
+        pageSize: 'A4'
+      })
+    ).toEqual({ success: false, error: 'printToPDF crashed' })
+    expect(mocks.windowInstance.destroy).toHaveBeenCalledTimes(1)
+    expect(mocks.fsWriteFile).not.toHaveBeenCalled()
+
+    mocks.windowInstance.destroy.mockClear()
+    mocks.windowInstance.loadURL.mockRejectedValueOnce(new Error('loadURL crashed'))
+    expect(
+      await invoke(NotesChannels.invoke.EXPORT_PDF, {
+        noteId: 'note-a',
+        outputPath: '/tmp/Daily_note.pdf',
+        includeMetadata: false,
+        pageSize: 'A4'
+      })
+    ).toEqual({ success: false, error: 'loadURL crashed' })
+    expect(mocks.windowInstance.destroy).toHaveBeenCalledTimes(1)
+
+    // An already-destroyed window is never destroyed twice.
+    mocks.windowInstance.destroy.mockClear()
+    mocks.windowInstance.isDestroyed.mockReturnValue(true)
+    mocks.webContents.printToPDF.mockRejectedValueOnce(new Error('printToPDF crashed'))
+    expect(
+      await invoke(NotesChannels.invoke.EXPORT_PDF, {
+        noteId: 'note-a',
+        outputPath: '/tmp/Daily_note.pdf',
+        includeMetadata: false,
+        pageSize: 'A4'
+      })
+    ).toEqual({ success: false, error: 'printToPDF crashed' })
+    expect(mocks.windowInstance.destroy).not.toHaveBeenCalled()
   })
 
   it('handles position, version, folder, and local-only helper handlers', async () => {

--- a/apps/desktop/src/main/ipc/notes-handlers.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.ts
@@ -838,27 +838,31 @@ export function registerNotesHandlers(): void {
         }
       })
 
-      await win.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`)
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      let pdfData: Buffer
+      try {
+        await win.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`)
+        await new Promise((resolve) => setTimeout(resolve, 100))
 
-      const pageSizeMap: Record<string, Electron.PrintToPDFOptions['pageSize']> = {
-        A4: 'A4',
-        Letter: 'Letter',
-        Legal: 'Legal'
+        const pageSizeMap: Record<string, Electron.PrintToPDFOptions['pageSize']> = {
+          A4: 'A4',
+          Letter: 'Letter',
+          Legal: 'Legal'
+        }
+
+        pdfData = await win.webContents.printToPDF({
+          printBackground: true,
+          pageSize: pageSizeMap[input.pageSize] || 'A4',
+          margins: {
+            top: 0.5,
+            bottom: 0.5,
+            left: 0.5,
+            right: 0.5
+          }
+        })
+      } finally {
+        if (!win.isDestroyed()) win.destroy()
       }
 
-      const pdfData = await win.webContents.printToPDF({
-        printBackground: true,
-        pageSize: pageSizeMap[input.pageSize] || 'A4',
-        margins: {
-          top: 0.5,
-          bottom: 0.5,
-          left: 0.5,
-          right: 0.5
-        }
-      })
-
-      win.destroy()
       await fs.writeFile(targetPath, pdfData)
 
       trackMainEvent('note_exported', {


### PR DESCRIPTION
## Problem

`notes:export-pdf` creates a hidden `BrowserWindow`, loads the rendered note HTML via a `data:` URL, calls `printToPDF`, then destroys the window — but `win.destroy()` sat on the happy path only, with no `try`/`finally`.

If `loadURL` or `printToPDF` rejected (renderer crash, oversized/malformed note HTML, print subsystem failure), the hidden window and its whole renderer process survived for the rest of the session. `registerCommand`'s `withErrorHandler` converts the rejection into a `{ success: false, error }` envelope, so the user just sees "export failed" and retries — leaking another renderer process every attempt. The leaked windows also stay in `BrowserWindow.getAllWindows()`, so they receive every main→renderer broadcast and are counted by the shutdown flush.

## Root cause

`apps/desktop/src/main/ipc/notes-handlers.ts` — window teardown was a plain statement between `printToPDF` and `fs.writeFile` instead of a cleanup guaranteed on every exit path.

## Fix

Wrap the load/print sequence in `try { ... } finally { if (!win.isDestroyed()) win.destroy() }`. `fs.writeFile` stays outside the `try`, so the window is torn down before the file write as before. The `isDestroyed()` guard keeps the cleanup safe if the window is already gone (e.g. app quit racing the export).

No contract, schema, IPC channel, settings, or vault-format change — the handler's inputs and outputs are byte-identical. Success path is unchanged: window still destroyed exactly once, before the PDF is written. Failure path now returns the same error envelope it always did, minus the leaked process.

## Test evidence

New test in `apps/desktop/src/main/ipc/notes-handlers-extra.test.ts`: `destroys the hidden PDF window when rendering fails` — covers `printToPDF` rejection, `loadURL` rejection, and the already-destroyed guard.

**RED (before the fix):**

```
PASS (0) FAIL (1) skipped (5)

1. notes-handlers extra coverage destroys the hidden PDF window when rendering fails
   AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
```

**GREEN (after the fix):**

```
 Test Files  2 passed (2)
      Tests  59 passed (59)
```
(`notes-handlers-extra.test.ts` + `notes-handlers.test.ts`, `--project main`)

**Mutation verification** — two single-line mutants, both killed:

| Mutant | Result |
| --- | --- |
| `if (!win.isDestroyed()) win.destroy()` → `if (win.isDestroyed()) win.destroy()` (guard flipped) | RED — `expected "vi.fn()" to be called 1 times, but got 0 times` |
| `finally` body emptied (`} finally { }`) | RED — `expected "vi.fn()" to be called 1 times, but got 0 times` |

**Verify commands:**

- `pnpm typecheck` — `Tasks: 16 successful, 16 total` (includes `rpc:check` + IPC invoke map check: "Generated RPC bindings are up to date", "IPC invoke map is up to date")
- `pnpm lint` — `✖ 14 problems (0 errors, 14 warnings)`; all 14 are pre-existing renderer warnings, none in the changed files
- `git diff --check` — clean

## Risk & backward compatibility

Very low. Behavior on the success path is identical; the only observable difference is that a failed export no longer leaves a renderer process behind. No persisted data, DB schema, sync payload, IPC contract, or settings shape is touched, so older and newer app versions interoperate unchanged.

## Docs

`pnpm docs:impact --strict` reports `missing-docs` because `notes-handlers.ts` is a desktop file, but this is an internal resource-lifecycle fix with no user-facing surface: no new setting, no changed dialog, no changed export output or error text. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1` for that reason.

Closes #1020
