### PR TITLE
perf(sync): reuse the pinned https.Agent and cache the vault identity

### DIFF
--- a/apps/desktop/src/main/sync/certificate-pinning.test.ts
+++ b/apps/desktop/src/main/sync/certificate-pinning.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type tls from 'node:tls'
+import { PINNED_CERTIFICATE_HASHES_BY_HOST } from './certificate-pins'
 
 const mockApp = vi.hoisted(() => ({ isPackaged: false }))
 
@@ -23,6 +24,8 @@ import {
   computeSpkiHashFromPem,
   verifyCertificatePin,
   createPinnedAgent,
+  getSharedPinnedAgent,
+  resetSharedPinnedAgent,
   CertificatePinningError,
   getPinnedCertificateHashes,
   isPinningDisabled,
@@ -261,6 +264,71 @@ describe('certificate-pinning', () => {
       expect(agent).toBeDefined()
       expect(agent.options.checkServerIdentity).toBeUndefined()
       expect(agent.options.rejectUnauthorized).not.toBe(false)
+    })
+  })
+
+  describe('getSharedPinnedAgent', () => {
+    const STAGING_HOST = 'sync-staging.memrynote.com'
+
+    beforeEach(() => {
+      resetSharedPinnedAgent()
+    })
+
+    it('#given repeated connects #then hands back the same agent instance', () => {
+      // #when — what a WebSocket reconnect loop does
+      const first = getSharedPinnedAgent()
+      const second = getSharedPinnedAgent()
+      const third = getSharedPinnedAgent()
+
+      // #then
+      expect(second).toBe(first)
+      expect(third).toBe(first)
+    })
+
+    it('#given the pinning decision flips #then rebuilds and destroys the stale agent', () => {
+      // #given a dev-mode (pinning disabled) agent
+      const devAgent = getSharedPinnedAgent()
+      const destroySpy = vi.spyOn(devAgent, 'destroy')
+
+      // #when the construction-time decision changes
+      mockApp.isPackaged = true
+      const packagedAgent = getSharedPinnedAgent()
+
+      // #then the cached instance is not reused under the new decision
+      expect(packagedAgent).not.toBe(devAgent)
+      expect(destroySpy).toHaveBeenCalled()
+    })
+
+    it('#given a pinned host #then an updated pin table applies to the already-shared agent', () => {
+      // #given a packaged build pinned to a host with real (non-placeholder) pins
+      vi.stubEnv('SYNC_SERVER_URL', `https://${STAGING_HOST}`)
+      mockApp.isPackaged = true
+      const originalPins = PINNED_CERTIFICATE_HASHES_BY_HOST[STAGING_HOST]
+
+      try {
+        const agent = getSharedPinnedAgent()
+        const checkServerIdentity = agent.options.checkServerIdentity
+        expect(checkServerIdentity).toBeDefined()
+
+        // A cert whose SPKI hash is not in the table. subjectaltname makes the
+        // stock TLS hostname check pass so the pin check is what decides.
+        const cert = {
+          ...makeMockCertWithRaw(getTestCertDer()),
+          subjectaltname: `DNS:${STAGING_HOST}`
+        } as tls.PeerCertificate
+
+        // #then it is rejected
+        expect(checkServerIdentity!(STAGING_HOST, cert)).toBeInstanceOf(CertificatePinningError)
+
+        // #when the pin table is updated to trust it — no restart, no cache flush
+        PINNED_CERTIFICATE_HASHES_BY_HOST[STAGING_HOST] = [computeSpkiHashFromPem(TEST_CERT_PEM)]
+
+        // #then the SAME already-shared agent honours the new pins: the check
+        // resolves them per handshake, so reuse never freezes a pin decision
+        expect(checkServerIdentity!(STAGING_HOST, cert)).toBeUndefined()
+      } finally {
+        PINNED_CERTIFICATE_HASHES_BY_HOST[STAGING_HOST] = originalPins
+      }
     })
   })
 

--- a/apps/desktop/src/main/sync/certificate-pinning.ts
+++ b/apps/desktop/src/main/sync/certificate-pinning.ts
@@ -115,6 +115,43 @@ export function createPinnedAgent(pins?: string[]): https.Agent {
   })
 }
 
+/**
+ * The WebSocket manager built a fresh agent on every reconnect. An https.Agent
+ * created here has `keepAlive` off and the `ws` upgrade detaches its socket
+ * (`agentRemove`), so the agent owns nothing between connects — the object was
+ * the only thing being reallocated.
+ *
+ * Reuse does NOT weaken the pin. The check lives in `checkServerIdentity`,
+ * which resolves the connecting hostname's pins from `certificate-pins.ts` on
+ * every TLS handshake, so a reused agent verifies exactly what a fresh one
+ * would and an updated pin table takes effect on the very next handshake — no
+ * restart, no cache flush. Only the two branches `createPinnedAgent` decides at
+ * construction time are frozen into the instance: whether pinning is disabled
+ * (dev/test) and whether the configured host still carries placeholder pins.
+ * Those two form the cache key below, so if either flips, the cached agent is
+ * destroyed and rebuilt rather than silently reused under the old decision.
+ */
+let sharedPinnedAgent: { key: string; agent: https.Agent } | null = null
+
+function pinnedAgentCacheKey(): string {
+  const disabled = isPinningDisabled() ? 'disabled' : 'enabled'
+  return `${disabled}|${getConfiguredPinnedCertificateHashes().join(',')}`
+}
+
+export function getSharedPinnedAgent(): https.Agent {
+  const key = pinnedAgentCacheKey()
+  if (sharedPinnedAgent && sharedPinnedAgent.key === key) return sharedPinnedAgent.agent
+  sharedPinnedAgent?.agent.destroy()
+  sharedPinnedAgent = { key, agent: createPinnedAgent() }
+  return sharedPinnedAgent.agent
+}
+
+/** Drop the shared agent (tests; and any future explicit pin reload). */
+export function resetSharedPinnedAgent(): void {
+  sharedPinnedAgent?.agent.destroy()
+  sharedPinnedAgent = null
+}
+
 export function getPinnedCertificateHashes(): readonly string[] {
   const pins = [...getConfiguredPinnedCertificateHashes()]
   if (!isPinningDisabled() && hasPlaceholderHashes(pins)) {

--- a/apps/desktop/src/main/sync/http-client.test.ts
+++ b/apps/desktop/src/main/sync/http-client.test.ts
@@ -37,6 +37,7 @@ import {
   postToServer,
   getFromServer,
   deleteFromServer,
+  resetSyncVaultHeadersCache,
   SyncServerError,
   NetworkError,
   RateLimitError,
@@ -57,9 +58,18 @@ const createJsonResponse = (
   } as unknown as Response
 }
 
+const lastRequestHeaders = (): Record<string, string> => {
+  const calls = mockFetch.mock.calls
+  return calls[calls.length - 1][1].headers as Record<string, string>
+}
+
 describe('http-client', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // The vault identity is cached per DataDb handle for the process lifetime,
+    // and mockDb is one shared object, so without this every test after the
+    // first would silently read the previous test's cached value.
+    resetSyncVaultHeadersCache()
     mockGetDatabase.mockReturnValue(mockDb)
     mockGetOrCreateVaultUuid.mockReturnValue('vault-1')
   })
@@ -279,6 +289,76 @@ describe('http-client', () => {
         // its own message rather than the generic unreachable one.
         message: 'errors:sync.requestTimedOut'
       })
+    })
+  })
+
+  describe('vault identity header', () => {
+    it('resolves the vault uuid once and reuses it across authenticated requests', async () => {
+      // #given the vault uuid is a session-stable SQLite row that used to be
+      // re-read (drizzle query build + statement) on every request
+      mockFetch.mockResolvedValue(createJsonResponse({ success: true }))
+
+      // #when
+      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
+      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
+      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
+
+      // #then one read, and every request still carries the identity
+      expect(mockGetOrCreateVaultUuid).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+      for (const call of mockFetch.mock.calls) {
+        expect((call[1].headers as Record<string, string>)['X-Memry-Vault-Id']).toBe('vault-1')
+      }
+    })
+
+    it('re-resolves when the vault handle is replaced by a vault switch', async () => {
+      // #given a request against the first vault
+      mockFetch.mockResolvedValue(createJsonResponse({ success: true }))
+      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
+
+      // #when openVault installs a new DataDb instance for a different vault
+      const otherDb = { name: 'other-db' }
+      mockGetDatabase.mockReturnValue(otherDb)
+      mockGetOrCreateVaultUuid.mockReturnValue('vault-2')
+      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
+
+      // #then the new vault's identity is used, not the cached one
+      expect(mockGetOrCreateVaultUuid).toHaveBeenLastCalledWith(otherDb)
+      expect(lastRequestHeaders()['X-Memry-Vault-Id']).toBe('vault-2')
+    })
+
+    it('re-resolves after an in-place adoption invalidates the cache', async () => {
+      // #given a request before adoption
+      mockFetch.mockResolvedValue(createJsonResponse({ success: true }))
+      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
+      expect(lastRequestHeaders()['X-Memry-Vault-Id']).toBe('vault-1')
+
+      // #when adoptVaultLocally rewrites the uuid on the SAME handle and
+      // invalidates the cache
+      mockGetOrCreateVaultUuid.mockReturnValue('adopted-vault')
+      resetSyncVaultHeadersCache()
+      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
+
+      // #then registration and every later request bind to the adopted vault
+      expect(lastRequestHeaders()['X-Memry-Vault-Id']).toBe('adopted-vault')
+    })
+
+    it('does not cache a miss while no vault is open', async () => {
+      // #given getDatabase() throws until a vault is opened
+      mockFetch.mockResolvedValue(createJsonResponse({ success: true }))
+      mockGetDatabase.mockImplementation(() => {
+        throw new Error('Database not initialized')
+      })
+
+      // #when
+      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
+
+      // #then no identity header, and nothing poisoned for the next attempt
+      expect(lastRequestHeaders()['X-Memry-Vault-Id']).toBeUndefined()
+
+      mockGetDatabase.mockReturnValue(mockDb)
+      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
+      expect(lastRequestHeaders()['X-Memry-Vault-Id']).toBe('vault-1')
     })
   })
 

--- a/apps/desktop/src/main/sync/http-client.ts
+++ b/apps/desktop/src/main/sync/http-client.ts
@@ -70,14 +70,43 @@ export function parseRetryAfterHeader(header: string | null): number | undefined
   return undefined
 }
 
+// The vault UUID is one SQLite row that is stable for as long as a vault stays
+// open, yet it was re-read — through a freshly built drizzle query — on every
+// authenticated request and every WebSocket connect. Cache it against the
+// DataDb instance `getDatabase()` hands back: opening, closing or switching a
+// vault installs a new instance (see database/client.ts initDatabase), so the
+// key misses on its own and no vault switch can be served a stale identity.
+// The one rewrite that keeps the same handle — a linked device adopting the
+// initiator's uuid — calls resetSyncVaultHeadersCache() explicitly.
+let cachedVaultHeaders: Record<string, string> | null = null
+let cachedVaultHeadersDb: unknown = null
+
+/** Invalidate after an in-place rewrite of the vault_metadata singleton. */
+export function resetSyncVaultHeadersCache(): void {
+  cachedVaultHeaders = null
+  cachedVaultHeadersDb = null
+}
+
 export async function getSyncVaultHeaders(): Promise<Record<string, string>> {
   try {
+    // The imports stay inside the call: hoisting them to module scope would
+    // pull ../database in at import time, which is exactly the eagerness the
+    // lazy resolution in this file exists to avoid. They resolve from the
+    // module registry after the first call; the SQLite read is what this
+    // cache removes.
     const [{ getDatabase }, { getOrCreateVaultUuid }] = await Promise.all([
       import('../database'),
       import('../agent/storage/vault-id')
     ])
-    const vaultId = getOrCreateVaultUuid(getDatabase())
-    return vaultId ? { 'X-Memry-Vault-Id': vaultId } : {}
+    const db = getDatabase()
+    if (cachedVaultHeaders && cachedVaultHeadersDb === db) return cachedVaultHeaders
+    const vaultId = getOrCreateVaultUuid(db)
+    const headers: Record<string, string> = vaultId ? { 'X-Memry-Vault-Id': vaultId } : {}
+    // Frozen because every caller now receives this same instance.
+    Object.freeze(headers)
+    cachedVaultHeaders = headers
+    cachedVaultHeadersDb = db
+    return headers
   } catch {
     return {}
   }

--- a/apps/desktop/src/main/sync/vault-adoption.ts
+++ b/apps/desktop/src/main/sync/vault-adoption.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm'
 
 import type { DataDb } from '../database/types'
 import { VAULT_KEY_VERIFIER_SETTING } from '../crypto/vault-key-state'
+import { resetSyncVaultHeadersCache } from './http-client'
 import { createLogger } from '../lib/logger'
 
 const logger = createLogger('Sync:VaultAdoption')
@@ -26,5 +27,10 @@ export function adoptVaultLocally(db: DataDb, vaultUuid: string): void {
             updated_at = excluded.updated_at`
     )
   })
+  // The adopted uuid replaces the local one on the SAME database handle, so the
+  // handle-keyed cache in http-client would keep stamping the pre-adoption
+  // identity on every authenticated request — including the device registration
+  // that immediately follows.
+  resetSyncVaultHeadersCache()
   logger.info('Adopted shared vault identity for linked device', { vaultUuid })
 }

--- a/apps/desktop/src/main/sync/websocket.test.ts
+++ b/apps/desktop/src/main/sync/websocket.test.ts
@@ -25,7 +25,7 @@ const { MockWebSocket, getInstances, resetInstances } = vi.hoisted(() => {
 
     constructor(
       public url: string,
-      public options?: { headers?: Record<string, string> }
+      public options?: { headers?: Record<string, string>; agent?: unknown }
     ) {
       super()
       instances.push(this)
@@ -138,6 +138,25 @@ describe('WebSocketManager', () => {
 
       await vi.advanceTimersByTimeAsync(2_000)
       expect(getInstances().length).toBe(3)
+    })
+
+    it('#then reuses one pinned agent across reconnects', async () => {
+      // #given a wss endpoint, so the pinned agent is actually attached
+      const manager = new WebSocketManager(
+        createMockDeps({ serverUrl: 'https://sync.memrynote.com' })
+      )
+
+      // #when the socket drops and the manager reconnects
+      await manager.connect()
+      const firstAgent = lastWs().options?.agent
+      lastWs().simulateOpen()
+      lastWs().simulateClose()
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      // #then the reconnect did not allocate a second agent
+      expect(getInstances().length).toBe(2)
+      expect(firstAgent).toBeDefined()
+      expect(lastWs().options?.agent).toBe(firstAgent)
     })
   })
 

--- a/apps/desktop/src/main/sync/websocket.ts
+++ b/apps/desktop/src/main/sync/websocket.ts
@@ -2,7 +2,7 @@ import WebSocket from 'ws'
 import { EventEmitter } from 'events'
 import { z } from 'zod'
 import { createLogger } from '../lib/logger'
-import { createPinnedAgent, CertificatePinningError } from './certificate-pinning'
+import { getSharedPinnedAgent, CertificatePinningError } from './certificate-pinning'
 import { getSyncVaultHeaders } from './http-client'
 import { trackMainEvent } from '../telemetry/track'
 
@@ -120,7 +120,7 @@ export class WebSocketManager extends EventEmitter {
         'X-App-Version': this.deps.getAppVersion(),
         ...vaultHeaders
       },
-      agent: wsUrl.startsWith('wss://') ? createPinnedAgent() : undefined
+      agent: wsUrl.startsWith('wss://') ? getSharedPinnedAgent() : undefined
     })
 
     this.ws = ws

--- a/apps/desktop/src/main/test-hooks.ts
+++ b/apps/desktop/src/main/test-hooks.ts
@@ -7,6 +7,7 @@ import { yDocToMarkdown } from './sync/blocknote-converter'
 import { getCrdtProvider, resetCrdtProvider } from './sync/crdt-provider'
 import { getWritebackDebugState } from './sync/crdt-writeback'
 import { getCrdtQueue, getNetworkMonitor, startSyncRuntime } from './sync/runtime'
+import { resetSyncVaultHeadersCache } from './sync/http-client'
 import { getDatabase } from './database'
 import { sql } from 'drizzle-orm'
 import { getNoteMetadataById } from '@memry/storage-data'
@@ -276,6 +277,9 @@ export function registerTestHooks(): void {
               vault_uuid = excluded.vault_uuid,
               updated_at = excluded.updated_at`
       )
+      // Same in-place rewrite adoptVaultLocally performs, so drop the
+      // handle-keyed vault-header cache for the same reason.
+      resetSyncVaultHeadersCache()
 
       const deviceId = await persistKeysAndRegisterDevice(
         Buffer.from(input.masterKeyBase64, 'base64'),

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -439,6 +439,14 @@ Names are encrypted client-side by `encryptVaultName` (AAD bound to the vault UU
 locally; the server never sees a plaintext vault name. Registration is authenticated but does not
 require the vault to have synced any items, so a freshly created vault still appears in the directory.
 
+Every authenticated sync call — and the WebSocket handshake — stamps the active vault's UUID into
+`X-Memry-Vault-Id`. That UUID is a single `vault_metadata` row, so it is resolved once and cached
+against the open data-database handle rather than re-read per request. Opening, closing or switching
+a vault installs a new handle and therefore misses the cache on its own; the one rewrite that keeps
+the same handle — a linked device adopting the initiator's vault identity — invalidates it
+explicitly, so device registration and the first sync bind to the adopted vault, never the
+pre-adoption one.
+
 Desktop reads the directory over IPC:
 
 | IPC method                                     | Purpose                                                                                              |
@@ -513,6 +521,22 @@ The renewal hook belongs to the running sync runtime, not to the token manager: 
 it at start and detaches it at stop. A refresh that lands after a vault switch or sign-out therefore
 renews nothing instead of reaching into a torn-down socket and CRDT queue, and the runtime that
 replaces it installs its own hook.
+
+### Certificate pinning on the socket
+
+A `wss://` socket connects through a pinned `https.Agent`. One agent is shared for the process
+rather than rebuilt per reconnect: the agent holds nothing between connects (`keepAlive` is off, and
+the WebSocket upgrade detaches its socket), so a fresh one per reconnect only produced garbage.
+
+Sharing does not freeze the pin. The check lives in the agent's `checkServerIdentity`, which
+resolves the connecting hostname's pins from `certificate-pins.ts` on **every** TLS handshake — an
+updated pin table applies to the next handshake with no restart and no cache flush. Only the two
+decisions made when the agent is constructed are cached with it: whether pinning is disabled
+(unpackaged dev/test builds) and whether the configured host still carries placeholder pins. Both
+form the cache key, so a change in either destroys the cached agent and builds a new one.
+
+A pin mismatch is terminal for the session: the manager latches `certificate_pin_failed`, stops
+reconnecting, and requires an app restart.
 
 ## Vault-Key Verification
 


### PR DESCRIPTION
Closes #1096. Part of epic #987 (memory/CPU audit 2026-08).

Both halves verified still live on current `main` (`f4a5dd4f7`) before implementing — neither was silently fixed by the MEDIUM batch.

## What was wrong

**1. A new pinned `https.Agent` on every WebSocket reconnect** — `sync/websocket.ts:123`

```ts
agent: wsUrl.startsWith('wss://') ? createPinnedAgent() : undefined
```

`connect()` runs on every reconnect, and `createPinnedAgent()` (`sync/certificate-pinning.ts:77`) builds a fresh `https.Agent` each time. The previous one is dropped when `cleanup()` nulls `this.ws` — churn, not a leak, but pure waste: the agent has `keepAlive` off and the WebSocket upgrade detaches its socket (`agentRemove`), so it owns nothing between connects.

**2. The vault UUID re-read from SQLite on every authenticated request** — `sync/http-client.ts:73-84`, called from `http-client.ts:123`, `websocket.ts:115`, `attachments.ts:180`

```ts
const [{ getDatabase }, { getOrCreateVaultUuid }] = await Promise.all([...])
const vaultId = getOrCreateVaultUuid(getDatabase())
return vaultId ? { 'X-Memry-Vault-Id': vaultId } : {}
```

`getOrCreateVaultUuid` builds a drizzle query and runs a `SELECT` against the `vault_metadata` singleton. That row is stable for as long as a vault stays open, yet it was re-resolved per request, per WS connect and per attachment transfer.

## What changed

**Shared pinned agent** (`certificate-pinning.ts`) — new `getSharedPinnedAgent()` / `resetSharedPinnedAgent()`; `websocket.ts` calls the former. `createPinnedAgent()` is untouched and still builds a fresh agent for any caller that passes explicit pins.

**How a pin update still takes effect** — this was the main design constraint. The pin check is *not* baked into the agent. It lives in `checkServerIdentity`, which resolves the connecting hostname's pins from `certificate-pins.ts` on **every** TLS handshake:

```ts
const effectivePins = pins ? [...pins] : [...getPinnedCertificateHashesForHostname(hostname)]
```

So a reused agent verifies exactly what a fresh one would, and an updated pin table applies to the very next handshake — no restart, no cache flush. Only the two branches `createPinnedAgent` decides at construction time are frozen into the instance: whether pinning is disabled (unpackaged dev/test) and whether the configured host still carries placeholder pins. **Both form the cache key** (`isPinningDisabled()` + the configured pin list), so if either flips, the cached agent is `destroy()`ed and rebuilt rather than silently reused under a stale decision. A test asserts the update-takes-effect property directly against an already-shared agent.

The `certificate_pin_failed` latch is unchanged: a mismatch still stops reconnects for the session.

**Cached vault identity** (`http-client.ts`) — the resolved header object is cached against the `DataDb` instance `getDatabase()` returns. `initDatabase()` installs a new instance on every vault open/switch (`database/client.ts:40-74`), so a vault switch misses the cache on its own — there is no way to serve another vault's identity. The returned object is frozen, since every caller now receives the same instance.

The one rewrite that keeps the same handle is `adoptVaultLocally()` (linked device adopting the initiator's vault UUID) — it now calls `resetSyncVaultHeadersCache()` inside the same function, so the device registration that immediately follows binds to the adopted vault. The E2E `bootstrapSyncDevice` hook performs the same in-place rewrite in raw SQL and invalidates alongside it.

**Deliberately not done:**

- The two dynamic `import()`s stay *inside* `getSyncVaultHeaders()`. Hoisting them to module scope would pull `../database` in at import time, which is precisely the eagerness the lazy resolution in this file exists to avoid (see the `resolveSyncServerUrl` comment at `http-client.ts:105`). They resolve from the module registry after the first call; the SQLite read is what actually cost anything, and that is what the cache removes.
- No caching inside `getOrCreateVaultUuid()` itself. That would speed up eight more call sites (canvas, crypto handlers, device registration) but widens the blast radius of a stale read well past this issue.
- No `agent.destroy()` on the WS teardown path — the upgraded socket is already detached from the agent, so there is nothing there to destroy.

## How it was proven

Mutation test: the two cache reads were disabled (`if (false && …)`) while every test file was left exactly as committed, then restored and byte-verified identical against the saved diff.

| | `http-client.test.ts` + `certificate-pinning.test.ts` + `websocket.test.ts` |
| --- | --- |
| Cache disabled (pre-fix behaviour) | **3 failed \| 90 passed (93)** |
| Fix in place | **93 passed (93)** |

The three that flip:

- `websocket.test.ts` → *reuses one pinned agent across reconnects* — drives a real `connect()` → close → reconnect against a `wss://` endpoint and asserts `options.agent` is the same object. Pre-fix: `expected Agent{…} to be Agent{…} // Object.is equality`.
- `http-client.test.ts` → *resolves the vault uuid once and reuses it across authenticated requests* — pre-fix: `expected "vi.fn()" to be called 1 times, but got 3 times`.
- `certificate-pinning.test.ts` → *hands back the same agent instance*.

Guard tests that hold in both directions (correctness, not perf):

- *an updated pin table applies to the already-shared agent* — calls `checkServerIdentity` on one shared agent, gets a `CertificatePinningError` for an untrusted cert, mutates the host's pin entry, and gets `undefined` from the **same** agent. This is the security claim above, asserted rather than argued.
- *the pinning decision flips → rebuilds and destroys the stale agent*.
- *re-resolves when the vault handle is replaced by a vault switch*.
- *re-resolves after an in-place adoption invalidates the cache*.
- *does not cache a miss while no vault is open* (a `getDatabase()` throw must not poison the next attempt).

## Verification

```
pnpm --filter @memry/desktop typecheck:node      → clean (no output)
pnpm exec vitest run --project main \
  http-client certificate-pinning websocket vault-adoption \
  test-hooks device-registration attachments runtime linking-service
                                                → Test Files 9 passed (9), Tests 168 passed (168)
pnpm exec eslint <8 changed files>              → 0 errors (3 "file ignored" warnings: *.test.ts are lint-ignored by config)
pnpm exec prettier --check <8 changed files>    → All matched files use Prettier code style!
pnpm check:architecture                         → architecture boundary check passed
pnpm check:contracts                            → contracts boundary check passed
git diff --check                                → clean
pnpm docs:impact --base origin/main --strict    → docs impact: covered against origin/main
pnpm docs:build                                 → build complete in 8.21s
```

No renderer files touched, so `typecheck:web` was not run. No IPC contract change, so `ipc:generate`/`ipc:check` do not apply.

## Backward compatibility

Wire format, DB schema, IPC contracts and settings shapes are all unchanged — `X-Memry-Vault-Id` and the pinned TLS handshake carry exactly the same values as before, just resolved once instead of per request; existing installs and older peers are unaffected.
