### PR TITLE
fix(sync): emit terminal transfer phases so a dead attachment transfer clears its overlay

### DIFF
--- a/apps/desktop/src/main/sync/attachments.test.ts
+++ b/apps/desktop/src/main/sync/attachments.test.ts
@@ -74,6 +74,8 @@ function buildSignedManifest(opts: {
   plaintext: Buffer
   vaultKey: Uint8Array
   signingKeypair: { privateKey: Uint8Array; publicKey: Uint8Array }
+  /** Override the whole-file checksum to force an integrity failure after the chunk decrypts. */
+  checksum?: string
 }): { encManifest: Record<string, string>; encryptedChunk: Uint8Array } {
   const toB64 = (b: Uint8Array): string => sodium.to_base64(b, sodium.base64_variants.ORIGINAL)
   const fileKey = generateFileKey()
@@ -96,7 +98,7 @@ function buildSignedManifest(opts: {
     filename: opts.filename,
     mimeType: 'text/plain',
     size: opts.plaintext.length,
-    checksum: plaintextHash,
+    checksum: opts.checksum ?? plaintextHash,
     chunks: [
       {
         index: 0,
@@ -666,8 +668,10 @@ describe('AttachmentSyncService', () => {
       })
 
       // #then only the caller that owns this transfer hears about it — a second
-      // concurrent download can no longer clobber or silence this one
-      expect(perCall).toEqual(['att-dir'])
+      // concurrent download can no longer clobber or silence this one. Both the
+      // chunk progress and the terminal event go to the per-call callback.
+      expect(new Set(perCall)).toEqual(new Set(['att-dir']))
+      expect(perCall.length).toBeGreaterThan(0)
       expect(shared).toEqual([])
     })
   })
@@ -1129,6 +1133,211 @@ describe('AttachmentSyncService', () => {
       releaseSecond.resolve()
       await live
       expect(service.getDownloadProgress('att-shared')).toBeNull()
+    })
+  })
+})
+
+describe('terminal transfer phases', () => {
+  const uploadResponses = (
+    sessionId: string
+  ): Map<string, { status: number; body?: unknown; binary?: Uint8Array }> => {
+    const responses = new Map<string, { status: number; body?: unknown; binary?: Uint8Array }>()
+    responses.set('POST /attachments/upload/initiate', {
+      status: 200,
+      body: { sessionId, expiresAt: Date.now() + 3600000 }
+    })
+    responses.set(`GET /attachments/upload/${sessionId}`, {
+      status: 200,
+      body: {
+        sessionId,
+        attachmentId: '',
+        totalSize: 0,
+        chunkCount: 1,
+        uploadedChunks: [],
+        expiresAt: 0
+      }
+    })
+    responses.set(`PUT /attachments/upload/${sessionId}/chunk/`, {
+      status: 200,
+      body: { success: true, uploadedChunks: 1 }
+    })
+    responses.set(`POST /attachments/upload/${sessionId}/complete`, {
+      status: 200,
+      body: { success: true }
+    })
+    return responses
+  }
+
+  describe('#given an upload that reported progress #when it finishes', () => {
+    it('#then the last event is a completed phase for the same attachmentId', async () => {
+      const testFile = path.join(tmpDir, 'terminal-ok.bin')
+      await writeFile(testFile, Buffer.alloc(1024, 'A'))
+
+      const service = new AttachmentSyncService(
+        createTestDeps(createMockFetch(uploadResponses('session-ok')))
+      )
+      const events: TransferProgress[] = []
+      service.setProgressCallback((p) => events.push({ ...p }))
+
+      const result = await service.uploadAttachment('note-1', testFile)
+
+      expect(events.at(-1)).toEqual({
+        attachmentId: result.attachmentId,
+        phase: 'completed',
+        chunksCompleted: 1,
+        totalChunks: 1,
+        bytesTransferred: 1024,
+        totalBytes: 1024
+      })
+    })
+
+    it('#then a throw after the first progress event still ends in a failed phase', async () => {
+      const testFile = path.join(tmpDir, 'terminal-fail.bin')
+      await writeFile(testFile, Buffer.alloc(1024, 'B'))
+
+      // The hashing/encrypting pass has already reported progress by the time
+      // the session is initiated, so this is exactly the transfer that used to
+      // strand its entry in the renderer.
+      const responses = uploadResponses('session-fail')
+      responses.set('POST /attachments/upload/initiate', { status: 500, body: { error: 'boom' } })
+
+      const service = new AttachmentSyncService(createTestDeps(createMockFetch(responses)))
+      const events: TransferProgress[] = []
+      service.setProgressCallback((p) => events.push({ ...p }))
+
+      await expect(service.uploadAttachment('note-1', testFile)).rejects.toThrow(
+        'Failed to initiate upload'
+      )
+
+      expect(events.at(-1)?.phase).toBe('failed')
+      expect(events.at(-1)?.attachmentId).toBe(events[0].attachmentId)
+      expect(events.filter((e) => e.phase === 'failed')).toHaveLength(1)
+    })
+
+    it('#then a chunk rejection also ends in a failed phase', async () => {
+      const testFile = path.join(tmpDir, 'terminal-chunk-fail.bin')
+      await writeFile(testFile, Buffer.alloc(1024, 'C'))
+
+      const responses = uploadResponses('session-chunk')
+      responses.set('PUT /attachments/upload/session-chunk/chunk/', {
+        status: 500,
+        body: { error: 'boom' }
+      })
+
+      const service = new AttachmentSyncService(createTestDeps(createMockFetch(responses)))
+      const events: TransferProgress[] = []
+      service.setProgressCallback((p) => events.push({ ...p }))
+
+      await expect(service.uploadAttachment('note-1', testFile)).rejects.toThrow(
+        'Failed to upload chunk'
+      )
+
+      expect(events.at(-1)?.phase).toBe('failed')
+    })
+  })
+
+  describe('#given an upload that dies before any progress #when it throws', () => {
+    it('#then no terminal event is emitted', async () => {
+      const service = new AttachmentSyncService(createTestDeps(createMockFetch(new Map())))
+      const events: TransferProgress[] = []
+      service.setProgressCallback((p) => events.push({ ...p }))
+
+      await expect(
+        service.uploadAttachment('note-1', path.join(tmpDir, 'never-existed.bin'))
+      ).rejects.toThrow()
+
+      // Nothing was ever reported, so there is no renderer entry to terminate —
+      // a terminal event here would invent an overlay that never existed.
+      expect(events).toEqual([])
+    })
+  })
+
+  describe('#given a download that reported progress #when it fails', () => {
+    it('#then the last event is a failed phase', async () => {
+      const vaultKey = generateFileKey()
+      const signingKeypair = sodium.crypto_sign_keypair()
+      // Chunk hashes still match, so the chunk decrypts and reports progress;
+      // the whole-file checksum then fails, after the renderer has an entry.
+      const { encManifest, encryptedChunk } = buildSignedManifest({
+        attachmentId: 'att-terminal-fail',
+        filename: 'terminal.txt',
+        plaintext: Buffer.alloc(256, 'T'),
+        vaultKey,
+        signingKeypair,
+        checksum: 'f'.repeat(64)
+      })
+
+      const fetchFn = vi.fn(async (url: string | URL | Request) => {
+        const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+        if (urlStr.includes('/att-terminal-fail/manifest')) {
+          return new Response(JSON.stringify(encManifest), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        }
+        if (urlStr.includes('/chunks/')) {
+          return new Response(encryptedChunk, {
+            status: 200,
+            headers: { 'Content-Type': 'application/octet-stream' }
+          })
+        }
+        return new Response(null, { status: 404 })
+      })
+
+      const service = new AttachmentSyncService(
+        createDownloadDeps(fetchFn, vaultKey, signingKeypair.publicKey)
+      )
+      const events: TransferProgress[] = []
+
+      await expect(
+        service.downloadAttachment('att-terminal-fail', path.join(tmpDir, 'terminal.txt'), {
+          onProgress: (p) => events.push({ ...p })
+        })
+      ).rejects.toThrow('File integrity failure')
+
+      expect(events.map((e) => e.phase)).toEqual(['decrypting', 'failed'])
+    })
+
+    it('#then a successful download ends in a completed phase', async () => {
+      const vaultKey = generateFileKey()
+      const signingKeypair = sodium.crypto_sign_keypair()
+      const { encManifest, encryptedChunk } = buildSignedManifest({
+        attachmentId: 'att-terminal-ok',
+        filename: 'terminal-ok.txt',
+        plaintext: Buffer.alloc(256, 'K'),
+        vaultKey,
+        signingKeypair
+      })
+
+      const fetchFn = vi.fn(async (url: string | URL | Request) => {
+        const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+        if (urlStr.includes('/att-terminal-ok/manifest')) {
+          return new Response(JSON.stringify(encManifest), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        }
+        if (urlStr.includes('/chunks/')) {
+          return new Response(encryptedChunk, {
+            status: 200,
+            headers: { 'Content-Type': 'application/octet-stream' }
+          })
+        }
+        return new Response(null, { status: 404 })
+      })
+
+      const service = new AttachmentSyncService(
+        createDownloadDeps(fetchFn, vaultKey, signingKeypair.publicKey)
+      )
+      const events: TransferProgress[] = []
+
+      await service.downloadAttachment(
+        'att-terminal-ok',
+        path.join(tmpDir, 'terminal-ok-out.txt'),
+        { onProgress: (p) => events.push({ ...p }) }
+      )
+
+      expect(events.map((e) => e.phase)).toEqual(['decrypting', 'completed'])
     })
   })
 })

--- a/apps/desktop/src/main/sync/attachments.ts
+++ b/apps/desktop/src/main/sync/attachments.ts
@@ -79,9 +79,26 @@ export interface DownloadResult {
   manifest: AttachmentManifest
 }
 
+/**
+ * 'completed' and 'failed' are terminal: exactly one of them is emitted for
+ * every transfer that reported any progress at all, and nothing follows it for
+ * that attachmentId. The renderer keys its transfer overlay by attachmentId and
+ * has no other way to learn a transfer ended — without a terminal phase a
+ * transfer that dies below 100% pins its overlay for the life of the window.
+ * Age heuristics are not an option: 'waiting_network' is legitimately silent for
+ * long stretches and would be torn down while still live.
+ */
 export interface TransferProgress {
   attachmentId: string
-  phase: 'hashing' | 'encrypting' | 'uploading' | 'downloading' | 'decrypting' | 'waiting_network'
+  phase:
+    | 'hashing'
+    | 'encrypting'
+    | 'uploading'
+    | 'downloading'
+    | 'decrypting'
+    | 'waiting_network'
+    | 'completed'
+    | 'failed'
   chunksCompleted: number
   totalChunks: number
   bytesTransferred: number
@@ -263,7 +280,18 @@ export class AttachmentSyncService {
   ): Promise<UploadResult> {
     const [token, vaultKey, signingKeys] = await this.requireAuth()
     const fileKey = generateFileKey()
-    const emit = (p: TransferProgress): void => (onProgress ?? this.onProgress)?.(p)
+    // Remember the last payload so the terminal emit can reuse its attachmentId
+    // and counts. Null until the first progress event, which is precisely the
+    // window in which the renderer has no entry that could be stranded — so
+    // failures before it need (and get) no terminal emit.
+    let lastProgress: TransferProgress | null = null
+    const emit = (p: TransferProgress): void => {
+      lastProgress = p
+      ;(onProgress ?? this.onProgress)?.(p)
+    }
+    const emitTerminal = (phase: 'completed' | 'failed'): void => {
+      if (lastProgress) emit({ ...lastProgress, phase })
+    }
     // Set once the session is registered below, so the finally can drop it on
     // every exit — success, throw, or abort — instead of only the happy path.
     let trackedSessionId: string | null = null
@@ -451,8 +479,17 @@ export class AttachmentSyncService {
       await this.completeUploadSession(token, sessionId, encryptedManifest, netOpts)
 
       log.info('upload complete', { attachmentId, sessionId })
+      emitTerminal('completed')
 
       return { attachmentId, sessionId, manifest }
+    } catch (err) {
+      // Every failure past the first progress event lands here: a rejected
+      // initiate/chunk/complete response, a dead-lettered or aborted retry, a
+      // cancelled upload. The attachmentId is minted per call, so a queue-level
+      // retry reports under a NEW id — this attempt's id is finished either way
+      // and must be stamped terminal rather than left in flight forever.
+      emitTerminal('failed')
+      throw err
     } finally {
       // The transfer is over by the time finally runs, so this can never orphan
       // an in-flight upload. The key is a server-issued session id unique to
@@ -477,7 +514,16 @@ export class AttachmentSyncService {
     // Per-call callback wins over the shared slot, mirroring uploadAttachment:
     // two concurrent downloads that both went through the singleton clobbered
     // each other, and whichever finished first cleared it for the survivor.
-    const emit = (p: TransferProgress): void => (opts?.onProgress ?? this.onProgress)?.(p)
+    // See uploadAttachment: lastProgress carries the id/counts the terminal emit
+    // reuses, and stays null while no renderer entry exists to strand.
+    let lastProgress: TransferProgress | null = null
+    const emit = (p: TransferProgress): void => {
+      lastProgress = p
+      ;(opts?.onProgress ?? this.onProgress)?.(p)
+    }
+    const emitTerminal = (phase: 'completed' | 'failed'): void => {
+      if (lastProgress) emit({ ...lastProgress, phase })
+    }
 
     log.info('starting download', { attachmentId })
 
@@ -566,8 +612,15 @@ export class AttachmentSyncService {
       await this.atomicWriteBinary(destPath, reassembled)
 
       log.info('download complete', { attachmentId, path: destPath })
+      emitTerminal('completed')
 
       return { filePath: destPath, manifest }
+    } catch (err) {
+      // Chunk fetch/decrypt failures, integrity mismatches and write failures
+      // all reach here. The already-materialized early return above is silent by
+      // design: it emits no progress, so there is nothing to terminate.
+      emitTerminal('failed')
+      throw err
     } finally {
       // Unlike uploads, the key here is the attachmentId, which a concurrent
       // download of the same attachment shares — it overwrites this entry when

--- a/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
@@ -741,6 +741,51 @@ describe('syncReducer', () => {
       expect(state.uploadProgress).toEqual({ 'att-live': { progress: 40, status: 'uploading' } })
     })
 
+    it('#then drops a transfer that ended below 100% and keeps a silent one', () => {
+      let state = syncReducer(initialState, uploadEvent('att-dead', 40))
+      state = syncReducer(state, uploadEvent('att-waiting', 40))
+      // A transfer that is only waiting for the network is still live and must
+      // survive the sweep — the reason this cannot be an age heuristic.
+      state = syncReducer(state, {
+        type: 'UPLOAD_PROGRESS',
+        attachmentId: 'att-waiting',
+        progress: 40,
+        status: 'waiting_network'
+      })
+      state = syncReducer(state, {
+        type: 'UPLOAD_PROGRESS',
+        attachmentId: 'att-dead',
+        progress: 40,
+        status: 'failed'
+      })
+
+      state = syncReducer(state, {
+        type: 'PRUNE_STALE',
+        now: Date.now() + SYNC_PROGRESS_RETENTION_MS
+      })
+
+      expect(state.uploadProgress).toEqual({
+        'att-waiting': { progress: 40, status: 'waiting_network' }
+      })
+    })
+
+    it('#then drops a download that reported completed below 100%', () => {
+      let state = syncReducer(initialState, downloadEvent('dl-x', 60))
+      state = syncReducer(state, {
+        type: 'DOWNLOAD_PROGRESS',
+        attachmentId: 'dl-x',
+        progress: 60,
+        status: 'completed'
+      })
+
+      state = syncReducer(state, {
+        type: 'PRUNE_STALE',
+        now: Date.now() + SYNC_PROGRESS_RETENTION_MS
+      })
+
+      expect(state.downloadProgress).toBeNull()
+    })
+
     it('#then keeps a just-finished entry and returns the same state object', () => {
       const state = syncReducer(initialState, uploadEvent('att-done', 100))
       const swept = syncReducer(state, { type: 'PRUNE_STALE', now: Date.now() })

--- a/apps/desktop/src/renderer/src/contexts/sync-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.tsx
@@ -26,15 +26,24 @@ import type { SyncStatus } from '@/sync/collaboration-status'
 interface ProgressEntry {
   progress: number
   status: string
-  /** Set once the transfer reaches 100%; the prune sweep drops it after the retention window. */
+  /** Set once the transfer ends; the prune sweep drops it after the retention window. */
   completedAt?: number
 }
 
 /**
+ * Terminal statuses main sends when a transfer is over. They are the only
+ * end-of-transfer signal for a transfer that dies below 100% — a failed or
+ * abandoned one — so they must mark the entry finishable exactly like a full
+ * bar does, or its file-block overlay stays pinned for the life of the window.
+ * An age heuristic cannot stand in for them: 'waiting_network' is legitimately
+ * silent for long stretches and is still live.
+ */
+const TERMINAL_TRANSFER_STATUSES = new Set(['completed', 'failed'])
+
+/**
  * How long a finished transfer's entry survives so the progress UI can settle.
- * Main only ever emits transfer *phases* ('uploading', 'decrypting', …) and
- * never a terminal status, so a full bar is the only end-of-transfer signal
- * the renderer gets.
+ * A full bar also counts as finished: main reaches 100% before the last
+ * server round-trip, so the terminal event can still be several seconds out.
  */
 export const SYNC_PROGRESS_RETENTION_MS = 5_000
 /**
@@ -121,8 +130,10 @@ function recordProgress(
   progress: number,
   status: string
 ): Record<string, ProgressEntry> {
-  const entry: ProgressEntry =
-    progress >= 100 ? { progress, status, completedAt: Date.now() } : { progress, status }
+  const finished = progress >= 100 || TERMINAL_TRANSFER_STATUSES.has(status)
+  const entry: ProgressEntry = finished
+    ? { progress, status, completedAt: Date.now() }
+    : { progress, status }
   return { ...current, [attachmentId]: entry }
 }
 

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -126,6 +126,8 @@ Attachment payloads sync as encrypted R2 blobs (the same path as note bodies). L
 
 ### Transfer Progress
 
-Transfers report progress as a whole percentage, updating only when that percentage changes rather than on every chunk — a large file moves through the same 0–100% either way, without flooding the interface. Every transfer finishes on 100%.
+Transfers report progress as a whole percentage, updating only when that percentage changes rather than on every chunk — a large file moves through the same 0–100% either way, without flooding the interface.
 
 Several attachments can upload and download at once, and each one tracks its own progress. One transfer finishing never stops another that is still running from reporting.
+
+Every transfer ends, and the progress bar on the attachment ends with it. A transfer that succeeds clears its bar; a transfer that fails shows it briefly as failed and then clears too. So a bar that stays on an attachment means the transfer is genuinely still going — including a transfer that is only waiting for the network, which can sit quiet for a long time on a bad connection without being abandoned. If a transfer fails you still get the notification described in [When an attachment doesn't sync](#when-an-attachment-doesn-t-sync); the bar clearing is not a sign it worked.

--- a/packages/contracts/src/ipc-events.ts
+++ b/packages/contracts/src/ipc-events.ts
@@ -72,6 +72,13 @@ export interface LinkingApprovedEvent {
   sessionId: string
 }
 
+/**
+ * `status` is the transfer phase ('hashing' | 'encrypting' | 'uploading' |
+ * 'waiting_network'), plus the terminal 'completed' and 'failed' that main emits
+ * once when the transfer ends. The terminal values are additive to an existing
+ * free-form field — the payload shape is unchanged, and a receiver that does not
+ * know them simply treats them as one more phase.
+ */
 export interface UploadProgressEvent {
   attachmentId: string
   sessionId: string
@@ -79,6 +86,7 @@ export interface UploadProgressEvent {
   status: string
 }
 
+/** Same `status` contract as {@link UploadProgressEvent}; phases are 'downloading' | 'decrypting'. */
 export interface DownloadProgressEvent {
   attachmentId: string
   progress: number


### PR DESCRIPTION
Closes #1325. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`TransferProgress.phase` in `apps/desktop/src/main/sync/attachments.ts` had no terminal state, so the renderer had no way to learn a transfer had ended:

```ts
phase: 'hashing' | 'encrypting' | 'uploading' | 'downloading' | 'decrypting' | 'waiting_network'
```

Those phases reach the renderer verbatim as `status` on `sync:upload-progress` / `sync:download-progress`. `recordProgress` in `sync-context.tsx` only stamped an entry finishable at a full bar:

```ts
const entry: ProgressEntry =
  progress >= 100 ? { progress, status, completedAt: Date.now() } : { progress, status }
```

and the `PRUNE_STALE` sweep keeps anything without `completedAt` forever. So a transfer that died below 100% — a rejected initiate/chunk/complete, an aborted retry, a chunk integrity failure — left an entry nothing could ever remove, and `file-block.tsx` kept rendering its transfer overlay for the life of the window.

This is worse than it looks for uploads: `attachmentId` is minted **per call** inside `uploadAttachment`, so when `UploadQueue` re-queues a `NetworkError` the retry reports under a *new* id. The failed attempt's id is orphaned on the spot, and the retry's overlay stacks on top of it.

## What changed

Main now emits a terminal phase, and the reducer treats it as finishable.

- `attachments.ts`: `TransferProgress.phase` gains `'completed' | 'failed'`. Both `uploadAttachment` and `downloadAttachment` wrap their `emit` to remember the last payload and emit `{...last, phase}` on the success return and from a new `catch` that rethrows. Reusing the last payload means the terminal event carries the same `attachmentId` and counts the renderer has been keying on, and `lastProgress === null` (nothing reported yet) suppresses the terminal emit — that is exactly the window where the renderer has no entry to strand, so a failure there stays silent instead of inventing an overlay.
- `sync-context.tsx`: `recordProgress` stamps `completedAt` for `progress >= 100` **or** a terminal status, so the existing 5s sweep collects it.
- `apps/docs/src/user-guide/notes/attachments.md`: the Transfer Progress section said "Every transfer finishes on 100%", which was never true for a failed one. Replaced with what a lingering bar now means.

Deliberately **not** done:

- **No age heuristic.** `waiting_network` transfers are legitimately silent for long stretches; a timeout would tear down live transfers. This is the whole reason the fix has to come from main.
- **The `file-block.tsx` gate is untouched.** The issue asked whether to emit `'completed'` or change the `status !== 'completed'` gate. Emitting it is right: `SyncProgressOverlay` already branches on both `'completed'` (green bar, "Uploaded") and `'failed'` (red bar, "Failed") and already hides the percentage for both — the component was written for terminal statuses main never sent. Emitting them makes it coherent: success hides the overlay at once, failure shows the red bar until the sweep drops it. Changing the gate instead would have left main with no failure signal, which is the actual bug.
- **No throttle change.** `throttlePerTransfer` in `sync-attachment-handlers.ts` dedupes on `${phase}:${percent}`, so a terminal phase is always a new key and can never be suppressed.

## How it was proven

Before/after by reverting only the two source files (`git checkout origin/main -- attachments.ts sync-context.tsx`) with the tests in place:

| suite | before | after |
| --- | --- | --- |
| `main` `apps/desktop/src/main/sync/attachments.test.ts` | **5 failed** / 25 passed (30) | 30 passed (30) |
| `renderer` `apps/desktop/src/renderer/src/contexts/sync-context.test.tsx` | **2 failed** / 30 passed (32) | 32 passed (32) |

New coverage:

- upload success ends on `completed` with the same `attachmentId` and full counts
- upload that throws at initiate — i.e. **after** the hashing/encrypting pass already reported progress — ends on `failed`, exactly once, under the id it had been reporting
- upload that throws on a chunk PUT ends on `failed`
- upload that dies before any progress (missing file) emits **nothing** — no phantom terminal event
- download whose whole-file checksum fails after a chunk decrypted ends `['decrypting', 'failed']`; a successful one ends `['decrypting', 'completed']`
- reducer: a `failed` entry at 40% is swept, while a `waiting_network` entry at 40% survives the same sweep (the regression guard for the "don't use a timeout" constraint)
- reducer: a `completed` download at 60% is swept

One pre-existing assertion was relaxed: the per-call-callback test asserted an exact one-event array; it now asserts every event belongs to that transfer and the shared slot stays empty. The extra event is the new terminal one.

## Verification

- `pnpm --filter @memry/desktop typecheck:node` — clean
- `pnpm --filter @memry/desktop typecheck:web` — clean
- `pnpm exec eslint <5 changed files>` — 0 errors (2 "file ignored" warnings for the test files)
- `pnpm check:contracts` — `contracts boundary check passed`
- `pnpm ipc:generate` then `pnpm ipc:check` — `Generated RPC bindings are up to date` / `IPC invoke map is up to date`, no regenerated diff
- `git diff --check` — clean
- `pnpm docs:impact --base origin/main --strict` — `covered`
- `pnpm docs:build` — `build complete`

## Backward compatibility

No wire-shape change: `UploadProgressEvent.status` / `DownloadProgressEvent.status` are already `string`, so `'completed'` and `'failed'` are additive **values** in an existing free-form field — an older payload (phase-only, no terminal event) still parses and still behaves exactly as before, because `progress >= 100` remains a finishable condition on its own. No schema, DB, settings or sync-protocol change.
