### PR TITLE
fix(sync): dispose the attachment upload queue on sync-runtime teardown

### DIFF
--- a/apps/desktop/src/main/ipc/sync-attachment-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/sync-attachment-handlers.test.ts
@@ -175,6 +175,10 @@ import {
   unregisterAttachmentHandlers
 } from './sync-attachment-handlers'
 import { getStatus as getVaultStatus } from '../vault/index'
+import { getNetworkMonitor } from '../sync/runtime'
+import { resetAttachmentQueue } from '../sync/attachment-outbox'
+import { UploadQueue } from '../sync/upload-queue'
+import type { NetworkMonitor } from '../sync/network'
 import { getValidAccessToken } from '../sync/token-manager'
 import { isDatabaseInitialized } from '../database/client'
 import {
@@ -204,6 +208,8 @@ describe('sync-attachment-handlers', () => {
       .mockReset()
       .mockResolvedValue({ attachmentId: 'attachment-1', sessionId: 'session-1' })
     attachmentMocks.queue.dispose.mockReset()
+    vi.mocked(UploadQueue).mockClear()
+    vi.mocked(getNetworkMonitor).mockReturnValue(null)
     outboxUploaders.length = 0
     mockOnSaved.mockClear()
     mockOnDownloadNeeded.mockClear()
@@ -264,6 +270,74 @@ describe('sync-attachment-handlers', () => {
 
     // #then — safe to call multiple times without throwing
     expect(() => clearAttachmentState()).not.toThrow()
+  })
+
+  // ==========================================================================
+  // Runtime-restart lifecycle (vault switch, sign-out/in)
+  //
+  // The queue captures getNetworkMonitor() once, at construction, and only
+  // unsubscribes in dispose(). Reusing it across a runtime restart leaves it
+  // bound to the previous, now-stopped monitor: its `online` flag is frozen and
+  // it can never emit 'status-changed' again, so the reconnect wake-up is dead
+  // for the rest of the session and vault A's leftovers upload under vault B.
+  // ==========================================================================
+
+  it('registers its disposer with the sync runtime on register and clears it on unregister', () => {
+    const dispose = vi.fn()
+    attachmentMocks.queue.dispose = dispose
+
+    registerAttachmentHandlers()
+    vi.mocked(getNetworkMonitor).mockReturnValue({ id: 'monitor-a' } as unknown as NetworkMonitor)
+    getCanvasAssetIO()
+
+    // #when the sync runtime tears down
+    resetAttachmentQueue()
+
+    // #then the IPC layer's queue went with it
+    expect(dispose).toHaveBeenCalledTimes(1)
+
+    unregisterAttachmentHandlers()
+    resetAttachmentQueue()
+
+    // #then a deregistered handler set is not reachable from the runtime
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('rebuilds the upload queue against the CURRENT NetworkMonitor after a runtime reset', () => {
+    const monitorA = { id: 'monitor-a' } as unknown as NetworkMonitor
+    const monitorB = { id: 'monitor-b' } as unknown as NetworkMonitor
+
+    // #given a first runtime built the queue
+    vi.mocked(getNetworkMonitor).mockReturnValue(monitorA)
+    registerAttachmentHandlers()
+    expect(getCanvasAssetIO()).not.toBeNull()
+    expect(vi.mocked(UploadQueue).mock.calls).toHaveLength(1)
+    expect(vi.mocked(UploadQueue).mock.calls[0][1]).toBe(monitorA)
+
+    // #when that runtime stops and a second one starts with a fresh monitor
+    resetAttachmentQueue()
+    expect(attachmentMocks.queue.dispose).toHaveBeenCalledTimes(1)
+    vi.mocked(getNetworkMonitor).mockReturnValue(monitorB)
+    expect(getCanvasAssetIO()).not.toBeNull()
+
+    // #then a NEW queue was constructed, bound to the live monitor
+    expect(vi.mocked(UploadQueue).mock.calls).toHaveLength(2)
+    expect(vi.mocked(UploadQueue).mock.calls[1][1]).toBe(monitorB)
+  })
+
+  it('does not rebuild the queue while a single runtime is alive', () => {
+    const monitorA = { id: 'monitor-a' } as unknown as NetworkMonitor
+    vi.mocked(getNetworkMonitor).mockReturnValue(monitorA)
+    registerAttachmentHandlers()
+
+    getCanvasAssetIO()
+    getCanvasAssetIO()
+    getCanvasAssetIO()
+
+    // The singleton is still a singleton — the fix scopes its lifetime to the
+    // runtime, it does not make every caller build a new queue.
+    expect(vi.mocked(UploadQueue).mock.calls).toHaveLength(1)
+    expect(attachmentMocks.queue.dispose).not.toHaveBeenCalled()
   })
 
   it('uploads through the queue after authentication and maps upload progress', async () => {

--- a/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
+++ b/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
@@ -34,6 +34,7 @@ import {
   enqueueUpload,
   clearUpload,
   markUploadFailed,
+  registerAttachmentQueueReset,
   registerOutboxUploader
 } from '../sync/attachment-outbox'
 import { markWritebackIgnored } from '../sync/crdt-writeback'
@@ -198,6 +199,26 @@ export function getCanvasAssetIO(): {
   }
 }
 
+/**
+ * Drop both attachment singletons so the next sync runtime builds them fresh.
+ *
+ * Nulling `uploadQueue` is not optional bookkeeping: the queue captured
+ * `getNetworkMonitor()` at construction and only unsubscribes in `dispose()`, so
+ * a queue reused across a runtime restart stays bound to the PREVIOUS,
+ * now-stopped NetworkMonitor — whose `online` flag is frozen and which never
+ * emits 'status-changed' again. The reconnect wake-up would be dead for the rest
+ * of the session. `attachmentService` goes with it because its key/device
+ * closures resolve `getDatabase()` lazily, so a carried-over service would sign
+ * and encrypt vault A's leftovers with vault B's key.
+ *
+ * Pending uploads are rejected by `dispose()` rather than carried over. That is
+ * deliberate and safe for note attachments: the intent row is persisted to the
+ * attachment outbox BEFORE the upload is attempted, the rejection is recorded by
+ * `markUploadFailed`, and the next `startSyncRuntime()` re-drives it via
+ * `drainAttachmentOutbox()`. Carrying items across would be the actual data bug.
+ *
+ * Idempotent — the runtime teardown and session teardown both call it.
+ */
 export function clearAttachmentState(): void {
   if (uploadQueue) {
     uploadQueue.dispose()
@@ -318,6 +339,10 @@ export function registerAttachmentHandlers(): void {
     },
     'errors:attachment.downloadProgressFailed'
   )
+
+  // The sync runtime owns the queue's lifetime (it owns the NetworkMonitor the
+  // queue binds to), so hand it the disposer to call on every teardown.
+  registerAttachmentQueueReset(clearAttachmentState)
 
   registerOutboxUploader(
     async (noteId, diskPath) => {
@@ -453,6 +478,8 @@ export function registerAttachmentHandlers(): void {
 
 export function unregisterAttachmentHandlers(): void {
   registerOutboxUploader(null, null, null)
+  registerAttachmentQueueReset(null)
+  clearAttachmentState()
   attachmentEvents.removeAllListeners('saved')
   attachmentEvents.removeAllListeners('download-needed')
 

--- a/apps/desktop/src/main/sync/attachment-outbox.ts
+++ b/apps/desktop/src/main/sync/attachment-outbox.ts
@@ -162,6 +162,7 @@ type RegisteredUploader = (noteId: string, diskPath: string) => Promise<{ attach
 let registeredUploader: RegisteredUploader | null = null
 let getDbForDrain: (() => DrizzleDb) | null = null
 let onUploadedForDrain: ((noteId: string, attachmentId: string) => void) | null = null
+let registeredQueueReset: (() => void) | null = null
 let draining = false
 
 export function registerOutboxUploader(
@@ -172,6 +173,24 @@ export function registerOutboxUploader(
   registeredUploader = uploader
   getDbForDrain = getDb
   onUploadedForDrain = onUploaded
+}
+
+/**
+ * The IPC layer owns the UploadQueue singleton, but the sync RUNTIME owns its
+ * lifetime: the queue subscribes to the NetworkMonitor of the runtime that
+ * built it and only detaches in dispose(). A queue that outlives its runtime is
+ * therefore bound to a stopped monitor, whose `online` flag is frozen and which
+ * can never emit 'status-changed' again — so the reconnect wake-up is dead and
+ * the queue can still serve the wrong vault. The IPC layer registers its
+ * disposer here; the runtime calls it on every teardown.
+ */
+export function registerAttachmentQueueReset(reset: (() => void) | null): void {
+  registeredQueueReset = reset
+}
+
+/** No-ops until the IPC layer has registered a disposer. */
+export function resetAttachmentQueue(): void {
+  registeredQueueReset?.()
 }
 
 export async function drainAttachmentOutbox(): Promise<void> {

--- a/apps/desktop/src/main/sync/attachment-queue-lifecycle.test.ts
+++ b/apps/desktop/src/main/sync/attachment-queue-lifecycle.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { NetworkMonitor, type NetworkMonitorDeps } from './network'
+import { NetworkError } from './http-client'
+import { UploadQueue, type UploadFn } from './upload-queue'
+import { registerAttachmentQueueReset, resetAttachmentQueue } from './attachment-outbox'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+vi.mock('../telemetry/diagnostics', () => ({
+  trackMainLog: vi.fn()
+}))
+
+const inertDeps = (online: boolean): NetworkMonitorDeps => ({
+  getIsOnline: () => online,
+  onResume: () => {},
+  onSuspend: () => {},
+  offResume: () => {},
+  offSuspend: () => {}
+})
+
+/** A real NetworkMonitor with no Electron behind it. */
+const makeMonitor = (online = true): NetworkMonitor => new NetworkMonitor(0, inertDeps(online))
+
+/** Drive a real 'status-changed' {online:true} emission. */
+const emitNetworkRestored = (monitor: NetworkMonitor): void => {
+  monitor.setOnlineForTests(false)
+  monitor.setOnlineForTests(true)
+}
+
+const okUpload = (): UploadFn =>
+  vi.fn(async (noteId: string) => ({
+    attachmentId: `att-${noteId}`,
+    sessionId: `sess-${noteId}`,
+    manifest: {} as never
+  }))
+
+describe('attachment upload queue lifecycle', () => {
+  afterEach(() => {
+    registerAttachmentQueueReset(null)
+    vi.useRealTimers()
+  })
+
+  // ==========================================================================
+  // Why the singleton must not outlive its runtime
+  // ==========================================================================
+
+  describe('binding to the NetworkMonitor', () => {
+    it('subscribes to the monitor it was constructed with and detaches on dispose', () => {
+      const monitor = makeMonitor()
+
+      const queue = new UploadQueue(okUpload(), monitor)
+      expect(monitor.listenerCount('status-changed')).toBe(1)
+
+      queue.dispose()
+      expect(monitor.listenerCount('status-changed')).toBe(0)
+    })
+
+    // #given a runtime restart builds a brand-new NetworkMonitor
+    it('a queue carried across a restart stays deaf to the CURRENT monitor', async () => {
+      const dead = makeMonitor()
+      const uploadFn = okUpload()
+      const carriedOver = new UploadQueue(uploadFn, dead)
+      const live = makeMonitor()
+
+      // #when the live monitor reports the network came back
+      emitNetworkRestored(live)
+      await Promise.resolve()
+
+      // #then nothing reaches the carried-over queue — this is the bug: its only
+      // wake-up is wired to a monitor that is stopped and can never emit again.
+      expect(live.listenerCount('status-changed')).toBe(0)
+      expect(dead.listenerCount('status-changed')).toBe(1)
+
+      carriedOver.dispose()
+    })
+
+    it('a disposed-and-rebuilt queue binds the current monitor and leaves the dead one clean', () => {
+      const dead = makeMonitor()
+      const first = new UploadQueue(okUpload(), dead)
+      first.dispose()
+
+      const live = makeMonitor()
+      const second = new UploadQueue(okUpload(), live)
+
+      expect(live.listenerCount('status-changed')).toBe(1)
+      expect(dead.listenerCount('status-changed')).toBe(0)
+
+      second.dispose()
+    })
+
+    it('does not accumulate listeners across repeated stop/start cycles', () => {
+      const monitors: NetworkMonitor[] = []
+
+      for (let i = 0; i < 12; i++) {
+        const monitor = makeMonitor()
+        monitors.push(monitor)
+        const queue = new UploadQueue(okUpload(), monitor)
+        expect(monitor.listenerCount('status-changed')).toBe(1)
+        // What the runtime teardown now does on every cycle.
+        queue.dispose()
+      }
+
+      // 12 cycles, zero survivors — a leak would show as a monitor still holding
+      // its subscriber, and NetworkMonitor's ceiling is only 10.
+      for (const monitor of monitors) {
+        expect(monitor.listenerCount('status-changed')).toBe(0)
+      }
+    })
+  })
+
+  // ==========================================================================
+  // The wake-up that is lost when the binding goes stale
+  // ==========================================================================
+
+  describe('network-restored wake-up', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    it('drains a queue sitting in network backoff without waiting out the delay', async () => {
+      const monitor = makeMonitor()
+      let attempts = 0
+      const uploadFn: UploadFn = vi.fn(async (noteId: string) => {
+        attempts++
+        if (attempts === 1) throw new NetworkError('offline')
+        return { attachmentId: `att-${noteId}`, sessionId: 'sess', manifest: {} as never }
+      })
+      const queue = new UploadQueue(uploadFn, monitor)
+
+      const pending = queue.enqueue('note-1', '/tmp/a.pdf')
+      await vi.advanceTimersByTimeAsync(0)
+      // First attempt failed and the item went back on the queue behind a 1s
+      // network backoff.
+      expect(uploadFn).toHaveBeenCalledTimes(1)
+
+      // #when the network comes back
+      emitNetworkRestored(monitor)
+      await vi.advanceTimersByTimeAsync(0)
+
+      // #then it retried immediately — no timer advance was needed to get here.
+      expect(uploadFn).toHaveBeenCalledTimes(2)
+      await expect(pending).resolves.toMatchObject({ attachmentId: 'att-note-1' })
+
+      queue.dispose()
+    })
+
+    it('a restored event on a different monitor does not wake the queue', async () => {
+      const bound = makeMonitor()
+      let attempts = 0
+      const uploadFn: UploadFn = vi.fn(async (noteId: string) => {
+        attempts++
+        if (attempts === 1) throw new NetworkError('offline')
+        return { attachmentId: `att-${noteId}`, sessionId: 'sess', manifest: {} as never }
+      })
+      const queue = new UploadQueue(uploadFn, bound)
+
+      const pending = queue.enqueue('note-1', '/tmp/a.pdf')
+      await vi.advanceTimersByTimeAsync(0)
+      expect(uploadFn).toHaveBeenCalledTimes(1)
+
+      // #when the RESTART's monitor reports the network is back
+      const live = makeMonitor()
+      emitNetworkRestored(live)
+      await vi.advanceTimersByTimeAsync(0)
+
+      // #then the queue is unmoved — it only resumes once its own backoff timer
+      // expires, which is the session-long stall this fix exists to prevent.
+      expect(uploadFn).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(uploadFn).toHaveBeenCalledTimes(2)
+      await expect(pending).resolves.toMatchObject({ attachmentId: 'att-note-1' })
+
+      queue.dispose()
+    })
+  })
+
+  // ==========================================================================
+  // The seam the sync runtime uses to enforce all of the above
+  // ==========================================================================
+
+  describe('reset registry', () => {
+    it('no-ops when no disposer is registered', () => {
+      expect(() => resetAttachmentQueue()).not.toThrow()
+    })
+
+    it('invokes the registered disposer', () => {
+      const dispose = vi.fn()
+      registerAttachmentQueueReset(dispose)
+
+      resetAttachmentQueue()
+
+      expect(dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('stops invoking the disposer once deregistered', () => {
+      const dispose = vi.fn()
+      registerAttachmentQueueReset(dispose)
+      resetAttachmentQueue()
+
+      registerAttachmentQueueReset(null)
+      resetAttachmentQueue()
+
+      expect(dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('really does tear the queue off its monitor when wired to a queue holder', () => {
+      // The production shape: a module-level slot the IPC layer owns and the
+      // runtime resets.
+      const monitor = makeMonitor()
+      let queue: UploadQueue | null = new UploadQueue(okUpload(), monitor)
+      registerAttachmentQueueReset(() => {
+        queue?.dispose()
+        queue = null
+      })
+      expect(monitor.listenerCount('status-changed')).toBe(1)
+
+      resetAttachmentQueue()
+
+      expect(queue).toBeNull()
+      expect(monitor.listenerCount('status-changed')).toBe(0)
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -880,6 +880,40 @@ describe('sync runtime', () => {
     expect(runtimeMocks.NetworkMonitor.instances[0].stop).toHaveBeenCalled()
   })
 
+  // The attachment UploadQueue lives in the IPC layer but binds THIS runtime's
+  // NetworkMonitor for its lifetime, so it has to be reset on the same paths the
+  // other per-vault singletons are. Left alive it stays subscribed to a stopped
+  // monitor — reconnect wake-up dead, `online` frozen — and serves the next vault.
+  it('resets the attachment upload queue on stop', async () => {
+    const runtime = await loadRuntime()
+    // resetModules ran in beforeEach, so this is the same module instance the
+    // freshly-loaded runtime imports.
+    const { registerAttachmentQueueReset } = await import('./attachment-outbox')
+    const resetAttachmentQueue = vi.fn()
+    registerAttachmentQueueReset(resetAttachmentQueue)
+
+    await runtime.startSyncRuntime()
+    expect(resetAttachmentQueue).not.toHaveBeenCalled()
+
+    await runtime.stopSyncRuntime({ skipFinalSync: true })
+
+    expect(resetAttachmentQueue).toHaveBeenCalled()
+  })
+
+  it('resets the attachment upload queue when startup fails after the runtime is assembled', async () => {
+    const runtime = await loadRuntime()
+    const { registerAttachmentQueueReset } = await import('./attachment-outbox')
+    const resetAttachmentQueue = vi.fn()
+    registerAttachmentQueueReset(resetAttachmentQueue)
+    runtimeMocks.engineStartError = new Error('engine start failed')
+
+    await expect(runtime.startSyncRuntime()).resolves.toBeNull()
+
+    // A queue built during the doomed start would otherwise outlive the monitor
+    // that was just stopped in the same cleanup block.
+    expect(resetAttachmentQueue).toHaveBeenCalled()
+  })
+
   it('destroys CRDT provider when stopped without an active runtime', async () => {
     const runtime = await loadRuntime()
 

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -34,6 +34,7 @@ import { initProjectSyncService, resetProjectSyncService } from './project-sync'
 import { initSettingsSyncManager, resetSettingsSyncManager } from './settings-sync'
 import { initNoteSyncService, resetNoteSyncService } from './note-sync'
 import { resetRequestedAttachmentDownloads } from './item-handlers/note-handler'
+import { resetAttachmentQueue } from './attachment-outbox'
 import { initJournalSyncService, resetJournalSyncService } from './journal-sync'
 import { initTagDefinitionSyncService, resetTagDefinitionSyncService } from './tag-definition-sync'
 import { initTagCategorySyncService, resetTagCategorySyncService } from './tag-category-sync'
@@ -196,6 +197,11 @@ function resetSyncServiceSingletons(): void {
   // Module-level state on the note item handler, not a service singleton, but
   // it is per-vault and torn down on exactly the same paths.
   resetRequestedAttachmentDownloads()
+  // The attachment UploadQueue lives in the IPC layer but captures THIS
+  // runtime's NetworkMonitor, so it has to die with the runtime: a carried-over
+  // queue stays subscribed to a stopped monitor (reconnect wake-up dead, its
+  // `online` flag frozen) and would upload vault A's leftovers under vault B.
+  resetAttachmentQueue()
 }
 
 function getCurrentDeviceId(db: DataDb): string | null {

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -346,11 +346,11 @@ bug trips `MaxListenersExceededWarning` instead of hiding behind a generous budg
 counts, so raising either needs a test change and an explanation.
 
 Every subscriber is detached on teardown: the engine removes its own in `stop()`,
-and the runtime keeps a reference to its `status-changed` handler so
-`stopSyncRuntime()` can remove it. That last detach matters because the attachment
-`UploadQueue` is a module singleton that keeps holding the `NetworkMonitor` past a
-runtime stop — an attached handler would keep the dead CRDT queue and provider
-reachable for the rest of the session.
+the runtime keeps a reference to its `status-changed` handler so
+`stopSyncRuntime()` can remove it, and the attachment `UploadQueue` is disposed
+with the runtime that built it (see "Upload queue lifetime" under Note
+Attachments). A subscriber left attached does more than leak: it keeps the dead
+CRDT queue and provider reachable for the rest of the session.
 
 ## Manifest Integrity
 
@@ -382,6 +382,23 @@ across devices:
   path that is outside this device's allowed roots by remapping its
   `attachments/<noteId>/<file>` tail onto the local vault (traversal-guarded),
   so notes written on another OS render without rewriting note content.
+- **Upload queue lifetime** — the in-memory `UploadQueue` is a module singleton
+  owned by the IPC layer, but its lifetime is scoped to the sync _runtime_. It
+  binds `getNetworkMonitor()` once, at construction, and only unsubscribes in
+  `dispose()`, so a queue reused across a runtime restart (vault switch,
+  sign-out/in) would stay attached to the previous monitor. That monitor is
+  stopped, which clears its poll timer: its `online` flag is frozen and it can
+  never emit `status-changed` again, so the reconnect wake-up that clears the
+  network backoff would be dead for the rest of the session — and a frozen
+  offline flag makes every retry burn the full five-minute offline wait before
+  failing. `resetSyncServiceSingletons()` therefore disposes the queue and the
+  attachment service on both teardown paths (`stopSyncRuntime()` and the
+  startup-failure cleanup), so the next runtime builds them against the live
+  monitor and vault A's queue can never serve vault B. The IPC layer registers
+  its disposer through `attachment-outbox`, which is already the seam between
+  the sync runtime and this singleton, so no import cycle is introduced.
+  Uploads pending at dispose are rejected rather than carried over — the outbox
+  below is what makes that safe.
 - **Durable upload outbox** — the upload intent is persisted in the data DB
   (`attachment_upload_queue`, migration 0039) before the transfer starts and
   cleared only after the server accepts the file. Failed or quit-interrupted


### PR DESCRIPTION
## What was wrong

`uploadQueue` in `apps/desktop/src/main/ipc/sync-attachment-handlers.ts:68` is a lazy module singleton that captures the `NetworkMonitor` **once**, at construction (`:70-79`), and `UploadQueue` only unsubscribes in `dispose()` (`apps/desktop/src/main/sync/upload-queue.ts:48-62`, `:81-86`).

A disposer exists — `clearAttachmentState()` (`sync-attachment-handlers.ts:201-207`) — but nothing on the runtime-restart path called it:

- its only caller was `clearInMemoryAuthState()` (`apps/desktop/src/main/ipc/sync-core-handlers.ts:189-193`), reachable only from `teardownSession()` (`apps/desktop/src/main/sync/session-teardown.ts:69`) — i.e. sign-out;
- **vault switch never goes through that path** — `closeVault()` calls `stopSyncRuntime()` directly (`apps/desktop/src/main/vault/index.ts:645`);
- `resetSyncServiceSingletons()` (`apps/desktop/src/main/sync/runtime.ts:176-199`) resets 19 per-vault singletons on both teardown paths (`:847` startup-failure, `:913` stop) but did not touch the attachment ones.

Every `startSyncRuntime()` builds a fresh monitor (`runtime.ts:672`), so after a restart the live monitor and the queue's monitor are different objects.

## Why the stale binding is worse than a dangling listener

`NetworkMonitor.stop()` clears the poll timer (`apps/desktop/src/main/sync/network.ts:73-90`), so the dead monitor's `_online` is **frozen** and `applyStatus()` never emits again. The queue feeds that frozen flag into every upload (`upload-queue.ts:148-150`), and `withRetry` blocks on it (`apps/desktop/src/main/sync/retry.ts:104-113`):

1. **The reconnect wake-up is permanently dead.** `upload-queue.ts:49-60` is what resets `networkAttempts` and clears the backoff on reconnect. Attached to the dead monitor, it can never fire again — every retry waits out the full escalated delay, pinned at the 60s ceiling because the attempt counter never resets either.
2. **Offline at teardown ⇒ stuck until the app restarts.** The frozen `isOnline()` returns `false` forever, so each attempt burns the full 5-minute `MAX_OFFLINE_WAIT_MS`, throws `NetworkError('Offline wait timeout exceeded')`, is re-queued with escalating backoff, and repeats — *even though the machine is back online*. The only escape hatch is the wake-up from (1).
3. **Cross-vault leakage.** Neither singleton was reset on vault switch, and `AttachmentSyncService`'s key/device closures resolve `getDatabase()` / `getOrCreateVaultUuid(db)` lazily (`sync-attachment-handlers.ts:136-139`) — so a vault-A attachment left in the queue got encrypted with **vault B's** key and recorded against vault B.

**User-visible symptom:** after switching vaults (or signing out and back in) in one session, attachment uploads that hit any network trouble stop making progress. The file stays local, the note references an attachment that exists on one machine only, and the user sees repeated "attachment upload failed" errors that do not recover when the network returns — only quitting and relaunching fixes it.

## What changed

1. `apps/desktop/src/main/sync/attachment-outbox.ts` — new `registerAttachmentQueueReset()` / `resetAttachmentQueue()` slot. This module is already the documented seam between the sync runtime and the IPC-layer queue singleton (it owns `registerOutboxUploader` / `drainAttachmentOutbox` for exactly this reason), so the hook adds no import cycle and pulls no Electron into `runtime.ts`.
2. `apps/desktop/src/main/sync/runtime.ts` — `resetSyncServiceSingletons()` now calls `resetAttachmentQueue()`. That function is already invoked on **both** teardown paths, which is the pattern #1237 established for the runtime's own network subscriber.
3. `apps/desktop/src/main/ipc/sync-attachment-handlers.ts` — registers `clearAttachmentState` as that disposer on `registerAttachmentHandlers()`, clears the slot on `unregisterAttachmentHandlers()`, and disposes there too so the singleton no longer survives a handler register/unregister cycle.

`clearAttachmentState()` itself is unchanged (it already disposed and nulled both singletons) — the bug was purely that nothing called it. It is idempotent, so the sign-out path calling it twice is fine.

## What happens to queued uploads on dispose

They are **rejected, not carried over** — deliberately. Carrying them across is the actual data bug (that is how a vault-A file gets uploaded under vault B's key).

Rejecting is safe because the durable outbox already covers it: `attachmentEvents.onSaved` persists the intent row **before** the transfer is attempted (`sync-attachment-handlers.ts:338-344`), the rejection is recorded by `markUploadFailed`, and the next `startSyncRuntime()` re-drives every pending row through `drainAttachmentOutbox()` (`runtime.ts:810`). So no user attachment is dropped — a vault switch costs the in-flight transfer its progress and one outbox attempt, and the upload resumes on the next runtime start against the correct vault.

Ordering is safe: `closeVault()` awaits `stopSyncRuntime()` before `closeAllDatabases()`, so the rejection's `markUploadFailed` still writes to the live (vault A) DB.

Canvas assets need no equivalent handling — `asset-service-context.ts` calls `getCanvasAssetIO()` per operation, so it picks up the new queue automatically.

## Verification

Mutation-tested by reverting only the two wiring changes and keeping the new registry API, so the failures are assertion-level rather than import errors:

```
× sync-attachment-handlers.test.ts > registers its disposer with the sync runtime on register and clears it on unregister
  → expected "vi.fn()" to be called 1 times, but got 0 times
× sync-attachment-handlers.test.ts > rebuilds the upload queue against the CURRENT NetworkMonitor after a runtime reset
  → expected [ [ [Function bound Mock], …(1) ] ] to have a length of 2 but got 1
× sync-attachment-handlers.test.ts > does not rebuild the queue while a single runtime is alive
  → expected "vi.fn()" to not be called at all, but actually been called 1 times
× runtime.test.ts > resets the attachment upload queue on stop
  → expected "vi.fn()" to be called at least once
× runtime.test.ts > resets the attachment upload queue when startup fails after the runtime is assembled
  → expected "vi.fn()" to be called at least once

 Tests  5 failed | 48 passed (53)
```

New `apps/desktop/src/main/sync/attachment-queue-lifecycle.test.ts` drives the **real** `UploadQueue` against a **real** `NetworkMonitor` (injected deps, no Electron) rather than mocked IPC: constructor subscribes and `dispose()` detaches; a carried-over queue is provably deaf to the current monitor while the dead one still holds its subscriber; a rebuilt queue binds the live monitor; 12 stop/start cycles leave every monitor at zero listeners; and a restored event drains a queue sitting in backoff *without advancing the backoff timer*, while the same event on a different monitor does not.

With the fix applied:

```
$ pnpm exec vitest run --config config/vitest.config.ts --project main src/main/sync
 Test Files  141 passed (141)
      Tests  1797 passed | 1 expected fail | 3 skipped (1801)

$ pnpm --filter @memry/desktop typecheck:node      # clean
$ pnpm exec eslint <changed source files>          # 0 errors
$ git diff --check                                 # clean
$ pnpm ipc:generate && pnpm ipc:check              # invoke map + RPC bindings up to date, no diff
$ pnpm docs:impact --base origin/main --strict     # covered
$ pnpm docs:build                                  # build complete in 14.19s
```

## Backward compatibility

In-process lifetime only. No DB schema, sync protocol, IPC contract, vault file format, or settings shape is touched — `pnpm ipc:generate` produced no diff. The `attachment_upload_queue` table and its drain semantics are unchanged; this only ensures the drain runs against a live monitor.

Closes #1252
Part of epic #987, follow-up to #1075 / #1237
