### PR TITLE
fix(settings): retire the two dead journal sidebar visibility toggles

### DIFF
--- a/apps/desktop/src/renderer/src/pages/settings/journal-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/journal-section.tsx
@@ -74,22 +74,6 @@ export function JournalSettings() {
     [setDefaultTemplate, t]
   )
 
-  const handleShowScheduleChange = useCallback(
-    async (checked: boolean) => {
-      const success = await updateSettings({ showSchedule: checked })
-      if (!success) toast.error(t('journal.updateError'))
-    },
-    [t, updateSettings]
-  )
-
-  const handleShowTasksChange = useCallback(
-    async (checked: boolean) => {
-      const success = await updateSettings({ showTasks: checked })
-      if (!success) toast.error(t('journal.updateError'))
-    },
-    [t, updateSettings]
-  )
-
   const handleShowStatsFooterChange = useCallback(
     async (checked: boolean) => {
       const success = await updateSettings({ showStatsFooter: checked })
@@ -181,36 +165,14 @@ export function JournalSettings() {
         </SettingRow>
       </SettingsGroup>
 
-      <SettingsGroup label={t('journal.groups.sidebarVisibility')}>
-        <SettingRow
-          label={t('journal.showSchedule.label')}
-          description={t('journal.showSchedule.description')}
-        >
-          <Switch
-            checked={settings.showSchedule}
-            onCheckedChange={(...args) => void handleShowScheduleChange(...args)}
-            className={ACCENT_SWITCH}
-          />
-        </SettingRow>
-
-        <SettingRow
-          label={t('journal.showTasks.label')}
-          description={t('journal.showTasks.description')}
-        >
-          <Switch
-            checked={settings.showTasks}
-            onCheckedChange={(...args) => void handleShowTasksChange(...args)}
-            className={ACCENT_SWITCH}
-          />
-        </SettingRow>
-
-        {/*
-         * No "Show AI Connections" row: nothing renders AIConnectionsPanel, so the toggle
-         * controlled nothing. `journal.showAIConnections` stays persisted and readable/writable
-         * through settings so existing installs keep their value and re-exposing the row later
-         * is a UI-only change.
-         */}
-      </SettingsGroup>
+      {/*
+       * No "Sidebar Visibility" group. All three of its rows controlled nothing:
+       * JournalDayPanel gates its schedule and task sections on feature flags and emptiness
+       * only, never on `showSchedule` / `showTasks`, and nothing renders AIConnectionsPanel at
+       * all. `journal.showSchedule`, `journal.showTasks`, and `journal.showAIConnections` stay
+       * persisted and readable/writable through settings so existing installs keep their values
+       * and re-exposing the rows later is a UI-only change.
+       */}
 
       <SettingsGroup label={t('journal.groups.footer')}>
         <SettingRow

--- a/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
@@ -620,11 +620,15 @@ describe('settings section coverage', () => {
       expect(mocks.journalSettings.setDefaultTemplate).toHaveBeenCalledWith('daily')
     )
 
-    // AIConnectionsPanel has no call site, so the journal settings page must not offer a
-    // toggle for it. The persisted `showAIConnections` value is untouched.
+    // The whole "Sidebar Visibility" group is gone: JournalDayPanel never reads showSchedule /
+    // showTasks, and nothing renders AIConnectionsPanel, so none of the three toggles controlled
+    // anything. The persisted values are untouched.
+    expect(screen.queryByText('journal.groups.sidebarVisibility')).toBeNull()
+    expect(screen.queryByText('journal.showSchedule.label')).toBeNull()
+    expect(screen.queryByText('journal.showTasks.label')).toBeNull()
     expect(screen.queryByText('journal.showAIConnections.label')).toBeNull()
 
-    fireEvent.click(screen.getAllByRole('switch')[5])
+    fireEvent.click(screen.getAllByRole('switch')[3])
     await waitFor(() =>
       expect(mocks.journalSettings.updateSettings).toHaveBeenCalledWith({
         showStatsFooter: false

--- a/apps/docs/src/user-guide/cli.md
+++ b/apps/docs/src/user-guide/cli.md
@@ -270,7 +270,7 @@ memrynote settings list
 memrynote settings groups
 memrynote settings group general
 memrynote settings set-group general '{"theme":"dark","language":"tr"}'
-memrynote settings set-group journal '{"defaultTemplate":"Daily Review","showSchedule":false}'
+memrynote settings set-group journal '{"defaultTemplate":"Daily Review","showStatsFooter":false}'
 memrynote settings set-group tabs '{"restoreSessionOnStart":false,"tabCloseButton":"active"}'
 memrynote settings set-group noteEditor '{"toolbarMode":"sticky"}'
 memrynote settings group voiceTranscription

--- a/apps/docs/src/user-guide/journal/calendar-navigation.md
+++ b/apps/docs/src/user-guide/journal/calendar-navigation.md
@@ -10,7 +10,7 @@ The default writing surface for a single date.
 
 - Header arrows move ±1 day
 - Date in the breadcrumb opens the picker
-- The editor shows that day's entry; sidebar panes show schedule and tasks (per your settings)
+- The editor shows that day's entry; the day panel shows that date's schedule and tasks when the Calendar and Tasks features are enabled
 
 ## Month View
 

--- a/apps/docs/src/user-guide/journal/daily-entries.md
+++ b/apps/docs/src/user-guide/journal/daily-entries.md
@@ -22,13 +22,6 @@ Use **Add property** or **Add tag** above the date heading to organize a daily e
 
 Journal pages follow the global **Width** setting in [Settings → Editor](/user-guide/settings#editor). To override it just for the Journal, use the **Full width** toggle in the journal ⋮ menu — it widens the writing column edge to edge and applies to every journal page until you turn it off.
 
-## Sidebar Toggles
-
-Show or hide the journal sidebar panes from [Settings → Journal](/user-guide/settings#journal):
-
-- **Schedule** — calendar / events for the focused date
-- **Tasks** — tasks due that day
-
 ## Stats Footer
 
 If enabled, the editor footer shows:

--- a/apps/docs/src/user-guide/journal/templates-settings.md
+++ b/apps/docs/src/user-guide/journal/templates-settings.md
@@ -1,6 +1,6 @@
 # Journal Templates & Settings
 
-Pick a default starting template for new entries and toggle the sidebar panes.
+Pick a default starting template for new entries and toggle the stats footer.
 
 <!-- screenshot: journal settings panel -->
 
@@ -17,17 +17,6 @@ Useful for prompts like:
 - Mood / energy log
 
 If the template uses date variables, they're filled in for the current entry's date.
-
-## Sidebar Visibility
-
-Toggle which panes appear in the journal sidebar:
-
-| Toggle        | Shows                                |
-| ------------- | ------------------------------------ |
-| Show Schedule | Calendar events for the focused date |
-| Show Tasks    | Tasks due that day                   |
-
-Each toggle is independent. Turn them on as you find them useful.
 
 ## Stats Footer
 

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -167,13 +167,6 @@ Clicking a row — built-in or custom — opens it in the [template editor](/use
 
 Pick the template seeded into new journal entries.
 
-### Sidebar Visibility
-
-Show or hide journal sidebar panes:
-
-- **Show Schedule** — calendar / events for the date
-- **Show Tasks** — tasks due that day
-
 ### Footer
 
 **Show Stats Footer** displays writing statistics (word, character, and entry counts).


### PR DESCRIPTION
Fixes #1348

## Root cause

`journal.showSchedule` and `journal.showTasks` have a complete persistence path — key constants and defaults in `packages/app-core/src/settings.ts`, the group shape in `packages/rpc/src/settings.ts`, read/write in `apps/desktop/src/main/ipc/settings-handlers.ts`, types in `apps/desktop/src/preload/index.d.ts`, hook defaults in `use-journal-settings.ts` — and two live `Switch` rows in Settings → Journal. **Nothing reads either key.**

The pane those switches claimed to control is `JournalDayPanel` (`apps/desktop/src/renderer/src/components/journal/journal-day-panel.tsx`, mounted from `components/day-panel/global-day-panel.tsx`). It gates its schedule and task sections on the `calendar` / `tasks` feature flags and emptiness only:

```tsx
{isEnabled('calendar') && schedule.length > 0 && ( … )}
{isEnabled('tasks') && tasks.length > 0 && ( … )}
```

It never consults the settings. `git grep -n "showSchedule\|\bshowTasks\b"` returns, outside tests and locale files, only the persistence layer, the hook defaults, and the two `SettingRow`s. (`showTasks` in `hooks/use-graph-filters.ts` is an unrelated graph filter key.)

Both default to on, so a user who wanted a quieter journal sidebar found two controls that looked exactly right, flipped them, got a success path with no error toast — and nothing changed. Four docs pages confirmed the wrong mental model and a fifth handed out a CLI command that did the same nothing.

## Why retire rather than wire up

Following the precedent already merged in #1345, which removed the third row of this same "Sidebar Visibility" group for the identical reason (`showAIConnections` had no consumer either).

Wiring the panel up is not a UI fix: `JournalDayPanel` is mounted from the shared `global-day-panel.tsx`, so making a *journal* setting govern it needs a product decision about a journal preference controlling a surface that is not journal-only. Retiring the inert UI is the honest, reversible move.

Removing both rows leaves the "Sidebar Visibility" group empty (AI Connections was already gone), so the group goes too. A comment in its place records why all three rows are absent.

## The persisted keys are untouched

This is a UI + docs change only. Deliberately **not** modified:

- `packages/app-core/src/settings.ts` — key constants, defaults, read and write paths
- `packages/rpc/src/settings.ts` — group shape
- `apps/desktop/src/main/ipc/settings-handlers.ts` — `SETTINGS_KEYS`, getter, setter
- `apps/desktop/src/preload/index.d.ts` — types
- `apps/desktop/src/renderer/src/hooks/use-journal-settings.ts` — defaults
- `apps/desktop/tests/e2e/settings-persistence.e2e.ts` — still round-trips both keys
- the locale strings in all 30 locales (same policy #1345 used)

No migration, no settings-shape change. Existing installs keep whatever value they wrote, the CLI and IPC still read and write both keys, and re-exposing the rows later is a one-block UI change.

## Docs corrected

- `apps/docs/src/user-guide/settings.md` — dropped the now-empty "Sidebar Visibility" section
- `apps/docs/src/user-guide/journal/templates-settings.md` — dropped the "Sidebar Visibility" table and fixed the page intro
- `apps/docs/src/user-guide/journal/daily-entries.md` — dropped the "Sidebar Toggles" section
- `apps/docs/src/user-guide/journal/calendar-navigation.md` — the day panel shows schedule and tasks when the Calendar and Tasks features are enabled, not "per your settings"
- `apps/docs/src/user-guide/cli.md` — the `settings set-group journal` example now uses `showStatsFooter`, which has a real consumer (`pages/journal.tsx`), instead of the inert `showSchedule`

## Verification

| Command | Result |
| --- | --- |
| `pnpm lint` | pass (exit 0; 0 errors, 92 pre-existing warnings, none in touched files) |
| `pnpm --filter @memry/desktop typecheck:web` | pass (exit 0) |
| `pnpm typecheck` | pass (exit 0; 16/16 tasks) |
| `npx vitest run --config config/vitest.config.ts --project renderer src/renderer/src/pages/settings/settings-sections.test.tsx` | pass (11/11) |
| `pnpm --filter @memry/desktop i18n:check` | pass (exit 0) |
| `pnpm docs:build` | pass (exit 0) |
| `pnpm docs:impact --base origin/main --strict` | `covered against origin/main` |
| `git diff --check` | clean |

`settings-sections.test.tsx` now asserts the group label and all three row labels are absent, and drives the remaining Stats Footer switch at its new index.
