### PR TITLE
perf(editor): throttle file drag-over measuring to one frame

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-drag-drop-throttle.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-drag-drop-throttle.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useEditorDragDrop } from './use-editor-drag-drop'
+import { findDropTarget } from '../drop-target-utils'
+
+// Regression cover for #1088: `dragover` fires continuously while a file hovers
+// the editor. Measuring every block and committing a fresh drop-target object on
+// each event re-rendered the editor dozens of times per second. Measuring must be
+// throttled to one frame, and the commit must bail out when the target is
+// unchanged — without changing where the drop actually lands.
+
+const BLOCK_COUNT = 40
+const BLOCK_HEIGHT = 20
+
+let measureCount = 0
+let scrollOffset = 0
+let frameCallbacks: Array<{ id: number; cb: FrameRequestCallback }> = []
+let nextFrameId = 1
+
+function createContainer(): HTMLDivElement {
+  const container = document.createElement('div')
+  for (let i = 0; i < BLOCK_COUNT; i += 1) {
+    const el = document.createElement('div')
+    el.setAttribute('data-id', `block-${i}`)
+    const documentTop = i * BLOCK_HEIGHT
+    el.getBoundingClientRect = (): DOMRect => {
+      measureCount += 1
+      const top = documentTop - scrollOffset
+      return {
+        top,
+        bottom: top + BLOCK_HEIGHT,
+        height: BLOCK_HEIGHT,
+        left: 0,
+        right: 100,
+        width: 100,
+        x: 0,
+        y: top,
+        toJSON: () => ({})
+      } as DOMRect
+    }
+    container.appendChild(el)
+  }
+  return container
+}
+
+function dragEvent(clientY: number, clientX = 50): React.DragEvent {
+  return {
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    dataTransfer: { types: ['Files'] },
+    clientX,
+    clientY,
+    currentTarget: {
+      getBoundingClientRect: () => ({ left: 0, right: 100, top: 0, bottom: 500 })
+    }
+  } as unknown as React.DragEvent
+}
+
+function flushFrames(): void {
+  const pending = frameCallbacks
+  frameCallbacks = []
+  act(() => {
+    pending.forEach(({ cb }) => cb(0))
+  })
+}
+
+describe('useEditorDragDrop dragover throttling', () => {
+  let containerRef: React.RefObject<HTMLDivElement | null>
+
+  beforeEach(() => {
+    measureCount = 0
+    scrollOffset = 0
+    frameCallbacks = []
+    nextFrameId = 1
+    containerRef = { current: createContainer() }
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+      const id = nextFrameId
+      nextFrameId += 1
+      frameCallbacks.push({ id, cb })
+      return id
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number): void => {
+      frameCallbacks = frameCallbacks.filter((frame) => frame.id !== id)
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('measures at most once per frame across a dragover burst, but always preventDefaults', () => {
+    // #given
+    const { result } = renderHook(() => useEditorDragDrop({ containerRef }))
+    const events = Array.from({ length: 20 }, (_, i) => dragEvent(150 + i))
+
+    // #when — a burst of dragover events arrives inside a single frame
+    act(() => {
+      events.forEach((event) => result.current.handleDragOver(event))
+    })
+
+    // #then — the drop is still accepted, but nothing has been measured yet
+    events.forEach((event) => expect(event.preventDefault).toHaveBeenCalled())
+    expect(measureCount).toBe(0)
+    expect(frameCallbacks).toHaveLength(1)
+
+    // #when — the frame runs
+    flushFrames()
+
+    // #then — a single measurement pass, resolved from the newest pointer position
+    expect(measureCount).toBeGreaterThan(0)
+    expect(measureCount).toBeLessThanOrEqual(BLOCK_COUNT)
+    measureCount = 0
+    expect(result.current.dropTarget).toEqual(findDropTarget(169, containerRef))
+  })
+
+  it('does not re-render while the drop target is unchanged', () => {
+    // #given
+    let renderCount = 0
+    const { result } = renderHook(() => {
+      renderCount += 1
+      return useEditorDragDrop({ containerRef })
+    })
+    act(() => {
+      result.current.handleDragOver(dragEvent(150))
+    })
+    flushFrames()
+    const committed = result.current.dropTarget
+    expect(committed).not.toBeNull()
+    // React may render a component once more before it settles into bailing out,
+    // so let the first unchanged update absorb that before counting.
+    act(() => {
+      result.current.handleDragOver(dragEvent(151))
+    })
+    flushFrames()
+    const rendersAfterCommit = renderCount
+
+    // #when — the cursor keeps hovering the same block
+    for (let i = 0; i < 10; i += 1) {
+      act(() => {
+        result.current.handleDragOver(dragEvent(151))
+      })
+      flushFrames()
+    }
+
+    // #then — same object, no extra renders
+    expect(result.current.dropTarget).toBe(committed)
+    expect(renderCount).toBe(rendersAfterCommit)
+  })
+
+  it('commits a new target when the cursor moves to another block', () => {
+    // #given
+    const { result } = renderHook(() => useEditorDragDrop({ containerRef }))
+    act(() => {
+      result.current.handleDragOver(dragEvent(150))
+    })
+    flushFrames()
+    const first = result.current.dropTarget
+
+    // #when
+    act(() => {
+      result.current.handleDragOver(dragEvent(410))
+    })
+    flushFrames()
+
+    // #then
+    expect(result.current.dropTarget).not.toBe(first)
+    expect(result.current.dropTarget).toEqual(findDropTarget(410, containerRef))
+  })
+
+  it.each([
+    ['first block, top half', 1],
+    ['first block, bottom half', 15],
+    ['a middle block', 333],
+    ['last block', 795],
+    ['past the last block', 5000]
+  ])('resolves the same drop target as an unthrottled measurement (%s)', (_label, clientY) => {
+    // #given
+    const { result } = renderHook(() => useEditorDragDrop({ containerRef }))
+
+    // #when — a fast cursor move ending at clientY, then one frame
+    act(() => {
+      result.current.handleDragOver(dragEvent(clientY - 40))
+      result.current.handleDragOver(dragEvent(clientY))
+    })
+    flushFrames()
+
+    // #then
+    expect(result.current.dropTarget).toEqual(findDropTarget(clientY, containerRef))
+  })
+
+  it('re-measures live geometry when the note scrolls mid-drag', () => {
+    // #given — hovering block-7 at y=150
+    const { result } = renderHook(() => useEditorDragDrop({ containerRef }))
+    act(() => {
+      result.current.handleDragOver(dragEvent(150))
+    })
+    flushFrames()
+    expect(result.current.dropTarget?.blockId).toBe('block-7')
+
+    // #when — the note scrolls under a stationary cursor
+    scrollOffset = 200
+    act(() => {
+      result.current.handleDragOver(dragEvent(150))
+    })
+    flushFrames()
+
+    // #then — resolved against the new rects, not cached ones
+    expect(result.current.dropTarget?.blockId).toBe('block-17')
+    expect(result.current.dropTarget).toEqual(findDropTarget(150, containerRef))
+  })
+
+  it('cancels a pending frame on drop', () => {
+    // #given
+    const { result } = renderHook(() => useEditorDragDrop({ containerRef }))
+    act(() => {
+      result.current.handleDragOver(dragEvent(150))
+    })
+    flushFrames()
+    act(() => {
+      result.current.handleDragOver(dragEvent(410))
+    })
+    expect(frameCallbacks).toHaveLength(1)
+
+    // #when
+    act(() => {
+      result.current.handleDrop()
+    })
+
+    // #then — no ghost target lands after the drop
+    expect(frameCallbacks).toHaveLength(0)
+    measureCount = 0
+    flushFrames()
+    expect(measureCount).toBe(0)
+    expect(result.current.dropTarget).toBeNull()
+    expect(result.current.isDragging).toBe(false)
+  })
+
+  it('cancels a pending frame when the cursor leaves the container', () => {
+    // #given
+    const { result } = renderHook(() => useEditorDragDrop({ containerRef }))
+    act(() => {
+      result.current.handleDragOver(dragEvent(150))
+    })
+    expect(frameCallbacks).toHaveLength(1)
+
+    // #when — cursor exits the container bounds
+    act(() => {
+      result.current.handleDragLeave(dragEvent(150, -10))
+    })
+
+    // #then
+    expect(frameCallbacks).toHaveLength(0)
+    measureCount = 0
+    flushFrames()
+    expect(measureCount).toBe(0)
+    expect(result.current.dropTarget).toBeNull()
+  })
+
+  it('cancels a pending frame on unmount', () => {
+    // #given
+    const { result, unmount } = renderHook(() => useEditorDragDrop({ containerRef }))
+    act(() => {
+      result.current.handleDragOver(dragEvent(150))
+    })
+    expect(frameCallbacks).toHaveLength(1)
+
+    // #when
+    unmount()
+
+    // #then
+    expect(frameCallbacks).toHaveLength(0)
+  })
+
+  it('cancels a pending frame when the drag ends globally', () => {
+    // #given
+    const { result } = renderHook(() => useEditorDragDrop({ containerRef }))
+    act(() => {
+      result.current.handleDragOver(dragEvent(150))
+    })
+    expect(frameCallbacks).toHaveLength(1)
+
+    // #when
+    act(() => {
+      window.dispatchEvent(new Event('dragend'))
+    })
+
+    // #then
+    expect(frameCallbacks).toHaveLength(0)
+    measureCount = 0
+    flushFrames()
+    expect(measureCount).toBe(0)
+    expect(result.current.isDragging).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-drag-drop.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-drag-drop.ts
@@ -1,6 +1,12 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { findDropTarget, type DropTarget } from '../drop-target-utils'
 import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
+
+function isSameDropTarget(a: DropTarget | null, b: DropTarget | null): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  return a.blockId === b.blockId && a.position === b.position
+}
 
 interface EditorDragDropParams {
   containerRef: React.RefObject<HTMLDivElement | null>
@@ -18,9 +24,33 @@ export function useEditorDragDrop({ containerRef }: EditorDragDropParams): Edito
   const [isDragging, setIsDragging] = useState(false)
   const [dropTarget, setDropTarget] = useState<DropTarget | null>(null)
 
+  // `dragover` fires continuously while the cursor hovers, and resolving the drop
+  // target walks the block list reading `getBoundingClientRect` on each one. Park
+  // the latest pointer Y here and resolve it at most once per frame instead.
+  const pendingClientYRef = useRef(0)
+  const measureFrameRef = useRef<number | null>(null)
+
+  const cancelPendingMeasure = useCallback((): void => {
+    if (measureFrameRef.current === null) return
+    cancelAnimationFrame(measureFrameRef.current)
+    measureFrameRef.current = null
+  }, [])
+
+  // Measures live rects every frame rather than caching them for the drag: the
+  // note can scroll, reflow or settle an image mid-drag, and a stale rect would
+  // land the drop somewhere the indicator never pointed at.
+  const measureDropTarget = useCallback((): void => {
+    measureFrameRef.current = null
+    const next = findDropTarget(pendingClientYRef.current, containerRef)
+    // Keep the previous object when the target is unchanged so React bails out
+    // instead of re-rendering the editor and repositioning the indicator.
+    setDropTarget((prev) => (isSameDropTarget(prev, next) ? prev : next))
+  }, [containerRef])
+
   // Global event listeners to reset drag state when cancelled or tab loses focus
   useEffect(() => {
     const resetDragState = (): void => {
+      cancelPendingMeasure()
       setIsDragging(false)
       setDropTarget(null)
     }
@@ -39,8 +69,9 @@ export function useEditorDragDrop({ containerRef }: EditorDragDropParams): Edito
       window.removeEventListener('dragend', resetDragState)
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       window.removeEventListener('blur', resetDragState)
+      cancelPendingMeasure()
     }
-  }, [])
+  }, [cancelPendingMeasure])
 
   // Highlight drop target block with subtle background. useLayoutEffect avoids
   // running after paint and removes a no-pass-live-state-to-parent false positive.
@@ -68,27 +99,38 @@ export function useEditorDragDrop({ containerRef }: EditorDragDropParams): Edito
       e.preventDefault()
       if (isInternalItem && !isFileDrag) e.dataTransfer.dropEffect = 'copy'
       setIsDragging(true)
-      const target = findDropTarget(e.clientY, containerRef)
-      setDropTarget(target)
+      // preventDefault above runs on every event — only the measuring is throttled,
+      // otherwise the browser would reject the drop.
+      pendingClientYRef.current = e.clientY
+      if (measureFrameRef.current === null) {
+        measureFrameRef.current = requestAnimationFrame(measureDropTarget)
+      }
     },
-    [containerRef]
+    [measureDropTarget]
   )
 
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    const rect = e.currentTarget.getBoundingClientRect()
-    const { clientX: x, clientY: y } = e
-    if (x < rect.left || x >= rect.right || y < rect.top || y >= rect.bottom) {
-      setIsDragging(false)
-      setDropTarget(null)
-    }
-  }, [])
+  const handleDragLeave = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      const rect = e.currentTarget.getBoundingClientRect()
+      const { clientX: x, clientY: y } = e
+      if (x < rect.left || x >= rect.right || y < rect.top || y >= rect.bottom) {
+        cancelPendingMeasure()
+        setIsDragging(false)
+        setDropTarget(null)
+      }
+    },
+    [cancelPendingMeasure]
+  )
 
+  // Drops consume the committed target — the one the indicator is showing — so a
+  // frame still in flight is dropped rather than flushed.
   const handleDrop = useCallback(() => {
+    cancelPendingMeasure()
     setIsDragging(false)
     setDropTarget(null)
-  }, [])
+  }, [cancelPendingMeasure])
 
   return { isDragging, dropTarget, handleDragOver, handleDragLeave, handleDrop }
 }

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -13,6 +13,8 @@ Three ways:
 - **Drag from the sidebar** — drag a file item (PDF, image, audio, …) from the left sidebar onto a note. This **embeds it by reference** using the item's own vault path, so no second copy is made.
 - **Slash menu** — `/file` inserts a File block; click to pick a file.
 
+While you drag over a note, a line marks where the file will land, and dropping inserts it exactly there. The line follows the cursor once per frame instead of on every pointer event, so dragging over a long note stays smooth.
+
 ## File Block
 
 Each attachment renders as a block with:


### PR DESCRIPTION
Closes #1088. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-drag-drop.ts:70-72` ran on **every** `dragover` — and `dragover` fires continuously while a file hovers the editor, not just when the pointer moves:

```ts
setIsDragging(true)
const target = findDropTarget(e.clientY, containerRef)  // querySelectorAll + getBoundingClientRect loop
setDropTarget(target)                                    // always a fresh object
```

`findDropTarget` (`drop-target-utils.ts:39-58`) does `querySelectorAll('[data-id]')` and reads `getBoundingClientRect` per block until it passes `clientY`, so cost grows with how far down the note you hover. And because the committed value was always a new object, React never bailed out: each event re-rendered `ContentArea`, re-ran the `useLayoutEffect` that strips and re-adds the highlight classes on the target block (killing its own CSS transition), re-ran `calculateIndicatorPosition`, and re-registered the capture-phase `drop` listener in `useEditorFileUpload` (it lists `dropTarget` in its deps).

## What changed

Only `use-editor-drag-drop.ts`:

- Park the latest `e.clientY` in a ref and resolve the drop target in a `requestAnimationFrame` — at most one measurement pass per frame regardless of event rate.
- `e.preventDefault()` still runs on every single `dragover` (throttling it would make the browser reject the drop). Only the measuring/committing is throttled.
- Commit through an updater that returns the previous object when `blockId`/`position` are unchanged, so React bails out instead of re-rendering.
- **No geometry is cached.** Rects are re-read live on the frame they are used, so a scroll, reflow, or an image settling mid-drag can never feed a stale rect into the drop — same reasoning as the marquee fix (#1050), which also deliberately measures live.
- The pending frame is cancelled on drop, on drag-leave-outside, on the global `dragend`/`blur`/`visibilitychange` resets, and on unmount. Previously nothing could leak here because there was no frame; now the cancel also removes a real bug class — a frame landing *after* a drop and painting a ghost indicator.

Drop position semantics are untouched: `findDropTarget` is unchanged, and both the indicator (`BlockDropIndicator`) and the insertion path (`useEditorFileUpload`) read the same committed `dropTarget` state, so the file lands exactly where the line was drawn. On drop the in-flight frame is cancelled rather than flushed, precisely so the drop can never use a target the user never saw.

## How the drop target was proven unchanged

New file `use-editor-drag-drop-throttle.test.ts` builds a 40-block container with stubbed rects and a controllable rAF queue, and asserts the hook's committed target is `toEqual(findDropTarget(clientY, containerRef))` — i.e. identical to an unthrottled measurement — for: first block top half, first block bottom half, a middle block, the last block, past the last block, and after a fast two-event cursor move. A separate case scrolls the note under a stationary cursor mid-drag (`block-7` → `block-17`) to prove the frame re-measures live geometry rather than reusing anything.

Perf assertions in the same file: a 20-event burst does zero `getBoundingClientRect` calls and schedules exactly one frame (each of the 20 events still `preventDefault`s); after the frame, one bounded measurement pass; ten further hover events on the same block produce zero additional renders and keep object identity.

Before/after on the current implementation (`git stash` of the hook only):

```
before fix: 6 failed | 6 passed  (the 6 "same drop target" cases pass on both sides — that is the point)
after fix:  22 passed (both drag-drop test files)
```

## Verification

```
pnpm --filter @memry/desktop typecheck:web          # clean
vitest --project renderer (5 content-area files)    # Test Files 5 passed | Tests 50 passed
pnpm exec eslint <changed files>                    # 0 errors
git diff --check                                    # clean
pnpm docs:impact --base origin/main --strict        # covered
pnpm docs:build                                     # build complete
```

Patch coverage checked locally with `--coverage.include` on the hook: 96.8% lines; the only uncovered lines (61-62, the `document.hidden` branch) are pre-existing and outside this diff.

Backward compatible: renderer-only behavior change, no schema, contract, protocol, or settings shape touched.