### PR TITLE
fix(telemetry): keep scraped page metadata out of dimensions and diagnostics

### DIFF
--- a/apps/desktop/src/main/inbox/metadata.test.ts
+++ b/apps/desktop/src/main/inbox/metadata.test.ts
@@ -11,6 +11,20 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdirSync, rmSync } from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+
+// warn/error records are intercepted by the log-ship transport and shipped off
+// the device (telemetry/log-ship.ts), so what this scope logs at those levels is
+// a privacy surface, not just noise. Captured here to assert on it (#1142).
+const shippedLogs = vi.hoisted(() => ({ warn: vi.fn(), error: vi.fn(), debug: vi.fn() }))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: shippedLogs.warn,
+    error: shippedLogs.error,
+    debug: shippedLogs.debug
+  })
+}))
+
 import {
   fetchUrlMetadata,
   fetchUrlHtml,
@@ -643,5 +657,63 @@ describe('fetchUrlHtml', () => {
   it('throws on non-ok status', async () => {
     mockFetch.mockResolvedValue(new Response('nope', { status: 404 }))
     await expect(fetchUrlHtml('https://example.com/missing')).rejects.toThrow()
+  })
+})
+
+// ==========================================================================
+// #1142 — scraped page content must not reach the diagnostics that leave the
+// device. warn/error go to log-ship; thrown messages reach telemetry as
+// app_error_seen.error.message via trackMainError in jobs.ts.
+// ==========================================================================
+describe('scraped content never reaches shipped diagnostics', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    shippedLogs.warn.mockReset()
+    shippedLogs.error.mockReset()
+    shippedLogs.debug.mockReset()
+  })
+
+  it('keeps the clipped url and the scraped title out of warn/error records', async () => {
+    const url = 'https://sensitive-health-forum.example.com/threads/my-diagnosis'
+    const botTitle = 'Just a moment...'
+    mockFetch.mockResolvedValue(
+      new Response(`<html><head><title>${botTitle}</title></head><body></body></html>`, {
+        status: 200
+      })
+    )
+
+    const metadata = await fetchUrlMetadata(url)
+
+    // #then the bot page is still detected and the title discarded
+    expect(metadata.title).toBeUndefined()
+
+    // #and nothing shipped carries the address the user clipped or its title
+    const shipped = [...shippedLogs.warn.mock.calls, ...shippedLogs.error.mock.calls]
+      .flat()
+      .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+      .join(' ')
+    expect(shipped).not.toContain(url)
+    expect(shipped).not.toContain('sensitive-health-forum')
+    expect(shipped).not.toContain(botTitle)
+    // #and the event stays countable rather than being silently dropped
+    expect(shippedLogs.warn).toHaveBeenCalled()
+  })
+
+  it('omits the remote reason phrase from the metadata fetch error', async () => {
+    const reason = 'Blocked: user 4417 flagged for scraping /threads/my-diagnosis'
+    mockFetch.mockResolvedValue(new Response('nope', { status: 403, statusText: reason }))
+
+    await expect(
+      fetchUrlMetadata('https://sensitive-health-forum.example.com/threads/my-diagnosis')
+    ).rejects.toThrow(/^HTTP 403$/)
+  })
+
+  it('omits the clipped url from the article fetch error', async () => {
+    const url = 'https://sensitive-health-forum.example.com/threads/my-diagnosis'
+    mockFetch.mockResolvedValue(new Response('nope', { status: 500 }))
+
+    await expect(fetchUrlHtml(url)).rejects.toThrow(
+      expect.objectContaining({ message: expect.not.stringContaining('sensitive-health-forum') })
+    )
   })
 })

--- a/apps/desktop/src/main/inbox/metadata.ts
+++ b/apps/desktop/src/main/inbox/metadata.ts
@@ -198,14 +198,22 @@ export async function fetchUrlMetadata(url: string): Promise<UrlMetadata> {
     })
 
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+      // Status code only. `statusText` is the remote server's free-text reason
+      // phrase — raw network data — and this message rides along to telemetry as
+      // app_error_seen.error.message via trackMainError in jobs.ts (#1142).
+      throw new Error(`HTTP ${response.status}`)
     }
 
     const html = await response.text()
     const metadata = await scraper({ html, url })
 
     if (metadata.title && isBotPageTitle(metadata.title)) {
-      log.warn(`Bot page detected for ${url}: "${metadata.title}"`)
+      // debug, not warn: log-ship only intercepts warn/error, so the clipped URL
+      // and the scraped title stay in the on-device log file instead of being
+      // redacted-but-preserved into a shipped diagnostic line (#1142). The
+      // warn below keeps the event countable without carrying page content.
+      log.debug(`Bot page detected for ${url}: "${metadata.title}"`)
+      log.warn('Bot page detected; falling back to a URL-derived title')
       return { url, title: undefined }
     }
 
@@ -239,7 +247,11 @@ export async function fetchUrlHtml(url: string): Promise<string> {
       }
     })
     if (!response.ok) {
-      throw new Error(`Failed to fetch ${url}: ${response.status}`)
+      // No URL in the message: this one reaches telemetry as
+      // app_error_seen.error.message (trackMainError('inbox','article_extract')),
+      // and redactText keeps scheme+host+path — so the clipped address would
+      // have shipped verbatim (#1142). The item row still records the URL.
+      throw new Error(`Failed to fetch article HTML: ${response.status}`)
     }
     const contentLength = response.headers.get('content-length')
     if (contentLength && parseInt(contentLength, 10) > MAX_HTML_SIZE) {

--- a/apps/desktop/src/main/telemetry/client.test.ts
+++ b/apps/desktop/src/main/telemetry/client.test.ts
@@ -407,15 +407,18 @@ describe('createTelemetryClient — crash durability', () => {
     expect(revived.getQueueDepth()).toBe(TELEMETRY_QUEUE_LIMIT)
   })
 
-  it('cannot be made to forge mirror entries by a hostile dimension value', () => {
-    // #given an event whose dimension carries remote-controlled text — inbox link
-    // metadata is scraped from arbitrary pages, which is the taint path CodeQL
-    // flags into this file — shaped to break out of a newline-delimited journal
+  it('cannot be made to forge mirror entries by a hostile free-text value', () => {
+    // #given an event whose error message carries remote-controlled text — inbox
+    // link metadata is scraped from arbitrary pages, which is the taint path
+    // CodeQL flags into this file — shaped to break out of a newline-delimited
+    // journal. The message field is used rather than a dimension because
+    // dimensions are now allowlisted away before they ever reach the journal
+    // (see the scraped-metadata test below); free text can still reach here.
     const hostile = '\n{"id":"forged","name":"app_crashed","surface":"app"}\n'
     const client = createTelemetryClient(createDeps({ persistPath }).deps)
     client.track({
       ...buildEvent('11111111-1111-1111-1111-111111111111', 'inbox_item_added'),
-      dimensions: { source: hostile }
+      error: { message: hostile }
     })
     client.track(buildEvent('22222222-2222-2222-2222-222222222222'))
 
@@ -430,7 +433,59 @@ describe('createTelemetryClient — crash durability', () => {
       fs.readFileSync(persistPath, 'utf-8').split('\n')[1]
     ) as TelemetryEvent
     expect(restored.name).toBe('inbox_item_added')
-    expect(restored.dimensions?.source).toBe(hostile)
+    expect(restored.error?.message).toBe(hostile)
+  })
+
+  it('never queues, mirrors or ships scraped page metadata as a dimension', async () => {
+    // #given the metadata a real clip pulls off a third-party page: every one of
+    // these passes the safe-value shape (no @, no ://, no slash, under 64 chars),
+    // which is exactly why a blocklist could not stop them
+    const scraped = {
+      page_title: 'Divorce settlement calculator - LawFirm',
+      description: 'Work out what you are owed after separation',
+      og_site_name: 'Sensitive Health Forum',
+      author: 'Dr. Jane Roe'
+    }
+    const { deps, calls } = createDeps({ persistPath })
+    const client = createTelemetryClient(deps)
+
+    client.track({
+      ...buildEvent('11111111-1111-1111-1111-111111111111', 'inbox_captured'),
+      dimensions: scraped
+    })
+    await client.flush('manual')
+
+    // #then no fragment of the page survives in the queue file or on the wire
+    const mirrored = fs.readFileSync(persistPath, 'utf-8')
+    const shipped = String(calls[0].init?.body)
+    for (const value of Object.values(scraped)) {
+      expect(mirrored).not.toContain(value)
+      expect(shipped).not.toContain(value)
+    }
+    for (const key of Object.keys(scraped)) {
+      expect(mirrored).not.toContain(key)
+      expect(shipped).not.toContain(key)
+    }
+
+    // #and the event itself still ships — the shape is the signal, not the content
+    const batch = JSON.parse(shipped) as { events: TelemetryEvent[] }
+    expect(batch.events).toHaveLength(1)
+    expect(batch.events[0].name).toBe('inbox_captured')
+    expect(batch.events[0].dimensions).toBeUndefined()
+  })
+
+  it('keeps an allowlisted dimension whose value is a bounded enum', async () => {
+    const { deps, calls } = createDeps({ persistPath })
+    const client = createTelemetryClient(deps)
+
+    client.track({
+      ...buildEvent('11111111-1111-1111-1111-111111111111', 'inbox_captured'),
+      dimensions: { capture_type: 'clipper' }
+    })
+    await client.flush('manual')
+
+    const batch = JSON.parse(String(calls[0].init?.body)) as { events: TelemetryEvent[] }
+    expect(batch.events[0].dimensions).toEqual({ capture_type: 'clipper' })
   })
 
   it('never restores events for an install that opted out between launches', () => {

--- a/apps/desktop/src/main/telemetry/client.ts
+++ b/apps/desktop/src/main/telemetry/client.ts
@@ -6,6 +6,7 @@ import type {
   TelemetryPlatform,
   TelemetrySyncState
 } from '@memry/contracts/telemetry-api'
+import { sanitizeTelemetryDimensions } from '@memry/contracts/telemetry-api'
 
 import { createLogger } from '../lib/logger'
 import { createQueueStore } from './queue-store'
@@ -116,11 +117,19 @@ export const createTelemetryClient = (deps: TelemetryClientDeps): TelemetryClien
     events
   })
 
+  // The single chokepoint every event passes on its way to the queue file and
+  // then off the device: trackMainEvent, the renderer's IPC handler, the
+  // bootstrap events in runtime.ts and the direct runtime.track callers all end
+  // up here. Enforcing the dimension allowlist at this one point is what makes
+  // it structurally impossible for a new call site to ship free text as a
+  // dimension — no producer can opt out by not calling a helper (#1142).
   const track = (event: TelemetryEvent): void => {
     if (!enabled) return
-    queue.push(event)
+    const dimensions = sanitizeTelemetryDimensions(event.dimensions)
+    const safe = dimensions === event.dimensions ? event : { ...event, dimensions }
+    queue.push(safe)
     trimQueue()
-    persistAppend(event)
+    persistAppend(safe)
   }
 
   const flush = async (reason: TelemetryFlushReason): Promise<TelemetryFlushResult> => {

--- a/apps/desktop/src/renderer/src/lib/telemetry.test.ts
+++ b/apps/desktop/src/renderer/src/lib/telemetry.test.ts
@@ -89,7 +89,7 @@ describe('trackTelemetry (renderer wrapper)', () => {
       surface: 'search',
       action: 'queried',
       dimensions: {
-        provider: 'local',
+        format: 'markdown',
         leak: 'alice@example.com',
         leakUrl: 'https://example.com/x',
         leakPath: '/Users/me/docs'
@@ -97,7 +97,22 @@ describe('trackTelemetry (renderer wrapper)', () => {
     })
 
     const event = trackFn.mock.calls[0][0] as TrackedEventShape
-    expect(event.dimensions).toEqual({ provider: 'local' })
+    expect(event.dimensions).toEqual({ format: 'markdown' })
+  })
+
+  it('drops a dimension key that is not on the allowlist, however safe it looks', async () => {
+    const trackFn = window.api.telemetry!.track as ReturnType<typeof vi.fn>
+
+    // Scraped page metadata clears every safe-value rule — short, no @, no ://,
+    // no slash — so only a closed key namespace can keep it off the wire (#1142).
+    await trackTelemetry('inbox_captured', {
+      surface: 'inbox',
+      action: 'captured',
+      dimensions: { page_title: 'Divorce settlement calculator' }
+    })
+
+    const event = trackFn.mock.calls[0][0] as TrackedEventShape
+    expect(event.dimensions).toBeUndefined()
   })
 
   it('drops unsafe dimension keys and UUID-shaped values', async () => {

--- a/apps/desktop/src/renderer/src/lib/telemetry.ts
+++ b/apps/desktop/src/renderer/src/lib/telemetry.ts
@@ -4,36 +4,19 @@ import type {
   TelemetryResult,
   TelemetrySurface
 } from '@memry/contracts/telemetry-api'
+import { sanitizeTelemetryDimensions } from '@memry/contracts/telemetry-api'
 
 /**
  * Renderer-side, non-blocking, safe telemetry wrapper.
  *
  * Privacy guarantees:
  * - Never includes content, paths, URLs, or other free-form text
- * - Strips dimension values that look like emails, URLs, or paths
- * - Truncates over-long dimension values
+ * - Keeps only allowlisted dimension keys carrying bounded, enumerable values
  * - Catches every IPC error so a failing main process never breaks the UI
  */
 
-const SAFE_DIMENSION_VALUE = /^(?!.*@)(?!.*:\/\/)(?!.*[/\\]).{1,64}$/
-const UUID_SHAPED_VALUE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
-
-const isSafeDimensionValue = (value: unknown): value is string =>
-  typeof value === 'string' && SAFE_DIMENSION_VALUE.test(value) && !UUID_SHAPED_VALUE.test(value)
-
-const sanitizeDimensions = (
-  dimensions: Record<string, string> | undefined
-): Record<string, string> | undefined => {
-  if (!dimensions) return undefined
-  const cleaned: Record<string, string> = {}
-  for (const [key, value] of Object.entries(dimensions)) {
-    if (isSafeDimensionValue(key) && isSafeDimensionValue(value)) {
-      cleaned[key] = value
-      break
-    }
-  }
-  return Object.keys(cleaned).length > 0 ? cleaned : undefined
-}
+// Shared with the main process rather than re-derived here: the key allowlist is
+// the whole guarantee, and two copies of it would drift (#1142).
 
 export interface TrackTelemetryOptions {
   surface: TelemetrySurface
@@ -80,7 +63,7 @@ export const trackTelemetry = async (
       source: options.source,
       result: options.result,
       errorCode: options.errorCode,
-      dimensions: sanitizeDimensions(options.dimensions),
+      dimensions: sanitizeTelemetryDimensions(options.dimensions),
       metrics: options.metrics,
       error: options.error
     }

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -116,12 +116,47 @@ Recognized surfaces (`TelemetrySurface` in `packages/contracts/telemetry-api`):
 - Tag names
 - User file paths and note filenames
 - Raw (unredacted) exception messages — a desktop error message can embed a note title or content
+- Scraped page metadata — the `<title>`, description or address of a URL the user clipped
 
 The contract uses string-typed enums for surfaces and actions; arbitrary strings can't sneak
 through. The one exception is error diagnostics, which additionally ship a redacted **stack
 trace** of code locations and, optionally, a message — but only after the client has run it
 through `redactText` (`packages/contracts/src/redact.ts`), never the raw string — see
 [Error Reporting](#error-reporting).
+
+#### The dimension allowlist
+
+`dimensions` is the one free-form slot on an event, so its key namespace is **closed**.
+`TELEMETRY_DIMENSION_KEYS` in `packages/contracts/src/telemetry-api.ts` lists every key allowed to
+leave the device; `sanitizeTelemetryDimensions` keeps at most one entry, drops any key not on the
+list, and drops any value that fails the safe-value shape (no `@`, no `://`, no slash, ≤ 64 chars,
+not UUID-shaped).
+
+The shape check alone is not enough, which is why the allowlist exists: a scraped page title such
+as `Divorce settlement calculator` passes every one of those rules. Only an enumerable key
+namespace can tell a bounded enum from arbitrary user or page content.
+
+Enforcement sits in `createTelemetryClient`'s `track()`
+(`apps/desktop/src/main/telemetry/client.ts`) — the single chokepoint every event crosses before
+the durable queue and the network, whether it came from `trackMainEvent`, the renderer's IPC
+handler, or a direct `runtime.track` call. A new call site cannot opt out by skipping a helper.
+The renderer wrapper (`src/renderer/src/lib/telemetry.ts`) applies the same shared function so the
+UI drops rejected dimensions before the IPC hop.
+
+**Adding a key is the review gate.** If the value cannot be enumerated ahead of time, it does not
+belong in a dimension — send a metric instead (a count, a duration, or a bucket label such as
+`result_bucket`).
+
+The allowlist is deliberately **not** part of `TelemetryDimensionsSchema`. The sync-server
+validates `/telemetry/batch` with that schema and rejects a whole batch on one bad event, so
+narrowing it would make a newly deployed server 400 batches sent by already-shipped desktop
+builds. The allowlist is enforced on the client, where the data still is.
+
+Because `warn`/`error` log records ship too (Path A, see [What Ships](#what-ships) and
+[Error & Diagnostic Logs in PostHog](#error-diagnostic-logs-in-posthog)), the same rule applies to
+log lines and thrown error messages in content-handling code: the inbox scraper
+(`apps/desktop/src/main/inbox/metadata.ts`) logs the clipped URL and scraped title at `debug`
+— below the ship floor — and keeps a content-free `warn` so the event stays countable.
 
 ## Tracking Pattern
 

--- a/packages/contracts/src/telemetry-api.test.ts
+++ b/packages/contracts/src/telemetry-api.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  TELEMETRY_DIMENSION_KEYS,
   TelemetryBatchSchema,
+  TelemetryDimensionsSchema,
   TelemetryErrorDetailSchema,
   TelemetryEventNameSchema,
   TelemetryEventSchema,
@@ -9,6 +11,7 @@ import {
   buildErrorDetail,
   normalizeRejectionReason,
   normalizeWindowError,
+  sanitizeTelemetryDimensions,
   toErrorCode
 } from './telemetry-api'
 
@@ -979,5 +982,50 @@ describe('contract widening for PostHog migration', () => {
   it('rejects an over-long error message', () => {
     const parsed = TelemetryErrorDetailSchema.safeParse({ message: 'x'.repeat(513) })
     expect(parsed.success).toBe(false)
+  })
+})
+
+describe('sanitizeTelemetryDimensions', () => {
+  it('keeps an allowlisted key whose value is a bounded enum', () => {
+    expect(sanitizeTelemetryDimensions({ capture_type: 'clipper' })).toEqual({
+      capture_type: 'clipper'
+    })
+  })
+
+  it('drops scraped page metadata even though it clears the safe-value shape', () => {
+    // Every value here is short, has no @, no :// and no slash, so the value
+    // blocklist alone would have shipped all of it (#1142).
+    const scraped = {
+      page_title: 'Divorce settlement calculator - LawFirm',
+      description: 'What you are owed after separation',
+      og_site_name: 'Sensitive Health Forum'
+    }
+    for (const [key, value] of Object.entries(scraped)) {
+      expect(sanitizeTelemetryDimensions({ [key]: value })).toBeUndefined()
+    }
+  })
+
+  it('drops an allowlisted key whose value breaks the safe-value shape', () => {
+    expect(sanitizeTelemetryDimensions({ target: 'https://example.com/x' })).toBeUndefined()
+    expect(sanitizeTelemetryDimensions({ setting: 'a'.repeat(65) })).toBeUndefined()
+    expect(
+      sanitizeTelemetryDimensions({ value: '550e8400-e29b-41d4-a716-446655440000' })
+    ).toBeUndefined()
+  })
+
+  it('keeps at most one dimension, skipping past disallowed keys', () => {
+    expect(
+      sanitizeTelemetryDimensions({ page_title: 'Anything', transport: 'record', tool: 'read' })
+    ).toEqual({ transport: 'record' })
+  })
+
+  it('passes undefined through untouched so the caller can omit the field', () => {
+    expect(sanitizeTelemetryDimensions(undefined)).toBeUndefined()
+  })
+
+  it('only allowlists keys the schema itself would accept', () => {
+    for (const key of TELEMETRY_DIMENSION_KEYS) {
+      expect(TelemetryDimensionsSchema.safeParse({ [key]: 'ok' }).success).toBe(true)
+    }
   })
 })

--- a/packages/contracts/src/telemetry-api.ts
+++ b/packages/contracts/src/telemetry-api.ts
@@ -148,6 +148,71 @@ export const TelemetryDimensionsSchema = z
     message: 'Telemetry events support at most one dimension'
   })
 
+/**
+ * The ONLY dimension keys allowed to leave the device.
+ *
+ * `SafeDimensionValueSchema` is a blocklist: it rejects emails, urls, paths and
+ * over-long strings, but a short free-text string sails through it. A scraped
+ * `<title>` ("Divorce settlement calculator") is a legal safe-dimension value.
+ * That is how page-derived text reached telemetry (issue #1142): nothing
+ * downstream could tell a bounded enum from arbitrary content.
+ *
+ * So the key namespace is closed instead. Each entry below is a bounded enum,
+ * a version string, or a bucket label — never free text derived from user
+ * content, page content, or a filename. Adding a key here is the review gate:
+ * if the value cannot be enumerated ahead of time, it does not belong in a
+ * dimension. Send a metric (a count, a duration, a length bucket) instead.
+ */
+export const TELEMETRY_DIMENSION_KEYS = [
+  'capture_type',
+  'changed_fields',
+  'decision',
+  'filed_action',
+  'format',
+  'from_version',
+  'itemType',
+  'log_action',
+  'prior_app_version',
+  'result_bucket',
+  'setting',
+  'target',
+  'target_app_version',
+  'tool',
+  'transport',
+  'value'
+] as const
+
+export type TelemetryDimensionKey = (typeof TELEMETRY_DIMENSION_KEYS)[number]
+
+const ALLOWED_DIMENSION_KEYS: ReadonlySet<string> = new Set(TELEMETRY_DIMENSION_KEYS)
+
+/**
+ * Reduce a caller-supplied dimensions bag to what is allowed to ship: at most
+ * one entry, whose key is in the allowlist above and whose value still passes
+ * the safe-value shape.
+ *
+ * Drops rather than rejects. Telemetry must never break a feature, and losing
+ * one dimension is always preferable to either shipping user content or
+ * discarding the whole event (a batch containing one bad event is rejected
+ * wholesale by the sync-server, which would cost every other event in it).
+ *
+ * Deliberately NOT folded into `TelemetryDimensionsSchema`: the sync-server
+ * validates `/telemetry/batch` with that schema, so narrowing it would make a
+ * newly deployed server 400 entire batches coming from already-shipped desktop
+ * builds. The allowlist is enforced on the client, where the data still is.
+ */
+export const sanitizeTelemetryDimensions = (
+  dimensions: Record<string, string> | undefined
+): Record<string, string> | undefined => {
+  if (!dimensions) return undefined
+  for (const [key, value] of Object.entries(dimensions)) {
+    if (!ALLOWED_DIMENSION_KEYS.has(key)) continue
+    if (!SafeDimensionValueSchema.safeParse(value).success) continue
+    return { [key]: value }
+  }
+  return undefined
+}
+
 export const TelemetryMetricsSchema = z.object({
   durationMs: z.number().finite().nonnegative().optional(),
   itemCount: z.number().finite().nonnegative().optional(),


### PR DESCRIPTION
Closes #1142. Part of epic #987 (audit follow-ups).

## Validation — the issue is real on current `main`

CodeQL named the source (`net.fetch` in `chromiumFetch`, `apps/desktop/src/main/inbox/metadata.ts`) but not the sink. Traced end to end, page-derived text reaches the wire by **three** concrete routes, none of which is the dimension CodeQL guessed at — plus the dimension slot really is open, just unused by the clip path today.

**1. The scraped title and the clipped URL ship as a diagnostic log line.**

`apps/desktop/src/main/inbox/metadata.ts:208` (pre-fix):

```ts
log.warn(`Bot page detected for ${url}: "${metadata.title}"`)
```

`installLogShip` (`apps/desktop/src/main/telemetry/log-ship.ts:169-186`) installs an electron-log transport that intercepts **every** main-process `warn`/`error`, runs `redactLogLine`, and batches them to `/telemetry/logs`. Scope `Inbox:Metadata` is not in `SKIP_SCOPES`; `warn` is at the floor. `redactText` strips query strings but explicitly keeps scheme + host + path, and has no rule that would touch a page title. So both the address the user clipped and the third-party `<title>` left the device intact.

**2. `response.statusText` — raw remote free text — reaches `app_error_seen.error.message`.**

`metadata.ts:201` threw `HTTP ${status}: ${statusText}`; `jobs.ts:310` calls `trackMainError('inbox', 'metadata_scrape', error)`, and `TelemetryErrorDetailSchema.message` accepts up to 512 redacted chars. The reason phrase is whatever the remote server writes.

**3. The clipped URL reaches the same field via article extraction.**

`fetchUrlHtml` threw `Failed to fetch ${url}: ${status}` → `jobs.ts:349` `trackMainError('inbox', 'article_extract', error)`.

**And the dimension slot itself is ungated.** `dimensions` is `Record<string, string>`, filtered only by `SafeDimensionValueSchema` — a blocklist (no `@`, no `://`, no slash, ≤ 64 chars, not UUID-shaped). A scraped title like `Divorce settlement calculator` clears all of it. Worse, main-process events are validated **nowhere**: `TelemetryEventSchema.safeParse` runs only on the renderer→main IPC hop (`ipc/telemetry-handlers.ts:24`). `trackMainEvent` → `runtime.track` → `client.track` → queue file → PostHog never sees a schema.

## What changed

**Structural: the dimension key namespace is now closed.**

- `packages/contracts/src/telemetry-api.ts` — `TELEMETRY_DIMENSION_KEYS` (the 16 keys actually in use) plus `sanitizeTelemetryDimensions`, which keeps at most one entry, drops any key off the list, and drops any value failing the safe-value shape.
- `apps/desktop/src/main/telemetry/client.ts` — enforced in `track()`. That is the **single chokepoint** every event crosses before the durable queue and the network: `trackMainEvent`, the renderer IPC handler, the bootstrap events in `runtime.ts`, and the direct `runtime.track` caller in `vault-handlers.ts` all funnel through it. A new call site cannot opt out by not calling a helper — which is what "structurally impossible" has to mean here.
- `apps/desktop/src/renderer/src/lib/telemetry.ts` — the sibling defect. It had its own weaker copy of the blocklist; it now shares the allowlist instead of re-deriving one that could drift.

Allowlist over blocklist, and it drops rather than rejects: telemetry must never break a feature, and a batch containing one invalid event is rejected wholesale by the sync-server.

**Deliberately NOT in `TelemetryDimensionsSchema`.** The sync-server validates `/telemetry/batch` with that schema. Narrowing it would make a newly deployed server 400 entire batches coming from already-shipped desktop builds — the deploy-order hazard called out at the top of the contract file. The allowlist belongs on the client, where the data still is.

**The three live leaks, plugged** (`apps/desktop/src/main/inbox/metadata.ts`):

- bot-page detection logs URL + title at `debug` (the ship floor is clamped to `>= warn`, so debug structurally cannot ship) and keeps a content-free `warn` so the event stays countable
- the metadata fetch error carries the status code only, not `statusText`
- the article fetch error no longer names the URL (the item row still records it)

**Side effect worth noting:** `telemetry/update-install-marker.ts:115` sends two dimensions, which `TelemetryDimensionsSchema`'s `<= 1` refinement rejects — meaning any batch containing that event was 400ing wholesale on the server, taking every other event in it down. The sanitizer now trims it to one, so those batches land. Not chased further here.

## Backward compatibility

No schema, IPC contract, DB, or sync-protocol change. Old clients keep sending what they always sent; the server keeps accepting it. The only behaviour change is client-side: fewer dimensions ship.

## Verification

Mutation-tested — source reverted, tests re-run, 5 new assertions fail exactly as intended:

```
× |main| client.test.ts > never queues, mirrors or ships scraped page metadata as a dimension
  → expected '{"schemaVersion":1,"installId":"550e8…' not to contain 'Divorce settlement calculator - LawFi…'
× |main| metadata.test.ts > keeps the clipped url and the scraped title out of warn/error records
  → expected 'Bot page detected for https://sensiti…' not to contain 'https://sensitive-health-forum.exampl…'
× |main| metadata.test.ts > omits the remote reason phrase from the metadata fetch error
  → expected [Function] to throw error matching /^HTTP 403$/ but got 'HTTP 403: Blocked: user 4417 flagged …'
× |main| metadata.test.ts > omits the clipped url from the article fetch error
  → expected error to match asymmetric matcher
× |renderer| telemetry.test.ts > drops a dimension key that is not on the allowlist, however safe it looks
  → expected { Object (page_title) } to be undefined
 Test Files  3 failed (3)
      Tests  5 failed | 75 passed (80)
```

The tests feed realistic scraped metadata (`Divorce settlement calculator - LawFirm`, `Sensitive Health Forum`, a health-forum thread URL) through the real path and assert no fragment survives in the queue file **or** the HTTP body.

The pre-existing journal-forgery test from #1113 was moved from a dimension to `error.message`, deliberately: dimensions are now allowlisted away before reaching the journal, so leaving it there would have quietly stopped exercising the escaping it exists to guard, and its own mutation test would have gone green for the wrong reason.

With the fix in place:

```
 Test Files  43 passed (43)
      Tests  676 passed (676)
```
(`src/main/telemetry`, `src/main/inbox`, `packages/contracts/telemetry-api`, renderer telemetry, plus the settings/search handler suites that assert on dimensions)

```
pnpm --filter @memry/desktop typecheck:node   ✓
pnpm --filter @memry/desktop typecheck:web    ✓
pnpm exec eslint <changed files>              ✓ 0 errors
pnpm ipc:generate && pnpm ipc:check           ✓ IPC invoke map is up to date
pnpm check:contracts                          ✓ contracts boundary check passed
pnpm check:architecture                       ✓ architecture boundary check passed
git diff --check                              ✓ clean
pnpm docs:impact --base origin/main --strict  ✓ docs changed on this branch
pnpm docs:build                               ✓ build complete
```

## For Kaan — disclosure question

Routes 1–3 are live on `main` and in shipped builds, so installs with telemetry enabled have been sending clipped-page titles and URLs to PostHog inside `warn` log lines and error messages. Volume is bounded (route 1 only fires on bot-wall pages, 2 and 3 only on fetch failures), but it is real user browsing data under a "server never sees your content" promise. Worth deciding whether it needs a disclosure note and whether the already-ingested PostHog log lines should be purged.