### PR TITLE
fix(calendar): page through Google events.list so no events are dropped

### DIFF
--- a/apps/desktop/src/main/calendar/google/client.test.ts
+++ b/apps/desktop/src/main/calendar/google/client.test.ts
@@ -573,6 +573,148 @@ describe('google calendar client — push channels (Task 7)', () => {
       })
     })
 
+    it('follows nextPageToken across pages and reads the cursor from the final page only', async () => {
+      const requested: URL[] = []
+      fetchMock
+        .mockImplementationOnce(async (input) => {
+          requested.push(new URL(String(input)))
+          // Google omits nextSyncToken while a nextPageToken exists.
+          return new Response(
+            JSON.stringify({
+              nextPageToken: 'page-2',
+              items: [
+                {
+                  id: 'recurring-instance-1',
+                  summary: 'Standup',
+                  start: { dateTime: '2026-05-05T09:00:00.000Z' },
+                  end: { dateTime: '2026-05-05T09:15:00.000Z' }
+                }
+              ]
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          )
+        })
+        .mockImplementationOnce(async (input) => {
+          requested.push(new URL(String(input)))
+          return new Response(
+            JSON.stringify({
+              nextSyncToken: 'cursor-final',
+              items: [
+                {
+                  id: 'one-off-1',
+                  summary: 'Dentist',
+                  start: { dateTime: '2026-05-12T14:00:00.000Z' },
+                  end: { dateTime: '2026-05-12T15:00:00.000Z' }
+                }
+              ]
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          )
+        })
+
+      const client = createGoogleCalendarClient({ accountId: LEGACY_DEFAULT_ACCOUNT_ID })
+      const result = await client.listEvents({
+        calendarId: 'primary',
+        timeMin: '2026-05-01T00:00:00.000Z',
+        timeMax: '2026-06-01T00:00:00.000Z',
+        syncCursor: null
+      })
+
+      expect(result.events.map((event) => event.id)).toEqual(['recurring-instance-1', 'one-off-1'])
+      expect(result.nextSyncCursor).toBe('cursor-final')
+
+      expect(requested).toHaveLength(2)
+      expect(requested[0]?.searchParams.get('maxResults')).toBe('250')
+      expect(requested[0]?.searchParams.has('pageToken')).toBe(false)
+      expect(requested[1]?.searchParams.get('pageToken')).toBe('page-2')
+      // The window survives across pages.
+      expect(requested[1]?.searchParams.get('timeMin')).toBe('2026-05-01T00:00:00.000Z')
+      expect(requested[1]?.searchParams.get('timeMax')).toBe('2026-06-01T00:00:00.000Z')
+    })
+
+    it('paginates the sync-token branch too, carrying the syncToken on every page', async () => {
+      const requested: URL[] = []
+      fetchMock
+        .mockImplementationOnce(async (input) => {
+          requested.push(new URL(String(input)))
+          return new Response(
+            JSON.stringify({
+              nextPageToken: 'delta-page-2',
+              items: [{ id: 'delta-1', start: { dateTime: '2026-05-05T09:00:00.000Z' } }]
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          )
+        })
+        .mockImplementationOnce(async (input) => {
+          requested.push(new URL(String(input)))
+          return new Response(
+            JSON.stringify({
+              nextSyncToken: 'cursor-delta-final',
+              items: [{ id: 'delta-2', start: { dateTime: '2026-05-06T09:00:00.000Z' } }]
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          )
+        })
+
+      const client = createGoogleCalendarClient({ accountId: LEGACY_DEFAULT_ACCOUNT_ID })
+      const result = await client.listEvents({ calendarId: 'primary', syncCursor: 'cursor-1' })
+
+      expect(result.events.map((event) => event.id)).toEqual(['delta-1', 'delta-2'])
+      expect(result.nextSyncCursor).toBe('cursor-delta-final')
+      expect(requested).toHaveLength(2)
+      expect(requested[0]?.searchParams.get('syncToken')).toBe('cursor-1')
+      expect(requested[1]?.searchParams.get('syncToken')).toBe('cursor-1')
+      expect(requested[1]?.searchParams.get('pageToken')).toBe('delta-page-2')
+    })
+
+    it('makes exactly one request when the first page is the last page', async () => {
+      const requested: URL[] = []
+      fetchMock.mockImplementationOnce(async (input) => {
+        requested.push(new URL(String(input)))
+        return new Response(
+          JSON.stringify({
+            nextSyncToken: 'cursor-single',
+            items: [{ id: 'only-1', start: { dateTime: '2026-05-05T09:00:00.000Z' } }]
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      })
+
+      const client = createGoogleCalendarClient({ accountId: LEGACY_DEFAULT_ACCOUNT_ID })
+      const result = await client.listEvents({
+        calendarId: 'primary',
+        timeMin: '2026-05-01T00:00:00.000Z',
+        timeMax: '2026-06-01T00:00:00.000Z',
+        syncCursor: null
+      })
+
+      expect(result.events.map((event) => event.id)).toEqual(['only-1'])
+      expect(result.nextSyncCursor).toBe('cursor-single')
+      expect(requested).toHaveLength(1)
+      expect(requested[0]?.searchParams.has('pageToken')).toBe(false)
+    })
+
+    it('discards partial pages and clears the cursor when Google returns 410 mid-pagination', async () => {
+      fetchMock
+        .mockImplementationOnce(
+          async () =>
+            new Response(
+              JSON.stringify({
+                nextPageToken: 'delta-page-2',
+                items: [{ id: 'delta-1', start: { dateTime: '2026-05-05T09:00:00.000Z' } }]
+              }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } }
+            )
+        )
+        .mockImplementationOnce(async () => new Response('gone', { status: 410 }))
+
+      const client = createGoogleCalendarClient({ accountId: LEGACY_DEFAULT_ACCOUNT_ID })
+      await expect(
+        client.listEvents({ calendarId: 'primary', syncCursor: 'stale-cursor' })
+      ).resolves.toEqual({ events: [], nextSyncCursor: null })
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
     it('sends PATCH headers and optional rich event fields on update', async () => {
       let capturedUrl = ''
       let capturedInit: RequestInit | undefined

--- a/apps/desktop/src/main/calendar/google/client.ts
+++ b/apps/desktop/src/main/calendar/google/client.ts
@@ -19,6 +19,13 @@ const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
 
 const pendingRefreshes = new Map<string, Promise<string>>()
 
+// events.list defaults to 250 per page and caps at 2500. Pin the default explicitly so the
+// page size is visible at the call site instead of being whatever Google picks.
+const GOOGLE_EVENTS_PAGE_SIZE = 250
+// Safety bound on the pagination loop: a remote that keeps handing back a pageToken must not
+// spin forever. 100 pages ≈ 25k events per calendar per pass, far above any real calendar.
+const GOOGLE_EVENTS_MAX_PAGES = 100
+
 const GoogleCalendarListItemSchema = z.object({
   id: z.string().min(1),
   summary: z.string().optional(),
@@ -100,6 +107,7 @@ const GoogleEventSchema = z.object({
 
 const GoogleEventsListSchema = z.object({
   items: z.array(GoogleEventSchema).default([]),
+  nextPageToken: z.string().optional(),
   nextSyncToken: z.string().optional()
 })
 
@@ -494,37 +502,64 @@ export function createGoogleCalendarClient(
       events: GoogleCalendarRemoteEvent[]
       nextSyncCursor: string | null
     }> {
-      const useSyncToken = Boolean(input.syncCursor)
+      const syncToken = input.syncCursor ?? undefined
+      const baseQuery: Record<string, string | undefined | null> = syncToken
+        ? {
+            showDeleted: 'true',
+            singleEvents: 'true',
+            syncToken
+          }
+        : {
+            showDeleted: 'true',
+            singleEvents: 'true',
+            timeMin: input.timeMin ?? undefined,
+            timeMax: input.timeMax ?? undefined
+          }
 
-      const response = await withAuthorizedResponse(accountId, {
-        path: `/calendars/${encodeURIComponent(input.calendarId)}/events`,
-        query: useSyncToken
-          ? {
-              showDeleted: 'true',
-              singleEvents: 'true',
-              syncToken: input.syncCursor!
-            }
-          : {
-              showDeleted: 'true',
-              singleEvents: 'true',
-              timeMin: input.timeMin ?? undefined,
-              timeMax: input.timeMax ?? undefined
-            }
+      // Both branches paginate: a token-based delta can span pages just like a windowed
+      // listing. Google only emits nextSyncToken on the LAST page, so reading it before the
+      // traversal ends leaves the cursor permanently null and incremental sync never engages.
+      const events: GoogleCalendarRemoteEvent[] = []
+      let pageToken: string | undefined
+
+      for (let page = 0; page < GOOGLE_EVENTS_MAX_PAGES; page += 1) {
+        const response = await withAuthorizedResponse(accountId, {
+          path: `/calendars/${encodeURIComponent(input.calendarId)}/events`,
+          query: {
+            ...baseQuery,
+            maxResults: String(GOOGLE_EVENTS_PAGE_SIZE),
+            pageToken
+          }
+        })
+
+        // A 410 anywhere in the traversal invalidates the whole run — the pages already
+        // collected came from a token Google has since expired. Drop them and report a null
+        // cursor so the caller re-syncs from scratch, exactly as on a first-page 410.
+        if (response.status === 410) {
+          return { events: [], nextSyncCursor: null }
+        }
+
+        if (!response.ok) {
+          await throwCalendarApiFailure(response, 'list Google calendar events')
+        }
+
+        const parsed = GoogleEventsListSchema.parse(await response.json())
+        for (const item of parsed.items) {
+          events.push(mapRemoteEvent(input.calendarId, item))
+        }
+
+        if (!parsed.nextPageToken) {
+          return { events, nextSyncCursor: parsed.nextSyncToken ?? null }
+        }
+        pageToken = parsed.nextPageToken
+      }
+
+      log.error('Google calendar event pagination hit the page cap; results truncated', {
+        calendarId: input.calendarId,
+        maxPages: GOOGLE_EVENTS_MAX_PAGES,
+        eventCount: events.length
       })
-
-      if (response.status === 410) {
-        return { events: [], nextSyncCursor: null }
-      }
-
-      if (!response.ok) {
-        await throwCalendarApiFailure(response, 'list Google calendar events')
-      }
-
-      const parsed = GoogleEventsListSchema.parse(await response.json())
-      return {
-        events: parsed.items.map((item) => mapRemoteEvent(input.calendarId, item)),
-        nextSyncCursor: parsed.nextSyncToken ?? null
-      }
+      return { events, nextSyncCursor: null }
     },
 
     async getEvent(input): Promise<GoogleCalendarRemoteEvent> {

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -171,6 +171,9 @@ memrynote pulls about every 5 minutes in the background. When Google push notifi
 for your selected calendars, changes arrive as they happen and the background pull falls back to
 roughly every 30 minutes.
 
+Google returns a busy calendar in pages. Every pull follows all of them before it finishes, so a
+calendar full of repeating meetings cannot crowd your one-off appointments out of the results.
+
 Two extra pulls sit on top of that: memrynote syncs immediately when your machine wakes from sleep,
 and bringing the memrynote window back to the front pulls again if the last pull was more than two
 minutes ago. Re-focusing the window more often than that is deliberately ignored so alt-tabbing all


### PR DESCRIPTION
Closes #1200

## What was wrong

`listEvents` issued exactly one request per calendar and read `parsed.items` from that single response. Google's `events.list` caps a page at 250 events and hands back `nextPageToken` for the rest, so everything past page 1 was silently discarded. With `singleEvents: 'true'` on both query branches, a handful of recurring series expands to enough occurrences to fill page 1 on its own — which is exactly why Adam saw only repeat events and none of his one-off appointments.

Second consequence: `nextSyncToken` is only present on the **last** page. Any account with more than one page got `nextSyncCursor: null` forever, so `syncGoogleCalendarSource` kept resetting the cursor and re-fetching the same first page on every pass.

## What changed

`apps/desktop/src/main/calendar/google/client.ts`

- The query is built once into `baseQuery`, then the request loops on `pageToken` until Google stops returning `nextPageToken`, accumulating mapped events across pages. Both branches paginate — a token-based delta pages just like a windowed listing.
- `nextSyncToken` is read **only** from the final page (the one with no `nextPageToken`), so the incremental cursor now actually gets stored.
- `maxResults=250` is set explicitly. That is the value Google was already defaulting to, so page size is unchanged in practice — it is just visible at the call site now.
- The 410 branch moved inside the loop. A 410 anywhere in the traversal invalidates the whole run (the pages already collected came from a token Google has since expired), so the partial result is discarded and `{ events: [], nextSyncCursor: null }` is returned — identical to the previous first-page behaviour, which `syncGoogleCalendarSource` already handles by clearing the cursor and re-syncing.
- Dropped the `input.syncCursor!` non-null assertion in favour of a local `syncToken` const. Same semantics, and it keeps the staged-secret scanner quiet.

## Safety bound on the loop

Yes, it is bounded — `GOOGLE_EVENTS_MAX_PAGES = 100`, roughly 25k events per calendar per pass. An unbounded `while (pageToken)` trusts a remote to eventually stop, and a server that echoes the same token back would spin forever inside a sync pass with no way out. 100 pages is far above any real calendar (a 90-day-back / 365-day-forward initial window would need ~55 occurrences a day to reach it), so the cap should never be hit in practice. If it is, the client logs an error with the calendar id and event count and returns what it collected with a null cursor — the same "re-sync from scratch" signal the caller already understands, so it degrades to today's behaviour rather than deadlocking.

## Backward compatibility

No contract, schema, or settings change. `listEvents` keeps its exact return shape. Existing installs holding a cursor written by the current code keep working: that cursor is either valid (the sync-token branch now just pages through the delta correctly) or stale, in which case Google's 410 takes the same path it always did. Installs stuck with a permanently null cursor start storing a real one on the next pass.

## Tests

`apps/desktop/src/main/calendar/google/client.test.ts` only ever used single-page fixtures. Added four:

- two-page windowed listing returns **all** events from both pages and a non-null cursor taken from the final page, with `maxResults=250`, no `pageToken` on page 1, and `timeMin`/`timeMax` carried onto page 2
- the sync-token branch pages too, carrying `syncToken` on every request alongside `pageToken`
- a single-page response still makes exactly one request and behaves as before
- a 410 on page 2 discards the partial page and returns a null cursor

## Verification

- `pnpm exec vitest run --project main src/main/calendar/google/client.test.ts` — 19 passed
- `pnpm exec vitest run --project main src/main/calendar/google/sync-service.test.ts` — 34 passed
- `pnpm --filter @memry/desktop typecheck:node` — clean
- `pnpm lint` — 0 errors (18 pre-existing warnings, all in untouched renderer files)
- `pnpm docs:impact --base origin/main --strict` — covered; `pnpm docs:build` — clean

Not manually exercised against a real multi-page Google account.
