### PR TITLE
fix(inbox): translate the snooze-due notification and toast

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx
@@ -322,12 +322,14 @@ describe('more major hooks coverage', () => {
     ;(Notification as unknown as { permission: string }).permission = 'granted'
     callback({ items: [{ id: 'item-a', title: 'Read paper' }] })
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['inbox', 'lists'] })
+    // `t` is stubbed to echo its key here, so these assert the wiring; the
+    // rendered copy is covered in use-inbox-notifications.test.tsx.
     expect(Notification).toHaveBeenCalledWith('Read paper', {
-      body: 'Your snoozed item is ready for review',
+      body: 'snoozeDue.notificationBody',
       icon: '/icon.png',
       tag: 'inbox-snooze-due:item-a'
     })
-    expect(mocks.toastInfo).toHaveBeenCalledWith('"Read paper" is back from snooze')
+    expect(mocks.toastInfo).toHaveBeenCalledWith('snoozeDue.toast')
 
     callback({
       items: [
@@ -335,12 +337,12 @@ describe('more major hooks coverage', () => {
         { id: 'item-c', title: 'Two' }
       ]
     })
-    expect(Notification).toHaveBeenCalledWith('2 snoozed items', {
-      body: 'Your snoozed items are ready',
+    expect(Notification).toHaveBeenCalledWith('snoozeDue.notificationTitle', {
+      body: 'snoozeDue.notificationBody',
       icon: '/icon.png',
       tag: 'inbox-snooze-due:item-b,item-c'
     })
-    expect(mocks.toastInfo).toHaveBeenCalledWith('2 snoozed items are back')
+    expect(mocks.toastInfo).toHaveBeenCalledWith('snoozeDue.toast')
 
     callback({ items: [] })
     expect(invalidate).toHaveBeenCalledTimes(2)
@@ -373,7 +375,7 @@ describe('more major hooks coverage', () => {
     // A genuinely new resurface sharing the same title is still its own banner.
     first({ items: [{ id: 'item-3', title: 'Read paper' }] })
     expect(Notification).toHaveBeenLastCalledWith('Read paper', {
-      body: 'Your snoozed item is ready for review',
+      body: 'snoozeDue.notificationBody',
       icon: '/icon.png',
       tag: 'inbox-snooze-due:item-3'
     })

--- a/apps/desktop/src/renderer/src/hooks/use-inbox-notifications.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-inbox-notifications.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * useInboxNotifications tests
+ *
+ * These drive the REAL i18n instance (no `t: (key) => key` stub), because the
+ * bug being guarded here is precisely that the copy never reached the
+ * catalogue: a stubbed `t` would happily "pass" against hard-coded English.
+ * The German case is the one that actually discriminates — before the fix the
+ * hook emitted English no matter what locale was mounted.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nextProvider } from 'react-i18next'
+import type { i18n as I18nInstance } from 'i18next'
+import { createRendererI18n } from '@memry/i18n/renderer'
+import type { InboxItemListItem, InboxSnoozeDueEvent } from '@memry/rpc/inbox'
+import { useInboxNotifications } from './use-inbox-notifications'
+
+const { toastInfo } = vi.hoisted(() => ({ toastInfo: vi.fn() }))
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    info: toastInfo,
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    message: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+    promise: vi.fn(),
+    custom: vi.fn()
+  }),
+  Toaster: () => null
+}))
+
+// German copy for the same three keys. It only exists in this test: the repo
+// convention is to land new keys in `en` and bulk-translate later, so shipping
+// a hand-rolled `de` string would jump that queue.
+const GERMAN_SNOOZE_DUE = {
+  snoozeDue: {
+    notificationTitle:
+      '{count, plural, one {# zurückgestellter Eintrag} other {# zurückgestellte Einträge}}',
+    notificationBody:
+      '{count, plural, one {Dein zurückgestellter Eintrag ist bereit} other {Deine zurückgestellten Einträge sind bereit}}',
+    toast:
+      '{count, plural, =1 {„{itemTitle}“ ist zurück aus dem Schlummer} other {# zurückgestellte Einträge sind zurück}}'
+  }
+}
+
+let i18nEn: I18nInstance
+let i18nDe: I18nInstance
+
+type RaisedNotification = { title: string; options: NotificationOptions }
+
+const raised: RaisedNotification[] = []
+const requestPermission = vi.fn(() => Promise.resolve<NotificationPermission>('granted'))
+
+class NotificationStub {
+  static permission: NotificationPermission = 'granted'
+  static requestPermission = requestPermission
+
+  constructor(title: string, options: NotificationOptions = {}) {
+    raised.push({ title, options })
+  }
+}
+
+let snoozeDue: ((event: InboxSnoozeDueEvent) => void) | null = null
+const unsubscribe = vi.fn()
+
+function item(id: string, title: string): InboxItemListItem {
+  return { id, title } as InboxItemListItem
+}
+
+function mountWith(i18n: I18nInstance): void {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+  })
+  renderHook(() => useInboxNotifications(), {
+    wrapper: ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </I18nextProvider>
+    )
+  })
+}
+
+beforeAll(async () => {
+  i18nEn = await createRendererI18n({ locale: 'en' })
+  i18nDe = await createRendererI18n({ locale: 'de' })
+  i18nDe.addResourceBundle('de', 'inbox', GERMAN_SNOOZE_DUE, true, true)
+})
+
+beforeEach(() => {
+  raised.length = 0
+  snoozeDue = null
+  toastInfo.mockClear()
+  requestPermission.mockClear()
+  unsubscribe.mockClear()
+  NotificationStub.permission = 'granted'
+  ;(window as unknown as { Notification: unknown }).Notification = NotificationStub
+  window.api.onInboxSnoozeDue = vi.fn((callback: (event: InboxSnoozeDueEvent) => void) => {
+    snoozeDue = callback
+    return unsubscribe
+  }) as never
+})
+
+describe('useInboxNotifications', () => {
+  it('names the single resurfaced item and pluralizes its body from the catalogue', () => {
+    mountWith(i18nEn)
+    snoozeDue?.({ items: [item('a', 'Quarterly review')] })
+
+    expect(raised).toHaveLength(1)
+    expect(raised[0].title).toBe('Quarterly review')
+    expect(raised[0].options.body).toBe('Your snoozed item is ready for review')
+    expect(toastInfo).toHaveBeenCalledWith('"Quarterly review" is back from snooze')
+  })
+
+  it('summarizes several resurfaced items through the ICU plural forms', () => {
+    mountWith(i18nEn)
+    snoozeDue?.({ items: [item('a', 'One'), item('b', 'Two'), item('c', 'Three')] })
+
+    expect(raised).toHaveLength(1)
+    expect(raised[0].title).toBe('3 snoozed items')
+    expect(raised[0].options.body).toBe('Your snoozed items are ready')
+    expect(toastInfo).toHaveBeenCalledWith('3 snoozed items are back')
+  })
+
+  it('renders the active locale, not English, when the catalogue has a translation', () => {
+    mountWith(i18nDe)
+    snoozeDue?.({ items: [item('a', 'Quartalsbericht')] })
+
+    expect(raised[0].title).toBe('Quartalsbericht')
+    expect(raised[0].options.body).toBe('Dein zurückgestellter Eintrag ist bereit')
+    expect(toastInfo).toHaveBeenCalledWith('„Quartalsbericht“ ist zurück aus dem Schlummer')
+
+    toastInfo.mockClear()
+    raised.length = 0
+    snoozeDue?.({ items: [item('a', 'Eins'), item('b', 'Zwei')] })
+
+    expect(raised[0].title).toBe('2 zurückgestellte Einträge')
+    expect(raised[0].options.body).toBe('Deine zurückgestellten Einträge sind bereit')
+    expect(toastInfo).toHaveBeenCalledWith('2 zurückgestellte Einträge sind zurück')
+  })
+
+  it('still collapses duplicate banners by resurfaced-id tag', () => {
+    mountWith(i18nEn)
+    snoozeDue?.({ items: [item('b', 'Two'), item('a', 'One')] })
+
+    expect(raised[0].options.tag).toBe('inbox-snooze-due:a,b')
+  })
+
+  it('resubscribes on a language change without re-asking for permission', async () => {
+    NotificationStub.permission = 'default'
+    const i18n = await createRendererI18n({ locale: 'en' })
+    mountWith(i18n)
+
+    expect(requestPermission).toHaveBeenCalledTimes(1)
+    expect(window.api.onInboxSnoozeDue).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await i18n.changeLanguage('de')
+    })
+
+    // The listener re-registers so the copy follows the new language, but the
+    // permission prompt lives in its own effect and does not fire again.
+    expect(window.api.onInboxSnoozeDue).toHaveBeenCalledTimes(2)
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+    expect(requestPermission).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-inbox-notifications.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-inbox-notifications.ts
@@ -1,11 +1,13 @@
 import { useEffect } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
+import { useT } from '@memry/i18n/renderer'
 import { onInboxSnoozeDue } from '@/services/inbox-service'
 import { inboxKeys } from '@/hooks/use-inbox'
 
 export function useInboxNotifications(): void {
   const queryClient = useQueryClient()
+  const { t } = useT('inbox')
 
   useEffect(() => {
     const unsubscribe = onInboxSnoozeDue((event) => {
@@ -13,11 +15,17 @@ export function useInboxNotifications(): void {
       if (dueItems.length > 0) {
         void queryClient.invalidateQueries({ queryKey: inboxKeys.lists() })
 
+        const count = dueItems.length
+        const itemTitle = dueItems[0].title
+
         if ('Notification' in window && Notification.permission === 'granted') {
-          const count = dueItems.length
-          const title = count === 1 ? dueItems[0].title : `${count} snoozed items`
-          const body =
-            count === 1 ? 'Your snoozed item is ready for review' : 'Your snoozed items are ready'
+          // A lone resurfaced item names itself: that title is the user's own
+          // data, so there is nothing to translate and no plural to select. Two
+          // or more collapse into a count, which is a real plural and goes
+          // through ICU so locales with more than one/other can spell out their
+          // own categories (ru uses `one` again at 21, ar has six).
+          const title = count === 1 ? itemTitle : t('snoozeDue.notificationTitle', { count })
+          const body = t('snoozeDue.notificationBody', { count })
           // The snooze-due event is broadcast to every window, and the inbox page
           // can be mounted more than once inside one window (split view), so a
           // single resurface would otherwise raise one banner per mount. Tagging
@@ -31,18 +39,21 @@ export function useInboxNotifications(): void {
           new Notification(title, { body, icon: '/icon.png', tag })
         }
 
-        toast.info(
-          dueItems.length === 1
-            ? `"${dueItems[0].title}" is back from snooze`
-            : `${dueItems.length} snoozed items are back`
-        )
+        // One ICU message covers both shapes: the `=1` branch names the item,
+        // every other count falls through to the plural categories.
+        toast.info(t('snoozeDue.toast', { count, itemTitle }))
       }
     })
 
+    return () => unsubscribe()
+  }, [queryClient, t])
+
+  // Asking for permission is deliberately its own effect: `t` changes identity
+  // when the user switches language, and re-running the prompt on a language
+  // change would re-ask anyone who dismissed the first request.
+  useEffect(() => {
     if ('Notification' in window && Notification.permission === 'default') {
       void Notification.requestPermission()
     }
-
-    return () => unsubscribe()
-  }, [queryClient])
+  }, [])
 }

--- a/apps/docs/src/user-guide/inbox/snooze-archive.md
+++ b/apps/docs/src/user-guide/inbox/snooze-archive.md
@@ -40,6 +40,8 @@ When wake fires, the item appears at the top of the active inbox. If memrynote i
 
 If the inbox is open — including in more than one pane or window — you also get a single system notification for that wake, not one per open inbox. A later wake for different items always gets its own notification, even when the titles happen to match.
 
+A wake for one item names that item; a wake for several summarises the count. Both the notification and the in-app toast follow the app language you picked under [Settings → Language & Region](/user-guide/settings#language-region), falling back to English for any language that has no translation for them yet.
+
 ## Archive
 
 Archived items leave the active inbox but stay in your vault. They're still:

--- a/packages/i18n/src/locales/en/inbox.json
+++ b/packages/i18n/src/locales/en/inbox.json
@@ -531,5 +531,10 @@
     "title": "{count, plural, one {Time to review # item} other {Time to review # items}}",
     "description": "Process today's captures in one calm pass.",
     "action": "Open inbox"
+  },
+  "snoozeDue": {
+    "notificationTitle": "{count, plural, one {# snoozed item} other {# snoozed items}}",
+    "notificationBody": "{count, plural, one {Your snoozed item is ready for review} other {Your snoozed items are ready}}",
+    "toast": "{count, plural, =1 {\"{itemTitle}\" is back from snooze} other {# snoozed items are back}}"
   }
 }


### PR DESCRIPTION
Closes #1283. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/hooks/use-inbox-notifications.ts:17-38` built every user-facing string from an English literal. The file had no `useT` / `t()` anywhere, so a user running the app in German, Japanese or Arabic got a fully translated UI and then an English OS banner and an English toast the moment a snoozed inbox item resurfaced — the OS banner being the more visible of the two, since it lands outside the app window.

```ts
const title = count === 1 ? dueItems[0].title : `${count} snoozed items`
const body =
  count === 1 ? 'Your snoozed item is ready for review' : 'Your snoozed items are ready'
…
toast.info(
  dueItems.length === 1
    ? `"${dueItems[0].title}" is back from snooze`
    : `${dueItems.length} snoozed items are back`
)
```

The plural handling was also `count === 1` ternaries, which only ever express two forms. Russian needs `one` again at 21, Polish switches to `few` at 2–4, Arabic has six categories — none of that is expressible this way.

Worth noting why the existing `i18n/no-toast-string-literal` ESLint rule never caught it: the rule skips `TemplateLiteral` nodes with `expressions.length > 0` (`apps/desktop/scripts/i18n/eslint/no-toast-string-literal.mjs:36`), and both toast arms interpolate. Left alone here — widening that rule is its own change with its own fallout.

## What changed

Three keys added to the `inbox` namespace (`packages/i18n/src/locales/en/inbox.json`), all as ICU plural blocks:

```json
"snoozeDue": {
  "notificationTitle": "{count, plural, one {# snoozed item} other {# snoozed items}}",
  "notificationBody": "{count, plural, one {Your snoozed item is ready for review} other {Your snoozed items are ready}}",
  "toast": "{count, plural, =1 {\"{itemTitle}\" is back from snooze} other {# snoozed items are back}}"
}
```

The hook reads them through `useT('inbox')`. Rendered English copy is byte-identical to what shipped before.

Deliberate calls:

- **`en` only, no other locales.** Every locale-touching commit since #936 lands new keys in `en` and lets the other 31 fall back (`78a7fa809`, `63d118a79`, `68231487c`, `2f174bde3`, …); `i18n:check` reports the others as warnings, not errors, and #936 was the bulk-translation pass. Machine-translating three strings into 31 languages by hand would jump that queue. So this makes the copy *translatable* and puts it in the pipeline — non-English users still see English until the next translation pass, which is the same deal every key in the catalogue got.
- **The single-item notification title stays a `count === 1` branch.** When exactly one item resurfaces the title is the item's own title — user data, not copy. There is no message to translate and no plural to select. It could not be folded into the ICU block anyway: a plural branch whose entire body is a placeholder is written `=1 {{itemTitle}}`, and the repo's `icu-brace-style` test rejects `{{…}}` outright (it is how i18next's double-brace syntax silently ships raw templates to users). The toast *is* one key, because its `=1` branch opens with a quote character rather than a brace.
- **`notificationTitle` keeps its `one` form** even though English never reaches it (the code only calls it with count ≥ 2). Russian selects `one` at 21, 31, 101 — the branch is live in other locales.
- **The permission request moved into its own effect.** Adding `t` to the subscription's deps means the effect re-runs when the user switches language; leaving `Notification.requestPermission()` inside it would re-prompt anyone still sitting on `permission === 'default'`. Same split, same reason as the sibling `use-inbox-review-notifications.ts`.

## How it was proven

New `use-inbox-notifications.test.tsx` (the hook had no test file of its own) drives a **real** `createRendererI18n` instance rather than a `t: (key) => key` stub — a stub would have "passed" against the hard-coded English and proven nothing.

```
git checkout origin/main -- apps/desktop/src/renderer/src/hooks/use-inbox-notifications.ts
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  src/renderer/src/hooks/use-inbox-notifications.test.tsx
  → Tests  2 failed | 3 passed (5)

git checkout HEAD -- apps/desktop/src/renderer/src/hooks/use-inbox-notifications.ts
  → Tests  5 passed (5)
```

The two that discriminate:

- *"renders the active locale, not English, when the catalogue has a translation"* — mounts a `de` instance with a German bundle for these three keys and asserts German out, including the 2-item plural. Before: `expected 'Your snoozed item is ready for review' to be 'Dein zurückgestellter Eintrag ist bereit'`.
- *"resubscribes on a language change without re-asking for permission"* — `changeLanguage('de')` re-registers the listener (1 → 2 registrations, 1 unsubscribe) while `requestPermission` stays at 1 call. Before: 1 registration, and on the old single-effect shape the prompt would have fired again.

The other three assert the exact English copy and the `inbox-snooze-due:<sorted ids>` tag from #1272, so they pass on both sides — they are the copy/regression guards.

`more-major-hooks.test.tsx` also exercises this hook and stubs `t` to echo its key; its five hard-coded English expectations were updated to the key names, with a comment pointing at the new file for the real copy.

## Verification

```
pnpm --filter @memry/desktop typecheck:web          exit 0
pnpm --filter @memry/desktop i18n:check             exit 0 — "ok: 3993 keys used across 1656 files",
                                                     "ok: all referenced keys exist in en/* bundles"
pnpm exec eslint …/use-inbox-notifications.ts        exit 0
vitest --project renderer use-inbox-notifications.test.tsx
       more-major-hooks.test.tsx                     13 passed (13)
vitest --project renderer use-inbox.test.tsx
       use-inbox-review-notifications.test.tsx       27 passed (27) with the above
packages/i18n vitest run                             56 passed (56) — covers icu-brace-style
                                                     and placeholder-parity for the new strings
pnpm docs:impact --base origin/main --strict         "docs impact: covered"
pnpm docs:build                                      build complete
git diff --check                                     clean
```

## Backward compatibility

Renderer-only copy change: no schema, contract, IPC, settings or sync shape touched, and locales without the new keys fall back to the English that shipped before, so an older or partially-translated catalogue renders exactly what users see today.
