### PR TITLE
fix(inbox): close the playback-waveform AudioContext on every decode exit path

### DIFF
--- a/apps/desktop/src/renderer/src/components/inbox-detail/content-section.test.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/content-section.test.tsx
@@ -374,8 +374,12 @@ describe('ContentSection', () => {
 
   it('closes the waveform AudioContext when the item unmounts mid-decode', async () => {
     const close = vi.fn()
+    let finishDecode: (buffer: unknown) => void = () => {}
+    const decoded = new Promise((resolve) => {
+      finishDecode = resolve
+    })
     const audioContextCtor = vi.fn(function AudioContext(this: any) {
-      this.decodeAudioData = vi.fn(() => new Promise(() => {}))
+      this.decodeAudioData = vi.fn(() => decoded)
       this.close = close
     })
 
@@ -402,6 +406,48 @@ describe('ContentSection', () => {
 
     unmount()
     expect(close).toHaveBeenCalledTimes(1)
+
+    // The in-flight decode still settles afterwards; it must not close twice.
+    finishDecode({ getChannelData: vi.fn(() => new Float32Array(120)) })
+    await decoded
+    await Promise.resolve()
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('never opens an AudioContext when the item unmounts before the audio bytes arrive', async () => {
+    let sendBytes: (buffer: ArrayBuffer) => void = () => {}
+    const bytes = new Promise<ArrayBuffer>((resolve) => {
+      sendBytes = resolve
+    })
+    const audioContextCtor = vi.fn(function AudioContext(this: any) {
+      this.decodeAudioData = vi.fn(async () => ({
+        getChannelData: vi.fn(() => new Float32Array(120))
+      }))
+      this.close = vi.fn()
+    })
+    const fetchMock = vi.fn(async () => ({ arrayBuffer: vi.fn(() => bytes) }))
+
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('AudioContext', audioContextCtor)
+
+    const { unmount } = render(
+      <ContentSection
+        item={baseItem('voice', {
+          title: 'Pending memo',
+          attachmentUrl: 'memry-file://pending.wav',
+          duration: 12,
+          metadata: { duration: 12, format: 'wav' }
+        })}
+      />
+    )
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    unmount()
+    sendBytes(new ArrayBuffer(8))
+    await bytes
+    await Promise.resolve()
+    expect(audioContextCtor).not.toHaveBeenCalled()
   })
 
   it('renders voice transcription pending, processing, empty, and failed retrying states', () => {

--- a/apps/desktop/src/renderer/src/components/inbox-detail/content-section.test.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/content-section.test.tsx
@@ -337,6 +337,73 @@ describe('ContentSection', () => {
     expect(screen.getByText('cannot decode')).toBeInTheDocument()
   })
 
+  it('closes the waveform AudioContext when the decode fails, and only once', async () => {
+    const close = vi.fn()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        arrayBuffer: vi.fn(async () => new ArrayBuffer(8))
+      }))
+    )
+    vi.stubGlobal(
+      'AudioContext',
+      vi.fn(function AudioContext(this: any) {
+        this.decodeAudioData = vi.fn(async () => {
+          throw new Error('unsupported audio file')
+        })
+        this.close = close
+      })
+    )
+
+    const { unmount } = render(
+      <ContentSection
+        item={baseItem('voice', {
+          title: 'Corrupt memo',
+          attachmentUrl: 'memry-file://corrupt.wav',
+          duration: 12,
+          metadata: { duration: 12, format: 'wav' }
+        })}
+      />
+    )
+
+    await waitFor(() => expect(close).toHaveBeenCalledTimes(1))
+
+    unmount()
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the waveform AudioContext when the item unmounts mid-decode', async () => {
+    const close = vi.fn()
+    const audioContextCtor = vi.fn(function AudioContext(this: any) {
+      this.decodeAudioData = vi.fn(() => new Promise(() => {}))
+      this.close = close
+    })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        arrayBuffer: vi.fn(async () => new ArrayBuffer(8))
+      }))
+    )
+    vi.stubGlobal('AudioContext', audioContextCtor)
+
+    const { unmount } = render(
+      <ContentSection
+        item={baseItem('voice', {
+          title: 'Slow memo',
+          attachmentUrl: 'memry-file://slow.wav',
+          duration: 12,
+          metadata: { duration: 12, format: 'wav' }
+        })}
+      />
+    )
+
+    await waitFor(() => expect(audioContextCtor).toHaveBeenCalledTimes(1))
+
+    unmount()
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
   it('renders voice transcription pending, processing, empty, and failed retrying states', () => {
     const { rerender } = render(
       <ContentSection item={baseItem('voice', { transcriptionStatus: 'processing' })} />

--- a/apps/desktop/src/renderer/src/components/inbox-detail/content-section.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/content-section.tsx
@@ -374,17 +374,27 @@ const VoicePreview = ({
     if (storedWaveform && storedWaveform.length > 0) return
 
     let cancelled = false
+    let activeContext: AudioContext | null = null
+    // Browsers cap concurrent AudioContexts, so every exit path has to release
+    // this one. close() throws if it runs twice, hence the single-shot guard.
+    const releaseContext = (): void => {
+      const context = activeContext
+      if (!context) return
+      activeContext = null
+      void context.close()
+    }
+
     const decodeWaveform = async (): Promise<void> => {
       try {
         const response = await fetch(audioUrl)
         const arrayBuffer = await response.arrayBuffer()
+        if (cancelled) return
+
         const audioContext = new AudioContext()
+        activeContext = audioContext
         const audioBuffer = await audioContext.decodeAudioData(arrayBuffer)
 
-        if (cancelled) {
-          void audioContext.close()
-          return
-        }
+        if (cancelled) return
 
         const rawData = audioBuffer.getChannelData(0)
         const samplesPerBar = Math.floor(rawData.length / PLAYBACK_BAR_COUNT)
@@ -405,19 +415,19 @@ const VoicePreview = ({
           (b) => PLAYBACK_MIN_HEIGHT + (b / maxRms) * (PLAYBACK_MAX_HEIGHT - PLAYBACK_MIN_HEIGHT)
         )
 
-        if (!cancelled) {
-          setWaveformBars(normalized)
-        }
-
-        void audioContext.close()
+        setWaveformBars(normalized)
       } catch (err) {
-        log.error('Failed to decode waveform', err)
+        // A cancelled decode rejects because we closed its context on unmount.
+        if (!cancelled) log.error('Failed to decode waveform', err)
+      } finally {
+        releaseContext()
       }
     }
 
     void decodeWaveform()
     return () => {
       cancelled = true
+      releaseContext()
     }
   }, [audioUrl, storedWaveform])
 

--- a/apps/docs/src/user-guide/inbox/capturing.md
+++ b/apps/docs/src/user-guide/inbox/capturing.md
@@ -60,7 +60,9 @@ seconds before the 5-minute limit. Keyboard shortcuts work too: **Esc** cancels 
 **Enter** or **Space** stops and saves it.
 
 The recording's waveform is captured alongside the audio, so the detail panel shows the real
-waveform instantly when you open a voice item.
+waveform instantly when you open a voice item. Older voice items recorded before waveforms were
+stored are decoded on demand instead; if that file is missing or unreadable the panel keeps the flat
+placeholder bars, and playback of other voice items stays unaffected no matter how many you open.
 
 If voice transcription is enabled, memrynote transcribes the audio in the background — see [Voice Transcription](/user-guide/ai/voice-transcription).
 


### PR DESCRIPTION
Part of epic #987 (Memory & CPU full-app performance audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/components/inbox-detail/content-section.tsx:377-416` (pre-fix) — the
legacy voice-memo waveform fallback built an `AudioContext` and closed it on the happy path
(line 412) and the cancelled path (line 385), but the `catch` at 413-415 only logged:

```ts
      } catch (err) {
        log.error('Failed to decode waveform', err)
      }
```

Opening any voice item captured before waveform persistence whose attachment is missing, corrupt, or
in an unsupported codec therefore orphaned one `AudioContext` — plus its decode backing memory — per
attempt, unbounded across a day of inbox browsing. Browsers cap concurrent `AudioContext`s, so this
eventually breaks audio playback outright, not just leaks memory.

Second hole in the same effect: unmounting mid-decode set `cancelled = true` but the context stayed
open until `decodeAudioData` settled, and if that decode then rejected the `catch` swallowed it
without closing either.

## What changed

`content-section.tsx` — the waveform effect now releases the context through a single-shot
`releaseContext()` guard, called from both the decode's `finally` and the effect cleanup:

- every exit path (success, cancel, throw, unmount) closes the context
- the guard nulls the ref before closing, so a normal teardown after a decode-path close cannot
  double-close (`AudioContext.close()` throws `InvalidStateError` on the second call)
- the post-fetch `cancelled` check moved ahead of `new AudioContext()`, so an already-unmounted item
  never allocates one at all
- a decode rejected *because* we closed its context on unmount no longer logs a spurious error

No contract, schema, or persisted-format change — purely renderer-local lifecycle. Stored-waveform
items still short-circuit before the effect, so behavior for current recordings is untouched.

## How it was verified

Two regression tests added to `content-section.test.tsx`, using the same `vi.stubGlobal('AudioContext', …)`
mocking approach as the neighbouring voice test.

Both fail on unfixed code:

```
 FAIL  |renderer| … > closes the waveform AudioContext when the decode fails, and only once
 FAIL  |renderer| … > closes the waveform AudioContext when the item unmounts mid-decode
 AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 Tests  2 failed | 8 passed (10)
```

Pass after:

```
 ✓ … > closes the waveform AudioContext when the decode fails, and only once 60ms
 ✓ … > closes the waveform AudioContext when the item unmounts mid-decode 58ms
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Also green locally: `pnpm --filter @memry/desktop typecheck:web`, `pnpm exec eslint` on the changed
source, `git diff --check`, `pnpm docs:impact --base origin/main --strict` (covered),
`pnpm docs:build`.

Closes #1068
