### PR TITLE
fix(sync): back off between NetworkError retries when the machine is online

### DIFF
--- a/apps/desktop/src/main/sync/engine-retries.test.ts
+++ b/apps/desktop/src/main/sync/engine-retries.test.ts
@@ -453,7 +453,14 @@ describe('SyncEngine', () => {
           payload: JSON.stringify({ title: 'Test', clock: { 'device-1': 1 } })
         })
 
-        await engine.push()
+        // The mock network reports online, so withRetry treats an unreachable
+        // server as transient and spaces its retries by backoff (~31s of wall
+        // clock). Drive that with fake timers rather than waiting for it.
+        vi.useFakeTimers()
+        const pushed = engine.push()
+        await vi.advanceTimersByTimeAsync(60_000)
+        await pushed
+        vi.useRealTimers()
 
         expect(engine.currentState).toBe('offline')
         expect(engine.getStatus().error).toBeUndefined()

--- a/apps/desktop/src/main/sync/retry.test.ts
+++ b/apps/desktop/src/main/sync/retry.test.ts
@@ -99,6 +99,51 @@ describe('withRetry', () => {
     })
   })
 
+  describe('#given NetworkError #when isOnline is not supplied', () => {
+    it('#then spaces retries by exponential backoff instead of firing them back-to-back', async () => {
+      const fn = vi.fn().mockRejectedValue(new NetworkError('server unreachable'))
+
+      // Only jitter is pinned. maxRetries / baseDelayMs / maxDelayMs / isOnline
+      // all stay at their defaults — the exact shape most callers use.
+      const promise = withRetry(fn, { jitterMs: 0 })
+      promise.catch(() => {})
+
+      // The first attempt runs straight away and nothing else does.
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fn).toHaveBeenCalledTimes(1)
+
+      const expectedDelaysMs = [1000, 2000, 4000, 8000, 16_000]
+      for (let i = 0; i < expectedDelaysMs.length; i++) {
+        await vi.advanceTimersByTimeAsync(expectedDelaysMs[i] - 1)
+        expect(fn).toHaveBeenCalledTimes(i + 1)
+        await vi.advanceTimersByTimeAsync(1)
+        expect(fn).toHaveBeenCalledTimes(i + 2)
+      }
+
+      // The budget is spent over ~31s, not in one tick, and no attempt is lost.
+      expect(fn).toHaveBeenCalledTimes(6)
+      await expect(promise).rejects.toThrow(DeadLetterError)
+      await expect(promise).rejects.toMatchObject({ attempts: 6 })
+    })
+  })
+
+  describe('#given NetworkError #when the machine stays offline past the wait cap', () => {
+    it('#then throws a bare NetworkError so callers can keep the work queued', async () => {
+      const fn = vi.fn().mockRejectedValue(new NetworkError('offline'))
+
+      const promise = withRetry(fn, { isOnline: () => false, jitterMs: 0 })
+      promise.catch(() => {})
+
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 2000)
+
+      const err = await promise.catch((e: unknown) => e)
+      expect(err).toBeInstanceOf(NetworkError)
+      expect(err).not.toBeInstanceOf(DeadLetterError)
+      expect((err as Error).message).toBe('Offline wait timeout exceeded')
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('#given aborted signal #when retrying', () => {
     it('#then throws AbortError', async () => {
       const controller = new AbortController()

--- a/apps/desktop/src/main/sync/retry.ts
+++ b/apps/desktop/src/main/sync/retry.ts
@@ -101,7 +101,7 @@ export async function withRetry<T>(
 
       if (error instanceof RateLimitError && error.retryAfter !== undefined) {
         delayMs = error.retryAfter * 1000
-      } else if (error instanceof NetworkError) {
+      } else if (error instanceof NetworkError && !opts.isOnline!()) {
         opts.onRetry?.(attempt + 1, lastError, ONLINE_POLL_MS)
         const offlineStart = Date.now()
         while (!opts.isOnline!()) {
@@ -112,6 +112,11 @@ export async function withRetry<T>(
         }
         continue
       } else {
+        // A NetworkError while isOnline() reports true means the machine has a
+        // link but the server is unreachable (captive portal, DNS failure,
+        // server down). The offline poll above never waits in that case, so
+        // without this backoff the whole retry budget fires back-to-back in a
+        // single tick and a two-second blip dead-letters the work.
         delayMs = computeBackoff(attempt, opts)
       }
 

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -464,6 +464,7 @@ phrase can restore the correct key. See
 | Failure             | Behavior                                                                                   |
 | ------------------- | ------------------------------------------------------------------------------------------ |
 | Offline             | Outbox queues; retry with backoff                                                          |
+| Server unreachable  | Machine still has a link, so requests are retried with exponential backoff, not instantly  |
 | Auth expired (401)  | Refresh the access token and retry the request once; only a failed refresh prompts sign-in |
 | Refresh rejected    | Stop refreshing entirely (see below); prompt the user to sign in again                     |
 | Payment required    | Sync stays local-only until a paid plan is active                                          |


### PR DESCRIPTION
## Problem

`withRetry` is the shared retry helper for the whole sync layer. Its `NetworkError`
branch only ever waited *while the machine was offline*:

```ts
} else if (error instanceof NetworkError) {
  opts.onRetry?.(attempt + 1, lastError, ONLINE_POLL_MS)
  const offlineStart = Date.now()
  while (!opts.isOnline!()) { ...poll every 2s... }
  continue          // <- no delay at all when isOnline() is true
}
```

`DEFAULTS.isOnline` is `() => true`, and most call sites omit `isOnline`. So whenever
the server is unreachable but the OS still reports a link — captive portal, DNS
failure, server down, TLS reset — the `while` loop never ran once and `continue` fired
the next attempt in the same tick.

**Measured**, not inferred. Before the fix, with fake timers and *zero* clock
advance, all six attempts had already run:

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 6 times
 ❯ src/main/sync/retry.test.ts:113:18
    112|       await vi.advanceTimersByTimeAsync(0)
    113|       expect(fn).toHaveBeenCalledTimes(1)
```

The entire retry budget was spent in well under a millisecond, so any blip longer
than "one event-loop tick" dead-lettered the work. It also meant `onRetry` reported
`ONLINE_POLL_MS` (2000) as the delay when the real delay was 0.

## Root cause

The offline-wait loop was doing double duty as the delay for *both* the offline case
and the server-unreachable case, but it is a no-op in the second one.

## Fix

One production line. The `NetworkError` branch is now guarded on actually being
offline; a `NetworkError` while `isOnline()` is true falls through to the same
`computeBackoff` the 5xx path already uses.

```diff
-      } else if (error instanceof NetworkError) {
+      } else if (error instanceof NetworkError && !opts.isOnline!()) {
```

Everything inside the offline branch — the 2s poll, `MAX_OFFLINE_WAIT_MS`, and the
**bare `NetworkError`** it throws — is byte-for-byte unchanged.

Delay sequence at defaults (`baseDelayMs` 1000, `maxDelayMs` 30 000, `maxRetries` 5),
jitter pinned to 0: **1000, 2000, 4000, 8000, 16 000 ms — 6 attempts, ~31 s total**,
then `DeadLetterError`. That is exactly the cadence a 500-ing server already produced,
so no call site gets a worst case it did not already have on the 5xx path.

I deliberately did **not** take the issue's alternative suggestion of defaulting
`isOnline` to the real `NetworkMonitor`. That would couple a pure module to a
singleton and would fix nothing here — in every scenario described the monitor
*is* online.

## Call sites — per-site impact

`withRetry` is shared, so here is every non-test caller.

| Call site | passes `isOnline`? | Behaviour change |
| --- | --- | --- |
| `sync/manifest-check.ts:67` | yes (`deps.isOnline`) | Online + unreachable now backs off (defaults, ~31 s) instead of 6 instant hits. Runs behind a `MIN_INTERVAL_MS` gate, background only. |
| `sync/device-keys.ts:47` | no | `maxRetries: 3, baseDelayMs: 2000` → 2 s, 4 s, 8 s (~14 s) instead of 0. Startup key fetch, not user-blocking. |
| `sync/linking-service.ts:313` (`/auth/linking/complete`) | no | 2 s, 4 s, 8 s. This is polled by `LinkingPending`; the poll cadence is still the outer retry and `retryOn429: false` is untouched. A poll tick can now take up to ~14 s when the server is unreachable — the UI already shows a pending state, and the previous behaviour spent the whole budget instantly on every tick, which is the storm this backoff prevents. |
| `sync/linking-service.ts:492` (`/auth/recovery-info`) | no | 2 s, 4 s, 8 s. One-shot during device setup. |
| `sync/attachments.ts:627` initUpload | only if caller supplies it | 2 s, 4 s, 8 s. Background transfer. |
| `sync/attachments.ts:657` checkResumableSession | conditional | `maxRetries: 2` → 1 s, 2 s. Failure already falls back to "start fresh". |
| `sync/attachments.ts:694` uploadChunk | conditional | `maxRetries: 5, baseDelayMs: 2000` → 2/4/8/16/30 s (`maxDelayMs` cap). `onWaitingNetwork` still fires on every `NetworkError` — no notification lost. |
| `sync/attachments.ts:718` completeUpload | conditional | 2 s, 4 s, 8 s. |
| `sync/runtime.ts:503` CRDT update batch | no | 2 s, 4 s, 8 s. Background push; on failure `crdtQueue` re-buffers the batch. |
| `sync/runtime.ts:562` CRDT snapshot push | no | 2 s, 4 s, 8 s. Caller keeps `pendingSnapshotBytes`, so nothing is dropped. |
| `sync/http-client.ts:242` `fetchCrdtSnapshot` | no | 2 s, 4 s, 8 s. **Worth flagging**: called per note from `applySnapshotBaseline` inside a serial loop, so a hard server outage stretches that loop by ~14 s per note instead of failing instantly. Accepted: the same loop already pays this on a 500, and failing fast here means a 3-second blip loses every baseline. No signal is threaded here today. |
| `sync/engine/crdt-sync-coordinator.ts:110` incrementals | no | 2 s, 4 s, 8 s; `signal: effectiveSignal` aborts the sleep. |
| `sync/engine/crdt-sync-coordinator.ts:234` batch pull | no | 2 s, 4 s, 8 s; abort signal honoured. |
| `sync/engine/corrupt-item-tracker.ts:85` | yes (real monitor) | Defaults → ~31 s; abort signal honoured. |
| `sync/engine/pull-coordinator.ts:288` `/sync/changes` | yes (real monitor) | Defaults → ~31 s; abort signal honoured. |
| `sync/engine/pull-coordinator.ts:552` `/sync/pull` | yes (real monitor) | Defaults → ~31 s; abort signal honoured. |
| `sync/engine/push-coordinator.ts:187` `/sync/push` | yes (real monitor) | Defaults → ~31 s; abort signal honoured. This is the path `engine-retries.test.ts` exercises, and why that test moved to fake timers. |

**No caller loses attempts, and no retryable failure becomes permanent.**
`maxRetries` is untouched, the loop bound is untouched, `attempts` in the result and
in `DeadLetterError` is unchanged, and the non-429 4xx immediate-throw at the top of
the catch is untouched. Every listed site strictly gains time to succeed. The only
cost is latency on paths that were already failing.

Every sleep is `sleep(delayMs, opts.signal)`, so callers passing an `AbortSignal`
cancel out of the new delay exactly as they do out of the existing 5xx backoff.

## Relationship to #1167 (`upload-queue-network-backoff`, #1028)

`UploadQueue` treats `DeadLetterError` as permanent and only re-queues a **bare**
`NetworkError` — the one thrown from the `MAX_OFFLINE_WAIT_MS` branch at
`retry.ts:108-110`. That branch is inside the offline path, which this change does
not touch: the guard I added is `!opts.isOnline!()`, so when the machine is genuinely
offline the code takes the identical path it took before, throws the identical bare
`NetworkError`, and #1167's per-item backoff still catches it. Nothing that used to
escape as retryable now escapes as `DeadLetterError`, so no upload is converted into a
dropped one. There is a regression test pinning this (below). The two layers remain
complementary, not substitutes.

## Test evidence

New tests in `apps/desktop/src/main/sync/retry.test.ts`, both fake-timer driven, no
wall-clock timing:

1. `#given NetworkError #when isOnline is not supplied` — pins the **exact** delay
   sequence `[1000, 2000, 4000, 8000, 16000]` by asserting the call count at
   `delay - 1` and again at `delay`, plus the exact attempt count (6) and
   `DeadLetterError.attempts === 6`. A test that only distinguished "delays" from
   "doesn't" would not catch a wrong value; this one does (see mutant 2).
2. `#given NetworkError #when the machine stays offline past the wait cap` — asserts
   the escape is `instanceof NetworkError` and **not** `instanceof DeadLetterError`,
   with message `Offline wait timeout exceeded`. This is the #1167 contract guard.

The pre-existing `#given NetworkError #when offline #then polls isOnline until true`
still passes unmodified, which is the proof that reconnect stays prompt — no backoff
is inserted after the network monitor flips back online.

RED before the fix:

```
 × retry.test.ts > #given NetworkError #when isOnline is not supplied > #then spaces retries by exponential backoff instead of firing them back-to-back
   → expected "vi.fn()" to be called 1 times, but got 6 times
 Tests  1 failed | 15 passed (16)
```

GREEN after:

```
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

### Mutation verification

**Mutant 1** — `retry.ts:104`, revert the guard to `} else if (error instanceof NetworkError) {`:

```
 × #given NetworkError #when isOnline is not supplied > #then spaces retries ...
   AssertionError: expected "vi.fn()" to be called 1 times, but got 6 times
 ✓ #given NetworkError #when the machine stays offline past the wait cap ...   (correctly unaffected)
 Tests  1 failed | 15 passed (16)
```

Killed. The offline-escape test staying green under this mutant is itself
confirmation that the two branches are independent.

**Mutant 2** — `retry.ts:66`, `Math.pow(2, attempt)` → `Math.pow(3, attempt)`, to
prove the test pins values rather than merely "nonzero":

```
   AssertionError: expected "vi.fn()" to be called 3 times, but got 2 times
   AssertionError: expected [ 100, 300, 500, 500 ] to deeply equal [ 100, 200, 400, 500 ]
 Tests  3 failed | 13 passed (16)
```

Killed. Both mutants reverted before committing.

### Full verification

```
pnpm exec vitest run --project main
  Test Files  477 passed | 1 skipped (478)
       Tests  5442 passed | 1 expected fail | 4 skipped (5447)

pnpm typecheck    Tasks: 16 successful, 16 total
pnpm lint         ✖ 15 problems (0 errors, 15 warnings)   — all pre-existing, all in renderer files
git diff --check  clean (exit 0)
pnpm docs:build   build complete
```

`pnpm ipc:check` / `pnpm ipc:generate` not required — no contract, preload or IPC
change. `pnpm typecheck` runs `rpc:check` and the IPC invoke-map check anyway; both
reported up to date.

### One test updated

`engine-retries.test.ts` → `#given push encounters network error` previously finished
instantly because the retry budget burned in one tick. With the fix it takes ~31 s of
real time, so it timed out at 30 s. Switched to fake timers and
`advanceTimersByTimeAsync(60_000)`; all 21 tests in that file pass and the assertions
are unchanged. That timeout is itself independent evidence the fix reaches a real
caller.

## Risk & backward compatibility

- No schema, migration, sync-protocol, IPC-contract, vault-format or settings change.
  Nothing is written to disk or the wire. A mixed-version fleet is unaffected: this is
  purely client-local timing.
- No public signature change. `RetryOptions`, `RetryResult` and `DeadLetterError` are
  untouched, so callers that already pass `isOnline` keep their exact prior behaviour
  in both the offline and the online case they care about.
- Behavioural risk is latency, and only on paths that were already failing. The
  ceiling is `maxDelayMs` (30 s default) per attempt, bounded by each call site's own
  `maxRetries`, and every existing `AbortSignal` cancels it.
- The one site worth watching is `fetchCrdtSnapshot`, called serially per note with no
  abort signal — called out in the table above rather than fixed here, since threading
  a signal through it is outside this issue.

Closes #1029
