### PR TITLE
perf(sync): prune completed transfer progress and stale conflicts from renderer state

### DIFF
--- a/apps/desktop/src/renderer/src/components/sync/sync-components.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sync/sync-components.test.tsx
@@ -41,7 +41,8 @@ const mocks = vi.hoisted(() => ({
     triggerSync: vi.fn(),
     pause: vi.fn(),
     resume: vi.fn(),
-    clearError: vi.fn()
+    clearError: vi.fn(),
+    clearConflicts: vi.fn()
   },
   syncHistory: {
     entries: [] as any[],

--- a/apps/desktop/src/renderer/src/components/sync/sync-status.tsx
+++ b/apps/desktop/src/renderer/src/components/sync/sync-status.tsx
@@ -37,7 +37,8 @@ export function SyncStatus({ onOpenSettings, iconOnly }: SyncStatusProps): React
     triggerSync,
     pause,
     resume,
-    clearError
+    clearError,
+    clearConflicts
   } = useSyncStatus()
 
   const isSyncing = status === 'syncing'
@@ -127,10 +128,20 @@ export function SyncStatus({ onOpenSettings, iconOnly }: SyncStatusProps): React
                 </p>
               )}
               {conflicts.length > 0 && (
-                <p className="text-xs text-yellow-600 dark:text-yellow-400">
-                  {conflicts.length} {conflicts.length === 1 ? 'conflict' : 'conflicts'}{' '}
-                  {tPhaseF('phaseF.componentsSyncSyncStatus.detected')}
-                </p>
+                <div className="flex items-center gap-2">
+                  <p className="text-xs text-yellow-600 dark:text-yellow-400">
+                    {conflicts.length} {conflicts.length === 1 ? 'conflict' : 'conflicts'}{' '}
+                    {tPhaseF('phaseF.componentsSyncSyncStatus.detected')}
+                  </p>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={clearConflicts}
+                    className="ms-auto h-5 px-1.5 text-xs"
+                  >
+                    {tPhaseF('phaseF.componentsSyncSyncStatus.dismissConflicts')}
+                  </Button>
+                </div>
               )}
               {clockSkewDetected && (
                 <p className="text-xs text-yellow-600 dark:text-yellow-400">

--- a/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
@@ -234,7 +234,15 @@ beforeEach(async () => {
 })
 
 import { useAuth } from './auth-context'
-import { SyncProvider, useSync } from './sync-context'
+import {
+  SyncProvider,
+  useSync,
+  syncReducer,
+  initialState,
+  SYNC_PROGRESS_RETENTION_MS,
+  SYNC_CONFLICT_TTL_MS,
+  SYNC_CONFLICT_CAP
+} from './sync-context'
 
 function wrapper({ children }: { children: ReactNode }) {
   return (
@@ -542,6 +550,39 @@ describe('SyncProvider', () => {
       expect(result.current.state.syncActivity).toEqual({ pushCount: 0, pullCount: 0 })
     })
 
+    it('#then bounds retained conflicts instead of growing one entry per event', async () => {
+      const { result } = renderHook(() => useSync(), { wrapper })
+      await vi.waitFor(() => expect(conflictDetectedListeners.length).toBeGreaterThan(0))
+
+      act(() => {
+        // One item re-detected on every pull, plus a wide burst of distinct items.
+        for (let i = 0; i < 150; i++) {
+          for (const cb of conflictDetectedListeners) cb({ itemId: 'note-loud', type: 'note' })
+        }
+        for (let i = 0; i < 150; i++) {
+          for (const cb of conflictDetectedListeners) cb({ itemId: `note-${i}`, type: 'note' })
+        }
+      })
+
+      expect(result.current.state.conflicts.length).toBeLessThanOrEqual(100)
+      expect(result.current.state.conflicts.at(-1)?.itemId).toBe('note-149')
+    })
+
+    it('#then clears conflicts through the exposed action', async () => {
+      const { result } = renderHook(() => useSync(), { wrapper })
+      await vi.waitFor(() => expect(conflictDetectedListeners.length).toBeGreaterThan(0))
+
+      act(() => {
+        for (const cb of conflictDetectedListeners) cb({ itemId: 'note-1', type: 'note' })
+      })
+      expect(result.current.state.conflicts).toHaveLength(1)
+
+      act(() => {
+        result.current.clearConflicts()
+      })
+      expect(result.current.state.conflicts).toEqual([])
+    })
+
     it('#then handles linking lifecycle, key-rotation errors, and clear/dismiss actions', async () => {
       const { result } = renderHook(() => useSync(), { wrapper })
       await vi.waitFor(() => expect(linkingRequestListeners.length).toBeGreaterThan(0))
@@ -654,6 +695,118 @@ describe('SyncProvider', () => {
         'Secure connection to sync server could not be verified. Syncing has been paused for your protection.',
         { duration: 15000 }
       )
+    })
+  })
+})
+
+describe('syncReducer', () => {
+  const uploadEvent = (id: string, progress: number) =>
+    ({ type: 'UPLOAD_PROGRESS', attachmentId: id, progress, status: 'uploading' }) as const
+  const downloadEvent = (id: string, progress: number) =>
+    ({ type: 'DOWNLOAD_PROGRESS', attachmentId: id, progress, status: 'decrypting' }) as const
+  const conflictEvent = (itemId: string) =>
+    ({ type: 'CONFLICT_DETECTED', itemId, itemType: 'note' }) as const
+
+  describe('#given many attachments finished transferring #when the sweep runs', () => {
+    it('#then retains no completed progress entries', () => {
+      let state = initialState
+      for (let i = 0; i < 500; i++) {
+        state = syncReducer(state, uploadEvent(`att-${i}`, 40))
+        state = syncReducer(state, uploadEvent(`att-${i}`, 100))
+        state = syncReducer(state, downloadEvent(`dl-${i}`, 100))
+      }
+      expect(Object.keys(state.uploadProgress ?? {})).toHaveLength(500)
+      expect(Object.keys(state.downloadProgress ?? {})).toHaveLength(500)
+
+      state = syncReducer(state, {
+        type: 'PRUNE_STALE',
+        now: Date.now() + SYNC_PROGRESS_RETENTION_MS
+      })
+
+      expect(state.uploadProgress).toBeNull()
+      expect(state.downloadProgress).toBeNull()
+    })
+  })
+
+  describe('#given a transfer still in flight #when the sweep runs', () => {
+    it('#then drops only the finished entry', () => {
+      let state = syncReducer(initialState, uploadEvent('att-live', 40))
+      state = syncReducer(state, uploadEvent('att-done', 100))
+
+      state = syncReducer(state, {
+        type: 'PRUNE_STALE',
+        now: Date.now() + SYNC_PROGRESS_RETENTION_MS
+      })
+
+      expect(state.uploadProgress).toEqual({ 'att-live': { progress: 40, status: 'uploading' } })
+    })
+
+    it('#then keeps a just-finished entry and returns the same state object', () => {
+      const state = syncReducer(initialState, uploadEvent('att-done', 100))
+      const swept = syncReducer(state, { type: 'PRUNE_STALE', now: Date.now() })
+
+      expect(Object.keys(swept.uploadProgress ?? {})).toEqual(['att-done'])
+      expect(swept).toBe(state)
+    })
+  })
+
+  describe('#given a burst of conflicts #when they exceed the cap', () => {
+    it('#then keeps only the newest capped entries', () => {
+      let state = initialState
+      for (let i = 0; i < SYNC_CONFLICT_CAP + 37; i++) {
+        state = syncReducer(state, conflictEvent(`note-${i}`))
+      }
+
+      expect(SYNC_CONFLICT_CAP).toBe(100)
+      expect(state.conflicts).toHaveLength(SYNC_CONFLICT_CAP)
+      expect(state.conflicts[0].itemId).toBe('note-37')
+      expect(state.conflicts.at(-1)?.itemId).toBe(`note-${SYNC_CONFLICT_CAP + 36}`)
+    })
+  })
+
+  describe('#given one item conflicts repeatedly #when more conflicts arrive', () => {
+    it('#then counts the item once instead of evicting distinct conflicts', () => {
+      let state = syncReducer(initialState, conflictEvent('note-a'))
+      state = syncReducer(state, conflictEvent('note-b'))
+      for (let i = 0; i < 500; i++) {
+        state = syncReducer(state, conflictEvent('note-loud'))
+      }
+
+      expect(state.conflicts.map((entry) => entry.itemId)).toEqual([
+        'note-a',
+        'note-b',
+        'note-loud'
+      ])
+    })
+  })
+
+  describe('#given conflicts older than the TTL #when the sweep runs', () => {
+    it('#then drops the expired entries', () => {
+      let state = syncReducer(initialState, conflictEvent('note-old'))
+      state = syncReducer(state, { type: 'PRUNE_STALE', now: Date.now() + SYNC_CONFLICT_TTL_MS })
+
+      expect(state.conflicts).toEqual([])
+    })
+
+    it('#then keeps entries inside the TTL', () => {
+      const state = syncReducer(initialState, conflictEvent('note-fresh'))
+      const swept = syncReducer(state, {
+        type: 'PRUNE_STALE',
+        now: Date.now() + SYNC_CONFLICT_TTL_MS - 1_000
+      })
+
+      expect(swept.conflicts).toHaveLength(1)
+      expect(swept).toBe(state)
+    })
+  })
+
+  describe('#given conflicts #when CLEAR_CONFLICTS is dispatched', () => {
+    it('#then empties the list and bails out when already empty', () => {
+      const withConflict = syncReducer(initialState, conflictEvent('note-a'))
+      const cleared = syncReducer(withConflict, { type: 'CLEAR_CONFLICTS' })
+
+      expect(cleared.conflicts).toEqual([])
+      expect(syncReducer(cleared, { type: 'CLEAR_CONFLICTS' })).toBe(cleared)
     })
   })
 })

--- a/apps/desktop/src/renderer/src/contexts/sync-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.tsx
@@ -26,7 +26,25 @@ import type { SyncStatus } from '@/sync/collaboration-status'
 interface ProgressEntry {
   progress: number
   status: string
+  /** Set once the transfer reaches 100%; the prune sweep drops it after the retention window. */
+  completedAt?: number
 }
+
+/**
+ * How long a finished transfer's entry survives so the progress UI can settle.
+ * Main only ever emits transfer *phases* ('uploading', 'decrypting', …) and
+ * never a terminal status, so a full bar is the only end-of-transfer signal
+ * the renderer gets.
+ */
+export const SYNC_PROGRESS_RETENTION_MS = 5_000
+/**
+ * The cap is what bounds memory; this TTL is purely a staleness policy, so it
+ * is deliberately generous — expiring a conflict only ever retracts a warning
+ * the user may not have read yet.
+ */
+export const SYNC_CONFLICT_TTL_MS = 24 * 60 * 60 * 1_000
+export const SYNC_CONFLICT_CAP = 100
+const PRUNE_INTERVAL_MS = 5_000
 
 interface ConflictEntry {
   itemId: string
@@ -73,13 +91,15 @@ type SyncAction =
   | { type: 'SESSION_EXPIRED'; error: string }
   | { type: 'DEVICE_REVOKED'; unsyncedCount: number; error: string }
   | { type: 'CONFLICT_DETECTED'; itemId: string; itemType: string }
+  | { type: 'CLEAR_CONFLICTS' }
+  | { type: 'PRUNE_STALE'; now: number }
   | { type: 'QUEUE_CLEARED' }
   | { type: 'CLOCK_SKEW_WARNING' }
   | { type: 'ITEM_SYNCED'; lastSyncAt: number; operation: 'push' | 'pull' }
   | { type: 'INITIAL_SYNC_PROGRESS'; phase: InitialSyncPhase; current: number; total: number }
   | { type: 'RESET' }
 
-const initialState: SyncState = {
+export const initialState: SyncState = {
   status: 'unknown',
   lastSyncAt: null,
   pendingCount: 0,
@@ -95,7 +115,38 @@ const initialState: SyncState = {
   syncActivity: { pushCount: 0, pullCount: 0 }
 }
 
-function syncReducer(state: SyncState, action: SyncAction): SyncState {
+function recordProgress(
+  current: Record<string, ProgressEntry> | null,
+  attachmentId: string,
+  progress: number,
+  status: string
+): Record<string, ProgressEntry> {
+  const entry: ProgressEntry =
+    progress >= 100 ? { progress, status, completedAt: Date.now() } : { progress, status }
+  return { ...current, [attachmentId]: entry }
+}
+
+/** Returns the same reference when nothing expired, so the reducer can bail out. */
+function pruneProgress(
+  current: Record<string, ProgressEntry> | null,
+  now: number
+): Record<string, ProgressEntry> | null {
+  if (!current) return current
+  const kept = Object.entries(current).filter(
+    ([, entry]) =>
+      entry.completedAt === undefined || now - entry.completedAt < SYNC_PROGRESS_RETENTION_MS
+  )
+  if (kept.length === Object.keys(current).length) return current
+  return kept.length > 0 ? Object.fromEntries(kept) : null
+}
+
+/** Returns the same reference when nothing expired, so the reducer can bail out. */
+function pruneConflicts(conflicts: ConflictEntry[], now: number): ConflictEntry[] {
+  const fresh = conflicts.filter((entry) => now - entry.detectedAt < SYNC_CONFLICT_TTL_MS)
+  return fresh.length === conflicts.length ? conflicts : fresh
+}
+
+export function syncReducer(state: SyncState, action: SyncAction): SyncState {
   switch (action.type) {
     case 'STATUS_CHANGED': {
       const leavingSyncing = state.status === 'syncing' && action.status !== 'syncing'
@@ -124,18 +175,22 @@ function syncReducer(state: SyncState, action: SyncAction): SyncState {
     case 'UPLOAD_PROGRESS':
       return {
         ...state,
-        uploadProgress: {
-          ...state.uploadProgress,
-          [action.attachmentId]: { progress: action.progress, status: action.status }
-        }
+        uploadProgress: recordProgress(
+          state.uploadProgress,
+          action.attachmentId,
+          action.progress,
+          action.status
+        )
       }
     case 'DOWNLOAD_PROGRESS':
       return {
         ...state,
-        downloadProgress: {
-          ...state.downloadProgress,
-          [action.attachmentId]: { progress: action.progress, status: action.status }
-        }
+        downloadProgress: recordProgress(
+          state.downloadProgress,
+          action.attachmentId,
+          action.progress,
+          action.status
+        )
       }
     case 'SESSION_EXPIRED':
       return { ...state, sessionExpired: true, status: 'error', error: action.error }
@@ -146,14 +201,37 @@ function syncReducer(state: SyncState, action: SyncAction): SyncState {
         status: 'error',
         error: action.error
       }
-    case 'CONFLICT_DETECTED':
+    case 'CONFLICT_DETECTED': {
+      const now = Date.now()
+      // Every pull that re-detects the same item emits again, so an item that
+      // ping-pongs between devices used to append an entry per round. Key by
+      // item: the popover counts conflicting *items*, and one noisy note can
+      // no longer push 99 genuinely distinct conflicts out of the cap.
+      const kept = pruneConflicts(state.conflicts, now).filter(
+        (entry) => entry.itemId !== action.itemId || entry.itemType !== action.itemType
+      )
+      const next = [...kept, { itemId: action.itemId, itemType: action.itemType, detectedAt: now }]
       return {
         ...state,
-        conflicts: [
-          ...state.conflicts,
-          { itemId: action.itemId, itemType: action.itemType, detectedAt: Date.now() }
-        ]
+        conflicts:
+          next.length > SYNC_CONFLICT_CAP ? next.slice(next.length - SYNC_CONFLICT_CAP) : next
       }
+    }
+    case 'CLEAR_CONFLICTS':
+      return state.conflicts.length === 0 ? state : { ...state, conflicts: [] }
+    case 'PRUNE_STALE': {
+      const uploadProgress = pruneProgress(state.uploadProgress, action.now)
+      const downloadProgress = pruneProgress(state.downloadProgress, action.now)
+      const conflicts = pruneConflicts(state.conflicts, action.now)
+      if (
+        uploadProgress === state.uploadProgress &&
+        downloadProgress === state.downloadProgress &&
+        conflicts === state.conflicts
+      ) {
+        return state
+      }
+      return { ...state, uploadProgress, downloadProgress, conflicts }
+    }
     case 'QUEUE_CLEARED':
       return { ...state, pendingCount: 0 }
     case 'CLOCK_SKEW_WARNING':
@@ -190,6 +268,7 @@ interface SyncContextValue {
   pause: () => Promise<void>
   resume: () => Promise<void>
   clearError: () => void
+  clearConflicts: () => void
   linkingRequest: LinkingRequestEvent | null
   clearLinkingRequest: () => void
   dismissDeviceRevoked: () => void
@@ -443,6 +522,17 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
     }
   }, [authState.status, t])
 
+  // Progress and conflict entries used to accumulate for the whole session and
+  // only cleared on logout. Sweep them on a timer; the reducer returns the same
+  // state object when nothing expired, so an idle sweep costs no rerender.
+  useEffect(() => {
+    if (authState.status !== 'authenticated') return
+    const timer = setInterval(() => {
+      dispatch({ type: 'PRUNE_STALE', now: Date.now() })
+    }, PRUNE_INTERVAL_MS)
+    return () => clearInterval(timer)
+  }, [authState.status])
+
   useEffect(() => {
     if (authState.status === 'authenticated' && state.sessionExpired) {
       dispatch({ type: 'CLEAR_ERROR' })
@@ -481,6 +571,10 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
     dispatch({ type: 'CLEAR_ERROR' })
   }, [])
 
+  const clearConflicts = useCallback(() => {
+    dispatch({ type: 'CLEAR_CONFLICTS' })
+  }, [])
+
   const clearLinkingRequest = useCallback(() => {
     setLinkingRequest(null)
   }, [])
@@ -500,6 +594,7 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
       pause,
       resume,
       clearError,
+      clearConflicts,
       linkingRequest,
       clearLinkingRequest,
       dismissDeviceRevoked,
@@ -512,6 +607,7 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
       pause,
       resume,
       clearError,
+      clearConflicts,
       linkingRequest,
       clearLinkingRequest,
       dismissDeviceRevoked,

--- a/apps/desktop/src/renderer/src/hooks/use-sync-status.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-sync-status.ts
@@ -46,6 +46,7 @@ interface SyncStatusResult extends SyncStatusDisplay {
   pause: () => Promise<void>
   resume: () => Promise<void>
   clearError: () => void
+  clearConflicts: () => void
 }
 
 const STATUS_MAP: Record<string, Omit<SyncStatusDisplay, 'label'> & { labelKey: string }> = {
@@ -91,7 +92,7 @@ const FALLBACK_DISPLAY = STATUS_MAP.unknown
 
 export function useSyncStatus(): SyncStatusResult {
   const { t } = useT('settings')
-  const { state, triggerSync, pause, resume, clearError } = useSync()
+  const { state, triggerSync, pause, resume, clearError, clearConflicts } = useSync()
   const {
     status,
     lastSyncAt,
@@ -185,6 +186,7 @@ export function useSyncStatus(): SyncStatusResult {
     triggerSync,
     pause,
     resume,
-    clearError
+    clearError,
+    clearConflicts
   }
 }

--- a/apps/docs/src/user-guide/sync/conflict-health.md
+++ b/apps/docs/src/user-guide/sync/conflict-health.md
@@ -39,6 +39,12 @@ When a conflict requires your attention (very rare given the strategies above), 
 - Adds an entry to **Sync History**
 - Lets you choose to keep your version, the remote version, or merge manually
 
+### Conflict Count in the Sync Menu
+
+The sync status menu shows how many items hit a conflict, with a **Dismiss** button to clear the notice once you have seen it.
+
+The count tracks _items_, not events — an item that keeps conflicting is counted once, not once per sync round. The notice clears when you dismiss it, when you sign out, or automatically after 24 hours.
+
 ## Sync History
 
 A panel that lists recent sync events:

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -1470,6 +1470,7 @@
       "pending": "pending",
       "localOnly": "local-only",
       "detected": "detected",
+      "dismissConflicts": "Dismiss",
       "clockSkewDetected": "Clock skew detected",
       "items": "items",
       "willSyncWhenBackOnline": "Will sync when back online",


### PR DESCRIPTION
Closes #449. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

Three entries in `apps/desktop/src/renderer/src/contexts/sync-context.tsx` grew for the whole session and were only cleared by `RESET` on logout (`:180`).

`UPLOAD_PROGRESS` / `DOWNLOAD_PROGRESS` (`:124-138`) spread-and-add, one key per attachment, forever:

```ts
uploadProgress: { ...state.uploadProgress, [action.attachmentId]: { progress, status } }
```

`CONFLICT_DETECTED` (`:149-156`) appended unconditionally — no clear action, no expiry, no cap:

```ts
conflicts: [...state.conflicts, { itemId, itemType, detectedAt: Date.now() }]
```

Every one of those objects sits in `useReducer` state that is spread on each subsequent action, so the cost is retained memory *plus* per-event copy work that scales with everything that came before. Issue #1062 → PR #1212 throttled the emission side only; the retained set was untouched.

### The issue's suggested fix does not work as written

The issue asks to drop entries "on terminal status". **There is no terminal status.** `sync-attachment-handlers.ts:112-129` sends `status: progress.phase`, and the phase union in `apps/desktop/src/main/sync/attachments.ts:84` is:

```ts
phase: 'hashing' | 'encrypting' | 'uploading' | 'downloading' | 'decrypting' | 'waiting_network'
```

Nothing ever emits `completed` / `failed` / `done`. So this PR keys off the only real end-of-transfer signal the renderer gets: `progress >= 100`.

This same wrong assumption is already live in `file-block.tsx:544`, which gates its overlay on `activeTransfer.status !== 'completed'` — a condition that can never be true today, so a finished attachment's progress overlay stayed pinned at 100% until logout. Pruning the entry makes that overlay disappear as a side effect; `file-block.tsx` is unchanged.

## What changed

`sync-context.tsx`:

- `ProgressEntry` gains an optional `completedAt`, stamped only when a transfer reports `progress >= 100`. Non-terminal entries are byte-identical to before, so existing assertions still hold.
- New `PRUNE_STALE` action carrying an explicit `now`, dispatched from a single 5s `setInterval` in the provider (authenticated only, cleared on unmount). It drops completed progress entries past a 5s retention window and expired conflicts. When nothing expires it returns **the same state object**, so an idle sweep triggers no rerender.
- New `CLEAR_CONFLICTS` action, exposed as `clearConflicts` on the context and surfaced as a **Dismiss** button next to the conflict count in the sync popover. Added deliberately rather than shipping an action with no caller.
- `CONFLICT_DETECTED` now expires stale entries, keys by `itemId`+`itemType`, and caps at 100 (oldest dropped).

Deliberately **not** done:

- **No stale-drop for in-flight progress entries.** A failed or abandoned upload still leaves one stuck entry. Dropping non-terminal entries by age would also delete legitimately parked `waiting_network` transfers, because `throttlePerTransfer` emits `phase:percent` once and then goes silent. Bounded by failure rate; not worth the regression. Noted below as a separate finding.
- **No change to `file-block.tsx`** — its dead `!== 'completed'` check is now harmless.
- **No IPC, contract, schema, or migration change.** Entirely renderer-local state.

### Judgement call: can this discard a conflict the user still needs?

Asked explicitly, and the answer is **no** — verified rather than assumed:

1. `pull-coordinator.ts:891-924` — `handleConflict` emits the event and *immediately* `queue.enqueue(...)` the local version. The conflict is already auto-resolved (local wins, re-pushed) before the renderer ever sees it. Nothing waits on the user.
2. The renderer keeps only `{ itemId, itemType, detectedAt }`. `sync-context.tsx:365` throws away the `localVersion` / `remoteVersion` the event carries, so this state could not drive a resolution UI even if one existed.
3. Consumers are `use-sync-status.ts:167` (`hasIssues`) and `sync-status.tsx:129` — a count in a popover. There is no resolve, inspect, or dismiss action anywhere.

So the only thing at risk is *the count*. Two safer choices follow from that:

- **TTL is 24 hours, not the 1 hour the issue asked for.** The 100-cap alone fully bounds memory; the TTL contributes nothing to the memory goal and is purely a staleness policy. Its only possible effect is retracting a warning the user has not read — and the warning does matter, because "auto-resolved" here means a remote edit from another device was discarded. A 1h TTL could silently clear that while the user is at lunch, for zero memory benefit. 24h keeps it alive across a working day and still bounds a long-running session. (It already dies on app restart regardless — this state is not persisted.)
- **Conflicts are keyed by item, so the cap cannot evict a distinct conflict for a noisy one.** Each pull that re-detects an item re-emits, and since `handleConflict` re-pushes the local version, an item can ping-pong indefinitely. Under a naive append-and-cap, one such note would fill all 100 slots and evict 99 genuinely distinct conflicts — the exact "silently drop something the user needed" failure. Keying by item makes the count mean *conflicting items*, which is also what the popover's "N conflicts detected" already implies.

The explicit **Dismiss** button completes the policy: the user acknowledges the notice rather than depending on a silent timer.

## How it was proven

New provider-level test drives 300 real `sync:conflict-detected` events through the actual listener and asserts on retained reducer state. It compiles against both revisions, so the numbers are directly comparable.

Protocol: commit first, `git checkout origin/main -- apps/desktop/src/renderer/src/contexts/sync-context.tsx`, run, restore with `git checkout HEAD -- ...`. No `git stash` (shared across worktrees).

**Before** (`sync-context.tsx` at `origin/main`):

```
× #then bounds retained conflicts instead of growing one entry per event
  → expected 300 to be less than or equal to 100
 Test Files  1 failed (1)
      Tests  1 failed | 29 skipped (30)
```

**After** (fix restored):

```
✓ #then bounds retained conflicts instead of growing one entry per event 17ms
 Test Files  1 passed (1)
      Tests  1 passed | 29 skipped (30)
```

300 retained → 100. The 8 new `syncReducer` unit tests cannot run against `origin/main` at all (the reducer is not exported there and the pruning actions do not exist); they cover completion pruning (500 uploads + 500 downloads → `uploadProgress`/`downloadProgress` both back to `null`), in-flight entries surviving the sweep, the retention window, cap eviction ordering, per-item dedupe, TTL expiry both sides of the boundary, `CLEAR_CONFLICTS`, and the same-object bail-out.

## Verification

| Command | Result |
| --- | --- |
| `vitest run --project renderer` on `sync-context.test.tsx`, `sync-components.test.tsx`, `use-sync-hooks.test.tsx`, `file-block.test.tsx` | **4 files, 48 tests passed** (was 36 before this PR) |
| `vitest run --project renderer settings-sections.test.tsx` | 1 file, 11 passed |
| `pnpm --filter @memry/desktop typecheck:web` | clean |
| `pnpm exec eslint` on all changed source files | 0 errors, 0 warnings |
| `pnpm --filter @memry/desktop i18n:check` | `ok: i18n check passed` |
| `pnpm docs:impact --base origin/main --strict` | `docs impact: covered against origin/main` |
| `pnpm docs:build` | `build complete in 4.25s` |
| `git diff --check` | clean |

No main-process files touched, so `typecheck:node` is not applicable. New Tailwind uses logical properties (`ms-auto`).

## Backward compatibility

Renderer-only in-memory reducer state — no IPC contract, DB schema, sync payload, vault file, or settings shape is touched, so nothing an older or newer app version reads or writes changes.

## Issue hygiene

The issue body was corrected before opening this PR. It required a `pnpm memory:snapshot` benchmark showing "renderer reducer state size reduced by >= 5 MB". That number is not attainable: the retained values are `{ progress, status }` and `{ itemId, itemType, detectedAt }`, a few dozen bytes each, so even 10k entries is nowhere near 5 MB. The leak is real but entry-count-shaped, not megabyte-shaped, and the old criterion would have sent an implementer chasing a delta that cannot exist. It is replaced with reducer-state entry-count assertions, which is what the tests here measure.

## Out of scope, found while working

- A failed or abandoned transfer leaves one permanently stuck progress entry (no event ever reports 100%), which also pins its `file-block` progress overlay. Fixing it safely needs a terminal/failure signal from main rather than an age heuristic, since `waiting_network` transfers are legitimately silent for long stretches.
- `apps/docs/src/user-guide/sync/conflict-health.md` describes a manual conflict resolution flow ("Compare the two versions side-by-side", "Pick Keep mine, Keep remote") that does not exist in the code — `handleConflict` auto-resolves and the renderer only keeps a count. Not corrected here; that is a docs-accuracy issue of its own.
