### PR TITLE
fix(tooling): serialise the Electron binary install and swap it in atomically

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -94,6 +94,12 @@ jobs:
       - name: Test e2e keychain cleanup tooling
         run: node --test apps/desktop/scripts/purge-e2e-keychain.test.mjs
 
+      # Guards the install lock + atomic swap that keep a concurrent Electron
+      # install from breaking unrelated suites at `require('electron')` time.
+      # Runs fully offline against a fixture zip.
+      - name: Test Electron binary installer concurrency
+        run: node --test apps/desktop/scripts/install-electron-binary.test.cjs
+
   unit:
     name: Unit & integration tests
     runs-on: ubuntu-latest

--- a/apps/desktop/scripts/install-electron-binary.cjs
+++ b/apps/desktop/scripts/install-electron-binary.cjs
@@ -9,6 +9,17 @@ const path = require('path')
 const electronDir = process.argv[2]
 const officialMirror = 'https://github.com/electron/electron/releases/download/'
 
+// Several processes can reach this script at once on one machine: `ensure-native.sh`
+// (predev / prebuild / pretest:e2e / rebuild:electron) and every Playwright worker,
+// which falls back to installing when `path.txt` is missing (see
+// tests/e2e/utils/electron-lifecycle.ts, `workers: 2` locally). They all target the
+// same `dist/`, so the install is serialised with a lock and swapped into place
+// atomically — otherwise concurrent `unzip`s collide and readers of the package
+// (`require('electron')` throws without `path.txt` + `dist/`) observe a half-written
+// tree and fail with "Electron failed to install correctly".
+const LOCK_POLL_MS = 250
+const LOCK_STALE_MS = 10 * 60 * 1000
+
 if (!electronDir) {
   console.error('Usage: install-electron-binary.cjs <electron-package-dir>')
   process.exit(2)
@@ -92,6 +103,106 @@ function validateChecksum(zipPath, expectedHash) {
   }
 }
 
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false
+  }
+
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    // EPERM means the process exists but belongs to another user.
+    return error.code === 'EPERM'
+  }
+}
+
+function isLockAbandoned(lockPath) {
+  let holder
+  try {
+    holder = JSON.parse(fs.readFileSync(lockPath, 'utf8'))
+  } catch {
+    // Unreadable or torn lock file: treat as abandoned rather than wait forever.
+    return true
+  }
+
+  if (isProcessAlive(holder.pid)) {
+    // Backstop for a live-but-wedged holder, so this can never deadlock.
+    return Date.now() - holder.startedAt > LOCK_STALE_MS
+  }
+
+  return true
+}
+
+/**
+ * Take an exclusive install lock for `electronDir`. Returns `{ contended }` so the
+ * caller can skip a redundant download when another process just did the work.
+ * Recovers from a lock left behind by a killed process.
+ */
+function acquireInstallLock(lockPath) {
+  let contended = false
+
+  for (;;) {
+    try {
+      const handle = fs.openSync(lockPath, 'wx')
+      fs.writeFileSync(handle, JSON.stringify({ pid: process.pid, startedAt: Date.now() }))
+      fs.closeSync(handle)
+      return { contended }
+    } catch (error) {
+      if (error.code !== 'EEXIST') {
+        throw error
+      }
+    }
+
+    if (!contended) {
+      contended = true
+      console.log('[electron] another install is in progress — waiting for it to finish')
+    }
+
+    if (isLockAbandoned(lockPath)) {
+      console.log('[electron] clearing an abandoned install lock')
+      fs.rmSync(lockPath, { force: true })
+      continue
+    }
+
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, LOCK_POLL_MS)
+  }
+}
+
+function releaseInstallLock(lockPath) {
+  fs.rmSync(lockPath, { force: true })
+}
+
+function hasValidInstall(distDir, pathFile, platformPath) {
+  try {
+    return (
+      fs.readFileSync(pathFile, 'utf8').trim() === platformPath &&
+      fs.existsSync(path.join(distDir, platformPath))
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Remove staging/retired trees from a previous run that was killed mid-install.
+ * Safe because the caller holds the install lock.
+ */
+function sweepStaleWorkDirs(electronDir) {
+  let entries = []
+  try {
+    entries = fs.readdirSync(electronDir)
+  } catch {
+    return
+  }
+
+  for (const entry of entries) {
+    if (entry.startsWith('.dist-staging-') || entry.startsWith('.dist-retired-')) {
+      fs.rmSync(path.join(electronDir, entry), { recursive: true, force: true })
+    }
+  }
+}
+
 function main() {
   const platform = process.env.npm_config_platform || process.platform
   const arch = getArch(platform)
@@ -107,33 +218,63 @@ function main() {
     throw new Error(`No Electron checksum found for ${zipName}`)
   }
 
-  fs.rmSync(distDir, { recursive: true, force: true })
-  fs.rmSync(pathFile, { force: true })
-
-  console.log(`[electron] installing ${version} for ${platform}-${arch} from ${officialMirror}`)
-
   const executablePath = path.join(distDir, platformPath)
+  const lockPath = path.join(electronDir, '.install-electron-binary.lock')
+  // Staging and retired trees live beside `dist/` so the swap below is a rename on
+  // the same filesystem; `os.tmpdir()` can be a different device (EXDEV).
+  const stagingDir = path.join(electronDir, `.dist-staging-${process.pid}`)
+  const retiredDir = path.join(electronDir, `.dist-retired-${process.pid}`)
+
+  const { contended } = acquireInstallLock(lockPath)
+
   try {
-    downloadArtifact(`${officialMirror}v${version}/${zipName}`, zipPath)
-    validateChecksum(zipPath, expectedHash)
-    extractArtifact(zipPath, distDir)
-
-    const typeDefinitionsPath = path.join(distDir, 'electron.d.ts')
-    if (fs.existsSync(typeDefinitionsPath)) {
-      const targetTypeDefinitionsPath = path.join(electronDir, 'electron.d.ts')
-      fs.rmSync(targetTypeDefinitionsPath, { force: true })
-      fs.renameSync(typeDefinitionsPath, targetTypeDefinitionsPath)
+    // Another process held the lock and may have just completed the install.
+    if (contended && hasValidInstall(distDir, pathFile, platformPath)) {
+      console.log(`[electron] ${version} already installed by a concurrent run: ${executablePath}`)
+      return
     }
 
-    fs.writeFileSync(pathFile, platformPath)
+    sweepStaleWorkDirs(electronDir)
 
-    if (!fs.existsSync(executablePath)) {
-      throw new Error(`Electron binary was not found after install: ${executablePath}`)
+    console.log(`[electron] installing ${version} for ${platform}-${arch} from ${officialMirror}`)
+
+    try {
+      downloadArtifact(`${officialMirror}v${version}/${zipName}`, zipPath)
+      validateChecksum(zipPath, expectedHash)
+      extractArtifact(zipPath, stagingDir)
+
+      // Validate the staged tree before the live `dist/` is touched at all, so a
+      // failed download can never leave the package worse than it started.
+      const stagedExecutablePath = path.join(stagingDir, platformPath)
+      if (!fs.existsSync(stagedExecutablePath)) {
+        throw new Error(`Electron binary was not found after install: ${stagedExecutablePath}`)
+      }
+
+      const typeDefinitionsPath = path.join(stagingDir, 'electron.d.ts')
+      if (fs.existsSync(typeDefinitionsPath)) {
+        const targetTypeDefinitionsPath = path.join(electronDir, 'electron.d.ts')
+        fs.rmSync(targetTypeDefinitionsPath, { force: true })
+        fs.renameSync(typeDefinitionsPath, targetTypeDefinitionsPath)
+      }
+
+      // Swap: two renames, so the window where `dist/` is absent is microseconds
+      // instead of the whole download+extract. `path.txt` is the commit marker and
+      // is written last — and never removed — so a reader either sees the previous
+      // install or the new one.
+      if (fs.existsSync(distDir)) {
+        fs.renameSync(distDir, retiredDir)
+      }
+      fs.renameSync(stagingDir, distDir)
+      fs.writeFileSync(pathFile, platformPath)
+
+      console.log(`[electron] installed ${version} for ${platform}-${arch}: ${executablePath}`)
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+      fs.rmSync(stagingDir, { recursive: true, force: true })
+      fs.rmSync(retiredDir, { recursive: true, force: true })
     }
-
-    console.log(`[electron] installed ${version} for ${platform}-${arch}: ${executablePath}`)
   } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true })
+    releaseInstallLock(lockPath)
   }
 }
 

--- a/apps/desktop/scripts/install-electron-binary.cjs
+++ b/apps/desktop/scripts/install-electron-binary.cjs
@@ -269,11 +269,13 @@ function main() {
 
       console.log(`[electron] installed ${version} for ${platform}-${arch}: ${executablePath}`)
     } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true })
       fs.rmSync(stagingDir, { recursive: true, force: true })
       fs.rmSync(retiredDir, { recursive: true, force: true })
     }
   } finally {
+    // `tempDir` is created before the lock, so it must be cleaned up on the
+    // early-return path too.
+    fs.rmSync(tempDir, { recursive: true, force: true })
     releaseInstallLock(lockPath)
   }
 }

--- a/apps/desktop/scripts/install-electron-binary.test.cjs
+++ b/apps/desktop/scripts/install-electron-binary.test.cjs
@@ -96,9 +96,11 @@ function buildElectronDir(root, fixtureZip) {
   return dir
 }
 
-function runInstaller(electronDir, binDir) {
+function runInstaller(electronDir, binDir, tmpDir) {
   return childProcess.spawn(process.execPath, [INSTALLER, electronDir], {
-    env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+    // A dedicated TMPDIR makes the installer's scratch dirs observable, so a leak
+    // on any exit path is caught rather than hidden in the shared system tmp.
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH}`, TMPDIR: tmpDir },
     stdio: ['ignore', 'pipe', 'pipe']
   })
 }
@@ -126,11 +128,17 @@ async function withFixture(run, options) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-install-electron-test-'))
   try {
     const fixtureZip = buildFixtureZip(root)
+    const electronDir = buildElectronDir(root, fixtureZip)
+    const defaultBinDir = buildCurlShim(root, fixtureZip, options)
+    const tmpDir = path.join(root, 'tmp')
+    fs.mkdirSync(tmpDir)
+
     return await run({
       root,
       fixtureZip,
-      electronDir: buildElectronDir(root, fixtureZip),
-      binDir: buildCurlShim(root, fixtureZip, options)
+      electronDir,
+      tmpDir,
+      install: (binDir = defaultBinDir) => runInstaller(electronDir, binDir, tmpDir)
     })
   } finally {
     fs.rmSync(root, { recursive: true, force: true })
@@ -141,8 +149,8 @@ test(
   'a reinstall never exposes a half-written install to concurrent readers',
   { skip: unsupported },
   async () => {
-    await withFixture(async ({ electronDir, binDir }) => {
-      const seed = await settled(runInstaller(electronDir, binDir))
+    await withFixture(async ({ electronDir, install }) => {
+      const seed = await settled(install())
       assert.equal(seed.code, 0, seed.output)
       assert.ok(readerSeesValidInstall(electronDir))
 
@@ -153,7 +161,7 @@ test(
         if (!readerSeesValidInstall(electronDir)) broken++
       }, 5)
 
-      const reinstall = await settled(runInstaller(electronDir, binDir))
+      const reinstall = await settled(install())
       clearInterval(poll)
 
       assert.equal(reinstall.code, 0, reinstall.output)
@@ -167,11 +175,8 @@ test(
   'concurrent installs are serialised instead of corrupting dist/',
   { skip: unsupported },
   async () => {
-    await withFixture(async ({ electronDir, binDir }) => {
-      const [first, second] = await Promise.all([
-        settled(runInstaller(electronDir, binDir)),
-        settled(runInstaller(electronDir, binDir))
-      ])
+    await withFixture(async ({ electronDir, tmpDir, install }) => {
+      const [first, second] = await Promise.all([settled(install()), settled(install())])
 
       assert.equal(first.code, 0, first.output)
       assert.equal(second.code, 0, second.output)
@@ -181,6 +186,10 @@ test(
       const combined = `${first.output}${second.output}`
       assert.match(combined, /already installed by a concurrent run/)
       assert.equal(combined.match(/installing 0\.0\.0-test/g).length, 1)
+
+      // The waiter returns before the download block, so its scratch dir has to be
+      // cleaned up on that early-return path too.
+      assert.deepEqual(fs.readdirSync(tmpDir), [], 'an install leaked a scratch directory')
     })
   }
 )
@@ -189,12 +198,12 @@ test(
   'a lock left by a killed process is reclaimed, not waited on forever',
   { skip: unsupported },
   async () => {
-    await withFixture(async ({ electronDir, binDir }) => {
+    await withFixture(async ({ electronDir, install }) => {
       // A pid that cannot be running: recorded far in the past and never alive.
       const lockPath = path.join(electronDir, '.install-electron-binary.lock')
       fs.writeFileSync(lockPath, JSON.stringify({ pid: 2 ** 30, startedAt: 0 }))
 
-      const result = await settled(runInstaller(electronDir, binDir))
+      const result = await settled(install())
 
       assert.equal(result.code, 0, result.output)
       assert.match(result.output, /clearing an abandoned install lock/)
@@ -205,13 +214,13 @@ test(
 )
 
 test('a failed download leaves the previous install intact', { skip: unsupported }, async () => {
-  await withFixture(async ({ root, electronDir, fixtureZip }) => {
+  await withFixture(async ({ root, electronDir, fixtureZip, tmpDir, install }) => {
     const workingBin = buildCurlShim(path.join(root, 'ok'), fixtureZip)
-    const seed = await settled(runInstaller(electronDir, workingBin))
+    const seed = await settled(install(workingBin))
     assert.equal(seed.code, 0, seed.output)
 
     const failingBin = buildCurlShim(path.join(root, 'bad'), fixtureZip, { fail: true })
-    const failed = await settled(runInstaller(electronDir, failingBin))
+    const failed = await settled(install(failingBin))
 
     assert.notEqual(failed.code, 0, 'expected the install to fail')
     assert.ok(readerSeesValidInstall(electronDir), 'a failed install destroyed the good one')

--- a/apps/desktop/scripts/install-electron-binary.test.cjs
+++ b/apps/desktop/scripts/install-electron-binary.test.cjs
@@ -1,0 +1,229 @@
+// Guards the concurrency behaviour of install-electron-binary.cjs.
+//
+// Several processes reach that script at once on one machine (`ensure-native.sh`
+// from predev/prebuild/pretest:e2e, plus every Playwright worker via
+// tests/e2e/utils/electron-lifecycle.ts). They all target the same `dist/`, and
+// `require('electron')` throws "Electron failed to install correctly" whenever
+// `path.txt` or `dist/` is missing — so a half-written install fails unrelated
+// vitest suites at import time.
+//
+// These tests drive the real script end to end, offline: a `curl` shim earlier on
+// PATH serves a fixture zip, and the real `unzip` extracts it.
+
+const assert = require('node:assert/strict')
+const test = require('node:test')
+const childProcess = require('node:child_process')
+const crypto = require('node:crypto')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const INSTALLER = path.join(__dirname, 'install-electron-binary.cjs')
+const VERSION = '0.0.0-test'
+const CURL_DELAY_MS = 300
+
+function hasCommand(command) {
+  return childProcess.spawnSync('sh', ['-c', `command -v ${command}`]).status === 0
+}
+
+// The shim is a shell script and the swap relies on POSIX rename semantics.
+const unsupported =
+  process.platform === 'win32' || !hasCommand('zip') || !hasCommand('unzip')
+    ? 'requires a POSIX shell with zip and unzip'
+    : false
+
+function platformPathFor(platform) {
+  switch (platform) {
+    case 'mas':
+    case 'darwin':
+      return 'Electron.app/Contents/MacOS/Electron'
+    case 'win32':
+      return 'electron.exe'
+    default:
+      return 'electron'
+  }
+}
+
+const platformPath = platformPathFor(process.platform)
+const zipName = `electron-v${VERSION}-${process.platform}-${process.arch}.zip`
+
+/** Build a fixture big enough that extraction takes real time. */
+function buildFixtureZip(root) {
+  const stage = path.join(root, 'stage')
+  const target = path.join(stage, platformPath)
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, Buffer.alloc(2 * 1024 * 1024, 7))
+  for (let i = 0; i < 20; i++) {
+    fs.writeFileSync(path.join(stage, `resource-${i}.pak`), Buffer.alloc(128 * 1024, i))
+  }
+
+  const zipPath = path.join(root, zipName)
+  childProcess.execFileSync('zip', ['-q', '-r', zipPath, '.'], { cwd: stage })
+  return zipPath
+}
+
+/** A `curl` earlier on PATH that serves the fixture instead of hitting GitHub. */
+function buildCurlShim(root, fixtureZip, { fail = false } = {}) {
+  const binDir = path.join(root, 'bin')
+  fs.mkdirSync(binDir, { recursive: true })
+  const shim = path.join(binDir, 'curl')
+  fs.writeFileSync(
+    shim,
+    `#!/bin/sh
+out=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--output" ]; then out="$a"; fi
+  prev="$a"
+done
+sleep ${CURL_DELAY_MS / 1000}
+${fail ? 'echo "curl: (22) simulated download failure" >&2; exit 22' : 'cp ' + JSON.stringify(fixtureZip) + ' "$out"'}
+`
+  )
+  fs.chmodSync(shim, 0o755)
+  return binDir
+}
+
+function buildElectronDir(root, fixtureZip) {
+  const dir = path.join(root, 'electron-pkg')
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: 'electron', version: VERSION })
+  )
+  const hash = crypto.createHash('sha256').update(fs.readFileSync(fixtureZip)).digest('hex')
+  fs.writeFileSync(path.join(dir, 'checksums.json'), JSON.stringify({ [zipName]: hash }))
+  return dir
+}
+
+function runInstaller(electronDir, binDir) {
+  return childProcess.spawn(process.execPath, [INSTALLER, electronDir], {
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+}
+
+function settled(child) {
+  return new Promise((resolve) => {
+    let output = ''
+    child.stdout.on('data', (chunk) => (output += chunk))
+    child.stderr.on('data', (chunk) => (output += chunk))
+    child.on('close', (code) => resolve({ code, output }))
+  })
+}
+
+/** The check `ensure-native.sh` and `node_modules/electron/index.js` both perform. */
+function readerSeesValidInstall(electronDir) {
+  try {
+    const relativePath = fs.readFileSync(path.join(electronDir, 'path.txt'), 'utf8').trim()
+    return relativePath ? fs.existsSync(path.join(electronDir, 'dist', relativePath)) : false
+  } catch {
+    return false
+  }
+}
+
+async function withFixture(run, options) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-install-electron-test-'))
+  try {
+    const fixtureZip = buildFixtureZip(root)
+    return await run({
+      root,
+      fixtureZip,
+      electronDir: buildElectronDir(root, fixtureZip),
+      binDir: buildCurlShim(root, fixtureZip, options)
+    })
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test(
+  'a reinstall never exposes a half-written install to concurrent readers',
+  { skip: unsupported },
+  async () => {
+    await withFixture(async ({ electronDir, binDir }) => {
+      const seed = await settled(runInstaller(electronDir, binDir))
+      assert.equal(seed.code, 0, seed.output)
+      assert.ok(readerSeesValidInstall(electronDir))
+
+      let samples = 0
+      let broken = 0
+      const poll = setInterval(() => {
+        samples++
+        if (!readerSeesValidInstall(electronDir)) broken++
+      }, 5)
+
+      const reinstall = await settled(runInstaller(electronDir, binDir))
+      clearInterval(poll)
+
+      assert.equal(reinstall.code, 0, reinstall.output)
+      assert.ok(samples > 20, `expected a meaningful sample window, got ${samples}`)
+      assert.equal(broken, 0, `reader saw a broken install in ${broken}/${samples} samples`)
+    })
+  }
+)
+
+test(
+  'concurrent installs are serialised instead of corrupting dist/',
+  { skip: unsupported },
+  async () => {
+    await withFixture(async ({ electronDir, binDir }) => {
+      const [first, second] = await Promise.all([
+        settled(runInstaller(electronDir, binDir)),
+        settled(runInstaller(electronDir, binDir))
+      ])
+
+      assert.equal(first.code, 0, first.output)
+      assert.equal(second.code, 0, second.output)
+      assert.ok(readerSeesValidInstall(electronDir), 'dist/ was left unusable')
+
+      // Exactly one process should have done the work; the other waits and no-ops.
+      const combined = `${first.output}${second.output}`
+      assert.match(combined, /already installed by a concurrent run/)
+      assert.equal(combined.match(/installing 0\.0\.0-test/g).length, 1)
+    })
+  }
+)
+
+test(
+  'a lock left by a killed process is reclaimed, not waited on forever',
+  { skip: unsupported },
+  async () => {
+    await withFixture(async ({ electronDir, binDir }) => {
+      // A pid that cannot be running: recorded far in the past and never alive.
+      const lockPath = path.join(electronDir, '.install-electron-binary.lock')
+      fs.writeFileSync(lockPath, JSON.stringify({ pid: 2 ** 30, startedAt: 0 }))
+
+      const result = await settled(runInstaller(electronDir, binDir))
+
+      assert.equal(result.code, 0, result.output)
+      assert.match(result.output, /clearing an abandoned install lock/)
+      assert.ok(readerSeesValidInstall(electronDir))
+      assert.equal(fs.existsSync(lockPath), false, 'lock file was not released')
+    })
+  }
+)
+
+test('a failed download leaves the previous install intact', { skip: unsupported }, async () => {
+  await withFixture(async ({ root, electronDir, fixtureZip }) => {
+    const workingBin = buildCurlShim(path.join(root, 'ok'), fixtureZip)
+    const seed = await settled(runInstaller(electronDir, workingBin))
+    assert.equal(seed.code, 0, seed.output)
+
+    const failingBin = buildCurlShim(path.join(root, 'bad'), fixtureZip, { fail: true })
+    const failed = await settled(runInstaller(electronDir, failingBin))
+
+    assert.notEqual(failed.code, 0, 'expected the install to fail')
+    assert.ok(readerSeesValidInstall(electronDir), 'a failed install destroyed the good one')
+    assert.equal(
+      fs.existsSync(path.join(electronDir, '.install-electron-binary.lock')),
+      false,
+      'lock file survived a failed install'
+    )
+    assert.deepEqual(
+      fs.readdirSync(electronDir).filter((entry) => entry.startsWith('.dist-')),
+      [],
+      'staging directories were left behind'
+    )
+  })
+})

--- a/apps/docs/src/contribute/testing.md
+++ b/apps/docs/src/contribute/testing.md
@@ -211,6 +211,18 @@ directory. If CI still reaches the launcher with a missing `path.txt` or executa
 runs the same installer helper once, trusts the helper's validation, and passes the platform-specific
 package executable path directly instead of importing `electron/index.js`.
 
+Because several processes can reach that helper at once on one machine — `ensure-native.sh` from
+`predev` / `prebuild` / `pretest:e2e`, plus each Playwright worker (`workers: 2` locally) — the
+install is serialised with a lock file next to the `electron` package, and only one process
+downloads: the others wait and reuse the finished install. The archive is extracted into a staging
+directory beside `dist/` and swapped in with a rename, and `path.txt` is written last and never
+deleted, so a concurrent `require('electron')` always sees either the previous install or the new
+one. Without that, an install in flight makes unrelated Vitest suites fail at import time with
+`Electron failed to install correctly`, which reads like a code regression rather than an
+environment problem. A failed download now also leaves an existing install untouched. The behaviour
+is covered by `node --test apps/desktop/scripts/install-electron-binary.test.cjs`, which runs
+offline against a fixture archive.
+
 Release builds create one staged dependency tree per macOS architecture. Build x64 on an Intel
 runner and arm64 on an Apple Silicon runner; do not build `--x64 --arm64` from the same staged
 package, because native modules are rebuilt for one target architecture at a time.


### PR DESCRIPTION
Closes #1343. Part of epic #987 (memory/CPU audit 2026-08).

## What was wrong

`apps/desktop/scripts/install-electron-binary.cjs` wiped the shared install before it had a replacement, and nothing serialised concurrent runs:

```js
fs.rmSync(distDir, { recursive: true, force: true })
fs.rmSync(pathFile, { force: true })
// ...seconds of download + unzip...
extractArtifact(zipPath, distDir)
fs.writeFileSync(pathFile, platformPath)   // written last
```

`node_modules/electron/index.js` throws `Electron failed to install correctly` at `require()` time whenever `path.txt` or `dist/` is missing. So for the whole download+extract window, any Vitest file that loads real `electron` — directly or transitively via `electron-log` — dies during module setup and the whole file is reported failed. Files that stub `electron` pass, which is why the failure set looks arbitrary and reads as a logic regression.

**The racer, since the issue asked for it to be nailed down first.** The filer's guess that worktrees share one Electron cache is wrong: every worktree has its own `node_modules/.pnpm/electron@43.1.1/node_modules/electron/dist` (verified — distinct inodes, link count 1). The real second entrant is in-process and in-repo:

- `apps/desktop/tests/e2e/utils/electron-lifecycle.ts:49-89` — `getElectronExecutablePath()` is itself an unlocked check-then-act that shells out to this same installer when `path.txt` is missing, and it runs **per Playwright worker** (`apps/desktop/config/playwright.config.ts:24`, `workers: 2` locally). One `pnpm test:e2e` is therefore enough to put two installers on the same `dist/`.
- `ensure-native.sh` reaches the same script from `predev` / `prebuild` / `pretest:e2e` / `rebuild:electron`, so a parallel `pnpm dev` is a second route.

Confirmed by reproduction rather than by reading. A harness drives the real script offline (fixture zip served by a `curl` shim earlier on `PATH`, real `unzip`), against `origin/main`:

- one reinstall, polled by a concurrent reader every 5 ms → **108 of 119 samples saw a broken install**
- two concurrent installers → **both exit 1**, and `dist/` is left permanently unusable (`unzip: ... File exists`, `write error`)

## What changed

One file does the work — `install-electron-binary.cjs`:

- **Serialised.** An exclusive `O_EXCL` lock file next to the `electron` package. The loser waits, then re-checks under the lock and no-ops instead of re-downloading. Stale locks are reclaimed: the holder's pid is probed with `process.kill(pid, 0)`, with a 10-minute age backstop for a live-but-wedged holder, so it cannot deadlock.
- **Atomic.** The archive extracts into a `.dist-staging-<pid>` sibling (same filesystem — `os.tmpdir()` can be a different device, EXDEV), is validated there before the live `dist/` is touched at all, then swapped in with two renames. `path.txt` is the commit marker: written last, and never deleted. A reader now sees either the previous install or the new one.
- Scratch dirs left by a killed run are swept under the lock; the pre-lock temp dir is cleaned on the early-return path too.

**Deliberately not done:**

- **No `flock` in `ensure-native.sh`.** macOS ships no `flock` binary, and once the installer is itself locked and idempotent the shell-level check-then-act is harmless — the second entrant simply waits and no-ops. Same reasoning for `electron-lifecycle.ts`: both workers may spawn the installer, one installs, the other returns the finished path. Putting the lock at the single choke point both callers already go through keeps this to one file and works on every platform.
- **`path.txt` is not written before the swap**, contrary to the issue's suggestion. Readers check `path.txt` *and* `dist/<path>`, so publishing the marker early would just move the broken window rather than close it.
- The pre-existing `dist/` absent after a fresh `pnpm install` (see below) is out of scope.

## How it was proven

New `apps/desktop/scripts/install-electron-binary.test.cjs` — 4 tests, fully offline, driving the real script through a `curl` shim and real `unzip`/renames.

Per the brief, source-only revert (`git checkout origin/main -- apps/desktop/scripts/install-electron-binary.cjs`, test file untouched):

| | tests | pass | fail |
|---|---|---|---|
| before (`origin/main` source) | 4 | **0** | **4** |
| after (fix restored) | 4 | **4** | **0** |

The headline before-failure: `reader saw a broken install in 121/168 samples`.

Also mutation-tested rather than assumed: removing just the early-return scratch cleanup turns the concurrency test red with `an install leaked a scratch directory` (3 pass / 1 fail), then green again on restore.

## Verification

```
node --test apps/desktop/scripts/install-electron-binary.test.cjs
  → tests 4, pass 4, fail 0

pnpm exec eslint apps/desktop/scripts/install-electron-binary{,.test}.cjs
  → 0 errors (both files match an ignore pattern)

pnpm exec prettier --check <changed files>   → All matched files use Prettier code style
pnpm docs:impact --base origin/main --strict → docs impact: covered
pnpm docs:build                              → build complete in 3.54s
git diff --check                             → clean
```

No TypeScript changed, so `typecheck:web` / `typecheck:node` are not applicable. Wired into CI next to the existing tooling-script tests (`.github/workflows/desktop-ci.yml`), and it skips itself where `zip`/`unzip`/POSIX `sh` are unavailable.

**Not verified here:** a real Electron download. This sandbox cannot reach the GitHub release mirror (`curl: (56) Connection died`) — `origin/main`'s script fails identically on the same box, so that is environmental and not a regression. The swap is a directory `rename`, which does not touch contents, permissions, or the symlinks inside `Electron.app`, but a real `pnpm dev` on an unrestricted network is worth one manual pass before this leaves draft.

## Backward compatibility

Tooling only — no runtime, IPC, schema, sync, or settings surface is touched, and the installed layout (`dist/` + `path.txt`) is byte-for-byte what it was, so existing worktrees and CI caches keep working unchanged.
