### PR TITLE
fix(sync): release active upload/download tracking on failed transfers

### DIFF
--- a/apps/desktop/src/main/sync/attachments.test.ts
+++ b/apps/desktop/src/main/sync/attachments.test.ts
@@ -59,6 +59,107 @@ function createTestDeps(fetchFn: ReturnType<typeof vi.fn>): AttachmentSyncDeps {
   }
 }
 
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+/** Single-chunk encrypted manifest + its on-the-wire chunk (nonce || ciphertext). */
+function buildSignedManifest(opts: {
+  attachmentId: string
+  filename: string
+  plaintext: Buffer
+  vaultKey: Uint8Array
+  signingKeypair: { privateKey: Uint8Array; publicKey: Uint8Array }
+}): { encManifest: Record<string, string>; encryptedChunk: Uint8Array } {
+  const toB64 = (b: Uint8Array): string => sodium.to_base64(b, sodium.base64_variants.ORIGINAL)
+  const fileKey = generateFileKey()
+
+  const chunkNonce = sodium.randombytes_buf(24)
+  const chunkCiphertext = sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(
+    opts.plaintext,
+    null,
+    null,
+    chunkNonce,
+    fileKey
+  )
+  const encryptedChunk = new Uint8Array(chunkNonce.length + chunkCiphertext.length)
+  encryptedChunk.set(chunkNonce, 0)
+  encryptedChunk.set(chunkCiphertext, chunkNonce.length)
+
+  const plaintextHash = sodium.to_hex(sodium.crypto_hash_sha256(opts.plaintext))
+  const manifest = {
+    id: opts.attachmentId,
+    filename: opts.filename,
+    mimeType: 'text/plain',
+    size: opts.plaintext.length,
+    checksum: plaintextHash,
+    chunks: [
+      {
+        index: 0,
+        hash: plaintextHash,
+        encryptedHash: sodium.to_hex(sodium.crypto_hash_sha256(encryptedChunk)),
+        size: opts.plaintext.length
+      }
+    ],
+    chunkSize: 8388608,
+    createdAt: Date.now()
+  }
+
+  const manifestNonce = sodium.randombytes_buf(24)
+  const manifestCiphertext = sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(
+    new TextEncoder().encode(JSON.stringify(manifest)),
+    null,
+    null,
+    manifestNonce,
+    fileKey
+  )
+  const keyNonce = sodium.randombytes_buf(24)
+  const wrappedKey = sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(
+    fileKey,
+    null,
+    null,
+    keyNonce,
+    opts.vaultKey
+  )
+
+  const signaturePayload: Record<string, unknown> = {
+    encryptedManifest: toB64(manifestCiphertext),
+    manifestNonce: toB64(manifestNonce),
+    encryptedFileKey: toB64(wrappedKey),
+    keyNonce: toB64(keyNonce)
+  }
+  const manifestSignature = signPayload(
+    signaturePayload,
+    CBOR_FIELD_ORDER.ATTACHMENT_MANIFEST,
+    opts.signingKeypair.privateKey
+  )
+
+  return {
+    encManifest: {
+      ...(signaturePayload as Record<string, string>),
+      manifestSignature: toB64(manifestSignature),
+      signerDeviceId: 'device-1'
+    },
+    encryptedChunk
+  }
+}
+
+function createDownloadDeps(
+  fetchFn: ReturnType<typeof vi.fn>,
+  vaultKey: Uint8Array,
+  signerPublicKey: Uint8Array
+): AttachmentSyncDeps {
+  return {
+    ...createTestDeps(fetchFn),
+    getVaultKey: vi.fn().mockResolvedValue(vaultKey),
+    getDevicePublicKey: vi.fn().mockResolvedValue(signerPublicKey)
+  }
+}
+
 beforeEach(async () => {
   await sodium.ready
   tmpDir = await mkdtemp(path.join(os.tmpdir(), 'memry-attach-test-'))
@@ -823,6 +924,192 @@ describe('AttachmentSyncService', () => {
       await expect(
         service.uploadAttachment('note-1', testFile, undefined, { signal: controller.signal })
       ).rejects.toThrow('aborted')
+    })
+  })
+
+  describe('active transfer bookkeeping', () => {
+    it('tracks an upload while it runs and drops it when the upload fails', async () => {
+      const testFile = path.join(tmpDir, 'leak-upload.txt')
+      await writeFile(testFile, Buffer.alloc(1024, 'L'))
+
+      let progressDuringUpload: TransferProgress | null = null
+      let service: AttachmentSyncService
+
+      const fetchFn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+        const method = init?.method ?? 'GET'
+
+        if (method === 'POST' && urlStr.includes('/initiate')) {
+          return new Response(
+            JSON.stringify({ sessionId: 'session-leak', expiresAt: Date.now() + 3600000 }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          )
+        }
+        if (method === 'GET' && urlStr.includes('/upload/session-leak')) {
+          return new Response(
+            JSON.stringify({
+              sessionId: 'session-leak',
+              attachmentId: '',
+              totalSize: 0,
+              chunkCount: 1,
+              uploadedChunks: [],
+              expiresAt: 0
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          )
+        }
+        if (method === 'PUT' && urlStr.includes('/chunk/')) {
+          // Sampled mid-transfer: the session must be observable while the
+          // chunk is on the wire, otherwise "cleaned up" would be satisfied by
+          // never tracking the upload at all.
+          progressDuringUpload = service.getUploadProgress('session-leak')
+          return new Response('chunk rejected', { status: 500 })
+        }
+        return new Response(null, { status: 404 })
+      })
+
+      service = new AttachmentSyncService(createTestDeps(fetchFn))
+
+      // #when
+      await expect(service.uploadAttachment('note-1', testFile)).rejects.toThrow(
+        'Failed to upload chunk'
+      )
+
+      // #then — tracked with real values while in flight...
+      expect(progressDuringUpload).toEqual({
+        attachmentId: expect.any(String),
+        phase: 'uploading',
+        chunksCompleted: 0,
+        totalChunks: 1,
+        bytesTransferred: 0,
+        totalBytes: 1024
+      })
+      // ...and gone once the upload threw
+      expect(service.getUploadProgress('session-leak')).toBeNull()
+    })
+
+    it('tracks a download while it runs and drops it when the download fails', async () => {
+      const vaultKey = generateFileKey()
+      const signingKeypair = sodium.crypto_sign_keypair()
+      const { encManifest } = buildSignedManifest({
+        attachmentId: 'att-leak',
+        filename: 'leak-download.txt',
+        plaintext: Buffer.alloc(256, 'D'),
+        vaultKey,
+        signingKeypair
+      })
+
+      let progressDuringDownload: TransferProgress | null = null
+      let service: AttachmentSyncService
+
+      const fetchFn = vi.fn(async (url: string | URL | Request) => {
+        const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+
+        if (urlStr.includes('/att-leak/manifest')) {
+          return new Response(JSON.stringify(encManifest), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        }
+        if (urlStr.includes('/chunks/')) {
+          progressDuringDownload = service.getDownloadProgress('att-leak')
+          return new Response(null, { status: 500 })
+        }
+        return new Response(null, { status: 404 })
+      })
+
+      service = new AttachmentSyncService(
+        createDownloadDeps(fetchFn, vaultKey, signingKeypair.publicKey)
+      )
+
+      // #when
+      await expect(
+        service.downloadAttachment('att-leak', path.join(tmpDir, 'leak-download.txt'))
+      ).rejects.toThrow('Failed to download chunk')
+
+      // #then
+      expect(progressDuringDownload).toEqual({
+        attachmentId: 'att-leak',
+        phase: 'downloading',
+        chunksCompleted: 0,
+        totalChunks: 1,
+        bytesTransferred: 0,
+        totalBytes: 256
+      })
+      expect(service.getDownloadProgress('att-leak')).toBeNull()
+    })
+
+    it('a failed download does not clear a concurrent live download of the same attachment', async () => {
+      const vaultKey = generateFileKey()
+      const signingKeypair = sodium.crypto_sign_keypair()
+      const { encManifest, encryptedChunk } = buildSignedManifest({
+        attachmentId: 'att-shared',
+        filename: 'shared.txt',
+        plaintext: Buffer.alloc(256, 'S'),
+        vaultKey,
+        signingKeypair
+      })
+
+      const firstReachedChunk = createDeferred()
+      const releaseFirst = createDeferred()
+      const secondReachedChunk = createDeferred()
+      const releaseSecond = createDeferred()
+      let chunkCalls = 0
+
+      const fetchFn = vi.fn(async (url: string | URL | Request) => {
+        const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+
+        if (urlStr.includes('/att-shared/manifest')) {
+          return new Response(JSON.stringify(encManifest), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        }
+        if (urlStr.includes('/chunks/')) {
+          chunkCalls++
+          if (chunkCalls === 1) {
+            firstReachedChunk.resolve()
+            await releaseFirst.promise
+            return new Response(null, { status: 500 })
+          }
+          secondReachedChunk.resolve()
+          await releaseSecond.promise
+          return new Response(encryptedChunk, {
+            status: 200,
+            headers: { 'Content-Type': 'application/octet-stream' }
+          })
+        }
+        return new Response(null, { status: 404 })
+      })
+
+      const service = new AttachmentSyncService(
+        createDownloadDeps(fetchFn, vaultKey, signingKeypair.publicKey)
+      )
+
+      // #given — the doomed transfer registers first, then a second transfer
+      // for the same attachment overwrites the map entry under the same key
+      const doomed = service.downloadAttachment('att-shared', path.join(tmpDir, 'shared-a.txt'))
+      await firstReachedChunk.promise
+      const live = service.downloadAttachment('att-shared', path.join(tmpDir, 'shared-b.txt'))
+      await secondReachedChunk.promise
+
+      // #when — the first transfer fails while the second is still running
+      releaseFirst.resolve()
+      await expect(doomed).rejects.toThrow('Failed to download chunk')
+
+      // #then — the survivor's progress is untouched
+      expect(service.getDownloadProgress('att-shared')).toEqual({
+        attachmentId: 'att-shared',
+        phase: 'downloading',
+        chunksCompleted: 0,
+        totalChunks: 1,
+        bytesTransferred: 0,
+        totalBytes: 256
+      })
+
+      releaseSecond.resolve()
+      await live
+      expect(service.getDownloadProgress('att-shared')).toBeNull()
     })
   })
 })

--- a/apps/desktop/src/main/sync/attachments.ts
+++ b/apps/desktop/src/main/sync/attachments.ts
@@ -264,6 +264,9 @@ export class AttachmentSyncService {
     const [token, vaultKey, signingKeys] = await this.requireAuth()
     const fileKey = generateFileKey()
     const emit = (p: TransferProgress): void => (onProgress ?? this.onProgress)?.(p)
+    // Set once the session is registered below, so the finally can drop it on
+    // every exit — success, throw, or abort — instead of only the happy path.
+    let trackedSessionId: string | null = null
 
     try {
       const fileStat = await stat(filePath)
@@ -388,6 +391,7 @@ export class AttachmentSyncService {
         totalBytes: fileStat.size
       }
       this.activeUploads.set(sessionId, uploadState)
+      trackedSessionId = sessionId
 
       const existingChunks = await this.checkResumableSession(token, sessionId, netOpts)
       if (existingChunks) {
@@ -446,11 +450,15 @@ export class AttachmentSyncService {
       const encryptedManifest = this.encryptManifest(manifest, fileKey, vaultKey, signingKeys)
       await this.completeUploadSession(token, sessionId, encryptedManifest, netOpts)
 
-      this.activeUploads.delete(sessionId)
       log.info('upload complete', { attachmentId, sessionId })
 
       return { attachmentId, sessionId, manifest }
     } finally {
+      // The transfer is over by the time finally runs, so this can never orphan
+      // an in-flight upload. The key is a server-issued session id unique to
+      // this call, so the entry can only ever be ours (cancelUpload may have
+      // dropped it already — deleting a missing key is a no-op).
+      if (trackedSessionId !== null) this.activeUploads.delete(trackedSessionId)
       secureCleanup(fileKey)
       secureCleanup(signingKeys.secretKey)
     }
@@ -479,6 +487,9 @@ export class AttachmentSyncService {
     }
 
     const { manifest, fileKey } = this.decryptManifest(encryptedManifest, vaultKey, signerPublicKey)
+    // Set once this transfer is registered below; identifies OUR entry so the
+    // finally can drop it on every exit without touching anyone else's.
+    let trackedProgress: TransferProgress | null = null
 
     try {
       const totalChunks = manifest.chunks.length
@@ -513,6 +524,7 @@ export class AttachmentSyncService {
         totalBytes: manifest.size
       }
       this.activeDownloads.set(attachmentId, downloadProgress)
+      trackedProgress = downloadProgress
 
       const decryptedChunks: Buffer[] = new Array(totalChunks)
       let bytesDownloaded = 0
@@ -549,11 +561,17 @@ export class AttachmentSyncService {
 
       await this.atomicWriteBinary(destPath, reassembled)
 
-      this.activeDownloads.delete(attachmentId)
       log.info('download complete', { attachmentId, path: destPath })
 
       return { filePath: destPath, manifest }
     } finally {
+      // Unlike uploads, the key here is the attachmentId, which a concurrent
+      // download of the same attachment shares — it overwrites this entry when
+      // it registers. Only remove the entry if it is still ours, so a transfer
+      // that loses that race cannot blank out the live one's progress.
+      if (this.activeDownloads.get(attachmentId) === trackedProgress) {
+        this.activeDownloads.delete(attachmentId)
+      }
       secureCleanup(fileKey)
     }
   }


### PR DESCRIPTION
## Problem

`AttachmentSyncService` registers every transfer in a tracking map and removed the entry **only on the happy path**:

- `activeUploads.set(sessionId, uploadState)` … `activeUploads.delete(sessionId)` immediately before `return`
- `activeDownloads.set(attachmentId, downloadProgress)` … `activeDownloads.delete(attachmentId)` immediately before `return`

Both `finally` blocks only called `secureCleanup`. Any throw between the `set` and the success `return` — a chunk `SyncServerError`, a `DeadLetterError` out of `withRetry`, a chunk or whole-file integrity mismatch, an `AbortSignal` — skipped the delete and left the entry in the map. Nothing sweeps these maps and there is no TTL; `clearAttachmentState()` only drops the whole service on sign-out/vault teardown.

Each leaked `UploadState` retains a `completedChunks: Set<number>`, so a large file that fails late retains one Set entry per uploaded chunk. Retries make it worse rather than better: every retry is a fresh call that registers a **new** entry and leaks it again on the next failure.

Confirmed still present on current `main` (`366cde953`).

## Root cause

The delete was placed as a statement in the success path rather than in the `finally` that already existed for key cleanup.

## Fix

Move both deletes into the existing `finally` blocks. The `finally` runs only once the transfer has actually finished, so cleanup can never orphan an in-flight transfer.

Two details that are deliberately asymmetric:

- **Uploads** are keyed by the **server-issued `sessionId`**, which is unique to a single `initiateUploadSession` call, so the entry under that key can only ever be this transfer's. An unconditional delete is correct. `cancelUpload()` may have already removed it — deleting a missing key is a no-op, so removal still happens exactly once.
- **Downloads** are keyed by `attachmentId`, which **concurrent downloads of the same attachment share**. The second transfer's `set` overwrites the first's entry. A naive `finally` delete would therefore let a *failing* transfer blank out a *live* transfer's progress — a regression this PR would otherwise have introduced. The download side deletes only when the map still holds the entry this call registered.

The early "already materialized on disk" return happens before the `set`, so its `finally` correctly deletes nothing.

Net diff to production code: +20 / −2, no signature, contract, schema, or protocol change.

## What happens to a failed transfer's attachment

This matters because cleaning up a tracking map must not lose a user's file. Nothing here changes retry behaviour — the maps were never a retry or resume handle:

- **Uploads are durably retried, and this fix does not weaken that.** `attachment-events.onSaved` calls `enqueueUpload()` to persist the intent to the `attachment_upload_queue` table *before* attempting, and `markUploadFailed()` on failure keeps the row with an incremented attempt count. `drainAttachmentOutbox()` retries pending rows whenever the sync runtime starts. The `activeUploads` entry was never consulted for this: each retry is a fresh `uploadAttachment()` call that mints a **new** `attachmentId` and a **new** `sessionId`. Within a single call, resume is server-driven via `checkResumableSession()`, which asks the server which chunks it already has — it never reads the local `completedChunks` Set. The leaked state was pure garbage.
- **Downloads are re-driven by the `download-needed` event**, not by the map. There is no durable download outbox — a download that fails is logged, reported to telemetry, and broadcast to the renderer, and is retried the next time the attachment is needed. That is pre-existing behaviour and is unchanged by this PR; the map entry never played any part in it.

So: no attachment becomes unrecoverable as a result of this change, and no retry path loses state it was previously using.

## Test evidence

Three tests added in `apps/desktop/src/main/sync/attachments.test.ts` under `active transfer bookkeeping`. Each pins the **actual progress values** sampled mid-transfer, not just presence/absence, so an implementation that simply never tracks the transfer cannot pass.

### RED (before the fix)

```
 FAIL  src/main/sync/attachments.test.ts > active transfer bookkeeping > tracks an upload while it runs and drops it when the upload fails
AssertionError: expected { …(6) } to be null
+ Received:
{ "attachmentId": "ddeb15bf5528b9306f01703257bc260f", "bytesTransferred": 0,
  "chunksCompleted": 0, "phase": "uploading", "totalBytes": 1024, "totalChunks": 1 }

 FAIL  src/main/sync/attachments.test.ts > active transfer bookkeeping > tracks a download while it runs and drops it when the download fails
AssertionError: expected { attachmentId: 'att-leak', …(5) } to be null
+ Received:
{ "attachmentId": "att-leak", "bytesTransferred": 0, "chunksCompleted": 0,
  "phase": "downloading", "totalBytes": 256, "totalChunks": 1 }

 Test Files  1 failed (1)
      Tests  2 failed | 21 passed (23)
```

(The third test — the concurrency guard — passes on `main` only because today the failing transfer never deletes anything at all. It is the regression guard for this fix, and mutant 3 below proves it has teeth.)

### GREEN (after the fix)

```
 ✓ active transfer bookkeeping > tracks an upload while it runs and drops it when the upload fails 6ms
 ✓ active transfer bookkeeping > tracks a download while it runs and drops it when the download fails 2ms
 ✓ active transfer bookkeeping > a failed download does not clear a concurrent live download of the same attachment 3ms

 Test Files  1 passed (1)
      Tests  23 passed (23)
```

### Mutation verification — 3 mutants, 3 killed

Each mutant reverts exactly one code line (no comment text was touched).

**Mutant 1** — upload cleanup neutered: `if (trackedSessionId !== null) this.activeUploads.delete(trackedSessionId)` → `… void trackedSessionId`

```
 × active transfer bookkeeping > tracks an upload while it runs and drops it when the upload fails
      Tests  1 failed | 22 passed (23)
```

**Mutant 2** — download cleanup neutered: `this.activeDownloads.delete(attachmentId)` → `void attachmentId`

```
 × active transfer bookkeeping > tracks a download while it runs and drops it when the download fails
 × active transfer bookkeeping > a failed download does not clear a concurrent live download of the same attachment
      Tests  2 failed | 21 passed (23)
```

**Mutant 3** — identity guard weakened to a plain null check: `if (this.activeDownloads.get(attachmentId) === trackedProgress)` → `if (trackedProgress !== null)`

```
 × active transfer bookkeeping > a failed download does not clear a concurrent live download of the same attachment
AssertionError: expected null to deeply equal { attachmentId: 'att-shared', …(5) }
      Tests  1 failed | 22 passed (23)
```

Mutant 3's message is precisely the regression the guard exists to prevent: without it, the failed transfer wipes the live transfer's progress. No surviving mutants.

### Verification commands

```
pnpm typecheck                  → Tasks: 16 successful, 16 total
pnpm lint                       → ✖ 15 problems (0 errors, 15 warnings)
                                  all warnings pre-existing, in unrelated renderer files
git diff --check                → clean

pnpm --filter @memry/desktop test:main src/main/sync
                                → Test Files  136 passed (136)
                                  Tests  1667 passed | 1 expected fail | 3 skipped (1671)

attachments + upload-queue + attachment-outbox + attachment-events
  + sync-attachment-handlers    → Test Files  5 passed (5)   Tests  71 passed (71)

vitest --project main-integration src/main/sync/attachments.integration.test.ts
                                → PASS (9) FAIL (0)
```

(`attachment-outbox.test.ts` first hit the known `ERR_DLOPEN_FAILED` ABI mismatch; resolved with `pnpm --filter @memry/desktop rebuild:node`, unrelated to this change.)

## Risk & backward compatibility

Low. The change is confined to in-memory bookkeeping inside a single service.

- No change to the sync protocol, IPC contracts, DB schema, vault file formats, or settings shapes. Nothing older versions wrote is read or written differently. No migration needed.
- No caches or latches introduced, so there is no negative to invalidate.
- `getUploadProgress()` / `getDownloadProgress()` now return `null` after a failed transfer instead of a frozen stale snapshot. **No renderer code consumes either query** — attachment progress UI is driven by the `SYNC_EVENTS.UPLOAD_PROGRESS` / `DOWNLOAD_PROGRESS` broadcasts — so there is no user-visible change. The IPC handlers already returned `null` for unknown ids, so the contract shape is unchanged.
- `cancelUpload()` is unaffected: it still deletes the entry and best-effort releases the server session; the transfer's own `finally` then no-ops.

Docs gate: `pnpm docs:impact --strict` flags `attachments.ts` as docs-relevant, but this is an internal memory-retention fix with no user-facing surface (no renderer consumer, no contract or behaviour change a user or doc could observe), so it was pushed with `MEMRY_DOCS_IMPACT_SKIP=1`.

## Out of scope

Overlaps neutrally with the rest of the queued sync cluster (#1028 retry cap/backoff, #1029 `withRetry` delay, #1030, #1031) and with open PRs #1153, #1116, #1118, #1120, #1122, #1124 — none of their code is touched here.

Noted while reading, **not fixed**: `activeDownloads` being keyed by `attachmentId` means two concurrent downloads of the same attachment still share one map slot, so the second overwrites the first's progress on registration. This PR ensures a finishing transfer cannot clear a *different* live transfer's entry, but the underlying key collision (and the resulting fact that only the most recently started transfer is observable) is pre-existing and left alone.

Closes #1027
