### PR TITLE
fix(shortcuts): keep the quick-capture fallback shortcut across settings saves

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -9,7 +9,19 @@ const getPathMock = vi.fn((name: string) => `/mock/${name}`)
 const setPathMock = vi.fn()
 const dotenvConfigMock = vi.fn(() => ({ error: undefined }))
 const registerAllHandlersMock = vi.fn()
-const applyGlobalCaptureShortcutMock = vi.fn(() => ({ registered: true }))
+let globalCaptureRegistered = true
+let globalCaptureAppliedHandler: ((configuredRegistered: boolean) => void) | null = null
+// Mirrors the real module: applying the configured accelerator always reports the
+// outcome to the fallback owner in index.ts.
+const applyGlobalCaptureShortcutMock = vi.fn(() => {
+  globalCaptureAppliedHandler?.(globalCaptureRegistered)
+  return { registered: globalCaptureRegistered }
+})
+const setGlobalCaptureAppliedHandlerMock = vi.fn(
+  (handler: ((configuredRegistered: boolean) => void) | null) => {
+    globalCaptureAppliedHandler = handler
+  }
+)
 const autoOpenLastVaultMock = vi.fn(async () => undefined)
 const closeVaultMock = vi.fn(async () => undefined)
 const vaultStatusChangedListeners: Array<(status: VaultStatus) => void> = []
@@ -80,6 +92,7 @@ const setPermissionRequestHandlerMock = vi.fn()
 const setPermissionCheckHandlerMock = vi.fn()
 const crashReporterStartMock = vi.fn()
 const globalShortcutRegisterMock = vi.fn(() => true)
+const globalShortcutUnregisterMock = vi.fn()
 const globalShortcutUnregisterAllMock = vi.fn()
 const menuSetApplicationMenuMock = vi.fn()
 const netFetchMock = vi.fn(async () => new Response('file'))
@@ -157,7 +170,8 @@ vi.mock('./ipc', () => ({
 }))
 
 vi.mock('./ipc/settings-handlers', () => ({
-  applyGlobalCaptureShortcut: applyGlobalCaptureShortcutMock
+  applyGlobalCaptureShortcut: applyGlobalCaptureShortcutMock,
+  setGlobalCaptureAppliedHandler: setGlobalCaptureAppliedHandlerMock
 }))
 
 vi.mock('./vault', () => ({
@@ -379,6 +393,7 @@ vi.mock('electron', () => ({
   },
   globalShortcut: {
     register: globalShortcutRegisterMock,
+    unregister: globalShortcutUnregisterMock,
     unregisterAll: globalShortcutUnregisterAllMock
   },
   clipboard: {
@@ -488,7 +503,8 @@ describe('main index phase2 exports', () => {
     getPathMock.mockImplementation((name: string) => `/mock/${name}`)
     whenReadyMock.mockImplementation(() => new Promise<void>(() => {}))
     requestSingleInstanceLockMock.mockReturnValue(true)
-    applyGlobalCaptureShortcutMock.mockReturnValue({ registered: true })
+    globalCaptureRegistered = true
+    globalCaptureAppliedHandler = null
     getCurrentVaultPathMock.mockReturnValue(null)
     getStoredLocaleMock.mockReturnValue(null)
     getVaultsMock.mockReturnValue([])
@@ -1504,7 +1520,7 @@ describe('main index phase2 exports', () => {
   it('falls back to the global quick-capture shortcut and manages the quick window', async () => {
     vi.useFakeTimers()
     whenReadyMock.mockResolvedValue(undefined)
-    applyGlobalCaptureShortcutMock.mockReturnValue({ registered: false })
+    globalCaptureRegistered = false
 
     await importMainModule()
     await flushReadyWork()
@@ -1553,11 +1569,61 @@ describe('main index phase2 exports', () => {
     expect(BrowserWindowMock).toHaveBeenCalledTimes(3)
   })
 
+  it('keeps the quick-capture fallback shortcut alive across keyboard settings saves', async () => {
+    // Saving keyboard settings re-applies the configured accelerator. That path used
+    // to call globalShortcut.unregisterAll(), which silently dropped the fallback and
+    // left quick capture with no working shortcut at all (#1087).
+    whenReadyMock.mockResolvedValue(undefined)
+    globalCaptureRegistered = false
+
+    await importMainModule()
+    await flushReadyWork()
+
+    const fallbackRegistrations = (): Array<[string, () => void]> =>
+      (globalShortcutRegisterMock.mock.calls as unknown as Array<[string, () => void]>).filter(
+        ([accelerator]) => accelerator === 'CommandOrControl+Shift+Space'
+      )
+
+    expect(fallbackRegistrations()).toHaveLength(1)
+    // Without this wiring a later re-apply can never restore the fallback.
+    expect(setGlobalCaptureAppliedHandlerMock).toHaveBeenCalledWith(expect.any(Function))
+
+    // Two further saves while the configured accelerator is still taken.
+    applyGlobalCaptureShortcutMock()
+    applyGlobalCaptureShortcutMock()
+
+    expect(fallbackRegistrations()).toHaveLength(1)
+    expect(globalShortcutUnregisterMock).not.toHaveBeenCalledWith('CommandOrControl+Shift+Space')
+
+    // Still bound: firing it opens the quick capture window.
+    const shortcutHandler = fallbackRegistrations()[0][1]
+    shortcutHandler()
+    expect(browserWindows.length).toBeGreaterThan(1)
+  })
+
+  it('releases the quick-capture fallback once the configured accelerator registers', async () => {
+    whenReadyMock.mockResolvedValue(undefined)
+    globalCaptureRegistered = false
+
+    await importMainModule()
+    await flushReadyWork()
+
+    globalCaptureRegistered = true
+    applyGlobalCaptureShortcutMock()
+
+    expect(globalShortcutUnregisterMock).toHaveBeenCalledWith('CommandOrControl+Shift+Space')
+
+    // Idempotent: a repeat save must not release an accelerator we no longer hold.
+    globalShortcutUnregisterMock.mockClear()
+    applyGlobalCaptureShortcutMock()
+    expect(globalShortcutUnregisterMock).not.toHaveBeenCalled()
+  })
+
   it('loads quick capture from the dev renderer URL and wires load-failure logging', async () => {
     whenReadyMock.mockResolvedValue(undefined)
     isDevMock.dev = true
     process.env.ELECTRON_RENDERER_URL = 'http://localhost:5173/'
-    applyGlobalCaptureShortcutMock.mockReturnValue({ registered: false })
+    globalCaptureRegistered = false
 
     await importMainModule()
     await flushReadyWork()
@@ -1576,7 +1642,7 @@ describe('main index phase2 exports', () => {
 
   it('routes quick capture settings to the main window before closing the capture window', async () => {
     whenReadyMock.mockResolvedValue(undefined)
-    applyGlobalCaptureShortcutMock.mockReturnValue({ registered: false })
+    globalCaptureRegistered = false
 
     await importMainModule()
     await flushReadyWork()
@@ -1664,7 +1730,7 @@ describe('main index phase2 exports', () => {
     // slower renderer is torn down with unsaved edits still pending.
     vi.useFakeTimers()
     whenReadyMock.mockResolvedValue(undefined)
-    applyGlobalCaptureShortcutMock.mockReturnValue({ registered: false })
+    globalCaptureRegistered = false
 
     await importMainModule()
     await flushReadyWork()
@@ -1694,7 +1760,7 @@ describe('main index phase2 exports', () => {
     // another window's behalf, because that window's saves are still in flight.
     vi.useFakeTimers()
     whenReadyMock.mockResolvedValue(undefined)
-    applyGlobalCaptureShortcutMock.mockReturnValue({ registered: false })
+    globalCaptureRegistered = false
 
     await importMainModule()
     await flushReadyWork()

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -26,7 +26,7 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { LocaleSchema, FALLBACK_LOCALE, type Locale } from '@memry/contracts/locale-api'
 import { createMainI18n, type I18nInstance } from '@memry/i18n/main'
 import { registerAllHandlers } from './ipc'
-import { applyGlobalCaptureShortcut } from './ipc/settings-handlers'
+import { applyGlobalCaptureShortcut, setGlobalCaptureAppliedHandler } from './ipc/settings-handlers'
 import {
   autoOpenLastVault,
   beginVaultShutdown,
@@ -1608,13 +1608,11 @@ const appReady = app.whenReady().then(async () => {
     .initPersistence()
     .catch((err) => mainLog.warn('Early CRDT persistence init failed (non-fatal)', err))
 
-  // Register global shortcut for quick capture from keyboard settings (fallback: hardcoded default)
-  const globalCaptureResult = applyGlobalCaptureShortcut()
-  quickCaptureShortcutRegistration.configuredRegistered = globalCaptureResult.registered
-  quickCaptureShortcutRegistration.registered = globalCaptureResult.registered
-  if (!globalCaptureResult.registered) {
-    registerQuickCaptureShortcut()
-  }
+  // Register global shortcut for quick capture from keyboard settings (fallback: hardcoded default).
+  // The handler also runs on every later re-apply (keyboard settings save), so a save can no
+  // longer leave quick capture with no working shortcut at all.
+  setGlobalCaptureAppliedHandler(syncQuickCaptureFallbackShortcut)
+  applyGlobalCaptureShortcut()
   registerQuickCaptureTestHooks()
 
   // Configure CSP, cert pinning, and permission handlers before the window loads
@@ -1843,6 +1841,12 @@ function handleQuickCaptureShortcut(): void {
 }
 
 function registerQuickCaptureShortcut(): void {
+  // Idempotent: a re-apply must not register an accelerator we already hold.
+  if (quickCaptureShortcutRegistration.fallbackRegistered) {
+    quickCaptureShortcutRegistration.registered = true
+    return
+  }
+
   const registered = globalShortcut.register(QUICK_CAPTURE_SHORTCUT, handleQuickCaptureShortcut)
 
   quickCaptureShortcutRegistration.fallbackAttempted = true
@@ -1863,6 +1867,30 @@ function registerQuickCaptureShortcut(): void {
       })
     }
   }
+}
+
+function unregisterQuickCaptureFallbackShortcut(): void {
+  if (!quickCaptureShortcutRegistration.fallbackRegistered) return
+
+  globalShortcut.unregister(QUICK_CAPTURE_SHORTCUT)
+  quickCaptureShortcutRegistration.fallbackRegistered = false
+}
+
+/**
+ * Keep the hardcoded fallback shortcut in step with the configured global capture
+ * accelerator. Runs at startup and after every keyboard settings save, so saving
+ * settings can no longer drop the fallback (or report one that is not registered).
+ */
+function syncQuickCaptureFallbackShortcut(configuredRegistered: boolean): void {
+  quickCaptureShortcutRegistration.configuredRegistered = configuredRegistered
+
+  if (configuredRegistered) {
+    unregisterQuickCaptureFallbackShortcut()
+    quickCaptureShortcutRegistration.registered = true
+    return
+  }
+
+  registerQuickCaptureShortcut()
 }
 
 function registerQuickCaptureTestHooks(): void {

--- a/apps/desktop/src/main/ipc/settings-handlers.inbox.test.ts
+++ b/apps/desktop/src/main/ipc/settings-handlers.inbox.test.ts
@@ -38,6 +38,7 @@ vi.mock('electron', () => ({
   },
   globalShortcut: {
     unregisterAll: vi.fn(),
+    unregister: vi.fn(),
     register: vi.fn()
   },
   systemPreferences: {

--- a/apps/desktop/src/main/ipc/settings-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/settings-handlers.test.ts
@@ -18,6 +18,7 @@ const electronMocks = vi.hoisted(() => {
     getAllWindows: vi.fn(() => [{ isDestroyed: () => false, webContents: { send } }]),
     setLoginItemSettings: vi.fn(),
     globalShortcutUnregisterAll: vi.fn(),
+    globalShortcutUnregister: vi.fn(),
     globalShortcutRegister: vi.fn(),
     isTrustedAccessibilityClient: vi.fn()
   }
@@ -26,6 +27,7 @@ const mockSend = electronMocks.send
 const mockGetAllWindows = electronMocks.getAllWindows
 const mockSetLoginItemSettings = electronMocks.setLoginItemSettings
 const mockGlobalShortcutUnregisterAll = electronMocks.globalShortcutUnregisterAll
+const mockGlobalShortcutUnregister = electronMocks.globalShortcutUnregister
 const mockGlobalShortcutRegister = electronMocks.globalShortcutRegister
 const mockIsTrustedAccessibilityClient = electronMocks.isTrustedAccessibilityClient
 const mockTrackMainEvent = vi.hoisted(() => vi.fn())
@@ -66,6 +68,7 @@ vi.mock('electron', () => ({
   },
   globalShortcut: {
     unregisterAll: electronMocks.globalShortcutUnregisterAll,
+    unregister: electronMocks.globalShortcutUnregister,
     register: electronMocks.globalShortcutRegister
   },
   systemPreferences: {
@@ -149,6 +152,7 @@ vi.mock('../store', () => ({
 import {
   applyGlobalCaptureShortcut,
   registerSettingsHandlers,
+  setGlobalCaptureAppliedHandler,
   unregisterSettingsHandlers
 } from './settings-handlers'
 import { getDatabase } from '../database'
@@ -183,6 +187,7 @@ describe('settings-handlers', () => {
       .mockReturnValue([{ isDestroyed: () => false, webContents: { send: mockSend } }])
     mockSetLoginItemSettings.mockReset()
     mockGlobalShortcutUnregisterAll.mockReset()
+    mockGlobalShortcutUnregister.mockReset()
     mockGlobalShortcutRegister.mockReset().mockReturnValue(true)
     mockIsTrustedAccessibilityClient.mockReset().mockReturnValue(true)
     mockUpdateField.mockClear()
@@ -886,14 +891,16 @@ describe('settings-handlers', () => {
   })
 
   describe('global capture shortcut', () => {
-    it('#given no binding #when registered #then unregisters existing shortcuts only', () => {
+    it('#given no binding #when registered #then leaves shortcuts it does not own alone', () => {
       registerSettingsHandlers()
       ;(settingsQueries.getSetting as Mock).mockReturnValue(JSON.stringify({}))
 
       const result = applyGlobalCaptureShortcut()
 
       expect(result).toEqual({ success: true, registered: false })
-      expect(mockGlobalShortcutUnregisterAll).toHaveBeenCalledTimes(1)
+      // unregisterAll() would also drop the quick capture fallback accelerator
+      // registered by main/index.ts, killing quick capture entirely (#1087).
+      expect(mockGlobalShortcutUnregisterAll).not.toHaveBeenCalled()
       expect(mockGlobalShortcutRegister).not.toHaveBeenCalled()
     })
 
@@ -953,6 +960,78 @@ describe('settings-handlers', () => {
       callback?.()
       expect(mockGlobalShortcutRegister).toHaveBeenCalledWith('Control+K', expect.any(Function))
       expect(mockSend).toHaveBeenCalledWith('quick-capture:open')
+    })
+
+    it('#given a re-apply #when the accelerator changes #then releases only the accelerator it owns', () => {
+      registerSettingsHandlers()
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+      ;(settingsQueries.getSetting as Mock).mockReturnValue(
+        JSON.stringify({ globalCapture: { key: 'J', modifiers: { ctrl: true } } })
+      )
+      applyGlobalCaptureShortcut()
+      mockGlobalShortcutUnregister.mockClear()
+      ;(settingsQueries.getSetting as Mock).mockReturnValue(
+        JSON.stringify({ globalCapture: { key: 'L', modifiers: { ctrl: true } } })
+      )
+
+      expect(applyGlobalCaptureShortcut()).toEqual({ success: true, registered: true })
+      expect(mockGlobalShortcutUnregister).toHaveBeenCalledTimes(1)
+      expect(mockGlobalShortcutUnregister).toHaveBeenCalledWith('Control+J')
+      expect(mockGlobalShortcutUnregisterAll).not.toHaveBeenCalled()
+    })
+
+    it('#given repeated saves #when the accelerator is unchanged #then re-registers exactly once each time', () => {
+      registerSettingsHandlers()
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+      ;(settingsQueries.getSetting as Mock).mockReturnValue(
+        JSON.stringify({ globalCapture: { key: 'P', modifiers: { ctrl: true } } })
+      )
+      applyGlobalCaptureShortcut()
+      mockGlobalShortcutRegister.mockClear()
+      mockGlobalShortcutUnregister.mockClear()
+
+      applyGlobalCaptureShortcut()
+      applyGlobalCaptureShortcut()
+
+      // Each save releases the previous binding before taking it again, so no
+      // stale duplicate registration is left behind.
+      expect(mockGlobalShortcutUnregister.mock.calls).toEqual([['Control+P'], ['Control+P']])
+      expect(mockGlobalShortcutRegister).toHaveBeenCalledTimes(2)
+    })
+
+    it('#given a fallback owner #when applying succeeds or fails #then it is told the real outcome', () => {
+      registerSettingsHandlers()
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+      const onApplied = vi.fn()
+      setGlobalCaptureAppliedHandler(onApplied)
+      ;(settingsQueries.getSetting as Mock).mockReturnValue(
+        JSON.stringify({ globalCapture: { key: 'M', modifiers: { ctrl: true } } })
+      )
+      mockGlobalShortcutRegister.mockReturnValueOnce(false)
+
+      // A conflict is reported to the caller AND handed to the fallback owner,
+      // instead of being swallowed with quick capture left unbound (#1087).
+      const conflict = applyGlobalCaptureShortcut()
+      expect(conflict.success).toBe(false)
+      expect(conflict.error).toBe('Shortcut Control+M is already in use')
+      expect(onApplied).toHaveBeenLastCalledWith(false)
+
+      applyGlobalCaptureShortcut()
+      expect(onApplied).toHaveBeenLastCalledWith(true)
+
+      setGlobalCaptureAppliedHandler(null)
+    })
+
+    it('#given no binding #when applied #then the fallback owner is told nothing is registered', () => {
+      registerSettingsHandlers()
+      const onApplied = vi.fn()
+      setGlobalCaptureAppliedHandler(onApplied)
+      ;(settingsQueries.getSetting as Mock).mockReturnValue(JSON.stringify({}))
+
+      expect(applyGlobalCaptureShortcut()).toEqual({ success: true, registered: false })
+      expect(onApplied).toHaveBeenCalledWith(false)
+
+      setGlobalCaptureAppliedHandler(null)
     })
   })
 

--- a/apps/desktop/src/main/ipc/settings-handlers.ts
+++ b/apps/desktop/src/main/ipc/settings-handlers.ts
@@ -1013,11 +1013,40 @@ export interface GlobalCaptureResult {
 }
 
 /**
+ * Accelerator currently held by the configured global capture shortcut. Only
+ * this one is released on re-apply: `globalShortcut.unregisterAll()` would also
+ * drop the quick capture fallback shortcut owned by `main/index.ts`.
+ */
+let registeredGlobalCaptureAccelerator: string | null = null
+
+/** Notified after every apply so the quick capture fallback stays in step. */
+let globalCaptureAppliedHandler: ((configuredRegistered: boolean) => void) | null = null
+
+/**
+ * Let `main/index.ts` keep its hardcoded quick capture fallback in step with the
+ * configured accelerator without this module importing the entrypoint.
+ */
+export function setGlobalCaptureAppliedHandler(
+  handler: ((configuredRegistered: boolean) => void) | null
+): void {
+  globalCaptureAppliedHandler = handler
+}
+
+/**
  * Read keyboard.globalCapture from settings and register/unregister OS shortcut.
  * Safe to call at startup and on settings change.
  */
 export function applyGlobalCaptureShortcut(): GlobalCaptureResult {
-  globalShortcut.unregisterAll()
+  const result = registerConfiguredGlobalCapture()
+  globalCaptureAppliedHandler?.(result.registered)
+  return result
+}
+
+function registerConfiguredGlobalCapture(): GlobalCaptureResult {
+  if (registeredGlobalCaptureAccelerator) {
+    globalShortcut.unregister(registeredGlobalCaptureAccelerator)
+    registeredGlobalCaptureAccelerator = null
+  }
 
   const settings = readGroupSettings('keyboard', KEYBOARD_SHORTCUTS_DEFAULTS)
   const binding = settings.globalCapture
@@ -1052,6 +1081,7 @@ export function applyGlobalCaptureShortcut(): GlobalCaptureResult {
     }
   }
 
+  registeredGlobalCaptureAccelerator = accelerator
   logger.info(`Global capture: registered ${accelerator}`)
   return { success: true, registered: true }
 }

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -239,6 +239,8 @@ Eight presets — indigo, amber, emerald, red, violet, cyan, pink, orange — pl
 
 Set a system-wide hotkey to focus the memrynote window from anywhere. macOS requires Accessibility permission.
 
+If your chosen hotkey is already claimed by another app, memrynote keeps its built-in quick capture hotkey (`Cmd`/`Ctrl` + `Shift` + `Space`) registered as a fallback, so quick capture keeps working. Saving keyboard settings re-checks this, and releases the fallback once your own hotkey registers successfully.
+
 ### Shortcut List
 
 Searchable, grouped by category (Navigation, Tabs, Editor, View). Click any row to capture a new binding. Custom bindings show a badge.


### PR DESCRIPTION
## What was wrong

`applyGlobalCaptureShortcut()` opened with `globalShortcut.unregisterAll()` (`apps/desktop/src/main/ipc/settings-handlers.ts:1020` on `main` @ 0e272a690). That releases **every** global accelerator the app holds — including the hardcoded quick-capture fallback `CommandOrControl+Shift+Space` registered separately by `apps/desktop/src/main/index.ts:1846`. It then only re-registered the configured accelerator, so the fallback was gone and never came back.

`quickCaptureShortcutRegistration.fallbackRegistered` was left stale-`true`, so the E2E/diagnostics hook reported a shortcut that no longer existed.

## User-visible symptom

On an install where the user's configured global-capture hotkey is already owned by another app (so the fallback is what actually works), saving **any** keyboard setting containing `globalCapture` (`settings-handlers.ts:897`) silently killed the global quick-capture hotkey. No error, no UI change, no way to tell why — quick capture just stopped responding until the app was restarted.

## What changed

`apps/desktop/src/main/ipc/settings-handlers.ts`
- Track the accelerator this module actually owns and release only that one on re-apply, instead of `unregisterAll()`.
- New `setGlobalCaptureAppliedHandler()`: every apply reports its real outcome (`registered` true/false) to the fallback owner, without this module importing the entrypoint.
- Failure paths are unchanged and still return `{ success: false, error: shortcutInUse }` / `permissionRequired` to the caller, so a conflict is surfaced rather than swallowed.

`apps/desktop/src/main/index.ts`
- Installs `syncQuickCaptureFallbackShortcut` as that handler at startup, so it runs on startup *and* on every later re-apply.
- Registers the fallback when the configured accelerator is unavailable; releases it once the configured one registers.
- `registerQuickCaptureShortcut()` is now idempotent — repeated saves cannot double-register or leave a stale binding. Everything is still released on quit via the existing `will-quit` → `globalShortcut.unregisterAll()`.

No contract, settings-shape, or DB change: the keyboard settings JSON is untouched, so older app versions read it exactly as before.

## How it was verified

Regression tests added in `settings-handlers.test.ts` and `index.phase2.test.ts` cover: unrelated saves leave the fallback registered and firing, repeated saves do not double-register, the fallback is released when the configured accelerator takes over, and a registration conflict is reported to both the caller and the fallback owner.

Mutation-checked — reintroducing `unregisterAll()` and dropping the handler wiring fails 4 of the new tests:

```
 × #given no binding #when registered #then leaves shortcuts it does not own alone
 × #given a re-apply #when the accelerator changes #then releases only the accelerator it owns
 × #given repeated saves #when the accelerator is unchanged #then re-registers exactly once each time
 × releases the quick-capture fallback once the configured accelerator registers
 Tests  4 failed | 108 passed (112)
```

With the fix in place:

```
 Test Files  497 passed | 1 skipped (498)
      Tests  5929 passed | 1 expected fail | 4 skipped (5934)
```

- `pnpm --filter @memry/desktop typecheck:node` — clean
- `pnpm exec eslint <changed source files>` — 0 errors
- `git diff --check` — clean
- `pnpm ipc:check` (via pre-commit) — invoke map up to date
- `pnpm docs:impact --base origin/main --strict` — `covered`; `pnpm docs:build` — `build complete`

Closes #1087
Part of epic #987