### PR TITLE
perf(crdt): route renderer CRDT updates per note instead of one global fan-out

### DIFF
--- a/apps/desktop/src/preload/api/preload-api.test.ts
+++ b/apps/desktop/src/preload/api/preload-api.test.ts
@@ -26,7 +26,7 @@ import { remindersApi, reminderEvents } from './reminders'
 import { graphApi, searchApi, searchEvents } from './search'
 import { syncEvents } from './sync-events'
 import { syncAuth, syncSetup, syncLinking, accountApi, syncDevices } from './sync-identity'
-import { syncOps, cryptoApi, syncAttachments, syncCrdt, onCrdtStateChanged } from './sync-ops'
+import { syncOps, cryptoApi, syncAttachments, syncCrdt } from './sync-ops'
 import { tagsApi, tagEvents } from './tags'
 import { updaterApi, updaterEvents } from './updater'
 import { vaultApi, vaultEvents } from './vault'
@@ -1039,7 +1039,8 @@ describe('preload api wrappers', () => {
       () => syncEvents.onVaultRecoveryNeeded(callback),
       SYNC_EVENTS.VAULT_RECOVERY_NEEDED
     )
-    expectSubscribe(() => onCrdtStateChanged(callback), SYNC_EVENTS.STATE_CHANGED)
+    // `onCrdtStateChanged` is note-scoped rather than a plain channel wrapper —
+    // its routing and listener lifetime are covered in `sync-ops.test.ts`.
     expectSubscribe(
       () => updaterEvents.onUpdaterStateChanged(callback),
       UpdaterChannels.events.STATE_CHANGED

--- a/apps/desktop/src/preload/api/sync-ops.test.ts
+++ b/apps/desktop/src/preload/api/sync-ops.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SYNC_EVENTS } from '@memry/contracts/ipc-sync'
+
+const electronMock = vi.hoisted(() => ({
+  ipcRenderer: {
+    invoke: vi.fn(),
+    send: vi.fn(),
+    sendSync: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn()
+  }
+}))
+
+vi.mock('electron', () => electronMock)
+
+import { onCrdtStateChanged } from './sync-ops'
+
+type StateChangedPayload = { noteId: string; update: Uint8Array; origin: string }
+
+/**
+ * Stand-in for the main process broadcasting on the shared CRDT channel: pushes
+ * a payload through whatever handler the preload registry attached to
+ * `ipcRenderer`, exactly as Electron would.
+ */
+function broadcast(payload: StateChangedPayload): void {
+  const attached = electronMock.ipcRenderer.on.mock.calls.filter(
+    ([channel]) => channel === SYNC_EVENTS.STATE_CHANGED
+  )
+  const removed = electronMock.ipcRenderer.removeListener.mock.calls.filter(
+    ([channel]) => channel === SYNC_EVENTS.STATE_CHANGED
+  )
+  const live = attached
+    .map(([, handler]) => handler as (event: unknown, data: unknown) => void)
+    .filter((handler) => !removed.some(([, removedHandler]) => removedHandler === handler))
+
+  for (const handler of live) handler({}, payload)
+}
+
+function liveListenerCount(): number {
+  const attached = electronMock.ipcRenderer.on.mock.calls.filter(
+    ([channel]) => channel === SYNC_EVENTS.STATE_CHANGED
+  )
+  const removed = electronMock.ipcRenderer.removeListener.mock.calls.filter(
+    ([channel]) => channel === SYNC_EVENTS.STATE_CHANGED
+  )
+  return attached.length - removed.length
+}
+
+function update(value: string): Uint8Array {
+  return new TextEncoder().encode(value)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('onCrdtStateChanged note routing', () => {
+  it('delivers a note update only to that note’s subscriber', () => {
+    // #given — two open notes, each with its own subscriber
+    const noteA = vi.fn()
+    const noteB = vi.fn()
+    const offA = onCrdtStateChanged('note-a', noteA)
+    const offB = onCrdtStateChanged('note-b', noteB)
+
+    // #when — the main process broadcasts an update for note A
+    broadcast({ noteId: 'note-a', update: update('a'), origin: 'local' })
+
+    // #then — note B's provider is never woken, and never sees A's bytes
+    expect(noteA).toHaveBeenCalledTimes(1)
+    expect(noteA).toHaveBeenCalledWith({
+      noteId: 'note-a',
+      update: update('a'),
+      origin: 'local'
+    })
+    expect(noteB).not.toHaveBeenCalled()
+
+    offA()
+    offB()
+  })
+
+  it('keeps every subscriber of the same note (registry is not last-writer-wins)', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const offFirst = onCrdtStateChanged('note-a', first)
+    const offSecond = onCrdtStateChanged('note-a', second)
+
+    broadcast({ noteId: 'note-a', update: update('a'), origin: 'network' })
+
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).toHaveBeenCalledTimes(1)
+
+    offFirst()
+    offSecond()
+  })
+
+  it('drops updates for notes nobody subscribed to without throwing', () => {
+    const noteA = vi.fn()
+    const off = onCrdtStateChanged('note-a', noteA)
+
+    expect(() =>
+      broadcast({ noteId: 'note-unknown', update: update('x'), origin: 'local' })
+    ).not.toThrow()
+    expect(noteA).not.toHaveBeenCalled()
+
+    off()
+  })
+
+  it('isolates a throwing subscriber from the others on the same note', () => {
+    const boom = vi.fn(() => {
+      throw new Error('subscriber exploded')
+    })
+    const healthy = vi.fn()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const offBoom = onCrdtStateChanged('note-a', boom)
+    const offHealthy = onCrdtStateChanged('note-a', healthy)
+
+    broadcast({ noteId: 'note-a', update: update('a'), origin: 'local' })
+
+    expect(boom).toHaveBeenCalledTimes(1)
+    expect(healthy).toHaveBeenCalledTimes(1)
+    expect(consoleError).toHaveBeenCalled()
+
+    offBoom()
+    offHealthy()
+  })
+
+  it('tolerates a subscriber that unsubscribes itself mid-dispatch', () => {
+    const other = vi.fn()
+    let offSelf = (): void => {}
+    const selfClosing = vi.fn(() => offSelf())
+    offSelf = onCrdtStateChanged('note-a', selfClosing)
+    const offOther = onCrdtStateChanged('note-a', other)
+
+    expect(() =>
+      broadcast({ noteId: 'note-a', update: update('a'), origin: 'local' })
+    ).not.toThrow()
+    expect(other).toHaveBeenCalledTimes(1)
+
+    offOther()
+  })
+})
+
+describe('onCrdtStateChanged listener lifetime', () => {
+  it('attaches the channel listener synchronously so no broadcast is missed', () => {
+    // #given/#when — the very first broadcast lands the instant we subscribe
+    const noteA = vi.fn()
+    const off = onCrdtStateChanged('note-a', noteA)
+
+    // #then — the ipcRenderer listener already exists, so nothing is lost in the
+    // gap between opening a note and its provider being wired.
+    expect(liveListenerCount()).toBe(1)
+    broadcast({ noteId: 'note-a', update: update('a'), origin: 'local' })
+    expect(noteA).toHaveBeenCalledTimes(1)
+
+    off()
+  })
+
+  it('shares one ipcRenderer listener across many open notes', () => {
+    const unsubscribes = Array.from({ length: 25 }, (_, index) =>
+      onCrdtStateChanged(`note-${index}`, vi.fn())
+    )
+
+    expect(liveListenerCount()).toBe(1)
+
+    for (const off of unsubscribes) off()
+    expect(liveListenerCount()).toBe(0)
+  })
+
+  it('keeps the channel listener while any other note is still subscribed', () => {
+    const noteB = vi.fn()
+    const offA = onCrdtStateChanged('note-a', vi.fn())
+    const offB = onCrdtStateChanged('note-b', noteB)
+
+    offA()
+
+    expect(liveListenerCount()).toBe(1)
+    broadcast({ noteId: 'note-b', update: update('b'), origin: 'local' })
+    expect(noteB).toHaveBeenCalledTimes(1)
+
+    offB()
+    expect(liveListenerCount()).toBe(0)
+  })
+
+  it('stays bounded across many open/close cycles', () => {
+    // #given/#when — 200 open→close cycles, the shape of a user tabbing around
+    for (let cycle = 0; cycle < 200; cycle += 1) {
+      const off = onCrdtStateChanged(`note-${cycle}`, vi.fn())
+      expect(liveListenerCount()).toBe(1)
+      off()
+    }
+
+    // #then — nothing accumulates: no leaked ipcRenderer listener, and the
+    // closed notes leave no per-note bucket behind (a leak would keep the
+    // channel listener attached).
+    expect(liveListenerCount()).toBe(0)
+  })
+
+  it('is idempotent on repeated unsubscribe and does not detach a live listener', () => {
+    const noteB = vi.fn()
+    const offA = onCrdtStateChanged('note-a', vi.fn())
+    offA()
+    expect(liveListenerCount()).toBe(0)
+
+    const offB = onCrdtStateChanged('note-b', noteB)
+    offA()
+
+    expect(liveListenerCount()).toBe(1)
+    broadcast({ noteId: 'note-b', update: update('b'), origin: 'local' })
+    expect(noteB).toHaveBeenCalledTimes(1)
+
+    offB()
+  })
+
+  it('re-arms cleanly after a full teardown (vault switch)', () => {
+    // #given — a vault's notes are open
+    const beforeSwitch = vi.fn()
+    const offBefore = onCrdtStateChanged('note-a', beforeSwitch)
+
+    // #when — the vault switch tears every provider down, then the new vault's
+    // notes subscribe
+    offBefore()
+    expect(liveListenerCount()).toBe(0)
+
+    const afterSwitch = vi.fn()
+    const offAfter = onCrdtStateChanged('note-a', afterSwitch)
+
+    // #then — exactly one listener again, delivering to the new subscriber only
+    expect(liveListenerCount()).toBe(1)
+    broadcast({ noteId: 'note-a', update: update('a'), origin: 'local' })
+    expect(afterSwitch).toHaveBeenCalledTimes(1)
+    expect(beforeSwitch).not.toHaveBeenCalled()
+
+    offAfter()
+  })
+})

--- a/apps/desktop/src/preload/api/sync-ops.ts
+++ b/apps/desktop/src/preload/api/sync-ops.ts
@@ -1,5 +1,5 @@
 import { SYNC_CHANNELS, SYNC_EVENTS } from '@memry/contracts/ipc-sync'
-import { invoke, subscribe } from '../lib/ipc'
+import { invoke, logListenerError, subscribe } from '../lib/ipc'
 
 export const syncOps = {
   getStatus: () => invoke(SYNC_CHANNELS.GET_STATUS),
@@ -66,10 +66,69 @@ export const syncCrdt = {
     invoke(SYNC_CHANNELS.SYNC_STEP_2, input)
 }
 
+type CrdtStateChangedPayload = { noteId: string; update: Uint8Array; origin: string }
+type CrdtStateChangedCallback = (data: CrdtStateChangedPayload) => void
+
+/**
+ * CRDT updates arrive on one global channel, but each subscriber only ever
+ * wants one note. Subscribing every open editor's provider to the raw channel
+ * made every keystroke in any note walk all N provider callbacks; this registry
+ * keeps a single channel subscription for the window and dispatches by noteId,
+ * so the cost per update is one map lookup regardless of how many notes are open.
+ */
+const crdtNoteSubscribers = new Map<string, Set<CrdtStateChangedCallback>>()
+let crdtChannelCleanup: (() => void) | null = null
+
+const dispatchCrdtStateChanged = (data: CrdtStateChangedPayload): void => {
+  const subscribers = crdtNoteSubscribers.get(data.noteId)
+  if (!subscribers) return
+  // Snapshot: a callback may unsubscribe itself (teardown) mid-dispatch. The
+  // per-callback guard mirrors `subscribe()` — one throwing provider must not
+  // starve the others registered for the same note.
+  for (const callback of [...subscribers]) {
+    try {
+      callback(data)
+    } catch (error) {
+      logListenerError(SYNC_EVENTS.STATE_CHANGED, error)
+    }
+  }
+}
+
 export const onCrdtStateChanged = (
-  callback: (data: { noteId: string; update: Uint8Array; origin: string }) => void
-): (() => void) =>
-  subscribe<{ noteId: string; update: Uint8Array; origin: string }>(
+  noteId: string,
+  callback: CrdtStateChangedCallback
+): (() => void) => {
+  let subscribers = crdtNoteSubscribers.get(noteId)
+  if (!subscribers) {
+    subscribers = new Set()
+    crdtNoteSubscribers.set(noteId, subscribers)
+  }
+  subscribers.add(callback)
+
+  // Attach the channel listener before returning so the caller is live from the
+  // moment it subscribes — no window where a main-process broadcast is dropped.
+  crdtChannelCleanup ??= subscribe<CrdtStateChangedPayload>(
     SYNC_EVENTS.STATE_CHANGED,
-    callback
+    dispatchCrdtStateChanged
   )
+
+  let unsubscribed = false
+  return () => {
+    if (unsubscribed) return
+    unsubscribed = true
+
+    const current = crdtNoteSubscribers.get(noteId)
+    if (!current) return
+    current.delete(callback)
+    if (current.size > 0) return
+
+    // Drop the note's bucket so closed notes cannot accumulate, and release the
+    // channel listener entirely once nothing is listening (note close, window
+    // reload, vault switch).
+    crdtNoteSubscribers.delete(noteId)
+    if (crdtNoteSubscribers.size === 0) {
+      crdtChannelCleanup?.()
+      crdtChannelCleanup = null
+    }
+  }
+}

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1864,6 +1864,7 @@ interface API extends WindowAPI, GeneratedRpcApi {
   onMainInvoke: (callback: (payload: MainInvokePayload) => void | Promise<void>) => () => void
   respondToMainInvoke: (requestId: string, response: unknown) => void
   onCrdtStateChanged: (
+    noteId: string,
     callback: (data: { noteId: string; update: Uint8Array; origin: string }) => void
   ) => () => void
   onFlushRequested: (callback: (requestId?: string) => void) => () => void

--- a/apps/desktop/src/preload/lib/ipc.ts
+++ b/apps/desktop/src/preload/lib/ipc.ts
@@ -15,7 +15,7 @@ import type {
  * it on this world's global. Falling back to console keeps the failure visible
  * when it isn't there (tests, or an initialize that didn't run).
  */
-function logListenerError(channel: string, error: unknown): void {
+export function logListenerError(channel: string, error: unknown): void {
   const message = `[PreloadIpc] Listener for "${channel}" threw`
   const sink = (globalThis as typeof globalThis & { __electronLog?: unknown }).__electronLog as
     | { error?: (...data: unknown[]) => void }

--- a/apps/desktop/src/renderer/src/sync/yjs-ipc-provider.test.ts
+++ b/apps/desktop/src/renderer/src/sync/yjs-ipc-provider.test.ts
@@ -10,7 +10,28 @@ const mockOpenDoc = vi.fn()
 const mockApplyUpdate = vi.fn()
 const mockSyncStep1 = vi.fn()
 const mockSyncStep2 = vi.fn()
-const mockOnCrdtStateChanged = vi.fn(() => () => {})
+type StateChangedPayload = { noteId: string; update: Uint8Array; origin: string }
+type StateChangedCallback = (data: StateChangedPayload) => void
+
+/**
+ * Mirrors the preload registry (`preload/api/sync-ops.ts`): subscriptions are
+ * note-scoped and a broadcast only reaches that note's subscribers. Testing the
+ * provider against a global fan-out fake would hide a misrouted update.
+ */
+const noteSubscribers = new Map<string, Set<StateChangedCallback>>()
+const mockOnCrdtStateChanged = vi.fn((noteId: string, callback: StateChangedCallback) => {
+  const subscribers = noteSubscribers.get(noteId) ?? new Set<StateChangedCallback>()
+  subscribers.add(callback)
+  noteSubscribers.set(noteId, subscribers)
+  return () => {
+    subscribers.delete(callback)
+    if (subscribers.size === 0) noteSubscribers.delete(noteId)
+  }
+})
+
+function broadcastStateChanged(payload: StateChangedPayload): void {
+  for (const callback of [...(noteSubscribers.get(payload.noteId) ?? [])]) callback(payload)
+}
 
 beforeEach(() => {
   mockOpenDoc.mockResolvedValue({ success: true })
@@ -33,6 +54,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks()
+  noteSubscribers.clear()
 })
 
 vi.mock('@/lib/logger', () => ({
@@ -97,29 +119,24 @@ describe('YjsIpcProvider.connect', () => {
   })
 
   it('applies matching IPC updates and forwards local document updates', async () => {
-    let stateChanged:
-      | ((data: { noteId: string; update: Uint8Array; origin: string }) => void)
-      | null = null
-    mockOnCrdtStateChanged.mockImplementationOnce((callback) => {
-      stateChanged = callback
-      return vi.fn()
-    })
-
     const doc = new Y.Doc()
     const provider = new YjsIpcProvider({ noteId: 'note-42', doc })
 
     await provider.connect()
 
+    // The provider claims its own note, not the global channel.
+    expect(mockOnCrdtStateChanged).toHaveBeenCalledWith('note-42', expect.any(Function))
+
     const otherDoc = new Y.Doc()
     otherDoc.getMap('meta').set('remote', true)
-    stateChanged?.({
+    broadcastStateChanged({
       noteId: 'other-note',
       update: Y.encodeStateAsUpdate(otherDoc),
       origin: 'remote'
     })
     expect(doc.getMap('meta').get('remote')).toBeUndefined()
 
-    stateChanged?.({
+    broadcastStateChanged({
       noteId: 'note-42',
       update: Y.encodeStateAsUpdate(otherDoc),
       origin: 'remote'
@@ -156,6 +173,75 @@ describe('YjsIpcProvider.connect', () => {
     expect(mockSyncStep1).not.toHaveBeenCalled()
 
     doc.destroy()
+  })
+})
+
+describe('YjsIpcProvider note-scoped subscription', () => {
+  it('never wakes another note’s provider for an update it does not own', async () => {
+    // #given — two notes open in the same window, the shape that used to make
+    // every provider run for every keystroke in any note
+    const docA = new Y.Doc()
+    const docB = new Y.Doc()
+    const providerA = new YjsIpcProvider({ noteId: 'note-a', doc: docA })
+    const providerB = new YjsIpcProvider({ noteId: 'note-b', doc: docB })
+    await providerA.connect()
+    await providerB.connect()
+
+    const sourceDoc = new Y.Doc()
+    sourceDoc.getMap('meta').set('remote', true)
+
+    // #when — an update lands for note A only
+    broadcastStateChanged({
+      noteId: 'note-a',
+      update: Y.encodeStateAsUpdate(sourceDoc),
+      origin: 'remote'
+    })
+
+    // #then — A applied it, B was not invoked at all and its doc is untouched
+    expect(docA.getMap('meta').get('remote')).toBe(true)
+    expect(docB.getMap('meta').get('remote')).toBeUndefined()
+    expect(noteSubscribers.get('note-b')?.size).toBe(1)
+
+    providerA.destroy()
+    providerB.destroy()
+    docA.destroy()
+    docB.destroy()
+    sourceDoc.destroy()
+  })
+
+  it('releases its subscription on destroy so repeated open/close stays bounded', async () => {
+    // #given/#when — 50 open→close cycles of the same note
+    for (let cycle = 0; cycle < 50; cycle += 1) {
+      const doc = new Y.Doc()
+      const provider = new YjsIpcProvider({ noteId: 'note-cycled', doc })
+      await provider.connect()
+      expect(noteSubscribers.get('note-cycled')?.size).toBe(1)
+      provider.destroy()
+      doc.destroy()
+    }
+
+    // #then — nothing accumulates for a note that was opened and closed
+    expect(noteSubscribers.has('note-cycled')).toBe(false)
+  })
+
+  it('stops applying updates for a note after the provider is destroyed', async () => {
+    const doc = new Y.Doc()
+    const provider = new YjsIpcProvider({ noteId: 'note-42', doc })
+    await provider.connect()
+    provider.destroy()
+
+    const sourceDoc = new Y.Doc()
+    sourceDoc.getMap('meta').set('remote', true)
+    broadcastStateChanged({
+      noteId: 'note-42',
+      update: Y.encodeStateAsUpdate(sourceDoc),
+      origin: 'remote'
+    })
+
+    expect(doc.getMap('meta').get('remote')).toBeUndefined()
+
+    doc.destroy()
+    sourceDoc.destroy()
   })
 })
 

--- a/apps/desktop/src/renderer/src/sync/yjs-ipc-provider.ts
+++ b/apps/desktop/src/renderer/src/sync/yjs-ipc-provider.ts
@@ -30,7 +30,12 @@ export class YjsIpcProvider extends Observable<string> {
     }
     this.doc.on('update', this.updateHandler)
 
+    // Note-scoped subscription: the preload registry dispatches by noteId, so
+    // this provider is no longer woken by every other open note's updates. The
+    // id check stays as a cheap assertion — applying another note's update to
+    // this doc would be silent corruption, so it must never be reachable.
     this.ipcCleanup = window.api.onCrdtStateChanged(
+      this.noteId,
       (data: { noteId: string; update: Uint8Array; origin: string }) => {
         if (data.noteId !== this.noteId) return
         Y.applyUpdate(this.doc, data.update, 'remote')

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -63,6 +63,19 @@ opening.
 - Persistence via y-leveldb is a Node-side concern.
 - Main can broadcast updates to multiple renderer windows (when split view exists).
 
+## Renderer Update Delivery
+
+Main broadcasts every CRDT update on one channel (`crdt:state-changed`), scoped to the
+windows attached to that doc. Inside a window, the preload layer keeps a
+`noteId → subscribers` registry behind a single channel listener, so an update is
+dispatched only to the provider that owns the note. Opening ten notes still installs one
+Electron listener, and a keystroke in one note does not wake the other nine providers.
+
+Each provider subscribes with its own `noteId` before it opens the doc, so no broadcast
+can land in the gap between opening a note and being wired to it. Unsubscribing the last
+provider for a note drops its entry, and the channel listener is released once nothing is
+listening — note close, window reload, and vault switch all take that path.
+
 ## Open Doc Lifecycle
 
 Main keeps a Y.Doc open while an editor window is attached to it. Sync pulls may also


### PR DESCRIPTION
Part of epic #987 (Memory & CPU full-app performance audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/sync/yjs-ipc-provider.ts:33-40` (pre-change) had every provider subscribe to the raw global `crdt:state-changed` channel and drop payloads whose `noteId` did not match:

```ts
this.ipcCleanup = window.api.onCrdtStateChanged((data) => {
  if (data.noteId !== this.noteId) return
  ...
})
```

`apps/desktop/src/preload/api/sync-ops.ts:69-75` passed the callback straight to `subscribe()`, which fans every payload out to every registered callback (`apps/desktop/src/preload/lib/ipc.ts:60-77`). Main-side broadcast is already note-scoped per window (`apps/desktop/src/main/sync/crdt-provider.ts:741-777`), so this was purely renderer-local waste: with N notes open, one keystroke in one note ran N callbacks — each inside its own `try`/`catch` frame — to do one unit of work.

Validated on current `main` (`0e272a690`) before implementing; behaviour was unchanged from the audit snapshot.

## What changed

The preload layer now owns a `noteId → Set<callback>` registry behind **one** channel subscription, and `onCrdtStateChanged(noteId, callback)` is note-scoped:

- `apps/desktop/src/preload/api/sync-ops.ts` — registry + dispatcher; the channel listener is attached on first subscribe and released when the last subscriber goes away.
- `apps/desktop/src/preload/lib/ipc.ts` — `logListenerError` exported so the per-callback isolation guard moves with the fan-out loop.
- `apps/desktop/src/preload/index.d.ts` — signature.
- `apps/desktop/src/renderer/src/sync/yjs-ipc-provider.ts` — passes its `noteId`.

Cost per update is now one map lookup regardless of how many notes are open.

## How I proved nothing is lost or misrouted

| Risk | Proof |
| --- | --- |
| Update reaches the wrong note | `sync-ops.test.ts` "delivers a note update only to that note's subscriber" — B's callback is never invoked. Renderer-side, `yjs-ipc-provider.test.ts` "never wakes another note's provider…" wires **two real providers** against a faithful note-routing fake and asserts B's `Y.Doc` is untouched. The `data.noteId !== this.noteId` check is deliberately **kept** in the provider as a belt-and-braces assertion — applying another note's update would be silent corruption, so it must be unreachable, not merely unlikely. |
| Update lost between opening a note and subscribing | The channel listener is attached synchronously inside `onCrdtStateChanged`, before it returns, and the provider still subscribes **before** `openDoc()` — unchanged ordering. Covered by "attaches the channel listener synchronously so no broadcast is missed". |
| Listeners accumulate for notes opened once and closed | "stays bounded across many open/close cycles" (200 cycles) and "shares one ipcRenderer listener across many open notes" (25 notes → 1 listener). Provider-level: "releases its subscription on destroy so repeated open/close stays bounded" (50 cycles, registry empty afterwards). Relevant to #1098. |
| Teardown on note close / window reload / vault switch | All three run `provider.destroy()` → unsubscribe. "re-arms cleanly after a full teardown (vault switch)" asserts the listener is removed and a fresh subscribe re-installs exactly one, delivering only to the new subscriber. |
| One bad subscriber starving others | "isolates a throwing subscriber from the others on the same note" and "tolerates a subscriber that unsubscribes itself mid-dispatch" preserve the guarantee `subscribe()` documents. |

Mutation-checked: replacing the keyed lookup with a global fan-out makes "delivers a note update only to that note's subscriber" fail.

## Compat

No IPC channel name, payload shape, DB schema, sync-protocol or vault-format change — `crdt:state-changed` and its payload are byte-identical. The only change is a preload API signature, consumed solely by the renderer bundled in the same app version. `pnpm ipc:generate` produced no diff; `pnpm ipc:check` reports the invoke map and RPC bindings up to date.

## Verification

- `typecheck:web` clean, `typecheck:node` clean
- preload project: 30/30 pass (4 files); renderer sync tests: 12/12 pass
- `eslint` on changed files: 0 errors
- `check:architecture` / `check:contracts` pass, `git diff --check` clean
- `docs:impact --base origin/main --strict` → `covered`; `docs:build` complete

Closes #1085