### PR TITLE
fix(crdt): stop compaction from writing into a doc entry close() already retired

### DIFF
--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -675,6 +675,106 @@ describe('CrdtProvider', () => {
     )
   })
 
+  it('does not start compacting a doc that close() is already retiring', async () => {
+    const compactedDoc = new Y.Doc()
+    compactedDoc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [new Y.XmlText('compact')])
+    mocks.compactYDoc.mockReturnValue({
+      compacted: Y.encodeStateAsUpdate(compactedDoc),
+      savedBytes: 120
+    })
+
+    await provider.open('note-1', undefined, { skipSeed: true })
+    provider.updateMeta('note-1', { title: 'Before close' })
+
+    // Hold close() at its snapshot push: the entry is marked closing but the
+    // map still holds it, which is exactly what checkAndCompact's setImmediate
+    // sees when eviction and compaction fire on the same windowless doc.
+    let releaseClosePush: (() => void) | undefined
+    pushSnapshot.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseClosePush = resolve
+        })
+    )
+    const closePromise = provider.close('note-1')
+    await Promise.resolve()
+
+    mocks.compactYDoc.mockClear()
+    await provider.compactDoc('note-1')
+    expect(mocks.compactYDoc).not.toHaveBeenCalled()
+
+    releaseClosePush?.()
+    await closePromise
+    expect(provider.getDoc('note-1')).toBeUndefined()
+  })
+
+  it('abandons the compacted swap when close() starts mid-compaction', async () => {
+    const compactedDoc = new Y.Doc()
+    compactedDoc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [new Y.XmlText('compact')])
+    mocks.compactYDoc.mockReturnValue({
+      compacted: Y.encodeStateAsUpdate(compactedDoc),
+      savedBytes: 120
+    })
+
+    const originalDoc = await provider.open('note-1', undefined, { skipSeed: true })
+    provider.updateMeta('note-1', { title: 'Before compaction' })
+
+    // Start close() from inside the compaction's persistence write, and park it
+    // on its own flush: the entry stays in the map, just marked closing.
+    let closePromise: Promise<void> | undefined
+    let releaseCloseFlush: (() => void) | undefined
+    mocks.persistenceInstances[0].storeUpdate.mockImplementationOnce(async () => {
+      mocks.persistenceInstances[0].flushDocument.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseCloseFlush = resolve
+          })
+      )
+      closePromise = provider.close('note-1')
+      await Promise.resolve()
+    })
+
+    await provider.compactDoc('note-1')
+
+    // No swap onto a doc that close() is about to destroy.
+    expect(provider.getDoc('note-1')).toBe(originalDoc)
+
+    releaseCloseFlush?.()
+    await closePromise
+    expect(provider.getDoc('note-1')).toBeUndefined()
+  })
+
+  it('replays buffered remote updates onto the live doc when a reopen replaces the entry mid-compaction', async () => {
+    const compactedDoc = new Y.Doc()
+    compactedDoc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [new Y.XmlText('compact')])
+    mocks.compactYDoc.mockReturnValue({
+      compacted: Y.encodeStateAsUpdate(compactedDoc),
+      savedBytes: 120
+    })
+
+    createWindow(6)
+    await provider.open('note-1', undefined, { skipSeed: true })
+    provider.updateMeta('note-1', { title: 'Before compaction' })
+
+    // Suspend the compaction inside its snapshot push and run the production
+    // sequence in that window: eviction closes the windowless doc, the editor
+    // reopens the note onto a fresh entry, then a sync pull lands.
+    let reopenedDoc: Y.Doc | undefined
+    pushSnapshot.mockImplementationOnce(async () => {
+      await provider.close('note-1')
+      reopenedDoc = await provider.open('note-1', 6, { skipSeed: true })
+      provider.applyRemoteUpdate('note-1', makeRemoteUpdate('pulled after reopen'))
+    })
+
+    await provider.compactDoc('note-1')
+
+    // The compaction belongs to the retired entry, so it must not touch the
+    // live doc — and the update it swallowed must still reach that doc.
+    expect(provider.getDoc('note-1')).toBe(reopenedDoc)
+    expect(reopenedDoc?.isDestroyed).toBe(false)
+    expect(provider.getDoc('note-1')?.getMap('meta').get('title')).toBe('pulled after reopen')
+  })
+
   it('keeps a reopened doc alive if close races with a new open', async () => {
     let releaseFlush: (() => void) | undefined
     mocks.persistenceInstances[0].flushDocument.mockImplementationOnce(

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -887,6 +887,11 @@ export class CrdtProvider {
     const entry = this.docs.get(noteId)
     if (!entry) return
 
+    if (entry.closing) {
+      log.debug('Skipping compaction: doc is closing', { noteId })
+      return
+    }
+
     if (entry.windowIds.size > 0) {
       log.debug('Skipping compaction: editors open', { noteId, windowCount: entry.windowIds.size })
       return
@@ -919,8 +924,22 @@ export class CrdtProvider {
         await this.persistence.flushDocument(noteId)
       }
 
-      if (entry.windowIds.size > 0) {
-        log.info('Compaction aborted: editor opened during compaction', { noteId })
+      // close() only flips `entry.closing` and then deletes (or lets doOpen
+      // replace) the map entry — it never consults compaction state, so the
+      // entry captured above can be retired, and the note reopened onto a
+      // fresh entry, while the pushes above are in flight. Comparing entry
+      // identity is what catches that: swapping `entry.doc` on a detached
+      // entry would drop the compaction into an object nothing reads, and
+      // strand the remote updates buffered for it.
+      const live = this.docs.get(noteId)
+      if (live !== entry || live?.closing || entry.windowIds.size > 0) {
+        log.info('Compaction abandoned: the doc was reopened, closed or replaced mid-compaction', {
+          noteId,
+          replaced: live !== entry,
+          closing: live?.closing === true,
+          windowCount: entry.windowIds.size
+        })
+        this.drainCompactionBuffer(noteId, live)
         return
       }
 
@@ -949,6 +968,27 @@ export class CrdtProvider {
       this.compactingDocs.delete(noteId)
       this.compactionBuffers.delete(noteId)
     }
+  }
+
+  /**
+   * Hand the updates buffered for an abandoned compaction to whatever doc is
+   * live now. applyRemoteUpdate diverts remote updates into this buffer for the
+   * whole compaction window and reports nothing back to the sync coordinator,
+   * which has already recorded those sequence numbers as applied — so a
+   * discarded buffer is a silently lost remote update, not a retried one.
+   */
+  private drainCompactionBuffer(noteId: string, target: ActiveDoc | undefined): void {
+    const buffered = this.compactionBuffers.get(noteId)
+    this.compactionBuffers.delete(noteId)
+    if (!buffered?.length || !target || target.doc.isDestroyed) return
+
+    for (const update of buffered) {
+      Y.applyUpdate(target.doc, update, ORIGIN_NETWORK)
+    }
+    log.debug('Replayed remote updates buffered for an abandoned compaction', {
+      noteId,
+      count: buffered.length
+    })
   }
 
   /**

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -101,6 +101,17 @@ pins a doc for the rest of the session: the renderer's `crdt:close-doc` on unmou
 window that turns out to be gone, and provider teardown on vault close or switch. Once
 released, the doc is evictable and compactable again.
 
+Local compaction runs under that same condition as closing and eviction — a doc with no
+windows attached — and it is asynchronous for the same reason, so the two can be in flight
+at once for one note. Compaction therefore treats the entry it captured as provisional: it
+does not start on a doc that is already closing, and before swapping the compacted doc in
+it re-checks that the provider's map still holds the same entry. If the note was closed —
+or closed and reopened onto a fresh entry — in the meantime, the compaction is abandoned
+rather than written into an entry nothing reads. Remote updates that arrive during a
+compaction are buffered for it rather than applied directly, so an abandoned compaction
+hands its buffer to whichever doc is live at that point instead of discarding it: the sync
+coordinator counts those updates as applied and will not fetch them again.
+
 Closing is asynchronous — it flushes the doc to persistence first — so a note can be
 reopened while its own close is still in flight. The reopen builds a fresh Y.Doc and takes
 over the provider's entry for that note, and the close then finds that the entry no longer
@@ -108,17 +119,6 @@ belongs to it. It leaves that entry alone, because the reopened doc is the one t
 is typing into, and destroys only the doc it superseded. Nothing can reach the superseded
 doc at that point: every route into a Y.Doc looks the note id up in the provider's map,
 which now resolves the replacement.
-
-Local compaction runs under the same condition as closing and eviction — a doc with no
-windows attached — and it is asynchronous for the same reason, so the two can be in flight
-at once for one note. Compaction therefore treats its entry as provisional: it does not
-start on a doc that is already closing, and before swapping the compacted doc in it
-re-checks that the provider's map still holds the same entry. If the note was closed, or
-closed and reopened, in the meantime, the compaction is abandoned rather than written into
-an entry nothing reads. Remote updates that arrived during that window are buffered for the
-compaction rather than applied directly, so an abandoned compaction hands its buffer to
-whichever doc is live at that point instead of discarding it — the sync coordinator counts
-those updates as applied and will not fetch them again.
 
 ## IPC Loop Prevention
 

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -109,6 +109,17 @@ is typing into, and destroys only the doc it superseded. Nothing can reach the s
 doc at that point: every route into a Y.Doc looks the note id up in the provider's map,
 which now resolves the replacement.
 
+Local compaction runs under the same condition as closing and eviction — a doc with no
+windows attached — and it is asynchronous for the same reason, so the two can be in flight
+at once for one note. Compaction therefore treats its entry as provisional: it does not
+start on a doc that is already closing, and before swapping the compacted doc in it
+re-checks that the provider's map still holds the same entry. If the note was closed, or
+closed and reopened, in the meantime, the compaction is abandoned rather than written into
+an entry nothing reads. Remote updates that arrived during that window are buffered for the
+compaction rather than applied directly, so an abandoned compaction hands its buffer to
+whichever doc is live at that point instead of discarding it — the sync coordinator counts
+those updates as applied and will not fetch them again.
+
 ## IPC Loop Prevention
 
 Three pieces of metadata prevent feedback loops:


### PR DESCRIPTION
Closes #1285. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`compactDoc()` and `close()` both run on a doc with no windows attached, both are
asynchronous, and neither excluded the other.

`close()` (`apps/desktop/src/main/sync/crdt-provider.ts:310`) flips `entry.closing`
synchronously, then awaits a snapshot push and a persistence flush, then deletes the entry —
or leaves it alone if a reopen replaced it.

`compactDoc()` (`crdt-provider.ts:886`) gated on **open editors only**. It never read
`entry.closing`, and its post-await guard re-checked only the window count:

```ts
if (entry.windowIds.size > 0) {
  log.info('Compaction aborted: editor opened during compaction', { noteId })
  return
}
const oldDoc = entry.doc
const newDoc = new Y.Doc()
...
entry.doc = newDoc
```

So an entry that `close()` had already marked closing — or already deleted and replaced by a
reopen — still got the compacted doc swapped in. Two consequences:

1. **The compaction is dropped.** `entry` is no longer what `this.docs` holds, so
   `entry.doc = newDoc` writes into an object nothing reads. The live doc stays uncompacted
   and the new `Y.Doc` (plus its `update` listener) is built for nobody.
2. **A remote update is lost.** This is the user-visible half. `applyRemoteUpdate` diverts
   remote updates into `compactionBuffers` for the whole compaction window
   (`crdt-provider.ts:430`) — and it looks the buffer up by `noteId`, so it keeps diverting
   after the entry has been replaced. `compactDoc` then replays that buffer into the orphan
   `newDoc` and the `finally` block discards it. The update never reaches the doc the editor
   is on. `CrdtSyncCoordinator` treats `applyRemoteUpdate` as fire-and-forget and records the
   sequence number as applied straight after (`engine/crdt-sync-coordinator.ts:86-87`), so it
   is never re-fetched: a pulled edit from another device silently vanishes.

Reachable through ordinary paths — `checkAndCompact` fires compaction from a `setImmediate`
under `windowIds.size === 0`, which is the same condition `closeIfInactive()` and
`evictInactiveDocsIfNeeded()` (called from `open()`) run under.

## What changed

`crdt-provider.ts`, `compactDoc()` only:

- Bail up front when `entry.closing` — never start compacting a doc `close()` is retiring.
- Replace the post-await window check with an **entry-identity** check:
  `live !== entry || live?.closing || entry.windowIds.size > 0`. Entry identity is what
  catches the reopen, since an in-place `entry.doc` swap is invisible to `close()`'s own
  guard.
- New `drainCompactionBuffer()` hands any updates buffered for an abandoned compaction to
  whatever doc is live at that point, instead of dropping them.

Deliberately **not** done:

- **`close()` is untouched.** The issue floated changing its post-await guard to compare doc
  identity instead of entry identity. Not needed: with the `closing` re-check above,
  compaction no longer swaps a doc out from under an in-flight close, and in the ordering
  where it did, `close()` destroyed the compacted doc and `compactDoc` destroyed the old one
  — nothing leaked. Leaving `close()` alone also keeps this off PR #1295's file set.
- **No lock/serialisation between the two.** Compaction is a pure optimization; abandoning it
  is correct and cheaper than making `close()` wait.
- The unified guard also means the pre-existing "editor opened during compaction" abort now
  replays its buffer instead of discarding it. That is the same `if` block and the same
  data-loss mechanism, so it is fixed rather than left half-correct.

## How it was proven

Three tests in `crdt-provider.test.ts`, all driving the race through the real public API
(`open`/`close`/`compactDoc`/`applyRemoteUpdate`) with the persistence and snapshot-push
mocks used as the suspension points:

- `does not start compacting a doc that close() is already retiring`
- `abandons the compacted swap when close() starts mid-compaction`
- `replays buffered remote updates onto the live doc when a reopen replaces the entry mid-compaction`

Before/after on the same test file, reverting only `crdt-provider.ts` to `origin/main`:

```
before: Tests  3 failed | 43 passed (46)
          → expected "vi.fn()" to not be called at all, but actually been called 1 times
          → expected Doc{...} to be Doc{...}  (compacted doc swapped onto a closing entry)
          → expected undefined to be 'pulled after reopen'  (remote update swallowed)
after:  Tests  46 passed (46)
```

## Verification

```
pnpm --filter @memry/desktop typecheck:node                → clean
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  src/main/sync/crdt-provider.test.ts crdt-ipc-handlers.test.ts engine-crdt.test.ts \
  crdt-writeback.test.ts                                   → Test Files 4 passed, Tests 88 passed
./node_modules/.bin/eslint apps/desktop/src/main/sync/crdt-provider.ts  → 0 errors
git diff --check                                            → clean
pnpm docs:impact --base origin/main --strict                → covered
pnpm docs:build                                             → build complete
```

## Backward compatibility

In-memory doc lifetime only — no schema, IPC contract, sync protocol, vault format or
settings shape is touched, and the persisted compacted state is still written exactly as
before (the abandoned path only skips the in-memory swap).
