### PR TITLE
refactor(agent): delete the dead AgentRuntime.inFlight registry and the no-op backend cancel() surface

### DIFF
--- a/apps/desktop/src/main/agent/backends/__tests__/claude-cli-backend.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/claude-cli-backend.test.ts
@@ -93,7 +93,6 @@ describe('ClaudeCliBackend', () => {
       windowId: 'window-1',
       options: { backend: 'codex_cli', reasoningEffort: 'medium' }
     })
-    backend.cancel('conversation-1')
 
     expect(spawn).toHaveBeenNthCalledWith(
       1,

--- a/apps/desktop/src/main/agent/backends/__tests__/codex-cli-backend.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/codex-cli-backend.test.ts
@@ -60,7 +60,6 @@ describe('CodexCliBackend', () => {
       windowId: 'window-1',
       options: { backend: 'codex_cli', reasoningEffort: 'medium' }
     })
-    backend.cancel('conversation-1')
 
     expect(spawn).toHaveBeenNthCalledWith(1, expect.objectContaining({ purpose: 'title' }))
     expect(spawn).toHaveBeenNthCalledWith(2, expect.objectContaining({ purpose: 'summary' }))

--- a/apps/desktop/src/main/agent/backends/__tests__/local-openai-compatible-backend.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/local-openai-compatible-backend.test.ts
@@ -161,7 +161,6 @@ describe('LocalOpenAICompatibleBackend', () => {
       prompt: 'User: hello',
       options: { backend: 'local_openai_compatible', model: 'llama3.2', toolsEnabled: false }
     })
-    backend.cancel('conversation-1')
 
     expect(mocks.streamText).toHaveBeenCalledWith(
       expect.not.objectContaining({

--- a/apps/desktop/src/main/agent/backends/claude-cli-backend.ts
+++ b/apps/desktop/src/main/agent/backends/claude-cli-backend.ts
@@ -30,10 +30,6 @@ export class ClaudeCliBackend implements AgentBackend {
     return this.run(input, 'summary')
   }
 
-  cancel(conversationId: string): void {
-    void conversationId
-  }
-
   async getStatus() {
     const status = await detectClaudeBinary()
     return {

--- a/apps/desktop/src/main/agent/backends/codex-cli-backend.ts
+++ b/apps/desktop/src/main/agent/backends/codex-cli-backend.ts
@@ -28,10 +28,6 @@ export class CodexCliBackend implements AgentBackend {
     return this.run(input, 'summary')
   }
 
-  cancel(conversationId: string): void {
-    void conversationId
-  }
-
   async getStatus() {
     const status = await detectCodexBinary()
     return {

--- a/apps/desktop/src/main/agent/backends/local-openai-compatible-backend.ts
+++ b/apps/desktop/src/main/agent/backends/local-openai-compatible-backend.ts
@@ -74,10 +74,6 @@ export class LocalOpenAICompatibleBackend implements AgentBackend {
     return this.run(input, false)
   }
 
-  cancel(conversationId: string): void {
-    void conversationId
-  }
-
   async getStatus(): Promise<AgentBackendStatus> {
     const settings = await this.deps.getSettings()
     const apiKey = await this.deps.getApiKey()

--- a/apps/desktop/src/main/agent/backends/types.ts
+++ b/apps/desktop/src/main/agent/backends/types.ts
@@ -33,7 +33,6 @@ export interface AgentBackend {
   runTurn(input: AgentBackendRunInput): Promise<BackendRunHandle>
   generateTitle(input: AgentBackendRunInput): Promise<BackendRunHandle>
   summarize(input: AgentBackendRunInput): Promise<BackendRunHandle>
-  cancel(conversationId: string): void
   getStatus(): Promise<AgentBackendStatus>
   probeCapabilities?(): Promise<AgentLocalProviderProbeResult>
 }

--- a/apps/desktop/src/main/agent/runtime/__tests__/runtime-cancel.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/runtime-cancel.test.ts
@@ -1,13 +1,32 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  setWriteGate: vi.fn()
+  setWriteGate: vi.fn(),
+  createOpenAI: vi.fn(() => ({
+    chat: vi.fn((model: string) => ({ provider: 'openai-compatible', model }))
+  })),
+  streamText: vi.fn()
 }))
 
 vi.mock('../../mcp/lifecycle', () => ({
   setWriteGate: mocks.setWriteGate
 }))
 
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: mocks.createOpenAI
+}))
+
+vi.mock('ollama-ai-provider-v2', () => ({
+  createOllama: vi.fn(() => vi.fn((model: string) => ({ provider: 'ollama', model })))
+}))
+
+vi.mock('ai', () => ({
+  streamText: mocks.streamText,
+  stepCountIs: vi.fn((count: number) => ({ type: 'step-count', count })),
+  tool: (definition: unknown) => definition
+}))
+
+import { LocalOpenAICompatibleBackend } from '../../backends/local-openai-compatible-backend'
 import type { ConversationStore } from '../../storage/conversation-store'
 import type { MessageStore } from '../../storage/message-store'
 import { AgentRuntime } from '../runtime'
@@ -56,6 +75,49 @@ describe('AgentRuntime subprocess cancellation', () => {
     agentRuntime.cancelTurn('conversation-1')
 
     expect(kill).not.toHaveBeenCalled()
+  })
+
+  // The runtime has no separate AbortController registry — killing the tracked run
+  // handle is the whole of cancellation. This is the case that registry was meant to
+  // cover: an in-process backend with no OS child, whose only handle on the work is an
+  // AbortController. It is tracked and cancelled through exactly the same path as a CLI
+  // child, so cancellation reaches it too.
+  it('cancels an in-process backend that owns an AbortController instead of an OS child', async () => {
+    let signal: AbortSignal | undefined
+    mocks.streamText.mockImplementationOnce((options: { abortSignal?: AbortSignal }) => {
+      signal = options.abortSignal
+      return { fullStream: (async function* () {})() }
+    })
+
+    const backend = new LocalOpenAICompatibleBackend({
+      getSettings: async () => ({
+        preset: 'lmstudio',
+        baseUrl: 'http://localhost:1234/v1',
+        model: 'llama3.2',
+        apiKeyConfigured: false,
+        allowNonLoopback: false
+      }),
+      getApiKey: async () => null,
+      toolBridge: { execute: vi.fn() } as never
+    })
+    const handle = await backend.runTurn({
+      conversationId: 'conversation-1',
+      windowId: 'window-1',
+      prompt: 'User: hello',
+      options: { backend: 'local_openai_compatible', model: 'llama3.2', toolsEnabled: false }
+    })
+
+    const agentRuntime = runtime()
+    // Mirrors trackRunHandle in agent-handlers.ts, which every backend run passes through.
+    agentRuntime.trackSubprocess('conversation-1', handle)
+
+    expect(signal?.aborted).toBe(false)
+
+    agentRuntime.cancelTurn('conversation-2')
+    expect(signal?.aborted).toBe(false)
+
+    agentRuntime.cancelTurn('conversation-1')
+    expect(signal?.aborted).toBe(true)
   })
 
   it('kills subprocesses, waits for active turns, and clears the MCP write gate on shutdown', async () => {

--- a/apps/desktop/src/main/agent/runtime/runtime.ts
+++ b/apps/desktop/src/main/agent/runtime/runtime.ts
@@ -53,7 +53,6 @@ function trackApprovalDecided(decision: string, result: 'success' | 'failed'): v
 }
 
 export class AgentRuntime {
-  private inFlight = new Map<string, AbortController>()
   private pending = new Map<string, PendingApproval>()
   private subprocesses = new Map<number, TrackedSubprocess>()
   private turnLocks = new Set<string>()
@@ -147,8 +146,12 @@ export class AgentRuntime {
     }
   }
 
+  // Killing the tracked run handles is the whole of cancellation. Every backend
+  // reaches this map: BackendRunHandle requires `kill()`, and turn.ts routes each
+  // handle through trackRunHandle -> trackSubprocess. For the CLI backends that
+  // kill is a signal to a real child; for the in-process local backend it is the
+  // AbortController driving streamText, registered under a negative pseudo-pid.
   cancelTurn(conversationId: string): void {
-    this.inFlight.get(conversationId)?.abort()
     this.denyPendingApprovals(conversationId)
     for (const sub of this.subprocesses.values()) {
       if (sub.conversationId !== conversationId) continue
@@ -235,10 +238,6 @@ export class AgentRuntime {
     }
     await Promise.all(tracked.map((sub) => this.reapSubprocess(sub)))
 
-    for (const controller of this.inFlight.values()) {
-      controller.abort()
-    }
-    this.inFlight.clear()
     this.turnLocks.clear()
 
     const turns = [...this.activeTurns.values()].flatMap((entries) => [...entries])


### PR DESCRIPTION
Closes #1108. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`AgentRuntime` carried a second, entirely fictional cancellation mechanism next to the real one.

`apps/desktop/src/main/agent/runtime/runtime.ts:56` declared `private inFlight = new Map<string, AbortController>()`. The map was read in `cancelTurn` and drained in `killAll` — and never written. There is no `inFlight.set(...)` anywhere in the repo:

```ts
cancelTurn(conversationId: string): void {
  this.inFlight.get(conversationId)?.abort()   // always undefined -> no-op
  this.denyPendingApprovals(conversationId)
  for (const sub of this.subprocesses.values()) { ... sub.kill() ... }  // this is what actually cancels
}
```

It is a leftover from `4e7676b7f` (the first turn orchestrator). Real cancellation arrived later in `e9b444621` via the `subprocesses` map, and the placeholder was never removed.

The same commit left `cancel(conversationId): void { void conversationId }` on the `AgentBackend` interface (`backends/types.ts:36`) and on all three implementations (`claude-cli-backend.ts:33`, `codex-cli-backend.ts:31`, `local-openai-compatible-backend.ts:77`). Nothing outside tests has ever called it — and the three test call sites asserted nothing about it.

### The user-facing cancel path is fine — I checked before deleting

The issue could have been a real bug rather than cleanup, so the first question was whether any cancel affordance depends on the dead field. It does not:

- **Stop button** — `renderer/src/agent-chat/composer.tsx:807` → `cancelTurn()` at `:530`
- **Escape key** — `renderer/src/agent-chat/conversation-view.tsx:61` → `:50`
- both → `agent-context.tsx:307` → IPC `agent:cancelTurn` (`packages/contracts/src/ipc-agent.ts:18`) → `main/ipc/agent-handlers.ts:250` → `runtime.cancelTurn()`

and `cancelTurn` reaches every backend through `subprocesses`, because every run handle is registered there: `runtime/turn.ts:173/444/545` route each handle (turn, title, summary) through `deps.trackRunHandle`, which `agent-handlers.ts:197` wires to `runtime.trackSubprocess`.

The issue's stated worry — *"a future backend without a subprocess handle would be silently un-cancellable"* — cannot happen: `BackendRunHandle` (`backends/types.ts:13`) requires `pid: number` and `kill: () => void`, so a backend that offers no way to stop it does not typecheck. The local AI-SDK backend already proves the no-OS-process case works: it returns a negative pseudo-pid and `kill: () => controller.abort()`.

## What changed

- Deleted `inFlight`, its `?.abort()` in `cancelTurn`, and its abort-loop + `clear()` in `killAll`.
- Deleted `AgentBackend.cancel()` from the interface and from all three backends, plus the three incidental `backend.cancel('conversation-1')` lines in backend tests (they asserted nothing).
- Added a comment on `cancelTurn` recording that killing the tracked run handle *is* the whole of cancellation, so the next reader does not re-add a parallel registry.
- Added a regression test locking the case the dead field pretended to cover: an in-process backend whose only handle on the work is an `AbortController`.

**Deliberately not done — why "wire it up" was rejected.** The alternative was to register a per-turn `AbortController` and abort it in `cancelTurn`. There is nothing for such a controller to abort that `kill()` does not already abort: for the CLI backends cancellation *is* the signal to the child, and the local backend already owns the only `AbortController` in play and exposes it as `kill`. Wiring it would add bookkeeping for zero behavior change and leave two registries that must agree. Deleting is the option that removes a method which silently pretends to work.

**Also deliberately not done:** there is a genuine (pre-existing, separate) gap — pressing stop *before* `backend.runTurn()` resolves finds nothing tracked yet, so the turn proceeds. For the local backend that window can span a capability probe. Closing it needs an `AbortSignal` threaded into `runTurn` across all three backends, which is a behavior change well outside this cleanup. Reported separately rather than smuggled in here.

## How it was proven

New test: `runtime-cancel.test.ts` → *"cancels an in-process backend that owns an AbortController instead of an OS child"*. It builds the real `LocalOpenAICompatibleBackend`, takes its real run handle, registers it exactly the way `trackRunHandle` does, and asserts the `AbortSignal` handed to `streamText` flips to aborted only for the cancelled conversation.

A deletion has no honest "fails before / passes after", so the evidence is the pair of runs that actually matter — both against `origin/main`'s `runtime.ts` with the new test file in place:

| run | `runtime.ts` | result |
|---|---|---|
| **A** | `origin/main` — `inFlight` present, kill loop present | **4 passed** |
| **B** | `origin/main` — `inFlight` present, kill loop neutralized | **2 failed, 2 passed** |
| **C** | this branch — `inFlight` deleted, kill loop present | **4 passed** |

A vs C: removing `inFlight` changes nothing — it was contributing nothing.
B: with the kill loop gone and `this.inFlight.get(conversationId)?.abort()` still there, the test fails on `expect(signal?.aborted).toBe(true)` → `Expected true, Received false`. That is the direct proof the field was dead, and it also shows the new test has teeth rather than passing vacuously.

## Verification

```
pnpm --filter @memry/desktop typecheck:node                      # clean, no output
eslint <5 changed source files>                                  # exit 0
vitest --project main apps/desktop/src/main/agent \
                      apps/desktop/src/main/ipc/agent-handlers.test.ts
                                                                 # 60 files, 446 tests passed
vitest --project main .../runtime-cancel.test.ts                 # 4 passed
git diff --check                                                 # clean
```

No renderer files touched, so `typecheck:web` is not implicated.

`pnpm docs:impact --base origin/main --strict` reports `missing-docs` on the path heuristic alone. Nothing user-facing changed, and `apps/docs/src/user-guide/ai/agent-mcp.md:150` already documents the behavior this PR locks with a test ("Stop requests are scoped to the active conversation across Claude, Codex, and local providers"), so it is accurate as written. Noting for the record that `MEMRY_DOCS_IMPACT_SKIP` is not implemented in `scripts/docs-impact.mjs`, so the flag cannot be used to record that judgement in-band.

## Backward compatibility

None at risk: `AgentRuntime.inFlight` is a private field and `AgentBackend` is an internal main-process interface. No IPC contract, DB schema, sync payload, vault format or settings shape is touched — the `agent:cancelTurn` channel and its payload are unchanged.
