### PR TITLE
fix(sync): seed a clock on imported Google Calendar events so pushes stop failing

### DIFF
--- a/apps/desktop/src/main/calendar/google/sync-service.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.test.ts
@@ -12,6 +12,7 @@ import { calendarBindings } from '@memry/db-schema/schema/calendar-bindings'
 import { calendarEvents } from '@memry/db-schema/schema/calendar-events'
 import { calendarExternalEvents } from '@memry/db-schema/schema/calendar-external-events'
 import { calendarSources } from '@memry/db-schema/schema/calendar-sources'
+import { syncDevices } from '@memry/db-schema/schema/sync-devices'
 import { reminders } from '@memry/db-schema/schema/reminders'
 import { settings } from '@memry/db-schema/schema/settings'
 import { tasks } from '@memry/db-schema/schema/tasks'
@@ -506,6 +507,68 @@ describe('google calendar sync service', () => {
       title: 'Imported review',
       remoteEtag: '"etag-1"'
     })
+  })
+
+  it('seeds a clock on newly imported Google events and preserves an existing one (#1215)', async () => {
+    seedGoogleCalendarSource({
+      id: 'google-calendar:selected',
+      remoteId: 'remote-selected-calendar',
+      title: 'Work',
+      isMemryManaged: false
+    })
+
+    db.insert(syncDevices)
+      .values({
+        id: 'device-a',
+        name: 'Fedora',
+        platform: 'linux',
+        appVersion: '2026.08.11',
+        linkedAt: new Date('2026-04-12T09:00:00.000Z'),
+        isCurrentDevice: true,
+        signingPublicKey: 'pub-key'
+      })
+      .run()
+
+    const client = {
+      listEvents: vi.fn(async () => ({
+        nextSyncCursor: 'cursor-2',
+        events: [
+          {
+            id: 'remote-event-clock',
+            calendarId: 'remote-selected-calendar',
+            title: 'Imported review',
+            startAt: '2026-04-14T13:00:00.000Z',
+            endAt: '2026-04-14T14:00:00.000Z',
+            isAllDay: false,
+            timezone: 'UTC',
+            status: 'confirmed' as const,
+            etag: '"etag-1"',
+            updatedAt: '2026-04-12T10:20:00.000Z',
+            raw: { summary: 'Imported review' }
+          }
+        ]
+      }))
+    }
+
+    // #when an event this device has never seen is imported
+    await syncGoogleCalendarSource(db, 'google-calendar:selected', { client })
+
+    // #then it is stored with a clock — a NULL clock is rejected by the server
+    // for calendar_external_event and fails the entire push batch
+    const [imported] = db.select().from(calendarExternalEvents).all()
+    expect(imported.clock).toEqual({ 'device-a': 1 })
+
+    // #when the same event comes back on a later sync, having been clocked by a peer
+    db.update(calendarExternalEvents)
+      .set({ clock: { 'device-b': 4 } })
+      .where(eq(calendarExternalEvents.id, imported.id))
+      .run()
+
+    await syncGoogleCalendarSource(db, 'google-calendar:selected', { client })
+
+    // #then the import inherits the stored clock instead of restamping it
+    const [reimported] = db.select().from(calendarExternalEvents).all()
+    expect(reimported.clock).toEqual({ 'device-b': 4 })
   })
 
   it('writes truncated lastError + syncStatus="error" when listEvents throws (M6 T6)', async () => {

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -4,6 +4,7 @@ import { calendarEvents } from '@memry/db-schema/schema/calendar-events'
 import { calendarSources } from '@memry/db-schema/schema/calendar-sources'
 import { inboxItems } from '@memry/db-schema/schema/inbox'
 import { reminders } from '@memry/db-schema/schema/reminders'
+import { syncDevices } from '@memry/db-schema/schema/sync-devices'
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { createLogger } from '../../lib/logger'
 import { requireDatabase, type DataDb } from '../../database'
@@ -21,6 +22,7 @@ import {
 import { resolveTargetGoogleAccountId } from './account-routing'
 import { loadSourceAsGoogleEvent, pushEventWithConflictRetry } from './push-conflict-retry'
 import { isMemryUserSignedIn } from '../../sync/auth-state'
+import { increment } from '../../sync/vector-clock'
 import { createGoogleCalendarClient } from './client'
 import { CALENDAR_EVENT_SYNCABLE_FIELDS } from '../field-merge-calendar'
 import {
@@ -52,6 +54,20 @@ let syncInFlight = false
 
 function getNow(): string {
   return new Date().toISOString()
+}
+
+/**
+ * Local copy of the sync runtime's device lookup — `sync/offline-clock` is on
+ * the architecture check's blocked list for feature modules, and this is the
+ * same three-line query `runtime.ts` and `offline-clock.ts` already keep.
+ */
+function getCurrentDeviceId(db: DataDb): string | null {
+  const device = db
+    .select({ id: syncDevices.id })
+    .from(syncDevices)
+    .where(eq(syncDevices.isCurrentDevice, true))
+    .get()
+  return device?.id ?? null
 }
 
 function isGoneError(error: unknown): boolean {
@@ -777,6 +793,8 @@ async function syncGoogleCalendarSourceInner(
     return await syncGoogleCalendarSource(db, sourceId, deps)
   }
 
+  const importDeviceId = getCurrentDeviceId(db)
+
   for (const remoteEvent of result.events) {
     const binding = findCalendarBindingByRemoteEvent(
       db,
@@ -811,7 +829,16 @@ async function syncGoogleCalendarSourceInner(
 
     upsertCalendarExternalEvent(db, {
       ...record,
-      clock: existing?.clock
+      // A brand-new event has no `existing` clock to inherit, and `undefined`
+      // lands the row with a NULL clock. `calendar_external_event` is in
+      // RECORD_CLOCK_REQUIRED_ITEM_TYPES, so the server rejects a clock-less
+      // push item — and because RecordPushRequestSchema validates the whole
+      // items array, that ONE row fails the entire batch and stalls every other
+      // pending change on the device (#1215). Seed the same first clock
+      // `seedUnclocked` assigns. With no device row yet (vault not registered)
+      // there is no id to tick, so the clock stays NULL and the unclocked
+      // sweep/push repair still owns its first push.
+      clock: existing?.clock ?? (importDeviceId ? increment({}, importDeviceId) : undefined)
     })
     markSyncedTableMutation('calendar_external_event', record.id, Boolean(existing))
     emitCalendarChanged({ entityType: 'calendar_external_event', id: record.id })

--- a/apps/desktop/src/main/sync/item-handlers/calendar-external-event-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/calendar-external-event-handler.test.ts
@@ -350,6 +350,72 @@ describe('calendar external event handler — rich fields (M5 Codex P2c)', () =>
     ).toMatchObject({ sourceId: 'source-rich', title: 'Existing' })
   })
 
+  it('stamps and persists a first clock when pushing a row the import left unclocked (#1215)', () => {
+    const handler = getHandler('calendar_external_event')
+    testDb.db
+      .insert(calendarExternalEvents)
+      .values([
+        {
+          id: 'external-unclocked',
+          sourceId: 'source-rich',
+          remoteEventId: 'google-unclocked',
+          title: 'Imported without a clock',
+          startAt: '2026-04-22T09:00:00.000Z',
+          isAllDay: false,
+          status: 'confirmed'
+        },
+        {
+          id: 'external-clocked',
+          sourceId: 'source-rich',
+          remoteEventId: 'google-clocked',
+          title: 'Already clocked',
+          startAt: '2026-04-23T09:00:00.000Z',
+          isAllDay: false,
+          status: 'confirmed',
+          clock: { 'device-b': 3 }
+        }
+      ])
+      .run()
+
+    // #when the stuck row is pushed — the queue row already exists, so the
+    // startup-only seed never gets to repair it before this batch is built
+    const pushed = handler?.buildPushPayload?.(
+      testDb.db as unknown as DrizzleDb,
+      'external-unclocked',
+      'device-a',
+      'create'
+    )
+
+    // #then the payload carries a clock, so the server no longer rejects the
+    // whole batch...
+    expect(JSON.parse(pushed ?? '{}').clock).toEqual({ 'device-a': 1 })
+    // #and it is persisted, so the next local edit ticks forward instead of
+    // re-inventing the acked clock
+    expect(
+      testDb.db
+        .select()
+        .from(calendarExternalEvents)
+        .where(eq(calendarExternalEvents.id, 'external-unclocked'))
+        .get()?.clock
+    ).toEqual({ 'device-a': 1 })
+
+    // #and a row that already has a clock keeps it untouched
+    const clocked = handler?.buildPushPayload?.(
+      testDb.db as unknown as DrizzleDb,
+      'external-clocked',
+      'device-a',
+      'update'
+    )
+    expect(JSON.parse(clocked ?? '{}').clock).toEqual({ 'device-b': 3 })
+    expect(
+      testDb.db
+        .select()
+        .from(calendarExternalEvents)
+        .where(eq(calendarExternalEvents.id, 'external-clocked'))
+        .get()?.clock
+    ).toEqual({ 'device-b': 3 })
+  })
+
   it('handles stale/concurrent clocks, delete guards, fetch, null payload, and seed queueing', () => {
     const handler = getHandler('calendar_external_event')
     testDb.db

--- a/apps/desktop/src/main/sync/item-handlers/calendar-external-event-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/calendar-external-event-handler.ts
@@ -211,13 +211,42 @@ class CalendarExternalEventHandler extends BaseItemHandler<CalendarExternalEvent
       .get() as Record<string, unknown> | undefined
   }
 
-  buildPushPayload(db: DrizzleDb, itemId: string): string | null {
+  /**
+   * Stamp the first clock on a row that has none, and persist it.
+   *
+   * Shared by `seedUnclocked` (startup sweep) and `buildPushPayload` (per-push
+   * repair) so both produce the same first-push clock. Persisting is
+   * load-bearing: a clock invented for the payload alone would leave the row
+   * NULL, and the next real edit would tick from `{}` to the SAME clock the
+   * server already acked — a replay the server drops, losing the edit.
+   */
+  private stampFirstClock(db: DrizzleDb, itemId: string, deviceId: string): VectorClock {
+    const clock = increment({}, deviceId)
+    db.update(calendarExternalEvents)
+      .set({ clock })
+      .where(eq(calendarExternalEvents.id, itemId))
+      .run()
+    return clock
+  }
+
+  buildPushPayload(db: DrizzleDb, itemId: string, deviceId?: string): string | null {
     const row = db
       .select()
       .from(calendarExternalEvents)
       .where(eq(calendarExternalEvents.id, itemId))
       .get()
     if (!row) return null
+
+    // #1215 repair for installs that already have the damage. Rows written
+    // before the import seeded a clock are ALREADY in the queue, and
+    // `seedUnclocked` only runs from `runInitialSeed` inside a full sync — an
+    // incremental push cycle never reaches it, so the clock-less row is
+    // re-sent and rejected on every attempt. Since one clock-less item fails
+    // the whole batch at request level, that single row blocks all sync until
+    // the next full sync. Repairing here drains the stuck queue on the very
+    // next push, with no reset and no schema change.
+    const rowClock = (row.clock as VectorClock | null) ?? null
+    const clock = rowClock ?? (deviceId ? this.stampFirstClock(db, itemId, deviceId) : undefined)
     const payload: CalendarExternalEventSyncPayload = {
       sourceId: row.sourceId,
       remoteEventId: row.remoteEventId,
@@ -239,7 +268,7 @@ class CalendarExternalEventHandler extends BaseItemHandler<CalendarExternalEvent
       conferenceData: (row.conferenceData as Record<string, unknown> | null) ?? null,
       rawPayload: row.rawPayload ?? null,
       archivedAt: row.archivedAt ?? null,
-      clock: (row.clock as VectorClock) ?? undefined,
+      clock,
       createdAt: row.createdAt,
       modifiedAt: row.modifiedAt
     }
@@ -253,11 +282,7 @@ class CalendarExternalEventHandler extends BaseItemHandler<CalendarExternalEvent
       .where(isNull(calendarExternalEvents.clock))
       .all()
     for (const item of items) {
-      const nextClock = increment({}, deviceId)
-      db.update(calendarExternalEvents)
-        .set({ clock: nextClock })
-        .where(eq(calendarExternalEvents.id, item.id))
-        .run()
+      const nextClock = this.stampFirstClock(db, item.id, deviceId)
       queue.enqueue({
         type: 'calendar_external_event',
         itemId: item.id,

--- a/apps/docs/src/architecture/sync-handlers.md
+++ b/apps/docs/src/architecture/sync-handlers.md
@@ -274,6 +274,18 @@ device forever.
 `agent_conversation` and `agent_message` are the intentional exception — their `seedUnclocked`
 returns `0` because agent data syncs through the entitlement-gated backfill in `main/agent/sync/`.
 
+The seed is a safety net, not a licence to write clock-less rows. A type in
+`RECORD_CLOCK_REQUIRED_ITEM_TYPES` is rejected by `RecordPushItemSchema` when its push item carries
+no clock, and `RecordPushRequestSchema` validates the whole `items` array — so **one** clock-less row
+fails the entire batch with a request-level `VALIDATION_ERROR`, not a per-item rejection. Every push
+then fails and nothing drains until the row is repaired. Any write path that inserts such a row and
+enqueues it must stamp `increment({}, deviceId)` itself; the Google Calendar import
+(`calendar/google/sync-service.ts`) does this for events it has never seen before, and
+`calendarExternalEventHandler.buildPushPayload` stamps and persists a first clock for rows already
+queued by older builds, so a stuck queue drains on the next push instead of waiting for the next full
+sync. Stamping without persisting is not enough: the next local edit would tick from `{}` to the same
+clock the server already acked, and the update would be dropped as a replay.
+
 Handlers that persist locally encrypted fields must receive the vault key from the sync engine during
 pull apply and push payload encoding. Agent conversation and message handlers use that key to decrypt
 their SQLite envelopes and re-encode sync payloads without exposing plaintext to the server.


### PR DESCRIPTION
## The outage

A newly imported Google Calendar event was written with `clock: existing?.clock`. For an event this
device has never seen, `existing` is `undefined`, so the row landed with a **NULL clock** and
`markSyncedTableMutation` enqueued it immediately.

`calendar_external_event` is in `RECORD_CLOCK_REQUIRED_ITEM_TYPES`, so `RecordPushItemSchema` rejects
a clock-less item — and `RecordPushRequestSchema` validates the whole `items` array, so the failure
is a **request-level** `VALIDATION_ERROR`, not a per-item entry in `rejected`. One bad row therefore
fails the entire batch: every push returns `VALIDATION_ERROR: … "calendar_external_event" requires
clock metadata`, nothing drains, and *all* sync stops — notes and tasks included — for anyone with
Google Calendar connected. Reported at 591 pending changes on a live release (#1215); disconnecting
the calendar does not help, because the rows are already queued.

## What this changes

**1. Stop creating unclocked rows** — `calendar/google/sync-service.ts` seeds `increment({}, deviceId)`
for an event it has never seen, the same first clock `seedUnclocked` assigns. The device id is read
from `sync_devices` with the same three-line query `runtime.ts` / `offline-clock.ts` already keep
(`sync/offline-clock` is on the architecture check's blocked list for feature modules, so it cannot
be imported here). With no device row yet, the clock stays NULL and the unclocked sweep still owns
the first push. The `cancelled` / `archivedAt` branch above is unchanged — it is only reachable when
`existing` is truthy, so it always inherits a real clock.

**2. Repair installs that already have the damage** — `seedUnclocked` only runs from `runInitialSeed`,
i.e. inside a full sync; an incremental push cycle never reaches it, so an already-queued clock-less
row is re-sent and rejected on every attempt in between. `calendarExternalEventHandler.buildPushPayload`
now stamps and **persists** a first clock when the row has none, using the `deviceId` the push path
already passes it. Stuck queues drain on the next push with no reset and no migration. Persisting is
load-bearing: a clock invented for the payload alone would leave the row NULL, and the next local
edit would tick from `{}` to the same clock the server just acked — a replay the server drops.
`seedUnclocked` now calls the same helper, so both paths produce identical clocks.

## Deliberately not in this PR

Whether **one malformed item should be able to fail a whole push batch**. `PushResponseSchema`
already models per-item rejection, but request-level schema validation bypasses it, so any future
underspecified row halts all sync indefinitely. That is a protocol decision (client and server) and
is left to #1215.

Also not included: the broader guard test asserting that *no* write path can insert-and-enqueue a
clock-less row for any type in `RECORD_CLOCK_REQUIRED_ITEM_TYPES`.

## Backward compatibility

No schema change, no migration, no reset. `clock` is an existing nullable column; older builds read a
stamped row exactly as they read a peer-clocked one, and the repair only ever fills a NULL.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts --project main src/main/sync/item-handlers src/main/sync/offline-clock.test.ts src/main/sync/engine/push-coordinator.test.ts src/main/calendar` → **52 files, 587 passed**
- Both new tests mutation-checked: reverting the two source files fails them with
  `expected null to deeply equal { 'device-a': 1 }` and `expected undefined to deeply equal { 'device-a': 1 }`
- `pnpm --filter @memry/desktop typecheck:node` clean · `pnpm lint` 0 errors · `pnpm check:architecture` / `check:contracts` pass · `pnpm docs:impact --base origin/main --strict` covered · `pnpm docs:build` clean

New coverage: a new import gets a clock; a re-import inherits the stored clock instead of restamping;
`buildPushPayload` stamps + persists on a NULL-clock row and leaves a clocked row untouched.

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)
