### PR TITLE
docs(vault): note the batch-stable notes folder in the embed config read

### DIFF
--- a/apps/desktop/src/main/vault/resolve-embed.ts
+++ b/apps/desktop/src/main/vault/resolve-embed.ts
@@ -173,7 +173,10 @@ export function resolveVaultEmbeds(refs: string[], notePath?: string): Record<st
 
   // Read once per batch, not once per ref: `getConfig` no longer re-parses
   // config.json — the parse is cached — but every call still stats the file to
-  // revalidate that cache and rebuilds the config object it hands back.
+  // revalidate that cache and rebuilds the config object it hands back. Reading
+  // it once also pins one notes folder for the whole batch, so a config change
+  // landing mid-resolve cannot send half a note's embeds to the old folder and
+  // half to the new one.
   const notesFolder = getConfig().defaultNoteFolder || 'notes'
 
   return resolveAgainstVault(status.path, notesFolder, refs, notePath)


### PR DESCRIPTION
## What

Extends the comment above the once-per-batch `getConfig()` call in `resolveVaultEmbeds` with the second reason the read is hoisted: one read pins one notes folder for the whole batch.

## Why

PR #1261 corrected the stale cost claim (the parse is cached since #1241; each call still stats config.json and rebuilds the config object) but left the consistency reason unstated — a config change landing mid-resolve must not send half a note's embeds to the old folder and half to the new one. Comment-only, no behaviour change.