### PR TITLE
perf(sync): throttle attachment progress and key it per transfer

### DIFF
--- a/apps/desktop/src/main/ipc/sync-attachment-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/sync-attachment-handlers.test.ts
@@ -85,6 +85,24 @@ vi.mock('../sync/upload-queue', () => ({
   })
 }))
 
+// The outbox uploader is only reachable as a registered callback. Keep the real
+// module and just record what gets registered, so the uploader's own progress
+// wiring can be driven directly.
+type OutboxUploader = Parameters<
+  typeof import('../sync/attachment-outbox').registerOutboxUploader
+>[0]
+const outboxUploaders = vi.hoisted(() => [] as OutboxUploader[])
+vi.mock('../sync/attachment-outbox', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../sync/attachment-outbox')>()
+  return {
+    ...actual,
+    registerOutboxUploader: (...args: Parameters<typeof actual.registerOutboxUploader>): void => {
+      outboxUploaders.push(args[0])
+      actual.registerOutboxUploader(...args)
+    }
+  }
+})
+
 const mockOnSaved = vi.fn()
 const mockOnDownloadNeeded = vi.fn()
 const mockRemoveAll = vi.fn()
@@ -152,6 +170,7 @@ vi.mock('libsodium-wrappers-sumo', () => ({
 
 import {
   clearAttachmentState,
+  getCanvasAssetIO,
   registerAttachmentHandlers,
   unregisterAttachmentHandlers
 } from './sync-attachment-handlers'
@@ -185,6 +204,7 @@ describe('sync-attachment-handlers', () => {
       .mockReset()
       .mockResolvedValue({ attachmentId: 'attachment-1', sessionId: 'session-1' })
     attachmentMocks.queue.dispose.mockReset()
+    outboxUploaders.length = 0
     mockOnSaved.mockClear()
     mockOnDownloadNeeded.mockClear()
     mockRemoveAll.mockClear()
@@ -425,6 +445,70 @@ describe('sync-attachment-handlers', () => {
         }
       ]
     )
+  })
+
+  it('hands canvas asset uploads a fresh broadcaster and sends downloads straight to the service', async () => {
+    // #given the canvas asset IO bound over the shared singletons
+    const io = getCanvasAssetIO()
+    expect(io).not.toBeNull()
+
+    // #when two canvas uploads and a canvas download run through it
+    await io!.uploadAttachment('canvas-1', '/vault/attachments/canvas-1.png')
+    await io!.uploadAttachment('canvas-2', '/vault/attachments/canvas-2.png')
+    await io!.downloadAttachment('attachment-1', '/vault/attachments/canvas-1.png')
+
+    // #then each upload carries its own callback, never one shared instance
+    expect(attachmentMocks.queue.enqueue).toHaveBeenCalledWith(
+      'canvas-1',
+      '/vault/attachments/canvas-1.png',
+      expect.any(Function)
+    )
+    expect(attachmentMocks.queue.enqueue.mock.calls[0][2]).not.toBe(
+      attachmentMocks.queue.enqueue.mock.calls[1][2]
+    )
+    expect(attachmentMocks.service.downloadAttachment).toHaveBeenCalledWith(
+      'attachment-1',
+      '/vault/attachments/canvas-1.png'
+    )
+  })
+
+  it('gives the outbox uploader its own throttled progress broadcaster', async () => {
+    // #given the uploader registered with the attachment outbox
+    registerAttachmentHandlers()
+    const uploader = outboxUploaders.filter(Boolean).at(-1)
+    expect(uploader).toBeDefined()
+
+    // #when the outbox drains one queued attachment
+    await expect(uploader!('note-1', '/vault/attachments/outbox.pdf')).resolves.toEqual({
+      attachmentId: 'attachment-1'
+    })
+    expect(attachmentMocks.queue.enqueue).toHaveBeenCalledWith(
+      'note-1',
+      '/vault/attachments/outbox.pdf',
+      expect.any(Function)
+    )
+
+    // #then the broadcaster it was handed dedupes on its own state
+    const broadcaster = attachmentMocks.queue.enqueue.mock.calls[0][2] as (
+      progress: TransferProgress
+    ) => void
+    const halfway: TransferProgress = {
+      attachmentId: 'attachment-1',
+      phase: 'uploading',
+      chunksCompleted: 1,
+      totalChunks: 2,
+      bytesTransferred: 1,
+      totalBytes: 2
+    }
+    broadcaster(halfway)
+    broadcaster({ ...halfway })
+
+    expect(attachmentMocks.sent.filter((e) => e.channel === SYNC_EVENTS.UPLOAD_PROGRESS)).toEqual([
+      {
+        channel: SYNC_EVENTS.UPLOAD_PROGRESS,
+        payload: { attachmentId: 'attachment-1', sessionId: '', progress: 50, status: 'uploading' }
+      }
+    ])
   })
 
   it('maps download progress and uploads saved attachments from event callbacks', async () => {

--- a/apps/desktop/src/main/ipc/sync-attachment-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/sync-attachment-handlers.test.ts
@@ -163,7 +163,7 @@ import {
   recordUploadedAttachment
 } from '../sync/note-attachment-metadata'
 import { markWritebackIgnored } from '../sync/crdt-writeback'
-import { AttachmentTooLargeError } from '../sync/attachments'
+import { AttachmentTooLargeError, type TransferProgress } from '../sync/attachments'
 import { SyncServerError } from '../sync/http-client'
 import { setCachedEntitlementFromStatus, getCachedMaxFileSize } from '../billing/entitlement-cache'
 import type { BillingStatus } from '../billing/paddle-billing'
@@ -283,7 +283,7 @@ describe('sync-attachment-handlers', () => {
     })
   })
 
-  it('downloads only inside the vault attachments directory and clears progress callbacks', async () => {
+  it('downloads only inside the vault attachments directory with a per-transfer progress callback', async () => {
     vi.mocked(getValidAccessToken).mockResolvedValue('token-1')
     vi.mocked(getVaultStatus).mockReturnValue({ path: '/vault' } as any)
     registerAttachmentHandlers()
@@ -297,9 +297,12 @@ describe('sync-attachment-handlers', () => {
 
     expect(attachmentMocks.service.downloadAttachment).toHaveBeenCalledWith(
       'attachment-1',
-      '/vault/attachments/file.pdf'
+      '/vault/attachments/file.pdf',
+      { onProgress: expect.any(Function) }
     )
-    expect(attachmentMocks.service.setProgressCallback).toHaveBeenLastCalledWith(null)
+    // The shared slot is never touched, so nothing can clear a concurrent
+    // transfer's progress.
+    expect(attachmentMocks.service.setProgressCallback).not.toHaveBeenCalled()
 
     await expect(
       invokeHandler(SYNC_CHANNELS.DOWNLOAD_ATTACHMENT, {
@@ -310,6 +313,118 @@ describe('sync-attachment-handlers', () => {
       success: false,
       error: 'Target path must be within the vault attachments directory'
     })
+  })
+
+  it('collapses per-chunk upload progress to whole-percent changes and still delivers 100%', async () => {
+    // #given an upload whose progress callback is captured from the queue
+    vi.mocked(getValidAccessToken).mockResolvedValue('token-1')
+    let onProgress: ((progress: TransferProgress) => void) | null = null
+    attachmentMocks.queue.enqueue.mockImplementation(
+      async (_noteId: string, _filePath: string, cb: (progress: TransferProgress) => void) => {
+        onProgress = cb
+        return { attachmentId: 'attachment-1', sessionId: 'session-1' }
+      }
+    )
+    registerAttachmentHandlers()
+
+    await invokeHandler(SYNC_CHANNELS.UPLOAD_ATTACHMENT, {
+      noteId: 'note-1',
+      filePath: '/vault/attachments/big.bin'
+    })
+    expect(onProgress).not.toBeNull()
+
+    // #when 500 chunks complete, one event each
+    const totalChunks = 500
+    for (let i = 1; i <= totalChunks; i++) {
+      onProgress!({
+        attachmentId: 'attachment-1',
+        phase: 'uploading',
+        chunksCompleted: i,
+        totalChunks,
+        bytesTransferred: i,
+        totalBytes: totalChunks
+      })
+    }
+
+    // #then at most one broadcast per distinct whole percent
+    const events = attachmentMocks.sent.filter((e) => e.channel === SYNC_EVENTS.UPLOAD_PROGRESS)
+    expect(events.length).toBeLessThanOrEqual(101)
+    const percents = events.map((e) => (e.payload as { progress: number }).progress)
+    expect(new Set(percents).size).toBe(percents.length)
+    // #then the terminal event still reaches the UI
+    expect(events.at(-1)?.payload).toEqual({
+      attachmentId: 'attachment-1',
+      sessionId: '',
+      progress: 100,
+      status: 'uploading'
+    })
+  })
+
+  it('gives each concurrent download its own progress callback and throttle state', async () => {
+    // #given a slow download that is still in flight when a second one finishes
+    vi.mocked(getValidAccessToken).mockResolvedValue('token-1')
+    const callbacks = new Map<string, (progress: TransferProgress) => void>()
+    let releaseSlow: (() => void) | null = null
+    attachmentMocks.service.downloadAttachment.mockImplementation(
+      async (
+        attachmentId: string,
+        _targetPath: string,
+        opts?: { onProgress?: (progress: TransferProgress) => void }
+      ) => {
+        if (opts?.onProgress) callbacks.set(attachmentId, opts.onProgress)
+        if (attachmentId === 'attachment-slow') {
+          await new Promise<void>((resolve) => {
+            releaseSlow = resolve
+          })
+        }
+        return { filePath: `/tmp/${attachmentId}.pdf` }
+      }
+    )
+    registerAttachmentHandlers()
+
+    const slow = invokeHandler(SYNC_CHANNELS.DOWNLOAD_ATTACHMENT, {
+      attachmentId: 'attachment-slow',
+      targetPath: '/tmp/slow.pdf'
+    })
+    await expect(
+      invokeHandler(SYNC_CHANNELS.DOWNLOAD_ATTACHMENT, {
+        attachmentId: 'attachment-fast',
+        targetPath: '/tmp/fast.pdf'
+      })
+    ).resolves.toEqual({ success: true, filePath: '/tmp/attachment-fast.pdf' })
+
+    // #then both transfers hold distinct callbacks, not one shared slot
+    expect(callbacks.size).toBe(2)
+    expect(callbacks.get('attachment-slow')).not.toBe(callbacks.get('attachment-fast'))
+    expect(attachmentMocks.service.setProgressCallback).not.toHaveBeenCalled()
+
+    // #when both report the same percent, after one transfer already finished
+    const halfway = (attachmentId: string): TransferProgress => ({
+      attachmentId,
+      phase: 'downloading',
+      chunksCompleted: 5,
+      totalChunks: 10,
+      bytesTransferred: 5,
+      totalBytes: 10
+    })
+    callbacks.get('attachment-fast')!(halfway('attachment-fast'))
+    callbacks.get('attachment-slow')!(halfway('attachment-slow'))
+    releaseSlow?.()
+    await expect(slow).resolves.toEqual({ success: true, filePath: '/tmp/attachment-slow.pdf' })
+
+    // #then neither transfer swallowed the other's event
+    expect(attachmentMocks.sent.filter((e) => e.channel === SYNC_EVENTS.DOWNLOAD_PROGRESS)).toEqual(
+      [
+        {
+          channel: SYNC_EVENTS.DOWNLOAD_PROGRESS,
+          payload: { attachmentId: 'attachment-fast', progress: 50, status: 'downloading' }
+        },
+        {
+          channel: SYNC_EVENTS.DOWNLOAD_PROGRESS,
+          payload: { attachmentId: 'attachment-slow', progress: 50, status: 'downloading' }
+        }
+      ]
+    )
   })
 
   it('maps download progress and uploads saved attachments from event callbacks', async () => {

--- a/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
+++ b/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
@@ -18,6 +18,7 @@ import {
 import {
   AttachmentSyncService,
   AttachmentTooLargeError,
+  type ProgressCallback,
   type TransferProgress,
   type UploadResult
 } from '../sync/attachments'
@@ -77,18 +78,54 @@ const getOrCreateUploadQueue = (): UploadQueue | null => {
   return uploadQueue
 }
 
-const broadcastUploadProgress = (progress: TransferProgress): void => {
-  const percent =
-    progress.totalChunks > 0
-      ? Math.round((progress.chunksCompleted / progress.totalChunks) * 100)
-      : 0
-  broadcastToAllWindows(SYNC_EVENTS.UPLOAD_PROGRESS, {
-    attachmentId: progress.attachmentId,
-    sessionId: '',
-    progress: percent,
-    status: progress.phase
-  })
+/**
+ * Wrap a progress sink so it only fires when the broadcast payload would
+ * actually change.
+ *
+ * Progress fires once per chunk: a 500-chunk transfer produced 500 structured
+ * clones to every window for ~100 distinct percent values. The payload is only
+ * (attachmentId, whole percent, phase), so an event repeating the previous
+ * percent AND phase is byte-for-byte what the UI already has — dropping it
+ * cannot leave anything stuck. The final 100% still goes out, because the first
+ * chunk that rounds to 100 is a change like any other.
+ *
+ * The dedupe state is created per transfer, never module-level — a shared slot
+ * would make two concurrent transfers suppress each other's events.
+ */
+const throttlePerTransfer = (
+  send: (percent: number, progress: TransferProgress) => void
+): ProgressCallback => {
+  let lastKey: string | null = null
+  return (progress) => {
+    const percent =
+      progress.totalChunks > 0
+        ? Math.round((progress.chunksCompleted / progress.totalChunks) * 100)
+        : 0
+    const key = `${progress.phase}:${percent}`
+    if (key === lastKey) return
+    lastKey = key
+    send(percent, progress)
+  }
 }
+
+const createUploadProgressBroadcaster = (): ProgressCallback =>
+  throttlePerTransfer((percent, progress) => {
+    broadcastToAllWindows(SYNC_EVENTS.UPLOAD_PROGRESS, {
+      attachmentId: progress.attachmentId,
+      sessionId: '',
+      progress: percent,
+      status: progress.phase
+    })
+  })
+
+const createDownloadProgressBroadcaster = (): ProgressCallback =>
+  throttlePerTransfer((percent, progress) => {
+    broadcastToAllWindows(SYNC_EVENTS.DOWNLOAD_PROGRESS, {
+      attachmentId: progress.attachmentId,
+      progress: percent,
+      status: progress.phase
+    })
+  })
 
 const getOrCreateAttachmentService = (): AttachmentSyncService | null => {
   if (attachmentService) return attachmentService
@@ -154,7 +191,7 @@ export function getCanvasAssetIO(): {
   if (!queue || !service) return null
   return {
     uploadAttachment: (canvasId, filePath) =>
-      queue.enqueue(canvasId, filePath, broadcastUploadProgress),
+      queue.enqueue(canvasId, filePath, createUploadProgressBroadcaster()),
     downloadAttachment: async (attachmentId, targetPath) => {
       await service.downloadAttachment(attachmentId, targetPath)
     }
@@ -186,7 +223,11 @@ export function registerAttachmentHandlers(): void {
         return { success: false, error: getMainI18n().t('errors:sync.engineNotInitialized') }
 
       try {
-        const result = await queue.enqueue(input.noteId, input.filePath, broadcastUploadProgress)
+        const result = await queue.enqueue(
+          input.noteId,
+          input.filePath,
+          createUploadProgressBroadcaster()
+        )
         return { success: true, attachmentId: result.attachmentId, sessionId: result.sessionId }
       } catch (err) {
         logger.error('Attachment upload failed', err)
@@ -228,18 +269,6 @@ export function registerAttachmentHandlers(): void {
       if (!service)
         return { success: false, error: getMainI18n().t('errors:sync.engineNotInitialized') }
 
-      service.setProgressCallback((progress) => {
-        const percent =
-          progress.totalChunks > 0
-            ? Math.round((progress.chunksCompleted / progress.totalChunks) * 100)
-            : 0
-        broadcastToAllWindows(SYNC_EVENTS.DOWNLOAD_PROGRESS, {
-          attachmentId: progress.attachmentId,
-          progress: percent,
-          status: progress.phase
-        })
-      })
-
       try {
         const targetPath = input.targetPath ?? ''
         if (!targetPath) return { success: false, error: 'Target path is required' }
@@ -256,14 +285,14 @@ export function registerAttachmentHandlers(): void {
           }
         }
 
-        const result = await service.downloadAttachment(input.attachmentId, targetPath)
+        const result = await service.downloadAttachment(input.attachmentId, targetPath, {
+          onProgress: createDownloadProgressBroadcaster()
+        })
         return { success: true, filePath: result.filePath }
       } catch (err) {
         logger.error('Attachment download failed', err)
         trackMainError('sync_attachments', 'attachment_download_failed', err)
         return { success: false, error: err instanceof Error ? err.message : String(err) }
-      } finally {
-        service.setProgressCallback(null)
       }
     },
     'errors:attachment.downloadFailed'
@@ -294,7 +323,7 @@ export function registerAttachmentHandlers(): void {
     async (noteId, diskPath) => {
       const queue = getOrCreateUploadQueue()
       if (!queue) throw new Error('Sync not initialized')
-      const result = await queue.enqueue(noteId, diskPath, broadcastUploadProgress)
+      const result = await queue.enqueue(noteId, diskPath, createUploadProgressBroadcaster())
       return { attachmentId: result.attachmentId }
     },
     () => getDatabase(),
@@ -320,7 +349,7 @@ export function registerAttachmentHandlers(): void {
       const queue = getOrCreateUploadQueue()
       if (!queue) return
       try {
-        const result = await queue.enqueue(noteId, diskPath, broadcastUploadProgress)
+        const result = await queue.enqueue(noteId, diskPath, createUploadProgressBroadcaster())
         if (isDatabaseInitialized()) {
           recordUploadedAttachment(noteId, result.attachmentId)
           // Outbox cleanup must never turn a successful upload into a failure.

--- a/apps/desktop/src/main/sync/attachments.test.ts
+++ b/apps/desktop/src/main/sync/attachments.test.ts
@@ -651,6 +651,25 @@ describe('AttachmentSyncService', () => {
       expect(path.dirname(result.filePath)).toBe(dir)
       expect(result.filePath.includes('..')).toBe(false)
     })
+
+    it('reports progress to the per-call callback instead of the shared slot', async () => {
+      // #given a transfer that passes its own callback while the shared slot is set
+      const { deps } = buildDownloadFixture('per-call.pdf')
+      const service = new AttachmentSyncService(deps)
+      const shared: string[] = []
+      const perCall: string[] = []
+      service.setProgressCallback((p) => shared.push(p.attachmentId))
+
+      // #when
+      await service.downloadAttachment('att-dir', path.join(tmpDir, 'per-call.pdf'), {
+        onProgress: (p) => perCall.push(p.attachmentId)
+      })
+
+      // #then only the caller that owns this transfer hears about it — a second
+      // concurrent download can no longer clobber or silence this one
+      expect(perCall).toEqual(['att-dir'])
+      expect(shared).toEqual([])
+    })
   })
 
   describe('progress tracking', () => {

--- a/apps/desktop/src/main/sync/attachments.ts
+++ b/apps/desktop/src/main/sync/attachments.ts
@@ -471,9 +471,13 @@ export class AttachmentSyncService {
   async downloadAttachment(
     attachmentId: string,
     targetPath: string,
-    opts?: { targetIsDir?: boolean }
+    opts?: { targetIsDir?: boolean; onProgress?: ProgressCallback }
   ): Promise<DownloadResult> {
     const [token, vaultKey] = await this.requireAuth()
+    // Per-call callback wins over the shared slot, mirroring uploadAttachment:
+    // two concurrent downloads that both went through the singleton clobbered
+    // each other, and whichever finished first cleared it for the survivor.
+    const emit = (p: TransferProgress): void => (opts?.onProgress ?? this.onProgress)?.(p)
 
     log.info('starting download', { attachmentId })
 
@@ -549,7 +553,7 @@ export class AttachmentSyncService {
         downloadProgress.chunksCompleted++
         downloadProgress.bytesTransferred = bytesDownloaded
         downloadProgress.phase = 'decrypting'
-        this.emitProgress({ ...downloadProgress })
+        emit({ ...downloadProgress })
       })
 
       const reassembled = Buffer.concat(decryptedChunks)
@@ -868,10 +872,6 @@ export class AttachmentSyncService {
     if (!signingKeys) throw new Error('Device keys not available')
 
     return [token, vaultKey, signingKeys]
-  }
-
-  private emitProgress(progress: TransferProgress): void {
-    this.onProgress?.(progress)
   }
 
   private async atomicWriteBinary(filePath: string, data: Buffer): Promise<void> {

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -102,3 +102,9 @@ Files that are no longer referenced by any note are pruned during periodic vacuu
 ## Sync Behavior
 
 Attachment payloads sync as encrypted R2 blobs (the same path as note bodies). Large files don't block notes — sync interleaves uploads and prioritizes metadata.
+
+### Transfer Progress
+
+Transfers report progress as a whole percentage, updating only when that percentage changes rather than on every chunk — a large file moves through the same 0–100% either way, without flooding the interface. Every transfer finishes on 100%.
+
+Several attachments can upload and download at once, and each one tracks its own progress. One transfer finishing never stops another that is still running from reporting.


### PR DESCRIPTION
Part of epic #987 (memory/CPU audit 2026-08). Closes #1062.

## What was wrong

**Unthrottled fan-out.** `apps/desktop/src/main/ipc/sync-attachment-handlers.ts:80-91` (upload) and `:232-241` (download) broadcast progress once per chunk to every window with no dedupe. A 500-chunk transfer produced 500 structured clones for ~100 distinct percent values. The payload only carries `(attachmentId, whole percent, phase)`, so ~80% of those sends were byte-for-byte identical to the one before.

**Concurrent downloads clobbered each other.** `:231` mutated the shared `AttachmentSyncService` singleton's progress slot per invoke. Two concurrent downloads overwrote each other's callback, and the `service.setProgressCallback(null)` in the `finally` at `:266` killed progress for whichever transfer was still running — its UI sat frozen mid-progress until completion.

## What changed

- `AttachmentSyncService.downloadAttachment` takes `opts.onProgress`, mirroring the per-call callback `uploadAttachment` already had (`attachments.ts:266`). Per-call wins over the shared slot; `setProgressCallback` is untouched and still works, so nothing else that relies on it breaks. The now-orphaned private `emitProgress` helper is gone.
- The download handler passes a fresh broadcaster per invoke and never touches the shared slot, so the `finally` that nulled it is gone too.
- `throttlePerTransfer` wraps a progress sink and drops any event repeating the previous `(phase, whole percent)`. Because the payload holds nothing else, a dropped event is exactly what the UI already has. The terminal event still lands: the first chunk that rounds to 100 is a change like any other, so 100% is always broadcast.
- Throttle state is created per transfer at each of the 5 call sites (4 upload paths + download), never module-level — a shared counter would let one transfer suppress another's events.
- Broadcasts keep going through `broadcastToAllWindows`, which already skips destroyed windows and contains per-window send failures (#935).

No contract, protocol, schema, or settings change. `pnpm ipc:generate` produced no diff. Event payload shapes on `sync:upload-progress` / `sync:download-progress` are identical — only their frequency changed — so older renderers are unaffected.

## Verification

4 new/updated regression tests, all failing before the fix and passing after. Stashing only the two source files (tests untouched):

```
× ... downloads only inside the vault attachments directory with a per-transfer progress callback
  → expected "vi.fn()" to be called with arguments: [ 'attachment-1', …(2) ]
× ... collapses per-chunk upload progress to whole-percent changes and still delivers 100%
  → expected 500 to be less than or equal to 101
× ... gives each concurrent download its own progress callback and throttle state
  → expected +0 to be 2
× AttachmentSyncService > ... > reports progress to the per-call callback instead of the shared slot
  → expected [] to deeply equal [ 'att-dir' ]
 Tests  4 failed | 37 passed (41)
```

With the fix in place:

```
pnpm exec vitest run --config config/vitest.config.ts --project main \
  src/main/ipc/sync-attachment-handlers.test.ts src/main/sync/attachments.test.ts
 Test Files  2 passed (2)
      Tests  41 passed (41)
```

The 500-chunk case is the issue's own acceptance criterion: 500 events before, 101 after (0–100 inclusive), last event `progress: 100`. The concurrency test asserts both transfers hold distinct callbacks, that `setProgressCallback` is never called, and that a transfer finishing does not swallow the survivor's events.

Also green: `pnpm --filter @memry/desktop typecheck:node`, `pnpm exec eslint` on the changed source (0 errors), `pnpm ipc:generate && pnpm ipc:check` (up to date), `git diff --check`, `pnpm docs:impact --base origin/main --strict` (covered), `pnpm docs:build`.

## Note

The `attachmentEvents.onDownloadNeeded` path (embedded attachments materializing on note open) still passes no progress callback, so it broadcasts nothing. Before this change it only reported progress by accident — when an unrelated explicit download happened to have the shared slot set. Wiring it deliberately is a behavior change beyond this issue; left out on purpose.
