### PR TITLE
perf(hint-mode): bind the capture keydown listener once per mount

### DIFF
--- a/apps/desktop/src/renderer/src/contexts/hint-mode/context.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/hint-mode/context.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { act, render, renderHook } from '@testing-library/react'
+import { memo } from 'react'
+import {
+  HintModeProvider,
+  useHintModeActions,
+  useHintModeContext,
+  useHintModeState,
+  type HintModeActions
+} from '@/contexts/hint-mode'
+
+const mockRect: DOMRect = {
+  x: 10,
+  y: 10,
+  width: 100,
+  height: 30,
+  top: 10,
+  left: 10,
+  bottom: 40,
+  right: 110,
+  toJSON: () => ({})
+} as DOMRect
+
+const addButton = (text: string): HTMLButtonElement => {
+  const btn = document.createElement('button')
+  btn.textContent = text
+  btn.getBoundingClientRect = () => mockRect
+  Object.defineProperty(btn, 'offsetParent', { value: document.body, configurable: true })
+  document.body.appendChild(btn)
+  return btn
+}
+
+describe('hint mode state/action contexts', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('keeps actions-only consumers out of the hint keystroke render path', () => {
+    addButton('Tags')
+    addButton('Tasks')
+
+    let actionsRenders = 0
+    let stateRenders = 0
+    const actionsSeen: HintModeActions[] = []
+
+    const ActionsOnly = memo(function ActionsOnly(): null {
+      actionsSeen.push(useHintModeActions())
+      actionsRenders += 1
+      return null
+    })
+
+    const StateOnly = memo(function StateOnly(): null {
+      useHintModeState()
+      stateRenders += 1
+      return null
+    })
+
+    render(
+      <HintModeProvider>
+        <ActionsOnly />
+        <StateOnly />
+      </HintModeProvider>
+    )
+
+    expect(actionsRenders).toBe(1)
+    expect(stateRenders).toBe(1)
+
+    const actions = actionsSeen[0]
+
+    act(() => actions.activate())
+    expect(stateRenders).toBe(2)
+    expect(actionsRenders).toBe(1)
+
+    act(() => actions.typeChar('T'))
+    expect(stateRenders).toBe(3)
+    expect(actionsRenders).toBe(1)
+
+    act(() => actions.backspace())
+    expect(stateRenders).toBe(4)
+    expect(actionsRenders).toBe(1)
+
+    act(() => actions.deactivate())
+    expect(stateRenders).toBe(5)
+    expect(actionsRenders).toBe(1)
+
+    // Same bundle throughout: this identity is what lets the global keydown
+    // listener bind once instead of per keystroke.
+    expect(actionsSeen).toHaveLength(1)
+  })
+
+  it('exposes stable action identities while the state object changes', () => {
+    addButton('Tags')
+    addButton('Tasks')
+
+    const { result } = renderHook(
+      () => ({ state: useHintModeState(), actions: useHintModeActions() }),
+      { wrapper: HintModeProvider }
+    )
+
+    const firstState = result.current.state
+    const firstActions = result.current.actions
+
+    act(() => result.current.actions.activate())
+    expect(result.current.state).not.toBe(firstState)
+    expect(result.current.actions).toBe(firstActions)
+    expect(result.current.actions.activate).toBe(firstActions.activate)
+    expect(result.current.actions.typeChar).toBe(firstActions.typeChar)
+    expect(result.current.actions.backspace).toBe(firstActions.backspace)
+    expect(result.current.actions.deactivate).toBe(firstActions.deactivate)
+
+    const activeState = result.current.state
+    act(() => result.current.actions.typeChar('T'))
+    expect(result.current.state).not.toBe(activeState)
+    expect(result.current.actions).toBe(firstActions)
+  })
+
+  it('composes useHintModeContext from both contexts', () => {
+    addButton('Tags')
+    addButton('Tasks')
+
+    const { result, rerender } = renderHook(() => useHintModeContext(), {
+      wrapper: HintModeProvider
+    })
+
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+
+    act(() => result.current.activate())
+    expect(result.current).not.toBe(first)
+    expect(result.current.state.isActive).toBe(true)
+    expect(result.current.activate).toBe(first.activate)
+  })
+
+  it('throws when the hooks are used outside the provider', () => {
+    expect(() => renderHook(() => useHintModeState())).toThrow(
+      'useHintModeState must be inside HintModeProvider'
+    )
+    expect(() => renderHook(() => useHintModeActions())).toThrow(
+      'useHintModeActions must be inside HintModeProvider'
+    )
+    expect(() => renderHook(() => useHintModeContext())).toThrow(
+      'useHintModeState must be inside HintModeProvider'
+    )
+  })
+})

--- a/apps/desktop/src/renderer/src/contexts/hint-mode/context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/hint-mode/context.tsx
@@ -1,5 +1,14 @@
-import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react'
-import type { HintModeState, HintModeContextType } from './types'
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  useCallback,
+  useEffect,
+  type ReactNode
+} from 'react'
+import type { HintModeState, HintModeActions, HintModeContextType } from './types'
 import { scanClickableElements } from '@/lib/dom-scanner'
 import { assignLabels } from '@/lib/label-assigner'
 import { hintModeActiveRef } from './active-ref'
@@ -10,10 +19,23 @@ const INITIAL_STATE: HintModeState = {
   typedChars: ''
 }
 
-const HintModeContext = createContext<HintModeContextType | null>(null)
+// State and actions live in separate contexts: the state object changes on every
+// typed hint character, the action bundle never does. Consumers that only need
+// the actions (the global keydown listener) stay out of that render path.
+const HintModeStateContext = createContext<HintModeState | null>(null)
+const HintModeActionsContext = createContext<HintModeActions | null>(null)
 
 export const HintModeProvider = ({ children }: { children: ReactNode }): React.JSX.Element => {
   const [state, setState] = useState<HintModeState>(INITIAL_STATE)
+
+  // Latest committed state, read inside the actions so each one keeps a stable
+  // identity across renders (same pattern as use-keyboard-shortcuts-base.ts).
+  // Synced in an effect, not during render, so the actions observe exactly the
+  // value the previous closures would have captured.
+  const stateRef = useRef(state)
+  useEffect(() => {
+    stateRef.current = state
+  }, [state])
 
   const deactivate = useCallback(() => {
     hintModeActiveRef.current = false
@@ -21,7 +43,7 @@ export const HintModeProvider = ({ children }: { children: ReactNode }): React.J
   }, [])
 
   const activate = useCallback(() => {
-    if (state.isActive) {
+    if (stateRef.current.isActive) {
       deactivate()
       return
     }
@@ -32,13 +54,13 @@ export const HintModeProvider = ({ children }: { children: ReactNode }): React.J
     const hints = assignLabels(elements)
     hintModeActiveRef.current = true
     setState({ isActive: true, hints, typedChars: '' })
-  }, [state.isActive, deactivate])
+  }, [deactivate])
 
   const typeChar = useCallback(
     (char: string) => {
       const upper = char.toUpperCase()
-      const next = state.typedChars + upper
-      const matching = state.hints.filter((h) => h.label.startsWith(next))
+      const next = stateRef.current.typedChars + upper
+      const matching = stateRef.current.hints.filter((h) => h.label.startsWith(next))
 
       if (matching.length === 0) return
 
@@ -52,7 +74,7 @@ export const HintModeProvider = ({ children }: { children: ReactNode }): React.J
 
       setState((prev) => ({ ...prev, typedChars: next }))
     },
-    [state.typedChars, state.hints, deactivate]
+    [deactivate]
   )
 
   const backspace = useCallback(() => {
@@ -68,13 +90,32 @@ export const HintModeProvider = ({ children }: { children: ReactNode }): React.J
     }
   }, [])
 
-  const value: HintModeContextType = { state, activate, deactivate, typeChar, backspace }
+  const actions = useMemo<HintModeActions>(
+    () => ({ activate, deactivate, typeChar, backspace }),
+    [activate, deactivate, typeChar, backspace]
+  )
 
-  return <HintModeContext.Provider value={value}>{children}</HintModeContext.Provider>
+  return (
+    <HintModeActionsContext.Provider value={actions}>
+      <HintModeStateContext.Provider value={state}>{children}</HintModeStateContext.Provider>
+    </HintModeActionsContext.Provider>
+  )
+}
+
+export const useHintModeState = (): HintModeState => {
+  const state = useContext(HintModeStateContext)
+  if (!state) throw new Error('useHintModeState must be inside HintModeProvider')
+  return state
+}
+
+export const useHintModeActions = (): HintModeActions => {
+  const actions = useContext(HintModeActionsContext)
+  if (!actions) throw new Error('useHintModeActions must be inside HintModeProvider')
+  return actions
 }
 
 export const useHintModeContext = (): HintModeContextType => {
-  const ctx = useContext(HintModeContext)
-  if (!ctx) throw new Error('useHintModeContext must be inside HintModeProvider')
-  return ctx
+  const state = useHintModeState()
+  const actions = useHintModeActions()
+  return useMemo(() => ({ state, ...actions }), [state, actions])
 }

--- a/apps/desktop/src/renderer/src/contexts/hint-mode/index.ts
+++ b/apps/desktop/src/renderer/src/contexts/hint-mode/index.ts
@@ -1,3 +1,8 @@
-export { HintModeProvider, useHintModeContext } from './context'
+export {
+  HintModeProvider,
+  useHintModeContext,
+  useHintModeState,
+  useHintModeActions
+} from './context'
 export { hintModeActiveRef } from './active-ref'
-export type { HintTarget, HintModeState, HintModeContextType } from './types'
+export type { HintTarget, HintModeState, HintModeActions, HintModeContextType } from './types'

--- a/apps/desktop/src/renderer/src/contexts/hint-mode/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/hint-mode/types.ts
@@ -11,10 +11,13 @@ export interface HintModeState {
   typedChars: string
 }
 
-export interface HintModeContextType {
-  state: HintModeState
+export interface HintModeActions {
   activate: () => void
   deactivate: () => void
   typeChar: (char: string) => void
   backspace: () => void
+}
+
+export interface HintModeContextType extends HintModeActions {
+  state: HintModeState
 }

--- a/apps/desktop/src/renderer/src/hooks/use-hint-activation.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-hint-activation.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, act, fireEvent } from '@testing-library/react'
-import { type ReactNode } from 'react'
+import { renderHook, act, fireEvent, render } from '@testing-library/react'
+import { memo, type ReactNode } from 'react'
 import { HintModeProvider, useHintModeContext } from '@/contexts/hint-mode'
 import { useHintActivation } from '@/hooks/use-hint-activation'
 
@@ -201,5 +201,305 @@ describe('HintModeProvider', () => {
     input.focus()
     fireEvent.keyDown(window, { key: 'Escape' })
     expect(document.activeElement).not.toBe(input)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Regression guard for the listener/context stabilisation (issue #1101).
+  // `routes` below must stay byte-identical before and after that change: it is
+  // the proof that stabilising the capture-phase listener did not move a single
+  // key between "hint mode swallows it" and "hint mode lets it through".
+  // ---------------------------------------------------------------------------
+
+  interface Routed {
+    prevented: boolean
+    reachedDocument: boolean
+    isActive: boolean
+    typedChars: string
+    inputFocused: boolean
+  }
+
+  const keydownCalls = (spy: ReturnType<typeof vi.spyOn>): number =>
+    spy.mock.calls.filter((call) => call[0] === 'keydown').length
+
+  it('routes every key to the same outcome, active and inactive', () => {
+    const tags = addButton('Tags')
+    addButton('Tasks')
+    const tagsClick = vi.spyOn(tags, 'click')
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    // Dispatch target below `window` so a capture-phase stopPropagation() is
+    // observable: window capture runs first, document capture only if allowed.
+    const surface = document.createElement('div')
+    document.body.appendChild(surface)
+
+    const { result } = renderHook(
+      () => {
+        useHintActivation()
+        return useHintModeContext()
+      },
+      { wrapper }
+    )
+
+    const routes: Record<string, Routed> = {}
+    const route = (name: string, init: Record<string, unknown>): void => {
+      let reachedDocument = false
+      const probe = (): void => {
+        reachedDocument = true
+      }
+      document.addEventListener('keydown', probe, true)
+      const notPrevented = fireEvent.keyDown(surface, init)
+      document.removeEventListener('keydown', probe, true)
+      routes[name] = {
+        prevented: !notPrevented,
+        reachedDocument,
+        isActive: result.current.state.isActive,
+        typedChars: result.current.state.typedChars,
+        inputFocused: document.activeElement === input
+      }
+    }
+
+    // --- hint mode inactive -------------------------------------------------
+    route('composing f', { key: 'f', code: 'KeyF', isComposing: true })
+    route('ime f (keyCode 229)', { key: 'f', code: 'KeyF', keyCode: 229 })
+    route('meta+f', { key: 'f', code: 'KeyF', metaKey: true })
+    route('ctrl+f', { key: 'f', code: 'KeyF', ctrlKey: true })
+    route('shift+f', { key: 'F', code: 'KeyF', shiftKey: true })
+    route('plain a', { key: 'a', code: 'KeyA' })
+    route('escape, nothing focused', { key: 'Escape', code: 'Escape' })
+    input.focus()
+    route('plain f, input focused', { key: 'f', code: 'KeyF' })
+    route('escape, input focused', { key: 'Escape', code: 'Escape' })
+    route('plain f, input blurred', { key: 'f', code: 'KeyF' })
+
+    // --- hint mode active ---------------------------------------------------
+    route('active: no-match z', { key: 'z', code: 'KeyZ' })
+    route('active: t narrows', { key: 't', code: 'KeyT' })
+    route('active: backspace', { key: 'Backspace', code: 'Backspace' })
+    route('active: meta+a', { key: 'a', code: 'KeyA', metaKey: true })
+    route('active: ctrl+a', { key: 'a', code: 'KeyA', ctrlKey: true })
+    route('active: alt+a', { key: 'a', code: 'KeyA', altKey: true })
+    route('active: tab', { key: 'Tab', code: 'Tab' })
+    route('active: escape deactivates', { key: 'Escape', code: 'Escape' })
+
+    // --- alt+F re-entry, through to a unique match --------------------------
+    route('alt+f re-activates', { key: 'F', code: 'KeyF', altKey: true })
+    route('active: t narrows again', { key: 't', code: 'KeyT' })
+    route('active: a picks TA', { key: 'a', code: 'KeyA' })
+
+    expect(routes).toEqual({
+      'composing f': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: false,
+        typedChars: '',
+        inputFocused: false
+      },
+      'ime f (keyCode 229)': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: false,
+        typedChars: '',
+        inputFocused: false
+      },
+      'meta+f': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: false,
+        typedChars: '',
+        inputFocused: false
+      },
+      'ctrl+f': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: false,
+        typedChars: '',
+        inputFocused: false
+      },
+      'shift+f': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: false,
+        typedChars: '',
+        inputFocused: false
+      },
+      'plain a': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: false,
+        typedChars: '',
+        inputFocused: false
+      },
+      'escape, nothing focused': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: false,
+        typedChars: '',
+        inputFocused: false
+      },
+      'plain f, input focused': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: false,
+        typedChars: '',
+        inputFocused: true
+      },
+      'escape, input focused': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: false,
+        typedChars: '',
+        inputFocused: false
+      },
+      'plain f, input blurred': {
+        prevented: true,
+        reachedDocument: false,
+        isActive: true,
+        typedChars: '',
+        inputFocused: false
+      },
+      'active: no-match z': {
+        prevented: true,
+        reachedDocument: false,
+        isActive: true,
+        typedChars: '',
+        inputFocused: false
+      },
+      'active: t narrows': {
+        prevented: true,
+        reachedDocument: false,
+        isActive: true,
+        typedChars: 'T',
+        inputFocused: false
+      },
+      'active: backspace': {
+        prevented: true,
+        reachedDocument: false,
+        isActive: true,
+        typedChars: '',
+        inputFocused: false
+      },
+      'active: meta+a': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: true,
+        typedChars: '',
+        inputFocused: false
+      },
+      'active: ctrl+a': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: true,
+        typedChars: '',
+        inputFocused: false
+      },
+      'active: alt+a': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: true,
+        typedChars: '',
+        inputFocused: false
+      },
+      'active: tab': {
+        prevented: false,
+        reachedDocument: true,
+        isActive: true,
+        typedChars: '',
+        inputFocused: false
+      },
+      'active: escape deactivates': {
+        prevented: true,
+        reachedDocument: false,
+        isActive: false,
+        typedChars: '',
+        inputFocused: false
+      },
+      'alt+f re-activates': {
+        prevented: true,
+        reachedDocument: false,
+        isActive: true,
+        typedChars: '',
+        inputFocused: false
+      },
+      'active: t narrows again': {
+        prevented: true,
+        reachedDocument: false,
+        isActive: true,
+        typedChars: 'T',
+        inputFocused: false
+      },
+      'active: a picks TA': {
+        prevented: true,
+        reachedDocument: false,
+        isActive: false,
+        typedChars: '',
+        inputFocused: false
+      }
+    } satisfies Record<string, Routed>)
+
+    expect(tagsClick).toHaveBeenCalledOnce()
+  })
+
+  it('binds the capture-phase keydown listener once for a whole hint session', () => {
+    addButton('Tags')
+    addButton('Tasks')
+
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+
+    try {
+      const { result, unmount } = renderHook(
+        () => {
+          useHintActivation()
+          return useHintModeContext()
+        },
+        { wrapper }
+      )
+
+      expect(keydownCalls(addSpy)).toBe(1)
+
+      fireEvent.keyDown(window, { key: 'F', code: 'KeyF', altKey: true })
+      fireEvent.keyDown(window, { key: 't' })
+      fireEvent.keyDown(window, { key: 'Backspace' })
+      fireEvent.keyDown(window, { key: 't' })
+      fireEvent.keyDown(window, { key: 'Escape' })
+
+      expect(result.current.state.isActive).toBe(false)
+      // Before the fix this was 6 adds / 5 removes: every state change rebuilt
+      // `typeChar`/`activate`, which were effect deps.
+      expect(keydownCalls(addSpy)).toBe(1)
+      expect(keydownCalls(removeSpy)).toBe(0)
+
+      unmount()
+      expect(keydownCalls(removeSpy)).toBe(1)
+    } finally {
+      addSpy.mockRestore()
+      removeSpy.mockRestore()
+    }
+  })
+
+  it('keeps the context value referentially stable across provider re-renders', () => {
+    let consumerRenders = 0
+
+    const Consumer = memo(function Consumer(): null {
+      useHintModeContext()
+      consumerRenders += 1
+      return null
+    })
+
+    const Host = ({ tick }: { tick: number }): React.JSX.Element => (
+      <HintModeProvider>
+        <span>{tick}</span>
+        <Consumer />
+      </HintModeProvider>
+    )
+
+    const { rerender } = render(<Host tick={0} />)
+    expect(consumerRenders).toBe(1)
+
+    // Provider re-renders (new children), hint state untouched. Before the fix
+    // the provider handed out a fresh value object here and every consumer
+    // re-rendered with it.
+    rerender(<Host tick={1} />)
+    expect(consumerRenders).toBe(1)
   })
 })

--- a/apps/desktop/src/renderer/src/hooks/use-hint-activation.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-hint-activation.ts
@@ -1,15 +1,20 @@
 import { useEffect } from 'react'
-import { useHintModeContext } from '@/contexts/hint-mode'
+import { hintModeActiveRef, useHintModeActions } from '@/contexts/hint-mode'
 import { isInputFocused } from '@/hooks/use-keyboard-shortcuts'
 
 export const useHintActivation = (): void => {
-  const { state, activate, deactivate, typeChar, backspace } = useHintModeContext()
+  // Actions only: the hint state object changes on every typed character, and
+  // subscribing to it here would re-render the whole app shell and tear the
+  // capture-phase window listener down and back up per keystroke. Active-ness is
+  // read from hintModeActiveRef, the same gate use-keyboard-shortcuts-base,
+  // use-chord-shortcuts and use-modifier-held already read at keypress time.
+  const { activate, deactivate, typeChar, backspace } = useHintModeActions()
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.isComposing || e.keyCode === 229) return
 
-      if (state.isActive) {
+      if (hintModeActiveRef.current) {
         if (e.key === 'Escape') {
           e.preventDefault()
           e.stopPropagation()
@@ -57,5 +62,5 @@ export const useHintActivation = (): void => {
 
     window.addEventListener('keydown', handleKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
-  }, [state.isActive, activate, deactivate, typeChar, backspace])
+  }, [activate, deactivate, typeChar, backspace])
 }

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -124,7 +124,12 @@ Hint mode overlays numeric badges on interactive elements so you can act without
 | ------------------ | ----------------------------------------- |
 | Activate hint mode | <kbd>F</kbd> or <kbd>⌥</kbd>+<kbd>F</kbd> |
 | Pick a target      | Type the number shown                     |
+| Undo a keystroke   | <kbd>Backspace</kbd>                      |
 | Exit               | <kbd>Esc</kbd>                            |
+
+Each keystroke narrows the badges in place, and <kbd>Backspace</kbd> takes back the
+last character you typed. Only the badge overlay repaints as you type, so hint mode
+stays responsive on screens with a lot of targets.
 
 ## Global Undo (Tasks)
 


### PR DESCRIPTION
Closes #1101. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

Confirmed still live on `origin/main` @ `f4a5dd4f7`.

`apps/desktop/src/renderer/src/contexts/hint-mode/context.tsx:71` built a fresh context value on every render:

```tsx
const value: HintModeContextType = { state, activate, deactivate, typeChar, backspace }
```

and `activate` / `typeChar` were rebuilt whenever `state` changed (`[state.isActive, deactivate]`, `[state.typedChars, state.hints, deactivate]`).

`apps/desktop/src/renderer/src/hooks/use-hint-activation.ts:60` listed those callbacks as effect deps:

```ts
}, [state.isActive, activate, deactivate, typeChar, backspace])
```

So every typed hint character tore down and re-registered the **capture-phase `window` keydown listener**. `useHintActivation()` is called from the top-level app shell component (`App.tsx:219`), and it subscribed to the hint state, so each keystroke also re-rendered the whole shell — not just the badge overlay.

Measured on the pre-fix code: a five-key hint session (`⌥F`, `t`, `Backspace`, `t`, `Esc`) produced **6 `addEventListener('keydown')` / 5 `removeEventListener`** calls.

## What changed

- `context.tsx` — split into `HintModeStateContext` (changes per keystroke) and `HintModeActionsContext` (a `useMemo`'d bundle that never changes). The actions read the latest committed state from a ref synced in an effect, the same pattern `use-keyboard-shortcuts-base.ts:87` already uses and for the same reason. The ref is synced **in an effect, not during render**, so the actions observe exactly the value the old closures captured.
- New `useHintModeState()` / `useHintModeActions()`. `useHintModeContext()` is kept and now composes both behind a `useMemo`, so existing consumers (`hint-overlay.tsx`, `hint-indicator.tsx`, tests) are untouched and its value is referentially stable when nothing changed.
- `use-hint-activation.ts` — subscribes to actions only, and reads active-ness from `hintModeActiveRef`. Effect deps are now all stable, so the listener binds once per mount.

Deliberately **not** done:
- Did not migrate `hint-overlay.tsx` / `hint-indicator.tsx` to `useHintModeState()`. They legitimately need the state and re-render on it either way; changing them would be noise.
- Did not touch `state.hints` holding raw `HTMLElement` refs. The issue notes these are released on deactivate and only retained while hint mode is active — that is correct behaviour, not a leak.
- Did not fix the pre-existing docs inaccuracy that hint badges are "numeric" (they are letters, see `label-assigner.ts`) — out of scope, reported separately.

### Why `hintModeActiveRef` and not `state.isActive`

This is a capture-phase global keydown handler, so the read source matters. `hintModeActiveRef` is already the app-wide gate for exactly this question — `use-keyboard-shortcuts-base.ts:95`, `use-chord-shortcuts.ts:244` and `use-modifier-held.ts:25` all read it at keypress time — and the provider is its only writer, setting it in lockstep with `state.isActive` (true only when activating with ≥1 hint, false on deactivate and on unmount). The only difference from `state.isActive` is that it is accurate synchronously rather than after commit, which is unobservable for native discrete key events since React flushes them before the next event.

## How it was proven

Source files reverted to `origin/main` with the new tests in place (`git checkout origin/main -- <sources>`, never `git stash`):

| | before | after |
|---|---|---|
| `use-hint-activation.test.tsx` | **2 failed, 11 passed (13)** | **13 passed** |
| all three hint-mode files | n/a (new API) | **19 passed (3 files)** |

The two that flipped:
- `binds the capture-phase keydown listener once for a whole hint session` — before: `expected 6 to be 1` adds. After: 1 add, 0 removes until unmount, 1 remove on unmount.
- `keeps the context value referentially stable across provider re-renders` — before: a `memo`'d consumer re-rendered on a provider re-render that changed no hint state (`expected 2 to be 1`). After: 1.

**Key-routing proof.** `routes every key to the same outcome, active and inactive` is a 21-row matrix that dispatches each key on a node *below* `window` and records, per key: `preventDefault` fired, whether the event survived to a `document` capture listener (i.e. whether `stopPropagation` swallowed it), the resulting `isActive` / `typedChars`, and whether the focused input stayed focused. It covers IME (`isComposing`, `keyCode 229`), `⌘/Ctrl/Shift/Alt+F`, plain `F` with and without an input focused, `Esc` blur-out-of-input, and in active mode: no-match keys, narrowing, `Backspace`, `⌘/Ctrl/Alt`-modified keys, `Tab`, `Esc`, and typing through to a unique match that clicks its target.

That test **passes byte-identically against `origin/main` sources and against this branch** — that is the evidence that nothing moved between "hint mode swallows it" and "hint mode lets it through".

Also re-ran the neighbouring consumers of `hintModeActiveRef`: `use-chord-shortcuts.test.tsx`, `use-modifier-held.test.ts`, `App.test.tsx`, `App.workspace-counts.test.tsx` — **20 passed (4 files)**.

## Verification

```
pnpm --filter @memry/desktop typecheck:web                        # clean, no output
pnpm exec vitest run --project renderer \
  src/renderer/src/hooks/use-hint-activation.test.tsx \
  src/renderer/src/contexts/hint-mode/context.test.tsx \
  src/renderer/src/components/hint-overlay/hint-overlay.test.tsx  # 19 passed (3 files)
pnpm exec vitest run --project renderer \
  use-chord-shortcuts / use-modifier-held / App / App.workspace-counts  # 20 passed (4 files)
pnpm exec eslint <6 changed files>                                # 0 errors
pnpm exec prettier --check <changed files>                        # all match
git diff --check                                                  # clean
pnpm docs:impact --base origin/main --strict                      # covered
pnpm docs:build                                                   # build complete in 6.54s
```

## Backward compatibility

Renderer-only. No schema, IPC contract, settings, sync or file-format change; `useHintModeContext()` keeps its exact shape and `HintModeContextType` is unchanged structurally (now `extends HintModeActions`), so nothing that reads hint mode needs to change.
