### PR TITLE
perf(snooze): share one minute tick across all snooze countdowns

### DIFF
--- a/apps/desktop/src/renderer/src/components/snooze/use-snooze-countdown.test.tsx
+++ b/apps/desktop/src/renderer/src/components/snooze/use-snooze-countdown.test.tsx
@@ -1,0 +1,107 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSnoozeCountdown } from './use-snooze-countdown'
+
+function Row({ until }: { until: Date | string | null }): React.JSX.Element {
+  const countdown = useSnoozeCountdown(until)
+  return <span data-testid="row">{countdown ?? 'none'}</span>
+}
+
+function Rows({ count, until }: { count: number; until: Date | string | null }): React.JSX.Element {
+  return (
+    <>
+      {Array.from({ length: count }, (_, i) => (
+        <Row key={i} until={until} />
+      ))}
+    </>
+  )
+}
+
+let setIntervalSpy: ReturnType<typeof vi.spyOn>
+let clearIntervalSpy: ReturnType<typeof vi.spyOn>
+let addListenerSpy: ReturnType<typeof vi.spyOn>
+let removeListenerSpy: ReturnType<typeof vi.spyOn>
+
+/** Only the minute tick registers a 60s interval; ignore anything React schedules. */
+const minuteIntervals = (): number =>
+  setIntervalSpy.mock.calls.filter((call) => call[1] === 60000).length
+
+const visibilityListeners = (spy: typeof addListenerSpy): number =>
+  spy.mock.calls.filter((call) => call[0] === 'visibilitychange').length
+
+describe('useSnoozeCountdown shared tick', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-10T09:00:00.000Z'))
+    setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    addListenerSpy = vi.spyOn(document, 'addEventListener')
+    removeListenerSpy = vi.spyOn(document, 'removeEventListener')
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('creates one interval and one visibilitychange listener for many rows', () => {
+    render(<Rows count={50} until="2026-05-10T10:00:00.000Z" />)
+
+    expect(screen.getAllByTestId('row')).toHaveLength(50)
+    expect(minuteIntervals()).toBe(1)
+    expect(visibilityListeners(addListenerSpy)).toBe(1)
+  })
+
+  it('keeps the shared tick alive until the last row unmounts', () => {
+    const { rerender, unmount } = render(<Rows count={3} until="2026-05-10T10:00:00.000Z" />)
+
+    rerender(<Rows count={1} until="2026-05-10T10:00:00.000Z" />)
+    expect(clearIntervalSpy).not.toHaveBeenCalled()
+    expect(visibilityListeners(removeListenerSpy)).toBe(0)
+
+    unmount()
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+    expect(visibilityListeners(removeListenerSpy)).toBe(1)
+
+    // A later row starts a fresh tick rather than reusing a dead one.
+    render(<Rows count={1} until="2026-05-10T10:00:00.000Z" />)
+    expect(minuteIntervals()).toBe(2)
+  })
+
+  it('never starts the clock for rows without a snooze', () => {
+    render(<Rows count={5} until={null} />)
+
+    expect(screen.getAllByTestId('row')[0]).toHaveTextContent('none')
+    expect(minuteIntervals()).toBe(0)
+    expect(visibilityListeners(addListenerSpy)).toBe(0)
+  })
+
+  it('updates every row on each shared minute tick', () => {
+    render(<Rows count={3} until="2026-05-10T10:00:00.000Z" />)
+    for (const row of screen.getAllByTestId('row')) {
+      expect(row).toHaveTextContent('1h left')
+    }
+
+    act(() => {
+      vi.advanceTimersByTime(60000)
+    })
+    for (const row of screen.getAllByTestId('row')) {
+      expect(row).toHaveTextContent('59m left')
+    }
+  })
+
+  it('refreshes rows when the app returns to the foreground', () => {
+    render(<Rows count={2} until="2026-05-10T10:00:00.000Z" />)
+    expect(screen.getAllByTestId('row')[0]).toHaveTextContent('1h left')
+
+    // Background throttling: the clock moved on without the interval firing.
+    act(() => {
+      vi.setSystemTime(new Date('2026-05-10T09:30:00.000Z'))
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    for (const row of screen.getAllByTestId('row')) {
+      expect(row).toHaveTextContent('30m left')
+    }
+  })
+})

--- a/apps/desktop/src/renderer/src/components/snooze/use-snooze-countdown.ts
+++ b/apps/desktop/src/renderer/src/components/snooze/use-snooze-countdown.ts
@@ -7,8 +7,59 @@
  * @module components/snooze/use-snooze-countdown
  */
 
-import { useState, useEffect, useCallback } from 'react'
+import { useSyncExternalStore } from 'react'
 import { formatSnoozeReturn } from './snooze-presets'
+
+/**
+ * The minute tick, shared by every mounted countdown.
+ *
+ * One `setInterval` and one `visibilitychange` listener serve all rows instead
+ * of one pair per row — an inbox with 200 snoozed items used to hold 200 timers
+ * and 200 document listeners, each firing its own re-render. Both are torn down
+ * as soon as the last subscriber unsubscribes.
+ *
+ * The snapshot is a version counter rather than the wall clock so that a
+ * `visibilitychange` still forces a re-render even when it lands inside the same
+ * minute — matching the pre-shared-tick behaviour exactly.
+ */
+const listeners = new Set<() => void>()
+let timer: ReturnType<typeof setInterval> | null = null
+let version = 0
+
+function notify(): void {
+  version += 1
+  for (const listener of listeners) listener()
+}
+
+function handleVisibilityChange(): void {
+  // Timers are throttled while the app is backgrounded, so refresh on return.
+  if (document.visibilityState === 'visible') {
+    notify()
+  }
+}
+
+function subscribe(onChange: () => void): () => void {
+  listeners.add(onChange)
+  if (timer === null) {
+    timer = setInterval(notify, 60000)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+  }
+  return (): void => {
+    listeners.delete(onChange)
+    if (listeners.size === 0 && timer !== null) {
+      clearInterval(timer)
+      timer = null
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }
+}
+
+/** Rows without a snooze need no clock at all, so they never join the tick. */
+function subscribeIdle(): () => void {
+  return (): void => {}
+}
+
+const getVersion = (): number => version
 
 /**
  * Hook that returns a live-updating snooze countdown string.
@@ -18,37 +69,9 @@ import { formatSnoozeReturn } from './snooze-presets'
  * @returns Formatted countdown string like "4h left", "1d left"
  */
 export function useSnoozeCountdown(snoozedUntil: Date | string | null): string | null {
-  const getFormattedTime = useCallback(() => {
-    if (!snoozedUntil) return null
-    const date = snoozedUntil instanceof Date ? snoozedUntil : new Date(snoozedUntil)
-    return formatSnoozeReturn(date)
-  }, [snoozedUntil])
+  useSyncExternalStore(snoozedUntil ? subscribe : subscribeIdle, getVersion, getVersion)
 
-  const [tick, setTick] = useState(0)
-
-  useEffect(() => {
-    if (!snoozedUntil) return
-
-    // Set up interval to update every minute (60000ms)
-    const intervalId = setInterval(() => {
-      setTick((current) => current + 1)
-    }, 60000)
-
-    // Also update when window regains focus (in case app was in background)
-    const handleVisibilityChange = (): void => {
-      if (document.visibilityState === 'visible') {
-        setTick((current) => current + 1)
-      }
-    }
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-
-    // Cleanup
-    return (): void => {
-      clearInterval(intervalId)
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
-    }
-  }, [snoozedUntil])
-
-  void tick
-  return getFormattedTime()
+  if (!snoozedUntil) return null
+  const date = snoozedUntil instanceof Date ? snoozedUntil : new Date(snoozedUntil)
+  return formatSnoozeReturn(date)
 }

--- a/apps/docs/src/user-guide/inbox/snooze-archive.md
+++ b/apps/docs/src/user-guide/inbox/snooze-archive.md
@@ -30,6 +30,10 @@ A separate view tab lists currently snoozed items and reminder rows generated fr
 - **Reschedule** — pick a different wake time
 - **Cancel snooze** — also returns to inbox
 
+Every countdown refreshes once a minute off a single shared tick, and again as
+soon as the app returns to the foreground, so a long snoozed list stays accurate
+without one timer per row.
+
 ### When the Wake Fires
 
 When wake fires, the item appears at the top of the active inbox. If memrynote isn't running, the item appears next time the app opens.


### PR DESCRIPTION
Part of epic #987 — Memory & CPU full-app performance audit 2026-08.

## What was wrong

`apps/desktop/src/renderer/src/components/snooze/use-snooze-countdown.ts:29-50` gave **every** `SnoozeCountdown` its own clock:

```ts
const intervalId = setInterval(() => setTick((c) => c + 1), 60000)
document.addEventListener('visibilitychange', handleVisibilityChange)
```

`SnoozeCountdown` renders once per snoozed inbox row, so an inbox with 200 snoozed items held 200 live 60s intervals and 200 `visibilitychange` listeners on `document`, each waking React for an independent single-row re-render. Cleanup was already correct, so this is timer/listener churn rather than a leak — but it scales linearly with row count.

The shared-tick pattern already existed in the codebase at `apps/desktop/src/renderer/src/pages/project/use-relative-time.ts:14-31`.

## What changed

`use-snooze-countdown.ts` now reads a module-level store through `useSyncExternalStore`:

- One `setInterval(60s)` and one `visibilitychange` listener serve every mounted countdown.
- Both are created lazily on the first subscriber and **torn down when the last subscriber unsubscribes** (`listeners.size === 0`), so the shared subscription can never outlive its rows.
- The snapshot is a version counter, not a wall-clock minute bucket, so a foreground return still forces a refresh even when it lands inside the same minute — identical to the old `setTick` behaviour.
- Rows with `snoozedUntil == null` subscribe to a no-op and never start a clock (matching the old `if (!snoozedUntil) return` guard).

No public API change: `useSnoozeCountdown(snoozedUntil)` keeps the same signature and the same output strings from `formatSnoozeReturn`. No contract, schema, or persisted-format change, so nothing to migrate.

## How it was verified

New `use-snooze-countdown.test.tsx` (5 tests). The two consolidation tests fail against the pre-fix file and pass after:

```
× creates one interval and one visibilitychange listener for many rows
   → expected 50 to be 1 // Object.is equality
× keeps the shared tick alive until the last row unmounts
   → expected "clearInterval" to not be called at all, but actually been called 2 times
      Tests  2 failed | 3 passed (5)
```

After the fix:

```
✓ creates one interval and one visibilitychange listener for many rows
✓ keeps the shared tick alive until the last row unmounts
✓ never starts the clock for rows without a snooze
✓ updates every row on each shared minute tick
✓ refreshes rows when the app returns to the foreground
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

The remaining three guard visible correctness: 50 rows → 1 interval + 1 listener; all rows still step `1h left` → `59m left` on the shared tick; a `visibilitychange` after 30 background minutes still repaints every row.

Existing suites touching this hook (`zero-leaf-surfaces.test.tsx`, `more-leaf-surfaces.test.tsx`, `components/snooze/*`) — `Test Files 5 passed (5)`, `Tests 23 passed (23)`.

Also green: `pnpm --filter @memry/desktop typecheck:web`, `pnpm exec eslint` on the changed files, `git diff --check`, `pnpm docs:impact --base origin/main --strict` (`docs impact: covered`), `pnpm docs:build`.

Closes #1071
