### PR TITLE
fix(sync): reset per-note write-back and CRDT maps on vault teardown

### DIFF
--- a/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
+++ b/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
@@ -48,7 +48,8 @@ vi.mock('./crdt-writeback', () => ({
   scheduleWriteback: vi.fn(),
   cancelPendingWritebacks: vi.fn(),
   flushPendingWritebacks: vi.fn(),
-  recordNetworkUpdate: vi.fn()
+  recordNetworkUpdate: vi.fn(),
+  resetWritebackState: vi.fn()
 }))
 vi.mock('./microtask-batch-broadcaster', () => ({
   MicrotaskBatchBroadcaster: class {

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -70,6 +70,7 @@ const mocks = vi.hoisted(() => {
     scheduleWriteback: vi.fn(),
     flushPendingWritebacks: vi.fn(),
     recordNetworkUpdate: vi.fn(),
+    resetWritebackState: vi.fn(),
     persistenceInstances: [] as Array<{
       getYDoc: ReturnType<typeof vi.fn>
       clearDocument: ReturnType<typeof vi.fn>
@@ -157,7 +158,8 @@ vi.mock('./crdt-compact-utils', () => ({
 vi.mock('./crdt-writeback', () => ({
   scheduleWriteback: (...args: unknown[]) => mocks.scheduleWriteback(...args),
   flushPendingWritebacks: (...args: unknown[]) => mocks.flushPendingWritebacks(...args),
-  recordNetworkUpdate: (...args: unknown[]) => mocks.recordNetworkUpdate(...args)
+  recordNetworkUpdate: (...args: unknown[]) => mocks.recordNetworkUpdate(...args),
+  resetWritebackState: (...args: unknown[]) => mocks.resetWritebackState(...args)
 }))
 
 vi.mock('./microtask-batch-broadcaster', () => ({
@@ -399,6 +401,9 @@ describe('CrdtProvider', () => {
     await provider.destroy()
     expect(mocks.flushPendingWritebacks).toHaveBeenCalled()
     expect(mocks.persistenceInstances[0].destroy).toHaveBeenCalled()
+    // Vault close / vault switch runs through here, so the write-back module's
+    // per-note maps must not carry this vault's ids into the next one.
+    expect(mocks.resetWritebackState).toHaveBeenCalled()
   })
 
   it('returns state vectors and diffs only for open docs', async () => {

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -9,7 +9,12 @@ import { getIndexDatabase } from '../database/client'
 import { getNoteCacheById } from '@main/database/queries/notes'
 import type { CrdtUpdateQueue } from './crdt-queue'
 import { MicrotaskBatchBroadcaster } from './microtask-batch-broadcaster'
-import { scheduleWriteback, flushPendingWritebacks, recordNetworkUpdate } from './crdt-writeback'
+import {
+  scheduleWriteback,
+  flushPendingWritebacks,
+  recordNetworkUpdate,
+  resetWritebackState
+} from './crdt-writeback'
 import { runCrdtPreflight } from './crdt-preflight'
 import { moveStoreDir } from './crdt-store-move'
 import { toAbsolutePath } from '../vault/notes'
@@ -466,6 +471,10 @@ export class CrdtProvider {
     this.openLocks.clear()
     this.updateQueue = null
     this.snapshotPushFn = null
+
+    // Write-back keeps its own module-level per-note maps, keyed by ids and
+    // absolute paths belonging to the vault being torn down here.
+    resetWritebackState()
 
     log.info('CrdtProvider destroyed')
   }

--- a/apps/desktop/src/main/sync/crdt-writeback.test.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.test.ts
@@ -131,10 +131,12 @@ import {
   cancelPendingWritebacks,
   flushPendingWritebacks,
   getWritebackDebugState,
+  getWritebackStateSizes,
   handleSyncDeletion,
   isWritebackIgnored,
   markWritebackIgnored,
   recordNetworkUpdate,
+  resetWritebackState,
   scheduleWriteback,
   wasRecentNetworkUpdate
 } from './crdt-writeback'
@@ -583,5 +585,77 @@ describe('crdt writeback', () => {
         options: { frontmatterEdited: true }
       })
     )
+  })
+})
+
+describe('crdt-writeback per-vault state reset', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetWritebackState()
+  })
+
+  afterEach(() => {
+    cancelPendingWritebacks()
+    resetWritebackState()
+    vi.useRealTimers()
+  })
+
+  it('drops ignored writes, network-update marks and debug state on vault teardown', () => {
+    // #given — a vault session that populated every module-level per-note map
+    markWritebackIgnored('/vault-a/notes/One.md')
+    recordNetworkUpdate('note-1')
+    scheduleWriteback('note-1', makeDoc('One'))
+
+    expect(isWritebackIgnored('/vault-a/notes/One.md')).toBe(true)
+    expect(wasRecentNetworkUpdate('note-1')).toBe(true)
+    expect(getWritebackDebugState('note-1')).not.toBeNull()
+
+    // #when — the vault is closed (CrdtProvider.destroy)
+    cancelPendingWritebacks()
+    resetWritebackState()
+
+    // #then — nothing from the old vault survives into the next one
+    expect(isWritebackIgnored('/vault-a/notes/One.md')).toBe(false)
+    expect(wasRecentNetworkUpdate('note-1')).toBe(false)
+    expect(getWritebackDebugState('note-1')).toBeNull()
+    expect(getWritebackStateSizes()).toEqual({
+      ignoredWrites: 0,
+      networkUpdates: 0,
+      debugState: 0
+    })
+  })
+
+  it('evicts expired network-update marks instead of keeping one per note forever', () => {
+    // #given — a note that received a network update
+    recordNetworkUpdate('note-old')
+    expect(wasRecentNetworkUpdate('note-old')).toBe(true)
+
+    // #when — the concurrent-edit window passes and any other note updates.
+    // `wasRecentNetworkUpdate('note-old')` is deliberately NOT called here: it
+    // used to be the only thing that ever deleted an entry, so a note nobody
+    // re-reads is exactly the case that leaked.
+    vi.advanceTimersByTime(2500)
+    recordNetworkUpdate('note-new')
+
+    // #then — only the fresh note is still held; the stale key was evicted
+    // rather than merely reported as expired
+    expect(getWritebackStateSizes().networkUpdates).toBe(1)
+    expect(wasRecentNetworkUpdate('note-old')).toBe(false)
+    expect(wasRecentNetworkUpdate('note-new')).toBe(true)
+  })
+
+  it('evicts expired ignored writes from the write path, not only from watcher reads', () => {
+    // #given — a write-back marked a file as self-written
+    markWritebackIgnored('/vault-a/notes/Old.md')
+
+    // #when — the TTL passes and another write-back lands, with no watcher event
+    // in between (a stopped watcher never calls `isWritebackIgnored`)
+    vi.advanceTimersByTime(6000)
+    markWritebackIgnored('/vault-a/notes/New.md')
+
+    // #then — the expired entry did not survive the session
+    expect(getWritebackStateSizes().ignoredWrites).toBe(1)
+    expect(isWritebackIgnored('/vault-a/notes/Old.md')).toBe(false)
+    expect(isWritebackIgnored('/vault-a/notes/New.md')).toBe(true)
   })
 })

--- a/apps/desktop/src/main/sync/crdt-writeback.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.ts
@@ -149,10 +149,29 @@ function journalIdToDate(journalId: string): string {
   return journalId.slice(1)
 }
 
+/**
+ * Amortized TTL eviction, at most one full pass per TTL window.
+ *
+ * Both maps below are keyed per file/per note and are only ever written, so
+ * they need a sweep to stay bounded — but the sweep must not run per call:
+ * `isWritebackIgnored` fires on every watcher file event, where an inline pass
+ * cost O(map) each time. Gating the pass on its own TTL keeps both maps to the
+ * entries written in the last two windows at amortized O(1) per call.
+ */
+function sweepExpired(entries: Map<string, number>, ttlMs: number, now: number): void {
+  for (const [key, ts] of entries) {
+    if (now - ts >= ttlMs) entries.delete(key)
+  }
+}
+
+let ignoredWritesSweptAt = 0
+let networkUpdatesSweptAt = 0
+
 export function isWritebackIgnored(absolutePath: string): boolean {
   const now = Date.now()
-  for (const [p, ts] of ignoredWrites) {
-    if (now - ts >= IGNORED_WRITE_TTL_MS) ignoredWrites.delete(p)
+  if (now - ignoredWritesSweptAt >= IGNORED_WRITE_TTL_MS) {
+    ignoredWritesSweptAt = now
+    sweepExpired(ignoredWrites, IGNORED_WRITE_TTL_MS, now)
   }
   const ts = ignoredWrites.get(absolutePath)
   if (!ts) return false
@@ -163,14 +182,36 @@ export function clearWritebackIgnore(_absolutePath: string): void {
   // no-op: auto-evicted by TTL in isWritebackIgnored
 }
 
+/**
+ * Sweeping on the write path too, so a stopped watcher (which is what stops
+ * `isWritebackIgnored` from being called at all) cannot leave the map growing
+ * one entry per written file for the rest of the session.
+ */
+function rememberIgnoredWrite(absolutePath: string): void {
+  const now = Date.now()
+  if (now - ignoredWritesSweptAt >= IGNORED_WRITE_TTL_MS) {
+    ignoredWritesSweptAt = now
+    sweepExpired(ignoredWrites, IGNORED_WRITE_TTL_MS, now)
+  }
+  ignoredWrites.set(absolutePath, now)
+}
+
 export function markWritebackIgnored(absolutePath: string): void {
-  ignoredWrites.set(absolutePath, Date.now())
+  rememberIgnoredWrite(absolutePath)
 }
 
 const CONCURRENT_EDIT_WINDOW_MS = 2000
 
 export function recordNetworkUpdate(noteId: string): void {
-  lastNetworkUpdateMs.set(noteId, Date.now())
+  const now = Date.now()
+  // Only `wasRecentNetworkUpdate` used to delete, and it is reached only when
+  // that note is edited externally on disk — so without this the map grew one
+  // entry per note ever received from the network, for the whole session.
+  if (now - networkUpdatesSweptAt >= CONCURRENT_EDIT_WINDOW_MS) {
+    networkUpdatesSweptAt = now
+    sweepExpired(lastNetworkUpdateMs, CONCURRENT_EDIT_WINDOW_MS, now)
+  }
+  lastNetworkUpdateMs.set(noteId, now)
 }
 
 export function wasRecentNetworkUpdate(noteId: string): boolean {
@@ -252,6 +293,40 @@ export function cancelPendingWritebacks(): void {
   }
   pendingTimers.clear()
   lastWritebackCost.clear()
+}
+
+/**
+ * Sizes of the module-level maps. Diagnostics only — the growth of these maps
+ * is the bug this bookkeeping exists to keep regression-testable, and neither
+ * `isWritebackIgnored` nor `wasRecentNetworkUpdate` can distinguish "entry
+ * expired" from "entry evicted", so a leak is otherwise unobservable.
+ */
+export function getWritebackStateSizes(): {
+  ignoredWrites: number
+  networkUpdates: number
+  debugState: number
+} {
+  return {
+    ignoredWrites: ignoredWrites.size,
+    networkUpdates: lastNetworkUpdateMs.size,
+    debugState: debugState.size
+  }
+}
+
+/**
+ * Drop every per-note/per-file map. These are module-level, so without this a
+ * vault switch would carry the previous vault's bookkeeping — paths and note
+ * ids that no longer exist here — into the next session, and each successive
+ * vault would add to it. Called from `CrdtProvider.destroy()`, which is the
+ * one point every vault close, vault switch and sync-runtime stop goes through.
+ */
+export function resetWritebackState(): void {
+  lastWritebackCost.clear()
+  ignoredWrites.clear()
+  lastNetworkUpdateMs.clear()
+  debugState.clear()
+  ignoredWritesSweptAt = 0
+  networkUpdatesSweptAt = 0
 }
 
 export async function flushPendingWritebacks(): Promise<void> {
@@ -385,7 +460,7 @@ async function writebackExisting(
     }
   }
 
-  ignoredWrites.set(absolutePath, Date.now())
+  rememberIgnoredWrite(absolutePath)
   await atomicWrite(absolutePath, fileContent)
 
   syncNoteToCache(
@@ -436,7 +511,7 @@ async function writebackNewNote(
   const { frontmatter } = mergeFrontmatter(null, doc)
   const fileContent = serializeNote(frontmatter, markdown)
 
-  ignoredWrites.set(absolutePath, Date.now())
+  rememberIgnoredWrite(absolutePath)
   await atomicWrite(absolutePath, fileContent)
 
   syncNoteToCache(
@@ -513,7 +588,7 @@ async function writebackJournal(
       }
     }
 
-    ignoredWrites.set(absolutePath, Date.now())
+    rememberIgnoredWrite(absolutePath)
     await atomicWrite(absolutePath, fileContent)
 
     syncNoteToCache(
@@ -552,7 +627,7 @@ async function writebackJournal(
   const { frontmatter } = mergeJournalFrontmatter(date, null, doc)
   const fileContent = serializeNote(frontmatter, markdown)
 
-  ignoredWrites.set(journalPath, Date.now())
+  rememberIgnoredWrite(journalPath)
   await atomicWrite(journalPath, fileContent)
 
   syncNoteToCache(
@@ -597,7 +672,7 @@ async function handleJournalCollision(
   const fileContent = serializeNote(frontmatter, markdown)
 
   await ensureDirectory(journalDir)
-  ignoredWrites.set(collisionPath, Date.now())
+  rememberIgnoredWrite(collisionPath)
   await atomicWrite(collisionPath, fileContent)
 
   syncNoteToCache(
@@ -635,7 +710,7 @@ export async function handleSyncDeletion(noteId: string): Promise<void> {
   deleteNoteFromCache(indexDb, noteId)
   void flushProjectionEvents()
 
-  ignoredWrites.set(absolutePath, Date.now())
+  rememberIgnoredWrite(absolutePath)
   await deleteFile(absolutePath).catch((err) => {
     log.error('Failed to delete synced note file', { noteId, error: err })
   })

--- a/apps/desktop/src/main/sync/engine-retries.test.ts
+++ b/apps/desktop/src/main/sync/engine-retries.test.ts
@@ -224,8 +224,13 @@ describe('SyncEngine', () => {
       getServerMock.mockClear()
 
       const pullCrdtForNote = vi.fn().mockResolvedValue(undefined)
-      ;(engine as unknown as { crdtSync: { pullCrdtForNote: typeof pullCrdtForNote } }).crdtSync = {
-        pullCrdtForNote
+      ;(
+        engine as unknown as {
+          crdtSync: { pullCrdtForNote: typeof pullCrdtForNote; clearCaches: () => void }
+        }
+      ).crdtSync = {
+        pullCrdtForNote,
+        clearCaches: vi.fn()
       }
 
       const pullDone = new Promise<void>((resolve) => {
@@ -280,8 +285,13 @@ describe('SyncEngine', () => {
       await engine.start()
 
       const pullCrdtForNote = vi.fn().mockResolvedValue(undefined)
-      ;(engine as unknown as { crdtSync: { pullCrdtForNote: typeof pullCrdtForNote } }).crdtSync = {
-        pullCrdtForNote
+      ;(
+        engine as unknown as {
+          crdtSync: { pullCrdtForNote: typeof pullCrdtForNote; clearCaches: () => void }
+        }
+      ).crdtSync = {
+        pullCrdtForNote,
+        clearCaches: vi.fn()
       }
 
       // Deterministic drain: the reconnect handler runs through scheduleSync,

--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -289,6 +289,7 @@ export class SyncEngine extends EventEmitter {
     this.ctx.deps.ws.disconnect()
     this.fullSyncRunner.dispose()
     this.pullCoordinator.clearCaches()
+    this.crdtSync.clearCaches()
     this.quarantine.clear()
     this.ctx.syncing = false
     this.stateManager.setState('idle')

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
@@ -518,3 +518,57 @@ describe('CrdtSyncCoordinator', () => {
     expect(postToServerMock).not.toHaveBeenCalled()
   })
 })
+
+describe('CrdtSyncCoordinator.clearCaches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('drops the per-note applied-sequence cursors so a new vault starts from the server baseline', async () => {
+    const applyRemoteUpdate = vi.fn()
+    const crdtProvider = {
+      applyRemoteUpdate,
+      open: vi.fn().mockResolvedValue({}),
+      closeIfInactive: vi.fn().mockResolvedValue(true),
+      getDoc: vi.fn().mockReturnValue({}),
+      getStateVector: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
+      seedFromMarkdownPublic: vi.fn()
+    }
+    const ctx = {
+      deps: { crdtProvider },
+      abortController: new AbortController()
+    } as unknown as SyncContext
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn().mockResolvedValue(new Uint8Array([9])))
+
+    fetchCrdtSnapshotMock.mockResolvedValue({
+      snapshot: new Uint8Array([1]),
+      sequenceNum: 2,
+      signerDeviceId: 'dev-1'
+    })
+    decryptCrdtUpdateMock.mockReturnValue(new Uint8Array([1]))
+    getFromServerMock
+      .mockResolvedValueOnce({
+        updates: [{ sequenceNum: 7, data: 'eA==', createdAt: 0, signerDeviceId: 'dev-1' }],
+        hasMore: false
+      })
+      .mockResolvedValue({ updates: [], hasMore: false })
+
+    // #given — a pass that advanced this note's cursor past the snapshot baseline
+    await coordinator.applyCrdtIncrementals('note-1', 'token', new Uint8Array([2]))
+    coordinator.addPendingPull('note-1')
+    getFromServerMock.mockClear()
+
+    // #when — a second pass runs against the same remembered cursor
+    await coordinator.applyCrdtIncrementals('note-1', 'token', new Uint8Array([2]))
+    expect(getFromServerMock.mock.calls[0][0]).toContain('since=7')
+
+    // #then — after teardown (engine.stop on vault close) the cursor is gone and
+    // the next pass restarts from the server snapshot baseline
+    coordinator.clearCaches()
+    expect(coordinator.pendingPullCount).toBe(0)
+
+    getFromServerMock.mockClear()
+    await coordinator.applyCrdtIncrementals('note-1', 'token', new Uint8Array([2]))
+    expect(getFromServerMock.mock.calls[0][0]).toContain('since=2')
+  })
+})

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -42,6 +42,19 @@ export class CrdtSyncCoordinator {
     return this.pendingPulls.size
   }
 
+  /**
+   * Both maps hold one entry per note ever CRDT-synced — i.e. the whole vault
+   * after the first full sync — so they must not outlive the engine that filled
+   * them. Dropping `lastAppliedSequence` is safe: the next pass re-derives its
+   * `since` cursor from the server snapshot baseline, and re-applying a CRDT
+   * update is a no-op.
+   */
+  clearCaches(): void {
+    this.pendingPulls.clear()
+    this.lastAppliedSequence.clear()
+    this.applyFailureReported.clear()
+  }
+
   private rememberAppliedSequence(noteId: string, sequenceNum: number): number {
     const known = this.lastAppliedSequence.get(noteId) ?? 0
     const next = Math.max(known, sequenceNum)

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.test.ts
@@ -138,7 +138,7 @@ vi.mock('../../vault/index', () => ({
   getStatus: vi.fn(() => ({ path: VAULT_ROOT }))
 }))
 
-import { noteHandler } from './note-handler'
+import { noteHandler, resetRequestedAttachmentDownloads } from './note-handler'
 import { deleteFile } from '../../vault/file-ops'
 import { parseNote, serializeParsedNote } from '../../vault/frontmatter'
 import { deleteNoteFromCache, syncFileToCache, syncNoteToCache } from '../../vault/note-sync'
@@ -751,5 +751,21 @@ describe('noteHandler.applyUpsert — embedded attachment references', () => {
     const call = mockUpdateNoteMetadata.mock.calls.find((c) => c[1] === 'note-att-none')
     expect(call).toBeTruthy()
     expect((call![2] as Record<string, unknown>).attachmentReferences).toBeUndefined()
+  })
+
+  it('re-requests downloads after a vault teardown clears the session guard', () => {
+    // #given — a note whose attachment was already requested this session
+    const payload = makeNotePayload({ attachmentReferences: ['att-a'] })
+    noteHandler.applyUpsert(ctx, 'note-att-vault', payload, {})
+    noteHandler.applyUpsert(ctx, 'note-att-vault', payload, {})
+    expect(downloadEvents).toHaveLength(1)
+
+    // #when — the vault is switched (stopSyncRuntime → resetSyncServiceSingletons)
+    resetRequestedAttachmentDownloads()
+    noteHandler.applyUpsert(ctx, 'note-att-vault', payload, {})
+
+    // #then — the guard no longer carries the previous vault's keys, so the new
+    // vault's copy of the note asks for its attachment again
+    expect(downloadEvents).toHaveLength(2)
   })
 })

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.ts
@@ -90,6 +90,28 @@ async function removeEmptyParents(dir: string, stopAt: string): Promise<void> {
 // files that already exist on disk.
 const requestedAttachmentDownloads = new Set<string>()
 
+/**
+ * Ceiling on that guard. Entries are never retired individually, so without one
+ * the Set grows by every note×attachment this device has ever pulled — across
+ * vaults, since it is module-level. Insertion order is FIFO, so the oldest key
+ * goes first; re-requesting it later is cheap because the downloader skips
+ * files that already exist on disk.
+ */
+const MAX_REQUESTED_ATTACHMENT_DOWNLOADS = 5000
+
+/** Vault switch / sync-runtime stop: these keys belong to the old vault's notes. */
+export function resetRequestedAttachmentDownloads(): void {
+  requestedAttachmentDownloads.clear()
+}
+
+function rememberAttachmentDownload(key: string): void {
+  if (requestedAttachmentDownloads.size >= MAX_REQUESTED_ATTACHMENT_DOWNLOADS) {
+    const oldest = requestedAttachmentDownloads.values().next().value
+    if (oldest !== undefined) requestedAttachmentDownloads.delete(oldest)
+  }
+  requestedAttachmentDownloads.add(key)
+}
+
 function mergeAttachmentReferences(
   local: string[] | null | undefined,
   remote: string[] | null | undefined
@@ -132,7 +154,7 @@ function requestEmbeddedAttachmentDownloads(
     // never asked for again for the life of the process. Skipping the record
     // lets the next pull of the same note re-request it; the downloader still
     // skips files that already exist on disk, so a re-request is cheap.
-    if (delivered) requestedAttachmentDownloads.add(key)
+    if (delivered) rememberAttachmentDownload(key)
   }
 }
 

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -32,6 +32,7 @@ import { initCanvasSyncService, resetCanvasSyncService } from './canvas-sync'
 import { initProjectSyncService, resetProjectSyncService } from './project-sync'
 import { initSettingsSyncManager, resetSettingsSyncManager } from './settings-sync'
 import { initNoteSyncService, resetNoteSyncService } from './note-sync'
+import { resetRequestedAttachmentDownloads } from './item-handlers/note-handler'
 import { initJournalSyncService, resetJournalSyncService } from './journal-sync'
 import { initTagDefinitionSyncService, resetTagDefinitionSyncService } from './tag-definition-sync'
 import { initTagCategorySyncService, resetTagCategorySyncService } from './tag-category-sync'
@@ -183,6 +184,9 @@ function resetSyncServiceSingletons(): void {
   resetCalendarSourceSyncService()
   resetCalendarBindingSyncService()
   resetCalendarExternalEventSyncService()
+  // Module-level state on the note item handler, not a service singleton, but
+  // it is per-vault and torn down on exactly the same paths.
+  resetRequestedAttachmentDownloads()
 }
 
 function getCurrentDeviceId(db: DataDb): string | null {

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -97,6 +97,11 @@ document to its vault `.md` file and re-indexes it for search.
 - **Nothing is deferred indefinitely** — the trailing pass always runs, and
   `flushPendingWritebacks()` forces any pending pass through before the CRDT provider is
   destroyed, which covers app quit and vault switch.
+- **Per-vault bookkeeping** — write-back tracks self-written files and recent inbound
+  network updates in short-TTL maps. Entries are evicted in an amortized pass (at most one
+  sweep per TTL window) rather than scanned on every watcher event, and
+  `CrdtProvider.destroy()` clears the maps outright, so no vault's note ids or file paths
+  survive into the next one.
 
 While a write-back is queued or mid-write the `.md` file is knowingly behind the Y.Doc, so
 markdown-as-truth readers (task checkbox reconciliation) stand down for that window. Search

--- a/apps/docs/src/architecture/sync-handlers.md
+++ b/apps/docs/src/architecture/sync-handlers.md
@@ -98,6 +98,20 @@ The Yjs `meta` title is not a source of truth in the other direction either. It 
 creation and updated only while the note's doc is open in memory, so a note renamed from the sidebar
 never records the new title there. Read it only when nothing else knows the note.
 
+## Module-Level Handler State Is Per-Vault
+
+A handler that keeps module-level state — the note handler's guard against re-requesting the same
+embedded attachment download is the one that exists — must treat that state as belonging to the open
+vault. It is reset from `resetSyncServiceSingletons()`, which runs on sync-runtime stop and therefore
+on vault close, vault switch and sign-out, alongside the per-type service singletons. Session-scoped
+collections also need a ceiling: the attachment guard is FIFO-capped, because keys are never retired
+individually and re-requesting one is cheap (the downloader skips files already on disk).
+
+The same rule holds inside the engine. `CrdtSyncCoordinator` caches an applied-sequence cursor per
+note, which after a full sync means the entire vault; `engine.stop()` clears it. Dropping the cursors
+is safe because the next pass re-derives `since` from the server snapshot baseline and re-applying a
+CRDT update is a no-op.
+
 ## Renderer Events From the Sync Path
 
 Handlers notify the renderer through `ctx.emit`, typed `(channel: string, data: unknown)`. That


### PR DESCRIPTION
Part of epic #987 (memory & CPU audit 2026-08).

## What was wrong

Four module-level per-note collections in the sync layer grew for the life of the session and survived vault switches, so one vault's bookkeeping stayed in memory — and readable — while the next vault was open. Validated against `origin/main` @ 21d1dae9b; all four were still present.

| Site | Problem |
| --- | --- |
| `crdt-writeback.ts:99` `lastNetworkUpdateMs` | Written on every inbound network update (`crdt-provider.ts` → `recordNetworkUpdate`). The only delete lived in `wasRecentNetworkUpdate`, reached only when that same note is *also* edited externally on disk. Grew with synced-note count. |
| `crdt-writeback.ts:152-160` `ignoredWrites` | `isWritebackIgnored` swept the whole map inline — O(map) on **every** watcher file event — and stopped sweeping entirely if the watcher stopped. |
| `item-handlers/note-handler.ts:91` `requestedAttachmentDownloads` | Add-only `Set` keyed `noteId:attachmentId`, module-level, so it accumulated across vault switches. |
| `engine/crdt-sync-coordinator.ts:21,24` `lastAppliedSequence` + `applyFailureReported` | One entry per note ever CRDT-synced — the whole vault after the first full sync. `engine.stop()` (`engine.ts:291`) cleared `pullCoordinator` and `quarantine` but not these. |

## What changed

**Eviction**
- `sweepExpired()` + a per-map "last swept at" timestamp: a full pass runs at most once per TTL window instead of once per call, so `isWritebackIgnored` is amortized O(1) on the watcher hot path.
- The sweep also runs on the *write* path (`rememberIgnoredWrite`), which is what closes the "watcher stopped → nothing sweeps" hole. The six raw `ignoredWrites.set(...)` writes now go through it.
- `recordNetworkUpdate` sweeps `lastNetworkUpdateMs` on the same amortized schedule, bounding it to notes touched in the last two 2 s windows.
- `requestedAttachmentDownloads` is FIFO-capped at 5000; `Set` insertion order makes the oldest key the eviction target, and re-requesting is cheap because the downloader skips files already on disk.

**Teardown wiring** (real paths, not test-only exports)
- `resetWritebackState()` ← called from `CrdtProvider.destroy()`, the single point every vault close, vault switch and sync-runtime stop passes through (`stopSyncRuntime` destroys the provider on both its active and inactive branches).
- `resetRequestedAttachmentDownloads()` ← called from `resetSyncServiceSingletons()` in `sync/runtime.ts`, which runs on sync-runtime stop and on startup failure.
- `CrdtSyncCoordinator.clearCaches()` ← called from `engine.stop()`, next to the existing `pullCoordinator.clearCaches()`.

Dropping `lastAppliedSequence` is safe: the next pass re-derives its `since` cursor from the server snapshot baseline, and re-applying a CRDT update is a no-op. No sync-protocol, IPC-contract, DB-schema, vault-format or settings change — all state here is in-process only, so older installs are unaffected.

## Verification

Six regression tests added, each **mutation-verified** — reverting the corresponding production behaviour makes exactly that test fail:

- `crdt-writeback.test.ts` — reset empties ignored writes / network marks / debug state; both TTL maps evict expired keys rather than merely reporting them expired (asserted on map size via a new `getWritebackStateSizes()` diagnostics export, because `isWritebackIgnored`/`wasRecentNetworkUpdate` cannot distinguish "expired" from "evicted").
- `crdt-provider.test.ts` — `destroy()` calls the write-back reset, i.e. the vault-switch path is actually wired.
- `crdt-sync-coordinator.test.ts` — a second pass reuses `since=7`; after `clearCaches()` the next pass restarts from the snapshot baseline `since=2`.
- `note-handler.test.ts` — a repeat apply emits no download, and after the reset the same note requests its attachment again.

Mutation run (all four production behaviours reverted at once):

```
Tests  4 failed | 88 passed (92)
 FAIL crdt-provider.test.ts > ... destroys storage
 FAIL crdt-writeback.test.ts > ... drops ignored writes, network-update marks and debug state on vault teardown
 FAIL crdt-sync-coordinator.test.ts > ... drops the per-note applied-sequence cursors
 FAIL note-handler.test.ts > ... re-requests downloads after a vault teardown clears the session guard
```

Sweeps reverted separately:

```
Tests  2 failed | 18 passed (20)
 FAIL ... evicts expired ignored writes from the write path, not only from watcher reads
 FAIL ... evicts expired network-update marks instead of keeping one per note forever
```

Green locally:

```
pnpm --filter @memry/desktop test:main   → 492 passed | 1 skipped (493 files), 5680 tests
pnpm --filter @memry/desktop typecheck:node → exit 0
pnpm exec eslint <changed files>         → 0 errors
git diff --check                         → clean
pnpm docs:impact --base origin/main --strict → docs changed on this branch
pnpm docs:build                          → exit 0
```

Two existing harnesses needed their stubs widened (they replace `crdtSync` / mock `crdt-writeback` with partial objects): `engine-retries.test.ts` and `crdt-ipc-handlers.test.ts`.

No measured heap delta attached — the leak is proportional to synced-note count over a long session, which the unit-level assertions on map contents capture more precisely than a snapshot would.

Closes #1061