### PR TITLE
fix(tabs): open to the side into the pane the split creates

### DIFF
--- a/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
@@ -25,7 +25,7 @@ import type {
   SplitDirection
 } from './types'
 import { tabReducer } from './reducer'
-import { createInitialState, createTabFromSidebarItem } from './helpers'
+import { createInitialState, createTabFromSidebarItem, generateId } from './helpers'
 import { useCloseGuardRegistry, type TabCloseGuard } from './close-guard'
 import { UnsavedChangesDialog } from '@/components/tabs/unsaved-changes-dialog'
 
@@ -182,9 +182,15 @@ interface TabActionsContextType {
   ) => void
 
   /**
-   * Split the view
+   * Split the view.
+   *
+   * Returns the id of the pane it created, so a caller can act on that pane in
+   * the same dispatch batch instead of guessing when the split lands: SPLIT_VIEW
+   * deliberately leaves `activeGroupId` on the source pane, so a follow-up
+   * `openTab` with no `groupId` would land back in the pane that was split.
+   * Returns null when the source group no longer exists and nothing was split.
    */
-  splitView: (direction: SplitDirection, groupId?: string) => void
+  splitView: (direction: SplitDirection, groupId?: string) => string | null
 
   /**
    * Close a split pane
@@ -632,12 +638,19 @@ export const TabProvider = ({
     []
   )
 
-  const splitView = useCallback((direction: SplitDirection, groupId?: string) => {
+  const splitView = useCallback((direction: SplitDirection, groupId?: string): string | null => {
     const actualGroupId = groupId ?? activeGroupIdRef.current
+    // Mirrors the reducer's own guard: splitting a group that is already gone is
+    // a no-op, and callers must not get an id for a pane that was never created.
+    if (!tabGroupsRef.current[actualGroupId]) return null
+    // Naming the pane here (instead of inside the reducer) is what makes the
+    // split observable to the caller without waiting for a render to commit.
+    const newGroupId = generateId()
     dispatch({
       type: 'SPLIT_VIEW',
-      payload: { direction, groupId: actualGroupId }
+      payload: { direction, groupId: actualGroupId, newGroupId }
     })
+    return newGroupId
   }, [])
 
   const closeSplit = useCallback((groupId: string) => {

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/layout-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/layout-reducer.ts
@@ -35,7 +35,7 @@ const resetRatiosInTree = (layout: SplitLayout): SplitLayout => {
 export function layoutReducer(state: TabSystemState, action: LayoutAction): TabSystemState {
   switch (action.type) {
     case 'SPLIT_VIEW': {
-      const { direction, groupId } = action.payload
+      const { direction, groupId, newGroupId } = action.payload
 
       const sourceGroup = state.tabGroups[groupId]
       if (!sourceGroup) return state
@@ -52,7 +52,7 @@ export function layoutReducer(state: TabSystemState, action: LayoutAction): TabS
         : createDefaultTab()
 
       const newGroup: TabGroup = {
-        id: generateId(),
+        id: newGroupId ?? generateId(),
         tabs: [clonedTab],
         activeTabId: clonedTab.id,
         isActive: false,

--- a/apps/desktop/src/renderer/src/contexts/tabs/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/types.ts
@@ -283,7 +283,14 @@ export type TabAction =
     }
 
   // Split view
-  | { type: 'SPLIT_VIEW'; payload: { direction: SplitDirection; groupId: string } }
+  | {
+      type: 'SPLIT_VIEW'
+      /**
+       * `newGroupId` lets the caller name the pane before it exists, so it can
+       * target it in the same dispatch batch. Omitted, the reducer mints one.
+       */
+      payload: { direction: SplitDirection; groupId: string; newGroupId?: string }
+    }
   | { type: 'RESIZE_SPLIT'; payload: { path: number[]; ratio: number } }
   | { type: 'CLOSE_SPLIT'; payload: { groupId: string } }
   | { type: 'TOGGLE_MAXIMIZE_GROUP'; payload: { groupId: string } }

--- a/apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => ({
   removeTagFromNote: vi.fn(),
   requestPermission: vi.fn(),
   setActiveTab: vi.fn(),
-  splitView: vi.fn(),
+  splitView: vi.fn(() => 'group-split'),
   tabsDispatch: vi.fn(),
   toastInfo: vi.fn(),
   unpinNoteFromTag: vi.fn()
@@ -266,10 +266,11 @@ describe('more major hooks coverage', () => {
       { toTheSide: true }
     )
     expect(mocks.splitView).toHaveBeenCalledWith('horizontal', 'group-1')
-    act(() => vi.runOnlyPendingTimers())
+    // The open targets the pane splitView reports creating, in the same turn —
+    // no timer to flush, and no dependence on which pane is active by then.
     expect(mocks.openTab).toHaveBeenLastCalledWith(
       expect.objectContaining({ path: '/folder/new' }),
-      { background: undefined }
+      { groupId: 'group-split', background: undefined }
     )
 
     result.current.openAsPin({ type: 'tasks', title: 'Tasks', path: '/tasks' } as never)

--- a/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.split.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.split.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * "Open to the side" must land the tab in the pane the split created.
+ *
+ * These run against the real reducer and the real TabProvider on purpose: the
+ * defect is entirely about which group the OPEN_TAB action resolves to, so a
+ * test that stubs `splitView`/`openTab` cannot see it. The probe reports where
+ * the item actually ended up, labelled relative to the panes that existed
+ * before the gesture.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { TabProvider, useTabActions, useTabs } from '@/contexts/tabs'
+import type { SidebarItem } from '@/contexts/tabs/types'
+import { SettingsModalProvider } from '@/contexts/settings-modal-context'
+import { FEATURES_SETTINGS_DEFAULTS } from '@memry/contracts/settings-schemas'
+import { renderWithProviders, userEvent } from '@tests/utils/render'
+import { useSidebarNavigation } from './use-sidebar-navigation'
+
+// Feature gating is a different concern (and 'note' is not a gated type); this
+// keeps the hook off window.api so the test only exercises tab routing.
+vi.mock('./use-feature-flags', () => ({
+  useFeatureFlags: () => ({ flags: FEATURES_SETTINGS_DEFAULTS })
+}))
+
+const NOTE_ITEM: SidebarItem = {
+  type: 'note',
+  title: 'Note B',
+  path: '/notes/b.md',
+  entityId: 'note-b'
+}
+
+/** Panes that existed before the gesture under test, recorded by `snapshot-panes`. */
+const preExistingGroupIds = new Set<string>()
+
+function Probe(): React.JSX.Element {
+  const { openSidebarItem } = useSidebarNavigation()
+  const { splitView, setActiveGroup, openTab } = useTabActions()
+  const { state } = useTabs()
+
+  const groupIds = Object.keys(state.tabGroups)
+  const originalGroupId = groupIds[0]
+  const holdsItem = (groupId: string): boolean =>
+    state.tabGroups[groupId].tabs.some((tab) => tab.entityId === NOTE_ITEM.entityId)
+
+  // Every pane holding the item, named relative to the panes that were already
+  // on screen — so an assertion cannot pass by landing in the pane we split
+  // away from, or in some other pane that happened to be focused.
+  const itemLocations = groupIds.filter(holdsItem).map((groupId) => {
+    if (groupId === originalGroupId) return 'original-pane'
+    if (preExistingGroupIds.has(groupId)) return 'pre-existing-pane'
+    return 'split-created-pane'
+  })
+
+  return (
+    <div>
+      <span data-testid="group-count">{groupIds.length}</span>
+      <span data-testid="item-locations">{itemLocations.join(',') || 'not-open'}</span>
+      <span data-testid="active-pane-has-item">{String(holdsItem(state.activeGroupId))}</span>
+      <button type="button" onClick={() => openSidebarItem(NOTE_ITEM, { toTheSide: true })}>
+        open-to-the-side
+      </button>
+      <button type="button" onClick={() => openSidebarItem(NOTE_ITEM)}>
+        open-here
+      </button>
+      <button type="button" onClick={() => splitView('horizontal', originalGroupId)}>
+        pre-split
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          // Freeze the current pane list so the probe can tell "the pane the
+          // gesture under test created" from "a pane that was already there".
+          // Clicked after any setup splits, before the gesture being asserted.
+          for (const id of groupIds) preExistingGroupIds.add(id)
+        }}
+      >
+        snapshot-panes
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          // The race, made deterministic: something else takes focus in the same
+          // turn as the split. An open that resolves its target group "later"
+          // follows that focus and lands in the wrong pane.
+          openSidebarItem(NOTE_ITEM, { toTheSide: true })
+          const otherGroupId = groupIds.find((id) => id !== state.activeGroupId)
+          if (otherGroupId) setActiveGroup(otherGroupId)
+        }}
+      >
+        open-to-the-side-then-refocus
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          openTab(
+            {
+              type: 'note',
+              title: NOTE_ITEM.title,
+              icon: 'FileText',
+              path: NOTE_ITEM.path,
+              entityId: NOTE_ITEM.entityId,
+              isPinned: false,
+              isModified: false,
+              isPreview: false,
+              isDeleted: false
+            },
+            { background: true }
+          )
+        }
+      >
+        open-item-here-in-background
+      </button>
+    </div>
+  )
+}
+
+const renderProbe = (): void => {
+  preExistingGroupIds.clear()
+  renderWithProviders(
+    <SettingsModalProvider>
+      <TabProvider>
+        <Probe />
+      </TabProvider>
+    </SettingsModalProvider>
+  )
+}
+
+describe('useSidebarNavigation — open to the side', () => {
+  it('opens the item in the pane the split created, not the pane it split from', async () => {
+    const user = userEvent.setup()
+    renderProbe()
+
+    await user.click(screen.getByText('open-to-the-side'))
+
+    expect(screen.getByTestId('group-count')).toHaveTextContent('2')
+    expect(screen.getByTestId('item-locations')).toHaveTextContent(/^split-created-pane$/)
+    // Focus follows the item into the new pane, which is the point of the gesture.
+    expect(screen.getByTestId('active-pane-has-item')).toHaveTextContent('true')
+  })
+
+  it('still lands in the split-created pane when focus moves before the open resolves', async () => {
+    const user = userEvent.setup()
+    renderProbe()
+
+    // Two panes already on screen, focus on the first.
+    await user.click(screen.getByText('pre-split'))
+    expect(screen.getByTestId('group-count')).toHaveTextContent('2')
+    await user.click(screen.getByText('snapshot-panes'))
+
+    await user.click(screen.getByText('open-to-the-side-then-refocus'))
+
+    // Three panes now; the item must be in the one this gesture created, not in
+    // the pane that took focus a beat later.
+    expect(screen.getByTestId('group-count')).toHaveTextContent('3')
+    expect(screen.getByTestId('item-locations')).toHaveTextContent(/^split-created-pane$/)
+  })
+
+  it('splits again and opens in the new pane when the view is already split', async () => {
+    const user = userEvent.setup()
+    renderProbe()
+
+    await user.click(screen.getByText('pre-split'))
+    await user.click(screen.getByText('snapshot-panes'))
+    await user.click(screen.getByText('open-to-the-side'))
+
+    expect(screen.getByTestId('group-count')).toHaveTextContent('3')
+    expect(screen.getByTestId('item-locations')).toHaveTextContent(/^split-created-pane$/)
+    expect(screen.getByTestId('active-pane-has-item')).toHaveTextContent('true')
+  })
+
+  it('gives the item its own tab in the new pane even when it is already open elsewhere', async () => {
+    const user = userEvent.setup()
+    renderProbe()
+
+    // Item already open (unfocused) in the pane we are about to split.
+    await user.click(screen.getByText('open-item-here-in-background'))
+    expect(screen.getByTestId('item-locations')).toHaveTextContent(/^original-pane$/)
+
+    await user.click(screen.getByText('open-to-the-side'))
+
+    expect(screen.getByTestId('group-count')).toHaveTextContent('2')
+    // Both copies: the original, plus one in the pane the split created.
+    expect(screen.getByTestId('item-locations')).toHaveTextContent(
+      /^original-pane,split-created-pane$/
+    )
+    expect(screen.getByTestId('active-pane-has-item')).toHaveTextContent('true')
+  })
+
+  it('opens in the active pane without splitting when toTheSide is not requested', async () => {
+    const user = userEvent.setup()
+    renderProbe()
+
+    await user.click(screen.getByText('open-here'))
+
+    expect(screen.getByTestId('group-count')).toHaveTextContent('1')
+    expect(screen.getByTestId('item-locations')).toHaveTextContent(/^original-pane$/)
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.ts
@@ -19,7 +19,6 @@ import { SINGLETON_TAB_TYPES } from '@/contexts/tabs/types'
 import type { Tab, TabSystemState, SidebarItem } from '@/contexts/tabs/types'
 import { useIsItemActive } from './use-is-item-active'
 import { useFeatureFlags } from './use-feature-flags'
-import { useTrackedTimeout } from './use-tracked-timeout'
 import { useSettingsModal } from '@/contexts/settings-modal-context'
 import { featureForTabType } from '@memry/contracts/feature-flags'
 import type { FeaturesSettings } from '@memry/contracts/settings-schemas'
@@ -149,9 +148,6 @@ export const useSidebarNavigation = () => {
   const { flags } = useFeatureFlags()
   const { open: openSettings } = useSettingsModal()
 
-  // The post-split "open in the new pane" hop must not fire after unmount
-  const scheduleTimeout = useTrackedTimeout()
-
   // Use refs for state to avoid recreating callbacks
   const stateRef = useRef(state)
   useEffect(() => {
@@ -195,19 +191,19 @@ export const useSidebarNavigation = () => {
       const tabData = createTabFromSidebarItem(item, false)
 
       if (toTheSide) {
-        // Create split and open in new pane
-        splitView('horizontal', currentState.activeGroupId)
-        // The new group will be active, so opening a tab there
-        // Note: This is a simplification - ideally we'd wait for the split
-        // and then open the tab in the new pane
-        scheduleTimeout(() => {
-          openTab(tabData, { background: inBackground })
-        }, 0)
+        // Split, then open into the pane the split just created — by id, not by
+        // timing. SPLIT_VIEW leaves activeGroupId on the source pane, so an open
+        // that relies on "whatever is active next" lands back in the pane we
+        // split from, leaving the new pane holding only the cloned tab.
+        // Both dispatches queue on the same reducer, so OPEN_TAB always sees the
+        // group SPLIT_VIEW created, however late the render commits.
+        const newGroupId = splitView('horizontal', currentState.activeGroupId)
+        openTab(tabData, { groupId: newGroupId ?? undefined, background: inBackground })
       } else {
         openTab(tabData, { background: inBackground })
       }
     },
-    [openTab, setActiveTab, splitView, flags, openSettings, scheduleTimeout]
+    [openTab, setActiveTab, splitView, flags, openSettings]
   )
 
   /**

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -58,6 +58,16 @@ Drag a tab to the left, right, top, or bottom edge of the window to open a secon
 
 <!-- screenshot: tab being dragged into a drop zone to create a split -->
 
+### Open to the Side
+
+Right-click any sidebar item and choose **Open to the Side** to split the current pane and open
+that item in the new pane in one step. The new pane takes focus, so you can start reading or
+editing straight away.
+
+The item always lands in the pane that gesture created — even when the item is already open in
+another pane (you get a second, independent copy), and even if something else takes focus while
+the split is being drawn. Use it to put a note beside a canvas, or a project beside your journal.
+
 ### Drop Zones
 
 When dragging a tab, the workspace highlights drop zones:


### PR DESCRIPTION
Closes #1289. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.ts:193-205` — "open to the side" requested a split, then opened the tab from a zero-delay macrotask with no target group:

```ts
splitView('horizontal', currentState.activeGroupId)
// The new group will be active, so opening a tab there
// Note: This is a simplification - ideally we'd wait for the split
// and then open the tab in the new pane
scheduleTimeout(() => {
  openTab(tabData, { background: inBackground })
}, 0)
```

The comment's premise is false. `SPLIT_VIEW` (`contexts/tabs/reducers/layout-reducer.ts:37-70`) creates the new group with `isActive: false` and **never touches `state.activeGroupId`** — the same fact already documented in `pages/canvas/use-note-edit-lock.test.tsx:31-38`. So `openTab` with no `groupId` defaulted to the pane we split *from*, and the item landed there every time, not just under load. The user got a new pane holding only a clone of the old tab, and the item doubled up in the original pane.

Two further consequences of resolving the target group "later":

- Anything that took focus between the split and the timer redirected the tab into *that* pane (issue's race; reproduced in test 2 below, which landed in a pre-existing pane).
- With no explicit `groupId`, `OPEN_TAB`'s cross-group entity dedup (`tab-crud-reducer.ts:229-256`) fired, so opening an already-open item to the side just refocused the old tab and left an empty split behind.

## What changed

Made the open depend on the split's result instead of on timing, as the issue suggested:

- `splitView` now mints the new group id itself, passes it to the reducer as `payload.newGroupId`, and **returns it** (`string | null`; `null` when the source group is gone and nothing was split). `SPLIT_VIEW` uses `newGroupId ?? generateId()`, so raw dispatches without it behave exactly as before.
- `openSidebarItem` passes it straight through: `openTab(tabData, { groupId: newGroupId ?? undefined, background: inBackground })`. Both dispatches queue on the same reducer, so `OPEN_TAB` always sees the group `SPLIT_VIEW` created, however late the render commits. This mirrors the existing-tab branch a few lines above, which already passed `{ groupId: existingTab.groupId }`.
- The `setTimeout(0)` hop and its `useTrackedTimeout` usage are gone — with a real target id there is nothing to defer, so the unmount-after-fire concern disappears rather than being managed.

Deliberately **not** done: no change to `SPLIT_VIEW` focus semantics (it still leaves `activeGroupId` on the source pane — `use-tab-keyboard-shortcuts` and the canvas edit-lock both rely on that). Focus moves to the new pane here only because `OPEN_TAB` focuses its target group, which is what the gesture should do. `use-tracked-timeout` itself is untouched and still used by six other call sites.

One intentional behavior change: opening an item to the side while it is already open elsewhere now gives you an independent copy in the new pane instead of refocusing the old tab and leaving the split empty.

## How it was proven

New `apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.split.test.tsx` drives the real `TabProvider` and the real reducer (no stubbed `splitView`/`openTab` — the bug is entirely about which group `OPEN_TAB` resolves to, so a mocked test cannot see it) and reports which pane the item ended up in, labelled relative to the panes that existed before the gesture.

Before (source files reverted to `origin/main`, tests kept):

```
Tests  4 failed | 1 passed (5)
  opens the item in the pane the split created …            → expected /^split-created-pane$/, got "original-pane"
  still lands in the split-created pane when focus moves …  → expected /^split-created-pane$/, got "pre-existing-pane"
  splits again and opens in the new pane when already split → expected /^split-created-pane$/, got "original-pane"
  gives the item its own tab … already open elsewhere       → expected /^original-pane,split-created-pane$/, got "original-pane"
  opens in the active pane without splitting …              ✓ (non-split path, passes both before and after)
```

After: `Tests  5 passed (5)`.

`more-major-hooks.test.tsx` (mocked-hook coverage of the same call site) went 1 failed → passing, updated to assert the new `{ groupId, background }` call shape with no timer flush.

## Verification

- `pnpm --filter @memry/desktop typecheck:web` → exit 0
- `./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer` over the new file plus `more-major-hooks`, `contexts/tabs/**`, `use-tab-keyboard-shortcuts`, `use-note-edit-lock`, `timer-raf-cleanup`, `calendar`, `components/split-view` → **25 files, 182 tests passed**
- `pnpm exec eslint` on the changed source files → 0 errors
- `git diff --check` → clean
- `pnpm docs:impact --base origin/main --strict` → `docs changed on this branch`; `pnpm docs:build` → build complete

## Backward compatibility

Renderer-only and in-memory: `newGroupId` is an optional field on a runtime-only Redux-style action, group ids stay `crypto.randomUUID()`, and nothing about persisted tab-session shape, IPC contracts, or DB schema changes — restored sessions from older versions load unchanged.
