### PR TITLE
perf(hooks): cancel renderer timers and rAF handles on unmount

### DIFF
--- a/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.tsx
@@ -15,6 +15,7 @@ import { FileText, Link as LinkIcon, Loader2, Mic, Paperclip, Send } from '@/lib
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts-base'
+import { useTrackedTimeout } from '@/hooks/use-tracked-timeout'
 import { isMac } from '@/lib/shortcut-registry'
 import { isLikelyUrl } from '@/lib/capture-intent'
 import { hasSpecialSyntax, parseQuickAdd } from '@/lib/quick-add-parser'
@@ -143,6 +144,8 @@ export const CaptureBar = ({
   const recorderDismissTimerRef = useRef<number | null>(null)
   // Guards the attach button's pointerdown/click pair (see the button below).
   const attachFiredByPointerRef = useRef(false)
+  // The delayed blur below must not fire after the bar is gone.
+  const scheduleTimeout = useTrackedTimeout()
 
   const disabled = isBusy
   const trimmed = value.trim()
@@ -402,7 +405,7 @@ export const CaptureBar = ({
               }}
               onFocus={() => setIsFocused(true)}
               // Delayed so clicks on the dropdown and the detail hint land first.
-              onBlur={() => window.setTimeout(() => setIsFocused(false), 150)}
+              onBlur={() => scheduleTimeout(() => setIsFocused(false), 150)}
               onKeyDown={handleKeyDown}
               placeholder={placeholder}
               disabled={disabled}

--- a/apps/desktop/src/renderer/src/components/viewers/audio-player.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/audio-player.tsx
@@ -21,6 +21,7 @@ import { Button } from '@/components/ui/button'
 import { Slider } from '@/components/ui/slider'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
+import { useTrackedTimeout } from '@/hooks/use-tracked-timeout'
 
 // ============================================================================
 // Types
@@ -70,6 +71,8 @@ export function AudioPlayer({
   const [error, setError] = useState(false)
   const [copied, setCopied] = useState(false)
   const transcript = transcription?.trim()
+  // The "copied" badge reset must not outlive the player
+  const scheduleTimeout = useTrackedTimeout()
 
   // Sync audio element with state
   useEffect(() => {
@@ -151,7 +154,7 @@ export function AudioPlayer({
     if (transcript) {
       await navigator.clipboard.writeText(transcript)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      scheduleTimeout(() => setCopied(false), 2000)
     }
   }
 

--- a/apps/desktop/src/renderer/src/contexts/drag-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/drag-context.tsx
@@ -26,6 +26,7 @@ import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 
 import type { SubtaskProgress } from '@/lib/subtask-utils'
 import type { Task } from '@/data/task-model'
+import { useTrackedTimeout } from '@/hooks/use-tracked-timeout'
 
 // ============================================================================
 // TYPES
@@ -334,6 +335,7 @@ export const DragProvider = ({
   onDragCancel: onDragCancelCallback
 }: DragProviderProps): React.JSX.Element => {
   const [dragState, setDragStateInternal] = useState<DragState>(initialDragState)
+  const scheduleTimeout = useTrackedTimeout()
 
   // Sensor configuration
   const sensors = useSensors(
@@ -509,13 +511,16 @@ export const DragProvider = ({
       resetDragState()
 
       if (droppedId && event.over) {
-        setTimeout(() => {
+        scheduleTimeout(() => {
           setDragStateInternal((prev) => ({ ...prev, lastDroppedId: droppedId }))
-          setTimeout(() => setDragStateInternal((prev) => ({ ...prev, lastDroppedId: null })), 1100)
+          scheduleTimeout(
+            () => setDragStateInternal((prev) => ({ ...prev, lastDroppedId: null })),
+            1100
+          )
         }, 200)
       }
     },
-    [dragState, resetDragState, onDragEndCallback]
+    [dragState, resetDragState, onDragEndCallback, scheduleTimeout]
   )
 
   // Handle drag cancel

--- a/apps/desktop/src/renderer/src/hooks/timer-raf-cleanup.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/timer-raf-cleanup.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Unmount cleanup for renderer timers and rAF handles (issue #1089).
+ *
+ * Every case arms a hook's delayed work, unmounts the owner, and then asserts
+ * nothing is left pending. `vi.getTimerCount()` is the load-bearing assertion:
+ * it counts handles the fake clock still owns, so it only reaches zero when the
+ * hook really called `clearTimeout`. A leaked handle also keeps its callback's
+ * closure — and everything that closure captured — alive until it fires, which
+ * is the actual footprint cost these fixes remove.
+ */
+
+import { act, render, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+import { useTrackedTimeout } from './use-tracked-timeout'
+import { useRevealInSidebar } from './use-reveal-in-sidebar'
+import { usePropertySection } from './use-property-section'
+import { useUndoableAction } from './use-undoable-action'
+import { useFocusTrap } from './use-focus-trap'
+import { getAIConnections } from '@/services/ai-connections-service'
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn(), info: vi.fn() })
+}))
+
+vi.mock('@/hooks/use-properties', () => ({
+  useProperties: () => ({
+    properties: [],
+    updateProperty: vi.fn().mockResolvedValue(undefined),
+    addProperty: vi.fn().mockResolvedValue(undefined),
+    removeProperty: vi.fn().mockResolvedValue(undefined),
+    renameProperty: vi.fn().mockResolvedValue(undefined),
+    reorderProperties: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('@/services/inbox-service', () => ({
+  inboxService: {
+    archive: vi.fn().mockResolvedValue({ success: true }),
+    undoArchive: vi.fn().mockResolvedValue({ success: true }),
+    undoFile: vi.fn().mockResolvedValue({ success: true })
+  }
+}))
+
+describe('renderer timer/rAF cleanup on unmount', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  describe('useTrackedTimeout', () => {
+    it('runs the callback and forgets the handle once it fires', () => {
+      const spy = vi.fn()
+      const { result } = renderHook(() => useTrackedTimeout())
+
+      act(() => result.current(spy, 500))
+      expect(vi.getTimerCount()).toBe(1)
+
+      act(() => void vi.advanceTimersByTime(500))
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(vi.getTimerCount()).toBe(0)
+    })
+
+    it('cancels every pending callback when the owner unmounts', () => {
+      const first = vi.fn()
+      const second = vi.fn()
+      const { result, unmount } = renderHook(() => useTrackedTimeout())
+
+      act(() => {
+        result.current(first, 500)
+        result.current(second, 5000)
+      })
+      expect(vi.getTimerCount()).toBe(2)
+
+      unmount()
+      expect(vi.getTimerCount()).toBe(0)
+
+      vi.advanceTimersByTime(10_000)
+      expect(first).not.toHaveBeenCalled()
+      expect(second).not.toHaveBeenCalled()
+    })
+  })
+
+  it('useRevealInSidebar drops the 2s highlight auto-clear', () => {
+    const { result, unmount } = renderHook(() => useRevealInSidebar([]))
+
+    act(() => result.current.setHighlightedItemId('item-1'))
+    expect(vi.getTimerCount()).toBe(1)
+
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('usePropertySection drops the "newly added" highlight timer', async () => {
+    const { result, unmount } = renderHook(() => usePropertySection({ entityId: 'note-1' }))
+
+    await act(async () => {
+      await result.current.handleAddProperty({ name: 'Status note', type: 'text' })
+    })
+    expect(vi.getTimerCount()).toBe(1)
+
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('useUndoableAction drops every open 5s undo window', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { result, unmount } = renderHook(() => useUndoableAction(), { wrapper })
+
+    await act(async () => {
+      await result.current.archiveWithUndo('item-1', 'First')
+      await result.current.fileWithUndo('item-2', 'Second')
+    })
+    expect(vi.getTimerCount()).toBe(2)
+
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('useFocusTrap cancels a queued auto-focus when the trap deactivates first', () => {
+    const frames: Array<() => void> = []
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => frames.push(cb))
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      frames[id - 1] = () => {}
+    })
+
+    try {
+      const Trap = ({ isActive }: { isActive: boolean }) => {
+        const ref = useFocusTrap({ isActive, restoreFocus: false })
+        return (
+          <div ref={ref}>
+            <button type="button">Inside</button>
+          </div>
+        )
+      }
+
+      const outside = document.createElement('button')
+      document.body.append(outside)
+      outside.focus()
+
+      const { rerender, container } = render(<Trap isActive />)
+      const inside = container.querySelector('button')!
+
+      // Trap goes away inside the same frame the auto-focus was queued for.
+      rerender(<Trap isActive={false} />)
+      act(() => frames.forEach((frame) => frame()))
+
+      expect(document.activeElement).not.toBe(inside)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('getAIConnections removes its abort listener once the delay resolves', async () => {
+    const controller = new AbortController()
+    const add = vi.spyOn(controller.signal, 'addEventListener')
+    const remove = vi.spyOn(controller.signal, 'removeEventListener')
+
+    const pending = getAIConnections('x'.repeat(500), controller.signal)
+    expect(add).toHaveBeenCalledWith('abort', expect.any(Function), { once: true })
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+      await pending
+    })
+
+    expect(remove).toHaveBeenCalledWith('abort', expect.any(Function))
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-drag-handlers.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-drag-handlers.test.tsx
@@ -806,6 +806,41 @@ describe('useDragHandlers', () => {
     expect(onUpdateTask).toHaveBeenCalledWith('task-1', { priority: 'high' })
   })
 
+  it('clears the dropped-priority flash timer when the board unmounts', () => {
+    vi.useFakeTimers()
+    try {
+      const project = createProject()
+      const { result, unmount } = renderHook(() =>
+        useDragHandlers({
+          tasks: [createTask({ id: 'task-1', priority: 'low' })],
+          projects: [project],
+          onUpdateTask: vi.fn(),
+          onDeleteTask: vi.fn(),
+          onReorder: vi.fn()
+        })
+      )
+
+      act(() => {
+        result.current.handleDragEnd(
+          createDragEvent({
+            over: {
+              id: 'priority-high',
+              data: { current: { type: 'column', columnId: 'priority-high' } }
+            }
+          }),
+          createDragState({ sourceContainerId: 'priority-low' })
+        )
+      })
+      expect(vi.getTimerCount()).toBe(1)
+
+      // The 2.5s flash reset must not outlive the board that scheduled it.
+      unmount()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('handles cross-section canonical and project-status drops, including completion toggles', () => {
     const project = createProject()
     const tasks = [

--- a/apps/desktop/src/renderer/src/hooks/use-drag-handlers.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-drag-handlers.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { DragEndEvent, DragStartEvent, DragOverEvent } from '@dnd-kit/core'
 import { arrayMove } from '@dnd-kit/sortable'
 import { toast } from 'sonner'
@@ -186,6 +186,14 @@ export const useDragHandlers = ({
   const [lastActionDescription, setLastActionDescription] = useState<string | null>(null)
   const [droppedPriorities, setDroppedPriorities] = useState<Map<string, Priority>>(new Map())
   const priorityTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  // Drop the pending "dropped priority" flash timer when the board unmounts
+  useEffect(
+    () => () => {
+      if (priorityTimerRef.current) clearTimeout(priorityTimerRef.current)
+    },
+    []
+  )
 
   // Record an action for undo
   const recordAction = useCallback((action: UndoAction, description: string) => {

--- a/apps/desktop/src/renderer/src/hooks/use-find-in-page.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-find-in-page.ts
@@ -143,6 +143,8 @@ export function useFindInPage(
   // the debounce window can never feed stale ranges into the highlight.
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pendingQueryRef = useRef<string | null>(null)
+  // Frame queued by `open()` to focus the input once the bar is painted
+  const focusFrameRef = useRef<number | null>(null)
 
   const cancelPendingSearch = useCallback(() => {
     if (searchTimeoutRef.current !== null) clearTimeout(searchTimeoutRef.current)
@@ -194,7 +196,9 @@ export function useFindInPage(
     if (query) {
       performSearch(query)
     }
-    requestAnimationFrame(() => {
+    if (focusFrameRef.current !== null) cancelAnimationFrame(focusFrameRef.current)
+    focusFrameRef.current = requestAnimationFrame(() => {
+      focusFrameRef.current = null
       inputRef.current?.focus()
       inputRef.current?.select()
     })
@@ -273,6 +277,10 @@ export function useFindInPage(
   useEffect(() => {
     return () => {
       cancelPendingSearch()
+      if (focusFrameRef.current !== null) {
+        cancelAnimationFrame(focusFrameRef.current)
+        focusFrameRef.current = null
+      }
       clearHighlights()
     }
   }, [cancelPendingSearch, clearHighlights])

--- a/apps/desktop/src/renderer/src/hooks/use-focus-trap.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-focus-trap.ts
@@ -67,9 +67,11 @@ export function useFocusTrap({
     }
 
     // Auto-focus first focusable element
+    let autoFocusFrame: number | undefined
     if (autoFocus) {
       // Use requestAnimationFrame to ensure DOM is ready
-      requestAnimationFrame(() => {
+      autoFocusFrame = requestAnimationFrame(() => {
+        autoFocusFrame = undefined
         const focusableElements = getFocusableElements()
         if (focusableElements.length > 0) {
           focusableElements[0].focus()
@@ -111,6 +113,10 @@ export function useFocusTrap({
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
+
+      // Drop a queued auto-focus: a trap torn down inside the same frame must
+      // not steal focus from whatever replaced it.
+      if (autoFocusFrame !== undefined) cancelAnimationFrame(autoFocusFrame)
 
       // Restore focus when deactivating
       if (restoreFocus && previousFocusRef.current) {

--- a/apps/desktop/src/renderer/src/hooks/use-note-editor.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-note-editor.ts
@@ -17,6 +17,7 @@ import { extractErrorMessage } from '@/lib/ipc-error'
 import { trackRendererError } from '@/lib/telemetry-diagnostics'
 import { notesService, onNoteDeleted, onNoteExternalChange } from '@/services/notes-service'
 import { registerPendingSave, unregisterPendingSave } from '@/lib/save-registry'
+import { useTrackedTimeout } from '@/hooks/use-tracked-timeout'
 import { toast } from 'sonner'
 
 // ============================================================================
@@ -111,6 +112,9 @@ export function useNoteEditor(
   const lastSavedContentRef = useRef<string>('')
   const pendingContentRef = useRef<string | null>(null)
   const performSaveRef = useRef<(content: string) => Promise<void>>(async () => {})
+
+  // Cancels the "saved" -> "idle" status reset if the editor unmounts first
+  const scheduleTimeout = useTrackedTimeout()
 
   // ============================================================================
   // Load Note
@@ -239,7 +243,7 @@ export function useNoteEditor(
           setSaveStatus('saved')
 
           // Reset to idle after 2 seconds
-          setTimeout(() => {
+          scheduleTimeout(() => {
             setSaveStatus((current) => (current === 'saved' ? 'idle' : current))
           }, 2000)
         }
@@ -256,7 +260,7 @@ export function useNoteEditor(
         }
       }
     },
-    [noteId, note, isDeleted, showToasts]
+    [noteId, note, isDeleted, showToasts, scheduleTimeout]
   )
 
   // Keep ref in sync so cleanup always calls the latest version

--- a/apps/desktop/src/renderer/src/hooks/use-property-section.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-property-section.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useState, useRef } from 'react'
 import { type NewProperty, type Property } from '@/components/note/info-section'
 import { useProperties } from '@/hooks/use-properties'
 import {
@@ -45,6 +45,9 @@ export function usePropertySection({
 
   const [newlyAddedPropertyId, setNewlyAddedPropertyId] = useState<string | null>(null)
   const clearTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  // Drop the pending "newly added" highlight timer when the section unmounts
+  useEffect(() => () => clearTimeout(clearTimerRef.current), [])
 
   const properties: Property[] = useMemo(() => {
     return backendProperties.map((prop) => ({

--- a/apps/desktop/src/renderer/src/hooks/use-reveal-in-sidebar.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-reveal-in-sidebar.ts
@@ -5,6 +5,7 @@
 
 import { useEffect, useState, useCallback } from 'react'
 import type { SidebarItem } from '@/contexts/tabs/types'
+import { useTrackedTimeout } from '@/hooks/use-tracked-timeout'
 
 /**
  * Event detail for reveal-in-sidebar custom event
@@ -38,20 +39,24 @@ export const useRevealInSidebar = (
   expandSection?: (sectionId: string) => void
 ): RevealInSidebarState => {
   const [highlightedItemId, setHighlightedItemIdState] = useState<string | null>(null)
+  const scheduleTimeout = useTrackedTimeout()
 
   /**
    * Set highlighted item with auto-clear
    */
-  const setHighlightedItemId = useCallback((id: string | null) => {
-    setHighlightedItemIdState(id)
+  const setHighlightedItemId = useCallback(
+    (id: string | null) => {
+      setHighlightedItemIdState(id)
 
-    if (id) {
-      // Auto-clear highlight after 2 seconds
-      setTimeout(() => {
-        setHighlightedItemIdState((current) => (current === id ? null : current))
-      }, 2000)
-    }
-  }, [])
+      if (id) {
+        // Auto-clear highlight after 2 seconds
+        scheduleTimeout(() => {
+          setHighlightedItemIdState((current) => (current === id ? null : current))
+        }, 2000)
+      }
+    },
+    [scheduleTimeout]
+  )
 
   /**
    * Find item by path or entityId (recursive)

--- a/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.ts
@@ -19,6 +19,7 @@ import { SINGLETON_TAB_TYPES } from '@/contexts/tabs/types'
 import type { Tab, TabSystemState, SidebarItem } from '@/contexts/tabs/types'
 import { useIsItemActive } from './use-is-item-active'
 import { useFeatureFlags } from './use-feature-flags'
+import { useTrackedTimeout } from './use-tracked-timeout'
 import { useSettingsModal } from '@/contexts/settings-modal-context'
 import { featureForTabType } from '@memry/contracts/feature-flags'
 import type { FeaturesSettings } from '@memry/contracts/settings-schemas'
@@ -148,6 +149,9 @@ export const useSidebarNavigation = () => {
   const { flags } = useFeatureFlags()
   const { open: openSettings } = useSettingsModal()
 
+  // The post-split "open in the new pane" hop must not fire after unmount
+  const scheduleTimeout = useTrackedTimeout()
+
   // Use refs for state to avoid recreating callbacks
   const stateRef = useRef(state)
   useEffect(() => {
@@ -196,14 +200,14 @@ export const useSidebarNavigation = () => {
         // The new group will be active, so opening a tab there
         // Note: This is a simplification - ideally we'd wait for the split
         // and then open the tab in the new pane
-        setTimeout(() => {
+        scheduleTimeout(() => {
           openTab(tabData, { background: inBackground })
         }, 0)
       } else {
         openTab(tabData, { background: inBackground })
       }
     },
-    [openTab, setActiveTab, splitView, flags, openSettings]
+    [openTab, setActiveTab, splitView, flags, openSettings, scheduleTimeout]
   )
 
   /**

--- a/apps/desktop/src/renderer/src/hooks/use-subtask-management.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-subtask-management.ts
@@ -27,6 +27,7 @@ import {
 } from '@/lib/subtask-bulk-utils'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { useTaskSettings } from './use-task-settings'
+import { useTrackedTimeout } from './use-tracked-timeout'
 import type { Task, Priority } from '@/data/task-model'
 import type { Project } from '@/data/tasks-data'
 import { getI18n } from 'react-i18next'
@@ -131,6 +132,9 @@ export const useSubtaskManagement = ({
   void _projects
   // Get settings
   const { subtaskSettings } = useTaskSettings()
+
+  // Celebration-animation delays must not outlive the list that scheduled them
+  const scheduleTimeout = useTrackedTimeout()
 
   // Delete parent dialog state
   const [deleteParentDialogOpen, setDeleteParentDialogOpen] = useState(false)
@@ -566,7 +570,7 @@ export const useSubtaskManagement = ({
 
         if (subtaskSettings.autoCompleteParent) {
           // Delay auto-complete to let celebration animation play
-          setTimeout(() => {
+          scheduleTimeout(() => {
             // Use database-aware callback if available
             if (onUpdateTask) {
               onUpdateTask(parentId, { completedAt: new Date() })
@@ -603,14 +607,14 @@ export const useSubtaskManagement = ({
           }, 200) // Wait 0.2 seconds for celebration animation
         } else {
           // Show dialog to ask user (after a brief delay for the animation)
-          setTimeout(() => {
+          scheduleTimeout(() => {
             setPendingAutoCompleteParent(parent)
             setAllSubtasksCompleteDialogOpen(true)
           }, 1000)
         }
       }
     },
-    [tasks, onTasksChange, onUpdateTask, subtaskSettings.autoCompleteParent]
+    [tasks, onTasksChange, onUpdateTask, subtaskSettings.autoCompleteParent, scheduleTimeout]
   )
 
   // ========================================================================
@@ -682,7 +686,7 @@ export const useSubtaskManagement = ({
         const allComplete = checkAllSubtasksComplete(parentId, updatedTasks)
 
         if (allComplete && subtaskSettings.autoCompleteParent) {
-          setTimeout(() => {
+          scheduleTimeout(() => {
             if (onUpdateTask) {
               onUpdateTask(parentId, { completedAt: new Date() })
               toast.success(getI18n().getFixedT(null, 'tasks')('phaseI.toasts.taskMarkedAsDone'))
@@ -704,7 +708,7 @@ export const useSubtaskManagement = ({
         )
       }
     },
-    [tasks, onTasksChange, onUpdateTask, subtaskSettings.autoCompleteParent]
+    [tasks, onTasksChange, onUpdateTask, subtaskSettings.autoCompleteParent, scheduleTimeout]
   )
 
   // ========================================================================

--- a/apps/desktop/src/renderer/src/hooks/use-tracked-timeout.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tracked-timeout.ts
@@ -1,0 +1,49 @@
+/**
+ * Tracked Timeout Hook
+ *
+ * `setTimeout` scheduled from a callback outlives the component that scheduled
+ * it: the handle is unreachable, so nothing can cancel it and the callback's
+ * closure (and everything it captures) stays alive until the timer fires.
+ *
+ * `useTrackedTimeout` hands back a scheduler that remembers every pending
+ * handle and clears the whole set when the owning component unmounts.
+ *
+ * @module hooks/use-tracked-timeout
+ */
+
+import { useCallback, useEffect, useRef } from 'react'
+
+/** Schedules `callback` after `delayMs`; cancelled automatically on unmount. */
+export type TrackedTimeoutScheduler = (callback: () => void, delayMs: number) => void
+
+/**
+ * Returns a stable `setTimeout` wrapper whose pending timers are cleared on
+ * unmount.
+ *
+ * @example
+ * ```ts
+ * const scheduleTimeout = useTrackedTimeout()
+ * scheduleTimeout(() => setCopied(false), 2000)
+ * ```
+ */
+export function useTrackedTimeout(): TrackedTimeoutScheduler {
+  const handlesRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
+
+  useEffect(() => {
+    const handles = handlesRef.current
+    return () => {
+      for (const handle of handles) clearTimeout(handle)
+      handles.clear()
+    }
+  }, [])
+
+  return useCallback((callback: () => void, delayMs: number) => {
+    const handle = setTimeout(() => {
+      handlesRef.current.delete(handle)
+      callback()
+    }, delayMs)
+    handlesRef.current.add(handle)
+  }, [])
+}
+
+export default useTrackedTimeout

--- a/apps/desktop/src/renderer/src/hooks/use-undoable-action.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-undoable-action.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { inboxService } from '@/services/inbox-service'
@@ -23,6 +23,15 @@ export interface UseUndoableActionResult {
 export function useUndoableAction(): UseUndoableActionResult {
   const queryClient = useQueryClient()
   const pendingRef = useRef<Map<string, PendingUndo>>(new Map())
+
+  // Drop every open undo window when the hook owner unmounts
+  useEffect(() => {
+    const pending = pendingRef.current
+    return () => {
+      for (const entry of pending.values()) clearTimeout(entry.timer)
+      pending.clear()
+    }
+  }, [])
 
   const invalidateAll = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: inboxKeys.lists() })

--- a/apps/desktop/src/renderer/src/hooks/use-vault.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-vault.ts
@@ -86,10 +86,13 @@ export function useVault() {
       setError(extractErrorMessage(errorMsg, ''))
     })
 
+    let recoveryClearTimer: ReturnType<typeof setTimeout> | undefined
+
     const unsubRecovered = onVaultIndexRecovered((event) => {
       setRecoveryInfo(event)
       // Auto-clear recovery info after 10 seconds
-      setTimeout(() => setRecoveryInfo(null), 10000)
+      clearTimeout(recoveryClearTimer)
+      recoveryClearTimer = setTimeout(() => setRecoveryInfo(null), 10000)
     })
 
     return () => {
@@ -97,6 +100,7 @@ export function useVault() {
       unsubProgress()
       unsubError()
       unsubRecovered()
+      clearTimeout(recoveryClearTimer)
     }
   }, [])
 

--- a/apps/desktop/src/renderer/src/services/ai-connections-service.ts
+++ b/apps/desktop/src/renderer/src/services/ai-connections-service.ts
@@ -104,15 +104,20 @@ export async function getAIConnections(
 
   // Simulate AI analysis delay
   await new Promise<void>((resolve, reject) => {
-    const timeoutId = setTimeout(resolve, AI_ANALYSIS_DELAY_MS)
+    const timeoutId = setTimeout(() => {
+      // A caller-owned signal outlives this call, so drop the listener (and the
+      // closure it holds) as soon as the delay is over.
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, AI_ANALYSIS_DELAY_MS)
+
+    const onAbort = (): void => {
+      clearTimeout(timeoutId)
+      reject(new DOMException('Aborted', 'AbortError'))
+    }
 
     // Handle abort signal
-    if (signal) {
-      signal.addEventListener('abort', () => {
-        clearTimeout(timeoutId)
-        reject(new DOMException('Aborted', 'AbortError'))
-      })
-    }
+    signal?.addEventListener('abort', onAbort, { once: true })
   })
 
   // Check if aborted after delay

--- a/apps/docs/src/contribute/gotchas.md
+++ b/apps/docs/src/contribute/gotchas.md
@@ -127,6 +127,26 @@ Keep it that way when editing these hooks:
 - Do not close over that state inside the registered listener either. Read it through the ref, or the shortcut acts on the state from the first render.
 - Callers may keep building a fresh shortcut array on every render; the hook absorbs the churn.
 
+## Timers and rAF Handles Scheduled from Callbacks
+
+A `setTimeout` fired from an event handler or a `useCallback` has no owner: the handle is unreachable, so nothing can cancel it. The pending callback keeps its closure — and every value that closure captured — alive until it fires, then runs `setState` on a component that may already be gone.
+
+Use `useTrackedTimeout` (`hooks/use-tracked-timeout.ts`) for delayed work scheduled from a callback. It returns a stable `(callback, delayMs) => void` that remembers each pending handle and clears the set on unmount:
+
+```ts
+const scheduleTimeout = useTrackedTimeout()
+scheduleTimeout(() => setCopied(false), 2000)
+```
+
+Two cases stay hand-rolled:
+
+- A timer created **inside** an effect belongs to that effect — hold it in an effect-scoped variable and `clearTimeout` it in the effect's own cleanup, so it also dies when the effect re-runs, not just on unmount.
+- A timer already tracked in a ref (a debounce that each new call replaces) only needs the missing unmount cleanup: `useEffect(() => () => clearTimeout(ref.current), [])`.
+
+`requestAnimationFrame` has the same rule: keep the id and `cancelAnimationFrame` it in the cleanup. A queued auto-focus frame that survives its own teardown will steal focus from whatever replaced it.
+
+Regression coverage: `hooks/timer-raf-cleanup.test.tsx` asserts `vi.getTimerCount() === 0` after unmount, which only passes when the handle was really cleared.
+
 ## Cross-Platform Env Vars in package Scripts
 
 `VAR=value cmd` is POSIX-only. pnpm runs package scripts through cmd on Windows, where `MEMRY_ENV=production pnpm ...` fails with `'MEMRY_ENV' is not recognized`. This broke the Windows release build (`apps/desktop` `build` script). Use `cross-env` for any inline env var that must work on Windows too:


### PR DESCRIPTION
Closes #1089. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

All 14 sites in the issue are still real on current `main` (paths drifted: they live under `apps/desktop/src/renderer/src/**`, not `apps/desktop/src/renderer/**`). They split into three mechanisms.

**1. Handle never stored at all (8 sites).** A `setTimeout` fired from a callback has no owner — the handle is unreachable, so nothing can cancel it. The pending callback keeps its closure, and everything that closure captured, alive until it fires, then runs `setState` on a component that may already be gone.

```ts
// hooks/use-reveal-in-sidebar.ts:50 (before)
const setHighlightedItemId = useCallback((id: string | null) => {
  setHighlightedItemIdState(id)
  if (id) {
    setTimeout(() => {                       // handle discarded
      setHighlightedItemIdState((current) => (current === id ? null : current))
    }, 2000)
  }
}, [])
```

Same shape at `hooks/use-vault.ts:92` (10 s), `hooks/use-note-editor.ts:242` (2 s per save), `contexts/drag-context.tsx:512-514` (nested 200 ms -> 1100 ms per drop), `hooks/use-subtask-management.ts:569,606,685`, `hooks/use-sidebar-navigation.ts:199`, `components/capture-bar/capture-bar.tsx:405` (blur 150 ms), `components/viewers/audio-player.tsx:154` (2 s).

**2. Handle tracked in a ref, but no unmount cleanup (3 sites).** `hooks/use-drag-handlers.ts:397,737` and `hooks/use-property-section.ts:98` each clear the *previous* timer before arming a new one, but neither file had any cleanup effect, so the last one armed always outlived the component. `hooks/use-undoable-action.ts:57-61` keeps a `Map` of 5 s timers with the same hole.

**3. rAF handles (2 sites).** `hooks/use-focus-trap.ts:72` queues an auto-focus frame and drops the id — a trap torn down inside the same frame still yanks focus away from whatever replaced it. `hooks/use-find-in-page.ts:197` (issue cited :161; the *setTimeout* there was already cleaned up by a later commit) queues a focus frame in `open()` with no cancel path.

**4. Listener leak.** `services/ai-connections-service.ts:111` registered an `abort` listener without `{ once: true }` and never removed it, so a caller-owned `AbortSignal` reused across calls accumulated one listener (and one captured `timeoutId` closure) per call.

## What changed

New `hooks/use-tracked-timeout.ts` (49 lines): returns a stable `(callback, delayMs) => void` that records every pending handle in a `Set` and clears the set on unmount, deleting each handle as it fires. Adopted at the 8 mechanism-1 sites.

Mechanism 2 got only the missing cleanup effect — the existing ref/debounce logic is untouched. Mechanism 3 cancels its own frame in the cleanup it already had. The service registers with `{ once: true }` and removes the listener once the delay resolves.

Deliberately **not** changed:

- `hooks/use-focus-trap.ts:118` — that rAF is created *inside* the effect cleanup to restore focus after React commits. There is no later cleanup that could cancel it, and cancelling it would delete the feature. It holds a ref object for one frame; not worth breaking focus restore for.
- `hooks/use-find-in-page.ts` search debounce — already tracked in `searchTimeoutRef` and cleared by the unmount effect at :273. Left alone; only the rAF was added to that same cleanup.
- No `useRafCallback` util. Only one rAF site needed cross-render tracking, so a second abstraction for a single caller would not have earned itself.

## How it was proven

New `hooks/timer-raf-cleanup.test.tsx` plus one case appended to the existing `hooks/use-drag-handlers.test.tsx`. Each arms the hook's delayed work, unmounts, and asserts `vi.getTimerCount() === 0` — a handle count the fake clock still owns, so it only reaches zero when `clearTimeout` really ran. The focus-trap case stubs rAF with a controllable frame queue and asserts focus is not stolen.

Stashed the source fixes, kept the tests:

```
before: Test Files 2 failed (2) | Tests 6 failed | 34 passed (40)
after:  Test Files 3 passed (3) | Tests 48 passed (48)
```

The 6 that flip: `useRevealInSidebar`, `usePropertySection`, `useUndoableAction`, `useFocusTrap`, `getAIConnections`, and `useDragHandlers` board unmount. The two `useTrackedTimeout` cases cover the new file itself.

## Verification

```
pnpm --filter @memry/desktop typecheck:web        -> clean
pnpm exec eslint <17 changed files>               -> 0 errors, 0 warnings
git diff --check                                  -> clean
pnpm docs:impact --base origin/main --strict      -> docs changed on this branch
pnpm docs:build                                   -> build complete in 5.04s
```

Regression run over every suite that touches a changed file (`timer-raf-cleanup`, `use-drag-handlers`, `use-find-in-page`, `use-vault`, `use-note-editor`, `drag-context`, `capture-bar`, `viewers`, `more-major-hooks`, `cold-renderer-surfaces`):

```
Test Files 10 passed (10) | Tests 128 passed (128)
```

## Backward compatibility

Renderer-lifecycle only — no schema, IPC contract, settings, sync payload, or vault-format surface is touched, so existing installs are unaffected.
