### PR TITLE
docs(vault): correct the stale getConfig reason on the batched embed read

### DIFF
--- a/apps/desktop/src/main/vault/resolve-embed.ts
+++ b/apps/desktop/src/main/vault/resolve-embed.ts
@@ -171,8 +171,9 @@ export function resolveVaultEmbeds(refs: string[], notePath?: string): Record<st
   const status = getStatus()
   if (!status.isOpen || !status.path) return {}
 
-  // Read once per batch, not once per ref: `getConfig` re-reads and re-parses
-  // config.json off disk on every call.
+  // Read once per batch, not once per ref: `getConfig` no longer re-parses
+  // config.json — the parse is cached — but every call still stats the file to
+  // revalidate that cache and rebuilds the config object it hands back.
   const notesFolder = getConfig().defaultNoteFolder || 'notes'
 
   return resolveAgainstVault(status.path, notesFolder, refs, notePath)


### PR DESCRIPTION
Comment-only. No executable line changes.

## The stale claim

`resolveVaultEmbeds` in `apps/desktop/src/main/vault/resolve-embed.ts` hoists the vault config read out of the per-ref loop. The comment explaining why said:

> Read once per batch, not once per ref: `getConfig` re-reads and re-parses config.json off disk on every call.

## Why it is stale

That was accurate when the batching landed in #1152. It stopped being true in #1241 (issue #1079), which added a per-config-path cache to `readVaultConfig` in `apps/desktop/src/main/vault/init.ts`. `getConfig` no longer re-reads and re-parses on every call — the parsed config is cached and revalidated against the file's inode, size and nanosecond mtime, so the read + `JSON.parse` only happens when `config.json` actually changed.

## The corrected reasoning

The batching is still worth having, just for a smaller reason: every `getConfig()` call still costs a `statSync` on `config.json` to revalidate the cache, plus a fresh copy of the config object (`copyConfig`, then the `resolved` object `getConfig` builds on top of it) and the `syncJournalConfig` comparison. Hoisting it out of the loop turns N of those into one.

New text:

```ts
// Read once per batch, not once per ref: `getConfig` no longer re-parses
// config.json — the parse is cached — but every call still stats the file to
// revalidate that cache and rebuilds the config object it hands back.
```

The batching logic below the comment is unchanged, and `resolve-embed.test.ts` still asserts it ("reads the vault config once and touches the index once for a whole batch").

## Verification

- `pnpm --filter @memry/desktop typecheck:node` — clean
- `pnpm exec eslint apps/desktop/src/main/vault/resolve-embed.ts` — clean, exit 0
- `vitest run --project main src/main/vault/resolve-embed` — 18/18 passed
- `git diff --check` — clean
- No lockfile changes

## Docs gate

`pnpm docs:impact --base origin/main --strict` reports `missing-docs`, because it routes on file path (`apps/desktop/**`) and cannot tell that the diff touches only a comment. There is no user-facing behavior change here and nothing to document, so no docs page was added rather than inventing one.

Part of epic #987. No issue to close.
