### PR TITLE
perf(ipc): cap and sweep the IPC error-throttle map

### DIFF
--- a/apps/desktop/src/main/ipc/validate.test.ts
+++ b/apps/desktop/src/main/ipc/validate.test.ts
@@ -21,7 +21,7 @@ vi.mock('../telemetry/diagnostics', () => ({
 import { getDatabase } from '../database'
 import { trackMainError } from '../telemetry/diagnostics'
 import { markExpectedCondition } from '../telemetry/expected-conditions'
-import { withErrorHandler, withDb } from './validate'
+import { withErrorHandler, withDb, ipcErrorThrottleKeyCount } from './validate'
 
 const mockGetDatabase = vi.mocked(getDatabase)
 const mockTrackMainError = vi.mocked(trackMainError)
@@ -390,6 +390,52 @@ describe('IPC error telemetry', () => {
     expect(mockTrackMainError).toHaveBeenCalledWith('ipc', 'mask probe', genuine)
     // #and the suppressed error never reached telemetry at all
     expect(mockTrackMainError).not.toHaveBeenCalledWith('ipc', 'mask probe', expected)
+  })
+
+  it('bounds the throttle map when distinct codes burst inside one window', async () => {
+    // #given a handler whose errors carry a code we never anticipated — the
+    // throttle Map grew one entry per `action:errorCode` with no cap, so an
+    // error loop producing novel codes retained them for the process lifetime
+    vi.useFakeTimers()
+    try {
+      const handler = withErrorHandler(async (name: string) => {
+        throw namedError(name)
+      }, 'cap probe')
+
+      // #when 1200 distinct codes arrive without the window ever elapsing
+      for (let i = 0; i < 1200; i++) {
+        await handler(`CapProbe${i}Error`)
+      }
+
+      // #then the map never exceeds the cap
+      expect(ipcErrorThrottleKeyCount()).toBeLessThanOrEqual(1000)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('sweeps keys whose throttle window has elapsed', async () => {
+    // #given a full map of keys that have all aged out
+    vi.useFakeTimers()
+    try {
+      const handler = withErrorHandler(async (name: string) => {
+        throw namedError(name)
+      }, 'sweep probe')
+
+      vi.advanceTimersByTime(61_000)
+      for (let i = 0; i < 1000; i++) {
+        await handler(`SweepProbe${i}Error`)
+      }
+      vi.advanceTimersByTime(61_000)
+
+      // #when one more error crosses the cap
+      await handler('SweepTriggerError')
+
+      // #then every expired key is released, leaving only the live one
+      expect(ipcErrorThrottleKeyCount()).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('separates typed codes from the same handler within one window', async () => {

--- a/apps/desktop/src/main/ipc/validate.ts
+++ b/apps/desktop/src/main/ipc/validate.ts
@@ -14,7 +14,32 @@ const ipcLog = createLogger('IPC')
 // masked a genuine different "Error" from another handler for a whole window.
 // Keying by action + errorCode keeps the loop protection per failure mode.
 const ERROR_TRACK_THROTTLE_MS = 60_000
+// The key alphabet is finite in practice (handler names × error codes), but
+// `toErrorCode` adopts an error's own `.code`/`.telemetryCode`, so a third-party
+// or errno-suffixed code we never anticipated would grow this Map for the life
+// of the process. Same cap as telemetry/throttle.ts.
+const MAX_TRACKED_ERROR_KEYS = 1000
 const lastTrackedByCode = new Map<string, number>()
+
+const sweepTrackedErrorKeys = (now: number): void => {
+  if (lastTrackedByCode.size <= MAX_TRACKED_ERROR_KEYS) return
+  for (const [key, trackedAt] of lastTrackedByCode) {
+    if (now - trackedAt >= ERROR_TRACK_THROTTLE_MS) lastTrackedByCode.delete(key)
+  }
+  // A burst of more than MAX distinct codes inside a single window leaves
+  // nothing expired to sweep, so the oldest-inserted keys are dropped to keep
+  // the bound hard. Dropping a key only forfeits its throttle, never an event.
+  for (const key of lastTrackedByCode.keys()) {
+    if (lastTrackedByCode.size <= MAX_TRACKED_ERROR_KEYS) break
+    lastTrackedByCode.delete(key)
+  }
+}
+
+/**
+ * Number of live throttle keys. Exported so the memory bound is directly
+ * assertable in tests; production code never reads it.
+ */
+export const ipcErrorThrottleKeyCount = (): number => lastTrackedByCode.size
 
 const trackIpcError = (action: string, error: unknown): void => {
   try {
@@ -28,6 +53,7 @@ const trackIpcError = (action: string, error: unknown): void => {
     const last = lastTrackedByCode.get(code)
     if (last !== undefined && now - last < ERROR_TRACK_THROTTLE_MS) return
     lastTrackedByCode.set(code, now)
+    sweepTrackedErrorKeys(now)
     // Only the action key and error name/stack leave the process; the envelope
     // `error` message may contain note-derived text and must never be sent.
     trackMainError('ipc', action, error)

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -532,6 +532,21 @@ line is stripped — so a crash's location shows up as, for example, `TypeError`
 files); any home-directory prefix (`/Users/<name>`, `C:\Users\<name>`) is rewritten to `~`, and
 emails, UUIDs, JWTs, and bearer tokens are scrubbed from anything that ships.
 
+### IPC Error Throttling
+
+Every IPC envelope error becomes a telemetry event, so a handler stuck in a failure loop could
+flood the queue. `trackIpcError` (`main/ipc/validate.ts`) therefore emits at most one event per
+`action:errorCode` per 60-second window, in-memory and reset on restart. The key includes the
+action because keying on the error name alone let one handler's benign recurring `Error` mask a
+genuine `Error` from an unrelated handler for the whole window. An expected condition (Ollama not
+running, an abandoned OAuth flow) is skipped before the key is claimed, for the same reason —
+otherwise the suppressed error would keep refreshing a key it never reports on.
+
+That key set is bounded to 1000 entries. Once past the cap, keys whose window has elapsed are
+swept; if a burst of previously unseen codes fills the map inside a single window with nothing to
+expire, the oldest-inserted keys are dropped instead. Dropping a key only forfeits its throttle —
+the next error for it is reported rather than lost.
+
 ### Vault File Errors
 
 A class name alone is often too coarse to act on: every failed note save reported `NoteError`,


### PR DESCRIPTION
Closes #1091. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/ipc/validate.ts:17,30` (pre-change) — `lastTrackedByCode` gained one entry per `${action}:${errorCode}` and never released any of them:

```ts
const ERROR_TRACK_THROTTLE_MS = 60_000
const lastTrackedByCode = new Map<string, number>()
// ...
lastTrackedByCode.set(code, now)   // no cap, no sweep — entries live for the process lifetime
```

Every IPC envelope error routes through here (`withErrorHandler`, `withDb`, `createValidatedHandler`, `createHandler`), so the map is on the hot error path for the whole main process. It was the only throttle map in the codebase with no bound — `main/telemetry/throttle.ts` already caps at `MAX_TRACKED_KEYS = 1000` and sweeps.

The issue text calls the key space "bounded in practice by a finite code alphabet". That is only half true. The `action` half is bounded by source (handler names / literal fallbacks), but the `errorCode` half is not ours to bound: `toErrorCode` (`packages/contracts/src/telemetry-api.ts`) deliberately **adopts the error's own** `telemetryCode`/`.code`, walking the `cause`/`AggregateError.errors` chain, and accepts anything matching `/^[A-Za-z][A-Za-z0-9_.:-]{0,63}$/`. Composite codes like `NOTE_WRITE_FAILED:EBUSY` are already the product of two axes, and a third-party or driver error carrying an unanticipated `.code` is admitted verbatim. So the growth is slow and small rather than impossible — which is exactly why this is LOW, not why it should stay unbounded.

## What changed

`main/ipc/validate.ts` only:

- `MAX_TRACKED_ERROR_KEYS = 1000`, matching `telemetry/throttle.ts`.
- `sweepTrackedErrorKeys(now)` runs after an insert, and only when the map is over the cap (so the steady state stays O(1) per error, same shape as `shouldEmitThrottled`).
- Sweep first drops keys whose 60s window has elapsed. If a burst of distinct novel codes fills the map inside one window and nothing is expired, the oldest-inserted keys are dropped so the bound is hard rather than advisory. Dropping a key only forfeits its throttle — the next error for that key is **reported**, never lost.
- `ipcErrorThrottleKeyCount()` exported so the bound is directly assertable (mirrors `resetTelemetryThrottle`'s test-only role); production code never reads it.

Deliberately **not** done:

- **Did not reuse `shouldEmitThrottled` from `telemetry/throttle.ts`.** It sweeps using the *calling* invocation's `windowMs`. Routing the 60s IPC throttle through that shared map would evict 5-minute-window entries (`note_updated`, `journal_updated`) at 60s, re-emitting throttled product events early. A separate local map keeps both windows correct.
- Did not change the throttle window, the key shape, or the expected-condition skip — all deliberate prior fixes with tests covering them.

## How it was proven

Two new tests in `main/ipc/validate.test.ts`. Proven by removing only the `sweepTrackedErrorKeys(now)` call (the getter export kept so the import still resolves) and re-running:

**Before the fix — `Tests 2 failed | 21 passed (23)`**

```
× bounds the throttle map when distinct codes burst inside one window
  → expected 1213 to be less than or equal to 1000
× sweeps keys whose throttle window has elapsed
  → expected 2214 to be 1
```

**After the fix — `Tests 23 passed (23)`**

The two numbers are the real map size: 1213 and 2214 retained keys become 1000 and 1.

## Verification

```
pnpm exec vitest run --config config/vitest.config.ts --project main src/main/ipc/validate.test.ts
  → Test Files 1 passed (1) | Tests 23 passed (23)

pnpm --filter @memry/desktop typecheck:node
  → clean, no output

pnpm exec eslint apps/desktop/src/main/ipc/validate.ts apps/desktop/src/main/ipc/validate.test.ts
  → 0 errors (validate.test.ts reported as ignored by the flat config — pre-existing)

git diff --check
  → clean

pnpm docs:impact --base origin/main --strict
  → docs impact: covered against origin/main

pnpm docs:build
  → build complete in 6.42s
```

Docs: `apps/docs/src/architecture/observability.md` gains an **IPC Error Throttling** subsection. The 60s-per-`action:errorCode` window was undocumented; the section now records it along with the new bound.

## Backward compatibility

None affected — a process-local in-memory Map with no persistence, no schema, no IPC contract, and no sync/settings shape; behavior for every non-pathological error stream is byte-identical to before.
