### PR TITLE
perf(editor): scope the date-pill MutationObserver to the DOM that changed

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/use-triggered-date-pills.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/use-triggered-date-pills.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import {
   computeFiredAnchorIds,
@@ -12,6 +12,27 @@ function makePill(anchorId: string): HTMLElement {
   el.className = 'date-mention'
   el.setAttribute('data-anchor-id', anchorId)
   return el
+}
+
+/**
+ * Counts the work a paint pass does: every pill it visits has its anchor id
+ * read. Returns the pills that were visited since tracking started.
+ */
+function trackVisits(pills: HTMLElement[]): () => HTMLElement[] {
+  const visited: HTMLElement[] = []
+  for (const pill of pills) {
+    const real = pill.getAttribute.bind(pill)
+    vi.spyOn(pill, 'getAttribute').mockImplementation((name: string) => {
+      if (name === 'data-anchor-id') visited.push(pill)
+      return real(name)
+    })
+  }
+  return () => visited
+}
+
+/** Let the MutationObserver deliver its records. */
+function flushMutations(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
 }
 
 describe('computeFiredAnchorIds', () => {
@@ -65,6 +86,81 @@ describe('watchFiredPills', () => {
     await new Promise((resolve) => setTimeout(resolve, 0)) // let the observer flush
 
     expect(p1.getAttribute('data-fired')).toBe('true')
+    stop()
+    container.remove()
+  })
+
+  it('scans no pills when a keystroke only rewrites a text node', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const paragraph = document.createElement('p')
+    const pills = Array.from({ length: 50 }, (_, i) => makePill(`a${i}`))
+    paragraph.append(...pills)
+    paragraph.appendChild(document.createTextNode(''))
+    container.appendChild(paragraph)
+
+    const stop = watchFiredPills(container, () => new Set(['a0']))
+    const visited = trackVisits(pills)
+
+    // ProseMirror swaps the edited text node on every character.
+    for (let i = 1; i <= 10; i++) {
+      paragraph.replaceChild(document.createTextNode('x'.repeat(i)), paragraph.lastChild!)
+      await flushMutations()
+    }
+
+    expect(visited()).toEqual([])
+    stop()
+    container.remove()
+  })
+
+  it('scans only the pill that was just created, not the whole note', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const paragraph = document.createElement('p')
+    const pills = Array.from({ length: 50 }, (_, i) => makePill(`a${i}`))
+    paragraph.append(...pills)
+    container.appendChild(paragraph)
+
+    const stop = watchFiredPills(container, () => new Set(['a0', 'fresh']))
+    const visited = trackVisits(pills)
+
+    const fresh = makePill('fresh')
+    paragraph.appendChild(fresh)
+    await flushMutations()
+
+    expect(visited()).toEqual([])
+    expect(fresh.getAttribute('data-fired')).toBe('true')
+    stop()
+    container.remove()
+  })
+
+  it('re-applies fired state to a pill nested inside a re-rendered block', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const stop = watchFiredPills(container, () => new Set(['a1']))
+
+    const block = document.createElement('div')
+    const pill = makePill('a1')
+    block.appendChild(pill)
+    container.appendChild(block)
+    await flushMutations()
+
+    expect(pill.getAttribute('data-fired')).toBe('true')
+    stop()
+    container.remove()
+  })
+
+  it('re-applies fired state when a pill swaps its anchor id in place', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const pill = makePill('a2')
+    container.appendChild(pill)
+    const stop = watchFiredPills(container, () => new Set(['a1']))
+
+    pill.setAttribute('data-anchor-id', 'a1')
+    await flushMutations()
+
+    expect(pill.getAttribute('data-fired')).toBe('true')
     stop()
     container.remove()
   })

--- a/apps/desktop/src/renderer/src/components/note/content-area/use-triggered-date-pills.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/use-triggered-date-pills.ts
@@ -26,35 +26,82 @@ export function computeFiredAnchorIds(reminders: FiredCandidate[]): Set<string> 
   return ids
 }
 
-/**
- * Toggle `data-fired` on every date pill in `container` so CSS can recolor fired
- * ones. Idempotent — safe to call repeatedly.
- */
-export function applyFiredState(container: HTMLElement, firedAnchorIds: Set<string>): void {
-  const pills = container.querySelectorAll<HTMLElement>('.date-mention[data-anchor-id]')
-  pills.forEach((pill) => {
+const PILL_SELECTOR = '.date-mention[data-anchor-id]'
+
+function isElement(node: Node): node is HTMLElement {
+  return node.nodeType === Node.ELEMENT_NODE
+}
+
+/** `root` itself when it is a date pill, plus every date pill inside it. */
+function collectPills(root: HTMLElement): HTMLElement[] {
+  const pills = root.matches(PILL_SELECTOR) ? [root] : []
+  pills.push(...root.querySelectorAll<HTMLElement>(PILL_SELECTOR))
+  return pills
+}
+
+/** Toggle `data-fired` on the given pills. Idempotent. */
+function paintPills(pills: HTMLElement[], firedAnchorIds: Set<string>): void {
+  for (const pill of pills) {
     const anchorId = pill.getAttribute('data-anchor-id')
     if (anchorId && firedAnchorIds.has(anchorId)) {
       pill.setAttribute('data-fired', 'true')
     } else {
       pill.removeAttribute('data-fired')
     }
-  })
+  }
+}
+
+/**
+ * Toggle `data-fired` on every date pill in `container` so CSS can recolor fired
+ * ones. Idempotent — safe to call repeatedly.
+ */
+export function applyFiredState(container: HTMLElement, firedAnchorIds: Set<string>): void {
+  paintPills(collectPills(container), firedAnchorIds)
+}
+
+/**
+ * The pills a mutation batch can have left unpainted: pills inside freshly
+ * attached elements, and pills whose anchor id just changed. A keystroke that
+ * only rewrites text yields none, so nothing is scanned.
+ */
+function pillsTouchedBy(records: MutationRecord[]): HTMLElement[] {
+  const pills: HTMLElement[] = []
+  for (const record of records) {
+    if (record.type === 'attributes') {
+      if (isElement(record.target)) pills.push(record.target)
+      continue
+    }
+    for (const node of record.addedNodes) {
+      if (isElement(node)) pills.push(...collectPills(node))
+    }
+  }
+  return pills
 }
 
 /**
  * Re-apply fired state whenever BlockNote recreates pill DOM (raw node-views are
- * rebuilt on updateBlock). `getFiredAnchorIds` is read lazily so the latest set
- * is used on every mutation. Returns a cleanup that disconnects the observer.
+ * rebuilt on updateBlock). Only the changed subtrees are scanned — ProseMirror
+ * touches the DOM on every keystroke, so scanning the whole note here costs a
+ * full-document query per character. `getFiredAnchorIds` is read lazily so the
+ * latest set is used on every mutation. Returns a cleanup that disconnects the
+ * observer.
  */
 export function watchFiredPills(
   container: HTMLElement,
   getFiredAnchorIds: () => Set<string>
 ): () => void {
-  const observer = new MutationObserver(() => {
-    applyFiredState(container, getFiredAnchorIds())
+  const observer = new MutationObserver((records) => {
+    const pills = pillsTouchedBy(records)
+    if (pills.length > 0) paintPills(pills, getFiredAnchorIds())
   })
-  observer.observe(container, { childList: true, subtree: true })
+  // `data-fired` is deliberately not in the filter: painting must not re-trigger
+  // the observer.
+  observer.observe(container, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['data-anchor-id']
+  })
   return () => observer.disconnect()
 }
 


### PR DESCRIPTION
## Problem

`use-triggered-date-pills.ts` wired a `MutationObserver` on the whole editor container with `{ childList: true, subtree: true }`, and its callback ran `applyFiredState(container, …)` — a full `container.querySelectorAll('.date-mention[data-anchor-id]')` plus an attribute pass over every result. ProseMirror mutates the DOM on essentially every keystroke, so typing paid a full-document query per character and the cost scaled with note length. Wired unconditionally at `ContentArea.tsx:189`.

Verified still present on current `origin/main` before changing anything.

## Root cause

The observer was event-agnostic: it treated *any* childList mutation anywhere in the note as "a pill may have been recreated" and answered by re-scanning the entire document. The records it was already being handed carry exactly which subtrees changed; they were discarded.

## Fix

The observer now paints only the pills a mutation batch could have left unpainted:

- `addedNodes` that are elements → the element itself if it is a pill, plus `element.querySelectorAll(PILL_SELECTOR)` on that subtree only.
- `data-anchor-id` attribute changes → repaint that element.

A keystroke that only rewrites a text node yields no candidates, so nothing is scanned. The `getFiredAnchorIds` lazy read and the disconnect-on-cleanup contract are unchanged.

**No debounce, no rAF, no cache.** Deliberate: `MutationObserver` already coalesces records per microtask checkpoint, and after filtering the callback does zero work for plain typing. Deferring behind a frame would only add a pending-frame lifecycle to unwind on unmount and would stall repaints in occluded windows for no measurable gain. Nothing is dropped or delayed, so there is no "last event in the window" question.

## Staleness: what still triggers a re-scan

Every path that can put a date pill on screen still repaints it:

| Path | Covered by |
|---|---|
| Typing a date mention | The pill node-view is raw DOM built fresh in `createDateMentionPillDom`; ProseMirror attaches it → `addedNodes` |
| Pasting content containing a pill | Pasted block elements are attached → `addedNodes`, pill found via the subtree query |
| Undo / redo | ProseMirror re-renders the affected block → `addedNodes` |
| External sync update rewriting the body | Same — blocks are replaced, new pill DOM attached |
| Switching notes in the same editor instance | `editorContainerRef` element is stable, content is replaced → `addedNodes` |
| Split view | Each `ContentAreaEditor` instance owns its own container + observer; unchanged |
| Reminder fires while the note is open | Unchanged path — `useFiredDatePillAnchors` refetch → the effect calls `applyFiredState` over the **whole** container synchronously |
| A pill stops being fired (dismiss/re-arm) | Same whole-container effect pass, which still clears `data-fired` |
| A pill swaps `data-anchor-id` in place | **New** coverage — see below |

`DateMention` is a `createInlineContentSpec` with no `update()`, so its DOM is always rebuilt rather than patched; the `addedNodes` path is therefore complete for pill creation. The `data-anchor-id` observation is added coverage rather than a hole being patched: before this change an in-place anchor swap only repainted if some *unrelated* childList mutation happened to fire at the same time.

`data-fired` is deliberately **not** in `attributeFilter`, so painting cannot re-trigger the observer.

## Test evidence

`apps/desktop/src/renderer/src/components/note/content-area/use-triggered-date-pills.test.ts` — tests assert observable work (pills visited, measured by spying on each pill's `getAttribute('data-anchor-id')`), not timing.

RED, before the fix:

```
PASS (8) FAIL (3)
1. watchFiredPills scans no pills when a keystroke only rewrites a text node
   AssertionError: expected [ <span …(3)></span>, …(501) ] to deeply equal []
2. watchFiredPills scans only the pill that was just created, not the whole note
   AssertionError: expected [ <span …(3)></span>, …(51) ] to deeply equal []
3. watchFiredPills re-applies fired state when a pill swaps its anchor id in place
   AssertionError: expected null to be 'true'
```

502 pill visits for 10 keystrokes in a 50-pill note. GREEN, after:

```
PASS (11) FAIL (0)
```

### Mutation verification

Three single-line mutants, each reverted after the run:

1. `const pills = pillsTouchedBy(records)` → `const pills = collectPills(container)` (restores the old full scan) — **killed**, 2 failures, the keystroke test back to 502 visits.
2. `attributes: true` → `attributes: false` — **killed**, anchor-swap test fails.
3. `if (isElement(node))` → `if (!isElement(node))` (never scan added elements) — **killed**, 4 failures including the pre-existing `useTriggeredDatePills` recreation test.

No survivors.

## Verification

```
pnpm typecheck        16 successful, 16 total
pnpm lint             ✖ 15 problems (0 errors, 15 warnings) — all pre-existing, none in the changed files
git diff --check      clean
```

Renderer tests (`--project renderer`, changed file + its consumer + the pill spec):

```
use-triggered-date-pills.test.ts + ContentArea.test.tsx + date-mention.test.ts
PASS (35) FAIL (0)
```

`react-doctor` not run: no React component or hook body was modified — the change is confined to the two non-React DOM helpers in this module.

## Risk & backward compatibility

Renderer-only, presentational. No DB, IPC contract, vault file format, settings shape, or markdown serialization is touched — `data-fired` is a per-device CSS hook that was already never written into pill props or note markdown. No change to the editor's change pipeline, no `setState` in an input handler, no focus handling, so neither of the known editor landmines is in play. Nothing to migrate; older installs are unaffected.

## Relation to #1140

PR #1140 (`editor-destroy-and-journal-remount`) also lives in editor lifecycle — it destroys BlockNote editors on unmount and stops remounting the note/journal editors per external update. There is no textual overlap: #1140 edits `ContentArea.tsx`, `use-editor-sync`, and adds `use-editor-teardown`; this branch only edits `use-triggered-date-pills.{ts,test.ts}`. Behaviourally the two are complementary — #1140 makes external updates patch the editor in place instead of remounting it, which produces *fewer* container-wide DOM replacements, and this observer handles whatever `addedNodes` those in-place updates do produce. Derived from current `origin/main`; #1140 was not modified.

## Docs

Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`. The change is internal: identical rendered output and identical user-visible date-pill behaviour, only less redundant DOM scanning. Nothing in `apps/docs/src` describes the observer.

Closes #1047
