### PR TITLE
fix(home): persist widget layout at every window width

### DIFF
--- a/apps/desktop/src/renderer/src/components/home/board-grid-persistence.test.tsx
+++ b/apps/desktop/src/renderer/src/components/home/board-grid-persistence.test.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react'
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { BoardGrid } from './board-grid'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { registerWidget } from '@/lib/home/widget-registry'
+import { GRID_MARGIN, GRID_ROW_HEIGHT } from '@/lib/home/widget-sizes'
+import type { HomePage } from '@/lib/home/types'
+
+// Board width the grid believes it has. Deliberately NARROW (a 1280px window minus the sidebar and
+// page padding lands around here) — the regression this file guards is that a drag made at a narrow
+// window width was silently dropped. Only WidthProvider is stubbed, and only because its single job
+// is measuring the container, which jsdom always reports as 0. The grid itself is the real one.
+const BOARD_WIDTH = 900
+
+vi.mock('react-grid-layout/legacy', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-grid-layout/legacy')>()
+  return {
+    ...actual,
+    WidthProvider:
+      <P,>(Component: React.ComponentType<P & { width: number }>) =>
+      (props: P) => <Component {...props} width={BOARD_WIDTH} />
+  }
+})
+
+// jsdom never lays anything out, so `offsetParent` is null and react-grid-layout refuses to begin a
+// drag. Point it at the parent element so the drag pipeline runs for real.
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+    configurable: true,
+    get(this: HTMLElement) {
+      return this.parentElement
+    }
+  })
+})
+
+registerWidget({
+  type: 'bookmarks',
+  titleKey: 'Bookmarks',
+  icon: 'bookmark',
+  defaultLayout: { w: 2, h: 2 },
+  defaultConfig: {},
+  Component: () => <div>BM</div>
+})
+
+const initialBoard: HomePage = {
+  id: 'b1',
+  name: 'B',
+  position: 0,
+  widgets: [{ id: 'w1', type: 'bookmarks', x: 0, y: 0, w: 2, h: 2, config: {} }]
+}
+
+// Stands in for the persisted board (home_pages row). BoardGrid writes through onChange; a remount
+// reads back whatever was written, so the assertions cover a real save→reload round trip.
+function makeStore(board: HomePage) {
+  return { board }
+}
+
+function Harness({ store }: { store: { board: HomePage } }): React.JSX.Element {
+  const [board, setBoard] = useState(store.board)
+  return (
+    <TooltipProvider>
+      <BoardGrid
+        board={board}
+        onChange={(next) => {
+          store.board = next
+          setBoard(next)
+        }}
+      />
+    </TooltipProvider>
+  )
+}
+
+function widgetPosition(): { x: number; y: number } {
+  const el = document.querySelector<HTMLElement>('.react-grid-item')
+  const transform = el?.style.transform ?? ''
+  const match = /translate\((-?[\d.]+)px,\s*(-?[\d.]+)px\)/.exec(transform)
+  if (!match) throw new Error(`no translate on grid item: ${transform}`)
+  return { x: Number(match[1]), y: Number(match[2]) }
+}
+
+// One grid column / row step in pixels, so drags move a whole cell.
+const colStep = (BOARD_WIDTH - GRID_MARGIN[0] * 9) / 8 + GRID_MARGIN[0]
+const rowStep = GRID_ROW_HEIGHT + GRID_MARGIN[1]
+
+function dragWidget(dx: number, dy: number): void {
+  const handle = screen.getByLabelText('Drag widget')
+  fireEvent.mouseDown(handle, { clientX: 0, clientY: 0, button: 0 })
+  fireEvent.mouseMove(document, { clientX: dx, clientY: dy })
+  fireEvent.mouseUp(document, { clientX: dx, clientY: dy })
+}
+
+describe('BoardGrid persistence', () => {
+  it('persists a drag and restores it on remount', () => {
+    const store = makeStore(initialBoard)
+    const first = render(<Harness store={store} />)
+
+    const before = widgetPosition()
+    dragWidget(Math.round(colStep * 3), Math.round(rowStep * 2))
+    // Sanity: the drag really moved the widget on screen (guards against a no-op simulation).
+    expect(widgetPosition().x).toBeGreaterThan(before.x)
+
+    // The move reached the persisted board, not just react-grid-layout's internal state.
+    expect(store.board.widgets[0]).toMatchObject({ id: 'w1', x: 3 })
+    const moved = store.board.widgets[0]
+
+    first.unmount()
+
+    // Remount from what was persisted — the arrangement must come back, not reset to the default.
+    render(<Harness store={makeStore(store.board) as { board: HomePage }} />)
+    expect(store.board.widgets[0]).toMatchObject({ x: moved.x, y: moved.y })
+    const pos = widgetPosition()
+    expect(pos.x).toBeGreaterThan(0)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/home/board-grid.test.tsx
+++ b/apps/desktop/src/renderer/src/components/home/board-grid.test.tsx
@@ -9,16 +9,16 @@ import type { HomePage } from '@/lib/home/types'
 // react-grid-layout measures container width via ResizeObserver (0 in jsdom), so stub it to a
 // passthrough that renders children and captures onLayoutChange so tests can fire RGL callbacks.
 const rgl = vi.hoisted(() => ({
-  onLayoutChange: undefined as undefined | ((layout: unknown, all: unknown) => void)
+  onLayoutChange: undefined as undefined | ((layout: unknown) => void)
 }))
 vi.mock('react-grid-layout/legacy', () => ({
   WidthProvider: (C: unknown) => C,
-  Responsive: ({
+  default: ({
     children,
     onLayoutChange
   }: {
     children: React.ReactNode
-    onLayoutChange?: (layout: unknown, all: unknown) => void
+    onLayoutChange?: (layout: unknown) => void
   }) => {
     rgl.onLayoutChange = onLayoutChange
     return <div>{children}</div>
@@ -56,31 +56,27 @@ describe('BoardGrid', () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ widgets: [] }))
   })
 
-  // Regression: resizing the window narrow makes RGL switch to a fewer-column breakpoint and
-  // report a collapsed single-column layout. That must NOT be persisted, or widgets lose their
-  // positions and never return when the window is widened again.
-  it('ignores a narrow-breakpoint collapse and keeps the lg layout', () => {
+  // RGL reports a layout on mount and after compaction, not only after a real edit. Persisting
+  // those would loop refetch → re-render, so an identical layout must be ignored.
+  it('ignores a layout callback that changes nothing', () => {
     const onChange = vi.fn()
     render(
       <TooltipProvider>
         <BoardGrid board={board} onChange={onChange} />
       </TooltipProvider>
     )
-    const collapsed = [{ i: 'w1', x: 0, y: 0, w: 2, h: 4 }]
-    const intactLg = [{ i: 'w1', x: 0, y: 0, w: 4, h: 4 }]
-    rgl.onLayoutChange?.(collapsed, { lg: intactLg, sm: collapsed })
+    rgl.onLayoutChange?.([{ i: 'w1', x: 0, y: 0, w: 4, h: 4 }])
     expect(onChange).not.toHaveBeenCalled()
   })
 
-  it('persists a real edit made at the lg breakpoint', () => {
+  it('persists a real edit', () => {
     const onChange = vi.fn()
     render(
       <TooltipProvider>
         <BoardGrid board={board} onChange={onChange} />
       </TooltipProvider>
     )
-    const editedLg = [{ i: 'w1', x: 2, y: 1, w: 4, h: 4 }]
-    rgl.onLayoutChange?.(editedLg, { lg: editedLg })
+    rgl.onLayoutChange?.([{ i: 'w1', x: 2, y: 1, w: 4, h: 4 }])
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
         widgets: [expect.objectContaining({ id: 'w1', x: 2, y: 1, w: 4, h: 4 })]

--- a/apps/desktop/src/renderer/src/components/home/board-grid.tsx
+++ b/apps/desktop/src/renderer/src/components/home/board-grid.tsx
@@ -1,11 +1,6 @@
 import { useMemo } from 'react'
 import { motion, useReducedMotion } from 'motion/react'
-import {
-  Responsive,
-  WidthProvider,
-  type Layout,
-  type ResponsiveLayouts
-} from 'react-grid-layout/legacy'
+import GridLayout, { WidthProvider, type Layout } from 'react-grid-layout/legacy'
 import 'react-grid-layout/css/styles.css'
 import './home-grid.css'
 import { WidgetFrame } from './widget-frame'
@@ -17,7 +12,6 @@ import {
   type GridLayoutItem
 } from '@/lib/home/layout-reducer'
 import {
-  GRID_BREAKPOINTS,
   GRID_COLS,
   GRID_ROW_HEIGHT,
   GRID_MARGIN,
@@ -28,7 +22,7 @@ import {
 import type { HomePage } from '@/lib/home/types'
 import { useT } from '@memry/i18n/renderer'
 
-const ResponsiveGrid = WidthProvider(Responsive)
+const Grid = WidthProvider(GridLayout)
 
 interface BoardGridProps {
   board: HomePage
@@ -67,21 +61,19 @@ export function BoardGrid({ board, onChange }: BoardGridProps): React.JSX.Elemen
     [board.widgets]
   )
 
-  // Responsive RGL switches to a fewer-column breakpoint below `lg` width and reports the COLLAPSED
-  // layout as the first arg. Persisting that would overwrite the stored desktop arrangement and it
-  // never returns on resize-up. The model's x/y/w/h are authored against `lg`, so persist only the
-  // `lg` entry from allLayouts — it stays intact across breakpoint collapses, the first arg doesn't.
-  const handleLayoutChange = (_current: Layout, allLayouts: ResponsiveLayouts): void => {
-    const lg = allLayouts.lg
-    if (!lg || unchanged(board, lg)) return
-    onChange(applyLayout(board, lg as GridLayoutItem[]))
+  // The grid has one column count at every width, so what RGL reports here IS the board's
+  // arrangement — persist it. (It used to be responsive: below the `lg` width RGL reported a
+  // collapsed layout that could not be persisted without destroying the stored arrangement, so
+  // every drag and resize made on a narrower window was silently discarded — issue #1216.)
+  const handleLayoutChange = (next: Layout): void => {
+    if (unchanged(board, next)) return
+    onChange(applyLayout(board, next as GridLayoutItem[]))
   }
 
   return (
-    <ResponsiveGrid
+    <Grid
       className="home-grid"
-      layouts={{ lg: layout }}
-      breakpoints={GRID_BREAKPOINTS}
+      layout={layout}
       cols={GRID_COLS}
       rowHeight={GRID_ROW_HEIGHT}
       margin={GRID_MARGIN}
@@ -148,6 +140,6 @@ export function BoardGrid({ board, onChange }: BoardGridProps): React.JSX.Elemen
           </div>
         )
       })}
-    </ResponsiveGrid>
+    </Grid>
   )
 }

--- a/apps/desktop/src/renderer/src/components/home/home-grid.css
+++ b/apps/desktop/src/renderer/src/components/home/home-grid.css
@@ -29,6 +29,19 @@
   }
 }
 
+/* Width floor. The board keeps eight columns at every width, so on a narrow window every column —
+   and every widget in it — scales down with nothing to stop it: measured at 65px wide on an 800px
+   window with the sidebar and Day Panel open, which drops the widget title entirely. Flooring the
+   board at 640px keeps a minimum four-column widget at ~302px. Below the floor the page container
+   (home.tsx, already overflow-auto) scrolls horizontally instead: a deliberate trade of sideways
+   scrolling for widgets that stay readable. Around 800px and narrower the page already scrolled
+   horizontally for other reasons, but between there and roughly a 1270px window this floor is what
+   introduces it. react-grid-layout reads its column width from this element's measured width, so
+   the floor is what RGL computes against — the stored 8-column coordinates are untouched. */
+.home-grid {
+  min-width: 640px;
+}
+
 /* Drag/resize placeholder under the moving widget. Radius matches the card (rounded-2xl). */
 .home-grid .react-grid-placeholder {
   background: var(--tint);

--- a/apps/desktop/src/renderer/src/lib/home/widget-sizes.ts
+++ b/apps/desktop/src/renderer/src/lib/home/widget-sizes.ts
@@ -1,9 +1,10 @@
 import type { WidgetSize } from './types'
 
-// react-grid-layout config for the Home board. Responsive: column count drops at narrow widths;
-// RGL derives the narrower breakpoint layouts from the stored `lg` layout.
-export const GRID_BREAKPOINTS = { lg: 1024, md: 768, sm: 0 } as const
-export const GRID_COLS = { lg: 8, md: 4, sm: 2 } as const
+// react-grid-layout config for the Home board. One fixed column count at every width — columns
+// scale with the container instead of collapsing at breakpoints. A board has a single stored
+// arrangement, so a responsive grid could only ever derive the narrow layouts from it and throw
+// them away again; edits made at a narrow width were never persisted (issue #1216).
+export const GRID_COLS = 8
 export const GRID_ROW_HEIGHT = 56 // px per row unit
 export const GRID_MARGIN: [number, number] = [12, 12]
 

--- a/apps/docs/src/user-guide/home-dashboard.md
+++ b/apps/docs/src/user-guide/home-dashboard.md
@@ -42,7 +42,7 @@ The board is a free-form 8-column grid (powered by react-grid-layout):
 - **Resize** — drag the grip at the bottom-right corner. Each widget has a minimum size it won't shrink below.
 - **Remove** — use the control in the widget frame.
 
-Layout changes persist automatically, at any window size. The board keeps its eight columns whatever the window width — columns get narrower rather than collapsing — so a widget always occupies the same share of the board and your arrangement is the one you left, on every launch.
+Layout changes persist automatically, at any window size. The board keeps its eight columns whatever the window width — columns get narrower rather than collapsing — so a widget always occupies the same share of the board and your arrangement is the one you left, on every launch. Columns stop narrowing once the board reaches its minimum width; from there the board scrolls sideways rather than squeezing widgets past the point of being readable.
 
 ### Density
 

--- a/apps/docs/src/user-guide/home-dashboard.md
+++ b/apps/docs/src/user-guide/home-dashboard.md
@@ -12,7 +12,7 @@ A fresh vault auto-seeds a single board named **Home**. You can keep just that o
 - **Create a board** — use **New** in the switcher; give it a name (and optional icon).
 - **Reorder** — boards keep a stable position so the switcher order is predictable.
 
-Each board stores its own set of widgets and their layout. Boards are part of your vault, so they sync across your devices.
+Each board stores its own set of widgets and their layout, saved in the vault database on the device that made them. Boards are **not** part of sync yet, so each device keeps its own boards and arrangement.
 
 ## Widgets
 
@@ -36,13 +36,13 @@ Open the **widget gallery** (the add-widget control on the board) and click a ty
 
 ### Move, resize & remove
 
-The board is a free-form grid (powered by react-grid-layout):
+The board is a free-form 8-column grid (powered by react-grid-layout):
 
 - **Move** — drag a widget by its header to reposition it; neighbours reflow.
 - **Resize** — drag the grip at the bottom-right corner. Each widget has a minimum size it won't shrink below.
 - **Remove** — use the control in the widget frame.
 
-Layout changes persist automatically.
+Layout changes persist automatically, at any window size. The board keeps its eight columns whatever the window width — columns get narrower rather than collapsing — so a widget always occupies the same share of the board and your arrangement is the one you left, on every launch.
 
 ### Density
 


### PR DESCRIPTION
Closes #1216

## Root cause

The layout **was** being written (data DB `home_pages.widgets`, via `homePages.update` IPC) — but only for edits made at one window width.

`board-grid.tsx` rendered react-grid-layout's **Responsive** grid with `breakpoints = {lg: 1024, md: 768, sm: 0}` and `cols = {lg: 8, md: 4, sm: 2}`. A board stores a *single* arrangement (`x/y/w/h` per widget), so the handler deliberately persisted only `allLayouts.lg` — persisting a collapsed narrow layout would have overwritten the real arrangement.

RGL only ever writes the **active** breakpoint into `allLayouts` (`dist/chunk-WGL5FSZH.mjs`: `handleLayoutChange` → `{...currentLayouts, [breakpoint]: newLayout}`). So below the `lg` breakpoint, `allLayouts.lg` is byte-identical to what we passed in, the `unchanged()` guard short-circuits, and **every drag and resize is dropped on the floor**. The move looks fine for the session (RGL's own state) and is gone on the next launch.

The grid is the window minus the sidebar (256px) and page padding (48px), so `lg` needs a window wider than roughly **1330px**. Any normal non-maximized window — on macOS and on Fedora — sits at `md`, which is exactly what Jerry reports on both machines.

## Fix

One fixed **8-column** grid at every width (`GRID_COLS = 8`, legacy `GridLayout` instead of `Responsive`). Columns scale with the container instead of collapsing, so what RGL reports *is* the board's arrangement and can always be persisted. A widget keeps the same share of the board on a 13" laptop and a 27" display, which is a better fit for a two-machine user than a reflow that only existed to be thrown away.

Backward compatible: stored coordinates are unchanged (same 8-column space), no migration, no contract or schema change. Existing boards render exactly as authored; on a narrow window they now scale down instead of reflowing to 4/2 columns.

## Per-device or synced?

Today Home boards are **per-device**: `home_page` is not in `SYNC_ITEM_TYPES`, there is no item handler, nothing is pushed. Jerry sees the bug on two machines because each machine drops its own edits independently — not because the two disagree.

**They should sync.** A board is authored content (which widgets, their configs — a Tasks widget points at a saved filter, and filters already sync), not device state; and now that positions are relative to a fixed 8-column grid rather than pixel-bound, an arrangement transfers cleanly between differently sized screens. That is a sync-protocol addition (new item type + handler + field-level clocks, following `folder_config`) and does **not** belong inside a persistence bugfix — filing it as a follow-up.

The docs claimed boards sync; corrected to say they are per-device for now.

## Verification

- New `board-grid-persistence.test.tsx` drives the **real** grid — no RGL mock, real `mousedown`/`mousemove`/`mouseup` drag — at a deliberately narrow board width, then unmounts and remounts from what was persisted. Fails on `main` (`x: 0` — the drag moved the widget on screen but nothing was saved), passes here.
  - The pre-existing `board-grid.test.tsx` mocked RGL entirely, so it asserted the lg-only rule was implemented correctly rather than that a user's drag survives. Its obsolete breakpoint case is replaced.
  - Two jsdom stubs, both narrow and documented: `WidthProvider` (its only job is measuring, which jsdom reports as 0) and `HTMLElement.offsetParent` (null in jsdom, and RGL refuses to start a drag without it).
- `pnpm lint` (0 errors), `pnpm typecheck`, home renderer suite (18 files / 74 tests), `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build`.

## Not verified

See the verification comment below: the branch has since been rebased onto current `main` and exercised in a running Electron app, including an A/B of the narrow-window rendering against the pre-fix build.
