### PR TITLE
fix(undo): subscribe useUndoTracker to the stack and keep reads out of render

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-undo.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-undo.test.ts
@@ -492,3 +492,140 @@ describe('createUndoableAction', () => {
     expect(result).toEqual(newTask)
   })
 })
+
+// ============================================================================
+// Subscription / render-purity Tests
+// ============================================================================
+
+/** Matches UNDO_EXPIRY_MS in use-undo.ts */
+const UNDO_EXPIRY_MS = 10_000
+
+describe('useUndoTracker subscription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // The undo stack is module-global and only resets when the last tracker
+    // unmounts. Mount + unmount one to drain anything earlier tests left behind.
+    renderHook(() => useUndoTracker()).unmount()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('flips canUndo on an already-mounted tracker when an action is registered', () => {
+    const { result } = renderHook(() => useUndoTracker())
+    expect(result.current.canUndo).toBe(false)
+
+    act(() => {
+      result.current.registerUndo('Delete task', vi.fn())
+    })
+
+    expect(result.current.canUndo).toBe(true)
+    expect(result.current.lastActionDescription).toBe('Delete task')
+  })
+
+  it('notifies every mounted tracker, not just the one that registered', () => {
+    const { result: a } = renderHook(() => useUndoTracker())
+    const { result: b } = renderHook(() => useUndoTracker())
+
+    act(() => {
+      a.current.registerUndo('Archive project', vi.fn())
+    })
+
+    expect(b.current.canUndo).toBe(true)
+    expect(b.current.lastActionDescription).toBe('Archive project')
+  })
+
+  it('clears canUndo once the last entry is undone', () => {
+    const { result } = renderHook(() => useUndoTracker())
+
+    act(() => {
+      result.current.registerUndo('Delete task', vi.fn())
+    })
+    expect(result.current.canUndo).toBe(true)
+
+    act(() => {
+      result.current.undo()
+    })
+
+    expect(result.current.canUndo).toBe(false)
+    expect(result.current.lastActionDescription).toBeNull()
+  })
+
+  it('clears canUndo when the last entry is removed by ID', () => {
+    const { result } = renderHook(() => useUndoTracker())
+
+    let id = ''
+    act(() => {
+      id = result.current.registerUndo('Delete task', vi.fn())
+    })
+    expect(result.current.canUndo).toBe(true)
+
+    act(() => {
+      result.current.removeUndoEntry(id)
+    })
+
+    expect(result.current.canUndo).toBe(false)
+  })
+
+  it('updates a mounted tracker when Cmd+Z consumes the entry', () => {
+    Object.defineProperty(navigator, 'platform', { value: 'MacIntel', writable: true })
+
+    const { result } = renderHook(() => useUndoTracker())
+    const undoFn = vi.fn()
+
+    act(() => {
+      result.current.registerUndo('Delete task', undoFn)
+    })
+    expect(result.current.canUndo).toBe(true)
+
+    renderHook(() => useUndoKeyboardShortcut())
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', metaKey: true, bubbles: true }))
+    })
+
+    expect(undoFn).toHaveBeenCalledTimes(1)
+    expect(result.current.canUndo).toBe(false)
+  })
+
+  it('drops the entry on the expiry sweep and re-renders subscribers', () => {
+    vi.useFakeTimers()
+    const start = Date.now()
+
+    const { result } = renderHook(() => useUndoTracker())
+    act(() => {
+      result.current.registerUndo('Delete task', vi.fn())
+    })
+    expect(result.current.canUndo).toBe(true)
+
+    vi.setSystemTime(start + UNDO_EXPIRY_MS + 1)
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(result.current.canUndo).toBe(false)
+    expect(result.current.lastActionDescription).toBeNull()
+  })
+
+  it('does not mutate module state during render', () => {
+    vi.useFakeTimers()
+    const start = Date.now()
+
+    const { result, rerender } = renderHook(() => useUndoTracker())
+    act(() => {
+      result.current.registerUndo('Delete task', vi.fn())
+    })
+
+    // Wall clock passes the expiry window, but the 1s sweep has not run yet.
+    vi.setSystemTime(start + UNDO_EXPIRY_MS + 1)
+
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    rerender()
+
+    // Before the fix, render called getLastUndoEntry(), which filtered the
+    // module-level stack and stopped the cleanup interval mid-render.
+    expect(clearIntervalSpy).not.toHaveBeenCalled()
+    clearIntervalSpy.mockRestore()
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-undo.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-undo.ts
@@ -13,7 +13,7 @@
  * to the database. This is an acceptable limitation per the spec.
  */
 
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
 import { createLogger } from '@/lib/logger'
 import { toast } from 'sonner'
 import { useT } from '@memry/i18n/renderer'
@@ -47,13 +47,11 @@ let cleanupInterval: ReturnType<typeof setInterval> | null = null
 function startCleanupInterval() {
   if (cleanupInterval) return
   cleanupInterval = setInterval(() => {
-    const now = Date.now()
-    const hadEntries = globalUndoStack.length > 0
-    globalUndoStack = globalUndoStack.filter((entry) => now - entry.timestamp < UNDO_EXPIRY_MS)
+    const pruned = pruneExpiredEntries()
     if (globalUndoStack.length === 0) {
       stopCleanupInterval()
     }
-    if (hadEntries && globalUndoStack.length === 0) {
+    if (pruned) {
       notifyListeners()
     }
   }, 1000)
@@ -67,8 +65,66 @@ function stopCleanupInterval() {
   }
 }
 
+/**
+ * Immutable view of the stack that `useSyncExternalStore` renders from.
+ * Recomputed only inside `notifyListeners`, so `getUndoSnapshot` can stay pure
+ * and returns a referentially stable object between mutations (a fresh object
+ * on every read would make `useSyncExternalStore` loop forever).
+ */
+interface UndoSnapshot {
+  canUndo: boolean
+  lastActionDescription: string | null
+}
+
+let undoSnapshot: UndoSnapshot = { canUndo: false, lastActionDescription: null }
+
+function refreshSnapshot() {
+  const last = globalUndoStack[globalUndoStack.length - 1]
+  const canUndo = !!last
+  const lastActionDescription = last?.description ?? null
+  if (
+    undoSnapshot.canUndo === canUndo &&
+    undoSnapshot.lastActionDescription === lastActionDescription
+  ) {
+    return
+  }
+  undoSnapshot = { canUndo, lastActionDescription }
+}
+
+function getUndoSnapshot(): UndoSnapshot {
+  return undoSnapshot
+}
+
+function subscribeToUndoStack(listener: () => void): () => void {
+  globalUndoListeners.add(listener)
+  return () => {
+    globalUndoListeners.delete(listener)
+    if (globalUndoListeners.size === 0) {
+      globalUndoStack = []
+      stopCleanupInterval()
+      refreshSnapshot()
+    }
+  }
+}
+
 function notifyListeners() {
+  refreshSnapshot()
   globalUndoListeners.forEach((listener) => listener())
+}
+
+/**
+ * Drop entries older than `UNDO_EXPIRY_MS`. Returns whether anything was removed.
+ * Callers are responsible for notifying listeners — never call this during render.
+ */
+function pruneExpiredEntries(): boolean {
+  const now = Date.now()
+  const before = globalUndoStack.length
+  globalUndoStack = globalUndoStack.filter((entry) => now - entry.timestamp < UNDO_EXPIRY_MS)
+  if (globalUndoStack.length === before) return false
+  if (globalUndoStack.length === 0) {
+    stopCleanupInterval()
+  }
+  return true
 }
 
 function pushUndoEntry(entry: Omit<UndoEntry, 'id' | 'timestamp'>) {
@@ -111,12 +167,10 @@ function removeUndoEntryById(id: string): boolean {
   return true
 }
 
+/** Read the newest live entry. Mutates the stack, so event handlers only. */
 function getLastUndoEntry(): UndoEntry | undefined {
-  // Filter out expired entries
-  const now = Date.now()
-  globalUndoStack = globalUndoStack.filter((entry) => now - entry.timestamp < UNDO_EXPIRY_MS)
-  if (globalUndoStack.length === 0) {
-    stopCleanupInterval()
+  if (pruneExpiredEntries()) {
+    notifyListeners()
   }
   return globalUndoStack[globalUndoStack.length - 1]
 }
@@ -145,19 +199,9 @@ interface UseUndoTrackerReturn {
 export const useUndoTracker = (): UseUndoTrackerReturn => {
   const { t } = useT('common')
 
-  // Force re-render when stack changes
-  const forceUpdate = useCallback(() => {}, [])
-
-  useEffect(() => {
-    globalUndoListeners.add(forceUpdate)
-    return () => {
-      globalUndoListeners.delete(forceUpdate)
-      if (globalUndoListeners.size === 0) {
-        globalUndoStack = []
-        stopCleanupInterval()
-      }
-    }
-  }, [forceUpdate])
+  // Re-render when the stack changes. `getUndoSnapshot` is pure and returns a
+  // stable reference until a mutation actually changes the derived values.
+  const snapshot = useSyncExternalStore(subscribeToUndoStack, getUndoSnapshot, getUndoSnapshot)
 
   const registerUndo = useCallback((description: string, undoFn: () => void): string => {
     return pushUndoEntry({ description, undoFn })
@@ -184,14 +228,12 @@ export const useUndoTracker = (): UseUndoTrackerReturn => {
     }
   }, [t])
 
-  const lastEntry = getLastUndoEntry()
-
   return {
     registerUndo,
     removeUndoEntry,
     undo,
-    canUndo: !!lastEntry,
-    lastActionDescription: lastEntry?.description ?? null
+    canUndo: snapshot.canUndo,
+    lastActionDescription: snapshot.lastActionDescription
   }
 }
 

--- a/apps/docs/src/user-guide/tasks/bulk-actions.md
+++ b/apps/docs/src/user-guide/tasks/bulk-actions.md
@@ -46,6 +46,8 @@ If multiple tasks are selected, dragging any of them moves the **whole selection
 
 After 10 seconds the action is committed and undo no longer reaches it. (You can still manually reverse, of course.)
 
+The undo window is app-wide, not per view. The most recent undoable action is shared across Tasks, Projects, and Calendar, so <kbd>⌘</kbd>+<kbd>Z</kbd> reverses whichever action happened last no matter where you switched to, and it expires on the same 10-second timer everywhere.
+
 ## Multi-Select Across Filters
 
 Multi-select operates on the visible task list. If you want to act on tasks not currently visible, change filters or scope first, then select.


### PR DESCRIPTION
Closes #1102. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

Confirmed still live on `main` @ f4a5dd4f7 (the MEDIUM batch did not touch this file).

**1. The subscriber was a no-op** — `apps/desktop/src/renderer/src/hooks/use-undo.ts:149`

```ts
// Force re-render when stack changes
const forceUpdate = useCallback(() => {}, [])

useEffect(() => {
  globalUndoListeners.add(forceUpdate)
  ...
}, [forceUpdate])
```

Every mutation path (`pushUndoEntry`, `popUndoEntry`, `removeUndoEntryById`, the 1s expiry sweep) faithfully called `notifyListeners()`, which invoked a set of empty functions. A mounted `useUndoTracker()` therefore never re-rendered: `canUndo` and `lastActionDescription` were frozen at whatever they were when the component last rendered for some other reason. The only way to observe a correct value was to mount a *fresh* hook — which is exactly what the existing tests did, so the suite passed while the runtime API was dead.

**2. The stack was mutated during render** — `use-undo.ts:187`

```ts
const lastEntry = getLastUndoEntry()   // called in the hook body, i.e. during render
```

`getLastUndoEntry()` reassigned the module-level `globalUndoStack` (filtering expired entries) and called `stopCleanupInterval()`. A render pass that dropped the last live entry also killed the sweep timer and never notified listeners, so any other mounted tracker kept a stale view. React 19 may call a component body more than once per commit; side effects there are a purity violation.

**3. The sweep under-notified** — the interval only called `notifyListeners()` when the stack went from non-empty to *empty*. Expiring 1 of 3 entries silently changed `lastActionDescription` with no notification.

## What changed

- Added a module-level `undoSnapshot` (`{ canUndo, lastActionDescription }`) recomputed inside `notifyListeners()`. `refreshSnapshot()` only allocates a new object when a derived value actually changes, so `getUndoSnapshot()` is pure and referentially stable between mutations — the precondition for `useSyncExternalStore` not to loop forever.
- `useUndoTracker` now reads through `useSyncExternalStore(subscribeToUndoStack, getUndoSnapshot, getUndoSnapshot)`. `subscribeToUndoStack` is a stable module-level function (so React subscribes once per mount, never resubscribes) and keeps the existing teardown semantics exactly: when the last tracker unmounts, the global stack is cleared and the sweep timer stopped.
- Extracted `pruneExpiredEntries()`; the sweep now notifies whenever it actually removed something, not only when the stack empties. It still self-stops when the stack is empty, so the timer lifetime is unchanged.
- `getLastUndoEntry()` (now used only from the Cmd+Z keydown handler, an event context where mutation is fine) prunes and notifies. Nothing mutates module state during render any more.

Deliberately **not** done:

- Did not delete the tracker. `canUndo` / `lastActionDescription` are public hook API with existing test coverage, and the availability transitions are worth having correct rather than removed.
- Did not remove the "wipe the stack when the last tracker unmounts" behavior. It is pre-existing, and both the tests and the 10s-window product semantics rely on it.
- Did not change `popUndoEntry()` to prune before popping. That is pre-existing behavior and the 1s sweep bounds the window to under a second.

**Re-render cost.** The three consumers (`pages/tasks.tsx`, `pages/project/index.tsx`, `pages/calendar.tsx`) destructure only `registerUndo` / `removeUndoEntry`, so they now take one extra render when an undoable action is registered or consumed, and one when it expires. Those pages already re-render from the mutation + query invalidation that produced the undo entry, so this is noise next to the existing work — and it is the price of the API being correct at all. No infinite loop: `getSnapshot` returns a cached object whose identity only changes when the values change, so React bails out of every no-op notification.

## How it was proven

7 new tests in `use-undo.test.ts` cover the availability transitions (register → `canUndo` true on an already-mounted tracker, cross-instance propagation, `undo()` → false, `removeUndoEntry` → false, Cmd+Z → false, expiry sweep → false) and render purity (a re-render while an entry is past its expiry must not call `clearInterval`, i.e. must not touch module state).

Before/after using `git checkout origin/main -- apps/desktop/src/renderer/src/hooks/use-undo.ts` with the new test file in place:

- **Before the fix: `Tests 7 failed | 20 passed (27)`** — all 7 new tests fail.
- **After the fix: `Tests 27 passed (27)`.**

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  apps/desktop/src/renderer/src/hooks/use-undo.test.ts \
  apps/desktop/src/renderer/src/pages/tasks.test.tsx
  -> Test Files 2 passed (2) | Tests 40 passed (40)

pnpm --filter @memry/desktop typecheck:web   -> clean
pnpm exec eslint apps/desktop/src/renderer/src/hooks/use-undo.ts   -> 0 errors
git diff --check   -> clean
pnpm docs:impact --base origin/main --strict   -> covered
pnpm docs:build   -> build complete in 7.59s
```

## Backward compatibility

Renderer-only, in-memory hook. No schema, IPC contract, sync payload, vault format, or settings shape is touched; the hook's public return type is unchanged.
