### PR TITLE
feat(comments): rich-text formatting with a selection toolbar

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-prompt-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-prompt-editor.test.tsx
@@ -4,10 +4,14 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
-import { AgentPromptEditor, type AgentPromptEditorHandle } from '../agent-prompt-editor'
+import {
+  AgentPromptEditor,
+  buildPromptExtensions,
+  type AgentPromptEditorHandle
+} from '../agent-prompt-editor'
 import type { MentionAttachment } from '../mention-icons'
 
-function renderPromptEditor() {
+function renderPromptEditor(richTextMarks = false) {
   const ref = createRef<AgentPromptEditorHandle>()
   const onEscape = vi.fn()
   const onMentionKeyDown = vi.fn(() => false)
@@ -20,6 +24,7 @@ function renderPromptEditor() {
       ref={ref}
       disabled={false}
       placeholder="Ask memrynote anything. @ to use mention file"
+      richTextMarks={richTextMarks}
       onEscape={onEscape}
       onMentionKeyDown={onMentionKeyDown}
       onMentionQueryChange={onMentionQueryChange}
@@ -53,7 +58,7 @@ describe('AgentPromptEditor', () => {
       label: 'Folder',
       icon: { kind: 'folder' }
     })
-    expect(ref.current?.getValue()).toEqual({ text: '', attachments: [] })
+    expect(ref.current?.getValue()).toEqual({ text: '', attachments: [], formatRanges: [] })
 
     await typePrompt('hello')
     fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' })
@@ -66,8 +71,8 @@ describe('AgentPromptEditor', () => {
       ref.current?.clear()
     })
 
-    expect(ref.current?.getValue()).toEqual({ text: '', attachments: [] })
-    expect(onValueChange).toHaveBeenLastCalledWith({ text: '', attachments: [] })
+    expect(ref.current?.getValue()).toEqual({ text: '', attachments: [], formatRanges: [] })
+    expect(onValueChange).toHaveBeenLastCalledWith({ text: '', attachments: [], formatRanges: [] })
   })
 
   it('inserts plain text through the imperative handle', async () => {
@@ -77,7 +82,7 @@ describe('AgentPromptEditor', () => {
       ref.current?.insertText('@')
     })
 
-    expect(ref.current?.getValue()).toEqual({ text: '@', attachments: [] })
+    expect(ref.current?.getValue()).toEqual({ text: '@', attachments: [], formatRanges: [] })
     expect(onMentionQueryChange).toHaveBeenLastCalledWith('')
   })
 
@@ -90,7 +95,7 @@ describe('AgentPromptEditor', () => {
     })
 
     // A leading space is prepended so the mention regex matches after a word.
-    expect(ref.current?.getValue()).toEqual({ text: 'hello @', attachments: [] })
+    expect(ref.current?.getValue()).toEqual({ text: 'hello @', attachments: [], formatRanges: [] })
     expect(onMentionQueryChange).toHaveBeenLastCalledWith('')
   })
 
@@ -101,7 +106,7 @@ describe('AgentPromptEditor', () => {
       ref.current?.insertMentionTrigger()
     })
 
-    expect(ref.current?.getValue()).toEqual({ text: '@', attachments: [] })
+    expect(ref.current?.getValue()).toEqual({ text: '@', attachments: [], formatRanges: [] })
     expect(onMentionQueryChange).toHaveBeenLastCalledWith('')
   })
 
@@ -149,7 +154,8 @@ describe('AgentPromptEditor', () => {
         { kind: 'current_note', ref_id: 'note-1', label: 'Current Note' },
         { kind: 'folder', ref_id: 'folder-1', label: 'Reference Folder' },
         { kind: 'project', ref_id: 'project-1', label: 'Reference Project' }
-      ]
+      ],
+      formatRanges: []
     })
     expect(onMentionQueryChange).toHaveBeenLastCalledWith(null)
   })
@@ -173,5 +179,72 @@ describe('AgentPromptEditor', () => {
       expect(screen.queryByTestId('agent-mention-task-task-1')).not.toBeInTheDocument()
     })
     expect(ref.current?.getValue().attachments).toEqual([])
+  })
+
+  it('keeps every inline mark disabled unless rich text is opted into', () => {
+    const starterKitOptions = (richTextMarks: boolean): Record<string, unknown> =>
+      (
+        buildPromptExtensions(richTextMarks, '')[0] as unknown as {
+          options: Record<string, unknown>
+        }
+      ).options
+    const plainStarterKit = { options: starterKitOptions(false) }
+    const richStarterKit = { options: starterKitOptions(true) }
+
+    for (const mark of ['bold', 'italic', 'underline', 'strike', 'code']) {
+      expect(plainStarterKit.options[mark]).toBe(false)
+      expect(richStarterKit.options[mark]).not.toBe(false)
+    }
+    // Block-level nodes stay off in both: a comment is one paragraph.
+    for (const block of ['heading', 'bulletList', 'codeBlock', 'link']) {
+      expect(richStarterKit.options[block]).toBe(false)
+    }
+  })
+
+  it('reports formatting as offsets into the flattened text, mentions kept whole', () => {
+    const { ref } = renderPromptEditor(true)
+
+    act(() => {
+      ref.current?.seed([
+        { kind: 'text', text: 'see ' },
+        { kind: 'text', text: 'this', marks: ['bold', 'code'] },
+        { kind: 'text', text: ' and ' },
+        {
+          kind: 'mention',
+          attachment: {
+            kind: 'note',
+            ref_id: 'note-1',
+            label: 'Planning',
+            icon: { kind: 'note', emoji: null }
+          },
+          marks: ['italic']
+        },
+        { kind: 'text', text: '\nnext line', marks: ['strikethrough'] }
+      ])
+    })
+
+    const value = ref.current?.getValue()
+    expect(value?.text).toBe('see this and @Planning\nnext line')
+    expect(value?.formatRanges).toEqual([
+      { start: 4, end: 8, marks: ['bold', 'code'] },
+      { start: 13, end: 22, marks: ['italic'] },
+      // Never coalesced across the block separator.
+      { start: 23, end: 32, marks: ['strikethrough'] }
+    ])
+  })
+
+  it('round-trips a seeded value through getValue unchanged', () => {
+    const { ref } = renderPromptEditor(true)
+    const parts = [
+      { kind: 'text' as const, text: 'alpha ' },
+      { kind: 'text' as const, text: 'beta', marks: ['bold' as const] },
+      { kind: 'text' as const, text: ' gamma' }
+    ]
+
+    act(() => ref.current?.seed(parts))
+    const first = ref.current?.getValue()
+
+    act(() => ref.current?.seed(parts))
+    expect(ref.current?.getValue()).toEqual(first)
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/agent-prompt-editor.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-prompt-editor.tsx
@@ -1,7 +1,12 @@
-import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from 'react'
 
 import type { AttachmentInput } from '@memry/contracts/ipc-agent'
 import type { InboxItemType } from '@memry/contracts/inbox-api'
+import {
+  CRITIC_MARKUP_COMMENT_FORMAT_MARKS,
+  type CriticMarkupCommentFormatMark,
+  type CriticMarkupCommentFormatRange
+} from '@memry/shared'
 import { Node, mergeAttributes, type Editor, type JSONContent } from '@tiptap/core'
 import Placeholder from '@tiptap/extension-placeholder'
 import {
@@ -24,6 +29,8 @@ import { cn } from '@/lib/utils'
 export interface AgentPromptValue {
   text: string
   attachments: AttachmentInput[]
+  /** Inline formatting as offsets into `text`. Always empty unless `richTextMarks`. */
+  formatRanges: CriticMarkupCommentFormatRange[]
 }
 
 interface MentionQuery {
@@ -35,8 +42,8 @@ interface MentionQuery {
 }
 
 export type AgentPromptSeedPart =
-  | { kind: 'text'; text: string }
-  | { kind: 'mention'; attachment: MentionAttachment }
+  | { kind: 'text'; text: string; marks?: CriticMarkupCommentFormatMark[] }
+  | { kind: 'mention'; attachment: MentionAttachment; marks?: CriticMarkupCommentFormatMark[] }
 
 export interface AgentPromptEditorHandle {
   clear: () => void
@@ -58,6 +65,15 @@ interface AgentPromptEditorProps {
   placeholder: string
   /** Extra classes merged onto the ProseMirror element; wins over the defaults. */
   editorClassName?: string
+  /**
+   * Enables the inline mark set (bold/italic/underline/strike/code) and their
+   * keyboard shortcuts. Read once when the editor is constructed: `setOptions`
+   * does not rebuild the extension manager or schema, so flipping this after
+   * mount is a no-op. Pass a literal.
+   */
+  richTextMarks?: boolean
+  /** Rendered once the editor instance exists, so callers can attach a toolbar. */
+  renderSelectionToolbar?: (editor: Editor) => React.ReactNode
   onEscape: () => void
   onMentionKeyDown: (event: KeyboardEvent) => boolean
   onMentionQueryChange: (query: string | null) => void
@@ -257,11 +273,91 @@ const AgentMention = Node.create({
   }
 })
 
-function serializePromptNode(node: JSONContent): string {
-  if (node.type === 'text') return node.text ?? ''
-  if (node.type === 'hardBreak') return '\n'
-  if (node.type === 'agentMention') return `@${String(node.attrs?.label ?? '')}`
-  return (node.content ?? []).map(serializePromptNode).join('')
+const TIPTAP_MARK_NAMES: Record<string, CriticMarkupCommentFormatMark> = {
+  bold: 'bold',
+  italic: 'italic',
+  underline: 'underline',
+  strike: 'strikethrough',
+  code: 'code'
+}
+
+const MARK_NAME_TO_TIPTAP: Record<CriticMarkupCommentFormatMark, string> = {
+  bold: 'bold',
+  italic: 'italic',
+  underline: 'underline',
+  strikethrough: 'strike',
+  code: 'code'
+}
+
+interface PromptTextRun {
+  text: string
+  marks: CriticMarkupCommentFormatMark[]
+}
+
+function promptMarksFromNode(node: JSONContent): CriticMarkupCommentFormatMark[] {
+  if (!node.marks?.length) return []
+  const marks = new Set<CriticMarkupCommentFormatMark>()
+  for (const mark of node.marks) {
+    const mapped = TIPTAP_MARK_NAMES[mark.type]
+    if (mapped) marks.add(mapped)
+  }
+  return CRITIC_MARKUP_COMMENT_FORMAT_MARKS.filter((mark) => marks.has(mark))
+}
+
+/**
+ * Flattens the doc to text and formatting in one pass so the two can't drift.
+ * Mirrors the previous plain serializer node for node — a mention is emitted
+ * whole, so a range can never start inside an `@label`.
+ */
+function collectPromptRuns(node: JSONContent, runs: PromptTextRun[]): void {
+  if (node.type === 'text') {
+    runs.push({ text: node.text ?? '', marks: promptMarksFromNode(node) })
+    return
+  }
+  if (node.type === 'hardBreak') {
+    runs.push({ text: '\n', marks: [] })
+    return
+  }
+  if (node.type === 'agentMention') {
+    runs.push({
+      text: `@${String(node.attrs?.label ?? '')}`,
+      marks: promptMarksFromNode(node)
+    })
+    return
+  }
+  ;(node.content ?? []).forEach((child) => collectPromptRuns(child, runs))
+}
+
+function promptRunsToValue(runs: PromptTextRun[]): {
+  text: string
+  formatRanges: CriticMarkupCommentFormatRange[]
+} {
+  let text = ''
+  const formatRanges: CriticMarkupCommentFormatRange[] = []
+
+  for (const run of runs) {
+    const start = text.length
+    text += run.text
+    if (!run.text || run.marks.length === 0) continue
+
+    // Only coalesce with an immediately adjacent run, so a range never spans
+    // the newline between two blocks.
+    const previous = formatRanges.at(-1)
+    if (previous && previous.end === start && sameMarkList(previous.marks, run.marks)) {
+      previous.end = text.length
+      continue
+    }
+    formatRanges.push({ start, end: text.length, marks: run.marks })
+  }
+
+  return { text, formatRanges }
+}
+
+function sameMarkList(
+  first: CriticMarkupCommentFormatMark[],
+  second: CriticMarkupCommentFormatMark[]
+): boolean {
+  return first.length === second.length && first.every((mark, index) => mark === second[index])
 }
 
 function collectMentionAttachments(node: JSONContent, attachments: AttachmentInput[]): void {
@@ -288,16 +384,35 @@ function dedupeAttachments(attachments: AttachmentInput[]): AttachmentInput[] {
 }
 
 function readEditorValue(editor: Editor | null): AgentPromptValue {
-  if (!editor) return { text: '', attachments: [] }
+  if (!editor) return emptyPromptValue()
 
   const json = editor.getJSON()
-  const text = (json.content ?? []).map(serializePromptNode).join('\n')
+  const runs: PromptTextRun[] = []
+  ;(json.content ?? []).forEach((block, index) => {
+    // The block separator carries no marks — this is the old `.join('\n')`.
+    if (index > 0) runs.push({ text: '\n', marks: [] })
+    collectPromptRuns(block, runs)
+  })
+
+  const { text, formatRanges } = promptRunsToValue(runs)
   const attachments: AttachmentInput[] = []
   collectMentionAttachments(json, attachments)
   return {
     text,
-    attachments: dedupeAttachments(attachments)
+    attachments: dedupeAttachments(attachments),
+    formatRanges
   }
+}
+
+function emptyPromptValue(): AgentPromptValue {
+  return { text: '', attachments: [], formatRanges: [] }
+}
+
+function seedMarks(marks: CriticMarkupCommentFormatMark[] | undefined): {
+  marks?: { type: string }[]
+} {
+  if (!marks?.length) return {}
+  return { marks: marks.map((mark) => ({ type: MARK_NAME_TO_TIPTAP[mark] })) }
 }
 
 function findMentionQuery(editor: Editor): MentionQuery | null {
@@ -319,12 +434,60 @@ function findMentionQuery(editor: Editor): MentionQuery | null {
   }
 }
 
+// Every mark off by default: the agent composer is a plain-text prompt box.
+const PLAIN_STARTER_KIT = {
+  blockquote: false,
+  bold: false,
+  bulletList: false,
+  code: false,
+  codeBlock: false,
+  dropcursor: false,
+  gapcursor: false,
+  heading: false,
+  horizontalRule: false,
+  italic: false,
+  listItem: false,
+  listKeymap: false,
+  link: false,
+  orderedList: false,
+  strike: false,
+  trailingNode: false,
+  underline: false
+} as const
+
+// Same as plain, minus the five inline marks. Blocks stay off — a comment is
+// one paragraph, not a document.
+const RICH_TEXT_STARTER_KIT = {
+  blockquote: false,
+  bulletList: false,
+  codeBlock: false,
+  dropcursor: false,
+  gapcursor: false,
+  heading: false,
+  horizontalRule: false,
+  listItem: false,
+  listKeymap: false,
+  link: false,
+  orderedList: false,
+  trailingNode: false
+} as const
+
+export function buildPromptExtensions(richTextMarks: boolean, placeholder: string) {
+  return [
+    StarterKit.configure(richTextMarks ? RICH_TEXT_STARTER_KIT : PLAIN_STARTER_KIT),
+    Placeholder.configure({ placeholder }),
+    AgentMention
+  ]
+}
+
 export const AgentPromptEditor = forwardRef<AgentPromptEditorHandle, AgentPromptEditorProps>(
   function AgentPromptEditor(
     {
       disabled,
       placeholder,
       editorClassName,
+      richTextMarks,
+      renderSelectionToolbar,
       onEscape,
       onMentionKeyDown,
       onMentionQueryChange,
@@ -348,30 +511,13 @@ export const AgentPromptEditor = forwardRef<AgentPromptEditorHandle, AgentPrompt
       onValueChangeRef.current = onValueChange
     }, [onEscape, onMentionKeyDown, onMentionQueryChange, onSubmit, onValueChange])
 
+    // Init-only by contract (see `richTextMarks`), and memoising also stops
+    // `StarterKit.configure` from handing `useEditor` a fresh array every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const extensions = useMemo(() => buildPromptExtensions(richTextMarks ?? false, placeholder), [])
+
     const editor = useEditor({
-      extensions: [
-        StarterKit.configure({
-          blockquote: false,
-          bold: false,
-          bulletList: false,
-          code: false,
-          codeBlock: false,
-          dropcursor: false,
-          gapcursor: false,
-          heading: false,
-          horizontalRule: false,
-          italic: false,
-          listItem: false,
-          listKeymap: false,
-          link: false,
-          orderedList: false,
-          strike: false,
-          trailingNode: false,
-          underline: false
-        }),
-        Placeholder.configure({ placeholder }),
-        AgentMention
-      ],
+      extensions,
       content: '',
       editable: !disabled,
       editorProps: {
@@ -430,7 +576,7 @@ export const AgentPromptEditor = forwardRef<AgentPromptEditorHandle, AgentPrompt
           editor?.commands.clearContent(true)
           activeMentionRef.current = null
           onMentionQueryChangeRef.current(null)
-          onValueChangeRef.current({ text: '', attachments: [] })
+          onValueChangeRef.current(emptyPromptValue())
         },
         focus: () => {
           editor?.commands.focus('end')
@@ -469,16 +615,20 @@ export const AgentPromptEditor = forwardRef<AgentPromptEditorHandle, AgentPrompt
 
           const paragraphs: JSONContent[][] = [[]]
           for (const part of parts) {
+            const marks = seedMarks(part.marks)
             if (part.kind === 'mention') {
               paragraphs[paragraphs.length - 1].push({
                 type: 'agentMention',
-                attrs: mentionAttrs(part.attachment)
+                attrs: mentionAttrs(part.attachment),
+                ...marks
               })
               continue
             }
             part.text.split('\n').forEach((chunk, index) => {
               if (index > 0) paragraphs.push([])
-              if (chunk) paragraphs[paragraphs.length - 1].push({ type: 'text', text: chunk })
+              if (chunk) {
+                paragraphs[paragraphs.length - 1].push({ type: 'text', text: chunk, ...marks })
+              }
             })
           }
 
@@ -512,6 +662,11 @@ export const AgentPromptEditor = forwardRef<AgentPromptEditorHandle, AgentPrompt
       [editor]
     )
 
-    return <EditorContent editor={editor} />
+    return (
+      <>
+        <EditorContent editor={editor} />
+        {editor && renderSelectionToolbar?.(editor)}
+      </>
+    )
   }
 )

--- a/apps/desktop/src/renderer/src/agent-chat/composer.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/composer.tsx
@@ -206,7 +206,8 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
   const pendingMentionRef = useRef(false)
   const [promptValue, setPromptValue] = useState<AgentPromptValue>({
     text: '',
-    attachments: []
+    attachments: [],
+    formatRanges: []
   })
   const [currentNoteAttachment, setCurrentNoteAttachment] = useState<AttachmentInput | null>(null)
   const [mentionQuery, setMentionQuery] = useState<string | null>(null)
@@ -518,7 +519,7 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
         attachments: currentAttachments
       })
       promptEditorRef.current?.clear()
-      setPromptValue({ text: '', attachments: [] })
+      setPromptValue({ text: '', attachments: [], formatRanges: [] })
       closePicker()
     } catch {
       // Agent context owns the user-facing error; leave the draft text in place.

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -881,6 +881,53 @@
   line-height: 16px;
 }
 
+/* Selection toolbar inside the comment composer. Sizing mirrors the note
+   editor's compact formatting popover above so the two read as one system. */
+.critic-comment-format-toolbar {
+  z-index: 50;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--popover);
+  color: var(--popover-foreground);
+  box-shadow: 0 16px 40px color-mix(in srgb, black 24%, transparent);
+}
+
+.critic-comment-format-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.critic-comment-format-button {
+  display: inline-flex;
+  height: 28px;
+  width: 28px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.critic-comment-format-button:hover,
+.critic-comment-format-button[aria-pressed='true'] {
+  background-color: var(--accent);
+  color: var(--accent-foreground);
+}
+
+.critic-comment-format-button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
+}
+
+/* Marks in a saved comment stay inline so the collapsed card can still clamp. */
+.critic-review-body-mark {
+  display: inline;
+}
+
 .critic-review-textarea {
   margin-top: 8px;
   min-height: 78px;

--- a/apps/desktop/src/renderer/src/components/note/review/comment-body.ts
+++ b/apps/desktop/src/renderer/src/components/note/review/comment-body.ts
@@ -1,9 +1,18 @@
 import type { MentionIconSpec } from '@/agent-chat/mention-icons'
-import type { CriticMarkupCommentMentionRef } from '@memry/shared'
+import {
+  CRITIC_MARKUP_COMMENT_FORMAT_MARKS,
+  type CriticMarkupCommentFormatMark,
+  type CriticMarkupCommentFormatRange,
+  type CriticMarkupCommentMentionRef
+} from '@memry/shared'
 
 export type CommentBodyPart =
-  | { kind: 'text'; text: string }
-  | { kind: 'mention'; mention: CriticMarkupCommentMentionRef }
+  | { kind: 'text'; text: string; start: number; end: number }
+  | { kind: 'mention'; mention: CriticMarkupCommentMentionRef; start: number; end: number }
+
+export type FormattedCommentBodyPart = CommentBodyPart & {
+  marks: CriticMarkupCommentFormatMark[]
+}
 
 export function splitCommentBody(
   body: string,
@@ -33,14 +42,111 @@ export function splitCommentBody(
     }
 
     if (!next) break
-    if (next.start > cursor) parts.push({ kind: 'text', text: body.slice(cursor, next.start) })
-    parts.push({ kind: 'mention', mention: next.mention })
+    if (next.start > cursor) {
+      parts.push({
+        kind: 'text',
+        text: body.slice(cursor, next.start),
+        start: cursor,
+        end: next.start
+      })
+    }
+    parts.push({ kind: 'mention', mention: next.mention, start: next.start, end: next.end })
     used.add(next.key)
     cursor = next.end
   }
 
-  if (cursor < body.length) parts.push({ kind: 'text', text: body.slice(cursor) })
+  if (cursor < body.length) {
+    parts.push({ kind: 'text', text: body.slice(cursor), start: cursor, end: body.length })
+  }
   return parts
+}
+
+/**
+ * Layers formatting on top of the mention segmentation, which runs first and
+ * unchanged. Formatting can subdivide a text run but never a mention: the write
+ * side emits `@label` as one unit, so a range can't begin inside one.
+ */
+export function splitCommentBodyWithFormat(
+  body: string,
+  mentions: CriticMarkupCommentMentionRef[],
+  formatRanges: CriticMarkupCommentFormatRange[]
+): FormattedCommentBodyPart[] {
+  const parts = splitCommentBody(body, mentions)
+  if (formatRanges.length === 0) return parts.map((part) => ({ ...part, marks: [] }))
+
+  const marksAt = buildMarkLookup(body.length, formatRanges)
+  return parts.flatMap((part): FormattedCommentBodyPart[] => {
+    if (part.kind === 'mention') return [{ ...part, marks: marksAt(part.start) }]
+
+    const runs: FormattedCommentBodyPart[] = []
+    let runStart = part.start
+    for (let offset = part.start; offset < part.end; offset++) {
+      const isLast = offset === part.end - 1
+      if (!isLast && sameMarks(marksAt(offset), marksAt(offset + 1))) continue
+      runs.push({
+        kind: 'text',
+        text: body.slice(runStart, offset + 1),
+        start: runStart,
+        end: offset + 1,
+        marks: marksAt(runStart)
+      })
+      runStart = offset + 1
+    }
+    return runs
+  })
+}
+
+/**
+ * Trims the composer text the way the storage layer will, shifting the ranges
+ * with it. Trimming must happen exactly once, or the offsets drift.
+ */
+export function trimCommentBodyWithFormat(
+  text: string,
+  formatRanges: CriticMarkupCommentFormatRange[]
+): { body: string; formatRanges: CriticMarkupCommentFormatRange[] } {
+  const body = text.trim()
+  if (!body) return { body, formatRanges: [] }
+
+  const offset = text.indexOf(body)
+  const shifted = formatRanges.flatMap((range) => {
+    const start = Math.max(0, range.start - offset)
+    const end = Math.min(body.length, range.end - offset)
+    if (end <= start) return []
+    return [{ start, end, marks: range.marks }]
+  })
+  return { body, formatRanges: shifted }
+}
+
+// Char-level rather than range-intersection so overlapping or hand-edited
+// ranges degrade to a union instead of producing tangled output.
+function buildMarkLookup(
+  bodyLength: number,
+  formatRanges: CriticMarkupCommentFormatRange[]
+): (offset: number) => CriticMarkupCommentFormatMark[] {
+  const table: Set<CriticMarkupCommentFormatMark>[] = Array.from(
+    { length: bodyLength },
+    () => new Set()
+  )
+  for (const range of formatRanges) {
+    for (
+      let offset = Math.max(0, range.start);
+      offset < Math.min(bodyLength, range.end);
+      offset++
+    ) {
+      for (const mark of range.marks) table[offset].add(mark)
+    }
+  }
+  const resolved = table.map((marks) =>
+    CRITIC_MARKUP_COMMENT_FORMAT_MARKS.filter((mark) => marks.has(mark))
+  )
+  return (offset) => resolved[offset] ?? []
+}
+
+function sameMarks(
+  first: CriticMarkupCommentFormatMark[],
+  second: CriticMarkupCommentFormatMark[]
+): boolean {
+  return first.length === second.length && first.every((mark, index) => mark === second[index])
 }
 
 export function iconForMention(mention: CriticMarkupCommentMentionRef): MentionIconSpec {

--- a/apps/desktop/src/renderer/src/components/note/review/comment-composer.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/comment-composer.tsx
@@ -22,13 +22,19 @@ import { extractErrorMessage } from '@/lib/ipc-error'
 import { trackRendererError } from '@/lib/telemetry-diagnostics'
 import { cn } from '@/lib/utils'
 import { notesService } from '@/services/notes-service'
+import type { Editor } from '@tiptap/core'
 import { useT } from '@memry/i18n/renderer'
 import type {
   CriticMarkupCommentAttachmentRef,
   CriticMarkupCommentMentionKind,
   CriticMarkupCommentMentionRef
 } from '@memry/shared'
-import { iconForMention, splitCommentBody } from './comment-body'
+import {
+  iconForMention,
+  splitCommentBodyWithFormat,
+  trimCommentBodyWithFormat
+} from './comment-body'
+import { CommentFormatToolbar } from './comment-format-toolbar'
 import type { SubmitCommentInput } from './use-critic-markup-review'
 
 interface CommentComposerProps {
@@ -39,7 +45,7 @@ interface CommentComposerProps {
   onSubmit: (input: SubmitCommentInput) => void
 }
 
-const emptyEditorValue: AgentPromptValue = { text: '', attachments: [] }
+const emptyEditorValue: AgentPromptValue = { text: '', attachments: [], formatRanges: [] }
 
 export function CommentComposer({
   targetId,
@@ -127,16 +133,34 @@ export function CommentComposer({
   )
 
   const handleSubmit = useCallback(() => {
-    const body = editorValue.text.trim()
+    // Trim here and only here — the offsets shift with the text, and the
+    // storage layer trims again downstream.
+    const { body, formatRanges } = trimCommentBodyWithFormat(
+      editorValue.text,
+      editorValue.formatRanges
+    )
     if (!body || isUploading) return
 
-    onSubmit({ body, mentions, attachments })
+    onSubmit({ body, mentions, attachments, formatRanges })
     editorRef.current?.clear()
     setEditorValue(emptyEditorValue)
     setAttachments([])
     setUploadError(null)
     closeMentionPicker()
-  }, [attachments, closeMentionPicker, editorValue.text, isUploading, mentions, onSubmit])
+  }, [
+    attachments,
+    closeMentionPicker,
+    editorValue.formatRanges,
+    editorValue.text,
+    isUploading,
+    mentions,
+    onSubmit
+  ])
+
+  const renderFormatToolbar = useCallback(
+    (editor: Editor) => <CommentFormatToolbar editor={editor} suppressed={mentionQuery !== null} />,
+    [mentionQuery]
+  )
 
   const handleAttachClick = useCallback(() => {
     fileInputRef.current?.click()
@@ -184,7 +208,12 @@ export function CommentComposer({
       if (!target) return
       // The mention picker renders in a body-level portal, so its options sit
       // outside the composer subtree; treat clicks inside it as inside.
-      if (target instanceof Element && target.closest('[data-ref-picker]')) return
+      if (
+        target instanceof Element &&
+        target.closest('[data-ref-picker], [data-comment-format-toolbar]')
+      ) {
+        return
+      }
       if (composer.contains(target)) return
       cancelIfEmpty()
     }
@@ -222,6 +251,8 @@ export function CommentComposer({
             disabled={false}
             editorClassName="!min-h-[22px] max-h-[130px] overflow-y-auto !p-0 !py-0.5 !text-[13px] !leading-5"
             placeholder={t('comments.commentPlaceholder')}
+            richTextMarks
+            renderSelectionToolbar={renderFormatToolbar}
             onEscape={cancelIfEmpty}
             onMentionKeyDown={handleMentionKeyDown}
             onMentionQueryChange={setMentionQuery}
@@ -316,18 +347,20 @@ export function CommentComposer({
 }
 
 function seedPartsFromComment(initial: SubmitCommentInput): AgentPromptSeedPart[] {
-  return splitCommentBody(initial.body, initial.mentions).map((part) =>
-    part.kind === 'mention'
-      ? {
-          kind: 'mention' as const,
-          attachment: {
-            kind: part.mention.kind,
-            ref_id: part.mention.refId,
-            label: part.mention.label,
-            icon: iconForMention(part.mention)
+  return splitCommentBodyWithFormat(initial.body, initial.mentions, initial.formatRanges).map(
+    (part) =>
+      part.kind === 'mention'
+        ? {
+            kind: 'mention' as const,
+            attachment: {
+              kind: part.mention.kind,
+              ref_id: part.mention.refId,
+              label: part.mention.label,
+              icon: iconForMention(part.mention)
+            },
+            marks: part.marks
           }
-        }
-      : { kind: 'text' as const, text: part.text }
+        : { kind: 'text' as const, text: part.text, marks: part.marks }
   )
 }
 

--- a/apps/desktop/src/renderer/src/components/note/review/comment-format-toolbar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/comment-format-toolbar.test.tsx
@@ -1,0 +1,215 @@
+import { createRef } from 'react'
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { Editor } from '@tiptap/core'
+import { Schema } from '@tiptap/pm/model'
+import { EditorState, NodeSelection, TextSelection } from '@tiptap/pm/state'
+
+import { AgentPromptEditor, type AgentPromptEditorHandle } from '@/agent-chat/agent-prompt-editor'
+import {
+  CommentFormatButtons,
+  CommentFormatToolbar,
+  COMMENT_FORMAT_ITEMS,
+  shouldShowCommentFormatToolbar
+} from './comment-format-toolbar'
+
+// The live editor instance is only handed to the render prop, so capture it there.
+let capturedEditor: Editor | null = null
+function editorForHandle(): Editor {
+  if (!capturedEditor) throw new Error('editor not mounted')
+  return capturedEditor
+}
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key, i18n: { language: 'en' } })
+}))
+
+// Mirrors the shape that matters here: inline text plus a selectable atom, the
+// way `agentMention` behaves in the real composer.
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*', toDOM: () => ['p', 0] },
+    mention: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      selectable: true,
+      toDOM: () => ['span', '@label']
+    },
+    text: { group: 'inline' }
+  }
+})
+
+function stateWith(text: string, select: (doc: ReturnType<typeof buildDoc>) => unknown) {
+  const doc = buildDoc(text)
+  return EditorState.create({ doc, selection: select(doc) as never })
+}
+
+function buildDoc(text: string) {
+  return schema.node('doc', null, [
+    schema.node('paragraph', null, [...(text ? [schema.text(text)] : []), schema.node('mention')])
+  ])
+}
+
+const baseArgs = { isEditable: true, element: null, suppressed: false, hasFocus: true }
+
+describe('shouldShowCommentFormatToolbar', () => {
+  it('shows for a focused, non-empty text selection', () => {
+    const state = stateWith('hello there', (doc) => TextSelection.create(doc, 1, 6))
+    expect(shouldShowCommentFormatToolbar({ ...baseArgs, state })).toBe(true)
+  })
+
+  it('hides for an empty selection', () => {
+    const state = stateWith('hello there', (doc) => TextSelection.create(doc, 3, 3))
+    expect(shouldShowCommentFormatToolbar({ ...baseArgs, state })).toBe(false)
+  })
+
+  it('hides while the mention picker owns the selection', () => {
+    const state = stateWith('hello there', (doc) => TextSelection.create(doc, 1, 6))
+    expect(shouldShowCommentFormatToolbar({ ...baseArgs, state, suppressed: true })).toBe(false)
+  })
+
+  it('hides when the editor is not editable', () => {
+    const state = stateWith('hello there', (doc) => TextSelection.create(doc, 1, 6))
+    expect(shouldShowCommentFormatToolbar({ ...baseArgs, state, isEditable: false })).toBe(false)
+  })
+
+  it('hides for a whitespace-only range', () => {
+    const state = stateWith('    ', (doc) => TextSelection.create(doc, 1, 5))
+    expect(shouldShowCommentFormatToolbar({ ...baseArgs, state })).toBe(false)
+  })
+
+  it('hides when an @mention chip is node-selected', () => {
+    const doc = buildDoc('hello ')
+    const state = EditorState.create({ doc, selection: NodeSelection.create(doc, 7) })
+    expect(state.selection).toBeInstanceOf(NodeSelection)
+    expect(shouldShowCommentFormatToolbar({ ...baseArgs, state })).toBe(false)
+  })
+
+  it('stays open while focus sits inside the toolbar itself', () => {
+    const state = stateWith('hello there', (doc) => TextSelection.create(doc, 1, 6))
+    const element = document.createElement('div')
+    const button = document.createElement('button')
+    element.appendChild(button)
+    document.body.appendChild(element)
+    button.focus()
+
+    expect(shouldShowCommentFormatToolbar({ ...baseArgs, state, element, hasFocus: false })).toBe(
+      true
+    )
+    element.remove()
+  })
+})
+
+describe('CommentFormatButtons', () => {
+  function fakeEditor(activeMark: string | null) {
+    const run = vi.fn()
+    const chain = {
+      focus: () => chain,
+      toggleBold: () => chain,
+      toggleItalic: () => chain,
+      toggleUnderline: () => chain,
+      toggleStrike: () => chain,
+      toggleCode: () => chain,
+      run
+    }
+    return {
+      editor: {
+        isActive: (mark: string) => mark === activeMark,
+        chain: () => chain
+      } as unknown as Editor,
+      run
+    }
+  }
+
+  it('renders every mark button and runs its command on click', () => {
+    const { editor, run } = fakeEditor(null)
+    render(<CommentFormatButtons editor={editor} />)
+
+    for (const item of COMMENT_FORMAT_ITEMS) {
+      const button = screen.getByLabelText(item.labelKey)
+      expect(button).toHaveAttribute('aria-pressed', 'false')
+      fireEvent.click(button)
+    }
+    expect(run).toHaveBeenCalledTimes(COMMENT_FORMAT_ITEMS.length)
+  })
+
+  it('marks the active mark as pressed', () => {
+    const { editor } = fakeEditor('bold')
+    render(<CommentFormatButtons editor={editor} />)
+
+    expect(screen.getByLabelText('comments.format.bold')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByLabelText('comments.format.italic')).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('swallows pointer events so the text selection survives the click', () => {
+    const { editor } = fakeEditor(null)
+    const { container } = render(<CommentFormatButtons editor={editor} />)
+    const row = container.querySelector('.critic-comment-format-row') as HTMLElement
+
+    expect(fireEvent.mouseDown(row)).toBe(false)
+    expect(fireEvent.pointerDown(row)).toBe(false)
+  })
+})
+
+describe('CommentFormatToolbar mounted on a real editor', () => {
+  it('portals a tagged toolbar to the body for a live text selection', async () => {
+    // jsdom has no layout; floating-ui needs rects to place the bubble.
+    const rect = { x: 0, y: 0, top: 0, left: 0, bottom: 20, right: 60, width: 60, height: 20 }
+    vi.spyOn(Range.prototype, 'getBoundingClientRect').mockReturnValue(rect as DOMRect)
+    // ProseMirror's coordsAtPos indexes into the list, so it must be array-like.
+    const rectList = Object.assign([rect], { item: () => rect })
+    vi.spyOn(Range.prototype, 'getClientRects').mockReturnValue(rectList as unknown as DOMRectList)
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+      }
+    )
+
+    const ref = createRef<AgentPromptEditorHandle>()
+    render(
+      <AgentPromptEditor
+        ref={ref}
+        disabled={false}
+        placeholder="Add a comment..."
+        richTextMarks
+        renderSelectionToolbar={(editor) => {
+          capturedEditor = editor
+          return <CommentFormatToolbar editor={editor} suppressed={false} />
+        }}
+        onEscape={vi.fn()}
+        onMentionKeyDown={vi.fn(() => false)}
+        onMentionQueryChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onValueChange={vi.fn()}
+      />
+    )
+
+    act(() => ref.current?.seed([{ kind: 'text', text: 'needs a source' }]))
+    act(() => {
+      ref.current?.focus()
+      // ProseMirror doc positions run one ahead of the flattened text offsets.
+      editorForHandle().commands.setTextSelection({ from: 9, to: 15 })
+    })
+
+    await waitFor(() => {
+      expect(document.querySelector('body > [data-comment-format-toolbar]')).not.toBeNull()
+    })
+
+    // The command reaches the real schema: the mark set is genuinely enabled.
+    act(() => {
+      editorForHandle().chain().focus().toggleBold().run()
+    })
+    const value = ref.current?.getValue()
+    expect(value?.formatRanges).toEqual([{ start: 8, end: 14, marks: ['bold'] }])
+    expect(value?.text.slice(8, 14)).toBe('source')
+
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/review/comment-format-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/comment-format-toolbar.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+import type { Editor } from '@tiptap/core'
+import { NodeSelection, type EditorState } from '@tiptap/pm/state'
+import type { EditorView } from '@tiptap/pm/view'
+import { isTextSelection } from '@tiptap/core'
+import { BubbleMenu } from '@tiptap/react/menus'
+
+import { Bold, Code, Italic, Strikethrough, Underline } from '@/lib/icons'
+import { useT } from '@memry/i18n/renderer'
+
+/**
+ * Marks the toolbar so the composer's outside-pointerdown auto-cancel can tell
+ * a toolbar click from a click that should discard the draft. The toolbar is
+ * portalled to the body, so it is outside the composer subtree.
+ */
+export const COMMENT_FORMAT_TOOLBAR_ATTR = 'data-comment-format-toolbar'
+
+interface CommentFormatItem {
+  id: string
+  markName: string
+  labelKey: string
+  Icon: typeof Bold
+  run: (editor: Editor) => void
+}
+
+export const COMMENT_FORMAT_ITEMS: CommentFormatItem[] = [
+  {
+    id: 'bold',
+    markName: 'bold',
+    labelKey: 'comments.format.bold',
+    Icon: Bold,
+    run: (editor) => editor.chain().focus().toggleBold().run()
+  },
+  {
+    id: 'italic',
+    markName: 'italic',
+    labelKey: 'comments.format.italic',
+    Icon: Italic,
+    run: (editor) => editor.chain().focus().toggleItalic().run()
+  },
+  {
+    id: 'underline',
+    markName: 'underline',
+    labelKey: 'comments.format.underline',
+    Icon: Underline,
+    run: (editor) => editor.chain().focus().toggleUnderline().run()
+  },
+  {
+    id: 'strike',
+    markName: 'strike',
+    labelKey: 'comments.format.strike',
+    Icon: Strikethrough,
+    run: (editor) => editor.chain().focus().toggleStrike().run()
+  },
+  {
+    id: 'code',
+    markName: 'code',
+    labelKey: 'comments.format.code',
+    Icon: Code,
+    run: (editor) => editor.chain().focus().toggleCode().run()
+  }
+]
+
+export function shouldShowCommentFormatToolbar({
+  isEditable,
+  element,
+  state,
+  suppressed,
+  hasFocus
+}: {
+  isEditable: boolean
+  element: Element | null
+  state: Pick<EditorState, 'selection' | 'doc'>
+  suppressed: boolean
+  hasFocus: boolean
+}): boolean {
+  // The mention picker owns the selection while it is open.
+  if (suppressed) return false
+  if (!isEditable) return false
+
+  const { selection } = state
+  if (selection.empty) return false
+  // Clicking an @mention chip selects the atom node — non-empty, but there is
+  // nothing to format.
+  if (selection instanceof NodeSelection) return false
+  if (!isTextSelection(selection)) return false
+  if (!state.doc.textBetween(selection.from, selection.to, ' ').trim()) return false
+
+  // Stay open while focus is inside the bubble itself (keyboard users).
+  const activeElement = element?.ownerDocument?.activeElement ?? null
+  return hasFocus || Boolean(activeElement && element?.contains(activeElement))
+}
+
+export function CommentFormatButtons({ editor }: { editor: Editor }): React.JSX.Element {
+  const { t } = useT('notes')
+
+  return (
+    <div
+      className="critic-comment-format-row"
+      // The bubble sits outside the contenteditable, so a plain mousedown moves
+      // focus and collapses the selection before the command can run.
+      onMouseDown={(event) => event.preventDefault()}
+      onPointerDown={(event) => event.preventDefault()}
+    >
+      {COMMENT_FORMAT_ITEMS.map((item) => (
+        <button
+          key={item.id}
+          type="button"
+          className="critic-comment-format-button"
+          data-test={`comment-format-${item.id}`}
+          aria-label={t(item.labelKey)}
+          aria-pressed={editor.isActive(item.markName)}
+          tabIndex={-1}
+          onClick={() => item.run(editor)}
+        >
+          <item.Icon className="size-3.5" aria-hidden="true" />
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export function CommentFormatToolbar({
+  editor,
+  suppressed
+}: {
+  editor: Editor
+  suppressed: boolean
+}): React.JSX.Element {
+  const { t } = useT('notes')
+  // The plugin captures `shouldShow` once, so the live value has to come
+  // through a ref rather than the closure.
+  const suppressedRef = useRef(suppressed)
+  suppressedRef.current = suppressed
+
+  const elementRef = useRef<HTMLDivElement | null>(null)
+  const setMenuElement = useCallback((element: HTMLDivElement | null) => {
+    elementRef.current = element
+    // `restProps` land on the inner portalled div; the node actually appended to
+    // the body is the plugin's own wrapper. Tag both so `closest()` finds one.
+    element?.setAttribute(COMMENT_FORMAT_TOOLBAR_ATTR, '')
+    element?.parentElement?.setAttribute(COMMENT_FORMAT_TOOLBAR_ATTR, '')
+  }, [])
+
+  const shouldShow = useCallback(
+    ({ state, view }: { state: EditorState; view: EditorView }) =>
+      shouldShowCommentFormatToolbar({
+        isEditable: editor.isEditable,
+        element: elementRef.current,
+        state,
+        suppressed: suppressedRef.current,
+        hasFocus: view.hasFocus()
+      }),
+    [editor]
+  )
+
+  // The rail, the flyout and the editor are three separate scroll containers and
+  // `scroll` does not bubble, so the plugin's single window listener misses two
+  // of them. Capture phase catches all three.
+  useEffect(() => {
+    let frame = 0
+    const reposition = () => {
+      if (frame) return
+      frame = requestAnimationFrame(() => {
+        frame = 0
+        if (editor.isDestroyed) return
+        editor.view.dispatch(editor.state.tr.setMeta('bubbleMenu', 'updatePosition'))
+      })
+    }
+
+    window.addEventListener('scroll', reposition, true)
+    return () => {
+      if (frame) cancelAnimationFrame(frame)
+      window.removeEventListener('scroll', reposition, true)
+    }
+  }, [editor])
+
+  // Escape closes the bubble before the composer's own Escape cancels the draft.
+  useEffect(() => {
+    const dom = editor.view.dom
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      if (!elementRef.current?.isConnected) return
+      event.stopPropagation()
+      editor.commands.setTextSelection(editor.state.selection.to)
+    }
+
+    dom.addEventListener('keydown', handleKeyDown, true)
+    return () => dom.removeEventListener('keydown', handleKeyDown, true)
+  }, [editor])
+
+  return (
+    <BubbleMenu
+      editor={editor}
+      pluginKey="commentFormatToolbar"
+      updateDelay={100}
+      appendTo={() => document.body}
+      shouldShow={shouldShow}
+      options={{
+        strategy: 'fixed',
+        placement: 'top',
+        offset: 8,
+        flip: {},
+        shift: { padding: 8 },
+        hide: true
+      }}
+      ref={setMenuElement}
+      role="toolbar"
+      aria-label={t('comments.formatToolbarAria')}
+      aria-orientation="horizontal"
+      className="critic-comment-format-toolbar"
+    >
+      <CommentFormatButtons editor={editor} />
+    </BubbleMenu>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/note/review/review-card.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/review-card.tsx
@@ -9,9 +9,13 @@ import type { ClockFormat } from '@/lib/time-format'
 import { cn } from '@/lib/utils'
 import type { CriticMarkupReviewController } from './use-critic-markup-review'
 import { useT } from '@memry/i18n/renderer'
-import type { CriticMarkupCommentMentionRef, CriticMarkupMark } from '@memry/shared'
+import type {
+  CriticMarkupCommentFormatMark,
+  CriticMarkupCommentMentionRef,
+  CriticMarkupMark
+} from '@memry/shared'
 import { CommentAttachments } from './comment-attachments'
-import { iconForMention, splitCommentBody } from './comment-body'
+import { iconForMention, splitCommentBodyWithFormat } from './comment-body'
 import { CommentComposer } from './comment-composer'
 import { syncInlineHoverClass } from './inline-hover'
 
@@ -74,7 +78,8 @@ export function ReviewCard({
           initialValue={{
             body: mark.body ?? '',
             mentions: mark.mentions ?? [],
-            attachments: mark.attachments ?? []
+            attachments: mark.attachments ?? [],
+            formatRanges: mark.formatRanges ?? []
           }}
           onSubmit={(input) => {
             review.updateComment(mark.id, input)
@@ -186,20 +191,48 @@ function CommentDate({
 function CommentBody({ mark }: { mark: CriticMarkupMark }): React.JSX.Element | null {
   if (!mark.body) return null
 
-  const parts = splitCommentBody(mark.body, mark.mentions ?? [])
+  const parts = splitCommentBodyWithFormat(mark.body, mark.mentions ?? [], mark.formatRanges ?? [])
   return (
     <p className="critic-review-body critic-review-text-collapsible">
-      {parts.map((part, index) =>
-        part.kind === 'mention' ? (
-          <CommentMentionLink
-            key={`${part.mention.kind}-${part.mention.refId}-${index}`}
-            mention={part.mention}
-          />
-        ) : (
-          <span key={`text-${index}`}>{part.text}</span>
-        )
-      )}
+      {parts.map((part, index) => (
+        <FormattedCommentPart key={`part-${index}`} marks={part.marks}>
+          {part.kind === 'mention' ? (
+            <CommentMentionLink mention={part.mention} />
+          ) : (
+            <span>{part.text}</span>
+          )}
+        </FormattedCommentPart>
+      ))}
     </p>
+  )
+}
+
+const MARK_ELEMENTS: Record<CriticMarkupCommentFormatMark, 'strong' | 'em' | 'u' | 's' | 'code'> = {
+  bold: 'strong',
+  italic: 'em',
+  underline: 'u',
+  strikethrough: 's',
+  code: 'code'
+}
+
+/**
+ * Wraps a part in its marks outermost-first, so the same mark set always
+ * produces the same DOM. Everything stays inline — the collapsed card clamps
+ * the body with `text-overflow: ellipsis`.
+ */
+function FormattedCommentPart({
+  marks,
+  children
+}: {
+  marks: CriticMarkupCommentFormatMark[]
+  children: React.ReactNode
+}): React.JSX.Element {
+  return marks.reduceRight<React.JSX.Element>(
+    (wrapped, mark) => {
+      const Element = MARK_ELEMENTS[mark]
+      return <Element className="critic-review-body-mark">{wrapped}</Element>
+    },
+    <>{children}</>
   )
 }
 

--- a/apps/desktop/src/renderer/src/components/note/review/review-ui.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/review-ui.test.tsx
@@ -98,6 +98,8 @@ describe('review UI', () => {
     expect(css).toContain(
       ".critic-review-card[data-expanded='true'] .critic-review-text-collapsible"
     )
+    expect(css).toContain('.critic-comment-format-toolbar')
+    expect(css).toContain('.critic-comment-format-button')
     expect(css).toContain('.critic-comment-main-row')
     expect(css).toContain('display: flex')
     expect(css).toContain('.critic-comment-editor .ProseMirror')
@@ -264,7 +266,8 @@ describe('review UI', () => {
     expect(review.submitComment).toHaveBeenCalledWith({
       body: 'Draft body',
       mentions: [],
-      attachments: []
+      attachments: [],
+      formatRanges: []
     })
   })
 
@@ -360,7 +363,8 @@ describe('review UI', () => {
     expect(review.updateComment).toHaveBeenCalledWith('comment-1', {
       body: 'Original body @Planning note more',
       mentions: [{ kind: 'note', refId: 'note-1', label: 'Planning note' }],
-      attachments: [expect.objectContaining({ path: 'attachments/note-1/spec.pdf' })]
+      attachments: [expect.objectContaining({ path: 'attachments/note-1/spec.pdf' })],
+      formatRanges: []
     })
     expect(screen.queryByLabelText('comments.commentPlaceholder')).not.toBeInTheDocument()
   })
@@ -545,7 +549,8 @@ describe('review UI', () => {
           mimeType: 'application/pdf',
           type: 'file'
         }
-      ]
+      ],
+      formatRanges: []
     })
   })
 
@@ -622,7 +627,12 @@ describe('review UI', () => {
     expect(result.current.activeDraft).toMatchObject({ text: 'comment target', top: 72 })
 
     act(() => {
-      result.current.submitComment({ body: 'Needs work', mentions: [], attachments: [] })
+      result.current.submitComment({
+        body: 'Needs work',
+        mentions: [],
+        attachments: [],
+        formatRanges: []
+      })
     })
 
     act(() => {
@@ -634,7 +644,12 @@ describe('review UI', () => {
       result.current.openCommentComposer({ text: 'comment target', isEmpty: false })
     })
     act(() => {
-      result.current.submitComment({ body: 'Needs work', mentions: [], attachments: [] })
+      result.current.submitComment({
+        body: 'Needs work',
+        mentions: [],
+        attachments: [],
+        formatRanges: []
+      })
     })
     act(() => {
       result.current.resolveMark(result.current.marks[0].id)
@@ -690,7 +705,12 @@ describe('review UI', () => {
       result.current.openCommentComposer({ text: 'Mobile', isEmpty: false, from: 13, to: 19 })
     })
     act(() => {
-      result.current.submitComment({ body: 'Needs work', mentions: [], attachments: [] })
+      result.current.submitComment({
+        body: 'Needs work',
+        mentions: [],
+        attachments: [],
+        formatRanges: []
+      })
     })
 
     // Source offset 14: the "\n\n" run collapses to one visible "\n"
@@ -709,7 +729,12 @@ describe('review UI', () => {
       result.current.openCommentComposer({ text: 'Mobile', isEmpty: false })
     })
     act(() => {
-      result.current.submitComment({ body: 'Needs work', mentions: [], attachments: [] })
+      result.current.submitComment({
+        body: 'Needs work',
+        mentions: [],
+        attachments: [],
+        formatRanges: []
+      })
     })
 
     expect(result.current.marks[0]).toMatchObject({ kind: 'comment', start: 0, end: 6 })
@@ -736,7 +761,8 @@ describe('review UI', () => {
             mimeType: 'application/pdf',
             type: 'file'
           }
-        ]
+        ],
+        formatRanges: []
       })
     })
 
@@ -763,7 +789,8 @@ describe('review UI', () => {
       result.current.submitComment({
         body: 'Needs work',
         mentions: [{ kind: 'note', refId: 'note-1', label: 'Planning note' }],
-        attachments: []
+        attachments: [],
+        formatRanges: []
       })
     })
     const commentId = result.current.marks[0].id
@@ -779,7 +806,8 @@ describe('review UI', () => {
             path: 'attachments/note-1/spec.pdf',
             type: 'file'
           }
-        ]
+        ],
+        formatRanges: []
       })
     })
 
@@ -789,7 +817,9 @@ describe('review UI', () => {
       body: 'Needs more work',
       attachments: [expect.objectContaining({ path: 'attachments/note-1/spec.pdf' })]
     })
-    expect(result.current.marks[0].mentions).toBeUndefined()
+    // An edit always writes all three structured keys, so an emptied one is
+    // cleared from the file instead of being stranded there.
+    expect(result.current.marks[0].mentions).toEqual([])
     expect(onMarkdownChange).toHaveBeenLastCalledWith(expect.stringContaining('attachments='))
     expect(onMarkdownChange).toHaveBeenLastCalledWith(expect.not.stringContaining('mentions='))
 
@@ -813,14 +843,29 @@ describe('review UI', () => {
       result.current.openCommentComposer({ text: 'comment target', isEmpty: false })
     })
     act(() => {
-      result.current.submitComment({ body: 'Needs work', mentions: [], attachments: [] })
+      result.current.submitComment({
+        body: 'Needs work',
+        mentions: [],
+        attachments: [],
+        formatRanges: []
+      })
     })
     const commentId = result.current.marks[0].id
     onMarkdownChange.mockClear()
 
     act(() => {
-      result.current.updateComment('missing-id', { body: 'x', mentions: [], attachments: [] })
-      result.current.updateComment(commentId, { body: '   ', mentions: [], attachments: [] })
+      result.current.updateComment('missing-id', {
+        body: 'x',
+        mentions: [],
+        attachments: [],
+        formatRanges: []
+      })
+      result.current.updateComment(commentId, {
+        body: '   ',
+        mentions: [],
+        attachments: [],
+        formatRanges: []
+      })
     })
 
     expect(onMarkdownChange).not.toHaveBeenCalled()
@@ -836,7 +881,12 @@ describe('review UI', () => {
       result.current.openCommentComposer({ text: 'base', isEmpty: false })
     })
     act(() => {
-      result.current.submitComment({ body: 'note', mentions: [], attachments: [] })
+      result.current.submitComment({
+        body: 'note',
+        mentions: [],
+        attachments: [],
+        formatRanges: []
+      })
     })
     expect(result.current.marks).toHaveLength(1)
 
@@ -865,7 +915,12 @@ describe('review UI', () => {
       result.current.openCommentComposer({ text: 'comment target', isEmpty: false })
     })
     act(() => {
-      result.current.submitComment({ body: 'Needs work', mentions: [], attachments: [] })
+      result.current.submitComment({
+        body: 'Needs work',
+        mentions: [],
+        attachments: [],
+        formatRanges: []
+      })
     })
     expect(result.current.marks).toHaveLength(1)
     const commentId = result.current.marks[0].id
@@ -893,5 +948,98 @@ describe('review UI', () => {
       rerender({ markdown: 'totally different external content' })
     })
     expect(result.current.marks).toHaveLength(0)
+  })
+
+  it('renders comment formatting as nested inline elements, outermost mark first', () => {
+    const review = createReview({
+      marks: [
+        {
+          id: 'comment-1',
+          kind: 'comment',
+          visibleText: 'target',
+          body: 'see this now',
+          start: 0,
+          end: 6,
+          formatRanges: [
+            { start: 4, end: 8, marks: ['bold', 'code'] },
+            { start: 9, end: 12, marks: ['italic'] }
+          ]
+        }
+      ]
+    })
+
+    const { container } = render(<ReviewRail review={review} />)
+    const body = container.querySelector('.critic-review-body') as HTMLElement
+
+    expect(body).toHaveTextContent('see this now')
+    expect(body.querySelector('strong > code')?.textContent).toBe('this')
+    expect(body.querySelector('em')?.textContent).toBe('now')
+    // Anything not covered by a range stays unwrapped.
+    expect(body.querySelector('u')).toBeNull()
+  })
+
+  it('renders a comment saved before formatting existed with no mark elements', () => {
+    const review = createReview({
+      marks: [
+        {
+          id: 'comment-1',
+          kind: 'comment',
+          visibleText: 'target',
+          body: 'plain 2 * 3 and snake_case_name',
+          start: 0,
+          end: 6
+        }
+      ]
+    })
+
+    const { container } = render(<ReviewRail review={review} />)
+    const body = container.querySelector('.critic-review-body') as HTMLElement
+
+    expect(body).toHaveTextContent('plain 2 * 3 and snake_case_name')
+    expect(body.querySelector('strong, em, u, s, code')).toBeNull()
+  })
+
+  it('keeps the mention link intact when a format range spans it', () => {
+    const review = createReview({
+      marks: [
+        {
+          id: 'comment-1',
+          kind: 'comment',
+          visibleText: 'target',
+          body: 'ping @Planning note now',
+          mentions: [{ kind: 'note', refId: 'note-1', label: 'Planning note' }],
+          formatRanges: [{ start: 0, end: 23, marks: ['bold'] }],
+          start: 0,
+          end: 6
+        }
+      ]
+    })
+
+    const { container } = render(<ReviewRail review={review} />)
+    const link = container.querySelector('a[href="memry://note/note-1"]') as HTMLElement
+
+    expect(link).not.toBeNull()
+    expect(link.textContent).toContain('@Planning note')
+    // The mark wraps around the anchor; it never subdivides it.
+    expect(link.closest('strong')).not.toBeNull()
+    expect(link.querySelector('strong')).toBeNull()
+  })
+
+  it('does not cancel an empty draft when the pointer goes down on the format toolbar', async () => {
+    const review = createReview({ activeDraft: { text: 'draft target' } })
+    render(<ReviewRail review={review} />)
+    await nextFrame()
+
+    const toolbar = document.createElement('div')
+    toolbar.setAttribute('data-comment-format-toolbar', '')
+    document.body.appendChild(toolbar)
+
+    fireEvent.pointerDown(toolbar)
+    expect(review.cancelCommentDraft).not.toHaveBeenCalled()
+
+    fireEvent.pointerDown(document.body)
+    expect(review.cancelCommentDraft).toHaveBeenCalled()
+
+    toolbar.remove()
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/review/use-critic-markup-review.ts
+++ b/apps/desktop/src/renderer/src/components/note/review/use-critic-markup-review.ts
@@ -3,10 +3,12 @@ import type { EditorState } from '@tiptap/pm/state'
 import type { EditorView } from '@tiptap/pm/view'
 import {
   deleteCriticMark,
+  normalizeCriticMarkupCommentFormatRanges,
   parseCriticMarkup,
   resolveCriticMark,
   serializeCriticMarkup,
   type CriticMarkupCommentAttachmentRef,
+  type CriticMarkupCommentFormatRange,
   type CriticMarkupCommentMentionRef,
   type CriticMarkupKind,
   type CriticMarkupMark
@@ -56,6 +58,7 @@ export interface SubmitCommentInput {
   body: string
   mentions: CriticMarkupCommentMentionRef[]
   attachments: CriticMarkupCommentAttachmentRef[]
+  formatRanges: CriticMarkupCommentFormatRange[]
 }
 
 export interface CriticMarkupReviewController {
@@ -259,6 +262,8 @@ export function useCriticMarkupReview({
 
       const id = createCriticMarkId('comment')
       const createdAt = Date.now()
+      const formatRanges =
+        normalizeCriticMarkupCommentFormatRanges(input.formatRanges, trimmedBody.length) ?? []
       const nextMarks = [
         ...marksRef.current,
         {
@@ -270,6 +275,7 @@ export function useCriticMarkupReview({
           createdAt,
           ...(input.mentions.length > 0 ? { mentions: input.mentions } : {}),
           ...(input.attachments.length > 0 ? { attachments: input.attachments } : {}),
+          ...(formatRanges.length > 0 ? { formatRanges } : {}),
           start,
           end: start + draft.text.length
         }
@@ -295,14 +301,25 @@ export function useCriticMarkupReview({
       const existing = marksRef.current.find((mark) => mark.id === id && mark.kind === 'comment')
       if (!existing) return
 
+      const formatRanges =
+        normalizeCriticMarkupCommentFormatRanges(input.formatRanges, trimmedBody.length) ?? []
       const nextMarks = marksRef.current.map((mark) => {
         if (mark.id !== id) return mark
-        const { mentions: _mentions, attachments: _attachments, ...rest } = mark
+        const {
+          mentions: _mentions,
+          attachments: _attachments,
+          formatRanges: _formatRanges,
+          ...rest
+        } = mark
+        // Passed unconditionally: `buildCommentMetadata` only rewrites these keys
+        // when it receives arrays, so omitting an emptied one strands the stale
+        // `mentions=`/`attachments=`/`format=` in the file.
         return {
           ...rest,
           body: trimmedBody,
-          ...(input.mentions.length > 0 ? { mentions: input.mentions } : {}),
-          ...(input.attachments.length > 0 ? { attachments: input.attachments } : {})
+          mentions: input.mentions,
+          attachments: input.attachments,
+          formatRanges
         }
       })
       pushReviewUndoEntry(

--- a/apps/desktop/tests/e2e/critic-markup-review.e2e.ts
+++ b/apps/desktop/tests/e2e/critic-markup-review.e2e.ts
@@ -212,6 +212,41 @@ test.describe('CriticMarkup review flows', () => {
     await expect(page.locator('[data-journal-review-rail]')).toBeHidden()
     await expect(editor).toBeVisible()
   })
+
+  test('formats a comment draft from the selection toolbar without cancelling the draft', async ({
+    page
+  }) => {
+    await createNote(
+      page,
+      `Review Format ${Date.now()}`,
+      'format setup line\n\nsecond setup line\n\nformat target line'
+    )
+
+    await selectEditorText(page, 'format target line')
+    await page.locator('[data-test="review-comment"]').last().click()
+
+    const draft = commentComposer(page)
+    await expect(draft).toBeVisible()
+    const commentInput = draft.getByLabel('Add a comment...')
+    await commentInput.click()
+    await page.keyboard.type('needs a source')
+
+    await selectComposerText(page, 'source')
+
+    const toolbar = page.locator('[data-comment-format-toolbar]').first()
+    await expect(toolbar).toBeVisible()
+
+    await page.locator('[data-test="comment-format-bold"]').click()
+
+    // The bubble is portalled to the body, so clicking it must not trip the
+    // composer's outside-pointerdown auto-cancel.
+    await expect(draft).toBeVisible()
+    await expect(commentInput.locator('strong')).toHaveText('source')
+
+    await draft.getByLabel('Send comment').click()
+    await expect(reviewRail(page)).toContainText('needs a source')
+    await expect(reviewRail(page).locator('.critic-review-body strong')).toHaveText('source')
+  })
 })
 
 async function selectEditorText(page: Page, targetText: string): Promise<void> {
@@ -355,6 +390,37 @@ async function currentLocalDate(page: Page): Promise<string> {
       String(now.getDate()).padStart(2, '0')
     ].join('-')
   })
+}
+
+async function selectComposerText(page: Page, targetText: string): Promise<void> {
+  const didSelect = await page.evaluate((text) => {
+    const root = document.querySelector('.critic-comment-editor .ProseMirror')
+    if (!(root instanceof HTMLElement)) return false
+
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+    let node: Node | null
+    while ((node = walker.nextNode())) {
+      const index = (node.textContent ?? '').indexOf(text)
+      if (index === -1) continue
+
+      root.focus()
+      const range = document.createRange()
+      range.setStart(node, index)
+      range.setEnd(node, index + text.length)
+
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+
+      root.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }))
+      root.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+      document.dispatchEvent(new Event('selectionchange', { bubbles: true }))
+      return true
+    }
+    return false
+  }, targetText)
+
+  expect(didSelect).toBe(true)
 }
 
 function reviewRail(page: Page) {

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -149,6 +149,22 @@ Select text to open the floating toolbar. **Comment** creates an anchored review
 
 Comments can carry file attachments. Image attachments show an inline thumbnail; clicking an image or PDF opens it in the in-app viewer (close with Esc, a click outside, or the ✕). Other file types open in your operating system's default app.
 
+### Formatting a Comment
+
+Comment text supports bold, italic, underline, strikethrough and inline code. Select text inside the comment box and a small toolbar appears above the selection, or use the usual shortcuts:
+
+| Shortcut                                   | Mark          |
+| ------------------------------------------ | ------------- |
+| <kbd>⌘</kbd>+<kbd>B</kbd>                  | Bold          |
+| <kbd>⌘</kbd>+<kbd>I</kbd>                  | Italic        |
+| <kbd>⌘</kbd>+<kbd>U</kbd>                  | Underline     |
+| <kbd>⌘</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> | Strikethrough |
+| <kbd>⌘</kbd>+<kbd>E</kbd>                  | Inline code   |
+
+Markdown shortcuts work too — typing `**bold**` or `` `code` `` formats as you type. The toolbar stays hidden while the `@` mention picker is open.
+
+The comment text itself is stored in your note file as plain text, with the formatting recorded separately alongside the comment's other metadata. Comments written before this feature keep rendering exactly as they did, and a comment you format still reads cleanly if you open the note in another markdown editor. Editing a comment's text outside memrynote drops its formatting rather than applying it to the wrong words.
+
 ## What Notes Are Made Of
 
 Under the hood, every note is a Yjs CRDT (`Y.Doc`). Markdown is a derived export, not the canonical form — this is what lets edits from two devices merge cleanly. See [CRDT & Notes Sync](/architecture/crdt) for details.

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -239,6 +239,14 @@
     "attachAria": "Attach file",
     "mentionAria": "Mention a person, page or date",
     "sendAria": "Send comment",
+    "formatToolbarAria": "Text formatting",
+    "format": {
+      "bold": "Bold",
+      "italic": "Italic",
+      "underline": "Underline",
+      "strike": "Strikethrough",
+      "code": "Code"
+    },
     "openImageAria": "Open image {name}",
     "openAttachmentAria": "Open attachment {name}",
     "kind": {

--- a/packages/shared/src/critic-markup/parser.test.ts
+++ b/packages/shared/src/critic-markup/parser.test.ts
@@ -187,3 +187,130 @@ describe('parseCriticMarkup', () => {
     ).toBe(plainText)
   })
 })
+
+describe('comment format ranges', () => {
+  const plainText = 'Alpha quote end'
+  const baseMark = {
+    id: 'c1',
+    kind: 'comment' as const,
+    visibleText: 'quote',
+    metadata: 'id=c1;type=comment',
+    start: 6,
+    end: 11
+  }
+
+  it('round-trips format ranges through the comment metadata', () => {
+    const serialized = serializeCriticMarkup(plainText, [
+      {
+        ...baseMark,
+        body: 'see this and that',
+        formatRanges: [{ start: 4, end: 8, marks: ['bold'] }]
+      }
+    ])
+
+    expect(serialized).toContain('format=')
+    const parsed = parseCriticMarkup(serialized)
+    expect(parsed.plainText).toBe(plainText)
+    expect(parsed.marks[0].body).toBe('see this and that')
+    expect(parsed.marks[0].formatRanges).toEqual([{ start: 4, end: 8, marks: ['bold'] }])
+
+    // Re-serializing what we parsed must be byte-identical, or every open note
+    // would look dirty to the resync check in useCriticMarkupReview.
+    expect(serializeCriticMarkup(parsed.plainText, parsed.marks)).toBe(serialized)
+  })
+
+  it('omits the format key for undefined and empty ranges alike', () => {
+    const withoutKey = serializeCriticMarkup(plainText, [{ ...baseMark, body: 'plain body' }])
+
+    expect(withoutKey).not.toContain('format=')
+    expect(
+      serializeCriticMarkup(plainText, [{ ...baseMark, body: 'plain body', formatRanges: [] }])
+    ).toBe(withoutKey)
+  })
+
+  it('drops formatting when the body no longer matches the hash it was measured against', () => {
+    const serialized = serializeCriticMarkup(plainText, [
+      {
+        ...baseMark,
+        body: 'see this and that',
+        mentions: [{ kind: 'note', refId: 'note-1', label: 'Planning' }],
+        formatRanges: [{ start: 4, end: 8, marks: ['bold'] }]
+      }
+    ])
+
+    // Simulates an edit made outside the app (Obsidian, an older client).
+    const edited = serialized.replace('see this and that', 'see that and this')
+    const parsed = parseCriticMarkup(edited)
+
+    expect(parsed.marks[0].body).toBe('see that and this')
+    expect(parsed.marks[0].formatRanges).toBeUndefined()
+    expect(parsed.marks[0].mentions).toHaveLength(1)
+  })
+
+  it('ignores malformed format metadata without throwing', () => {
+    for (const encoded of ['%7Bbad', '%5B%5D', encodeURIComponent('{"v":2,"ranges":[]}')]) {
+      const parsed = parseCriticMarkup(
+        `A {==quote==}{>>id=c1;type=comment;format=${encoded} | body<<}`
+      )
+      expect(parsed.marks[0].formatRanges).toBeUndefined()
+      expect(parsed.marks[0].body).toBe('body')
+    }
+  })
+
+  it('clamps, drops, and canonically orders ranges on the way out', () => {
+    const serialized = serializeCriticMarkup(plainText, [
+      {
+        ...baseMark,
+        body: 'abcdef',
+        formatRanges: [
+          { start: 4, end: 99, marks: ['code'] },
+          { start: 0, end: 2, marks: ['code', 'bold', 'bold'] },
+          { start: 3, end: 3, marks: ['bold'] },
+          { start: -1, end: 2, marks: ['bold'] },
+          { start: 9, end: 11, marks: ['bold'] },
+          { start: 2, end: 3, marks: ['nonsense'] as never }
+        ]
+      }
+    ])
+
+    expect(parseCriticMarkup(serialized).marks[0].formatRanges).toEqual([
+      { start: 0, end: 2, marks: ['bold', 'code'] },
+      { start: 4, end: 6, marks: ['code'] }
+    ])
+  })
+
+  it('rewrites a stale format key and strips it when the ranges are cleared', () => {
+    const serialized = serializeCriticMarkup(plainText, [
+      { ...baseMark, body: 'abcdef', formatRanges: [{ start: 0, end: 3, marks: ['bold'] }] }
+    ])
+    const [parsedMark] = parseCriticMarkup(serialized).marks
+
+    const rewritten = serializeCriticMarkup(plainText, [
+      { ...parsedMark, formatRanges: [{ start: 3, end: 6, marks: ['italic'] }] }
+    ])
+    expect(parseCriticMarkup(rewritten).marks[0].formatRanges).toEqual([
+      { start: 3, end: 6, marks: ['italic'] }
+    ])
+
+    const cleared = serializeCriticMarkup(plainText, [{ ...parsedMark, formatRanges: [] }])
+    expect(cleared).not.toContain('format=')
+    expect(parseCriticMarkup(cleared).marks[0].formatRanges).toBeUndefined()
+  })
+
+  it('keeps formatting and mentions aligned when a range spans a mention', () => {
+    const body = 'ping @Planning now'
+    const serialized = serializeCriticMarkup(plainText, [
+      {
+        ...baseMark,
+        body,
+        mentions: [{ kind: 'note', refId: 'note-1', label: 'Planning' }],
+        formatRanges: [{ start: 0, end: body.length, marks: ['bold'] }]
+      }
+    ])
+
+    const [mark] = parseCriticMarkup(serialized).marks
+    expect(mark.body).toBe(body)
+    expect(mark.mentions).toEqual([{ kind: 'note', refId: 'note-1', label: 'Planning' }])
+    expect(mark.formatRanges).toEqual([{ start: 0, end: body.length, marks: ['bold'] }])
+  })
+})

--- a/packages/shared/src/critic-markup/parser.ts
+++ b/packages/shared/src/critic-markup/parser.ts
@@ -1,11 +1,7 @@
 export type CriticMarkupKind = 'addition' | 'deletion' | 'substitution' | 'comment'
 
 export type CriticMarkupCommentMentionKind =
-  | 'note'
-  | 'task'
-  | 'journal'
-  | 'inbox'
-  | 'calendar_event'
+  'note' | 'task' | 'journal' | 'inbox' | 'calendar_event'
 
 export interface CriticMarkupCommentMentionRef {
   kind: CriticMarkupCommentMentionKind
@@ -22,6 +18,17 @@ export interface CriticMarkupCommentAttachmentRef {
   type?: 'image' | 'file'
 }
 
+export type CriticMarkupCommentFormatMark =
+  'bold' | 'italic' | 'underline' | 'strikethrough' | 'code'
+
+/** Inline formatting for a slice of a comment body, as UTF-16 offsets into it. */
+export interface CriticMarkupCommentFormatRange {
+  start: number
+  /** Exclusive. */
+  end: number
+  marks: CriticMarkupCommentFormatMark[]
+}
+
 export interface CriticMarkupMark {
   id: string
   kind: CriticMarkupKind
@@ -34,6 +41,7 @@ export interface CriticMarkupMark {
   createdAt?: number
   mentions?: CriticMarkupCommentMentionRef[]
   attachments?: CriticMarkupCommentAttachmentRef[]
+  formatRanges?: CriticMarkupCommentFormatRange[]
 }
 
 export interface ParsedCriticMarkup {
@@ -166,6 +174,7 @@ export function parseCriticMarkup(markdown: string): ParsedCriticMarkup {
         createdAt: payload.createdAt ?? createdAtFromCommentMarkId(payload.id),
         mentions: payload.mentions,
         attachments: payload.attachments,
+        formatRanges: payload.formatRanges,
         start,
         end: plainText.length
       })
@@ -213,6 +222,7 @@ export function parseCriticMarkup(markdown: string): ParsedCriticMarkup {
         createdAt: payload.createdAt ?? createdAtFromCommentMarkId(payload.id),
         mentions: payload.mentions,
         attachments: payload.attachments,
+        formatRanges: payload.formatRanges,
         start,
         end: start
       })
@@ -246,10 +256,13 @@ export function serializeCriticMarkup(plainText: string, marks: CriticMarkupMark
 }
 
 export function buildCommentPayload(
-  mark: Pick<CriticMarkupMark, 'id' | 'body' | 'metadata' | 'mentions' | 'attachments'>
+  mark: Pick<
+    CriticMarkupMark,
+    'id' | 'body' | 'metadata' | 'mentions' | 'attachments' | 'formatRanges'
+  >
 ) {
-  const metadata = buildCommentMetadata(mark)
   const body = mark.body ?? ''
+  const metadata = buildCommentMetadata(mark, body)
   return `${metadata} | ${body}`
 }
 
@@ -302,6 +315,86 @@ export function normalizeCriticMarkupCommentAttachments(
   return attachments.length > 0 ? attachments : undefined
 }
 
+/** Canonical mark order. Also the outermost-first nesting order when rendered. */
+export const CRITIC_MARKUP_COMMENT_FORMAT_MARKS: CriticMarkupCommentFormatMark[] = [
+  'bold',
+  'italic',
+  'underline',
+  'strikethrough',
+  'code'
+]
+
+const COMMENT_FORMAT_VERSION = 1
+
+/**
+ * Fingerprints the body the ranges were measured against. Offsets desync when
+ * the body is edited outside the app (another client, Obsidian, a hand edit);
+ * a mismatch drops the formatting instead of painting it over the wrong words.
+ */
+export function criticMarkupCommentBodyHash(body: string): string {
+  return hash(body.trim())
+}
+
+export function normalizeCriticMarkupCommentFormatRanges(
+  value: unknown,
+  bodyLength: number
+): CriticMarkupCommentFormatRange[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const ranges = value.flatMap((item) => {
+    if (!item || typeof item !== 'object') return []
+    const range = item as Record<string, unknown>
+    const start = range.start
+    const end = range.end
+    if (typeof start !== 'number' || !Number.isFinite(start) || start < 0) return []
+    if (typeof end !== 'number' || !Number.isFinite(end) || end <= start) return []
+    if (start >= bodyLength) return []
+
+    const marks = normalizeCommentFormatMarks(range.marks)
+    if (marks.length === 0) return []
+    return [{ start, end: Math.min(end, bodyLength), marks }]
+  })
+
+  // Canonical order: `areCriticMarkupMarksEqual` and the Y.Doc writer both
+  // compare marks by JSON.stringify, so an unstable order reads as a change.
+  ranges.sort((a, b) => a.start - b.start || a.end - b.end)
+  return ranges.length > 0 ? ranges : undefined
+}
+
+export function parseCriticMarkupCommentFormat(
+  encoded: string | undefined,
+  body: string
+): CriticMarkupCommentFormatRange[] | undefined {
+  if (!encoded) return undefined
+  try {
+    const payload = JSON.parse(decodeURIComponent(encoded)) as Record<string, unknown>
+    if (!payload || typeof payload !== 'object') return undefined
+    if (payload.v !== COMMENT_FORMAT_VERSION) return undefined
+    if (payload.hash !== criticMarkupCommentBodyHash(body)) return undefined
+    return normalizeCriticMarkupCommentFormatRanges(payload.ranges, body.length)
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeCommentFormatMarks(value: unknown): CriticMarkupCommentFormatMark[] {
+  if (!Array.isArray(value)) return []
+  const marks = new Set<CriticMarkupCommentFormatMark>()
+  for (const mark of value) {
+    if (isCriticMarkupCommentFormatMark(mark)) marks.add(mark)
+  }
+  return CRITIC_MARKUP_COMMENT_FORMAT_MARKS.filter((mark) => marks.has(mark))
+}
+
+function isCriticMarkupCommentFormatMark(value: unknown): value is CriticMarkupCommentFormatMark {
+  return (
+    value === 'bold' ||
+    value === 'italic' ||
+    value === 'underline' ||
+    value === 'strikethrough' ||
+    value === 'code'
+  )
+}
+
 function serializeMark(mark: CriticMarkupMark, visibleText: string): string {
   switch (mark.kind) {
     case 'addition':
@@ -343,6 +436,7 @@ function parseCommentPayload(payload: string): {
   createdAt?: number
   mentions?: CriticMarkupCommentMentionRef[]
   attachments?: CriticMarkupCommentAttachmentRef[]
+  formatRanges?: CriticMarkupCommentFormatRange[]
 } {
   const separator = payload.indexOf(' | ')
   const metadata = separator === -1 ? undefined : payload.slice(0, separator).trim()
@@ -361,17 +455,20 @@ function parseCommentPayload(payload: string): {
     attachments: parseStructuredCommentMetadata(
       fields.get('attachments'),
       normalizeCriticMarkupCommentAttachments
-    )
+    ),
+    formatRanges: parseCriticMarkupCommentFormat(fields.get('format'), body)
   }
 }
 
 function buildCommentMetadata(
-  mark: Pick<CriticMarkupMark, 'id' | 'metadata' | 'mentions' | 'attachments'>
+  mark: Pick<CriticMarkupMark, 'id' | 'metadata' | 'mentions' | 'attachments' | 'formatRanges'>,
+  body: string
 ): string {
   const metadata = mark.metadata?.trim() || `id=${mark.id};type=comment`
   const hasMentionInput = Array.isArray(mark.mentions)
   const hasAttachmentInput = Array.isArray(mark.attachments)
-  if (!hasMentionInput && !hasAttachmentInput) return metadata
+  const hasFormatInput = Array.isArray(mark.formatRanges)
+  if (!hasMentionInput && !hasAttachmentInput && !hasFormatInput) return metadata
 
   const parts = metadata
     .split(';')
@@ -380,13 +477,27 @@ function buildCommentMetadata(
       const separator = part.indexOf('=')
       if (separator <= 0) return part.length > 0
       const key = part.slice(0, separator)
-      return key !== 'mentions' && key !== 'attachments'
+      return key !== 'mentions' && key !== 'attachments' && key !== 'format'
     })
 
   const mentions = normalizeCriticMarkupCommentMentions(mark.mentions)
   const attachments = normalizeCriticMarkupCommentAttachments(mark.attachments)
+  const trimmedBody = body.trim()
+  const formatRanges = normalizeCriticMarkupCommentFormatRanges(
+    mark.formatRanges,
+    trimmedBody.length
+  )
   if (mentions) parts.push(`mentions=${encodeURIComponent(JSON.stringify(mentions))}`)
   if (attachments) parts.push(`attachments=${encodeURIComponent(JSON.stringify(attachments))}`)
+  // Last, so comments without formatting serialize byte-identically to before.
+  if (formatRanges) {
+    const payload = {
+      v: COMMENT_FORMAT_VERSION,
+      hash: criticMarkupCommentBodyHash(trimmedBody),
+      ranges: formatRanges
+    }
+    parts.push(`format=${encodeURIComponent(JSON.stringify(payload))}`)
+  }
   return parts.join(';') || `id=${mark.id};type=comment`
 }
 

--- a/packages/shared/src/critic-markup/yjs.test.ts
+++ b/packages/shared/src/critic-markup/yjs.test.ts
@@ -101,4 +101,28 @@ describe('critic markup Yjs helpers', () => {
       expect.objectContaining({ createdAt: 1748254022000 })
     ])
   })
+
+  it('preserves comment format ranges and drops invalid ones', () => {
+    const doc = new FakeYDoc()
+
+    writeCriticMarkupMarksToYDoc(doc, [
+      {
+        id: 'c1',
+        kind: 'comment',
+        visibleText: 'quote',
+        body: 'see this and that',
+        start: 0,
+        end: 5,
+        formatRanges: [
+          { start: 4, end: 8, marks: ['bold'] },
+          { start: 4, end: 2, marks: ['italic'] },
+          { start: 0, end: 3, marks: [] }
+        ]
+      }
+    ])
+
+    expect(readCriticMarkupMarksFromYDoc(doc)[0].formatRanges).toEqual([
+      { start: 4, end: 8, marks: ['bold'] }
+    ])
+  })
 })

--- a/packages/shared/src/critic-markup/yjs.ts
+++ b/packages/shared/src/critic-markup/yjs.ts
@@ -1,5 +1,6 @@
 import {
   normalizeCriticMarkupCommentAttachments,
+  normalizeCriticMarkupCommentFormatRanges,
   normalizeCriticMarkupCommentMentions,
   type CriticMarkupKind,
   type CriticMarkupMark
@@ -65,6 +66,10 @@ function normalizeCriticMarkupMark(value: unknown): CriticMarkupMark | null {
 
   const mentions = normalizeCriticMarkupCommentMentions(mark.mentions)
   const attachments = normalizeCriticMarkupCommentAttachments(mark.attachments)
+  const formatRanges = normalizeCriticMarkupCommentFormatRanges(
+    mark.formatRanges,
+    (typeof mark.body === 'string' ? mark.body : '').trim().length
+  )
 
   return {
     id: mark.id,
@@ -79,7 +84,8 @@ function normalizeCriticMarkupMark(value: unknown): CriticMarkupMark | null {
       ? { createdAt: mark.createdAt }
       : {}),
     ...(mentions ? { mentions } : {}),
-    ...(attachments ? { attachments } : {})
+    ...(attachments ? { attachments } : {}),
+    ...(formatRanges ? { formatRanges } : {})
   }
 }
 
@@ -95,6 +101,7 @@ function toSerializableMark(mark: CriticMarkupMark): Record<string, unknown> {
     ...(mark.metadata !== undefined ? { metadata: mark.metadata } : {}),
     ...(mark.createdAt !== undefined ? { createdAt: mark.createdAt } : {}),
     ...(mark.mentions !== undefined ? { mentions: mark.mentions } : {}),
-    ...(mark.attachments !== undefined ? { attachments: mark.attachments } : {})
+    ...(mark.attachments !== undefined ? { attachments: mark.attachments } : {}),
+    ...(mark.formatRanges !== undefined ? { formatRanges: mark.formatRanges } : {})
   }
 }


### PR DESCRIPTION
## What

Selecting text in the comment composer pops a floating toolbar offering bold, italic, underline, strikethrough, and code. Formatting is stored as offset ranges in a new `format=` comment metadata key, so the comment body stays byte-identical plain text and older app versions keep rendering it unchanged.

## Why

Closes #806 — comment marks were explicitly disabled, so Cmd+B and `**bold**` genuinely did nothing.

Two things worth a reviewer's eye:

- `updateComment` now writes `mentions`/`attachments`/`formatRanges` unconditionally. This is required to clear an emptied key, and it fixes a pre-existing bug where removing every mention left a stale `mentions=` in the vault file.
- The E2E case is written but unverified — the suite hangs in `beforeEach` waiting for the vault to open, identically on unmodified `main`.