### PR TITLE
perf(viewers): pan the image viewer without a React render per mousemove

### DIFF
--- a/apps/desktop/src/renderer/src/components/viewers/image-viewer.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/image-viewer.tsx
@@ -24,6 +24,16 @@ interface ImageViewerProps {
   className?: string
 }
 
+interface Position {
+  x: number
+  y: number
+}
+
+/** Single source of truth for the image transform, shared by React and the imperative pan writes. */
+function buildTransform(position: Position, scale: number, rotation: number): string {
+  return `translate(${position.x}px, ${position.y}px) scale(${scale}) rotate(${rotation}deg)`
+}
+
 // ============================================================================
 // Image Viewer Component
 // ============================================================================
@@ -35,14 +45,22 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
 
   const [scale, setScale] = useState(1)
   const [rotation, setRotation] = useState(0)
-  const [position, setPosition] = useState({ x: 0, y: 0 })
+  const [position, setPosition] = useState<Position>({ x: 0, y: 0 })
   const [isDragging, setIsDragging] = useState(false)
-  const [dragStart, setDragStart] = useState({ x: 0, y: 0 })
   const [loaded, setLoaded] = useState(false)
   const [error, setError] = useState(false)
 
+  /** Live pan offset. Leads `position` during a drag; `position` catches up on pointer-up. */
+  const positionRef = useRef<Position>(position)
+  const dragStartRef = useRef<Position>({ x: 0, y: 0 })
+
+  const commitPosition = useCallback((next: Position) => {
+    positionRef.current = next
+    setPosition(next)
+  }, [])
+
   if (scale === 1 && (position.x !== 0 || position.y !== 0)) {
-    setPosition({ x: 0, y: 0 })
+    commitPosition({ x: 0, y: 0 })
   }
 
   // Attach wheel event with passive: false to allow preventDefault
@@ -72,8 +90,8 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
 
   const resetZoom = useCallback(() => {
     setScale(1)
-    setPosition({ x: 0, y: 0 })
-  }, [])
+    commitPosition({ x: 0, y: 0 })
+  }, [commitPosition])
 
   const rotate = useCallback(() => {
     setRotation((r) => (r + 90) % 360)
@@ -91,35 +109,52 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
       const newScale = Math.min(scaleX, scaleY, 1)
 
       setScale(newScale)
-      setPosition({ x: 0, y: 0 })
+      commitPosition({ x: 0, y: 0 })
     }
-  }, [])
+  }, [commitPosition])
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
       if (scale > 1) {
+        dragStartRef.current = {
+          x: e.clientX - positionRef.current.x,
+          y: e.clientY - positionRef.current.y
+        }
         setIsDragging(true)
-        setDragStart({ x: e.clientX - position.x, y: e.clientY - position.y })
       }
     },
-    [scale, position]
+    [scale]
   )
 
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent) => {
-      if (isDragging) {
-        setPosition({
-          x: e.clientX - dragStart.x,
-          y: e.clientY - dragStart.y
-        })
+  // Pan writes the transform straight to the DOM so a gesture costs zero React renders.
+  // Listeners live on the window so the drag survives leaving the container and still
+  // ends on mouseup outside it; `position` is reconciled once the gesture finishes.
+  useEffect(() => {
+    if (!isDragging) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const next = {
+        x: e.clientX - dragStartRef.current.x,
+        y: e.clientY - dragStartRef.current.y
       }
-    },
-    [isDragging, dragStart]
-  )
+      positionRef.current = next
+      if (imageRef.current) {
+        imageRef.current.style.transform = buildTransform(next, scale, rotation)
+      }
+    }
 
-  const handleMouseUp = useCallback(() => {
-    setIsDragging(false)
-  }, [])
+    const handleMouseUp = () => {
+      setIsDragging(false)
+      commitPosition(positionRef.current)
+    }
+
+    window.addEventListener('mousemove', handleMouseMove)
+    window.addEventListener('mouseup', handleMouseUp)
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [isDragging, scale, rotation, commitPosition])
 
   const handleImageLoad = useCallback(() => {
     setLoaded(true)
@@ -209,9 +244,6 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
           isDragging && 'cursor-grabbing'
         )}
         onMouseDown={handleMouseDown}
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseUp}
       >
         <img
           ref={imageRef}
@@ -225,7 +257,9 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
             isDragging && 'transition-none'
           )}
           style={{
-            transform: `translate(${position.x}px, ${position.y}px) scale(${scale}) rotate(${rotation}deg)`
+            // Live ref, not `position`: a render triggered mid-drag (e.g. wheel zoom) must not
+            // rewrite the transform with the stale pointer-down offset.
+            transform: buildTransform(positionRef.current, scale, rotation)
           }}
           draggable={false}
         />

--- a/apps/desktop/src/renderer/src/components/viewers/viewers.test.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/viewers.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { Profiler } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AudioPlayer } from './audio-player'
@@ -210,6 +211,51 @@ describe('viewer components', () => {
     expect(
       screen.getByText('phaseF.componentsViewersImageViewer.failedToLoadImage')
     ).toBeInTheDocument()
+  })
+
+  it('pans an image without re-rendering per mousemove and commits the final offset', async () => {
+    const user = userEvent.setup()
+    const onRender = vi.fn()
+    const { container } = render(
+      <Profiler id="image-viewer" onRender={onRender}>
+        <ImageViewer src="memry-file://pan.png" alt="Pan" />
+      </Profiler>
+    )
+    const image = screen.getByRole('img', { name: 'Pan' })
+    const imageContainer = image.parentElement as HTMLDivElement
+
+    // Pan only engages above 100%.
+    await user.click(container.querySelectorAll('button')[1])
+    expect(screen.getByText('125%')).toBeInTheDocument()
+
+    fireEvent.mouseDown(imageContainer, { clientX: 100, clientY: 100 })
+    onRender.mockClear()
+
+    const steps = 12
+    for (let step = 1; step <= steps; step += 1) {
+      fireEvent.mouseMove(imageContainer, { clientX: 100 + step * 3, clientY: 100 + step * 5 })
+    }
+
+    // The gesture drives the transform imperatively: pixel-accurate, zero React commits.
+    expect(onRender).not.toHaveBeenCalled()
+    expect(image).toHaveStyle('transform: translate(36px, 60px) scale(1.25) rotate(0deg)')
+
+    // The pointer leaving the container must not abort or freeze the pan.
+    fireEvent.mouseMove(window, { clientX: 140, clientY: 170 })
+    expect(onRender).not.toHaveBeenCalled()
+    expect(image).toHaveStyle('transform: translate(40px, 70px) scale(1.25) rotate(0deg)')
+
+    // Mouseup outside the container still ends the drag and commits state once.
+    fireEvent.mouseUp(window)
+    expect(onRender).toHaveBeenCalledTimes(1)
+
+    // A later re-render must not snap back to the pointer-down offset.
+    await user.click(screen.getByTitle('phaseF.componentsViewersImageViewer.rotate'))
+    expect(image).toHaveStyle('transform: translate(40px, 70px) scale(1.25) rotate(90deg)')
+
+    // Dropping back to 100% still recenters.
+    await user.click(screen.getByTitle('phaseF.componentsViewersImageViewer.resetZoom'))
+    expect(image).toHaveStyle('transform: translate(0px, 0px) scale(1) rotate(90deg)')
   })
 
   it('loads PDFs, navigates pages, changes zoom/sidebar/rotation, and reports load errors', async () => {

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -45,6 +45,16 @@ transcript with the audio file, so opening the file page shows the player and tr
 
 Images render as image blocks (not file blocks). Drag them to resize; double-click for the lightbox.
 
+### Zooming and Panning
+
+Opening an image as a file page gives you the full viewer: zoom in and out, reset to fit, and rotate
+in 90° steps. Above 100% the image can be panned — drag it with the mouse and it tracks the cursor
+one-for-one.
+
+A pan keeps following your pointer even when it leaves the viewer or the app window, and ends
+wherever you release the button, so you can drag a zoomed image right to its edge in one motion.
+Zooming back out to 100% recenters the image.
+
 ### Images From Another App's Vault
 
 Vaults written by Obsidian, Capacities and similar apps keep media in a shared


### PR DESCRIPTION
Part of epic #987 (Memory & CPU full-app performance audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/components/viewers/image-viewer.tsx:108-118` — pan was state-driven. `handleMouseMove` (wired as `onMouseMove` on the image container at `:212`) called `setPosition` on **every** mousemove, so a single drag gesture cost one React render + commit per pointer event. On a 60 Hz trackpad that is ~60 commits/second of the whole viewer subtree for the duration of the drag.

Two related weaknesses on the same path:

- `onMouseLeave={handleMouseUp}` (`:214`) aborted the pan the moment the cursor left the container, so you could not drag a zoomed image to its edge in one motion, and a mouseup outside the container was never seen.
- The rendered transform came from `position` state only, so any render that happened mid-drag would have written a stale offset.

Measured with a `Profiler`: a 12-step pan produced **12 React commits**.

## What changed

- Pan now writes `style.transform` directly to the image element via `imageRef`, so the gesture costs **zero** React commits. `position` state is reconciled exactly once, on mouseup, so a later re-render cannot snap the image back to a stale offset.
- `mousemove`/`mouseup` listeners moved to `window` for the duration of the drag (bound in an effect gated on `isDragging`, torn down on gesture end/unmount). The drag now survives the pointer leaving the container or the window and still ends correctly on release.
- The rendered transform reads the live `positionRef` rather than `position`, so a render triggered mid-drag (e.g. wheel zoom while dragging) cannot rewrite the transform with the pointer-down offset.
- Extracted `buildTransform()` so React and the imperative write share one transform string — they cannot drift.
- Replaced `dragStart` state with `dragStartRef` (it was only ever read inside handlers, never rendered).

`transition-transform` + `isDragging && 'transition-none'` behaviour is unchanged — `isDragging` is still set on mousedown, before any move, so the transition is already off for the first frame of the gesture.

No contract, schema, IPC or persisted-format change — purely renderer-local component internals, so nothing to migrate for existing installs.

## Scope note

Issue #1077 also mentions the render-phase `setPosition` at `:44-46`. That is LOW issue #1103's territory and is left in place; it was only threaded through the new `commitPosition` helper so the ref and the state cannot diverge. See the issue thread for detail.

## How it was verified

New regression test in `viewers.test.tsx` — `pans an image without re-rendering per mousemove and commits the final offset`. It wraps the viewer in a `Profiler`, zooms to 125%, then drives a 12-step pan and asserts zero commits, that the transform equals the cumulative delta, that the pan continues after the pointer leaves the container, that mouseup outside the container commits exactly once, and that a subsequent rotate keeps the panned offset.

Confirmed it fails on the unfixed component (test file kept, component reverted):

```
× viewer components > pans an image without re-rendering per mousemove and commits the final offset
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 12 times
  Tests  1 failed | 5 passed (6)
```

After the fix:

```
✓ |renderer| src/renderer/src/components/viewers/viewers.test.tsx > viewer components > zooms, rotates, pans, fits, and errors image previews 42ms
✓ |renderer| src/renderer/src/components/viewers/viewers.test.tsx > viewer components > pans an image without re-rendering per mousemove and commits the final offset 38ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

12 commits → 0 for the same gesture. The pre-existing image test (`zooms, rotates, pans, fits, and errors image previews`) is unmodified and still passes.

Also green locally:

- `pnpm --filter @memry/desktop typecheck:web` — clean
- `pnpm exec eslint apps/desktop/src/renderer/src/components/viewers/image-viewer.tsx` — 0 problems
- `git diff --check` — clean
- `pnpm docs:impact --base origin/main --strict` — `docs impact: covered against origin/main`
- `pnpm docs:build` — `build complete in 2.77s`

Closes #1077