### PR TITLE
fix(tabs): honour inNewTab and inBackground for sidebar Open in New Tab, Cmd-click and middle-click

### DIFF
--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar-nav-item.new-tab.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar-nav-item.new-tab.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * "Open in New Tab" must actually open a new tab.
+ *
+ * Driven through the real `SidebarNavItem` (so the Cmd-click / middle-click /
+ * context-menu handlers are the ones under test) against the real `TabProvider`
+ * and reducer. A stubbed `openTab` cannot see this defect: the hook did call
+ * `openTab`/`setActiveTab`, it just called them with intent the reducer then
+ * deduplicated away. Only the resulting tab list tells the truth.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { TabProvider, useTabActions, useTabs } from '@/contexts/tabs'
+import { createTabFromSidebarItem } from '@/contexts/tabs/helpers'
+import type { SidebarItem } from '@/contexts/tabs/types'
+import { SettingsModalProvider } from '@/contexts/settings-modal-context'
+import { FEATURES_SETTINGS_DEFAULTS } from '@memry/contracts/settings-schemas'
+import { SidebarNavItem } from './sidebar-nav-item'
+
+// Feature gating is a different concern; this keeps the hook off window.api so
+// the test only exercises tab routing.
+vi.mock('@/hooks/use-feature-flags', () => ({
+  useFeatureFlags: () => ({ flags: FEATURES_SETTINGS_DEFAULTS })
+}))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key })
+}))
+
+const NOTE_ITEM: SidebarItem = {
+  type: 'note',
+  title: 'Note A',
+  path: '/notes/a.md',
+  entityId: 'note-a'
+}
+
+/** A declared SINGLETON_TAB_TYPES view — one instance, by design. */
+const INBOX_ITEM: SidebarItem = {
+  type: 'inbox',
+  title: 'Inbox',
+  path: '/inbox'
+}
+
+function Probe({ item }: { item: SidebarItem }): React.JSX.Element {
+  const { state } = useTabs()
+  const { openTab } = useTabActions()
+
+  const group = state.tabGroups[state.activeGroupId]
+  const matches = group.tabs.filter((tab) =>
+    item.entityId ? tab.entityId === item.entityId : tab.type === item.type
+  )
+  const activeTab = group.tabs.find((tab) => tab.id === group.activeTabId)
+
+  return (
+    <div>
+      <span data-testid="tabs-for-item">{matches.length}</span>
+      {/* Distinct reducer-minted ids, not one tab counted twice. */}
+      <span data-testid="distinct-tab-ids">{new Set(matches.map((tab) => tab.id)).size}</span>
+      <span data-testid="active-tab-type">{activeTab?.type ?? 'none'}</span>
+      <span data-testid="active-tab-is-item">
+        {String(
+          activeTab !== undefined &&
+            (item.entityId ? activeTab.entityId === item.entityId : activeTab.type === item.type)
+        )}
+      </span>
+      <button
+        type="button"
+        onClick={() => openTab(createTabFromSidebarItem(item), { background: true })}
+      >
+        seed-unfocused-tab
+      </button>
+    </div>
+  )
+}
+
+const renderItem = (item: SidebarItem): void => {
+  render(
+    <SettingsModalProvider>
+      <TabProvider>
+        <Probe item={item} />
+        <SidebarNavItem item={item} />
+      </TabProvider>
+    </SettingsModalProvider>
+  )
+}
+
+/** The sidebar row itself (the Probe's buttons are named, this one is not). */
+const sidebarRow = (item: SidebarItem): HTMLElement =>
+  screen.getByRole('button', { name: item.title })
+
+/** Item already open, sitting unfocused behind the default Home tab. */
+const seedUnfocusedTab = (item: SidebarItem): void => {
+  fireEvent.click(screen.getByText('seed-unfocused-tab'))
+  expect(screen.getByTestId('tabs-for-item')).toHaveTextContent('1')
+  expect(screen.getByTestId('active-tab-type')).toHaveTextContent('home')
+}
+
+describe('SidebarNavItem — open in new tab', () => {
+  it('gives a plain click the tab that is already open, not a second one', () => {
+    renderItem(NOTE_ITEM)
+    seedUnfocusedTab(NOTE_ITEM)
+
+    fireEvent.click(sidebarRow(NOTE_ITEM))
+
+    expect(screen.getByTestId('tabs-for-item')).toHaveTextContent('1')
+    expect(screen.getByTestId('active-tab-is-item')).toHaveTextContent('true')
+  })
+
+  it('opens a second tab on Cmd-click even though the item is already open', () => {
+    renderItem(NOTE_ITEM)
+    seedUnfocusedTab(NOTE_ITEM)
+
+    fireEvent.click(sidebarRow(NOTE_ITEM), { metaKey: true })
+
+    expect(screen.getByTestId('tabs-for-item')).toHaveTextContent('2')
+    expect(screen.getByTestId('distinct-tab-ids')).toHaveTextContent('2')
+    // Cmd-click without Shift focuses what it opened.
+    expect(screen.getByTestId('active-tab-is-item')).toHaveTextContent('true')
+  })
+
+  it('opens a second tab on Ctrl-click (Windows/Linux modifier)', () => {
+    renderItem(NOTE_ITEM)
+    seedUnfocusedTab(NOTE_ITEM)
+
+    fireEvent.click(sidebarRow(NOTE_ITEM), { ctrlKey: true })
+
+    expect(screen.getByTestId('tabs-for-item')).toHaveTextContent('2')
+    expect(screen.getByTestId('distinct-tab-ids')).toHaveTextContent('2')
+  })
+
+  it('opens a second tab in the background on middle-click', () => {
+    renderItem(NOTE_ITEM)
+    seedUnfocusedTab(NOTE_ITEM)
+
+    fireEvent.mouseDown(sidebarRow(NOTE_ITEM), { button: 1 })
+
+    expect(screen.getByTestId('tabs-for-item')).toHaveTextContent('2')
+    expect(screen.getByTestId('distinct-tab-ids')).toHaveTextContent('2')
+    // Background: focus stays where it was.
+    expect(screen.getByTestId('active-tab-type')).toHaveTextContent('home')
+  })
+
+  it('opens a second tab from the "Open in New Tab" context-menu entry', async () => {
+    renderItem(NOTE_ITEM)
+    seedUnfocusedTab(NOTE_ITEM)
+
+    fireEvent.contextMenu(sidebarRow(NOTE_ITEM))
+    const menuItem = await screen.findByText('Open in New Tab')
+    fireEvent.click(menuItem)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tabs-for-item')).toHaveTextContent('2')
+    })
+    expect(screen.getByTestId('distinct-tab-ids')).toHaveTextContent('2')
+    expect(screen.getByTestId('active-tab-is-item')).toHaveTextContent('true')
+  })
+
+  it('keeps singleton views single-instance and leaves focus alone in the background', () => {
+    // Deliberate policy: SINGLETON_TAB_TYPES (Inbox, Calendar, Tasks, …) are
+    // declared one-instance, so "new tab" cannot mint a second identical view.
+    // What it must still honour is `inBackground` — middle-click may not yank
+    // focus onto a tab it did not open.
+    renderItem(INBOX_ITEM)
+    seedUnfocusedTab(INBOX_ITEM)
+
+    fireEvent.mouseDown(sidebarRow(INBOX_ITEM), { button: 1 })
+
+    expect(screen.getByTestId('tabs-for-item')).toHaveTextContent('1')
+    expect(screen.getByTestId('active-tab-type')).toHaveTextContent('home')
+  })
+
+  it('still focuses the existing singleton tab on a foreground open', () => {
+    renderItem(INBOX_ITEM)
+    seedUnfocusedTab(INBOX_ITEM)
+
+    fireEvent.click(sidebarRow(INBOX_ITEM), { metaKey: true })
+
+    expect(screen.getByTestId('tabs-for-item')).toHaveTextContent('1')
+    expect(screen.getByTestId('active-tab-type')).toHaveTextContent('inbox')
+  })
+})

--- a/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
@@ -372,6 +372,7 @@ export const TabProvider = ({
           groupId: options.groupId,
           position: options.position,
           background: options.background,
+          forceNew: options.forceNew,
           replaceActive: options.replaceActive
         }
       })

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
@@ -110,6 +110,7 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
         groupId = state.activeGroupId,
         position,
         background,
+        forceNew,
         replaceActive
       } = action.payload
       const targetGroup = state.tabGroups[groupId]
@@ -143,8 +144,11 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
         }
       }
 
+      // `forceNew` is an explicit "I want another tab" (sidebar Open in New Tab,
+      // Cmd/Ctrl-click, middle-click). It skips every dedup/focus branch below so
+      // the open falls through to the mint-a-new-tab path.
       // Per-group singleton dedup: only check within the target group
-      if (tab.type) {
+      if (!forceNew && tab.type) {
         const existingInGroup = findExistingTabInGroup(targetGroup, tab.type)
         if (
           existingInGroup &&
@@ -179,6 +183,7 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
 
       // Cross-group singleton focus: when no explicit groupId, find singleton anywhere
       if (
+        !forceNew &&
         SINGLETON_TAB_TYPES.includes(tab.type) &&
         !action.payload.groupId &&
         tab.entityId === undefined
@@ -201,7 +206,7 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
       }
 
       // Per-group entityId dedup
-      if (tab.entityId) {
+      if (!forceNew && tab.entityId) {
         const existingInGroup = findTabByEntityIdInGroup(targetGroup, tab.entityId)
         if (existingInGroup) {
           const updatedTabs = targetGroup.tabs.map((t) =>

--- a/apps/desktop/src/renderer/src/contexts/tabs/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/types.ts
@@ -233,6 +233,8 @@ export type TabAction =
         groupId?: string
         position?: number
         background?: boolean
+        /** Skip every dedup/focus branch and always mint a new tab */
+        forceNew?: boolean
         /** Replace the currently active tab instead of creating a new one */
         replaceActive?: boolean
       }

--- a/apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx
@@ -247,18 +247,22 @@ describe('more major hooks coverage', () => {
       { type: 'note', title: 'B', path: '/notes/b.md', entityId: 'note-b' } as never,
       {}
     )
+    // A plain open must never force a duplicate: `forceNew: false` is what keeps
+    // the reducer free to focus a tab this item already has.
     expect(mocks.openTab).toHaveBeenCalledWith(
       expect.objectContaining({ entityId: 'note-b', isPreview: false }),
-      { background: undefined }
+      { background: undefined, forceNew: false }
     )
 
     result.current.openSidebarItem(
       { type: 'note', title: 'C', path: '/notes/c.md', entityId: 'note-c' } as never,
       { inNewTab: true, inBackground: true }
     )
+    // `inNewTab` on a non-singleton reaches the reducer as `forceNew`, which is
+    // what makes it skip entity dedup and mint a genuinely new tab.
     expect(mocks.openTab).toHaveBeenCalledWith(
       expect.objectContaining({ entityId: 'note-c', isPreview: false }),
-      { background: true }
+      { background: true, forceNew: true }
     )
 
     result.current.openSidebarItem(

--- a/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.ts
@@ -165,13 +165,20 @@ export const useSidebarNavigation = () => {
         return
       }
 
-      const { inBackground, toTheSide } = options
+      const { inNewTab, inBackground, toTheSide } = options
       const currentState = stateRef.current
+
+      // "Open in New Tab" / Cmd-click / middle-click earn a genuinely new tab —
+      // but only for items that can meaningfully exist twice. SINGLETON_TAB_TYPES
+      // (Home, Inbox, Calendar, Tasks, Journal, Graph, Tags) are declared
+      // single-instance and stay that way; a second identical Inbox is not what
+      // the gesture is for, so those keep focusing the tab that already exists.
+      const forceNewTab = inNewTab === true && !SINGLETON_TAB_TYPES.includes(item.type)
 
       // Check for existing tab
       const existingTab = findExistingTabForItem(currentState, item)
 
-      if (existingTab && !toTheSide) {
+      if (existingTab && !toTheSide && !forceNewTab) {
         // Re-open singletons that carry per-view intent so the reducer merges
         // the fresh viewState (nonce) into the existing tab and refocuses it.
         // Passing the found groupId keeps the merge in the right split-view pane.
@@ -182,8 +189,12 @@ export const useSidebarNavigation = () => {
           })
           return
         }
-        // Focus existing tab
-        setActiveTab(existingTab.tab.id, existingTab.groupId)
+        // Focus existing tab — unless the caller asked to stay put (middle-click
+        // or Shift+Cmd-click on an item we just declined to duplicate). Stealing
+        // focus is the one thing `inBackground` exists to prevent.
+        if (!inBackground) {
+          setActiveTab(existingTab.tab.id, existingTab.groupId)
+        }
         return
       }
 
@@ -200,7 +211,7 @@ export const useSidebarNavigation = () => {
         const newGroupId = splitView('horizontal', currentState.activeGroupId)
         openTab(tabData, { groupId: newGroupId ?? undefined, background: inBackground })
       } else {
-        openTab(tabData, { background: inBackground })
+        openTab(tabData, { background: inBackground, forceNew: forceNewTab })
       }
     },
     [openTab, setActiveTab, splitView, flags, openSettings]

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -48,6 +48,21 @@ heavier surfaces such as Tasks, Calendar, Graph, and the right-side Agent/Day Pa
 user opens them. This keeps startup memory tied to the visible workspace instead of every possible
 feature surface.
 
+### Opening a Second Copy
+
+When you want the same item open twice — two places in a long note, a reference you keep alongside your work — ask for a new tab explicitly from the sidebar:
+
+| Gesture                                      | Result                              |
+| -------------------------------------------- | ----------------------------------- |
+| <kbd>⌘</kbd> (macOS) / <kbd>Ctrl</kbd> click | Opens another tab and focuses it    |
+| <kbd>⌘</kbd>+<kbd>⇧</kbd> click              | Opens another tab in the background |
+| Middle-click                                 | Opens another tab in the background |
+| Right-click → **Open in New Tab**            | Opens another tab and focuses it    |
+
+Each copy is an independent tab: close, pin, or move one and the other stays put. Edits made in either appear in both.
+
+Whole-app views — Home, Inbox, Calendar, Tasks, Journal, Graph, and Tags — stay single-instance, since a second copy would show exactly the same thing. These gestures focus the tab that already exists; the background gestures leave your focus where it is.
+
 ## Mouse Navigation
 
 Mouse Back and Forward side buttons move through tab focus history across the whole window, including split panes. Back returns to the previously focused tab; Forward replays the next tab after a Back action. Opening or selecting another tab starts a new history path.


### PR DESCRIPTION
Closes #1322. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`OpenSidebarItemOptions.inNewTab` was declared but never destructured, so it could not influence anything.

`apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.ts:168` (pre-fix):

```ts
const { inBackground, toTheSide } = options   // inNewTab dropped on the floor
...
if (existingTab && !toTheSide) {
  ...
  setActiveTab(existingTab.tab.id, existingTab.groupId)   // fires regardless
  return
}
```

Three controls passed `inNewTab` and got a plain focus instead:

- `components/sidebar/sidebar-nav-item.tsx:53-56` — Cmd/Ctrl-click
- `components/sidebar/sidebar-nav-item.tsx:67` — middle-click
- `components/sidebar/sidebar-item-context-menu.tsx:50` — the **"Open in New Tab"** menu entry

Same defect shape, second half: `inBackground` was inert on that branch too. It was only forwarded when `item.viewState` was set; otherwise `setActiveTab` yanked focus even though the caller had explicitly asked not to. Middle-click on an already-open item stole focus.

Skipping the hook's short-circuit is not sufficient on its own. `OPEN_TAB` dedups **within the target group** unconditionally (`reducers/tab-crud-reducer.ts` — per-group singleton dedup, per-group `entityId` dedup); only the *cross-group* branches are gated on `!action.payload.groupId`. That is why `toTheSide` already produces a second tab for an open item (it opens into a brand-new empty pane where nothing can match) while a same-pane "new tab" could not. The reducer needed a real opt-out.

## What changed

`OpenTabOptions.forceNew` already existed in `types.ts:219` ("Open even if singleton exists") and was never forwarded or read anywhere — the plumbing was simply missing. Completed it, and used it:

- `contexts/tabs/types.ts` — added `forceNew?: boolean` to the `OPEN_TAB` action payload.
- `contexts/tabs/context.tsx` — `openTab` now forwards `options.forceNew` into the dispatch.
- `contexts/tabs/reducers/tab-crud-reducer.ts` — `forceNew` skips all three dedup/focus branches so the open falls through to the mint-a-new-tab path. Three `!forceNew &&` guards, no restructuring.
- `hooks/use-sidebar-navigation.ts` — destructures `inNewTab`; skips the existing-tab short-circuit and passes `forceNew` when honouring it; and only calls `setActiveTab` when `!inBackground`.

### The semantics question, answered deliberately

**With `inNewTab`, an already-open item gets a second, independent tab — but only if it is not a `SINGLETON_TAB_TYPES` view.**

- **Content items** (notes, files, folders, canvases, tags, searches, collections, agent chats, template editors) get a real second tab. That is what the label promises, it matches browser and Obsidian behaviour, and it is not a new state for the app to be in: `toTheSide` already creates duplicate entity tabs today, and `use-sidebar-navigation.split.test.tsx` asserts exactly that ("gives the item its own tab in the new pane even when it is already open elsewhere"). Duplicate tabs get distinct reducer-minted ids via `generateId()`; the new test asserts that directly rather than just counting matches.
- **Singleton views** (Home, Inbox, Calendar, Tasks, Journal, Graph, Tags, plus the legacy `all-tasks`/`today`/`completed`) stay single-instance. `SINGLETON_TAB_TYPES` is a deliberate, documented invariant enforced in two separate reducer branches; a second identical Inbox shows the same content and would make every `findExistingTab` consumer ambiguous. For these, `inNewTab` focuses the existing tab — but now correctly honours `inBackground`, so middle-click no longer steals focus. The policy lives in the hook; the reducer's `forceNew` remains a full override, matching its existing doc comment.

Plain clicks are unchanged and still focus the existing tab — covered by a control test that passes both before and after.

### Deliberately not done

- **`toTheSide` untouched.** It splits into a fresh empty pane where nothing can dedup, so it needs no `forceNew`, and `use-sidebar-navigation.split.test.tsx` pins its current behaviour.
- **`openFromSidebar` untouched.** Its signature already excludes `forceNew` (`Omit<OpenTabOptions, 'forceNew'>`) on purpose.
- **No UI change to the context menu.** Hiding/disabling "Open in New Tab" for singletons was considered and rejected as more churn than this issue warrants; the entry now does the closest honest thing.

## How it was proven

New test `apps/desktop/src/renderer/src/components/sidebar/sidebar-nav-item.new-tab.test.tsx` drives the real `SidebarNavItem` (so the actual Cmd-click / Ctrl-click / middle-click / context-menu handlers run) inside a real `TabProvider` and reducer. A stubbed `openTab` cannot see this bug — the hook *did* call `openTab`, the reducer just deduplicated the result away — so the assertions read the resulting tab list.

Before/after on the same test file, source reverted to `origin/main` with the test kept:

- **Before the fix: 5 failed | 2 passed (7)**
- **After the fix: 7 passed (7)**

The 2 that pass both ways are the controls: plain click focuses the existing tab, and a foreground open of a singleton still focuses it.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  apps/desktop/src/renderer/src/components/sidebar/sidebar-nav-item.new-tab.test.tsx
  → Test Files 1 passed (1) | Tests 7 passed (7)

# regression sweep over everything that touches the reducer/hook
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  apps/desktop/src/renderer/src/contexts/tabs \
  apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.split.test.tsx \
  apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.test.ts \
  apps/desktop/src/renderer/src/components/sidebar/sidebar-nav.test.tsx
  → Test Files 14 passed (14) | Tests 119 passed (119)

pnpm --filter @memry/desktop typecheck:web   → clean, no output
./node_modules/.bin/eslint <4 changed source files>   → 0 errors, 0 warnings
git diff --check   → clean
pnpm docs:impact --base origin/main --strict   → covered
pnpm docs:build   → build complete in 6.93s
```

Docs: `apps/docs/src/user-guide/tabs-split-view.md` gains an "Opening a Second Copy" subsection covering the four gestures and the singleton exception.

## Backward compatibility

Renderer-only and additive: `forceNew` is a new optional field on an in-memory action payload, defaulting to the pre-existing behaviour when absent. No DB, IPC contract, sync, settings, or persisted-session shape is touched — `Tab` and `TabSystemState` are unchanged, so restored sessions from older versions load exactly as before.


---

### Follow-up: existing expectation updated (rebased on latest `main`)

`src/renderer/src/hooks/more-major-hooks.test.tsx` asserted `openTab`'s options object **exactly**, so the added `forceNew` broke it. Both affected expectations now pin the real behaviour rather than being widened:

- plain open → `{ background: undefined, forceNew: false }` — a plain click must **not** force a duplicate, which is what leaves the reducer free to focus an existing tab.
- `{ inNewTab: true, inBackground: true }` on a note → `{ background: true, forceNew: true }` — previously this expectation passed only because `inNewTab` was inert; it now pins the flag actually reaching the reducer.

The `toTheSide` expectation in the same test is unchanged, since that path deliberately does not pass `forceNew`.

Swept every test file referencing `useSidebarNavigation`/`openSidebarItem` (19 files) for the same exact-options pattern; `more-major-hooks.test.tsx` was the only one affected — every other `openTab` assertion either calls `openTab` directly or mocks the hook itself.

**Post-rebase verification**

```
vitest --project renderer <19 files touching useSidebarNavigation> + own suite
  → Test Files 19 passed | Tests 252 passed
vitest --project renderer src/renderer/src/hooks/more-major-hooks.test.tsx
  → Test Files 1 passed (1) | Tests 8 passed (8)
vitest --project renderer <own suite + contexts/tabs + both use-sidebar-navigation tests>
  → Test Files 14 passed (14) | Tests 124 passed (124)
pnpm --filter @memry/desktop typecheck:web  → clean
eslint / git diff --check                   → clean
pnpm docs:impact --base origin/main --strict → covered
```
