### PR TITLE
perf(notes): give the sidebar tree a lighter notes:list row shape

### DIFF
--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -218,7 +218,7 @@ export interface MainIpcInvokeHandlers {
   "notes:get-version": (...args: [string]) => Awaited<Promise<import("../vault/notes-versions").SnapshotDetail | null>>
   "notes:get-versions": (...args: [string]) => Awaited<Promise<import("../vault/notes-versions").SnapshotListItem[]>>
   "notes:import-files": (...args: [{ sourcePaths: string[]; targetFolder?: string | undefined; }]) => Awaited<Promise<import("../vault/notes-crud").ImportFilesResult> | { success: false; error: string }>
-  "notes:list": (...args: [{ folder?: string | undefined; tags?: string[] | undefined; sortBy?: "title" | "position" | "modified" | "created" | undefined; sortOrder?: "asc" | "desc" | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../vault/notes-crud").NoteListResponse>>
+  "notes:list": (...args: [{ folder?: string | undefined; tags?: string[] | undefined; sortBy?: "title" | "position" | "modified" | "created" | undefined; sortOrder?: "asc" | "desc" | undefined; limit?: number | undefined; offset?: number | undefined; fields?: "full" | "tree" | undefined; }]) => Awaited<Promise<import("../vault/notes-crud").NoteListResponse>>
   "notes:list-attachments": (...args: [string]) => Awaited<Promise<import("../vault/attachments").AttachmentInfo[]>>
   "notes:move": (...args: [{ id: string; newFolder: string; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
   "notes:open-external": (...args: [string]) => Awaited<Promise<void>>

--- a/apps/desktop/src/main/vault/notes-crud.ts
+++ b/apps/desktop/src/main/vault/notes-crud.ts
@@ -148,6 +148,13 @@ export interface NoteUpdateInput {
   emoji?: string | null
 }
 
+/**
+ * Which per-note fields `listNotes` should build. Omit for the full shape —
+ * `'tree'` drops what the sidebar never reads (`snippet`, `mimeType`,
+ * `fileSize`) so a whole-vault sidebar fetch stops shipping them.
+ */
+export type NoteListFields = 'full' | 'tree'
+
 export interface NoteListOptions {
   folder?: string
   tags?: string[]
@@ -156,6 +163,7 @@ export interface NoteListOptions {
   limit?: number
   offset?: number
   includeProperties?: boolean
+  fields?: NoteListFields
 }
 
 export interface NoteListResponse {

--- a/apps/desktop/src/main/vault/notes-queries.ts
+++ b/apps/desktop/src/main/vault/notes-queries.ts
@@ -59,6 +59,14 @@ export function listNotes(options: NoteListOptions = {}): NoteListResponse {
 
   const propertiesMap = options.includeProperties ? getPropertiesForNotes(db, noteIds) : null
 
+  // The sidebar tree renders path/title/modified/tags/emoji/localOnly/fileType
+  // and nothing else, but a whole-vault fetch of the full shape still ships a
+  // ~200-char snippet plus the mime/size pair for every note in the vault —
+  // over IPC, and again on every list invalidation. 'tree' builds only what the
+  // sidebar reads; the fields it skips are all optional on NoteListItem, so a
+  // 'tree' row stays a valid NoteListItem for any other consumer.
+  const treeShape = options.fields === 'tree'
+
   const noteItems: NoteListItem[] = notes.map((c) => ({
     id: c.id,
     path: c.path,
@@ -67,12 +75,11 @@ export function listNotes(options: NoteListOptions = {}): NoteListResponse {
     modified: new Date(c.modifiedAt),
     tags: tagsMap.get(c.id) ?? [],
     wordCount: c.wordCount ?? 0,
-    snippet: c.snippet ?? undefined,
+    ...(treeShape ? {} : { snippet: c.snippet ?? undefined }),
     emoji: c.emoji,
     localOnly: c.localOnly ?? false,
     fileType: c.fileType ?? 'markdown',
-    mimeType: c.mimeType,
-    fileSize: c.fileSize,
+    ...(treeShape ? {} : { mimeType: c.mimeType, fileSize: c.fileSize }),
     ...(propertiesMap && { properties: propertiesMap.get(c.id) ?? {} })
   }))
 

--- a/apps/desktop/src/main/vault/notes.test.ts
+++ b/apps/desktop/src/main/vault/notes.test.ts
@@ -1062,6 +1062,81 @@ describe('notes operations', () => {
       // Most recently created should be first
       expect(result.notes[0].title).toBe('Note C')
     })
+
+    // ------------------------------------------------------------------
+    // #445: sidebar-shaped rows
+    // ------------------------------------------------------------------
+
+    it('#445: omitting fields keeps the full row byte-identical (back-compat)', async () => {
+      const legacy = await notes.listNotes({})
+      const explicitFull = await notes.listNotes({ fields: 'full' })
+
+      expect(explicitFull).toEqual(legacy)
+      expect(legacy.notes.every((n) => typeof n.snippet === 'string')).toBe(true)
+      expect(legacy.notes.every((n) => 'mimeType' in n && 'fileSize' in n)).toBe(true)
+    })
+
+    it("#445: fields: 'tree' drops snippet and file metadata but keeps every field the sidebar renders", async () => {
+      const full = await notes.listNotes({})
+      const tree = await notes.listNotes({ fields: 'tree' })
+
+      expect(tree.notes).toHaveLength(full.notes.length)
+      expect(tree.total).toBe(full.total)
+      expect(tree.hasMore).toBe(full.hasMore)
+
+      for (const note of tree.notes) {
+        expect('snippet' in note).toBe(false)
+        expect('mimeType' in note).toBe(false)
+        expect('fileSize' in note).toBe(false)
+      }
+
+      // buildTreeFromNotes / noteMap / the row renderer read exactly these.
+      const sidebarView = (list: typeof full.notes) =>
+        list.map((n) => ({
+          id: n.id,
+          path: n.path,
+          title: n.title,
+          modified: n.modified,
+          tags: n.tags,
+          emoji: n.emoji,
+          localOnly: n.localOnly,
+          fileType: n.fileType
+        }))
+
+      expect(sidebarView(tree.notes)).toEqual(sidebarView(full.notes))
+    })
+
+    it('#445: cuts the whole-vault sidebar payload for a large vault', async () => {
+      const { insertNoteCache } = await import('@main/database/queries/notes')
+
+      // A realistic markdown vault row: ~200-char snippet, mime/size present.
+      const snippet = 'x'.repeat(200)
+      for (let i = 0; i < 500; i++) {
+        insertNoteCache(testDb.db, {
+          id: `bulk-${i}`,
+          path: `notes/bulk-${i}.md`,
+          title: `Bulk note ${i}`,
+          contentHash: `hash-${i}`,
+          fileType: 'markdown',
+          mimeType: 'text/markdown',
+          fileSize: 4096,
+          wordCount: 320,
+          snippet,
+          createdAt: '2026-01-15T12:00:00.000Z',
+          modifiedAt: '2026-01-15T12:00:00.000Z',
+          indexedAt: '2026-01-15T12:00:00.000Z'
+        })
+      }
+
+      const fullBytes = JSON.stringify(await notes.listNotes({ limit: 10000 })).length
+      const treeBytes = JSON.stringify(
+        await notes.listNotes({ limit: 10000, fields: 'tree' })
+      ).length
+
+      // Same rows either way — this is a payload cut, not a row cut.
+      expect((await notes.listNotes({ limit: 10000, fields: 'tree' })).notes).toHaveLength(503)
+      expect(treeBytes).toBeLessThan(fullBytes * 0.5)
+    })
   })
 
   // ==========================================================================

--- a/apps/desktop/src/renderer/src/components/notes-tree.test.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree.test.tsx
@@ -227,6 +227,33 @@ describe('T521: NotesTree - folder tree display', () => {
     expect(screen.queryByText('Meeting Notes')).not.toBeInTheDocument()
   })
 
+  // #445: the sidebar is the one caller that fetches the whole vault, so it is
+  // the one caller that must not ask for the heavy per-note fields it never
+  // renders. Anything else keeps the full shape by omitting `fields`.
+  it('#445: requests the sidebar-only note shape', () => {
+    renderWithProviders(<NotesTree />)
+
+    expect(useNotesList).toHaveBeenCalledWith({ limit: 10000, fields: 'tree' })
+  })
+
+  it('#445: renders notes that carry no snippet, mimeType or fileSize', () => {
+    const treeShaped = [
+      createNote('note-1', 'Meeting Notes.md'),
+      createNote('note-5', 'Daily Journal.md', { emoji: '📝', localOnly: true })
+    ].map((note) => {
+      const { snippet: _snippet, ...rest } = note as NoteListItem & { snippet?: string }
+      void _snippet
+      return rest as NoteListItem
+    })
+
+    setupMocks(treeShaped, [])
+    renderWithProviders(<NotesTree />)
+
+    expect(screen.getByText('Meeting Notes')).toBeInTheDocument()
+    expect(screen.getByText('Daily Journal')).toBeInTheDocument()
+    expect(screen.getByText('📝')).toBeInTheDocument()
+  })
+
   it('should render error state when error occurs', () => {
     setupMocks([], [], false, new Error('Failed to load notes'))
     renderWithProviders(<NotesTree />)

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts
@@ -30,7 +30,11 @@ export interface NoteTreeData {
 }
 
 export function useNoteTreeData(): NoteTreeData {
-  const { notes, isLoading, error } = useNotesList({ limit: 10000 })
+  // `fields: 'tree'` — the sidebar renders path/title/modified/tags/emoji/
+  // localOnly/fileType and nothing else, so main skips the snippet and the
+  // mime/size pair. At a 10k-note ceiling those are the bulk of the payload,
+  // and this list is refetched on every note create/update/rename/move.
+  const { notes, isLoading, error } = useNotesList({ limit: 10000, fields: 'tree' })
   const mutations = useNoteMutations()
   const { folders, createFolder, setFolderIcon, refetch: refreshFolders } = useNoteFoldersQuery()
 

--- a/apps/desktop/src/renderer/src/hooks/use-notes-query.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-notes-query.ts
@@ -11,6 +11,7 @@ import type {
   FolderInfo,
   Note,
   NoteLinksResponse,
+  NoteListFields,
   NoteListItem,
   NoteListResponse
 } from '@memry/rpc/notes'
@@ -61,6 +62,13 @@ export interface NoteListInput {
   sortOrder?: 'asc' | 'desc'
   limit?: number
   offset?: number
+  /**
+   * Omit for the full row. `'tree'` asks main to skip the fields the sidebar
+   * never renders (`snippet`, `mimeType`, `fileSize`) — it is part of the
+   * query key, so the two shapes are cached separately and a `'tree'` fetch
+   * can never overwrite a full-shape consumer's cache entry.
+   */
+  fields?: NoteListFields
 }
 
 export interface UseNoteOptions {
@@ -537,4 +545,4 @@ export function useNoteMutations() {
 // =============================================================================
 
 // Re-export types
-export type { Note, NoteListItem, NoteListResponse, NoteLinksResponse }
+export type { Note, NoteListFields, NoteListItem, NoteListResponse, NoteLinksResponse }

--- a/apps/docs/src/architecture/ipc.md
+++ b/apps/docs/src/architecture/ipc.md
@@ -81,6 +81,19 @@ log.info('created note', { id })
 - The renderer owns UI state, tabs, and the BlockNote editor.
 - CRDT updates flow renderer → main via the Yjs IPC provider; updates are tagged with `sourceWindowId` and Y.Doc origin parameters to prevent loops.
 
+## Response Shape Narrowing
+
+A handler that some caller invokes over the whole vault has to answer two different questions: "give me a row I can display in detail" and "give me just enough to draw a list entry". Answering both with one fat shape means the second caller pays for fields it never reads — on every fetch, and again on every cache invalidation.
+
+`notes:list` is the worked example. The sidebar tree is the only caller that asks for the entire vault (`useNoteTreeData` requests `limit: 10000`), it re-fetches on every note create/update/rename/move, and it renders only `path`, `title`, `modified`, `tags`, `emoji`, `localOnly`, and `fileType`. The full row additionally carries a ~200-character `snippet` plus `mimeType`/`fileSize`, none of which reach the screen. So `NoteListSchema` takes an optional `fields: 'full' | 'tree'`, and `listNotes` builds the trimmed row when it is `'tree'`.
+
+Two properties make this shape kind of narrowing safe to add to a shipped channel:
+
+- **The flag is `.optional()`, not `.default()`.** A caller that omits it gets a byte-identical response to the one it got before the flag existed, so no existing consumer — renderer, MCP tool, or handler test — has to change or even know.
+- **Only already-optional fields may be dropped.** A narrowed row stays a valid instance of the same response type, so it can flow into any consumer of that type without a guard and without a second interface to keep in sync. If a field a caller may rely on unconditionally has to go, that is a different, breaking change and needs its own type.
+
+Put the flag in the query key on the renderer side (`notesKeys.list(options)` already includes the whole options object). The two shapes then cache separately, and a narrowed fetch can never overwrite a full-shape consumer's cache entry with rows missing the fields it reads.
+
 ## Main → Renderer Broadcasts
 
 Main-process code that fans an event out to every open window — sync status, task and calendar change events, inbox capture/filing/snooze/transcription events, search and embedding progress, updater state, reminders, agent events, and FTS rebuild progress — goes through `broadcastToAllWindows(channel, data)` in `src/main/lib/window-broadcast.ts`. The helper skips destroyed windows: short-lived windows (splash, quick capture, print/export) can still appear in `BrowserWindow.getAllWindows()` after destruction, and an unguarded `webContents.send()` throws — inside a sync item handler that throw escapes `ctx.emit` within the item's DB transaction and rolls it back. Use the helper instead of hand-rolling a `getAllWindows()` loop.

--- a/packages/contracts/src/notes-api.ts
+++ b/packages/contracts/src/notes-api.ts
@@ -40,6 +40,17 @@ export interface Note {
   emoji?: string | null // Emoji icon for visual identification
 }
 
+/**
+ * A row of `notes:list`.
+ *
+ * The optional fields are the ones `NoteListFields` controls: with
+ * `fields: 'tree'` the main process omits `snippet` (and the file-metadata
+ * pair on the main-side row type) because the sidebar tree never reads them,
+ * and a whole-vault sidebar fetch would otherwise ship ~200 chars of snippet
+ * per note across IPC on every list invalidation. Every field a caller can
+ * rely on unconditionally stays required, so `'tree'` rows are still ordinary
+ * `NoteListItem`s and no existing consumer needs a guard.
+ */
 export interface NoteListItem {
   id: string
   path: string
@@ -48,10 +59,20 @@ export interface NoteListItem {
   modified: Date
   tags: string[]
   wordCount: number
-  snippet?: string // First 200 chars of content
+  snippet?: string // First 200 chars of content — omitted when fields: 'tree'
   emoji?: string | null // Emoji icon for visual identification
   localOnly?: boolean
 }
+
+/**
+ * Which per-note fields `notes:list` should build.
+ *
+ * - `full` (default, and what every pre-existing caller gets by omitting it):
+ *   the complete `NoteListItem`.
+ * - `tree`: identity + what the sidebar renders (path, title, modified, tags,
+ *   emoji, localOnly, fileType). Heavy display-only fields are left off.
+ */
+export type NoteListFields = 'full' | 'tree'
 
 export interface NoteLink {
   sourceId: string
@@ -110,7 +131,11 @@ export const NoteListSchema = z.object({
   sortBy: z.enum(['modified', 'created', 'title', 'position']).default('modified'),
   sortOrder: z.enum(['asc', 'desc']).default('desc'),
   limit: z.number().int().min(1).max(10000).default(100),
-  offset: z.number().int().min(0).default(0)
+  offset: z.number().int().min(0).default(0),
+  // Optional (not `.default()`) on purpose: an older renderer omits it and the
+  // handler still resolves to the full shape, so the payload an existing
+  // caller receives is byte-identical to before this field existed.
+  fields: z.enum(['full', 'tree']).optional()
 })
 
 export const NoteReorderSchema = z.object({

--- a/packages/rpc/src/notes.ts
+++ b/packages/rpc/src/notes.ts
@@ -232,6 +232,13 @@ export interface ApplyTemplateInput {
   mode: 'full' | 'body'
 }
 
+/**
+ * Which per-note fields `notes.list` should build. Omit for the full shape —
+ * `'tree'` drops the sidebar-irrelevant heavy fields (`snippet`, `mimeType`,
+ * `fileSize`) from every row.
+ */
+export type NoteListFields = 'full' | 'tree'
+
 export interface NoteListOptions {
   folder?: string
   tags?: string[]
@@ -239,6 +246,7 @@ export interface NoteListOptions {
   sortOrder?: 'asc' | 'desc'
   limit?: number
   offset?: number
+  fields?: NoteListFields
 }
 
 export interface NoteCreateResponse {


### PR DESCRIPTION
Closes #445. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

The sidebar note tree is the only caller in the app that fetches the whole vault, and it asks for the full per-note row:

`apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts:33`

```ts
const { notes, isLoading, error } = useNotesList({ limit: 10000 })
```

`listNotes` (`apps/desktop/src/main/vault/notes-queries.ts:62`) builds every row with a cached `snippet` (first ~200 chars of the note) plus `mimeType` and `fileSize`:

```ts
const noteItems: NoteListItem[] = notes.map((c) => ({
  ...
  snippet: c.snippet ?? undefined,
  ...
  mimeType: c.mimeType,
  fileSize: c.fileSize,
}))
```

None of those three reach the screen. Everything the tree renders comes from `path`, `title`, `modified`, `tags`, `emoji`, `localOnly`, `fileType` — verified by reading every consumer of `useNoteTreeData().notes` / `.noteMap`: `notes-tree.tsx`, `notes-tree-utils.tsx` (`buildTreeFromNotes` uses `modified` for sort order and `fileType` for the icon), `virtualized-notes-tree.tsx`, `note-tree-internal.tsx`, `use-tree-drag-drop.ts`, `use-tree-delete.ts`, `use-note-tree-actions.ts`. The only field outside id/path/title anyone touches is `note.localOnly` at `notes-tree.tsx:388`.

Two things make this worse than a one-off cost: the payload is retained in the TanStack Query cache for as long as the sidebar is mounted, and `useNotesList` invalidates `notesKeys.lists()` on **every** note create / update / rename / move / delete — so the whole thing is re-serialised across IPC and re-materialised in the renderer on each of those.

## What changed

An additive `fields: 'full' | 'tree'` option on `notes:list`. `'tree'` omits `snippet`, `mimeType` and `fileSize`; the sidebar passes it, nothing else does.

- `packages/contracts/src/notes-api.ts` — `NoteListSchema` gains `fields: z.enum(['full','tree']).optional()`, plus a `NoteListFields` type. **`.optional()`, not `.default()`**, so a caller that omits it gets a byte-identical response to before.
- `packages/rpc/src/notes.ts`, `apps/desktop/src/main/vault/notes-crud.ts` — `NoteListOptions` gains `fields?: NoteListFields`.
- `apps/desktop/src/main/vault/notes-queries.ts` — `listNotes` skips the three fields when `fields === 'tree'`.
- `apps/desktop/src/renderer/src/hooks/use-notes-query.ts` — `NoteListInput` gains `fields`. It is part of `notesKeys.list(options)`, so the two shapes cache separately and a tree fetch can never overwrite a full-shape consumer's cache entry.
- `apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts` — the one call site: `useNotesList({ limit: 10000, fields: 'tree' })`.
- `apps/docs/src/architecture/ipc.md` — new "Response Shape Narrowing" section.

`NoteListItem` itself is **unchanged**: only fields that were already optional are dropped, so a `'tree'` row is still a valid `NoteListItem` and no consumer anywhere needs a guard or a second interface.

### Deliberately NOT done — the task half of #445, and why

The issue also asks to drop `includeCompleted` / `includeArchived` from the root task fetch (`use-task-queries.ts:220-224`) behind a main-side aggregate badge count. I read that path and it is **not safe as one PR**, so it is not in here:

- The root `tasks` array is not just badge input. It is the value of `TasksProvider` (`App.tsx:490`) and `DragProvider` (`App.tsx:593`), i.e. the data source for the entire task UI.
- Completed rows are load-bearing far beyond the Completed view. Subtask progress reads `completedAt !== null` on rows from that same array: `kanban-card.tsx:67`, `task-detail-drawer.tsx:230,477`, `subtask-utils.ts:65`, `subtask-bulk-utils.ts:28,98,322`. Dropping completed rows silently zeroes every "2/3 subtasks" indicator and empties every kanban done column, on top of breaking `getCompletedTasks` / `getCompletedTodayTasks` (`pages/tasks.tsx:456,461`).
- Archived rows are not free to drop either: `getTaskWorkspaceCounts` increments `projectTaskCounts` *before* its `if (task.archivedAt) continue`, so archived non-done tasks currently count toward project sidebar badges. Removing them changes displayed numbers.

So the task-side work needs each of those surfaces to gain its own scoped fetch first — a multi-file refactor of the task UI with real regression surface. Doing it half-way is exactly the risky migration the issue's ship-decision gate warns about. It also has a much smaller ceiling: the root task fetch is already capped at `limit: 1000` rows with no large text fields, whereas the sidebar note fetch is capped at 10000 rows each carrying a 200-char string. Filed as follow-up work rather than smuggled in here.

## How it was proven

Real DB-backed test (`createTestIndexDb`, real `listNotes`), not a mocked IPC round-trip. New test seeds 500 notes with realistic 200-char snippets + mime/size and measures the serialised response:

| whole-vault sidebar fetch, 503 notes | payload |
| --- | --- |
| `listNotes({ limit: 10000 })` (before / `fields` omitted) | **240,052 bytes** |
| `listNotes({ limit: 10000, fields: 'tree' })` (after) | **111,887 bytes** |
| | **−53.4%**, same 503 rows |

Extrapolated to the hook's actual 10,000-note ceiling that is ~4.8 MB → ~2.2 MB per fetch, and this list re-fetches on every note mutation.

Before/after by reverting only the source files (`git checkout origin/main -- notes-queries.ts use-note-tree-data.ts`, tests kept):

```
BEFORE  main     Tests  2 failed | 1 passed
        renderer Tests  1 failed | 1 passed
          × #445: fields: 'tree' drops snippet and file metadata ... → expected true to be false
          × #445: cuts the whole-vault sidebar payload → expected 240052 to be less than 120026
          × #445: requests the sidebar-only note shape → expected vi.fn() to be called with [{ limit: 10000, fields: 'tree' }]

AFTER   main     Tests  3 passed
        renderer Tests  2 passed
```

New tests:
- `notes.test.ts` — `#445: omitting fields keeps the full row byte-identical (back-compat)` (asserts `listNotes({})` deep-equals `listNotes({ fields: 'full' })` and still carries snippet/mime/size), `#445: fields: 'tree' drops snippet and file metadata but keeps every field the sidebar renders` (asserts the sidebar-visible projection of tree rows is deep-equal to the full rows'), `#445: cuts the whole-vault sidebar payload for a large vault`.
- `notes-tree.test.tsx` — `#445: requests the sidebar-only note shape`, `#445: renders notes that carry no snippet, mimeType or fileSize` (tree renders titles + emoji from rows with the fields stripped).

## Verification

```
pnpm ipc:generate && pnpm ipc:check   → Generated RPC bindings are up to date / IPC invoke map is up to date
pnpm check:contracts                  → contracts boundary check passed
pnpm check:architecture               → architecture boundary check passed
pnpm --filter @memry/desktop typecheck:web    → clean
pnpm --filter @memry/desktop typecheck:node   → clean
vitest --project main  notes.test.ts notes-handlers.test.ts notes-handlers-extra.test.ts
                                      → Test Files 3 passed, Tests 141 passed
vitest --project renderer notes-tree.test.tsx use-notes-query.test.tsx
                          notes-tree-utils.test.tsx virtualized-notes-tree.test.tsx
                          notes-tree-isolated.test.tsx
                                      → Test Files 5 passed, Tests 91 passed (39 + 52)
pnpm exec eslint <changed files>      → 0 errors
git diff --check                      → clean
pnpm docs:impact --base origin/main --strict → docs changed on this branch
pnpm docs:build                       → build complete
```

## Backward compatibility

Purely additive and opt-in: `fields` is an optional request field with no default, every existing caller that omits it receives the exact same `NoteListResponse` as before (asserted by a test), and `NoteListItem` is unchanged — only fields that were already optional on it are ever omitted, so a `'tree'` row remains a valid `NoteListItem` for any consumer. No DB, sync-protocol, vault-format or settings change.
