### PR TITLE
fix(crdt): keep compaction-window local edits counted as unpushed snapshot bytes

### DIFF
--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -764,6 +764,66 @@ describe('CrdtProvider', () => {
     expect(mocks.scheduleWriteback).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps a local edit that lands during the compaction push eligible for the next snapshot', async () => {
+    const compactedDoc = new Y.Doc()
+    compactedDoc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [new Y.XmlText('compact')])
+    mocks.compactYDoc.mockReturnValue({
+      compacted: Y.encodeStateAsUpdate(compactedDoc),
+      savedBytes: 120
+    })
+
+    await provider.open('note-1', undefined, { skipSeed: true })
+    provider.updateMeta('note-1', { date: '2026-01-01' })
+
+    // crdt:apply-update routes straight to applyIpcUpdate, which has no
+    // compaction guard (only remote updates are buffered), so a keystroke can
+    // reach entry.doc after compactYDoc already encoded the payload being
+    // pushed here.
+    const typed = makeRemoteUpdate('typed during the push')
+    pushSnapshot.mockImplementationOnce(async () => {
+      provider.applyIpcUpdate('note-1', typed, 1)
+    })
+
+    await provider.compactDoc('note-1')
+
+    // Those bytes are not in the pushed payload, so the note must stay armed
+    // instead of reading as fully pushed.
+    expect(provider.getDocSizeMetrics()[0].pendingSnapshotBytes).toBe(typed.byteLength)
+    pushSnapshot.mockClear()
+    await expect(provider.pushAllSnapshots()).resolves.toBe(1)
+  })
+
+  it('re-pushes a local edit that landed while an abandoned compaction was pushing', async () => {
+    const compactedDoc = new Y.Doc()
+    compactedDoc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [new Y.XmlText('compact')])
+    mocks.compactYDoc.mockReturnValue({
+      compacted: Y.encodeStateAsUpdate(compactedDoc),
+      savedBytes: 120
+    })
+
+    const originalDoc = await provider.open('note-1', undefined, { skipSeed: true })
+    provider.updateMeta('note-1', { date: '2026-01-01' })
+
+    // The editor reopens the note mid-compaction: open() adds the window to the
+    // same entry, the keystroke that follows lands on the pre-compaction doc,
+    // and the swap is then abandoned — so this edit lives only in originalDoc
+    // and only a later snapshot push can carry it to the server.
+    pushSnapshot.mockImplementationOnce(async () => {
+      await provider.open('note-1', 42, { skipSeed: true })
+      provider.applyIpcUpdate('note-1', makeRemoteUpdate('typed after reopen'), 42)
+    })
+
+    await provider.compactDoc('note-1')
+
+    expect(provider.getDoc('note-1')).toBe(originalDoc)
+
+    pushSnapshot.mockClear()
+    await expect(provider.pushAllSnapshots()).resolves.toBe(1)
+    const roundTrip = new Y.Doc()
+    Y.applyUpdate(roundTrip, pushSnapshot.mock.calls[0][1] as Uint8Array)
+    expect(roundTrip.getMap('meta').get('title')).toBe('typed after reopen')
+  })
+
   it('abandons the compacted swap if an editor opens during compaction', async () => {
     const compactedDoc = new Y.Doc()
     compactedDoc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [new Y.XmlText('compact')])

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -833,8 +833,17 @@ export class CrdtProvider {
 
     try {
       if (this.snapshotPushFn && entry.pendingSnapshotBytes > 0) {
+        // Credit only the bytes this payload actually covers. result.compacted
+        // was encoded before the await, and applyIpcUpdate writes straight to
+        // entry.doc with no compaction guard (only remote updates are
+        // buffered), so a local edit landing during the push is genuinely
+        // unpushed. Zeroing wiped it, and every path that re-pushes a note —
+        // close() and pushAllSnapshots — is gated on this counter, so the note
+        // read as pushed and stayed unpushed until a later edit re-armed it.
+        // Clamped: close() may have zeroed the counter mid-push.
+        const pushedBytes = entry.pendingSnapshotBytes
         await this.snapshotPushFn(noteId, result.compacted)
-        entry.pendingSnapshotBytes = 0
+        entry.pendingSnapshotBytes = Math.max(0, entry.pendingSnapshotBytes - pushedBytes)
       }
 
       if (this.persistence) {

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -242,6 +242,15 @@ retry `429`s inline — honouring `Retry-After` per note would stall the whole p
 sync cadence is the retry instead. A single note that fails its snapshot baseline is
 skipped and retried on the next pass rather than abandoning the remaining notes.
 
+Whether a note still owes the server a snapshot is tracked per open doc as a byte count of
+the local updates applied since the last successful push; closing a note and the push-all
+pass both skip a note whose count is zero. A push therefore subtracts only the bytes its
+payload actually covered instead of resetting the count to zero. The payload is encoded
+before the push is awaited, and typing can reach the doc during that await — compaction is
+the widest window, since it encodes its snapshot up front and buffers only remote updates,
+not local ones. Discarding the whole count marked that edit as pushed, and the note was
+then skipped until some later edit re-armed it.
+
 ## Sign-Out / Sign-In Ordering
 
 A sign out → sign in cycle has a sharp ordering rule:


### PR DESCRIPTION
Closes #1320. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/main/sync/crdt-provider.ts:835-838` — `compactDoc()` zeroed
`pendingSnapshotBytes` after its snapshot push:

```ts
if (this.snapshotPushFn && entry.pendingSnapshotBytes > 0) {
  await this.snapshotPushFn(noteId, result.compacted)
  entry.pendingSnapshotBytes = 0        // <- wipes bytes the payload never carried
}
```

`result.compacted` is encoded by `compactYDoc` on line 820 — **before** the `await`. Local
updates can land on `entry.doc` during that push and are not in the payload:

- `applyIpcUpdate` (`crdt-provider.ts:927-934`) applies straight to `entry.doc` with no
  compaction guard. Only `applyRemoteUpdate` buffers (`crdt-provider.ts:348`). Its caller,
  the `crdt:apply-update` handler (`apps/desktop/src/main/ipc/crdt-handlers.ts:93-101`),
  does no windowIds check either.
- `compactDoc` requires `entry.windowIds.size === 0` at entry, but a window can join
  **during** the await: `open()` on an existing entry just does
  `existing.windowIds.add(windowId)` on the *same* entry (`crdt-provider.ts:130-140`), which
  is what `crdt:open-doc` and the `crdt:sync-step-1` fallback both call. The reopened editor
  then types into the pre-compaction doc.

Either way `onDocUpdate` does `entry.pendingSnapshotBytes += update.byteLength`
(`crdt-provider.ts:655`) and line 837 then threw it away.

**Cost to the user:** `pendingSnapshotBytes > 0` is the gate for `close()`
(`crdt-provider.ts:241`) and `pushAllSnapshots()` (`crdt-provider.ts:460`). Zeroed early,
both skip the note — so an edit made during a compaction push never reaches the server as a
snapshot until some unrelated later edit re-arms the counter. On a note that is compacted
and then left alone (the common case: compaction only runs on windowless docs), the server
keeps the pre-compaction snapshot. The content is not lost — it is in the local store and in
`CrdtUpdateQueue` — but the note's server-side snapshot baseline silently lags, which is
exactly the state a fresh device or a snapshot-first pull reads.

## What changed

One `compactDoc()` hunk. Subtract what the payload covered instead of resetting to zero:

```ts
const pushedBytes = entry.pendingSnapshotBytes
await this.snapshotPushFn(noteId, result.compacted)
entry.pendingSnapshotBytes = Math.max(0, entry.pendingSnapshotBytes - pushedBytes)
```

Anything that lands during the await survives the subtraction and keeps the note armed. The
clamp covers `close()` or `pushSnapshotForNote()` zeroing the counter mid-push.

**Divergence from the issue's suggested direction.** #1320 suggests copying
`pushSnapshotForNote`'s shape — clear *before* the push, restore additively on failure.
Implemented differently on purpose:

- Clearing before the push would make a `close()` that starts mid-compaction read
  `pendingSnapshotBytes === 0` and **skip its own snapshot push**
  (`crdt-provider.ts:241`). Today that close pushes the fuller, post-compaction-start state.
  The compaction then abandons (`live?.closing`), and the additive restore lands on an entry
  `close()` is about to delete — so the push would be lost, not deferred. That is a
  regression the current code does not have. Subtracting after the push leaves `close()`
  behaving exactly as it does today. `pushSnapshotForNote` can clear early because
  suppressing the duplicate close-push is its stated intent; compaction's payload is a
  *stale* encode, so it cannot make that claim.
- The issue's second failure mode — the abandonment `return` (`crdt-provider.ts:853-862`)
  and a throw from `storeUpdate`/`flushDocument` — needs **no** restore once the subtraction
  is correct. `compactYDoc` (`crdt-compact-utils.ts:6-46`) copies every shared type, so a
  successful `snapshotPushFn(noteId, result.compacted)` genuinely delivers the doc's content
  as of line 820 to the server whether or not the local swap is later adopted. Restoring
  those bytes would schedule a redundant re-push of content the server already has. What was
  actually wrong on those paths was the same thing as on the happy path: the mid-await bytes.
  Both are now covered by the one subtraction.

Deliberately **not** done:

- **`accumulatedBytes` (`crdt-provider.ts:878`) left alone**, which #1320 asks to consider.
  Its caller `checkAndCompact` already zeroes it before invoking `compactDoc`
  (`crdt-provider.ts:756`), so compactDoc is not the authority on it; it gates only
  compaction/flush cadence, never a push, so a stale zero costs at most one deferred size
  check and nothing user-visible.
- **No overlap with #1318 / PR #1346**, now merged and rebased onto. That PR rewrote the
  post-guard doc-swap block; this touches only the push block above it. Its
  attach-handler → `entry.doc = newDoc` → `oldDoc.destroy()` → `drainCompactionBuffer(noteId, entry)`
  sequence is preserved exactly, and the drain replays with `ORIGIN_NETWORK`, which
  `onDocUpdate` deliberately does not count into `pendingSnapshotBytes` — so the two changes
  do not interact. The docs paragraph is in `## Snapshot Failure Handling`, a different
  section from #1346's.

## How it was proven

Two tests in `apps/desktop/src/main/sync/crdt-provider.test.ts`, both driving the race
through the real public API (`open` / `updateMeta` / `applyIpcUpdate` / `compactDoc` /
`pushAllSnapshots`) with the snapshot push as the suspension point. Neither asserts on the
counter alone — both end on whether the note actually gets pushed again.

- `keeps a local edit that lands during the compaction push eligible for the next snapshot` —
  `applyIpcUpdate` fires inside `pushSnapshot`, compaction then completes normally.
  `pendingSnapshotBytes` must equal exactly the typed update's `byteLength`, and
  `pushAllSnapshots()` must return 1.
- `re-pushes a local edit that landed while an abandoned compaction was pushing` — the
  editor reopens the note mid-push (`open('note-1', 42)`) and types; the swap is abandoned,
  so the edit lives only in the original doc. The test decodes the payload
  `pushAllSnapshots()` sends and asserts the typed title is in it — i.e. the edit really
  reaches the server, not just that a counter is non-zero.

Before/after on the same test file, reverting only `crdt-provider.ts` to `origin/main`
(`git checkout origin/main -- <file>`; no `git stash`):

```
before: Tests  2 failed | 48 passed (50)
          expected +0 to be 46   (pendingSnapshotBytes wiped)
          expected +0 to be 1    (pushAllSnapshots skipped the note)
after:  Tests  50 passed (50)
```

(Re-run after rebasing onto merged PR #1346, which added two tests to the same file.)

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  crdt-provider.test.ts crdt-writeback.test.ts crdt-ipc-handlers.test.ts engine-crdt.test.ts
                                              -> Test Files 4 passed, Tests 97 passed (97)
pnpm --filter @memry/desktop typecheck:node   -> clean
./node_modules/.bin/eslint apps/desktop/src/main/sync/crdt-provider.ts -> 0 errors
git diff --check                              -> clean
pnpm docs:impact --base origin/main --strict  -> covered
pnpm docs:build                               -> build complete in 2.58s
```

## Backward compatibility

Arithmetic on an in-memory per-doc counter. No schema, migration, IPC contract, sync
protocol, vault file format or settings shape is touched, and the wire payload is unchanged —
the only difference is that a note which owes the server a snapshot now still says so.
