### PR TITLE
fix(sync): serialize SyncWorkerBridge start/stop so a raced start does not lose the worker

### DIFF
--- a/apps/desktop/src/main/sync/worker-bridge.test.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.test.ts
@@ -383,6 +383,128 @@ describe('SyncWorkerBridge', () => {
     })
   })
 
+  describe('#given a stop() inside its shutdown window #when start() races it', () => {
+    const startReady = async (): Promise<MockWorker> => {
+      const p = bridge.start()
+      mockWorkerInstance.simulateMessage({ type: 'ready' })
+      await p
+      return mockWorkerInstance
+    }
+
+    /**
+     * The raced start() resumes on the microtask queue behind stop()'s own
+     * resolution — nothing here is timer-driven — so the fresh Worker is not
+     * constructed yet when `await stopPromise` returns.
+     */
+    const flushMicrotasks = async (): Promise<void> => {
+      for (let i = 0; i < 5; i++) await Promise.resolve()
+    }
+
+    /** stop() that hits the 3s timeout with a start() issued mid-window. */
+    const raceStartAgainstTimingOutStop = async (): Promise<void> => {
+      const stopPromise = bridge.stop()
+      const startPromise = bridge.start()
+
+      vi.advanceTimersByTime(3_001)
+      await stopPromise
+      await flushMicrotasks()
+
+      mockWorkerInstance.simulateMessage({ type: 'ready' })
+      await startPromise
+    }
+
+    it('#then a crypto batch still reaches a worker instead of "Worker not started"', async () => {
+      // #given
+      await startReady()
+
+      // #when — the caller does not await the stop before starting again
+      await raceStartAgainstTimingOutStop()
+
+      // #then — start() reported success and there is a thread behind it. When
+      // start() no-opped on stop()'s still-non-null `this.worker`, stop()'s
+      // continuation left the bridge with no worker at all and this batch
+      // rejected with 'Worker not started' — three of which latch the bridge
+      // off to main-thread crypto for the rest of the session.
+      const promise = bridge.encryptBatch([], new Uint8Array(32), new Uint8Array(64), 'device-1')
+      const posted = mockWorkerInstance.postMessage.mock.calls
+        .filter(([m]) => m.type === 'encrypt-batch')
+        .at(-1)?.[0]
+      mockWorkerInstance.simulateMessage({
+        type: 'encrypt-batch-result',
+        // Never issued means the bridge refused the batch — assert on the
+        // rejection rather than a TypeError on the missing message.
+        requestId: posted?.requestId ?? 'never-issued',
+        results: [],
+        errors: []
+      })
+      await expect(promise).resolves.toEqual({ results: [], errors: [] })
+      expect(bridge.isRunning).toBe(true)
+    })
+
+    it('#then the raced start spawns a fresh thread, not the one shutting down', async () => {
+      // #given
+      const stopping = await startReady()
+
+      // #when
+      await raceStartAgainstTimingOutStop()
+
+      // #then — terminate() was already fired at the old thread, so reusing it
+      // is not an option
+      expect(mockWorkerInstance).not.toBe(stopping)
+      expect(stopping.terminate).toHaveBeenCalled()
+    })
+
+    it('#then the raced start still clears a latched-off bridge', async () => {
+      // #given — a latched bridge, whose only in-session recovery is stop()
+      // followed by start()
+      await startReady()
+      for (let i = 0; i < MAX_CONSECUTIVE_FAILURES; i++) {
+        const request = bridge.encryptBatch([], new Uint8Array(32), new Uint8Array(64), 'device-1')
+        vi.advanceTimersByTime(60_001)
+        await expect(request).rejects.toThrow('Worker request timed out')
+      }
+      expect(bridge.isRunning).toBe(false)
+
+      // #when — that recovery is issued without awaiting the stop
+      await raceStartAgainstTimingOutStop()
+
+      // #then — a start() that bails on the `this.worker` guard never reaches
+      // the latch reset, so the recovery silently did nothing
+      expect(bridge.isRunning).toBe(true)
+    })
+
+    it('#then isRunning is false while the thread is being shut down', async () => {
+      // #given
+      const worker = await startReady()
+
+      // #when
+      const stopPromise = bridge.stop()
+
+      // #then — sync-crypto-batch gates on this, so the batch goes to
+      // main-thread crypto now instead of waiting out REQUEST_TIMEOUT_MS for a
+      // reply from a thread that has been told to exit
+      expect(bridge.isRunning).toBe(false)
+
+      worker.simulateExit(0)
+      await stopPromise
+    })
+
+    it('#then a second stop() joins the one in flight instead of racing it', async () => {
+      // #given
+      const worker = await startReady()
+
+      // #when
+      const first = bridge.stop()
+      const second = bridge.stop()
+      worker.simulateExit(0)
+      await Promise.all([first, second])
+
+      // #then — one shutdown, one exit race, one window
+      expect(worker.postMessage.mock.calls.filter(([m]) => m.type === 'shutdown')).toHaveLength(1)
+      expect(bridge.isRunning).toBe(false)
+    })
+  })
+
   describe('#given running bridge #when encryptBatch called', () => {
     it('#then sends message and returns result', async () => {
       // #given

--- a/apps/desktop/src/main/sync/worker-bridge.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.ts
@@ -73,8 +73,23 @@ export class SyncWorkerBridge {
   private consecutiveFailures = 0
   private latchedOff = false
   private sweepTimer: ReturnType<typeof setInterval> | null = null
+  /** Non-null for exactly as long as a stop() is inside its shutdown window. */
+  private stopPromise: Promise<void> | null = null
 
   async start(): Promise<void> {
+    // stop() keeps `this.worker` non-null for the whole of its 3 s shutdown
+    // window, so the guard below cannot tell "running" from "being torn down".
+    // Without this wait a start() issued inside that window returned having
+    // spawned nothing, reset nothing and awaited no `ready`; stop()'s
+    // continuation then nulled the field and left the caller believing a worker
+    // was running when there was none, so every later batch rejected with
+    // 'Worker not started' and three of those latch the bridge off for the
+    // session. Waiting the stop out is what a lifecycle caller means by
+    // "start"; the wait is bounded by stop()'s own 3 s timeout, and the loop
+    // re-checks in case another stop() began while this one waited. A stop()
+    // failure belongs to the stop caller, not to this start().
+    while (this.stopPromise) await this.stopPromise.catch(() => {})
+
     if (this.worker) return
 
     // A freshly spawned thread is not the thread that failed, so it gets a
@@ -84,34 +99,35 @@ export class SyncWorkerBridge {
     this.latchedOff = false
 
     const workerPath = join(__dirname, 'sync-worker.js')
-    this.worker = new Worker(workerPath)
+    const worker = new Worker(workerPath)
+    this.worker = worker
 
     this.readyPromise = new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
-        this.disposeFailedWorker()
+        this.disposeFailedWorker(worker)
         reject(new Error('Worker failed to start within timeout'))
       }, 10_000)
 
       const initErrorHandler = (err: Error): void => {
         clearTimeout(timeout)
         log.error('Sync worker init error', err)
-        this.disposeFailedWorker()
+        this.disposeFailedWorker(worker)
         reject(err)
       }
 
       const onMessage = (msg: WorkerToMainMessage): void => {
         if (msg.type === 'ready') {
           clearTimeout(timeout)
-          this.worker!.off('message', onMessage)
-          this.worker!.off('error', initErrorHandler)
+          worker.off('message', onMessage)
+          worker.off('error', initErrorHandler)
           this.setupMessageHandler()
           log.info('Sync worker ready')
           resolve()
         }
       }
 
-      this.worker!.on('message', onMessage)
-      this.worker!.on('error', initErrorHandler)
+      worker.on('message', onMessage)
+      worker.on('error', initErrorHandler)
     })
 
     await this.readyPromise
@@ -120,14 +136,18 @@ export class SyncWorkerBridge {
   // A worker that never reached ready must not stay attached: isRunning would
   // report true and route crypto batches to a dead thread. Detach so callers
   // fall back to main-thread crypto.
-  private disposeFailedWorker(): void {
-    const worker = this.worker
-    this.worker = null
-    this.readyPromise = null
-    if (worker) {
-      worker.removeAllListeners()
-      void worker.terminate()
+  //
+  // Scoped to the thread this start() spawned, on the same identity rule as
+  // isAbandoned(): a start() that waited out a stop() can have put a live
+  // thread in the field before this start()'s 10 s init timeout gets here, and
+  // the unscoped version would tear that one down instead.
+  private disposeFailedWorker(worker: Worker): void {
+    if (this.worker === worker) {
+      this.worker = null
+      this.readyPromise = null
     }
+    worker.removeAllListeners()
+    void worker.terminate()
   }
 
   /**
@@ -383,18 +403,35 @@ export class SyncWorkerBridge {
   // straight to main-thread crypto without a round trip. stop() deliberately
   // checks `this.worker` instead, so a latched-but-alive thread is still shut
   // down cleanly.
+  //
+  // A thread already told to shut down is not running either: it may never
+  // answer again, and a batch handed to it inside the shutdown window buys a
+  // full REQUEST_TIMEOUT_MS wait and a latch step for a reply that is not
+  // coming. Main-thread crypto is the same crypto and is available now.
   get isRunning(): boolean {
-    return this.worker !== null && !this.latchedOff
+    return this.worker !== null && !this.latchedOff && this.stopPromise === null
   }
 
-  async stop(): Promise<void> {
-    if (!this.worker) return
+  stop(): Promise<void> {
+    // A second stop() means the same thing as the one already in flight —
+    // posting another shutdown and racing a second exit against the same thread
+    // only gives the two overlapping windows to null `this.worker` out from
+    // under each other.
+    if (this.stopPromise) return this.stopPromise
 
-    this.worker.postMessage({ type: 'shutdown' } satisfies MainToWorkerMessage)
+    const worker = this.worker
+    if (!worker) return Promise.resolve()
+
+    this.stopPromise = this.shutdownWorker(worker).finally(() => {
+      this.stopPromise = null
+    })
+    return this.stopPromise
+  }
+
+  private async shutdownWorker(worker: Worker): Promise<void> {
+    worker.postMessage({ type: 'shutdown' } satisfies MainToWorkerMessage)
 
     await new Promise<void>((resolve) => {
-      const worker = this.worker!
-
       const onExit = (): void => {
         this.rejectAll(new Error('Worker exited'))
         clearTimeout(timeout)

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -697,3 +697,11 @@ arrives from a thread it has already walked away from is ignored, and that threa
 outright. Without this, the late exit of a terminated worker would take the _live_ worker out of the
 rotation — a bridge reporting no worker at all while a healthy thread sat idle, leaving every batch
 for the rest of the session on the main thread.
+
+Starting and stopping the bridge are serialised against each other. A start requested while a
+shutdown is still running waits for that shutdown to finish and then spawns a fresh thread, instead
+of mistaking the thread on its way out for a running one and returning with nothing behind it. For
+the same reason a thread that has been asked to exit no longer counts as running, so batches raised
+during the shutdown window go straight to the main thread rather than waiting out a request timeout
+against a worker that is leaving. This is what keeps a vault switch or a sync restart from ending up
+on main-thread crypto for the rest of the session.


### PR DESCRIPTION
Closes #1321. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/sync/worker-bridge.ts` used `this.worker` as the only lifecycle signal, and `stop()` kept that field non-null for its entire 3 s shutdown window:

```ts
async stop(): Promise<void> {
  if (!this.worker) return
  this.worker.postMessage({ type: 'shutdown' } ...)
  await new Promise<void>((resolve) => { /* exit race, 3s terminate timeout */ })
  this.worker = null          // only here
}

async start(): Promise<void> {
  if (this.worker) return     // ← can't tell "running" from "being torn down"
```

A `start()` issued inside that window returned immediately having spawned nothing, reset nothing (`consecutiveFailures` / `latchedOff` are set below that guard) and awaited no `ready`. Moments later `stop()`'s continuation nulled the field, leaving the bridge with no worker at all despite `start()` reporting success. Every later `sendRequest` then rejected with `Worker not started`, and three of those latch the bridge off via `recordRequestFailure` — sync crypto silently runs on the main thread for the rest of the session, and the failure reads as a worker problem rather than a lifecycle one.

`isRunning` had the same blind spot: `this.worker !== null && !this.latchedOff` was true for a thread that had already been told to exit, so a batch raised mid-shutdown paid a full 60 s `REQUEST_TIMEOUT_MS` waiting for a reply that was never coming.

## What changed

- `stop()` publishes an in-flight `stopPromise` for exactly the length of its shutdown window; the body moved to a private `shutdownWorker(worker)` (unchanged internals).
- `start()` awaits that promise before its `this.worker` guard, then proceeds — spawning a fresh thread and running the latch reset. **Queue rather than reject**, because both callers are lifecycle code and "start after the stop finishes" is what they mean; the wait is bounded by `stop()`'s own 3 s timeout, so it can never hang. A `stop()` failure is swallowed for the waiter (`.catch(() => {})`) — it belongs to the stop caller, not to this start.
- `stop()` called again while one is in flight returns the same promise instead of posting a second shutdown and racing a second exit handler at the same thread.
- `isRunning` is false while a stop is in flight.
- `disposeFailedWorker` is now scoped to the thread the calling `start()` spawned, on the same identity rule as `isAbandoned()` (PR #1296). This guards a path the serialization opens: a queued start can install a live thread before the earlier start's 10 s init timeout fires, and the unscoped version would have torn that live thread down.

Deliberately **not** done: `stop()` does not wait for an in-flight `start()`. That direction is pre-existing behaviour, is not what #1321 describes, and adding it needs care to avoid a start↔stop deadlock. The two merged fixes in this file are untouched — PR #1262's detached `once('exit')` and PR #1296's `isAbandoned()` identity checks are both still in place and still tested.

## How it was proven

Source file reverted to `origin/main` with the new tests in place, then restored (`git checkout origin/main -- worker-bridge.ts` / `git checkout HEAD -- ...`, never `git stash`):

- **Before:** `Tests 5 failed | 36 passed (41)` — the headline failure is exactly the reported symptom: `#then a crypto batch still reaches a worker instead of "Worker not started"` → `promise rejected "Error: Worker not started" instead of resolving`. Also failing: fresh-thread identity, latch not cleared, `isRunning` true mid-shutdown, two shutdowns posted.
- **After:** `Tests 41 passed (41)`.

The two merged fixes still hold — their tests are in the same file and pass in that 41:
- PR #1262 (detached timeout exit listener): `#then drops the shutdown exit listener when the 3s timeout fires`, `#then a late exit from the timed-out worker cannot reject a restarted bridge` — 2 tests, both green.
- PR #1296 (`isAbandoned` identity checks): the whole `#given a timed-out stop() and a restart #when the abandoned thread speaks` block — 4 tests, all green.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  apps/desktop/src/main/sync/worker-bridge.test.ts \
  apps/desktop/src/main/sync/runtime.test.ts \
  apps/desktop/src/main/sync/sync-crypto-batch.test.ts
    → Test Files 3 passed (3), Tests 75 passed (75)

pnpm --filter @memry/desktop typecheck:node   → clean
pnpm exec eslint apps/desktop/src/main/sync/worker-bridge.ts   → 0 errors
git diff --check   → clean
pnpm docs:impact --base origin/main --strict   → covered
pnpm docs:build   → build complete
```

No renderer files touched, so `typecheck:web` was not run.

## Backward compatibility

Main-process internals only — no schema, IPC contract, settings, vault-file or sync-protocol shape changes, and the worker remains a pure optimisation with the same main-thread crypto fallback.
