### PR TITLE
fix(sync): throttle the reconnect CRDT sweep to editor-less cached docs

### DIFF
--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -396,6 +396,21 @@ describe('CrdtProvider', () => {
     )
   })
 
+  it('separates docs with a live editor from the ones the cache merely retains', async () => {
+    // getOpenNoteIds() is every doc in the LRU cache, including the up-to-32 an
+    // editor has already released. Reconnect recovery needs the smaller set.
+    createWindow(1)
+    await provider.open('with-editor', 1, { skipSeed: true })
+    await provider.open('cached-only', undefined, { skipSeed: true })
+
+    expect(provider.getOpenNoteIds().sort()).toEqual(['cached-only', 'with-editor'])
+    expect(provider.getOpenNoteIds({ active: true })).toEqual(['with-editor'])
+
+    await provider.close('with-editor', 1)
+
+    expect(provider.getOpenNoteIds({ active: true })).toEqual([])
+  })
+
   it('exposes aggregate open-doc metrics with per-doc size and window counts', async () => {
     createWindow(1)
     await provider.open('note-1', 1, { skipSeed: true })

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -438,8 +438,15 @@ export class CrdtProvider {
     log.info('CrdtProvider destroyed')
   }
 
-  getOpenNoteIds(): string[] {
-    return Array.from(this.docs.keys())
+  /**
+   * Every doc the provider holds, which is not the same as every doc an editor
+   * has open: the LRU keeps up to inactiveDocLimit docs cached after their
+   * editors closed. Pass `{ active: true }` for the strict subset that still has
+   * a window attached — what a caller wants when it must bound per-doc work to
+   * what the user is actually looking at.
+   */
+  getOpenNoteIds({ active = false } = {}): string[] {
+    return [...this.docs].filter(([, doc]) => !active || doc.windowIds.size > 0).map(([id]) => id)
   }
 
   getDocSizeMetrics(): CrdtDocSizeMetric[] {

--- a/apps/desktop/src/main/sync/engine-retries.test.ts
+++ b/apps/desktop/src/main/sync/engine-retries.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { EventEmitter } from 'events'
-import { SyncEngine, type SyncEngineDeps } from './engine'
+import { INACTIVE_CRDT_SWEEP_MIN_INTERVAL_MS, SyncEngine, type SyncEngineDeps } from './engine'
 import { NetworkError } from './http-client'
 import type { WebSocketMessage } from './websocket'
 import { createMockDeps, createMockNetwork, setupTestDb } from '@tests/utils/engine-mocks'
@@ -215,8 +215,8 @@ describe('SyncEngine', () => {
 
       const deps = createMockDeps(getDb(), {
         crdtProvider: {
-          getOpenNoteIds: vi.fn().mockReturnValue(['note-1', 'note-2'])
-        } as SyncEngineDeps['crdtProvider']
+          getOpenNoteIds: vi.fn(({ active = false } = {}) => (active ? [] : ['note-1', 'note-2']))
+        } as unknown as SyncEngineDeps['crdtProvider']
       })
       const engine = new SyncEngine(deps)
       await engine.start()
@@ -245,6 +245,128 @@ describe('SyncEngine', () => {
       expect(pullCrdtForNote).toHaveBeenCalledWith('note-2')
 
       await engine.stop()
+      vi.restoreAllMocks()
+    })
+  })
+
+  describe('#given cached CRDT docs with no editor attached #when the socket reconnects', () => {
+    // The provider keeps up to 32 editor-less docs in its LRU cache, and
+    // reconnect backoff caps at 30s — so re-pulling the whole cache on every
+    // reconnect buys a snapshot GET, paged incrementals and a vault-key
+    // derivation per cached doc, twice a minute, for as long as the network
+    // flaps (#1026). Docs with a live editor are what the user is actually
+    // looking at and stay on the every-reconnect path.
+    const OPEN_IDS = ['editor-1', 'cached-1', 'cached-2']
+
+    async function startEngine(): Promise<{
+      engine: SyncEngine
+      deps: SyncEngineDeps
+      pullCrdtForNote: ReturnType<typeof vi.fn>
+      settle: () => Promise<void>
+    }> {
+      vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
+        items: [],
+        deleted: [],
+        hasMore: false,
+        nextCursor: 0
+      })
+
+      const deps = createMockDeps(getDb(), {
+        crdtProvider: {
+          getOpenNoteIds: vi.fn(({ active = false } = {}) => (active ? ['editor-1'] : OPEN_IDS))
+        } as unknown as SyncEngineDeps['crdtProvider']
+      })
+      const engine = new SyncEngine(deps)
+      await engine.start()
+
+      const pullCrdtForNote = vi.fn().mockResolvedValue(undefined)
+      ;(engine as unknown as { crdtSync: { pullCrdtForNote: typeof pullCrdtForNote } }).crdtSync = {
+        pullCrdtForNote
+      }
+
+      // Deterministic drain: the reconnect handler runs through scheduleSync,
+      // so the work is only observable once the engine's in-flight chain is
+      // empty. Polling with waitFor would only prove pulls that DID happen.
+      const ctx = (engine as unknown as { ctx: { inFlightSync: Promise<void> | null } }).ctx
+      const settle = async (): Promise<void> => {
+        while (ctx.inFlightSync) {
+          await ctx.inFlightSync.catch(() => {})
+        }
+      }
+
+      return { engine, deps, pullCrdtForNote, settle }
+    }
+
+    const pulledIds = (mock: ReturnType<typeof vi.fn>): string[] =>
+      mock.mock.calls.map(([noteId]) => noteId as string).sort()
+
+    it('#then the first reconnect still pulls every cached doc', async () => {
+      const { engine, deps, pullCrdtForNote, settle } = await startEngine()
+
+      deps.ws.emit('connected')
+      await settle()
+
+      expect(pulledIds(pullCrdtForNote)).toEqual([...OPEN_IDS].sort())
+
+      await engine.stop()
+      vi.restoreAllMocks()
+    })
+
+    it('#then a reconnect inside the sweep window pulls only docs with a live editor', async () => {
+      const { engine, deps, pullCrdtForNote, settle } = await startEngine()
+
+      deps.ws.emit('connected')
+      await settle()
+      pullCrdtForNote.mockClear()
+
+      deps.ws.emit('connected')
+      await settle()
+
+      expect(pulledIds(pullCrdtForNote)).toEqual(['editor-1'])
+
+      await engine.stop()
+      vi.restoreAllMocks()
+    })
+
+    it('#then a reconnect past the sweep window sweeps the cache again', async () => {
+      const { engine, deps, pullCrdtForNote, settle } = await startEngine()
+
+      deps.ws.emit('connected')
+      await settle()
+      pullCrdtForNote.mockClear()
+
+      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + INACTIVE_CRDT_SWEEP_MIN_INTERVAL_MS + 1)
+      deps.ws.emit('connected')
+      await settle()
+
+      expect(pulledIds(pullCrdtForNote)).toEqual([...OPEN_IDS].sort())
+
+      await engine.stop()
+      vi.restoreAllMocks()
+    })
+
+    it('#then a sweep the window held back is paid by the pull tick, not dropped', async () => {
+      // Nothing else re-pulls an editor-less body: note records in the change
+      // feed carry no body, and a socket-only reconnect never runs a fullSync.
+      // If the throttled sweep were dropped rather than deferred, an edit made
+      // on another device during the outage would never land here.
+      vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] })
+      const { engine, deps, pullCrdtForNote, settle } = await startEngine()
+
+      deps.ws.emit('connected')
+      await settle()
+      deps.ws.emit('connected')
+      await settle()
+      pullCrdtForNote.mockClear()
+
+      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + INACTIVE_CRDT_SWEEP_MIN_INTERVAL_MS + 1)
+      await vi.advanceTimersByTimeAsync(60_000)
+      await settle()
+
+      expect(pulledIds(pullCrdtForNote)).toEqual(['cached-1', 'cached-2'])
+
+      await engine.stop()
+      vi.useRealTimers()
       vi.restoreAllMocks()
     })
   })

--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -43,6 +43,28 @@ const MAX_SYNC_ENGINE_LISTENERS = 50
 // makes periodicPull skip forever, and only an app restart recovers.
 export const SYNC_LOCK_STALE_MS = 15 * 60 * 1000
 
+// How often a WebSocket reconnect may re-pull the CRDT docs the provider still
+// caches without an editor attached (up to inactiveDocLimit, currently 32).
+//
+// They cannot be dropped from reconnect recovery: a body-only remote edit
+// reaches this device as a `crdt_updated` broadcast and by no other route —
+// note records in the change feed carry no body — so an edit made while the
+// socket was down is discovered either here or by the vault-wide sweep at the
+// end of the next fullSync, and a socket-only reconnect does not run a
+// fullSync. They also cannot run on every reconnect: backoff caps at 30s
+// (websocket.ts), so a flapping connection buys a snapshot GET, paged
+// incrementals and a vault-key derivation per cached doc twice a minute, for as
+// long as the network misbehaves.
+//
+// 5 minutes therefore bounds the flapping case to roughly one cache pass per
+// five minutes instead of ten, while costing nothing on a healthy connection —
+// a stable socket delivers every edit live, and docs with a live editor stay on
+// the every-reconnect path regardless. A pass suppressed inside the window is
+// remembered and paid by the next reconnect or the periodic pull tick, so the
+// worst case is an editor-less doc going stale for a few extra minutes during
+// an outage, never a body that is not pulled at all.
+export const INACTIVE_CRDT_SWEEP_MIN_INTERVAL_MS = 5 * 60 * 1000
+
 const classifySyncErrorCode = (error: unknown): string => {
   try {
     const info = classifyError(error)
@@ -67,6 +89,11 @@ export class SyncEngine extends EventEmitter {
   private networkReconnectAbortController: AbortController | null = null
   private syncLockAcquiredAt: number | null = null
   private activeLockRelease: (() => void) | null = null
+  // Zero means "never swept by this engine", so the first reconnect after a
+  // start, vault switch or engine rebuild always sweeps. Instance state only:
+  // a timestamp from a previous process says nothing about this socket.
+  private lastInactiveCrdtSweepAt = 0
+  private inactiveCrdtSweepOwed = false
 
   constructor(deps: SyncEngineDeps, options?: Partial<SyncEngineOptions>) {
     super()
@@ -517,6 +544,7 @@ export class SyncEngine extends EventEmitter {
     if (this.pullInterval) return
     this.pullInterval = setInterval(() => {
       this.recoverStaleSyncLock()
+      this.payOwedInactiveCrdtSweep()
       this.pullCoordinator.periodicPull()
     }, 60_000)
   }
@@ -690,11 +718,54 @@ export class SyncEngine extends EventEmitter {
       this.scheduleSync(async () => {
         await this.pull()
 
-        const openNoteIds = this.ctx.deps.crdtProvider?.getOpenNoteIds() ?? []
-        for (const noteId of openNoteIds) {
+        // Docs with a live editor are what the user is looking at right now:
+        // pulled on every reconnect, however often the socket flaps.
+        const activeNoteIds = this.ctx.deps.crdtProvider?.getOpenNoteIds({ active: true }) ?? []
+        for (const noteId of activeNoteIds) {
           await this.crdtSync.pullCrdtForNote(noteId)
         }
+
+        await this.sweepInactiveCrdtDocs()
       })
     }
+  }
+
+  /**
+   * Re-pull the cached CRDT docs no editor holds open, at most once per
+   * INACTIVE_CRDT_SWEEP_MIN_INTERVAL_MS. A pass the window suppresses is
+   * remembered rather than dropped — see the constant for why neither dropping
+   * it nor running it every reconnect is acceptable.
+   */
+  private async sweepInactiveCrdtDocs(): Promise<void> {
+    const crdtProvider = this.ctx.deps.crdtProvider
+    if (!crdtProvider) return
+
+    if (Date.now() - this.lastInactiveCrdtSweepAt < INACTIVE_CRDT_SWEEP_MIN_INTERVAL_MS) {
+      this.inactiveCrdtSweepOwed = true
+      return
+    }
+
+    this.lastInactiveCrdtSweepAt = Date.now()
+    this.inactiveCrdtSweepOwed = false
+
+    // Re-read both sets here rather than reusing the reconnect's snapshot: an
+    // editor may have opened or closed while the active pulls above ran.
+    const activeNoteIds = new Set(crdtProvider.getOpenNoteIds({ active: true }))
+    for (const noteId of crdtProvider.getOpenNoteIds()) {
+      if (activeNoteIds.has(noteId)) continue
+      await this.crdtSync.pullCrdtForNote(noteId)
+    }
+  }
+
+  /**
+   * Settles a sweep the window held back when no further reconnect arrives to
+   * carry it — a socket that flaps twice and then stabilises still owes one.
+   * Paused or mid-fullSync it stays owed: resume() and fullSync both end in the
+   * vault-wide CRDT sweep, and the flag survives for the next tick regardless.
+   */
+  private payOwedInactiveCrdtSweep(): void {
+    if (!this.inactiveCrdtSweepOwed || this.stateManager.isPaused()) return
+    if (Date.now() - this.lastInactiveCrdtSweepAt < INACTIVE_CRDT_SWEEP_MIN_INTERVAL_MS) return
+    this.scheduleSync(() => this.sweepInactiveCrdtDocs())
   }
 }

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -91,6 +91,21 @@ Notes flow through **both** sync paths:
 
 Snapshots are pushed **pre-batch** so other devices receive correct state before the sync notification reaches them.
 
+## Reconnect Recovery
+
+A note body only ever travels as a CRDT update, so a remote body edit reaches a device
+as a `crdt_updated` WebSocket broadcast — record changes in the pull feed carry no body.
+Anything broadcast while the socket was down therefore has to be re-discovered when it
+comes back.
+
+When the socket reconnects, the engine pulls the record feed, then re-pulls the CRDT for
+every note that still has an editor window attached. The rest of the LRU-cached docs —
+the ones the provider retains after their editors closed — are swept too, but at most
+once per five minutes, because each pull costs a snapshot fetch, paged incrementals, and
+a vault-key derivation, and reconnect backoff caps at 30 seconds. A sweep suppressed by
+that window is not dropped: it is paid by the next reconnect or by the 60-second pull
+tick, and the vault-wide sweep at the end of a full sync covers every note regardless.
+
 ## Snapshot Failure Handling
 
 A snapshot is a **compaction optimization**, not the source of truth: the authoritative


### PR DESCRIPTION
Closes #1026

## Problem

`handleWsConnected` re-pulled the CRDT for every doc the provider held. `getOpenNoteIds()` returns the whole LRU cache — up to 32 docs whose editors already closed, plus anything pinned by a stale windowId — not just notes with a live editor. Each pull is a snapshot GET, paged incrementals and a vault-key derivation, and reconnect backoff caps at 30 s (`websocket.ts`), so a flaky network produced a sustained request storm: ~32 pulls every half-minute for as long as the socket flapped.

Confirmed still present on `origin/main` before implementing: `engine.ts` `handleWsConnected` iterated `crdtProvider.getOpenNoteIds()`, and `crdt-provider.ts` returned `Array.from(this.docs.keys())`.

## Root cause

The provider had no way to express "docs an editor actually has open" — `getOpenNoteIds()` conflated live editors with the LRU's retained docs, and the reconnect handler treated both identically and unconditionally.

## Fix

- `CrdtProvider.getOpenNoteIds({ active: true })` returns the strict subset that still has a window attached. Default behaviour is unchanged for the two existing callers.
- On reconnect, notes with a live editor are pulled on **every** reconnect, as before.
- The editor-less remainder of the cache is still swept, but at most once per `INACTIVE_CRDT_SWEEP_MIN_INTERVAL_MS` (5 min). A sweep suppressed inside that window is **remembered, not dropped**, and paid by the next reconnect or by the existing 60 s pull tick.

### Why nothing stops being pulled

A body-only remote edit reaches a device only as a `crdt_updated` broadcast — note records in the change feed carry no body (`crdt-writeback.ts` enqueues no record update for body edits), so the reconnect sweep is the recovery path for the socket gap. Narrowing it to open editors and "letting full sync cover the rest" would have been silent staleness: a socket-only reconnect does not run a full sync, and opening a note does not pull (`CRDT_CHANNELS.OPEN_DOC` only opens the doc from local persistence).

So no doc is dropped from the sweep. Where an editor-less cached doc is pulled instead of "immediately on this reconnect":

1. the next reconnect that lands outside the 5-minute window — `sweepInactiveCrdtDocs()` in `engine.ts`;
2. failing that, `payOwedInactiveCrdtSweep()` on the 60 s `armPeriodicPull` tick, which is the guaranteed payment path when the socket stabilises and no further reconnect arrives;
3. and independently, the vault-wide sweep at the end of every full sync (`full-sync-runner.ts`, `getAllCrdtNoteIds`), which covers every note in the vault, including docs evicted from the cache in the meantime.

Paused or mid-full-sync, the debt stays owed for the next tick, and both of those states end in a full sync that sweeps the whole vault anyway.

Cache invalidation points for the two new fields (`lastInactiveCrdtSweepAt`, `inactiveCrdtSweepOwed`): both are per-engine instance state, so vault switch, sign-out and engine rebuild reset them (`lastInactiveCrdtSweepAt = 0` means the first reconnect always sweeps); reconnect and the pull tick are the read points; token refresh is irrelevant because `pullCrdtForNote` fetches a fresh token per call. Nothing is persisted, and no negative is cached permanently — the owed flag only ever delays a sweep, never cancels it. The worst-case stale positive a user can see is an editor-less note being a few minutes behind during a network outage; a note on screen is unaffected.

## Test evidence

New tests in `engine-retries.test.ts` and `crdt-provider.test.ts`. RED first:

```
 FAIL  src/main/sync/crdt-provider.test.ts > separates docs with a live editor from the ones the cache merely retains
 FAIL  src/main/sync/engine-retries.test.ts > #then a reconnect inside the sweep window pulls only docs with a live editor
   AssertionError: expected [ 'cached-1', 'cached-2', 'editor-1' ] to deeply equal [ 'editor-1' ]
 FAIL  src/main/sync/engine-retries.test.ts > #then a sweep the window held back is paid by the pull tick, not dropped
   AssertionError: expected [] to deeply equal [ 'cached-1', 'cached-2' ]
 Tests  3 failed | 61 passed (64)
```

GREEN after the fix:

```
 Test Files  2 passed (2)
      Tests  64 passed (64)
```

Full main-process suite:

```
 Test Files  476 passed | 1 skipped (477)
      Tests  5430 passed | 1 expected fail | 4 skipped (5435)
```

`pnpm typecheck` — 16/16 tasks successful. `pnpm lint` — 0 errors, 15 pre-existing warnings. `git diff --check` clean. `pnpm docs:impact --base origin/main --strict` — covered. `pnpm docs:build` — build complete.

### Mutation verification

Three mutants, each a single code line reverted, re-run against the final code:

| Mutant | Result |
| --- | --- |
| `getOpenNoteIds({ active: true })` → `getOpenNoteIds()` in the reconnect handler | **killed** — 3 failed \| 22 passed |
| drop `this.inactiveCrdtSweepOwed = true` (throttled pass dropped, not remembered) | **killed** — 1 failed \| 24 passed |
| remove `this.payOwedInactiveCrdtSweep()` from the pull tick | **killed** — 1 failed \| 24 passed |

No surviving mutants.

## Risk & backward compatibility

No protocol, schema, contract or persisted-format change: nothing new is written to disk or sent over the wire, and the server sees no new request shape. `getOpenNoteIds()` with no argument behaves exactly as before, so the shutdown-snapshot caller in `index.ts` is untouched. CRDT ownership and `sourceWindowId` tagging are not involved. An older peer that pushes a body edit during an outage is still recovered by the paths listed above. Worst realistic regression is a few minutes of extra staleness on a note with no editor open, during a network outage.

## Relationship to #1120

PR #1120 (issue #998) scopes the vault-wide CRDT sweep that runs at the end of `fullSync`, in `full-sync-runner.ts`. This PR is the separate WebSocket-reconnect path in `engine.ts`, and touches no file that PR changes. The two are complementary: reconnect recovery here relies on the full-sync sweep only as the outer safety net for notes that are not cached at all, and #1120 keeps that sweep running whenever the socket dropped and came back — which is exactly the case where this path defers work.

## Out of scope, noted not fixed

- `getOpenNoteIds({ active: true })` trusts `windowIds`, which #1122 reports can be pinned by windows that closed without releasing. Stale pins over-report the active set, so this change stays safe (it pulls more, never less), but the storm reduction is smaller until #1122 lands.
- `apps/desktop/src/main/sync/crdt-provider.ts` sits exactly at the 800-code-line `max-lines` ceiling on `main`, so any added code line fails lint. That is why the active-doc filter is an option on the existing accessor rather than a new `getActiveNoteIds()` method. Splitting the file is a separate change.
