### PR TITLE
fix(tabs): surface quit-time tab-state save failures instead of swallowing them

### DIFF
--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts
@@ -10,7 +10,12 @@ import { toast } from 'sonner'
 import { useTabs } from '@/contexts/tabs'
 import type { TabSystemState } from '@/contexts/tabs/types'
 import { extractErrorMessage } from '@/lib/ipc-error'
-import { getDefaultStorage, isQuotaExceededError, saveSync } from './storage'
+import {
+  consumeSyncSaveFailure,
+  getDefaultStorage,
+  isQuotaExceededError,
+  saveSync
+} from './storage'
 import { serializeTabState, deserializeTabState, extractPinnedTabs } from './serialization'
 import type { TabStorage } from './types'
 import { registerPendingSave, unregisterPendingSave } from '@/lib/save-registry'
@@ -20,6 +25,7 @@ import { useFeatureFlags } from '@/hooks/use-feature-flags'
 const log = createLogger('TabPersistence:Hooks')
 const FLUSH_REGISTRY_KEY = 'tab-state'
 const SAVE_FAILURE_TOAST_ID = 'tab-state-save-failed'
+const LAST_SESSION_TOAST_ID = 'tab-state-last-session-not-saved'
 
 // =============================================================================
 // AUTO-SAVE HOOK
@@ -56,7 +62,14 @@ export const useTabPersistence = (options: UseTabPersistenceOptions = {}): void 
 
     registerPendingSave(FLUSH_REGISTRY_KEY, () => {
       const serialized = serializeTabState(stateRef.current)
-      saveSync(serialized)
+      const result = saveSync(serialized)
+      if (!result.ok) {
+        // Claiming a flush that never happened is what made this invisible:
+        // whoever diagnoses "my tabs came back wrong after quitting" needs the
+        // log to say the write was refused, and why.
+        log.error('failed to flush tab state via registry', { reason: result.reason })
+        return
+      }
       log.info('flushed tab state via registry')
     })
 
@@ -136,7 +149,10 @@ export const useTabPersistence = (options: UseTabPersistenceOptions = {}): void 
 
     const handleBeforeUnload = (): void => {
       const serialized = serializeTabState(stateRef.current)
-      saveSync(serialized)
+      const result = saveSync(serialized)
+      if (!result.ok) {
+        log.error('failed to save tab state on unload', { reason: result.reason })
+      }
     }
 
     window.addEventListener('beforeunload', handleBeforeUnload)
@@ -219,6 +235,23 @@ export const useSessionRestore = (
         }
       } else {
         log.info('no persisted tab state found')
+      }
+
+      // The quit-time write is the one save the user can never be told about
+      // while it fails — the window is already closing. If it left a marker,
+      // this launch is the first moment the explanation is worth anything:
+      // whatever just got restored is older than what they closed the app with.
+      const saveFailure = consumeSyncSaveFailure()
+      if (saveFailure) {
+        log.warn('previous session was not saved on exit', { reason: saveFailure.reason })
+        const t = getI18n().getFixedT(null, 'common')
+        toast.warning(t('tabs.persistence.lastSessionNotSaved'), {
+          id: LAST_SESSION_TOAST_ID,
+          description:
+            saveFailure.reason === 'quota'
+              ? t('tabs.persistence.lastSessionNotSavedQuota')
+              : t('tabs.persistence.lastSessionNotSavedGeneric')
+        })
       }
 
       hasRestoredRef.current = true

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/index.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/index.ts
@@ -11,6 +11,7 @@ export { serializeTabState, deserializeTabState, extractPinnedTabs } from './ser
 
 // Storage adapters
 export { localStorageAdapter, getDefaultStorage, saveSync } from './storage'
+export type { SyncSaveFailure, SyncSaveResult } from './storage'
 
 // Migrations
 export { migratePersistedState, needsMigration, getMigrationDescription } from './migrations'

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
@@ -3,7 +3,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useManualPersistence, useSessionRestore, useTabPersistence } from './hooks'
-import { isQuotaExceededError, localStorageAdapter, saveSync } from './storage'
+import {
+  consumeSyncSaveFailure,
+  isQuotaExceededError,
+  localStorageAdapter,
+  saveSync
+} from './storage'
 import { deserializeTabState, extractPinnedTabs, serializeTabState } from './serialization'
 import { STORAGE_KEY, type PersistedTabState, type TabStorage } from './types'
 import type { Tab, TabSystemState } from '@/contexts/tabs/types'
@@ -17,11 +22,13 @@ const mocks = vi.hoisted(() => ({
     mocks.pendingSave = callback
   }),
   unregisterPendingSave: vi.fn(),
-  toastError: vi.fn()
+  toastError: vi.fn(),
+  toastWarning: vi.fn(),
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
 }))
 
 vi.mock('sonner', () => ({
-  toast: { error: mocks.toastError }
+  toast: { error: mocks.toastError, warning: mocks.toastWarning }
 }))
 
 // Counts full tab-tree serializations so the auto-save tests can assert how many
@@ -50,8 +57,26 @@ vi.mock('@/lib/save-registry', () => ({
 }))
 
 vi.mock('@/lib/logger', () => ({
-  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+  createLogger: () => mocks.logger
 }))
+
+/**
+ * Refuse writes to one key, the way a full origin refuses the tab payload while
+ * still having room for a handful of bytes.
+ */
+function refuseWritesTo(key: string, error: unknown) {
+  const original = Storage.prototype.setItem
+  return vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+    this: Storage,
+    name: string,
+    value: string
+  ) {
+    if (name === key) throw error
+    original.call(this, name, value)
+  })
+}
+
+const quotaError = (): DOMException => new DOMException('over quota', 'QuotaExceededError')
 
 const tab = (overrides: Partial<Tab> = {}): Tab =>
   ({
@@ -316,11 +341,44 @@ describe('tab persistence serialization and storage', () => {
     await localStorageAdapter.clear()
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
 
+    // Every write refused, including the failure marker: the quit path still
+    // must not throw, and it must still tell its caller the write was lost.
     const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw new Error('quota')
     })
-    expect(() => saveSync(persisted())).not.toThrow()
+    expect(saveSync(persisted())).toMatchObject({ ok: false, reason: 'error' })
     setItem.mockRestore()
+    expect(consumeSyncSaveFailure()).toBeNull()
+  })
+
+  it('reports a refused synchronous save and leaves a marker for the next launch', () => {
+    const setItem = refuseWritesTo(STORAGE_KEY, quotaError())
+
+    expect(saveSync(persisted())).toEqual({ ok: false, reason: 'quota', at: expect.any(Number) })
+    setItem.mockRestore()
+
+    // The marker is what the next launch reads; consuming it is one-shot, so a
+    // single failed quit cannot nag on every later launch.
+    expect(consumeSyncSaveFailure()).toMatchObject({ reason: 'quota', at: expect.any(Number) })
+    expect(consumeSyncSaveFailure()).toBeNull()
+  })
+
+  it('clears the failure marker once a synchronous save succeeds', () => {
+    const setItem = refuseWritesTo(STORAGE_KEY, quotaError())
+    saveSync(persisted())
+    setItem.mockRestore()
+
+    expect(saveSync(persisted())).toEqual({ ok: true })
+    expect(localStorage.getItem(STORAGE_KEY)).toContain('pin-1')
+    expect(consumeSyncSaveFailure()).toBeNull()
+  })
+
+  it('ignores a corrupt or foreign failure marker', () => {
+    localStorage.setItem('memry_tab_state_save_failed', '{')
+    expect(consumeSyncSaveFailure()).toBeNull()
+
+    localStorage.setItem('memry_tab_state_save_failed', JSON.stringify({ reason: 'whatever' }))
+    expect(consumeSyncSaveFailure()).toBeNull()
   })
 
   it('recognises quota failures and only quota failures', () => {
@@ -542,6 +600,100 @@ describe('tab persistence hooks', () => {
     expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null')).toEqual(
       expectedPersisted(CLOCK_START)
     )
+  })
+
+  it('flushes a normal quit and logs the flush that really happened', () => {
+    const storage: TabStorage = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn(),
+      clear: vi.fn()
+    }
+
+    render(<TabPersistenceProbe storage={storage} debounceMs={25} />)
+
+    act(() => mocks.pendingSave?.())
+
+    expect(localStorage.getItem(STORAGE_KEY)).toContain('pin-1')
+    expect(mocks.logger.info).toHaveBeenCalledWith('flushed tab state via registry')
+    expect(mocks.logger.error).not.toHaveBeenCalled()
+    expect(consumeSyncSaveFailure()).toBeNull()
+  })
+
+  it('does not claim a flush when the quit-time write is refused', () => {
+    const storage: TabStorage = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn(),
+      clear: vi.fn()
+    }
+
+    // What the user would get restored if the last write never lands.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted({ savedAt: 1 })))
+    const stale = localStorage.getItem(STORAGE_KEY)
+
+    render(<TabPersistenceProbe storage={storage} debounceMs={25} />)
+    const setItem = refuseWritesTo(STORAGE_KEY, quotaError())
+
+    // Neither quit path may throw — an exception here would stop the app closing.
+    expect(() => act(() => mocks.pendingSave?.())).not.toThrow()
+    expect(() => act(() => window.dispatchEvent(new Event('beforeunload')))).not.toThrow()
+
+    setItem.mockRestore()
+
+    expect(mocks.logger.info).not.toHaveBeenCalledWith('flushed tab state via registry')
+    expect(mocks.logger.error).toHaveBeenCalledWith('failed to flush tab state via registry', {
+      reason: 'quota'
+    })
+    expect(mocks.logger.error).toHaveBeenCalledWith('failed to save tab state on unload', {
+      reason: 'quota'
+    })
+    // The stale payload is still what would be restored, and the failure is now
+    // recorded so the next launch can say so.
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(stale)
+    expect(consumeSyncSaveFailure()).toMatchObject({ reason: 'quota' })
+  })
+
+  it('tells the user at the next launch that the last session was never saved', async () => {
+    const setItem = refuseWritesTo(STORAGE_KEY, quotaError())
+    saveSync(serializeTabState(state()))
+    setItem.mockRestore()
+
+    const storage: TabStorage = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue(persisted()),
+      clear: vi.fn()
+    }
+
+    render(withQueryClient(<SessionRestoreProbe storage={storage} />))
+
+    await waitFor(() => expect(mocks.toastWarning).toHaveBeenCalledTimes(1))
+    expect(mocks.toastWarning.mock.calls[0][0]).toBe(
+      'Your last session was not saved when Memry closed'
+    )
+    expect(mocks.toastWarning.mock.calls[0][1]).toMatchObject({
+      description: expect.stringContaining('Storage was full')
+    })
+
+    // One failed quit, one warning: the marker is consumed by the launch that
+    // reported it, so the launch after that is quiet.
+    mocks.dispatch.mockClear()
+    render(withQueryClient(<SessionRestoreProbe storage={storage} />))
+    await waitFor(() =>
+      expect(mocks.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'RESTORE_SESSION' })
+      )
+    )
+    expect(mocks.toastWarning).toHaveBeenCalledTimes(1)
+
+    // A refusal that is not about space explains itself differently.
+    const failAgain = refuseWritesTo(STORAGE_KEY, new Error('storage backend offline'))
+    saveSync(serializeTabState(state()))
+    failAgain.mockRestore()
+
+    render(withQueryClient(<SessionRestoreProbe storage={storage} />))
+    await waitFor(() => expect(mocks.toastWarning).toHaveBeenCalledTimes(2))
+    expect(mocks.toastWarning.mock.calls[1][1]).toMatchObject({
+      description: expect.stringContaining('could not store your tabs on exit')
+    })
   })
 
   it('restores full sessions, pinned-only sessions, errors, and manual operations', async () => {

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/storage.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/storage.ts
@@ -72,16 +72,89 @@ export const localStorageAdapter: TabStorage = {
 // SYNCHRONOUS STORAGE (for beforeunload)
 // =============================================================================
 
+/** Marker recording that the last quit-time write never reached storage. */
+const SAVE_FAILURE_KEY = 'memry_tab_state_save_failed'
+
+/** Why a synchronous save failed, as far as the storage layer can tell. */
+export interface SyncSaveFailure {
+  reason: 'quota' | 'error'
+  /** Epoch ms of the failed attempt. */
+  at: number
+}
+
+export type SyncSaveResult = { ok: true } | ({ ok: false } & SyncSaveFailure)
+
+/**
+ * Leave a breadcrumb the next launch can read.
+ *
+ * `saveSync` only ever runs while the window is going away, so there is no
+ * moment left to tell the user anything. Persisting the failure is what turns
+ * it from invisible into diagnosable: the restore path picks it up on the next
+ * launch and explains why the tabs that came back are older than the ones the
+ * user closed the app with.
+ */
+const recordSaveFailure = (failure: SyncSaveFailure): void => {
+  try {
+    localStorage.setItem(SAVE_FAILURE_KEY, JSON.stringify(failure))
+  } catch (error) {
+    // A few dozen bytes can still be refused on a full origin. Best effort only
+    // — the quit path must never throw.
+    log.warn('Failed to record tab state save failure:', error)
+  }
+}
+
+const clearSaveFailure = (): void => {
+  try {
+    localStorage.removeItem(SAVE_FAILURE_KEY)
+  } catch (error) {
+    log.warn('Failed to clear tab state save failure marker:', error)
+  }
+}
+
+/**
+ * Read and remove the marker left by a failed quit-time save.
+ * Returns null when the last quit wrote successfully.
+ */
+export const consumeSyncSaveFailure = (): SyncSaveFailure | null => {
+  try {
+    const raw = localStorage.getItem(SAVE_FAILURE_KEY)
+    if (!raw) return null
+    localStorage.removeItem(SAVE_FAILURE_KEY)
+
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const { reason, at } = parsed as { reason?: unknown; at?: unknown }
+    if (reason !== 'quota' && reason !== 'error') return null
+
+    return { reason, at: typeof at === 'number' ? at : 0 }
+  } catch (error) {
+    log.warn('Failed to read tab state save failure marker:', error)
+    return null
+  }
+}
+
 /**
  * Synchronously save to localStorage
  * Used for beforeunload event where async isn't reliable
+ *
+ * Never throws: both callers run on a quit path, where an exception would be a
+ * regression far worse than the failed write. The result is returned instead so
+ * they can log the truth rather than claim a flush that did not happen.
  */
-export const saveSync = (state: PersistedTabState): void => {
+export const saveSync = (state: PersistedTabState): SyncSaveResult => {
   try {
     const json = JSON.stringify(state)
     localStorage.setItem(STORAGE_KEY, json)
+    clearSaveFailure()
+    return { ok: true }
   } catch (error) {
     log.error('Failed to save tab state synchronously:', error)
+    const failure: SyncSaveFailure = {
+      reason: isQuotaExceededError(error) ? 'quota' : 'error',
+      at: Date.now()
+    }
+    recordSaveFailure(failure)
+    return { ok: false, ...failure }
   }
 }
 

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -137,6 +137,12 @@ memrynote now tells you when that happens: a toast reads **"Your open tabs are n
 
 Previously the failure was silent — the app kept running normally and you only found out at the next launch, when the restored layout turned out to be stale.
 
+### If the last save on quit fails
+
+The layout is written one last time while memrynote closes (⌘Q, or closing the window). If storage is full at that moment, that final write is refused too — the tabs you had when you quit are lost, and what comes back is whatever was stored before them.
+
+A toast is no use while the window is going away, so memrynote records the failure and reports it at the next launch instead: **"Your last session was not saved when Memry closed"**, along with the reason. It appears once, on the first launch after the failed quit, so you know the restored layout is older than the one you left.
+
 ## Modified Indicator
 
 A small dot appears on a tab title when there are unsaved changes (rare — memrynote auto-saves). On a compressed tab the dot takes the close button's place, so unsaved work stays visible. Closing a modified tab triggers a flush before close.

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -56,7 +56,10 @@
     "persistence": {
       "saveFailed": "Your open tabs are no longer being saved",
       "saveFailedQuota": "This session is too large to store. Close some tabs, or it may not be restored the next time you open Memry.",
-      "saveFailedGeneric": "Memry could not store this session, so it may not be restored the next time you open the app."
+      "saveFailedGeneric": "Memry could not store this session, so it may not be restored the next time you open the app.",
+      "lastSessionNotSaved": "Your last session was not saved when Memry closed",
+      "lastSessionNotSavedQuota": "Storage was full at the time, so these tabs are from an earlier save. Close some tabs to make room.",
+      "lastSessionNotSavedGeneric": "Memry could not store your tabs on exit, so these tabs are from an earlier save."
     },
     "contextMenu": {
       "close": "Close",


### PR DESCRIPTION
Closes #1328. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`saveSync` — the last-chance write on both quit paths — returned `void` and swallowed every failure, quota included (`apps/desktop/src/renderer/src/contexts/tabs/persistence/storage.ts:83` on `origin/main`):

```ts
export const saveSync = (state: PersistedTabState): void => {
  try {
    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
  } catch (error) {
    log.error('Failed to save tab state synchronously:', error)
  }
}
```

Its callers therefore could not tell a write from a no-op. The Cmd+Q flush-registry callback (`hooks.ts:59`) logged `flushed tab state via registry` unconditionally, and the `beforeunload` handler (`hooks.ts:124`) logged nothing at all. On a full origin the final write is refused, the stale payload already in `localStorage` is what gets restored next launch, and the only trace is a log line contradicted by the "flushed" line right after it.

PR #1297 fixed the async sibling (catch + toast + `lastSavedRef` kept on the last value that really landed). This is the synchronous half.

## What changed

- `saveSync` now returns `{ ok: true } | { ok: false; reason: 'quota' | 'error'; at: number }`, classifying via the `isQuotaExceededError` helper that already lived in the same file. It still never throws — both callers run while the window is closing, where an exception would be a far worse regression than the lost write.
- On failure it writes a tiny marker key (`memry_tab_state_save_failed`) and clears that marker on any successful sync save. The marker write is itself best-effort and wrapped, so a truly full origin degrades to a log line instead of an exception.
- Both quit callers now log the truth: `failed to flush tab state via registry` / `failed to save tab state on unload` with the reason, and the success line only when the write actually landed.
- `useSessionRestore` consumes the marker on the next launch and raises one toast — *"Your last session was not saved when Memry closed"* — with a quota-specific or generic description. Consuming is one-shot, so a single failed quit cannot nag on every later launch.
- Three English strings under `tabs.persistence.*`; docs section added to `apps/docs/src/user-guide/tabs-split-view.md` next to the one #1297 added.

Deliberately **not** done:

- **No toast at quit time.** The window is already going away; nobody would read it. The next launch is the first moment the message is worth anything, which is exactly when the user is looking at a layout that is older than the one they left.
- **No retry with a trimmed payload.** Dropping tabs to make the write fit is the same data loss with less evidence, and it would silently change what "restore session" means. And no `removeItem`-then-retry either: Chromium accounts for a replaced value when it checks quota, so freeing our own key first buys nothing.
- **No IPC to the main process.** A fire-and-forget `invoke` during `beforeunload` is not reliably delivered, and it would drag a contract change into a renderer-local problem.

## How it was proven

`persistence.test.tsx`, renderer project:

- **Before** (source reverted to `origin/main`, tests kept): **7 failed | 9 passed (16)** — `expected undefined to deeply equal { ok: false, reason: 'quota', … }`, `consumeSyncSaveFailure is not a function`, `expected "vi.fn()" to not be called with arguments: [ 'flushed tab state via registry' ]`, `expected "vi.fn()" to be called 1 times, but got 0 times`.
- **Before, caller-side only** (only `hooks.ts` reverted, so the new storage API is present): **2 failed | 14 passed (16)** — the pre-fix flush callback still claims `flushed tab state via registry` on a refused write, and the next launch never warns.
- **After**: **16 passed (16)**.

New coverage: refused sync save reports `{ ok: false, reason: 'quota' }` and leaves a marker; the marker is consumed once; a later successful save clears it; a corrupt/foreign marker is ignored; a **normal quit still writes the state and logs the flush** (`expect(mocks.logger.error).not.toHaveBeenCalled()`); neither quit path throws when the write is refused and the stale payload is left untouched; the next launch warns once, with the quota wording for a quota failure and the generic wording otherwise.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
  → Test Files 1 passed (1) | Tests 16 passed (16)

pnpm --filter @memry/desktop typecheck:web   → clean
pnpm --filter @memry/desktop i18n:check      → ok: i18n check passed
./node_modules/.bin/eslint apps/desktop/src/renderer/src/contexts/tabs/persistence/  → 0 problems
packages/i18n vitest run                     → 11 files, 56 tests passed
pnpm docs:impact --base origin/main --strict → docs changed on this branch
pnpm docs:build                              → build complete
git diff --check                             → clean
```

## Backward compatibility

Additive only: the tab-state payload, `STORAGE_KEY`, and the persisted schema are untouched, the new marker lives under its own key that older builds simply ignore, and an install upgrading with no marker present behaves exactly as before.
