### PR TITLE
fix(sync): report oversized sync payloads as note-too-large, not storage-full

### DIFF
--- a/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
@@ -421,7 +421,31 @@ describe('PushCoordinator', () => {
   })
 
   describe('#given the account is out of storage #when push runs', () => {
-    it('#then an HTTP 413 surfaces as storage_quota_exceeded without discarding the item', async () => {
+    it('#then an HTTP 413 with the quota code surfaces as storage_quota_exceeded without discarding the item', async () => {
+      const { coordinator, queue, ctx, stateManager } = createHarness(getDb())
+      postToServerMock.mockRejectedValue(
+        new SyncServerError(
+          'Storage quota exceeded',
+          413,
+          '{"error":{"code":"STORAGE_QUOTA_EXCEEDED","message":"Storage quota exceeded"}}'
+        )
+      )
+
+      const payload = JSON.stringify({ title: 'Too big' })
+      queue.enqueue({ type: 'note', itemId: 'note-1', operation: 'update', payload })
+
+      await coordinator.push()
+
+      expect(ctx.lastErrorInfo?.category).toBe('storage_quota_exceeded')
+      expect(stateManager.setState).toHaveBeenCalledWith('error')
+      expect(queue.getSize()).toBe(1)
+      expect(queue.peek()[0].payload).toBe(payload)
+    })
+
+    it('#then a bare HTTP 413 surfaces as note_too_large, not storage_quota_exceeded', async () => {
+      // A 413 without the quota code comes from a body-size layer (the server's
+      // body-limit middleware, an edge proxy) — telling the user their storage
+      // is full would send them to free up space, which never fixes it.
       const { coordinator, queue, ctx, stateManager } = createHarness(getDb())
       postToServerMock.mockRejectedValue(new SyncServerError('Payload too large', 413))
 
@@ -430,7 +454,7 @@ describe('PushCoordinator', () => {
 
       await coordinator.push()
 
-      expect(ctx.lastErrorInfo?.category).toBe('storage_quota_exceeded')
+      expect(ctx.lastErrorInfo?.category).toBe('note_too_large')
       expect(stateManager.setState).toHaveBeenCalledWith('error')
       expect(queue.getSize()).toBe(1)
       expect(queue.peek()[0].payload).toBe(payload)

--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -336,11 +336,22 @@ vi.mock('./crdt-encrypt', () => ({
 vi.mock('./http-client', () => ({
   postToServer: runtimeMocks.postToServer,
   pushCrdtSnapshot: runtimeMocks.pushCrdtSnapshot,
-  SyncServerError: runtimeMocks.SyncServerError
+  SyncServerError: runtimeMocks.SyncServerError,
+  // runtime.ts → sync-errors.ts imports these; they only need to exist here.
+  NetworkError: class NetworkError extends Error {},
+  RateLimitError: class RateLimitError extends Error {},
+  AttachmentTooLargeError: class AttachmentTooLargeError extends Error {}
 }))
 
 vi.mock('./retry', () => ({
-  withRetry: runtimeMocks.withRetry
+  withRetry: runtimeMocks.withRetry,
+  // runtime.ts → sync-errors.ts imports this; the class itself is exercised in
+  // sync-errors.test.ts, here it only needs to exist.
+  DeadLetterError: class DeadLetterError extends Error {
+    constructor(public lastError: unknown) {
+      super('dead letter')
+    }
+  }
 }))
 
 vi.mock('./token-manager', () => ({
@@ -616,6 +627,9 @@ describe('sync runtime', () => {
     expect(queue.pause).toHaveBeenCalled()
     expect(runtimeMocks.emitSessionExpired).not.toHaveBeenCalled()
 
+    // Bare 413 = body-limit rejection (oversized note), NOT quota: report
+    // note_too_large and keep the queue running for every other note.
+    const pauseCallsBeforeBodyLimit = queue.pause.mock.calls.length
     runtimeMocks.postToServer.mockRejectedValueOnce(new runtimeMocks.SyncServerError(413))
     await expect(queue.onBatch?.('note-1', [new Uint8Array([1])])).rejects.toThrow(
       'sync server error'
@@ -624,9 +638,27 @@ describe('sync runtime', () => {
       'sync:status-changed',
       expect.objectContaining({
         status: 'error',
+        errorCategory: 'note_too_large'
+      })
+    )
+    expect(queue.pause.mock.calls.length).toBe(pauseCallsBeforeBodyLimit)
+
+    // 413 carrying the server's quota code is the real storage-full case:
+    // everything will fail, so pausing the queue is correct.
+    runtimeMocks.postToServer.mockRejectedValueOnce(
+      new runtimeMocks.SyncServerError(413, 'STORAGE_QUOTA_EXCEEDED: Storage quota exceeded')
+    )
+    await expect(queue.onBatch?.('note-1', [new Uint8Array([1])])).rejects.toThrow(
+      'STORAGE_QUOTA_EXCEEDED'
+    )
+    expect(runtimeMocks.browserSend).toHaveBeenCalledWith(
+      'sync:status-changed',
+      expect.objectContaining({
+        status: 'error',
         errorCategory: 'storage_quota_exceeded'
       })
     )
+    expect(queue.pause.mock.calls.length).toBe(pauseCallsBeforeBodyLimit + 1)
 
     await runtime.stopSyncRuntime({ skipFinalSync: true })
     expect(runtimeMocks.crdtProvider.pushAllSnapshots).not.toHaveBeenCalled()
@@ -671,14 +703,30 @@ describe('sync runtime', () => {
     expect(runtimeMocks.refreshAccessToken).toHaveBeenCalled()
     expect(runtimeMocks.emitSessionExpired).not.toHaveBeenCalled()
 
+    // Bare 413 on snapshot push = the note's snapshot is over the body limit:
+    // note_too_large, no queue pause (other notes must keep syncing).
+    const pauseCallsBeforeSnapshot = queue.pause.mock.calls.length
     runtimeMocks.pushCrdtSnapshot.mockRejectedValueOnce(new runtimeMocks.SyncServerError(413))
-    await expect(snapshotPush('note-quota', new Uint8Array([1]))).rejects.toThrow(
+    await expect(snapshotPush('note-oversized', new Uint8Array([1]))).rejects.toThrow(
       'sync server error'
+    )
+    expect(runtimeMocks.browserSend).toHaveBeenCalledWith(
+      'sync:status-changed',
+      expect.objectContaining({ errorCategory: 'note_too_large' })
+    )
+    expect(queue.pause.mock.calls.length).toBe(pauseCallsBeforeSnapshot)
+
+    runtimeMocks.pushCrdtSnapshot.mockRejectedValueOnce(
+      new runtimeMocks.SyncServerError(413, 'STORAGE_QUOTA_EXCEEDED: Storage quota exceeded')
+    )
+    await expect(snapshotPush('note-quota', new Uint8Array([1]))).rejects.toThrow(
+      'STORAGE_QUOTA_EXCEEDED'
     )
     expect(runtimeMocks.browserSend).toHaveBeenCalledWith(
       'sync:status-changed',
       expect.objectContaining({ errorCategory: 'storage_quota_exceeded' })
     )
+    expect(queue.pause.mock.calls.length).toBe(pauseCallsBeforeSnapshot + 1)
   })
 
   it('exposes engine dependency branches for signing keys, device keys, and calendar sync', async () => {

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -58,6 +58,7 @@ import { CrdtUpdateQueue } from './crdt-queue'
 import { recoverDirtyItems } from './dirty-recovery'
 import { encryptCrdtUpdate } from './crdt-encrypt'
 import { postToServer, pushCrdtSnapshot, SyncServerError } from './http-client'
+import { classifyError } from './sync-errors'
 import {
   EVENT_CHANNELS,
   type SyncStatusChangedEvent,
@@ -115,6 +116,15 @@ function emitQuotaExceeded(): void {
     pendingCount: 0,
     error: 'Storage quota exceeded',
     errorCategory: 'storage_quota_exceeded'
+  })
+}
+
+function emitNoteTooLarge(): void {
+  emitSyncStatus({
+    status: 'error',
+    pendingCount: 0,
+    error: 'A note is too large to sync',
+    errorCategory: 'note_too_large'
   })
 }
 
@@ -531,8 +541,14 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
             crdtQueue.pause()
           }
           if (err instanceof SyncServerError && err.statusCode === 413) {
-            crdtQueue.pause()
-            emitQuotaExceeded()
+            if (classifyError(err).category === 'storage_quota_exceeded') {
+              crdtQueue.pause()
+              emitQuotaExceeded()
+            } else {
+              // Body-limit 413: one oversized note must not stall the queue
+              // for every other note.
+              emitNoteTooLarge()
+            }
           }
           throw err
         } finally {
@@ -583,8 +599,14 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
             crdtQueue.pause()
           }
           if (err instanceof SyncServerError && err.statusCode === 413) {
-            crdtQueue.pause()
-            emitQuotaExceeded()
+            if (classifyError(err).category === 'storage_quota_exceeded') {
+              crdtQueue.pause()
+              emitQuotaExceeded()
+            } else {
+              // Body-limit 413: one oversized note must not stall the queue
+              // for every other note.
+              emitNoteTooLarge()
+            }
           }
           throw err
         } finally {

--- a/apps/desktop/src/main/sync/sync-errors.test.ts
+++ b/apps/desktop/src/main/sync/sync-errors.test.ts
@@ -22,11 +22,25 @@ describe('classifyError', () => {
     expect(result.retryable).toBe(false)
   })
 
-  it('#given SyncServerError 413 without a file-too-large code #then storage_quota_exceeded', () => {
-    const err = new SyncServerError('Storage quota exceeded', 413)
+  it('#given SyncServerError 413 with VALIDATION_BODY_TOO_LARGE #then note_too_large', () => {
+    // The server's body-limit middleware 413s oversized CRDT payloads. Calling
+    // that "storage full" sends the user to free up space, which never fixes it.
+    const body = '{"error":{"code":"VALIDATION_BODY_TOO_LARGE","message":"Request body too large"}}'
+    const err = new SyncServerError(`Failed to push snapshot: ${body}`, 413, body)
     const result = classifyError(err)
 
-    expect(result.category).toBe('storage_quota_exceeded')
+    expect(result.category).toBe('note_too_large')
+    expect(result.retryable).toBe(false)
+  })
+
+  it('#given SyncServerError 413 with no error code #then note_too_large, not retryable', () => {
+    // Real quota responses always carry STORAGE_QUOTA_EXCEEDED in the body. A
+    // bare 413 comes from a body-size layer (middleware, edge proxy), so it is
+    // a payload-size problem, not an account-storage problem.
+    const err = new SyncServerError('Request Entity Too Large', 413)
+    const result = classifyError(err)
+
+    expect(result.category).toBe('note_too_large')
     expect(result.retryable).toBe(false)
   })
 
@@ -79,8 +93,9 @@ describe('classifyError', () => {
     expect(result.retryable).toBe(true)
   })
 
-  it('#given SyncServerError 413 #then storage_quota_exceeded, not retryable', () => {
-    const err = new SyncServerError('Storage quota exceeded', 413)
+  it('#given SyncServerError 413 with STORAGE_QUOTA_EXCEEDED #then storage_quota_exceeded', () => {
+    const body = '{"error":{"code":"STORAGE_QUOTA_EXCEEDED","message":"Storage quota exceeded"}}'
+    const err = new SyncServerError('Storage quota exceeded', 413, body)
     const result = classifyError(err)
 
     expect(result.category).toBe('storage_quota_exceeded')

--- a/apps/desktop/src/main/sync/sync-errors.ts
+++ b/apps/desktop/src/main/sync/sync-errors.ts
@@ -70,10 +70,13 @@ export function classifyError(error: unknown): SyncErrorInfo {
       }
     }
     if (error.statusCode === 413) {
-      // 413 covers two different problems. STORAGE_FILE_TOO_LARGE means this one
-      // file is over the plan's per-file limit; a bare 413 means the account is
-      // out of storage. Reporting "Storage quota exceeded" for the former sends
-      // the user to free up space, which never fixes it.
+      // 413 covers three different problems. STORAGE_FILE_TOO_LARGE means this
+      // one file is over the plan's per-file limit; STORAGE_QUOTA_EXCEEDED
+      // means the account is out of storage; anything else (the body-limit
+      // middleware's VALIDATION_BODY_TOO_LARGE, or a bare edge-proxy 413) means
+      // a single payload is too big. Real quota responses always carry their
+      // code, so only they may report "storage full" — anything else would send
+      // the user to free up space, which never fixes a payload problem.
       if (
         error.serverError?.includes('STORAGE_FILE_TOO_LARGE') ||
         error.message.includes('STORAGE_FILE_TOO_LARGE')
@@ -84,9 +87,19 @@ export function classifyError(error: unknown): SyncErrorInfo {
           retryable: false
         }
       }
+      if (
+        error.serverError?.includes('STORAGE_QUOTA_EXCEEDED') ||
+        error.message.includes('STORAGE_QUOTA_EXCEEDED')
+      ) {
+        return {
+          category: 'storage_quota_exceeded',
+          message: 'Storage quota exceeded',
+          retryable: false
+        }
+      }
       return {
-        category: 'storage_quota_exceeded',
-        message: 'Storage quota exceeded',
+        category: 'note_too_large',
+        message: 'A note is too large to sync',
         retryable: false
       }
     }

--- a/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
@@ -450,6 +450,24 @@ describe('SyncProvider', () => {
       )
     })
 
+    it('#then shows the note-too-large toast for note_too_large status errors', async () => {
+      // A 413 from the body-limit middleware is a payload problem, not a quota
+      // problem. Telling the user to free up space would never fix it.
+      renderHook(() => useSync(), { wrapper })
+      await vi.waitFor(() => expect(syncStatusListeners.length).toBeGreaterThan(0))
+
+      act(() => {
+        for (const cb of syncStatusListeners) {
+          cb({ status: 'error', pendingCount: 0, errorCategory: 'note_too_large' })
+        }
+      })
+
+      expect(toastMock.error).toHaveBeenCalledWith(
+        'A note is too large to sync. Splitting it into smaller notes will fix this.',
+        { duration: 10000 }
+      )
+    })
+
     it('#then translates session and device revoked state errors', async () => {
       const { result } = renderHook(() => useSync(), { wrapper })
       await vi.waitFor(() => expect(sessionExpiredListeners.length).toBeGreaterThan(0))

--- a/apps/desktop/src/renderer/src/contexts/sync-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.tsx
@@ -273,6 +273,9 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
         if (event.errorCategory === 'file_too_large') {
           toast.error(t('sync.fileTooLarge'), { duration: 10000 })
         }
+        if (event.errorCategory === 'note_too_large') {
+          toast.error(t('sync.noteTooLarge'), { duration: 10000 })
+        }
       })
     )
 

--- a/apps/desktop/src/renderer/src/lib/error-messages.test.ts
+++ b/apps/desktop/src/renderer/src/lib/error-messages.test.ts
@@ -82,6 +82,7 @@ describe('getSyncErrorMessage', () => {
     expect(getSyncErrorMessage('crypto_failure')).toBeTruthy()
     expect(getSyncErrorMessage('version_incompatible')).toBeTruthy()
     expect(getSyncErrorMessage('storage_quota_exceeded')).toBeTruthy()
+    expect(getSyncErrorMessage('note_too_large')).toBeTruthy()
     expect(getSyncErrorMessage('sync_payment_required')).toBeTruthy()
     expect(getSyncErrorMessage('certificate_pin_failed')).toBeTruthy()
     expect(getSyncErrorMessage('unknown')).toBeTruthy()

--- a/apps/desktop/src/renderer/src/lib/error-messages.ts
+++ b/apps/desktop/src/renderer/src/lib/error-messages.ts
@@ -95,6 +95,7 @@ const SYNC_ERROR_KEYS: Record<SyncErrorCategory, string> = {
   version_incompatible: 'sync.versionIncompatible',
   storage_quota_exceeded: 'sync.storageQuotaExceeded',
   file_too_large: 'sync.fileTooLarge',
+  note_too_large: 'sync.noteTooLarge',
   sync_payment_required: 'sync.paymentRequired',
   certificate_pin_failed: 'sync.certificatePinFailed',
   unknown: 'sync.unknown'

--- a/apps/docs/src/user-guide/sync/conflict-health.md
+++ b/apps/docs/src/user-guide/sync/conflict-health.md
@@ -63,15 +63,16 @@ This is the actionable punch list — fix everything here and sync should be cle
 
 ## Common Sync Errors
 
-| Error                            | Likely cause                                          | Fix                                                                                                             |
-| -------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| "Authentication expired"         | Refresh token expired                                 | Sign in again                                                                                                   |
-| "Quota exceeded"                 | Vault size hit storage limit                          | Upgrade plan or clean attachments                                                                               |
-| "Network unreachable"            | Offline                                               | Reconnect; sync auto-resumes                                                                                    |
-| "Server temporarily unavailable" | Cloudflare hiccup                                     | Wait; backoff retries automatically                                                                             |
-| "Blob hash mismatch"             | Corruption (rare)                                     | Push the affected item again from the source device                                                             |
-| "Crypto version mismatch"        | Sync server behind a desktop release                  | Wait for server to update or downgrade desktop                                                                  |
-| "All items failed to decrypt"    | This device's vault key no longer matches the account | The app signs you out and prompts recovery — sign in and enter your recovery phrase; your server data is intact |
+| Error                            | Likely cause                                                                                             | Fix                                                                                                             |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| "Authentication expired"         | Refresh token expired                                                                                    | Sign in again                                                                                                   |
+| "Quota exceeded"                 | Vault size hit storage limit                                                                             | Upgrade plan or clean attachments                                                                               |
+| "A note is too large to sync"    | One note's encrypted sync payload is over the per-request limit — a payload problem, not account storage | Split the note into smaller notes, or move large pasted content into attachments; other notes keep syncing      |
+| "Network unreachable"            | Offline                                                                                                  | Reconnect; sync auto-resumes                                                                                    |
+| "Server temporarily unavailable" | Cloudflare hiccup                                                                                        | Wait; backoff retries automatically                                                                             |
+| "Blob hash mismatch"             | Corruption (rare)                                                                                        | Push the affected item again from the source device                                                             |
+| "Crypto version mismatch"        | Sync server behind a desktop release                                                                     | Wait for server to update or downgrade desktop                                                                  |
+| "All items failed to decrypt"    | This device's vault key no longer matches the account                                                    | The app signs you out and prompts recovery — sign in and enter your recovery phrase; your server data is intact |
 
 ## Resolving a Conflict Manually
 

--- a/apps/sync-server/src/index.test.ts
+++ b/apps/sync-server/src/index.test.ts
@@ -189,6 +189,42 @@ describe('sync-server app entry point', () => {
       }
     })
   })
+
+  it('lets multi-MB sync bodies through so route-level 5MB payload checks are reachable', async () => {
+    const request = new Request('http://localhost/sync/crdt/snapshot', {
+      method: 'POST',
+      body: new Uint8Array(2 * ONE_MB)
+    })
+
+    const response = await app.request(request, {}, createEnv())
+
+    expect(response.status).toBe(401)
+    const body = await response.json()
+    expect(body).toEqual({
+      error: {
+        code: 'AUTH_INVALID_TOKEN',
+        message: 'Missing or malformed Authorization header'
+      }
+    })
+  })
+
+  it('rejects sync bodies above the sync route limit', async () => {
+    const request = new Request('http://localhost/sync/crdt/snapshot', {
+      method: 'POST',
+      body: new Uint8Array(8 * ONE_MB + 1)
+    })
+
+    const response = await app.request(request, {}, createEnv())
+
+    expect(response.status).toBe(413)
+    const body = await response.json()
+    expect(body).toEqual({
+      error: {
+        code: 'VALIDATION_BODY_TOO_LARGE',
+        message: 'Request body too large'
+      }
+    })
+  })
 })
 
 describe('scheduled cleanup', () => {

--- a/apps/sync-server/src/index.ts
+++ b/apps/sync-server/src/index.ts
@@ -48,6 +48,10 @@ const app = new Hono<AppContext>()
 app.use('*', securityHeaders)
 
 const MAX_BODY_BYTES_API = 1 * 1024 * 1024
+// Sync routes carry encrypted payloads the routes themselves cap at 5MB
+// decoded (MAX_UPDATE_BYTES, MAX_ENCRYPTED_DATA_BYTES); base64 plus the JSON
+// envelope needs headroom above that, or those route checks are unreachable.
+const MAX_BODY_BYTES_SYNC = 8 * 1024 * 1024
 const MAX_BODY_BYTES_BLOB = 10 * 1024 * 1024
 const MAX_BODY_BYTES_TELEMETRY = 128 * 1024
 
@@ -63,7 +67,11 @@ const getMaxBodyBytes = (path: string): number => {
   }
 
   const isBlobRoute = path.includes('/blob') || path.includes('/attachments/')
-  return isBlobRoute ? MAX_BODY_BYTES_BLOB : MAX_BODY_BYTES_API
+  if (isBlobRoute) {
+    return MAX_BODY_BYTES_BLOB
+  }
+
+  return path.startsWith('/sync/') ? MAX_BODY_BYTES_SYNC : MAX_BODY_BYTES_API
 }
 
 const isBodyWithinLimit = async (request: Request, maxBodyBytes: number): Promise<boolean> => {

--- a/packages/contracts/src/ipc-sync-ops.ts
+++ b/packages/contracts/src/ipc-sync-ops.ts
@@ -38,6 +38,9 @@ export type SyncErrorCategory =
   // One file is over the plan's per-file limit — distinct from being out of
   // storage, and not fixable by freeing space.
   | 'file_too_large'
+  // One note's sync payload is over the server's per-request body limit —
+  // a payload problem, not an account-storage problem.
+  | 'note_too_large'
   | 'sync_payment_required'
   | 'certificate_pin_failed'
   | 'unknown'

--- a/packages/i18n/src/locales/en/errors.json
+++ b/packages/i18n/src/locales/en/errors.json
@@ -83,6 +83,7 @@
     "versionIncompatible": "This version of memrynote is no longer supported. Please update.",
     "storageQuotaExceeded": "Your sync storage is full. Free up space or upgrade your plan.",
     "fileTooLarge": "This file is larger than your plan allows. Upgrade your plan to sync larger files.",
+    "noteTooLarge": "A note is too large to sync. Splitting it into smaller notes will fix this.",
     "attachmentUploadFailed": "Couldn't sync attachment \"{filename}\". It stays on this device.",
     "paymentRequired": "A paid Sync plan is required to use hosted encrypted sync.",
     "certificatePinFailed": "Secure connection failed. Check your network connection.",


### PR DESCRIPTION
## Problem

A Believer-plan user on Fedora reported a persistent **"Your Sync storage is full. Free up space or upgrade your plan."** toast while Settings showed ~20 MB used of 50 GB. Production evidence (D1 + server logs) traced it to one note whose encrypted CRDT snapshot crossed the server's request body limit:

1. The global body-limit middleware caps every `/sync/` request at **1 MiB** (`MAX_BODY_BYTES_API`), so the routes' own 5 MB payload checks were unreachable dead code, and oversized snapshots got `413 VALIDATION_BODY_TOO_LARGE` on every push.
2. The desktop treated **any** HTTP 413 on the CRDT push paths as quota-exceeded (`runtime.ts`), and `classifyError` defaulted bare 413s to `storage_quota_exceeded` — so a payload-size problem rendered as "storage full".
3. Worse, that handler also **paused the whole CRDT update queue**, stalling live sync for every note until a token refresh or restart.

The real quota branch has never fired in production (zero `push_quota_exceeded` telemetry events).

## Changes

**Server** (fixes the affected user immediately on deploy, no desktop release needed):
- New `MAX_BODY_BYTES_SYNC = 8 MiB` tier for `/sync/` routes — headroom for the 5 MB decoded payload cap after base64 + JSON envelope. Blob/attachment routes keep 10 MiB; everything else keeps 1 MiB.

**Desktop:**
- `classifyError`: 413 maps to `storage_quota_exceeded` only when the response carries `STORAGE_QUOTA_EXCEEDED` (real quota responses always do). `STORAGE_FILE_TOO_LARGE` keeps its category; all other 413s become the new **`note_too_large`** category.
- `runtime.ts` CRDT push handlers branch on that classification: genuine quota still pauses the queue and shows the storage toast; body-limit 413s emit `note_too_large` and **no longer pause the queue** — one oversized note can't stall the rest of the vault.
- New toast + i18n copy: *"A note is too large to sync. Splitting it into smaller notes will fix this."*
- `SyncErrorCategory` contract extended (`pnpm ipc:generate` — invoke map unchanged).

**Docs:** new row in the Common Sync Errors table.

## Compatibility

- Server limit raise is strictly permissive — older clients simply stop receiving false 413s for 1–5 MB payloads.
- `note_too_large` is additive to the IPC contract; renderer handles unknown categories with the generic banner, and the exhaustive `Record<SyncErrorCategory, string>` map forces the i18n entry at compile time.
- Payloads over 5 MB decoded still 413 at the route level by design; chunked/split snapshots are a separate follow-up.

## Tests

- Server: sync-tier body-limit tests (2 MB passes middleware, >8 MiB rejected) — `index.test.ts` 12/12.
- `sync-errors.test.ts`: 413 × {`STORAGE_FILE_TOO_LARGE`, `STORAGE_QUOTA_EXCEEDED`, `VALIDATION_BODY_TOO_LARGE`, bare} classification matrix.
- `runtime.test.ts`: bare-413 emits `note_too_large` without pausing the queue; quota-marker 413 still pauses + emits quota — both push paths.
- `push-coordinator.test.ts`: batch-level 413 split into quota-marker vs bare cases.
- `sync-context.test.tsx` + `error-messages.test.ts`: new toast and i18n key resolution.
- Full runs green: main sync subtree 1666 passed, sync-server 927 passed, renderer context/error suites passed, `pnpm typecheck` 16/16, lint clean, `pnpm docs:build` clean.