### PR TITLE
fix(settings): drop the dead AI Connections journal toggle and its docs claims

### DIFF
--- a/apps/desktop/src/renderer/src/pages/settings/journal-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/journal-section.tsx
@@ -90,14 +90,6 @@ export function JournalSettings() {
     [t, updateSettings]
   )
 
-  const handleShowAIConnectionsChange = useCallback(
-    async (checked: boolean) => {
-      const success = await updateSettings({ showAIConnections: checked })
-      if (!success) toast.error(t('journal.updateError'))
-    },
-    [t, updateSettings]
-  )
-
   const handleShowStatsFooterChange = useCallback(
     async (checked: boolean) => {
       const success = await updateSettings({ showStatsFooter: checked })
@@ -212,16 +204,12 @@ export function JournalSettings() {
           />
         </SettingRow>
 
-        <SettingRow
-          label={t('journal.showAIConnections.label')}
-          description={t('journal.showAIConnections.description')}
-        >
-          <Switch
-            checked={settings.showAIConnections}
-            onCheckedChange={(...args) => void handleShowAIConnectionsChange(...args)}
-            className={ACCENT_SWITCH}
-          />
-        </SettingRow>
+        {/*
+         * No "Show AI Connections" row: nothing renders AIConnectionsPanel, so the toggle
+         * controlled nothing. `journal.showAIConnections` stays persisted and readable/writable
+         * through settings so existing installs keep their value and re-exposing the row later
+         * is a UI-only change.
+         */}
       </SettingsGroup>
 
       <SettingsGroup label={t('journal.groups.footer')}>

--- a/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
@@ -620,10 +620,14 @@ describe('settings section coverage', () => {
       expect(mocks.journalSettings.setDefaultTemplate).toHaveBeenCalledWith('daily')
     )
 
+    // AIConnectionsPanel has no call site, so the journal settings page must not offer a
+    // toggle for it. The persisted `showAIConnections` value is untouched.
+    expect(screen.queryByText('journal.showAIConnections.label')).toBeNull()
+
     fireEvent.click(screen.getAllByRole('switch')[5])
     await waitFor(() =>
       expect(mocks.journalSettings.updateSettings).toHaveBeenCalledWith({
-        showAIConnections: true
+        showStatsFooter: false
       })
     )
   })

--- a/apps/docs/src/user-guide/ai/embeddings-search.md
+++ b/apps/docs/src/user-guide/ai/embeddings-search.md
@@ -9,7 +9,6 @@ Run a local embedding model so search ranks by meaning, not just keywords.
 When embeddings are loaded, memrynote can rank notes by **semantic similarity** to your query — not just keyword overlap. This affects:
 
 - The [search palette](/user-guide/search) (semantic boost on top of keyword match)
-- **AI Connections** in the [Journal](/user-guide/journal/daily-entries) sidebar
 - "Related notes" suggestions in some surfaces
 
 A query like "setting up authentication" can surface a note titled "OAuth flow" even when the words don't overlap.

--- a/apps/docs/src/user-guide/journal/calendar-navigation.md
+++ b/apps/docs/src/user-guide/journal/calendar-navigation.md
@@ -10,7 +10,7 @@ The default writing surface for a single date.
 
 - Header arrows move ±1 day
 - Date in the breadcrumb opens the picker
-- The editor shows that day's entry; sidebar panes show schedule, tasks, AI connections (per your settings)
+- The editor shows that day's entry; sidebar panes show schedule and tasks (per your settings)
 
 ## Month View
 

--- a/apps/docs/src/user-guide/journal/daily-entries.md
+++ b/apps/docs/src/user-guide/journal/daily-entries.md
@@ -28,7 +28,6 @@ Show or hide the journal sidebar panes from [Settings → Journal](/user-guide/s
 
 - **Schedule** — calendar / events for the focused date
 - **Tasks** — tasks due that day
-- **AI Connections** — semantically related entries (requires AI enabled)
 
 ## Stats Footer
 

--- a/apps/docs/src/user-guide/journal/templates-settings.md
+++ b/apps/docs/src/user-guide/journal/templates-settings.md
@@ -22,11 +22,10 @@ If the template uses date variables, they're filled in for the current entry's d
 
 Toggle which panes appear in the journal sidebar:
 
-| Toggle | Shows |
-| --- | --- |
+| Toggle        | Shows                                |
+| ------------- | ------------------------------------ |
 | Show Schedule | Calendar events for the focused date |
-| Show Tasks | Tasks due that day |
-| Show AI Connections | Semantically related entries (requires AI enabled) |
+| Show Tasks    | Tasks due that day                   |
 
 Each toggle is independent. Turn them on as you find them useful.
 

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -173,7 +173,6 @@ Show or hide journal sidebar panes:
 
 - **Show Schedule** — calendar / events for the date
 - **Show Tasks** — tasks due that day
-- **Show AI Connections** — semantically related entries
 
 ### Footer
 
@@ -259,8 +258,8 @@ For the full default list see [Keyboard Shortcuts](/user-guide/keyboard-shortcut
 
 A master toggle for AI features. Off by default — memrynote never reaches out to AI services until you turn this on.
 When off, memrynote also hides AI entry points in the app: inline editor AI, Agent Chat in the right
-sidebar, AI tag/folder/note suggestions, journal AI connections, voice recording/transcription
-controls, and quick-capture voice capture.
+sidebar, AI tag/folder/note suggestions, voice recording/transcription controls, and
+quick-capture voice capture.
 
 ### Voice Transcription
 


### PR DESCRIPTION
Closes #1333. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`AIConnectionsPanel` has no call site. `git grep -n AIConnectionsPanel` on `origin/main` returns only its own definition, the barrel export, and two test files — no page, no journal layout, no sidebar renders it. Its only data source was the mock connections service deleted by PR #1303.

Meanwhile the app shipped a live toggle for it. `apps/desktop/src/renderer/src/pages/settings/journal-section.tsx:215` (pre-fix):

```tsx
<SettingRow
  label={t('journal.showAIConnections.label')}
  description={t('journal.showAIConnections.description')}
>
  <Switch
    checked={settings.showAIConnections}
    onCheckedChange={(...args) => void handleShowAIConnectionsChange(...args)}
    className={ACCENT_SWITCH}
  />
</SettingRow>
```

The switch is on by default (`settings-handlers.ts:425`, `showAIConnectionsStr !== 'false'`) and controls nothing — no consumer ever reads `showAIConnections`. Six docs pages describe the panel as a working feature, so a user can read the docs, find the toggle, flip it, and get nothing either way.

## What changed

Honest, reversible, minimal — this deliberately does **not** make the product decision the issue asks for.

1. **Docs (6 references, 5 files)** — removed the claims that the panel exists:
   - `apps/docs/src/user-guide/settings.md` — the "Show AI Connections" bullet, and "journal AI connections" from the AI master-switch list
   - `apps/docs/src/user-guide/journal/daily-entries.md` — the sidebar-toggle bullet
   - `apps/docs/src/user-guide/journal/templates-settings.md` — the sidebar-visibility table row
   - `apps/docs/src/user-guide/journal/calendar-navigation.md` — "AI connections" from the Day View sentence
   - `apps/docs/src/user-guide/ai/embeddings-search.md` — the "What This Powers" bullet
2. **Settings UI** — removed the `SettingRow` and its now-orphaned `handleShowAIConnectionsChange` callback. A control that changes nothing is a defect regardless of which way the product decision goes.

Deliberately **not** done, because both would presume the "retire" outcome:

- **`journal.showAIConnections` is untouched.** The key, its default, and its full read/write path stay exactly as they are: `settings-handlers.ts` (`SETTINGS_KEYS`, `getJournalSettings`, `setJournalSettings`), `packages/app-core/src/settings.ts`, `packages/rpc/src/settings.ts`, `use-journal-settings.ts`, `preload/index.d.ts`. **No migration, no settings-shape change.** Re-exposing the row later is a one-line UI change.
- **The 30 locales keep their strings.** `journal.showAIConnections.label` / `.description` stay in `packages/i18n/src/locales/*/settings.json`. `i18n:check` reports unreferenced English keys as warnings only, so this does not fail the gate.
- **`ai-connections-panel.tsx` and its tests stay in the tree.** Deleting them would decide the question.

If the answer is "wire it up", this PR reverses in one commit. If the answer is "retire", the key removal + i18n cleanup is a separate, deliberate change.

## How it was proven

Extended the existing journal-settings case in `settings-sections.test.tsx` to assert (a) the AI Connections label is absent, and (b) the sixth switch is now Stats Footer — which only holds if exactly one switch was removed.

- **Before** (fix reverted with `git checkout origin/main -- journal-section.tsx`, test kept): `Tests 1 failed | 10 passed (11)` — `expected <span …(1)></span> to be null`, received `journal.showAIConnections.label`
- **After**: `Tests 11 passed (11)`

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx \
  apps/desktop/src/renderer/src/components/journal/journal-components.test.tsx \
  apps/desktop/src/renderer/src/components/journal/journal-i18n.test.tsx
  → Test Files 3 passed (3) · Tests 22 passed (22)

pnpm --filter @memry/desktop typecheck:web       → clean
pnpm exec eslint apps/desktop/src/renderer/src/pages/settings/journal-section.tsx  → 0 errors
pnpm --filter @memry/desktop i18n:check          → ok: i18n check passed
pnpm docs:impact --base origin/main --strict     → docs impact: covered against origin/main
pnpm docs:build                                  → build complete in 2.57s
git diff --check                                 → clean
```

The two panel test files (`journal-components.test.tsx`, `journal-i18n.test.tsx`) still pass untouched, confirming the component was left intact.

## Backward compatibility

No settings-shape change: `journal.showAIConnections` remains persisted, defaulted, readable, and writable through IPC and `@memry/app-core`, so existing installs keep their stored value and older/newer app versions agree on the settings shape — only the UI row is gone. `tests/e2e/settings-persistence.e2e.ts` still round-trips the key unchanged.
