### PR TITLE
fix(crdt): resolve the write-back doc by note id at fire time

### DIFF
--- a/apps/desktop/src/main/sync/crdt-writeback.test.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.test.ts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   deleteNoteFromCache: vi.fn(),
   flushProjectionEvents: vi.fn(),
   closeDoc: vi.fn(),
+  getDoc: vi.fn(),
   syncNoteDateReminders: vi.fn(),
   clearNoteDateReminders: vi.fn(),
   createRemindersService: vi.fn(),
@@ -56,7 +57,7 @@ vi.mock('../lib/logger', () => ({
 }))
 
 vi.mock('./crdt-provider', () => ({
-  getCrdtProvider: () => ({ close: mocks.closeDoc })
+  getCrdtProvider: () => ({ close: mocks.closeDoc, getDoc: mocks.getDoc })
 }))
 
 vi.mock('./blocknote-converter', () => ({
@@ -190,6 +191,10 @@ describe('crdt writeback', () => {
     mocks.deleteFile.mockResolvedValue(undefined)
     mocks.ensureDirectory.mockResolvedValue(undefined)
     mocks.closeDoc.mockResolvedValue(undefined)
+    // Default: the note is not in the provider's map (closed, or never opened
+    // through the provider), so a pending write-back falls back to the doc it
+    // captured — the behaviour every case below except the reopen ones wants.
+    mocks.getDoc.mockReturnValue(undefined)
     mocks.maybeCreateSignificantSnapshot.mockReturnValue({ id: 'snap-1' })
   })
 
@@ -585,6 +590,120 @@ describe('crdt writeback', () => {
         options: { frontmatterEdited: true }
       })
     )
+  })
+
+  /**
+   * The note's markdown file, for real: `safeRead` hands back what the last
+   * `atomicWrite` put there, and the body written is a pure function of the doc
+   * that was serialized. That is what makes an overwrite by a stale doc show up
+   * as the wrong bytes in the file instead of as a mock-call shape.
+   */
+  describe('a note closed and reopened inside the debounce window', () => {
+    let vaultFile = ''
+
+    function makeDocWithBody(body: string): Y.Doc {
+      const doc = makeDoc('Existing')
+      doc.getText('body').insert(0, body)
+      return doc
+    }
+
+    beforeEach(() => {
+      vaultFile = ''
+      mocks.yDocToMarkdown.mockImplementation(async (doc: Y.Doc) => doc.getText('body').toString())
+      mocks.safeRead.mockImplementation(async () => vaultFile)
+      mocks.atomicWrite.mockImplementation(async (_path: string, content: string) => {
+        vaultFile = content
+      })
+      mocks.parseNote.mockImplementation((raw: string) => ({ frontmatter: {}, content: raw }))
+      mocks.serializeParsedNote.mockImplementation((_parsed, markdown: string) => markdown)
+      mocks.serializeNote.mockImplementation((_frontmatter, markdown: string) => markdown)
+    })
+
+    it('does not overwrite the file with the superseded doc when the note was reopened', async () => {
+      // #given — the user edits, arming a write-back against the doc that is
+      // live right now
+      const closedDoc = makeDocWithBody('paragraph one')
+      vaultFile = 'paragraph one'
+      scheduleWriteback('note-1', closedDoc)
+
+      // #when — the note is closed and reopened inside the debounce: the
+      // provider's map now holds a different Y.Doc for the same id, and a sync
+      // pull has already landed the remote paragraph in both the file and the
+      // reopened doc
+      const reopenedDoc = makeDocWithBody('paragraph one\n\nparagraph two from another device')
+      vaultFile = 'paragraph one\n\nparagraph two from another device'
+      mocks.getDoc.mockReturnValue(reopenedDoc)
+
+      await vi.advanceTimersByTimeAsync(500)
+
+      // #then — the file still holds the live content. Serializing the
+      // superseded doc here would have written 'paragraph one' back over it and
+      // destroyed the pulled paragraph.
+      expect(vaultFile).toBe('paragraph one\n\nparagraph two from another device')
+      expect(mocks.atomicWrite).not.toHaveBeenCalled()
+    })
+
+    it('writes the reopened doc, so content only that doc has still reaches disk', async () => {
+      // #given — same race, but this time the file is the stale side: the
+      // reopened doc holds content that has not been written yet
+      const closedDoc = makeDocWithBody('paragraph one')
+      vaultFile = 'paragraph one'
+      scheduleWriteback('note-1', closedDoc)
+
+      const reopenedDoc = makeDocWithBody('paragraph one\n\nparagraph two from another device')
+      mocks.getDoc.mockReturnValue(reopenedDoc)
+
+      await vi.advanceTimersByTimeAsync(500)
+
+      // #then — the pass serialized the live doc, so the new paragraph lands.
+      // Serializing the superseded doc would have produced a byte-identical
+      // no-op and left it on disk-less limbo until the next edit.
+      expect(vaultFile).toBe('paragraph one\n\nparagraph two from another device')
+      expect(mocks.atomicWrite).toHaveBeenCalledWith(
+        '/vault/notes/Existing.md',
+        'paragraph one\n\nparagraph two from another device'
+      )
+    })
+
+    it('still lands a pending write-back for a note that was NOT superseded', async () => {
+      // #given — the note stays open on the same doc for the whole debounce
+      const liveDoc = makeDocWithBody('paragraph one edited')
+      vaultFile = 'paragraph one'
+      mocks.getDoc.mockReturnValue(liveDoc)
+
+      scheduleWriteback('note-1', liveDoc)
+      await vi.advanceTimersByTimeAsync(500)
+
+      expect(vaultFile).toBe('paragraph one edited')
+    })
+
+    it('still lands a pending write-back for a note that was closed and not reopened', async () => {
+      // #given — the note is closed (or LRU-evicted) before the timer fires, so
+      // the provider has no doc for it. The captured doc is the last known
+      // state and must not be dropped on the floor.
+      const closedDoc = makeDocWithBody('paragraph one edited')
+      vaultFile = 'paragraph one'
+      scheduleWriteback('note-1', closedDoc)
+      mocks.getDoc.mockReturnValue(undefined)
+
+      await vi.advanceTimersByTimeAsync(500)
+
+      expect(vaultFile).toBe('paragraph one edited')
+    })
+
+    it('resolves the live doc on the shutdown flush too', async () => {
+      const closedDoc = makeDocWithBody('paragraph one')
+      vaultFile = 'paragraph one\n\nparagraph two from another device'
+      scheduleWriteback('note-1', closedDoc)
+
+      mocks.getDoc.mockReturnValue(
+        makeDocWithBody('paragraph one\n\nparagraph two from another device')
+      )
+      await flushPendingWritebacks()
+
+      expect(vaultFile).toBe('paragraph one\n\nparagraph two from another device')
+      expect(mocks.atomicWrite).not.toHaveBeenCalled()
+    })
   })
 })
 

--- a/apps/desktop/src/main/sync/crdt-writeback.test.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.test.ts
@@ -633,6 +633,11 @@ describe('crdt writeback', () => {
       const reopenedDoc = makeDocWithBody('paragraph one\n\nparagraph two from another device')
       vaultFile = 'paragraph one\n\nparagraph two from another device'
       mocks.getDoc.mockReturnValue(reopenedDoc)
+      // What `CrdtProvider.close()` does to the doc it superseded. It is not
+      // what makes this safe: a destroyed Y.Doc keeps its store readable, so
+      // the stale pass would serialize it just fine.
+      closedDoc.destroy()
+      expect(closedDoc.getText('body').toString()).toBe('paragraph one')
 
       await vi.advanceTimersByTimeAsync(500)
 

--- a/apps/desktop/src/main/sync/crdt-writeback.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.ts
@@ -242,11 +242,37 @@ function writebackDelayMs(noteId: string): number {
   return Math.max(WRITEBACK_DEBOUNCE_MS, last.finishedAt + cooldownMs - Date.now())
 }
 
+/**
+ * The doc to serialize for this note at the moment the pass actually runs.
+ *
+ * A scheduled write-back captures the Y.Doc that was live when it was armed,
+ * but a note can be closed and reopened inside the debounce window: `doOpen`
+ * puts a *different* Y.Doc in the provider's map for the same note id, and the
+ * still-armed timer would otherwise serialize the superseded doc straight onto
+ * the markdown file — clobbering whatever landed there in the meantime (a sync
+ * pull writing the file, an external editor, or the replacement doc's own
+ * state). Destroying the superseded doc on the close path does not prevent
+ * this: `Y.Doc.destroy()` leaves the doc's store readable, so the stale
+ * serialize still succeeds.
+ *
+ * The provider's map is the authority for "which doc is this note", so resolve
+ * by note id here rather than trusting the captured reference. When the note is
+ * genuinely absent from the map — closed and not reopened, or evicted by the
+ * inactive-doc LRU — the captured doc is still the last known state and its
+ * write-back must still land, so it stays the fallback.
+ */
+function resolveWritebackDoc(noteId: string, captured: Y.Doc): Y.Doc {
+  const live = getCrdtProvider().getDoc(noteId)
+  if (!live || live === captured) return captured
+  log.debug('Write-back doc was superseded; serializing the live doc', { noteId })
+  return live
+}
+
 /** Runs a pass and records what it cost, which is what paces the next one. */
 async function runWriteback(noteId: string, doc: Y.Doc): Promise<void> {
   const startedAt = Date.now()
   try {
-    await performWriteback(noteId, doc)
+    await performWriteback(noteId, resolveWritebackDoc(noteId, doc))
   } finally {
     const finishedAt = Date.now()
     lastWritebackCost.set(noteId, { finishedAt, durationMs: finishedAt - startedAt })

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -107,7 +107,9 @@ over the provider's entry for that note, and the close then finds that the entry
 belongs to it. It leaves that entry alone, because the reopened doc is the one the editor
 is typing into, and destroys only the doc it superseded. Nothing can reach the superseded
 doc at that point: every route into a Y.Doc looks the note id up in the provider's map,
-which now resolves the replacement.
+which now resolves the replacement. That includes a write-back armed before the close —
+destroying the superseded doc is not what makes it safe, since a destroyed Y.Doc can still
+be read; resolving the note id when the pass runs is.
 
 ## IPC Loop Prevention
 
@@ -132,6 +134,13 @@ document to its vault `.md` file and re-indexes it for search.
 - **Nothing is deferred indefinitely** — the trailing pass always runs, and
   `flushPendingWritebacks()` forces any pending pass through before the CRDT provider is
   destroyed, which covers app quit and vault switch.
+- **The doc is resolved when the pass runs, not when it is scheduled** — a note closed and
+  reopened inside the debounce window gets a fresh Y.Doc, so the pass looks the note id up
+  in the provider's map at fire time rather than serializing the doc it captured. Otherwise
+  the file would be overwritten with the superseded doc's content, discarding whatever
+  landed in the meantime. A note that is genuinely gone from the map — closed and not
+  reopened, or LRU-evicted — still has its pending pass written from the captured doc, so
+  no edit is dropped.
 - **Per-vault bookkeeping** — write-back tracks self-written files and recent inbound
   network updates in short-TTL maps. Entries are evicted in an amortized pass (at most one
   sweep per TTL window) rather than scanned on every watcher event, and


### PR DESCRIPTION
Closes #1280. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/sync/crdt-writeback.ts` — `scheduleWriteback` captured the `Y.Doc` object itself, and the timer fired against that captured reference:

```ts
const timer = setTimeout(() => {
  pendingTimers.delete(noteId)
  inFlightWritebacks.add(noteId)
  runWriteback(noteId, doc)   // <- the doc captured when the timer was armed
  ...
}, writebackDelayMs(noteId))
```

Nothing on the close path re-targeted or cancelled it. `CrdtProvider.close()` is async (it flushes to persistence first), so a note closed and reopened inside the debounce window ends up with a **new** `Y.Doc` in `this.docs` while the still-armed timer serializes the **old** one straight onto the vault markdown file (`yDocToMarkdown(doc)` → `atomicWrite`). The file is overwritten with content from a doc that is no longer the source of truth, clobbering whatever landed there in the meantime — a sync pull writing the file, an external editor, or the replacement doc's own state. This is the note-content route, so the consequence is user data loss.

`hasPendingWriteback` guards markdown-as-truth readers but does not help here: the stale doc *is* the writer.

### Interaction with #1268 (merged)

#1268 destroys the superseded `Y.Doc` when a note is reopened mid-close, and its comment claims "nothing outside the provider retains a Y.Doc across awaits". The pending write-back timer was exactly such a retainer, and `Y.Doc.destroy()` leaves the doc's store readable — `yDocToMarkdown` on a destroyed doc still returns its full content. Verified two ways: a standalone probe (`doc.getText('body').insert(...)`, `doc.destroy()`, then read) still returns `"paragraph one"`, the meta map, the tags array and a 65-byte `encodeStateAsUpdate`; and the repro test below calls `closedDoc.destroy()` at exactly the point `close()` does, asserts the destroyed doc is still readable, and the stale write still lands on the unfixed source. So #1268 does not prevent this write; it only means the stale serialize reads from a destroyed object. The two changes are complementary: #1268 detaches the superseded doc's `update` listener, this PR stops the write-back from reading it. With both in, the "every route into a Y.Doc looks the note id up in the provider's map" invariant that #1268's comment asserts is finally true.

## What changed

One helper, called from `runWriteback` — which is the single funnel for both the debounce timer and `flushPendingWritebacks`, so shutdown flush is covered by the same code path:

```ts
function resolveWritebackDoc(noteId: string, captured: Y.Doc): Y.Doc {
  const live = getCrdtProvider().getDoc(noteId)
  if (!live || live === captured) return captured
  log.debug('Write-back doc was superseded; serializing the live doc', { noteId })
  return live
}
```

**Resolve at fire time, not cancel on supersede.** Both options were on the table; resolve is the one that is provably correct:

- Cancelling the note's pending timer inside `CrdtProvider.close()` would *lose* a legitimate write-back — the vault file would stay behind the reopened doc until the next edit re-armed a timer, which for a note that is reopened and then just read never happens.
- Cancelling only covers the reopen that `close()` itself detects. Resolving by id also covers the other doc-identity swap in the provider (`compactDoc` replaces `entry.doc` in place) and needs no new coupling from the provider back into write-back.
- The live doc is never *older* than the captured one: a reopen loads from the same LevelDB store the captured doc's updates were persisted into (and `close()` flushes before releasing the entry), and `compactDoc` builds its replacement from the compacted state plus every buffered update.
- Falling back to the captured doc when the map has no entry keeps the "closed and not reopened" and "LRU-evicted" cases writing exactly what they write today.

Deliberately **not** done: no per-note cancel/flush API added to write-back, and `CrdtProvider.close()` is untouched — the fix needs neither, and adding a cancel path is what would introduce the lost-write risk.

## How it was proven

New `describe('a note closed and reopened inside the debounce window')` in `crdt-writeback.test.ts`. It backs `safeRead`/`atomicWrite` with an in-memory stand-in for the note's `.md` file and makes the serialized body a pure function of the doc handed to the pass, so an overwrite by a stale doc shows up as **the wrong bytes in the file**, not as a mock-call shape.

- `does not overwrite the file with the superseded doc when the note was reopened` — file and reopened doc both hold `paragraph one\n\nparagraph two from another device`, the superseded doc holds `paragraph one`. Before: the file is overwritten with `paragraph one` and the pulled paragraph is gone. After: file untouched, no write at all (byte-identical no-op).
- `writes the reopened doc, so content only that doc has still reaches disk` — the mirror case where the file is the stale side.
- `resolves the live doc on the shutdown flush too` — same race through `flushPendingWritebacks()`.
- `still lands a pending write-back for a note that was NOT superseded` and `... for a note that was closed and not reopened` — the no-lost-writes controls; both pass before and after, i.e. the fix does not buy safety by dropping writes.

Before/after on the same test file (source reverted to `origin/main`, tests kept):

```
before: Tests  3 failed | 22 passed (25)
after:  Tests  25 passed (25)
```

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  apps/desktop/src/main/sync/crdt-writeback.test.ts \
  apps/desktop/src/main/sync/crdt-provider.test.ts \
  apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
  -> Test Files 3 passed (3), Tests 84 passed (84)

pnpm --filter @memry/desktop typecheck:node   -> clean
pnpm exec eslint apps/desktop/src/main/sync/crdt-writeback.ts   -> 0 errors
git diff --check                              -> clean
pnpm docs:impact --base origin/main --strict  -> covered
pnpm docs:build                               -> build complete
```

## Backward compatibility

No schema, IPC contract, settings or sync-payload change — a pending write-back now serializes the live doc for that note id instead of a stale reference, so older data and older peers are unaffected.
