### PR TITLE
perf(agent-chat): splice upserted messages instead of re-sorting the transcript

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context-message-order.test.ts
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context-message-order.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AgentEvent, Conversation, Message } from '@memry/contracts/ipc-agent'
+
+import { agentReducer, initialAgentState, type AgentState } from '../agent-context.reducer'
+
+const CONVERSATION_ID = 'conversation-1'
+
+function conversation(id: string): Conversation {
+  return {
+    id,
+    vaultId: 'vault-1',
+    title: id,
+    backend: 'claude_cli',
+    backendModel: null,
+    trustList: [],
+    pinned: false,
+    vectorClock: {},
+    fieldClocks: {},
+    createdAt: 100,
+    updatedAt: 100,
+    deletedAt: null,
+    lastSyncedAt: null
+  }
+}
+
+function message(input: { id: string; createdAt: number; text?: string }): Message {
+  return {
+    id: input.id,
+    conversationId: CONVERSATION_ID,
+    role: 'assistant',
+    content: { role: 'assistant', data: { text: input.text ?? input.id } },
+    toolCallId: null,
+    attachments: [],
+    status: 'completed',
+    vectorClock: {},
+    createdAt: input.createdAt,
+    updatedAt: input.createdAt,
+    deletedAt: null
+  }
+}
+
+/**
+ * The merge-then-full-sort this reducer used to run on every `message_upserted`.
+ * Kept verbatim as the oracle the fast paths must agree with, message for
+ * message, for every arrival order.
+ */
+function legacyUpsert(messages: Message[], nextMessage: Message): Message[] {
+  const existing = messages.findIndex((candidate) => candidate.id === nextMessage.id)
+  const next =
+    existing === -1
+      ? [...messages, nextMessage]
+      : messages.map((candidate, index) => (index === existing ? nextMessage : candidate))
+  return [...next].sort((left, right) => left.createdAt - right.createdAt)
+}
+
+function upsertEvent(nextMessage: Message): AgentEvent {
+  return { kind: 'message_upserted', message: nextMessage }
+}
+
+function hydrated(messages: Message[]): AgentState {
+  return agentReducer(initialAgentState, {
+    type: 'set_active_conversation',
+    conversation: conversation(CONVERSATION_ID),
+    messages
+  })
+}
+
+function transcript(state: AgentState): Message[] {
+  return state.messagesByConversation[CONVERSATION_ID] ?? []
+}
+
+/** Applies every upsert through both the reducer and the old algorithm. */
+function bothOrders(
+  initial: Message[],
+  upserts: Message[]
+): { actual: Message[]; oracle: Message[] } {
+  let state = hydrated(initial)
+  let oracle = initial
+  for (const nextMessage of upserts) {
+    state = agentReducer(state, { type: 'event', event: upsertEvent(nextMessage) })
+    oracle = legacyUpsert(oracle, nextMessage)
+  }
+  return { actual: transcript(state), oracle }
+}
+
+function ids(messages: Message[]): string[] {
+  return messages.map((entry) => entry.id)
+}
+
+describe('agent reducer message ordering', () => {
+  it('matches the old full sort for shuffled arrivals', () => {
+    const arrivals = [
+      message({ id: 'e', createdAt: 500 }),
+      message({ id: 'b', createdAt: 200 }),
+      message({ id: 'd', createdAt: 400 }),
+      message({ id: 'a', createdAt: 100 }),
+      message({ id: 'c', createdAt: 300 })
+    ]
+    const { actual, oracle } = bothOrders([], arrivals)
+    expect(ids(actual)).toEqual(ids(oracle))
+    expect(ids(actual)).toEqual(['a', 'b', 'c', 'd', 'e'])
+  })
+
+  it('matches the old full sort for equal timestamps', () => {
+    const arrivals = [
+      message({ id: 'first', createdAt: 100 }),
+      message({ id: 'second', createdAt: 100 }),
+      message({ id: 'third', createdAt: 100 }),
+      message({ id: 'later', createdAt: 200 }),
+      message({ id: 'fourth', createdAt: 100 })
+    ]
+    const { actual, oracle } = bothOrders([], arrivals)
+    expect(ids(actual)).toEqual(ids(oracle))
+    // Equal timestamps keep arrival order; the newer one stays last.
+    expect(ids(actual)).toEqual(['first', 'second', 'third', 'fourth', 'later'])
+  })
+
+  it('matches the old full sort when a message is re-sent unchanged', () => {
+    const initial = [
+      message({ id: 'a', createdAt: 100 }),
+      message({ id: 'b', createdAt: 100 }),
+      message({ id: 'c', createdAt: 200 })
+    ]
+    const { actual, oracle } = bothOrders(initial, [
+      message({ id: 'a', createdAt: 100, text: 'edited' })
+    ])
+    expect(ids(actual)).toEqual(ids(oracle))
+    expect(ids(actual)).toEqual(['a', 'b', 'c'])
+    expect(actual[0].content).toEqual({ role: 'assistant', data: { text: 'edited' } })
+  })
+
+  it('matches the old full sort when a re-sent message moves later', () => {
+    const initial = [
+      message({ id: 'a', createdAt: 100 }),
+      message({ id: 'b', createdAt: 200 }),
+      message({ id: 'c', createdAt: 300 })
+    ]
+    const { actual, oracle } = bothOrders(initial, [message({ id: 'a', createdAt: 250 })])
+    expect(ids(actual)).toEqual(ids(oracle))
+    expect(ids(actual)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('matches the old full sort when a re-sent message moves earlier', () => {
+    const initial = [
+      message({ id: 'a', createdAt: 100 }),
+      message({ id: 'b', createdAt: 200 }),
+      message({ id: 'c', createdAt: 300 })
+    ]
+    const { actual, oracle } = bothOrders(initial, [message({ id: 'c', createdAt: 150 })])
+    expect(ids(actual)).toEqual(ids(oracle))
+    expect(ids(actual)).toEqual(['a', 'c', 'b'])
+  })
+
+  it('matches the old full sort when the hydrated transcript arrives out of order', () => {
+    const initial = [
+      message({ id: 'late', createdAt: 300 }),
+      message({ id: 'early', createdAt: 100 })
+    ]
+    const { actual, oracle } = bothOrders(initial, [message({ id: 'mid', createdAt: 200 })])
+    expect(ids(actual)).toEqual(ids(oracle))
+  })
+
+  it('does not re-sort the transcript on every upsert', () => {
+    const initial = Array.from({ length: 40 }, (_, index) =>
+      message({ id: `seed-${index}`, createdAt: index + 1 })
+    )
+    let state = hydrated(initial)
+    // The first upsert on a transcript from main still sorts; from then on the
+    // order is known and appending must not compare anything.
+    state = agentReducer(state, {
+      type: 'event',
+      event: upsertEvent(message({ id: 'warm', createdAt: 41 }))
+    })
+
+    let comparisons = 0
+    for (const entry of transcript(state)) {
+      Object.defineProperty(entry, 'createdAt', {
+        configurable: true,
+        enumerable: true,
+        get() {
+          comparisons += 1
+          return entry.updatedAt
+        }
+      })
+    }
+    state = agentReducer(state, {
+      type: 'event',
+      event: upsertEvent(message({ id: 'appended', createdAt: 42 }))
+    })
+
+    expect(ids(transcript(state)).at(-1)).toBe('appended')
+    // A binary search over 41 entries, not the ~41·log2(41) reads a sort costs.
+    expect(comparisons).toBeLessThanOrEqual(6)
+  })
+
+  it('reads only the newest timestamp when placing a tool call', () => {
+    const initial = Array.from({ length: 30 }, (_, index) =>
+      message({ id: `seed-${index}`, createdAt: index + 1 })
+    )
+    let state = hydrated(initial)
+    state = agentReducer(state, {
+      type: 'event',
+      event: upsertEvent(message({ id: 'warm', createdAt: 31 }))
+    })
+
+    let reads = 0
+    for (const entry of transcript(state)) {
+      Object.defineProperty(entry, 'createdAt', {
+        configurable: true,
+        enumerable: true,
+        get() {
+          reads += 1
+          return entry.updatedAt
+        }
+      })
+    }
+    state = agentReducer(state, {
+      type: 'event',
+      event: {
+        kind: 'tool_call_started',
+        conversationId: CONVERSATION_ID,
+        toolCallId: 'call-1',
+        name: 'search_notes',
+        args: {}
+      }
+    })
+
+    const messages = transcript(state)
+    expect(messages.at(-1)?.id).toBe('tool-call-call-1')
+    expect(messages.at(-1)?.createdAt).toBe(32)
+    // The old reduce read `createdAt` on all 31 messages just to find the max.
+    expect(reads).toBeLessThanOrEqual(6)
+  })
+
+  it('keeps the transcript ordered across streamed deltas and tool results', () => {
+    let state = hydrated([message({ id: 'a', createdAt: 100 })])
+    state = agentReducer(state, {
+      type: 'event',
+      event: upsertEvent(message({ id: 'b', createdAt: 200, text: '' }))
+    })
+    state = agentReducer(state, {
+      type: 'event',
+      event: {
+        kind: 'assistant_text_delta',
+        conversationId: CONVERSATION_ID,
+        messageId: 'b',
+        text: 'hello'
+      }
+    })
+    state = agentReducer(state, {
+      type: 'event',
+      event: {
+        kind: 'tool_call_started',
+        conversationId: CONVERSATION_ID,
+        toolCallId: 'call-1',
+        name: 'search_notes',
+        args: {}
+      }
+    })
+    state = agentReducer(state, {
+      type: 'event',
+      event: {
+        kind: 'tool_call_completed',
+        conversationId: CONVERSATION_ID,
+        toolCallId: 'call-1',
+        result: { ok: true }
+      }
+    })
+    state = agentReducer(state, {
+      type: 'event',
+      event: upsertEvent(message({ id: 'c', createdAt: 300 }))
+    })
+
+    expect(ids(transcript(state))).toEqual(['a', 'b', 'tool-call-call-1', 'c'])
+  })
+})

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/use-vault-item-icon.test.ts
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/use-vault-item-icon.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  clearVaultItemIconCache,
+  ICON_CACHE_LIMIT,
+  ICON_CACHE_TTL_MS,
+  lookupVaultItemIcon
+} from '../messages/use-vault-item-icon'
+
+const get = vi.fn(async (id: string) => ({ emoji: `icon-${id}` }))
+
+beforeEach(() => {
+  clearVaultItemIconCache()
+  get.mockClear()
+  get.mockImplementation(async (id: string) => ({ emoji: `icon-${id}` }))
+  ;(window as unknown as { api: unknown }).api = { notes: { get } }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('lookupVaultItemIcon', () => {
+  it('shares one in-flight request between concurrent callers', async () => {
+    const first = lookupVaultItemIcon('note', 'note-1')
+    const second = lookupVaultItemIcon('note', 'note-1')
+
+    expect(first).toBe(second)
+    await expect(first).resolves.toBe('icon-note-1')
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  it('serves a resolved icon from the cache', async () => {
+    await lookupVaultItemIcon('note', 'note-1')
+    await lookupVaultItemIcon('note', 'note-1')
+
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  it('caps the cache and drops the least recently used entry first', async () => {
+    for (let index = 0; index <= ICON_CACHE_LIMIT; index++) {
+      await lookupVaultItemIcon('note', `note-${index}`)
+    }
+    expect(get).toHaveBeenCalledTimes(ICON_CACHE_LIMIT + 1)
+
+    // The newest key is still cached, the oldest was evicted by the cap.
+    await lookupVaultItemIcon('note', `note-${ICON_CACHE_LIMIT}`)
+    expect(get).toHaveBeenCalledTimes(ICON_CACHE_LIMIT + 1)
+
+    await lookupVaultItemIcon('note', 'note-0')
+    expect(get).toHaveBeenCalledTimes(ICON_CACHE_LIMIT + 2)
+  })
+
+  it('keeps a re-read entry out of the eviction window', async () => {
+    await lookupVaultItemIcon('note', 'note-0')
+    for (let index = 1; index < ICON_CACHE_LIMIT; index++) {
+      await lookupVaultItemIcon('note', `note-${index}`)
+    }
+    // Re-reading note-0 makes it the most recent, so the next insert evicts note-1.
+    await lookupVaultItemIcon('note', 'note-0')
+    await lookupVaultItemIcon('note', 'overflow')
+    get.mockClear()
+
+    await lookupVaultItemIcon('note', 'note-0')
+    expect(get).not.toHaveBeenCalled()
+
+    await lookupVaultItemIcon('note', 'note-1')
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not cache a failed lookup as a permanent missing icon', async () => {
+    get.mockRejectedValueOnce(new Error('vault unavailable'))
+
+    await expect(lookupVaultItemIcon('note', 'note-1')).resolves.toBeNull()
+    expect(get).toHaveBeenCalledTimes(1)
+
+    await expect(lookupVaultItemIcon('note', 'note-1')).resolves.toBe('icon-note-1')
+    expect(get).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-reads an icon once its cached entry goes stale', async () => {
+    const start = Date.now()
+    const now = vi.spyOn(Date, 'now').mockReturnValue(start)
+
+    await lookupVaultItemIcon('note', 'note-1')
+    now.mockReturnValue(start + ICON_CACHE_TTL_MS - 1)
+    await lookupVaultItemIcon('note', 'note-1')
+    expect(get).toHaveBeenCalledTimes(1)
+
+    now.mockReturnValue(start + ICON_CACHE_TTL_MS)
+    await lookupVaultItemIcon('note', 'note-1')
+    expect(get).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves null without touching the vault for anything but notes', async () => {
+    await expect(lookupVaultItemIcon('task', 'task-1')).resolves.toBeNull()
+    await expect(lookupVaultItemIcon('note', undefined)).resolves.toBeNull()
+    expect(get).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
@@ -82,6 +82,47 @@ export const initialAgentState: AgentState = {
   error: null
 }
 
+/**
+ * Transcripts already known to be ordered by `createdAt`. Every array this
+ * reducer produces preserves that order, so once one is marked the next upsert
+ * can splice a message into place instead of re-sorting and re-copying the
+ * whole transcript on every streamed event. Arrays handed over by main are not
+ * marked, so the first upsert on one still pays for a sort — and marks its
+ * result. Keyed by array identity, so entries disappear with the transcript.
+ */
+const orderedTranscripts = new WeakSet<Message[]>()
+
+function markOrdered(messages: Message[]): Message[] {
+  orderedTranscripts.add(messages)
+  return messages
+}
+
+/** Positional copies (`slice`/`map`) keep `createdAt` order, so they inherit the mark. */
+function carryOrder(source: Message[], next: Message[]): Message[] {
+  return orderedTranscripts.has(source) ? markOrdered(next) : next
+}
+
+/** First index whose `createdAt` is greater than `createdAt`. Assumes an ordered array. */
+function upperBound(messages: Message[], createdAt: number): number {
+  let low = 0
+  let high = messages.length
+  while (low < high) {
+    const mid = (low + high) >>> 1
+    if (messages[mid].createdAt <= createdAt) low = mid + 1
+    else high = mid
+  }
+  return low
+}
+
+/** The original merge-then-sort, kept for transcripts whose order we cannot vouch for. */
+function sortMerged(messages: Message[], existing: number, nextMessage: Message): Message[] {
+  const merged =
+    existing === -1
+      ? [...messages, nextMessage]
+      : messages.map((message, index) => (index === existing ? nextMessage : message))
+  return markOrdered(merged.sort((left, right) => left.createdAt - right.createdAt))
+}
+
 function appendAssistantDelta(messages: Message[], event: AgentEvent): Message[] {
   if (event.kind !== 'assistant_text_delta') return messages
 
@@ -106,16 +147,37 @@ function appendAssistantDelta(messages: Message[], event: AgentEvent): Message[]
       }
     }
   }
-  return next
+  return carryOrder(messages, next)
 }
 
 function upsertMessage(messages: Message[], nextMessage: Message): Message[] {
   const existing = messages.findIndex((message) => message.id === nextMessage.id)
-  const next =
-    existing === -1
-      ? [...messages, nextMessage]
-      : messages.map((message, index) => (index === existing ? nextMessage : message))
-  return [...next].sort((left, right) => left.createdAt - right.createdAt)
+  // Unknown order, or a re-sent message whose timestamp moved: only a full sort
+  // can place it, so fall back to the original behaviour.
+  if (!orderedTranscripts.has(messages)) return sortMerged(messages, existing, nextMessage)
+  if (existing === -1) {
+    // A stable sort keeps an appended message last among equal timestamps, which
+    // is exactly the upper bound of its `createdAt` in an ordered transcript.
+    const next = messages.slice()
+    next.splice(upperBound(messages, nextMessage.createdAt), 0, nextMessage)
+    return markOrdered(next)
+  }
+  if (messages[existing].createdAt !== nextMessage.createdAt) {
+    return sortMerged(messages, existing, nextMessage)
+  }
+  // Same timestamp: a stable sort cannot move it past its equal-timestamp
+  // neighbours, so replacing in place is the same array the sort would produce.
+  const next = messages.slice()
+  next[existing] = nextMessage
+  return markOrdered(next)
+}
+
+/** Newest `createdAt` in the transcript; O(1) once the transcript order is known. */
+function newestCreatedAt(messages: Message[]): number {
+  if (!orderedTranscripts.has(messages)) {
+    return messages.reduce((max, message) => Math.max(max, message.createdAt), 0)
+  }
+  return Math.max(0, messages[messages.length - 1]?.createdAt ?? 0)
 }
 
 function upsertToolCallMessage(
@@ -128,7 +190,7 @@ function upsertToolCallMessage(
     status: ToolCallStatus
   }
 ): Message[] {
-  const newest = messages.reduce((max, message) => Math.max(max, message.createdAt), 0)
+  const newest = newestCreatedAt(messages)
   return upsertMessage(messages, {
     id: `tool-call-${input.toolCallId}`,
     conversationId: input.conversationId,
@@ -182,7 +244,7 @@ function updateToolCallStatus(
       }
     }
   })
-  return matched ? next : messages
+  return matched ? carryOrder(messages, next) : messages
 }
 
 function updateToolCallStatusIn(

--- a/apps/desktop/src/renderer/src/agent-chat/messages/use-vault-item-icon.ts
+++ b/apps/desktop/src/renderer/src/agent-chat/messages/use-vault-item-icon.ts
@@ -5,20 +5,37 @@ import { useEffect, useState } from 'react'
  * a memry:// href. The backend pipeline (tool results → model text → source
  * refs) only carries icons as best-effort hints; the vault is the source of
  * truth, and this works even while a turn is still streaming.
+ *
+ * A single agent session can link an unbounded number of distinct notes, so the
+ * cache is capped (least recently used first out) and entries go stale, rather
+ * than pinning one promise per note for the lifetime of the window and serving
+ * the icon a user has since changed.
  */
-const iconCache = new Map<string, Promise<string | null>>()
+export const ICON_CACHE_LIMIT = 128
+export const ICON_CACHE_TTL_MS = 5 * 60_000
+
+interface CachedIcon {
+  pending: Promise<string | null>
+  cachedAt: number
+}
+
+const iconCache = new Map<string, CachedIcon>()
 
 type VaultIconKind = 'note'
 
 async function fetchIcon(kind: VaultIconKind, id: string): Promise<string | null> {
-  try {
-    if (kind === 'note') {
-      const note = await window.api?.notes?.get?.(id)
-      return note?.emoji ?? null
-    }
-    return null
-  } catch {
-    return null
+  if (kind === 'note') {
+    const note = await window.api?.notes?.get?.(id)
+    return note?.emoji ?? null
+  }
+  return null
+}
+
+/** A Map iterates in insertion order, so its leading keys are the least recently used. */
+function evictOverflow(): void {
+  for (const key of iconCache.keys()) {
+    if (iconCache.size <= ICON_CACHE_LIMIT) break
+    iconCache.delete(key)
   }
 }
 
@@ -28,12 +45,28 @@ export function lookupVaultItemIcon(
 ): Promise<string | null> {
   if (kind !== 'note' || !id) return Promise.resolve(null)
   const key = `${kind}:${id}`
-  let pending = iconCache.get(key)
-  if (!pending) {
-    pending = fetchIcon(kind, id)
-    iconCache.set(key, pending)
+  const cached = iconCache.get(key)
+  if (cached) {
+    // Re-inserting counts the key as the most recently used one.
+    iconCache.delete(key)
+    if (Date.now() - cached.cachedAt < ICON_CACHE_TTL_MS) {
+      iconCache.set(key, cached)
+      return cached.pending
+    }
   }
-  return pending
+  const entry: CachedIcon = {
+    // Concurrent callers share this one in-flight request; a failed lookup is
+    // dropped again so the next one retries instead of inheriting a permanent
+    // "this note has no icon".
+    pending: fetchIcon(kind, id).catch(() => {
+      if (iconCache.get(key) === entry) iconCache.delete(key)
+      return null
+    }),
+    cachedAt: Date.now()
+  }
+  iconCache.set(key, entry)
+  evictOverflow()
+  return entry.pending
 }
 
 export function clearVaultItemIconCache(): void {


### PR DESCRIPTION
Closes #1082. Part of epic #987 (memory/CPU audit 2026-08).

## Validation

All three sub-problems were still live on `main` @ `0e272a690`. Nothing here overlaps the already-merged siblings — #1125 (transcript eviction), #1126 (per-token render scoping), #1127 (tool-result scoping), #1133 (derived `hasStreamingMessage`) all left `upsertMessage`, `upsertToolCallMessage` and the icon cache untouched. This is the first change to the allocation cost of those three call sites.

## What was wrong

1. `agent-context.reducer.ts:112-119` — `upsertMessage` merged the message and then ran `[...next].sort(...)` on **every** `message_upserted`: an O(N log N) sort plus **two** full array copies per event.
2. `agent-context.reducer.ts:131` — `upsertToolCallMessage` did `messages.reduce((max, m) => Math.max(max, m.createdAt), 0)`, walking the whole transcript just to find the newest timestamp, and then paid for (1) on top.
3. `messages/use-vault-item-icon.ts:9` — module-level `Map<string, Promise<string|null>>` with no cap, no TTL and no invalidation (`clearVaultItemIconCache` is only called from a test). It grew with every distinct note the agent ever linked and held it for the lifetime of the window. `fetchIcon` also swallowed errors into `null`, so one transient IPC failure was cached as a permanent "this note has no icon".

## What changed

**Reducer.** Transcripts arrive from main ordered by `createdAt` (`main/agent/storage/message-store.ts:190`, `orderBy(asc(agentMessages.createdAt))`) and every reducer path is a positional `slice`/`map` that preserves that order. Ordered transcripts are now tracked by array identity in a module-level `WeakSet`, and `upsertMessage` splices instead of sorting:

- new message → binary-searched upper-bound insert, one copy;
- re-sent message with the same `createdAt` → in-place replace, one copy;
- **anything else** (unknown order, or a re-send whose `createdAt` moved) → the original merge-then-sort, unchanged.

`upsertToolCallMessage` now reads the newest timestamp off the last entry when the order is known, else falls back to the old `reduce`.

**Icon cache.** LRU-capped at 128 entries with a 5-minute staleness window, still sharing a single in-flight promise between concurrent callers for the same key, and dropping a failed lookup from the cache (identity-checked, so a newer entry is never clobbered) so the next render retries. `fetchIcon` no longer swallows the error itself; `lookupVaultItemIcon` still resolves `null`, so callers are unaffected.

## How ordering equivalence was proved

`Array.prototype.sort` is stable, so for an already-ordered transcript:

- **Insert.** The appended message is last in pre-sort order, so a stable sort places it after every element with `createdAt <= c` and before every element with `createdAt > c` — exactly the upper bound of `c`. Everything else is already in order and cannot move.
- **Replace at index `e`.** Writing `p = clamp(e, lowerBound, upperBound)` for the array minus `e`, the message lands back at `p == e` **iff** `messages[e].createdAt === c`. That is the guard on the fast path; every other case takes the old sort, which is equivalent by definition.

`__tests__/agent-context-message-order.test.ts` keeps the old merge-then-sort verbatim as an oracle and asserts the reducer agrees with it message-for-message across shuffled arrivals, equal timestamps, a re-sent message that moves later, one that moves earlier, an unchanged re-send, and a transcript that arrives from main out of order. Two more tests instrument `createdAt` getters to count reads per event.

Before the fix (`git stash` of the two source files, tests kept):

```
× does not re-sort the transcript on every upsert
    AssertionError: expected 81 to be less than or equal to 6
× reads only the newest timestamp when placing a tool call
    AssertionError: expected 92 to be less than or equal to 6
× caps the cache and drops the least recently used entry first
× does not cache a failed lookup as a permanent missing icon
    AssertionError: expected null to be 'icon-note-1'
× re-reads an icon once its cached entry goes stale
 Test Files  2 failed (2)
      Tests  5 failed | 11 passed (16)
```

81 and 92 `createdAt` reads per event become 5 and 6. The ordering-oracle tests pass on both sides — that is the point: they are the guard that the new fast paths did not change what the user sees.

## Verification

```
$ pnpm exec vitest run --config config/vitest.config.ts --project renderer \
    src/renderer/src/agent-chat/__tests__/use-vault-item-icon.test.ts \
    src/renderer/src/agent-chat/__tests__/agent-context-message-order.test.ts
 Test Files  2 passed (2)
      Tests  16 passed (16)

$ pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/agent-chat
 Test Files  20 passed (20)
      Tests  172 passed (172)

$ pnpm --filter @memry/desktop typecheck:web      # clean
$ pnpm exec eslint <changed files>                # 0 errors
$ git diff --check                                # clean
```

Main process untouched, so no `typecheck:node` / `ipc:check` surface.

## For Kaan

`pnpm docs:impact --base origin/main --strict` reports `missing-docs` for the two changed desktop files. Nothing here is user-visible — no behaviour, setting, contract or format change — and there is no Agent Chat renderer-store page under `apps/docs/src/**` for an internal allocation fix to land in. Worth noting: the `MEMRY_DOCS_IMPACT_SKIP=1` escape hatch that `CLAUDE.md` documents is **not implemented** in `scripts/docs-impact.mjs` (`grep` finds no reference), so there is currently no way to acknowledge a genuinely non-docs desktop change. Sibling #1125 changed this same file and merged with no docs. Neither CI nor the pre-push hook runs the gate today, so this does not block the PR — but the missing flag is probably worth fixing separately.

Second, smaller call: the icon cache gets a 5-minute staleness window rather than the issue's suggested "invalidate on note icon change", which would need a note-update subscription living at module scope with no unsubscribe. Happy to swap it if you would rather have real invalidation.