### PR TITLE
fix(sync): resolve certificate pins once, for the connecting host

### DIFF
--- a/apps/desktop/src/main/sync/certificate-pinning.test.ts
+++ b/apps/desktop/src/main/sync/certificate-pinning.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type tls from 'node:tls'
-import { PINNED_CERTIFICATE_HASHES_BY_HOST } from './certificate-pins'
+import { DEFAULT_SYNC_CERT_HOSTNAME, PINNED_CERTIFICATE_HASHES_BY_HOST } from './certificate-pins'
 
 const mockApp = vi.hoisted(() => ({ isPackaged: false }))
 
@@ -232,6 +232,23 @@ describe('certificate-pinning', () => {
   })
 
   describe('createPinnedAgent', () => {
+    const STAGING_HOST = 'sync-staging.memrynote.com'
+
+    /** A cert whose SAN covers `hostname`, so the stock TLS identity check
+     *  passes and the pin check is what decides the outcome. */
+    function certFor(hostname: string): tls.PeerCertificate {
+      return {
+        ...makeMockCertWithRaw(getTestCertDer()),
+        subjectaltname: `DNS:${hostname}`
+      } as tls.PeerCertificate
+    }
+
+    function checkOf(agent: ReturnType<typeof createPinnedAgent>) {
+      const check = agent.options.checkServerIdentity
+      expect(check).toBeDefined()
+      return check!
+    }
+
     it('#given dev mode (app.isPackaged=false) #then returns agent without pin checking', () => {
       // #when
       const agent = createPinnedAgent()
@@ -239,6 +256,7 @@ describe('certificate-pinning', () => {
       // #then
       expect(agent).toBeDefined()
       expect(agent.options.rejectUnauthorized).not.toBe(false)
+      expect(agent.options.checkServerIdentity).toBeUndefined()
     })
 
     it('#given packaged mode #then returns agent with checkServerIdentity', () => {
@@ -253,17 +271,107 @@ describe('certificate-pinning', () => {
       expect(agent.options.checkServerIdentity).toBeDefined()
     })
 
-    it('#given packaged mode with placeholder hashes #then returns standard TLS agent', () => {
+    it('#given the connecting host has real pins and the cert does not match #then rejects', () => {
+      // #given a packaged build dialing a host with real (non-placeholder) pins
+      vi.stubEnv('SYNC_SERVER_URL', `https://${STAGING_HOST}`)
+      mockApp.isPackaged = true
+
+      // #when a certificate arrives whose SPKI hash is not in the table
+      const result = checkOf(createPinnedAgent())(STAGING_HOST, certFor(STAGING_HOST))
+
+      // #then it is rejected — pinning still enforces
+      expect(result).toBeInstanceOf(CertificatePinningError)
+    })
+
+    it('#given the connecting host has real pins and the cert matches #then accepts', () => {
+      // #given
+      vi.stubEnv('SYNC_SERVER_URL', `https://${STAGING_HOST}`)
+      mockApp.isPackaged = true
+      const originalPins = PINNED_CERTIFICATE_HASHES_BY_HOST[STAGING_HOST]
+
+      try {
+        PINNED_CERTIFICATE_HASHES_BY_HOST[STAGING_HOST] = [computeSpkiHashFromPem(TEST_CERT_PEM)]
+
+        // #when / #then
+        expect(checkOf(createPinnedAgent())(STAGING_HOST, certFor(STAGING_HOST))).toBeUndefined()
+      } finally {
+        PINNED_CERTIFICATE_HASHES_BY_HOST[STAGING_HOST] = originalPins
+      }
+    })
+
+    it('#given the configured host is placeholder-pinned but the connecting host has real pins #then the connecting host still enforces', () => {
+      // #given SYNC_SERVER_URL naming the shipping host, whose entry is still
+      // placeholders — the branch that used to decide "do not pin at all"
+      vi.stubEnv('SYNC_SERVER_URL', `https://${DEFAULT_SYNC_CERT_HOSTNAME}`)
+      mockApp.isPackaged = true
+
+      // #when the handshake is against a *different* host that does have pins
+      const result = checkOf(createPinnedAgent())(STAGING_HOST, certFor(STAGING_HOST))
+
+      // #then the connecting host's pins decide, so a non-matching cert is
+      // rejected instead of silently accepted under the configured host's
+      // placeholder verdict
+      expect(result).toBeInstanceOf(CertificatePinningError)
+    })
+
+    it('#given the connecting host still has placeholder pins #then standard TLS applies', () => {
+      // #given the shipping configuration: pinning never activated for this host
+      vi.stubEnv('SYNC_SERVER_URL', `https://${DEFAULT_SYNC_CERT_HOSTNAME}`)
+      mockApp.isPackaged = true
+
+      // #when / #then — unchanged behaviour for the host we actually ship
+      expect(
+        checkOf(createPinnedAgent())(
+          DEFAULT_SYNC_CERT_HOSTNAME,
+          certFor(DEFAULT_SYNC_CERT_HOSTNAME)
+        )
+      ).toBeUndefined()
+    })
+
+    it('#given explicit placeholder pins #then standard TLS applies', () => {
       // #given
       mockApp.isPackaged = true
 
-      // #when
-      const agent = createPinnedAgent(['sha256/PLACEHOLDER_PRIMARY_CERT_HASH_BASE64'])
+      // #when / #then
+      expect(
+        checkOf(createPinnedAgent(['sha256/PLACEHOLDER_PRIMARY_CERT_HASH_BASE64']))(
+          STAGING_HOST,
+          certFor(STAGING_HOST)
+        )
+      ).toBeUndefined()
+    })
 
-      // #then
-      expect(agent).toBeDefined()
-      expect(agent.options.checkServerIdentity).toBeUndefined()
-      expect(agent.options.rejectUnauthorized).not.toBe(false)
+    it('#given the connecting host has no pin entry #then falls back to standard TLS and warns once', () => {
+      // #given a pinning agent built for a host that does have pins...
+      vi.stubEnv('SYNC_SERVER_URL', `https://${STAGING_HOST}`)
+      mockApp.isPackaged = true
+      const unpinnedHost = 'sync-unlisted.memrynote.test'
+      mockLog.warn.mockClear()
+
+      // #when the handshake is against a host with no entry at all
+      const check = checkOf(createPinnedAgent())
+      const first = check(unpinnedHost, certFor(unpinnedHost))
+      const second = check(unpinnedHost, certFor(unpinnedHost))
+
+      // #then it is not rejected — an empty pin list has no reference hash to
+      // compare against, so rejecting would kill the legitimate cert too
+      expect(first).toBeUndefined()
+      expect(second).toBeUndefined()
+      expect(mockLog.warn).toHaveBeenCalledTimes(1)
+      expect(mockLog.warn).toHaveBeenCalledWith(expect.any(String), { hostname: unpinnedHost })
+    })
+
+    it('#given a cert whose SAN does not cover the connecting host #then the stock TLS identity check still rejects', () => {
+      // #given
+      vi.stubEnv('SYNC_SERVER_URL', `https://${STAGING_HOST}`)
+      mockApp.isPackaged = true
+
+      // #when the cert is for a different host entirely
+      const result = checkOf(createPinnedAgent())(STAGING_HOST, certFor('evil.example.com'))
+
+      // #then hostname verification rejects before the pin check is reached
+      expect(result).toBeInstanceOf(Error)
+      expect(result).not.toBeInstanceOf(CertificatePinningError)
     })
   })
 

--- a/apps/desktop/src/main/sync/certificate-pinning.ts
+++ b/apps/desktop/src/main/sync/certificate-pinning.ts
@@ -74,16 +74,53 @@ export function verifyCertificatePin(
   return pins.some((pin) => pin === spkiHash)
 }
 
+/**
+ * A host with no entry in the pin table and a host whose entry is still
+ * placeholders are the same state — pinning was never activated for it — and
+ * get the same outcome: standard TLS. `rejectUnauthorized: true` still enforces
+ * the full CA chain and `tls.checkServerIdentity` still enforces the hostname,
+ * so nothing is skipped; only the extra SPKI pin is absent.
+ *
+ * The two used to differ, because `hasPlaceholderHashes([])` is false: a host
+ * with no entry built a pinning agent whose pin list could only ever be empty,
+ * so it rejected *every* certificate for that host, the legitimate one
+ * included. With no reference hash there is nothing to compare against, so that
+ * branch could not tell an attacker's certificate from the real server's — it
+ * was an unconditional outage, not a pin check. The session-level verify proc
+ * (`configureCertificatePinning`, src/main/index.ts) has always passed unpinned
+ * hosts straight through to Chromium's own verification; this matches it.
+ *
+ * Unlike placeholders — the deliberate shipping state, logged once at debug per
+ * #846 — a host with no entry at all is a configuration mistake, so it logs at
+ * warn. One slot rather than a set: this agent dials the single configured sync
+ * host, so the target hostname changing is itself worth a line.
+ */
+let warnedUnpinnedHostname: string | null = null
+
+function warnHostnameUnpinnedOnce(hostname: string): void {
+  if (warnedUnpinnedHostname === hostname) return
+  warnedUnpinnedHostname = hostname
+  log.warn('No certificate pins configured for host — using standard TLS', { hostname })
+}
+
+/**
+ * Pins are resolved once, at handshake time, for the hostname TLS is actually
+ * dialing.
+ *
+ * The decision used to be split across two independent lookups: whether to pin
+ * at all came from the *configured* host (`SYNC_SERVER_URL`, falling back to
+ * `sync.memrynote.com`), while `checkServerIdentity` verified against the
+ * *connecting* hostname's pins. Nothing enforced that those were the same host
+ * — the WebSocket manager's `serverUrl` is an injected dep, not a call into
+ * this module — and the two fallbacks already disagreed (`resolveSyncServerUrl`
+ * falls back to localhost or throws). Any divergence failed silently in one
+ * direction: the branch sees a placeholder-pinned host, hands back a plain TLS
+ * agent, and pinning is skipped for a host that has real pins. One lookup, one
+ * hostname, nothing left to diverge.
+ */
 export function createPinnedAgent(pins?: string[]): https.Agent {
   if (isPinningDisabled()) {
     log.debug('Certificate pinning disabled (dev/test mode)')
-    return new https.Agent({ rejectUnauthorized: true })
-  }
-
-  const configuredPins = pins ? [...pins] : [...getConfiguredPinnedCertificateHashes()]
-
-  if (hasPlaceholderHashes(configuredPins)) {
-    warnPinningUnconfiguredOnce()
     return new https.Agent({ rejectUnauthorized: true })
   }
 
@@ -94,6 +131,17 @@ export function createPinnedAgent(pins?: string[]): https.Agent {
       if (tlsCheckResult) return tlsCheckResult
 
       const effectivePins = pins ? [...pins] : [...getPinnedCertificateHashesForHostname(hostname)]
+
+      if (hasPlaceholderHashes(effectivePins)) {
+        warnPinningUnconfiguredOnce()
+        return undefined
+      }
+
+      if (effectivePins.length === 0) {
+        warnHostnameUnpinnedOnce(hostname)
+        return undefined
+      }
+
       const spkiHash = computeSpkiHash(cert)
       if (!effectivePins.some((pin) => pin === spkiHash)) {
         const err = new CertificatePinningError(
@@ -125,17 +173,18 @@ export function createPinnedAgent(pins?: string[]): https.Agent {
  * which resolves the connecting hostname's pins from `certificate-pins.ts` on
  * every TLS handshake, so a reused agent verifies exactly what a fresh one
  * would and an updated pin table takes effect on the very next handshake — no
- * restart, no cache flush. Only the two branches `createPinnedAgent` decides at
- * construction time are frozen into the instance: whether pinning is disabled
- * (dev/test) and whether the configured host still carries placeholder pins.
- * Those two form the cache key below, so if either flips, the cached agent is
- * destroyed and rebuilt rather than silently reused under the old decision.
+ * restart, no cache flush. `isPinningDisabled()` is now the only decision
+ * `createPinnedAgent` freezes into the instance, so it is the whole cache key:
+ * if it flips, the cached agent is destroyed and rebuilt rather than silently
+ * reused under the old decision. The configured host's pins used to be part of
+ * this key because they gated a construction-time branch; that branch moved
+ * into `checkServerIdentity` (see above), so keying on them would now only
+ * rebuild an agent that already reads the live table.
  */
 let sharedPinnedAgent: { key: string; agent: https.Agent } | null = null
 
 function pinnedAgentCacheKey(): string {
-  const disabled = isPinningDisabled() ? 'disabled' : 'enabled'
-  return `${disabled}|${getConfiguredPinnedCertificateHashes().join(',')}`
+  return isPinningDisabled() ? 'disabled' : 'enabled'
 }
 
 export function getSharedPinnedAgent(): https.Agent {

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -163,11 +163,20 @@ allowed through the Electron verifier instead of being compared against an unrel
 pins. Development builds keep pinning disabled so local sync servers and test certificates remain
 usable.
 
+Both pinned surfaces — the Electron session verifier and the `https.Agent` the sync WebSocket
+connects through — resolve pins from the hostname the connection is actually dialing, at handshake
+time. Neither consults the configured `SYNC_SERVER_URL` host to decide whether to pin, so the host
+being verified is always the host whose pins were looked up.
+
 ### Pin activation state
 
 A host entry in `certificate-pins.ts` may hold placeholder hashes, which means pinning has not been
 activated for that host yet. This is a supported state, not a broken one: the runtime falls back to
-standard TLS verification for placeholder pins rather than failing the connection.
+standard TLS verification for placeholder pins rather than failing the connection. A host with no
+entry at all is treated the same way at runtime — pinning was never activated for it, so standard
+TLS applies. Standard TLS here still means full CA-chain validation plus hostname verification; only
+the extra SPKI pin comparison is absent. A missing entry is caught at build time instead, where
+`pnpm cert:check` fails.
 
 `pnpm cert:check` (also run by `prebuild` and `build:release`) audits the configured host and
 reflects the same rule:


### PR DESCRIPTION
Closes #1279. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/sync/certificate-pinning.ts:83-96` made one decision out of two independent hostname lookups:

```ts
const configuredPins = pins ? [...pins] : [...getConfiguredPinnedCertificateHashes()]

if (hasPlaceholderHashes(configuredPins)) {      // ← the CONFIGURED host
  warnPinningUnconfiguredOnce()
  return new https.Agent({ rejectUnauthorized: true })
}

return new https.Agent({
  rejectUnauthorized: true,
  checkServerIdentity: (hostname, cert) => {
    ...
    const effectivePins = pins ? [...pins] : [...getPinnedCertificateHashesForHostname(hostname)]
    //                                                                              ↑ the CONNECTING host
```

`getConfiguredPinnedCertificateHashes()` resolves through `getConfiguredSyncCertHostname(process.env.SYNC_SERVER_URL)`, which falls back to `sync.memrynote.com`. `checkServerIdentity` gets the hostname TLS is actually dialing.

**This is latent, not a live bypass.** Verified on this branch: the one production caller is `websocket.ts:123` (`getSharedPinnedAgent()`), whose `wsUrl` comes from `deps.serverUrl`, which `sync/runtime.ts:714` sets from `resolveSyncServerUrl()` — the same `SYNC_SERVER_URL`. Both lookups land on the same host today.

What is real is that nothing *enforces* that. `serverUrl` is an injected dep on the WebSocket manager, not a call into the cert module, and the two fallbacks already disagree: `getConfiguredSyncCertHostname` falls back to `sync.memrynote.com`, `resolveSyncServerUrl` to `http://localhost:8787` or a throw. On divergence the failure is silent in the dangerous direction — the branch sees the placeholder-pinned default host, hands back a plain TLS agent, and pinning is skipped for a connecting host that has real pins.

### Second finding: the empty-pin-list branch — a real hole, not correct-as-is

The issue also flags that `hasPlaceholderHashes([])` is `false`, so a host with **no** entry in `PINNED_CERTIFICATE_HASHES_BY_HOST` passed the branch and built a pinning agent whose `effectivePins` could only ever be `[]`. Confirmed. The verdict is **not** "fail-closed, therefore fine":

- With an empty pin list there is no reference hash, so the check cannot distinguish an attacker's certificate from the real server's — it rejects **both**. That is an unconditional outage, not a security control. It surfaces as `Certificate pin mismatch for <host>` with `pinnedCount: 0`.
- The sibling surface already does the opposite, deliberately: the Electron session verify proc (`configureCertificatePinning`, `src/main/index.ts:565-569`) does `if (pinsForHostname.length === 0) { callback(0); return }` — unpinned hosts pass through to Chromium's own verification.
- `[]` already means "pinning not activated" inside this very module pair: `getPinnedCertificateHashes()` maps packaged-with-placeholders to `[]`, and `index.ts:559` reads `[]` as "do not install the verify proc at all".
- Nobody wrote "empty means reject". It was the fall-through of a predicate that only asks about placeholders.

So the two branches now agree: **placeholder pins and no pins are the same state — pinning was never activated for this host — and both fall back to standard TLS.** Standard TLS here is not "skipped": `rejectUnauthorized: true` still enforces the full CA chain and `tls.checkServerIdentity` still enforces the hostname. Only the extra SPKI comparison is absent.

## What changed

`createPinnedAgent` now performs **one** pin lookup, inside `checkServerIdentity`, for the hostname TLS is dialing. The construction-time placeholder branch is gone, so there is no second host to diverge from. In packaged mode the agent always carries `checkServerIdentity`; the placeholder case returns `undefined` after the stock TLS identity check, which is exactly what the plain agent did.

A host with no entry logs once at `warn` (`No certificate pins configured for host`) instead of failing every handshake. Placeholders keep their existing once-per-process `debug` line — that is the shipping state and #846 established it must not be in the warn/error stream. No shipped configuration reaches the new warn path.

`pinnedAgentCacheKey()` reduces to `isPinningDisabled()`, now the only decision frozen at construction. The configured host's pins were in the key because they gated the branch that just moved; keying on them would only rebuild an agent that already reads the live table every handshake. The existing test that flips `isPackaged` and asserts the stale agent is destroyed still passes, as does the one proving an updated pin table applies to the already-shared agent without a rebuild.

Deliberately **not** done:

- **Enforcement for `sync.memrynote.com` is unchanged.** Its entry is still placeholders, so it still gets standard TLS. This PR does not activate pinning for any host and does not touch `certificate-pins.ts`.
- **Placeholder semantics unchanged.** Any placeholder in a host's list still means "not activated" for the whole list. Filtering placeholders and pinning the remainder would be strictly stronger but would turn a half-updated entry into hard failures during cert rotation — out of scope.
- **`createPinnedAgent(pins)` keeps its signature.** Passing an explicit list still overrides the table for both the decision and the verification, so it remains a single source.
- **The session verify proc in `index.ts` is untouched** — it was already correct; this change makes the agent match it.

## How it was proven

`apps/desktop/src/main/sync/certificate-pinning.test.ts`, source file reverted to `origin/main` with the new tests in place:

- **Before:** `Tests 4 failed | 27 passed (31)`
- **After:** `Tests 31 passed (31)`

The four that fail without the fix:

| Test | Pre-fix behaviour |
| --- | --- |
| configured host is placeholder-pinned but the connecting host has real pins → connecting host still enforces | plain agent, no `checkServerIdentity` — **pinning skipped for a host with real pins** |
| connecting host still has placeholder pins → standard TLS applies | plain agent (same effect, different route) |
| explicit placeholder pins → standard TLS applies | plain agent |
| connecting host has no pin entry → standard TLS + warns once | returned `CertificatePinningError` — every cert rejected |

Rejection is proven, not just acceptance:

- real pins + non-matching cert → `CertificatePinningError` (the core enforcement path)
- real pins + matching cert → accepted
- placeholder-configured host + real-pinned connecting host + non-matching cert → `CertificatePinningError` (the regression this PR fixes)
- cert whose SAN does not cover the connecting host → rejected by `tls.checkServerIdentity` before the pin check, and *not* a `CertificatePinningError`, proving the stock identity check is still in the path

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  apps/desktop/src/main/sync/certificate-pinning.test.ts apps/desktop/src/main/sync/certificate-pins.test.ts
  → Test Files 2 passed (2) | Tests 42 passed (42)

./node_modules/.bin/vitest run ... --project main \
  apps/desktop/src/main/sync/websocket.test.ts apps/desktop/src/main/sync/emitter-budget.test.ts
  → Test Files 2 passed (2) | Tests 42 passed (42)

./node_modules/.bin/vitest run ... --project main apps/desktop/src/main/index.phase2.test.ts
  → Test Files 1 passed (1) | Tests 62 passed (62)

pnpm --filter @memry/desktop typecheck:node   → clean, no output
./node_modules/.bin/eslint apps/desktop/src/main/sync/certificate-pinning.ts → 0 errors
git diff --check                              → clean
pnpm docs:impact --base origin/main --strict  → covered
pnpm docs:build                               → build complete
```

## Backward compatibility

No schema, contract, IPC, settings or wire-format change. The only runtime behaviour that differs for an existing install is that a sync host with no pin entry now connects over standard TLS instead of failing every TLS handshake — and no shipped build can be in that state, because `pnpm cert:check` (run by `prebuild` and `build:release`) fails on a host with no entry. The shipping host `sync.memrynote.com` and the staging host behave exactly as before.
