### PR TITLE
perf(sync): lower the sync emitter listener ceilings from 50 to 10

### DIFF
--- a/apps/desktop/src/main/sync/emitter-budget.test.ts
+++ b/apps/desktop/src/main/sync/emitter-budget.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NetworkMonitor, type NetworkMonitorDeps } from './network'
+import { WebSocketManager } from './websocket'
+import { SyncEngine } from './engine'
+import { createMockDeps, setupTestDb } from '@tests/utils/engine-mocks'
+
+/**
+ * The three sync emitters used to carry `setMaxListeners(50)`, which meant an
+ * accumulating-subscriber bug could reach 49 instances per event before Node
+ * said anything. These tests pin the real steady-state counts so the ceiling
+ * can stay near Node's default of 10 — low enough that a leak warns, high
+ * enough that normal operation never does.
+ */
+const EXPECTED_LISTENER_BUDGET = 10
+
+function createNetworkDeps(): NetworkMonitorDeps {
+  return {
+    getIsOnline: () => true,
+    onResume: () => {},
+    onSuspend: () => {},
+    offResume: () => {},
+    offSuspend: () => {}
+  }
+}
+
+function createWebSocketManager(): WebSocketManager {
+  return new WebSocketManager({
+    getAccessToken: async () => 'token',
+    getAppVersion: () => '1.0.0',
+    isOnline: () => true,
+    serverUrl: 'https://sync.invalid'
+  })
+}
+
+describe('sync emitter listener budgets', () => {
+  const { getDb } = setupTestDb()
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('#given the three sync emitters #when constructed', () => {
+    it('#then each keeps a ceiling low enough to still warn on a leak', () => {
+      const monitor = new NetworkMonitor(0, createNetworkDeps())
+      const ws = createWebSocketManager()
+      const engine = new SyncEngine(createMockDeps(getDb()))
+
+      expect(monitor.getMaxListeners()).toBe(EXPECTED_LISTENER_BUDGET)
+      expect(ws.getMaxListeners()).toBe(EXPECTED_LISTENER_BUDGET)
+      expect(engine.getMaxListeners()).toBe(EXPECTED_LISTENER_BUDGET)
+    })
+  })
+
+  describe('#given a NetworkMonitor #when every real subscriber attaches', () => {
+    it('#then the count stays well inside the budget', () => {
+      const monitor = new NetworkMonitor(0, createNetworkDeps())
+
+      // The three production subscribers: SyncEngine, the sync runtime, and the
+      // attachment UploadQueue. See engine.ts, runtime.ts and upload-queue.ts.
+      monitor.on('status-changed', () => {})
+      monitor.on('status-changed', () => {})
+      monitor.on('status-changed', () => {})
+
+      expect(monitor.listenerCount('status-changed')).toBe(3)
+      expect(monitor.listenerCount('status-changed')).toBeLessThan(monitor.getMaxListeners())
+
+      monitor.stop()
+    })
+  })
+
+  describe('#given a WebSocketManager #when constructed', () => {
+    it('#then only its own error logger is attached', () => {
+      const ws = createWebSocketManager()
+
+      // The engine adds one listener per event name on top of this; nothing
+      // stacks multiple listeners on the same event.
+      expect(ws.listenerCount('error')).toBe(1)
+      expect(ws.eventNames()).toEqual(['error'])
+    })
+  })
+
+  describe('#given an engine #when it runs a full start/stop cycle', () => {
+    it('#then every listener it attached is gone again', async () => {
+      vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
+        items: [],
+        deleted: [],
+        hasMore: false,
+        nextCursor: 0
+      })
+      const deps = createMockDeps(getDb())
+      const engine = new SyncEngine(deps)
+
+      await engine.start()
+
+      // Exactly one listener per event — a second start/stop cycle must not
+      // double these, which is what the lowered ceiling now guards.
+      expect(deps.network.listenerCount('status-changed')).toBe(1)
+      expect(deps.ws.listenerCount('message')).toBe(1)
+      expect(deps.ws.listenerCount('connected')).toBe(1)
+      expect(deps.ws.listenerCount('device_revoked')).toBe(1)
+      expect(deps.ws.listenerCount('certificate_pin_failed')).toBe(1)
+
+      await engine.stop()
+
+      expect(deps.network.listenerCount('status-changed')).toBe(0)
+      expect(deps.ws.listenerCount('message')).toBe(0)
+      expect(deps.ws.listenerCount('connected')).toBe(0)
+      expect(deps.ws.listenerCount('device_revoked')).toBe(0)
+      expect(deps.ws.listenerCount('certificate_pin_failed')).toBe(0)
+    })
+
+    it('#then repeated cycles never accumulate listeners', async () => {
+      vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
+        items: [],
+        deleted: [],
+        hasMore: false,
+        nextCursor: 0
+      })
+      const deps = createMockDeps(getDb())
+
+      // Well past the old ceiling of 50: under the previous budget an engine
+      // that forgot to detach would have hit the warning here and nowhere else.
+      for (let i = 0; i < 6; i++) {
+        const engine = new SyncEngine(deps)
+        await engine.start()
+        await engine.stop()
+      }
+
+      expect(deps.network.listenerCount('status-changed')).toBe(0)
+      expect(deps.ws.listenerCount('message')).toBe(0)
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -35,7 +35,11 @@ import { trackMainEvent } from '../telemetry/track'
 export type { SyncEngineDeps, SyncEngineOptions }
 
 const log = createLogger('SyncEngine')
-const MAX_SYNC_ENGINE_LISTENERS = 50
+// Nothing in the main process subscribes to the engine today — status reaches
+// the renderer through `emitToRenderer`, not through listeners. Keeping the
+// ceiling at Node's default leaves headroom without hiding an accumulating
+// subscriber behind a silent budget. See src/main/sync/emitter-budget.test.ts.
+const MAX_SYNC_ENGINE_LISTENERS = 10
 
 // A sync run legitimately spans many paged requests plus retry backoff, so
 // this sits far above SYNC_REQUEST_TIMEOUT_MS × the retry budget. A lock held

--- a/apps/desktop/src/main/sync/network.ts
+++ b/apps/desktop/src/main/sync/network.ts
@@ -22,7 +22,12 @@ function createElectronDeps(): NetworkMonitorDeps {
 
 const POLL_INTERVAL_MS = 5000
 const DEFAULT_DEBOUNCE_MS = 2000
-const MAX_NETWORK_MONITOR_LISTENERS = 50
+// 'status-changed' is the only event, and it has three steady-state
+// subscribers: the SyncEngine (attached in start(), removed in stop()), the
+// sync runtime, and the attachment UploadQueue. Keeping the ceiling at Node's
+// default leaves headroom without hiding an accumulating subscriber behind a
+// silent budget. See src/main/sync/emitter-budget.test.ts.
+const MAX_NETWORK_MONITOR_LISTENERS = 10
 
 export class NetworkMonitor extends EventEmitter {
   private _online: boolean

--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -43,6 +43,9 @@ const runtimeMocks = vi.hoisted(() => {
     on = vi.fn((event: string, cb: (payload: { online: boolean }) => void) => {
       this.listeners.set(event, cb)
     })
+    removeListener = vi.fn((event: string, cb: (payload: { online: boolean }) => void) => {
+      if (this.listeners.get(event) === cb) this.listeners.delete(event)
+    })
     constructor() {
       NetworkMonitor.instances.push(this)
       this.online = runtimeMocks.networkOnline
@@ -845,6 +848,36 @@ describe('sync runtime', () => {
     expect(runtimeMocks.crdtProvider.destroy).toHaveBeenCalled()
     expect(runtimeMocks.resetCrdtProvider).toHaveBeenCalled()
     expect(runtime.getSyncEngine()).toBeNull()
+  })
+
+  it('detaches its network subscriber on stop so the dead runtime graph is unreachable', async () => {
+    const runtime = await loadRuntime()
+    await runtime.startSyncRuntime()
+
+    const deadNetwork = runtimeMocks.NetworkMonitor.instances[0]
+    const deadQueue = runtimeMocks.CrdtUpdateQueue.instances[0]
+    // The subscriber the runtime installed really does reach this runtime's
+    // CRDT queue — that is what makes leaving it attached a live wire.
+    deadNetwork.listeners.get('status-changed')?.({ online: false })
+    expect(deadQueue.pause).toHaveBeenCalled()
+    deadQueue.pause.mockClear()
+
+    await runtime.stopSyncRuntime({ skipFinalSync: true })
+
+    // The attachment UploadQueue is a module singleton that keeps holding this
+    // NetworkMonitor after the runtime is gone, so an attached subscriber would
+    // keep the dead crdtQueue/crdtProvider graph reachable for the session.
+    expect(deadNetwork.listeners.size).toBe(0)
+  })
+
+  it('detaches its network subscriber when startup fails after the runtime is assembled', async () => {
+    const runtime = await loadRuntime()
+    runtimeMocks.engineStartError = new Error('engine start failed')
+
+    await expect(runtime.startSyncRuntime()).resolves.toBeNull()
+
+    expect(runtimeMocks.NetworkMonitor.instances[0].listeners.size).toBe(0)
+    expect(runtimeMocks.NetworkMonitor.instances[0].stop).toHaveBeenCalled()
   })
 
   it('destroys CRDT provider when stopped without an active runtime', async () => {

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -100,6 +100,13 @@ interface SyncRuntimeState {
   crdtQueue: CrdtUpdateQueue
   snapshotScheduler: CrdtSnapshotScheduler
   workerBridge: SyncWorkerBridge
+  /**
+   * Kept so teardown can detach it. The closure reaches this runtime's
+   * crdtQueue and crdtProvider, and the attachment UploadQueue is a module
+   * singleton that holds the NetworkMonitor past a runtime stop — leaving the
+   * subscriber attached keeps the whole dead graph reachable.
+   */
+  onNetworkStatusChanged: (event: { online: boolean }) => void
 }
 
 function getVerifiedVaultKey(db: DataDb): Promise<Uint8Array> {
@@ -663,14 +670,15 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
       if (!network.online) {
         crdtQueue.pause()
       }
-      network.on('status-changed', ({ online }: { online: boolean }) => {
+      const onNetworkStatusChanged = ({ online }: { online: boolean }): void => {
         if (online) {
           crdtQueue.resume()
           replayPendingCrdtNotes()
         } else {
           crdtQueue.pause()
         }
-      })
+      }
+      network.on('status-changed', onNetworkStatusChanged)
       const ws = new WebSocketManager({
         getAccessToken: () => getValidAccessToken(),
         getAppVersion: () => app.getVersion(),
@@ -778,7 +786,8 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
         engine,
         crdtQueue,
         snapshotScheduler,
-        workerBridge
+        workerBridge,
+        onNetworkStatusChanged
       }
       runtime = pendingRuntime
 
@@ -815,6 +824,10 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
         pendingRuntime.snapshotScheduler.stop()
         pendingRuntime.crdtQueue.stop()
         pendingRuntime.ws.disconnect()
+        pendingRuntime.network.removeListener(
+          'status-changed',
+          pendingRuntime.onNetworkStatusChanged
+        )
         pendingRuntime.network.stop()
         await pendingRuntime.workerBridge.stop().catch(() => {})
         await pendingRuntime.engine.stop().catch(() => {})
@@ -922,6 +935,7 @@ export async function stopSyncRuntime(options?: { skipFinalSync?: boolean }): Pr
     })
   resetCrdtProvider()
   active.ws.disconnect()
+  active.network.removeListener('status-changed', active.onNetworkStatusChanged)
   active.network.stop()
   log.info('Sync runtime stopped')
 }

--- a/apps/desktop/src/main/sync/websocket.ts
+++ b/apps/desktop/src/main/sync/websocket.ts
@@ -15,7 +15,12 @@ const RECONNECT_JITTER_MS = 500
 const PING_INTERVAL_MS = 25_000
 const HTTP_UNAUTHORIZED = 401
 const HTTP_UPGRADE_REQUIRED = 426
-const MAX_WEBSOCKET_MANAGER_LISTENERS = 50
+// Steady state is one listener per event name: the constructor's own 'error'
+// logger, plus the SyncEngine's four ('message', 'connected', 'device_revoked',
+// 'certificate_pin_failed') attached in start() and removed in stop(). Keeping
+// the ceiling at Node's default leaves headroom without hiding an accumulating
+// subscriber behind a silent budget. See src/main/sync/emitter-budget.test.ts.
+const MAX_WEBSOCKET_MANAGER_LISTENERS = 10
 
 const WebSocketMessageSchema = z.object({
   type: z.enum([

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -309,6 +309,31 @@ retryable network error instead of pinning the sync lock forever. If the lock is
 and lets the next pull proceed. Skipped periodic pulls log `Periodic pull skipped` with the
 blocking flags, which is the first thing to look for when a device shows stale data.
 
+## Runtime Emitters and Listener Budgets
+
+Three main-process objects in the sync runtime are `EventEmitter`s: `NetworkMonitor`
+(`status-changed`), `WebSocketManager` (`message`, `connected`, `device_revoked`,
+`certificate_pin_failed`, `error`) and `SyncEngine`.
+
+Their subscriber counts are small and fixed. `NetworkMonitor` has three
+`status-changed` subscribers — the `SyncEngine`, the sync runtime itself and the
+attachment `UploadQueue`. `WebSocketManager` has at most one listener per event
+name. Nothing in the main process subscribes to `SyncEngine`: its status reaches
+the renderer through `emitToRenderer`, not through listeners.
+
+Each one calls `setMaxListeners(10)`, Node's default. That is deliberate: the
+ceiling has to stay close enough to the real count that an accumulating-subscriber
+bug trips `MaxListenersExceededWarning` instead of hiding behind a generous budget.
+`src/main/sync/emitter-budget.test.ts` pins both the budget and the observed
+counts, so raising either needs a test change and an explanation.
+
+Every subscriber is detached on teardown: the engine removes its own in `stop()`,
+and the runtime keeps a reference to its `status-changed` handler so
+`stopSyncRuntime()` can remove it. That last detach matters because the attachment
+`UploadQueue` is a module singleton that keeps holding the `NetworkMonitor` past a
+runtime stop — an attached handler would keep the dead CRDT queue and provider
+reachable for the rest of the session.
+
 ## Manifest Integrity
 
 Desktop periodically compares `/sync/manifest` with local syncable records. Notes and journals are


### PR DESCRIPTION
## What was wrong

Three sync emitters raised their listener ceiling to 50:

- `apps/desktop/src/main/sync/engine.ts:38` — `MAX_SYNC_ENGINE_LISTENERS = 50`
- `apps/desktop/src/main/sync/network.ts:25` — `MAX_NETWORK_MONITOR_LISTENERS = 50`
- `apps/desktop/src/main/sync/websocket.ts:18` — `MAX_WEBSOCKET_MANAGER_LISTENERS = 50`

All three landed together in `179681da1` ("sync: address low-severity review findings") as a blanket defensive bump, not as a workaround for anything that legitimately attaches many listeners. The effect is that an accumulating-subscriber bug can reach 49 instances per event name before Node emits `MaxListenersExceededWarning`.

## Measured steady-state listener counts

Counted from the call sites, then pinned in tests:

| Emitter | Event | Subscribers | Where |
| --- | --- | --- | --- |
| `NetworkMonitor` | `status-changed` | **3** | `engine.ts:185` (removed at `engine.ts:284`), `runtime.ts:666`, `upload-queue.ts:61` (removed in `dispose()`) |
| `WebSocketManager` | `error` | **1** | its own constructor logger (`websocket.ts:64`) |
| `WebSocketManager` | `message` / `connected` / `device_revoked` / `certificate_pin_failed` | **1 each** | `engine.ts:186-189`, all removed at `engine.ts:285-288` |
| `SyncEngine` | — | **0** | nothing in main subscribes; status reaches the renderer via `emitToRenderer` |

Genuinely bounded and low, so the ceiling goes back to Node's default of 10 — enough headroom that normal operation never warns, low enough that a leak does.

## What changed

1. All three constants `50` → `10`, each with a comment naming the real subscribers.
2. The sync runtime's own `status-changed` subscriber (`runtime.ts:666`) was an anonymous arrow with no stored reference. It is now named, stored on `SyncRuntimeState`, and removed in both teardown paths (`stopSyncRuntime()` and the startup-failure cleanup).

Point 2 is worth more than tidiness. The attachment `UploadQueue` is a module singleton in `sync-attachment-handlers.ts` that is never reset, so it keeps holding the first `NetworkMonitor` it saw — past a runtime stop. While that anonymous subscriber stayed attached, its closure kept the stopped runtime's `crdtQueue` and `crdtProvider` reachable for the rest of the process lifetime. Detaching it breaks that chain.

No `MaxListenersExceededWarning` is introduced: the highest observed count is 3 against a ceiling of 10.

## Verification

New `apps/desktop/src/main/sync/emitter-budget.test.ts` (5 tests) pins the budget and the real counts, including a 6× engine start/stop cycle that asserts listeners return to zero. Two new tests in `runtime.test.ts` assert the runtime's subscriber is detached on stop and on startup failure.

Mutation-tested: with the source changes stashed, 3 of the new tests fail —

```
× runtime.test.ts > detaches its network subscriber on stop ...
  → expected 1 to be +0
× runtime.test.ts > detaches its network subscriber when startup fails ...
  → expected 1 to be +0
× emitter-budget.test.ts > #then each keeps a ceiling low enough to still warn on a leak
  → expected 50 to be 10
```

With the fix applied:

```
$ pnpm exec vitest run --config config/vitest.config.ts --project main src/main/sync/
 Test Files  140 passed (140)
      Tests  1764 passed | 1 expected fail | 3 skipped (1768)

$ pnpm --filter @memry/desktop typecheck:node
$ pnpm exec tsc --noEmit -p tsconfig.node.json --composite false   # clean

$ pnpm exec eslint <changed source files>                          # 0 errors
$ git diff --check                                                 # clean
$ pnpm docs:impact --base origin/main --strict                     # docs changed on this branch
$ pnpm docs:build                                                  # build complete
```

## Backward compatibility

Listener budgets are in-process only — no DB, sync protocol, IPC contract or settings surface is touched.

## Follow-up (not fixed here, out of scope)

`uploadQueue` in `apps/desktop/src/main/ipc/sync-attachment-handlers.ts:67` is a lazy module singleton that is never nulled and never `dispose()`d — `unregisterAttachmentHandlers()` leaves it alone. After a sync runtime restart (vault switch, sign-out/in) it stays bound to the *old* `NetworkMonitor`, so a network-restored event never wakes the queue again for the rest of the session. Worth its own issue.

Closes #1075
Part of epic #987
