### PR TITLE
perf(agent): stream assistant deltas only to the windows showing the conversation

### DIFF
--- a/apps/desktop/src/main/agent/runtime/__tests__/event-bus.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/event-bus.test.ts
@@ -8,7 +8,20 @@ vi.mock('electron', () => ({
 
 import { AgentChannels, type AgentEvent } from '@memry/contracts/ipc-agent'
 
-import { broadcastAgentEvent } from '../event-bus'
+import { broadcastAgentEvent, setAgentStreamTarget } from '../event-bus'
+
+const DELTA: AgentEvent = {
+  kind: 'assistant_text_delta',
+  conversationId: 'conversation-1',
+  messageId: 'message-1',
+  text: 'hello'
+}
+
+function windowWithId(id: number): MockBrowserWindow {
+  const win = new MockBrowserWindow()
+  win.id = id
+  return win
+}
 
 describe('broadcastAgentEvent', () => {
   beforeEach(() => {
@@ -48,5 +61,77 @@ describe('broadcastAgentEvent', () => {
 
     expect(destroyed.webContents.send).not.toHaveBeenCalled()
     expect(live.webContents.send).toHaveBeenCalledWith(AgentChannels.events.AGENT_EVENT, event)
+  })
+
+  it('sends assistant deltas only to the windows showing that conversation', () => {
+    const viewer = windowWithId(11)
+    const other = windowWithId(12)
+    MockBrowserWindow.getAllWindows.mockReturnValue([viewer, other] as never)
+    setAgentStreamTarget(11, 'conversation-1')
+    setAgentStreamTarget(12, 'conversation-2')
+
+    broadcastAgentEvent(DELTA)
+
+    expect(viewer.webContents.send).toHaveBeenCalledWith(AgentChannels.events.AGENT_EVENT, DELTA)
+    expect(other.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('sends assistant deltas to every window showing the conversation, skipping destroyed ones', () => {
+    const secondViewer = windowWithId(21)
+    const destroyedViewer = windowWithId(22)
+    destroyedViewer.destroy()
+    MockBrowserWindow.getAllWindows.mockReturnValue([secondViewer, destroyedViewer] as never)
+    setAgentStreamTarget(21, 'conversation-1')
+    setAgentStreamTarget(22, 'conversation-1')
+
+    expect(() => broadcastAgentEvent(DELTA)).not.toThrow()
+
+    expect(secondViewer.webContents.send).toHaveBeenCalledWith(
+      AgentChannels.events.AGENT_EVENT,
+      DELTA
+    )
+    expect(destroyedViewer.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('drops assistant deltas for a conversation no window shows', () => {
+    const idle = windowWithId(31)
+    MockBrowserWindow.getAllWindows.mockReturnValue([idle] as never)
+    setAgentStreamTarget(31, null)
+
+    broadcastAgentEvent(DELTA)
+
+    expect(idle.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('falls back to every window when no live window has reported a target', () => {
+    const first = windowWithId(41)
+    const second = windowWithId(42)
+    MockBrowserWindow.getAllWindows.mockReturnValue([first, second] as never)
+    // Left over from a window that has since closed: it must be forgotten, not
+    // counted as "somebody is watching".
+    setAgentStreamTarget(999, 'conversation-1')
+
+    broadcastAgentEvent(DELTA)
+
+    expect(first.webContents.send).toHaveBeenCalledWith(AgentChannels.events.AGENT_EVENT, DELTA)
+    expect(second.webContents.send).toHaveBeenCalledWith(AgentChannels.events.AGENT_EVENT, DELTA)
+  })
+
+  it('still broadcasts non-delta events to windows that show another conversation', () => {
+    const viewer = windowWithId(51)
+    const other = windowWithId(52)
+    MockBrowserWindow.getAllWindows.mockReturnValue([viewer, other] as never)
+    setAgentStreamTarget(51, 'conversation-1')
+    setAgentStreamTarget(52, 'conversation-2')
+    const event: AgentEvent = {
+      kind: 'turn_completed',
+      conversationId: 'conversation-1',
+      turnId: 'turn-1'
+    }
+
+    broadcastAgentEvent(event)
+
+    expect(viewer.webContents.send).toHaveBeenCalledWith(AgentChannels.events.AGENT_EVENT, event)
+    expect(other.webContents.send).toHaveBeenCalledWith(AgentChannels.events.AGENT_EVENT, event)
   })
 })

--- a/apps/desktop/src/main/agent/runtime/event-bus.ts
+++ b/apps/desktop/src/main/agent/runtime/event-bus.ts
@@ -1,7 +1,88 @@
+import { BrowserWindow } from 'electron'
+
 import { AgentChannels, type AgentEvent } from '@memry/contracts/ipc-agent'
 
+import { createLogger } from '../../lib/logger'
 import { broadcastToAllWindows } from '../../lib/window-broadcast'
 
+const logger = createLogger('AgentEventBus')
+
+/**
+ * Which conversation each window currently shows in Agent Chat, keyed by
+ * `BrowserWindow.id` (the same id the renderer sends as `sourceWindowId`).
+ *
+ * A window that has never reported is absent, which is deliberately different
+ * from a window that reported `null`: absent means "we do not know", and an
+ * unknown window still gets the full stream.
+ */
+const streamTargetByWindowId = new Map<number, string | null>()
+
+/** Records the conversation `windowId` currently shows; `null` clears it. */
+export function setAgentStreamTarget(windowId: number, conversationId: string | null): void {
+  streamTargetByWindowId.set(windowId, conversationId)
+}
+
+/**
+ * Fan an agent event out to the renderer.
+ *
+ * Every event kind except `assistant_text_delta` goes to all windows: they are
+ * per-turn, not per-token, and other windows need them to keep their
+ * conversation list and transcript current.
+ *
+ * `assistant_text_delta` is emitted once per token, and a window that does not
+ * show the conversation pays full reducer cost for text it will never render.
+ * Those go only to the windows that reported this conversation — with the
+ * completed `message_upserted` still broadcast to everyone, so a window that is
+ * skipped mid-stream converges on the final text instead of being stranded.
+ *
+ * If no live window has reported at all (bootstrap race, agent runtime still
+ * lazy-starting), targeting would be a guess, so the delta is broadcast exactly
+ * as before. That keeps the change additive: streaming can only ever be
+ * narrowed by a window that opted in.
+ */
 export function broadcastAgentEvent(event: AgentEvent): void {
-  broadcastToAllWindows(AgentChannels.events.AGENT_EVENT, event)
+  if (event.kind !== 'assistant_text_delta') {
+    broadcastToAllWindows(AgentChannels.events.AGENT_EVENT, event)
+    return
+  }
+
+  const targets = resolveDeltaTargets(event.conversationId)
+  if (targets === null) {
+    broadcastToAllWindows(AgentChannels.events.AGENT_EVENT, event)
+    return
+  }
+
+  for (const win of targets) {
+    // A window can die between the liveness check below and this send. Contain
+    // that per window: the turn keeps streaming and still persists its message,
+    // exactly like broadcastToAllWindows does for the fan-out path.
+    try {
+      win.webContents.send(AgentChannels.events.AGENT_EVENT, event)
+    } catch (err) {
+      logger.warn('Failed to deliver an assistant delta to a window:', err)
+    }
+  }
+}
+
+/**
+ * Windows that should receive deltas for `conversationId`, or `null` when no
+ * live window has reported a target and the caller should broadcast instead.
+ *
+ * Also prunes entries for windows that no longer exist, so the map cannot grow
+ * across a session of opening and closing windows.
+ */
+function resolveDeltaTargets(conversationId: string): BrowserWindow[] | null {
+  const liveWindows = BrowserWindow.getAllWindows().filter((win) => !isUnreachable(win))
+  const liveIds = new Set(liveWindows.map((win) => win.id))
+  for (const windowId of streamTargetByWindowId.keys()) {
+    if (!liveIds.has(windowId)) streamTargetByWindowId.delete(windowId)
+  }
+  if (streamTargetByWindowId.size === 0) return null
+
+  return liveWindows.filter((win) => streamTargetByWindowId.get(win.id) === conversationId)
+}
+
+function isUnreachable(win: BrowserWindow): boolean {
+  if (win.isDestroyed()) return true
+  return typeof win.webContents.isDestroyed === 'function' && win.webContents.isDestroyed()
 }

--- a/apps/desktop/src/main/ipc/agent-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.test.ts
@@ -51,6 +51,7 @@ vi.mock('../agent/settings', () => ({
 
 import { AgentChannels } from '@memry/contracts/ipc-agent'
 
+import { broadcastAgentEvent } from '../agent/runtime/event-bus'
 import {
   registerAgentHandlers,
   registerUnavailableAgentHandlers,
@@ -453,6 +454,87 @@ describe('agent IPC handlers', () => {
 
     expect(mockElectron.BrowserWindow.fromWebContents).toHaveBeenCalledWith({ id: 123 })
     expect(result).toEqual({ windowId: '42' })
+  })
+
+  it('records the sender window so streamed deltas reach only it', async () => {
+    registerAgentHandlers(deps)
+    const viewer = new mockElectron.BrowserWindow()
+    const other = new mockElectron.BrowserWindow()
+    mockElectron.BrowserWindow.fromWebContents.mockReturnValue(viewer as never)
+    mockElectron.BrowserWindow.getAllWindows.mockReturnValue([viewer, other] as never)
+
+    const result = await findHandler(AgentChannels.invoke.SET_STREAM_TARGET)(
+      { sender: viewer.webContents },
+      { conversationId: 'conversation-1' }
+    )
+    broadcastAgentEvent({
+      kind: 'assistant_text_delta',
+      conversationId: 'conversation-1',
+      messageId: 'message-1',
+      text: 'hello'
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(viewer.webContents.send).toHaveBeenCalledWith(
+      AgentChannels.events.AGENT_EVENT,
+      expect.objectContaining({ kind: 'assistant_text_delta' })
+    )
+    expect(other.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('records the sender window even while the agent runtime is unavailable', async () => {
+    registerUnavailableAgentHandlers('missing key')
+    const viewer = new mockElectron.BrowserWindow()
+    const other = new mockElectron.BrowserWindow()
+    mockElectron.BrowserWindow.fromWebContents.mockReturnValue(viewer as never)
+    mockElectron.BrowserWindow.getAllWindows.mockReturnValue([viewer, other] as never)
+
+    const result = await findHandler(AgentChannels.invoke.SET_STREAM_TARGET)(
+      { sender: viewer.webContents },
+      { conversationId: 'conversation-2' }
+    )
+    broadcastAgentEvent({
+      kind: 'assistant_text_delta',
+      conversationId: 'conversation-2',
+      messageId: 'message-2',
+      text: 'hello'
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(viewer.webContents.send).toHaveBeenCalledWith(
+      AgentChannels.events.AGENT_EVENT,
+      expect.objectContaining({ kind: 'assistant_text_delta' })
+    )
+    expect(other.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('leaves a sender whose window cannot be resolved unrecorded', async () => {
+    registerAgentHandlers(deps)
+    const first = new mockElectron.BrowserWindow()
+    const second = new mockElectron.BrowserWindow()
+    mockElectron.BrowserWindow.getAllWindows.mockReturnValue([first, second] as never)
+
+    // Two live windows and no match: resolveSenderWindowId gives up, so the
+    // sender stays unknown and keeps receiving the full stream.
+    await findHandler(AgentChannels.invoke.SET_STREAM_TARGET)(
+      { sender: { id: 999 } },
+      { conversationId: 'conversation-3' }
+    )
+    broadcastAgentEvent({
+      kind: 'assistant_text_delta',
+      conversationId: 'conversation-3',
+      messageId: 'message-3',
+      text: 'hello'
+    })
+
+    expect(first.webContents.send).toHaveBeenCalledWith(
+      AgentChannels.events.AGENT_EVENT,
+      expect.objectContaining({ kind: 'assistant_text_delta' })
+    )
+    expect(second.webContents.send).toHaveBeenCalledWith(
+      AgentChannels.events.AGENT_EVENT,
+      expect.objectContaining({ kind: 'assistant_text_delta' })
+    )
   })
 
   it('falls back to matching sender webContents when resolving window id', async () => {

--- a/apps/desktop/src/main/ipc/agent-handlers.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.ts
@@ -8,6 +8,7 @@ import {
   AgentChannels,
   AgentLocalProviderSettingsUpdateSchema,
   AgentPreferencesUpdateSchema,
+  AgentStreamTargetRequestSchema,
   ApproveToolRequestSchema,
   PreviewDiffRequestSchema,
   type AgentBackendOptions,
@@ -33,7 +34,7 @@ import type { AgentBackendRegistry } from '../agent/backends/registry'
 import type { ConversationStore } from '../agent/storage/conversation-store'
 import type { MessageStore } from '../agent/storage/message-store'
 import type { Conversation, Message } from '../agent/storage/types'
-import { broadcastAgentEvent } from '../agent/runtime/event-bus'
+import { broadcastAgentEvent, setAgentStreamTarget } from '../agent/runtime/event-bus'
 import { broadcastToAllWindows } from '../lib/window-broadcast'
 import { createLogger } from '../lib/logger'
 import { getMainI18n } from '../lib/main-i18n'
@@ -318,6 +319,10 @@ export function registerAgentHandlers(deps: AgentHandlerDeps): void {
   ipcMain.handle(AgentChannels.invoke.GET_WINDOW_ID, (event) => ({
     windowId: resolveSenderWindowId(event.sender)
   }))
+  ipcMain.handle(AgentChannels.invoke.SET_STREAM_TARGET, (event, payload: unknown) => {
+    recordStreamTarget(event.sender, payload)
+    return { ok: true }
+  })
 }
 
 export function registerUnavailableAgentHandlers(reason: string): void {
@@ -381,6 +386,13 @@ export function registerUnavailableAgentHandlers(reason: string): void {
   registerUnavailableHandler(AgentChannels.invoke.GET_WINDOW_ID, (event) => ({
     windowId: resolveSenderWindowId(event.sender)
   }))
+  // Recording where a conversation is displayed needs no runtime, and keeping it
+  // answered here means a window that mounts Agent Chat while the runtime is
+  // unavailable is still a known target once the runtime does come up.
+  registerUnavailableHandler(AgentChannels.invoke.SET_STREAM_TARGET, (event, payload) => {
+    recordStreamTarget(event.sender, payload)
+    return { ok: true }
+  })
 }
 
 export function unregisterAgentHandlers(): void {
@@ -453,6 +465,19 @@ function broadcastConversation(conversation: Conversation): void {
  */
 function broadcastConversationsChanged(conversationId: string): void {
   broadcastToAllWindows(AgentChannels.events.CONVERSATIONS_CHANGED, { conversationId })
+}
+
+/**
+ * Note which conversation the sending window shows, so streamed deltas can skip
+ * the windows that would only throw them away. A sender whose window cannot be
+ * resolved is left unrecorded — it then counts as "unknown" and keeps receiving
+ * the full stream, rather than being silently cut off.
+ */
+function recordStreamTarget(sender: WebContents, payload: unknown): void {
+  const { conversationId } = AgentStreamTargetRequestSchema.parse(payload)
+  const windowId = resolveSenderWindowId(sender)
+  if (windowId === null) return
+  setAgentStreamTarget(Number(windowId), conversationId)
 }
 
 function resolveSenderWindowId(sender: WebContents): string | null {

--- a/apps/desktop/src/main/ipc/agent-lazy-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/agent-lazy-handlers.test.ts
@@ -135,6 +135,20 @@ describe('lazy agent IPC handlers', () => {
     expect(mocks.setAgentPreferences).toHaveBeenCalledWith({ toolApprovalMode: 'ask' })
   })
 
+  it('records a stream target without starting the runtime', () => {
+    const window = new mockElectron.BrowserWindow()
+    mockElectron.BrowserWindow.fromWebContents.mockReturnValue(window)
+    registerLazyAgentHandlers()
+
+    expect(
+      findHandler(AgentChannels.invoke.SET_STREAM_TARGET)(
+        { sender: window.webContents },
+        { conversationId: 'conversation-1' }
+      )
+    ).toEqual({ ok: true })
+    expect(mocks.ensureLazyAgentServicesStarted).not.toHaveBeenCalled()
+  })
+
   it('starts services when resolving the sender window id', () => {
     const window = new mockElectron.BrowserWindow()
     mockElectron.BrowserWindow.fromWebContents.mockReturnValue(window)

--- a/apps/desktop/src/main/ipc/agent-lazy-handlers.ts
+++ b/apps/desktop/src/main/ipc/agent-lazy-handlers.ts
@@ -5,6 +5,7 @@ import {
   AgentChannels,
   AgentLocalProviderSettingsUpdateSchema,
   AgentPreferencesUpdateSchema,
+  AgentStreamTargetRequestSchema,
   type AgentLocalModelList,
   type AgentLocalProviderProbeResult,
   type AgentLocalProviderSettings,
@@ -17,6 +18,7 @@ import {
 
 import { getAgentPreferences, setAgentPreferences } from '../agent/settings'
 import { getDisclosureState, acceptDisclosure } from '../agent/runtime/disclosure-state'
+import { setAgentStreamTarget } from '../agent/runtime/event-bus'
 import { ensureLazyAgentServicesStarted } from '../agent/lazy-services'
 import { createLogger } from '../lib/logger'
 import { getMainI18n } from '../lib/main-i18n'
@@ -178,6 +180,15 @@ export function registerLazyAgentHandlers(): void {
       logger.warn('Failed to start lazy agent services', error)
     })
     return { windowId: resolveSenderWindowId(event.sender) }
+  })
+  // Answered before the runtime exists on purpose: a window that mounts Agent
+  // Chat during the lazy start would otherwise stay "unknown", which forces the
+  // delta fan-out to fall back to every window for the first turn.
+  ipcMain.handle(AgentChannels.invoke.SET_STREAM_TARGET, (event, payload: unknown) => {
+    const { conversationId } = AgentStreamTargetRequestSchema.parse(payload)
+    const windowId = resolveSenderWindowId(event.sender)
+    if (windowId !== null) setAgentStreamTarget(Number(windowId), conversationId)
+    return { ok: true }
   })
 }
 

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -29,6 +29,7 @@ export interface MainIpcInvokeHandlers {
   "agent:sendTurn": (...args: [unknown]) => Awaited<Promise<{ ok: boolean; error: string; } | { ok: boolean; error?: undefined; }>>
   "agent:setLocalProviderSettings": (...args: [unknown]) => Awaited<Promise<{ preset: "custom" | "ollama" | "lm_studio" | "llama_cpp"; baseUrl: string; model: string; apiKeyConfigured: boolean; allowNonLoopback: boolean; }>>
   "agent:setPreferences": (...args: [unknown]) => Awaited<Promise<{ accessMode: "vault_only" | "computer_access"; toolApprovalMode: "always_accept" | "ask"; }>>
+  "agent:setStreamTarget": (...args: [unknown]) => Awaited<{ ok: boolean; }>
   "agent:testLocalProvider": (...args: []) => Awaited<Promise<{ connected: boolean; modelAvailable: boolean; streamingSupported: boolean; toolCallingSupported: boolean; toolContinuationSupported: boolean; toolsEnabled: boolean; detail: string | null; }>>
   "ai-inline:get-server-port": (...args: []) => Awaited<number | null>
   "ai-inline:get-settings": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ai-inline-channels").AIInlineSettings>

--- a/apps/desktop/src/preload/api/agent.ts
+++ b/apps/desktop/src/preload/api/agent.ts
@@ -9,6 +9,7 @@ import type {
   AgentLocalProviderSettingsUpdate,
   AgentPreferences,
   AgentPreferencesUpdate,
+  AgentStreamTargetRequest,
   ApproveToolRequest,
   BackendStatusesResponse,
   PreviewDiffRequest,
@@ -73,6 +74,8 @@ export const agentApi = {
     invoke(AgentChannels.invoke.GET_DISCLOSURE_STATE),
   getWindowId: (): Promise<{ windowId: string | null }> =>
     invoke(AgentChannels.invoke.GET_WINDOW_ID),
+  setStreamTarget: (input: AgentStreamTargetRequest): Promise<{ ok: boolean }> =>
+    invoke(AgentChannels.invoke.SET_STREAM_TARGET, input),
   onEvent: (callback: (event: AgentEvent) => void): (() => void) =>
     subscribe<AgentEvent>(AgentChannels.events.AGENT_EVENT, callback),
   onConversationsChanged: (callback: (payload: { conversationId: string }) => void): (() => void) =>

--- a/apps/desktop/src/preload/api/preload-api.test.ts
+++ b/apps/desktop/src/preload/api/preload-api.test.ts
@@ -926,6 +926,11 @@ describe('preload api wrappers', () => {
       AgentChannels.invoke.GET_DISCLOSURE_STATE
     )
     await expectInvoke(() => agentApi.getWindowId(), AgentChannels.invoke.GET_WINDOW_ID)
+    await expectInvoke(
+      () => agentApi.setStreamTarget({ conversationId: 'conversation-1' }),
+      AgentChannels.invoke.SET_STREAM_TARGET,
+      { conversationId: 'conversation-1' }
+    )
     expectSubscribe(() => agentApi.onEvent(callback), AgentChannels.events.AGENT_EVENT)
   })
 

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx
@@ -93,6 +93,7 @@ describe('AgentProvider', () => {
     getDisclosureState: ReturnType<typeof vi.fn>
     acceptDisclosure: ReturnType<typeof vi.fn>
     getWindowId: ReturnType<typeof vi.fn>
+    setStreamTarget: ReturnType<typeof vi.fn>
     onEvent: ReturnType<typeof vi.fn>
   }
 
@@ -114,6 +115,7 @@ describe('AgentProvider', () => {
       getDisclosureState: vi.fn().mockResolvedValue({ accepted: false }),
       acceptDisclosure: vi.fn().mockResolvedValue({ accepted: true }),
       getWindowId: vi.fn().mockResolvedValue({ windowId: 'window-1' }),
+      setStreamTarget: vi.fn().mockResolvedValue({ ok: true }),
       onEvent: vi.fn((callback: (event: unknown) => void) => {
         eventHandler = callback
         return unsubscribe
@@ -137,6 +139,22 @@ describe('AgentProvider', () => {
 
     unmount()
     expect(unsubscribe).toHaveBeenCalled()
+  })
+
+  it('reports which conversation this window shows so deltas can be targeted', async () => {
+    const { result } = renderHook(() => useAgent(), { wrapper })
+
+    await waitFor(() =>
+      expect(agentApi.setStreamTarget).toHaveBeenCalledWith({ conversationId: null })
+    )
+
+    await act(async () => {
+      await result.current.loadConversation(conversation.id)
+    })
+
+    await waitFor(() =>
+      expect(agentApi.setStreamTarget).toHaveBeenCalledWith({ conversationId: conversation.id })
+    )
   })
 
   it('retries backend status bootstrap while lazy agent handlers start', async () => {

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx
@@ -157,6 +157,15 @@ describe('AgentProvider', () => {
     )
   })
 
+  it('keeps bootstrapping when the stream-target report fails', async () => {
+    agentApi.setStreamTarget.mockRejectedValue(new Error('stream target unavailable'))
+
+    const { result } = renderHook(() => useAgent(), { wrapper })
+
+    await waitFor(() => expect(result.current.state.sourceWindowId).toBe('window-1'))
+    expect(agentApi.setStreamTarget).toHaveBeenCalled()
+  })
+
   it('retries backend status bootstrap while lazy agent handlers start', async () => {
     agentApi.getBackendStatuses.mockRejectedValueOnce(
       new Error(

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
@@ -60,6 +60,12 @@ interface AgentClientApi {
   getDisclosureState: () => Promise<DisclosureState>
   acceptDisclosure: () => Promise<DisclosureState>
   getWindowId: () => Promise<{ windowId: string | null }>
+  /**
+   * Reports which conversation this window shows so main can stream deltas only
+   * here. Optional for the same reason as the sync listeners below: older
+   * preload bundles and the test stubs written against them do not expose it.
+   */
+  setStreamTarget?: (input: { conversationId: string | null }) => Promise<{ ok: boolean }>
   onEvent: (callback: (event: AgentEvent) => void) => () => void
   /**
    * Fired when a sync pull rewrites a conversation row. Optional because older
@@ -465,6 +471,33 @@ export function AgentProvider({
       unsubscribeMessages?.()
     }
   }, [t, active, refreshConversations, loadConversation, flushAssistantDeltas])
+
+  // Main emits one `assistant_text_delta` per token, and a window that does not
+  // show the conversation runs the whole reducer for text it never renders.
+  // Telling main what this window shows lets it address those deltas; a window
+  // that never gets here stays unknown to main and keeps receiving all of them,
+  // so a failure degrades to the old fan-out rather than to a stalled
+  // transcript.
+  useEffect(() => {
+    const setStreamTarget = getAgentApi().setStreamTarget
+    if (!setStreamTarget) return
+
+    const conversationId = active ? state.activeConversationId : null
+    let cancelled = false
+
+    void invokeWhenAgentReady(() =>
+      // A retry that outlives its effect must not overwrite a newer target: the
+      // bootstrap loop retries for seconds, and conversation switches are fast.
+      cancelled ? Promise.resolve({ ok: false }) : setStreamTarget({ conversationId })
+    ).catch((error) => {
+      if (cancelled) return
+      trackRendererError('agent_set_stream_target', error)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [active, state.activeConversationId])
 
   const value = useMemo<AgentContextValue>(
     () => ({

--- a/apps/docs/src/architecture/ipc.md
+++ b/apps/docs/src/architecture/ipc.md
@@ -91,6 +91,18 @@ An ESLint `no-restricted-syntax` rule over `apps/desktop/src/main/**` rejects `f
 
 Picking a single window (focusing the app from a notification click, targeting the sender) is also not a fan-out. Those sites take the first _live_ window — `BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())` — rather than `getAllWindows()[0]`, which throws when the window at index 0 has been destroyed.
 
+### Agent Chat streaming deltas
+
+`agent:event` is one channel carrying two very different traffic shapes. Turn-lifecycle events (`message_upserted`, `conversation_updated`, `tool_call_*`, `turn_completed`, `turn_error`) are per turn and still fan out to every window through `broadcastToAllWindows`. `assistant_text_delta` is emitted once per token, and a window that does not display that conversation would run the whole agent reducer for text it never renders, so `broadcastAgentEvent` in `src/main/agent/runtime/event-bus.ts` addresses those to the windows that do.
+
+Each window reports what it shows over `agent:setStreamTarget` (`{ conversationId: string | null }`, `null` meaning Agent Chat is open with nothing selected). `AgentProvider` sends it whenever its active conversation changes; main keys the report by `BrowserWindow.id` — the same id the renderer already sends as `sourceWindowId`.
+
+Three properties keep the narrowing safe:
+
+- A window that has never reported is _unknown_, not uninterested. While no live window has reported at all — bootstrap race, agent runtime still lazy-starting — deltas broadcast exactly as before, so a failed registration degrades to the old fan-out rather than to a transcript that never fills in. `agent:setStreamTarget` is answered by the lazy and unavailable handler sets too, so a window that mounts Agent Chat before the runtime exists still becomes known.
+- Targeting is per conversation, not per turn, so two windows showing the same conversation both stream. A window skipped mid-stream is never stranded either: the terminal `message_upserted` carries the full text and still goes to everyone.
+- Sends are guarded per window like the fan-out helper, and window ids that are no longer live are pruned on each delta, so a window destroyed mid-turn neither throws into the turn loop nor leaves an entry behind.
+
 ### Subscribing to a broadcast from the renderer
 
 A high-frequency broadcast must not be subscribed to per component. `useAppUpdater` originally kept `useState` per instance, so its five mounted consumers each ran `updater.getState()` on mount, each registered `onUpdaterStateChanged`, and each re-rendered on every `download-progress` tick — including the one at the App root, which re-rendered the whole tree several times per second during a download.

--- a/packages/contracts/src/ipc-agent.test.ts
+++ b/packages/contracts/src/ipc-agent.test.ts
@@ -48,7 +48,8 @@ describe('AgentChannels', () => {
         PROBE_LOCAL_PROVIDER: 'agent:probeLocalProvider',
         ACCEPT_DISCLOSURE: 'agent:acceptDisclosure',
         GET_DISCLOSURE_STATE: 'agent:getDisclosureState',
-        GET_WINDOW_ID: 'agent:getWindowId'
+        GET_WINDOW_ID: 'agent:getWindowId',
+        SET_STREAM_TARGET: 'agent:setStreamTarget'
       },
       events: {
         AGENT_EVENT: 'agent:event',

--- a/packages/contracts/src/ipc-agent.ts
+++ b/packages/contracts/src/ipc-agent.ts
@@ -30,7 +30,14 @@ export const AgentChannels = {
     PROBE_LOCAL_PROVIDER: 'agent:probeLocalProvider',
     ACCEPT_DISCLOSURE: 'agent:acceptDisclosure',
     GET_DISCLOSURE_STATE: 'agent:getDisclosureState',
-    GET_WINDOW_ID: 'agent:getWindowId'
+    GET_WINDOW_ID: 'agent:getWindowId',
+    /**
+     * The calling window tells main which conversation it currently shows, so
+     * per-token `assistant_text_delta` events reach only the windows that can
+     * render them. Purely additive: a window that never calls this is treated
+     * as "unknown", never as "not interested".
+     */
+    SET_STREAM_TARGET: 'agent:setStreamTarget'
   },
   events: {
     AGENT_EVENT: 'agent:event',
@@ -427,6 +434,12 @@ export const SendTurnRequestSchema = z.object({
   permissions: AgentTurnPermissionsSchema.optional()
 })
 export type SendTurnRequest = z.infer<typeof SendTurnRequestSchema>
+
+/** `null` means the window has Agent Chat open but no conversation selected. */
+export const AgentStreamTargetRequestSchema = z.object({
+  conversationId: z.string().nullable()
+})
+export type AgentStreamTargetRequest = z.infer<typeof AgentStreamTargetRequestSchema>
 
 export const SendTurnResponseSchema = z.object({
   ok: z.boolean(),


### PR DESCRIPTION
Closes #1065. Part of epic #987 (Memory & CPU full-app performance audit 2026-08).

## What was wrong

`apps/desktop/src/main/agent/runtime/event-bus.ts:5-7` sent **every** agent event through `broadcastToAllWindows`, including `assistant_text_delta`, which `handleBackendEvent` (`apps/desktop/src/main/agent/runtime/turn.ts:583-591`) emits once per token.

Every window with an activated `AgentProvider` therefore ran the full buffer + reducer path per token — even a window showing a different conversation, or no Agent Chat at all — multiplying renderer-side streaming cost by window count. There was no per-conversation or per-window filtering.

Validated on current `main` (21d1dae9b) before implementing: the behavior is unchanged since the audit, only line numbers drifted.

## What changed

Windows now tell main which conversation they display; deltas are addressed to those windows.

- `packages/contracts/src/ipc-agent.ts` — new additive invoke channel `agent:setStreamTarget` + `AgentStreamTargetRequestSchema` (`{ conversationId: string | null }`, `null` = Agent Chat open with nothing selected).
- `apps/desktop/src/main/agent/runtime/event-bus.ts` — keeps a `BrowserWindow.id → conversationId | null` map. `assistant_text_delta` goes only to windows that reported that conversation; every other event kind still fans out to all windows.
- `apps/desktop/src/main/ipc/agent-handlers.ts`, `agent-lazy-handlers.ts` — register the channel in the full, lazy, and unavailable handler sets, resolving the sender through the existing `resolveSenderWindowId`.
- `apps/desktop/src/preload/api/agent.ts`, `apps/desktop/src/renderer/src/agent-chat/agent-context.tsx` — `AgentProvider` reports its active conversation (and `null` when inactive); a retry that outlives its effect cannot overwrite a newer target.
- `apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts` — regenerated.

### Safety properties

- **Never strands a viewer.** Targeting is per conversation, not per turn, so two windows on the same conversation both stream. A window skipped mid-stream still receives the terminal `message_upserted` with the full text, which is broadcast to everyone.
- **Unknown ≠ uninterested.** While no live window has reported at all (bootstrap race, lazy runtime start, or any registration failure), deltas broadcast exactly as before. Narrowing only ever happens because a window opted in — so a failure degrades to today's behavior, not to a frozen transcript. The channel is also answered by the lazy/unavailable handler sets so an early-mounting window still becomes known.
- **Destroyed / reloaded windows.** Sends are guarded per window the same way `broadcastToAllWindows` guards its fan-out, so a window dying mid-send is logged and skipped and the turn still completes and persists. Dead window ids are pruned on each delta, so the map cannot grow across a session. A reload re-registers under the same window id.
- **Backward compatible.** Purely additive: no existing channel, payload, or event shape changed.

## How it was verified

```
pnpm --filter @memry/desktop typecheck:node   # clean
pnpm --filter @memry/desktop typecheck:web    # clean

vitest --project main  src/main/agent/runtime/__tests__/event-bus.test.ts
vitest --project main  src/main/ipc/agent-lazy-handlers.test.ts       # 13 passed
vitest --project preload src/preload/api/preload-api.test.ts          # 8 passed
vitest --project renderer .../agent-provider.test.tsx                 # 14 passed
packages/contracts: vitest src/ipc-agent.test.ts                      # 15 passed

pnpm exec eslint <changed files>   # 0 errors
git diff --check                   # clean
pnpm ipc:generate && pnpm ipc:check  # invoke map up to date
pnpm docs:impact --base origin/main --strict  # docs changed on this branch
pnpm docs:build                    # build complete
```

New main-process regression tests in `apps/desktop/src/main/agent/runtime/__tests__/event-bus.test.ts` cover targeted delivery, a second window on the same conversation, a destroyed window mid-stream, dropping deltas nobody shows, pruning + fallback, and non-delta events still reaching all windows.

**Mutation-checked**, not mock-trusted: reverting `broadcastAgentEvent` to the pre-fix broadcast path while keeping the tests fails exactly the two targeting assertions —

```
× sends assistant deltas only to the windows showing that conversation
× drops assistant deltas for a conversation no window shows
  Tests  2 failed | 5 passed (7)
```

Manual check for the issue's stated verification (two windows, one chat: second window receives no per-token traffic) has not been run on a packaged build.