### PR TITLE
fix(sync): detach the token-refresh callback when the sync runtime stops

### DIFF
--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -133,7 +133,13 @@ const runtimeMocks = vi.hoisted(() => {
     pushCrdtSnapshot: vi.fn(),
     withRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
     emitSessionExpired: vi.fn(),
-    setOnTokenRefreshed: vi.fn(),
+    // token-manager keeps exactly one callback slot, and a refresh invokes
+    // whatever is in it. Model that instead of a bare spy so "who does a token
+    // refresh actually reach after teardown" is observable.
+    tokenRefreshedCallback: null as (() => void) | null,
+    setOnTokenRefreshed: vi.fn((cb: (() => void) | null) => {
+      runtimeMocks.tokenRefreshedCallback = cb
+    }),
     trackMainEvent: vi.fn(),
     logDebug: vi.fn(),
     logInfo: vi.fn(),
@@ -784,5 +790,95 @@ describe('sync runtime', () => {
     expect(runtimeMocks.WebSocketManager.instances[0].disconnect).toHaveBeenCalled()
     expect(runtimeMocks.NetworkMonitor.instances[0].stop).toHaveBeenCalled()
     expect(runtimeMocks.resetCrdtProvider).toHaveBeenCalled()
+  })
+
+  describe('token-refresh callback lifecycle', () => {
+    /** What token-manager does on a successful refresh: invoke the one slot. */
+    const fireTokenRefresh = (): void => runtimeMocks.tokenRefreshedCallback?.()
+
+    beforeEach(() => {
+      runtimeMocks.tokenRefreshedCallback = null
+    })
+
+    it('detaches the callback on stop so a later refresh cannot reach the dead runtime', async () => {
+      const runtime = await loadRuntime()
+      await runtime.startSyncRuntime()
+
+      const deadQueue = runtimeMocks.CrdtUpdateQueue.instances[0]
+      const deadWs = runtimeMocks.WebSocketManager.instances[0]
+      const deadNetwork = runtimeMocks.NetworkMonitor.instances[0]
+      // The closure the runtime installed really is the one that reaches into
+      // these three — that is what makes leaving it installed a live wire.
+      fireTokenRefresh()
+      expect(deadQueue.resume).toHaveBeenCalledTimes(1)
+      expect(deadWs.refreshAuth).toHaveBeenCalledTimes(1)
+      deadQueue.resume.mockClear()
+      deadWs.refreshAuth.mockClear()
+
+      await runtime.stopSyncRuntime({ skipFinalSync: true })
+      expect(deadQueue.stop).toHaveBeenCalledTimes(1)
+      expect(deadWs.disconnect).toHaveBeenCalledTimes(1)
+      expect(deadNetwork.stop).toHaveBeenCalledTimes(1)
+
+      // The slot token-manager reads is empty: nothing in the token layer still
+      // holds this runtime's queue, socket or network monitor.
+      expect(runtimeMocks.tokenRefreshedCallback).toBeNull()
+
+      fireTokenRefresh()
+      expect(deadQueue.resume).not.toHaveBeenCalled()
+      expect(deadWs.refreshAuth).not.toHaveBeenCalled()
+    })
+
+    it('leaves token refresh working for the runtime that replaces a stopped one', async () => {
+      const runtime = await loadRuntime()
+      await runtime.startSyncRuntime()
+      const firstQueue = runtimeMocks.CrdtUpdateQueue.instances[0]
+      const firstWs = runtimeMocks.WebSocketManager.instances[0]
+
+      await runtime.stopSyncRuntime({ skipFinalSync: true })
+      await runtime.startSyncRuntime()
+
+      const secondQueue = runtimeMocks.CrdtUpdateQueue.instances[1]
+      const secondWs = runtimeMocks.WebSocketManager.instances[1]
+      expect(secondQueue).not.toBe(firstQueue)
+      expect(secondWs).not.toBe(firstWs)
+      firstQueue.resume.mockClear()
+      firstWs.refreshAuth.mockClear()
+
+      fireTokenRefresh()
+
+      // Clearing on stop must not outlive the stop: the vault-switch runtime
+      // still re-authenticates, or sync dies silently for the rest of the session.
+      expect(secondQueue.resume).toHaveBeenCalledTimes(1)
+      expect(secondWs.refreshAuth).toHaveBeenCalledTimes(1)
+      expect(firstQueue.resume).not.toHaveBeenCalled()
+      expect(firstWs.refreshAuth).not.toHaveBeenCalled()
+    })
+
+    it('does not unhook a runtime that starts while the previous one is still tearing down', async () => {
+      const runtime = await loadRuntime()
+      await runtime.startSyncRuntime()
+
+      // stopSyncRuntime clears `runtime` before it awaits its teardown, so a
+      // start that lands during those awaits — the deferred-start timer, a
+      // sync:enable IPC — builds a whole new runtime while the old stop is
+      // still in flight. engine.stop is the first of those awaits.
+      runtimeMocks.SyncEngine.instances[0].stop.mockImplementationOnce(async () => {
+        await runtime.startSyncRuntime()
+      })
+      await runtime.stopSyncRuntime({ skipFinalSync: true })
+
+      const secondQueue = runtimeMocks.CrdtUpdateQueue.instances[1]
+      const secondWs = runtimeMocks.WebSocketManager.instances[1]
+      expect(secondQueue).toBeDefined()
+
+      fireTokenRefresh()
+
+      // The live runtime keeps its token refresh. Detaching any later than the
+      // tick that clears `runtime` would strand this one with no way to
+      // re-authenticate, and sync would stop with no error surfaced.
+      expect(secondQueue.resume).toHaveBeenCalledTimes(1)
+      expect(secondWs.refreshAuth).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -820,6 +820,14 @@ export async function stopSyncRuntime(options?: { skipFinalSync?: boolean }): Pr
 
   runtime = null
   startPromise = null
+  // token-manager holds this runtime's callback in a single slot and keeps
+  // firing it long after teardown (its refresh timer is independent), so the
+  // closure pins the dead crdtQueue/ws/network graph and resumes a stopped
+  // queue on the next refresh. Detach in the same tick that clears `runtime`:
+  // that is the last moment before a concurrent startSyncRuntime() can get past
+  // its `if (runtime) return` guard and install its own callback — clearing
+  // after any of the awaits below would silently unhook the *live* runtime.
+  setOnTokenRefreshed(null)
 
   resetSyncServiceSingletons()
 

--- a/apps/desktop/src/main/sync/token-manager.test.ts
+++ b/apps/desktop/src/main/sync/token-manager.test.ts
@@ -454,5 +454,32 @@ describe('token-manager', () => {
       // #then
       expect(callback).toHaveBeenCalledTimes(1)
     })
+
+    it('detaches the previous callback when passed null', async () => {
+      // #given a sync runtime that installed a callback and was then stopped
+      const callback = vi.fn()
+      setOnTokenRefreshed(callback)
+      setOnTokenRefreshed(null)
+
+      mockRetrieveKey.mockImplementation((entry) => {
+        if (entry.account === 'refresh-token') {
+          return Promise.resolve(new TextEncoder().encode('refresh-tok'))
+        }
+        return Promise.resolve(null)
+      })
+
+      mockPostToServer.mockResolvedValue({
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresIn: 900
+      })
+
+      // #when
+      await expect(refreshAccessToken()).resolves.toBe(true)
+
+      // #then the refresh still succeeds, it just no longer calls into the
+      // torn-down runtime the closure captured.
+      expect(callback).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/desktop/src/main/sync/token-manager.ts
+++ b/apps/desktop/src/main/sync/token-manager.ts
@@ -42,7 +42,7 @@ let onTokenRefreshedCallback: (() => void) | null = null
 let refreshRejections = 0
 let refreshBlockedUntil = 0
 
-export function setOnTokenRefreshed(cb: () => void): void {
+export function setOnTokenRefreshed(cb: (() => void) | null): void {
   onTokenRefreshedCallback = cb
 }
 

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -450,6 +450,11 @@ The server verifies the token and requires it to belong to the same device befor
 expiry. Renewal is best-effort: a rejected or unanswered `auth` leaves the original expiry in place,
 so the socket closes at expiry and the client reconnects with a fresh token as it otherwise would.
 
+The renewal hook belongs to the running sync runtime, not to the token manager: the runtime installs
+it at start and detaches it at stop. A refresh that lands after a vault switch or sign-out therefore
+renews nothing instead of reaching into a torn-down socket and CRDT queue, and the runtime that
+replaces it installs its own hook.
+
 ## Vault-Key Verification
 
 Before syncing — and whenever an entire pull page fails to decrypt — the client verifies its local


### PR DESCRIPTION
## Problem

`token-manager` keeps the sync runtime's token-refresh callback in a single module slot and its refresh timer runs independently of the runtime. `stopSyncRuntime()` tore down the engine, CRDT queue, WebSocket and network monitor but never emptied that slot, so the closure stayed installed holding `crdtQueue`, `ws` and `network` — and through `crdtQueue.pushFn`, the whole runtime graph including the old vault's DB handles.

The window is a vault switch (`closeVault()` → `stopSyncRuntime()`): the refresh token stays in the keychain, the refresh timer stays armed, and every on-demand `getValidAccessToken()` caller (calendar, billing, agent) can trigger a refresh. Sign-out is not affected — `teardownSession` calls `resetTokenManagerState()`, which already nulls the slot.

## Root cause

What the stale callback actually does when it fires after teardown, verified rather than assumed:

- `ws.refreshAuth()` — a no-op. `disconnect()` sets `_connected = false` and `ws = null`, and `refreshAuth` early-returns.
- `crdtQueue.resume()` — **not** a no-op. `CrdtUpdateQueue.stop()` clears the flush timer but leaves `paused` and `pushFn` intact, so `resume()` on a queue that was paused at stop unpauses it and runs `flushAll()` against the stopped runtime's push function.
- Nothing throws.

So the concrete harm is the retention plus a resumed dead queue, not a crash.

## Fix

One line in `stopSyncRuntime`: `setOnTokenRefreshed(null)`, placed in the same synchronous tick that clears `runtime`. `setOnTokenRefreshed`'s parameter is widened to `(() => void) | null` (type-only).

Placement is load-bearing. While `runtime` is still set, a concurrent `startSyncRuntime()` returns early at its `if (runtime) return` guard and cannot install a callback; the moment `runtime = null` lands it can. Clearing after any of the awaits that follow would detach the callback the *live* replacement runtime installed, and sync would stop re-authenticating with no error surfaced.

## Test evidence

Three tests in `runtime.test.ts` (the `setOnTokenRefreshed` mock now models token-manager's real single slot, so "who does a refresh reach" is observable) plus one in `token-manager.test.ts` against the real module.

Premise proof, on unmodified `main` with the slot assertion removed:

```
1. detaches the callback on stop so a later refresh cannot reach the dead runtime
   AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
```

That is `deadQueue.resume()` after `stopSyncRuntime()` returned.

RED before the fix:

```
PASS (14) FAIL (1)
1. detaches the callback on stop so a later refresh cannot reach the dead runtime
   AssertionError: expected [Function] to be null
```

GREEN after: `PASS (16) FAIL (0)`, and `PASS (1669) FAIL (0) skipped (3)` across the whole `src/main/sync` suite.

### Mutation

Reverted the fix line by line number (`830s` → `void 0`, so no comment sharing the text was touched):

```
PASS (38) FAIL (1)
1. detaches the callback on stop so a later refresh cannot reach the dead runtime
   AssertionError: expected [Function] to be null
```

Second mutant, to prove the placement guard is not vacuous — same clear, moved to the end of teardown after the awaits:

```
PASS (15) FAIL (1)
1. does not unhook a runtime that starts while the previous one is still tearing down
   AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
```

That is exactly the silent-desync failure mode: the replacement runtime loses its token refresh.

The widened signature in `token-manager.ts` is a type-only change and cannot be killed by a runtime test — passing `null` already worked at runtime, only the type forbade it. `token-manager.test.ts` covers the behaviour against the real module instead: after `setOnTokenRefreshed(null)`, a successful `refreshAccessToken()` still resolves `true` and does not invoke the previous callback.

## Risk & backward compat

Main-process in-memory lifecycle only. No sync protocol, IPC contract, DB schema, vault format or settings shape is touched, so nothing older versions wrote is affected. The added call is a synchronous assignment, so the quit path's 5s force-exit budget is unchanged. Token refresh for a live runtime is unchanged and covered by two of the three new tests.

## Verification

- `pnpm typecheck` — 16/16 tasks successful
- `pnpm lint` — 0 errors (15 pre-existing renderer warnings, none in touched files)
- `pnpm exec vitest run --project main src/main/sync` — PASS (1669) FAIL (0)
- `git diff --check` — clean
- `pnpm docs:impact --base origin/main --strict` — `covered`; `pnpm docs:build` — build complete

No contracts/preload/IPC changes, so `ipc:generate`/`ipc:check` were not required (the typecheck run includes the IPC map check and reports it up to date).

## Out of scope, not fixed

`startSyncRuntime`'s `catch` block tears down `pendingRuntime` the same way but also leaves the callback installed, pinning that graph until the next start or stop. Same shape, different trigger; left for a separate issue.

Closes #1031
