### PR TITLE
fix(undo): prune expired entries inside popUndoEntry so undo() cannot replay a stale action

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-undo.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-undo.test.ts
@@ -608,6 +608,61 @@ describe('useUndoTracker subscription', () => {
     expect(result.current.lastActionDescription).toBeNull()
   })
 
+  it('undo() refuses an entry that expired since the last sweep', () => {
+    vi.useFakeTimers()
+    const start = Date.now()
+
+    const { result } = renderHook(() => useUndoTracker())
+    const undoFn = vi.fn()
+    act(() => {
+      result.current.registerUndo('Delete task', undoFn)
+    })
+
+    // Wall clock passes the expiry window, but the 1s sweep has not run yet.
+    vi.setSystemTime(start + UNDO_EXPIRY_MS + 1)
+
+    let success = true
+    act(() => {
+      success = result.current.undo()
+    })
+
+    expect(success).toBe(false)
+    expect(undoFn).not.toHaveBeenCalled()
+    expect(toast.success).not.toHaveBeenCalled()
+    expect(result.current.canUndo).toBe(false)
+  })
+
+  it('undo() still runs a live entry and discards the expired one beneath it', () => {
+    vi.useFakeTimers()
+    const start = Date.now()
+
+    const { result } = renderHook(() => useUndoTracker())
+    const staleFn = vi.fn()
+    const liveFn = vi.fn()
+
+    act(() => {
+      result.current.registerUndo('Stale action', staleFn)
+    })
+
+    vi.setSystemTime(start + UNDO_EXPIRY_MS - 1000)
+    act(() => {
+      result.current.registerUndo('Live action', liveFn)
+    })
+
+    // Only the first entry is past its window; no sweep has run.
+    vi.setSystemTime(start + UNDO_EXPIRY_MS + 1)
+
+    act(() => {
+      expect(result.current.undo()).toBe(true)
+    })
+    expect(liveFn).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      expect(result.current.undo()).toBe(false)
+    })
+    expect(staleFn).not.toHaveBeenCalled()
+  })
+
   it('does not mutate module state during render', () => {
     vi.useFakeTimers()
     const start = Date.now()

--- a/apps/desktop/src/renderer/src/hooks/use-undo.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-undo.ts
@@ -146,7 +146,12 @@ function pushUndoEntry(entry: Omit<UndoEntry, 'id' | 'timestamp'>) {
   return newEntry.id
 }
 
+/**
+ * Take the newest live entry off the stack. Prunes first so an expired entry can
+ * never be handed back between 1 s sweeps, whichever accessor the caller used.
+ */
 function popUndoEntry(): UndoEntry | undefined {
+  pruneExpiredEntries()
   const entry = globalUndoStack.pop()
   if (globalUndoStack.length === 0) {
     stopCleanupInterval()

--- a/apps/docs/src/user-guide/tasks/bulk-actions.md
+++ b/apps/docs/src/user-guide/tasks/bulk-actions.md
@@ -44,7 +44,7 @@ If multiple tasks are selected, dragging any of them moves the **whole selection
 - Due date changes
 - Deletion (restores the tasks)
 
-After 10 seconds the action is committed and undo no longer reaches it. (You can still manually reverse, of course.)
+After 10 seconds the action is committed and undo no longer reaches it. (You can still manually reverse, of course.) The cutoff is enforced at the moment you trigger undo, so an action that has just aged out is never replayed — whichever way you reach undo, it either runs a change that is still inside the window or does nothing.
 
 The undo window is app-wide, not per view. The most recent undoable action is shared across Tasks, Projects, and Calendar, so <kbd>⌘</kbd>+<kbd>Z</kbd> reverses whichever action happened last no matter where you switched to, and it expires on the same 10-second timer everywhere.
 


### PR DESCRIPTION
Closes #1288. Part of epic #987 (memory/CPU audit 2026-08).

**This is hardening, not a user-visible bugfix.** I verified the gap is unreachable from any code path that ships today. Filing it anyway because the fix is two lines and it makes the hook's advertised contract actually true.

## What was wrong

`apps/desktop/src/renderer/src/hooks/use-undo.ts:149` — `popUndoEntry()` was the only stack accessor that touched `globalUndoStack` without first applying the 10 s expiry filter:

```ts
function popUndoEntry(): UndoEntry | undefined {
  const entry = globalUndoStack.pop()   // no prune
  ...
}
```

Its sibling `getLastUndoEntry()` (line 171) calls `pruneExpiredEntries()` first, and the background sweep in `startCleanupInterval()` (line 47) only runs once per second. So between sweeps the stack legitimately holds entries older than `UNDO_EXPIRY_MS`, and whether an expired entry could be executed depended on which accessor a caller happened to go through.

**Reachability — checked, and the issue's own correction holds:**

- Cmd+Z is safe. `useUndoKeyboardShortcut` calls `getLastUndoEntry()` (which prunes) and only pops when that returns an entry, in the same synchronous tick — no timer can interleave, so the popped entry is always the pruned one.
- The unguarded path is the `undo()` callback from `useUndoTracker` (line 214), which pops directly. Grepping the whole workspace, no consumer destructures `undo` or `canUndo`: `pages/calendar.tsx:253` takes `registerUndo`, `pages/tasks.tsx:134` and `pages/project/index.tsx:43` take `registerUndo` / `removeUndoEntry`. Nothing else imports the hook.

So today this is latent. The cost is that the first consumer to wire up `undo()` — an explicit Undo button, a second shortcut, batch undo — silently inherits a window of up to ~1 s in which the app re-applies a mutation the user was told had expired, with nothing in the hook's surface signalling it.

## What changed

`popUndoEntry()` prunes before popping, so the expiry filter gates every read of the stack regardless of entry point:

```ts
function popUndoEntry(): UndoEntry | undefined {
  pruneExpiredEntries()
  const entry = globalUndoStack.pop()
  ...
}
```

`pruneExpiredEntries()` already stops the cleanup interval when it empties the stack, and the existing `notifyListeners()` call at the end now also clears a stale `canUndo` when the pop finds nothing left.

Deliberately **not** done:

- **Did not prune in `refreshSnapshot()` / `getUndoSnapshot()`.** Those run during render and must stay pure — PR #1274 (#1102) exists precisely because a render-time prune mutated module state and killed the cleanup interval mid-render. `canUndo` therefore still lags by up to one sweep; that is a display value, and the execution path is now gated. Changing it would need a different mechanism than a filter-on-read.
- **Did not restructure the two accessors into one shared helper.** The issue offered that as an alternative; the one-line prune achieves the same guarantee without churning `getLastUndoEntry()`, which #1274 just reworked.
- Double-prune on the Cmd+Z path (`getLastUndoEntry()` then `popUndoEntry()`) is intentional and harmless — the second call is a no-op.

## How it was proven

Two tests in `use-undo.test.ts` that drive the wall clock past `UNDO_EXPIRY_MS` **without** letting the 1 s sweep run, then call `undo()`:

- `undo() refuses an entry that expired since the last sweep` — asserts the undo fn is not invoked, no success toast, `undo()` returns `false`.
- `undo() still runs a live entry and discards the expired one beneath it` — guards against over-pruning: the in-window entry still executes, the stale one underneath does not.

```
before (source reverted to origin/main, tests kept):  Tests  2 failed | 27 passed (29)
after  (fix in place):                                Tests  29 passed (29)
```

Both failures were the two new tests; no pre-existing test changed state.

## Verification

```
pnpm --filter @memry/desktop typecheck:web                     clean, no output
pnpm exec eslint apps/.../use-undo.ts                          0 errors (test file is eslint-ignored by config)
vitest run --project renderer .../use-undo.test.ts             29 passed (29)
git diff --check                                               exit 0
pnpm docs:impact --base origin/main --strict                   covered
pnpm docs:build                                                build complete in 7.24s
```

Docs: `apps/docs/src/user-guide/tasks/bulk-actions.md` already promised "after 10 seconds the action is committed and undo no longer reaches it" — one sentence added to state that the cutoff is checked when undo runs, which this change makes true.

## Backward compatibility

Renderer-only, in-memory state: no schema, IPC contract, sync payload, settings or vault-format change, and no behavior change on any path a shipped build can reach.
