### PR TITLE
perf(tasks): derive workspace badge counts in a single pass

### DIFF
--- a/apps/desktop/src/renderer/src/App.test.tsx
+++ b/apps/desktop/src/renderer/src/App.test.tsx
@@ -82,7 +82,10 @@ vi.mock('@/data/tasks-data', () => ({
 }))
 
 vi.mock('@/lib/task-utils', () => ({
-  getFilteredTasks: (allTasks: unknown[]) => allTasks
+  getTaskWorkspaceCounts: (allTasks: unknown[], _projects: unknown[], viewIds: string[]) => ({
+    viewCounts: Object.fromEntries(viewIds.map((id) => [id, allTasks.length])),
+    projectTaskCounts: {}
+  })
 }))
 
 vi.mock('@/services/tasks-service', () => ({

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -72,7 +72,7 @@ import { createLogger } from '@/lib/logger'
 import { getStartupTheme, THEME_STORAGE_KEY } from '@/lib/startup-theme'
 import { useTaskWorkspaceData, useTaskWorkspaceMutations } from '@/features/tasks/use-task-queries'
 import { useTaskUiStore } from '@/features/tasks/use-task-ui-store'
-import { getFilteredTasks } from '@/lib/task-utils'
+import { getTaskWorkspaceCounts } from '@/lib/task-utils'
 import { useAgentMcpCurrentNoteResponder } from '@/agent-mcp/current-note-handler'
 import { useAgentMcpDesktopApiResponder } from '@/agent-mcp/desktop-api-handler'
 import { useAgentMcpCanvasWriteResponder } from '@/agent-mcp/canvas-write-handler'
@@ -93,6 +93,9 @@ export type TaskSelectionType = 'view' | 'project'
 
 // Combined page type for routing
 export type AppPage = BasePage | 'tasks' | 'home'
+
+// Sidebar badge ids, hoisted so the count pass gets a stable input array.
+const taskViewIds = taskViews.map((view) => view.id)
 
 // =============================================================================
 // THEME SYNC MANAGER (inside ThemeProvider)
@@ -397,27 +400,21 @@ function App(): React.JSX.Element {
     selectedTaskIdsRef.current = selectedTaskIds
   }, [selectedTaskIds])
 
-  // Calculate view counts dynamically
-  const viewCounts = useMemo(() => {
-    const counts: Record<string, number> = {}
-    taskViews.forEach((view) => {
-      const filtered = getFilteredTasks(tasks, view.id, 'view', projects)
-      counts[view.id] = filtered.length
-    })
-    return counts
-  }, [tasks, projects])
+  // Calculate view counts and project task counts in a single pass over the
+  // tasks. Both recompute on every task mutation, so re-filtering the whole list
+  // once per view and once per project is the wrong shape at this level.
+  const { viewCounts, projectTaskCounts } = useMemo(
+    () => getTaskWorkspaceCounts(tasks, projects, taskViewIds),
+    [tasks, projects]
+  )
 
   // Update project task counts
   const projectsWithCounts = useMemo(() => {
-    return projects.map((project) => {
-      const projectTasks = tasks.filter((t) => t.projectId === project.id)
-      const incompleteTasks = projectTasks.filter((t) => {
-        const status = project.statuses.find((s) => s.id === t.statusId)
-        return status?.type !== 'done'
-      })
-      return { ...project, taskCount: incompleteTasks.length }
-    })
-  }, [projects, tasks])
+    return projects.map((project) => ({
+      ...project,
+      taskCount: projectTaskCounts[project.id] ?? 0
+    }))
+  }, [projects, projectTaskCounts])
 
   const taskOrder = useTaskOrder({ persist: true })
 

--- a/apps/desktop/src/renderer/src/App.workspace-counts.test.tsx
+++ b/apps/desktop/src/renderer/src/App.workspace-counts.test.tsx
@@ -1,0 +1,337 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import App from './App'
+import { taskViews } from '@/data/tasks-data'
+
+/**
+ * Measures the work the App root performs to produce the sidebar view badges and
+ * the per-project task counts. Both counters feed `TasksProvider` / `AppSidebar` /
+ * `TaskDragOverlay` and recompute on every task mutation, so the cost has to stay
+ * proportional to the task list — not to (views x tasks x projects).
+ *
+ * The probe counts reads of `task.projectId`, which is the lookup key every
+ * incomplete/complete decision needs. One read per task per recompute means one
+ * pass; more means the counts are being derived by re-filtering the whole list
+ * once per view and once per project.
+ */
+let projectIdReads = 0
+
+interface ProbeTask {
+  id: string
+  title: string
+  projectId: string
+  statusId: string
+  parentId: string | null
+  dueDate: Date | null
+  archivedAt: Date | null
+}
+
+function makeTask(overrides: Partial<ProbeTask> & { id: string }): ProbeTask {
+  const task: ProbeTask = {
+    title: overrides.id,
+    projectId: 'project-a',
+    statusId: 'todo',
+    parentId: null,
+    dueDate: null,
+    archivedAt: null,
+    ...overrides
+  }
+
+  const projectId = task.projectId
+  Object.defineProperty(task, 'projectId', {
+    get() {
+      projectIdReads += 1
+      return projectId
+    },
+    enumerable: true,
+    configurable: true
+  })
+
+  return task
+}
+
+const YESTERDAY = new Date(Date.now() - 24 * 60 * 60 * 1000)
+
+function makeTasks(): ProbeTask[] {
+  return [
+    makeTask({ id: 'a-open', projectId: 'project-a', statusId: 'todo', dueDate: YESTERDAY }),
+    makeTask({ id: 'a-open-sub', projectId: 'project-a', statusId: 'todo', parentId: 'a-open' }),
+    makeTask({ id: 'a-done', projectId: 'project-a', statusId: 'done' }),
+    makeTask({ id: 'b-open', projectId: 'project-b', statusId: 'todo' }),
+    makeTask({ id: 'b-done', projectId: 'project-b', statusId: 'done' }),
+    makeTask({
+      id: 'b-archived',
+      projectId: 'project-b',
+      statusId: 'todo',
+      archivedAt: YESTERDAY
+    })
+  ]
+}
+
+function makeProjects(): unknown[] {
+  return [
+    {
+      id: 'project-a',
+      name: 'Alpha',
+      statuses: [
+        { id: 'todo', type: 'todo' },
+        { id: 'done', type: 'done' }
+      ]
+    },
+    {
+      id: 'project-b',
+      name: 'Beta',
+      statuses: [
+        { id: 'todo', type: 'todo' },
+        { id: 'done', type: 'done' }
+      ]
+    }
+  ]
+}
+
+let tasks: ProbeTask[] = makeTasks()
+let projects: unknown[] = makeProjects()
+
+let sidebarRenders = 0
+let belowProviderRenders = 0
+let lastViewCounts: Record<string, number> = {}
+let lastProjectCounts: Record<string, number> = {}
+
+const openTab = vi.fn()
+const openSettings = vi.fn()
+const createNote = vi.fn()
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ clear: vi.fn() })
+}))
+
+vi.mock('next-themes', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useTheme: () => ({ setTheme: vi.fn() })
+}))
+
+vi.mock('@/lib/icons', () => ({
+  Loader2: () => <div data-testid="loader" />
+}))
+
+vi.mock('@/lib/startup-theme', () => ({
+  THEME_STORAGE_KEY: 'theme',
+  getStartupTheme: () => 'system'
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })
+}))
+
+vi.mock('@/lib/telemetry', () => ({
+  trackTelemetry: vi.fn()
+}))
+
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: { reorderProjects: vi.fn() },
+  queueTaskReorder: vi.fn()
+}))
+
+vi.mock('@/services/notes-service', () => ({
+  notesService: { create: (...args: unknown[]) => createNote(...args) }
+}))
+
+vi.mock('@/hooks', () => ({
+  useTabKeyboardShortcuts: vi.fn(),
+  useMouseNavButtons: vi.fn(),
+  useChordShortcuts: () => true,
+  useSettingsShortcut: vi.fn(),
+  useNewNoteShortcut: vi.fn(),
+  useUndoKeyboardShortcut: vi.fn(),
+  useReminderNotifications: vi.fn(),
+  useInboxReviewNotifications: vi.fn(),
+  useSearchShortcut: vi.fn(),
+  useHintActivation: vi.fn(),
+  useFolderViewEvents: vi.fn(),
+  useFlushOnQuit: vi.fn(),
+  useVault: () => ({ status: { isOpen: true, path: '/vault/a' }, isLoading: false }),
+  useTaskOrder: () => ({
+    applyOrderUpdates: vi.fn(),
+    getOrder: vi.fn(),
+    getOrderedTasks: vi.fn((input) => input)
+  }),
+  useDragHandlers: () => ({ handleDragEnd: vi.fn(), droppedPriorities: new Map() }),
+  isInputFocused: () => false
+}))
+
+vi.mock('@/hooks/use-folder-view-events', () => ({ useFolderViewEvents: vi.fn() }))
+vi.mock('@/hooks/use-flush-on-quit', () => ({ useFlushOnQuit: vi.fn() }))
+vi.mock('@/hooks/use-theme-sync', () => ({ useThemeSync: vi.fn() }))
+
+vi.mock('@/features/tasks/use-task-queries', () => ({
+  useTaskWorkspaceData: () => ({ tasks, projects }),
+  useTaskWorkspaceMutations: () => ({
+    setProjects: vi.fn(),
+    updateTask: vi.fn(),
+    deleteTask: vi.fn()
+  })
+}))
+
+vi.mock('@/features/tasks/use-task-ui-store', () => ({
+  useTaskUiStore: () => ({ selectedTaskIds: new Set<string>(), setSelectedTaskIds: vi.fn() })
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  TabProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useTabs: () => ({ openTab }),
+  useActiveTab: () => ({ type: 'inbox' })
+}))
+
+vi.mock('@/contexts/tabs/persistence', () => ({
+  STORAGE_KEY: 'tabs-state',
+  useTabPersistence: vi.fn(),
+  useSessionRestore: vi.fn()
+}))
+
+vi.mock('@/contexts/tasks', () => ({
+  TasksProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/contexts/drag-context', () => ({
+  DragProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/contexts/dropped-priority-context', () => ({
+  DroppedPriorityProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/contexts/ai-inline-context', () => ({
+  AIInlineProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/contexts/day-panel-context', () => ({
+  DayPanelProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useDayPanel: () => ({ isOpen: false })
+}))
+
+vi.mock('@/contexts/calendar-view-context', () => ({
+  CalendarViewProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/contexts/sidebar-drill-down', () => ({
+  SidebarDrillDownProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/contexts/selected-folder-context', () => ({
+  SelectedFolderProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/contexts/hint-mode', () => ({
+  HintModeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/contexts/settings-modal-context', () => ({
+  SettingsModalProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSettingsModal: () => ({ open: openSettings })
+}))
+
+vi.mock('@/components/app-sidebar', () => ({
+  AppSidebar: ({ viewCounts }: { viewCounts: Record<string, number> }) => {
+    sidebarRenders += 1
+    lastViewCounts = viewCounts
+    return <aside data-testid="app-sidebar" />
+  }
+}))
+
+vi.mock('@/components/ui/sidebar', () => ({
+  SidebarProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SidebarInset: ({ children }: { children: React.ReactNode }) => <main>{children}</main>,
+  useSidebar: () => ({ toggleSidebar: vi.fn() })
+}))
+
+vi.mock('@/components/window-controls', () => ({ WindowControls: () => <div /> }))
+vi.mock('@/components/ui/sonner', () => ({ Toaster: () => <div /> }))
+vi.mock('@/components/day-panel', () => ({ GlobalDayPanel: () => <div /> }))
+
+vi.mock('@/components/tasks/drag-drop', () => ({
+  TaskDragOverlay: ({
+    projects: withCounts
+  }: {
+    projects: { id: string; taskCount: number }[]
+  }) => {
+    belowProviderRenders += 1
+    lastProjectCounts = Object.fromEntries(withCounts.map((p) => [p.id, p.taskCount]))
+    return <div data-testid="task-drag-overlay" />
+  }
+}))
+
+vi.mock('@/components/tabs', () => ({
+  TabDragProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TabErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/split-view', () => ({ SplitViewContainer: () => <div /> }))
+
+vi.mock('@/components/keyboard', () => ({
+  ChordIndicator: () => <div />,
+  KeyboardShortcutsDialog: () => <div />
+}))
+
+vi.mock('@/components/hint-overlay', () => ({
+  HintOverlay: () => <div />,
+  HintIndicator: () => <div />
+}))
+
+vi.mock('@/components/search/command-palette', () => ({ CommandPalette: () => <div /> }))
+vi.mock('@/components/settings-modal', () => ({ SettingsModal: () => <div /> }))
+vi.mock('@/components/vault-onboarding', () => ({ VaultOnboarding: () => <div /> }))
+
+describe('App workspace count computation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    tasks = makeTasks()
+    projects = makeProjects()
+    projectIdReads = 0
+    sidebarRenders = 0
+    belowProviderRenders = 0
+    lastViewCounts = {}
+    lastProjectCounts = {}
+    ;(
+      window as Window & { api: { onSettingsOpenRequested?: unknown } }
+    ).api.onSettingsOpenRequested = vi.fn(() => vi.fn())
+  })
+
+  it('derives every view badge and project badge from a single pass over the tasks', () => {
+    const { rerender } = render(<App />)
+
+    // A task mutation lands as a fresh array identity from the workspace query.
+    tasks = makeTasks()
+    projectIdReads = 0
+
+    rerender(<App />)
+
+    expect(projectIdReads).toBe(tasks.length)
+  })
+
+  it('keeps the exact counts the per-view filters produce', () => {
+    render(<App />)
+
+    expect(taskViews.map((view) => view.id)).toEqual(['all', 'today', 'completed'])
+    // all: a-open + a-open-sub + b-open
+    // today: a-open (overdue) + a-open-sub
+    // completed: a-done + b-done
+    expect(lastViewCounts).toEqual({ all: 3, today: 2, completed: 2 })
+    // project-a: a-open, a-open-sub | project-b: b-open, b-archived (archived still counts here)
+    expect(lastProjectCounts).toEqual({ 'project-a': 2, 'project-b': 2 })
+  })
+
+  it('recomputes the counts when a task changes', () => {
+    const { rerender } = render(<App />)
+    expect(lastViewCounts.all).toBe(3)
+
+    tasks = makeTasks().filter((task) => task.id !== 'b-open')
+    rerender(<App />)
+
+    expect(lastViewCounts).toEqual({ all: 2, today: 2, completed: 2 })
+    expect(lastProjectCounts).toEqual({ 'project-a': 2, 'project-b': 1 })
+    expect(sidebarRenders).toBeGreaterThan(0)
+    expect(belowProviderRenders).toBeGreaterThan(0)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/task-utils/index.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/index.ts
@@ -55,6 +55,8 @@ export {
 
 export {
   getFilteredTasks,
+  type TaskWorkspaceCounts,
+  getTaskWorkspaceCounts,
   type TaskCounts,
   getTaskCounts,
   formatTaskSubtitle,

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts
@@ -1,5 +1,5 @@
 import type { Task } from '@/data/task-model'
-import type { Project } from '@/data/tasks-data'
+import type { Project, StatusType } from '@/data/tasks-data'
 import {
   startOfDay,
   addDays,
@@ -109,6 +109,127 @@ export const getFilteredTasks = (
   }
 
   return includeSubtasksForMatchingParents(incompleteTopLevel, nonArchivedTasks)
+}
+
+// ============================================================================
+// WORKSPACE BADGE COUNTS (SINGLE PASS)
+// ============================================================================
+
+export interface TaskWorkspaceCounts {
+  /** Per view id, equal to `getFilteredTasks(tasks, viewId, 'view', projects).length`. */
+  viewCounts: Record<string, number>
+  /** Per `task.projectId`, the number of that project's tasks not in a `done` status. */
+  projectTaskCounts: Record<string, number>
+}
+
+/**
+ * Derives every sidebar view badge and every project badge in one pass over the
+ * task list.
+ *
+ * Calling `getFilteredTasks` once per view re-walks the whole list per view and,
+ * because its status lookup is `projects.find(...)` per task, costs
+ * O(views x tasks x projects) on every task mutation. This bucket-as-you-go
+ * version is O(tasks) after an O(projects x statuses) index build, and is exactly
+ * equivalent — the equivalence is asserted against `getFilteredTasks` in
+ * `task-workspace-counts.test.ts`.
+ */
+export const getTaskWorkspaceCounts = (
+  tasks: Task[],
+  projects: Project[],
+  viewIds: readonly string[]
+): TaskWorkspaceCounts => {
+  const statusTypesByProject = new Map<string, Map<string, StatusType>>()
+  for (const project of projects) {
+    const statusTypes = new Map<string, StatusType>()
+    for (const status of project.statuses) {
+      statusTypes.set(status.id, status.type)
+    }
+    statusTypesByProject.set(project.id, statusTypes)
+  }
+
+  const today = startOfDay(new Date())
+  const tomorrow = addDays(today, 1)
+  const weekFromNow = addDays(today, 7)
+  const weekEnd = endOfWeek(today)
+
+  const matchesView = (viewId: string, task: Task, isIncomplete: boolean): boolean => {
+    if (viewId === 'completed') return !isIncomplete
+    if (!isIncomplete) return false
+
+    switch (viewId) {
+      case 'today': {
+        if (!task.dueDate) return false
+        const taskDate = startOfDay(task.dueDate)
+        return isSameDay(taskDate, today) || isBefore(taskDate, today)
+      }
+
+      case 'upcoming': {
+        if (!task.dueDate) return false
+        const taskDate = startOfDay(task.dueDate)
+        return isAfter(taskDate, today) && !isAfter(taskDate, weekFromNow)
+      }
+
+      case 'tomorrow': {
+        if (!task.dueDate) return false
+        return isSameDay(startOfDay(task.dueDate), tomorrow)
+      }
+
+      case 'week': {
+        if (!task.dueDate) return false
+        const taskDate = startOfDay(task.dueDate)
+        return !isBefore(taskDate, today) && !isAfter(taskDate, weekEnd)
+      }
+
+      // 'all', and every unknown id, land on getFilteredTasks' default arm.
+      default:
+        return true
+    }
+  }
+
+  const viewCounts: Record<string, number> = {}
+  const matchedParentsByView = new Map<string, Set<string>>()
+  for (const viewId of viewIds) {
+    viewCounts[viewId] = 0
+    matchedParentsByView.set(viewId, new Set<string>())
+  }
+
+  const projectTaskCounts: Record<string, number> = {}
+  const nonArchivedSubtaskParentIds: string[] = []
+
+  for (const task of tasks) {
+    const projectId = task.projectId
+    const isIncomplete = statusTypesByProject.get(projectId)?.get(task.statusId) !== 'done'
+
+    if (isIncomplete) {
+      projectTaskCounts[projectId] = (projectTaskCounts[projectId] ?? 0) + 1
+    }
+
+    if (task.archivedAt) continue
+
+    if (task.parentId !== null) {
+      nonArchivedSubtaskParentIds.push(task.parentId)
+      continue
+    }
+
+    for (const viewId of viewIds) {
+      if (!matchesView(viewId, task, isIncomplete)) continue
+      viewCounts[viewId] += 1
+      matchedParentsByView.get(viewId)?.add(task.id)
+    }
+  }
+
+  // `getFilteredTasks` pulls in every non-archived subtask of a matching
+  // top-level task regardless of the subtask's own status, so the badges must
+  // too. Parents can appear after their subtasks, hence the second walk.
+  for (const parentId of nonArchivedSubtaskParentIds) {
+    for (const viewId of viewIds) {
+      if (matchedParentsByView.get(viewId)?.has(parentId)) {
+        viewCounts[viewId] += 1
+      }
+    }
+  }
+
+  return { viewCounts, projectTaskCounts }
 }
 
 // ============================================================================

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-workspace-counts.test.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-workspace-counts.test.ts
@@ -1,0 +1,356 @@
+/**
+ * getTaskWorkspaceCounts — the single-pass replacement for "call getFilteredTasks
+ * once per sidebar view, then filter the task list once per project".
+ *
+ * A badge that stops counting a task is indistinguishable from a lost task, so
+ * every assertion here is pinned against `getFilteredTasks` itself: whatever the
+ * real filter would show, the badge must show. The mutation matrix at the bottom
+ * walks every input that has to invalidate the counts.
+ */
+import { describe, it, expect } from 'vitest'
+import type { Task } from '@/data/task-model'
+import type { Project, StatusType } from '@/data/tasks-data'
+import { getFilteredTasks, getTaskWorkspaceCounts } from '.'
+import { addDays, startOfDay } from './task-date-utils'
+
+const ALL_VIEW_IDS = [
+  'all',
+  'today',
+  'upcoming',
+  'tomorrow',
+  'week',
+  'completed',
+  'some-future-view'
+] as const
+
+const TODAY = startOfDay(new Date())
+
+const createTask = (overrides: Partial<Task> & { id: string }): Task => ({
+  title: overrides.id,
+  description: '',
+  projectId: 'project-a',
+  statusId: 'todo',
+  priority: 'none',
+  dueDate: null,
+  dueTime: null,
+  isRepeating: false,
+  repeatConfig: null,
+  linkedNoteIds: [],
+  sourceNoteId: null,
+  tags: [],
+  parentId: null,
+  subtaskIds: [],
+  createdAt: TODAY,
+  completedAt: null,
+  archivedAt: null,
+  ...overrides
+})
+
+const createProject = (id: string, statuses: { id: string; type: StatusType }[]): Project => ({
+  id,
+  name: id,
+  description: '',
+  icon: 'folder',
+  color: '#000000',
+  statuses: statuses.map((status, order) => ({
+    id: status.id,
+    name: status.id,
+    color: '#000000',
+    type: status.type,
+    order
+  })),
+  isDefault: false,
+  isArchived: false,
+  createdAt: TODAY,
+  taskCount: 0
+})
+
+const projects: Project[] = [
+  createProject('project-a', [
+    { id: 'todo', type: 'todo' },
+    { id: 'doing', type: 'in_progress' },
+    { id: 'done', type: 'done' }
+  ]),
+  createProject('project-b', [
+    { id: 'todo', type: 'todo' },
+    { id: 'done', type: 'done' }
+  ])
+]
+
+/**
+ * Covers every branch the counts depend on: both projects, all three status
+ * types, overdue / today / tomorrow / this-week / next-week / no due date,
+ * subtasks under open and under completed parents, an archived task, a task
+ * pointing at a project that no longer exists, and a task whose status id is not
+ * in its project (both of which the filter treats as incomplete).
+ */
+const baselineTasks = (): Task[] => [
+  createTask({ id: 'overdue', dueDate: addDays(TODAY, -3) }),
+  createTask({ id: 'overdue-sub', parentId: 'overdue' }),
+  createTask({ id: 'due-today', dueDate: TODAY, statusId: 'doing' }),
+  createTask({ id: 'due-tomorrow', dueDate: addDays(TODAY, 1) }),
+  createTask({ id: 'due-in-3', dueDate: addDays(TODAY, 3) }),
+  createTask({ id: 'due-in-20', dueDate: addDays(TODAY, 20) }),
+  createTask({ id: 'no-due-date' }),
+  createTask({ id: 'done-a', statusId: 'done' }),
+  createTask({ id: 'done-a-sub', statusId: 'todo', parentId: 'done-a' }),
+  createTask({ id: 'b-open', projectId: 'project-b', dueDate: TODAY }),
+  createTask({ id: 'b-done', projectId: 'project-b', statusId: 'done' }),
+  createTask({
+    id: 'b-archived',
+    projectId: 'project-b',
+    dueDate: addDays(TODAY, -1),
+    archivedAt: TODAY
+  }),
+  createTask({ id: 'archived-sub', projectId: 'project-b', parentId: 'b-open', archivedAt: TODAY }),
+  createTask({ id: 'ghost-project', projectId: 'project-gone' }),
+  createTask({ id: 'ghost-status', statusId: 'status-gone' }),
+  createTask({ id: 'orphan-sub', parentId: 'never-existed' })
+]
+
+/** The exact expression App.tsx used before the single-pass rewrite. */
+const legacyProjectTaskCount = (tasks: Task[], project: Project): number =>
+  tasks
+    .filter((t) => t.projectId === project.id)
+    .filter((t) => project.statuses.find((s) => s.id === t.statusId)?.type !== 'done').length
+
+const expectMatchesFilters = (tasks: Task[], allProjects: Project[] = projects): void => {
+  const { viewCounts, projectTaskCounts } = getTaskWorkspaceCounts(tasks, allProjects, ALL_VIEW_IDS)
+
+  for (const viewId of ALL_VIEW_IDS) {
+    expect(`${viewId}:${viewCounts[viewId]}`).toBe(
+      `${viewId}:${getFilteredTasks(tasks, viewId, 'view', allProjects).length}`
+    )
+  }
+
+  for (const project of allProjects) {
+    expect(`${project.id}:${projectTaskCounts[project.id] ?? 0}`).toBe(
+      `${project.id}:${legacyProjectTaskCount(tasks, project)}`
+    )
+  }
+}
+
+describe('getTaskWorkspaceCounts', () => {
+  it('produces the exact badge numbers for the baseline workspace', () => {
+    const { viewCounts, projectTaskCounts } = getTaskWorkspaceCounts(
+      baselineTasks(),
+      projects,
+      ALL_VIEW_IDS
+    )
+
+    expect(viewCounts).toEqual({
+      // every incomplete top-level task (9) + subtasks of those (overdue-sub)
+      all: 10,
+      // overdue + due-today + b-open, plus overdue-sub riding along with overdue
+      today: 4,
+      // due-tomorrow + due-in-3 (due-in-20 is past the 7-day window)
+      upcoming: 2,
+      tomorrow: 1,
+      // today through end of week — date dependent, pinned against the filter below
+      week: getFilteredTasks(baselineTasks(), 'week', 'view', projects).length,
+      // done-a + b-done, plus done-a-sub riding along with done-a
+      completed: 3,
+      // an unknown id falls back to the same list as `all`
+      'some-future-view': 10
+    })
+
+    expect(projectTaskCounts).toEqual({
+      // project-a incomplete: overdue, overdue-sub, due-today, due-tomorrow,
+      // due-in-3, due-in-20, no-due-date, done-a-sub, ghost-status, orphan-sub
+      'project-a': 10,
+      // project-b incomplete: b-open, b-archived (archived still counts here),
+      // archived-sub
+      'project-b': 3,
+      'project-gone': 1
+    })
+  })
+
+  it('matches getFilteredTasks for every view on the baseline workspace', () => {
+    expectMatchesFilters(baselineTasks())
+  })
+
+  it('matches getFilteredTasks on an empty workspace', () => {
+    expectMatchesFilters([])
+    expect(getTaskWorkspaceCounts([], projects, ALL_VIEW_IDS).viewCounts).toEqual({
+      all: 0,
+      today: 0,
+      upcoming: 0,
+      tomorrow: 0,
+      week: 0,
+      completed: 0,
+      'some-future-view': 0
+    })
+  })
+
+  it('counts subtasks listed before their parent', () => {
+    const reversed = baselineTasks().reverse()
+
+    expect(getTaskWorkspaceCounts(reversed, projects, ALL_VIEW_IDS).viewCounts.all).toBe(10)
+    expectMatchesFilters(reversed)
+  })
+
+  it('reads each task once per recompute', () => {
+    const tasks = baselineTasks()
+    let projectIdReads = 0
+
+    const probed = tasks.map((task) => {
+      const { projectId, ...rest } = task
+      return Object.defineProperty({ ...rest } as Task, 'projectId', {
+        get() {
+          projectIdReads += 1
+          return projectId
+        },
+        enumerable: true,
+        configurable: true
+      })
+    })
+
+    getTaskWorkspaceCounts(probed, projects, ALL_VIEW_IDS)
+
+    expect(projectIdReads).toBe(tasks.length)
+  })
+})
+
+describe('getTaskWorkspaceCounts invalidation matrix', () => {
+  // Each entry is a mutation the workspace query can deliver — locally or as a
+  // field-level vector-clock update written by another device. After every one,
+  // the badges must still agree with getFilteredTasks, and the counts named in
+  // `changes` must actually move.
+  const mutations: {
+    name: string
+    apply: (tasks: Task[]) => Task[]
+    changes: Partial<Record<(typeof ALL_VIEW_IDS)[number] | 'project-a' | 'project-b', number>>
+  }[] = [
+    {
+      name: 'task created',
+      apply: (tasks) => [...tasks, createTask({ id: 'fresh', dueDate: TODAY })],
+      changes: { all: 11, today: 5, 'project-a': 11 }
+    },
+    {
+      name: 'task edited (title only)',
+      apply: (tasks) => tasks.map((t) => (t.id === 'overdue' ? { ...t, title: 'renamed' } : t)),
+      changes: {}
+    },
+    {
+      name: 'task completed',
+      apply: (tasks) =>
+        tasks.map((t) => (t.id === 'overdue' ? { ...t, statusId: 'done', completedAt: TODAY } : t)),
+      changes: { all: 8, today: 2, completed: 5, 'project-a': 9 }
+    },
+    {
+      name: 'task uncompleted',
+      apply: (tasks) =>
+        tasks.map((t) => (t.id === 'done-a' ? { ...t, statusId: 'todo', completedAt: null } : t)),
+      changes: { all: 12, completed: 1, 'project-a': 11 }
+    },
+    {
+      name: 'task deleted',
+      apply: (tasks) => tasks.filter((t) => t.id !== 'due-today'),
+      changes: { all: 9, today: 3, 'project-a': 9 }
+    },
+    {
+      name: 'parent deleted (its subtask stops riding along)',
+      apply: (tasks) => tasks.filter((t) => t.id !== 'overdue'),
+      changes: { all: 8, today: 2, 'project-a': 9 }
+    },
+    {
+      name: 'due date moved out of today',
+      apply: (tasks) =>
+        tasks.map((t) => (t.id === 'overdue' ? { ...t, dueDate: addDays(TODAY, 30) } : t)),
+      changes: { today: 2 }
+    },
+    {
+      name: 'due date cleared',
+      apply: (tasks) => tasks.map((t) => (t.id === 'due-today' ? { ...t, dueDate: null } : t)),
+      changes: { today: 3 }
+    },
+    {
+      name: 'project reassigned',
+      apply: (tasks) =>
+        tasks.map((t) =>
+          t.id === 'no-due-date' ? { ...t, projectId: 'project-b', statusId: 'todo' } : t
+        ),
+      changes: { 'project-a': 9, 'project-b': 4 }
+    },
+    {
+      name: 'status reassigned within the project',
+      apply: (tasks) => tasks.map((t) => (t.id === 'due-in-3' ? { ...t, statusId: 'doing' } : t)),
+      changes: {}
+    },
+    {
+      name: 'tags reassigned',
+      apply: (tasks) => tasks.map((t) => (t.id === 'b-open' ? { ...t, tags: ['home'] } : t)),
+      changes: {}
+    },
+    {
+      name: 'task archived',
+      apply: (tasks) => tasks.map((t) => (t.id === 'due-today' ? { ...t, archivedAt: TODAY } : t)),
+      changes: { all: 9, today: 3 }
+    },
+    {
+      name: 'task unarchived',
+      apply: (tasks) => tasks.map((t) => (t.id === 'b-archived' ? { ...t, archivedAt: null } : t)),
+      changes: { all: 11, today: 5 }
+    },
+    {
+      name: 'inbox item converted into a task',
+      apply: (tasks) => [
+        ...tasks,
+        createTask({ id: 'from-inbox', sourceNoteId: 'note-1', dueDate: addDays(TODAY, 1) })
+      ],
+      changes: { all: 11, upcoming: 3, tomorrow: 2, 'project-a': 11 }
+    },
+    {
+      name: 'remote device writes a subtask under an open parent',
+      apply: (tasks) => [...tasks, createTask({ id: 'remote-sub', parentId: 'due-today' })],
+      changes: { all: 11, today: 5, 'project-a': 11 }
+    }
+  ]
+
+  for (const mutation of mutations) {
+    it(`stays equal to getFilteredTasks after: ${mutation.name}`, () => {
+      const mutated = mutation.apply(baselineTasks())
+
+      expectMatchesFilters(mutated)
+
+      const { viewCounts, projectTaskCounts } = getTaskWorkspaceCounts(
+        mutated,
+        projects,
+        ALL_VIEW_IDS
+      )
+      for (const [key, expected] of Object.entries(mutation.changes)) {
+        const actual = key.startsWith('project-') ? projectTaskCounts[key] : viewCounts[key]
+        expect(`${mutation.name}/${key}:${actual}`).toBe(`${mutation.name}/${key}:${expected}`)
+      }
+    })
+  }
+
+  it('follows a project renaming its statuses', () => {
+    const renamedProjects = [
+      createProject('project-a', [
+        { id: 'todo', type: 'todo' },
+        { id: 'doing', type: 'todo' },
+        { id: 'done', type: 'todo' }
+      ]),
+      projects[1]
+    ]
+
+    expectMatchesFilters(baselineTasks(), renamedProjects)
+    // 'done' is no longer a done-type status, so done-a and its subtask move out
+    // of `completed` and into `all`.
+    expect(
+      getTaskWorkspaceCounts(baselineTasks(), renamedProjects, ALL_VIEW_IDS).viewCounts
+    ).toMatchObject({ all: 12, completed: 1 })
+  })
+
+  it('follows a project being removed from the workspace', () => {
+    const remaining = [projects[0]]
+
+    expectMatchesFilters(baselineTasks(), remaining)
+    // project-b's tasks have no project to resolve a status from, so they read as
+    // incomplete: b-open and b-done join `all`, and b-done leaves `completed`.
+    expect(
+      getTaskWorkspaceCounts(baselineTasks(), remaining, ALL_VIEW_IDS).viewCounts
+    ).toMatchObject({ all: 11, completed: 2 })
+  })
+})


### PR DESCRIPTION
## Problem

`App.tsx` recomputed two counters on **every** task mutation, both keyed off `[tasks, projects]`:

- `viewCounts` — `getFilteredTasks(tasks, view.id, 'view', projects)` once per entry in `taskViews`.
- `projectsWithCounts` — `tasks.filter(t => t.projectId === project.id)` once per project.

`getFilteredTasks` resolves each task's status with `projects.find(p => p.id === task.projectId)`, and it runs that predicate twice per view (once to build `incompleteTopLevel`, once for `completedTopLevel`). So the root paid **O(views × tasks × projects)** on every create / edit / complete / delete, and again on every sync-driven refetch.

## Validation (the premise was measured, not assumed)

`App.workspace-counts.test.tsx` renders the real `App` and counts reads of `task.projectId` — the lookup key every incomplete/complete decision needs — across one task change.

With 6 tasks / 2 projects / 3 views:

| | reads per task change |
|---|---|
| before | **54** |
| after | **6** (one per task) |

Attributed by stack: 42 from `task-view-helpers.ts:42` (`projects.find` inside `isIncomplete`), 12 from `App.tsx:413` (`tasks.filter` per project). The per-project term is why the cost is superlinear in *both* list lengths.

## Root cause

The badge counts were derived by re-running the full view filter, which returns task *lists* nobody at the root wants — only `.length` was ever read — and whose status lookup is a linear scan of `projects` per task.

## Fix

New `getTaskWorkspaceCounts(tasks, projects, viewIds)` in `lib/task-utils/task-view-helpers.ts`, next to `getFilteredTasks`:

- builds an `O(projects × statuses)` status-type index once,
- walks the task list **once**, bucketing each task into every matching view and into its project's incomplete count,
- walks the collected subtask parent ids once more (no task reads) so subtasks still ride along with a matching parent even when they appear before it in the array.

It mirrors `getFilteredTasks`' arms exactly, including the archived skip, the `default:` arm that makes unknown view ids behave like `all`, and treating a missing project or a missing status as incomplete. `App.tsx` now consumes one memo and maps `projectTaskCounts` onto the projects; `viewCounts` and `projectsWithCounts` keep their existing shapes and identical numbers.

## Test evidence

`apps/desktop/src/renderer/src/lib/task-utils/task-workspace-counts.test.ts` (22 tests) pins exact counts and asserts equivalence against `getFilteredTasks` itself for `all / today / upcoming / tomorrow / week / completed / <unknown id>` plus the pre-rewrite per-project expression, over a fixture with subtasks under open **and** completed parents, an archived task, an archived subtask, an orphan subtask, a task on a deleted project, and a task with a status id its project does not have.

**Every input that must invalidate the counts, each proven to still land** (each row re-asserts full equivalence with `getFilteredTasks` *and* pins the counts that must move):

| input | proven |
| --- | --- |
| task created | `all` 10→11, `today` 4→5, `project-a` 10→11 |
| task edited (title only) | counts unchanged, still equal to the filters |
| task completed | `all`→8, `today`→2, `completed`→5, `project-a`→9 |
| task uncompleted | `all`→12, `completed`→1, `project-a`→11 |
| task deleted | `all`→9, `today`→3, `project-a`→9 |
| parent deleted | subtask stops riding along: `all`→8, `today`→2 |
| due date moved / cleared | `today`→2 / `today`→3 |
| project reassigned | `project-a`→9, `project-b`→4 |
| status reassigned in-project | unchanged, still equal to the filters |
| tag reassigned | unchanged, still equal to the filters |
| task archived / unarchived | `all`→9 / `all`→11 |
| inbox→task conversion | `all`→11, `upcoming`→3, `tomorrow`→2 |
| remote device writes a subtask (field-level vector clock) | `all`→11, `today`→5 |
| view filter set changes | `viewIds` is an argument; an unknown id gets the `all` list |
| view created / renamed / deleted | driven by `taskViews`; ids are re-read on every call |
| project statuses re-typed / project removed | `completed`↔`all` move with the status types |

Memo keys are deliberately **unchanged** — still `[tasks, projects]`. A remote field-level task update lands as a new array identity from the workspace query, exactly as before; nothing was narrowed, debounced, or cached across renders, so there is no window in which an event can be dropped.

### Mutation verification

Six single-line reverts, each re-run:

| mutant | result |
| --- | --- |
| delete the subtask-inclusion `viewCounts[viewId] += 1` | **RED** |
| delete `if (task.archivedAt) continue` | **RED** |
| `isIncomplete` `!== 'done'` → `!== 'todo'` | **RED** |
| delete the top-level `viewCounts[viewId] += 1` | **RED** |
| `taskCount: projectTaskCounts[project.id] ?? 0` → `taskCount: 0` | **RED** |
| revert `App.tsx` to the pre-fix per-view / per-project filters | **RED** — `expected 54 to be 6` |

No survivors. Note the last mutant leaves the *correctness* tests green and only trips the single-pass measurement — which is the point: the rewrite is behaviour-preserving, and the perf test is what guards the shape.

## Verification

```
pnpm typecheck                         16 successful, 16 total (contracts + architecture + IPC checks passed)
pnpm lint                              0 errors, 15 warnings (all pre-existing, none in touched files)
vitest --project renderer (full)       PASS (6333) FAIL (0) skipped (6)
git diff --check                       clean
npx react-doctor@latest . (x2)         1855 files both runs, identical output, no findings in touched files
```

## Risk & backward compatibility

Renderer-only, and pure-computation only. No schema, no migration, no IPC contract, no vault file format, no settings shape, no persisted state. The counters produce byte-identical numbers to the previous code — that equivalence is the test suite's main assertion — so nothing an older version wrote is read differently.

The only public-surface change is `App.tsx`'s import (`getFilteredTasks` → `getTaskWorkspaceCounts`); `getFilteredTasks` itself is untouched and still used by its nine other callers.

## Out of scope, deliberately

The issue also suggests moving the counts into a selector-backed store "so only badge consumers re-render". **Measured: that would be a no-op today.** In the same harness, a component consuming neither `viewCounts` nor `projectsWithCounts` (`SplitViewContainer`) re-renders just as often as the badge consumers, because `tasks` itself is a root-level prop into `TasksProvider` — `App` re-renders on every task change and recreates the whole element tree regardless of where the counts live. Scoping those re-renders means reducing the root data load, which is #445.

## Docs

`pnpm docs:impact --base origin/main --strict` reports `missing-docs` for `App.tsx` and `lib/task-utils/*`. **No docs update is warranted**: this is an internal, behaviour-preserving performance change with no user-visible surface — the badge numbers are provably identical to before. Nothing in `apps/docs/src` becomes stale.

Closes #1055
