### PR TITLE
perf(sync): cap the main-process corrupt-item, quarantine and worker-bridge maps

### DIFF
--- a/apps/desktop/src/main/sync/engine/corrupt-item-tracker.test.ts
+++ b/apps/desktop/src/main/sync/engine/corrupt-item-tracker.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { CorruptItemTracker } from './corrupt-item-tracker'
-import { CORRUPT_ITEM_COOLDOWN_MS } from './sync-context'
+import { CORRUPT_ITEM_COOLDOWN_MS, MAX_CORRUPT_ITEMS } from './sync-context'
 import type { SyncContext } from './sync-context'
 import type { QuarantineManager } from './quarantine-manager'
 import { postToServer } from '../http-client'
@@ -140,6 +140,57 @@ describe('CorruptItemTracker', () => {
 
         expect(tracker.shouldRetry({ id: 'item-1', type: 'task' })).toBe(true)
         expect(tracker.shouldRetry({ id: 'item-2', type: 'task' })).toBe(true)
+      })
+    })
+  })
+
+  describe('cap enforcement', () => {
+    describe('#given more failures than the cap #when markFailed called', () => {
+      it('#then keeps exactly MAX_CORRUPT_ITEMS entries on cooldown', () => {
+        const tracker = createTracker()
+
+        for (let i = 0; i < MAX_CORRUPT_ITEMS + 250; i++) {
+          tracker.markFailed({ id: `item-${i}`, type: 'task' })
+        }
+
+        let onCooldown = 0
+        for (let i = 0; i < MAX_CORRUPT_ITEMS + 250; i++) {
+          if (!tracker.shouldRetry({ id: `item-${i}`, type: 'task' })) onCooldown++
+        }
+        expect(onCooldown).toBe(MAX_CORRUPT_ITEMS)
+      })
+
+      it('#then evicts the coldest entries first and keeps the newest', () => {
+        const tracker = createTracker()
+
+        for (let i = 0; i < MAX_CORRUPT_ITEMS; i++) {
+          tracker.markFailed({ id: `item-${i}`, type: 'task' })
+        }
+        // #when — one more entry pushes the map over the cap
+        tracker.markFailed({ id: 'newest', type: 'task' })
+
+        // #then — the oldest failedAt lost its cooldown, the newest kept it
+        expect(tracker.shouldRetry({ id: 'item-0', type: 'task' })).toBe(true)
+        expect(tracker.shouldRetry({ id: 'item-1', type: 'task' })).toBe(false)
+        expect(tracker.shouldRetry({ id: 'newest', type: 'task' })).toBe(false)
+      })
+    })
+
+    describe('#given a re-failed old entry #when the cap is exceeded', () => {
+      it('#then the refreshed entry survives and a colder one is evicted', () => {
+        const tracker = createTracker()
+
+        for (let i = 0; i < MAX_CORRUPT_ITEMS; i++) {
+          tracker.markFailed({ id: `item-${i}`, type: 'task' })
+        }
+        // item-0 is the coldest; failing it again must make it the hottest.
+        vi.advanceTimersByTime(1000)
+        tracker.markFailed({ id: 'item-0', type: 'task' })
+
+        tracker.markFailed({ id: 'newest', type: 'task' })
+
+        expect(tracker.shouldRetry({ id: 'item-0', type: 'task' })).toBe(false)
+        expect(tracker.shouldRetry({ id: 'item-1', type: 'task' })).toBe(true)
       })
     })
   })

--- a/apps/desktop/src/main/sync/engine/corrupt-item-tracker.ts
+++ b/apps/desktop/src/main/sync/engine/corrupt-item-tracker.ts
@@ -6,7 +6,7 @@ import { withRetry } from '../retry'
 import { postToServer } from '../http-client'
 import type { SyncContext } from './sync-context'
 import type { QuarantineManager } from './quarantine-manager'
-import { CORRUPT_ITEM_COOLDOWN_MS, itemRefKey } from './sync-context'
+import { CORRUPT_ITEM_COOLDOWN_MS, MAX_CORRUPT_ITEMS, itemRefKey } from './sync-context'
 
 const log = createLogger('CorruptItemTracker')
 
@@ -27,7 +27,14 @@ export interface RecoveredItem {
 }
 
 export class CorruptItemTracker {
+  /**
+   * (type, id) -> cooldown entry, capped at MAX_CORRUPT_ITEMS.
+   *
+   * Insertion order is kept equal to `failedAt` order (see `markFailed`), so
+   * eviction is "delete from the front" without a sort.
+   */
   private corruptItems = new Map<string, { failedAt: number; attempts: number }>()
+  private evictionLogged = false
   private ctx: SyncContext
   private quarantine: QuarantineManager
   private resolveDeviceKey: ResolveDeviceKey
@@ -49,13 +56,21 @@ export class CorruptItemTracker {
   }
 
   markFailed(ref: ItemRef): void {
-    const entry = this.corruptItems.get(itemRefKey(ref.type, ref.id))
+    const key = itemRefKey(ref.type, ref.id)
+    const entry = this.corruptItems.get(key)
     if (entry) {
       entry.attempts++
       entry.failedAt = Date.now()
+      // Re-insert so Map iteration order stays `failedAt` order. `set` on an
+      // existing key does not move it, and `failedAt` is mutated in place, so
+      // without this the eviction below would drop arbitrary entries instead of
+      // the coldest ones.
+      this.corruptItems.delete(key)
+      this.corruptItems.set(key, entry)
     } else {
-      this.corruptItems.set(itemRefKey(ref.type, ref.id), { failedAt: Date.now(), attempts: 1 })
+      this.corruptItems.set(key, { failedAt: Date.now(), attempts: 1 })
     }
+    this.evictOverflow()
   }
 
   clearExpired(): void {
@@ -69,6 +84,35 @@ export class CorruptItemTracker {
 
   clear(): void {
     this.corruptItems.clear()
+    this.evictionLogged = false
+  }
+
+  /**
+   * Keep the map at MAX_CORRUPT_ITEMS. Expired entries go first (they are dead
+   * weight already), then the oldest `failedAt` entries — the ones whose
+   * cooldown is closest to lapsing. An evicted entry only means the item is
+   * eligible for one more re-fetch on the next pull that carries it, never a
+   * hot loop: the very next failure re-inserts the cooldown.
+   */
+  private evictOverflow(): void {
+    if (this.corruptItems.size <= MAX_CORRUPT_ITEMS) return
+    this.clearExpired()
+
+    let overflow = this.corruptItems.size - MAX_CORRUPT_ITEMS
+    if (overflow <= 0) return
+
+    for (const key of this.corruptItems.keys()) {
+      if (overflow <= 0) break
+      this.corruptItems.delete(key)
+      overflow--
+    }
+
+    if (!this.evictionLogged) {
+      this.evictionLogged = true
+      log.warn('Corrupt-item tracker at cap — evicting coldest entries', {
+        cap: MAX_CORRUPT_ITEMS
+      })
+    }
   }
 
   async refetch(

--- a/apps/desktop/src/main/sync/engine/pull-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/pull-coordinator.ts
@@ -410,6 +410,11 @@ export class PullCoordinator {
 
   private cleanupAfterPull(vaultKey: Uint8Array | null, cleanup: () => void): void {
     this.deviceKeyCache.clear()
+    // Cooldown entries otherwise only expire when a later pull happens to
+    // re-fetch the same item, so a burst of corruption that then stops leaves
+    // the tracker holding every entry for the rest of the session. Sweeping
+    // here is O(entries) once per pull and drops nothing that is still live.
+    this.corruptTracker.clearExpired()
     try {
       if (vaultKey) secureCleanup(vaultKey)
     } finally {

--- a/apps/desktop/src/main/sync/engine/quarantine-manager.test.ts
+++ b/apps/desktop/src/main/sync/engine/quarantine-manager.test.ts
@@ -2,7 +2,23 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { eq } from 'drizzle-orm'
 import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
 import { QuarantineManager } from './quarantine-manager'
-import { QUARANTINE_MAX_ATTEMPTS, SYNC_STATE_KEYS } from './sync-context'
+import {
+  QUARANTINE_MAX_ATTEMPTS,
+  QUARANTINE_ENTRY_TTL_MS,
+  MAX_QUARANTINE_ENTRIES,
+  SYNC_STATE_KEYS
+} from './sync-context'
+
+// The cap tests quarantine tens of thousands of items; the real logger and the
+// real telemetry sink would turn that into tens of thousands of log lines and
+// events. Nothing in this file asserts on either.
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+vi.mock('../../telemetry/diagnostics', () => ({
+  trackMainError: vi.fn()
+}))
 import type { SyncContext } from './sync-context'
 import { syncState } from '@memry/db-schema/schema/sync-state'
 import { EVENT_CHANNELS } from '@memry/contracts/ipc-events'
@@ -284,6 +300,107 @@ describe('QuarantineManager', () => {
       // #then
       expect(fresh.isQuarantined('round-trip', 'project')).toBe(true)
       expect(fresh.getQuarantinedItems()[0].lastError).toBe('err')
+    })
+  })
+
+  describe('in-session TTL sweep', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('#given an entry older than the TTL #when another item is quarantined #then the stale entry is dropped', () => {
+      // #given
+      manager.quarantineItem('stale', 'task', 'device-a', 'bad sig')
+
+      // #when — a session that never restarts crosses the same TTL loadState uses
+      vi.advanceTimersByTime(QUARANTINE_ENTRY_TTL_MS + 1)
+      manager.quarantineItem('fresh', 'task', 'device-a', 'bad sig')
+
+      // #then
+      const ids = manager.getQuarantinedItems().map((i) => i.itemId)
+      expect(ids).toEqual(['fresh'])
+    })
+
+    it('#given a permanent entry inside the TTL #when another item is quarantined #then it is kept', () => {
+      // #given
+      for (let i = 0; i < QUARANTINE_MAX_ATTEMPTS; i++) {
+        manager.quarantineItem('perm', 'task', 'device-a', 'bad sig')
+      }
+
+      // #when
+      vi.advanceTimersByTime(QUARANTINE_ENTRY_TTL_MS - 1000)
+      manager.quarantineItem('fresh', 'task', 'device-a', 'bad sig')
+
+      // #then — still protecting the vault from the bad item
+      expect(manager.isQuarantined('perm', 'task')).toBe(true)
+    })
+  })
+
+  describe('cap enforcement', () => {
+    it('#given more non-permanent entries than the cap #when quarantining #then the map stays at the cap', () => {
+      // #when
+      for (let i = 0; i < MAX_QUARANTINE_ENTRIES + 100; i++) {
+        manager.quarantineItem(`item-${i}`, 'task', 'device-a', 'bad sig')
+      }
+
+      // #then
+      expect(manager.getQuarantinedItems()).toHaveLength(MAX_QUARANTINE_ENTRIES)
+    })
+
+    it('#given the cap is exceeded #when evicting #then the coldest entry goes and the newest stays', () => {
+      // #given
+      for (let i = 0; i < MAX_QUARANTINE_ENTRIES; i++) {
+        manager.quarantineItem(`item-${i}`, 'task', 'device-a', 'bad sig')
+      }
+
+      // #when
+      manager.quarantineItem('newest', 'task', 'device-a', 'bad sig')
+
+      // #then
+      const ids = new Set(manager.getQuarantinedItems().map((i) => i.itemId))
+      expect(ids.has('item-0')).toBe(false)
+      expect(ids.has('item-1')).toBe(true)
+      expect(ids.has('newest')).toBe(true)
+    })
+
+    it('#given a permanent entry is the coldest #when the cap is exceeded #then it survives and a non-permanent one is evicted', () => {
+      // #given — the oldest entry is a permanent quarantine
+      for (let i = 0; i < QUARANTINE_MAX_ATTEMPTS; i++) {
+        manager.quarantineItem('perm', 'task', 'device-a', 'bad sig')
+      }
+      for (let i = 0; i < MAX_QUARANTINE_ENTRIES; i++) {
+        manager.quarantineItem(`item-${i}`, 'task', 'device-a', 'bad sig')
+      }
+
+      // #then — the permanent record is never the thing that gets dropped
+      expect(manager.isQuarantined('perm', 'task')).toBe(true)
+      const ids = new Set(manager.getQuarantinedItems().map((i) => i.itemId))
+      expect(ids.has('item-0')).toBe(false)
+    })
+
+    it('#given eviction happened #when a new permanent entry persists #then persisted permanents are intact', () => {
+      // #given — one permanent entry, then enough traffic to force evictions
+      for (let i = 0; i < QUARANTINE_MAX_ATTEMPTS; i++) {
+        manager.quarantineItem('perm', 'task', 'device-a', 'bad sig')
+      }
+      for (let i = 0; i < MAX_QUARANTINE_ENTRIES + 100; i++) {
+        manager.quarantineItem(`item-${i}`, 'task', 'device-a', 'bad sig')
+      }
+
+      // #when — a second permanent entry triggers a re-serialise of the map
+      for (let i = 0; i < QUARANTINE_MAX_ATTEMPTS; i++) {
+        manager.quarantineItem('perm-2', 'note', 'device-b', 'bad sig')
+      }
+
+      // #then — eviction never removed a permanent record from disk
+      const fresh = new QuarantineManager(ctx)
+      fresh.loadState()
+      expect(fresh.isQuarantined('perm', 'task')).toBe(true)
+      expect(fresh.isQuarantined('perm-2', 'note')).toBe(true)
     })
   })
 

--- a/apps/desktop/src/main/sync/engine/quarantine-manager.ts
+++ b/apps/desktop/src/main/sync/engine/quarantine-manager.ts
@@ -9,13 +9,20 @@ import {
   SYNC_STATE_KEYS,
   QUARANTINE_MAX_ATTEMPTS,
   QUARANTINE_ENTRY_TTL_MS,
+  MAX_QUARANTINE_ENTRIES,
   itemRefKey
 } from './sync-context'
 
 const log = createLogger('QuarantineManager')
 
 export class QuarantineManager {
+  /**
+   * (type, id) -> quarantine entry. Insertion order is kept equal to `failedAt`
+   * order (see `quarantineItem`) so `evictOverflow` can walk it coldest-first
+   * without a sort.
+   */
   private quarantinedItems = new Map<string, QuarantineEntry>()
+  private evictionLogged = false
   private ctx: SyncContext
 
   constructor(ctx: SyncContext) {
@@ -23,11 +30,15 @@ export class QuarantineManager {
   }
 
   quarantineItem(itemId: string, itemType: string, signerDeviceId: string, error: string): void {
-    const existing = this.quarantinedItems.get(itemRefKey(itemType, itemId))
+    const key = itemRefKey(itemType, itemId)
+    const existing = this.quarantinedItems.get(key)
     const attemptCount = existing ? existing.attemptCount + 1 : 1
     const permanent = attemptCount >= QUARANTINE_MAX_ATTEMPTS
 
-    this.quarantinedItems.set(itemRefKey(itemType, itemId), {
+    // Delete before set: `set` on an existing key leaves it where it was, and
+    // the entry's `failedAt` has just moved forward.
+    this.quarantinedItems.delete(key)
+    this.quarantinedItems.set(key, {
       itemId,
       itemType,
       signerDeviceId,
@@ -35,6 +46,8 @@ export class QuarantineManager {
       attemptCount,
       lastError: error
     })
+    this.sweepExpired()
+    this.evictOverflow()
 
     log.warn('SECURITY_AUDIT: Signature verification failed', {
       itemId,
@@ -124,6 +137,64 @@ export class QuarantineManager {
 
   clear(): void {
     this.quarantinedItems.clear()
+    this.evictionLogged = false
+  }
+
+  /**
+   * Drop entries past QUARANTINE_ENTRY_TTL_MS — the same filter `loadState()`
+   * applies to persisted entries on startup, just applied while the process
+   * keeps running. Before this, a session that never restarted held every
+   * quarantine it ever created, including ones for server rows repaired or
+   * purged weeks earlier. A still-broken item re-quarantines within
+   * QUARANTINE_MAX_ATTEMPTS pulls, which is exactly what a restart already did.
+   */
+  private sweepExpired(): void {
+    const now = Date.now()
+    let dropped = 0
+    for (const [key, entry] of this.quarantinedItems) {
+      if (now - entry.failedAt < QUARANTINE_ENTRY_TTL_MS) continue
+      this.quarantinedItems.delete(key)
+      dropped++
+    }
+    if (dropped > 0) {
+      log.info('Expired stale quarantine entries', { dropped })
+    }
+  }
+
+  /**
+   * Bound the map at MAX_QUARANTINE_ENTRIES by dropping the coldest
+   * NON-permanent entries only.
+   *
+   * A non-permanent entry is an attempt counter and nothing else: evicting one
+   * gives the item a fresh QUARANTINE_MAX_ATTEMPTS window, so the worst case is
+   * a few extra decrypt attempts before it is branded again. A permanent entry
+   * is what keeps a failed-signature item out of the vault, and `persistState`
+   * serialises this map — evicting one would drop it from disk too. So the cap
+   * is deliberately soft: if every entry is permanent the map is allowed to
+   * exceed it.
+   */
+  private evictOverflow(): void {
+    if (this.quarantinedItems.size <= MAX_QUARANTINE_ENTRIES) return
+
+    let overflow = this.quarantinedItems.size - MAX_QUARANTINE_ENTRIES
+    let evicted = 0
+    for (const [key, entry] of this.quarantinedItems) {
+      if (overflow <= 0) break
+      if (entry.attemptCount >= QUARANTINE_MAX_ATTEMPTS) continue
+      this.quarantinedItems.delete(key)
+      overflow--
+      evicted++
+    }
+
+    if (this.evictionLogged) return
+    this.evictionLogged = true
+    log.warn('Quarantine map at cap', {
+      cap: MAX_QUARANTINE_ENTRIES,
+      evicted,
+      // > 0 means the cap could not be honoured: every remaining entry is a
+      // permanent quarantine and dropping one would re-admit a bad item.
+      permanentOverflow: overflow
+    })
   }
 
   private persistState(): void {

--- a/apps/desktop/src/main/sync/engine/sync-context.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.ts
@@ -100,8 +100,33 @@ export const MAX_PUSH_ITERATIONS = 50
 export const CLOCK_SKEW_THRESHOLD_SECONDS = 300
 export const PULL_PAGE_LIMIT = 100
 export const CORRUPT_ITEM_COOLDOWN_MS = 60 * 60 * 1000
+/**
+ * Hard cap on live corrupt-item cooldown entries.
+ *
+ * Each entry is only a (type, id) key plus two numbers, so 5,000 costs well
+ * under a megabyte — but nothing bounded the map before, and a server-side
+ * poisoned-payload event (2026-07-18 class) marks every item of a failing page
+ * on every pull for a whole hour. Overflow evicts the oldest `failedAt` first:
+ * those are the entries closest to expiring anyway, so the only thing an
+ * eviction can cost is one extra re-fetch attempt for an item that was already
+ * eligible to retry minutes later.
+ */
+export const MAX_CORRUPT_ITEMS = 5000
 export const QUARANTINE_MAX_ATTEMPTS = 3
 export const QUARANTINE_ENTRY_TTL_MS = 7 * 24 * 60 * 60 * 1000
+/**
+ * Soft cap on in-memory quarantine entries.
+ *
+ * Deliberately soft: only entries below QUARANTINE_MAX_ATTEMPTS are evictable.
+ * Those are pure attempt counters — losing one costs the item a fresh set of
+ * attempts, and it re-quarantines within QUARANTINE_MAX_ATTEMPTS pulls if it is
+ * still broken. Permanent entries are the record that keeps a failed-signature
+ * item out of the vault, and `persistState()` serialises the map, so evicting
+ * one would also erase it from disk. They are never evicted here; if a session
+ * somehow accumulates more than this many permanent quarantines the map is
+ * allowed to exceed the cap and the overflow is logged instead.
+ */
+export const MAX_QUARANTINE_ENTRIES = 10_000
 export const STALE_CURSOR_THRESHOLD_MS = 24 * 60 * 60 * 1000
 export const MAX_RATE_LIMIT_BACKOFF_MS = 5 * 60 * 1000
 export const BASE_RATE_LIMIT_BACKOFF_MS = 5_000

--- a/apps/desktop/src/main/sync/worker-bridge.test.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.test.ts
@@ -43,7 +43,7 @@ vi.mock('../lib/logger', () => ({
   createLogger: () => logger
 }))
 
-import { MAX_CONSECUTIVE_FAILURES, SyncWorkerBridge } from './worker-bridge'
+import { MAX_CONSECUTIVE_FAILURES, MAX_PENDING_REQUESTS, SyncWorkerBridge } from './worker-bridge'
 
 describe('SyncWorkerBridge', () => {
   let bridge: SyncWorkerBridge
@@ -597,6 +597,96 @@ describe('SyncWorkerBridge', () => {
 
       // #then — a fresh thread is not the thread that failed
       expect(bridge.isRunning).toBe(true)
+    })
+  })
+
+  describe('#given running bridge #when pending requests are never answered', () => {
+    const startReadyBridge = async (): Promise<void> => {
+      const p = bridge.start()
+      mockWorkerInstance.simulateMessage({ type: 'ready' })
+      await p
+    }
+
+    const sendUnanswered = (): Promise<unknown> => {
+      const request = bridge.encryptBatch([], new Uint8Array(32), new Uint8Array(64), 'device-1')
+      request.catch(() => {})
+      return request
+    }
+
+    it('#then rejects once the pending map is at MAX_PENDING_REQUESTS', async () => {
+      // #given — the worker accepts requests and never replies
+      await startReadyBridge()
+      for (let i = 0; i < MAX_PENDING_REQUESTS; i++) sendUnanswered()
+
+      // #when / #then
+      await expect(
+        bridge.encryptBatch([], new Uint8Array(32), new Uint8Array(64), 'device-1')
+      ).rejects.toThrow('Worker request queue full')
+    })
+
+    it('#then the rejected request is never posted to the worker', async () => {
+      // #given
+      await startReadyBridge()
+      for (let i = 0; i < MAX_PENDING_REQUESTS; i++) sendUnanswered()
+
+      // #when
+      await bridge
+        .encryptBatch([], new Uint8Array(32), new Uint8Array(64), 'device-1')
+        .catch(() => {})
+
+      // #then — capped requests cost nothing: no message, no pending entry
+      const posted = mockWorkerInstance.postMessage.mock.calls.filter(
+        ([m]) => m.type === 'encrypt-batch'
+      )
+      expect(posted).toHaveLength(MAX_PENDING_REQUESTS)
+    })
+
+    it('#then a request whose own timeout never fired is swept', async () => {
+      // #given
+      await startReadyBridge()
+      const request = sendUnanswered()
+
+      // #when — the wall clock moves past the stale threshold without advancing
+      // the timer queue, so the request's own 60s timeout has not fired
+      vi.setSystemTime(Date.now() + 70_000)
+      vi.advanceTimersByTime(30_000)
+
+      // #then
+      await expect(request).rejects.toThrow('Worker request abandoned')
+    })
+
+    it('#then the sweep never preempts a live per-request timeout', async () => {
+      // #given
+      await startReadyBridge()
+      const request = sendUnanswered()
+
+      // #when — real elapsed time, so the 60s request timeout owns the failure
+      vi.advanceTimersByTime(61_000)
+
+      // #then
+      await expect(request).rejects.toThrow('Worker request timed out')
+    })
+
+    it('#then no timer is left running once the last request settles', async () => {
+      // #given
+      await startReadyBridge()
+      const request = bridge.encryptBatch([], new Uint8Array(32), new Uint8Array(64), 'device-1')
+      const posted = mockWorkerInstance.postMessage.mock.calls.find(
+        ([m]) => m.type === 'encrypt-batch'
+      )![0]
+      expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+      // #when
+      mockWorkerInstance.simulateMessage({
+        type: 'encrypt-batch-result',
+        requestId: posted.requestId,
+        results: [],
+        errors: []
+      })
+      await request
+
+      // #then — the sweep interval is not left ticking for the session
+      expect(vi.getTimerCount()).toBe(0)
     })
   })
 

--- a/apps/desktop/src/main/sync/worker-bridge.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.ts
@@ -18,9 +18,36 @@ type PendingRequest = {
   resolve: (value: WorkerToMainMessage) => void
   reject: (error: Error) => void
   timer: ReturnType<typeof setTimeout>
+  startedAt: number
 }
 
 const REQUEST_TIMEOUT_MS = 60_000
+
+/**
+ * Hard cap on simultaneously in-flight worker requests.
+ *
+ * Nothing bounded `pendingRequests` before: every entry pins the caller's
+ * promise callbacks, which close over the request's items, vault key and
+ * signing key. Sync only ever has a handful of batches in flight, so anything
+ * near this number means the worker has stopped answering and requests are
+ * stacking up faster than they time out. Rejecting at the door makes the caller
+ * fall back to main-thread crypto — same crypto, same result — and three such
+ * rejections latch the bridge off for the session (see recordRequestFailure).
+ */
+export const MAX_PENDING_REQUESTS = 1000
+
+/** How often the stale-pending sweep runs while requests are outstanding. */
+const PENDING_SWEEP_INTERVAL_MS = 30_000
+
+/**
+ * Age at which the sweep considers a pending request abandoned.
+ *
+ * Deliberately past REQUEST_TIMEOUT_MS: the per-request timer is the primary
+ * path and must keep owning the timeout, so the sweep can only ever collect an
+ * entry whose own timer never fired. The grace period keeps the two from racing
+ * on the same request.
+ */
+const PENDING_STALE_AFTER_MS = REQUEST_TIMEOUT_MS + 5_000
 
 /**
  * Consecutive failed worker requests before the bridge stops offering itself.
@@ -45,6 +72,7 @@ export class SyncWorkerBridge {
   private requestCounter = 0
   private consecutiveFailures = 0
   private latchedOff = false
+  private sweepTimer: ReturnType<typeof setInterval> | null = null
 
   async start(): Promise<void> {
     if (this.worker) return
@@ -115,6 +143,7 @@ export class SyncWorkerBridge {
         if (pending) {
           clearTimeout(pending.timer)
           this.pendingRequests.delete(msg.requestId)
+          if (this.pendingRequests.size === 0) this.stopSweepTimer()
           pending.resolve(msg)
           return
         }
@@ -155,6 +184,41 @@ export class SyncWorkerBridge {
       pending.reject(err)
       this.pendingRequests.delete(id)
     }
+    this.stopSweepTimer()
+  }
+
+  /**
+   * Backstop for pending entries whose own timeout never fired — the map is
+   * otherwise only ever drained by a reply, a per-request timer, or rejectAll.
+   * The interval exists only while requests are outstanding and stops itself as
+   * soon as the map empties, so an idle bridge costs no wakeups.
+   */
+  private ensureSweepTimer(): void {
+    if (this.sweepTimer) return
+    this.sweepTimer = setInterval(() => this.sweepStalePending(), PENDING_SWEEP_INTERVAL_MS)
+    this.sweepTimer.unref?.()
+  }
+
+  private stopSweepTimer(): void {
+    if (!this.sweepTimer) return
+    clearInterval(this.sweepTimer)
+    this.sweepTimer = null
+  }
+
+  private sweepStalePending(): void {
+    const now = Date.now()
+    let swept = 0
+    for (const [id, pending] of this.pendingRequests) {
+      if (now - pending.startedAt <= PENDING_STALE_AFTER_MS) continue
+      clearTimeout(pending.timer)
+      this.pendingRequests.delete(id)
+      pending.reject(new Error('Worker request abandoned: no reply and no timeout'))
+      swept++
+    }
+    if (swept > 0) {
+      log.warn('Swept abandoned worker requests', { count: swept })
+    }
+    if (this.pendingRequests.size === 0) this.stopSweepTimer()
   }
 
   /**
@@ -197,13 +261,25 @@ export class SyncWorkerBridge {
       return Promise.reject(new Error('Worker not started'))
     }
 
+    if (this.pendingRequests.size >= MAX_PENDING_REQUESTS) {
+      // Never enqueued, so nothing to sweep later. The caller degrades to
+      // main-thread crypto rather than waiting behind a wedged worker.
+      log.warn('Worker request queue full — rejecting request', {
+        pending: this.pendingRequests.size,
+        cap: MAX_PENDING_REQUESTS
+      })
+      return Promise.reject(new Error('Worker request queue full'))
+    }
+
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingRequests.delete(msg.requestId)
+        if (this.pendingRequests.size === 0) this.stopSweepTimer()
         reject(new Error(`Worker request timed out: ${msg.type}`))
       }, REQUEST_TIMEOUT_MS)
 
-      this.pendingRequests.set(msg.requestId, { resolve, reject, timer })
+      this.pendingRequests.set(msg.requestId, { resolve, reject, timer, startedAt: Date.now() })
+      this.ensureSweepTimer()
       this.worker!.postMessage(msg)
     })
   }

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -118,6 +118,20 @@ broken the item re-quarantines within a few pulls, and if it was repaired server
 again without an emergency wipe. The manifest-check throttle (30 minutes) persists in sync state, so
 engine restarts and vault switches cannot re-arm an immediate check.
 
+Both of those in-memory ledgers are bounded, because a server-side incident can brand a very large
+number of items in a single session. The corrupt-item tracker holds at most 5,000 cooldown entries
+and sheds the coldest ones first; the coldest entry is also the one closest to its one-hour cooldown
+lapsing, so the most an eviction can cost is one extra re-fetch for an item that was about to become
+eligible anyway. Expired entries are also swept at the end of every pull, not only when a later pull
+happens to touch the same item.
+
+The quarantine ledger applies the same 7-day expiry to live entries that it already applied to
+persisted ones, so a long-running session behaves like a restart. Its 10,000-entry cap is
+deliberately soft: only entries that have not yet reached the permanent threshold can be evicted,
+because those are attempt counters and a still-broken item simply re-quarantines. Permanent
+quarantines are the record that keeps a failed-signature item out of the vault and are never dropped
+to satisfy the cap.
+
 ### Push acknowledgements and in-flight mutations
 
 The push queue coalesces: a new mutation for an item that already has an unattempted row overwrites
@@ -664,6 +678,12 @@ the session its worker — so a successful batch resets the count and only conse
 Waiting longer is expensive, because the penalty is paid in whole minutes. The thread is left alive
 rather than terminated, and restarting the sync runtime gives the bridge a fresh worker and a clean
 count.
+
+In-flight requests are bounded too. Each one carries the batch's items and key material until it is
+answered, so the bridge refuses to hold more than 1,000 at once; past that point requests are
+rejected at the door and fall to the main thread, which is the same degradation a wedged worker
+already triggers. A sweep runs while requests are outstanding and collects any request that outlived
+its own timeout, and it stops itself as soon as nothing is pending, so an idle bridge costs nothing.
 
 Shutting the bridge down asks the worker to exit and waits three seconds before terminating it. A
 worker that misses that window is fully detached first, so the exit that terminating eventually


### PR DESCRIPTION
Closes #450. Part of epic #987 (memory/CPU audit 2026-08).

I also edited the issue body before opening this: the crdt-queue bullet is struck out as already covered (#995 → PR #1118 coalescing + shutdown persistence, #1141 → PR #1258 byte caps), and the "20k corrupt items / 5k quarantines / 2 worker restarts" chaos test is downgraded to unit-level cap and eviction-order criteria, which is what this PR ships.

## What was wrong

Three main-process sync maps had no bound at all.

**`engine/corrupt-item-tracker.ts:30`** — `corruptItems` grew freely. `clearExpired()` only dropped entries past the 1-hour cooldown, and the only call site was `pull-coordinator.ts:772`, gated on `allRefetchRefs.length > 0 && pageApplied > 0`. A burst of corruption that then stops leaves every entry resident until a later pull happens to carry a corrupt item again.

**`engine/quarantine-manager.ts:18`** — `quarantinedItems` had no runtime eviction of any kind. Persistence already filtered (`:131` writes permanent entries only, `:94` drops entries past `QUARANTINE_ENTRY_TTL_MS = 7d` on load), so a restart cleaned up; a session that never restarts never did.

**`sync/worker-bridge.ts:193-209`** — `sendRequest` set into `pendingRequests` unconditionally:

```ts
this.pendingRequests.set(msg.requestId, { resolve, reject, timer })
this.worker!.postMessage(msg)
```

Each entry pins the caller's promise callbacks, which close over the batch items, the vault key and the signing key. `rejectAll` on exit/error exists and #1092 → PR #1262 fixed the stale exit listener, but nothing capped concurrent pending requests and nothing collected an entry whose own timer never fired.

## What changed

**corrupt-item-tracker** — `MAX_CORRUPT_ITEMS = 5000`. `markFailed` now re-inserts an existing key (delete-then-set) so Map insertion order stays equal to `failedAt` order; overflow then runs `clearExpired()` first and, if still over, deletes from the front. No sort, O(1) amortised. `clearExpired()` is additionally called from `pull-coordinator.cleanupAfterPull`, so it runs once per pull regardless of whether that pull hit any corruption.

**quarantine-manager** — added an in-session `sweepExpired()` using the same `QUARANTINE_ENTRY_TTL_MS` that `loadState` already applies, plus a **soft** cap `MAX_QUARANTINE_ENTRIES = 10_000` that evicts only entries below `QUARANTINE_MAX_ATTEMPTS`.

**worker-bridge** — `MAX_PENDING_REQUESTS = 1000`; over that, `sendRequest` rejects with `Worker request queue full` *before* enqueueing or posting. Added a 30s sweep that collects pending entries older than `REQUEST_TIMEOUT_MS + 5s`; the interval is created lazily on the first pending request, `unref`'d, and stopped as soon as the map empties, so an idle bridge costs no wakeups.

### What each eviction can and cannot lose

- **Corrupt-item eviction can lose:** one item's remaining cooldown. It cannot cause a hot retry loop — the entry only suppresses a *re-fetch* of an item that failed decryption on the current page, and the very next failure re-inserts the cooldown. Eviction is coldest-`failedAt`-first, i.e. the entries closest to expiring on their own, so the realistic cost is one extra re-fetch minutes early.
- **Quarantine eviction can lose:** a non-permanent attempt counter. Worst case the item gets a fresh `QUARANTINE_MAX_ATTEMPTS` window and is branded permanent again a few pulls later.
- **Quarantine eviction cannot lose a permanent quarantine.** This is why the cap is soft rather than hard. `persistState()` serialises the whole map, so evicting a permanent entry would also erase it from disk and re-admit an item that failed signature verification three times. `evictOverflow` skips permanent entries entirely; if every entry is permanent the map is allowed to exceed the cap and the overflow is logged instead. A test asserts the persisted permanents survive an eviction pass.
- **The TTL sweep can drop a permanent entry** once it is 7 days old — which is exactly what `loadState` has always done to the same entry on the next restart. It makes a never-restarted session behave like a restarted one, and a still-broken item re-quarantines within `QUARANTINE_MAX_ATTEMPTS` pulls.
- **Worker-bridge rejections lose nothing.** A rejected or swept request degrades to main-thread crypto, which runs the same code on the same inputs; three such failures latch the bridge off for the session, which is the existing documented behaviour for a wedged worker.

### Deliberately not done

- **The sweep threshold is `REQUEST_TIMEOUT_MS + 5s`, not 30s.** The issue asked for a sweep that rejects "requests older than threshold" every 30s. Rejecting at 30s would kill legitimately slow large batches that the worker would still answer, and count them toward the latch — a correctness regression traded for nothing. The per-request 60s timer stays the primary path; the sweep only ever collects an entry whose own timer did not fire, and a test asserts it does not preempt a live timeout.
- **No global byte budget on `crdt-queue`** — already covered by #1118 and #1258. Worth flagging for a follow-up: `crdt-queue.ts:34` `buffers` is keyed per noteId with per-note byte caps but **no cross-note total budget**, so a long offline session across many notes still grows by note count. Out of scope here.
- **No cap on `QuarantineEntry.lastError` length.** It comes from libsodium and is short; truncating would change what the UI and the persisted record show for no measurable win.

## How it was proven

Reverted the four source files to `origin/main` (keeping the new constants in `sync-context.ts` so the tests exercise the real cap values) and re-ran the same three suites:

- **Before:** `Tests  10 failed | 57 passed (67)`
- **After:** `Tests  67 passed (67)`

The 10 that flip: 3 corrupt-item cap/eviction-order tests, 4 quarantine TTL-sweep and cap/eviction-order tests, 3 worker-bridge pending-cap and sweep tests. Two more are regression guards that pass in both states (the sweep not preempting a live timeout; no timer left running after the last request settles).

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  apps/desktop/src/main/sync/worker-bridge.test.ts \
  apps/desktop/src/main/sync/engine/corrupt-item-tracker.test.ts \
  apps/desktop/src/main/sync/engine/quarantine-manager.test.ts
→ Test Files 3 passed (3) · Tests 67 passed (67)

./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  apps/desktop/src/main/sync/engine/pull-coordinator.test.ts \
  apps/desktop/src/main/sync/engine/orphan-repair.test.ts \
  apps/desktop/src/main/sync/corrupt-recovery.test.ts
→ Test Files 3 passed (3) · Tests 18 passed (18)

pnpm --filter @memry/desktop typecheck:node   → clean
eslint <8 changed files>                      → 0 errors
git diff --check                              → clean
pnpm docs:impact --base origin/main --strict  → "docs changed on this branch"
pnpm docs:build                               → build complete in 4.62s
```

`quarantine-manager.test.ts` now mocks the logger and `trackMainError`: the cap tests quarantine tens of thousands of items and the real sinks would emit that many log lines and telemetry events. Nothing in the file asserted on either.

## Backward compatibility

No schema, contract, IPC, settings or wire-format change — all three maps are process-local, and the persisted quarantine record keeps the same `{ v: 2, entries }` shape, still written from permanent entries only.
