### PR TITLE
fix(i18n): catch interpolated template literals in the toast lint gate

### DIFF
--- a/apps/desktop/scripts/i18n/eslint/no-toast-string-literal.mjs
+++ b/apps/desktop/scripts/i18n/eslint/no-toast-string-literal.mjs
@@ -35,7 +35,10 @@ function isStringLiteralWithLetters(arg) {
   if (arg.type === 'Literal' && typeof arg.value === 'string') {
     return hasLetters(arg.value)
   }
-  if (arg.type === 'TemplateLiteral' && arg.expressions.length === 0) {
+  if (arg.type === 'TemplateLiteral') {
+    // Only the static text counts. A template assembled purely from translated
+    // parts (`${t('a')} ${t('b')}`) leaves nothing but punctuation/whitespace in
+    // the quasis, so it stays valid; hard-coded English between the holes does not.
     const raw = arg.quasis.map((q) => q.value.cooked).join('')
     return hasLetters(raw)
   }

--- a/apps/desktop/scripts/i18n/eslint/no-toast-string-literal.test.mjs
+++ b/apps/desktop/scripts/i18n/eslint/no-toast-string-literal.test.mjs
@@ -17,10 +17,19 @@ test('no-toast-string-literal', () => {
       { code: "toast.error(t('notes:page.toast.saveFailed'))" },
       { code: 'toast.info(message)' },
       { code: 'toast.success(`${greeting}, ${name}`)' },
+      // Interpolation of already-translated parts: every letter comes out of t(),
+      // the quasis hold nothing but punctuation and spacing.
+      { code: "toast.info(t('inbox:toast.snoozed', { count }))" },
+      { code: "toast.error(`${t('common:saveFailed')}: ${err.message}`)" },
+      { code: "toast.success(`${t('notes:created')} ${t('notes:openHint')}`)" },
       { code: 'someOtherFn.success("ignored")' },
       {
         code: `// TODO(i18n): wrap toast in t()
 toast.error('Failed to save')`
+      },
+      {
+        code: `// TODO(i18n): wrap toast in t()
+toast.error(\`Could not open \${name}\`)`
       },
       { code: 'toast(getMessage())' }
     ],
@@ -39,6 +48,24 @@ toast.error('Failed to save')`
       },
       {
         code: 'toast("Welcome")',
+        errors: [{ messageId: 'toastLiteral' }]
+      },
+      // Interpolation is a formatting detail, not evidence of translation: the
+      // English sitting between the holes is exactly as hard-coded as a plain literal.
+      {
+        code: 'toast.info(`${count} items snoozed`)',
+        errors: [{ messageId: 'toastLiteral' }]
+      },
+      {
+        code: 'toast.error(`Could not open ${name}`)',
+        errors: [{ messageId: 'toastLiteral' }]
+      },
+      {
+        code: 'toast.success(`Imported ${n} file${n > 1 ? "s" : ""}`)',
+        errors: [{ messageId: 'toastLiteral' }]
+      },
+      {
+        code: 'toast(`Welcome back, ${name}`)',
         errors: [{ messageId: 'toastLiteral' }]
       }
     ]

--- a/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { forwardRef, useEffect, useImperativeHandle, type ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
 
 import { AppSidebar } from './app-sidebar'
 import { BookmarkItemTypes } from '@memry/contracts/bookmarks-api'
@@ -19,6 +20,13 @@ const mocks = vi.hoisted(() => ({
   notesTreeCreateNote: vi.fn(),
   notesTreeCreateFolder: vi.fn(),
   canvasTreeCreateFolder: vi.fn(),
+  fileDrop: { onDrop: null as ((paths: string[]) => Promise<void> | void) | null },
+  // Keyless calls collapse to the last key segment; interpolated ones append
+  // their values so a test can prove the caller passed them through.
+  translate: (key: string, values?: Record<string, unknown>): string => {
+    const label = key.split('.').at(-1) ?? key
+    return values ? `${label}:${JSON.stringify(values)}` : label
+  },
   authState: { status: 'unauthenticated' },
   inboxItems: [
     { id: 'inbox-1', type: 'note' },
@@ -28,7 +36,11 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@memry/i18n/renderer', () => ({
-  useT: () => ({ t: (key: string) => key.split('.').at(-1) ?? key })
+  useT: () => ({ t: mocks.translate })
+}))
+
+vi.mock('react-i18next', () => ({
+  getI18n: () => ({ getFixedT: () => mocks.translate })
 }))
 
 vi.mock('@/components/onboarding/use-first-run-tour', () => ({
@@ -266,7 +278,10 @@ vi.mock('@/hooks/use-inbox', () => ({
 }))
 
 vi.mock('@/hooks/use-file-drop', () => ({
-  useFileDrop: () => ({ isDraggingFiles: false, dropHandlers: {} })
+  useFileDrop: (options: { onDrop: (paths: string[]) => Promise<void> | void }) => {
+    mocks.fileDrop.onDrop = options.onDrop
+    return { isDraggingFiles: false, dropHandlers: {} }
+  }
 }))
 
 // Minimal stateful Picker mock: the real Radix Popover does not open on click in
@@ -437,5 +452,26 @@ describe('AppSidebar', () => {
     rerender(<AppSidebar currentPage="inbox" viewCounts={{}} />)
     expect(screen.queryByRole('button', { name: 'Sync status' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'syncDisabled' })).not.toBeInTheDocument()
+  })
+
+  // Both import toasts used to be interpolated template literals, which the i18n
+  // lint gate could not see (issue #1340). Assert the key *and* the count so a
+  // regression back to English prose fails here, not just in review.
+  it('reports dropped-file import results through translation keys with counts', async () => {
+    render(<AppSidebar currentPage="inbox" viewCounts={{}} />)
+    mocks.importFiles.mockResolvedValueOnce({
+      imported: 2,
+      failed: 1,
+      errors: ['bad.zip: unsupported']
+    })
+
+    await act(async () => {
+      await mocks.fileDrop.onDrop?.(['a.md', 'b.md', 'bad.zip'])
+    })
+
+    expect(toast.success).toHaveBeenCalledWith('filesImported:{"count":2}')
+    expect(toast.error).toHaveBeenCalledWith('filesImportFailed:{"count":1}', {
+      description: 'bad.zip: unsupported'
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/components/app-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.tsx
@@ -117,12 +117,13 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
   const handleFileDrop = useCallback(async (paths: string[]) => {
     try {
       const result = await notesService.importFiles(paths, targetFolderRef.current)
+      const tCommon = getI18n().getFixedT(null, 'common')
 
       if (result.imported > 0) {
-        toast.success(`Imported ${result.imported} file${result.imported > 1 ? 's' : ''}`)
+        toast.success(tCommon('toast.filesImported', { count: result.imported }))
       }
       if (result.failed > 0) {
-        toast.error(`Failed to import ${result.failed} file${result.failed > 1 ? 's' : ''}`, {
+        toast.error(tCommon('toast.filesImportFailed', { count: result.failed }), {
           description: result.errors?.join('\n')
         })
       }

--- a/apps/desktop/src/renderer/src/components/medium-cold-surfaces.test.tsx
+++ b/apps/desktop/src/renderer/src/components/medium-cold-surfaces.test.tsx
@@ -19,8 +19,11 @@ const dismissMutate = vi.hoisted(() => vi.fn())
 const clipboardWrite = vi.fn()
 
 vi.mock('@memry/i18n/renderer', () => ({
+  // Keyless calls still render as the bare key; interpolated ones append their
+  // values so a test can prove the caller actually passed them through.
   useT: () => ({
-    t: (key: string) => key
+    t: (key: string, values?: Record<string, unknown>) =>
+      values ? `${key}:${JSON.stringify(values)}` : key
   })
 }))
 
@@ -378,8 +381,8 @@ describe('medium cold renderer surfaces', () => {
     })
 
     expect(toastMock.base).toHaveBeenCalledTimes(5)
-    expect(toastMock.info).toHaveBeenCalledWith('1 more reminder(s) due', {
-      description: 'Check the reminders panel for details'
+    expect(toastMock.info).toHaveBeenCalledWith('toast.moreRemindersDue:{"count":1}', {
+      description: 'toast.moreRemindersDueHint'
     })
 
     const firstToastOptions = toastMock.base.mock.calls[0][1]

--- a/apps/desktop/src/renderer/src/hooks/use-reminder-notifications.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-reminder-notifications.ts
@@ -14,6 +14,7 @@ import { useEffect, useCallback } from 'react'
 import { createLogger } from '@/lib/logger'
 import { toast } from 'sonner'
 import { useTabs } from '@/contexts/tabs'
+import { useT } from '@memry/i18n/renderer'
 import { useDismissReminder } from '@/hooks/use-reminders'
 import type { ReminderWithTarget } from '@/services/reminder-service'
 
@@ -42,6 +43,7 @@ interface ReminderClickedEvent {
  */
 export function useReminderNotifications(): void {
   const { openTab } = useTabs()
+  const { t } = useT('common')
   const dismissMutation = useDismissReminder()
 
   // Navigate to reminder target
@@ -148,8 +150,8 @@ export function useReminderNotifications(): void {
 
       // If there are more than 5, show a summary
       if (event.count > 5) {
-        toast.info(`${event.count - 5} more reminder(s) due`, {
-          description: 'Check the reminders panel for details'
+        toast.info(t('toast.moreRemindersDue', { count: event.count - 5 }), {
+          description: t('toast.moreRemindersDueHint')
         })
       }
     })
@@ -157,7 +159,7 @@ export function useReminderNotifications(): void {
     return () => {
       unsubscribeDue()
     }
-  }, [showReminderToast])
+  }, [showReminderToast, t])
 
   // Handle desktop notification click events (navigate to target)
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/hooks/use-undoable-action.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-undoable-action.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * The undo-restore toast used to be an interpolated template literal
+ * (`` `"${pending.title}" restored` ``), which the i18n lint gate could not see
+ * (issue #1340). This pins it to a translation key and proves the item title is
+ * still handed to the formatter as a placeholder value rather than pre-baked
+ * into English prose.
+ */
+
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+import { useUndoableAction } from './use-undoable-action'
+
+// Typed off what the hook actually hands sonner, not off sonner's own signature.
+// `ExternalToast['action']` is `ReactNode | Action`, and `Action.onClick` takes a
+// React MouseEvent — reading the callback back off that union needs either an
+// unsound cast or a fabricated synthetic event. The hook passes a zero-argument
+// closure, which satisfies both shapes, so describing the call site directly keeps
+// the read type-safe.
+const mocks = vi.hoisted(() => ({
+  toastSuccess:
+    vi.fn<
+      (message: string, options?: { action?: { label: string; onClick: () => void } }) => void
+    >(),
+  toastInfo: vi.fn<(message: string) => void>()
+}))
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: mocks.toastSuccess,
+    error: vi.fn(),
+    info: mocks.toastInfo
+  })
+}))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  // Keyless calls render as the bare key; interpolated ones append their values
+  // so the assertion can prove the caller passed them through.
+  useT: () => ({
+    t: (key: string, values?: Record<string, unknown>) =>
+      values ? `${key}:${JSON.stringify(values)}` : key
+  })
+}))
+
+vi.mock('@/services/inbox-service', () => ({
+  inboxService: {
+    archive: vi.fn().mockResolvedValue({ success: true }),
+    undoArchive: vi.fn().mockResolvedValue({ success: true }),
+    undoFile: vi.fn().mockResolvedValue({ success: true })
+  }
+}))
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+describe('useUndoableAction', () => {
+  it('announces a restored item through a translation key, not hard-coded English', async () => {
+    const { result } = renderHook(() => useUndoableAction(), { wrapper })
+
+    await act(async () => {
+      await result.current.archiveWithUndo('item-1', 'Saved Link')
+    })
+
+    const undoAction = mocks.toastSuccess.mock.calls[0]?.[1]?.action
+    if (!undoAction) throw new Error('the archive toast did not offer an undo action')
+
+    await act(async () => {
+      undoAction.onClick()
+    })
+
+    expect(mocks.toastInfo).toHaveBeenCalledWith('toast.restored:{"title":"Saved Link"}')
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-undoable-action.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-undoable-action.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
+import { useT } from '@memry/i18n/renderer'
 import { inboxService } from '@/services/inbox-service'
 import { inboxKeys } from './use-inbox'
 
@@ -22,6 +23,7 @@ export interface UseUndoableActionResult {
 
 export function useUndoableAction(): UseUndoableActionResult {
   const queryClient = useQueryClient()
+  const { t } = useT('inbox')
   const pendingRef = useRef<Map<string, PendingUndo>>(new Map())
 
   // Drop every open undo window when the hook owner unmounts
@@ -53,10 +55,10 @@ export function useUndoableAction(): UseUndoableActionResult {
 
       if (result.success) {
         invalidateAll()
-        toast.info(`"${pending.title}" restored`)
+        toast.info(t('toast.restored', { title: pending.title }))
       }
     },
-    [invalidateAll]
+    [invalidateAll, t]
   )
 
   const enqueue = useCallback(

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -68,7 +68,12 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@memry/i18n/renderer', () => ({
-  useT: () => ({ t: (key: string) => key })
+  // Keyless calls still render as the bare key; interpolated ones append their
+  // values so a test can prove the caller actually passed them through.
+  useT: () => ({
+    t: (key: string, values?: Record<string, unknown>) =>
+      values ? `${key}:${JSON.stringify(values)}` : key
+  })
 }))
 
 vi.mock('react-i18next', () => ({
@@ -898,7 +903,9 @@ describe('NotePage', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Internal missing file' }))
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('File not found: Missing.png'))
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('page.toast.fileNotFound:{"target":"Missing.png"}')
+    )
 
     mocks.createNote.mockResolvedValueOnce({ success: false })
     fireEvent.click(screen.getByRole('button', { name: 'Internal create link' }))

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -1025,7 +1025,7 @@ export function NotePage({ noteId }: NotePageProps) {
 
           case 'not-found':
             // File-like target not found - show error instead of creating a note
-            toast.error(`File not found: ${target}`)
+            toast.error(t('page.toast.fileNotFound', { target }))
             break
         }
       } catch (err) {

--- a/apps/docs/src/contribute/testing.md
+++ b/apps/docs/src/contribute/testing.md
@@ -160,6 +160,20 @@ in the English bundles, and keeps non-English locale files aligned with English 
 tool tests when changing `apps/desktop/scripts/i18n/*` so scanner allowlists, JSON output, TODO
 limits, and locale-completeness behavior stay covered.
 
+Alongside it, the `i18n/no-toast-string-literal` ESLint rule guards toast copy in the renderer. It
+judges the static text of the first argument, so interpolation is no exemption — a hard-coded
+English template such as ``toast.error(`Could not open ${name}`)`` is reported exactly like
+`toast.error('Could not open file')`. Pass the values as placeholders instead:
+
+```ts
+toast.error(t('notes:page.toast.fileNotFound', { target }))
+```
+
+A template whose letters all come out of `t()` — ``toast.error(`${t('a')}: ${t('b')}`)`` — stays
+valid, because only punctuation and spacing are hard-coded. `TODO(i18n): wrap … in t()` silences the
+rule for one call site, but `pnpm i18n:check` runs with `--max-todo 0`, so it is a review aid rather
+than a way to land untranslated copy.
+
 ## Focused Typecheck
 
 Skip the flaky pre-hooks and known pre-existing errors:

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -86,7 +86,11 @@
     "actionFailed": "Action failed",
     "nothingToUndo": "Nothing to undo",
     "undone": "Undone: {description}",
-    "undoFailed": "Failed to undo action"
+    "undoFailed": "Failed to undo action",
+    "filesImported": "{count, plural, one {Imported # file} other {Imported # files}}",
+    "filesImportFailed": "{count, plural, one {Failed to import # file} other {Failed to import # files}}",
+    "moreRemindersDue": "{count, plural, one {# more reminder due} other {# more reminders due}}",
+    "moreRemindersDueHint": "Check the reminders panel for details"
   },
   "dateRelative": {
     "today": "Today",

--- a/packages/i18n/src/locales/en/inbox.json
+++ b/packages/i18n/src/locales/en/inbox.json
@@ -108,7 +108,8 @@
     "appliedTags": "{tagCount, plural, one {Applied # tag} other {Applied # tags}} to {itemCount, plural, one {# item} other {# items}}",
     "archivedItems": "{count, plural, one {Archived # item} other {Archived # items}}",
     "snoozedUntil": "Snoozed until {time}",
-    "snoozedItemsUntil": "{count, plural, one {Snoozed # item until {time}} other {Snoozed # items until {time}}}"
+    "snoozedItemsUntil": "{count, plural, one {Snoozed # item until {time}} other {Snoozed # items until {time}}}",
+    "restored": "\"{title}\" restored"
   },
   "bulk": {
     "selected": "{count} selected",

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -12,6 +12,7 @@
       "cannotRenameDeleted": "Cannot rename - note was deleted",
       "createLinkedFailed": "Failed to create linked note",
       "openLinkedFailed": "Failed to open linked item",
+      "fileNotFound": "File not found: {target}",
       "localOnly": "Note set to local only",
       "willSync": "Note will sync to cloud",
       "renameFailed": "Failed to rename note",


### PR DESCRIPTION
Closes #1340. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/scripts/i18n/eslint/no-toast-string-literal.mjs:38` only accepted a template literal as a string when it had **no** interpolations:

```js
if (arg.type === 'TemplateLiteral' && arg.expressions.length === 0) {
  const raw = arg.quasis.map((q) => q.value.cooked).join('')
  return hasLetters(raw)
}
```

`CallExpression` reports only when `isStringLiteralWithLetters(firstArg)` is true, so the moment a toast interpolated anything, the whole call fell out of the gate:

```ts
toast.info(`${count} items snoozed`)   // never reported
toast.success('Snoozed')               // reported
```

The English in the quasis is exactly as hard-coded either way. Interpolation is a formatting detail, not evidence of translation — which is how the hard-coded English in #1283 got past lint.

## What changed

**The rule** now drops the `expressions.length === 0` guard and judges the joined static quasis, which already distinguishes the two cases without needing to reason about the expressions:

- `` toast.error(`Could not open ${name}`) `` → quasis join to `Could not open ` → **reported**.
- `` toast.error(`${t('a')}: ${t('b')}`) `` → quasis join to `: ` → **valid**, because every letter comes out of `t()`.
- `toast.info(t('x', { n }))` is a `CallExpression`, untouched.

**Fallout, measured first.** Run against the rule's real scope (`apps/desktop/src/renderer/src/**/*.{ts,tsx}` minus tests) with `--no-cache`, the widened rule flagged **5** pre-existing sites — few enough to translate rather than allowlist:

| site | old copy |
| --- | --- |
| `components/app-sidebar.tsx:122` | `` `Imported ${result.imported} file${…}` `` |
| `components/app-sidebar.tsx:125` | `` `Failed to import ${result.failed} file${…}` `` |
| `hooks/use-reminder-notifications.ts:151` | `` `${event.count - 5} more reminder(s) due` `` |
| `hooks/use-undoable-action.ts:56` | `` `"${pending.title}" restored` `` |
| `pages/note.tsx:1028` | `` `File not found: ${target}` `` |

All five now go through `t()` with ICU placeholders, adding 5 English keys (`common:toast.filesImported` / `filesImportFailed` / `moreRemindersDue` / `moreRemindersDueHint`, `inbox:toast.restored`, `notes:page.toast.fileNotFound`). The two counted strings became real `{count, plural, …}` blocks instead of the `n > 1 ? 's' : ''` suffix hack, which never worked outside English anyway.

**Deliberately not done:**

- **No `TODO(i18n)` staging.** The issue suggests it, but `pnpm i18n:check` runs `--max-todo 0`, so any TODO turns that gate red. The escape hatch is a review aid, not a landing strategy — the docs note now says so.
- **No allowlist and no per-directory disable.** Five sites did not justify either.
- **Adjacent untranslated copy left alone** (`'Archived'` / `'Filed'` / `'Undo'` in `use-undoable-action.ts`, `'View'` / `'Dismiss'` / `'Note reminder'` in `use-reminder-notifications.ts`). Those are hard-coded English the rule cannot see — they reach the toast through variables, not literals — so they are a separate scope, not this regression.
- `app-sidebar.tsx` keeps its two import toasts on `getI18n().getFixedT(null, 'common')`, the pattern already used in the same `catch` branch. Routing them through the component's `tPhaseF` instead would have forced it into `handleFileDrop`'s dep array, re-indenting the whole callback and dragging the untested `catch` body into the patch for no behavioural gain.

## How it was proven

New rule cases in `no-toast-string-literal.test.mjs`: 4 invalid (interpolated English, including the `${n > 1 ? "s" : ""}` shape) and 3 valid (`t()` with options, and two templates assembled purely from `t()` parts).

```
# rule reverted to origin/main, new tests kept
AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
ℹ tests 1  ℹ pass 0  ℹ fail 1

# rule restored
✔ no-toast-string-literal
ℹ tests 1  ℹ pass 1  ℹ fail 0
```

Call-site count under the widened rule, `--no-cache` both times: **5 before** the call-site fixes, **0 after**.

Renderer coverage for the changed lines:

- `hooks/use-undoable-action.test.tsx` (new) — drives archive → undo and asserts `toast.restored:{"title":"Saved Link"}`.
- `components/app-sidebar.test.tsx` — new case captures the `useFileDrop` `onDrop`, imports 2 / fails 1, and asserts both keys **with their counts**. `react-i18next` is stubbed the same way `note.test.tsx` already stubs it, so `getFixedT` resolves in jsdom.
- `pages/note.test.tsx` and `components/medium-cold-surfaces.test.tsx` — existing assertions on the old English strings updated to the keys. Both files' `useT` mocks now serialize the interpolation values, so these assertions prove the values are passed through rather than just that a key was used.

## Verification

```
pnpm --filter @memry/desktop typecheck:web        → exit 0
pnpm exec eslint <8 changed renderer files>       → exit 0, 0 problems
node --test apps/desktop/scripts/i18n/eslint/*.test.mjs → 6 pass, 0 fail
vitest --project renderer <10 affected files>     → 10 files, 79 tests passed
vitest packages/i18n src/locales                  → 3 files, 9 tests passed (ICU brace style, placeholder parity)
pnpm --filter @memry/desktop i18n:check           → ok, 3997 keys used across 1651 files
pnpm docs:impact --base origin/main --strict      → docs changed on this branch
pnpm docs:build                                   → build complete
git diff --check                                  → clean
```

## Patch coverage

The first push went red on `codecov/patch` alone. Cause: `handleFileDrop` had been rewritten into the multi-line `useCallback(fn, deps)` form, which re-indented the pre-existing `catch` body — pulling `app-sidebar.tsx:131-132` into the patch as changed lines that no test executes. Those lines were never part of this fix, so the re-indent is reverted rather than papered over with a test for an unrelated error branch.

Measured locally against the merge base (v8 lcov, cross-referenced with the added lines of `git diff`):

```
app-sidebar.tsx               patch lines instrumented=3  missed=none
use-reminder-notifications.ts patch lines instrumented=2  missed=none
use-undoable-action.ts        patch lines instrumented=2  missed=none
note.tsx                      patch lines instrumented=1  missed=none
PATCH COVERAGE: 8/8 = 100.0%
```

No `codecov.yml` or ignore list was touched.

## Backward compatibility

Lint-rule and copy change only — no schema, IPC contract, settings, or sync shape is touched, and the new English keys are additive, so older locale bundles keep falling back to English exactly as they do for the 120 keys already missing per locale.
