### PR TITLE
perf(window): debounce window-bounds persistence at 1.5s and drop no-op writes

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -43,7 +43,11 @@ import {
   setStoredLocale,
   setWindowBounds
 } from './store'
-import { resolveStartupBounds } from './window-bounds'
+import {
+  createWindowBoundsPersister,
+  resolveStartupBounds,
+  type SavedWindowBounds
+} from './window-bounds'
 import { resolveOsLocale } from './startup-locale'
 import { configureSessionPermissions } from './session-permissions'
 import { startSnoozeScheduler, stopSnoozeScheduler, checkDueItemsOnStartup } from './inbox/snooze'
@@ -620,28 +624,17 @@ function resizeWindowIfNeeded(
   window.setSize(size.width, size.height)
 }
 
-let persistWindowBoundsTimer: ReturnType<typeof setTimeout> | null = null
-
 /**
- * Save the main window's geometry so the next launch / dock reopen restores it.
- * Guarded to the real app window — the compact vault picker is never remembered.
- * When maximized we store the *normal* (un-maximized) bounds plus the flag, so a
- * later restore can place the window correctly and then re-maximize.
+ * Read the main window's geometry for persistence, or null when there is nothing
+ * worth remembering. Guarded to the real app window — the compact vault picker is
+ * never remembered. When maximized we report the *normal* (un-maximized) bounds
+ * plus the flag, so a later restore can place the window correctly and re-maximize.
  */
-function persistWindowBounds(window: BrowserWindow): void {
-  if (window.isDestroyed() || !getCurrentVaultPath()) return
+function readWindowBounds(window: BrowserWindow): SavedWindowBounds | null {
+  if (window.isDestroyed() || !getCurrentVaultPath()) return null
   const isMaximized = window.isMaximized()
   const { width, height, x, y } = isMaximized ? window.getNormalBounds() : window.getBounds()
-  setWindowBounds({ width, height, x, y, isMaximized })
-}
-
-/** Debounced persist for the noisy resize/move event streams. */
-function scheduleWindowBoundsPersist(window: BrowserWindow): void {
-  if (persistWindowBoundsTimer) clearTimeout(persistWindowBoundsTimer)
-  persistWindowBoundsTimer = setTimeout(() => {
-    persistWindowBoundsTimer = null
-    persistWindowBounds(window)
-  }, 400)
+  return { width, height, x, y, isMaximized }
 }
 
 function createWindow(): void {
@@ -691,18 +684,20 @@ function createWindow(): void {
   if (startupBounds.maximize) mainWindow.maximize()
   recordLaunchPhase('window_created')
 
-  // Remember geometry as the user resizes/moves/maximizes it, and on close.
-  mainWindow.on('resize', () => scheduleWindowBoundsPersist(mainWindow))
-  mainWindow.on('move', () => scheduleWindowBoundsPersist(mainWindow))
-  mainWindow.on('maximize', () => persistWindowBounds(mainWindow))
-  mainWindow.on('unmaximize', () => persistWindowBounds(mainWindow))
-  mainWindow.on('close', () => {
-    if (persistWindowBoundsTimer) {
-      clearTimeout(persistWindowBoundsTimer)
-      persistWindowBoundsTimer = null
-    }
-    persistWindowBounds(mainWindow)
+  // Remember geometry as the user resizes/moves/maximizes it, and on close. Every
+  // persist rewrites the whole config file synchronously, so all four event streams
+  // share one trailing debounce that also drops geometry identical to the last write
+  // (maximize/unmaximize each fire alongside their own `resize`). `close` flushes so
+  // the final geometry is never lost to a pending timer.
+  const boundsPersister = createWindowBoundsPersister({
+    read: () => readWindowBounds(mainWindow),
+    write: setWindowBounds
   })
+  mainWindow.on('resize', () => boundsPersister.schedule())
+  mainWindow.on('move', () => boundsPersister.schedule())
+  mainWindow.on('maximize', () => boundsPersister.schedule())
+  mainWindow.on('unmaximize', () => boundsPersister.schedule())
+  mainWindow.on('close', () => boundsPersister.flush())
 
   const unsubscribeVaultStatus = onVaultStatusChanged((status) => {
     if (mainWindow.isDestroyed()) return

--- a/apps/desktop/src/main/window-bounds.test.ts
+++ b/apps/desktop/src/main/window-bounds.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest'
-import { resolveStartupBounds, type DisplayLike, type SavedWindowBounds } from './window-bounds'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  createWindowBoundsPersister,
+  resolveStartupBounds,
+  WINDOW_BOUNDS_PERSIST_DELAY_MS,
+  type DisplayLike,
+  type SavedWindowBounds
+} from './window-bounds'
 
 const FALLBACK = { width: 1550, height: 900 }
 
@@ -70,5 +76,129 @@ describe('resolveStartupBounds', () => {
     const result = resolveStartupBounds(saved, [PRIMARY], FALLBACK)
     expect(result.width).toBe(FALLBACK.width)
     expect(result.height).toBe(FALLBACK.height)
+  })
+})
+
+describe('createWindowBoundsPersister', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /** Collects every persisted geometry, standing in for the config-file write. */
+  function trackWrites(): {
+    writes: SavedWindowBounds[]
+    write: (bounds: SavedWindowBounds) => void
+  } {
+    const writes: SavedWindowBounds[] = []
+    return { writes, write: (bounds) => void writes.push(bounds) }
+  }
+
+  it('writes once for a continuous 5 s drag gesture', () => {
+    const { writes, write } = trackWrites()
+    let x = 100
+    const persister = createWindowBoundsPersister({
+      read: () => ({ width: 1200, height: 800, x, y: 60, isMaximized: false }),
+      write
+    })
+
+    // Electron emits `move` far faster than the debounce during a real drag.
+    for (let elapsed = 0; elapsed < 5000; elapsed += 16) {
+      x += 1
+      persister.schedule()
+      vi.advanceTimersByTime(16)
+    }
+    expect(writes).toHaveLength(0)
+
+    vi.advanceTimersByTime(WINDOW_BOUNDS_PERSIST_DELAY_MS)
+    expect(writes).toHaveLength(1)
+    expect(writes[0].x).toBe(x)
+  })
+
+  it('rides out the mid-gesture stalls a 400 ms debounce would write through', () => {
+    const { writes, write } = trackWrites()
+    let x = 100
+    const persister = createWindowBoundsPersister({
+      read: () => ({ width: 1200, height: 800, x, y: 60, isMaximized: false }),
+      write
+    })
+
+    // Drags stall — the pointer pauses, or the compositor coalesces events. Each
+    // stall here outlasts the old 400 ms debounce but not the current one, so the
+    // gesture must still settle into a single write.
+    for (let step = 0; step < 5; step += 1) {
+      x += 20
+      persister.schedule()
+      vi.advanceTimersByTime(600)
+    }
+    expect(writes).toHaveLength(0)
+
+    vi.advanceTimersByTime(WINDOW_BOUNDS_PERSIST_DELAY_MS)
+    expect(writes).toHaveLength(1)
+  })
+
+  it('debounces maximize instead of writing immediately', () => {
+    const { writes, write } = trackWrites()
+    let isMaximized = false
+    const persister = createWindowBoundsPersister({
+      read: () => ({ width: 1200, height: 800, x: 100, y: 60, isMaximized }),
+      write
+    })
+
+    // Electron fires `resize` alongside `maximize`; both share the one timer now.
+    isMaximized = true
+    persister.schedule()
+    persister.schedule()
+    expect(writes).toHaveLength(0)
+
+    vi.advanceTimersByTime(WINDOW_BOUNDS_PERSIST_DELAY_MS)
+    expect(writes).toEqual([{ width: 1200, height: 800, x: 100, y: 60, isMaximized: true }])
+  })
+
+  it('skips the write when the geometry is unchanged since the last one', () => {
+    const { writes, write } = trackWrites()
+    const persister = createWindowBoundsPersister({
+      read: () => ({ width: 1200, height: 800, x: 100, y: 60, isMaximized: false }),
+      write
+    })
+
+    persister.schedule()
+    vi.advanceTimersByTime(WINDOW_BOUNDS_PERSIST_DELAY_MS)
+    expect(writes).toHaveLength(1)
+
+    // A window nudged and snapped back re-emits `move` with identical geometry.
+    persister.schedule()
+    vi.advanceTimersByTime(WINDOW_BOUNDS_PERSIST_DELAY_MS)
+    persister.flush()
+    expect(writes).toHaveLength(1)
+  })
+
+  it('flushes the pending geometry once on close and cancels the timer', () => {
+    const { writes, write } = trackWrites()
+    const persister = createWindowBoundsPersister({
+      read: () => ({ width: 1000, height: 700, x: 10, y: 20, isMaximized: false }),
+      write
+    })
+
+    persister.schedule()
+    persister.flush()
+    expect(writes).toHaveLength(1)
+
+    // The cancelled timer must not land a second, redundant write.
+    vi.advanceTimersByTime(WINDOW_BOUNDS_PERSIST_DELAY_MS * 2)
+    expect(writes).toHaveLength(1)
+  })
+
+  it('writes nothing when there is no geometry worth remembering', () => {
+    const { writes, write } = trackWrites()
+    const persister = createWindowBoundsPersister({ read: () => null, write })
+
+    persister.schedule()
+    vi.advanceTimersByTime(WINDOW_BOUNDS_PERSIST_DELAY_MS)
+    persister.flush()
+    expect(writes).toHaveLength(0)
   })
 })

--- a/apps/desktop/src/main/window-bounds.ts
+++ b/apps/desktop/src/main/window-bounds.ts
@@ -87,3 +87,78 @@ export function resolveStartupBounds(
 
   return result
 }
+
+/**
+ * Trailing debounce applied to the noisy `resize`/`move` event streams.
+ *
+ * Persisting bounds rewrites the entire pretty-printed config file synchronously
+ * (vault list, sync state, entitlement cache, allowlists), so the delay is long
+ * enough that a continuous drag settles into a single write once the gesture ends.
+ */
+export const WINDOW_BOUNDS_PERSIST_DELAY_MS = 1500
+
+export interface WindowBoundsPersister {
+  /** Queue a trailing-debounced write; each call pushes the pending write back. */
+  schedule(): void
+  /** Drop the pending write and persist right now (window close). */
+  flush(): void
+}
+
+function isSameBounds(a: SavedWindowBounds, b: SavedWindowBounds): boolean {
+  return (
+    a.width === b.width &&
+    a.height === b.height &&
+    a.x === b.x &&
+    a.y === b.y &&
+    a.isMaximized === b.isMaximized
+  )
+}
+
+/**
+ * Debounce and de-duplicate main-window geometry writes.
+ *
+ * `read` returns the window's current geometry, or null when there is nothing to
+ * remember (window destroyed, no vault open). Geometry identical to the last write
+ * is dropped, so repeated events that do not actually move the window — maximize
+ * firing alongside its own `resize`, or a drag that lands where it started — never
+ * rewrite the config.
+ *
+ * Electron-free by design so the debounce can be unit tested with fake timers.
+ */
+export function createWindowBoundsPersister({
+  read,
+  write,
+  delayMs = WINDOW_BOUNDS_PERSIST_DELAY_MS
+}: {
+  read: () => SavedWindowBounds | null
+  write: (bounds: SavedWindowBounds) => void
+  delayMs?: number
+}): WindowBoundsPersister {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let lastWritten: SavedWindowBounds | null = null
+
+  const persistNow = (): void => {
+    const bounds = read()
+    if (!bounds) return
+    if (lastWritten !== null && isSameBounds(lastWritten, bounds)) return
+    lastWritten = bounds
+    write(bounds)
+  }
+
+  return {
+    schedule(): void {
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        timer = null
+        persistNow()
+      }, delayMs)
+    },
+    flush(): void {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      persistNow()
+    }
+  }
+}

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -69,6 +69,32 @@ Inside the vault directory (chosen during [first run](/guide/first-run)):
 └─ leveldb/          # y-leveldb store for Yjs CRDTs
 ```
 
+## App Config File
+
+App-level state that must be readable before any vault opens lives in a single JSON file,
+`<userData>/memry-config.json` (`src/main/store.ts`): the known-vault list, current vault,
+locale, sync state, cached entitlement, capture allowlist, updater preferences and the last
+main-window geometry.
+
+It is read once into an in-memory cache and every `store.set` rewrites the **whole**
+pretty-printed file synchronously. That makes the file cheap to read but expensive to write,
+so high-frequency writers must batch.
+
+### Window Geometry
+
+The main window's size and position are persisted so the next launch (or macOS dock reopen)
+restores them. `resize`, `move`, `maximize` and `unmaximize` all feed one trailing debounce
+(`createWindowBoundsPersister` in `src/main/window-bounds.ts`,
+`WINDOW_BOUNDS_PERSIST_DELAY_MS` = 1500 ms), so a continuous drag settles into a single
+config write instead of rewriting the file throughout the gesture. The persister also drops
+writes whose geometry matches the previous one — `maximize`/`unmaximize` each fire alongside
+their own `resize`, and a window nudged back to where it started re-emits `move` unchanged.
+The window `close` handler flushes the pending write so the final geometry is never lost to
+a timer that never fired.
+
+The persister is deliberately free of Electron imports (it takes `read`/`write` callbacks) so
+the debounce can be unit tested with fake timers.
+
 ## Canvas Files
 
 A canvas is a plain `.excalidraw` document in `<vault>/canvases/`, the same way a note is a


### PR DESCRIPTION
Part of epic #987 (Memory & CPU full-app performance audit 2026-08).

## What was wrong

Persisting the main window's geometry goes through `store.set` → `writeConfig`
(`apps/desktop/src/main/store.ts:186`), which rewrites the **entire** pretty-printed
config file synchronously — vault list, sync state, entitlement cache, capture
allowlist, updater prefs.

Two problems on top of that, both confirmed still present on `main` @ 21d1dae9b:

- `apps/desktop/src/main/index.ts:639-645` — the `resize`/`move` debounce was only
  400 ms. Real drag gestures stall (pointer pauses, compositor coalescing), and any
  stall longer than 400 ms wrote the whole config mid-gesture.
- `apps/desktop/src/main/index.ts:697-698` — `maximize`/`unmaximize` bypassed the
  debounce and wrote immediately. Electron fires `resize` alongside each of them, so
  a single maximize produced an immediate write plus a second debounced write.

## What changed

- `apps/desktop/src/main/window-bounds.ts` — new `createWindowBoundsPersister`:
  a trailing debounce (`WINDOW_BOUNDS_PERSIST_DELAY_MS` = 1500 ms) that also skips
  writes whose geometry is identical to the last one. Deliberately Electron-free
  (takes `read`/`write` callbacks) so the debounce is unit testable with fake timers.
- `apps/desktop/src/main/index.ts` — `resize`, `move`, `maximize` and `unmaximize`
  now all feed that one debounce; `close` flushes it so the final geometry is never
  lost to a pending timer. `persistWindowBounds` became `readWindowBounds` (returns
  the geometry instead of writing it); the module-global `persistWindowBoundsTimer`
  is gone.

**Backward compatibility:** the stored `windowBounds` shape is unchanged, so
`memry-config.json` stays readable by older app versions. No schema, contract, or
IPC changes.

## Verification

Targeted main-project tests (6 new cases, `apps/desktop/src/main/window-bounds.test.ts`):

```
✓ createWindowBoundsPersister > writes once for a continuous 5 s drag gesture
✓ createWindowBoundsPersister > rides out the mid-gesture stalls a 400 ms debounce would write through
✓ createWindowBoundsPersister > debounces maximize instead of writing immediately
✓ createWindowBoundsPersister > skips the write when the geometry is unchanged since the last one
✓ createWindowBoundsPersister > flushes the pending geometry once on close and cancels the timer
✓ createWindowBoundsPersister > writes nothing when there is no geometry worth remembering

Test Files  1 passed (1)
     Tests  13 passed (13)
```

The issue's own acceptance criterion ("continuous 5 s drag produces ≤ 2 writes") is
covered directly: a 5 s drag at ~60 fps produces **1** write, after the gesture ends.

Mutation-tested — reverting `WINDOW_BOUNDS_PERSIST_DELAY_MS` to the old 400 ms makes
the stall test fail, so it is a real regression test:

```
--- MUTATED to 400ms ---
× createWindowBoundsPersister > rides out the mid-gesture stalls a 400 ms debounce would write through
     Tests  1 failed | 12 passed (13)
```

Also green: `pnpm --filter @memry/desktop typecheck:node`, `pnpm exec eslint` on the
changed files (0 errors), `git diff --check`, `pnpm docs:impact --base origin/main
--strict` (covered), `pnpm docs:build`.

## Note for review

Moving the debounce state into a per-window persister also removes the module-global
`persistWindowBoundsTimer` that issue #1093 (LOW) is about — `createWindow()` runs more
than once (startup at `index.ts:1630`, macOS dock reopen at `index.ts:1710`), and each
window now owns its own timer. This fell out of making the debounce testable rather than
being targeted work; #1093 may be closable off the back of it, but that is a judgement
call for the epic owner and I have left it open.

Closes #1058