### PR TITLE
fix(notifications): release reminder notification closures and de-duplicate snooze banners

### DIFF
--- a/apps/desktop/src/main/lib/reminders.test.ts
+++ b/apps/desktop/src/main/lib/reminders.test.ts
@@ -102,6 +102,11 @@ class MockNotification {
   emit(event: string, ...args: unknown[]): void {
     this.handlers[event]?.(...args)
   }
+
+  removeAllListeners(): this {
+    this.handlers = {}
+    return this
+  }
 }
 
 let remindersService: typeof import('./reminders')
@@ -684,6 +689,129 @@ describe('reminders service', () => {
         'Failed to remove delivered notification for reminder rem-nc6:',
         removeError
       )
+    })
+  })
+
+  describe('live notification lifecycle', () => {
+    const fireDueReminder = (id: string): MockNotification => {
+      seedReminder({
+        id,
+        targetType: 'note',
+        targetId: 'note-1',
+        remindAt: '2000-01-01T00:00:00.000Z',
+        status: reminderStatus.PENDING
+      })
+      remindersService.startReminderScheduler()
+      remindersService.stopReminderScheduler()
+      return notificationInstances[notificationInstances.length - 1]!
+    }
+
+    it('detaches the listeners holding the reminder once the banner is clicked', () => {
+      const notification = fireDueReminder('rem-live-click')
+      expect(Object.keys(notification.handlers)).toEqual(
+        expect.arrayContaining(['click', 'close', 'failed'])
+      )
+
+      notification.emit('click')
+
+      // Navigation still happened, but nothing keeps the ReminderWithTarget alive.
+      expect(window.webContents.send).toHaveBeenCalledWith(
+        ReminderChannels.events.CLICKED,
+        expect.objectContaining({ reminder: expect.objectContaining({ id: 'rem-live-click' }) })
+      )
+      expect(Object.keys(notification.handlers)).toEqual([])
+    })
+
+    it('detaches the listeners when the banner is closed by the OS', () => {
+      const notification = fireDueReminder('rem-live-close')
+
+      notification.emit('close')
+
+      expect(Object.keys(notification.handlers)).toEqual([])
+      // Already released: a later in-app dismiss must not re-close it.
+      remindersService.dismissReminder('rem-live-close')
+      expect(notification.close).not.toHaveBeenCalled()
+    })
+
+    it('closes the live banner on in-app dismiss where Notification.remove does not exist', () => {
+      setPlatform('win32')
+      const notification = fireDueReminder('rem-live-win')
+
+      remindersService.dismissReminder('rem-live-win')
+
+      expect(notification.close).toHaveBeenCalledTimes(1)
+      expect(MockNotification.remove).not.toHaveBeenCalled()
+      expect(Object.keys(notification.handlers)).toEqual([])
+    })
+
+    it('closes the live banner on in-app snooze', () => {
+      setPlatform('win32')
+      const notification = fireDueReminder('rem-live-snooze')
+
+      remindersService.snoozeReminder({
+        id: 'rem-live-snooze',
+        snoozeUntil: new Date(Date.now() + 60 * 60 * 1000).toISOString()
+      })
+
+      expect(notification.close).toHaveBeenCalledTimes(1)
+      expect(Object.keys(notification.handlers)).toEqual([])
+    })
+
+    it('supersedes its own earlier banner when the same reminder fires again', () => {
+      setPlatform('win32')
+      const first = fireDueReminder('rem-live-again')
+
+      // Snoozed then due once more: the same reminder id fires a second time.
+      dataDb.db
+        .update(reminders)
+        .set({ status: reminderStatus.PENDING })
+        .where(eq(reminders.id, 'rem-live-again'))
+        .run()
+      remindersService.startReminderScheduler()
+      remindersService.stopReminderScheduler()
+
+      const second = notificationInstances[notificationInstances.length - 1]!
+      expect(second).not.toBe(first)
+      expect(first.close).toHaveBeenCalledTimes(1)
+      expect(Object.keys(first.handlers)).toEqual([])
+      // The replacement is live and clickable.
+      expect(second.close).not.toHaveBeenCalled()
+      expect(Object.keys(second.handlers)).toContain('click')
+    })
+
+    it('keeps a failed delivery from leaving a tracked notification behind', () => {
+      setPlatform('win32')
+      const notification = fireDueReminder('rem-live-failed')
+
+      notification.emit('failed', {}, new Error('delivery failed'))
+
+      expect(Object.keys(notification.handlers)).toEqual([])
+      remindersService.dismissReminder('rem-live-failed')
+      expect(notification.close).not.toHaveBeenCalled()
+    })
+
+    it('evicts the oldest tracked notifications past the cap without closing them', () => {
+      // 51 unactioned banners: one past the 50-entry ceiling.
+      for (let index = 0; index < 51; index += 1) {
+        seedReminder({
+          id: `rem-cap-${index}`,
+          targetType: 'note',
+          targetId: 'note-1',
+          remindAt: `2000-01-01T00:00:${String(index).padStart(2, '0')}.000Z`,
+          status: reminderStatus.PENDING
+        })
+      }
+
+      remindersService.startReminderScheduler()
+      remindersService.stopReminderScheduler()
+
+      expect(notificationInstances).toHaveLength(51)
+      const evicted = notificationInstances[0]!
+      const retained = notificationInstances[50]!
+      expect(Object.keys(evicted.handlers)).toEqual([])
+      expect(Object.keys(retained.handlers)).toContain('click')
+      // Eviction only drops the handle — the banner itself is left on screen.
+      expect(evicted.close).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/desktop/src/main/lib/reminders.ts
+++ b/apps/desktop/src/main/lib/reminders.ts
@@ -61,6 +61,25 @@ const MINUTE_TICK_ID = 'reminders'
 /** Last value handed to the OS badge, so an idle tick skips the native call. */
 let lastBadgeCount: number | null = null
 
+/**
+ * Reminder notifications that are still alive, keyed by reminder id.
+ *
+ * Two jobs: (1) an in-app dismiss/snooze can pull its own banner down on
+ * Windows/Linux, where the macOS-only `Notification.remove` is a no-op, and
+ * (2) the `click`/`failed` listeners — which capture the whole
+ * `ReminderWithTarget` — get detached once the banner's life is over instead of
+ * being held for as long as the OS keeps the notification around.
+ */
+const liveNotifications = new Map<string, Notification>()
+
+/**
+ * Ceiling on tracked notifications. `close` is not guaranteed on every platform
+ * (macOS can park a banner in Notification Center indefinitely), so the map is
+ * evicted oldest-first rather than trusted to drain on its own. Far above any
+ * plausible number of unactioned reminder banners.
+ */
+const MAX_LIVE_NOTIFICATIONS = 50
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -239,6 +258,49 @@ function createReminderInboxItem(reminder: ReminderWithTarget): void {
 }
 
 /**
+ * Stop tracking a reminder's notification: detach its listeners (releasing the
+ * captured `ReminderWithTarget`) and, when asked, dismiss the banner too.
+ *
+ * `dismissBanner` is only ever set for an explicit user action on that exact
+ * reminder (clicking it, or dismissing/snoozing it in-app) — never on a timer —
+ * so a banner the user has not looked at yet is left on screen.
+ *
+ * @param reminderId - Stable reminder id used as the notification id
+ * @param dismissBanner - Also close the on-screen notification
+ */
+function releaseNotification(reminderId: string, dismissBanner = false): void {
+  const notification = liveNotifications.get(reminderId)
+  if (!notification) return
+
+  liveNotifications.delete(reminderId)
+
+  if (dismissBanner) {
+    try {
+      notification.close()
+    } catch (error) {
+      logger.warn(`Failed to close notification for reminder ${reminderId}:`, error)
+    }
+  }
+
+  notification.removeAllListeners()
+}
+
+/**
+ * Track a shown notification, evicting the oldest entries past the cap so a run
+ * of never-actioned banners cannot grow the map without bound. An evicted entry
+ * only loses its click handler; the banner itself stays where the OS put it.
+ */
+function trackNotification(reminderId: string, notification: Notification): void {
+  liveNotifications.set(reminderId, notification)
+
+  while (liveNotifications.size > MAX_LIVE_NOTIFICATIONS) {
+    const oldest = liveNotifications.keys().next().value
+    if (oldest === undefined) break
+    releaseNotification(oldest)
+  }
+}
+
+/**
  * Show a desktop notification for a due reminder
  * @param reminder - The reminder that is due
  */
@@ -268,6 +330,11 @@ function showDesktopNotification(reminder: ReminderWithTarget): void {
     body = typeLabels[reminder.targetType] || t('notification.reminder.fallback')
   }
 
+  // A reminder that fires a second time (snoozed, then due again) supersedes its
+  // own earlier banner rather than leaving a stale one — and its listeners —
+  // behind. Scoped to this one reminder id, so nothing else on screen is touched.
+  releaseNotification(reminder.id, true)
+
   try {
     const notification = new Notification({
       // Electron 42+: a stable per-reminder id lets a delivered banner be cleared
@@ -286,12 +353,22 @@ function showDesktopNotification(reminder: ReminderWithTarget): void {
     // destruction, and any access to one throws "Object has been destroyed" —
     // which would kill the click with nothing focused and nothing navigated.
     notification.on('click', () => {
+      // Clicking consumes the banner, so drop the tracking (and with it this
+      // closure's hold on `reminder`) before doing the navigation work.
+      releaseNotification(reminder.id)
       const win = BrowserWindow.getAllWindows().find((candidate) => !candidate.isDestroyed())
       if (!win) return
       if (win.isMinimized()) win.restore()
       win.focus()
       // Emit event to navigate to the reminder target
       win.webContents.send(ReminderChannels.events.CLICKED, { reminder })
+    })
+
+    // The banner is gone (user swiped it away, or the toast timed out into the
+    // Windows Action Center) — nothing left to click, so let the captured
+    // reminder go. Not emitted on every platform, hence the cap on the map.
+    notification.on('close', () => {
+      releaseNotification(reminder.id)
     })
 
     // Electron 42+ routes macOS notifications through UNUserNotificationCenter:
@@ -301,9 +378,12 @@ function showDesktopNotification(reminder: ReminderWithTarget): void {
     notification.on('failed', (_event, error) => {
       logger.error(`Desktop notification failed for reminder ${reminder.id}:`, error)
       trackMainError('reminders', 'reminder_notification_failed', error)
+      // Nothing was ever shown, so there is no banner to keep a handle on.
+      releaseNotification(reminder.id)
     })
 
     notification.show()
+    trackNotification(reminder.id, notification)
     logger.debug(`Showed desktop notification for reminder ${reminder.id}`)
   } catch (error) {
     logger.error('Failed to show desktop notification:', error)
@@ -315,9 +395,15 @@ function showDesktopNotification(reminder: ReminderWithTarget): void {
  * Remove a delivered notification banner for a reminder from Notification
  * Center. `Notification.remove` is Electron 42+ and only implemented on
  * macOS — everywhere else this is a silent no-op.
+ *
+ * Called after the user has dismissed or snoozed that reminder in-app, so
+ * closing its own still-live notification is the point, not a side effect:
+ * on Windows/Linux `close()` is the only way to retire the banner at all.
  * @param reminderId - Stable reminder id used as the notification id
  */
 function removeDeliveredNotification(reminderId: string): void {
+  releaseNotification(reminderId, true)
+
   if (process.platform !== 'darwin') return
   if (typeof Notification.remove !== 'function') return
 

--- a/apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx
@@ -317,26 +317,66 @@ describe('more major hooks coverage', () => {
     expect(mocks.requestPermission).toHaveBeenCalled()
 
     const callback = mocks.onInboxSnoozeDue.mock.calls[0][0] as (event: {
-      items: Array<{ title: string }>
+      items: Array<{ id: string; title: string }>
     }) => void
     ;(Notification as unknown as { permission: string }).permission = 'granted'
-    callback({ items: [{ title: 'Read paper' }] })
+    callback({ items: [{ id: 'item-a', title: 'Read paper' }] })
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['inbox', 'lists'] })
     expect(Notification).toHaveBeenCalledWith('Read paper', {
       body: 'Your snoozed item is ready for review',
-      icon: '/icon.png'
+      icon: '/icon.png',
+      tag: 'inbox-snooze-due:item-a'
     })
     expect(mocks.toastInfo).toHaveBeenCalledWith('"Read paper" is back from snooze')
 
-    callback({ items: [{ title: 'One' }, { title: 'Two' }] })
+    callback({
+      items: [
+        { id: 'item-b', title: 'One' },
+        { id: 'item-c', title: 'Two' }
+      ]
+    })
     expect(Notification).toHaveBeenCalledWith('2 snoozed items', {
       body: 'Your snoozed items are ready',
-      icon: '/icon.png'
+      icon: '/icon.png',
+      tag: 'inbox-snooze-due:item-b,item-c'
     })
     expect(mocks.toastInfo).toHaveBeenCalledWith('2 snoozed items are back')
 
     callback({ items: [] })
     expect(invalidate).toHaveBeenCalledTimes(2)
+  })
+
+  it('tags snooze notifications by resurfaced item id so concurrent mounts collapse to one banner', () => {
+    // Split view (or a second window) mounts the inbox page twice, and the
+    // snooze-due event is delivered to every subscriber.
+    renderHook(() => useInboxNotifications(), { wrapper: queryWrapper() })
+    renderHook(() => useInboxNotifications(), { wrapper: queryWrapper() })
+
+    type SnoozeCallback = (event: { items: Array<{ id: string; title: string }> }) => void
+    const first = mocks.onInboxSnoozeDue.mock.calls[0][0] as SnoozeCallback
+    const second = mocks.onInboxSnoozeDue.mock.calls[1][0] as SnoozeCallback
+    ;(Notification as unknown as { permission: string }).permission = 'granted'
+
+    // Same resurface, different sources, and item order is not guaranteed.
+    const dueItems = [
+      { id: 'item-2', title: 'Read paper' },
+      { id: 'item-1', title: 'Read paper' }
+    ]
+    first({ items: dueItems })
+    second({ items: [...dueItems].reverse() })
+
+    const tags = (
+      Notification as unknown as { mock: { calls: [string, { tag: string }][] } }
+    ).mock.calls.map(([, options]) => options.tag)
+    expect(tags).toEqual(['inbox-snooze-due:item-1,item-2', 'inbox-snooze-due:item-1,item-2'])
+
+    // A genuinely new resurface sharing the same title is still its own banner.
+    first({ items: [{ id: 'item-3', title: 'Read paper' }] })
+    expect(Notification).toHaveBeenLastCalledWith('Read paper', {
+      body: 'Your snoozed item is ready for review',
+      icon: '/icon.png',
+      tag: 'inbox-snooze-due:item-3'
+    })
   })
 
   it('loads project, month entries, and year stats query hooks', async () => {

--- a/apps/desktop/src/renderer/src/hooks/use-inbox-notifications.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-inbox-notifications.ts
@@ -18,7 +18,17 @@ export function useInboxNotifications(): void {
           const title = count === 1 ? dueItems[0].title : `${count} snoozed items`
           const body =
             count === 1 ? 'Your snoozed item is ready for review' : 'Your snoozed items are ready'
-          new Notification(title, { body, icon: '/icon.png' })
+          // The snooze-due event is broadcast to every window, and the inbox page
+          // can be mounted more than once inside one window (split view), so a
+          // single resurface would otherwise raise one banner per mount. Tagging
+          // by the exact set of resurfaced item ids makes the OS collapse those
+          // into one banner, while a genuinely different resurface — different
+          // ids, even with an identical title — still gets a banner of its own.
+          const tag = `inbox-snooze-due:${dueItems
+            .map((item) => item.id)
+            .sort()
+            .join(',')}`
+          new Notification(title, { body, icon: '/icon.png', tag })
         }
 
         toast.info(

--- a/apps/docs/src/user-guide/inbox/snooze-archive.md
+++ b/apps/docs/src/user-guide/inbox/snooze-archive.md
@@ -38,6 +38,8 @@ without one timer per row.
 
 When wake fires, the item appears at the top of the active inbox. If memrynote isn't running, the item appears next time the app opens.
 
+If the inbox is open — including in more than one pane or window — you also get a single system notification for that wake, not one per open inbox. A later wake for different items always gets its own notification, even when the titles happen to match.
+
 ## Archive
 
 Archived items leave the active inbox but stay in your vault. They're still:

--- a/apps/docs/src/user-guide/snooze-reminders.md
+++ b/apps/docs/src/user-guide/snooze-reminders.md
@@ -58,7 +58,7 @@ memrynote shows a toast with:
 - Title and snippet
 - Action buttons (snooze 5 min, snooze 10 min, custom snooze, open, dismiss)
 
-A system notification is shown as well. On macOS, dismissing or snoozing the reminder also removes its delivered banner from Notification Center, so handled reminders don't pile up there.
+A system notification is shown as well. Dismissing or snoozing the reminder also retires its system notification — on macOS it is removed from Notification Center, and on Windows and Linux the banner is closed — so handled reminders don't pile up. If a snoozed reminder comes due again, its new notification replaces the earlier one for that reminder instead of stacking a second banner. Notifications you haven't acted on are never dismissed for you.
 
 Dismissing or snoozing a reminder syncs to your other devices, so a reminder you've handled on one device won't fire again on another. Each device still shows its own toast and system notification locally when the reminder's time arrives.
 


### PR DESCRIPTION
Closes #1099. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

**1. `apps/desktop/src/main/lib/reminders.ts` — notification listeners hold the reminder for the OS's lifetime.**

Every due reminder built a `Notification`, attached `click` + `failed` listeners that close over the whole `ReminderWithTarget`, and then dropped the handle:

```ts
notification.on('click', () => {
  …
  win.webContents.send(ReminderChannels.events.CLICKED, { reminder }) // captures `reminder`
})
notification.on('failed', (_event, error) => { … })
notification.show()   // no handle kept, listeners never detached
```

Nothing ever detached those listeners, so each fired reminder pinned its target snapshot (title, note, `highlightText`, …) for as long as the OS kept the notification alive. The only cleanup path, `removeDeliveredNotification`, is guarded by `process.platform !== 'darwin'` and `Notification.remove` — a no-op on Windows and Linux, where there was no way to retire a banner at all. A reminder that was snoozed and came due again also stacked a second live notification for the same id.

**2. `apps/desktop/src/renderer/src/hooks/use-inbox-notifications.ts:21` — one OS banner per mount.**

```ts
new Notification(title, { body, icon: '/icon.png' })
```

No `tag`. The `inbox:snooze-due` event is fanned out with `broadcastToAllWindows` (`apps/desktop/src/main/inbox/snooze.ts:401`), and `useInboxNotifications()` runs inside `InboxPage`, which `TabContent` mounts once per pane — so split view, or a second window, raises N identical banners for a single wake.

## What changed

**Main process.** A `liveNotifications` map keyed by reminder id now holds each shown notification. `releaseNotification(id)` detaches the listeners (freeing the captured `ReminderWithTarget`); `releaseNotification(id, true)` also closes the banner. It is called on `click`, on `close`, on `failed`, when the same reminder fires again, and from `removeDeliveredNotification` — which means an in-app dismiss/snooze now retires the banner on **Windows and Linux** too, not just macOS. The map is capped at 50 entries, evicted oldest-first, because `close` is not guaranteed on every platform (macOS can park a banner in Notification Center forever) and an unbounded map in a long-lived main process would just relocate the leak. Eviction only drops the click handler; it never closes a banner.

**No TTL close.** `close()` is only ever reached from an explicit user action on that exact reminder (clicking it, or dismissing/snoozing it in-app) or when that same reminder id supersedes itself. A banner the user has not looked at is never dismissed by a timer, on unmount, or on app quit.

**Renderer.** The snooze-due banner now carries `tag: inbox-snooze-due:<sorted due item ids>`. De-duplication identity is **the exact set of resurfaced inbox item ids**, not the title or the count: concurrent mounts receive the same event, so they produce the same tag and the OS collapses them into one banner, while a later wake for different items produces a different tag and gets its own banner — even when the titles are identical (`{id: item-3, title: 'Read paper'}` still notifies after `{id: item-1, title: 'Read paper'}`). Sorting makes it order-independent.

**Deliberately not done:**

- The issue's suggested fix says to "drop the renderer duplicate (single notification source in main)". That premise is wrong — the renderer banner is for inbox **snooze-wake**, and no main-process notification exists for it (`processDueItems` only emits the IPC event). Deleting it would remove the only OS notification for a resurfaced item. Moving it into main would also newly notify users who do not have the inbox open, which is a behavior expansion outside this issue.
- No renderer-side `close()`/`useRef` handle. The renderer notification attaches no handlers and captures nothing, so it has no retention to fix; adding a ref would only add one. Its defect was duplication, which `tag` fixes at the layer designed for it.
- `stopReminderScheduler()` does not flush the map — it only runs on app quit (`apps/desktop/src/main/index.ts:2052`), where releasing is moot.

## How it was proven

Both source files reverted with `git checkout origin/main -- <file>` (never `git stash`), tests kept:

| Suite | Before fix | After fix |
| --- | --- | --- |
| `main` → `apps/desktop/src/main/lib/reminders.test.ts` | **7 failed**, 46 passed (53) | **53 passed** (53) |
| `renderer` → `apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx` | **2 failed**, 6 passed (8) | **8 passed** (8) |

New coverage: listener detachment on click / OS close / failed delivery, `close()` on in-app dismiss and snooze under `win32` (where `Notification.remove` is unavailable), same-reminder supersede, 51-banner cap eviction, and the renderer tag identity across two concurrent mounts plus the same-title-different-id case.

## Verification

```
pnpm --filter @memry/desktop typecheck:node   → clean
pnpm --filter @memry/desktop typecheck:web    → clean
pnpm exec eslint <4 changed files>            → 0 errors (2 "file ignored" warnings; test globs are eslint-ignored repo-wide)
vitest run --project main    …/reminders.test.ts           → 53 passed
vitest run --project renderer …/more-major-hooks.test.tsx  → 8 passed
git diff --check                              → clean
pnpm docs:impact --base origin/main --strict  → covered
pnpm docs:build                               → build complete
```

## Backward compatibility

No schema, contract, IPC, settings, or sync-payload changes — main-process notification bookkeeping and one added web-Notification `tag`, both entirely runtime-local, so existing installs are unaffected.
