### PR TITLE
fix(embeddings): back off model-load retries instead of latching on first failure

### DIFF
--- a/apps/desktop/src/main/lib/embeddings.test.ts
+++ b/apps/desktop/src/main/lib/embeddings.test.ts
@@ -678,4 +678,142 @@ describe('embeddings', () => {
       expect(isInformationalWorkerStderr('   \n  ')).toBe(false)
     })
   })
+
+  // One win32 install re-attempted the ~23MB model download 48 times in 10 minutes
+  // (`fetch failed` — offline/proxy/blocked CDN). The pre-existing breaker latched on
+  // the FIRST failure and never re-opened, so the opposite failure mode was just as
+  // bad: a 5-second blip silently killed semantic indexing until the app restarted (#840).
+  describe('model load backoff', () => {
+    /**
+     * Drive one load attempt that fails the way a blocked download does. The fork
+     * is synchronous inside initEmbeddingModel(), so the worker to talk to is
+     * whichever instance exists immediately after the call.
+     */
+    const failOneLoad = async (): Promise<void> => {
+      const previous = mockUtilityProcessInstance
+      const promise = initEmbeddingModel()
+      const worker = mockUtilityProcessInstance
+      const baseline = worker === previous ? worker.postMessage.mock.calls.length : 0
+
+      worker.simulateMessage({ type: 'ready' })
+      await vi.waitFor(() => {
+        expect(worker.postMessage.mock.calls.length).toBeGreaterThan(baseline)
+      })
+
+      const request = worker.postMessage.mock.calls.at(-1)?.[0] as { requestId: string }
+      worker.simulateMessage({ type: 'error', requestId: request.requestId, error: 'fetch failed' })
+      await expect(promise).resolves.toBe(false)
+    }
+
+    /** Drive one load attempt that succeeds. */
+    const succeedOneLoad = async (): Promise<void> => {
+      const previous = mockUtilityProcessInstance
+      const promise = initEmbeddingModel()
+      const worker = mockUtilityProcessInstance
+      const baseline = worker === previous ? worker.postMessage.mock.calls.length : 0
+
+      worker.simulateMessage({ type: 'ready' })
+      await vi.waitFor(() => {
+        expect(worker.postMessage.mock.calls.length).toBeGreaterThan(baseline)
+      })
+
+      const request = worker.postMessage.mock.calls.at(-1)?.[0] as { requestId: string }
+      worker.simulateMessage({ type: 'load-model-result', requestId: request.requestId })
+      await expect(promise).resolves.toBe(true)
+    }
+
+    /** load-model requests the CURRENT worker has been sent. */
+    const loadRequests = (): number =>
+      mockUtilityProcessInstance.postMessage.mock.calls.filter(
+        (call) => (call[0] as { type: string }).type === 'load-model'
+      ).length
+
+    // Long enough for the 30s idle shutdown plus its 3s force-kill to complete, and
+    // for the 60s first backoff to expire — but SHORTER than the 120s second step,
+    // so a test that expects a retry here fails if the backoff wrongly escalated.
+    const FIRST_BACKOFF_ELAPSED_MS = 70_000
+
+    it('does not retry the download immediately after a failure', async () => {
+      vi.useFakeTimers()
+      await failOneLoad()
+      expect(loadRequests()).toBe(1)
+
+      // #when the projector asks again straight away (the next note edit)
+      await expect(initEmbeddingModel()).resolves.toBe(false)
+
+      // #then no second download is attempted — this is the tight retry loop
+      expect(loadRequests()).toBe(1)
+    })
+
+    it('retries once the backoff window elapses', async () => {
+      vi.useFakeTimers()
+      await failOneLoad()
+
+      // #when the first backoff expires (by which point the network may be back)
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF_ELAPSED_MS)
+      await succeedOneLoad()
+
+      // #then indexing recovers on its own, with no restart and no user action
+      expect(isModelLoaded()).toBe(true)
+    })
+
+    it('gives up for the session after repeated failures', async () => {
+      vi.useFakeTimers()
+
+      // #given five consecutive failures, each one waited out
+      for (let attempt = 0; attempt < 5; attempt++) {
+        await failOneLoad()
+        await vi.advanceTimersByTimeAsync(20 * 60_000)
+      }
+
+      // #when yet more time passes and another note is edited
+      const forksBefore = mockFork.mock.calls.length
+      await expect(initEmbeddingModel()).resolves.toBe(false)
+
+      // #then the breaker is latched: no worker, no download, until app restart or
+      // an explicit user retry (re-enable AI / load model / reindex)
+      expect(mockFork.mock.calls.length).toBe(forksBefore)
+    })
+
+    it('clears the backoff on a successful load', async () => {
+      vi.useFakeTimers()
+      await failOneLoad()
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF_ELAPSED_MS)
+      await succeedOneLoad()
+
+      // #when the network breaks again later
+      await failOneLoad()
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF_ELAPSED_MS)
+
+      // #then the wait is the FIRST backoff step again, not an escalated one — a
+      // flaky network can never accumulate its way to the permanent latch
+      await succeedOneLoad()
+      expect(isModelLoaded()).toBe(true)
+    })
+
+    it('short-circuits embed while the breaker is open', async () => {
+      vi.useFakeTimers()
+      await failOneLoad()
+      const requestsAfterFailure = mockUtilityProcessInstance.postMessage.mock.calls.length
+
+      // #when a note is edited during the backoff window
+      await expect(generateEmbedding('content long enough for embeddings')).resolves.toBeNull()
+
+      // #then no embed request is sent — the worker re-drives the download inside
+      // handleEmbed, which is the breaker hole embed() used to have
+      expect(mockUtilityProcessInstance.postMessage.mock.calls.length).toBe(requestsAfterFailure)
+    })
+
+    it('lets an explicit user retry bypass the backoff window', async () => {
+      vi.useFakeTimers()
+      await failOneLoad()
+
+      // #when the user re-enables AI / hits "Load model" inside the cooldown
+      resetEmbeddingModelFailure()
+
+      // #then it retries immediately instead of making them wait out the backoff
+      await succeedOneLoad()
+      expect(isModelLoaded()).toBe(true)
+    })
+  })
 })

--- a/apps/desktop/src/main/lib/embeddings.ts
+++ b/apps/desktop/src/main/lib/embeddings.ts
@@ -68,6 +68,22 @@ const START_TIMEOUT_MS = 10_000
 const SHUTDOWN_TIMEOUT_MS = 3_000
 const IDLE_SHUTDOWN_MS = 30_000
 
+/**
+ * Model-load retry policy (#840).
+ *
+ * A failed load is almost always the ~23MB download failing (offline, proxy,
+ * blocked CDN), so it IS worth retrying — one prod install would have recovered
+ * on its own. But it must be retried on a widening schedule: that same install
+ * re-attempted the download 48 times in 10 minutes, and every attempt costs a
+ * worker fork plus two error lines in the log feed.
+ *
+ * 60s → 2m → 4m → 8m, then stop for the session. `resetEmbeddingModelFailure()`
+ * (AI re-enable / manual load / reindex) always bypasses this — an explicit user
+ * retry should never have to wait out a backoff.
+ */
+const LOAD_RETRY_BASE_DELAY_MS = 60_000
+const MAX_CONSECUTIVE_LOAD_FAILURES = 5
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -118,12 +134,19 @@ class EmbeddingModelBridge {
   private requestCounter = 0
   private loaded = false
   private loading = false
-  // Circuit breaker: latched when a model load fails (download stall, worker
-  // crash, timeout). While set, loadModel() short-circuits instead of re-forking
-  // the worker and re-attempting the ~23MB download per note — the loop that made
-  // vault-open hang indefinitely (#803). Cleared on a successful load, on reset(),
-  // and when AI is re-enabled (resetEmbeddingModelFailure).
+  // Circuit breaker: latched when model loads keep failing (download stall, worker
+  // crash, timeout). While set, loadModel() and embed() short-circuit instead of
+  // re-forking the worker and re-attempting the ~23MB download per note — the loop
+  // that made vault-open hang indefinitely (#803). Cleared on a successful load, on
+  // reset(), and when AI is re-enabled (resetEmbeddingModelFailure).
   private loadFailed = false
+  // Consecutive failures feeding the retry backoff. Latching on the FIRST failure
+  // (as this breaker originally did) meant a 5-second network blip silently killed
+  // semantic indexing for the rest of the app session, so instead the failures are
+  // counted and spaced out, and only the Nth latches for good (#840).
+  private consecutiveFailures = 0
+  // Epoch ms before which no load may be attempted. 0 = retry allowed now.
+  private retryNotBefore = 0
   private error: string | null = null
   private shuttingDown = false
   private idleShutdownTimer: ReturnType<typeof setTimeout> | null = null
@@ -153,10 +176,11 @@ class EmbeddingModelBridge {
   }
 
   async loadModel(): Promise<boolean> {
-    // A previous load already failed this session — do not re-fork the worker or
-    // re-attempt the download. Recover via resetEmbeddingModelFailure() (AI
-    // re-enable), unloadModel(), or app restart.
-    if (this.loadFailed) {
+    // A recent load already failed — do not re-fork the worker or re-attempt the
+    // download until the backoff expires. Once the breaker latches for good,
+    // recover via resetEmbeddingModelFailure() (AI re-enable), unloadModel(), or
+    // app restart.
+    if (this.isBreakerOpen()) {
       return false
     }
 
@@ -172,31 +196,44 @@ class EmbeddingModelBridge {
       if (response.type === 'error') {
         this.error = response.error
         this.loading = false
-        this.loadFailed = true
+        this.recordFailure()
         return false
       }
 
       if (response.type !== 'load-model-result') {
         this.error = `Unexpected response type: ${response.type}`
         this.loading = false
-        this.loadFailed = true
+        this.recordFailure()
         return false
       }
 
       this.loaded = true
       this.loading = false
-      this.loadFailed = false
       this.error = null
+      this.recordSuccess()
       return true
     } catch (error) {
       this.loading = false
       this.error = error instanceof Error ? error.message : String(error)
-      this.loadFailed = true
+      this.recordFailure()
       return false
     }
   }
 
   async embed(text: string): Promise<Float32Array | null> {
+    // Belt-and-suspenders for the same loop: callers reach embeddings through
+    // isModelLoaded() -> initEmbeddingModel(), but nothing forces them to, and the
+    // worker re-drives the download inside handleEmbed. Without this an embed()
+    // caller that skips that guard reopens the retry loop the breaker exists to close.
+    if (this.isBreakerOpen()) {
+      return null
+    }
+
+    // A failure on a call that had to (re)load the model is a load failure and
+    // feeds the backoff. A failure with the model already loaded is a crash or an
+    // inference fault — leave the breaker alone so the next note simply re-forks.
+    const wasLoaded = this.loaded
+
     try {
       this.loading = !this.loaded
       await this.start()
@@ -210,6 +247,9 @@ class EmbeddingModelBridge {
       if (response.type === 'error') {
         this.error = response.error
         this.loading = false
+        if (!wasLoaded) {
+          this.recordFailure()
+        }
         logger.warn('Embedding worker failed:', response.error)
         return null
       }
@@ -229,10 +269,14 @@ class EmbeddingModelBridge {
       this.loaded = true
       this.loading = false
       this.error = null
+      this.recordSuccess()
       return embedding
     } catch (error) {
       this.loading = false
       this.error = error instanceof Error ? error.message : String(error)
+      if (!wasLoaded) {
+        this.recordFailure()
+      }
       logger.error('Generation failed:', error)
       // Until now this failure only ever reached electron-log, so a user
       // silently losing semantic-search indexing was invisible to us. Throttled
@@ -303,13 +347,48 @@ class EmbeddingModelBridge {
     this.rejectAll(new Error('Embedding utility reset'))
     this.loaded = false
     this.loading = false
-    this.loadFailed = false
+    this.clearLoadFailure()
     this.error = null
     this.shuttingDown = false
   }
 
   clearLoadFailure(): void {
     this.loadFailed = false
+    this.consecutiveFailures = 0
+    this.retryNotBefore = 0
+  }
+
+  /** True while a load must not be attempted: backing off, or latched for good. */
+  private isBreakerOpen(): boolean {
+    return this.loadFailed || Date.now() < this.retryNotBefore
+  }
+
+  private recordFailure(): void {
+    this.consecutiveFailures += 1
+
+    if (this.consecutiveFailures >= MAX_CONSECUTIVE_LOAD_FAILURES) {
+      this.loadFailed = true
+      this.retryNotBefore = 0
+      logger.error('Embedding model failed repeatedly — giving up until restart', {
+        attempts: this.consecutiveFailures,
+        error: this.error
+      })
+      return
+    }
+
+    const delay = LOAD_RETRY_BASE_DELAY_MS * 2 ** (this.consecutiveFailures - 1)
+    this.retryNotBefore = Date.now() + delay
+    logger.warn('Embedding model failed — backing off before retry', {
+      attempt: this.consecutiveFailures,
+      retryInMs: delay,
+      error: this.error
+    })
+  }
+
+  private recordSuccess(): void {
+    this.loadFailed = false
+    this.consecutiveFailures = 0
+    this.retryNotBefore = 0
   }
 
   private async start(): Promise<void> {

--- a/apps/docs/src/user-guide/ai/embeddings-search.md
+++ b/apps/docs/src/user-guide/ai/embeddings-search.md
@@ -30,9 +30,27 @@ The status line shows:
 - **Loaded** — ready
 - **Loading** — initialization in progress
 - **Not downloaded** — needs download
-- **Error** — see logs; usually disk space or hash mismatch
+- **Error** — see logs; usually disk space, a hash mismatch, or a failed download
 
 You can **Unload** the model from settings to free memory; reload as needed.
+
+### When the Download Fails
+
+The model is fetched once (~23MB). If that download fails — you are offline, behind a proxy, or the
+CDN is blocked — memrynote does **not** hammer the network. It waits before trying again, backing off
+each time (about one minute, then two, four, and eight), and after several consecutive failures it
+stops retrying for the rest of the session. Semantic search falls back to keyword-only meanwhile;
+nothing else is affected, and no notes are lost.
+
+If the connection comes back on its own, a later retry picks it up and indexing resumes with no action
+from you. To retry immediately instead of waiting out the backoff, do any of these — each one clears
+the wait:
+
+- Toggle **Enable** off and on in [Settings → AI](/user-guide/settings#ai)
+- Click **Download** / **Load model**
+- Click **Rebuild Index**
+
+Restarting memrynote also clears it.
 
 Opening a vault never blocks on embeddings. When a vault has notes that still need embedding — for
 example the first open after importing a vault — memrynote embeds them in the **background** after the


### PR DESCRIPTION
Part of #836 (prod log triage epic). Addresses the code portion of #840.

> Rebased onto current `main`. Note: **#840 item 4 (content-length stderr noise) was already fixed on `main`** by `isInformationalWorkerStderr`, so this PR carries **only the backoff/breaker change** (item 3).

## What & why

The embeddings model-load circuit breaker (#803/#821) latched on the **first** failure and never re-opened. That fixed the vault-open hang, but created the opposite failure mode: a brief network blip (offline, proxy, blocked CDN) silently disabled semantic indexing for the **rest of the app session**, recoverable only by restart. Meanwhile one prod win32 install re-attempted the ~23MB download **48 times in 10 minutes** — a tight retry loop with no backoff.

This replaces the one-shot latch with a counted exponential backoff and closes a hole where `embed()` bypassed the breaker entirely.

## Changes

- **Backoff instead of permanent latch** — consecutive load failures back off `60s → 2m → 4m → 8m`, then latch for the session. If the network recovers on its own, a later retry resumes indexing with no user action.
- **`embed()` now respects the breaker** — previously it neither read nor set it, and the worker re-drives the download inside `handleEmbed`, so any caller skipping the `isModelLoaded() → initEmbeddingModel()` guard reopened the loop. Failures there only feed the backoff when the call had to load the model, so a crash with the model already loaded still recovers by re-forking on the next note.
- **Explicit user retries bypass the wait** — re-enabling AI, "Load model", and "Rebuild Index" all call `resetEmbeddingModelFailure()`, which clears the backoff immediately.

## Verification

- `embeddings.test.ts`: 34/34 (6 new backoff tests). Full `main` project: **6227 pass / 0 unexpected fail**.
- New tests mutation-checked: first-failure-latch and the missing `embed()` guard each fail at least one test.
- `tsc` (node + test) clean · `eslint` clean · `docs:impact --strict` covered · `docs:build` green.
- Docs updated: `apps/docs/src/user-guide/ai/embeddings-search.md` (new "When the Download Fails" section).

## Not in this PR (release-ops, tracked in #840)

- [ ] Cut the next release so #820/#821 actually ship (`git tag --contains` on their merge commits is currently empty).
- [ ] After release: re-query Loki, confirm the darwin `Utility:crashed:Embeddings` exit-6 group clears for the new `app_version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
