### PR TITLE
perf(editor): stop hover dismiss from re-rendering the editor on every scroll

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-link-mention-hover.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-link-mention-hover.test.tsx
@@ -97,6 +97,80 @@ describe('useLinkMentionHover', () => {
     expect(result.current.isVisible).toBe(true)
   })
 
+  it('re-renders nothing when a scroll arrives with no preview open', () => {
+    const { container } = setupMention('https://example.com/quiet')
+    const ref = { current: container }
+    let renders = 0
+    renderHook(() => {
+      renders++
+      return useLinkMentionHover(ref)
+    })
+
+    const baseline = renders
+    // One act() per event so React cannot batch them into a single render.
+    for (let i = 0; i < 5; i++) {
+      act(() => container.dispatchEvent(new Event('scroll', { bubbles: true })))
+    }
+
+    expect(renders).toBe(baseline)
+  })
+
+  it('hides an open preview on scroll, then stops re-rendering', async () => {
+    const { container, favicon } = setupMention('https://example.com/open')
+    const ref = { current: container }
+    let renders = 0
+    const { result } = renderHook(() => {
+      renders++
+      return useLinkMentionHover(ref)
+    })
+
+    act(() => favicon.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+    expect(result.current.isVisible).toBe(true)
+
+    act(() => container.dispatchEvent(new Event('scroll', { bubbles: true })))
+    expect(result.current.isVisible).toBe(false)
+
+    // One more scroll to absorb React's render-phase bailout: right after a real
+    // update it re-renders this component once before it can compare eagerly.
+    act(() => container.dispatchEvent(new Event('scroll', { bubbles: true })))
+    const settled = renders
+
+    for (let i = 0; i < 5; i++) {
+      act(() => container.dispatchEvent(new Event('scroll', { bubbles: true })))
+    }
+
+    expect(renders).toBe(settled)
+    expect(result.current.isVisible).toBe(false)
+  })
+
+  it('cancels an armed preview on scroll so no card pops up over scrolled content', async () => {
+    const { container, favicon } = setupMention('https://example.com/armed')
+    const ref = { current: container }
+    let renders = 0
+    const { result } = renderHook(() => {
+      renders++
+      return useLinkMentionHover(ref)
+    })
+
+    act(() => favicon.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150)
+    })
+
+    const baseline = renders
+    act(() => container.dispatchEvent(new Event('scroll', { bubbles: true })))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(api.inbox.previewLink).not.toHaveBeenCalled()
+    expect(result.current.isVisible).toBe(false)
+    expect(renders).toBe(baseline)
+  })
+
   it('dismisses when the cursor leaves the mention entirely', async () => {
     const { container, link, favicon } = setupMention('https://example.com/c')
     const ref = { current: container }

--- a/apps/desktop/src/renderer/src/hooks/use-link-mention-hover.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-link-mention-hover.ts
@@ -50,9 +50,16 @@ export function useLinkMentionHover(
   }, [])
 
   const dismiss = useCallback(() => {
+    // Timers and the active target are cleared unconditionally: a scroll (or a
+    // mouseout) that lands while a preview is merely *armed* must cancel it, or
+    // the card pops up moments later over content the user has moved past.
     clearTimers()
     activeTargetRef.current = null
-    setState({ url: null, preview: null, position: null, isVisible: false })
+    // Nothing shown means nothing to hide. Handing back `prev` lets React bail
+    // out instead of re-rendering the whole editor tree for an identical state.
+    setState((prev) =>
+      prev.isVisible ? { url: null, preview: null, position: null, isVisible: false } : prev
+    )
   }, [clearTimers])
 
   const computePosition = useCallback((linkEl: Element, url: string): HoverPosition => {

--- a/apps/desktop/src/renderer/src/hooks/use-wiki-link-hover.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-wiki-link-hover.test.tsx
@@ -133,6 +133,85 @@ describe('useWikiLinkHover', () => {
     expect(result.current.isVisible).toBe(true)
   })
 
+  it('re-renders nothing when a scroll arrives with no preview open', () => {
+    const { container } = setupLink()
+    const ref = { current: container }
+    let renders = 0
+    renderHook(() => {
+      renders++
+      return useWikiLinkHover(ref)
+    })
+
+    const baseline = renders
+    // One act() per event so React cannot batch them into a single render.
+    for (let i = 0; i < 5; i++) {
+      act(() => container.dispatchEvent(new Event('scroll', { bubbles: true })))
+    }
+
+    expect(renders).toBe(baseline)
+  })
+
+  it('hides an open preview on scroll, then stops re-rendering', async () => {
+    const { container, link } = setupLink()
+    const ref = { current: container }
+    let renders = 0
+    const { result } = renderHook(() => {
+      renders++
+      return useWikiLinkHover(ref)
+    })
+
+    act(() => link.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+    expect(result.current.isVisible).toBe(true)
+
+    act(() => container.dispatchEvent(new Event('scroll', { bubbles: true })))
+    expect(result.current.isVisible).toBe(false)
+
+    // One more scroll to absorb React's render-phase bailout: right after a real
+    // update it re-renders this component once before it can compare eagerly.
+    act(() => container.dispatchEvent(new Event('scroll', { bubbles: true })))
+    const settled = renders
+
+    for (let i = 0; i < 5; i++) {
+      act(() => container.dispatchEvent(new Event('scroll', { bubbles: true })))
+    }
+
+    expect(renders).toBe(settled)
+    expect(result.current.isVisible).toBe(false)
+  })
+
+  it('cancels an armed preview on scroll so no card pops up over scrolled content', async () => {
+    const api = getMockApi() as {
+      notes: {
+        previewByTitle: ReturnType<typeof vi.fn>
+      }
+    }
+    const { container, link } = setupLink()
+    const ref = { current: container }
+    let renders = 0
+    const { result } = renderHook(() => {
+      renders++
+      return useWikiLinkHover(ref)
+    })
+
+    act(() => link.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150)
+    })
+
+    const baseline = renders
+    act(() => container.dispatchEvent(new Event('scroll', { bubbles: true })))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(api.notes.previewByTitle).not.toHaveBeenCalled()
+    expect(result.current.isVisible).toBe(false)
+    expect(renders).toBe(baseline)
+  })
+
   it('ignores missing targets, null previews, stale async results, and service failures', async () => {
     const api = getMockApi() as {
       notes: {

--- a/apps/desktop/src/renderer/src/hooks/use-wiki-link-hover.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-wiki-link-hover.ts
@@ -49,9 +49,16 @@ export function useWikiLinkHover(
   }, [])
 
   const dismiss = useCallback(() => {
+    // Timers and the active target are cleared unconditionally: a scroll (or a
+    // mouseout) that lands while a preview is merely *armed* must cancel it, or
+    // the card pops up moments later over content the user has moved past.
     clearTimers()
     activeTargetRef.current = null
-    setState({ preview: null, position: null, isVisible: false })
+    // Nothing shown means nothing to hide. Handing back `prev` lets React bail
+    // out instead of re-rendering the whole editor tree for an identical state.
+    setState((prev) =>
+      prev.isVisible ? { preview: null, position: null, isVisible: false } : prev
+    )
   }, [clearTimers])
 
   const computePosition = useCallback((linkEl: Element): HoverPosition | null => {


### PR DESCRIPTION
## Problem

`useWikiLinkHover` and `useLinkMentionHover` both mount in `ContentAreaEditor`
(`ContentArea.tsx:185-186`). Each registers a capture-phase `scroll` listener and a
`mouseout` handler that call `dismiss()`. `dismiss()` unconditionally did:

```ts
setState({ preview: null, position: null, isVisible: false })
```

A brand-new object every call, so React never bailed out — even when no preview was
open and the state was already exactly that. Two hooks × one full re-render of the
~1,400-line `ContentAreaEditor` per dismissed event.

## Validity on current `origin/main`

Confirmed still present; six new tests go red on `main` (see evidence below).

**One correction to the issue's framing.** The issue says the trigger is "every scroll
of any note". It is not. The listener is bound to `editorContainerRef` = `.bn-container`
(`ContentArea.tsx:1132`), which sits *inside* the note scroller
(`note-layout.tsx:122`, `flex-1 overflow-y-auto`). `scroll` does not bubble, and capture
only visits ancestors of the target, so a note-page scroll never reaches this listener.
Verified in jsdom with the real nesting: a `scroll` dispatched on the scroller fires the
`.bn-container` capture listener 0 times; a `scroll` dispatched on a `<pre>` inside it
fires it once.

The wasted renders are real, just on different paths:

- `mouseout` off **any** wiki-link or link-mention → 100 ms later `dismiss()` →
  a full editor re-render, even when no card was ever shown (hover under 300 ms,
  no matching note, failed metadata fetch). This is the common case.
- `scroll` of anything scrollable *inside* the editor: horizontally scrolling code
  blocks and tables, and BlockNote's mention / wiki-link / hashtag / emoji suggestion
  menus (`overflow-y-auto`, rendered inside `.bn-container`).

## Root cause

`useState` only bails out when the new state is `Object.is`-equal to the old one.
Allocating a fresh literal guarantees it never is.

## Fix

```ts
const dismiss = useCallback(() => {
  clearTimers()
  activeTargetRef.current = null
  setState((prev) =>
    prev.isVisible ? { preview: null, position: null, isVisible: false } : prev
  )
}, [clearTimers])
```

Two lines per hook, plus comments. Nothing else touched.

### Why not the issue's suggested remedy

The issue suggests `if (!state.isVisible) return` at the top of `dismiss()`. **That
causes a visible regression** and I did not take it: it skips `clearTimers()`, so a
scroll landing while a preview is merely *armed* (inside the 300 ms hover delay) no
longer cancels it — the card fetches and pops up moments later, floating over content
the user has already scrolled past. It would also put `state.isVisible` in the
`useCallback` deps, changing `dismiss`'s identity on every state change and re-running
the listener effect (remove + re-add three listeners).

I implemented that remedy and ran this branch's suite against it:

```
1. useWikiLinkHover cancels an armed preview on scroll so no card pops up over scrolled content
   AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
   Received: 1st vi.fn() call: [ "Daily Note" ]
```

The timer clear and `activeTargetRef` reset therefore stay **unconditional**; only the
`setState` is guarded.

## Test evidence

`apps/desktop/src/renderer/src/hooks/use-wiki-link-hover.test.tsx` and
`use-link-mention-hover.test.tsx`, three tests each. All assert observable render
counts (a counter incremented in the `renderHook` callback), never timing.

**RED on `main`** — 6 new tests fail:

```
PASS (7) FAIL (6)
1. useLinkMentionHover re-renders nothing when a scroll arrives with no preview open
   AssertionError: expected 6 to be 1
2. useLinkMentionHover dismisses an open preview on scroll ...
   AssertionError: expected 4 to be 3
3. useLinkMentionHover cancels an armed preview on scroll ...
   AssertionError: expected 2 to be 1
4. useWikiLinkHover re-renders nothing when a scroll arrives with no preview open
   AssertionError: expected 6 to be 1
5. useWikiLinkHover dismisses an open preview on scroll ...
   AssertionError: expected 4 to be 3
6. useWikiLinkHover cancels an armed preview on scroll ...
```

Exact values, not "fewer": 5 idle scrolls cost `6` renders on `main` and must cost
exactly `1` (the initial render) after the fix.

**GREEN**:

```
$ pnpm exec vitest run --config config/vitest.config.ts --project renderer \
    src/renderer/src/hooks/use-wiki-link-hover.test.tsx \
    src/renderer/src/hooks/use-link-mention-hover.test.tsx
PASS (13) FAIL (0)
```

with `ContentArea.test.tsx` included: `PASS (21) FAIL (0)`.

### Mutation verification

One code line per hook carries the behaviour, mutated separately (the guard, not a
comment — no comment contains `prev.isVisible`).

`use-wiki-link-hover.ts:59`, `prev.isVisible` → `true`:

```
PASS (4) FAIL (3)
1. re-renders nothing when a scroll arrives with no preview open  expected 6 to be 1
2. hides an open preview on scroll, then stops re-rendering        expected 9 to be 4
3. cancels an armed preview on scroll ...                          expected 2 to be 1
```

`use-link-mention-hover.ts`, same mutation:

```
PASS (3) FAIL (3)
1. re-renders nothing when a scroll arrives with no preview open  expected 6 to be 1
2. hides an open preview on scroll, then stops re-rendering        expected 9 to be 4
3. cancels an armed preview on scroll ...                          expected 2 to be 1
```

Both killed, no survivors. The two hooks are independent (separate test files), so
neither masks the other's mutant.

**Measured render counts** (probe, `[initial, preview shown, then 6 scrolls]`):
`[1, 2, 3, 4, 4, 4, 4, 4]`. Scroll 1 is the real dismiss; scroll 2 is React's
render-phase bailout after an update (it re-renders the component once before it can
compare eagerly); every scroll after that costs zero. On `main` the same sequence is
`[1, 2, 3, 4, 5, 6, 7, 8]`. The test asserts the settled state rather than hard-coding
`4`, so a future React that drops the trailing render will not produce a false failure.

## Hover / scroll interactions re-tested

| Interaction | Result |
| --- | --- |
| Scroll while hovering, nothing shown yet (armed preview) | Preview cancelled, no card appears, 0 re-renders. `previewByTitle` / `previewLink` not called. Covered by "cancels an armed preview on scroll…". |
| Scroll with the preview card open | Card hides on the first scroll (`isVisible === false`); further scrolls cost 0 renders. Covered by "hides an open preview on scroll, then stops re-rendering" in both files. |
| Hover → scroll → hover the same link again | Card shows again. `activeTargetRef.current = null` stays unconditional in `dismiss()`, so the `activeTargetRef.current === target` early-return does not block re-arming. Covered by the pre-existing "uses cached previews and places the card above…" test, which scrolls and then re-hovers the same link. |
| Idle scroll, never hovered | 0 re-renders (was 1 per hook per event). |
| Mouse out of a link without waiting for the card | Still dismisses; now costs 0 renders instead of 1 per hook. Covered by the pre-existing mouseout tests, still green. |
| Card hover-in / hover-out (mouse moves onto the card, then off) | Unchanged — `handleCardMouseEnter` / `handleCardMouseLeave` untouched; pre-existing test still green. |
| Split view, two editors | Each `ContentAreaEditor` instance owns its own hook state, timers and container listener; `dismiss()` is per-instance and reads only `prev` from its own `useState`. No shared state was introduced, so one editor's scroll cannot suppress the other's dismiss. |

## Risk & backward compatibility

Renderer-only, and only the React state-update path. No DB, migration, IPC contract,
vault file format, settings shape, markdown serialization or sync payload is touched —
nothing this change writes or reads persists anywhere. No new dependency, no lockfile
change. No `beforeinput` handler and no BlockNote menu focus guard involved: `dismiss()`
runs from `scroll` and `setTimeout`, never from an input event, so the native-edit and
menu-focus landmines are not in play. Nothing is cached or memoized, so there is no
negative to invalidate. The only behaviour change is that an already-hidden card stops
scheduling a no-op render.

## Relationship to neighbouring PRs

- **#1154** (`use-triggered-date-pills` MutationObserver scoping, #1047) — read before
  starting; this branch is cut from current `origin/main` and touches no file it
  touches. Both hooks here are `src/renderer/src/hooks/*`, #1154 is
  `components/note/content-area/use-triggered-date-pills.*`. No overlap.
- **#1140** (`editor-destroy-and-journal-remount`, #1017) — read before writing code. It
  edits `ContentArea.tsx` (adds `useEditorTeardown`, `externalContentRevision`) and
  `ContentArea.test.tsx`. This branch edits **neither**, so there is no textual conflict.
  Noting the adjacency neutrally: #1140 destroys BlockNote editors on unmount; this PR
  only changes what `dismiss()` hands to `setState` inside two hooks that mount in the
  same component. The two are independent.

## Docs

`pnpm docs:impact --base origin/main --strict` reports `missing-docs` for the two hook
files. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: this is an internal render-bailout
optimization with no user-visible behaviour change — the hover previews look and behave
identically, and there is no new setting, surface or format to document. Needs the
`docs:not-needed` label for CI.

## Verification

```
$ pnpm typecheck
Tasks: 16 successful, 16 total

$ pnpm lint
✖ 15 problems (0 errors, 15 warnings)     # 16 before; the removed one was mine
                                          # (prettier), remaining are pre-existing

$ git diff --check
(clean)

$ npx -y react-doctor@latest .            # run twice, outputs byte-identical
231 issues                                # both runs; scans diffed clean
```

`react-doctor` lists `use-wiki-link-hover.ts:130` and `use-link-mention-hover.ts:109`
under `effect-needs-cleanup`. Pre-existing false positives on the listener `useEffect`,
which does return a cleanup removing all three listeners and clearing timers — that
effect is untouched by this diff; only the line numbers shifted by the added comments.

## Out of scope — found, not fixed

1. **Dismiss-on-scroll never fires for the note page scroll.** As shown above, the
   capture listener on `.bn-container` cannot see a scroll on its own scrolling
   ancestor. The preview cards are `position: fixed` portals into `document.body`
   (`wiki-link-preview-card.tsx:31`, `link-mention-preview-card.tsx`), so an open card
   stays pinned to the viewport while the note scrolls away underneath it. Pre-existing;
   moving the listener would be a behaviour change well outside #1048.
2. **`useTriggeredDatePills` observer effect deps** (known context from #1047): its
   effect deps are `[containerRef]` while `ContentArea.tsx:647` assigns
   `editorContainerRef.current = el` from a ref callback, so a swapped div would leave
   the observer bound to a detached node. My change does **not** interact with it — both
   hover hooks read `editorContainerRef.current` inside their own effect and have the
   same latent exposure, which this PR neither worsens nor fixes.

Closes #1048
