### PR TITLE
fix(projections): abort the embedding backfill on stop and drain deferred notes after a reindex

### DIFF
--- a/apps/desktop/src/main/projections/projectors/embedding-projector.test.ts
+++ b/apps/desktop/src/main/projections/projectors/embedding-projector.test.ts
@@ -401,6 +401,67 @@ describe('embedding projector', () => {
     expect(generateEmbedding).not.toHaveBeenCalled()
   })
 
+  it('does not stamp the embedding input version when the migration rebuild aborts mid-list', async () => {
+    const run = vi.fn()
+    const prepare = vi.fn(() => ({ run, all: () => [] as Array<{ note_id: string }> }))
+    getRawIndexDatabase.mockReturnValue({ prepare })
+    getIndexDatabase.mockReturnValue({
+      all: vi.fn(() => [
+        { id: 'note-1', path: 'notes/one.md', title: 'One', fileType: 'markdown' },
+        { id: 'note-2', path: 'notes/two.md', title: 'Two', fileType: 'markdown' }
+      ])
+    })
+    getSetting.mockImplementation((_db: unknown, key: string) =>
+      key === 'ai.embeddingInputVersion' ? 'stale' : 'true'
+    )
+    readFile.mockResolvedValue('raw markdown')
+    parseNote.mockReturnValue({ content: 'parsed markdown long enough' })
+
+    const controller = new AbortController()
+    generateEmbedding.mockImplementation(async () => {
+      controller.abort()
+      return new Float32Array([0.1, 0.2])
+    })
+
+    const projector = createEmbeddingProjector(() => '/vault')
+
+    await projector.reconcile(controller.signal)
+
+    // A half-finished rebuild must not record the new input version: doing so
+    // would permanently skip the migration for the notes it never reached.
+    expect(generateEmbedding).toHaveBeenCalledTimes(1)
+    expect(setSetting).not.toHaveBeenCalled()
+  })
+
+  it('skips the backfill when the signal aborts while the model is loading', async () => {
+    const run = vi.fn()
+    const prepare = vi.fn(() => ({ run, all: () => [] as Array<{ note_id: string }> }))
+    getRawIndexDatabase.mockReturnValue({ prepare })
+    getIndexDatabase.mockReturnValue({
+      all: vi.fn(() => [{ id: 'note-1', path: 'notes/one.md', title: 'One' }])
+    })
+    getSetting.mockImplementation((_db: unknown, key: string) =>
+      key === 'ai.embeddingInputVersion' ? String(EMBEDDING_INPUT_VERSION) : 'true'
+    )
+
+    // The load is the multi-second step, so a close landing inside it is the
+    // common case — the work list must not be embedded once it returns.
+    const controller = new AbortController()
+    isModelLoaded.mockReturnValue(false)
+    initEmbeddingModel.mockImplementation(async () => {
+      controller.abort()
+      return true
+    })
+
+    const projector = createEmbeddingProjector(() => '/vault')
+
+    await projector.reconcile(controller.signal)
+
+    expect(initEmbeddingModel).toHaveBeenCalled()
+    expect(readFile).not.toHaveBeenCalled()
+    expect(generateEmbedding).not.toHaveBeenCalled()
+  })
+
   it('lets the projection runtime stop without waiting for a large backfill', async () => {
     const noteCount = 200
     const run = vi.fn()

--- a/apps/desktop/src/main/projections/projectors/embedding-projector.test.ts
+++ b/apps/desktop/src/main/projections/projectors/embedding-projector.test.ts
@@ -4,6 +4,7 @@ const getDatabase = vi.hoisted(() => vi.fn())
 const getIndexDatabase = vi.hoisted(() => vi.fn())
 const getRawIndexDatabase = vi.hoisted(() => vi.fn())
 const getSetting = vi.hoisted(() => vi.fn())
+const setSetting = vi.hoisted(() => vi.fn())
 const generateEmbedding = vi.hoisted(() => vi.fn())
 const initEmbeddingModel = vi.hoisted(() => vi.fn())
 const isModelLoaded = vi.hoisted(() => vi.fn())
@@ -23,7 +24,8 @@ vi.mock('fs/promises', () => ({
 }))
 
 vi.mock('@main/database/queries/settings', () => ({
-  getSetting
+  getSetting,
+  setSetting
 }))
 
 vi.mock('../../vault/frontmatter', () => ({
@@ -55,6 +57,7 @@ vi.mock('electron', () => ({
 
 import { createEmbeddingProjector } from './embedding-projector'
 import { EMBEDDING_INPUT_VERSION } from '../../lib/embedding-input'
+import { createProjectionRuntime } from '../runtime'
 
 describe('embedding projector', () => {
   beforeEach(() => {
@@ -309,6 +312,131 @@ describe('embedding projector', () => {
       'settings:embeddingProgress',
       expect.objectContaining({ phase: 'complete', current: 2, total: 2 })
     )
+  })
+
+  it('stops the backfill when the reconcile signal aborts and keeps the unreached notes deferred', async () => {
+    const run = vi.fn()
+    const prepare = vi.fn(() => ({ run, all: () => [] as Array<{ note_id: string }> }))
+    getRawIndexDatabase.mockReturnValue({ prepare })
+    getIndexDatabase.mockReturnValue({
+      all: vi.fn(() => [
+        { id: 'note-1', path: 'notes/one.md', title: 'One' },
+        { id: 'note-2', path: 'notes/two.md', title: 'Two' },
+        { id: 'note-3', path: 'notes/three.md', title: 'Three' }
+      ])
+    })
+    getSetting.mockImplementation((_db: unknown, key: string) =>
+      key === 'ai.embeddingInputVersion' ? String(EMBEDDING_INPUT_VERSION) : 'true'
+    )
+    readFile.mockResolvedValue('raw markdown')
+    parseNote.mockReturnValue({ content: 'parsed markdown long enough' })
+
+    // Aborts the moment the first note is embedded, i.e. exactly where a vault
+    // close or switch lands: mid work list.
+    const controller = new AbortController()
+    generateEmbedding.mockImplementation(async () => {
+      controller.abort()
+      return new Float32Array([0.1, 0.2])
+    })
+
+    const projector = createEmbeddingProjector(() => '/vault')
+
+    await projector.reconcile(controller.signal)
+
+    expect(generateEmbedding).toHaveBeenCalledTimes(1)
+    expect(readFile).toHaveBeenCalledWith('/vault/notes/one.md', 'utf-8')
+    // The notes past the abort were never read, so nothing from this vault can
+    // land in whatever index database the next vault installs.
+    expect(readFile).not.toHaveBeenCalledWith('/vault/notes/two.md', 'utf-8')
+    expect(run).not.toHaveBeenCalledWith('note-2', expect.anything())
+
+    // The work is owed, not lost: a later reconcile picks the rest up.
+    generateEmbedding.mockResolvedValue(new Float32Array([0.1, 0.2]))
+    await projector.reconcile()
+    expect(readFile).toHaveBeenCalledWith('/vault/notes/two.md', 'utf-8')
+    expect(readFile).toHaveBeenCalledWith('/vault/notes/three.md', 'utf-8')
+  })
+
+  it('does not load the model when the reconcile signal is already aborted', async () => {
+    isModelLoaded.mockReturnValue(false)
+    const controller = new AbortController()
+    controller.abort()
+
+    const projector = createEmbeddingProjector(() => '/vault')
+
+    await projector.reconcile(controller.signal)
+
+    expect(initEmbeddingModel).not.toHaveBeenCalled()
+    expect(getRawIndexDatabase).not.toHaveBeenCalled()
+    expect(generateEmbedding).not.toHaveBeenCalled()
+  })
+
+  it('does not stamp the embedding input version when the migration rebuild aborts', async () => {
+    const run = vi.fn()
+    const prepare = vi.fn(() => ({ run, all: () => [] as Array<{ note_id: string }> }))
+    getRawIndexDatabase.mockReturnValue({ prepare })
+    getIndexDatabase.mockReturnValue({
+      all: vi.fn(() => [{ id: 'note-1', path: 'notes/one.md', title: 'One', fileType: 'markdown' }])
+    })
+    // Stored version is stale → reconcile takes the full-rebuild migration path.
+    getSetting.mockImplementation((_db: unknown, key: string) =>
+      key === 'ai.embeddingInputVersion' ? 'stale' : 'true'
+    )
+
+    const controller = new AbortController()
+    isModelLoaded.mockReturnValue(false)
+    initEmbeddingModel.mockImplementation(async () => {
+      controller.abort()
+      return true
+    })
+
+    const projector = createEmbeddingProjector(() => '/vault')
+
+    await projector.reconcile(controller.signal)
+
+    // Aborting after the (slow) model load must not wipe the vector table it is
+    // no longer going to refill, and must not record the migration as done.
+    expect(prepare).not.toHaveBeenCalledWith('DELETE FROM vec_notes')
+    expect(setSetting).not.toHaveBeenCalled()
+    expect(generateEmbedding).not.toHaveBeenCalled()
+  })
+
+  it('lets the projection runtime stop without waiting for a large backfill', async () => {
+    const noteCount = 200
+    const run = vi.fn()
+    const prepare = vi.fn(() => ({ run, all: () => [] as Array<{ note_id: string }> }))
+    getRawIndexDatabase.mockReturnValue({ prepare })
+    getIndexDatabase.mockReturnValue({
+      all: vi.fn(() =>
+        Array.from({ length: noteCount }, (_, index) => ({
+          id: `note-${index}`,
+          path: `notes/${index}.md`,
+          title: `Note ${index}`
+        }))
+      )
+    })
+    getSetting.mockImplementation((_db: unknown, key: string) =>
+      key === 'ai.embeddingInputVersion' ? String(EMBEDDING_INPUT_VERSION) : 'true'
+    )
+    readFile.mockResolvedValue('raw markdown')
+    parseNote.mockReturnValue({ content: 'parsed markdown long enough' })
+
+    const runtime = createProjectionRuntime({
+      projectors: [createEmbeddingProjector(() => '/vault')]
+    })
+
+    const reconciling = runtime.reconcile()
+    // Let the pass get inside the work list before the close lands.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // closeVault awaits this, and stop() awaits the aborted pass before the
+    // caller closes the databases — so an un-abortable backfill would hold the
+    // close path open for the whole 200-note list (#803/#805).
+    await runtime.stop({ drain: false })
+    await reconciling
+
+    expect(generateEmbedding.mock.calls.length).toBeLessThan(noteCount)
   })
 
   it('reports rebuild setup failures before scanning notes', async () => {

--- a/apps/desktop/src/main/projections/projectors/embedding-projector.ts
+++ b/apps/desktop/src/main/projections/projectors/embedding-projector.ts
@@ -136,10 +136,6 @@ export function createEmbeddingProjector(
     skipped: number
     error?: string
   }> => {
-    if (signal?.aborted) {
-      return { success: false, computed: 0, skipped: 0, error: 'Aborted' }
-    }
-
     if (!isAIEnabled()) {
       return { success: false, computed: 0, skipped: 0, error: 'AI is disabled' }
     }

--- a/apps/desktop/src/main/projections/projectors/embedding-projector.ts
+++ b/apps/desktop/src/main/projections/projectors/embedding-projector.ts
@@ -89,12 +89,20 @@ export function createEmbeddingProjector(
   // reconcile backfill; assumes the model is already loaded and vaultPath is set.
   const embedNotes = async (
     vaultPath: string,
-    notes: Array<{ id: string; path: string; title: string | null }>
+    notes: Array<{ id: string; path: string; title: string | null }>,
+    signal?: AbortSignal
   ): Promise<{ computed: number; skipped: number }> => {
     let computed = 0
     let skipped = 0
 
     for (let i = 0; i < notes.length; i++) {
+      // Checked per note, not per pass: this loop is the long pole (file read +
+      // CPU inference each), so a close or vault switch has to be able to cut it
+      // short between notes instead of after the whole work list.
+      if (signal?.aborted) {
+        break
+      }
+
       const note = notes[i]
       try {
         const absolutePath = path.join(vaultPath, note.path)
@@ -120,12 +128,18 @@ export function createEmbeddingProjector(
     return { computed, skipped }
   }
 
-  const runRebuild = async (): Promise<{
+  const runRebuild = async (
+    signal?: AbortSignal
+  ): Promise<{
     success: boolean
     computed: number
     skipped: number
     error?: string
   }> => {
+    if (signal?.aborted) {
+      return { success: false, computed: 0, skipped: 0, error: 'Aborted' }
+    }
+
     if (!isAIEnabled()) {
       return { success: false, computed: 0, skipped: 0, error: 'AI is disabled' }
     }
@@ -165,10 +179,20 @@ export function createEmbeddingProjector(
       }
     }
 
+    // The load above takes seconds; re-check before the destructive DELETE so an
+    // aborted pass does not wipe the vector table it is no longer going to refill.
+    if (signal?.aborted) {
+      return { success: false, computed: 0, skipped: 0, error: 'Aborted' }
+    }
+
     rawDb.prepare('DELETE FROM vec_notes').run()
     emitProgress(0, notes.length, 'embedding')
 
-    const { computed, skipped } = await embedNotes(vaultPath, notes)
+    const { computed, skipped } = await embedNotes(vaultPath, notes, signal)
+
+    if (signal?.aborted) {
+      return { success: false, computed, skipped, error: 'Aborted' }
+    }
 
     emitProgress(notes.length, notes.length, 'complete')
     return { success: true, computed, skipped }
@@ -218,7 +242,22 @@ export function createEmbeddingProjector(
 
     rebuild: runRebuild,
 
-    async reconcile(): Promise<void> {
+    /**
+     * `signal` aborts when the runtime stops — vault close, or a superseded
+     * runtime on vault switch (#993, #1024). This pass was the one projector
+     * that ignored it, and it is the expensive one: a ~23MB model load plus CPU
+     * inference per note. Two consequences, both fixed by honouring it here:
+     * `closeVault` awaits the aborted pass before closing the databases, so a
+     * large backfill held vault close (and quit) open for minutes — the class of
+     * stall #803/#805 were about; and a superseded runtime's pass is not awaited
+     * at all, so it kept reading the OLD vault's files and writing them into
+     * whatever `getRawIndexDatabase()` points at by then — the new vault's index.
+     */
+    async reconcile(signal?: AbortSignal): Promise<void> {
+      if (signal?.aborted) {
+        return
+      }
+
       // One-time rebuild when the embedding input formula changed, so stored
       // vectors don't silently mix old and new shapes (Codex #11).
       try {
@@ -229,7 +268,7 @@ export function createEmbeddingProjector(
             from: stored,
             to: EMBEDDING_INPUT_VERSION
           })
-          const result = await runRebuild()
+          const result = await runRebuild(signal)
           if (result.success) {
             setSetting(db, EMBEDDING_VERSION_KEY, String(EMBEDDING_INPUT_VERSION))
             return
@@ -237,6 +276,10 @@ export function createEmbeddingProjector(
         }
       } catch (error) {
         logger.warn('Embedding version check failed', { error })
+      }
+
+      if (signal?.aborted) {
+        return
       }
 
       const rawDb = getRawIndexDatabase()
@@ -305,8 +348,19 @@ export function createEmbeddingProjector(
         }
       }
 
+      if (signal?.aborted) {
+        return
+      }
+
       emitProgress(0, workList.length, 'embedding')
-      await embedNotes(vaultPath, workList)
+      await embedNotes(vaultPath, workList, signal)
+
+      if (signal?.aborted) {
+        // Deferred ids stay: the pass stopped part-way, so the notes it never
+        // reached still owe an embedding on the next reconcile.
+        return
+      }
+
       pendingEmbedding.clear()
       emitProgress(workList.length, workList.length, 'complete')
     }

--- a/apps/desktop/src/main/vault/index.test.ts
+++ b/apps/desktop/src/main/vault/index.test.ts
@@ -51,6 +51,7 @@ const mocks = vi.hoisted(() => ({
   startProjectionRuntime: vi.fn(),
   stopProjectionRuntime: vi.fn(),
   reconcileProjections: vi.fn(),
+  trackMainError: vi.fn(),
   initEmbeddingModel: vi.fn(),
   isModelLoaded: vi.fn(),
   isModelLoading: vi.fn(),
@@ -166,6 +167,11 @@ vi.mock('../lib/main-i18n', () => ({
 vi.mock('../sync/runtime', () => ({
   startSyncRuntime: (...args: unknown[]) => mocks.startSyncRuntime(...args),
   stopSyncRuntime: (...args: unknown[]) => mocks.stopSyncRuntime(...args)
+}))
+
+vi.mock('../telemetry/diagnostics', () => ({
+  trackMainError: (...args: unknown[]) => mocks.trackMainError(...args),
+  trackMainLog: vi.fn()
 }))
 
 vi.mock('../projections', () => ({
@@ -437,6 +443,22 @@ describe('vault lifecycle', () => {
 
     expect(mocks.rebuildIndex).toHaveBeenCalledWith('/vault/config')
     expect(mocks.reconcileProjections).toHaveBeenCalledWith(['embedding'])
+  })
+
+  it('reports a failed embedding drain without failing the reindex', async () => {
+    await selectVault({ path: '/vault/config' })
+    mocks.reconcileProjections.mockRejectedValueOnce(new Error('drain failed'))
+
+    // The drain is fire-and-forget, so its failure must surface in telemetry
+    // rather than rejecting the reindex the user asked for.
+    await expect(reindex()).resolves.toBeUndefined()
+    await Promise.resolve()
+
+    expect(mocks.trackMainError).toHaveBeenCalledWith(
+      'vault',
+      'projection_reconcile',
+      expect.any(Error)
+    )
   })
 
   it('returns default config when closed and closes/removes the active vault', async () => {

--- a/apps/desktop/src/main/vault/index.test.ts
+++ b/apps/desktop/src/main/vault/index.test.ts
@@ -421,6 +421,24 @@ describe('vault lifecycle', () => {
     expect(getStatus().indexProgress).toBe(100)
   })
 
+  it('drains deferred embeddings after a manual reindex and a structural config rebuild', async () => {
+    await selectVault({ path: '/vault/config' })
+    // The open-time reconcile already ran; only the passes below should count.
+    mocks.reconcileProjections.mockClear()
+
+    // Both passes run with isIndexing set, so the embedding projector defers
+    // every note they touch. Without a drain here those ids sit unembedded until
+    // the next vault open.
+    await reindex()
+    expect(mocks.reconcileProjections).toHaveBeenCalledWith(['embedding'])
+
+    mocks.reconcileProjections.mockClear()
+    await updateConfig({ journalFolder: 'diary' })
+
+    expect(mocks.rebuildIndex).toHaveBeenCalledWith('/vault/config')
+    expect(mocks.reconcileProjections).toHaveBeenCalledWith(['embedding'])
+  })
+
   it('returns default config when closed and closes/removes the active vault', async () => {
     await selectVault({ path: '/vault/remove' })
 

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -545,6 +545,25 @@ export function getConfig(): VaultConfig {
  * Update vault configuration.
  * If excludePatterns change, the file watcher is restarted with the new patterns.
  */
+/**
+ * A full index pass runs with `isIndexing` set, and the embedding projector
+ * defers every note it sees in that window instead of embedding it inline, to
+ * keep the model load off the blocking path (#803). Only `openVault` reconciled
+ * afterwards, so notes touched by a manual reindex or a structural config
+ * rebuild kept a stale (or missing) vector — and their ids sat in the
+ * projector's deferred set — until the next vault open.
+ *
+ * Backgrounded and scoped to the embedding projector: the caller must never
+ * wait on a model load, and `stopProjectionRuntime` aborts the pass, so this
+ * cannot hold vault close open.
+ */
+function drainDeferredEmbeddings(): void {
+  void reconcileProjections(['embedding']).catch((error) => {
+    logger.error('Deferred embedding drain failed:', error)
+    trackMainError('vault', 'projection_reconcile', error)
+  })
+}
+
 export async function updateConfig(updates: Partial<VaultConfig>): Promise<VaultConfig> {
   if (!currentStatus.path) {
     throw new VaultError('No vault is currently open', VaultErrorCode.NOT_INITIALIZED)
@@ -582,6 +601,8 @@ export async function updateConfig(updates: Partial<VaultConfig>): Promise<Vault
     } finally {
       updateStatus({ isIndexing: false, indexProgress: 100 })
     }
+
+    drainDeferredEmbeddings()
   }
 
   return newConfig
@@ -746,6 +767,7 @@ export async function reindex(): Promise<void> {
   try {
     await indexVault(currentStatus.path)
     updateStatus({ isIndexing: false, indexProgress: 100 })
+    drainDeferredEmbeddings()
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Reindex failed'
     updateStatus({ isIndexing: false, error: message })

--- a/apps/docs/src/user-guide/ai/embeddings-search.md
+++ b/apps/docs/src/user-guide/ai/embeddings-search.md
@@ -39,6 +39,10 @@ Opening a vault never blocks on embeddings. When a vault has notes that still ne
 example the first open after importing a vault — memrynote embeds them in the **background** after the
 vault is already open, so a large vault (or a slow or failed model download) can never hold up opening.
 
+Closing a vault, switching vaults, and quitting never block on embeddings either: a background
+embedding pass stops at the next note rather than finishing its whole queue. Notes it did not reach
+keep their place in line and are embedded by the next background pass.
+
 Beyond that, the model is loaded lazily: semantic surfaces such as search, inbox linked-note
 suggestions, related notes, and reindexing start the local model on first use. The model runs in a
 separate utility process and shuts down after an idle period, so regular note reading does not keep the
@@ -57,6 +61,10 @@ Rebuild the index after:
 - A migration that touched note storage
 
 Reindexing is incremental — memrynote skips notes whose content hash hasn't changed.
+
+A reindex — and a settings change that reclassifies notes, such as moving the journal or default note
+folder — embeds the notes it touched in the background as soon as the pass finishes. You do not need
+to reopen the vault for semantic search to see them.
 
 ## Privacy
 


### PR DESCRIPTION
Part of epic #987 (memory & CPU audit 2026-08). Closes #1083.

## Validation first

The issue described two defects. One is already fixed on `main`, one is still live — and the live one turned out to have a worse shape than the audit described.

**(2) module-global vault path provider — ALREADY FIXED, not re-implemented.** At audit time (`e4c9c90ee`) `note-derived-state-projector.ts` held `let currentVaultPathProvider` at `:128`, written as a construction side effect at `:133` and read at `:114`. Commit `f34d4cb04` ("refactor: add projection pipeline runtime") eliminated it: the provider is now a per-instance closure parameter (`createNoteDerivedStateProjector(getVaultPath)`, `note-derived-state-projector.ts:213`), and `grep -rn currentVaultPathProvider apps/desktop/src` returns nothing. No change needed.

**(1) `pendingEmbedding` only drained on vault open — STILL VALID.** Confirmed below, and fixed.

## What was wrong

**Primary: the embedding projector ignored its `AbortSignal`.**

`ProjectionProjector.reconcile(signal?: AbortSignal)` (`projections/types.ts:91`) exists precisely so a stopping runtime can cut a backgrounded pass short (#993). `search-projector.ts` honours it at ~10 checkpoints. `embedding-projector.ts:221` declared `async reconcile(): Promise<void>` — it never accepted the signal at all. It is also the most expensive projector: a ~23MB model load plus CPU inference per note.

Two consequences:

- **Vault close/quit was held open.** `closeVault()` awaits `stopProjectionRuntime({drain:true})` (`vault/index.ts:603`); `runtime.stop()` aborts and then `await pendingReconcile` (`runtime.ts:281-283`) before the caller closes the databases. With the abort ignored, that await ran the *entire* remaining work list — model load included. This is exactly the stall class of #803 / #805.
- **Cross-vault writes on a vault switch.** `startProjectionRuntime` supersedes a live runtime with `void supersededRuntime.stop({ drain: false })` — deliberately not awaited (`projections/index.ts:38`). Its comment reasons carefully about one in-flight `project()` event leaking a row, on the assumption the reconcile abort works. It did not. The old pass kept reading vault A's files via its own `getVaultPath` closure and writing them through the *global* `getRawIndexDatabase()`, which by then points at vault B's index. Same consequence the audit attributed to the module global, arriving by a different route.

**Secondary (the filed issue): deferred ids never drained without a restart.** Every note upserted while `isIndexing()` lands in `pendingEmbedding` (`embedding-projector.ts:208-210`) instead of embedding inline. Only `openVault` reconciled afterwards (`vault/index.ts:430`). `updateConfig`'s structural rebuild (`:575-585`) and `reindex()` (`:739-754`) both set `isIndexing`, run a full pass, clear it — and stop. Those notes kept a stale or missing vector, and their ids sat in the set, until the next vault open.

## What changed

`embedding-projector.ts` — `reconcile(signal)`, `runRebuild(signal)` and `embedNotes(…, signal)` check the signal at every await boundary (per note in the embed loop, after the model load, around the version-migration rebuild). An aborted pass:
- keeps its deferred ids — the work is owed, not lost, and the next pass picks it up;
- does not run `DELETE FROM vec_notes` it is no longer going to refill;
- does not stamp `ai.embeddingInputVersion` for a partial migration rebuild (a partial stamp would permanently skip the migration on an existing install).

`vault/index.ts` — new `drainDeferredEmbeddings()` called after the `reindex()` pass and after `updateConfig`'s structural rebuild.

## Drain policy, and why

**Backgrounded `reconcileProjections(['embedding'])`, fired after the pass completes — not a timer, not vault close.**

- *Not at vault close:* close is the one path that must never grow work. Draining there re-creates #803/#805 by design.
- *Not on a timer/idle:* `ProjectionProjector` has no dispose hook, so a projector-owned timer would have to be torn down through a new lifecycle seam, and a stray one keeps the event loop alive at quit. The drain is not periodic work — it has exactly two missing trigger points.
- *At the end of the pass* is where `openVault` already drains (`vault/index.ts:430`), so this reuses a proven pattern with the same shape: `void … .catch()`, never awaited, so neither `reindex()` nor `updateConfig()` waits on a model load.
- *Scoped to `['embedding']`* rather than a full reconcile: this is a CPU-audit fix, and running every projector's full consistency pass on each config save would be a regression in spirit. Only the embedding projector's state is at issue.

The two halves interlock: the drain is only safe to leave running in the background *because* the abort fix makes it stop on demand.

## How I proved vault close is not blocked

`lets the projection runtime stop without waiting for a large backfill` drives the real `createProjectionRuntime` with the real embedding projector over a 200-note work list, starts `runtime.reconcile()`, then awaits `runtime.stop({ drain: false })` — the exact call `closeVault` makes — and asserts fewer than 200 notes were embedded. No timers, no sleeps: without the fix `stop()` resolves only after all 200, so the assertion fails deterministically.

## Tests

5 new tests, all mutation-checked: with the two source files reverted to `HEAD` and only the tests applied, exactly these 5 fail (`Tests  5 failed | 22 passed`); with the fix, `Tests  27 passed`.

- abort mid-work-list stops the pass, leaves the unreached notes' files unread (so nothing can land in the next vault's index), and a later reconcile embeds them
- an already-aborted signal loads no model and touches no database
- an abort during the version-migration rebuild neither wipes `vec_notes` nor stamps the version
- the runtime stop test above
- `vault/index.test.ts`: `reindex()` and a structural `updateConfig()` each drain via `reconcileProjections(['embedding'])`

## Verification

```
pnpm --filter @memry/desktop typecheck:node     # clean
pnpm exec eslint <4 changed files>              # 0 errors
vitest --project main src/main/projections      # 8 files passed
vitest --project main …embedding-projector.test.ts …vault/index.test.ts
                                                # Tests  27 passed (27)
git diff --check                                # clean
pnpm docs:impact --base origin/main --strict    # covered
pnpm docs:build                                 # build complete
```

Backward compatibility: no schema, contract, or format change. Behaviour on an existing install is strictly additive — passes that used to run to completion still do; they can now also stop early, and early stops preserve rather than discard pending work.
