### PR TITLE
perf(sync): cache the vault uuid per data-db handle so every call site reads it once

### DIFF
--- a/apps/desktop/src/main/agent/storage/__tests__/vault-id.test.ts
+++ b/apps/desktop/src/main/agent/storage/__tests__/vault-id.test.ts
@@ -3,9 +3,9 @@ import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 
 import * as schema from '@memry/db-schema/data-schema'
-import { getOrCreateVaultUuid } from '../vault-id'
+import { getOrCreateVaultUuid, resetVaultUuidCache } from '../vault-id'
 
-function freshDb() {
+function freshSqlite() {
   const sqlite = new Database(':memory:')
   sqlite.exec(`
     CREATE TABLE vault_metadata (
@@ -15,13 +15,25 @@ function freshDb() {
       updated_at INTEGER NOT NULL
     );
   `)
-  return drizzle(sqlite, { schema })
+  return sqlite
+}
+
+function freshDb() {
+  return drizzle(freshSqlite(), { schema })
+}
+
+/** Rewrite the singleton behind drizzle's back, the way adoptVaultLocally does. */
+function rewriteUuid(sqlite: Database.Database, uuid: string): void {
+  sqlite.prepare(`UPDATE vault_metadata SET vault_uuid = ? WHERE id = 'singleton'`).run(uuid)
 }
 
 describe('getOrCreateVaultUuid', () => {
   let db: ReturnType<typeof freshDb>
 
   beforeEach(() => {
+    // Module-level cache, so leaking one test's handle into the next would
+    // mask exactly the staleness these tests exist to pin.
+    resetVaultUuidCache()
     db = freshDb()
   })
 
@@ -43,5 +55,77 @@ describe('getOrCreateVaultUuid', () => {
     getOrCreateVaultUuid(db)
     const rows = db.select().from(schema.vaultMetadata).all()
     expect(rows).toHaveLength(1)
+  })
+
+  it('reads the singleton row once per handle instead of on every call', () => {
+    // #given a handle whose SELECTs are counted at the SQLite layer, so this
+    // measures real query execution rather than a mocked drizzle
+    const sqlite = freshSqlite()
+    let selects = 0
+    const counting = new Proxy(sqlite, {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver)
+        if (prop !== 'prepare') return typeof value === 'function' ? value.bind(target) : value
+        return (source: string) => {
+          if (/^\s*select/i.test(source)) selects++
+          return target.prepare(source)
+        }
+      }
+    }) as Database.Database
+    const countedDb = drizzle(counting, { schema })
+
+    // #when the same vault identity is resolved from several call sites
+    getOrCreateVaultUuid(countedDb)
+    const selectsAfterFirst = selects
+    for (let i = 0; i < 10; i++) getOrCreateVaultUuid(countedDb)
+
+    // #then only the first call touched the database
+    expect(selects).toBe(selectsAfterFirst)
+  })
+
+  it('serves an existing row from cache after the first read', () => {
+    const sqlite = freshSqlite()
+    sqlite
+      .prepare(
+        `INSERT INTO vault_metadata (id, vault_uuid, created_at, updated_at)
+         VALUES ('singleton', 'pre-existing', 0, 0)`
+      )
+      .run()
+    const existingDb = drizzle(sqlite, { schema })
+
+    expect(getOrCreateVaultUuid(existingDb)).toBe('pre-existing')
+    // Rewritten with no invalidation → the cached value is what comes back,
+    // which is the property every explicit reset call site depends on.
+    rewriteUuid(sqlite, 'rewritten')
+    expect(getOrCreateVaultUuid(existingDb)).toBe('pre-existing')
+  })
+
+  it('re-reads after resetVaultUuidCache, so an in-place adoption is observed', () => {
+    const sqlite = freshSqlite()
+    const adoptedDb = drizzle(sqlite, { schema })
+    const own = getOrCreateVaultUuid(adoptedDb)
+
+    rewriteUuid(sqlite, 'initiator-uuid')
+    resetVaultUuidCache()
+
+    expect(getOrCreateVaultUuid(adoptedDb)).toBe('initiator-uuid')
+    expect(getOrCreateVaultUuid(adoptedDb)).not.toBe(own)
+  })
+
+  it('never serves one vault handle the identity of another', () => {
+    // #given two open vaults — a vault switch installs a new drizzle instance
+    const first = freshSqlite()
+    const second = freshSqlite()
+    const firstDb = drizzle(first, { schema })
+    const secondDb = drizzle(second, { schema })
+
+    // #when each mints its own identity
+    const firstUuid = getOrCreateVaultUuid(firstDb)
+    const secondUuid = getOrCreateVaultUuid(secondDb)
+
+    // #then the cache keys on the handle, so neither is confused for the other
+    expect(secondUuid).not.toBe(firstUuid)
+    expect(getOrCreateVaultUuid(firstDb)).toBe(firstUuid)
+    expect(getOrCreateVaultUuid(secondDb)).toBe(secondUuid)
   })
 })

--- a/apps/desktop/src/main/agent/storage/vault-id.ts
+++ b/apps/desktop/src/main/agent/storage/vault-id.ts
@@ -6,19 +6,52 @@ import * as schema from '@memry/db-schema/data-schema'
 
 const SINGLETON_ID = 'singleton'
 
-export function getOrCreateVaultUuid(db: BetterSQLite3Database<typeof schema>): string {
+type VaultUuidDb = BetterSQLite3Database<typeof schema>
+
+// vault_metadata holds a single row keyed on the literal 'singleton', and its
+// uuid never changes for as long as a vault stays open — yet every one of the
+// eleven call sites (sync runtime, canvas reconcile, crypto handlers, per
+// attachment, device registration, the HTTP request header) rebuilt a drizzle
+// query and re-read it. Cache it against the DataDb instance the caller passes:
+// opening, closing or switching a vault installs a brand-new drizzle instance
+// (see database/client.ts initDatabase), so the key misses on its own and no
+// vault switch can be served the previous vault's identity — which would be a
+// correctness bug in sync and crypto, not a perf one. WeakMap so a closed
+// vault's entry dies with its handle.
+//
+// The one rewrite that keeps the *same* handle — a linked device adopting the
+// initiator's uuid (sync/vault-adoption.ts, and the E2E bootstrapSyncDevice
+// hook) — must call resetVaultUuidCache() explicitly.
+let vaultUuidCache = new WeakMap<VaultUuidDb, string>()
+
+/** Invalidate after an in-place rewrite of the vault_metadata singleton. */
+export function resetVaultUuidCache(): void {
+  // Whole-map reset rather than a per-handle delete: an adoption can run
+  // against a handle the caller resolved separately, and dropping every entry
+  // is always safe (the next call re-reads one indexed row).
+  vaultUuidCache = new WeakMap()
+}
+
+export function getOrCreateVaultUuid(db: VaultUuidDb): string {
+  const cached = vaultUuidCache.get(db)
+  if (cached !== undefined) return cached
+
   const existing = db
     .select()
     .from(schema.vaultMetadata)
     .where(eq(schema.vaultMetadata.id, SINGLETON_ID))
     .get()
 
-  if (existing) return existing.vaultUuid
+  if (existing) {
+    vaultUuidCache.set(db, existing.vaultUuid)
+    return existing.vaultUuid
+  }
 
   const uuid = randomUUID()
   const now = Date.now()
   db.insert(schema.vaultMetadata)
     .values({ id: SINGLETON_ID, vaultUuid: uuid, createdAt: now, updatedAt: now })
     .run()
+  vaultUuidCache.set(db, uuid)
   return uuid
 }

--- a/apps/desktop/src/main/sync/http-client.test.ts
+++ b/apps/desktop/src/main/sync/http-client.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+import * as schema from '@memry/db-schema/data-schema'
 
 const mockFetch = vi.fn()
-const mockDb = { name: 'db' }
 const mockGetDatabase = vi.fn()
-const mockGetOrCreateVaultUuid = vi.fn()
 
 vi.stubEnv('SYNC_SERVER_URL', 'http://localhost:8787')
 
@@ -18,9 +19,10 @@ vi.mock('../database', () => ({
   getDatabase: () => mockGetDatabase()
 }))
 
-vi.mock('../agent/storage/vault-id', () => ({
-  getOrCreateVaultUuid: (...args: unknown[]) => mockGetOrCreateVaultUuid(...args)
-}))
+// ../agent/storage/vault-id is deliberately NOT mocked: the vault-identity
+// cache lives inside getOrCreateVaultUuid, so a stubbed module would assert
+// nothing about whether the header path actually stops re-reading SQLite — or
+// whether it observes an in-place adoption. These run against a real handle.
 
 // NetworkError copy resolves through the main-process i18n singleton, which only
 // exists after setMainI18n() during app boot. Echo the key back so the assertion
@@ -37,12 +39,37 @@ import {
   postToServer,
   getFromServer,
   deleteFromServer,
-  resetSyncVaultHeadersCache,
   SyncServerError,
   NetworkError,
   RateLimitError,
   parseRetryAfterHeader
 } from './http-client'
+import { resetVaultUuidCache } from '../agent/storage/vault-id'
+
+/** A real data.db handle carrying the vault_metadata singleton. */
+const createVaultDb = (vaultUuid: string) => {
+  const sqlite = new Database(':memory:')
+  sqlite.exec(`
+    CREATE TABLE vault_metadata (
+      id TEXT PRIMARY KEY,
+      vault_uuid TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `)
+  sqlite
+    .prepare(
+      `INSERT INTO vault_metadata (id, vault_uuid, created_at, updated_at)
+       VALUES ('singleton', ?, 0, 0)`
+    )
+    .run(vaultUuid)
+  return { sqlite, db: drizzle(sqlite, { schema }) }
+}
+
+/** Rewrite the singleton in place, the way adoptVaultLocally does. */
+const rewriteVaultUuid = (sqlite: Database.Database, vaultUuid: string): void => {
+  sqlite.prepare(`UPDATE vault_metadata SET vault_uuid = ? WHERE id = 'singleton'`).run(vaultUuid)
+}
 
 const createJsonResponse = (
   body: unknown,
@@ -64,14 +91,15 @@ const lastRequestHeaders = (): Record<string, string> => {
 }
 
 describe('http-client', () => {
+  let vault: ReturnType<typeof createVaultDb>
+
   beforeEach(() => {
     vi.clearAllMocks()
     // The vault identity is cached per DataDb handle for the process lifetime,
-    // and mockDb is one shared object, so without this every test after the
-    // first would silently read the previous test's cached value.
-    resetSyncVaultHeadersCache()
-    mockGetDatabase.mockReturnValue(mockDb)
-    mockGetOrCreateVaultUuid.mockReturnValue('vault-1')
+    // so without this a test could read a previous test's cached value.
+    resetVaultUuidCache()
+    vault = createVaultDb('vault-1')
+    mockGetDatabase.mockReturnValue(vault.db)
   })
 
   describe('syncFetch', () => {
@@ -161,7 +189,6 @@ describe('http-client', () => {
       await syncFetch('GET', '/sync/changes', undefined, 'my-token-123')
 
       // #then
-      expect(mockGetOrCreateVaultUuid).toHaveBeenCalledWith(mockDb)
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
@@ -297,14 +324,15 @@ describe('http-client', () => {
       // #given the vault uuid is a session-stable SQLite row that used to be
       // re-read (drizzle query build + statement) on every request
       mockFetch.mockResolvedValue(createJsonResponse({ success: true }))
-
-      // #when
-      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
-      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
       await syncFetch('GET', '/sync/changes', undefined, 'token-1')
 
-      // #then one read, and every request still carries the identity
-      expect(mockGetOrCreateVaultUuid).toHaveBeenCalledTimes(1)
+      // #when the row changes underneath with no invalidation — an observable
+      // stand-in for "did this request re-run the SELECT?"
+      rewriteVaultUuid(vault.sqlite, 'not-read-again')
+      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
+      await syncFetch('GET', '/sync/changes', undefined, 'token-1')
+
+      // #then no request re-read the row, and every one still carries the identity
       expect(mockFetch).toHaveBeenCalledTimes(3)
       for (const call of mockFetch.mock.calls) {
         expect((call[1].headers as Record<string, string>)['X-Memry-Vault-Id']).toBe('vault-1')
@@ -317,13 +345,10 @@ describe('http-client', () => {
       await syncFetch('GET', '/sync/changes', undefined, 'token-1')
 
       // #when openVault installs a new DataDb instance for a different vault
-      const otherDb = { name: 'other-db' }
-      mockGetDatabase.mockReturnValue(otherDb)
-      mockGetOrCreateVaultUuid.mockReturnValue('vault-2')
+      mockGetDatabase.mockReturnValue(createVaultDb('vault-2').db)
       await syncFetch('GET', '/sync/changes', undefined, 'token-1')
 
       // #then the new vault's identity is used, not the cached one
-      expect(mockGetOrCreateVaultUuid).toHaveBeenLastCalledWith(otherDb)
       expect(lastRequestHeaders()['X-Memry-Vault-Id']).toBe('vault-2')
     })
 
@@ -335,8 +360,8 @@ describe('http-client', () => {
 
       // #when adoptVaultLocally rewrites the uuid on the SAME handle and
       // invalidates the cache
-      mockGetOrCreateVaultUuid.mockReturnValue('adopted-vault')
-      resetSyncVaultHeadersCache()
+      rewriteVaultUuid(vault.sqlite, 'adopted-vault')
+      resetVaultUuidCache()
       await syncFetch('GET', '/sync/changes', undefined, 'token-1')
 
       // #then registration and every later request bind to the adopted vault
@@ -356,7 +381,7 @@ describe('http-client', () => {
       // #then no identity header, and nothing poisoned for the next attempt
       expect(lastRequestHeaders()['X-Memry-Vault-Id']).toBeUndefined()
 
-      mockGetDatabase.mockReturnValue(mockDb)
+      mockGetDatabase.mockReturnValue(vault.db)
       await syncFetch('GET', '/sync/changes', undefined, 'token-1')
       expect(lastRequestHeaders()['X-Memry-Vault-Id']).toBe('vault-1')
     })

--- a/apps/desktop/src/main/sync/http-client.ts
+++ b/apps/desktop/src/main/sync/http-client.ts
@@ -70,43 +70,22 @@ export function parseRetryAfterHeader(header: string | null): number | undefined
   return undefined
 }
 
-// The vault UUID is one SQLite row that is stable for as long as a vault stays
-// open, yet it was re-read — through a freshly built drizzle query — on every
-// authenticated request and every WebSocket connect. Cache it against the
-// DataDb instance `getDatabase()` hands back: opening, closing or switching a
-// vault installs a new instance (see database/client.ts initDatabase), so the
-// key misses on its own and no vault switch can be served a stale identity.
-// The one rewrite that keeps the same handle — a linked device adopting the
-// initiator's uuid — calls resetSyncVaultHeadersCache() explicitly.
-let cachedVaultHeaders: Record<string, string> | null = null
-let cachedVaultHeadersDb: unknown = null
-
-/** Invalidate after an in-place rewrite of the vault_metadata singleton. */
-export function resetSyncVaultHeadersCache(): void {
-  cachedVaultHeaders = null
-  cachedVaultHeadersDb = null
-}
-
 export async function getSyncVaultHeaders(): Promise<Record<string, string>> {
   try {
     // The imports stay inside the call: hoisting them to module scope would
     // pull ../database in at import time, which is exactly the eagerness the
     // lazy resolution in this file exists to avoid. They resolve from the
-    // module registry after the first call; the SQLite read is what this
-    // cache removes.
+    // module registry after the first call.
     const [{ getDatabase }, { getOrCreateVaultUuid }] = await Promise.all([
       import('../database'),
       import('../agent/storage/vault-id')
     ])
-    const db = getDatabase()
-    if (cachedVaultHeaders && cachedVaultHeadersDb === db) return cachedVaultHeaders
-    const vaultId = getOrCreateVaultUuid(db)
-    const headers: Record<string, string> = vaultId ? { 'X-Memry-Vault-Id': vaultId } : {}
-    // Frozen because every caller now receives this same instance.
-    Object.freeze(headers)
-    cachedVaultHeaders = headers
-    cachedVaultHeadersDb = db
-    return headers
+    // The SQLite read this used to repeat per authenticated request is now
+    // cached inside getOrCreateVaultUuid, keyed on the same DataDb handle —
+    // one mechanism for all eleven call sites, one invalidation hook
+    // (resetVaultUuidCache) instead of a second cache to keep in step here.
+    const vaultId = getOrCreateVaultUuid(getDatabase())
+    return vaultId ? { 'X-Memry-Vault-Id': vaultId } : {}
   } catch {
     return {}
   }

--- a/apps/desktop/src/main/sync/vault-adoption.test.ts
+++ b/apps/desktop/src/main/sync/vault-adoption.test.ts
@@ -37,7 +37,11 @@ describe('adoptVaultLocally', () => {
   })
 
   it('binds the joiner to the initiator vault uuid instead of a fresh one', () => {
-    // Joiner opened a fresh local vault first → its own random uuid + a stale verifier.
+    // Joiner opened a fresh local vault first → its own random uuid + a stale
+    // verifier. This first call also primes the handle-keyed cache inside
+    // getOrCreateVaultUuid — keep it: without adoptVaultLocally's explicit
+    // invalidation, every later call site would still read the joiner's own id
+    // and register the device against the wrong vault.
     const joinerOwnUuid = getOrCreateVaultUuid(db)
     db.insert(schema.settings)
       .values({ key: VAULT_KEY_VERIFIER_SETTING, value: 'stale-verifier' })
@@ -47,6 +51,8 @@ describe('adoptVaultLocally', () => {
     adoptVaultLocally(db, INITIATOR_UUID)
 
     // vault_metadata now holds the initiator's uuid → registration will send V.
+    expect(getOrCreateVaultUuid(db)).toBe(INITIATOR_UUID)
+    // and it stays adopted once re-cached, rather than flapping per call.
     expect(getOrCreateVaultUuid(db)).toBe(INITIATOR_UUID)
     // stale verifier cleared so bindLocalVaultToMasterKey can rebind cleanly.
     const verifier = db

--- a/apps/desktop/src/main/sync/vault-adoption.ts
+++ b/apps/desktop/src/main/sync/vault-adoption.ts
@@ -2,7 +2,7 @@ import { sql } from 'drizzle-orm'
 
 import type { DataDb } from '../database/types'
 import { VAULT_KEY_VERIFIER_SETTING } from '../crypto/vault-key-state'
-import { resetSyncVaultHeadersCache } from './http-client'
+import { resetVaultUuidCache } from '../agent/storage/vault-id'
 import { createLogger } from '../lib/logger'
 
 const logger = createLogger('Sync:VaultAdoption')
@@ -28,9 +28,9 @@ export function adoptVaultLocally(db: DataDb, vaultUuid: string): void {
     )
   })
   // The adopted uuid replaces the local one on the SAME database handle, so the
-  // handle-keyed cache in http-client would keep stamping the pre-adoption
-  // identity on every authenticated request — including the device registration
-  // that immediately follows.
-  resetSyncVaultHeadersCache()
+  // handle-keyed cache in getOrCreateVaultUuid would keep handing back the
+  // pre-adoption identity to every call site — the request header, the device
+  // registration that immediately follows, and the vault-key derivation.
+  resetVaultUuidCache()
   logger.info('Adopted shared vault identity for linked device', { vaultUuid })
 }

--- a/apps/desktop/src/main/test-hooks.test.ts
+++ b/apps/desktop/src/main/test-hooks.test.ts
@@ -21,6 +21,7 @@ const getCrdtQueueMock = vi.fn(() => ({ getOutstandingCount: outstandingCountMoc
 const startSyncRuntimeMock = vi.fn(async () => ({}))
 const getOrInitializeLocalVaultKeyMock = vi.fn(async () => new Uint8Array([1]))
 const getOrCreateVaultUuidMock = vi.fn(() => 'vault-1')
+const resetVaultUuidCacheMock = vi.fn()
 const dbRunMock = vi.fn()
 const dbGetMock = vi.fn(() => ({ id: 'project-1' }))
 const insertRunMock = vi.fn()
@@ -96,7 +97,8 @@ vi.mock('./crypto/vault-key-state', () => ({
 }))
 
 vi.mock('./agent/storage/vault-id', () => ({
-  getOrCreateVaultUuid: getOrCreateVaultUuidMock
+  getOrCreateVaultUuid: getOrCreateVaultUuidMock,
+  resetVaultUuidCache: resetVaultUuidCacheMock
 }))
 
 vi.mock('./database', () => ({
@@ -239,6 +241,10 @@ describe('main test hooks', () => {
       })
     )
     expect(dbRunMock).toHaveBeenCalled()
+    // The hook rewrites vault_metadata on the already-open handle, so the
+    // handle-keyed vault-uuid cache has to be dropped or every later call site
+    // (registration, vault key, request header) keeps the pre-bootstrap id.
+    expect(resetVaultUuidCacheMock).toHaveBeenCalled()
     expect(getOrInitializeLocalVaultKeyMock).toHaveBeenCalled()
     expect(startSyncRuntimeMock).toHaveBeenCalled()
 

--- a/apps/desktop/src/main/test-hooks.ts
+++ b/apps/desktop/src/main/test-hooks.ts
@@ -7,7 +7,6 @@ import { yDocToMarkdown } from './sync/blocknote-converter'
 import { getCrdtProvider, resetCrdtProvider } from './sync/crdt-provider'
 import { getWritebackDebugState } from './sync/crdt-writeback'
 import { getCrdtQueue, getNetworkMonitor, startSyncRuntime } from './sync/runtime'
-import { resetSyncVaultHeadersCache } from './sync/http-client'
 import { getDatabase } from './database'
 import { sql } from 'drizzle-orm'
 import { getNoteMetadataById } from '@memry/storage-data'
@@ -25,7 +24,7 @@ import { listCalendarExternalEventsBySource } from './calendar/repositories/cale
 import { calendarEvents } from '@memry/db-schema/schema/calendar-events'
 import { getMainI18n } from './lib/main-i18n'
 import { getOrInitializeLocalVaultKey, VAULT_KEY_VERIFIER_SETTING } from './crypto/vault-key-state'
-import { getOrCreateVaultUuid } from './agent/storage/vault-id'
+import { getOrCreateVaultUuid, resetVaultUuidCache } from './agent/storage/vault-id'
 import { inboxItems, inboxItemType } from '@memry/db-schema/schema/inbox'
 import { runReviewTick } from './inbox/review-scheduler'
 import { writeInboxReviewSettings } from './ipc/settings-handlers'
@@ -278,8 +277,8 @@ export function registerTestHooks(): void {
               updated_at = excluded.updated_at`
       )
       // Same in-place rewrite adoptVaultLocally performs, so drop the
-      // handle-keyed vault-header cache for the same reason.
-      resetSyncVaultHeadersCache()
+      // handle-keyed vault-uuid cache for the same reason.
+      resetVaultUuidCache()
 
       const deviceId = await persistKeysAndRegisterDevice(
         Buffer.from(input.masterKeyBase64, 'base64'),

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -474,11 +474,13 @@ require the vault to have synced any items, so a freshly created vault still app
 
 Every authenticated sync call — and the WebSocket handshake — stamps the active vault's UUID into
 `X-Memry-Vault-Id`. That UUID is a single `vault_metadata` row, so it is resolved once and cached
-against the open data-database handle rather than re-read per request. Opening, closing or switching
-a vault installs a new handle and therefore misses the cache on its own; the one rewrite that keeps
-the same handle — a linked device adopting the initiator's vault identity — invalidates it
-explicitly, so device registration and the first sync bind to the adopted vault, never the
-pre-adoption one.
+against the open data-database handle rather than re-read per request. The cache lives with the
+resolver itself, so every consumer shares it: the request header, device registration, vault-key
+derivation, canvas reconcile and per-attachment uploads all read the row once per open vault instead
+of once per operation. Opening, closing or switching a vault installs a new handle and therefore
+misses the cache on its own; the one rewrite that keeps the same handle — a linked device adopting
+the initiator's vault identity — invalidates it explicitly, so device registration and the first
+sync bind to the adopted vault, never the pre-adoption one.
 
 Desktop reads the directory over IPC:
 


### PR DESCRIPTION
Closes #1293. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/agent/storage/vault-id.ts:9` rebuilt a drizzle query and re-read the `vault_metadata` singleton on **every** call:

```ts
export function getOrCreateVaultUuid(db: BetterSQLite3Database<typeof schema>): string {
  const existing = db
    .select()
    .from(schema.vaultMetadata)
    .where(eq(schema.vaultMetadata.id, SINGLETON_ID))
    .get()
  if (existing) return existing.vaultUuid
```

The row is keyed on the literal `'singleton'` and cannot change while a vault stays open, so every call after the first is pure waste. Eleven non-test call sites on `origin/main` (`0a2eddb7c`), several of them per-operation:

| File:line | Cadence |
| --- | --- |
| `src/main/canvas/reconcile.ts:361` | per canvas reconcile (default parameter) |
| `src/main/ipc/sync-attachment-handlers.ts:140` | per attachment |
| `src/main/ipc/crypto-handlers.ts:87` | per vault-key resolve |
| `src/main/sync/runtime.ts:116` | per vault-key resolve |
| `src/main/sync/http-client.ts:103` | per authenticated request (the only one #1269 covered) |
| `src/main/sync/device-registration.ts:119`, `src/main/sync/vault-transfer.ts:44`, `src/main/agent/bootstrap.ts:59`, `src/main/canvas/vault-key.ts:36`, `src/main/canvas/assets/asset-service-context.ts:37`, `src/main/vault/index.ts:479` | per operation |

#1269 (merged) solved this for the request-header path only, with a handle-keyed cache plus a `resetSyncVaultHeadersCache()` escape hatch. Ten call sites kept the redundant read.

## What changed

The #1269 shape is **hoisted into `vault-id.ts`** rather than duplicated:

- `getOrCreateVaultUuid` now memoizes into a `WeakMap<DataDb, string>` keyed on the drizzle handle the caller passes. `initDatabase()` (`database/client.ts:40`) installs a brand-new drizzle instance on every vault open/close/switch, so the key misses on its own — no vault switch can be served another vault's id. `WeakMap` so a closed vault's entry dies with its handle.
- `resetVaultUuidCache()` is the single explicit invalidation hook, for the two places that rewrite the singleton **in place on an already-open handle**:
  - `sync/vault-adoption.ts:34` — a linked device adopting the initiator's uuid.
  - `test-hooks.ts:281` — the E2E `bootstrapSyncDevice` hook (same UPSERT).
- **Deliberately removed** the header-object cache in `sync/http-client.ts` rather than leaving it alongside. Two caches would mean two resets that must be kept in step at every future in-place-rewrite site — exactly the failure mode this issue is about. `getSyncVaultHeaders` is back to building its small header object per call; the SQLite read it was really avoiding is now avoided one layer down, and its lazy per-call `import()`s are unchanged.

**Deliberately not done:** no call site was changed to hold onto the uuid itself, and `reconcile.ts:361`'s default-parameter shape is untouched — the point is that all eleven now share one correct mechanism.

Invalidation paths audited, all covered: `initDatabase`/`closeDatabase` (new handle → natural miss), `adoptVaultLocally` (explicit reset), `bootstrapSyncDevice` (explicit reset), `createDormantVault` (goes through `adoptVaultLocally`). No sync item handler, migration, or importer writes `vault_metadata`; `scripts/seed-vault/db-writer.ts` writes it in a separate process before the app opens the vault.

## How it was proven

Tests run against **real `better-sqlite3` handles**, not a mocked resolver — `http-client.test.ts` no longer stubs `../agent/storage/vault-id`, so the header path exercises the actual cache.

**Before** (`vault-id.ts` reverted to `origin/main`, tests unchanged) — `3 failed | 44 passed (47)`:

```
× vault-id > reads the singleton row once per handle instead of on every call
    AssertionError: expected 11 to be 1
× vault-id > serves an existing row from cache after the first read
    AssertionError: expected 'rewritten' to be 'pre-existing'
× http-client > vault identity header > resolves the vault uuid once and reuses it
    AssertionError: expected 'not-read-again' to be 'vault-1'
```

`expected 11 to be 1` is a SQLite-layer `SELECT` counter: 11 statements for 11 resolves before, 1 after.

**After** — `47 passed (47)` on those four files, and `2695 passed | 1 expected fail | 3 skipped (2699)` across 226 files covering every call site.

**Mutation tests** — the invalidation is load-bearing, not decorative:

- Delete `resetVaultUuidCache()` from `adoptVaultLocally` → `vault-adoption.test.ts` fails: `expected 'c0f8e463-...' to be '8945f5fd-...'`, i.e. the joiner would register the device against its **own** vault instead of the initiator's.
- Delete it from `bootstrapSyncDevice` → `test-hooks.test.ts` fails.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  src/main/agent src/main/sync src/main/canvas src/main/ipc/crypto-handlers.test.ts \
  src/main/ipc/sync-attachment-handlers.test.ts src/main/ipc/canvas-handlers.test.ts \
  src/main/ipc/canvas-folder-handlers.test.ts src/main/test-hooks.test.ts
  -> Test Files 226 passed (226) | Tests 2695 passed | 1 expected fail | 3 skipped (2699)

pnpm --filter @memry/desktop typecheck:node   -> clean, no output
pnpm exec eslint <8 changed files>            -> 0 errors (4 "file ignored" warnings on test files, pre-existing config)
git diff --check                              -> clean
pnpm docs:impact --base origin/main --strict  -> covered
pnpm docs:build                               -> build complete in 4.53s
```

No renderer files touched, so `typecheck:web` was not run.

## Backward compatibility

Pure in-memory memoization — no schema, migration, IPC contract, sync-protocol, vault-file or settings change. Existing installs read the same `vault_metadata` row they always did, just once per open vault.
