### PR TITLE
fix(crdt): attribute a handshake-opened Y.Doc to the sender window

### DIFF
--- a/apps/desktop/src/main/ipc/crdt-handlers.ts
+++ b/apps/desktop/src/main/ipc/crdt-handlers.ts
@@ -104,10 +104,24 @@ export function registerCrdtIpcHandlers(): void {
     CRDT_CHANNELS.SYNC_STEP_1,
     createValidatedHandler(
       CrdtSyncStep1Schema,
-      async (input): Promise<CrdtSyncStep1Result | null> => {
+      async (input, event): Promise<CrdtSyncStep1Result | null> => {
         const provider = getCrdtProvider()
         if (!provider.isInitialized()) return null
-        const doc = await provider.open(input.noteId)
+
+        // The handshake can be the call that creates the doc: crdt:open-doc may
+        // have been skipped or errored, or a provider reset (vault switch) may
+        // have dropped the entry in between. Opening it here without the
+        // sender's windowId left the doc with an EMPTY windowIds set while the
+        // editor was about to type into it — so it counted as inactive, and the
+        // next eviction pass could destroy it mid-edit. applyIpcUpdate() then
+        // silently returns on the missing entry, dropping the keystrokes.
+        // Attribute it to exactly the window crdt:open-doc would have.
+        const win = BrowserWindow.fromWebContents(event.sender)
+        // Hook before the first await, mirroring open-doc: a window destroyed
+        // while open() is in flight has already emitted 'closed'.
+        if (win) hookWindowClose(win)
+
+        const doc = await provider.open(input.noteId, win?.id)
         const diff = Y.encodeStateAsUpdate(doc, input.stateVector)
         const stateVector = Y.encodeStateVector(doc)
         return { diff, stateVector }

--- a/apps/desktop/src/main/ipc/lib/register-command.test.ts
+++ b/apps/desktop/src/main/ipc/lib/register-command.test.ts
@@ -59,7 +59,9 @@ describe('registerCommand', () => {
     const result = await registeredHandler({}, { id: 'abc' })
 
     // #then
-    expect(command).toHaveBeenCalledWith({ id: 'abc' })
+    // The invoke event trails the validated input for handlers that need the
+    // sender window; this one ignores it.
+    expect(command).toHaveBeenCalledWith({ id: 'abc' }, expect.anything())
     expect(result).toEqual({ success: true, id: 'abc' })
   })
 

--- a/apps/desktop/src/main/ipc/validate.ts
+++ b/apps/desktop/src/main/ipc/validate.ts
@@ -41,7 +41,9 @@ const trackIpcError = (action: string, error: unknown): void => {
  * Throws an error with validation details if input is invalid.
  *
  * @param schema - Zod schema to validate input against
- * @param handler - Handler function that receives validated input
+ * @param handler - Handler function that receives validated input, plus the raw
+ *   invoke event for the handlers that need to attribute work to the sender
+ *   window (CRDT doc ownership). Handlers that ignore it stay one-parameter.
  * @returns IPC handler function compatible with ipcMain.handle
  *
  * @example
@@ -61,12 +63,12 @@ const trackIpcError = (action: string, error: unknown): void => {
  */
 export function createValidatedHandler<TSchema extends z.ZodSchema, TResult>(
   schema: TSchema,
-  handler: (input: z.infer<TSchema>) => TResult | Promise<TResult>
+  handler: (input: z.infer<TSchema>, event: IpcMainInvokeEvent) => TResult | Promise<TResult>
 ): (event: IpcMainInvokeEvent, rawInput: z.input<TSchema>) => Promise<TResult> {
-  return async (_event: IpcMainInvokeEvent, rawInput: z.input<TSchema>): Promise<TResult> => {
+  return async (event: IpcMainInvokeEvent, rawInput: z.input<TSchema>): Promise<TResult> => {
     try {
       const validated = schema.parse(rawInput)
-      return await handler(validated)
+      return await handler(validated, event)
     } catch (error) {
       if (error instanceof ZodError) {
         const issues = error.issues ?? (error as { errors?: unknown[] }).errors ?? []

--- a/apps/desktop/src/main/ipc/vault-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/vault-handlers.test.ts
@@ -355,7 +355,7 @@ describe('vault-handlers', () => {
 
       const result = await invokeHandler(VaultChannels.invoke.REMOVE, '/path/to/vault')
 
-      expect(vault.removeVault).toHaveBeenCalledWith('/path/to/vault')
+      expect(vault.removeVault).toHaveBeenCalledWith('/path/to/vault', expect.anything())
       expect(result).toBeUndefined()
     })
   })

--- a/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
+++ b/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
 
 import { invokeHandler, mockIpcMain, resetIpcMocks } from '@tests/utils/mock-ipc'
 import { CRDT_CHANNELS } from '@memry/contracts/ipc-crdt'
@@ -232,6 +233,113 @@ describe('CRDT IPC handlers — lifecycle resilience', () => {
       await vi.waitFor(() => {
         expect(provider.getOpenNoteIds()).toEqual([])
       })
+    })
+  })
+
+  describe('the sync handshake attributes the doc to the sender window', () => {
+    const handshake = (noteId: string): Promise<unknown> =>
+      invokeHandler(CRDT_CHANNELS.SYNC_STEP_1, { noteId, stateVector: new Uint8Array([0]) })
+
+    beforeEach(() => {
+      senderWindow.current = { id: 77, once: vi.fn() }
+      mockGetNoteCacheById.mockReturnValue({ id: 'n1', path: 'n1.md', fileType: 'markdown' })
+    })
+
+    it('leaves a handshake-opened doc ineligible for eviction while it is in use', async () => {
+      // crdt:open-doc can be skipped or fail, or a provider reset can drop the
+      // entry — then the handshake is what creates the doc. Opened with no
+      // windowId it had an empty windowIds set, so the doc the editor was about
+      // to type into counted as inactive and was evictable mid-edit.
+      const provider = getCrdtProvider()
+      await provider.init()
+
+      // #when — only the handshake runs, no crdt:open-doc
+      await handshake('n1')
+
+      // #then — closeIfInactive() is the exact primitive the eviction pass runs
+      // per doc; it must refuse this one.
+      await expect(provider.closeIfInactive('n1')).resolves.toBe(false)
+      expect(provider.getOpenNoteIds({ active: true })).toEqual(['n1'])
+    })
+
+    it('keeps an edit that lands after an eviction pass instead of dropping it', async () => {
+      // The eviction destroyed the entry, and applyIpcUpdate() returns early on
+      // a missing entry — so the keystrokes were silently lost.
+      const provider = getCrdtProvider()
+      await provider.init()
+      await handshake('n1')
+
+      // #given — an eviction pass sweeps while the editor is still open
+      await provider.closeIfInactive('n1')
+
+      // #when — the renderer sends the next edit
+      const source = new Y.Doc()
+      source.getMap('probe').set('typed', 'after-eviction-pass')
+      await invokeHandler(CRDT_CHANNELS.APPLY_UPDATE, {
+        noteId: 'n1',
+        update: Y.encodeStateAsUpdate(source)
+      })
+
+      // #then — the update reached the live doc
+      expect(provider.getDoc('n1')?.getMap('probe').get('typed')).toBe('after-eviction-pass')
+    })
+
+    it('hooks the sender window once, not once per handshake', async () => {
+      // Stacking a 'closed' listener per doc would trip Electron's
+      // max-listeners warning on a window holding dozens of notes.
+      const provider = getCrdtProvider()
+      await provider.init()
+
+      await handshake('n1')
+      await handshake('n2')
+      await handshake('n3')
+
+      expect(senderWindow.current.once).toHaveBeenCalledTimes(1)
+      expect(senderWindow.current.once).toHaveBeenCalledWith('closed', expect.any(Function))
+    })
+
+    it('releases the attribution when the window is destroyed', async () => {
+      // The other half of the bug: an id that is never released pins the doc
+      // for the session and disables eviction and compaction with it.
+      const provider = getCrdtProvider()
+      await provider.init()
+      await handshake('n1')
+      await handshake('n2')
+
+      // #when — ⌘W / renderer crash: the window emits 'closed'
+      const onClosed = senderWindow.current.once.mock.calls[0][1] as () => void
+      onClosed()
+
+      // #then — both docs released, so eviction and compaction see them again
+      await vi.waitFor(() => {
+        expect(provider.getOpenNoteIds()).toEqual([])
+      })
+    })
+
+    it('releases the attribution on crdt:close-doc', async () => {
+      // The renderer sends this on unmount, including the remount after a
+      // window reload — the handshake-recorded id must clear the same way.
+      const provider = getCrdtProvider()
+      await provider.init()
+      await handshake('n1')
+
+      // #when
+      await invokeHandler(CRDT_CHANNELS.CLOSE_DOC, { noteId: 'n1' })
+
+      // #then
+      expect(provider.getOpenNoteIds()).toEqual([])
+    })
+
+    it('releases the attribution when the vault closes', async () => {
+      const provider = getCrdtProvider()
+      await provider.init()
+      await handshake('n1')
+
+      // #when — vault close/switch tears the provider down
+      await provider.destroy()
+
+      // #then
+      expect(provider.getOpenNoteIds()).toEqual([])
     })
   })
 

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -74,6 +74,20 @@ targets docs with zero attached windows, so active editor docs are never evicted
 provider metrics expose the open doc count, encoded size, and per-doc `windowCount`
 so memory growth can be observed without inspecting private provider state.
 
+Because "attached window" is what makes a doc safe from eviction, every IPC entry point
+that can open a doc attributes it to the sender window — `crdt:open-doc` and the
+`crdt:sync-step-1` handshake alike. The handshake matters because it can be the call that
+creates the doc: `crdt:open-doc` may have been skipped or failed, or a provider reset
+during a vault switch may have dropped the entry in between. A doc opened without a window
+would count as inactive while an editor was typing into it, and an update that arrives
+after its entry is gone is dropped rather than applied.
+
+Attribution is released on every path that ends a window's interest in a doc, so it never
+pins a doc for the rest of the session: the renderer's `crdt:close-doc` on unmount, a
+`closed` hook per window for ⌘W and renderer crashes, a broadcast-time backstop for any
+window that turns out to be gone, and provider teardown on vault close or switch. Once
+released, the doc is evictable and compactable again.
+
 ## IPC Loop Prevention
 
 Three pieces of metadata prevent feedback loops:


### PR DESCRIPTION
## What was wrong

`apps/desktop/src/main/ipc/crdt-handlers.ts:110` — the `crdt:sync-step-1` handler called
`provider.open(input.noteId)` with **no windowId**.

The handshake can be the call that actually creates the doc: `crdt:open-doc` may have been
skipped or returned an error, or a provider reset (vault switch) may have dropped the entry
between the two invokes. In that case the doc landed in `CrdtProvider.docs` with an **empty
`windowIds` set** while the editor was about to type into it.

That makes it indistinguishable from a cached, unused doc:

- `evictInactiveDocsIfNeeded` (`crdt-provider.ts:849-852`) selects on `windowIds.size === 0`,
  so opening any other note could evict this one **mid-edit**.
- `applyIpcUpdate` (`crdt-provider.ts:946-948`) is `if (!entry) return` — once the entry is
  gone, the renderer's next keystrokes are **silently dropped**. That is the primary defect
  here: unflushed CRDT updates lost, not just wasted memory.

Exact mirror image of #999 — that bug pinned docs forever, this one leaves an in-use doc
unpinned.

## What changed

- `crdt-handlers.ts` — the handshake resolves `BrowserWindow.fromWebContents(event.sender)`,
  registers the same per-window `closed` hook `crdt:open-doc` uses, and passes `win?.id` into
  `provider.open()`.
- `validate.ts` — `createValidatedHandler` now forwards the invoke event to its handler as a
  second argument, so a validated handler can attribute work to the sender window. Handlers
  that do not need it stay one-parameter and are unchanged.
- `apps/docs/src/architecture/crdt.md` — documents that every IPC entry point which can open
  a doc attributes it to the sender window, and every path that releases it.

No change to the on-disk CRDT format or the sync wire protocol. `pnpm ipc:generate` produced
no diff — the IPC contract is untouched, so old and new renderers interoperate.

## How both failure modes were avoided

**(a) Re-creating #999's permanent pinning / re-disabling compaction.** On the normal path the
windowId recorded here is *the same id `crdt:open-doc` already recorded* for the same
webContents — so the common case adds no new pinning surface at all. Beyond that, the
attribution is released by every existing release path, each covered by a test:

- **window close** — `hookWindowClose` is registered before the first `await` (a window
  destroyed while `open()` is in flight has already emitted `closed`), and one listener per
  *window*, not per doc, so a window with dozens of notes cannot trip Electron's max-listeners
  warning. `forgetWindow` → `closeIfInactive` flushes to persistence before destroying.
- **renderer unmount / reload remount** — `crdt:close-doc`, which `YjsIpcProvider.disconnect()`
  always sends.
- **vault close/switch** — `provider.destroy()` clears every doc.
- **window already gone** — the existing `broadcastToWindows` backstop still sheds the id.

Tests assert the doc is fully released (`getOpenNoteIds() === []`) after each, i.e. evictable
and compactable again — not merely "still present".

**(b) Leaving it unattributed and keeping the mid-edit eviction risk.** The handshake now
always attributes when a sender window resolves, and the tests drive the real eviction
primitive rather than asserting on internals.

## Tests

New `describe` in `apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts`, exercising the real
`CrdtProvider` through the registered IPC handlers (not mocked IPC):

- a handshake-opened doc makes `closeIfInactive` return `false` — `closeIfInactive` is the exact
  per-doc primitive the eviction pass runs
- an edit applied after an eviction pass still reaches the doc (the no-update-lost case)
- the window is hooked once, not once per handshake
- attribution released on window `closed`, on `crdt:close-doc`, and on vault close

Mutation-tested: with the handler fix reverted, **4 of the 6 new tests fail** (the 2 that pass
either way are the anti-#999 release guards, which is expected).

Two pre-existing assertions (`register-command.test.ts`, `vault-handlers.test.ts`) used
exact-argument matching and now see the trailing event; they assert "forwards validated data",
so they were widened with `expect.anything()` rather than changed in meaning.

## Verification

- `pnpm --filter @memry/desktop test:main` → `Test Files 497 passed | 1 skipped (498)`,
  `Tests 5929 passed | 1 expected fail | 4 skipped (5934)`
- `pnpm --filter @memry/desktop typecheck:node` → clean
- `pnpm exec eslint <changed files>` → 0 errors
- `pnpm ipc:generate` → no diff; `pnpm ipc:check` → "IPC invoke map is up to date"
- `pnpm docs:impact --base origin/main --strict` → `covered`; `pnpm docs:build` → build complete
- `git diff --check` → clean

Closes #1084
Part of epic #987
