### PR TITLE
fix(build): audit the sync host the build stages in the cert-pin gate

### DIFF
--- a/apps/desktop/config/vitest.config.ts
+++ b/apps/desktop/config/vitest.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
           environment: 'node',
           include: [
             'src/main/**/*.{test,spec}.{ts,tsx}',
+            'scripts/*.{test,spec}.ts',
             'scripts/seed-data/**/*.{test,spec}.{ts,tsx}'
           ],
           // `*.integration.test.ts` boots a real Worker (miniflare + esbuild) and

--- a/apps/desktop/scripts/check-cert-hashes-config.test.ts
+++ b/apps/desktop/scripts/check-cert-hashes-config.test.ts
@@ -1,0 +1,180 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  describeCertCheckHost,
+  resolveCertCheckConfig,
+  resolveRuntimeEnvFileName
+} from './check-cert-hashes-config.ts'
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url))
+const gateScript = join(scriptsDir, 'check-cert-hashes.ts')
+
+const stagedAppRoots: string[] = []
+
+/** Stand-in for apps/desktop: only the runtime env file the gate must read. */
+function stageAppRoot(envFileName: string, contents: string | null): string {
+  const appRoot = mkdtempSync(join(tmpdir(), 'memry-cert-check-'))
+  stagedAppRoots.push(appRoot)
+
+  if (contents !== null) {
+    writeFileSync(join(appRoot, envFileName), contents, 'utf8')
+  }
+
+  return appRoot
+}
+
+function runGate(appRoot: string): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', '--experimental-transform-types', gateScript, appRoot],
+    {
+      encoding: 'utf8',
+      // Strip any ambient sync host so the run only reflects the staged env file.
+      env: { ...process.env, SYNC_SERVER_URL: '', MEMRY_CERT_PINS_STRICT: '', MEMRY_ENV: '' }
+    }
+  )
+
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr }
+}
+
+afterEach(() => {
+  while (stagedAppRoots.length > 0) {
+    rmSync(stagedAppRoots.pop() as string, { force: true, recursive: true })
+  }
+})
+
+describe('resolveRuntimeEnvFileName', () => {
+  it('defaults to the production env file, which is what prebuild/build:release stage', () => {
+    expect(resolveRuntimeEnvFileName({})).toBe('.env.production')
+    expect(resolveRuntimeEnvFileName({ MEMRY_ENV: '  ' })).toBe('.env.production')
+  })
+
+  it('follows MEMRY_ENV when the caller selects a different runtime env', () => {
+    expect(resolveRuntimeEnvFileName({ MEMRY_ENV: 'staging' })).toBe('.env.staging')
+  })
+})
+
+describe('resolveCertCheckConfig', () => {
+  it('reads the sync host from the runtime env file the build stages', () => {
+    const appRoot = stageAppRoot(
+      '.env.production',
+      'SYNC_SERVER_URL=https://sync-example.invalid\n'
+    )
+
+    const config = resolveCertCheckConfig(appRoot, {})
+
+    expect(config.syncServerUrl).toBe('https://sync-example.invalid')
+    expect(config.hostSource).toBe('env-file')
+    expect(config.envFile).toBe('.env.production')
+    expect(config.envFileFound).toBe(true)
+  })
+
+  it('reads the env file selected by MEMRY_ENV', () => {
+    const appRoot = stageAppRoot(
+      '.env.staging',
+      'SYNC_SERVER_URL=https://sync-staging.memrynote.com\n'
+    )
+
+    const config = resolveCertCheckConfig(appRoot, { MEMRY_ENV: 'staging' })
+
+    expect(config.syncServerUrl).toBe('https://sync-staging.memrynote.com')
+    expect(config.hostSource).toBe('env-file')
+  })
+
+  it('lets an explicit ambient SYNC_SERVER_URL override the env file', () => {
+    const appRoot = stageAppRoot(
+      '.env.production',
+      'SYNC_SERVER_URL=https://sync-example.invalid\n'
+    )
+
+    const config = resolveCertCheckConfig(appRoot, {
+      SYNC_SERVER_URL: 'https://sync-staging.memrynote.com'
+    })
+
+    expect(config.syncServerUrl).toBe('https://sync-staging.memrynote.com')
+    expect(config.hostSource).toBe('process-env')
+  })
+
+  it('falls back to the default host when no env file and no ambient url exist', () => {
+    const appRoot = stageAppRoot('.env.production', null)
+
+    const config = resolveCertCheckConfig(appRoot, {})
+
+    expect(config.syncServerUrl).toBe('')
+    expect(config.hostSource).toBe('default')
+    expect(config.envFileFound).toBe(false)
+    expect(describeCertCheckHost(config, 'sync.memrynote.com')).toContain(
+      'No apps/desktop/.env.production'
+    )
+  })
+
+  it('keeps strict off by default so placeholder pins never fail a build (#876)', () => {
+    const appRoot = stageAppRoot(
+      '.env.production',
+      'SYNC_SERVER_URL=https://sync-example.invalid\n'
+    )
+
+    expect(resolveCertCheckConfig(appRoot, {}).strict).toBe(false)
+  })
+
+  it('turns strict on from the runtime env file that activates pinning for the host', () => {
+    const appRoot = stageAppRoot(
+      '.env.production',
+      'SYNC_SERVER_URL=https://sync-example.invalid\nMEMRY_CERT_PINS_STRICT=1\n'
+    )
+
+    expect(resolveCertCheckConfig(appRoot, {}).strict).toBe(true)
+  })
+
+  it('lets an ambient MEMRY_CERT_PINS_STRICT override the env file', () => {
+    const appRoot = stageAppRoot(
+      '.env.production',
+      'SYNC_SERVER_URL=https://sync-example.invalid\nMEMRY_CERT_PINS_STRICT=1\n'
+    )
+
+    expect(resolveCertCheckConfig(appRoot, { MEMRY_CERT_PINS_STRICT: '0' }).strict).toBe(false)
+  })
+})
+
+describe('check-cert-hashes gate', () => {
+  it('fails the build when the staged host has no pin entry', () => {
+    const appRoot = stageAppRoot(
+      '.env.production',
+      'SYNC_SERVER_URL=https://sync-example.invalid\n'
+    )
+
+    const { status, stdout, stderr } = runGate(appRoot)
+
+    expect(stdout).toContain('sync-example.invalid')
+    expect(stderr).toContain('No certificate pins configured for sync host sync-example.invalid')
+    expect(status).toBe(1)
+  })
+
+  it('audits the staged host rather than the default one when they differ', () => {
+    const appRoot = stageAppRoot(
+      '.env.production',
+      'SYNC_SERVER_URL=https://sync-staging.memrynote.com\n'
+    )
+
+    const { status, stdout } = runGate(appRoot)
+
+    expect(stdout).toContain('Certificate pins OK for sync-staging.memrynote.com')
+    expect(stdout).not.toContain('sync.memrynote.com')
+    expect(status).toBe(0)
+  })
+
+  it('still audits the default host, and says so, when no env file is staged', () => {
+    const appRoot = stageAppRoot('.env.production', null)
+
+    const { status, stdout } = runGate(appRoot)
+
+    expect(stdout).toContain('auditing the default sync host sync.memrynote.com')
+    expect(status).toBe(0)
+  })
+})

--- a/apps/desktop/scripts/check-cert-hashes-config.ts
+++ b/apps/desktop/scripts/check-cert-hashes-config.ts
@@ -1,0 +1,86 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import dotenv from 'dotenv'
+
+/**
+ * Where the sync host being audited came from.
+ *
+ * `env-file` is the one that matters: a packaged build stages
+ * `apps/desktop/.env.<MEMRY_ENV>` as `app-config` (see build-packaged-app.js),
+ * and that file's `SYNC_SERVER_URL` is the host the shipped app dials. The gate
+ * has to read the same file or it audits a host the build never contacts.
+ */
+export type CertCheckHostSource = 'process-env' | 'env-file' | 'default'
+
+export interface CertCheckConfig {
+  /** Sync server URL to derive the audited host from. Empty means "default host". */
+  syncServerUrl: string
+  strict: boolean
+  hostSource: CertCheckHostSource
+  /** Runtime env file consulted, relative to apps/desktop (e.g. `.env.production`). */
+  envFile: string
+  envFileFound: boolean
+}
+
+const DEFAULT_MEMRY_ENV = 'production'
+
+/**
+ * `prebuild` and `build:release` run the gate with no `MEMRY_ENV`, and both feed
+ * a production package, so production is the right default.
+ */
+export function resolveRuntimeEnvFileName(env: NodeJS.ProcessEnv = process.env): string {
+  return `.env.${env.MEMRY_ENV?.trim() || DEFAULT_MEMRY_ENV}`
+}
+
+export function resolveCertCheckConfig(
+  appRoot: string,
+  env: NodeJS.ProcessEnv = process.env
+): CertCheckConfig {
+  const envFile = resolveRuntimeEnvFileName(env)
+  const envFilePath = join(appRoot, envFile)
+  const envFileFound = existsSync(envFilePath)
+  const fileEnv = envFileFound ? dotenv.parse(readFileSync(envFilePath, 'utf8')) : {}
+
+  // An explicit ambient SYNC_SERVER_URL is a deliberate "audit this host instead"
+  // and wins, matching dotenv's own no-override semantics. No build path sets it,
+  // so in practice the env file decides.
+  const ambientUrl = env.SYNC_SERVER_URL?.trim() ?? ''
+  const fileUrl = fileEnv.SYNC_SERVER_URL?.trim() ?? ''
+  const syncServerUrl = ambientUrl || fileUrl
+  const hostSource: CertCheckHostSource = ambientUrl
+    ? 'process-env'
+    : fileUrl
+      ? 'env-file'
+      : 'default'
+
+  // Strict is opt-in, not on by default: the production host still ships
+  // placeholder pins, so forcing it would fail every prebuild (see #876). Reading
+  // it from the runtime env file lets the environment that activates pinning for
+  // a host turn the gate strict in the same file that names that host.
+  const strictValue = env.MEMRY_CERT_PINS_STRICT ?? fileEnv.MEMRY_CERT_PINS_STRICT
+
+  return {
+    syncServerUrl,
+    strict: strictValue === '1',
+    hostSource,
+    envFile,
+    envFileFound
+  }
+}
+
+export function describeCertCheckHost(config: CertCheckConfig, hostname: string): string {
+  if (config.hostSource === 'process-env') {
+    return `Auditing sync host ${hostname} from SYNC_SERVER_URL.`
+  }
+
+  if (config.hostSource === 'env-file') {
+    return `Auditing sync host ${hostname} from apps/desktop/${config.envFile}.`
+  }
+
+  if (config.envFileFound) {
+    return `apps/desktop/${config.envFile} sets no SYNC_SERVER_URL and none is exported — auditing the default sync host ${hostname}.`
+  }
+
+  return `No apps/desktop/${config.envFile} and no SYNC_SERVER_URL — auditing the default sync host ${hostname}. A packaged build stages ${config.envFile}, so run this where that file exists to audit the host the build ships against.`
+}

--- a/apps/desktop/scripts/check-cert-hashes.sh
+++ b/apps/desktop/scripts/check-cert-hashes.sh
@@ -6,5 +6,8 @@ APP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # No CI escape hatch: placeholder pins now warn instead of failing, so the check
 # is safe to run everywhere and is only useful where releases are actually built.
+# APP_ROOT is passed through so the check resolves .env.<MEMRY_ENV> from the app
+# directory regardless of the caller's cwd — that file is what a packaged build
+# stages as app-config, so it names the host the shipped app actually dials.
 node --experimental-strip-types --experimental-transform-types \
-  "$APP_ROOT/scripts/check-cert-hashes.ts"
+  "$APP_ROOT/scripts/check-cert-hashes.ts" "$APP_ROOT"

--- a/apps/desktop/scripts/check-cert-hashes.ts
+++ b/apps/desktop/scripts/check-cert-hashes.ts
@@ -3,12 +3,19 @@ import {
   getConfiguredPinnedCertificateHashes,
   getConfiguredSyncCertHostname
 } from '../src/main/sync/certificate-pins.ts'
+import { describeCertCheckHost, resolveCertCheckConfig } from './check-cert-hashes-config.ts'
 
-const hostname = getConfiguredSyncCertHostname(process.env.SYNC_SERVER_URL)
-const pins = getConfiguredPinnedCertificateHashes(process.env.SYNC_SERVER_URL)
-const strict = process.env.MEMRY_CERT_PINS_STRICT === '1'
+// App root comes from the shell wrapper; cwd is the fallback for `pnpm cert:check`
+// style invocations from apps/desktop.
+const appRoot = process.argv[2] ?? process.cwd()
+const config = resolveCertCheckConfig(appRoot)
 
-const result = checkCertificatePinConfig({ hostname, pins, strict })
+const hostname = getConfiguredSyncCertHostname(config.syncServerUrl)
+const pins = getConfiguredPinnedCertificateHashes(config.syncServerUrl)
+
+console.log(describeCertCheckHost(config, hostname))
+
+const result = checkCertificatePinConfig({ hostname, pins, strict: config.strict })
 
 if (result.level === 'error') {
   console.error(`ERROR: ${result.message}`)

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -188,10 +188,28 @@ reflects the same rule:
 | Placeholder hashes with `MEMRY_CERT_PINS_STRICT=1` | fails                                |
 | No entry for the host, or a malformed pin          | fails                                |
 
+### Which host the check audits
+
+The host is resolved from the same file a packaged build ships: `apps/desktop/.env.<MEMRY_ENV>`
+(`.env.production` when `MEMRY_ENV` is unset, which is how `prebuild` and `build:release` run it).
+That file is staged into the app as `app-config` and is what the shipped app dials, so the audit and
+the build agree on one host. An explicit `SYNC_SERVER_URL` in the environment overrides the file, for
+auditing a host ad hoc. With neither present — a fresh checkout or CI, where no `.env` file exists —
+the check audits the default production host and prints that it is doing so, rather than appearing to
+have checked the build's host.
+
+The first line of output always names the audited host and where it came from:
+
+```
+Auditing sync host sync.memrynote.com from apps/desktop/.env.production.
+```
+
 To activate pinning for a host, run `pnpm cert:extract -- <hostname>`, replace that host's
 placeholders with the emitted hashes (keep a backup pin for rotation), and set
-`MEMRY_CERT_PINS_STRICT=1` in the release build so the host can never silently regress to
-unpinned.
+`MEMRY_CERT_PINS_STRICT=1` so the host can never silently regress to unpinned. Strict mode is
+opt-in and can be set either in the environment or in the same `.env.<MEMRY_ENV>` file that names the
+host. It is deliberately off by default: the production host still carries placeholder pins, so
+enabling it globally would fail every `prebuild` and every fresh checkout.
 
 ## Renderer Permission Policy
 


### PR DESCRIPTION
Closes #1339. Part of epic #987 (memory/CPU audit 2026-08).

Build-time gate accuracy only. Runtime pinning is untouched: a packaged app loads `app-config` into `process.env` before sync runs, so `createPinnedAgent` already resolves the real host.

## What was wrong

`apps/desktop/scripts/check-cert-hashes.ts` read the host from ambient `process.env` and nothing else:

```ts
const hostname = getConfiguredSyncCertHostname(process.env.SYNC_SERVER_URL)
const pins = getConfiguredPinnedCertificateHashes(process.env.SYNC_SERVER_URL)
```

The host a build actually ships against comes from a different place: `scripts/build-packaged-app.js:158-167` parses `apps/desktop/.env.production` into a local object (never into `process.env`) and stages it as `app-config`. Neither the `.sh` nor the `.ts` ever loaded that file, and no caller exports `SYNC_SERVER_URL` — `build:release` (`package.json:46`), `prebuild` (`package.json:57`), and the three `desktop-ci.yml` steps all run with it unset. So `getConfiguredSyncCertHostname` silently fell back to `DEFAULT_SYNC_CERT_HOSTNAME` on every invocation.

Net effect: the gate always audited `sync.memrynote.com` regardless of what the build staged, which made the `pins.length === 0` → `level: 'error'` branch ("a host with no pin entry fails the build") unreachable — the fallback host always has an entry. A build staged against a different host was reported OK on the strength of a host it would never contact.

## What changed

- New `apps/desktop/scripts/check-cert-hashes-config.ts` resolves the audited host from `apps/desktop/.env.<MEMRY_ENV>` (`.env.production` by default, which is how `prebuild` and `build:release` run) using dotenv's `parse` — the same file and the same parser the packaging script stages from. Precedence: explicit ambient `SYNC_SERVER_URL` → env file → default host.
- `check-cert-hashes.sh` passes `APP_ROOT` through so the file is resolved from the app directory, not the caller's cwd.
- The gate now prints which host it audited and where that host came from, as its first line. The old silent fallback is gone:
  ```
  Auditing sync host sync-staging.memrynote.com from apps/desktop/.env.production.
  No apps/desktop/.env.production and no SYNC_SERVER_URL — auditing the default sync host sync.memrynote.com. ...
  ```
- One line added to the `main` vitest project include (`scripts/*.{test,spec}.ts`) so the new test runs in CI. `scripts/seed-data/**` was already in that project, and `scripts/**` is outside the coverage `include`, so no coverage-ratchet movement.
- Docs: `apps/docs/src/architecture/cryptography.md` gains a "Which host the check audits" section.

**Deliberately not done — `MEMRY_CERT_PINS_STRICT` stays opt-in.** The issue is right that no script or workflow sets it. Wiring it on for `prebuild`/`build:release` would fail every build today, because the production host still ships `PLACEHOLDER_*` pins — that is exactly #876 ("fresh checkout cannot build"), which is why placeholders warn instead of failing in the first place. Removing it would delete the documented switch for a host whose pinning has been activated. So it is kept as opt-in and made actually settable: it is now read from `.env.<MEMRY_ENV>` as well as the environment, so the release env file that names the activated host can flip the gate strict in the same place, without a package.json edit.

**Also deliberately not done — a missing `.env.<MEMRY_ENV>` is not an error.** The three CI steps and every fresh checkout have no `.env` file (`.env*` is gitignored). They keep auditing the default host and now say so explicitly instead of doing it by accident. Failing there would re-create #876.

## How it was proven

`apps/desktop/scripts/check-cert-hashes-config.test.ts` spawns the real gate script against a staged app root containing a real `.env.production`, and asserts on exit code and output — not on mocks.

Before/after via `git checkout origin/main -- apps/desktop/scripts/check-cert-hashes.ts` (fix committed first, resolver module left in place so the unit tests still import):

- **Before:** `Tests 3 failed | 9 passed (12)` — the gate exited 0 for a staged host with no pin entry, printed nothing about the host, and reported `sync.memrynote.com` when the staged host was `sync-staging.memrynote.com`.
- **After:** `Tests 12 passed (12)`.

Demonstrated run against a real `.env.production` in `apps/desktop` (removed afterwards; gitignored, nothing committed):

```
$ printf 'SYNC_SERVER_URL=https://sync-example.invalid\n' > apps/desktop/.env.production
Auditing sync host sync-example.invalid from apps/desktop/.env.production.
ERROR: No certificate pins configured for sync host sync-example.invalid. Add an entry to certificate-pins.ts.   # exit 1

$ printf 'SYNC_SERVER_URL=https://sync-staging.memrynote.com\n' > apps/desktop/.env.production
Auditing sync host sync-staging.memrynote.com from apps/desktop/.env.production.
Certificate pins OK for sync-staging.memrynote.com (1 pinned)                                                   # exit 0
```

On `origin/main` both of those print `sync.memrynote.com` and exit 0.

No real host or pin values are introduced: `sync-staging.memrynote.com` and its pin are already in `certificate-pins.ts`; everything else uses `sync-example.invalid`.

## Verification

```
pnpm --filter @memry/desktop typecheck:node                          # clean
vitest --project main scripts/check-cert-hashes-config.test.ts       # 12 passed (12)
vitest --project main src/main/sync/certificate-pin{s,ning}.test.ts
  + src/main/sync/cert-hash-cli.test.ts                              # 47 passed (3 files)
pnpm exec eslint <changed files>                                     # 0 errors (scripts/ + config/ are ignore-pattern matched, pre-existing)
git diff --check                                                     # clean
pnpm docs:impact --base origin/main --strict                         # covered
pnpm docs:build                                                      # build complete in 15.36s
pnpm --filter @memry/desktop cert:check                              # warns on the default host, exit 0 (unchanged for a checkout with no .env)
```

## Backward compatibility

Build-script only — no schema, contract, IPC, sync-protocol, settings, or runtime change; a checkout with no `.env.<MEMRY_ENV>` behaves exactly as before apart from one extra informational line.
