### PR TITLE
perf(telemetry): enforce a hard key cap on the throttle map with per-entry windows

### DIFF
--- a/apps/desktop/src/main/telemetry/throttle.test.ts
+++ b/apps/desktop/src/main/telemetry/throttle.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { resetTelemetryThrottle, shouldEmitThrottled } from './throttle'
+import { resetTelemetryThrottle, shouldEmitThrottled, telemetryThrottleKeyCount } from './throttle'
+
+// Mirrors MAX_TRACKED_KEYS in throttle.ts, which stays module-private.
+const MAX_TRACKED_KEYS = 1000
 
 describe('shouldEmitThrottled', () => {
   beforeEach(() => {
@@ -30,5 +33,49 @@ describe('shouldEmitThrottled', () => {
   it('tracks keys independently', () => {
     shouldEmitThrottled('note_updated:abc')
     expect(shouldEmitThrottled('note_updated:def')).toBe(true)
+  })
+
+  it('bounds the map when distinct keys burst inside one window', () => {
+    // #given keys are per-document, so a vault import or a writeback pass can
+    // put far more than MAX_TRACKED_KEYS live keys in the map inside one window
+    // #when 1200 distinct notes are touched without the window ever elapsing
+    for (let i = 0; i < 1200; i++) {
+      shouldEmitThrottled(`note_updated:${i}`)
+    }
+
+    // #then the map never exceeds the cap — the sweep found nothing expired,
+    // so oldest-inserted keys were dropped to keep the bound hard
+    expect(telemetryThrottleKeyCount()).toBeLessThanOrEqual(MAX_TRACKED_KEYS)
+  })
+
+  it('releases keys whose window has elapsed once the cap is crossed', () => {
+    // #given a full map of keys that have all aged out
+    for (let i = 0; i < MAX_TRACKED_KEYS; i++) {
+      shouldEmitThrottled(`note_updated:${i}`)
+    }
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1)
+
+    // #when one more key crosses the cap
+    shouldEmitThrottled('note_updated:trigger')
+
+    // #then every expired key is released, leaving only the live one
+    expect(telemetryThrottleKeyCount()).toBe(1)
+  })
+
+  it('does not let a short-window caller evict long-window entries', () => {
+    // #given a full map of default 5-minute entries (note_updated:*)
+    for (let i = 0; i < MAX_TRACKED_KEYS; i++) {
+      shouldEmitThrottled(`note_updated:${i}`)
+    }
+    // #and 61s pass — past a 60s window, well inside the 5-minute one
+    vi.advanceTimersByTime(61_000)
+
+    // #when a 60s caller (google-sync-runner) crosses the cap
+    expect(shouldEmitThrottled('calendar_google_sync_failed:push', 60_000)).toBe(true)
+
+    // #then the 5-minute entries are still throttled: expiry is judged per
+    // entry's own window, not by whichever call happened to trigger the sweep
+    expect(shouldEmitThrottled(`note_updated:${MAX_TRACKED_KEYS - 1}`)).toBe(false)
+    expect(telemetryThrottleKeyCount()).toBe(MAX_TRACKED_KEYS)
   })
 })

--- a/apps/desktop/src/main/telemetry/throttle.ts
+++ b/apps/desktop/src/main/telemetry/throttle.ts
@@ -1,7 +1,30 @@
 export const TELEMETRY_THROTTLE_WINDOW_MS = 5 * 60 * 1000
 const MAX_TRACKED_KEYS = 1000
 
-const lastEmitted = new Map<string, number>()
+// The window each entry was recorded under travels with the entry. Callers pass
+// their own `windowMs` (60s in google-sync-runner, the 5-minute default for
+// `note_updated`/`journal_updated`), and the sweep below runs on whichever call
+// happens to cross the cap — keying expiry off the *sweeping* call's window
+// would let a 60s caller drop a still-live 5-minute entry and re-emit it.
+type ThrottleEntry = { emittedAt: number; windowMs: number }
+
+const lastEmitted = new Map<string, ThrottleEntry>()
+
+const sweepTrackedKeys = (now: number): void => {
+  if (lastEmitted.size <= MAX_TRACKED_KEYS) return
+  for (const [trackedKey, entry] of lastEmitted) {
+    if (now - entry.emittedAt >= entry.windowMs) lastEmitted.delete(trackedKey)
+  }
+  // Keys are per-document (`note_updated:${id}`, `journal_updated:${date}`), so
+  // more than MAX distinct keys inside one window is ordinary — a vault import
+  // or a writeback pass. With nothing expired the sweep above deletes nothing,
+  // so the oldest-inserted keys are dropped to keep the bound hard. Dropping a
+  // key only forfeits its throttle, never an event.
+  for (const trackedKey of lastEmitted.keys()) {
+    if (lastEmitted.size <= MAX_TRACKED_KEYS) break
+    lastEmitted.delete(trackedKey)
+  }
+}
 
 /**
  * Returns true when an event for this key should be emitted, false while a
@@ -14,15 +37,17 @@ export const shouldEmitThrottled = (
 ): boolean => {
   const now = Date.now()
   const last = lastEmitted.get(key)
-  if (last !== undefined && now - last < windowMs) return false
-  lastEmitted.set(key, now)
-  if (lastEmitted.size > MAX_TRACKED_KEYS) {
-    for (const [trackedKey, emittedAt] of lastEmitted) {
-      if (now - emittedAt >= windowMs) lastEmitted.delete(trackedKey)
-    }
-  }
+  if (last !== undefined && now - last.emittedAt < windowMs) return false
+  lastEmitted.set(key, { emittedAt: now, windowMs })
+  sweepTrackedKeys(now)
   return true
 }
+
+/**
+ * Number of live throttle keys. Exported so the memory bound is directly
+ * assertable in tests; production code never reads it.
+ */
+export const telemetryThrottleKeyCount = (): number => lastEmitted.size
 
 export const resetTelemetryThrottle = (): void => {
   lastEmitted.clear()

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -447,6 +447,19 @@ from `ipc/crdt-handlers.ts`) now emits `note_updated` with `source: 'editor_body
 share one 5-minute window per note. Only the throttle key ever sees the note id; the event itself
 carries no identifier.
 
+The shared throttle map (`telemetry/throttle.ts`) is bounded to 1000 keys. Because the keys are
+per-document (`note_updated:<noteId>`, `journal_updated:<date>`, and the CRDT writeback keys),
+exceeding that inside one window is ordinary operation — a vault import or a writeback pass over a
+large vault does it — so the cap is enforced rather than advisory: keys whose window has elapsed
+are swept first, and if nothing has expired the oldest-inserted keys are dropped anyway. Dropping a
+key only forfeits its throttle, never an event.
+
+Each entry records the window it was written under, and the sweep judges expiry per entry rather
+than by the window of whichever call happened to cross the cap. Callers do not share one window —
+the Google Calendar sync runner throttles on 60 seconds while the autosave keys use the 5-minute
+default — so a short-window caller must not be able to expire a still-live 5-minute entry and make
+`note_updated` re-emit early.
+
 ## Release Download Counts
 
 Downloads happen on GitHub Releases, where PostHog cannot see them — the landing site's


### PR DESCRIPTION
Closes #1291. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/telemetry/throttle.ts:19-23` — the cap was advisory. Past 1000 keys it ran a sweep that only deletes *already expired* entries, so when everything tracked is still inside its window the loop deletes nothing and the map keeps growing:

```ts
lastEmitted.set(key, now)
if (lastEmitted.size > MAX_TRACKED_KEYS) {
  for (const [trackedKey, emittedAt] of lastEmitted) {
    if (now - emittedAt >= windowMs) lastEmitted.delete(trackedKey)
  }
}
```

The keys are per-document, not a bounded enum — `note_updated:${note.id}`, `journal_updated:${entry.date}`, `note_writeback_error:${noteId}`, `writeback_conversion_null:${noteId}` — so more than 1000 live keys inside five minutes is ordinary operation (vault import, bulk edit, writeback pass over a large vault), not an edge case. Nothing clears the map afterwards except `resetTelemetryThrottle()` or a restart, and past the threshold every subsequent call walks the whole map, so per-call cost grows with the overflow it failed to prevent.

**Second defect, found while fixing the first.** That sweep compares every entry against `windowMs` — the window of *whichever call happened to trigger the sweep*, not the window the entry was recorded under. Callers do not share a window: `google-sync-runner.ts` passes 60 s, the autosave keys use the 5-minute default. So one 60 s-throttled calendar event crossing the cap wiped every `note_updated` / `journal_updated` entry older than 60 s, and those product events re-emitted early — a correctness bug, not just a memory one. The new cross-window test fails on `origin/main` with `expected true to be false` (see below).

## What changed

`apps/desktop/src/main/telemetry/throttle.ts`:

- Entries are now `{ emittedAt, windowMs }` and the sweep judges expiry per entry's own window, so a short-window caller can no longer expire a live long-window entry.
- The sweep moved into `sweepTrackedKeys(now)` with a second pass that drops oldest-inserted keys until the map is back at 1000 — the bound holds even when nothing has expired. Dropping a key only forfeits its throttle, never an event.
- Added `telemetryThrottleKeyCount()` so the bound is directly assertable; production code never reads it.

This mirrors what landed in the sibling map in #1264 (`main/ipc/validate.ts`), including the exported count getter — but deliberately does **not** share code with it: that map has a single fixed 60 s window, this one is per-caller, and collapsing them would reintroduce exactly the cross-window eviction described above.

Deliberately not done: no change to the read path. `shouldEmitThrottled` still decides suppression using the *caller's* `windowMs` (`now - last.emittedAt < windowMs`), which is existing behavior — the stored window is only consulted by the sweep. `MAX_TRACKED_KEYS` stays 1000 and module-private, matching the sibling.

## How it was proven

`apps/desktop/src/main/telemetry/throttle.test.ts` gains three tests. Run with the fix reverted to `origin/main` (`git checkout origin/main -- apps/desktop/src/main/telemetry/throttle.ts`, test file kept):

**Before — `Tests 3 failed | 4 passed (7)`**

- `does not let a short-window caller evict long-window entries` → `AssertionError: expected true to be false` — a 60 s caller crossing the cap evicted 1000 live 5-minute `note_updated` entries, and `note_updated:999` re-emitted.
- `bounds the map when distinct keys burst inside one window` and `releases keys whose window has elapsed once the cap is crossed` → `TypeError: telemetryThrottleKeyCount is not a function` (the bound was not observable at all before this change).

**After — `Tests 7 passed (7)`**

The 4 pre-existing window tests pass unchanged in both runs.

## Verification

```
pnpm --filter @memry/desktop typecheck:node          → clean, no output
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts \
  --project main apps/desktop/src/main/telemetry/throttle.test.ts
                                                     → Test Files 1 passed (1), Tests 7 passed (7)
eslint apps/desktop/src/main/telemetry/throttle.ts   → 0 errors (test file is ignored by the flat config)
git diff --check origin/main..HEAD                   → clean
pnpm docs:impact --base origin/main --strict         → covered
pnpm docs:build                                      → build complete in 7.72s
```

No renderer files touched, so `typecheck:web` was not run.

## Backward compatibility

Process-local, in-memory only — no schema, contract, settings, or sync-shape change; the throttle map has always reset on restart, so there is nothing persisted for an older build to read.
