### PR TITLE
fix(notes): surface and page past the sidebar note-tree 10k ceiling

### DIFF
--- a/apps/desktop/src/renderer/src/components/note-tree-states.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note-tree-states.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { NotesTreeTruncationNotice } from './note-tree-states'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string, values?: Record<string, unknown>) =>
+      values?.count === undefined ? key : `${key}:${values.count}`
+  })
+}))
+
+describe('NotesTreeTruncationNotice', () => {
+  it('states how many notes the tree is not showing and offers to load them', () => {
+    const onLoadMore = vi.fn()
+    render(
+      <NotesTreeTruncationNotice hiddenCount={2431} isLoadingMore={false} onLoadMore={onLoadMore} />
+    )
+
+    expect(screen.getByText('tree.truncated.hidden:2431')).toBeInTheDocument()
+
+    const button = screen.getByRole('button', { name: 'tree.truncated.loadMore' })
+    expect(button).not.toBeDisabled()
+    fireEvent.click(button)
+    expect(onLoadMore).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the button while the next page is in flight', () => {
+    const onLoadMore = vi.fn()
+    render(<NotesTreeTruncationNotice hiddenCount={500} isLoadingMore onLoadMore={onLoadMore} />)
+
+    const button = screen.getByRole('button', { name: 'tree.truncated.loadMore' })
+    expect(button).toBeDisabled()
+    fireEvent.click(button)
+    expect(onLoadMore).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note-tree-states.tsx
+++ b/apps/desktop/src/renderer/src/components/note-tree-states.tsx
@@ -7,10 +7,10 @@ export function NotesTreeSkeleton() {
   return (
     <div className="space-y-2 p-2">
       <Skeleton className="h-6 w-full" />
-      <Skeleton className="h-6 w-3/4 ml-4" />
-      <Skeleton className="h-6 w-3/4 ml-4" />
+      <Skeleton className="h-6 w-3/4 ms-4" />
+      <Skeleton className="h-6 w-3/4 ms-4" />
       <Skeleton className="h-6 w-full" />
-      <Skeleton className="h-6 w-2/3 ml-4" />
+      <Skeleton className="h-6 w-2/3 ms-4" />
     </div>
   )
 }
@@ -42,6 +42,41 @@ export function NotesTreeEmpty({
           <Plus className="h-3.5 w-3.5" />
         )}
         {t('tree.empty.newNote')}
+      </Button>
+    </div>
+  )
+}
+
+/**
+ * Footer for a truncated tree.
+ *
+ * The sidebar fetches notes a page at a time, newest-modified first. Without
+ * this row the notes past the ceiling are simply absent — and since the tree is
+ * the primary navigation surface, absent reads as deleted.
+ */
+export function NotesTreeTruncationNotice({
+  hiddenCount,
+  isLoadingMore,
+  onLoadMore
+}: {
+  hiddenCount: number
+  isLoadingMore: boolean
+  onLoadMore: () => void
+}) {
+  const { t } = useT('notes')
+
+  return (
+    <div className="flex items-center justify-between gap-2 px-2 py-1.5 text-xs text-muted-foreground">
+      <span>{t('tree.truncated.hidden', { count: hiddenCount })}</span>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onLoadMore}
+        disabled={isLoadingMore}
+        className="h-6 gap-1 px-2 text-xs"
+      >
+        {isLoadingMore && <Loader2 className="h-3 w-3 animate-spin" />}
+        {t('tree.truncated.loadMore')}
       </Button>
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/notes-tree-isolated.test.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree-isolated.test.tsx
@@ -160,7 +160,17 @@ vi.mock('@/components/note-tree-states', () => ({
       empty create
     </button>
   ),
-  NotesTreeError: ({ error }: { error: string }) => <div>{error}</div>
+  NotesTreeError: ({ error }: { error: string }) => <div>{error}</div>,
+  NotesTreeTruncationNotice: ({ hiddenCount, isLoadingMore, onLoadMore }: any) => (
+    <button
+      type="button"
+      data-testid="truncation-notice"
+      disabled={isLoadingMore}
+      onClick={onLoadMore}
+    >
+      hidden:{hiddenCount}
+    </button>
+  )
 }))
 
 vi.mock('@/components/virtualized-notes-tree', () => ({
@@ -268,7 +278,10 @@ const createData = () => ({
   refreshFolders: vi.fn(),
   setFolderIcon: vi.fn(),
   mutations: {},
-  computeTargetFolder: vi.fn((ids: string[]) => `target:${ids.join(',')}`)
+  computeTargetFolder: vi.fn((ids: string[]) => `target:${ids.join(',')}`),
+  hiddenNoteCount: 0,
+  isLoadingMore: false,
+  loadMore: vi.fn()
 })
 
 const createActions = (overrides: Record<string, unknown> = {}) => ({
@@ -510,5 +523,19 @@ describe('NotesTree isolated coverage', () => {
     expect(mocks.virtualActions.collapseAll).toHaveBeenCalled()
     expect(mocks.virtualActions.expandAll).toHaveBeenCalled()
     expect(mocks.virtualActions.expandNode).toHaveBeenCalledWith('folder-Work/Nested')
+  })
+
+  it('surfaces the truncation footer only when notes are missing from the page', () => {
+    const { unmount } = render(<NotesTree />)
+    expect(screen.queryByTestId('truncation-notice')).toBeNull()
+    unmount()
+
+    mocks.data = { ...createData(), hiddenNoteCount: 500 }
+    render(<NotesTree />)
+
+    const notice = screen.getByTestId('truncation-notice')
+    expect(notice).toHaveTextContent('hidden:500')
+    fireEvent.click(notice)
+    expect(mocks.data.loadMore).toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/src/components/notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree.tsx
@@ -23,7 +23,12 @@ import { useNoteTreeData } from '@/hooks/use-note-tree-data'
 import { useNoteTreeActions } from '@/hooks/use-note-tree-actions'
 import { NoteTreeDeleteDialog, NoteTreeTemplateSelector } from '@/components/note-tree-dialogs'
 import { ApplyTemplateToNoteDialog } from '@/components/note/apply-template-to-note-dialog'
-import { NotesTreeSkeleton, NotesTreeEmpty, NotesTreeError } from '@/components/note-tree-states'
+import {
+  NotesTreeSkeleton,
+  NotesTreeEmpty,
+  NotesTreeError,
+  NotesTreeTruncationNotice
+} from '@/components/note-tree-states'
 import {
   TreeFolderIcon,
   RevealHandler,
@@ -606,6 +611,14 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
             )}
           </TreeView>
         </TreeProvider>
+      )}
+
+      {data.hiddenNoteCount > 0 && (
+        <NotesTreeTruncationNotice
+          hiddenCount={data.hiddenNoteCount}
+          isLoadingMore={data.isLoadingMore}
+          onLoadMore={data.loadMore}
+        />
       )}
 
       <NoteTreeDeleteDialog

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-data.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-data.test.tsx
@@ -1,0 +1,167 @@
+import type { ReactNode } from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { NOTE_TREE_PAGE_SIZE, useNoteTreeData } from './use-note-tree-data'
+import type { NoteListItem } from '@memry/rpc/notes'
+
+type ListOptions = { limit?: number; offset?: number }
+
+const mocks = vi.hoisted(() => ({
+  notesService: {
+    list: vi.fn(),
+    getFolders: vi.fn(),
+    getAllPositions: vi.fn(),
+    getFolderConfig: vi.fn(),
+    setFolderConfig: vi.fn(),
+    createFolder: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    rename: vi.fn(),
+    move: vi.fn()
+  }
+}))
+
+vi.mock('@/services/notes-service', () => {
+  const unsubscribe = () => vi.fn()
+  return {
+    notesService: mocks.notesService,
+    onNoteCreated: unsubscribe,
+    onNoteUpdated: unsubscribe,
+    onNoteDeleted: unsubscribe,
+    onNoteRenamed: unsubscribe,
+    onNoteMoved: unsubscribe,
+    onNoteExternalChange: unsubscribe,
+    onTagsChanged: unsubscribe,
+    onFolderConfigUpdated: unsubscribe
+  }
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+  })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+/**
+ * A vault big enough to overflow one page. The rows are flat (no folder
+ * segments) so `buildTreeFromNotes` puts every one of them in `rootNotes`.
+ */
+function makeVault(size: number): NoteListItem[] {
+  return Array.from(
+    { length: size },
+    (_, index) =>
+      ({
+        id: `note-${index}`,
+        path: `Note ${index}.md`,
+        title: `Note ${index}`,
+        created: new Date(0),
+        modified: new Date(0),
+        tags: [],
+        wordCount: 0,
+        emoji: null,
+        localOnly: false,
+        fileType: 'markdown'
+      }) as unknown as NoteListItem
+  )
+}
+
+/** Serves `vault` the way `listNotes` does: one `limit`-sized page plus the real total. */
+function serve(vault: NoteListItem[], onCall?: (options: ListOptions) => void) {
+  mocks.notesService.list.mockImplementation(async (options: ListOptions = {}) => {
+    onCall?.(options)
+    const limit = options.limit ?? 100
+    const offset = options.offset ?? 0
+    const page = vault.slice(offset, offset + limit)
+    return { notes: page, total: vault.length, hasMore: offset + page.length < vault.length }
+  })
+}
+
+describe('useNoteTreeData truncation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.notesService.getFolders.mockResolvedValue([])
+    mocks.notesService.getAllPositions.mockResolvedValue({ success: true, positions: {} })
+  })
+
+  it('reports the notes the first page could not cover', async () => {
+    const vault = makeVault(NOTE_TREE_PAGE_SIZE + 500)
+    serve(vault)
+
+    const { result } = renderHook(() => useNoteTreeData(), { wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // The page itself is unchanged — still bounded at the ceiling.
+    expect(result.current.notes).toHaveLength(NOTE_TREE_PAGE_SIZE)
+    expect(result.current.tree.rootNotes).toHaveLength(NOTE_TREE_PAGE_SIZE)
+    // ...but the overflow is now reported instead of vanishing.
+    expect(result.current.hiddenNoteCount).toBe(500)
+  })
+
+  it('reports nothing hidden when the vault fits in one page', async () => {
+    serve(makeVault(42))
+
+    const { result } = renderHook(() => useNoteTreeData(), { wrapper })
+
+    await waitFor(() => expect(result.current.notes).toHaveLength(42))
+    expect(result.current.hiddenNoteCount).toBe(0)
+  })
+
+  it('loadMore pulls the rest of the vault into the tree', async () => {
+    const vault = makeVault(NOTE_TREE_PAGE_SIZE + 500)
+    const limits: number[] = []
+    serve(vault, (options) => limits.push(options.limit ?? 0))
+
+    const { result } = renderHook(() => useNoteTreeData(), { wrapper })
+
+    await waitFor(() => expect(result.current.hiddenNoteCount).toBe(500))
+
+    act(() => result.current.loadMore())
+
+    await waitFor(() => expect(result.current.notes).toHaveLength(vault.length))
+    expect(result.current.hiddenNoteCount).toBe(0)
+    expect(result.current.tree.rootNotes).toHaveLength(vault.length)
+    // The last note in the vault — the one the first page dropped — is reachable.
+    expect(result.current.noteMap.has(`note-${vault.length - 1}`)).toBe(true)
+    expect(limits).toEqual([NOTE_TREE_PAGE_SIZE, NOTE_TREE_PAGE_SIZE * 2])
+  })
+
+  it('keeps the loaded tree on screen while the next page is in flight', async () => {
+    const vault = makeVault(NOTE_TREE_PAGE_SIZE + 500)
+    let release: (() => void) | null = null
+    mocks.notesService.list.mockImplementation(async (options: ListOptions = {}) => {
+      const limit = options.limit ?? 100
+      if (limit > NOTE_TREE_PAGE_SIZE) {
+        await new Promise<void>((resolve) => {
+          release = resolve
+        })
+      }
+      const page = vault.slice(0, limit)
+      return { notes: page, total: vault.length, hasMore: page.length < vault.length }
+    })
+
+    const { result } = renderHook(() => useNoteTreeData(), { wrapper })
+
+    await waitFor(() => expect(result.current.hiddenNoteCount).toBe(500))
+
+    act(() => result.current.loadMore())
+
+    await waitFor(() => expect(result.current.isLoadingMore).toBe(true))
+    // The sidebar must not fall back to a skeleton mid-page: the tree it already
+    // has stays mounted, and the footer carries the pending state.
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.notes).toHaveLength(NOTE_TREE_PAGE_SIZE)
+    expect(result.current.hiddenNoteCount).toBe(500)
+
+    await act(async () => {
+      release?.()
+    })
+
+    await waitFor(() => expect(result.current.notes).toHaveLength(vault.length))
+    expect(result.current.isLoadingMore).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from 'react'
+import { useMemo, useState, useEffect, useCallback, useRef } from 'react'
 import {
   useNotesList,
   useNoteFoldersQuery,
@@ -10,6 +10,26 @@ import { buildTreeFromNotes, type TreeStructure } from '@/components/notes-tree-
 import { createLogger } from '@/lib/logger'
 
 const log = createLogger('Hook:NoteTreeData')
+
+/**
+ * How many notes one sidebar page pulls.
+ *
+ * The ceiling stays deliberately bounded: the tree needs the whole array in the
+ * renderer to build folder structure, and this list is invalidated and refetched
+ * on every note create/update/rename/move, so an unbounded fetch would make a
+ * huge vault pay for the entire note set on every keystroke-driven write. What
+ * changes here is that the overflow is now reported and reachable on demand
+ * instead of being dropped without a trace.
+ */
+export const NOTE_TREE_PAGE_SIZE = 10000
+
+interface LoadedPage {
+  notes: NoteListItem[]
+  total: number
+  hasMore: boolean
+}
+
+const EMPTY_PAGE: LoadedPage = { notes: [], total: 0, hasMore: false }
 
 export interface NoteTreeData {
   notes: NoteListItem[]
@@ -27,14 +47,43 @@ export interface NoteTreeData {
   folderTemplateNames: Map<string, string>
   setFolderTemplateNames: React.Dispatch<React.SetStateAction<Map<string, string>>>
   computeTargetFolder: (selectedIds: string[]) => string
+  /** Notes in the vault that the pages fetched so far do not cover. */
+  hiddenNoteCount: number
+  /** True while a `loadMore()` page is in flight and the current tree is still shown. */
+  isLoadingMore: boolean
+  /** Pull one more page into the tree. No-op once nothing is hidden. */
+  loadMore: () => void
 }
 
 export function useNoteTreeData(): NoteTreeData {
+  const [limit, setLimit] = useState(NOTE_TREE_PAGE_SIZE)
+
   // `fields: 'tree'` — the sidebar renders path/title/modified/tags/emoji/
   // localOnly/fileType and nothing else, so main skips the snippet and the
   // mime/size pair. At a 10k-note ceiling those are the bulk of the payload,
   // and this list is refetched on every note create/update/rename/move.
-  const { notes, isLoading, error } = useNotesList({ limit: 10000, fields: 'tree' })
+  const {
+    notes: fetchedNotes,
+    total,
+    hasMore,
+    isLoading: isPageLoading,
+    error
+  } = useNotesList({ limit, fields: 'tree' })
+
+  // Raising the ceiling changes the query key, so TanStack starts a fresh entry
+  // with no data and `isLoading` flips back to true. Hold the page already on
+  // screen so "load more" grows the tree instead of collapsing it to a skeleton.
+  const loadedPageRef = useRef<LoadedPage>(EMPTY_PAGE)
+  if (!isPageLoading && loadedPageRef.current.notes !== fetchedNotes) {
+    loadedPageRef.current = { notes: fetchedNotes, total, hasMore }
+  }
+  const page = loadedPageRef.current
+  const notes = page.notes
+
+  const loadMore = useCallback(() => {
+    setLimit((current) => current + NOTE_TREE_PAGE_SIZE)
+  }, [])
+
   const mutations = useNoteMutations()
   const { folders, createFolder, setFolderIcon, refetch: refreshFolders } = useNoteFoldersQuery()
 
@@ -122,7 +171,7 @@ export function useNoteTreeData(): NoteTreeData {
 
   return {
     notes,
-    isLoading,
+    isLoading: isPageLoading && notes.length === 0,
     error,
     folders,
     createFolder,
@@ -135,6 +184,9 @@ export function useNoteTreeData(): NoteTreeData {
     setNotePositions,
     folderTemplateNames,
     setFolderTemplateNames,
-    computeTargetFolder
+    computeTargetFolder,
+    hiddenNoteCount: page.hasMore ? Math.max(page.total - notes.length, 0) : 0,
+    isLoadingMore: isPageLoading && notes.length > 0,
+    loadMore
   }
 }

--- a/apps/docs/src/guide/tour.md
+++ b/apps/docs/src/guide/tour.md
@@ -24,6 +24,8 @@ Sections from top to bottom:
 
 Drag any section item to reorder, or right-click for a context menu.
 
+The **Notes** tree loads 10,000 notes at a time, most recently modified first. If your vault holds more than that, a footer row under the tree says how many older notes it is not showing and offers **Load more** to pull in the next batch. Notes past the ceiling are never hidden silently — and they stay reachable through search either way.
+
 At the bottom of the sidebar, a footer row holds three controls, left to right:
 
 - **Sync status** — shows whether sync is connected; click it to open account settings (or to sign in when you're signed out).

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -49,6 +49,10 @@
       "newNote": "New Note"
     },
     "loadingError": "Failed to load notes",
+    "truncated": {
+      "hidden": "{count, plural, one {# older note not shown} other {# older notes not shown}}",
+      "loadMore": "Load more"
+    },
     "actions": {
       "newNote": "New Note",
       "newFolder": "New Folder",


### PR DESCRIPTION
Closes #1324. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts:37` fetched the whole vault with a hard-coded ceiling and destructured away the paging signal that came back with it:

```ts
const { notes, isLoading, error } = useNotesList({ limit: 10000, fields: 'tree' })
```

`listNotes` (`apps/desktop/src/main/vault/notes-queries.ts:52`) does the work to report truncation — it over-fetches by one (`limit + 1`) to compute `hasMore`, and runs a real `countNotes` for `total`. `useNotesList` surfaces both (`use-notes-query.ts:265-266`). The tree read neither, so a `hasMore: true` was discarded on the floor.

Because `listNotesFromCache` orders by `modifiedAt desc` by default and applies the limit as a plain SQL `.limit()`, the rows that fell off the end were the *least recently modified* notes. Past 10,000 notes the sidebar silently stopped showing them: no banner, no count, no error. The tree is the primary navigation surface, so a note missing from it reads as a deleted note.

## What changed

Kept the bounded page. Made the overflow visible and reachable.

- `use-note-tree-data.ts` — the ceiling becomes a page size (`NOTE_TREE_PAGE_SIZE = 10000`) held in state, and the hook now reads `hasMore`/`total`. It returns three new fields: `hiddenNoteCount`, `isLoadingMore`, and `loadMore()`.
- `note-tree-states.tsx` — new `NotesTreeTruncationNotice` footer: "*N* older notes not shown" plus a **Load more** button.
- `notes-tree.tsx` — renders that footer when `hiddenNoteCount > 0`.
- `packages/i18n/src/locales/en/notes.json` — `tree.truncated.hidden` (ICU plural) and `tree.truncated.loadMore`.

**Why not just raise or remove the cap.** The tree needs the entire array in the renderer to build folder structure, and this list is invalidated and refetched on *every* note create/update/rename/move. An unbounded fetch would make a huge vault re-materialise its whole note set on every keystroke-driven write — exactly the class of cost this epic exists to remove. Auto-paginating until `hasMore` is false has the same problem plus N round-trips per invalidation. So the default stays bounded and the extra pages are opt-in: the user pays for them only when they ask.

**Deliberately not done:** no change to `listNotesFromCache`, `listNotes`, or any IPC contract — main already reported everything the renderer needed. No offset-cursor accumulation either; `loadMore()` just raises the ceiling and refetches, which keeps one cache entry and one array instead of stitching pages together.

One thing had to change that isn't strictly the fix: `check-staged-renderer-guards.mjs` scans the whole staged file, so three pre-existing `ml-4` in `NotesTreeSkeleton` blocked the commit. Swapped them to the logical `ms-4` (RTL-correct, no visual change in LTR).

## How it was proven

New `use-note-tree-data.test.tsx` drives the real hook against a mocked `notesService` that serves a **10,500-note** vault the way `listNotes` does (one `limit`-sized page + true `total` + real `hasMore`). Plus footer-component and tree-branch tests.

```
# with the fix reverted (git checkout origin/main -- <3 source files>, tests kept)
Test Files  3 failed (3)
      Tests  7 failed | 4 passed (11)
   → hiddenNoteCount: expected 500, received undefined

# with the fix
Test Files  3 passed (3)
      Tests  11 passed (11)
```

The 4 that pass either way are the pre-existing `notes-tree-isolated` cases.

Coverage: `hiddenNoteCount`, `isLoadingMore`, `loadMore`, the sticky-page branch, the footer component (both enabled and in-flight states), and the `notes-tree.tsx` render branch (shown and not-shown) all have assertions.

## Verification

| command | result |
| --- | --- |
| `vitest --project renderer` on the 3 touched test files | **11 passed / 3 files** |
| `pnpm --filter @memry/desktop typecheck:web` | exit 0, no output |
| `pnpm exec eslint` on the 6 changed files | 0 errors (3 "file ignored" warnings — test files, pre-existing config) |
| `pnpm --filter @memry/desktop i18n:check` | `ok: i18n check passed` |
| `vitest` on `icu-brace-style` + `placeholder-parity` | 6 passed (guards the new ICU plural string) |
| `git diff --check` | clean |
| `pnpm docs:impact --base origin/main --strict` | `covered` |
| `pnpm docs:build` | `build complete in 9.60s` |

## Backward compatibility

Renderer-only. No schema, IPC contract, sync payload, or settings shape touched — the page size lives in component state and resets to 10,000 on every mount, so an older or newer build reads exactly the same data off the same unchanged `notes:list` call.
