### PR TITLE
fix(projections): abort every outstanding reconcile pass at stop()

### DIFF
--- a/apps/desktop/src/main/projections/runtime.test.ts
+++ b/apps/desktop/src/main/projections/runtime.test.ts
@@ -380,6 +380,174 @@ describe('projection runtime', () => {
   })
 
   /**
+   * A pass that polls its signal between steps, so an abort that never arrives
+   * shows up as work continuing after stop() resolved.
+   */
+  function createReconcileTracker(steps = 40, stepMs = 20) {
+    const state = { inFlight: 0, completed: 0, steps: 0 }
+
+    const reconcile = async (signal?: AbortSignal): Promise<void> => {
+      state.inFlight += 1
+      try {
+        for (let i = 0; i < steps; i++) {
+          if (signal?.aborted) {
+            return
+          }
+          state.steps += 1
+          await new Promise((resolve) => setTimeout(resolve, stepMs))
+        }
+        state.completed += 1
+      } finally {
+        state.inFlight -= 1
+      }
+    }
+
+    return { state, reconcile }
+  }
+
+  /**
+   * #1083's post-reindex embedding drain (`reconcileProjections(['embedding'])`)
+   * can fire while `openVault`'s backgrounded full pass is still running, so two
+   * reconciles overlap. The runtime kept a single controller/promise pair and
+   * the second call overwrote both, leaving the first pass with a signal nobody
+   * held: stop() aborted and awaited only the newest pass, and the older one
+   * kept reading the vault the caller was already closing (#803/#805 stall
+   * class).
+   */
+  it('stop aborts every outstanding reconcile pass, not just the newest', async () => {
+    const { state, reconcile } = createReconcileTracker()
+    const runtime = createProjectionRuntime({
+      projectors: [createProjector('search', { reconcile })]
+    })
+
+    const first = runtime.reconcile()
+    const second = runtime.reconcile(['search'])
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    await runtime.stop()
+
+    // Nothing may still be inside reconcile() when stop() resolves: the caller
+    // closes the databases on the next line.
+    expect(state.inFlight).toBe(0)
+    expect(state.completed).toBe(0)
+
+    // And no pass may resume afterwards.
+    const stepsAtStop = state.steps
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    expect(state.steps).toBe(stepsAtStop)
+
+    await Promise.all([first, second])
+  })
+
+  it('stop stays bounded with two reconcile passes outstanding', async () => {
+    // 40 steps x 20ms = 800ms per pass if nothing aborts it.
+    const { state, reconcile } = createReconcileTracker()
+    const runtime = createProjectionRuntime({
+      projectors: [createProjector('search', { reconcile })]
+    })
+
+    const first = runtime.reconcile()
+    const second = runtime.reconcile(['search'])
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    const startedAt = Date.now()
+    await runtime.stop()
+    const elapsed = Date.now() - startedAt
+
+    // Prompt: `closeVault()` awaits stop(), and 800ms of unaborted repair per
+    // pass must not be on that path.
+    expect(elapsed).toBeLessThan(400)
+    expect(state.steps).toBeLessThan(10)
+    // Prompt *and* complete — returning early while a pass keeps reading the
+    // vault is what made the old stall silent.
+    expect(state.inFlight).toBe(0)
+
+    await Promise.all([first, second])
+  })
+
+  it('runs overlapping reconcile passes one at a time', async () => {
+    const { state, reconcile } = createReconcileTracker(2, 10)
+    const peak = { inFlight: 0 }
+    const runtime = createProjectionRuntime({
+      projectors: [
+        createProjector('search', {
+          reconcile: async (signal?: AbortSignal) => {
+            const pass = reconcile(signal)
+            peak.inFlight = Math.max(peak.inFlight, state.inFlight)
+            await pass
+          }
+        })
+      ]
+    })
+
+    await Promise.all([runtime.reconcile(), runtime.reconcile(['search'])])
+
+    // Both repairs still run — serializing must not coalesce one away.
+    expect(state.completed).toBe(2)
+    expect(peak.inFlight).toBe(1)
+  })
+
+  it('keeps queuing passes after one fails, and no-ops a pass requested after stop', async () => {
+    const seen: string[] = []
+    const runtime = createProjectionRuntime({
+      projectors: [
+        createProjector('search', {
+          reconcile: vi.fn(async () => {
+            seen.push('pass')
+            if (seen.length === 1) {
+              throw new Error('reconcile exploded')
+            }
+          })
+        })
+      ]
+    })
+
+    const failing = runtime.reconcile()
+    const next = runtime.reconcile()
+
+    await expect(failing).rejects.toThrow('reconcile exploded')
+    await next
+    expect(seen).toHaveLength(2)
+
+    await runtime.stop()
+
+    // The databases are closed by now, so a late caller must not reach a
+    // projector.
+    await runtime.reconcile()
+    expect(seen).toHaveLength(2)
+  })
+
+  it('loses no projection events while reconcile passes are outstanding', async () => {
+    const projected: string[] = []
+    const { reconcile } = createReconcileTracker()
+    const runtime = createProjectionRuntime({
+      projectors: [
+        createProjector('search', {
+          reconcile,
+          project: async (event: ProjectionEvent) => {
+            await new Promise((resolve) => setTimeout(resolve, 1))
+            projected.push(eventEntityId(event))
+          }
+        })
+      ]
+    })
+
+    const first = runtime.reconcile()
+    const second = runtime.reconcile(['search'])
+
+    const ids = ['note-a', 'note-b', 'note-c']
+    for (const id of ids) {
+      runtime.publish(markdownEvent(id, id))
+    }
+
+    await runtime.stop()
+
+    expect(projected).toEqual(ids)
+
+    await Promise.all([first, second])
+  })
+
+  /**
    * #1078: `flushProjectionEvents()` waited for *every* lane, and the indexer
    * awaits it once per file. That put the embedding lane's model load plus
    * per-note inference in front of every file the 8-worker pool touched.

--- a/apps/desktop/src/main/projections/runtime.ts
+++ b/apps/desktop/src/main/projections/runtime.ts
@@ -92,8 +92,38 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
   // it), so stop() has to be able to cut it short: without this, switching
   // vaults left the previous runtime's pass reading the old vault path against
   // a database that closeVault had already closed (#993).
-  let reconcileAbort: AbortController | null = null
-  let activeReconcile: Promise<unknown> | null = null
+  //
+  // There can be more than one outstanding pass: `openVault` fires a full
+  // reconcile without awaiting it, and a reindex or a structural config change
+  // fires the embedding drain on top of it (#1083). A single
+  // controller/promise pair let the second call overwrite the first, so stop()
+  // aborted and awaited only the newest pass while the older one kept reading
+  // the closing vault with a signal nobody held — the same unabortable stall as
+  // #803/#805. Every outstanding controller is tracked so stop() can abort all
+  // of them.
+  const reconcileControllers = new Set<AbortController>()
+  // Passes run one at a time, chained onto this tail: two concurrent passes
+  // would repeat the same repair work (the embedding drain is a subset of the
+  // full pass) against the same index database. stop() awaits the tail, which
+  // covers the running pass and everything queued behind it.
+  let reconcileChain: Promise<unknown> = Promise.resolve()
+
+  const runReconcilePass = async (
+    controller: AbortController,
+    names?: string[]
+  ): Promise<Record<string, unknown>> => {
+    const results: Record<string, unknown> = {}
+
+    for (const projector of selectProjectors(options.projectors, names)) {
+      if (controller.signal.aborted) {
+        break
+      }
+
+      results[projector.name] = await projector.reconcile(controller.signal)
+    }
+
+    return results
+  }
 
   const lanes: ProjectorLane[] = options.projectors.map((projector) => ({
     projector,
@@ -293,38 +323,35 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
 
     async reconcile(names) {
       const controller = new AbortController()
-      const run = (async () => {
-        const results: Record<string, unknown> = {}
 
-        for (const projector of selectProjectors(options.projectors, names)) {
-          if (controller.signal.aborted) {
-            break
-          }
+      // A pass that arrives once stop() has begun would run against databases
+      // the caller is about to close, and stop() has already aborted the
+      // controllers it knew about. Start it pre-aborted so it no-ops instead.
+      if (isStopping || isStopped) {
+        controller.abort()
+      }
 
-          results[projector.name] = await projector.reconcile(controller.signal)
-        }
+      reconcileControllers.add(controller)
 
-        return results
-      })()
-
-      reconcileAbort = controller
-      activeReconcile = run
+      const run = reconcileChain.then(() => runReconcilePass(controller, names))
+      // The tail swallows, so it never rejects: a failing pass must not stop
+      // the next one from being queued, and stop() awaits this handle.
+      reconcileChain = run.then(
+        () => {},
+        () => {}
+      )
 
       try {
         return await run
       } finally {
-        if (reconcileAbort === controller) {
-          reconcileAbort = null
-        }
-        if (activeReconcile === run) {
-          activeReconcile = null
-        }
+        reconcileControllers.delete(controller)
       }
     },
 
     async stop(stopOptions) {
-      reconcileAbort?.abort()
-      const pendingReconcile = activeReconcile
+      for (const controller of reconcileControllers) {
+        controller.abort()
+      }
 
       isStopping = true
 
@@ -345,11 +372,11 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
         lane.bus.clear()
       }
 
-      // Wait for the aborted pass to unwind before returning: the caller closes
-      // the databases right after this resolves.
-      if (pendingReconcile) {
-        await pendingReconcile.catch(() => {})
-      }
+      // Wait for the aborted passes to unwind before returning: the caller
+      // closes the databases right after this resolves. Reading the tail here
+      // (rather than at the top of stop()) also covers a pass queued during the
+      // drain — which starts pre-aborted, so it adds no wait.
+      await reconcileChain
     },
 
     getPendingCount() {

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -66,6 +66,16 @@ still being refilled cannot keep it alive) and gives up after a few seconds. Wha
 queued at that point is derived state; the next open re-derives it. The event already inside
 `project()` is always awaited, so the databases never close underneath a running projector.
 
+**Reconcile passes run one at a time and are all cancellable.** Alongside the event queues,
+projectors expose a reconcile pass that repairs derived state wholesale. More than one can be
+requested at once — opening a vault fires a full pass in the background, and a reindex or a
+structural config change fires an embedding-only pass on top of it — so the passes are chained
+and run sequentially rather than concurrently over the same index database. Every outstanding
+pass receives a cancellation signal when the vault closes, and the close waits for all of them
+to unwind before the databases are closed; a pass requested after the close has started never
+reaches a projector. This keeps vault switching and app quit bounded no matter how many repairs
+are in flight.
+
 ## Where the Files Live
 
 Inside the vault directory (chosen during [first run](/guide/first-run)):


### PR DESCRIPTION
Closes #1253. Part of the performance audit epic #987.

## The bug

`apps/desktop/src/main/projections/runtime.ts:95-96` tracked the in-flight reconcile pass in a single pair:

```ts
let reconcileAbort: AbortController | null = null
let activeReconcile: Promise<unknown> | null = null
```

`reconcile()` overwrote both on every call (`runtime.ts:310-311`), so a second pass starting while a first was still running dropped the first one's controller and promise on the floor. `stop()` (`runtime.ts:326` and `runtime.ts:350-352`) only ever aborted and awaited the newest pass — the older one had a signal nobody held and nothing waiting on it.

`stop()` is what `closeVault()` and app quit await, and the caller closes the data and index databases as soon as it resolves. So an orphaned pass kept reading a vault that was being torn down: exactly what the abort handle was added for in #993, and the same unabortable-work stall as #803 (vault hang on embeddings) and #805 (Windows update "cannot close").

**#1243 (issue #1083) made the overlap likely.** There are now two callers that can run at the same time:

- `apps/desktop/src/main/vault/index.ts:434` — `void reconcileProjections()` fired unawaited right after the vault is marked open; the embedding portion runs for minutes on a large vault.
- `apps/desktop/src/main/vault/index.ts:580` — `drainDeferredEmbeddings()` → `void reconcileProjections(['embedding'])`, added by #1243 after `reindex()` and after `updateConfig`'s structural rebuild.

A reindex started during the open-time pass clobbered that pass's abort handle. #1243's own comment at `vault/index.ts:576-578` — "`stopProjectionRuntime` aborts the pass, so this cannot hold vault close open" — was not true in that window. This PR makes it true.

## Design chosen: serialize, and track every controller

Both were on the table. I took **(a) serialize** as the primary mechanism and folded in **(b) track everything** as the safety net, because serialization alone still needs a handle on the queued passes:

- Passes chain onto a `reconcileChain` tail and run one at a time. Concurrency here was never a feature — `reconcileProjections(['embedding'])` is a strict *subset* of the full pass, so overlapping them re-ran the same model inference over the same deferred set, twice, against the same index DB. Serializing removes duplicated repair work as well as the abort hazard.
- Every outstanding controller (running *and* queued) lives in a `Set`, so `stop()` aborts all of them, not just the head.
- A pass requested once `stop()` has begun starts pre-aborted — the databases are closing, so it must not reach a projector.

Serializing does not coalesce: each `reconcile()` call still runs its pass, just after the previous one. A repair is never dropped.

## How I proved close stays bounded

`stop()` aborts every controller, then awaits `reconcileChain` — the tail, which covers the running pass *and* everything queued behind it. Because every queued pass is pre-aborted, it breaks before its first projector, so the tail adds no wait beyond the one pass actually in flight. `isStopping`, the 5s `DEFAULT_STOP_DRAIN_TIMEOUT_MS` drain cap, and the `await Promise.all(lane.activeDrain)` from #1240 are untouched.

Two of the new tests cover it directly:

- `stop stays bounded with two reconcile passes outstanding` — two passes each worth 800ms of unaborted repair; asserts `stop()` returns in under 400ms **and** that `inFlight === 0` when it does. Prompt *and* complete: returning early while a pass keeps reading the vault is what made the old stall silent.
- `stop aborts every outstanding reconcile pass, not just the newest` — asserts nothing is inside `reconcile()` when `stop()` resolves, and that no pass resumes in the 120ms after.

## Verification

Mutation test — reverted `runtime.ts` to `origin/main`, kept the new tests:

```
 × stop aborts every outstanding reconcile pass, not just the newest 46ms
   → expected 1 to be +0 // Object.is equality
 × runs overlapping reconcile passes one at a time 22ms
   → expected 2 to be 1 // Object.is equality
      Tests  2 failed | 19 passed (21)
```

`expected 1 to be +0` is a reconcile pass still running after `stop()` resolved — the bug, reproduced. With the fix restored, all pass.

```
$ pnpm --filter @memry/desktop typecheck:node
$ pnpm exec tsc --noEmit -p tsconfig.node.json --composite false
(clean)

$ pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/projections src/main/vault
 Test Files  29 passed (29)
      Tests  615 passed (615)

$ pnpm exec eslint apps/desktop/src/main/projections/runtime.ts
(0 errors)

$ git diff --check
(clean)
```

Patch coverage on the changed file, locally:

```
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
 runtime.ts |   98.37 |    96.29 |   96.96 |   98.24 | 138,198
```

Lines 138 and 198 are pre-existing and outside this diff; every new line is covered.

Docs: `pnpm docs:impact --base origin/main --strict` → `covered`, `pnpm docs:build` → `build complete`. `apps/docs/src/architecture/local-storage.md` gained a paragraph on reconcile passes being serialized and cancellable, next to the existing vault-close drain paragraph.

## Tests added

- `stop aborts every outstanding reconcile pass, not just the newest`
- `stop stays bounded with two reconcile passes outstanding`
- `runs overlapping reconcile passes one at a time` (both repairs still run — serializing must not coalesce one away)
- `keeps queuing passes after one fails, and no-ops a pass requested after stop`
- `loses no projection events while reconcile passes are outstanding` — events published while two passes are outstanding all land, in publish order, across the stop drain

Refs #987, #1243, #1240.
