### PR TITLE
docs(shortcuts): describe hint mode's letter badges instead of numeric ones

### DIFF
--- a/apps/docs/src/guide/tour.md
+++ b/apps/docs/src/guide/tour.md
@@ -93,14 +93,14 @@ Tasks live alongside notes. Two views — **list** and **kanban**. Group tasks u
 
 memrynote is keyboard-friendly. The full shortcut list is at [Keyboard Shortcuts](/user-guide/keyboard-shortcuts). Highlights:
 
-| Shortcut                   | Action                                              |
-| -------------------------- | --------------------------------------------------- |
-| <kbd>⌘</kbd>+<kbd>N</kbd>  | New note                                            |
-| <kbd>⌘</kbd>+<kbd>F</kbd>  | Search / command palette                            |
-| <kbd>⌘</kbd>+<kbd>,</kbd>  | Settings                                            |
-| <kbd>⌘</kbd>+<kbd>B</kbd>  | Toggle sidebar                                      |
-| <kbd>⌘</kbd>+<kbd>\\</kbd> | Split right                                         |
-| <kbd>F</kbd>               | Hint mode (numeric badges on every clickable thing) |
+| Shortcut                   | Action                                             |
+| -------------------------- | -------------------------------------------------- |
+| <kbd>⌘</kbd>+<kbd>N</kbd>  | New note                                           |
+| <kbd>⌘</kbd>+<kbd>F</kbd>  | Search / command palette                           |
+| <kbd>⌘</kbd>+<kbd>,</kbd>  | Settings                                           |
+| <kbd>⌘</kbd>+<kbd>B</kbd>  | Toggle sidebar                                     |
+| <kbd>⌘</kbd>+<kbd>\\</kbd> | Split right                                        |
+| <kbd>F</kbd>               | Hint mode (letter badges on every clickable thing) |
 
 Open the in-app shortcuts dialog with <kbd>⌘</kbd>+<kbd>/</kbd> for the live list.
 

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -118,18 +118,30 @@ menu. See [Organizing Canvases](/user-guide/canvas/organizing).
 
 ## Hint Mode
 
-Hint mode overlays numeric badges on interactive elements so you can act without the mouse.
+Hint mode overlays letter badges on interactive elements so you can act without the mouse.
 
 | Action             | Shortcut                                  |
 | ------------------ | ----------------------------------------- |
 | Activate hint mode | <kbd>F</kbd> or <kbd>⌥</kbd>+<kbd>F</kbd> |
-| Pick a target      | Type the number shown                     |
+| Pick a target      | Type the letters shown                    |
 | Undo a keystroke   | <kbd>Backspace</kbd>                      |
 | Exit               | <kbd>Esc</kbd>                            |
 
-Each keystroke narrows the badges in place, and <kbd>Backspace</kbd> takes back the
-last character you typed. Only the badge overlay repaints as you type, so hint mode
-stays responsive on screens with a lot of targets.
+Badges are mnemonics built from each target's own name — its accessibility label,
+its visible text, or its tooltip, in that order. A target whose first letter is
+unique on screen gets that single letter (**Inbox** → `I`). When several targets
+share a first letter they get two characters: the shared letter plus the next
+distinct letter from that target's own text (**Tags** → `TA`, **Tasks** → `TS`).
+Anything with no usable letter to start from — an icon-only button, or a name that
+doesn't begin with A–Z — falls back to a sequential two-letter code (`AA`, `AB`,
+…), and those codes never reuse a letter that is already a badge on its own.
+
+Typing is case-insensitive and matches from the start of a badge. Each keystroke
+narrows the badges in place, keys that match nothing are ignored, and
+<kbd>Backspace</kbd> takes back the last character you typed. The moment what
+you've typed is a complete badge, that element is clicked and focused and hint
+mode exits. Only the badge overlay repaints as you type, so hint mode stays
+responsive on screens with a lot of targets.
 
 ## Global Undo (Tasks)
 


### PR DESCRIPTION
Closes #1287. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

Two docs pages described hint mode as numeric. It has never been numeric.

`apps/docs/src/user-guide/keyboard-shortcuts.md:121,126`

```md
Hint mode overlays numeric badges on interactive elements so you can act without the mouse.
| Pick a target      | Type the number shown                     |
```

`apps/docs/src/guide/tour.md:103`

```md
| <kbd>F</kbd>               | Hint mode (numeric badges on every clickable thing) |
```

Every label path in `apps/desktop/src/renderer/src/lib/label-assigner.ts` produces
uppercase ASCII letters; no path produces a digit:

- `extractElementText()` reads `aria-label` → `textContent` → `title`, in that order.
- Unique first letter → that one letter is the label (`Inbox` → `I`), recorded in
  `singleCharLabels`.
- Shared first letter → shared letter + the next distinct ASCII letter from that
  target's own text via `asciiLettersAfter()` (`Tags` → `TA`, `Tasks` → `TS`).
- No usable ASCII first letter (icon-only button, `日本語`), or two-char mnemonics
  exhausted → `generateSequentialCode()` walks `'ABCDEFGHIJKLMNOPQRSTUVWXYZ'` pairs
  (`AA`, `AB`, …) and skips any code whose first char is already a single-char
  label, so a one-letter badge is never a prefix of a two-letter one.

The typing side in `contexts/hint-mode/context.tsx:59-78` is prefix matching, not
index lookup: `typeChar()` uppercases the key, filters `label.startsWith(next)`,
ignores the keystroke entirely when nothing matches, and clicks + focuses + exits
only when the typed string equals a whole label.

A user who activates hint mode, sees `TA`, and follows the docs by typing a digit
gets nothing at all — the keystroke is silently dropped. Hint mode reads as broken.

## What changed

Docs only — no source change, because the source is correct and the docs are not.

- `keyboard-shortcuts.md` — "numeric badges" → "letter badges", "Type the number
  shown" → "Type the letters shown", plus a paragraph stating the real rule
  (mnemonic from the target's own name; single letter when unique; two letters on
  a first-letter collision; sequential `AA`/`AB` fallback for unlabelled or
  non-Latin targets) and a paragraph on typing behaviour (case-insensitive, prefix
  match, non-matching keys ignored, click+focus+exit on a complete label).
- `tour.md` — "numeric badges" → "letter badges" in the highlights table.

Deliberately **not** done:

- No change to `packages/i18n`. The only hint-mode string there is
  `phaseF.componentsHintOverlayHintIndicator.hint` — the literal word "HINT" on the
  indicator pill. No locale describes the labels as numbers.
- No change to `apps/desktop/src/renderer/src/components/hint-overlay/*`. The badge
  renders `hint.label` directly; there is no user-visible copy to correct.
- No change to `CHANGELOG.md:267`, which already described this correctly in 2026-04
  ("single-char mnemonics, two-char fallback on first-letter collisions"), and none
  to `apps/landing/src/pages/Roadmap.tsx:169`, which only says "Vim hint mode".
- `apps/docs/src/user-guide/search.md:41` ("Type the number, then your query") and
  `snooze-reminders.md:67` ("Numeric badges … Dock") are genuinely numeric features
  — search scope prefixes and the Dock badge — and were left alone.
- The `tour.md` table reflows one column narrower. That is Prettier's canonical
  output for the shorter cell, not a hand reformat; `tour.md` is Prettier-clean on
  `origin/main` and stays Prettier-clean here.

## How it was proven

No before/after vitest run: this is a docs-only correction with no source change,
so there is no behaviour to regress and nothing new to cover.

The existing suite already pins the behaviour the docs now describe —
`apps/desktop/src/renderer/src/lib/label-assigner.test.ts` asserts `['I','J','T']`
for unique first letters, `TA`/`TS` for the `Tags`/`Tasks` collision, `/^[A-Z]{2}$/`
for no-text and for `日本語`, and that no single-char label is a prefix of a
two-char one. Those tests are the source of truth the new wording was written
against; they are untouched by this PR.

## Verification

```
$ pnpm docs:impact --base origin/main --strict
docs impact: no desktop/sync-server docs-relevant changes detected

$ pnpm docs:build
vitepress v1.6.4
✓ building client + server bundles...
✓ rendering pages...
build complete in 2.85s.

$ pnpm exec prettier --check apps/docs/src/user-guide/keyboard-shortcuts.md apps/docs/src/guide/tour.md
Checking formatting...
All matched files use Prettier code style!

$ git diff --check origin/main
(no output)
```

No typecheck/vitest/eslint run: zero `.ts`/`.tsx` files are touched (`git diff
--stat origin/main` = 2 markdown files, +25 −13; the tour.md table reflow accounts for the extra lines).

## Backward compatibility

No runtime, schema, contract, IPC, settings, or sync-shape changes — two markdown
files only, so there is nothing for an existing install to migrate.
