### PR TITLE
perf(sync): trim the offline task clock log to a debug line

### DIFF
--- a/apps/desktop/src/main/sync/offline-clock.test.ts
+++ b/apps/desktop/src/main/sync/offline-clock.test.ts
@@ -1,16 +1,36 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { eq } from 'drizzle-orm'
 import { createTestDataDb, asClientDb, type TestDatabaseResult } from '@tests/utils/test-db'
 import { bookmarks } from '@memry/db-schema/schema/bookmarks'
 import { reminders } from '@memry/db-schema/schema/reminders'
 import { templates } from '@memry/db-schema/schema/templates'
+import { tasks } from '@memry/db-schema/schema/tasks'
+import { projects } from '@memry/db-schema/schema/projects'
 import { noteMetadata } from '@memry/db-schema/data-schema'
 import { syncDevices } from '@memry/db-schema/schema/sync-devices'
+
+const logMocks = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    debug: (...args: unknown[]) => logMocks.debug(...args),
+    info: (...args: unknown[]) => logMocks.info(...args),
+    warn: (...args: unknown[]) => logMocks.warn(...args),
+    error: (...args: unknown[]) => logMocks.error(...args)
+  })
+}))
+
 import {
   OFFLINE_DEVICE_KEY,
   incrementBookmarkClockOffline,
   incrementNoteClockOffline,
   incrementReminderClockOffline,
+  incrementTaskClocksOffline,
   incrementTemplateClockOffline
 } from './offline-clock'
 
@@ -38,10 +58,59 @@ describe('offline clock helpers', () => {
 
   beforeEach(() => {
     testDb = createTestDataDb()
+    logMocks.debug.mockClear()
+    logMocks.info.mockClear()
+    logMocks.warn.mockClear()
+    logMocks.error.mockClear()
   })
 
   afterEach(() => {
     testDb.close()
+  })
+
+  // Tasks are the highest-volume offline path: this runs once per field change
+  // for every task edited while the sync runtime is down, and every argument is
+  // built eagerly regardless of the transport's level. So the payload itself,
+  // not just the level, is what has to stay small.
+  describe('incrementTaskClocksOffline', () => {
+    const insertTask = (values: Record<string, unknown>): void => {
+      testDb.db.insert(projects).values({ id: 'p1', name: 'P1', color: '#000', position: 0 }).run()
+      testDb.db
+        .insert(tasks)
+        .values({ id: 'task-1', projectId: 'p1', title: 'A task', ...values } as never)
+        .run()
+    }
+
+    it('#given a field change while offline #then bumps the doc clock and the changed field clock', () => {
+      insertTask({ clock: { [OFFLINE_DEVICE_KEY]: 1 } })
+
+      incrementTaskClocksOffline(asClientDb(testDb.db), 'task-1', ['title'])
+
+      const row = testDb.db.select().from(tasks).where(eq(tasks.id, 'task-1')).get()
+      expect(row?.clock).toEqual({ [OFFLINE_DEVICE_KEY]: 2 })
+      expect(row?.fieldClocks?.title).toEqual({ [OFFLINE_DEVICE_KEY]: 2 })
+    })
+
+    it('#then logs at debug with ids only, never an info line carrying clock objects', () => {
+      insertTask({ clock: { [OFFLINE_DEVICE_KEY]: 1 } })
+
+      incrementTaskClocksOffline(asClientDb(testDb.db), 'task-1', ['title', 'priority'])
+
+      expect(logMocks.info).not.toHaveBeenCalled()
+      expect(logMocks.debug).toHaveBeenCalledTimes(1)
+      expect(logMocks.debug).toHaveBeenCalledWith('Incremented offline task clocks', {
+        taskId: 'task-1',
+        changedFields: ['title', 'priority']
+      })
+    })
+
+    it('#given the task does not exist #then no-ops without logging', () => {
+      expect(() =>
+        incrementTaskClocksOffline(asClientDb(testDb.db), 'missing', ['title'])
+      ).not.toThrow()
+      expect(logMocks.debug).not.toHaveBeenCalled()
+      expect(logMocks.info).not.toHaveBeenCalled()
+    })
   })
 
   describe('incrementTemplateClockOffline', () => {

--- a/apps/desktop/src/main/sync/offline-clock.ts
+++ b/apps/desktop/src/main/sync/offline-clock.ts
@@ -114,12 +114,10 @@ export function incrementTaskClocksOffline(
       .where(eq(tasks.id, taskId))
       .run()
 
-    log.info('=== OFFLINE CLOCK: task incremented ===', {
-      taskId,
-      changedFields,
-      newClock,
-      updatedFieldClocks: Object.fromEntries(changedFields.map((f) => [f, updatedFC[f]]))
-    })
+    // Debug, and ids only. This fires once per field change for every task
+    // edited while the sync runtime is down, and a leftover `info` line built a
+    // fresh clock object per call that then rode the shipped-log queue.
+    log.debug('Incremented offline task clocks', { taskId, changedFields })
   } catch (err) {
     log.warn('Failed to increment offline task clocks', { taskId, error: err })
   }

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -38,6 +38,13 @@ steady states at `debug`:
   unknown content-length during a model download (`main/lib/embeddings.ts`). A stderr chunk is
   only downgraded when every line in it matches a known-benign pattern, so a real failure
   interleaved with progress output still reaches `error`.
+- Vector-clock bumps the `increment*ClockOffline` helpers make while the sync runtime is down
+  (`main/sync/offline-clock.ts`) — the normal offline-edit path, one call per edited row (per
+  changed field for tasks and projects).
+
+A log payload is built before the transport decides whether to keep it, so a hot path pays for
+its arguments at every level. Keep these lines to identifiers: log the row id and the changed
+field names, not the resulting clock or field-clock objects.
 
 ### Log Locations
 


### PR DESCRIPTION
Closes #1095. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/sync/offline-clock.ts:117` — `incrementTaskClocksOffline` ended with an `info`-level line carrying a freshly built clock payload:

```ts
log.info('=== OFFLINE CLOCK: task incremented ===', {
  taskId,
  changedFields,
  newClock,
  updatedFieldClocks: Object.fromEntries(changedFields.map((f) => [f, updatedFC[f]]))
})
```

Two costs, both paid on the offline edit path:

1. **The payload is built eagerly.** Arguments are evaluated before the transport looks at the level, so the `Object.fromEntries(changedFields.map(...))` allocation (plus the `newClock` object it holds a reference to) happens on every call regardless of whether anything is listening.
2. **`info` ships.** The line is above the file-transport floor and rides the shipped-log ring buffer (the telemetry MAJOR in this epic), so a burst of offline task edits pushes real clock objects through the queue.

The call site is per field change, per task, for the whole time the sync runtime is down (`local-mutations.ts:76/85`, `task-sync.ts:108/110`). Every sibling helper in the same file already logs at `debug` with ids only — `incrementProjectClocksOffline` right below it does exactly `log.debug('Incremented offline project clocks', { projectId, fields })`. This was leftover debug output, not a deliberate exception.

## What changed

One log statement, matched to its siblings:

```ts
log.debug('Incremented offline task clocks', { taskId, changedFields })
```

Deliberately **not** done:

- Did not merely lower `info` → `debug` while keeping the payload, which is one of the two options the issue offered. The level alone does not fix it: the payload is constructed before the level is consulted, so the allocation survives. Dropping `newClock`/`updatedFieldClocks` is the part that actually removes the per-change work.
- Did not touch the clock math, the DB write, or the `catch` branch's `log.warn`. The bump itself is load-bearing for offline edits and is out of scope here.
- Did not sweep the other `increment*ClockOffline` helpers — they were already correct.

## How it was proven

Added `incrementTaskClocksOffline` coverage to the existing `offline-clock.test.ts` (real in-memory data DB, not a mocked IPC surface): the clock and field-clock bumps are asserted against the persisted row, and a separate test asserts the log is `debug`, called once, with `{ taskId, changedFields }` and nothing else — and that `info` is never called.

Stashed the source fix, kept the tests:

```
Test Files  1 failed (1)
     Tests  1 failed | 18 passed (19)
```

The failure output printed the exact object the issue describes (`newClock: { _offline: 2 }`, `updatedFieldClocks: { title: {…}, priority: {…} }`).

Unstashed:

```
Test Files  1 passed (1)
     Tests  19 passed (19)
```

## Verification

```
pnpm exec vitest run --config config/vitest.config.ts --project main src/main/sync/offline-clock.test.ts
  -> Test Files 1 passed (1), Tests 19 passed (19)

pnpm exec vitest run --config config/vitest.config.ts --project main \
  src/main/sync/task-sync.test.ts src/main/sync/local-mutations.test.ts src/main/ipc/tasks-handlers.test.ts
  -> Test Files 3 passed (3), Tests 91 passed (91)

pnpm --filter @memry/desktop typecheck:node                    -> clean, no diagnostics
pnpm exec eslint apps/desktop/src/main/sync/offline-clock.ts   -> 0 errors
git diff --check                                               -> clean
pnpm docs:impact --base origin/main --strict                   -> covered
pnpm docs:build                                                -> build complete in 10.65s
```

Also grepped the repo for `OFFLINE CLOCK` — no test, script, or E2E log scrape depended on the removed string.

Docs: added the offline clock bumps to the "Choosing a Level" list in `apps/docs/src/architecture/observability.md`, plus the general rule that a log payload is built before the transport decides to keep it, so hot-path lines stay identifier-only.

## Backward compatibility

No behavior change outside logging. No schema, contract, sync-payload, or settings shape is touched, and the clock values written to the row are byte-identical to before.
