### PR TITLE
test(crypto): make the corrupted-checksum recovery-phrase case deterministic

### DIFF
--- a/apps/desktop/src/main/crypto/recovery.test.ts
+++ b/apps/desktop/src/main/crypto/recovery.test.ts
@@ -80,11 +80,15 @@ describe('validateRecoveryPhrase', () => {
   })
 
   it('rejects a phrase with a corrupted checksum word', async () => {
-    // #given a generated phrase whose final (checksum) word is swapped for a different valid word
+    // #given a generated phrase whose final word is swapped for the neighbouring wordlist entry.
+    // The 24th word packs the last 3 entropy bits followed by all 8 checksum bits, so toggling
+    // only bit 0 of its index leaves the entropy — and therefore the expected checksum —
+    // untouched while claiming a different one. Any other replacement re-derives a matching
+    // checksum by chance (7/2048, ~1 in 293) and would make this case flaky. See #1251.
     const { phrase } = await generateRecoveryPhrase()
     const words = phrase.split(' ')
     const lastWord = words[words.length - 1]
-    const replacement = lastWord === 'abandon' ? 'ability' : 'abandon'
+    const replacement = bip39.wordlists.english[bip39.wordlists.english.indexOf(lastWord) ^ 1]
     words[words.length - 1] = replacement
 
     // #then validation rejects the tampered phrase (checksum mismatch)


### PR DESCRIPTION
Closes #1251. Part of epic #987.

## The flake

`validateRecoveryPhrase > rejects a phrase with a corrupted checksum word` corrupted a freshly generated phrase by swapping the last word for a **fixed** one, which re-derives a *valid* BIP-39 checksum roughly **1 run in 293**.

**Measured: 0.339% over 200,000 trials** (678 false-valid corruptions, 1 in 295), matching the predicted **7/2048 = 0.3418%**.

It actually fired on **PR #1240** (`projection-queue-mechanics`), Desktop CI [run 31544489521 attempt 1](https://github.com/memrynote/memry/actions/runs/31544489521/job/93953948509) — the only failed test in the entire job — and passed on attempt 2 with no code change:

```
 FAIL   main  src/main/crypto/recovery.test.ts > validateRecoveryPhrase > rejects a phrase with a corrupted checksum word
AssertionError: expected true to be false // Object.is equality
 ❯ src/main/crypto/recovery.test.ts:91:53
```

## Bit-level cause

`generateRecoveryPhrase()` uses `bip39.generateMnemonic(256)`: ENT = 256, CS = ENT/32 = **8 checksum bits**, 264 bits total = 24 words x 11 bits. The **24th word packs bits 253..263** — the last **3 entropy bits** followed by all **8 checksum bits**.

Swapping it for a fixed word therefore rewrites the entropy tail *and* the claimed checksum, and `validateMnemonic` compares two effectively independent 8-bit values:

- last 3 entropy bits already `000` (p = 1/8) → entropy unchanged, checksum unchanged, and a claimed `0x00` can only match if the word already was `abandon`, which the ternary excluded → never a false pass;
- otherwise (p = 7/8) → entropy changes, recomputed checksum is uniform over 256 values, matches the claimed one with p = 1/256.

**P = 7/8 x 1/256 = 7/2048 ≈ 1 in 293.** (The 1/8 branch was confirmed empirically too: 12.42% of swaps left the entropy untouched, vs 12.5% expected.)

## What changed

One test file, one line of logic. The replacement is now **derived from the actual last word** instead of being a constant:

```ts
const replacement = bip39.wordlists.english[bip39.wordlists.english.indexOf(lastWord) ^ 1]
```

Toggling **bit 0** of the wordlist index changes only a checksum bit and leaves all 3 entropy bits alone, so the recomputed checksum cannot move while the claimed one does — the mismatch is guaranteed for every phrase, and `index ^ 1` is always a distinct valid index in `[0, 2047]`.

The assertion itself is untouched and still real: 24 genuine wordlist words, only the checksum wrong, still `expect(...).toBe(false)`. No retries, no loosened assertion, no seeded RNG, nothing deleted.

## Proof of determinism

2500 iterations of the corruption path through the real `validateRecoveryPhrase` export, old form vs new, in the same run (temporary spec, not committed):

```
NEW form: 0/2500 corrupted phrases still validated
OLD form: 9/2500 corrupted phrases still validated (0.360%) — each one is a red CI run
✓ NEW corruption (wordlist[index ^ 1]) is rejected every single time 26816ms
✓ OLD corruption (fixed abandon/ability) is NOT rejected every time 23568ms
```

And 200,000 iterations directly against `bip39`:

```
iterations: 200000
OLD (fixed 'abandon'/'ability') corrupted-but-still-VALID: 679  -> 0.3395% (1 in 295)  => FLAKY
NEW (wordlist[index ^ 1])      corrupted-but-still-VALID: 0    -> 0.0000%             => DETERMINISTIC
```

So the fix is about determinism, not luck: the old form fails often enough to be caught in minutes, the new one cannot fail at all.

## Sibling audit

The other corruption case in the same file (`rejects a phrase containing a word outside the BIP-39 wordlist`) splices a non-wordlist token and is deterministic. `crypto.test.ts`, `foundation.test.ts` and `tests/e2e/auth-state-machine.e2e.ts` all use fixed known-valid phrases. This was the only instance of the pattern — nothing else needed the same fix.

## Verification

```
pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/crypto
 Test Files  16 passed | 1 skipped (17)
      Tests  254 passed | 1 skipped (255)

pnpm --filter @memry/desktop typecheck:node   # clean
git diff --check                              # clean
pnpm docs:impact --base origin/main --strict  # no desktop/sync-server docs-relevant changes detected
```

ESLint reports the file as ignored — `**/*.test.ts` is in the repo's global `ignores`.

Test-only change: no runtime code, no contract, schema, or format change, so no docs impact and no backward-compatibility surface.
