### PR TITLE
perf(editor): stop measuring every block on each marquee frame

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.test.tsx
@@ -12,6 +12,9 @@ vi.mock('./task-block-marquee-indent', () => marqueeIndentMocks)
 
 import { topLevelSelectedBlockIds, useBlockMarqueeSelection } from './use-block-marquee-selection'
 
+/** Every stubbed `getBoundingClientRect()` bumps this — one measure, one count. */
+let rectReads = 0
+
 function setRect(el: Element, rect: Partial<DOMRect>): void {
   const value = {
     left: rect.left ?? 0,
@@ -25,7 +28,10 @@ function setRect(el: Element, rect: Partial<DOMRect>): void {
     toJSON: () => ({})
   } as DOMRect
   Object.defineProperty(el, 'getBoundingClientRect', {
-    value: () => value,
+    value: () => {
+      rectReads += 1
+      return value
+    },
     configurable: true
   })
 }
@@ -230,6 +236,296 @@ describe('useBlockMarqueeSelection', () => {
 
     unmount()
     trigger.remove()
+  })
+})
+
+// --- Marquee measurement cost -------------------------------------------------
+
+interface BlockSpec {
+  id: string
+  children?: BlockSpec[]
+}
+
+const BLOCK_ROW_PX = 20
+const BLOCK_GAP_PX = 4
+const NEST_INDENT_PX = 24
+
+/**
+ * Lay a note out the way CSS block flow does: siblings stack top-to-bottom in
+ * document order and a nested block is rendered inside its parent's box, so the
+ * parent's rect encloses every descendant. Returns the y the caller continues at.
+ */
+function layoutBlocks(
+  specs: ReadonlyArray<BlockSpec>,
+  parent: HTMLElement,
+  startTop: number,
+  left: number
+): number {
+  let y = startTop
+  for (const spec of specs) {
+    const el = document.createElement('div')
+    el.className = 'bn-block'
+    el.dataset.id = spec.id
+    parent.append(el)
+    const top = y
+    y += BLOCK_ROW_PX
+    if (spec.children?.length) {
+      y = layoutBlocks(spec.children, el, y, left + NEST_INDENT_PX)
+    }
+    setRect(el, { left, top, width: 300 - (left - 10), height: y - top })
+    y += BLOCK_GAP_PX
+  }
+  return y
+}
+
+function setupNote(specs: ReadonlyArray<BlockSpec>): {
+  trigger: HTMLDivElement
+  blockContainer: HTMLDivElement
+  blockContainerRef: React.RefObject<HTMLDivElement | null>
+  cleanup: () => void
+} {
+  const trigger = document.createElement('div')
+  const blockContainer = document.createElement('div')
+  const height = layoutBlocks(specs, blockContainer, 10, 10)
+  setRect(trigger, { left: 0, top: 0, width: 400, height: height + 10 })
+  trigger.append(blockContainer)
+  document.body.append(trigger)
+  return {
+    trigger,
+    blockContainer,
+    blockContainerRef: { current: blockContainer },
+    cleanup: () => trigger.remove()
+  }
+}
+
+function flatNote(count: number): BlockSpec[] {
+  return Array.from({ length: count }, (_, index) => ({ id: `b${index}` }))
+}
+
+/**
+ * The reference implementation: measure every block, keep the ones the box
+ * touches. Whatever the hook does, it must agree with this exactly.
+ */
+function exhaustiveHits(
+  blockContainer: HTMLElement,
+  box: { left: number; top: number; right: number; bottom: number }
+): string[] {
+  const ids: string[] = []
+  blockContainer.querySelectorAll<HTMLElement>('.bn-block[data-id]').forEach((el) => {
+    const r = el.getBoundingClientRect()
+    if (!(r.right < box.left || r.left > box.right || r.bottom < box.top || r.top > box.bottom)) {
+      const id = el.dataset.id
+      if (id && !ids.includes(id)) ids.push(id)
+    }
+  })
+  return ids
+}
+
+function boxOf(
+  from: { x: number; y: number },
+  to: { x: number; y: number }
+): { left: number; top: number; right: number; bottom: number } {
+  return {
+    left: Math.min(from.x, to.x),
+    right: Math.max(from.x, to.x),
+    top: Math.min(from.y, to.y),
+    bottom: Math.max(from.y, to.y)
+  }
+}
+
+/** Deterministic LCG so a failure is reproducible from the seed alone. */
+function makeRandom(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0
+    return state / 0x100000000
+  }
+}
+
+describe('useBlockMarqueeSelection measurement cost', () => {
+  const editor = { prosemirrorView: { dom: { blur: vi.fn() } } }
+
+  beforeEach(() => {
+    rectReads = 0
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    document.body.innerHTML = ''
+  })
+
+  function drag(
+    trigger: HTMLElement,
+    blockContainerRef: React.RefObject<HTMLDivElement | null>,
+    from: { x: number; y: number },
+    to: { x: number; y: number },
+    downTarget?: HTMLElement
+  ): { ids: string[]; readsForOneFrame: number; unmount: () => void } {
+    const { result, unmount } = renderHook(() =>
+      useBlockMarqueeSelection({ editor, blockContainerRef, triggerContainerEl: trigger })
+    )
+    act(() => {
+      ;(downTarget ?? trigger).dispatchEvent(
+        mouse('mousedown', { clientX: from.x, clientY: from.y })
+      )
+    })
+    rectReads = 0
+    act(() => {
+      document.dispatchEvent(mouse('mousemove', { clientX: to.x, clientY: to.y }))
+    })
+    const readsForOneFrame = rectReads
+    act(() => {
+      document.dispatchEvent(mouse('mouseup', { clientX: to.x, clientY: to.y }))
+    })
+    return { ids: [...result.current.selectedBlockIds], readsForOneFrame, unmount }
+  }
+
+  it('measures a handful of blocks per frame instead of every block in the note', () => {
+    // 200 flat blocks on a 24px pitch: b0 spans 10..30, b199 spans 4786..4806.
+    const { trigger, blockContainerRef, cleanup } = setupNote(flatNote(200))
+    // A marquee low in the note — the case where "scan from the top" is worst.
+    const from = { x: 5, y: 4002 }
+    const to = { x: 200, y: 4060 }
+
+    const { ids, readsForOneFrame, unmount } = drag(trigger, blockContainerRef, from, to)
+
+    // Identical selection to the reference scan…
+    expect(ids).toEqual(exhaustiveHits(blockContainerRef.current!, boxOf(from, to)))
+    expect(ids).toEqual(['b166', 'b167', 'b168'])
+    // …at a fixed cost: 1 trigger rect + 7 binary-search probes + 4 blocks
+    // walked back from the marquee (3 hits plus the one that ends above it).
+    expect(readsForOneFrame).toBe(12)
+
+    unmount()
+    cleanup()
+  })
+
+  it('still selects an enclosing parent when the marquee only covers its deep children', () => {
+    // The parent's own rect reaches down over its children, so a marquee that
+    // touches only the children touches the parent too.
+    const { trigger, blockContainerRef, cleanup } = setupNote([
+      { id: 'lead' },
+      {
+        id: 'parent',
+        children: Array.from({ length: 12 }, (_, index) => ({ id: `child${index}` }))
+      },
+      { id: 'tail' }
+    ])
+    const from = { x: 5, y: 150 }
+    const to = { x: 200, y: 195 }
+
+    const { ids, unmount } = drag(trigger, blockContainerRef, from, to)
+
+    expect(ids).toEqual(exhaustiveHits(blockContainerRef.current!, boxOf(from, to)))
+    expect(ids).toEqual(['parent', 'child4', 'child5'])
+
+    unmount()
+    cleanup()
+  })
+
+  it('selects the same blocks as an exhaustive scan for every drag shape', () => {
+    const specs: BlockSpec[] = [
+      { id: 'b0' },
+      { id: 'b1', children: [{ id: 'b1a' }, { id: 'b1b', children: [{ id: 'b1b1' }] }] },
+      { id: 'b2' },
+      { id: 'b3', children: [{ id: 'b3a' }] },
+      { id: 'b4' },
+      { id: 'b5' }
+    ]
+
+    const shapes: Array<{
+      name: string
+      from: { x: number; y: number }
+      to: { x: number; y: number }
+      onBlock?: string
+      expected: string[]
+    }> = [
+      {
+        name: 'down',
+        from: { x: 5, y: 15 },
+        to: { x: 250, y: 120 },
+        expected: ['b0', 'b1', 'b1a', 'b1b', 'b1b1']
+      },
+      {
+        name: 'up',
+        from: { x: 250, y: 200 },
+        to: { x: 5, y: 60 },
+        expected: ['b1', 'b1a', 'b1b', 'b1b1', 'b2', 'b3', 'b3a']
+      },
+      {
+        name: 'right-to-left',
+        from: { x: 320, y: 60 },
+        to: { x: 12, y: 130 },
+        expected: ['b1', 'b1a', 'b1b', 'b1b1', 'b2']
+      },
+      {
+        name: 'starts inside a block',
+        from: { x: 40, y: 140 },
+        to: { x: 250, y: 260 },
+        onBlock: 'b2',
+        expected: ['b2', 'b3', 'b3a', 'b4', 'b5']
+      },
+      // A thin drag in the left gutter: vertically over the note, horizontally
+      // clear of every block, so it must select nothing.
+      { name: 'selects nothing', from: { x: 1, y: 60 }, to: { x: 6, y: 200 }, expected: [] }
+    ]
+
+    for (const shape of shapes) {
+      const { trigger, blockContainer, blockContainerRef, cleanup } = setupNote(specs)
+      const downTarget = shape.onBlock
+        ? blockContainer.querySelector<HTMLElement>(`[data-id="${shape.onBlock}"]`)!
+        : undefined
+
+      const { ids, unmount } = drag(trigger, blockContainerRef, shape.from, shape.to, downTarget)
+
+      expect({ shape: shape.name, ids }).toEqual({
+        shape: shape.name,
+        ids: exhaustiveHits(blockContainer, boxOf(shape.from, shape.to))
+      })
+      expect({ shape: shape.name, ids }).toEqual({ shape: shape.name, ids: shape.expected })
+
+      unmount()
+      cleanup()
+    }
+  })
+
+  it('agrees with the exhaustive scan across randomised marquees on a nested note', () => {
+    const specs: BlockSpec[] = Array.from({ length: 40 }, (_, index) =>
+      index % 3 === 0
+        ? {
+            id: `n${index}`,
+            children: [
+              { id: `n${index}c0` },
+              { id: `n${index}c1`, children: [{ id: `n${index}c1c` }] }
+            ]
+          }
+        : { id: `n${index}` }
+    )
+    const random = makeRandom(20260808)
+
+    for (let i = 0; i < 150; i += 1) {
+      const { trigger, blockContainer, blockContainerRef, cleanup } = setupNote(specs)
+      const height = trigger.getBoundingClientRect().height
+      const y1 = Math.round(random() * height)
+      const y2 = Math.max(
+        0,
+        Math.min(height, y1 + (random() < 0.5 ? -1 : 1) * (16 + random() * 400))
+      )
+      const from = { x: Math.round(random() * 380), y: y1 }
+      const to = { x: Math.round(random() * 380), y: Math.round(y2) }
+
+      const { ids, unmount } = drag(trigger, blockContainerRef, from, to)
+
+      expect({ i, ids }).toEqual({ i, ids: exhaustiveHits(blockContainer, boxOf(from, to)) })
+
+      unmount()
+      cleanup()
+    }
   })
 })
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.ts
@@ -88,6 +88,21 @@ interface MeasuredBlock {
 // image settling to its final height, a zoom change or a block appearing can
 // never feed a stale rect into the selection — the only way a wrong rect gets
 // in is if the browser hands us one.
+//
+// TRIPWIRE, read this before changing how blocks are laid out. Both facts above
+// hold only while every `.bn-block` is in normal block flow. What was checked to
+// establish that: `@blocknote/xl-multi-column` is not a dependency, there is no
+// column block in `editor-schema.ts`, and no rule in `base.css` floats a
+// `.bn-block`, positions one absolutely, or puts siblings side by side.
+//
+// Introducing ANY non-normal-flow block layout — multi-column blocks,
+// side-by-side callouts, floats, absolute positioning — breaks those facts, and
+// this function then returns a WRONG selection rather than a slow one. That
+// selection feeds bulk delete/move, so the failure is data loss, not a glitch.
+// The tests cannot catch it: they build normal-flow DOM and compare against an
+// exhaustive scan of that same DOM, so they stay green while the assumption is
+// false. Revisit this function — pruning has to become per-column — as part of
+// any such change, not after a bug report.
 function collectMarqueeHits(
   container: HTMLElement,
   blocks: ArrayLike<HTMLElement>,

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.ts
@@ -69,6 +69,73 @@ function rectsIntersect(
   return !(a.right < b.left || a.left > b.right || a.bottom < b.top || a.top > b.bottom)
 }
 
+interface MeasuredBlock {
+  element: HTMLElement
+  rect: DOMRect
+}
+
+// Find the blocks a marquee box covers without measuring the whole note.
+//
+// Blocks live in normal block flow: siblings stack top-to-bottom in document
+// order and a nested block is laid out inside its parent's box. So across the
+// document-order list `rect.top` is non-decreasing, and any block that precedes
+// another without being its ancestor finishes before that one starts. Those two
+// facts are enough to skip everything above and below the marquee, which is why
+// a drag on a 500-block note costs the same as a drag on a 5-block one.
+//
+// Nothing here is cached. `blocks` is re-queried and every rect is re-read on
+// the frame it is used, so scrolling mid-drag, a resize, a sidebar toggle, an
+// image settling to its final height, a zoom change or a block appearing can
+// never feed a stale rect into the selection — the only way a wrong rect gets
+// in is if the browser hands us one.
+function collectMarqueeHits(
+  container: HTMLElement,
+  blocks: ArrayLike<HTMLElement>,
+  box: { left: number; top: number; right: number; bottom: number }
+): MeasuredBlock[] {
+  // Binary search for the first block that starts below the marquee's bottom
+  // edge. Every later block starts at least as low, so none of them intersect.
+  let lo = 0
+  let hi = blocks.length
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1
+    if (blocks[mid].getBoundingClientRect().top > box.bottom) hi = mid
+    else lo = mid + 1
+  }
+
+  const hits: MeasuredBlock[] = []
+  let stopIndex = -1
+  for (let i = lo - 1; i >= 0; i -= 1) {
+    const element = blocks[i]
+    const rect = element.getBoundingClientRect()
+    if (rect.bottom < box.top) {
+      // This block ends above the marquee. Every earlier block is either one of
+      // its ancestors or finishes before it starts, so the ancestors are the
+      // only boxes left that can still reach down into the marquee.
+      stopIndex = i
+      break
+    }
+    if (rectsIntersect(rect, box)) hits.push({ element, rect })
+  }
+  hits.reverse()
+
+  if (stopIndex === -1) return hits
+
+  const ancestors: MeasuredBlock[] = []
+  let node = blocks[stopIndex].parentElement
+  while (node && node !== container) {
+    if (node.matches('.bn-block[data-id]')) {
+      const rect = node.getBoundingClientRect()
+      if (rectsIntersect(rect, box)) ancestors.push({ element: node, rect })
+    }
+    node = node.parentElement
+  }
+  // Walked innermost-first; document order wants the outermost ancestor first,
+  // and every ancestor precedes every block the backwards scan collected.
+  ancestors.reverse()
+  return [...ancestors, ...hits]
+}
+
 function getOrderedBlockIds(container: HTMLElement, ids: ReadonlySet<string>): string[] {
   if (ids.size === 0) return []
   const ordered: string[] = []
@@ -358,11 +425,10 @@ export function useBlockMarqueeSelection({
         const blockEls = blockContainer.querySelectorAll<HTMLElement>('.bn-block[data-id]')
         const next = new Set<string>()
         const nextRects: BlockHighlightRect[] = []
-        blockEls.forEach((el) => {
-          const id = el.getAttribute('data-id')
-          if (!id || next.has(id)) return
-          const blockRect = el.getBoundingClientRect()
-          if (rectsIntersect(blockRect, { left, top, right, bottom })) {
+        collectMarqueeHits(blockContainer, blockEls, { left, top, right, bottom }).forEach(
+          ({ element, rect: blockRect }) => {
+            const id = element.getAttribute('data-id')
+            if (!id || next.has(id)) return
             next.add(id)
             nextRects.push({
               id,
@@ -372,7 +438,7 @@ export function useBlockMarqueeSelection({
               height: blockRect.height
             })
           }
-        })
+        )
         selectedRef.current = next
         setHighlightRects(nextRects)
 


### PR DESCRIPTION
## Problem

Every animation frame of a marquee block-selection drag re-measured the entire note.
`tick()` ran `blockContainer.querySelectorAll('.bn-block[data-id]')` and then called
`getBoundingClientRect()` on **every** result, for a box that typically covers three
or four blocks. Cost scaled linearly with note length, so the longer the note the
worse the drag felt.

Measured on a 200-block note (`rectReads` counted in the test harness, one frame):

| | rect measures per frame |
|---|---|
| before | **201** (1 trigger + 200 blocks) |
| after | **12** (1 trigger + 7 binary-search probes + 4 blocks around the marquee) |

A 500-block note was 501 before; it is still ~13 after, because the cost no longer
depends on note length.

## Root cause

The hit-test was a full linear scan with no attempt to narrow the candidate set,
re-run on every rAF tick for the whole duration of the drag.

## Fix

Blocks are laid out in normal block flow — siblings stack top-to-bottom in document
order and a nested block is laid out inside its parent's box. Two consequences:

1. `rect.top` is non-decreasing across the document-order block list.
2. A block that precedes another without being its ancestor finishes before that one starts.

`collectMarqueeHits()` uses both:

- binary search for the first block that starts below the marquee — everything after
  it starts lower still, so nothing there can intersect;
- walk backwards from there, collecting hits, until a block ends *above* the marquee;
- at that point the only earlier boxes that can still reach down into the marquee are
  that block's **ancestors**, so walk those explicitly instead of scanning to the top.

The 2-D `rectsIntersect` test is unchanged and still applied to every candidate, so
horizontal behaviour (gutter drags, right-to-left drags) is untouched.

### Caching decision: nothing is cached

The obvious fix — cache block rects at drag start and invalidate on scroll/resize — is
the trap here. A stale rect means a block the user dragged over is *not* selected, or a
block they never touched *is*, and that selection then feeds Backspace/Delete. That is
data loss. It would have to be invalidated correctly for: scroll during the drag, window
resize, sidebar toggle, an image or lazy embed finishing load and changing a block's
height, a block added or removed mid-drag, and zoom. Height changes triggered by
*content* (image load) produce no scroll or resize event at all, so that set cannot be
covered reliably.

So this PR caches **neither geometry nor element references**. The block list is
re-queried and every rect is re-read on the frame it is used, exactly as before — only
the *number* of blocks measured changes. Every invalidation case above is therefore
inapplicable by construction: there is no cache to go stale. This is the same discipline
as sibling PR #1170 (#1049), which deliberately cached element references only and never
offsets; this one is stricter and caches nothing.

### TRIPWIRE: the normal-flow assumption

The whole optimisation rests on one invariant — **every `.bn-block` is in normal block
flow**, which is what gives non-decreasing `rect.top` in document order and a
non-ancestor predecessor finishing before its successor starts.

What was checked to establish it holds today:

- `@blocknote/xl-multi-column` is not a dependency;
- `editor-schema.ts` declares no column / `columnList` block (the `'column'` hits
  elsewhere in the repo are the kanban drag context, unrelated to the editor);
- no rule in `base.css` floats a `.bn-block`, positions one absolutely, or lays
  siblings out side by side (`.bn-block-group { flex: 1 }` is a flex *item* property,
  not `display: flex`).

**Introducing any non-normal-flow block layout — multi-column blocks, side-by-side
callouts, floats, absolute positioning — requires revisiting `collectMarqueeHits`.** Once
the invariant is false the function returns a *wrong* selection rather than a slow one,
and that selection feeds bulk delete/move, so the failure mode is data loss rather than a
glitch. The tests cannot observe the violation: they build normal-flow DOM and compare
against an exhaustive scan of that same DOM, so they stay green while the assumption is
false. Vertical pruning would have to become per-column. The same note is carried in the
comment above `collectMarqueeHits` so it is visible at the point of change.

## Test evidence

New tests in `use-block-marquee-selection.test.tsx`, all driving the real hook through
mousedown/mousemove/mouseup. Every one of them asserts the selection is **identical to
an exhaustive reference scan** over the same DOM, and pins the exact id list:

- **measure count** — 200-block note, marquee low in the note: exact count `12`, exact
  selection `['b166','b167','b168']`.
- **enclosing parent** — marquee covers only deep children; the parent must still be
  selected: `['parent','child4','child5']`.
- **every drag shape** — down, up, right-to-left, starting inside a block, and a
  gutter drag that selects nothing; each compared to the exhaustive scan *and* to a
  literal expected id list.
- **randomised** — 150 seeded random marquees over a 40-block note with two levels of
  nesting, each compared to the exhaustive scan.

RED first: the correctness tests passed against the old implementation (they pin
existing behaviour), and the count test failed `expected 201 to be 12`. After the fix,
11/11 pass.

### Mutation verification

Three single-line mutations, each targeted by line number:

| mutation | result |
|---|---|
| line 122 → unconditional `return hits` (drops the ancestor walk) | **killed** — `expected ['child4','child5'] to deeply equal ['parent','child4','child5']`, plus the randomised oracle at `i: 2` |
| line 116 `break` → commented out (no early stop) | **killed** — `expected 177 to be 12` |
| line 102 `> box.bottom` → `>= box.bottom` (binary-search off-by-one) | **killed** — `right-to-left` shape and the randomised oracle at `i: 4` |

No survivors.

## Verification

```
pnpm typecheck                      16 successful, 16 total
pnpm lint                           0 errors (15 pre-existing warnings, none in touched files)
eslint --no-cache --max-warnings=0  clean on the changed source file
vitest --project renderer  note/content-area/ + pages/note.test.tsx   PASS (433) FAIL (0) skipped (6)
vitest --project renderer  use-block-marquee-selection.test.tsx       PASS (11) FAIL (0)
git diff --check                    clean
react-doctor (run twice, compared)  identical apart from the timing line; the one
                                    finding in this file (effect-needs-cleanup:350)
                                    is pre-existing — it was line 283 before, shifted
                                    by the 67 inserted lines
```

## Risk & backward compatibility

Renderer-only, and confined to one function plus its call site. No DB, migration, IPC
contract, sync payload, vault format or settings shape is touched, and markdown
serialization is untouched — nothing is written differently, so older and newer app
versions read and write identical data. `shouldStartMarquee`'s BlockNote menu focus
guards are unchanged, and no `setState` was added to any `beforeinput` path.

The residual risk is the normal-flow assumption. If a future editor feature lays
`.bn-block` siblings out side by side (a column block), the vertical pruning would need
to become per-column; the comment above `collectMarqueeHits` states the assumption
explicitly so it is visible at the point of change.

## Docs

`pnpm docs:impact --base origin/main --strict` reports `missing-docs` for
`use-block-marquee-selection.ts`. **Deliberately not updating docs**: the gate flags any
desktop source change, and this one has no user-visible behaviour — the selected set is
provably identical, only the measurement cost changed. There is no new setting, UI,
format or contract. The only doc that references this hook,
`apps/docs/src/contribute/gotchas.md`, describes `shouldStartMarquee`'s menu focus
guards, which this PR does not touch, and remains accurate.

Closes #1050

