### PR TITLE
docs(sync): describe the conflict flow that actually ships on the Conflict & Health page

### DIFF
--- a/apps/docs/src/user-guide/sync/conflict-health.md
+++ b/apps/docs/src/user-guide/sync/conflict-health.md
@@ -2,7 +2,7 @@
 
 How memrynote handles conflicting edits across devices, and where to see sync health.
 
-<!-- screenshot: sync history panel showing recent activity -->
+<!-- screenshot: sync status popover showing the conflict count and Dismiss -->
 
 ## Conflict Resolution
 
@@ -29,15 +29,19 @@ This is much friendlier than naive last-writer-wins on the whole record.
 
 ### Doc-Level Conflicts
 
-For inbox items, templates, and other lower-frequency types, a same-record concurrent change resolves with a single doc-level vector clock. memrynote surfaces a banner if a true unresolvable case occurs (rare).
+For inbox items, templates, tags, folders, bookmarks, saved filters, reminders, and note / journal **metadata** (title, emoji, path, tags — not the text), a same-record concurrent change resolves with a single doc-level vector clock. When both devices changed the record without having seen each other's change, the incoming remote record is written over the local one, the two clocks are merged, and the merged record is queued straight back for push so the other device converges on the same result.
 
-## Conflict Indicators
+That all happens inside the pull. Nothing stops to ask you.
 
-When a conflict requires your attention (very rare given the strategies above), memrynote:
+## What You Actually See
 
-- Shows a yellow banner on the affected item
-- Adds an entry to **Sync History**
-- Lets you choose to keep your version, the remote version, or merge manually
+A conflict is **already resolved** by the time the app mentions it. There is no prompt, no marker on the affected note or task, and no compare view — when the count appears, the winning version has been written to your local database and queued back for push.
+
+The whole conflict surface is:
+
+- A yellow **"N conflicts detected"** line in the sync status popover, with a **Dismiss** button
+- Nothing on the item itself
+- Nothing in [Sync History](#sync-history) — it records pushes, pulls, and errors, not conflicts
 
 ### Conflict Count in the Sync Menu
 
@@ -45,16 +49,36 @@ The sync status menu shows how many items hit a conflict, with a **Dismiss** but
 
 The count tracks _items_, not events — an item that keeps conflicting is counted once, not once per sync round. The notice clears when you dismiss it, when you sign out, or automatically after 24 hours.
 
+## What "Resolved" Means for Your Data
+
+Auto-resolved is not the same as auto-merged. CRDT text keeps both sides. Everywhere else, resolving means picking a winner, and the losing version is overwritten in place.
+
+| Your item                                                                                     | How it resolves                                                                                                                                     | What you can lose                                                                    |
+| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Note & journal **text**                                                                       | Yjs merges both sides                                                                                                                               | Nothing — both edits survive                                                         |
+| Tasks & projects                                                                              | Per field, the higher clock tick-sum wins. On an exact tie with differing values the **remote** value wins, unless your local edit was made offline | The losing value on a tied field — you set priority High here, and it comes back Low |
+| Note / journal metadata, inbox items, templates, tags, folders, bookmarks, filters, reminders | The **remote** record overwrites the local one and the clocks merge                                                                                 | Your local change to those fields                                                    |
+| Canvases                                                                                      | Neither side is dropped — the other version lands as a [conflict copy](/user-guide/canvas/sync-and-limits#conflict-copies)                          | Nothing; you end up with a second canvas                                             |
+
+So the popover count is a **notice, not a task list**. Dismissing it changes nothing about your data — the resolution already happened, and dismissing only retires the warning.
+
 ## Sync History
 
-A panel that lists recent sync events:
+A record of recent sync runs, stored in the local database:
 
-- Pushes (succeeded / failed)
-- Pulls (counts of new items)
-- Conflicts (with links to the items)
-- Auth events (sign-in, key rotation, device link)
+- Pushes (item count, duration)
+- Pulls (item count, duration)
+- Errors (with the failure message)
 
-Open from the sync status indicator menu.
+It does **not** record conflicts, auth events, or links to affected items.
+
+There is currently no panel for it in the app. Read it from the [CLI](/user-guide/cli#sync-diagnostics):
+
+```bash
+memrynote sync history --limit 20
+```
+
+The log is cleared when you sign out of sync; it is not aged out on a timer.
 
 ## Health View
 
@@ -80,22 +104,22 @@ This is the actionable punch list — fix everything here and sync should be cle
 | "Crypto version mismatch"        | Sync server behind a desktop release                                                                     | Wait for server to update or downgrade desktop                                                                  |
 | "All items failed to decrypt"    | This device's vault key no longer matches the account                                                    | The app signs you out and prompts recovery — sign in and enter your recovery phrase; your server data is intact |
 
-## Resolving a Conflict Manually
+## Recovering an Overwritten Edit
 
-If the rare manual-conflict banner appears on a non-CRDT item:
+There is no undo for an auto-resolved conflict, and no conflict log to read back. What you can do:
 
-1. Click the banner
-2. Compare the two versions side-by-side
-3. Pick **Keep mine**, **Keep remote**, or copy text between them and save
-4. The conflict marker clears
+- **Note and journal text** — [Version history](/user-guide/notes/version-history) keeps snapshots, so you can open the timeline and restore. Versions are local to each device, so look on the device you typed the lost text on.
+- **Everything else** — set the value again on the device you want to win. That edit carries a higher clock, so it sticks on the next push.
 
-For CRDT items (notes / journals), there's no manual conflict step — the merge always succeeds.
+A side-by-side compare with **Keep mine** / **Keep remote** does not exist in memrynote. If you want one, that is a feature request, not a setting you have missed.
 
 ## What memrynote Won't Do
 
 memrynote doesn't auto-merge **across record types** — e.g. it won't combine two competing project structures. The vector clock comparison stays within a single record.
 
-It also doesn't store a permanent "conflict log" — once resolved, the conflict is gone. Sync History keeps the metadata for a few weeks for debugging.
+It also won't ask you to pick a winner. Every strategy above is built to resolve without a prompt, which is why there is no manual-resolution screen.
+
+And it doesn't store a conflict log. Once a conflict resolves, the losing version is gone from the database, and Sync History never held conflicts to begin with.
 
 ## See Also
 


### PR DESCRIPTION
Closes #1338. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/docs/src/user-guide/sync/conflict-health.md` documented a manual conflict-resolution UI that no code implements, plus a Sync History panel that is not reachable from anywhere in the app.

**1. Conflicts resolve before the renderer ever hears about them.** `apps/desktop/src/main/sync/engine/pull-coordinator.ts:896-938` — the item has already been written by `applier.apply()` (line 456) by the time `handleConflict` runs; `handleConflict` only emits the event and re-queues a push:

```ts
this.ctx.deps.emitToRenderer(EVENT_CHANNELS.CONFLICT_DETECTED, { ... })
this.ctx.deps.queue.enqueue({ type: dec.type as SyncItemType, itemId: dec.id, operation: 'update', payload: '{}' })
trackMainLog('info', { scope: 'PullCoordinator', action: 'conflict_resolved', errorCode: dec.type })
```

`apps/desktop/src/renderer/src/contexts/sync-context.tsx:442-444` then throws away `localVersion` / `remoteVersion` / both clocks and keeps `{ itemId, itemType, detectedAt }` only. The single conflict surface in the whole renderer is the count + **Dismiss** in `components/sync/sync-status.tsx:130-145`. There is no per-item banner, no side-by-side compare, no Keep mine / Keep remote — `grep -rn -i conflict apps/desktop/src/renderer/src` returns nothing else outside tests.

**2. The page also had the resolution direction backwards.** For doc-level types, `resolveClockConflict` (`item-handlers/types.ts:59-69`) returns `merge` on concurrent clocks, and every handler's merge branch writes the *remote* fields over the local row with a merged clock (e.g. `bookmark-handler.ts:40-52`, `note-handler.ts:276` / `:506`) before returning `'conflict'`. So the remote record wins and the merged result is re-pushed — it is not "local wins", which is how the issue described it.

**3. Sync History was documented as a panel with conflict entries and auth events.** `SyncHistoryPanel` (`components/sync/sync-history.tsx:104`) is exported but never mounted — its only other reference in the repo is its own test. `SyncHistoryEntry.type` is `'push' | 'pull' | 'error'` (`packages/contracts/src/ipc-sync-ops.ts:67-75`), written only by `stateManager.recordHistory(...)` from the push/pull coordinators, so conflicts and auth events were never in there. Rows are deleted wholesale on sign-out (`main/sync/session-teardown.ts:104`) and never aged out, so "keeps the metadata for a few weeks" was wrong too. The reachable reader is the CLI: `apps/cli/src/run.ts:2032` (`memrynote sync history`).

## What changed

Docs only — one file, `apps/docs/src/user-guide/sync/conflict-health.md`.

- **Conflict Indicators** → **What You Actually See**: states that resolution has already happened, and lists the real surface (yellow count line in the sync popover + Dismiss, nothing on the item, nothing in Sync History).
- New **What "Resolved" Means for Your Data** table, per domain, with a "what you can lose" column: CRDT text loses nothing; tasks/projects can lose the losing side of a tick-sum tie (remote wins ties unless the local edit carries the offline clock marker — `main/sync/field-merge.ts:84-100`); doc-level types lose the local change; canvases get a conflict copy instead.
- **Resolving a Conflict Manually** → **Recovering an Overwritten Edit**: version history for note/journal text (local per device), re-apply the value on the device you want to win for everything else, and an explicit line that Keep mine / Keep remote does not exist.
- **Doc-Level Conflicts** paragraph now names the actual type list and describes remote-overwrites-local + clock merge + re-push, instead of claiming a banner appears.
- **Sync History** now says push/pull/error only, no panel in the app, read it via `memrynote sync history`, cleared on sign-out.
- **What memrynote Won't Do**: corrected the "few weeks" retention claim and added that it will not ask you to pick a winner.

Deliberately **not** done:
- The **Conflict Count in the Sync Menu** section is left as-is — PR #1313 added it and it is already accurate (item-keyed count, 24h TTL, Dismiss).
- No source changes. A compare-and-choose UI would be a feature, not a docs fix, and the page now says so.
- Did not touch the **Health View** or **Common Sync Errors** sections, or the `Conflict Resolution` strategy table — out of this issue's scope.
- Did not "quietly drop" the section: the page now states plainly that a conflict means one side's value was overwritten, and what recourse exists.

## Sweep

Grepped `apps/docs/src` for the same claim (`Keep mine`, `Keep remote`, `side-by-side`, `banner`, `conflict`, `Sync History`). The manual-resolution / conflict-banner claim appears **only** in `conflict-health.md` (lines 32, 38, 85, 87 pre-change) — all fixed here. Other conflict mentions are unrelated and correct: `canvas/sync-and-limits.md` (conflict copies — real, `canvas-handler.ts:323`), `keyboard-shortcuts.md` (shortcut binding conflicts), `architecture/sync-handlers.md` and `sync-protocol.md` (accurate internals).

## How it was proven

Docs-only change, so there is no before/after vitest run. Every claim in the rewritten sections was derived by reading current `origin/main` source, cited above by file:line.

## Verification

```
npx prettier --check apps/docs/src/user-guide/sync/conflict-health.md
  → All matched files use Prettier code style!

pnpm docs:build
  → building client + server bundles... ✓ rendering pages... ✓ build complete in 5.11s
    (VitePress dead-link check passes, so the new /user-guide/notes/version-history,
     /user-guide/canvas/sync-and-limits#conflict-copies and /user-guide/cli#sync-diagnostics
     links resolve)

pnpm docs:impact --base origin/main --strict
  → docs impact: no desktop/sync-server docs-relevant changes detected

git diff --check
  → clean
```

No typecheck/lint/test runs: no `.ts`/`.tsx` files are touched.

## Backward compatibility

No runtime, schema, contract, or settings changes — a single Markdown file under `apps/docs/src`, so there is nothing for existing installs to migrate.
