### PR TITLE
fix(agent): drain stderr for title and summary turns

### DIFF
--- a/apps/desktop/src/main/agent/runtime/__tests__/turn-stderr-drain.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/turn-stderr-drain.test.ts
@@ -1,0 +1,457 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../event-bus', () => ({
+  broadcastAgentEvent: vi.fn()
+}))
+
+vi.mock('../../../telemetry/track', () => ({
+  trackMainEvent: vi.fn()
+}))
+
+// vi.hoisted, not a plain const: the logger module is pulled in eagerly by the
+// main-process import graph, so the factory runs before a plain const exists.
+const { loggerWarnMock } = vi.hoisted(() => ({ loggerWarnMock: vi.fn() }))
+vi.mock('../../../lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: loggerWarnMock,
+    error: vi.fn()
+  })
+}))
+
+import type { AgentBackendRegistry } from '../../backends/registry'
+import type { AgentBackend, BackendRunHandle, RawSubprocessHandle } from '../../backends/types'
+import { ClaudeCliBackend } from '../../backends/claude-cli-backend'
+import type { BackendEvent } from '../../cli/types'
+import type { ConversationStore } from '../../storage/conversation-store'
+import type { MessageStore } from '../../storage/message-store'
+import type { Conversation, Message, MessageContent, MessageRole } from '../../storage/types'
+import { runTurn } from '../turn'
+
+// Nothing here is mocked below the backend: a real child process writes a real
+// megabyte to a real stderr pipe. 1 MB is 16x the 64 KB OS pipe buffer, so the
+// child hits backpressure long before it is done and only finishes if the
+// parent actually reads. The reply line the turn needs is written to stdout
+// *after* the flood, so a parent that never drains stderr never sees stdout,
+// never sees the child exit, and hangs forever.
+const STDERR_BYTES = 1024 * 1024
+
+// Well under the 30s project testTimeout, so a hang fails as an explicit
+// deadline error with the child killed, not as a suite-wide timeout that
+// strands a blocked process.
+const DEADLINE_MS = 8000
+
+const FLOOD_SCRIPT = `'use strict'
+const total = Number(process.env.MEMRY_TEST_STDERR_BYTES)
+const reply = process.env.MEMRY_TEST_STDOUT_LINE
+const tail = process.env.MEMRY_TEST_STDERR_TAIL || ''
+const CHUNK = Buffer.alloc(64 * 1024, 0x61)
+let remaining = total
+const pump = () => {
+  while (remaining > 0) {
+    const size = Math.min(CHUNK.length, remaining)
+    remaining -= size
+    if (!process.stderr.write(CHUNK.subarray(0, size))) {
+      process.stderr.once('drain', pump)
+      return
+    }
+  }
+  if (tail) process.stderr.write(tail)
+  if (reply) process.stdout.write(reply + '\\n')
+  // Set, never process.exit(): exiting here would truncate the pipes.
+  process.exitCode = Number(process.env.MEMRY_TEST_EXIT_CODE || '0')
+}
+pump()
+`
+
+// Written last, after the megabyte of noise, exactly where a real CLI puts the
+// reason it died.
+const FATAL_TAIL = 'FATAL: memry mcp handshake refused'
+
+// Every fixture lives inside a per-run mkdtemp directory, so no test ever
+// creates a file at a predictable path in the OS temp dir.
+let fixtureDir: string
+let floodScript: string
+const children: ChildProcess[] = []
+
+beforeAll(async () => {
+  fixtureDir = await mkdtemp(path.join(tmpdir(), 'memry-turn-stderr-drain-'))
+  floodScript = path.join(fixtureDir, 'flood.cjs')
+  await writeFile(floodScript, FLOOD_SCRIPT)
+})
+
+afterEach(() => {
+  loggerWarnMock.mockClear()
+  // Runs even when the test body throws, so a red run never leaves a blocked
+  // child behind holding the vitest fork open.
+  for (const child of children.splice(0)) {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL')
+  }
+})
+
+afterAll(async () => {
+  await rm(fixtureDir, { recursive: true, force: true })
+})
+
+describe('agent turns against a CLI that floods stderr', () => {
+  it('completes the title turn and applies the generated title', async () => {
+    const messages = createFakeMessageStore()
+    const conversations = createFakeConversationStore()
+    const cli = floodingCli('{"type":"result","result":"Weekly Review Plan"}')
+
+    await withDeadline(
+      'title turn',
+      runTurn(
+        {
+          conversations,
+          messages,
+          backends: createFakeRegistry(backendOverFloodingCli(cli.spawn, 'title'))
+        },
+        {
+          conversationId: 'conversation-1',
+          sourceWindowId: 'window-1',
+          text: 'plan my week from my notes',
+          attachments: [],
+          backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+        }
+      )
+    )
+
+    // The generated title, not deterministicTitle('plan my week from my notes')
+    // — the fallback a swallowed title failure would have produced.
+    expect(conversations.update).toHaveBeenCalledWith(
+      'conversation-1',
+      { title: 'Weekly Review Plan' },
+      ['title']
+    )
+    // Proof the pipe really was filled and then drained end to end.
+    expect(cli.stderrBytesRead()).toBe(STDERR_BYTES)
+    expect(cli.child()?.exitCode).toBe(0)
+    // No listener or stream left behind on the success path.
+    expect(cli.child()?.stderr?.readableEnded).toBe(true)
+    expect(cli.child()?.stdout?.readableEnded).toBe(true)
+  })
+
+  it('completes the compaction summary turn and records the summary', async () => {
+    // Two oversized messages push the assembled prompt past COMPACTION_THRESHOLD;
+    // the seeded user message is also what keeps the title path out of this test.
+    const messages = createFakeMessageStore([
+      seedMessage({
+        id: 'old-1',
+        role: 'user',
+        content: { role: 'user', data: { text: 'a'.repeat(210_000) } },
+        createdAt: 1
+      }),
+      seedMessage({
+        id: 'old-2',
+        role: 'assistant',
+        content: { role: 'assistant', data: { text: 'b'.repeat(210_000) } },
+        createdAt: 2
+      })
+    ])
+    const conversations = createFakeConversationStore()
+    const cli = floodingCli(
+      '{"type":"result","result":"Earlier in this conversation: shipped the drain fix"}'
+    )
+
+    await withDeadline(
+      'compaction summary turn',
+      runTurn(
+        {
+          conversations,
+          messages,
+          backends: createFakeRegistry(backendOverFloodingCli(cli.spawn, 'summary'))
+        },
+        {
+          conversationId: 'conversation-1',
+          sourceWindowId: 'window-1',
+          text: 'continue',
+          attachments: [],
+          backendOptions: { backend: 'claude_cli', claudeEffort: 'high' }
+        }
+      )
+    )
+
+    // A hung or failed summarize is swallowed by runTurn and leaves no marker,
+    // so the compacted payload is the only proof the summary actually landed.
+    const compacted = messages
+      .listByConversation('conversation-1')
+      .find((message) => message.role === 'system')
+    expect(compacted?.content).toEqual({
+      role: 'system',
+      data: {
+        kind: 'compacted',
+        payload: {
+          summary: 'Earlier in this conversation: shipped the drain fix',
+          summarizedThroughId: 'old-1',
+          summarizedAt: expect.any(Number)
+        }
+      }
+    })
+    expect(cli.stderrBytesRead()).toBe(STDERR_BYTES)
+    expect(cli.child()?.exitCode).toBe(0)
+    expect(cli.child()?.stderr?.readableEnded).toBe(true)
+    expect(cli.child()?.stdout?.readableEnded).toBe(true)
+  })
+
+  it('keeps the stderr tail for the failure log and discards the noise before it', async () => {
+    const messages = createFakeMessageStore()
+    const conversations = createFakeConversationStore()
+    // No stdout reply and a non-zero exit: the CLI dies after its own noise.
+    const cli = floodingCli('', { stderrTail: FATAL_TAIL, exitCode: 1 })
+
+    await withDeadline(
+      'failed title turn',
+      runTurn(
+        {
+          conversations,
+          messages,
+          backends: createFakeRegistry(backendOverFloodingCli(cli.spawn, 'title'))
+        },
+        {
+          conversationId: 'conversation-1',
+          sourceWindowId: 'window-1',
+          text: 'plan my week from my notes',
+          attachments: [],
+          backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+        }
+      )
+    )
+
+    expect(cli.child()?.exitCode).toBe(1)
+    // Every byte was read — that is what unblocks the child — but only the tail
+    // is retained.
+    expect(cli.stderrBytesRead()).toBe(STDERR_BYTES + FATAL_TAIL.length)
+    const warned = loggerWarnMock.mock.calls.find(
+      (call) => call[0] === 'Conversation title backend exited non-zero'
+    )
+    expect(warned?.[1]).toEqual({
+      backend: 'claude_cli',
+      exitCode: 1,
+      stderr: expect.stringMatching(new RegExp(`^a{8158}${FATAL_TAIL}$`))
+    })
+    expect((warned?.[1] as { stderr: string }).stderr).toHaveLength(8192)
+    // A failed title never costs the user their message: the turn still runs and
+    // the conversation falls back to a title derived from what they typed.
+    expect(conversations.update).toHaveBeenCalledWith(
+      'conversation-1',
+      { title: 'plan my week from my notes' },
+      ['title']
+    )
+    expect(messages.listByConversation('conversation-1').map((message) => message.role)).toEqual([
+      'user',
+      'assistant'
+    ])
+  })
+})
+
+async function withDeadline<T>(label: string, work: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} did not complete within ${DEADLINE_MS}ms`)),
+      DEADLINE_MS
+    )
+  })
+  try {
+    // Promise.race keeps a handler attached to `work`, so a later settlement of
+    // the losing promise never surfaces as an unhandled rejection.
+    return await Promise.race([work, deadline])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function floodingCli(
+  reply: string,
+  opts: { stderrTail?: string; exitCode?: number } = {}
+): {
+  spawn: () => Promise<RawSubprocessHandle>
+  stderrBytesRead: () => number
+  child: () => ChildProcess | null
+} {
+  let stderrBytes = 0
+  let child: ChildProcess | null = null
+
+  return {
+    stderrBytesRead: () => stderrBytes,
+    child: () => child,
+    // The adapter shape from agent/bootstrap.ts: the raw child pipes, and an
+    // exit promise that only ever listens for 'exit'.
+    spawn: async () => {
+      const proc = spawn(process.execPath, [floodScript], {
+        env: {
+          ...process.env,
+          MEMRY_TEST_STDERR_BYTES: String(STDERR_BYTES),
+          MEMRY_TEST_STDOUT_LINE: reply,
+          MEMRY_TEST_STDERR_TAIL: opts.stderrTail ?? '',
+          MEMRY_TEST_EXIT_CODE: String(opts.exitCode ?? 0)
+        }
+      })
+      children.push(proc)
+      child = proc
+      const stdout = proc.stdout
+      const stderr = proc.stderr
+      if (!stdout || !stderr) {
+        throw new Error('Claude subprocess stdio unavailable')
+      }
+      const exitCodePromise = new Promise<number>((resolve) => {
+        proc.once('exit', (code) => resolve(code ?? 0))
+      })
+
+      return {
+        stdout,
+        // Pull-based like the raw Readable it wraps: it counts what the consumer
+        // actually reads and drains nothing on its own.
+        stderr: (async function* () {
+          for await (const chunk of stderr) {
+            stderrBytes += (chunk as Buffer).length
+            yield chunk as Buffer
+          }
+        })(),
+        pid: proc.pid ?? -1,
+        kill: () => proc.kill('SIGTERM'),
+        waitExit: () => exitCodePromise,
+        cleanup: async () => {}
+      }
+    }
+  }
+}
+
+function backendOverFloodingCli(
+  spawnFn: () => Promise<RawSubprocessHandle>,
+  route: 'title' | 'summary'
+): AgentBackend {
+  // Real ClaudeCliBackend, so the flooding child goes through the real stream
+  // parser and the real BackendRunHandle wiring.
+  const real = new ClaudeCliBackend({ spawn: spawnFn })
+  return {
+    id: 'claude_cli',
+    // The main turn path already drains stderr, so it stays trivial here; only
+    // the path under test gets the flooding CLI.
+    runTurn: async () =>
+      quickHandle([{ kind: 'assistant_delta', text: 'ok' }, { kind: 'message_stop' }]),
+    generateTitle: async (input) => (route === 'title' ? real.generateTitle(input) : quickHandle()),
+    summarize: async (input) => (route === 'summary' ? real.summarize(input) : quickHandle()),
+    cancel: () => {},
+    getStatus: async () => ({ backend: 'claude_cli' as const, available: true })
+  }
+}
+
+function quickHandle(events: BackendEvent[] = [{ kind: 'message_stop' }]): BackendRunHandle {
+  return {
+    events: (async function* () {
+      yield* events
+    })(),
+    stderr: (async function* () {})(),
+    pid: 1,
+    kill: () => {},
+    waitExit: async () => 0,
+    cleanup: async () => {}
+  }
+}
+
+function createFakeRegistry(backend: AgentBackend): AgentBackendRegistry {
+  return {
+    get: vi.fn(() => backend),
+    list: vi.fn(() => [backend])
+  }
+}
+
+function createFakeConversationStore(): ConversationStore {
+  const conversation = {
+    id: 'conversation-1',
+    vaultId: 'vault-1',
+    title: 'New conversation',
+    backend: 'claude_cli',
+    backendModel: null,
+    trustList: [],
+    pinned: false,
+    vectorClock: {},
+    fieldClocks: {},
+    createdAt: 1,
+    updatedAt: 1,
+    deletedAt: null,
+    lastSyncedAt: null
+  } as Conversation
+
+  return {
+    create: vi.fn(),
+    getById: vi.fn(() => conversation),
+    listByVault: vi.fn(() => [conversation]),
+    update: vi.fn((_id, patch) => ({ ...conversation, ...patch, updatedAt: 2 })),
+    softDelete: vi.fn(),
+    addToTrustList: vi.fn(),
+    removeFromTrustList: vi.fn()
+  }
+}
+
+function createFakeMessageStore(seed: Message[] = []): MessageStore {
+  const messages: Message[] = [...seed]
+  let nextId = 1
+
+  return {
+    append(input) {
+      const message: Message = {
+        id: `message-${nextId++}`,
+        conversationId: input.conversationId,
+        role: input.role,
+        content: input.content,
+        toolCallId: input.toolCallId ?? null,
+        attachments: input.attachments,
+        status: input.status,
+        vectorClock: { d: 1 },
+        createdAt: nextId,
+        updatedAt: nextId,
+        deletedAt: null
+      }
+      messages.push(message)
+      return message
+    },
+    getById(id) {
+      return messages.find((message) => message.id === id) ?? null
+    },
+    listByConversation(conversationId) {
+      return messages.filter((message) => message.conversationId === conversationId)
+    },
+    updateStreaming(id, patch) {
+      const message = this.getById(id)
+      if (!message) throw new Error(`Message ${id} not found`)
+      Object.assign(message, patch, { updatedAt: message.updatedAt + 1 })
+      return message
+    },
+    markTerminal(id, status, patch) {
+      const message = this.getById(id)
+      if (!message) throw new Error(`Message ${id} not found`)
+      Object.assign(message, patch, { status, updatedAt: message.updatedAt + 1 })
+      return message
+    }
+  }
+}
+
+function seedMessage(input: {
+  id: string
+  role: MessageRole
+  content: MessageContent
+  createdAt: number
+}): Message {
+  return {
+    id: input.id,
+    conversationId: 'conversation-1',
+    role: input.role,
+    content: input.content,
+    toolCallId: null,
+    attachments: [],
+    status: 'completed',
+    vectorClock: { d: 1 },
+    createdAt: input.createdAt,
+    updatedAt: input.createdAt,
+    deletedAt: null
+  }
+}

--- a/apps/desktop/src/main/agent/runtime/__tests__/turn-stderr-drain.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/turn-stderr-drain.test.ts
@@ -200,6 +200,115 @@ describe('agent turns against a CLI that floods stderr', () => {
     expect(cli.child()?.stdout?.readableEnded).toBe(true)
   })
 
+  it('logs why the summary CLI died and leaves the history uncompacted', async () => {
+    const messages = createFakeMessageStore([
+      seedMessage({
+        id: 'old-1',
+        role: 'user',
+        content: { role: 'user', data: { text: 'a'.repeat(210_000) } },
+        createdAt: 1
+      }),
+      seedMessage({
+        id: 'old-2',
+        role: 'assistant',
+        content: { role: 'assistant', data: { text: 'b'.repeat(210_000) } },
+        createdAt: 2
+      })
+    ])
+    const conversations = createFakeConversationStore()
+    // No stdout reply and a non-zero exit: the CLI dies after its own noise.
+    const cli = floodingCli('', { stderrTail: FATAL_TAIL, exitCode: 1 })
+
+    await withDeadline(
+      'failed compaction summary turn',
+      runTurn(
+        {
+          conversations,
+          messages,
+          backends: createFakeRegistry(backendOverFloodingCli(cli.spawn, 'summary'))
+        },
+        {
+          conversationId: 'conversation-1',
+          sourceWindowId: 'window-1',
+          text: 'continue',
+          attachments: [],
+          backendOptions: { backend: 'claude_cli', claudeEffort: 'high' }
+        }
+      )
+    )
+
+    expect(cli.child()?.exitCode).toBe(1)
+    expect(cli.stderrBytesRead()).toBe(STDERR_BYTES + FATAL_TAIL.length)
+    // The thrown error is swallowed into a compaction warning upstream, so this
+    // log line is the only place the CLI's own reason survives.
+    const warned = loggerWarnMock.mock.calls.find(
+      (call) => call[0] === 'Conversation summary backend exited non-zero'
+    )
+    expect(warned?.[1]).toEqual({
+      backend: 'claude_cli',
+      exitCode: 1,
+      stderr: expect.stringMatching(new RegExp(`^a{8158}${FATAL_TAIL}$`))
+    })
+    expect((warned?.[1] as { stderr: string }).stderr).toHaveLength(8192)
+    // No 'compacted' marker: a failed summary must never replace the history it
+    // failed to summarize. The user's turn runs anyway, uncompacted.
+    expect(messages.listByConversation('conversation-1').map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+      'assistant'
+    ])
+  })
+
+  it('survives a stderr read error without stranding a rejection in main', async () => {
+    const messages = createFakeMessageStore()
+    const conversations = createFakeConversationStore()
+    // A pipe can fail mid-read — the child is killed and its stdio destroyed
+    // with an error (stop button, killAll on vault teardown). The CLI here still
+    // exits 0, so nothing awaits the drain: unhandled, that rejection reaches
+    // main's swallowing uncaughtException handler and vanishes.
+    const readError = new Error('read ECONNRESET')
+    const unhandled: unknown[] = []
+    const recordUnhandled = (reason: unknown): void => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', recordUnhandled)
+
+    try {
+      await withDeadline(
+        'title turn over a failing stderr pipe',
+        runTurn(
+          {
+            conversations,
+            messages,
+            backends: createFakeRegistry(backendWithFailingTitleStderr(readError))
+          },
+          {
+            conversationId: 'conversation-1',
+            sourceWindowId: 'window-1',
+            text: 'plan my week from my notes',
+            attachments: [],
+            backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+          }
+        )
+      )
+      // An unhandled rejection is reported a tick after the promise is dropped.
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    } finally {
+      process.off('unhandledRejection', recordUnhandled)
+    }
+
+    expect(unhandled).toEqual([])
+    // The read error is reported, not silently eaten.
+    expect(loggerWarnMock).toHaveBeenCalledWith('Failed to read backend stderr', readError)
+    // And the turn is unaffected: the title the CLI produced still lands.
+    expect(conversations.update).toHaveBeenCalledWith(
+      'conversation-1',
+      { title: 'Weekly Review Plan' },
+      ['title']
+    )
+  })
+
   it('keeps the stderr tail for the failure log and discards the noise before it', async () => {
     const messages = createFakeMessageStore()
     const conversations = createFakeConversationStore()
@@ -339,6 +448,32 @@ function backendOverFloodingCli(
       quickHandle([{ kind: 'assistant_delta', text: 'ok' }, { kind: 'message_stop' }]),
     generateTitle: async (input) => (route === 'title' ? real.generateTitle(input) : quickHandle()),
     summarize: async (input) => (route === 'summary' ? real.summarize(input) : quickHandle()),
+    cancel: () => {},
+    getStatus: async () => ({ backend: 'claude_cli' as const, available: true })
+  }
+}
+
+function backendWithFailingTitleStderr(readError: Error): AgentBackend {
+  return {
+    id: 'claude_cli',
+    runTurn: async () =>
+      quickHandle([{ kind: 'assistant_delta', text: 'ok' }, { kind: 'message_stop' }]),
+    generateTitle: async () => ({
+      events: (async function* () {
+        yield { kind: 'assistant_delta', text: 'Weekly Review Plan' } as BackendEvent
+      })(),
+      stderr: (async function* () {
+        yield Buffer.from('claude: starting\n')
+        throw readError
+      })(),
+      pid: 2,
+      kill: () => {},
+      // Exit 0: the failure branch that awaits the drain is never taken, so the
+      // rejection has no other observer.
+      waitExit: async () => 0,
+      cleanup: async () => {}
+    }),
+    summarize: async () => quickHandle(),
     cancel: () => {},
     getStatus: async () => ({ backend: 'claude_cli' as const, available: true })
   }

--- a/apps/desktop/src/main/agent/runtime/turn.ts
+++ b/apps/desktop/src/main/agent/runtime/turn.ts
@@ -30,6 +30,10 @@ export interface TurnDeps {
 }
 
 const DEFAULT_CONVERSATION_TITLE = 'New conversation'
+// Title and summary stderr is drained purely to keep the child moving, so it is
+// retained as a bounded tail rather than in full: a CLI can emit megabytes of
+// node warnings and MCP diagnostics, and the reason it failed is at the end.
+const STDERR_TAIL_LIMIT = 8 * 1024
 const DEFAULT_TURN_PERMISSIONS: AgentTurnPermissions = {
   accessMode: 'vault_only',
   webSearchEnabled: false
@@ -332,6 +336,11 @@ async function generateTitleWithBackend(
     purpose: 'title'
   })
   const sub = deps.trackRunHandle?.(input.conversationId, rawSub) ?? rawSub
+  // Draining has to start before the event loop below, not after waitExit():
+  // once the OS stderr pipe buffer fills, the child blocks on write, so it
+  // stops producing stdout and never exits, and both the loop and waitExit()
+  // wait forever on a child that is waiting on us.
+  const stderrTailPromise = sub.stderr ? collectStreamTail(sub.stderr) : Promise.resolve('')
   let raw = ''
   let title = ''
 
@@ -345,7 +354,7 @@ async function generateTitleWithBackend(
 
     const exitCode = await sub.waitExit()
     if (exitCode !== 0) {
-      const stderrText = sub.stderr ? (await collectStreamText(sub.stderr)).trim() : ''
+      const stderrText = (await stderrTailPromise).trim()
       logger.warn('Conversation title backend exited non-zero', {
         backend: input.backend.id,
         exitCode,
@@ -428,6 +437,10 @@ async function summarizeWithBackend(
     purpose: 'summary'
   })
   const sub = deps.trackRunHandle?.(input.conversationId, rawSub) ?? rawSub
+  // Same deadlock as the title path: a summarize child that fills the stderr
+  // pipe blocks on write and never exits, and this one runs before the turn's
+  // own subprocess, so it strands the whole turn.
+  const stderrTailPromise = sub.stderr ? collectStreamTail(sub.stderr) : Promise.resolve('')
   let summary = ''
 
   try {
@@ -436,6 +449,13 @@ async function summarizeWithBackend(
     }
     const exitCode = await sub.waitExit()
     if (exitCode !== 0) {
+      // The thrown message is swallowed into a compaction warning upstream, so
+      // stderr is logged here or the CLI's own reason is lost entirely.
+      logger.warn('Conversation summary backend exited non-zero', {
+        backend: input.backend.id,
+        exitCode,
+        stderr: (await stderrTailPromise).trim()
+      })
       throw new Error(`${input.backend.id} summarize exited with code ${exitCode}`)
     }
     const trimmed = summary.trim()
@@ -446,6 +466,24 @@ async function summarizeWithBackend(
   } finally {
     await sub.cleanup()
   }
+}
+
+// Consumes the stream to the end — that is the point, the child cannot finish
+// until it does — while retaining only the last STDERR_TAIL_LIMIT characters.
+// Never rejects: callers only await it on the failure branch, so a read error
+// on a stream nobody is waiting for must not become an unhandled rejection in
+// main (where index.ts's uncaughtException handler would silently swallow it).
+async function collectStreamTail(stream: AsyncIterable<Buffer | string>): Promise<string> {
+  let text = ''
+  try {
+    for await (const chunk of stream) {
+      text += typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+      if (text.length > STDERR_TAIL_LIMIT) text = text.slice(-STDERR_TAIL_LIMIT)
+    }
+  } catch (error) {
+    logger.warn('Failed to read backend stderr', error)
+  }
+  return text
 }
 
 async function collectStreamText(stream: AsyncIterable<Buffer | string>): Promise<string> {

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -56,6 +56,13 @@ Agent Chat can:
 - stop an in-flight turn
 - compact older conversation history when a prompt grows too large
 
+Naming a new conversation and compacting its history both run the CLI in the background. A CLI that
+prints a lot of diagnostic output while doing so no longer stalls the turn: memrynote reads that
+output as it arrives rather than waiting for the CLI to finish. If the CLI then fails, the tail of
+that output is written to the local log, the conversation falls back to a title derived from your
+first message, and the turn continues with its history uncompacted — your message and the
+conversation are never lost.
+
 While a turn runs, its tool calls collapse into a single activity row instead of stacking one row per
 step, so a long turn no longer pushes the answer off screen. The row names the tool the agent is
 running, counts the steps so far, and shows a spinner until the turn ends. Once the turn is done the


### PR DESCRIPTION
Closes #1035

## Problem

Agent Chat spawns the CLI with piped stdio for every turn. The main turn path drains stderr from the
moment the handle exists (`turn.ts:153`), but the two background paths did not:

- `generateTitleWithBackend` read `sub.stderr` only inside the `exitCode !== 0` branch, i.e. **after**
  `waitExit()` had already resolved.
- `summarizeWithBackend` never touched `sub.stderr` at all.

A CLI that writes more than the ~64 KB OS pipe buffer to stderr (node warnings, MCP diagnostics)
blocks on write. Blocked, it stops producing stdout and never exits, so the `for await (const event of
sub.events)` loop never ends and `waitExit()` never resolves. A hung title turn takes the whole user
turn with it, because `runTurn`'s `finally` awaits `titlePromise`; a hung summarize strands the turn
before it even starts. Either way the conversation's turn lock is held for the rest of the app run,
with a live child attached.

## Root cause

Draining stderr was treated as error reporting, so it only ran on the failure branch. It is actually a
liveness requirement: the parent must keep reading or the child cannot finish.

## Fix

Both paths now start draining as soon as the run handle exists, exactly as the main turn path already
does. The drain helper (`collectStreamTail`):

- **Retains the last 8 KB, discards everything before it.** That is where a CLI puts the reason it
  died; the megabytes of preamble are read (which is the point) and thrown away instead of being held
  in main-process memory. Everything is still consumed, so the child always unblocks.
- **Never rejects.** Callers only await it on the failure branch, so a read error on a stream nobody
  is waiting for must not become an unhandled rejection — `src/main/index.ts` installs a swallowing
  `uncaughtException` handler, which would turn that into a silent hang.

The summarize failure now logs that tail. Previously the CLI's own reason was discarded entirely and
the only trace was `... summarize exited with code N`.

No listeners are attached and no stream is left open on any path: the drain is a `for await` over the
handle's own stderr iterable, which ends when the child's fd closes, on both the success and the
failure branch. The tests assert `stderr.readableEnded` and `stdout.readableEnded` after each turn.

## Test evidence

`apps/desktop/src/main/agent/runtime/__tests__/turn-stderr-drain.test.ts` — a **real** child process
(`node`, no mocking below the backend) writes a real 1 MB to a real stderr pipe under real
backpressure. 1 MB is 16x the 64 KB pipe buffer. The single stdout line the turn needs is written only
after the whole flood has been accepted, so a parent that never drains never sees stdout, never sees
the child exit, and hangs. Every fixture lives in a per-run `mkdtemp` directory (never a predictable
temp path) and is removed in `afterAll`; surviving children are SIGKILLed in `afterEach`, which runs
even when the test body throws.

Pre-fix (RED) — all three time out at the 8 s deadline:

```
× completes the title turn and applies the generated title 8024ms
× completes the compaction summary turn and records the summary 8006ms
× keeps the stderr tail for the failure log and discards the noise before it 8005ms
  Tests  3 failed (3)
```

Post-fix (GREEN):

```
✓ completes the title turn and applies the generated title 40ms
✓ completes the compaction summary turn and records the summary 37ms
✓ keeps the stderr tail for the failure log and discards the noise before it 37ms
  Tests  3 passed (3)
```

Values are pinned, not shapes: the conversation title is asserted to be the generated
`Weekly Review Plan` (not the `deterministicTitle` fallback a swallowed failure would produce), the
compacted payload is asserted to equal the exact summary text, `stderrBytesRead()` is asserted to
equal the full 1 048 576 bytes (proof the pipe was filled and then fully drained), and the retained
tail is asserted to be exactly 8192 chars matching `/^a{8158}FATAL: memry mcp handshake refused$/`.

### Mutation verification

Each mutation targeted a single line by line number and was reverted afterwards.

| # | line | mutation | result |
|---|------|----------|--------|
| 1 | `turn.ts:343` | title drain -> `Promise.resolve('')` | **killed** — title + tail tests time out (8 s); summary test correctly survives, different path |
| 2 | `turn.ts:443` | summarize drain -> `Promise.resolve('')` | **killed** — summary test times out (8 s) |
| 3 | `turn.ts:481` | tail cap -> `if (false)` | **killed** — retained stderr becomes the full 1 MB instead of the 8192-char tail |

No survivors.

## Verification

```
pnpm typecheck                                    16 successful, 16 total
pnpm lint                                         0 errors (15 pre-existing warnings, all renderer)
vitest --project main src/main/agent              50 files, 330 tests passed
vitest --project main turn-stderr-drain.test.ts   3 passed
git diff --check                                  clean
pnpm docs:impact --base origin/main --strict      covered
pnpm docs:build                                   build complete
```

No contracts, preload, IPC channel or Agent Chat channel types were touched, so `ipc:generate` /
`ipc:check` are unaffected (`pnpm typecheck` reports "IPC invoke map is up to date").

## Risk & backward compatibility

Low. No DB schema, IPC contract, settings shape, sync payload or vault format is touched — the change
is confined to `runTurn`'s two internal helpers, plus one new local helper function. Nothing is
persisted differently, so older and newer app versions read and write identical data.

Behaviour deltas, all in the failing direction only:

- A title or summary turn that previously hung now completes.
- The title failure log's `stderr` field is now capped at the last 8 KB instead of being the full
  (previously unbounded) capture. The `exitCode !== 0` reason still reaches the log; only leading
  noise is dropped.
- Summarize failures now emit one additional `logger.warn` carrying that tail.

**Data loss:** none, in either direction. A failed title is already caught inside
`maybeGenerateConversationTitle` and falls back to a title derived from the user's own first message;
a failed summarize is already caught in `runTurn` and skips compaction for that turn so the
conversation history is left intact and uncompacted. The user's message and the assistant turn run
regardless — and that is exactly what stopped happening when these paths hung.

## Relation to #1171

Same file family, no overlap. #1171 changes `cli/spawn.ts` and `cli/codex-spawn.ts` (waiting for the
`'spawn'` event, rejecting on `'error'`); this changes `runtime/turn.ts` only, and does not touch the
spawn helpers or their tests. The two are complementary: #1171 covers a child that never starts, this
covers a child that starts and then cannot finish. The only shared file is
`apps/docs/src/user-guide/ai/agent-mcp.md`, where #1171 edits the CLI-detection paragraph and this
adds a separate paragraph ~13 lines below it; they should merge cleanly.


---

## Follow-up: `codecov/patch` (84.61% -> added lines fully covered)

Measured locally instead of guessing, over every test file that loads `turn.ts`
(`turn.test.ts`, `turn-stderr-drain.test.ts`, `agent-handlers.test.ts`). Exactly two added lines were
unhit — 11/13 = 84.61%, matching the gate:

- `turn.ts:454` — the `logger.warn` carrying the summarize CLI's stderr tail. My three tests only ran
  a summarize that exited **0**.
- `turn.ts:484` — the `logger.warn` inside `collectStreamTail`'s catch.

Both are behaviour this PR claims, so both got a real test. No production code changed.

**`logs why the summary CLI died and leaves the history uncompacted`** — the summarize CLI floods
stderr *and* exits non-zero. Asserts the 8192-char tail reaches `logger.warn` (the only place that
reason survives, since the thrown error is swallowed into a compaction warning upstream) and that the
message roles are exactly `['user', 'assistant', 'user', 'assistant']` — no `compacted` marker, so a
failed summary never replaces the history it failed to summarize.

**`survives a stderr read error without stranding a rejection in main`** — the stderr iterable throws
mid-read (a pipe destroyed with an error: stop button, `killAll` on vault teardown) while the CLI
still exits 0, so nothing awaits the drain. Asserts no `unhandledRejection` escapes, the read error is
logged, and the title still lands.

Re-measured: **no added statement/line is uncovered.**

### Mutation results — all seven mutants killed, none survived

| # | line | mutation | killed by |
|---|------|----------|-----------|
| 1 | `343` | title drain -> `Promise.resolve('')` | title / read-error / tail tests (2 time out at 8 s) |
| 2 | `443` | summarize drain -> `Promise.resolve('')` | both summary tests (time out at 8 s) |
| 3 | `481` | tail cap -> `if (false)` | both tail-assertion tests |
| 4 | `454` | `logger.warn` -> `logger.debug` | summary-failure test |
| 5 | `484` | `logger.warn(...)` -> `throw error` | read-error test: `expected [ Error: read ECONNRESET ] to deeply equal []` |
| 6 | `484` | `logger.warn(...)` -> `void error` | read-error test (proves the log assertion stands alone) |

Each mutation targeted a single line by number and was reverted before the next.

### Justified gaps — branches, not lines; deliberately not tested

Three *branch* arms on added lines remain uncovered. `codecov/patch` is line-based so none of these
affect the gate, and I would rather flag them than write a test that only colours them green:

- `turn.ts:343` and `turn.ts:443`, the `: Promise.resolve('')` arm — taken only when a
  `BackendRunHandle` omits `stderr`. The field is optional in the type, but all three shipped backends
  always populate it (`claude-cli` and `codex-cli` pass `proc.stderr`; `local-openai-compatible`
  passes `textToStream(...)`). Type-level defensiveness with no production caller.
- `turn.ts:480`, the `typeof chunk === 'string'` arm — unreachable: the parameter type is
  `AsyncIterable<Buffer | string>` (copied from the pre-existing `collectStreamText` for consistency),
  but `textToStream` is declared `AsyncIterable<Buffer>` and yields `Buffer.from(text)`, so every
  shipped backend yields Buffers only.

### Re-verification

```
pnpm typecheck                                  16 successful, 16 total
pnpm lint                                       0 errors (15 pre-existing warnings, all renderer)
vitest --project main src/main/agent            50 files, 332 tests passed
git diff --check                                clean
```
