### PR TITLE
fix(tooling): implement the docs-gate escape hatch and restore the pre-push docs check

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -106,6 +106,11 @@ jobs:
       - name: Test Electron binary installer concurrency
         run: node --test apps/desktop/scripts/install-electron-binary.test.cjs
 
+      # The pre-push docs block was deleted by an unrelated PR and stayed deleted for
+      # weeks because nothing ran these guards. Keep them in CI.
+      - name: Test docs gate and pre-push policy
+        run: node --test scripts/docs-impact.test.mjs scripts/pre-push-policy.test.mjs
+
   unit:
     name: Unit & integration tests
     runs-on: ubuntu-latest

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -38,3 +38,39 @@ code_changed='^(apps/desktop|apps/sync-server|packages|scripts|package.json|pnpm
 if ! has_changes "$code_changed"; then
   exit 0
 fi
+
+# MEMRY_DOCS_IMPACT_SKIP=1 is honoured inside scripts/docs-impact.mjs, so the manual
+# `pnpm docs:impact --strict` run and this hook share one escape hatch.
+set +e
+pnpm docs:impact --base "$base_commit" --strict
+docs_impact_status=$?
+set -e
+
+if [ "$docs_impact_status" -ne 0 ]; then
+  if [ "$docs_impact_status" -ne 1 ]; then
+    exit "$docs_impact_status"
+  fi
+
+  if ! git diff --quiet -- apps/docs/src ||
+    ! git diff --cached --quiet -- apps/docs/src; then
+    printf '\npre-push: uncommitted docs changes exist. Commit them before pushing.\n\n' >&2
+    exit 1
+  fi
+
+  if [ "${MEMRY_DOCS_AI_AUTO:-0}" = "1" ]; then
+    printf '\npre-push: running AI docs updater for desktop/sync-server changes...\n\n' >&2
+    pnpm docs:ai-update --base "$base_commit"
+
+    if ! git diff --quiet -- apps/docs/src; then
+      printf '\npre-push: AI updated docs. Review, verify, commit, and push again.\n\n' >&2
+    else
+      printf '\npre-push: AI did not change docs. If no docs are needed, retry with MEMRY_DOCS_IMPACT_SKIP=1.\n\n' >&2
+    fi
+  else
+    printf '\npre-push: docs update required. Run `pnpm docs:ai-update --base %s` or update apps/docs/src manually.\n' "$base_commit" >&2
+    printf 'pre-push: set MEMRY_DOCS_AI_AUTO=1 to let this hook run the updater.\n' >&2
+    printf 'pre-push: if this change genuinely needs no docs, retry with MEMRY_DOCS_IMPACT_SKIP=1.\n\n' >&2
+  fi
+
+  exit 1
+fi

--- a/apps/docs/src/contribute/workflow.md
+++ b/apps/docs/src/contribute/workflow.md
@@ -61,7 +61,7 @@ pnpm docs:build
 
 `docs:ai-update` uses the Codex CLI to inspect the branch diff and update only `apps/docs/src`. The pre-push hook only runs the docs impact check; when docs are missing, it stops the push and points you to the manual updater. Set `MEMRY_DOCS_AI_AUTO=1` only when you want the hook to run the updater for that push. Lint, typecheck, and test suites run in GitHub Actions.
 
-If a change truly has no docs impact, use the `docs:not-needed` PR label for CI and `MEMRY_DOCS_IMPACT_SKIP=1 git push` for the local hook.
+If a change truly has no docs impact, set `MEMRY_DOCS_IMPACT_SKIP=1` — `MEMRY_DOCS_IMPACT_SKIP=1 git push` for the hook, or `MEMRY_DOCS_IMPACT_SKIP=1 pnpm docs:impact --strict` for a manual run. The gate then reports the waived files and passes; say why the change needs no docs in the PR. There is no CI-side docs gate and no `docs:not-needed` label — the check is local only.
 
 ## Pre-Land Checks
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typecheck:emails": "pnpm --filter @memry/marketing-emails typecheck",
     "test": "pnpm repair:links && node scripts/run-turbo.js run test --filter=@memry/contracts --filter=@memry/app-core --filter=@memry/cli --filter=@memry/desktop --filter=@memry/sync-server --filter=@memry/landing",
     "test:cli": "pnpm --filter @memry/app-core test && pnpm --filter @memry/cli test",
-    "test:release": "node --test scripts/release-utils.test.mjs scripts/release-notes-utils.test.mjs scripts/reddit-release-utils.test.mjs scripts/pre-push-policy.test.mjs scripts/package-scripts.test.mjs apps/desktop/scripts/build-packaged-app-utils.test.cjs apps/desktop/scripts/check-packaged-runtime-deps-utils.test.cjs",
+    "test:release": "node --test scripts/release-utils.test.mjs scripts/release-notes-utils.test.mjs scripts/reddit-release-utils.test.mjs scripts/pre-push-policy.test.mjs scripts/docs-impact.test.mjs scripts/package-scripts.test.mjs apps/desktop/scripts/build-packaged-app-utils.test.cjs apps/desktop/scripts/check-packaged-runtime-deps-utils.test.cjs",
     "test:desktop": "pnpm --filter @memry/desktop test",
     "test:sync-server": "pnpm --filter @memry/sync-server test",
     "test:sync-harness": "pnpm --filter @memry/sync-harness build:worker && pnpm --filter @memry/sync-harness test",

--- a/scripts/docs-impact.mjs
+++ b/scripts/docs-impact.mjs
@@ -80,6 +80,10 @@ ${fileList}
 `
 }
 
+export function isStrictSkipEnabled(env = process.env) {
+  return env.MEMRY_DOCS_IMPACT_SKIP === '1'
+}
+
 export function resolveBaseRef() {
   const upstreamRef = runGitOrNull(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'])
   if (upstreamRef) {
@@ -199,8 +203,17 @@ function runCli() {
   }
 
   if (options.strict && result.status === 'missing-docs') {
+    if (isStrictSkipEnabled()) {
+      console.error(
+        `\ndocs impact: strict gate bypassed via MEMRY_DOCS_IMPACT_SKIP=1. Waived docs-relevant files:\n${result.relevantFiles
+          .map((filePath) => `  ${filePath}`)
+          .join('\n')}\nExplain in the PR why this change needs no docs.\n`
+      )
+      return
+    }
+
     console.error(
-      '\ndocs impact: desktop/sync-server changes need docs review. Run `pnpm docs:ai-update` or update apps/docs/src, then commit the docs changes.\n'
+      '\ndocs impact: desktop/sync-server changes need docs review. Run `pnpm docs:ai-update` or update apps/docs/src, then commit the docs changes.\nIf this change genuinely has no user-facing docs impact, re-run with MEMRY_DOCS_IMPACT_SKIP=1 and say why in the PR.\n'
     )
     process.exit(1)
   }

--- a/scripts/docs-impact.test.mjs
+++ b/scripts/docs-impact.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { after, before, describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { isStrictSkipEnabled } from './docs-impact.mjs'
+
+const scriptPath = fileURLToPath(new URL('./docs-impact.mjs', import.meta.url))
+
+let repo
+let baseCommit
+
+function git(args) {
+  return execFileSync('git', ['-c', 'core.hooksPath=', ...args], {
+    cwd: repo,
+    encoding: 'utf8'
+  }).trim()
+}
+
+function writeRepoFile(relativePath, contents) {
+  const target = path.join(repo, relativePath)
+  mkdirSync(path.dirname(target), { recursive: true })
+  writeFileSync(target, contents)
+}
+
+function commit(message) {
+  git(['add', '-A'])
+  git(['-c', 'user.email=test@memry.local', '-c', 'user.name=Memry Test', 'commit', '-m', message])
+  return git(['rev-parse', 'HEAD'])
+}
+
+function runGate(env = {}) {
+  return spawnSync(process.execPath, [scriptPath, '--base', baseCommit, '--strict'], {
+    cwd: repo,
+    encoding: 'utf8',
+    env: { ...process.env, MEMRY_DOCS_IMPACT_SKIP: '', ...env }
+  })
+}
+
+before(() => {
+  repo = mkdtempSync(path.join(tmpdir(), 'docs-impact-'))
+  git(['init', '--quiet'])
+  writeRepoFile('README.md', '# base\n')
+  baseCommit = commit('base')
+})
+
+after(() => {
+  rmSync(repo, { force: true, recursive: true })
+})
+
+describe('isStrictSkipEnabled', () => {
+  it('only opts out on an exact "1"', () => {
+    assert.equal(isStrictSkipEnabled({ MEMRY_DOCS_IMPACT_SKIP: '1' }), true)
+    assert.equal(isStrictSkipEnabled({ MEMRY_DOCS_IMPACT_SKIP: '0' }), false)
+    assert.equal(isStrictSkipEnabled({ MEMRY_DOCS_IMPACT_SKIP: 'true' }), false)
+    assert.equal(isStrictSkipEnabled({}), false)
+  })
+})
+
+describe('docs:impact --strict', () => {
+  it('fails an undocumented desktop change when the flag is unset', () => {
+    writeRepoFile('apps/desktop/src/feature.ts', 'export const feature = 1\n')
+    commit('add desktop feature')
+
+    const unset = runGate()
+    assert.equal(unset.status, 1)
+    assert.match(unset.stderr, /desktop\/sync-server changes need docs review/)
+    assert.match(unset.stderr, /MEMRY_DOCS_IMPACT_SKIP=1/)
+
+    const explicitZero = runGate({ MEMRY_DOCS_IMPACT_SKIP: '0' })
+    assert.equal(explicitZero.status, 1)
+  })
+
+  it('passes the same change when MEMRY_DOCS_IMPACT_SKIP=1 and names the waived files', () => {
+    const skipped = runGate({ MEMRY_DOCS_IMPACT_SKIP: '1' })
+
+    assert.equal(skipped.status, 0)
+    assert.match(skipped.stderr, /bypassed via MEMRY_DOCS_IMPACT_SKIP=1/)
+    assert.match(skipped.stderr, /apps\/desktop\/src\/feature\.ts/)
+  })
+
+  it('leaves stdout parseable as JSON while bypassing', () => {
+    const skipped = spawnSync(
+      process.execPath,
+      [scriptPath, '--base', baseCommit, '--strict', '--json'],
+      {
+        cwd: repo,
+        encoding: 'utf8',
+        env: { ...process.env, MEMRY_DOCS_IMPACT_SKIP: '1' }
+      }
+    )
+
+    assert.equal(skipped.status, 0)
+    assert.equal(JSON.parse(skipped.stdout).status, 'missing-docs')
+  })
+
+  it('still passes without the flag once docs cover the change', () => {
+    writeRepoFile('apps/docs/src/user-guide/feature.md', '# Feature\n')
+    commit('document desktop feature')
+
+    const covered = runGate()
+    assert.equal(covered.status, 0)
+  })
+})


### PR DESCRIPTION
Closes #1342. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

The issue reported three documented docs-gate mechanics that do not exist. All three confirmed — and the first two turn out to have one root cause.

**1. `MEMRY_DOCS_IMPACT_SKIP` was implemented, then deleted as collateral damage.**

It never lived in `scripts/docs-impact.mjs`. It lived in `.husky/pre-push`, and commit `c2e46b2c7` — *"chore: UI component updates and refactoring (#611)"*, a UI refactor — deleted 35 lines from the hook on 2026-06-26, taking the flag and the whole docs gate with it:

```diff
 if ! has_changes "$code_changed"; then
   exit 0
 fi
-
-if [ "${MEMRY_DOCS_IMPACT_SKIP:-0}" != "1" ]; then
-  set +e
-  pnpm docs:impact --base "$base_commit" --strict
-  ...
```

That is also why `.husky/pre-push` now ends at line 40 right after the `code_changed` early-exit: every line above it (`base_commit`, `changed_files`, `has_changes`, `code_changed`) computes inputs for a block that no longer exists.

**2. The guard that should have caught it was already red — and nothing runs it.**

`scripts/pre-push-policy.test.mjs:37` still asserts `keeps the docs impact gate in the pre-push hook`. On `origin/main` today, 2 of its 3 tests fail. `pnpm test:release` is the only thing that runs that file, and `grep -rn 'test:release' .github` returns nothing. The regression has been red and invisible for ~7 weeks.

**3. `docs:not-needed` never existed.** `git grep 'docs:not-needed' -- .github` returns nothing, and there is no docs job in any workflow. The claim in `apps/docs/src/contribute/workflow.md:64` was aspirational.

## What changed

- **`scripts/docs-impact.mjs`** — new exported `isStrictSkipEnabled(env)`; `runCli()` honours `MEMRY_DOCS_IMPACT_SKIP=1` under `--strict` by printing the waived docs-relevant file list to **stderr** and returning 0. The failure message now names the escape hatch, which is how you find it. Exactly `'1'` opts out (parity with the old hook's `!= "1"`), so `=0`/`=true` do not silently bypass.
  - Put deliberately in the script, not back in the hook: the flag now covers the manual `pnpm docs:impact --strict` that CLAUDE.md and `workflow.md` both tell people to run, not just `git push`. Single source of truth for the bypass.
  - `status` stays `missing-docs` in `--json` when bypassed — only the exit code changes, and the bypass notice goes to stderr so stdout stays parseable.
- **`.husky/pre-push`** — restored the deleted docs block, minus its now-redundant shell-level `MEMRY_DOCS_IMPACT_SKIP` wrapper (the script owns the flag). Added one line pointing at the escape hatch in the non-`MEMRY_DOCS_AI_AUTO` branch.
  - This re-adds **only** the docs check. No lint, typecheck, test, or `docs:build` came back — CLAUDE.md:57 forbids that and `pre-push-policy.test.mjs` asserts it. CLAUDE.md:56 already describes the hook as doing exactly this; the hook was accidentally out of sync with its own documentation and its own test.
- **`apps/docs/src/contribute/workflow.md:64`** — the `docs:not-needed` label claim is removed rather than implemented. Wiring a CI docs gate is a real behavioral change to every PR in the repo and is not what this issue asks for. The line now states the truth: the gate is local only, and `MEMRY_DOCS_IMPACT_SKIP=1` works for both the hook and a manual run.
- **`scripts/docs-impact.test.mjs`** (new) + **`package.json`** — registered in `test:release`.
- **`.github/workflows/desktop-ci.yml`** — one step in the existing `Static checks` job runs both tooling tests. This is the only change beyond the issue's literal scope, and it is the reason the regression survived: the guard existed and nothing executed it. It follows the pattern already in that job (`node --test scripts/validate-mac-update-manifest.test.mjs`) and needs no extra dependencies.

`CLAUDE.md` needed no edit — every claim in its Docs Automation section is true again once the hook and flag are restored.

## How it was proven

`scripts/docs-impact.test.mjs` drives the real CLI in a throwaway git repo (`git init`, real commits, `spawnSync` on the actual script) and asserts exit codes — no mocks.

```
# BEFORE  (git checkout origin/main -- scripts/docs-impact.mjs .husky/pre-push, tests kept)
ℹ tests 4   ℹ pass 1   ℹ fail 3
  ✖ keeps docs AI updates opt-in instead of running them on every push
  ✖ keeps the docs impact gate in the pre-push hook
  (docs-impact.test.mjs fails to load — no isStrictSkipEnabled export)

# AFTER
ℹ tests 8   ℹ pass 8   ℹ fail 0
```

Direct CLI demonstration on the same synthetic repo (one undocumented `apps/desktop/src/*.ts` change):

| script | env | exit |
| --- | --- | --- |
| `origin/main` | `MEMRY_DOCS_IMPACT_SKIP=1` | **1** (flag ignored) |
| this branch | `MEMRY_DOCS_IMPACT_SKIP=1` | **0** + `strict gate bypassed via MEMRY_DOCS_IMPACT_SKIP=1` listing `apps/desktop/src/b.ts` |
| this branch | unset | **1** |
| this branch | `MEMRY_DOCS_IMPACT_SKIP=0` | **1** |

An unset run still fails a genuinely undocumented change, and a covered change (docs committed) still passes without the flag — both asserted.

## Verification

```
node --test <full test:release list>        ℹ tests 49  ℹ pass 49  ℹ fail 0
node scripts/docs-impact.mjs --base origin/main --strict
                                            → "no desktop/sync-server docs-relevant changes detected", exit 0
pnpm --filter @memry/docs build             → build complete in 26.58s
sh -n .husky/pre-push                        → clean
prettier --check <all changed files>         → "All matched files use Prettier code style!"
git diff --check                             → clean
```

No `pnpm lint` / `pnpm typecheck`: `eslint.config.mjs` ignores `scripts/**`, and no TypeScript was touched.

## Backward compatibility

Tooling only — no runtime, schema, contract, sync, or settings surface is touched; the gate's default behavior with the flag unset is byte-for-byte the previous behavior plus one extra hint line.
