### PR TITLE
fix(editor): scope the editor link-click handler to its own pane

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-note-setup.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-note-setup.test.ts
@@ -44,6 +44,51 @@ function createEditor(options?: { registerCreatesExtension?: boolean }) {
   return { editor, getAIExtension: () => aiExtension }
 }
 
+/**
+ * Build the real editor DOM shape — `.bn-container` (the ref'd element) wrapping
+ * a `.bn-editor` surface — and attach it to the document so an unscoped
+ * `document.querySelector('.bn-editor')` can find it too.
+ */
+function mountEditorSurface(container: HTMLElement, href: string): HTMLElement {
+  const editorElement = document.createElement('div')
+  editorElement.className = 'bn-editor'
+  editorElement.innerHTML = `
+      <button data-wiki-link data-target=" Launch Plan ">wiki</button>
+      <a href="${href}">external</a>
+      <a href="#local">local</a>
+    `
+  container.appendChild(editorElement)
+  if (!container.isConnected) document.body.appendChild(container)
+  return editorElement
+}
+
+/** One split-view pane: its own container, its own `.bn-editor`, its own callbacks. */
+function createPane(href: string) {
+  const container = document.createElement('div')
+  container.className = 'bn-container'
+  const editorElement = mountEditorSurface(container, href)
+  const { editor } = createEditor()
+  const onLinkClick = vi.fn()
+  const onInternalLinkClick = vi.fn()
+
+  return {
+    container,
+    editor,
+    onLinkClick,
+    onInternalLinkClick,
+    params: {
+      editorContainerRef: { current: container } as React.RefObject<HTMLDivElement | null>,
+      onLinkClick,
+      onInternalLinkClick
+    },
+    clickExternalLink: (): void => {
+      editorElement
+        .querySelector(`a[href="${href}"]`)!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    }
+  }
+}
+
 describe('useBlockNoteSetup', () => {
   let editorContainerRef: React.RefObject<HTMLDivElement | null>
 
@@ -193,14 +238,7 @@ describe('useBlockNoteSetup', () => {
     const onLinkClick = vi.fn()
     const onInternalLinkClick = vi.fn()
     const wikiEvent = vi.fn()
-    const editorElement = document.createElement('div')
-    editorElement.className = 'bn-editor'
-    editorElement.innerHTML = `
-      <button data-wiki-link data-target=" Launch Plan ">wiki</button>
-      <a href="https://memry.app">external</a>
-      <a href="#local">local</a>
-    `
-    document.body.appendChild(editorElement)
+    const editorElement = mountEditorSurface(editorContainerRef.current!, 'https://memry.app')
     window.addEventListener('wikilink:click', wikiEvent)
 
     const { unmount } = renderHook(() =>
@@ -229,6 +267,42 @@ describe('useBlockNoteSetup', () => {
 
     unmount()
     window.removeEventListener('wikilink:click', wikiEvent)
+  })
+
+  it('binds each split-view pane to its own editor surface', () => {
+    const left = createPane('https://left.example')
+    const right = createPane('https://right.example')
+
+    renderHook(() => useBlockNoteSetup({ editor: left.editor, ...left.params }))
+    renderHook(() => useBlockNoteSetup({ editor: right.editor, ...right.params }))
+
+    left.clickExternalLink()
+
+    expect(left.onLinkClick).toHaveBeenCalledTimes(1)
+    expect(left.onLinkClick).toHaveBeenCalledWith('https://left.example')
+    expect(right.onLinkClick).not.toHaveBeenCalled()
+
+    right.clickExternalLink()
+
+    expect(right.onLinkClick).toHaveBeenCalledTimes(1)
+    expect(right.onLinkClick).toHaveBeenCalledWith('https://right.example')
+    expect(left.onLinkClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the surviving pane wired after the other split-view pane unmounts', () => {
+    const left = createPane('https://left.example')
+    const right = createPane('https://right.example')
+
+    const leftHook = renderHook(() => useBlockNoteSetup({ editor: left.editor, ...left.params }))
+    renderHook(() => useBlockNoteSetup({ editor: right.editor, ...right.params }))
+
+    leftHook.unmount()
+    left.container.remove()
+
+    right.clickExternalLink()
+
+    expect(right.onLinkClick).toHaveBeenCalledWith('https://right.example')
+    expect(left.onLinkClick).not.toHaveBeenCalled()
   })
 
   it('opens the AI menu with the keyboard shortcut when a block is selected', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-note-setup.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-note-setup.ts
@@ -148,13 +148,19 @@ export function useBlockNoteSetup({
       }
     }
 
-    const editorElement = document.querySelector('.bn-editor')
+    // Scope the lookup to this instance's own container. `document.querySelector`
+    // returns whichever `.bn-editor` is first in the document, so with more than
+    // one editor mounted (split view, or a note alongside the inbox/task
+    // description editors) every instance bound to the same element: clicks in
+    // the first pane fired every pane's callbacks, and clicks in any later pane
+    // fired none.
+    const editorElement = editorContainerRef.current?.querySelector('.bn-editor')
     editorElement?.addEventListener('click', handleClick)
 
     return () => {
       editorElement?.removeEventListener('click', handleClick)
     }
-  }, [onLinkClick, onInternalLinkClick])
+  }, [onLinkClick, onInternalLinkClick, editorContainerRef])
 
   // Scroll to highlight on mount
   useEffect(() => {

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -108,6 +108,10 @@ A small dot appears on a tab title when there are unsaved changes (rare — memr
 
 Canvases open as tabs too, so you can keep a board in one pane and a note in the other. Note that a note open in a visible pane is edited there, not on the canvas card — see [Cards & Links](./canvas/cards-and-links.md).
 
+## Links in Split Panes
+
+Each pane handles its own links. Clicking an external link or a `[[wiki link]]` in either pane opens it from that pane, and closing one pane leaves the other pane's links working.
+
 ## See Also
 
 - [Folder View](/user-guide/folder-view) — opens in a tab like everything else


### PR DESCRIPTION
Closes #1104. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-note-setup.ts:151` looked up the editor surface globally:

```ts
const editorElement = document.querySelector('.bn-editor')
editorElement?.addEventListener('click', handleClick)
```

`document.querySelector` returns whichever `.bn-editor` is **first in the document**, not this hook instance's own. Every mounted editor therefore bound its link-click handler to the same element. With two panes open:

- clicking a link in the **left** pane ran **both** panes' `onLinkClick`/`onInternalLinkClick`;
- clicking a link in the **right** pane ran **nothing** — its handler was sitting on the left pane's DOM.

Same failure whenever a note editor coexists with another `.bn-editor` instance (inbox content editor `inbox-content-editor.tsx:145`, task-description editor) that happens to come first in document order.

**Divergence from the issue text:** the issue says "the second editor's cleanup removes the first one's listener". That part is not accurate — each effect closes over its own `handleClick`, so `removeEventListener` only detaches its own. The real defect is the shared bind target described above. The user-visible symptom (and the issue's verification steps) are unchanged, so the fix is the same.

## What changed

One line plus the dep array — scope the lookup to the container ref the hook already receives:

```ts
const editorElement = editorContainerRef.current?.querySelector('.bn-editor')
```

`editorContainerRef` points at this instance's `.bn-container` div (`ContentArea.tsx:1139`), which wraps `BlockNoteView` and therefore its `.bn-editor`. The ref callback runs during commit, before this effect, so the container is always present.

Deliberately **not** done:

- Did not attach the listener to the container itself. The container also hosts BlockNote's floating toolbars, the tag-suggestion popover and the wiki-link preview card; keeping `.bn-editor` as the target preserves the exact click surface the handler had before.
- Did not add `editor` to the effect deps or otherwise rework the effect lifecycle — out of scope for this issue.

## How it was proven

Test file: `apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-note-setup.test.ts`

- reworked the existing single-editor test so the `.bn-editor` lives inside the ref'd container (the real DOM shape) and the container is attached to the document, so it exercises both the old global lookup and the new scoped one;
- added `binds each split-view pane to its own editor surface` — two panes, each with its own container/`.bn-editor`/callbacks; a click in either pane must fire only that pane's callback;
- added `keeps the surviving pane wired after the other split-view pane unmounts` — unmount the first pane, then click a link in the second.

Before/after on the same test file (source reverted to `origin/main`, tests kept):

```
before: Tests  2 failed | 9 passed (11)
after:  Tests  11 passed (11)
```

Both failures were the new split-view tests. The single-editor test passed in **both** runs — that is the no-regression proof for the one-editor case.

## Verification

```
$ ./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
    .../hooks/use-block-note-setup.test.ts .../content-area/ContentArea.test.tsx
  Test Files  2 passed (2)
       Tests  21 passed (21)

$ pnpm --filter @memry/desktop typecheck:web
  clean (no output)

$ pnpm exec eslint .../use-block-note-setup.ts .../use-block-note-setup.test.ts
  0 errors (1 warning: test file matches an eslint ignore pattern)

$ git diff --check
  clean

$ pnpm docs:impact --base origin/main --strict
  docs impact: covered against origin/main

$ pnpm docs:build
  build complete in 5.83s
```

## Backward compatibility

Renderer-only DOM wiring; no schema, IPC contract, sync payload, vault format or settings shape is touched, so existing installs are unaffected.
