### PR TITLE
perf(editor): debounce find-in-page query so a typed burst costs one DOM walk

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-find-in-page.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-find-in-page.test.tsx
@@ -1,6 +1,32 @@
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, type RenderHookResult } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useFindInPage } from './use-find-in-page'
+
+/**
+ * Counters for the DOM work one search costs. `findTextRanges` walks the whole
+ * container with a `TreeWalker` and allocates one `Range` per match, so these
+ * three numbers are the entire per-search cost and they are what the debounce
+ * has to hold down while the user is typing.
+ */
+let treeWalks = 0
+let textNodesVisited = 0
+let rangesAllocated = 0
+
+/** Captured once: re-reading `globalThis.Range` per test would nest the counter. */
+const NativeRange = globalThis.Range
+
+/** Typing burst: how long a fast typist leaves between two characters. */
+const KEYSTROKE_GAP_MS = 30
+/** The longest a user should wait after the last keystroke before results land. */
+const RESULTS_DEADLINE_MS = 200
+
+type Hook = RenderHookResult<ReturnType<typeof useFindInPage>, unknown>
+
+/** `node.textContent[start-end]` for every highlighted range, in document order. */
+function describeRanges(value: unknown): string[] {
+  const ranges = (value as { ranges?: Range[] } | undefined)?.ranges ?? []
+  return ranges.map((r) => `${r.startContainer.textContent}[${r.startOffset}-${r.endOffset}]`)
+}
 
 describe('useFindInPage', () => {
   let container: HTMLDivElement
@@ -14,6 +40,34 @@ describe('useFindInPage', () => {
     document.body.append(container)
     ref = { current: container }
     highlights = new Map()
+
+    treeWalks = 0
+    textNodesVisited = 0
+    rangesAllocated = 0
+
+    const createTreeWalker = document.createTreeWalker.bind(document)
+    vi.spyOn(document, 'createTreeWalker').mockImplementation((root, whatToShow, filter) => {
+      treeWalks += 1
+      const walker = createTreeWalker(root, whatToShow, filter)
+      const nextNode = walker.nextNode.bind(walker)
+      walker.nextNode = () => {
+        const node = nextNode()
+        if (node) textNodesVisited += 1
+        return node
+      }
+      return walker
+    })
+
+    Object.defineProperty(globalThis, 'Range', {
+      configurable: true,
+      writable: true,
+      value: class CountingRange extends NativeRange {
+        constructor() {
+          super()
+          rangesAllocated += 1
+        }
+      }
+    })
 
     Object.defineProperty(globalThis, 'CSS', {
       configurable: true,
@@ -39,12 +93,26 @@ describe('useFindInPage', () => {
 
   afterEach(() => {
     document.body.innerHTML = ''
+    Object.defineProperty(globalThis, 'Range', {
+      configurable: true,
+      writable: true,
+      value: NativeRange
+    })
     vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
+  /** Type a query and wait long enough that the user would expect results. */
+  function typeQuery(hook: Hook, query: string): void {
+    act(() => {
+      hook.result.current.setQuery(query)
+      vi.advanceTimersByTime(RESULTS_DEADLINE_MS)
+    })
+  }
+
   it('opens, searches text ranges, navigates matches, and closes cleanly', () => {
-    const { result, unmount } = renderHook(() => useFindInPage(ref))
+    const hook = renderHook(() => useFindInPage(ref))
+    const { result, unmount } = hook
     const input = document.createElement('input')
     result.current.inputRef.current = input
     vi.spyOn(input, 'focus')
@@ -55,7 +123,7 @@ describe('useFindInPage', () => {
     expect(input.focus).toHaveBeenCalled()
     expect(input.select).toHaveBeenCalled()
 
-    act(() => result.current.setQuery('alpha'))
+    typeQuery(hook, 'alpha')
     expect(result.current.query).toBe('alpha')
     expect(result.current.matchCount).toBe(2)
     expect(result.current.currentIndex).toBe(0)
@@ -68,7 +136,7 @@ describe('useFindInPage', () => {
     act(() => result.current.prev())
     expect(result.current.currentIndex).toBe(1)
 
-    act(() => result.current.setQuery('missing'))
+    typeQuery(hook, 'missing')
     expect(result.current.matchCount).toBe(0)
     expect(result.current.currentIndex).toBe(-1)
 
@@ -83,16 +151,17 @@ describe('useFindInPage', () => {
 
   it('handles keyboard shortcut, disabled mode, DOM mutations, and missing containers', async () => {
     Object.defineProperty(navigator, 'platform', { configurable: true, value: 'MacIntel' })
-    const { result, rerender } = renderHook(({ enabled }) => useFindInPage(ref, enabled), {
+    const hook = renderHook(({ enabled }) => useFindInPage(ref, enabled), {
       initialProps: { enabled: true }
     })
+    const { result, rerender } = hook
 
     act(() => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'f', metaKey: true }))
     })
     expect(result.current.isOpen).toBe(true)
 
-    act(() => result.current.setQuery('beta'))
+    typeQuery(hook, 'beta')
     expect(result.current.matchCount).toBe(2)
 
     await act(async () => {
@@ -114,7 +183,183 @@ describe('useFindInPage', () => {
     act(() => {
       result.current.open()
       result.current.setQuery('alpha')
+      vi.advanceTimersByTime(RESULTS_DEADLINE_MS)
     })
     expect(result.current.matchCount).toBe(0)
+  })
+
+  describe('query debounce', () => {
+    it('costs one whole-container walk for a typed burst, not one per keystroke', () => {
+      // 200 paragraphs, each `alpha beta gamma alpha`: 200 text nodes, and 'a'
+      // alone matches 7 times per paragraph.
+      container.innerHTML = '<p>alpha beta gamma alpha</p>'.repeat(200)
+
+      const hook = renderHook(() => useFindInPage(ref))
+      act(() => hook.result.current.open())
+
+      const prefixes = ['a', 'al', 'alp', 'alph', 'alpha']
+      for (const prefix of prefixes) {
+        act(() => {
+          hook.result.current.setQuery(prefix)
+          vi.advanceTimersByTime(KEYSTROKE_GAP_MS)
+        })
+      }
+
+      // Mid-burst: every intermediate prefix was skipped entirely.
+      expect(treeWalks).toBe(0)
+      expect(textNodesVisited).toBe(0)
+      expect(rangesAllocated).toBe(0)
+      expect(hook.result.current.query).toBe('alpha')
+
+      // Trailing edge: the last keystroke always lands, and within the deadline.
+      act(() => vi.advanceTimersByTime(RESULTS_DEADLINE_MS - KEYSTROKE_GAP_MS))
+
+      expect(treeWalks).toBe(1)
+      expect(textNodesVisited).toBe(200)
+      expect(rangesAllocated).toBe(400)
+      expect(hook.result.current.matchCount).toBe(400)
+      expect(hook.result.current.currentIndex).toBe(0)
+      expect(describeRanges(highlights.get('find-matches'))).toHaveLength(400)
+    })
+
+    it('pins the exact match set produced by the trailing keystroke', () => {
+      const hook = renderHook(() => useFindInPage(ref))
+      act(() => hook.result.current.open())
+
+      act(() => {
+        hook.result.current.setQuery('alph')
+        vi.advanceTimersByTime(KEYSTROKE_GAP_MS)
+        hook.result.current.setQuery('alpha')
+        vi.advanceTimersByTime(KEYSTROKE_GAP_MS)
+      })
+      expect(treeWalks).toBe(0)
+      expect(hook.result.current.matchCount).toBe(0)
+
+      act(() => vi.advanceTimersByTime(RESULTS_DEADLINE_MS - KEYSTROKE_GAP_MS))
+
+      expect(treeWalks).toBe(1)
+      expect(hook.result.current.matchCount).toBe(2)
+      expect(describeRanges(highlights.get('find-matches'))).toEqual([
+        'Alpha beta alpha[0-5]',
+        'Alpha beta alpha[11-16]'
+      ])
+      expect(describeRanges(highlights.get('find-current'))).toEqual(['Alpha beta alpha[0-5]'])
+    })
+
+    it('cancels the pending search when the bar is closed', () => {
+      const hook = renderHook(() => useFindInPage(ref))
+      act(() => hook.result.current.open())
+
+      act(() => {
+        hook.result.current.setQuery('alpha')
+        vi.advanceTimersByTime(KEYSTROKE_GAP_MS)
+      })
+      act(() => hook.result.current.close())
+      act(() => vi.advanceTimersByTime(5000))
+
+      expect(treeWalks).toBe(0)
+      expect(hook.result.current.matchCount).toBe(0)
+      expect(hook.result.current.query).toBe('')
+      expect(highlights.has('find-matches')).toBe(false)
+
+      // Reopening starts clean rather than resurrecting the cancelled search.
+      act(() => hook.result.current.open())
+      act(() => vi.advanceTimersByTime(5000))
+      expect(treeWalks).toBe(0)
+      expect(hook.result.current.matchCount).toBe(0)
+    })
+
+    it('flushes the pending search before next/prev so navigation uses the current query', () => {
+      container.innerHTML = '<p>one two two three three three</p>'
+      const hook = renderHook(() => useFindInPage(ref))
+      act(() => hook.result.current.open())
+
+      typeQuery(hook, 'two')
+      expect(hook.result.current.matchCount).toBe(2)
+      expect(treeWalks).toBe(1)
+
+      // Enter pressed inside the debounce window: the stale 'two' match set must
+      // not be what gets navigated.
+      act(() => {
+        hook.result.current.setQuery('three')
+        vi.advanceTimersByTime(KEYSTROKE_GAP_MS)
+      })
+      act(() => hook.result.current.next())
+
+      expect(treeWalks).toBe(2)
+      expect(hook.result.current.matchCount).toBe(3)
+      expect(hook.result.current.currentIndex).toBe(1)
+      expect(describeRanges(highlights.get('find-current'))).toEqual([
+        'one two two three three three[18-23]'
+      ])
+
+      // The flush consumed the pending search; the timer must not fire again.
+      act(() => vi.advanceTimersByTime(5000))
+      expect(treeWalks).toBe(2)
+
+      act(() => hook.result.current.prev())
+      expect(hook.result.current.currentIndex).toBe(0)
+      expect(describeRanges(highlights.get('find-current'))).toEqual([
+        'one two two three three three[12-17]'
+      ])
+
+      // Same again but with Shift+Enter as the first navigation after a change:
+      // prev() must flush too, or it walks backwards through the 'three' set.
+      act(() => {
+        hook.result.current.setQuery('two')
+        vi.advanceTimersByTime(KEYSTROKE_GAP_MS)
+      })
+      act(() => hook.result.current.prev())
+
+      expect(treeWalks).toBe(3)
+      expect(hook.result.current.matchCount).toBe(2)
+      expect(hook.result.current.currentIndex).toBe(1)
+      expect(describeRanges(highlights.get('find-current'))).toEqual([
+        'one two two three three three[8-11]'
+      ])
+    })
+
+    it('re-runs the search when the note is edited or swapped under an open bar', async () => {
+      const hook = renderHook(() => useFindInPage(ref))
+      act(() => hook.result.current.open())
+      typeQuery(hook, 'alpha')
+      expect(hook.result.current.matchCount).toBe(2)
+
+      // Edit while the bar is open.
+      await act(async () => {
+        container.querySelector('p')?.append(document.createTextNode(' alpha'))
+        await Promise.resolve()
+        vi.advanceTimersByTime(300)
+      })
+      expect(hook.result.current.matchCount).toBe(3)
+      expect(describeRanges(highlights.get('find-matches'))).toEqual([
+        'Alpha beta alpha[0-5]',
+        'Alpha beta alpha[11-16]',
+        ' alpha[1-6]'
+      ])
+
+      // Note switched under the open bar: the container's content is replaced.
+      await act(async () => {
+        container.innerHTML = '<p>alpha</p>'
+        await Promise.resolve()
+        vi.advanceTimersByTime(300)
+      })
+      expect(hook.result.current.matchCount).toBe(1)
+      expect(describeRanges(highlights.get('find-matches'))).toEqual(['alpha[0-5]'])
+    })
+
+    it('cancels the pending search on unmount', () => {
+      const hook = renderHook(() => useFindInPage(ref))
+      act(() => hook.result.current.open())
+      act(() => {
+        hook.result.current.setQuery('alpha')
+        vi.advanceTimersByTime(KEYSTROKE_GAP_MS)
+      })
+
+      hook.unmount()
+      act(() => vi.advanceTimersByTime(5000))
+
+      expect(treeWalks).toBe(0)
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/hooks/use-find-in-page.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-find-in-page.ts
@@ -8,6 +8,22 @@ import {
   type RefObject
 } from 'react'
 
+/**
+ * How long the find bar waits after the last keystroke before searching.
+ *
+ * One search is a `TreeWalker` over the entire note plus one `Range` per match,
+ * so running it per character makes every intermediate prefix — the ones with
+ * the most matches, e.g. a bare `a` — the expensive ones, and none of them is
+ * ever read. 150 ms swallows a typed burst while staying under the ~200 ms
+ * where a UI starts to feel unresponsive.
+ *
+ * Trailing edge only: there is deliberately no leading-edge call, because the
+ * first character is the worst case. The final keystroke always searches — the
+ * timer is only ever restarted by another keystroke, or cancelled by `close()`
+ * / unmount, and `next()` / `prev()` flush it rather than skip it.
+ */
+const QUERY_DEBOUNCE_MS = 150
+
 interface FindInPageResult {
   isOpen: boolean
   query: string
@@ -121,6 +137,26 @@ export function useFindInPage(
     [containerRef, clearHighlights, highlightAndScroll]
   )
 
+  // Pending debounced search. `pendingQueryRef` is the query the timer will run,
+  // and is null exactly when no timer is armed. Nothing about the DOM is cached:
+  // a flushed search walks the note from scratch, so an edit that lands inside
+  // the debounce window can never feed stale ranges into the highlight.
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingQueryRef = useRef<string | null>(null)
+
+  const cancelPendingSearch = useCallback(() => {
+    if (searchTimeoutRef.current !== null) clearTimeout(searchTimeoutRef.current)
+    searchTimeoutRef.current = null
+    pendingQueryRef.current = null
+  }, [])
+
+  const flushPendingSearch = useCallback(() => {
+    const pending = pendingQueryRef.current
+    if (pending === null) return
+    cancelPendingSearch()
+    performSearch(pending)
+  }, [cancelPendingSearch, performSearch])
+
   // Highlight current match + scroll into view on navigation (next/prev)
   useEffect(() => {
     highlightAndScroll(currentIndex)
@@ -166,41 +202,49 @@ export function useFindInPage(
 
   const close = useCallback(() => {
     setIsOpen(false)
+    cancelPendingSearch()
     setQueryState('')
     clearHighlights()
     matchesRef.current = []
     setMatchCount(0)
     setCurrentIndex(-1)
     currentIndexRef.current = -1
-  }, [clearHighlights])
+  }, [cancelPendingSearch, clearHighlights])
 
   const setQuery = useCallback(
     (q: string) => {
       setQueryState(q)
-      if (isOpen) {
+      if (!isOpen) return
+      cancelPendingSearch()
+      pendingQueryRef.current = q
+      searchTimeoutRef.current = setTimeout(() => {
+        searchTimeoutRef.current = null
+        pendingQueryRef.current = null
         performSearch(q)
-      }
+      }, QUERY_DEBOUNCE_MS)
     },
-    [isOpen, performSearch]
+    [isOpen, performSearch, cancelPendingSearch]
   )
 
   const next = useCallback(() => {
+    flushPendingSearch()
     const len = matchesRef.current.length
     if (len === 0) return
     const newIndex = (currentIndexRef.current + 1) % len
     currentIndexRef.current = newIndex
     setCurrentIndex(newIndex)
     highlightAndScroll(newIndex)
-  }, [highlightAndScroll])
+  }, [flushPendingSearch, highlightAndScroll])
 
   const prev = useCallback(() => {
+    flushPendingSearch()
     const len = matchesRef.current.length
     if (len === 0) return
     const newIndex = (currentIndexRef.current - 1 + len) % len
     currentIndexRef.current = newIndex
     setCurrentIndex(newIndex)
     highlightAndScroll(newIndex)
-  }, [highlightAndScroll])
+  }, [flushPendingSearch, highlightAndScroll])
 
   // Cmd+F / Ctrl+F shortcut
   useEffect(() => {
@@ -227,8 +271,11 @@ export function useFindInPage(
 
   // Cleanup on unmount
   useEffect(() => {
-    return () => clearHighlights()
-  }, [clearHighlights])
+    return () => {
+      cancelPendingSearch()
+      clearHighlights()
+    }
+  }, [cancelPendingSearch, clearHighlights])
 
   return {
     isOpen,

--- a/apps/docs/src/user-guide/notes/find-in-page.md
+++ b/apps/docs/src/user-guide/notes/find-in-page.md
@@ -42,3 +42,5 @@ PDF previews use their own embedded find — memrynote's find bar doesn't reach 
 ## Performance
 
 Find runs against the rendered document, so it sees what you see (including code blocks, list items, callout text). It does not cross block boundaries that aren't visually adjacent.
+
+Typing in the bar is debounced: on a long note the matches update a moment after you stop typing rather than on every character. Whatever you typed last always gets searched, and pressing <kbd>Enter</kbd> or <kbd>⇧</kbd>+<kbd>Enter</kbd> searches straight away instead of waiting. Editing the note while the bar is open re-runs the search too, so the match count and highlights stay in step with the text.


### PR DESCRIPTION
Closes #1051

## Problem

Every keystroke in the find bar ran a full search. `setQuery` called `performSearch` synchronously, which walks the entire editor container with a `TreeWalker` and allocates one `Range` per match. Intermediate prefixes are the expensive ones — a bare `a` matches almost everywhere — and none of them is ever read by the user.

Measured on a 200-paragraph note (`<p>alpha beta gamma alpha</p>` × 200), typing the five characters of `alpha`:

| | walks | text nodes visited | `Range` allocations |
|---|---|---|---|
| before | 5 | 1000 | 3000 |
| after | 1 | 200 | 400 |

The 3000 Ranges break down as 1400 (`a`) + 400 each for `al`/`alp`/`alph`/`alpha` — 2600 of them thrown away unread. Both axes scale linearly with note length, so a note 10× longer costs 10× more.

## Root cause

`use-find-in-page.ts` had a 300 ms debounce on the `MutationObserver` path (re-search after an edit) but none on the typing path. Confirmed still present on current `main`: `setQuery` → `performSearch` → `findTextRanges` with no timer between them.

## Fix

Trailing-edge debounce at **150 ms** on the query path only.

- **150 ms** collapses a typed burst (fast typing leaves 30–80 ms between characters) while staying under the ~200 ms where a UI starts to feel unresponsive. Tests pin the delay from both sides: a 30 ms gap must not trigger a search, and results must have landed by 200 ms after the last keystroke.
- **No leading edge**, deliberately — the first character is the worst case, not the cheapest.
- **The last keystroke always searches.** The timer is only ever restarted by another keystroke, cancelled by `close()` / unmount (where there is nothing left to show results in), or *flushed* by `next()` / `prev()`. It is never dropped.
- **Nothing is cached.** No incremental narrowing, no memoised positions or text — same discipline as #1173. Every search re-walks the note from scratch, so an edit landing inside the debounce window cannot feed a stale range into the highlight. Incremental narrowing was considered and rejected: it is exactly a cache of DOM positions, and any edit invalidates it.

`close()` and unmount cancel the pending timer, which otherwise resurrects highlights on a closed find bar 150 ms after Escape. `next()` / `prev()` flush it, so pressing Enter inside the window navigates the *current* query's matches rather than the previous query's stale set — identical to the old undebounced ordering (search lands on match 0, Enter advances to 1).

## What re-runs the search, and proof each still does

| trigger | mechanism | test |
|---|---|---|
| query changed | debounced trailing search | `costs one whole-container walk for a typed burst` |
| last keystroke of a burst | trailing edge, ≤ 200 ms | `pins the exact match set produced by the trailing keystroke` |
| note edited with the bar open | `MutationObserver`, 300 ms (unchanged) | `re-runs the search when the note is edited or swapped` |
| note switched with the bar open | same observer sees the wholesale content replacement | same test, second half |
| next / previous navigation | `flushPendingSearch()` before navigating | `flushes the pending search before next/prev` |
| match count display | `matchCount` asserted in every test above | — |
| closing the bar | pending search cancelled, highlights cleared | `cancels the pending search when the bar is closed` |
| reopening the bar | starts clean, cancelled search does not resurrect | same test, second half |
| unmount | pending search cancelled | `cancels the pending search on unmount` |

Assertions pin exact counts *and* exact highlight positions (`node.textContent[start-end]`), so a cheaper-but-wrong implementation cannot pass.

## Test evidence

Instrumentation counts real DOM work — `document.createTreeWalker` calls, `TreeWalker.nextNode()` hits, and `Range` constructions — never wall-clock time. Fake timers throughout.

RED, whole source file reverted to `origin/main`:

```
PASS (4) FAIL (4)
1. query debounce costs one whole-container walk for a typed burst, not one per keystroke
2. query debounce pins the exact match set produced by the trailing keystroke
3. query debounce cancels the pending search when the bar is closed
4. query debounce cancels the pending search on unmount
```

GREEN: `PASS (8) FAIL (0)`.

### Mutation verification — one line reverted at a time

| line | mutation | result |
|---|---|---|
| 25 | `QUERY_DEBOUNCE_MS = 150` → `0` | **killed** (4 red) |
| 25 | `QUERY_DEBOUNCE_MS = 150` → `500` | **killed** (6 red) |
| 156 | drop `cancelPendingSearch()` in `flushPendingSearch` | **killed** (1 red) |
| 205 | drop `cancelPendingSearch()` in `close()` | **killed** (1 red) |
| 218 | drop `cancelPendingSearch()` in `setQuery()` | **killed** (2 red) |
| 219 | drop `pendingQueryRef.current = q` | **killed** (1 red) |
| 230 | drop `flushPendingSearch()` in `next()` | **killed** (1 red) |
| 240 | drop `flushPendingSearch()` in `prev()` | **killed** (1 red) |
| 275 | drop `cancelPendingSearch()` in unmount cleanup | **killed** (1 red) |

Line 240 (`prev()`) initially **survived** — the test only ever called `prev()` after `next()` had already flushed, so nothing was pending. Fixed by adding a case where Shift+Enter is the first navigation after a query change; it now fails with `matchCount 3, offset 24` (the stale `three` set) instead of `matchCount 2, offset 8`.

The harness itself had a bug worth noting: re-reading `globalThis.Range` in `beforeEach` re-wrapped the previous test's counting subclass, so the Nth test counted every allocation N times. `NativeRange` is now captured once at module scope and restored in `afterEach`.

### Verification

```
pnpm typecheck   → Tasks: 16 successful, 16 total
pnpm lint        → ✖ 15 problems (0 errors, 15 warnings) — all pre-existing, none in the changed files
git diff --check → clean
pnpm exec vitest run --config config/vitest.config.ts --project renderer \
  src/renderer/src/hooks/use-find-in-page.test.tsx \
  src/renderer/src/pages/note.test.tsx \
  src/renderer/src/pages/journal.test.tsx
                 → PASS (39) FAIL (0)
npx react-doctor . (×2) → Scanned 1855 files, 231 issues, byte-identical between runs,
                          zero findings in use-find-in-page.ts
pnpm docs:impact --base origin/main --strict → covered
pnpm docs:build  → build complete
```

## Risk & backward compatibility

Low. The change is confined to `use-find-in-page.ts` — one `setTimeout`, one cancel, one flush. No persisted state, no schema, no IPC contract, no sync payload, no serialization: markdown remains the source of truth and nothing about what gets written to disk changes. Old and new app versions read and write identical data.

No new `beforeinput` handler and no BlockNote menu interaction, so neither editor landmine is introduced. No new Tailwind classes.

The one behavioural change a user can perceive is that on a long note the match count settles ~150 ms after they stop typing instead of flickering through every prefix. Documented in `apps/docs/src/user-guide/notes/find-in-page.md`.

## Relation to sibling PRs

- **#1173 (#1050)** — adopted its caching discipline verbatim: this hook caches no DOM positions and no text, so there is no invalidation problem to get wrong. The debounce delays work; it never reuses a previous result.
- **#1140 (#1017)** — touches `note.tsx` and `journal.tsx`, the two call sites. This PR does not touch either file, only the hook they call, so the two are orthogonal.
- **#1154 / #1165 / #1170** — different hooks, no overlap.
