### PR TITLE
feat(calendar): multiple Google accounts, per-account calendar selection

### DIFF
--- a/apps/desktop/src/main/calendar/google/calendar-source-discovery.test.ts
+++ b/apps/desktop/src/main/calendar/google/calendar-source-discovery.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { createTestDataDb, type TestDatabaseResult, type TestDb } from '@tests/utils/test-db'
+import { calendarSources } from '@memry/db-schema/schema/calendar-sources'
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => [])
+  }
+}))
+
+vi.mock('./oauth', () => ({
+  hasGoogleCalendarConnection: vi.fn(async () => true),
+  listGoogleAccountIds: vi.fn(() => ['work@example.com']),
+  resolveDefaultGoogleAccountId: vi.fn(() => 'work@example.com')
+}))
+
+vi.mock('../../sync/auth-state', () => ({
+  isMemryUserSignedIn: vi.fn(async () => true)
+}))
+
+import { discoverGoogleCalendarSources } from './sync-service'
+import { upsertCalendarSource } from '../repositories/calendar-sources-repository'
+
+const REMOTE_CALENDARS = [
+  {
+    id: 'work@example.com',
+    title: 'Work',
+    timezone: 'Europe/Istanbul',
+    color: '#0ea5e9',
+    isPrimary: true
+  },
+  {
+    id: 'team-standup@group.calendar.google.com',
+    title: 'Team standup',
+    timezone: 'Europe/Istanbul',
+    color: '#f97316',
+    isPrimary: false
+  },
+  {
+    id: 'holidays@group.v.calendar.google.com',
+    title: 'Holidays',
+    timezone: 'UTC',
+    color: '#22c55e',
+    isPrimary: false
+  }
+]
+
+function stubClient(calendars = REMOTE_CALENDARS) {
+  return { listCalendars: vi.fn(async () => calendars) }
+}
+
+describe('discoverGoogleCalendarSources', () => {
+  let dbResult: TestDatabaseResult
+  let db: TestDb
+
+  beforeEach(() => {
+    dbResult = createTestDataDb()
+    db = dbResult.db
+  })
+
+  it('records every calendar on the account, pre-selecting only the primary', async () => {
+    await discoverGoogleCalendarSources(db, stubClient(), 'work@example.com')
+
+    const rows = db
+      .select()
+      .from(calendarSources)
+      .where(eq(calendarSources.kind, 'calendar'))
+      .all()
+      .sort((left, right) => left.remoteId.localeCompare(right.remoteId))
+
+    expect(rows.map((row) => row.remoteId)).toEqual([
+      'holidays@group.v.calendar.google.com',
+      'team-standup@group.calendar.google.com',
+      'work@example.com'
+    ])
+    expect(rows.every((row) => row.accountId === 'work@example.com')).toBe(true)
+    // Only the primary is on by default — the others are the user's to opt into.
+    expect(rows.filter((row) => row.isSelected).map((row) => row.remoteId)).toEqual([
+      'work@example.com'
+    ])
+  })
+
+  it('leaves an existing selection alone when re-run', async () => {
+    await discoverGoogleCalendarSources(db, stubClient(), 'work@example.com')
+
+    const standupId = 'google-calendar:team-standup@group.calendar.google.com'
+    const primaryId = 'google-calendar:work@example.com'
+    const standup = db.select().from(calendarSources).where(eq(calendarSources.id, standupId)).get()
+    const primary = db.select().from(calendarSources).where(eq(calendarSources.id, primaryId)).get()
+    // The user turns the standup calendar on and the primary off.
+    upsertCalendarSource(db, { ...standup!, isSelected: true })
+    upsertCalendarSource(db, { ...primary!, isSelected: false })
+
+    await discoverGoogleCalendarSources(db, stubClient(), 'work@example.com')
+
+    const after = db
+      .select()
+      .from(calendarSources)
+      .where(eq(calendarSources.kind, 'calendar'))
+      .all()
+    const selected = after.filter((row) => row.isSelected).map((row) => row.remoteId)
+
+    expect(selected).toEqual(['team-standup@group.calendar.google.com'])
+  })
+
+  it('refreshes a renamed calendar without disturbing its sync cursor', async () => {
+    await discoverGoogleCalendarSources(db, stubClient(), 'work@example.com')
+
+    const standupId = 'google-calendar:team-standup@group.calendar.google.com'
+    const seeded = db.select().from(calendarSources).where(eq(calendarSources.id, standupId)).get()
+    upsertCalendarSource(db, {
+      ...seeded!,
+      isSelected: true,
+      syncCursor: 'cursor-abc',
+      syncStatus: 'ok',
+      lastSyncedAt: '2026-08-08T00:00:00.000Z'
+    })
+
+    await discoverGoogleCalendarSources(
+      db,
+      stubClient([
+        REMOTE_CALENDARS[0],
+        { ...REMOTE_CALENDARS[1], title: 'Team standup (renamed)', color: '#a855f7' },
+        REMOTE_CALENDARS[2]
+      ]),
+      'work@example.com'
+    )
+
+    const row = db.select().from(calendarSources).where(eq(calendarSources.id, standupId)).get()
+
+    expect(row?.title).toBe('Team standup (renamed)')
+    expect(row?.color).toBe('#a855f7')
+    // Dropping the cursor would re-pull the whole calendar from scratch.
+    expect(row?.syncCursor).toBe('cursor-abc')
+    expect(row?.lastSyncedAt).toBe('2026-08-08T00:00:00.000Z')
+  })
+
+  it('revives a calendar archived by an earlier disconnect', async () => {
+    await discoverGoogleCalendarSources(db, stubClient(), 'work@example.com')
+
+    // Disconnect archives every source of the account; listCalendarSources
+    // filters archived rows out, so leaving the flag set would make a
+    // reconnected account come back with an empty calendar picker.
+    const rows = db.select().from(calendarSources).where(eq(calendarSources.kind, 'calendar')).all()
+    for (const row of rows) {
+      upsertCalendarSource(db, { ...row, archivedAt: '2026-08-08T00:00:00.000Z' })
+    }
+
+    await discoverGoogleCalendarSources(db, stubClient(), 'work@example.com')
+
+    const after = db
+      .select()
+      .from(calendarSources)
+      .where(eq(calendarSources.kind, 'calendar'))
+      .all()
+
+    expect(after.every((row) => row.archivedAt === null)).toBe(true)
+  })
+
+  it('keeps two accounts separate rather than reassigning shared calendars', async () => {
+    await discoverGoogleCalendarSources(db, stubClient(), 'work@example.com')
+    await discoverGoogleCalendarSources(
+      db,
+      stubClient([
+        {
+          id: 'personal@example.com',
+          title: 'Personal',
+          timezone: 'Europe/Istanbul',
+          color: '#ec4899',
+          isPrimary: true
+        }
+      ]),
+      'personal@example.com'
+    )
+
+    const rows = db.select().from(calendarSources).where(eq(calendarSources.kind, 'calendar')).all()
+
+    expect(rows).toHaveLength(4)
+    expect(rows.filter((row) => row.accountId === 'work@example.com')).toHaveLength(3)
+    expect(rows.filter((row) => row.accountId === 'personal@example.com')).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/main/calendar/google/oauth.test.ts
+++ b/apps/desktop/src/main/calendar/google/oauth.test.ts
@@ -166,7 +166,7 @@ describe('google calendar oauth', () => {
       expect(parsed.pathname).toBe('/o/oauth2/v2/auth')
       expect(parsed.searchParams.get('scope')).toContain(GOOGLE_CALENDAR_SCOPE)
       expect(parsed.searchParams.get('access_type')).toBe('offline')
-      expect(parsed.searchParams.get('prompt')).toBe('consent')
+      expect(parsed.searchParams.get('prompt')).toBe('select_account consent')
 
       const state = parsed.searchParams.get('state')
       const redirectUri = parsed.searchParams.get('redirect_uri')
@@ -232,10 +232,28 @@ describe('google calendar oauth', () => {
     expect(parsed.searchParams.get('scope')).toBe(`openid email profile ${GOOGLE_CALENDAR_SCOPE}`)
     expect(parsed.searchParams.get('state')).toBe('state-123')
     expect(parsed.searchParams.get('access_type')).toBe('offline')
-    expect(parsed.searchParams.get('prompt')).toBe('consent')
+    expect(parsed.searchParams.get('prompt')).toBe('select_account consent')
     expect(parsed.searchParams.get('include_granted_scopes')).toBe('true')
     expect(parsed.searchParams.get('code_challenge')).toBe('challenge-123')
     expect(parsed.searchParams.get('code_challenge_method')).toBe('S256')
+  })
+
+  it('asks Google for the account chooser so a second account can be added', () => {
+    // Without select_account Google silently reuses whichever account is already
+    // signed in to the browser, so connecting a second account is impossible —
+    // the flow completes and lands right back on the account already linked.
+    const authUrl = buildGoogleCalendarAuthUrl({
+      clientId: 'client-id',
+      redirectUri: 'http://127.0.0.1:1234/callback',
+      state: 'state-123',
+      codeChallenge: 'challenge-123'
+    })
+
+    const prompt = new URL(authUrl).searchParams.get('prompt')?.split(' ') ?? []
+
+    expect(prompt).toContain('select_account')
+    // Still required: only a consent round-trip returns a refresh token.
+    expect(prompt).toContain('consent')
   })
 
   it('rejects provider error and malformed callback responses before token exchange', async () => {

--- a/apps/desktop/src/main/calendar/google/oauth.ts
+++ b/apps/desktop/src/main/calendar/google/oauth.ts
@@ -551,7 +551,11 @@ export function buildGoogleCalendarAuthUrl(input: {
   authUrl.searchParams.set('scope', GOOGLE_ALL_SCOPES.join(' '))
   authUrl.searchParams.set('state', input.state)
   authUrl.searchParams.set('access_type', 'offline')
-  authUrl.searchParams.set('prompt', 'consent')
+  // select_account: without it Google reuses whichever account the browser is
+  // already signed in to, so a second account can never be added — the flow
+  // completes and returns the account that is already linked.
+  // consent: still required, it is what makes Google return a refresh token.
+  authUrl.searchParams.set('prompt', 'select_account consent')
   authUrl.searchParams.set('include_granted_scopes', 'true')
   authUrl.searchParams.set('code_challenge', input.codeChallenge)
   authUrl.searchParams.set('code_challenge_method', 'S256')

--- a/apps/desktop/src/main/calendar/google/sync-service.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.test.ts
@@ -1793,6 +1793,58 @@ describe('google calendar sync service', () => {
       )
     })
 
+    it('discovers the account calendars so an already-connected install fills its picker', async () => {
+      // Users connected before multi-calendar shipped only ever got a source
+      // row for their primary. Discovery has to happen on the ordinary sync
+      // pass, or they would have to disconnect and reconnect to see the rest.
+      seedGoogleCalendarSource({
+        id: 'google-calendar:work-primary',
+        remoteId: 'work-primary',
+        title: 'Work',
+        isPrimary: true,
+        isMemryManaged: false
+      })
+
+      const client = buildClient()
+      client.listCalendars.mockResolvedValue([
+        {
+          id: 'work-primary',
+          title: 'Work',
+          timezone: 'Europe/Istanbul',
+          color: '#0ea5e9',
+          isPrimary: true
+        },
+        {
+          id: 'team@group.calendar.google.com',
+          title: 'Team',
+          timezone: 'Europe/Istanbul',
+          color: '#f97316',
+          isPrimary: false
+        }
+      ])
+      client.createCalendar.mockResolvedValue({
+        id: 'memry-managed',
+        title: 'memrynote',
+        timezone: 'UTC',
+        color: '#0f9d58',
+        isPrimary: false
+      })
+      client.listEvents.mockResolvedValue({ nextSyncCursor: 'cursor', events: [] })
+
+      await syncGoogleCalendarNow(db, { client: client as never })
+
+      const team = db
+        .select()
+        .from(calendarSources)
+        .where(eq(calendarSources.remoteId, 'team@group.calendar.google.com'))
+        .get()
+
+      expect(team).toBeDefined()
+      expect(team?.accountId).toBe('test-account@example.com')
+      // Discovered, not silently switched on — that stays the user's choice.
+      expect(team?.isSelected).toBe(false)
+    })
+
     it('skips all Google API calls when memrynote user is not signed in', async () => {
       vi.mocked(isMemryUserSignedIn).mockResolvedValue(false)
       const client = buildClient()

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -175,6 +175,54 @@ async function ensureMemryCalendarSource(
   return saved
 }
 
+/**
+ * Bring every calendar on `accountId` into `calendar_sources`, so the settings
+ * picker has something to offer beyond the primary.
+ *
+ * Selection stays the user's: a row we have never seen is pre-selected only if
+ * it is the account's primary, and a row that already exists keeps whatever the
+ * user chose along with its cursor and sync state. Re-running this is therefore
+ * safe — it refreshes titles and colours, it does not re-enable a calendar the
+ * user turned off.
+ */
+export async function discoverGoogleCalendarSources(
+  db: DataDb,
+  client: Pick<GoogleCalendarClient, 'listCalendars'>,
+  accountId: string
+): Promise<void> {
+  const discovered = await client.listCalendars()
+  const now = getNow()
+
+  for (const remote of discovered) {
+    const localId = `google-calendar:${remote.id}`
+    const existing = getCalendarSourceById(db, localId)
+
+    const saved = upsertCalendarSource(db, {
+      ...existing,
+      id: localId,
+      provider: 'google',
+      kind: 'calendar',
+      accountId,
+      remoteId: remote.id,
+      title: remote.title,
+      timezone: remote.timezone ?? LOCAL_TIMEZONE,
+      color: remote.color,
+      isPrimary: remote.isPrimary,
+      isSelected: existing ? existing.isSelected : remote.isPrimary,
+      isMemryManaged: existing?.isMemryManaged ?? false,
+      // Google still lists it, so it is not gone. A stale archivedAt here is
+      // the tombstone a previous disconnect left behind, and leaving it set
+      // would hide the calendar from the picker on reconnect.
+      archivedAt: null,
+      createdAt: existing?.createdAt ?? now,
+      modifiedAt: now
+    })
+
+    markSyncedTableMutation('calendar_source', saved.id, Boolean(existing))
+    emitCalendarChanged({ entityType: 'calendar_source', id: saved.id })
+  }
+}
+
 function getMemryManagedGoogleSource(
   db: DataDb,
   accountId?: string
@@ -793,6 +841,23 @@ export async function syncGoogleCalendarNow(
   try {
     const accountIds = listGoogleAccountIds(db)
     const defaultAccountId = resolveDefaultGoogleAccountId(db)
+
+    // Refresh the calendar list every pass. This is what fills the picker for
+    // installs that connected before multi-calendar support existed — they
+    // only ever got a source row for their primary — and it is how a calendar
+    // created in Google later shows up without a reconnect. Non-fatal: a
+    // failure must not stop the event sync below.
+    for (const accountId of accountIds) {
+      const client =
+        deps.client && accountId === defaultAccountId
+          ? deps.client
+          : createGoogleCalendarClient({ accountId })
+      try {
+        await discoverGoogleCalendarSources(db, client, accountId)
+      } catch (error) {
+        log.warn('Calendar discovery failed', { accountId, error })
+      }
+    }
 
     // One-way (inbound-only) mode: skip provisioning the managed "memrynote"
     // calendar — ensureMemryCalendarSource may call createCalendar, an outbound

--- a/apps/desktop/src/main/ipc/calendar-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/calendar-handlers.test.ts
@@ -19,6 +19,7 @@ const mockHasGoogleCalendarLocalAuth = vi.fn()
 const mockHasAnyGoogleCalendarLocalAuth = vi.fn()
 const mockListGoogleAccountIds = vi.fn(() => [] as string[])
 const mockResolveDefaultGoogleAccountId = vi.fn(() => null as string | null)
+const mockDiscoverGoogleCalendarSources = vi.fn()
 const mockSyncGoogleCalendarNow = vi.fn()
 const mockSyncGoogleCalendarSource = vi.fn()
 const mockSyncLocalSourceToGoogleCalendar = vi.fn(async () => null)
@@ -83,6 +84,7 @@ vi.mock('../calendar/google/oauth', () => ({
 }))
 
 vi.mock('../calendar/google/sync-service', () => ({
+  discoverGoogleCalendarSources: (...args: unknown[]) => mockDiscoverGoogleCalendarSources(...args),
   syncGoogleCalendarNow: (...args: unknown[]) => mockSyncGoogleCalendarNow(...args),
   syncGoogleCalendarSource: (...args: unknown[]) => mockSyncGoogleCalendarSource(...args),
   syncLocalSourceToGoogleCalendar: (...args: unknown[]) =>
@@ -651,6 +653,160 @@ describe('calendar-handlers', () => {
       isSelected: false,
       calendarId: 'remote-calendar-1'
     })
+  })
+
+  it('brings every calendar on the account into the picker when connecting', async () => {
+    registerCalendarHandlers()
+    mockConnectGoogleCalendar.mockResolvedValue({
+      accountId: 'work@example.com',
+      account: {
+        remoteId: 'work@example.com',
+        email: 'work@example.com',
+        title: 'Work Example',
+        timezone: 'Europe/Istanbul'
+      },
+      primaryCalendar: {
+        remoteId: 'work@example.com',
+        title: 'Work Example',
+        timezone: 'Europe/Istanbul',
+        color: '#0ea5e9',
+        isPrimary: true
+      }
+    })
+    mockHasAnyGoogleCalendarLocalAuth.mockResolvedValue(true)
+    mockListGoogleAccountIds.mockReturnValue(['work@example.com'])
+    // Stand-in for the real discovery pass, which has its own real-DB tests.
+    mockDiscoverGoogleCalendarSources.mockImplementation(async () => {
+      db.run(sql`
+        INSERT INTO calendar_sources (
+          id, provider, kind, account_id, remote_id, title, timezone,
+          is_selected, sync_status, created_at, modified_at
+        )
+        VALUES (
+          ${'google-calendar:team@group.calendar.google.com'}, ${'google'}, ${'calendar'},
+          ${'work@example.com'}, ${'team@group.calendar.google.com'}, ${'Team'},
+          ${'Europe/Istanbul'}, ${0}, ${'idle'},
+          ${'2026-04-12T08:01:00.000Z'}, ${'2026-04-12T08:01:00.000Z'}
+        )
+      `)
+    })
+
+    await invokeHandler(CalendarChannels.invoke.CONNECT_PROVIDER, { provider: 'google' })
+
+    expect(mockDiscoverGoogleCalendarSources).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'work@example.com'
+    )
+
+    const sources = await invokeHandler(CalendarChannels.invoke.LIST_SOURCES, {
+      provider: 'google',
+      kind: 'calendar'
+    })
+
+    // The account's other calendars have to reach the picker; otherwise there
+    // is nothing for the user to turn on and only the primary ever syncs.
+    expect(sources.sources.map((source: { remoteId: string }) => source.remoteId)).toEqual(
+      expect.arrayContaining(['work@example.com', 'team@group.calendar.google.com'])
+    )
+  })
+
+  it('deletes a de-selected calendar events and leaves the other calendars alone', async () => {
+    registerCalendarHandlers()
+
+    for (const [id, remoteId, title] of [
+      ['google-calendar-1', 'remote-calendar-1', 'Work'],
+      ['google-calendar-2', 'remote-calendar-2', 'Personal']
+    ]) {
+      db.run(sql`
+        INSERT INTO calendar_sources (
+          id, provider, kind, account_id, remote_id, title, timezone,
+          is_selected, sync_status, created_at, modified_at
+        )
+        VALUES (
+          ${id}, ${'google'}, ${'calendar'}, ${'google-account-1'}, ${remoteId}, ${title},
+          ${'Europe/Istanbul'}, ${1}, ${'ok'},
+          ${'2026-04-12T08:01:00.000Z'}, ${'2026-04-12T08:01:00.000Z'}
+        )
+      `)
+    }
+
+    for (const [id, sourceId, remoteEventId, title] of [
+      ['ext-1', 'google-calendar-1', 'remote-event-1', 'Standup'],
+      ['ext-2', 'google-calendar-1', 'remote-event-2', 'Retro'],
+      ['ext-3', 'google-calendar-2', 'remote-event-3', 'Dentist']
+    ]) {
+      db.run(sql`
+        INSERT INTO calendar_external_events (
+          id, source_id, remote_event_id, title, start_at, created_at, modified_at
+        )
+        VALUES (
+          ${id}, ${sourceId}, ${remoteEventId}, ${title}, ${'2026-04-12T09:00:00.000Z'},
+          ${'2026-04-12T08:01:00.000Z'}, ${'2026-04-12T08:01:00.000Z'}
+        )
+      `)
+    }
+
+    await invokeHandler(CalendarChannels.invoke.UPDATE_SOURCE_SELECTION, {
+      id: 'google-calendar-1',
+      isSelected: false
+    })
+
+    const remaining = db
+      .all<{ id: string }>(sql`SELECT id FROM calendar_external_events ORDER BY id`)
+      .map((row) => row.id)
+
+    // Turning a calendar off has to take its events with it — otherwise they
+    // linger on the calendar view with nothing left to refresh or remove them.
+    expect(remaining).toEqual(['ext-3'])
+    expect(enqueueLocalSyncDelete).toHaveBeenCalledWith(
+      'calendar_external_event',
+      'ext-1',
+      expect.any(String)
+    )
+    expect(enqueueLocalSyncDelete).toHaveBeenCalledWith(
+      'calendar_external_event',
+      'ext-2',
+      expect.any(String)
+    )
+  })
+
+  it('keeps a calendar events when it is turned back on', async () => {
+    registerCalendarHandlers()
+
+    db.run(sql`
+      INSERT INTO calendar_sources (
+        id, provider, kind, account_id, remote_id, title, timezone,
+        is_selected, sync_status, created_at, modified_at
+      )
+      VALUES (
+        ${'google-calendar-1'}, ${'google'}, ${'calendar'}, ${'google-account-1'},
+        ${'remote-calendar-1'}, ${'Work'}, ${'Europe/Istanbul'}, ${0}, ${'idle'},
+        ${'2026-04-12T08:01:00.000Z'}, ${'2026-04-12T08:01:00.000Z'}
+      )
+    `)
+    db.run(sql`
+      INSERT INTO calendar_external_events (
+        id, source_id, remote_event_id, title, start_at, created_at, modified_at
+      )
+      VALUES (
+        ${'ext-1'}, ${'google-calendar-1'}, ${'remote-event-1'}, ${'Standup'},
+        ${'2026-04-12T09:00:00.000Z'}, ${'2026-04-12T08:01:00.000Z'},
+        ${'2026-04-12T08:01:00.000Z'}
+      )
+    `)
+
+    await invokeHandler(CalendarChannels.invoke.UPDATE_SOURCE_SELECTION, {
+      id: 'google-calendar-1',
+      isSelected: true
+    })
+
+    const remaining = db
+      .all<{ id: string }>(sql`SELECT id FROM calendar_external_events`)
+      .map((row) => row.id)
+
+    expect(remaining).toEqual(['ext-1'])
+    expect(enqueueLocalSyncDelete).not.toHaveBeenCalled()
   })
 
   it('covers calendar handler error and provider edge paths', async () => {

--- a/apps/desktop/src/main/ipc/calendar-handlers.ts
+++ b/apps/desktop/src/main/ipc/calendar-handlers.ts
@@ -63,6 +63,7 @@ import { getCalendarRangeProjection } from '../calendar/projection'
 import { getCalendarEnabledPropertyNames } from '../calendar/calendar-property-visibility'
 import { getCalendarSettings } from './settings-handlers'
 import {
+  discoverGoogleCalendarSources,
   startGoogleCalendarSyncRunner,
   stopGoogleCalendarSyncRunner,
   syncGoogleCalendarNow,
@@ -249,6 +250,80 @@ function syncCalendarSourceUpsert(
   return mapCalendarSource(saved)
 }
 
+/**
+ * Drop the local mirror of one or more calendar sources: the external events
+ * pulled from them and the bindings tying Memry items to their remote events.
+ *
+ * Promoted events live in `calendar_events` and are the user's own copy, so
+ * they deliberately stay — only the mirror of the remote calendar goes. This
+ * runs both when a calendar is de-selected and when its account is
+ * disconnected; in both cases nothing is left to refresh those rows, so
+ * leaving them behind would strand them on the calendar view forever.
+ */
+function purgeCalendarSourceMirrors(
+  db: DataDb,
+  provider: string,
+  sources: (typeof calendarSources.$inferSelect)[]
+): void {
+  if (sources.length === 0) return
+
+  const sourceIds = sources.map((source) => source.id)
+  const remoteIds = sources.map((source) => source.remoteId)
+
+  const externalRows = db
+    .select()
+    .from(calendarExternalEvents)
+    .where(inArray(calendarExternalEvents.sourceId, sourceIds))
+    .all()
+
+  const bindingRows = db
+    .select()
+    .from(calendarBindings)
+    .where(
+      and(
+        eq(calendarBindings.provider, provider),
+        inArray(calendarBindings.remoteCalendarId, remoteIds)
+      )
+    )
+    .all()
+
+  if (externalRows.length === 0 && bindingRows.length === 0) return
+
+  db.transaction((tx) => {
+    if (externalRows.length > 0) {
+      tx.delete(calendarExternalEvents)
+        .where(
+          inArray(
+            calendarExternalEvents.id,
+            externalRows.map((row) => row.id)
+          )
+        )
+        .run()
+    }
+
+    if (bindingRows.length > 0) {
+      tx.delete(calendarBindings)
+        .where(
+          inArray(
+            calendarBindings.id,
+            bindingRows.map((row) => row.id)
+          )
+        )
+        .run()
+    }
+  })
+
+  for (const row of externalRows) {
+    syncCalendarExternalEventDelete(row.id, JSON.stringify(row))
+    emitCalendarChanged({ entityType: 'calendar_external_event', id: row.id })
+  }
+
+  for (const row of bindingRows) {
+    syncCalendarBindingDelete(row.id, JSON.stringify(row))
+    emitCalendarChanged({ entityType: 'calendar_binding', id: row.id })
+  }
+}
+
 async function disconnectGoogleAccount(
   db: DataDb,
   provider: string,
@@ -292,58 +367,15 @@ async function disconnectGoogleAccount(
     }
   }
 
-  const targetSourceIds = targetSources.map((source) => source.id)
-  const externalRows =
-    targetSourceIds.length > 0
-      ? db
-          .select()
-          .from(calendarExternalEvents)
-          .where(inArray(calendarExternalEvents.sourceId, targetSourceIds))
-          .all()
-      : []
-
-  const bindingRows =
-    targetSourceIds.length > 0
-      ? db
-          .select()
-          .from(calendarBindings)
-          .where(
-            and(
-              eq(calendarBindings.provider, provider),
-              inArray(
-                calendarBindings.remoteCalendarId,
-                targetSources.map((s) => s.remoteId)
-              )
-            )
-          )
-          .all()
-      : []
+  // Mirrors first, then the tombstones. If a crash lands between the two the
+  // sources stay unarchived with nothing under them, which the next disconnect
+  // or a rediscovery both resolve — the reverse order would strand events
+  // under a source no longer listed anywhere.
+  purgeCalendarSourceMirrors(db, provider, targetSources)
 
   const now = new Date().toISOString()
 
   db.transaction((tx) => {
-    if (externalRows.length > 0) {
-      tx.delete(calendarExternalEvents)
-        .where(
-          inArray(
-            calendarExternalEvents.id,
-            externalRows.map((row) => row.id)
-          )
-        )
-        .run()
-    }
-
-    if (bindingRows.length > 0) {
-      tx.delete(calendarBindings)
-        .where(
-          inArray(
-            calendarBindings.id,
-            bindingRows.map((row) => row.id)
-          )
-        )
-        .run()
-    }
-
     for (const source of targetSources) {
       if (source.archivedAt) continue
       tx.update(calendarSources)
@@ -352,16 +384,6 @@ async function disconnectGoogleAccount(
         .run()
     }
   })
-
-  for (const row of externalRows) {
-    syncCalendarExternalEventDelete(row.id, JSON.stringify(row))
-    emitCalendarChanged({ entityType: 'calendar_external_event', id: row.id })
-  }
-
-  for (const row of bindingRows) {
-    syncCalendarBindingDelete(row.id, JSON.stringify(row))
-    emitCalendarChanged({ entityType: 'calendar_binding', id: row.id })
-  }
 
   for (const source of targetSources) {
     if (source.archivedAt) continue
@@ -605,6 +627,13 @@ export function registerCalendarHandlers(): void {
           modifiedAt: new Date().toISOString()
         })
 
+        // Turning a calendar off takes its events with it. Nothing polls an
+        // unselected source, so anything left behind would sit on the calendar
+        // view with no way to refresh or remove it.
+        if (!input.isSelected) {
+          purgeCalendarSourceMirrors(db, existing.provider, [existing])
+        }
+
         if (
           updated.provider === 'google' &&
           updated.kind === 'calendar' &&
@@ -687,6 +716,23 @@ export function registerCalendarHandlers(): void {
           createdAt: now,
           modifiedAt: now
         })
+
+        // Pull in the rest of the account's calendars so the picker has more
+        // than the primary to offer. Non-fatal: a failure here leaves the user
+        // connected with the primary working, and the next sync retries it.
+        try {
+          await discoverGoogleCalendarSources(
+            db,
+            createGoogleCalendarClient({ accountId: connected.accountId }),
+            connected.accountId
+          )
+        } catch (error) {
+          log.warn('Calendar discovery failed after connect', {
+            accountId: connected.accountId,
+            error
+          })
+          trackMainError('calendar', 'source_discovery', error)
+        }
 
         void startGoogleCalendarSyncRunner().catch((error) => {
           // Only the inner sync self-logs; pre-sync awaits (keychain read, auth

--- a/apps/desktop/src/renderer/src/components/settings/google-calendar-integration-row.test.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/google-calendar-integration-row.test.tsx
@@ -228,6 +228,133 @@ describe('Google Calendar integration row', () => {
     mockRetryGoogleCalendarSourceSync.mockReset()
   })
 
+  function calendarSource(
+    overrides: Partial<CalendarSourceRecord> & Pick<CalendarSourceRecord, 'id' | 'accountId'>
+  ): CalendarSourceRecord {
+    return {
+      provider: 'google',
+      kind: 'calendar',
+      remoteId: overrides.id,
+      title: 'Calendar',
+      timezone: 'Europe/Istanbul',
+      color: '#0ea5e9',
+      isPrimary: false,
+      isSelected: false,
+      isMemryManaged: false,
+      syncCursor: null,
+      syncStatus: 'ok',
+      lastSyncedAt: null,
+      lastError: null,
+      metadata: null,
+      archivedAt: null,
+      syncedAt: null,
+      createdAt: '2026-04-12T08:00:00.000Z',
+      modifiedAt: '2026-04-12T08:00:00.000Z',
+      ...overrides
+    } as CalendarSourceRecord
+  }
+
+  const TWO_ACCOUNT_SOURCES: CalendarSourceRecord[] = [
+    calendarSource({
+      id: 'google-calendar:alice-work',
+      accountId: 'alice@example.com',
+      title: 'Alice Work',
+      isPrimary: true,
+      isSelected: true
+    }),
+    calendarSource({
+      id: 'google-calendar:alice-team',
+      accountId: 'alice@example.com',
+      title: 'Alice Team'
+    }),
+    calendarSource({
+      id: 'google-calendar:bob-work',
+      accountId: 'bob@example.com',
+      title: 'Bob Work',
+      isPrimary: true,
+      isSelected: true
+    })
+  ]
+
+  it('lists each account with only its own calendars underneath', async () => {
+    mockGetGoogleCalendarStatus.mockResolvedValue(TWO_ACCOUNT_STATUS)
+    mockListSources.mockResolvedValue({ sources: TWO_ACCOUNT_SOURCES })
+
+    renderIntegrationList()
+
+    const aliceGroup = await screen.findByTestId('calendar-account-group-alice@example.com')
+    const bobGroup = await screen.findByTestId('calendar-account-group-bob@example.com')
+
+    // A flat list gives no way to tell which account a calendar belongs to,
+    // and two accounts can both have a calendar called "Work".
+    expect(aliceGroup).toHaveTextContent('alice@example.com')
+    expect(aliceGroup).toHaveTextContent('Alice Work')
+    expect(aliceGroup).toHaveTextContent('Alice Team')
+    expect(aliceGroup).not.toHaveTextContent('Bob Work')
+    expect(bobGroup).toHaveTextContent('Bob Work')
+    expect(bobGroup).not.toHaveTextContent('Alice Work')
+  })
+
+  it('offers adding a second Google account while one is already connected', async () => {
+    const user = userEvent.setup()
+
+    mockGetGoogleCalendarStatus.mockResolvedValue(CONNECTED_STATUS)
+    mockListSources.mockResolvedValue({ sources: CONNECTED_SOURCES })
+    mockConnectGoogleCalendarProvider.mockResolvedValue({
+      success: true,
+      status: TWO_ACCOUNT_STATUS
+    })
+
+    renderIntegrationList()
+
+    const addAccount = await screen.findByTestId('calendar-add-account')
+    await user.click(addAccount)
+
+    expect(mockConnectGoogleCalendarProvider).toHaveBeenCalledTimes(1)
+  })
+
+  it('disconnects one account without touching the other', async () => {
+    const user = userEvent.setup()
+
+    mockGetGoogleCalendarStatus.mockResolvedValue(TWO_ACCOUNT_STATUS)
+    mockListSources.mockResolvedValue({ sources: TWO_ACCOUNT_SOURCES })
+    mockDisconnectGoogleCalendarProvider.mockResolvedValue({
+      success: true,
+      status: CONNECTED_STATUS
+    })
+
+    renderIntegrationList()
+
+    const disconnectBob = await screen.findByTestId('calendar-account-disconnect-bob@example.com')
+    await user.click(disconnectBob)
+
+    // Without the account id the handler falls through to its disconnect-all
+    // branch and takes the other account down too.
+    expect(mockDisconnectGoogleCalendarProvider).toHaveBeenCalledWith('bob@example.com')
+  })
+
+  it('still offers a disconnect when the install reports no per-account rows', async () => {
+    const user = userEvent.setup()
+
+    // Legacy installs can be connected while every account source predates the
+    // account_id column, so status.accounts comes back empty. Per-account
+    // disconnect lives inside the groups, so with no groups the user would be
+    // connected with no way out.
+    mockGetGoogleCalendarStatus.mockResolvedValue({ ...CONNECTED_STATUS, accounts: [] })
+    mockListSources.mockResolvedValue({ sources: CONNECTED_SOURCES })
+    mockDisconnectGoogleCalendarProvider.mockResolvedValue({
+      success: true,
+      status: DISCONNECTED_STATUS
+    })
+
+    renderIntegrationList()
+
+    const disconnect = await screen.findByTestId('calendar-disconnect-all')
+    await user.click(disconnect)
+
+    expect(mockDisconnectGoogleCalendarProvider).toHaveBeenCalledWith(undefined)
+  })
+
   it('starts the Google Calendar connect flow from Settings', async () => {
     const user = userEvent.setup()
 

--- a/apps/desktop/src/renderer/src/components/settings/google-calendar-integration-row.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/google-calendar-integration-row.tsx
@@ -14,6 +14,7 @@ import {
   retryGoogleCalendarSourceSync,
   updateGoogleCalendarSourceSelection
 } from '@/services/calendar-service'
+import type { CalendarProviderStatus } from '@/services/calendar-service'
 import { GoogleCalendarSourcePicker } from './google-calendar-source-picker'
 import { GoogleCalendarOnboardingDialog } from '@/components/calendar/google-calendar-onboarding-dialog'
 import { googleCalendarsQueryKey } from '@/hooks/use-google-calendars'
@@ -29,6 +30,27 @@ async function invalidateGoogleCalendarQueries(queryClient: ReturnType<typeof us
     queryClient.invalidateQueries({ queryKey: GOOGLE_SOURCES_QUERY_KEY }),
     queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
   ])
+}
+
+type GoogleAccountStatus = NonNullable<CalendarProviderStatus['accounts']>[number]
+
+function accountDetail(account: GoogleAccountStatus, reconnectLabel: string): string | null {
+  if (account.status === 'reconnect_required') return reconnectLabel
+  if (account.status === 'error') return account.lastError?.slice(0, 60) ?? null
+  return null
+}
+
+function accountToneClass(status: GoogleAccountStatus['status']): string {
+  switch (status) {
+    case 'connected':
+      return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+    case 'reconnect_required':
+      return 'border-amber-500/40 bg-amber-500/10 text-amber-800 dark:text-amber-300'
+    case 'error':
+      return 'border-destructive/50 bg-destructive/10 text-destructive'
+    default:
+      return 'border-muted-foreground/30 bg-muted text-muted-foreground'
+  }
 }
 
 export function GoogleCalendarIntegrationRow(): React.JSX.Element {
@@ -88,8 +110,8 @@ export function GoogleCalendarIntegrationRow(): React.JSX.Element {
   })
 
   const disconnectMutation = useMutation({
-    mutationFn: async () => {
-      const result = await disconnectGoogleCalendarProvider()
+    mutationFn: async (accountId?: string) => {
+      const result = await disconnectGoogleCalendarProvider(accountId)
       if (!result.success) {
         throw new Error(result.error ?? t('integrations.googleCalendar.disconnectFailed'))
       }
@@ -173,6 +195,25 @@ export function GoogleCalendarIntegrationRow(): React.JSX.Element {
     () => (sourcesData?.sources ?? []).filter((source) => !source.isMemryManaged),
     [sourcesData?.sources]
   )
+
+  // One group per connected account, plus a trailing group for calendars whose
+  // accountId matches no account we know about. Those exist on installs that
+  // connected before sources carried an account id — dropping them here would
+  // make a working calendar silently disappear from Settings.
+  const accountGroups = useMemo(() => {
+    const accounts = statusData?.accounts ?? []
+    const claimed = new Set<string>()
+    const groups = accounts.map((account) => {
+      const calendars = importedSources.filter((source) => {
+        if (source.accountId !== account.accountId) return false
+        claimed.add(source.id)
+        return true
+      })
+      return { account, calendars }
+    })
+    const unclaimed = importedSources.filter((source) => !claimed.has(source.id))
+    return { groups, unclaimed }
+  }, [statusData?.accounts, importedSources])
   const status = statusData
   const pushEventsToGoogle = googleSettingsData?.pushEventsToGoogle ?? true
   // Only an explicit grant counts. Unanswered (null) and revoked both read as off.
@@ -225,43 +266,6 @@ export function GoogleCalendarIntegrationRow(): React.JSX.Element {
               {t('integrations.googleCalendar.description')}
             </p>
 
-            {status?.accounts && status.accounts.length > 0 && (
-              <div className="flex flex-wrap gap-1.5">
-                {status.accounts.map((account) => {
-                  const tone =
-                    account.status === 'connected'
-                      ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
-                      : account.status === 'reconnect_required'
-                        ? 'border-amber-500/40 bg-amber-500/10 text-amber-800 dark:text-amber-300'
-                        : account.status === 'error'
-                          ? 'border-destructive/50 bg-destructive/10 text-destructive'
-                          : 'border-muted-foreground/30 bg-muted text-muted-foreground'
-                  const detail =
-                    account.status === 'reconnect_required'
-                      ? t('integrations.googleCalendar.accountReconnect')
-                      : account.status === 'error'
-                        ? account.lastError?.slice(0, 60)
-                        : null
-                  return (
-                    <span
-                      key={account.accountId}
-                      data-testid={`calendar-account-chip-${account.accountId}`}
-                      data-account-status={account.status}
-                      className={`inline-flex max-w-full items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px]/4 ${tone}`}
-                      title={account.lastError ?? undefined}
-                    >
-                      <span className="truncate">{account.email}</span>
-                      {detail && (
-                        <span className="max-w-[12rem] truncate text-[10px]/3 opacity-75">
-                          · {detail}
-                        </span>
-                      )}
-                    </span>
-                  )
-                })}
-              </div>
-            )}
-
             {mutationError && (
               <p className="text-xs text-destructive">
                 {extractErrorMessage(mutationError, t('integrations.googleCalendar.syncFailed'))}
@@ -298,11 +302,27 @@ export function GoogleCalendarIntegrationRow(): React.JSX.Element {
                 variant="outline"
                 size="sm"
                 className="h-7 px-3 text-xs/4"
+                data-testid="calendar-add-account"
                 disabled={isPending}
-                onClick={() => disconnectMutation.mutate()}
+                onClick={() => connectMutation.mutate()}
               >
-                {t('integrations.googleCalendar.disconnect')}
+                {t('integrations.googleCalendar.addAccount')}
               </Button>
+              {/* Per-account disconnect lives in each group below. This is the
+                  way out for an install that reports no account rows at all —
+                  without it such a user would be connected with no way to undo it. */}
+              {accountGroups.groups.length === 0 && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 px-3 text-xs/4"
+                  data-testid="calendar-disconnect-all"
+                  disabled={isPending}
+                  onClick={() => disconnectMutation.mutate(undefined)}
+                >
+                  {t('integrations.googleCalendar.disconnect')}
+                </Button>
+              )}
             </>
           ) : (
             <Button
@@ -329,15 +349,64 @@ export function GoogleCalendarIntegrationRow(): React.JSX.Element {
             </span>
           </div>
 
-          <GoogleCalendarSourcePicker
-            sources={importedSources}
-            isUpdating={isPending}
-            onToggleSource={(sourceId, isSelected) =>
-              sourceMutation.mutate({ sourceId, isSelected })
-            }
-            onRetrySource={(sourceId) => retryMutation.mutate(sourceId)}
-            retryingSourceId={retryMutation.isPending ? (retryMutation.variables ?? null) : null}
-          />
+          {accountGroups.groups.map(({ account, calendars }) => (
+            <div
+              key={account.accountId}
+              data-testid={`calendar-account-group-${account.accountId}`}
+              className="grid gap-2 rounded-md border border-border/70 px-3 py-2.5"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span
+                  data-testid={`calendar-account-chip-${account.accountId}`}
+                  data-account-status={account.status}
+                  className={`inline-flex min-w-0 items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px]/4 ${accountToneClass(account.status)}`}
+                  title={account.lastError ?? undefined}
+                >
+                  <span className="truncate">{account.email}</span>
+                  {accountDetail(account, t('integrations.googleCalendar.accountReconnect')) && (
+                    <span className="max-w-[12rem] truncate text-[10px]/3 opacity-75">
+                      · {accountDetail(account, t('integrations.googleCalendar.accountReconnect'))}
+                    </span>
+                  )}
+                </span>
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 shrink-0 px-2 text-[11px]/4"
+                  data-testid={`calendar-account-disconnect-${account.accountId}`}
+                  disabled={isPending}
+                  onClick={() => disconnectMutation.mutate(account.accountId)}
+                >
+                  {t('integrations.googleCalendar.disconnect')}
+                </Button>
+              </div>
+
+              <GoogleCalendarSourcePicker
+                sources={calendars}
+                isUpdating={isPending}
+                onToggleSource={(sourceId, isSelected) =>
+                  sourceMutation.mutate({ sourceId, isSelected })
+                }
+                onRetrySource={(sourceId) => retryMutation.mutate(sourceId)}
+                retryingSourceId={
+                  retryMutation.isPending ? (retryMutation.variables ?? null) : null
+                }
+              />
+            </div>
+          ))}
+
+          {accountGroups.unclaimed.length > 0 && (
+            <GoogleCalendarSourcePicker
+              sources={accountGroups.unclaimed}
+              isUpdating={isPending}
+              onToggleSource={(sourceId, isSelected) =>
+                sourceMutation.mutate({ sourceId, isSelected })
+              }
+              onRetrySource={(sourceId) => retryMutation.mutate(sourceId)}
+              retryingSourceId={retryMutation.isPending ? (retryMutation.variables ?? null) : null}
+            />
+          )}
 
           <div className="mt-1 flex items-start justify-between gap-3 border-t border-border/60 pt-3">
             <div className="flex min-w-0 flex-col gap-0.5">

--- a/apps/desktop/src/renderer/src/services/calendar-service.ts
+++ b/apps/desktop/src/renderer/src/services/calendar-service.ts
@@ -79,8 +79,17 @@ export function connectGoogleCalendarProvider(): Promise<CalendarProviderMutatio
   return calendarService.connectProvider({ provider: 'google' })
 }
 
-export function disconnectGoogleCalendarProvider(): Promise<CalendarProviderMutationResponse> {
-  return calendarService.disconnectProvider({ provider: 'google' })
+/**
+ * Omitting `accountId` disconnects every linked Google account — that is the
+ * main-process fallback branch. Pass one to unlink a single account.
+ */
+export function disconnectGoogleCalendarProvider(
+  accountId?: string
+): Promise<CalendarProviderMutationResponse> {
+  return calendarService.disconnectProvider({
+    provider: 'google',
+    ...(accountId ? { accountId } : {})
+  })
 }
 
 export function refreshGoogleCalendarProvider(): Promise<CalendarProviderMutationResponse> {

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -140,6 +140,18 @@ External events are **read-mostly**: titles and times sync in. Inline edits prop
 
 While no Google account is linked, the calendar toolbar shows a **Connect Google** button. It opens a short prompt covering what a linked calendar unlocks — seeing your Google events beside notes and tasks, two-way sync, and scheduling tasks and notes on your calendar — then runs the same connect flow as Settings. The button disappears once an account is connected.
 
+### Multiple Accounts and Calendars
+
+You can link more than one Google account. In [Settings → Integrations](/user-guide/settings#integrations) → Google Calendar, **Add account** starts the connect flow again and Google shows its account chooser, so you can pick a different account than the one your browser is already signed in to.
+
+Each linked account gets its own group listing every calendar on that account — shared calendars, team calendars, holiday calendars, all of them — with a checkbox each. Tick a calendar to bring its events into memrynote; untick it to take them out. Only your primary calendar is ticked when an account is first linked, so nothing else arrives until you ask for it.
+
+**Unticking a calendar deletes its events from memrynote.** Nothing refreshes a calendar you have turned off, so its events are removed rather than left behind to go stale, and the removal reaches your other devices. Tick it again and the events are fetched fresh. Events you [promoted to your vault](#promote-external-events) are your own copy and are not affected.
+
+The calendar list refreshes on every sync, so a calendar you create in Google later shows up on its own. If you linked an account before this existed, your other calendars appear after the next sync — no need to reconnect.
+
+Each account has its own **Disconnect**, which unlinks only that account and removes only its events.
+
 ### Sync Direction
 
 By default Google Calendar sync is **two-way**: events, tasks, reminders, and snoozes you create in memrynote are pushed up to Google, and changes made in Google flow back into memrynote.

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -328,6 +328,8 @@ as collapsed tool rows, or they can require inline approval when **Tool Confirma
 
 Link a Google account to show external events alongside vault events on the [Calendar](/user-guide/calendar). Status and source pickers appear here.
 
+**Add account** links a second (or third) Google account. Each account is listed with its own calendars and its own Disconnect. Tick the calendars you want in memrynote — unticking one [removes its events](/user-guide/calendar#multiple-accounts-and-calendars).
+
 **Show memrynote events in Google Calendar** controls sync direction. Leave it on for two-way sync, or turn it off for [one-way (inbound only)](/user-guide/calendar#sync-direction) — Google events still appear in memrynote, but memrynote events are not pushed to Google.
 
 ---

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -1083,6 +1083,7 @@
         "reconnectRequired": "Reconnect Required"
       },
       "accountReconnect": "Reconnect Google",
+      "addAccount": "Add account",
       "importedCalendars": "Imported Calendars",
       "selected": "{count} selected",
       "syncNow": "Sync Now",


### PR DESCRIPTION
## What

- OAuth asks for `select_account consent`, so a second Google account can actually be linked.
- New `discoverGoogleCalendarSources` brings every calendar on an account into `calendar_sources` — on connect and on each sync pass, so existing installs fill their picker without reconnecting.
- De-selecting a calendar drops its external events and bindings; disconnect now shares the same `purgeCalendarSourceMirrors`.
- Settings lists one group per account, each with its own calendars and Disconnect, plus Add account.

## Why

Connect only ever provisioned the account's primary calendar, and `prompt=consent` reuses whichever account the browser is signed in to — so a user could add neither a second account nor a second calendar. Closes #1161.

No schema or contract change: `calendar_sources` already carried `kind`/`accountId`/`isSelected`, the sync loop already iterated accounts, and `DISCONNECT_PROVIDER` already took an optional `accountId`.