### PR TITLE
perf(agent-chat): debounce the mention picker's search and calendar queries

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/ref-picker.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/ref-picker.test.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps } from 'react'
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RefPicker } from '../ref-picker'
@@ -8,20 +8,63 @@ import { RefPicker } from '../ref-picker'
 const mockSearchQuery = vi.fn()
 const mockCalendarListEvents = vi.fn()
 
-function renderRefPicker(overrides: Partial<ComponentProps<typeof RefPicker>> = {}) {
-  const props: ComponentProps<typeof RefPicker> = {
-    query: 'star',
+/** Comfortably past the picker's 150 ms search debounce. */
+const SETTLE_MS = 200
+
+function baseProps(query: string): ComponentProps<typeof RefPicker> {
+  return {
+    query,
     selectedIndex: 0,
     anchorRef: { current: document.createElement('div') },
     onItemsChange: vi.fn(),
     onPick: vi.fn(),
     onSelectedIndexChange: vi.fn(),
-    onClose: vi.fn(),
-    ...overrides
+    onClose: vi.fn()
   }
+}
+
+function renderRefPicker(overrides: Partial<ComponentProps<typeof RefPicker>> = {}) {
+  const props: ComponentProps<typeof RefPicker> = { ...baseProps('star'), ...overrides }
 
   render(<RefPicker {...props} />)
   return props
+}
+
+/** Renders the picker and hands back a "type another character" helper. */
+function renderTypeablePicker(query: string) {
+  const props = baseProps(query)
+  const { rerender, unmount } = render(<RefPicker {...props} />)
+  return {
+    props,
+    unmount,
+    retype: (next: string) => rerender(<RefPicker {...props} query={next} />)
+  }
+}
+
+function noteResponse(id: string, title: string) {
+  return {
+    groups: [
+      {
+        type: 'note',
+        totalInGroup: 1,
+        results: [
+          {
+            id,
+            type: 'note',
+            title,
+            snippet: '',
+            score: 1,
+            normalizedScore: 1,
+            matchType: 'title',
+            modifiedAt: '2026-05-10T00:00:00.000Z',
+            metadata: { type: 'note', path: `/${title}`, tags: [], emoji: null }
+          }
+        ]
+      }
+    ],
+    totalCount: 1,
+    queryTimeMs: 1
+  }
 }
 
 describe('RefPicker', () => {
@@ -273,5 +316,114 @@ describe('RefPicker', () => {
         icon: { kind: 'calendar_event' }
       }
     ])
+  })
+
+  it('debounces mention searches so a burst of keystrokes costs one round-trip', async () => {
+    vi.useFakeTimers()
+    try {
+      const { retype } = renderTypeablePicker('s')
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(SETTLE_MS)
+      })
+
+      mockSearchQuery.mockClear()
+      mockCalendarListEvents.mockClear()
+
+      const keystrokes = ['st', 'sta', 'star', 'starw', 'starwa', 'starwar', 'starwars']
+      for (const query of keystrokes) {
+        retype(query)
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(20)
+        })
+      }
+
+      // Undebounced these 7 keystrokes cost 7 FTS queries + 7 calendar queries.
+      expect(mockSearchQuery).not.toHaveBeenCalled()
+      expect(mockCalendarListEvents).not.toHaveBeenCalled()
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(SETTLE_MS)
+      })
+
+      expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+      expect(mockCalendarListEvents).toHaveBeenCalledTimes(1)
+      expect(mockSearchQuery).toHaveBeenCalledWith({ text: 'starwars', limit: 20 })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps the newest query and discards a stale search that resolves late', async () => {
+    vi.useFakeTimers()
+    try {
+      const resolvers = new Map<string, (value: unknown) => void>()
+      mockSearchQuery.mockImplementation(
+        (args: { text: string }) =>
+          new Promise((resolve) => {
+            resolvers.set(args.text, resolve)
+          })
+      )
+
+      const { props, retype } = renderTypeablePicker('old')
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(SETTLE_MS)
+      })
+
+      retype('new')
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(SETTLE_MS)
+      })
+
+      expect([...resolvers.keys()]).toEqual(['old', 'new'])
+
+      // The newer search answers first, then the stale one lands behind it.
+      await act(async () => {
+        resolvers.get('new')?.(noteResponse('note-new', 'Newest note'))
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      await act(async () => {
+        resolvers.get('old')?.(noteResponse('note-old', 'Stale note'))
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(screen.getByText('Newest note')).toBeInTheDocument()
+      expect(screen.queryByText('Stale note')).not.toBeInTheDocument()
+      expect(props.onItemsChange).toHaveBeenLastCalledWith([
+        {
+          kind: 'note',
+          ref_id: 'note-new',
+          label: 'Newest note',
+          icon: { kind: 'note', emoji: null }
+        }
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears the pending search timer when the picker closes', async () => {
+    vi.useFakeTimers()
+    try {
+      const { retype, unmount } = renderTypeablePicker('a')
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(SETTLE_MS)
+      })
+
+      mockSearchQuery.mockClear()
+      mockCalendarListEvents.mockClear()
+      retype('ab')
+
+      // Closing the picker mid-debounce must not leave a timer behind that
+      // still fires a search after the component is gone.
+      unmount()
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(SETTLE_MS * 5)
+      })
+
+      expect(mockSearchQuery).not.toHaveBeenCalled()
+      expect(mockCalendarListEvents).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/ref-picker.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/ref-picker.tsx
@@ -7,6 +7,7 @@ import type { SearchResultItem } from '@memry/contracts/search-api'
 import { useT } from '@memry/i18n/renderer'
 
 import { MentionIcon, type MentionAttachment, type MentionIconSpec } from './mention-icons'
+import { useDebouncedValue } from '@/hooks/use-task-filters'
 import { cn } from '@/lib/utils'
 
 interface RefPickerProps {
@@ -27,6 +28,11 @@ interface RefPickerProps {
 const PICKER_GAP = 8
 const PICKER_MARGIN = 8
 const PICKER_MAX_HEIGHT = 256
+/**
+ * Short enough that typing then pausing still feels instant, long enough that a
+ * burst of keystrokes collapses into a single search + calendar round-trip.
+ */
+const SEARCH_DEBOUNCE_MS = 150
 
 interface RefPickerResult {
   kind: AttachmentInput['kind']
@@ -132,6 +138,7 @@ export function RefPicker({
   onClose
 }: RefPickerProps): React.JSX.Element {
   const { t } = useT('common')
+  const debouncedQuery = useDebouncedValue(query, SEARCH_DEBOUNCE_MS)
   const [results, setResults] = useState<RefPickerResult[]>([])
   const [prevQuery, setPrevQuery] = useState(query)
   const [portalStyle, setPortalStyle] = useState<CSSProperties>({
@@ -147,11 +154,21 @@ export function RefPicker({
     setResults([])
   }
 
+  // Dropping the mention list is cheap and has to happen on every keystroke so
+  // the parent can never insert a ref belonging to a previous query.
   useEffect(() => {
-    const text = query.trim()
-    let cancelled = false
     onItemsChange([])
     onSelectedIndexChange(-1)
+  }, [onItemsChange, onSelectedIndexChange, query])
+
+  // The sources behind the list are not cheap — an FTS query and a calendar
+  // range query, one main-process round-trip each — so they run off the
+  // debounced query instead. A burst of typing costs one pair of round-trips
+  // rather than one pair per character; `cancelled` drops a slower in-flight
+  // search so it cannot clobber a newer query's results.
+  useEffect(() => {
+    const text = debouncedQuery.trim()
+    let cancelled = false
 
     void Promise.all([loadSearchResults(text), loadCalendarResults(text)]).then(
       ([searchResults, calendarResults]) => {
@@ -166,7 +183,7 @@ export function RefPicker({
     return () => {
       cancelled = true
     }
-  }, [onItemsChange, onSelectedIndexChange, query])
+  }, [debouncedQuery, onItemsChange, onSelectedIndexChange])
 
   // Anchor the portal to the composer and keep it aligned while the surrounding
   // container scrolls or the window resizes. Prefers the side with more room so

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -106,6 +106,10 @@ prompt such as `summarize @Star Wars Movies` keeps the referenced item visibly a
 prompt. Mention tags submit as readable `@Title` text plus an encrypted structured attachment
 reference.
 
+The picker waits for a brief pause in typing before it searches, so typing a long mention runs one
+search rather than one per character. The list always reflects the last thing you typed — a slower
+search for an earlier query is discarded rather than shown.
+
 The prompt box uses the operating-system text editing menu, so Cut, Copy, Paste, Select All, and
 native right-click editing work like other text fields.
 


### PR DESCRIPTION
Closes #1076. Part of epic #987 (memory & CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/agent-chat/ref-picker.tsx:150-169` — the fetch effect was keyed directly on `query`, so it ran `Promise.all([loadSearchResults, loadCalendarResults])` on **every keystroke** of an `@` mention. Each run is two IPC round-trips into the main process: a search FTS query and a calendar range query. A 15-character mention cost 30 round-trips and 30 database queries.

The existing `cancelled` flag only discarded the *results* — the main-process work had already happened.

Validated on current `main` before implementing: still present, `git log` on the file shows no later fix (last touch is #825, unrelated clipping fix). Both call sites (`agent-chat/composer.tsx:539`, `components/note/review/comment-composer.tsx:208`) pass stable `useState` setters for the effect's callback deps, so `query` was the sole re-run driver — one keystroke really did equal two round-trips.

## What changed

- `ref-picker.tsx` now drives the two sources off `useDebouncedValue(query, 150)` — the debounce helper already used by `hooks/use-task-filters.ts` (also consumed by `link-input.tsx` and `folder-view.tsx`). No new dependency, no hand-rolled timer.
- The cheap part of the old effect — dropping the current mention list so the parent can never insert a ref belonging to a previous query — stays keyed on `query` and still runs on every keystroke. Only the expensive queries are debounced.
- Out-of-order safety is unchanged and now locked by a test: the effect cleanup marks a superseded search `cancelled`, so a slower earlier query cannot clobber a newer one's results.
- The pending timer is cleared on unmount/close by `useDebouncedValue`'s own cleanup.

150 ms keeps the picker a typeahead — type, pause, results are there with no perceptible lag.

## Verification

Three new tests in `__tests__/ref-picker.test.tsx`, using fake timers. Two of them fail on the unfixed source — reverting only `ref-picker.tsx` and re-running:

```
 × debounces mention searches so a burst of keystrokes costs one round-trip
   → expected "vi.fn()" to not be called at all, but actually been called 7 times
 × clears the pending search timer when the picker closes
   → expected "vi.fn()" to not be called at all, but actually been called 1 times
 Tests  2 failed | 5 passed (7)
```

7 keystrokes → 7 searches + 7 calendar queries, exactly the 2N behaviour the issue describes. With the fix the same burst produces **1** search and **1** calendar query, for the final query text.

The stale-response test passes both before and after; it is a regression lock on the `cancelled` guarantee, not proof of the fix.

With the fix in place:

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Wider suites touching both RefPicker call sites:

```
src/renderer/src/agent-chat          Test Files 18 passed (18)   Tests 159 passed (159)
src/renderer/src/components/note/review  Test Files 3 passed (3)  Tests  50 passed (50)
```

Also green: `pnpm --filter @memry/desktop typecheck:web`, `pnpm exec eslint` on the changed source, `git diff --check`, `pnpm docs:impact --base origin/main --strict` (covered), `pnpm docs:build`.

## Compatibility

Renderer-only behavioural change inside one component. No schema, contract, IPC, sync-protocol, or settings change.