### PR TITLE
fix(inbox): enqueue a sync push when an item is filed

### DIFF
--- a/apps/desktop/src/main/inbox/filing.test.ts
+++ b/apps/desktop/src/main/inbox/filing.test.ts
@@ -29,6 +29,16 @@ vi.mock('../database/queries/notes', () => ({
   setNoteTags: (...args: unknown[]) => mockSetNoteTags(...args)
 }))
 
+const { mockSyncInboxUpdate, mockPublishInboxUpserted } = vi.hoisted(() => ({
+  mockSyncInboxUpdate: vi.fn(),
+  mockPublishInboxUpserted: vi.fn()
+}))
+
+vi.mock('./runtime-effects', () => ({
+  syncInboxUpdate: mockSyncInboxUpdate,
+  publishInboxUpserted: mockPublishInboxUpserted
+}))
+
 const mockSend = vi.fn()
 const mockRename = vi.fn()
 const mockCopyFile = vi.fn()
@@ -191,6 +201,8 @@ describe('Inbox Filing Operations', () => {
     mockSetTaskTags.mockReset()
     mockGetInboxProject.mockReset().mockReturnValue({ id: 'project-inbox' })
     mockCreateReminder.mockReset().mockReturnValue({ id: 'rem_1' })
+    mockSyncInboxUpdate.mockReset()
+    mockPublishInboxUpserted.mockReset()
     vi.mocked(getStatus).mockReturnValue({ isOpen: true, path: '/mock-vault' } as never)
 
     mockCreateNote.mockResolvedValue({
@@ -1509,6 +1521,115 @@ describe('Inbox Filing Operations', () => {
 
       expect(result.processedCount).toBe(2)
       expect(result.errors).toHaveLength(1)
+    })
+  })
+
+  // ==========================================================================
+  // Sync enqueue on filing (#1159)
+  //
+  // Filing is the Inbox's primary action, and every path funnels through
+  // markItemAsFiled. Without a push the filed state never leaves the device,
+  // and a stale peer's next push — buildPushPayload ships the whole row, so it
+  // still carries filedAt: null — reads as a deliberate unfile and resurrects
+  // the item on the device that filed it.
+  // ==========================================================================
+  describe('filing enqueues a sync push', () => {
+    async function seedTargetNote(): Promise<void> {
+      mockGetNoteById.mockResolvedValue({
+        id: 'target-note',
+        content: '# Target',
+        path: 'notes/target.md'
+      })
+    }
+
+    it('fileToFolder (text) pushes the filed state', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'item-1', type: 'note', title: 'Test Item' })
+
+      await fileToFolder(itemId, 'projects')
+
+      expect(mockSyncInboxUpdate).toHaveBeenCalledWith(itemId)
+    })
+
+    it('fileToFolder (binary) pushes the filed state', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'image-1', type: 'image', title: 'Shot' })
+      updateInboxItem(itemId, { attachmentPath: 'attachments/inbox/image-1/shot.png' })
+
+      await fileToFolder(itemId, 'projects')
+
+      expect(mockSyncInboxUpdate).toHaveBeenCalledWith(itemId)
+    })
+
+    it('convertToNote pushes the filed state', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'item-1', type: 'note', title: 'Test Item' })
+
+      await convertToNote(itemId)
+
+      expect(mockSyncInboxUpdate).toHaveBeenCalledWith(itemId)
+    })
+
+    it('convertToTask pushes the filed state', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'item-1', type: 'note', title: 'Test Item' })
+
+      await convertToTask(itemId)
+
+      expect(mockSyncInboxUpdate).toHaveBeenCalledWith(itemId)
+    })
+
+    it('convertToEvent pushes the filed state', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'item-1', type: 'note', title: 'Test Item' })
+
+      await convertToEvent(itemId, { startAt: '2099-01-02T15:00:00.000Z' })
+
+      expect(mockSyncInboxUpdate).toHaveBeenCalledWith(itemId)
+    })
+
+    it('convertToReminder pushes the filed state', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'item-1', type: 'note', title: 'Test Item' })
+
+      await convertToReminder(itemId, { remindAt: '2099-01-02T09:00:00.000Z' })
+
+      expect(mockSyncInboxUpdate).toHaveBeenCalledWith(itemId)
+    })
+
+    it('linkToNotes (text) pushes the filed state', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'item-1', type: 'note', title: 'Test Item' })
+      await seedTargetNote()
+
+      await linkToNotes(itemId, ['target-note'])
+
+      expect(mockSyncInboxUpdate).toHaveBeenCalledWith(itemId)
+    })
+
+    it('linkToNotes (binary) pushes the filed state', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'image-2', type: 'image', title: 'Shot' })
+      updateInboxItem(itemId, { attachmentPath: 'attachments/inbox/image-2/shot.png' })
+      await seedTargetNote()
+
+      await linkToNotes(itemId, ['target-note'])
+
+      expect(mockSyncInboxUpdate).toHaveBeenCalledWith(itemId)
+    })
+
+    it('keeps the filing when the sync enqueue throws, and still publishes locally', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'item-1', type: 'note', title: 'Test Item' })
+      mockSyncInboxUpdate.mockImplementation(() => {
+        throw new Error('sync service down')
+      })
+
+      const result = await fileToFolder(itemId, 'projects')
+
+      expect(result.success).toBe(true)
+      const row = testDb.db.select().from(inboxItems).where(eq(inboxItems.id, itemId)).get()
+      expect(row?.filedAt).toBeTruthy()
+      expect(row?.filedAction).toBe('folder')
+      // syncInboxUpdate publishes the projection itself; when it throws before
+      // getting there the local Inbox list would otherwise go stale.
+      expect(mockPublishInboxUpserted).toHaveBeenCalledWith(itemId)
+      expect(mockTrackMainError).toHaveBeenCalledWith(
+        'inbox',
+        'filing_sync_enqueue',
+        expect.any(Error)
+      )
     })
   })
 })

--- a/apps/desktop/src/main/inbox/filing.ts
+++ b/apps/desktop/src/main/inbox/filing.ts
@@ -30,7 +30,7 @@ import { createReminder } from '../lib/reminders'
 import { resolveAttachmentUrl, deleteInboxAttachments } from './attachments'
 import { extractYouTubeVideoId } from '@memry/shared/youtube'
 import { extractDomain } from './metadata-utils'
-import { publishProjectionEvent } from '../projections'
+import { publishInboxUpserted, syncInboxUpdate } from './runtime-effects'
 import { syncTaskCreate } from '../tasks/runtime-effects'
 import { trackMainError } from '../telemetry/diagnostics'
 import { trackMainEvent } from '../telemetry/track'
@@ -462,10 +462,21 @@ function markItemAsFiled(itemId: string, filedTo: string, filedAction: FilingAct
     .where(eq(inboxItems.id, itemId))
     .run()
 
-  publishProjectionEvent({
-    type: 'inbox.upserted',
-    itemId
-  })
+  // Filing must reach the other devices. Without a push the filed state never
+  // leaves this device, and a peer that still holds `filedAt: null` pushes that
+  // whole row on its next change — which applyUpsert reads as a deliberate
+  // unfile and applies here, resurrecting the item the user already filed.
+  // Best-effort like convertToTask's enqueue: a sync outage must not fail a
+  // filing that already succeeded locally, but it must stay countable.
+  try {
+    syncInboxUpdate(itemId)
+  } catch (error) {
+    log.warn('syncInboxUpdate failed; filing persisted locally', error)
+    trackMainError('inbox', 'filing_sync_enqueue', error)
+    // syncInboxUpdate publishes the projection itself; republish here so a
+    // failed enqueue doesn't also leave the local Inbox list stale.
+    publishInboxUpserted(itemId)
+  }
 
   // Emit filed event
   emitInboxEvent(InboxChannels.events.FILED, {

--- a/apps/desktop/src/main/inbox/sync-enqueue-guard.test.ts
+++ b/apps/desktop/src/main/inbox/sync-enqueue-guard.test.ts
@@ -26,67 +26,267 @@ const TRIAGE_COLUMNS = [
   'snoozeReason'
 ] as const
 
-/** Any of the runtime-effects enqueues, including the injected `deps.` form used by crud.ts. */
-const SYNC_ENQUEUE_PATTERN = /\bsyncInbox(?:Create|Update|Delete)\b/
+/**
+ * Any of the runtime-effects enqueues, including the injected `deps.` form used
+ * by crud.ts, plus the calendar writeback's own publisher — it reaches the same
+ * queue through `tryEnqueueProjectionSyncUpdate('inbox', …)` rather than
+ * through inbox/runtime-effects.
+ */
+const SYNC_ENQUEUE_PATTERN =
+  /\b(?:syncInbox(?:Create|Update|Delete)|publishInboxCalendarMutation)\b/
 
 const INBOX_DIR = path.dirname(fileURLToPath(import.meta.url))
+/**
+ * The fence is the whole main process, not `inbox/`. `readdirSync(INBOX_DIR)`
+ * was both non-recursive and directory-scoped, so the Google Calendar
+ * writeback (`calendar/google/sync-service.ts`) — which clears `snoozedUntil`
+ * on `inbox_items` — sat outside it entirely. Any module that can write triage
+ * state is in scope; the `inboxItems` prefilter keeps the scan to the handful
+ * of files that touch the table.
+ */
+const MAIN_DIR = path.resolve(INBOX_DIR, '..')
 
-function inboxSourceFiles(): string[] {
-  return readdirSync(INBOX_DIR)
-    .filter((name) => name.endsWith('.ts') && !name.endsWith('.test.ts'))
-    .sort()
+/**
+ * Modules whose triage writes must NOT enqueue, with the reason. Keyed by path
+ * relative to `src/main`. Kept deliberately tiny: an entry here is a promise
+ * that the file only ever applies triage state that already came from
+ * somewhere else.
+ */
+const LOCAL_ONLY_WRITERS: Record<string, string> = {
+  'sync/item-handlers/inbox-handler.ts':
+    'Remote-apply path. These writes ARE the incoming peer push; enqueueing here would echo every pulled change straight back to the server.'
+}
+
+function mainSourceFiles(dir: string = MAIN_DIR): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  )) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...mainSourceFiles(full))
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+function relativeToMain(file: string): string {
+  return path.relative(MAIN_DIR, file).split(path.sep).join('/')
 }
 
 /**
- * Slice each `update(inboxItems)` / `insert(inboxItems)` statement out of the
- * source so a column name only counts when it is being written — `filedAt` in
- * a select filter or a type annotation must not satisfy the guard.
+ * The innermost `{ … }` block containing `index`, brace-matched outwards. This
+ * is what makes the guard statement-level: the old version tested the enqueue
+ * pattern against the whole file, so once `filing.ts` gained one
+ * `syncInboxUpdate` every *other* triage write anyone added to it passed for
+ * free, and only a brand-new file with zero enqueues could ever be caught.
+ *
+ * Scanning starts at the `update(inboxItems)` token, so the `.set({ … })`
+ * braces of the statement itself are never in the way.
  */
-function writeStatements(source: string): string[] {
-  const statements: string[] = []
+function enclosingBlock(source: string, index: number): string {
+  let depth = 0
+  let open = -1
+  for (let i = index; i >= 0; i--) {
+    const ch = source[i]
+    if (ch === '}') depth++
+    else if (ch === '{') {
+      if (depth === 0) {
+        open = i
+        break
+      }
+      depth--
+    }
+  }
+  if (open === -1) return source
+
+  depth = 0
+  for (let i = open; i < source.length; i++) {
+    const ch = source[i]
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) return source.slice(open, i + 1)
+    }
+  }
+  return source.slice(open)
+}
+
+/**
+ * Blank out string literals and comments before looking for an enqueue.
+ * `markItemAsFiled` logs `'syncInboxUpdate failed; filing persisted locally'`
+ * in its catch, and that string alone would satisfy the guard for every write
+ * in the block — a mention is not a call.
+ */
+function codeOnly(block: string): string {
+  return block
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ')
+    .replace(/'(?:\\.|[^'\\])*'/g, "''")
+    .replace(/"(?:\\.|[^"\\])*"/g, '""')
+    .replace(/`(?:\\.|[^`\\])*`/g, '``')
+}
+
+export interface TriageWrite {
+  /** 1-based line of the `update(inboxItems)` / `insert(inboxItems)` token. */
+  line: number
+  columns: string[]
+  guarded: boolean
+}
+
+/**
+ * Every `update(inboxItems)` / `insert(inboxItems)` statement that assigns a
+ * triage column, paired with whether an enqueue lives in the same block.
+ *
+ * A column name only counts when it is being written — `filedAt` in a select
+ * filter or a type annotation must not satisfy the guard — so the statement is
+ * sliced from the write token to its `.run()`.
+ */
+export function findTriageWrites(source: string): TriageWrite[] {
+  const writes: TriageWrite[] = []
   const writeStart = /\b(?:update|insert)\(inboxItems\)/g
 
   let match: RegExpExecArray | null
   while ((match = writeStart.exec(source)) !== null) {
     const end = source.indexOf('.run()', match.index)
-    statements.push(source.slice(match.index, end === -1 ? source.length : end))
+    const statement = source.slice(match.index, end === -1 ? source.length : end)
+    const columns = TRIAGE_COLUMNS.filter((column) => statement.includes(column))
+    if (columns.length === 0) continue
+
+    writes.push({
+      line: source.slice(0, match.index).split('\n').length,
+      columns,
+      guarded: SYNC_ENQUEUE_PATTERN.test(codeOnly(enclosingBlock(source, match.index)))
+    })
   }
 
-  return statements
+  return writes
+}
+
+interface ScannedFile {
+  relative: string
+  writes: TriageWrite[]
+}
+
+function scanTriageWriters(): ScannedFile[] {
+  const scanned: ScannedFile[] = []
+  for (const file of mainSourceFiles()) {
+    const source = readFileSync(file, 'utf8')
+    // Cheap prefilter: only a module that names the table can write to it.
+    if (!source.includes('inboxItems')) continue
+
+    const writes = findTriageWrites(source)
+    if (writes.length > 0) scanned.push({ relative: relativeToMain(file), writes })
+  }
+  return scanned
 }
 
 describe('inbox triage writes enqueue a sync push', () => {
-  const offenders: string[] = []
+  const scanned = scanTriageWriters()
 
-  for (const file of inboxSourceFiles()) {
-    const source = readFileSync(path.join(INBOX_DIR, file), 'utf8')
-    const writesTriageState = writeStatements(source).some((statement) =>
-      TRIAGE_COLUMNS.some((column) => statement.includes(column))
-    )
+  it('no triage write in the main process lands without an enqueue beside it', () => {
+    const offenders = scanned
+      .filter((file) => !(file.relative in LOCAL_ONLY_WRITERS))
+      .flatMap((file) =>
+        file.writes
+          .filter((write) => !write.guarded)
+          .map((write) => `${file.relative}:${write.line} [${write.columns.join(', ')}]`)
+      )
 
-    if (writesTriageState && !SYNC_ENQUEUE_PATTERN.test(source)) {
-      offenders.push(file)
-    }
-  }
-
-  it('no inbox module writes filed/archived/snoozed state without enqueueing a push', () => {
     expect(offenders).toEqual([])
   })
 
-  it('actually inspects the modules that own triage state', () => {
-    // Cheap tripwire: if the scan silently stops matching (a refactor renames
-    // the columns, or the write shape changes), the guard above would pass
-    // vacuously. These three are the triage writers today.
-    const scanned = inboxSourceFiles()
-    expect(scanned).toEqual(expect.arrayContaining(['crud.ts', 'filing.ts', 'snooze.ts']))
+  it('actually inspects every module that owns triage state', () => {
+    // Tripwire: if the scan silently stops matching (a refactor renames the
+    // columns, moves a module, or changes the write shape), the guard above
+    // would pass vacuously. These are the triage writers today.
+    const writers = scanned.map((file) => file.relative)
+    expect(writers).toEqual(
+      expect.arrayContaining([
+        'inbox/crud.ts',
+        'inbox/filing.ts',
+        'inbox/snooze.ts',
+        'calendar/google/sync-service.ts',
+        'sync/item-handlers/inbox-handler.ts'
+      ])
+    )
+  })
 
-    for (const file of ['crud.ts', 'filing.ts', 'snooze.ts']) {
-      const source = readFileSync(path.join(INBOX_DIR, file), 'utf8')
-      const statements = writeStatements(source)
-      expect(
-        statements.some((statement) => TRIAGE_COLUMNS.some((column) => statement.includes(column))),
-        `${file} should contain a triage-state write`
-      ).toBe(true)
+  it('keeps the local-only allowlist honest', () => {
+    // A stale entry is worse than no entry: it silently exempts a file that no
+    // longer writes triage state — and would exempt whatever is added to it
+    // later. Every allowlisted path must still be a real, scanned writer.
+    for (const [relative, reason] of Object.entries(LOCAL_ONLY_WRITERS)) {
+      expect(scanned.map((file) => file.relative)).toContain(relative)
+      expect(reason.length).toBeGreaterThan(0)
     }
+  })
+})
+
+describe('findTriageWrites', () => {
+  // The guard is only worth its runtime if it fails on the shape it exists to
+  // catch. These run the analyzer against synthetic sources so a regression in
+  // the analyzer itself cannot make the scan above pass vacuously.
+
+  it('flags a triage write with no enqueue in its block', () => {
+    const source = `
+      function unfile(id: string): void {
+        db.update(inboxItems).set({ filedAt: null }).where(eq(inboxItems.id, id)).run()
+      }
+    `
+    expect(findTriageWrites(source)).toEqual([
+      expect.objectContaining({ columns: ['filedAt'], guarded: false })
+    ])
+  })
+
+  it('flags a second unguarded write in a file that already enqueues elsewhere', () => {
+    // The exact hole in the file-level guard this replaced.
+    const source = `
+      function file(id: string): void {
+        db.update(inboxItems).set({ filedAt: now }).where(eq(inboxItems.id, id)).run()
+        syncInboxUpdate(id)
+      }
+
+      function archive(id: string): void {
+        db.update(inboxItems).set({ archivedAt: now }).where(eq(inboxItems.id, id)).run()
+      }
+    `
+    expect(findTriageWrites(source).map((write) => write.guarded)).toEqual([true, false])
+  })
+
+  it('accepts an enqueue that sits in a nested block of the same function', () => {
+    const source = `
+      function file(id: string): void {
+        db.update(inboxItems).set({ filedAt: now }).where(eq(inboxItems.id, id)).run()
+        try {
+          syncInboxUpdate(id)
+        } catch (error) {
+          log.warn('failed', error)
+        }
+      }
+    `
+    expect(findTriageWrites(source).map((write) => write.guarded)).toEqual([true])
+  })
+
+  it('does not accept a log message that merely names the enqueue', () => {
+    const source = `
+      function file(id: string): void {
+        db.update(inboxItems).set({ filedAt: now }).where(eq(inboxItems.id, id)).run()
+        log.warn('syncInboxUpdate failed; filing persisted locally')
+      }
+    `
+    expect(findTriageWrites(source).map((write) => write.guarded)).toEqual([false])
+  })
+
+  it('does not count a triage column that is only read', () => {
+    const source = `
+      function markViewed(id: string): void {
+        const existing = db.select().from(inboxItems).where(eq(inboxItems.filedAt, null)).get()
+        db.update(inboxItems).set({ viewedAt: now }).where(eq(inboxItems.id, id)).run()
+      }
+    `
+    expect(findTriageWrites(source)).toEqual([])
   })
 })

--- a/apps/desktop/src/main/inbox/sync-enqueue-guard.test.ts
+++ b/apps/desktop/src/main/inbox/sync-enqueue-guard.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+/**
+ * Guard for the #1159 bug class.
+ *
+ * Filing wrote `filedAt`/`filedTo`/`filedAction` and never enqueued a sync
+ * push, so filed items stayed filed on one device only — and a stale peer's
+ * next push (buildPushPayload ships the whole row, still carrying
+ * `filedAt: null`) read as a deliberate unfile and resurrected them.
+ *
+ * The columns below are the Inbox's triage state: they decide whether an item
+ * shows up in another device's Inbox at all, so a local-only write to any of
+ * them is a silent divergence. Enrichment columns (title, content, metadata,
+ * processingStatus, transcription*) are deliberately out of scope here — they
+ * ride along on the next push of the whole row.
+ */
+const TRIAGE_COLUMNS = [
+  'filedAt',
+  'filedTo',
+  'filedAction',
+  'archivedAt',
+  'snoozedUntil',
+  'snoozeReason'
+] as const
+
+/** Any of the runtime-effects enqueues, including the injected `deps.` form used by crud.ts. */
+const SYNC_ENQUEUE_PATTERN = /\bsyncInbox(?:Create|Update|Delete)\b/
+
+const INBOX_DIR = path.dirname(fileURLToPath(import.meta.url))
+
+function inboxSourceFiles(): string[] {
+  return readdirSync(INBOX_DIR)
+    .filter((name) => name.endsWith('.ts') && !name.endsWith('.test.ts'))
+    .sort()
+}
+
+/**
+ * Slice each `update(inboxItems)` / `insert(inboxItems)` statement out of the
+ * source so a column name only counts when it is being written — `filedAt` in
+ * a select filter or a type annotation must not satisfy the guard.
+ */
+function writeStatements(source: string): string[] {
+  const statements: string[] = []
+  const writeStart = /\b(?:update|insert)\(inboxItems\)/g
+
+  let match: RegExpExecArray | null
+  while ((match = writeStart.exec(source)) !== null) {
+    const end = source.indexOf('.run()', match.index)
+    statements.push(source.slice(match.index, end === -1 ? source.length : end))
+  }
+
+  return statements
+}
+
+describe('inbox triage writes enqueue a sync push', () => {
+  const offenders: string[] = []
+
+  for (const file of inboxSourceFiles()) {
+    const source = readFileSync(path.join(INBOX_DIR, file), 'utf8')
+    const writesTriageState = writeStatements(source).some((statement) =>
+      TRIAGE_COLUMNS.some((column) => statement.includes(column))
+    )
+
+    if (writesTriageState && !SYNC_ENQUEUE_PATTERN.test(source)) {
+      offenders.push(file)
+    }
+  }
+
+  it('no inbox module writes filed/archived/snoozed state without enqueueing a push', () => {
+    expect(offenders).toEqual([])
+  })
+
+  it('actually inspects the modules that own triage state', () => {
+    // Cheap tripwire: if the scan silently stops matching (a refactor renames
+    // the columns, or the write shape changes), the guard above would pass
+    // vacuously. These three are the triage writers today.
+    const scanned = inboxSourceFiles()
+    expect(scanned).toEqual(expect.arrayContaining(['crud.ts', 'filing.ts', 'snooze.ts']))
+
+    for (const file of ['crud.ts', 'filing.ts', 'snooze.ts']) {
+      const source = readFileSync(path.join(INBOX_DIR, file), 'utf8')
+      const statements = writeStatements(source)
+      expect(
+        statements.some((statement) => TRIAGE_COLUMNS.some((column) => statement.includes(column))),
+        `${file} should contain a triage-state write`
+      ).toBe(true)
+    }
+  })
+})

--- a/apps/desktop/src/main/sync/dirty-recovery.test.ts
+++ b/apps/desktop/src/main/sync/dirty-recovery.test.ts
@@ -4,12 +4,14 @@ import { createTestDataDb, asClientDb, type TestDatabaseResult } from '@tests/ut
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { projects } from '@memry/db-schema/schema/projects'
 import { noteMetadata } from '@memry/db-schema/data-schema'
+import { inboxItems } from '@memry/db-schema/schema/inbox'
 import { syncDevices } from '@memry/db-schema/schema/sync-devices'
 import type { DataDb } from '../database/client'
 import { incrementNoteClockOffline } from './offline-clock'
 import { SyncQueueManager } from './queue'
 import { initTaskSyncService, resetTaskSyncService } from './task-sync'
 import { initProjectSyncService, resetProjectSyncService } from './project-sync'
+import { initInboxSyncService, resetInboxSyncService } from './inbox-sync'
 import { recoverDirtyItems } from './dirty-recovery'
 
 const TEST_PROJECT = {
@@ -186,8 +188,7 @@ describe('dirty-recovery', () => {
     expect(queued?.operation).toBe('update')
     const payload = queued ? (JSON.parse(queued.payload) as Record<string, unknown>) : null
     const payloadFieldClocks = payload?.fieldClocks as
-      | Record<string, Record<string, number>>
-      | undefined
+      Record<string, Record<string, number>> | undefined
     expect(payload?.clock).toEqual({ 'old-device': 1, 'device-A': 1 })
     expect(payloadFieldClocks?.statusId).toEqual({ 'old-device': 1, 'device-A': 1 })
     expect(payloadFieldClocks?.title).toEqual({ 'old-device': 1 })
@@ -521,6 +522,139 @@ describe('dirty-recovery', () => {
 
       const row = db.select().from(noteMetadata).where(eq(noteMetadata.id, 'journal-tagged')).get()
       expect(row?.clock).toEqual({ 'device-A': 3 })
+    })
+  })
+
+  // Builds before the #1159 fix filed items without enqueueing anything, and
+  // nothing else on an existing install ever touches those rows again:
+  // seedUnclocked only takes clock-less rows, the manifest check is
+  // presence-based and the item is present, and filing.ts refuses to re-file an
+  // item that already has a filedAt. This arm is the only thing that heals them.
+  describe('inbox', () => {
+    // Deliberately the real InboxSyncService and the real queue, not a stub:
+    // the thing under test is that a queue row is actually produced *and* that
+    // the vector clock advances past what the server already holds. A fake
+    // adapter would assert neither.
+    const insertItem = (values: Record<string, unknown>): void => {
+      db.insert(inboxItems)
+        .values({
+          type: 'link',
+          title: 'A capture',
+          createdAt: '2026-01-01T00:00:00Z',
+          ...values
+        } as never)
+        .run()
+    }
+
+    beforeEach(() => {
+      initInboxSyncService({ queue, db, getDeviceId: () => 'device-A' })
+    })
+
+    afterEach(() => {
+      resetInboxSyncService()
+    })
+
+    it('recovers an item filed before the fix, at a clock the server cannot dismiss', () => {
+      // #given — captured and pushed, then filed by a pre-fix build: filedAt
+      // and modifiedAt moved, the clock and syncedAt did not
+      insertItem({
+        id: 'inbox-filed',
+        clock: { 'device-A': 1 },
+        syncedAt: '2026-01-01T00:00:00Z',
+        modifiedAt: '2026-01-02T00:00:00Z',
+        filedAt: '2026-01-02T00:00:00Z',
+        filedTo: 'notes/Filed.md',
+        filedAction: 'folder'
+      })
+
+      // #when
+      const result = recoverDirtyItems(db)
+
+      // #then — one real queue row carrying the filed state
+      expect(result.inbox).toBe(1)
+      expect(queue.getPendingCount()).toBe(1)
+
+      const queued = queue.peek(1)[0]
+      expect(queued?.type).toBe('inbox')
+      expect(queued?.itemId).toBe('inbox-filed')
+      expect(queued?.operation).toBe('update')
+
+      const payload = JSON.parse(queued?.payload ?? '{}') as Record<string, unknown>
+      expect(payload.filedAt).toBe('2026-01-02T00:00:00Z')
+      expect(payload.filedTo).toBe('notes/Filed.md')
+      // The clock MUST advance. Replaying {device-A: 1} — the clock the server
+      // already has — loses to any peer that has moved on since, and the filing
+      // would be dropped a second time.
+      expect(payload.clock).toEqual({ 'device-A': 2 })
+
+      const row = db.select().from(inboxItems).where(eq(inboxItems.id, 'inbox-filed')).get()
+      expect(row?.clock).toEqual({ 'device-A': 2 })
+    })
+
+    it('leaves clean, local-only and clock-less items alone', () => {
+      // clean: stamped after its last write — the whole inbox must not re-push
+      insertItem({
+        id: 'inbox-clean',
+        clock: { 'device-A': 1 },
+        syncedAt: '2026-01-03T00:00:00Z',
+        modifiedAt: '2026-01-02T00:00:00Z'
+      })
+      // local-only: never leaves this device
+      insertItem({
+        id: 'inbox-local',
+        clock: { 'device-A': 1 },
+        localOnly: true,
+        syncedAt: '2026-01-01T00:00:00Z',
+        modifiedAt: '2026-01-02T00:00:00Z'
+      })
+      // clock-less: inboxHandler.seedUnclocked owns the first push
+      insertItem({ id: 'inbox-unclocked', modifiedAt: '2026-01-02T00:00:00Z' })
+
+      // #when
+      const result = recoverDirtyItems(db)
+
+      // #then
+      expect(result.inbox).toBe(0)
+      expect(queue.getPendingCount()).toBe(0)
+    })
+
+    it('recovers an item the server confirmed but never stamped as pushed', () => {
+      // #given — legacy rows carry no syncedAt at all
+      insertItem({
+        id: 'inbox-legacy',
+        clock: { 'device-A': 1 },
+        syncedAt: null,
+        modifiedAt: '2026-01-02T00:00:00Z'
+      })
+
+      // #when / #then
+      expect(recoverDirtyItems(db).inbox).toBe(1)
+    })
+
+    it('stops firing once the push is stamped, and never queues a row twice', () => {
+      insertItem({
+        id: 'inbox-filed',
+        clock: { 'device-A': 1 },
+        syncedAt: '2026-01-01T00:00:00Z',
+        modifiedAt: '2026-01-02T00:00:00Z',
+        filedAt: '2026-01-02T00:00:00Z'
+      })
+
+      // #when — two launches before the push drains
+      expect(recoverDirtyItems(db).inbox).toBe(1)
+      expect(recoverDirtyItems(db).inbox).toBe(1)
+
+      // #then — the queue deduplicates on itemId+type+operation
+      expect(queue.getPendingCount()).toBe(1)
+
+      // #when — the push lands and markPushSynced stamps the row
+      db.update(inboxItems)
+        .set({ syncedAt: '2026-01-03T00:00:00Z' })
+        .where(eq(inboxItems.id, 'inbox-filed'))
+        .run()
+
+      // #then — the sweep goes quiet for good
+      expect(recoverDirtyItems(db).inbox).toBe(0)
     })
   })
 })

--- a/apps/desktop/src/main/sync/dirty-recovery.ts
+++ b/apps/desktop/src/main/sync/dirty-recovery.ts
@@ -5,6 +5,8 @@ import { noteMetadata } from '@memry/db-schema/data-schema'
 import type { SyncAdapterRegistry } from '@memry/sync-core'
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { projects } from '@memry/db-schema/schema/projects'
+import { inboxItems } from '@memry/db-schema/schema/inbox'
+import { getInboxSyncService } from './inbox-sync'
 import { getJournalSyncService } from './journal-sync'
 import { getNoteSyncService } from './note-sync'
 import { getProjectSyncService } from './project-sync'
@@ -20,6 +22,7 @@ export interface RecoveryResult {
   projects: number
   notes: number
   journals: number
+  inbox: number
 }
 
 /**
@@ -96,17 +99,25 @@ export function recoverDirtyItems(
 
   const noteCount = recoverDirtyNotes(db, adapters)
   const journalCount = recoverDirtyJournals(db, adapters)
+  const inboxCount = recoverDirtyInbox(db, adapters)
 
-  if (taskCount > 0 || projectCount > 0 || noteCount > 0 || journalCount > 0) {
+  if (taskCount > 0 || projectCount > 0 || noteCount > 0 || journalCount > 0 || inboxCount > 0) {
     log.info('Recovered dirty items for sync', {
       tasks: taskCount,
       projects: projectCount,
       notes: noteCount,
-      journals: journalCount
+      journals: journalCount,
+      inbox: inboxCount
     })
   }
 
-  return { tasks: taskCount, projects: projectCount, notes: noteCount, journals: journalCount }
+  return {
+    tasks: taskCount,
+    projects: projectCount,
+    notes: noteCount,
+    journals: journalCount,
+    inbox: inboxCount
+  }
 }
 
 /**
@@ -156,6 +167,70 @@ function recoverDirtyNotes(
   }
 
   return dirtyNotes.length
+}
+
+/**
+ * Heal inbox items whose triage state never left this device.
+ *
+ * Builds before #1159's fix filed items without enqueueing anything: `filedAt`,
+ * `filedTo` and `filedAction` were written straight to the row, so the filing
+ * never reached the other devices and the clock never advanced. Nothing else
+ * repairs those rows on an existing install — `seedUnclocked` only picks rows
+ * with a NULL clock, the manifest check is presence-based and the item is
+ * present on the server, and `inbox/filing.ts` refuses to re-file an item that
+ * already has a `filedAt`, so no later write ever touches them again. Without
+ * this sweep they stay unpushed forever, and stay exposed to the stale-peer
+ * push that reads their `filedAt: null` as a deliberate unfile.
+ *
+ * Same predicate as the arms above — `syncedAt IS NULL` or
+ * `modifiedAt > syncedAt` — because filing does stamp `modifiedAt`. That keeps
+ * the scan to one indexed-free table read that returns nothing on a healthy
+ * install, instead of re-pushing the whole inbox at every launch. It is
+ * self-clearing: the push stamps `syncedAt` past `modifiedAt`
+ * (`inboxHandler.markPushSynced`), so the row is clean on the next launch, and
+ * a row that never gets pushed is deduplicated by
+ * `SyncQueueManager.enqueue()` on itemId+type+operation.
+ *
+ * Scope matches the note arm: only items the server already knows (`clock`
+ * set — clock-less ones belong to `inboxHandler.seedUnclocked`) and not
+ * local-only.
+ *
+ * Unlike tasks/projects/notes this deliberately goes through the ordinary
+ * `enqueueUpdate`, which bumps the vector clock. `enqueueRecoveredUpdate`
+ * exists to re-push a change whose clock was *already* advanced at write time;
+ * these rows never got that far, so replaying their stored clock would lose to
+ * any peer that has since moved on and the filing would be dropped a second
+ * time. Bumping produces exactly the push the fix in `markItemAsFiled` would
+ * have produced at filing time.
+ */
+function recoverDirtyInbox(
+  db: DrizzleDb,
+  adapters?: SyncAdapterRegistry<DrizzleDb, (channel: string, data: unknown) => void>
+): number {
+  const inboxSync = adapters?.getLocal('inbox') ?? getInboxSyncService()
+  if (!inboxSync) return 0
+
+  const dirtyItems = db
+    .select({ id: inboxItems.id })
+    .from(inboxItems)
+    .where(
+      and(
+        isNotNull(inboxItems.clock),
+        sql`${inboxItems.localOnly} IS NOT 1`,
+        or(
+          isNull(inboxItems.syncedAt),
+          and(isNotNull(inboxItems.syncedAt), gt(inboxItems.modifiedAt, inboxItems.syncedAt))
+        )
+      )
+    )
+    .all()
+
+  for (const item of dirtyItems) {
+    log.debug('Recovering dirty inbox item', { itemId: item.id })
+    inboxSync.enqueueUpdate(item.id)
+  }
+
+  return dirtyItems.length
 }
 
 /**

--- a/apps/docs/src/user-guide/inbox/triage.md
+++ b/apps/docs/src/user-guide/inbox/triage.md
@@ -37,6 +37,12 @@ Each card shows:
 | **Open**                | Open the source URL in your browser.                                                                                                                  |
 | **Delete**              | Discard. (Confirms first.)                                                                                                                            |
 
+## Triage Decisions Across Devices
+
+Filing, archiving, and snoozing **sync across your devices**, like the item itself. File a web clip on your laptop and it leaves the inbox on your desktop too, once both have synced — you only triage an item once.
+
+If a device is offline when you file, the decision is queued and pushes on its next sync. Until then that device's inbox is simply behind; nothing is lost.
+
 ## Keyboard Shortcuts
 
 When the inbox or a triage card has focus:

--- a/apps/docs/src/user-guide/inbox/triage.md
+++ b/apps/docs/src/user-guide/inbox/triage.md
@@ -43,6 +43,8 @@ Filing, archiving, and snoozing **sync across your devices**, like the item itse
 
 If a device is offline when you file, the decision is queued and pushes on its next sync. Until then that device's inbox is simply behind; nothing is lost.
 
+Items you filed on an older version of Memry are repaired automatically: the first time each device starts up and syncs after updating, it sends any triage decision that never reached your other devices. You do not need to re-file anything.
+
 ## Keyboard Shortcuts
 
 When the inbox or a triage card has focus:


### PR DESCRIPTION
Fixes #1159

## Summary

`markItemAsFiled()` wrote `filedAt` / `filedTo` / `filedAction`, published the projection event and emitted the `FILED` IPC event — but never enqueued a sync push. `filing.ts` did not import `syncInboxUpdate` at all. All 8 filing paths funnel through that one function, so **no form of filing reached another device**, while undo-file, snooze, archive, create, update and delete all pushed.

The reporter's second symptom follows from the same omission. `buildPushPayload` ships the whole row, so a peer that never learned the item was filed still holds `filedAt: null` and pushes that row on its own next change to the item. `applyUpsert` reads a present-and-null `filedAt` as the deliberate remote unfile clear (the `hasKey` semantics from #955), so the origin device wipes its own filed state — the item reappears on the very device that filed it.

**The fix:** route the write through `syncInboxUpdate(itemId)`, which enqueues the push *and* publishes the same projection. It also fires `emitCalendarProjectionChanged` / `scheduleGoogleCalendarSourceSync`, which filing genuinely wants since it clears `snoozedUntil` — a second, quieter gap that closes for free.

Best-effort like `convertToTask`'s enqueue (#973): a sync outage must not fail a filing that already succeeded locally. One addition — the catch republishes via `publishInboxUpserted`, because a throw inside `syncInboxUpdate` happens *before* its own projection publish and would otherwise leave the local Inbox list stale.

## Compat

No payload, schema or protocol change. An older peer just starts receiving filed rows it already knows how to apply — #955 hardened that apply side. Nothing new is required of older builds.

## Guard test

`src/main/inbox/sync-enqueue-guard.test.ts` scans every non-test file under `src/main/inbox/`, slices out `update(inboxItems)` / `insert(inboxItems)` statements up to `.run()`, and fails any file that writes a **triage column** (`filedAt`, `filedTo`, `filedAction`, `archivedAt`, `snoozedUntil`, `snoozeReason`) without referencing `syncInbox(Create|Update|Delete)`. Statement slicing matters — those column names appear in plenty of selects and filters.

Mutation-verified: strip the fix and it reports `['filing.ts']`.

### Why triage columns and not every write

The issue floated "every write to `inboxItems` either enqueues a push or is explicitly listed as local-only". `capture.ts`, `jobs.ts`, `ingest.ts` and `transcription.ts` all write `inboxItems` without enqueuing — allowlisting them would assert they are local-only, which is false. They are a real but milder gap (enrichment rides along on the row's next syncing write; only a never-touched-again item stays diverged), tracked separately rather than papered over here.

## Release note

Filing an item in the Inbox now syncs to your other devices. Previously a filed item stayed filed only on the device you filed it from, and could reappear in the Inbox there once another device synced.

## Test plan

- 9 new tests in `filing.test.ts`, one per filing path (folder text + binary, note, task, event, reminder, link text + binary) plus an enqueue-throws resilience case asserting the filing persists, the projection is still published and the failure is counted. Verified RED first — 9/9 failed before the fix.
- `pnpm exec vitest run --config config/vitest.config.ts --project main` — 5452 passed, 0 failed, 4 skipped
- `pnpm lint` — 0 errors (15 pre-existing warnings)
- `pnpm --filter @memry/desktop typecheck:node`, `pnpm check:architecture`, `pnpm check:contracts` — pass
- `pnpm docs:impact --base origin/main --strict` — covered; `pnpm docs:build` — pass
- `git diff --check` — clean
