### PR TITLE
fix(crdt): persist, broadcast and write back the remote updates a successful compaction buffered

### DIFF
--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -653,6 +653,107 @@ describe('CrdtProvider', () => {
     expect(mocks.persistenceInstances[0].storeUpdate).toHaveBeenCalledWith('note-1', compacted)
   })
 
+  it('persists, broadcasts and writes back the remote updates buffered by a successful compaction', async () => {
+    // A store that actually stores: storeUpdate appends, getYDoc replays. A
+    // lost update then shows up as missing content after a restart rather than
+    // as a mock-call shape.
+    const stored: Uint8Array[] = []
+    const wireStore = (store: (typeof mocks.persistenceInstances)[number]): void => {
+      store.storeUpdate.mockImplementation(async (_noteId: string, update: Uint8Array) => {
+        stored.push(update)
+      })
+      store.getYDoc.mockImplementation(async () => {
+        const doc = new Y.Doc()
+        for (const update of stored) Y.applyUpdate(doc, update)
+        return doc
+      })
+    }
+    wireStore(mocks.persistenceInstances[0])
+
+    // The compacted snapshot touches only the body fragment and the remote
+    // update only meta.title, so the merged state is deterministic instead of
+    // resolved by client id.
+    const compactedDoc = new Y.Doc()
+    compactedDoc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [new Y.XmlText('compact')])
+    mocks.compactYDoc.mockReturnValue({
+      compacted: Y.encodeStateAsUpdate(compactedDoc),
+      savedBytes: 120
+    })
+
+    await provider.open('note-1', undefined, { skipSeed: true })
+    provider.updateMeta('note-1', { date: '2026-01-01' })
+    expect(mocks.scheduleWriteback).not.toHaveBeenCalled()
+
+    // A sync pull lands while the compaction is parked on its snapshot push,
+    // so applyRemoteUpdate diverts it into the compaction buffer.
+    pushSnapshot.mockImplementationOnce(async () => {
+      provider.applyRemoteUpdate('note-1', makeRemoteUpdate('pulled during compaction'))
+    })
+
+    await provider.compactDoc('note-1')
+
+    const compactedLiveDoc = provider.getDoc('note-1')
+    expect(compactedLiveDoc?.getMap('meta').get('title')).toBe('pulled during compaction')
+
+    // 1. The vault markdown file must be scheduled for a rewrite.
+    expect(mocks.scheduleWriteback).toHaveBeenCalledWith('note-1', compactedLiveDoc)
+
+    // 2. The queued network broadcast must reach the editor: the user reopens
+    //    the note, then the batcher flushes on shutdown.
+    createWindow(9)
+    await provider.open('note-1', 9, { skipSeed: true })
+    await provider.destroy()
+
+    const broadcast = mocks.sent.find(
+      (sent) => sent.windowId === 9 && sent.channel === CRDT_EVENTS.STATE_CHANGED
+    )
+    expect(broadcast).toBeDefined()
+    const broadcastDoc = new Y.Doc()
+    Y.applyUpdate(broadcastDoc, (broadcast!.payload as { update: Uint8Array }).update)
+    expect(broadcastDoc.getMap('meta').get('title')).toBe('pulled during compaction')
+
+    // 3. It must survive a restart, i.e. be readable back out of the store.
+    const restarted = new CrdtProvider()
+    await restarted.init(queue as any, pushSnapshot)
+    wireStore(mocks.persistenceInstances[mocks.persistenceInstances.length - 1])
+    const reloaded = await restarted.open('note-1', undefined, { skipSeed: true })
+    expect(reloaded.getMap('meta').get('title')).toBe('pulled during compaction')
+    expect(reloaded.getMap('meta').get('date')).toBe('2026-01-01')
+    await restarted.destroy()
+  })
+
+  it('does not re-store or re-broadcast the compacted snapshot itself', async () => {
+    const compactedDoc = new Y.Doc()
+    compactedDoc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [new Y.XmlText('compact')])
+    const compacted = Y.encodeStateAsUpdate(compactedDoc)
+    mocks.compactYDoc.mockReturnValue({ compacted, savedBytes: 120 })
+
+    await provider.open('note-1', undefined, { skipSeed: true })
+    provider.updateMeta('note-1', { date: '2026-01-01' })
+
+    pushSnapshot.mockImplementationOnce(async () => {
+      provider.applyRemoteUpdate('note-1', makeRemoteUpdate('pulled during compaction'))
+    })
+
+    await provider.compactDoc('note-1')
+
+    const store = mocks.persistenceInstances[0]
+    const storedUpdates = store.storeUpdate.mock.calls.map(([, update]) => update as Uint8Array)
+
+    // The snapshot is written by compactDoc itself; seeding newDoc with it must
+    // not send it through onDocUpdate and store it a second time.
+    expect(storedUpdates.filter((update) => update === compacted)).toHaveLength(1)
+
+    // The buffered update reaches the store exactly once, not once per path.
+    const carriesRemoteTitle = (update: Uint8Array): boolean => {
+      const probe = new Y.Doc()
+      Y.applyUpdate(probe, update)
+      return probe.getMap('meta').get('title') === 'pulled during compaction'
+    }
+    expect(storedUpdates.filter(carriesRemoteTitle)).toHaveLength(1)
+    expect(mocks.scheduleWriteback).toHaveBeenCalledTimes(1)
+  })
+
   it('abandons the compacted swap if an editor opens during compaction', async () => {
     const compactedDoc = new Y.Doc()
     compactedDoc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [new Y.XmlText('compact')])

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -693,13 +693,9 @@ describe('CrdtProvider', () => {
     await provider.compactDoc('note-1')
 
     const compactedLiveDoc = provider.getDoc('note-1')
-    expect(compactedLiveDoc?.getMap('meta').get('title')).toBe('pulled during compaction')
 
-    // 1. The vault markdown file must be scheduled for a rewrite.
-    expect(mocks.scheduleWriteback).toHaveBeenCalledWith('note-1', compactedLiveDoc)
-
-    // 2. The queued network broadcast must reach the editor: the user reopens
-    //    the note, then the batcher flushes on shutdown.
+    // The queued network broadcast reaches the editor: the user reopens the
+    // note, then the batcher flushes on shutdown.
     createWindow(9)
     await provider.open('note-1', 9, { skipSeed: true })
     await provider.destroy()
@@ -707,18 +703,32 @@ describe('CrdtProvider', () => {
     const broadcast = mocks.sent.find(
       (sent) => sent.windowId === 9 && sent.channel === CRDT_EVENTS.STATE_CHANGED
     )
-    expect(broadcast).toBeDefined()
     const broadcastDoc = new Y.Doc()
-    Y.applyUpdate(broadcastDoc, (broadcast!.payload as { update: Uint8Array }).update)
-    expect(broadcastDoc.getMap('meta').get('title')).toBe('pulled during compaction')
+    if (broadcast) Y.applyUpdate(broadcastDoc, (broadcast.payload as { update: Uint8Array }).update)
 
-    // 3. It must survive a restart, i.e. be readable back out of the store.
+    // A restart must still see it, i.e. it is readable back out of the store.
     const restarted = new CrdtProvider()
     await restarted.init(queue as any, pushSnapshot)
     wireStore(mocks.persistenceInstances[mocks.persistenceInstances.length - 1])
     const reloaded = await restarted.open('note-1', undefined, { skipSeed: true })
-    expect(reloaded.getMap('meta').get('title')).toBe('pulled during compaction')
-    expect(reloaded.getMap('meta').get('date')).toBe('2026-01-01')
+
+    // Asserted together so a regression reports every limb it broke, not just
+    // the first one.
+    expect({
+      inMemory: compactedLiveDoc?.getMap('meta').get('title'),
+      writtenBackDoc: mocks.scheduleWriteback.mock.calls.at(-1),
+      broadcastToEditor: broadcastDoc.getMap('meta').get('title'),
+      afterRestart: reloaded.getMap('meta').get('title'),
+      // Control: the pre-compaction local edit must survive the same round trip.
+      dateAfterRestart: reloaded.getMap('meta').get('date')
+    }).toEqual({
+      inMemory: 'pulled during compaction',
+      writtenBackDoc: ['note-1', compactedLiveDoc],
+      broadcastToEditor: 'pulled during compaction',
+      afterRestart: 'pulled during compaction',
+      dateAfterRestart: '2026-01-01'
+    })
+
     await restarted.destroy()
   })
 

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -863,12 +863,10 @@ export class CrdtProvider {
 
       const oldDoc = entry.doc
       const newDoc = new Y.Doc()
+      // Seeded before the handler is attached on purpose: result.compacted was
+      // already pushed and persisted above, so routing it through onDocUpdate
+      // would store and broadcast the whole snapshot a second time.
       Y.applyUpdate(newDoc, result.compacted)
-
-      const buffered = this.compactionBuffers.get(noteId) ?? []
-      for (const update of buffered) {
-        Y.applyUpdate(newDoc, update, ORIGIN_NETWORK)
-      }
 
       newDoc.on('update', (update: Uint8Array, origin: unknown) => {
         this.onDocUpdate(noteId, update, origin)
@@ -881,6 +879,17 @@ export class CrdtProvider {
 
       oldDoc.destroy()
 
+      // Replay the buffer only after the swap, so the updates land on the doc
+      // this.docs points at and go through the handler. onDocUpdate is the
+      // single funnel for persistUpdate, queueNetworkBroadcast and
+      // scheduleWriteback; replaying ahead of it left the compaction window's
+      // remote updates in memory only — dropped from the CRDT store, from the
+      // vault markdown file and from the broadcast — on every successful
+      // compaction that buffered at least one update. Still inside the try, so
+      // compactingDocs holds noteId and onDocUpdate's maybeCompact cannot
+      // re-enter.
+      this.drainCompactionBuffer(noteId, entry)
+
       log.info('Doc compacted', { noteId, beforeSize, afterSize: result.compacted.byteLength })
     } finally {
       this.compactingDocs.delete(noteId)
@@ -889,11 +898,17 @@ export class CrdtProvider {
   }
 
   /**
-   * Hand the updates buffered for an abandoned compaction to whatever doc is
-   * live now. applyRemoteUpdate diverts remote updates into this buffer for the
-   * whole compaction window and reports nothing back to the sync coordinator,
-   * which has already recorded those sequence numbers as applied — so a
-   * discarded buffer is a silently lost remote update, not a retried one.
+   * Hand the updates buffered for a finished compaction to whatever doc is live
+   * now — the compacted replacement on the happy path, or the doc that took its
+   * place when the compaction was abandoned. applyRemoteUpdate diverts remote
+   * updates into this buffer for the whole compaction window and reports
+   * nothing back to the sync coordinator, which has already recorded those
+   * sequence numbers as applied — so a buffer that is discarded, or replayed
+   * into a doc with no 'update' handler, is a silently lost remote update, not
+   * a retried one.
+   *
+   * Always call this with the entry `this.docs` currently holds: applying to a
+   * detached entry would resurrect the update into a doc nothing reads.
    */
   private drainCompactionBuffer(noteId: string, target: ActiveDoc | undefined): void {
     const buffered = this.compactionBuffers.get(noteId)

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -117,6 +117,15 @@ compaction are buffered for it rather than applied directly, so an abandoned com
 hands its buffer to whichever doc is live at that point instead of discarding it: the sync
 coordinator counts those updates as applied and will not fetch them again.
 
+A compaction that succeeds hands its buffer over the same way, and only after the compacted
+doc has taken the entry's place and had its update handler attached. That handler is the one
+funnel that stores an update, broadcasts it to open editors and schedules the vault
+write-back, so replaying ahead of it would leave the compaction window's remote updates in
+memory alone — absent from the CRDT store after a restart and from the note's markdown file
+on disk. The compacted snapshot itself is applied before the handler is attached, on purpose:
+compaction has already persisted and pushed it, and routing it through the handler would
+store and broadcast the whole note a second time.
+
 Closing is asynchronous — it flushes the doc to persistence first — so a note can be
 reopened while its own close is still in flight. The reopen builds a fresh Y.Doc and takes
 over the provider's entry for that note, and the close then finds that the entry no longer


### PR DESCRIPTION
Closes #1318. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/sync/crdt-provider.ts:864-877` — on the **successful** path of
`compactDoc()`, the buffered remote updates were replayed into `newDoc` *before* the `update`
handler was attached:

```ts
const oldDoc = entry.doc
const newDoc = new Y.Doc()
Y.applyUpdate(newDoc, result.compacted)

const buffered = this.compactionBuffers.get(noteId) ?? []
for (const update of buffered) {
  Y.applyUpdate(newDoc, update, ORIGIN_NETWORK)   // <- nothing is listening yet
}

newDoc.on('update', (update, origin) => this.onDocUpdate(noteId, update, origin))
entry.doc = newDoc
```

`onDocUpdate` is the only caller of `persistUpdate`, `queueNetworkBroadcast` and
`scheduleWriteback`, so for those updates none of it ran. They were not persisted anywhere
else either: `applyRemoteUpdate` (`crdt-provider.ts:348`) diverts remote updates into
`compactionBuffers` and returns *before* touching the old doc, and what compaction writes to
the store is `result.compacted`, computed before the buffer existed. The `finally` then
deletes the buffer.

Net effect on **every** successful compaction that buffered at least one update: the
compaction window's remote updates lived only in the new doc's in-memory state. Gone from the
CRDT store after a quit or an eviction, never written back to the note's markdown file, never
broadcast. `CrdtSyncCoordinator` has already recorded those sequence numbers as applied, so
they are never re-fetched — a silent drop of note content, not a deferred one.

This is not the abandonment race #1285 / PR #1302 fixed; that one covers the path where
compaction is abandoned and `drainCompactionBuffer` replays into the live doc. This is the
happy path.

## What changed

`compactDoc()` only — one block moved, plus a comment on `drainCompactionBuffer`:

- Attach the `update` handler and swap `entry.doc = newDoc` **first**, then replay the buffer
  through the existing `drainCompactionBuffer(noteId, entry)`. The updates now take exactly
  the route an ordinary remote update takes: `onDocUpdate` → persist, network broadcast,
  write-back, `recordNetworkUpdate`.
- The replay stays **inside the `try`**, so `compactingDocs` still holds the note and
  `onDocUpdate`'s `maybeCompact` cannot re-enter (it also can't on byte count —
  `accumulatedBytes` was just reset). The `this.docs.get(noteId)` lookup inside `onDocUpdate`
  resolves the same `entry`, whose `.doc` is already `newDoc`, so `scheduleWriteback` is
  handed the live doc directly rather than relying on PR #1295's fire-time resolution to
  correct a stale reference.
- `result.compacted` is still applied **before** the handler is attached. Deliberate: it was
  already pushed and stored a few lines above, and routing it through `onDocUpdate` would
  store and broadcast the entire note a second time. There is a test pinning that.

Deliberately **not** done:

- **PR #1302 is untouched.** The pre-swap `live !== entry || live?.closing || entry.windowIds.size > 0`
  guard stays exactly as it is, and the replay happens only after it passes — with no `await`
  between the guard and the replay, so the buffer can never be resurrected into a doc that has
  since been superseded. The abandoned path still returns early into its own
  `drainCompactionBuffer(noteId, live)`.
- **PR #1295 is untouched**, and this change does not depend on it.
- No new buffer, flag or API. `drainCompactionBuffer` already did the right thing; it just was
  not called on this path.

## How it was proven

Two tests in `crdt-provider.test.ts`, driving the race through the real public API
(`open`/`updateMeta`/`compactDoc`/`applyRemoteUpdate`) with the snapshot push as the
suspension point. The store mock is made **stateful** for the first one — `storeUpdate`
appends, `getYDoc` replays — so a lost update shows up as missing note content after a
simulated restart rather than as a mock-call shape.

`persists, broadcasts and writes back the remote updates buffered by a successful compaction`
asserts all four observations in one `toEqual`, so a regression reports every limb it broke:

```
- Expected                                    + Received (origin/main)

-   "afterRestart": "pulled during compaction",   +   "afterRestart": undefined,
-   "broadcastToEditor": "pulled during compaction", +   "broadcastToEditor": undefined,
-   "writtenBackDoc": ["note-1", Doc{…}],         +   "writtenBackDoc": undefined,
    "inMemory": "pulled during compaction",       (unchanged — this is why it is silent)
    "dateAfterRestart": "2026-01-01",             (control: the pre-compaction local edit)
```

- `afterRestart` — a second `CrdtProvider` reading the same store back finds the update.
- `broadcastToEditor` — the editor reopens the note, the queued network broadcast flushes,
  and the decoded `CRDT_EVENTS.STATE_CHANGED` payload carries it.
- `writtenBackDoc` — `scheduleWriteback` is called with the note id and the **compacted live
  doc**.
- `inMemory` passes before and after: the update *is* in the doc, which is exactly why the
  loss is invisible until a restart.
- `dateAfterRestart` is the control — the local edit made before compaction survives the same
  round trip either way, so the assertion is not just "persistence is broken".

`does not re-store or re-broadcast the compacted snapshot itself` is the no-double-apply
guard: the snapshot reaches `storeUpdate` exactly once, exactly one stored update decodes to
the buffered remote title, and `scheduleWriteback` fires once.

Before/after on the same test file, reverting only `crdt-provider.ts` to `origin/main`
(`git checkout origin/main -- <file>`; no `git stash`):

```
before: Tests  2 failed | 46 passed (48)
after:  Tests  48 passed (48)
```

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  crdt-provider.test.ts crdt-writeback.test.ts crdt-ipc-handlers.test.ts engine-crdt.test.ts
                                              -> Test Files 4 passed, Tests 95 passed (95)
pnpm --filter @memry/desktop typecheck:node   -> clean
./node_modules/.bin/eslint apps/desktop/src/main/sync/crdt-provider.ts -> 0 errors
git diff --check                              -> clean
pnpm docs:impact --base origin/main --strict  -> covered
pnpm docs:build                               -> build complete in 9.27s
```

## Backward compatibility

In-memory doc lifetime and the order of two existing calls — no schema, migration, IPC
contract, sync protocol, vault format or settings shape is touched. The persisted bytes are a
strict superset of what was written before (the compacted snapshot, plus the buffered updates
that used to be dropped), and older peers and older stores read it unchanged.
