### PR TITLE
fix(tooling): stop the secret scanner reading fts5 tokenize= as a credential

### DIFF
--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Test secret scanner rules
+        run: node --test scripts/check-staged-secrets.test.mjs
+
       - name: Scan changed files for secrets
         env:
           BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}

--- a/apps/desktop/src/main/database/fts-inbox.ts
+++ b/apps/desktop/src/main/database/fts-inbox.ts
@@ -12,14 +12,14 @@ import type { DataDb } from './client'
  */
 
 export function createFtsInboxTable(db: DataDb): void {
-  // `tokenize=` trails the column above deliberately — see the note in fts.ts.
   db.run(sql`
     CREATE VIRTUAL TABLE IF NOT EXISTS fts_inbox USING fts5(
       id UNINDEXED,
       title,
       content,
       transcription,
-      source_title, tokenize='porter unicode61'
+      source_title,
+      tokenize='porter unicode61'
     )
   `)
 }

--- a/apps/desktop/src/main/database/fts-tasks.ts
+++ b/apps/desktop/src/main/database/fts-tasks.ts
@@ -12,13 +12,13 @@ import type { DataDb } from './client'
  */
 
 export function createFtsTasksTable(db: DataDb): void {
-  // `tokenize=` trails the column above deliberately — see the note in fts.ts.
   db.run(sql`
     CREATE VIRTUAL TABLE IF NOT EXISTS fts_tasks USING fts5(
       id UNINDEXED,
       title,
       description,
-      tags, tokenize='porter unicode61'
+      tags,
+      tokenize='porter unicode61'
     )
   `)
 }

--- a/apps/desktop/src/main/database/fts.ts
+++ b/apps/desktop/src/main/database/fts.ts
@@ -22,17 +22,13 @@ export function createFtsTable(db: IndexDb): void {
   // - content: searchable note body (markdown)
   // - tags: space-separated tags for searching
   // - tokenize: porter stemmer + unicode support for international text
-  //
-  // Keep `tokenize=` trailing the column above rather than starting its own
-  // line: scripts/check-staged-secrets.mjs flags any line-initial assignment
-  // whose key contains "token", so a bare `tokenize=` line fails the Secret
-  // scan CI job on every PR that touches this file.
   db.run(sql`
     CREATE VIRTUAL TABLE IF NOT EXISTS fts_notes USING fts5(
       id UNINDEXED,
       title,
       content,
-      tags, tokenize='porter unicode61'
+      tags,
+      tokenize='porter unicode61'
     )
   `)
 }

--- a/apps/docs/src/contribute/gotchas.md
+++ b/apps/docs/src/contribute/gotchas.md
@@ -202,6 +202,8 @@ GitHub code scanning and the local staged-secret hook are intentionally conserva
 - For generated TypeScript, prefer data tables plus runtime assembly over interpolating dynamic keys into code snippets.
 - In fixtures, avoid object fields named `token`, `secret`, or `apiKey` when the value is runtime data. Use a neutral field name and keep the real header name only at the request boundary.
 
+`scripts/check-staged-secrets.mjs` treats an assignment as credential-shaped only when a sensitive keyword (`SECRET`, `TOKEN`, `PASSWORD`, `API_KEY`, …) is a whole word in the key: `ACCESS_TOKEN`, `refreshToken`, and `APIToken` are scanned, while identifiers that merely contain one inside a longer word — fts5's `tokenize='porter unicode61'`, `tokenizer`, `passwordless` — are not. `scripts/check-staged-secrets.test.mjs` covers both directions and runs in the Secret scan CI job; extend it when you change the rules rather than reformatting the code that trips them.
+
 ## Pre-Production Database
 
 memrynote is pre-production and the DB schema is **resettable**. There are no backward-compat constraints on schema changes within the desktop app. If a migration is messy, deleting the local vault is a valid recovery.

--- a/scripts/check-staged-secrets.mjs
+++ b/scripts/check-staged-secrets.mjs
@@ -18,8 +18,23 @@ const testPathPattern = /(?:\.test|\.spec)\.[cm]?[jt]sx?$/
 
 const markdownPathPattern = /\.md$/i
 
-const secretAssignmentPattern =
-  /^\s*(?:export\s+)?([A-Z0-9_]*(?:SECRET|TOKEN|PRIVATE_KEY|API_KEY|PASSWORD|HMAC_KEY|CSC_LINK|KEY_PASSWORD)[A-Z0-9_]*)\s*[:=]\s*["']?([^"'\s#][^#\n]*)/i
+const secretKeywords = [
+  'SECRET',
+  'TOKEN',
+  'PRIVATE_KEY',
+  'API_KEY',
+  'PASSWORD',
+  'HMAC_KEY',
+  'CSC_LINK',
+  'KEY_PASSWORD'
+]
+
+const secretAssignmentPattern = new RegExp(
+  `^\\s*(?:export\\s+)?([A-Z0-9_]*(?:${secretKeywords.join('|')})[A-Z0-9_]*)\\s*[:=]\\s*["']?([^"'\\s#][^#\\n]*)`,
+  'i'
+)
+
+const secretKeywordWordPattern = new RegExp(`(?:^|_)(?:${secretKeywords.join('|')})(?:_|$)`)
 
 const tokenPatterns = [
   {
@@ -134,6 +149,19 @@ function isCodeDeclarationValue(filePath, value) {
   )
 }
 
+function isSecretKeywordKey(key) {
+  // Only treat the key as credential-shaped when a sensitive keyword stands as
+  // its own word (`ACCESS_TOKEN`, `refreshToken`, `token`). Identifiers that
+  // merely contain one inside a longer word are ordinary SQL or config syntax
+  // — fts5's `tokenize='porter unicode61'` is not a leaked token.
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .toUpperCase()
+
+  return secretKeywordWordPattern.test(words)
+}
+
 function isPlaceholderValue(value) {
   const normalized = normalizeValue(value).toLowerCase()
 
@@ -212,6 +240,7 @@ export function scanTextForSecrets(filePath, text) {
 
     if (
       tokenLines.has(index + 1) ||
+      !isSecretKeywordKey(key) ||
       key.toUpperCase().includes('PUBLIC_KEY') ||
       isCodeDeclarationValue(filePath, value) ||
       isPlaceholderValue(value)

--- a/scripts/check-staged-secrets.test.mjs
+++ b/scripts/check-staged-secrets.test.mjs
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test'
 import { scanTextForSecrets } from './check-staged-secrets.mjs'
 
 const rules = (text) => scanTextForSecrets('apps/example/Component.tsx', text).map((f) => f.rule)
+const envRules = (text) => scanTextForSecrets('deploy/service.env', text).map((f) => f.rule)
 
 describe('check-staged-secrets JSX handling', () => {
   it('ignores token-named JSX props whose value is a code reference', () => {
@@ -50,6 +51,57 @@ describe('check-staged-secrets function values', () => {
 
   it('still flags an arrow function body containing a string literal', () => {
     assert.deepEqual(rules("  getAccessToken: (force) => 'hunter2secretvalue'"), [
+      'high-risk-secret-assignment'
+    ])
+  })
+})
+
+describe('check-staged-secrets keyword word boundaries', () => {
+  it('ignores an fts5 tokenize= option in a CREATE VIRTUAL TABLE block', () => {
+    const ddl = [
+      'db.run(sql`',
+      '  CREATE VIRTUAL TABLE IF NOT EXISTS fts_notes USING fts5(',
+      '    id UNINDEXED,',
+      '    title,',
+      '    content,',
+      '    tags,',
+      "    tokenize='porter unicode61'",
+      '  )',
+      '`)'
+    ].join('\n')
+
+    assert.deepEqual(
+      scanTextForSecrets('apps/desktop/src/main/database/fts.ts', ddl).map((f) => f.rule),
+      []
+    )
+  })
+
+  it('ignores identifiers that only contain a sensitive keyword inside a longer word', () => {
+    assert.deepEqual(rules("  tokenizer: 'porter unicode61',"), [])
+    assert.deepEqual(rules("  passwordless: 'magic-link-flow',"), [])
+  })
+
+  it('still flags a snake-case token key assigned a credential literal', () => {
+    assert.deepEqual(rules("  API_TOKEN = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'"), [
+      'high-risk-secret-assignment'
+    ])
+  })
+
+  it('still flags a camelCase token key assigned a credential literal', () => {
+    assert.deepEqual(rules("  accessToken: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',"), [
+      'high-risk-secret-assignment'
+    ])
+  })
+
+  it('still flags a consecutive-caps token key assigned a credential literal', () => {
+    assert.deepEqual(rules("  APIToken: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',"), [
+      'high-risk-secret-assignment'
+    ])
+  })
+
+  it('still flags env-style credential assignments', () => {
+    assert.deepEqual(envRules('API_TOKEN=a1b2c3d4e5f67890abcdef'), ['high-risk-secret-assignment'])
+    assert.deepEqual(envRules('export DB_PASSWORD=hunter2hunter2'), [
       'high-risk-secret-assignment'
     ])
   })


### PR DESCRIPTION
Follow-up from epic #987 (MAJOR tier). Surfaced in PR #1114 (issue #993).

## The false positive

`scripts/check-staged-secrets.mjs` matched any line-initial key that merely *contained* `SECRET` / `TOKEN` / `PASSWORD` / ... as a substring, so an fts5 table option read as a leaked credential:

```
apps/desktop/src/main/database/fts.ts:31 high-risk-secret-assignment - tokenize assignment
apps/desktop/src/main/database/fts-tasks.ts:21 high-risk-secret-assignment - tokenize assignment
apps/desktop/src/main/database/fts-inbox.ts:22 high-risk-secret-assignment - tokenize assignment
```

(that output is the pre-fix scanner run against the DDL in this PR). The `isSourceCodeReferenceValue` escape hatch never applied either — it bails on quoted values, and the value is `'porter unicode61'`. The `Secret scan` job in `security-ci.yml` runs the same script, so the PR check went red and `--no-verify` was the fastest way past it.

## Pattern before / after

Before — one regex, keyword anywhere inside the key:

```js
/^\s*(?:export\s+)?([A-Z0-9_]*(?:SECRET|TOKEN|...)[A-Z0-9_]*)\s*[:=]\s*["']?([^"'\s#][^#\n]*)/i
```

After — same match, plus a key guard requiring the keyword to stand as its own word. The keyword list is now a single shared source for both the assignment pattern and the guard:

```js
const secretKeywordWordPattern = new RegExp(`(?:^|_)(?:${secretKeywords.join('|')})(?:_|$)`)

function isSecretKeywordKey(key) {
  const words = key
    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
    .toUpperCase()

  return secretKeywordWordPattern.test(words)
}
```

Only the **key** is narrowed. Every value heuristic, the `tokenPatterns` list (GitHub / Slack / AWS / OpenAI / private-key blocks), and the file-scope rules are untouched — no path exclusion, no rule deleted.

The three FTS DDL blocks go back to natural formatting (`tokenize=` on its own line) and the comments explaining the reformat are gone.

## Fixtures — both directions

`scripts/check-staged-secrets.test.mjs`, now wired into the `Secret scan` job (`node --test`, no install needed):

Stops matching: a full `CREATE VIRTUAL TABLE ... tokenize='porter unicode61'` block, `tokenizer: 'porter unicode61'`, `passwordless: 'magic-link-flow'`.

Still matches (`high-risk-secret-assignment`): `API_TOKEN = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'`, `accessToken: '...'`, `APIToken: '...'`, `API_TOKEN=a1b2c3d4e5f67890abcdef` and `export DB_PASSWORD=hunter2hunter2` in a non-source `.env` path — plus all nine pre-existing "still flags" cases.

Mutation-tested in both directions:

```
=== MUTATION: scanner reverted to origin/main ===
ℹ tests 17
ℹ pass 15
ℹ fail 2
✖ ignores an fts5 tokenize= option in a CREATE VIRTUAL TABLE block
✖ ignores identifiers that only contain a sensitive keyword inside a longer word

=== MUTATION 2: rule narrowed to nothing (isSecretKeywordKey -> false) ===
ℹ tests 17
ℹ pass 8
ℹ fail 9   (every "still flags ..." case)

=== fix in place ===
ℹ tests 17
ℹ pass 17
ℹ fail 0
```

## Local verification

- `node scripts/check-staged-secrets.mjs --changed origin/main` → exit 0
- `node --test scripts/check-staged-secrets.test.mjs` → 17/17
- `eslint` on the changed files → 0 errors; `git diff --check` clean
- `tsc --noEmit -p tsconfig.node.json` (desktop) → exit 0
- `docs:impact --base origin/main --strict` → `covered`; `docs:build` → complete

## Noted, not changed

`privateKey`-style camelCase keys never matched the assignment rule at all (`PRIVATE_KEY` in the keyword list needs the underscore). That is a pre-existing gap in the *widening* direction and out of scope here.

Closes #1143
