### PR TITLE
ci(desktop): cache the verified Electron release zip so E2E shards stop re-downloading it

### DIFF
--- a/.github/actions/cache-electron-binary/action.yml
+++ b/.github/actions/cache-electron-binary/action.yml
@@ -1,0 +1,47 @@
+name: Cache Electron binary
+description: >-
+  Reuse the Electron release zip that apps/desktop/scripts/install-electron-binary.cjs
+  downloads, so a runner that needs a real Electron runtime normally does no network
+  I/O for it. Without this every job — including all 16 "Electron E2E full" shards —
+  pulls ~115 MB from GitHub releases at the same moment, and the connection drops
+  ("curl: (56) Connection died") kill shards before a single test runs.
+
+  Safety: the installer treats a restored artifact as untrusted input. It hashes it
+  against the checksums.json shipped inside the electron npm package before extracting
+  anything, and falls back to a fresh download if it does not match — so a cache entry
+  planted from another branch is discarded, never executed. Requires actions/setup-node
+  to have run first (the version is resolved with node).
+
+runs:
+  using: composite
+  steps:
+    # The key has to move with the locked Electron version, or a future bump silently
+    # reuses the previous release's zip. Read it from pnpm-lock.yaml rather than
+    # apps/desktop/package.json, whose range ("^43.1.1") does not identify a build.
+    - name: Resolve the locked Electron version
+      id: electron
+      shell: bash
+      run: |
+        set -euo pipefail
+        version="$(node -e '
+          const lock = require("node:fs").readFileSync("pnpm-lock.yaml", "utf8")
+          const match = lock.match(/^ {2}electron@([0-9][^:(\s]*):/m)
+          if (!match) {
+            console.error("Could not resolve the Electron version from pnpm-lock.yaml")
+            process.exit(1)
+          }
+          process.stdout.write(match[1])
+        ')"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "MEMRY_ELECTRON_CACHE_DIR=$RUNNER_TEMP/electron-binary-cache" >> "$GITHUB_ENV"
+        echo "Caching the Electron $version binary for $RUNNER_OS/$RUNNER_ARCH"
+
+    # runner.os + runner.arch keep a macOS runner from ever restoring a linux-x64
+    # build; the zip is additionally named per platform+arch, so a wrongly restored
+    # entry would read as a miss rather than as the wrong binary. No restore-keys:
+    # a near-miss prefix has nothing usable in it.
+    - name: Restore the Electron binary cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/electron-binary-cache
+        key: electron-binary-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron.outputs.version }}

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -227,6 +227,9 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+      - name: Cache Electron binary
+        uses: ./.github/actions/cache-electron-binary
+
       - name: Install system dependencies
         run: |
           # GitHub runners ship Microsoft/Azure apt repos that intermittently 403
@@ -297,6 +300,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
+
+      - name: Cache Electron binary
+        uses: ./.github/actions/cache-electron-binary
 
       - name: Install dependencies
         env:
@@ -461,6 +467,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
+
+      - name: Cache Electron binary
+        uses: ./.github/actions/cache-electron-binary
 
       - name: Install system dependencies
         run: |

--- a/apps/desktop/scripts/install-electron-binary.cjs
+++ b/apps/desktop/scripts/install-electron-binary.cjs
@@ -20,6 +20,21 @@ const officialMirror = 'https://github.com/electron/electron/releases/download/'
 const LOCK_POLL_MS = 250
 const LOCK_STALE_MS = 10 * 60 * 1000
 
+// Every CI job that needs a real Electron runtime re-downloads the ~115 MB release
+// zip, and `Electron E2E full` fans out to 16 shards that all start at once — GitHub
+// releases regularly drops those connections ("curl: (56) Connection died, tried 5
+// times before giving up"), failing shards before a single test runs. When
+// MEMRY_ELECTRON_CACHE_DIR is set the verified zip is kept there between runs, so the
+// usual path does no network I/O at all. Unset (the default) behaves exactly as before.
+//
+// SECURITY: the artifact is an executable the job then runs, and on CI the cache is
+// shared with — and writable by — every branch. A restored zip is therefore never
+// trusted: it is copied into this run's scratch dir and hashed against the
+// `checksums.json` that ships inside the `electron` npm package, the same gate a fresh
+// download passes, before anything is extracted. Anything that does not match is
+// deleted and re-downloaded rather than failing the job.
+const cacheDir = process.env.MEMRY_ELECTRON_CACHE_DIR
+
 if (!electronDir) {
   console.error('Usage: install-electron-binary.cjs <electron-package-dir>')
   process.exit(2)
@@ -100,6 +115,54 @@ function validateChecksum(zipPath, expectedHash) {
   const actualHash = crypto.createHash('sha256').update(fs.readFileSync(zipPath)).digest('hex')
   if (actualHash !== expectedHash) {
     throw new Error(`Electron checksum mismatch: expected ${expectedHash}, got ${actualHash}`)
+  }
+}
+
+/** `fs.rmSync(..., { force: true })` still throws on e.g. ENOTDIR; cleanup must not. */
+function removeQuietly(target) {
+  try {
+    fs.rmSync(target, { force: true })
+  } catch {
+    // Nothing useful to do: the cache is advisory.
+  }
+}
+
+/**
+ * Copy a cached artifact into this run's scratch dir and verify it. Returns false —
+ * after discarding the entry — for anything missing, unreadable or tampered with, so
+ * the caller falls back to a fresh download instead of failing.
+ */
+function restoreFromCache(cachedZipPath, zipPath, expectedHash) {
+  if (!fs.existsSync(cachedZipPath)) {
+    return false
+  }
+
+  try {
+    // Copy first and hash the copy, so the bytes that get extracted are exactly the
+    // bytes that were verified even if the cache entry changes underneath us.
+    fs.copyFileSync(cachedZipPath, zipPath)
+    validateChecksum(zipPath, expectedHash)
+    return true
+  } catch (error) {
+    console.log(`[electron] discarding unusable cached artifact: ${error.message}`)
+    removeQuietly(zipPath)
+    removeQuietly(cachedZipPath)
+    return false
+  }
+}
+
+/** Best effort: a cache write must never be the reason an install fails. */
+function storeInCache(zipPath, cachedZipPath) {
+  const pendingPath = `${cachedZipPath}.${process.pid}.partial`
+
+  try {
+    fs.mkdirSync(path.dirname(cachedZipPath), { recursive: true })
+    fs.copyFileSync(zipPath, pendingPath)
+    // Publish with a rename so a concurrent reader never sees a half-copied zip.
+    fs.renameSync(pendingPath, cachedZipPath)
+  } catch (error) {
+    removeQuietly(pendingPath)
+    console.log(`[electron] could not cache the artifact: ${error.message}`)
   }
 }
 
@@ -213,6 +276,9 @@ function main() {
   const expectedHash = checksums[zipName]
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-electron-'))
   const zipPath = path.join(tempDir, zipName)
+  // Keyed by the exact zip name, so a version/platform/arch change can never reuse a
+  // stale artifact even if the cache entry itself was restored too loosely.
+  const cachedZipPath = cacheDir ? path.join(cacheDir, zipName) : null
 
   if (!expectedHash) {
     throw new Error(`No Electron checksum found for ${zipName}`)
@@ -236,11 +302,21 @@ function main() {
 
     sweepStaleWorkDirs(electronDir)
 
-    console.log(`[electron] installing ${version} for ${platform}-${arch} from ${officialMirror}`)
+    console.log(`[electron] installing ${version} for ${platform}-${arch}`)
 
     try {
-      downloadArtifact(`${officialMirror}v${version}/${zipName}`, zipPath)
-      validateChecksum(zipPath, expectedHash)
+      if (cachedZipPath && restoreFromCache(cachedZipPath, zipPath, expectedHash)) {
+        console.log(`[electron] reusing the cached ${zipName} from ${cacheDir}`)
+      } else {
+        console.log(`[electron] downloading ${zipName} from ${officialMirror}`)
+        downloadArtifact(`${officialMirror}v${version}/${zipName}`, zipPath)
+        validateChecksum(zipPath, expectedHash)
+
+        if (cachedZipPath) {
+          storeInCache(zipPath, cachedZipPath)
+        }
+      }
+
       extractArtifact(zipPath, stagingDir)
 
       // Validate the staged tree before the live `dist/` is touched at all, so a

--- a/apps/desktop/scripts/install-electron-binary.test.cjs
+++ b/apps/desktop/scripts/install-electron-binary.test.cjs
@@ -47,19 +47,31 @@ function platformPathFor(platform) {
 const platformPath = platformPathFor(process.platform)
 const zipName = `electron-v${VERSION}-${process.platform}-${process.arch}.zip`
 
+const GENUINE_BYTE = 7
+const POISONED_BYTE = 0xba
+
 /** Build a fixture big enough that extraction takes real time. */
-function buildFixtureZip(root) {
-  const stage = path.join(root, 'stage')
+function buildFixtureZip(root, { name = zipName, fillByte = GENUINE_BYTE } = {}) {
+  const stage = path.join(root, `stage-${fillByte}`)
   const target = path.join(stage, platformPath)
   fs.mkdirSync(path.dirname(target), { recursive: true })
-  fs.writeFileSync(target, Buffer.alloc(2 * 1024 * 1024, 7))
+  fs.writeFileSync(target, Buffer.alloc(2 * 1024 * 1024, fillByte))
   for (let i = 0; i < 20; i++) {
     fs.writeFileSync(path.join(stage, `resource-${i}.pak`), Buffer.alloc(128 * 1024, i))
   }
 
-  const zipPath = path.join(root, zipName)
+  const zipPath = path.join(root, name)
   childProcess.execFileSync('zip', ['-q', '-r', zipPath, '.'], { cwd: stage })
   return zipPath
+}
+
+function sha256(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+}
+
+/** The fill byte of the executable the installer actually left in `dist/`. */
+function installedExecutableByte(electronDir) {
+  return fs.readFileSync(path.join(electronDir, 'dist', platformPath))[0]
 }
 
 /** A `curl` earlier on PATH that serves the fixture instead of hitting GitHub. */
@@ -91,16 +103,23 @@ function buildElectronDir(root, fixtureZip) {
     path.join(dir, 'package.json'),
     JSON.stringify({ name: 'electron', version: VERSION })
   )
-  const hash = crypto.createHash('sha256').update(fs.readFileSync(fixtureZip)).digest('hex')
-  fs.writeFileSync(path.join(dir, 'checksums.json'), JSON.stringify({ [zipName]: hash }))
+  fs.writeFileSync(
+    path.join(dir, 'checksums.json'),
+    JSON.stringify({ [zipName]: sha256(fixtureZip) })
+  )
   return dir
 }
 
-function runInstaller(electronDir, binDir, tmpDir) {
+function runInstaller(electronDir, binDir, tmpDir, extraEnv) {
   return childProcess.spawn(process.execPath, [INSTALLER, electronDir], {
     // A dedicated TMPDIR makes the installer's scratch dirs observable, so a leak
     // on any exit path is caught rather than hidden in the shared system tmp.
-    env: { ...process.env, PATH: `${binDir}:${process.env.PATH}`, TMPDIR: tmpDir },
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      TMPDIR: tmpDir,
+      ...extraEnv
+    },
     stdio: ['ignore', 'pipe', 'pipe']
   })
 }
@@ -132,13 +151,18 @@ async function withFixture(run, options) {
     const defaultBinDir = buildCurlShim(root, fixtureZip, options)
     const tmpDir = path.join(root, 'tmp')
     fs.mkdirSync(tmpDir)
+    // Not pre-created: the installer has to create its own cache directory.
+    const cacheDir = path.join(root, 'cache')
 
     return await run({
       root,
       fixtureZip,
       electronDir,
       tmpDir,
-      install: (binDir = defaultBinDir) => runInstaller(electronDir, binDir, tmpDir)
+      cacheDir,
+      cachedZip: path.join(cacheDir, zipName),
+      install: (binDir = defaultBinDir, extraEnv) =>
+        runInstaller(electronDir, binDir, tmpDir, extraEnv)
     })
   } finally {
     fs.rmSync(root, { recursive: true, force: true })
@@ -234,5 +258,89 @@ test('a failed download leaves the previous install intact', { skip: unsupported
       [],
       'staging directories were left behind'
     )
+  })
+})
+
+// MEMRY_ELECTRON_CACHE_DIR keeps the release zip between runs so 16 parallel E2E
+// shards stop pulling ~115 MB each from GitHub releases (curl 56 "Connection died"
+// killed 4 of 16 shards before a single test ran). The cache is shared and writable
+// by any branch on CI, and the artifact is an executable the job then runs, so every
+// restored entry has to survive the same checksum gate as a fresh download.
+
+test('a cache miss downloads, installs, and populates the cache', { skip: unsupported }, async () => {
+  await withFixture(async ({ electronDir, fixtureZip, cacheDir, cachedZip, install }) => {
+    const result = await settled(install(undefined, { MEMRY_ELECTRON_CACHE_DIR: cacheDir }))
+
+    assert.equal(result.code, 0, result.output)
+    assert.match(result.output, /downloading electron-v0\.0\.0-test/)
+    assert.doesNotMatch(result.output, /reusing the cached/)
+    assert.ok(readerSeesValidInstall(electronDir))
+    assert.equal(fs.existsSync(cachedZip), true, 'the artifact was not cached')
+    assert.equal(sha256(cachedZip), sha256(fixtureZip), 'the cached artifact was corrupted')
+    assert.deepEqual(fs.readdirSync(cacheDir), [zipName], 'a partial cache write was left behind')
+  })
+})
+
+test('a cache hit installs with no network access at all', { skip: unsupported }, async () => {
+  await withFixture(async ({ root, electronDir, fixtureZip, cacheDir, install }) => {
+    const workingBin = buildCurlShim(path.join(root, 'ok'), fixtureZip)
+    const seed = await settled(install(workingBin, { MEMRY_ELECTRON_CACHE_DIR: cacheDir }))
+    assert.equal(seed.code, 0, seed.output)
+
+    // Any download at all now fails, so a passing install proves the cache was used.
+    const failingBin = buildCurlShim(path.join(root, 'bad'), fixtureZip, { fail: true })
+    const cached = await settled(install(failingBin, { MEMRY_ELECTRON_CACHE_DIR: cacheDir }))
+
+    assert.equal(cached.code, 0, cached.output)
+    assert.match(cached.output, /reusing the cached electron-v0\.0\.0-test/)
+    assert.doesNotMatch(cached.output, /downloading electron-v0\.0\.0-test/)
+    assert.ok(readerSeesValidInstall(electronDir))
+    assert.equal(installedExecutableByte(electronDir), GENUINE_BYTE)
+  })
+})
+
+test(
+  'a poisoned cache entry is rejected and never extracted',
+  { skip: unsupported },
+  async () => {
+    await withFixture(async ({ root, electronDir, fixtureZip, cacheDir, cachedZip, install }) => {
+      // A structurally valid zip carrying a different executable — exactly what a
+      // cache-poisoning branch would plant. Only the checksum tells them apart.
+      const poisoned = buildFixtureZip(path.join(root, 'attacker'), {
+        name: 'poisoned.zip',
+        fillByte: POISONED_BYTE
+      })
+      fs.mkdirSync(cacheDir, { recursive: true })
+      fs.copyFileSync(poisoned, cachedZip)
+
+      const result = await settled(install(undefined, { MEMRY_ELECTRON_CACHE_DIR: cacheDir }))
+
+      assert.equal(result.code, 0, result.output)
+      assert.match(result.output, /discarding unusable cached artifact/)
+      assert.match(result.output, /Electron checksum mismatch/)
+      // Rejection must fall back to a fresh download, not fail the job.
+      assert.match(result.output, /downloading electron-v0\.0\.0-test/)
+      assert.ok(readerSeesValidInstall(electronDir))
+      assert.equal(
+        installedExecutableByte(electronDir),
+        GENUINE_BYTE,
+        'the poisoned executable was installed'
+      )
+      assert.equal(sha256(cachedZip), sha256(fixtureZip), 'the poisoned entry was not replaced')
+    })
+  }
+)
+
+test('an unusable cache directory never fails the install', { skip: unsupported }, async () => {
+  await withFixture(async ({ root, electronDir, install }) => {
+    // A file where the cache directory should be: mkdir and copy both fail.
+    const blocked = path.join(root, 'blocked-cache')
+    fs.writeFileSync(blocked, 'not a directory')
+
+    const result = await settled(install(undefined, { MEMRY_ELECTRON_CACHE_DIR: blocked }))
+
+    assert.equal(result.code, 0, result.output)
+    assert.match(result.output, /could not cache the artifact/)
+    assert.ok(readerSeesValidInstall(electronDir))
   })
 })

--- a/apps/docs/src/contribute/gotchas.md
+++ b/apps/docs/src/contribute/gotchas.md
@@ -15,6 +15,29 @@ Two fix paths depending on the target:
 
 > Using the Node fix for Electron leaves `autoOpenLastVault` silently failing with `ERR_DLOPEN_FAILED`. The app never opens the test vault, and E2E waits for workspace surfaces time out.
 
+## Electron binary re-downloads on every worktree
+
+`bash apps/desktop/scripts/ensure-native.sh electron` (and the E2E fixtures, when
+`path.txt` is missing) fetch the ~115 MB Electron release zip from GitHub releases.
+Every fresh worktree pays that again, and the download is the single most common
+reason the install fails outright: `curl: (56) Connection died, tried 5 times before
+giving up`.
+
+Set `MEMRY_ELECTRON_CACHE_DIR` to reuse one copy across worktrees:
+
+```bash
+export MEMRY_ELECTRON_CACHE_DIR="$HOME/.cache/memry-electron"
+```
+
+The installer stores the verified zip there and, on later runs, restores it instead of
+downloading. Restored artifacts are not trusted: each one is hashed against the
+`checksums.json` shipped inside the `electron` npm package before extraction, and a
+mismatch deletes the entry and falls back to a normal download. Leaving the variable
+unset keeps the previous always-download behaviour.
+
+Desktop CI sets this automatically via `.github/actions/cache-electron-binary`, keyed
+by the locked Electron version plus the runner's OS and arch.
+
 ## Electron major upgrade — native ABI + V8 API removals
 
 Bumping the `electron` major (e.g. 39 → 43) is more than a version change:


### PR DESCRIPTION
## What was wrong

`Desktop CI` run 31632288280 on `main` lost 4 of 16 `Electron E2E full` shards. None of
them ran a test — they died in the Electron install:

```
[electron] installing 43.1.1 for linux-x64 from https://github.com/electron/electron/releases/download/
curl: (56) Connection died, tried 5 times before giving up
```

`.github/workflows/desktop-ci.yml` had no cache for the Electron binary, so every job
that needs a real Electron runtime — 16 `e2e-full` shards plus `e2e-smoke` and
`e2e-smoke (macOS)` — pulls the same ~115 MB zip fresh from GitHub releases, 18 at a
time, on every run. `apps/desktop/scripts/install-electron-binary.cjs:75-93` retries
three times and then gives up; the whole shard fails before a test starts.

`git log` on that script shows three prior commits already fighting this area ("Install
Electron binary directly for E2E CI", "Fix Electron binary installer process", "Trust
Electron E2E installer helper check"), so this is recurring, not a one-off.

## What changed

**Cache the zip, not the extracted `dist/`.** `checksums.json` inside the `electron`
npm package is a manifest of SHA-256 hashes *of the release zips*. Caching the zip means
a restored artifact can be verified byte-for-byte against a manifest that ships with the
source tree; an extracted `dist/` has no equivalent manifest and could only be
"validated" by re-zipping it deterministically, which is not something to depend on for
a security gate. The zip is also ~115 MB against ~305 MB extracted, so restore is
faster.

- `apps/desktop/scripts/install-electron-binary.cjs` — when `MEMRY_ELECTRON_CACHE_DIR`
  is set, look for `<cacheDir>/electron-v<version>-<platform>-<arch>.zip`; on a hit,
  skip the download. On a successful download, publish the zip into the cache via a
  `.partial` + rename. Unset (the default, and every non-CI caller today) behaves
  exactly as before.
- `.github/actions/cache-electron-binary/action.yml` (new) — resolves the locked
  Electron version from `pnpm-lock.yaml`, exports `MEMRY_ELECTRON_CACHE_DIR`, and wraps
  `actions/cache@v4`.
- `.github/workflows/desktop-ci.yml` — one step added to `e2e-smoke`,
  `e2e-smoke-macos` and `e2e-full`, after `Setup Node.js` and before `Install
  dependencies`.
- `apps/docs/src/contribute/gotchas.md` — the variable is useful locally too (every
  fresh worktree currently re-downloads 115 MB), so it is documented.

### How a poisoned cache entry is rejected

The Actions cache is writable from any branch and this artifact is an executable CI then
runs, so a restored entry is treated as untrusted input:

1. The cached file is **copied into this run's scratch dir first**, then the *copy* is
   hashed. The bytes that get extracted are exactly the bytes that were verified — there
   is no verify-then-read window on the shared file.
2. The hash is compared against `checksums[zipName]` from the `checksums.json` shipped
   inside the `electron` npm package (pinned by `pnpm-lock.yaml`, not by the cache) —
   the identical `validateChecksum` gate a fresh download passes.
3. A mismatch (or an unreadable/absent entry) logs `discarding unusable cached
   artifact`, deletes the entry, and **falls back to a fresh download**. It never fails
   the job, and nothing is ever extracted from an unverified zip.

Proven below with a real, genuine, correctly-signed Electron **39.8.10** zip planted
under the 43.1.1 cache name — the attack a cache-poisoning branch would actually
attempt. It was rejected and 43.1.1 was installed.

### Cache key

`electron-binary-${{ runner.os }}-${{ runner.arch }}-<locked version>`. The version is
read from `pnpm-lock.yaml` (`^ {2}electron@([0-9][^:(\s]*):`), **not** hardcoded and not
from `apps/desktop/package.json`, whose `^43.1.1` range does not identify a build — a
future bump moves the key automatically, and the step fails loudly if the entry cannot
be found. Two independent guards stop a cross-platform restore: the key carries
`runner.os` + `runner.arch`, and the cached file is named per platform+arch, so even a
wrongly restored entry reads as a miss rather than as the wrong binary. No
`restore-keys` — a prefix near-miss has nothing usable in it.

### Deliberately not done

- **`e2e-smoke-windows` and `package-smoke` are untouched.** Neither runs this installer
  (Windows hand-rolls the rebuild and has no `unzip`; `package-smoke` gets Electron
  through electron-builder). Adding a cache there would be dead weight.
- **`@electron/get`'s own cache (`~/.cache/electron`) is not cached.** Different layout,
  different integrity story, and it is not the download that is failing.
- **The `--retry 3 --retry-delay 2` download is unchanged.** The cache reduces how often
  the network is touched; it does not replace the retry.
- **PR #1370 (`d0405ac23`) is untouched.** The `O_EXCL` lock, pid-liveness stale
  recovery, `.dist-staging-<pid>` extraction, staged-tree validation before `dist/` is
  touched, the two-rename swap and `path.txt`-written-last are all unchanged. The cache
  only changes *how the zip arrives in the scratch dir*; extraction and the swap still
  run inside the lock, exactly as before.

## How it was proven

New tests in `apps/desktop/scripts/install-electron-binary.test.cjs` (4 added, driving
the real script end to end against a fixture zip, offline):

| run | result |
| --- | --- |
| new tests against `origin/main`'s installer | **4 pass / 4 fail** |
| new tests against this branch | **8 pass / 0 fail** |

```
✖ a cache miss downloads, installs, and populates the cache
✖ a cache hit installs with no network access at all
✖ a poisoned cache entry is rejected and never extracted
✖ an unusable cache directory never fails the install
ℹ tests 8   ℹ pass 4   ℹ fail 4        # origin/main installer
ℹ tests 8   ℹ pass 8   ℹ fail 0        # this branch
```

**Mutation test on the security gate.** Deleting the single line
`validateChecksum(zipPath, expectedHash)` from `restoreFromCache` — leaving everything
else intact — flips the suite to **7 pass / 1 fail**, and the failure is the poisoned
executable being installed. The test guards the checksum, not a log string.

The poisoned-cache test plants a *structurally valid* zip carrying a different
executable and asserts the installed binary is the genuine one, so "rejected" means the
attacker payload never reached `dist/`, not just that a warning was printed.

The first test also caught a real bug while being written: `fs.rmSync(pending, { force:
true })` still throws `ENOTDIR` when the cache path is a file, which escaped the catch
and failed the install. Hence `removeQuietly`.

## Verification

Local, against the real mirror (`node apps/desktop/scripts/install-electron-binary.cjs`
on a throwaway package dir seeded with the real `package.json` + `checksums.json`):

```
# cold cache
[electron] downloading electron-v43.1.1-darwin-arm64.zip from https://github.com/...
[electron] installed 43.1.1 for darwin-arm64
cache/electron-v43.1.1-darwin-arm64.zip   116 MB
$ dist/Electron.app/Contents/MacOS/Electron --version  ->  v43.1.1

# warm cache, curl replaced by a shim that always exits 7 (no network possible)
[electron] reusing the cached electron-v43.1.1-darwin-arm64.zip from .../cache
[electron] installed 43.1.1 for darwin-arm64
elapsed: 2s
$ dist/Electron.app/Contents/MacOS/Electron --version  ->  v43.1.1

# poisoned cache: a real Electron 39.8.10 zip planted under the 43.1.1 cache name
[electron] discarding unusable cached artifact: Electron checksum mismatch:
  expected d6d0598d042ef4d146278d08d84deac9dde145eae31eb4f32ef46206d6bd6169,
  got      f7e3ed2cc34dd2eba3f2a95234b576fe8082d35fb133e482102c08105f298572
[electron] downloading electron-v43.1.1-darwin-arm64.zip from https://github.com/...
$ dist/Electron.app/Contents/MacOS/Electron --version  ->  v43.1.1   (not 39.8.10)
$ shasum -a 256 cache/electron-v43.1.1-darwin-arm64.zip
  d6d0598d...6169   == checksums.json                (entry healed)
```

Other checks:

```
node --test apps/desktop/scripts/install-electron-binary.test.cjs
  ℹ tests 8  ℹ pass 8  ℹ fail 0

# both YAML files parse; no duplicate step names in any job; the cache step
# lands before "Install dependencies" in all three jobs
node -e '<yaml parse + step-name audit>'
  OK parse: .github/workflows/desktop-ci.yml
    e2e-smoke: 10 steps, duplicate names: none   cache step at 3, install deps at 5 -> before install (ok)
    e2e-smoke-macos: 8 steps, duplicate names: none   cache step at 3, install deps at 4 -> before install (ok)
    e2e-full: 10 steps, duplicate names: none   cache step at 3, install deps at 5 -> before install (ok)
  OK parse: .github/actions/cache-electron-binary/action.yml

# the composite action's version-resolution step, extracted from the YAML and run verbatim
version=43.1.1
MEMRY_ELECTRON_CACHE_DIR=$RUNNER_TEMP/electron-binary-cache
# and against a lockfile with no electron entry:
Could not resolve the Electron version from pnpm-lock.yaml   exit=1

pnpm --filter @memry/desktop exec eslint scripts/install-electron-binary{,.test}.cjs
  0 errors (both files are covered by a pre-existing ignore pattern)

pnpm docs:impact --base origin/main --strict   ->  covered
pnpm docs:build                                ->  build complete in 8.61s
git diff --check                               ->  clean
```

### Not verifiable locally

GitHub Actions cannot be run here, so the first real CI run is what proves:

- that `actions/cache`'s **post/save step fires from inside a composite action** (nested
  post steps are supported by the runner, but this repo has no prior `actions/cache`
  usage at all — this is its first);
- the actual hit rate and time saved on `ubuntu-latest` / `macos-latest`;
- that `runner.temp` is writable and survives between the cache step and
  `ensure-native.sh electron` in the same job (it is the documented per-job temp dir);
- that a *first* run on this branch is a clean miss and populates the entry.

If any of that is wrong the jobs still pass — a miss or a restore failure just falls
through to today's download path, which is constraint 4 by construction.

## Backward compatibility

No runtime, schema, contract or user-data change: build tooling only, and the installer's
behaviour with `MEMRY_ELECTRON_CACHE_DIR` unset is byte-identical to `main`.
