### PR TITLE
perf(crdt): destroy the superseded Y.Doc when a note is reopened mid-close

### DIFF
--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -704,6 +704,40 @@ describe('CrdtProvider', () => {
     expect(provider.getDoc('note-1')).toBe(replacementDoc)
   })
 
+  it('destroys the superseded doc when a real reopen replaces it mid-close', async () => {
+    createWindow(5)
+    let releaseFlush: (() => void) | undefined
+    mocks.persistenceInstances[0].flushDocument.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFlush = resolve
+        })
+    )
+    const supersededDoc = await provider.open('note-1', undefined, { skipSeed: true })
+
+    const closePromise = provider.close('note-1')
+    await Promise.resolve()
+
+    // A real reopen through open() — the editor mounting again while the
+    // close's flush is still in flight — not a hand-built map entry.
+    const replacementDoc = await provider.open('note-1', 5, { skipSeed: true })
+    expect(replacementDoc).not.toBe(supersededDoc)
+
+    releaseFlush?.()
+    await closePromise
+
+    // The live doc must survive: the map still points at it and keystrokes
+    // arriving after the race still land in it.
+    expect(provider.getDoc('note-1')).toBe(replacementDoc)
+    expect(replacementDoc.isDestroyed).toBe(false)
+    provider.applyIpcUpdate('note-1', makeRemoteUpdate('typed after reopen'), 5)
+    expect(replacementDoc.getMap('meta').get('title')).toBe('typed after reopen')
+
+    // The orphan is torn down instead of being left for GC with its 'update'
+    // listener still attached.
+    expect(supersededDoc.isDestroyed).toBe(true)
+  })
+
   it('returns false when pushing a snapshot without a configured push callback', async () => {
     const noSnapshotProvider = new CrdtProvider()
     await noSnapshotProvider.init()

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -333,7 +333,21 @@ export class CrdtProvider {
     })
 
     if (this.docs.get(noteId) !== entry) {
-      log.debug('Doc reopened during async close, skipping destroy', { noteId })
+      // The note was reopened while the flush above was in flight, so doOpen()
+      // put a *different* entry — with its own Y.Doc — in the map. That
+      // replacement is what the editor is typing into, so the map entry must
+      // stay exactly as it is. Only the superseded doc is retired here, and it
+      // is provably unreachable: every routing path (applyIpcUpdate,
+      // applyIpcSyncStep2, applyRemoteUpdate, getDoc, getDiff, getStateVector,
+      // updateMeta, onDocUpdate, broadcastToWindows) re-reads this.docs by
+      // noteId and therefore resolves the replacement; nothing outside the
+      // provider retains a Y.Doc across awaits; and entry.doc is assigned only
+      // in doOpen and in compactDoc's in-place swap, so one doc belongs to
+      // exactly one entry and can never be shared with the replacement.
+      // Destroying it detaches its 'update' listener instead of leaving it for
+      // GC to notice.
+      log.debug('Doc reopened during async close, destroying the superseded doc', { noteId })
+      entry.doc.destroy()
       return
     }
 

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -101,6 +101,14 @@ pins a doc for the rest of the session: the renderer's `crdt:close-doc` on unmou
 window that turns out to be gone, and provider teardown on vault close or switch. Once
 released, the doc is evictable and compactable again.
 
+Closing is asynchronous — it flushes the doc to persistence first — so a note can be
+reopened while its own close is still in flight. The reopen builds a fresh Y.Doc and takes
+over the provider's entry for that note, and the close then finds that the entry no longer
+belongs to it. It leaves that entry alone, because the reopened doc is the one the editor
+is typing into, and destroys only the doc it superseded. Nothing can reach the superseded
+doc at that point: every route into a Y.Doc looks the note id up in the provider's map,
+which now resolves the replacement.
+
 ## IPC Loop Prevention
 
 Three pieces of metadata prevent feedback loops:


### PR DESCRIPTION
Closes #1097. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/sync/crdt-provider.ts:335-338` (on `origin/main` @ `f4a5dd4f7` — still live, the MEDIUM batch did not touch this path):

```ts
await this.flushDoc(noteId).catch((err) => { ... })

if (this.docs.get(noteId) !== entry) {
  log.debug('Doc reopened during async close, skipping destroy', { noteId })
  return
}

entry.doc.destroy()
this.docs.delete(noteId)
```

`close()` is asynchronous — it awaits a snapshot push and `flushDoc()`. While it is suspended, `open()` sees `existing.closing === true`, falls through to `doOpen()`, builds a fresh `Y.Doc` and overwrites `this.docs.get(noteId)` with a new entry. `close()` then resumes, correctly refuses to touch the map, and returns — but it returns *without* retiring the doc it was closing. That doc keeps the `'update'` listener attached at `:301`, which closes over the provider, so the deliberate teardown step is skipped and the orphan is left for GC to notice.

## What changed

One branch: destroy the superseded doc before returning. The `this.docs` entry is deliberately left untouched — that is what keeps the replacement alive.

**Proof the superseded doc is unreachable before it is destroyed** (this is the bar #1084 / PR #1246 set: `applyIpcUpdate` is `if (!entry) return`, so a doc destroyed or dropped while a renderer still holds it silently swallows keystrokes — this is a data-loss-shaped path, not just a memory one):

1. **The map no longer points at it.** `this.docs.get(noteId) !== entry` *is* that proof, evaluated after the last `await`. The entry now in the map is a different object created by `doOpen()`.
2. **No provider route can reach it.** Every path that touches a `Y.Doc` re-reads `this.docs` by note id and therefore resolves the *replacement*, not the captured `entry`: `applyIpcUpdate`, `applyIpcSyncStep2`, `applyRemoteUpdate`, `getDoc`, `getDiff`, `getStateVector`, `updateMeta`, `seedFromMarkdownPublic`, `onDocUpdate`, `broadcastToWindows`, `maybeCompact`/`checkAndCompact`/`compactDoc`. Renderer keystrokes arrive over `crdt:apply-update` → `applyIpcUpdate` → map lookup, so they land in the replacement.
3. **Nothing outside the provider holds a `Y.Doc` across an await.** Every external consumer of a returned doc (`ipc/crdt-handlers.ts:82,124`, `sync/engine/crdt-sync-coordinator.ts:110,214`, `sync/crdt-feed.ts`, `vault/watcher.ts`, `test-hooks.ts`) uses it synchronously or only null-checks it; none stores one.
4. **A doc belongs to exactly one entry.** `entry.doc` is assigned in only two places — the `doOpen()` object literal and `compactDoc()`'s in-place swap (`:926`, which destroys the doc it replaces). So `entry !== current` implies `entry.doc !== current.doc`; there is no way to destroy the live doc here.

Deliberately **not** done: no change to the map, no `docs.delete()` in this branch (that would evict the live replacement), no cancellation of a write-back that may still hold the superseded doc — `crdt-writeback.ts` `pendingTimers` keys by note id and `Y.Doc.destroy()` does not clear the doc's store, so a pending write-back still serializes correctly. The normal close path at `:340` has always destroyed docs with write-backs pending, so this introduces no new class of risk.

Docs: extended the "Open Doc Lifecycle" section of `apps/docs/src/architecture/crdt.md` — the docs gate flags `crdt-provider.ts` as docs-relevant.

## How it was proven

New test `destroys the superseded doc when a real reopen replaces it mid-close` in `apps/desktop/src/main/sync/crdt-provider.test.ts`. It hangs `flushDocument()` mid-close, then does a **real** `provider.open('note-1', 5)` (not a hand-built map entry, unlike the pre-existing sibling test), releases the flush, and asserts all four properties: the map still points at the replacement, the replacement is **not** destroyed, an `applyIpcUpdate()` after the race still lands in the replacement (no swallowed keystroke), and the superseded doc **is** destroyed.

Before/after, source file reverted with `git checkout origin/main -- apps/desktop/src/main/sync/crdt-provider.ts` (never `git stash` — it is shared across this repo's worktrees):

- **Before the fix:** `Tests 1 failed | 42 passed (43)` — `AssertionError: expected false to be true` on `supersededDoc.isDestroyed`.
- **After the fix:** `Tests 43 passed (43)`.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  apps/desktop/src/main/sync/crdt-provider.test.ts
  → Test Files 1 passed (1) | Tests 43 passed (43)

./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  apps/desktop/src/main/sync/ apps/desktop/src/main/ipc/crdt-handlers.test.ts
  → Test Files 140 passed (140) | Tests 1646 passed | 1 expected fail | 3 skipped

pnpm --filter @memry/desktop typecheck:node   → clean
eslint apps/desktop/src/main/sync/crdt-provider.ts{,.test.ts}  → 0 errors
git diff --check                              → clean
pnpm docs:impact --base origin/main --strict  → covered
pnpm docs:build                               → build complete in 8.50s
```

(An earlier run of the 140-file sync suite reported 5 file-level failures with **zero** failing tests; a clean re-run was all-green. Known parallel-worker flake in this suite, unrelated to this change.)

## Backward compatibility

No schema, IPC contract, settings, sync-protocol or vault-format change — a single in-memory teardown call on a doc the provider has already stopped referencing, so existing installs and older app versions are unaffected.
