### PR TITLE
fix(sync): back off exponentially between UploadQueue network retries

### DIFF
--- a/apps/desktop/src/main/sync/upload-queue.test.ts
+++ b/apps/desktop/src/main/sync/upload-queue.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { EventEmitter } from 'node:events'
 import { UploadQueue, type UploadFn } from './upload-queue'
 import { NetworkError, RateLimitError } from './http-client'
@@ -39,6 +39,10 @@ describe('UploadQueue', () => {
   beforeEach(() => {
     uploadFn = makeUploadFn(10)
     queue = new UploadQueue(uploadFn)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('caps concurrent uploads to 3', async () => {
@@ -214,6 +218,109 @@ describe('UploadQueue', () => {
       ;(monitor as unknown as { setOnline: (v: boolean) => void }).setOnline(false)
       await new Promise((r) => setTimeout(r, 20))
       expect(drainSpy.mock.calls.length).toBe(callsAfterEvent)
+    })
+
+    it('backs off exponentially between NetworkError retries and caps the delay at 60s', async () => {
+      // #given — an upload that is unreachable for its first 8 attempts. The
+      // bound matters: without backoff the re-queue loop is pure microtasks and
+      // an unbounded failure would starve the timers instead of failing.
+      vi.useFakeTimers()
+      let calls = 0
+      const fn: UploadFn = vi.fn(async (noteId: string) => {
+        calls++
+        if (calls <= 8) throw new NetworkError('offline')
+        return { attachmentId: `att-${noteId}`, sessionId: `sess-${noteId}`, manifest: {} as never }
+      })
+      const q = new UploadQueue(fn)
+
+      // #when
+      const pending = q.enqueue('n1', '/p1')
+      await vi.advanceTimersByTimeAsync(0)
+
+      // #then — one attempt, then each retry waits its exact backoff
+      expect(calls).toBe(1)
+
+      // 1s, 2s, 4s, 8s, 16s, 32s, then the 60s ceiling (not 64s, not 128s)
+      const expectedDelaysMs = [1000, 2000, 4000, 8000, 16_000, 32_000, 60_000, 60_000]
+      for (let i = 0; i < expectedDelaysMs.length; i++) {
+        await vi.advanceTimersByTimeAsync(expectedDelaysMs[i] - 1)
+        expect(calls).toBe(i + 1)
+        await vi.advanceTimersByTimeAsync(1)
+        expect(calls).toBe(i + 2)
+      }
+
+      // the caller's promise settles — the item is never dropped
+      await expect(pending).resolves.toMatchObject({ attachmentId: 'att-n1' })
+    })
+
+    it('resumes immediately on reconnect and resets the escalated backoff', async () => {
+      // #given — offline, escalated all the way to the 60s ceiling
+      vi.useFakeTimers()
+      let calls = 0
+      const fn: UploadFn = vi.fn(async (noteId: string) => {
+        calls++
+        if (calls <= 12) throw new NetworkError('offline')
+        return { attachmentId: `att-${noteId}`, sessionId: `sess-${noteId}`, manifest: {} as never }
+      })
+      const monitor = createMockNetworkMonitor(false)
+      const q = new UploadQueue(fn, monitor)
+
+      const pending = q.enqueue('n1', '/p1')
+      await vi.advanceTimersByTimeAsync(0)
+      for (const delay of [1000, 2000, 4000, 8000, 16_000, 32_000]) {
+        await vi.advanceTimersByTimeAsync(delay)
+      }
+      expect(calls).toBe(7)
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(calls).toBe(7)
+
+      // #when — network comes back halfway through the 60s ceiling wait
+      ;(monitor as unknown as { setOnline: (v: boolean) => void }).setOnline(true)
+      await vi.advanceTimersByTimeAsync(0)
+
+      // #then — retried at once, not after the remaining 30s
+      expect(calls).toBe(8)
+
+      // and the escalation is reset: the next retry is 1s again, not 60s
+      await vi.advanceTimersByTimeAsync(999)
+      expect(calls).toBe(8)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(calls).toBe(9)
+
+      await vi.advanceTimersByTimeAsync(120_000)
+      await expect(pending).resolves.toMatchObject({ attachmentId: 'att-n1' })
+    })
+
+    it('a successful transfer clears the network backoff holding the rest of the queue', async () => {
+      // #given — n1 is unreachable, n2 succeeds 500ms in
+      vi.useFakeTimers()
+      let n1Calls = 0
+      const fn: UploadFn = vi.fn(async (noteId: string) => {
+        if (noteId === 'n1') {
+          n1Calls++
+          if (n1Calls <= 5) throw new NetworkError('offline')
+        } else {
+          await new Promise((r) => setTimeout(r, 500))
+        }
+        return { attachmentId: `att-${noteId}`, sessionId: `sess-${noteId}`, manifest: {} as never }
+      })
+      const q = new UploadQueue(fn)
+
+      const p1 = q.enqueue('n1', '/p1')
+      const p2 = q.enqueue('n2', '/p2')
+      await vi.advanceTimersByTimeAsync(0)
+      expect(n1Calls).toBe(1)
+
+      // #when — n2 completes at t=500, inside n1's 1000ms network backoff
+      await vi.advanceTimersByTimeAsync(500)
+      await vi.advanceTimersByTimeAsync(0)
+
+      // #then — the proven-good network releases the queue straight away
+      await expect(p2).resolves.toMatchObject({ attachmentId: 'att-n2' })
+      expect(n1Calls).toBe(2)
+
+      await vi.advanceTimersByTimeAsync(300_000)
+      await expect(p1).resolves.toMatchObject({ attachmentId: 'att-n1' })
     })
 
     it('dispose() stops listening without nuking other listeners', async () => {

--- a/apps/desktop/src/main/sync/upload-queue.ts
+++ b/apps/desktop/src/main/sync/upload-queue.ts
@@ -1,12 +1,18 @@
 import { createLogger } from '../lib/logger'
 import { NetworkError, RateLimitError } from './http-client'
-import { sleep } from './retry'
 import type { NetworkMonitor } from './network'
 import type { ProgressCallback, UploadResult } from './attachments'
 
 const log = createLogger('UploadQueue')
 
 const MAX_CONCURRENT_UPLOADS = 3
+// A NetworkError is transient by definition — the machine is offline or the
+// server is unreachable — so the item is NEVER dropped, only slowed down.
+// Delays go 1s, 2s, 4s, 8s, 16s, 32s and then sit on the ceiling forever.
+// Without this the re-queue below spun the CPU (and re-encrypted the whole
+// attachment) as fast as the transfer could fail.
+const NETWORK_BASE_BACKOFF_MS = 1000
+const NETWORK_MAX_BACKOFF_MS = 60_000
 
 export type UploadFn = (
   noteId: string,
@@ -19,6 +25,7 @@ interface QueueItem {
   noteId: string
   filePath: string
   onProgress?: ProgressCallback
+  networkAttempts: number
   resolve: (result: UploadResult) => void
   reject: (error: Error) => void
 }
@@ -27,6 +34,8 @@ export class UploadQueue {
   private queue: QueueItem[] = []
   private running = 0
   private backoffUntil = 0
+  private networkBackoffUntil = 0
+  private wakeBackoff: (() => void) | null = null
   private draining = false
   private readonly uploadFn: UploadFn
   private readonly network?: NetworkMonitor
@@ -38,7 +47,13 @@ export class UploadQueue {
 
     if (network) {
       this.boundHandler = (ev: { online: boolean }) => {
-        if (ev.online && this.queue.length > 0) {
+        if (!ev.online) return
+        // A reconnect makes every escalated delay stale. Clear the per-item
+        // counts too, otherwise someone who was offline overnight comes back
+        // and still waits out a ceiling-length backoff before anything moves.
+        for (const queued of this.queue) queued.networkAttempts = 0
+        this.resetNetworkBackoff()
+        if (this.queue.length > 0) {
           log.info('network restored, draining upload queue', { pending: this.queue.length })
           void this.drain()
         }
@@ -49,7 +64,7 @@ export class UploadQueue {
 
   enqueue(noteId: string, filePath: string, onProgress?: ProgressCallback): Promise<UploadResult> {
     return new Promise<UploadResult>((resolve, reject) => {
-      this.queue.push({ noteId, filePath, onProgress, resolve, reject })
+      this.queue.push({ noteId, filePath, onProgress, networkAttempts: 0, resolve, reject })
       log.debug('enqueued upload', { noteId, queueLength: this.queue.length })
       void this.drain()
     })
@@ -85,10 +100,11 @@ export class UploadQueue {
     try {
       while (this.queue.length > 0 && this.running < MAX_CONCURRENT_UPLOADS) {
         const now = Date.now()
-        if (this.backoffUntil > now) {
-          const waitMs = this.backoffUntil - now
+        const resumeAt = Math.max(this.backoffUntil, this.networkBackoffUntil)
+        if (resumeAt > now) {
+          const waitMs = resumeAt - now
           log.info('global backoff active', { waitMs })
-          await sleep(waitMs)
+          await this.waitForBackoff(waitMs)
           continue
         }
 
@@ -106,11 +122,35 @@ export class UploadQueue {
     }
   }
 
+  /** Interruptible backoff wait — resolves early when the network comes back. */
+  private waitForBackoff(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.wakeBackoff = null
+        resolve()
+      }, ms)
+      this.wakeBackoff = () => {
+        clearTimeout(timer)
+        this.wakeBackoff = null
+        resolve()
+      }
+    })
+  }
+
+  /** Drop the shared network wait and let a sleeping drain() proceed at once. */
+  private resetNetworkBackoff(): void {
+    this.networkBackoffUntil = 0
+    this.wakeBackoff?.()
+  }
+
   private async processItem(item: QueueItem): Promise<void> {
     try {
       const result = await this.uploadFn(item.noteId, item.filePath, item.onProgress, {
         isOnline: this.network ? () => this.network!.online : undefined
       })
+      // A completed transfer proves the network works, so nothing should still
+      // be sitting behind a network backoff another item scheduled.
+      this.resetNetworkBackoff()
       item.resolve(result)
     } catch (err) {
       if (err instanceof RateLimitError) {
@@ -122,7 +162,17 @@ export class UploadQueue {
         return
       }
       if (err instanceof NetworkError) {
-        log.warn('network error, re-queuing upload', { noteId: item.noteId })
+        item.networkAttempts++
+        const backoffMs = Math.min(
+          NETWORK_BASE_BACKOFF_MS * 2 ** (item.networkAttempts - 1),
+          NETWORK_MAX_BACKOFF_MS
+        )
+        this.networkBackoffUntil = Math.max(this.networkBackoffUntil, Date.now() + backoffMs)
+        log.warn('network error, re-queuing upload with backoff', {
+          noteId: item.noteId,
+          attempt: item.networkAttempts,
+          backoffMs
+        })
         this.queue.unshift(item)
         return
       }

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -91,6 +91,8 @@ If a file is over your plan's per-file limit, MemryNote tells you before it spen
 
 If an attachment can't be uploaded, you get a notification naming the file. The file is never lost: it stays in `<vault>/attachments/` and the note keeps working on this device. Only the synced copy is missing, so other devices won't see it until the upload succeeds.
 
+When the upload fails because you're offline or the server is unreachable, MemryNote keeps retrying rather than giving up — being offline for a day is normal, and the queued upload is never discarded. Each retry waits a little longer than the last (one second, then two, four, and so on up to a minute) so a long offline stretch doesn't burn battery re-encrypting the file over and over. As soon as the network comes back, the wait is abandoned and everything queued is retried straight away.
+
 ## Garbage Collection
 
 Files that are no longer referenced by any note are pruned during periodic vacuum. You don't need to clean them up manually.


### PR DESCRIPTION
## Problem

`UploadQueue.processItem` treated a `NetworkError` as "put it back and try again", with no delay and no attempt count:

```ts
if (err instanceof NetworkError) {
  log.warn('network error, re-queuing upload', { noteId: item.noteId })
  this.queue.unshift(item)
  return
}
```

`processItem`'s `.finally()` calls `drain()`, `drain()` shifts the item straight back off the head, and the cycle repeats on the next microtask. While the network is down this is an unbounded hot loop, and every cycle re-runs the *entire* `uploadAttachment` pipeline — `readFileChunks`, a SHA-256 pass, and an XChaCha20 encrypt of the whole attachment — for a request that cannot succeed.

Reproduced on current `origin/main` before any code change: a queue whose upload fn throws `NetworkError` reached **9 attempts inside a single microtask drain, with zero fake time elapsed** (`AssertionError: expected 9 to be 1`). The issue is valid as filed; only the line numbers had drifted.

## Root cause

The 429 path already had a shared `backoffUntil`; the `NetworkError` path had nothing. There was no per-item state to escalate from and nothing to make `drain()` wait.

## Fix

`apps/desktop/src/main/sync/upload-queue.ts` only.

- `QueueItem` gains an in-memory `networkAttempts` counter.
- On `NetworkError`, the item's count increments and schedules a shared `networkBackoffUntil` of `min(1000 * 2^(n-1), 60_000)`.
- `drain()` waits on `max(backoffUntil, networkBackoffUntil)`. The two are kept separate on purpose so clearing a network wait can never cut a rate-limit wait short.
- The wait is interruptible (`waitForBackoff` keeps a `wakeBackoff` resolver) instead of the previous fire-and-forget `sleep`, so a reset takes effect immediately rather than after the current sleep expires.

### Delay sequence and ceiling

**1s → 2s → 4s → 8s → 16s → 32s → 60s → 60s → …** — ceiling `NETWORK_MAX_BACKOFF_MS = 60_000`, held forever. Both the sequence and the ceiling are asserted exactly, not just "some nonzero delay".

### Where backoff resets

1. **On a successful transfer** — `processItem`'s success path calls `resetNetworkBackoff()`. A completed upload proves the network works, so nothing else should stay parked behind a wait some other item scheduled. It deliberately does **not** reset other items' counters: an item that keeps timing out on its own (an oversized file on a slow link) must keep escalating even while its neighbours succeed, or it becomes a hot loop again.
2. **On a network-restored event** — the `status-changed` handler clears the shared wait *and* every queued item's `networkAttempts`, then drains. Without the counter reset, someone offline overnight would come back and still sit out a full 60s at the ceiling before anything moved. The interruptible wait is what makes the resume immediate rather than "at the end of the current 60s".

### Transient vs permanent

| Error | Treatment | Why |
| --- | --- | --- |
| `NetworkError` | Retry forever with escalating backoff | Transient — the machine is offline or the server is unreachable. Being offline is normal and can last days. |
| `RateLimitError` (429) | Existing shared `Retry-After` backoff, unchanged | Transient, and the server tells us how long. |
| 4xx `SyncServerError`, `AttachmentTooLargeError`, everything else | Rejected to the caller immediately, unchanged | Permanent — retrying cannot help. `withRetry` already throws non-429 4xx without retrying, and those surface here as non-`NetworkError` and reject. |

### No user item is ever dropped

Confirmed explicitly. There is **no attempt cap and no discard path**. An item that keeps failing with `NetworkError` stays at the head of the queue and is retried at most once a minute, forever, until it succeeds or `clear()`/`dispose()` tears the queue down at vault switch. The caller's promise is not rejected on a network failure — that behaviour is unchanged from before this PR, and deliberately so: `getCanvasAssetIO()` and the `UPLOAD_ATTACHMENT` IPC handler enqueue with **no** durable outbox row behind them, so rejecting a queued upload after N tries would silently strand a canvas asset the user believes is synced. The durable `attachment_upload_queue` row (for the `attachmentEvents.onSaved` path) is likewise untouched and still survives restarts.

## Test evidence

`apps/desktop/src/main/sync/upload-queue.test.ts`, three new fake-timer tests (no wall-clock timing anywhere, so nothing to flake in CI). Each failing upload fn is bounded so that on unfixed code the microtask storm terminates and *fails* instead of hanging the runner.

RED, before the fix:

```
PASS (10) FAIL (3)
1. backs off exponentially between NetworkError retries and caps the delay at 60s
   AssertionError: expected 9 to be 1
2. resumes immediately on reconnect and resets the escalated backoff
   AssertionError: expected 13 to be 7
3. a successful transfer clears the network backoff holding the rest of the queue
   AssertionError: expected 6 to be 1
```

GREEN, after: `PASS (13) FAIL (0)`.

### Mutation verification

Five single-line mutations, each reverting exactly one behavioural line (targets verified by line number, not by text substitution that could also hit a comment). **No survivors:**

| # | Mutation | Result |
| --- | --- | --- |
| M1 | `NETWORK_BASE_BACKOFF_MS * 2 ** (n-1)` → `NETWORK_BASE_BACKOFF_MS` (flat delay) | `FAIL (2)` |
| M2 | `NETWORK_MAX_BACKOFF_MS` → `Number.MAX_SAFE_INTEGER` (no ceiling) | `FAIL (1)` |
| M3 | drop `this.wakeBackoff?.()` (non-interruptible wait) | `FAIL (2)` |
| M4 | drop `resetNetworkBackoff()` from the success path | `FAIL (1)` |
| M5 | drop the per-item counter reset on reconnect | `FAIL (1)` |

M3 is killed by two tests and M1 by two, but neither pair is redundant: dropping the ceiling (M2) is caught only by the sequence test, and the reconnect test separately distinguishes the wake (immediate resume) from the counter reset (next delay back to 1s), so each line carries behaviour of its own.

## Verification

```
pnpm typecheck                       16 successful, 16 total
pnpm lint                            15 problems (0 errors, 15 warnings)  — all pre-existing, none in changed files
pnpm --filter @memry/desktop test:main
                                     Test Files  477 passed | 1 skipped (478)
                                     Tests  5443 passed | 1 expected fail | 4 skipped (5448)
git diff --check                     clean
pnpm docs:impact --base origin/main --strict
                                     docs impact: covered against origin/main
pnpm docs:build                      build complete in 53.41s
```

No contracts, preload or IPC handler changes, so `ipc:generate`/`ipc:check` are not implicated — `pnpm typecheck` runs `rpc:check` and the IPC invoke map check and both reported up to date.

## Risk and backward compatibility

**No migration is needed, and none is included.** `networkAttempts`, `networkBackoffUntil` and `wakeBackoff` are all in-memory fields on a runtime object that is rebuilt on every launch. No SQLite column, no schema change, no persisted shape. The durable `attachment_upload_queue` table, its `attempts` column, the sync protocol, IPC contracts, vault file formats and settings shapes are all untouched, so rows and payloads written by older app versions are read and processed exactly as before, and a downgrade to an older build reads nothing new.

Behavioural risk is limited to timing: an upload that hits a network failure now waits 1–60s before retrying instead of retrying instantly. That is strictly less work, never more. The 429 path is untouched and is kept in its own field so it cannot be shortened by a network-side reset. The `sleep` import became unused once `drain()` moved to the interruptible wait and was removed; nothing else in the file used it.

## Relationship to neighbouring work

- **#1029** (`withRetry` retries `NetworkError` with zero delay when `isOnline` is not supplied) is the same failure mode one layer down, and the two overlap on this path: `UploadQueue` reaches the network through `AttachmentSyncService`, which wraps each request in `withRetry`. This PR deliberately leaves `retry.ts` alone and confines itself to the queue's own re-queue loop. Note the two are not substitutes: `withRetry` dead-letters into a `DeadLetterError`, which this queue rejects as permanent, so only a bare `NetworkError` escaping `withRetry` (its `MAX_OFFLINE_WAIT_MS` throw at `retry.ts:108-110`) lands in the branch fixed here. #1029 still needs its own fix for the callers that omit `isOnline`.
- **#1162** (`attachment-sync-active-map-cleanup`, open) is not touched. Its analysis is what confirmed the design constraint here: uploads are durably retried via `attachment_upload_queue` + `drainAttachmentOutbox()`, and each retry mints a fresh `attachmentId`/`sessionId` — so repeated retries do not accumulate server-side session state, and slowing the cadence costs nothing but latency.

Closes #1028
