### PR TITLE
perf(vault): resolve a note's embeds against one config read and one index scan

### DIFF
--- a/apps/desktop/src/main/vault/resolve-embed.test.ts
+++ b/apps/desktop/src/main/vault/resolve-embed.test.ts
@@ -182,4 +182,46 @@ describe('resolveVaultEmbed', () => {
     const resolved = resolver.resolveVaultEmbeds(['Images/photo.png', 'missing.png'])
     expect(Object.keys(resolved)).toEqual(['Images/photo.png'])
   })
+
+  // The batch exists so that opening a note costs one round trip. Resolving each
+  // ref on its own re-read config.json (readFileSync + JSON.parse) and re-ran the
+  // whole-image-table fallback scan once per embed, so a 20-image note paid both
+  // costs 20 times.
+  it('reads the vault config once and touches the index once for a whole batch', () => {
+    writeVaultFile('Images/photo.png')
+    writeVaultFile('deep/nested/found.png')
+    indexDb.sqlite
+      .prepare(
+        `INSERT INTO note_cache (id, path, title, file_type, created_at, modified_at)
+         VALUES (?, ?, ?, 'image', 0, 0)`
+      )
+      .run('img1', 'deep/nested/found.png', 'found')
+
+    const readConfig = vi.mocked(vaultIndex.getConfig)
+    const openIndex = vi.mocked(database.getIndexDatabase)
+    readConfig.mockClear()
+    openIndex.mockClear()
+
+    const resolved = resolver.resolveVaultEmbeds([
+      'Images/photo.png',
+      'found.png',
+      'missing-one.png',
+      'missing-two.png'
+    ])
+
+    expect(Object.keys(resolved).sort()).toEqual(['Images/photo.png', 'found.png'])
+    expect.soft(readConfig).toHaveBeenCalledTimes(1)
+    expect.soft(openIndex).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the index entirely when every target is already on disk', () => {
+    writeVaultFile('Images/a.png')
+    writeVaultFile('Images/b.png')
+    const openIndex = vi.mocked(database.getIndexDatabase)
+    openIndex.mockClear()
+
+    resolver.resolveVaultEmbeds(['Images/a.png', 'Images/b.png'])
+
+    expect(openIndex).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/main/vault/resolve-embed.ts
+++ b/apps/desktop/src/main/vault/resolve-embed.ts
@@ -49,10 +49,18 @@ function candidatePaths(vaultPath: string, notesFolder: string, ref: string): st
 }
 
 /**
- * Look a bare filename up in the index, which already carries every non-markdown
+ * Look bare filenames up in the index, which already carries every non-markdown
  * file in the vault (`indexBinaryFile`). Paths are vault-relative.
+ *
+ * Takes the whole batch at once: the query has no filename predicate to push
+ * down (`note_cache` stores full paths, not basenames), so running it per ref
+ * re-read every image row in the vault once per embed. Keys are lowercased
+ * filenames, matching how the caller looks them up.
  */
-function lookupByFilename(vaultPath: string, filename: string): string | null {
+function lookupByFilenames(vaultPath: string, filenames: Set<string>): Map<string, string> {
+  const found = new Map<string, string>()
+  if (filenames.size === 0) return found
+
   try {
     const db = getIndexDatabase()
     const rows = db
@@ -61,22 +69,28 @@ function lookupByFilename(vaultPath: string, filename: string): string | null {
       .where(eq(noteCache.fileType, 'image'))
       .all()
 
-    // Several folders can hold the same filename; Obsidian picks the shortest
-    // path, which is also the least surprising answer here.
-    const matches = rows
-      .map((row) => row.path)
-      .filter((p) => path.basename(p).toLowerCase() === filename.toLowerCase())
-      .sort((a, b) => a.split('/').length - b.split('/').length || a.localeCompare(b))
+    const byName = new Map<string, string[]>()
+    for (const row of rows) {
+      const name = path.basename(row.path).toLowerCase()
+      if (!filenames.has(name)) continue
+      const paths = byName.get(name)
+      if (paths) paths.push(row.path)
+      else byName.set(name, [row.path])
+    }
 
-    const match = matches[0]
-    if (!match) return null
+    for (const [name, paths] of byName) {
+      // Several folders can hold the same filename; Obsidian picks the shortest
+      // path, which is also the least surprising answer here.
+      paths.sort((a, b) => a.split('/').length - b.split('/').length || a.localeCompare(b))
 
-    const absPath = path.resolve(vaultPath, match)
-    return isInsideVault(vaultPath, absPath) && fs.existsSync(absPath) ? absPath : null
+      const absPath = path.resolve(vaultPath, paths[0])
+      if (isInsideVault(vaultPath, absPath) && fs.existsSync(absPath)) found.set(name, absPath)
+    }
   } catch (error) {
-    logger.warn('index lookup failed', { filename, error })
-    return null
+    logger.warn('index lookup failed', { filenames: [...filenames], error })
   }
+
+  return found
 }
 
 /**
@@ -97,29 +111,55 @@ function embedTarget(vaultPath: string, absPath: string, notePath?: string): str
   return encodeAttachmentUrl(relative)
 }
 
+/** The file on disk an embed target names, or null when nothing is there. */
+function findOnDisk(vaultPath: string, notesFolder: string, ref: string): string | null {
+  for (const candidate of candidatePaths(vaultPath, notesFolder, ref)) {
+    if (!isInsideVault(vaultPath, candidate)) continue
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate
+  }
+  return null
+}
+
+/**
+ * Resolve a batch against one already-read vault path and notes folder. Refs
+ * that miss on disk are collected and handed to the index in a single lookup,
+ * which is skipped entirely when everything was found on disk.
+ */
+function resolveAgainstVault(
+  vaultPath: string,
+  notesFolder: string,
+  refs: string[],
+  notePath?: string
+): Record<string, string> {
+  const resolved: Record<string, string> = {}
+  const pending = new Map<string, string>()
+
+  for (const ref of refs) {
+    // A URL or an absolute path is not ours to resolve.
+    if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(ref) || path.isAbsolute(ref)) continue
+
+    const onDisk = findOnDisk(vaultPath, notesFolder, ref)
+    if (onDisk) resolved[ref] = embedTarget(vaultPath, onDisk, notePath)
+    else pending.set(ref, path.basename(ref).toLowerCase())
+  }
+
+  const byName = lookupByFilenames(vaultPath, new Set(pending.values()))
+  for (const [ref, filename] of pending) {
+    const absPath = byName.get(filename)
+    if (absPath) resolved[ref] = embedTarget(vaultPath, absPath, notePath)
+  }
+
+  return resolved
+}
+
 /**
  * Resolve one embed target, or null when the vault is closed or nothing matches.
  * See the module comment for why `notePath` changes the shape of the result.
  */
 export function resolveVaultEmbed(ref: string, notePath?: string): string | null {
-  const status = getStatus()
-  if (!status.isOpen || !status.path) return null
-  const vaultPath = status.path
-
-  // A URL or an absolute path is not ours to resolve.
-  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(ref) || path.isAbsolute(ref)) return null
-
-  const notesFolder = getConfig().defaultNoteFolder || 'notes'
-
-  for (const candidate of candidatePaths(vaultPath, notesFolder, ref)) {
-    if (!isInsideVault(vaultPath, candidate)) continue
-    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
-      return embedTarget(vaultPath, candidate, notePath)
-    }
-  }
-
-  const byName = lookupByFilename(vaultPath, path.basename(ref))
-  return byName ? embedTarget(vaultPath, byName, notePath) : null
+  const resolved = resolveVaultEmbeds([ref], notePath)
+  // Plain `resolved[ref]` would read through the prototype for a ref like `__proto__`.
+  return Object.prototype.hasOwnProperty.call(resolved, ref) ? resolved[ref] : null
 }
 
 /**
@@ -128,10 +168,12 @@ export function resolveVaultEmbed(ref: string, notePath?: string): string | null
  * Unresolvable targets are omitted rather than mapped to null.
  */
 export function resolveVaultEmbeds(refs: string[], notePath?: string): Record<string, string> {
-  const resolved: Record<string, string> = {}
-  for (const ref of refs) {
-    const target = resolveVaultEmbed(ref, notePath)
-    if (target) resolved[ref] = target
-  }
-  return resolved
+  const status = getStatus()
+  if (!status.isOpen || !status.path) return {}
+
+  // Read once per batch, not once per ref: `getConfig` re-reads and re-parses
+  // config.json off disk on every call.
+  const notesFolder = getConfig().defaultNoteFolder || 'notes'
+
+  return resolveAgainstVault(status.path, notesFolder, refs, notePath)
 }


### PR DESCRIPTION
## Problem

`resolveVaultEmbeds(refs, notePath)` was a thin loop over `resolveVaultEmbed(ref, notePath)`, and each iteration paid the full setup cost from scratch:

- `getConfig()` → `readVaultConfig` → `fs.readFileSync` + `JSON.parse` of `.memry/config.json` (`apps/desktop/src/main/vault/init.ts`), once **per embed**.
- on a filesystem miss, `lookupByFilename` ran `SELECT path FROM note_cache WHERE file_type = 'image'` — **every image row in the vault** — then filtered and sorted it in JS, once **per embed**.

Opening a note with 20 images in a 5,000-image vault therefore cost 20 synchronous config reads and 20 full image-table scans, on the main process, on the note-open path. The module's own doc comment claimed the batch form cost "a single round trip instead of one per image"; it did not.

## Root cause

The batch entry point delegated to the single-ref entry point instead of the other way round, so everything invariant across the batch (vault status, notes folder, the image-row snapshot) was recomputed for each ref.

## Fix

Inverted the delegation. `resolveVaultEmbeds` now:

1. reads `getStatus()` and `getConfig().defaultNoteFolder` **once** per call;
2. walks the refs, resolving each against the filesystem candidates exactly as before, and collecting the ones that miss;
3. issues **one** index lookup for all missed basenames, skipped entirely when nothing missed.

`resolveVaultEmbed` (single ref) is now a one-element call into the batch, so it keeps its exact signature and behaviour.

Resolution semantics are unchanged: same candidate paths (vault root, then notes folder), same `isInsideVault` guard, same scheme/absolute-path rejection, same shortest-path-then-lexicographic tie-break for ambiguous filenames, same `fs.existsSync` check on the index hit, same omission (never `null` mapping) of unresolvable targets.

**No cache was added — deliberately.** See "Caching" below.

## Caching: why there is none, and the invalidation points that made that the right call

The issue suggested "read config once per call **or** cache with invalidation". This PR takes the first option only. Everything read here is scoped to a single synchronous function call and thrown away when it returns, so there is no cross-call state that can go stale.

That matters because a cache here would have to be invalidated on every one of the following, and several of them are not observable from this module:

| Invalidation point | Why a cache would break |
| --- | --- |
| Vault switch (close/open a different vault) | Cached `vaultPath` / notes folder / image rows all belong to the previous vault; embeds would resolve into the old vault's files. |
| `config.json` edited on disk by an external editor | `defaultNoteFolder` changes with no in-process event; there is no watcher on `.memry/config.json`. Cached notes folder silently keeps using the old value. |
| `config.json` rewritten by `writeVaultConfig` (settings UI) | In-process, so catchable — but only if every writer remembers to invalidate. |
| `config.json` rewritten by a sync-driven write | Same as above, from a different code path that has no reason to know this cache exists. |
| Image added (drop, paste, attachment import) | A **negative** cache entry would pin "not found", so a newly added image keeps rendering as unresolved until restart. This is the one the brief calls out and it is the strongest argument against caching here. |
| Image renamed | Positive entry points at the old path; the embed rewrites to a path that no longer exists. |
| Image deleted | Positive entry points at a deleted file. |
| Attachment import (bulk) | Many rows added at once; both the negative-miss and the ambiguity tie-break (shortest path wins) can change. |
| Sign-out / vault teardown | Cache outlives the DB handle it was derived from. |

**What a stale positive looks like to the user:** the embed is rewritten into the note's markdown as a relative path pointing at a file that has moved or been deleted, so the editor shows a broken-image placeholder — and because the rewrite is what `blocksToMarkdownLossy` writes back on the next save, that broken path gets **persisted into the vault file and synced to other devices**. That is a data-fidelity bug, not just a rendering glitch. Per-call scoping makes it unreachable.

**What a stale negative looks like:** an image you just added stays unresolved (raw `![[photo.png]]` left in place, no rewrite) until the app restarts. Also unreachable here.

`getConfig()` itself is untouched — its per-call `readFileSync` is tracked separately in #1079. This PR only changes how many times the embed path calls it.

## Test evidence

Two new tests in `apps/desktop/src/main/vault/resolve-embed.test.ts`, running against a real temp vault and a real index DB (existing harness), asserting both the resolved output and the call counts.

### RED (before the fix)

```
 × reads the vault config once and touches the index once for a whole batch
   → expected "getConfig" to be called 1 times, but got 4 times

 Test Files  1 failed (1)
      Tests  1 failed | 17 passed (18)
```

### GREEN (after the fix)

```
 ✓ reads the vault config once and touches the index once for a whole batch 16ms
 ✓ skips the index entirely when every target is already on disk 16ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
```

### Mutation verification — 3 mutants, 3 killed

| # | Mutated line | Result |
| --- | --- | --- |
| A | `findOnDisk(vaultPath, notesFolder, ref)` → `findOnDisk(vaultPath, getConfig().defaultNoteFolder \|\| 'notes', ref)` (config read back inside the per-ref loop) | **killed** — `expected "getConfig" to be called 1 times, but got 5 times` |
| B | `const absPath = byName.get(filename)` → `const absPath = lookupByFilenames(vaultPath, new Set([filename])).get(filename)` (index lookup back to once per pending ref) | **killed** — `expected "getIndexDatabase" to be called 1 times, but got 4 times` |
| C | deleted `if (filenames.size === 0) return found` (empty-batch index guard) | **killed** — `skips the index entirely when every target is already on disk` fails |

Each mutant targeted the code line itself, not a comment. While setting mutant C up I found the implementation had two redundant empty-batch guards, which made either one individually an equivalent mutant; I removed the redundant outer `if (pending.size === 0) return resolved` so exactly one line carries that behaviour and the test can kill it.

### Other verification

```
$ pnpm typecheck
 Tasks:    16 successful, 16 total

$ pnpm lint
✖ 15 problems (0 errors, 15 warnings)      # all pre-existing, none in resolve-embed.*

$ pnpm --filter @memry/desktop test:main \
    src/main/vault/resolve-embed.test.ts src/main/sync/embed-roundtrip.test.ts \
    src/main/sync/blocknote-converter.test.ts src/main/ipc/vault-handlers.test.ts \
    src/main/vault/index.test.ts
 Test Files  5 passed (5)
      Tests  93 passed (93)

$ git diff --check
(clean)
```

## Risk & backward compatibility

- **Pure main-process refactor.** No DB schema change, no migration, no new column or index. `note_cache` is read exactly as before.
- **No IPC contract, preload API, or handler signature change** — `vault:resolveEmbeds` still takes `(refs, notePath)` and returns `Record<string, string>`. `pnpm ipc:generate`/`ipc:check` are clean (typecheck runs the `--check` form and reported "IPC invoke map is up to date").
- **No vault file-format or `config.json` shape change.** A `config.json` written by an older version parses exactly as before; this PR does not touch `readVaultConfig`/`writeVaultConfig`.
- **No sync-protocol change.** The resolved target that gets spliced into markdown is byte-identical to before for every input the old code handled — the existing round-trip tests (`embed-roundtrip`, `blocknote-converter`) cover that and pass unchanged.
- **No data can be dropped.** Nothing is bounded, coalesced or evicted; the batch resolves every ref it is given.
- One intentional micro-hardening: `resolveVaultEmbed` reads its result with `hasOwnProperty` rather than plain indexing, so a ref literally named `__proto__` returns `null` instead of `Object.prototype` now that the single-ref path goes through the record. Previously unreachable, kept unreachable.

## Docs

`pnpm docs:impact --base origin/main --strict` reports `missing-docs` for `resolve-embed.ts`. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: this is an internal performance change to how embed resolution batches its I/O, with no user-visible behaviour, no new setting, no UI surface and no format change — there is nothing for `apps/docs/src/**` to say about it.

## Scope

Confined to `apps/desktop/src/main/vault/resolve-embed.ts` and its test. Did not touch `main/database/client.ts`, `main/projections/**`, or the open/close lifecycle in `main/vault/index.ts`.

Closes #1025
