### PR TITLE
fix(calendar): let a Google reconnect revive the account source disconnect tombstoned

### DIFF
--- a/apps/desktop/src/main/ipc/calendar-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/calendar-handlers.test.ts
@@ -1100,6 +1100,77 @@ describe('calendar-handlers', () => {
     expect(sourceIds).toContain('google-calendar:bob-primary')
   })
 
+  it('reconnects an account that was disconnected, reviving its tombstoned rows (#1201)', async () => {
+    registerCalendarHandlers()
+
+    const connection = {
+      accountId: 'adam@example.com',
+      account: {
+        remoteId: 'adam@example.com',
+        email: 'adam@example.com',
+        title: 'Adam Example',
+        timezone: 'Europe/London'
+      },
+      primaryCalendar: {
+        remoteId: 'adam@example.com',
+        title: 'Adam Example',
+        timezone: 'Europe/London',
+        color: '#0ea5e9',
+        isPrimary: true
+      }
+    }
+    mockConnectGoogleCalendar.mockResolvedValue(connection)
+    mockHasAnyGoogleCalendarLocalAuth.mockResolvedValue(true)
+    mockHasGoogleCalendarLocalAuth.mockResolvedValue(true)
+    mockListGoogleAccountIds.mockReturnValue(['adam@example.com'])
+    // Isolate the account + primary rows this test asserts on; discovery has
+    // its own coverage and an earlier test leaves an implementation behind.
+    mockDiscoverGoogleCalendarSources.mockReset()
+
+    await invokeHandler(CalendarChannels.invoke.CONNECT_PROVIDER, { provider: 'google' })
+
+    // Per-account disconnect — the button the settings UI actually wires up.
+    // It tombstones the rows rather than deleting them.
+    mockHasAnyGoogleCalendarLocalAuth.mockResolvedValue(false)
+    mockHasGoogleCalendarLocalAuth.mockResolvedValue(false)
+    const disconnected = await invokeHandler(CalendarChannels.invoke.DISCONNECT_PROVIDER, {
+      provider: 'google',
+      accountId: 'adam@example.com'
+    })
+    expect(disconnected.status.connected).toBe(false)
+
+    // Reconnecting the same account must bring it back. Before the fix the
+    // upsert left `archived_at` set, so every read path kept filtering the
+    // account row out and the user could never connect again.
+    mockHasAnyGoogleCalendarLocalAuth.mockResolvedValue(true)
+    mockHasGoogleCalendarLocalAuth.mockResolvedValue(true)
+    const reconnected = await invokeHandler(CalendarChannels.invoke.CONNECT_PROVIDER, {
+      provider: 'google'
+    })
+
+    expect(reconnected.success).toBe(true)
+    expect(reconnected.status.connected).toBe(true)
+    expect(reconnected.status.account).toEqual({
+      id: 'google-account:adam@example.com',
+      title: 'Adam Example'
+    })
+    expect(reconnected.status.accounts).toEqual([
+      expect.objectContaining({ accountId: 'adam@example.com', status: 'connected' })
+    ])
+    expect(reconnected.status.calendars.selected).toBe(1)
+
+    const sources = await invokeHandler(CalendarChannels.invoke.LIST_SOURCES, {
+      provider: 'google'
+    })
+    expect(sources.sources.map((source: { id: string }) => source.id)).toEqual([
+      'google-account:adam@example.com',
+      'google-calendar:adam@example.com'
+    ])
+    for (const source of sources.sources as Array<{ archivedAt: string | null }>) {
+      expect(source.archivedAt).toBeNull()
+    }
+  })
+
   it('refreshes Google provider state only when local auth exists', async () => {
     registerCalendarHandlers()
     mockHasAnyGoogleCalendarLocalAuth.mockResolvedValue(false)

--- a/apps/desktop/src/main/ipc/calendar-handlers.ts
+++ b/apps/desktop/src/main/ipc/calendar-handlers.ts
@@ -694,6 +694,12 @@ export function registerCalendarHandlers(): void {
           isMemryManaged: false,
           syncStatus: 'pending',
           metadata: { connectedVia: 'oauth', email: connected.account.email },
+          // A per-account disconnect tombstones these rows instead of deleting
+          // them, and every read path filters on `archivedAt IS NULL`. Without
+          // clearing it here the reconnect finishes, stores fresh tokens, and
+          // still leaves the account row invisible — so status reports "Not
+          // Connected" forever and the user can never get back in (#1201).
+          archivedAt: null,
           createdAt: now,
           modifiedAt: now
         })
@@ -712,6 +718,10 @@ export function registerCalendarHandlers(): void {
           isMemryManaged: false,
           syncStatus: 'pending',
           metadata: null,
+          // Same tombstone as above: discovery already revives calendar rows
+          // (`discoverGoogleCalendarSources`), but it runs after this upsert and
+          // is allowed to fail, so the primary has to clear its own.
+          archivedAt: null,
           createdAt: now,
           modifiedAt: now
         })

--- a/apps/desktop/src/renderer/src/components/settings/google-calendar-integration-row.test.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/google-calendar-integration-row.test.tsx
@@ -276,6 +276,20 @@ describe('Google Calendar integration row', () => {
     })
   ]
 
+  it('counts only the calendars it renders, not the hidden memrynote one (#1205)', async () => {
+    // CONNECTED_STATUS reports calendars.selected = 2 (Work + the memrynote-
+    // managed calendar), but the list below hides memrynote-managed rows, so
+    // only Work is visible as selected. Reporting the raw status count is what
+    // made a single-account install read as two connected calendars.
+    mockGetGoogleCalendarStatus.mockResolvedValue(CONNECTED_STATUS)
+    mockListSources.mockResolvedValue({ sources: CONNECTED_SOURCES })
+
+    renderIntegrationList()
+
+    expect(await screen.findByText('1 selected')).toBeInTheDocument()
+    expect(screen.queryByText('2 selected')).not.toBeInTheDocument()
+  })
+
   it('lists each account with only its own calendars underneath', async () => {
     mockGetGoogleCalendarStatus.mockResolvedValue(TWO_ACCOUNT_STATUS)
     mockListSources.mockResolvedValue({ sources: TWO_ACCOUNT_SOURCES })

--- a/apps/desktop/src/renderer/src/components/settings/google-calendar-integration-row.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/google-calendar-integration-row.tsx
@@ -196,6 +196,15 @@ export function GoogleCalendarIntegrationRow(): React.JSX.Element {
     [sourcesData?.sources]
   )
 
+  // Count what this section actually renders. `status.calendars.selected` counts
+  // every selected calendar row including the memrynote-managed one, which the
+  // list above deliberately hides — so a single connected account read as
+  // "2 selected" next to one visible calendar (#1205).
+  const importedSelectedCount = useMemo(
+    () => importedSources.filter((source) => source.isSelected).length,
+    [importedSources]
+  )
+
   // One group per connected account, plus a trailing group for calendars whose
   // accountId matches no account we know about. Those exist on installs that
   // connected before sources carried an account id — dropping them here would
@@ -345,7 +354,7 @@ export function GoogleCalendarIntegrationRow(): React.JSX.Element {
               {t('integrations.googleCalendar.importedCalendars')}
             </span>
             <span className="text-xs text-muted-foreground">
-              {t('integrations.googleCalendar.selected', { count: status.calendars.selected })}
+              {t('integrations.googleCalendar.selected', { count: importedSelectedCount })}
             </span>
           </div>
 

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -152,6 +152,10 @@ The calendar list refreshes on every sync, so a calendar you create in Google la
 
 Each account has its own **Disconnect**, which unlinks only that account and removes only its events.
 
+Disconnecting is reversible. Linking the same account again restores it along with its calendars and your calendar choices, and the events are fetched fresh on the next sync.
+
+The **selected** count above the account groups reflects the calendars listed there. The memrynote calendar memrynote creates in Google to hold your pushed events is managed for you, so it is not listed and not counted.
+
 ### Sync Direction
 
 By default Google Calendar sync is **two-way**: events, tasks, reminders, and snoozes you create in memrynote are pushed up to Google, and changes made in Google flow back into memrynote.


### PR DESCRIPTION
## Root cause — confirmed, not instrumentation

**A per-account Google Calendar disconnect is a one-way door.** `disconnectGoogleAccount` tombstones the `calendar_sources` rows (`archivedAt = now`, `calendar-handlers.ts:377-385`) instead of deleting them, and every read path filters on `archivedAt IS NULL` (`listCalendarSources`, `calendar-sources-repository.ts:40`).

The `CONNECT_PROVIDER` upsert never cleared `archivedAt`. `upsertCalendarSource` does `.set(source)`, and the object the connect handler passes has no `archivedAt` key, so drizzle leaves the tombstone in place. The result:

1. OAuth succeeds, tokens land in the keychain.
2. The `google-account:<email>` row is written — still archived.
3. `buildProviderStatus` → `listCalendarSourceRows` filters it out → `accountSources` is empty → `connected: false`.
4. `resolveDefaultGoogleAccountId` returns `null`, `hasAnyGoogleCalendarLocalAuth` returns `false`, the sync runner has no account to run against.
5. Settings shows **Not Connected** and a Connect button. Clicking it repeats steps 1-4 forever.

`discoverGoogleCalendarSources` already handles exactly this case for `kind: 'calendar'` rows — it passes `archivedAt: null` with a comment explaining that a stale tombstone would hide the calendar on reconnect (`sync-service.ts:213-216`). The `kind: 'account'` row had nobody doing that for it, and it is the row every connected-state check keys off. Nothing anywhere in the calendar code ever clears `archivedAt` on an account row.

This matches Adam's report exactly: "I thought I would disconnect the calendar and reconnect… Now, I cant connect to my gcal at all. I've attempted a number of times." The connect flow was not failing — it was succeeding and then reporting itself as not connected.

### Ruled out, and why the reasoning holds

- **Poisoned secret (#1151).** Confirmed shipped in his build. Also irrelevant here: no throw ever reaches the user, so no `oauth-errors.ts` message is involved.
- **Google withholding `refresh_token`.** Would throw `'Google Calendar OAuth did not return a refresh token'` and surface an error. Adam saw a state, not an error.
- **Revoke swallowed on failure.** Real, but benign for reconnect: `prompt=consent` mints a new refresh token regardless of whether the old grant survived.
- **Win32 loopback / `select_account`.** Not needed to explain it. The bug is platform-independent; both reporters being on Windows is not load-bearing.

## #1205 — also a real bug, and #1187 did not fix it

Correction to the issue text: `git tag --contains e9b53c624` returns `v2026-08-08.2`, so **#1187 was in Adam's build**. It is not the fix, and it is not the cause.

The divergence is a counting bug that is still on `main`. `ensureMemryCalendarSource` creates the memrynote-managed calendar with `isSelected: true` (`sync-service.ts:161-163`). `buildProviderStatus.calendars.selected` counts every selected `kind: 'calendar'` row including that one, while the settings list filters memry-managed rows out before rendering. One connected account with one ticked calendar therefore renders one calendar under a header reading "2 selected" — "it states that two calendars are connected, while I can only see one connected."

Not case (c): no duplicate rows. The account row and the primary calendar row share the same `remoteId` (the user's email) but differ in `kind` and `id`, and both list and count read the same archived-filtered query.

## Changes

- `calendar-handlers.ts` — `archivedAt: null` on both `CONNECT_PROVIDER` upserts (account row and primary calendar row).
- `google-calendar-integration-row.tsx` — the header counts the calendars the section actually renders. Renderer-only; the `CalendarProviderStatus` contract is untouched and this was its only consumer.

Backward compatible: no schema change, no migration. An install already stuck in this state recovers by clicking Connect once.

## Verification

- `calendar-handlers.test.ts` — new test walks connect → per-account disconnect → reconnect and asserts the account row comes back unarchived and `status.connected` is true. **Mutation-tested**: dropping `archivedAt: null` fails it (`1 failed | 18 passed`). 19/19 with the fix.
- `google-calendar-integration-row.test.tsx` — new test asserts "1 selected" against the existing fixture that has a memry-managed calendar plus one ticked user calendar. 17/17.
- `pnpm lint` (0 errors), `pnpm typecheck` (16/16), `pnpm docs:impact --base origin/main --strict` (covered), `pnpm docs:build`.

Not reproduced on Windows hardware — the mechanism is platform-independent and the tests exercise it directly.

Closes #1201
Closes #1205
