### PR TITLE
fix(agent): hide tombstoned conversations from ConversationStore.getById

### DIFF
--- a/apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import sodium from 'libsodium-wrappers-sumo'
 
 const mocks = vi.hoisted(() => ({
   setWriteGate: vi.fn(),
@@ -13,9 +16,11 @@ vi.mock('../event-bus', () => ({
   broadcastAgentEvent: mocks.broadcastAgentEvent
 }))
 
+import * as schema from '@memry/db-schema/data-schema'
 import type { VaultServiceHandles } from '../../mcp/tools/handles'
 import { buildWriteTools } from '../../mcp/tools/write-tools'
 import type { ConversationStore } from '../../storage/conversation-store'
+import { createConversationStore } from '../../storage/conversation-store'
 import type { MessageStore } from '../../storage/message-store'
 import { AgentRuntime } from '../runtime'
 
@@ -77,11 +82,83 @@ function installedGate() {
   return gate
 }
 
+/**
+ * Same runtime, but wired to a real SQLite-backed ConversationStore instead of
+ * a `vi.fn()`. The tombstone bug lives in the store's SQL, so a mocked store
+ * cannot see it.
+ */
+function createRuntimeWithRealStore(vaultKey: Uint8Array) {
+  const sqlite = new Database(':memory:')
+  sqlite.exec(`
+    CREATE TABLE agent_conversations (
+      id TEXT PRIMARY KEY,
+      vault_id TEXT NOT NULL,
+      title_ciphertext TEXT NOT NULL,
+      backend TEXT NOT NULL,
+      backend_model TEXT,
+      trust_list TEXT NOT NULL DEFAULT '[]',
+      pinned INTEGER NOT NULL DEFAULT 0,
+      vector_clock TEXT NOT NULL,
+      field_clocks TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER,
+      last_synced_at INTEGER
+    );
+  `)
+  const conversations = createConversationStore({
+    db: drizzle(sqlite, { schema }),
+    vaultKey,
+    deviceId: 'device-1'
+  })
+  const runtime = new AgentRuntime({
+    conversations,
+    messages: {} as MessageStore,
+    getPreferences: () => ({ accessMode: 'vault_only', toolApprovalMode: 'always_accept' })
+  })
+
+  return { runtime, conversations }
+}
+
 describe('AgentRuntime approval gate', () => {
+  let vaultKey: Uint8Array
+
+  beforeAll(async () => {
+    await sodium.ready
+    vaultKey = sodium.randombytes_buf(sodium.crypto_aead_xchacha20poly1305_ietf_KEYBYTES)
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(Date, 'now').mockReturnValue(100)
     vi.spyOn(Math, 'random').mockReturnValue(0.5)
+  })
+
+  it('rejects writes into a soft-deleted conversation', async () => {
+    const { runtime, conversations } = createRuntimeWithRealStore(vaultKey)
+    const conversation = conversations.create({
+      vaultId: 'v',
+      title: 'Doomed',
+      backend: 'claude_cli'
+    })
+
+    runtime.install()
+    const gate = installedGate()
+    const write = {
+      conversationId: conversation.id,
+      toolName: 'vault_create_task',
+      parsedArgs: { title: 'Task' }
+    }
+
+    await expect(gate(write)).resolves.toEqual({ approved: true })
+
+    // A remote delete applied by the sync handler leaves exactly this state.
+    conversations.softDelete(conversation.id)
+
+    await expect(gate(write)).resolves.toEqual({
+      approved: false,
+      reason: 'Unknown conversation'
+    })
   })
 
   it('rejects writes for unknown conversations', async () => {

--- a/apps/desktop/src/main/agent/storage/__tests__/conversation-store.test.ts
+++ b/apps/desktop/src/main/agent/storage/__tests__/conversation-store.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import Database from 'better-sqlite3'
+import { eq } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import sodium from 'libsodium-wrappers-sumo'
 
@@ -144,8 +145,43 @@ describe('Conversation store', () => {
     const conversation = store.create({ vaultId: 'v', title: 'X', backend: 'claude_cli' })
     store.softDelete(conversation.id)
 
-    const fetched = store.getById(conversation.id)
+    const fetched = store.getById(conversation.id, { includeDeleted: true })
     expect(fetched?.deletedAt).not.toBeNull()
+  })
+
+  it('hides a soft-deleted conversation from getById by default', () => {
+    const conversation = store.create({ vaultId: 'v', title: 'X', backend: 'claude_cli' })
+    store.softDelete(conversation.id)
+
+    expect(store.getById(conversation.id)).toBeNull()
+    expect(store.listByVault('v')).toEqual([])
+  })
+
+  it('refuses to mutate the trust list of a soft-deleted conversation', () => {
+    const conversation = store.create({ vaultId: 'v', title: 'X', backend: 'claude_cli' })
+    store.softDelete(conversation.id)
+
+    expect(() => store.addToTrustList(conversation.id, 'vault_create_note')).toThrow(
+      `Conversation ${conversation.id} not found`
+    )
+    expect(() => store.removeFromTrustList(conversation.id, 'vault_create_note')).toThrow(
+      `Conversation ${conversation.id} not found`
+    )
+    expect(store.getById(conversation.id, { includeDeleted: true })?.trustList).toEqual([])
+  })
+
+  it('still soft-deletes a conversation the sync layer already tombstoned', () => {
+    const conversation = store.create({ vaultId: 'v', title: 'X', backend: 'claude_cli' })
+    db.update(schema.agentConversations)
+      .set({ deletedAt: 1 })
+      .where(eq(schema.agentConversations.id, conversation.id))
+      .run()
+
+    store.softDelete(conversation.id)
+
+    const fetched = store.getById(conversation.id, { includeDeleted: true })
+    expect(fetched?.deletedAt).not.toBe(1)
+    expect(fetched?.vectorClock['device-1']).toBe(2)
   })
 
   it('addToTrustList is idempotent', () => {

--- a/apps/desktop/src/main/agent/storage/conversation-store.ts
+++ b/apps/desktop/src/main/agent/storage/conversation-store.ts
@@ -30,7 +30,7 @@ export interface ConversationStore {
     backend: AgentBackendId
     backendModel?: string | null
   }): Conversation
-  getById(id: string): Conversation | null
+  getById(id: string, opts?: { includeDeleted?: boolean }): Conversation | null
   listByVault(vaultId: string, opts?: { includeDeleted?: boolean }): Conversation[]
   update(
     id: string,
@@ -144,12 +144,17 @@ export function createConversationStore(deps: StoreDeps): ConversationStore {
       }
     },
 
-    getById(id) {
-      const row = db
-        .select()
-        .from(schema.agentConversations)
-        .where(eq(schema.agentConversations.id, id))
-        .get()
+    getById(id, opts) {
+      // Tombstoned rows are hidden by default, exactly like `listByVault`.
+      // `getById` is the existence gate the MCP write gate and the IPC handlers
+      // read, so a row carrying `deletedAt` must not answer "yes, write here" —
+      // an inbound remote delete can set that tombstone without this device
+      // ever touching the row.
+      const where = opts?.includeDeleted
+        ? eq(schema.agentConversations.id, id)
+        : and(eq(schema.agentConversations.id, id), isNull(schema.agentConversations.deletedAt))
+
+      const row = db.select().from(schema.agentConversations).where(where).get()
       return row ? agentConversationRowToModel(row, vaultKey) : null
     },
 
@@ -220,7 +225,13 @@ export function createConversationStore(deps: StoreDeps): ConversationStore {
     },
 
     softDelete(id) {
-      const existing = this.getById(id)
+      // Opt in to the tombstoned row: re-deleting has always re-stamped
+      // `deletedAt` and ticked the clock, and this keeps that behaviour.
+      // NOTE: this still has no production caller. Whoever wires conversation
+      // delete to the UI must also cancel any in-flight turn for the
+      // conversation (`AgentRuntime.cancelTurn`), or the run keeps writing into
+      // a record the user believes is gone.
+      const existing = this.getById(id, { includeDeleted: true })
       if (!existing) return
       const now = Date.now()
       db.update(schema.agentConversations)

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -249,6 +249,11 @@ Client-specific config keys vary. Use the copied URL as the MCP server URL and t
 Bearer authorization header. Plain external clients can use read tools, but they do not get the
 in-app conversation/window context that approved writes require.
 
+A write is only approved for a conversation that still exists. A conversation that has been deleted —
+including one deleted on another device and carried here by sync — no longer counts as an existing
+conversation, so its write tools are refused rather than writing into a record that is gone from your
+chat history everywhere.
+
 ## Tools
 
 Read tools are available to Agent Chat and external MCP clients:


### PR DESCRIPTION
Closes #1335. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`ConversationStore.getById` did not filter `deletedAt`, so a tombstoned conversation still answered "yes, this exists".

`apps/desktop/src/main/agent/storage/conversation-store.ts:147` (pre-fix):

```ts
getById(id) {
  const row = db
    .select()
    .from(schema.agentConversations)
    .where(eq(schema.agentConversations.id, id))
    .get()
  return row ? agentConversationRowToModel(row, vaultKey) : null
}
```

`listByVault` right below it already filtered `isNull(deletedAt)` by default. `getById` is what the MCP write gate reads as its existence check — `apps/desktop/src/main/agent/runtime/runtime.ts:110`:

```ts
const conversation = this.deps.conversations.getById(ctx.conversationId)
if (!conversation) {
  return { approved: false, reason: 'Unknown conversation' }
}
```

So a row carrying `deletedAt` passed the gate and kept accepting tool writes into a conversation invisible in every list. Same for `addToTrustList` / `removeFromTrustList`, which read through `getById` and then write.

### Reachability — I checked, and it is latent, not live

The issue and the triage note both raised the possibility that sync can already produce the tombstone here. It cannot, today. `deletedAt` on `agent_conversations` has exactly three writers:

- `conversation-store.ts` `softDelete` — still zero production callers (`grep softDelete` finds the store, its test, and `vi.fn()` stubs only).
- `sync/item-handlers/agent-conversation-handler.ts:200` (`applyDelete`) — needs an inbound remote **delete op**.
- `agent-conversation-handler.ts:127` / `:259` (`applyUpsert`) — needs an inbound payload with non-null `deletedAt`, which `buildPushPayload` only produces from a locally tombstoned row.

Both sync paths require some device to have called `softDelete` first, and no shipped code does. The push side confirms it: `AgentSyncEnqueueRequest` (`apps/desktop/src/main/agent/sync/entitlement-gate.ts:5`) has `type`, `id`, `status` and **no operation field at all**, so the agent sync surface can only enqueue upserts — it has no way to express a conversation delete. So the defect is real but unreachable until conversation delete ships. Filing it as a correctness fix ahead of that, not as a live incident.

## What changed

`getById(id, opts?: { includeDeleted?: boolean })` — filters `isNull(deletedAt)` by default, mirroring `listByVault`'s existing signature exactly. `softDelete` moves to `getById(id, { includeDeleted: true })` so re-deleting an already-tombstoned row keeps re-stamping `deletedAt` and ticking the vector clock, unchanged from today.

Deliberately **not** done:

- **No change to the sync handler.** I checked every `getById` caller before changing the default. `AgentConversationHandler` never touches `ConversationStore` — it reads and writes `agentConversations` through drizzle directly (`:104`, `:186`, `:209`, `:228`, `:248`) and uses only the exported pure helpers `agentConversationRowToModel` / `encryptConversationTitle`. Sync reconciliation therefore still sees tombstoned rows and is completely unaffected by the new default.
- **No change to `update()`.** It reads the row directly rather than through `getById`. Every production path into it is now gated by the filtered `getById` (`addToTrustList`/`removeFromTrustList` at `:237`/`:244`, and `agent-handlers.ts:152`'s `conversation && …` backend-change branch), so filtering there too would be redundant churn.
- **No change to `runtime.ts`.** PR #1349 owns `cancelTurn` right now. The issue's second half — that whoever wires conversation delete to the UI must also cancel any in-flight turn via `AgentRuntime.cancelTurn`, or the run keeps writing into a record the user believes is gone — is preserved as a `NOTE:` comment on `softDelete` so it is visible at the exact call site a future delete feature will reach for.

Behaviour changes that follow from the new default, all of them intended: `agent:loadConversation` returns `conversation: null` for a tombstoned id (the IPC contract is already `Conversation | null` and the renderer already threads null through `set_active_conversation`), and trust-list mutations on a tombstoned conversation now throw `Conversation <id> not found` instead of silently writing.

## How it was proven

Before/after on the same tests, source file reverted with `git checkout origin/main -- <file>` (never `git stash`):

- **Before the fix: `Tests 3 failed | 22 passed (25)`** — `hides a soft-deleted conversation from getById by default`, `refuses to mutate the trust list of a soft-deleted conversation`, and the runtime test `rejects writes into a soft-deleted conversation` all fail.
- **After the fix: `Tests 25 passed (25)`.**

The runtime test is not a mocked-store test. `runtime-approval.test.ts` previously stubbed `conversations.getById` with `vi.fn()`, which cannot see a bug that lives in the store's SQL. The new case builds a real in-memory SQLite `ConversationStore`, wires it into `AgentRuntime`, asserts the installed MCP write gate approves a `vault_create_task`, calls `softDelete`, and asserts the same gate now returns `{ approved: false, reason: 'Unknown conversation' }`.

New/changed tests:

- `runtime-approval.test.ts` — `rejects writes into a soft-deleted conversation` (real store + real gate).
- `conversation-store.test.ts` — `hides a soft-deleted conversation from getById by default`; `refuses to mutate the trust list of a soft-deleted conversation`; `still soft-deletes a conversation the sync layer already tombstoned` (covers the `includeDeleted` path `softDelete` now uses, with a `deletedAt` written straight to the row as the sync handler would); existing `soft-deletes a conversation` updated to read through `{ includeDeleted: true }`.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project main \
  apps/desktop/src/main/agent apps/desktop/src/main/ipc/agent-handlers.test.ts \
  apps/desktop/src/main/sync/item-handlers/__tests__/agent-conversation-handler.test.ts
  → Test Files 61 passed (61) · Tests 462 passed (462)

pnpm --filter @memry/desktop typecheck:node   → clean, no errors
./node_modules/.bin/eslint apps/desktop/src/main/agent/storage/conversation-store.ts
  → 0 errors (test files are ignored by the flat config)
git diff --check                              → clean
pnpm docs:impact --base origin/main --strict  → covered
pnpm docs:build                               → build complete in 6.66s
```

No renderer files touched, so `typecheck:web` was not run.

## Backward compatibility

No schema, contract, sync-payload or settings change — `getById` gains an optional second argument with a default that preserves the pre-existing result for every non-tombstoned row, and no tombstoned `agent_conversations` row can exist in any shipped install today (see the reachability section), so no user's data reads differently after this lands.
