### PR TITLE
perf(telemetry): make the log-ship ring buffer O(1) per line

### DIFF
--- a/apps/desktop/src/main/telemetry/log-ship.test.ts
+++ b/apps/desktop/src/main/telemetry/log-ship.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import log from 'electron-log'
 
+import type { DiagnosticLogLine } from '@memry/contracts/diagnostics-api'
+
 vi.mock('electron', () => ({ net: { fetch: vi.fn() } }))
 
 const getCurrentVaultPathMock = vi.fn<() => string | null>(() => null)
@@ -35,6 +37,27 @@ const getTransport = (): RawTransport => {
   const transport = (log.transports as unknown as Record<string, unknown>).logShip
   if (typeof transport !== 'function') throw new Error('logShip transport not installed')
   return transport as RawTransport
+}
+
+// Counts `new Date(...)` constructions inside `run` — the per-line cost the old
+// ring paid once per retained entry. `Date.now()` is a static call, not a
+// construction, so it is deliberately not counted.
+const countDateConstructions = (run: () => void): number => {
+  const RealDate = globalThis.Date
+  let constructions = 0
+  class CountingDate extends RealDate {
+    constructor(...args: unknown[]) {
+      super(...(args as [number]))
+      constructions += 1
+    }
+  }
+  globalThis.Date = CountingDate as unknown as DateConstructor
+  try {
+    run()
+  } finally {
+    globalThis.Date = RealDate
+  }
+  return constructions
 }
 
 const createFetch = () => {
@@ -256,6 +279,109 @@ describe('installLogShip', () => {
     }
 
     expect(shipped.recentLines()).toHaveLength(200)
+  })
+
+  it('does per-line ring work that does not grow with the ring (O(1), not O(buffer))', () => {
+    const { fetchMock } = createFetch()
+    const shipped = installLogShip({
+      buildChannel: 'production',
+      fetch: fetchMock,
+      endpoint: 'https://sync.test/telemetry/logs',
+      salt: FIXED_SALT,
+      flushIntervalMs: null
+    })
+
+    // The old ring re-parsed every retained `ts` (`new Date(l.ts)`) on each push, so
+    // the cost of one warn scaled with how full the ring was: ~1 Date on an empty
+    // ring, ~201 on a full one.
+    const onEmptyRing = countDateConstructions(() => {
+      getTransport()({ level: 'warn', scope: 'Sync', data: ['first'] })
+    })
+
+    for (let i = 0; i < 250; i++) {
+      getTransport()({ level: 'warn', scope: 'Sync', data: [`fill-${i}`] })
+    }
+    expect(shipped.recentLines()).toHaveLength(200)
+
+    const onFullRing = countDateConstructions(() => {
+      getTransport()({ level: 'warn', scope: 'Sync', data: ['on-full-ring'] })
+    })
+
+    expect(onFullRing).toBe(onEmptyRing)
+    expect(onFullRing).toBeLessThan(10)
+  })
+
+  it('keeps the same retention window and eviction order as the filter+slice ring it replaced', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-07T12:00:00.000Z'))
+    try {
+      const { fetchMock } = createFetch()
+      const shipped = installLogShip({
+        buildChannel: 'production',
+        fetch: fetchMock,
+        endpoint: 'https://sync.test/telemetry/logs',
+        salt: FIXED_SALT,
+        flushIntervalMs: null
+      })
+
+      // Byte-for-byte the pre-fix eviction: append, drop anything older than the
+      // 5-minute window, then trim to the newest 200.
+      let reference: DiagnosticLogLine[] = []
+      const referencePush = (line: DiagnosticLogLine): void => {
+        reference.push(line)
+        const cutoff = Date.now() - 5 * 60 * 1000
+        reference = reference.filter((l) => new Date(l.ts).getTime() >= cutoff)
+        if (reference.length > 200) reference = reference.slice(reference.length - 200)
+      }
+
+      // Bursts (0ms) fill the ring to its cap; the 400s gaps blow the whole window
+      // away, so both eviction paths run many times over the fixture.
+      const deltasMs = [0, 0, 250, 1500, 0, 3200, 0, 900, 0, 400_000]
+      for (let i = 0; i < 260; i++) {
+        vi.advanceTimersByTime(deltasMs[i % deltasMs.length])
+        getTransport()({ level: 'warn', scope: 'Sync', data: [`msg-${i}`] })
+
+        const lines = shipped.recentLines()
+        const newest = lines[lines.length - 1]
+        expect(newest?.message).toBe(`msg-${i}`)
+        referencePush(newest)
+        expect(lines).toEqual(reference)
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('loses nothing under a burst and evicts oldest-first past the cap', async () => {
+    const { calls, fetchMock } = createFetch()
+    const shipped = installLogShip({
+      buildChannel: 'production',
+      fetch: fetchMock,
+      endpoint: 'https://sync.test/telemetry/logs',
+      salt: FIXED_SALT,
+      flushIntervalMs: null
+    })
+
+    for (let i = 0; i < 200; i++) {
+      getTransport()({ level: 'warn', scope: 'Sync', data: [`burst-${i}`] })
+    }
+
+    const full = shipped.recentLines()
+    expect(full.map((l) => l.message)).toEqual(Array.from({ length: 200 }, (_, i) => `burst-${i}`))
+
+    getTransport()({ level: 'warn', scope: 'Sync', data: ['burst-200'] })
+    const evicted = shipped.recentLines()
+    expect(evicted).toHaveLength(200)
+    expect(evicted.map((l) => l.message)).toEqual(
+      Array.from({ length: 200 }, (_, i) => `burst-${i + 1}`)
+    )
+
+    // The burst reaches the wire in emission order too, oldest batch first.
+    await shipped.dispose()
+    const body = calls[0]?.body as { lines: { message: string }[] }
+    expect(body.lines.map((l) => l.message)).toEqual(
+      Array.from({ length: 50 }, (_, i) => `burst-${i}`)
+    )
   })
 
   it('collapses repeated identical warns within the throttle window into a repeat count', () => {

--- a/apps/desktop/src/main/telemetry/log-ship.ts
+++ b/apps/desktop/src/main/telemetry/log-ship.ts
@@ -118,12 +118,39 @@ export const installLogShip = (deps: LogShipDeps): LogShip => {
   const floorRank = Math.max(LEVEL_ORDER.warn, LEVEL_ORDER[configuredLevel] ?? LEVEL_ORDER.warn)
   const transportLevel: 'warn' | 'error' = floorRank >= LEVEL_ORDER.error ? 'error' : 'warn'
 
-  let ring: DiagnosticLogLine[] = []
-  const pushRing = (line: DiagnosticLogLine): void => {
-    ring.push(line)
-    const cutoff = Date.now() - RING_MS
-    ring = ring.filter((l) => new Date(l.ts).getTime() >= cutoff)
-    if (ring.length > RING_LIMIT) ring = ring.slice(ring.length - RING_LIMIT)
+  // Fixed-capacity circular buffer over preallocated slots. Both evictions (the
+  // RING_MS window and the RING_LIMIT cap) only ever drop the oldest entries, so a
+  // head index reproduces exactly what the old filter+slice kept — while doing O(1)
+  // amortized work per line instead of re-parsing up to RING_LIMIT timestamps and
+  // reallocating the array on every warn/error. Epoch ms is captured at push time in
+  // a parallel array, so the shipped line shape (`ts` ISO string) is untouched.
+  const ringLines = new Array<DiagnosticLogLine | null>(RING_LIMIT).fill(null)
+  const ringTsMs = new Array<number>(RING_LIMIT).fill(0)
+  let ringHead = 0
+  let ringSize = 0
+
+  const pushRing = (line: DiagnosticLogLine, tsMs: number): void => {
+    const slot = (ringHead + ringSize) % RING_LIMIT
+    ringLines[slot] = line
+    ringTsMs[slot] = tsMs
+    if (ringSize === RING_LIMIT) ringHead = (ringHead + 1) % RING_LIMIT
+    else ringSize += 1
+    const cutoff = tsMs - RING_MS
+    while (ringSize > 0 && ringTsMs[ringHead] < cutoff) {
+      // Null the evicted slot so the ring stops pinning the line object.
+      ringLines[ringHead] = null
+      ringHead = (ringHead + 1) % RING_LIMIT
+      ringSize -= 1
+    }
+  }
+
+  const snapshotRing = (): DiagnosticLogLine[] => {
+    const out: DiagnosticLogLine[] = []
+    for (let i = 0; i < ringSize; i++) {
+      const line = ringLines[(ringHead + i) % RING_LIMIT]
+      if (line) out.push(line)
+    }
+    return out
   }
 
   const throttleMap = new Map<string, { line: DiagnosticLogLine; windowStart: number }>()
@@ -217,7 +244,7 @@ export const installLogShip = (deps: LogShipDeps): LogShip => {
       }
       throttleMap.set(key, { line, windowStart: now })
       sweepThrottle(now)
-      pushRing(line)
+      pushRing(line, now)
 
       syncQueueEnabled()
       queue.enqueue(line)
@@ -253,7 +280,7 @@ export const installLogShip = (deps: LogShipDeps): LogShip => {
       logShipInstance = null
     },
     ingestForwarded: (record, workerName) => handleRecord(record, 'worker', workerName),
-    recentLines: () => ring.slice()
+    recentLines: () => snapshotRing()
   }
 
   logShipInstance = ship

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -592,7 +592,10 @@ detail (stacks, operational messages) that a PostHog _event_ deliberately omits.
   30s, drop-4xx-except-429) to `POST /telemetry/logs`, gated on the telemetry toggle
   (`getTelemetryRuntime().getSettings().enabled`) and disabled outright in dev builds. Repeated
   identical `level|scope|message` lines within a 3s window are throttled into one line with a
-  `repeatCount` field. A record's arguments are flattened by `parseRecord`: the first string wins
+  `repeatCount` field. The Path B ring those lines also feed is a fixed-capacity circular buffer
+  (200 slots, 5-minute window) that stores each line's epoch ms at push time and evicts oldest-first
+  through a head index, so one `warn`/`error` costs O(1) instead of re-parsing every retained
+  timestamp — the error path has to stay cheap when something is looping. A record's arguments are flattened by `parseRecord`: the first string wins
   the `message` slot, plain objects merge into the fields, and an `Error` contributes `errorName`
   plus `errorMessage`. That last part matters — `logger.error('updater error', err)` used to ship
   `{"errorName":"Error"}` and nothing else, because the label had already claimed the message slot


### PR DESCRIPTION
Closes #1086. Part of epic #987 (memory & CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/telemetry/log-ship.ts:121-127` (pre-fix):

```ts
let ring: DiagnosticLogLine[] = []
const pushRing = (line: DiagnosticLogLine): void => {
  ring.push(line)
  const cutoff = Date.now() - RING_MS
  ring = ring.filter((l) => new Date(l.ts).getTime() >= cutoff)
  if (ring.length > RING_LIMIT) ring = ring.slice(ring.length - RING_LIMIT)
}
```

Every `warn`/`error` — including records forwarded from the embeddings/image/voice workers — re-parsed the whole ring (`new Date(l.ts)` per retained entry, up to 200) and allocated a fresh array, plus a second array from the `slice`. That is O(buffer) work on the error path, exactly where the app is already in trouble. Memory stays bounded (200 entries / 5 min); this is CPU + allocation churn.

Still valid on current `main` (`0e272a690`); the file has not been touched since #979.

## What changed

The array is replaced with a fixed-capacity circular buffer: 200 preallocated slots, a parallel `number[]` holding each line's epoch ms captured **at push time**, and a head index. Both evictions (5-minute window, 200-entry cap) only ever drop the oldest entries, so head-index eviction reproduces exactly what `filter` + `slice` kept. Evicted slots are nulled so the ring stops pinning the line objects.

- The shipped payload is untouched: `DiagnosticLogLine` still carries only its ISO `ts`; the epoch ms lives in a side array that never leaves the ring. Same fields, same order, same `POST /telemetry/logs` body shape.
- Nothing about what is buffered, retained, or shipped is widened — same 200/5-min retention, same redaction, same lines.
- A line's timestamp is still minted when the line is created (`now`, the same value already used as the throttle-window anchor), never at read time.
- `pushRing` has no throw path: no parsing, no allocation beyond the two fixed arrays built at install.

## How I proved observable behavior is unchanged

**1. Parity against the old implementation on a fixture.** New test runs the literal pre-fix `filter`+`slice` as a reference alongside the real ring over 260 records on fake timers, with deltas `[0, 0, 250, 1500, 0, 3200, 0, 900, 0, 400_000]` — bursts fill the ring to its cap, the 400s gaps flush the whole window — and asserts `recentLines()` deep-equals the reference **after every single push**. Mutation check: widening the window to `RING_MS * 2` makes this test fail.

**2. Burst loses nothing, evicts oldest-first.** 200 same-instant records → all 200 present in emission order; the 201st evicts exactly `burst-0` and leaves `burst-1..burst-200` in order; the first shipped batch is `burst-0..burst-49`, i.e. order survives into the wire. Mutation check: advancing the head by 2 on overflow makes this test fail.

**3. Per-line work is O(1), not O(buffer).** New test counts `new Date(...)` constructions for one record on an empty ring vs. a full one and asserts they are equal. Against the pre-fix implementation (stashed source, same test file):

```
× does per-line ring work that does not grow with the ring (O(1), not O(buffer))
  → expected 202 to be 2
```

After the fix it is `2` in both cases.

**Microbench** (200k pushes against a full ring, same line objects, old vs new eviction):

```
old 3692ms  new 61ms  -> 60.6x
per push: old 18.46us  new 0.30us
```

## Local verification

```
pnpm --filter @memry/desktop typecheck:node        # clean
pnpm exec eslint apps/desktop/src/main/telemetry/log-ship.ts   # 0 problems
vitest run --project main src/main/telemetry src/main/diagnostics
  Test Files  14 passed (14)
       Tests  176 passed (176)
git diff --check                                   # clean
pnpm docs:impact --base origin/main --strict       # covered
pnpm docs:build                                    # build complete
```

`apps/docs/src/architecture/observability.md` gained a sentence describing the ring's structure and O(1) eviction.