### PR TITLE
perf(tabs): scroll the active tab into view once per activation, not three times

### DIFF
--- a/apps/desktop/src/renderer/src/components/tabs/tab-bar-scroll.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-bar-scroll.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { TabBarWithDrag } from './tab-bar-with-drag'
+
+const mocks = vi.hoisted(() => ({
+  tabGroup: null as Record<string, unknown> | null
+}))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  horizontalListSortingStrategy: {}
+}))
+
+vi.mock('@/contexts/day-panel-context', () => ({
+  useDayPanel: () => ({ isOpen: false, width: 320, isResizing: false, toggle: vi.fn() })
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabGroup: () => mocks.tabGroup
+}))
+
+vi.mock('@/components/ui/sidebar', () => ({
+  useSidebar: () => ({ state: 'expanded' })
+}))
+
+vi.mock('./sortable-tab', () => ({
+  SortableTab: ({ tab }: { tab: { id: string; title: string } }) => (
+    <div data-tab-id={tab.id}>{tab.title}</div>
+  )
+}))
+
+vi.mock('./pinned-tab', () => ({
+  PinnedTab: ({ tab }: { tab: { title: string } }) => <div>{tab.title}</div>
+}))
+
+vi.mock('./tab-bar-action', () => ({
+  TabBarAction: ({ tooltip, onClick }: { tooltip: string; onClick: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {tooltip}
+    </button>
+  )
+}))
+
+vi.mock('./new-tab-menu', () => ({
+  NewTabMenu: () => <button type="button">new tab</button>
+}))
+
+vi.mock('./tab-bar-context-menu', () => ({
+  TabBarContextMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('./tab-context-menu', () => ({
+  TabContextMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+/** Strip geometry jsdom does not compute — drives the chevron gutter state. */
+const strip = { scrollLeft: 0, scrollWidth: 1000, clientWidth: 300 }
+
+const defineMetric = (name: 'scrollWidth' | 'clientWidth' | 'scrollLeft'): PropertyDescriptor =>
+  ({
+    configurable: true,
+    get: () => strip[name],
+    set: (value: number) => {
+      strip[name] = value
+    }
+  }) as PropertyDescriptor
+
+const originalDescriptors = new Map<string, PropertyDescriptor | undefined>()
+
+const group = (activeTabId: string): Record<string, unknown> => ({
+  id: 'group-1',
+  activeTabId,
+  tabs: [
+    { id: 'tab-1', title: 'First', isPinned: false, type: 'note' },
+    { id: 'tab-2', title: 'Second', isPinned: false, type: 'note' },
+    { id: 'tab-3', title: 'Third', isPinned: false, type: 'note' }
+  ]
+})
+
+describe('TabBarWithDrag active-tab scrolling', () => {
+  let scrollIntoView: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    strip.scrollLeft = 0
+    strip.scrollWidth = 1000
+    strip.clientWidth = 300
+
+    for (const name of ['scrollWidth', 'clientWidth', 'scrollLeft'] as const) {
+      originalDescriptors.set(name, Object.getOwnPropertyDescriptor(HTMLElement.prototype, name))
+      Object.defineProperty(HTMLElement.prototype, name, defineMetric(name))
+    }
+
+    scrollIntoView = vi.fn()
+    HTMLElement.prototype.scrollIntoView =
+      scrollIntoView as unknown as HTMLElement['scrollIntoView']
+    mocks.tabGroup = group('tab-1')
+  })
+
+  afterEach(() => {
+    for (const [name, descriptor] of originalDescriptors) {
+      if (descriptor) {
+        Object.defineProperty(HTMLElement.prototype, name, descriptor)
+      } else {
+        delete (HTMLElement.prototype as unknown as Record<string, unknown>)[name]
+      }
+    }
+    originalDescriptors.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('scrolls the active tab into view once, not again as the chevron gutters resize', () => {
+    // Mount: the strip overflows, so checkScroll flips canScrollToEnd in the same
+    // commit as the scroll — the gutter re-render must not re-animate.
+    render(<TabBarWithDrag groupId="group-1" />)
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+
+    // Scrolling past the start edge flips canScrollToStart, adding the second
+    // gutter. The active tab is still on screen, so no second animation.
+    strip.scrollLeft = 50
+    fireEvent.scroll(screen.getByTestId('tab-strip'))
+    expect(
+      screen.getByRole('button', { name: 'phaseF.componentsTabsTabBarWithDrag.scrollTabsLeft' })
+    ).toBeInTheDocument()
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+  })
+
+  it('still scrolls when a different tab becomes active', () => {
+    const { rerender } = render(<TabBarWithDrag groupId="group-1" />)
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+    expect(scrollIntoView.mock.instances[0]).toHaveAttribute('data-tab-id', 'tab-1')
+
+    mocks.tabGroup = group('tab-3')
+    rerender(<TabBarWithDrag groupId="group-1" />)
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(2)
+    expect(scrollIntoView.mock.instances[1]).toHaveAttribute('data-tab-id', 'tab-3')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx
@@ -40,6 +40,21 @@ const handleWheel = (e: React.WheelEvent<HTMLDivElement>): void => {
 }
 
 /**
+ * Is the tab already fully inside the strip's visible area?
+ * The chevron gutters are inline padding on the strip, so they are subtracted —
+ * a tab sitting under a chevron does not count as visible. Physical sides are
+ * used because that is what the rects report in both LTR and RTL.
+ */
+const isTabFullyVisible = (strip: HTMLElement, tabEl: Element): boolean => {
+  const stripRect = strip.getBoundingClientRect()
+  const tabRect = tabEl.getBoundingClientRect()
+  const style = getComputedStyle(strip)
+  const visibleLeft = stripRect.left + (parseFloat(style.paddingLeft) || 0)
+  const visibleRight = stripRect.right - (parseFloat(style.paddingRight) || 0)
+  return tabRect.left >= visibleLeft - 1 && tabRect.right <= visibleRight + 1
+}
+
+/**
  * Tab bar with drag-to-reorder support and context menu
  * DndContext is provided by SplitViewContainer for cross-panel support
  */
@@ -107,12 +122,20 @@ export const TabBarWithDrag = ({
   // Keep the active tab visible — without this the strip stays pinned at the start
   // and a newly opened (or newly activated) tab sits past the end edge.
   // Re-runs on the chevron gutters too: they widen the scroll content one render
-  // after the scroll fires, which would push the tab back out of view.
+  // after the scroll fires, which would push the tab back out of view. Those
+  // follow-up runs used to fire a second and third smooth scrollIntoView for the
+  // same activation, restarting the animation mid-flight; they now only re-scroll
+  // when the resized gutters actually pushed the tab out of the strip.
+  const scrolledTabIdRef = useRef<string | null>(null)
   useLayoutEffect(() => {
     if (!activeTabId || activeDragItem) return
-    const tabEl = scrollRef.current?.querySelector(`[data-tab-id="${CSS.escape(activeTabId)}"]`)
+    const strip = scrollRef.current
+    const tabEl = strip?.querySelector(`[data-tab-id="${CSS.escape(activeTabId)}"]`)
+    if (!strip || !tabEl) return
+    if (scrolledTabIdRef.current === activeTabId && isTabFullyVisible(strip, tabEl)) return
+    scrolledTabIdRef.current = activeTabId
     // scrollIntoView is not implemented in jsdom
-    tabEl?.scrollIntoView?.({ inline: 'nearest', block: 'nearest', behavior: 'smooth' })
+    tabEl.scrollIntoView?.({ inline: 'nearest', block: 'nearest', behavior: 'smooth' })
   }, [activeTabId, regularTabsLength, activeDragItem, canScrollToStart, canScrollToEnd])
 
   // If group doesn't exist, don't render (after all hooks)

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -12,7 +12,9 @@ Every note, view, search, project, journal entry, or settings panel opens in a t
 
 Across the top of the app. Drag to reorder. Drag onto a pane edge to split.
 
-Tabs share the width of the bar evenly. Widen the window and they grow, up to a comfortable maximum; open more tabs, or narrow the window, and they compress — first the close button tucks away, then the title, leaving just the icon. Once tabs reach that icon-only minimum the bar scrolls sideways instead of shrinking further: scroll over it with a trackpad or mouse wheel, or use the chevrons that appear at either end. The active tab is always scrolled into view, so opening a new tab never leaves it hidden off the end. The **+** button stays pinned at the end of the bar while it scrolls.
+Tabs share the width of the bar evenly. Widen the window and they grow, up to a comfortable maximum; open more tabs, or narrow the window, and they compress — first the close button tucks away, then the title, leaving just the icon. Once tabs reach that icon-only minimum the bar scrolls sideways instead of shrinking further: scroll over it with a trackpad or mouse wheel, or use the chevrons that appear at either end. The active tab is always scrolled into view, so opening a new tab never leaves it hidden off the end. That scroll animates once per tab you activate — the chevrons appearing part-way through it no longer restart the animation, and a tab already fully in view is left where it is. The **+** button stays pinned at the end of the bar while it scrolls.
+
+There is no limit on how many tabs you can have open, and memrynote never closes one for you: use the tab context menu (**Close others**, **Close to the right**) when the bar gets long.
 
 ### Tab Context Menu
 


### PR DESCRIPTION
Closes #1105. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx:111-116` (pre-fix) — one tab activation fired **three** smooth `scrollIntoView` animations:

```tsx
useLayoutEffect(() => {
  if (!activeTabId || activeDragItem) return
  const tabEl = scrollRef.current?.querySelector(`[data-tab-id="${CSS.escape(activeTabId)}"]`)
  tabEl?.scrollIntoView?.({ inline: 'nearest', block: 'nearest', behavior: 'smooth' })
}, [activeTabId, regularTabsLength, activeDragItem, canScrollToStart, canScrollToEnd])
```

`canScrollToStart` / `canScrollToEnd` are gutter flags, and each one that flips adds a `ps-7` / `pe-7` gutter to the strip. The activation scroll is what makes them flip, so the effect re-entered twice more and re-issued a *smooth* scroll each time, restarting the animation mid-flight. Measured on a strip that overflows: **3 `scrollIntoView` calls for a single activation** (1 on activation, +1 when `canScrollToEnd` flips in the same commit, +1 when `canScrollToStart` flips on the first scroll event).

The gutter re-runs are not pointless — a widening gutter really can push the tab back out of view — so they could not simply be dropped from the deps.

## What changed

- The effect now remembers which tab it last scrolled to (`scrolledTabIdRef`). A run whose target changed always animates; a *repeat* run for the same tab (i.e. a gutter-driven one) re-scrolls only if the tab is no longer fully inside the strip. `isTabFullyVisible` compares the rects and subtracts the strip's inline padding, so a tab hidden under a chevron still counts as out of view — the correction the old deps existed for is preserved, minus the redundant animations.
- Docs: `apps/docs/src/user-guide/tabs-split-view.md` — one line on the single scroll animation, one line stating tabs are never auto-closed.

### Deliberately NOT done: the tab cap

The issue also asks for a `maxTabs` soft cap with LRU-close. I did not add one, on purpose:

- **Every cap variant can destroy user state.** LRU-closing loses a tab the user deliberately kept (and `recentlyClosed` only retains 25 entries, in memory, so it is not a safety net across a restart). Refusing to open past a limit means clicking a note in the sidebar silently does nothing. Both are worse than the thing they fix. This is a live-user build; tab state is persisted.
- **The cost being capped is already small and already bounded.** Hidden tabs are not mounted — `split-view/tab-pane.tsx:57` renders `<TabContent>` for the active tab only — so an idle tab costs one record plus its `viewState`. The other per-tab accumulators are already capped: activation history at 50 (`reducers/history-helpers.ts:3`), recently-closed at 25 (`reducers/tab-crud-reducer.ts:29`), and the persistence serialize + `JSON.stringify` now runs once per debounce window rather than per state change (#1174, which closed #1056 — re-verified in `persistence/hooks.ts:62-88`).
- The user-facing remedy already exists and is non-destructive: **Close others** / **Close to the right** / **Close all** in the tab context menu, now called out in the docs.

The only `maxTabs` reference in the tree is a stray field in a test fixture (`persistence/persistence.test.tsx:112`) that is cast away and read by nothing; left untouched as pre-existing dead data. Since no cap is introduced, a persisted session of any size still restores in full.

## How it was proven

New `apps/desktop/src/renderer/src/components/tabs/tab-bar-scroll.test.tsx` drives the real component with stubbed strip geometry (`scrollWidth` / `clientWidth` / `scrollLeft`), so the gutter flags flip exactly as they do in the app, and counts `scrollIntoView` calls.

| | after mount+activation | after the second gutter flips | after switching to another tab |
|---|---|---|---|
| before (`origin/main` source, same test) | **2** | **3** | 3 |
| after | **1** | **1** | 2 (1 per activation) |

- Before: `git checkout origin/main -- …/tab-bar-with-drag.tsx` → `Test Files 1 failed (1) / Tests 2 failed (2)` — `expected "vi.fn()" to be called 1 times, but got 2 times`.
- After: `Test Files 1 passed (1) / Tests 2 passed (2)`.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  src/renderer/src/components/tabs src/renderer/src/components/cold-major-components.test.tsx \
  src/renderer/src/components/small-zero-surfaces.test.tsx src/renderer/src/components/split-view
  → Test Files 17 passed (17), Tests 90 passed (90)
    (includes the pre-existing "scrolls the active tab into view so it never stays
     past the strip edge" case, still green)

pnpm --filter @memry/desktop typecheck:web   → clean
pnpm exec eslint …/tab-bar-with-drag.tsx     → 0 errors
git diff --check                             → clean
pnpm docs:impact --base origin/main --strict → covered
pnpm docs:build                              → build complete
```

## Backward compatibility

Render-time only: no schema, contract, settings, persisted-tab-state, or sync-shape change, and no cap that could drop tabs from an existing session.
