### PR TITLE
perf(graph): reuse the physics neighbour grid instead of rebuilding it every tick

### DIFF
--- a/apps/desktop/src/renderer/src/lib/graph-physics.test.ts
+++ b/apps/desktop/src/renderer/src/lib/graph-physics.test.ts
@@ -27,6 +27,76 @@ function settle(physics: GraphPhysics, ticks = 600): void {
   for (let i = 0; i < ticks; i++) physics.tick()
 }
 
+/** Deterministic scatter wide enough that the spatial grid holds many occupied cells. */
+function makeSpreadGraph(count: number): Graph {
+  const graph = new Graph({ multi: true, type: 'undirected' })
+  let seed = 42
+  const next = (): number => {
+    seed = (seed * 48271) % 2147483647
+    return seed / 2147483647
+  }
+  for (let i = 0; i < count; i++) {
+    graph.addNode(`n${i}`, {
+      x: (next() - 0.5) * 2400,
+      y: (next() - 0.5) * 2400,
+      size: 4 + (i % 5)
+    })
+  }
+  for (let i = 1; i < count; i++) {
+    graph.addEdgeWithKey(`e${i}`, `n${i}`, `n${Math.floor(next() * i)}`, { weight: 1 })
+  }
+  return graph
+}
+
+function positions(graph: Graph): Array<[string, number, number]> {
+  const out: Array<[string, number, number]> = []
+  graph.forEachNode((id, attrs) => {
+    out.push([id, attrs.x as number, attrs.y as number])
+  })
+  return out
+}
+
+/** The grid the tick reuses. Private on purpose — only the reuse tests look at it. */
+interface GridInternals {
+  grid: Map<unknown, unknown[]>
+  cellPool: unknown[][]
+}
+
+function internals(physics: GraphPhysics): GridInternals {
+  return physics as unknown as GridInternals
+}
+
+function binnedNodes(physics: GraphPhysics): unknown[] {
+  const out: unknown[] = []
+  for (const cell of internals(physics).grid.values()) out.push(...cell)
+  return out
+}
+
+/**
+ * Positions after 120 ticks of `makeSpreadGraph(16)`, captured from the original
+ * string-keyed grid (`${Math.floor(x / cellSize)},${...}` + a fresh `Map` per
+ * tick). The grid is only an acceleration structure, so swapping how cells are
+ * addressed must not move a single node by a single bit — these are exact.
+ */
+const GOLDEN_SPREAD_16: Array<[string, number, number]> = [
+  ['n0', 13.374592190624796, 85.31019820180218],
+  ['n1', -63.40504478077077, 105.68555806828485],
+  ['n2', -31.089578232049266, 151.71702195809863],
+  ['n3', -122.82749496246768, 101.11862016166009],
+  ['n4', 14.497199600987559, 4.661536423989247],
+  ['n5', 5.471105573919566, -70.11216121173707],
+  ['n6', 78.72092452520624, -57.77896580999497],
+  ['n7', 111.20033541491098, -108.5714484994886],
+  ['n8', 170.36569149718136, -118.50090037424494],
+  ['n9', -3.692196145145418, -126.12050776324871],
+  ['n10', -100.53604670110629, 58.940910955942115],
+  ['n11', -96.17639386828299, 149.9957170597185],
+  ['n12', -46.98210943129166, -97.05925879041261],
+  ['n13', 205.38353279485526, -76.38864009200664],
+  ['n14', 118.03378949328601, -14.243118321828911],
+  ['n15', -22.68429529230571, 50.26736166843403]
+]
+
 describe('GraphPhysics', () => {
   it('writes simulated positions back onto the graphology graph', () => {
     const graph = makeGraph([
@@ -220,5 +290,85 @@ describe('GraphPhysics', () => {
 
     expect(() => physics.tick()).not.toThrow()
     expect(physics.isSettled).toBe(true)
+  })
+
+  describe('spatial grid', () => {
+    it('lands every node exactly where the string-keyed grid left it', () => {
+      const graph = makeSpreadGraph(16)
+      const physics = new GraphPhysics(graph)
+
+      for (let i = 0; i < 120; i++) physics.tick()
+
+      expect(positions(graph)).toEqual(GOLDEN_SPREAD_16)
+    })
+
+    it('reuses one number-keyed grid and one pool of cell arrays across ticks', () => {
+      const physics = new GraphPhysics(makeSpreadGraph(16))
+      physics.tick()
+      const { grid, cellPool } = internals(physics)
+
+      expect(grid).toBeInstanceOf(Map)
+      expect(grid.size).toBeGreaterThan(1)
+      expect([...new Set([...grid.keys()].map((key) => typeof key))]).toEqual(['number'])
+      const firstCell = cellPool[0]
+
+      physics.tick()
+
+      expect(internals(physics).grid).toBe(grid)
+      expect(internals(physics).cellPool).toBe(cellPool)
+      expect(internals(physics).cellPool[0]).toBe(firstCell)
+      expect([...grid.values()]).toContain(firstCell)
+    })
+
+    it('rebins every node exactly once a tick, with nothing left over from the last one', () => {
+      const physics = new GraphPhysics(makeSpreadGraph(16))
+
+      for (let i = 0; i < 5; i++) {
+        physics.tick()
+        expect(binnedNodes(physics)).toHaveLength(16)
+        expect(new Set(binnedNodes(physics)).size).toBe(16)
+      }
+
+      // A drag of several cells: the node's old cell must not still be holding it.
+      physics.grab('n0')
+      physics.dragTo('n0', 9000, -9000)
+      physics.tick()
+
+      expect(binnedNodes(physics)).toHaveLength(16)
+      expect(new Set(binnedNodes(physics)).size).toBe(16)
+    })
+
+    it('runs two simulations side by side without either disturbing the other', () => {
+      const aloneA = makeSpreadGraph(16)
+      const aloneB = makeSpreadGraph(9)
+      const physicsAloneA = new GraphPhysics(aloneA)
+      for (let i = 0; i < 60; i++) physicsAloneA.tick()
+      const physicsAloneB = new GraphPhysics(aloneB)
+      for (let i = 0; i < 60; i++) physicsAloneB.tick()
+
+      const togetherA = makeSpreadGraph(16)
+      const togetherB = makeSpreadGraph(9)
+      const physicsA = new GraphPhysics(togetherA)
+      const physicsB = new GraphPhysics(togetherB)
+      for (let i = 0; i < 60; i++) {
+        physicsA.tick()
+        physicsB.tick()
+      }
+
+      expect(positions(togetherA)).toEqual(positions(aloneA))
+      expect(positions(togetherB)).toEqual(positions(aloneB))
+    })
+
+    it('lets go of the grid on destroy', () => {
+      const physics = new GraphPhysics(makeSpreadGraph(16))
+      physics.tick()
+      expect(internals(physics).grid.size).toBeGreaterThan(0)
+      expect(internals(physics).cellPool.length).toBeGreaterThan(0)
+
+      physics.destroy()
+
+      expect(internals(physics).grid.size).toBe(0)
+      expect(internals(physics).cellPool).toHaveLength(0)
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/lib/graph-physics.ts
+++ b/apps/desktop/src/renderer/src/lib/graph-physics.ts
@@ -58,6 +58,23 @@ const REPULSION_CUTOFF_FACTOR = 6
 const COLLIDE_ITERATIONS = 1
 
 /**
+ * Grid cells are addressed by one number, so a tick never builds a key string.
+ * `(cellX + OFFSET) * STRIDE + (cellY + OFFSET)` stays exact in a double well
+ * past any coordinate a layout reaches, and two cells can only share a key when
+ * they sit a whole `STRIDE` of rows apart: `key(x, y) === key(x', y')` forces
+ * `y' - y === (x - x') * STRIDE`. Cells inside one 3x3 neighbourhood are at most
+ * two rows apart, so they can never collide — no pair is visited twice or missed
+ * — and anything that does share a bucket is millions of cells away, far outside
+ * the distance cutoff both sweeps already apply.
+ */
+const CELL_KEY_OFFSET = 1 << 20
+const CELL_KEY_STRIDE = 1 << 21
+
+function cellKey(cellX: number, cellY: number): number {
+  return (cellX + CELL_KEY_OFFSET) * CELL_KEY_STRIDE + (cellY + CELL_KEY_OFFSET)
+}
+
+/**
  * A continuously-running force simulation bound to a graphology graph.
  *
  * Unlike a one-shot layout, this never "finishes" on its own terms: it cools
@@ -75,6 +92,14 @@ export class GraphPhysics {
   private readonly nodesById = new Map<string, PhysicsNode>()
   private readonly links: PhysicsLink[] = []
   private readonly cutoff: number
+  /**
+   * Neighbour grid, kept alive between ticks so the hot loop allocates nothing.
+   * `buildGrid` is the only writer and resets both halves before it bins a
+   * single node. Instance state, never module state: the main graph and the
+   * local-graph panel each run their own simulation at the same time.
+   */
+  private readonly grid = new Map<number, PhysicsNode[]>()
+  private readonly cellPool: PhysicsNode[][] = []
   private alphaValue = 1
   private alphaTarget = 0
   private destroyed = false
@@ -179,6 +204,40 @@ export class GraphPhysics {
     this.nodes.length = 0
     this.links.length = 0
     this.nodesById.clear()
+    this.grid.clear()
+    this.cellPool.length = 0
+  }
+
+  /**
+   * Bin every node into a uniform grid of `cellSize`.
+   *
+   * The map and the cell arrays outlive the tick, so this is where they are
+   * reset and the only place they are: the map is emptied up front, and the
+   * pool cursor rewinds to zero so each array is truncated the moment it is
+   * handed out again. Nothing from the previous pass can survive into this one.
+   */
+  private buildGrid(cellSize: number): void {
+    this.grid.clear()
+    let pooled = 0
+
+    for (const node of this.nodes) {
+      const key = cellKey(Math.floor(node.x / cellSize), Math.floor(node.y / cellSize))
+      const occupied = this.grid.get(key)
+      if (occupied) {
+        occupied.push(node)
+        continue
+      }
+
+      let cell = this.cellPool[pooled]
+      if (cell) cell.length = 0
+      else {
+        cell = []
+        this.cellPool[pooled] = cell
+      }
+      pooled++
+      cell.push(node)
+      this.grid.set(key, cell)
+    }
   }
 
   /** Springs pulling each linked pair toward `linkDistance`. */
@@ -208,14 +267,7 @@ export class GraphPhysics {
     const { chargeStrength } = this.settings
     const cutoff = this.cutoff
     const cutoffSquared = cutoff * cutoff
-    const grid = new Map<string, PhysicsNode[]>()
-
-    for (const node of this.nodes) {
-      const key = `${Math.floor(node.x / cutoff)},${Math.floor(node.y / cutoff)}`
-      const cell = grid.get(key)
-      if (cell) cell.push(node)
-      else grid.set(key, [node])
-    }
+    this.buildGrid(cutoff)
 
     for (const node of this.nodes) {
       const cellX = Math.floor(node.x / cutoff)
@@ -223,7 +275,7 @@ export class GraphPhysics {
 
       for (let ox = -1; ox <= 1; ox++) {
         for (let oy = -1; oy <= 1; oy++) {
-          const cell = grid.get(`${cellX + ox},${cellY + oy}`)
+          const cell = this.grid.get(cellKey(cellX + ox, cellY + oy))
           if (!cell) continue
 
           for (const other of cell) {
@@ -281,17 +333,10 @@ export class GraphPhysics {
 
   /** Position-based separation so node discs never overlap — the "cell" packing. */
   private applyCollision(): void {
-    const grid = new Map<string, PhysicsNode[]>()
     let maxRadius = 0
     for (const node of this.nodes) maxRadius = Math.max(maxRadius, node.radius)
     const cellSize = Math.max(maxRadius * 2, 1)
-
-    for (const node of this.nodes) {
-      const key = `${Math.floor(node.x / cellSize)},${Math.floor(node.y / cellSize)}`
-      const cell = grid.get(key)
-      if (cell) cell.push(node)
-      else grid.set(key, [node])
-    }
+    this.buildGrid(cellSize)
 
     for (const node of this.nodes) {
       const cellX = Math.floor(node.x / cellSize)
@@ -299,7 +344,7 @@ export class GraphPhysics {
 
       for (let ox = -1; ox <= 1; ox++) {
         for (let oy = -1; oy <= 1; oy++) {
-          const cell = grid.get(`${cellX + ox},${cellY + oy}`)
+          const cell = this.grid.get(cellKey(cellX + ox, cellY + oy))
           if (!cell) continue
 
           for (const other of cell) {


### PR DESCRIPTION
## Problem

`GraphPhysics` runs two uniform-grid neighbour sweeps per tick — `applyRepulsion` and
`applyCollision`. Each one built a **fresh `Map`** and gave every node a **template-literal
key** (`` `${cellX},${cellY}` ``), then built **nine more key strings per node** while walking
the 3x3 neighbourhood, plus one new array per occupied cell.

For a 3,000-node vault at 60 fps that is roughly 60k short-lived strings per frame, ~6k
arrays, and 120 `Map` objects per second — the dominant GC pressure while the graph animates.

Confirmed still present on current `origin/main` before implementing.

## Root cause

The grid is a pure *acceleration structure*: both sweeps distance-filter every candidate they
pull out of it, so the grid's only job is to narrow the search. It was nevertheless being
rebuilt from scratch — container, buckets, and keys — on every one of its two calls per tick,
and addressed by strings because that was the cheapest way to key a 2D cell in a `Map`.

## Fix

One instance-owned `Map<number, PhysicsNode[]>` plus a pool of cell arrays, both reused
across ticks and shared by the two sweeps (they run strictly one after the other).

Cells are addressed by a packed number:

```ts
const CELL_KEY_OFFSET = 1 << 20
const CELL_KEY_STRIDE = 1 << 21
cellKey(cellX, cellY) = (cellX + CELL_KEY_OFFSET) * CELL_KEY_STRIDE + (cellY + CELL_KEY_OFFSET)
```

I did **not** take the hash suggested in the issue (`cellX * 73856093 ^ cellY * 19349663`).
A hash can collide, and two colliding cells inside the same 3x3 block would double-apply a
force pair — a silent physics corruption. The linear pack is collision-*proof where it
matters*: `key(x, y) === key(x', y')` forces `y' - y === (x - x') * STRIDE`, so aliasing
cells are at least 2^21 rows apart. Cells in one 3x3 neighbourhood are at most two rows
apart, so **they can never share a key** — no pair is ever visited twice or missed.

### Numerical identity

The physics output is **bit-identical**, and that is asserted, not asserted-about. Before
touching the implementation I captured the exact final coordinates of a deterministic
16-node graph after 120 ticks (a run that visits 20 distinct grid cells) from the *old*
string-keyed code, and pinned all 32 doubles as `GOLDEN_SPREAD_16` in the test file. The
test compares with `toEqual` — exact equality, not `toBeCloseTo`. It passed before the
change and passes after.

It stays identical because the change preserves every ordering the accumulation depends on:

- outer node order — untouched (`this.nodes`)
- neighbour visit order — same `ox` then `oy` loops, same nine cells
- within-cell order — buckets are still filled in `this.nodes` order
- cell membership — unchanged, because the packed key is injective across any 3x3

### Where each reused structure is reset

Both live on the instance and both are reset in exactly one place, `buildGrid`, before it
bins a single node:

| Structure | Reset | When |
|---|---|---|
| `this.grid` | `this.grid.clear()` (first statement of `buildGrid`) | every `buildGrid` call — twice per tick |
| `this.cellPool` | `pooled` cursor rewinds to `0`; every array is truncated with `cell.length = 0` the moment it is handed out again | every `buildGrid` call |
| both | `this.grid.clear()` + `this.cellPool.length = 0` | `destroy()`, so an unmounted panel stops pinning node objects |

Nothing from a previous pass can survive into the next: the map is emptied up front, and a
pooled array is only ever reachable again through a `set` that follows its truncation.

### Two graph instances at once

`grid` and `cellPool` are **instance fields, not module state** — deliberately, because the
main graph and `LocalGraphPanel` each construct their own `GraphPhysics` and tick on
independent animation frames. Test `runs two simulations side by side without either
disturbing the other` runs a 16-node and a 9-node graph solo, then reruns both interleaved
tick-for-tick, and requires the interleaved positions to equal the solo positions exactly.
Hoisting either structure to module scope fails it.

Node added/removed mid-simulation, graph replaced, and unmount/remount are all unchanged:
`GraphPhysics` snapshots nodes at construction and `physics-layout.tsx` builds a new
instance when `graph` changes, so a reused grid never outlives the node set it was built
from. `syncPositions` still guards on `graph.hasNode`.

## Test evidence

Six tests, five new, in `graph-physics.test.ts`.

**RED** (before the fix, 19 tests):

```
 × spatial grid > reuses one number-keyed grid and one pool of cell arrays across ticks
   → expected undefined to be an instance of Map
 × spatial grid > rebins every node exactly once a tick, with nothing left over from the last one
   → Cannot read properties of undefined (reading 'values')
 × spatial grid > lets go of the grid on destroy
   → Cannot read properties of undefined (reading 'size')
 ✓ spatial grid > lands every node exactly where the string-keyed grid left it   (baseline)
      Tests  3 failed | 16 passed (19)
```

**GREEN** (after the fix):

```
      Tests  19 passed (19)
```

Full graph surface, 7 files:

```
 Test Files  7 passed (7)
      Tests  51 passed (51)
```

### Mutation verification

**Mutant 1 — the pool reset (primary).** `if (cell) cell.length = 0` → `if (cell) cell.length = cell.length`
(code line only; substitution is unique to the statement). **KILLED**, by two tests:

```
 × spatial grid > rebins every node exactly once a tick, with nothing left over from the last one
   → expected [ { id: 'n0', …(8) }, …(31) ] to have a length of 16 but got 32
 × spatial grid > lands every node exactly where the string-keyed grid left it
   → expected [ …(16) ] to deeply equal [ …(16) ]
      Tests  2 failed | 17 passed (19)
```

32 binned nodes instead of 16 — precisely the stale-bucket hazard — and the physics output
diverges from the pinned goldens. Exactly the failure mode this fix has to not have.

**Mutant 2 — `CELL_KEY_STRIDE = 1 << 21` → `1 << 2`. SURVIVED (equivalent mutant).**
With stride 4, aliasing cells are 4 rows apart, still outside every 3x3 block, and any
candidate dragged in from an aliased bucket is ≥ 4 cells away — beyond `cutoffSquared` in
`applyRepulsion` and beyond `minimum` in `applyCollision`, both of which are pre-existing
distance filters I am not removing. So the mutant genuinely computes the same physics; it
is not a gap in the test. Reported rather than papered over. The large stride is kept
because it makes the no-aliasing-in-a-3x3 property hold on its own, without leaning on
those distance filters.

**Mutant 3 — `CELL_KEY_STRIDE = 1 << 21` → `1 << 0`,** which *does* alias inside a 3x3
(e.g. `(0,0)` and `(1,-1)`). **KILLED:**

```
 × spatial grid > lands every node exactly where the string-keyed grid left it
   → expected [ …(16) ] to deeply equal [ …(16) ]
      Tests  1 failed | 18 passed (19)
```

So the golden test does catch a wrong-but-plausible key packing, which is the whole reason
it pins values rather than shapes.

### Other verification

```
pnpm typecheck   → Tasks: 16 successful, 16 total
pnpm lint        → 15 problems (0 errors, 15 warnings) — all pre-existing, none in the changed files
git diff --check → clean
```

`react-doctor` not run: no React render path is touched, only the plain `GraphPhysics` class
and its unit test.

## Risk & backward compatibility

Renderer-only, in-memory layout maths. No DB, no migration, no IPC contract, no vault file
format, no settings shape, no persisted data of any kind — nothing an older or newer app
version can observe. Positions are recomputed from scratch on every mount and are proven
bit-identical, so no user's graph moves.

The one new bound worth naming: the packed key is exact for cell indices within ±2^20. The
collision grid's cell size is at least 6 units (a node radius floors at 3), so that covers
coordinates past ±6e6 — orders of magnitude beyond anything the centering force allows. Past
that, keys may alias, and the pre-existing distance filters still reject the extra
candidates.

Memory: the pool retains at most one array per occupied cell, bounded by node count, and is
released in `destroy()`.

## Notes

- Overlaps the same file region as nothing currently open. #1043 / PR #1157 changes the
  `sigma.refresh` call inside `LivePhysics.step()` in `physics-layout.tsx`; this change is
  confined to `lib/graph-physics.ts` and its test, so the two do not touch. Derived from
  current `origin/main`.
- Out of scope and deliberately untouched: #1045 (`syncPositions` writing `x` and `y` as two
  separate `setNodeAttribute` calls, two `nodeAttributesUpdated` events per node per tick)
  and #1046 (`LocalGraphPanel` recreating Sigma per local-graph refetch).
- Docs gate: `pnpm docs:impact --strict` reports `missing-docs` for
  `apps/desktop/src/renderer/src/lib/graph-physics.ts`. Intentionally skipped — the change
  is an internal allocation optimisation with provably identical output and no user-visible
  surface, so there is nothing truthful to add under `apps/docs/src/**`.

Closes #1044
