### PR TITLE
perf(main): release the launch-timeline vault-status listener when auto-open settles

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -947,6 +947,46 @@ describe('main index phase2 exports', () => {
     expect(createdWindow.setSize).toHaveBeenCalledWith(760, 560)
   })
 
+  it('drops the launch-timeline vault-status listener when the vault fails to open', async () => {
+    whenReadyMock.mockResolvedValue(undefined)
+    getCurrentVaultPathMock.mockReturnValue('/vault')
+    autoOpenLastVaultMock.mockRejectedValueOnce(new Error('vault open failed'))
+
+    await importMainModule()
+    await flushReadyWork()
+    await flushUntil(() => vaultStatusChangedListeners.length === 1)
+
+    // isOpen:true never arrives on a failed open, so the timeline listener has to
+    // be dropped by the settled promise or it leaks for the whole session. Only
+    // the window-resize listener may survive.
+    expect(vaultStatusChangedListeners).toHaveLength(1)
+
+    // ...and the survivor is the window-resize listener, not the timeline one.
+    const createdWindow = browserWindows[0]
+    createdWindow.getSize.mockReturnValue([1550, 900])
+    vaultStatusChangedListeners[0]?.({
+      isOpen: false,
+      path: null,
+      isIndexing: false,
+      indexProgress: 0,
+      error: null
+    })
+    expect(createdWindow.setSize).toHaveBeenCalledWith(760, 560)
+  })
+
+  // The stale-vault-path case: a stored path whose folder is gone resolves
+  // autoOpenLastVault without ever opening a vault, so isOpen:true never fires.
+  it('drops the launch-timeline vault-status listener when auto-open resolves without opening', async () => {
+    whenReadyMock.mockResolvedValue(undefined)
+    getCurrentVaultPathMock.mockReturnValue('/vault')
+
+    await importMainModule()
+    await flushReadyWork()
+    await flushUntil(() => vaultStatusChangedListeners.length === 1)
+
+    expect(vaultStatusChangedListeners).toHaveLength(1)
+  })
+
   it('covers dev-only startup paths for CSP, renderer URL loading, and React DevTools', async () => {
     whenReadyMock.mockResolvedValue(undefined)
     isDevMock.dev = true

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1632,9 +1632,10 @@ const appReady = app.whenReady().then(async () => {
   // isOpen — not to the promise, which also waits on the first full sync. Only
   // when there is a vault to restore: a launch onto the picker has no such
   // phase, and stamping one would report it as forever-pending.
+  let unsubscribeLaunchVaultStatus: (() => void) | null = null
   if (getCurrentVaultPath()) {
     recordLaunchPhase('vault_open_start')
-    let unsubscribeLaunchVaultStatus: (() => void) | null = onVaultStatusChanged((status) => {
+    unsubscribeLaunchVaultStatus = onVaultStatusChanged((status) => {
       if (!status.isOpen) return
       recordLaunchPhase('vault_open_ready')
       unsubscribeLaunchVaultStatus?.()
@@ -1696,6 +1697,16 @@ const appReady = app.whenReady().then(async () => {
     .catch((err) => {
       mainLog.error('autoOpenLastVault failed:', err)
       trackMainError('main_process', 'auto_open_last_vault_failed', err)
+    })
+    .finally(() => {
+      // The listener above only clears itself on the first isOpen:true. A vault
+      // that fails to open (or one whose status emit is suppressed by shutdown)
+      // never sends that, so the closure would sit in the vault module's
+      // statusListeners set for the rest of the session. autoOpenLastVault
+      // settles after openVault has already flipped isOpen, so on the happy path
+      // this is a no-op — vault_open_ready is stamped before we get here.
+      unsubscribeLaunchVaultStatus?.()
+      unsubscribeLaunchVaultStatus = null
     })
 
   app.on('activate', function () {


### PR DESCRIPTION
Closes #1090. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/index.ts:1635-1643` — the launch-timeline subscription only unsubscribed from inside its own handler, on the first `isOpen: true`:

```ts
if (getCurrentVaultPath()) {
  recordLaunchPhase('vault_open_start')
  let unsubscribeLaunchVaultStatus: (() => void) | null = onVaultStatusChanged((status) => {
    if (!status.isOpen) return
    recordLaunchPhase('vault_open_ready')
    unsubscribeLaunchVaultStatus?.()
    unsubscribeLaunchVaultStatus = null
  })
}
```

`isOpen: true` is the only exit. It never arrives when:

- `openVault()` throws inside `autoOpenLastVault()` (`vault/index.ts:839-846` catches, clears the stored path, and resolves) — corrupt/locked DB, keychain failure, vault on an unmounted drive;
- the stored path exists but `isVaultInitialized()` is false (folder deleted/moved) — `autoOpenLastVault()` resolves without opening anything;
- the app is quitting, where `emitStatusChanged()` returns early on `isShuttingDown` (`vault/index.ts:229`).

The handle was also `let`-scoped **inside** the `if` block, so nothing outside could release it. The closure then stays in the vault module's `statusListeners` set (`vault/index.ts:122`) for the whole session and runs on every later vault status change — including a subsequent successful open, where it stamps `vault_open_ready` long after launch and skews the timeline that phase exists to measure.

One fixed-size listener, so the memory cost is small; the stale late `vault_open_ready` stamp is the more concrete symptom.

## What changed

- Hoisted `unsubscribeLaunchVaultStatus` out of the `if` block (initialised to `null`), so the assignment inside stays otherwise identical.
- Added a `.finally()` to the existing `autoOpenLastVault()` chain that releases the handle and nulls it.

That is the whole change — two hunks, no behavior change on the happy path.

**Divergence from the issue text.** The issue suggested "a failure signal **or** a timeout". I did not add a timer. `autoOpenLastVault()` settles *after* `openVault()` has already flipped `isOpen` (the promise additionally waits on the first full sync — that ordering is why the existing comment times the phase to `isOpen` and not to the promise), so settling is a strictly better signal than a wall-clock deadline: it covers the reject path, the resolve-without-open path and the shutdown-suppressed path, and — unlike a timeout — it can never fire early on a slow-but-healthy open and drop a legitimate `vault_open_ready`. It also adds no timer of its own to clean up.

## How it was proven

Two tests added to `apps/desktop/src/main/index.phase2.test.ts`, one per no-`isOpen` path (rejected auto-open, resolved-without-opening). The suite's `onVaultStatusChanged` mock keeps a real add/remove listener array, so the assertion is on the actual subscription set, not on a spy call count. The first test also fires the surviving listener and asserts it is the window-resize one, so a fix that unsubscribed the wrong listener would not pass.

- Source fix stashed, tests kept: **2 failed | 59 passed (61)** — `AssertionError: expected [ [Function], [Function] ] to have a length of 1 but got 2`
- Fix restored: **61 passed (61)**

## Verification

```
apps/desktop $ vitest run --config config/vitest.config.ts --project main src/main/index.phase2.test.ts
  Test Files  1 passed (1)
       Tests  61 passed (61)

apps/desktop $ tsc --noEmit -p tsconfig.node.json --composite false
  exit 0, no output

$ eslint apps/desktop/src/main/index.ts apps/desktop/src/main/index.phase2.test.ts
  0 errors (index.phase2.test.ts is covered by the repo's test-file ignore pattern)

$ git diff --check
  clean
```

`typecheck:web` not run — no renderer files touched. `docs:impact --base origin/main --strict` reports `missing-docs` for `apps/desktop/src/main/index.ts`; there is no user-facing behavior to document (internal listener lifetime only), matching the rest of the merged perf PRs in this epic.

## Backward compatibility

No schema, IPC contract, settings, sync or vault-format change — main-process listener lifetime only, so every existing install is unaffected.
