### PR TITLE
fix(database): close the previous connection before re-initializing

### DIFF
--- a/apps/desktop/src/main/database/client.test.ts
+++ b/apps/desktop/src/main/database/client.test.ts
@@ -3,6 +3,20 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import Database from 'better-sqlite3'
+
+const { loggerWarnMock } = vi.hoisted(() => ({
+  loggerWarnMock: vi.fn()
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: loggerWarnMock,
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
 import { runIndexMigrations } from './migrate'
 import {
   initDatabase,
@@ -23,6 +37,7 @@ describe('database client', () => {
   let indexDbPath: string
 
   beforeEach(() => {
+    loggerWarnMock.mockClear()
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-db-client-'))
     dataDbPath = path.join(tempDir, 'data.db')
     indexDbPath = path.join(tempDir, 'index.db')
@@ -121,6 +136,70 @@ describe('database client', () => {
     expect(liveRaw).not.toBe(orphanRaw)
     expect(liveRaw.open).toBe(true)
     expect(getIndexDatabase()).toBe(live)
+  })
+
+  it('leaks rather than fails the open when the previous data handle refuses to close', () => {
+    // #given — a stale connection whose close() throws, the way better-sqlite3
+    // rejects a close on a busy connection
+    const orphan = initDatabase(dataDbPath)
+    const orphanClient = (orphan as unknown as { $client: Database.Database }).$client
+    const refusingClose = vi.spyOn(orphanClient, 'close').mockImplementation(() => {
+      throw new Error('database is busy')
+    })
+
+    // #when — the retry re-enters initDatabase on top of it
+    const live = initDatabase(dataDbPath)
+    const liveClient = (live as unknown as { $client: Database.Database }).$client
+
+    // #then — the refusal degrades to a leak, never to a failed vault open
+    expect(liveClient).not.toBe(orphanClient)
+    expect(liveClient.open).toBe(true)
+    expect(liveClient.prepare('SELECT 1 AS ok').get()).toEqual({ ok: 1 })
+
+    // #then — post-init state is coherent: the getter resolves the new handle,
+    // never the stale one closeDatabase() left behind when its close() threw
+    expect(getDatabase()).toBe(live)
+    expect((getDatabase() as unknown as { $client: Database.Database }).$client).toBe(liveClient)
+
+    // #then — the returning leak is visible in the diagnostic logs
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining('previous data connection'),
+      expect.any(Error)
+    )
+
+    refusingClose.mockRestore()
+    orphanClient.close()
+  })
+
+  it('leaks rather than fails the open when the previous index handle refuses to close', () => {
+    // #given — a stale index connection whose close() throws
+    initIndexDatabase(indexDbPath)
+    const orphanRaw = getRawIndexDatabase()
+    const refusingClose = vi.spyOn(orphanRaw, 'close').mockImplementation(() => {
+      throw new Error('database is busy')
+    })
+
+    // #when — the retry re-enters initIndexDatabase on top of it
+    const live = initIndexDatabase(indexDbPath)
+    const liveRaw = getRawIndexDatabase()
+
+    // #then — the refusal degrades to a leak, never to a failed vault open
+    expect(liveRaw).not.toBe(orphanRaw)
+    expect(liveRaw.open).toBe(true)
+    expect(liveRaw.prepare('SELECT 1 AS ok').get()).toEqual({ ok: 1 })
+
+    // #then — post-init state is coherent: both getters resolve the new handle
+    expect(getIndexDatabase()).toBe(live)
+    expect(getRawIndexDatabase()).toBe(liveRaw)
+
+    // #then — the returning leak is visible in the diagnostic logs
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining('previous index connection'),
+      expect.any(Error)
+    )
+
+    refusingClose.mockRestore()
+    orphanRaw.close()
   })
 
   it('closes databases and resets getters', () => {

--- a/apps/desktop/src/main/database/client.test.ts
+++ b/apps/desktop/src/main/database/client.test.ts
@@ -88,6 +88,41 @@ describe('database client', () => {
     expect(raw.pragma('temp_store', { simple: true })).toBe(2)
   })
 
+  it('closes the previous data handle when initDatabase runs again', () => {
+    // #given — a connection left behind by an open that threw after
+    // initDatabase, so closeVault() early-returned and never closed it
+    const orphan = initDatabase(dataDbPath)
+    const orphanClient = (orphan as unknown as { $client: Database.Database }).$client
+    expect(orphanClient.open).toBe(true)
+
+    // #when — the retry re-enters initDatabase on top of that orphan
+    const live = initDatabase(dataDbPath)
+    const liveClient = (live as unknown as { $client: Database.Database }).$client
+
+    // #then — the orphan (16MB page cache + fd + WAL) is gone, one live handle left
+    expect(orphanClient.open).toBe(false)
+    expect(liveClient).not.toBe(orphanClient)
+    expect(liveClient.open).toBe(true)
+    expect(getDatabase()).toBe(live)
+  })
+
+  it('closes the previous index handle when initIndexDatabase runs again', () => {
+    // #given — an index connection from a vault open that never reached close
+    initIndexDatabase(indexDbPath)
+    const orphanRaw = getRawIndexDatabase()
+    expect(orphanRaw.open).toBe(true)
+
+    // #when — the retry re-enters initIndexDatabase on top of that orphan
+    const live = initIndexDatabase(indexDbPath)
+    const liveRaw = getRawIndexDatabase()
+
+    // #then — the orphan (32MB page cache + fd + WAL) is gone, one live handle left
+    expect(orphanRaw.open).toBe(false)
+    expect(liveRaw).not.toBe(orphanRaw)
+    expect(liveRaw.open).toBe(true)
+    expect(getIndexDatabase()).toBe(live)
+  })
+
   it('closes databases and resets getters', () => {
     initDatabase(dataDbPath)
     initIndexDatabase(indexDbPath)

--- a/apps/desktop/src/main/database/client.ts
+++ b/apps/desktop/src/main/database/client.ts
@@ -19,7 +19,29 @@ export const SQLITE_DATA_CACHE_KIB = 16000
 export const SQLITE_INDEX_CACHE_KIB = 32000
 export const SQLITE_TEMP_STORE = 'MEMORY'
 
+/**
+ * Close a leftover connection before re-initializing on top of it. A close that
+ * refuses (better-sqlite3 throws while a connection is busy) must not escalate a
+ * leaked handle into a failed vault open, so the new connection replaces it
+ * either way — the pre-fix behaviour.
+ */
+function closeStaleHandle(close: () => void): void {
+  try {
+    close()
+  } catch {
+    // fall through to the fresh connection below
+  }
+}
+
 export function initDatabase(dbPath: string): DataDb {
+  // A handle already here is an orphan: openVault can throw after this point,
+  // which leaves isOpen false so closeVault() early-returns and never closes it,
+  // and createDormantVault repoints this singleton with no close at all. Every
+  // orphan keeps its 16MB page cache, fd and WAL alive. Closing is safe here —
+  // better-sqlite3 is synchronous, so nothing is mid-statement, and consumers
+  // resolve the connection through getDatabase() per call rather than holding it.
+  closeStaleHandle(closeDatabase)
+
   sqliteDataDb = new Database(dbPath)
 
   // WAL mode for better concurrency and crash recovery
@@ -48,6 +70,9 @@ export function initDatabase(dbPath: string): DataDb {
 }
 
 export function initIndexDatabase(dbPath: string): IndexDb {
+  // Same orphan handling as initDatabase, for the 32MB index connection.
+  closeStaleHandle(closeIndexDatabase)
+
   sqliteIndexDb = new Database(dbPath)
 
   // WAL mode for better concurrency

--- a/apps/desktop/src/main/database/client.ts
+++ b/apps/desktop/src/main/database/client.ts
@@ -5,10 +5,13 @@ import * as dataSchema from '@memry/db-schema/data-schema'
 import * as indexSchema from '@memry/db-schema/index-schema'
 import * as sqliteVec from 'sqlite-vec'
 import { EMBEDDING_DIMENSION } from '../lib/embeddings-constants'
+import { createLogger } from '../lib/logger'
 import { registerDataDbFunctions } from './sqlite-functions'
 import type { DataDb, IndexDb, RawIndexDb } from './types'
 
 export type { DataDb, IndexDb, RawIndexDb } from './types'
+
+const logger = createLogger('DatabaseClient')
 
 let dataDb: DataDb | null = null
 let indexDb: IndexDb | null = null
@@ -23,13 +26,14 @@ export const SQLITE_TEMP_STORE = 'MEMORY'
  * Close a leftover connection before re-initializing on top of it. A close that
  * refuses (better-sqlite3 throws while a connection is busy) must not escalate a
  * leaked handle into a failed vault open, so the new connection replaces it
- * either way — the pre-fix behaviour.
+ * either way — the pre-fix behaviour. That degrade re-leaks the handle, so it is
+ * logged rather than swallowed: silence here would hide a returning leak.
  */
-function closeStaleHandle(close: () => void): void {
+function closeStaleHandle(label: string, close: () => void): void {
   try {
     close()
-  } catch {
-    // fall through to the fresh connection below
+  } catch (error) {
+    logger.warn(`Failed to close the previous ${label} connection; it stays leaked`, error)
   }
 }
 
@@ -40,7 +44,7 @@ export function initDatabase(dbPath: string): DataDb {
   // orphan keeps its 16MB page cache, fd and WAL alive. Closing is safe here —
   // better-sqlite3 is synchronous, so nothing is mid-statement, and consumers
   // resolve the connection through getDatabase() per call rather than holding it.
-  closeStaleHandle(closeDatabase)
+  closeStaleHandle('data', closeDatabase)
 
   sqliteDataDb = new Database(dbPath)
 
@@ -71,7 +75,7 @@ export function initDatabase(dbPath: string): DataDb {
 
 export function initIndexDatabase(dbPath: string): IndexDb {
   // Same orphan handling as initDatabase, for the 32MB index connection.
-  closeStaleHandle(closeIndexDatabase)
+  closeStaleHandle('index', closeIndexDatabase)
 
   sqliteIndexDb = new Database(dbPath)
 


### PR DESCRIPTION
Closes #1023

## Problem

`initDatabase` / `initIndexDatabase` in `apps/desktop/src/main/database/client.ts` assigned a fresh `better-sqlite3` handle straight over the module singleton (`sqliteDataDb = new Database(dbPath)`) without closing whatever was already there.

The happy path is safe — `selectVault` → `closeVault` → `closeAllDatabases`. Two live paths are not:

1. **Failed vault open + retry.** `openVault` can throw after `initDatabase` (migrations, `ensureDefaultTaskProject`, template migration, `PropertyDefinitionsService.init`, index work). `isOpen` never flips true, so `closeVault()` early-returns at `vault/index.ts:571-573` and the handle is never closed. The next open attempt re-enters `initDatabase` on top of the orphan.
2. **`createDormantVault`** (`main/sync/vault-provisioning.ts:31`) intentionally repoints the data.db singleton during multi-vault linking and never closes the connection it replaces — one leak per dormant vault provisioned.

Each orphan holds its page cache (`cache_size = -16000` ≈ 16MB data, `-32000` ≈ 32MB index), an fd, and a WAL reference for the rest of the process lifetime.

Still reproducible on current `main` — verified by reading the file and by the tests below, which fail without the fix.

## Root cause

Handle-closing was the caller's responsibility, and the failure path has no caller that closes.

## Fix

`initDatabase` / `initIndexDatabase` close the previous handle themselves via the already-idempotent `closeDatabase()` / `closeIndexDatabase()`, through a small `closeStaleHandle(label, close)` helper.

Why closing here is safe (established before writing it):

- `better-sqlite3` is fully synchronous, so nothing is mid-statement when `init*` runs; there is no pending write to drop. There are no `.iterate()` call sites in main that could leave a connection busy across an await.
- Consumers never hold the connection across a re-init: every reader goes through `getDatabase()` / `getIndexDatabase()` / `getRawIndexDatabase()` per operation (all five projectors, inbox suggestions, query modules). There are no module-scope or class-field captures of a handle.
- A close that refuses anyway (busy connection) is caught, so a leaked handle can never escalate into a *failed* vault open — the failure semantics stay exactly as they are today. That degrade re-leaks the handle, so it is **logged**, not swallowed: `createLogger('DatabaseClient')` emits a `warn` naming the connection (`data` / `index`) and carrying the error, so a returning leak is visible in the diagnostic logs instead of silent.
- `rebuildIndex` already did `closeIndexDatabase()` → `initIndexDatabase()`; the second close is now a no-op, not a double close.

Only `client.ts` changed. No contracts/IPC/preload changes, no schema or migration changes.

## Test evidence

`apps/desktop/src/main/database/client.test.ts`, four new tests:

- two assert that a second `init*` call leaves the first raw handle with `.open === false`, a distinct live handle open, and the getters pointing at the new one;
- two cover the **degrade branch** — the previous handle's `close()` is stubbed to throw the way better-sqlite3 rejects a close on a busy connection, and the test asserts `init*` still returns a working connection (`SELECT 1` runs on it), that `getDatabase()` / `getIndexDatabase()` / `getRawIndexDatabase()` resolve the **new** handle rather than the stale one `closeDatabase()` leaves in place when its `close()` throws, and that the warn was emitted.

**RED** (before the fix):
```
 FAIL  |main| client.test.ts > closes the previous data handle when initDatabase runs again
 FAIL  |main| client.test.ts > closes the previous index handle when initIndexDatabase runs again
AssertionError: expected true to be false
      Tests  2 failed | 6 passed (8)
```

**GREEN** (after the fix):
```
 ✓ closes the previous data handle when initDatabase runs again 11ms
 ✓ closes the previous index handle when initIndexDatabase runs again 27ms
 ✓ leaks rather than fails the open when the previous data handle refuses to close 10ms
 ✓ leaks rather than fails the open when the previous index handle refuses to close 21ms
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

**Mutation verification** — each fix line reverted in turn:

| mutant | result |
| --- | --- |
| `closeStaleHandle('data', closeDatabase)` removed | killed — both data tests fail |
| `closeStaleHandle('index', closeIndexDatabase)` removed | killed — both index tests fail |
| `logger.warn(...)` removed (empty catch) | killed — both degrade tests fail |
| `try`/`catch` guard removed (bare `close()`) | killed — 5 tests fail, incl. both degrade tests |

No survivors; every mutant died on the tests written for it.

## Verification

- `pnpm typecheck` — `Tasks: 16 successful, 16 total`
- `pnpm lint` — `14 problems (0 errors, 14 warnings)`, all pre-existing renderer warnings in untouched files
- `pnpm --filter @memry/desktop test:main src/main/database/client.test.ts` — `Test Files 1 passed (1)`, `Tests 10 passed (10)`
- `pnpm --filter @memry/desktop test:main` (full main suite) — `Test Files 475 passed | 1 skipped (476)`, `Tests 5420 passed | 1 expected fail | 4 skipped (5425)`
- `git diff --check` — clean

## Risk & backward compatibility

Low. No schema, migration, sync-protocol, IPC-contract, vault-file-format or settings change — existing installs are unaffected at rest. The only behavioural delta is that a connection which was previously leaked is now closed; because every consumer resolves the handle lazily through the accessors, nothing that would have kept working keeps a reference to it. On the happy path the added call is a no-op (`sqliteDataDb` is already `null` after `closeVault`). Worst case for an unforeseen busy connection is the pre-fix behaviour (leak) — now logged rather than silent.

## Docs

`pnpm docs:impact` flags `client.ts` as docs-relevant, but this is an internal connection-lifecycle fix with no user-visible surface — no new setting, command, IPC surface or workflow to document. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`.