### PR TITLE
perf(agent): list and decrypt conversation history once per turn

### DIFF
--- a/apps/desktop/src/main/agent/runtime/__tests__/compactor.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/compactor.test.ts
@@ -77,16 +77,71 @@ describe('Conversation compactor', () => {
     const messages = fakeStore([message({ id: 'm1', createdAt: 1 })])
     const summarize = vi.fn(async () => 'summary')
 
-    await maybeCompact({
+    const compaction = await maybeCompact({
       conversationId: 'conversation-1',
       messages,
+      history: messages.listByConversation('conversation-1'),
       summarize,
       estimateLimit: 100_000,
       currentEstimate: 1_000
     })
 
+    expect(compaction).toBeNull()
     expect(summarize).not.toHaveBeenCalled()
     expect(messages.listByConversation('conversation-1')).toHaveLength(1)
+  })
+
+  it('reads the caller-supplied history instead of re-listing the conversation', async () => {
+    const seed = Array.from({ length: 6 }, (_, index) =>
+      message({
+        id: `m${index}`,
+        content: { role: 'user', data: { text: `msg-${index}` } },
+        createdAt: index
+      })
+    )
+    const messages = fakeStore(seed)
+    const listSpy = vi.spyOn(messages, 'listByConversation')
+    const history = seed.slice()
+
+    await maybeCompact({
+      conversationId: 'conversation-1',
+      messages,
+      history,
+      summarize: vi.fn(async () => 'summary'),
+      estimateLimit: 1,
+      currentEstimate: 2
+    })
+
+    expect(listSpy).not.toHaveBeenCalled()
+    // The caller keeps using this array for the rest of the turn, so compaction
+    // must not sort it out from under them.
+    expect(history).toEqual(seed)
+  })
+
+  it('returns the appended compaction marker so callers can skip a re-list', async () => {
+    const messages = fakeStore(
+      Array.from({ length: 4 }, (_, index) =>
+        message({
+          id: `m${index}`,
+          content: { role: 'user', data: { text: `msg-${index}` } },
+          createdAt: index
+        })
+      )
+    )
+
+    const compaction = await maybeCompact({
+      conversationId: 'conversation-1',
+      messages,
+      history: messages.listByConversation('conversation-1'),
+      summarize: vi.fn(async () => 'Earlier in this conversation: stuff'),
+      estimateLimit: 1,
+      currentEstimate: 2
+    })
+
+    expect(compaction).not.toBeNull()
+    expect(compaction?.role).toBe('system')
+    const stored = messages.listByConversation('conversation-1').at(-1)
+    expect(compaction).toBe(stored)
   })
 
   it('summarizes the oldest half and persists a compacted system message', async () => {
@@ -104,6 +159,7 @@ describe('Conversation compactor', () => {
     await maybeCompact({
       conversationId: 'conversation-1',
       messages,
+      history: messages.listByConversation('conversation-1'),
       summarize,
       estimateLimit: 1,
       currentEstimate: 2

--- a/apps/desktop/src/main/agent/runtime/__tests__/turn.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/turn.test.ts
@@ -397,6 +397,97 @@ describe('runTurn against a stub backend', () => {
     ).toBe(true)
   })
 
+  // Every list re-runs two AEAD opens, two JSON.parses and a zod parse per row,
+  // so a turn that lists three or four times pays O(history) that many times.
+  it('lists and decrypts the conversation history once per turn', async () => {
+    const messages = createFakeMessageStore([
+      seedMessage({
+        id: 'old-1',
+        role: 'user',
+        content: { role: 'user', data: { text: 'earlier question' } },
+        createdAt: 1
+      }),
+      seedMessage({
+        id: 'old-2',
+        role: 'assistant',
+        content: { role: 'assistant', data: { text: 'earlier answer' } },
+        createdAt: 2
+      })
+    ])
+    const conversations = createFakeConversationStore({ title: 'Existing conversation' })
+    const backend = createFakeBackend({ turn: [{ kind: 'message_stop' }] })
+    const listSpy = vi.spyOn(messages, 'listByConversation')
+
+    await runTurn(
+      {
+        conversations,
+        messages,
+        backends: createFakeRegistry(backend)
+      },
+      {
+        conversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
+        text: 'follow up',
+        attachments: [],
+        backendOptions: { backend: 'claude_cli', claudeEffort: 'medium' }
+      }
+    )
+
+    expect(listSpy).toHaveBeenCalledTimes(1)
+    expect(backend.summarize).not.toHaveBeenCalled()
+    // The single list still has to carry the whole transcript into the prompt.
+    const prompt = backend.runTurn.mock.calls[0][0].prompt
+    expect(prompt).toContain('earlier question')
+    expect(prompt).toContain('earlier answer')
+    expect(prompt).toContain('follow up')
+  })
+
+  it('lists the conversation history once even when compaction appends a marker', async () => {
+    const messages = createFakeMessageStore([
+      seedMessage({
+        id: 'old-1',
+        role: 'user',
+        content: { role: 'user', data: { text: 'a'.repeat(210_000) } },
+        createdAt: 1
+      }),
+      seedMessage({
+        id: 'old-2',
+        role: 'assistant',
+        content: { role: 'assistant', data: { text: 'b'.repeat(210_000) } },
+        createdAt: 2
+      })
+    ])
+    const conversations = createFakeConversationStore({ title: 'Existing conversation' })
+    const backend = createFakeBackend({
+      summary: [{ kind: 'assistant_delta', text: 'Earlier in this conversation: old summary' }],
+      turn: [{ kind: 'message_stop' }]
+    })
+    const listSpy = vi.spyOn(messages, 'listByConversation')
+
+    await runTurn(
+      {
+        conversations,
+        messages,
+        backends: createFakeRegistry(backend)
+      },
+      {
+        conversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
+        text: 'continue',
+        attachments: [],
+        backendOptions: { backend: 'claude_cli', claudeEffort: 'medium' }
+      }
+    )
+
+    expect(listSpy).toHaveBeenCalledTimes(1)
+    // The compacted prompt is rebuilt from the marker the compactor returned,
+    // not from a fresh list, so it must still replace the summarized history.
+    const prompt = backend.runTurn.mock.calls[0][0].prompt
+    expect(prompt).toContain('Earlier in this conversation: old summary')
+    expect(prompt).not.toContain('a'.repeat(210_000))
+    expect(prompt).toContain('continue')
+  })
+
   it('uses the selected backend subprocess to title a default conversation from the first prompt', async () => {
     const messages = createFakeMessageStore()
     const conversations = createFakeConversationStore()

--- a/apps/desktop/src/main/agent/runtime/compactor.ts
+++ b/apps/desktop/src/main/agent/runtime/compactor.ts
@@ -7,26 +7,36 @@ export const COMPACT_PROMPT =
 export interface MaybeCompactInput {
   conversationId: string
   messages: MessageStore
+  /**
+   * The conversation transcript the caller already listed, including the turn's
+   * own user message. Taken as input rather than re-listed here because every
+   * list re-runs two AEAD opens, two JSON.parses and a zod parse per message.
+   */
+  history: Message[]
   summarize: (toSummarize: string) => Promise<string>
   estimateLimit: number
   currentEstimate: number
 }
 
-export async function maybeCompact(input: MaybeCompactInput): Promise<void> {
-  if (input.currentEstimate < input.estimateLimit) return
+/**
+ * Returns the appended compaction marker, or null when nothing was compacted so
+ * the caller can skip re-assembling a prompt that would come out byte-identical.
+ */
+export async function maybeCompact(input: MaybeCompactInput): Promise<Message | null> {
+  if (input.currentEstimate < input.estimateLimit) return null
 
-  const all = input.messages
-    .listByConversation(input.conversationId)
-    .sort((a, b) => a.createdAt - b.createdAt)
+  // Copied before sorting: the array belongs to the caller, which keeps using it
+  // for the rest of the turn.
+  const all = [...input.history].sort((a, b) => a.createdAt - b.createdAt)
   const lastCompactedIndex = findLastCompactedIndex(all)
   const activeHistory = all.slice(lastCompactedIndex + 1)
-  if (activeHistory.length < 2) return
+  if (activeHistory.length < 2) return null
 
   const oldest = activeHistory.slice(0, Math.floor(activeHistory.length / 2))
   const dump = oldest.map(renderForSummary).join('\n')
   const summary = await input.summarize(`${COMPACT_PROMPT}\n\n${dump}`)
 
-  input.messages.append({
+  return input.messages.append({
     conversationId: input.conversationId,
     role: 'system',
     content: {

--- a/apps/desktop/src/main/agent/runtime/turn.ts
+++ b/apps/desktop/src/main/agent/runtime/turn.ts
@@ -53,14 +53,20 @@ export interface RunTurnInput {
 
 export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ turnId: string }> {
   const turnId = randomUUID()
-  const existingMessages = deps.messages.listByConversation(input.conversationId)
+  // Listing the transcript is the expensive part of a turn: every row costs two
+  // AEAD opens, two JSON.parses and a zod parse. It is listed once here and
+  // threaded through the rest of the turn, so the cost stays O(history) per
+  // message instead of a multiple of it. Nothing appends to this conversation
+  // between here and the last use below except this turn itself, and those
+  // appends return the message, so the in-memory copy stays authoritative.
+  const history = deps.messages.listByConversation(input.conversationId)
   const existingConversation = deps.conversations.getById(input.conversationId)
   const backend = deps.backends.get(input.backendOptions.backend)
   const permissions = input.permissions ?? DEFAULT_TURN_PERMISSIONS
   // agent_chat_started keys on this heuristic; revisit if a user-facing rename path is added
   const shouldGenerateTitle =
     existingConversation?.title.trim() === DEFAULT_CONVERSATION_TITLE &&
-    !existingMessages.some((message) => message.role === 'user')
+    !history.some((message) => message.role === 'user')
 
   const user = deps.messages.append({
     conversationId: input.conversationId,
@@ -101,9 +107,6 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
       })
     : Promise.resolve()
 
-  let history = deps.messages
-    .listByConversation(input.conversationId)
-    .filter((message) => message.id !== user.id)
   const promptContext = buildPromptContext()
   const prompt = assemblePrompt({
     history,
@@ -113,10 +116,14 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
     context: promptContext
   })
 
+  let compactedPrompt = prompt
   try {
-    await maybeCompact({
+    const compaction = await maybeCompact({
       conversationId: input.conversationId,
       messages: deps.messages,
+      // assemblePrompt renders the turn's own user message separately, but
+      // compaction weighs the whole transcript, so it gets history plus `user`.
+      history: [...history, user],
       summarize: (toSummarize) =>
         summarizeWithBackend(deps, {
           prompt: toSummarize,
@@ -128,6 +135,18 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
       estimateLimit: COMPACTION_THRESHOLD,
       currentEstimate: estimateTokens(prompt)
     })
+    // Compaction only ever appends a marker, so the post-compaction history is
+    // exactly the pre-compaction one plus that marker — no re-list needed. When
+    // it did nothing, re-assembling would have rebuilt a byte-identical prompt.
+    if (compaction) {
+      compactedPrompt = assemblePrompt({
+        history: [...history, compaction],
+        userMessage: input.text,
+        attachments: input.attachments,
+        permissions,
+        context: promptContext
+      })
+    }
   } catch (error) {
     // A failed or empty summarization must not become a 'compacted' marker —
     // compactedHistory replaces all prior history with the summary, so a bad
@@ -136,17 +155,6 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
     logger.warn('Conversation compaction failed; skipping compaction for this turn', error)
     trackMainError('agent', 'compact_summarize', error)
   }
-
-  history = deps.messages
-    .listByConversation(input.conversationId)
-    .filter((message) => message.id !== user.id)
-  const compactedPrompt = assemblePrompt({
-    history,
-    userMessage: input.text,
-    attachments: input.attachments,
-    permissions,
-    context: promptContext
-  })
 
   const rawSub = await backend.runTurn({
     prompt: compactedPrompt,

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -72,6 +72,12 @@ that output is written to the local log, the conversation falls back to a title 
 first message, and the turn continues with its history uncompacted — your message and the
 conversation are never lost.
 
+Conversation history is stored encrypted, so every message you send has to decrypt the transcript
+before the agent can see it. memrynote reads and decrypts that history once per message and reuses it
+for the rest of the turn, so sending a message into a long conversation costs the same single pass
+whether or not the turn also compacts. Long conversations stay responsive instead of getting slower
+with every reply.
+
 While a turn runs, its tool calls collapse into a single activity row instead of stacking one row per
 step, so a long turn no longer pushes the answer off screen. The row names the tool the agent is
 running, counts the steps so far, and shows a spinner until the turn ends. Once the turn is done the


### PR DESCRIPTION
Closes #1064. Part of epic #987 (memory & CPU audit 2026-08).

## What was wrong

`runTurn` listed the full conversation transcript **three times per message**, and a fourth time when compaction ran:

- `apps/desktop/src/main/agent/runtime/turn.ts:56` — for the "should I generate a title?" heuristic
- `apps/desktop/src/main/agent/runtime/turn.ts:104` — to build the prompt
- `apps/desktop/src/main/agent/runtime/turn.ts:140` — to rebuild the prompt after compaction
- `apps/desktop/src/main/agent/runtime/compactor.ts:19` — `maybeCompact` re-listed on its own

Each list runs `agentMessageRowToModel` over every row (`apps/desktop/src/main/agent/storage/message-store.ts:185-193`), which is **two AEAD opens + two `JSON.parse`s + a zod parse per message**. So the per-message cost was a multiple of O(history) and grew with conversation length.

`assemblePrompt` also ran twice unconditionally (`turn.ts:108` and `turn.ts:143`) — sorting and string-joining the entire transcript a second time to produce a byte-identical prompt whenever `maybeCompact` did nothing, which is the common case.

Measured on the pre-fix code by the new regression tests:

```
AssertionError: expected "listByConversation" to be called 1 times, but got 3 times
AssertionError: expected "listByConversation" to be called 1 times, but got 4 times
```

## What changed

- **`turn.ts`** — list once at the top of the turn and thread that array through. The pre-append list is exactly the old `list().filter(id !== user.id)`, so the prompt history is unchanged.
- **`compactor.ts`** — `maybeCompact` takes the caller's already-decrypted `history` instead of re-listing, and returns the compaction marker it appended (or `null`). It copies before sorting so it does not sort the caller's array out from under the rest of the turn.
- **`turn.ts`** — compaction only ever *appends* a marker, so the post-compaction history is the pre-compaction one plus that marker. The second `assemblePrompt` is rebuilt from that and **skipped entirely when no compaction happened**.

Net: 3 lists → 1 (4 → 1 when compacting), and 2 full prompt assembles → 1 on the common path.

Behavior is unchanged: no contract, IPC, schema, or on-disk format touched, so nothing to migrate and older installs are unaffected.

## Security

**No decrypted history is cached.** The fix removes redundant decrypts rather than memoizing them, so there is no new cache to scope or invalidate, no vault-close/switch or conversation-delete invalidation surface, and no plaintext written anywhere new. The plaintext lifetime is unchanged and its footprint is strictly *smaller* than before — two of the three duplicate plaintext transcript copies per turn are gone.

## Verification

New regression tests (fail before, pass after):

- `turn.test.ts` — "lists and decrypts the conversation history once per turn" (was 3) and "lists the conversation history once even when compaction appends a marker" (was 4). Both also assert the prompt still carries the full transcript / the compaction summary, so the count assertion cannot be satisfied by dropping history.
- `compactor.test.ts` — `maybeCompact` never calls `listByConversation`, does not mutate the caller's array, and returns the appended marker / `null`.

These test the main-process units directly, not through mocked IPC.

```
$ pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/agent/runtime
 Test Files  15 passed (15)
      Tests  104 passed (104)

$ pnpm --filter @memry/desktop typecheck:node
$ pnpm exec tsc --noEmit -p tsconfig.node.json --composite false   # clean

$ pnpm exec eslint <changed files>
✖ 2 problems (0 errors, 2 warnings)   # both "file ignored by config" on the test files

$ git diff --check                     # clean
$ pnpm docs:impact --base origin/main --strict
docs impact: covered against origin/main
$ pnpm docs:build
build complete in 3.75s.
```


## One deliberate semantic narrowing

The prompt history is now snapshotted when the turn starts rather than re-read after compaction. `agent_messages` rows can also arrive from sync (another device), so in principle a remote message landing during the compaction subprocess would previously have slipped into the prompt and now will not.

This is incidental rather than designed behavior — the old code took a point-in-time snapshot too, just a slightly later one, and the pre-compaction prompt at `turn.ts:108` never saw those messages either. Snapshotting at send time is arguably the more predictable of the two. Nothing is lost or dropped: the message is persisted normally and appears in the next turn's history.
