### PR TITLE
perf(canvas): coalesce card-overlay recompute and stop measuring the clip per commit

### DIFF
--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useRef } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CanvasCardLayer } from './canvas-card-overlay'
 import { CANVAS_ITEM_DRAG_MIME, noteCardSize, type CardElement } from './canvas-cards'
@@ -705,5 +705,280 @@ describe('CanvasCardLayer — dnd-kit drops', () => {
     })
 
     await waitFor(() => expect(screen.queryByTestId('canvas-drop-ring')).toBeNull())
+  })
+})
+
+// --- Recompute scoping (#1052) ----------------------------------------------
+//
+// Excalidraw triggers its onChange emitter from componentDidUpdate for EVERY
+// committed state change, not just scene edits: a pan tick, a zoom tick, a
+// pointer-move that only changed which element is hovered. So the work the
+// overlay does per onChange is work it does per frame — several times per frame
+// while the wheel outruns the display — and `clientWidth`/`clientHeight` in
+// that path is a forced synchronous layout in the critical path of every frame.
+//
+// These tests pin counts (scene reads = full passes, clip measurements = forced
+// layouts) and the exact overlay geometry, so an implementation that gets cheap
+// by drifting off its cards cannot pass.
+
+/** Clip viewport the counting getters below report, in CSS px. */
+const CLIP_WIDTH = 800
+const CLIP_HEIGHT = 600
+
+describe('CanvasCardLayer — recompute scoping', () => {
+  let clipWidth = CLIP_WIDTH
+  let clipHeight = CLIP_HEIGHT
+  /** Every clientWidth/clientHeight read anywhere in the tree — one forced layout each. */
+  let clipMeasures = 0
+  let frames = new Map<number, FrameRequestCallback>()
+  let nextFrameId = 1
+  let resizeCallbacks: ResizeObserverCallback[] = []
+  let widthDescriptor: PropertyDescriptor | undefined
+  let heightDescriptor: PropertyDescriptor | undefined
+
+  function flushFrames(): void {
+    const pending = [...frames.values()]
+    frames = new Map()
+    pending.forEach((callback) => callback(0))
+  }
+
+  /** The transformed overlay layer — where the whole card plane sits. */
+  function layer(): HTMLElement {
+    return document.querySelector('[data-canvas-overlay]') as HTMLElement
+  }
+
+  /** The absolutely positioned box wrapping one card. */
+  function cardBox(elementId: string): Record<string, string> {
+    const style = (screen.getByTestId(`card-${elementId}`).parentElement as HTMLElement).style
+    return {
+      left: style.left,
+      top: style.top,
+      width: style.width,
+      height: style.height
+    }
+  }
+
+  /** A scene whose appState and elements the test mutates between onChange fires. */
+  function makeLiveApi(elements: CardElement[]): {
+    api: ExcalidrawImperativeAPI
+    fire: () => void
+    appState: { scrollX: number; scrollY: number; zoom: { value: number } }
+    /** Full recompute passes so far — readScene() reads the elements exactly once. */
+    passes: () => number
+  } {
+    let onChangeCb: (() => void) | null = null
+    let passes = 0
+    const appState = { scrollX: 0, scrollY: 0, zoom: { value: 1 }, offsetLeft: 0, offsetTop: 0 }
+    const api = {
+      getSceneElements: () => {
+        passes += 1
+        return elements
+      },
+      getSceneElementsIncludingDeleted: () => elements,
+      getAppState: () => appState,
+      getFiles: () => ({}),
+      updateScene: vi.fn(),
+      refresh: vi.fn(),
+      onChange: (cb: () => void) => {
+        onChangeCb = cb
+        return () => {
+          onChangeCb = null
+        }
+      }
+    } as unknown as ExcalidrawImperativeAPI
+    return { api, fire: () => onChangeCb?.(), appState, passes: () => passes }
+  }
+
+  beforeEach(() => {
+    mocks.openTab.mockReset()
+    mocks.notesGet.mockReset()
+    mocks.notesGet.mockResolvedValue({ id: 'n', content: '' })
+    mocks.entities = new Map()
+    mocks.lockReason = null
+    dnd.listeners = {}
+    dnd.isOver = false
+    dnd.dragContext = null
+
+    clipWidth = CLIP_WIDTH
+    clipHeight = CLIP_HEIGHT
+    clipMeasures = 0
+    frames = new Map()
+    nextFrameId = 1
+    resizeCallbacks = []
+
+    // jsdom reports 0 for every layout box, so the viewport would be empty and
+    // virtualization untestable. These getters give the clip a real size AND
+    // count the reads, which is the forced layout this issue is about.
+    widthDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'clientWidth')
+    heightDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'clientHeight')
+    Object.defineProperty(Element.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => {
+        clipMeasures += 1
+        return clipWidth
+      }
+    })
+    Object.defineProperty(Element.prototype, 'clientHeight', {
+      configurable: true,
+      get: () => {
+        clipMeasures += 1
+        return clipHeight
+      }
+    })
+
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      const id = nextFrameId
+      nextFrameId += 1
+      frames.set(id, callback)
+      return id
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      frames.delete(id)
+    })
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallbacks.push(callback)
+        }
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+      }
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    if (widthDescriptor) {
+      Object.defineProperty(Element.prototype, 'clientWidth', widthDescriptor)
+    }
+    if (heightDescriptor) {
+      Object.defineProperty(Element.prototype, 'clientHeight', heightDescriptor)
+    }
+  })
+
+  it('coalesces a burst of pan commits into one pass, with the overlay glued meanwhile', () => {
+    const { api, fire, appState, passes } = makeLiveApi([
+      cardEl('e1', 'n1', 0, 0),
+      cardEl('e2', 'n2', 400, 0)
+    ])
+    render(<Harness api={api} />)
+
+    // Mount: one pass, one clip measurement (width + height).
+    expect(passes()).toBe(1)
+    expect(clipMeasures).toBe(2)
+    expect(layer().style.transform).toBe('translate(0px, 0px) scale(1)')
+
+    const passesBefore = passes()
+    const measuresBefore = clipMeasures
+    // Five pan commits landing before the browser gets a frame.
+    for (let step = 1; step <= 5; step += 1) {
+      appState.scrollX = -step * 10
+      fire()
+    }
+
+    // The layer must already be over the panned scene — waiting for the frame
+    // would leave every card lagging the rectangle it covers.
+    expect(layer().style.transform).toBe('translate(-50px, 0px) scale(1)')
+    expect(passes()).toBe(passesBefore)
+
+    act(flushFrames)
+
+    expect(passes() - passesBefore).toBe(1)
+    expect(clipMeasures - measuresBefore).toBe(0)
+    expect(layer().style.transform).toBe('translate(-50px, 0px) scale(1)')
+    expect(cardBox('e1')).toEqual({ left: '0px', top: '0px', width: '260px', height: '168px' })
+    expect(cardBox('e2')).toEqual({ left: '400px', top: '0px', width: '260px', height: '168px' })
+  })
+
+  it('applies zoom to the layer immediately and leaves card boxes in scene units', () => {
+    const { api, fire, appState, passes } = makeLiveApi([cardEl('e1', 'n1', 0, 0)])
+    render(<Harness api={api} />)
+    const passesBefore = passes()
+    const measuresBefore = clipMeasures
+
+    appState.zoom = { value: 2 }
+    appState.scrollX = 20
+    appState.scrollY = -30
+    fire()
+    fire()
+    fire()
+
+    expect(layer().style.transform).toBe('translate(40px, -60px) scale(2)')
+
+    act(flushFrames)
+
+    expect(passes() - passesBefore).toBe(1)
+    expect(clipMeasures - measuresBefore).toBe(0)
+    expect(layer().style.transform).toBe('translate(40px, -60px) scale(2)')
+    // Cards are positioned in scene coordinates; the layer's scale does the zoom.
+    expect(cardBox('e1')).toEqual({ left: '0px', top: '0px', width: '260px', height: '168px' })
+  })
+
+  it('follows a dragged element to its exact new geometry', () => {
+    const moved = cardEl('e1', 'n1', 0, 0)
+    const { api, fire, passes } = makeLiveApi([moved])
+    render(<Harness api={api} />)
+    const passesBefore = passes()
+    const measuresBefore = clipMeasures
+
+    // Excalidraw mutates elements in place during a drag and commits per tick.
+    moved.x = 120
+    moved.y = 45
+    fire()
+    moved.x = 137
+    moved.y = 52
+    fire()
+
+    act(flushFrames)
+
+    expect(passes() - passesBefore).toBe(1)
+    expect(clipMeasures - measuresBefore).toBe(0)
+    expect(cardBox('e1')).toEqual({ left: '137px', top: '52px', width: '260px', height: '168px' })
+  })
+
+  it('unmounts a card deleted from the scene', () => {
+    const elements = [cardEl('e1', 'n1', 0, 0), cardEl('e2', 'n2', 400, 0)]
+    const { api, fire } = makeLiveApi(elements)
+    render(<Harness api={api} />)
+    expect(screen.getByTestId('card-e2')).toBeInTheDocument()
+
+    elements[1].isDeleted = true
+    fire()
+    act(flushFrames)
+
+    expect(screen.queryByTestId('card-e2')).toBeNull()
+    expect(cardBox('e1')).toEqual({ left: '0px', top: '0px', width: '260px', height: '168px' })
+  })
+
+  it('re-measures the clip after a resize, so a card entering the wider viewport mounts', () => {
+    // e2 sits past 800px viewport + 200px enter padding, so it starts unmounted.
+    const { api } = makeLiveApi([cardEl('e1', 'n1', 0, 0), cardEl('e2', 'n2', 1500, 0)])
+    render(<Harness api={api} />)
+    expect(screen.queryByTestId('card-e2')).toBeNull()
+
+    // A window resize / sidebar toggle widens the clip. Nothing about the scene
+    // or the viewport transform changed, so only a fresh clip measurement can
+    // bring e2 in — a held size would leave a blank hole where the card is.
+    clipWidth = 2000
+    act(() => {
+      resizeCallbacks.forEach((callback) => callback([], {} as ResizeObserver))
+    })
+
+    expect(screen.getByTestId('card-e2')).toBeInTheDocument()
+    expect(cardBox('e2')).toEqual({ left: '1500px', top: '0px', width: '260px', height: '168px' })
+  })
+
+  it('drops a scheduled pass when the layer unmounts before the frame runs', () => {
+    const { api, fire, passes } = makeLiveApi([cardEl('e1', 'n1', 0, 0)])
+    const { unmount } = render(<Harness api={api} />)
+    const passesBefore = passes()
+
+    fire()
+    unmount()
+    act(flushFrames)
+
+    expect(passes()).toBe(passesBefore)
   })
 })

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.tsx
@@ -91,6 +91,10 @@ export const CanvasCardLayer = ({
   const [visibleRefs, setVisibleRefs] = useState<CanvasCardRef[]>([])
   const visibleIdsRef = useRef<Set<string>>(new Set())
   const signatureRef = useRef('')
+  /** Last measurement of the clip's box; dropped by the ResizeObserver below. */
+  const clipSizeRef = useRef<{ width: number; height: number } | null>(null)
+  /** The coalescing frame, so N Excalidraw commits in one frame cost one pass. */
+  const frameRef = useRef<number | null>(null)
 
   // Level of detail: cards render their entity at full editor fidelity until
   // the scene gets too small to read or too crowded to mount (see
@@ -151,23 +155,65 @@ export const CanvasCardLayer = ({
     return { cards: getCardRefs(elements), appState }
   }, [excalidrawAPI])
 
-  const recompute = useCallback(() => {
-    const { cards, appState } = readScene()
+  /**
+   * Glue the layer onto the scene. Style writes only, no layout read, so this
+   * is what keeps running on every Excalidraw commit while the heavier pass
+   * below is coalesced onto a frame — pan and zoom stay exactly as immediate as
+   * they are today, which is the whole point of the overlay.
+   */
+  const syncViewport = useCallback((): void => {
     const clip = clipRef.current
     const layer = layerRef.current
     if (!clip || !layer) {
       return
     }
-    // Transform is imperative: no React render during pan/zoom.
+    const appState = excalidrawAPI.getAppState() as unknown as CanvasAppStateView
     layer.style.transform = overlayTransform(appState)
     clip.dataset.scrollX = String(appState.scrollX)
     clip.dataset.scrollY = String(appState.scrollY)
     clip.dataset.zoom = String(appState.zoom.value)
+  }, [excalidrawAPI])
 
-    const rect = viewportSceneRect(appState, {
-      width: clip.clientWidth,
-      height: clip.clientHeight
-    })
+  /**
+   * The clip's box, measured at most once per size change. `clientWidth` /
+   * `clientHeight` force a synchronous layout, and the pass that needs them runs
+   * on every Excalidraw commit — including commits that only changed which
+   * element is hovered — so reading them unconditionally put a forced layout in
+   * the critical path of every frame.
+   *
+   * Holding the measurement is only safe because the ResizeObserver below
+   * watches this exact element and CLEARS this cache: a ResizeObserver reports
+   * any box change whatever caused it (window resize, sidebar toggle, split
+   * drag, tab show/hide, a stylesheet landing late), which is the invalidation
+   * a scroll/resize listener could not give. Nothing here stores a size taken
+   * from the observer entry — the next pass re-reads the live element — so a
+   * padding or box-sizing change cannot desync the two.
+   *
+   * A stale measurement can never move the overlay: the layer transform is
+   * derived from appState alone (`syncViewport`). It only feeds virtualization,
+   * so the worst case is one pass deciding membership against the previous
+   * viewport size, inside the 200/500px hysteresis band.
+   */
+  const clipSize = useCallback((clip: HTMLDivElement): { width: number; height: number } => {
+    const cached = clipSizeRef.current
+    if (cached) {
+      return cached
+    }
+    const size = { width: clip.clientWidth, height: clip.clientHeight }
+    clipSizeRef.current = size
+    return size
+  }, [])
+
+  const recompute = useCallback(() => {
+    const { cards, appState } = readScene()
+    const clip = clipRef.current
+    if (!clip || !layerRef.current) {
+      return
+    }
+    // Transform is imperative: no React render during pan/zoom.
+    syncViewport()
+
+    const rect = viewportSceneRect(appState, clipSize(clip))
     const nextIds = withActivePinned(
       computeVisibleCardIds(cards, rect, {
         enterPadding: ENTER_PADDING,
@@ -209,13 +255,38 @@ export const CanvasCardLayer = ({
       signatureRef.current = signature
       setVisibleRefs(visible)
     }
-  }, [readScene, dispatchActive])
+  }, [readScene, dispatchActive, syncViewport, clipSize])
+
+  /**
+   * Excalidraw triggers onChange from componentDidUpdate for EVERY committed
+   * state change — a pan tick, a zoom tick, a pointer-move that only changed
+   * the hovered element — and several of those can land in one frame while the
+   * wheel outruns the display. The glue runs on each of them; deciding which
+   * cards are mounted and where is worth doing once per frame, not once per
+   * commit.
+   */
+  const scheduleRecompute = useCallback(() => {
+    syncViewport()
+    if (frameRef.current !== null) {
+      return
+    }
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null
+      recompute()
+    })
+  }, [syncViewport, recompute])
 
   useEffect(() => {
     recompute()
-    const unsubscribe = excalidrawAPI.onChange(() => recompute())
-    return unsubscribe
-  }, [excalidrawAPI, recompute])
+    const unsubscribe = excalidrawAPI.onChange(scheduleRecompute)
+    return () => {
+      unsubscribe()
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current)
+        frameRef.current = null
+      }
+    }
+  }, [excalidrawAPI, recompute, scheduleRecompute])
 
   // Container resize changes the viewport → recompute membership + let
   // Excalidraw recalc its canvas offsets so coordinate math stays correct.
@@ -225,6 +296,7 @@ export const CanvasCardLayer = ({
       return
     }
     const observer = new ResizeObserver(() => {
+      clipSizeRef.current = null
       excalidrawAPI.refresh()
       recompute()
     })


### PR DESCRIPTION
## Problem

`CanvasCardLayer` subscribes `recompute()` to `excalidrawAPI.onChange`. Excalidraw triggers that emitter from `App.componentDidUpdate` **unconditionally** (`@excalidraw/excalidraw@0.18.1` `dist/dev/index.js:30536-30539`, guarded only by `!isLoading`), so it fires on every committed state change — not only scene edits. Pan and zoom go through `translateCanvas` → `setState` (`:25869`, wheel pan/zoom at `:29293-29316`, space-drag pan at `:27710`, pinch at `:26978`), and so do commits that changed nothing but the hovered element or the cursor.

Each of those ran the whole pass: `getSceneElements()` + `getCardRefs()` over every element, a write to `layer.style.transform` and three `clip.dataset.*` attributes, then `clip.clientWidth` / `clip.clientHeight` — reads that, following those writes, force a synchronous style+layout recalculation — then visibility, level-of-detail and a per-card signature string. No coalescing, so several commits in one frame paid it several times.

## Root cause

Two separate things were tied to the wrong clock:

1. The **whole** pass was on the onChange clock, when only the layer transform has to be.
2. The clip's box was re-measured on every pass, although it only changes when the container resizes — and a `ResizeObserver` on that exact element was already mounted in this component.

## Fix

- `syncViewport()` — the layer transform plus the diagnostic `data-scroll-x/y`/`data-zoom` attributes. Style writes only, no layout read. It still runs **inline on every onChange**, so pan and zoom keep the overlay exactly where it is today.
- `scheduleRecompute()` — calls `syncViewport()`, then coalesces the membership/geometry pass onto one `requestAnimationFrame`, skipping the schedule when a frame is already pending. Cancelled on unmount.
- `clipSize()` — holds the `clientWidth`/`clientHeight` measurement. The existing `ResizeObserver` **clears** it (it never writes a size taken from the observer entry, so the next pass re-reads the live element and a padding/box-sizing change cannot desync the two).

Nothing else moved. Scene persistence, serialization and the drop/dblclick/wheel handlers are untouched.

### Caching decision

The only thing cached is the clip's own box, and the invalidation is a `ResizeObserver` on that same element — which reports any box change whatever caused it (window resize, sidebar toggle, split drag, tab show/hide, a stylesheet landing late). That is the signal PR #1173 correctly refused to fake with scroll/resize listeners. Element offsets are **not** cached: `getCardRefs()` re-reads the scene every pass, so an in-place Excalidraw mutation can never feed stale geometry to a card box.

A stale clip measurement cannot move the overlay: the layer transform comes from `appState` alone. It only feeds virtualization, so the worst case is one pass computing membership against the previous viewport size, inside the existing 200/500 px hysteresis band — and `re-measures the clip after a resize…` pins that it recovers.

## What must move the overlay, and proof each still does

| Trigger | Path | Covered by |
| --- | --- | --- |
| Pan | `onChange` → `syncViewport()` inline | `coalesces a burst of pan commits…` asserts the transform **before** the frame runs |
| Zoom | same | `applies zoom to the layer immediately…` |
| Element dragged | `onChange` → frame → signature change → `setVisibleRefs` | `follows a dragged element to its exact new geometry` |
| Element resized | same signature path (w/h are in the signature) | same test's exact `width`/`height` assertions |
| Element deleted | `getCardRef` rejects `isDeleted` → membership change | `unmounts a card deleted from the scene` |
| New card added | `createCardElements()` calls `recompute()` directly (synchronous) | pre-existing drop/capture/dnd tests |
| Scene loaded / switched | `CanvasEditor` mounts → mount effect `recompute()` | `renders a card for each visible card element` |
| Undo / redo | Excalidraw history → `setState` → `onChange` → frame | same path as element edit above |
| Window resize | `ResizeObserver` → clear measurement + `refresh()` + `recompute()` | `re-measures the clip after a resize…` |
| Sidebar toggle | same `ResizeObserver` path | same |
| Remote / sync scene update | `registerLiveCanvas` → `api.updateScene()` → `onChange` → frame | same path as element edit above |

## Test evidence

Measured with a harness that counts full passes (one `getSceneElements()` per pass) and clip measurements (one forced layout per `clientWidth`/`clientHeight` read), driving 10 `onChange` fires per scenario. Same test file, run against `origin/main` and against this branch:

```
########## BEFORE (origin/main) ##########
mount : passes=1 layoutReads=2
pan   : 10 onChange -> passes=10 layoutReads=20
zoom  : 10 onChange -> passes=10 layoutReads=20
edit  : 10 onChange -> passes=10 layoutReads=20

########## AFTER (this branch) ##########
mount : passes=1 layoutReads=2
pan   : 10 onChange -> passes=1 layoutReads=0
zoom  : 10 onChange -> passes=1 layoutReads=0
edit  : 10 onChange -> passes=1 layoutReads=0
```

Forced layouts go to zero on the interaction path; the pass itself collapses to at most one per frame. Tests assert counts and exact geometry (`translate(-50px, 0px) scale(1)`, `translate(40px, -60px) scale(2)`, `left/top/width/height` per card) — never timing — so an implementation that gets cheap by letting the overlay drift cannot pass.

### Mutation verification

Five single-line reverts, one at a time, full file re-run each:

| # | Line reverted | Result |
| --- | --- | --- |
| M1 | coalescing guard `if (frameRef.current !== null)` | **3 failed** / 26 passed |
| M2 | `clipSizeRef.current = size` (hold the measurement) | **3 failed** / 26 passed |
| M3 | `clipSizeRef.current = null` (resize invalidation) | **1 failed** / 28 passed |
| M4 | `syncViewport()` inside `scheduleRecompute` | **2 failed** / 27 passed |
| M5 | `cancelAnimationFrame(frameRef.current)` | **1 failed** / 28 passed |
| — | restored | 29 passed (29) |

No survivors. M3, M4 and M5 are each killed by a test the others do not kill, so the lines are not shielding each other.

### Verification

```
pnpm typecheck                                  exit=0  (16/16 tasks)
pnpm lint                                       exit=0  (0 errors; 15 pre-existing warnings, none in this file)
git diff --check                                exit=0
vitest --project renderer canvas-card-overlay   Tests  29 passed (29)
vitest --project renderer (full)                Test Files  560 passed (560)
                                                Tests  6314 passed | 6 skipped (6320)
npx react-doctor@latest . (twice)               identical output apart from the scan timing line
```

`react-doctor` reports one finding in this file, `no-permanent-will-change` on the layer's `will-change-transform` — pre-existing on `origin/main:756` and deliberate for a per-frame transform; not touched.

## Risk & backward compatibility

Renderer-only, inside one component. No change to the canvas file format, what gets serialized, or when it is written — the scene persister is not touched, so the stale-scene cross-save hazard is not approached. No IPC contract, settings shape or DB change. Nothing persisted, so nothing for an older app version to read differently.

The one behavioural delta: card mounting/geometry now lands on the animation frame after the commit rather than inside Excalidraw's commit. The layer transform is unchanged and still inline, so pan/zoom are pixel-identical; Excalidraw's own canvas draw is itself `throttleRAF`-gated (`renderInteractiveSceneThrottled` / `renderStaticSceneThrottled`), so both sides settle within the same frame. No new Tailwind classes, so no RTL surface.

## Relation to other in-flight work

`#1156` (canvas folder tree / rename / duplicate / delete) touches no file under `apps/desktop/src/renderer/src/pages/canvas/` — its renderer work is in `components/sidebar/canvas-tree/` and its main-process work in `src/main/canvas/`. No overlap.

## Docs

`pnpm docs:impact --base origin/main --strict` reports `missing-docs` for this file. Declining, deliberately: this is an internal render-scheduling change with no user-visible delta — same cards, same positions, same interactions, no new setting or surface — and there is nothing in `apps/docs/src` it makes wrong. The gate is advisory here: no pre-push hook exists in this repo, no workflow in `.github/workflows` invokes `docs:impact`, and `MEMRY_DOCS_IMPACT_SKIP` is implemented nowhere, so nothing was bypassed to say this.

Closes #1052
