### PR TITLE
perf(graph): reuse one Sigma instance in the local graph panel

### DIFF
--- a/apps/desktop/config/vitest.config.ts
+++ b/apps/desktop/config/vitest.config.ts
@@ -107,6 +107,12 @@ export default defineConfig({
           include: ['src/renderer/**/*.{test,spec}.{ts,tsx}'],
           setupFiles: ['tests/setup.ts', 'tests/setup-dom.ts'],
           css: true,
+          // `@react-sigma/core` is the only renderer dependency a test drives for
+          // real rather than stubbing: local-graph-panel-sigma-lifecycle.test.tsx
+          // needs the container's genuine "recreate Sigma on prop identity change"
+          // rule. Externalised it would import the real `sigma` (WebGL, absent in
+          // jsdom) and ignore `vi.mock('sigma')`; inlined, the stub applies.
+          server: { deps: { inline: ['@react-sigma/core'] } },
           testTimeout: 30000,
           hookTimeout: 30000,
           environmentOptions: {

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel-sigma-lifecycle.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel-sigma-lifecycle.test.tsx
@@ -1,0 +1,391 @@
+/**
+ * Renderer lifecycle harness for the local graph panel.
+ *
+ * Unlike `local-graph-panel.test.tsx` — which stubs `SigmaContainer` with a plain
+ * div — this suite drives the *real* `SigmaContainer` from `@react-sigma/core` and
+ * stubs the `sigma` package underneath it, so the container's real "recreate on
+ * graph/settings identity change" rule decides how many Sigma instances (and
+ * therefore WebGL contexts) get built. That makes the instance count an observable
+ * assertion instead of a claim about timing.
+ */
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type Graph from 'graphology'
+import type { GraphDataResponse } from '@memry/contracts/graph-api'
+
+const mocks = vi.hoisted(() => ({
+  localGraph: { data: null as GraphDataResponse | null, isLoading: false },
+  /** Every Sigma ever constructed in this test file, in creation order. */
+  instances: [] as FakeSigmaLike[]
+}))
+
+interface FakeSigmaLike {
+  graph: Graph
+  settings: Record<string, unknown>
+  killed: boolean
+  refreshCount: number
+  cameraState: { x: number; y: number; ratio: number; angle: number }
+  getGraph: () => Graph
+}
+
+vi.mock('sigma', () => {
+  class FakeSigma {
+    killed = false
+    refreshCount = 0
+    cameraState = { x: 0, y: 0, ratio: 1, angle: 0 }
+    private readonly camera = {
+      getState: (): FakeSigma['cameraState'] => this.cameraState,
+      setState: (state: FakeSigma['cameraState']): void => {
+        this.cameraState = { ...state }
+      }
+    }
+
+    constructor(
+      public graph: Graph,
+      public container: HTMLElement,
+      public settings: Record<string, unknown>
+    ) {
+      mocks.instances.push(this as unknown as FakeSigmaLike)
+    }
+
+    getGraph(): Graph {
+      return this.graph
+    }
+
+    getCamera(): FakeSigma['camera'] {
+      return this.camera
+    }
+
+    setSetting(key: string, value: unknown): void {
+      this.settings = { ...this.settings, [key]: value }
+    }
+
+    refresh(): void {
+      this.refreshCount += 1
+    }
+
+    /** A killed Sigma releases its WebGL context; a leaked one never does. */
+    kill(): void {
+      this.killed = true
+    }
+  }
+
+  return { Sigma: FakeSigma, default: FakeSigma }
+})
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' })
+}))
+
+vi.mock('@/hooks/use-graph-data', () => ({
+  useLocalGraphData: () => mocks.localGraph
+}))
+
+vi.mock('./graph-events', () => ({
+  GraphEvents: () => null
+}))
+
+const { LocalGraphPanel } = await import('./local-graph-panel')
+
+function node(
+  id: string,
+  label: string,
+  overrides: Partial<GraphDataResponse['nodes'][number]> = {}
+): GraphDataResponse['nodes'][number] {
+  return {
+    id,
+    type: 'note',
+    label,
+    tags: [],
+    wordCount: 5,
+    connectionCount: 1,
+    emoji: null,
+    isOrphan: false,
+    isUnresolved: false,
+    ...overrides
+  }
+}
+
+/** note-a (the centre) linked to note-b, plus an unconnected note-c. */
+const baseData: GraphDataResponse = {
+  nodes: [node('note-a', 'Alpha'), node('note-b', 'Beta'), node('note-c', 'Gamma')],
+  edges: [{ source: 'note-a', target: 'note-b', type: 'wikilink', weight: 1 }]
+}
+
+function liveContextCount(): number {
+  return mocks.instances.filter((instance) => !instance.killed).length
+}
+
+function currentSigma(): FakeSigmaLike {
+  const sigma = mocks.instances.at(-1)
+  if (!sigma) throw new Error('no Sigma was constructed')
+  return sigma
+}
+
+function nodeIds(graph: Graph): string[] {
+  return graph.nodes().sort()
+}
+
+function edgeKeys(graph: Graph): string[] {
+  return graph.edges().sort()
+}
+
+/**
+ * Pending animation frames, keyed by handle so a cancel really drops the callback —
+ * a torn-down simulation must not keep stepping just because its frame was queued.
+ */
+let frames = new Map<number, FrameRequestCallback>()
+let nextFrameHandle = 0
+
+function runFrames(count: number): void {
+  act(() => {
+    for (let i = 0; i < count; i++) {
+      const next = frames.entries().next()
+      if (next.done) return
+      frames.delete(next.value[0])
+      next.value[1](16 * (i + 1))
+    }
+  })
+}
+
+describe('LocalGraphPanel Sigma lifecycle', () => {
+  beforeEach(() => {
+    mocks.instances.length = 0
+    mocks.localGraph = { data: baseData, isLoading: false }
+    frames = new Map()
+    nextFrameHandle = 0
+    document.documentElement.style.setProperty('--graph-dimmed-node', '#dddddd')
+    document.documentElement.style.setProperty('--graph-edge-soft', '#cccccc')
+    document.documentElement.style.setProperty('--graph-label-color', '#111111')
+    // Deterministic node seeding so a moved node is a force, not a coin flip.
+    let seed = 0.13
+    vi.spyOn(Math, 'random').mockImplementation(() => {
+      seed = (seed * 9301 + 0.49297) % 1
+      return seed
+    })
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      nextFrameHandle += 1
+      frames.set(nextFrameHandle, callback)
+      return nextFrameHandle
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((handle) => {
+      frames.delete(handle)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function renderPanel(noteId = 'note-a'): ReturnType<typeof render> {
+    return render(<LocalGraphPanel noteId={noteId} onClose={vi.fn()} />)
+  }
+
+  function refetch(
+    view: ReturnType<typeof render>,
+    data: GraphDataResponse,
+    noteId = 'note-a'
+  ): void {
+    // React Query hands back a fresh object for every refetch whose payload is not
+    // deeply equal to the cached one — a note save changes wordCount, so it always is.
+    mocks.localGraph = { data, isLoading: false }
+    act(() => {
+      view.rerender(<LocalGraphPanel noteId={noteId} onClose={vi.fn()} />)
+    })
+  }
+
+  it('builds one Sigma instance and holds one WebGL context across repeated refetches', () => {
+    const view = renderPanel()
+    expect(mocks.instances).toHaveLength(1)
+
+    for (let i = 1; i <= 10; i++) {
+      refetch(view, {
+        nodes: baseData.nodes.map((n) =>
+          n.id === 'note-a' ? { ...n, wordCount: 5 + i } : { ...n }
+        ),
+        edges: baseData.edges.map((edge) => ({ ...edge }))
+      })
+    }
+
+    expect(mocks.instances).toHaveLength(1)
+    expect(liveContextCount()).toBe(1)
+  })
+
+  it('shows exactly the refetched local graph, with no leftovers from the previous one', () => {
+    const view = renderPanel()
+    const sigma = currentSigma()
+    expect(nodeIds(sigma.getGraph())).toEqual(['note-a', 'note-b', 'note-c'])
+    expect(edgeKeys(sigma.getGraph())).toEqual(['note-a-note-b-wikilink'])
+
+    // note-c is gone, note-d arrived and is linked, note-b was renamed.
+    refetch(view, {
+      nodes: [
+        node('note-a', 'Alpha'),
+        node('note-b', 'Beta renamed'),
+        node('note-d', 'Delta', { tags: ['ideas'] })
+      ],
+      edges: [{ source: 'note-a', target: 'note-d', type: 'wikilink', weight: 1 }]
+    })
+
+    const graph = currentSigma().getGraph()
+    expect(mocks.instances).toHaveLength(1)
+    expect(nodeIds(graph)).toEqual(['note-a', 'note-b', 'note-d', 'tag:ideas'])
+    expect(edgeKeys(graph)).toEqual(['note-a-note-d-wikilink', 'note-d-tag:ideas-entity-tag'])
+    expect(graph.getNodeAttribute('note-b', 'label')).toBe('Beta renamed')
+  })
+
+  it('keeps the position a surviving node was simulated to, and the camera the user set', () => {
+    const view = renderPanel()
+    const sigma = currentSigma()
+    runFrames(3)
+    sigma.getCamera().setState({ x: 0.25, y: -0.5, ratio: 0.4, angle: 0 })
+    const settled = {
+      x: sigma.getGraph().getNodeAttribute('note-a', 'x') as number,
+      y: sigma.getGraph().getNodeAttribute('note-a', 'y') as number
+    }
+
+    refetch(view, {
+      nodes: [node('note-a', 'Alpha'), node('note-b', 'Beta'), node('note-c', 'Gamma')],
+      edges: [{ source: 'note-a', target: 'note-b', type: 'wikilink', weight: 1 }]
+    })
+
+    expect(currentSigma().getGraph().getNodeAttribute('note-a', 'x')).toBe(settled.x)
+    expect(currentSigma().getGraph().getNodeAttribute('note-a', 'y')).toBe(settled.y)
+    expect(currentSigma().getCamera().getState()).toEqual({
+      x: 0.25,
+      y: -0.5,
+      ratio: 0.4,
+      angle: 0
+    })
+  })
+
+  it('lets the simulation place a node that a refetch added', () => {
+    const view = renderPanel()
+    runFrames(3)
+
+    refetch(view, {
+      nodes: [...baseData.nodes, node('note-d', 'Delta')],
+      edges: baseData.edges.map((edge) => ({ ...edge }))
+    })
+
+    const graph = currentSigma().getGraph()
+    const seeded = graph.getNodeAttribute('note-d', 'x') as number
+    runFrames(3)
+    expect(graph.getNodeAttribute('note-d', 'x')).not.toBe(seeded)
+  })
+
+  describe('rebuilding the simulation', () => {
+    /**
+     * The graph instance now outlives the data, so the effect keyed on it no longer
+     * re-runs and a stale simulation would keep pushing nodes the refetch deleted.
+     *
+     * A rebuilt simulation re-reads positions from the graph; a running one keeps its
+     * own copy and writes it back every tick. So: park a sentinel on a surviving node,
+     * refetch, tick once, and the sentinel survives only if the simulation was rebuilt.
+     */
+    const SENTINEL = 1_000_000
+
+    function simulationWasRebuilt(
+      view: ReturnType<typeof render>,
+      data: GraphDataResponse
+    ): boolean {
+      runFrames(2)
+      currentSigma().getGraph().setNodeAttribute('note-a', 'x', SENTINEL)
+      refetch(view, data)
+      runFrames(1)
+      return Math.abs(currentSigma().getGraph().getNodeAttribute('note-a', 'x') as number) > 1_000
+    }
+
+    it('is left alone when only node attributes changed', () => {
+      const view = renderPanel()
+      expect(
+        simulationWasRebuilt(view, {
+          nodes: baseData.nodes.map((n) => ({ ...n, wordCount: 99 })),
+          edges: baseData.edges.map((edge) => ({ ...edge }))
+        })
+      ).toBe(false)
+    })
+
+    it('is rebuilt when a refetch removed a node', () => {
+      const view = renderPanel()
+      expect(
+        simulationWasRebuilt(view, {
+          nodes: baseData.nodes.filter((n) => n.id !== 'note-c'),
+          edges: baseData.edges.map((edge) => ({ ...edge }))
+        })
+      ).toBe(true)
+    })
+
+    it('is rebuilt when a refetch removed a link but kept every node', () => {
+      const view = renderPanel()
+      expect(simulationWasRebuilt(view, { nodes: baseData.nodes, edges: [] })).toBe(true)
+    })
+
+    it('is rebuilt when a refetch added a link between nodes it already had', () => {
+      const view = renderPanel()
+      expect(
+        simulationWasRebuilt(view, {
+          nodes: baseData.nodes,
+          edges: [
+            { source: 'note-a', target: 'note-b', type: 'wikilink', weight: 1 },
+            { source: 'note-a', target: 'note-c', type: 'wikilink', weight: 1 }
+          ]
+        })
+      ).toBe(true)
+    })
+  })
+
+  it('re-centres on a new note without building a second Sigma', () => {
+    const view = renderPanel('note-a')
+    const sigma = currentSigma()
+    expect(
+      (sigma.settings.nodeReducer as (id: string, attrs: Record<string, unknown>) => unknown)(
+        'note-b',
+        { size: 5 }
+      )
+    ).not.toMatchObject({ color: '#f59e0b' })
+
+    refetch(view, baseData, 'note-b')
+
+    expect(mocks.instances).toHaveLength(1)
+    expect(
+      (
+        currentSigma().settings.nodeReducer as (
+          id: string,
+          attrs: Record<string, unknown>
+        ) => unknown
+      )('note-b', { size: 5 })
+    ).toMatchObject({ color: '#f59e0b', highlighted: true, forceLabel: true })
+  })
+
+  it('kills its Sigma instance on unmount, releasing the WebGL context', () => {
+    const view = renderPanel()
+    refetch(view, {
+      nodes: [...baseData.nodes, node('note-d', 'Delta')],
+      edges: baseData.edges.map((edge) => ({ ...edge }))
+    })
+
+    view.unmount()
+
+    expect(mocks.instances).toHaveLength(1)
+    expect(liveContextCount()).toBe(0)
+  })
+
+  it('releases every context when the panel is remounted, as a vault switch does', () => {
+    for (let i = 0; i < 4; i++) {
+      const view = renderPanel()
+      refetch(view, {
+        nodes: baseData.nodes.map((n) => ({ ...n, wordCount: 5 + i })),
+        edges: baseData.edges.map((edge) => ({ ...edge }))
+      })
+      view.unmount()
+    }
+
+    expect(mocks.instances).toHaveLength(4)
+    expect(liveContextCount()).toBe(0)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel.test.tsx
@@ -11,6 +11,9 @@ const mocks = vi.hoisted(() => ({
   },
   sigma: {
     refresh: vi.fn(),
+    // The panel freezes SigmaContainer's `settings` prop and pushes later reducers
+    // through setSetting, so the stub has to accept them.
+    setSetting: vi.fn(),
     // The live simulation refreshes only the instance that owns the graph it is
     // stepping, so the mock has to model getGraph like the real Sigma does.
     getGraph: (): unknown => mocks.sigmaContainerProps?.graph
@@ -212,28 +215,41 @@ describe('LocalGraphPanel', () => {
 
   it('runs a live simulation and stops it on unmount', () => {
     // The suite-wide stub runs frames synchronously, which would settle the whole
-    // simulation during mount. Queue them instead so each step is observable.
-    const frames: FrameRequestCallback[] = []
+    // simulation during mount. Queue them instead so each step is observable, keyed by
+    // handle so a cancel really drops the callback — the simulation is rebuilt once the
+    // panel's graph is filled, and its first, superseded frame must not still be pending.
+    const frames = new Map<number, FrameRequestCallback>()
+    let nextHandle = 0
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
-      frames.push(callback)
-      return frames.length
+      nextHandle += 1
+      frames.set(nextHandle, callback)
+      return nextHandle
     })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((handle) => {
+      frames.delete(handle)
+    })
+    const runNextFrame = (time: number): void => {
+      const next = frames.entries().next()
+      if (next.done) return
+      frames.delete(next.value[0])
+      next.value[1](time)
+    }
 
     const { unmount } = render(<LocalGraphPanel noteId="note-a" onClose={vi.fn()} />)
     const graph = mocks.sigmaContainerProps?.graph
     const before = graph.getNodeAttribute('note-a', 'x')
-    expect(frames).toHaveLength(1)
+    expect(frames.size).toBe(1)
 
     act(() => {
-      frames.shift()?.(16)
+      runNextFrame(16)
     })
     expect(graph.getNodeAttribute('note-a', 'x')).not.toBe(before)
-    expect(frames).toHaveLength(1)
+    expect(frames.size).toBe(1)
 
     unmount()
     const afterUnmount = graph.getNodeAttribute('note-a', 'x')
     act(() => {
-      frames.shift()?.(32)
+      runNextFrame(32)
     })
     expect(graph.getNodeAttribute('note-a', 'x')).toBe(afterUnmount)
   })

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel.tsx
@@ -3,7 +3,9 @@ import { SigmaContainer, useSigma } from '@react-sigma/core'
 import { useTheme } from 'next-themes'
 import '@react-sigma/core/lib/style.css'
 import { X, Maximize2 } from '@/lib/icons'
+import Graph from 'graphology'
 import type { NodeDisplayData, EdgeDisplayData } from 'sigma/types'
+import type { GraphDataResponse } from '@memry/contracts/graph-api'
 import { Button } from '@/components/ui/button'
 import { useLocalGraphData } from '@/hooks/use-graph-data'
 import { buildGraphologyGraph } from '@/lib/graph-builder'
@@ -57,8 +59,8 @@ export function LocalGraphPanel({
   const softEdgeColor = useMemo(() => resolveGraphVar('--graph-edge-soft', '#d5d3cd'), [])
 
   const labelColor = useMemo(() => resolveGraphVar('--graph-label-color', '#1a1a1a'), [])
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const graph = useMemo(() => (data ? buildGraphologyGraph(data) : null), [data, resolvedTheme])
+
+  const { graph, layoutRevision } = useLiveLocalGraph(data, resolvedTheme)
 
   const nodeReducer = useCallback(
     (node: string, attrs: Record<string, unknown>): Partial<NodeDisplayData> => {
@@ -121,7 +123,7 @@ export function LocalGraphPanel({
     [graph, softEdgeColor]
   )
 
-  const sigmaSettings = useMemo(
+  const initialSigmaSettings = useMemo(
     () => ({
       nodeReducer,
       edgeReducer,
@@ -132,7 +134,10 @@ export function LocalGraphPanel({
       renderEdgeLabels: false,
       minEdgeThickness: 0.5
     }),
-    [nodeReducer, edgeReducer, labelColor]
+    // Frozen on purpose: a new settings object makes SigmaContainer rebuild the
+    // renderer. Reducers that change afterwards are pushed by LocalSigmaSettingsSync.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   )
 
   const handleFocusNode = useCallback(() => {}, [])
@@ -149,7 +154,7 @@ export function LocalGraphPanel({
     physicsHandleRef.current?.release(nodeId)
   }, [])
 
-  if (isLoading || !graph) {
+  if (isLoading || !data) {
     return (
       <div className="relative h-[250px] rounded-md border border-border bg-muted/30">
         <div className="flex h-full items-center justify-center">
@@ -160,7 +165,7 @@ export function LocalGraphPanel({
     )
   }
 
-  if (graph.order === 0) {
+  if (data.nodes.length === 0) {
     return (
       <div className="relative h-[250px] rounded-md border border-border bg-muted/30">
         <div className="flex h-full items-center justify-center">
@@ -175,13 +180,21 @@ export function LocalGraphPanel({
     <div className="relative h-[250px] rounded-md border border-border bg-muted/30 overflow-hidden">
       <PanelHeader onClose={onClose} onOpenFullGraph={onOpenFullGraph} />
 
-      <SigmaContainer graph={graph} settings={sigmaSettings} className="h-full w-full">
+      <SigmaContainer graph={graph} settings={initialSigmaSettings} className="h-full w-full">
+        <LocalSigmaSettingsSync nodeReducer={nodeReducer} edgeReducer={edgeReducer} />
         <LocalHoverFadeAnimator
           hoveredNode={hoveredNode}
           fadeRef={fadeRef}
           hoverTargetRef={hoverTargetRef}
         />
-        <LivePhysics graph={graph} handleRef={physicsHandleRef} options={LOCAL_PHYSICS} />
+        {/* Remounting the simulation is how nodes a refetch added get placed: the
+            graph instance outlives them now, so the effect keyed on it never re-runs. */}
+        <LivePhysics
+          key={layoutRevision}
+          graph={graph}
+          handleRef={physicsHandleRef}
+          options={LOCAL_PHYSICS}
+        />
         <GraphEvents
           onHoverNode={setHoveredNode}
           onTooltipMove={setTooltipPos}
@@ -197,6 +210,123 @@ export function LocalGraphPanel({
       )}
     </div>
   )
+}
+
+/**
+ * One graphology instance for the panel's lifetime, refilled in place as data arrives.
+ *
+ * `SigmaContainer` kills and rebuilds Sigma — and with it the WebGL context — whenever
+ * the `graph` or `settings` prop changes identity, and the note page invalidates
+ * `graphKeys.local(noteId)` on every 1s save debounce. Building a new graph per refetch
+ * therefore burned a WebGL context per keystroke pause; browsers cap the live ones and
+ * silently drop the oldest, which blanks graphs elsewhere in the app.
+ *
+ * `layoutRevision` counts the refills that changed the node or edge set, so the force
+ * simulation is restarted only when it has something new to place.
+ */
+function useLiveLocalGraph(
+  data: GraphDataResponse | undefined,
+  themeKey: string | undefined
+): { graph: Graph; layoutRevision: number } {
+  const [graph] = useState(() => new Graph({ multi: true, type: 'undirected' }))
+  const appliedRef = useRef<{ data: GraphDataResponse; themeKey: string | undefined } | null>(null)
+  const [layoutRevision, setLayoutRevision] = useState(0)
+
+  useEffect(() => {
+    if (!data) return
+    const applied = appliedRef.current
+    // `themeKey` takes part because a theme flip re-resolves the CSS colour
+    // variables every node and edge attribute was built from.
+    if (applied && applied.data === data && applied.themeKey === themeKey) return
+    appliedRef.current = { data, themeKey }
+    /* eslint-disable react-you-might-not-need-an-effect/no-event-handler,
+       react-you-might-not-need-an-effect/no-chain-state-updates,
+       react-you-might-not-need-an-effect/no-adjust-state-on-prop-change -- genuine external sync: the
+       graphology instance Sigma is bound to is mutated here, and the counter only records that
+       its node or edge set moved so the simulation can be rebuilt. Refilling during render
+       would fire graphology's change events mid-render. */
+    if (refillGraph(graph, buildGraphologyGraph(data))) {
+      setLayoutRevision((current) => current + 1)
+    }
+    /* eslint-enable react-you-might-not-need-an-effect/no-event-handler,
+       react-you-might-not-need-an-effect/no-chain-state-updates,
+       react-you-might-not-need-an-effect/no-adjust-state-on-prop-change */
+  }, [graph, data, themeKey])
+
+  return { graph, layoutRevision }
+}
+
+/**
+ * Make `graph` hold exactly what `next` holds, without replacing the instance.
+ *
+ * Attributes are copied from a freshly built graph rather than recomputed here, so this
+ * can never drift from `buildGraphologyGraph` (tag nodes, degree-scaled sizes). Nodes
+ * that survive keep the position the simulation settled them at — the arrangement the
+ * user is looking at. Returns true when the node or edge set changed.
+ */
+function refillGraph(graph: Graph, next: Graph): boolean {
+  // Measured before the refill, and only over the node and edge sets: an attribute-only
+  // refetch — a word count ticking up as the user types — must not disturb the layout.
+  const structureChanged =
+    next.someNode((node) => !graph.hasNode(node)) ||
+    graph.someNode((node) => !next.hasNode(node)) ||
+    next.someEdge((edge) => !graph.hasEdge(edge)) ||
+    graph.someEdge((edge) => !next.hasEdge(edge))
+
+  for (const node of graph.nodes()) {
+    if (!next.hasNode(node)) graph.dropNode(node)
+  }
+
+  for (const edge of graph.edges()) {
+    if (!next.hasEdge(edge)) graph.dropEdge(edge)
+  }
+
+  next.forEachNode((node, attributes) => {
+    if (!graph.hasNode(node)) {
+      graph.addNode(node, attributes)
+      return
+    }
+    graph.replaceNodeAttributes(node, {
+      ...attributes,
+      x: graph.getNodeAttribute(node, 'x'),
+      y: graph.getNodeAttribute(node, 'y')
+    })
+  })
+
+  next.forEachEdge((edge, attributes, source, target) => {
+    if (graph.hasEdge(edge)) {
+      graph.replaceEdgeAttributes(edge, attributes)
+      return
+    }
+    graph.addEdgeWithKey(edge, source, target, attributes)
+  })
+
+  return structureChanged
+}
+
+/**
+ * Pushes the current reducers onto the live Sigma. `settings` is frozen at first render
+ * because handing SigmaContainer a new object rebuilds the renderer, so reducers that
+ * close over changed props (a different centre note) have to be applied imperatively.
+ */
+function LocalSigmaSettingsSync({
+  nodeReducer,
+  edgeReducer
+}: {
+  nodeReducer: (node: string, attrs: Record<string, unknown>) => Partial<NodeDisplayData>
+  edgeReducer: (edge: string, attrs: Record<string, unknown>) => Partial<EdgeDisplayData>
+}): null {
+  const sigma = useSigma()
+
+  useEffect(() => {
+    sigma.setSetting('nodeReducer', nodeReducer)
+  }, [sigma, nodeReducer])
+
+  useEffect(() => {
+    sigma.setSetting('edgeReducer', edgeReducer)
+  }, [sigma, edgeReducer])
+
+  return null
 }
 
 function PanelHeader({


### PR DESCRIPTION
Closes #1046

## Problem

Editing a note with its local graph panel open churned WebGL contexts. `pages/note.tsx` invalidates `graphKeys.local(noteId)` after every save (1s debounce), and each refetch tore down and rebuilt the whole Sigma renderer.

Measured on `origin/main` with a harness that drives the real `SigmaContainer` over a stubbed `sigma`:

| | Sigma instances / WebGL contexts |
|---|---|
| 1 mount + 10 refetches, before | **21** |
| 1 mount + 10 refetches, after | **1** |

Browsers cap live WebGL contexts (~16) and silently drop the oldest, so the churn shows up as a blank graph elsewhere in the app.

## Root cause

`SigmaContainer` recreates Sigma whenever **either** the `graph` prop or the `settings` prop changes identity (`useEffect(..., [containerRef, graph, sigmaSettings])`, with settings compared by a deep `isEqual` that treats functions as unequal unless referentially identical).

The issue attributed this to the `settings` object alone. That is only half of it, and not the dominant half: `graph` was a `useMemo` over `data`, so a refetch changed **both** props. That is why the count was 21 and not 11 — two rebuilds per refetch (one for the new graph, one for the follow-up settings state update). Freezing the settings alone, as the issue suggested, would have left the instance count unchanged.

## Fix

`local-graph-panel.tsx` only:

- One graphology instance for the panel's lifetime, refilled in place (`refillGraph`) as data arrives. Attributes are copied from a freshly built graph so this cannot drift from `buildGraphologyGraph` (tag nodes, degree-scaled sizes); surviving nodes keep the position the simulation settled them at.
- `initialSigmaSettings` frozen at first render, with a small `LocalSigmaSettingsSync` pushing later reducers through `sigma.setSetting` — the `GraphCanvas` pattern. This is what keeps a centre-note change (`noteId` changing under a mounted panel) from rebuilding the renderer.
- `<LivePhysics key={layoutRevision}>` — the graph now outlives the data, so the effect keyed on it no longer re-runs. `layoutRevision` bumps only when the node or edge set actually changed, so an attribute-only refetch (word count ticking up while you type) leaves the layout completely undisturbed, while an added/removed node or link rebuilds the simulation so it does not keep pushing nodes that are gone.

`physics-layout.tsx`, `graph-physics.ts` and `graph-canvas.tsx` are untouched.

**Camera state: preserved, deliberately.** With no rebuild, the user's zoom and pan are simply never touched across a refetch. Surviving nodes also keep their positions, so the view no longer jumps. (Previously `SigmaContainer` copied the camera state onto the new instance, but the graph underneath had been re-seeded with fresh random positions, so the preserved camera pointed at a re-scattered layout.) A node that no longer exists cannot be "kept in view" because the camera is not node-anchored.

## Test evidence

New `local-graph-panel-sigma-lifecycle.test.tsx` drives the **real** `SigmaContainer` (via `server.deps.inline`) over a stubbed `sigma` that counts constructions and `kill()`s, so instance and live-context counts are observable rather than inferred from timing.

RED on `origin/main` — 6 of 7 failing, including `expected [...] to have a length of 1 but got 21`. GREEN after the fix, 12/12. Full renderer project: **561 files, 6319 passed, 6 skipped, 0 failed**.

Mutation verification — every load-bearing line reverted individually by line number, all killed:

| # | Line reverted | Killed by |
|---|---|---|
| 1 | live graph → per-refetch `useMemo` rebuild | 8 tests |
| 2 | frozen settings deps → reactive deps | re-centres on a new note |
| 3 | `key={layoutRevision}` → `key={0}` | 4 tests |
| 4 | node-added clause of `structureChanged` | simulation places an added node |
| 5 | node-removed clause | rebuilt when a node was removed |
| 6 | edge-added clause | rebuilt when a link was added |
| 7 | edge-removed clause | rebuilt when a link was removed |
| 8 | `graph.dropNode` | shows exactly the refetched graph |
| 9 | `graph.dropEdge` | shows exactly the refetched graph |
| 10 | preserved `x` on a surviving node | 4 tests |
| 11 | `setSetting('nodeReducer', …)` | re-centres on a new note |

A first pass used `order`/`size` counters alongside containment checks; those two mutants **survived** because each shielded the other. Collapsed to four clauses that each carry one distinct behaviour (node added / node removed / edge added / edge removed), and all four now die.

Correctness is pinned on content, not just counts: after a refetch the tests assert the exact node set (`['note-a','note-b','note-d','tag:ideas']`) and edge set, plus a renamed label — no stale nodes, edges or tag nodes survive a refill. Teardown is asserted too: `kill()` on unmount leaves 0 live contexts, and four mount/refetch/unmount cycles (a vault switch) leave 0 live contexts across 4 instances.

## Risk & backward compatibility

Renderer-only. No DB, migration, IPC contract, vault format or settings shape is touched, so nothing older versions wrote is affected. The one shared change is a `server.deps.inline` entry for `@react-sigma/core` in the renderer vitest project — needed because externalised, the container pulls in real `sigma` (WebGL, absent in jsdom) and ignores `vi.mock('sigma')`. The full renderer project is green with it.

`react-doctor` category counts are byte-identical to `origin/main` (scanned twice, 1855 files, same result). `pnpm lint` is at the same 15 warnings / 0 errors as base.

## Docs

`pnpm docs:impact --base origin/main --strict` reports `missing-docs`, and I am not adding docs. No documented behaviour, setting, or surface changes here — the local graph panel is not documented today, and the Graph View page describes the standalone graph, which this PR does not touch. Documenting the panel is worth doing, but not inside a performance fix.

## Relation to #1139

Same class of fix — stop rebuilding the graphology instance per refetch — applied to the local panel instead of the main canvas. Kept deliberately independent so neither PR blocks the other: `refillGraph` lives inside `local-graph-panel.tsx` and does not touch `graph-builder.ts`. If #1139 lands first, `refillGraph` should be replaced by its `syncGraphologyGraph`, and `key={layoutRevision}` by the `revision` prop it adds to `LivePhysics`. Whichever lands second gets a small follow-up; there are no file-level conflicts today.
