### PR TITLE
perf(notes): narrow the note_cache SQL projection for the sidebar tree shape

### DIFF
--- a/apps/desktop/src/main/database/queries/notes/index.ts
+++ b/apps/desktop/src/main/database/queries/notes/index.ts
@@ -15,7 +15,8 @@ export {
   getAllCrdtNoteIds,
   getNotesModifiedAfter,
   type ListNotesOptions,
-  type NoteCacheFileRow
+  type NoteCacheFileRow,
+  type NoteTreeCacheRow
 } from './note-crud'
 
 export {

--- a/apps/desktop/src/main/database/queries/notes/note-crud.ts
+++ b/apps/desktop/src/main/database/queries/notes/note-crud.ts
@@ -82,6 +82,27 @@ export function getLocalOnlyCount(db: IndexDb): number {
 // Note Listing
 // ============================================================================
 
+/**
+ * The columns `listNotes`'s `fields: 'tree'` shape actually maps (PR #1316).
+ * Selecting only these keeps SQLite from reading the cached ~200-char `snippet`
+ * — plus `mimeType`/`fileSize` and the six columns no list caller ever reads —
+ * for every row of a whole-vault sidebar fetch that then throws them away.
+ */
+const NOTE_TREE_COLUMNS = {
+  id: noteCache.id,
+  path: noteCache.path,
+  title: noteCache.title,
+  fileType: noteCache.fileType,
+  emoji: noteCache.emoji,
+  localOnly: noteCache.localOnly,
+  wordCount: noteCache.wordCount,
+  createdAt: noteCache.createdAt,
+  modifiedAt: noteCache.modifiedAt
+} as const
+
+/** A `shape: 'tree'` row. Deliberately not a `NoteCache` — it has fewer columns. */
+export type NoteTreeCacheRow = Pick<NoteCache, keyof typeof NOTE_TREE_COLUMNS>
+
 export interface ListNotesOptions {
   folder?: string
   tags?: string[]
@@ -89,10 +110,34 @@ export interface ListNotesOptions {
   sortOrder?: 'asc' | 'desc'
   limit?: number
   offset?: number
+  /**
+   * `'tree'` narrows the SQL projection to {@link NOTE_TREE_COLUMNS}. Defaults
+   * to the full `note_cache` row so every existing caller is unaffected.
+   */
+  shape?: 'full' | 'tree'
 }
 
-export function listNotesFromCache(db: IndexDb, options: ListNotesOptions = {}): NoteCache[] {
-  const { folder, tags, sortBy = 'modified', sortOrder = 'desc', limit = 100, offset = 0 } = options
+export function listNotesFromCache(
+  db: IndexDb,
+  options?: ListNotesOptions & { shape?: 'full' }
+): NoteCache[]
+export function listNotesFromCache(
+  db: IndexDb,
+  options: ListNotesOptions & { shape: 'tree' }
+): NoteTreeCacheRow[]
+export function listNotesFromCache(
+  db: IndexDb,
+  options: ListNotesOptions = {}
+): NoteCache[] | NoteTreeCacheRow[] {
+  const {
+    folder,
+    tags,
+    sortBy = 'modified',
+    sortOrder = 'desc',
+    limit = 100,
+    offset = 0,
+    shape = 'full'
+  } = options
 
   const conditions: SQL<unknown>[] = []
 
@@ -133,13 +178,27 @@ export function listNotesFromCache(db: IndexDb, options: ListNotesOptions = {}):
 
   const orderFn = sortOrder === 'asc' ? asc : desc
 
-  let query = db.select().from(noteCache)
+  const where = conditions.length > 0 ? and(...conditions) : undefined
 
-  if (conditions.length > 0) {
-    query = query.where(and(...conditions)) as typeof query
+  if (shape === 'tree') {
+    return db
+      .select(NOTE_TREE_COLUMNS)
+      .from(noteCache)
+      .where(where)
+      .orderBy(orderFn(sortColumn))
+      .limit(limit)
+      .offset(offset)
+      .all()
   }
 
-  return query.orderBy(orderFn(sortColumn)).limit(limit).offset(offset).all()
+  return db
+    .select()
+    .from(noteCache)
+    .where(where)
+    .orderBy(orderFn(sortColumn))
+    .limit(limit)
+    .offset(offset)
+    .all()
 }
 
 export interface NoteCacheFileRow {

--- a/apps/desktop/src/main/database/queries/notes/notes.test.ts
+++ b/apps/desktop/src/main/database/queries/notes/notes.test.ts
@@ -130,6 +130,119 @@ describe('notes cache queries', () => {
     expect(sorted[0].id).toBe('note-4')
   })
 
+  // --------------------------------------------------------------------------
+  // #1329: push PR #1316's field choice down into the SQL projection
+  // --------------------------------------------------------------------------
+
+  const insertProjectionNote = (id: string, overrides: Partial<NewNoteCache> = {}) =>
+    insertNoteCache(db, {
+      id,
+      path: `notes/${id}.md`,
+      title: `Projection ${id}`,
+      fileType: 'markdown',
+      mimeType: 'text/markdown',
+      fileSize: 4096,
+      attachmentId: null,
+      emoji: '📝',
+      localOnly: false,
+      contentHash: `hash-${id}`,
+      wordCount: 320,
+      characterCount: 1800,
+      snippet: 'x'.repeat(200),
+      date: null,
+      clock: null,
+      syncedAt: null,
+      createdAt: '2026-01-10T00:00:00.000Z',
+      modifiedAt: '2026-01-12T00:00:00.000Z',
+      indexedAt: '2026-01-14T00:00:00.000Z',
+      ...overrides
+    })
+
+  it('#1329: the default shape still returns the whole note_cache row, byte for byte', () => {
+    insertProjectionNote('proj-1')
+
+    // Byte-level golden: the full-shape row must survive the projection change
+    // untouched, including column order, for every existing caller.
+    expect(JSON.stringify(listNotesFromCache(db))).toBe(
+      '[{"id":"proj-1","path":"notes/proj-1.md","title":"Projection proj-1","fileType":"markdown",' +
+        '"mimeType":"text/markdown","fileSize":4096,"attachmentId":null,"emoji":"📝","localOnly":false,' +
+        '"contentHash":"hash-proj-1","wordCount":320,"characterCount":1800,"snippet":"' +
+        'x'.repeat(200) +
+        '","date":null,"clock":null,"syncedAt":null,"createdAt":"2026-01-10T00:00:00.000Z",' +
+        '"modifiedAt":"2026-01-12T00:00:00.000Z","indexedAt":"2026-01-14T00:00:00.000Z"}]'
+    )
+  })
+
+  it("#1329: shape: 'tree' selects only the columns the sidebar shape maps", () => {
+    insertProjectionNote('proj-2')
+
+    const [row] = listNotesFromCache(db, { shape: 'tree' })
+
+    expect(Object.keys(row)).toEqual([
+      'id',
+      'path',
+      'title',
+      'fileType',
+      'emoji',
+      'localOnly',
+      'wordCount',
+      'createdAt',
+      'modifiedAt'
+    ])
+    expect('snippet' in row).toBe(false)
+    expect('mimeType' in row).toBe(false)
+    expect('fileSize' in row).toBe(false)
+  })
+
+  it("#1329: shape: 'tree' honours the same filters, sorting and paging", () => {
+    insertProjectionNote('tree-a', {
+      path: 'projects/tree-a.md',
+      modifiedAt: '2026-01-11T00:00:00.000Z'
+    })
+    insertProjectionNote('tree-b', {
+      path: 'projects/tree-b.md',
+      modifiedAt: '2026-01-12T00:00:00.000Z'
+    })
+    insertProjectionNote('tree-c', { path: 'archive/tree-c.md' })
+    insertProjectionNote('tree-d', { path: 'journal/2026-01-10.md', date: '2026-01-10' })
+    setNoteTags(db, 'tree-a', ['alpha', 'beta'])
+    setNoteTags(db, 'tree-b', ['alpha'])
+
+    const ids = (rows: { id: string }[]) => rows.map((r) => r.id)
+
+    expect(ids(listNotesFromCache(db, { shape: 'tree', folder: 'projects' })).sort()).toEqual(
+      ids(listNotesFromCache(db, { folder: 'projects' })).sort()
+    )
+    expect(ids(listNotesFromCache(db, { shape: 'tree', tags: ['alpha', 'beta'] }))).toEqual([
+      'tree-a'
+    ])
+    expect(
+      ids(listNotesFromCache(db, { shape: 'tree', sortBy: 'modified', sortOrder: 'desc' }))
+    ).toEqual(ids(listNotesFromCache(db, { sortBy: 'modified', sortOrder: 'desc' })))
+    expect(
+      ids(listNotesFromCache(db, { shape: 'tree', limit: 1, offset: 1, sortBy: 'title' }))
+    ).toEqual(ids(listNotesFromCache(db, { limit: 1, offset: 1, sortBy: 'title' })))
+  })
+
+  it('#1329: the tree projection cuts the row bytes SQLite marshals for a whole-vault fetch', () => {
+    for (let i = 0; i < 500; i++) {
+      insertProjectionNote(`bulk-${i}`)
+    }
+
+    const fullRows = listNotesFromCache(db, { limit: 10000 })
+    const treeRows = listNotesFromCache(db, { limit: 10000, shape: 'tree' })
+
+    // Same rows either way — this is a column cut, not a row cut.
+    expect(treeRows).toHaveLength(fullRows.length)
+    expect(treeRows).toHaveLength(500)
+
+    const fullBytes = JSON.stringify(fullRows).length
+    const treeBytes = JSON.stringify(treeRows).length
+
+    // Measured: 315,061 B → 111,171 B for these 500 rows (−64.7%).
+    expect(treeBytes).toBeLessThan(fullBytes * 0.55)
+  })
+
   it('counts notes with folder filters', () => {
     createNote('note-7', { path: 'projects/note-7.md' })
     createNote('note-8', { path: 'projects/note-8.md' })

--- a/apps/desktop/src/main/vault/notes-queries.ts
+++ b/apps/desktop/src/main/vault/notes-queries.ts
@@ -19,8 +19,10 @@ import {
   deleteTagDefinition,
   getPropertiesForNotes,
   getOutgoingLinks,
-  getIncomingReferences
+  getIncomingReferences,
+  type NoteTreeCacheRow
 } from '@main/database/queries/notes'
+import type { NoteCache } from '@memry/db-schema/schema/notes-cache'
 import { getAllTaskTags } from '@main/database/queries/tasks'
 import { getDatabase, getIndexDatabase } from '../database'
 import { toAbsolutePath } from './notes-io'
@@ -38,16 +40,31 @@ import type {
 // List
 // ============================================================================
 
+/**
+ * A row `listNotes` can build a `NoteListItem` from: the narrow tree projection
+ * plus the three columns only the full shape reads. A `NoteCache` satisfies it.
+ */
+type ListedNoteRow = NoteTreeCacheRow &
+  Partial<Pick<NoteCache, 'snippet' | 'mimeType' | 'fileSize'>>
+
 export function listNotes(options: NoteListOptions = {}): NoteListResponse {
   const db = getIndexDatabase()
   const limit = options.limit ?? 100
   const offset = options.offset ?? 0
 
-  const cached = listNotesFromCache(db, {
-    ...options,
-    limit: limit + 1,
-    offset
-  })
+  // The sidebar tree renders path/title/modified/tags/emoji/localOnly/fileType
+  // and nothing else, but a whole-vault fetch of the full shape still ships a
+  // ~200-char snippet plus the mime/size pair for every note in the vault —
+  // over IPC, and again on every list invalidation. 'tree' builds only what the
+  // sidebar reads; the fields it skips are all optional on NoteListItem, so a
+  // 'tree' row stays a valid NoteListItem for any other consumer. The same
+  // choice is pushed down into the SQL projection so SQLite never reads the
+  // dropped columns in the first place.
+  const treeShape = options.fields === 'tree'
+
+  const cached: ListedNoteRow[] = treeShape
+    ? listNotesFromCache(db, { ...options, limit: limit + 1, offset, shape: 'tree' })
+    : listNotesFromCache(db, { ...options, limit: limit + 1, offset })
 
   const hasMore = cached.length > limit
   const notes = cached.slice(0, limit)
@@ -58,14 +75,6 @@ export function listNotes(options: NoteListOptions = {}): NoteListResponse {
   const tagsMap = getTagsForNotes(db, noteIds)
 
   const propertiesMap = options.includeProperties ? getPropertiesForNotes(db, noteIds) : null
-
-  // The sidebar tree renders path/title/modified/tags/emoji/localOnly/fileType
-  // and nothing else, but a whole-vault fetch of the full shape still ships a
-  // ~200-char snippet plus the mime/size pair for every note in the vault —
-  // over IPC, and again on every list invalidation. 'tree' builds only what the
-  // sidebar reads; the fields it skips are all optional on NoteListItem, so a
-  // 'tree' row stays a valid NoteListItem for any other consumer.
-  const treeShape = options.fields === 'tree'
 
   const noteItems: NoteListItem[] = notes.map((c) => ({
     id: c.id,

--- a/apps/docs/src/architecture/ipc.md
+++ b/apps/docs/src/architecture/ipc.md
@@ -94,6 +94,8 @@ Two properties make this shape kind of narrowing safe to add to a shipped channe
 
 Put the flag in the query key on the renderer side (`notesKeys.list(options)` already includes the whole options object). The two shapes then cache separately, and a narrowed fetch can never overwrite a full-shape consumer's cache entry with rows missing the fields it reads.
 
+Push the narrowing all the way down to the query, not just the mapping step. Dropping a field while building the response still makes SQLite read it and the driver marshal it into JS first. `listNotesFromCache` therefore takes a matching `shape: 'full' | 'tree'` and issues a narrowed `SELECT` for `'tree'`; for 500 rows that cuts the marshalled row data from 315 kB to 111 kB, at roughly half the query wall time. The narrowed row is deliberately a different, smaller type than the full row rather than a lie about the full one, and `'full'` stays the default so every other caller of the query keeps the whole row.
+
 ## Main → Renderer Broadcasts
 
 Main-process code that fans an event out to every open window — sync status, task and calendar change events, inbox capture/filing/snooze/transcription events, search and embedding progress, updater state, reminders, agent events, and FTS rebuild progress — goes through `broadcastToAllWindows(channel, data)` in `src/main/lib/window-broadcast.ts`. The helper skips destroyed windows: short-lived windows (splash, quick capture, print/export) can still appear in `BrowserWindow.getAllWindows()` after destruction, and an unguarded `webContents.send()` throws — inside a sync item handler that throw escapes `ctx.emit` within the item's DB transaction and rolls it back. Use the helper instead of hand-rolling a `getAllWindows()` loop.


### PR DESCRIPTION
Closes #1329. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/database/queries/notes/note-crud.ts:136` built a bare `db.select()` — `SELECT *` over `note_cache` — no matter what the caller wanted:

```ts
let query = db.select().from(noteCache)

if (conditions.length > 0) {
  query = query.where(and(...conditions)) as typeof query
}

return query.orderBy(orderFn(sortColumn)).limit(limit).offset(offset).all()
```

PR #1316 gave `notes:list` a `fields: 'tree'` shape that drops `snippet` (a cached ~200-char excerpt), `mimeType` and `fileSize` — but only at the **mapping** layer above, `apps/desktop/src/main/vault/notes-queries.ts:78,82`. So for the sidebar tree's whole-vault fetch (`limit: 10000`, re-run on every note create/update/rename/move) SQLite still read the snippet for every row, better-sqlite3 still marshalled it into a JS string, and `listNotes` then discarded it. #1316's win started *after* the DB had already paid.

The same file already knew better: `noteCacheExists` at `:68` narrows its projection to `{ id }`.

## What changed

`listNotesFromCache` gains `shape?: 'full' | 'tree'` (default `'full'`) and issues a narrowed `SELECT` for `'tree'`, over the nine columns the tree shape actually maps: `id, path, title, fileType, emoji, localOnly, wordCount, createdAt, modifiedAt`. `listNotes` passes `shape: 'tree'` exactly when `fields === 'tree'`, so the SQL projection and #1316's field choice are now the same decision expressed once.

- `note-crud.ts` — `NOTE_TREE_COLUMNS`, an exported `NoteTreeCacheRow = Pick<NoteCache, …>`, the `shape` option, and two overloads so the return type stays honest: `'full'`/omitted → `NoteCache[]`, `'tree'` → `NoteTreeCacheRow[]`. A narrowed row is **not** a `NoteCache` and is not typed as one.
- `notes-queries.ts` — branches the fetch on `treeShape`; the mapper now takes `ListedNoteRow` (the tree row plus the three optional columns only the full shape reads), which a `NoteCache` satisfies. The `snippet`/`mimeType`/`fileSize` mapping is untouched.
- `queries/notes/index.ts` — re-exports the new row type.
- `apps/docs/src/architecture/ipc.md` — extends #1316's "Response Shape Narrowing" section with the query-layer half.

Deliberately **not** done:

- `suggestions.ts:258` (`listNotesFromCache(indexDb, { limit: 10000 })` for the embedding reindex) reads only `noteItem.id` and would benefit from an even narrower projection — but the issue explicitly scopes that caller out, and an id-only shape is a separate change with its own type. Left alone.
- No new projection for the `'full'` path, even though `listNotes` never reads `attachmentId`, `contentHash`, `characterCount`, `date`, `clock`, `syncedAt` or `indexedAt`. `listNotesFromCache` returns `NoteCache` to several other consumers; narrowing the default would be the breaking half of this change for no measured benefit on the hot path.

## How it was proven

Real DB-backed tests (`createTestIndexDb`, real `listNotesFromCache`) in `apps/desktop/src/main/database/queries/notes/notes.test.ts`, plus #1316's existing vault-level `fields: 'tree'` tests, which now exercise the narrowed projection end to end.

Measured on 500 seeded markdown rows carrying a realistic 200-char snippet + mime/size, `limit: 10000`:

| whole-vault fetch, 500 rows | row bytes out of SQLite | query wall time (avg of 100) |
| --- | --- | --- |
| `listNotesFromCache({ limit: 10000 })` | **315,061 B** | 1.96 ms / 3.79 ms |
| `listNotesFromCache({ limit: 10000, shape: 'tree' })` | **111,171 B** | 1.11 ms / 2.01 ms |
| | **−64.7 %** | **~1.8× faster**, two runs |

Before/after by reverting only the source files (`git checkout origin/main -- note-crud.ts index.ts notes-queries.ts`, tests kept):

```
BEFORE  Test Files  1 failed | 1 passed (2)
        Tests  2 failed | 103 passed (105)
          × #1329: shape: 'tree' selects only the columns the sidebar shape maps
              → AssertionError: expected [ 'id', 'path', 'title', …(16) ] to deeply equal [ 'id', 'path', 'title', …(6) ]
          × #1329: the tree projection cuts the row bytes SQLite marshals for a whole-vault fetch
              → AssertionError: expected 315061 to be less than 173283.55000000002

AFTER   Test Files  2 passed (2)
        Tests  105 passed (105)
```

New tests:

- `#1329: the default shape still returns the whole note_cache row, byte for byte` — a byte-level golden `JSON.stringify` of the full-shape row, column order included. **It passes on `origin/main` source and on this branch**, which is the proof that `'full'` callers are byte-identical.
- `#1329: shape: 'tree' selects only the columns the sidebar shape maps`
- `#1329: shape: 'tree' honours the same filters, sorting and paging` — tree vs full agree on folder, tag, sort and limit/offset results.
- `#1329: the tree projection cuts the row bytes SQLite marshals for a whole-vault fetch`

## Verification

```
pnpm --filter @memry/desktop typecheck:node                     → clean
vitest --project main notes.test.ts (queries) + vault/notes.test.ts
                                                                → Test Files 2 passed, Tests 105 passed
vitest --project main inbox/suggestions.test.ts ipc/notes-handlers.test.ts
                                                                → Test Files 2 passed, Tests 65 passed
pnpm exec eslint <changed files>                                → 0 errors, 0 warnings
pnpm check:architecture                                         → architecture boundary check passed
pnpm check:contracts                                            → contracts boundary check passed
git diff --check                                                → clean
pnpm docs:impact --base origin/main --strict                    → docs changed on this branch
pnpm docs:build                                                 → build complete
```

Renderer untouched, so `typecheck:web` is not in scope. No IPC contract change, so `ipc:generate`/`ipc:check` are unaffected.

## Backward compatibility

Purely additive and opt-in: `shape` defaults to `'full'`, every existing caller of `listNotesFromCache` still receives the complete `NoteCache` row (asserted byte for byte), and `NoteListItem` / the `notes:list` response are unchanged. No DB schema, migration, sync-protocol, vault-format or settings change.
