### PR TITLE
fix(auth): give the recovery screen a way out and stop calling expired setup tokens invalid

### DIFF
--- a/apps/desktop/src/main/ipc/auth-device-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/auth-device-handlers.test.ts
@@ -17,10 +17,12 @@ vi.mock('../sync/http-client', () => ({
   deleteFromServer: (...args: unknown[]) => mockDeleteFromServer(...args),
   patchToServer: (...args: unknown[]) => mockPatchToServer(...args),
   SyncServerError: class SyncServerError extends Error {
-    status: number
-    constructor(msg: string, status: number) {
+    statusCode: number
+    serverError?: string
+    constructor(msg: string, statusCode: number, serverError?: string) {
       super(msg)
-      this.status = status
+      this.statusCode = statusCode
+      this.serverError = serverError
     }
   }
 }))
@@ -128,12 +130,15 @@ vi.mock('electron', () => ({
 const mockGetValidAccessToken = vi.fn()
 const mockRetrieveToken = vi.fn()
 const mockStoreToken = vi.fn()
+const mockIsTokenExpired = vi.fn()
 vi.mock('../sync/token-manager', () => ({
   getValidAccessToken: (...args: unknown[]) => mockGetValidAccessToken(...args),
+  isTokenExpired: (...args: unknown[]) => mockIsTokenExpired(...args),
   retrieveToken: (...args: unknown[]) => mockRetrieveToken(...args),
   storeToken: (...args: unknown[]) => mockStoreToken(...args)
 }))
 
+import { SyncServerError } from '../sync/http-client'
 import { registerAuthDeviceHandlers, unregisterAuthDeviceHandlers } from './auth-device-handlers'
 
 // ============================================================================
@@ -147,6 +152,7 @@ describe('auth-device handlers', () => {
     vi.useFakeTimers()
     mockStoreGet.mockReturnValue({})
     mockRetrieveToken.mockResolvedValue('mock-access-token')
+    mockIsTokenExpired.mockReturnValue(false)
     mockStoreToken.mockResolvedValue(undefined)
     mockGetValidAccessToken.mockResolvedValue('mock-access-token')
     mockValidateKeyVerifier.mockReturnValue(true)
@@ -437,7 +443,8 @@ describe('auth-device handlers', () => {
       // #then
       expect(result).toEqual({
         success: false,
-        error: 'Session expired. Please sign in again.'
+        error:
+          'Your sign-in timed out before this finished. Sign in again, then enter your recovery phrase.'
       })
     })
 
@@ -585,6 +592,52 @@ describe('auth-device handlers', () => {
       expect(mockSecureCleanup).toHaveBeenCalledWith(signingSecretKey)
     })
 
+    it('reports setup-token failures as a sign-in timeout, never the server wording', async () => {
+      // #given — the sentence a user can act on (#1202: they saw "Invalid setup token")
+      registerAuthDeviceHandlers()
+      const timedOut = {
+        success: false,
+        error:
+          'Your sign-in timed out before this finished. Sign in again, then enter your recovery phrase.'
+      }
+      const phrase = { recoveryPhrase: 'correct horse battery staple' }
+
+      // #when — the five-minute token already ran out while the user hunted for their phrase
+      mockIsTokenExpired.mockReturnValueOnce(true)
+
+      // #then — answered locally, no pointless round trip
+      await expect(invokeHandler(SYNC_CHANNELS.LINK_VIA_RECOVERY, phrase)).resolves.toEqual(
+        timedOut
+      )
+      expect(mockGetFromServer).not.toHaveBeenCalled()
+
+      // #when / #then — the server's own 401 wording is translated, not forwarded
+      mockGetFromServer.mockRejectedValueOnce(
+        new SyncServerError('Invalid setup token', 401, 'AUTH_INVALID_TOKEN: Invalid setup token')
+      )
+      await expect(invokeHandler(SYNC_CHANNELS.LINK_VIA_RECOVERY, phrase)).resolves.toEqual(
+        timedOut
+      )
+
+      // #when / #then — same for a token already consumed by a device registration
+      mockGetFromServer.mockResolvedValueOnce({ kdfSalt: 'salt', keyVerifier: 'verifier' })
+      mockRecoverMasterKeyFromPhrase.mockResolvedValueOnce({
+        masterKey: new Uint8Array(32).fill(3),
+        kdfSalt: 'salt',
+        keyVerifier: 'verifier'
+      })
+      mockGetOrCreateSigningKeyPair.mockResolvedValueOnce({
+        publicKey: new Uint8Array(32),
+        secretKey: new Uint8Array(64)
+      })
+      mockPersistKeysAndRegisterDevice.mockRejectedValueOnce(
+        new SyncServerError('Setup token already used', 401)
+      )
+      await expect(invokeHandler(SYNC_CHANNELS.LINK_VIA_RECOVERY, phrase)).resolves.toEqual(
+        timedOut
+      )
+    })
+
     it('returns recovery-linking validation and verifier failures without registering a device', async () => {
       registerAuthDeviceHandlers()
 
@@ -598,7 +651,11 @@ describe('auth-device handlers', () => {
         invokeHandler(SYNC_CHANNELS.LINK_VIA_RECOVERY, {
           recoveryPhrase: 'correct horse battery staple'
         })
-      ).resolves.toEqual({ success: false, error: 'Session expired. Please sign in again.' })
+      ).resolves.toEqual({
+        success: false,
+        error:
+          'Your sign-in timed out before this finished. Sign in again, then enter your recovery phrase.'
+      })
 
       mockGetFromServer.mockResolvedValueOnce({ kdfSalt: 'salt', keyVerifier: 'verifier' })
       mockRecoverMasterKeyFromPhrase.mockResolvedValueOnce({

--- a/apps/desktop/src/main/ipc/auth-device-handlers.ts
+++ b/apps/desktop/src/main/ipc/auth-device-handlers.ts
@@ -32,7 +32,13 @@ import {
 } from '../crypto'
 import { getDatabase, isDatabaseInitialized } from '../database/client'
 import { store } from '../store'
-import { deleteFromServer, getFromServer, patchToServer, postToServer } from '../sync/http-client'
+import {
+  deleteFromServer,
+  getFromServer,
+  patchToServer,
+  postToServer,
+  SyncServerError
+} from '../sync/http-client'
 import { persistKeysAndRegisterDevice } from '../sync/device-registration'
 import {
   approveDeviceLinking,
@@ -42,7 +48,12 @@ import {
   initiateDeviceLinking,
   linkViaQr
 } from '../sync/linking-service'
-import { getValidAccessToken, retrieveToken, storeToken } from '../sync/token-manager'
+import {
+  getValidAccessToken,
+  isTokenExpired,
+  retrieveToken,
+  storeToken
+} from '../sync/token-manager'
 import { createLogger } from '../lib/logger'
 import { registerCommand } from './lib/register-command'
 import { getMainI18n } from '../lib/main-i18n'
@@ -173,6 +184,44 @@ export async function performFirstDeviceSetup(setupToken: string): Promise<First
 }
 
 // ============================================================================
+// Setup-token failures
+// ============================================================================
+
+/**
+ * The setup token minted at sign-in is valid for five minutes and is consumed
+ * by the first device registration. Finishing a reinstall takes longer than
+ * that whenever the user has to go and find their 24-word recovery phrase, so
+ * the server answers 401 and its wording — "Invalid setup token", "Setup token
+ * already used" — used to reach the user verbatim (issue #1202). Nobody can
+ * act on a message about an artifact they never saw.
+ *
+ * Every setup-token rejection is translated into one sentence about signing in
+ * again, and logged with the (non-sensitive) reason so a diagnostic report can
+ * separate "expired while the user was reading" from "never persisted". Token
+ * contents are never logged.
+ */
+function isSetupTokenRejection(err: unknown): boolean {
+  return err instanceof SyncServerError && err.statusCode === 401
+}
+
+function setupSessionExpiredMessage(): string {
+  return getMainI18n().t('errors:auth.setupSessionExpired')
+}
+
+function logSetupTokenFailure(
+  stage: 'recovery-info' | 'device-register' | 'first-device-setup',
+  reason: 'absent' | 'locally-expired' | 'rejected',
+  err?: unknown
+): void {
+  logger.warn('Setup token unusable during account setup', {
+    stage,
+    reason,
+    statusCode: err instanceof SyncServerError ? err.statusCode : undefined,
+    serverError: err instanceof SyncServerError ? err.serverError : undefined
+  })
+}
+
+// ============================================================================
 // OTP Clipboard Detection State
 // ============================================================================
 
@@ -272,11 +321,18 @@ export function registerAuthDeviceHandlers(): void {
   ipcMain.handle(SYNC_CHANNELS.SETUP_NEW_ACCOUNT, async () => {
     const setupToken = await retrieveToken(KEYCHAIN_ENTRIES.SETUP_TOKEN)
     if (!setupToken) {
-      return { success: false, error: getMainI18n().t('errors:auth.sessionExpired') }
+      logSetupTokenFailure('first-device-setup', 'absent')
+      return { success: false, error: setupSessionExpiredMessage() }
     }
 
-    const { deviceId } = await performFirstDeviceSetup(setupToken)
-    return { success: true, deviceId }
+    try {
+      const { deviceId } = await performFirstDeviceSetup(setupToken)
+      return { success: true, deviceId }
+    } catch (err) {
+      if (!isSetupTokenRejection(err)) throw err
+      logSetupTokenFailure('first-device-setup', 'rejected', err)
+      return { success: false, error: setupSessionExpiredMessage() }
+    }
   })
 
   registerCommand(
@@ -344,10 +400,25 @@ export function registerAuthDeviceHandlers(): void {
 
       const setupToken = await retrieveToken(KEYCHAIN_ENTRIES.SETUP_TOKEN)
       if (!setupToken) {
-        return { success: false, error: getMainI18n().t('errors:auth.sessionExpired') }
+        logSetupTokenFailure('recovery-info', 'absent')
+        return { success: false, error: setupSessionExpiredMessage() }
       }
 
-      const rawRecovery = await getFromServer<unknown>('/auth/recovery-info', setupToken)
+      // Checked locally first: a token that already ran out cannot be salvaged
+      // by a round trip, and the server's own wording for it is unreadable.
+      if (isTokenExpired(setupToken)) {
+        logSetupTokenFailure('recovery-info', 'locally-expired')
+        return { success: false, error: setupSessionExpiredMessage() }
+      }
+
+      let rawRecovery: unknown
+      try {
+        rawRecovery = await getFromServer<unknown>('/auth/recovery-info', setupToken)
+      } catch (err) {
+        if (!isSetupTokenRejection(err)) throw err
+        logSetupTokenFailure('recovery-info', 'rejected', err)
+        return { success: false, error: setupSessionExpiredMessage() }
+      }
       const recoveryInfo = RecoveryDataResponseSchema.parse(rawRecovery)
 
       const derived = await recoverMasterKeyFromPhrase(input.recoveryPhrase, recoveryInfo.kdfSalt)
@@ -362,16 +433,22 @@ export function registerAuthDeviceHandlers(): void {
         const keyPair = await getOrCreateSigningKeyPair()
         signingSecretKey = keyPair.secretKey
 
-        const deviceId = await persistKeysAndRegisterDevice(
-          derived.masterKey,
-          signingSecretKey,
-          setupToken,
-          derived.kdfSalt,
-          derived.keyVerifier,
-          true
-        )
+        try {
+          const deviceId = await persistKeysAndRegisterDevice(
+            derived.masterKey,
+            signingSecretKey,
+            setupToken,
+            derived.kdfSalt,
+            derived.keyVerifier,
+            true
+          )
 
-        return { success: true, deviceId }
+          return { success: true, deviceId }
+        } catch (err) {
+          if (!isSetupTokenRejection(err)) throw err
+          logSetupTokenFailure('device-register', 'rejected', err)
+          return { success: false, error: setupSessionExpiredMessage() }
+        }
       } finally {
         secureCleanup(derived.masterKey)
         if (signingSecretKey) secureCleanup(signingSecretKey)

--- a/apps/desktop/src/renderer/src/components/sync/start-fresh-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/sync/start-fresh-panel.tsx
@@ -1,0 +1,87 @@
+import { AlertTriangle } from '@/lib/icons'
+import { Button } from '@/components/ui/button'
+import { useT } from '@memry/i18n/renderer'
+
+interface StartFreshPanelProps {
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+/**
+ * The way out of the recovery prompt for someone who cannot produce a recovery
+ * phrase. Without it, a reinstall with no phrase and no second device leaves
+ * uninstalling as the only remaining move (issue #1202).
+ *
+ * Deliberately never a default action: it is only reachable from a subdued
+ * link, it states every consequence before the confirm button, and the confirm
+ * button is the destructive variant. Signing out deletes this device's master
+ * key, so anything already encrypted under it becomes unreadable for good —
+ * that has to be a decision, never a slip.
+ */
+export function StartFreshPanel({ onConfirm, onCancel }: StartFreshPanelProps): React.JSX.Element {
+  const { t } = useT('settings')
+
+  const consequences = [
+    t('setup.startFresh.consequenceSignOut'),
+    t('setup.startFresh.consequenceKey'),
+    t('setup.startFresh.consequenceLocal')
+  ]
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-3">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-destructive/10">
+          <AlertTriangle className="size-5 text-destructive" aria-hidden="true" />
+        </div>
+        <div className="space-y-1.5">
+          <h3 className="font-semibold text-base/5 tracking-[-0.01em] text-foreground">
+            {t('setup.startFresh.title')}
+          </h3>
+          <p className="text-xs/4 text-muted-foreground">{t('setup.startFresh.description')}</p>
+        </div>
+      </div>
+
+      <ul className="space-y-2 rounded-xl border border-border bg-muted/30 p-3 text-xs/4 text-muted-foreground">
+        {consequences.map((consequence) => (
+          <li key={consequence} className="flex items-start gap-2">
+            <span
+              aria-hidden="true"
+              className="mt-1.5 size-1 shrink-0 rounded-full bg-muted-foreground/60"
+            />
+            <span>{consequence}</span>
+          </li>
+        ))}
+      </ul>
+
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <Button variant="outline" onClick={onCancel}>
+          {t('setup.startFresh.cancel')}
+        </Button>
+        <Button variant="destructive" onClick={onConfirm}>
+          {t('setup.startFresh.confirm')}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The subdued entry point to {@link StartFreshPanel}. Styled as a quiet link so
+ * it never competes with "Restore access", but always present so the recovery
+ * screen is never a dead end.
+ */
+export function StartFreshTrigger({ onClick }: { onClick: () => void }): React.JSX.Element {
+  const { t } = useT('settings')
+
+  return (
+    <div className="flex justify-center pt-1">
+      <button
+        type="button"
+        onClick={onClick}
+        className="rounded-sm text-xs/4 text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        {t('setup.startFresh.trigger')}
+      </button>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/sync/vault-recovery-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sync/vault-recovery-dialog.test.tsx
@@ -108,6 +108,29 @@ describe('VaultRecoveryDialog', () => {
     expect(onSignOut).toHaveBeenCalledTimes(1)
   })
 
+  it('offers a start-fresh escape that only signs out after an explicit confirmation', () => {
+    const onSignOut = vi.fn()
+    render(
+      <VaultRecoveryDialog open onRecovered={vi.fn()} onDismiss={vi.fn()} onSignOut={onSignOut} />
+    )
+
+    openInput()
+    fireEvent.click(screen.getByRole('button', { name: /recovery phrase back/i }))
+
+    // Consequences are stated before anything is destroyed.
+    expect(screen.getByText(/without the recovery phrase/i)).toBeInTheDocument()
+    expect(onSignOut).not.toHaveBeenCalled()
+
+    // Backing out returns to the phrase input with the session intact.
+    fireEvent.click(screen.getByRole('button', { name: 'Go back' }))
+    expect(onSignOut).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'submit-phrase' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /recovery phrase back/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out and start fresh' }))
+    expect(onSignOut).toHaveBeenCalledTimes(1)
+  })
+
   it('surfaces a wrong-phrase error without recovering or offering re-auth', async () => {
     hoisted.linkViaRecovery.mockRejectedValueOnce(
       new Error('Recovery phrase does not match. Please try again.')

--- a/apps/desktop/src/renderer/src/components/sync/vault-recovery-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/sync/vault-recovery-dialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react'
+import { useT } from '@memry/i18n/renderer'
 import {
   AlertDialog,
   AlertDialogContent,
@@ -11,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { AlertTriangle } from '@/lib/icons'
 import { useAuth } from '@/contexts/auth-context'
 import { RecoveryPhraseInput } from './recovery-phrase-input'
+import { StartFreshPanel, StartFreshTrigger } from './start-fresh-panel'
 
 interface VaultRecoveryDialogProps {
   open: boolean
@@ -33,8 +35,9 @@ export function VaultRecoveryDialog({
   onDismiss,
   onSignOut
 }: VaultRecoveryDialogProps): React.JSX.Element {
+  const { t } = useT('settings')
   const { linkViaRecovery } = useAuth()
-  const [phase, setPhase] = useState<'intro' | 'input'>('intro')
+  const [phase, setPhase] = useState<'intro' | 'input' | 'start-fresh'>('intro')
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [sessionExpired, setSessionExpired] = useState(false)
@@ -98,6 +101,13 @@ export function VaultRecoveryDialog({
               </Button>
             </AlertDialogFooter>
           </>
+        ) : phase === 'start-fresh' ? (
+          <>
+            <AlertDialogHeader className="sr-only">
+              <AlertDialogTitle>{t('setup.startFresh.title')}</AlertDialogTitle>
+            </AlertDialogHeader>
+            <StartFreshPanel onConfirm={onSignOut} onCancel={() => setPhase('input')} />
+          </>
         ) : (
           <>
             <AlertDialogHeader>
@@ -118,6 +128,7 @@ export function VaultRecoveryDialog({
                 </Button>
               </AlertDialogFooter>
             )}
+            <StartFreshTrigger onClick={() => setPhase('start-fresh')} />
           </>
         )}
       </AlertDialogContent>

--- a/apps/desktop/src/renderer/src/pages/settings/setup-wizard.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/setup-wizard.test.tsx
@@ -395,4 +395,28 @@ describe('SetupWizard', () => {
     await user.click(screen.getByRole('button', { name: 'back to link choice' }))
     expect(auth.setWizardStep).toHaveBeenCalledWith('linking-choice')
   })
+
+  it('offers a start-fresh escape from the recovery step that only signs out after confirmation', async () => {
+    // #given
+    const user = userEvent.setup()
+    const auth = mockAuth({ wizardStep: 'recovery-input' })
+    render(<SetupWizard />)
+
+    // #when — the escape is one subdued link away, never a default action
+    await user.click(screen.getByRole('button', { name: 'setup.startFresh.trigger' }))
+
+    // #then — consequences first, nothing destroyed yet
+    expect(screen.getByText('setup.startFresh.consequenceKey')).toBeInTheDocument()
+    expect(auth.logout).not.toHaveBeenCalled()
+
+    // #when — backing out leaves the session alone
+    await user.click(screen.getByRole('button', { name: 'setup.startFresh.cancel' }))
+    expect(auth.logout).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'submit recovery phrase' })).toBeInTheDocument()
+
+    // #when / #then — only the explicit confirm signs out
+    await user.click(screen.getByRole('button', { name: 'setup.startFresh.trigger' }))
+    await user.click(screen.getByRole('button', { name: 'setup.startFresh.confirm' }))
+    expect(auth.logout).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/desktop/src/renderer/src/pages/settings/setup-wizard.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/setup-wizard.tsx
@@ -12,6 +12,7 @@ import { OAuthButtons } from '@/components/sync/oauth-buttons'
 import { RecoveryPhraseDisplay } from '@/components/sync/recovery-phrase-display'
 import { RecoveryPhraseConfirm } from '@/components/sync/recovery-phrase-confirm'
 import { RecoveryPhraseInput } from '@/components/sync/recovery-phrase-input'
+import { StartFreshPanel, StartFreshTrigger } from '@/components/sync/start-fresh-panel'
 import { LinkingCodeEntry } from '@/components/sync/linking-code-entry'
 import { LinkingPending } from '@/components/sync/linking-pending'
 import { VaultPickerStep } from '@/components/sync/vault-picker-step'
@@ -62,6 +63,7 @@ export function SetupWizard(): React.JSX.Element {
   const [isResending, setIsResending] = useState(false)
   const [recoveryPhrase, setRecoveryPhrase] = useState<string | null>(null)
   const [recoveryPhraseError, setRecoveryPhraseError] = useState(false)
+  const [isStartingFresh, setIsStartingFresh] = useState(false)
   const [now, setNow] = useState(() => Date.now())
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -222,6 +224,15 @@ export function SetupWizard(): React.JSX.Element {
     void logout()
   }, [logout])
 
+  // Signing out is what "start fresh" means here: the session, this device's
+  // key material and the sync tables go, the vault folder on disk stays. See
+  // StartFreshPanel for the consequences the user confirms first.
+  const handleStartFresh = useCallback(() => {
+    setIsStartingFresh(false)
+    clearWizardError()
+    void logout()
+  }, [clearWizardError, logout])
+
   const currentStepIndex = STEP_MAP[wizardStep]
 
   return (
@@ -375,14 +386,23 @@ export function SetupWizard(): React.JSX.Element {
         />
       )}
 
-      {wizardStep === 'recovery-input' && (
-        <RecoveryPhraseInput
-          onSubmit={handleRecoverySubmit}
-          isLoading={isLoading}
-          error={wizardError}
-          onBack={() => setWizardStep('linking-choice')}
-        />
-      )}
+      {wizardStep === 'recovery-input' &&
+        (isStartingFresh ? (
+          <StartFreshPanel
+            onConfirm={handleStartFresh}
+            onCancel={() => setIsStartingFresh(false)}
+          />
+        ) : (
+          <>
+            <RecoveryPhraseInput
+              onSubmit={handleRecoverySubmit}
+              isLoading={isLoading}
+              error={wizardError}
+              onBack={() => setWizardStep('linking-choice')}
+            />
+            <StartFreshTrigger onClick={() => setIsStartingFresh(true)} />
+          </>
+        ))}
     </div>
   )
 }

--- a/apps/docs/src/user-guide/sync/recovery-rotation.md
+++ b/apps/docs/src/user-guide/sync/recovery-rotation.md
@@ -53,6 +53,27 @@ app signs that device out and routes you into this same recovery flow — sign i
 recovery phrase, and the device re-derives the correct key and pulls everything cleanly. Data on
 the server is never affected.
 
+### If the Sign-In Times Out
+
+The sign-in that precedes recovery is only valid for a few minutes. If you go looking for your
+recovery phrase and come back after it has run out, the app tells you the sign-in timed out and
+asks you to sign in again before entering the phrase — the phrase itself is still fine, and
+nothing was lost.
+
+### If You Can't Get Your Recovery Phrase Back
+
+The recovery screen offers **"I can't get my recovery phrase back"**. It is deliberately quiet,
+and it explains everything before it does anything:
+
+- This device signs out and stops syncing.
+- The encryption key held on this device is deleted. Anything already stored in your account
+  stays encrypted under the old key, and without the recovery phrase **nothing can ever read it
+  again**. This cannot be undone.
+- Notes already saved on this computer stay in your vault folder and keep working.
+
+Only use it when the phrase is gone for good. If there is any chance of finding it — a password
+manager, a printout, another device still signed in — recover instead.
+
 ## Key Rotation
 
 The **rotation wizard** generates a new vault key, re-encrypts all payloads under it, and reseals the new key for every linked device.

--- a/apps/sync-server/src/lib/jwt-errors.ts
+++ b/apps/sync-server/src/lib/jwt-errors.ts
@@ -1,0 +1,28 @@
+/**
+ * Classify a failed `jwtVerify` rejection as "the token expired".
+ *
+ * jose reports expiry as `JWTExpired` whose message is
+ * `"exp" claim timestamp check failed` — the word "expired" never appears in
+ * it. Call sites that sniffed the message therefore never matched, and every
+ * expired token was reported to the client as *invalid* instead. That is how a
+ * timed-out setup token reached users as "Invalid setup token" after a
+ * reinstall (issue #1202): the five-minute setup token had simply run out
+ * while they went looking for their recovery phrase.
+ *
+ * Match on jose's stable error code and keep the message check as a fallback
+ * for anything else that throws its own expiry error.
+ */
+export const JWT_EXPIRED_ERROR_CODE = 'ERR_JWT_EXPIRED'
+
+export function isJwtExpiredError(err: unknown): boolean {
+  if (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { code?: unknown }).code === JWT_EXPIRED_ERROR_CODE
+  ) {
+    return true
+  }
+
+  const message = err instanceof Error ? err.message : ''
+  return message.includes('expired') || message.includes('"exp" claim timestamp check failed')
+}

--- a/apps/sync-server/src/middleware/auth.ts
+++ b/apps/sync-server/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import type { MiddlewareHandler } from 'hono'
 
 import { AppError, ErrorCodes } from '../lib/errors'
+import { isJwtExpiredError } from '../lib/jwt-errors'
 import { JwtKeyError, verifyAccessToken } from '../lib/jwt-verify'
 import type { AppContext } from '../types'
 
@@ -27,7 +28,7 @@ export const authMiddleware: MiddlewareHandler<AppContext> = async (c, next) => 
       throw new AppError(ErrorCodes.INTERNAL_ERROR, 'Invalid JWT verify key configuration', 500)
     }
     const message = err instanceof Error ? err.message : 'Token verification failed'
-    if (message.includes('expired')) {
+    if (isJwtExpiredError(err)) {
       throw new AppError(ErrorCodes.AUTH_TOKEN_EXPIRED, 'Token has expired', 401)
     }
     throw new AppError(ErrorCodes.AUTH_INVALID_TOKEN, message, 401)

--- a/apps/sync-server/src/middleware/setup-auth.test.ts
+++ b/apps/sync-server/src/middleware/setup-auth.test.ts
@@ -139,6 +139,28 @@ describe('setup-auth middleware', () => {
     } satisfies Partial<AppError>)
   })
 
+  it("maps jose's real expiry rejection to AUTH_TOKEN_EXPIRED, not AUTH_INVALID_TOKEN", async () => {
+    // #given — the shape jose actually throws: the message never says "expired",
+    // so a substring check reported timed-out setup tokens as invalid (#1202).
+    const expired = Object.assign(new Error('"exp" claim timestamp check failed'), {
+      code: 'ERR_JWT_EXPIRED'
+    })
+    hoisted.jwtVerifyMock.mockRejectedValue(expired)
+    const { context } = createContext()
+
+    // #when / #then
+    await expect(
+      setupAuthMiddleware(
+        context as never,
+        vi.fn(async () => undefined)
+      )
+    ).rejects.toMatchObject({
+      code: ErrorCodes.AUTH_TOKEN_EXPIRED,
+      message: 'Setup token has expired',
+      statusCode: 401
+    } satisfies Partial<AppError>)
+  })
+
   it('rejects tokens with invalid signature', async () => {
     // #given
     hoisted.jwtVerifyMock.mockRejectedValue(new Error('signature verification failed'))

--- a/apps/sync-server/src/middleware/setup-auth.ts
+++ b/apps/sync-server/src/middleware/setup-auth.ts
@@ -2,6 +2,7 @@ import { jwtVerify } from 'jose'
 import type { MiddlewareHandler } from 'hono'
 
 import { AppError, ErrorCodes } from '../lib/errors'
+import { isJwtExpiredError } from '../lib/jwt-errors'
 import { getPublicKey } from '../lib/jwt-keys'
 import type { AppContext } from '../types'
 
@@ -37,8 +38,7 @@ export const setupAuthMiddleware: MiddlewareHandler<AppContext> = async (c, next
     })
     payload = result.payload as typeof payload
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Token verification failed'
-    if (message.includes('expired')) {
+    if (isJwtExpiredError(err)) {
       throw new AppError(ErrorCodes.AUTH_TOKEN_EXPIRED, 'Setup token has expired', 401)
     }
     throw new AppError(ErrorCodes.AUTH_INVALID_TOKEN, 'Invalid setup token', 401)

--- a/apps/sync-server/src/routes/auth.ts
+++ b/apps/sync-server/src/routes/auth.ts
@@ -17,6 +17,7 @@ import {
 import { buildOtpEmailHtml } from '../emails/otp-template'
 import { safeBase64Decode } from '../lib/encoding'
 import { AppError, ErrorCodes } from '../lib/errors'
+import { isJwtExpiredError } from '../lib/jwt-errors'
 import { createLogger } from '../lib/logger'
 import { getPrivateKey, getPublicKey } from '../lib/jwt-keys'
 import { authMiddleware } from '../middleware/auth'
@@ -750,8 +751,7 @@ auth.post('/refresh', refreshRateLimit, async (c) => {
     })
     claims = result.payload as typeof claims
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Token verification failed'
-    if (message.includes('expired')) {
+    if (isJwtExpiredError(err)) {
       throw new AppError(ErrorCodes.AUTH_TOKEN_EXPIRED, 'Refresh token has expired', 401)
     }
     throw new AppError(ErrorCodes.AUTH_INVALID_TOKEN, 'Invalid refresh token', 401)

--- a/packages/i18n/src/locales/en/errors.json
+++ b/packages/i18n/src/locales/en/errors.json
@@ -123,6 +123,7 @@
   "auth": {
     "notAuthenticated": "Not authenticated",
     "sessionExpired": "Session expired. Please sign in again.",
+    "setupSessionExpired": "Your sign-in timed out before this finished. Sign in again, then enter your recovery phrase.",
     "invalidRecoveryPhraseFormat": "Invalid recovery phrase format",
     "recoveryPhraseMismatch": "Recovery phrase does not match. Please try again.",
     "cannotRemoveCurrentDevice": "Cannot remove the current device",

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -701,6 +701,16 @@
         "startOver": "Start over"
       }
     },
+    "startFresh": {
+      "trigger": "I can't get my recovery phrase back",
+      "title": "Start fresh on this device",
+      "description": "Only do this if your recovery phrase is gone for good. It cannot be undone.",
+      "consequenceSignOut": "This device signs out and stops syncing.",
+      "consequenceKey": "The encryption key held on this device is deleted. Anything already stored in your account stays encrypted under the old key — without the recovery phrase, nothing can ever read it again.",
+      "consequenceLocal": "Notes already saved on this computer stay in your vault folder and keep working.",
+      "confirm": "Sign out and start fresh",
+      "cancel": "Go back"
+    },
     "linking": {
       "choiceTitle": "Link this device",
       "choiceDescription": "Transfer encryption keys from another device or restore from your recovery phrase.",


### PR DESCRIPTION
Fixes both halves of #1202.

## Problem 1 — "invalid set up token" (root cause found)

The setup token minted at sign-in lives **5 minutes** (`SETUP_TOKEN_EXPIRY = '5m'`) and is single-use. Finishing a reinstall takes longer than that whenever the user has to go and find a 24-word phrase.

When it expires, `setupAuthMiddleware` was supposed to answer `AUTH_TOKEN_EXPIRED` / "Setup token has expired". It never did:

```js
// jose 6.1.3 — dist/webapi/lib/jwt_claims_set.js:155
throw new JWTExpired('"exp" claim timestamp check failed', payload, 'exp', 'check_failed')
```

The message never contains the word "expired", so `message.includes('expired')` was dead code and every expired token fell through to `AUTH_INVALID_TOKEN, 'Invalid setup token'` — the exact string the user quoted. The one test covering it passed a synthetic `new Error('token expired')`, which is why it was never caught.

Downstream, the desktop forwarded that message verbatim, and `VaultRecoveryDialog` only offers "Sign in again" when the message matches `/sign in again|session expired/i` — so the misclassification also swallowed the re-auth button. Dead end.

Fixed:

- `isJwtExpiredError` classifies on jose's stable `ERR_JWT_EXPIRED` code (message check kept as a fallback). Applied to `setup-auth`, `auth` middleware and the refresh route, which all carried the same latent bug.
- Desktop checks the setup token locally before the round trip and translates every setup-token 401 into one sentence about signing in again — the user never sees the word "token".
- Instrumentation for whatever is left: each failure logs `{ stage, reason, statusCode, serverError }` (`absent` / `locally-expired` / `rejected`), so the next diagnostic report separates expiry from a token that was never persisted. No token, phrase or key material is ever logged.

## Problem 2 — the escape hatch

Both the wizard's recovery step and the vault recovery dialog now offer a subdued **"I can't get my recovery phrase back"**. It opens a panel that states the consequences before anything happens:

- this device signs out and stops syncing;
- the encryption key held here is deleted — anything already stored in the account stays encrypted under the old key and **nothing can ever read it again**;
- notes already on this computer stay in the vault folder and keep working.

Confirm is the destructive variant and is the only thing that calls `logout()`. It is never a default action and cannot fire from a stray click; both tests assert the cancel path leaves the session untouched.

## Compat

No schema, contract or protocol change. Server-side the only difference is the error *code and wording* on an already-401 response; no client keys off `AUTH_TOKEN_EXPIRED`. Nothing new discards key material — the escape hatch reuses the existing sign-out teardown, which already deletes the master key on an explicit sign-out.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts --project renderer <dialog + wizard>` — 14 passed
- `pnpm exec vitest run --config config/vitest.config.ts --project main src/main/ipc/auth-device-handlers.test.ts` — 30 passed
- `pnpm exec vitest run src/middleware/setup-auth.test.ts src/middleware/auth.test.ts src/routes/auth.test.ts` (sync-server) — 94 passed
- `pnpm lint` (0 errors), `pnpm typecheck`, `pnpm --filter @memry/desktop i18n:check`, `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build`

Not reproduced on a real Windows reinstall — the diagnosis is from the code and jose's source, and the instrumentation is there to confirm it from the next report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)