### PR TITLE
perf(folder-view): coalesce note-update folder-view cache invalidation

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-folder-view-events.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-folder-view-events.test.tsx
@@ -1,0 +1,147 @@
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { folderViewKeys } from './use-folder-view'
+import { useFolderViewEvents } from './use-folder-view-events'
+
+const mocks = vi.hoisted(() => ({
+  noteListeners: {} as Record<string, () => void>,
+  unsubscribe: vi.fn()
+}))
+
+vi.mock('@/services/notes-service', () => {
+  const subscribe = (name: string) =>
+    vi.fn((callback: () => void) => {
+      mocks.noteListeners[name] = callback
+      return mocks.unsubscribe
+    })
+  return {
+    notesService: {},
+    onTagsChanged: subscribe('tags-changed'),
+    onNoteMoved: subscribe('moved'),
+    onNoteDeleted: subscribe('deleted'),
+    onNoteCreated: subscribe('created'),
+    onNoteUpdated: subscribe('updated'),
+    onNoteRenamed: subscribe('renamed'),
+    onNoteExternalChange: subscribe('external')
+  }
+})
+
+const SCOPE = { kind: 'folder', path: 'Notes' } as const
+
+/** Longer than any coalescing window the hook is allowed to use. */
+const PAST_THE_COALESCING_WINDOW_MS = 10_000
+
+/**
+ * Mounts the global event hook next to a real, active folder-view listing
+ * query, so the assertions count actual refetches (queryFn calls) rather than
+ * invalidation bookkeeping.
+ */
+function renderHarness() {
+  const listNotes = vi.fn(async () => ({ notes: [] }))
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } }
+  })
+
+  const wrapper = ({ children }: { children: ReactNode }): React.JSX.Element => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  const rendered = renderHook(
+    () => {
+      useFolderViewEvents()
+      useQuery({ queryKey: folderViewKeys.notes(SCOPE), queryFn: listNotes })
+    },
+    { wrapper }
+  )
+
+  return { listNotes, queryClient, ...rendered }
+}
+
+async function settle(ms = 0): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+describe('useFolderViewEvents', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    for (const key of Object.keys(mocks.noteListeners)) delete mocks.noteListeners[key]
+    mocks.unsubscribe.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not refetch the listing while note updates keep arriving', async () => {
+    const { listNotes } = renderHarness()
+    await settle()
+    expect(listNotes).toHaveBeenCalledTimes(1)
+
+    // A typing session: the editor autosaves on a 1s debounce, and every save
+    // emits notes:updated.
+    for (let i = 0; i < 5; i++) {
+      act(() => mocks.noteListeners.updated())
+      await settle(1000)
+    }
+
+    expect(listNotes).toHaveBeenCalledTimes(1)
+  })
+
+  it('refetches the listing exactly once after the update burst ends', async () => {
+    const { listNotes } = renderHarness()
+    await settle()
+
+    act(() => {
+      mocks.noteListeners.updated()
+      mocks.noteListeners.updated()
+      mocks.noteListeners.updated()
+    })
+    await settle(PAST_THE_COALESCING_WINDOW_MS)
+
+    expect(listNotes).toHaveBeenCalledTimes(2)
+  })
+
+  it.each(['created', 'renamed', 'moved', 'deleted', 'external'])(
+    'refetches the listing immediately on note %s',
+    async (event) => {
+      const { listNotes } = renderHarness()
+      await settle()
+
+      act(() => mocks.noteListeners[event]())
+      await settle()
+
+      expect(listNotes).toHaveBeenCalledTimes(2)
+    }
+  )
+
+  it('does not refetch again for updates a structural event already covered', async () => {
+    const { listNotes } = renderHarness()
+    await settle()
+
+    act(() => mocks.noteListeners.updated())
+    act(() => mocks.noteListeners.created())
+    await settle(PAST_THE_COALESCING_WINDOW_MS)
+
+    expect(listNotes).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops a pending update refetch and unsubscribes on unmount', async () => {
+    const { listNotes, queryClient, unmount } = renderHarness()
+    await settle()
+    // The unmounted listing is inactive, so a late timer would not show up as a
+    // refetch — assert on the invalidation the timer would still fire.
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+    act(() => mocks.noteListeners.updated())
+    unmount()
+    await settle(PAST_THE_COALESCING_WINDOW_MS)
+
+    expect(listNotes).toHaveBeenCalledTimes(1)
+    expect(invalidateQueries).not.toHaveBeenCalled()
+    expect(mocks.unsubscribe).toHaveBeenCalledTimes(6)
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-folder-view-events.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-folder-view-events.ts
@@ -26,6 +26,24 @@ import {
 import { folderViewKeys } from './use-folder-view'
 
 /**
+ * How long a burst of `notes:updated` events is coalesced before the folder-view
+ * caches are invalidated.
+ *
+ * `notes:updated` fires on every autosave (the editor debounces at 1s), on every
+ * CRDT write-back, and on every watcher-observed file change, so typing with a
+ * folder or tag view in a split pane used to refetch the whole listing about
+ * once a second. A content update can never change *which* notes a view
+ * contains: folder membership moves through `notes:created`/`renamed`/`moved`/
+ * `deleted`, and tag membership through the tag events `useFolderView`
+ * subscribes to per scope. Only row data (Modified, word count, properties,
+ * title, emoji) is at stake, so the burst is coalesced instead of dropped.
+ *
+ * Trailing edge: the last update in a burst is always the one that invalidates,
+ * so no event is lost — the refetch just lands this many ms after typing stops.
+ */
+const NOTE_UPDATE_INVALIDATE_DELAY_MS = 3000
+
+/**
  * Global event handler for folder-view cache invalidation.
  * Call this once in App.tsx to ensure all folder-view tabs stay in sync.
  */
@@ -36,18 +54,32 @@ export function useFolderViewEvents(): void {
     // Invalidate ALL folder-view caches when notes change
     // This ensures all tabs (mounted or not) get fresh data when activated
 
+    let updateTimer: ReturnType<typeof setTimeout> | null = null
+
     const invalidate = () => {
+      // A structural event invalidates the same key a pending content update
+      // would have, and happens after it, so it supersedes the pending refetch.
+      if (updateTimer) {
+        clearTimeout(updateTimer)
+        updateTimer = null
+      }
       void queryClient.invalidateQueries({ queryKey: folderViewKeys.all })
+    }
+
+    const invalidateAfterUpdateBurst = () => {
+      if (updateTimer) clearTimeout(updateTimer)
+      updateTimer = setTimeout(invalidate, NOTE_UPDATE_INVALIDATE_DELAY_MS)
     }
 
     const unsubMoved = onNoteMoved(invalidate)
     const unsubDeleted = onNoteDeleted(invalidate)
     const unsubCreated = onNoteCreated(invalidate)
-    const unsubUpdated = onNoteUpdated(invalidate)
+    const unsubUpdated = onNoteUpdated(invalidateAfterUpdateBurst)
     const unsubRenamed = onNoteRenamed(invalidate)
     const unsubExternal = onNoteExternalChange(invalidate)
 
     return () => {
+      if (updateTimer) clearTimeout(updateTimer)
       unsubMoved()
       unsubDeleted()
       unsubCreated()

--- a/apps/docs/src/user-guide/folder-view.md
+++ b/apps/docs/src/user-guide/folder-view.md
@@ -94,6 +94,14 @@ Opening a tag (see [Properties & Tags](/user-guide/notes/properties-tags)) shows
 
 If you opened folder view from a folder, a breadcrumb at the top lets you navigate up to parent folders. A tag-scoped folder view shows the tag instead, as a locked `tag = <name>` filter chip that can't be removed — it defines the view.
 
+## Staying Up To Date
+
+A folder view refreshes itself as the vault changes, so you can keep one open in a split pane next to the note you are writing.
+
+Rows appear, disappear, and move immediately when a note is created, renamed, moved to another folder, or deleted — whether you did it in Memry, another device did it and it arrived over sync, or you did it in Finder, Explorer, or Obsidian. Tag-scoped views update the same way when a note gains or loses the tag.
+
+Row _contents_ — Modified, word count, properties, title, emoji — settle a few seconds after you stop typing rather than on every autosave. Which notes are listed is never delayed; only their columns are.
+
 ## See Also
 
 - [Properties & Tags](/user-guide/notes/properties-tags)


### PR DESCRIPTION
## Problem

`useFolderViewEvents` is mounted for the app's lifetime at the App root (`App.tsx:211`) and invalidated `folderViewKeys.all` on all six note events. `notes:updated` fires on every autosave (the editor debounces at 1s in `use-note-editor.ts:100`), on every CRDT write-back, and on every watcher-observed file change. So typing with a folder or tag view in a split pane refetched the whole listing — `exists`, `views`, `available-properties` and the paginated `notes` query, for **every** mounted scope — about once a second.

## Root cause

One invalidation callback was shared by all six subscriptions. `notes:updated` is a high-frequency content event, but it was treated exactly like the rare structural events (`created`/`renamed`/`moved`/`deleted`).

## Fix

`notes:updated` is coalesced on a **3s trailing edge**; the other five stay immediate.

Why coalesce rather than drop or narrow the key:

- A content update can never change *which* notes a view contains. Folder membership moves through `notes:created`/`renamed`/`moved`/`deleted`; tag membership moves through the tag events `useFolderView` already subscribes to per scope (`use-folder-view.ts:1060-1079`), which are untouched.
- The payload cannot discriminate. `notes-crud.ts:638` sends `title`/`content`/`tags`/`properties`/`emoji` unconditionally on every save, so there is no "content-only" flag to filter on.
- Trailing edge means **the last update in a burst is always the one that invalidates**. Nothing is dropped — the refetch lands after typing stops.
- The invalidation key is unchanged (`folderViewKeys.all`). Nothing was narrowed, so nothing can go stale that wasn't already covered. In particular the `views` query still refetches on note events, which is the only thing that picks up an externally edited `.folder.md` short of a window focus — `onFolderConfigUpdated` is consumed by `use-notes-query.ts` only. This keeps well clear of the folder-view-config-reset regression class (#720): the change is read-side invalidation only and writes nothing.

A structural event also cancels a pending update refetch it already supersedes (same key, later in time), and unmount clears the pending timer so no invalidation fires against a torn-down tree.

## Events that still invalidate the folder listing

| Event | Path in this hook | Emitters |
| --- | --- | --- |
| Note created (in-app) | `onNoteCreated` → immediate | `main/vault/notes-crud.ts:300` |
| Note created (sync, other device) | `onNoteCreated` → immediate | `main/sync/crdt-writeback.ts:398`, `main/sync/item-handlers/note-handler.ts:540,608` |
| File appears via watcher (Obsidian/Finder) | `onNoteCreated` → immediate | `main/vault/watcher.ts:401` (markdown), `:510` (binaries) |
| Note renamed | `onNoteRenamed` → immediate | `main/vault/notes-rename.ts:95`, `main/vault/rename-tracker.ts:81` (watcher-detected), `note-handler.ts:216,348` (sync) |
| Note moved between folders | `onNoteMoved` → immediate | `main/vault/notes-rename.ts:177`, `note-handler.ts:226,358` (sync) |
| Note deleted | `onNoteDeleted` → immediate | `main/vault/notes-crud.ts:687`, `main/vault/watcher.ts:730` (external), `crdt-writeback.ts:595`, `note-handler.ts:639` (sync) |
| Folder created / renamed / deleted | `onNoteCreated`/`Renamed`/`Moved`/`Deleted` → immediate | `notes-crud.ts:738-758` do pure fs work and emit nothing themselves; the watcher emits per-note add/rename/unlink, which is what the listing and the `exists` query key off |
| Tag added/removed on a note, tag-scoped view | untouched — `use-folder-view.ts:1060-1079` invalidates `folderViewKeys.notes(scope)` immediately | `tags:notes-changed`, `notes:tags-changed` (`notes-crud.ts:663`) |
| Note icon/emoji, title, properties, word count, Modified | `onNoteUpdated` → coalesced, ≤3s | `notes-crud.ts:638`, `watcher.ts:606,680` (external), `crdt-writeback.ts:352`, `note-handler.ts:249,472` (sync) |
| `notes:external-change` | `onNoteExternalChange` → immediate (unchanged) | none — see out-of-scope note below |

Only the last row changes timing, and only for row *contents*. Row membership is never delayed.

## Test evidence

New `apps/desktop/src/renderer/src/hooks/use-folder-view-events.test.tsx` mounts the hook next to a **real active** `useInfiniteQuery`-style listing query and counts actual `queryFn` calls, not invalidation bookkeeping.

RED before the fix:

```
PASS (5) FAIL (4)
1. does not refetch the listing while note updates keep arriving
   expected "vi.fn()" to be called 1 times, but got 6 times
2. refetches the listing exactly once after the update burst ends
   expected "vi.fn()" to be called 2 times, but got 4 times
3. does not refetch again for updates a structural event already covered
   expected "vi.fn()" to be called 2 times, but got 3 times
4. drops a pending update refetch and unsubscribes on unmount
   expected "vi.fn()" to be called 1 times, but got 2 times
```

GREEN after: `PASS (9) FAIL (0)`.

### Mutation verification

Every line of the fix was reverted individually and re-run:

| Mutant | Result |
| --- | --- |
| `onNoteUpdated(invalidateAfterUpdateBurst)` → `onNoteUpdated(invalidate)` (the whole fix) | **killed** — 4 tests red |
| drop the supersede `clearTimeout` in `invalidate` | **killed** — 1 test red (3 refetches, expected 2) |
| drop the burst-reset `clearTimeout` in `invalidateAfterUpdateBurst` | **killed** — 2 tests red |
| drop the cleanup `clearTimeout` in the effect teardown | **survived on first attempt**, then killed after rewriting the test |

The last one is worth calling out. After unmount the listing query is inactive, so a late timer produces an invalidation but *no* refetch — it was invisible to a pure refetch count. The test now also asserts `invalidateQueries` is never called after unmount, which kills it.

## Verification

```
pnpm typecheck            16 successful, 16 total
pnpm lint                 15 problems (0 errors, 15 warnings) — all pre-existing, none in the changed files
                          eslint --no-cache on the two changed files: 0 problems
                          (the .test.tsx is ignored by the flat config)
git diff --check          clean
vitest --project renderer (full suite)
                          PASS (6317) FAIL (0) skipped (6)
react-doctor              run twice; zero findings for use-folder-view-events.ts in either run
pnpm docs:impact --base origin/main --strict
                          docs impact: covered against origin/main
pnpm docs:build           build complete in 13.35s
```

## Risk & backward compatibility

No IPC contract, DB schema, vault file format, or settings shape is touched — this is renderer-side query-cache scheduling in a single hook. Nothing is persisted, so there is nothing for an older or newer install to misread, and no migration is involved.

Failure mode if the trade-off is wrong: with a folder view in a split pane beside the note being edited, its Modified / word-count / emoji / title cells lag up to 3s behind. No row can go missing or linger, because membership changes are all on the immediate path. No cache or memo is added and no negative result is cached, so an empty folder that gains a note still updates on the `created` event.

## Relationship to #1137

No file overlap. #1137 (`use-tab-actions-stable-identity`, issue #1019) touches `contexts/tabs/context.tsx` and its test; this touches `hooks/use-folder-view-events.ts` and adds a test beside it. Both reduce App-root-driven work, from opposite ends — #1137 stops tab-state changes re-rendering action-only consumers, this stops note-save events refetching folder listings — and neither depends on or contradicts the other. Derived from current `origin/main`.

## Out of scope, not fixed

- `notes:external-change` (`NotesChannels.events.EXTERNAL_CHANGE`, `contracts/src/notes-channels.ts:133`) has **no emitter anywhere in main**. `onNoteExternalChange` is a dead subscription; the watcher uses `CREATED`/`UPDATED`/`DELETED` with `source: 'external'` instead. Left wired and immediate, so behaviour is unchanged either way.
- Issues #1054 / #1055 / #1056 (DragProvider `dragover`, task workspace recompute, tab persistence serialization) were not swept up.

Closes #1053
