### PR TITLE
perf(voice): stop double-buffering and retaining the decode when preparing a voice memo

### DIFF
--- a/apps/desktop/src/renderer/src/lib/voice-memo-audio.test.ts
+++ b/apps/desktop/src/renderer/src/lib/voice-memo-audio.test.ts
@@ -26,10 +26,65 @@ function readAscii(buffer: ArrayBuffer, offset: number, length: number): string 
   return String.fromCharCode(...bytes)
 }
 
-function makeBlob(): Blob {
+function makeBlob(bytes: ArrayBuffer = new ArrayBuffer(8)): Blob {
   return {
-    arrayBuffer: vi.fn(async () => new ArrayBuffer(8))
+    arrayBuffer: vi.fn(async () => bytes)
   } as unknown as Blob
+}
+
+/**
+ * Byte-for-byte copy of the pcm16 WAV encoder as it stood before the allocation fix,
+ * kept as an oracle so the stored audio format can never drift.
+ */
+function encodePcm16WavReference(audioBuffer: AudioBuffer): ArrayBuffer {
+  const channelData = audioBuffer.getChannelData(0)
+  const frameCount = channelData.length
+  const dataSize = frameCount * 2
+  const buffer = new ArrayBuffer(44 + dataSize)
+  const view = new DataView(buffer)
+
+  const writeString = (offset: number, value: string): void => {
+    for (let index = 0; index < value.length; index += 1) {
+      view.setUint8(offset + index, value.charCodeAt(index))
+    }
+  }
+
+  writeString(0, 'RIFF')
+  view.setUint32(4, 36 + dataSize, true)
+  writeString(8, 'WAVE')
+  writeString(12, 'fmt ')
+  view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true)
+  view.setUint16(22, 1, true)
+  view.setUint32(24, audioBuffer.sampleRate, true)
+  view.setUint32(28, audioBuffer.sampleRate * 2, true)
+  view.setUint16(32, 2, true)
+  view.setUint16(34, 16, true)
+  writeString(36, 'data')
+  view.setUint32(40, dataSize, true)
+
+  let offset = 44
+  for (let index = 0; index < frameCount; index += 1) {
+    const sample = Math.max(-1, Math.min(1, channelData[index] ?? 0))
+    view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true)
+    offset += 2
+  }
+
+  return buffer
+}
+
+/** Deterministic signal covering silence, both polarities, and out-of-range clipping. */
+function makeRepresentativeSamples(count: number): number[] {
+  const samples: number[] = []
+  for (let index = 0; index < count; index += 1) {
+    samples.push(Math.sin(index / 7) * (1.4 - (index % 100) / 100))
+  }
+  samples[0] = 0
+  samples[1] = -1
+  samples[2] = 1
+  samples[3] = -3
+  samples[4] = 3
+  return samples
 }
 
 describe('prepareVoiceMemoAudio', () => {
@@ -90,9 +145,14 @@ describe('prepareVoiceMemoAudio', () => {
     const source = {
       buffer: null as AudioBuffer | null,
       connect: vi.fn(),
+      disconnect: vi.fn(),
       start: vi.fn()
     }
-    const startRendering = vi.fn(async () => rendered)
+    let bufferAtRender: AudioBuffer | null = null
+    const startRendering = vi.fn(async () => {
+      bufferAtRender = source.buffer
+      return rendered
+    })
     const createBufferSource = vi.fn(() => source)
     const AudioContextMock = vi.fn(function AudioContext(this: any) {
       this.decodeAudioData = vi.fn(async () => decoded)
@@ -119,12 +179,137 @@ describe('prepareVoiceMemoAudio', () => {
     const view = new DataView(result.data)
 
     expect(OfflineAudioContextMock).toHaveBeenCalledWith(1, 8000, 16_000)
-    expect(source.buffer).toBe(decoded)
+    expect(bufferAtRender).toBe(decoded)
     expect(source.connect).toHaveBeenCalledTimes(1)
     expect(source.start).toHaveBeenCalledWith(0)
     expect(startRendering).toHaveBeenCalledTimes(1)
     expect(result.duration).toBe(0.5)
     expect(view.getUint32(24, true)).toBe(16_000)
     expect(view.getUint32(40, true)).toBe(4)
+    expect(source.disconnect).toHaveBeenCalledTimes(1)
+    expect(source.buffer).toBeNull()
+  })
+
+  it('decodes the blob buffer in place instead of copying the encoded bytes', async () => {
+    const encodedBytes = new ArrayBuffer(64)
+    const slice = vi.spyOn(encodedBytes, 'slice')
+    const decoded = makeAudioBuffer({
+      sampleRate: 16_000,
+      numberOfChannels: 1,
+      duration: 0.1,
+      samples: [0.5]
+    })
+    const decodeAudioData = vi.fn(async () => decoded)
+    const AudioContextMock = vi.fn(function AudioContext(this: any) {
+      this.decodeAudioData = decodeAudioData
+      this.close = vi.fn()
+    })
+
+    vi.stubGlobal('AudioContext', AudioContextMock)
+    vi.stubGlobal('OfflineAudioContext', vi.fn())
+
+    await prepareVoiceMemoAudio(makeBlob(encodedBytes))
+
+    expect(decodeAudioData).toHaveBeenCalledWith(encodedBytes)
+    expect(slice).not.toHaveBeenCalled()
+  })
+
+  it('releases the decoded buffer from the render graph before encoding the wav', async () => {
+    const decoded = makeAudioBuffer({
+      sampleRate: 48_000,
+      numberOfChannels: 2,
+      duration: 0.5,
+      samples: [0.25]
+    })
+    const rendered = makeAudioBuffer({
+      sampleRate: 16_000,
+      numberOfChannels: 1,
+      duration: 0.5,
+      samples: [0.25, -0.25]
+    })
+    const source = {
+      buffer: null as AudioBuffer | null,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      start: vi.fn()
+    }
+    const AudioContextMock = vi.fn(function AudioContext(this: any) {
+      this.decodeAudioData = vi.fn(async () => decoded)
+      this.close = vi.fn()
+    })
+    const OfflineAudioContextMock = vi.fn(function OfflineAudioContext(this: any) {
+      this.destination = {}
+      this.createBufferSource = vi.fn(() => source)
+      this.startRendering = vi.fn(async () => rendered)
+    })
+
+    vi.stubGlobal('AudioContext', AudioContextMock)
+    vi.stubGlobal('OfflineAudioContext', OfflineAudioContextMock)
+
+    await prepareVoiceMemoAudio(makeBlob())
+
+    const releasedAt = (source.disconnect.mock.invocationCallOrder[0] ?? Infinity) as number
+    const encodedAt = ((rendered.getChannelData as unknown as ReturnType<typeof vi.fn>).mock
+      .invocationCallOrder[0] ?? -Infinity) as number
+
+    expect(source.buffer).toBeNull()
+    expect(releasedAt).toBeLessThan(encodedAt)
+  })
+
+  it('releases the decoded buffer when rendering fails', async () => {
+    const decoded = makeAudioBuffer({
+      sampleRate: 48_000,
+      numberOfChannels: 2,
+      duration: 0.5,
+      samples: [0.25]
+    })
+    const source = {
+      buffer: null as AudioBuffer | null,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      start: vi.fn()
+    }
+    const AudioContextMock = vi.fn(function AudioContext(this: any) {
+      this.decodeAudioData = vi.fn(async () => decoded)
+      this.close = vi.fn()
+    })
+    const OfflineAudioContextMock = vi.fn(function OfflineAudioContext(this: any) {
+      this.destination = {}
+      this.createBufferSource = vi.fn(() => source)
+      this.startRendering = vi.fn(async () => {
+        throw new Error('render failed')
+      })
+    })
+
+    vi.stubGlobal('AudioContext', AudioContextMock)
+    vi.stubGlobal('OfflineAudioContext', OfflineAudioContextMock)
+
+    await expect(prepareVoiceMemoAudio(makeBlob())).rejects.toThrow('render failed')
+
+    expect(source.disconnect).toHaveBeenCalledTimes(1)
+    expect(source.buffer).toBeNull()
+  })
+
+  it('produces bytes identical to the previous encoder for a representative memo', async () => {
+    const samples = makeRepresentativeSamples(5_000)
+    const decoded = makeAudioBuffer({
+      sampleRate: 16_000,
+      numberOfChannels: 1,
+      duration: samples.length / 16_000,
+      samples
+    })
+    const AudioContextMock = vi.fn(function AudioContext(this: any) {
+      this.decodeAudioData = vi.fn(async () => decoded)
+      this.close = vi.fn()
+    })
+
+    vi.stubGlobal('AudioContext', AudioContextMock)
+    vi.stubGlobal('OfflineAudioContext', vi.fn())
+
+    const result = await prepareVoiceMemoAudio(makeBlob())
+    const expected = encodePcm16WavReference(decoded)
+
+    expect(result.data.byteLength).toBe(44 + samples.length * 2)
+    expect(new Uint8Array(result.data)).toEqual(new Uint8Array(expected))
   })
 })

--- a/apps/desktop/src/renderer/src/lib/voice-memo-audio.ts
+++ b/apps/desktop/src/renderer/src/lib/voice-memo-audio.ts
@@ -30,11 +30,13 @@ function computeWaveform(audioBuffer: AudioBuffer, buckets: number): number[] {
 }
 
 async function decodeAudioBlob(blob: Blob): Promise<AudioBuffer> {
+  // `blob.arrayBuffer()` hands back a buffer nobody else holds, so `decodeAudioData`
+  // may detach it directly. Copying it first only doubled the encoded bytes in memory.
   const arrayBuffer = await blob.arrayBuffer()
   const audioContext = new AudioContext()
 
   try {
-    return await audioContext.decodeAudioData(arrayBuffer.slice(0))
+    return await audioContext.decodeAudioData(arrayBuffer)
   } finally {
     void audioContext.close()
   }
@@ -51,7 +53,15 @@ async function renderMonoWavAudio(audioBuffer: AudioBuffer): Promise<AudioBuffer
   source.buffer = audioBuffer
   source.connect(offlineContext.destination)
   source.start(0)
-  return offlineContext.startRendering()
+
+  try {
+    return await offlineContext.startRendering()
+  } finally {
+    // Rendering is done, so drop the graph's hold on the full-rate decode (~100 MB for a
+    // 5-minute stereo memo) before the caller allocates the WAV buffer.
+    source.disconnect()
+    source.buffer = null
+  }
 }
 
 function encodePcm16Wav(audioBuffer: AudioBuffer): ArrayBuffer {
@@ -92,8 +102,9 @@ function encodePcm16Wav(audioBuffer: AudioBuffer): ArrayBuffer {
 }
 
 export async function prepareVoiceMemoAudio(blob: Blob): Promise<PreparedVoiceMemo> {
-  const decoded = await decodeAudioBlob(blob)
-  const rendered = await renderMonoWavAudio(decoded)
+  // Deliberately not kept in a local: holding the decode would keep the full-rate buffer
+  // reachable through the WAV encode and the waveform pass that follow.
+  const rendered = await renderMonoWavAudio(await decodeAudioBlob(blob))
 
   return {
     data: encodePcm16Wav(rendered),

--- a/apps/docs/src/user-guide/inbox/capturing.md
+++ b/apps/docs/src/user-guide/inbox/capturing.md
@@ -62,6 +62,11 @@ seconds before the 5-minute limit. Keyboard shortcuts work too: **Esc** cancels 
 The recording's waveform is captured alongside the audio, so the detail panel shows the real
 waveform instantly when you open a voice item.
 
+Every recording is stored as a mono 16 kHz PCM WAV file, which is what the transcription models
+expect. Preparing that file releases the decoded audio as soon as each stage is done, so saving a
+full 5-minute memo no longer holds the whole recording in memory several times over. The stored
+format is unchanged, so voice items recorded by earlier versions still play.
+
 If voice transcription is enabled, memrynote transcribes the audio in the background — see [Voice Transcription](/user-guide/ai/voice-transcription).
 
 If voice transcription setup is incomplete, memrynote takes you to AI settings before recording. If


### PR DESCRIPTION
Closes #1070. Part of epic #987 (Memory & CPU full-app performance audit 2026-08).

## Verification (issue is real on current `main`)

`apps/desktop/src/renderer/src/lib/voice-memo-audio.ts` @ `21d1dae9b` — unchanged since #724, no later fix:

- `:33-37` — `blob.arrayBuffer()` then `decodeAudioData(arrayBuffer.slice(0))`. The `slice(0)` is a defensive copy against `decodeAudioData` detaching its input, but `blob.arrayBuffer()` returns a freshly allocated buffer that nothing else holds, so the copy only duplicates the encoded bytes.
- `:49-54` — `source.buffer = audioBuffer` keeps the full-rate decode (≈115 MB of float32 for a 300 s stereo 48 kHz memo) reachable through the render graph, and nothing ever drops that reference.
- `:95-96,99-102` — `const decoded` stays a live local while `encodePcm16Wav` allocates the 9.6 MB WAV buffer and `computeWaveform` walks the rendered buffer, so decode (≈115 MB) + render (≈19 MB) + WAV (≈9.6 MB) are all reachable simultaneously.

Not overlapping #1130 (merged, cancelled-recording discard) — that lives in `hooks/use-voice-capture.ts` and is untouched here; it now prevents this pipeline from running at all for a cancelled recording, which is complementary.

## Change

`apps/desktop/src/renderer/src/lib/voice-memo-audio.ts`, +14/−4:

- `decodeAudioBlob` passes the blob's own `ArrayBuffer` to `decodeAudioData` instead of `arrayBuffer.slice(0)`. Ownership is exclusive, so letting the decoder detach it in place is safe and removes one full copy of the encoded bytes.
- `renderMonoWavAudio` wraps `startRendering()` in `try/finally` and, once rendering has resolved, calls `source.disconnect()` and sets `source.buffer = null`. Rendering is complete before `finally` runs, so the produced `AudioBuffer` cannot be affected; assigning `null` to `AudioBufferSourceNode.buffer` is explicitly allowed (the "buffer already set" `InvalidStateError` guard only applies to non-null assignments), and argument-less `disconnect()` never throws.
- `prepareVoiceMemoAudio` no longer parks the decode in a named local across the encode and waveform passes.

The mono-16 kHz passthrough branch is untouched, so the decode is still returned as-is when no resampling is needed.

**No change to the audio itself.** `encodePcm16Wav` and `computeWaveform` are byte-for-byte untouched, and no work moved off or onto the main thread — the main-thread cost drops by exactly the removed `slice(0)` memcpy. Backward compatible: the stored format is identical, so existing voice memos in vaults are unaffected.

## Tests

`apps/desktop/src/renderer/src/lib/voice-memo-audio.test.ts` — 4 new tests plus a byte-identity oracle, using the file's existing global-stub mocking approach (jsdom has no real `AudioContext`):

1. `decodeAudioData` receives the exact `ArrayBuffer` the blob returned, and `slice` is never called on it
2. `source.buffer` is null and `disconnect()` has run **before** the rendered buffer's `getChannelData` is first read (asserted via `mock.invocationCallOrder`, i.e. released before the WAV encode allocates)
3. the release still happens when `startRendering()` rejects, and the rejection still propagates
4. byte identity: a 5 000-sample representative signal (silence, both polarities, clipping above ±1) encoded through `prepareVoiceMemoAudio` equals the output of an inlined copy of the pre-fix encoder, byte for byte

The existing "renders non-target audio through OfflineAudioContext" test now records `source.buffer` at render time (it is deliberately null afterwards) and asserts the release.

Red → green:

```
# before the fix
 × renders non-target audio through OfflineAudioContext before encoding
   → expected "vi.fn()" to be called 1 times, but got 0 times
 × decodes the blob buffer in place instead of copying the encoded bytes
   → expected "slice" to not be called at all, but actually been called 1 times
 × releases the decoded buffer from the render graph before encoding the wav
   → expected { sampleRate: 48000, …(3) } to be null
 × releases the decoded buffer when rendering fails
   → expected "vi.fn()" to be called 1 times, but got 0 times
 ✓ produces bytes identical to the previous encoder for a representative memo
 Tests  4 failed | 2 passed (6)

# after the fix
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

The byte-identity test passing in **both** runs is the proof that the output bytes are unchanged.

## Checks

- `vitest --project renderer` across every voice surface (`voice-memo-audio`, `use-voice-capture`, `voice-recorder`, `capture-input`, `quick-capture`, `agent-chat/composer`) — `Test Files 6 passed (6)`, `Tests 65 passed (65)`
- `pnpm --filter @memry/desktop typecheck:web` — clean
- `pnpm exec eslint apps/desktop/src/renderer/src/lib/voice-memo-audio.ts` — `0 errors`
- `git diff --check` — clean
- `pnpm docs:impact --base origin/main --strict` — `covered`; `pnpm docs:build` — `build complete`
