### PR TITLE
perf(editor): scope active-heading lookups to the pane and cache resolved nodes

### DIFF
--- a/apps/desktop/src/renderer/src/components/medium-gap-extra.test.tsx
+++ b/apps/desktop/src/renderer/src/components/medium-gap-extra.test.tsx
@@ -317,7 +317,7 @@ describe('medium gap renderer surfaces', () => {
     const h2 = document.createElement('h2')
     h2.dataset.id = 'h2'
     h2.getBoundingClientRect = () => rect(760, 800)
-    document.body.append(h1, h2)
+    container.append(h1, h2)
 
     const scrollContainerRef = { current: container }
     const { result } = renderHook(() =>

--- a/apps/desktop/src/renderer/src/hooks/use-active-heading.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-active-heading.test.tsx
@@ -1,0 +1,198 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useActiveHeading, type HeadingItem } from './use-active-heading'
+
+let rafCallbacks: FrameRequestCallback[] = []
+
+function flushRaf(): void {
+  const callbacks = [...rafCallbacks]
+  rafCallbacks = []
+  callbacks.forEach((callback) => callback(0))
+}
+
+/** A scroll container that is nowhere near its bottom. */
+function makePane(): HTMLDivElement {
+  const pane = document.createElement('div')
+  Object.defineProperties(pane, {
+    scrollHeight: { value: 5000, configurable: true },
+    clientHeight: { value: 800, configurable: true },
+    scrollTop: { value: 0, configurable: true, writable: true }
+  })
+  document.body.append(pane)
+  return pane
+}
+
+function addHeading(pane: HTMLElement, id: string, top: number): HTMLElement {
+  const element = document.createElement('h2')
+  element.dataset.id = id
+  element.getBoundingClientRect = () => ({ top, bottom: top + 30 }) as DOMRect
+  pane.append(element)
+  return element
+}
+
+function headingItems(ids: string[]): HeadingItem[] {
+  return ids.map((id, index) => ({ id, level: 2, text: id, position: index }))
+}
+
+describe('useActiveHeading', () => {
+  beforeEach(() => {
+    rafCallbacks = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      rafCallbacks.push(callback)
+      return rafCallbacks.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    document.body.innerHTML = ''
+  })
+
+  it('resolves headings inside its own pane when the same note is open in split view', () => {
+    const paneA = makePane()
+    const paneB = makePane()
+    // Both panes render the same note, so the block ids are identical and a
+    // document-wide lookup hands pane B the element that belongs to pane A.
+    addHeading(paneA, 'block-1', 900)
+    addHeading(paneA, 'block-2', 960)
+    addHeading(paneB, 'block-1', 10)
+    addHeading(paneB, 'block-2', 60)
+    const scrollContainerRef = { current: paneB }
+
+    const { result } = renderHook(() =>
+      useActiveHeading({
+        headings: headingItems(['block-1', 'block-2']),
+        offset: 120,
+        throttleMs: 0,
+        scrollContainerRef
+      })
+    )
+
+    act(flushRaf)
+
+    expect(result.current.activeHeadingId).toBe('block-2')
+  })
+
+  it('stops querying the DOM for heading elements once they are resolved', () => {
+    const pane = makePane()
+    const ids = Array.from({ length: 60 }, (_, index) => `block-${index}`)
+    // Every heading sits above the offset line, so the scan walks all 60.
+    ids.forEach((id, index) => addHeading(pane, id, index * 10 - 500))
+    const scrollContainerRef = { current: pane }
+
+    const documentQuery = vi.spyOn(document, 'querySelector')
+    const paneQuery = vi.spyOn(pane, 'querySelector')
+
+    const { result } = renderHook(() =>
+      useActiveHeading({
+        headings: headingItems(ids),
+        offset: 120,
+        throttleMs: 0,
+        scrollContainerRef
+      })
+    )
+
+    act(flushRaf)
+    expect(result.current.activeHeadingId).toBe('block-59')
+
+    const lookupsToResolve = paneQuery.mock.calls.length
+    documentQuery.mockClear()
+    paneQuery.mockClear()
+
+    for (let tick = 0; tick < 20; tick++) {
+      act(() => {
+        pane.dispatchEvent(new Event('scroll'))
+      })
+    }
+
+    expect(result.current.activeHeadingId).toBe('block-59')
+    expect(lookupsToResolve).toBe(60)
+    expect(documentQuery).not.toHaveBeenCalled()
+    expect(paneQuery).not.toHaveBeenCalled()
+  })
+
+  it('re-resolves a heading whose element the editor replaced', () => {
+    const pane = makePane()
+    addHeading(pane, 'block-1', -200)
+    const stale = addHeading(pane, 'block-2', -100)
+    addHeading(pane, 'block-3', 400)
+    const scrollContainerRef = { current: pane }
+    const headings = headingItems(['block-1', 'block-2', 'block-3'])
+
+    const { result } = renderHook(() =>
+      useActiveHeading({ headings, offset: 120, throttleMs: 0, scrollContainerRef })
+    )
+
+    act(flushRaf)
+    expect(result.current.activeHeadingId).toBe('block-2')
+
+    // A sync update rewrites the body: the old node is detached and a fresh
+    // node carrying the same block id lands further down the document.
+    stale.remove()
+    addHeading(pane, 'block-2', 500)
+
+    act(() => {
+      pane.dispatchEvent(new Event('scroll'))
+    })
+
+    expect(result.current.activeHeadingId).toBe('block-1')
+  })
+
+  it('keeps its scroll subscription when the editor re-emits an identical headings array', () => {
+    const pane = makePane()
+    addHeading(pane, 'block-1', -100)
+    addHeading(pane, 'block-2', 400)
+    const scrollContainerRef = { current: pane }
+
+    const addListener = vi.spyOn(pane, 'addEventListener')
+    const removeListener = vi.spyOn(pane, 'removeEventListener')
+
+    const { result, rerender } = renderHook(
+      (headings: HeadingItem[]) =>
+        useActiveHeading({ headings, offset: 120, throttleMs: 0, scrollContainerRef }),
+      { initialProps: headingItems(['block-1', 'block-2']) }
+    )
+
+    act(flushRaf)
+    const subscriptions = addListener.mock.calls.length
+
+    // The editor re-extracts headings 200 ms after every keystroke and hands
+    // back a brand-new array even when nothing about the outline changed.
+    for (let sync = 0; sync < 5; sync++) {
+      rerender(headingItems(['block-1', 'block-2']))
+    }
+
+    expect(addListener.mock.calls.length).toBe(subscriptions)
+    expect(removeListener).not.toHaveBeenCalled()
+    expect(result.current.activeHeadingId).toBe('block-1')
+  })
+
+  it('re-runs when a heading is added while the note is scrolled', () => {
+    const pane = makePane()
+    addHeading(pane, 'block-1', -300)
+    addHeading(pane, 'block-2', 400)
+    const scrollContainerRef = { current: pane }
+
+    const { result, rerender } = renderHook(
+      (headings: HeadingItem[]) =>
+        useActiveHeading({ headings, offset: 120, throttleMs: 0, scrollContainerRef }),
+      { initialProps: headingItems(['block-1', 'block-2']) }
+    )
+
+    act(flushRaf)
+    expect(result.current.activeHeadingId).toBe('block-1')
+
+    const inserted = document.createElement('h2')
+    inserted.dataset.id = 'block-1a'
+    inserted.getBoundingClientRect = () => ({ top: -50, bottom: -20 }) as DOMRect
+    pane.insertBefore(inserted, pane.children[1])
+
+    rerender(headingItems(['block-1', 'block-1a', 'block-2']))
+    act(flushRaf)
+
+    expect(result.current.activeHeadingId).toBe('block-1a')
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-active-heading.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-active-heading.ts
@@ -8,7 +8,7 @@
  * being enabled via setIdAttribute: true
  */
 
-import { useState, useEffect, useCallback, useRef, type RefObject } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef, type RefObject } from 'react'
 
 interface HeadingItem {
   id: string
@@ -36,6 +36,17 @@ interface UseActiveHeadingResult {
 }
 
 /**
+ * The editor re-extracts headings 200 ms after every keystroke, so an untouched
+ * outline still arrives as a brand-new array. Collapsing equal arrays onto one
+ * identity keeps the scroll listeners subscribed instead of churning them.
+ */
+function headingsSignature(headings: HeadingItem[]): string {
+  return headings
+    .map((h) => `${h.id}\u0000${h.level}\u0000${h.position}\u0000${h.text}`)
+    .join('\u0001')
+}
+
+/**
  * Determines the active heading based on scroll position.
  * Returns the heading that is at or just above the viewport top.
  */
@@ -48,9 +59,33 @@ export function useActiveHeading({
   const [activeHeadingId, setActiveHeadingId] = useState<string | null>(null)
   const lastScrollTimeRef = useRef(0)
   const rafIdRef = useRef<number | null>(null)
+  const headingElementsRef = useRef(new Map<string, Element>())
+
+  const signature = headingsSignature(headings)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const stableHeadings = useMemo(() => headings, [signature])
+
+  const resolveHeadingElement = useCallback(
+    (id: string): Element | null => {
+      const cached = headingElementsRef.current.get(id)
+      // A cached node survives scrolling but not a body rewrite: once the editor
+      // replaces the block, the old node is detached and its rect reads as zero.
+      if (cached && cached.isConnected) return cached
+
+      // Scoped to this pane. In split view both panes render the same note's
+      // block ids, and a document-wide lookup hands this pane the other one's
+      // element — the outline would then highlight against the wrong scroller.
+      const root: ParentNode = scrollContainerRef?.current ?? document
+      const element = root.querySelector(`[data-id="${id}"]`)
+      if (element) headingElementsRef.current.set(id, element)
+      else headingElementsRef.current.delete(id)
+      return element
+    },
+    [scrollContainerRef]
+  )
 
   const findActiveHeading = useCallback(() => {
-    if (headings.length === 0) {
+    if (stableHeadings.length === 0) {
       setActiveHeadingId(null)
       return
     }
@@ -61,12 +96,12 @@ export function useActiveHeading({
     if (container) {
       const atBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 2
       if (atBottom) {
-        for (let i = headings.length - 1; i >= 0; i--) {
-          const el = document.querySelector(`[data-id="${headings[i].id}"]`)
+        for (let i = stableHeadings.length - 1; i >= 0; i--) {
+          const el = resolveHeadingElement(stableHeadings[i].id)
           if (el) {
             const rect = el.getBoundingClientRect()
             if (rect.top < window.innerHeight && rect.bottom > 0) {
-              setActiveHeadingId(headings[i].id)
+              setActiveHeadingId(stableHeadings[i].id)
               return
             }
           }
@@ -76,8 +111,8 @@ export function useActiveHeading({
 
     let activeId: string | null = null
 
-    for (const heading of headings) {
-      const element = document.querySelector(`[data-id="${heading.id}"]`)
+    for (const heading of stableHeadings) {
+      const element = resolveHeadingElement(heading.id)
       if (element) {
         const rect = element.getBoundingClientRect()
         if (rect.top <= offset) {
@@ -89,18 +124,18 @@ export function useActiveHeading({
     }
 
     // If no heading is above threshold, use the first visible heading
-    if (!activeId && headings.length > 0) {
-      const firstElement = document.querySelector(`[data-id="${headings[0].id}"]`)
+    if (!activeId && stableHeadings.length > 0) {
+      const firstElement = resolveHeadingElement(stableHeadings[0].id)
       if (firstElement) {
         const rect = firstElement.getBoundingClientRect()
         if (rect.top < window.innerHeight && rect.bottom > 0) {
-          activeId = headings[0].id
+          activeId = stableHeadings[0].id
         }
       }
     }
 
     setActiveHeadingId(activeId)
-  }, [headings, offset, scrollContainerRef])
+  }, [stableHeadings, offset, scrollContainerRef, resolveHeadingElement])
 
   const handleScroll = useCallback(() => {
     const now = Date.now()
@@ -122,7 +157,11 @@ export function useActiveHeading({
   }, [findActiveHeading, throttleMs])
 
   useEffect(() => {
-    if (headings.length === 0) return
+    // Drop references to the previous outline's nodes so a long editing session
+    // does not retain a detached element for every heading it ever rendered.
+    headingElementsRef.current = new Map()
+
+    if (stableHeadings.length === 0) return
 
     const initialCalculation = requestAnimationFrame(findActiveHeading)
 
@@ -144,7 +183,7 @@ export function useActiveHeading({
         rafIdRef.current = null
       }
     }
-  }, [headings, handleScroll, findActiveHeading, scrollContainerRef])
+  }, [stableHeadings, handleScroll, findActiveHeading, scrollContainerRef])
 
   const setActiveHeading = useCallback((id: string) => {
     setActiveHeadingId(id)


### PR DESCRIPTION
Closes #1049

## Problem

`useActiveHeading` drives the outline/TOC highlight. On every throttled scroll tick it walked the headings array and, for each one, ran an **unscoped** `document.querySelector('[data-id="…"]')` followed by `getBoundingClientRect()`.

Measured with a harness (60-heading note, 20 scroll ticks ≈ 1 s of scrolling):

| | before | after |
|---|---|---|
| `document.querySelector` during scroll | **1200** | **0** |
| `getBoundingClientRect` during scroll | 1200 | 1200 (deliberate — see below) |
| scoped lookups to resolve all headings | 0 | 60, once |
| scroll/resize re-subscriptions per 5 identical heading emissions | 6 | 1 |

Two separate defects:

1. **Correctness.** The lookup was document-wide. In split view both panes render the same note's block ids, so `document.querySelector` returns whichever pane appears first in document order. The second pane's outline highlighted against the first pane's geometry — a navigation aid that lies.
2. **Cost.** ~20 ticks/s × N headings of DOM tree-walking, re-done from scratch every tick, plus the listener churn from the editor re-emitting a fresh headings array 200 ms after every keystroke (`use-editor-sync.ts` debounce → `setHeadings` in `note.tsx` / `journal.tsx` → new array identity → `findActiveHeading`/`handleScroll` identity change → the effect tears down and re-adds the scroll and resize listeners).

## Root cause

- The element lookup was neither scoped nor memoised: `document.querySelector` per heading per tick.
- The subscription effect depends on `headings`, which is a new array reference on every editor sync even when the outline is unchanged.

## Fix

All in `apps/desktop/src/renderer/src/hooks/use-active-heading.ts`:

- `resolveHeadingElement(id)` scopes the query to `scrollContainerRef.current` (falling back to `document` when no container is supplied) and caches the resolved node in a ref keyed by block id.
- The cache is revalidated with `isConnected` on every read, so a body rewrite that detaches the old node re-resolves instead of measuring a detached element (which reports `top: 0` and would mark everything active).
- The cache is dropped whenever the outline changes, so a long editing session does not retain a detached node for every heading it ever rendered.
- `stableHeadings` collapses content-equal heading arrays onto one identity via a content signature (`id`/`level`/`position`/`text`), so the editor's 200 ms re-extraction no longer churns the listeners.

**Only element references are cached, never positions.** Every tick still calls `getBoundingClientRect()` live, so window resize, sidebar toggle, font/zoom change, image load, or a block expanding cannot strand a stale offset. That is why the rect-read count is unchanged; the N reads in a tight loop force at most one layout recalculation per tick anyway (nothing mutates the DOM between them), so the avoidable N-cost was the `querySelector` tree walk, not the layout flush. The issue's "~1,200 layout reads/s" is accurate as a call count but the reads are not 1,200 separate forced layouts.

No throttling or debouncing was added or changed, so no event can be dropped. The existing trailing-`requestAnimationFrame` fallback that guarantees the last event in a throttle window is still processed is untouched.

## The outline must stay correct — enumeration

| Change | Still updates? | Proof |
|---|---|---|
| Scrolling | yes | `stops querying the DOM…` and `re-resolves a heading whose element the editor replaced` dispatch real `scroll` events and assert the resulting active id |
| Heading added while scrolled | yes | `re-runs when a heading is added while the note is scrolled` — signature changes → effect re-runs, cache cleared, recompute |
| Heading edited / removed | yes | signature includes `id`, `level`, `position` and `text`, so any of these changing produces a new identity (mutant M4 below proves the signature is load-bearing) |
| Note switched in the same editor instance | yes | headings array replaced → new signature → effect re-runs and clears the cache; separately the old nodes detach so `isConnected` forces re-resolution |
| Collapsing/expanding a section | unchanged from before | positions are read live, never cached; *when* a recompute is triggered (scroll/resize) is not touched by this change |
| External sync rewriting the body | yes | `re-resolves a heading whose element the editor replaced` simulates exactly this: detach the old node, insert a new one with the same block id further down |
| Split view, two editors each with its own outline | yes, and now correct | `resolves headings inside its own pane when the same note is open in split view` — two panes with identical block ids; the hook bound to pane B must resolve pane B's elements |

## Test evidence

New: `apps/desktop/src/renderer/src/hooks/use-active-heading.test.tsx` (5 tests). Existing `medium-gap-extra.test.tsx` had its two heading elements appended to `document.body` while passing a scroll container; they now go inside the container, matching how the app actually nests them.

RED first — 3 of 5 failed on unmodified `main`:

```
1. resolves headings inside its own pane when the same note is open in split view
   AssertionError: expected null to be 'block-2'
2. stops querying the DOM for heading elements once they are resolved
   AssertionError: expected +0 to be 60
3. keeps its scroll subscription when the editor re-emits an identical headings array
   AssertionError: expected 6 to be 1
```

GREEN after the fix, plus the full renderer suite:

```
PASS (6313) FAIL (0) skipped (6)
```

### Mutation verification — 4 mutants, all killed

| # | Mutation (code line, not comment) | Result |
|---|---|---|
| M1 | `const root = scrollContainerRef?.current ?? document` → `const root = document` | **RED** — `expected null to be 'block-2'` + `expected +0 to be 60` |
| M2 | disable the cache-hit return | **RED** — `expected "querySelector" to not be called at all, but actually been called 1200 times` |
| M3 | `if (cached && cached.isConnected)` → `if (cached)` | **RED** — `expected 'block-2' to be 'block-1'` (stale detached node wins) |
| M4 | `useMemo(() => headings, [signature])` → `[headings]` | **RED** — `expected "querySelector" … called 60 times` + `expected 6 to be 1` |

M1 is killed by two independent assertions because the split-view test alone would not catch it if the cache masked the query count — asserting the *scoped* lookup count as well as the *document* count closes that hole.

## Verification

```
pnpm typecheck   → Tasks: 16 successful, 16 total
pnpm lint        → 15 problems (0 errors, 15 warnings) — all pre-existing, none in the changed files
git diff --check → clean
npx -y react-doctor@latest .  → run twice, 1855 files scanned both times, 231 issues, zero findings in use-active-heading.ts
apps/desktop: pnpm exec vitest run --config config/vitest.config.ts --project renderer
                 → PASS (6313) FAIL (0) skipped (6)
```

## Docs

`pnpm docs:impact --base origin/main --strict` reports `missing-docs` for `use-active-heading.ts`. **Deliberately not adding docs.** The gate flags the path, not a user-facing surface: nothing in `apps/docs/src` documents the note outline or its active-heading highlight (the only `outline` hits are about a calendar day's border). This change adds no feature and alters no documented behaviour — it fixes a highlight that was wrong in split view and removes redundant DOM work. The gate is advisory; `.husky/pre-push` does not invoke it and `MEMRY_DOCS_IMPACT_SKIP` is not implemented anywhere.

## Risk & backward compatibility

Renderer-only, single hook. No DB, IPC contract, vault file format, settings shape, sync payload, or markdown serialization is touched, so nothing an older version wrote is affected. The fallback to `document` preserves the old behaviour for any caller that does not pass a scroll container (both current callers — `note-layout.tsx` and `journal.tsx` — do). No BlockNote menu focus guard is added or removed and no `setState` is introduced in a `beforeinput` handler. No new Tailwind classes.

The one behaviour change to be aware of: a heading element rendered **outside** the hook's scroll container is no longer found. In the app both callers mount the editor inside the container they pass, so this only affected a test that placed elements on `document.body`.

## Relation to other open PRs

Deliberately does **not** touch `use-editor-sync.ts`, `note.tsx` or `journal.tsx` — the natural place to dedupe the headings array at source, but all three are being edited by #1140. The dedupe is done inside the hook instead, so the two changes cannot conflict. No overlap with #1154 (`use-triggered-date-pills.ts`) or #1165 (hover hooks).
