### PR TITLE
fix(updater): stop one busy file from making a Windows update impossible

### DIFF
--- a/apps/desktop/build/installer.nsh
+++ b/apps/desktop/build/installer.nsh
@@ -1,0 +1,68 @@
+# Custom NSIS include, picked up automatically from directories.buildResources.
+#
+# Why this exists — stock electron-builder makes a Windows update all-or-nothing.
+# templates/nsis/uninstaller.nsh runs two different removal paths:
+#
+#   ${if} ${isUpdated}                 # update: every file in $INSTDIR is
+#     un.atomicRMDir                   # Rename'd into $PLUGINSDIR\old-install,
+#     ${if} $R0 != 0                   # and ONE unrenameable file (AV holding a
+#       un.restoreFiles                # handle, a stray process, an ACL) rolls
+#       Abort                          # the whole thing back and aborts.
+#   ${endif}
+#   RMDir /r $INSTDIR                  # plain uninstall: best-effort, tolerant
+#
+# The Abort exits the uninstaller with code 2, and include/installUtil.nsh's
+# handleUninstallResult turns that into "Failed to uninstall old application
+# files. Please try running the installer again.: 2" and quits the installer.
+# Nothing is installed. Since the installer always passes --updated when it
+# removes the old version, BOTH the in-app updater and manually running the new
+# setup.exe over an existing install take the strict path and fail — while
+# uninstalling from Control Panel first takes the tolerant RMDir path and works.
+# That is exactly the "the only way I can update is to uninstall and reinstall"
+# report from Windows users.
+#
+# customRemoveFiles replaces that whole block (see the !ifmacrodef in
+# uninstaller.nsh), so this macro owns both paths. It keeps the atomic rename as
+# the happy path — it is the safest way to remove files, and on success nothing
+# changes — but a busy file now falls back to the same tolerant sweep a manual
+# uninstall would have done instead of making the update impossible.
+#
+# The one case still worth aborting for is the app binary itself: if that cannot
+# be removed the app is genuinely still running, and letting the installer
+# extract over a live executable trades a clean failure (old version intact) for
+# a half-written install. That abort keeps stock behaviour for the case where
+# stock behaviour is right.
+!macro customRemoveFiles
+  ${if} ${isUpdated}
+    CreateDirectory "$PLUGINSDIR\old-install"
+
+    Push ""
+    Call un.atomicRMDir
+    Pop $R0
+
+    ${if} $R0 != 0
+      DetailPrint "File is busy: $R0"
+      DetailPrint "Atomic removal failed; falling back to in-place removal."
+
+      # Move back whatever was already relocated, so the sweep below deletes
+      # from one place instead of leaving half the old install in $PLUGINSDIR.
+      Push ""
+      Call un.restoreFiles
+      Pop $R9
+    ${endif}
+  ${endif}
+
+  # Move out of $INSTDIR so it can be removed. Tolerant by design: RMDir /r
+  # deletes what it can and skips what it cannot, leaving only genuinely locked
+  # files behind for the installer to overwrite.
+  SetOutPath $TEMP
+  RMDir /r $INSTDIR
+
+  # Do NOT schedule leftovers with /REBOOTOK here: the installer is about to
+  # extract the new version into this very directory, and a pending reboot-time
+  # delete would take the fresh install with it.
+  ${if} ${FileExists} "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
+    DetailPrint "$INSTDIR\${APP_EXECUTABLE_FILENAME} is still in use."
+    Abort `Can't remove "$INSTDIR\${APP_EXECUTABLE_FILENAME}".`
+  ${endif}
+!macroend

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -109,7 +109,12 @@ import { safeRead } from './vault/file-ops'
 import { SnapshotReasons } from '@memry/db-schema/schema/notes-cache'
 import { SettingsChannels, InboxChannels } from '@memry/contracts/ipc-channels'
 import { parseInboxOpenItemId } from './deeplink-utils'
-import { initializeUpdater, isQuitAndInstallRequested, performQuitAndInstall } from './updater'
+import {
+  initializeUpdater,
+  isQuitAndInstallRequested,
+  noteFailedUpdateInstall,
+  performQuitAndInstall
+} from './updater'
 import { clearPendingInstallMarker, isPendingInstallInFlight } from './updater-install-guard'
 import { applyGpuCrashGuard, recordGpuCrash, shouldRecordGpuCrash } from './gpu-crash-guard'
 import { buildAppMenu, buildEditableTextContextMenu } from './menu'
@@ -1434,7 +1439,13 @@ const appReady = app.whenReady().then(async () => {
   // Same shape as the crash marker: an update install that never applied left a
   // marker behind because the failure itself happened after this runtime was
   // disposed on the previous quit.
-  detectFailedUpdateInstall(app.getVersion())
+  const failedInstall = detectFailedUpdateInstall(app.getVersion())
+  if (failedInstall) {
+    // Telemetry alone leaves the user stuck: same prompt, same Restart, same
+    // old version. Hand it to the updater state so the renderer can offer the
+    // manual installer instead of silently looping.
+    noteFailedUpdateInstall(failedInstall.toVersion ?? null)
+  }
   installCrashMarker(telemetryRuntime.context.sessionId, app.getVersion())
   startActiveHeartbeat(() => BrowserWindow.getFocusedWindow() !== null)
 

--- a/apps/desktop/src/main/telemetry/update-install-marker.test.ts
+++ b/apps/desktop/src/main/telemetry/update-install-marker.test.ts
@@ -81,6 +81,26 @@ describe('update install marker', () => {
     )
   })
 
+  it('returns the failed attempt so the caller can surface it in-app', () => {
+    // #given an install handed off from 2026.806.2 to v2026-08-07.2
+    markUpdateInstallStarted('2026.806.2', 'v2026-08-07.2')
+
+    // #when the app boots as the SAME old build
+    const failed = detectFailedUpdateInstall('2026.806.2')
+
+    // #then the attempt comes back, not just a telemetry event
+    expect(failed).toMatchObject({ fromVersion: '2026.806.2', toVersion: 'v2026-08-07.2' })
+  })
+
+  it('returns null when the install applied', () => {
+    // #given an install handed off from 2026.806.2
+    markUpdateInstallStarted('2026.806.2', 'v2026-08-07.2')
+
+    // #when the app boots as the new build
+    // #then there is nothing to surface
+    expect(detectFailedUpdateInstall('2026.807.2')).toBeNull()
+  })
+
   it('consumes the marker so the same failure is never reported twice', () => {
     // #given a failed install already reported on the previous boot
     markUpdateInstallStarted('2026.806.2')

--- a/apps/desktop/src/main/telemetry/update-install-marker.ts
+++ b/apps/desktop/src/main/telemetry/update-install-marker.ts
@@ -21,7 +21,7 @@ const logger = createLogger('UpdateInstallMarker')
 
 export const UPDATE_INSTALL_MARKER_FILENAME = 'update-install-attempt.json'
 
-interface UpdateInstallAttempt {
+export interface UpdateInstallAttempt {
   /**
    * Raw `app.getVersion()` of the build that handed off to the installer — the
    * one value the next launch can compare itself against. Never the display
@@ -75,13 +75,16 @@ export const markUpdateInstallStarted = (fromVersion: string, toVersion?: string
  * never applied. Call once per launch, after the telemetry runtime initializes.
  * The marker is consumed on every launch whatever the verdict, so a stale one
  * can neither accumulate nor report the same failure twice.
+ *
+ * Returns the failed attempt so the caller can surface it in-app: telemetry
+ * tells us, but the user is the one stuck on an old version with no idea why.
  */
-export const detectFailedUpdateInstall = (currentVersion: string): void => {
+export const detectFailedUpdateInstall = (currentVersion: string): UpdateInstallAttempt | null => {
   let raw: string
   try {
     raw = fs.readFileSync(markerPath(), 'utf-8')
   } catch {
-    return // no attempt recorded: normal launch
+    return null // no attempt recorded: normal launch
   }
 
   try {
@@ -93,9 +96,9 @@ export const detectFailedUpdateInstall = (currentVersion: string): void => {
   const attempt = parseAttempt(raw)
   // A corrupt marker proves an install was attempted but not from WHICH
   // version, and without that the applied/failed split is a coin flip.
-  if (!attempt) return
+  if (!attempt) return null
   // Booted as a different build: the installer did its job.
-  if (attempt.fromVersion !== currentVersion) return
+  if (attempt.fromVersion !== currentVersion) return null
 
   const startedAt = Date.parse(attempt.startedAt)
   const durationMs = Number.isFinite(startedAt) ? Math.max(0, Date.now() - startedAt) : undefined
@@ -117,4 +120,6 @@ export const detectFailedUpdateInstall = (currentVersion: string): void => {
       ...(attempt.toVersion ? { target_app_version: attempt.toVersion } : {})
     }
   })
+
+  return attempt
 }

--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -652,6 +652,27 @@ describe('updater', () => {
     )
   })
 
+  it("surfaces a previous session's failed install in the state the renderer reads", async () => {
+    const updater = await loadUpdater()
+
+    // Called at startup from the update-install marker, BEFORE initializeUpdater.
+    updater.noteFailedUpdateInstall('v1.2.7')
+    updater.initializeUpdater()
+
+    // Must survive updater init: otherwise the user gets the same prompt, the
+    // same Restart, and never learns the install is what is failing.
+    expect(updater.getUpdateState().installFailed).toEqual({ version: 'v1.2.7' })
+  })
+
+  it('records a failed install whose target version the marker never captured', async () => {
+    const updater = await loadUpdater()
+
+    updater.noteFailedUpdateInstall(null)
+
+    // Still worth surfacing: the failure is what matters, not which version.
+    expect(updater.getUpdateState().installFailed).toEqual({ version: null })
+  })
+
   it("routes electron-updater's own diagnostics into the app log instead of a dead console", async () => {
     const updater = await loadUpdater()
     updater.initializeUpdater()

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -172,7 +172,22 @@ let state: AppUpdateState = {
   lastCheckedAt: null,
   error: null,
   autoDownloadEnabled: false,
-  autoCheckEnabled: true
+  autoCheckEnabled: true,
+  installFailed: null
+}
+
+/**
+ * Surface a previous session's failed install to the renderer. Called at startup
+ * from the update-install marker, which runs long before initializeUpdater() —
+ * setState merges, so the flag survives updater init either way.
+ *
+ * Without this the failure is telemetry-only: the user sees the update prompt
+ * again on every launch, presses Restart again, and never learns why nothing
+ * changes. With it, the renderer can offer the manual installer instead.
+ */
+export function noteFailedUpdateInstall(version: string | null): void {
+  logger.warn('previous update install did not apply', { version })
+  setState({ installFailed: { version } })
 }
 
 export function initializeUpdater(): void {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -57,6 +57,7 @@ import { IncidentReportProvider } from '@/components/diagnostics/incident-report
 import { VaultOnboarding } from '@/components/vault-onboarding'
 import { UpdatingScreen } from '@/components/updating-screen'
 import { UpdatePromptDialog } from '@/components/updater/update-prompt-dialog'
+import { UpdateInstallFailedDialog } from '@/components/updater/update-install-failed-dialog'
 import { GithubStarCard } from '@/components/onboarding/github-star-card'
 import { UpdateReleaseNotesTabOpener } from '@/components/updater/update-release-notes-tab-opener'
 import { ReleaseNotesDevTrigger } from '@/components/updater/release-notes-dev-trigger'
@@ -574,6 +575,7 @@ function App(): React.JSX.Element {
           </TabErrorBoundary>
         </IncidentReportProvider>
         <UpdatePromptDialog />
+        <UpdateInstallFailedDialog />
         <Toaster />
       </ThemeProvider>
     )
@@ -601,6 +603,7 @@ function App(): React.JSX.Element {
           </DragProvider>
         </SidebarProvider>
         <UpdatePromptDialog />
+        <UpdateInstallFailedDialog />
         {/* Vault-open branch only: the tour that arms this never runs without a vault. */}
         <GithubStarCard />
         <Toaster />

--- a/apps/desktop/src/renderer/src/components/updater/update-install-failed-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/updater/update-install-failed-dialog.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { AppUpdateState } from '@memry/contracts/ipc-updater'
+
+const mocks = vi.hoisted(() => ({
+  state: {} as AppUpdateState
+}))
+
+vi.mock('@/hooks/use-app-updater', () => ({
+  useAppUpdater: () => ({ state: mocks.state })
+}))
+
+import {
+  UpdateInstallFailedDialog,
+  shouldShowInstallFailedPrompt
+} from './update-install-failed-dialog'
+
+function state(overrides: Partial<AppUpdateState> = {}): AppUpdateState {
+  return {
+    currentVersion: '2026.700.1',
+    status: 'idle',
+    updateSupported: true,
+    availableVersion: null,
+    releaseName: null,
+    releaseDate: null,
+    releaseNotes: null,
+    releaseNotesHtml: null,
+    downloadProgressPercent: null,
+    lastCheckedAt: null,
+    error: null,
+    autoDownloadEnabled: false,
+    autoCheckEnabled: true,
+    installFailed: null,
+    ...overrides
+  }
+}
+
+describe('shouldShowInstallFailedPrompt', () => {
+  it('surfaces a failed install', () => {
+    expect(
+      shouldShowInstallFailedPrompt(state({ installFailed: { version: 'v1.2.7' } }), false)
+    ).toBe(true)
+  })
+
+  it('surfaces a failure whose target version was never recorded', () => {
+    // The failure is what matters — losing the version must not hide it.
+    expect(shouldShowInstallFailedPrompt(state({ installFailed: { version: null } }), false)).toBe(
+      true
+    )
+  })
+
+  it('stays silent on a normal launch', () => {
+    expect(shouldShowInstallFailedPrompt(state(), false)).toBe(false)
+  })
+
+  it('stays silent once dismissed', () => {
+    expect(
+      shouldShowInstallFailedPrompt(state({ installFailed: { version: 'v1.2.7' } }), true)
+    ).toBe(false)
+  })
+
+  it('stays silent where updates are not supported (dev builds)', () => {
+    expect(
+      shouldShowInstallFailedPrompt(
+        state({ installFailed: { version: 'v1.2.7' }, updateSupported: false }),
+        false
+      )
+    ).toBe(false)
+  })
+})
+
+describe('UpdateInstallFailedDialog', () => {
+  beforeEach(() => {
+    mocks.state = state()
+  })
+
+  it('renders nothing on a normal launch', () => {
+    const { container } = render(<UpdateInstallFailedDialog />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('names both versions so the user can see they did not move', () => {
+    mocks.state = state({ installFailed: { version: 'v1.2.7' } })
+
+    render(<UpdateInstallFailedDialog />)
+
+    expect(screen.getByText(/v1\.2\.7/)).toBeInTheDocument()
+    expect(screen.getByText(/2026\.700\.1/)).toBeInTheDocument()
+  })
+
+  it('still explains the failure when the target version is unknown', () => {
+    mocks.state = state({ installFailed: { version: null } })
+
+    render(<UpdateInstallFailedDialog />)
+
+    // Falls back to the version-less copy rather than rendering a raw
+    // placeholder or hiding the failure entirely.
+    expect(screen.getByText(/tried to install an update/)).toBeInTheDocument()
+  })
+
+  it('hands the user the manual installer and closes', async () => {
+    mocks.state = state({ installFailed: { version: 'v1.2.7' } })
+    const open = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    render(<UpdateInstallFailedDialog />)
+    await userEvent.click(screen.getByRole('button', { name: /download installer/i }))
+
+    expect(open).toHaveBeenCalledWith(
+      'https://memrynote.com/download',
+      '_blank',
+      'noopener,noreferrer'
+    )
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    open.mockRestore()
+  })
+
+  it('can be dismissed for the session', async () => {
+    mocks.state = state({ installFailed: { version: 'v1.2.7' } })
+
+    render(<UpdateInstallFailedDialog />)
+    await userEvent.click(screen.getByRole('button', { name: /later/i }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/updater/update-install-failed-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/updater/update-install-failed-dialog.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useState } from 'react'
+import type { AppUpdateState } from '@memry/contracts/ipc-updater'
+import { useT } from '@memry/i18n/renderer'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Download } from '@/lib/icons'
+import { useAppUpdater } from '@/hooks/use-app-updater'
+import memryLogo from '@/assets/icon-logo.png'
+
+const DOWNLOAD_URL = 'https://memrynote.com/download'
+
+/**
+ * Only surfaces for an install that was attempted and never applied — the flag is
+ * set once per launch from the update-install marker and cleared with it, so this
+ * can neither fire on a normal launch nor repeat after the update succeeds.
+ */
+export function shouldShowInstallFailedPrompt(state: AppUpdateState, dismissed: boolean): boolean {
+  return state.updateSupported && !dismissed && Boolean(state.installFailed)
+}
+
+/**
+ * Recovery prompt for an update that downloaded, restarted the app, and then
+ * silently failed to install. Before this the failure was invisible: the same
+ * update prompt returned on the next launch, Restart did the same nothing, and
+ * the user's only way out was to work out on their own that uninstalling and
+ * reinstalling was the way to move versions.
+ *
+ * Deliberately not blocking — the app works, it is just the wrong version — and
+ * dismissible for the session. The marker is consumed on the launch that reads
+ * it, so a successful update never shows this again.
+ */
+export function UpdateInstallFailedDialog(): React.JSX.Element | null {
+  const { t } = useT('common')
+  const { state } = useAppUpdater()
+  const [dismissed, setDismissed] = useState(false)
+
+  const handleDownload = useCallback(() => {
+    // Routed to the OS browser by the main-process openExternal allowlist.
+    window.open(DOWNLOAD_URL, '_blank', 'noopener,noreferrer')
+    setDismissed(true)
+  }, [])
+
+  if (!shouldShowInstallFailedPrompt(state, dismissed)) return null
+
+  const failedVersion = state.installFailed?.version ?? null
+  const body = failedVersion
+    ? t('updatePrompt.installFailedBody', {
+        version: failedVersion,
+        current: state.currentVersion
+      })
+    : t('updatePrompt.installFailedBodyUnknownVersion', { current: state.currentVersion })
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) setDismissed(true)
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <div className="flex items-start gap-4">
+          <img src={memryLogo} alt="" className="size-12 shrink-0" />
+          <div className="flex flex-col gap-1.5 pe-6">
+            <DialogTitle className="text-base">{t('updatePrompt.installFailedTitle')}</DialogTitle>
+            <DialogDescription>{body}</DialogDescription>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <Button variant="outline" size="sm" onClick={() => setDismissed(true)}>
+            {t('updatePrompt.later')}
+          </Button>
+          <Button size="sm" onClick={handleDownload}>
+            <Download className="size-4" />
+            {t('updatePrompt.downloadInstaller')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/docs/src/guide/install.md
+++ b/apps/docs/src/guide/install.md
@@ -25,19 +25,23 @@ memrynote checks for updates in the background and prompts you to restart when o
 ready. Both the check and the download are optional — turn either off in
 **Settings → General**.
 
-The install itself runs after the app has closed. If the app reopens on the same
-version, the installer did not apply the update. That is worth reporting: the app now
-records the attempt and reports it on the next launch, and its log holds the reason.
+The install itself runs after the app has closed. If the installer does not apply the
+update, memrynote tells you on the next launch and offers to download the installer so
+you can run it yourself. Running it over your existing install is enough — your vault
+and settings are untouched, and you do not need to uninstall first.
 
-Send us the log file along with the report:
+It is still worth reporting, because the app's log holds the reason. Send us the log
+file along with the report:
 
 - **Windows** — `%APPDATA%\memrynote\logs\main.log`
 - **macOS** — `~/Library/Logs/memrynote/main.log`
 - **Linux** — `~/.config/memrynote/logs/main.log`
 
-As a workaround, download the current installer from the
-[download page](https://memrynote.com/download/desktop) and run it over your existing
-install. Your vault and settings are untouched — you do not need to uninstall first.
+On Windows, an update can also be blocked by a file in the install folder being held
+open — antivirus and leftover memrynote processes are the usual causes. The installer
+works around this on its own now, and it writes an `install.log` next to the app
+(typically `%LOCALAPPDATA%\Programs\memrynote`) that names the file it could not move.
+That log is the most useful thing you can send us if an update still fails.
 
 ## Run from Source
 

--- a/packages/contracts/src/ipc-updater.ts
+++ b/packages/contracts/src/ipc-updater.ts
@@ -46,4 +46,13 @@ export interface AppUpdateState {
   autoDownloadEnabled: boolean
   /** Whether the app checks for updates automatically at launch and on an interval (persisted). */
   autoCheckEnabled: boolean
+  /**
+   * Set on launch when the PREVIOUS session handed off to the update installer and
+   * the install never applied (see telemetry/update-install-marker), null on a
+   * normal launch. `version` is the update that failed, or null when the marker
+   * did not record one — the failure is still worth surfacing without it.
+   * Optional so an older renderer bundle reading a newer main keeps type-checking:
+   * absent and null both mean "no failed install".
+   */
+  installFailed?: { version: string | null } | null
 }

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -16,7 +16,11 @@
     "remindLater": "Remind Me Later",
     "download": "Download",
     "later": "Later",
-    "restartNow": "Restart Now"
+    "restartNow": "Restart Now",
+    "installFailedTitle": "The update could not be installed",
+    "installFailedBody": "MemryNote tried to install {version} and the installer did not finish, so you are still on {current}. This usually means a file in the install folder was locked — by antivirus, or by a copy of MemryNote that was still running. Downloading the installer and running it yourself normally gets past it.",
+    "installFailedBodyUnknownVersion": "MemryNote tried to install an update and the installer did not finish, so you are still on {current}. This usually means a file in the install folder was locked — by antivirus, or by a copy of MemryNote that was still running. Downloading the installer and running it yourself normally gets past it.",
+    "downloadInstaller": "Download installer"
   },
   "button": {
     "save": "Save",


### PR DESCRIPTION
## What

- `build/installer.nsh` adds a `customRemoveFiles` macro: the update path keeps the atomic rename as its happy path but falls back to the tolerant `RMDir /r` instead of aborting the whole install, and only refuses when the app binary itself survives.
- A failed install is now surfaced to the user — `detectFailedUpdateInstall` returns the attempt, `AppUpdateState.installFailed` carries it, and a new dialog offers the manual installer.
- Docs: what the recovery prompt is, and where the Windows `install.log` lives.

## Why

Stock electron-builder aborts the entire update when one file in `$INSTDIR` cannot be renamed (antivirus handle, stray process). Since the installer always passes `--updated`, running a freshly downloaded setup.exe over an existing install fails identically — leaving uninstall-then-reinstall as the only way these users can change versions. Reported by a Win11 user who hit it on every update.

## Not verified

The `.nsh` is never compiled here: no local makensis, and `.env.production` / `app-config` are absent so `build:win` cannot run. Needs a Windows check — install an old build, hold a file open in the install dir, run the new installer.