### PR TITLE
fix(notifications): emit a dismissed event for every bulk-dismissed reminder

### DIFF
--- a/apps/desktop/src/main/lib/reminders.test.ts
+++ b/apps/desktop/src/main/lib/reminders.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { eq } from 'drizzle-orm'
 import { reminders } from '@memry/db-schema/schema/reminders'
-import { reminderStatus } from '@memry/contracts/reminders-api'
+import { reminderStatus, type Reminder } from '@memry/contracts/reminders-api'
 import { inboxItems } from '@memry/db-schema/schema/inbox'
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { projects } from '@memry/db-schema/schema/projects'
@@ -142,6 +142,11 @@ describe('reminders service', () => {
     dataDb.db.insert(reminders).values(reminder).run()
     return reminder.id
   }
+
+  const dismissedEventPayloads = (): { reminder: Reminder }[] =>
+    window.webContents.send.mock.calls
+      .filter((call) => call[0] === ReminderChannels.events.DISMISSED)
+      .map((call) => call[1] as { reminder: Reminder })
 
   const seedTask = (id: string, title: string, projectId: string): void => {
     const now = '2025-01-01T00:00:00.000Z'
@@ -626,6 +631,71 @@ describe('reminders service', () => {
       sourceType: 'reminder',
       sourceId: 'rem-b2'
     })
+  })
+
+  it('emits one dismissed event per bulk-dismissed reminder', () => {
+    seedReminder({
+      id: 'rem-be1',
+      targetType: 'note',
+      targetId: 'note-be',
+      status: reminderStatus.PENDING
+    })
+    seedReminder({
+      id: 'rem-be2',
+      targetType: 'journal',
+      targetId: '2025-01-24',
+      status: reminderStatus.TRIGGERED
+    })
+    // Not part of the batch: no event may mention it.
+    seedReminder({ id: 'rem-be3', status: reminderStatus.PENDING })
+
+    expect(remindersService.bulkDismissReminders(['rem-be1', 'rem-be2'])).toBe(2)
+
+    const payloads = dismissedEventPayloads()
+    expect(payloads).toHaveLength(2)
+    // The target-scoped hooks match on targetType/targetId, so the row itself
+    // has to reach the renderer, not just the id.
+    expect(payloads[0]).toEqual({
+      reminder: expect.objectContaining({
+        id: 'rem-be1',
+        targetType: 'note',
+        targetId: 'note-be',
+        status: reminderStatus.DISMISSED
+      })
+    })
+    expect(payloads[1]).toEqual({
+      reminder: expect.objectContaining({
+        id: 'rem-be2',
+        targetType: 'journal',
+        targetId: '2025-01-24',
+        status: reminderStatus.DISMISSED
+      })
+    })
+    expect(payloads[0].reminder.dismissedAt).toBeTruthy()
+    expect(payloads.map((payload) => payload.reminder.id)).not.toContain('rem-be3')
+  })
+
+  it('emits no dismissed event for a bulk-dismiss id that matched no row', () => {
+    seedReminder({ id: 'rem-bg1', status: reminderStatus.PENDING })
+
+    expect(remindersService.bulkDismissReminders(['rem-bg1', 'rem-bulk-ghost'])).toBe(1)
+
+    expect(dismissedEventPayloads().map((payload) => payload.reminder.id)).toEqual(['rem-bg1'])
+  })
+
+  it('emits exactly one dismissed event for a single-reminder dismiss', () => {
+    seedReminder({ id: 'rem-single-ev', status: reminderStatus.PENDING })
+
+    expect(remindersService.dismissReminder('rem-single-ev')?.status).toBe(reminderStatus.DISMISSED)
+
+    expect(dismissedEventPayloads()).toEqual([
+      {
+        reminder: expect.objectContaining({
+          id: 'rem-single-ev',
+          status: reminderStatus.DISMISSED
+        })
+      }
+    ])
   })
 
   describe('delivered notification cleanup (Electron 42+, macOS)', () => {

--- a/apps/desktop/src/main/lib/reminders.ts
+++ b/apps/desktop/src/main/lib/reminders.ts
@@ -810,7 +810,11 @@ export function bulkDismissReminders(reminderIds: string[]): number {
   let dismissedCount = 0
 
   for (const id of reminderIds) {
-    const result = db
+    // RETURNING hands back the updated row in the same statement, so the
+    // DISMISSED event carries a real reminder without a second SELECT per id.
+    // A row comes back only when the id matched, which is the old
+    // `result.changes > 0` test.
+    const row = db
       .update(reminders)
       .set({
         status: reminderStatus.DISMISSED,
@@ -818,15 +822,20 @@ export function bulkDismissReminders(reminderIds: string[]): number {
         modifiedAt: timestamp
       })
       .where(eq(reminders.id, id))
-      .run()
+      .returning()
+      .get()
 
-    if (result.changes > 0) {
+    if (row) {
       dismissedCount++
+      // Same event as the single-reminder dismiss, one per dismissed id.
+      // Without it no reminder view invalidates: the target-scoped hooks match
+      // on `reminder.targetType`/`targetId`, so the row itself has to travel.
+      emitEvent(ReminderChannels.events.DISMISSED, { reminder: toReminder(row) })
       enqueueLocalSyncUpdate('reminder', id)
       syncReminderCalendarState(id)
       // Same contract as the single-reminder dismiss: only ids the user actually
-      // dismissed (changes > 0) lose their banner, so an unrelated reminder that
-      // is not part of this batch is left alone.
+      // dismissed lose their banner, so an unrelated reminder that is not part
+      // of this batch is left alone.
       removeDeliveredNotification(id)
     }
   }

--- a/apps/docs/src/user-guide/snooze-reminders.md
+++ b/apps/docs/src/user-guide/snooze-reminders.md
@@ -60,6 +60,8 @@ memrynote shows a toast with:
 
 A system notification is shown as well. Dismissing, snoozing, or deleting the reminder also retires its system notification — on macOS it is removed from Notification Center, and on Windows and Linux the banner is closed — so handled reminders don't pile up. "Dismiss all" does the same for every reminder in the batch, and only for those: a reminder that wasn't part of the action keeps its notification. If a snoozed reminder comes due again, its new notification replaces the earlier one for that reminder instead of stacking a second banner. Notifications you haven't acted on are never dismissed for you.
 
+Dismissing a reminder updates every place it appears right away — the inbox reminders view, the note's reminder pill, the journal badge, the task chip, and any other open memrynote window. "Dismiss all" behaves the same way, refreshing those views once per reminder it actually dismissed.
+
 Dismissing or snoozing a reminder syncs to your other devices, so a reminder you've handled on one device won't fire again on another. Each device still shows its own toast and system notification locally when the reminder's time arrives.
 
 ### Dock & Taskbar Badge


### PR DESCRIPTION
Closes #1334. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`bulkDismissReminders` (`apps/desktop/src/main/lib/reminders.ts:806`) did everything the single-reminder dismiss does — flip the row, enqueue the sync update, refresh calendar projection state, retire the delivered banner — except emit the event that tells the UI anything happened:

```ts
if (result.changes > 0) {
  dismissedCount++
  enqueueLocalSyncUpdate('reminder', id)
  syncReminderCalendarState(id)
  removeDeliveredNotification(id)
}
```

`dismissReminder` at `apps/desktop/src/main/lib/reminders.ts:752` emits `ReminderChannels.events.DISMISSED`; the bulk path emitted nothing on that channel, and did not fall through to `UPDATED` either. Both renderer consumers subscribe to `DISMISSED` and nothing else covers them for a bulk call:

- `apps/desktop/src/renderer/src/hooks/use-reminders.ts:107` — invalidates `reminderKeys.lists()`
- `apps/desktop/src/renderer/src/hooks/use-reminders.ts:168` — `invalidateIfMatching` for the target-scoped views (fired pill, journal badge, task chip)

So after a bulk dismiss every reminder view except the one that issued the call kept rendering reminders already dismissed in the DB, until an unrelated event or refetch invalidated the cache. Other windows never learned at all.

**Reachability — one correction to the issue text.** The issue says there is no call site. That is true of the in-app UI: no component or hook calls `reminderService.bulkDismiss`, and there is no "Dismiss all" button yet. But `reminders.bulkDismiss` is on the agent write allowlist (`packages/contracts/src/agent-mcp-channels.ts:286`), and the `vault_desktop_write` MCP tool resolves operations dynamically off `window.api` (`apps/desktop/src/renderer/src/agent-mcp/desktop-api-handler.ts:17`, `apps/desktop/src/main/agent/mcp/tools/write-tools.ts:704`). An approved agent bulk dismiss therefore reaches this code today and leaves the views stale. Still narrow — agent-only, behind the approval gate — but not purely latent.

## What changed

One function, `bulkDismissReminders`:

- The per-id `UPDATE ... .run()` becomes `.returning().get()`. The updated row comes back in the same statement, so `null`/row replaces `result.changes > 0` with identical semantics (the `WHERE` is on the primary key, so at most one row) and the event gets a real reminder without the N extra `SELECT`s the issue was worried about. Same pattern already used by `packages/app-core/src/reminders.ts:255` for its own bulk dismiss and by `apps/desktop/src/main/database/queries/settings.ts:73`.
- Inside the changed-row branch, emit `ReminderChannels.events.DISMISSED` with `{ reminder }` — same channel, same payload shape as the single dismiss, one per dismissed id, only for ids that actually changed. The full row has to travel because `useRemindersForTarget` matches on the reminder's `targetType`/`targetId`.

Deliberately **not** done:

- No new batched event shape. That is an IPC contract change for a path with one narrow caller; the per-id emit is smaller and keeps the single- and bulk-dismiss contracts identical, which is what the consumers already assume.
- `updateAppBadge()` stays a single post-loop call. Untouched.
- No changes to `removeDeliveredNotification` placement or semantics from #1294 — it stays inside the same changed-row branch, and its tests still pass unmodified.
- No `bulkDismiss` UI affordance added. Out of scope.

## How it was proven

Three tests added to `apps/desktop/src/main/lib/reminders.test.ts`: N ids emit N events with the right rows, a ghost id in the batch emits none, and the single-reminder path still emits exactly one.

```
# fix reverted (git checkout origin/main -- apps/desktop/src/main/lib/reminders.ts), tests kept
Tests  2 failed | 60 passed (62)
  AssertionError: expected [] to have a length of 2 but got +0
  AssertionError: expected [] to deeply equal [ 'rem-bg1' ]

# fix restored
Tests  62 passed (62)
```

The single-dismiss regression guard passes in both runs, which is the point — that path is unchanged.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  apps/desktop/src/main/lib/reminders.test.ts \
  apps/desktop/src/main/ipc/reminder-handlers.test.ts \
  apps/desktop/src/main/sync/reminder-outbound.test.ts
  → Test Files 3 passed (3), Tests 82 passed (82)

pnpm --filter @memry/desktop typecheck:node   → clean, no output
pnpm exec eslint apps/desktop/src/main/lib/reminders.ts   → 0 errors
git diff --check                              → clean
pnpm docs:impact --base origin/main --strict  → covered
pnpm docs:build                               → build complete in 14.79s
```

## Backward compatibility

No schema, contract, sync-payload or settings change — `ReminderChannels.events.DISMISSED` and its `{ reminder }` payload already exist and are already handled by every listener; an older renderer paired with this main process simply receives an event it already knows how to ignore or act on.
