### PR TITLE
fix(agent-chat): persist settled tool activity rows so reloaded transcripts keep them

### DIFF
--- a/apps/desktop/src/main/agent/runtime/__tests__/turn-tool-activity.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/turn-tool-activity.test.ts
@@ -1,0 +1,416 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import sodium from 'libsodium-wrappers-sumo'
+
+import * as schema from '@memry/db-schema/data-schema'
+
+vi.mock('../event-bus', () => ({
+  broadcastAgentEvent: vi.fn()
+}))
+
+vi.mock('../../../telemetry/track', () => ({
+  trackMainEvent: vi.fn()
+}))
+
+import type { AgentBackendRegistry } from '../../backends/registry'
+import type { AgentBackend, BackendRunHandle } from '../../backends/types'
+import type { ConversationStore } from '../../storage/conversation-store'
+import { createMessageStore, type MessageStore } from '../../storage/message-store'
+import type { Conversation } from '../../storage/types'
+import { persistToolActivity, summarizeToolArgs } from '../tool-activity'
+import { runTurn } from '../turn'
+
+// The persisted transcript is the only copy of a tool row once the renderer has
+// dropped it, so these run against the real encrypted store rather than a stub.
+function freshDb() {
+  const sqlite = new Database(':memory:')
+  sqlite.exec(`
+    CREATE TABLE agent_messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content_ciphertext TEXT NOT NULL,
+      attachments_ciphertext TEXT NOT NULL,
+      tool_call_id TEXT,
+      status TEXT NOT NULL,
+      vector_clock TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER
+    );
+  `)
+  return drizzle(sqlite, { schema })
+}
+
+describe('tool activity persistence', () => {
+  let vaultKey: Uint8Array
+  let db: ReturnType<typeof freshDb>
+  let messages: MessageStore
+
+  beforeAll(async () => {
+    await sodium.ready
+    vaultKey = sodium.randombytes_buf(sodium.crypto_aead_xchacha20poly1305_ietf_KEYBYTES)
+  })
+
+  beforeEach(() => {
+    db = freshDb()
+    messages = createMessageStore({ db, vaultKey, deviceId: 'device-1' })
+  })
+
+  it('keeps the tool rows of a turn in the reloaded transcript', async () => {
+    const backend = createFakeBackend({
+      turn: [
+        {
+          kind: 'tool_use',
+          toolUseId: 'toolu-1',
+          name: 'vault_read_note',
+          args: { title: 'Roadmap' }
+        },
+        { kind: 'tool_result', toolUseId: 'toolu-1', ok: true, data: { text: 'note body' } },
+        { kind: 'assistant_delta', text: 'Read it.' },
+        { kind: 'message_stop' }
+      ]
+    })
+
+    await runTurn(
+      {
+        conversations: createFakeConversationStore(),
+        messages,
+        backends: createFakeRegistry(backend)
+      },
+      {
+        conversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
+        text: 'what is on the roadmap?',
+        attachments: [],
+        backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+      }
+    )
+
+    // Reload — exactly what the renderer re-hydrates with after an eviction.
+    const reloaded = messages.listByConversation('conversation-1')
+    const toolRows = reloaded.filter((message) => message.role === 'tool_call')
+
+    expect(toolRows).toHaveLength(1)
+    expect(toolRows[0].id).toBe('tool-call-toolu-1')
+    expect(toolRows[0].toolCallId).toBe('toolu-1')
+    expect(toolRows[0].status).toBe('completed')
+    expect(toolRows[0].content).toEqual({
+      role: 'tool_call',
+      data: {
+        tool: 'vault_read_note',
+        args: { title: 'Roadmap' },
+        status: 'output-available'
+      }
+    })
+    // The row sits after the assistant message it belongs to, as it does live.
+    expect(reloaded.map((message) => message.role)).toEqual(['user', 'assistant', 'tool_call'])
+  })
+
+  it('records a denied tool call as denied', async () => {
+    const backend = createFakeBackend({
+      turn: [
+        {
+          kind: 'tool_use',
+          toolUseId: 'toolu-2',
+          name: 'vault_update_note',
+          args: { title: 'Roadmap' }
+        },
+        {
+          kind: 'tool_result',
+          toolUseId: 'toolu-2',
+          ok: false,
+          error: { code: 'PERMISSION_DENIED', message: 'User denied request.' }
+        },
+        { kind: 'message_stop' }
+      ]
+    })
+
+    await runTurn(
+      {
+        conversations: createFakeConversationStore(),
+        messages,
+        backends: createFakeRegistry(backend)
+      },
+      {
+        conversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
+        text: 'update the roadmap',
+        attachments: [],
+        backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+      }
+    )
+
+    const toolRow = messages
+      .listByConversation('conversation-1')
+      .find((message) => message.role === 'tool_call')
+
+    expect(toolRow?.status).toBe('error')
+    expect(toolRow?.content).toEqual({
+      role: 'tool_call',
+      data: {
+        tool: 'vault_update_note',
+        args: { title: 'Roadmap' },
+        status: 'output-denied',
+        error: { code: 'PERMISSION_DENIED', message: 'User denied request.' }
+      }
+    })
+  })
+
+  it('stores neither the tool output nor a whole note body from the args', async () => {
+    const noteBody = 'SECRET-BODY '.repeat(200)
+    const backend = createFakeBackend({
+      turn: [
+        {
+          kind: 'tool_use',
+          toolUseId: 'toolu-3',
+          name: 'vault_update_note',
+          args: { title: 'Roadmap', content_markdown: noteBody, mode: 'replace' }
+        },
+        {
+          kind: 'tool_result',
+          toolUseId: 'toolu-3',
+          ok: true,
+          data: { note: { markdown: 'WHOLE-NOTE-OUTPUT' } }
+        },
+        { kind: 'message_stop' }
+      ]
+    })
+
+    await runTurn(
+      {
+        conversations: createFakeConversationStore(),
+        messages,
+        backends: createFakeRegistry(backend)
+      },
+      {
+        conversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
+        text: 'rewrite the roadmap',
+        attachments: [],
+        backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+      }
+    )
+
+    const toolRow = messages
+      .listByConversation('conversation-1')
+      .find((message) => message.role === 'tool_call')
+    const stored = JSON.stringify(toolRow?.content)
+
+    expect(stored).not.toContain('WHOLE-NOTE-OUTPUT')
+    expect(stored.length).toBeLessThan(noteBody.length)
+    expect(toolRow?.content.role === 'tool_call' && toolRow.content.data.args).toEqual({
+      title: 'Roadmap',
+      content_markdown: `${noteBody.slice(0, 200)}…`,
+      mode: 'replace'
+    })
+  })
+
+  it('does not replay persisted tool rows into the next prompt', async () => {
+    const first = createFakeBackend({
+      turn: [
+        {
+          kind: 'tool_use',
+          toolUseId: 'toolu-4',
+          name: 'vault_read_note',
+          args: { title: 'Roadmap' }
+        },
+        { kind: 'tool_result', toolUseId: 'toolu-4', ok: true, data: {} },
+        { kind: 'assistant_delta', text: 'Done.' },
+        { kind: 'message_stop' }
+      ]
+    })
+    const conversations = createFakeConversationStore()
+    await runTurn(
+      { conversations, messages, backends: createFakeRegistry(first) },
+      {
+        conversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
+        text: 'first',
+        attachments: [],
+        backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+      }
+    )
+
+    const second = createFakeBackend({ turn: [{ kind: 'message_stop' }] })
+    await runTurn(
+      { conversations, messages, backends: createFakeRegistry(second) },
+      {
+        conversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
+        text: 'second',
+        attachments: [],
+        backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+      }
+    )
+
+    const prompt = second.runTurn.mock.calls[0][0].prompt as string
+    expect(prompt).toContain('User: first')
+    expect(prompt).toContain('Assistant: Done.')
+    // The tool catalogue names the tools; the transcript must not replay them.
+    expect(prompt).not.toContain('Tool call:')
+    expect(prompt.slice(prompt.indexOf('--- Prior turns ---'))).not.toContain('vault_read_note')
+  })
+
+  it('loads a legacy conversation that has no persisted tool rows', async () => {
+    messages.append({
+      conversationId: 'legacy-1',
+      role: 'user',
+      content: { role: 'user', data: { text: 'older build wrote this' } },
+      attachments: [],
+      status: 'completed'
+    })
+    messages.append({
+      conversationId: 'legacy-1',
+      role: 'assistant',
+      content: { role: 'assistant', data: { text: 'and this' } },
+      attachments: [],
+      status: 'completed'
+    })
+
+    const reloaded = messages.listByConversation('legacy-1')
+    expect(reloaded.map((message) => message.role)).toEqual(['user', 'assistant'])
+    expect(reloaded.some((message) => message.role === 'tool_call')).toBe(false)
+
+    const backend = createFakeBackend({ turn: [{ kind: 'message_stop' }] })
+    await expect(
+      runTurn(
+        {
+          conversations: createFakeConversationStore(),
+          messages,
+          backends: createFakeRegistry(backend)
+        },
+        {
+          conversationId: 'legacy-1',
+          sourceWindowId: 'window-1',
+          text: 'continue',
+          attachments: [],
+          backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+        }
+      )
+    ).resolves.toEqual({ turnId: expect.any(String) })
+  })
+
+  it('never fails a turn because the row could not be written', () => {
+    persistToolActivity(messages, {
+      conversationId: 'conversation-1',
+      toolCallId: 'toolu-dup',
+      name: 'vault_read_note',
+      args: {},
+      outcome: { ok: true }
+    })
+
+    expect(() =>
+      persistToolActivity(messages, {
+        conversationId: 'conversation-1',
+        toolCallId: 'toolu-dup',
+        name: 'vault_read_note',
+        args: {},
+        outcome: { ok: true }
+      })
+    ).not.toThrow()
+    expect(messages.listByConversation('conversation-1')).toHaveLength(1)
+  })
+
+  it('marks an unlabelled failure as an error rather than a denial', () => {
+    persistToolActivity(messages, {
+      conversationId: 'conversation-1',
+      toolCallId: 'toolu-5',
+      name: 'vault_search_notes',
+      args: {},
+      outcome: { ok: false, error: undefined }
+    })
+
+    const row = messages.listByConversation('conversation-1')[0]
+    expect(row.content.role === 'tool_call' && row.content.data.status).toBe('output-error')
+  })
+
+  describe('summarizeToolArgs', () => {
+    it('drops nested payloads and non-object args', () => {
+      expect(summarizeToolArgs({ query: 'roadmap', filters: { tag: 'x' }, ids: [1, 2] })).toEqual({
+        query: 'roadmap'
+      })
+      expect(summarizeToolArgs('not an object')).toEqual({})
+      expect(summarizeToolArgs([1, 2])).toEqual({})
+      expect(summarizeToolArgs(null)).toEqual({})
+    })
+
+    it('keeps scalars and caps the number of keys', () => {
+      const args = Object.fromEntries(
+        Array.from({ length: 20 }, (_, index) => [`key-${index}`, index])
+      )
+      expect(Object.keys(summarizeToolArgs(args))).toHaveLength(12)
+      expect(summarizeToolArgs({ limit: 5, recursive: true, cursor: null })).toEqual({
+        limit: 5,
+        recursive: true,
+        cursor: null
+      })
+    })
+  })
+})
+
+function createFakeConversationStore(overrides: Partial<Conversation> = {}): ConversationStore {
+  const conversation = {
+    id: 'conversation-1',
+    vaultId: 'vault-1',
+    title: 'Existing conversation',
+    backend: 'claude_cli',
+    backendModel: null,
+    trustList: [],
+    pinned: false,
+    vectorClock: {},
+    fieldClocks: {},
+    createdAt: 1,
+    updatedAt: 1,
+    deletedAt: null,
+    lastSyncedAt: null,
+    ...overrides
+  }
+
+  return {
+    create: vi.fn(),
+    getById: vi.fn(() => conversation),
+    listByVault: vi.fn(() => [conversation]),
+    update: vi.fn((_id, patch) => ({ ...conversation, ...patch, updatedAt: 2 })),
+    softDelete: vi.fn(),
+    addToTrustList: vi.fn(),
+    removeFromTrustList: vi.fn()
+  }
+}
+
+function createFakeRegistry(backend: AgentBackend): AgentBackendRegistry {
+  return {
+    get: vi.fn(() => backend),
+    list: vi.fn(() => [backend])
+  }
+}
+
+function createFakeBackend(input: {
+  turn: BackendRunHandle['events'] extends AsyncIterable<infer Event> ? Event[] : never
+}): AgentBackend & { runTurn: ReturnType<typeof vi.fn> } {
+  return {
+    id: 'claude_cli',
+    runTurn: vi.fn(async () => createRunHandle(input.turn)),
+    generateTitle: vi.fn(async () => createRunHandle([])),
+    summarize: vi.fn(async () => createRunHandle([])),
+    cancel: vi.fn(),
+    getStatus: vi.fn(async () => ({ backend: 'claude_cli' as const, available: true })),
+    probeCapabilities: vi.fn()
+  }
+}
+
+function createRunHandle(
+  events: BackendRunHandle['events'] extends AsyncIterable<infer Event> ? Event[] : never
+): BackendRunHandle {
+  return {
+    events: (async function* () {
+      yield* events
+    })(),
+    stderr: (async function* () {})(),
+    pid: 1234,
+    kill: vi.fn(),
+    waitExit: vi.fn(async () => 0),
+    cleanup: vi.fn(async () => {})
+  }
+}

--- a/apps/desktop/src/main/agent/runtime/tool-activity.ts
+++ b/apps/desktop/src/main/agent/runtime/tool-activity.ts
@@ -1,0 +1,96 @@
+import type { ToolCallStatus } from '@memry/contracts/ipc-agent'
+
+import { createLogger } from '../../lib/logger'
+import type { MessageStore } from '../storage/message-store'
+
+const logger = createLogger('AgentRuntime:ToolActivity')
+
+// A tool row is a record of what the agent did, not a copy of what it moved.
+// Args can carry a whole note body (`vault_update_note`) and results can carry
+// a whole search response, so only the identifying scalars are kept, each one
+// bounded. Nested payloads are dropped and the tool output is never stored.
+const MAX_ARG_KEYS = 12
+const MAX_ARG_CHARS = 200
+const MAX_ERROR_CHARS = 500
+
+export type ToolActivityOutcome =
+  | { ok: true }
+  | { ok: false; error: { code: string; message: string } | undefined }
+
+/**
+ * Reduces raw tool args to the small, bounded shape the transcript row renders:
+ * the scalars that name what was touched (`title`, `path`, `query`, ids), with
+ * long strings truncated and nested payloads dropped.
+ */
+export function summarizeToolArgs(args: unknown): Record<string, unknown> {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return {}
+
+  const summary: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+    if (Object.keys(summary).length >= MAX_ARG_KEYS) break
+    if (typeof value === 'string') {
+      summary[key] = value.length > MAX_ARG_CHARS ? `${value.slice(0, MAX_ARG_CHARS)}…` : value
+      continue
+    }
+    if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
+      summary[key] = value
+    }
+  }
+  return summary
+}
+
+function toolStatusFor(outcome: ToolActivityOutcome): ToolCallStatus {
+  if (outcome.ok) return 'output-available'
+  return outcome.error?.code === 'PERMISSION_DENIED' ? 'output-denied' : 'output-error'
+}
+
+/**
+ * Writes a settled tool call into the conversation so the transcript still
+ * shows what the agent did after the renderer drops it — on eviction, on a
+ * sync-driven reload, or on the next app start.
+ *
+ * The id matches the one the renderer synthesises for the live row, so the
+ * reloaded transcript renders the same row rather than a second copy.
+ *
+ * Only settled calls are written: a row appended at `tool_use` time would be
+ * left mid-flight forever if the turn died before the result, and reload it
+ * as a tool that is still spinning.
+ *
+ * Never throws. A transcript record is not worth failing a turn the user's
+ * agent already completed.
+ */
+export function persistToolActivity(
+  messages: MessageStore,
+  input: {
+    conversationId: string
+    toolCallId: string
+    name: string
+    args: unknown
+    outcome: ToolActivityOutcome
+  }
+): void {
+  try {
+    const error = input.outcome.ok ? undefined : input.outcome.error
+    messages.append({
+      id: `tool-call-${input.toolCallId}`,
+      conversationId: input.conversationId,
+      role: 'tool_call',
+      content: {
+        role: 'tool_call',
+        data: {
+          tool: input.name,
+          args: summarizeToolArgs(input.args),
+          status: toolStatusFor(input.outcome),
+          ...(error && {
+            error: { code: error.code, message: error.message.slice(0, MAX_ERROR_CHARS) }
+          })
+        }
+      },
+      toolCallId: input.toolCallId,
+      attachments: [],
+      status: input.outcome.ok ? 'completed' : 'error'
+    })
+  } catch (error) {
+    logger.warn('Failed to persist tool activity row', error)
+  }
+}

--- a/apps/desktop/src/main/agent/runtime/turn.ts
+++ b/apps/desktop/src/main/agent/runtime/turn.ts
@@ -17,6 +17,7 @@ import { broadcastAgentEvent } from './event-bus'
 import { maybeCompact } from './compactor'
 import { assemblePrompt, type PromptContext } from './prompt-assembler'
 import { COMPACTION_THRESHOLD, estimateTokens } from './token-estimator'
+import { persistToolActivity } from './tool-activity'
 import { extractAgentSourceRefs } from '../source-refs'
 import type { AgentSourceRef } from '@memry/contracts/ipc-agent'
 
@@ -59,7 +60,12 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
   // message instead of a multiple of it. Nothing appends to this conversation
   // between here and the last use below except this turn itself, and those
   // appends return the message, so the in-memory copy stays authoritative.
-  const history = deps.messages.listByConversation(input.conversationId)
+  // Tool rows are persisted for the transcript UI only. Prompt assembly has
+  // never seen them — the backends carry their own tool context inside a turn —
+  // so replaying them would double-feed the model and grow every later prompt.
+  const history = deps.messages
+    .listByConversation(input.conversationId)
+    .filter((message) => message.role !== 'tool_call')
   const existingConversation = deps.conversations.getById(input.conversationId)
   const backend = deps.backends.get(input.backendOptions.backend)
   const permissions = input.permissions ?? DEFAULT_TURN_PERMISSIONS
@@ -212,21 +218,39 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
         },
         onToolResult: (toolUseId, data) => {
           const toolCall = toolCalls.get(toolUseId)
+          // An unmatched result names no tool, so there is nothing to record.
           if (!toolCall) return
+          persistToolActivity(deps.messages, {
+            conversationId: input.conversationId,
+            toolCallId: toolUseId,
+            name: toolCall.name,
+            args: toolCall.args,
+            outcome: { ok: true }
+          })
           for (const ref of extractAgentSourceRefs(toolCall.name, toolCall.args, data)) {
             sourceRefs.set(ref.href, ref)
           }
         },
-        onToolFailed: (toolUseId, errorCode) => {
+        onToolFailed: (toolUseId, error) => {
           // The only tool-failure signal for CLI backends — transport failures
           // never reach the MCP server's own catch. Tool name only, never args.
-          const toolName = toolCalls.get(toolUseId)?.name
+          const toolCall = toolCalls.get(toolUseId)
+          const toolName = toolCall?.name
+          if (toolCall) {
+            persistToolActivity(deps.messages, {
+              conversationId: input.conversationId,
+              toolCallId: toolUseId,
+              name: toolCall.name,
+              args: toolCall.args,
+              outcome: { ok: false, error }
+            })
+          }
           trackMainEvent('ai_action_completed', {
             surface: 'ai',
             action: 'tool_call',
             source: backendLabel,
             result: 'failed',
-            errorCode: toSafeToken(errorCode ?? 'INTERNAL', 'INTERNAL'),
+            errorCode: toSafeToken(error?.code ?? 'INTERNAL', 'INTERNAL'),
             ...(toolName ? { dimensions: { tool: toSafeToken(toolName, 'unknown_tool') } } : {})
           })
         },
@@ -583,7 +607,7 @@ async function handleBackendEvent(
     assistantMessageId: string
     onToolUse: (toolUseId: string, name: string, args: unknown) => void
     onToolResult: (toolUseId: string, data: unknown) => void
-    onToolFailed: (toolUseId: string, errorCode: string | undefined) => void
+    onToolFailed: (toolUseId: string, error: { code: string; message: string } | undefined) => void
     onAssistantText: (text: string) => void
     onUnknownEvent: () => void
   }
@@ -621,7 +645,7 @@ async function handleBackendEvent(
         result: event.data
       })
     } else {
-      ctx.onToolFailed(event.toolUseId, event.error?.code)
+      ctx.onToolFailed(event.toolUseId, event.error)
       broadcastAgentEvent({
         kind: 'tool_call_failed',
         conversationId: ctx.conversationId,

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -85,6 +85,16 @@ row settles to a step count, and selecting it expands the individual tool calls 
 and results. A tool that needs your approval keeps the row open, because the Allow and Deny buttons
 live inside it.
 
+Tool activity is saved with the conversation, encrypted in the vault database like the rest of the
+transcript. Reopening a conversation later — after a restart, after a sync, or after memrynote has
+dropped an older transcript from memory — still shows which tools ran, with what parameters, and
+whether each one succeeded, failed, or was denied. The saved record is deliberately smaller than the
+live one: it keeps the tool name, its identifying parameters (long values are shortened), and the
+outcome, but not the tool's returned data. Only tools that finished are recorded, so a turn stopped
+mid-tool leaves no half-finished row behind. Conversations from before this was added simply show no
+tool rows; nothing else about them changes. Saved tool rows are a record for you, not context for the
+assistant — they are never replayed into a later prompt.
+
 When a tool result includes a real memrynote reference, Agent Chat renders that item as a clickable
 mention instead of plain text. Lists link each returned note, task, inbox item, journal entry,
 calendar event, project, or folder that has a navigable reference. Create and update confirmations


### PR DESCRIPTION
Closes #1144. Follow-up from epic #987 (MAJOR tier), surfaced by PR #1125 (issue #1004, transcript eviction).

## Validated on current `main` first

Still real at `f4a5dd4f7`:

- `apps/desktop/src/main/agent/runtime/turn.ts:602-612` — a `tool_use` event only calls `broadcastAgentEvent({ kind: 'tool_call_started' })`. Nothing writes it.
- `apps/desktop/src/main/agent/runtime/turn.ts:614-632` — `tool_result` likewise only broadcasts.
- `MessageStore.append` is called in exactly two places, both in `turn.ts`: `:71` with role `user` and `:179` with role `assistant`.
- `apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts:183-217` — `upsertToolCallMessage` synthesises the row into renderer state only, with a fabricated `tool-call-<toolCallId>` id.

So a reloaded conversation came back with the assistant's text and none of what it actually did. Restart, sync reload, and — since #1125 — LRU eviction of the 7th-oldest transcript all hit it. No later fix in `git log`/blame.

Took option (a) from the issue: persist. Writes to the vault are consent-gated, and the tool rows are the record of that consent, so they should survive the session that produced them.

## What changed

**New `apps/desktop/src/main/agent/runtime/tool-activity.ts`** — `persistToolActivity` writes one `tool_call` message through the existing encrypted `MessageStore`, plus `summarizeToolArgs`.

**`turn.ts`** — persists a row when a tool *settles* (`onToolResult` / `onToolFailed`), and filters `tool_call` rows out of the history it feeds the prompt.

Four decisions worth reviewing:

- **Only settled calls are written.** A row appended at `tool_use` time would be stranded mid-flight if the turn died before the result, and reload as a tool that is still spinning — a broken partial. Denials are not lost: a denied call arrives as `tool_result{ok:false, PERMISSION_DENIED}` and is stored as `output-denied`.
- **The row id is `tool-call-<toolUseId>`** — exactly the id the reducer synthesises — and nothing is broadcast. The live row is untouched; the reloaded transcript renders the same row rather than a duplicate.
- **Stored shape is deliberately small.** Tool name, status, `error{code,message}` (500 chars), and args reduced to scalars only, strings truncated to 200 chars, 12 keys max. **The tool output is never stored**, and nested arg payloads are dropped. Without this, `vault_update_note` would duplicate a whole note body into `agent_messages` and `vault_read_note` would duplicate the note it just read. What survives is what the row renders: which tool, on what, with what outcome.
- **Persisted tool rows are excluded from prompt assembly.** `prompt-assembler.ts:231` can render them, but nothing ever produced them, so including them now would double-feed the model and inflate every later prompt. Filtering at the single `listByConversation` in `turn.ts` keeps prompts and compaction estimates byte-identical to today.

Approval-gate rows (`runtime.ts:85`, id `gate-…`) stay session-only. They are transient prompts, and their outcome already lands on the persisted tool row.

## Migration + compat plan

**No DB migration, no schema change, no contract change, no IPC change.**

- `agent_messages` already stores `role` as free text with a `tool_call_id` column; `MessageRoleSchema` (`packages/contracts/src/ipc-agent.ts:232`) and `MessageContentSchema` (`:310`) already include `tool_call`, and `sync-payloads.ts:364,471` already accept the role on the wire. Nothing new to teach any reader — this uses a lane that was already open.
- **Existing conversations** have no tool rows and get none retroactively. They load exactly as before and simply show no tool activity. Covered by a test.
- **Older app versions** reading a vault or receiving a synced row parse it with the same schemas listed above; the shape is a strict subset of `ToolCallContentSchema` (no `output`, no `approvedArgs`). Their reducer already renders `tool_call` messages, and `ToolCallMessage` already handles a row with no pending approval and no output — that is the shape of every live row before its result arrives.
- **Failure is non-fatal.** `persistToolActivity` never throws: a duplicate id or a write error logs a warning and the turn continues. A transcript record is not worth failing a turn the user's agent already completed.
- Live rows still show full args and output. Reloaded rows show the reduced record. Documented in `apps/docs/src/user-guide/ai/agent-mcp.md`.

## Verification

Tests run against the **real** `createMessageStore` on SQLite with real XChaCha20 encryption, driving `runTurn` with a stub backend — not mocked IPC.

`vitest run --project main src/main/agent/runtime/__tests__/ src/main/agent/storage/__tests__/`

```
 Test Files  21 passed (21)
      Tests  141 passed (141)
```

**Mutation check** — `git stash push -- turn.ts` (source reverted, tests untouched):

```
 × keeps the tool rows of a turn in the reloaded transcript
     AssertionError: expected [] to have a length of 1 but got +0
 × records a denied tool call as denied
     AssertionError: expected undefined to be 'error'
 × stores neither the tool output nor a whole note body from the args
     AssertionError: the given combination of arguments (undefined and string) is invalid
 ✓ does not replay persisted tool rows into the next prompt
 ✓ loads a legacy conversation that has no persisted tool rows
 Tests  3 failed | 6 passed (9)
```

The three reload assertions are load-bearing. The legacy-conversation and prompt-replay cases pass both ways by design — they guard the compat and double-feed risks the fix introduces, not the bug it fixes. Restored and re-verified green.

Also green:

- `pnpm --filter @memry/desktop typecheck:node` and `typecheck:web` — clean
- `pnpm exec eslint` on the changed files — 0 errors, 0 warnings
- `git diff --check` — clean
- `pnpm docs:impact --base origin/main --strict` — `covered`
- `pnpm docs:build` — `build complete in 6.32s`

`pnpm ipc:generate` / `ipc:check` not applicable: no contract, preload, handler, or channel touched.
