### PR TITLE
perf(main): consolidate the three 60s pollers onto one shared minute tick

### DIFF
--- a/apps/desktop/src/main/inbox/review-scheduler.tick.test.ts
+++ b/apps/desktop/src/main/inbox/review-scheduler.tick.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const show = vi.fn()
 const send = vi.fn()
@@ -38,7 +38,14 @@ vi.mock('../database/queries/settings', () => ({
   setSetting: (_db: unknown, k: string, v: string) => void store.set(k, v)
 }))
 
-import { runReviewTick, getLastReviewFireForTest } from './review-scheduler'
+import {
+  runReviewTick,
+  getLastReviewFireForTest,
+  startInboxReviewScheduler,
+  stopInboxReviewScheduler,
+  isReviewSchedulerRunning
+} from './review-scheduler'
+import { getMinuteTickIds, isMinuteTickRunning } from '../lib/minute-tick'
 
 const at = (h: number, mi: number) => new Date(2026, 6, 17, h, mi, 0, 0)
 
@@ -81,5 +88,28 @@ describe('runReviewTick', () => {
   it('does not notify with an empty inbox', () => {
     count = 0
     expect(runReviewTick(at(18, 0)).notified).toBe(false)
+  })
+})
+
+describe('startInboxReviewScheduler', () => {
+  afterEach(() => {
+    stopInboxReviewScheduler()
+  })
+
+  it('subscribes to the shared minute tick instead of owning a timer', () => {
+    enabled = false // keep the startup catch-up quiet
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+
+    startInboxReviewScheduler()
+
+    expect(getMinuteTickIds()).toEqual(['inbox-review'])
+    expect(isReviewSchedulerRunning()).toBe(true)
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+
+    stopInboxReviewScheduler()
+
+    expect(getMinuteTickIds()).toEqual([])
+    expect(isMinuteTickRunning()).toBe(false)
+    setIntervalSpy.mockRestore()
   })
 })

--- a/apps/desktop/src/main/inbox/review-scheduler.ts
+++ b/apps/desktop/src/main/inbox/review-scheduler.ts
@@ -17,6 +17,7 @@ import { showReviewNotification } from './review-notification'
 import { InboxChannels } from '@memry/contracts/inbox-channels'
 import { REVIEW_REMINDER_TIME_PATTERN } from '@memry/contracts/settings-schemas'
 import { createLogger } from '../lib/logger'
+import { registerMinuteTick, unregisterMinuteTick, hasMinuteTick } from '../lib/minute-tick'
 import { broadcastToAllWindows } from '../lib/window-broadcast'
 import { INBOX_REVIEW_LAST_NOTIFIED_KEY } from './review-reminder-constants'
 
@@ -71,9 +72,10 @@ export function decideReviewNotification(input: ReviewDecisionInput): ReviewDeci
 }
 
 const logger = createLogger('InboxReview')
-const SCHEDULER_INTERVAL_MS = 60 * 1000
 
-let schedulerInterval: ReturnType<typeof setInterval> | null = null
+/** Id for this poller's subscription to the shared minute tick. */
+const MINUTE_TICK_ID = 'inbox-review'
+
 let resumeHandler: (() => void) | null = null
 let lastFire: { date: string; count: number } | null = null
 
@@ -146,21 +148,18 @@ function safeTick(): void {
 }
 
 export function startInboxReviewScheduler(): void {
-  if (schedulerInterval) {
+  if (hasMinuteTick(MINUTE_TICK_ID)) {
     logger.warn('Review scheduler already running')
     return
   }
   safeTick() // startup catch-up
-  schedulerInterval = setInterval(safeTick, SCHEDULER_INTERVAL_MS)
+  registerMinuteTick(MINUTE_TICK_ID, safeTick)
   resumeHandler = () => safeTick()
   powerMonitor.on('resume', resumeHandler)
 }
 
 export function stopInboxReviewScheduler(): void {
-  if (schedulerInterval) {
-    clearInterval(schedulerInterval)
-    schedulerInterval = null
-  }
+  unregisterMinuteTick(MINUTE_TICK_ID)
   if (resumeHandler) {
     powerMonitor.removeListener('resume', resumeHandler)
     resumeHandler = null
@@ -168,7 +167,7 @@ export function stopInboxReviewScheduler(): void {
 }
 
 export function isReviewSchedulerRunning(): boolean {
-  return schedulerInterval !== null
+  return hasMinuteTick(MINUTE_TICK_ID)
 }
 
 export function getLastReviewFireForTest(): { date: string; count: number } | null {

--- a/apps/desktop/src/main/inbox/snooze.test.ts
+++ b/apps/desktop/src/main/inbox/snooze.test.ts
@@ -74,6 +74,7 @@ vi.mock('./runtime-effects', () => ({
 }))
 
 import { getDatabase, requireDatabase } from '../database'
+import { getMinuteTickIds, isMinuteTickRunning } from '../lib/minute-tick'
 
 describe('Inbox Snooze Service', () => {
   let testDb: TestDatabaseResult
@@ -490,6 +491,21 @@ describe('Inbox Snooze Service', () => {
       startSnoozeScheduler()
 
       expect(isSchedulerActive()).toBe(true)
+    })
+
+    it('should subscribe to the shared minute tick instead of owning a timer', () => {
+      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+
+      startSnoozeScheduler()
+
+      expect(getMinuteTickIds()).toEqual(['inbox-snooze'])
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+
+      stopSnoozeScheduler()
+
+      expect(getMinuteTickIds()).toEqual([])
+      expect(isMinuteTickRunning()).toBe(false)
+      setIntervalSpy.mockRestore()
     })
 
     it('should not start duplicate schedulers', () => {

--- a/apps/desktop/src/main/inbox/snooze.ts
+++ b/apps/desktop/src/main/inbox/snooze.ts
@@ -11,6 +11,7 @@
 
 import { eq, and, isNotNull, lte, isNull } from 'drizzle-orm'
 import { createLogger } from '../lib/logger'
+import { registerMinuteTick, unregisterMinuteTick, hasMinuteTick } from '../lib/minute-tick'
 import { broadcastToAllWindows } from '../lib/window-broadcast'
 import { getDatabase, requireDatabase } from '../database'
 import { getStatus } from '../vault'
@@ -56,18 +57,8 @@ export interface SnoozedItem {
 // Constants
 // ============================================================================
 
-/** Scheduler check interval in milliseconds (1 minute) */
-const SCHEDULER_INTERVAL_MS = 60 * 1000
-
-// ============================================================================
-// Module State
-// ============================================================================
-
-/** Reference to the scheduler interval */
-let schedulerInterval: NodeJS.Timeout | null = null
-
-/** Flag to track if scheduler is running */
-let isSchedulerRunning = false
+/** Id for this poller's subscription to the shared minute tick */
+const MINUTE_TICK_ID = 'inbox-snooze'
 
 // ============================================================================
 // Helper Functions
@@ -440,7 +431,7 @@ export function checkDueItemsOnStartup(): void {
  * Checks for due items every minute
  */
 export function startSnoozeScheduler(): void {
-  if (isSchedulerRunning) {
+  if (hasMinuteTick(MINUTE_TICK_ID)) {
     log.debug('Scheduler already running')
     return
   }
@@ -448,22 +439,16 @@ export function startSnoozeScheduler(): void {
   // Run immediately on start
   processDueItems()
 
-  // Then run every minute
-  schedulerInterval = setInterval(() => {
-    processDueItems()
-  }, SCHEDULER_INTERVAL_MS)
-
-  isSchedulerRunning = true
+  // Then run on the shared main-process minute tick
+  registerMinuteTick(MINUTE_TICK_ID, processDueItems)
 }
 
 /**
  * Stop the snooze scheduler
  */
 export function stopSnoozeScheduler(): void {
-  if (schedulerInterval) {
-    clearInterval(schedulerInterval)
-    schedulerInterval = null
-    isSchedulerRunning = false
+  if (hasMinuteTick(MINUTE_TICK_ID)) {
+    unregisterMinuteTick(MINUTE_TICK_ID)
     log.info('Scheduler stopped')
   }
 }
@@ -472,7 +457,7 @@ export function stopSnoozeScheduler(): void {
  * Check if scheduler is currently running
  */
 export function isSchedulerActive(): boolean {
-  return isSchedulerRunning
+  return hasMinuteTick(MINUTE_TICK_ID)
 }
 
 // ============================================================================

--- a/apps/desktop/src/main/lib/minute-tick.test.ts
+++ b/apps/desktop/src/main/lib/minute-tick.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared minute tick tests
+ *
+ * @module main/lib/minute-tick.test
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+vi.mock('./logger', () => ({
+  createLogger: () => loggerMock
+}))
+
+import {
+  registerMinuteTick,
+  unregisterMinuteTick,
+  hasMinuteTick,
+  isMinuteTickRunning,
+  getMinuteTickIds,
+  MINUTE_TICK_INTERVAL_MS
+} from './minute-tick'
+
+describe('shared minute tick', () => {
+  afterEach(() => {
+    for (const id of getMinuteTickIds()) unregisterMinuteTick(id)
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('drives every listener from a single 60s timer', () => {
+    vi.useFakeTimers()
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const reminders = vi.fn()
+    const snooze = vi.fn()
+    const review = vi.fn()
+
+    registerMinuteTick('reminders', reminders)
+    registerMinuteTick('inbox-snooze', snooze)
+    registerMinuteTick('inbox-review', review)
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), MINUTE_TICK_INTERVAL_MS)
+    expect(getMinuteTickIds()).toEqual(['reminders', 'inbox-snooze', 'inbox-review'])
+
+    vi.advanceTimersByTime(MINUTE_TICK_INTERVAL_MS)
+
+    expect(reminders).toHaveBeenCalledTimes(1)
+    expect(snooze).toHaveBeenCalledTimes(1)
+    expect(review).toHaveBeenCalledTimes(1)
+  })
+
+  it('unrefs the timer so polling alone never holds the process open', () => {
+    const nativeSetInterval = globalThis.setInterval
+    let unrefSpy: ReturnType<typeof vi.fn> | null = null
+
+    vi.spyOn(globalThis, 'setInterval').mockImplementation(((
+      handler: Parameters<typeof setInterval>[0],
+      ms?: number
+    ) => {
+      const timer = nativeSetInterval(handler, ms)
+      const nativeUnref = timer.unref.bind(timer)
+      unrefSpy = vi.fn(() => nativeUnref())
+      timer.unref = unrefSpy as unknown as typeof timer.unref
+      return timer
+    }) as typeof globalThis.setInterval)
+
+    registerMinuteTick('reminders', vi.fn())
+
+    expect(unrefSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps ticking the other listeners when one throws', () => {
+    vi.useFakeTimers()
+    const boom = new Error('tick failed')
+    const failing = vi.fn(() => {
+      throw boom
+    })
+    const healthy = vi.fn()
+
+    registerMinuteTick('inbox-snooze', failing)
+    registerMinuteTick('reminders', healthy)
+
+    expect(() => vi.advanceTimersByTime(MINUTE_TICK_INTERVAL_MS * 2)).not.toThrow()
+    expect(failing).toHaveBeenCalledTimes(2)
+    expect(healthy).toHaveBeenCalledTimes(2)
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      'Minute tick listener "inbox-snooze" failed:',
+      boom
+    )
+  })
+
+  it('clears the timer only once the last listener unregisters', () => {
+    vi.useFakeTimers()
+    const reminders = vi.fn()
+    const snooze = vi.fn()
+
+    registerMinuteTick('reminders', reminders)
+    registerMinuteTick('inbox-snooze', snooze)
+    expect(isMinuteTickRunning()).toBe(true)
+
+    unregisterMinuteTick('reminders')
+    expect(isMinuteTickRunning()).toBe(true)
+    expect(hasMinuteTick('reminders')).toBe(false)
+
+    vi.advanceTimersByTime(MINUTE_TICK_INTERVAL_MS)
+    expect(reminders).not.toHaveBeenCalled()
+    expect(snooze).toHaveBeenCalledTimes(1)
+
+    unregisterMinuteTick('inbox-snooze')
+    expect(isMinuteTickRunning()).toBe(false)
+
+    vi.advanceTimersByTime(MINUTE_TICK_INTERVAL_MS)
+    expect(snooze).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a duplicate registration for the same id', () => {
+    vi.useFakeTimers()
+    const first = vi.fn()
+    const second = vi.fn()
+
+    registerMinuteTick('reminders', first)
+    registerMinuteTick('reminders', second)
+
+    vi.advanceTimersByTime(MINUTE_TICK_INTERVAL_MS)
+
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).not.toHaveBeenCalled()
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      'Minute tick listener "reminders" already registered'
+    )
+  })
+})

--- a/apps/desktop/src/main/lib/minute-tick.ts
+++ b/apps/desktop/src/main/lib/minute-tick.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared Minute Tick
+ *
+ * One 60-second timer for every main-process poller that runs on a minute
+ * cadence (reminders, inbox snooze, inbox review). Three independent timers
+ * meant three process wakeups a minute for the whole app lifetime; one shared
+ * timer means one. The timer is `unref`'d so polling alone never holds the
+ * event loop open.
+ *
+ * @module main/lib/minute-tick
+ */
+
+import { createLogger } from './logger'
+
+const logger = createLogger('MinuteTick')
+
+/** Shared cadence for main-process minute pollers. */
+export const MINUTE_TICK_INTERVAL_MS = 60 * 1000
+
+const listeners = new Map<string, () => void>()
+let timer: ReturnType<typeof setInterval> | null = null
+
+function runTick(): void {
+  for (const [id, listener] of listeners) {
+    try {
+      listener()
+    } catch (error) {
+      // A throwing listener must not take the shared timer down with it.
+      logger.error(`Minute tick listener "${id}" failed:`, error)
+    }
+  }
+}
+
+/**
+ * Subscribe to the shared minute tick, starting the timer on first use.
+ * Re-registering the same id is a no-op (matches the schedulers' start guards).
+ */
+export function registerMinuteTick(id: string, listener: () => void): void {
+  if (listeners.has(id)) {
+    logger.warn(`Minute tick listener "${id}" already registered`)
+    return
+  }
+
+  listeners.set(id, listener)
+
+  if (!timer) {
+    timer = setInterval(runTick, MINUTE_TICK_INTERVAL_MS)
+    // Polling must never be the reason the process stays awake.
+    timer.unref()
+  }
+}
+
+/** Unsubscribe, clearing the shared timer once the last listener is gone. */
+export function unregisterMinuteTick(id: string): void {
+  listeners.delete(id)
+
+  if (listeners.size === 0 && timer) {
+    clearInterval(timer)
+    timer = null
+  }
+}
+
+/** Whether a given poller is subscribed. */
+export function hasMinuteTick(id: string): boolean {
+  return listeners.has(id)
+}
+
+/** Whether the shared timer is currently running. */
+export function isMinuteTickRunning(): boolean {
+  return timer !== null
+}
+
+/** Subscribed poller ids, in registration order. */
+export function getMinuteTickIds(): string[] {
+  return [...listeners.keys()]
+}

--- a/apps/desktop/src/main/lib/reminders.test.ts
+++ b/apps/desktop/src/main/lib/reminders.test.ts
@@ -776,6 +776,64 @@ describe('reminders service', () => {
     })
   })
 
+  describe('scheduler tick', () => {
+    it('subscribes to the shared minute tick instead of owning a timer', async () => {
+      const { getMinuteTickIds, isMinuteTickRunning } = await import('./minute-tick')
+      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+
+      remindersService.startReminderScheduler()
+
+      expect(getMinuteTickIds()).toEqual(['reminders'])
+      expect(remindersService.isSchedulerRunning()).toBe(true)
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+
+      remindersService.stopReminderScheduler()
+
+      expect(getMinuteTickIds()).toEqual([])
+      expect(isMinuteTickRunning()).toBe(false)
+      setIntervalSpy.mockRestore()
+    })
+
+    it('runs a single count query and no badge call on an idle tick', () => {
+      vi.useFakeTimers()
+      try {
+        remindersService.startReminderScheduler()
+        setBadgeCountMock.mockClear()
+        const prepareSpy = vi.spyOn(dataDb.sqlite, 'prepare')
+
+        vi.advanceTimersByTime(60 * 1000)
+
+        const statements = prepareSpy.mock.calls.map((call) => String(call[0]).toLowerCase())
+        expect(statements).toHaveLength(1)
+        expect(statements[0]).toContain('count(*)')
+        expect(setBadgeCountMock).not.toHaveBeenCalled()
+        prepareSpy.mockRestore()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('still triggers a reminder that becomes due after the scheduler started', () => {
+      vi.useFakeTimers()
+      try {
+        remindersService.startReminderScheduler()
+
+        seedReminder({
+          id: 'rem-tick',
+          remindAt: '2000-01-01T00:00:00.000Z',
+          status: reminderStatus.PENDING
+        })
+
+        vi.advanceTimersByTime(60 * 1000)
+
+        const row = dataDb.db.select().from(reminders).where(eq(reminders.id, 'rem-tick')).get()
+        expect(row?.status).toBe(reminderStatus.TRIGGERED)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
   it('validates reminder mutations, missing rows, and pending count fallbacks', () => {
     const pastDate = '2000-01-01T00:00:00.000Z'
     const futureDate = new Date(Date.now() + 60 * 60 * 1000).toISOString()

--- a/apps/desktop/src/main/lib/reminders.ts
+++ b/apps/desktop/src/main/lib/reminders.ts
@@ -34,6 +34,7 @@ import { trackMainError } from '../telemetry/diagnostics'
 import { broadcastToAllWindows } from './window-broadcast'
 import { getMainI18n } from './main-i18n'
 import { publishProjectionEvent } from '../projections'
+import { registerMinuteTick, unregisterMinuteTick, hasMinuteTick } from './minute-tick'
 import { emitCalendarProjectionChanged } from '../calendar/change-events'
 import { scheduleGoogleCalendarSourceSync } from '../calendar/google/local-sync-effects'
 import {
@@ -54,8 +55,11 @@ type ReminderRow = typeof reminders.$inferSelect
 // Scheduler State
 // ============================================================================
 
-let schedulerInterval: ReturnType<typeof setInterval> | null = null
-const SCHEDULER_INTERVAL_MS = 60 * 1000 // Check every 60 seconds
+/** Id for this poller's subscription to the shared minute tick. */
+const MINUTE_TICK_ID = 'reminders'
+
+/** Last value handed to the OS badge, so an idle tick skips the native call. */
+let lastBadgeCount: number | null = null
 
 // ============================================================================
 // Helper Functions
@@ -329,12 +333,21 @@ function removeDeliveredNotification(reminderId: string): void {
  * (macOS dock + Unity launcher; a no-op false return on Windows).
  * A badge failure must never break the reminder flow.
  */
-function updateAppBadge(): void {
+function setAppBadge(count: number): void {
+  // The scheduler re-asserts the badge every minute; skip the native call when
+  // the count has not moved so an idle app does no dock work.
+  if (count === lastBadgeCount) return
+
   try {
-    app.setBadgeCount(countPendingReminders())
+    app.setBadgeCount(count)
+    lastBadgeCount = count
   } catch (error) {
     logger.warn('Failed to update app badge count:', error)
   }
+}
+
+function updateAppBadge(): void {
+  setAppBadge(countPendingReminders())
 }
 
 // ============================================================================
@@ -741,12 +754,22 @@ function processDueReminders(): void {
   if (!getStatus().isOpen) return
 
   try {
+    // Cheap count first: nothing pending or snoozed means nothing can be due,
+    // so an idle vault skips the due-reminder lookup entirely. It also doubles
+    // as the badge value, so the tick runs one query instead of two.
+    const pendingCount = countPendingReminders()
+
+    if (pendingCount === 0) {
+      setAppBadge(0)
+      return
+    }
+
     const dueReminders = getDueReminders()
 
     if (dueReminders.length === 0) {
       // Reminders can also mutate outside this module (e.g. note date pills),
       // so refresh the badge on every tick to self-heal a stale count.
-      updateAppBadge()
+      setAppBadge(pendingCount)
       return
     }
 
@@ -798,7 +821,7 @@ function processDueReminders(): void {
  * Called on app ready
  */
 export function startReminderScheduler(): void {
-  if (schedulerInterval) {
+  if (hasMinuteTick(MINUTE_TICK_ID)) {
     logger.warn('Scheduler already running')
     return
   }
@@ -810,8 +833,8 @@ export function startReminderScheduler(): void {
   // when the vault is not open yet).
   updateAppBadge()
 
-  // Set up interval to check for due reminders
-  schedulerInterval = setInterval(processDueReminders, SCHEDULER_INTERVAL_MS)
+  // Check for due reminders on the shared main-process minute tick
+  registerMinuteTick(MINUTE_TICK_ID, processDueReminders)
 }
 
 /**
@@ -819,9 +842,8 @@ export function startReminderScheduler(): void {
  * Called on app quit
  */
 export function stopReminderScheduler(): void {
-  if (schedulerInterval) {
-    clearInterval(schedulerInterval)
-    schedulerInterval = null
+  if (hasMinuteTick(MINUTE_TICK_ID)) {
+    unregisterMinuteTick(MINUTE_TICK_ID)
     logger.info('Scheduler stopped')
   }
 }
@@ -830,7 +852,7 @@ export function stopReminderScheduler(): void {
  * Check if the scheduler is running
  */
 export function isSchedulerRunning(): boolean {
-  return schedulerInterval !== null
+  return hasMinuteTick(MINUTE_TICK_ID)
 }
 
 /**

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -163,6 +163,25 @@ The pipeline is wired into both duplicated serializers: the renderer save path (
 
 better-sqlite3 is synchronous and single-process. The main process is the only writer. The renderer never touches SQLite directly — all reads and writes go through IPC.
 
+## Background Polling (Shared Minute Tick)
+
+Three features watch the clock rather than an event: due reminders, snoozed inbox items that should
+resurface, and the daily inbox review nudge. They share one 60-second timer in
+`main/lib/minute-tick.ts` instead of each owning an interval, so an idle app wakes the process once
+a minute, not three times. The timer is `unref`'d — polling alone never keeps the process alive —
+and it only exists while at least one poller is registered.
+
+Each poller stays cheap when there is nothing to do:
+
+- **Reminders** count pending/snoozed rows first. Zero means nothing can be due, so the due lookup
+  is skipped and the tick costs one indexed count. The dock badge is only re-asserted when the
+  count actually changes.
+- **Inbox snooze** runs a single filtered query that returns no rows when nothing is due.
+- **Inbox review** returns before touching the database when the reminder is disabled (the default).
+
+All three also short-circuit when no vault is open. Add a new minute-cadence job by registering it
+on the shared tick — do not start another interval.
+
 ## SQLite Memory Budget
 
 The desktop main process opens both databases with bounded SQLite page caches:


### PR DESCRIPTION
Closes #1057. Part of epic #987 (memory & CPU audit 2026-08).

## What was wrong

Three independent minute pollers ran for the whole app lifetime, on `main` @ 21d1dae9b:

- `apps/desktop/src/main/lib/reminders.ts:814` — `setInterval(processDueReminders, 60_000)`
- `apps/desktop/src/main/inbox/snooze.ts:452` — `setInterval(() => processDueItems(), 60_000)`
- `apps/desktop/src/main/inbox/review-scheduler.ts:154` — `setInterval(safeTick, 60_000)`

Three timers means three process wakeups a minute (~4,300/day), and none were `unref`'d. The
reminder tick was the worst offender: with zero reminders it still ran `getDueReminders()`, then
`updateAppBadge()` (a second count query), then a native `app.setBadgeCount()` call — every minute,
forever.

## What changed

- New `apps/desktop/src/main/lib/minute-tick.ts`: one `unref`'d 60s timer that fans out to
  registered listeners. Started on first registration, cleared when the last one unregisters, and a
  throwing listener is logged without taking the shared timer down.
- All three schedulers register on it instead of owning an interval. Their public
  start/stop/is-running APIs are unchanged, as are the startup catch-up runs and the review
  scheduler's `powerMonitor` resume handler.
- Reminder tick now counts pending/snoozed rows first. Zero means nothing can be due (`due` is a
  strict subset of pending+snoozed), so the due lookup is skipped and the tick costs one indexed
  count instead of two queries. The count doubles as the badge value.
- `app.setBadgeCount()` is skipped when the value has not moved, so an idle app does no dock work.

Snooze keeps its single filtered query — it already returns zero rows when nothing is due, so a
count gate would cost the same. A cross-module "is anything scheduled" cache was deliberately not
added: reminders and snoozes are also written by sync pull, note date pills, and imports, so an
invalidation miss would silently stop reminders from firing.

No contract, schema, settings, or sync-protocol change. Behavior is identical from the user's side.

## Verification

`pnpm --filter @memry/desktop exec vitest run --project main` on the four affected files:

```
 Test Files  4 passed (4)
      Tests  86 passed (86)
```

Mutation check — reverting only the three source files (tests untouched) fails the new tests:

```
 × review-scheduler.tick.test.ts > subscribes to the shared minute tick instead of owning a timer
 × snooze.test.ts > should subscribe to the shared minute tick instead of owning a timer
 × reminders.test.ts > subscribes to the shared minute tick instead of owning a timer
 × reminders.test.ts > runs a single count query and no badge call on an idle tick
      Tests  4 failed | 77 passed (81)
```

The idle-tick test asserts against a real SQLite database (`prepare` spy): exactly one statement,
containing `count(*)`, and no `setBadgeCount` call. A companion test proves the short-circuit does
not swallow real work — a reminder seeded after start still flips to `triggered` on the next tick.

Also green: `pnpm --filter @memry/desktop typecheck:node`, `pnpm exec eslint <changed files>`
(0 errors), `pnpm exec prettier --check`, `pnpm check:architecture`, `git diff --check`,
`pnpm docs:impact --base origin/main --strict` (covered), `pnpm docs:build`.
