### PR TITLE
perf(sync): ignore a worker thread the bridge has already walked away from

### DIFF
--- a/apps/desktop/src/main/sync/worker-bridge.test.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.test.ts
@@ -274,6 +274,115 @@ describe('SyncWorkerBridge', () => {
     })
   })
 
+  describe('#given a timed-out stop() and a restart #when the abandoned thread speaks', () => {
+    const startReady = async (): Promise<MockWorker> => {
+      const p = bridge.start()
+      mockWorkerInstance.simulateMessage({ type: 'ready' })
+      await p
+      return mockWorkerInstance
+    }
+
+    /**
+     * stop() that hits the 3s timeout — terminate() is fired but the thread is
+     * abandoned without waiting for its exit — followed by the documented
+     * in-session recovery, start() on a fresh thread.
+     */
+    const abandonThenRestart = async (): Promise<[MockWorker, MockWorker]> => {
+      const abandoned = await startReady()
+      const stopPromise = bridge.stop()
+      vi.advanceTimersByTime(3_001)
+      await stopPromise
+
+      const live = await startReady()
+      expect(live).not.toBe(abandoned)
+      return [abandoned, live]
+    }
+
+    const inFlightEncrypt = (
+      live: MockWorker
+    ): { promise: Promise<unknown>; requestId: string } => {
+      const promise = bridge.encryptBatch([], new Uint8Array(32), new Uint8Array(64), 'device-1')
+      const posted = live.postMessage.mock.calls
+        .filter(([m]) => m.type === 'encrypt-batch')
+        .at(-1)?.[0]
+      // Never issued means the bridge refused the batch — the wedge this suite
+      // is about. Keep going so the assertion reports the rejection, not a
+      // TypeError on the missing message.
+      return { promise, requestId: posted?.requestId ?? 'never-issued' }
+    }
+
+    it('#then a batch submitted after its exit still reaches the live worker', async () => {
+      // #given
+      const [abandoned, live] = await abandonThenRestart()
+
+      // #when — terminate() lands and the abandoned thread finally exits, with
+      // the non-zero code terminate() produces
+      abandoned.simulateExit(1)
+
+      // #then — the bridge still owns the live thread, so a new batch goes to
+      // the worker instead of rejecting with 'Worker not started' and degrading
+      // the rest of the session to main-thread crypto
+      const { promise, requestId } = inFlightEncrypt(live)
+      live.simulateMessage({
+        type: 'encrypt-batch-result',
+        requestId,
+        results: [],
+        errors: []
+      })
+      await expect(promise).resolves.toEqual({ results: [], errors: [] })
+      expect(bridge.isRunning).toBe(true)
+    })
+
+    it('#then its message and error listeners are detached too, not just exit', async () => {
+      // #given
+      const [abandoned] = await abandonThenRestart()
+
+      // #when
+      abandoned.simulateExit(1)
+
+      // #then — nothing of the bridge is left on the thread it walked away from
+      expect(abandoned.listenerCount('message')).toBe(0)
+      expect(abandoned.listenerCount('error')).toBe(0)
+      expect(abandoned.listenerCount('exit')).toBe(0)
+    })
+
+    it('#then a late reply from it cannot answer the live worker request', async () => {
+      // #given
+      const [abandoned, live] = await abandonThenRestart()
+      const { promise, requestId } = inFlightEncrypt(live)
+
+      // #when — the abandoned thread replies against the live thread's request
+      abandoned.simulateMessage({ type: 'error', requestId, error: 'ghost batch' })
+
+      // #then — only the live worker's own reply settles it
+      live.simulateMessage({
+        type: 'encrypt-batch-result',
+        requestId,
+        results: [],
+        errors: []
+      })
+      await expect(promise).resolves.toEqual({ results: [], errors: [] })
+    })
+
+    it('#then a late error from it cannot reject the live worker request', async () => {
+      // #given
+      const [abandoned, live] = await abandonThenRestart()
+      const { promise, requestId } = inFlightEncrypt(live)
+
+      // #when — terminate() tears the abandoned thread down mid-flight
+      abandoned.simulateError(new Error('terminated mid-batch'))
+
+      // #then
+      live.simulateMessage({
+        type: 'encrypt-batch-result',
+        requestId,
+        results: [],
+        errors: []
+      })
+      await expect(promise).resolves.toEqual({ results: [], errors: [] })
+    })
+  })
+
   describe('#given running bridge #when encryptBatch called', () => {
     it('#then sends message and returns result', async () => {
       // #given

--- a/apps/desktop/src/main/sync/worker-bridge.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.ts
@@ -102,10 +102,33 @@ export class SyncWorkerBridge {
     }
   }
 
-  private setupMessageHandler(): void {
-    if (!this.worker) return
+  /**
+   * True when `worker` is no longer the thread this bridge routes to.
+   *
+   * The handlers below are permanent, and stop()'s 3 s timeout walks away from
+   * a thread that is still alive: terminate() lands later, and by then a
+   * start() may have put a *different* thread in `this.worker`. Anything the
+   * abandoned thread says after that must not touch live state — its
+   * unconditional `this.worker = null` alone was enough to wedge every later
+   * batch on `Worker not started`.
+   *
+   * Detaching on the way out is what stops the abandoned thread talking to the
+   * bridge at all, `message` and `error` included, not just the `exit` that
+   * usually gets there first.
+   */
+  private isAbandoned(worker: Worker): boolean {
+    if (worker === this.worker) return false
+    worker.removeAllListeners()
+    return true
+  }
 
-    this.worker.on('message', (msg: WorkerToMainMessage) => {
+  private setupMessageHandler(): void {
+    const worker = this.worker
+    if (!worker) return
+
+    worker.on('message', (msg: WorkerToMainMessage) => {
+      if (this.isAbandoned(worker)) return
+
       // `ready` is consumed by start(); `shutdown-ack` is the expected reply to
       // stop() and carries no requestId. Neither is a dropped reply.
       if (msg.type === 'ready' || msg.type === 'shutdown-ack') return
@@ -133,12 +156,16 @@ export class SyncWorkerBridge {
       })
     })
 
-    this.worker.on('error', (err: Error) => {
+    worker.on('error', (err: Error) => {
+      if (this.isAbandoned(worker)) return
+
       log.error('Sync worker error', err)
       this.rejectAll(err)
     })
 
-    this.worker.on('exit', (code) => {
+    worker.on('exit', (code) => {
+      if (this.isAbandoned(worker)) return
+
       if (code !== 0) {
         log.error('Sync worker exited unexpectedly', { code })
         log.warn('Crypto operations will fall back to main thread')

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -669,3 +669,9 @@ Shutting the bridge down asks the worker to exit and waits three seconds before 
 worker that misses that window is fully detached first, so the exit that terminating eventually
 produces cannot land on a bridge that has already been restarted and cancel the new worker's
 in-flight batches.
+
+The bridge only listens to the thread it is currently routing to. A message, error, or exit that
+arrives from a thread it has already walked away from is ignored, and that thread is disconnected
+outright. Without this, the late exit of a terminated worker would take the _live_ worker out of the
+rotation — a bridge reporting no worker at all while a healthy thread sat idle, leaving every batch
+for the rest of the session on the main thread.


### PR DESCRIPTION
Closes #1281. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/sync/worker-bridge.ts:105-150` (pre-fix) — the `message` / `error` / `exit`
listeners installed by `setupMessageHandler` are permanent and unconditional. The exit handler in
particular:

```ts
this.worker.on('exit', (code) => {
  if (code !== 0) { ...; this.rejectAll(new Error(`Worker exited with code ${code}`)) }
  this.worker = null
})
```

`stop()` abandons a thread when shutdown times out: it fires `terminate()` and returns after 3 s
without waiting for the real `exit`. `start()` then puts a **different** thread in `this.worker`.
When the abandoned thread's exit finally lands — with the non-zero code `terminate()` produces — its
still-attached handler runs `rejectAll()` and `this.worker = null` against the *live* bridge.
`isRunning` (`this.worker !== null && !this.latchedOff`) goes false and every later batch takes the
`Worker not started` path at line 196, so sync crypto stays on the main thread for the rest of the
session while a perfectly healthy worker thread sits idle.

This is a different mechanism from #1092 / PR #1262 (now merged). That fix detaches the *stop-local*
`once('exit')` listener; it does not touch these permanent handlers, so the wedge survived it.

## What changed

One private predicate plus a guard at the top of each of the three handlers:

```ts
private isAbandoned(worker: Worker): boolean {
  if (worker === this.worker) return false
  worker.removeAllListeners()
  return true
}
```

`setupMessageHandler` captures the thread it is wiring up in a local `const worker`, and every
handler returns early unless that thread is still the bridge's current one. The first thing an
abandoned thread says also detaches it outright — `message` and `error` included, not just `exit`.

Deliberately **not** done:

- **#1262 is left intact.** Its `worker.off('exit', onExit)` before `terminate()` stays, and so do
  both of its tests. The two are not redundant: `off()` runs synchronously inside the timeout
  callback, whereas `removeAllListeners()` here can only run once the abandoned thread speaks.
- **No blanket `removeAllListeners()` in `stop()`.** It would fix the timeout path, but it would also
  make the identity guard unreachable and #1262's structural listener-count test vacuous. Detaching
  from inside the guard covers *every* way a thread can be abandoned, present or future, and is
  deterministic in practice because `terminate()` guarantees an eventual `exit`. Nothing leaks in the
  meantime: the bridge no longer references the abandoned `Worker`, and the handler closures only
  reference it in a self-contained, collectable cycle.

## How it was proven

Four new tests in `apps/desktop/src/main/sync/worker-bridge.test.ts`, all under
`#given a timed-out stop() and a restart #when the abandoned thread speaks`. The first is the
end-to-end symptom: time out `stop()`, `start()` a fresh thread, fire `exit(1)` on the abandoned one,
then submit a crypto batch to the new worker.

Source file reverted to `origin/main`, tests kept:

```
Tests  4 failed | 27 passed (31)
  → #then a batch submitted after its exit still reaches the live worker
      promise rejected "Error: Worker not started" instead of resolving
  → #then its message and error listeners are detached too, not just exit
      expected 1 to be +0
  → #then a late reply from it cannot answer the live worker request
      promise rejected "Error: ghost batch" instead of resolving
  → #then a late error from it cannot reject the live worker request
      promise rejected "Error: terminated mid-batch" instead of resolving
```

Fix restored:

```
Tests  31 passed (31)
```

## Verification

| command | result |
| --- | --- |
| `vitest run --config config/vitest.config.ts --project main src/main/sync/worker-bridge.test.ts` | 1 file passed, 31/31 tests |
| `pnpm --filter @memry/desktop typecheck:node` | clean, no output |
| `pnpm exec eslint apps/desktop/src/main/sync/worker-bridge.ts` | 0 errors, 0 warnings |
| `git diff --check` | clean |
| `pnpm docs:impact --base origin/main --strict` | `covered` |
| `pnpm docs:build` | `build complete in 8.00s` |

Renderer typecheck not run — no renderer files touched.

## Backward compatibility

None affected: main-process-internal listener bookkeeping only. No schema, IPC contract, settings,
sync protocol, or on-disk format change.
