### PR TITLE
perf(undo): wake on the exact entry expiry instead of a 1 Hz sweep

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-undo.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-undo.test.ts
@@ -591,7 +591,6 @@ describe('useUndoTracker subscription', () => {
 
   it('drops the entry on the expiry sweep and re-renders subscribers', () => {
     vi.useFakeTimers()
-    const start = Date.now()
 
     const { result } = renderHook(() => useUndoTracker())
     act(() => {
@@ -599,13 +598,55 @@ describe('useUndoTracker subscription', () => {
     })
     expect(result.current.canUndo).toBe(true)
 
-    vi.setSystemTime(start + UNDO_EXPIRY_MS + 1)
     act(() => {
-      vi.advanceTimersByTime(1000)
+      vi.advanceTimersByTime(UNDO_EXPIRY_MS)
     })
 
     expect(result.current.canUndo).toBe(false)
     expect(result.current.lastActionDescription).toBeNull()
+  })
+
+  it('clears the snapshot at the entry expiry instant, not on a later sweep tick', () => {
+    vi.useFakeTimers()
+
+    const { result } = renderHook(() => useUndoTracker())
+    act(() => {
+      result.current.registerUndo('First action', vi.fn())
+    })
+
+    // Second entry lands 300 ms in, so its expiry falls *between* the ticks a
+    // 1 Hz sweep (aligned to the first registration) would have produced.
+    act(() => {
+      vi.advanceTimersByTime(300)
+      result.current.registerUndo('Second action', vi.fn())
+    })
+    expect(result.current.lastActionDescription).toBe('Second action')
+
+    // Advance to exactly the instant the second entry dies. A 1 Hz sweep would
+    // not notice until 700 ms later, and would still advertise it here.
+    act(() => {
+      vi.advanceTimersByTime(UNDO_EXPIRY_MS)
+    })
+
+    expect(result.current.canUndo).toBe(false)
+    expect(result.current.lastActionDescription).toBeNull()
+  })
+
+  it('arms a single expiry timer instead of a 1 Hz poll', () => {
+    vi.useFakeTimers()
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+
+    const { result } = renderHook(() => useUndoTracker())
+    act(() => {
+      result.current.registerUndo('Delete task', vi.fn())
+    })
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), UNDO_EXPIRY_MS)
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+
+    setTimeoutSpy.mockRestore()
+    setIntervalSpy.mockRestore()
   })
 
   it('undo() refuses an entry that expired since the last sweep', () => {
@@ -676,11 +717,14 @@ describe('useUndoTracker subscription', () => {
     vi.setSystemTime(start + UNDO_EXPIRY_MS + 1)
 
     const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
     rerender()
 
     // Before the fix, render called getLastUndoEntry(), which filtered the
-    // module-level stack and stopped the cleanup interval mid-render.
+    // module-level stack and tore down the expiry timer mid-render.
     expect(clearIntervalSpy).not.toHaveBeenCalled()
+    expect(clearTimeoutSpy).not.toHaveBeenCalled()
     clearIntervalSpy.mockRestore()
+    clearTimeoutSpy.mockRestore()
   })
 })

--- a/apps/desktop/src/renderer/src/hooks/use-undo.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-undo.ts
@@ -41,28 +41,40 @@ interface UndoEntry {
 let globalUndoStack: UndoEntry[] = []
 const globalUndoListeners: Set<() => void> = new Set()
 
-// Clean up expired entries periodically
-let cleanupInterval: ReturnType<typeof setInterval> | null = null
+/**
+ * One-shot timer armed for the exact instant the oldest live entry expires.
+ * A 1 Hz poll left the snapshot advertising a dead entry for up to a second
+ * after it expired; this fires on the boundary instead, and wakes once per
+ * entry rather than ten times over its lifetime.
+ */
+let expiryTimer: ReturnType<typeof setTimeout> | null = null
 
-function startCleanupInterval() {
-  if (cleanupInterval) return
-  cleanupInterval = setInterval(() => {
+function cancelExpirySweep() {
+  if (expiryTimer) {
+    clearTimeout(expiryTimer)
+    expiryTimer = null
+  }
+}
+
+/**
+ * (Re)arm the expiry timer for the oldest entry — entries are pushed in
+ * timestamp order, so index 0 always dies first. Leaves the timer cancelled
+ * when the stack is empty. Mutates module state, so never call during render.
+ */
+function scheduleExpirySweep() {
+  cancelExpirySweep()
+  const oldest = globalUndoStack[0]
+  if (!oldest) return
+  const delay = Math.max(0, oldest.timestamp + UNDO_EXPIRY_MS - Date.now())
+  expiryTimer = setTimeout(() => {
+    expiryTimer = null
     const pruned = pruneExpiredEntries()
-    if (globalUndoStack.length === 0) {
-      stopCleanupInterval()
-    }
+    scheduleExpirySweep()
     if (pruned) {
       notifyListeners()
     }
-  }, 1000)
-  cleanupInterval.unref?.()
-}
-
-function stopCleanupInterval() {
-  if (cleanupInterval) {
-    clearInterval(cleanupInterval)
-    cleanupInterval = null
-  }
+  }, delay)
+  expiryTimer.unref?.()
 }
 
 /**
@@ -101,7 +113,7 @@ function subscribeToUndoStack(listener: () => void): () => void {
     globalUndoListeners.delete(listener)
     if (globalUndoListeners.size === 0) {
       globalUndoStack = []
-      stopCleanupInterval()
+      cancelExpirySweep()
       refreshSnapshot()
     }
   }
@@ -114,17 +126,14 @@ function notifyListeners() {
 
 /**
  * Drop entries older than `UNDO_EXPIRY_MS`. Returns whether anything was removed.
- * Callers are responsible for notifying listeners — never call this during render.
+ * Callers are responsible for rescheduling the sweep and notifying listeners —
+ * never call this during render.
  */
 function pruneExpiredEntries(): boolean {
   const now = Date.now()
   const before = globalUndoStack.length
   globalUndoStack = globalUndoStack.filter((entry) => now - entry.timestamp < UNDO_EXPIRY_MS)
-  if (globalUndoStack.length === before) return false
-  if (globalUndoStack.length === 0) {
-    stopCleanupInterval()
-  }
-  return true
+  return globalUndoStack.length !== before
 }
 
 function pushUndoEntry(entry: Omit<UndoEntry, 'id' | 'timestamp'>) {
@@ -140,7 +149,7 @@ function pushUndoEntry(entry: Omit<UndoEntry, 'id' | 'timestamp'>) {
     globalUndoStack.shift()
   }
 
-  startCleanupInterval()
+  scheduleExpirySweep()
   notifyListeners()
 
   return newEntry.id
@@ -148,14 +157,12 @@ function pushUndoEntry(entry: Omit<UndoEntry, 'id' | 'timestamp'>) {
 
 /**
  * Take the newest live entry off the stack. Prunes first so an expired entry can
- * never be handed back between 1 s sweeps, whichever accessor the caller used.
+ * never be handed back, whichever accessor the caller used.
  */
 function popUndoEntry(): UndoEntry | undefined {
   pruneExpiredEntries()
   const entry = globalUndoStack.pop()
-  if (globalUndoStack.length === 0) {
-    stopCleanupInterval()
-  }
+  scheduleExpirySweep()
   notifyListeners()
   return entry
 }
@@ -165,9 +172,7 @@ function removeUndoEntryById(id: string): boolean {
   if (idx === -1) return false
 
   globalUndoStack.splice(idx, 1)
-  if (globalUndoStack.length === 0) {
-    stopCleanupInterval()
-  }
+  scheduleExpirySweep()
   notifyListeners()
   return true
 }
@@ -175,6 +180,7 @@ function removeUndoEntryById(id: string): boolean {
 /** Read the newest live entry. Mutates the stack, so event handlers only. */
 function getLastUndoEntry(): UndoEntry | undefined {
   if (pruneExpiredEntries()) {
+    scheduleExpirySweep()
     notifyListeners()
   }
   return globalUndoStack[globalUndoStack.length - 1]

--- a/apps/docs/src/user-guide/tasks/bulk-actions.md
+++ b/apps/docs/src/user-guide/tasks/bulk-actions.md
@@ -46,6 +46,8 @@ If multiple tasks are selected, dragging any of them moves the **whole selection
 
 After 10 seconds the action is committed and undo no longer reaches it. (You can still manually reverse, of course.) The cutoff is enforced at the moment you trigger undo, so an action that has just aged out is never replayed — whichever way you reach undo, it either runs a change that is still inside the window or does nothing.
 
+The window closes on the 10-second mark itself, not on a rounded-off tick shortly after, so anything the app shows about the pending undo disappears at the same instant undo stops accepting it.
+
 The undo window is app-wide, not per view. The most recent undoable action is shared across Tasks, Projects, and Calendar, so <kbd>⌘</kbd>+<kbd>Z</kbd> reverses whichever action happened last no matter where you switched to, and it expires on the same 10-second timer everywhere.
 
 ## Multi-Select Across Filters


### PR DESCRIPTION
Closes #1336. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/hooks/use-undo.ts` expired undo entries with a 1 Hz poll, while the `useSyncExternalStore` snapshot was only recomputed on mutation:

```ts
cleanupInterval = setInterval(() => {
  const pruned = pruneExpiredEntries()
  if (globalUndoStack.length === 0) stopCleanupInterval()
  if (pruned) notifyListeners()
}, 1000)
```

The interval starts on the *first* push, so its ticks are aligned to that entry, not to later ones. An entry registered 300 ms after the first one expires at +10 300 ms but is not swept until +11 000 ms. For those 700 ms `canUndo` stays `true` and `lastActionDescription` still names the dead action.

`getUndoSnapshot()` cannot filter on read — PR #1274 made the snapshot a module-level cached object precisely because a fresh object per read makes `useSyncExternalStore` loop forever, and it removed the render-time mutation that used to hide this. So the only correct place to fix it is the sweep itself.

## What changed

Replaced the 1 Hz interval with a self-rescheduling one-shot timer armed for the exact instant the oldest entry expires. Entries are pushed in timestamp order, so index 0 always dies first; when the timer fires it prunes, re-arms for the new oldest, and notifies.

```ts
function scheduleExpirySweep() {
  cancelExpirySweep()
  const oldest = globalUndoStack[0]
  if (!oldest) return
  const delay = Math.max(0, oldest.timestamp + UNDO_EXPIRY_MS - Date.now())
  expiryTimer = setTimeout(() => { ... }, delay)
  expiryTimer.unref?.()
}
```

Every mutating path (`pushUndoEntry`, `popUndoEntry`, `removeUndoEntryById`, `getLastUndoEntry`) re-arms; the `subscribeToUndoStack` teardown cancels when the last tracker unmounts, exactly where `stopCleanupInterval()` used to be called. `pruneExpiredEntries` no longer touches the timer — it is now purely a stack filter, and its callers own the rescheduling.

This is also strictly *less* timer work than before: one wakeup per entry lifetime instead of ten, which is why the alternative "tighten the sweep interval" was rejected — it would have bought freshness with 10× the wakeups on a CPU-audit epic.

Deliberately **not** done:

- No change to `getUndoSnapshot()` / `refreshSnapshot()`. The getter stays render-pure and referentially stable; the render-loop and render-mutation properties from PR #1274 are untouched (there is a regression test for both).
- No extra timer layered on top of the interval. Replacing it is simpler and cheaper than running two.
- Did not close the issue as "not worth a mechanism". That was a live option given no consumer renders these fields today, but the fix is ~20 lines, removes a poll rather than adding one, and leaves the hook correct for the first consumer instead of shipping a known-stale affordance.

## How it was proven

`apps/desktop/src/renderer/src/hooks/use-undo.test.ts`:

- **new** `clears the snapshot at the entry expiry instant, not on a later sweep tick` — registers one entry, registers a second 300 ms later, advances to the second entry's exact expiry, asserts `canUndo === false`. This is the 700 ms gap above.
- **new** `arms a single expiry timer instead of a 1 Hz poll` — asserts `setTimeout` is armed for the full `UNDO_EXPIRY_MS` and `setInterval` is never called.
- **updated** `drops the entry on the expiry sweep and re-renders subscribers` — advanced fake timers by `UNDO_EXPIRY_MS` instead of `setSystemTime` + a 1 s tick, since that shape only worked against a poll. Passes both before and after.
- **updated** `does not mutate module state during render` — also spies `clearTimeout` now, so the PR #1274 render-purity guarantee is still enforced against the new timer.

Before/after, same test file:

```
pre-fix  (git checkout origin/main -- use-undo.ts):  2 failed | 29 passed (31)
post-fix (git checkout HEAD -- use-undo.ts):         31 passed (31)
```

The two failures are exactly the two new tests.

## Verification

```
pnpm exec vitest run --project renderer apps/desktop/src/renderer/src/hooks/use-undo.test.ts
  → Test Files 1 passed (1) · Tests 31 passed (31)

pnpm --filter @memry/desktop typecheck:web
  → clean (no output)

pnpm exec eslint apps/desktop/src/renderer/src/hooks/use-undo.ts
  → 0 errors, 0 warnings

git diff --check
  → clean

pnpm docs:impact --base origin/main --strict
  → docs impact: covered against origin/main

pnpm docs:build
  → build complete in 7.06s
```

## Backward compatibility

Renderer-only, in-memory module state. No schema, IPC contract, settings, sync or vault format touched; the public `useUndoTracker` surface is unchanged.
