### PR TITLE
fix(editor): turn selected lines into a bulleted, numbered or check list

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -6,7 +6,6 @@ import {
   SuggestionMenuController,
   GridSuggestionMenuController,
   useCreateBlockNote,
-  FormattingToolbar,
   getDefaultReactSlashMenuItems,
   type SuggestionMenuProps
 } from '@blocknote/react'
@@ -1220,18 +1219,17 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
             knownTaskBlockIdsRef.current = intents.currentTaskIds
           }}
           theme={editorTheme}
-          formattingToolbar={!stickyToolbar && !review}
+          formattingToolbar={false}
           slashMenu={false}
           emojiPicker={false}
         >
-          {stickyToolbar &&
-            (review ? (
-              <ReviewFormattingToolbar variant="sticky" onAddComment={review.onAddComment} />
-            ) : (
-              <FormattingToolbar />
-            ))}
-          {!stickyToolbar && review && (
-            <ReviewFormattingToolbarController onAddComment={review.onAddComment} />
+          {/* Memry's toolbar on every surface, review or not: BlockNote's stock
+              one has no list toggles, so the template editor used to be the odd
+              one out with no visible way to turn selected lines into a list. */}
+          {stickyToolbar ? (
+            <ReviewFormattingToolbar variant="sticky" onAddComment={review?.onAddComment} />
+          ) : (
+            <ReviewFormattingToolbarController onAddComment={review?.onAddComment} />
           )}
           {aiEnabled && aiReady && <AIMenuController aiMenu={CustomAIMenu} />}
           <SuggestionMenuController

--- a/apps/desktop/src/renderer/src/components/note/content-area/list-type-buttons.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/list-type-buttons.tsx
@@ -1,0 +1,82 @@
+import { useBlockNoteEditor, useComponentsContext, useEditorState } from '@blocknote/react'
+import { List, ListChecks, ListOrdered } from '@/lib/icons'
+import { useT } from '@memry/i18n/renderer'
+import {
+  canToggleListType,
+  isListTypeActive,
+  toggleListType,
+  type ListBlockType
+} from './list-type-conversion'
+
+const LIST_BUTTONS: Array<{
+  type: ListBlockType
+  icon: typeof List
+  labelKey: 'editor.list.bulleted' | 'editor.list.numbered' | 'editor.list.checklist'
+  testId: string
+}> = [
+  {
+    type: 'bulletListItem',
+    icon: List,
+    labelKey: 'editor.list.bulleted',
+    testId: 'list-type-bulleted'
+  },
+  {
+    type: 'numberedListItem',
+    icon: ListOrdered,
+    labelKey: 'editor.list.numbered',
+    testId: 'list-type-numbered'
+  },
+  {
+    type: 'checkListItem',
+    icon: ListChecks,
+    labelKey: 'editor.list.checklist',
+    testId: 'list-type-checklist'
+  }
+]
+
+/**
+ * Bulleted / numbered / checklist toggles for the formatting toolbar.
+ *
+ * The block type dropdown next to them can already retype a whole selection,
+ * but it is labelled with the block's current type ("Paragraph"), so people
+ * looking for bullets never open it — see issue #1206. These give the same
+ * transform a visible, single-click home on the toolbar that appears the moment
+ * text is selected.
+ */
+export function ListTypeButtons() {
+  const { t } = useT('notes')
+  const Components = useComponentsContext()
+  const editor = useBlockNoteEditor()
+  const state = useEditorState({
+    editor,
+    selector: ({ editor }) => ({
+      canToggle: canToggleListType(editor),
+      active: LIST_BUTTONS.filter((button) => isListTypeActive(editor, button.type)).map(
+        (button) => button.type
+      )
+    })
+  })
+
+  if (!Components) return null
+
+  return (
+    <>
+      {LIST_BUTTONS.map(({ type, icon: Icon, labelKey, testId }) => {
+        const label = t(labelKey)
+        return (
+          <Components.FormattingToolbar.Button
+            key={type}
+            className="bn-button"
+            data-test={testId}
+            label={label}
+            mainTooltip={label}
+            isDisabled={!state.canToggle}
+            isSelected={state.active.includes(type)}
+            icon={<Icon size={16} />}
+            onClick={() => toggleListType(editor, type)}
+          />
+        )
+      })}
+    </>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/note/content-area/list-type-conversion.integration.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/list-type-conversion.integration.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { BlockNoteEditor } from '@blocknote/core'
+import {
+  canToggleListType,
+  getBlocksForListConversion,
+  isListTypeActive,
+  toggleListType
+} from './list-type-conversion'
+
+// Issue #1206: a first-session user pasted a list and could not turn the lines
+// into bullets. These run against a real mounted BlockNote editor to pin down
+// what actually happens to a multi-block selection.
+//
+// Uses the default BlockNote schema — the custom schema's extra block specs drag
+// react-pdf into jsdom and none of them are convertible anyway.
+
+const mounted: Array<{ editor: BlockNoteEditor; el: HTMLElement }> = []
+
+afterEach(() => {
+  for (const { editor, el } of mounted.splice(0)) {
+    editor.mount(undefined)
+    el.remove()
+  }
+})
+
+function mountEditor(): BlockNoteEditor {
+  const editor = BlockNoteEditor.create({
+    initialContent: [
+      { type: 'paragraph', content: 'Milk' },
+      { type: 'paragraph', content: 'Eggs' },
+      { type: 'paragraph', content: 'Bread' }
+    ]
+  })
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  editor.mount(el)
+  mounted.push({ editor, el })
+  return editor
+}
+
+// BlockNote keeps a trailing empty paragraph after the last block, so select
+// exactly the three pasted lines — what a user drags over.
+function selectPastedLines(editor: BlockNoteEditor): void {
+  const blocks = editor.document
+  editor.setSelection(blocks[0].id, blocks[2].id)
+}
+
+function blockTypes(editor: BlockNoteEditor): string[] {
+  return editor.document.map((block) => block.type)
+}
+
+function blockText(editor: BlockNoteEditor, index: number): string {
+  const content = editor.document[index].content as Array<{ text?: string }> | undefined
+  return (content ?? []).map((item) => item.text ?? '').join('')
+}
+
+describe('list type conversion on a multi-block selection', () => {
+  it('reports every selected block, not just the one under the cursor', () => {
+    const editor = mountEditor()
+    selectPastedLines(editor)
+
+    expect(getBlocksForListConversion(editor)).toHaveLength(3)
+  })
+
+  it('turns all selected paragraphs into bullets and keeps their text', () => {
+    const editor = mountEditor()
+    selectPastedLines(editor)
+
+    toggleListType(editor, 'bulletListItem')
+
+    expect(blockTypes(editor)).toEqual([
+      'bulletListItem',
+      'bulletListItem',
+      'bulletListItem',
+      'paragraph'
+    ])
+    expect(blockText(editor, 0)).toBe('Milk')
+    expect(blockText(editor, 2)).toBe('Bread')
+  })
+
+  it('covers numbered lists and checklists the same way', () => {
+    const numbered = mountEditor()
+    selectPastedLines(numbered)
+    toggleListType(numbered, 'numberedListItem')
+    expect(blockTypes(numbered)).toEqual([
+      'numberedListItem',
+      'numberedListItem',
+      'numberedListItem',
+      'paragraph'
+    ])
+
+    const checklist = mountEditor()
+    selectPastedLines(checklist)
+    toggleListType(checklist, 'checkListItem')
+    expect(blockTypes(checklist)).toEqual([
+      'checkListItem',
+      'checkListItem',
+      'checkListItem',
+      'paragraph'
+    ])
+  })
+
+  it('toggles a list back to paragraphs when every selected block is already it', () => {
+    const editor = mountEditor()
+    selectPastedLines(editor)
+    toggleListType(editor, 'bulletListItem')
+
+    selectPastedLines(editor)
+    expect(isListTypeActive(editor, 'bulletListItem')).toBe(true)
+
+    toggleListType(editor, 'bulletListItem')
+    expect(blockTypes(editor)).toEqual(['paragraph', 'paragraph', 'paragraph', 'paragraph'])
+  })
+
+  it('converts a mixed selection to the target type instead of toggling it off', () => {
+    const editor = mountEditor()
+    editor.updateBlock(editor.document[0], { type: 'bulletListItem' })
+    selectPastedLines(editor)
+
+    expect(isListTypeActive(editor, 'bulletListItem')).toBe(false)
+
+    toggleListType(editor, 'bulletListItem')
+    expect(blockTypes(editor)).toEqual([
+      'bulletListItem',
+      'bulletListItem',
+      'bulletListItem',
+      'paragraph'
+    ])
+  })
+
+  it('falls back to the cursor block when nothing is selected', () => {
+    const editor = mountEditor()
+    editor.setTextCursorPosition(editor.document[1].id, 'end')
+
+    expect(canToggleListType(editor)).toBe(true)
+
+    toggleListType(editor, 'bulletListItem')
+    expect(blockTypes(editor)).toEqual([
+      'paragraph',
+      'bulletListItem',
+      'paragraph',
+      'paragraph'
+    ])
+  })
+
+  it('leaves blocks without inline content alone', () => {
+    const editor = mountEditor()
+    editor.insertBlocks([{ type: 'image' }], editor.document[1].id, 'after')
+    editor.setSelection(editor.document[0].id, editor.document[3].id)
+
+    expect(getBlocksForListConversion(editor).map((block) => block.type)).toEqual([
+      'paragraph',
+      'paragraph',
+      'paragraph'
+    ])
+
+    toggleListType(editor, 'bulletListItem')
+    expect(blockTypes(editor)).toEqual([
+      'bulletListItem',
+      'bulletListItem',
+      'image',
+      'bulletListItem',
+      'paragraph'
+    ])
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/list-type-conversion.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/list-type-conversion.ts
@@ -1,0 +1,57 @@
+import type { Block, BlockNoteEditor } from '@blocknote/core'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type AnyEditor = BlockNoteEditor<any, any, any>
+type AnyBlock = Block<any, any, any>
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export const LIST_BLOCK_TYPES = ['bulletListItem', 'numberedListItem', 'checkListItem'] as const
+
+export type ListBlockType = (typeof LIST_BLOCK_TYPES)[number]
+
+// Same guard BlockNote's own `Mod-Shift-8` shortcut uses: only blocks whose
+// schema content is inline text can become a list item. This keeps our custom
+// blocks with `content: 'none'` (taskBlock, file, bookmark, youtubeEmbed) out of
+// a bulk retype — for taskBlock that matters beyond formatting, because the
+// editor's change handler deletes the task row when its block disappears.
+function canConvert(editor: AnyEditor, block: AnyBlock): boolean {
+  return editor.schema.blockSchema[block.type]?.content === 'inline'
+}
+
+/**
+ * Blocks a list toggle applies to: every convertible block in the selection,
+ * or the block holding the text cursor when nothing is selected.
+ */
+export function getBlocksForListConversion(editor: AnyEditor): AnyBlock[] {
+  const selected = editor.getSelection()?.blocks ?? [editor.getTextCursorPosition().block]
+  return selected.filter((block: AnyBlock) => canConvert(editor, block))
+}
+
+/** True when every block the toggle would touch is already that list type. */
+export function isListTypeActive(editor: AnyEditor, type: ListBlockType): boolean {
+  const blocks = getBlocksForListConversion(editor)
+  return blocks.length > 0 && blocks.every((block) => block.type === type)
+}
+
+export function canToggleListType(editor: AnyEditor): boolean {
+  return getBlocksForListConversion(editor).length > 0
+}
+
+/**
+ * Turns every selected block into `type`, or back into paragraphs when they all
+ * already are it. Props are left alone so colours and alignment survive the
+ * retype; BlockNote drops the ones the new type doesn't declare.
+ */
+export function toggleListType(editor: AnyEditor, type: ListBlockType): void {
+  const blocks = getBlocksForListConversion(editor)
+  if (blocks.length === 0) return
+
+  const nextType = blocks.every((block) => block.type === type) ? 'paragraph' : type
+
+  editor.focus()
+  editor.transact(() => {
+    for (const block of blocks) {
+      editor.updateBlock(block, { type: nextType })
+    }
+  })
+}

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
@@ -7,21 +7,47 @@ const toolbarMocks = vi.hoisted(() => ({
     prosemirrorState: {
       selection: { empty: false, from: 2, to: 15 },
       doc: { textBetween: vi.fn(() => 'selected text') }
-    }
+    },
+    schema: {
+      blockSchema: {
+        paragraph: { content: 'inline' },
+        bulletListItem: { content: 'inline' },
+        numberedListItem: { content: 'inline' },
+        checkListItem: { content: 'inline' }
+      }
+    },
+    selectedBlocks: [
+      { id: 'b1', type: 'paragraph' },
+      { id: 'b2', type: 'paragraph' }
+    ] as Array<{ id: string; type: string }>,
+    getSelection: vi.fn(() => ({ blocks: toolbarMocks.editor.selectedBlocks })),
+    getTextCursorPosition: vi.fn(() => ({ block: toolbarMocks.editor.selectedBlocks[0] })),
+    focus: vi.fn(),
+    transact: vi.fn((fn: () => void) => fn()),
+    updateBlock: vi.fn()
   }
 }))
+
+const listLabels: Record<string, string> = {
+  'editor.list.bulleted': 'Bulleted list',
+  'editor.list.numbered': 'Numbered list',
+  'editor.list.checklist': 'Check list'
+}
 
 vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({
     t: (key: string) => {
       if (key === 'comments.toolbarComment') return 'Comment'
-      return key
+      return listLabels[key] ?? key
     }
   })
 }))
 
 vi.mock('@/lib/icons', () => ({
-  MessageCircle: () => <span data-testid="comment-icon" />
+  MessageCircle: () => <span data-testid="comment-icon" />,
+  List: () => <span data-testid="bulleted-icon" />,
+  ListOrdered: () => <span data-testid="numbered-icon" />,
+  ListChecks: () => <span data-testid="checklist-icon" />
 }))
 
 vi.mock('@blocknote/react', () => ({
@@ -81,6 +107,11 @@ describe('ReviewFormattingToolbar', () => {
     toolbarMocks.editor.prosemirrorState.selection.empty = false
     ;(toolbarMocks.editor.prosemirrorState.selection as { node?: unknown }).node = undefined
     toolbarMocks.editor.prosemirrorState.doc.textBetween.mockClear()
+    toolbarMocks.editor.selectedBlocks = [
+      { id: 'b1', type: 'paragraph' },
+      { id: 'b2', type: 'paragraph' }
+    ]
+    toolbarMocks.editor.updateBlock.mockClear()
     ;(toolbarMocks.editor as { _tiptapEditor?: unknown })._tiptapEditor = undefined
   })
 
@@ -100,6 +131,74 @@ describe('ReviewFormattingToolbar', () => {
     render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
 
     expect(screen.getByText('block type')).toBeInTheDocument()
+  })
+
+  // Issue #1206: the block type dropdown could already retype a whole
+  // selection, but it is labelled with the current type ("Paragraph"), so
+  // nobody hunting for bullets opened it. The toggles make that transform
+  // visible in both toolbar variants.
+  it('offers bulleted, numbered and check list toggles in the floating toolbar', () => {
+    render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+
+    expect(screen.getByText('Bulleted list')).toBeInTheDocument()
+    expect(screen.getByText('Numbered list')).toBeInTheDocument()
+    expect(screen.getByText('Check list')).toBeInTheDocument()
+  })
+
+  it('offers the list toggles in the sticky toolbar too', () => {
+    render(<ReviewFormattingToolbar variant="sticky" onAddComment={vi.fn()} />)
+
+    expect(screen.getByText('Bulleted list')).toBeInTheDocument()
+    expect(screen.getByText('Numbered list')).toBeInTheDocument()
+    expect(screen.getByText('Check list')).toBeInTheDocument()
+  })
+
+  it('converts every selected block, not just the first', () => {
+    render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Bulleted list'))
+
+    expect(toolbarMocks.editor.updateBlock).toHaveBeenCalledTimes(2)
+    expect(toolbarMocks.editor.updateBlock).toHaveBeenNthCalledWith(
+      1,
+      { id: 'b1', type: 'paragraph' },
+      { type: 'bulletListItem' }
+    )
+    expect(toolbarMocks.editor.updateBlock).toHaveBeenNthCalledWith(
+      2,
+      { id: 'b2', type: 'paragraph' },
+      { type: 'bulletListItem' }
+    )
+  })
+
+  it('toggles a fully bulleted selection back to paragraphs', () => {
+    toolbarMocks.editor.selectedBlocks = [
+      { id: 'b1', type: 'bulletListItem' },
+      { id: 'b2', type: 'bulletListItem' }
+    ]
+
+    render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+    fireEvent.click(screen.getByText('Bulleted list'))
+
+    expect(toolbarMocks.editor.updateBlock).toHaveBeenNthCalledWith(1, expect.anything(), {
+      type: 'paragraph'
+    })
+  })
+
+  it('leaves blocks without inline content out of the conversion', () => {
+    toolbarMocks.editor.selectedBlocks = [
+      { id: 'b1', type: 'paragraph' },
+      { id: 'task', type: 'taskBlock' }
+    ]
+
+    render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+    fireEvent.click(screen.getByText('Bulleted list'))
+
+    expect(toolbarMocks.editor.updateBlock).toHaveBeenCalledTimes(1)
+    expect(toolbarMocks.editor.updateBlock).toHaveBeenCalledWith(
+      { id: 'b1', type: 'paragraph' },
+      { type: 'bulletListItem' }
+    )
   })
 
   it('captures selected text before clicking Comment collapses selection', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
@@ -20,6 +20,7 @@ import {
 } from '@blocknote/react'
 import { MessageCircle } from '@/lib/icons'
 import type { ReviewSelection } from './types'
+import { ListTypeButtons } from './list-type-buttons'
 import { useT } from '@memry/i18n/renderer'
 
 interface ReviewFormattingToolbarProps {
@@ -60,6 +61,7 @@ export function ReviewFormattingToolbar({
     return (
       <FormattingToolbar {...toolbarProps}>
         {getFormattingToolbarItems(toolbarProps.blockTypeSelectItems)}
+        <ListTypeButtons />
         <ReviewToolbarButton onSelect={onAddComment} />
       </FormattingToolbar>
     )
@@ -83,6 +85,10 @@ export function ReviewFormattingToolbar({
           <BasicTextStyleButton basicTextStyle="italic" />
           <BasicTextStyleButton basicTextStyle="underline" />
           <BasicTextStyleButton basicTextStyle="strike" />
+          {/* Turning selected lines into a list is the reason most people open
+              this popup (#1206), so the toggles sit next to the text styles
+              rather than behind the "Paragraph" dropdown above. */}
+          <ListTypeButtons />
           <TextAlignButton textAlignment="left" />
           <TextAlignButton textAlignment="center" />
           <TextAlignButton textAlignment="right" />

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -117,6 +117,10 @@ The formatting toolbar can be sticky at the top or float above selections — ch
 
 Both modes offer the same formatting controls: the block type (paragraph, heading, list) plus inline styles, alignment, colour, indent, and links. The block type control is hidden for blocks that have no alternative type, such as tasks, callouts, and files.
 
+### Turning existing lines into a list
+
+Select the lines — a whole pasted block of them if you like — and press **Bulleted list**, **Numbered list**, or **Check list** on the toolbar. Every selected line is converted, not just the one holding the cursor, and pressing the same button again turns them back into paragraphs. Blocks that cannot become list items, such as tasks and files, are left as they are.
+
 ## Text Formatting
 
 Bold, italic and strikethrough are written to the vault as plain Markdown (`**bold**`, `*italic*`, `~~strike~~`).

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -91,6 +91,11 @@
       "listPlaceholder": "List item",
       "todoPlaceholder": "To-do item"
     },
+    "list": {
+      "bulleted": "Bulleted list",
+      "numbered": "Numbered list",
+      "checklist": "Check list"
+    },
     "toolbar": {
       "reminderSet": "Reminder set",
       "setReminder": "Set reminder",


### PR DESCRIPTION
Closes #1206

## What I found first

**Both.** The transform exists and works on a multi-block selection — it is reachable from exactly one control, and that control does not look like what people are hunting for.

I ran the real thing rather than guessing: `list-type-conversion.integration.test.ts` mounts a real BlockNote editor, selects three pasted paragraphs, and converts them. It works. `BlockTypeSelect` (`@blocknote/react` 0.47.1) already loops over `editor.getSelection().blocks` and calls `updateBlock` on each, and Memry renders it in both toolbar variants.

Route by route, on a selection of several existing paragraphs:

| Route | Converts the whole selection? |
| --- | --- |
| Block type dropdown in the formatting toolbar | **Yes** — but it is labelled with the block's *current* type ("Paragraph"), so it reads as a status, not an action |
| Slash menu (`/`) | No — `insertOrUpdateBlockForSlashMenu` only retypes the current block when it is empty or just `/`; otherwise it **inserts a new block after**. This is exactly what the reporter saw: "I can create a bulleted list, but maybe not from an existing list" |
| <kbd>Mod</kbd>+<kbd>Shift</kbd>+<kbd>8</kbd>/<kbd>7</kbd>/<kbd>9</kbd> | No — reads `editor.getTextCursorPosition()`, so it retypes one block and silently ignores the rest of the selection |
| Markdown `- ` retyping | No — input rule, fires per block as you type |
| Finder-style marquee drag | No — it highlights blocks without a ProseMirror text selection, so no toolbar appears at all |

So a user who selects their pasted lines gets a popup of bold/italic/underline/strike/align/colour/indent/link and a dropdown that says "Paragraph". There is no bullet icon anywhere in it. That is the whole bug.

## The fix

Bulleted / numbered / check list toggles on the selection toolbar, sharing the transform BlockNote already has — `updateBlock` over `editor.getSelection().blocks` — rather than a second conversion path.

- All three list types together, since they were one gap, not three.
- Toggling: converts every selected block to the type, or back to paragraph when they all already are it. Active state shown on the button.
- Blocks whose schema content is not `inline` are skipped — the same guard BlockNote's own `Mod-Shift-8` uses. That keeps `taskBlock`, `file`, `bookmark` and `youtubeEmbed` out of a bulk retype; for `taskBlock` that matters beyond formatting, because `ContentArea`'s change handler deletes the task row when its block disappears.
- Props are not reset on retype, so colour and alignment survive.

One extra line of consistency: the toolbar now renders on every editor surface instead of only when a `review` prop is passed. Notes and journal passed it; the template editor did not and fell back to BlockNote's stock toolbar, which would have been the one editor without the new toggles. `review-formatting-toolbar.test.tsx` already carries a comment about the last time these controls existed in only one variant.

No lockfile, contract, schema or sync changes.

## Verification

- `pnpm exec vitest run --project renderer .../list-type-conversion.integration.test.ts` — 7 passed (real mounted editor: multi-block convert, all three types, toggle back, mixed selection, cursor fallback, non-inline blocks skipped)
- `pnpm exec vitest run --project renderer .../review-formatting-toolbar.test.tsx` — 12 passed
- `pnpm exec vitest run --project renderer .../ContentArea.test.tsx .../ai-surfaces.test.tsx` — 14 passed
- `pnpm lint` — 0 errors (18 pre-existing warnings, none in changed files)
- `pnpm typecheck` — 16/16 tasks pass
- `pnpm --filter @memry/desktop i18n:check` — ok
- `pnpm docs:impact --base origin/main --strict` — covered; `pnpm docs:build` — complete

Not verified: no manual run in the packaged app. The click path is covered by the component test and the transform by the integration test, but the popup's new 4-column row has not been looked at on screen.
