### PR TITLE
fix(agent): kill an abandoned turn child before cleanup untracks it

### DIFF
--- a/apps/desktop/src/main/agent/runtime/__tests__/turn-child-kill.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/turn-child-kill.test.ts
@@ -138,6 +138,89 @@ describe('runTurn subprocess lifetime on the turn error path', () => {
     expect(tracking.aliveWhenCleanupRan).toBe(false)
   })
 
+  it('keeps the turn error and still cleans up when the kill call itself throws', async () => {
+    const child = startChild({ first: deltaLine('hello'), linger: LINGER_MS })
+    // What ChildProcess.kill() does when the platform rejects the signal
+    // (EINVAL/ENOSYS) — the one way kill() raises instead of returning false.
+    child.killImpl = () => {
+      throw new Error('kill EINVAL')
+    }
+    const backend = createClaudeBackend(child.handle)
+    const tracking = createTrackingHarness(child)
+
+    broadcastAgentEventMock.mockImplementation((event: { kind: string }) => {
+      if (event.kind === 'assistant_text_delta') {
+        throw new Error('Object has been destroyed')
+      }
+    })
+
+    const startedAt = Date.now()
+    // The error the user is shown is still the one that actually ended the
+    // turn. Anything thrown out of the finally would replace it with
+    // 'kill EINVAL' and bury the real cause.
+    await expect(
+      runTurn(
+        {
+          conversations: createFakeConversationStore({ title: 'Existing conversation' }),
+          messages: createFakeMessageStore(),
+          backends: createFakeRegistry(backend),
+          trackRunHandle: tracking.trackRunHandle
+        },
+        {
+          conversationId: 'conversation-1',
+          sourceWindowId: 'window-1',
+          text: 'hi',
+          attachments: [],
+          backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+        }
+      )
+    ).rejects.toThrow('Object has been destroyed')
+
+    expect(child.killCount).toBe(1)
+    // Nothing was signalled, so there is nothing to wait for: the turn must not
+    // burn the grace period, and cleanup still has to run to drop the spawn
+    // temp directory.
+    expect(Date.now() - startedAt).toBeLessThan(1000)
+    expect(child.cleanupCount).toBe(1)
+  })
+
+  it('keeps the turn error and still cleans up when the exit promise rejects', async () => {
+    const child = startChild({ first: deltaLine('hello'), linger: LINGER_MS })
+    child.waitExitImpl = () => Promise.reject(new Error('exit watch failed'))
+    const backend = createClaudeBackend(child.handle)
+    const tracking = createTrackingHarness(child)
+
+    broadcastAgentEventMock.mockImplementation((event: { kind: string }) => {
+      if (event.kind === 'assistant_text_delta') {
+        throw new Error('Object has been destroyed')
+      }
+    })
+
+    await expect(
+      runTurn(
+        {
+          conversations: createFakeConversationStore({ title: 'Existing conversation' }),
+          messages: createFakeMessageStore(),
+          backends: createFakeRegistry(backend),
+          trackRunHandle: tracking.trackRunHandle
+        },
+        {
+          conversationId: 'conversation-1',
+          sourceWindowId: 'window-1',
+          text: 'hi',
+          attachments: [],
+          backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+        }
+      )
+    ).rejects.toThrow('Object has been destroyed')
+
+    expect(child.killCount).toBe(1)
+    expect(child.cleanupCount).toBe(1)
+    // turn.ts could not confirm the exit, but the signal it sent was real.
+    await waitForExit(child.proc, 5000)
+    expect(child.proc.signalCode).toBe('SIGTERM')
+  })
+
   it('gives up on a child that ignores the kill instead of hanging the turn', async () => {
     const child = startChild({
       first: deltaLine('hello'),
@@ -220,7 +303,14 @@ interface StartedChild {
   handle: RawSubprocessHandle
   proc: ChildProcess
   killCount: number
+  cleanupCount: number
   onKill: () => void
+  // Overridable so a test can model a backend handle whose kill() or exit
+  // promise fails. Both are ordinary implementations of BackendRunHandle:
+  // ChildProcess.kill() throws on EINVAL/ENOSYS, and waitExit() is a plain
+  // Promise any backend may reject.
+  killImpl: () => void
+  waitExitImpl: () => Promise<number>
 }
 
 function startChild(input: {
@@ -256,7 +346,12 @@ function startChild(input: {
   const started: StartedChild = {
     proc,
     killCount: 0,
+    cleanupCount: 0,
     onKill: () => {},
+    killImpl: () => {
+      proc.kill('SIGTERM')
+    },
+    waitExitImpl: () => exitCodePromise,
     handle: {
       stdout,
       stderr,
@@ -264,13 +359,28 @@ function startChild(input: {
       kill: () => {
         started.killCount += 1
         started.onKill()
-        proc.kill('SIGTERM')
+        started.killImpl()
       },
-      waitExit: () => exitCodePromise,
-      cleanup: async () => {}
+      waitExit: () => started.waitExitImpl(),
+      cleanup: async () => {
+        started.cleanupCount += 1
+      }
     }
   }
   return started
+}
+
+// Proves a signal was really delivered in the cases where turn.ts deliberately
+// does not wait for the exit itself.
+function waitForExit(proc: ChildProcess, timeoutMs: number): Promise<void> {
+  if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve()
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('child did not exit in time')), timeoutMs)
+    proc.once('exit', () => {
+      clearTimeout(timer)
+      resolve()
+    })
+  })
 }
 
 interface TrackingHarness {

--- a/apps/desktop/src/main/agent/runtime/__tests__/turn-child-kill.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/turn-child-kill.test.ts
@@ -1,0 +1,408 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+const { broadcastAgentEventMock } = vi.hoisted(() => ({ broadcastAgentEventMock: vi.fn() }))
+vi.mock('../event-bus', () => ({
+  broadcastAgentEvent: broadcastAgentEventMock
+}))
+
+vi.mock('../../../telemetry/track', () => ({
+  trackMainEvent: vi.fn()
+}))
+
+import { ClaudeCliBackend } from '../../backends/claude-cli-backend'
+import type { AgentBackendRegistry } from '../../backends/registry'
+import type { AgentBackend, BackendRunHandle, RawSubprocessHandle } from '../../backends/types'
+import type { ConversationStore } from '../../storage/conversation-store'
+import type { MessageStore } from '../../storage/message-store'
+import type { Conversation, Message, MessageContent, MessageRole } from '../../storage/types'
+import { runTurn } from '../turn'
+
+// Nothing below the backend is faked: a real `node` child writes real bytes to a
+// real pipe. The child never writes again after its first line, so destroying
+// the parent's read end of stdout — which is all an abandoned `for await` does —
+// cannot make it exit. Only an actual signal can. That is what makes an unkilled
+// child here a genuine orphan rather than a child that was about to die anyway.
+const CHILD_SCRIPT = `'use strict'
+const first = process.env.MEMRY_TEST_FIRST_LINE
+const second = process.env.MEMRY_TEST_SECOND_LINE
+const delayMs = Number(process.env.MEMRY_TEST_DELAY_MS || '0')
+const lingerMs = Number(process.env.MEMRY_TEST_LINGER_MS || '0')
+if (process.env.MEMRY_TEST_IGNORE_SIGTERM === '1') process.on('SIGTERM', () => {})
+if (first) process.stdout.write(first + '\\n')
+setTimeout(() => {
+  if (second) process.stdout.write(second + '\\n')
+  // Holds the event loop open while writing nothing at all.
+  if (lingerMs > 0) setTimeout(() => {}, lingerMs)
+}, delayMs)
+`
+
+// Long enough that a surviving child is unambiguously an orphan and not a race,
+// short enough that a leaked one cannot outlive the suite by much.
+const LINGER_MS = 60000
+
+const deltaLine = (text: string): string =>
+  JSON.stringify({
+    type: 'stream_event',
+    event: { type: 'content_block_delta', delta: { type: 'text_delta', text } }
+  })
+
+const STOP_LINE = JSON.stringify({ type: 'stream_event', event: { type: 'message_stop' } })
+
+// Every fixture lives inside a per-run mkdtemp directory, so no test writes to a
+// predictable path in the OS temp dir.
+let fixtureDir: string
+let childScript: string
+const children: ChildProcess[] = []
+
+beforeAll(async () => {
+  fixtureDir = await mkdtemp(path.join(tmpdir(), 'memry-turn-child-kill-'))
+  childScript = path.join(fixtureDir, 'child.cjs')
+  await writeFile(childScript, CHILD_SCRIPT)
+})
+
+afterEach(() => {
+  broadcastAgentEventMock.mockReset()
+  // Runs even when the test body throws, so a red run never leaks a 60s child.
+  for (const child of children.splice(0)) {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL')
+  }
+})
+
+afterAll(async () => {
+  await rm(fixtureDir, { recursive: true, force: true })
+})
+
+// The only honest liveness check: ask the OS about the pid. `kill(pid, 0)`
+// throws ESRCH once the child is gone and reaped, which is exactly the state
+// `waitExit()` resolving guarantees.
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function describeChild(pid: number, tracked: Map<number, unknown>): string {
+  if (!isAlive(pid)) return 'gone'
+  return tracked.has(pid) ? 'alive-and-tracked' : 'alive-and-untracked-orphan'
+}
+
+describe('runTurn subprocess lifetime on the turn error path', () => {
+  it('kills the child before cleanup untracks it, so no orphan survives a mid-turn throw', async () => {
+    const child = startChild({ first: deltaLine('hello'), linger: LINGER_MS })
+    const backend = createClaudeBackend(child.handle)
+    const tracking = createTrackingHarness(child)
+
+    // The issue's stated trigger: an exception raised while handling a turn
+    // event. A destroyed window makes the real IPC send throw here.
+    broadcastAgentEventMock.mockImplementation((event: { kind: string }) => {
+      if (event.kind === 'assistant_text_delta') {
+        throw new Error('Object has been destroyed')
+      }
+    })
+
+    await expect(
+      runTurn(
+        {
+          conversations: createFakeConversationStore({ title: 'Existing conversation' }),
+          messages: createFakeMessageStore(),
+          backends: createFakeRegistry(backend),
+          trackRunHandle: tracking.trackRunHandle
+        },
+        {
+          conversationId: 'conversation-1',
+          sourceWindowId: 'window-1',
+          text: 'hi',
+          attachments: [],
+          backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+        }
+      )
+    ).rejects.toThrow('Object has been destroyed')
+
+    // Both halves of the bug in one readable value: before the fix this is
+    // 'alive-and-untracked-orphan' — a child still running that cleanup() has
+    // already removed from the map killAll() walks at quit.
+    expect(describeChild(child.handle.pid, tracking.tracked)).toBe('gone')
+    expect(child.proc.signalCode).toBe('SIGTERM')
+    // killAll() reaches the child at every point where it still exists: the kill
+    // is issued while the pid is tracked, and the untrack only runs once the
+    // child is already gone.
+    expect(tracking.trackedWhenKilled).toBe(true)
+    expect(tracking.aliveWhenCleanupRan).toBe(false)
+  })
+
+  it('gives up on a child that ignores the kill instead of hanging the turn', async () => {
+    const child = startChild({
+      first: deltaLine('hello'),
+      linger: LINGER_MS,
+      ignoreSigterm: true
+    })
+    const backend = createClaudeBackend(child.handle)
+    const tracking = createTrackingHarness(child)
+
+    broadcastAgentEventMock.mockImplementation((event: { kind: string }) => {
+      if (event.kind === 'assistant_text_delta') {
+        throw new Error('Object has been destroyed')
+      }
+    })
+
+    const startedAt = Date.now()
+    await expect(
+      runTurn(
+        {
+          conversations: createFakeConversationStore({ title: 'Existing conversation' }),
+          messages: createFakeMessageStore(),
+          backends: createFakeRegistry(backend),
+          trackRunHandle: tracking.trackRunHandle
+        },
+        {
+          conversationId: 'conversation-1',
+          sourceWindowId: 'window-1',
+          text: 'hi',
+          attachments: [],
+          backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+        }
+      )
+    ).rejects.toThrow('Object has been destroyed')
+
+    // The wait is bounded, so closeVault() on the quit path still finishes well
+    // inside the 5s budget main gives shutdown before it force-exits. Without
+    // the bound this never returns and the leak becomes a hang.
+    expect(Date.now() - startedAt).toBeLessThan(5000)
+    expect(tracking.killCount).toBe(1)
+  })
+
+  it('never kills a turn that is merely slow', async () => {
+    const child = startChild({
+      first: deltaLine('thinking'),
+      second: STOP_LINE,
+      // Longer than any plausible "is it stuck?" heuristic would tolerate, and
+      // the child produces nothing at all while it waits.
+      delay: 400
+    })
+    const backend = createClaudeBackend(child.handle)
+    const tracking = createTrackingHarness(child)
+    const messages = createFakeMessageStore()
+
+    await runTurn(
+      {
+        conversations: createFakeConversationStore({ title: 'Existing conversation' }),
+        messages,
+        backends: createFakeRegistry(backend),
+        trackRunHandle: tracking.trackRunHandle
+      },
+      {
+        conversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
+        text: 'hi',
+        attachments: [],
+        backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+      }
+    )
+
+    expect(tracking.killCount).toBe(0)
+    expect(child.proc.signalCode).toBeNull()
+    expect(child.proc.exitCode).toBe(0)
+    const all = messages.listByConversation('conversation-1')
+    expect(all[1].status).toBe('completed')
+    expect(all[1].content).toEqual({ role: 'assistant', data: { text: 'thinking' } })
+  })
+})
+
+interface StartedChild {
+  handle: RawSubprocessHandle
+  proc: ChildProcess
+  killCount: number
+  onKill: () => void
+}
+
+function startChild(input: {
+  first: string
+  second?: string
+  delay?: number
+  linger?: number
+  ignoreSigterm?: boolean
+}): StartedChild {
+  const proc = spawn(process.execPath, [childScript], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      MEMRY_TEST_FIRST_LINE: input.first,
+      ...(input.second ? { MEMRY_TEST_SECOND_LINE: input.second } : {}),
+      MEMRY_TEST_DELAY_MS: String(input.delay ?? 0),
+      MEMRY_TEST_LINGER_MS: String(input.linger ?? 0),
+      ...(input.ignoreSigterm ? { MEMRY_TEST_IGNORE_SIGTERM: '1' } : {})
+    }
+  })
+  children.push(proc)
+
+  const stdout = proc.stdout
+  const stderr = proc.stderr
+  if (!stdout || !stderr) throw new Error('test child stdio unavailable')
+
+  // Created eagerly and reused, exactly like the production adapter in
+  // bootstrap.ts, so waitExit() still resolves when it is called after exit.
+  const exitCodePromise = new Promise<number>((resolve) => {
+    proc.once('exit', (code) => resolve(code ?? 0))
+  })
+
+  const started: StartedChild = {
+    proc,
+    killCount: 0,
+    onKill: () => {},
+    handle: {
+      stdout,
+      stderr,
+      pid: proc.pid ?? -1,
+      kill: () => {
+        started.killCount += 1
+        started.onKill()
+        proc.kill('SIGTERM')
+      },
+      waitExit: () => exitCodePromise,
+      cleanup: async () => {}
+    }
+  }
+  return started
+}
+
+interface TrackingHarness {
+  trackRunHandle: (conversationId: string, handle: BackendRunHandle) => BackendRunHandle
+  tracked: Map<number, { kill: () => void }>
+  trackedWhenKilled: boolean
+  aliveWhenCleanupRan: boolean | null
+  killCount: number
+}
+
+// Mirrors the wrapper agent-handlers.ts installs around every run handle: track
+// on creation, untrack inside cleanup(). Untracking is what removes the pid from
+// the map killAll() iterates, so the observations below are the real question —
+// was the child already dead by the time it stopped being reachable?
+function createTrackingHarness(child: StartedChild): TrackingHarness {
+  const tracked = new Map<number, { kill: () => void }>()
+  const harness: TrackingHarness = {
+    tracked,
+    trackedWhenKilled: false,
+    aliveWhenCleanupRan: null,
+    get killCount() {
+      return child.killCount
+    },
+    trackRunHandle: (_conversationId, handle) => {
+      tracked.set(handle.pid, { kill: handle.kill })
+      return {
+        ...handle,
+        cleanup: async () => {
+          harness.aliveWhenCleanupRan = isAlive(handle.pid)
+          try {
+            await handle.cleanup()
+          } finally {
+            tracked.delete(handle.pid)
+          }
+        }
+      }
+    }
+  }
+  child.onKill = () => {
+    harness.trackedWhenKilled = tracked.has(child.handle.pid)
+  }
+  return harness
+}
+
+function createClaudeBackend(handle: RawSubprocessHandle): AgentBackend {
+  return new ClaudeCliBackend({ spawn: async () => handle })
+}
+
+function createFakeRegistry(backend: AgentBackend): AgentBackendRegistry {
+  return {
+    get: () => backend,
+    list: () => [backend]
+  }
+}
+
+function createFakeConversationStore(overrides: Partial<Conversation> = {}): ConversationStore {
+  const conversation = {
+    id: 'conversation-1',
+    vaultId: 'vault-1',
+    title: 'New conversation',
+    backend: 'claude_cli',
+    backendModel: null,
+    trustList: [],
+    pinned: false,
+    vectorClock: {},
+    fieldClocks: {},
+    createdAt: 1,
+    updatedAt: 1,
+    deletedAt: null,
+    lastSyncedAt: null,
+    ...overrides
+  }
+
+  return {
+    create: vi.fn(),
+    getById: vi.fn(() => conversation),
+    listByVault: vi.fn(() => [conversation]),
+    update: vi.fn((_id, patch) => ({ ...conversation, ...patch, updatedAt: 2 })),
+    softDelete: vi.fn(),
+    addToTrustList: vi.fn(),
+    removeFromTrustList: vi.fn()
+  }
+}
+
+function createFakeMessageStore(): MessageStore {
+  const messages: Message[] = []
+  let nextId = 1
+
+  const makeMessage = (input: {
+    conversationId: string
+    role: MessageRole
+    content: MessageContent
+    status: Message['status']
+    attachments: Message['attachments']
+    toolCallId?: string | null
+  }): Message => ({
+    id: `message-${nextId++}`,
+    conversationId: input.conversationId,
+    role: input.role,
+    content: input.content,
+    toolCallId: input.toolCallId ?? null,
+    attachments: input.attachments,
+    status: input.status,
+    vectorClock: { d: 1 },
+    createdAt: nextId,
+    updatedAt: nextId,
+    deletedAt: null
+  })
+
+  return {
+    append(input) {
+      const message = makeMessage(input)
+      messages.push(message)
+      return message
+    },
+    getById(id) {
+      return messages.find((message) => message.id === id) ?? null
+    },
+    listByConversation(conversationId) {
+      return messages.filter((message) => message.conversationId === conversationId)
+    },
+    updateStreaming(id, patch) {
+      const message = this.getById(id)
+      if (!message) throw new Error(`Message ${id} not found`)
+      Object.assign(message, patch, { updatedAt: message.updatedAt + 1 })
+      return message
+    },
+    markTerminal(id, status, patch) {
+      const message = this.getById(id)
+      if (!message) throw new Error(`Message ${id} not found`)
+      Object.assign(message, patch, { status, updatedAt: message.updatedAt + 1 })
+      return message
+    }
+  }
+}

--- a/apps/desktop/src/main/agent/runtime/turn.ts
+++ b/apps/desktop/src/main/agent/runtime/turn.ts
@@ -29,6 +29,9 @@ export interface TurnDeps {
   trackRunHandle?: (conversationId: string, handle: BackendRunHandle) => BackendRunHandle
 }
 
+// How long an abandoned child gets to die before the turn stops waiting on it.
+// Comfortably inside the 5s force-exit budget main gives the whole shutdown.
+const ABANDONED_KILL_GRACE_MS = 2000
 const DEFAULT_CONVERSATION_TITLE = 'New conversation'
 const DEFAULT_TURN_PERMISSIONS: AgentTurnPermissions = {
   accessMode: 'vault_only',
@@ -166,6 +169,7 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
 
   let buffered = ''
   let backendError: string | null = null
+  let exitObserved = false
   let unknownEventCount = 0
   const toolCalls = new Map<string, { name: string; args: unknown }>()
   const sourceRefs = new Map<string, AgentSourceRef>()
@@ -210,6 +214,7 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
       })
     }
     const exitCode = await sub.waitExit()
+    exitObserved = true
     const stderrText = (await stderrTextPromise).trim()
 
     if (backendError || exitCode !== 0) {
@@ -268,11 +273,45 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
     }
     trackTurnCompleted('success')
   } finally {
+    // Only ever reached once the turn is over: either waitExit() already
+    // resolved (exitObserved) or the event loop above threw and abandoned a
+    // child that is still running. A slow turn is still inside the loop, so it
+    // is never touched here.
+    if (!exitObserved) await killAbandonedChild(sub)
     await sub.cleanup()
     await titlePromise
   }
 
   return { turnId }
+}
+
+// cleanup() is where the tracked-handle wrapper untracks the pid, which removes
+// it from the map killAll() walks at quit. A child still alive at that moment is
+// unreachable forever, so it has to be killed first — and cleanup() must wait
+// for it to actually be gone, not merely signalled.
+async function killAbandonedChild(sub: BackendRunHandle): Promise<void> {
+  try {
+    sub.kill()
+  } catch (error) {
+    logger.warn('Failed to kill abandoned agent subprocess', { pid: sub.pid, error })
+    return
+  }
+
+  // Bounded: killAll() awaits in-flight turns and main force-exits 5s into
+  // shutdown, so an unbounded wait here would trade the leak for a hang.
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timedOut = new Promise<false>((resolve) => {
+    timer = setTimeout(() => resolve(false), ABANDONED_KILL_GRACE_MS)
+  })
+  try {
+    if (!(await Promise.race([sub.waitExit().then(() => true), timedOut]))) {
+      logger.warn('Abandoned agent subprocess did not exit after kill', { pid: sub.pid })
+    }
+  } catch (error) {
+    logger.warn('Failed to await abandoned agent subprocess exit', { pid: sub.pid, error })
+  } finally {
+    clearTimeout(timer)
+  }
 }
 
 async function maybeGenerateConversationTitle(

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -154,6 +154,11 @@ backend also generates a short conversation title. memrynote stores that title o
 conversation row and refreshes the sidebar title without giving the title-generation subprocess
 access to memrynote MCP tools.
 
+If a turn fails partway through — a window closing while the reply is still streaming, for example —
+memrynote stops the chat backend it started for that turn instead of leaving it running in the
+background. The unfinished reply is lost, but your message and the rest of the conversation are kept,
+so you can send the prompt again. A turn that is simply taking a long time is never stopped this way.
+
 Conversation rows, message bodies, and message attachments are encrypted at rest before they are
 written to SQLite. Free accounts keep agent chat history local-only. Paid accounts can sync finalized
 conversations and terminal messages through memrynote Sync; in-progress streaming messages are not


### PR DESCRIPTION
## Problem

An exception raised while handling a turn event orphans the chat backend process permanently.

`runTurn`'s event loop (`apps/desktop/src/main/agent/runtime/turn.ts`) runs arbitrary side-effecting
code per event: `broadcastAgentEvent` (an IPC send that throws on a destroyed window), message-store
writes, telemetry. When any of that throws, the `for await` is abandoned and the `finally` ran
`await sub.cleanup()` and nothing else — **no `kill()` on any error path**.

Worse, `cleanup()` is where the tracked-handle wrapper in `apps/desktop/src/main/ipc/agent-handlers.ts`
calls `runtime.untrackSubprocess(pid)`. So the still-running child was removed from the `subprocesses`
map that `killAll()` walks at quit. One permanently orphaned `claude`/`codex` process per failure,
invisible to shutdown, surviving until the user reboots.

Abandoning the `for await` only destroys the parent's read end of the child's stdout. A child that
is mid-tool-call and writing nothing does not notice and does not exit.

## Root cause

`finally { await sub.cleanup() }` untracks before anything kills. Ordering was the whole bug.

## Fix

`runTurn` records whether `waitExit()` actually resolved. If it did not, the `finally` kills the child
and waits for it to be gone **before** `cleanup()` runs:

- the kill is always issued while the pid is still tracked, so `killAll()` can reach the child at
  every point where it exists;
- the untrack only happens once the process no longer exists.

The wait is bounded at 2s — comfortably inside the 5s budget `main` gives shutdown before it
force-exits — so a child that ignores the signal cannot turn the leak into a hang. `killAll()` awaits
in-flight turns, so an unbounded wait here would have been exactly that trade.

The guard is `exitObserved`, not a timer: a turn that is merely slow is still inside the event loop
and never reaches the `finally` at all.

Both `catch` arms inside `killAbandonedChild` exist for one reason: a throw escaping the `finally`
would **replace the error that actually ended the turn**, so the user would be shown `kill EINVAL`
instead of the real cause. Behaviour when `kill()` itself throws is to log and return without waiting
— see "Degradation when the kill fails" below for why that is the right call rather than a repeat of
the bug.

39 lines in one file, plus a docs paragraph.

## Test evidence

`apps/desktop/src/main/agent/runtime/__tests__/turn-child-kill.test.ts`. Nothing below the backend is
faked — a real `node` child on a real pipe, driven through the real `ClaudeCliBackend` and the real
stream parser. The child writes one line and then never writes again, so destroying the parent's read
end cannot kill it; only a signal can. Liveness is checked with `process.kill(pid, 0)`, never with
"was `kill` called". Fixtures live in a per-run `mkdtemp` dir, removed in `afterAll`; `afterEach`
`SIGKILL`s any survivor even when the test body throws.

**RED — premise proven, both halves in one value:**

```
 × kills the child before cleanup untracks it, so no orphan survives a mid-turn throw
   → expected 'alive-and-untracked-orphan' to be 'gone'
   Expected: "gone"
   Received: "alive-and-untracked-orphan"
```

**GREEN:**

```
 ✓ kills the child before cleanup untracks it, so no orphan survives a mid-turn throw
 ✓ keeps the turn error and still cleans up when the kill call itself throws
 ✓ keeps the turn error and still cleans up when the exit promise rejects
 ✓ gives up on a child that ignores the kill instead of hanging the turn 2034ms
 ✓ never kills a turn that is merely slow
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

### Patch coverage

The first push measured `codecov/patch` at 81.25%. The unhit lines were pinned by running v8 coverage
over every test file that loads the module (`turn.test.ts`, `turn-child-kill.test.ts`,
`agent-handlers.test.ts`) and intersecting the report with the diff's added lines — not inferred from
the percentage. Exactly three: **296–297** (the `catch` around `sub.kill()`) and **311** (the `catch`
around the bounded exit wait). After the two new tests:

```
ADDED LINES STILL UNCOVERED: NONE — 100% of the diff hit
```

The lines still uncovered in `turn.ts` overall (132, 133, 190, 337, 347, 444, 478, 482) are all
pre-existing and outside this diff.

### Mutation verification

Seven single-line reverts, each targeted by line number. All seven die, and no two are killed by the
same assertion — the paths do not shield each other.

| # | Mutation | Result |
|---|---|---|
| M1 | delete `if (!exitObserved) await killAbandonedChild(sub)` (L280) | RED — `expected 'alive-and-untracked-orphan' to be 'gone'` (+3 more) |
| M2 | delete `exitObserved = true` (L217) | RED — *merely slow* test: `expected 1 to be +0` (kill count) |
| M3 | `await` → `void` on the kill (L280) | RED — cleanup/untrack runs while the child is still alive |
| M4 | `ABANDONED_KILL_GRACE_MS` 2000 → 600000 (L34) | RED — `Test timed out in 30000ms` (the bound is real) |
| N1 | delete the early `return` after a failed kill (L297) | RED — `expected 2038 to be less than 1000` (grace period burned for nothing) |
| N2 | `return` → `throw error` (L297), i.e. no catch around `sub.kill()` | RED — `expected [Function] to throw error including 'Object has been destroyed' but got 'kill EINVAL'` |
| N3 | `logger.warn` → `throw error` (L311), i.e. no catch around the exit wait | RED — `expected [Function] to throw error including 'Object has been destroyed' but got 'exit watch failed'` |

M2 is the proof that a slow turn is never killed: without the happy-path guard the kill fires on a
turn that completed normally, and only that test notices. N2 and N3 are the error-masking bug the two
catches prevent, shown directly.

### Verification

- `pnpm typecheck` — `Tasks: 16 successful, 16 total`
- `pnpm lint` — `0 errors, 15 warnings`, all pre-existing renderer warnings; zero findings in changed files
- targeted `test:main` (`turn-child-kill` + `turn` + `agent-handlers`) — `Test Files 3 passed (3)`, `Tests 37 passed (37)`
- full `pnpm --filter @memry/desktop test:main` — `Test Files 478 passed | 1 skipped (479)`, `Tests 5445 passed | 1 expected fail | 4 skipped (5450)`
- `git diff --check` — clean
- `pnpm docs:impact --base origin/main --strict` — `covered`
- `pnpm docs:build` — `build complete`
- No `ps` survivors of the fixture script after any run

No contracts/preload/IPC types changed, so `ipc:generate`/`ipc:check` are not implicated (the
`typecheck` run above still reports the IPC invoke map and RPC bindings up to date).

## Degradation when the kill fails

If `sub.kill()` throws, `killAbandonedChild` logs and returns, and `cleanup()` still untracks a child
that may well be alive. That looks like the bug this PR fixes, so it is worth stating why it is the
right behaviour rather than an oversight:

- `killAll()` at quit calls **the same `kill` closure that just threw**. Staying tracked buys a retry
  that is guaranteed to throw again (`killAll` catches and logs it). There is no second mechanism to
  fall back on.
- Skipping `cleanup()` to preserve tracking would leak the spawn temp directory on disk and leave a
  permanent entry in the map, for that same worthless retry.
- Escalating to `SIGKILL` is #1038's, deliberately not pre-empted here.

So the choice is between an untracked live child and an untracked live child plus a leaked temp dir
plus 2s of pointless waiting. This is degradation, not a regression: before this PR that path did not
exist, because nothing was ever killed at all. Flagging it rather than quietly changing it.

## Risk & backward compatibility

Low. No schema, contract, vault-format, sync-protocol, or settings change. Behaviour only differs on a
path that previously leaked: the abandoned-turn branch. The success path is untouched — `exitObserved`
is set the moment `waitExit()` resolves, so a completed turn never enters the new code, and a slow turn
has not reached the `finally` at all.

Shutdown gets strictly safer, not slower in practice: `killAll()` already signals every tracked child
before it awaits in-flight turns, so by the time a turn's `finally` runs the child has usually already
exited and the new wait resolves immediately. The 2s ceiling is the worst case for a child that ignores
the signal, still inside the 5s force-exit budget.

**What the user loses on an abandoned turn** (unchanged by this PR): the partial assistant reply for
that turn. The user's own message and the conversation are persisted before the turn starts. The turn
lock is already released in `agent-handlers.ts`'s `.finally()` and a `turn_error` is broadcast from its
`.catch()`, so there is no stuck turn lock — the user can simply send again.

## Deliberately out of scope

- **#1038** — the kill is SIGTERM-only with no SIGKILL escalation and no reap. A child that ignores
  SIGTERM is logged and abandoned here rather than escalated; that escalation is #1038's, and this PR
  is careful not to pre-empt it (the tests assert boundedness, not that such a child survives).
- **#1037** — where the subprocess is tracked relative to the try block is untouched.
- **#1171 / #1176** — no overlap with `cli/spawn.ts` or `cli/codex-spawn.ts`; within `turn.ts` this PR
  only adds to `runTurn`'s `finally` and a new module-level helper, while #1176 edits the try-bodies of
  `generateTitleWithBackend`/`summarizeWithBackend` and adds `collectStreamTail`. Different hunks.
- `generateTitleWithBackend` and `summarizeWithBackend` have the same `finally { await sub.cleanup() }`
  shape, but their event loops only concatenate strings and cannot throw, and both throw only *after*
  `waitExit()` has resolved. Left alone to keep this surgical and off #1176's lines.

Closes #1036
