### PR TITLE
fix(editor): stop StrictMode's double effect from destroying every editor

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -396,7 +396,7 @@ describe('ContentArea', () => {
     resetEditor()
   })
 
-  it('destroys the editor and releases the window handle when it unmounts', () => {
+  it('destroys the editor and releases the window handle when it unmounts', async () => {
     const editor = contentAreaMocks.editor
     const win = window as unknown as { ProseMirror?: unknown }
     // `useCreateBlockNote` parks the newest instance here; nothing ever clears it.
@@ -406,6 +406,8 @@ describe('ContentArea', () => {
     expect(editor._tiptapEditor.destroy).not.toHaveBeenCalled()
 
     unmount()
+    // Teardown is deferred by a microtask so StrictMode's remount can cancel it.
+    await Promise.resolve()
 
     expect(editor._tiptapEditor.destroy).toHaveBeenCalledTimes(1)
     expect(win.ProseMirror).toBeUndefined()

--- a/apps/desktop/src/renderer/src/hooks/use-editor-teardown.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-editor-teardown.test.ts
@@ -1,6 +1,10 @@
 import { renderHook } from '@testing-library/react'
+import { StrictMode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useEditorTeardown } from './use-editor-teardown'
+
+/** Teardown is deferred by a microtask so StrictMode can cancel it. */
+const settleTeardown = (): Promise<void> => Promise.resolve()
 
 function createEditor() {
   const listeners = new Map<string, Set<() => void>>()
@@ -24,7 +28,7 @@ afterEach(() => {
 })
 
 describe('useEditorTeardown', () => {
-  it('destroys the editor on unmount and drops its registered listeners', () => {
+  it('destroys the editor on unmount and drops its registered listeners', async () => {
     const { editor, tiptap, listeners } = createEditor()
     tiptap.on('update', () => {})
     const win = window as unknown as { ProseMirror?: unknown }
@@ -34,6 +38,7 @@ describe('useEditorTeardown', () => {
     expect(tiptap.destroy).not.toHaveBeenCalled()
 
     unmount()
+    await settleTeardown()
 
     expect(tiptap.destroy).toHaveBeenCalledTimes(1)
     expect(tiptap.isDestroyed).toBe(true)
@@ -41,7 +46,7 @@ describe('useEditorTeardown', () => {
     expect(win.ProseMirror).toBeUndefined()
   })
 
-  it('keeps a window handle that belongs to a different editor', () => {
+  it('keeps a window handle that belongs to a different editor', async () => {
     const { editor } = createEditor()
     const other = createEditor()
     const win = window as unknown as { ProseMirror?: unknown }
@@ -49,8 +54,51 @@ describe('useEditorTeardown', () => {
 
     const { unmount } = renderHook(() => useEditorTeardown(editor))
     unmount()
+    await settleTeardown()
 
     expect(win.ProseMirror).toBe(other.tiptap)
+  })
+
+  it('survives the StrictMode double effect that remounts the same editor', async () => {
+    const { editor, tiptap } = createEditor()
+    const flush = vi.fn()
+
+    // StrictMode runs setup → cleanup → setup on the same fiber. `useMemo`
+    // hands the same editor back, so destroying it here blanks every editing
+    // surface for the rest of the session.
+    const { unmount } = renderHook(() => useEditorTeardown(editor, flush), {
+      wrapper: StrictMode
+    })
+    await settleTeardown()
+
+    expect(tiptap.destroy).not.toHaveBeenCalled()
+    expect(tiptap.isDestroyed).toBe(false)
+    expect(flush).not.toHaveBeenCalled()
+
+    unmount()
+    await settleTeardown()
+
+    expect(tiptap.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('still tears the previous editor down when the editor identity changes', async () => {
+    const first = createEditor()
+    const second = createEditor()
+
+    const { rerender, unmount } = renderHook(({ editor }) => useEditorTeardown(editor), {
+      initialProps: { editor: first.editor as unknown }
+    })
+
+    rerender({ editor: second.editor as unknown })
+    await settleTeardown()
+
+    expect(first.tiptap.destroy).toHaveBeenCalledTimes(1)
+    expect(second.tiptap.destroy).not.toHaveBeenCalled()
+
+    unmount()
+    await settleTeardown()
+
+    expect(second.tiptap.destroy).toHaveBeenCalledTimes(1)
   })
 
   it('waits for an async flush before destroying, and destroys even if it rejects', async () => {
@@ -69,6 +117,7 @@ describe('useEditorTeardown', () => {
 
     const { unmount } = renderHook(() => useEditorTeardown(editor, flush))
     unmount()
+    await settleTeardown()
 
     expect(flush).toHaveBeenCalledTimes(1)
     expect(tiptap.destroy).not.toHaveBeenCalled()

--- a/apps/desktop/src/renderer/src/hooks/use-editor-teardown.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-editor-teardown.ts
@@ -22,6 +22,15 @@ interface TiptapHost {
  * `beforeDestroy` runs first and may return a promise: teardown waits for it so
  * a pending save can still read the document while the editor is intact. It is
  * awaited even when it rejects — a failed save must not strand the editor.
+ *
+ * Teardown is deferred by a microtask so it can be cancelled. In development
+ * StrictMode runs setup → cleanup → setup on the same fiber, and
+ * `useCreateBlockNote` is a `useMemo`, so that simulated remount hands back the
+ * SAME editor. Destroying it in the cleanup would kill every editing surface
+ * the moment it first mounted — the view getter then throws "The editor view is
+ * not available" and the note, journal, task and canvas bodies all render
+ * blank. React runs the double-invoke synchronously, so a microtask lands after
+ * the second setup has had its chance to cancel.
  */
 export function useEditorTeardown(
   editor: unknown,
@@ -32,7 +41,18 @@ export function useEditorTeardown(
     beforeDestroyRef.current = beforeDestroy
   })
 
+  const pendingRef = useRef<{ editor: unknown; cancelled: boolean } | null>(null)
+
   useEffect(() => {
+    // Only a remount of the same editor is StrictMode's doing. A different
+    // editor means the previous one is genuinely gone and must still be torn
+    // down, so its pending teardown is left to run.
+    const pending = pendingRef.current
+    if (pending && pending.editor === editor) {
+      pending.cancelled = true
+      pendingRef.current = null
+    }
+
     return () => {
       const tiptap = (editor as TiptapHost | null)?._tiptapEditor
       const destroy = (): void => {
@@ -47,21 +67,29 @@ export function useEditorTeardown(
         }
       }
 
-      let pending: void | Promise<void> = undefined
-      try {
-        pending = beforeDestroyRef.current?.()
-      } catch (error) {
-        log.warn('Editor teardown flush threw', error)
-      }
+      const token = { editor, cancelled: false }
+      pendingRef.current = token
 
-      if (pending && typeof pending.then === 'function') {
-        void pending.then(destroy, (error: unknown) => {
-          log.warn('Editor teardown flush rejected', error)
-          destroy()
-        })
-        return
-      }
-      destroy()
+      queueMicrotask(() => {
+        if (token.cancelled) return
+        if (pendingRef.current === token) pendingRef.current = null
+
+        let flushed: void | Promise<void> = undefined
+        try {
+          flushed = beforeDestroyRef.current?.()
+        } catch (error) {
+          log.warn('Editor teardown flush threw', error)
+        }
+
+        if (flushed && typeof flushed.then === 'function') {
+          void flushed.then(destroy, (error: unknown) => {
+            log.warn('Editor teardown flush rejected', error)
+            destroy()
+          })
+          return
+        }
+        destroy()
+      })
     }
   }, [editor])
 }


### PR DESCRIPTION
Regression from #1140 (epic #987 MAJOR tier), dev-only.

`useEditorTeardown` destroyed the Tiptap instance directly in its effect cleanup. In development React StrictMode runs setup → cleanup → setup on the same fiber, and `useCreateBlockNote` is a bare `useMemo`, so the simulated remount hands back the **same** editor — already destroyed. Every editing surface (note, journal, task description, inbox detail, canvas note body) rendered blank for the rest of the session, and anything reaching for the view threw `The editor view is not available`.

Teardown is now deferred by a microtask and cancelled when the effect re-runs for the same editor. A different editor still tears the previous one down; real unmount is unchanged apart from the microtask hop.

Production is unaffected — React only double-invokes effects in dev — but the whole app is unusable under `pnpm dev`.

## Verification
- New test renders the hook inside `StrictMode` and asserts the editor survives. Mutation-tested: it fails on the pre-fix hook, passes after.
- New test covers editor-identity change still tearing the previous editor down.
- `ContentArea` and `use-editor-teardown` unmount assertions now await the microtask.
- 164 files / 1548 renderer tests green across content-area, journal, note, hooks, tasks, inbox-detail.