### PR TITLE
perf(sync): back off idle wakeup sources in the network monitor and pull tick

### DIFF
--- a/apps/desktop/src/main/sync/engine.test.ts
+++ b/apps/desktop/src/main/sync/engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { SyncEngine, SYNC_LOCK_STALE_MS } from './engine'
+import { SyncEngine, SYNC_LOCK_STALE_MS, PERIODIC_PULL_MAX_QUIET_MS } from './engine'
 import type { WebSocketMessage } from './websocket'
 import { createMockDeps, createMockNetwork, setupTestDb } from '@tests/utils/engine-mocks'
 
@@ -53,6 +53,102 @@ describe('SyncEngine', () => {
       // #then — the 60s tick still pulls, so sync self-heals this session
       const callsAfterStart = getSpy.mock.calls.length
       await vi.advanceTimersByTimeAsync(60_000)
+      expect(getSpy.mock.calls.length).toBeGreaterThan(callsAfterStart)
+
+      await engine.stop()
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    })
+  })
+
+  describe('#given a socket that has not dropped #when the 60s pull tick fires', () => {
+    // deps.ws is an EventEmitter stand-in without the real getter.
+    const withGeneration = (
+      deps: ReturnType<typeof createMockDeps>,
+      read: () => number
+    ): ReturnType<typeof createMockDeps> => {
+      Object.defineProperty(deps.ws, 'connectionGeneration', {
+        configurable: true,
+        get: read
+      })
+      return deps
+    }
+
+    const startArmedEngine = async (
+      getSpy: { mock: { calls: unknown[] } },
+      read: () => number
+    ): Promise<{ engine: SyncEngine; callsAfterStart: number }> => {
+      const deps = withGeneration(createMockDeps(getDb()), read)
+      const engine = new SyncEngine(deps)
+      // fullSync is exercised elsewhere; here it only has to leave the tick armed.
+      vi.spyOn(engine, 'fullSync').mockResolvedValue()
+      await engine.start()
+      return { engine, callsAfterStart: getSpy.mock.calls.length }
+    }
+
+    const mockPullTransport = async (): Promise<ReturnType<typeof vi.spyOn>> =>
+      vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
+        items: [],
+        deleted: [],
+        hasMore: false,
+        nextCursor: 0
+      })
+
+    it('#then it issues no request, and pulls again once the socket generation moves', async () => {
+      vi.useFakeTimers()
+      const getSpy = await mockPullTransport()
+      let generation = 1
+      const { engine, callsAfterStart } = await startArmedEngine(getSpy, () => generation)
+
+      // #when — two ticks on the same, still-connected socket
+      await vi.advanceTimersByTimeAsync(60_000)
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      // #then — nothing could have been missed, so nothing is fetched
+      expect(getSpy.mock.calls.length).toBe(callsAfterStart)
+
+      // #when — the socket dropped and came back between ticks
+      generation += 1
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      // #then — broadcasts may have been missed, so the tick pulls again
+      expect(getSpy.mock.calls.length).toBeGreaterThan(callsAfterStart)
+
+      await engine.stop()
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    })
+
+    it('#then the quiet floor still forces a self-heal pull', async () => {
+      // A server that silently stops broadcasting is indistinguishable from a
+      // quiet vault, so the tick must not go quiet forever.
+      vi.useFakeTimers()
+      const getSpy = await mockPullTransport()
+      const { engine, callsAfterStart } = await startArmedEngine(getSpy, () => 1)
+
+      await vi.advanceTimersByTimeAsync(PERIODIC_PULL_MAX_QUIET_MS - 60_000)
+      expect(getSpy.mock.calls.length).toBe(callsAfterStart)
+
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(getSpy.mock.calls.length).toBeGreaterThan(callsAfterStart)
+
+      await engine.stop()
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    })
+
+    it('#then a disconnected socket keeps the every-tick pull', async () => {
+      vi.useFakeTimers()
+      const getSpy = await mockPullTransport()
+      const deps = withGeneration(createMockDeps(getDb()), () => 1)
+      const engine = new SyncEngine(deps)
+      vi.spyOn(engine, 'fullSync').mockResolvedValue()
+      await engine.start()
+      deps.ws.disconnect()
+      const callsAfterStart = getSpy.mock.calls.length
+
+      await vi.advanceTimersByTimeAsync(60_000)
+
       expect(getSpy.mock.calls.length).toBeGreaterThan(callsAfterStart)
 
       await engine.stop()

--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -69,6 +69,26 @@ export const SYNC_LOCK_STALE_MS = 15 * 60 * 1000
 // an outage, never a body that is not pulled at all.
 export const INACTIVE_CRDT_SWEEP_MIN_INTERVAL_MS = 5 * 60 * 1000
 
+// Floor between two pulls issued by the 60s tick while the socket has been
+// continuously up.
+//
+// The tick's pull exists to heal a `changes_available` broadcast that never
+// arrived. When the same socket is still connected as at the previous tick
+// (`connectionGeneration` unchanged, `connected` true) no broadcast could have
+// been missed: the socket pings every 25s and terminates itself after 31s of
+// silence, so a half-open connection reports disconnected long before a tick
+// would trust it. The pull is then a guaranteed-empty request, once a minute,
+// per device, for the life of the app — and the same reasoning already decides
+// the reconnect CRDT sweep in full-sync-runner.ts.
+//
+// Throttled rather than dropped, because one failure mode is not observable
+// from here: a server that stops broadcasting looks exactly like a quiet vault.
+// A floor keeps that self-heal — along with the deferred-apply retries and
+// orphan repair that ride on the same pull — alive at a fifth of the cost, with
+// a bounded worst case. Any drop between ticks bumps the generation and
+// restores the every-tick pull, and the reconnect itself already pulls.
+export const PERIODIC_PULL_MAX_QUIET_MS = 5 * 60 * 1000
+
 const classifySyncErrorCode = (error: unknown): string => {
   try {
     const info = classifyError(error)
@@ -98,6 +118,11 @@ export class SyncEngine extends EventEmitter {
   // a timestamp from a previous process says nothing about this socket.
   private lastInactiveCrdtSweepAt = 0
   private inactiveCrdtSweepOwed = false
+  // The socket generation the previous pull tick observed, and when the tick
+  // last actually pulled. Both are instance state re-armed with the interval —
+  // see armPeriodicPull.
+  private lastPullTickWsGeneration: number | null = null
+  private lastPullTickPullAt = 0
 
   constructor(deps: SyncEngineDeps, options?: Partial<SyncEngineOptions>) {
     super()
@@ -548,11 +573,39 @@ export class SyncEngine extends EventEmitter {
 
   private armPeriodicPull(): void {
     if (this.pullInterval) return
-    this.pullInterval = setInterval(() => {
-      this.recoverStaleSyncLock()
-      this.payOwedInactiveCrdtSweep()
-      this.pullCoordinator.periodicPull()
-    }, 60_000)
+    // Arming always follows a pull that just ran or is about to (start(),
+    // network restored), so the floor starts now rather than firing on the
+    // first tick.
+    this.lastPullTickWsGeneration = this.ctx.deps.ws?.connectionGeneration ?? null
+    this.lastPullTickPullAt = Date.now()
+    this.pullInterval = setInterval(() => this.runPullTick(), 60_000)
+  }
+
+  private runPullTick(): void {
+    // Both of these are in-process watchdogs with no network cost, and both
+    // must keep running every tick regardless of what the socket is doing.
+    this.recoverStaleSyncLock()
+    this.payOwedInactiveCrdtSweep()
+
+    const ws = this.ctx.deps.ws
+    const generation = ws?.connectionGeneration ?? null
+    // Same socket as the previous tick and still up: nothing could have been
+    // missed in between. A drop and reconnect bumps the generation; a drop
+    // without one leaves `connected` false. See PERIODIC_PULL_MAX_QUIET_MS.
+    const sameSocketSinceLastTick =
+      generation !== null && generation === this.lastPullTickWsGeneration && ws?.connected === true
+    this.lastPullTickWsGeneration = generation
+
+    if (
+      sameSocketSinceLastTick &&
+      Date.now() - this.lastPullTickPullAt < PERIODIC_PULL_MAX_QUIET_MS
+    ) {
+      log.debug('Periodic pull skipped: socket continuously connected since last tick')
+      return
+    }
+
+    this.lastPullTickPullAt = Date.now()
+    this.pullCoordinator.periodicPull()
   }
 
   // Last-resort watchdog. Request timeouts make a hung HTTP call settle on its

--- a/apps/desktop/src/main/sync/network.test.ts
+++ b/apps/desktop/src/main/sync/network.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { NetworkMonitor, NetworkMonitorDeps } from './network'
+import {
+  NetworkMonitor,
+  NetworkMonitorDeps,
+  OFFLINE_POLL_INTERVAL_MS,
+  ONLINE_POLL_INTERVAL_MS
+} from './network'
 
 interface MockDeps extends NetworkMonitorDeps {
   triggerResume: () => void
@@ -60,7 +65,7 @@ describe('NetworkMonitor', () => {
       monitor.start()
 
       deps.setOnline(false)
-      vi.advanceTimersByTime(5000)
+      vi.advanceTimersByTime(ONLINE_POLL_INTERVAL_MS)
 
       expect(handler).not.toHaveBeenCalled()
       expect(monitor.online).toBe(true)
@@ -90,7 +95,7 @@ describe('NetworkMonitor', () => {
       monitor.start()
 
       deps.setOnline(false)
-      vi.advanceTimersByTime(5000)
+      vi.advanceTimersByTime(ONLINE_POLL_INTERVAL_MS)
 
       monitor.stop()
 
@@ -122,7 +127,7 @@ describe('NetworkMonitor', () => {
       monitor.start()
 
       deps.setOnline(true)
-      vi.advanceTimersByTime(5000)
+      vi.advanceTimersByTime(OFFLINE_POLL_INTERVAL_MS)
 
       expect(handler).not.toHaveBeenCalled()
 
@@ -173,7 +178,7 @@ describe('NetworkMonitor', () => {
       monitor.start()
 
       deps.setOnline(false)
-      vi.advanceTimersByTime(5000)
+      vi.advanceTimersByTime(ONLINE_POLL_INTERVAL_MS)
 
       deps.setOnline(true)
       deps.triggerResume()
@@ -190,18 +195,90 @@ describe('NetworkMonitor', () => {
       monitor.start()
 
       deps.setOnline(false)
-      vi.advanceTimersByTime(5000)
+      vi.advanceTimersByTime(ONLINE_POLL_INTERVAL_MS)
 
       deps.setOnline(true)
       vi.advanceTimersByTime(2000)
 
       deps.setOnline(false)
-      vi.advanceTimersByTime(5000)
+      vi.advanceTimersByTime(OFFLINE_POLL_INTERVAL_MS)
 
       vi.advanceTimersByTime(200)
 
       expect(handler).toHaveBeenCalledOnce()
       expect(handler).toHaveBeenCalledWith({ online: false })
+    })
+  })
+
+  describe('#given the adaptive poll cadence', () => {
+    it('#when online and idle #then does not wake at the offline cadence', () => {
+      deps = createMockDeps(true)
+      monitor = new NetworkMonitor(200, deps)
+      const handler = vi.fn()
+      monitor.on('status-changed', handler)
+      monitor.start()
+
+      deps.setOnline(false)
+      // A full offline-cadence period plus the debounce: nothing has polled, so
+      // the drop is not seen yet. This is the wakeup the app no longer pays
+      // twelve times a minute while it just sits there connected.
+      vi.advanceTimersByTime(OFFLINE_POLL_INTERVAL_MS + 200)
+      expect(handler).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(ONLINE_POLL_INTERVAL_MS - OFFLINE_POLL_INTERVAL_MS + 200)
+      expect(handler).toHaveBeenCalledOnce()
+      expect(handler).toHaveBeenCalledWith({ online: false })
+    })
+
+    it('#when offline #then a returning network is still seen at the fast cadence', () => {
+      deps = createMockDeps(false)
+      monitor = new NetworkMonitor(200, deps)
+      const handler = vi.fn()
+      monitor.on('status-changed', handler)
+      monitor.start()
+
+      deps.setOnline(true)
+      vi.advanceTimersByTime(OFFLINE_POLL_INTERVAL_MS + 200)
+
+      expect(handler).toHaveBeenCalledOnce()
+      expect(handler).toHaveBeenCalledWith({ online: true })
+    })
+
+    it('#when it drops offline while running #then it switches to the fast cadence at once', () => {
+      // The reconnect guarantee: however long the slow cadence took to notice
+      // the drop, the poll that sees the network return is 5s away, not 30s.
+      deps = createMockDeps(true)
+      monitor = new NetworkMonitor(200, deps)
+      const handler = vi.fn()
+      monitor.on('status-changed', handler)
+      monitor.start()
+
+      deps.setOnline(false)
+      vi.advanceTimersByTime(ONLINE_POLL_INTERVAL_MS + 200)
+      expect(handler).toHaveBeenCalledWith({ online: false })
+
+      deps.setOnline(true)
+      vi.advanceTimersByTime(OFFLINE_POLL_INTERVAL_MS + 200)
+
+      expect(handler).toHaveBeenNthCalledWith(2, { online: true })
+      expect(monitor.online).toBe(true)
+    })
+
+    it('#when suspended and resumed #then the wake is polled immediately', () => {
+      deps = createMockDeps(true)
+      monitor = new NetworkMonitor(200, deps)
+      const handler = vi.fn()
+      monitor.on('status-changed', handler)
+      monitor.start()
+
+      deps.triggerSuspend()
+      expect(handler).toHaveBeenCalledWith({ online: false })
+
+      // No timer advance at all: resume polls rather than waiting for a tick.
+      deps.triggerResume()
+      vi.advanceTimersByTime(200)
+
+      expect(handler).toHaveBeenNthCalledWith(2, { online: true })
     })
   })
 

--- a/apps/desktop/src/main/sync/network.ts
+++ b/apps/desktop/src/main/sync/network.ts
@@ -20,7 +20,30 @@ function createElectronDeps(): NetworkMonitorDeps {
   }
 }
 
-const POLL_INTERVAL_MS = 5000
+// Electron exposes no main-process event for `net.online` — only powerMonitor
+// resume/suspend, which are already wired below — so the status has to be
+// polled. The read itself is a cheap in-process property; the cost is purely
+// the timer wakeup, and a wakeup every 5s for the lifetime of the app is what
+// keeps the main process out of deep idle / App Nap on an otherwise idle
+// machine.
+//
+// The two directions are not worth the same, so they do not poll at the same
+// rate:
+//
+// - Offline -> online is latency-critical. It is what re-arms the WebSocket,
+//   the periodic pull and the CRDT queue, so a returning network must be seen
+//   fast. It stays at 5s, and powerMonitor 'resume' additionally polls at once,
+//   so a machine waking with the network back is picked up immediately rather
+//   than at the next tick.
+// - Online -> offline is not. A lost network is already surfaced by the request
+//   that fails and by the WebSocket heartbeat (25s ping / 31s terminate); all
+//   this transition adds is the offline status and the eager teardown. Seeing
+//   it up to 30s later costs nothing the retry paths do not already cover.
+//
+// Because 'suspend' applies offline immediately, a suspended machine is on the
+// 5s cadence before it sleeps — the slow cadence never applies to a wake.
+export const OFFLINE_POLL_INTERVAL_MS = 5000
+export const ONLINE_POLL_INTERVAL_MS = 30_000
 const DEFAULT_DEBOUNCE_MS = 2000
 // 'status-changed' is the only event, and it has three steady-state
 // subscribers: the SyncEngine (attached in start(), removed in stop()), the
@@ -32,7 +55,8 @@ const MAX_NETWORK_MONITOR_LISTENERS = 10
 export class NetworkMonitor extends EventEmitter {
   private _online: boolean
   private onlineOverrideForTests: boolean | null = null
-  private pollTimer: ReturnType<typeof setInterval> | null = null
+  private pollTimer: ReturnType<typeof setTimeout> | null = null
+  private polling = false
   private debounceTimer: ReturnType<typeof setTimeout> | null = null
   private readonly deps: NetworkMonitorDeps
   private readonly debounceMs: number
@@ -61,7 +85,8 @@ export class NetworkMonitor extends EventEmitter {
   }
 
   start(): void {
-    this.pollTimer = setInterval(() => this.poll(), POLL_INTERVAL_MS)
+    this.polling = true
+    this.schedulePoll()
 
     this.resumeHandler = () => this.poll()
     this.suspendHandler = () => this.applyStatus(false)
@@ -71,8 +96,9 @@ export class NetworkMonitor extends EventEmitter {
   }
 
   stop(): void {
+    this.polling = false
     if (this.pollTimer) {
-      clearInterval(this.pollTimer)
+      clearTimeout(this.pollTimer)
       this.pollTimer = null
     }
     if (this.debounceTimer) {
@@ -87,6 +113,22 @@ export class NetworkMonitor extends EventEmitter {
       this.deps.offSuspend(this.suspendHandler)
       this.suspendHandler = null
     }
+  }
+
+  /**
+   * Re-arms the poll at the cadence for the status we currently believe. A
+   * self-rescheduling timeout rather than an interval so a status change can
+   * switch cadence at once instead of after one tick at the old rate.
+   */
+  private schedulePoll(): void {
+    if (!this.polling) return
+    if (this.pollTimer) clearTimeout(this.pollTimer)
+    const delay = this._online ? ONLINE_POLL_INTERVAL_MS : OFFLINE_POLL_INTERVAL_MS
+    this.pollTimer = setTimeout(() => {
+      this.pollTimer = null
+      this.poll()
+      this.schedulePoll()
+    }, delay)
   }
 
   private poll(): void {
@@ -114,6 +156,9 @@ export class NetworkMonitor extends EventEmitter {
   private applyStatus(status: boolean): void {
     if (status === this._online) return
     this._online = status
+    // Going offline must drop us onto the fast cadence immediately, so the
+    // network coming back is still seen within OFFLINE_POLL_INTERVAL_MS.
+    this.schedulePoll()
     this.emit('status-changed', { online: status })
   }
 

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -315,10 +315,26 @@ terminal status.
 
 ## Pull Scheduling and Hang Recovery
 
-A periodic pull fires every 60 seconds; WebSocket `changes_available` and `connected` messages
+A periodic tick fires every 60 seconds; WebSocket `changes_available` and `connected` messages
 schedule additional pulls in between. The interval is armed before the first full sync, and a
 failure in that first sync is logged rather than propagated, so one transient error at startup
 cannot leave a session without a pull cycle.
+
+The tick does not always pull. Its pull exists to heal a `changes_available` broadcast that never
+arrived, so when the socket has been continuously connected since the previous tick — same
+`connectionGeneration`, still `connected` — the request is skipped: the socket pings every 25s and
+terminates itself after 31s of silence, so a half-open connection reports disconnected before a
+tick would trust it. Any drop between ticks bumps the generation and restores the every-tick pull,
+and a reconnect pulls on its own. A 5-minute floor caps the skipping, because a server that stops
+broadcasting is indistinguishable from a quiet vault from the client side. The stale-lock watchdog
+and the owed CRDT sweep run on every tick regardless.
+
+Network status feeds the same scheduling. Electron exposes no main-process event for `net.online`,
+so it is polled — every 5 seconds while offline, every 30 seconds while online, dropping back to
+the fast cadence the moment the status goes offline. A returning network is therefore always
+detected within ~5 seconds (plus a 2-second debounce), and `powerMonitor` `resume` polls
+immediately rather than waiting for a tick; `suspend` applies offline right away, so a machine
+waking from sleep is already on the fast cadence.
 
 Three guards keep a wedged sync from lasting until restart. Every sync HTTP request carries a
 60-second abort timeout, so a black-holed socket (suspend/resume, NAT teardown) surfaces as a


### PR DESCRIPTION
Closes #1094. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

Two permanent wakeup sources ran at full rate on a machine that was doing nothing.

**`apps/desktop/src/main/sync/network.ts:64`** — `net.online` polled every 5s for the life of the app, whatever the status:

```ts
start(): void {
  this.pollTimer = setInterval(() => this.poll(), POLL_INTERVAL_MS) // 5000
```

720 timer wakeups an hour, forever, to re-read a property that almost never changes.

**`apps/desktop/src/main/sync/engine.ts:549-556`** — the 60s tick pulled unconditionally:

```ts
this.pullInterval = setInterval(() => {
  this.recoverStaleSyncLock()
  this.payOwedInactiveCrdtSweep()
  this.pullCoordinator.periodicPull()
}, 60_000)
```

`periodicPull()` only skips when already syncing/paused/offline — never because the pull is provably pointless. On a healthy socket that is 60 empty `/sync/changes` round trips an hour, per device, forever, each one taking the sync lock and a vault-key derivation.

## What changed

**Adaptive network poll cadence.** `OFFLINE_POLL_INTERVAL_MS = 5000` (unchanged), `ONLINE_POLL_INTERVAL_MS = 30_000`. `setInterval` became a self-rescheduling `setTimeout` so a status change switches cadence immediately instead of after one tick at the old rate; `applyStatus` re-arms.

**Pull tick skips a provably empty pull.** When the socket has been continuously connected since the previous tick — same `connectionGeneration`, still `connected` — no broadcast could have been missed (25s ping / 31s heartbeat terminate, so a half-open socket reports disconnected long before a tick trusts it). This is the exact signal `engine/full-sync-runner.ts:96-113` already uses to decide the reconnect CRDT sweep.

### Returning network is still detected promptly — this is the safety-critical part

The backoff is deliberately one-directional. Nothing on the reconnect path got slower:

- **Offline stays at 5s.** The latency-critical direction is offline → online, because that is what re-arms the WebSocket, the pull tick and the CRDT queue. It polls at the same 5s as before, so a returning network is seen within 5s + the existing 2s debounce, exactly as today.
- **Going offline flips the cadence instantly.** `applyStatus` calls `schedulePoll()`, so the moment the status becomes offline the next poll is 5s away, not 30s. There is no window where we are offline and polling slowly.
- **Machine wake is unaffected.** `powerMonitor` `suspend` applies offline immediately (already on the 5s cadence before sleeping) and `resume` calls `poll()` directly with no timer wait at all. Both are covered by tests.
- **Only network *loss* can be seen later** (≤30s instead of ≤5s). That transition adds nothing the failing request and the 31s WebSocket heartbeat do not already cover — it only marks the status offline and tears the socket down eagerly.
- **A drop shorter than the slow poll is invisible on purpose** — nothing was torn down, and the WebSocket's own reconnect brings it back, which pulls via `handleWsConnected`.

### Deliberately not done

- **Not event-driven.** The issue suggests "prefer Electron's `net.online` events". Electron exposes no main-process event for `net.online` — only `powerMonitor` resume/suspend, which this file already wires. The poll has to stay; the fix is its rate.
- **Pull ticks are not skipped indefinitely.** The issue suggests "skip pull ticks while the WS is connected and quiet". Unbounded, that removes the self-heal for a server that stops broadcasting — indistinguishable from a quiet vault from the client. Instead `PERIODIC_PULL_MAX_QUIET_MS = 5 * 60 * 1000` forces a pull at least every 5 minutes: an 80% cut with a bounded worst case, and it keeps the deferred-apply retries and orphan repair that ride on the same pull alive.
- **`recoverStaleSyncLock()` and `payOwedInactiveCrdtSweep()` still run every 60s.** They are in-process watchdogs with no network cost, and the stale-lock watchdog must not be gated on socket health.
- **No new hook on WebSocket `disconnected`.** Considered (it would cut the offline-detection lag back to zero) and rejected as extra lifecycle surface for a transition that is not on the reconnect path.

## How it was proven

Both fixes were mutation-tested: the source was reverted to the pre-fix behaviour (`schedulePoll` back to a single 5s delay; the tick's skip branch forced off) with the tests unchanged.

```
Before fix:  Test Files  2 failed (2)   Tests  7 failed | 45 passed (52)
After fix:   Test Files  2 passed (2)   Tests  52 passed (52)
```

The 7 failures were the real assertions, not import errors:

```
× network.test.ts > #given the adaptive poll cadence > #when online and idle #then does not wake at the offline cadence
  → expected "vi.fn()" to not be called at all, but actually been called 1 times
× engine.test.ts > #given a socket that has not dropped ... #then it issues no request, and pulls again once the socket generation moves
  → expected 3 to be 1
× engine.test.ts > #given a socket that has not dropped ... #then the quiet floor still forces a self-heal pull
  → expected 5 to be 1
```

New tests: 4 in `network.test.ts` (slow cadence while online; returning network still fast while offline; cadence flips back on drop; resume polls with zero timer advance) and 3 in `engine.test.ts` (skip on a continuously-connected socket + pull again when the generation moves; the 5-minute floor still fires; a disconnected socket keeps the every-tick pull). Four pre-existing `network.test.ts` cases were retimed to the constants because the online cadence genuinely changed.

## Verification

```
pnpm --filter @memry/desktop typecheck:node                    clean
pnpm exec eslint <4 changed files>                             clean (0 errors, 0 warnings)
pnpm exec vitest --project main src/main/sync/network.test.ts src/main/sync/engine.test.ts
                                                               52 passed (52)
pnpm exec vitest --project main src/main/sync/
                                                               140 files, 1792 passed | 1 expected fail | 3 skipped
pnpm docs:impact --base origin/main --strict                   covered
pnpm docs:build                                                build complete in 6.19s
git diff --check                                               clean
```

## Backward compatibility

Timing-only, main-process-local: no schema, IPC contract, sync protocol, vault format or settings shape is touched, so old and new builds interoperate unchanged — a device on this build syncs identically with one that is not.
