### PR TITLE
fix(sync-server): content-address item blobs so concurrent pushes cannot tear signature from payload

### DIFF
--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -85,12 +85,22 @@ The blob is the encrypted body. The server can reason about order, dedupe, and a
 
 Item ids are human-readable and may repeat across types: the default project id is `inbox`, a
 `tag_definition` id is the lowercased tag name, and a `folder_config` id is the folder path. R2 keys
-for sync-item payloads therefore include the item type — new pushes write to
-`<user>/vaults/<vault>/items-v2/<type>/<id>`, so a project and a tag both named `inbox` own separate
-objects. Rows written before this layout keep their legacy untyped `items/<id>` key; every read path
-resolves the `blob_key` stored on the row rather than re-deriving it, so old rows continue to work
-without a migration. (The old layout let same-id items of different types overwrite one shared
-object, which permanently broke the losing row's signature.)
+for sync-item payloads therefore include the item type, and since `items-v3` also the payload's
+content hash — new pushes write to `<user>/vaults/<vault>/items-v3/<type>/<id>/<content-hash>`, so a
+project and a tag both named `inbox` own separate objects, and every push writes its own immutable
+object instead of mutating a shared per-item one. Content-addressing is what makes concurrent pushes
+of the same item safe: with a shared mutable key, two devices racing on one id (external calendar
+events have deterministic ids, so every device pushes the same ids) could interleave blob and row
+writes such that the surviving row carried one push's signature over the other push's bytes — the
+item then failed Ed25519 verification on every pull until re-pushed. After a replacing push commits
+its row, the previous version's object is deleted best-effort; a delete that loses a race merely
+leaks a bounded orphan object. Rows written before these layouts keep their legacy `items/<id>` or
+`items-v2/<type>/<id>` keys; every read path resolves the `blob_key` stored on the row rather than
+re-deriving it, so old rows continue to work without a migration. (The untyped layout let same-id
+items of different types overwrite one shared object, which permanently broke the losing row's
+signature.) A pull that finds a row whose object is missing skips that row instead of failing the
+page: a replaced item re-arrives at a later cursor, and a dangling row must not wedge every puller
+behind one broken item.
 
 ### Per-item bookkeeping and retry semantics
 

--- a/apps/sync-server/src/services/blob.test.ts
+++ b/apps/sync-server/src/services/blob.test.ts
@@ -51,23 +51,32 @@ describe('generateBlobKey', () => {
 })
 
 describe('generateItemBlobKey', () => {
-  it('should create type-scoped item key', () => {
-    expect(generateItemBlobKey('user-1', 'task', 'item-1', 'vault-1')).toBe(
-      'user-1/vaults/vault-1/items-v2/task/item-1'
+  it('should create a content-addressed, type-scoped item key', () => {
+    expect(generateItemBlobKey('user-1', 'task', 'item-1', 'vault-1', 'hash-abc')).toBe(
+      'user-1/vaults/vault-1/items-v3/task/item-1/hash-abc'
     )
   })
 
   it('should give distinct keys to same-id items of different types', () => {
-    const projectKey = generateItemBlobKey('user-1', 'project', 'inbox', 'vault-1')
-    const tagKey = generateItemBlobKey('user-1', 'tag_definition', 'inbox', 'vault-1')
+    const projectKey = generateItemBlobKey('user-1', 'project', 'inbox', 'vault-1', 'hash-abc')
+    const tagKey = generateItemBlobKey('user-1', 'tag_definition', 'inbox', 'vault-1', 'hash-abc')
     expect(projectKey).not.toBe(tagKey)
+  })
+
+  it('should give distinct keys to different payloads of the same item', () => {
+    // Two concurrent pushes of the same item must never overwrite each other's
+    // object — the D1 row's signature has to keep pointing at the exact bytes
+    // it was computed over.
+    const first = generateItemBlobKey('user-1', 'task', 'item-1', 'vault-1', 'hash-a')
+    const second = generateItemBlobKey('user-1', 'task', 'item-1', 'vault-1', 'hash-b')
+    expect(first).not.toBe(second)
   })
 
   it('should never collide with the legacy untyped namespace, even for slash-containing ids', () => {
     // folder_config ids are folder paths and may contain slashes; a legacy key
     // like items/task/x must not equal a typed key for task 'x'.
-    const legacyNestedFolder = generateBlobKey('user-1', 'task/x', 'vault-1')
-    const typedTask = generateItemBlobKey('user-1', 'task', 'x', 'vault-1')
+    const legacyNestedFolder = generateBlobKey('user-1', 'task/x/hash-a', 'vault-1')
+    const typedTask = generateItemBlobKey('user-1', 'task', 'x', 'vault-1', 'hash-a')
     expect(legacyNestedFolder).not.toBe(typedTask)
   })
 })

--- a/apps/sync-server/src/services/blob.ts
+++ b/apps/sync-server/src/services/blob.ts
@@ -8,17 +8,28 @@ export const generateBlobKey = (userId: string, itemId: string, vaultId = 'defau
 // id = lowercased tag name, folder_config id = folder path), so an untyped key
 // makes a project and a tag named 'inbox' overwrite ONE R2 object while D1 keeps
 // two rows — the losing row's signature can never verify again and its payload
-// is silently destroyed. The 'items-v2' segment keeps the typed namespace fully
-// disjoint from legacy untyped keys (folder_config ids may contain slashes, so
-// nesting types under 'items/' could still collide with an old key). Reads are
-// unaffected: every consumer reads the per-row stored blob_key, never re-derives
-// it, so legacy rows keep resolving to their old untyped objects.
+// is silently destroyed ('items-v2' fixed that; folder_config ids may contain
+// slashes, so nesting types under 'items/' could still collide with an old key).
+//
+// Keys must ALSO include the content hash: a mutable per-item key let two
+// concurrent pushes of the same item id tear the row apart — putBlob(A),
+// putBlob(B), upsert(B), upsert(A) leaves A's signature on the D1 row with B's
+// bytes in R2, and the item fails Ed25519 verification on every pull until
+// someone re-pushes it. External calendar events made this real: their ids are
+// deterministic, so every device pushes the same ids independently. With the
+// hash in the key ('items-v3') each push writes its own immutable object and
+// the row always points at exactly the bytes its signature covers; the loser
+// of an upsert race leaks one bounded orphan object instead of poisoning the
+// item. Reads are unaffected: every consumer reads the per-row stored
+// blob_key, never re-derives it, so v2 and legacy untyped rows keep resolving
+// to their old objects.
 export const generateItemBlobKey = (
   userId: string,
   itemType: string,
   itemId: string,
-  vaultId = 'default'
-): string => `${userId}/vaults/${vaultId}/items-v2/${itemType}/${itemId}`
+  vaultId = 'default',
+  contentHash: string
+): string => `${userId}/vaults/${vaultId}/items-v3/${itemType}/${itemId}/${contentHash}`
 
 export const generateCrdtKey = (userId: string, noteId: string, vaultId = 'default'): string =>
   `${userId}/vaults/${vaultId}/crdt/${noteId}/snapshot`

--- a/apps/sync-server/src/services/sync.test.ts
+++ b/apps/sync-server/src/services/sync.test.ts
@@ -1200,8 +1200,10 @@ describe('pullItems', () => {
     ).rejects.toMatchObject({ code: ErrorCodes.INTERNAL_ERROR })
   })
 
-  it('should reject missing blobs and corrupt blob payloads', async () => {
-    // #given
+  it('should skip missing blobs but still reject corrupt blob payloads', async () => {
+    // #given — a missing object costs only its own row (a dangling row must
+    // not wedge every pull page), while corruption stays loud: bytes that
+    // exist but cannot be parsed mean something is actively wrong.
     const row = {
       item_id: 'item-1',
       item_type: 'note',
@@ -1223,7 +1225,7 @@ describe('pullItems', () => {
     // #when / #then
     await expect(
       pullItems(db as unknown as D1Database, {} as R2Bucket, 'user-1', ['item-1'])
-    ).rejects.toMatchObject({ code: ErrorCodes.STORAGE_BLOB_NOT_FOUND })
+    ).resolves.toEqual([])
 
     const corruptStmt = createMockStatement()
     corruptStmt.all.mockResolvedValue({ results: [row] })
@@ -1790,8 +1792,12 @@ describe('processPushItem', () => {
     const projectKey = await runPush('project')
     const tagKey = await runPush('tag_definition')
 
-    expect(projectKey).toBe('user-1/vaults/vault-1/items-v2/project/inbox')
-    expect(tagKey).toBe('user-1/vaults/vault-1/items-v2/tag_definition/inbox')
+    // Keys are content-addressed since items-v3, so assert the type-scoped
+    // prefix and cross-type disjointness rather than a literal full key.
+    expect(projectKey).toMatch(/^user-1\/vaults\/vault-1\/items-v3\/project\/inbox\/[0-9a-f]{64}$/)
+    expect(tagKey).toMatch(
+      /^user-1\/vaults\/vault-1\/items-v3\/tag_definition\/inbox\/[0-9a-f]{64}$/
+    )
     expect(projectKey).not.toBe(tagKey)
   })
 
@@ -2101,5 +2107,278 @@ describe('sync-type negotiation', () => {
       expect(result).toEqual([])
       expect(db.prepare).not.toHaveBeenCalled()
     })
+  })
+})
+
+// ============================================================================
+// Tests: torn-write protection (concurrent same-item pushes)
+// ============================================================================
+
+describe('concurrent same-item pushes (torn blob regression)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedGetNextCursor.mockResolvedValue(42)
+    mockedVerifyEd25519.mockResolvedValue(true)
+    mockedGetDevice.mockResolvedValue({
+      id: 'device-1',
+      user_id: 'user-1',
+      name: 'test',
+      platform: 'desktop',
+      os_version: null,
+      app_version: '1.0.0',
+      auth_public_key: btoa(String.fromCharCode(...new Array(32).fill(0))),
+      push_token: null,
+      revoked_at: null,
+      last_sync_at: null,
+      created_at: 1000,
+      updated_at: 1000
+    })
+  })
+
+  it('keeps the winning row pointing at the exact bytes its signature covers', async () => {
+    // Jerry's 2026-08-10 incident shape: two devices race to push the same
+    // item id (external calendar events have deterministic ids, so every
+    // device pushes the same ids independently). With a shared mutable blob
+    // key, the interleaving putBlob(A), putBlob(B), upsert(B), upsert(A)
+    // leaves A's signature on the row while B's bytes sit in the object —
+    // the item then fails Ed25519 verification on every pull, forever.
+    const r2 = new Map<string, string>()
+    vi.mocked(putBlob).mockImplementation(async (_storage, key, data) => {
+      r2.set(key, new TextDecoder().decode(new Uint8Array(data as ArrayBuffer)))
+      return { etag: 'e' } as unknown as R2Object
+    })
+
+    const finalRow: { blobKey?: string; signature?: string } = {}
+    const gates: Array<() => void> = []
+
+    const makeGatedDb = () => {
+      const stmt = createMockStatement()
+      stmt.first.mockResolvedValue(null)
+      const db = createMockDb()
+      db.prepare.mockReturnValue(stmt)
+      db.batch.mockImplementation(async () => {
+        await new Promise<void>((resolve) => gates.push(resolve))
+        const upsertArgs = stmt.bind.mock.calls.find((call) => call.length === 19)
+        finalRow.blobKey = upsertArgs?.[5] as string
+        finalRow.signature = upsertArgs?.[13] as string
+        return []
+      })
+      return db
+    }
+
+    const sigA = btoa(String.fromCharCode(...new Array(64).fill(1)))
+    const sigB = btoa(String.fromCharCode(...new Array(64).fill(2)))
+    const itemA = createValidPushItem({
+      encryptedData: btoa('payload-from-device-A'),
+      signature: sigA
+    })
+    const itemB = createValidPushItem({
+      encryptedData: btoa('payload-from-device-B'),
+      signature: sigB,
+      signerDeviceId: 'device-2',
+      clock: { 'device-2': 1 }
+    })
+
+    const waitForGates = async (count: number) => {
+      while (gates.length < count) await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+
+    // Device A uploads its blob, then stalls just before its row write.
+    const pushA = processPushItem(
+      makeGatedDb() as unknown as D1Database,
+      {} as R2Bucket,
+      'user-1',
+      'device-1',
+      itemA
+    )
+    await waitForGates(1)
+
+    // Device B pushes the same item id start-to-finish while A is stalled.
+    const pushB = processPushItem(
+      makeGatedDb() as unknown as D1Database,
+      {} as R2Bucket,
+      'user-1',
+      'device-2',
+      itemB
+    )
+    await waitForGates(2)
+    gates[1]()
+    await pushB
+
+    // A's row write lands last, so A's signature owns the row.
+    gates[0]()
+    await pushA
+
+    expect(finalRow.signature).toBe(sigA)
+    // The row's blob must contain exactly the payload A signed.
+    expect(r2.get(finalRow.blobKey ?? '')).toBe(serializePayload(itemA))
+  })
+})
+
+// ============================================================================
+// Tests: replaced-blob cleanup
+// ============================================================================
+
+describe('processPushItem replaced blob cleanup', () => {
+  const oldBlobKey = 'user-1/vaults/default/items-v2/note/550e8400-e29b-41d4-a716-446655440000'
+
+  const existingRow = {
+    version: 1,
+    clock: '{"device-1":1}',
+    created_at: 1000,
+    size_bytes: 10,
+    blob_key: oldBlobKey
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedGetNextCursor.mockResolvedValue(42)
+    mockedVerifyEd25519.mockResolvedValue(true)
+    mockedGetDevice.mockResolvedValue({
+      id: 'device-1',
+      user_id: 'user-1',
+      name: 'test',
+      platform: 'desktop',
+      os_version: null,
+      app_version: '1.0.0',
+      auth_public_key: btoa(String.fromCharCode(...new Array(32).fill(0))),
+      push_token: null,
+      revoked_at: null,
+      last_sync_at: null,
+      created_at: 1000,
+      updated_at: 1000
+    })
+    vi.mocked(putBlob).mockResolvedValue({ etag: 'etag-1' } as unknown as R2Object)
+  })
+
+  it('deletes the replaced blob only after the row points at the new one', async () => {
+    const stmt = createMockStatement()
+    stmt.first.mockResolvedValue(existingRow)
+    const db = createMockDb()
+    db.prepare.mockReturnValue(stmt)
+    const storage = { delete: vi.fn().mockResolvedValue(undefined) } as unknown as R2Bucket
+
+    const result = await processPushItem(
+      db as unknown as D1Database,
+      storage,
+      'user-1',
+      'device-1',
+      createValidPushItem({ operation: 'update', clock: { 'device-1': 2 } })
+    )
+
+    expect(result.accepted).toBe(true)
+    const deleteMock = vi.mocked(storage.delete)
+    expect(deleteMock).toHaveBeenCalledWith(oldBlobKey)
+    // Ordering: the D1 row must point at the new blob before the old one goes.
+    expect(db.batch.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteMock.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('does not delete anything for a first-time item', async () => {
+    const stmt = createMockStatement()
+    stmt.first.mockResolvedValue(null)
+    const db = createMockDb()
+    db.prepare.mockReturnValue(stmt)
+    const storage = { delete: vi.fn().mockResolvedValue(undefined) } as unknown as R2Bucket
+
+    const result = await processPushItem(
+      db as unknown as D1Database,
+      storage,
+      'user-1',
+      'device-1',
+      createValidPushItem()
+    )
+
+    expect(result.accepted).toBe(true)
+    expect(vi.mocked(storage.delete)).not.toHaveBeenCalled()
+  })
+
+  it('still accepts the push when the old blob delete fails', async () => {
+    const stmt = createMockStatement()
+    stmt.first.mockResolvedValue(existingRow)
+    const db = createMockDb()
+    db.prepare.mockReturnValue(stmt)
+    const storage = {
+      delete: vi.fn().mockRejectedValue(new Error('R2 hiccup'))
+    } as unknown as R2Bucket
+
+    const result = await processPushItem(
+      db as unknown as D1Database,
+      storage,
+      'user-1',
+      'device-1',
+      createValidPushItem({ operation: 'update', clock: { 'device-1': 2 } })
+    )
+
+    expect(result.accepted).toBe(true)
+  })
+})
+
+// ============================================================================
+// Tests: pull tolerance for missing blobs
+// ============================================================================
+
+describe('pullItems missing blob tolerance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('skips a row whose blob is missing instead of failing the whole page', async () => {
+    // A dangling row (blob deleted, row alive) must not wedge every puller:
+    // one 404 used to reject the whole Promise.all, so the pull page failed
+    // on every retry and the client cursor never advanced.
+    const stmt = createMockStatement()
+    stmt.all.mockResolvedValue({
+      results: [
+        {
+          item_id: 'item-gone',
+          item_type: 'note',
+          blob_key: 'user-1/vaults/default/items-v2/note/item-gone',
+          crypto_version: 1,
+          operation: 'update',
+          signer_device_id: 'device-1',
+          signature: 'sig-gone',
+          state_vector: null,
+          clock: null,
+          deleted_at: null,
+          server_cursor: 7
+        },
+        {
+          item_id: 'item-ok',
+          item_type: 'note',
+          blob_key: 'user-1/vaults/default/items-v2/note/item-ok',
+          crypto_version: 1,
+          operation: 'update',
+          signer_device_id: 'device-1',
+          signature: 'sig-ok',
+          state_vector: null,
+          clock: null,
+          deleted_at: null,
+          server_cursor: 8
+        }
+      ]
+    })
+    const db = createMockDb()
+    db.prepare.mockReturnValue(stmt)
+    vi.mocked(getBlob).mockImplementation(async (_storage, key) =>
+      key.includes('item-gone')
+        ? null
+        : ({
+            body: JSON.stringify({
+              encryptedKey: 'ek',
+              keyNonce: 'kn',
+              encryptedData: 'ed',
+              dataNonce: 'dn'
+            })
+          } as unknown as R2ObjectBody)
+    )
+
+    const result = await pullItems(db as unknown as D1Database, {} as R2Bucket, 'user-1', [
+      'item-gone',
+      'item-ok'
+    ])
+
+    expect(result.map((item) => item.id)).toEqual(['item-ok'])
   })
 })

--- a/apps/sync-server/src/services/sync.ts
+++ b/apps/sync-server/src/services/sync.ts
@@ -18,7 +18,7 @@ import {
 import { encodeSignaturePayload } from '../lib/cbor'
 import { safeBase64Decode, verifyEd25519 } from '../lib/encoding'
 import { AppError, ErrorCodes } from '../lib/errors'
-import { generateItemBlobKey, getBlob, putBlob } from './blob'
+import { deleteBlob, generateItemBlobKey, getBlob, putBlob } from './blob'
 import { getNextCursor } from './cursor'
 import { getDevice } from './device'
 import { adjustStorageUsed, checkQuota, reserveStorage } from './quota'
@@ -35,6 +35,7 @@ const placeholdersFor = (types: readonly RecordSyncItemType[]): string =>
 interface ExistingSyncItemRow {
   version: number
   clock: string | VectorClock | null
+  blob_key?: string | null
   size_bytes?: number | null
   created_at?: number | null
   createdAt?: number | null
@@ -256,7 +257,21 @@ const toPullItemResponse = async (
     return null
   }
 
-  const payload = await readEncryptedPayload(storage, row.blob_key, userId, row.item_id)
+  let payload: EncryptedItemPayload
+  try {
+    payload = await readEncryptedPayload(storage, row.blob_key, userId, row.item_id)
+  } catch (error) {
+    // A missing object must cost only this row, not the page: one dangling row
+    // (or the transient window where a replacing push just deleted the blob
+    // this row version pointed at) used to reject the whole Promise.all, so
+    // every pull retry failed on the same item and the client cursor never
+    // advanced. Skipping is safe — a replaced item re-arrives at a later
+    // cursor, and a genuinely dangling row has no bytes to deliver anyway.
+    if (error instanceof AppError && error.code === ErrorCodes.STORAGE_BLOB_NOT_FOUND) {
+      return null
+    }
+    throw error
+  }
 
   if (!row.signer_device_id || !row.signature) {
     throw new AppError(
@@ -385,7 +400,7 @@ export const processPushItem = async (
       reservedBytes = sizeDelta
     }
 
-    const blobKey = generateItemBlobKey(userId, item.type, item.id, vaultId)
+    const blobKey = generateItemBlobKey(userId, item.type, item.id, vaultId, contentHash)
     try {
       await putBlob(storage, blobKey, payloadBytes.slice().buffer, userId)
     } catch (error) {
@@ -461,6 +476,20 @@ export const processPushItem = async (
         await adjustStorageUsed(db, userId, -reservedBytes)
       }
       throw error
+    }
+
+    // The row now points at the new content-addressed object, so the previous
+    // version's blob is unreachable through any row and can go. Best-effort: a
+    // failed delete leaks one bounded orphan object, never a dangling row. An
+    // in-flight pull that read the old row before this upsert may 404 on the
+    // old key; the pull path tolerates that per item, and the replacement row
+    // re-arrives at a later cursor.
+    if (existing?.blob_key && existing.blob_key !== blobKey) {
+      try {
+        await deleteBlob(storage, existing.blob_key, userId)
+      } catch {
+        // Orphans are invisible to readers; acceptable until a sweep job exists.
+      }
     }
 
     return { accepted: true, serverCursor }


### PR DESCRIPTION
## Problem

A paid user's two devices (macOS + Fedora) started seeing **"A sync item failed signature verification and will be retried"** on every pull, dominated by `calendar_external_event` items, right after v2026-08-08.x revived Google Calendar sync on both machines.

Root cause is a server-side torn write. Item blob keys were mutable per item (`items-v2/<type>/<id>`), and the push path writes R2 first, then D1 — with no atomicity across the two stores. Two devices pushing the same item id concurrently can interleave as:

```
putBlob(A) → putBlob(B) → upsert(B) → upsert(A)
```

leaving **A's signature on the D1 row with B's bytes in R2**. The item then fails Ed25519 verification on every pull, quarantines client-side, and after 3 attempts is permanently skipped — silent cross-device data loss until something re-pushes the item. External calendar events are the pathological trigger: their ids are deterministic, so every device pushes the same ids independently on every sync cycle. Same failure class as the 2026-07-18 blob-collision incident, which was mitigated (namespace bump + cleanup) but never structurally fixed.

Separately, a pull page that hit one row whose object was missing rejected the **whole page** (`Promise.all` with no per-item tolerance), so a single dangling row could wedge a puller's cursor forever.

## Fix

- **`items-v3` content-addressed keys** — `<user>/vaults/<vault>/items-v3/<type>/<id>/<content-hash>`. Every push writes its own immutable object; the D1 row always points at exactly the bytes its signature covers. Losing a same-item race now just means losing the row to last-writer-wins — never a signature/payload mismatch.
- **Replaced-blob cleanup** — after the row commits, the previous version's object is deleted best-effort. A failed or raced delete leaks one bounded orphan object, never a dangling row.
- **Per-item pull tolerance** — a missing object now skips that row instead of failing the page. Safe: a replaced item re-arrives at a later cursor, and a genuinely dangling row has no bytes to deliver anyway. Corrupt-but-present blobs still fail loudly.

## Backward compatibility

Server-only change; no desktop release needed. Key derivation happens exclusively at push time on the server, and every read/delete path resolves the `blob_key` stored on the row — verified for pull (`toPullItemResponse`, `getItem`) and cleanup (`deleteRowsAndBlobs`). Existing `items-v2` and legacy untyped rows keep resolving to their old objects with no migration.

## Tests

All 931 sync-server tests green; new coverage, each verified red on the pre-fix code:

- **Torn-write regression** — deterministically interleaves two concurrent `processPushItem` calls for the same id via gated D1 batches and asserts the final row's blob contains exactly the payload its signature covers.
- Replaced-blob cleanup: deleted only after the row points at the new object (call-order asserted), never for first-time items, and a failed delete doesn't fail the push.
- Pull tolerance: missing blob skips the row, corrupt blob still rejects.
- Key generation: content-hash and cross-type disjointness, no collision with legacy namespaces.

## Follow-ups (not in this PR)

- Heal script for already-torn rows: re-verify each row's signature against its blob server-side, purge mismatches so clients re-push clean copies (unblocks the affected user).
- `generateCrdtKey` (`crdt/<note>/snapshot`) shares the mutable-key shape, but the snapshot signature travels inside the blob, so a race there cannot tear signature from payload — lower severity, separate change if desired.
- Periodic orphan sweep for blobs leaked by raced deletes.