### PR TITLE
fix(tabs): surface tab-state save failures instead of losing the session silently

### DIFF
--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts
@@ -5,9 +5,12 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { useMutation } from '@tanstack/react-query'
+import { getI18n } from 'react-i18next'
+import { toast } from 'sonner'
 import { useTabs } from '@/contexts/tabs'
 import type { TabSystemState } from '@/contexts/tabs/types'
-import { getDefaultStorage, saveSync } from './storage'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { getDefaultStorage, isQuotaExceededError, saveSync } from './storage'
 import { serializeTabState, deserializeTabState, extractPinnedTabs } from './serialization'
 import type { TabStorage } from './types'
 import { registerPendingSave, unregisterPendingSave } from '@/lib/save-registry'
@@ -16,6 +19,7 @@ import { useFeatureFlags } from '@/hooks/use-feature-flags'
 
 const log = createLogger('TabPersistence:Hooks')
 const FLUSH_REGISTRY_KEY = 'tab-state'
+const SAVE_FAILURE_TOAST_ID = 'tab-state-save-failed'
 
 // =============================================================================
 // AUTO-SAVE HOOK
@@ -39,6 +43,7 @@ export const useTabPersistence = (options: UseTabPersistenceOptions = {}): void 
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastSavedRef = useRef<string>('')
   const stateRef = useRef(state)
+  const saveFailureNotifiedRef = useRef(false)
 
   // Keep ref in sync for flush registry access
   useEffect(() => {
@@ -75,9 +80,32 @@ export const useTabPersistence = (options: UseTabPersistenceOptions = {}): void 
 
       if (json === lastSavedRef.current) return
 
-      void storage.save(serialized).then(() => {
-        lastSavedRef.current = json
-      })
+      // A rejected save must never escape as an unhandled rejection: the
+      // adapters rethrow, so without a handler a full-quota localStorage write
+      // drops the user's session on the floor with nothing but a renderer log
+      // line. Handle it here, keep `lastSavedRef` on the last value that really
+      // reached storage so the next state change retries, and tell the user
+      // once that their tab layout is no longer being saved.
+      void storage
+        .save(serialized)
+        .then(() => {
+          lastSavedRef.current = json
+          saveFailureNotifiedRef.current = false
+        })
+        .catch((error: unknown) => {
+          log.error('Failed to save tab state:', error)
+          if (saveFailureNotifiedRef.current) return
+          saveFailureNotifiedRef.current = true
+
+          const t = getI18n().getFixedT(null, 'common')
+          const quota = isQuotaExceededError(error)
+          toast.error(t('tabs.persistence.saveFailed'), {
+            id: SAVE_FAILURE_TOAST_ID,
+            description: quota
+              ? t('tabs.persistence.saveFailedQuota')
+              : extractErrorMessage(error, t('tabs.persistence.saveFailedGeneric'))
+          })
+        })
     }, debounceMs)
 
     return () => {

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useManualPersistence, useSessionRestore, useTabPersistence } from './hooks'
-import { indexedDBAdapter, localStorageAdapter, saveSync } from './storage'
+import { indexedDBAdapter, isQuotaExceededError, localStorageAdapter, saveSync } from './storage'
 import { deserializeTabState, extractPinnedTabs, serializeTabState } from './serialization'
 import { STORAGE_KEY, type PersistedTabState, type TabStorage } from './types'
 import type { Tab, TabSystemState } from '@/contexts/tabs/types'
@@ -16,7 +16,12 @@ const mocks = vi.hoisted(() => ({
   registerPendingSave: vi.fn((_: string, callback: () => void) => {
     mocks.pendingSave = callback
   }),
-  unregisterPendingSave: vi.fn()
+  unregisterPendingSave: vi.fn(),
+  toastError: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: mocks.toastError }
 }))
 
 // Counts full tab-tree serializations so the auto-save tests can assert how many
@@ -370,6 +375,13 @@ describe('tab persistence serialization and storage', () => {
     setItem.mockRestore()
   })
 
+  it('recognises quota failures and only quota failures', () => {
+    expect(isQuotaExceededError(new DOMException('over quota', 'QuotaExceededError'))).toBe(true)
+    expect(isQuotaExceededError(new DOMException('over quota', 'QUOTA_EXCEEDED_ERR'))).toBe(true)
+    expect(isQuotaExceededError(new Error('disk on fire'))).toBe(false)
+    expect(isQuotaExceededError('QuotaExceededError')).toBe(false)
+  })
+
   it('saves, loads, and clears via indexedDB adapter', async () => {
     installIndexedDbMock()
 
@@ -444,6 +456,78 @@ describe('tab persistence hooks', () => {
     expect(mocks.serializeCalls).toBe(1)
     await waitFor(() => expect(storage.save).toHaveBeenCalledTimes(1))
     expect(storage.save).toHaveBeenCalledWith(expectedPersisted(CLOCK_START + 25))
+  })
+
+  it('reports a quota failure to the user and keeps saving afterwards', async () => {
+    const storage: TabStorage = {
+      save: vi
+        .fn()
+        .mockRejectedValueOnce(new DOMException('quota exceeded', 'QuotaExceededError'))
+        .mockResolvedValue(undefined),
+      load: vi.fn(),
+      clear: vi.fn()
+    }
+
+    const { rerender } = render(<TabPersistenceProbe storage={storage} debounceMs={25} />)
+
+    act(() => vi.advanceTimersByTime(25))
+    await waitFor(() => expect(storage.save).toHaveBeenCalledTimes(1))
+
+    // The rejected save must be handled, not left as an unhandled rejection:
+    // the user has to learn their session stopped being saved now, not at the
+    // next launch when the restored layout turns out to be stale.
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledTimes(1))
+    expect(mocks.toastError.mock.calls[0][0]).toBe('Your open tabs are no longer being saved')
+    expect(mocks.toastError.mock.calls[0][1]).toMatchObject({
+      description: expect.stringContaining('too large to store')
+    })
+
+    // One failure must not wedge the saver: the next tab-state change is still
+    // written, and the payload is the new state rather than the failed one.
+    const next = state()
+    next.tabGroups['group-1'].tabs[0] = tab({ title: 'After the quota error' })
+    mocks.tabsState = next
+    rerender(<TabPersistenceProbe storage={storage} debounceMs={25} />)
+
+    act(() => vi.advanceTimersByTime(25))
+    await waitFor(() => expect(storage.save).toHaveBeenCalledTimes(2))
+    expect(storage.save).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        tabGroups: expect.objectContaining({
+          'group-1': expect.objectContaining({
+            tabs: expect.arrayContaining([
+              expect.objectContaining({ title: 'After the quota error' })
+            ])
+          })
+        })
+      })
+    )
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+  })
+
+  it('warns once across a run of failures and falls back to the error message', async () => {
+    const storage: TabStorage = {
+      save: vi.fn().mockRejectedValue(new Error('storage backend offline')),
+      load: vi.fn(),
+      clear: vi.fn()
+    }
+
+    const { rerender } = render(<TabPersistenceProbe storage={storage} debounceMs={25} />)
+
+    act(() => vi.advanceTimersByTime(25))
+    await waitFor(() => expect(storage.save).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledTimes(1))
+    expect(mocks.toastError.mock.calls[0][1]).toMatchObject({
+      description: 'storage backend offline'
+    })
+
+    applyStateChanges(() => rerender(<TabPersistenceProbe storage={storage} debounceMs={25} />))
+    act(() => vi.advanceTimersByTime(25))
+    await waitFor(() => expect(storage.save).toHaveBeenCalledTimes(2))
+
+    // Every debounced save keeps failing, but the user is told once, not once
+    // per keystroke-sized tab-state change.
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
   })
 
   it('registers the unload handler once and writes the latest state on unload', () => {

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/storage.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/storage.ts
@@ -13,6 +13,21 @@ const toError = (error: unknown, fallback: string): Error => {
   return error instanceof Error ? error : new Error(fallback)
 }
 
+/**
+ * Whether a storage write failed because the origin ran out of quota.
+ *
+ * Chromium — the only engine this app ships a renderer on — throws a
+ * `DOMException` named `QuotaExceededError`; `QUOTA_EXCEEDED_ERR` is the legacy
+ * name older WebKit builds report for the same condition. Matched by shape
+ * rather than `instanceof Error`, because jsdom's `DOMException` does not
+ * inherit from `Error` the way a browser's does.
+ */
+export const isQuotaExceededError = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) return false
+  const { name } = error as { name?: unknown }
+  return name === 'QuotaExceededError' || name === 'QUOTA_EXCEEDED_ERR'
+}
+
 // =============================================================================
 // LOCALSTORAGE ADAPTER
 // =============================================================================

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -102,6 +102,14 @@ If **Restore Session** is on, the entire tab and split layout restores on app la
 - Split layout and ratios
 - Active tab per pane
 
+### If the layout can't be saved
+
+Session layout is stored in the app's local browser storage, which has a size limit. A very large session — many open tabs, several split panes, tabs holding a lot of view state — can hit that limit, and once it does the layout stops being saved.
+
+memrynote now tells you when that happens: a toast reads **"Your open tabs are no longer being saved"**, and explains that the session is too large to store and may not be restored the next time you open the app. Close some tabs to get back under the limit; the next save after that succeeds on its own and the warning does not come back.
+
+Previously the failure was silent — the app kept running normally and you only found out at the next launch, when the restored layout turned out to be stale.
+
 ## Modified Indicator
 
 A small dot appears on a tab title when there are unsaved changes (rare — memrynote auto-saves). On a compressed tab the dot takes the close button's place, so unsaved work stays visible. Closing a modified tab triggers a flush before close.

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -53,6 +53,11 @@
   "tabs": {
     "pin": "Pin Tab",
     "unpin": "Unpin Tab",
+    "persistence": {
+      "saveFailed": "Your open tabs are no longer being saved",
+      "saveFailedQuota": "This session is too large to store. Close some tabs, or it may not be restored the next time you open Memry.",
+      "saveFailedGeneric": "Memry could not store this session, so it may not be restored the next time you open the app."
+    },
     "contextMenu": {
       "close": "Close",
       "closeOthers": "Close Others",


### PR DESCRIPTION
Closes #1292. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts:78` fired the debounced tab-state save with no rejection handler:

```ts
void storage.save(serialized).then(() => {
  lastSavedRef.current = json
})
```

`localStorageAdapter.save` rethrows (`storage.ts:31`), so a `QuotaExceededError` from a large session — many open tabs, split panes, tabs carrying `viewState`, all sharing the renderer's ~5 MB per-origin localStorage budget — became an unhandled promise rejection. Nothing caught it, nothing told the user, and the only trace was one renderer log line. The app kept running normally; the user found out at the next launch, when the restored layout turned out to be stale and their open tabs were gone.

**One correction to the issue text.** The issue claims the failure "wedges" every later save because `lastSavedRef` is never advanced. It does not: `serializeTabState` stamps `savedAt: Date.now()` (`serialization.ts:75`), so the `json === lastSavedRef.current` short-circuit above it is effectively never true, and the next tab-state change does re-attempt the save. The real damage is narrower but still real — the rejection escapes unhandled, the user is never told, and the payload that failed is dropped if no further state change follows. The "no wedge" property is now locked down by a test so it cannot regress.

## What changed

- `hooks.ts` — the debounced save now handles its own rejection: log it, keep `lastSavedRef` on the last value that actually reached storage so the next state change retries, and surface a toast. The notice is emitted once per run of failures (a ref reset on the next successful save), so a user typing through a full-quota session gets one warning instead of one per debounce window.
- `storage.ts` — new `isQuotaExceededError`, matching `QuotaExceededError` / legacy `QUOTA_EXCEEDED_ERR` by `name`. Matched by shape rather than `instanceof Error` because jsdom's `DOMException` does not inherit from `Error` the way Chromium's does. Quota failures get an actionable "close some tabs" message; anything else falls back to `extractErrorMessage`.
- `packages/i18n/src/locales/en/common.json` — three new strings under `tabs.persistence`. English only; the other 30 locales fall back to en, which `i18n:check` treats as a warning.
- `apps/docs/src/user-guide/tabs-split-view.md` — documents the new warning under Tab Persistence.

**Deliberately not done: swapping the storage backend to the unused `indexedDBAdapter`.** The issue's second suggestion is a backend migration on a production app with persisted user state. It needs a migration read from the existing `memry_tab_state` localStorage key, a decision about what happens to that key afterwards, and a rollback story for a user who downgrades — all of which is its own change with its own compat plan, not a rider on a three-line rejection handler. `getDefaultStorage()` still returns `localStorageAdapter`.

Also not done: retrying a failed save on a timer. The current behaviour (retry on the next tab-state change) is preserved and now asserted; an unconditional retry loop is a behaviour change this issue does not ask for.

## How it was proven

Before/after on the same test file, reverting only `hooks.ts` to `origin/main` (`git checkout origin/main -- .../hooks.ts`, never `git stash`):

| run | result |
| --- | --- |
| before (`hooks.ts` from `origin/main`) | **2 failed \| 8 passed (10)**, plus **2 unhandled rejections** reported by vitest — the `QuotaExceededError` DOMException and `Error: storage backend offline` |
| after (fix restored) | **10 passed (10)**, 0 errors |

The two new hook tests assert the behaviour the issue asks for:

- `reports a quota failure to the user and keeps saving afterwards` — first save rejects with `new DOMException('quota exceeded', 'QuotaExceededError')`; asserts the toast title and the "too large to store" description (the user is not left unaware), then changes tab state and asserts the second save is still called **and receives the new payload** (no wedge), with still exactly one toast.
- `warns once across a run of failures and falls back to the error message` — every save rejects; asserts one toast across 20 further tab-state changes and that a non-quota error's own message is shown.
- `recognises quota failures and only quota failures` covers all four branches of `isQuotaExceededError` for the patch-coverage gate.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
  → Test Files 1 passed (1) | Tests 10 passed (10)

./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  apps/desktop/src/renderer/src/contexts/tabs
  → Test Files 11 passed (11) | Tests 109 passed (109)

(cd packages/i18n && vitest run src/locales)   → 3 files, 9 tests passed (ICU brace + placeholder parity)
pnpm --filter @memry/desktop typecheck:web     → clean
pnpm --filter @memry/desktop i18n:check        → ok: i18n check passed
eslint (hooks.ts, storage.ts)                  → 0 errors
git diff --check                               → clean
pnpm docs:impact --base origin/main --strict   → docs impact: covered
pnpm docs:build                                → build complete
```

## Backward compatibility

None affected: no schema, contract, storage-key, or persisted-shape change — the same `memry_tab_state` localStorage payload is written and read, and existing sessions restore exactly as before. The only new behaviour is a toast on a save path that previously failed silently.
