### PR TITLE
perf(editor): bound the renderer link-preview cache with a 200-entry LRU

### DIFF
--- a/apps/desktop/src/renderer/src/lib/url-metadata.test.ts
+++ b/apps/desktop/src/renderer/src/lib/url-metadata.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getStartupTheme } from './startup-theme'
-import { extractDomain, fetchLinkPreview, getFaviconUrl } from './url-metadata'
+import {
+  clearLinkPreviewCache,
+  extractDomain,
+  fetchLinkPreview,
+  getFaviconUrl,
+  linkPreviewCacheSize
+} from './url-metadata'
 import { getYouTubeEmbedUrl, getYouTubeThumbnailUrl } from './youtube-utils'
 
 const api = window.api as unknown as {
@@ -10,6 +16,7 @@ const api = window.api as unknown as {
 
 describe('URL metadata utilities', () => {
   beforeEach(() => {
+    clearLinkPreviewCache()
     api.inbox.previewLink.mockReset()
     api.inbox.previewLink.mockResolvedValue({
       title: 'Example',
@@ -49,6 +56,36 @@ describe('URL metadata utilities', () => {
       favicon: 'https://www.google.com/s2/favicons?domain=retry.test&sz=32'
     })
     expect(api.inbox.previewLink).toHaveBeenCalledTimes(2)
+  })
+
+  it('caps the preview cache at 200 entries', async () => {
+    for (let i = 0; i < 1000; i++) {
+      await fetchLinkPreview(`https://example.com/page-${i}`)
+    }
+
+    expect(linkPreviewCacheSize()).toBeLessThanOrEqual(200)
+    expect(linkPreviewCacheSize()).toBe(200)
+  })
+
+  it('evicts the least recently used preview, not the oldest inserted', async () => {
+    for (let i = 0; i < 200; i++) {
+      await fetchLinkPreview(`https://example.com/page-${i}`)
+    }
+    expect(api.inbox.previewLink).toHaveBeenCalledTimes(200)
+
+    // Touch the oldest insert so it becomes the most recently used entry.
+    await fetchLinkPreview('https://example.com/page-0')
+    expect(api.inbox.previewLink).toHaveBeenCalledTimes(200)
+
+    // One more distinct URL pushes past the cap and must evict page-1.
+    await fetchLinkPreview('https://example.com/page-200')
+    expect(linkPreviewCacheSize()).toBe(200)
+
+    await fetchLinkPreview('https://example.com/page-0')
+    expect(api.inbox.previewLink).toHaveBeenCalledTimes(201)
+
+    await fetchLinkPreview('https://example.com/page-1')
+    expect(api.inbox.previewLink).toHaveBeenCalledTimes(202)
   })
 })
 

--- a/apps/desktop/src/renderer/src/lib/url-metadata.ts
+++ b/apps/desktop/src/renderer/src/lib/url-metadata.ts
@@ -16,14 +16,56 @@ export function extractDomain(url: string): string {
   }
 }
 
+/**
+ * Link previews are cached for the whole renderer session so reopening a note
+ * does not refetch every link it contains. Eviction policy: LRU, capped at
+ * PREVIEW_CACHE_LIMIT entries.
+ *
+ * The cap matters because nothing here is user-driven — `hydrateLinkMentionFavicons`
+ * calls `fetchLinkPreview` for every link mention in every note that gets opened,
+ * so an unbounded map retains one resolved promise (title, description, image and
+ * favicon URLs) per distinct link URL for as long as the window lives.
+ *
+ * A `Map` iterates in insertion order, so insertion order is used as the recency
+ * order: a cache hit reinserts its key, which makes the first key the least
+ * recently *used* one and therefore the one evicted when the cap is exceeded.
+ */
+const PREVIEW_CACHE_LIMIT = 200
 const cache = new Map<string, Promise<UrlPreviewData>>()
+
+function readCache(url: string): Promise<UrlPreviewData> | undefined {
+  const cached = cache.get(url)
+  if (!cached) return undefined
+  cache.delete(url)
+  cache.set(url, cached)
+  return cached
+}
+
+function writeCache(url: string, promise: Promise<UrlPreviewData>): void {
+  cache.set(url, promise)
+  while (cache.size > PREVIEW_CACHE_LIMIT) {
+    const oldest = cache.keys().next().value
+    if (oldest === undefined) break
+    cache.delete(oldest)
+  }
+}
+
+/** Dev/test tooling: drop every cached link preview. */
+export function clearLinkPreviewCache(): void {
+  cache.clear()
+}
+
+/** Dev/test tooling: how many link previews are currently cached. */
+export function linkPreviewCacheSize(): number {
+  return cache.size
+}
 
 export function getFaviconUrl(domain: string): string {
   return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=32`
 }
 
 export function fetchLinkPreview(url: string): Promise<UrlPreviewData> {
-  const cached = cache.get(url)
+  const cached = readCache(url)
   if (cached) return cached
 
   const domain = extractDomain(url)
@@ -31,7 +73,12 @@ export function fetchLinkPreview(url: string): Promise<UrlPreviewData> {
     ...data,
     favicon: data.favicon || getFaviconUrl(data.domain || domain)
   }))
-  cache.set(url, promise)
-  promise.catch(() => cache.delete(url))
+  writeCache(url, promise)
+  promise.catch(() => {
+    // Only evict when this exact promise is still the cached one: eviction plus a
+    // refetch can already have replaced it, and dropping that entry would throw
+    // away a good preview.
+    if (cache.get(url) === promise) cache.delete(url)
+  })
   return promise
 }

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -137,6 +137,12 @@ Color and underline are kept on separate nested spans, so an older version of Me
 
 Formatting applied in MemryNote round-trips. Underline written any other way — Obsidian's `<u>` tags, for example — is not read back, and is dropped the next time MemryNote saves the note.
 
+## Link Previews
+
+Links in a note are enriched with the page title, site name and favicon, both for inline link mentions and for bookmark blocks. The lookup runs once per URL and the result is kept in memory, so reopening a note with the same links does not refetch them.
+
+That in-memory cache holds the 200 most recently used links and evicts the least recently used entry beyond that, which keeps a long session with many link-heavy notes from growing without a limit. Evicted links are simply fetched again the next time they are shown.
+
 ## Comments
 
 Select text to open the floating toolbar. **Comment** creates an anchored review card in the right rail; selecting the text itself does not open the rail. The right rail aligns each card beside the marked text. Comment cards can be resolved or deleted.


### PR DESCRIPTION
Closes #448. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/lib/url-metadata.ts:19` kept every link preview it ever fetched, for the life of the window:

```ts
const cache = new Map<string, Promise<UrlPreviewData>>()
// ...
cache.set(url, promise)
promise.catch(() => cache.delete(url))
```

The only removal path was rejection. Nothing evicted a *successful* preview, and nothing was user-driven: `hydrateLinkMentionFavicons` (`components/note/content-area/hooks/use-editor-sync.ts:85-102`) calls `fetchLinkPreview` for every link mention in every note that gets opened. So the map accumulated one retained resolved promise — title, description, site name, plus image and favicon URLs — per distinct link URL across the whole session.

## What changed

`url-metadata.ts` only.

- The map is now an LRU capped at `PREVIEW_CACHE_LIMIT = 200`. `Map` insertion order is the recency order: a cache hit re-inserts its key, so the first key is always the least recently *used* one and is the one dropped once the cap is exceeded.
- The cap and the eviction policy are stated in a comment above the cache, per the issue's acceptance criteria.
- The rejection handler now only evicts when the cached promise is still the same object it was created for. Without that guard, an eviction plus a refetch followed by the old promise rejecting would throw away a good preview.
- Two small helpers are exported for dev/test tooling: `clearLinkPreviewCache()` (the "dev-tooling clear method" the issue asks for) and `linkPreviewCacheSize()`.

Deliberately **not** done:

- **Wiki hover cache** (`hooks/use-wiki-link-hover.ts:19`) — already capped at `CACHE_LIMIT = 50`, and only the active tab's pane is mounted (`components/split-view/tab-pane.tsx:57`), so the real ceiling is roughly 2 × 50 entries of note snippet. Hoisting it to a shared module-level LRU would also make the previews outlive the editor that populated them — across note edits, deletes and vault switches — trading a negligible memory win for a staleness regression in preview content. Left as is.
- **Quick capture blob** (`components/quick-capture.tsx`) — not a real leak. `:196-202` revokes the object URL in an effect keyed on `clipboardImageUrl`, each paste replaces the single `Blob`, and the window closes itself on a successful capture (`:581-582`). One blob at a time, freed at teardown. Untouched.

The issue body was edited before this PR to drop the quick-capture bullet and its "20 large screenshot pastes" acceptance criterion, since they no longer describe the code.

The issue's epic note claims this duplicates an audit finding. It does not — #1042 is the AI folder-suggestion cache and #1082 is the agent-chat icon cache. This cache was genuinely unfixed.

## How it was proven

Two new tests in `url-metadata.test.ts`: the acceptance-criteria size test (1000 distinct previews → cache holds ≤ 200, and exactly 200), and an LRU-ordering test proving eviction is by recency and not insertion (touch the oldest key, add one past the cap, then assert the touched key is still cached and its neighbour was refetched).

Before/after on the same test file, reverting only the source file (`git checkout origin/main -- apps/desktop/src/renderer/src/lib/url-metadata.ts`):

- **Before the fix:** `Tests 5 failed | 2 passed (7)` — `TypeError: clearLinkPreviewCache is not a function`.
- **After the fix:** `Tests 7 passed (7)`.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  apps/desktop/src/renderer/src/lib/url-metadata.test.ts
  → Test Files 1 passed (1) | Tests 7 passed (7)

./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  .../hooks/use-editor-sync.test.tsx .../content-area/ContentArea.test.tsx
  → Test Files 2 passed (2) | Tests 20 passed (20)   # the two consumers of fetchLinkPreview

pnpm --filter @memry/desktop typecheck:web   → clean
pnpm exec eslint apps/desktop/src/renderer/src/lib/url-metadata.ts   → 0 errors
git diff --check                             → clean
pnpm docs:impact --base origin/main --strict → covered
pnpm docs:build                              → build complete
```

## Backward compatibility

Renderer-only, in-memory cache; no schema, contract, settings or sync shape is touched, and an evicted preview is simply refetched the next time it is rendered.
