### PR TITLE
fix(agent-mcp): keep a lifetime 'error' listener on the MCP server

### DIFF
--- a/apps/desktop/src/main/agent/mcp/__tests__/server-lifetime-error.test.ts
+++ b/apps/desktop/src/main/agent/mcp/__tests__/server-lifetime-error.test.ts
@@ -1,0 +1,106 @@
+import http from 'node:http'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+  trackMainError: vi.fn(),
+  trackMainLog: vi.fn()
+}))
+
+vi.mock('../../../lib/logger', () => ({
+  createLogger: () => ({
+    info: mocks.logInfo,
+    warn: mocks.logWarn,
+    error: mocks.logError
+  })
+}))
+
+vi.mock('../../../telemetry/diagnostics', () => ({
+  trackMainError: mocks.trackMainError,
+  trackMainLog: mocks.trackMainLog
+}))
+
+import { startAgentMcpServer, type AgentMcpServerHandle } from '../server'
+
+/**
+ * A server-level 'error' after listen has no listener once the listen-only one
+ * is removed, so EventEmitter throws it out of Node's own `onconnection`
+ * callback. In the app that lands in main/index.ts's uncaughtException handler,
+ * which only reports telemetry — the process survives, nothing reaches the log
+ * file, and the report is filed under `main_process:uncaught_exception` with no
+ * hint that the MCP endpoint was involved.
+ */
+describe('Agent MCP server late errors', () => {
+  let handle: AgentMcpServerHandle
+  let server: http.Server
+
+  beforeEach(async () => {
+    mocks.logError.mockClear()
+    mocks.trackMainError.mockClear()
+
+    // Real server, real listen — the spy only hands the test the instance so it
+    // can emit on it the way Node's accept path does.
+    const created: http.Server[] = []
+    const realCreateServer = http.createServer
+    const spy = vi.spyOn(http, 'createServer').mockImplementation(((...args: unknown[]) => {
+      const instance = (realCreateServer as (...a: unknown[]) => http.Server)(...args)
+      created.push(instance)
+      return instance
+    }) as typeof http.createServer)
+    try {
+      handle = await startAgentMcpServer({ toolRegistrations: [] })
+    } finally {
+      spy.mockRestore()
+    }
+    server = created[0]
+  })
+
+  afterEach(async () => {
+    if (server.listening) await handle.stop()
+  })
+
+  it('logs and reports a post-listen server error instead of throwing out of the emit', async () => {
+    // #given the error Node's net.js onconnection() builds and emits on the
+    // server when accept(2) fails after listen
+    const acceptError = Object.assign(new Error('accept EMFILE'), {
+      code: 'EMFILE',
+      syscall: 'accept'
+    })
+
+    // #when the listening server emits it
+    expect(() => server.emit('error', acceptError)).not.toThrow()
+
+    // #then it is surfaced under this server's own scope, not swallowed into
+    // the generic uncaughtException bucket
+    expect(mocks.logError).toHaveBeenCalledWith('Agent MCP server error', acceptError)
+    expect(mocks.trackMainError).toHaveBeenCalledWith('agent', 'mcp_server', acceptError)
+
+    // #and the endpoint stays up: an accept failure is per-connection, the
+    // listening socket is untouched, so Agent Chat keeps working
+    expect(server.listening).toBe(true)
+    const response = await fetch(`${handle.url}/healthz`, {
+      headers: { authorization: `Bearer ${handle.token}` }
+    })
+    expect(response.status).toBe(200)
+  })
+
+  it('still stops cleanly after a late error, and the next start binds a fresh server', async () => {
+    server.emit('error', new Error('accept ENOBUFS'))
+
+    await handle.stop()
+    expect(server.listening).toBe(false)
+
+    const next = await startAgentMcpServer({ toolRegistrations: [] })
+    try {
+      expect(next.url).not.toBe(handle.url)
+      const response = await fetch(`${next.url}/healthz`, {
+        headers: { authorization: `Bearer ${next.token}` }
+      })
+      expect(response.status).toBe(200)
+    } finally {
+      await next.stop()
+    }
+  })
+})

--- a/apps/desktop/src/main/agent/mcp/server.ts
+++ b/apps/desktop/src/main/agent/mcp/server.ts
@@ -128,6 +128,22 @@ export async function startAgentMcpServer(opts: StartOptions): Promise<AgentMcpS
     server.once('error', reject)
     server.listen(0, '127.0.0.1', () => {
       server.off('error', reject)
+      // Lifetime handler, installed in the same tick the listen-only one is
+      // removed. Without it a later server-level 'error' — accept(2) failing
+      // after listen — is an unhandled EventEmitter error thrown out of Node's
+      // onconnection callback, and main/index.ts's uncaughtException handler
+      // absorbs it into telemetry as `main_process:uncaught_exception`: nothing
+      // in the log file, and no hint the MCP endpoint was involved.
+      //
+      // Log and report only. An accept failure never closes the listening
+      // socket, so the endpoint keeps serving; stopping it here would kill
+      // Agent Chat for the rest of the vault session, because
+      // startAgentMcpLifecycle() early-returns while it holds this handle and
+      // nothing would rebind until the vault is switched.
+      server.on('error', (err) => {
+        logger.error('Agent MCP server error', err)
+        trackMainError('agent', 'mcp_server', err)
+      })
       resolve()
     })
   })

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -185,6 +185,11 @@ The localhost MCP endpoint can serve overlapping Agent Chat turns and external r
 keeps the URL/token stable for the app session, but handles each MCP request with an isolated
 transport so one client connection does not block another.
 
+If the operating system refuses a connection to the endpoint — for example when the app has run out
+of file handles — memrynote records the failure in the app log as an `AgentMcpServer` error and keeps
+the endpoint listening on the same URL and token. Individual client connections can be dropped, but
+Agent Chat and external clients can reconnect without restarting the app or reopening the vault.
+
 Client-specific config keys vary. Use the copied URL as the MCP server URL and the copied token as a
 Bearer authorization header. Plain external clients can use read tools, but they do not get the
 in-app conversation/window context that approved writes require.


### PR DESCRIPTION
## Problem

`apps/desktop/src/main/agent/mcp/server.ts` removed its listen-only `'error'` listener once
`listen()` succeeded and never replaced it, so the localhost MCP server ran its whole life with
`listenerCount('error') === 0`.

The issue title says this crashes the main process. **It does not** — and the real behaviour is
harder to notice. `src/main/index.ts` `registerMainDiagnostics()` installs an `uncaughtException`
handler that only calls `trackMainError(...)`: it never rethrows and never exits. Registering any
`uncaughtException` listener also suppresses Node's default crash. So today a late server error is
silently absorbed.

Reproduced against a real listening server, using Node's own `net.js` `onconnection` callback (the
exact function libuv invokes when `accept(2)` fails), fired from an event-loop tick so the throw
unwinds into C++ the way it does in production, with `index.ts`'s swallowing handler installed:

```
listening on 127.0.0.1:59719  listenerCount('error')=0
process alive     = true (pid 48596)
server.listening  = true
uncaught events   = [{"message":"accept EMFILE","code":"EMFILE","stackTop":"at TCP.onconnection (node:net:2310:24)"}]
request after err = 200
process exit code: 0
```

What that means in production today:

- The process survives and the endpoint keeps serving (`healthz` → `200`).
- **Nothing is written to the log file.** `trackMainError` is PostHog-only; it does not touch
  `electron-log`. A user's diagnostic log has no record at all.
- The only record is a PostHog `app_error_seen` filed under `source: main_process`,
  `action: uncaught_exception` — the generic bucket, with no indication the MCP endpoint was
  involved and nothing to distinguish it from any other main-process fault.
- Survival is incidental, not designed: it depends entirely on that swallowing handler staying
  registered.

The issue's stated triggers are only partly right and worth correcting for the record. `ECONNRESET`
is a *socket*-level error and never reaches the server object. Plain `EMFILE` usually does not either:
libuv's `uv__emfile_trick` reserves a spare fd, accepts and closes the pending connection, and returns
`EAGAIN` — verified locally under `ulimit -n 96` with the fd table exhausted, where three connections
were accepted-and-closed and no `'error'` was emitted. The reachable post-listen paths are accept
failures that fall straight through to `connection_cb`: `ENOBUFS`, `ENOMEM`, `EPROTO`, `EPERM`
(host firewall), and `EMFILE`/`ENFILE` once the spare-fd trick can no longer recover. Rarer than the
issue claims — but real, and unhandled.

## Root cause

`server.off('error', reject)` in the `listen` callback left the server with no `'error'` listener for
the rest of its life. `capture/server.ts` already documents and fixes this exact pattern.

## Fix

Install the lifetime handler in the same tick the listen-only one is removed, so there is no window:

```ts
server.on('error', (err) => {
  logger.error('Agent MCP server error', err)
  trackMainError('agent', 'mcp_server', err)
})
```

**The error is not hidden.** After this change the user's `main.log` gets a line under the
`AgentMcpServer` scope naming the failure (`accept EMFILE`, `accept ENOBUFS`, …), and telemetry files
it as `agent` / `mcp_server` instead of `main_process` / `uncaught_exception`, so MCP endpoint faults
are attributable in PostHog for the first time.

**Post-error state: the server stays listening, deliberately.** An accept failure is per-connection —
the listening socket is untouched, proven by `server.listening === true` and a `200` from `/healthz`
after the error. Stopping or restarting it here would be strictly worse: `startAgentMcpLifecycle()`
early-returns while it holds a handle, so nothing would rebind until the vault is switched, turning a
transient per-connection failure into a permanently dead Agent Chat for the rest of the session. A
covering test also proves `stop()` still completes after a late error and a fresh
`startAgentMcpServer()` binds a new port and serves — so the endpoint remains restartable on the
normal vault-switch path.

The user sees no change in the happy path. In the failure case they see what they see today —
individual client connections dropped — except the reason is now in the log.

## Test evidence

New file `apps/desktop/src/main/agent/mcp/__tests__/server-lifetime-error.test.ts`. Both tests run a
real `startAgentMcpServer` on a real port; the `http.createServer` spy only hands the test the server
instance so it can emit the way Node's accept path does.

RED (before the fix):

```
 × logs and reports a post-listen server error instead of throwing out of the emit
   → expected [Function] to not throw an error but 'Error: accept EMFILE' was thrown
 × still stops cleanly after a late error, and the next start binds a fresh server
   → accept ENOBUFS
 Tests  2 failed (2)
```

GREEN:

```
 ✓ logs and reports a post-listen server error instead of throwing out of the emit 24ms
 ✓ still stops cleanly after a late error, and the next start binds a fresh server 6ms
 Tests  2 passed (2)
```

Mutation verification — each added line reverted individually by line number, all three killed, no
survivors and no mutual shielding:

| # | mutation | result |
|---|----------|--------|
| A | line 143 `server.on('error'` → `server.on('listening'` | `Tests 2 failed (2)` |
| B | line 144 `logger.error(...)` deleted | `expected "vi.fn()" to be called with arguments: [ 'Agent MCP server error', …(1) ]` — `1 failed \| 1 passed` |
| C | line 145 `trackMainError(...)` deleted | `expected "vi.fn()" to be called with arguments: [ 'agent', 'mcp_server', …(1) ]` — `1 failed \| 1 passed` |

Restored → `Tests 2 passed (2)`.

Verification:

```
pnpm --filter @memry/desktop test:main src/main/agent/mcp   Test Files 15 passed (15)   Tests 105 passed (105)
pnpm typecheck                                              16 successful, 16 total (rpc:check + IPC invoke map up to date)
pnpm lint                                                   ✖ 15 problems (0 errors, 15 warnings)  [all pre-existing, renderer files, untouched]
git diff --check                                            clean
pnpm docs:impact --base origin/main --strict                docs impact: covered
pnpm docs:build                                             build complete in 5.50s
```

Docs: the gate reported `missing-docs`, and there genuinely is a user-facing note to make, so
`apps/docs/src/user-guide/ai/agent-mcp.md` now states that an OS-level connection refusal is logged
as an `AgentMcpServer` error and that the endpoint keeps its URL and token. No `MEMRY_DOCS_IMPACT_SKIP`
was used (it is implemented nowhere).

## Risk & backward compatibility

Additive only: one `'error'` listener on a server object that is created and discarded per vault
session, plus two statements inside it. No IPC contract, preload API, settings shape, DB schema, sync
protocol or vault file format is touched, so nothing older versions wrote is affected. No change to
the authorization path: external MCP clients stay read-only by default and writes still require an
active conversation and the approval UI. Nothing new runs on the quit path, so `closeVault()`'s 5s
budget is unaffected — a crash is not traded for a hang.

## Related

- #1123 (MCP server destroys in-flight connections on stop) touches the `stop()` body; this change
  touches the `listen` callback. No overlap, and the new test file is separate from
  `__tests__/server.test.ts` which that PR extends.
- #1164 (`agentMcpStarted` so MCP teardown runs after a failed runtime start) touches
  `vault/index.ts` and `mcp/lifecycle.ts`. Its `startAgentMcpLifecycle()` early-return is exactly why
  this fix keeps the server listening rather than tearing it down.

Closes #1039
