### PR TITLE
perf(hooks): bind shortcut keydown listeners once instead of per state change

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/missing-hooks.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/missing-hooks.test.tsx
@@ -493,6 +493,59 @@ describe('navigation and keyboard hooks', () => {
     expect(callbacks.onOpenBulkArchiveDialog).toHaveBeenCalled()
   })
 
+  it('keeps one inbox keydown listener across item churn and reads the latest items', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+    const callbacks = {
+      onRefresh: vi.fn(),
+      onArchiveFocusedItem: vi.fn(),
+      onOpenBulkArchiveDialog: vi.fn(),
+      onOpenSourceUrl: vi.fn()
+    }
+    const baseProps = {
+      enabled: true,
+      isDetailPanelOpen: false,
+      isBulkFilePanelOpen: false,
+      isInBulkMode: false,
+      focusedItemId: 'item-1',
+      ...callbacks
+    }
+    const { rerender, unmount } = renderHook((props) => useInboxKeyboard(props), {
+      initialProps: { ...baseProps, items: mocks.inbox.items as never }
+    })
+
+    const keydownAdds = (): unknown[] => addSpy.mock.calls.filter(([type]) => type === 'keydown')
+    const keydownRemoves = (): unknown[] =>
+      removeSpy.mock.calls.filter(([type]) => type === 'keydown')
+
+    expect(keydownAdds()).toHaveLength(1)
+
+    // Every refetch/optimistic update hands the hook a fresh array identity.
+    for (let i = 0; i < 5; i++) {
+      rerender({ ...baseProps, items: [...mocks.inbox.items] as never })
+    }
+
+    expect(keydownAdds()).toHaveLength(1)
+    expect(keydownRemoves()).toHaveLength(0)
+
+    // The single listener must still see the newest items array.
+    rerender({
+      ...baseProps,
+      items: [
+        { id: 'item-1', title: 'First', sourceUrl: 'https://example.com/one' },
+        { id: 'item-9', title: 'Ninth', sourceUrl: 'https://example.com/nine' }
+      ] as never
+    })
+    fireEvent.keyDown(window, { key: 'Delete' })
+    expect(callbacks.onArchiveFocusedItem).toHaveBeenCalledWith('item-1', 'item-9')
+
+    unmount()
+    expect(keydownRemoves()).toHaveLength(1)
+
+    addSpy.mockRestore()
+    removeSpy.mockRestore()
+  })
+
   it('handles search, settings, countdown, and flush lifecycle hooks', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-10T12:00:00.000Z'))

--- a/apps/desktop/src/renderer/src/hooks/use-chord-shortcuts.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-chord-shortcuts.test.tsx
@@ -114,6 +114,41 @@ const renderWithState = (initialState: TabSystemState) => {
   }
 }
 
+type TabsDispatch = ReturnType<typeof useTabs>['dispatch']
+
+interface ControlProps {
+  onState: (s: TabSystemState) => void
+  onDispatch: (d: TabsDispatch) => void
+}
+
+const HookWithControls = ({ onState, onDispatch }: ControlProps): null => {
+  useChordShortcuts()
+  const { state, dispatch } = useTabs()
+  useEffect(() => {
+    onState(state)
+    onDispatch(dispatch)
+  }, [state, dispatch, onState, onDispatch])
+  return null
+}
+
+const renderWithControls = (initialState: TabSystemState) => {
+  let latest: TabSystemState = initialState
+  let dispatch: TabsDispatch = () => {}
+  const { unmount } = renderHook(() => null, {
+    wrapper: ({ children }) => (
+      <TabProvider initialState={initialState}>
+        <HookWithControls onState={(s) => (latest = s)} onDispatch={(d) => (dispatch = d)} />
+        {children}
+      </TabProvider>
+    )
+  })
+  return {
+    unmount,
+    getState: () => latest,
+    dispatch: (action: Parameters<TabsDispatch>[0]) => dispatch(action)
+  }
+}
+
 const dispatchKey = (key: string, opts: { meta?: boolean; shift?: boolean } = {}) => {
   window.dispatchEvent(
     new KeyboardEvent('keydown', {
@@ -311,6 +346,63 @@ describe('useChordShortcuts', () => {
     expect(getState().tabGroups[g3.id].tabs.some((tab) => tab.title === 'Moving backward')).toBe(
       true
     )
+  })
+
+  it('binds the window keydown listener once across tab state changes', () => {
+    // #given a two-group setup with the listener spies installed
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+    const g1 = makeGroup([makeTab()])
+    const g2 = makeGroup([makeTab()], false)
+    const { unmount, dispatch } = renderWithControls(makeState([g1, g2]))
+
+    const keydownAdds = (): unknown[] => addSpy.mock.calls.filter(([type]) => type === 'keydown')
+    const keydownRemoves = (): unknown[] =>
+      removeSpy.mock.calls.filter(([type]) => type === 'keydown')
+
+    expect(keydownAdds()).toHaveLength(1)
+
+    // #when the active group flips back and forth six times
+    for (let i = 0; i < 6; i++) {
+      const groupId = i % 2 === 0 ? g2.id : g1.id
+      act(() => {
+        dispatch({ type: 'SET_ACTIVE_GROUP', payload: { groupId } })
+      })
+    }
+
+    // #then the listener was never detached and reattached
+    expect(keydownAdds()).toHaveLength(1)
+    expect(keydownRemoves()).toHaveLength(0)
+
+    // #and unmount still removes it
+    unmount()
+    expect(keydownRemoves()).toHaveLength(1)
+
+    addSpy.mockRestore()
+    removeSpy.mockRestore()
+  })
+
+  it('completes a chord against the tab state at keypress time', () => {
+    // #given three groups with the second one made active after mount
+    const g1 = makeGroup([makeTab()])
+    const g2 = makeGroup([makeTab()], false)
+    const g3 = makeGroup([makeTab()], false)
+    const { getState, dispatch } = renderWithControls(makeState([g1, g2, g3]))
+
+    act(() => {
+      dispatch({ type: 'SET_ACTIVE_GROUP', payload: { groupId: g2.id } })
+    })
+
+    // #when ⌘K then ArrowRight fires
+    act(() => {
+      dispatchKey('k', { meta: true })
+    })
+    act(() => {
+      dispatchKey('ArrowRight', { meta: true })
+    })
+
+    // #then it advances from the new active group, not the one from first render
+    expect(getState().activeGroupId).toBe(g3.id)
   })
 
   it('ignores typing targets, hint mode, unsupported chords, and timeout expiry', () => {

--- a/apps/desktop/src/renderer/src/hooks/use-chord-shortcuts.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-chord-shortcuts.ts
@@ -3,7 +3,7 @@
  * Handles two-key sequences (e.g., ⌘K ⌘→)
  */
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTabs } from '@/contexts/tabs'
 import { isMac } from './use-keyboard-shortcuts-base'
 import { calculateGroupPositions, type GroupPosition } from './use-pane-navigation'
@@ -240,36 +240,45 @@ export const useChordShortcuts = (): boolean => {
     ]
   )
 
-  // Event listener for chord keys
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (hintModeActiveRef.current) return
+  const handleKeyDown = (e: KeyboardEvent): void => {
+    if (hintModeActiveRef.current) return
 
-      const metaOrCtrl = isMac ? e.metaKey : e.ctrlKey
+    const metaOrCtrl = isMac ? e.metaKey : e.ctrlKey
 
-      // Ignore if typing in input
-      const target = e.target as HTMLElement
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
-        return
-      }
-
-      // Check for chord start (⌘K)
-      if (metaOrCtrl && e.key.toLowerCase() === 'k' && !chord.isActive) {
-        e.preventDefault()
-        startChord('k')
-        return
-      }
-
-      // Check for chord completion
-      if (chord.isActive && (metaOrCtrl || e.shiftKey)) {
-        e.preventDefault()
-        handleChordSecondKey(e.key, e.shiftKey)
-      }
+    // Ignore if typing in input
+    const target = e.target as HTMLElement
+    if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+      return
     }
 
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [chord.isActive, startChord, handleChordSecondKey])
+    // Check for chord start (⌘K)
+    if (metaOrCtrl && e.key.toLowerCase() === 'k' && !chord.isActive) {
+      e.preventDefault()
+      startChord('k')
+      return
+    }
+
+    // Check for chord completion
+    if (chord.isActive && (metaOrCtrl || e.shiftKey)) {
+      e.preventDefault()
+      handleChordSecondKey(e.key, e.shiftKey)
+    }
+  }
+
+  // The handler closes over chord + tab state, both of which change constantly.
+  // Keep the latest one in a ref so the window listener binds once per mount.
+  const handleKeyDownRef = useRef(handleKeyDown)
+  useEffect(() => {
+    handleKeyDownRef.current = handleKeyDown
+  })
+
+  // Event listener for chord keys
+  useEffect(() => {
+    const listener = (e: KeyboardEvent): void => handleKeyDownRef.current(e)
+
+    window.addEventListener('keydown', listener)
+    return () => window.removeEventListener('keydown', listener)
+  }, [])
 
   return chord.isActive
 }

--- a/apps/desktop/src/renderer/src/hooks/use-inbox-keyboard.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-inbox-keyboard.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import type { InboxItemListItem } from '@memry/rpc/inbox'
 import { toast } from 'sonner'
 import { isInputFocused } from '@/hooks/use-keyboard-shortcuts'
@@ -31,64 +31,63 @@ export function useInboxKeyboard(options: UseInboxKeyboardOptions): void {
     onOpenSourceUrl
   } = options
 
+  const handleGlobalKeyDown = (e: KeyboardEvent): void => {
+    if (isDetailPanelOpen || isBulkFilePanelOpen) return
+
+    if (isInputFocused()) return
+
+    if (e.key.toLowerCase() === 'r' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault()
+      onRefresh()
+      toast.success(getI18n().getFixedT(null, 'inbox')('phaseI.toasts.inboxRefreshed'))
+      return
+    }
+
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      if (isInBulkMode) {
+        e.preventDefault()
+        onOpenBulkArchiveDialog()
+        return
+      }
+
+      if (focusedItemId && !isDetailPanelOpen) {
+        e.preventDefault()
+        const focusedItem = items.find((i) => i.id === focusedItemId)
+        if (focusedItem) {
+          const currentIndex = items.findIndex((i) => i.id === focusedItemId)
+          const nextItem = items[currentIndex + 1] || items[currentIndex - 1]
+          onArchiveFocusedItem(focusedItemId, nextItem?.id ?? null)
+        }
+      }
+      return
+    }
+
+    if (e.key.toLowerCase() === 'o' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      if (focusedItemId) {
+        const focusedItem = items.find((i) => i.id === focusedItemId)
+        if (focusedItem?.sourceUrl) {
+          e.preventDefault()
+          onOpenSourceUrl(focusedItem.sourceUrl)
+        }
+      }
+      return
+    }
+  }
+
+  // `items` gets a new identity on every refetch/optimistic update, and the
+  // panel/focus flags change constantly. Read the handler from a ref so the
+  // window listener binds once instead of rebinding on every one of those.
+  const handleGlobalKeyDownRef = useRef(handleGlobalKeyDown)
+  useEffect(() => {
+    handleGlobalKeyDownRef.current = handleGlobalKeyDown
+  })
+
   useEffect(() => {
     if (!enabled) return
 
-    const handleGlobalKeyDown = (e: KeyboardEvent): void => {
-      if (isDetailPanelOpen || isBulkFilePanelOpen) return
+    const listener = (e: KeyboardEvent): void => handleGlobalKeyDownRef.current(e)
 
-      if (isInputFocused()) return
-
-      if (e.key.toLowerCase() === 'r' && !e.metaKey && !e.ctrlKey && !e.altKey) {
-        e.preventDefault()
-        onRefresh()
-        toast.success(getI18n().getFixedT(null, 'inbox')('phaseI.toasts.inboxRefreshed'))
-        return
-      }
-
-      if (e.key === 'Delete' || e.key === 'Backspace') {
-        if (isInBulkMode) {
-          e.preventDefault()
-          onOpenBulkArchiveDialog()
-          return
-        }
-
-        if (focusedItemId && !isDetailPanelOpen) {
-          e.preventDefault()
-          const focusedItem = items.find((i) => i.id === focusedItemId)
-          if (focusedItem) {
-            const currentIndex = items.findIndex((i) => i.id === focusedItemId)
-            const nextItem = items[currentIndex + 1] || items[currentIndex - 1]
-            onArchiveFocusedItem(focusedItemId, nextItem?.id ?? null)
-          }
-        }
-        return
-      }
-
-      if (e.key.toLowerCase() === 'o' && !e.metaKey && !e.ctrlKey && !e.altKey) {
-        if (focusedItemId) {
-          const focusedItem = items.find((i) => i.id === focusedItemId)
-          if (focusedItem?.sourceUrl) {
-            e.preventDefault()
-            onOpenSourceUrl(focusedItem.sourceUrl)
-          }
-        }
-        return
-      }
-    }
-
-    window.addEventListener('keydown', handleGlobalKeyDown)
-    return () => window.removeEventListener('keydown', handleGlobalKeyDown)
-  }, [
-    enabled,
-    isDetailPanelOpen,
-    isBulkFilePanelOpen,
-    isInBulkMode,
-    focusedItemId,
-    items,
-    onRefresh,
-    onArchiveFocusedItem,
-    onOpenBulkArchiveDialog,
-    onOpenSourceUrl
-  ])
+    window.addEventListener('keydown', listener)
+    return () => window.removeEventListener('keydown', listener)
+  }, [enabled])
 }

--- a/apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts-base.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts-base.test.ts
@@ -80,6 +80,83 @@ describe('useKeyboardShortcuts', () => {
 
       expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function), false)
     })
+
+    it('should bind the listener once when callers pass a fresh array every render', () => {
+      const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+      const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+      const action = vi.fn()
+
+      const keydownAdds = (): unknown[] =>
+        addEventListenerSpy.mock.calls.filter(([type]) => type === 'keydown')
+      const keydownRemoves = (): unknown[] =>
+        removeEventListenerSpy.mock.calls.filter(([type]) => type === 'keydown')
+
+      // Callers such as useTabKeyboardShortcuts rebuild the array whenever tab
+      // state changes, so the hook receives a new identity on every render.
+      const { rerender, unmount } = renderHook(
+        ({ description }: { description: string }) =>
+          useKeyboardShortcuts([{ key: 'a', action, description }]),
+        { initialProps: { description: 'render-0' } }
+      )
+
+      expect(keydownAdds()).toHaveLength(1)
+
+      for (let i = 1; i <= 5; i++) {
+        rerender({ description: `render-${i}` })
+      }
+
+      expect(keydownAdds()).toHaveLength(1)
+      expect(keydownRemoves()).toHaveLength(0)
+
+      unmount()
+
+      expect(keydownRemoves()).toHaveLength(1)
+
+      addEventListenerSpy.mockRestore()
+      removeEventListenerSpy.mockRestore()
+    })
+
+    it('should run the newest action after the shortcut array changes', () => {
+      const firstAction = vi.fn()
+      const secondAction = vi.fn()
+
+      const { rerender } = renderHook(
+        ({ action }: { action: () => void }) =>
+          useKeyboardShortcuts([{ key: 'a', action, description: 'Test A' }]),
+        { initialProps: { action: firstAction } }
+      )
+
+      rerender({ action: secondAction })
+
+      act(() => {
+        window.dispatchEvent(createKeyboardEvent('a'))
+      })
+
+      expect(secondAction).toHaveBeenCalledTimes(1)
+      expect(firstAction).not.toHaveBeenCalled()
+    })
+
+    it('should evaluate `when` against the latest render state', () => {
+      const action = vi.fn()
+
+      const { rerender } = renderHook(
+        ({ allowed }: { allowed: boolean }) =>
+          useKeyboardShortcuts([{ key: 'a', action, description: 'Test A', when: () => allowed }]),
+        { initialProps: { allowed: false } }
+      )
+
+      act(() => {
+        window.dispatchEvent(createKeyboardEvent('a'))
+      })
+      expect(action).not.toHaveBeenCalled()
+
+      rerender({ allowed: true })
+
+      act(() => {
+        window.dispatchEvent(createKeyboardEvent('a'))
+      })
+      expect(action).toHaveBeenCalledTimes(1)
+    })
   })
 
   // ==========================================================================

--- a/apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts-base.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts-base.ts
@@ -3,7 +3,7 @@
  * Handles keyboard event binding and shortcut matching
  */
 
-import { useEffect, useCallback, useMemo } from 'react'
+import { useEffect, useRef } from 'react'
 import { hintModeActiveRef } from '@/contexts/hint-mode'
 
 // =============================================================================
@@ -81,11 +81,17 @@ export const useKeyboardShortcuts = (
   options: UseKeyboardShortcutsOptions = {}
 ): void => {
   const { capture = false } = options
-  // Memoize shortcuts to prevent unnecessary re-renders
-  const memoizedShortcuts = useMemo(() => shortcuts, [shortcuts])
+  // Callers rebuild the shortcut array whenever their state changes. Read it
+  // from a ref at keypress time so the window listener binds once per mount
+  // instead of detaching/reattaching on every render.
+  const shortcutsRef = useRef(shortcuts)
 
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
+  useEffect(() => {
+    shortcutsRef.current = shortcuts
+  }, [shortcuts])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
       if (hintModeActiveRef.current) return
 
       const target = e.target as HTMLElement
@@ -94,7 +100,7 @@ export const useKeyboardShortcuts = (
       const isInputField =
         target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable
 
-      for (const shortcut of memoizedShortcuts) {
+      for (const shortcut of shortcutsRef.current) {
         const { key, modifiers = {}, action, when, allowInInput } = shortcut
 
         // Skip if in input and not allowed
@@ -141,14 +147,11 @@ export const useKeyboardShortcuts = (
         action()
         return
       }
-    },
-    [memoizedShortcuts]
-  )
+    }
 
-  useEffect(() => {
     window.addEventListener('keydown', handleKeyDown, capture)
     return () => window.removeEventListener('keydown', handleKeyDown, capture)
-  }, [handleKeyDown, capture])
+  }, [capture])
 }
 
 export default useKeyboardShortcuts

--- a/apps/docs/src/contribute/gotchas.md
+++ b/apps/docs/src/contribute/gotchas.md
@@ -117,6 +117,16 @@ if (
 
 This mirrors `shouldStartMarquee` in `use-block-marquee-selection.ts`. Regression coverage: `tests/e2e/editor-drag-handle-menu.e2e.ts`.
 
+## Global Keydown Listeners Must Not Depend on Render State
+
+`useKeyboardShortcuts` (`hooks/use-keyboard-shortcuts-base.ts`), `useChordShortcuts` and `useInboxKeyboard` each bind exactly one `window` `keydown` listener per mount. The handler reads the shortcut list — and the tab/inbox state it acts on — from a ref refreshed after every render, so it always sees fresh values without re-registering.
+
+Keep it that way when editing these hooks:
+
+- Do not put render-derived values (shortcut arrays, tab state, list items, callbacks) in the registration effect's dependency array. Every tab open/close/switch and every inbox refetch would then detach and reattach the listener.
+- Do not close over that state inside the registered listener either. Read it through the ref, or the shortcut acts on the state from the first render.
+- Callers may keep building a fresh shortcut array on every render; the hook absorbs the churn.
+
 ## Cross-Platform Env Vars in package Scripts
 
 `VAR=value cmd` is POSIX-only. pnpm runs package scripts through cmd on Windows, where `MEMRY_ENV=production pnpm ...` fails with `'MEMRY_ENV' is not recognized`. This broke the Windows release build (`apps/desktop` `build` script). Use `cross-env` for any inline env var that must work on Windows too:


### PR DESCRIPTION
Closes #1074 — part of epic #987 (memory & CPU audit 2026-08).

## Verification — still real on `main`

All three churn sites reproduce on `origin/main` @ `0e272a690`.

1. `apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts-base.ts:85` — `useMemo(() => shortcuts, [shortcuts])` is a no-op (the dep *is* the fresh array), so `handleKeyDown` (`:87`) was a new function every render and the `window` keydown effect (`:148-151`) re-ran each time. `use-tab-keyboard-shortcuts.ts:236` feeds it an array memoized on `state.tabGroups`/`state.activeGroupId`, so every tab open/close/switch rebound the listener. Same for `app-sidebar.tsx:282`, `ui/sidebar.tsx:131`, `use-settings-shortcut.ts:28`.
2. `apps/desktop/src/renderer/src/hooks/use-chord-shortcuts.ts:272` — deps `[chord.isActive, startChord, handleChordSecondKey]`, and `handleChordSecondKey` (`:233-241`) chains through the whole `chord` object plus `state.tabGroups`/`state.activeGroupId`.
3. `apps/desktop/src/renderer/src/hooks/use-inbox-keyboard.ts:82-93` — deps include `items`, whose identity changes on every refetch/optimistic update, plus five other per-render flags.

Measured on `main` with the new tests: 6 tab-group switches produced **7** `addEventListener('keydown', …)` calls for the chord hook, 5 renders produced **6** for the base hook, and 5 inbox refetches produced **6**.

## Change

Same pattern as #1135 (issue #1014): a ref holds the latest value, the listener registers once.

- `use-keyboard-shortcuts-base.ts` — the shortcut array goes into `shortcutsRef`, refreshed by its own effect; the keydown effect now depends only on `capture`, and the matcher loops over `shortcutsRef.current`. Every call site is fixed without touching it, so `use-tab-keyboard-shortcuts.ts` is unchanged.
- `use-chord-shortcuts.ts` — the handler is built per render and stored in `handleKeyDownRef`; the registration effect has an empty dep array and forwards to `handleKeyDownRef.current(e)`.
- `use-inbox-keyboard.ts` — same, with the registration effect keeping `[enabled]` so a disabled inbox still binds nothing at all.

Behaviour preserved exactly: capture-phase flag still threaded through both `addEventListener` and `removeEventListener` (the base hook's existing test still asserts the literal `false` third argument), `preventDefault`/`stopPropagation` untouched, input-field and hint-mode guards untouched, cleanup still removes the listener on unmount.

### No stale closure

Each handler is rebuilt on every render and written to its ref in an effect, so it closes over that render's `state.tabGroups`, `items`, `focusedItemId`, `when`, `action`, etc. A keypress always runs the newest one. Three of the new tests exist specifically to prove this (see below).

No new dependency, no behaviour change for users, no contract/schema/format change — backward compatible by construction.

## Tests

7 new tests, all red before the fix and green after.

Red on `main` (source reverted, tests kept):

```
× use-keyboard-shortcuts-base.test.ts > should bind the listener once when callers pass a fresh array every render
  → expected [ …(6) ] to have a length of 1 but got 6
× use-chord-shortcuts.test.tsx > binds the window keydown listener once across tab state changes
  → expected [ [ 'keydown', …(1) ], …(6) ] to have a length of 1 but got 7
× missing-hooks.test.tsx > keeps one inbox keydown listener across item churn and reads the latest items
  → expected [ [ 'keydown', …(1) ], …(5) ] to have a length of 1 but got 6

Tests  3 failed | 47 passed (50)
```

Green after:

```
Test Files  3 passed (3)
     Tests  50 passed (50)
```

What they cover:

- **Bind-once** — `addEventListener('keydown', …)` called exactly once across 5 array-identity changes (base), 6 tab-group switches (chord), 5 refetches with a fresh `items` array (inbox), with `removeEventListener` at 0 throughout.
- **Unmount** — after `unmount()`, `removeEventListener('keydown', …)` is at exactly 1 in all three, so no listener survives and none leaks.
- **Stale-closure guard** — the base hook runs the *newest* `action` after a rerender and not the old one; it re-evaluates `when` against the latest render's state; the chord hook completes `⌘K →` against the active group set *after* mount (3 groups, active moved to the 2nd, so a stale closure would land on the 2nd instead of the 3rd); the inbox hook archives against the newest `items` array (`onArchiveFocusedItem('item-1', 'item-9')` where `item-9` only exists in the latest array).

## Checks

- `pnpm --filter @memry/desktop typecheck:web` — clean.
- Renderer tests for every consumer of the shared hook (`hooks/`, `components/capture-bar/`, `pages/inbox/`): `Test Files 78 passed (78) · Tests 830 passed (830)`.
- `pnpm exec eslint --no-cache --max-warnings=0` on the three source files — 0 errors, 0 warnings.
- `git diff --check` — clean.
- `pnpm docs:impact --base origin/main --strict` — `covered`; `pnpm docs:build` — `build complete`.
