### PR TITLE
perf(projections): lane-scoped flush and a bounded, abortable stop drain

### DIFF
--- a/apps/desktop/src/main/projections/index.ts
+++ b/apps/desktop/src/main/projections/index.ts
@@ -1,5 +1,9 @@
 import { createLogger } from '../lib/logger'
-import { createProjectionRuntime, type ProjectionRuntime } from './runtime'
+import {
+  createProjectionRuntime,
+  type ProjectionRuntime,
+  type ProjectionStopOptions
+} from './runtime'
 import type { ProjectionEvent, ProjectionProjector } from './types'
 
 const logger = createLogger('Projections')
@@ -32,9 +36,9 @@ export function startProjectionRuntime(projectors: ProjectionProjector[]): Proje
     const supersededRuntime = runtime
     runtime = null
     logger.warn('Projection runtime already running; restarting it for the new projectors')
-    // `stop({ drain: false })` has no await before it sets `isStopped`, so this
-    // promise is already settled and cannot reject — `void` only marks it
-    // intentionally unawaited.
+    // `stop({ drain: false })` refuses further publishes synchronously and only
+    // then awaits whatever a lane already has in flight; it never rejects, so
+    // `void` just marks it intentionally unawaited.
     void supersededRuntime.stop({ drain: false })
   }
 
@@ -66,7 +70,7 @@ export async function reconcileProjections(names?: string[]): Promise<Record<str
   return (await runtime?.reconcile(names)) ?? {}
 }
 
-export async function stopProjectionRuntime(options?: { drain?: boolean }): Promise<void> {
+export async function stopProjectionRuntime(options?: ProjectionStopOptions): Promise<void> {
   if (!runtime) {
     return
   }
@@ -77,4 +81,4 @@ export async function stopProjectionRuntime(options?: { drain?: boolean }): Prom
 }
 
 export type { ProjectionEvent, ProjectionLogger, ProjectionProjector } from './types'
-export type { ProjectionRuntime } from './runtime'
+export type { ProjectionRuntime, ProjectionStopOptions } from './runtime'

--- a/apps/desktop/src/main/projections/projectors/embedding-projector.ts
+++ b/apps/desktop/src/main/projections/projectors/embedding-projector.ts
@@ -177,6 +177,11 @@ export function createEmbeddingProjector(
   return {
     name: 'embedding',
 
+    // Nothing reads embeddings back in the same turn, and project() below can
+    // await a model load plus CPU inference — so callers of
+    // flushProjectionEvents() must not queue behind this lane (#1078).
+    background: true,
+
     handles(event: ProjectionEvent): boolean {
       return event.type === 'note.upserted' || event.type === 'note.deleted'
     },

--- a/apps/desktop/src/main/projections/runtime.test.ts
+++ b/apps/desktop/src/main/projections/runtime.test.ts
@@ -36,6 +36,7 @@ function createProjector(
 ): ProjectionProjector {
   return {
     name,
+    background: overrides.background,
     handles: overrides.handles ?? (() => true),
     project: overrides.project ?? vi.fn(),
     rebuild: overrides.rebuild ?? vi.fn(),
@@ -376,5 +377,133 @@ describe('projection runtime', () => {
     expect(steps).toEqual([0])
 
     await reconcilePromise
+  })
+
+  /**
+   * #1078: `flushProjectionEvents()` waited for *every* lane, and the indexer
+   * awaits it once per file. That put the embedding lane's model load plus
+   * per-note inference in front of every file the 8-worker pool touched.
+   */
+  it('flush does not wait for a background lane', async () => {
+    let releaseBackground: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      releaseBackground = resolve
+    })
+    const embedded: string[] = []
+    const embedding = createProjector('embedding', {
+      background: true,
+      project: vi.fn(async (event: ProjectionEvent) => {
+        await gate
+        embedded.push(eventEntityId(event))
+      })
+    })
+    const search = createProjector('search', { project: vi.fn() })
+    const runtime = createProjectionRuntime({ projectors: [embedding, search] })
+
+    runtime.publish(markdownEvent('note-1', 'body'))
+    runtime.publish(markdownEvent('note-2', 'body'))
+
+    await runtime.flush()
+
+    expect(search.project).toHaveBeenCalledTimes(2)
+    expect(embedded).toEqual([])
+
+    // The barrier is lifted, not the work: the lane still holds both events, in
+    // publish order, and stop({ drain: true }) still drains it.
+    releaseBackground()
+    await runtime.stop({ drain: true })
+
+    expect(embedded).toEqual(['note-1', 'note-2'])
+  })
+
+  /**
+   * #1078: publish() kept accepting events for the whole stop drain, so anything
+   * still emitting refilled a lane as fast as it emptied and drain()'s wait loop
+   * never settled — closeVault() hung behind it.
+   */
+  it('refuses events published during stop so a refilled lane cannot keep the drain alive', async () => {
+    const logger = { warn: vi.fn() }
+    let projected = 0
+    const echoing = createProjector('echoing', {
+      project: vi.fn(async () => {
+        projected++
+        // Yield to the macrotask queue so a regression here surfaces as a test
+        // timeout rather than starving the event loop outright.
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        runtime.publish(markdownEvent(`echo-${projected}`, 'body'))
+      })
+    })
+    const runtime = createProjectionRuntime({
+      projectors: [echoing],
+      scheduleDrain: () => {},
+      logger
+    })
+
+    runtime.publish(markdownEvent('note-1', 'body'))
+    await runtime.stop({ drain: true })
+
+    expect(projected).toBe(1)
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Projection event published after runtime stop',
+      expect.anything()
+    )
+  })
+
+  /**
+   * #1078: closeVault() awaits stopProjectionRuntime({ drain: true }), so an
+   * unbounded drain made a vault switch wait out the whole backlog.
+   */
+  it('stops a long backlog at the drain deadline and still finishes the in-flight event', async () => {
+    const logger = { warn: vi.fn() }
+    const started: string[] = []
+    const finished: string[] = []
+    const slow = createProjector('slow', {
+      project: vi.fn(async (event: ProjectionEvent) => {
+        started.push(eventEntityId(event))
+        await new Promise((resolve) => setTimeout(resolve, 30))
+        finished.push(eventEntityId(event))
+      })
+    })
+    const runtime = createProjectionRuntime({ projectors: [slow], logger })
+
+    for (let i = 0; i < 50; i++) {
+      runtime.publish(markdownEvent(`note-${i}`, 'body'))
+    }
+
+    const startedAt = Date.now()
+    await runtime.stop({ drain: true, drainTimeoutMs: 40 })
+
+    // Draining all 50 would take ~1.5s; the deadline plus the one in-flight
+    // event is ~70ms.
+    expect(Date.now() - startedAt).toBeLessThan(600)
+    expect(started.length).toBeLessThan(50)
+    // Cut short, never abandoned: everything that entered project() came back
+    // out before stop() resolved and the caller closed the databases.
+    expect(finished).toEqual(started)
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Projection stop drain timed out — cutting the backlog short',
+      expect.objectContaining({ timeoutMs: 40 })
+    )
+  })
+
+  it('waits for the event already inside a projector even when the drain is skipped', async () => {
+    let started = false
+    let finished = false
+    const slow = createProjector('slow', {
+      project: vi.fn(async () => {
+        started = true
+        await new Promise((resolve) => setTimeout(resolve, 30))
+        finished = true
+      })
+    })
+    const runtime = createProjectionRuntime({ projectors: [slow] })
+
+    runtime.publish(noteEvent)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(started).toBe(true)
+
+    await runtime.stop({ drain: false })
+
+    expect(finished).toBe(true)
   })
 })

--- a/apps/desktop/src/main/projections/runtime.ts
+++ b/apps/desktop/src/main/projections/runtime.ts
@@ -9,14 +9,34 @@ interface ProjectionRuntimeOptions {
   queueLimit?: number
 }
 
+export interface ProjectionStopOptions {
+  drain?: boolean
+  /** Cap on the stop drain. See DEFAULT_STOP_DRAIN_TIMEOUT_MS. */
+  drainTimeoutMs?: number
+}
+
 export interface ProjectionRuntime {
   publish(event: ProjectionEvent): void
   flush(): Promise<void>
   rebuild(names?: string[]): Promise<Record<string, unknown>>
   reconcile(names?: string[]): Promise<Record<string, unknown>>
-  stop(options?: { drain?: boolean }): Promise<void>
+  stop(options?: ProjectionStopOptions): Promise<void>
   getPendingCount(): number
 }
+
+/**
+ * How long `stop({ drain: true })` will wait for the backlog before cutting the
+ * drain short (#1078).
+ *
+ * `closeVault()` awaits this, so an unbounded drain makes a vault switch hang
+ * behind whatever the slowest lane is doing — the embedding lane's model load
+ * and per-note inference can hold it for minutes. The deadline only stops
+ * *dequeuing*: the event already inside project() is still awaited, so the
+ * databases are never closed underneath a running projector. What the deadline
+ * leaves queued is derived state, and the next open re-derives it (indexVault
+ * plus the backgrounded reconcileProjections).
+ */
+export const DEFAULT_STOP_DRAIN_TIMEOUT_MS = 5_000
 
 function selectProjectors(
   projectors: ProjectionProjector[],
@@ -59,6 +79,14 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
   const queueLimit = options.queueLimit ?? DEFAULT_PROJECTION_QUEUE_LIMIT
 
   let isStopped = false
+  // Set at the top of stop(), before the stop drain. publish() used to keep
+  // accepting events for the whole drain, so anything still emitting — a sync
+  // write-back, a watcher event that beat stopWatcher() — refilled a lane as
+  // fast as it emptied and drain()'s wait loop never settled (#1078). Those
+  // events were doomed anyway: the bus is cleared moments later. Refusing them
+  // up front makes the stop drain finite, and logs the refusal instead of
+  // swallowing it.
+  let isStopping = false
 
   // A reconcile pass runs backgrounded (vault open fires it and does not await
   // it), so stop() has to be able to cut it short: without this, switching
@@ -171,12 +199,45 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
     return handle
   }
 
-  const drain = async (): Promise<void> => {
+  const drain = async (target: ProjectorLane[]): Promise<void> => {
     // Lanes advance independently, so a lane can still be busy (or have been
     // refilled) when a faster one settles. Loop until every lane is idle — or
     // until the runtime stops, since a stopped lane never drains its backlog.
-    while (!isStopped && lanes.some((lane) => lane.bus.size > 0 || lane.activeDrain !== null)) {
-      await Promise.all(lanes.map((lane) => drainLane(lane)))
+    while (!isStopped && target.some((lane) => lane.bus.size > 0 || lane.activeDrain !== null)) {
+      await Promise.all(target.map((lane) => drainLane(lane)))
+    }
+  }
+
+  /** Lanes a flush() barrier is allowed to wait on. See `background` in types.ts. */
+  const foregroundLanes = lanes.filter((lane) => !lane.projector.background)
+
+  /**
+   * Drain every lane, but stop dequeuing once `timeoutMs` elapses.
+   *
+   * The deadline flips `isStopped`, which each lane loop re-reads before its
+   * next event; the event already in flight keeps its await. stop() then waits
+   * on the outstanding lane handles, so nothing is abandoned mid-write.
+   */
+  const drainWithDeadline = async (timeoutMs: number): Promise<void> => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const deadline = new Promise<void>((resolve) => {
+      timer = setTimeout(
+        () => {
+          logger?.warn?.('Projection stop drain timed out — cutting the backlog short', {
+            timeoutMs,
+            pending: lanes.reduce((total, lane) => total + lane.bus.size, 0)
+          })
+          isStopped = true
+          resolve()
+        },
+        Math.max(0, timeoutMs)
+      )
+    })
+
+    try {
+      await Promise.race([drain(lanes), deadline])
+    } finally {
+      clearTimeout(timer)
     }
   }
 
@@ -193,7 +254,7 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
 
   return {
     publish(event) {
-      if (isStopped) {
+      if (isStopped || isStopping) {
         logger?.warn?.('Projection event published after runtime stop', { event })
         return
       }
@@ -217,7 +278,7 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
     },
 
     async flush() {
-      await drain()
+      await drain(foregroundLanes)
     },
 
     async rebuild(names) {
@@ -265,12 +326,20 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
       reconcileAbort?.abort()
       const pendingReconcile = activeReconcile
 
+      isStopping = true
+
       const shouldDrain = stopOptions?.drain ?? true
       if (shouldDrain) {
-        await drain()
+        await drainWithDeadline(stopOptions?.drainTimeoutMs ?? DEFAULT_STOP_DRAIN_TIMEOUT_MS)
       }
 
       isStopped = true
+
+      // The caller closes the databases as soon as this resolves, so a lane the
+      // deadline (or `drain: false`) cut short must not still be inside
+      // project(). Its handle only settles once that event's await returns.
+      await Promise.all(lanes.map((lane) => lane.activeDrain ?? Promise.resolve()))
+
       for (const lane of lanes) {
         lane.isScheduled = false
         lane.bus.clear()

--- a/apps/desktop/src/main/projections/types.ts
+++ b/apps/desktop/src/main/projections/types.ts
@@ -80,6 +80,17 @@ export type ProjectionEvent =
 
 export interface ProjectionProjector {
   name: string
+  /**
+   * Lane nothing reads back synchronously, so `flush()` does not wait for it.
+   *
+   * `flushProjectionEvents()` exists to make *index-DB* derived state visible to
+   * the next read, and the indexer awaits it once per file. Waiting for the
+   * embedding lane there put a ~23MB model load plus per-note CPU inference in
+   * front of every file the 8-worker pool touched (#1078). A background lane
+   * still receives every event, in publish order, and still drains on its own;
+   * only the barrier is lifted. `stop({ drain: true })` drains it like any other.
+   */
+  background?: boolean
   handles(event: ProjectionEvent): boolean
   project(event: ProjectionEvent): void | Promise<void>
   rebuild(): unknown

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -52,7 +52,19 @@ Two consequences worth knowing:
   payload, never from another projector's output.
 - **Index reads are eventually consistent.** They settle a microtask after the canonical write,
   not synchronously with it. Callers needing the index to reflect a write immediately must
-  `await flushProjectionEvents()`, which drains every lane.
+  `await flushProjectionEvents()`, which drains every _foreground_ lane.
+
+A lane whose output nothing reads back in the same turn marks itself `background`, and
+`flushProjectionEvents()` does not wait for it. Only the embedding lane does: it awaits a ~23MB
+model load plus per-note CPU inference, and the indexer flushes once per file, so waiting for it
+put that cost in front of every file the indexer touched. A background lane still receives every
+event in publish order and still drains on its own — only the barrier is lifted.
+
+**Closing a vault does not wait out the whole backlog.** `closeVault()` drains the projections
+before closing the databases, but the drain stops accepting new events first (so a lane that is
+still being refilled cannot keep it alive) and gives up after a few seconds. Whatever is still
+queued at that point is derived state; the next open re-derives it. The event already inside
+`project()` is always awaited, so the databases never close underneath a running projector.
 
 ## Where the Files Live
 


### PR DESCRIPTION
Closes #1078. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

The audit listed three mechanics problems. **One was already fixed**, two were still live on `main`.

### Already fixed — O(n) `Array.shift()` dequeue

`apps/desktop/src/main/projections/bus.ts` no longer uses `Array.shift()`. It is a head-index queue with periodic rebasing (`COMPACT_AFTER = 512`, `bus.ts:76-105`), landed with the queue-cap work in #992. Nothing to do; no changes to `bus.ts` in this PR.

### 1. Per-file global drain barrier (`vault/indexer.ts:205,255`)

`indexMarkdownFile` and `indexBinaryFile` each `await flushProjectionEvents()`, and `flush() -> drain()` waited for **every** lane to go idle (`runtime.ts:174-181`). The embedding lane awaits a ~23MB model load plus per-note CPU inference inside `project()`, so every file the 8-worker pool touched queued behind it. The lane's own `isIndexing()` deferral (#803) only covers the initial index pass — the watcher path and inbox filing still paid it per file.

### 2. Unbounded, spinnable stop drain blocking vault close (`runtime.ts:174-181`, `vault/index.ts:603`)

`stop()` ran `await drain()` **before** setting `isStopped`, so `publish()` kept accepting events for the whole stop drain. Anything still emitting (sync write-back, a watcher event that beat `stopWatcher()`, a projector publishing from `reconcile()`) refilled a lane as fast as it emptied and the wait loop never settled — `closeVault()` hung behind it with no upper bound.

Separately, `stop({ drain: false })` returned without waiting for the event already inside `project()`, so the caller closed the databases underneath a running projector.

## What changed

- **`types.ts`** — new optional `background?: boolean` on `ProjectionProjector`. Opt-out, so a projector added later is awaited by default.
- **`projectors/embedding-projector.ts`** — one line, `background: true`. No change to the projector's own state or logic.
- **`runtime.ts`**
  - `drain()` takes the lanes to wait on; `flush()` passes only the foreground lanes. A background lane still gets every event, in publish order, still drains on its own schedule, and is still fully drained by `stop({ drain: true })` — only the barrier is lifted, no work is skipped.
  - `stop()` sets a new `isStopping` flag **before** draining, so `publish()` refuses (and logs) new events. That makes the stop drain finite. Those events were dropped silently anyway a moment later when `bus.clear()` ran, so this loses nothing and makes the refusal visible.
  - `drainWithDeadline()` caps the stop drain (`DEFAULT_STOP_DRAIN_TIMEOUT_MS = 5s`, overridable via `stop({ drainTimeoutMs })`). The deadline only stops *dequeuing*.
  - `stop()` then awaits every outstanding lane handle, so the event inside `project()` unwinds before the caller closes the databases. In-flight work is never abandoned — this also fixes the `drain: false` path.

Backward compatible: no schema, IPC contract, sync protocol or settings change. `background` is optional; `drainTimeoutMs` is optional. What the deadline leaves queued is derived state, and vault open already re-derives it (`indexVault` plus the backgrounded `reconcileProjections()`).

## How it was verified

Four new regression tests in `runtime.test.ts`, each confirmed **failing with `runtime.ts` reverted and passing with it**:

| test | without the fix |
| --- | --- |
| `flush does not wait for a background lane` | `Test timed out in 30000ms` (flush deadlocks on the gated lane) |
| `refuses events published during stop so a refilled lane cannot keep the drain alive` | `Test timed out in 6000ms` (drain loops forever) |
| `stops a long backlog at the drain deadline and still finishes the in-flight event` | `AssertionError: expected 1510 to be less than 600` |
| `waits for the event already inside a projector even when the drain is skipped` | `AssertionError: expected false to be true` |

They cover the required bar: per-file ordering (the background lane still reports `['note-1', 'note-2']` in publish order after the barrier is lifted), prompt vault close with a large queue (50 queued x 30ms events resolve in ~63ms instead of ~1.5s), and no event abandoned across an abort (`expect(finished).toEqual(started)`).

Local runs:

```
# projections + indexer, with the fix
Test Files  4 passed (4)
      Tests  52 passed (52)

# suites that depend on flushProjectionEvents semantics
# (crdt-writeback, note-handler, journal-handler, journal-handlers ipc, import/runner, vault/notes)
Test Files  6 passed (6)
      Tests  137 passed (137)

$ pnpm --filter @memry/desktop typecheck:node
$ pnpm exec tsc --noEmit -p tsconfig.node.json --composite false      # clean

$ pnpm exec eslint <changed files>                                     # 0 errors, 0 warnings
$ git diff --check                                                     # clean
$ pnpm docs:impact --base origin/main --strict
docs impact: covered against origin/main
$ pnpm docs:build                                                      # build complete
```

Docs: `apps/docs/src/architecture/local-storage.md` said `flushProjectionEvents()` "drains every lane", which is no longer true. Updated, plus a short note on the bounded close drain.
