### PR TITLE
perf(calendar): give window-focus Google sync a 2-minute cooldown

### DIFF
--- a/apps/desktop/src/main/calendar/google/google-sync-runner.ts
+++ b/apps/desktop/src/main/calendar/google/google-sync-runner.ts
@@ -22,7 +22,9 @@ const TRIGGER_COOLDOWN_MS = 10 * 1000
 // refresh calls syncGoogleCalendarNow directly, so focus only has to close the
 // gap between polls — not race them.
 const FOCUS_TRIGGER_COOLDOWN_MS = 2 * 60 * 1000
-const WINDOW_FOCUS_REASON = 'window-focus'
+// Exported so the focus handler in main/index.ts can pass this instead of its own
+// literal — a silent rename there would drop focus back to the 10 s cooldown.
+export const WINDOW_FOCUS_REASON = 'window-focus'
 
 let syncInterval: NodeJS.Timeout | null = null
 let currentPollIntervalMs = RUN_INTERVAL_MS

--- a/apps/desktop/src/main/calendar/google/google-sync-runner.ts
+++ b/apps/desktop/src/main/calendar/google/google-sync-runner.ts
@@ -16,6 +16,13 @@ const log = createLogger('Calendar:GoogleSyncRunner')
 const RUN_INTERVAL_MS = 5 * 60 * 1000
 export const PUSH_BACKOFF_INTERVAL_MS = 30 * 60 * 1000
 const TRIGGER_COOLDOWN_MS = 10 * 1000
+// Window focus fires on every alt-tab, so the 10 s cooldown let an all-day user
+// drive ~6 full calendar syncs a minute (network + DB writes + telemetry). The
+// periodic poll above still bounds staleness on its own schedule, and manual
+// refresh calls syncGoogleCalendarNow directly, so focus only has to close the
+// gap between polls — not race them.
+const FOCUS_TRIGGER_COOLDOWN_MS = 2 * 60 * 1000
+const WINDOW_FOCUS_REASON = 'window-focus'
 
 let syncInterval: NodeJS.Timeout | null = null
 let currentPollIntervalMs = RUN_INTERVAL_MS
@@ -69,7 +76,9 @@ export function triggerGoogleCalendarSyncNow(reason: string): void {
     return
   }
   const now = Date.now()
-  if (now - lastTriggerAt < TRIGGER_COOLDOWN_MS) {
+  const cooldownMs =
+    reason === WINDOW_FOCUS_REASON ? FOCUS_TRIGGER_COOLDOWN_MS : TRIGGER_COOLDOWN_MS
+  if (now - lastTriggerAt < cooldownMs) {
     log.debug('skipping Google Calendar sync trigger (cooldown)', { reason })
     return
   }

--- a/apps/desktop/src/main/calendar/google/sync-service-trigger.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service-trigger.test.ts
@@ -114,12 +114,48 @@ describe('triggerGoogleCalendarSyncNow (focus/resume/manual refresh)', () => {
     triggerGoogleCalendarSyncNow('window-focus')
     await Promise.resolve()
 
-    // #when time advances past the 10-second cooldown
-    vi.setSystemTime(new Date('2026-01-01T00:00:11Z'))
+    // #when time advances past the focus cooldown
+    vi.setSystemTime(new Date('2026-01-01T00:02:01Z'))
     triggerGoogleCalendarSyncNow('window-focus')
     await Promise.resolve()
 
     // #then a second sync fires
+    expect(syncNowMock).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
+  })
+
+  it('holds window-focus triggers to a 2-minute cooldown, not the short one', async () => {
+    // #given a focus trigger already fired at t=0
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    triggerGoogleCalendarSyncNow('window-focus')
+    await Promise.resolve()
+
+    // #when the window is re-focused repeatedly across the next two minutes
+    for (const at of ['00:00:11', '00:00:30', '00:01:00', '00:01:59']) {
+      vi.setSystemTime(new Date(`2026-01-01T${at}Z`))
+      triggerGoogleCalendarSyncNow('window-focus')
+      await Promise.resolve()
+    }
+
+    // #then no extra sync fires — alt-tabbing cannot drive network + DB writes
+    expect(syncNowMock).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
+
+  it('keeps the short cooldown for non-focus triggers', async () => {
+    // #given a focus trigger already fired at t=0
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    triggerGoogleCalendarSyncNow('window-focus')
+    await Promise.resolve()
+
+    // #when the machine wakes 11 seconds later
+    vi.setSystemTime(new Date('2026-01-01T00:00:11Z'))
+    triggerGoogleCalendarSyncNow('system-resume')
+    await Promise.resolve()
+
+    // #then resume still syncs immediately
     expect(syncNowMock).toHaveBeenCalledTimes(2)
     vi.useRealTimers()
   })

--- a/apps/desktop/src/main/calendar/google/sync-service-trigger.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service-trigger.test.ts
@@ -58,7 +58,8 @@ import {
   __resetTriggerForTests,
   triggerGoogleCalendarSyncNow,
   startGoogleCalendarSyncRunner,
-  stopGoogleCalendarSyncRunner
+  stopGoogleCalendarSyncRunner,
+  WINDOW_FOCUS_REASON
 } from './google-sync-runner'
 import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
 
@@ -141,6 +142,14 @@ describe('triggerGoogleCalendarSyncNow (focus/resume/manual refresh)', () => {
     // #then no extra sync fires — alt-tabbing cannot drive network + DB writes
     expect(syncNowMock).toHaveBeenCalledTimes(1)
     vi.useRealTimers()
+  })
+
+  it('keys the focus cooldown on the exact reason main/index.ts passes', () => {
+    // #given main/index.ts calls triggerGoogleCalendarSyncNow('window-focus') on
+    // window focus, and the runner branches on WINDOW_FOCUS_REASON
+    // #then the two must stay identical — the tests above pass the raw literal, so
+    // if the constant drifts the long cooldown silently reverts to 10 s
+    expect(WINDOW_FOCUS_REASON).toBe('window-focus')
   })
 
   it('keeps the short cooldown for non-focus triggers', async () => {

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -140,6 +140,20 @@ External events are **read-mostly**: titles and times sync in. Inline edits prop
 
 While no Google account is linked, the calendar toolbar shows a **Connect Google** button. It opens a short prompt covering what a linked calendar unlocks — seeing your Google events beside notes and tasks, two-way sync, and scheduling tasks and notes on your calendar — then runs the same connect flow as Settings. The button disappears once an account is connected.
 
+### How Often Google Events Refresh
+
+memrynote polls your linked Google calendars about every 5 minutes in the background. When Google
+push notifications are active for your selected calendars, changes arrive as they happen and the
+poll falls back to roughly every 30 minutes.
+
+Two extra pulls sit on top of that: memrynote syncs immediately when your machine wakes from sleep,
+and bringing the memrynote window back to the front pulls again if the last pull was more than two
+minutes ago. Re-focusing the window more often than that is deliberately ignored so alt-tabbing all
+day doesn't hammer the network.
+
+Need something right now? Click the **Refresh Google calendars** button in the calendar toolbar. It
+pulls straight away and never waits on any of the intervals above.
+
 ### Sync Direction
 
 By default Google Calendar sync is **two-way**: events, tasks, reminders, and snoozes you create in memrynote are pushed up to Google, and changes made in Google flow back into memrynote.


### PR DESCRIPTION
## Problem

`mainWindow.on('focus', () => triggerGoogleCalendarSyncNow('window-focus'))` (`apps/desktop/src/main/index.ts:773`) fired a full Google Calendar sync on every window focus, gated only by `TRIGGER_COOLDOWN_MS = 10 * 1000`. An all-day user alt-tabbing in and out of memrynote could drive ~6 full syncs a minute — Google API calls, projection DB writes, and telemetry — on top of the 5-minute periodic poll.

Verified still present on current `origin/main` (`27bc2b961`) before touching anything.

## Root cause

`triggerGoogleCalendarSyncNow` applied one 10-second cooldown to every caller. That value is right for `system-resume` (waking from sleep genuinely needs fresh data, once) but far too short for `window-focus`, which is a high-frequency UI event, not a staleness signal.

## Fix

One cooldown per reason: `window-focus` now needs a 2-minute gap since the last trigger; every other reason keeps the existing 10 s cooldown. `lastTriggerAt` stays a single shared timestamp, so the change is monotone — it can only suppress focus syncs, never add one.

```ts
const cooldownMs =
  reason === WINDOW_FOCUS_REASON ? FOCUS_TRIGGER_COOLDOWN_MS : TRIGGER_COOLDOWN_MS
```

### Follow-up: the `'window-focus'` reason is still a cross-module literal

The runner branches on `WINDOW_FOCUS_REASON`, but the call site in `main/index.ts` passes its own
independent `'window-focus'` literal. If anyone renames the call-site string, the focus cooldown
silently reverts to 10 s and no test catches it.

`WINDOW_FOCUS_REASON` is now **exported** so the call site has something to import. **A follow-up
should switch `mainWindow.on('focus', ...)` in `apps/desktop/src/main/index.ts` to the exported
constant.** That edit is intentionally not in this PR: `index.ts` is being touched by four
concurrent agents (#1020, #1021, #1023, #1024) and the collision risk outweighs the benefit of
bundling a one-line import here.

Until then, `keys the focus cooldown on the exact reason main/index.ts passes` pins the exported
constant to the literal the call site actually passes, so the export cannot drift from the
comparison.

### Freshness guarantee — what the user still gets

Nothing is dropped; the extra work was redundant. Every path that actually bounds staleness is untouched:

- **Periodic poll** — `setInterval(runPeriodicSync, 5 min)` runs independently of `lastTriggerAt`, so worst-case staleness is unchanged at 5 minutes (30 minutes only when Google push channels are live and delivering changes in real time).
- **Manual refresh** — the **Refresh Google calendars** toolbar button goes through `CalendarChannels.invoke.REFRESH_PROVIDER`, which calls `syncGoogleCalendarNow(db)` directly and never consults this cooldown. A user who needs data *now* is never blocked.
- **System resume** — still 10 s, so waking the laptop still syncs immediately.
- **Vault open / account connect** — `startGoogleCalendarSyncRunner()` performs an eager initial sync that ignores `lastTriggerAt` entirely, so switching vaults, signing in, or connecting a Google account still pulls right away.

The only thing lost is the ability to force a pull by clicking away and back within 2 minutes — which the refresh button covers explicitly.

### Cooldown invalidation

This is a debounce over a timestamp, not a cache, so there is no negative result to invalidate and no stale positive to surface:

- Nothing is memoized; each allowed trigger performs a real network sync.
- `lastTriggerAt` only ever delays work. The worst observable outcome is "the calendar refreshes on the poll instead of on focus".
- Vault switch, sign-out, disconnect/reconnect, and token rotation all run through `stop`/`startGoogleCalendarSyncRunner`, and `start` fires an unconditional initial sync — so a carried-over timestamp cannot leave a newly opened vault waiting.

## Test evidence

Added two tests to `sync-service-trigger.test.ts` and retimed one existing test whose 11-second advance no longer clears the focus cooldown.

**RED** (before the fix):

```
FAIL src/main/calendar/google/sync-service-trigger.test.ts > holds window-focus triggers to a 2-minute cooldown, not the short one
AssertionError: expected "vi.fn()" to be called 1 times, but got 5 times
 Test Files  1 failed (1)
      Tests  1 failed | 9 passed (10)
```

**GREEN** (after the fix):

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

**Mutation verification** — two mutants, both killed:

| Mutant | Result |
| --- | --- |
| `const cooldownMs = TRIGGER_COOLDOWN_MS` (revert the fix) | ✅ killed — `holds window-focus triggers to a 2-minute cooldown` → `expected 1 times, but got 5 times` |
| `const cooldownMs = FOCUS_TRIGGER_COOLDOWN_MS` (drop the reason guard) | ✅ killed — `keeps the short cooldown for non-focus triggers` → `expected 2 times, but got 1 times` |
| `WINDOW_FOCUS_REASON = 'focus'` (drift from the call-site literal) | ✅ killed — `expected 'focus' to be 'window-focus'`, plus the behavioural test → `expected 1 times, but got 5 times` |

The second mutant matters: without that test, slowing `system-resume` down to 2 minutes would have slipped through silently. The third is caught twice over — the behavioural tests pass the raw literal, so the pin's distinct value is catching the case where someone "fixes" a drift by updating the tests to use the constant instead of the literal.

**Full verification:**

- `pnpm typecheck` — 16/16 tasks successful
- `pnpm lint` — `✖ 14 problems (0 errors, 14 warnings)`, all pre-existing and none in the changed files
- `pnpm --filter @memry/desktop test:main src/main/calendar/google` — `Test Files 13 passed (13) / Tests 173 passed (173)`
- `pnpm --filter @memry/desktop test:main src/main/index.phase2.test.ts` — 53 passed (focus wiring assertion unchanged)
- `git diff --check` — clean
- `pnpm docs:impact --base origin/main --strict` — `covered`
- `pnpm docs:build` — build complete

## Risk & backward compatibility

Low. No schema, IPC contract, sync protocol, vault format, or settings change — `pnpm ipc:check` is not implicated. The change is one in-memory constant comparison inside the main process; older and newer installs interoperate identically because nothing crosses a persistence or wire boundary. Rollback is reverting one line.

## Merged `origin/main` (#1187 multi-account)

`origin/main` advanced mid-review and #1187 (*multiple Google accounts, per-account calendar
selection*) landed. Merged in (merge, not rebase — the branch was already pushed). The only conflict
was **docs-only**: both sides inserted a `###` section at the same anchor in
`user-guide/calendar.md`. `google-sync-runner.ts` and `sync-service-trigger.test.ts` were untouched
by main, so the fix itself merged clean and both mutation checks were re-run against the merged tree
and still fail correctly.

Resolved by keeping both, not concatenating: #1187's **Multiple Accounts and Calendars** stays in the
slot it landed in, and the cadence section moved below **Sync Direction** so the section reads
*what syncs → which direction → how often*. The wording was adapted to the new structure rather than
pasted back verbatim — it now states that one pull covers every linked account and every ticked
calendar, links to #1187's "the calendar list refreshes on every sync" line (which previously never
defined a cadence), and points at #1187's new **Reconnect required** section, since no interval
revives an account whose sign-in cannot be read. Both cross-reference anchors were verified against
the built HTML (`how-often-google-events-refresh`, `multiple-accounts-and-calendars`,
`if-the-account-says-reconnect-required`).

**The fix got more valuable, not less.** #1187 added a per-account `discoverGoogleCalendarSources`
(`client.listCalendars()` + an upsert per calendar) that now runs on *every* `syncGoogleCalendarNow`
pass. A focus-triggered sync therefore costs N accounts × a calendar-list round trip on top of the
event sync — so the pre-fix "up to 6 focus syncs a minute" is strictly more expensive on today's
`main` than when this issue was filed. Nothing about multi-account changes what the cooldown does:
`syncGoogleCalendarNow` enumerates all accounts internally in a single pass, so one trigger still
refreshes every account and no account can drift out of step with another.

## Overlap note

PR #1110 (`calendar-sync-runner-interval-race`, issue #989) also touches `google-sync-runner.ts`, in `startGoogleCalendarSyncRunner`'s start latch. This PR only changes the constants block and the cooldown comparison inside `triggerGoogleCalendarSyncNow`, so the two are logically independent; whichever lands second may need a trivial textual merge in that file.

Closes #1022
