### PR TITLE
perf(sync): stop scanning the queue per enqueue and SQLite per pause check

### DIFF
--- a/apps/desktop/src/main/sync/engine/sync-state-manager.test.ts
+++ b/apps/desktop/src/main/sync/engine/sync-state-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { eq } from 'drizzle-orm'
-import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import { createTestDataDb, trackPreparedSql, type TestDatabaseResult } from '@tests/utils/test-db'
 import { SyncStateManager, type NodeEmit } from './sync-state-manager'
 import { SYNC_STATE_KEYS, CLOCK_SKEW_THRESHOLD_SECONDS } from './sync-context'
 import type { SyncContext } from './sync-context'
@@ -107,6 +107,64 @@ describe('SyncStateManager', () => {
   describe('#given no SYNC_PAUSED key in DB #when isPaused called', () => {
     it('#then returns false', () => {
       // #when / #then
+      expect(mgr.isPaused()).toBe(false)
+    })
+  })
+
+  describe('#given sync is not paused #when isPaused called on every event', () => {
+    it('#then only the first call reads sync_state', () => {
+      // #given
+      const prepared = trackPreparedSql(testDb)
+      const syncStateReads = (): number =>
+        prepared.filter((s) => /from "sync_state"/.test(s)).length
+
+      // #when — stands in for a burst of WS messages / enqueues
+      for (let i = 0; i < 25; i++) {
+        expect(mgr.isPaused()).toBe(false)
+      }
+
+      // #then
+      expect(syncStateReads()).toBe(1)
+    })
+  })
+
+  describe('#given isPaused was answered from cache #when sync is paused', () => {
+    it('#then the very next isPaused reports paused', () => {
+      // #given
+      expect(mgr.isPaused()).toBe(false)
+
+      // #when
+      mgr.setStateValue(SYNC_STATE_KEYS.SYNC_PAUSED, 'true')
+
+      // #then
+      expect(mgr.isPaused()).toBe(true)
+    })
+  })
+
+  describe('#given sync is paused #when resumed', () => {
+    it('#then the very next isPaused reports not paused', () => {
+      // #given
+      mgr.setStateValue(SYNC_STATE_KEYS.SYNC_PAUSED, 'true')
+      expect(mgr.isPaused()).toBe(true)
+
+      // #when
+      mgr.setStateValue(SYNC_STATE_KEYS.SYNC_PAUSED, 'false')
+
+      // #then
+      expect(mgr.isPaused()).toBe(false)
+    })
+  })
+
+  describe('#given sync is paused #when the row is dropped outside the manager', () => {
+    it('#then isPaused re-reads and stops reporting paused', () => {
+      // #given — emergency wipe / teardown / re-registration delete rows directly
+      mgr.setStateValue(SYNC_STATE_KEYS.SYNC_PAUSED, 'true')
+      expect(mgr.isPaused()).toBe(true)
+
+      // #when
+      testDb.db.delete(syncState).where(eq(syncState.key, SYNC_STATE_KEYS.SYNC_PAUSED)).run()
+
+      // #then
       expect(mgr.isPaused()).toBe(false)
     })
   })

--- a/apps/desktop/src/main/sync/engine/sync-state-manager.ts
+++ b/apps/desktop/src/main/sync/engine/sync-state-manager.ts
@@ -22,6 +22,22 @@ export class SyncStateManager {
   private ctx: SyncContext
   private nodeEmit: NodeEmit
 
+  /**
+   * `true` once a read (or a write through `setStateValue`) has proved sync is
+   * NOT paused. `isPaused` is asked on every WS message, every enqueue and
+   * every pull tick, and answering it from SQLite each time is a table lookup
+   * per event.
+   *
+   * Only the negative answer is cached, deliberately. `sync_state` rows are
+   * also mutated outside this class — the emergency wipe, session teardown and
+   * device re-registration all delete rows directly — but every one of those
+   * paths only ever *removes* `syncPaused`, and a missing row means "not
+   * paused". So a cached `false` can never become wrong, while a cached `true`
+   * could; paused therefore always re-reads. That costs nothing in practice,
+   * because paused is exactly the state in which every hot caller stops early.
+   */
+  private knownNotPaused = false
+
   constructor(ctx: SyncContext, nodeEmit: NodeEmit) {
     this.ctx = ctx
     this.nodeEmit = nodeEmit
@@ -48,7 +64,10 @@ export class SyncStateManager {
   }
 
   isPaused(): boolean {
-    return this.getStateValue(SYNC_STATE_KEYS.SYNC_PAUSED) === 'true'
+    if (this.knownNotPaused) return false
+    const paused = this.getStateValue(SYNC_STATE_KEYS.SYNC_PAUSED) === 'true'
+    this.knownNotPaused = !paused
+    return paused
   }
 
   getStateValue(key: string): string | undefined {
@@ -57,6 +76,11 @@ export class SyncStateManager {
   }
 
   setStateValue(key: string, value: string): void {
+    // Write-through: every pause and resume in the app lands here, so the
+    // cached answer flips with the row rather than after it.
+    if (key === SYNC_STATE_KEYS.SYNC_PAUSED) {
+      this.knownNotPaused = value !== 'true'
+    }
     this.ctx.deps.db
       .insert(syncState)
       .values({ key, value, updatedAt: new Date() })

--- a/apps/desktop/src/main/sync/queue.test.ts
+++ b/apps/desktop/src/main/sync/queue.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import { syncQueue } from '@memry/db-schema/schema/sync-queue'
+import { createTestDataDb, trackPreparedSql, type TestDatabaseResult } from '@tests/utils/test-db'
 import { DEFAULT_MAX_ATTEMPTS, SyncQueueManager, type EnqueueInput } from './queue'
 
 const makeInput = (overrides: Partial<EnqueueInput> = {}): EnqueueInput => ({
@@ -341,6 +342,68 @@ describe('SyncQueueManager', () => {
       const items = queue.peek(1)
       expect(items[0].attempts).toBe(3)
       expect(items[0].errorMessage).toBe('err-3')
+    })
+  })
+
+  describe('auto-purge on enqueue', () => {
+    function seedDeadLetters(count: number, createdAt: Date): void {
+      for (let i = 0; i < count; i++) {
+        testDb.db
+          .insert(syncQueue)
+          .values({
+            id: `dead-${i}`,
+            type: 'note',
+            itemId: `item-dead-${i}`,
+            operation: 'update',
+            payload: '{}',
+            priority: 0,
+            attempts: DEFAULT_MAX_ATTEMPTS,
+            createdAt
+          })
+          .run()
+      }
+    }
+
+    it('does not count the queue on every enqueue', () => {
+      // #given
+      const prepared = trackPreparedSql(testDb)
+
+      // #when a burst of 100 items is queued
+      for (let i = 0; i < 100; i++) {
+        queue.enqueue(makeInput({ itemId: `burst-${i}` }))
+      }
+
+      // #then no aggregate scan of the queue is done for the purge threshold,
+      // and the bounded probe runs a fixed number of times, not per item
+      expect(prepared.filter((s) => /count\(\*\)/i.test(s))).toEqual([])
+      expect(prepared.filter((s) => /OFFSET/i.test(s)).length).toBeLessThanOrEqual(3)
+    })
+
+    it('still purges expired dead-letter items once the threshold is reached', () => {
+      // #given 50 dead-lettered items older than the retention window
+      const longAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+      seedDeadLetters(50, longAgo)
+      const fresh = new SyncQueueManager(testDb.db)
+
+      // #when
+      fresh.enqueue(makeInput({ itemId: 'trigger' }))
+
+      // #then
+      expect(fresh.getQueueStats().deadLetter).toBe(0)
+      expect(fresh.getSize()).toBe(1)
+    })
+
+    it('keeps dead-letter items while below the threshold', () => {
+      // #given one short of the threshold
+      const longAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+      seedDeadLetters(49, longAgo)
+      const fresh = new SyncQueueManager(testDb.db)
+
+      // #when
+      fresh.enqueue(makeInput({ itemId: 'trigger' }))
+
+      // #then
+      expect(fresh.getQueueStats().deadLetter).toBe(49)
     })
   })
 

--- a/apps/desktop/src/main/sync/queue.ts
+++ b/apps/desktop/src/main/sync/queue.ts
@@ -14,6 +14,18 @@ export const DEFAULT_MAX_ATTEMPTS = 5
 const DEAD_LETTER_PURGE_THRESHOLD = 50
 export const ERROR_RETENTION_DAYS = 7
 
+/**
+ * How many enqueues may pass between two auto-purge probes.
+ *
+ * Purging dead-lettered rows older than ERROR_RETENTION_DAYS is housekeeping,
+ * not correctness: nothing reads those rows, and they can only accumulate at
+ * the pace of `markFailed`. Re-evaluating the threshold on every single
+ * enqueue therefore bought nothing and cost a scan of `sync_queue` per queued
+ * mutation, which a bulk import or an import-sized burst pays thousands of
+ * times. The probe runs on the first enqueue and every Nth one after that.
+ */
+const AUTO_PURGE_CHECK_EVERY_N_ENQUEUES = 50
+
 export interface EnqueueInput {
   type: SyncItemType
   itemId: string
@@ -50,6 +62,9 @@ export class SyncQueueManager {
   constructor(private readonly db: DataDb) {}
 
   private onItemEnqueued: (() => void) | null = null
+
+  /** Seeded at the interval so the very first enqueue still probes. */
+  private enqueuesSincePurgeCheck = AUTO_PURGE_CHECK_EVERY_N_ENQUEUES
 
   setOnItemEnqueued(callback: () => void): void {
     this.onItemEnqueued = callback
@@ -292,11 +307,26 @@ export class SyncQueueManager {
   }
 
   private maybeAutoPurge(): void {
-    const stats = this.getQueueStats()
-    if (stats.deadLetter >= DEAD_LETTER_PURGE_THRESHOLD) {
-      const sevenDaysAgo = new Date(Date.now() - ERROR_RETENTION_DAYS * 24 * 60 * 60 * 1000)
-      this.purgeOldErrors(sevenDaysAgo)
-    }
+    this.enqueuesSincePurgeCheck++
+    if (this.enqueuesSincePurgeCheck < AUTO_PURGE_CHECK_EVERY_N_ENQUEUES) return
+    this.enqueuesSincePurgeCheck = 0
+
+    if (!this.hasDeadLetterBacklog()) return
+    const sevenDaysAgo = new Date(Date.now() - ERROR_RETENTION_DAYS * 24 * 60 * 60 * 1000)
+    this.purgeOldErrors(sevenDaysAgo)
+  }
+
+  /**
+   * Whether at least DEAD_LETTER_PURGE_THRESHOLD rows have exhausted their
+   * retry budget. `LIMIT 1 OFFSET threshold-1` stops walking as soon as the
+   * threshold-th row is reached, so it never counts the rest of the table —
+   * and the exact dead-letter total was never used, only compared.
+   */
+  private hasDeadLetterBacklog(): boolean {
+    const row = this.db.get<{ found: number }>(
+      sql`SELECT 1 AS found FROM sync_queue WHERE attempts >= ${DEFAULT_MAX_ATTEMPTS} LIMIT 1 OFFSET ${DEAD_LETTER_PURGE_THRESHOLD - 1}`
+    )
+    return row !== undefined
   }
 
   getQueueStats(): QueueStats {

--- a/apps/desktop/tests/utils/test-db.ts
+++ b/apps/desktop/tests/utils/test-db.ts
@@ -43,6 +43,26 @@ export function asSyncDb(db: TestDb): SyncDrizzleDb {
   return db as unknown as SyncDrizzleDb
 }
 
+/**
+ * Record every SQL statement the given database prepares from now on.
+ *
+ * Drizzle prepares each query as it executes it, so the returned array is a
+ * running log of the statements a unit under test actually sent to SQLite —
+ * which is how a test asserts that a code path stopped hitting the database,
+ * rather than asserting on a mock that was told what to return.
+ *
+ * The patch lives on the per-test connection and dies with `close()`.
+ */
+export function trackPreparedSql(result: TestDatabaseResult): string[] {
+  const sources: string[] = []
+  const original = result.sqlite.prepare.bind(result.sqlite)
+  result.sqlite.prepare = ((source: string) => {
+    sources.push(source)
+    return original(source)
+  }) as typeof result.sqlite.prepare
+  return sources
+}
+
 // ============================================================================
 // Database Factory Functions
 // ============================================================================

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -173,6 +173,24 @@ Migration 0047 resets `attempts` to 0 for rows that an earlier build had already
 stranded by the old in-cycle spend are retried again after upgrading. It preserves the row, its
 payload, and its recorded error.
 
+### Dead-letter purge and the pause flag are kept off the enqueue path
+
+Rows that exhausted their budget are purged once at least 50 of them are older than
+`ERROR_RETENTION_DAYS`. Nothing reads those rows and they can only accumulate at the pace of a
+failing push, so the threshold is probed on the first enqueue and every fiftieth after that rather
+than on every one — and the probe is a bounded existence check, not a count of the table. A bulk
+import therefore no longer scans `sync_queue` once per queued mutation. The purge itself is
+unchanged: same threshold, same retention window, same deletion.
+
+Whether sync is paused is asked on every WebSocket message, every enqueue and every pull tick, so
+the answer is held in memory. Only the _not paused_ answer is cached. Pause and resume write through
+the state manager and flip the cached answer with the row, so they take effect on the next call.
+Paused always re-reads, because `sync_state` rows are also removed outside the manager — the
+emergency wipe, session teardown and device re-registration all delete them — and a removed
+`syncPaused` row can only mean "not paused". A cached `false` can never go stale that way; a cached
+`true` could. That extra read costs nothing, because paused is exactly the state in which every
+caller stops early.
+
 ### Recovering pushes that never landed
 
 Items expose a "the server has this state" stamp (`syncedAt`) that advances on a confirmed push as


### PR DESCRIPTION
Closes #1059. Part of epic #987 (Memory & CPU full-app performance audit 2026-08).

## What was wrong

Validated on current `main` (21d1dae9b) — both hot paths were still there.

**1. Four `COUNT(*)` scans of `sync_queue` per enqueue.**
`apps/desktop/src/main/sync/queue.ts:61` — every `enqueue` called `maybeAutoPurge()`, which called `getQueueStats()` (`queue.ts:302-328`): `getSize()` plus three more `count()` queries. All four totals were computed so that one of them could be compared against `DEAD_LETTER_PURGE_THRESHOLD = 50`. A bulk import paid four full table scans per queued mutation.

**2. A SQLite read per `isPaused()`.**
`apps/desktop/src/main/sync/engine/sync-state-manager.ts:50-57` — `isPaused()` went to `sync_state` on every call, with no cache. Callers: `engine.ts:633,669,675` (per WS message), `engine.ts:718` (per WS connect), `push-coordinator.ts:351,358` (per enqueue via `requestPush`), `pull-coordinator.ts:165,171` (per 60s tick), plus `engine.ts:211,234,530,768` and `full-sync-runner.ts:278`.

## What changed

**`queue.ts`** — the purge probe now runs on the first enqueue and every 50th after that, and uses a bounded existence check (`SELECT 1 ... WHERE attempts >= 5 LIMIT 1 OFFSET 49`) instead of counting the table. The exact dead-letter total was never used, only compared against the threshold. Purge threshold, retention window and deletion behaviour are unchanged; only the cadence of the *check* moved, and dead-letter rows can only accumulate at the pace of a failing push.

**`sync-state-manager.ts`** — caches the pause flag in memory, and deliberately caches **only the negative answer**:

- `setStateValue` writes through, so `pause()` / `resume()` / the clock-skew pause flip the cached answer with the row. The next `isPaused()` is correct — a paused queue can never drain on a stale `false`.
- A cached `true` is never trusted: `isPaused()` re-reads. `sync_state` rows are also mutated outside this class — `engine.ts:480` (emergency wipe), `session-teardown.ts:103`, `device-registration.ts:184` — and every one of those paths only ever *deletes* `syncPaused`, which can only mean "not paused". So a cached `false` cannot go stale, while a cached `true` could.

**Tradeoff, stated explicitly:** the correctness-preferring half of that design costs one `sync_state` read per `isPaused()` while sync is paused. That is free in practice, because paused is exactly the state in which every hot caller returns early — there is no hot loop to pay it. The alternative (cache both answers, invalidate from three unrelated modules) would have been faster while paused and one missed call site away from silently draining a paused queue.

No schema, contract, IPC or protocol change. Nothing persisted changes shape, so old and new installs behave identically.

## How it was verified

Tests assert against the SQL actually prepared on the better-sqlite3 connection (new `trackPreparedSql` helper in `apps/desktop/tests/utils/test-db.ts`), not against mocks:

- 25 `isPaused()` calls issue exactly **1** `sync_state` read.
- A 100-item enqueue burst issues **zero** `COUNT(*)` statements and at most 3 bounded probes.
- Regression guards: pause takes effect on the next `isPaused()`; resume takes effect on the next `isPaused()`; deleting the row behind the manager's back stops it reporting paused.
- Behaviour guards: 50 expired dead-letter rows still get purged on the next enqueue; 49 do not.

Both perf tests were confirmed to **fail** against unmodified sources and pass with the fix:

```
 × sync-state-manager.test.ts > ... > #then only the first call reads sync_state
 × queue.test.ts > auto-purge on enqueue > does not count the queue on every enqueue
 Tests  2 failed | 51 passed (53)
```

Local runs:

```
pnpm exec vitest run --config config/vitest.config.ts --project main src/main/sync
 Test Files  138 passed (138)
      Tests  1734 passed | 1 expected fail | 3 skipped (1738)

pnpm --filter @memry/desktop typecheck:node   # clean
pnpm exec eslint <changed files>              # 0 errors
git diff --check                              # clean
pnpm docs:impact --base origin/main --strict  # covered
pnpm docs:build                               # build complete
```