### PR TITLE
fix(notifications): clear the delivered banner when a reminder is deleted or bulk-dismissed

### DIFF
--- a/apps/desktop/src/main/lib/reminders.test.ts
+++ b/apps/desktop/src/main/lib/reminders.test.ts
@@ -650,6 +650,45 @@ describe('reminders service', () => {
       expect(MockNotification.remove).toHaveBeenCalledWith('rem-nc2')
     })
 
+    it('removes the delivered notification banner on delete', () => {
+      setPlatform('darwin')
+      seedReminder({ id: 'rem-nc7', status: reminderStatus.TRIGGERED })
+
+      expect(remindersService.deleteReminder('rem-nc7')).toBe(true)
+      expect(MockNotification.remove).toHaveBeenCalledWith('rem-nc7')
+    })
+
+    it('leaves delivered banners alone when the delete finds no row', () => {
+      setPlatform('darwin')
+
+      expect(remindersService.deleteReminder('rem-nc-missing')).toBe(false)
+      expect(MockNotification.remove).not.toHaveBeenCalled()
+    })
+
+    it('removes the delivered banner for every reminder in a bulk dismiss', () => {
+      setPlatform('darwin')
+      seedReminder({ id: 'rem-nc8', status: reminderStatus.TRIGGERED })
+      seedReminder({ id: 'rem-nc9', status: reminderStatus.TRIGGERED })
+      seedReminder({ id: 'rem-nc10', status: reminderStatus.TRIGGERED })
+
+      expect(remindersService.bulkDismissReminders(['rem-nc8', 'rem-nc9'])).toBe(2)
+
+      expect(MockNotification.remove).toHaveBeenCalledWith('rem-nc8')
+      expect(MockNotification.remove).toHaveBeenCalledWith('rem-nc9')
+      // Not part of the batch: its banner must survive.
+      expect(MockNotification.remove).not.toHaveBeenCalledWith('rem-nc10')
+    })
+
+    it('skips bulk-dismiss ids that matched no row', () => {
+      setPlatform('darwin')
+      seedReminder({ id: 'rem-nc11', status: reminderStatus.TRIGGERED })
+
+      expect(remindersService.bulkDismissReminders(['rem-nc11', 'rem-nc-ghost'])).toBe(1)
+
+      expect(MockNotification.remove).toHaveBeenCalledWith('rem-nc11')
+      expect(MockNotification.remove).not.toHaveBeenCalledWith('rem-nc-ghost')
+    })
+
     it('does not touch delivered notifications on non-darwin platforms', () => {
       setPlatform('win32')
       seedReminder({ id: 'rem-nc3', status: reminderStatus.TRIGGERED })
@@ -755,6 +794,36 @@ describe('reminders service', () => {
 
       expect(notification.close).toHaveBeenCalledTimes(1)
       expect(Object.keys(notification.handlers)).toEqual([])
+    })
+
+    it('closes the live banner on delete and leaves other reminders alone', () => {
+      setPlatform('win32')
+      const deleted = fireDueReminder('rem-live-delete')
+      const untouched = fireDueReminder('rem-live-delete-keep')
+
+      remindersService.deleteReminder('rem-live-delete')
+
+      expect(deleted.close).toHaveBeenCalledTimes(1)
+      expect(Object.keys(deleted.handlers)).toEqual([])
+      // A reminder the user did not act on keeps its banner and its click handler.
+      expect(untouched.close).not.toHaveBeenCalled()
+      expect(Object.keys(untouched.handlers)).toContain('click')
+    })
+
+    it('closes the live banner for each bulk-dismissed reminder only', () => {
+      setPlatform('win32')
+      const first = fireDueReminder('rem-live-bulk-1')
+      const second = fireDueReminder('rem-live-bulk-2')
+      const untouched = fireDueReminder('rem-live-bulk-3')
+
+      expect(remindersService.bulkDismissReminders(['rem-live-bulk-1', 'rem-live-bulk-2'])).toBe(2)
+
+      expect(first.close).toHaveBeenCalledTimes(1)
+      expect(second.close).toHaveBeenCalledTimes(1)
+      expect(Object.keys(first.handlers)).toEqual([])
+      expect(Object.keys(second.handlers)).toEqual([])
+      expect(untouched.close).not.toHaveBeenCalled()
+      expect(Object.keys(untouched.handlers)).toContain('click')
     })
 
     it('supersedes its own earlier banner when the same reminder fires again', () => {

--- a/apps/desktop/src/main/lib/reminders.ts
+++ b/apps/desktop/src/main/lib/reminders.ts
@@ -262,8 +262,8 @@ function createReminderInboxItem(reminder: ReminderWithTarget): void {
  * captured `ReminderWithTarget`) and, when asked, dismiss the banner too.
  *
  * `dismissBanner` is only ever set for an explicit user action on that exact
- * reminder (clicking it, or dismissing/snoozing it in-app) — never on a timer —
- * so a banner the user has not looked at yet is left on screen.
+ * reminder (clicking it, or dismissing/snoozing/deleting it in-app) — never on
+ * a timer — so a banner the user has not looked at yet is left on screen.
  *
  * @param reminderId - Stable reminder id used as the notification id
  * @param dismissBanner - Also close the on-screen notification
@@ -396,8 +396,8 @@ function showDesktopNotification(reminder: ReminderWithTarget): void {
  * Center. `Notification.remove` is Electron 42+ and only implemented on
  * macOS — everywhere else this is a silent no-op.
  *
- * Called after the user has dismissed or snoozed that reminder in-app, so
- * closing its own still-live notification is the point, not a side effect:
+ * Called after the user has dismissed, snoozed or deleted that reminder in-app,
+ * so closing its own still-live notification is the point, not a side effect:
  * on Windows/Linux `close()` is the only way to retire the banner at all.
  * @param reminderId - Stable reminder id used as the notification id
  */
@@ -568,6 +568,10 @@ export function deleteReminder(id: string): boolean {
     targetId: reminder.targetId
   })
   syncReminderCalendarState(id)
+  // Deleting is an explicit user action on this exact reminder, so its banner
+  // must go with the row — otherwise Notification Center keeps a clickable
+  // banner that navigates to something that no longer exists.
+  removeDeliveredNotification(id)
   updateAppBadge()
 
   logger.info(`Deleted reminder ${id}`)
@@ -820,6 +824,10 @@ export function bulkDismissReminders(reminderIds: string[]): number {
       dismissedCount++
       enqueueLocalSyncUpdate('reminder', id)
       syncReminderCalendarState(id)
+      // Same contract as the single-reminder dismiss: only ids the user actually
+      // dismissed (changes > 0) lose their banner, so an unrelated reminder that
+      // is not part of this batch is left alone.
+      removeDeliveredNotification(id)
     }
   }
 

--- a/apps/docs/src/user-guide/snooze-reminders.md
+++ b/apps/docs/src/user-guide/snooze-reminders.md
@@ -58,7 +58,7 @@ memrynote shows a toast with:
 - Title and snippet
 - Action buttons (snooze 5 min, snooze 10 min, custom snooze, open, dismiss)
 
-A system notification is shown as well. Dismissing or snoozing the reminder also retires its system notification — on macOS it is removed from Notification Center, and on Windows and Linux the banner is closed — so handled reminders don't pile up. If a snoozed reminder comes due again, its new notification replaces the earlier one for that reminder instead of stacking a second banner. Notifications you haven't acted on are never dismissed for you.
+A system notification is shown as well. Dismissing, snoozing, or deleting the reminder also retires its system notification — on macOS it is removed from Notification Center, and on Windows and Linux the banner is closed — so handled reminders don't pile up. "Dismiss all" does the same for every reminder in the batch, and only for those: a reminder that wasn't part of the action keeps its notification. If a snoozed reminder comes due again, its new notification replaces the earlier one for that reminder instead of stacking a second banner. Notifications you haven't acted on are never dismissed for you.
 
 Dismissing or snoozing a reminder syncs to your other devices, so a reminder you've handled on one device won't fire again on another. Each device still shows its own toast and system notification locally when the reminder's time arrives.
 


### PR DESCRIPTION
Closes #1284. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`removeDeliveredNotification()` (`apps/desktop/src/main/lib/reminders.ts:404`) is the single place that retires a reminder's delivered banner — it calls `releaseNotification(id, true)` (closes the live `Notification`, detaches the `click`/`close`/`failed` listeners that capture the whole `ReminderWithTarget`) and, on macOS, `Notification.remove(id)` to pull the banner out of Notification Center.

`dismissReminder` and `snoozeReminder` both call it. Two other paths that also retire a reminder did not:

```ts
// deleteReminder — before
emitEvent(ReminderChannels.events.DELETED, { id, targetType, targetId })
syncReminderCalendarState(id)
updateAppBadge()          // row is gone; banner is not

// bulkDismissReminders — before
if (result.changes > 0) {
  dismissedCount++
  enqueueLocalSyncUpdate('reminder', id)
  syncReminderCalendarState(id) // no banner teardown anywhere in the loop
}
```

Consequences: deleting a reminder left a clickable macOS banner that navigates to a row that no longer exists, and "dismiss all" left every banner in the batch on screen even though the single-item dismiss right next to it clears its own. The listener closures for those banners also stayed attached, keeping their `ReminderWithTarget` alive until the map's 50-entry cap evicted them.

## What changed

Two call sites, reusing the machinery that landed in #1272 rather than adding a second mechanism:

- `deleteReminder` — `removeDeliveredNotification(id)` after `syncReminderCalendarState(id)`. It sits after the existing early `return false` for a missing row, so a delete that matched nothing touches no notification.
- `bulkDismissReminders` — `removeDeliveredNotification(id)` inside the existing `if (result.changes > 0)` branch, so only ids that were actually dismissed lose their banner. Ids in the array that matched no row are skipped.

Plus two doc-comment lines updated to mention the delete path, and one user-guide paragraph in `apps/docs/src/user-guide/snooze-reminders.md`.

Deliberately **not** done:

- No new teardown mechanism, no change to `releaseNotification` / `trackNotification` / the 50-entry cap.
- `bulkDismissReminders` still does not emit a `DISMISSED` event per id (the single-item path does). That asymmetry predates this issue and is out of scope.
- The `dismissBanner` contract from #1272 is preserved: `close()` is still only reachable from an explicit user action on that exact reminder. Delete and bulk-dismiss are such actions; the scheduler, the cap eviction, and the `close`/`failed` listeners all still pass `dismissBanner = false`.

## How it was proven

7 new tests in `apps/desktop/src/main/lib/reminders.test.ts` (real service against a real SQLite test db, `Notification` mocked at the Electron boundary; both the macOS `Notification.remove` path and the Windows/Linux `close()` path are asserted).

Same test file, source reverted to `origin/main` vs. with the fix:

| run | result |
| --- | --- |
| before (`git checkout origin/main -- apps/desktop/src/main/lib/reminders.ts`) | **5 failed \| 54 passed (59)** |
| after | **59 passed (59)** |

The 5 that fail without the fix:

- `removes the delivered notification banner on delete`
- `removes the delivered banner for every reminder in a bulk dismiss`
- `skips bulk-dismiss ids that matched no row`
- `closes the live banner on delete and leaves other reminders alone`
- `closes the live banner for each bulk-dismissed reminder only`

The last two are the blast-radius proof the issue asked for: a second/third live banner that was **not** the deleted or bulk-dismissed reminder keeps `close()` uncalled and keeps its `click` handler attached. Two more tests cover the no-op guards (`deleteReminder` on a missing row, and a ghost id inside a bulk dismiss) so no banner is touched for something that was never dismissed.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts \
  --project main apps/desktop/src/main/lib/reminders.test.ts
  -> Test Files 1 passed (1) - Tests 59 passed (59)

pnpm --filter @memry/desktop typecheck:node   -> clean (no diagnostics)
./node_modules/.bin/eslint apps/desktop/src/main/lib/reminders.ts
  -> 0 errors, 0 warnings
git diff --check                              -> clean
pnpm docs:impact --base origin/main --strict  -> covered
pnpm docs:build                               -> build complete in 3.52s
```

Renderer typecheck not run — no renderer files touched.

## Backward compatibility

Main-process behavior only: no schema, IPC contract, sync payload, or settings shape is touched, and `Notification.remove` stays behind its existing `darwin` + `typeof === 'function'` guards, so Electron <42, Windows, and Linux are unaffected.
