### PR TITLE
perf(image): bound in-flight image processing requests and queue the rest

### DIFF
--- a/apps/desktop/src/main/image-processing/bridge.test.ts
+++ b/apps/desktop/src/main/image-processing/bridge.test.ts
@@ -46,6 +46,11 @@ import {
   stopImageProcessing
 } from './bridge'
 
+const requestMessages = (): Array<{ type: string; requestId: string }> =>
+  mockUtilityProcessInstance.postMessage.mock.calls
+    .map((call) => call[0] as { type: string; requestId: string })
+    .filter((message) => message.type !== 'shutdown')
+
 describe('image-processing bridge', () => {
   beforeEach(() => {
     resetImageProcessingForTests()
@@ -192,6 +197,139 @@ describe('image-processing bridge', () => {
     await expect(exitedProcess).rejects.toThrow(
       'Image processing utility exited unexpectedly (code 9)'
     )
+  })
+
+  it('caps in-flight worker requests and drains the queue as results arrive', async () => {
+    const settled: string[] = []
+    const promises = Array.from({ length: 10 }, (_, index) =>
+      generateThumbnailInImageProcess(`/tmp/burst-${index}.jpg`, 'image/jpeg').then(
+        () => {
+          settled.push(`resolved-${index}`)
+        },
+        () => {
+          settled.push(`rejected-${index}`)
+        }
+      )
+    )
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(requestMessages()).toHaveLength(4)
+    })
+
+    for (let index = 0; index < 10; index += 1) {
+      const dispatched = requestMessages()
+      expect(dispatched.length - settled.length).toBeLessThanOrEqual(4)
+
+      mockUtilityProcessInstance.simulateMessage({
+        type: 'thumbnail-result',
+        requestId: dispatched[index].requestId,
+        result: null
+      })
+      await vi.waitFor(() => {
+        expect(settled).toHaveLength(index + 1)
+      })
+    }
+
+    await Promise.all(promises)
+    expect(requestMessages()).toHaveLength(10)
+    expect(new Set(settled).size).toBe(10)
+  })
+
+  it('starts the request timeout only once queued work is dispatched', async () => {
+    vi.useFakeTimers()
+    const outcomes: string[] = []
+    const promises = Array.from({ length: 8 }, (_, index) =>
+      generateThumbnailInImageProcess(`/tmp/timeout-${index}.jpg`, 'image/jpeg')
+        .then(
+          () => 'resolved',
+          (error: Error) => error.message
+        )
+        .then((outcome) => {
+          outcomes.push(outcome)
+        })
+    )
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(requestMessages()).toHaveLength(4)
+    })
+
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(outcomes).toHaveLength(4)
+    expect(
+      outcomes.every((outcome) => outcome.startsWith('Image processing request timed out'))
+    ).toBe(true)
+    expect(requestMessages()).toHaveLength(8)
+
+    for (const message of requestMessages().slice(4)) {
+      mockUtilityProcessInstance.simulateMessage({
+        type: 'thumbnail-result',
+        requestId: message.requestId,
+        result: null
+      })
+    }
+
+    await Promise.all(promises)
+    expect(outcomes.filter((outcome) => outcome === 'resolved')).toHaveLength(4)
+  })
+
+  it('rejects new image work once the wait queue is full', async () => {
+    const promises = Array.from({ length: 261 }, (_, index) =>
+      generateThumbnailInImageProcess(`/tmp/flood-${index}.jpg`, 'image/jpeg').then(
+        () => 'resolved',
+        (error: Error) => error.message
+      )
+    )
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+
+    await expect(promises[260]).resolves.toContain('Image processing is busy')
+    expect(requestMessages()).toHaveLength(4)
+
+    resetImageProcessingForTests()
+    const outcomes = await Promise.all(promises)
+    expect(outcomes.filter((outcome) => outcome === 'Image processing utility reset')).toHaveLength(
+      260
+    )
+  })
+
+  it('settles queued and in-flight work when the utility process stops', async () => {
+    vi.useFakeTimers()
+    const promises = Array.from({ length: 10 }, (_, index) =>
+      generateThumbnailInImageProcess(`/tmp/stop-${index}.jpg`, 'image/jpeg').then(
+        () => 'resolved',
+        (error: Error) => error.message
+      )
+    )
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(requestMessages()).toHaveLength(4)
+    })
+
+    const stopPromise = stopImageProcessing()
+    mockUtilityProcessInstance.simulateExit(0)
+    await stopPromise
+
+    const outcomes = await Promise.all(promises)
+    expect(outcomes).toEqual(Array.from({ length: 10 }, () => 'Image processing utility stopped'))
+    expect(vi.getTimerCount()).toBe(0)
+
+    const afterStop = Array.from({ length: 4 }, (_, index) =>
+      generateThumbnailInImageProcess(`/tmp/after-stop-${index}.jpg`, 'image/jpeg').then(
+        () => 'resolved',
+        (error: Error) => error.message
+      )
+    )
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(requestMessages()).toHaveLength(4)
+    })
+
+    resetImageProcessingForTests()
+    await Promise.all(afterStop)
   })
 
   it('stops a running utility process gracefully', async () => {

--- a/apps/desktop/src/main/image-processing/bridge.ts
+++ b/apps/desktop/src/main/image-processing/bridge.ts
@@ -323,17 +323,11 @@ class ImageProcessingBridge {
     })
   }
 
+  // Only ever called while the process is alive: every path that clears
+  // `this.process` also runs `rejectAll`, which empties the queue.
   private drainQueue(): void {
     while (this.queuedRequests.length > 0 && this.pendingRequests.size < MAX_IN_FLIGHT_REQUESTS) {
-      const next = this.queuedRequests.shift()
-      if (!next) {
-        return
-      }
-
-      if (!this.process) {
-        next.reject(new Error('Image processing utility is not running'))
-        continue
-      }
+      const next = this.queuedRequests.shift()!
 
       const timer = setTimeout(() => {
         this.pendingRequests.delete(next.message.requestId)
@@ -347,7 +341,7 @@ class ImageProcessingBridge {
         reject: next.reject,
         timer
       })
-      this.process.postMessage(next.message)
+      this.process!.postMessage(next.message)
     }
   }
 

--- a/apps/desktop/src/main/image-processing/bridge.ts
+++ b/apps/desktop/src/main/image-processing/bridge.ts
@@ -15,6 +15,12 @@ const REQUEST_TIMEOUT_MS = 60_000
 const START_TIMEOUT_MS = 10_000
 const SHUTDOWN_TIMEOUT_MS = 3_000
 const IDLE_SHUTDOWN_MS = 30_000
+// Bounds how many requests are posted to the worker (and therefore how many
+// request timeout timers exist) at once. Queued work waits without a timer so a
+// burst cannot time out while it is merely waiting its turn.
+const MAX_IN_FLIGHT_REQUESTS = 4
+// Backstop so a runaway caller cannot grow the wait queue without limit.
+const MAX_QUEUED_REQUESTS = 256
 
 export interface ImageProcessingThumbnailResult {
   data: Buffer
@@ -34,9 +40,16 @@ type PendingRequest = {
   timer: ReturnType<typeof setTimeout>
 }
 
+type QueuedRequest = {
+  message: Extract<ImageProcessingMainToWorkerMessage, { requestId: string }>
+  resolve: (value: ImageProcessingWorkerToMainMessage) => void
+  reject: (error: Error) => void
+}
+
 class ImageProcessingBridge {
   private process: ReturnType<typeof utilityProcess.fork> | null = null
   private pendingRequests = new Map<string, PendingRequest>()
+  private queuedRequests: QueuedRequest[] = []
   private readyPromise: Promise<void> | null = null
   private requestCounter = 0
   private shuttingDown = false
@@ -131,6 +144,7 @@ class ImageProcessingBridge {
     this.process = null
     this.readyPromise = null
     this.shuttingDown = false
+    this.rejectAll(new Error('Image processing utility stopped'))
   }
 
   reset(): void {
@@ -250,6 +264,7 @@ class ImageProcessingBridge {
 
         clearTimeout(pending.timer)
         this.pendingRequests.delete(message.requestId)
+        this.drainQueue()
 
         if (message.type === 'error') {
           this.scheduleIdleShutdown()
@@ -287,18 +302,53 @@ class ImageProcessingBridge {
       return Promise.reject(new Error('Image processing utility is not running'))
     }
 
+    if (this.queuedRequests.length >= MAX_QUEUED_REQUESTS) {
+      logger.warn('Image processing queue is full, rejecting request', {
+        type: message.type,
+        queued: this.queuedRequests.length,
+        inFlight: this.pendingRequests.size
+      })
+      return Promise.reject(
+        new Error(
+          `Image processing is busy (${MAX_QUEUED_REQUESTS} images already waiting); try again once the current images finish`
+        )
+      )
+    }
+
     this.clearIdleShutdown()
 
     return new Promise((resolve, reject) => {
+      this.queuedRequests.push({ message, resolve, reject })
+      this.drainQueue()
+    })
+  }
+
+  private drainQueue(): void {
+    while (this.queuedRequests.length > 0 && this.pendingRequests.size < MAX_IN_FLIGHT_REQUESTS) {
+      const next = this.queuedRequests.shift()
+      if (!next) {
+        return
+      }
+
+      if (!this.process) {
+        next.reject(new Error('Image processing utility is not running'))
+        continue
+      }
+
       const timer = setTimeout(() => {
-        this.pendingRequests.delete(message.requestId)
+        this.pendingRequests.delete(next.message.requestId)
+        this.drainQueue()
         this.scheduleIdleShutdown()
-        reject(new Error(`Image processing request timed out: ${message.type}`))
+        next.reject(new Error(`Image processing request timed out: ${next.message.type}`))
       }, REQUEST_TIMEOUT_MS)
 
-      this.pendingRequests.set(message.requestId, { resolve, reject, timer })
-      this.process!.postMessage(message)
-    })
+      this.pendingRequests.set(next.message.requestId, {
+        resolve: next.resolve,
+        reject: next.reject,
+        timer
+      })
+      this.process.postMessage(next.message)
+    }
   }
 
   private nextRequestId(): string {
@@ -320,6 +370,12 @@ class ImageProcessingBridge {
       clearTimeout(pending.timer)
       pending.reject(error)
       this.pendingRequests.delete(requestId)
+    }
+
+    const queued = this.queuedRequests
+    this.queuedRequests = []
+    for (const request of queued) {
+      request.reject(error)
     }
   }
 

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -198,6 +198,14 @@ thumbnail or inbox image metadata work is requested. That worker owns the lazy `
 load, returns the generated metadata or thumbnail bytes over IPC, and shuts down after it has been
 idle.
 
+The bridge to that worker is bounded. At most four requests are in flight at once; anything beyond
+that waits in a queue in the main process and is dispatched as earlier results come back. Only
+dispatched requests carry the 60-second request timeout, so a large import cannot time out while it
+is merely waiting its turn. The wait queue itself is capped at 256 requests — past that, new image
+work is rejected with a "busy" error rather than growing the queue, which callers surface as a
+missing thumbnail or basic file metadata. Every request is settled exactly once, including when the
+worker crashes or is stopped.
+
 ## better-sqlite3 ABI Quirk
 
 The native module must match the JS runtime. If you see `ERR_DLOPEN_FAILED`, rebuild for the right target:


### PR DESCRIPTION
## What was wrong

`apps/desktop/src/main/image-processing/bridge.ts` posted every request to the utility process the moment it arrived and stored an unbounded `pendingRequests` entry for it:

- `bridge.ts:39` — `pendingRequests` map with no cap.
- `bridge.ts:283-302` (pre-change) — `sendRequest` armed a 60 s `setTimeout` per request and immediately `postMessage`d it.

The worker fans every message out concurrently (`worker.ts:58-71` → `void handleGenerateThumbnail(...)`), so a burst — a large import, or an inbox drop of many images — put N requests in flight at once with N live timers in main. Two concrete consequences:

1. Main-process footprint grew linearly with burst size (map entries + timers), and the worker decoded everything at once through `sharp`.
2. Worse, the 60 s timeout started at enqueue time. With a big enough burst, requests that were only *waiting* for `libvips` to get to them blew their timeout and rejected even though nothing was broken.

`sync/attachments.ts` bounds its own fan-out via `parallelMap`, but the inbox (`inbox/domain.ts:310`) and direct thumbnail (`sync/thumbnails.ts:23`) callers were unbounded.

## What changed

`bridge.ts` now has a bounded dispatch window in front of the worker:

- `MAX_IN_FLIGHT_REQUESTS = 4` — at most four requests are posted to the worker at a time. Matches the default libuv threadpool size that `sharp` actually decodes on, and caps the number of live request timers at four.
- Everything else waits in `queuedRequests`, a timer-free queue holding only `{message, resolve, reject}` (messages carry file paths, not image bytes). `drainQueue()` dispatches the next entry whenever an in-flight request settles — on result, on error, and on timeout.
- The 60 s request timeout is armed at **dispatch** time, not enqueue time, so queued work no longer times out while waiting its turn.

## What happens at the cap, and why

- **Normal bursts back-pressure, they do not fail.** A 500-image import queues behind a 4-wide window and every request completes — that is the issue's verification criterion ("requests complete").
- **Beyond `MAX_QUEUED_REQUESTS = 256` queued**, `sendRequest` rejects immediately with `Image processing is busy (256 images already waiting); try again once the current images finish` and logs a warning. This is a backstop against a runaway caller, not the normal path. Rejecting is safe and non-silent: `sync/thumbnails.ts` catches and logs, degrading to no thumbnail, and `inbox/domain.ts` catches and falls back to basic file metadata. Nothing is dropped without a signal.
- **Every entry settles exactly once.** A request is in the queue or in the map, never both (dispatch shifts and sets synchronously). `rejectAll` now drains the queue as well as the map, so worker crash, `reset()`, and `stop()` all settle queued waiters instead of leaving them hanging forever — `stop()` previously left in-flight callers to hang until their 60 s timeout, and a queued waiter would have hung permanently. Timers are cleared on every path.

No IPC contract, protocol, or on-disk format change — this is entirely internal to the main-process bridge.

## Tests

Four new tests in `bridge.test.ts`, all of which fail on the pre-change bridge and pass after:

```
 × caps in-flight worker requests and drains the queue as results arrive
 × starts the request timeout only once queued work is dispatched
 × rejects new image work once the wait queue is full
 × settles queued and in-flight work when the utility process stops
 Tests  4 failed | 5 passed (9)      <- bridge.ts reverted

 Tests  9 passed (9)                 <- with the fix
```

They exercise the real main-process class (the utility process is mocked, not the bridge): a 10-request burst never exceeds four in flight and all ten resolve; a timed-out window hands off to queued work with fresh timers; the 261st request past the queue cap rejects while the first 260 stay queued; and after `stopImageProcessing()` all ten outstanding promises reject once, `vi.getTimerCount()` is `0`, and a fresh four-request window dispatches immediately (proving the map was left empty).

## Verification

```
pnpm --filter @memry/desktop typecheck:node   # clean
vitest --project main image-processing/ sync/thumbnails.test.ts inbox/domain.test.ts
  Test Files  4 passed (4)   Tests  28 passed (28)
pnpm exec eslint <changed files>              # 0 errors
git diff --check                              # clean
pnpm docs:impact --base origin/main --strict  # covered
pnpm docs:build                                # build complete
```

Closes #1081
Part of epic #987
