### PR TITLE
perf(sync): drop the stale exit listener when worker shutdown times out

### DIFF
--- a/apps/desktop/src/main/sync/worker-bridge.test.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.test.ts
@@ -166,6 +166,63 @@ describe('SyncWorkerBridge', () => {
       expect(bridge.isRunning).toBe(false)
     })
 
+    it('#then drops the shutdown exit listener when the 3s timeout fires', async () => {
+      // #given
+      const p = bridge.start()
+      mockWorkerInstance.simulateMessage({ type: 'ready' })
+      await p
+      const exitListenersBefore = mockWorkerInstance.listenerCount('exit')
+
+      // #when
+      const stopPromise = bridge.stop()
+      expect(mockWorkerInstance.listenerCount('exit')).toBe(exitListenersBefore + 1)
+      vi.advanceTimersByTime(3_001)
+      await stopPromise
+
+      // #then — only setupMessageHandler's listener is left
+      expect(mockWorkerInstance.listenerCount('exit')).toBe(exitListenersBefore)
+    })
+
+    it('#then a late exit from the timed-out worker cannot reject a restarted bridge', async () => {
+      // #given — a stop() that hit the 3s timeout
+      const p = bridge.start()
+      mockWorkerInstance.simulateMessage({ type: 'ready' })
+      await p
+      const abandonedWorker = mockWorkerInstance
+
+      const stopPromise = bridge.stop()
+      vi.advanceTimersByTime(3_001)
+      await stopPromise
+
+      // #and — the bridge is restarted on a fresh thread
+      const restart = bridge.start()
+      mockWorkerInstance.simulateMessage({ type: 'ready' })
+      await restart
+      expect(mockWorkerInstance).not.toBe(abandonedWorker)
+
+      const encryptPromise = bridge.encryptBatch(
+        [],
+        new Uint8Array(32),
+        new Uint8Array(64),
+        'device-1'
+      )
+
+      // #when — terminate() lands and the abandoned thread finally reports exit
+      abandonedWorker.simulateExit(0)
+
+      // #then — the new worker's in-flight request is untouched by the old thread
+      const posted = mockWorkerInstance.postMessage.mock.calls.find(
+        ([m]) => m.type === 'encrypt-batch'
+      )![0]
+      mockWorkerInstance.simulateMessage({
+        type: 'encrypt-batch-result',
+        requestId: posted.requestId,
+        results: [],
+        errors: []
+      })
+      await expect(encryptPromise).resolves.toEqual({ results: [], errors: [] })
+    })
+
     it('#then no-ops if not running', async () => {
       // #given bridge never started
       // #when / #then

--- a/apps/desktop/src/main/sync/worker-bridge.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.ts
@@ -290,17 +290,26 @@ export class SyncWorkerBridge {
     this.worker.postMessage({ type: 'shutdown' } satisfies MainToWorkerMessage)
 
     await new Promise<void>((resolve) => {
-      const timeout = setTimeout(() => {
-        this.rejectAll(new Error('Worker shutdown timeout'))
-        void this.worker?.terminate()
-        resolve()
-      }, 3_000)
+      const worker = this.worker!
 
-      this.worker!.once('exit', () => {
+      const onExit = (): void => {
         this.rejectAll(new Error('Worker exited'))
         clearTimeout(timeout)
         resolve()
-      })
+      }
+
+      const timeout = setTimeout(() => {
+        // Detach before terminating. terminate() still emits 'exit', and a
+        // stop()/start() cycle can have handed the bridge a fresh worker by
+        // then — the stale handler would reject that worker's in-flight
+        // requests with 'Worker exited'.
+        worker.off('exit', onExit)
+        this.rejectAll(new Error('Worker shutdown timeout'))
+        void worker.terminate()
+        resolve()
+      }, 3_000)
+
+      worker.once('exit', onExit)
     })
 
     this.worker = null

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -589,3 +589,8 @@ the session its worker — so a successful batch resets the count and only conse
 Waiting longer is expensive, because the penalty is paid in whole minutes. The thread is left alive
 rather than terminated, and restarting the sync runtime gives the bridge a fresh worker and a clean
 count.
+
+Shutting the bridge down asks the worker to exit and waits three seconds before terminating it. A
+worker that misses that window is fully detached first, so the exit that terminating eventually
+produces cannot land on a bridge that has already been restarted and cancel the new worker's
+in-flight batches.


### PR DESCRIPTION
Closes #1092. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/sync/worker-bridge.ts:292-304` (pre-fix) — `stop()` posts `shutdown`, then races a 3 s timeout against a `once('exit')` handler. The exit handler was registered inline and never detached on the timeout branch:

```ts
const timeout = setTimeout(() => {
  this.rejectAll(new Error('Worker shutdown timeout'))
  void this.worker?.terminate()
  resolve()
}, 3_000)

this.worker!.once('exit', () => {
  this.rejectAll(new Error('Worker exited'))
  clearTimeout(timeout)
  resolve()
})
```

The audit filed this as a dangling listener. It is worse than that in practice: `terminate()` still emits `'exit'`, so the handler *does* fire — just later, against `this.rejectAll` on the live bridge. `stop()` then `start()` is the documented in-session recovery path for a latched worker (`worker-bridge.ts` `MAX_CONSECUTIVE_FAILURES` comment, and the existing test `#then a restarted bridge is no longer latched`). If the old thread's exit lands after the restart, the stale handler rejects the **new** worker's in-flight encrypt/decrypt batches with `Worker exited`, costing a needless degrade to main-thread crypto.

## What changed

One function, `stop()`:

- The exit handler is hoisted to a named `onExit` and detached with `worker.off('exit', onExit)` in the timeout branch, before `terminate()`.
- The worker being shut down is captured in a local `const worker` so `off()` / `terminate()` provably target the same thread that `once()` was registered on (`this.worker` can be nulled by `setupMessageHandler`'s own exit handler).

Deliberately **not** done: `setupMessageHandler`'s `message` / `error` / `exit` listeners are also left attached to the abandoned thread, and its exit handler unconditionally does `this.worker = null`, which is its own cross-talk hazard after a restart. That is a separate defect with a separate blast radius and is out of scope for this issue.

## How it was proven

Two new tests in `apps/desktop/src/main/sync/worker-bridge.test.ts`, one structural and one behavioural:

- `#then drops the shutdown exit listener when the 3s timeout fires` — asserts `listenerCount('exit')` returns to its pre-`stop()` baseline.
- `#then a late exit from the timed-out worker cannot reject a restarted bridge` — times out a `stop()`, restarts the bridge on a fresh thread, issues an `encryptBatch`, then fires `'exit'` on the abandoned worker and asserts the new request still resolves.

Source fix stashed, tests kept:

```
Tests  2 failed | 25 passed (27)
  → expected 2 to be 1 // Object.is equality
  → promise rejected "Error: Worker exited" instead of resolving
```

Fix restored:

```
Tests  27 passed (27)
```

## Verification

| command | result |
| --- | --- |
| `pnpm exec vitest run --config config/vitest.config.ts --project main src/main/sync/worker-bridge.test.ts` | 1 file passed, 27/27 tests |
| `pnpm --filter @memry/desktop typecheck:node` | clean, no output |
| `pnpm exec eslint apps/desktop/src/main/sync/worker-bridge.ts` | 0 errors, 0 warnings |
| `git diff --check` | clean |
| `pnpm docs:impact --base origin/main --strict` | `covered` |
| `pnpm docs:build` | `build complete in 8.11s` |

Renderer typecheck not run — no renderer files touched.

## Backward compatibility

None affected: main-process-internal listener bookkeeping only, no schema, IPC contract, settings, sync protocol, or on-disk format change.