### PR TITLE
fix(agent): bound the wait for an in-flight agent start during vault teardown

### DIFF
--- a/apps/desktop/src/main/vault/index.test.ts
+++ b/apps/desktop/src/main/vault/index.test.ts
@@ -509,10 +509,19 @@ describe('vault lifecycle', () => {
     const startupInFlight = firstStarter()
     await startAgentEntered
 
-    const switchInFlight = selectVault({ path: '/vault/two' })
-    releaseStartAgent({ shutdown: mocks.agentShutdown })
-    await startupInFlight
-    await switchInFlight
+    vi.useFakeTimers()
+    try {
+      const switchInFlight = selectVault({ path: '/vault/two' })
+      releaseStartAgent({ shutdown: mocks.agentShutdown })
+      await startupInFlight
+      await switchInFlight
+
+      // The settle path must clear its timeout rather than leave a pending
+      // timer behind — closeVault() also runs on the quit path.
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
 
     // The orphaned runtime is shut down: handlers unregistered, subprocesses
     // killed, vault key zeroed.
@@ -538,6 +547,97 @@ describe('vault lifecycle', () => {
     await secondStarter()
     expect(mocks.startAgent).toHaveBeenCalledTimes(1)
     expect(mocks.currentVaultPath).toBe('/vault/two')
+  })
+
+  // closeVault() also runs on the quit path, where main/index.ts force-exits
+  // after 5s. Waiting on a start that never settles would trade the leak above
+  // for a frozen vault switch and a hung quit, so the wait is bounded.
+  it('does not block a vault switch on an agent startup that never settles', async () => {
+    await selectVault({ path: '/vault/one' })
+    const firstStarter = mocks.configureLazyAgentServices.mock.calls.at(
+      -1
+    )?.[0] as () => Promise<void>
+
+    let markStartAgentEntered!: () => void
+    const startAgentEntered = new Promise<void>((resolve) => {
+      markStartAgentEntered = resolve
+    })
+    // Wedged start: resolvable only by the test, so the module is not left
+    // holding a forever-pending promise after this case.
+    let releaseStuckStart!: (handle: { shutdown: () => Promise<void> }) => void
+    const stuckStart = new Promise<{ shutdown: () => Promise<void> }>((resolve) => {
+      releaseStuckStart = resolve
+    })
+    mocks.startAgent.mockImplementation(() => {
+      markStartAgentEntered()
+      return stuckStart
+    })
+
+    const startupInFlight = firstStarter()
+    await startAgentEntered
+
+    vi.useFakeTimers()
+    try {
+      let switchSettled = false
+      const switchInFlight = selectVault({ path: '/vault/two' }).then((result) => {
+        switchSettled = true
+        return result
+      })
+
+      // Burn exactly the teardown budget. advanceTimersByTimeAsync drains
+      // microtasks between ticks, so an unbounded wait leaves this false.
+      await vi.advanceTimersByTimeAsync(1000)
+
+      expect(switchSettled).toBe(true)
+      await switchInFlight
+    } finally {
+      vi.useRealTimers()
+      releaseStuckStart({ shutdown: mocks.agentShutdown })
+      await startupInFlight
+    }
+
+    // The switch completed and the new vault owns its own agent IPC handlers.
+    expect(getStatus()).toEqual(expect.objectContaining({ isOpen: true, path: '/vault/two' }))
+    expect(mocks.currentVaultPath).toBe('/vault/two')
+    expect(mocks.closeAllDatabases).toHaveBeenCalledTimes(1)
+    expect(mocks.registerLazyAgentHandlers.mock.invocationCallOrder.at(-1)).toBeGreaterThan(
+      mocks.unregisterLazyAgentHandlers.mock.invocationCallOrder[0] as number
+    )
+  })
+
+  // The bound has to be generous enough that a slow-but-healthy start is still
+  // waited for; a wait that gives up immediately would be no fix at all.
+  it('waits for a slow agent startup that settles inside the teardown budget', async () => {
+    await selectVault({ path: '/vault/one' })
+    const firstStarter = mocks.configureLazyAgentServices.mock.calls.at(
+      -1
+    )?.[0] as () => Promise<void>
+
+    vi.useFakeTimers()
+    try {
+      mocks.startAgent.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve({ shutdown: mocks.agentShutdown }), 500)
+          })
+      )
+
+      const startupInFlight = firstStarter()
+      await vi.advanceTimersByTimeAsync(0)
+
+      const switchInFlight = selectVault({ path: '/vault/two' })
+      await vi.advanceTimersByTimeAsync(500)
+      await startupInFlight
+      await switchInFlight
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(mocks.agentShutdown).toHaveBeenCalledTimes(1)
+    expect(mocks.stopAgentMcpLifecycle).toHaveBeenCalledTimes(1)
+    expect(mocks.agentShutdown.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.closeAllDatabases.mock.invocationCallOrder[0]
+    )
   })
 
   it('auto-opens the test vault and emits explicit progress/error events', async () => {

--- a/apps/desktop/src/main/vault/index.test.ts
+++ b/apps/desktop/src/main/vault/index.test.ts
@@ -479,6 +479,67 @@ describe('vault lifecycle', () => {
     expect(mocks.currentVaultPath).toBe('/vault/two')
   })
 
+  // A vault switch that lands while startAgent() is still in flight used to
+  // early-return from the agent teardown (agentHandle was still null), so the
+  // orphaned start resolved *after* the next vault registered its lazy
+  // handlers: registerAgentHandlers() replaced them with handlers closed over
+  // the previous vault's db/conversations/vaultId, and that runtime was never
+  // shut down (vault key left unzeroed, subprocesses left alive).
+  it('tears down an agent runtime that finishes starting during a vault switch', async () => {
+    await selectVault({ path: '/vault/one' })
+    const firstStarter = mocks.configureLazyAgentServices.mock.calls.at(
+      -1
+    )?.[0] as () => Promise<void>
+
+    // Park the startup inside startAgent() so the switch is guaranteed to run
+    // in the gap — no timers, no timing assumptions.
+    let markStartAgentEntered!: () => void
+    const startAgentEntered = new Promise<void>((resolve) => {
+      markStartAgentEntered = resolve
+    })
+    let releaseStartAgent!: (handle: { shutdown: () => Promise<void> }) => void
+    const staleHandle = new Promise<{ shutdown: () => Promise<void> }>((resolve) => {
+      releaseStartAgent = resolve
+    })
+    mocks.startAgent.mockImplementation(() => {
+      markStartAgentEntered()
+      return staleHandle
+    })
+
+    const startupInFlight = firstStarter()
+    await startAgentEntered
+
+    const switchInFlight = selectVault({ path: '/vault/two' })
+    releaseStartAgent({ shutdown: mocks.agentShutdown })
+    await startupInFlight
+    await switchInFlight
+
+    // The orphaned runtime is shut down: handlers unregistered, subprocesses
+    // killed, vault key zeroed.
+    expect(mocks.agentShutdown).toHaveBeenCalledTimes(1)
+    expect(mocks.stopAgentMcpLifecycle).toHaveBeenCalledTimes(1)
+
+    // ...and it is torn down before the previous vault's databases close and
+    // before the new vault publishes its own agent IPC handlers, so the new
+    // vault's channels are never replaced by old-vault-bound ones.
+    const shutdownOrder = mocks.agentShutdown.mock.invocationCallOrder[0]
+    expect(shutdownOrder).toBeLessThan(mocks.closeAllDatabases.mock.invocationCallOrder[0])
+    expect(shutdownOrder).toBeLessThan(
+      mocks.registerLazyAgentHandlers.mock.invocationCallOrder.at(-1) as number
+    )
+
+    // The new vault gets its own runtime rather than inheriting the stale
+    // handle — never two live runtimes, never zero.
+    mocks.startAgent.mockReset()
+    mocks.startAgent.mockResolvedValue({ shutdown: mocks.agentShutdown })
+    const secondStarter = mocks.configureLazyAgentServices.mock.calls.at(
+      -1
+    )?.[0] as () => Promise<void>
+    await secondStarter()
+    expect(mocks.startAgent).toHaveBeenCalledTimes(1)
+    expect(mocks.currentVaultPath).toBe('/vault/two')
+  })
+
   it('auto-opens the test vault and emits explicit progress/error events', async () => {
     process.env.NODE_ENV = 'test'
     process.env.TEST_VAULT_PATH = '/vault/e2e'

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -625,6 +625,16 @@ async function stopVaultAgentServices(): Promise<void> {
   configureLazyAgentServices(null)
   unregisterLazyAgentHandlers()
 
+  // A start that is still in flight owns this vault's db handles and calls
+  // registerAgentHandlers() when it resolves. Dropping the promise here let it
+  // land after the *next* vault had registered its own handlers, replacing them
+  // with handlers closed over the previous vault's db/conversations/vaultId,
+  // and left that runtime alive (vault key unzeroed, subprocesses running).
+  // Waiting makes the handle read below the one to tear down.
+  // startVaultAgentServicesOnce swallows its own failures so this cannot
+  // reject; the catch only keeps a future change from wedging vault switching.
+  if (agentStartupPromise) await agentStartupPromise.catch(() => undefined)
+
   const currentAgentHandle = agentHandle
   agentHandle = null
   agentStartupPromise = null

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -86,6 +86,24 @@ let currentStatus: VaultStatus = {
 }
 let agentHandle: AgentHandle | null = null
 let agentStartupPromise: Promise<void> | null = null
+
+/**
+ * How long stopVaultAgentServices() waits for an in-flight agent start before
+ * tearing down without it.
+ *
+ * Derived from the shutdown budget, not picked for roundness: closeVault() is
+ * the last step of the `before-quit` chain in main/index.ts, which force-exits
+ * the app after 5000ms. flushAllWindows() ahead of it can already spend 2000ms
+ * (flushWindow's default per-window timeout), and after this wait closeVault()
+ * still has to stop the watcher, drain projections, stop the sync runtime and
+ * close the databases. Claiming a third of the ~3000ms remainder keeps this
+ * step from ever being the one that blows the budget.
+ *
+ * It is a backstop, not a throttle: a healthy start is a localhost HTTP bind,
+ * one keychain read, a KDF and a few SQLite statements — orders of magnitude
+ * under this — so the timeout only fires when the start is genuinely wedged.
+ */
+const AGENT_STARTUP_TEARDOWN_WAIT_MS = 1000
 let isShuttingDown = false
 const statusListeners = new Set<(status: VaultStatus) => void>()
 
@@ -631,9 +649,32 @@ async function stopVaultAgentServices(): Promise<void> {
   // with handlers closed over the previous vault's db/conversations/vaultId,
   // and left that runtime alive (vault key unzeroed, subprocesses running).
   // Waiting makes the handle read below the one to tear down.
-  // startVaultAgentServicesOnce swallows its own failures so this cannot
-  // reject; the catch only keeps a future change from wedging vault switching.
-  if (agentStartupPromise) await agentStartupPromise.catch(() => undefined)
+  //
+  // The wait is bounded because closeVault() also runs on the quit path, where
+  // main/index.ts force-exits the app once its 5s budget is gone. A start
+  // that never settles must not turn the leak into a hung quit — on timeout,
+  // fall through to the teardown below and accept that the orphan may still
+  // land late (the pre-fix behaviour), which is strictly better than freezing.
+  if (agentStartupPromise) {
+    let settleTimer: ReturnType<typeof setTimeout> | undefined
+    const settled = await Promise.race([
+      // startVaultAgentServicesOnce swallows its own failures, so this only
+      // rejects if that ever changes; either way the start is over.
+      agentStartupPromise.then(
+        () => true,
+        () => true
+      ),
+      new Promise<boolean>((resolve) => {
+        settleTimer = setTimeout(() => resolve(false), AGENT_STARTUP_TEARDOWN_WAIT_MS)
+      })
+    ])
+    clearTimeout(settleTimer)
+    if (!settled) {
+      logger.warn(
+        `Agent startup did not settle within ${AGENT_STARTUP_TEARDOWN_WAIT_MS}ms; tearing down without it`
+      )
+    }
+  }
 
   const currentAgentHandle = agentHandle
   agentHandle = null


### PR DESCRIPTION
## Problem

`stopVaultAgentServices()` early-returned whenever `agentHandle` was still `null`, which is exactly the state while `startAgent()` is in flight. Opening Agent Chat and then switching vaults before the runtime finished starting left the previous vault's agent runtime alive and bound to the previous vault's data.

## Root cause

The teardown read `agentHandle` and threw away `agentStartupPromise` without waiting on it:

```ts
const currentAgentHandle = agentHandle   // still null mid-startup
agentHandle = null
agentStartupPromise = null
if (!currentAgentHandle) return          // no-op teardown
```

The interleaving (all yields are real `await`s in `startVaultAgentServicesOnce`):

1. Renderer opens Agent Chat → a lazy agent IPC handler calls `ensureLazyAgentServicesStarted()` → `startVaultAgentServices()` sets `agentStartupPromise` and parks on `await startAgentMcpLifecycle()` / `await startAgent()`. `agentHandle` is still `null`.
2. User switches vaults → `selectVault` → `closeVault` → `stopVaultAgentServices`. It unregisters the lazy handlers, reads `agentHandle` (`null`), nulls `agentStartupPromise`, and returns without awaiting anything.
3. `closeVault` continues: `closeAllDatabases()` closes vault A's data/index handles.
4. `openVault(B)` runs and calls `configureLazyAgentServices(startVaultAgentServices)` + `registerLazyAgentHandlers()` — vault B now owns every `AgentChannels.invoke` channel.
5. The orphaned `startAgent()` finally resolves. Inside, `registerAgentHandlers()` calls `unregisterAgentHandlers()` and re-registers **every** agent channel with handlers closed over vault A's `db`, `conversations`, `messages` and `vaultId`. Vault B's handlers are gone; `agentHandle` is reassigned to the stale handle; that handle's `shutdown()` (which does `unregisterAgentHandlers()` → `runtime.killAll()` → `secureCleanup(vaultKey)`) never runs.

Memry is E2E encrypted and sync is per-vault, so this is not just a leak: with vault B open, `agent:listConversations` / `agent:loadConversation` were served by vault A's stores under vault A's `vaultId`, and vault A's key material stayed resident and unzeroed.

## Fix

`stopVaultAgentServices()` now waits for the in-flight startup before reading the handle — but the wait is **bounded**, because `closeVault()` is also the last step of the `before-quit` chain in `main/index.ts`, which force-exits the app once its 5000ms budget is gone.

```ts
if (agentStartupPromise) {
  let settleTimer: ReturnType<typeof setTimeout> | undefined
  const settled = await Promise.race([
    agentStartupPromise.then(() => true, () => true),
    new Promise<boolean>((resolve) => {
      settleTimer = setTimeout(() => resolve(false), AGENT_STARTUP_TEARDOWN_WAIT_MS)
    })
  ])
  clearTimeout(settleTimer)
  if (!settled) logger.warn(...)
}
```

`startVaultAgentServicesOnce` assigns `agentHandle` as its last statement and its `.finally` nulls `agentStartupPromise` only after it settles, so on the settle path `agentHandle` is unambiguously the runtime that actually started; the existing `shutdown()` + `stopAgentMcpLifecycle()` path then tears it down. Because `closeVault` awaits `stopVaultAgentServices()` first, that completes before `closeAllDatabases()` and before `openVault(B)` registers anything.

### Where the timeout number comes from

`AGENT_STARTUP_TEARDOWN_WAIT_MS = 1000`, derived from the in-repo shutdown budget rather than picked for roundness:

- `main/index.ts` `before-quit` force-exits via `app.exit(1)` (and writes a `SHUTDOWN_TIMEOUT` crash marker) after **5000ms**.
- `flushAllWindows()` runs ahead of `closeVault()` and can already spend **2000ms** (`flushWindow`'s default per-window timeout), leaving ~3000ms.
- After this wait, `closeVault()` still owes `stopWatcher()`, `stopProjectionRuntime({ drain: true })`, `stopSyncRuntime()` and `closeAllDatabases()`, plus the MCP `handle.stop()`.

Claiming roughly a third of that ~3000ms remainder keeps this step from ever being the one that blows the budget. It is a backstop, not a throttle: a healthy start is a localhost HTTP bind, one keychain read, a blake2b KDF and a few SQLite statements — orders of magnitude under 1000ms — so in practice the settle path always wins. `clearTimeout` matters for the same reason: leaving a pending 1s timer behind on the quit path is precisely the class of problem being avoided, and it is covered by a `vi.getTimerCount()` assertion.

### Residual: the race is NOT unconditionally gone

Stated plainly, because the timeout path is a real degradation rather than a theoretical one. **If a start does not settle within 1000ms, the original #1032 race can still occur for that one switch.** When the wedged start eventually resolves, after teardown has already returned:

- its `registerAgentHandlers()` still replaces the new vault's channels with handlers closed over the **old** vault's `db`/`conversations`/`messages`/`vaultId`; and
- it still assigns `agentHandle`, so the new vault's lazy start hits `if (agentHandle) return` and never boots its own runtime.

So on that path the new vault can end up reachable by the old vault's data and with no runtime of its own — that is exactly today's `origin/main` behaviour, minus the hang. This is a deliberate trade: a leak degrades the session, a hang ends it (the app will not close, and the user gets a forced `app.exit(1)` plus a crash marker). Removing the residual entirely needs a generation token that `startVaultAgentServicesOnce` re-checks after `startAgent()` resolves, so a superseded start shuts itself down instead of registering. That is deliberately **not** in this PR — it is a second mechanism that would make this one partly redundant — and is the natural follow-up.

The three subsections below describe the settle path, which is the overwhelmingly common one.

### Why two live runtimes are impossible on the settle path

There is exactly one place that creates a runtime (`startVaultAgentServicesOnce`) and it is always reachable through `agentStartupPromise`. Teardown now joins that promise instead of skipping it, so `stopVaultAgentServices` cannot return while a runtime is still materializing. The old vault's runtime is fully shut down before `openVault` is entered, so vault B's lazy start can only ever begin after vault A's runtime is gone.

### Why zero runtimes are impossible on the settle path

The only way vault B could end up with no runtime was the orphan landing *after* vault B registered: it wiped vault B's channels, and its later `shutdown()` → `unregisterAgentHandlers()` would have removed them outright, leaving Agent Chat with "No handler registered" until restart. Ordering now guarantees the orphan's `registerAgentHandlers()` **and** its `unregisterAgentHandlers()` both happen before `openVault(B)` runs `registerLazyAgentHandlers()`, so vault B's channels are the last write and survive. The lazy start path for B is untouched, so the first Agent Chat invoke still boots B's own runtime.

### Double registration of the same IPC channel

`ipcMain.handle` throws `Attempted to register a second handler for '<channel>'` on a duplicate. Both registrars already defend against this by unregistering first — `registerLazyAgentHandlers()` opens with `unregisterLazyAgentHandlers()`, and `registerAgentHandlers()` opens with `unregisterAgentHandlers()`. That is precisely why the bug was silent clobbering rather than a throw. This change does not add a registration site; it only makes the *ordering* of the existing ones deterministic, so the last writer is always the currently-open vault.

### Data loss

None. On the settle path nothing is abandoned: the in-flight start completes and is shut down through its normal `shutdown()`, which calls `runtime.killAll()` to cancel any turn and release its lock rather than leaving a stuck lock. On the timeout path the start is not cancelled either — it is simply no longer waited for, and it completes on its own afterwards; no conversation or message write is dropped. No conversation, message, or provider/model/reasoning setting is touched — those remain persisted conversation settings.

### No cache or latch added

This adds no cache, latch or negative memoization — it removes a skipped await. `lazy-services` state is still reset per vault by the existing `configureLazyAgentServices(null)` / `configureLazyAgentServices(starter)` pair on close/open.

## Test evidence

Three deterministic tests in `apps/desktop/src/main/vault/index.test.ts`. The race is forced, never timed: the startup is parked *inside* `startAgent()` via a deferred, and the timeout cases use fake timers so no test depends on wall-clock behaviour.

1. `tears down an agent runtime that finishes starting during a vault switch` — the settle path, plus `expect(vi.getTimerCount()).toBe(0)` so the timer is not leaked.
2. `does not block a vault switch on an agent startup that never settles` — the timeout path: the switch must complete within the budget.
3. `waits for a slow agent startup that settles inside the teardown budget` — a start that settles at 500ms must still be torn down, so the bound is not degenerate.

RED on `origin/main` (test 1):

```
 × tears down an agent runtime that finishes starting during a vault switch
   → expected "vi.fn()" to be called 1 times, but got 0 times
 Test Files  1 failed (1)
      Tests  1 failed | 10 passed (11)
```

GREEN with the fix:

```
 ✓ tears down an agent runtime that finishes starting during a vault switch 2ms
 ✓ does not block a vault switch on an agent startup that never settles 1ms
 ✓ waits for a slow agent startup that settles inside the teardown budget 1ms
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

### Mutation verification — 5 mutants, 0 survivors

Each targets the exact code line; comments were left untouched so no substitution produced a false survivor.

**M1 — the timeout value** (`AGENT_STARTUP_TEARDOWN_WAIT_MS = 1000` → `0`). **Killed:**

```
 × waits for a slow agent startup that settles inside the teardown budget
   → expected "vi.fn()" to be called 1 times, but got 0 times
      Tests  1 failed | 12 passed (13)
```

M1 **survived the first time round** — the original two tests only distinguished *bounded* from *unbounded*, so any positive value passed. That was a genuine coverage hole in the bound itself, and test 3 was added to close it: with `0`, the timeout wins the race before a 500ms start settles and the handle is never torn down.

**M2 — the timeout arm removed** (unbounded wait, i.e. the version this review rejected). **Killed:**

```
 × does not block a vault switch on an agent startup that never settles
   → expected false to be true
      Tests  1 failed | 12 passed (13)
```

**M3 — `clearTimeout(settleTimer)` removed.** **Killed:**

```
 × tears down an agent runtime that finishes starting during a vault switch
   → expected 1 to be +0
      Tests  1 failed | 12 passed (13)
```

**M4 — the whole wait block removed** (= `origin/main` behaviour). **Killed:**

```
 × tears down an agent runtime that finishes starting during a vault switch
   → expected "vi.fn()" to be called 1 times, but got 0 times
 × waits for a slow agent startup that settles inside the teardown budget
   → expected "vi.fn()" to be called 1 times, but got 0 times
      Tests  2 failed | 11 passed (13)
```

**M5 — `await stopVaultAgentServices()` → `void ...` in `closeVault`**, proving the ordering assertions are not vacuous. **Killed** (also kills the pre-existing switch test):

```
 × restarts vault-scoped agent services when switching vaults   → expected 351 to be less than 323
 × tears down an agent runtime that finishes starting during a vault switch → expected 435 to be less than 407
 × waits for a slow agent startup that settles inside the teardown budget → expected 598 to be less than 568
      Tests  3 failed | 10 passed (13)
```

All mutants reverted; the source diff was re-read against intent and the suite re-confirmed green before committing.

## Verification

```
pnpm typecheck            Tasks: 16 successful, 16 total   (rpc:check + IPC invoke map up to date)
pnpm lint                 ✖ 15 problems (0 errors, 15 warnings)  — all pre-existing, zero in the two changed files
pnpm --filter @memry/desktop test:main src/main/vault src/main/agent \
    src/main/ipc/agent-{handlers,lazy-handlers,mcp-handlers}.test.ts
                          Test Files  73 passed (73)
                          Tests      865 passed (865)
git diff --check          clean (exit 0)
```

`pnpm ipc:check` is covered by `pnpm typecheck`, which runs `rpc:check` and `generate-ipc-invoke-map --check` — both report up to date. No contract, preload, IPC handler or provider file changed; the diff is confined to `vault/index.ts` teardown ordering.

## Risk & backward compatibility

Low. No schema, migration, contract, settings shape, sync payload or vault file format is touched, so nothing older versions wrote is affected and no DB reset is involved. The single behavioural change is that a vault switch started during agent startup now waits up to 1000ms for that startup to finish before closing the old vault. The wait is bounded specifically so `closeVault()` on the quit path cannot consume the 5000ms shutdown budget, and it is strictly better than today, where `getOrInitializeLocalVaultKey` could be racing `closeAllDatabases()` on the same handle. `startVaultAgentServicesOnce` swallows its own failures so the awaited promise cannot reject; the rejection arm of the race is there only so a future change to that function cannot wedge vault switching.

## Overlap with open PRs

Derives from current `origin/main`. Touches only `apps/desktop/src/main/vault/index.ts` + its test, so there is no file overlap with #1121, #1123, #1125, #1126, #1127, #1128, #1129, #1132 or #1133. #1123 (MCP server destroys in-flight connections on stop) is complementary — it hardens `handle.stop()`, which is what `stopAgentMcpLifecycle()` calls on the path this PR now reliably reaches.

## Docs

`pnpm docs:impact --strict` reports `missing-docs` for `apps/desktop/src/main/vault/index.ts`. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: this is an internal main-process lifecycle ordering fix with no user-facing surface — no new setting, IPC contract, UI, or documented behaviour. The only observable change is that Agent Chat no longer serves the previous vault's data after a mid-startup vault switch, which is the documented behaviour already.

## Out of scope (found, deliberately not fixed)

- The queued agent-lifecycle cluster #1033–#1039 is untouched. In particular the `if (!currentAgentHandle) return` guard is kept as-is: when the in-flight `startAgent()` *fails*, `startAgentMcpLifecycle()` has already succeeded and the MCP server is still left listening — that is exactly #1033 and belongs there.
- `agent/lazy-services.ts`: `ensureLazyAgentServicesStarted()` chains `starter().then(() => { started = true })`, and that chain is not invalidated by `configureLazyAgentServices()`. A superseded chain can therefore set the module-level `started = true` while `starter === null`. With this fix the switch path self-heals (`openVault` re-configures and resets `started = false`), and after a bare `closeVault()` the stale positive is benign because `getPublicStatus()` returns the same stopped status. Separately, a *failed* start also latches `started = true` with `agentHandle === null`, which makes every agent invoke return `AGENT_RUNTIME_STARTING_CODE` for the rest of the session — that is a real latent bug, adjacent to #1033, and is not fixed here.

Closes #1032

