### PR TITLE
fix(shutdown): scope the window flush handshake per window and request

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -455,6 +455,30 @@ async function flushUntil(predicate: () => boolean, maxTicks = 100): Promise<voi
   }
 }
 
+type FlushDoneListener = (event: { sender: unknown }, requestId?: string) => void
+
+function getFlushDoneListeners(): FlushDoneListener[] {
+  return ipcMainOnMock.mock.calls
+    .filter(([event]) => event === 'app:flush-done')
+    .map(([, handler]) => handler as FlushDoneListener)
+}
+
+function getFlushRequestId(window: ReturnType<typeof createBrowserWindowMock>): string | undefined {
+  return window.webContents.send.mock.calls
+    .filter(([channel]) => channel === 'app:request-flush')
+    .at(-1)?.[1] as string | undefined
+}
+
+// `app:flush-done` is a shared channel, so a reply only counts when it carries
+// the sender and the request id the main process actually asked for. Fanning the
+// reply out to every listener mirrors the real ipcMain dispatch.
+function completeFlush(window: ReturnType<typeof createBrowserWindowMock>): void {
+  const requestId = getFlushRequestId(window)
+  for (const listener of getFlushDoneListeners()) {
+    listener({ sender: window.webContents }, requestId)
+  }
+}
+
 describe('main index phase2 exports', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -1406,10 +1430,7 @@ describe('main index phase2 exports', () => {
     closeHandler()
     BrowserWindowMock.getFocusedWindow.mockReturnValueOnce(mainWindow)
     closeHandler()
-    const flushHandler = ipcMainOnMock.mock.calls.find(
-      ([event]) => event === 'app:flush-done'
-    )?.[1] as () => void
-    flushHandler()
+    completeFlush(browserWindows[0])
     await flushReadyWork()
     expect(mainWindow.close).toHaveBeenCalled()
 
@@ -1598,10 +1619,7 @@ describe('main index phase2 exports', () => {
     beforeQuitHandler({ preventDefault: duplicatePreventDefault })
     expect(duplicatePreventDefault).not.toHaveBeenCalled()
 
-    const flushHandler = ipcMainOnMock.mock.calls.find(
-      ([event]) => event === 'app:flush-done'
-    )?.[1] as () => void
-    flushHandler()
+    completeFlush(browserWindows[0])
     for (let i = 0; i < 40; i++) {
       await Promise.resolve()
     }
@@ -1612,6 +1630,131 @@ describe('main index phase2 exports', () => {
     // Memrynote.exe and blocks the Windows NSIS update install (#805).
     expect(stopEmbeddingModelMock).toHaveBeenCalled()
     expect(stopSyncRuntimeMock).toHaveBeenCalled()
+    expect(closeVaultMock).toHaveBeenCalled()
+  })
+
+  it('removes the flush-done listener when a window flush times out', async () => {
+    // A busy renderer that never answers must not leave a listener behind on the
+    // shared ipcMain: window-close runs on every close, so the leak is unbounded.
+    vi.useFakeTimers()
+    whenReadyMock.mockResolvedValue(undefined)
+
+    await importMainModule()
+    await flushReadyWork()
+    const { ipcMain } = await import('electron')
+
+    const mainWindow = browserWindows[0]
+    const closeHandler = ipcMainOnMock.mock.calls.find(
+      ([event]) => event === 'window-close'
+    )?.[1] as () => void
+    closeHandler()
+
+    const flushListener = getFlushDoneListeners().at(-1)
+    expect(flushListener).toBeDefined()
+
+    vi.advanceTimersByTime(2000)
+    await flushUntil(() => mainWindow.close.mock.calls.length > 0)
+
+    expect(mainWindow.close).toHaveBeenCalled()
+    expect(ipcMain.removeListener).toHaveBeenCalledWith('app:flush-done', flushListener)
+  })
+
+  it('waits for every window to answer its own flush before shutdown continues', async () => {
+    // One window replying must not satisfy the other window's flush, or the
+    // slower renderer is torn down with unsaved edits still pending.
+    vi.useFakeTimers()
+    whenReadyMock.mockResolvedValue(undefined)
+    applyGlobalCaptureShortcutMock.mockReturnValue({ registered: false })
+
+    await importMainModule()
+    await flushReadyWork()
+
+    const shortcutHandler = globalShortcutRegisterMock.mock.calls[0][1] as () => void
+    shortcutHandler()
+    expect(browserWindows.length).toBeGreaterThan(1)
+
+    const beforeQuitHandler = appOnMock.mock.calls.find(
+      ([event]) => event === 'before-quit'
+    )?.[1] as (event: { preventDefault: () => void }) => void
+    beforeQuitHandler({ preventDefault: vi.fn() })
+
+    expect(getFlushDoneListeners()).toHaveLength(browserWindows.length)
+
+    completeFlush(browserWindows[0])
+    await flushUntil(() => closeVaultMock.mock.calls.length > 0, 40)
+    expect(closeVaultMock).not.toHaveBeenCalled()
+
+    completeFlush(browserWindows[1])
+    await flushUntil(() => closeVaultMock.mock.calls.length > 0)
+    expect(closeVaultMock).toHaveBeenCalled()
+  })
+
+  it('ignores a flush-done from another window even when it carries the pending request id', async () => {
+    // Defence in depth on top of the request id: no renderer may answer on
+    // another window's behalf, because that window's saves are still in flight.
+    vi.useFakeTimers()
+    whenReadyMock.mockResolvedValue(undefined)
+    applyGlobalCaptureShortcutMock.mockReturnValue({ registered: false })
+
+    await importMainModule()
+    await flushReadyWork()
+
+    const shortcutHandler = globalShortcutRegisterMock.mock.calls[0][1] as () => void
+    shortcutHandler()
+
+    const beforeQuitHandler = appOnMock.mock.calls.find(
+      ([event]) => event === 'before-quit'
+    )?.[1] as (event: { preventDefault: () => void }) => void
+    beforeQuitHandler({ preventDefault: vi.fn() })
+
+    const impersonatedRequestId = getFlushRequestId(browserWindows[0])
+    for (const listener of getFlushDoneListeners()) {
+      listener({ sender: browserWindows[1].webContents }, impersonatedRequestId)
+    }
+
+    completeFlush(browserWindows[1])
+    await flushUntil(() => closeVaultMock.mock.calls.length > 0, 40)
+    expect(closeVaultMock).not.toHaveBeenCalled()
+
+    completeFlush(browserWindows[0])
+    await flushUntil(() => closeVaultMock.mock.calls.length > 0)
+    expect(closeVaultMock).toHaveBeenCalled()
+  })
+
+  it('ignores a stale flush-done from an earlier request on the same window', async () => {
+    // The close flush timed out and the renderer answered late. That reply is
+    // about older content, so it must not satisfy the quit flush.
+    vi.useFakeTimers()
+    whenReadyMock.mockResolvedValue(undefined)
+
+    await importMainModule()
+    await flushReadyWork()
+
+    const mainWindow = browserWindows[0]
+    const closeHandler = ipcMainOnMock.mock.calls.find(
+      ([event]) => event === 'window-close'
+    )?.[1] as () => void
+    closeHandler()
+    const staleRequestId = getFlushRequestId(mainWindow)
+    vi.advanceTimersByTime(2000)
+    await flushUntil(() => mainWindow.close.mock.calls.length > 0)
+
+    const beforeQuitHandler = appOnMock.mock.calls.find(
+      ([event]) => event === 'before-quit'
+    )?.[1] as (event: { preventDefault: () => void }) => void
+    beforeQuitHandler({ preventDefault: vi.fn() })
+
+    const quitRequestId = getFlushRequestId(mainWindow)
+    expect(quitRequestId).not.toBe(staleRequestId)
+
+    for (const listener of getFlushDoneListeners()) {
+      listener({ sender: mainWindow.webContents }, staleRequestId)
+    }
+    await flushUntil(() => closeVaultMock.mock.calls.length > 0, 40)
+    expect(closeVaultMock).not.toHaveBeenCalled()
+
+    completeFlush(mainWindow)
+    await flushUntil(() => closeVaultMock.mock.calls.length > 0)
     expect(closeVaultMock).toHaveBeenCalled()
   })
 
@@ -1628,10 +1771,7 @@ describe('main index phase2 exports', () => {
     )?.[1] as (event: { preventDefault: () => void }) => void
     beforeQuitHandler({ preventDefault: vi.fn() })
 
-    const flushHandler = ipcMainOnMock.mock.calls.find(
-      ([event]) => event === 'app:flush-done'
-    )?.[1] as () => void
-    flushHandler()
+    completeFlush(browserWindows[0])
     for (let i = 0; i < 40; i++) {
       await Promise.resolve()
     }
@@ -1658,10 +1798,7 @@ describe('main index phase2 exports', () => {
     )?.[1] as (event: { preventDefault: () => void }) => void
     beforeQuitHandler({ preventDefault: vi.fn() })
 
-    const flushHandler = ipcMainOnMock.mock.calls.find(
-      ([event]) => event === 'app:flush-done'
-    )?.[1] as () => void
-    flushHandler()
+    completeFlush(browserWindows[0])
     for (let i = 0; i < 40; i++) {
       await Promise.resolve()
     }
@@ -1698,10 +1835,7 @@ describe('main index phase2 exports', () => {
     )?.[1] as (event: { preventDefault: () => void }) => void
     beforeQuitHandler({ preventDefault: vi.fn() })
 
-    const flushHandler = ipcMainOnMock.mock.calls.find(
-      ([event]) => event === 'app:flush-done'
-    )?.[1] as () => void
-    flushHandler()
+    completeFlush(browserWindows[0])
     for (let i = 0; i < 30; i++) {
       await Promise.resolve()
     }
@@ -1737,10 +1871,7 @@ describe('main index phase2 exports', () => {
     )?.[1] as (event: { preventDefault: () => void }) => void
     beforeQuitHandler({ preventDefault: vi.fn() })
 
-    const flushHandler = ipcMainOnMock.mock.calls.find(
-      ([event]) => event === 'app:flush-done'
-    )?.[1] as () => void
-    flushHandler()
+    completeFlush(browserWindows[0])
     for (let i = 0; i < 20; i++) {
       await Promise.resolve()
     }
@@ -1763,10 +1894,7 @@ describe('main index phase2 exports', () => {
     )?.[1] as (event: { preventDefault: () => void }) => void
     beforeQuitHandler({ preventDefault: vi.fn() })
 
-    const flushHandler = ipcMainOnMock.mock.calls.find(
-      ([event]) => event === 'app:flush-done'
-    )?.[1] as () => void
-    flushHandler()
+    completeFlush(browserWindows[0])
     await flushUntil(() => vi.mocked(app.exit).mock.calls.length > 0)
 
     expect(app.exit).toHaveBeenCalledWith(1)

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,9 +13,10 @@ import {
   nativeImage,
   Menu,
   MenuItem,
-  dialog
+  dialog,
+  type IpcMainEvent
 } from 'electron'
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { join, resolve, normalize } from 'path'
 import { homedir } from 'node:os'
 import { existsSync, readdirSync, statSync, createReadStream } from 'node:fs'
@@ -1888,21 +1889,40 @@ function flushWindow(win: BrowserWindow, timeoutMs = 2000): Promise<void> {
 
     shutdownLog.info('flushWindow: requesting flush from window', win.id)
 
-    const timer = setTimeout(() => {
-      shutdownLog.warn('flushWindow: timeout for window', win.id)
-      resolve()
-    }, timeoutMs)
-
     const channel = 'app:flush-done'
-    const handler = (): void => {
-      shutdownLog.info('flushWindow: flush-done received from window', win.id)
+    const requestId = randomUUID()
+    let settled = false
+
+    const settle = (): void => {
+      if (settled) return
+      settled = true
       clearTimeout(timer)
+      // The timeout path used to skip this: a renderer that never answers left a
+      // listener on the shared ipcMain forever, and window-close runs this on
+      // every close.
       ipcMain.removeListener(channel, handler)
       resolve()
     }
 
+    // `app:flush-done` is one shared channel for every in-flight flush, so a
+    // reply only counts when it comes from this window AND answers this request.
+    // Without both checks the first window to reply resolved all of them, and a
+    // late reply to an earlier request satisfied the next one — either way a
+    // renderer gets torn down with unsaved edits still pending.
+    const handler = (event: IpcMainEvent, doneRequestId?: string): void => {
+      if (event.sender !== win.webContents) return
+      if (doneRequestId !== requestId) return
+      shutdownLog.info('flushWindow: flush-done received from window', win.id)
+      settle()
+    }
+
+    const timer = setTimeout(() => {
+      shutdownLog.warn('flushWindow: timeout for window', win.id)
+      settle()
+    }, timeoutMs)
+
     ipcMain.on(channel, handler)
-    win.webContents.send('app:request-flush')
+    win.webContents.send('app:request-flush', requestId)
   })
 }
 

--- a/apps/desktop/src/preload/api/core.ts
+++ b/apps/desktop/src/preload/api/core.ts
@@ -31,9 +31,11 @@ export const quickCaptureApi = {
 }
 
 export const flushApi = {
-  onFlushRequested: (callback: () => void): (() => void) =>
-    subscribe<void>('app:request-flush', () => callback()),
-  notifyFlushDone: (): void => {
-    ipcRenderer.send('app:flush-done')
+  // The request id scopes the reply to the flush the main process is waiting on;
+  // echo it back untouched or main falls back to its timeout.
+  onFlushRequested: (callback: (requestId?: string) => void): (() => void) =>
+    subscribe<string | undefined>('app:request-flush', (requestId) => callback(requestId)),
+  notifyFlushDone: (requestId?: string): void => {
+    ipcRenderer.send('app:flush-done', requestId)
   }
 }

--- a/apps/desktop/src/preload/api/preload-api.test.ts
+++ b/apps/desktop/src/preload/api/preload-api.test.ts
@@ -105,7 +105,7 @@ describe('preload api wrappers', () => {
     quickCaptureApi.close()
     quickCaptureApi.resize(240)
     quickCaptureApi.openSettings('sync')
-    flushApi.notifyFlushDone()
+    flushApi.notifyFlushDone('flush-1')
 
     expect(electronMock.ipcRenderer.send).toHaveBeenCalledWith('window-minimize')
     expect(electronMock.ipcRenderer.send).toHaveBeenCalledWith('window-maximize')
@@ -116,7 +116,7 @@ describe('preload api wrappers', () => {
       'quick-capture:open-settings',
       'sync'
     )
-    expect(electronMock.ipcRenderer.send).toHaveBeenCalledWith('app:flush-done')
+    expect(electronMock.ipcRenderer.send).toHaveBeenCalledWith('app:flush-done', 'flush-1')
 
     expect(getFileDropPaths([new File(['x'], 'note.md')])).toEqual(['/drop/note.md'])
     expect(electronMock.webUtils.getPathForFile).toHaveBeenCalled()
@@ -129,8 +129,8 @@ describe('preload api wrappers', () => {
     const flushCallback = vi.fn()
     const unsubscribeFlush = flushApi.onFlushRequested(flushCallback)
     const [, flushHandler] = electronMock.ipcRenderer.on.mock.calls.at(-1)!
-    flushHandler({}, undefined)
-    expect(flushCallback).toHaveBeenCalled()
+    flushHandler({}, 'flush-2')
+    expect(flushCallback).toHaveBeenCalledWith('flush-2')
     unsubscribeFlush()
   })
 

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1866,8 +1866,8 @@ interface API extends WindowAPI, GeneratedRpcApi {
   onCrdtStateChanged: (
     callback: (data: { noteId: string; update: number[]; origin: string }) => void
   ) => () => void
-  onFlushRequested: (callback: () => void) => () => void
-  notifyFlushDone: () => void
+  onFlushRequested: (callback: (requestId?: string) => void) => () => void
+  notifyFlushDone: (requestId?: string) => void
 }
 
 declare global {

--- a/apps/desktop/src/renderer/src/hooks/missing-hooks.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/missing-hooks.test.tsx
@@ -522,10 +522,12 @@ describe('navigation and keyboard hooks', () => {
 
     const flush = renderHook(() => useFlushOnQuit())
     await act(async () => {
-      await mocks.taskListeners.flush()
+      await mocks.taskListeners.flush('flush-1')
     })
     expect(mocks.flushAllPendingSaves).toHaveBeenCalled()
-    expect(window.api.notifyFlushDone).toHaveBeenCalled()
+    // The request id has to survive the round trip or main can't tell which
+    // flush was answered and falls back to its timeout.
+    expect(window.api.notifyFlushDone).toHaveBeenCalledWith('flush-1')
     mocks.hasPendingSaves.mockReturnValueOnce(true)
     fireEvent(window, new Event('beforeunload'))
     expect(mocks.flushAllPendingSaves).toHaveBeenCalledTimes(2)

--- a/apps/desktop/src/renderer/src/hooks/use-flush-on-quit.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-flush-on-quit.ts
@@ -6,11 +6,11 @@ const log = createLogger('FlushOnQuit')
 
 export function useFlushOnQuit(): void {
   useEffect(() => {
-    const unsubscribe = window.api.onFlushRequested(() => {
+    const unsubscribe = window.api.onFlushRequested((requestId) => {
       log.info('flush requested by main process')
       void flushAllPendingSaves().then(() => {
         log.info('flush complete, notifying main')
-        window.api.notifyFlushDone()
+        window.api.notifyFlushDone(requestId)
       })
     })
 


### PR DESCRIPTION
Closes #1021

## Problem

`flushWindow()` in `apps/desktop/src/main/index.ts` is the last line of defence against losing unsaved edits at window close and at quit. Two defects on that path:

1. **Listener leak.** The 2 s timeout branch called `resolve()` without `ipcMain.removeListener`. A busy or hung renderer that never answered left its listener on the shared `ipcMain` permanently. `ipcMain.on('window-close')` calls `flushWindow` on *every* window close, so the listener count grew for the life of the process.
2. **Any window could satisfy any flush.** `app:flush-done` had no request id and no `event.sender` check. `flushAllWindows()` registers one listener per window on that same channel, so the **first** window to reply resolved **all** of them — shutdown then continued while slower renderers still had saves in flight. A late reply to an earlier request (close flush timed out, renderer answered afterwards) could likewise satisfy the *next* request for the same window.

## Root cause

One shared, unscoped IPC channel used for N concurrent request/response pairs, plus a cleanup path that only ran on the success branch. `apps/desktop/src/main/lib/window-rpc.ts` already solves exactly this with a per-request id and a sender check; `flushWindow` predated it and never adopted the pattern.

## Fix

- `app:request-flush` now carries a `randomUUID()` request id; the renderer echoes it back on `app:flush-done` (`preload/api/core.ts`, `renderer/src/hooks/use-flush-on-quit.ts`).
- The main-side handler accepts a reply only when `event.sender === win.webContents` **and** the echoed id matches this request.
- Reply and timeout both go through a single idempotent `settle()` that always `clearTimeout`s and `ipcMain.removeListener`s.

Nothing was dropped or shortened. The failure mode is unchanged and still conservative: an unrecognised or absent reply simply falls through to the existing 2 s timeout, which resolves and lets shutdown continue exactly as it does today. No new way to lose data was introduced; two existing ways were removed.

## Test evidence

New tests in `apps/desktop/src/main/index.phase2.test.ts` (four), written before the fix.

RED, on unmodified `origin/main` code:

```
 FAIL  src/main/index.phase2.test.ts > removes the flush-done listener when a window flush times out
 FAIL  src/main/index.phase2.test.ts > waits for every window to answer its own flush before shutdown continues
 FAIL  src/main/index.phase2.test.ts > ignores a stale flush-done from an earlier request on the same window
 Tests  3 failed | 53 passed (56)
```

GREEN, after the fix:

```
 Tests  57 passed (57)
```

Full main-process suite:

```
 Test Files  475 passed | 1 skipped (476)
      Tests  5420 passed | 1 expected fail | 4 skipped (5425)
```

### Mutation verification

Each fix line reverted individually; every mutant died.

| Mutant | Test that caught it | Result |
| --- | --- | --- |
| timeout branch `settle()` -> `resolve()` (drops the listener cleanup) | `removes the flush-done listener when a window flush times out` | `Tests  1 failed \| 56 passed (57)` |
| drop `if (event.sender !== win.webContents) return` | `ignores a flush-done from another window even when it carries the pending request id` | `Tests  1 failed \| 56 passed (57)` |
| drop `if (doneRequestId !== requestId) return` | `ignores a stale flush-done from an earlier request on the same window` | `Tests  1 failed \| 56 passed (57)` |

Note on the second row: on the first pass the sender mutant **survived**, because the multi-window test was already killed by the request-id check alone (a `randomUUID` no other window can produce). Rather than accept a near-equivalent mutant, a fourth test was added that pins the sender check on its own terms — a window replying with *another* window's live request id must be ignored. That test kills it. The sender check is defence in depth on top of the id; both are kept because both are cheap and the issue asked for both.

## Verification

```
pnpm typecheck        -> 16 successful, 16 total
pnpm lint             -> 14 problems (0 errors, 14 warnings); zero in the touched files, all pre-existing
pnpm ipc:generate && pnpm ipc:check
                      -> Generated RPC bindings are up to date / IPC invoke map is up to date
                         (no regenerated output; the flush channels are hand-wired, not in the generated map)
pnpm --filter @memry/desktop test:main                        -> 5420 passed
pnpm exec vitest run --project renderer .../missing-hooks.test.tsx -> PASS (13) FAIL (0)
pnpm exec vitest run --project preload  .../preload-api.test.ts    -> PASS (8)  FAIL (0)
git diff --check      -> clean
```

## Risk and backward compatibility

Low. No database, sync-protocol, vault-format or settings change — nothing persisted or sent over the wire is touched, so nothing here can be read by, or has to tolerate, another app version. `app:request-flush` / `app:flush-done` are purely intra-process channels between the main process and its own renderer; main, preload and renderer ship in the same asar, so there is no version skew across the new argument. The main-side handler still tolerates a missing request id (it just falls through to the pre-existing 2 s timeout), so a stale renderer surviving a hot reload degrades to today's behavior rather than hanging.

The user-visible effect is only that a multi-window quit now waits for each window's own flush instead of the fastest one — strictly more saved work, at the cost of up to the same 2 s per-window bound that already existed.

No cache or latch was added.

## Scope

`flushWindow`/`flushAllWindows` only. `broadcastToAllWindows` and the window fan-out helpers touched by PRs #1119 and #937 are deliberately untouched; this change sits beside them in `index.ts` but shares no code with them, so it should rebase cleanly either way.

Docs gate: `pnpm docs:impact --strict` reports `missing-docs` for `apps/desktop/src/main/index.ts`, `preload/api/core.ts`, `preload/index.d.ts` and `use-flush-on-quit.ts`. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: this is an internal IPC-handshake correctness fix on the shutdown path with no user-facing surface, setting, or workflow change — there is no page under `apps/docs/src/**` that describes this behavior, and adding one would document an implementation detail.