### PR TITLE
perf(graph): walk the local graph outwards instead of building the whole vault

### DIFF
--- a/apps/desktop/src/main/database/queries/graph.test.ts
+++ b/apps/desktop/src/main/database/queries/graph.test.ts
@@ -6,8 +6,84 @@ import {
   type TestDatabaseResult,
   type TestDb
 } from '@tests/utils/test-db'
+import type { GraphDataResponse } from '@memry/contracts/graph-api'
 import { getGraphData, getLocalGraph } from './graph'
 import { setPropertyRefs } from './notes/property-ref-queries'
+
+/**
+ * The implementation `getLocalGraph` replaced: build the entire vault graph, then BFS over it
+ * and throw everything outside `depth` away. Kept here as the oracle the bounded traversal is
+ * measured against — it is the behaviour real vaults have been running on.
+ */
+function referenceLocalGraph(
+  indexDb: TestDb,
+  dataDb: TestDb,
+  noteId: string,
+  depth: number
+): GraphDataResponse {
+  const fullGraph = getGraphData(indexDb, dataDb)
+
+  const adjacency = new Map<string, Set<string>>()
+  for (const edge of fullGraph.edges) {
+    if (!adjacency.has(edge.source)) adjacency.set(edge.source, new Set())
+    if (!adjacency.has(edge.target)) adjacency.set(edge.target, new Set())
+    adjacency.get(edge.source)!.add(edge.target)
+    adjacency.get(edge.target)!.add(edge.source)
+  }
+
+  const visited = new Set<string>([noteId])
+  const queue: Array<{ id: string; level: number }> = [{ id: noteId, level: 0 }]
+
+  while (queue.length > 0) {
+    const { id, level } = queue.shift()!
+    if (level >= depth) continue
+    const neighbors = adjacency.get(id)
+    if (!neighbors) continue
+    for (const neighbor of neighbors) {
+      if (visited.has(neighbor)) continue
+      visited.add(neighbor)
+      queue.push({ id: neighbor, level: level + 1 })
+    }
+  }
+
+  return {
+    nodes: fullGraph.nodes.filter((node) => visited.has(node.id)),
+    edges: fullGraph.edges.filter((edge) => visited.has(edge.source) && visited.has(edge.target))
+  }
+}
+
+/**
+ * Node and edge arrays are consumed keyed by id (graphology), so array order carries no
+ * meaning — but every node object, every edge object and their multiplicities must match.
+ */
+function normalizeGraph(graph: GraphDataResponse): GraphDataResponse {
+  return {
+    nodes: graph.nodes
+      .map((node) => ({ ...node, tags: [...node.tags].sort() }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+    edges: [...graph.edges].sort((a, b) => a.id.localeCompare(b.id))
+  }
+}
+
+/** Counts the rows every statement on this connection actually materialises. */
+function trackRowsRead(sqlite: TestDatabaseResult['sqlite']): () => number {
+  let rows = 0
+  const originalPrepare = sqlite.prepare.bind(sqlite)
+  const patched = (source: string): unknown => {
+    const statement = originalPrepare(source) as unknown as {
+      all: (...params: unknown[]) => unknown[]
+    }
+    const originalAll = statement.all.bind(statement)
+    statement.all = (...params: unknown[]): unknown[] => {
+      const result = originalAll(...params)
+      rows += result.length
+      return result
+    }
+    return statement
+  }
+  sqlite.prepare = patched as unknown as typeof sqlite.prepare
+  return () => rows
+}
 
 function insertMarkdownNote(
   db: TestDb,
@@ -73,6 +149,81 @@ function insertTask(
     INSERT INTO tasks (id, project_id, status_id, title, position, archived_at)
     VALUES (${id}, ${projectId}, ${statusId}, ${`Task ${id}`}, 0, ${archivedAt})
   `)
+}
+
+function insertPropertyRef(
+  db: TestDb,
+  sourceNoteId: string,
+  propertyName: string,
+  targetType: 'note' | 'task' | 'event',
+  targetId: string
+): void {
+  db.run(sql`
+    INSERT INTO property_refs (source_note_id, property_name, target_type, target_id)
+    VALUES (${sourceNoteId}, ${propertyName}, ${targetType}, ${targetId})
+  `)
+}
+
+function insertTaskNote(db: TestDb, taskId: string, noteId: string): void {
+  db.run(sql`INSERT INTO task_notes (task_id, note_id) VALUES (${taskId}, ${noteId})`)
+}
+
+/**
+ * A vault with everything the traversal has to survive: a 3-note cycle, a pair of notes
+ * linking at each other, two rows collapsing onto one edge id, a ghost shared by two notes
+ * four hops apart, an orphan, relation refs in both directions, refs to a deleted note / a
+ * task / a non-markdown file, task↔note links, an archived task, and tasks whose project has
+ * been archived (which the whole-vault build leaves as a dangling edge).
+ */
+function seedNeighbourhood(indexDb: TestDb, dataDb: TestDb): void {
+  insertMarkdownNote(indexDb, 'n1', 'Alpha', { emoji: 'A', wordCount: 42 })
+  insertMarkdownNote(indexDb, 'n2', 'Beta')
+  insertMarkdownNote(indexDb, 'n3', 'Gamma')
+  insertMarkdownNote(indexDb, 'n4', 'Delta')
+  insertMarkdownNote(indexDb, 'n5', 'Epsilon')
+  insertMarkdownNote(indexDb, 'n6', 'Zeta')
+  insertMarkdownNote(indexDb, 'j1', 'Daily', { date: '2026-05-10' })
+  indexDb.run(sql`
+    INSERT INTO note_cache (id, path, title, file_type, mime_type, created_at, modified_at)
+    VALUES ('pdf-1', 'files/report.pdf', 'Report', 'pdf', 'application/pdf',
+      '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')
+  `)
+
+  insertTag(indexDb, 'n1', 'work')
+  insertTag(indexDb, 'n1', 'focus')
+  insertTag(indexDb, 'n2', 'inbox')
+
+  insertWikiLink(indexDb, 'n1', 'Beta', 'n2')
+  insertWikiLink(indexDb, 'n2', 'Gamma', 'n3')
+  insertWikiLink(indexDb, 'n3', 'Alpha', 'n1')
+  insertWikiLink(indexDb, 'n1', 'Delta', 'n4')
+  insertWikiLink(indexDb, 'n1', 'Delta Alias', 'n4')
+  insertWikiLink(indexDb, 'n4', 'Alpha', 'n1')
+  insertWikiLink(indexDb, 'j1', 'Alpha', 'n1')
+  insertWikiLink(indexDb, 'n2', 'Missing')
+  insertWikiLink(indexDb, 'n5', 'Missing')
+  insertWikiLink(indexDb, 'n1', 'Report', 'pdf-1')
+  insertWikiLink(indexDb, 'n1', 'Deleted', 'nte_gone')
+
+  insertPropertyRef(indexDb, 'n3', 'related', 'note', 'n4')
+  insertPropertyRef(indexDb, 'n4', 'mirror', 'note', 'n3')
+  insertPropertyRef(indexDb, 'n3', 'ghosted', 'note', 'nte_gone')
+  insertPropertyRef(indexDb, 'n3', 'assignee', 'task', 't1')
+
+  insertProject(dataDb, 'p1', 'Launch')
+  insertProject(dataDb, 'p-arch', 'Archived', '2026-05-10T00:00:00.000Z')
+  insertStatus(dataDb, 's1', 'p1')
+  insertStatus(dataDb, 's2', 'p-arch')
+  insertTask(dataDb, 't1', 'p1', 's1')
+  insertTask(dataDb, 't2', 'p1', 's1')
+  insertTask(dataDb, 't3', 'p-arch', 's2')
+  insertTask(dataDb, 't4', 'p-arch', 's2')
+  insertTask(dataDb, 't-arch', 'p1', 's1', '2026-05-10T00:00:00.000Z')
+
+  insertTaskNote(dataDb, 't1', 'n1')
+  insertTaskNote(dataDb, 't2', 'n5')
+  insertTaskNote(dataDb, 't3', 'n2')
+  insertTaskNote(dataDb, 't-arch', 'n1')
 }
 
 describe('graph queries', () => {
@@ -212,5 +363,79 @@ describe('graph queries', () => {
         .sort()
     ).toEqual(['a', 'b', 'c'])
     expect(getLocalGraph(indexDb, dataDb, 'missing', 2)).toEqual({ nodes: [], edges: [] })
+  })
+
+  describe('local graph traversal', () => {
+    it.each(['n1', 'n5', 'n6', 't1', 'p1', 'p-arch', 'nte_gone'])(
+      'returns exactly what the whole-vault build then filter returned, from %s',
+      (seed) => {
+        seedNeighbourhood(indexDb, dataDb)
+
+        for (const depth of [0, 1, 2, 3, 4]) {
+          const actual = normalizeGraph(getLocalGraph(indexDb, dataDb, seed, depth))
+          const expected = normalizeGraph(referenceLocalGraph(indexDb, dataDb, seed, depth))
+          expect(actual, `seed ${seed} at depth ${depth}`).toEqual(expected)
+        }
+      }
+    )
+
+    it('keeps whole-vault connection counts on the outermost ring', () => {
+      seedNeighbourhood(indexDb, dataDb)
+
+      const graph = getLocalGraph(indexDb, dataDb, 'n1', 2)
+      const byId = new Map(graph.nodes.map((node) => [node.id, node]))
+
+      // Reached at depth 2 and never expanded, yet still carries both of the links that
+      // point at it — the second one comes from n5, which is two hops further out.
+      expect(byId.get('ghost:Missing')?.connectionCount).toBe(2)
+      expect(graph.nodes.some((node) => node.id === 'n5')).toBe(false)
+      // Both rows that collapse onto the same n1→n4 edge id survive as separate edges.
+      expect(graph.edges.filter((edge) => edge.id === 'n1-n4-wikilink')).toHaveLength(2)
+      expect(byId.get('n1')?.tags.sort()).toEqual(['focus', 'work'])
+    })
+
+    it('reads a neighbourhood-sized number of rows no matter how big the vault is', () => {
+      seedNeighbourhood(indexDb, dataDb)
+      const smallIndexRows = trackRowsRead(indexResult.sqlite)
+      const smallDataRows = trackRowsRead(dataResult.sqlite)
+      const smallGraph = getLocalGraph(indexDb, dataDb, 'n1', 2)
+      const smallRows = smallIndexRows() + smallDataRows()
+
+      const bigIndex = createTestIndexDb()
+      const bigData = createTestDataDb()
+      try {
+        const bigIndexDb = bigIndex.db
+        const bigDataDb = bigData.db
+        // Same neighbourhood, 400 notes / 400 links / 200 tasks of unrelated vault around it.
+        seedNeighbourhood(bigIndexDb, bigDataDb)
+        insertProject(bigDataDb, 'p-far', 'Far')
+        insertStatus(bigDataDb, 's-far', 'p-far')
+        for (let i = 0; i < 400; i++) {
+          insertMarkdownNote(bigIndexDb, `far-${i}`, `Far ${i}`)
+          insertWikiLink(bigIndexDb, `far-${i}`, `Far ${i + 1}`, `far-${i + 1}`)
+          if (i < 200) insertTask(bigDataDb, `t-far-${i}`, 'p-far', 's-far')
+        }
+
+        const bigIndexRows = trackRowsRead(bigIndex.sqlite)
+        const bigDataRows = trackRowsRead(bigData.sqlite)
+        const bigGraph = getLocalGraph(bigIndexDb, bigDataDb, 'n1', 2)
+        const bigRows = bigIndexRows() + bigDataRows()
+
+        const referenceIndexRows = trackRowsRead(bigIndex.sqlite)
+        const referenceDataRows = trackRowsRead(bigData.sqlite)
+        referenceLocalGraph(bigIndexDb, bigDataDb, 'n1', 2)
+        const referenceRows = referenceIndexRows() + referenceDataRows()
+
+        expect(normalizeGraph(bigGraph)).toEqual(normalizeGraph(smallGraph))
+        expect(bigRows).toBe(smallRows)
+        expect(bigRows).toBeLessThan(100)
+        // The build-then-filter it replaced materialised the whole vault to answer the same
+        // question, and grew with every note added anywhere.
+        expect(referenceRows).toBeGreaterThan(1000)
+      } finally {
+        bigIndex.close()
+        bigData.close()
+      }
+    })
   })
 })

--- a/apps/desktop/src/main/database/queries/graph.ts
+++ b/apps/desktop/src/main/database/queries/graph.ts
@@ -1,4 +1,4 @@
-import { eq, isNull } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { noteCache, noteTags, noteLinks, propertyRefs } from '@memry/db-schema/schema/notes-cache'
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { taskNotes } from '@memry/db-schema/schema/task-relations'
@@ -14,6 +14,82 @@ const NODE_COLORS: Record<GraphNode['type'], string> = {
 }
 
 const GHOST_COLOR = 'var(--graph-ghost-node)'
+
+const GHOST_PREFIX = 'ghost:'
+
+/**
+ * Node factories shared by the whole-vault build and the local traversal, so the two can
+ * never drift on the shape of a node they both have to be able to emit.
+ */
+function createNoteNode(
+  row: {
+    id: string
+    title: string
+    date: string | null
+    wordCount: number | null
+    emoji: string | null
+  },
+  tags: string[]
+): GraphNode {
+  const type: GraphNode['type'] = row.date ? 'journal' : 'note'
+  return {
+    id: row.id,
+    type,
+    label: row.title || 'Untitled',
+    tags,
+    wordCount: row.wordCount ?? 0,
+    connectionCount: 0,
+    emoji: row.emoji ?? null,
+    color: NODE_COLORS[type],
+    isOrphan: false,
+    isUnresolved: false
+  }
+}
+
+function createTaskNode(row: { id: string; title: string }): GraphNode {
+  return {
+    id: row.id,
+    type: 'task',
+    label: row.title || 'Untitled Task',
+    tags: [],
+    wordCount: 0,
+    connectionCount: 0,
+    emoji: null,
+    color: NODE_COLORS.task,
+    isOrphan: false,
+    isUnresolved: false
+  }
+}
+
+function createProjectNode(row: { id: string; name: string; icon: string | null }): GraphNode {
+  return {
+    id: row.id,
+    type: 'project',
+    label: row.name || 'Untitled Project',
+    tags: [],
+    wordCount: 0,
+    connectionCount: 0,
+    emoji: row.icon ?? null,
+    color: NODE_COLORS.project,
+    isOrphan: false,
+    isUnresolved: false
+  }
+}
+
+function createGhostNode(targetTitle: string): GraphNode {
+  return {
+    id: `${GHOST_PREFIX}${targetTitle}`,
+    type: 'note',
+    label: targetTitle,
+    tags: [],
+    wordCount: 0,
+    connectionCount: 0,
+    emoji: null,
+    color: GHOST_COLOR,
+    isOrphan: false,
+    isUnresolved: true
+  }
+}
 
 export function getGraphData(indexDb: IndexDb, dataDb: DataDb): GraphDataResponse {
   const nodes: GraphNode[] = []
@@ -45,20 +121,7 @@ export function getGraphData(indexDb: IndexDb, dataDb: DataDb): GraphDataRespons
   }
 
   for (const note of allNotes) {
-    const type: GraphNode['type'] = note.date ? 'journal' : 'note'
-    const tags = tagsByNoteId.get(note.id) ?? []
-    nodes.push({
-      id: note.id,
-      type,
-      label: note.title || 'Untitled',
-      tags,
-      wordCount: note.wordCount ?? 0,
-      connectionCount: 0,
-      emoji: note.emoji ?? null,
-      color: NODE_COLORS[type],
-      isOrphan: false,
-      isUnresolved: false
-    })
+    nodes.push(createNoteNode(note, tagsByNoteId.get(note.id) ?? []))
     nodeIds.add(note.id)
   }
 
@@ -73,18 +136,7 @@ export function getGraphData(indexDb: IndexDb, dataDb: DataDb): GraphDataRespons
     .all()
 
   for (const task of allTasks) {
-    nodes.push({
-      id: task.id,
-      type: 'task',
-      label: task.title || 'Untitled Task',
-      tags: [],
-      wordCount: 0,
-      connectionCount: 0,
-      emoji: null,
-      color: NODE_COLORS.task,
-      isOrphan: false,
-      isUnresolved: false
-    })
+    nodes.push(createTaskNode(task))
     nodeIds.add(task.id)
 
     if (task.projectId) {
@@ -109,18 +161,7 @@ export function getGraphData(indexDb: IndexDb, dataDb: DataDb): GraphDataRespons
     .all()
 
   for (const project of allProjects) {
-    nodes.push({
-      id: project.id,
-      type: 'project',
-      label: project.name || 'Untitled Project',
-      tags: [],
-      wordCount: 0,
-      connectionCount: 0,
-      emoji: project.icon ?? null,
-      color: NODE_COLORS.project,
-      isOrphan: false,
-      isUnresolved: false
-    })
+    nodes.push(createProjectNode(project))
     nodeIds.add(project.id)
   }
 
@@ -143,20 +184,9 @@ export function getGraphData(indexDb: IndexDb, dataDb: DataDb): GraphDataRespons
         weight: 1
       })
     } else if (!link.targetId && nodeIds.has(link.sourceId)) {
-      const ghostId = `ghost:${link.targetTitle}`
+      const ghostId = `${GHOST_PREFIX}${link.targetTitle}`
       if (!nodeIds.has(ghostId)) {
-        nodes.push({
-          id: ghostId,
-          type: 'note',
-          label: link.targetTitle,
-          tags: [],
-          wordCount: 0,
-          connectionCount: 0,
-          emoji: null,
-          color: GHOST_COLOR,
-          isOrphan: false,
-          isUnresolved: true
-        })
+        nodes.push(createGhostNode(link.targetTitle))
         nodeIds.add(ghostId)
       }
       edges.push({
@@ -225,43 +255,391 @@ export function getGraphData(indexDb: IndexDb, dataDb: DataDb): GraphDataRespons
   return { nodes, edges }
 }
 
+/** Keeps every `IN (...)` list well under SQLite's bound-parameter ceiling. */
+const ID_CHUNK_SIZE = 400
+
+function chunk<T>(values: T[]): T[][] {
+  const batches: T[][] = []
+  for (let i = 0; i < values.length; i += ID_CHUNK_SIZE) {
+    batches.push(values.slice(i, i + ID_CHUNK_SIZE))
+  }
+  return batches
+}
+
+/**
+ * A full-graph edge, plus the identity of the row that produced it so the same row picked
+ * up from both of its endpoints is only ever counted once.
+ */
+interface EdgeCandidate {
+  rowKey: string
+  edge: GraphEdge
+  /**
+   * False only for `project-task`, which the whole-vault build emits without checking that
+   * the project is still a node — a task under an archived project keeps its dangling edge.
+   */
+  requiresBothNodes: boolean
+}
+
+/** Everything the traversal has resolved so far. Lives for one `getLocalGraph` call. */
+interface TraversalState {
+  /** Ids that resolved to a real graph node, with the node itself. */
+  nodes: Map<string, GraphNode>
+  /** Every id we have already tried to resolve, node or not. */
+  resolved: Set<string>
+  /** `tasks.project_id` for resolved task nodes, for the project-task edge off a task. */
+  taskProjectIds: Map<string, string | null>
+}
+
+function isGhostId(id: string): boolean {
+  return id.startsWith(GHOST_PREFIX)
+}
+
+/**
+ * Resolve ids to graph nodes with indexed primary-key lookups, mirroring exactly which rows
+ * the whole-vault build turns into nodes: markdown notes, unarchived tasks, unarchived
+ * projects. Anything else stays unresolved, which is what keeps its edges out of the result.
+ */
+function resolveNodes(
+  indexDb: IndexDb,
+  dataDb: DataDb,
+  ids: string[],
+  state: TraversalState
+): void {
+  const pending = ids.filter((id) => !state.resolved.has(id))
+  if (pending.length === 0) return
+
+  const realIds: string[] = []
+  for (const id of pending) {
+    state.resolved.add(id)
+    if (isGhostId(id)) {
+      state.nodes.set(id, createGhostNode(id.slice(GHOST_PREFIX.length)))
+    } else {
+      realIds.push(id)
+    }
+  }
+
+  const noteIds: string[] = []
+  for (const batch of chunk(realIds)) {
+    const noteRows = indexDb
+      .select({
+        id: noteCache.id,
+        title: noteCache.title,
+        date: noteCache.date,
+        wordCount: noteCache.wordCount,
+        emoji: noteCache.emoji
+      })
+      .from(noteCache)
+      .where(and(eq(noteCache.fileType, 'markdown'), inArray(noteCache.id, batch)))
+      .all()
+
+    for (const row of noteRows) {
+      state.nodes.set(row.id, createNoteNode(row, []))
+      noteIds.push(row.id)
+    }
+
+    const taskRows = dataDb
+      .select({ id: tasks.id, title: tasks.title, projectId: tasks.projectId })
+      .from(tasks)
+      .where(and(isNull(tasks.archivedAt), inArray(tasks.id, batch)))
+      .all()
+
+    for (const row of taskRows) {
+      state.nodes.set(row.id, createTaskNode(row))
+      state.taskProjectIds.set(row.id, row.projectId)
+    }
+
+    const projectRows = dataDb
+      .select({ id: projects.id, name: projects.name, icon: projects.icon })
+      .from(projects)
+      .where(and(isNull(projects.archivedAt), inArray(projects.id, batch)))
+      .all()
+
+    for (const row of projectRows) {
+      state.nodes.set(row.id, createProjectNode(row))
+    }
+  }
+
+  for (const batch of chunk(noteIds)) {
+    const tagRows = indexDb
+      .select({ noteId: noteTags.noteId, tag: noteTags.tag })
+      .from(noteTags)
+      .where(inArray(noteTags.noteId, batch))
+      .all()
+
+    for (const row of tagRows) {
+      state.nodes.get(row.noteId)?.tags.push(row.tag)
+    }
+  }
+}
+
+function projectTaskCandidate(taskId: string, projectId: string): EdgeCandidate {
+  return {
+    rowKey: `project-task\u0000${taskId}`,
+    requiresBothNodes: false,
+    edge: {
+      id: `${taskId}-${projectId}-project-task`,
+      source: taskId,
+      target: projectId,
+      type: 'project-task',
+      weight: 1
+    }
+  }
+}
+
+/**
+ * Every full-graph edge touching one of `frontier`, found with indexed lookups instead of a
+ * whole-vault scan. Both directions of every relationship are queried, so a node's backlinks
+ * are reached exactly like its outgoing links.
+ */
+function collectIncidentEdges(
+  indexDb: IndexDb,
+  dataDb: DataDb,
+  frontier: string[],
+  state: TraversalState
+): EdgeCandidate[] {
+  const noteIds: string[] = []
+  const taskIds: string[] = []
+  const ghostTitles: string[] = []
+  // Resolved projects, plus ids that resolved to nothing: a task can point at an archived or
+  // deleted project, and the whole-vault build still walks that edge.
+  const projectLikeIds: string[] = []
+
+  for (const id of frontier) {
+    if (isGhostId(id)) {
+      ghostTitles.push(id.slice(GHOST_PREFIX.length))
+      continue
+    }
+    const node = state.nodes.get(id)
+    if (!node || node.type === 'project') projectLikeIds.push(id)
+    else if (node.type === 'task') taskIds.push(id)
+    else noteIds.push(id)
+  }
+
+  const candidates: EdgeCandidate[] = []
+
+  for (const taskId of taskIds) {
+    const projectId = state.taskProjectIds.get(taskId)
+    if (projectId) candidates.push(projectTaskCandidate(taskId, projectId))
+  }
+
+  for (const batch of chunk(projectLikeIds)) {
+    const rows = dataDb
+      .select({ id: tasks.id, projectId: tasks.projectId })
+      .from(tasks)
+      .where(and(isNull(tasks.archivedAt), inArray(tasks.projectId, batch)))
+      .all()
+
+    for (const row of rows) {
+      if (row.projectId) candidates.push(projectTaskCandidate(row.id, row.projectId))
+    }
+  }
+
+  const linkColumns = {
+    sourceId: noteLinks.sourceId,
+    targetId: noteLinks.targetId,
+    targetTitle: noteLinks.targetTitle
+  }
+  const linkRows = new Map<
+    string,
+    { sourceId: string; targetId: string | null; targetTitle: string }
+  >()
+
+  for (const batch of chunk(noteIds)) {
+    for (const row of indexDb
+      .select(linkColumns)
+      .from(noteLinks)
+      .where(inArray(noteLinks.sourceId, batch))
+      .all()) {
+      linkRows.set(`${row.sourceId}\u0000${row.targetTitle}`, row)
+    }
+    for (const row of indexDb
+      .select(linkColumns)
+      .from(noteLinks)
+      .where(inArray(noteLinks.targetId, batch))
+      .all()) {
+      linkRows.set(`${row.sourceId}\u0000${row.targetTitle}`, row)
+    }
+  }
+
+  // A ghost is shared by every note linking to that missing title, so it is expanded by title.
+  for (const batch of chunk(ghostTitles)) {
+    for (const row of indexDb
+      .select(linkColumns)
+      .from(noteLinks)
+      .where(and(isNull(noteLinks.targetId), inArray(noteLinks.targetTitle, batch)))
+      .all()) {
+      linkRows.set(`${row.sourceId}\u0000${row.targetTitle}`, row)
+    }
+  }
+
+  for (const [rowKey, row] of linkRows) {
+    const target = row.targetId ?? `${GHOST_PREFIX}${row.targetTitle}`
+    candidates.push({
+      rowKey: `wikilink\u0000${rowKey}`,
+      requiresBothNodes: true,
+      edge: {
+        id: `${row.sourceId}-${target}-wikilink`,
+        source: row.sourceId,
+        target,
+        type: 'wikilink',
+        weight: 1
+      }
+    })
+  }
+
+  const refColumns = {
+    sourceNoteId: propertyRefs.sourceNoteId,
+    propertyName: propertyRefs.propertyName,
+    targetId: propertyRefs.targetId
+  }
+  const refRows = new Map<
+    string,
+    { sourceNoteId: string; propertyName: string; targetId: string }
+  >()
+
+  for (const batch of chunk(noteIds)) {
+    for (const row of indexDb
+      .select(refColumns)
+      .from(propertyRefs)
+      .where(and(eq(propertyRefs.targetType, 'note'), inArray(propertyRefs.sourceNoteId, batch)))
+      .all()) {
+      refRows.set(`${row.sourceNoteId}\u0000${row.propertyName}\u0000${row.targetId}`, row)
+    }
+    for (const row of indexDb
+      .select(refColumns)
+      .from(propertyRefs)
+      .where(and(eq(propertyRefs.targetType, 'note'), inArray(propertyRefs.targetId, batch)))
+      .all()) {
+      refRows.set(`${row.sourceNoteId}\u0000${row.propertyName}\u0000${row.targetId}`, row)
+    }
+  }
+
+  for (const [rowKey, row] of refRows) {
+    candidates.push({
+      rowKey: `relation\u0000${rowKey}`,
+      requiresBothNodes: true,
+      edge: {
+        id: `${row.sourceNoteId}-${row.targetId}-relation`,
+        source: row.sourceNoteId,
+        target: row.targetId,
+        type: 'relation',
+        weight: 1
+      }
+    })
+  }
+
+  const taskNoteRows = new Map<string, { taskId: string; noteId: string }>()
+  for (const batch of chunk(taskIds)) {
+    for (const row of dataDb
+      .select({ taskId: taskNotes.taskId, noteId: taskNotes.noteId })
+      .from(taskNotes)
+      .where(inArray(taskNotes.taskId, batch))
+      .all()) {
+      taskNoteRows.set(`${row.taskId}\u0000${row.noteId}`, row)
+    }
+  }
+  for (const batch of chunk(noteIds)) {
+    for (const row of dataDb
+      .select({ taskId: taskNotes.taskId, noteId: taskNotes.noteId })
+      .from(taskNotes)
+      .where(inArray(taskNotes.noteId, batch))
+      .all()) {
+      taskNoteRows.set(`${row.taskId}\u0000${row.noteId}`, row)
+    }
+  }
+
+  for (const [rowKey, row] of taskNoteRows) {
+    candidates.push({
+      rowKey: `task-note\u0000${rowKey}`,
+      requiresBothNodes: true,
+      edge: {
+        id: `${row.taskId}-${row.noteId}-task-note`,
+        source: row.taskId,
+        target: row.noteId,
+        type: 'task-note',
+        weight: 1
+      }
+    })
+  }
+
+  return candidates
+}
+
+/**
+ * The neighbourhood around `noteId` out to `depth` hops.
+ *
+ * Walks outwards one hop at a time with indexed lookups. It used to materialise the whole
+ * vault graph — every note, task, project, link and ref — and then throw all but the
+ * neighbourhood away, so opening a note's local graph cost the same on a 5k-note vault as
+ * rendering the global graph.
+ *
+ * Edges incident to the outermost ring are still enumerated (without following them), because
+ * `connectionCount` is a node's degree in the *whole* graph, not inside the returned slice.
+ */
 export function getLocalGraph(
   indexDb: IndexDb,
   dataDb: DataDb,
   noteId: string,
   depth: number
 ): GraphDataResponse {
-  const fullGraph = getGraphData(indexDb, dataDb)
-
-  const adjacency = new Map<string, Set<string>>()
-  for (const edge of fullGraph.edges) {
-    if (!adjacency.has(edge.source)) adjacency.set(edge.source, new Set())
-    if (!adjacency.has(edge.target)) adjacency.set(edge.target, new Set())
-    adjacency.get(edge.source)!.add(edge.target)
-    adjacency.get(edge.target)!.add(edge.source)
+  const state: TraversalState = {
+    nodes: new Map(),
+    resolved: new Set(),
+    taskProjectIds: new Map()
   }
+  resolveNodes(indexDb, dataDb, [noteId], state)
 
-  const visited = new Set<string>()
-  const queue: Array<{ id: string; level: number }> = [{ id: noteId, level: 0 }]
-  visited.add(noteId)
+  const visited = new Set<string>([noteId])
+  const edges = new Map<string, GraphEdge>()
+  let frontier = [noteId]
+  let level = 0
 
-  while (queue.length > 0) {
-    const { id, level } = queue.shift()!
-    if (level >= depth) continue
+  while (frontier.length > 0) {
+    const candidates = collectIncidentEdges(indexDb, dataDb, frontier, state)
+    resolveNodes(
+      indexDb,
+      dataDb,
+      candidates.flatMap((candidate) => [candidate.edge.source, candidate.edge.target]),
+      state
+    )
 
-    const neighbors = adjacency.get(id)
-    if (!neighbors) continue
-
-    for (const neighbor of neighbors) {
-      if (!visited.has(neighbor)) {
-        visited.add(neighbor)
-        queue.push({ id: neighbor, level: level + 1 })
+    const nextFrontier: string[] = []
+    for (const { rowKey, edge, requiresBothNodes } of candidates) {
+      if (requiresBothNodes && (!state.nodes.has(edge.source) || !state.nodes.has(edge.target))) {
+        continue
+      }
+      if (!edges.has(rowKey)) edges.set(rowKey, edge)
+      if (level >= depth) continue
+      for (const endpoint of [edge.source, edge.target]) {
+        if (visited.has(endpoint)) continue
+        visited.add(endpoint)
+        nextFrontier.push(endpoint)
       }
     }
+
+    if (level >= depth) break
+    level += 1
+    frontier = nextFrontier
   }
 
-  const localNodes = fullGraph.nodes.filter((n) => visited.has(n.id))
-  const localEdges = fullGraph.edges.filter((e) => visited.has(e.source) && visited.has(e.target))
+  const connectionCounts = new Map<string, number>()
+  for (const edge of edges.values()) {
+    connectionCounts.set(edge.source, (connectionCounts.get(edge.source) ?? 0) + 1)
+    connectionCounts.set(edge.target, (connectionCounts.get(edge.target) ?? 0) + 1)
+  }
 
-  return { nodes: localNodes, edges: localEdges }
+  const nodes: GraphNode[] = []
+  for (const id of visited) {
+    const node = state.nodes.get(id)
+    if (!node) continue
+    node.connectionCount = connectionCounts.get(id) ?? 0
+    node.isOrphan = node.connectionCount === 0
+    nodes.push(node)
+  }
+
+  const localEdges = [...edges.values()].filter(
+    (edge) => visited.has(edge.source) && visited.has(edge.target)
+  )
+
+  return { nodes, edges: localEdges }
 }

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -119,6 +119,22 @@ Drizzle schemas live in `packages/db-schema`. Tables of note:
 - `sync_items`, `sync_pull_cursor`, `sync_outbox` (sync state)
 - `field_clocks` JSON column on tasks and projects (per-field vector clocks)
 
+### Graph Queries
+
+`apps/desktop/src/main/database/queries/graph.ts` answers two different questions with two
+different query shapes:
+
+- **Whole graph** (`getGraphData`) scans every markdown note, tag, unarchived task, unarchived
+  project, wikilink, relation ref and task↔note row. The graph view asks for all of it, so it
+  costs what it costs.
+- **Local graph** (`getLocalGraph`) walks outwards from one note, one hop at a time, with
+  indexed lookups on both sides of every relationship. It reads the neighbourhood, not the
+  vault, so a note's local graph costs the same on a 5,000-note vault as on a small one.
+
+The local traversal still enumerates the edges touching its outermost ring without following
+them, because a node's `connectionCount` is its degree in the whole graph rather than inside the
+returned slice.
+
 ## Migrations
 
 ```bash


### PR DESCRIPTION
Closes #1080. Part of epic #987 (memory & CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/database/queries/graph.ts:234` (pre-change) — `getLocalGraph` called
`getGraphData(indexDb, dataDb)`, which materialises **every** markdown note, note tag, unarchived
task, unarchived project, wikilink, property ref and task↔note row in the vault, built a full
adjacency map over it, BFS'd `depth` hops, and then threw everything else away.

Every `GET_LOCAL_GRAPH` IPC (`apps/desktop/src/main/ipc/graph-handlers.ts:22`) paid whole-vault
cost to draw one note's neighbourhood, with no caching on the handler. Still valid on current
`main` — `git log` on the file shows no later fix (last touch was #942, the relation-property
work).

## What changed

`getLocalGraph` now walks outwards one hop at a time using indexed lookups on **both** sides of
every relationship (out-links and backlinks, relation refs in both directions, task↔note from
both ends, project↔task from both ends, plus ghost expansion by title). Node resolution is a
primary-key lookup per batch, chunked to stay under SQLite's bound-parameter ceiling.

Two subtleties the traversal has to keep, or it would silently change a user-visible view:

- **`connectionCount` is whole-graph degree**, not degree inside the returned slice. So the edges
  incident to the outermost ring are still enumerated — they just are not followed.
- **Edges between two nodes on the outermost ring** are part of the old result (both endpoints
  are visited), so they must be collected even though neither node is expanded.

Edge de-duplication is by *source row identity*, not by edge id: two `note_links` rows with
different titles can resolve to the same target and legitimately produce two edges with the same
id, and the old code emitted both.

`getGraphData` is unchanged in behaviour; the node literals it built inline are now shared
factories so the two code paths cannot drift on node shape.

## How output equivalence was proved

The old build-then-filter implementation is kept verbatim in the test file as
`referenceLocalGraph`, and the new traversal is compared against it on a fixture with a 3-note
cycle, a bidirectional link pair, two rows collapsing onto one edge id, a ghost node shared by
two notes four hops apart, an orphan, relation refs both ways, refs to a deleted note / a task /
a non-markdown file, task↔note links, an archived task, and tasks under an archived project (the
dangling `project-task` edge the old build leaves behind). Compared across **7 seeds x 5 depths**,
including a task seed, a project seed, an archived-project seed and a nonexistent-id seed.

Mutation-tested, not just asserted:

- Deleting the backlink query (`note_links WHERE target_id IN …`) → **5 equivalence tests fail**.
- Reinstating the whole-vault build → the row-count test fails with
  `expected 1079 to be 78`.

That last test is the "no whole-vault build" assertion: it instruments the raw better-sqlite3
connections and counts the rows every statement materialises. On a vault with 400 extra unrelated
notes / 400 links / 200 tasks, the new traversal reads **78 rows — byte-identical to the count on
the small vault** — while the old build-then-filter reads 1079 and grows with every note added
anywhere.

## Verification

```
pnpm --filter @memry/desktop typecheck:node      # clean
pnpm exec vitest run --project main src/main/database/queries/graph.test.ts
  Test Files  1 passed (1)
       Tests  14 passed (14)
pnpm exec eslint <changed files>                 # 0 errors, 0 warnings
git diff --check                                 # clean
pnpm docs:impact --base origin/main --strict     # covered
pnpm docs:build                                  # build complete
```

Array order is not asserted: node/edge arrays are consumed keyed by id (graphology `addNode` /
`addEdgeWithKey`), and the old order was itself SQLite-planner-dependent. Node objects, edge
objects and their multiplicities are compared exactly.
