### PR TITLE
perf(viewers): keep the audio player shell out of the timeupdate render path

### DIFF
--- a/apps/desktop/src/renderer/src/components/viewers/audio-player.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/audio-player.tsx
@@ -5,7 +5,7 @@
  * @module components/viewers/audio-player
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react'
+import { useState, useCallback, useRef, useEffect, memo, type RefObject } from 'react'
 import {
   Play,
   Pause,
@@ -50,6 +50,66 @@ function formatTime(seconds: number): string {
 }
 
 // ============================================================================
+// Progress Bar
+// ============================================================================
+
+interface AudioProgressProps {
+  /** Ref to the player's `<audio>` element, attached before this component's effects run. */
+  audioRef: RefObject<HTMLAudioElement | null>
+  /** Track length in seconds, owned by the parent so the skip controls can clamp to it. */
+  duration: number
+}
+
+/**
+ * Owns `currentTime` so the ~4 Hz `timeupdate` stream only re-renders the scrubber and the
+ * time labels. Keeping it in the parent re-rendered the whole player — both Radix sliders,
+ * every control button and the transcript — four times a second for the length of the track.
+ * State (not a ref) still drives the value, so the thumb keeps moving at full `timeupdate`
+ * resolution rather than stepping.
+ */
+const AudioProgress = memo(function AudioProgress({ audioRef, duration }: AudioProgressProps) {
+  const [currentTime, setCurrentTime] = useState(0)
+
+  useEffect(() => {
+    const audio = audioRef.current
+    if (!audio) return
+
+    const handleTimeUpdate = () => setCurrentTime(audio.currentTime)
+
+    audio.addEventListener('timeupdate', handleTimeUpdate)
+    return () => {
+      audio.removeEventListener('timeupdate', handleTimeUpdate)
+    }
+  }, [audioRef])
+
+  const handleSeek = useCallback(
+    (value: number[]) => {
+      const audio = audioRef.current
+      if (!audio) return
+      audio.currentTime = value[0]
+      setCurrentTime(value[0])
+    },
+    [audioRef]
+  )
+
+  return (
+    <div className="space-y-2">
+      <Slider
+        value={[currentTime]}
+        max={duration || 100}
+        step={0.1}
+        onValueChange={handleSeek}
+        className="cursor-pointer"
+      />
+      <div className="flex justify-between text-xs text-muted-foreground">
+        <span>{formatTime(currentTime)}</span>
+        <span>{formatTime(duration)}</span>
+      </div>
+    </div>
+  )
+})
+
+// ============================================================================
 // Audio Player Component
 // ============================================================================
 
@@ -64,7 +124,6 @@ export function AudioPlayer({
   const audioRef = useRef<HTMLAudioElement>(null)
 
   const [isPlaying, setIsPlaying] = useState(false)
-  const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
   const [volume, setVolume] = useState(1)
   const [isMuted, setIsMuted] = useState(false)
@@ -79,18 +138,15 @@ export function AudioPlayer({
     const audio = audioRef.current
     if (!audio) return
 
-    const handleTimeUpdate = () => setCurrentTime(audio.currentTime)
     const handleLoadedMetadata = () => setDuration(audio.duration)
     const handleEnded = () => setIsPlaying(false)
     const handleError = () => setError(true)
 
-    audio.addEventListener('timeupdate', handleTimeUpdate)
     audio.addEventListener('loadedmetadata', handleLoadedMetadata)
     audio.addEventListener('ended', handleEnded)
     audio.addEventListener('error', handleError)
 
     return () => {
-      audio.removeEventListener('timeupdate', handleTimeUpdate)
       audio.removeEventListener('loadedmetadata', handleLoadedMetadata)
       audio.removeEventListener('ended', handleEnded)
       audio.removeEventListener('error', handleError)
@@ -108,13 +164,6 @@ export function AudioPlayer({
     }
     setIsPlaying(!isPlaying)
   }, [isPlaying])
-
-  const handleSeek = useCallback((value: number[]) => {
-    const audio = audioRef.current
-    if (!audio) return
-    audio.currentTime = value[0]
-    setCurrentTime(value[0])
-  }, [])
 
   const handleVolumeChange = useCallback((value: number[]) => {
     const audio = audioRef.current
@@ -193,19 +242,7 @@ export function AudioPlayer({
             </div>
 
             {/* Progress bar */}
-            <div className="space-y-2">
-              <Slider
-                value={[currentTime]}
-                max={duration || 100}
-                step={0.1}
-                onValueChange={handleSeek}
-                className="cursor-pointer"
-              />
-              <div className="flex justify-between text-xs text-muted-foreground">
-                <span>{formatTime(currentTime)}</span>
-                <span>{formatTime(duration)}</span>
-              </div>
-            </div>
+            <AudioProgress audioRef={audioRef} duration={duration} />
 
             {/* Controls */}
             <div className="flex items-center justify-center gap-4">

--- a/apps/desktop/src/renderer/src/components/viewers/image-viewer.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/image-viewer.tsx
@@ -53,15 +53,27 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
   /** Live pan offset. Leads `position` during a drag; `position` catches up on pointer-up. */
   const positionRef = useRef<Position>(position)
   const dragStartRef = useRef<Position>({ x: 0, y: 0 })
+  /** Live scale, so the zoom handlers can compute the next value without a stale closure. */
+  const scaleRef = useRef(scale)
 
   const commitPosition = useCallback((next: Position) => {
     positionRef.current = next
     setPosition(next)
   }, [])
 
-  if (scale === 1 && (position.x !== 0 || position.y !== 0)) {
-    commitPosition({ x: 0, y: 0 })
-  }
+  // Every zoom write goes through here: dropping back to 1x recenters in the same batch as
+  // the scale change. Doing it in the render body instead (`if (scale === 1) setPosition(...)`)
+  // made React throw the render away and run the component a second time on every zoom-out.
+  const applyScale = useCallback(
+    (next: number) => {
+      scaleRef.current = next
+      setScale(next)
+      if (next === 1 && (positionRef.current.x !== 0 || positionRef.current.y !== 0)) {
+        commitPosition({ x: 0, y: 0 })
+      }
+    },
+    [commitPosition]
+  )
 
   // Attach wheel event with passive: false to allow preventDefault
   useEffect(() => {
@@ -71,27 +83,27 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
     const handleWheelEvent = (e: WheelEvent) => {
       e.preventDefault()
       const delta = e.deltaY > 0 ? -0.1 : 0.1
-      setScale((s) => Math.max(0.25, Math.min(5, s + delta)))
+      applyScale(Math.max(0.25, Math.min(5, scaleRef.current + delta)))
     }
 
     container.addEventListener('wheel', handleWheelEvent, { passive: false })
     return () => {
       container.removeEventListener('wheel', handleWheelEvent)
     }
-  }, [])
+  }, [applyScale])
 
   const zoomIn = useCallback(() => {
-    setScale((s) => Math.min(s + 0.25, 5))
-  }, [])
+    applyScale(Math.min(scaleRef.current + 0.25, 5))
+  }, [applyScale])
 
   const zoomOut = useCallback(() => {
-    setScale((s) => Math.max(s - 0.25, 0.25))
-  }, [])
+    applyScale(Math.max(scaleRef.current - 0.25, 0.25))
+  }, [applyScale])
 
   const resetZoom = useCallback(() => {
-    setScale(1)
+    applyScale(1)
     commitPosition({ x: 0, y: 0 })
-  }, [commitPosition])
+  }, [applyScale, commitPosition])
 
   const rotate = useCallback(() => {
     setRotation((r) => (r + 90) % 360)
@@ -108,10 +120,10 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
       const scaleY = containerHeight / imageHeight
       const newScale = Math.min(scaleX, scaleY, 1)
 
-      setScale(newScale)
+      applyScale(newScale)
       commitPosition({ x: 0, y: 0 })
     }
-  }, [commitPosition])
+  }, [applyScale, commitPosition])
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {

--- a/apps/desktop/src/renderer/src/components/viewers/viewers.test.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/viewers.test.tsx
@@ -15,12 +15,17 @@ const mocks = vi.hoisted(() => {
     addCustomPlayer: vi.fn((player: unknown) => customPlayers.push(player)),
     videoError: undefined as undefined | (() => void),
     logError: vi.fn(),
-    clipboardWrite: vi.fn()
+    clipboardWrite: vi.fn(),
+    // Render probes. `useT` runs once per component render *pass*, so it catches a render
+    // React throws away and redoes. `sliderRender` runs once per Slider render; `max === 1`
+    // is the volume slider, which the AudioPlayer shell owns.
+    useT: vi.fn(() => ({ t: (key: string) => key })),
+    sliderRender: vi.fn()
   }
 })
 
 vi.mock('@memry/i18n/renderer', () => ({
-  useT: () => ({ t: (key: string) => key })
+  useT: mocks.useT
 }))
 
 vi.mock('react-i18next', () => ({
@@ -40,11 +45,18 @@ vi.mock('@/components/ui/slider', () => ({
     value: number[]
     max?: number
     onValueChange?: (value: number[]) => void
-  }) => (
-    <button type="button" aria-label={`slider-${value[0]}`} onClick={() => onValueChange?.([max])}>
-      slider {value[0]}
-    </button>
-  )
+  }) => {
+    mocks.sliderRender({ max, value: value[0] })
+    return (
+      <button
+        type="button"
+        aria-label={`slider-${value[0]}`}
+        onClick={() => onValueChange?.([max])}
+      >
+        slider {value[0]}
+      </button>
+    )
+  }
 }))
 
 vi.mock('react-pdf', () => ({
@@ -156,6 +168,80 @@ describe('viewer components', () => {
     ).toBeInTheDocument()
   })
 
+  it('tracks playback in the scrubber without re-rendering the rest of the player', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<AudioPlayer src="memry-file://voice.mp3" fileName="Voice" />)
+    const audio = container.querySelector('audio') as HTMLAudioElement
+    Object.defineProperty(audio, 'duration', { value: 100, configurable: true })
+    let elapsed = 0
+    Object.defineProperty(audio, 'currentTime', {
+      configurable: true,
+      get: () => elapsed,
+      set: (next: number) => {
+        elapsed = next
+      }
+    })
+
+    fireEvent.loadedMetadata(audio)
+    const shellRenders = (): number =>
+      mocks.sliderRender.mock.calls.filter(([props]) => props.max === 1).length
+
+    mocks.sliderRender.mockClear()
+
+    // A ~4 Hz timeupdate stream, the way a playing track delivers it.
+    for (let tick = 1; tick <= 10; tick += 1) {
+      elapsed = tick * 1.5
+      fireEvent.timeUpdate(audio)
+    }
+
+    // The scrubber still follows playback at full timeupdate resolution...
+    expect(screen.getByLabelText('slider-15')).toBeInTheDocument()
+    expect(screen.getByText('0:15')).toBeInTheDocument()
+    // ...but the surrounding player (volume slider, controls, transcript) never re-rendered.
+    expect(shellRenders()).toBe(0)
+
+    // Seeking still moves the element and the display together.
+    await user.click(screen.getByLabelText('slider-15'))
+    expect(audio.currentTime).toBe(100)
+    expect(screen.getByLabelText('slider-100')).toBeInTheDocument()
+    // Elapsed and total both read 1:40 once the scrubber is dragged to the end.
+    expect(screen.getAllByText('1:40')).toHaveLength(2)
+
+    // Play, then `ended`, must still leave the button back in its "play" state.
+    const playButton = container.querySelectorAll('button')[2]
+    await user.click(playButton)
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(1)
+    fireEvent.ended(audio)
+    await user.click(playButton)
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(2)
+    expect(HTMLMediaElement.prototype.pause).not.toHaveBeenCalled()
+
+    // ...and pausing still pauses.
+    await user.click(playButton)
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalledTimes(1)
+  })
+
+  // `useTrackedTimeout` (#1266) owns the cancellation; this asserts the player is actually
+  // wired to it, which the hook's own unit test cannot see.
+  it('cancels the copy-confirmation timer when the player unmounts', async () => {
+    vi.useFakeTimers()
+    try {
+      const { unmount } = render(
+        <AudioPlayer src="memry-file://voice.mp3" fileName="Voice" transcription="Launch risks." />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'content.copyTranscription' }))
+      await act(async () => {})
+      expect(mocks.clipboardWrite).toHaveBeenCalledWith('Launch risks.')
+      expect(vi.getTimerCount()).toBe(1)
+
+      unmount()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('shows an available audio transcription and copies it', async () => {
     const user = userEvent.setup()
     Object.defineProperty(navigator, 'clipboard', {
@@ -256,6 +342,29 @@ describe('viewer components', () => {
     // Dropping back to 100% still recenters.
     await user.click(screen.getByTitle('phaseF.componentsViewersImageViewer.resetZoom'))
     expect(image).toHaveStyle('transform: translate(0px, 0px) scale(1) rotate(90deg)')
+  })
+
+  it('recenters on zoom-out to 100% without a throwaway render pass', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<ImageViewer src="memry-file://zoom.png" alt="Zoom" />)
+    const image = screen.getByRole('img', { name: 'Zoom' })
+    const imageContainer = image.parentElement as HTMLDivElement
+
+    // Zoom past 100% and pan, so there is an offset left to clear.
+    await user.click(container.querySelectorAll('button')[1])
+    expect(screen.getByText('125%')).toBeInTheDocument()
+    fireEvent.mouseDown(imageContainer, { clientX: 0, clientY: 0 })
+    fireEvent.mouseMove(window, { clientX: 30, clientY: 40 })
+    fireEvent.mouseUp(window)
+    expect(image).toHaveStyle('transform: translate(30px, 40px) scale(1.25) rotate(0deg)')
+
+    mocks.useT.mockClear()
+    await user.click(container.querySelectorAll('button')[0])
+
+    expect(screen.getByText('100%')).toBeInTheDocument()
+    expect(image).toHaveStyle('transform: translate(0px, 0px) scale(1) rotate(0deg)')
+    // Scale and the recenter land in the same batch: one render pass, not two.
+    expect(mocks.useT).toHaveBeenCalledTimes(1)
   })
 
   it('loads PDFs, navigates pages, changes zoom/sidebar/rotation, and reports load errors', async () => {

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -43,6 +43,11 @@ Size, crop, and alignment are **saved with the note** and restored when you reop
 Audio files render as inline audio blocks with playback controls. Filed voice memos keep their
 transcript with the audio file, so opening the file page shows the player and transcript together.
 
+The progress bar follows playback continuously, and only the scrubber and the time readout update
+as the track plays — so leaving a long recording running in a background tab costs nothing beyond
+the audio itself. Copying the transcript shows a checkmark for a couple of seconds; closing the
+file page before it clears cancels it cleanly.
+
 ## Image Attachments
 
 Images render as image blocks (not file blocks). Drag them to resize; double-click for the lightbox.


### PR DESCRIPTION
Closes #1103. Part of epic #987 (memory/CPU audit 2026-08).

Rebased onto current `main` (`0a2eddb7c`) after the rest of the LOW tier landed. See
"Overlap with #1266" below — one of this issue's three bullets is already fixed on `main`.

## What was wrong

**1. The whole audio player re-rendered ~4x/s for the length of every track.**
`components/viewers/audio-player.tsx:82,87` on `main` keeps `currentTime` on the `AudioPlayer` itself:

```ts
const handleTimeUpdate = () => setCurrentTime(audio.currentTime)
audio.addEventListener('timeupdate', handleTimeUpdate)
```

`timeupdate` fires roughly four times a second while audio plays, so every tick re-renders the
entire component: both Radix sliders (progress **and** volume), all four control buttons with their
SVG icons, and the transcript section. A 40-minute voice memo left playing means ~10k full-player
renders that only ever change a scrubber position and two time labels.

**2. Render-phase `setPosition` in the image viewer.** `components/viewers/image-viewer.tsx:62-64`:

```ts
if (scale === 1 && (position.x !== 0 || position.y !== 0)) {
  commitPosition({ x: 0, y: 0 })
}
```

Zooming back out to 100% after panning makes React discard the render it has just produced and run
the component a second time (2 render passes per zoom-out, measured). It also mutates
`positionRef.current` from the render body — a side effect in a render React is free to throw away.

#1077 (MEDIUM, shipped as #1239) fixed the image viewer's *pan* path and explicitly left this
render-phase reset, which was listed in both #1077 and this issue.

## Overlap with #1266 — the third bullet is already fixed

The issue's third item, the untracked 2 s "copied" timer at `:154`, was fixed on `main` by #1266
(`854ac7a93`), which introduced `hooks/use-tracked-timeout.ts` and switched this exact call site to
`scheduleTimeout(() => setCopied(false), 2000)`. This PR originally hand-rolled its own timer ref
for it; on rebase that was **dropped in favour of main's shared hook** rather than duplicating the
mechanism. No source change here for that bullet.

What is kept is a component-level regression test: #1266 tested the hook in
`hooks/timer-raf-cleanup.test.tsx`, which cannot see whether *this* component is actually wired to
it. The test asserts the pending timer count drops to 0 when the player unmounts mid-copy, and it
passes on `main` — it is a guard, not a fix, and is commented as such.

## What changed

- `currentTime` moved into a memoized `AudioProgress` child that subscribes to the `<audio>`
  element directly. The ~4 Hz stream now only re-renders the scrubber and its two time labels; the
  shell (volume slider, controls, transcript) is out of the path entirely.
- Every scale write in the image viewer goes through one `applyScale` helper that sets scale and,
  when it lands on exactly 1, clears the pan offset in the *same* batch. The render-body block is
  gone.

**Deliberately not done:** progress was *not* moved to a ref with imperative DOM writes. That would
have cut the render count to zero but taken the Radix thumb and the `<span>` labels out of React's
control, and the issue's own suggestion of "coarser state" would make the scrubber visibly step.
State at full `timeupdate` resolution, scoped to a small subtree, keeps the motion identical to
today. `fitToContainer`'s scale is still unclamped (it legitimately goes below 0.25 for very large
images), so `applyScale` clamps at the call sites rather than inside.

## How it was proven

New tests in `viewers.test.tsx`, run against `origin/main`'s sources with the new tests in place,
then against the fix (`git checkout origin/main -- <sources>` / `git checkout HEAD -- <sources>`):

| Assertion | Before | After |
|---|---|---|
| Player-shell renders across 10 `timeupdate` events | **10** | **0** |
| Render passes for zoom-out 125% -> 100% with a pan offset | **2** | **1** |
| Pending timers after unmounting mid-copy | 0 (already fixed by #1266) | 0 |

Before: `Tests 7 passed | 2 failed (9)`. After: `Tests 9 passed (9)`.

The render probes are real, not mocked-IPC theatre: shell renders are counted from the volume
slider's own render calls (`max === 1`, parent-owned), and render *passes* are counted from `useT`,
which runs once per invocation of the component function — so it catches a pass React throws away.
The same tests assert the visible behaviour those counts must not cost: the scrubber still reads
`0:15` and `slider-15` after ten ticks, seeking still moves both the element and the display,
`ended` still leaves the button in its play state, and pausing still pauses.

## Verification

Re-run after the rebase onto `0a2eddb7c`:

```
vitest --project renderer viewers.test.tsx + pages/file.test.tsx + hooks/timer-raf-cleanup.test.tsx
                                                           -> 23 passed (23), 3 files
pnpm --filter @memry/desktop typecheck:web                 -> clean
pnpm exec eslint <changed source files>                    -> 0 problems
pnpm exec prettier --check <changed files>                 -> all match
pnpm docs:impact --base origin/main --strict               -> covered
git diff --check                                           -> clean
```

`pages/file.test.tsx` is the only consumer of `AudioPlayer`; `hooks/timer-raf-cleanup.test.tsx` is
#1266's suite, included to confirm the rebase did not disturb it.

## Backward compatibility

Renderer-only, no schema, contract, settings, sync or vault-format change; the audio and image
viewers render and behave exactly as before, so existing installs are unaffected.
