### PR TITLE
fix(tasks): stop counting archived tasks in project sidebar badges

### DIFF
--- a/apps/desktop/src/renderer/src/App.workspace-counts.test.tsx
+++ b/apps/desktop/src/renderer/src/App.workspace-counts.test.tsx
@@ -318,8 +318,9 @@ describe('App workspace count computation', () => {
     // today: a-open (overdue) + a-open-sub
     // completed: a-done + b-done
     expect(lastViewCounts).toEqual({ all: 3, today: 2, completed: 2 })
-    // project-a: a-open, a-open-sub | project-b: b-open, b-archived (archived still counts here)
-    expect(lastProjectCounts).toEqual({ 'project-a': 2, 'project-b': 2 })
+    // project-a: a-open, a-open-sub | project-b: b-open only — b-archived is
+    // archived, so no view renders it and the badge must not count it (#1323)
+    expect(lastProjectCounts).toEqual({ 'project-a': 2, 'project-b': 1 })
   })
 
   it('recomputes the counts when a task changes', () => {
@@ -330,7 +331,9 @@ describe('App workspace count computation', () => {
     rerender(<App />)
 
     expect(lastViewCounts).toEqual({ all: 2, today: 2, completed: 2 })
-    expect(lastProjectCounts).toEqual({ 'project-a': 2, 'project-b': 1 })
+    // project-b is left with b-done and b-archived only, neither of which the
+    // project view renders as an open task, so its badge is empty
+    expect(lastProjectCounts).toEqual({ 'project-a': 2, 'project-b': 0 })
     expect(sidebarRenders).toBeGreaterThan(0)
     expect(belowProviderRenders).toBeGreaterThan(0)
   })

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts
@@ -118,7 +118,11 @@ export const getFilteredTasks = (
 export interface TaskWorkspaceCounts {
   /** Per view id, equal to `getFilteredTasks(tasks, viewId, 'view', projects).length`. */
   viewCounts: Record<string, number>
-  /** Per `task.projectId`, the number of that project's tasks not in a `done` status. */
+  /**
+   * Per `task.projectId`, the number of that project's non-archived tasks not in
+   * a `done` status — i.e. the rows `getFilteredTasks(tasks, projectId,
+   * 'project', projects)` renders, minus the completed ones.
+   */
   projectTaskCounts: Record<string, number>
 }
 
@@ -200,11 +204,14 @@ export const getTaskWorkspaceCounts = (
     const projectId = task.projectId
     const isIncomplete = statusTypesByProject.get(projectId)?.get(task.statusId) !== 'done'
 
+    // Archived tasks are dropped by `getFilteredTasks` before anything else, so
+    // no view — the project view included — can render them. Counting them in a
+    // badge makes it read higher than the list it opens.
+    if (task.archivedAt) continue
+
     if (isIncomplete) {
       projectTaskCounts[projectId] = (projectTaskCounts[projectId] ?? 0) + 1
     }
-
-    if (task.archivedAt) continue
 
     if (task.parentId !== null) {
       nonArchivedSubtaskParentIds.push(task.parentId)

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-workspace-counts.test.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-workspace-counts.test.ts
@@ -108,11 +108,23 @@ const baselineTasks = (): Task[] => [
   createTask({ id: 'orphan-sub', parentId: 'never-existed' })
 ]
 
-/** The exact expression App.tsx used before the single-pass rewrite. */
-const legacyProjectTaskCount = (tasks: Task[], project: Project): number =>
-  tasks
-    .filter((t) => t.projectId === project.id)
-    .filter((t) => project.statuses.find((s) => s.id === t.statusId)?.type !== 'done').length
+/**
+ * A project badge has to mean "tasks you will see when you open this project".
+ * The project view is `getFilteredTasks(..., 'project', ...)`, which drops
+ * archived rows up front, so the badge is that list minus its completed rows.
+ *
+ * This replaces the pre-single-pass App.tsx expression, which filtered by
+ * project id and status only and therefore counted archived tasks no view can
+ * render (#1323).
+ */
+const expectedProjectTaskCount = (
+  tasks: Task[],
+  project: Project,
+  allProjects: Project[]
+): number =>
+  getFilteredTasks(tasks, project.id, 'project', allProjects).filter(
+    (t) => project.statuses.find((s) => s.id === t.statusId)?.type !== 'done'
+  ).length
 
 const expectMatchesFilters = (tasks: Task[], allProjects: Project[] = projects): void => {
   const { viewCounts, projectTaskCounts } = getTaskWorkspaceCounts(tasks, allProjects, ALL_VIEW_IDS)
@@ -125,7 +137,7 @@ const expectMatchesFilters = (tasks: Task[], allProjects: Project[] = projects):
 
   for (const project of allProjects) {
     expect(`${project.id}:${projectTaskCounts[project.id] ?? 0}`).toBe(
-      `${project.id}:${legacyProjectTaskCount(tasks, project)}`
+      `${project.id}:${expectedProjectTaskCount(tasks, project, allProjects)}`
     )
   }
 }
@@ -158,9 +170,10 @@ describe('getTaskWorkspaceCounts', () => {
       // project-a incomplete: overdue, overdue-sub, due-today, due-tomorrow,
       // due-in-3, due-in-20, no-due-date, done-a-sub, ghost-status, orphan-sub
       'project-a': 10,
-      // project-b incomplete: b-open, b-archived (archived still counts here),
-      // archived-sub
-      'project-b': 3,
+      // project-b incomplete and renderable: b-open only. b-archived and
+      // archived-sub are archived, so the project view never lists them and the
+      // badge must not count them either (#1323).
+      'project-b': 1,
       'project-gone': 1
     })
   })
@@ -270,7 +283,7 @@ describe('getTaskWorkspaceCounts invalidation matrix', () => {
         tasks.map((t) =>
           t.id === 'no-due-date' ? { ...t, projectId: 'project-b', statusId: 'todo' } : t
         ),
-      changes: { 'project-a': 9, 'project-b': 4 }
+      changes: { 'project-a': 9, 'project-b': 2 }
     },
     {
       name: 'status reassigned within the project',
@@ -284,13 +297,16 @@ describe('getTaskWorkspaceCounts invalidation matrix', () => {
     },
     {
       name: 'task archived',
+      // The project badge has to fall with the view: archiving removes the row
+      // from the project list, so project-a drops 10 -> 9 (#1323).
       apply: (tasks) => tasks.map((t) => (t.id === 'due-today' ? { ...t, archivedAt: TODAY } : t)),
-      changes: { all: 9, today: 3 }
+      changes: { all: 9, today: 3, 'project-a': 9 }
     },
     {
       name: 'task unarchived',
+      // ...and rises again when the row comes back: project-b 1 -> 2 (#1323).
       apply: (tasks) => tasks.map((t) => (t.id === 'b-archived' ? { ...t, archivedAt: null } : t)),
-      changes: { all: 11, today: 5 }
+      changes: { all: 11, today: 5, 'project-b': 2 }
     },
     {
       name: 'inbox item converted into a task',

--- a/apps/docs/src/user-guide/projects.md
+++ b/apps/docs/src/user-guide/projects.md
@@ -43,6 +43,8 @@ Open the project's **⋯** menu and choose **Edit statuses**. From there you can
 
 The sidebar shows **incomplete** task counts per project — tasks whose status type is not `done`. This keeps the count meaningful even as you complete tasks.
 
+Archived tasks are excluded, so the badge always matches the number of open tasks you see when you open the project.
+
 ## Default Project
 
 [Settings → Tasks → Default Project](/user-guide/settings#tasks) sets which project new tasks go to when you quick-add outside any project view. "(No project)" is a valid default.


### PR DESCRIPTION
Closes #1323. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts:199-207` — the single-pass badge walk incremented `projectTaskCounts` **before** it skipped archived tasks:

```ts
for (const task of tasks) {
  const projectId = task.projectId
  const isIncomplete = statusTypesByProject.get(projectId)?.get(task.statusId) !== 'done'

  if (isIncomplete) {
    projectTaskCounts[projectId] = (projectTaskCounts[projectId] ?? 0) + 1
  }

  if (task.archivedAt) continue   // guards only the view badges below
```

`getFilteredTasks` (same file, `:39`) drops archived rows before anything else, and its `selectedType === 'project'` branch (`:107`) filters from that already-filtered set. So a project's sidebar badge could read 5 while opening that project listed 3 tasks — the extra 2 being archived non-`done` rows that no view in the app renders. The gap widens the more a user archives, so the badge degrades over the life of a vault. `viewCounts` was already archived-free; only the per-project badges were wrong.

The count is consumed at `App.tsx:409-420` (`taskCount: projectTaskCounts[project.id] ?? 0`) and rendered by `sortable-project-item.tsx:172` and `sidebar-drop-zones.tsx:148`.

## What changed

One move: the `projectTaskCounts` increment now sits **after** `if (task.archivedAt) continue` and before the subtask `continue`, so subtasks still count toward their project (unchanged) while archived rows do not. The `TaskWorkspaceCounts.projectTaskCounts` doc comment now states the actual contract.

The single-pass property from #1169 is preserved exactly: still one loop, still one `task.projectId` read per task per recompute — the `reads each task once per recompute` probe in `task-workspace-counts.test.ts` and the App-level `projectIdReads` probe in `App.workspace-counts.test.tsx` both still pass unchanged.

**Deliberately not done:** the root task fetch still asks for archived rows (`use-task-queries.ts:222`, `includeArchived: true`). Narrowing that is #1326 / #1327 and is owned separately — this PR stays inside the badge-counting code.

### Test expectations that were changed (called out explicitly, per the issue)

Three assertions encoded the old behaviour and are now updated. Every changed number is stated with why the new value is correct:

1. `task-workspace-counts.test.ts` — the oracle helper. `legacyProjectTaskCount` (commented "the exact expression App.tsx used before the single-pass rewrite") filtered by project id and status only, so it counted archived tasks. Replaced by `expectedProjectTaskCount`, which derives the expected badge from the surface the badge describes: the non-`done` rows of `getFilteredTasks(tasks, projectId, 'project', projects)`. The badge is now pinned to the real project view rather than to a superseded expression.
2. `task-workspace-counts.test.ts:157-165` — baseline `projectTaskCounts`. `'project-b': 3 -> 1`. The fixture's project-b holds `b-open` (open), `b-done` (done), `b-archived` (archived, non-`done`) and `archived-sub` (archived subtask). Only `b-open` is renderable and open, so 1 is correct; the old 3 included the two archived rows. `project-a: 10` and `project-gone: 1` are unchanged — neither has archived tasks.
3. `task-workspace-counts.test.ts` invalidation matrix — `project reassigned` `'project-b': 4 -> 2` (project-b's new total is `b-open` + the reassigned `no-due-date`; the two archived rows drop out). Two rows also gained a *new* assertion that directly pins the fix: `task archived` now asserts `'project-a': 9` (archiving `due-today` must pull the badge down 10 → 9) and `task unarchived` now asserts `'project-b': 2` (un-archiving `b-archived` must push it up 1 → 2). Both were silently unasserted before, and both fail against `origin/main`.
4. `App.workspace-counts.test.tsx:321-322` — `{'project-a': 2, 'project-b': 2}` → `{'project-a': 2, 'project-b': 1}` (`b-archived` no longer counted), and `:333` → `{'project-a': 2, 'project-b': 0}` after `b-open` is removed, because project-b is then left with only a done task and an archived one.

## How it was proven

Source file reverted to `origin/main` with the updated tests in place (`git checkout origin/main -- task-view-helpers.ts`, no `git stash`), then restored:

| state | result |
| --- | --- |
| `origin/main` source + new tests | **Test Files 2 failed (2) / Tests 21 failed \| 4 passed (25)** |
| fix applied | **Test Files 2 passed (2) / Tests 25 passed (25)** |

The 4 survivors under the reverted source are exactly the ones that do not touch a project badge: both single-pass `projectId`-read probes, the empty-workspace case, and `follows a project being removed from the workspace` (project-a has no archived tasks).

## Verification

```
vitest --project renderer task-workspace-counts.test.ts App.workspace-counts.test.tsx
                                        Test Files 2 passed (2) | Tests 25 passed (25)

vitest --project renderer lib/task-utils App.test.tsx pages/tasks.test.tsx pages/project
                          components/sidebar lib/home
                                        Tests 727 passed (727)
                                        (3 test *files* error out on a cwd-relative
                                         readFileSync of assets/base.css — the
                                         contrast/theme-token suites; they fail
                                         identically on origin/main when vitest is
                                         invoked from the repo root, and contain no
                                         assertions about counts)

pnpm --filter @memry/desktop typecheck:web    clean
eslint <3 changed files>                      0 errors (2 "file ignored" warnings — repo
                                              eslint config excludes *.test.* files)
git diff --check                              clean
pnpm docs:impact --base origin/main --strict  covered
pnpm docs:build                               build complete in 3.92s
```

## Docs

Unlike #1169, this change *is* user-visible — badge numbers move on live vaults. `apps/docs/src/user-guide/projects.md` documented the badge contract ("The sidebar shows **incomplete** task counts per project") and is updated to say archived tasks are excluded.

## Backward compatibility

Renderer-only pure computation: no schema, no migration, no IPC contract, no vault file format, no settings shape, no persisted state — the only change is a derived number rendered in the sidebar, which now moves down to match the list it opens.
