### PR TITLE
fix(agent-chat): time out pending tool approvals instead of holding them for the app's lifetime

### DIFF
--- a/apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts
@@ -24,6 +24,16 @@ function flushMicrotasks(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
 
+/**
+ * Real timers, not fake ones: the runtime's deadline is a real `setTimeout` and
+ * these tests assert it fires (and does not fire) on its own.
+ */
+const APPROVAL_TIMEOUT_TEST_MS = 15
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 function broadcastToolCallIds(): string[] {
   return mocks.broadcastAgentEvent.mock.calls
     .map(([event]) => event as { kind: string; toolCallId: string })
@@ -31,7 +41,22 @@ function broadcastToolCallIds(): string[] {
     .map((event) => event.toolCallId)
 }
 
-function createRuntime(toolApprovalMode: 'always_accept' | 'ask' = 'always_accept') {
+function failedToolCallEvents(): {
+  toolCallId: string
+  error: { code: string; message: string }
+}[] {
+  return mocks.broadcastAgentEvent.mock.calls
+    .map(
+      ([event]) =>
+        event as { kind: string; toolCallId: string; error: { code: string; message: string } }
+    )
+    .filter((event) => event.kind === 'tool_call_failed')
+}
+
+function createRuntime(
+  toolApprovalMode: 'always_accept' | 'ask' = 'always_accept',
+  approvalTimeoutMs?: number
+) {
   const conversations = {
     getById: vi.fn(),
     addToTrustList: vi.fn()
@@ -39,7 +64,8 @@ function createRuntime(toolApprovalMode: 'always_accept' | 'ask' = 'always_accep
   const runtime = new AgentRuntime({
     conversations: conversations as unknown as ConversationStore,
     messages: {} as MessageStore,
-    getPreferences: () => ({ accessMode: 'vault_only', toolApprovalMode })
+    getPreferences: () => ({ accessMode: 'vault_only', toolApprovalMode }),
+    approvalTimeoutMs
   })
 
   return { runtime, conversations }
@@ -250,6 +276,118 @@ describe('AgentRuntime approval gate', () => {
       Promise.race([settled, Promise.resolve('still-pending' as const)])
     ).resolves.toMatchObject({ code: 'PERMISSION_DENIED' })
     expect(create).not.toHaveBeenCalled()
+  })
+
+  it('settles an unanswered approval as expired, not as a denial', async () => {
+    const { runtime, conversations } = createRuntime('ask', APPROVAL_TIMEOUT_TEST_MS)
+    conversations.getById.mockReturnValue({ id: 'conversation-1', trustList: [] })
+
+    runtime.install()
+    const pending = installedGate()({
+      conversationId: 'conversation-1',
+      toolName: 'vault_create_task',
+      parsedArgs: { title: 'Task' }
+    })
+    const [toolCallId] = broadcastToolCallIds()
+    expect(runtime.getPendingApproval(toolCallId)).not.toBeNull()
+
+    await delay(APPROVAL_TIMEOUT_TEST_MS * 8)
+
+    // The map entry is gone, so the tool handler, its socket and the args it
+    // pinned are all released without anyone touching the app.
+    expect(runtime.getPendingApproval(toolCallId)).toBeNull()
+    const settled = await Promise.race([pending, Promise.resolve('still-pending' as const)])
+    expect(settled).toEqual({
+      approved: false,
+      reason: expect.stringContaining('expired') as string
+    })
+    // The model must not be told the user refused.
+    expect((settled as { reason: string }).reason).not.toContain('denied')
+
+    const failure = failedToolCallEvents().find((event) => event.toolCallId === toolCallId)
+    expect(failure?.error).toEqual({
+      code: 'APPROVAL_EXPIRED',
+      message: expect.stringContaining('expired') as string
+    })
+    // PERMISSION_DENIED is what the renderer renders as the "Denied" chip.
+    expect(failure?.error.code).not.toBe('PERMISSION_DENIED')
+  })
+
+  it('fails the awaiting write tool on expiry and never executes it', async () => {
+    const { runtime, conversations } = createRuntime('ask', APPROVAL_TIMEOUT_TEST_MS)
+    conversations.getById.mockReturnValue({ id: 'conversation-1', trustList: [] })
+
+    runtime.install()
+    const create = vi.fn(async () => ({ id: 'note-1' }))
+    const createNote = buildWriteTools(
+      { notes: { create } } as unknown as VaultServiceHandles,
+      installedGate()
+    ).find((tool) => tool.name === 'vault_create_note')
+    if (!createNote) throw new Error('vault_create_note is not registered')
+
+    const settled = createNote
+      .handler(
+        { title: 'Notes', content_markdown: 'body' },
+        { conversationId: 'conversation-1', windowId: null }
+      )
+      .then(
+        () => 'resolved-as-approved' as const,
+        (error: unknown) => error
+      )
+
+    await delay(APPROVAL_TIMEOUT_TEST_MS * 8)
+
+    await expect(
+      Promise.race([settled, Promise.resolve('still-pending' as const)])
+    ).resolves.toMatchObject({ message: expect.stringContaining('expired') as string })
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('cancels the deadline when the user decides in time', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const { runtime, conversations } = createRuntime('ask', APPROVAL_TIMEOUT_TEST_MS)
+    conversations.getById.mockReturnValue({ id: 'conversation-1', trustList: [] })
+
+    runtime.install()
+    const pending = installedGate()({
+      conversationId: 'conversation-1',
+      toolName: 'vault_create_task',
+      parsedArgs: { title: 'Task' }
+    })
+    const [toolCallId] = broadcastToolCallIds()
+
+    runtime.resolveApproval(toolCallId, { kind: 'allow' })
+    await expect(pending).resolves.toEqual({ approved: true, args: { title: 'Task' } })
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+
+    await delay(APPROVAL_TIMEOUT_TEST_MS * 8)
+
+    // An orphaned timer would fire here and broadcast a failure for a tool call
+    // the user already approved.
+    expect(failedToolCallEvents()).toEqual([])
+    clearTimeoutSpy.mockRestore()
+  })
+
+  /**
+   * Guards the deliberate decision NOT to truncate retained args: `previewDiff`
+   * reads this snapshot to build the approval diff, so a slice would show the
+   * user a partial version of what they are consenting to.
+   */
+  it('keeps the full args a pending approval was raised with', async () => {
+    const { runtime, conversations } = createRuntime('ask')
+    conversations.getById.mockReturnValue({ id: 'conversation-1', trustList: [] })
+
+    runtime.install()
+    const args = { id: 'note-1', content_markdown: 'x'.repeat(64 * 1024) }
+    void installedGate()({
+      conversationId: 'conversation-1',
+      toolName: 'vault_update_note',
+      parsedArgs: args
+    })
+    const [toolCallId] = broadcastToolCallIds()
+
+    expect(runtime.getPendingApproval(toolCallId)?.args).toEqual(args)
+    runtime.cancelTurn('conversation-1')
   })
 
   it('denies pending approvals and clears the MCP write gate on shutdown', async () => {

--- a/apps/desktop/src/main/agent/runtime/runtime.ts
+++ b/apps/desktop/src/main/agent/runtime/runtime.ts
@@ -11,11 +11,29 @@ import { decideToolGate } from './permission-gate'
 
 const logger = createLogger('AgentRuntime')
 
+/**
+ * What a pending approval can settle as. `expired` is runtime-only: the user
+ * never answered and the runtime settled the request itself. It is deliberately
+ * NOT an `ApproveToolDecision` — nothing outside this file may produce it, and
+ * it must never be reported to the user or the model as a denial.
+ */
+type ApprovalOutcome = ApproveToolDecision | { kind: 'expired' }
+
 interface PendingApproval {
-  resolve: (decision: ApproveToolDecision) => void
+  resolve: (outcome: ApprovalOutcome) => void
+  timer: ReturnType<typeof setTimeout>
   conversationId: string
   toolCallId: string
   name: string
+  /**
+   * Kept whole, on purpose. Slicing this frees nothing: it is the same object
+   * the suspended MCP tool handler already holds across its await
+   * (`write-tools.ts` gateOrDeny) and that the gate closure below reads after
+   * its own await. And it is the only source `agent:previewDiff` has for the
+   * approval diff, so a slice would break the preview on exactly the large
+   * notes that would motivate slicing. Bounding the lifetime — the deadline
+   * below — is what actually releases it.
+   */
   args: unknown
   requiresDiff: boolean
 }
@@ -35,13 +53,39 @@ interface TrackedSubprocess {
 // for a hang and lose the escalation entirely when main exits first.
 const KILL_REAP_BUDGET_MS = 1200
 
+// How long an approval may sit unanswered before the runtime settles it itself.
+//
+// Without a deadline the entry lives as long as the app: it pins the parsed
+// args, the suspended MCP tool handler, its HTTP response and socket, and the
+// per-request McpServer behind it — the same chain that blocks server.close()
+// at quit. One prompt left on screen while the user walks away is enough.
+//
+// Half an hour, not the five minutes the issue first suggested. Auto-denying is
+// the one outcome we must not get wrong: the model is told the call did not go
+// through, and a deadline that can elapse while someone reads a diff turns
+// "I stepped away" into "the user refused". Against a leak measured in days,
+// the retention difference between 5 and 30 minutes is noise, while the odds of
+// firing under a reader's hands are not. Deliberately not gated on window
+// focus either — the leak *is* the app sitting in the background, so a
+// focus-gated timer would never fire in the case it exists to bound, and an
+// approval can sit in a window the user is not currently looking at.
+const APPROVAL_TIMEOUT_MS = 30 * 60 * 1000
+
+// Shown to the user in the failed tool call, and handed to the model as the
+// gate's reason. Both have to say "expired", never "denied" — the user did not
+// refuse anything, and the model must not tell them they did.
+const APPROVAL_EXPIRED_MESSAGE =
+  'Approval request expired after 30 minutes with no answer. This was not a denial — the tool did not run; ask again if it is still needed.'
+
 export interface AgentRuntimeDeps {
   conversations: ConversationStore
   messages: MessageStore
   getPreferences?: () => AgentPreferences
+  /** Overridable for tests. Defaults to {@link APPROVAL_TIMEOUT_MS}. */
+  approvalTimeoutMs?: number
 }
 
-export type PendingApprovalSnapshot = Omit<PendingApproval, 'resolve'>
+export type PendingApprovalSnapshot = Omit<PendingApproval, 'resolve' | 'timer'>
 
 function trackApprovalDecided(decision: string, result: 'success' | 'failed'): void {
   trackMainEvent('ai_action_completed', {
@@ -106,10 +150,16 @@ export class AgentRuntime {
       })
       // Shutdown resolves every pending approval as deny; label that
       // abandonment distinctly so the funnel separates it from a real "No".
+      // An expiry is its own label for the same reason: neither is a decision
+      // the user made, and collapsing them into `deny` would overstate how
+      // often people actually refuse a tool call.
       trackApprovalDecided(
         this.isShuttingDown && userDecision.kind === 'deny' ? 'abandoned' : userDecision.kind,
-        userDecision.kind === 'deny' ? 'failed' : 'success'
+        userDecision.kind === 'deny' || userDecision.kind === 'expired' ? 'failed' : 'success'
       )
+      if (userDecision.kind === 'expired') {
+        return { approved: false, reason: APPROVAL_EXPIRED_MESSAGE }
+      }
       if (userDecision.kind === 'deny') {
         return { approved: false, reason: 'User denied request.' }
       }
@@ -124,14 +174,9 @@ export class AgentRuntime {
   }
 
   resolveApproval(toolCallId: string, decision: ApproveToolDecision): void {
-    const pending = this.pending.get(toolCallId)
-    if (!pending) {
+    if (!this.settleApproval(toolCallId, decision)) {
       logger.warn(`Stale approval for ${toolCallId}`)
-      return
     }
-
-    pending.resolve(decision)
-    this.pending.delete(toolCallId)
   }
 
   getPendingApproval(toolCallId: string): PendingApprovalSnapshot | null {
@@ -223,10 +268,9 @@ export class AgentRuntime {
     this.isShuttingDown = true
     setMcpWriteGate(null)
 
-    for (const approval of this.pending.values()) {
-      approval.resolve({ kind: 'deny' })
+    for (const toolCallId of [...this.pending.keys()]) {
+      this.settleApproval(toolCallId, { kind: 'deny' })
     }
-    this.pending.clear()
 
     const tracked = [...this.subprocesses.values()]
     for (const sub of tracked) {
@@ -279,10 +323,9 @@ export class AgentRuntime {
    * never runs.
    */
   private denyPendingApprovals(conversationId: string): void {
-    for (const [toolCallId, approval] of this.pending) {
+    for (const [toolCallId, approval] of [...this.pending]) {
       if (approval.conversationId !== conversationId) continue
-      this.pending.delete(toolCallId)
-      approval.resolve({ kind: 'deny' })
+      this.settleApproval(toolCallId, { kind: 'deny' })
       // The approval card is only ever cleared by a decision event; without
       // this the cancelled turn leaves a dead card the user can still click.
       broadcastAgentEvent({
@@ -294,9 +337,56 @@ export class AgentRuntime {
     }
   }
 
-  private waitForApproval(input: PendingApprovalSnapshot): Promise<ApproveToolDecision> {
+  /**
+   * Nobody answered in time. Settle the awaiting tool call so its MCP handler,
+   * socket and per-request server are released, and clear the card the user
+   * left on screen.
+   *
+   * The code is `APPROVAL_EXPIRED`, not `PERMISSION_DENIED`: the renderer maps
+   * `PERMISSION_DENIED` to the "Denied" chip, which would tell the user they
+   * refused something they never saw a decision on. Any other code lands on the
+   * generic error chip and surfaces the message below, which says what actually
+   * happened. Card clearing does not depend on the code — the reducer drops the
+   * pending approval for every `tool_call_failed`.
+   */
+  private expireApproval(toolCallId: string): void {
+    const approval = this.settleApproval(toolCallId, { kind: 'expired' })
+    if (!approval) return
+
+    logger.warn(`Approval ${toolCallId} expired with no decision`)
+    broadcastAgentEvent({
+      kind: 'tool_call_failed',
+      conversationId: approval.conversationId,
+      toolCallId,
+      error: { code: 'APPROVAL_EXPIRED', message: APPROVAL_EXPIRED_MESSAGE }
+    })
+  }
+
+  /**
+   * The single exit for a pending approval: drop the entry, cancel its
+   * deadline, then resolve. Clearing the timer matters as much as deleting the
+   * entry — an orphaned timer would fire on an id that is gone and, before
+   * `unref`, would also have kept the event loop alive.
+   */
+  private settleApproval(toolCallId: string, outcome: ApprovalOutcome): PendingApproval | null {
+    const approval = this.pending.get(toolCallId)
+    if (!approval) return null
+
+    clearTimeout(approval.timer)
+    this.pending.delete(toolCallId)
+    approval.resolve(outcome)
+    return approval
+  }
+
+  private waitForApproval(input: PendingApprovalSnapshot): Promise<ApprovalOutcome> {
     return new Promise((resolve) => {
-      this.pending.set(input.toolCallId, { ...input, resolve })
+      const timer = setTimeout(
+        () => this.expireApproval(input.toolCallId),
+        this.deps.approvalTimeoutMs ?? APPROVAL_TIMEOUT_MS
+      )
+      // An unanswered prompt must not be the reason the process refuses to exit.
+      timer.unref?.()
+      this.pending.set(input.toolCallId, { ...input, resolve, timer })
     })
   }
 }

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -473,6 +473,12 @@ denied.
 Stopping the turn while an approval is waiting counts as a denial: the pending request is refused,
 the tool never runs, and the approval controls disappear. Nothing is written to your vault.
 
+An approval you never answer expires after 30 minutes. The controls disappear, the tool never runs,
+and the tool row is marked as expired rather than denied — the agent is told the request timed out,
+not that you refused it. Take as long as you need to read a request or its diff; half an hour is
+there so a prompt left open overnight does not keep the request waiting forever, not to hurry you.
+If a request expires and you still want it, ask the agent again.
+
 ## Project Links
 
 `vault_list_projects` returns each project's `icon`, `home_note_id`, and `linked_counts` (notes,


### PR DESCRIPTION
Closes #451. Part of epic #987 (memory/CPU audit 2026-08).

The issue body was stale — it described `inFlight` (deleted by #1308), an `activeTurns` cap (unreachable), and cancel-time clearing (shipped in #1121). I rewrote it before starting; what is below is what is actually left.

## What was wrong

`apps/desktop/src/main/agent/runtime/runtime.ts:297-301` (pre-change):

```ts
private waitForApproval(input: PendingApprovalSnapshot): Promise<ApproveToolDecision> {
  return new Promise((resolve) => {
    this.pending.set(input.toolCallId, { ...input, resolve })
  })
}
```

Nothing settles that promise except a user decision, `denyPendingApprovals` (cancel) or `killAll` (shutdown). An approval nobody answers therefore lives as long as the app, and it is not just a Map entry: it pins the parsed tool args, the suspended MCP tool handler in `write-tools.ts` `gateOrDeny`, that handler's HTTP response and socket, and the per-request `McpServer` behind it — the same chain that blocks `server.close()` at quit. Leaving one prompt on screen and walking away is enough.

## What changed

Every pending approval now gets a deadline. On expiry `expireApproval` settles the awaiting tool call, drops the entry, and broadcasts `tool_call_failed` so the card clears. `settleApproval` became the single exit for a pending approval — it clears the timer, deletes the entry, then resolves — and `resolveApproval`, `denyPendingApprovals` and `killAll` all route through it, so a decided approval never leaves an armed timer behind. The timer is `unref`'d: an unanswered prompt must not be the reason the process refuses to exit.

### UX calls, made deliberately

**30 minutes, not the 5 the issue proposed.** Auto-denying is the one outcome that must not be wrong: the model is told the call did not go through, so a deadline that can elapse while someone reads a request or its diff turns "I stepped away for coffee" into "the user refused". Against a leak measured in days, the retention difference between 5 and 30 minutes is noise; the odds of firing under a reader's hands are not. Exposed as `AgentRuntimeDeps.approvalTimeoutMs` for tests rather than as a user preference — a memory-hygiene backstop does not deserve a settings row, IPC contract surface and translations.

**Not gated on window focus.** Tempting, and wrong twice over: the leak *is* the app sitting in the background, so a focus-gated timer would never fire in the exact case it exists to bound; and an approval can sit in a window the user is not currently looking at while they work in another Memry window. Focus is a bad proxy for attention. The long deadline is what protects the reader, not focus.

**Expired is reported as expired, never as denied**, on all three surfaces:

- **To the user.** The broadcast uses code `APPROVAL_EXPIRED`, not `PERMISSION_DENIED`. `agent-context.reducer.ts:521` maps `PERMISSION_DENIED` to the `output-denied` state, which renders the chip "Denied" — telling someone they refused a request they never got to decide on. Any other code lands on the generic error chip and surfaces the message, which says what actually happened. Card clearing does not depend on the code: the reducer drops the pending approval for every `tool_call_failed`.
- **To the model.** The gate returns `reason: 'Approval request expired after 30 minutes with no answer. This was not a denial — the tool did not run; ask again if it is still needed.'`, so the agent cannot report a refusal back to the user.
- **In telemetry.** Labelled `expired`, alongside the existing `abandoned` label for shutdown. Folding both into `deny` would overstate how often people actually refuse a tool call.

### Deliberately not done

**Not truncating retained `args`** — the issue asked for an 8 KB preview slice. It frees nothing and breaks a feature:

- `pending.args` is the *same object reference* the suspended MCP tool handler already holds. `gateOrDeny` keeps its `GateContext` alive across the await (`write-tools.ts:44-48`, it reads `ctx.parsedArgs` again at line 48), and the runtime's own gate closure reads `ctx.parsedArgs` after its await (`runtime.ts` line 121 pre-change). Slicing the third alias leaves the first two holding the full payload. Bytes freed: zero.
- That retained copy is the only source the approval diff has. `AgentChannels.invoke.PREVIEW_DIFF` runs `TOOL_SCHEMAS.vault_update_note.input.safeParse(pending.args)` (`agent-handlers.ts:270`), so a slice would break the before/after diff on exactly the large-content notes that motivate slicing — and truncating what a user is asked to consent to is not a trade worth making. Bounding the *lifetime* is the fix; bounding the bytes is not. A regression test now locks this in, and the field carries a comment explaining why it stays whole.

**Not wiring archive/delete to `cancelTurn`** — there is no such path. Agent Chat has no archive or delete affordance, and `ConversationStore.softDelete` has zero production callers; only the sync tombstone handler's `applyDelete` can mark a conversation deleted, and nothing in this app can originate that tombstone. Adding a runtime hook for it would be machinery for an unreachable path. The deadline bounds it in the meantime. Noted on the issue for whoever ships conversation delete.

## How it was proven

`apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts`, four new cases: expiry settles as expired and broadcasts `APPROVAL_EXPIRED` (asserting the reason contains "expired" and not "denied", and the code is not `PERMISSION_DENIED`); the awaiting write tool fails with the expiry message and `notes.create` is never called; a decision in time cancels the deadline and no stray failure event fires afterwards; and full args survive on the pending snapshot.

Source reverted to `origin/main` with the new tests in place (`git checkout origin/main -- runtime.ts`, no stash):

- **before: 3 failed | 9 passed (12)**
- **after: 12 passed (12)**

The args-retention test passes on both sides by design — it guards a deliberate non-change.

## Verification

| Command | Result |
| --- | --- |
| `vitest run --project main .../runtime-approval.test.ts` | 12 passed |
| `vitest run --project main src/main/agent src/main/ipc/agent-handlers.test.ts` | 60 files, 450 passed |
| `pnpm --filter @memry/desktop typecheck:node` | clean |
| `pnpm exec eslint apps/desktop/src/main/agent/runtime/runtime.ts` | 0 errors |
| `git diff --check` | clean |
| `pnpm docs:impact --base origin/main --strict` | `covered` |
| `pnpm docs:build` | build complete |

## Backward compatibility

Main-process only; no schema, sync payload, settings or IPC contract change. `AgentEvent.error.code` is already `z.string()`, so `APPROVAL_EXPIRED` needs no contract edit and an older renderer would render it on the generic error path rather than crash.
