### PR TITLE
fix(desktop): unbreak the two test files that predate the test typecheck gate

### DIFF
--- a/apps/desktop/src/main/agent/runtime/__tests__/runtime-cancel-before-handle.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/runtime-cancel-before-handle.test.ts
@@ -109,7 +109,7 @@ describe('cancelling a turn before the backend produces its run handle', () => {
 
     const backend = new LocalOpenAICompatibleBackend({
       getSettings: async () => ({
-        preset: 'lmstudio',
+        preset: 'lm_studio',
         baseUrl: 'http://localhost:1234/v1',
         model: MODEL,
         apiKeyConfigured: false,

--- a/apps/desktop/src/main/sync/crdt-queue.test.ts
+++ b/apps/desktop/src/main/sync/crdt-queue.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
-import { CrdtUpdateQueue } from './crdt-queue'
+import { CrdtUpdateQueue, type CrdtUpdateQueueOptions } from './crdt-queue'
 import { SyncServerError } from './http-client'
 
 vi.mock('../lib/logger', () => ({
@@ -310,7 +310,9 @@ describe('CrdtUpdateQueue', () => {
   })
 
   it('keeps every buffered update when recording notes for replay throws', () => {
-    const persistUnflushed = vi.fn(() => {
+    // Typed off the real option so the throwing implementation does not narrow the
+    // mock's return type to `never` and lock out the `undefined` restore below.
+    const persistUnflushed = vi.fn<NonNullable<CrdtUpdateQueueOptions['persistUnflushed']>>(() => {
       throw new Error('disk full')
     })
     const queue = new CrdtUpdateQueue({ persistUnflushed })


### PR DESCRIPTION
`main` is red on **Static checks**. Not an issue fix — a gate/merge-order collision.

## What was wrong

#1371 added `typecheck:test` (`tsconfig.test.node.json` + `tsconfig.test.web.json`, ~799 desktop test files, plus the CI steps). Two test files that merged **before** the gate existed have never been compiled by anything, and they do not compile:

```
src/main/agent/runtime/__tests__/runtime-cancel-before-handle.test.ts(111,32): error TS2322:
  Type '"lmstudio"' is not assignable to type '"custom" | "ollama" | "lm_studio" | "llama_cpp"'.
  Did you mean '"lm_studio"'?
src/main/sync/crdt-queue.test.ts(329,47): error TS2322:
  Type 'undefined' is not assignable to type 'never'.
```

Those are the only two errors in either project — `typecheck:test:web` is already clean.

**1. `runtime-cancel-before-handle.test.ts:112`** (from #1349, issue #1332). A plain typo in the fake local-provider settings:

```ts
const backend = new LocalOpenAICompatibleBackend({
  getSettings: async () => ({
    preset: 'lmstudio',   // not a member of AgentLocalProviderPresetSchema
```

`AgentLocalProviderPresetSchema` is `z.enum(['ollama', 'lm_studio', 'llama_cpp', 'custom'])`. The mock was building a settings object the real IPC contract would reject.

**2. `crdt-queue.test.ts:313`** (from #1355, issue #1319). The mock's implementation only ever throws, so TypeScript infers its return type as `never`:

```ts
const persistUnflushed = vi.fn(() => {
  throw new Error('disk full')
})
...
persistUnflushed.mockImplementation(() => undefined)   // undefined -> never
```

The final line restores a non-throwing implementation before `queue.stop()`, so the teardown does not blow up. Correct intent, untypeable inference.

## What changed

- `preset: 'lmstudio'` → `preset: 'lm_studio'`. The backend only ever branches on `settings.preset === 'ollama'` (`local-openai-compatible-backend.ts:142`; the only other read is the probe cache key at :315), so both the old invalid value and the corrected one take the identical OpenAI-compatible path. The test asserts exactly what it asserted before.
- `persistUnflushed` is now typed off the real option instead of inferred:
  ```ts
  vi.fn<NonNullable<CrdtUpdateQueueOptions['persistUnflushed']>>(() => { throw new Error('disk full') })
  ```
  which is `(noteIds: string[]) => void` — the same signature `CrdtUpdateQueue` actually calls. The throwing body is unchanged, so the test still drives the "persisting the replay list throws" path.

Deliberately **not** done:

- No `as any`, no `@ts-expect-error`, no loosened assertions. Both files still assert exactly what they did.
- **Neither file was added to the `exclude` backlog** in the new tsconfigs. That list is documented in-file as shrink-only ("Nothing new belongs in this list — fix a file's errors, delete its line, and the ratchet tightens"), and growing it on the gate's first day would defeat it.
- No source changes. Both defects are in test code.

## How it was proven

Same two files, before and after, same commands:

| | `typecheck:test:node` | `vitest --project main` (both files) |
|---|---|---|
| origin/main test files | **2 errors** | 18 passed (18) |
| this branch | **0 errors** | 18 passed (18) |

The before column was produced by restoring only the two test files from `origin/main` on top of this commit and re-running, then restoring them — so the test-count comparison is apples to apples. The point of the fix is that behaviour is *unchanged*: same 18 tests, same assertions, they simply now compile.

## Verification

```
apps/desktop $ tsc --noEmit -p tsconfig.test.node.json --composite false   # clean
apps/desktop $ tsc --noEmit -p tsconfig.test.web.json  --composite false   # clean
apps/desktop $ tsc --noEmit -p tsconfig.node.json      --composite false   # clean
apps/desktop $ tsc --noEmit -p tsconfig.web.json       --composite false   # clean
$ vitest run --project main crdt-queue.test.ts runtime-cancel-before-handle.test.ts
  Test Files  2 passed (2) / Tests  18 passed (18)
$ eslint <both files>   # 0 errors (both are matched by an ignore pattern — see below)
$ git diff --check      # clean
```

## The gap that let this through

#1371 built its exclude list by running tsc over the test suite at the time it was written. #1349 and #1355 merged inside the window between that measurement and #1371 landing. Their test files were therefore in neither set: not in the backlog (the list was already frozen) and not passing (nobody had ever compiled them). The gate's very first run on `main` was the first time either file met a typechecker.

The structural cause is that the covered set is effectively an **allow-list snapshot** — "everything except this frozen list" is only sound if the list and the tree are measured at the same instant, and a merge queue guarantees they are not. Worth a follow-up (not done here, out of scope for unblocking `main`): make the backlog a genuine deny-list that is *validated* rather than assumed — e.g. a CI step that fails if a path in `exclude` now compiles clean (forcing the ratchet to tighten) and, more to the point here, one that fails if any excluded path no longer exists or if the exclude list is the only thing standing between a file and the gate. A cheaper version of the same protection: have the gate's own PR re-measure at merge time rather than at authoring time.

Separately worth noting, since it is the other half of why two broken test files sat on `main` unnoticed: **`*.test.ts` is matched by an eslint ignore pattern**, so test files get neither lint nor (until #1371) typecheck. `typecheck:test` is now the only static coverage they have.

## Backward compatibility

None at risk — the change is confined to two test files. No source, schema, contract, sync, or settings shape is touched.
