### PR TITLE
fix(sync): never drop a CRDT update that overflows one request

### DIFF
--- a/apps/desktop/src/main/sync/crdt-payload.test.ts
+++ b/apps/desktop/src/main/sync/crdt-payload.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import {
+  planCrdtUpdatePush,
+  MAX_CRDT_UPDATE_PAYLOAD_CHARS,
+  MAX_CRDT_REQUEST_PAYLOAD_CHARS
+} from './crdt-payload'
+
+const payload = (chars: number): string => 'a'.repeat(chars)
+
+describe('planCrdtUpdatePush', () => {
+  it('keeps a batch that fits in one request', () => {
+    const updates = [payload(10), payload(20)]
+    expect(planCrdtUpdatePush(updates)).toEqual({ requests: [updates], oversized: [] })
+  })
+
+  it('splits a batch across requests instead of discarding it', () => {
+    // Six max-size updates: five fill a request exactly, the sixth starts another.
+    const updates = Array.from({ length: 6 }, () => payload(MAX_CRDT_UPDATE_PAYLOAD_CHARS))
+
+    const plan = planCrdtUpdatePush(updates)
+
+    expect(plan.oversized).toHaveLength(0)
+    expect(plan.requests.map((request) => request.length)).toEqual([5, 1])
+    // Nothing lost, nothing duplicated, order preserved.
+    expect(plan.requests.flat()).toHaveLength(updates.length)
+    for (const request of plan.requests) {
+      const chars = request.reduce((sum, update) => sum + update.length, 0)
+      expect(chars).toBeLessThanOrEqual(MAX_CRDT_REQUEST_PAYLOAD_CHARS)
+    }
+  })
+
+  it('reports an update larger than a single request as oversized, never dropped', () => {
+    const huge = payload(MAX_CRDT_UPDATE_PAYLOAD_CHARS + 1)
+    const small = payload(32)
+
+    const plan = planCrdtUpdatePush([small, huge, small])
+
+    expect(plan.oversized).toHaveLength(1)
+    expect(plan.oversized[0]).toBe(huge)
+    expect(plan.requests).toEqual([[small, small]])
+  })
+
+  it('sends an update sitting exactly on the per-update budget', () => {
+    const exact = payload(MAX_CRDT_UPDATE_PAYLOAD_CHARS)
+
+    const plan = planCrdtUpdatePush([exact])
+
+    expect(plan.oversized).toHaveLength(0)
+    expect(plan.requests).toHaveLength(1)
+    expect(plan.requests[0]?.[0]).toBe(exact)
+  })
+
+  it('handles an empty batch', () => {
+    expect(planCrdtUpdatePush([])).toEqual({ requests: [], oversized: [] })
+  })
+
+  it('stays inside the server limits it is derived from', () => {
+    // D1 caps a row at 1,000,000 bytes and base64 decodes to 3/4 of its length.
+    expect((MAX_CRDT_UPDATE_PAYLOAD_CHARS * 3) / 4).toBeLessThan(1_000_000)
+    // /sync/* bodies are capped at 8 MiB, envelope included.
+    expect(MAX_CRDT_REQUEST_PAYLOAD_CHARS).toBeLessThan(8 * 1024 * 1024)
+  })
+})

--- a/apps/desktop/src/main/sync/crdt-payload.ts
+++ b/apps/desktop/src/main/sync/crdt-payload.ts
@@ -1,0 +1,54 @@
+/**
+ * Size budgets for the CRDT incremental push path, in base64 characters —
+ * that is what actually rides on the wire, and base64 inflates bytes by 4/3.
+ *
+ * Per update: the server stores every update as a BLOB inside a D1
+ * `crdt_updates` row (`apps/sync-server/src/services/crdt.ts`), and a D1 row is
+ * capped at 1,000,000 bytes. 1,200,000 chars decode to 900,000 bytes, which
+ * leaves the rest of the row (ids, sequence, device, timestamps) inside the cap.
+ * The route's own 5MB check is not the binding limit here; D1 is.
+ *
+ * Per request: `/sync/*` bodies are capped at 8 MiB (`MAX_BODY_BYTES_SYNC` in
+ * `apps/sync-server/src/index.ts`), so a 6,000,000 char budget leaves ample room
+ * for the JSON envelope around the updates.
+ */
+export const MAX_CRDT_UPDATE_PAYLOAD_CHARS = 1_200_000
+export const MAX_CRDT_REQUEST_PAYLOAD_CHARS = 6_000_000
+
+export interface CrdtUpdatePushPlan {
+  /** Batches to POST in order. Every batch fits both budgets. */
+  requests: string[][]
+  /** Updates no single incremental request can carry. */
+  oversized: string[]
+}
+
+/**
+ * Split an encoded batch into requests the server will accept.
+ *
+ * Nothing is discarded: an update either lands in a request or in `oversized`,
+ * and the caller must route `oversized` somewhere that converges (a full
+ * snapshot push) rather than dropping it.
+ */
+export function planCrdtUpdatePush(b64Updates: string[]): CrdtUpdatePushPlan {
+  const requests: string[][] = []
+  const oversized: string[] = []
+  let current: string[] = []
+  let currentChars = 0
+
+  for (const update of b64Updates) {
+    if (update.length > MAX_CRDT_UPDATE_PAYLOAD_CHARS) {
+      oversized.push(update)
+      continue
+    }
+    if (current.length > 0 && currentChars + update.length > MAX_CRDT_REQUEST_PAYLOAD_CHARS) {
+      requests.push(current)
+      current = []
+      currentChars = 0
+    }
+    current.push(update)
+    currentChars += update.length
+  }
+  if (current.length > 0) requests.push(current)
+
+  return { requests, oversized }
+}

--- a/apps/desktop/src/main/sync/crdt-queue.ts
+++ b/apps/desktop/src/main/sync/crdt-queue.ts
@@ -8,7 +8,8 @@ const FLUSH_INTERVAL_MS = 1000
 const MAX_BATCH_SIZE = 50
 // Largest single merged update produced by coalescing. Merged updates are
 // pushed as one payload, so this keeps a long offline session from producing
-// one blob the server rejects (the push fn caps a batch at ~900KB base64).
+// one blob the server cannot store in a D1 row (the push fn splits a batch
+// across requests and falls back to a snapshot for anything still too large).
 const MAX_MERGED_UPDATE_BYTES = 256 * 1024
 // Largest raw payload a single flush may carry, for the same reason: after
 // coalescing a batch of 50 entries could otherwise be tens of megabytes.

--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -717,10 +717,19 @@ describe('sync runtime', () => {
     await queue.onBatch?.('note-missing-token', [new Uint8Array([1])])
     expect(runtimeMocks.postToServer).not.toHaveBeenCalled()
 
+    // A batch whose total is large but whose entries each fit a D1 row must be
+    // sent, not discarded: dropping it lost the user's paste on every device.
     runtimeMocks.encryptCrdtUpdate.mockReturnValueOnce(new Uint8Array(700_000))
     await queue.onBatch?.('note-too-large', [new Uint8Array([1]), new Uint8Array([2])])
-    expect(runtimeMocks.postToServer).not.toHaveBeenCalled()
+    expect(runtimeMocks.postToServer).toHaveBeenCalledWith(
+      '/sync/crdt/updates',
+      expect.objectContaining({ noteId: 'note-too-large' }),
+      'access-token'
+    )
+    const sentBody = runtimeMocks.postToServer.mock.calls[0][1] as { updates: string[] }
+    expect(sentBody.updates).toHaveLength(2)
 
+    runtimeMocks.postToServer.mockClear()
     runtimeMocks.encryptCrdtUpdate.mockReturnValue(new Uint8Array([10, 11]))
     runtimeMocks.crdtProvider.pushSnapshotForNote.mockRejectedValueOnce(
       new Error('snapshot failed')
@@ -770,6 +779,82 @@ describe('sync runtime', () => {
       expect.objectContaining({ errorCategory: 'storage_quota_exceeded' })
     )
     expect(queue.pause.mock.calls.length).toBe(pauseCallsBeforeSnapshot + 1)
+  })
+
+  it('splits a CRDT batch too big for one request across several requests', async () => {
+    const runtime = await loadRuntime()
+    await runtime.startSyncRuntime()
+    const queue = runtimeMocks.CrdtUpdateQueue.instances[0]
+    runtimeMocks.postToServer.mockClear()
+
+    // Six updates that each fit a D1 row but together exceed the 8 MiB body cap.
+    runtimeMocks.encryptCrdtUpdate.mockReturnValue(new Uint8Array(890_000))
+    const raw = Array.from({ length: 6 }, (_, i) => new Uint8Array([i]))
+
+    await queue.onBatch?.('note-1', raw)
+
+    expect(runtimeMocks.postToServer).toHaveBeenCalledTimes(2)
+    const sent = runtimeMocks.postToServer.mock.calls.flatMap(
+      (call) => (call[1] as { updates: string[] }).updates
+    )
+    // Every update reaches the server — the batch is split, never trimmed.
+    expect(sent).toHaveLength(6)
+    for (const call of runtimeMocks.postToServer.mock.calls) {
+      const body = call[1] as { updates: string[] }
+      const chars = body.updates.reduce((sum, update) => sum + update.length, 0)
+      expect(chars).toBeLessThanOrEqual(6_000_000)
+    }
+
+    runtimeMocks.encryptCrdtUpdate.mockReturnValue(new Uint8Array([10, 11]))
+    await runtime.stopSyncRuntime({ skipFinalSync: true })
+  })
+
+  it('pushes a snapshot when one CRDT update is too large for the incremental path', async () => {
+    const runtime = await loadRuntime()
+    await runtime.startSyncRuntime()
+    const queue = runtimeMocks.CrdtUpdateQueue.instances[0]
+    runtimeMocks.postToServer.mockClear()
+    runtimeMocks.crdtProvider.pushSnapshotForNote.mockReset()
+    runtimeMocks.crdtProvider.pushSnapshotForNote.mockResolvedValue(true)
+
+    // One paste: a single update far past what a D1 `crdt_updates` row holds.
+    runtimeMocks.encryptCrdtUpdate.mockReturnValueOnce(new Uint8Array(1_000_000))
+
+    await expect(
+      queue.onBatch?.('note-1', [new Uint8Array([1]), new Uint8Array([2])])
+    ).resolves.toBeUndefined()
+
+    // The small sibling still rides the incremental path...
+    expect(runtimeMocks.postToServer).toHaveBeenCalledTimes(1)
+    const body = runtimeMocks.postToServer.mock.calls[0][1] as { updates: string[] }
+    expect(body.updates).toHaveLength(1)
+    // ...and the oversized one converges through the R2-backed snapshot instead
+    // of vanishing.
+    expect(runtimeMocks.crdtProvider.pushSnapshotForNote).toHaveBeenCalledWith('note-1')
+
+    runtimeMocks.encryptCrdtUpdate.mockReturnValue(new Uint8Array([10, 11]))
+    await runtime.stopSyncRuntime({ skipFinalSync: true })
+  })
+
+  it('fails loudly when the snapshot fallback for an oversized CRDT update does not land', async () => {
+    const runtime = await loadRuntime()
+    await runtime.startSyncRuntime()
+    const queue = runtimeMocks.CrdtUpdateQueue.instances[0]
+    runtimeMocks.postToServer.mockClear()
+    runtimeMocks.crdtProvider.pushSnapshotForNote.mockReset()
+    runtimeMocks.crdtProvider.pushSnapshotForNote.mockResolvedValue(false)
+
+    runtimeMocks.encryptCrdtUpdate.mockReturnValue(new Uint8Array(1_000_000))
+
+    // Rejecting is what keeps the batch buffered for the next flush; resolving
+    // here would be the silent drop this path replaces.
+    await expect(queue.onBatch?.('note-1', [new Uint8Array([1])])).rejects.toThrow(
+      'CRDT snapshot fallback failed'
+    )
+    expect(runtimeMocks.postToServer).not.toHaveBeenCalled()
+
+    runtimeMocks.encryptCrdtUpdate.mockReturnValue(new Uint8Array([10, 11]))
+    await runtime.stopSyncRuntime({ skipFinalSync: true })
   })
 
   it('exposes engine dependency branches for signing keys, device keys, and calendar sync', async () => {

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -58,6 +58,7 @@ import { getDeviceSigningKey } from './device-keys'
 import { getCrdtProvider, resetCrdtProvider } from './crdt-provider'
 import { CrdtUpdateQueue } from './crdt-queue'
 import { CrdtSnapshotScheduler } from './crdt-snapshot-scheduler'
+import { planCrdtUpdatePush } from './crdt-payload'
 import { drainPendingCrdtNotes, recordPendingCrdtNotes } from './crdt-pending-notes'
 import { recoverDirtyItems } from './dirty-recovery'
 import { encryptCrdtUpdate } from './crdt-encrypt'
@@ -529,30 +530,47 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
             return Buffer.from(encrypted).toString('base64')
           })
 
-          const MAX_CRDT_PAYLOAD_BYTES = 900_000
-          const estimatedBytes = b64Updates.reduce((sum, s) => sum + s.length, 0) + 128
-          if (estimatedBytes > MAX_CRDT_PAYLOAD_BYTES) {
-            log.warn('CRDT payload exceeds size limit, dropping batch', {
-              noteId,
-              estimatedBytes,
-              updateCount: b64Updates.length
-            })
-            return
+          const { requests, oversized } = planCrdtUpdatePush(b64Updates)
+
+          for (const batch of requests) {
+            await withRetry(
+              () =>
+                withAuthRetry(
+                  (authToken) =>
+                    postToServer('/sync/crdt/updates', { noteId, updates: batch }, authToken),
+                  token!,
+                  crdtAuthRetryDeps,
+                  (fresh) => {
+                    token = fresh
+                  }
+                ),
+              { maxRetries: 3, baseDelayMs: 2000 }
+            )
           }
 
-          await withRetry(
-            () =>
-              withAuthRetry(
-                (authToken) =>
-                  postToServer('/sync/crdt/updates', { noteId, updates: b64Updates }, authToken),
-                token!,
-                crdtAuthRetryDeps,
-                (fresh) => {
-                  token = fresh
-                }
-              ),
-            { maxRetries: 3, baseDelayMs: 2000 }
-          )
+          if (oversized.length > 0) {
+            // One update this large cannot ride the incremental path at all: the
+            // server stores each update as a D1 blob. The operations are already
+            // in the local doc, so push the whole document to the R2-backed
+            // snapshot endpoint — an existing payload shape every client version
+            // pulls — instead of dropping the user's edit.
+            log.warn('CRDT update too large for the incremental path, pushing a snapshot instead', {
+              noteId,
+              oversizedCount: oversized.length,
+              largestChars: Math.max(...oversized.map((update) => update.length))
+            })
+            const pushed = await crdtProvider.pushSnapshotForNote(noteId)
+            if (!pushed) {
+              // Throwing re-buffers the batch, so the next flush retries the
+              // snapshot and shutdown records the note for replay. Returning
+              // here would be the silent drop this path exists to remove;
+              // snapshotPushFn already surfaced whatever went wrong.
+              log.error('CRDT snapshot fallback for an oversized update failed', { noteId })
+              throw new Error('CRDT snapshot fallback failed')
+            }
+            // The snapshot is itself the compaction point, so no scheduled one.
+            return
+          }
 
           // The incremental batch is already durable on the server; the full
           // snapshot is only a compaction point, so it rides a long debounce

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -464,6 +464,24 @@ list.
 | `POST /devices/*`         | mixed     | Linking, listing, revoking                                                     |
 | `POST /keys/*`            | mixed     | Key sealing during link, rotation                                              |
 
+### CRDT update sizing
+
+`POST /sync/crdt/updates` is bounded by two different server limits, and the client
+(`src/main/sync/crdt-payload.ts`) plans every batch against both:
+
+- **Per update.** Each update is stored as a BLOB inside a D1 `crdt_updates` row, so an update can
+  never exceed D1's 1 MB row limit. The route's own 5 MB check is not the binding one.
+- **Per request.** `/sync/*` bodies are capped at 8 MiB, which limits how many updates one POST can
+  carry.
+
+A batch that exceeds the request budget is split across several POSTs rather than truncated. A
+single update too large for a D1 row cannot use the incremental path at all; the client pushes the
+note's full document to `POST /sync/crdt/snapshot` instead, which is R2-backed and therefore not
+subject to the row limit. The local Y.Doc already contains those operations, so the snapshot carries
+them, and every client version already applies the snapshot as its baseline before pulling
+incrementals. If that fallback fails the push rejects, leaving the batch buffered for the next flush
+and — on quit — recorded for replay. No path discards an update.
+
 ### Server base URL
 
 Every path above is appended to a single resolved base URL. `resolveSyncServerUrl()`


### PR DESCRIPTION
Closes #1141. Epic #987 (MAJOR-tier follow-up from PR #1118 / issue #995).

## What was wrong

`apps/desktop/src/main/sync/runtime.ts:532-542` (pre-fix) computed the total base64 size of an encrypted CRDT batch and, if it passed `MAX_CRDT_PAYLOAD_BYTES = 900_000`, logged a warning and `return`ed. The queue treats a resolved push as delivered, so the batch was gone: no error, no retry, no alternative path. One large paste (~675KB raw in a single Yjs update) never reached the server or any other device, and nothing told the user.

Confirmed still live on current `main` (`f4a5dd4f7`) before touching anything — the constant, the `return`, and the log line were all still there.

Two ways it fired:

- **Aggregate.** Several updates that each fit fine, but whose sum passed 900KB — the whole batch was dropped, including the small ones.
- **Single update.** One paste large enough on its own. Nothing could ever send it.

## What the server actually accepts

Verified rather than assumed:

- `apps/sync-server/src/index.ts:54` — `MAX_BODY_BYTES_SYNC = 8 * 1024 * 1024` for every `/sync/*` path (raised in #1198, on `main`).
- `apps/sync-server/src/routes/sync.ts:134` — the route rejects an individual update over 5MB.
- **But the binding limit is D1, not the route.** `storeUpdates` (`apps/sync-server/src/services/crdt.ts`) writes `update_data` straight into a D1 `crdt_updates` row, and a D1 row caps at 1,000,000 bytes — the same limit this repo already documents (`apps/docs/src/architecture.md:32`). Snapshots are the opposite: `storeSnapshot` puts them in **R2** and keeps only a `blob_key` in D1.

So the incremental path has a hard ~1MB ceiling that no client-side change can lift, while the snapshot path does not.

## What changed

New `apps/desktop/src/main/sync/crdt-payload.ts` — a pure planner with the two budgets in base64 chars, each annotated with the server limit it derives from:

- `MAX_CRDT_UPDATE_PAYLOAD_CHARS = 1_200_000` → decodes to 900,000 bytes, leaving the rest of the D1 row inside the 1MB cap.
- `MAX_CRDT_REQUEST_PAYLOAD_CHARS = 6_000_000` → comfortably inside the 8 MiB `/sync/*` body cap, envelope included.

`planCrdtUpdatePush()` returns `{ requests, oversized }`. Nothing is discarded — an update lands in one or the other.

In `runtime.ts` the drop is replaced by:

1. POST each planned request in order (a batch too big for one body is **split**, not trimmed).
2. Anything still oversized goes to `crdtProvider.pushSnapshotForNote(noteId)` — the R2-backed snapshot endpoint. The local Y.Doc already holds those operations, so the snapshot carries them.
3. If that fallback does not land, **throw**. The queue re-buffers the batch for the next flush and `persistUnflushed` records the note for replay on the next start. Returning there would be the silent drop this change exists to remove; `snapshotPushFn` already emits the user-facing `note_too_large` / quota status for its own failures, so no duplicate or misleading toast is added.

Also updated the now-stale `~900KB base64` comment in `crdt-queue.ts` that pointed at the removed constant.

## Wire compatibility

No protocol change at all — that is the point of routing through the snapshot endpoint instead of inventing a chunked shape.

- **Request shape unchanged.** Still `POST /sync/crdt/updates` with `{ noteId, updates: string[] }`. Splitting a batch across two POSTs is something the endpoint already supports; the server assigns sequence numbers per update either way, and Yjs updates converge regardless of arrival order.
- **No new endpoint, field, header, or negotiation.** Nothing additive to gate.
- **Older clients read everything a new client writes.** `CrdtSyncCoordinator.applyCrdtIncrementals` already fetches the snapshot baseline first and then pulls incrementals since its sequence — that code is unchanged and ships in every live version, so a snapshot pushed by a new client is applied by an old one with no changes.
- **Older server.** Only one server is deployed, and it is already at 8 MiB / 5 MB (#1198, merged). The new budgets sit under both, and under D1's 1MB row limit, which is stricter than either.
- **No DB schema, IPC contract, vault format, or settings change.** `pnpm ipc:check` is not implicated.

## Verification

Targeted main-process suites, all green (36/36):

```
✓ src/main/sync/crdt-payload.test.ts  (6 tests)
✓ src/main/sync/crdt-queue.test.ts    (8 tests)
✓ src/main/sync/runtime.test.ts       (22 tests)
 Test Files  3 passed (3)
      Tests  36 passed (36)
```

The runtime tests drive the real push callback through the queue's registered `pushFn` with only the network mocked — not an IPC-shaped stand-in.

**Mutation-tested.** Reverting `runtime.ts` alone and rerunning `runtime.test.ts`:

```
× guards CRDT batches and handles snapshot push auth/quota failures
  → expected "vi.fn()" to be called with arguments: [ '/sync/crdt/updates', …(2) ]
× splits a CRDT batch too big for one request across several requests
  → expected "vi.fn()" to be called 2 times, but got 0 times
× pushes a snapshot when one CRDT update is too large for the incremental path
  → expected "vi.fn()" to be called 1 times, but got 0 times
× fails loudly when the snapshot fallback for an oversized CRDT update does not land
  → promise resolved "undefined" instead of rejecting
 Tests  4 failed | 18 passed (22)
```

That last line is the bug verbatim: the old code resolves as if the edit were delivered.

One pre-existing assertion in `runtime.test.ts` encoded the defect (`expect(postToServer).not.toHaveBeenCalled()` after a 700KB update) — it now asserts both updates are sent.

Also run: `pnpm --filter @memry/desktop typecheck:node` (clean), `pnpm exec eslint <changed files>` (0 errors; the one `crdt-queue.ts` warning is a pre-existing `run[0]!` assertion I did not touch), `git diff --check` (clean), `pnpm docs:impact --base origin/main --strict` → `covered`, `pnpm docs:build` (clean).

## Note for review

The snapshot fallback raises the effective ceiling for one paste from ~675KB to the 5MB snapshot limit, but it is not infinite: a note whose whole document exceeds 5MB will fail the snapshot too. That case now surfaces loudly as `note_too_large` and retries, instead of vanishing. Lifting it further would need real chunking with a negotiated wire shape — out of scope here.