### PR TITLE
fix(calendar): roll 'Today' and calendar ranges over at local midnight

### DIFF
--- a/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
@@ -16,6 +16,7 @@ import { DatePickerCalendar } from '@/components/tasks/date-picker-calendar'
 import { JournalDayPanel } from '@/components/journal'
 import { useJournalHeatmap } from '@/hooks/use-journal'
 import { useCalendarRange } from '@/hooks/use-calendar-range'
+import { useToday } from '@/hooks/use-today'
 import {
   useCalendarPreferences,
   resolveDayCellClickBehavior,
@@ -145,9 +146,10 @@ function GlobalDayPanelContent({ width }: { width: number }): React.JSX.Element 
     [selectedDate]
   )
 
+  const today = useToday()
   const selectedDateObj = parseISODate(selectedDate)
   const dayPanelLabel =
-    selectedDate === getTodayString()
+    selectedDate === today
       ? t('date.relative.today')
       : selectedDateObj.toLocaleDateString(i18n.language, { month: 'short', day: 'numeric' })
   const currentYear = selectedDateObj.getFullYear()

--- a/apps/desktop/src/renderer/src/components/home/widgets/calendar-header.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/calendar-header.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { useCalendarRange } from '@/hooks/use-calendar-range'
+import { useToday } from '@/hooks/use-today'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { useTabActions } from '@/contexts/tabs'
 import {
@@ -8,6 +9,7 @@ import {
   todayCalendarRange,
   toCalendarWidgetEvents
 } from '@/lib/home/calendar-widget-events'
+import { parseISODate } from '@/lib/journal-utils'
 import { ArrowRight } from '@/lib/icons/icon-map'
 import { useT } from '@memry/i18n/renderer'
 
@@ -22,7 +24,8 @@ export function CalendarHeaderLabel(): React.JSX.Element {
 
 export function CalendarHeaderCount(): React.JSX.Element | null {
   const { settings } = useGeneralSettings()
-  const range = useMemo(() => todayCalendarRange(new Date()), [])
+  const today = useToday()
+  const range = useMemo(() => todayCalendarRange(parseISODate(today)), [today])
   const { items, isLoading } = useCalendarRange(range)
   if (isLoading) return null
 
@@ -36,7 +39,8 @@ export function CalendarFooter(): React.JSX.Element {
   const { t } = useT('common')
   const { settings } = useGeneralSettings()
   const { openTab } = useTabActions()
-  const range = useMemo(() => todayCalendarRange(new Date()), [])
+  const today = useToday()
+  const range = useMemo(() => todayCalendarRange(parseISODate(today)), [today])
   const { items } = useCalendarRange(range)
   const [nowMs, setNowMs] = useState(() => Date.now())
 

--- a/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget.test.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, cleanup, render } from '@testing-library/react'
+import { CalendarWidget } from './calendar-widget'
+import { CalendarHeaderCount, CalendarFooter } from './calendar-header'
+
+// Every range the components ask for, in order — the assertion target: after midnight the widget
+// must query the new day instead of staying pinned to the range it computed at mount.
+let requestedRanges: Array<{ startAt: string; endAt: string }> = []
+
+vi.mock('@/hooks/use-calendar-range', () => ({
+  useCalendarRange: (input: { startAt: string; endAt: string }) => {
+    requestedRanges.push(input)
+    return { items: [], isLoading: false, error: null }
+  }
+}))
+
+vi.mock('@/hooks/use-general-settings', () => ({
+  useGeneralSettings: () => ({ settings: { clockFormat: '24h' } })
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabActions: () => ({ openTab: vi.fn() })
+}))
+
+function lastRange(): { startAt: string; endAt: string } {
+  return requestedRanges[requestedRanges.length - 1]
+}
+
+describe('calendar widget midnight rollover', () => {
+  beforeEach(() => {
+    requestedRanges = []
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 12, 23, 59, 30, 0))
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('queries the new day after local midnight without a remount', () => {
+    render(<CalendarWidget config={{}} size="M" />)
+    expect(lastRange().startAt).toBe('2026-08-12T00:00:00.000Z')
+    expect(lastRange().endAt).toBe('2026-08-13T00:00:00.000Z')
+
+    act(() => {
+      vi.advanceTimersByTime(30_000)
+    })
+
+    expect(lastRange().startAt).toBe('2026-08-13T00:00:00.000Z')
+    expect(lastRange().endAt).toBe('2026-08-14T00:00:00.000Z')
+  })
+
+  it('keeps the header count on the same day as the widget body after rollover', () => {
+    render(<CalendarHeaderCount />)
+    expect(lastRange().startAt).toBe('2026-08-12T00:00:00.000Z')
+
+    act(() => {
+      vi.advanceTimersByTime(30_000)
+    })
+
+    expect(lastRange().startAt).toBe('2026-08-13T00:00:00.000Z')
+  })
+
+  it('rolls the footer range over too', () => {
+    render(<CalendarFooter />)
+    expect(lastRange().startAt).toBe('2026-08-12T00:00:00.000Z')
+
+    act(() => {
+      vi.advanceTimersByTime(30_000)
+    })
+
+    expect(lastRange().startAt).toBe('2026-08-13T00:00:00.000Z')
+  })
+
+  it('keeps the range stable while the day has not changed', () => {
+    render(<CalendarWidget config={{}} size="M" />)
+    const before = lastRange()
+
+    act(() => {
+      vi.advanceTimersByTime(20_000)
+    })
+
+    expect(lastRange()).toEqual(before)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { useCalendarRange } from '@/hooks/use-calendar-range'
+import { useToday } from '@/hooks/use-today'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { formatTimeOfDay } from '@/lib/time-format'
 import {
@@ -10,6 +11,7 @@ import {
   toCalendarWidgetEvents,
   type CalendarWidgetEvent
 } from '@/lib/home/calendar-widget-events'
+import { parseISODate } from '@/lib/journal-utils'
 import type { WidgetComponentProps } from '@/lib/home/widget-registry'
 import { Skeleton } from '@/components/ui/skeleton'
 import { extractErrorMessage } from '@/lib/ipc-error'
@@ -21,7 +23,8 @@ export function CalendarWidget({ size }: WidgetComponentProps): React.JSX.Elemen
   const { t } = useT('common')
   const { settings } = useGeneralSettings()
   const clockFormat = settings.clockFormat
-  const range = useMemo(() => todayCalendarRange(new Date()), [])
+  const today = useToday()
+  const range = useMemo(() => todayCalendarRange(parseISODate(today)), [today])
   const { items, isLoading, error } = useCalendarRange(range)
   const [nowMs, setNowMs] = useState(() => Date.now())
 

--- a/apps/desktop/src/renderer/src/hooks/use-today.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-today.test.tsx
@@ -1,0 +1,226 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const HOUR_MS = 60 * 60 * 1000
+
+// Vitest workers ignore a runtime `process.env.TZ` assignment, so these tests cannot pin a
+// DST-observing zone. Instead they assert against the runtime's own local-midnight boundaries,
+// which stays meaningful in every zone: a day is 23h/25h long where DST applies and 24h where it
+// does not, and either way the rollover must land on local 00:00.
+function localDayLengthMs(year: number, monthIndex: number, day: number): number {
+  const start = new Date(year, monthIndex, day, 0, 0, 0, 0)
+  const next = new Date(year, monthIndex, day + 1, 0, 0, 0, 0)
+  return next.getTime() - start.getTime()
+}
+
+// The store keeps module-level state (current day, shared timer, listener set), so each test gets
+// a fresh module after the system clock is set.
+async function loadUseToday(): Promise<() => string> {
+  vi.resetModules()
+  const mod = await import('./use-today')
+  return mod.useToday
+}
+
+function makeProbe(useToday: () => string) {
+  return function Probe({ label = 'today' }: { label?: string }): React.JSX.Element {
+    return <span data-testid={label}>{useToday()}</span>
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('useToday', () => {
+  it('rolls over to the new local day at midnight without a remount', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 12, 23, 59, 0, 0))
+    const useToday = await loadUseToday()
+    const Probe = makeProbe(useToday)
+
+    render(<Probe />)
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-12')
+
+    act(() => {
+      vi.advanceTimersByTime(59_999)
+    })
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-12')
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-13')
+  })
+
+  it('re-arms after firing so the following midnight also rolls over', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 12, 23, 59, 59, 0))
+    const useToday = await loadUseToday()
+    const Probe = makeProbe(useToday)
+
+    render(<Probe />)
+
+    act(() => {
+      vi.advanceTimersByTime(1_000)
+    })
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-13')
+
+    act(() => {
+      vi.advanceTimersByTime(24 * HOUR_MS)
+    })
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-14')
+  })
+
+  it('schedules to the next local midnight rather than 24h from mount', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 12, 9, 0, 0, 0))
+    const useToday = await loadUseToday()
+    const Probe = makeProbe(useToday)
+
+    render(<Probe />)
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-12')
+
+    const untilMidnight = new Date(2026, 7, 13, 0, 0, 0, 0).getTime() - Date.now()
+    act(() => {
+      vi.advanceTimersByTime(untilMidnight - 1)
+    })
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-12')
+
+    // A `now + 24h` timer would still be pending here, leaving yesterday on screen until 09:00.
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-13')
+  })
+
+  it.each([
+    { label: 'spring-forward', year: 2026, monthIndex: 2, day: 8, next: '2026-03-09' },
+    { label: 'fall-back', year: 2026, monthIndex: 10, day: 1, next: '2026-11-02' }
+  ])(
+    'lands on local midnight on a $label transition date',
+    async ({ year, monthIndex, day, next }) => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(year, monthIndex, day, 0, 0, 0, 0))
+      const useToday = await loadUseToday()
+      const Probe = makeProbe(useToday)
+
+      render(<Probe />)
+
+      // 23h, 24h or 25h depending on the runtime zone — the timer must follow the calendar, not a
+      // hardcoded day length.
+      const dayLength = localDayLengthMs(year, monthIndex, day)
+      act(() => {
+        vi.advanceTimersByTime(dayLength - 1)
+      })
+      expect(screen.getByTestId('today').textContent).not.toBe(next)
+
+      act(() => {
+        vi.advanceTimersByTime(1)
+      })
+      expect(screen.getByTestId('today').textContent).toBe(next)
+    }
+  )
+
+  it('re-syncs on window focus when the clock jumped past midnight while suspended', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 12, 23, 30, 0, 0))
+    const useToday = await loadUseToday()
+    const Probe = makeProbe(useToday)
+
+    render(<Probe />)
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-12')
+
+    // Sleep/wake and system clock changes move the wall clock without running pending timers.
+    vi.setSystemTime(new Date(2026, 7, 14, 9, 0, 0, 0))
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-12')
+
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+    })
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-14')
+  })
+
+  it('re-syncs when the document becomes visible again', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 12, 23, 30, 0, 0))
+    const useToday = await loadUseToday()
+    const Probe = makeProbe(useToday)
+
+    render(<Probe />)
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-12')
+
+    vi.setSystemTime(new Date(2026, 7, 13, 8, 0, 0, 0))
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(screen.getByTestId('today').textContent).toBe('2026-08-13')
+  })
+
+  it('shares one timer across consumers and rolls them over together', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 12, 23, 59, 59, 0))
+    const useToday = await loadUseToday()
+    const Probe = makeProbe(useToday)
+
+    render(
+      <>
+        <Probe label="a" />
+        <Probe label="b" />
+        <Probe label="c" />
+      </>
+    )
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => {
+      vi.advanceTimersByTime(1_000)
+    })
+    expect(screen.getByTestId('a').textContent).toBe('2026-08-13')
+    expect(screen.getByTestId('b').textContent).toBe('2026-08-13')
+    expect(screen.getByTestId('c').textContent).toBe('2026-08-13')
+  })
+
+  it('clears the timer and its listeners when the last consumer unmounts', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 12, 12, 0, 0, 0))
+    const useToday = await loadUseToday()
+    const Probe = makeProbe(useToday)
+
+    const { unmount } = render(
+      <>
+        <Probe label="a" />
+        <Probe label="b" />
+      </>
+    )
+    expect(vi.getTimerCount()).toBe(1)
+
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+
+    // Listeners are gone too, so a resume event cannot re-arm an orphaned timer.
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('keeps the timer armed while at least one consumer is still mounted', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 12, 23, 59, 59, 0))
+    const useToday = await loadUseToday()
+    const Probe = makeProbe(useToday)
+
+    const first = render(<Probe label="a" />)
+    render(<Probe label="b" />)
+    expect(vi.getTimerCount()).toBe(1)
+
+    first.unmount()
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => {
+      vi.advanceTimersByTime(1_000)
+    })
+    expect(screen.getByTestId('b').textContent).toBe('2026-08-13')
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-today.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-today.ts
@@ -1,0 +1,68 @@
+import { useSyncExternalStore } from 'react'
+import { formatDateToISO, getTodayString } from '@/lib/journal-utils'
+
+/**
+ * Milliseconds from `from` until the next local midnight.
+ *
+ * Derived from calendar fields rather than a fixed 24h offset: on DST transition days the local
+ * day is 23 or 25 hours long, and a "now + 24h" timer would fire an hour early or late twice a
+ * year. Constructing the next local 00:00 lets the platform resolve the real offset.
+ */
+function msUntilNextLocalMidnight(from: Date): number {
+  const next = new Date(from.getFullYear(), from.getMonth(), from.getDate() + 1, 0, 0, 0, 0)
+  return next.getTime() - from.getTime()
+}
+
+// Shared so every consumer rolls over in the same notification: the calendar widget body, its
+// header count, and its footer derive one useCalendarRange query key from this value, and
+// independent per-component timers would briefly disagree and trigger duplicate fetches.
+let currentToday = getTodayString()
+let timer: ReturnType<typeof setTimeout> | undefined
+const listeners = new Set<() => void>()
+
+// Re-reads the wall clock and re-arms. Called on the midnight timer, and again whenever the app
+// resumes (sleep/wake and system clock changes can both delay or skip the timer), so a stale day
+// is corrected on the next resume rather than persisting for the rest of the session.
+function syncToday(): void {
+  if (timer !== undefined) clearTimeout(timer)
+  const now = new Date()
+  const next = formatDateToISO(now)
+  if (next !== currentToday) {
+    currentToday = next
+    for (const listener of listeners) listener()
+  }
+  timer = setTimeout(syncToday, msUntilNextLocalMidnight(now))
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  if (listeners.size === 1) {
+    document.addEventListener('visibilitychange', syncToday)
+    window.addEventListener('focus', syncToday)
+    syncToday()
+  }
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size > 0) return
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      timer = undefined
+    }
+    document.removeEventListener('visibilitychange', syncToday)
+    window.removeEventListener('focus', syncToday)
+  }
+}
+
+function getSnapshot(): string {
+  return currentToday
+}
+
+/**
+ * Today's local date as `YYYY-MM-DD`, re-rendering consumers when the local day rolls over.
+ *
+ * Use instead of a mount-time `getTodayString()` / `new Date()` anywhere the value stays on screen
+ * across midnight, so an app left open all day does not keep showing yesterday.
+ */
+export function useToday(): string {
+  return useSyncExternalStore(subscribe, getSnapshot)
+}

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -41,6 +41,7 @@ import { useNoteTagsQuery, useNoteLinksQuery } from '@/hooks/use-notes-query'
 import { usePropertiesCollapsed } from '@/hooks/use-properties-collapsed'
 import { usePropertySection } from '@/hooks/use-property-section'
 import { useJournalSettings } from '@/hooks/use-journal-settings'
+import { useToday } from '@/hooks/use-today'
 import { useEditorSettings, EDITOR_NORMAL_CONTENT_WIDTH } from '@/hooks/use-editor-settings'
 import { ExportDialog } from '@/components/note/export-dialog'
 import { VersionHistory } from '@/components/note/version-history'
@@ -51,7 +52,6 @@ import {
   createJournalDateLabels,
   formatDateToISO,
   formatDateParts,
-  getTodayString,
   parseISODate,
   addDays,
   getMonthStats,
@@ -116,7 +116,7 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
   const { t: commonT } = useT('common')
   const activeTab = useActiveTab()
   const { openTab } = useTabs()
-  const today = getTodayString()
+  const today = useToday()
   const dateLabels = useMemo(() => createJournalDateLabels(t), [t])
   const tabDate = activeTab?.viewState?.date as string | undefined
 

--- a/apps/docs/src/user-guide/day-panel.md
+++ b/apps/docs/src/user-guide/day-panel.md
@@ -56,6 +56,8 @@ same pointer location.
 
 When the panel is hidden, focus state still tracks (so reopening the panel restores the previously focused date).
 
+The **Today** label follows the real date: in a session left open past midnight it moves to the new day on its own, so yesterday is no longer labelled "Today".
+
 ## Why a Panel and a Calendar Tab?
 
 The Day Panel is the **always-visible** glance — what's today, what's due. The [Calendar tab](/user-guide/calendar) is the focused work surface for planning across days, weeks, and months.

--- a/apps/docs/src/user-guide/home-dashboard.md
+++ b/apps/docs/src/user-guide/home-dashboard.md
@@ -28,6 +28,8 @@ Widgets are the cards on a board. Available types:
 | Calendar        | An at-a-glance calendar of upcoming entries       |
 | Journal         | Today's journal entry and your current streak     |
 
+The Calendar widget shows today's events. If you leave Memry open overnight it rolls over on its own at local midnight — the widget, its event count, and the "Next:" line all switch to the new day without a restart. The same applies after the machine wakes from sleep or the system clock changes.
+
 ### Add a widget
 
 Open the **widget gallery** (the add-widget control on the board) and click a type. The new card drops in at the bottom of the board and the grid compacts it upward. Adding the same type twice is allowed — each is an independent instance with its own configuration.


### PR DESCRIPTION
Closes #1072. Part of epic #987 (Memory & CPU full-app performance audit 2026-08).

## What was wrong

"Today" was captured once and never refreshed, so an app left open past midnight kept showing yesterday.

- `apps/desktop/src/renderer/src/components/home/widgets/calendar-widget.tsx:24` — `useMemo(() => todayCalendarRange(new Date()), [])`. The empty dep array freezes the query range at mount. The widget's 60s interval only refreshed `nowMs` (the "now" line and the "starts in" label), never the range, so after midnight it queried **yesterday** for the rest of the session.
- `apps/desktop/src/renderer/src/components/home/widgets/calendar-header.tsx:25` and `:39` — the same frozen `useMemo` in `CalendarHeaderCount` and `CalendarFooter`. These deliberately share a `useCalendarRange` query key with the widget body, so all three went stale together.
- `apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx:150` — `selectedDate === getTodayString()` computed at render time with nothing to trigger a re-render, so the **Today** label stayed on yesterday.
- `apps/desktop/src/renderer/src/pages/journal.tsx:119` — `const today = getTodayString()`, same render-time capture; feeds `isToday`, the Today button and the editor placeholder.

This is a correctness bug first: the user sees the wrong day.

## What changed

New shared store `apps/desktop/src/renderer/src/hooks/use-today.ts` — `useToday()` on `useSyncExternalStore`, returning the local `YYYY-MM-DD`:

- **One timer for the whole app**, armed for the next local midnight. All consumers roll over in a single notification, so the widget body, header count and footer keep sharing one `useCalendarRange` query key instead of briefly disagreeing and firing duplicate fetches.
- **DST-safe.** The delay is `new Date(y, m, d + 1, 0, 0, 0, 0) - now`, not a fixed 24h offset — a "24 hours from now" timer is wrong twice a year on 23h/25h local days.
- **Resume-safe.** Re-syncs on `focus` and `visibilitychange`, because sleep/wake and system clock changes can delay or skip the timer. A stale day is corrected on the next resume rather than persisting all session.
- **Torn down.** Timer cleared and both listeners removed when the last consumer unmounts.

Consumers now derive from it. `todayCalendarRange` is unchanged and still takes a `Date`; callers pass `parseISODate(today)`, which yields the identical range for the same calendar day — no behavior change for an app opened and closed within one day, so existing installs are unaffected.

## Verification

Both test files were mutation-tested — they fail on the pre-fix code and pass after.

Reverting the two widgets to the frozen `useMemo(..., [])`:

```
 × calendar widget midnight rollover > queries the new day after local midnight without a remount
 × calendar widget midnight rollover > keeps the header count on the same day as the widget body after rollover
 × calendar widget midnight rollover > rolls the footer range over too
      Tests  3 failed | 1 passed (4)
```

Replacing the local-midnight delay with a hardcoded `24 * 60 * 60 * 1000`:

```
 × useToday > rolls over to the new local day at midnight without a remount
 × useToday > re-arms after firing so the following midnight also rolls over
 × useToday > schedules to the next local midnight rather than 24h from mount
 × useToday > shares one timer across consumers and rolls them over together
 × useToday > keeps the timer armed while at least one consumer is still mounted
      Tests  5 failed | 5 passed (10)
```

Green on the branch as committed:

```
 Test Files  1 passed (1)
      Tests  10 passed (10)   # use-today.test.tsx

 Test Files  1 passed (1)
      Tests  4 passed (4)     # calendar-widget.test.tsx
```

Affected renderer surfaces (hooks, home, day-panel, pages, lib/home):

```
 Test Files  159 passed (159)
      Tests  1414 passed (1414)
```

Also run: `pnpm --filter @memry/desktop typecheck:web` (clean), `pnpm exec eslint <changed files>` (0 errors), `git diff --check` (clean), `pnpm docs:impact --base origin/main --strict` → `covered`, `pnpm docs:build` → `build complete`.

Note on the DST tests: vitest workers ignore a runtime `process.env.TZ` assignment, so the transition-day cases assert against the runtime's own local-midnight boundaries (23h/25h where DST applies, 24h where it does not) and are paired with a mount-at-09:00 test that kills a `+24h` implementation in every timezone.
