### PR TITLE
fix(ai-inline): abort, stop at quit, and cap the inline chat server

### DIFF
--- a/apps/desktop/src/main/ai-inline/ai-chat-server.test.ts
+++ b/apps/desktop/src/main/ai-inline/ai-chat-server.test.ts
@@ -1,3 +1,4 @@
+import http from 'node:http'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getServerPort, startChatServer, stopChatServer } from './ai-chat-server'
 
@@ -10,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   toolDefinitionsToToolSet: vi.fn(),
   pipe: vi.fn(),
   logInfo: vi.fn(),
+  logWarn: vi.fn(),
   logError: vi.fn()
 }))
 
@@ -33,6 +35,7 @@ vi.mock('@blocknote/xl-ai/server', () => ({
 vi.mock('../lib/logger', () => ({
   createLogger: () => ({
     info: (...args: unknown[]) => mocks.logInfo(...args),
+    warn: (...args: unknown[]) => mocks.logWarn(...args),
     error: (...args: unknown[]) => mocks.logError(...args)
   })
 }))
@@ -50,6 +53,80 @@ async function postJson(port: number, body: unknown): Promise<Response> {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
+  })
+}
+
+// Declares an oversized body without ever writing it, so the size guard has to
+// reject on the header alone.
+function postDeclaredLength(
+  port: number,
+  contentLength: number
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port,
+        path: '/api/ai/chat',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Content-Length': String(contentLength) }
+      },
+      (res) => {
+        let body = ''
+        res.setEncoding('utf8')
+        res.on('data', (chunk: string) => {
+          body += chunk
+        })
+        res.on('end', () => {
+          settled = true
+          resolve({ status: res.statusCode ?? 0, body })
+        })
+      }
+    )
+    req.on('error', (err) => {
+      if (!settled) reject(err)
+    })
+    // Node only flushes request headers on the first write, and the rest of the
+    // declared body is deliberately never sent.
+    req.write('{')
+  })
+}
+
+// Chunked upload with no declared length, and valid JSON so that an
+// uncapped server would happily buffer it and reach the model.
+function postChunkedJson(port: number, fillerBytes: number): Promise<number | 'errored'> {
+  return new Promise((resolve) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port,
+        path: '/api/ai/chat',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      },
+      (res) => {
+        res.resume()
+        res.on('end', () => resolve(res.statusCode ?? 0))
+      }
+    )
+    req.on('error', () => resolve('errored'))
+
+    const chunk = Buffer.alloc(1024 * 1024, 0x61)
+    let written = 0
+    const pump = (): void => {
+      while (written < fillerBytes) {
+        if (req.destroyed || req.writableEnded) return
+        written += chunk.length
+        if (!req.write(chunk)) {
+          req.once('drain', pump)
+          return
+        }
+      }
+      if (!req.destroyed) req.end('"}],"toolDefinitions":[]}')
+    }
+    req.write('{"messages":[{"role":"user","content":"')
+    pump()
   })
 }
 
@@ -130,7 +207,8 @@ describe('AI inline chat server', () => {
       system: 'html-system',
       messages: [{ role: 'user', content: 'hello' }],
       tools: { insert: { description: 'tool' } },
-      toolChoice: 'required'
+      toolChoice: 'required',
+      abortSignal: expect.any(AbortSignal)
     })
 
     const missing = await fetch(`http://127.0.0.1:${port}/nope`, { method: 'POST' })
@@ -154,5 +232,102 @@ describe('AI inline chat server', () => {
     expect(response.status).toBe(500)
     expect(await response.json()).toEqual({ error: 'Internal server error' })
     expect(mocks.logError).toHaveBeenCalledWith('Chat request failed:', expect.any(Error))
+  })
+
+  it('aborts the provider request when the client disconnects mid-stream', async () => {
+    let capturedSignal: AbortSignal | undefined
+    mocks.streamText.mockImplementation((options: { abortSignal: AbortSignal }) => {
+      capturedSignal = options.abortSignal
+      return { pipeUIMessageStreamToResponse: mocks.pipe }
+    })
+    // Never end the response: the generation is still in flight.
+    mocks.pipe.mockImplementation((res: http.ServerResponse) => {
+      res.writeHead(200)
+      res.write('partial')
+    })
+
+    const port = await startChatServer(settings)
+    const controller = new AbortController()
+    const response = await fetch(`http://127.0.0.1:${port}/api/ai/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: [], toolDefinitions: [] }),
+      signal: controller.signal
+    })
+    const drained = response.text().catch(() => undefined)
+
+    await vi.waitFor(() => expect(capturedSignal).toBeDefined())
+    expect(capturedSignal?.aborted).toBe(false)
+
+    controller.abort()
+
+    await vi.waitFor(() => expect(capturedSignal?.aborted).toBe(true))
+    await drained
+  })
+
+  it('stops while a response is still streaming so quit cannot hang', async () => {
+    mocks.pipe.mockImplementation((res: http.ServerResponse) => {
+      res.writeHead(200)
+      res.write('partial')
+    })
+
+    const port = await startChatServer(settings)
+    const response = await postJson(port, { messages: [], toolDefinitions: [] })
+    const drained = response.text().catch(() => undefined)
+    expect(response.status).toBe(200)
+
+    // Without closeAllConnections() this never resolves and the before-quit
+    // chain stalls until the shutdown timeout force-exits the app.
+    await stopChatServer()
+
+    expect(getServerPort()).toBeNull()
+    await expect(fetch(`http://127.0.0.1:${port}/nope`)).rejects.toThrow()
+    await drained
+  })
+
+  it('rejects a body whose declared length exceeds the cap without reading it', async () => {
+    const port = await startChatServer(settings)
+
+    const response = await postDeclaredLength(port, 26 * 1024 * 1024)
+
+    expect(response.status).toBe(413)
+    expect(JSON.parse(response.body)).toEqual({ error: 'Request body too large' })
+    expect(mocks.streamText).not.toHaveBeenCalled()
+    expect(mocks.logWarn).toHaveBeenCalledWith('Rejected oversized chat request body')
+  })
+
+  it('drops a chunked body that grows past the cap instead of buffering it', async () => {
+    const port = await startChatServer(settings)
+
+    const result = await postChunkedJson(port, 26 * 1024 * 1024)
+
+    expect(result).not.toBe(200)
+    expect(mocks.streamText).not.toHaveBeenCalled()
+  }, 20000)
+
+  it('keeps a listening server closable after a post-listen error', async () => {
+    const created: http.Server[] = []
+    const createServer = http.createServer.bind(http) as (...args: unknown[]) => http.Server
+    const spy = vi.spyOn(http, 'createServer').mockImplementation(((...args: unknown[]) => {
+      const instance = createServer(...args)
+      created.push(instance)
+      return instance
+    }) as typeof http.createServer)
+
+    try {
+      const port = await startChatServer(settings)
+      expect(created).toHaveLength(1)
+
+      // A late socket error must not make the module forget a bound server, or
+      // stopChatServer() resolves without closing it and the port leaks.
+      created[0].emit('error', new Error('late socket failure'))
+
+      expect(getServerPort()).toBe(port)
+      await stopChatServer()
+      expect(getServerPort()).toBeNull()
+      await expect(fetch(`http://127.0.0.1:${port}/nope`)).rejects.toThrow()
+    } finally {
+      spy.mockRestore()
+    }
   })
 })

--- a/apps/desktop/src/main/ai-inline/ai-chat-server.ts
+++ b/apps/desktop/src/main/ai-inline/ai-chat-server.ts
@@ -13,6 +13,18 @@ import { trackMainError } from '../telemetry/diagnostics'
 
 const logger = createLogger('AI:ChatServer')
 
+// Same ceiling as the capture server: enough for a large document plus its
+// conversation, small enough that a runaway client cannot exhaust main-process
+// memory before the socket is dropped.
+const MAX_BODY_BYTES = 25 * 1024 * 1024
+
+class PayloadTooLargeError extends Error {
+  constructor() {
+    super('Request body too large')
+    this.name = 'PayloadTooLargeError'
+  }
+}
+
 let server: http.Server | null = null
 let currentPort: number | null = null
 let currentSettingsKey: string | null = null
@@ -108,12 +120,15 @@ export async function startChatServer(settings: AIInlineSettings): Promise<numbe
     })
 
     nextServer.on('error', (err) => {
-      if (server === nextServer) {
+      logger.error('Server error:', err)
+      // Only a server that never reached listening is safe to forget. Nulling a
+      // bound server here would make stopChatServer() resolve without closing
+      // it, leaking the listening socket for the rest of the process lifetime.
+      if (server === nextServer && !nextServer.listening) {
         server = null
         currentPort = null
         currentSettingsKey = null
       }
-      logger.error('Server error:', err)
       reject(err)
     })
   })
@@ -154,6 +169,10 @@ export async function stopChatServer(): Promise<void> {
       return
     }
 
+    // close() only refuses new connections and drops idle ones. A socket still
+    // streaming a generation would keep it pending forever, stalling the
+    // before-quit chain until the 5s shutdown timeout force-exits the app.
+    closingServer.closeAllConnections?.()
     closingServer.close(() => {
       if (server === closingServer) {
         server = null
@@ -171,6 +190,15 @@ async function handleChatRequest(
   res: http.ServerResponse,
   model: ReturnType<typeof createLanguageModel>
 ): Promise<void> {
+  // Dismissing the inline AI menu just drops the renderer's fetch. Without this
+  // the provider request keeps generating into a dead socket until the model
+  // finishes. 'close' also fires on a completed response, so writableFinished
+  // tells a normal finish apart from a client that went away.
+  const abortController = new AbortController()
+  res.on('close', () => {
+    if (!res.writableFinished) abortController.abort()
+  })
+
   try {
     const body = await readBody(req)
     const { messages, toolDefinitions } = JSON.parse(body)
@@ -180,11 +208,21 @@ async function handleChatRequest(
       system: aiDocumentFormats.html.systemPrompt,
       messages: await convertToModelMessages(injectDocumentStateMessages(messages)),
       tools: toolDefinitionsToToolSet(toolDefinitions),
-      toolChoice: 'required'
+      toolChoice: 'required',
+      abortSignal: abortController.signal
     })
 
     result.pipeUIMessageStreamToResponse(res)
   } catch (error) {
+    if (error instanceof PayloadTooLargeError) {
+      logger.warn('Rejected oversized chat request body')
+      if (!res.headersSent) {
+        res.writeHead(413, { 'Content-Type': 'application/json', Connection: 'close' })
+      }
+      res.end(JSON.stringify({ error: 'Request body too large' }))
+      return
+    }
+
     logger.error('Chat request failed:', error)
     trackMainError('ai_inline', 'inline_chat_request', error)
     if (!res.headersSent) {
@@ -196,8 +234,26 @@ async function handleChatRequest(
 
 function readBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
+    // Reject before a single byte is buffered when the client declares an
+    // oversized body; the streaming guard below covers chunked bodies and
+    // clients that under-declare their length.
+    const declaredLength = Number(req.headers['content-length'])
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_BODY_BYTES) {
+      reject(new PayloadTooLargeError())
+      return
+    }
+
     const chunks: Buffer[] = []
-    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    let size = 0
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length
+      if (size > MAX_BODY_BYTES) {
+        reject(new PayloadTooLargeError())
+        req.destroy()
+        return
+      }
+      chunks.push(chunk)
+    })
     req.on('end', () => resolve(Buffer.concat(chunks).toString()))
     req.on('error', reject)
   })

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -124,6 +124,7 @@ import { getHeadlessCliArgs, runHeadlessCli } from './cli/headless'
 import { reconcileBillingAndSync, startBillingCheckout } from './billing/paddle-billing'
 import { openPairingWindow } from './capture/pairing'
 import { startCaptureServer, stopCaptureServer } from './capture/server'
+import { stopChatServer } from './ai-inline/ai-chat-server'
 import { applyLoginShellPath } from './agent/cli/login-shell-path'
 
 if (process.type === 'browser') {
@@ -2036,6 +2037,10 @@ app.on('before-quit', (event) => {
     .then(() => {
       shutdownLog.info('stopping capture server...')
       return stopCaptureServer()
+    })
+    .then(() => {
+      shutdownLog.info('stopping AI inline chat server...')
+      return stopChatServer()
     })
     .then(() => {
       shutdownLog.info('stopping voice transcription utility...')

--- a/apps/docs/src/user-guide/ai/inline-menu.md
+++ b/apps/docs/src/user-guide/ai/inline-menu.md
@@ -44,6 +44,12 @@ After a transformation:
 
 Until you accept, your original text is unchanged.
 
+## Cancelling a Generation
+
+Dismissing the menu while a transformation is still streaming cancels the request to
+the provider. Nothing keeps generating in the background, so a run you walked away
+from stops consuming local model time (Ollama) or API tokens (OpenAI, Anthropic).
+
 ## Provider
 
 Inline AI uses whichever provider you configured in [Settings → AI Inline](/user-guide/settings#ai-inline):
@@ -59,6 +65,10 @@ See [Provider Setup](/user-guide/ai/provider-setup) for configuring each.
 Requests go to whichever provider you chose. With **Ollama**, your text never leaves your machine. With **OpenAI** or **Anthropic**, the request goes to their API — review their data policies before sending sensitive content.
 
 memrynote never proxies these requests through the sync server. The connection is direct from your device to the provider.
+
+Inline AI is served by a small helper that listens only on `127.0.0.1`, so nothing on
+your network can reach it. It rejects requests larger than 25 MB, and it shuts down
+when you quit memrynote — no port stays bound after the app closes.
 
 ## When the Menu Doesn't Appear
 


### PR DESCRIPTION
## What was wrong

All four sub-problems in #1066 were still real on `main` @ `21d1dae9b` — nothing had been fixed since the audit. Validated each one separately:

1. **No abort wiring** — `ai-chat-server.ts:178-184`: `streamText` got no `abortSignal`, and nothing watched `req`/`res` for `'close'`. Dismissing the inline AI menu mid-generation just dropped the renderer's fetch; the provider request kept generating into a dead socket until the model finished, burning local model time or API tokens.
2. **Never stopped at quit** — `stopChatServer()` (`ai-chat-server.ts:132`) was reachable only from the `STOP_SERVER` IPC and from `startChatServer` itself. The `before-quit` chain in `main/index.ts` never called it. It also used bare `close()`, so a socket still streaming a generation kept the close pending — the exact stall #1123 fixed for the agent MCP server.
3. **Unbounded request body** — `readBody` (`ai-chat-server.ts:197-204`) concatenated chunks with no cap, unlike `capture/server.ts:36-44`.
4. **Error path orphaned the listening socket** — `ai-chat-server.ts:110-118` nulled the module's `server` on *any* `'error'`, including post-listen. `stopChatServer()` then saw `!server` and resolved without closing, leaving the port bound for the rest of the process lifetime.

## What changed

`apps/desktop/src/main/ai-inline/ai-chat-server.ts`
- Per-request `AbortController` passed to `streamText` as `abortSignal`, aborted from `res.on('close')` guarded by `res.writableFinished` (that guard matters — `'close'` also fires on a normal finish, so an unguarded abort would fire on every successful generation).
- `MAX_BODY_BYTES = 25 * 1024 * 1024`, matching `capture/server.ts` rather than inventing a new number. Rejects on a declared `Content-Length` **before buffering a single byte**, and destroys the request when a chunked/under-declared body grows past the cap. Oversized requests get `413` + `{ error: 'Request body too large' }` instead of a generic 500.
- `stopChatServer()` calls `closeAllConnections?.()` before `close()`, same as `stopCaptureServer`.
- The lifetime `'error'` handler only clears module state when `!nextServer.listening`, so a bound server stays closable.

`apps/desktop/src/main/index.ts`
- `stopChatServer()` added to the `before-quit` chain, immediately after `stopCaptureServer()`.

No contract, IPC, settings-shape or on-disk-format changes — nothing for existing installs to migrate.

## How it was verified

Six tests in `ai-chat-server.test.ts` were confirmed red against the pre-fix source and green after (stashed the source file, kept the tests, re-ran):

```
 × aborts the provider request when the client disconnects mid-stream 31005ms
 × stops while a response is still streaming so quit cannot hang 30001ms
 × rejects a body whose declared length exceeds the cap without reading it 60002ms
 × drops a chunked body that grows past the cap instead of buffering it 25ms
 × keeps a listening server closable after a post-listen error 1ms
 × streams valid chat requests through the model and returns 404 for other paths 9ms
      Tests  6 failed | 4 passed (10)
```

After the fix:

```
      Tests  10 passed (10)
   Duration  372ms
```

The oversized-body tests deliberately drive raw `http.request` rather than `fetch`: the declared-length case sends a 26 MB `Content-Length` and never writes the body, and the chunked case streams **valid** JSON past the cap — an earlier draft used invalid JSON and passed trivially against the broken source, which would have been a false-confidence test.

Other gates:

```
pnpm --filter @memry/desktop typecheck:node      # clean
pnpm exec eslint <changed files>                 # 0 errors
pnpm exec vitest ... zero-runtime-effects.test.ts index.phase2.test.ts ai-inline-handlers.test.ts
      Test Files  3 passed (3)
      Tests  70 passed (70)
git diff --check                                 # clean
pnpm docs:impact --base origin/main --strict     # covered
pnpm docs:build                                  # build complete in 3.79s
```

The one remaining eslint warning on the file (`no-floating-promises` on `result.pipeUIMessageStreamToResponse(res)`) is pre-existing — it reports at `:186` on `origin/main` and `:215` here, only shifted by the added lines.

Part of epic #987.

Closes #1066

