### PR TITLE
fix(agent): honour a stop pressed before the backend returns its run handle

### DIFF
--- a/apps/desktop/src/main/agent/runtime/__tests__/runtime-cancel-before-handle.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/runtime-cancel-before-handle.test.ts
@@ -1,0 +1,397 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AgentBackendOptions } from '@memry/contracts/ipc-agent'
+
+const mocks = vi.hoisted(() => ({
+  setWriteGate: vi.fn(),
+  broadcastAgentEvent: vi.fn(),
+  streamText: vi.fn()
+}))
+
+vi.mock('../../mcp/lifecycle', () => ({
+  setWriteGate: mocks.setWriteGate
+}))
+
+vi.mock('../event-bus', () => ({
+  broadcastAgentEvent: mocks.broadcastAgentEvent
+}))
+
+vi.mock('../../../telemetry/track', () => ({
+  trackMainEvent: vi.fn()
+}))
+
+vi.mock('../../../telemetry/diagnostics', () => ({
+  trackMainError: vi.fn(),
+  trackMainLog: vi.fn()
+}))
+
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: vi.fn(() => ({
+    chat: vi.fn((model: string) => ({ provider: 'openai-compatible', model }))
+  }))
+}))
+
+vi.mock('ollama-ai-provider-v2', () => ({
+  createOllama: vi.fn(() => vi.fn((model: string) => ({ provider: 'ollama', model })))
+}))
+
+vi.mock('ai', () => ({
+  streamText: mocks.streamText,
+  stepCountIs: vi.fn((count: number) => ({ type: 'step-count', count })),
+  tool: (definition: unknown) => definition
+}))
+
+import { ClaudeCliBackend } from '../../backends/claude-cli-backend'
+import { CodexCliBackend } from '../../backends/codex-cli-backend'
+import { LocalOpenAICompatibleBackend } from '../../backends/local-openai-compatible-backend'
+import type { AgentBackendRegistry } from '../../backends/registry'
+import type { AgentBackend, RawSubprocessHandle } from '../../backends/types'
+import type { ConversationStore } from '../../storage/conversation-store'
+import type { MessageStore } from '../../storage/message-store'
+import type { Message } from '../../storage/types'
+import { AgentRuntime } from '../runtime'
+import { runTurn, type TurnDeps } from '../turn'
+
+const CONVERSATION_ID = 'conversation-1'
+const MODEL = 'llama3.2'
+
+/**
+ * The window this file is about: a stop pressed after the turn started but
+ * before `backend.runTurn()` produced its handle. `subprocesses` is empty for
+ * that whole stretch, so the cancel used to walk an empty map, find nothing and
+ * let the turn run to completion — assistant reply, tokens and all.
+ *
+ * Every case below drives the REAL backend class and the REAL `runTurn`, with
+ * only the outermost I/O faked (fetch for the local probe, spawn for the CLIs),
+ * and asserts the user-visible outcome: a cancelled turn, not a completed one.
+ */
+describe('cancelling a turn before the backend produces its run handle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // The widest window of the three, and the one users actually hit: the local
+  // backend awaits a capability probe (a /v1/models call plus a streaming
+  // completion) before it ever constructs its handle, so a slow or wedged local
+  // provider parks the turn here for as long as it likes.
+  it('aborts the local backend when stop lands during its capability probe', async () => {
+    const signals: AbortSignal[] = []
+    mocks.streamText.mockImplementation((options: { abortSignal?: AbortSignal }) => {
+      const signal = options.abortSignal
+      if (signal) signals.push(signal)
+      return {
+        fullStream: (async function* () {
+          // What the AI SDK does with an already-aborted signal: it never
+          // streams a token. Pre-fix the signal is clean here and the reply
+          // lands in the transcript.
+          if (signal?.aborted) throw new Error('The operation was aborted.')
+          yield { type: 'text-delta', text: 'assistant reply' }
+          yield { type: 'finish' }
+        })()
+      }
+    })
+
+    const probeEntered = gate()
+    const releaseProbe = gate()
+    const fetchImpl = (async (input: URL | RequestInfo) => {
+      if (String(input).includes('/models')) {
+        return new Response(JSON.stringify({ data: [{ id: MODEL }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        })
+      }
+      // Round trip two of the probe. Held open, then failed, so the probe
+      // reports "no streaming" and `run()` proceeds without the tool probe.
+      probeEntered.open()
+      await releaseProbe.promise
+      throw new Error('probe connection reset')
+    }) as unknown as typeof fetch
+
+    const backend = new LocalOpenAICompatibleBackend({
+      getSettings: async () => ({
+        preset: 'lmstudio',
+        baseUrl: 'http://localhost:1234/v1',
+        model: MODEL,
+        apiKeyConfigured: false,
+        allowNonLoopback: false
+      }),
+      getApiKey: async () => null,
+      toolBridge: { execute: vi.fn() } as never,
+      fetch: fetchImpl
+    })
+
+    const messages = await runCancelledTurn({
+      backend,
+      backendOptions: { backend: 'local_openai_compatible', model: MODEL, toolsEnabled: true },
+      reachedBackend: probeEntered.promise,
+      release: () => releaseProbe.open()
+    })
+
+    expect(signals).toHaveLength(1)
+    expect(signals[0]?.aborted).toBe(true)
+    expectCancelledTurn(messages)
+  })
+
+  it('kills the Claude CLI child when stop lands during its spawn', async () => {
+    const child = createFakeChild()
+    const backend = new ClaudeCliBackend({ spawn: child.spawn })
+
+    const messages = await runCancelledTurn({
+      backend,
+      backendOptions: { backend: 'claude_cli', claudeEffort: 'low' },
+      reachedBackend: child.entered,
+      release: child.release
+    })
+
+    expect(child.killCount()).toBe(1)
+    expectCancelledTurn(messages)
+  })
+
+  it('kills the Codex CLI child when stop lands during its spawn', async () => {
+    const child = createFakeChild()
+    const backend = new CodexCliBackend({ spawn: child.spawn })
+
+    const messages = await runCancelledTurn({
+      backend,
+      backendOptions: { backend: 'codex_cli', reasoningEffort: 'medium' },
+      reachedBackend: child.entered,
+      release: child.release
+    })
+
+    expect(child.killCount()).toBe(1)
+    expectCancelledTurn(messages)
+  })
+})
+
+describe('AgentRuntime cancel-before-handle bookkeeping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('kills a run handle that registers after the stop was pressed', () => {
+    const runtime = createRuntime()
+    const kill = vi.fn()
+
+    runtime.acquireTurnLock(CONVERSATION_ID)
+    runtime.cancelTurn(CONVERSATION_ID)
+    runtime.trackSubprocess(CONVERSATION_ID, { pid: 1, kill, waitExit: async () => 0 })
+
+    expect(kill).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves handles of other conversations alone', () => {
+    const runtime = createRuntime()
+    const kill = vi.fn()
+
+    runtime.cancelTurn(CONVERSATION_ID)
+    runtime.trackSubprocess('conversation-2', { pid: 2, kill, waitExit: async () => 0 })
+
+    expect(kill).not.toHaveBeenCalled()
+  })
+
+  // The flag must never outlive the turn it was pressed against, or the next
+  // message the user sends would be stopped before it started.
+  it('does not carry a stop over into the next turn', () => {
+    const runtime = createRuntime()
+    const kill = vi.fn()
+
+    runtime.acquireTurnLock(CONVERSATION_ID)
+    runtime.cancelTurn(CONVERSATION_ID)
+    runtime.releaseTurnLock(CONVERSATION_ID)
+
+    runtime.acquireTurnLock(CONVERSATION_ID)
+    runtime.trackSubprocess(CONVERSATION_ID, { pid: 3, kill, waitExit: async () => 0 })
+
+    expect(kill).not.toHaveBeenCalled()
+  })
+})
+
+function createRuntime(): AgentRuntime {
+  return new AgentRuntime({
+    conversations: {} as ConversationStore,
+    messages: {} as MessageStore
+  })
+}
+
+async function runCancelledTurn(input: {
+  backend: AgentBackend
+  backendOptions: AgentBackendOptions
+  reachedBackend: Promise<void>
+  release: () => void
+}): Promise<Message[]> {
+  const runtime = createRuntime()
+  const messages = createMessageStore()
+
+  // Mirrors agent-handlers.ts SEND_TURN: the lock is taken, then the turn runs
+  // with trackRunHandle wired straight into the runtime's subprocess map.
+  runtime.acquireTurnLock(CONVERSATION_ID)
+  const turn = runTurn(
+    {
+      conversations: createConversationStore(),
+      messages: messages.store,
+      backends: createRegistry(input.backend),
+      trackRunHandle: trackRunHandleLike(runtime)
+    },
+    {
+      conversationId: CONVERSATION_ID,
+      sourceWindowId: 'window-1',
+      text: 'hi',
+      attachments: [],
+      backendOptions: input.backendOptions
+    }
+  ).finally(() => runtime.releaseTurnLock(CONVERSATION_ID))
+
+  await input.reachedBackend
+  runtime.cancelTurn(CONVERSATION_ID)
+  input.release()
+  await turn
+
+  return messages.stored
+}
+
+function expectCancelledTurn(stored: Message[]): void {
+  const assistant = stored.find((message) => message.role === 'assistant')
+  expect(assistant?.status).toBe('error')
+
+  const kinds = mocks.broadcastAgentEvent.mock.calls.map(
+    (call) => (call[0] as { kind: string }).kind
+  )
+  expect(kinds).toContain('turn_error')
+  expect(kinds).not.toContain('turn_completed')
+}
+
+// Exactly the wrapper agent-handlers.ts installs, so the test exercises the real
+// registration path rather than a stand-in for it.
+function trackRunHandleLike(runtime: AgentRuntime): NonNullable<TurnDeps['trackRunHandle']> {
+  return (conversationId, subprocess) => {
+    runtime.trackSubprocess(conversationId, subprocess)
+    return {
+      ...subprocess,
+      cleanup: async () => {
+        try {
+          await subprocess.cleanup()
+        } finally {
+          runtime.untrackSubprocess(subprocess.pid)
+        }
+      }
+    }
+  }
+}
+
+/**
+ * A CLI child that cannot exist until the test lets the spawn finish. Killed
+ * before its stdout is read it produces nothing and exits 143; left alone it
+ * exits 0, which is the "stop was dropped" outcome.
+ */
+function createFakeChild(): {
+  spawn: () => Promise<RawSubprocessHandle>
+  entered: Promise<void>
+  release: () => void
+  killCount: () => number
+} {
+  const entered = gate()
+  const release = gate()
+  let kills = 0
+  let killed = false
+
+  return {
+    entered: entered.promise,
+    release: () => release.open(),
+    killCount: () => kills,
+    spawn: async () => {
+      entered.open()
+      await release.promise
+      return {
+        stdout: (async function* () {
+          if (killed) return
+          yield Buffer.from('')
+        })(),
+        stderr: (async function* () {})(),
+        pid: 4242,
+        kill: () => {
+          kills += 1
+          killed = true
+        },
+        waitExit: async () => (killed ? 143 : 0),
+        cleanup: async () => {}
+      }
+    }
+  }
+}
+
+function createRegistry(backend: AgentBackend): AgentBackendRegistry {
+  return { get: vi.fn(() => backend), list: vi.fn(() => [backend]) }
+}
+
+function createMessageStore(): { store: MessageStore; stored: Message[] } {
+  let nextId = 0
+  const stored: Message[] = []
+  const store = {
+    append: (input: Parameters<MessageStore['append']>[0]): Message => {
+      const message: Message = {
+        id: `message-${(nextId += 1)}`,
+        conversationId: input.conversationId,
+        role: input.role,
+        content: input.content,
+        toolCallId: input.toolCallId ?? null,
+        attachments: input.attachments,
+        status: input.status,
+        vectorClock: { d: 1 },
+        createdAt: nextId,
+        updatedAt: nextId,
+        deletedAt: null
+      }
+      stored.push(message)
+      return message
+    },
+    getById: (id: string) => stored.find((message) => message.id === id) ?? null,
+    listByConversation: () => [...stored],
+    updateStreaming: vi.fn(),
+    markTerminal: (id: string, status: Message['status']) => {
+      const message = stored.find((entry) => entry.id === id)
+      if (!message) throw new Error(`Message ${id} not found`)
+      message.status = status
+      return message
+    }
+  } as unknown as MessageStore
+
+  return { store, stored }
+}
+
+function createConversationStore(): ConversationStore {
+  const conversation = {
+    id: CONVERSATION_ID,
+    vaultId: 'vault-1',
+    // Not the default title, so the turn never starts a second run for the title.
+    title: 'Existing conversation',
+    backend: 'claude_cli',
+    backendModel: null,
+    trustList: [],
+    pinned: false,
+    vectorClock: {},
+    fieldClocks: {},
+    createdAt: 1,
+    updatedAt: 1,
+    deletedAt: null,
+    lastSyncedAt: null
+  }
+  return {
+    create: vi.fn(),
+    getById: vi.fn(() => conversation),
+    listByVault: vi.fn(() => [conversation]),
+    update: vi.fn(),
+    softDelete: vi.fn(),
+    addToTrustList: vi.fn(),
+    removeFromTrustList: vi.fn()
+  } as unknown as ConversationStore
+}
+
+// A one-shot latch. Every wait in this file is for "the code reached here" or
+// "the test says go", so nothing needs to carry a value.
+function gate(): { promise: Promise<void>; open: () => void } {
+  let open!: () => void
+  const promise = new Promise<void>((resolve) => {
+    open = () => resolve()
+  })
+  return { promise, open }
+}

--- a/apps/desktop/src/main/agent/runtime/runtime.ts
+++ b/apps/desktop/src/main/agent/runtime/runtime.ts
@@ -99,6 +99,16 @@ function trackApprovalDecided(decision: string, result: 'success' | 'failed'): v
 export class AgentRuntime {
   private pending = new Map<string, PendingApproval>()
   private subprocesses = new Map<number, TrackedSubprocess>()
+  // Conversations whose stop was pressed while no run handle existed yet.
+  //
+  // This is NOT a second cancellation mechanism: killing the tracked run handle
+  // is still the only thing that stops work. The flag exists because the handle
+  // can arrive *after* the decision to stop was taken, and `subprocesses` is
+  // empty for the whole of `await backend.runTurn(...)` — the local backend
+  // awaits a two-round-trip capability probe before it constructs its handle,
+  // the CLI backends await a spawn. A stop landing in that window used to walk
+  // an empty map and silently do nothing while the turn ran to completion.
+  private cancelRequested = new Set<string>()
   private turnLocks = new Set<string>()
   private activeTurns = new Map<string, Set<Promise<unknown>>>()
   private isShuttingDown = false
@@ -197,6 +207,10 @@ export class AgentRuntime {
   // kill is a signal to a real child; for the in-process local backend it is the
   // AbortController driving streamText, registered under a negative pseudo-pid.
   cancelTurn(conversationId: string): void {
+    // Recorded before the loop, so a handle still being built by an in-flight
+    // backend.runTurn() is killed the instant it registers (see trackSubprocess)
+    // instead of being missed by the walk below.
+    this.cancelRequested.add(conversationId)
     this.denyPendingApprovals(conversationId)
     for (const sub of this.subprocesses.values()) {
       if (sub.conversationId !== conversationId) continue
@@ -215,10 +229,19 @@ export class AgentRuntime {
       )
     }
     this.turnLocks.add(conversationId)
+    // A stop pressed against an earlier turn must never reach this one. Safe
+    // because this lock serializes turns per conversation: the previous turn
+    // registered its last run handle before its own releaseTurnLock, so there is
+    // nothing left for the flag to catch by the time a new turn can acquire.
+    this.cancelRequested.delete(conversationId)
   }
 
   releaseTurnLock(conversationId: string): void {
     this.turnLocks.delete(conversationId)
+    // Same reasoning, from the other end: the turn is over and produced its last
+    // handle before this ran, so dropping the flag here keeps the set bounded
+    // rather than holding an id until that conversation is used again.
+    this.cancelRequested.delete(conversationId)
   }
 
   trackTurn(conversationId: string, turn: Promise<unknown>): void {
@@ -251,7 +274,11 @@ export class AgentRuntime {
       kill: subprocess.kill,
       waitExit: subprocess.waitExit
     })
-    if (this.isShuttingDown) {
+    // Two late-arrival cases, one remedy: quit or stop was decided while this
+    // handle did not exist yet, so the walk in killAll/cancelTurn could not see
+    // it. This kill is the one that walk would have performed. The entry stays
+    // in the map either way — cleanup() is what untracks it.
+    if (this.isShuttingDown || this.cancelRequested.has(conversationId)) {
       try {
         subprocess.kill()
       } catch (error) {
@@ -283,6 +310,7 @@ export class AgentRuntime {
     await Promise.all(tracked.map((sub) => this.reapSubprocess(sub)))
 
     this.turnLocks.clear()
+    this.cancelRequested.clear()
 
     const turns = [...this.activeTurns.values()].flatMap((entries) => [...entries])
     if (turns.length > 0) {

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -151,6 +151,11 @@ Stop requests are scoped to the active conversation across Claude, Codex, and lo
 Automatic title generation and conversation summaries run through the selected backend without
 exposing memrynote MCP tools.
 
+Stop works from the moment you send a turn, including the pause before the backend starts answering
+— while a local provider is being checked for streaming and tool support, or while Claude or Codex is
+launching. Pressing stop in that window ends the turn there instead of letting it run to completion
+in the background.
+
 Stopping a turn — and quitting memrynote while one is running — asks the chat backend to shut down
 first, and forces it to close if it has not stopped shortly afterwards. Quitting waits for that to
 finish, so a backend is never left running in the background after memrynote is gone. A backend that


### PR DESCRIPTION
Closes #1332. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

Cancellation is handle-based: `cancelTurn` walks `subprocesses` and kills whatever it finds for the conversation (`apps/desktop/src/main/agent/runtime/runtime.ts:199`). Nothing enters that map until the backend has produced a run handle — `runtime/turn.ts:165`:

```ts
const rawSub = await backend.runTurn({ ... })          // <- map is empty for all of this
const sub = deps.trackRunHandle?.(input.conversationId, rawSub) ?? rawSub
```

So for the whole duration of that `await`, stop walked an empty map, found nothing, and returned. The turn then ran to completion as if the user had never pressed it: tokens spent, tools possibly executed, assistant reply in the transcript, and no signal at all that the stop was dropped.

The window is not instantaneous. `LocalOpenAICompatibleBackend.run()` awaits a capability probe before it constructs its handle (`backends/local-openai-compatible-backend.ts:153`) — a `/v1/models` call plus a streaming completion, i.e. two network round trips against a provider that may be slow or wedged, which is exactly when a user reaches for stop. The CLI backends have the smaller equivalent window of `await this.deps.spawn(...)`.

## What changed

`AgentRuntime` now records that a stop was requested, and `trackSubprocess` performs the kill the empty walk could not:

- `cancelTurn` adds the conversation to `cancelRequested` before it walks `subprocesses`.
- `trackSubprocess` kills on registration when the conversation is in that set — the same late-arrival guard that already existed one line above for `isShuttingDown`.
- `acquireTurnLock` / `releaseTurnLock` clear the entry, so a stop can never leak into a later turn and the set stays bounded. Safe because the turn lock serializes turns per conversation: the previous turn registered its last handle before its own release.
- `killAll` clears the set with `turnLocks`.

Result for the user is identical to a stop pressed mid-stream, because it takes the same path: the handle is killed, the backend exits non-zero, and `turn.ts` takes its existing error branch — assistant message marked `error`, `turn_error` broadcast, no `turn_completed`.

### Deliberately NOT the `AbortSignal` the issue suggested

The issue proposed threading an `AbortSignal` through `runTurn`/`generateTitle`/`summarize` into all three backends. I did not, for three reasons:

1. **It would break concurrent turns.** `resolveProbe` deliberately shares one in-flight probe across callers (`local-openai-compatible-backend.ts:113`, "Two turns starting at once must share one probe rather than racing"). A per-turn signal aborting the underlying fetches would reject a promise another conversation is awaiting, turning one user's stop into someone else's failed turn. Correcting for that needs refcounting the probe — real complexity, real new failure modes.
2. **The probe is not wasted work.** Its result is cached (`probeCache`) and reused by the next turn. Aborting it discards work the user is about to pay for again.
3. **PR #1308 warned against exactly a parallel registry**, and a per-conversation controller registry is one. This is not: cancellation is still only ever `kill()` on a tracked run handle. The flag does not stop anything itself — it only ensures the handle that arrives late gets the kill that was already requested.

What the signal would have bought over this is aborting the probe's HTTP requests. What it costs is the shared-probe regression above. Given the handle is killed within one `await` hop of being constructed — `trackRunHandle` runs synchronously after `runTurn` resolves, before the event loop starts — no assistant text is ever consumed and no tool ever runs either way.

**Also deliberately not done:** no early bail-out in `turn.ts`. A stop landing during compaction is already covered, because the summarize run registers a handle too: it gets killed, compaction fails into its existing warn-and-skip path, and the turn's own handle is then killed on registration. Adding a second check point would duplicate a guarantee `trackSubprocess` already gives for every handle a turn produces (turn, title and summary alike).

## How it was proven

New file `runtime/__tests__/runtime-cancel-before-handle.test.ts`. Each backend case drives the **real** backend class and the **real** `runTurn`, with only the outermost I/O faked — `fetch` for the local probe, `spawn` for the CLIs — and asserts the user-visible outcome, not the internals: assistant message `status === 'error'`, `turn_error` broadcast, and `turn_completed` never broadcast.

- **local** — `fetch` answers `/v1/models`, then parks on the streaming probe (round trip two). Stop is pressed while parked. Asserts the `AbortSignal` handed to `streamText` is aborted, so the model request never streamed a token.
- **claude_cli / codex_cli** — `spawn` parks, stop is pressed, spawn then resolves. Asserts the child was killed exactly once and exited 143 instead of 0.
- three unit cases lock the bookkeeping: kill on late registration, other conversations untouched, and a stop that must not carry into the next turn.

| run | `runtime.ts` | result |
|---|---|---|
| before | `origin/main` | **4 failed, 2 passed** |
| after | this branch | **6 passed** |

The two that pass in both runs are the negative controls (wrong conversation, next turn) — they are supposed to pass before the fix.

Pre-fix failures, in order: `expected false to be true` (local abort signal never fired), `expected +0 to be 1` ×2 (neither CLI child was ever killed), `expected "vi.fn()" to be called 1 times, but got 0 times`.

## Verification

```
pnpm --filter @memry/desktop typecheck:node                       clean, no output
eslint runtime.ts                                                 exit 0
prettier --check (both files)                                     all matched files use Prettier style
vitest --project main .../runtime-cancel-before-handle.test.ts    6 passed
vitest --project main apps/desktop/src/main/agent \
                      apps/desktop/src/main/ipc/agent-handlers.test.ts
                                                                  61 files, 460 tests passed (run twice)
pnpm docs:impact --base origin/main --strict                      covered
pnpm docs:build                                                   build complete
git diff --check                                                  clean
```

No renderer files touched, so `typecheck:web` is not implicated.

## Backward compatibility

None at risk. `cancelRequested` is a private field on a main-process class; no IPC contract, DB schema, sync payload, vault format or settings shape is touched, and the `agent:cancelTurn` channel and payload are unchanged. The only behavior change is that a stop pressed in a window where it previously did nothing now does what a stop pressed a moment later already did.
