### PR TITLE
fix(secrets): let a connect flow replace a secret it cannot decrypt

### DIFF
--- a/apps/desktop/src/main/calendar/google/keychain.ts
+++ b/apps/desktop/src/main/calendar/google/keychain.ts
@@ -40,7 +40,14 @@ async function getPassword(accountId: string, kind: GoogleTokenKind): Promise<st
   const account = getAccountKey(accountId, kind)
 
   try {
-    return await getSecret(SERVICE, account)
+    // Every consumer of these tokens either overwrites them (the OAuth connect
+    // and the refresh path), deletes them (disconnect), or only asks whether the
+    // account is still authorized. So an entry we cannot decrypt — the profiles
+    // stranded by the v2026-08-06 app-identity rename — must read as absent
+    // rather than throw, otherwise the pre-write read at oauth.ts kills the
+    // connect flow before the fresh tokens are ever stored and the account can
+    // never be reconnected from inside the app.
+    return await getSecret(SERVICE, account, { treatUnreadableAsAbsent: true })
   } catch (error) {
     throw new Error(
       `Failed to read Google Calendar credential (${account}): ${error instanceof Error ? error.message : 'unknown error'}`

--- a/apps/desktop/src/main/calendar/google/oauth-poisoned-secret.test.ts
+++ b/apps/desktop/src/main/calendar/google/oauth-poisoned-secret.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Regression cover for the "Connect can never recover" deadlock.
+ *
+ * An install that ran v2026-08-06 wrote its Google tokens under the short-lived
+ * `memrynote` safeStorage key; app-identity.ts then pinned the profile back to
+ * the legacy name, so those ciphertexts are undecryptable forever and keytar has
+ * no copy left. getSecret's #772 guard then THROWS rather than reporting the
+ * secret as absent — and connectGoogleCalendar reads the existing tokens BEFORE
+ * it stores the fresh ones, so the throw killed the flow before the write. Every
+ * retry hit the same wall, with no path back from inside the app.
+ *
+ * These tests drive the real oauth.ts + keychain.ts + secret-storage.ts against
+ * a real on-disk store seeded with an undecryptable entry.
+ */
+import fs from 'node:fs'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import keytar from 'keytar'
+
+const harness = vi.hoisted(() => ({
+  userDataDir: '',
+  keytarStore: new Map<string, string>()
+}))
+
+const mockOpenExternal = vi.fn()
+
+vi.mock('electron', () => ({
+  shell: {
+    openExternal: (...args: unknown[]) => mockOpenExternal(...args)
+  },
+  app: {
+    isReady: () => true,
+    getPath: (name: string) => {
+      if (name !== 'userData') throw new Error(`unexpected getPath(${name})`)
+      return harness.userDataDir
+    }
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    getSelectedStorageBackend: () => 'keychain_access',
+    encryptString: (value: string) => Buffer.from(`enc:${value}`, 'utf-8'),
+    decryptString: (buf: Buffer) => {
+      const raw = buf.toString('utf-8')
+      // Anything not written under the current identity fails to decrypt, which
+      // is exactly what Chromium's OSCrypt does with a foreign key.
+      if (!raw.startsWith('enc:')) throw new Error('safeStorage decrypt failed')
+      return raw.slice('enc:'.length)
+    }
+  }
+}))
+
+vi.mock('keytar', () => ({
+  default: {
+    setPassword: vi.fn(),
+    getPassword: vi.fn(),
+    deletePassword: vi.fn()
+  }
+}))
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}))
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => loggerMock
+}))
+
+vi.mock('../repositories/calendar-sources-repository', () => ({
+  listCalendarSources: vi.fn(() => [])
+}))
+
+vi.mock('../../lib/main-i18n', () => ({
+  getMainI18n: () => ({
+    t: (key: string) => key,
+    getFixedT: () => (key: string) => key
+  })
+}))
+
+import {
+  connectGoogleCalendar,
+  disconnectGoogleCalendar,
+  hasGoogleCalendarLocalAuth
+} from './oauth'
+import { getGoogleCalendarTokens, hasGoogleCalendarTokens } from './keychain'
+import { SECRET_STORE_FILENAME, resetSecretStorageForTests } from '../../secrets/secret-storage'
+
+const SERVICE = 'com.memry.calendar.google'
+const ACCOUNT_ID = 'user@example.com'
+
+const storeFilePath = (): string => path.join(harness.userDataDir, SECRET_STORE_FILENAME)
+
+const readStore = (): { entries: Record<string, Record<string, string>> } =>
+  JSON.parse(fs.readFileSync(storeFilePath(), 'utf-8'))
+
+/** Ciphertext this run's identity cannot decrypt — the poisoned v2026-08-06 entry. */
+const poisoned = (value: string): string =>
+  Buffer.from(`foreign-key:${value}`, 'utf-8').toString('base64')
+
+const seedPoisonedTokens = (): void => {
+  fs.mkdirSync(harness.userDataDir, { recursive: true })
+  fs.writeFileSync(
+    storeFilePath(),
+    JSON.stringify({
+      version: 1,
+      entries: {
+        [SERVICE]: {
+          [`access-token-${ACCOUNT_ID}`]: poisoned('dead-access'),
+          [`refresh-token-${ACCOUNT_ID}`]: poisoned('dead-refresh')
+        }
+      }
+    }),
+    'utf-8'
+  )
+}
+
+const stubGoogleEndpoints = (): void => {
+  const fetchMock = vi.fn<typeof fetch>(async (input) => {
+    const url = String(input)
+    if (url === 'https://oauth2.googleapis.com/token') {
+      return new Response(
+        JSON.stringify({
+          access_token: 'fresh-access-token',
+          refresh_token: 'fresh-refresh-token',
+          expires_in: 3600,
+          scope: 'openid email profile https://www.googleapis.com/auth/calendar',
+          token_type: 'Bearer'
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+    if (url === 'https://www.googleapis.com/oauth2/v2/userinfo') {
+      return new Response(
+        JSON.stringify({ email: ACCOUNT_ID, verified_email: true, name: 'User Example' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+    if (url === 'https://www.googleapis.com/calendar/v3/users/me/calendarList/primary') {
+      return new Response(
+        JSON.stringify({
+          id: ACCOUNT_ID,
+          summary: 'User Example',
+          timeZone: 'Europe/Istanbul',
+          primary: true
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+    if (url === 'https://oauth2.googleapis.com/revoke') {
+      return new Response('', { status: 200 })
+    }
+    throw new Error(`Unexpected fetch call: ${url}`)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+
+  mockOpenExternal.mockImplementation(async (authUrl: string) => {
+    const parsed = new URL(authUrl)
+    const state = parsed.searchParams.get('state')
+    const redirectUri = parsed.searchParams.get('redirect_uri')
+    setTimeout(() => {
+      http.get(`${redirectUri}?code=google-auth-code&state=${state}`)
+    }, 0)
+  })
+}
+
+describe('google calendar OAuth with an undecryptable stored token', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSecretStorageForTests()
+    harness.keytarStore.clear()
+    harness.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-google-poisoned-'))
+    process.env.GOOGLE_CALENDAR_CLIENT_ID = 'google-client-id-123'
+    delete process.env.GOOGLE_CALENDAR_CLIENT_SECRET
+    delete process.env.MEMRY_DEVICE
+
+    vi.mocked(keytar.setPassword).mockImplementation(async (service, account, value) => {
+      harness.keytarStore.set(`${service}:${account}`, value)
+    })
+    vi.mocked(keytar.getPassword).mockImplementation(
+      async (service, account) => harness.keytarStore.get(`${service}:${account}`) ?? null
+    )
+    vi.mocked(keytar.deletePassword).mockImplementation(async (service, account) =>
+      harness.keytarStore.delete(`${service}:${account}`)
+    )
+
+    seedPoisonedTokens()
+  })
+
+  afterEach(() => {
+    delete process.env.GOOGLE_CALENDAR_CLIENT_ID
+    vi.unstubAllGlobals()
+    fs.rmSync(harness.userDataDir, { recursive: true, force: true })
+  })
+
+  it('completes the connect flow and persists the fresh tokens over the poisoned ones', async () => {
+    stubGoogleEndpoints()
+
+    const result = await connectGoogleCalendar()
+
+    expect(result.accountId).toBe(ACCOUNT_ID)
+    // The whole point: the write at the end of the flow was reached.
+    expect(await getGoogleCalendarTokens(ACCOUNT_ID)).toEqual({
+      accessToken: 'fresh-access-token',
+      refreshToken: 'fresh-refresh-token'
+    })
+    // And the undecryptable bytes are gone from disk, not merely shadowed.
+    const entries = readStore().entries[SERVICE]
+    expect(entries[`access-token-${ACCOUNT_ID}`]).not.toBe(poisoned('dead-access'))
+    expect(entries[`refresh-token-${ACCOUNT_ID}`]).not.toBe(poisoned('dead-refresh'))
+  })
+
+  it('reports the account as needing reconnect instead of throwing at status read', async () => {
+    await expect(hasGoogleCalendarTokens(ACCOUNT_ID)).resolves.toBe(false)
+    await expect(hasGoogleCalendarLocalAuth(ACCOUNT_ID)).resolves.toBe(false)
+    await expect(getGoogleCalendarTokens(ACCOUNT_ID)).resolves.toEqual({
+      accessToken: null,
+      refreshToken: null
+    })
+  })
+
+  it('disconnect clears the poisoned entries instead of throwing', async () => {
+    stubGoogleEndpoints()
+
+    await expect(disconnectGoogleCalendar(ACCOUNT_ID)).resolves.toBeUndefined()
+
+    expect(readStore().entries[SERVICE]).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/main/capture/pairing.ts
+++ b/apps/desktop/src/main/capture/pairing.ts
@@ -23,7 +23,10 @@ export async function getCaptureToken(): Promise<string> {
   if (cachedToken) return cachedToken
   if (inFlightRead) return inFlightRead
   inFlightRead = (async () => {
-    const existing = await getSecret(SERVICE, ACCOUNT)
+    // An unreadable token is replaced on the next line, so treating it as
+    // absent is safe and is the only way a profile stranded by the
+    // v2026-08-06 identity rename can ever pair the clipper again.
+    const existing = await getSecret(SERVICE, ACCOUNT, { treatUnreadableAsAbsent: true })
     const token = existing ?? generateToken()
     if (!existing) await setSecret(SERVICE, ACCOUNT, token)
     cachedToken = token

--- a/apps/desktop/src/main/import/onenote/onenote-auth.ts
+++ b/apps/desktop/src/main/import/onenote/onenote-auth.ts
@@ -94,7 +94,11 @@ async function writeSecret(
 }
 
 async function readSecret(accountId: string, kind: OneNoteSecretKind): Promise<string | null> {
-  return getSecret(SERVICE, accountKey(accountId, kind))
+  // Same contract as the Google Calendar keychain: these reads either precede a
+  // write, precede a sign-out, or answer "is this account still connected". An
+  // entry left undecryptable by the v2026-08-06 app-identity rename therefore
+  // reads as absent so the user can simply sign in again.
+  return getSecret(SERVICE, accountKey(accountId, kind), { treatUnreadableAsAbsent: true })
 }
 
 const TokenResponseSchema = z.object({

--- a/apps/desktop/src/main/secrets/secret-storage.test.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.test.ts
@@ -317,6 +317,56 @@ describe('secret-storage', () => {
     })
   })
 
+  describe('treatUnreadableAsAbsent opt-in', () => {
+    const seedUndecryptable = (): void => {
+      fs.mkdirSync(harness.userDataDir, { recursive: true })
+      fs.writeFileSync(
+        storeFilePath(),
+        JSON.stringify({ version: 1, entries: { [SERVICE]: { [ACCOUNT]: 'not-decryptable' } } }),
+        'utf-8'
+      )
+      harness.keytarStore.clear()
+    }
+
+    it('returns null instead of throwing for a caller that is about to overwrite', async () => {
+      seedUndecryptable()
+
+      await expect(
+        getSecret(SERVICE, ACCOUNT, { treatUnreadableAsAbsent: true })
+      ).resolves.toBeNull()
+    })
+
+    it('also covers the safeStorage-unavailable-this-run shape', async () => {
+      await setSecret(SERVICE, ACCOUNT, 'store-value')
+      harness.keytarStore.clear()
+      harness.encryptionAvailable = false
+
+      await expect(
+        getSecret(SERVICE, ACCOUNT, { treatUnreadableAsAbsent: true })
+      ).resolves.toBeNull()
+    })
+
+    it('lets the caller heal the entry by writing over it', async () => {
+      seedUndecryptable()
+
+      expect(await getSecret(SERVICE, ACCOUNT, { treatUnreadableAsAbsent: true })).toBeNull()
+      await setSecret(SERVICE, ACCOUNT, 'healed-value')
+
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('healed-value')
+    })
+
+    it('leaves the guard armed for every caller that does not opt in', async () => {
+      // The master-key path must keep throwing: a false absence there
+      // regenerates the vault key and orphans the encrypted data (#772).
+      seedUndecryptable()
+
+      await expect(getSecret(SERVICE, ACCOUNT)).rejects.toThrow(/could not be read this run/)
+      await expect(getSecret(SERVICE, ACCOUNT, { treatUnreadableAsAbsent: false })).rejects.toThrow(
+        /could not be read this run/
+      )
+    })
+  })
+
   describe('deferred keytar delete', () => {
     it('persists the migrated secret but keeps the keytar copy until finalize', async () => {
       harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'master-key-material')

--- a/apps/desktop/src/main/secrets/secret-storage.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.ts
@@ -26,6 +26,21 @@ export interface GetSecretOptions {
    * (see finalizeKeytarMigration and crypto/vault-key-state.ts).
    */
   deferKeytarDelete?: boolean
+  /**
+   * Return `null` instead of throwing when the secret exists in the store but
+   * cannot be read this run (see the guard in getSecret).
+   *
+   * Opt in ONLY where a false absence is harmless because the very next thing
+   * the caller does is overwrite the entry, delete it, or report "not
+   * connected". Never opt in from a path that would regenerate key material or
+   * tear down local state on absence — that is the #772 data-loss shape the
+   * guard exists to prevent.
+   *
+   * Without this, an entry left undecryptable by the v2026-08-06 app-identity
+   * rename could never be replaced: the pre-write read threw before the write
+   * ran, so re-connecting an account was permanently impossible.
+   */
+  treatUnreadableAsAbsent?: boolean
 }
 
 // Lazy keytar cleanup (crash-resume: ciphertext persisted but the keytar
@@ -257,6 +272,15 @@ export async function getSecret(
   // its encrypted data. This is the failure mode behind the #772 keytar→
   // safeStorage regression. Fail loud so the caller retries on a healthy run.
   if (storePath !== null && readCiphertext(storePath, service, account) !== null) {
+    if (options?.treatUnreadableAsAbsent) {
+      // Logged at warn so the cohort stranded by the identity rename is
+      // measurable, and so a caller that opted in by mistake is still visible.
+      logger.warn('Secret exists but is unreadable; caller opted to treat it as absent', {
+        service,
+        account
+      })
+      return null
+    }
     throw new Error(
       `Secret ${service}/${account} exists in the secret store but could not be read this run; ` +
         'refusing to report it as absent'

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -77,7 +77,17 @@ key for other worktrees.
 
 An unreadable secret is never reported as absent. `getSecret()` throws when a ciphertext exists in
 the store but cannot be decrypted this run, because the callers that act on a `null` are destructive:
-they regenerate the vault master key or tear down local sync state. Relatedly, an `integrity`
+they regenerate the vault master key or tear down local sync state.
+
+The one exception is explicit and per-call. `getSecret(service, account, { treatUnreadableAsAbsent:
+true })` returns `null` instead, and is used only where a false absence cannot lose anything because
+the entry is immediately overwritten, immediately deleted, or only used to answer "is this account
+still connected": the Google Calendar keychain, the capture pairing token, and the OneNote auth
+store. Without it those flows could not recover at all — a re-connect reads the existing tokens
+before it writes the fresh ones, so a throw killed the flow before the write and the undecryptable
+entry could never be replaced. Every other caller, the master key included, keeps the guard armed.
+Each opt-in read that hits an unreadable entry is logged at `warn` so the affected population stays
+visible. Relatedly, an `integrity`
 teardown — which `checkSyncIntegrity()` triggers from a single failed device-signing-key read — clears
 the session tokens and the signing key but **never the vault master key**. That key cannot be
 re-issued by signing in again, so it is not collateral for another entry's absence; only an explicit

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -179,6 +179,16 @@ improve AI models.
 Note that promoting an external event (above) copies it into your vault as a memrynote event. From
 then on it is your own event, and the assistant can read it regardless of this setting.
 
+### If the account says "Reconnect required"
+
+An account can drop back to **Reconnect required** without you doing anything — most often after an
+app update, because the stored Google tokens are encrypted with a key tied to the app's identity on
+your machine and that identity can change across versions. memrynote never guesses at a credential
+it cannot read, so it asks you to reconnect rather than syncing with something stale.
+
+Press **Connect** and sign in again. That writes fresh tokens over the unreadable ones, and your
+calendars, selections and existing events are untouched — only the sign-in is redone.
+
 ## Day Cell Click Behavior
 
 [Settings → Calendar](/user-guide/settings#calendar) lets you choose what clicking a date does by default:


### PR DESCRIPTION
## What users see

On macOS, Google Calendar shows a red wall of text instead of a connection status, and pressing **Connect** never fixes it. You authorize in the browser, get sent back, and land on the same error:

> Failed to read Google Calendar credential (access-token-…): Secret com.memry.calendar.google/access-token-… exists in the secret store but could not be read this run; refusing to report it as absent

Reproduced on a real production install (v2026.807.2) and traced end to end.

## Root cause

Two layers.

**The poisoned data.** v2026-08-06 renamed the app unconditionally, so Chromium minted a second macOS Safe Storage key. Both items are still on the affected machine:

| keychain item | created |
|---|---|
| `@memry/desktop Safe Storage` | 2026-07-17 |
| `memrynote Safe Storage` | **2026-08-06** — release day |

Anything written during that window is encrypted under the `memrynote` key. `app-identity.ts` then correctly pinned the profile back to `@memry/desktop`, so those entries are undecryptable for good, and their keytar copies had already been dropped at migration.

The store is therefore *mixed*, which is the fingerprint: in the same file and the same run, one Google account's tokens log `Stored secret ciphertext unreadable` while a second account's decrypt fine. That rules out corruption and rules out safeStorage being unavailable — both are all-or-nothing.

**The deadlock.** `connectGoogleCalendar` reads the existing tokens at `oauth.ts:454` before storing the fresh ones at `:460`. That read hits `getSecret`'s #772 guard, which throws rather than reporting the secret as absent. So the throw killed the flow before the write: the good new grant was never persisted, the poisoned entry survived, and every retry hit the same wall. Disconnect goes through the same read, so there was no path back from inside the app.

The guard itself is right — a false absence on the master-key path regenerates the vault key and orphans the data. It is just wrong for a caller that was about to overwrite the entry anyway.

## The fix

Add an explicit `treatUnreadableAsAbsent` opt-in to `getSecret` and use it from the three call sites where a false absence cannot lose anything, because the entry is immediately overwritten, immediately deleted, or only read to answer "is this account still connected":

- `calendar/google/keychain.ts` — every consumer overwrites (connect, refresh), deletes (disconnect), or is a status probe, so one opt-in there fixes the connect flow, the disconnect flow, the refresh path, the settings row and the device-link transfer with no changes to any of them
- `capture/pairing.ts` — the token is regenerated on the next line
- `import/onenote/onenote-auth.ts` — same contract as Google

Every other caller, the master key included, keeps the guard armed. Opt-in reads that hit an unreadable entry log at `warn`, so the affected population stays visible.

## Blast radius

macOS only (Windows uses DPAPI, Linux keeps the legacy name). Affects any install whose profile predates the rename, ran v2026-08-06, and wrote a secret during that window. Google Calendar qualifies easily: `client.ts:366` re-stores tokens on **every** access-token refresh, roughly hourly, so any such user with Calendar connected for an hour on that build is stranded.

After this, they press **Connect** once and it works. The refresh token itself is unrecoverable, so re-authorizing is the only possible recovery — this change is what makes it reachable.

## Tests

`oauth-poisoned-secret.test.ts` drives the real `oauth.ts` + `keychain.ts` + `secret-storage.ts` against a real on-disk store seeded with an undecryptable entry:

- the full connect flow completes and the fresh tokens land on disk over the poisoned bytes
- the status read reports `false` instead of throwing
- disconnect clears the entries instead of throwing

Plus unit cover in `secret-storage.test.ts` for the option itself, including that the guard **stays armed** for callers that do not opt in.

All six failed before the change and pass after.

## Verification

- `pnpm exec vitest run --project main` — 5424 passed, 0 failed, 4 skipped
- `pnpm typecheck` — 16/16 tasks
- `pnpm lint` — 0 errors (14 pre-existing renderer warnings, untouched)
- `pnpm docs:impact --base 27bc2b961 --strict` — covered
- `pnpm docs:build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)