### PR TITLE
fix(voice): close the AudioContext when recorder waveform setup throws

### DIFF
--- a/apps/desktop/src/renderer/src/components/voice-recorder.test.tsx
+++ b/apps/desktop/src/renderer/src/components/voice-recorder.test.tsx
@@ -30,13 +30,25 @@ class MockMediaRecorder {
   }
 }
 
+// Every constructed context is recorded so a test can assert the one that was
+// orphaned by a failed setup still got closed.
+const audioContexts: MockAudioContext[] = []
+let waveformSetupError: Error | null = null
+
 class MockAudioContext {
-  createMediaStreamSource = vi.fn(() => ({ connect: vi.fn() }))
+  createMediaStreamSource = vi.fn(() => {
+    if (waveformSetupError) throw waveformSetupError
+    return { connect: vi.fn() }
+  })
   createAnalyser = vi.fn(() => ({
     fftSize: 2048,
     getByteTimeDomainData: vi.fn((array: Uint8Array) => array.fill(128))
   }))
   close = vi.fn().mockResolvedValue(undefined)
+
+  constructor() {
+    audioContexts.push(this)
+  }
 }
 
 describe('VoiceRecorder', () => {
@@ -47,6 +59,8 @@ describe('VoiceRecorder', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    audioContexts.length = 0
+    waveformSetupError = null
 
     Object.defineProperty(navigator, 'mediaDevices', {
       configurable: true,
@@ -152,6 +166,39 @@ describe('VoiceRecorder', () => {
 
     await userEvent.click(screen.getByRole('button', { name: '' }))
     expect(onCancel).toHaveBeenCalled()
+  })
+
+  // Chromium caps concurrent per-document AudioContexts. A context the cleanup
+  // path cannot reach is never closed, so enough failed setups break every later
+  // waveform for the whole session.
+  it('closes the AudioContext when the waveform graph fails to build', async () => {
+    waveformSetupError = new DOMException('too many contexts', 'NotSupportedError')
+
+    render(<VoiceRecorder onRecordingComplete={onRecordingComplete} onCancel={onCancel} />)
+
+    await userEvent.click(screen.getByLabelText('Start voice recording'))
+
+    // Recording still works; only the waveform is lost.
+    expect(await screen.findByLabelText('Stop recording')).toBeInTheDocument()
+
+    expect(audioContexts).toHaveLength(1)
+    expect(audioContexts[0].close).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not close the AudioContext twice when teardown follows a failed setup', async () => {
+    waveformSetupError = new DOMException('too many contexts', 'NotSupportedError')
+
+    const { unmount } = render(
+      <VoiceRecorder onRecordingComplete={onRecordingComplete} onCancel={onCancel} />
+    )
+
+    await userEvent.click(screen.getByLabelText('Start voice recording'))
+    expect(await screen.findByLabelText('Stop recording')).toBeInTheDocument()
+
+    unmount()
+
+    expect(audioContexts).toHaveLength(1)
+    expect(audioContexts[0].close).toHaveBeenCalledTimes(1)
   })
 
   it('supports imperative start and handles missing microphones', async () => {

--- a/apps/desktop/src/renderer/src/components/voice-recorder.tsx
+++ b/apps/desktop/src/renderer/src/components/voice-recorder.tsx
@@ -85,13 +85,18 @@ export const VoiceRecorder = forwardRef<VoiceRecorderHandle, VoiceRecorderProps>
 
     const startWaveformAnalysis = useCallback((stream: MediaStream) => {
       try {
+        // Publish the context before wiring the graph: createMediaStreamSource,
+        // createAnalyser and connect can all throw, and a context the cleanup path
+        // cannot reach is never closed. Chromium caps concurrent per-document
+        // AudioContexts, so orphans break every later waveform for the session.
         const audioContext = new AudioContext()
+        audioContextRef.current = audioContext
+
         const source = audioContext.createMediaStreamSource(stream)
         const analyser = audioContext.createAnalyser()
         analyser.fftSize = 2048
         source.connect(analyser)
 
-        audioContextRef.current = audioContext
         analyserRef.current = analyser
 
         const bufferLength = analyser.fftSize
@@ -128,6 +133,13 @@ export const VoiceRecorder = forwardRef<VoiceRecorderHandle, VoiceRecorderProps>
         rafRef.current = requestAnimationFrame(updateBars)
       } catch (err) {
         log.error('Failed to start waveform analysis', err)
+        // Mirrors cleanupAudio for the context it published above (inlined to keep
+        // this callback dependency-free). Nulling the ref as it closes keeps the
+        // close idempotent, so the effect teardown later is a no-op, not a second
+        // close. rafRef is untouched: every throw site here precedes scheduling.
+        void audioContextRef.current?.close().catch(() => {})
+        audioContextRef.current = null
+        analyserRef.current = null
       }
     }, [])
 


### PR DESCRIPTION
Closes #1067. Part of epic #987 (Memory & CPU full-app performance audit 2026-08).

## Verification (issue is real on current `main` @ 21d1dae9b)

`apps/desktop/src/renderer/src/components/voice-recorder.tsx` @ `origin/main`:

- `:88` — `const audioContext = new AudioContext()`
- `:89-92` — `createMediaStreamSource(stream)`, `createAnalyser()`, `analyser.fftSize = 2048`, `source.connect(analyser)`. Every one of these can throw.
- `:94` — `audioContextRef.current = audioContext`, reached only *after* all four.
- `:129-131` — the catch logs and nothing else:

```ts
} catch (err) {
  log.error('Failed to start waveform analysis', err)
}
```

So any throw between construction and `:94` leaves a live `AudioContext` that `cleanupAudio()` (`:74-84`, gated on `audioContextRef.current`) can never see, and therefore never closes. Chromium caps concurrent per-document `AudioContext`s, and the component stays mounted across retries, so each failed start strands one more. Once the cap is hit every later `new AudioContext()` throws — the recorder waveform and the playback waveform in `inbox-detail/content-section.tsx` are both dead for the rest of the session.

## Change

`apps/desktop/src/renderer/src/components/voice-recorder.tsx`, +13/-1, four executable lines:

- `audioContextRef.current = audioContext` moved to immediately after construction, before any node is created or connected, so the context is reachable by cleanup from the moment it exists.
- The catch now closes that context and nulls both refs instead of only logging.

Closing is idempotent: nulling `audioContextRef.current` as it closes means the effect teardown that runs later (`:184-187`) finds `null` and no-ops rather than double-closing. `rafRef` is deliberately untouched in the catch — every throw site precedes the `requestAnimationFrame` scheduling, so there is nothing to cancel.

The close is inlined rather than delegating to `cleanupAudio`. Taking that dependency makes prettier expand the `useCallback` into its multi-line form, which reindents ~90 untouched lines — including the rAF `updateBars` loop that no test executes, since the tests stub `requestAnimationFrame`. That churn is invisible to reviewers and to `git diff -w`, but codecov counts every reindented line as new and uncovered; the first push of this PR failed `codecov/patch` at `51.51% of diff hit (target 88.12%)` for exactly that reason. Keeping the dependency array empty keeps the diff honest.

## Tests

`voice-recorder.test.tsx` (+49). The existing `MockAudioContext` gained a constructor that records every instance, plus a module-level `waveformSetupError` flag that makes `createMediaStreamSource` throw — following the mocking approach already in the file rather than introducing a new one.

1. `closes the AudioContext when the waveform graph fails to build` — setup throws `NotSupportedError`; asserts recording still reaches the live controls (only the waveform is lost) and the one constructed context was closed exactly once.
2. `does not close the AudioContext twice when teardown follows a failed setup` — same throw, then `unmount()`; asserts `close` was still called exactly once, pinning the idempotency.

Red → green:

```
# before the fix (source reverted, new tests present)
 × closes the AudioContext when the waveform graph fails to build
   → expected "vi.fn()" to be called 1 times, but got 0 times
 × does not close the AudioContext twice when teardown follows a failed setup
   → expected "vi.fn()" to be called 1 times, but got 0 times
 Tests  2 failed | 5 passed (7)

# after the fix (+ both neighbouring voice suites)
 Test Files  3 passed (3)
      Tests  16 passed (16)
```

Mutation-tested, since mocked tests are otherwise easy to fool:

- Drop the close from the catch, keep the early ref assignment → `Tests 1 failed | 6 passed`. Test 1 dies: teardown alone only closes on unmount, far too late to stop the cap being hit.
- Drop the early ref assignment, keep the close in the catch → `Tests 2 failed | 5 passed`. Both die: there is nothing for the catch to find.

## Checks

- `pnpm --filter @memry/desktop typecheck:web` — clean, no output.
- `pnpm exec eslint --no-cache apps/desktop/src/renderer/src/components/voice-recorder.tsx` — clean, no output.
- Renderer: `voice-recorder.test.tsx` + `use-voice-capture.test.tsx` + `use-voice-capture-start-failure.test.tsx` → `16 passed (16)`.
- `git diff --check` — clean.
- `pnpm docs:impact --base origin/main --strict` reported `missing-docs`. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: no user-visible surface changes — no new setting, contract, UI, or documented behavior. The only delta is that a failed waveform setup now closes the context it already opened. Same call as sibling PR #1131 in this area.

## Scope

Only the recorder waveform path in `voice-recorder.tsx`. `inbox-detail/content-section.tsx:381` constructs its own playback `AudioContext` and is left alone — a separate surface, not what #1067 describes. Complements #1131 (#1012), which released the *microphone stream* on the recorder-start throw path; this one releases the *audio context* on the waveform-setup throw path.