### PR TITLE
refactor(tasks): remove the dead getArchivedTasks helper and its barrel entry

### DIFF
--- a/apps/desktop/src/renderer/src/lib/task-utils/index.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/index.ts
@@ -69,8 +69,7 @@ export {
   type DayHeaderText,
   getDayHeaderText,
   getCompletedTasks,
-  getCompletedTodayTasks,
-  getArchivedTasks
+  getCompletedTodayTasks
 } from './task-view-helpers'
 
 export {

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts
@@ -506,7 +506,7 @@ export const getDayHeaderText = (date: Date): DayHeaderText => {
 }
 
 // ============================================================================
-// COMPLETED VIEW & ARCHIVE HELPERS
+// COMPLETED VIEW HELPERS
 // ============================================================================
 
 export const getCompletedTasks = (tasks: Task[]): Task[] => {
@@ -524,8 +524,4 @@ export const getCompletedTodayTasks = (tasks: Task[]): Task[] => {
       task.parentId === null &&
       isSameDay(task.completedAt, today)
   )
-}
-
-export const getArchivedTasks = (tasks: Task[]): Task[] => {
-  return tasks.filter((task) => task.archivedAt !== null)
 }


### PR DESCRIPTION
Closes #1327. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts:529-531` defined a helper that nothing calls:

```ts
export const getArchivedTasks = (tasks: Task[]): Task[] => {
  return tasks.filter((task) => task.archivedAt !== null)
}
```

It was re-exported from the barrel at `apps/desktop/src/renderer/src/lib/task-utils/index.ts:73`, and the barrel entry was its only reference anywhere in the repo. There is no archived-tasks surface in the app, so the function was unreachable in every build.

## What changed

Two deletions and one stale comment word:

- removed the `getArchivedTasks` definition (`task-view-helpers.ts`)
- removed its barrel re-export (`task-utils/index.ts`)
- the section header directly above it read `COMPLETED VIEW & ARCHIVE HELPERS`; with the only archive helper gone it now reads `COMPLETED VIEW HELPERS`

Net: `2 files changed, 2 insertions(+), 7 deletions(-)`.

**Deliberately not done:**

- **`includeArchived: true` is untouched.** `use-task-queries.ts:222` still fetches archived rows. That flag is load-bearing for the project sidebar badges until the badge bug lands, and the archived-rows decision is tracked separately (#1326). This PR only removes the dead function.
- **No badge-counting lines touched.** `task-view-helpers.ts:199-207` (`projectTaskCounts`) is owned by #1323 / PR #1344; this diff stays above line 505.
- **No test added.** The change deletes an unreachable function, so there is no behavior to assert. A test that only asserts "this export no longer exists" would pin the barrel's shape, not any real behavior. The proof below is compile-time reachability instead.

## How it was proven

**Deletion bar — every reference form searched, repo-wide, `node_modules`/`.git`/`dist`/`out` excluded:**

```
$ grep -rn "getArchivedTasks" .
apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts:529:export const getArchivedTasks = ...
apps/desktop/src/renderer/src/lib/task-utils/index.ts:73:  getArchivedTasks
```

Exactly two hits: the definition and the barrel re-export. Also checked and empty:

- case-insensitive `ArchivedTasks` substring — only local `nonArchivedTasks` variables in `task-filters.ts` / `task-view-helpers.ts`, unrelated
- `getArchived` prefix (catches split/computed names) — same two hits
- `export *` star re-exports covering `task-utils` or `task-view-helpers` — none exist; the barrel is an explicit named list
- dynamic `import()` of `task-utils` / `task-view-helpers` — none
- `import * as … from '@/lib/task-utils'` or `Object.keys(taskUtils)` export-surface assertions — none
- tests: no test file references the symbol, so nothing was deleted alongside it. The three suites that `vi.importActual('@/lib/task-utils')` (`remaining-zero-surfaces`, `more-leaf-surfaces`, `zero-leaf-surfaces`) spread the real module and never name this export
- e2e and `apps/docs/src` — no mention
- no archived-tasks view exists or is planned: the only `'archived'` view type in the renderer is Inbox's (`inbox-segment-control.tsx:6`, its own IPC), and `isArchived` on projects is a different field

**Compile-time reachability, run as a pair:**

| state | `tsc --noEmit -p tsconfig.web.json` |
| --- | --- |
| A — definition deleted, barrel entry restored | **exit 2, 1 error:** `index.ts(73,3): error TS2305: Module '"./task-view-helpers"' has no exported member 'getArchivedTasks'.` |
| B — both deleted (this PR) | **exit 0, 0 errors** |

A proves the barrel entry was a genuine reference to the definition and that it was the *only* one — a single error, at the barrel line, and nowhere else in the renderer graph. B proves nothing consumed the barrel entry either.

## Verification

- `tsc --noEmit -p tsconfig.web.json --composite false` → **exit 0, 0 errors**
- `vitest run --project renderer` over `task-utils.test.ts`, `task-workspace-counts.test.ts`, `remaining-zero-surfaces.test.tsx`, `more-leaf-surfaces.test.tsx`, `zero-leaf-surfaces.test.tsx`, `tasks-widget.test.tsx` → **6 files passed, 433 tests passed**
- `eslint` on both changed files → **exit 0, no findings**
- `git diff --check` → clean
- `pnpm docs:impact --base origin/main --strict` → reports `missing-docs`. Not addressed on purpose: the gate is purely path-based (any edit under `apps/desktop/src/` that ships no docs change fails it) and has no notion of user-facing vs internal. This PR deletes an internal renderer helper that no build could ever reach, so there is no user-visible behavior to document; writing a docs page for it would document something that never existed. `docs:build` not run — no docs changed.
- Node typecheck not run: no main-process or node files touched.

## Backward compatibility

No runtime, IPC, schema, settings, sync, or vault-format surface is touched — this removes renderer-only code that was never reachable, so existing installs behave identically.
