### PR TITLE
fix(voice): reap the Whisper utility process when its start times out

### DIFF
--- a/apps/desktop/src/main/inbox/voice-model.test.ts
+++ b/apps/desktop/src/main/inbox/voice-model.test.ts
@@ -13,9 +13,17 @@ const getAllWindows = vi.hoisted(() => vi.fn())
 
 class MockUtilityProcess extends EventEmitter {
   postMessage = vi.fn()
-  kill = vi.fn().mockReturnValue(true)
-  stdout = null
-  stderr = null
+  // Models Electron's UtilityProcess.kill(): the child is reaped, so `exit`
+  // fires and the pipes go away. A second kill on a dead child returns false.
+  killed = false
+  kill = vi.fn(() => {
+    if (this.killed) return false
+    this.killed = true
+    this.emit('exit', 0)
+    return true
+  })
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
   pid = 1234
 
   simulateMessage(message: unknown): void {
@@ -336,6 +344,71 @@ describe('voice model', () => {
     await vi.advanceTimersByTimeAsync(5 * 60_000)
 
     await requestTimeoutExpectation
+  })
+
+  it('reaps the utility process and detaches its listeners when the start times out', async () => {
+    vi.useFakeTimers()
+    const startTimeout = transcribeWithLocalModel(Buffer.from('audio'))
+    const startTimeoutExpectation = expect(startTimeout).rejects.toThrow(
+      'Voice transcription utility failed to start within timeout'
+    )
+
+    const orphan = mockUtilityProcessInstance
+    const orphanStdout = orphan.stdout
+    const orphanStderr = orphan.stderr
+    expect(orphan.killed).toBe(false)
+    expect(orphanStdout.listenerCount('data')).toBe(1)
+    expect(orphanStderr.listenerCount('data')).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    await startTimeoutExpectation
+
+    // The child is still holding the Whisper model at this point, so dropping
+    // the reference is not enough — it has to be reaped.
+    expect(orphan.kill).toHaveBeenCalledTimes(1)
+    expect(orphan.killed).toBe(true)
+    // ...and nothing may still be pointing at it.
+    expect(orphan.listenerCount('message')).toBe(0)
+    expect(orphan.listenerCount('error')).toBe(0)
+    expect(orphan.listenerCount('exit')).toBe(0)
+    expect(orphanStdout.listenerCount('data')).toBe(0)
+    expect(orphanStderr.listenerCount('data')).toBe(0)
+  })
+
+  it('transcribes on the next attempt after a start timeout, ignoring the orphan', async () => {
+    vi.useFakeTimers()
+    const timedOut = transcribeWithLocalModel(Buffer.from('first'))
+    const timedOutExpectation = expect(timedOut).rejects.toThrow(
+      'Voice transcription utility failed to start within timeout'
+    )
+    const orphan = mockUtilityProcessInstance
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    await timedOutExpectation
+
+    const retry = transcribeWithLocalModel(Buffer.from('second'))
+    expect(mockFork).toHaveBeenCalledTimes(2)
+    const fresh = mockUtilityProcessInstance
+    expect(fresh).not.toBe(orphan)
+
+    // A worker that finally finished loading long after we gave up must not be
+    // able to reach back in and knock out the process we just started.
+    orphan.emit('message', { type: 'ready' })
+    orphan.emit('exit', 1)
+
+    fresh.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(fresh.postMessage).toHaveBeenCalledTimes(1)
+    })
+    const request = fresh.postMessage.mock.calls[0]?.[0] as { requestId: string }
+    fresh.simulateMessage({
+      type: 'transcribe-result',
+      requestId: request.requestId,
+      transcription: 'second memo'
+    })
+
+    await expect(retry).resolves.toBe('second memo')
+    expect(fresh.killed).toBe(false)
   })
 
   it('stops a running utility process via graceful shutdown or timeout kill', async () => {

--- a/apps/desktop/src/main/inbox/voice-model.ts
+++ b/apps/desktop/src/main/inbox/voice-model.ts
@@ -348,14 +348,35 @@ class VoiceModelBridge {
 
   private failProcess(error: Error): void {
     this.clearIdleShutdown()
-    if (this.process) {
+    const failed = this.process
+    if (failed) {
       this.process = null
+      this.teardownProcess(failed)
     }
     this.readyPromise = null
     this.loaded = false
     this.loading = false
     this.error = error.message
     this.rejectAll(error)
+  }
+
+  /**
+   * Reap a utility process we are giving up on.
+   *
+   * A start timeout leaves a child that is still loading Whisper — hundreds of
+   * MB of resident model — so dropping the reference alone leaks the whole
+   * process. Detach first: Electron drops `stdout`/`stderr` once the child
+   * exits, and a retained `exit`/`message` listener lets a late orphan reach
+   * back into the bridge and knock out the *next* process. `kill()` is not
+   * awaited, so this can never turn the leak into a hang.
+   */
+  private teardownProcess(child: ReturnType<typeof utilityProcess.fork>): void {
+    child.stdout?.removeAllListeners('data')
+    child.stderr?.removeAllListeners('data')
+    child.removeAllListeners('message')
+    child.removeAllListeners('error')
+    child.removeAllListeners('exit')
+    child.kill()
   }
 
   private rejectAll(error: Error): void {


### PR DESCRIPTION
## Problem

`VoiceModelBridge.failProcess()` nulled the utility-process handle without killing it. On a start timeout (`START_TIMEOUT_MS = 10s`, reached on cold/slow disks and first-run model downloads) the forked `voice-transcription-worker` keeps running with the Whisper model resident — hundreds of MB — permanently unreachable. The next transcription forks a fresh one, so every timeout adds another model-holding process that never goes away until the app quits. It shows up in Activity Monitor totals, not in the app's own RSS.

The stdout/stderr `data` listeners and the pre-ready `message`/`error`/`exit` listeners were left attached too, so the orphan retained the whole child object graph — and, worse, could still call back into the bridge (see root cause).

Reproduced with a real Electron `utilityProcess` on Electron 43.1.1 — PID checked with `process.kill(pid, 0)`, not by "we didn't call kill":

```
before (drop the reference, as today):
  pid 99308  aliveAfterTimeout: true
  listeners: { message: 1, error: 1, exit: 1, stdoutData: 1, stderrData: 1 }
after (detach + kill):
  pid 99427  killReturned: true  aliveAfterTeardown: false
  listeners: { message: 0, error: 0, exit: 0 }
subsequent start: pid 99529 alive: true
```

## Root cause

Two coupled omissions in `failProcess()`:

1. No `kill()`. Dropping the JS handle does not terminate an OS process. The siblings get this right — `stop()` kills on shutdown timeout, `reset()` kills unconditionally.
2. No listener detachment. The start-timeout branch does not run `cleanup()`, so `onMessage`/`onFatalError`/`onExitBeforeReady` stay bound to the orphan. That is not only a retention leak: a worker that *finally* finished loading after we gave up would fire `onMessage('ready')` → `setupProcessHandlers(orphan)`, and its eventual `exit` would re-enter `failProcess()` and null out the process started in the meantime — leaking that one too and failing the user's retry with "Voice transcription utility is not running".

## Fix

`failProcess()` now hands the child to a new `teardownProcess()` before dropping it. Teardown detaches the stdout/stderr `data` listeners and the `message`/`error`/`exit` listeners, then kills. Detach-before-kill is deliberate: Electron drops `child.stdout`/`child.stderr` once the child exits, so detaching afterwards would silently no-op.

`kill()` is **not** awaited, so this cannot turn the leak into a hang. Electron's `UtilityProcess.kill()` reaps the child (verified above: `ESRCH` after the call).

All five `failProcess()` call sites benefit; the start timeout is the one where the child is still alive and holding the model.

## What happens to the user's audio

Nothing is lost. `transcribeAudio(itemId, attachmentPath)` reads the WAV from the vault attachment that `captureVoice` already wrote, so a start timeout only writes `transcriptionStatus: 'failed'` + `processingError` on the inbox item via `createFailureResult`. The recording stays in the vault and `retryTranscription()` re-reads the same file. This PR does not change that path.

## Test evidence

`apps/desktop/src/main/inbox/voice-model.test.ts` — the mock now models real Electron semantics (`kill()` sets `killed`, emits `exit`, returns `false` on a dead child) and has real `stdout`/`stderr` emitters so listener counts are observable.

Two new tests pin actual values, not "a teardown function was called":

- **reaps the utility process and detaches its listeners when the start times out** — after the 10s timeout: `killed === true`, `kill` called once, and `listenerCount` is `0` for `message`, `error`, `exit`, `stdout:'data'`, `stderr:'data'` (each asserted `1` before the timeout).
- **transcribes on the next attempt after a start timeout, ignoring the orphan** — end-to-end: the retry forks a fresh process, the orphan then emits a late `ready` and `exit 1`, and the retry still resolves to `'second memo'`. This is the "a subsequent transcription still works" proof; without the fix the orphan's late `exit` nulls the fresh handle and the retry rejects.

RED before the fix: 2 failed / 9 passed.

### Mutation verification

Each behaviour line deleted individually, targeted by line number:

| line | statement | result |
|---|---|---|
| 354 | `this.teardownProcess(failed)` | 2 failed / 9 passed |
| 374 | `child.stdout?.removeAllListeners('data')` | 1 failed / 10 passed |
| 375 | `child.stderr?.removeAllListeners('data')` | 1 failed / 10 passed |
| 376 | `child.removeAllListeners('message')` | 2 failed / 9 passed |
| 377 | `child.removeAllListeners('error')` | 1 failed / 10 passed |
| 378 | `child.removeAllListeners('exit')` | 4 failed / 7 passed |
| 379 | `child.kill()` | 1 failed / 10 passed |

No survivors, no mutual shielding — every line carries behaviour a test observes.

### Verify

```
pnpm typecheck            16 successful, 16 total
pnpm lint                 15 problems (0 errors, 15 warnings) — all pre-existing, none in changed files
vitest --project main     Test Files 477 passed | 1 skipped (478)
                          Tests 5442 passed | 1 expected fail | 4 skipped (5447)
git diff --check          clean
```

## Risk & backward compatibility

Low. Main-process only, confined to `VoiceModelBridge`'s failure path. No IPC contract, preload, DB schema, vault format, or settings shape is touched — nothing to migrate and nothing an older version could have written differently. The externally visible behaviour is unchanged: the same `Error` still rejects, the same `processingError` still lands on the inbox item, the retry button still works.

One deliberate corner: if the worker exits with a **non-zero** code while `stop()` is awaiting its graceful shutdown, `failProcess()` now removes the `exit` listener that `stop()` registered, so `stop()` falls through to its existing `SHUTDOWN_TIMEOUT_MS` (3s) path and then resolves. Bounded, already-implemented behaviour, same end state (process dead, `stop()` resolves).

Docs: `pnpm docs:impact --base origin/main --strict` reports `missing-docs`. Not acting on it — the gate is advisory (pre-push exits before invoking it, no CI workflow references it, and `MEMRY_DOCS_IMPACT_SKIP` is implemented nowhere), and this change is invisible to users: same error text, same retry affordance, same audio retention. Nothing under `apps/docs/src` documents the transcription utility-process lifecycle.

Closes #1040
