### PR TITLE
test(sync): give the shared engine WebSocket mock a real connectionGeneration

### DIFF
--- a/apps/desktop/src/main/sync/engine.test.ts
+++ b/apps/desktop/src/main/sync/engine.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi } from 'vitest'
 import { SyncEngine, SYNC_LOCK_STALE_MS, PERIODIC_PULL_MAX_QUIET_MS } from './engine'
 import type { WebSocketMessage } from './websocket'
-import { createMockDeps, createMockNetwork, setupTestDb } from '@tests/utils/engine-mocks'
+import {
+  createMockDeps,
+  createMockNetwork,
+  createMockWs,
+  setupTestDb
+} from '@tests/utils/engine-mocks'
 
 describe('SyncEngine', () => {
   const { getDb } = setupTestDb()
@@ -62,24 +67,14 @@ describe('SyncEngine', () => {
   })
 
   describe('#given a socket that has not dropped #when the 60s pull tick fires', () => {
-    // deps.ws is an EventEmitter stand-in without the real getter.
-    const withGeneration = (
-      deps: ReturnType<typeof createMockDeps>,
-      read: () => number
-    ): ReturnType<typeof createMockDeps> => {
-      Object.defineProperty(deps.ws, 'connectionGeneration', {
-        configurable: true,
-        get: read
-      })
-      return deps
-    }
-
-    const startArmedEngine = async (
+    // Opened before start() so the engine arms the tick against a socket that
+    // is already up — the generation it stamps is the one the ticks then read.
+    const startArmedEngineOnLiveSocket = async (
       getSpy: { mock: { calls: unknown[] } },
-      read: () => number
+      ws: ReturnType<typeof createMockWs>
     ): Promise<{ engine: SyncEngine; callsAfterStart: number }> => {
-      const deps = withGeneration(createMockDeps(getDb()), read)
-      const engine = new SyncEngine(deps)
+      ws.simulateConnected()
+      const engine = new SyncEngine(createMockDeps(getDb(), { ws }))
       // fullSync is exercised elsewhere; here it only has to leave the tick armed.
       vi.spyOn(engine, 'fullSync').mockResolvedValue()
       await engine.start()
@@ -97,8 +92,8 @@ describe('SyncEngine', () => {
     it('#then it issues no request, and pulls again once the socket generation moves', async () => {
       vi.useFakeTimers()
       const getSpy = await mockPullTransport()
-      let generation = 1
-      const { engine, callsAfterStart } = await startArmedEngine(getSpy, () => generation)
+      const ws = createMockWs()
+      const { engine, callsAfterStart } = await startArmedEngineOnLiveSocket(getSpy, ws)
 
       // #when — two ticks on the same, still-connected socket
       await vi.advanceTimersByTimeAsync(60_000)
@@ -108,7 +103,8 @@ describe('SyncEngine', () => {
       expect(getSpy.mock.calls.length).toBe(callsAfterStart)
 
       // #when — the socket dropped and came back between ticks
-      generation += 1
+      ws.disconnect()
+      ws.simulateConnected()
       await vi.advanceTimersByTimeAsync(60_000)
 
       // #then — broadcasts may have been missed, so the tick pulls again
@@ -124,7 +120,7 @@ describe('SyncEngine', () => {
       // quiet vault, so the tick must not go quiet forever.
       vi.useFakeTimers()
       const getSpy = await mockPullTransport()
-      const { engine, callsAfterStart } = await startArmedEngine(getSpy, () => 1)
+      const { engine, callsAfterStart } = await startArmedEngineOnLiveSocket(getSpy, createMockWs())
 
       await vi.advanceTimersByTimeAsync(PERIODIC_PULL_MAX_QUIET_MS - 60_000)
       expect(getSpy.mock.calls.length).toBe(callsAfterStart)
@@ -140,11 +136,9 @@ describe('SyncEngine', () => {
     it('#then a disconnected socket keeps the every-tick pull', async () => {
       vi.useFakeTimers()
       const getSpy = await mockPullTransport()
-      const deps = withGeneration(createMockDeps(getDb()), () => 1)
-      const engine = new SyncEngine(deps)
-      vi.spyOn(engine, 'fullSync').mockResolvedValue()
-      await engine.start()
-      deps.ws.disconnect()
+      const ws = createMockWs()
+      const { engine } = await startArmedEngineOnLiveSocket(getSpy, ws)
+      ws.disconnect()
       const callsAfterStart = getSpy.mock.calls.length
 
       await vi.advanceTimersByTimeAsync(60_000)

--- a/apps/desktop/tests/utils/engine-mocks.ts
+++ b/apps/desktop/tests/utils/engine-mocks.ts
@@ -17,23 +17,57 @@ export function createMockNetwork(online = true): NetworkMonitor {
   return monitor
 }
 
-export function createMockWs(): WebSocketManager & { simulateConnected: () => void } {
-  const ws = new EventEmitter() as WebSocketManager & {
-    _connected: boolean
-    simulateConnected: () => void
+/**
+ * Everything the sync engine can read off `deps.ws`, derived from the real
+ * class rather than restated. `implements` on this is what turns a member added
+ * to WebSocketManager into a compile error here, instead of the mock silently
+ * answering `undefined` behind an `as WebSocketManager` cast.
+ */
+type WebSocketManagerSurface = Omit<WebSocketManager, keyof EventEmitter>
+
+export type MockWebSocketManager = WebSocketManager & { simulateConnected: () => void }
+
+class MockWs extends EventEmitter implements WebSocketManagerSurface {
+  private _connected = false
+  private _connectionGeneration = 0
+
+  get connected(): boolean {
+    return this._connected
   }
-  ws._connected = false
-  Object.defineProperty(ws, 'connected', { get: () => ws._connected })
-  ws.connect = vi.fn(async () => {
-    ws._connected = true
-  })
-  ws.disconnect = vi.fn(() => {
-    ws._connected = false
-  })
-  ws.simulateConnected = () => {
-    ws.emit('connected')
+
+  /** Advances once per socket open, mirroring the real manager's getter. */
+  get connectionGeneration(): number {
+    return this._connectionGeneration
   }
-  return ws
+
+  // Resolving does not mean the socket is up: the real connect() returns once
+  // the WebSocket has been constructed, and 'open' lands later. Tests that need
+  // a live socket call simulateConnected().
+  connect = vi.fn(async (): Promise<void> => {})
+
+  refreshAuth = vi.fn(async (): Promise<void> => {})
+
+  disconnect = vi.fn((): void => {
+    this._connected = false
+  })
+
+  /** One socket open: flips `connected`, advances the generation, announces it. */
+  simulateConnected = (): void => {
+    // The real manager opens at most one socket at a time, so a second open
+    // without an intervening disconnect is not a new generation.
+    if (!this._connected) {
+      this._connected = true
+      this._connectionGeneration++
+    }
+    this.emit('connected')
+  }
+}
+
+export function createMockWs(): MockWebSocketManager {
+  // WebSocketManager's private fields make it nominal, so a structural stand-in
+  // can never be assignable to it; the surface `implements` above is the check
+  // that matters.
+  return new MockWs() as unknown as MockWebSocketManager
 }
 
 export function createMockDeps(


### PR DESCRIPTION
Closes #1282. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/tests/utils/engine-mocks.ts:20-37` built the shared sync-engine WebSocket stand-in as a bare `EventEmitter` and cast it `as WebSocketManager`. The cast typechecks clean, so the missing `connectionGeneration` getter (real one at `apps/desktop/src/main/sync/websocket.ts:85-87`, advanced on every socket `open` at `:130`) surfaced as a silent `undefined`:

```ts
const ws = new EventEmitter() as WebSocketManager & { _connected: boolean; ... }
Object.defineProperty(ws, 'connected', { get: () => ws._connected })
// no connectionGeneration anywhere
```

Every guard keyed on it read `undefined` under test. In `engine.ts:591-596` that collapses to:

```ts
const generation = ws?.connectionGeneration ?? null   // always null
const sameSocketSinceLastTick = generation !== null && ...   // always false
```

so the 60s pull tick's "same socket as last tick, nothing could have been missed" skip never engaged in any engine test — the tick always pulled, and the tests that claimed to cover the skip were passing against a branch that could not be taken. `full-sync-runner.ts:156-159` (`hasReconnectGap`) reads the same getter. PR #1265 hit this and worked around it locally with an `Object.defineProperty(deps.ws, 'connectionGeneration', ...)` shim inside `engine.test.ts` rather than touching the shared mock.

A second, related divergence made the first one hard to see: the mock's `connect()` synchronously set `connected = true`, while the real `connect()` resolves once the `WebSocket` is constructed and `'open'` lands later. So a faithful generation counter bumped inside `connect()` would have made the mock claim "socket has been up and unchanged since the tick was armed" immediately after `start()` — the opposite of production, where `armPeriodicPull()` always stamps the pre-open generation and the first tick therefore pulls.

## What changed

`apps/desktop/tests/utils/engine-mocks.ts` — `createMockWs()` is now a `MockWs` class:

- `implements Omit<WebSocketManager, keyof EventEmitter>`. The surface is derived from the real class instead of restated, so adding a public member to `WebSocketManager` is a `TS2420` on the mock rather than a silent `undefined`. The `as unknown as WebSocketManager` on the return value stays — `WebSocketManager`'s private fields make it nominal, so no structural stand-in can ever be assignable to it; the `implements` clause is where the checking actually happens.
- Real `connectionGeneration`, backed by a counter advanced exactly once per socket open (a second open with no intervening `disconnect()` is not a new generation, matching the real `connect()`'s early return at `websocket.ts:99`).
- `connect()` no longer pretends the socket is open; `simulateConnected()` is now the socket open — it flips `connected`, advances the generation and emits `'connected'`. Nothing outside the mock read `ws.connected` except `engine.ts:596` and `full-sync-runner.ts:129`, so the blast radius of this is the pull-tick tests only.
- `refreshAuth` is stubbed because the derived surface requires it — it was the other member the cast was papering over. Nothing in the engine calls it (only `runtime.ts:723`, which uses its own mock).

`apps/desktop/src/main/sync/engine.test.ts` — PR #1265's `withGeneration` shim is deleted. The three pull-tick tests now open a real mock socket before `start()` (so the engine arms against a live socket) and simulate a genuine drop/reconnect with `ws.disconnect(); ws.simulateConnected()`. They exercise the same assertions through the mock's own generation counter instead of an injected getter.

Deliberately **not** done: adding `apps/desktop/tests/**` to a tsconfig. Neither `tsconfig.node.json` (`exclude: ["**/*.test.ts"]`, `include` has no `tests/**`) nor `tsconfig.web.json` covers test files, so no CI gate typechecks them today — and pulling them in surfaces unrelated pre-existing errors, including two in this very file (`createMockNetwork`'s `NetworkMonitor & { _online }` intersection reduces to `never`, and `TestDb` not being assignable to `DrizzleDb`). That is its own change; filed as an observation rather than smuggled in here.

## How it was proven

Both runs use the rewritten `engine.test.ts`; only `engine-mocks.ts` differs.

- **Before** (`git checkout origin/main -- apps/desktop/tests/utils/engine-mocks.ts`): `2 failed | 33 passed (35)` — `expected 3 to be 1` and `expected 5 to be 1`, i.e. the tick pulled on every tick because the generation was `undefined`.
- **After**: `35 passed (35)`.

The `implements` guard was mutation-tested: deleting the `connectionGeneration` getter and running `tsc` over the file produces `error TS2420: Class 'MockWs' incorrectly implements interface 'WebSocketManagerSurface'`; restoring it clears that error.

## Verification

```
pnpm --filter @memry/desktop typecheck:node                → clean
vitest --project main <8 engine-mocks consumers>           → 8 files, 121 passed
vitest --project main apps/desktop/src/main/sync           → 142 files, 1828 passed | 1 expected fail | 3 skipped
pnpm docs:impact --base origin/main --strict               → no docs-relevant changes
git diff --check                                            → clean
```

The eight suites that import `engine-mocks.ts` — `emitter-budget`, `engine-crdt`, `engine-pull`, `engine-push`, `engine-retries`, `engine`, `engine/pull-coordinator`, `engine/push-coordinator` — were run together before and after, and the whole `src/main/sync` tree on top of that.

Backward compatibility: test-only change — no production source, schema, contract or sync-shape is touched.
