### PR TITLE
fix(onboarding): tear the first-run tour down when the hook unmounts

### DIFF
--- a/apps/desktop/src/renderer/src/components/onboarding/use-first-run-tour.test.tsx
+++ b/apps/desktop/src/renderer/src/components/onboarding/use-first-run-tour.test.tsx
@@ -1,7 +1,9 @@
+import { StrictMode } from 'react'
 import { renderHook } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const driveSpy = vi.fn()
+const destroySpy = vi.fn()
 type TourStep = {
   element?: string
   onHighlightStarted?: () => void
@@ -13,7 +15,14 @@ let capturedConfig: TourConfig | undefined
 vi.mock('driver.js', () => ({
   driver: (config: TourConfig) => {
     capturedConfig = config
-    return { drive: driveSpy }
+    // Mirror driver.js: destroy() runs the onDestroyed hook.
+    return {
+      drive: driveSpy,
+      destroy: () => {
+        destroySpy()
+        config.onDestroyed?.()
+      }
+    }
   }
 }))
 vi.mock('driver.js/dist/driver.css', () => ({}))
@@ -28,6 +37,7 @@ describe('useFirstRunTour', () => {
   beforeEach(() => {
     localStorage.clear()
     driveSpy.mockClear()
+    destroySpy.mockClear()
     capturedConfig = undefined
     // jsdom lacks matchMedia
     vi.stubGlobal(
@@ -127,5 +137,72 @@ describe('useFirstRunTour', () => {
     expect(dayClick).toHaveBeenCalledTimes(1)
 
     document.body.innerHTML = ''
+  })
+
+  describe('cleanup', () => {
+    /**
+     * Real rAF semantics: a queued callback runs on the next frame unless it is
+     * cancelled first. `flush()` runs only the frames that survived.
+     */
+    const deferFrames = (): (() => void) => {
+      const pending = new Map<number, FrameRequestCallback>()
+      let nextHandle = 0
+      vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+        nextHandle += 1
+        pending.set(nextHandle, cb)
+        return nextHandle
+      })
+      vi.stubGlobal('cancelAnimationFrame', (handle: number) => {
+        pending.delete(handle)
+      })
+      return () => {
+        const frames = [...pending.values()]
+        pending.clear()
+        frames.forEach((cb) => cb(0))
+      }
+    }
+
+    it('cancels the queued frame when unmounted before the tour starts', () => {
+      const flush = deferFrames()
+
+      const { unmount } = renderHook(() => useFirstRunTour())
+      unmount()
+      flush()
+
+      expect(driveSpy).not.toHaveBeenCalled()
+    })
+
+    it('destroys the driver instance when unmounted while the tour is running', () => {
+      const { unmount } = renderHook(() => useFirstRunTour())
+      expect(driveSpy).toHaveBeenCalledTimes(1)
+
+      unmount()
+
+      expect(destroySpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not record the tour as seen when unmount is what tore it down', () => {
+      const announced = vi.fn()
+      window.addEventListener(STAR_PROMPT_EVENT, announced)
+
+      const { unmount } = renderHook(() => useFirstRunTour())
+      unmount()
+
+      expect(localStorage.getItem(TOUR_KEY)).toBeNull()
+      expect(localStorage.getItem(STAR_PROMPT_KEY)).toBeNull()
+      expect(announced).not.toHaveBeenCalled()
+
+      window.removeEventListener(STAR_PROMPT_EVENT, announced)
+    })
+
+    it('still starts exactly one tour when effects are double-invoked', () => {
+      const flush = deferFrames()
+
+      renderHook(() => useFirstRunTour(), { wrapper: StrictMode })
+      flush()
+
+      expect(driveSpy).toHaveBeenCalledTimes(1)
+      expect(localStorage.getItem(TOUR_KEY)).toBeNull()
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/components/onboarding/use-first-run-tour.ts
+++ b/apps/desktop/src/renderer/src/components/onboarding/use-first-run-tour.ts
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react'
-import { driver, type DriveStep } from 'driver.js'
+import { useEffect } from 'react'
+import { driver, type DriveStep, type Driver } from 'driver.js'
 import 'driver.js/dist/driver.css'
 import './tour.css'
 import { useT } from '@memry/i18n/renderer'
@@ -19,12 +19,20 @@ export const TOUR_KEY = 'memry:onboarding:tour:v1'
 export function useFirstRunTour(): void {
   const { t } = useT('common')
   const { open: openDayPanel } = useDayPanel()
-  const startedRef = useRef(false)
 
+  // Mount-scoped on purpose. The effect owns a live driver.js instance, so it
+  // must not be torn down and rebuilt just because react-i18next handed back a
+  // new `t` (it does on a language change): that would restart a running tour
+  // from step 1. The labels the tour needs are read once, when it is built.
   useEffect(() => {
-    if (startedRef.current) return
     if (localStorage.getItem(TOUR_KEY)) return
-    startedRef.current = true
+
+    // driver.js appends an overlay <svg> to <body> and attaches its own
+    // resize/scroll/keydown listeners; only destroy() takes those back down.
+    let tour: Driver | undefined
+    // Set by the cleanup so onDestroyed can tell an unmount-driven teardown from
+    // the user finishing, skipping, or closing the tour.
+    let unmounted = false
 
     // Open the right Day Panel so its calendar + Agent steps have live targets,
     // even for returning users whose saved layout has it closed.
@@ -154,12 +162,12 @@ export function useFirstRunTour(): void {
 
     // Defer one frame so the just-opened Day Panel has mounted before we test
     // for each step's target element.
-    requestAnimationFrame(() => {
+    const frame = requestAnimationFrame(() => {
       const visibleSteps = steps.filter(
         (step) => typeof step.element !== 'string' || document.querySelector(step.element) !== null
       )
 
-      const tour = driver({
+      tour = driver({
         showProgress: true,
         progressText,
         nextBtnText: t('onboarding.tour.next'),
@@ -175,6 +183,10 @@ export function useFirstRunTour(): void {
           popover.closeButton.setAttribute('aria-label', t('button.close'))
         },
         onDestroyed: () => {
+          // destroy() also runs on unmount, and that is not the user answering:
+          // leave the flag and the star prompt untouched so the tour still gets
+          // its one run, exactly as it did before this cleanup existed.
+          if (unmounted) return
           // ponytail: localStorage, app-wide once; move to a per-vault setting if we ever need to re-show per vault
           localStorage.setItem(TOUR_KEY, '1')
           // The tour lands here however it ended — finished, skipped, or closed —
@@ -189,5 +201,12 @@ export function useFirstRunTour(): void {
 
       tour.drive()
     })
-  }, [t, openDayPanel])
+
+    return () => {
+      unmounted = true
+      cancelAnimationFrame(frame)
+      tour?.destroy()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-scoped, see above
+  }, [])
 }

--- a/apps/docs/src/guide/first-run.md
+++ b/apps/docs/src/guide/first-run.md
@@ -100,6 +100,8 @@ All the heavy data is **encrypted at rest** with the vault key. The salt and ver
 
 After setup, memrynote shows a brief in-app tour pointing out the sidebar, tabs, and search. Click through or skip — you can revisit it via the keyboard shortcuts dialog.
 
+The tour counts as seen once you finish it, skip it, or close it. If it never got that far — you quit the app while the tour was still on screen — it is not counted, and memrynote offers it again on the next launch. Either way it opens the right-hand Day Panel so the calendar and Agent steps have something to point at, and leaves it open afterwards.
+
 ## Next Steps
 
 - Take [a Tour of memrynote](/guide/tour)


### PR DESCRIPTION
Closes #1100. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/components/onboarding/use-first-run-tour.ts` — the effect returned no cleanup. Two leaks fall out of that:

```ts
    requestAnimationFrame(() => {          // handle discarded
      const tour = driver({ ... })         // never destroy()ed
      tour.drive()
    })
  }, [t, openDayPanel])
```

1. **Orphaned rAF.** The handle was thrown away, so a frame queued right before unmount still ran and built a whole tour against a dead tree.
2. **driver.js instance never destroyed.** `driver()` appends an overlay `<svg>` to `<body>` and attaches its own window `resize`/`scroll`/`keydown` listeners (`driver.js@1.6.0`). Only `destroy()` takes those back down, so an unmount mid-tour left a click-blocking overlay and its listeners attached for the life of the window. That is also the shape the E2E helper works around today (`apps/desktop/tests/e2e/utils/electron-helpers.ts:225` — "its full-screen overlay intercepts pointer events").

Confirmed still live on `origin/main` @ `f4a5dd4f7` — the MEDIUM batch (#1209–#1250) did not touch this file.

## What changed

- The effect now returns a cleanup that `cancelAnimationFrame(frame)` and `tour?.destroy()`.
- `destroy()` runs driver.js's `onDestroyed` hook (verified in `driver.js.mjs`: `destroy: () => g(!1)`, and `g` calls `r("onDestroyed")`). That hook is where the once-per-install flag and the GitHub-star prompt are persisted, so the persistence is now guarded by an `unmounted` flag. **An unmount is not the user finishing, skipping, or closing the tour**, and must not burn the one run. This keeps first-run behaviour identical to today, where an unmount also left the flag unset.
- Deps drop to `[]` and `startedRef` goes away. Once a cleanup exists, keeping `[t, openDayPanel]` would destroy and rebuild a *running* tour every time react-i18next hands back a new `t` (it does on a language change), restarting it from step 1. With `[]`, the only re-run is React's dev-mode StrictMode double-invoke, which the new cleanup handles correctly (cancel the pending frame, re-arm) — that is exactly what `startedRef` used to guard, so it is now redundant.

**Deliberately not done:** the issue also flags `openDayPanel()` as "a side effect with no undo". Left alone. Opening the Day Panel is a documented product decision (the tour needs live targets for its calendar + Agent steps), the provider persists that state to `localStorage`, and snapping the panel shut when the tour ends would fight the layout the user was just shown. Reverting it is a UX change, not a leak fix, and out of scope here. It is now written down in the docs instead.

Per the epic caution: **when and whether the tour is shown is unchanged.** The `localStorage.getItem(TOUR_KEY)` gate, the `TOUR_KEY` value, and every persistence path are untouched. The E2E helper's Escape-then-set-flag dismissal still goes through the user path (`unmounted === false`), so it still persists.

## How it was proven

Same test file both runs; only `use-first-run-tour.ts` was reverted to `origin/main` between them (`git checkout origin/main -- <file>`).

**Before the fix — 2 failed | 9 passed:**

```
FAIL  cleanup > cancels the queued frame when unmounted before the tour starts
  expected "vi.fn()" to not be called at all, but actually been called 1 times
FAIL  cleanup > destroys the driver instance when unmounted while the tour is running
  expected "vi.fn()" to be called 1 times, but got 0 times
```

**After the fix — 11 passed | 0 failed.**

The rAF test models real `requestAnimationFrame` semantics (a queued callback runs on the next frame *unless cancelled*) rather than asserting on the mock: it keeps a pending-handle map, lets `cancelAnimationFrame` delete from it, and after unmount flushes only the frames that survived. The driver mock now mirrors the library — `destroy()` runs `onDestroyed` — so the "does not record the tour as seen" assertion exercises the real hook logic, not a stub.

Four tests added:
- cancels the queued frame when unmounted before the tour starts
- destroys the driver instance when unmounted while the tour is running
- does not record the tour as seen when unmount is what tore it down (`TOUR_KEY` null, star prompt unarmed, no `STAR_PROMPT_EVENT`)
- still starts exactly one tour when effects are double-invoked (regression guard for dropping `startedRef`; renders under `StrictMode`)

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts \
  --project renderer apps/desktop/src/renderer/src/components/onboarding/
  -> Test Files 2 passed (2) - Tests 18 passed (18)

pnpm --filter @memry/desktop typecheck:web      -> clean, no output
pnpm exec eslint .../use-first-run-tour.ts      -> clean, 0 problems
git diff --check                                -> clean
pnpm docs:impact --base origin/main --strict    -> docs impact: covered
pnpm docs:build                                 -> build complete in 5.97s
```

Not run: bare `pnpm test` (~8 min, blocks the shared runner) and the E2E suite.

## Backward compatibility

No schema, contract, IPC, settings, or sync-shape change; `TOUR_KEY`/`STAR_PROMPT_KEY` names, values, and write conditions are identical, so existing installs that have already seen the tour still skip it and those that have not still get exactly one run.
