### PR TITLE
fix(auth): let a reinstall finish after the setup token's five minutes

### DIFF
--- a/apps/desktop/src/main/ipc/auth-device-handlers.ts
+++ b/apps/desktop/src/main/ipc/auth-device-handlers.ts
@@ -50,12 +50,8 @@ import {
   initiateDeviceLinking,
   linkViaQr
 } from '../sync/linking-service'
-import {
-  getValidAccessToken,
-  isTokenExpired,
-  retrieveToken,
-  storeToken
-} from '../sync/token-manager'
+import { getValidAccessToken, storeToken } from '../sync/token-manager'
+import { ensureLiveSetupToken, getSetupDevicePublicKey } from '../sync/setup-token'
 import { createLogger } from '../lib/logger'
 import { registerCommand } from './lib/register-command'
 import { getMainI18n } from '../lib/main-i18n'
@@ -315,7 +311,10 @@ export function registerAuthDeviceHandlers(): void {
     async (input) => {
       const raw = await postToServer<unknown>('/auth/otp/verify', {
         email: input.email,
-        code: input.code
+        code: input.code,
+        // Committing this device's key here is what lets the setup token be
+        // renewed later, when the user comes back with their recovery phrase.
+        devicePublicKey: await getSetupDevicePublicKey()
       })
       const serverResponse = VerifyOtpResponseSchema.parse(raw)
 
@@ -338,7 +337,7 @@ export function registerAuthDeviceHandlers(): void {
   )
 
   ipcMain.handle(SYNC_CHANNELS.SETUP_NEW_ACCOUNT, async () => {
-    const setupToken = await retrieveToken(KEYCHAIN_ENTRIES.SETUP_TOKEN)
+    const setupToken = await ensureLiveSetupToken()
     if (!setupToken) {
       logSetupTokenFailure('first-device-setup', 'absent')
       return { success: false, error: setupSessionExpiredMessage() }
@@ -376,7 +375,7 @@ export function registerAuthDeviceHandlers(): void {
     SYNC_CHANNELS.LINK_VIA_QR,
     LinkViaQrSchema,
     async (input) => {
-      const token = input.oauthToken || (await retrieveToken(KEYCHAIN_ENTRIES.SETUP_TOKEN))
+      const token = input.oauthToken || (await ensureLiveSetupToken())
       if (!token) {
         // Same class of failure as the recovery path, on the QR surface: the
         // sign-in that minted the setup token ran out. "No auth token available
@@ -423,16 +422,13 @@ export function registerAuthDeviceHandlers(): void {
         return { success: false, error: getMainI18n().t('errors:auth.invalidRecoveryPhraseFormat') }
       }
 
-      const setupToken = await retrieveToken(KEYCHAIN_ENTRIES.SETUP_TOKEN)
+      // Finding a 24-word recovery phrase routinely outlasts the setup token's
+      // five minutes, so a token that ran out is renewed in place here rather
+      // than dead-ending the reinstall (#1202). Null means renewal was not
+      // possible either, which is where "sign in again" takes over.
+      const setupToken = await ensureLiveSetupToken()
       if (!setupToken) {
         logSetupTokenFailure('recovery-info', 'absent')
-        return setupSessionExpiredResult()
-      }
-
-      // Checked locally first: a token that already ran out cannot be salvaged
-      // by a round trip, and the server's own wording for it is unreadable.
-      if (isTokenExpired(setupToken)) {
-        logSetupTokenFailure('recovery-info', 'locally-expired')
         return setupSessionExpiredResult()
       }
 

--- a/apps/desktop/src/main/ipc/auth-oauth-handlers.ts
+++ b/apps/desktop/src/main/ipc/auth-oauth-handlers.ts
@@ -19,6 +19,7 @@ import { getSyncEngine, startSyncRuntime } from '../sync/runtime'
 import { startGoogleCalendarSyncRunner } from '../calendar/google/sync-service'
 import { teardownSession } from '../sync/session-teardown'
 import { refreshAccessToken, storeToken } from '../sync/token-manager'
+import { getSetupDevicePublicKey } from '../sync/setup-token'
 import { createLogger } from '../lib/logger'
 import { registerCommand } from './lib/register-command'
 import {
@@ -232,7 +233,10 @@ export function registerAuthOAuthHandlers(): void {
       const raw = await postToServer<unknown>(`/auth/oauth/${input.provider}/callback`, {
         code: input.oauthToken,
         state: input.state,
-        redirectUri: session.redirectUri
+        redirectUri: session.redirectUri,
+        // Committing this device's key here is what lets the setup token be
+        // renewed later, when the user comes back with their recovery phrase.
+        devicePublicKey: await getSetupDevicePublicKey()
       })
       const serverResponse = OAuthCallbackResponseSchema.parse(raw)
 

--- a/apps/desktop/src/main/sync/setup-token.test.ts
+++ b/apps/desktop/src/main/sync/setup-token.test.ts
@@ -1,0 +1,172 @@
+import sodium from 'libsodium-wrappers-sumo'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { KEYCHAIN_ENTRIES } from '@memry/contracts/crypto'
+
+/**
+ * The keychain and the network are stubbed; the signing is real. A renewal that
+ * carried a bogus signature would be rejected by the server, so the test
+ * verifies the challenge signature with libsodium exactly as the server does
+ * rather than asserting "postToServer was called".
+ */
+
+type KeychainEntry = (typeof KEYCHAIN_ENTRIES)[keyof typeof KEYCHAIN_ENTRIES]
+
+const keychain = new Map<KeychainEntry, Uint8Array>()
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+vi.mock('../lib/window-broadcast', () => ({
+  broadcastToAllWindows: vi.fn()
+}))
+
+vi.mock('../crypto', async () => {
+  const libsodium = (await import('libsodium-wrappers-sumo')).default
+  await libsodium.ready
+  return {
+    // Copy in and out, like a real keychain — so secureCleanup zeroing the
+    // caller's buffer cannot corrupt what was stored.
+    storeKey: vi.fn(async (entry: KeychainEntry, bytes: Uint8Array) => {
+      keychain.set(entry, new Uint8Array(bytes))
+    }),
+    retrieveKey: vi.fn(async (entry: KeychainEntry) => {
+      const stored = keychain.get(entry)
+      return stored ? new Uint8Array(stored) : null
+    }),
+    getOrCreateSigningKeyPair: vi.fn(async () => {
+      const pair = libsodium.crypto_sign_keypair()
+      return { deviceId: 'device-1', publicKey: pair.publicKey, secretKey: pair.privateKey }
+    }),
+    getDevicePublicKey: (secretKey: Uint8Array) =>
+      libsodium.crypto_sign_ed25519_sk_to_pk(secretKey),
+    secureCleanup: (...buffers: Uint8Array[]) => {
+      for (const buffer of buffers) libsodium.memzero(buffer)
+    }
+  }
+})
+
+vi.mock('./http-client', () => ({
+  postToServer: vi.fn(),
+  SyncServerError: class extends Error {}
+}))
+
+import { postToServer } from './http-client'
+import { ensureLiveSetupToken, getSetupDevicePublicKey } from './setup-token'
+
+const base64Url = (value: string): string =>
+  btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+const mintToken = (jti: string, expiresInSeconds: number): string =>
+  [
+    base64Url(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })),
+    base64Url(
+      JSON.stringify({
+        sub: 'user-1',
+        type: 'setup',
+        jti,
+        exp: Math.floor(Date.now() / 1000) + expiresInSeconds
+      })
+    ),
+    'signature'
+  ].join('.')
+
+const storeSetupToken = async (token: string): Promise<void> => {
+  keychain.set(KEYCHAIN_ENTRIES.SETUP_TOKEN, new TextEncoder().encode(token))
+}
+
+const readSetupToken = (): string | null => {
+  const stored = keychain.get(KEYCHAIN_ENTRIES.SETUP_TOKEN)
+  return stored ? new TextDecoder().decode(stored) : null
+}
+
+describe('setup token renewal', () => {
+  beforeEach(async () => {
+    await sodium.ready
+    keychain.clear()
+    vi.mocked(postToServer).mockReset()
+  })
+
+  it('hands back the stored token while it is still live', async () => {
+    // #given
+    const live = mintToken('jti-live', 600)
+    await storeSetupToken(live)
+
+    // #when
+    const token = await ensureLiveSetupToken()
+
+    // #then no round trip is spent on a perfectly good token.
+    expect(token).toBe(live)
+    expect(postToServer).not.toHaveBeenCalled()
+  })
+
+  it('renews in place when the sign-in that minted the token has run out', async () => {
+    // #given the #1202 shape: the user signed in, went to find their 24-word
+    // recovery phrase, and came back to a dead token.
+    const committedPublicKey = await getSetupDevicePublicKey()
+    expect(committedPublicKey).toBeDefined()
+
+    const expired = mintToken('jti-expired', -120)
+    await storeSetupToken(expired)
+
+    const renewed = mintToken('jti-renewed', 300)
+    vi.mocked(postToServer).mockResolvedValue({ success: true, setupToken: renewed })
+
+    // #when
+    const token = await ensureLiveSetupToken()
+
+    // #then the caller continues with a live token, and it is persisted so the
+    // rest of the registration burst uses the same one.
+    expect(token).toBe(renewed)
+    expect(readSetupToken()).toBe(renewed)
+
+    // #and the challenge really is signed by the key committed at sign-in.
+    const [path, body] = vi.mocked(postToServer).mock.calls[0]!
+    expect(path).toBe('/auth/setup-token/renew')
+    const { challengeNonce, challengeSignature, setupToken } = body as {
+      challengeNonce: string
+      challengeSignature: string
+      setupToken: string
+    }
+    expect(setupToken).toBe(expired)
+    expect(
+      sodium.crypto_sign_verify_detached(
+        sodium.from_base64(challengeSignature, sodium.base64_variants.ORIGINAL),
+        new TextEncoder().encode(`${challengeNonce}:jti-expired`),
+        sodium.from_base64(committedPublicKey!, sodium.base64_variants.ORIGINAL)
+      )
+    ).toBe(true)
+  })
+
+  it('gives up rather than guessing when no device key was ever committed', async () => {
+    // #given an install that signed in before the commitment existed.
+    await storeSetupToken(mintToken('jti-expired', -120))
+
+    // #when
+    const token = await ensureLiveSetupToken()
+
+    // #then it falls back to the existing "sign in again" path instead of
+    // sending an unsignable renewal.
+    expect(token).toBeNull()
+    expect(postToServer).not.toHaveBeenCalled()
+  })
+
+  it('keeps the committed device key stable across calls', async () => {
+    // #given the key committed at sign-in must be the same one that signs the
+    // renewal minutes later — getOrCreateSigningKeyPair alone mints a fresh
+    // ephemeral pair on a clean install.
+    const first = await getSetupDevicePublicKey()
+
+    // #when
+    const second = await getSetupDevicePublicKey()
+
+    // #then
+    expect(second).toBe(first)
+  })
+})

--- a/apps/desktop/src/main/sync/setup-token.ts
+++ b/apps/desktop/src/main/sync/setup-token.ts
@@ -1,0 +1,110 @@
+import sodium from 'libsodium-wrappers-sumo'
+
+import { RenewSetupTokenResponseSchema } from '@memry/contracts/auth-api'
+import { KEYCHAIN_ENTRIES } from '@memry/contracts/crypto'
+
+import {
+  getDevicePublicKey,
+  getOrCreateSigningKeyPair,
+  retrieveKey,
+  secureCleanup,
+  storeKey
+} from '../crypto'
+import { createLogger } from '../lib/logger'
+import { postToServer } from './http-client'
+import { extractJtiFromToken, isTokenExpired, retrieveToken, storeToken } from './token-manager'
+
+const log = createLogger('Sync:SetupToken')
+
+const toBase64 = (bytes: Uint8Array): string =>
+  sodium.to_base64(bytes, sodium.base64_variants.ORIGINAL)
+
+/**
+ * The signing key must be the SAME one at sign-in (when its public half is
+ * committed into the setup token) and at renewal (when it signs the challenge).
+ * `getOrCreateSigningKeyPair()` mints an ephemeral pair whenever the keychain
+ * is empty — a fresh install, which is precisely the recovery case — and only
+ * `persistKeysAndRegisterDevice` stores it, far too late to be the commitment.
+ * So persist it here, at the moment we commit to it.
+ */
+const getStableSigningSecretKey = async (): Promise<Uint8Array> => {
+  const existing = await retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY)
+  if (existing) return existing
+
+  const pair = await getOrCreateSigningKeyPair()
+  await storeKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY, pair.secretKey)
+  return pair.secretKey
+}
+
+/**
+ * Public half of this device's signing key, sent at sign-in so the server can
+ * bind setup-token renewal to this device and nobody else.
+ *
+ * Best-effort: if it cannot be produced the field is simply omitted and the
+ * setup token behaves exactly as it did before #1202 — one 5-minute grant, not
+ * renewable.
+ */
+export const getSetupDevicePublicKey = async (): Promise<string | undefined> => {
+  let secretKey: Uint8Array | undefined
+  try {
+    await sodium.ready
+    secretKey = await getStableSigningSecretKey()
+    return toBase64(getDevicePublicKey(secretKey))
+  } catch (err) {
+    log.warn('Could not commit a device key at sign-in — setup token will not be renewable', err)
+    return undefined
+  } finally {
+    if (secretKey) secureCleanup(secretKey)
+  }
+}
+
+const renewSetupToken = async (expiredToken: string): Promise<string | null> => {
+  let secretKey: Uint8Array | undefined
+  try {
+    await sodium.ready
+    secretKey = (await retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY)) ?? undefined
+    if (!secretKey) {
+      log.warn('No committed device key on this install — setup token cannot be renewed')
+      return null
+    }
+
+    const challengeNonce = crypto.randomUUID()
+    const jti = extractJtiFromToken(expiredToken)
+    const signature = sodium.crypto_sign_detached(
+      new TextEncoder().encode(`${challengeNonce}:${jti}`),
+      secretKey
+    )
+
+    const raw = await postToServer<unknown>('/auth/setup-token/renew', {
+      setupToken: expiredToken,
+      challengeNonce,
+      challengeSignature: toBase64(signature)
+    })
+    const { setupToken } = RenewSetupTokenResponseSchema.parse(raw)
+
+    await storeToken(KEYCHAIN_ENTRIES.SETUP_TOKEN, setupToken)
+    log.info('Renewed the setup token for an in-progress device setup')
+    return setupToken
+  } catch (err) {
+    log.warn('Setup token renewal failed', err)
+    return null
+  } finally {
+    if (secretKey) secureCleanup(secretKey)
+  }
+}
+
+/**
+ * The setup token the current device setup should use.
+ *
+ * #1202: the token is minted at sign-in but first used minutes later, once the
+ * user has come back with their 24-word recovery phrase. Rather than dead-end
+ * on the five-minute clock, renew it in place. Returns null only when there is
+ * nothing left to renew, which is where the existing "sign in again" path takes
+ * over.
+ */
+export const ensureLiveSetupToken = async (): Promise<string | null> => {
+  const stored = await retrieveToken(KEYCHAIN_ENTRIES.SETUP_TOKEN)
+  if (!stored) return null
+  if (!isTokenExpired(stored)) return stored
+  return renewSetupToken(stored)
+}

--- a/apps/docs/src/user-guide/sync/recovery-rotation.md
+++ b/apps/docs/src/user-guide/sync/recovery-rotation.md
@@ -55,10 +55,16 @@ the server is never affected.
 
 ### If the Sign-In Times Out
 
-The sign-in that precedes recovery is only valid for a few minutes. If you go looking for your
-recovery phrase and come back after it has run out, the app tells you the sign-in timed out and
-asks you to sign in again before entering the phrase — the phrase itself is still fine, and
-nothing was lost. A **Sign in again** button appears alongside the message so you can act on it
+The sign-in that precedes recovery is only valid for a few minutes, but going away to find your
+recovery phrase no longer costs you that sign-in. When you submit the phrase after the few minutes
+have passed, memrynote renews the sign-in in place — using a key it tied to this device when you
+signed in — and carries straight on. You do not have to do anything, and you can take as long as
+you need within a day of signing in.
+
+If it cannot renew — the app was reinstalled again in between, the sign-in is more than a day old,
+or it came from an older version that did not tie a key to the device — you are told the sign-in
+timed out and asked to sign in again before entering the phrase. The phrase itself is still fine
+and nothing was lost. A **Sign in again** button appears alongside the message so you can act on it
 straight away, in every language memrynote supports.
 
 ### If You Can't Get Your Recovery Phrase Back

--- a/apps/sync-server/src/routes/auth.test.ts
+++ b/apps/sync-server/src/routes/auth.test.ts
@@ -39,7 +39,11 @@ vi.mock('../services/auth', () => ({
     accessToken: 'new-access-token',
     refreshToken: 'new-refresh-token'
   }),
-  signSetupToken: vi.fn().mockResolvedValue('mock-setup-token')
+  signSetupToken: vi.fn().mockResolvedValue('mock-setup-token'),
+  // Renewal is covered for real in setup-token-renewal.real-jose.test.ts; this
+  // stub only keeps the module's export surface complete for this suite.
+  verifyRenewableSetupToken: vi.fn(),
+  SETUP_TOKEN_RENEWAL_WINDOW_SECONDS: 24 * 60 * 60
 }))
 
 vi.mock('../services/device', () => ({

--- a/apps/sync-server/src/routes/auth.ts
+++ b/apps/sync-server/src/routes/auth.ts
@@ -10,6 +10,7 @@ import {
   FirstDeviceSetupRequestSchema,
   RefreshTokenRequestSchema,
   OAuthCallbackSchema,
+  RenewSetupTokenRequestSchema,
   EmailChangeRequestSchema,
   EmailChangeVerifySchema,
   DeleteAccountRequestSchema
@@ -27,7 +28,8 @@ import {
   issueTokens,
   revokeDeviceTokens,
   rotateRefreshToken,
-  signSetupToken
+  signSetupToken,
+  verifyRenewableSetupToken
 } from '../services/auth'
 import { listDevices } from '../services/device'
 import { sendEmail } from '../services/email'
@@ -86,6 +88,14 @@ const recoveryIpRateLimit = createRateLimiter({
   maxRequests: 3,
   windowSeconds: 600,
   keyPrefix: 'recovery-ip'
+})
+
+// A legitimate setup renews at most a handful of times while its user hunts
+// for a recovery phrase; this only exists to cap signature-probing.
+const setupRenewRateLimit = createRateLimiter({
+  maxRequests: 10,
+  windowSeconds: 600,
+  keyPrefix: 'setup-renew'
 })
 
 const handleOtpRequest = async (c: Parameters<typeof otpIpRateLimit>[0]): Promise<Response> => {
@@ -265,7 +275,7 @@ auth.post('/otp/verify', otpIpRateLimit, async (c) => {
     throw new AppError(ErrorCodes.VALIDATION_ERROR, 'Invalid request body', 400)
   }
 
-  const { email, code, sessionNonce } = parsed.data
+  const { email, code, sessionNonce, devicePublicKey } = parsed.data
 
   await verifyOtp(c.env.DB, email, code, c.env.OTP_HMAC_KEY)
 
@@ -282,7 +292,9 @@ auth.post('/otp/verify', otpIpRateLimit, async (c) => {
     c.env.LOCAL_ADMIN_SYNC_EMAILS
   )
 
-  const setupToken = await signSetupToken(user.id, c.env.JWT_PRIVATE_KEY, sessionNonce)
+  const setupToken = await signSetupToken(user.id, c.env.JWT_PRIVATE_KEY, sessionNonce, {
+    devicePublicKey
+  })
 
   safeWaitUntil(
     c,
@@ -349,7 +361,7 @@ auth.post('/oauth/:provider/callback', async (c) => {
     throw new AppError(ErrorCodes.VALIDATION_ERROR, 'Invalid callback body', 400)
   }
 
-  const { code, state, sessionNonce } = parsed.data
+  const { code, state, sessionNonce, devicePublicKey } = parsed.data
 
   const statePayload = await verifyOAuthState(state, c.env.JWT_PUBLIC_KEY)
   const redirectUri = statePayload.redirectUri ?? c.env.GOOGLE_REDIRECT_URI
@@ -392,7 +404,9 @@ auth.post('/oauth/:provider/callback', async (c) => {
     c.env.LOCAL_ADMIN_SYNC_EMAILS
   )
 
-  const setupToken = await signSetupToken(user.id, c.env.JWT_PRIVATE_KEY, sessionNonce)
+  const setupToken = await signSetupToken(user.id, c.env.JWT_PRIVATE_KEY, sessionNonce, {
+    devicePublicKey
+  })
 
   safeWaitUntil(
     c,
@@ -408,6 +422,69 @@ auth.post('/oauth/:provider/callback', async (c) => {
     needsSetup: !user.kdf_salt,
     setupToken
   })
+})
+
+// POST /setup-token/renew
+//
+// #1202: the setup token is minted at sign-in but first used minutes later,
+// once the user has found their 24-word recovery phrase. It sat idle for its
+// whole 5-minute life and then died, stranding the reinstall.
+//
+// Renewal is deliberately NOT a bearer operation. It requires a signature from
+// the device key the client committed at sign-in, so a setup token lifted from
+// a log or an intercepted response is worth exactly the same five minutes it
+// was worth before. Presenting a grant retires it, so only one setup token is
+// ever redeemable, and `renewable_until` is signed into the grant at mint time
+// so the chain cannot outlive its original window.
+auth.post('/setup-token/renew', setupRenewRateLimit, async (c) => {
+  const body = await c.req.json()
+  const parsed = RenewSetupTokenRequestSchema.safeParse(body)
+  if (!parsed.success) {
+    throw new AppError(ErrorCodes.VALIDATION_ERROR, 'Invalid request body', 400)
+  }
+
+  const { setupToken, challengeNonce, challengeSignature } = parsed.data
+
+  let publicKey: CryptoKey
+  try {
+    publicKey = await getPublicKey(c.env.JWT_PUBLIC_KEY)
+  } catch {
+    throw new AppError(ErrorCodes.INTERNAL_ERROR, 'Invalid JWT verify key configuration', 500)
+  }
+
+  const claims = await verifyRenewableSetupToken(setupToken, publicKey)
+
+  const isValid = await verifyDeviceChallenge(
+    claims.devicePublicKey,
+    `${challengeNonce}:${claims.jti}`,
+    challengeSignature
+  )
+  if (!isValid) {
+    throw new AppError(ErrorCodes.AUTH_INVALID_TOKEN, 'Device challenge verification failed', 401)
+  }
+
+  // Same single-use ledger POST /devices writes, so a renewed-away token can
+  // never also register a device. expires_at is the chain deadline rather than
+  // now+5m: cleanup must not drop the row while the chain is still alive, or
+  // the retired jti would become renewable a second time.
+  const consumed = await c.env.DB.prepare(
+    'INSERT OR IGNORE INTO consumed_setup_tokens (jti, user_id, expires_at) VALUES (?, ?, ?)'
+  )
+    .bind(claims.jti, claims.userId, claims.renewableUntil)
+    .run()
+
+  if ((consumed.meta.changes ?? 0) === 0) {
+    throw new AppError(ErrorCodes.AUTH_INVALID_TOKEN, 'Setup token already used', 401)
+  }
+
+  const renewed = await signSetupToken(claims.userId, c.env.JWT_PRIVATE_KEY, claims.sessionNonce, {
+    devicePublicKey: claims.devicePublicKey,
+    renewableUntil: claims.renewableUntil
+  })
+
+  logger.info('Setup token renewed for an in-progress device setup', { userId: claims.userId })
+
+  return c.json({ success: true, setupToken: renewed })
 })
 
 // POST /devices

--- a/apps/sync-server/src/routes/setup-token-renewal.real-jose.test.ts
+++ b/apps/sync-server/src/routes/setup-token-renewal.real-jose.test.ts
@@ -1,0 +1,284 @@
+import { Hono } from 'hono'
+import { exportPKCS8, exportSPKI, generateKeyPair } from 'jose'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { errorHandler } from '../lib/errors'
+import type { AppContext } from '../types'
+
+/**
+ * Deliberately NO `vi.mock('jose')` and NO `vi.mock('../services/auth')`.
+ *
+ * `auth.test.ts` stubs both, so a renewal test living there would assert our
+ * mocks agreed with each other — the exact false confidence that let #1202 sit
+ * in production. Here the setup token is signed by the real signer, expired by
+ * moving the clock, and renewed through the real route with a real Ed25519
+ * device signature.
+ */
+
+vi.mock('../middleware/rate-limit', () => ({
+  createRateLimiter: () => async (_c: unknown, next: () => Promise<void>) => next()
+}))
+
+vi.mock('../services/analytics', () => ({
+  captureBusinessEvent: vi.fn().mockResolvedValue(undefined),
+  captureServerError: vi.fn().mockResolvedValue(undefined),
+  safeWaitUntil: vi.fn(),
+  waitUntilCaptured: vi.fn()
+}))
+
+vi.mock('../services/email', () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined)
+}))
+
+import { auth } from './auth'
+import { setupAuthMiddleware } from '../middleware/setup-auth'
+import { SETUP_TOKEN_RENEWAL_WINDOW_SECONDS, signSetupToken } from '../services/auth'
+
+const ALGORITHM = 'EdDSA'
+const SIGN_IN_AT_MS = Date.UTC(2026, 7, 13, 9, 0, 0)
+
+interface DeviceKeys {
+  publicKeyBase64: string
+  privateKey: CryptoKey
+}
+
+const toBase64 = (bytes: ArrayBuffer): string =>
+  btoa(String.fromCharCode(...new Uint8Array(bytes)))
+
+const createDeviceKeys = async (): Promise<DeviceKeys> => {
+  const { privateKey, publicKey } = await generateKeyPair(ALGORITHM, {
+    crv: 'Ed25519',
+    extractable: true
+  })
+  return {
+    publicKeyBase64: toBase64((await crypto.subtle.exportKey('raw', publicKey)) as ArrayBuffer),
+    privateKey
+  }
+}
+
+const signChallenge = async (
+  device: DeviceKeys,
+  challengeNonce: string,
+  jti: string
+): Promise<string> =>
+  toBase64(
+    await crypto.subtle.sign(
+      'Ed25519',
+      device.privateKey,
+      new TextEncoder().encode(`${challengeNonce}:${jti}`)
+    )
+  )
+
+const decodeJti = (token: string): string =>
+  JSON.parse(atob(token.split('.')[1]!)).jti as string
+
+/** Records every consumed_setup_tokens insert so single-use can be asserted. */
+const createEnv = (
+  jwtPrivateKey: string,
+  jwtPublicKey: string,
+  options?: { alreadyConsumed?: boolean }
+) => {
+  const consumedJtis: string[] = []
+
+  const statement = {
+    bind: vi.fn((...args: unknown[]) => {
+      consumedJtis.push(String(args[0]))
+      return statement
+    }),
+    first: vi.fn().mockResolvedValue(null),
+    run: vi.fn().mockResolvedValue({
+      success: true,
+      meta: { changes: options?.alreadyConsumed ? 0 : 1 }
+    }),
+    all: vi.fn().mockResolvedValue({ results: [] })
+  }
+
+  return {
+    env: {
+      DB: { prepare: vi.fn().mockReturnValue(statement), batch: vi.fn() },
+      JWT_PRIVATE_KEY: jwtPrivateKey,
+      JWT_PUBLIC_KEY: jwtPublicKey,
+      ENVIRONMENT: 'test'
+    } as unknown as Record<string, unknown>,
+    consumedJtis
+  }
+}
+
+const jsonPost = (body: unknown): RequestInit => ({
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body)
+})
+
+describe('POST /auth/setup-token/renew against real jose', () => {
+  let app: Hono<AppContext>
+  let jwtPrivateKey: string
+  let jwtPublicKey: string
+  let device: DeviceKeys
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(SIGN_IN_AT_MS)
+
+    const keys = await generateKeyPair(ALGORITHM, { crv: 'Ed25519', extractable: true })
+    jwtPrivateKey = await exportPKCS8(keys.privateKey)
+    jwtPublicKey = await exportSPKI(keys.publicKey)
+    device = await createDeviceKeys()
+
+    app = new Hono<AppContext>()
+    app.onError(errorHandler)
+    app.route('/auth', auth)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /** Sign in, then walk away for `minutes` looking for the recovery phrase. */
+  const signInThenWait = async (
+    minutes: number,
+    binding: { devicePublicKey?: string } = { devicePublicKey: device.publicKeyBase64 }
+  ): Promise<string> => {
+    const token = await signSetupToken('user-1', jwtPrivateKey, undefined, binding)
+    vi.setSystemTime(SIGN_IN_AT_MS + minutes * 60_000)
+    return token
+  }
+
+  it('renews a setup token that ran out while the user hunted for their phrase', async () => {
+    // #given the #1202 reinstall: the token was minted at sign-in and is stone
+    // dead 20 minutes later, when the user finally types their 24 words.
+    const expired = await signInThenWait(20)
+    const { env, consumedJtis } = createEnv(jwtPrivateKey, jwtPublicKey)
+    const challengeNonce = 'nonce-1'
+
+    // #when the device proves possession of the key it committed at sign-in.
+    const res = await app.request(
+      '/auth/setup-token/renew',
+      jsonPost({
+        setupToken: expired,
+        challengeNonce,
+        challengeSignature: await signChallenge(device, challengeNonce, decodeJti(expired))
+      }),
+      env
+    )
+
+    // #then it gets a live token back...
+    expect(res.status).toBe(200)
+    const { success, setupToken } = (await res.json()) as {
+      success: boolean
+      setupToken: string
+    }
+    expect(success).toBe(true)
+
+    // ...that the real setup-auth middleware admits,
+    const setMap = new Map<string, string>()
+    await setupAuthMiddleware(
+      {
+        req: { header: () => `Bearer ${setupToken}` },
+        env: { JWT_PUBLIC_KEY: jwtPublicKey },
+        set: (key: string, value: string) => setMap.set(key, value)
+      } as never,
+      vi.fn(async () => undefined)
+    )
+    expect(setMap.get('userId')).toBe('user-1')
+
+    // ...while the presented grant is retired, so only one is ever redeemable.
+    expect(consumedJtis).toContain(decodeJti(expired))
+    expect(decodeJti(setupToken)).not.toBe(decodeJti(expired))
+  })
+
+  it('refuses a renewal signed by a device key that was never committed', async () => {
+    // #given a setup token lifted from a log or an intercepted response — the
+    // attacker has the bearer token but not the device's private key.
+    const expired = await signInThenWait(20)
+    const attacker = await createDeviceKeys()
+    const { env, consumedJtis } = createEnv(jwtPrivateKey, jwtPublicKey)
+    const challengeNonce = 'nonce-2'
+
+    // #when
+    const res = await app.request(
+      '/auth/setup-token/renew',
+      jsonPost({
+        setupToken: expired,
+        challengeNonce,
+        challengeSignature: await signChallenge(attacker, challengeNonce, decodeJti(expired))
+      }),
+      env
+    )
+
+    // #then bearer possession alone buys nothing, and the grant is left intact
+    // for its real owner.
+    expect(res.status).toBe(401)
+    expect(consumedJtis).toHaveLength(0)
+  })
+
+  it('refuses to renew a setup token that committed no device key', async () => {
+    // #given a token minted for a client that predates the commitment (or could
+    // not produce a key) — it keeps exactly the old, non-renewable behaviour.
+    const expired = await signInThenWait(20, {})
+    const { env } = createEnv(jwtPrivateKey, jwtPublicKey)
+
+    // #when
+    const res = await app.request(
+      '/auth/setup-token/renew',
+      jsonPost({
+        setupToken: expired,
+        challengeNonce: 'nonce-3',
+        challengeSignature: await signChallenge(device, 'nonce-3', decodeJti(expired))
+      }),
+      env
+    )
+
+    // #then
+    expect(res.status).toBe(401)
+    expect((await res.json()) as { error?: { code?: string } }).toMatchObject({
+      error: { message: 'Setup token is not renewable' }
+    })
+  })
+
+  it('stops renewing once the grant window closes', async () => {
+    // #given the renewal window is an absolute bound signed into the grant, so
+    // the chain cannot outlive it however many times it was renewed.
+    const expired = await signInThenWait(SETUP_TOKEN_RENEWAL_WINDOW_SECONDS / 60 + 1)
+    const { env, consumedJtis } = createEnv(jwtPrivateKey, jwtPublicKey)
+
+    // #when
+    const res = await app.request(
+      '/auth/setup-token/renew',
+      jsonPost({
+        setupToken: expired,
+        challengeNonce: 'nonce-4',
+        challengeSignature: await signChallenge(device, 'nonce-4', decodeJti(expired))
+      }),
+      env
+    )
+
+    // #then
+    expect(res.status).toBe(401)
+    expect(consumedJtis).toHaveLength(0)
+  })
+
+  it('refuses a grant that was already spent', async () => {
+    // #given the jti is already in consumed_setup_tokens — it either registered
+    // a device or was renewed away. Either way it must not mint a second token.
+    const expired = await signInThenWait(20)
+    const { env } = createEnv(jwtPrivateKey, jwtPublicKey, { alreadyConsumed: true })
+
+    // #when
+    const res = await app.request(
+      '/auth/setup-token/renew',
+      jsonPost({
+        setupToken: expired,
+        challengeNonce: 'nonce-5',
+        challengeSignature: await signChallenge(device, 'nonce-5', decodeJti(expired))
+      }),
+      env
+    )
+
+    // #then
+    expect(res.status).toBe(401)
+    expect((await res.json()) as { error?: { message?: string } }).toMatchObject({
+      error: { message: 'Setup token already used' }
+    })
+  })
+})

--- a/apps/sync-server/src/services/auth.ts
+++ b/apps/sync-server/src/services/auth.ts
@@ -1,4 +1,4 @@
-import { SignJWT } from 'jose'
+import { SignJWT, jwtVerify, type JWTPayload } from 'jose'
 
 import { AppError, ErrorCodes } from '../lib/errors'
 import { getPrivateKey } from '../lib/jwt-keys'
@@ -216,10 +216,32 @@ export const revokeDeviceTokens = async (db: D1Database, deviceId: string): Prom
 
 const SETUP_TOKEN_EXPIRY = '5m'
 
+/**
+ * How long the setup grant as a whole stays renewable, measured from the
+ * original sign-in. The token itself still lives 5 minutes; this only bounds
+ * how long the device that committed its key at sign-in may ask for a fresh
+ * one (#1202: finishing a reinstall means finding a 24-word recovery phrase,
+ * which routinely outlasts five minutes).
+ *
+ * Renewal is NOT bearer-redeemable — it needs a signature from the committed
+ * device key — so this window governs an attacker who holds the token *and*
+ * that device's private key, i.e. someone already inside the OS keychain where
+ * the master key lives too.
+ */
+export const SETUP_TOKEN_RENEWAL_WINDOW_SECONDS = 24 * 60 * 60
+
+export interface SetupTokenBinding {
+  /** Base64 Ed25519 public key allowed to renew this grant. */
+  devicePublicKey?: string
+  /** Epoch seconds; inherited by renewals so the chain cannot outlive it. */
+  renewableUntil?: number
+}
+
 export const signSetupToken = async (
   userId: string,
   privateKeyPem: string,
-  sessionNonce?: string
+  sessionNonce?: string,
+  binding?: SetupTokenBinding
 ): Promise<string> => {
   const privateKey = await getPrivateKey(privateKeyPem)
   const claims: Record<string, unknown> = {
@@ -230,5 +252,70 @@ export const signSetupToken = async (
   if (sessionNonce) {
     claims.session_nonce = sessionNonce
   }
+  if (binding?.devicePublicKey) {
+    claims.device_public_key = binding.devicePublicKey
+    claims.renewable_until =
+      binding.renewableUntil ??
+      Math.floor(Date.now() / 1000) + SETUP_TOKEN_RENEWAL_WINDOW_SECONDS
+  }
   return signToken(claims, privateKey, SETUP_TOKEN_EXPIRY)
+}
+
+export interface RenewableSetupTokenClaims {
+  userId: string
+  jti: string
+  devicePublicKey: string
+  renewableUntil: number
+  sessionNonce?: string
+}
+
+/**
+ * Verify a setup token presented for renewal. The signature, issuer, audience
+ * and algorithm are checked in full; only `exp` is allowed to be in the past,
+ * and only as far back as the grant's own `renewable_until` claim — which is
+ * signed, so a caller cannot widen it.
+ */
+export const verifyRenewableSetupToken = async (
+  token: string,
+  publicKey: CryptoKey
+): Promise<RenewableSetupTokenClaims> => {
+  let payload: JWTPayload
+  try {
+    const result = await jwtVerify(token, publicKey, {
+      algorithms: [ALGORITHM],
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      // Bounded by renewable_until below; this only stops jose rejecting the
+      // token before we can read its claims.
+      clockTolerance: SETUP_TOKEN_RENEWAL_WINDOW_SECONDS
+    })
+    payload = result.payload
+  } catch {
+    throw new AppError(ErrorCodes.AUTH_INVALID_TOKEN, 'Invalid setup token', 401)
+  }
+
+  const devicePublicKey = payload.device_public_key
+  const renewableUntil = payload.renewable_until
+
+  if (
+    payload.type !== 'setup' ||
+    typeof payload.sub !== 'string' ||
+    typeof payload.jti !== 'string' ||
+    typeof devicePublicKey !== 'string' ||
+    typeof renewableUntil !== 'number'
+  ) {
+    throw new AppError(ErrorCodes.AUTH_INVALID_TOKEN, 'Setup token is not renewable', 401)
+  }
+
+  if (Math.floor(Date.now() / 1000) >= renewableUntil) {
+    throw new AppError(ErrorCodes.AUTH_TOKEN_EXPIRED, 'Setup token has expired', 401)
+  }
+
+  return {
+    userId: payload.sub,
+    jti: payload.jti,
+    devicePublicKey,
+    renewableUntil,
+    sessionNonce: typeof payload.session_nonce === 'string' ? payload.session_nonce : undefined
+  }
 }

--- a/packages/contracts/src/auth-api.ts
+++ b/packages/contracts/src/auth-api.ts
@@ -7,7 +7,12 @@ export const RequestOtpRequestSchema = z.object({
 export const VerifyOtpRequestSchema = z.object({
   email: z.string().email(),
   code: z.string().regex(/^\d{6}$/),
-  sessionNonce: z.string().min(1).optional()
+  sessionNonce: z.string().min(1).optional(),
+  // Ed25519 public key of the device that will redeem the setup token. Binds
+  // renewal (POST /auth/setup-token/renew) to this key so a leaked setup token
+  // on its own is never renewable. Optional: clients that omit it get exactly
+  // today's behaviour — one non-renewable 5-minute token.
+  devicePublicKey: z.string().min(1).max(128).optional()
 })
 
 export const ResendOtpRequestSchema = z.object({
@@ -38,7 +43,24 @@ export const RefreshTokenRequestSchema = z.object({
 export const OAuthCallbackSchema = z.object({
   code: z.string().min(1),
   state: z.string().min(1),
-  sessionNonce: z.string().min(1).optional()
+  sessionNonce: z.string().min(1).optional(),
+  devicePublicKey: z.string().min(1).max(128).optional()
+})
+
+/**
+ * Renew a setup token that ran out while the user was away finding their
+ * recovery phrase. Proof of possession of the committed device key — not mere
+ * possession of the (expired) token — is what authorises the new one.
+ */
+export const RenewSetupTokenRequestSchema = z.object({
+  setupToken: z.string().min(1),
+  challengeNonce: z.string().min(1).max(128),
+  challengeSignature: z.string().min(1).max(256)
+})
+
+export const RenewSetupTokenResponseSchema = z.object({
+  success: z.boolean(),
+  setupToken: z.string().min(1)
 })
 
 export const RequestOtpResponseSchema = z.object({


### PR DESCRIPTION
Fixes #1202

## What was already fixed

- **#1228** mapped jose's `ERR_JWT_EXPIRED` to `AUTH_TOKEN_EXPIRED` / "Setup token has expired", and added the "start fresh" escape panel.
- **#1376** threaded a machine-readable `errorCode` through both IPC hops so the "Sign in again" button renders in every locale, and added a real-jose expired-token test.

Both made the failure legible. Neither stopped it happening.

## The actual defect

`SETUP_TOKEN_EXPIRY = '5m'`, single-use, consumed by device registration. The token is minted at sign-in and first used when the user submits their recovery phrase — the recovery flow makes **both** of its server calls (`GET /auth/recovery-info`, `POST /auth/devices`) in one burst at submit. So the token sits completely idle for its whole life while the user goes to find 24 words, and the only thing that can spend the window is the hunt itself. Losing the race sent them back through a full sign-in into another five-minute window.

## Options considered

**(a) re-mint using the user's existing session — infeasible as literally specified.** At recovery time there is no session. Refresh tokens are only ever issued *by* `POST /auth/devices` (`issueTokens`, `apps/sync-server/src/routes/auth.ts`), which is the gated step. On a fresh install `token-manager.ts` has nothing in the keychain to refresh.

**(b) mint the setup token later — infeasible.** The mint authority is a fresh proof of email control (`/auth/otp/verify`, `/auth/oauth/:provider/callback`). Anything that survives the user's hunt so it can authorise a later mint *is itself* the long-lived device-registration credential. Deferring `/auth/otp/verify` to submit-time only moves the race onto the OTP's own 10-minute single-use clock and cannot work for OAuth at all.

**(a′) re-mint authorised by the expired setup token itself — implemented, with the piece that stops it being a lifetime extension.**

A renewal endpoint that accepts a bearer setup token *is* just a longer expiry with extra steps, and that trade is not mine to make. So renewal is **not a bearer operation**. The device commits its Ed25519 public key at sign-in (`device_public_key` claim); renewal requires a signature from that key over `${challengeNonce}:${jti}`. Possession of the token alone renews nothing.

**(c)** is not included. It only exists to warn users about a deadline, and after this change the deadline is not the thing that ends their reinstall.

## Security properties, before and after

| | Before | After |
|---|---|---|
| Token lifetime | 5 min | 5 min — unchanged |
| Single use | jti retired in `consumed_setup_tokens` by `POST /auth/devices` | unchanged, **and** renewal retires the presented jti in the same ledger, so a renewed-away token can never also register a device |
| Live tokens per grant | 1 | 1 — presenting a grant kills it before its replacement is minted |
| Scope | `/auth/recovery-info` + `/auth/devices` | unchanged |
| Value of a token leaked in a log or an intercepted response | one device registration within 5 min | **one device registration within 5 min — unchanged.** Renewal needs the device private key, which the token never conveys |
| Unauthenticated mint | impossible | impossible — renewal verifies a full JWT signature (issuer, audience, EdDSA) plus an Ed25519 challenge |
| Outer bound | n/a | `renewable_until`, **signed into the grant** at mint time and inherited by every renewal, so the chain cannot outlive its window or be widened by the caller. 24h. |

The 24h bound governs an attacker holding the token *and* the committed device private key — i.e. someone already inside the OS keychain, where the master key lives too. Dial the constant if you want it tighter; it is one named export (`SETUP_TOKEN_RENEWAL_WINDOW_SECONDS`).

Backward compatible both ways: `devicePublicKey` is optional, and a token minted without it is explicitly **not renewable** — older clients and the landing app keep exactly today's behaviour, one non-renewable 5-minute token. No schema change; `consumed_setup_tokens` is reused as-is (with `expires_at` set to the chain deadline so cleanup cannot resurrect a retired jti).

## Changes

- `packages/contracts/src/auth-api.ts` — optional `devicePublicKey` on OTP-verify and OAuth-callback; `RenewSetupTokenRequest/Response`.
- `apps/sync-server/src/services/auth.ts` — `signSetupToken` takes an optional binding; `verifyRenewableSetupToken` verifies signature/issuer/audience in full and lets only `exp` be past, bounded by the signed `renewable_until`.
- `apps/sync-server/src/routes/auth.ts` — `POST /auth/setup-token/renew`, rate-limited, reusing the existing `verifyDeviceChallenge`.
- `apps/desktop/src/main/sync/setup-token.ts` (new) — commits a *persisted* signing key at sign-in (`getOrCreateSigningKeyPair` mints an ephemeral pair on a clean install and only `persistKeysAndRegisterDevice` stores it, far too late to be a commitment) and renews in place.
- Recovery, QR linking and first-device setup now go through `ensureLiveSetupToken()` instead of dead-ending on a local expiry check.

## Verification

```
pnpm lint                 ✓ 90 problems (0 errors, 90 warnings) — all pre-existing prettier warnings
pnpm typecheck            ✓ Tasks: 16 successful, 16 total
pnpm test:sync-server     ✓ Test Files 62 passed (62) · Tests 941 passed (941)
desktop --project main    ✓ Test Files 3 passed (3) · Tests 53 passed (53)
pnpm ipc:generate && ipc:check  ✓ IPC invoke map is up to date
pnpm check:contracts      ✓ contracts boundary check passed
pnpm check:architecture   ✓ architecture boundary check passed
pnpm --filter @memry/desktop i18n:check  ✓ ok (no new strings)
pnpm docs:impact --base origin/main --strict  ✓ docs changed on this branch
pnpm docs:build           ✓ build complete
git diff --check          ✓ clean
```

### Mutation evidence

Mocked tests give false confidence here, so both fixes were reverted locally and the suites re-run:

- `signSetupToken` stripped of the `device_public_key` claim → **2 failed | 939 passed** in sync-server.
- `ensureLiveSetupToken` reverted to `if (isTokenExpired(stored)) return null` → **1 failed | 3 passed** in desktop.

Restored, both green again. The sync-server test is deliberately in its own file with **no** `vi.mock('jose')` and **no** `vi.mock('../services/auth')` — `auth.test.ts` stubs both, so a renewal test living there would only prove the mocks agree with each other. The desktop test stubs the keychain and the network but verifies the challenge signature with libsodium exactly as the server does.