### PR TITLE
refactor(crdt): split the CRDT store bootstrap out of crdt-provider and drop its max-lines override

### DIFF
--- a/apps/desktop/src/main/sync/crdt-persistence.ts
+++ b/apps/desktop/src/main/sync/crdt-persistence.ts
@@ -1,0 +1,153 @@
+import * as Y from 'yjs'
+import { LeveldbPersistence } from 'y-leveldb'
+import { existsSync, rmSync } from 'fs'
+import { createLogger } from '../lib/logger'
+import { runCrdtPreflight } from './crdt-preflight'
+import { moveStoreDir } from './crdt-store-move'
+
+// Same scope as crdt-provider on purpose: every line below was emitted under
+// 'CrdtProvider' before this module was split out of it, and production log
+// triage greps for that scope.
+const log = createLogger('CrdtProvider')
+
+const PERSISTENCE_PROBE_KEY = '__memry_crdt_probe__'
+const PERSISTENCE_PROBE_TIMEOUT_MS = 15_000
+
+export interface CrdtPersistence {
+  getYDoc(noteId: string): Promise<Y.Doc>
+  clearDocument(noteId: string): Promise<void>
+  destroy(): Promise<void> | void
+  storeUpdate(noteId: string, update: Uint8Array): Promise<void>
+  flushDocument(noteId: string): Promise<void>
+}
+
+/**
+ * Open the on-disk CRDT store, or return null when it cannot be trusted.
+ *
+ * Null is not a failure the caller has to handle specially: the provider
+ * degrades to in-memory mode, where notes still load from vault markdown and
+ * write back to disk and only CRDT history persistence is lost.
+ */
+export async function openCrdtPersistence(storagePath: string): Promise<CrdtPersistence | null> {
+  try {
+    // A binding that hard-aborts (unsupported CPU instructions, AV kills)
+    // takes the whole process down with no catchable error — observed on
+    // 2026.709.x: main died silently before the window painted. Exercise
+    // the binding in a disposable child first — against the real store, so
+    // corrupt on-disk state aborts the child too. Only load it here if the
+    // child survives.
+    let preflight = await runCrdtPreflight(storagePath)
+    // Only a child that actually opened the store can implicate it. A child
+    // that never started (Windows: utility process dies in Chromium/crashpad
+    // init) or that died loading the binding never touched the data, and
+    // quarantining on that verdict only churned the store dir every launch —
+    // with the restore then failing EPERM under AV. See crdt-preflight.ts.
+    if (!preflight.ok && preflight.stage === 'store' && existsSync(storagePath)) {
+      // The abort may be the store's data (torn LDB/MANIFEST from a past
+      // crash or full disk), not the binding. Quarantine the store and give
+      // the binding one clean shot at a fresh directory: pass → the data was
+      // the problem, keep the quarantine and start fresh (vault markdown is
+      // the source of truth; only CRDT history moves aside). Fail → the
+      // binding is the problem, so restore the store for a future launch
+      // with a working binding and fall through to in-memory mode.
+      const quarantinePath = `${storagePath}.broken-${Date.now()}`
+      const quarantined = await moveStoreDir(storagePath, quarantinePath)
+      if (!quarantined) {
+        log.warn('Could not quarantine the CRDT store — leaving it in place', { storagePath })
+      } else {
+        preflight = await runCrdtPreflight(storagePath)
+        if (preflight.ok) {
+          log.warn(
+            'CRDT store quarantined after failed preflight — continuing with a fresh store',
+            {
+              storagePath,
+              quarantinePath
+            }
+          )
+        } else {
+          // The failed re-probe can leave a partial fresh store behind, and
+          // on Windows renaming onto an existing directory fails EPERM —
+          // exactly what production logs show. That directory holds nothing
+          // (the probe never completed), so clear it before restoring.
+          try {
+            rmSync(storagePath, { recursive: true, force: true })
+          } catch (err) {
+            log.warn('Could not clear the fresh CRDT store before restoring', {
+              storagePath,
+              error: err
+            })
+          }
+          if (!(await moveStoreDir(quarantinePath, storagePath))) {
+            log.warn('Failed to restore quarantined CRDT store', { quarantinePath, storagePath })
+          }
+        }
+      }
+    }
+    if (!preflight.ok) {
+      throw new Error(`CRDT store preflight failed: ${preflight.reason ?? 'unknown'}`)
+    }
+    const persistence = new LeveldbPersistence(storagePath) as CrdtPersistence
+    await probePersistence(persistence)
+    log.debug('CrdtProvider persistence initialized', { storagePath })
+    return persistence
+  } catch (err) {
+    // A broken classic-level native binding (e.g. napi_create_reference
+    // failures on ABI mismatch, as shipped in 2026.705.1 on Windows) throws
+    // out-of-band or hangs instead of rejecting. Degrade to in-memory:
+    // notes still load from vault markdown and write back to disk; only
+    // CRDT history persistence is lost.
+    log.error(
+      'CRDT persistence unavailable — continuing in-memory (notes still load from vault files)',
+      { storagePath, error: err }
+    )
+    return null
+  }
+}
+
+/**
+ * Verify the CRDT store's native binding actually works before trusting it.
+ * A broken classic-level binding (ABI mismatch) doesn't reject cleanly — it
+ * throws out-of-band from an fs callback (surfacing as uncaughtException) or
+ * never invokes its callback at all (hanging the promise). Capture both so a
+ * bad binary degrades to in-memory mode instead of crashing note editing.
+ */
+async function probePersistence(persistence: CrdtPersistence): Promise<void> {
+  const probeDoc = new Y.Doc()
+  probeDoc.getMap('probe').set('ok', true)
+  const update = Y.encodeStateAsUpdate(probeDoc)
+  probeDoc.destroy()
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false
+    const settle = (fn: () => void): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      process.removeListener('uncaughtException', onUncaught)
+      fn()
+    }
+    const onUncaught = (err: Error): void => settle(() => reject(err))
+    const timer = setTimeout(
+      () =>
+        settle(() =>
+          reject(
+            new Error(`CRDT persistence probe timed out after ${PERSISTENCE_PROBE_TIMEOUT_MS}ms`)
+          )
+        ),
+      PERSISTENCE_PROBE_TIMEOUT_MS
+    )
+    process.prependListener('uncaughtException', onUncaught)
+
+    Promise.resolve()
+      .then(async () => {
+        await persistence.storeUpdate(PERSISTENCE_PROBE_KEY, update)
+        const loaded = await persistence.getYDoc(PERSISTENCE_PROBE_KEY)
+        loaded.destroy()
+        await persistence.clearDocument(PERSISTENCE_PROBE_KEY)
+      })
+      .then(
+        () => settle(resolve),
+        (err) => settle(() => reject(err instanceof Error ? err : new Error(String(err))))
+      )
+  })
+}

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -1,7 +1,6 @@
 import * as Y from 'yjs'
-import { LeveldbPersistence } from 'y-leveldb'
 import path from 'path'
-import { existsSync, rmSync } from 'fs'
+import { rmSync } from 'fs'
 import { app, BrowserWindow } from 'electron'
 import { CRDT_EVENTS, CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 import { createLogger } from '../lib/logger'
@@ -15,8 +14,7 @@ import {
   recordNetworkUpdate,
   resetWritebackState
 } from './crdt-writeback'
-import { runCrdtPreflight } from './crdt-preflight'
-import { moveStoreDir } from './crdt-store-move'
+import { openCrdtPersistence, type CrdtPersistence } from './crdt-persistence'
 import { toAbsolutePath } from '../vault/notes'
 import { safeRead } from '../vault/file-ops'
 import { parseNote } from '../vault/frontmatter'
@@ -38,8 +36,6 @@ const SIZE_CHECK_INTERVAL_MS = 60_000
 const ENCODED_SIZE_COMPACTION_THRESHOLD = 1024 * 1024
 const ACCUMULATED_BYTES_RECHECK_THRESHOLD = 512 * 1024
 const DEFAULT_INACTIVE_DOC_LIMIT = 32
-const PERSISTENCE_PROBE_KEY = '__memry_crdt_probe__'
-const PERSISTENCE_PROBE_TIMEOUT_MS = 15_000
 
 export type SnapshotPushFn = (noteId: string, state: Uint8Array) => Promise<void>
 
@@ -73,14 +69,6 @@ interface ActiveDoc {
   lastSizeCheckAt: number
   lastTouchedAt: number
   closing?: boolean
-}
-
-interface CrdtPersistence {
-  getYDoc(noteId: string): Promise<Y.Doc>
-  clearDocument(noteId: string): Promise<void>
-  destroy(): Promise<void> | void
-  storeUpdate(noteId: string, update: Uint8Array): Promise<void>
-  flushDocument(noteId: string): Promise<void>
 }
 
 export class CrdtProvider {
@@ -129,79 +117,9 @@ export class CrdtProvider {
 
   private async doInitPersistence(): Promise<void> {
     const storagePath = path.join(app.getPath('userData'), 'crdt-store')
-    try {
-      // A binding that hard-aborts (unsupported CPU instructions, AV kills)
-      // takes the whole process down with no catchable error — observed on
-      // 2026.709.x: main died silently before the window painted. Exercise
-      // the binding in a disposable child first — against the real store, so
-      // corrupt on-disk state aborts the child too. Only load it here if the
-      // child survives.
-      let preflight = await runCrdtPreflight(storagePath)
-      // Only a child that actually opened the store can implicate it. A child
-      // that never started (Windows: utility process dies in Chromium/crashpad
-      // init) or that died loading the binding never touched the data, and
-      // quarantining on that verdict only churned the store dir every launch —
-      // with the restore then failing EPERM under AV. See crdt-preflight.ts.
-      if (!preflight.ok && preflight.stage === 'store' && existsSync(storagePath)) {
-        // The abort may be the store's data (torn LDB/MANIFEST from a past
-        // crash or full disk), not the binding. Quarantine the store and give
-        // the binding one clean shot at a fresh directory: pass → the data was
-        // the problem, keep the quarantine and start fresh (vault markdown is
-        // the source of truth; only CRDT history moves aside). Fail → the
-        // binding is the problem, so restore the store for a future launch
-        // with a working binding and fall through to in-memory mode.
-        const quarantinePath = `${storagePath}.broken-${Date.now()}`
-        const quarantined = await moveStoreDir(storagePath, quarantinePath)
-        if (!quarantined) {
-          log.warn('Could not quarantine the CRDT store — leaving it in place', { storagePath })
-        } else {
-          preflight = await runCrdtPreflight(storagePath)
-          if (preflight.ok) {
-            log.warn(
-              'CRDT store quarantined after failed preflight — continuing with a fresh store',
-              {
-                storagePath,
-                quarantinePath
-              }
-            )
-          } else {
-            // The failed re-probe can leave a partial fresh store behind, and
-            // on Windows renaming onto an existing directory fails EPERM —
-            // exactly what production logs show. That directory holds nothing
-            // (the probe never completed), so clear it before restoring.
-            try {
-              rmSync(storagePath, { recursive: true, force: true })
-            } catch (err) {
-              log.warn('Could not clear the fresh CRDT store before restoring', {
-                storagePath,
-                error: err
-              })
-            }
-            if (!(await moveStoreDir(quarantinePath, storagePath))) {
-              log.warn('Failed to restore quarantined CRDT store', { quarantinePath, storagePath })
-            }
-          }
-        }
-      }
-      if (!preflight.ok) {
-        throw new Error(`CRDT store preflight failed: ${preflight.reason ?? 'unknown'}`)
-      }
-      const persistence = new LeveldbPersistence(storagePath) as CrdtPersistence
-      await probePersistence(persistence)
-      this.persistence = persistence
-      log.debug('CrdtProvider persistence initialized', { storagePath })
-    } catch (err) {
-      // A broken classic-level native binding (e.g. napi_create_reference
-      // failures on ABI mismatch, as shipped in 2026.705.1 on Windows) throws
-      // out-of-band or hangs instead of rejecting. Degrade to in-memory:
-      // notes still load from vault markdown and write back to disk; only
-      // CRDT history persistence is lost.
-      log.error(
-        'CRDT persistence unavailable — continuing in-memory (notes still load from vault files)',
-        { storagePath, error: err }
-      )
-      this.persistence = null
-    }
+    // Preflight, quarantine and probe live in crdt-persistence.ts; null means
+    // the store could not be trusted and this provider runs in-memory.
+    this.persistence = await openCrdtPersistence(storagePath)
     this.persistenceReady = true
   }
 
@@ -1021,54 +939,6 @@ export class CrdtProvider {
     this.touchDoc(entry)
     Y.applyUpdate(entry.doc, diff, { source: 'ipc', windowId: -1 } satisfies IpcOrigin)
   }
-}
-
-/**
- * Verify the CRDT store's native binding actually works before trusting it.
- * A broken classic-level binding (ABI mismatch) doesn't reject cleanly — it
- * throws out-of-band from an fs callback (surfacing as uncaughtException) or
- * never invokes its callback at all (hanging the promise). Capture both so a
- * bad binary degrades to in-memory mode instead of crashing note editing.
- */
-async function probePersistence(persistence: CrdtPersistence): Promise<void> {
-  const probeDoc = new Y.Doc()
-  probeDoc.getMap('probe').set('ok', true)
-  const update = Y.encodeStateAsUpdate(probeDoc)
-  probeDoc.destroy()
-
-  await new Promise<void>((resolve, reject) => {
-    let settled = false
-    const settle = (fn: () => void): void => {
-      if (settled) return
-      settled = true
-      clearTimeout(timer)
-      process.removeListener('uncaughtException', onUncaught)
-      fn()
-    }
-    const onUncaught = (err: Error): void => settle(() => reject(err))
-    const timer = setTimeout(
-      () =>
-        settle(() =>
-          reject(
-            new Error(`CRDT persistence probe timed out after ${PERSISTENCE_PROBE_TIMEOUT_MS}ms`)
-          )
-        ),
-      PERSISTENCE_PROBE_TIMEOUT_MS
-    )
-    process.prependListener('uncaughtException', onUncaught)
-
-    Promise.resolve()
-      .then(async () => {
-        await persistence.storeUpdate(PERSISTENCE_PROBE_KEY, update)
-        const loaded = await persistence.getYDoc(PERSISTENCE_PROBE_KEY)
-        loaded.destroy()
-        await persistence.clearDocument(PERSISTENCE_PROBE_KEY)
-      })
-      .then(
-        () => settle(resolve),
-        (err) => settle(() => reject(err instanceof Error ? err : new Error(String(err))))
-      )
-  })
 }
 
 function isIpcOrigin(origin: unknown): origin is IpcOrigin {

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -18,6 +18,11 @@ renderer  ──Yjs IPC provider──▶  main (Y.Doc)  ──y-leveldb──�
 
 ## Persistence Resilience
 
+Opening the store is a self-contained step that lives in `crdt-persistence.ts`,
+separate from the provider that owns the Y.Docs: it runs the checks below and
+hands back either a usable store or nothing, which is what puts the provider
+into in-memory mode.
+
 The classic-level native binding is first exercised in a **disposable
 utilityProcess** (`crdt-preflight-child.ts`) against the **real store
 directory**: a binding that hard-aborts (unsupported CPU instructions, AV

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -210,7 +210,6 @@ export default defineConfig(
       'apps/desktop/src/main/inbox/filing.ts',
       'apps/desktop/src/main/inbox/suggestions.ts',
       'apps/desktop/src/main/sync/attachments.ts',
-      'apps/desktop/src/main/sync/crdt-provider.ts',
       'apps/desktop/src/main/vault/watcher.ts'
     ],
     rules: {


### PR DESCRIPTION
Closes #1145. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`eslint.config.mjs:213` listed `apps/desktop/src/main/sync/crdt-provider.ts` in the large-main-process-module `max-lines: 'off'` override, added by PR #1122 because the `forgetWindow()` fix would not fit under the 800-line cap.

```js
'apps/desktop/src/main/sync/attachments.ts',
'apps/desktop/src/main/sync/crdt-provider.ts',   // ← the exemption
'apps/desktop/src/main/vault/watcher.ts'
```

With the guardrail off, nothing prompted a split, and the file kept growing — it was 800 lines when the override landed and **842 ESLint-counted lines** on current `main` (`max-lines` uses `skipBlankLines: true, skipComments: true`, so the physical count was 1094). Removing the override on `main` reproduces the debt directly:

```
crdt-provider.ts
  1048:1  error  File has too many lines (842). Maximum allowed is 800  max-lines
```

## What changed

One seam, the one the issue lists as "persistence": the CRDT **store bootstrap** moves to a new `apps/desktop/src/main/sync/crdt-persistence.ts`, which exports `openCrdtPersistence(storagePath): Promise<CrdtPersistence | null>`. It contains the `CrdtPersistence` interface, the preflight → quarantine → restore dance, the probe constants, and `probePersistence()`.

`CrdtProvider.doInitPersistence()` becomes the call site:

```ts
private async doInitPersistence(): Promise<void> {
  const storagePath = path.join(app.getPath('userData'), 'crdt-store')
  this.persistence = await openCrdtPersistence(storagePath)
  this.persistenceReady = true
}
```

The moved code is **byte-identical** to `origin/main` apart from exactly three lines, confirmed by diffing the dedented original block against the new file:

```
<     this.persistence = persistence     →  >     return persistence
<     this.persistence = null            →  >     return null
<   this.persistenceReady = true         →  (stays in doInitPersistence)
```

`crdt-provider.ts` drops from **842 → 748** ESLint-counted lines, so its entry is deleted from the override list. The other files in that override are untouched.

### Deliberately NOT done

- **No change to anything that owns doc state.** Doc identity, refcounting, `windowIds`, `forgetWindow`, the LRU/eviction pool, `broadcastToWindows`, `sourceWindowId` tagging, `compactDoc` and `drainCompactionBuffer` are byte-for-byte unchanged. The compaction path in particular carries today's two data-loss fixes (#1280 stale write-back doc, #1285 lost remote update during compaction) and was left alone on purpose.
- **`seedFromMarkdown` was considered and rejected.** Extracting it means passing `this.persistence` as a parameter, but the original reads `this.persistence` *after* `await markdownToYFragment(...)` — and `destroy()` sets that field to `null`. A captured parameter would read a stale value where the original reads the live one. That is a real behaviour difference, so it stays.
- **Log scope kept as `'CrdtProvider'`** in the new module rather than a new scope, so every emitted log line stays identical for production log triage.
- The only semantic delta anywhere is one extra microtask between `probePersistence()` resolving and `this.persistence` being assigned. Nothing observes it: `persistenceReady` still flips in the same tick as the assignment, and `this.persistence` was already `null` for the whole (much longer) async init window before this change.

## How it was proven

This is a pure refactor, so the bar is *the existing test surface is unchanged*, not a new failing→passing test. Both runs are on the same machine, baseline taken on pristine `origin/main` before any edit.

| Run | Before (`origin/main`) | After |
| --- | --- | --- |
| `src/main/sync` (full main-project suite) | **142 files passed (142)** · 1860 passed, 1 expected fail, 3 skipped (1864) | **142 files passed (142)** · 1860 passed, 1 expected fail, 3 skipped (1864) |
| `crdt-provider` + `crdt-ipc-handlers` + `crdt-writeback` + `engine-crdt` + `crdt-compaction` + `crdt-cursor-stability` | **6 files passed (6)** · 102 passed (102) | **6 files passed (6)** · 102 passed (102) |

Identical, both runs.

Coverage of the new file is not theoretical — 11 existing tests in `crdt-provider.test.ts` drive `crdt-persistence.ts` end to end through the provider, mocking `y-leveldb` and `runCrdtPreflight`: probe-rejects, probe-hangs, preflight child dies, quarantine-then-fresh-store, restore-on-second-failure, restore over a partial fresh store, no-quarantine for `bootstrap`/`binding` stages, no re-probe when no store exists, and no retry of a settled init.

## Verification

```
pnpm --filter @memry/desktop typecheck:node    → clean, no output
pnpm lint                                      → 0 errors, 19 warnings (all pre-existing, renderer files)
pnpm check:architecture                        → architecture boundary check passed
pnpm check:contracts                           → contracts boundary check passed
git diff --check                               → clean
pnpm docs:impact --base origin/main --strict   → covered
pnpm docs:build                                → build complete
eslint crdt-provider.ts crdt-persistence.ts    → clean with the override removed
```

`pnpm lint` passing with **0 errors** is the load-bearing one: it is what proves the override is genuinely no longer needed rather than merely deleted.

## Backward compatibility

No runtime behaviour, IPC contract, DB schema, sync payload, on-disk store layout or settings shape changes — the store path, quarantine naming and in-memory fallback are all identical, so existing installs are unaffected.
