### PR TITLE
fix(notes): rebase sidebar folder paths onto the configured notes root

### DIFF
--- a/apps/desktop/src/renderer/src/components/note-sidebar-surfaces.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note-sidebar-surfaces.test.tsx
@@ -35,6 +35,12 @@ vi.mock('@memry/i18n/renderer', () => ({
   })
 }))
 
+// Breadcrumb folder paths are relative to the vault's notes root; these fixtures
+// use `notes/...` paths, i.e. a vault with defaultNoteFolder = 'notes'.
+vi.mock('@/hooks/use-vault', () => ({
+  useNotesRoot: () => 'notes'
+}))
+
 vi.mock('@/components/note/note-reminder-button', () => ({
   NoteReminderButton: ({ noteId, disabled }: { noteId: string; disabled?: boolean }) => (
     <button type="button" disabled={disabled}>

--- a/apps/desktop/src/renderer/src/components/note/note-breadcrumb.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-breadcrumb.tsx
@@ -2,6 +2,8 @@ import { useMemo, useCallback } from 'react'
 import { ChevronLeft } from '@/lib/icons'
 import { useTabs } from '@/contexts/tabs'
 import { useT } from '@memry/i18n/renderer'
+import { useNotesRoot } from '@/hooks/use-vault'
+import { stripNotesRoot } from '@/components/notes-tree-utils'
 
 interface BreadcrumbSegment {
   label: string
@@ -13,17 +15,17 @@ interface NoteBreadcrumbProps {
   noteTitle: string
 }
 
-function parseBreadcrumbSegments(notePath: string): BreadcrumbSegment[] {
-  const parts = notePath.split('/')
+function parseBreadcrumbSegments(notePath: string, notesRoot: string): BreadcrumbSegment[] {
+  // Crumbs open folder tabs, so they must be in the same base as folder views:
+  // relative to the notes root, not the vault root (#1204).
+  const parts = stripNotesRoot(notePath, notesRoot).split('/')
+  parts.pop()
 
-  const withoutNotesPrefix = parts[0] === 'notes' ? parts.slice(1) : [...parts]
-  withoutNotesPrefix.pop()
+  if (parts.length === 0) return []
 
-  if (withoutNotesPrefix.length === 0) return []
-
-  return withoutNotesPrefix.map((segment, i) => ({
+  return parts.map((segment, i) => ({
     label: segment,
-    folderPath: withoutNotesPrefix.slice(0, i + 1).join('/')
+    folderPath: parts.slice(0, i + 1).join('/')
   }))
 }
 
@@ -36,7 +38,12 @@ export function NoteBreadcrumb({ notePath, noteTitle }: NoteBreadcrumbProps) {
   const { t } = useT('notes')
   const { openTab } = useTabs()
 
-  const segments = useMemo(() => parseBreadcrumbSegments(notePath), [notePath])
+  const notesRoot = useNotesRoot()
+
+  const segments = useMemo(
+    () => parseBreadcrumbSegments(notePath, notesRoot),
+    [notePath, notesRoot]
+  )
 
   const handleFolderClick = useCallback(
     (folderPath: string, folderName: string) => {

--- a/apps/desktop/src/renderer/src/components/notes-tree-utils.test.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree-utils.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import type { NoteListItem } from '@/hooks/use-notes-query'
 import {
   getDisplayName,
+  stripNotesRoot,
   extractFolderFromPath,
   getParentFolder,
   isDescendantOrSelf,
@@ -84,19 +85,29 @@ describe('getDisplayName', () => {
 
 describe('extractFolderFromPath', () => {
   it('extracts folder from notes-prefixed path', () => {
-    expect(extractFolderFromPath('notes/Projects/hello.md')).toBe('Projects')
+    expect(extractFolderFromPath('notes/Projects/hello.md', 'notes')).toBe('Projects')
   })
 
   it('returns empty for root note', () => {
-    expect(extractFolderFromPath('notes/hello.md')).toBe('')
+    expect(extractFolderFromPath('notes/hello.md', 'notes')).toBe('')
   })
 
   it('handles nested folders', () => {
-    expect(extractFolderFromPath('notes/a/b/c/file.md')).toBe('a/b/c')
+    expect(extractFolderFromPath('notes/a/b/c/file.md', 'notes')).toBe('a/b/c')
   })
 
   it('handles non-notes-prefixed path', () => {
-    expect(extractFolderFromPath('Projects/hello.md')).toBe('Projects')
+    expect(extractFolderFromPath('Projects/hello.md', 'notes')).toBe('Projects')
+  })
+
+  it('returns the folder relative to a differently named notes root', () => {
+    expect(extractFolderFromPath('Notes/Work/a.md', 'Notes')).toBe('Work')
+    expect(extractFolderFromPath('Notes/a.md', 'Notes')).toBe('')
+  })
+
+  it('treats the whole path as folder-bearing on a flat vault', () => {
+    expect(extractFolderFromPath('Work/a.md', '')).toBe('Work')
+    expect(extractFolderFromPath('notes/a.md', '')).toBe('notes')
   })
 })
 
@@ -218,7 +229,7 @@ describe('buildTreeFromNotes', () => {
     ]
     const folders = [{ path: 'Projects', icon: null }]
 
-    const tree = buildTreeFromNotes(notes, folders, {})
+    const tree = buildTreeFromNotes(notes, folders, {}, 'notes')
     expect(tree.rootNotes).toHaveLength(1)
     expect(tree.rootNotes[0].id).toBe('a')
     expect(tree.folders).toHaveLength(1)
@@ -236,13 +247,13 @@ describe('buildTreeFromNotes', () => {
     ]
     const positions = { 'notes/c.md': 0, 'notes/a.md': 1 }
 
-    const tree = buildTreeFromNotes(notes, [], positions)
+    const tree = buildTreeFromNotes(notes, [], positions, 'notes')
     expect(tree.rootNotes.map((n) => n.id)).toEqual(['c', 'a', 'b'])
   })
 
   it('creates intermediate folders for nested paths', () => {
     const notes = [createNote({ id: 'a', path: 'notes/a/b/c/file.md', modified: baseDate })]
-    const tree = buildTreeFromNotes(notes, [], {})
+    const tree = buildTreeFromNotes(notes, [], {}, 'notes')
     expect(tree.folders).toHaveLength(1)
     expect(tree.folders[0].name).toBe('a')
     expect(tree.folders[0].children[0].name).toBe('b')
@@ -255,6 +266,66 @@ describe('buildTreeFromNotes', () => {
 
     const tree = buildTreeFromNotes(notes, folders, {})
     expect(tree.folders[0].icon).toBe('📦')
+  })
+
+  // #1204: "Default Location for New Notes" = the name of an existing top-level
+  // folder. Note paths are vault-root-relative, folder paths are notes-root
+  // relative; before the fix the notes root leaked into the tree as a phantom
+  // node whose path resolved to <vault>/Notes/Notes, so the folder view that the
+  // grid button opens reported "Folder not found".
+  it('does not emit a folder node for the notes root itself', () => {
+    const notes = [
+      createNote({ id: 'a', path: 'Notes/hello.md', modified: baseDate }),
+      createNote({ id: 'b', path: 'Notes/Work/alpha.md', modified: baseDate })
+    ]
+    // What getFolders() returns for defaultNoteFolder = 'Notes': children only.
+    const folders = [{ path: 'Work', icon: null }]
+
+    const tree = buildTreeFromNotes(notes, folders, {}, 'Notes')
+
+    expect(tree.folders.map((f) => f.path)).toEqual(['Work'])
+    expect(tree.rootNotes.map((n) => n.id)).toEqual(['a'])
+    expect(tree.folders[0].notes.map((n) => n.id)).toEqual(['b'])
+  })
+
+  it('keeps a top-level folder named like the default browsable on a flat vault', () => {
+    const notes = [createNote({ id: 'a', path: 'notes/hello.md', modified: baseDate })]
+    const folders = [{ path: 'notes', icon: null }]
+
+    const tree = buildTreeFromNotes(notes, folders, {}, '')
+
+    expect(tree.rootNotes).toHaveLength(0)
+    expect(tree.folders.map((f) => f.path)).toEqual(['notes'])
+    expect(tree.folders[0].notes.map((n) => n.id)).toEqual(['a'])
+  })
+})
+
+// ============================================================================
+// stripNotesRoot
+// ============================================================================
+
+describe('stripNotesRoot', () => {
+  it('rebases a vault-relative note path onto the notes root', () => {
+    expect(stripNotesRoot('Notes/Work/a.md', 'Notes')).toBe('Work/a.md')
+    expect(stripNotesRoot('Notes/a.md', 'Notes')).toBe('a.md')
+    expect(stripNotesRoot('Notes', 'Notes')).toBe('')
+  })
+
+  it('leaves paths alone when there is no notes root', () => {
+    expect(stripNotesRoot('notes/a.md', '')).toBe('notes/a.md')
+  })
+
+  it('is case-sensitive and does not strip partial segment matches', () => {
+    expect(stripNotesRoot('notes/a.md', 'Notes')).toBe('notes/a.md')
+    expect(stripNotesRoot('Notesy/a.md', 'Notes')).toBe('Notesy/a.md')
+  })
+
+  it('tolerates paths outside the notes root', () => {
+    expect(stripNotesRoot('Archive/a.md', 'Notes')).toBe('Archive/a.md')
+  })
+
+  it('tolerates a slash-padded notes root', () => {
+    expect(stripNotesRoot('Notes/a.md', '/Notes/')).toBe('a.md')
   })
 })
 

--- a/apps/desktop/src/renderer/src/components/notes-tree-utils.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree-utils.tsx
@@ -17,12 +17,31 @@ export function getDisplayName(notePath: string): string {
   return lastDot > 0 ? filename.slice(0, lastDot) : filename
 }
 
-export function extractFolderFromPath(notePath: string): string {
-  const parts = notePath.split('/')
+/**
+ * Strip the configured notes root (`defaultNoteFolder`) off a vault-relative
+ * note path.
+ *
+ * Note paths from the index are relative to the VAULT root, but every folder
+ * consumer — `folderExists`, the folder view's LIKE query, `.folder.md` config,
+ * create/rename/delete folder — resolves folder paths against the NOTES root
+ * (`<vault>/<defaultNoteFolder>`). This used to strip a hardcoded `notes`
+ * literal, so any other value produced folder paths in the wrong base: a folder
+ * named after `defaultNoteFolder` resolved to `<vault>/<root>/<root>` and the
+ * view reported "Folder not found" (#1204).
+ *
+ * Tolerant on purpose: a path outside the notes root is returned unchanged,
+ * matching `noteFolderFromPath` in @memry/app-core.
+ */
+export function stripNotesRoot(notePath: string, notesRoot: string): string {
+  const root = notesRoot.replace(/^\/+|\/+$/g, '')
+  if (!root) return notePath
+  if (notePath === root) return ''
+  return notePath.startsWith(`${root}/`) ? notePath.slice(root.length + 1) : notePath
+}
+
+export function extractFolderFromPath(notePath: string, notesRoot = ''): string {
+  const parts = stripNotesRoot(notePath, notesRoot).split('/')
   parts.pop()
-  if (parts.length > 0 && parts[0] === 'notes') {
-    return parts.slice(1).join('/')
-  }
   return parts.join('/')
 }
 
@@ -83,7 +102,8 @@ export function getFoldersInParent(tree: TreeStructure, parentPath: string): str
 export function buildTreeFromNotes(
   notes: NoteListItem[],
   folders: FolderInfo[],
-  positions: Record<string, number>
+  positions: Record<string, number>,
+  notesRoot = ''
 ): TreeStructure {
   const folderMap = new Map<string, FolderNode>()
   const rootNotes: NoteListItem[] = []
@@ -135,18 +155,13 @@ export function buildTreeFromNotes(
   })
 
   notes.forEach((note) => {
-    const pathParts = note.path.split('/')
-    pathParts.pop()
+    // Folder nodes must stay in the same base as `folders` (notes-root-relative),
+    // because their path is what the grid button hands to `folderExists`.
+    const folderPath = extractFolderFromPath(note.path, notesRoot)
 
-    if (pathParts.length === 0 || pathParts[0] === 'notes') {
-      if (pathParts.length <= 1) {
-        rootNotes.push(note)
-      } else {
-        const folderPath = pathParts.slice(1).join('/')
-        ensureFolderInMap(folderPath).notes.push(note)
-      }
+    if (!folderPath) {
+      rootNotes.push(note)
     } else {
-      const folderPath = pathParts.join('/')
       ensureFolderInMap(folderPath).notes.push(note)
     }
   })

--- a/apps/desktop/src/renderer/src/components/notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree.tsx
@@ -127,6 +127,7 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
   const actions = useNoteTreeActions({
     noteMap: data.noteMap,
     tree: data.tree,
+    notesRoot: data.notesRoot,
     folders: data.folders,
     notePositions: data.notePositions,
     setNotePositions: data.setNotePositions,

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.test.tsx
@@ -95,12 +95,17 @@ const otherNote = createNote('other', 'notes/Other/C.pdf', { fileType: 'pdf' })
 const folders = [{ path: 'Work' }, { path: 'Other' }, { path: 'Work/Nested' }] as any[]
 const allNotes = [rootNote, workA, workB, otherNote]
 const noteMap = new Map(allNotes.map((note) => [note.id, note]))
-const tree = buildTreeFromNotes(allNotes, folders, {
-  'notes/Work/A.md': 1,
-  'notes/Work/B.md': 2,
-  Work: 1,
-  Other: 2
-})
+const tree = buildTreeFromNotes(
+  allNotes,
+  folders,
+  {
+    'notes/Work/A.md': 1,
+    'notes/Work/B.md': 2,
+    Work: 1,
+    Other: 2
+  },
+  'notes'
+)
 
 const createMutations = () =>
   ({
@@ -125,6 +130,7 @@ const renderActions = (overrides: Partial<NoteTreeActionsDeps> = {}) => {
   const deps: NoteTreeActionsDeps = {
     noteMap,
     tree,
+    notesRoot: 'notes',
     folders,
     notePositions: {},
     setNotePositions: vi.fn(),

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.ts
@@ -31,6 +31,8 @@ type NoteMutations = ReturnType<typeof useNoteMutations>
 export interface NoteTreeActionsDeps {
   noteMap: Map<string, NoteListItem>
   tree: TreeStructure
+  /** Vault's `defaultNoteFolder`; note paths are rebased onto it before use. */
+  notesRoot: string
   folders: FolderInfo[]
   notePositions: Record<string, number>
   setNotePositions: React.Dispatch<React.SetStateAction<Record<string, number>>>
@@ -596,11 +598,11 @@ export function useNoteTreeActions(deps: NoteTreeActionsDeps) {
       }
 
       const targetNote = deps.noteMap.get(targetId)
-      if (targetNote) return extractFolderFromPath(targetNote.path)
+      if (targetNote) return extractFolderFromPath(targetNote.path, deps.notesRoot)
 
       return ''
     },
-    [deps.noteMap]
+    [deps.noteMap, deps.notesRoot]
   )
 
   const handleNoteMove = useCallback(
@@ -608,7 +610,7 @@ export function useNoteTreeActions(deps: NoteTreeActionsDeps) {
       const note = deps.noteMap.get(noteId)
       if (!note) return false
 
-      const currentFolder = extractFolderFromPath(note.path)
+      const currentFolder = extractFolderFromPath(note.path, deps.notesRoot)
       if (currentFolder === targetFolder) return false
 
       try {
@@ -619,7 +621,7 @@ export function useNoteTreeActions(deps: NoteTreeActionsDeps) {
         return false
       }
     },
-    [deps.noteMap, deps.mutations.moveNote]
+    [deps.noteMap, deps.notesRoot, deps.mutations.moveNote]
   )
 
   const handleFolderMove = useCallback(
@@ -651,7 +653,7 @@ export function useNoteTreeActions(deps: NoteTreeActionsDeps) {
       } else {
         const targetNote = deps.noteMap.get(targetId)
         if (targetNote) {
-          const targetFolder = extractFolderFromPath(targetNote.path)
+          const targetFolder = extractFolderFromPath(targetNote.path, deps.notesRoot)
           newPath = targetFolder ? `${targetFolder}/${sourceFolderName}` : sourceFolderName
         } else {
           newPath = sourceFolderName
@@ -827,8 +829,8 @@ export function useNoteTreeActions(deps: NoteTreeActionsDeps) {
           const targetNoteObj = deps.noteMap.get(targetId)
 
           if (draggedNote && targetNoteObj) {
-            const draggedFolder = extractFolderFromPath(draggedNote.path)
-            const dropFolder = extractFolderFromPath(targetNoteObj.path)
+            const draggedFolder = extractFolderFromPath(draggedNote.path, deps.notesRoot)
+            const dropFolder = extractFolderFromPath(targetNoteObj.path, deps.notesRoot)
 
             if (draggedFolder === dropFolder) {
               const reordered = await handleReorderInFolder(

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts
@@ -6,7 +6,12 @@ import {
   type NoteListItem
 } from '@/hooks/use-notes-query'
 import { notesService } from '@/services/notes-service'
-import { buildTreeFromNotes, type TreeStructure } from '@/components/notes-tree-utils'
+import {
+  buildTreeFromNotes,
+  extractFolderFromPath,
+  type TreeStructure
+} from '@/components/notes-tree-utils'
+import { useNotesRoot } from '@/hooks/use-vault'
 import { createLogger } from '@/lib/logger'
 
 const log = createLogger('Hook:NoteTreeData')
@@ -20,6 +25,8 @@ export interface NoteTreeData {
   setFolderIcon: ReturnType<typeof useNoteFoldersQuery>['setFolderIcon']
   refreshFolders: ReturnType<typeof useNoteFoldersQuery>['refetch']
   mutations: ReturnType<typeof useNoteMutations>
+  /** Vault's `defaultNoteFolder` — the base every folder path in `tree` uses. */
+  notesRoot: string
   tree: TreeStructure
   noteMap: Map<string, NoteListItem>
   notePositions: Record<string, number>
@@ -33,6 +40,7 @@ export function useNoteTreeData(): NoteTreeData {
   const { notes, isLoading, error } = useNotesList({ limit: 10000 })
   const mutations = useNoteMutations()
   const { folders, createFolder, setFolderIcon, refetch: refreshFolders } = useNoteFoldersQuery()
+  const notesRoot = useNotesRoot()
 
   const [folderTemplateNames, setFolderTemplateNames] = useState<Map<string, string>>(new Map())
   const [notePositions, setNotePositions] = useState<Record<string, number>>({})
@@ -86,8 +94,8 @@ export function useNoteTreeData(): NoteTreeData {
   }, [notes])
 
   const tree = useMemo(() => {
-    return buildTreeFromNotes(notes, folders, notePositions)
-  }, [notes, folders, notePositions])
+    return buildTreeFromNotes(notes, folders, notePositions, notesRoot)
+  }, [notes, folders, notePositions, notesRoot])
 
   const noteMap = useMemo(() => {
     const map = new Map<string, NoteListItem>()
@@ -107,14 +115,13 @@ export function useNoteTreeData(): NoteTreeData {
 
       const note = noteMap.get(selectedId)
       if (note) {
-        const parts = note.path.split('/')
-        parts.pop()
-        return parts.join('/')
+        // createNote resolves `folder` against the notes root, so rebase here.
+        return extractFolderFromPath(note.path, notesRoot)
       }
 
       return ''
     }
-  }, [noteMap])
+  }, [noteMap, notesRoot])
 
   return {
     notes,
@@ -125,6 +132,7 @@ export function useNoteTreeData(): NoteTreeData {
     setFolderIcon,
     refreshFolders,
     mutations,
+    notesRoot,
     tree,
     noteMap,
     notePositions,

--- a/apps/desktop/src/renderer/src/hooks/use-vault.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-vault.ts
@@ -265,6 +265,45 @@ export function useVault() {
 }
 
 /**
+ * The vault's notes root (`config.defaultNoteFolder`); `''` for a flat vault.
+ *
+ * Folder paths — tree nodes, folder-view scopes, `.folder.md` config — are
+ * relative to this root, while note paths from the index are relative to the
+ * vault root. `stripNotesRoot` in `notes-tree-utils` rebases between the two.
+ *
+ * Deliberately lighter than `useVault()`: it holds a single string and only
+ * re-renders when that string actually changes, so the notes tree does not
+ * re-render on every index-progress tick.
+ */
+export function useNotesRoot(): string {
+  const [notesRoot, setNotesRoot] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+
+    const load = async () => {
+      try {
+        const config = await vaultService.getConfig()
+        if (!cancelled) setNotesRoot(config.defaultNoteFolder ?? '')
+      } catch {
+        // Keep the flat-vault default — the tree still renders, just unrebased.
+      }
+    }
+
+    void load()
+    // Changing defaultNoteFolder triggers a reindex, which emits a status change.
+    const unsubscribe = onVaultStatusChanged(() => void load())
+
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
+  }, [])
+
+  return notesRoot
+}
+
+/**
  * Hook for getting the list of all known vaults.
  */
 export function useVaultList() {

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -106,6 +106,13 @@ locale has finished loading.
 
 **Create in Selected Folder** routes new notes into whichever folder is currently selected in the sidebar.
 
+**Default Location for New Notes** sets the folder your notes live in. Leave it empty — the default —
+and notes sit directly in the vault root. Enter a folder name (say `Notes`) and that folder becomes
+the root of your notes tree: new notes are created inside it, and the sidebar shows *its* contents
+rather than the folder itself. Nothing is moved on disk, so switching the value back restores the
+previous layout. Notes that live outside this folder are still indexed and searchable, but they are
+listed relative to the vault root instead.
+
 ### Privacy
 
 **Telemetry** opts in or out of anonymous usage analytics. Off by default. Only enum-like event


### PR DESCRIPTION
Closes #1204

## What was wrong

Two producers feed the sidebar tree, and they used **different bases**:

| source | base |
| --- | --- |
| `notes:get-folders` (`notes-crud.ts` `getFolders()`) | notes root (`<vault>/<defaultNoteFolder>`) |
| folder nodes synthesised from `note.path` (`buildTreeFromNotes`) | **vault root**, minus a hardcoded `'notes'` literal |

Every consumer is notes-root-relative — `folderExists`, the folder view's `LIKE` query, `.folder.md`
config, `createNote({folder})`, `moveNote`. So any node the renderer synthesised was in the wrong
base unless `defaultNoteFolder` happened to be exactly the string `notes`.

With `defaultNoteFolder = "Notes"`, notes at `Notes/x.md` produced a phantom `Notes` tree node whose
path resolved to `<vault>/Notes/Notes`. `folderExists` returned false → `folderNotFound` →
"Folder not found" on the grid button. Same literal appeared in the note breadcrumb, so crumbs opened
the same broken view.

## The fix

Rebase note paths onto the **configured** notes root instead of a hardcoded literal, so the producer
and the consumer agree.

- `stripNotesRoot(notePath, notesRoot)` in `notes-tree-utils.tsx` — tolerant, mirroring
  `noteFolderFromPath` in `@memry/app-core`
- `extractFolderFromPath` and `buildTreeFromNotes` take the notes root
- `useNotesRoot()` in `use-vault.ts` — a single string, refreshed on vault status change (changing
  `defaultNoteFolder` triggers a reindex, which emits one). Deliberately lighter than `useVault()` so
  the tree does not re-render on index-progress ticks.
- Threaded through `use-note-tree-data` (tree build + `computeTargetFolder`, which feeds
  `createNote`), `use-note-tree-actions` (move/drag targets), and `note-breadcrumb`

The setting is **not** redefined — `defaultNoteFolder` stays the notes root, which is what every main
process consumer already implements. No validation-on-write was added: with the producer fixed,
pointing the setting at an existing top-level folder is now a working configuration, so rejecting it
would be wrong.

## Backward compatibility

Vault config shape, IPC contracts and on-disk layout are untouched; nothing is moved or migrated.

- `defaultNoteFolder = ''` (today's default, no top-level `notes/` folder) — no behaviour change.
- `defaultNoteFolder = 'notes'` (legacy vaults, and the field's placeholder) — the old hardcoded strip
  and the new configured strip produce identical paths. No change.
- `defaultNoteFolder = ''` **and** a real top-level folder named `notes/` — behaviour changes, as a
  fix: those notes used to be hoisted to the tree root while the `notes` node rendered empty. They now
  nest correctly, matching what `getFolders()` already reported for that vault.
- Any other value (the reported case) — the phantom root node disappears and folder paths resolve.
  Reverting the setting to empty still restores the previous view, as before.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts --project renderer` over
  `notes-tree-utils`, `use-note-tree-actions`, `note-sidebar-surfaces`, `notes-tree`,
  `virtualized-notes-tree`, `note`, `cold-zero-components`, `cold-major-components`, `app-sidebar`
  → 145 passed
- `pnpm lint` → 0 errors · `pnpm typecheck` → clean · `pnpm docs:build` → clean
- `pnpm docs:impact --base origin/main --strict` → docs changed on this branch

Regression test — `notes-tree-utils.test.tsx`, "does not emit a folder node for the notes root
itself": `defaultNoteFolder = 'Notes'`, notes at `Notes/hello.md` and `Notes/Work/alpha.md`, folders
as `getFolders()` reports them (`['Work']`). It asserts the tree's folder paths are exactly `['Work']`
— no `Notes` node for `folderExists` to reject. Pre-fix, the tree also contained `Notes` and
`rootNotes` was empty, so the test fails on `main`. Existing tests that encoded the hardcoded literal
now pass `'notes'` explicitly, preserving their intent.

## Known gap (not fixed here)

Notes stored **outside** the notes root (e.g. `Archive/x.md` when `defaultNoteFolder = 'Notes'`) are
still indexed and still shown, but their folder node cannot resolve under the notes root, so its grid
button reports "Folder not found". Handling those is a product call — hide them, hoist them to the
tree root, or widen the folder scope to the vault root — and is independent of this fix. Two more
copies of the same hardcoded `'notes'` literal remain in
`lib/virtualized-tree-utils.ts` (`getParentFolderId`, keyboard nav only) and `pages/note.tsx`
(backlink folder label, display only); neither produces a folder-view scope.
