### PR TITLE
perf(tabs): make the tab-state save dedupe short-circuit, and delete the unreachable IndexedDB adapter

### DIFF
--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts
@@ -76,7 +76,22 @@ export const useTabPersistence = (options: UseTabPersistenceOptions = {}): void 
     // changes walks the tab tree once instead of once per change.
     saveTimeoutRef.current = setTimeout(() => {
       const serialized = serializeTabState(state)
-      const json = JSON.stringify(serialized)
+
+      // Compare everything *except* `savedAt`. `serializeTabState` stamps a
+      // fresh `Date.now()` on every call, so comparing the whole payload made
+      // no two serializations ever equal and this guard never fired: state
+      // changes the persisted projection does not carry (`isModified`,
+      // `isDeleted`, `lastAccessedAt`, back/forward history, `recentlyClosed`)
+      // each cost a full stringify plus a synchronous `localStorage.setItem`
+      // that wrote back byte-identical content.
+      //
+      // Skipping a write leaves an older `savedAt` in storage, which is inert:
+      // nothing reads it — not `migratePersistedState`, not `deserializeTabState`,
+      // not `extractPinnedTabs`. Writes that do happen still carry the stamp
+      // from the moment they were made, and both quit paths (`beforeunload`,
+      // the Cmd+Q flush registry) write unconditionally regardless of this guard.
+      const { savedAt: _savedAt, ...fingerprint } = serialized
+      const json = JSON.stringify(fingerprint)
 
       if (json === lastSavedRef.current) return
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/index.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/index.ts
@@ -10,7 +10,7 @@ export { STORAGE_VERSION, STORAGE_KEY } from './types'
 export { serializeTabState, deserializeTabState, extractPinnedTabs } from './serialization'
 
 // Storage adapters
-export { localStorageAdapter, indexedDBAdapter, getDefaultStorage, saveSync } from './storage'
+export { localStorageAdapter, getDefaultStorage, saveSync } from './storage'
 
 // Migrations
 export { migratePersistedState, needsMigration, getMigrationDescription } from './migrations'

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useManualPersistence, useSessionRestore, useTabPersistence } from './hooks'
-import { indexedDBAdapter, isQuotaExceededError, localStorageAdapter, saveSync } from './storage'
+import { isQuotaExceededError, localStorageAdapter, saveSync } from './storage'
 import { deserializeTabState, extractPinnedTabs, serializeTabState } from './serialization'
 import { STORAGE_KEY, type PersistedTabState, type TabStorage } from './types'
 import type { Tab, TabSystemState } from '@/contexts/tabs/types'
@@ -247,58 +247,6 @@ function ManualPersistenceProbe({ storage }: { storage: TabStorage }) {
   return null
 }
 
-function installIndexedDbMock(): void {
-  let value: PersistedTabState | null = null
-  const createRequest = <T,>(result: T) => {
-    const request = {
-      error: null,
-      result,
-      onsuccess: null as null | (() => void),
-      onerror: null as null | (() => void)
-    }
-    setTimeout(() => request.onsuccess?.(), 0)
-    return request
-  }
-  const store = {
-    put: vi.fn((nextValue: PersistedTabState) => {
-      value = nextValue
-      return createRequest(undefined)
-    }),
-    get: vi.fn(() => createRequest(value)),
-    delete: vi.fn(() => {
-      value = null
-      return createRequest(undefined)
-    })
-  }
-  const db = {
-    objectStoreNames: { contains: vi.fn(() => false) },
-    createObjectStore: vi.fn(),
-    transaction: vi.fn(() => ({
-      objectStore: vi.fn(() => store)
-    }))
-  }
-
-  Object.defineProperty(globalThis, 'indexedDB', {
-    configurable: true,
-    value: {
-      open: vi.fn(() => {
-        const request = {
-          error: null,
-          result: db,
-          onsuccess: null as null | (() => void),
-          onerror: null as null | (() => void),
-          onupgradeneeded: null as null | ((event: { target: { result: typeof db } }) => void)
-        }
-        setTimeout(() => {
-          request.onupgradeneeded?.({ target: { result: db } })
-          request.onsuccess?.()
-        }, 0)
-        return request
-      })
-    }
-  })
-}
-
 describe('tab persistence serialization and storage', () => {
   beforeEach(() => {
     vi.useRealTimers()
@@ -381,15 +329,6 @@ describe('tab persistence serialization and storage', () => {
     expect(isQuotaExceededError(new Error('disk on fire'))).toBe(false)
     expect(isQuotaExceededError('QuotaExceededError')).toBe(false)
   })
-
-  it('saves, loads, and clears via indexedDB adapter', async () => {
-    installIndexedDbMock()
-
-    await indexedDBAdapter.save(persisted())
-    await expect(indexedDBAdapter.load()).resolves.toMatchObject({ version: 2 })
-    await indexedDBAdapter.clear()
-    await expect(indexedDBAdapter.load()).resolves.toBeNull()
-  })
 })
 
 describe('tab persistence hooks', () => {
@@ -456,6 +395,54 @@ describe('tab persistence hooks', () => {
     expect(mocks.serializeCalls).toBe(1)
     await waitFor(() => expect(storage.save).toHaveBeenCalledTimes(1))
     expect(storage.save).toHaveBeenCalledWith(expectedPersisted(CLOCK_START + 25))
+  })
+
+  it('skips the write when the persisted payload is unchanged, and stamps writes that happen', async () => {
+    const storage: TabStorage = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn(),
+      clear: vi.fn()
+    }
+    vi.setSystemTime(CLOCK_START)
+
+    const { rerender } = render(<TabPersistenceProbe storage={storage} debounceMs={25} />)
+
+    act(() => vi.advanceTimersByTime(25))
+    await waitFor(() => expect(storage.save).toHaveBeenCalledTimes(1))
+    expect(vi.mocked(storage.save).mock.calls[0][0].savedAt).toBe(CLOCK_START + 25)
+
+    // `isModified` flips on every editor dirty/clean transition but is stripped
+    // by `serializeTabState`, so this tab-state change projects to a payload
+    // byte-identical to the one already in storage. It must not be written:
+    // `savedAt: Date.now()` used to make every serialization unique, so the
+    // dedupe never matched and the redundant `setItem` ran anyway.
+    const unchanged = state()
+    unchanged.tabGroups['group-1'].tabs[0] = tab({ isModified: true })
+    mocks.tabsState = unchanged
+    rerender(<TabPersistenceProbe storage={storage} debounceMs={25} />)
+
+    await act(async () => {
+      vi.advanceTimersByTime(25)
+    })
+
+    // The tree is still walked — that is how the payload is compared at all —
+    // but nothing reaches storage.
+    expect(mocks.serializeCalls).toBe(2)
+    expect(storage.save).toHaveBeenCalledTimes(1)
+
+    // A change the payload does carry still writes, with the stamp taken at the
+    // moment of that write rather than the skipped one.
+    const changed = state()
+    changed.tabGroups['group-1'].tabs[0] = tab({ title: 'Renamed' })
+    mocks.tabsState = changed
+    rerender(<TabPersistenceProbe storage={storage} debounceMs={25} />)
+
+    act(() => vi.advanceTimersByTime(25))
+    await waitFor(() => expect(storage.save).toHaveBeenCalledTimes(2))
+
+    const written = vi.mocked(storage.save).mock.calls[1][0]
+    expect(written.savedAt).toBe(CLOCK_START + 75)
+    expect(written.tabGroups['group-1'].tabs[0].title).toBe('Renamed')
   })
 
   it('reports a quota failure to the user and keeps saving afterwards', async () => {

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/storage.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/storage.ts
@@ -9,10 +9,6 @@ import { createLogger } from '@/lib/logger'
 
 const log = createLogger('TabPersistence:Storage')
 
-const toError = (error: unknown, fallback: string): Error => {
-  return error instanceof Error ? error : new Error(fallback)
-}
-
 /**
  * Whether a storage write failed because the origin ran out of quota.
  *
@@ -90,89 +86,17 @@ export const saveSync = (state: PersistedTabState): void => {
 }
 
 // =============================================================================
-// INDEXEDDB ADAPTER (Optional, for larger state)
-// =============================================================================
-
-const DB_NAME = 'memry_tabs'
-const DB_VERSION = 1
-const STORE_NAME = 'tabState'
-
-/**
- * Open IndexedDB database
- */
-const openDatabase = (): Promise<IDBDatabase> => {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, DB_VERSION)
-
-    request.onerror = () => reject(toError(request.error, 'Failed to open IndexedDB'))
-    request.onsuccess = () => resolve(request.result)
-
-    request.onupgradeneeded = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result
-      if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME)
-      }
-    }
-  })
-}
-
-/**
- * IndexedDB adapter for tab persistence
- * Better for larger state that might exceed localStorage limits
- */
-export const indexedDBAdapter: TabStorage = {
-  save: async (state: PersistedTabState): Promise<void> => {
-    const db = await openDatabase()
-
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readwrite')
-      const store = tx.objectStore(STORE_NAME)
-      const request = store.put(state, 'current')
-
-      request.onerror = () => reject(toError(request.error, 'Failed to save tab state'))
-      request.onsuccess = () => resolve()
-    })
-  },
-
-  load: async (): Promise<PersistedTabState | null> => {
-    try {
-      const db = await openDatabase()
-
-      return new Promise((resolve, reject) => {
-        const tx = db.transaction(STORE_NAME, 'readonly')
-        const store = tx.objectStore(STORE_NAME)
-        const request = store.get('current')
-
-        request.onerror = () => reject(toError(request.error, 'Failed to load tab state'))
-        request.onsuccess = () => resolve(request.result || null)
-      })
-    } catch (error) {
-      log.error('Failed to load from IndexedDB:', error)
-      return null
-    }
-  },
-
-  clear: async (): Promise<void> => {
-    const db = await openDatabase()
-
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readwrite')
-      const store = tx.objectStore(STORE_NAME)
-      const request = store.delete('current')
-
-      request.onerror = () => reject(toError(request.error, 'Failed to clear tab state'))
-      request.onsuccess = () => resolve()
-    })
-  }
-}
-
-// =============================================================================
 // DEFAULT ADAPTER
 // =============================================================================
 
 /**
- * Get the default storage adapter
- * Uses localStorage for simplicity, can be changed to IndexedDB if needed
+ * Get the default storage adapter.
+ *
+ * localStorage is the only backend. An IndexedDB adapter used to sit here,
+ * exported but selected by nothing; it was removed rather than left to rot —
+ * see #1330. If the localStorage quota ever becomes the real constraint (#1292
+ * closed without moving off it), the replacement backend needs a migration read
+ * from `STORAGE_KEY` and a downgrade story, which is its own change.
  */
 export const getDefaultStorage = (): TabStorage => {
   return localStorageAdapter

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -112,6 +112,8 @@ If **Restore Session** is on, the entire tab and split layout restores on app la
 - Split layout and ratios
 - Active tab per pane
 
+The layout is written only when one of those things actually changes. Activity that leaves the layout alone — a note picking up and losing its modified dot, moving back and forward inside a tab — no longer triggers a rewrite. Quitting still writes the current layout either way, so nothing is lost by the skipped writes.
+
 ### If the layout can't be saved
 
 Session layout is stored in the app's local browser storage, which has a size limit. A very large session — many open tabs, several split panes, tabs holding a lot of view state — can hit that limit, and once it does the layout stops being saved.


### PR DESCRIPTION
Closes #1330. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

**(b) The `lastSavedRef` dedupe could never match.** `persistence/hooks.ts:78-81` compared the whole serialized payload against the last saved one:

```ts
const serialized = serializeTabState(state)
const json = JSON.stringify(serialized)

if (json === lastSavedRef.current) return
```

but `serializeTabState` stamps `savedAt: Date.now()` on every call (`persistence/serialization.ts:75`), so no two serializations are ever equal and the guard never short-circuited.

That is not free. `serializeTabState` strips `isModified`, `isDeleted`, `openedAt`, `lastAccessedAt`, `isPreview`, per-group `back`/`forward` and `recentlyClosed` — none of them are in `PersistedTab`/`PersistedTabState`. So every tab-state change that touches only those fields projected to a **byte-identical** payload and still paid a full `JSON.stringify` of the tab tree plus a synchronous `localStorage.setItem`. Concrete hot paths: `SET_TAB_MODIFIED` (template-editor dirty/clean, `template-editor.tsx:123`), `SET_TAB_DELETED` (`pages/note.tsx:474`), and `lastAccessedAt` bumps. `localStorage.setItem` is synchronous and disk-backed, on the renderer's main thread.

**(a) `indexedDBAdapter` was exported and reachable from nothing.** `storage.ts:123` implemented a full `TabStorage` over IndexedDB (plus `openDatabase`, `DB_NAME`, `DB_VERSION`, `STORE_NAME`, and the `toError` helper that only it used), `persistence/index.ts:13` re-exported it, and `getDefaultStorage()` returned `localStorageAdapter` unconditionally. Its only consumer anywhere was `persistence.test.tsx:385-392`, which made ~75 lines of unreachable code read as covered.

## What changed

**(b) The dedupe now works** — it compares everything except the timestamp:

```ts
const { savedAt: _savedAt, ...fingerprint } = serialized
const json = JSON.stringify(fingerprint)

if (json === lastSavedRef.current) return
```

I made it work rather than deleting it, because this is a perf epic and the guard is on the hot path — deleting it would have conceded the waste it was written to prevent. Checked before doing so:

- **Writes that do happen still carry a fresh stamp.** `storage.save(serialized)` is unchanged; `serialized` keeps its real `savedAt`. Only the comparison key drops it.
- **Nothing depends on `savedAt` advancing.** The only non-test readers of the field are the type declaration and the stamp itself — `migratePersistedState`, `deserializeTabState` and `extractPinnedTabs` never look at it, and there is no restore-freshness check anywhere. A skipped write leaving an older stamp in storage is inert.
- **Nothing depends on the write happening every time.** Both quit paths (`beforeunload` and the Cmd+Q flush registry) call `saveSync` unconditionally and do not consult `lastSavedRef`, so a quit always writes the current layout. `App.tsx:381` removes `STORAGE_KEY` on a vault switch; the debounce is per-state-change, not an interval, so that removal was never re-written by a spontaneous tick before this change either — behaviour there is unchanged.
- **The failure path still retries.** `lastSavedRef` is still only advanced after a save that actually resolved (#1297), so a rejected write leaves the old fingerprint in place and the next state change retries.

The tree walk itself is *not* skipped, and I did not try to: comparing the projection is the only way to know whether anything persisted changed. The saving is the stringify of the full payload and the `setItem`.

**(a) The IndexedDB adapter is deleted** — the adapter, `openDatabase`, `DB_NAME`/`DB_VERSION`/`STORE_NAME`, the now-orphaned `toError` helper, the `index.ts` export, and its test plus the ~50-line `installIndexedDbMock` harness.

**Say plainly, so you can disagree:** deleting it means the localStorage → IndexedDB migration would start from scratch. I think that is the right trade. #1292 — the HIGH-tier issue that asked the question — is closed, and its PR #1297 explicitly declined the swap ("it needs a migration read from the existing `memry_tab_state` localStorage key, a decision about what happens to that key afterwards, and a rollback story for a user who downgrades"). No open issue commits to the migration. And the ~75 lines being deleted are the easy part of that work: the hard part is the migration and downgrade story, none of which this code contains. `getDefaultStorage()` now carries a comment recording the decision and pointing at what a replacement backend would owe.

Deliberately not done: no change to `getDefaultStorage`'s behaviour, `STORAGE_KEY`, `STORAGE_VERSION`, the persisted shape, or the quota handling added by #1297/#1360.

## How it was proven

`persistence.test.tsx`, renderer project, reverting only `hooks.ts` to `origin/main` (`git checkout origin/main -- .../hooks.ts`, never `git stash`):

| run | result |
| --- | --- |
| before (`hooks.ts` from `origin/main`) | **1 failed \| 9 passed (10)** — `expected "vi.fn()" to be called 1 times, but got 2 times` |
| after (fix restored) | **10 passed (10)** |

The new test, `skips the write when the persisted payload is unchanged, and stamps writes that happen`, asserts all three halves of the behaviour:

1. after the first save, a state change that flips only `isModified` (stripped by `serializeTabState`) leaves `storage.save` at **1 call** — that is the assertion that fails on `origin/main`;
2. the tab tree is still walked for that change (`serializeCalls` goes 1 → 2), so the test documents what is saved and what is not rather than overclaiming;
3. a change the payload *does* carry writes, and the written payload's `savedAt` is the clock at the moment of that write (`CLOCK_START + 75`), not the skipped one — the stamp did not go stale.

The pre-existing tests that lock in the #1297 retry behaviour (`reports a quota failure to the user and keeps saving afterwards`, `warns once across a run of failures`) still pass unchanged, which is the evidence that a working dedupe does not wedge the saver after a failure.

## Verification

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
  → Test Files 1 passed (1) | Tests 10 passed (10)

./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  apps/desktop/src/renderer/src/contexts/tabs
  → Test Files 11 passed (11) | Tests 109 passed (109)

pnpm --filter @memry/desktop typecheck:web     → clean
./node_modules/.bin/eslint .../contexts/tabs/persistence/  → 0 problems
git diff --check                               → clean
pnpm docs:impact --base origin/main --strict   → docs changed on this branch
pnpm docs:build                                → build complete in 11.49s
```

## Backward compatibility

None affected. No schema, contract, storage-key or persisted-shape change: the same `memry_tab_state` localStorage payload with the same `STORAGE_VERSION` is written and read, and existing sessions restore exactly as before. The deleted IndexedDB adapter was never selected by any build, so no shipped install has ever written the `memry_tabs` database — nothing to migrate away from.

## Note for reviewers

#1360 (issue #1328) is open against the same directory and edits `storage.ts`, `hooks.ts`, `index.ts` and `persistence.test.tsx`. This branch keeps its diff to the two mechanisms above and does not touch `saveSync` or the quota handling; if #1360 lands first I will rebase.
