### PR TITLE
fix(notes): stop the notes-folder setting from making that folder unbrowsable

### DIFF
--- a/apps/desktop/src/renderer/src/components/notes-tree-utils.test.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree-utils.test.tsx
@@ -218,7 +218,7 @@ describe('buildTreeFromNotes', () => {
     ]
     const folders = [{ path: 'Projects', icon: null }]
 
-    const tree = buildTreeFromNotes(notes, folders, {})
+    const tree = buildTreeFromNotes(notes, folders, {}, 'notes')
     expect(tree.rootNotes).toHaveLength(1)
     expect(tree.rootNotes[0].id).toBe('a')
     expect(tree.folders).toHaveLength(1)
@@ -236,13 +236,13 @@ describe('buildTreeFromNotes', () => {
     ]
     const positions = { 'notes/c.md': 0, 'notes/a.md': 1 }
 
-    const tree = buildTreeFromNotes(notes, [], positions)
+    const tree = buildTreeFromNotes(notes, [], positions, 'notes')
     expect(tree.rootNotes.map((n) => n.id)).toEqual(['c', 'a', 'b'])
   })
 
   it('creates intermediate folders for nested paths', () => {
     const notes = [createNote({ id: 'a', path: 'notes/a/b/c/file.md', modified: baseDate })]
-    const tree = buildTreeFromNotes(notes, [], {})
+    const tree = buildTreeFromNotes(notes, [], {}, 'notes')
     expect(tree.folders).toHaveLength(1)
     expect(tree.folders[0].name).toBe('a')
     expect(tree.folders[0].children[0].name).toBe('b')
@@ -253,8 +253,79 @@ describe('buildTreeFromNotes', () => {
     const notes: NoteListItem[] = []
     const folders = [{ path: 'Archive', icon: '📦' }]
 
-    const tree = buildTreeFromNotes(notes, folders, {})
+    const tree = buildTreeFromNotes(notes, folders, {}, 'notes')
     expect(tree.folders[0].icon).toBe('📦')
+  })
+
+  // #1204: folder nodes are handed straight back to folderExists/getFolders,
+  // which resolve against `<vault>/<defaultNoteFolder>`. Any node path that is
+  // still vault-relative gets the notes root applied twice and renders
+  // "Folder not found".
+  describe('notes root (#1204)', () => {
+    it('strips a capitalised notes root instead of the literal "notes"', () => {
+      const notes = [
+        createNote({ id: 'a', path: 'Notes/hello.md', modified: baseDate }),
+        createNote({ id: 'b', path: 'Notes/Work/alpha.md', modified: baseDate })
+      ]
+      const folders = [{ path: 'Work', icon: null }]
+
+      const tree = buildTreeFromNotes(notes, folders, {}, 'Notes')
+
+      expect(tree.folders.map((f) => f.path)).toEqual(['Work'])
+      expect(tree.rootNotes.map((n) => n.id)).toEqual(['a'])
+      expect(tree.folders[0].notes.map((n) => n.id)).toEqual(['b'])
+    })
+
+    it('never emits a node whose path is the notes root itself', () => {
+      const notes = [createNote({ id: 'a', path: 'Notes/Work/alpha.md', modified: baseDate })]
+
+      const tree = buildTreeFromNotes(notes, [], {}, 'Notes')
+
+      const allPaths: string[] = []
+      const walk = (nodes: FolderNode[]): void => {
+        for (const node of nodes) {
+          allPaths.push(node.path)
+          walk(node.children)
+        }
+      }
+      walk(tree.folders)
+      expect(allPaths).not.toContain('Notes')
+      expect(allPaths).not.toContain('Notes/Work')
+      expect(allPaths).toContain('Work')
+    })
+
+    it('keeps a real "notes" folder browsable when the notes root is the vault root', () => {
+      const notes = [createNote({ id: 'a', path: 'notes/Work/alpha.md', modified: baseDate })]
+      const folders = [
+        { path: 'notes', icon: null },
+        { path: 'notes/Work', icon: null }
+      ]
+
+      const tree = buildTreeFromNotes(notes, folders, {}, '')
+
+      // The old hardcoded strip produced an orphan "Work" node that resolved to
+      // `<vault>/Work` and did not exist.
+      expect(tree.folders.map((f) => f.path)).toEqual(['notes'])
+      expect(tree.folders[0].children.map((f) => f.path)).toEqual(['notes/Work'])
+      expect(tree.folders[0].children[0].notes.map((n) => n.id)).toEqual(['a'])
+    })
+
+    it('puts notes outside the notes root at the top level rather than in an unopenable folder', () => {
+      const notes = [createNote({ id: 'a', path: 'Archive/old.md', modified: baseDate })]
+
+      const tree = buildTreeFromNotes(notes, [], {}, 'Notes')
+
+      expect(tree.folders).toEqual([])
+      expect(tree.rootNotes.map((n) => n.id)).toEqual(['a'])
+    })
+
+    it('tolerates a slash-padded notes root', () => {
+      const notes = [createNote({ id: 'a', path: 'Notes/Work/alpha.md', modified: baseDate })]
+
+      const tree = buildTreeFromNotes(notes, [], {}, '/Notes/')
+
+      expect(tree.folders.map((f) => f.path)).toEqual(['Work'])
+    })
   })
 })
 

--- a/apps/desktop/src/renderer/src/components/notes-tree-utils.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree-utils.tsx
@@ -80,10 +80,38 @@ export function getFoldersInParent(tree: TreeStructure, parentPath: string): str
 // Tree Building
 // ============================================================================
 
+/**
+ * Folder a note belongs to, expressed the way the folder APIs expect it:
+ * relative to the notes root, not to the vault.
+ *
+ * Note paths come out of the index vault-relative, but `getFolders`,
+ * `folderExists` and the folder view all resolve a folder path against
+ * `<vault>/<defaultNoteFolder>`. Feeding a vault-relative path to those APIs
+ * applies the notes root a second time, so a vault whose notes root is
+ * `Notes` looked for `<vault>/Notes/Notes` and rendered "Folder not found"
+ * (#1204). The prefix used to be the hardcoded literal `notes`, which is why
+ * only that exact spelling worked.
+ *
+ * Returns `null` for a note that lives outside the notes root: no folder node
+ * can represent it, so it belongs at the top level rather than under a folder
+ * that cannot be opened.
+ */
+export function folderPathRelativeToNotesRoot(notePath: string, notesRoot: string): string | null {
+  const dir = notePath.split('/').slice(0, -1).join('/')
+  const root = notesRoot.replace(/^\/+|\/+$/g, '')
+  if (!root) return dir
+  if (dir === root) return ''
+  return dir.startsWith(`${root}/`) ? dir.slice(root.length + 1) : null
+}
+
+/**
+ * @param notesRoot - The vault's `defaultNoteFolder`. Empty for a flat vault.
+ */
 export function buildTreeFromNotes(
   notes: NoteListItem[],
   folders: FolderInfo[],
-  positions: Record<string, number>
+  positions: Record<string, number>,
+  notesRoot: string
 ): TreeStructure {
   const folderMap = new Map<string, FolderNode>()
   const rootNotes: NoteListItem[] = []
@@ -135,18 +163,13 @@ export function buildTreeFromNotes(
   })
 
   notes.forEach((note) => {
-    const pathParts = note.path.split('/')
-    pathParts.pop()
+    const folderPath = folderPathRelativeToNotesRoot(note.path, notesRoot)
 
-    if (pathParts.length === 0 || pathParts[0] === 'notes') {
-      if (pathParts.length <= 1) {
-        rootNotes.push(note)
-      } else {
-        const folderPath = pathParts.slice(1).join('/')
-        ensureFolderInMap(folderPath).notes.push(note)
-      }
+    // `null` (outside the notes root) and `''` (directly in it) both mean there
+    // is no folder node to file this note under.
+    if (!folderPath) {
+      rootNotes.push(note)
     } else {
-      const folderPath = pathParts.join('/')
       ensureFolderInMap(folderPath).notes.push(note)
     }
   })

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.test.tsx
@@ -95,12 +95,17 @@ const otherNote = createNote('other', 'notes/Other/C.pdf', { fileType: 'pdf' })
 const folders = [{ path: 'Work' }, { path: 'Other' }, { path: 'Work/Nested' }] as any[]
 const allNotes = [rootNote, workA, workB, otherNote]
 const noteMap = new Map(allNotes.map((note) => [note.id, note]))
-const tree = buildTreeFromNotes(allNotes, folders, {
-  'notes/Work/A.md': 1,
-  'notes/Work/B.md': 2,
-  Work: 1,
-  Other: 2
-})
+const tree = buildTreeFromNotes(
+  allNotes,
+  folders,
+  {
+    'notes/Work/A.md': 1,
+    'notes/Work/B.md': 2,
+    Work: 1,
+    Other: 2
+  },
+  'notes'
+)
 
 const createMutations = () =>
   ({

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-data.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-data.test.tsx
@@ -21,7 +21,15 @@ const mocks = vi.hoisted(() => ({
     delete: vi.fn(),
     rename: vi.fn(),
     move: vi.fn()
+  },
+  vaultService: {
+    getConfig: vi.fn()
   }
+}))
+
+vi.mock('@/services/vault-service', () => ({
+  vaultService: mocks.vaultService,
+  onVaultStatusChanged: () => () => {}
 }))
 
 vi.mock('@/services/notes-service', () => {
@@ -85,6 +93,7 @@ describe('useNoteTreeData truncation', () => {
     vi.clearAllMocks()
     mocks.notesService.getFolders.mockResolvedValue([])
     mocks.notesService.getAllPositions.mockResolvedValue({ success: true, positions: {} })
+    mocks.vaultService.getConfig.mockResolvedValue({ defaultNoteFolder: '' })
   })
 
   it('reports the notes the first page could not cover', async () => {
@@ -163,5 +172,70 @@ describe('useNoteTreeData truncation', () => {
 
     await waitFor(() => expect(result.current.notes).toHaveLength(vault.length))
     expect(result.current.isLoadingMore).toBe(false)
+  })
+})
+
+/**
+ * #1204: "Default Location for New Notes" is the notes ROOT. Note paths arrive
+ * vault-relative, but every folder API resolves against
+ * `<vault>/<defaultNoteFolder>` — so the tree has to strip the *configured*
+ * root. It used to strip the hardcoded literal `notes/`, which left a folder
+ * node called `Notes` that resolved to `<vault>/Notes/Notes` and rendered
+ * "Folder not found".
+ */
+describe('useNoteTreeData notes root', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.notesService.getAllPositions.mockResolvedValue({ success: true, positions: {} })
+  })
+
+  function note(path: string): NoteListItem {
+    return {
+      id: path,
+      path,
+      title: path,
+      created: new Date(0),
+      modified: new Date(0),
+      tags: [],
+      wordCount: 0,
+      emoji: null,
+      localOnly: false,
+      fileType: 'markdown'
+    } as unknown as NoteListItem
+  }
+
+  it('makes a folder named after the notes root browsable', async () => {
+    mocks.vaultService.getConfig.mockResolvedValue({ defaultNoteFolder: 'Notes' })
+    // getFolders() is already notes-root-relative.
+    mocks.notesService.getFolders.mockResolvedValue([{ path: 'Work', icon: null }])
+    serve([note('Notes/Work/alpha.md'), note('Notes/loose.md')])
+
+    const { result } = renderHook(() => useNoteTreeData(), { wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    await waitFor(() => expect(result.current.tree.folders).toHaveLength(1))
+
+    // 'Work' resolves to <vault>/Notes/Work. 'Notes' would resolve to
+    // <vault>/Notes/Notes and fail folderExists.
+    expect(result.current.tree.folders.map((f) => f.path)).toEqual(['Work'])
+    expect(result.current.tree.folders[0].notes.map((n) => n.path)).toEqual(['Notes/Work/alpha.md'])
+    expect(result.current.tree.rootNotes.map((n) => n.path)).toEqual(['Notes/loose.md'])
+  })
+
+  it('keeps a literal notes/ folder intact when the notes root is the vault root', async () => {
+    mocks.vaultService.getConfig.mockResolvedValue({ defaultNoteFolder: '' })
+    mocks.notesService.getFolders.mockResolvedValue([
+      { path: 'notes', icon: null },
+      { path: 'notes/Work', icon: null }
+    ])
+    serve([note('notes/Work/alpha.md')])
+
+    const { result } = renderHook(() => useNoteTreeData(), { wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    await waitFor(() => expect(result.current.tree.folders).toHaveLength(1))
+
+    expect(result.current.tree.folders.map((f) => f.path)).toEqual(['notes'])
+    expect(result.current.tree.folders[0].children.map((f) => f.path)).toEqual(['notes/Work'])
   })
 })

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts
@@ -1,4 +1,5 @@
 import { useMemo, useState, useEffect, useCallback, useRef } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   useNotesList,
   useNoteFoldersQuery,
@@ -6,10 +7,43 @@ import {
   type NoteListItem
 } from '@/hooks/use-notes-query'
 import { notesService } from '@/services/notes-service'
+import { vaultService, onVaultStatusChanged } from '@/services/vault-service'
 import { buildTreeFromNotes, type TreeStructure } from '@/components/notes-tree-utils'
 import { createLogger } from '@/lib/logger'
 
 const log = createLogger('Hook:NoteTreeData')
+
+const notesRootKey = ['vault', 'notes-root'] as const
+
+/**
+ * The vault's notes root (`defaultNoteFolder`).
+ *
+ * The tree has to know it: note paths arrive vault-relative while folder paths
+ * are resolved against `<vault>/<defaultNoteFolder>`, so the tree must strip
+ * the configured root rather than a hardcoded `notes/` (#1204). Changing the
+ * setting rebuilds the index and pushes a vault status event, which is what
+ * invalidates this.
+ */
+function useNotesRoot(): string {
+  const queryClient = useQueryClient()
+  const { data } = useQuery({
+    queryKey: notesRootKey,
+    // Never undefined and never retried: the sidebar must not stay blank
+    // because one config read hiccuped. The vault-root default is what an
+    // unconfigured vault uses anyway.
+    queryFn: async () => (await vaultService.getConfig())?.defaultNoteFolder ?? '',
+    retry: false,
+    staleTime: 60_000
+  })
+
+  useEffect(() => {
+    return onVaultStatusChanged(() => {
+      void queryClient.invalidateQueries({ queryKey: notesRootKey })
+    })
+  }, [queryClient])
+
+  return data ?? ''
+}
 
 /**
  * How many notes one sidebar page pulls.
@@ -86,6 +120,7 @@ export function useNoteTreeData(): NoteTreeData {
 
   const mutations = useNoteMutations()
   const { folders, createFolder, setFolderIcon, refetch: refreshFolders } = useNoteFoldersQuery()
+  const notesRoot = useNotesRoot()
 
   const [folderTemplateNames, setFolderTemplateNames] = useState<Map<string, string>>(new Map())
   const [notePositions, setNotePositions] = useState<Record<string, number>>({})
@@ -139,8 +174,8 @@ export function useNoteTreeData(): NoteTreeData {
   }, [notes])
 
   const tree = useMemo(() => {
-    return buildTreeFromNotes(notes, folders, notePositions)
-  }, [notes, folders, notePositions])
+    return buildTreeFromNotes(notes, folders, notePositions, notesRoot)
+  }, [notes, folders, notePositions, notesRoot])
 
   const noteMap = useMemo(() => {
     const map = new Map<string, NoteListItem>()

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -106,6 +106,19 @@ locale has finished loading.
 
 **Create in Selected Folder** routes new notes into whichever folder is currently selected in the sidebar.
 
+**Notes Folder** sets the root of your notes tree inside the vault. Leave it empty (the default) and
+the vault root is the notes root. Set it to, say, `Notes` and memrynote treats `<vault>/Notes` as the top
+of the tree: new notes are created there, and everything inside it — `Notes/Work`, `Notes/Archive` —
+becomes a top-level folder in the sidebar. The `Notes` folder itself no longer appears, because it
+_is_ the root.
+
+Two consequences worth knowing:
+
+- Folders that live outside the notes root are not part of the notes tree. Their notes still show up,
+  but at the top level rather than under a folder.
+- The value is a path relative to the vault, not a nested one. `Notes` and `Notes/Inbox` are both
+  valid; a leading or trailing slash is ignored.
+
 ### Privacy
 
 **Telemetry** opts in or out of anonymous usage analytics. Off by default. Only enum-like event

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -174,8 +174,8 @@
         "description": "New notes and folders are created inside the currently selected folder. When off, items are always created at root."
       },
       "defaultNoteFolder": {
-        "label": "Default Location for New Notes",
-        "description": "Empty = vault root",
+        "label": "Notes Folder",
+        "description": "The folder your notes live in. New notes go here, and its contents become the top level of your notes tree — so this folder itself stops appearing in the sidebar. Leave empty to use the vault root.",
         "placeholder": "notes"
       }
     },


### PR DESCRIPTION
Fixes #1204

Jerry set **Default Location for New Notes** to `Notes` so new notes would land in his `Notes/` folder. From then on, opening that folder said **Folder not found**. Clearing the field fixed it.

## Root cause

The setting is the **root of the notes tree**, and the sidebar was building tree nodes against a hardcoded root instead of the configured one.

1. `apps/desktop/src/renderer/src/pages/settings/general-section.tsx:103-107` writes `config.defaultNoteFolder` on blur (input rendered at `:422-433`).
2. `apps/desktop/src/main/vault/notes-io.ts:31-35` — `getNotesDir()` is `path.join(vaultPath, config.defaultNoteFolder)`. There is a second copy at `apps/desktop/src/main/vault/folders.ts:41-47`.
3. `apps/desktop/src/main/vault/indexer.ts:90` indexes the **whole vault**, storing **vault-relative** paths. `apps/desktop/src/main/vault/notes-queries.ts:50` (`listNotes`) hands those straight to the renderer, unscoped.
4. `apps/desktop/src/renderer/src/components/notes-tree-utils.tsx:141` (pre-fix) stripped the **hardcoded literal** `'notes'` from those vault-relative paths — nothing else. With `defaultNoteFolder = 'Notes'` the comparison is case-sensitive and fails, so a note at `Notes/x.md` produced a tree node with path `Notes`.
5. Clicking that node opens the folder view with `scope.path = 'Notes'` → `apps/desktop/src/renderer/src/hooks/use-folder-view.ts:257-266` calls `folderExists('Notes')` → `apps/desktop/src/main/ipc/folder-view-handlers.ts:548` → `apps/desktop/src/main/vault/folders.ts:144-151` → `existsSync(<vault>/Notes/Notes)` → **false**.
6. `use-folder-view.ts:1108` sets `folderNotFound: true` → `apps/desktop/src/renderer/src/pages/folder-view.tsx:1077` renders `FolderViewEmptyState variant="folder-not-found"`.

Note that `getFolders()` (`apps/desktop/src/main/vault/notes-crud.ts:712`) already returns **notes-root-relative** paths. The tree merged those with vault-relative paths derived from note paths, so the two disagreed the moment the notes root was anything but the literal lowercase `notes`.

The same literal broke the mirror case: a vault with `defaultNoteFolder = ''` (the default) that happens to contain a real `notes/` folder had that prefix stripped anyway, producing a phantom top-level node that resolved to `<vault>/Work` and did not exist.

## Which semantics, and why

**Option (a) — keep `defaultNoteFolder` as the notes root.** No contract, schema, or on-disk change; no migration.

Option (b) (redefine it as a default destination that only note creation reads) would be a semantic change to a live setting with five other production consumers — `getNotesDir()`, `inbox/filing.ts:552` and `:1047`, `inbox/suggestions.ts:405`, `agent/mcp/tools/handles-adapter.ts:75`, `sync/note-sync.ts:132`, `vault/journal.ts:92`, `vault/resolve-embed.ts:180` — and it is not needed: the symptom is fully explained by one hardcoded string in the renderer.

Within option (a) the fix is the renderer tree, not write-time validation:

- **Fixed:** `buildTreeFromNotes` now strips the *configured* notes root. `use-note-tree-data` feeds it the live `defaultNoteFolder`, invalidated on vault status change (changing the setting triggers a full index rebuild, which pushes one).
- **Deliberately not added:** rejecting a value that collides with an existing top-level folder. After this fix that collision is the *supported* configuration — it is exactly what Jerry wanted. Refusing it would block the legitimate case to work around a bug that no longer exists. Instead the label and description now say what the field does.

Notes that live outside the notes root now appear at the top level instead of under a fabricated folder node. The invariant is that **every folder node in the tree carries a path the folder APIs can resolve** — which is what makes the reported symptom impossible rather than merely unlikely.

## Compatibility for existing installs

No schema, IPC contract, vault format, or settings-shape change. `defaultNoteFolder` keeps its meaning and its stored value; nothing is migrated or rewritten.

| Stored value | Before | After |
| --- | --- | --- |
| `''` (default, no `notes/` folder on disk) | correct | identical |
| `'notes'` | correct | identical |
| `''` **with** a real `notes/` folder | phantom top-level node resolving to `<vault>/<child>`, "Folder not found" | `notes/` is a real, browsable folder |
| `'Notes'`, `'MyNotes'`, any other spelling | every folder unbrowsable | correct |

The two changed rows both move from broken to correct; no configuration that worked before behaves differently.

Copy: the English `general.fileCreation.defaultNoteFolder` label/description now describe the notes root. The other 31 locales keep their existing translations, which remain accurate if less complete, and fall back to English for anything missing.

## Mutation evidence

The repo's own warning is that mocked-IPC tests give false confidence here, so both halves of the fix were reverted independently and the tests re-run.

**Mutation 1** — restore the pre-fix hardcoded `'notes'` strip in `buildTreeFromNotes`:

```
Failed Tests 7
 FAIL  notes-tree-utils.test.tsx > notes root (#1204) > strips a capitalised notes root instead of the literal "notes"
 FAIL  notes-tree-utils.test.tsx > notes root (#1204) > never emits a node whose path is the notes root itself
 FAIL  notes-tree-utils.test.tsx > notes root (#1204) > keeps a real "notes" folder browsable when the notes root is the vault root
 FAIL  notes-tree-utils.test.tsx > notes root (#1204) > puts notes outside the notes root at the top level rather than in an unopenable folder
 FAIL  notes-tree-utils.test.tsx > notes root (#1204) > tolerates a slash-padded notes root
 FAIL  use-note-tree-data.test.tsx > notes root > makes a folder named after the notes root browsable
 FAIL  use-note-tree-data.test.tsx > notes root > keeps a literal notes/ folder intact when the notes root is the vault root
 Tests  7 failed | 40 passed (47)
```

**Mutation 2** — keep the fixed function but break only the wiring (`buildTreeFromNotes(..., 'notes')` instead of the config value), to prove the hook tests catch a wiring regression the pure-function tests cannot see:

```
Failed Tests 2
 FAIL  use-note-tree-data.test.tsx > notes root > makes a folder named after the notes root browsable
 FAIL  use-note-tree-data.test.tsx > notes root > keeps a literal notes/ folder intact when the notes root is the vault root
 Tests  2 failed | 45 passed (47)
```

Both restored → `Tests 47 passed (47)`.

## Verification

| Command | Result |
| --- | --- |
| `pnpm install --frozen-lockfile` | `Done in 1m 20.5s` |
| `pnpm lint` | `0 errors, 92 warnings` (all pre-existing; none in changed files, `prettier --check` on the diff is clean) |
| `pnpm typecheck` | `16 successful, 16 total` |
| `npx vitest run --config config/vitest.config.ts --project renderer` (full) | `604 files passed, 6911 passed \| 6 skipped` |
| `pnpm --filter @memry/desktop i18n:check` | `ok: i18n check passed` |
| `pnpm docs:impact --base origin/main --strict` | `covered against origin/main` |
| `pnpm docs:build` | `build complete in 2.76s` |
| `git diff --check` | clean |

The full renderer project was run rather than only the touched files: `notes-tree.test.tsx` initially regressed on the first draft of the config query, which is why `useNotesRoot` never returns `undefined` and never retries — the sidebar must not depend on a config read succeeding.

## Not fixed here (same literal, different symptom)

`extractFolderFromPath` (`notes-tree-utils.tsx:20-27`) and `computeTargetFolder` (`use-note-tree-data.ts`) also hardcode `'notes'`. They feed drag-drop and create-here targets, not folder browsing, so they are a separate pre-existing defect that this change neither creates nor worsens. Filed separately rather than widened into this PR.
