### PR TITLE
perf(crdt): bound the CRDT update queue across notes, not just per note

### DIFF
--- a/apps/desktop/src/main/sync/crdt-queue.test.ts
+++ b/apps/desktop/src/main/sync/crdt-queue.test.ts
@@ -195,6 +195,141 @@ describe('CrdtUpdateQueue', () => {
     expect(persistUnflushed).toHaveBeenCalledWith(['note-a', 'note-b'])
   })
 
+  it('flushes instead of releasing when the total budget is crossed while running', async () => {
+    const persistUnflushed = vi.fn()
+    const queue = new CrdtUpdateQueue({ persistUnflushed })
+    const pushedNotes: string[] = []
+    const push = vi.fn(async (noteId: string) => {
+      pushedNotes.push(noteId)
+    })
+
+    queue.start(push)
+    // 40MB across 20 notes, past the 32MB total ceiling, with no pause: the
+    // sweep must drain to the server rather than release anything.
+    for (let i = 0; i < 20; i++) {
+      queue.enqueue(`note-${i}`, new Uint8Array(2 * 1024 * 1024))
+      vi.advanceTimersByTime(1)
+    }
+
+    expect(persistUnflushed).not.toHaveBeenCalled()
+    expect(queue.getPendingBytes()).toBeLessThanOrEqual(32 * 1024 * 1024)
+
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    expect(new Set(pushedNotes).size).toBe(20)
+    expect(queue.getPendingBytes()).toBe(0)
+
+    queue.stop()
+  })
+
+  it('bounds the total buffer across notes while paused without losing an update', async () => {
+    const persisted: string[] = []
+    const persistUnflushed = vi.fn((noteIds: string[]) => {
+      persisted.push(...noteIds)
+    })
+    const queue = new CrdtUpdateQueue({ persistUnflushed })
+    const pushedByNote = new Map<string, Uint8Array[]>()
+    const push = vi.fn(async (noteId: string, updates: Uint8Array[]) => {
+      const existing = pushedByNote.get(noteId) ?? []
+      existing.push(...updates)
+      pushedByNote.set(noteId, existing)
+    })
+
+    // 20 notes, ~2MB of real edits each — 40MB in total, well past the 32MB
+    // cross-note ceiling, while every per-note cap is still satisfied.
+    const noteIds = Array.from({ length: 20 }, (_, i) => `note-${i}`)
+    const docs = new Map<string, Y.Doc>()
+    const rawByNote = new Map<string, Uint8Array[]>()
+    for (const noteId of noteIds) {
+      const doc = new Y.Doc()
+      const raw: Uint8Array[] = []
+      doc.on('update', (update: Uint8Array) => raw.push(update))
+      doc.getText('body').insert(0, `${noteId}:${'x'.repeat(2 * 1024 * 1024)}`)
+      docs.set(noteId, doc)
+      rawByNote.set(noteId, raw)
+    }
+
+    queue.start(push)
+    queue.pause()
+    for (const noteId of noteIds) {
+      for (const update of rawByNote.get(noteId)!) {
+        queue.enqueue(noteId, update)
+      }
+      // Distinct timestamps so "oldest first" is a real ordering, not the
+      // stable-sort fallback.
+      vi.advanceTimersByTime(1)
+    }
+
+    // The map is bounded now, not just each note's slot in it.
+    expect(persisted.length).toBeGreaterThan(0)
+    // Released oldest first, and only as far as the low-water mark.
+    expect(persisted).toEqual(noteIds.slice(0, persisted.length))
+    expect(queue.getPendingBytes()).toBeLessThanOrEqual(32 * 1024 * 1024)
+    expect(push).not.toHaveBeenCalled()
+
+    queue.resume()
+    for (let i = 0; i < 5; i++) {
+      await flushPromises()
+      vi.advanceTimersByTime(1000)
+    }
+    await flushPromises()
+    expect(queue.getPendingBytes()).toBe(0)
+
+    // Nothing was lost: every note either reached the server through the queue
+    // or was recorded for the full-state replay `drainPendingCrdtNotes` runs.
+    const replayed = new Set(persisted)
+    expect(new Set([...replayed, ...pushedByNote.keys()])).toEqual(new Set(noteIds))
+    for (const noteId of noteIds) {
+      const replica = new Y.Doc()
+      if (replayed.has(noteId)) {
+        Y.applyUpdate(replica, Y.encodeStateAsUpdate(docs.get(noteId)!))
+      }
+      for (const update of pushedByNote.get(noteId) ?? []) {
+        Y.applyUpdate(replica, update)
+      }
+      expect(replica.getText('body').toString()).toBe(docs.get(noteId)!.getText('body').toString())
+    }
+
+    queue.stop()
+  })
+
+  it('keeps every buffered update when there is no durable store to release into', () => {
+    const queue = new CrdtUpdateQueue()
+
+    queue.start(vi.fn(async () => undefined))
+    queue.pause()
+    for (let i = 0; i < 20; i++) {
+      queue.enqueue(`note-${i}`, new Uint8Array(2 * 1024 * 1024))
+      vi.advanceTimersByTime(1)
+    }
+
+    expect(queue.getPendingCount()).toBe(20)
+    expect(queue.getPendingBytes()).toBe(40 * 1024 * 1024)
+
+    queue.stop()
+  })
+
+  it('keeps every buffered update when recording notes for replay throws', () => {
+    const persistUnflushed = vi.fn(() => {
+      throw new Error('disk full')
+    })
+    const queue = new CrdtUpdateQueue({ persistUnflushed })
+
+    queue.start(vi.fn(async () => undefined))
+    queue.pause()
+    for (let i = 0; i < 20; i++) {
+      queue.enqueue(`note-${i}`, new Uint8Array(2 * 1024 * 1024))
+      vi.advanceTimersByTime(1)
+    }
+
+    expect(persistUnflushed).toHaveBeenCalled()
+    expect(queue.getPendingCount()).toBe(20)
+    expect(queue.getPendingBytes()).toBe(40 * 1024 * 1024)
+
+    persistUnflushed.mockImplementation(() => undefined)
+    queue.stop()
+  })
+
   it('does not persist anything when the shutdown flush drains the buffers', async () => {
     const persistUnflushed = vi.fn()
     const queue = new CrdtUpdateQueue({ persistUnflushed })

--- a/apps/desktop/src/main/sync/crdt-queue.ts
+++ b/apps/desktop/src/main/sync/crdt-queue.ts
@@ -14,6 +14,16 @@ const MAX_MERGED_UPDATE_BYTES = 256 * 1024
 // Largest raw payload a single flush may carry, for the same reason: after
 // coalescing a batch of 50 entries could otherwise be tens of megabytes.
 const MAX_FLUSH_PAYLOAD_BYTES = 512 * 1024
+// Ceiling on everything buffered across every note. The caps above are all
+// per note; the map itself keeps one live buffer per note touched since the
+// queue was paused, so a long offline session still grows by note count.
+const MAX_TOTAL_BUFFERED_BYTES = 32 * 1024 * 1024
+// Release down to here once the ceiling is crossed, so one sweep buys room for
+// a while instead of running on every subsequent enqueue.
+const TOTAL_BUFFER_LOW_WATER_BYTES = 24 * 1024 * 1024
+// When a sweep cannot get back under the ceiling — because releasing would
+// mean losing updates — wait for this much extra growth before trying again.
+const BUDGET_RECHECK_STEP_BYTES = 4 * 1024 * 1024
 
 interface BufferedUpdate {
   noteId: string
@@ -21,11 +31,18 @@ interface BufferedUpdate {
   timestamp: number
 }
 
+function bytesOf(entries: readonly BufferedUpdate[]): number {
+  let total = 0
+  for (const entry of entries) total += entry.rawUpdate.byteLength
+  return total
+}
+
 export interface CrdtUpdateQueueOptions {
   /**
    * Called synchronously from `stop()` with the notes whose updates could not
-   * be flushed before shutdown. Must persist them durably — see
-   * `recordPendingCrdtNotes`.
+   * be flushed before shutdown, and from the total-buffer budget sweep with the
+   * notes whose payloads are about to be released. Must persist them durably —
+   * see `recordPendingCrdtNotes`.
    */
   persistUnflushed?: (noteIds: string[]) => void
 }
@@ -36,6 +53,8 @@ export class CrdtUpdateQueue {
   private flushingNotes = new Set<string>()
   private pushFn: ((noteId: string, updates: Uint8Array[]) => Promise<void>) | null = null
   private paused = false
+  private bufferedBytes = 0
+  private nextBudgetSweepBytes = MAX_TOTAL_BUFFERED_BYTES
 
   constructor(private readonly options: CrdtUpdateQueueOptions = {}) {}
 
@@ -92,18 +111,25 @@ export class CrdtUpdateQueue {
       this.buffers.set(noteId, buffer)
     }
     buffer.push({ noteId, rawUpdate, timestamp: Date.now() })
+    this.bufferedBytes += rawUpdate.byteLength
 
-    if (buffer.length < MAX_BATCH_SIZE) return
+    if (buffer.length >= MAX_BATCH_SIZE) {
+      this.flushNote(noteId)
 
-    this.flushNote(noteId)
+      // A paused, offline or mid-flight queue keeps the buffer. Merge it in
+      // place so an offline session costs the size of the edit instead of one
+      // retained Uint8Array per keystroke. Yjs update merging is lossless —
+      // nothing is evicted, the same operations are simply carried in fewer
+      // arrays.
+      const remaining = this.buffers.get(noteId)
+      if (remaining && remaining.length >= MAX_BATCH_SIZE) {
+        this.coalesce(noteId, remaining)
+      }
+    }
 
-    // A paused, offline or mid-flight queue keeps the buffer. Merge it in place
-    // so an offline session costs the size of the edit instead of one retained
-    // Uint8Array per keystroke. Yjs update merging is lossless — nothing is
-    // evicted, the same operations are simply carried in fewer arrays.
-    const remaining = this.buffers.get(noteId)
-    if (remaining && remaining.length >= MAX_BATCH_SIZE) {
-      this.coalesce(noteId, remaining)
+    // Every cap above is per note; this one bounds the map as a whole.
+    if (this.bufferedBytes >= this.nextBudgetSweepBytes) {
+      this.enforceTotalBudget()
     }
   }
 
@@ -115,8 +141,83 @@ export class CrdtUpdateQueue {
     return count
   }
 
+  /** Raw bytes held across every note's buffer. */
+  getPendingBytes(): number {
+    return this.bufferedBytes
+  }
+
   getOutstandingCount(): number {
     return this.getPendingCount() + this.flushingNotes.size
+  }
+
+  /**
+   * Bound the whole map rather than one note at a time.
+   *
+   * Tries every lossless option first — flush what the server will take, then
+   * merge each buffer in place — and only then releases the oldest notes'
+   * payloads. A release is not a drop: the note ids go to the durable pending
+   * store first, and `drainPendingCrdtNotes` re-pushes each note's full doc
+   * state (which strictly supersedes the buffered updates) on the next
+   * reconnect or start. If there is no durable store to release into, or
+   * recording fails, the memory is kept instead.
+   */
+  private enforceTotalBudget(): void {
+    // Free when running (takeBatch removes the bytes synchronously) and a
+    // no-op while paused, which is the case this budget actually exists for.
+    this.flushAll()
+
+    for (const [noteId, buffer] of this.buffers) {
+      if (buffer.length > 1) this.coalesce(noteId, buffer)
+    }
+
+    if (this.bufferedBytes <= MAX_TOTAL_BUFFERED_BYTES) {
+      this.nextBudgetSweepBytes = MAX_TOTAL_BUFFERED_BYTES
+      return
+    }
+
+    const persistUnflushed = this.options.persistUnflushed
+    if (!persistUnflushed) {
+      log.warn('CRDT buffers are over budget but there is no durable store to release into', {
+        bufferedBytes: this.bufferedBytes,
+        noteCount: this.buffers.size
+      })
+      this.nextBudgetSweepBytes = this.bufferedBytes + BUDGET_RECHECK_STEP_BYTES
+      return
+    }
+
+    // Oldest buffered edit first: the note the user is typing in right now is
+    // the newest, and the oldest is the one least likely to still be active.
+    const oldestFirst = Array.from(this.buffers.entries()).sort(
+      (a, b) => (a[1][0]?.timestamp ?? 0) - (b[1][0]?.timestamp ?? 0)
+    )
+    const release: string[] = []
+    let releasedBytes = 0
+    for (const [noteId, buffer] of oldestFirst) {
+      if (this.bufferedBytes - releasedBytes <= TOTAL_BUFFER_LOW_WATER_BYTES) break
+      release.push(noteId)
+      releasedBytes += bytesOf(buffer)
+    }
+
+    try {
+      // Durable first — the ids have to survive before the payloads go.
+      if (release.length > 0) persistUnflushed(release)
+    } catch (err) {
+      log.error('Failed to record CRDT notes for replay, keeping their updates buffered', {
+        noteCount: release.length,
+        error: err
+      })
+      this.nextBudgetSweepBytes = this.bufferedBytes + BUDGET_RECHECK_STEP_BYTES
+      return
+    }
+
+    for (const noteId of release) this.buffers.delete(noteId)
+    this.bufferedBytes -= releasedBytes
+    this.nextBudgetSweepBytes = MAX_TOTAL_BUFFERED_BYTES
+    log.warn('CRDT buffers over budget — released the oldest notes for full-state replay', {
+      noteCount: release.length,
+      releasedBytes,
+      bufferedBytes: this.bufferedBytes
+    })
   }
 
   /**
@@ -160,6 +261,7 @@ export class CrdtUpdateQueue {
     }
 
     if (merged.length >= buffer.length) return
+    this.bufferedBytes += bytesOf(merged) - bytesOf(buffer)
     buffer.splice(0, buffer.length, ...merged)
   }
 
@@ -194,6 +296,7 @@ export class CrdtUpdateQueue {
     if (!buffer || buffer.length === 0) return
 
     const updates = this.takeBatch(buffer)
+    this.bufferedBytes -= bytesOf(updates)
     if (buffer.length === 0) this.buffers.delete(noteId)
 
     if (!this.pushFn) {
@@ -226,6 +329,7 @@ export class CrdtUpdateQueue {
           this.buffers.set(noteId, existing)
         }
         existing.unshift(...updates)
+        this.bufferedBytes += bytesOf(updates)
       })
       .finally(() => {
         this.flushingNotes.delete(noteId)

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -252,6 +252,15 @@ A separate queue from `SyncQueueManager`:
 - Respects sequence ordering per `noteId`
 - Buffers updates when the network is paused
 
+### Memory bounds while paused
+
+While the queue is paused (offline, expired token, storage quota) nothing drains, so the buffers are capped on two axes:
+
+- **Per note** — a buffer that reaches the batch size is merged in place with `Y.mergeUpdates`, and merged updates and flush payloads are size-bounded. Merging is lossless; a long offline edit costs the size of the edit, not one array per keystroke.
+- **Across all notes** — the queue also caps its total buffered bytes, because the map keeps one live buffer per note touched since the pause. Crossing the ceiling first flushes whatever the server will take and merges every buffer, and only if that is not enough does it release the oldest notes' payloads.
+
+A release is never a drop. The note ids go to the durable pending-note store (`crdt-pending-notes.json`) **before** their payloads are freed, and `drainPendingCrdtNotes` pushes each note's full doc state — which supersedes the buffered updates — on the next reconnect or app start. If no durable store is wired up, or recording fails, the queue keeps the memory instead of releasing it.
+
 ## BlockNote Compatibility
 
 BlockNote uses Yjs natively. The renderer's BlockNote editor binds to the renderer-side Y.Doc proxy provided by the IPC provider; edits flow through main and back to disk.


### PR DESCRIPTION
Closes #1319. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/sync/crdt-queue.ts` bounds **one note's** backlog three ways — `MAX_BATCH_SIZE` (50 entries), `MAX_MERGED_UPDATE_BYTES` (256 KB per merged run), `MAX_FLUSH_PAYLOAD_BYTES` (512 KB per flush) — and nothing at all looks at the aggregate. `enqueue` creates a fresh buffer for any note id it has not seen:

```ts
enqueue(noteId: string, rawUpdate: Uint8Array): void {
  let buffer = this.buffers.get(noteId)
  if (!buffer) {
    buffer = []
    this.buffers.set(noteId, buffer)
  }
  buffer.push({ noteId, rawUpdate, timestamp: Date.now() })
```

While the queue is paused (offline / 401 / storage quota) `flushNote` no-ops, so every buffer is coalesced but never drained and the map holds one live entry per note touched for the rest of the session. A bulk offline session — an import, an agent editing many notes, a long flight — grows the main-process heap by note count with no ceiling.

## What changed

A cross-note budget in `crdt-queue.ts`, ordered so that **dropping is the last resort and never silent**:

1. `bufferedBytes` is now tracked incrementally at the four sites that mutate a buffer (`enqueue`, `coalesce`, `takeBatch` in `flushNote`, and the retryable-failure `unshift`), exposed as `getPendingBytes()`.
2. Crossing `MAX_TOTAL_BUFFERED_BYTES` (32 MB) runs `enforceTotalBudget()`, which tries the lossless options first: `flushAll()` (free when the queue is running, a no-op while paused) then an in-place `Y.mergeUpdates` coalesce of every multi-entry buffer.
3. Only if that leaves it over budget does it **release** the oldest notes' payloads down to a 24 MB low-water mark. A release is not a drop: the note ids go to the durable pending-note store via the existing `persistUnflushed` hook **before** the buffers are deleted, and `drainPendingCrdtNotes` re-pushes each note's full doc state — which strictly supersedes the buffered incremental updates — on the next reconnect (`runtime.ts` `onNetworkStatusChanged`) or app start.
4. If there is **no** `persistUnflushed` configured, or the durable write throws, nothing is released — the queue keeps the memory and backs off `BUDGET_RECHECK_STEP_BYTES` (4 MB) before sweeping again, so an unreleasable backlog cannot turn into a per-enqueue CPU sweep either.

Deliberately **not** done:

- **No weakening of #1258 or #1118.** `MAX_MERGED_UPDATE_BYTES`, `MAX_FLUSH_PAYLOAD_BYTES`, the lossless in-place coalesce, and the `stop()` shutdown-persistence path are all untouched; the new sweep reuses `coalesce` rather than replacing it.
- **No lossy cap.** The issue floated "drop the oldest note's buffered payloads". Dropping is only safe here *because* of the durable-record escape hatch, so the release is gated on that hatch actually being wired up and actually succeeding. Without it the queue prefers the memory over the data.
- **Nothing outside `crdt-queue.ts`.** No change to `crdt-provider.ts` (owned by #1318) or `runtime.ts`.
- The one pre-existing eslint warning in this file (`no-unnecessary-type-assertion` at line 238, from #1258) is left alone — untouched code.

Known latency, not loss: `replayPendingCrdtNotes()` is only called from app start and the network `status-changed` handler. A note released during a 401 or quota pause that later resolves *without* a network transition waits for the next start to replay. Its state is durably recorded the whole time, so nothing is lost — worth a follow-up, out of scope here.

## How it was proven

`apps/desktop/src/main/sync/crdt-queue.test.ts`, four new cases.

- **Before** (`git checkout origin/main -- crdt-queue.ts`, new tests kept): `Tests  4 failed | 8 passed (12)`. The headline case fails at `expect(persisted.length).toBeGreaterThan(0)` → `expected 0 to be greater than 0` — 40 MB across 20 notes is buffered while paused and the queue never bounds itself.
- **After**: `Tests  12 passed (12)`.

The main case, `bounds the total buffer across notes while paused without losing an update`, uses 20 real `Y.Doc`s with ~2 MB of real edits each and proves the no-loss invariant end to end: after resume it reconstructs every note's text from `(pushed updates) ∪ (full state replayed for each released note id)` and asserts it equals the source doc for all 20. The union of pushed and persisted note ids is asserted to be exactly the full set — no note falls in neither bucket. The other three cover: flush-before-release while running, keep-everything when no durable store is configured, and keep-everything when the durable write throws.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  crdt-queue.test.ts crdt-pending-notes.test.ts runtime.test.ts crdt-provider.test.ts
  → Test Files  4 passed (4)   Tests  86 passed (86)

pnpm --filter @memry/desktop typecheck:node   → clean
pnpm exec eslint apps/desktop/src/main/sync/crdt-queue.ts
  → 0 errors, 1 warning (pre-existing, line 238, untouched code)
git diff --check                              → clean
pnpm docs:impact --base origin/main --strict  → docs impact: covered
pnpm docs:build                               → build complete in 17.91s
```

## Backward compatibility

Main-process memory management only — no schema, contract, sync-protocol, vault-format or settings change, and the wire payloads and the on-disk `crdt-pending-notes.json` shape are both unchanged; the new code only writes ids into the store that `stop()` already writes into.
