### PR TITLE
perf(tasks): drop sync bookkeeping from the app-root tasks:list payload

### DIFF
--- a/apps/desktop/src/main/tasks/task-list-payload.test.ts
+++ b/apps/desktop/src/main/tasks/task-list-payload.test.ts
@@ -1,0 +1,195 @@
+/**
+ * #1326 — the app-root task fetch (`use-task-queries.ts`) pulls the whole
+ * workspace and re-runs on every task mutation and every incoming task sync
+ * event. Every row it returned used to carry the sync bookkeeping columns
+ * (`clock`, `fieldClocks`, `syncedAt`), which are not part of the declared
+ * `Task` shape and which no `tasks:list` consumer reads.
+ *
+ * Real data DB + the real production wiring from `domain.ts` (real
+ * `taskQueries`, real `createTasksRepository`, real `createTasksQueries`), so
+ * this measures the actual `tasks:list` response rather than a mocked one.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createTasksQueries } from '@memry/domain-tasks'
+import { createTasksRepository } from '@memry/storage-data'
+import type { VectorClock, FieldClocks } from '@memry/contracts/sync-api'
+import { asClientDb, createTestDataDb, sql } from '@tests/utils/test-db'
+import type { TestDatabaseResult, TestDb } from '@tests/utils/test-db'
+import * as taskQueries from '@main/database/queries/tasks'
+import * as projectQueries from '@main/database/queries/projects'
+import type { DataDb } from '../database'
+
+// Two real-shaped device ids, as a vault synced across a desktop and a laptop.
+const DEVICE_A = '7f3c1e8a-4d21-4b6f-9c05-2ea18d7b4f60'
+const DEVICE_B = 'b91d40c7-6a58-4e33-8f12-5c7d9ab30e41'
+
+// The exact list `initAllFieldClocks(clock, TASK_SYNCABLE_FIELDS)` seeds on a
+// task the moment it first syncs (apps/desktop/src/main/sync/field-merge.ts).
+const TASK_SYNCABLE_FIELDS = [
+  'title',
+  'description',
+  'projectId',
+  'statusId',
+  'parentId',
+  'priority',
+  'position',
+  'dueDate',
+  'dueTime',
+  'startDate',
+  'repeatConfig',
+  'repeatFrom',
+  'sourceNoteId',
+  'completedAt',
+  'archivedAt'
+]
+
+// Every field the renderer's `dbTaskToUiTask` reads off a `tasks:list` row
+// (apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts). If the
+// strip ever takes one of these, the task UI loses data.
+const RENDERER_READ_FIELDS = [
+  'id',
+  'title',
+  'description',
+  'projectId',
+  'statusId',
+  'priority',
+  'dueDate',
+  'dueTime',
+  'repeatConfig',
+  'linkedNoteIds',
+  'sourceNoteId',
+  'tags',
+  'parentId',
+  'createdAt',
+  'completedAt',
+  'archivedAt'
+] as const
+
+const SYNC_BOOKKEEPING_FIELDS = ['clock', 'fieldClocks', 'syncedAt'] as const
+
+function syncedClock(): VectorClock {
+  return { [DEVICE_A]: 12, [DEVICE_B]: 5 }
+}
+
+function syncedFieldClocks(): FieldClocks {
+  const clock = syncedClock()
+  return Object.fromEntries(TASK_SYNCABLE_FIELDS.map((field) => [field, { ...clock }]))
+}
+
+describe('#1326 tasks:list row shape', () => {
+  let dbResult: TestDatabaseResult
+  let db: TestDb
+  let clientDb: DataDb
+  let repo: ReturnType<typeof createTasksRepository<DataDb>>
+  let queries: ReturnType<typeof createTasksQueries>
+
+  const seedTask = (id: string, index: number) =>
+    taskQueries.insertTask(clientDb, {
+      id,
+      projectId: 'project-1',
+      statusId: 'status-todo',
+      title: `Ship the ${id} milestone`,
+      description: index % 3 === 0 ? `Follow up with the team about ${id}.` : null,
+      priority: index % 5,
+      position: index,
+      dueDate: '2026-09-01',
+      createdAt: '2026-08-01T09:00:00.000Z',
+      modifiedAt: '2026-08-11T09:00:00.000Z',
+      clock: syncedClock(),
+      fieldClocks: syncedFieldClocks(),
+      syncedAt: '2026-08-11T09:00:05.000Z'
+    })
+
+  beforeEach(() => {
+    dbResult = createTestDataDb()
+    db = dbResult.db
+    clientDb = asClientDb(db)
+
+    db.run(sql`
+      INSERT INTO projects (id, name, color, position, is_inbox)
+      VALUES ('project-1', 'Project 1', '#6366f1', 0, 0)
+    `)
+    db.run(sql`
+      INSERT INTO statuses (id, project_id, name, color, position, is_default, is_done)
+      VALUES ('status-todo', 'project-1', 'To Do', '#6b7280', 0, 1, 0)
+    `)
+
+    repo = createTasksRepository({ db: clientDb, taskQueries, projectQueries })
+    queries = createTasksQueries(repo)
+  })
+
+  afterEach(() => {
+    dbResult.close()
+  })
+
+  it('drops sync bookkeeping the renderer never reads', () => {
+    seedTask('task-1', 0)
+
+    const [row] = queries.listTasks({ includeCompleted: true, includeArchived: true }).tasks
+
+    for (const field of SYNC_BOOKKEEPING_FIELDS) {
+      expect(Object.hasOwn(row, field)).toBe(false)
+    }
+  })
+
+  it('keeps every field the task UI renders', () => {
+    seedTask('task-1', 0)
+    taskQueries.setTaskTags(clientDb, 'task-1', ['urgent', 'q3'])
+    taskQueries.setTaskNotes(clientDb, 'task-1', [])
+
+    const [row] = queries.listTasks({ includeCompleted: true, includeArchived: true }).tasks
+    const raw = taskQueries.getTaskById(clientDb, 'task-1')
+
+    for (const field of RENDERER_READ_FIELDS) {
+      expect(Object.hasOwn(row, field)).toBe(true)
+    }
+
+    // Same values, not just same keys — the strip must not perturb anything.
+    expect(row.id).toBe(raw?.id)
+    expect(row.title).toBe(raw?.title)
+    expect(row.description).toBe(raw?.description)
+    expect(row.projectId).toBe(raw?.projectId)
+    expect(row.statusId).toBe(raw?.statusId)
+    expect(row.priority).toBe(raw?.priority)
+    expect(row.dueDate).toBe(raw?.dueDate)
+    expect(row.parentId).toBe(raw?.parentId)
+    expect(row.createdAt).toBe(raw?.createdAt)
+    expect(row.completedAt).toBe(raw?.completedAt)
+    expect(row.archivedAt).toBe(raw?.archivedAt)
+    expect(row.tags).toEqual(['q3', 'urgent'])
+    expect(row.linkedNoteIds).toEqual([])
+  })
+
+  it('still carries the clock on getTask, which feeds the delete tombstone', () => {
+    // task-sync.ts `buildDeletePayload` runs `withIncrementedClock` over the
+    // JSON of this snapshot and reads `clock` back off it. Stripping the list
+    // rows must not reach this path or every task tombstone would push a fresh
+    // clock and lose ordering against a concurrent remote update.
+    seedTask('task-1', 0)
+
+    const snapshot = repo.getTask('task-1') as Record<string, unknown> | undefined
+
+    expect(snapshot?.clock).toEqual(syncedClock())
+  })
+
+  it('cuts the app-root workspace payload for a large task list', () => {
+    for (let index = 0; index < 500; index += 1) {
+      seedTask(`task-${index}`, index)
+    }
+
+    // Exactly the app-root fetch from use-task-queries.ts.
+    const response = queries.listTasks({
+      includeCompleted: true,
+      includeArchived: true,
+      limit: 1000
+    })
+
+    expect(response.tasks).toHaveLength(500)
+
+    const bytes = JSON.stringify(response).length
+    // Before the strip this response measured 620,032 bytes for these 500 rows.
+    // eslint-disable-next-line no-console
+    console.log(`#1326 tasks:list payload for ${response.tasks.length} rows: ${bytes} bytes`)
+    expect(bytes).toBeLessThan(310_016)
+  })
+})

--- a/apps/desktop/src/main/tasks/task-list-payload.test.ts
+++ b/apps/desktop/src/main/tasks/task-list-payload.test.ts
@@ -187,9 +187,12 @@ describe('#1326 tasks:list row shape', () => {
     expect(response.tasks).toHaveLength(500)
 
     const bytes = JSON.stringify(response).length
-    // Before the strip this response measured 620,032 bytes for these 500 rows.
+    // Before the strip this same response measured 1,061,350 bytes for these
+    // 500 rows; after it is 260,350. The threshold is deliberately loose enough
+    // to survive an added task field and tight enough that re-leaking the
+    // bookkeeping fails it.
     // eslint-disable-next-line no-console
     console.log(`#1326 tasks:list payload for ${response.tasks.length} rows: ${bytes} bytes`)
-    expect(bytes).toBeLessThan(310_016)
+    expect(bytes).toBeLessThan(400_000)
   })
 })

--- a/packages/storage-data/src/tasks-repository.ts
+++ b/packages/storage-data/src/tasks-repository.ts
@@ -152,6 +152,33 @@ function enrichTask<TDb>(db: TDb, taskQueries: TaskQueryModule<TDb>, task: TaskR
   }
 }
 
+/**
+ * Drop the sync bookkeeping columns from a listed row (#1326).
+ *
+ * `clock`, `fieldClocks` and `syncedAt` are not part of the declared `Task`
+ * shape — they only reach callers because `enrichTask` spreads the raw database
+ * row — and nothing that consumes `tasks:list` reads them. `fieldClocks` alone
+ * is a device-id-keyed vector clock per syncable field, which on a synced vault
+ * is the single largest part of a task row. The app-root workspace fetch pulls
+ * up to 1000 rows and re-runs on every task create / update / delete / complete
+ * and every incoming task sync event, so this is the payload worth cutting.
+ *
+ * Deliberately NOT done inside `enrichTask`: `getTask` feeds the delete
+ * snapshot that `task-sync.ts`'s `buildDeletePayload` hands to
+ * `withIncrementedClock`, which reads `clock` back off it. Stripping there
+ * would reset every task tombstone's vector clock to a fresh one.
+ */
+function stripSyncBookkeeping(task: Task): TaskListItem {
+  const {
+    clock: _clock,
+    fieldClocks: _fieldClocks,
+    syncedAt: _syncedAt,
+    ...rest
+  } = task as Task & { clock?: unknown; fieldClocks?: unknown; syncedAt?: unknown }
+
+  return rest as TaskListItem
+}
+
 export function createTasksRepository<TDb>({
   db,
   taskQueries,
@@ -190,7 +217,7 @@ export function createTasksRepository<TDb>({
     listTasks(options: TaskListOptions = {}): TaskListItem[] {
       return taskQueries
         .listTasks(db, options)
-        .map((task) => enrichTask(db, taskQueries, task) as TaskListItem)
+        .map((task) => stripSyncBookkeeping(enrichTask(db, taskQueries, task)))
     },
 
     countTasks(


### PR DESCRIPTION
Part of #1326 — **does not close it**. Part of epic #987 (memory/CPU audit 2026-08).

#1326 asks for the root task fetch's row *set* to shrink; this PR shrinks its row *shape* instead, for the reasons below. #1326 has been rewritten to carry only the remaining row-set work.

## What was wrong

The issue asks for the row **set** of the app-root task fetch to shrink. Measuring the fetch first showed the much larger, and provably invisible, problem is the row **shape**: **75% of that response is sync bookkeeping that no consumer reads.**

`listTasks` selects every column (`apps/desktop/src/main/database/queries/tasks.ts:184`):

```ts
let query = db.select().from(tasks)
```

so each row carries `clock`, `fieldClocks` and `syncedAt`. `enrichTask` then spreads the raw row (`packages/storage-data/src/tasks-repository.ts:141-152`):

```ts
return {
  ...task,
  priority: task.priority as Task['priority'],
  ...
}
```

Those three columns are **not declared on the domain `Task` / `TaskListItem` type at all** — they reach the renderer only because of that spread, which is why nothing has ever flagged them. `fieldClocks` is a device-id-keyed `VectorClock` per syncable field, and `initAllFieldClocks(clock, TASK_SYNCABLE_FIELDS)` seeds all **15** of them the moment a task first syncs (`apps/desktop/src/main/sync/field-merge.ts:11-27`). On a vault synced across two devices that is ~1.6 KB of UUID-keyed JSON per task.

The app-root fetch pulls up to 1000 such rows (`apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts:220-224`) and `useTaskWorkspaceData` invalidates `taskKeys.tasks()` on **every** task create / update / delete / complete **and** every incoming `onItemSynced` task event (`:230-274`), so the whole thing is re-serialised across IPC and re-materialised in the renderer each time.

Verified by reading every consumer: the queryFn's only use of the response is `tasksResponse.tasks.map(dbTaskToUiTask)`, and `dbTaskToUiTask` (`:99-120`) reads exactly 16 fields — none of them `clock`, `fieldClocks` or `syncedAt`. Nothing in `apps/desktop/src/renderer/**` reads those off a task.

## What changed

One function and one call site in `packages/storage-data/src/tasks-repository.ts`: `listTasks` now maps each enriched row through a new `stripSyncBookkeeping` that drops `clock`, `fieldClocks` and `syncedAt`.

Because those fields are absent from the declared `Task`/`TaskListItem` type, a stripped row is still a fully valid `TaskListItem`. **No contract, IPC, preload, renderer or type change anywhere** — `pnpm ipc:check` and `pnpm check:contracts` are untouched no-ops.

### Deliberately NOT done, and why

**1. The strip is on `listTasks` only — not in `enrichTask`.** Putting it in `enrichTask` would be a one-line change covering every task read, and it would be a **sync-correctness regression**. `repository.getTask(id)` is the delete snapshot (`packages/domain-tasks/src/commands.ts:396`), which is `JSON.stringify`'d into the sync queue (`apps/desktop/src/main/tasks/runtime-effects.ts:32-34`) and handed to:

```ts
buildDeletePayload: ({ extra, deviceId }) => withIncrementedClock(extra[0], deviceId)
```
`apps/desktop/src/main/sync/task-sync.ts:113`

`withIncrementedClock` reads `.clock` straight back off that JSON (`packages/sync-core/src/record-sync.ts:198`). Strip it there and every task tombstone pushes a fresh `{deviceId: 1}` clock instead of the incremented existing one, and can lose ordering against a concurrent remote update. There is a regression test pinning this.

**2. The row set still includes completed and archived tasks.** This is the part of #1326 I could not land safely, and I am saying so plainly rather than half-migrating a production task UI. The root array is the value of `TasksProvider` (`App.tsx:489`) and `DragProvider` (`:592`). I re-derived the consumer list on current `main` and it still holds:

- subtask progress reads `completedAt !== null` off rows from that same array — `kanban-card.tsx`, `task-detail-drawer.tsx`, `lib/subtask-utils.ts`, `lib/subtask-bulk-utils.ts`
- the Completed view is fed from it via `getCompletedTasks` / `getCompletedTodayTasks` (`pages/tasks.tsx`)
- archived rows currently count toward project sidebar badges in `getTaskWorkspaceCounts` (that increment-order bug is #1323, fixed by the open PR #1344 — I stayed entirely out of `task-view-helpers.ts` and its tests)

Each of those needs its own scoped fetch before the root array can narrow, and each changes numbers the user already sees. That is a multi-file task-UI refactor with real regression surface and it deserves its own PR with its own acceptance runs. **What this PR banks instead is bigger than dropping those rows would have been**: it takes ~75% off every row, completed and archived rows included, and changes zero displayed values.

Worth noting for whoever picks up the remainder: `enrichTask` runs `countSubtasks` + `getTaskTags` + `getTaskNoteIds` per row, so the same fetch is also ~3000 SQL round-trips at the 1000-row ceiling. Skipping the unused subtask counts needs a response-shape option (they are non-optional on `TaskListItem`), so it is not free the way this strip was.

## How it was proven

Real data DB (`createTestDataDb`) driving the **actual production wiring** from `apps/desktop/src/main/tasks/domain.ts` — real `taskQueries`, real `createTasksRepository`, real `createTasksQueries` — not a mocked IPC round-trip. 500 tasks seeded with the same `clock` / `fieldClocks` / `syncedAt` a two-device synced vault writes, then the exact app-root call is measured.

| app-root workspace fetch, 500 rows | payload |
| --- | --- |
| `listTasks({ includeCompleted: true, includeArchived: true, limit: 1000 })` before | **1,061,350 bytes** |
| same call, after | **260,350 bytes** |
| | **−75.5%**, identical 500 rows |

At the hook's real 1000-row ceiling that is ~2.1 MB → ~0.5 MB per fetch, and this list re-fetches on every task mutation and every incoming task sync event.

Before/after by reverting only the source file (test kept in place, no `git stash`):

```
BEFORE  git checkout origin/main -- packages/storage-data/src/tasks-repository.ts
        Tests  2 failed | 2 passed
          × drops sync bookkeeping the renderer never reads     → expected true to be false
          × cuts the app-root workspace payload for a large ...  → expected 1061350 to be less than 400000

AFTER   git checkout HEAD -- packages/storage-data/src/tasks-repository.ts
        Tests  4 passed
```

New test file `apps/desktop/src/main/tasks/task-list-payload.test.ts`:
- `drops sync bookkeeping the renderer never reads`
- `keeps every field the task UI renders` — asserts all 16 fields `dbTaskToUiTask` reads are present **with unchanged values** against the raw row
- `still carries the clock on getTask, which feeds the delete tombstone` — the guard for the regression described above
- `cuts the app-root workspace payload for a large task list`

## Verification

```
pnpm --filter @memry/desktop typecheck:node   → clean
pnpm --filter @memry/desktop typecheck:web    → clean (exit 0)
pnpm check:architecture                       → architecture boundary check passed
pnpm check:contracts                          → contracts boundary check passed
pnpm ipc:check                                → Generated RPC bindings are up to date / IPC invoke map is up to date

vitest --project main  src/main/tasks/ ipc/tasks-handlers.test.ts database/queries/tasks.test.ts
                                              → Test Files 10 passed, Tests 127 passed
vitest --project main  agent/mcp/tools/handles-adapter.test.ts sync/task-sync.test.ts
                       sync/item-handlers/task-handler.test.ts
                                              → Test Files 3 passed, Tests 36 passed
vitest --project shared packages/storage-data/src/tasks-repository.test.ts packages/domain-tasks/src
                                              → Test Files 7 passed, Tests 118 passed

pnpm exec eslint packages/storage-data/src/tasks-repository.ts → 0 errors
git diff --check                              → clean
pnpm docs:impact --base origin/main --strict  → no desktop/sync-server docs-relevant changes detected
```

## Backward compatibility

No DB, migration, sync-protocol, IPC-contract, vault-format or settings change. The only difference on the wire is the absence of three fields that were never part of the declared `TaskListItem` shape and that no consumer reads; a stripped row remains a valid `TaskListItem`, so nothing needs a guard or a second interface. Sync ordering is unaffected — the delete-tombstone clock path deliberately keeps its `clock` and has a test pinning it.
