### PR TITLE
fix(viewers): snap float-drifted image zoom back onto exactly 100%

### DIFF
--- a/apps/desktop/src/renderer/src/components/viewers/image-viewer.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/image-viewer.tsx
@@ -34,6 +34,29 @@ function buildTransform(position: Position, scale: number, rotation: number): st
   return `translate(${position.x}px, ${position.y}px) scale(${scale}) rotate(${rotation}deg)`
 }
 
+/**
+ * Widest float error a zoom round trip can accumulate, and still far narrower than any zoom
+ * level the user can land on. Wheel steps are 0.1 and button steps 0.25, so the closest real
+ * neighbours of 100% are 95% and 105% — a genuine 1.0499999999999998 stays untouched.
+ */
+const SCALE_EPSILON = 1e-9
+
+/**
+ * Snaps a scale that is one float wobble away from 1 back onto exactly 1.
+ *
+ * Mixing the 0.1 wheel steps with the 0.25 button steps does not round-trip in binary
+ * floating point: wheel-down, zoom-in, zoom-out, wheel-up leaves 0.9999999999999999, and
+ * the mirror sequence leaves 1.0000000000000002. Both render as "100%" via
+ * `Math.round(scale * 100)` while every exact read in this component disagrees — the
+ * `scale === 1` recenter never fires, so the image stays visibly offset, and `scale > 1`
+ * can even stay armed at a displayed 100%. Applying this once in `applyScale` — the single
+ * write path for scale — keeps every exact read honest instead of scattering tolerances
+ * across each one.
+ */
+function normalizeScale(next: number): number {
+  return Math.abs(next - 1) < SCALE_EPSILON ? 1 : next
+}
+
 // ============================================================================
 // Image Viewer Component
 // ============================================================================
@@ -65,7 +88,10 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
   // the scale change. Doing it in the render body instead (`if (scale === 1) setPosition(...)`)
   // made React throw the render away and run the component a second time on every zoom-out.
   const applyScale = useCallback(
-    (next: number) => {
+    (raw: number) => {
+      // Normalise before anything reads it, so the exact `=== 1` below and the `scale > 1`
+      // reads downstream cannot disagree with the "100%" the toolbar prints.
+      const next = normalizeScale(raw)
       scaleRef.current = next
       setScale(next)
       if (next === 1 && (positionRef.current.x !== 0 || positionRef.current.y !== 0)) {

--- a/apps/desktop/src/renderer/src/components/viewers/viewers.test.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/viewers.test.tsx
@@ -367,6 +367,105 @@ describe('viewer components', () => {
     expect(mocks.useT).toHaveBeenCalledTimes(1)
   })
 
+  // Zoom mixes 0.1 wheel steps with 0.25 button steps and those do not round-trip in binary
+  // floating point. Nothing below sets a scale directly: each test drives real events, so the
+  // values under test are whatever the component actually accumulates.
+  it('recenters when a wheel step lands back on a displayed 100%', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<ImageViewer src="memry-file://drift-down.png" alt="DriftDown" />)
+    const image = screen.getByRole('img', { name: 'DriftDown' })
+    const imageContainer = image.parentElement as HTMLDivElement
+    const [zoomOutButton, zoomInButton] = container.querySelectorAll('button')
+
+    // wheel-down, zoom-in, zoom-out, wheel-up leaves 0.9999999999999999, shown as "100%".
+    fireEvent.wheel(imageContainer, { deltaY: 1 })
+    await user.click(zoomInButton)
+    expect(screen.getByText('115%')).toBeInTheDocument()
+
+    fireEvent.mouseDown(imageContainer, { clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(window, { clientX: 140, clientY: 170 })
+    fireEvent.mouseUp(window)
+    expect(image.style.transform).toBe('translate(40px, 70px) scale(1.15) rotate(0deg)')
+
+    await user.click(zoomOutButton)
+    fireEvent.wheel(imageContainer, { deltaY: -1 })
+
+    expect(screen.getByText('100%')).toBeInTheDocument()
+    expect(image.style.transform).toBe('translate(0px, 0px) scale(1) rotate(0deg)')
+  })
+
+  it('does not leave drag-to-pan armed at a displayed 100%', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<ImageViewer src="memry-file://drift-up.png" alt="DriftUp" />)
+    const image = screen.getByRole('img', { name: 'DriftUp' })
+    const imageContainer = image.parentElement as HTMLDivElement
+    const [zoomOutButton, zoomInButton] = container.querySelectorAll('button')
+
+    // The mirror sequence lands on 1.0000000000000002 — also "100%", but above 1, so the
+    // pan affordances stayed switched on at what the toolbar called natural size.
+    fireEvent.wheel(imageContainer, { deltaY: -1 })
+    fireEvent.wheel(imageContainer, { deltaY: -1 })
+    expect(screen.getByText('120%')).toBeInTheDocument()
+
+    fireEvent.mouseDown(imageContainer, { clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(window, { clientX: 140, clientY: 170 })
+    fireEvent.mouseUp(window)
+
+    await user.click(zoomOutButton)
+    fireEvent.wheel(imageContainer, { deltaY: 1 })
+    fireEvent.wheel(imageContainer, { deltaY: 1 })
+    await user.click(zoomInButton)
+
+    expect(screen.getByText('100%')).toBeInTheDocument()
+    expect(image.style.transform).toBe('translate(0px, 0px) scale(1) rotate(0deg)')
+    expect(screen.queryByText('phaseF.componentsViewersImageViewer.dragToPan')).toBeNull()
+    expect(imageContainer.className).toContain('cursor-default')
+  })
+
+  it('still recenters on a toolbar-only round trip to 100%', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<ImageViewer src="memry-file://toolbar.png" alt="Toolbar" />)
+    const image = screen.getByRole('img', { name: 'Toolbar' })
+    const imageContainer = image.parentElement as HTMLDivElement
+    const [zoomOutButton, zoomInButton] = container.querySelectorAll('button')
+
+    await user.click(zoomInButton)
+    expect(screen.getByText('125%')).toBeInTheDocument()
+
+    fireEvent.mouseDown(imageContainer, { clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(window, { clientX: 140, clientY: 170 })
+    fireEvent.mouseUp(window)
+    expect(image.style.transform).toBe('translate(40px, 70px) scale(1.25) rotate(0deg)')
+
+    await user.click(zoomOutButton)
+    expect(screen.getByText('100%')).toBeInTheDocument()
+    expect(image.style.transform).toBe('translate(0px, 0px) scale(1) rotate(0deg)')
+  })
+
+  it('leaves a genuine 105% zoom alone instead of snapping it to 100%', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<ImageViewer src="memry-file://real-zoom.png" alt="RealZoom" />)
+    const image = screen.getByRole('img', { name: 'RealZoom' })
+    const imageContainer = image.parentElement as HTMLDivElement
+    const zoomInButton = container.querySelectorAll('button')[1]
+
+    await user.click(zoomInButton)
+    fireEvent.mouseDown(imageContainer, { clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(window, { clientX: 140, clientY: 170 })
+    fireEvent.mouseUp(window)
+
+    // 1.25 -> 1.15 -> 1.0499999999999998: a zoom level the user picked, 0.05 away from 1 and
+    // so nowhere near the snap tolerance. It must keep its offset and its pan affordances.
+    fireEvent.wheel(imageContainer, { deltaY: 1 })
+    fireEvent.wheel(imageContainer, { deltaY: 1 })
+
+    expect(screen.getByText('105%')).toBeInTheDocument()
+    expect(image.style.transform).toBe(
+      'translate(40px, 70px) scale(1.0499999999999998) rotate(0deg)'
+    )
+    expect(screen.getByText('phaseF.componentsViewersImageViewer.dragToPan')).toBeInTheDocument()
+  })
+
   it('loads PDFs, navigates pages, changes zoom/sidebar/rotation, and reports load errors', async () => {
     const user = userEvent.setup()
     const { container } = render(<PdfViewer src="memry-file://spec.pdf" />)

--- a/apps/desktop/src/renderer/src/components/viewers/viewers.test.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/viewers.test.tsx
@@ -417,9 +417,9 @@ describe('viewer components', () => {
     await user.click(zoomInButton)
 
     expect(screen.getByText('100%')).toBeInTheDocument()
-    expect(image.style.transform).toBe('translate(0px, 0px) scale(1) rotate(0deg)')
     expect(screen.queryByText('phaseF.componentsViewersImageViewer.dragToPan')).toBeNull()
     expect(imageContainer.className).toContain('cursor-default')
+    expect(image.style.transform).toBe('translate(0px, 0px) scale(1) rotate(0deg)')
   })
 
   it('still recenters on a toolbar-only round trip to 100%', async () => {

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -62,6 +62,10 @@ A pan keeps following your pointer even when it leaves the viewer or the app win
 wherever you release the button, so you can drag a zoomed image right to its edge in one motion.
 Zooming back out to 100% recenters the image.
 
+The scroll wheel and the toolbar buttons zoom in different increments, but they agree on what
+100% means: whenever the toolbar reads 100%, the image is recentred and the drag-to-pan hint is
+gone, no matter which mix of wheel and buttons you took to get there.
+
 ### Images From Another App's Vault
 
 Vaults written by Obsidian, Capacities and similar apps keep media in a shared


### PR DESCRIPTION
Closes #1286. Part of epic #987 (memory/CPU audit 2026-08).

Rebased onto current `main` (`c5a4ad456`) now that #1276 has landed — see "Rebase onto #1276"
below for what that changed in this diff.

## What was wrong

`components/viewers/image-viewer.tsx` gates the recenter on an exact float compare. Since #1276
that lives in `applyScale`:

```tsx
if (next === 1 && (positionRef.current.x !== 0 || positionRef.current.y !== 0)) {
  commitPosition({ x: 0, y: 0 })
}
```

The zoom label is `Math.round(scale * 100)`, so a scale one ULP off 1 still reads "100%" while
every exact read in the file disagrees with it. The recenter never fires and the image sits
visibly offset, and on the above-1 side `scale > 1` (`handleMouseDown`, the pan hint, the
`cursor-grab` class) keeps drag-to-pan armed at what the toolbar calls natural size.

**The issue's stated mechanism is not the real one, and the fix is wider because of it.** The
issue blames the 0.1 wheel steps alone and cites `1.1 - 0.1 === 1.0000000000000002`. That is
false — `1.1 - 0.1 === 1` exactly. Enumerating every state the wheel can reach from 1 on its own
(53 of them, `±0.1` with the 0.25/5 clamp) turns up no near-1 value at all, so wheel-only zoom
never reproduces this.

What does reproduce it is **mixing the 0.1 wheel steps with the 0.25 toolbar steps**, which is
just ordinary use — both controls sit in the same toolbar. Enumerating the reachable set for
`{±0.1 wheel, ±0.25 buttons}` gives two short paths, one on each side of 1:

| Sequence from 100% | Lands on | Label | `=== 1` | `> 1` |
|---|---|---|---|---|
| wheel-down, zoom-in, zoom-out, wheel-up | `0.9999999999999999` | 100% | false | false |
| wheel-up ×2, zoom-out, wheel-down ×2, zoom-in | `1.0000000000000002` | 100% | false | **true** |

So the issue's claim that "the toolbar buttons step by exact 0.25 … so they do recenter" only
holds if you never touch the wheel. Once the two are mixed, a *button* press is just as capable
of landing on the drifted value — the second row above ends on a zoom-in click. Fixing only the
wheel path, as the issue's title suggests, would have left that half broken.

## What changed

One module-level pure helper:

```tsx
const SCALE_EPSILON = 1e-9

function normalizeScale(next: number): number {
  return Math.abs(next - 1) < SCALE_EPSILON ? 1 : next
}
```

applied once at the top of #1276's `applyScale`, which is already the single write path for
scale, so wheel, `zoomIn`, `zoomOut`, `resetZoom` and `fitToContainer` all inherit it:

```tsx
const applyScale = useCallback(
  (raw: number) => {
    const next = normalizeScale(raw)
    scaleRef.current = next
    setScale(next)
    ...
```

This is the issue's "snap" option rather than its "compare with an epsilon" option: normalising
on write means the state itself is exact, so the existing `scale === 1` / `scale > 1` reads stay
correct as written and any future read gets the same guarantee for free. Scattering a tolerance
across each read site would have left the next one to be added un-guarded.

`1e-9` is ~7 orders of magnitude above the worst observed drift (~1e-16) and ~7 orders below the
nearest zoom level a user can actually select: with 0.1 and 0.25 steps the closest real
neighbours of 100% are 95% and 105%. A genuine `1.0499999999999998` is 0.05 away and untouched —
there is a test for exactly that.

**Deliberately not done:** the 0.1/0.25 step sizes and the toolbar's rounding are unchanged. This
only removes the disagreement between them; it does not restructure zoom.

## Rebase onto #1276

#1276 landed as `0cf2fb9c6` and rewrote these exact lines, so both files conflicted. Resolved the
way this PR originally proposed: **keep #1276's `applyScale` untouched and normalise at its top**,
dropping the four call-site wrappers this branch carried when it was written against pre-#1276
`main`. Net effect is that the diff got *smaller* — one helper plus one line inside `applyScale`,
instead of four wrapped call sites.

The test-file conflict was purely positional: #1276 inserted
`recenters on zoom-out to 100% without a throwaway render pass` at the same spot. Both sides kept,
neither modified. That test still passes here, so #1276's single-render-pass guarantee is intact.

## How it was proven

Four new tests in `viewers.test.tsx`. None of them sets a scale directly: each drives real wheel
and click events and asserts on what the component accumulates, so the drifted values under test
are the component's own arithmetic, not a hand-written constant.

Re-run after the rebase, against `origin/main`'s source (`c5a4ad456`, i.e. *with* #1276) with the
new tests in place, then against the fix (`git checkout origin/main -- <source>` /
`git checkout HEAD -- <source>`, no stash):

| Test | Before | After |
|---|---|---|
| Wheel step back to a displayed 100% recenters | **fail** — `translate(40px, 70px) scale(0.9999999999999999)` | pass |
| Drag-to-pan not armed at a displayed 100% | **fail** — pan hint still rendered (`expected <span></span> to be null`) | pass |
| Toolbar-only round trip to 100% still recenters | pass (regression guard) | pass |
| Genuine 105% zoom is not snapped to 100% | pass (regression guard) | pass |

Before: `Tests 2 failed | 11 passed (13)`. After: `Tests 13 passed (13)`.

The two guards passing on both sides is the point: they pin the behaviour the epsilon must not
break. The 105% guard asserts the transform keeps its `scale(1.0499999999999998)` and its pan
offset, so an over-wide tolerance would fail it.

## Verification

```
vitest --project renderer viewers.test.tsx + pages/file.test.tsx
                          + hooks/timer-raf-cleanup.test.tsx      -> 27 passed (27), 3 files
pnpm --filter @memry/desktop typecheck:web                        -> clean
pnpm exec eslint apps/.../image-viewer.tsx                        -> 0 problems
pnpm exec prettier --check <changed files>                        -> all match
pnpm docs:impact --base origin/main --strict                      -> covered
git diff --check origin/main                                      -> clean
```

`pages/file.test.tsx` is the `ImageViewer` consumer; `hooks/timer-raf-cleanup.test.tsx` is #1266's
suite, both included to confirm the rebase disturbed nothing.

## Backward compatibility

Renderer-only. No schema, contract, IPC, settings, sync or vault-format change. The only
behaviour difference is that a zoom the toolbar already labelled 100% now actually behaves like
100%.
