### PR TITLE
feat(tasks): quick-add speaks the note editor's grammar

### DIFF
--- a/apps/desktop/src/main/database/queries/tags.test.ts
+++ b/apps/desktop/src/main/database/queries/tags.test.ts
@@ -209,6 +209,29 @@ describe('getAllTagsWithCounts', () => {
     expect(typeof orphan?.color).toBe('string')
   })
 
+  it('gives a brand-new task-only tag a definition row, so quick-add tags are not colourless', () => {
+    // #given: the tag quick-add's `#tag` marker creates — it exists on a task
+    // and nowhere else, and no vault path ever ran `ensureTagDefinitions` for
+    // it (that is only wired to notes).
+    insertTask(dataDb, 't1')
+    insertTaskTag(dataDb, 't1', 'launch')
+    expect(
+      dataDb.all<{ name: string }>(sql`SELECT name FROM tag_definitions WHERE name = 'launch'`)
+    ).toEqual([])
+
+    // #when: the tag hub and the sidebar read the pool
+    const result = getAllTagsWithCounts(indexDb, dataDb)
+
+    // #then: it is listed, coloured, and now has a definition of its own —
+    // the read path back-fills what the task write path never created.
+    const launch = result.find((tag) => tag.name === 'launch')
+    expect(launch).toMatchObject({ name: 'launch', count: 1 })
+    expect(launch?.color).toBeTruthy()
+    expect(
+      dataDb.all<{ name: string }>(sql`SELECT name FROM tag_definitions WHERE name = 'launch'`)
+    ).toHaveLength(1)
+  })
+
   it('sorts results by count descending', () => {
     // #given: "beta" has more occurrences than "alpha"
     insertNote(indexDb, 'n1')

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -1207,6 +1207,8 @@
     --task-repeat: #3b82f6;
     --task-token-date: #f59e0b;
     --task-token-project: #60a5fa;
+    --task-token-tag: #8b5cf6;
+    --task-token-note: #0d9488;
 
     /* Checkbox */
     --task-checkbox-done: #7b9e87;
@@ -1339,6 +1341,8 @@
     --task-repeat: #3b82f6;
     --task-token-date: #f59e0b;
     --task-token-project: #60a5fa;
+    --task-token-tag: #8b5cf6;
+    --task-token-note: #0d9488;
 
     /* Checkbox */
     --task-checkbox-done: #7b9e87;
@@ -1476,6 +1480,8 @@
     --task-repeat: #60a5fa;
     --task-token-date: #fbbf24;
     --task-token-project: #93c5fd;
+    --task-token-tag: #a78bfa;
+    --task-token-note: #2dd4bf;
 
     /* Checkbox */
     --task-checkbox-done: #7b9e87;
@@ -2287,6 +2293,8 @@ del.bn-inline-content {
   --color-task-repeat: var(--task-repeat);
   --color-task-token-date: var(--task-token-date);
   --color-task-token-project: var(--task-token-project);
+  --color-task-token-tag: var(--task-token-tag);
+  --color-task-token-note: var(--task-token-note);
   --color-task-checkbox-done: var(--task-checkbox-done);
 
   /* ===== SIDEBAR ===== */

--- a/apps/desktop/src/renderer/src/components/capture-bar/capture-bar-suggestions.ts
+++ b/apps/desktop/src/renderer/src/components/capture-bar/capture-bar-suggestions.ts
@@ -1,0 +1,64 @@
+/**
+ * The two pools quick-add completes from: the app's tags (for the `#` ghost)
+ * and recent notes (for the `[[` picker).
+ *
+ * Both load the first time the user actually reaches for them, so a surface
+ * that never types a marker — and the Inbox, which passes no `quickAdd` at all —
+ * pays nothing.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { createLogger } from '@/lib/logger'
+import { notesService } from '@/services/notes-service'
+import { tagsService } from '@/services/tags-service'
+
+const log = createLogger('CaptureBarSuggestions')
+
+export interface NoteSuggestion {
+  id: string
+  title: string
+}
+
+/** Recent notes for the `[[` picker — the note editor's own list and order. */
+export function useNoteSuggestions(enabled: boolean): NoteSuggestion[] {
+  const [notes, setNotes] = useState<NoteSuggestion[]>([])
+  const requestedRef = useRef(false)
+
+  useEffect(() => {
+    if (!enabled || requestedRef.current) return
+    requestedRef.current = true
+
+    void (async () => {
+      try {
+        const result = await notesService.list({ limit: 500, sortBy: 'modified' })
+        setNotes(result.notes.map((note) => ({ id: note.id, title: note.title })))
+      } catch (error) {
+        log.error('Failed to load note suggestions', error)
+      }
+    })()
+  }, [enabled])
+
+  return notes
+}
+
+/** The app-wide tag pool, commonest first so the ghost offers the likeliest. */
+export function useTagSuggestions(enabled: boolean): string[] {
+  const [tags, setTags] = useState<string[]>([])
+  const requestedRef = useRef(false)
+
+  useEffect(() => {
+    if (!enabled || requestedRef.current) return
+    requestedRef.current = true
+
+    void (async () => {
+      try {
+        const result = await tagsService.getAllWithCounts()
+        setTags([...result.tags].sort((a, b) => b.count - a.count).map((tag) => tag.name))
+      } catch (error) {
+        log.error('Failed to load tag suggestions', error)
+      }
+    })()
+  }, [enabled])
+
+  return tags
+}

--- a/apps/desktop/src/renderer/src/components/capture-bar/capture-bar-tokens.tsx
+++ b/apps/desktop/src/renderer/src/components/capture-bar/capture-bar-tokens.tsx
@@ -12,9 +12,9 @@ import { useMemo } from 'react'
 import { cn } from '@/lib/utils'
 import {
   findQuickAddSpans,
-  getDateOptions,
   getPriorityOptions,
   getProjectOptions,
+  getTagOptions,
   predictRepeatCompletion,
   type AutocompleteOption,
   type QuickAddSpanKind
@@ -35,11 +35,12 @@ interface Token {
 }
 
 const TOKEN_STYLES: Record<Exclude<TokenKind, 'plain'>, string> = {
-  date: 'text-task-token-date bg-task-token-date/10 rounded px-0.5 -mx-0.5',
   priority: 'rounded px-0.5 -mx-0.5',
   project: 'text-task-token-project bg-task-token-project/10 rounded px-0.5 -mx-0.5',
+  tag: 'text-task-token-tag bg-task-token-tag/10 rounded px-0.5 -mx-0.5',
   // The natural-language forms read as one phrase rather than one word, so they
   // get the fuller pill: same metrics, rounder shell, stronger fill.
+  noteLink: 'text-task-token-note bg-task-token-note/15 rounded-full px-0.5 -mx-0.5',
   datePhrase: 'text-task-token-date bg-task-token-date/15 rounded-full px-0.5 -mx-0.5',
   repeat: 'text-task-repeat bg-task-repeat/15 rounded-full px-0.5 -mx-0.5'
 }
@@ -99,7 +100,7 @@ export const TokenOverlay = ({
         }
 
         if (token.kind === 'priority') {
-          const keyword = token.text.slice(2).toLowerCase()
+          const keyword = token.text.slice(1).toLowerCase()
           const colorClass =
             PRIORITY_COLORS[keyword] ?? 'text-task-priority-high bg-task-priority-high/10'
           return (
@@ -145,9 +146,9 @@ export function replaceTrigger(value: string, start: number, replacement: string
 // INLINE GHOST COMPLETION
 // ============================================================================
 
-type TriggerKind = 'date' | 'datePhrase' | 'priority' | 'project' | 'repeat'
+type TriggerKind = 'datePhrase' | 'priority' | 'project' | 'tag' | 'noteLink' | 'repeat'
 
-interface Trigger {
+export interface Trigger {
   kind: TriggerKind
   /** What has been typed after the trigger character (repeats keep "every"). */
   query: string
@@ -158,18 +159,24 @@ interface Trigger {
 /**
  * The quick-add trigger the caret is sitting in, if any.
  *
- * The sigil forms (`!`, `!!`, `#`) are one token; the natural-language forms
- * (`@next wednesday`, `every 2 weeks`) run over several words, so they are read
- * from their trigger word up to the end of the value instead.
+ * The sigil forms (`!`, `+`, `#`) are one token; the natural-language forms
+ * (`@next wednesday`, `every 2 weeks`, `[[Note title]]`) run over several
+ * words, so they are read from their trigger up to the end of the value.
  */
 export function detectTrigger(value: string): Trigger | null {
+  // An unclosed `[[` owns everything after it — a note title may hold any
+  // sigil, and the picker is what finishes it.
+  const linkStart = value.lastIndexOf('[[')
+  if (linkStart >= 0 && !value.slice(linkStart + 2).includes(']]')) {
+    return { kind: 'noteLink', query: value.slice(linkStart + 2), start: linkStart }
+  }
+
   const token = lastToken(value)
   const tokenStart = value.length - token.length
 
-  // `!!` before `!`: priority is the more specific trigger.
-  if (token.startsWith('!!')) return { kind: 'priority', query: token.slice(2), start: tokenStart }
-  if (token.startsWith('!')) return { kind: 'date', query: token.slice(1), start: tokenStart }
-  if (token.startsWith('#')) return { kind: 'project', query: token.slice(1), start: tokenStart }
+  if (token.startsWith('!')) return { kind: 'priority', query: token.slice(1), start: tokenStart }
+  if (token.startsWith('+')) return { kind: 'project', query: token.slice(1), start: tokenStart }
+  if (token.startsWith('#')) return { kind: 'tag', query: token.slice(1), start: tokenStart }
 
   // Multi-word triggers live on the caret's line; the nearest one wins.
   const lineStart = value.lastIndexOf('\n') + 1
@@ -195,7 +202,12 @@ function firstCompletion(options: AutocompleteOption[], typed: string): string |
   return options.find((option) => option.value.toLowerCase().startsWith(lower))?.value ?? null
 }
 
-function predictFor(trigger: Trigger, typed: string, projects: Project[]): string | null {
+function predictFor(
+  trigger: Trigger,
+  typed: string,
+  projects: Project[],
+  tags: string[]
+): string | null {
   switch (trigger.kind) {
     case 'datePhrase': {
       // The note editor's `@`-mention predictor, so both surfaces complete a
@@ -205,12 +217,16 @@ function predictFor(trigger: Trigger, typed: string, projects: Project[]): strin
     }
     case 'repeat':
       return predictRepeatCompletion(trigger.query)
-    case 'date':
-      return firstCompletion(getDateOptions(trigger.query), typed)
     case 'priority':
       return firstCompletion(getPriorityOptions(trigger.query), typed)
     case 'project':
       return firstCompletion(getProjectOptions(trigger.query, projects), typed)
+    case 'tag':
+      return firstCompletion(getTagOptions(trigger.query, tags), typed)
+    // Note titles are arbitrary user data, so `[[` gets the picker instead of a
+    // guess. CaptureBar reads the trigger and opens the dropdown.
+    case 'noteLink':
+      return null
   }
 }
 
@@ -228,12 +244,16 @@ export interface GhostCompletion {
  * nothing to finish. The prediction is always a case-insensitive superstring of
  * what the user typed, so accepting it never loses characters.
  */
-export function predictCompletion(value: string, projects: Project[]): GhostCompletion | null {
+export function predictCompletion(
+  value: string,
+  projects: Project[],
+  tags: string[] = []
+): GhostCompletion | null {
   const trigger = detectTrigger(value)
   if (!trigger) return null
 
   const typed = value.slice(trigger.start)
-  const text = predictFor(trigger, typed, projects)
+  const text = predictFor(trigger, typed, projects, tags)
   if (!text || !text.toLowerCase().startsWith(typed.toLowerCase())) return null
 
   const remainder = text.slice(typed.length)

--- a/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.test.tsx
@@ -22,7 +22,21 @@ import type { Project } from '@/data/tasks-data'
 // jsdom has no layout engine; the autocomplete dropdown scrolls its selection.
 Element.prototype.scrollIntoView = vi.fn()
 
-const mocks = vi.hoisted(() => ({ recorderStart: vi.fn() }))
+const mocks = vi.hoisted(() => ({
+  recorderStart: vi.fn(),
+  listNotes: vi.fn(),
+  getAllTagsWithCounts: vi.fn()
+}))
+
+// The `[[` picker and the `#` ghost read these pools lazily, the first time the
+// user reaches for one.
+vi.mock('@/services/notes-service', () => ({
+  notesService: { list: mocks.listNotes }
+}))
+
+vi.mock('@/services/tags-service', () => ({
+  tagsService: { getAllWithCounts: mocks.getAllTagsWithCounts }
+}))
 
 vi.mock('@/components/voice-recorder', () => ({
   VoiceRecorder: forwardRef(
@@ -111,8 +125,21 @@ const field = (): HTMLTextAreaElement =>
 /** The un-typed remainder painted after the caret by the inline completion. */
 const ghost = (): HTMLElement => screen.getByTestId('capture-bar-ghost')
 
+const mockNotes = [
+  { id: 'note-1', title: 'Roadmap' },
+  { id: 'note-2', title: 'Q1 Goals' },
+  { id: 'note-3', title: 'Hiring plan' }
+]
+
 beforeEach(() => {
   vi.clearAllMocks()
+  mocks.listNotes.mockResolvedValue({ notes: mockNotes })
+  mocks.getAllTagsWithCounts.mockResolvedValue({
+    tags: [
+      { name: 'launch', count: 9 },
+      { name: 'later', count: 2 }
+    ]
+  })
 })
 
 // ============================================================================
@@ -542,18 +569,22 @@ describe('CaptureBar — quick-add syntax', () => {
     quickAdd: { projects: mockProjects }
   }
 
-  it('parses date, priority and project out of the title', async () => {
+  it('parses date, priority, project and tags out of the title', async () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn()
     renderBar(<CaptureBar {...quickAddProps} onSubmit={onSubmit} />)
 
-    await user.type(field(), 'Buy groceries !tomorrow !!high #Personal')
+    await user.type(field(), 'Buy groceries @tomorrow !high +Personal #errands #food')
     await user.keyboard('{Enter}')
 
     expect(onSubmit).toHaveBeenCalledTimes(1)
     const [title, parsed] = onSubmit.mock.calls[0]
     expect(title).toBe('Buy groceries')
-    expect(parsed).toMatchObject({ priority: 'high', projectId: 'project-1' })
+    expect(parsed).toMatchObject({
+      priority: 'high',
+      projectId: 'project-1',
+      tags: ['errands', 'food']
+    })
     expect(parsed.dueDate).toBeInstanceOf(Date)
   })
 
@@ -562,35 +593,35 @@ describe('CaptureBar — quick-add syntax', () => {
     const onSubmit = vi.fn()
     renderBar(<CaptureBar {...baseProps} onSubmit={onSubmit} />)
 
-    await user.type(field(), 'Buy groceries !tomorrow{enter}')
+    await user.type(field(), 'Buy groceries @tomorrow{enter}')
 
-    expect(onSubmit).toHaveBeenCalledWith('Buy groceries !tomorrow')
+    expect(onSubmit).toHaveBeenCalledWith('Buy groceries @tomorrow')
   })
 
-  it('ghosts the completion for !date, !!priority and #project', async () => {
+  it('ghosts the completion for !priority, +project and #tag', async () => {
     const user = userEvent.setup()
     renderBar(<CaptureBar {...quickAddProps} onSubmit={vi.fn()} />)
 
-    await user.type(field(), 'Task !tom')
-    expect(ghost()).toHaveTextContent('orrow')
-
-    await user.clear(field())
-    await user.type(field(), 'Task !!hi')
+    await user.type(field(), 'Task !hi')
     expect(ghost()).toHaveTextContent('gh')
 
     await user.clear(field())
-    await user.type(field(), 'Task #per')
+    await user.type(field(), 'Task +per')
     expect(ghost()).toHaveTextContent('sonal')
+
+    await user.clear(field())
+    await user.type(field(), 'Task #lau')
+    await waitFor(() => expect(ghost()).toHaveTextContent('nch'))
   })
 
   it('completes the token on Tab', async () => {
     const user = userEvent.setup()
     renderBar(<CaptureBar {...quickAddProps} onSubmit={vi.fn()} />)
 
-    await user.type(field(), 'Task #per')
+    await user.type(field(), 'Task +per')
     await user.keyboard('{Tab}')
 
-    expect(field()).toHaveValue('Task #Personal ')
+    expect(field()).toHaveValue('Task +Personal ')
     expect(screen.queryByTestId('capture-bar-ghost')).not.toBeInTheDocument()
   })
 
@@ -598,17 +629,17 @@ describe('CaptureBar — quick-add syntax', () => {
     const user = userEvent.setup()
     renderBar(<CaptureBar {...quickAddProps} onSubmit={vi.fn()} />)
 
-    await user.type(field(), 'Task !!hi')
+    await user.type(field(), 'Task !hi')
     await user.keyboard('{ArrowRight}')
 
-    expect(field()).toHaveValue('Task !!high ')
+    expect(field()).toHaveValue('Task !high ')
   })
 
   it('detects the trigger on the last line of a multi-line capture', async () => {
     const user = userEvent.setup()
     renderBar(<CaptureBar {...quickAddProps} onSubmit={vi.fn()} />)
 
-    await user.type(field(), 'First line{Shift>}{Enter}{/Shift}#per')
+    await user.type(field(), 'First line{Shift>}{Enter}{/Shift}+per')
 
     expect(ghost()).toHaveTextContent('sonal')
   })
@@ -618,7 +649,7 @@ describe('CaptureBar — quick-add syntax', () => {
     const onSubmit = vi.fn()
     renderBar(<CaptureBar {...quickAddProps} onSubmit={onSubmit} />)
 
-    await user.type(field(), 'Important task !!high')
+    await user.type(field(), 'Important task !high')
     expect(screen.queryByTestId('capture-bar-ghost')).not.toBeInTheDocument()
     await user.keyboard('{Enter}')
 
@@ -644,6 +675,146 @@ describe('CaptureBar — quick-add syntax', () => {
     await user.type(field(), 'Task !')
 
     expect(screen.queryByTestId('capture-bar-ghost')).not.toBeInTheDocument()
+  })
+
+  it('leaves prose punctuation and code alone', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    renderBar(<CaptureBar {...quickAddProps} onSubmit={onSubmit} />)
+
+    await user.type(field(), 'Ship it! Learn C++{enter}')
+
+    expect(onSubmit.mock.calls[0][0]).toBe('Ship it! Learn C++')
+    expect(onSubmit.mock.calls[0][1]).toMatchObject({ priority: 'none', projectId: null })
+  })
+})
+
+// ============================================================================
+// `[[` note picker — the one completion that is a list, not a ghost
+// ============================================================================
+
+describe('CaptureBar — [[ note picker', () => {
+  const quickAddProps = {
+    ...baseProps,
+    quickAdd: { projects: mockProjects }
+  }
+
+  const options = (): HTMLElement[] => screen.getAllByRole('option')
+
+  // userEvent reads `[` as the start of a key descriptor, so a literal `[[`
+  // has to be typed as four brackets.
+  const OPEN_PICKER = 'Draft the plan [[[['
+
+  it('opens on [[ with recent notes and filters as you type', async () => {
+    const user = userEvent.setup()
+    renderBar(<CaptureBar {...quickAddProps} onSubmit={vi.fn()} />)
+
+    await user.type(field(), OPEN_PICKER)
+    await waitFor(() => expect(options()).toHaveLength(3))
+    expect(options().map((option) => option.textContent)).toEqual([
+      'Roadmap',
+      'Q1 Goals',
+      'Hiring plan'
+    ])
+
+    await user.type(field(), 'Q1')
+    await waitFor(() => expect(options()).toHaveLength(1))
+    expect(options()[0]).toHaveTextContent('Q1 Goals')
+  })
+
+  it('does not open for any other marker', async () => {
+    const user = userEvent.setup()
+    renderBar(<CaptureBar {...quickAddProps} onSubmit={vi.fn()} />)
+
+    await user.type(field(), 'Task #lau')
+    await waitFor(() => expect(ghost()).toBeInTheDocument())
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('writes the chosen title into the field on Enter', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    renderBar(<CaptureBar {...quickAddProps} onSubmit={onSubmit} />)
+
+    await user.type(field(), OPEN_PICKER)
+    await waitFor(() => expect(options()).toHaveLength(3))
+    await user.keyboard('{Enter}')
+
+    // Enter selected the note rather than submitting the task.
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(field()).toHaveValue('Draft the plan [[Roadmap]] ')
+  })
+
+  it('navigates with the arrow keys and selects with Tab', async () => {
+    const user = userEvent.setup()
+    renderBar(<CaptureBar {...quickAddProps} onSubmit={vi.fn()} />)
+
+    await user.type(field(), OPEN_PICKER)
+    await waitFor(() => expect(options()).toHaveLength(3))
+
+    await user.keyboard('{ArrowDown}{ArrowDown}{ArrowUp}')
+    expect(options()[1]).toHaveAttribute('aria-selected', 'true')
+
+    await user.keyboard('{Tab}')
+    expect(field()).toHaveValue('Draft the plan [[Q1 Goals]] ')
+  })
+
+  it('links the selected note on submit and drops the run from the title', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    renderBar(<CaptureBar {...quickAddProps} onSubmit={onSubmit} />)
+
+    await user.type(field(), OPEN_PICKER)
+    await waitFor(() => expect(options()).toHaveLength(3))
+    await user.keyboard('{Enter}')
+    await user.keyboard('{Enter}')
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit.mock.calls[0][0]).toBe('Draft the plan')
+    expect(onSubmit.mock.calls[0][1]).toMatchObject({ linkedNoteIds: ['note-1'] })
+  })
+
+  it('resolves a hand-typed [[Title]] by exact title', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    renderBar(<CaptureBar {...quickAddProps} onSubmit={onSubmit} />)
+
+    // The picker's fetch is what loads the pool; typing straight through it
+    // never selects anything.
+    await user.type(field(), OPEN_PICKER)
+    await waitFor(() => expect(options()).toHaveLength(3))
+    await user.type(field(), 'hiring plan]]')
+    await user.keyboard('{Enter}')
+
+    expect(onSubmit.mock.calls[0][0]).toBe('Draft the plan')
+    expect(onSubmit.mock.calls[0][1]).toMatchObject({ linkedNoteIds: ['note-3'] })
+  })
+
+  it('links nothing when the title matches no note', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    renderBar(<CaptureBar {...quickAddProps} onSubmit={onSubmit} />)
+
+    await user.type(field(), 'Draft the plan [[[[Nothing here]]{enter}')
+
+    expect(onSubmit.mock.calls[0][0]).toBe('Draft the plan')
+    expect(onSubmit.mock.calls[0][1]).toMatchObject({ linkedNoteIds: [] })
+  })
+
+  it('closes on Escape without clearing, and clears on the second Escape', async () => {
+    const user = userEvent.setup()
+    renderBar(<CaptureBar {...quickAddProps} onSubmit={vi.fn()} />)
+
+    await user.type(field(), OPEN_PICKER)
+    await waitFor(() => expect(options()).toHaveLength(3))
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(field()).toHaveValue('Draft the plan [[')
+
+    await user.keyboard('{Escape}')
+    expect(field()).toHaveValue('')
   })
 })
 

--- a/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.tsx
@@ -5,9 +5,10 @@
  * nowhere else, so the three surfaces cannot drift apart again. Everything a
  * single surface needs is a capability prop: pass `attachment` and a paperclip
  * appears, pass `voice` and the mic + inline recorder appear, pass `quickAdd`
- * and `@tomorrow` / `every monday` / `!!high` / `#project` get parsed, painted
- * as pills, and finished by the inline ghost completion. Omit them and the
- * affordance is not rendered at all.
+ * and `@tomorrow` / `every monday` / `!high` / `+project` / `#tag` / `[[Note]]`
+ * get parsed, painted as pills, and finished by the inline ghost completion (or,
+ * for `[[`, the note picker). Omit them and the affordance is not rendered at
+ * all.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -20,8 +21,16 @@ import { useTrackedTimeout } from '@/hooks/use-tracked-timeout'
 import { isMac } from '@/lib/shortcut-registry'
 import { isLikelyUrl } from '@/lib/capture-intent'
 import { hasSpecialSyntax, parseQuickAdd } from '@/lib/quick-add-parser'
+import { fuzzySearch } from '@/lib/fuzzy-search'
 import { VoiceRecorder, type VoiceRecorderHandle } from '@/components/voice-recorder'
-import { TokenOverlay, predictCompletion, replaceTrigger } from './capture-bar-tokens'
+import { AutocompleteDropdown } from '@/components/tasks/quick-add/autocomplete-dropdown'
+import {
+  TokenOverlay,
+  detectTrigger,
+  predictCompletion,
+  replaceTrigger
+} from './capture-bar-tokens'
+import { useNoteSuggestions, useTagSuggestions } from './capture-bar-suggestions'
 import { ownsFocusShortcut, registerCaptureField } from './focus-shortcut-owner'
 import type { Priority, RepeatConfig } from '@/data/task-model'
 import type { Project } from '@/data/tasks-data'
@@ -42,7 +51,14 @@ export interface CaptureBarParsed {
   priority: Priority
   projectId: string | null
   repeat: RepeatConfig | null
+  /** Every `#tag` in the input, case preserved. */
+  tags: string[]
+  /** Notes named by a `[[…]]` run that resolved to a real note. */
+  linkedNoteIds: string[]
 }
+
+/** How many notes the `[[` picker shows at once. */
+const NOTE_PICKER_LIMIT = 10
 
 export interface CaptureBarProps {
   placeholder: string
@@ -65,9 +81,9 @@ export interface CaptureBarProps {
   /** `'add'` = dashed plus, `'auto'` = link or document depending on the content. */
   icon?: 'auto' | 'add'
   /**
-   * Enables quick-add parsing, pills and ghost completion: `!date`,
-   * `!!priority`, `#project`, plus the natural-language `@next wednesday` and
-   * `every 2 weeks` phrases.
+   * Enables quick-add parsing, pills and completion — the note editor's own
+   * grammar: `@next wednesday`, `!high`, `+project`, `#tag`, `[[Note]]` and
+   * `every 2 weeks`. Everything but `[[` is finished by the inline ghost.
    */
   quickAdd?: { projects: Project[] }
   /** Renders the paperclip. */
@@ -234,16 +250,87 @@ export const CaptureBar = ({
     )
   }, [])
 
+  // The trigger the caret is in, shared by the ghost and the `[[` picker.
+  const trigger = useMemo(
+    () => (quickAdd && isFocused ? detectTrigger(value) : null),
+    [quickAdd, isFocused, value]
+  )
+
+  const noteQuery = trigger?.kind === 'noteLink' ? trigger.query : null
+  const notes = useNoteSuggestions(noteQuery !== null)
+  const tags = useTagSuggestions(trigger?.kind === 'tag')
+
   const ghost = useMemo(() => {
     if (!quickAdd || !isFocused || !caretAtEnd) return null
-    return predictCompletion(value, quickAdd.projects)
-  }, [quickAdd, isFocused, caretAtEnd, value])
+    return predictCompletion(value, quickAdd.projects, tags)
+  }, [quickAdd, isFocused, caretAtEnd, value, tags])
 
   const acceptGhost = useCallback((): void => {
     if (!ghost) return
     setValue((prev) => replaceTrigger(prev, ghost.start, ghost.text))
     fieldRef.current?.focus()
   }, [ghost])
+
+  // --------------------------------------------------------------------------
+  // `[[` note picker
+  //
+  // The one completion that is a list rather than a ghost: note titles are
+  // arbitrary user data, so guessing at them would be worse than showing them.
+  // --------------------------------------------------------------------------
+
+  // Closed by Esc, re-armed by the next keystroke.
+  const [pickerDismissed, setPickerDismissed] = useState(false)
+  const [pickerIndex, setPickerIndex] = useState(0)
+
+  // What the picker has handed out, so submit links the note the user actually
+  // chose rather than re-resolving a title two notes might share.
+  const pickedNoteIdsRef = useRef(new Map<string, string>())
+
+  const noteOptions = useMemo(() => {
+    if (noteQuery === null) return []
+    const query = noteQuery.trim()
+    const matched = query ? fuzzySearch(notes, query, ['title']) : notes
+    return matched
+      .slice(0, NOTE_PICKER_LIMIT)
+      .map((note) => ({ value: note.id, label: note.title }))
+  }, [noteQuery, notes])
+
+  // Reset the highlight during render whenever the list changes underneath it.
+  const [lastNoteOptions, setLastNoteOptions] = useState(noteOptions)
+  if (lastNoteOptions !== noteOptions) {
+    setLastNoteOptions(noteOptions)
+    setPickerIndex(0)
+  }
+
+  const isPickerOpen = noteQuery !== null && !pickerDismissed && noteOptions.length > 0
+
+  const selectNote = useCallback(
+    (noteId: string): void => {
+      const note = notes.find((candidate) => candidate.id === noteId)
+      if (!note || trigger?.kind !== 'noteLink') return
+      pickedNoteIdsRef.current.set(note.title.toLowerCase(), note.id)
+      setValue((prev) => replaceTrigger(prev, trigger.start, `[[${note.title}]]`))
+      fieldRef.current?.focus()
+    },
+    [notes, trigger]
+  )
+
+  // A `[[Title]]` the picker wrote is already known; one typed by hand is
+  // resolved against the loaded notes by exact title.
+  const resolveNoteIds = useCallback(
+    (titles: string[]): string[] =>
+      titles
+        .map((title) => {
+          const key = title.toLowerCase()
+          return (
+            pickedNoteIdsRef.current.get(key) ??
+            notes.find((note) => note.title.toLowerCase() === key)?.id ??
+            null
+          )
+        })
+        .filter((id): id is string => id !== null),
+    [notes]
+  )
 
   // --------------------------------------------------------------------------
   // Submit
@@ -260,7 +347,9 @@ export const CaptureBar = ({
             dueTime: parsed.dueTime,
             priority: parsed.priority,
             projectId: parsed.projectId,
-            repeat: parsed.repeat
+            repeat: parsed.repeat,
+            tags: parsed.tags,
+            linkedNoteIds: resolveNoteIds(parsed.noteTitles)
           })
         })()
       : await onSubmit(trimmed)
@@ -271,7 +360,7 @@ export const CaptureBar = ({
     }
     // Keep focus for rapid entry.
     fieldRef.current?.focus()
-  }, [trimmed, disabled, quickAdd, onSubmit])
+  }, [trimmed, disabled, quickAdd, onSubmit, resolveNoteIds])
 
   const openDetail = useCallback((): void => {
     if (!onOpenDetail) return
@@ -283,6 +372,33 @@ export const CaptureBar = ({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
+      // The `[[` picker owns the keyboard while it is open — including Enter,
+      // which selects a note here rather than submitting the task.
+      if (isPickerOpen) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault()
+          setPickerIndex((prev) => Math.min(prev + 1, noteOptions.length - 1))
+          return
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault()
+          setPickerIndex((prev) => Math.max(prev - 1, 0))
+          return
+        }
+        if (e.key === 'Enter' || e.key === 'Tab') {
+          e.preventDefault()
+          selectNote(noteOptions[pickerIndex].value)
+          return
+        }
+        // First Esc closes the list and leaves the text alone; a second one
+        // clears the field, the way Esc always has.
+        if (e.key === 'Escape') {
+          e.preventDefault()
+          setPickerDismissed(true)
+          return
+        }
+      }
+
       // Tab and → accept the ghost. Enter deliberately does not: it submits
       // exactly what is on screen, so a suggestion is never captured by
       // accident.
@@ -309,7 +425,17 @@ export const CaptureBar = ({
         fieldRef.current?.blur()
       }
     },
-    [ghost, acceptGhost, submit, onOpenDetail, openDetail]
+    [
+      isPickerOpen,
+      noteOptions,
+      pickerIndex,
+      selectNote,
+      ghost,
+      acceptGhost,
+      submit,
+      onOpenDetail,
+      openDetail
+    ]
   )
 
   // --------------------------------------------------------------------------
@@ -386,6 +512,7 @@ export const CaptureBar = ({
               value={value}
               onChange={(e) => {
                 setValue(e.target.value)
+                setPickerDismissed(false)
                 syncCaret()
               }}
               onSelect={syncCaret}
@@ -411,6 +538,16 @@ export const CaptureBar = ({
                   : 'text-foreground/90'
               )}
             />
+
+            {isPickerOpen && (
+              <AutocompleteDropdown
+                type="note"
+                options={noteOptions}
+                selectedIndex={pickerIndex}
+                onSelect={selectNote}
+                onClose={() => setPickerDismissed(true)}
+              />
+            )}
           </div>
 
           <div className="flex shrink-0 items-center gap-0.5">

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -729,7 +729,9 @@ describe('ContentArea', () => {
 
     expect(contentAreaMocks.tasksService.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Standalone #urgent',
+        // `#urgent` is a tag now, so it leaves the title and lands on the task.
+        title: 'Standalone',
+        tags: ['urgent'],
         linkedNoteIds: ['note-1']
       })
     )

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -783,7 +783,7 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
 
         const parsed = text
           ? parseQuickAdd(text, projects)
-          : { title: '', priority: 'none', projectId: null, dueDate: null }
+          : { title: '', priority: 'none', projectId: null, dueDate: null, tags: [] }
 
         try {
           const result = await tasksService.create({
@@ -792,6 +792,9 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
             title: parsed.title,
             priority: PRIORITY_REVERSE[parsed.priority] ?? 0,
             dueDate: parsed.dueDate ? formatDateKey(parsed.dueDate) : null,
+            // A `#tag` on the checklist line leaves the title now that `#` means
+            // tag, so it has to land on the task instead of being dropped.
+            tags: parsed.tags,
             linkedNoteIds: noteId ? [noteId] : []
           })
           if (result.success && result.task) {

--- a/apps/desktop/src/renderer/src/components/tasks/quick-add/autocomplete-dropdown.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/quick-add/autocomplete-dropdown.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
-import { Calendar, Flag, Folder } from '@/lib/icons'
+import { Calendar, FileText, Flag, Folder } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
 // ============================================================================
 // TYPES
 // ============================================================================
 
-export type AutocompleteType = 'date' | 'priority' | 'project' | null
+export type AutocompleteType = 'date' | 'priority' | 'project' | 'note' | null
 
 export interface AutocompleteOption {
   value: string
@@ -19,6 +19,12 @@ interface AutocompleteDropdownProps {
   options: AutocompleteOption[]
   onSelect: (value: string) => void
   onClose: () => void
+  /**
+   * Controlled highlight. Pass it when the caller already owns the keyboard —
+   * CaptureBar does, because its textarea handler runs before this component's
+   * window listener and would otherwise submit on the Enter that should select.
+   */
+  selectedIndex?: number
   className?: string
 }
 
@@ -32,7 +38,8 @@ const AUTOCOMPLETE_HEADERS: Record<
 > = {
   date: { icon: <Calendar className="size-3.5" />, label: 'Due Date' },
   priority: { icon: <Flag className="size-3.5" />, label: 'Priority' },
-  project: { icon: <Folder className="size-3.5" />, label: 'Project' }
+  project: { icon: <Folder className="size-3.5" />, label: 'Project' },
+  note: { icon: <FileText className="size-3.5" />, label: 'Link a note' }
 }
 
 const AutocompleteHeader = ({ type }: { type: AutocompleteType }): React.JSX.Element | null => {
@@ -104,16 +111,19 @@ export const AutocompleteDropdown = ({
   options,
   onSelect,
   onClose,
+  selectedIndex: controlledIndex,
   className
 }: AutocompleteDropdownProps): React.JSX.Element | null => {
-  const [selectedIndex, setSelectedIndex] = useState(0)
+  const isControlled = controlledIndex !== undefined
+  const [internalIndex, setInternalIndex] = useState(0)
+  const selectedIndex = isControlled ? controlledIndex : internalIndex
   const listRef = useRef<HTMLDivElement>(null)
 
   // Reset selection during render whenever the available options change.
   const [storedOptions, setStoredOptions] = useState(options)
   if (storedOptions !== options) {
     setStoredOptions(options)
-    setSelectedIndex(0)
+    setInternalIndex(0)
   }
 
   // Scroll selected item into view (layout work).
@@ -134,11 +144,11 @@ export const AutocompleteDropdown = ({
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault()
-          setSelectedIndex((prev) => Math.min(prev + 1, options.length - 1))
+          setInternalIndex((prev) => Math.min(prev + 1, options.length - 1))
           break
         case 'ArrowUp':
           e.preventDefault()
-          setSelectedIndex((prev) => Math.max(prev - 1, 0))
+          setInternalIndex((prev) => Math.max(prev - 1, 0))
           break
         case 'Enter':
         case 'Tab':
@@ -156,11 +166,13 @@ export const AutocompleteDropdown = ({
     [options, selectedIndex, onSelect, onClose]
   )
 
-  // Add/remove keyboard listener
+  // Add/remove keyboard listener — skipped while controlled, so the caller's
+  // own handler is the only one acting on a key.
   useEffect(() => {
+    if (isControlled) return
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [handleKeyDown])
+  }, [handleKeyDown, isControlled])
 
   // Don't render if no options
   if (options.length === 0) return null
@@ -188,7 +200,7 @@ export const AutocompleteDropdown = ({
             <OptionItem
               option={option}
               isSelected={index === selectedIndex}
-              showValue={type !== 'project'}
+              showValue={type !== 'project' && type !== 'note'}
               onClick={() => onSelect(option.value)}
             />
           </div>

--- a/apps/desktop/src/renderer/src/lib/quick-add-parser.test.ts
+++ b/apps/desktop/src/renderer/src/lib/quick-add-parser.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { Project } from '@/data/tasks-data'
 import {
-  parseDateKeyword,
   parsePriorityKeyword,
   findProjectByName,
   findDatePhrase,
+  findNoteLinks,
   findQuickAddSpans,
   parseQuickAdd,
   hasSpecialSyntax,
   getParsePreview,
-  getDateOptions,
   getPriorityOptions,
   getProjectOptions,
+  getTagOptions,
   predictRepeatCompletion
 } from './quick-add-parser'
 
@@ -31,239 +31,6 @@ const createMockProject = (overrides: Partial<Project> = {}): Project => ({
   createdAt: new Date(),
   taskCount: 0,
   ...overrides
-})
-
-// ============================================================================
-// T104: DATE KEYWORD PARSING
-// ============================================================================
-
-describe('parseDateKeyword', () => {
-  beforeEach(() => {
-    // January 10, 2026 is a Saturday
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(2026, 0, 10))
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  describe('today keyword', () => {
-    it("should parse 'today' to current date", () => {
-      const result = parseDateKeyword('today')
-      expect(result).toEqual(new Date(2026, 0, 10))
-    })
-
-    it("should handle uppercase 'TODAY'", () => {
-      const result = parseDateKeyword('TODAY')
-      expect(result).toEqual(new Date(2026, 0, 10))
-    })
-
-    it("should handle mixed case 'Today'", () => {
-      const result = parseDateKeyword('Today')
-      expect(result).toEqual(new Date(2026, 0, 10))
-    })
-  })
-
-  describe('tomorrow keywords', () => {
-    it("should parse 'tomorrow' to next day", () => {
-      const result = parseDateKeyword('tomorrow')
-      expect(result).toEqual(new Date(2026, 0, 11))
-    })
-
-    it("should parse 'tmr' to next day", () => {
-      const result = parseDateKeyword('tmr')
-      expect(result).toEqual(new Date(2026, 0, 11))
-    })
-
-    it("should parse 'tom' to next day", () => {
-      const result = parseDateKeyword('tom')
-      expect(result).toEqual(new Date(2026, 0, 11))
-    })
-  })
-
-  describe('next week keywords', () => {
-    it("should parse 'nextweek' to +7 days", () => {
-      const result = parseDateKeyword('nextweek')
-      expect(result).toEqual(new Date(2026, 0, 17))
-    })
-
-    it("should parse 'next' to +7 days", () => {
-      const result = parseDateKeyword('next')
-      expect(result).toEqual(new Date(2026, 0, 17))
-    })
-  })
-
-  describe('day name parsing (from Saturday Jan 10, 2026)', () => {
-    it("should parse 'sun' to next Sunday (Jan 11)", () => {
-      const result = parseDateKeyword('sun')
-      expect(result).toEqual(new Date(2026, 0, 11))
-    })
-
-    it("should parse 'sunday' to next Sunday (Jan 11)", () => {
-      const result = parseDateKeyword('sunday')
-      expect(result).toEqual(new Date(2026, 0, 11))
-    })
-
-    it("should parse 'mon' to next Monday (Jan 12)", () => {
-      const result = parseDateKeyword('mon')
-      expect(result).toEqual(new Date(2026, 0, 12))
-    })
-
-    it("should parse 'monday' to next Monday (Jan 12)", () => {
-      const result = parseDateKeyword('monday')
-      expect(result).toEqual(new Date(2026, 0, 12))
-    })
-
-    it("should parse 'tue' to next Tuesday (Jan 13)", () => {
-      const result = parseDateKeyword('tue')
-      expect(result).toEqual(new Date(2026, 0, 13))
-    })
-
-    it("should parse 'tuesday' to next Tuesday (Jan 13)", () => {
-      const result = parseDateKeyword('tuesday')
-      expect(result).toEqual(new Date(2026, 0, 13))
-    })
-
-    it("should parse 'wed' to next Wednesday (Jan 14)", () => {
-      const result = parseDateKeyword('wed')
-      expect(result).toEqual(new Date(2026, 0, 14))
-    })
-
-    it("should parse 'wednesday' to next Wednesday (Jan 14)", () => {
-      const result = parseDateKeyword('wednesday')
-      expect(result).toEqual(new Date(2026, 0, 14))
-    })
-
-    it("should parse 'thu' to next Thursday (Jan 15)", () => {
-      const result = parseDateKeyword('thu')
-      expect(result).toEqual(new Date(2026, 0, 15))
-    })
-
-    it("should parse 'thursday' to next Thursday (Jan 15)", () => {
-      const result = parseDateKeyword('thursday')
-      expect(result).toEqual(new Date(2026, 0, 15))
-    })
-
-    it("should parse 'fri' to next Friday (Jan 16)", () => {
-      const result = parseDateKeyword('fri')
-      expect(result).toEqual(new Date(2026, 0, 16))
-    })
-
-    it("should parse 'friday' to next Friday (Jan 16)", () => {
-      const result = parseDateKeyword('friday')
-      expect(result).toEqual(new Date(2026, 0, 16))
-    })
-
-    it("should parse 'sat' to next Saturday (Jan 17)", () => {
-      const result = parseDateKeyword('sat')
-      expect(result).toEqual(new Date(2026, 0, 17))
-    })
-
-    it("should parse 'saturday' to next Saturday (Jan 17)", () => {
-      const result = parseDateKeyword('saturday')
-      expect(result).toEqual(new Date(2026, 0, 17))
-    })
-  })
-
-  describe('month + day format', () => {
-    it("should parse 'dec20' to Dec 20, 2026", () => {
-      const result = parseDateKeyword('dec20')
-      expect(result).toEqual(new Date(2026, 11, 20))
-    })
-
-    it("should parse 'dec 20' (with space) to Dec 20, 2026", () => {
-      const result = parseDateKeyword('dec 20')
-      expect(result).toEqual(new Date(2026, 11, 20))
-    })
-
-    it("should parse 'december20' to Dec 20, 2026", () => {
-      const result = parseDateKeyword('december20')
-      expect(result).toEqual(new Date(2026, 11, 20))
-    })
-
-    it("should parse 'jan5' to Jan 5, 2027 (past date rolls to next year)", () => {
-      const result = parseDateKeyword('jan5')
-      expect(result).toEqual(new Date(2027, 0, 5))
-    })
-
-    it("should parse 'feb14' to Feb 14, 2026", () => {
-      const result = parseDateKeyword('feb14')
-      expect(result).toEqual(new Date(2026, 1, 14))
-    })
-
-    it("should parse 'mar1' to Mar 1, 2026", () => {
-      const result = parseDateKeyword('mar1')
-      expect(result).toEqual(new Date(2026, 2, 1))
-    })
-  })
-
-  describe('day + month format (day-first)', () => {
-    it("should parse '23may' to May 23, 2026", () => {
-      const result = parseDateKeyword('23may')
-      expect(result).toEqual(new Date(2026, 4, 23))
-    })
-
-    it("should parse '21jan' to Jan 21, 2026 (future date stays same year)", () => {
-      const result = parseDateKeyword('21jan')
-      expect(result).toEqual(new Date(2026, 0, 21))
-    })
-
-    it("should parse '5jan' to Jan 5, 2027 (past date rolls to next year)", () => {
-      const result = parseDateKeyword('5jan')
-      expect(result).toEqual(new Date(2027, 0, 5))
-    })
-
-    it("should parse '14february' to Feb 14, 2026", () => {
-      const result = parseDateKeyword('14february')
-      expect(result).toEqual(new Date(2026, 1, 14))
-    })
-
-    it("should parse '1mar' to Mar 1, 2026", () => {
-      const result = parseDateKeyword('1mar')
-      expect(result).toEqual(new Date(2026, 2, 1))
-    })
-
-    it("should parse '25dec' to Dec 25, 2026", () => {
-      const result = parseDateKeyword('25dec')
-      expect(result).toEqual(new Date(2026, 11, 25))
-    })
-
-    it("should return null for '32jan' (invalid day)", () => {
-      expect(parseDateKeyword('32jan')).toBeNull()
-    })
-
-    it("should return null for '0dec' (day 0 is invalid)", () => {
-      expect(parseDateKeyword('0dec')).toBeNull()
-    })
-  })
-
-  describe('invalid keywords', () => {
-    it("should return null for 'invalid'", () => {
-      const result = parseDateKeyword('invalid')
-      expect(result).toBeNull()
-    })
-
-    it("should return null for 'dec32' (invalid day)", () => {
-      const result = parseDateKeyword('dec32')
-      expect(result).toBeNull()
-    })
-
-    it('should return null for empty string', () => {
-      const result = parseDateKeyword('')
-      expect(result).toBeNull()
-    })
-
-    it('should return null for random text', () => {
-      const result = parseDateKeyword('xyz123')
-      expect(result).toBeNull()
-    })
-
-    it("should return null for 'dec0' (day 0 is invalid)", () => {
-      const result = parseDateKeyword('dec0')
-      expect(result).toBeNull()
-    })
-  })
 })
 
 // ============================================================================
@@ -469,6 +236,7 @@ describe('parseQuickAdd', () => {
   ]
 
   beforeEach(() => {
+    // Saturday, 10 January 2026.
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2026, 0, 10))
   })
@@ -486,7 +254,9 @@ describe('parseQuickAdd', () => {
         dueTime: null,
         priority: 'none',
         projectId: null,
-        repeat: null
+        repeat: null,
+        tags: [],
+        noteTitles: []
       })
     })
 
@@ -496,111 +266,225 @@ describe('parseQuickAdd', () => {
     })
   })
 
-  describe('date parsing', () => {
-    it("should parse '!today' in input", () => {
-      const result = parseQuickAdd('Buy groceries !today', projects)
-      expect(result.title).toBe('Buy groceries')
-      expect(result.dueDate).toEqual(new Date(2026, 0, 10))
-    })
+  // --------------------------------------------------------------------------
+  // ! — priority
+  // --------------------------------------------------------------------------
 
-    it("should parse '!tomorrow' in input", () => {
-      const result = parseQuickAdd('Meeting !tomorrow', projects)
-      expect(result.title).toBe('Meeting')
-      expect(result.dueDate).toEqual(new Date(2026, 0, 11))
-    })
-
-    it("should parse '!mon' in input", () => {
-      const result = parseQuickAdd('Review code !mon', projects)
-      expect(result.title).toBe('Review code')
-      expect(result.dueDate).toEqual(new Date(2026, 0, 12))
-    })
-  })
-
-  describe('priority parsing', () => {
-    it("should parse '!!high' in input", () => {
-      const result = parseQuickAdd('Buy groceries !!high', projects)
+  describe('priority', () => {
+    it("reads '!high' and takes it out of the title", () => {
+      const result = parseQuickAdd('Buy groceries !high', projects)
       expect(result.title).toBe('Buy groceries')
       expect(result.priority).toBe('high')
     })
 
-    it("should parse '!!urgent' in input", () => {
-      const result = parseQuickAdd('Emergency fix !!urgent', projects)
+    it("reads '!urgent'", () => {
+      const result = parseQuickAdd('Emergency fix !urgent', projects)
       expect(result.title).toBe('Emergency fix')
       expect(result.priority).toBe('urgent')
     })
 
-    it("should parse '!!low' in input", () => {
-      const result = parseQuickAdd('Nice to have !!low', projects)
-      expect(result.title).toBe('Nice to have')
+    it('reads the short forms', () => {
+      expect(parseQuickAdd('Task !u', projects).priority).toBe('urgent')
+      expect(parseQuickAdd('Task !h', projects).priority).toBe('high')
+      expect(parseQuickAdd('Task !med', projects).priority).toBe('medium')
+      expect(parseQuickAdd('Task !l', projects).priority).toBe('low')
+    })
+
+    it('is case-insensitive', () => {
+      expect(parseQuickAdd('Task !HIGH', projects).priority).toBe('high')
+    })
+
+    it('takes the first run that names a priority', () => {
+      const result = parseQuickAdd('Task !nope !low', projects)
       expect(result.priority).toBe('low')
+      expect(result.title).toBe('Task !nope')
+    })
+
+    it('leaves an unknown keyword in the title', () => {
+      const result = parseQuickAdd('Task !xyz', projects)
+      expect(result.title).toBe('Task !xyz')
+      expect(result.priority).toBe('none')
+    })
+
+    it('leaves prose punctuation alone', () => {
+      // Nothing follows the marker, so these are sentences, not syntax.
+      expect(parseQuickAdd('Ship it!', projects)).toMatchObject({
+        title: 'Ship it!',
+        priority: 'none'
+      })
+      expect(parseQuickAdd('Wow!!', projects)).toMatchObject({ title: 'Wow!!', priority: 'none' })
+    })
+
+    it('no longer reads the old double marker', () => {
+      // `!` is the priority marker now; `!!high` is not a second spelling of it.
+      const result = parseQuickAdd('Buy groceries !!high', projects)
+      expect(result.title).toBe('Buy groceries !!high')
+      expect(result.priority).toBe('none')
+    })
+
+    it('no longer reads a bare date keyword', () => {
+      // `!today` used to mean "due today". `@` covers all of it now.
+      const result = parseQuickAdd('Meeting !tomorrow', projects)
+      expect(result.title).toBe('Meeting !tomorrow')
+      expect(result.dueDate).toBeNull()
+    })
+
+    it('does not fire mid-word', () => {
+      const result = parseQuickAdd('Deploy hotfix-1!high', projects)
+      expect(result.title).toBe('Deploy hotfix-1!high')
+      expect(result.priority).toBe('none')
     })
   })
 
-  describe('project parsing', () => {
-    it("should parse '#work' in input", () => {
-      const result = parseQuickAdd('Review PR #work', projects)
+  // --------------------------------------------------------------------------
+  // + — project
+  // --------------------------------------------------------------------------
+
+  describe('project', () => {
+    it("reads '+work' and takes it out of the title", () => {
+      const result = parseQuickAdd('Review PR +work', projects)
       expect(result.title).toBe('Review PR')
       expect(result.projectId).toBe('work')
     })
 
-    it("should parse '#personal' in input", () => {
-      const result = parseQuickAdd('Buy groceries #personal', projects)
+    it('resolves a name as well as an id', () => {
+      const result = parseQuickAdd('Buy groceries +Personal', projects)
       expect(result.title).toBe('Buy groceries')
       expect(result.projectId).toBe('personal')
     })
 
-    it('should ignore invalid project reference', () => {
-      const result = parseQuickAdd('Task #nonexistent', projects)
-      expect(result.title).toBe('Task #nonexistent')
+    it('leaves an unresolved project in the title', () => {
+      const result = parseQuickAdd('Task +nonexistent', projects)
+      expect(result.title).toBe('Task +nonexistent')
       expect(result.projectId).toBeNull()
+    })
+
+    it('never fires mid-word', () => {
+      // The guards that make `+` safe in prose and in code.
+      expect(parseQuickAdd('Compute 1+2 today', projects)).toMatchObject({
+        title: 'Compute 1+2 today',
+        projectId: null
+      })
+      expect(parseQuickAdd('Learn C++', projects)).toMatchObject({
+        title: 'Learn C++',
+        projectId: null
+      })
+    })
+
+    it("no longer answers to the old '#' marker", () => {
+      // Migration: `#Work` files a *tag* now, not the Work project.
+      const result = parseQuickAdd('Review PR #Work', projects)
+      expect(result.projectId).toBeNull()
+      expect(result.tags).toEqual(['Work'])
     })
   })
 
-  describe('combined syntax', () => {
-    it('should parse all fields: date, priority, and project', () => {
-      const result = parseQuickAdd('Meeting !tomorrow !!urgent #work', projects)
-      expect(result.title).toBe('Meeting')
-      expect(result.dueDate).toEqual(new Date(2026, 0, 11))
-      expect(result.priority).toBe('urgent')
-      expect(result.projectId).toBe('work')
+  // --------------------------------------------------------------------------
+  // # — tags
+  // --------------------------------------------------------------------------
+
+  describe('tags', () => {
+    it('reads a tag and takes it out of the title', () => {
+      const result = parseQuickAdd('Ship the beta #launch', projects)
+      expect(result.title).toBe('Ship the beta')
+      expect(result.tags).toEqual(['launch'])
     })
 
-    it('should handle syntax in different order', () => {
-      const result = parseQuickAdd('#work Meeting !today !!high', projects)
+    it('reads every tag in the input, unlike the other markers', () => {
+      const result = parseQuickAdd('Ship the beta #launch #q1 #marketing', projects)
+      expect(result.title).toBe('Ship the beta')
+      expect(result.tags).toEqual(['launch', 'q1', 'marketing'])
+    })
+
+    it('reads the note editor’s nested form', () => {
+      const result = parseQuickAdd('Call the client #work/client', projects)
+      expect(result.title).toBe('Call the client')
+      expect(result.tags).toEqual(['work/client'])
+    })
+
+    it('keeps the case the user typed', () => {
+      expect(parseQuickAdd('Read the paper #MIT', projects).tags).toEqual(['MIT'])
+    })
+
+    it('never fires mid-word', () => {
+      expect(parseQuickAdd('Close issue#12', projects)).toMatchObject({
+        title: 'Close issue#12',
+        tags: []
+      })
+      expect(parseQuickAdd('Learn C# basics', projects)).toMatchObject({
+        title: 'Learn C# basics',
+        tags: []
+      })
+    })
+
+    it('ignores a bare #', () => {
+      const result = parseQuickAdd('Sort the # pile', projects)
+      expect(result.title).toBe('Sort the # pile')
+      expect(result.tags).toEqual([])
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // [[…]] — note links
+  // --------------------------------------------------------------------------
+
+  describe('note links', () => {
+    it('reads the title inside the brackets and drops the run', () => {
+      const result = parseQuickAdd('Draft the plan [[Roadmap]]', projects)
+      expect(result.title).toBe('Draft the plan')
+      expect(result.noteTitles).toEqual(['Roadmap'])
+    })
+
+    it('reads several links', () => {
+      const result = parseQuickAdd('Prep [[Roadmap]] and [[Q1 Goals]]', projects)
+      expect(result.title).toBe('Prep and')
+      expect(result.noteTitles).toEqual(['Roadmap', 'Q1 Goals'])
+    })
+
+    it('leaves an unclosed run alone — it is still being typed', () => {
+      const result = parseQuickAdd('Draft the plan [[Road', projects)
+      expect(result.title).toBe('Draft the plan [[Road')
+      expect(result.noteTitles).toEqual([])
+    })
+
+    it('treats a marker inside a link as part of the note title', () => {
+      const result = parseQuickAdd('Prep [[Q3 #launch +work]] #real', projects)
+      expect(result.noteTitles).toEqual(['Q3 #launch +work'])
+      expect(result.tags).toEqual(['real'])
+      expect(result.projectId).toBeNull()
+      expect(result.title).toBe('Prep')
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Everything together
+  // --------------------------------------------------------------------------
+
+  describe('combined syntax', () => {
+    it('parses the whole grammar in one line', () => {
+      const withMemry = [...projects, createMockProject({ id: 'memry', name: 'Memry' })]
+      const result = parseQuickAdd(
+        'Ship the beta @next friday !high +Memry #launch [[Roadmap]] every 2 weeks',
+        withMemry
+      )
+
+      expect(result.title).toBe('Ship the beta')
+      // From Saturday, "next friday" is next week's — the note editor's rule.
+      expect(result.dueDate).toEqual(new Date(2026, 0, 23))
+      expect(result.priority).toBe('high')
+      expect(result.projectId).toBe('memry')
+      expect(result.tags).toEqual(['launch'])
+      expect(result.noteTitles).toEqual(['Roadmap'])
+      expect(result.repeat).toMatchObject({ frequency: 'weekly', interval: 2 })
+    })
+
+    it('does not care about the order the markers are typed in', () => {
+      const result = parseQuickAdd('+work Meeting @today !high #sync', projects)
       expect(result.title).toBe('Meeting')
       expect(result.dueDate).toEqual(new Date(2026, 0, 10))
       expect(result.priority).toBe('high')
       expect(result.projectId).toBe('work')
-    })
-
-    it('should handle date and priority only', () => {
-      const result = parseQuickAdd('Task !today !!medium', projects)
-      expect(result.title).toBe('Task')
-      expect(result.dueDate).toEqual(new Date(2026, 0, 10))
-      expect(result.priority).toBe('medium')
-      expect(result.projectId).toBeNull()
-    })
-  })
-
-  describe('multiple dates', () => {
-    it('should use first valid date when multiple dates present', () => {
-      const result = parseQuickAdd('Task !today !tomorrow', projects)
-      expect(result.title).toBe('Task !tomorrow')
-      expect(result.dueDate).toEqual(new Date(2026, 0, 10))
-    })
-  })
-
-  describe('invalid syntax preserved', () => {
-    it('should preserve invalid date keyword in title', () => {
-      const result = parseQuickAdd('Buy !invalid groceries', projects)
-      expect(result.title).toBe('Buy !invalid groceries')
-      expect(result.dueDate).toBeNull()
-    })
-
-    it('should preserve invalid priority keyword in title', () => {
-      const result = parseQuickAdd('Task !!xyz', projects)
-      expect(result.title).toBe('Task !!xyz')
-      expect(result.priority).toBe('none')
+      expect(result.tags).toEqual(['sync'])
     })
   })
 
@@ -611,7 +495,7 @@ describe('parseQuickAdd', () => {
     })
 
     it('should clean whitespace after removing syntax', () => {
-      const result = parseQuickAdd('Buy  !today   groceries', projects)
+      const result = parseQuickAdd('Buy  @today   groceries', projects)
       expect(result.title).toBe('Buy groceries')
       expect(result.dueDate).toEqual(new Date(2026, 0, 10))
     })
@@ -623,80 +507,33 @@ describe('parseQuickAdd', () => {
 // ============================================================================
 
 describe('hasSpecialSyntax', () => {
-  describe('date detection', () => {
-    it("should detect date syntax '!today'", () => {
-      expect(hasSpecialSyntax('task !today')).toBe(true)
-    })
-
-    it("should detect date syntax '!tomorrow'", () => {
-      expect(hasSpecialSyntax('task !tomorrow')).toBe(true)
-    })
-
-    it("should detect date syntax '!mon'", () => {
-      expect(hasSpecialSyntax('task !mon')).toBe(true)
-    })
+  it('detects each marker', () => {
+    expect(hasSpecialSyntax('task !high')).toBe(true)
+    expect(hasSpecialSyntax('task +work')).toBe(true)
+    expect(hasSpecialSyntax('task #launch')).toBe(true)
+    expect(hasSpecialSyntax('task [[Roadmap]]')).toBe(true)
+    expect(hasSpecialSyntax('task @tomorrow')).toBe(true)
+    expect(hasSpecialSyntax('task every monday')).toBe(true)
   })
 
-  describe('priority detection', () => {
-    it("should detect priority syntax '!!high'", () => {
-      expect(hasSpecialSyntax('task !!high')).toBe(true)
-    })
-
-    it("should detect priority syntax '!!urgent'", () => {
-      expect(hasSpecialSyntax('task !!urgent')).toBe(true)
-    })
-
-    it("should detect priority syntax '!!low'", () => {
-      expect(hasSpecialSyntax('task !!low')).toBe(true)
-    })
+  it('is false for plain prose', () => {
+    expect(hasSpecialSyntax('plain task')).toBe(false)
+    expect(hasSpecialSyntax('')).toBe(false)
+    expect(hasSpecialSyntax('Check every door')).toBe(false)
   })
 
-  describe('project detection', () => {
-    it("should detect project syntax '#work'", () => {
-      expect(hasSpecialSyntax('task #work')).toBe(true)
-    })
-
-    it("should detect project syntax '#my-project'", () => {
-      expect(hasSpecialSyntax('task #my-project')).toBe(true)
-    })
+  it('is false for a lone marker', () => {
+    expect(hasSpecialSyntax('task !')).toBe(false)
+    expect(hasSpecialSyntax('task +')).toBe(false)
+    expect(hasSpecialSyntax('task #')).toBe(false)
+    expect(hasSpecialSyntax('task [[')).toBe(false)
   })
 
-  describe('no syntax', () => {
-    it('should return false for plain task', () => {
-      expect(hasSpecialSyntax('plain task')).toBe(false)
-    })
-
-    it('should return false for empty string', () => {
-      expect(hasSpecialSyntax('')).toBe(false)
-    })
-  })
-
-  describe('combined syntax', () => {
-    it('should detect combined syntax', () => {
-      expect(hasSpecialSyntax('task !today #work')).toBe(true)
-    })
-
-    it('should detect all three syntaxes', () => {
-      expect(hasSpecialSyntax('task !today !!high #work')).toBe(true)
-    })
-  })
-
-  describe('edge cases', () => {
-    it("should return false for '!' alone", () => {
-      expect(hasSpecialSyntax('task !')).toBe(false)
-    })
-
-    it("should return false for '!!' alone", () => {
-      expect(hasSpecialSyntax('task !!')).toBe(false)
-    })
-
-    it("should return false for '#' alone", () => {
-      expect(hasSpecialSyntax('task #')).toBe(false)
-    })
-
-    it('should detect syntax even with leading !!', () => {
-      expect(hasSpecialSyntax('!!high')).toBe(true)
-    })
+  it('does not carry state between calls', () => {
+    // The marker patterns are global and module-level; scanning with `.test()`
+    // would leave `lastIndex` behind and make every other call lie.
+    expect(hasSpecialSyntax('task #launch')).toBe(true)
+    expect(hasSpecialSyntax('task #launch')).toBe(true)
   })
 })
 
@@ -719,81 +556,41 @@ describe('getParsePreview', () => {
     vi.useRealTimers()
   })
 
-  describe('return structure', () => {
-    it('should return all required fields', () => {
-      const result = getParsePreview('task', projects)
-      expect(result).toHaveProperty('hasDate')
-      expect(result).toHaveProperty('hasPriority')
-      expect(result).toHaveProperty('hasProject')
-      expect(result).toHaveProperty('dueDate')
-      expect(result).toHaveProperty('priority')
-      expect(result).toHaveProperty('projectId')
-      expect(result).toHaveProperty('projectName')
-    })
+  it('should return all required fields', () => {
+    const result = getParsePreview('task', projects)
+    expect(result).toHaveProperty('hasDate')
+    expect(result).toHaveProperty('hasPriority')
+    expect(result).toHaveProperty('hasProject')
+    expect(result).toHaveProperty('dueDate')
+    expect(result).toHaveProperty('priority')
+    expect(result).toHaveProperty('projectId')
+    expect(result).toHaveProperty('projectName')
   })
 
-  describe('date preview', () => {
-    it('should show hasDate true when date present', () => {
-      const result = getParsePreview('task !today', projects)
-      expect(result.hasDate).toBe(true)
-      expect(result.dueDate).toEqual(new Date(2026, 0, 10))
-    })
-
-    it('should show hasDate false when no date', () => {
-      const result = getParsePreview('task', projects)
-      expect(result.hasDate).toBe(false)
-      expect(result.dueDate).toBeNull()
-    })
+  it('reports an empty input as carrying nothing', () => {
+    const result = getParsePreview('task', projects)
+    expect(result.hasDate).toBe(false)
+    expect(result.hasPriority).toBe(false)
+    expect(result.hasProject).toBe(false)
+    expect(result.projectName).toBeNull()
   })
 
-  describe('priority preview', () => {
-    it('should show hasPriority true when priority present', () => {
-      const result = getParsePreview('task !!high', projects)
-      expect(result.hasPriority).toBe(true)
-      expect(result.priority).toBe('high')
-    })
-
-    it('should show hasPriority false when priority is none', () => {
-      const result = getParsePreview('task', projects)
-      expect(result.hasPriority).toBe(false)
-      expect(result.priority).toBe('none')
-    })
+  it('reports every field the input carries', () => {
+    const result = getParsePreview('task @tomorrow !urgent +personal', projects)
+    expect(result.hasDate).toBe(true)
+    expect(result.hasPriority).toBe(true)
+    expect(result.hasProject).toBe(true)
+    expect(result.dueDate).toEqual(new Date(2026, 0, 11))
+    expect(result.priority).toBe('urgent')
+    expect(result.projectId).toBe('personal')
+    expect(result.projectName).toBe('Personal')
   })
 
-  describe('project preview', () => {
-    it('should show hasProject true with valid project', () => {
-      const result = getParsePreview('task #work', projects)
-      expect(result.hasProject).toBe(true)
-      expect(result.projectId).toBe('work')
-      expect(result.projectName).toBe('Work')
-    })
-
-    it('should show hasProject false with invalid project', () => {
-      const result = getParsePreview('task #nonexistent', projects)
-      expect(result.hasProject).toBe(false)
-      expect(result.projectId).toBeNull()
-      expect(result.projectName).toBeNull()
-    })
-
-    it('should show hasProject false when no project', () => {
-      const result = getParsePreview('task', projects)
-      expect(result.hasProject).toBe(false)
-      expect(result.projectId).toBeNull()
-      expect(result.projectName).toBeNull()
-    })
-  })
-
-  describe('combined preview', () => {
-    it('should handle all fields correctly', () => {
-      const result = getParsePreview('task !tomorrow !!urgent #personal', projects)
-      expect(result.hasDate).toBe(true)
-      expect(result.hasPriority).toBe(true)
-      expect(result.hasProject).toBe(true)
-      expect(result.dueDate).toEqual(new Date(2026, 0, 11))
-      expect(result.priority).toBe('urgent')
-      expect(result.projectId).toBe('personal')
-      expect(result.projectName).toBe('Personal')
-    })
+  it('reports an unresolved project as no project', () => {
+    const result = getParsePreview('task +nonexistent', projects)
+    expect(result.hasProject).toBe(false)
+    expect(result.projectId).toBeNull()
+    expect(result.projectName).toBeNull()
   })
 })
 
@@ -801,88 +598,17 @@ describe('getParsePreview', () => {
 // T110: AUTOCOMPLETE OPTIONS
 // ============================================================================
 
-describe('getDateOptions', () => {
-  describe('no query (default options)', () => {
-    it('should return first 5 options when no query', () => {
-      const result = getDateOptions('')
-      expect(result).toHaveLength(5)
-      expect(result.map((o) => o.value)).toEqual([
-        '!today',
-        '!tomorrow',
-        '!nextweek',
-        '!monday',
-        '!tuesday'
-      ])
-    })
-  })
-
-  describe('filtered by query', () => {
-    it("should filter options with 'to' query", () => {
-      const result = getDateOptions('to')
-      expect(result.map((o) => o.value)).toContain('!today')
-      expect(result.map((o) => o.value)).toContain('!tomorrow')
-    })
-
-    it("should filter options with 'mon' query", () => {
-      const result = getDateOptions('mon')
-      expect(result).toHaveLength(1)
-      expect(result[0].value).toBe('!monday')
-    })
-
-    it("should filter options with 'wed' query", () => {
-      const result = getDateOptions('wed')
-      expect(result).toHaveLength(1)
-      expect(result[0].value).toBe('!wednesday')
-    })
-  })
-
-  describe('option structure', () => {
-    it('should have value and label for each option', () => {
-      const result = getDateOptions('')
-      result.forEach((option) => {
-        expect(option).toHaveProperty('value')
-        expect(option).toHaveProperty('label')
-      })
-    })
-  })
-})
-
 describe('getPriorityOptions', () => {
-  describe('no query (all options)', () => {
-    it('should return all 4 options when no query', () => {
-      const result = getPriorityOptions('')
-      expect(result).toHaveLength(4)
-      expect(result.map((o) => o.value)).toEqual(['!!urgent', '!!high', '!!medium', '!!low'])
-    })
+  it('offers the four priorities, single-marker only', () => {
+    const result = getPriorityOptions('')
+    expect(result).toHaveLength(4)
+    expect(result.map((o) => o.value)).toEqual(['!urgent', '!high', '!medium', '!low'])
   })
 
-  describe('filtered by query', () => {
-    it("should filter options with 'h' query", () => {
-      const result = getPriorityOptions('h')
-      expect(result.map((o) => o.value)).toContain('!!high')
-    })
-
-    it("should filter options with 'ur' query", () => {
-      const result = getPriorityOptions('ur')
-      expect(result).toHaveLength(1)
-      expect(result[0].value).toBe('!!urgent')
-    })
-
-    it("should filter options with 'med' query", () => {
-      const result = getPriorityOptions('med')
-      expect(result).toHaveLength(1)
-      expect(result[0].value).toBe('!!medium')
-    })
-  })
-
-  describe('option structure', () => {
-    it('should have value and label for each option', () => {
-      const result = getPriorityOptions('')
-      result.forEach((option) => {
-        expect(option).toHaveProperty('value')
-        expect(option).toHaveProperty('label')
-      })
-    })
+  it('filters by what has been typed', () => {
+    expect(getPriorityOptions('h').map((o) => o.value)).toContain('!high')
+    expect(getPriorityOptions('ur')).toHaveLength(1)
+    expect(getPriorityOptions('med')[0].value).toBe('!medium')
   })
 })
 
@@ -894,58 +620,41 @@ describe('getProjectOptions', () => {
     createMockProject({ id: 'dev', name: 'Development' })
   ]
 
-  describe('no query (all non-archived)', () => {
-    it('should return all non-archived projects', () => {
-      const result = getProjectOptions('', projects)
-      expect(result).toHaveLength(3)
-      expect(result.map((o) => o.label)).toEqual(['Work', 'Personal', 'Development'])
-    })
-
-    it('should exclude archived projects', () => {
-      const result = getProjectOptions('', projects)
-      expect(result.map((o) => o.label)).not.toContain('Archived')
-    })
+  it('offers every active project', () => {
+    const result = getProjectOptions('', projects)
+    expect(result).toHaveLength(3)
+    expect(result.map((o) => o.label)).toEqual(['Work', 'Personal', 'Development'])
   })
 
-  describe('filtered by query', () => {
-    it("should filter by name 'work'", () => {
-      const result = getProjectOptions('work', projects)
-      expect(result).toHaveLength(1)
-      expect(result[0].label).toBe('Work')
-    })
-
-    it("should filter by name 'dev'", () => {
-      const result = getProjectOptions('dev', projects)
-      expect(result).toHaveLength(1)
-      expect(result[0].label).toBe('Development')
-    })
-
-    it("should filter by ID 'personal'", () => {
-      const result = getProjectOptions('personal', projects)
-      expect(result).toHaveLength(1)
-      expect(result[0].label).toBe('Personal')
-    })
-
-    it('should return empty for no matches', () => {
-      const result = getProjectOptions('xyz', projects)
-      expect(result).toHaveLength(0)
-    })
+  it('excludes archived projects', () => {
+    expect(getProjectOptions('', projects).map((o) => o.label)).not.toContain('Archived')
   })
 
-  describe('option structure', () => {
-    it("should have correct value format '#ProjectName'", () => {
-      const result = getProjectOptions('', projects)
-      expect(result[0].value).toBe('#Work')
-      expect(result[1].value).toBe('#Personal')
-    })
+  it('filters by name and by id', () => {
+    expect(getProjectOptions('dev', projects)[0].label).toBe('Development')
+    expect(getProjectOptions('personal', projects)[0].label).toBe('Personal')
+    expect(getProjectOptions('xyz', projects)).toHaveLength(0)
+  })
 
-    it('should have value and label for each option', () => {
-      const result = getProjectOptions('', projects)
-      result.forEach((option) => {
-        expect(option).toHaveProperty('value')
-        expect(option).toHaveProperty('label')
-      })
-    })
+  it("writes the value with the '+' marker", () => {
+    const result = getProjectOptions('', projects)
+    expect(result[0].value).toBe('+Work')
+    expect(result[1].value).toBe('+Personal')
+  })
+})
+
+describe('getTagOptions', () => {
+  const tags = ['launch', 'work/client', 'MIT']
+
+  it('offers the whole pool in the order it was given', () => {
+    const result = getTagOptions('', tags)
+    expect(result.map((o) => o.value)).toEqual(['#launch', '#work/client', '#MIT'])
+  })
+
+  it('filters case-insensitively', () => {
+    expect(getTagOptions('mit', tags).map((o) => o.value)).toEqual(['#MIT'])
+    expect(getTagOptions('client', tags).map((o) => o.value)).toEqual(['#work/client'])
+    expect(getTagOptions('zzz', tags)).toHaveLength(0)
   })
 })
 
@@ -996,6 +705,19 @@ describe('natural-language quick-add', () => {
     })
   })
 
+  describe('findNoteLinks', () => {
+    it('reads every finished run and where it sits', () => {
+      expect(findNoteLinks('Prep [[Roadmap]] then [[Q1 Goals]]')).toEqual([
+        { start: 5, end: 16, title: 'Roadmap' },
+        { start: 22, end: 34, title: 'Q1 Goals' }
+      ])
+    })
+
+    it('reads nothing from an unfinished run', () => {
+      expect(findNoteLinks('Prep [[Road')).toEqual([])
+    })
+  })
+
   describe('parseQuickAdd — date phrases', () => {
     it('pulls the phrase out of the title', () => {
       const result = parseQuickAdd('Call Bob @next wednesday', projects)
@@ -1011,7 +733,7 @@ describe('natural-language quick-add', () => {
     })
 
     it('combines with priority and project', () => {
-      const result = parseQuickAdd('Ship it @tomorrow !!high #Work', projects)
+      const result = parseQuickAdd('Ship it @tomorrow !high +Work', projects)
       expect(result.title).toBe('Ship it')
       expect(result.dueDate).toEqual(new Date(2026, 0, 11))
       expect(result.priority).toBe('high')
@@ -1024,10 +746,10 @@ describe('natural-language quick-add', () => {
       expect(result.dueDate).toBeNull()
     })
 
-    it('wins over a !keyword date so only one due date is taken', () => {
-      const result = parseQuickAdd('Call Bob @tomorrow !today', projects)
+    it('takes only the first phrase that reads as a date', () => {
+      const result = parseQuickAdd('Call Bob @tomorrow @friday', projects)
       expect(result.dueDate).toEqual(new Date(2026, 0, 11))
-      expect(result.title).toBe('Call Bob !today')
+      expect(result.title).toBe('Call Bob @friday')
     })
   })
 
@@ -1060,7 +782,7 @@ describe('natural-language quick-add', () => {
     })
 
     it('keeps a due date the user typed', () => {
-      const result = parseQuickAdd('Report !friday every week', projects)
+      const result = parseQuickAdd('Report @friday every week', projects)
       expect(result.dueDate).toEqual(new Date(2026, 0, 16))
       expect(result.repeat).toMatchObject({ frequency: 'weekly', interval: 1 })
     })
@@ -1075,16 +797,46 @@ describe('natural-language quick-add', () => {
 
   describe('findQuickAddSpans', () => {
     it('marks every syntax stretch, phrases included', () => {
-      expect(findQuickAddSpans('Sync @tomorrow every monday !!high #Work')).toEqual([
-        { start: 5, end: 14, kind: 'datePhrase' },
-        { start: 15, end: 27, kind: 'repeat' },
-        { start: 28, end: 34, kind: 'priority' },
-        { start: 35, end: 40, kind: 'project' }
+      expect(
+        findQuickAddSpans('Sync [[Roadmap]] @tomorrow every monday !high +Work #launch')
+      ).toEqual([
+        { start: 5, end: 16, kind: 'noteLink' },
+        { start: 17, end: 26, kind: 'datePhrase' },
+        { start: 27, end: 39, kind: 'repeat' },
+        { start: 40, end: 45, kind: 'priority' },
+        { start: 46, end: 51, kind: 'project' },
+        { start: 52, end: 59, kind: 'tag' }
       ])
     })
 
     it('marks nothing in plain prose', () => {
       expect(findQuickAddSpans('Buy groceries every door')).toEqual([])
+    })
+
+    it('marks a half-typed marker, so the pill appears as it is typed', () => {
+      expect(findQuickAddSpans('Task !hi')).toEqual([{ start: 5, end: 8, kind: 'priority' }])
+      expect(findQuickAddSpans('Task +foo')).toEqual([{ start: 5, end: 9, kind: 'project' }])
+    })
+
+    it('does not mark a marker that lives inside a note link', () => {
+      expect(findQuickAddSpans('Prep [[Q3 #launch]]')).toEqual([
+        { start: 5, end: 19, kind: 'noteLink' }
+      ])
+    })
+
+    it('agrees with what the parser strips', () => {
+      // Landmine: pills and title-stripping must not disagree, or the caret and
+      // the captured title stop matching what the user sees.
+      const input = 'Sync [[Roadmap]] @tomorrow every monday !high +Work #launch'
+      const spans = findQuickAddSpans(input)
+      const remainder = spans
+        .reduceRight((text, span) => text.slice(0, span.start) + text.slice(span.end), input)
+        .replace(/\s+/g, ' ')
+        .trim()
+
+      expect(remainder).toBe(
+        parseQuickAdd(input, [createMockProject({ id: 'work', name: 'Work' })]).title
+      )
     })
   })
 

--- a/apps/desktop/src/renderer/src/lib/quick-add-parser.ts
+++ b/apps/desktop/src/renderer/src/lib/quick-add-parser.ts
@@ -1,6 +1,5 @@
 import type { Priority, RepeatConfig } from '@/data/task-model'
 import type { Project } from '@/data/tasks-data'
-import { startOfDay, addDays } from '@/lib/task-utils'
 import { parseNaturalDate } from '@/lib/natural-date-parser'
 import { findRepeatPhrase, firstOccurrenceFor } from '@/lib/repeat-phrase'
 
@@ -16,10 +15,17 @@ export interface ParsedQuickAdd {
   priority: Priority
   projectId: string | null
   repeat: RepeatConfig | null
+  /** Every `#tag` in the input, in order, with the typed casing kept. */
+  tags: string[]
+  /**
+   * The titles inside `[[…]]`, in order. The parser only sees text, so the
+   * surface maps these to note ids (see CaptureBar).
+   */
+  noteTitles: string[]
 }
 
 /** A stretch of the input that carries syntax rather than title text. */
-export type QuickAddSpanKind = 'date' | 'priority' | 'project' | 'datePhrase' | 'repeat'
+export type QuickAddSpanKind = 'priority' | 'project' | 'tag' | 'noteLink' | 'datePhrase' | 'repeat'
 
 export interface QuickAddSpan {
   start: number
@@ -29,136 +35,79 @@ export interface QuickAddSpan {
 }
 
 // ============================================================================
-// DATE PARSING
+// MARKER GRAMMAR
 // ============================================================================
 
 /**
- * Map of day name abbreviations to day indices (0 = Sunday)
+ * `!` starts a word and needs at least one letter after it, so prose keeps its
+ * punctuation: "Ship it!" and "Wow!!" are titles, not priorities.
  */
-const dayNameMap: Record<string, number> = {
-  sun: 0,
-  sunday: 0,
-  mon: 1,
-  monday: 1,
-  tue: 2,
-  tuesday: 2,
-  wed: 3,
-  wednesday: 3,
-  thu: 4,
-  thursday: 4,
-  fri: 5,
-  friday: 5,
-  sat: 6,
-  saturday: 6
+const PRIORITY_PATTERN = /(?:^|\s)(![a-zA-Z]+)/g
+
+/** `+` starts a word, so "1+2" and "C++" never read as a project. */
+const PROJECT_PATTERN = /(?:^|\s)(\+[\w-]+)/g
+
+/**
+ * The note editor's tag grammar verbatim, nesting included — see
+ * `HASH_TAG_PATTERN` in `components/note/content-area/hash-tag.tsx`, which also
+ * requires the `#` to start a word. `C#` and `issue#12` are therefore prose.
+ */
+const TAG_PATTERN = /(?:^|\s)(#[a-zA-Z0-9][a-zA-Z0-9_-]*(?:\/[a-zA-Z0-9][a-zA-Z0-9_-]*)*)/g
+
+/** `[[Note title]]` — note titles are arbitrary, so anything but the brackets. */
+const NOTE_LINK_PATTERN = /\[\[([^[\]\n]+)\]\]/g
+
+interface MarkerRun {
+  start: number
+  /** Exclusive. */
+  end: number
+  /** The run including its sigil, e.g. `!high`. */
+  text: string
+  /** The run without its sigil, e.g. `high`. */
+  value: string
 }
 
 /**
- * Map of month name abbreviations to month indices (0 = January)
+ * Every run of `pattern` in `input`. The patterns above match a leading space
+ * to anchor the sigil to a word start, so the run itself is capture group 1.
  */
-const monthNameMap: Record<string, number> = {
-  jan: 0,
-  january: 0,
-  feb: 1,
-  february: 1,
-  mar: 2,
-  march: 2,
-  apr: 3,
-  april: 3,
-  may: 4,
-  jun: 5,
-  june: 5,
-  jul: 6,
-  july: 6,
-  aug: 7,
-  august: 7,
-  sep: 8,
-  september: 8,
-  oct: 9,
-  october: 9,
-  nov: 10,
-  november: 10,
-  dec: 11,
-  december: 11
+const findMarkerRuns = (input: string, pattern: RegExp): MarkerRun[] => {
+  const runs: MarkerRun[] = []
+  for (const match of input.matchAll(pattern)) {
+    const text = match[1]
+    const start = match.index + match[0].length - text.length
+    runs.push({ start, end: start + text.length, text, value: text.slice(1) })
+  }
+  return runs
+}
+
+export interface NoteLinkMatch {
+  start: number
+  /** Exclusive. */
+  end: number
+  /** The text between the brackets. */
+  title: string
+}
+
+/** Every finished `[[…]]` run. An unclosed `[[` is still being typed. */
+export const findNoteLinks = (input: string): NoteLinkMatch[] => {
+  const links: NoteLinkMatch[] = []
+  for (const match of input.matchAll(NOTE_LINK_PATTERN)) {
+    links.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      title: match[1].trim()
+    })
+  }
+  return links
 }
 
 /**
- * Get next occurrence of a day of the week
+ * A note title is user text and may well contain a sigil — `[[Q3 #launch]]`
+ * links a note, it does not tag the task. Markers inside a link are ignored.
  */
-const getNextDayOfWeek = (targetDay: number): Date => {
-  const today = startOfDay(new Date())
-  const currentDay = today.getDay()
-  let daysUntil = targetDay - currentDay
-
-  // If today is the target day, get next week's
-  if (daysUntil <= 0) {
-    daysUntil += 7
-  }
-
-  return addDays(today, daysUntil)
-}
-
-const buildDateWithRollover = (monthIndex: number, day: number): Date => {
-  const today = new Date()
-  const year = today.getFullYear()
-  const date = new Date(year, monthIndex, day)
-  date.setHours(0, 0, 0, 0)
-
-  if (date < startOfDay(today)) {
-    date.setFullYear(year + 1)
-  }
-
-  return date
-}
-
-/**
- * Parse date keyword to Date object
- * Supports: today, tomorrow, day names (mon, tue, etc.), month+day (dec20, 20dec)
- */
-export const parseDateKeyword = (keyword: string): Date | null => {
-  const lower = keyword.toLowerCase().trim()
-
-  if (lower === 'today') {
-    return startOfDay(new Date())
-  }
-
-  if (lower === 'tomorrow' || lower === 'tmr' || lower === 'tom') {
-    return addDays(startOfDay(new Date()), 1)
-  }
-
-  if (lower === 'nextweek' || lower === 'next') {
-    return addDays(startOfDay(new Date()), 7)
-  }
-
-  if (dayNameMap[lower] !== undefined) {
-    return getNextDayOfWeek(dayNameMap[lower])
-  }
-
-  // Month + day: dec20, dec 20, december20
-  const monthDayMatch = lower.match(/^([a-z]+)\s*(\d{1,2})$/)
-  if (monthDayMatch) {
-    const [, monthStr, dayStr] = monthDayMatch
-    const monthIndex = monthNameMap[monthStr]
-    const day = parseInt(dayStr, 10)
-
-    if (monthIndex !== undefined && day >= 1 && day <= 31) {
-      return buildDateWithRollover(monthIndex, day)
-    }
-  }
-
-  // Day + month: 20dec, 21jan, 23may
-  const dayMonthMatch = lower.match(/^(\d{1,2})\s*([a-z]+)$/)
-  if (dayMonthMatch) {
-    const [, dayStr, monthStr] = dayMonthMatch
-    const monthIndex = monthNameMap[monthStr]
-    const day = parseInt(dayStr, 10)
-
-    if (monthIndex !== undefined && day >= 1 && day <= 31) {
-      return buildDateWithRollover(monthIndex, day)
-    }
-  }
-
-  return null
-}
+const isInsideLink = (links: NoteLinkMatch[], index: number): boolean =>
+  links.some((link) => index >= link.start && index < link.end)
 
 // ============================================================================
 // NATURAL-LANGUAGE DATE PHRASES (@tomorrow, @next wednesday, @dec 20 at 3pm)
@@ -300,16 +249,17 @@ const stripSpans = (input: string, spans: QuickAddSpan[]): string => {
 /**
  * Parse quick add input string with special syntax
  *
- * Syntax:
- * - Due date: !today, !tomorrow, !mon, !dec20
- * - Natural due date: @tomorrow, @next wednesday, @dec 20 at 3pm
+ * Syntax (the note editor's grammar, so both surfaces agree):
+ * - Due date: @tomorrow, @next wednesday, @dec 20 at 3pm
  * - Repeat: every day, every weekday, every monday, every 2 weeks, every month
- * - Priority: !!urgent, !!high, !!medium, !!low
- * - Project: #project-name, #personal, #work
+ * - Priority: !urgent, !high, !medium, !low
+ * - Project: +project-name, +personal, +work
+ * - Tag: #launch, #work/client — every tag in the input counts
+ * - Note link: [[Roadmap]]
  *
  * Examples:
- * - "Buy groceries !today !!high" → title: "Buy groceries", due: today, priority: high
- * - "Review PR #work @next friday" → title: "Review PR", project: work, due: next Friday
+ * - "Buy groceries @today !high" → title: "Buy groceries", due: today, priority: high
+ * - "Review PR +work @next friday" → title: "Review PR", project: work, due: next Friday
  * - "Water plants every 2 weeks" → title: "Water plants", repeats every second week
  */
 export const parseQuickAdd = (input: string, projects: Project[]): ParsedQuickAdd => {
@@ -319,60 +269,57 @@ export const parseQuickAdd = (input: string, projects: Project[]): ParsedQuickAd
   let priority: Priority = 'none'
   let projectId: string | null = null
 
+  // Note links first: they own their whole run, sigils inside included.
+  const noteLinks = findNoteLinks(input)
+  for (const link of noteLinks) {
+    spans.push({ start: link.start, end: link.end, kind: 'noteLink' })
+  }
+
   // Natural-language due date: @tomorrow, @next wednesday
   const datePhrase = findDatePhrase(input)
-  if (datePhrase) {
+  if (datePhrase && !isInsideLink(noteLinks, datePhrase.start)) {
     dueDate = datePhrase.date
     dueTime = datePhrase.time
     spans.push({ start: datePhrase.start, end: datePhrase.end, kind: 'datePhrase' })
   }
 
-  // Due date keyword: !keyword (single !, never !!keyword — that is priority)
-  if (!dueDate) {
-    for (const match of input.matchAll(/(?<![!])!([a-zA-Z0-9]+)/g)) {
-      const parsedDate = parseDateKeyword(match[1])
-      if (parsedDate) {
-        dueDate = parsedDate
-        spans.push({ start: match.index, end: match.index + match[0].length, kind: 'date' })
-        break // Only use first valid date
-      }
-    }
-  }
-
   // Repeat: every monday, every 2 weeks. Anchored to the due date so a bare
   // "every month" repeats on the day the task is actually due.
   const repeatPhrase = findRepeatPhrase(input, dueDate ?? new Date())
-  const repeat = repeatPhrase?.config ?? null
-  if (repeatPhrase) {
+  const repeat =
+    repeatPhrase && !isInsideLink(noteLinks, repeatPhrase.start) ? repeatPhrase.config : null
+  if (repeatPhrase && repeat) {
     spans.push({ start: repeatPhrase.start, end: repeatPhrase.end, kind: 'repeat' })
   }
 
-  // Parse priority: !!keyword (double !)
-  const priorityMatch = input.match(/!!([a-zA-Z]+)/)
-  if (priorityMatch?.index !== undefined) {
-    const parsedPriority = parsePriorityKeyword(priorityMatch[1])
+  // Priority: !high. The first run that names a priority wins; "!nope" is prose.
+  for (const run of findMarkerRuns(input, PRIORITY_PATTERN)) {
+    if (isInsideLink(noteLinks, run.start)) continue
+    const parsedPriority = parsePriorityKeyword(run.value)
     if (parsedPriority) {
       priority = parsedPriority
-      spans.push({
-        start: priorityMatch.index,
-        end: priorityMatch.index + priorityMatch[0].length,
-        kind: 'priority'
-      })
+      spans.push({ start: run.start, end: run.end, kind: 'priority' })
+      break
     }
   }
 
-  // Parse project: #project-name
-  const projectMatch = input.match(/#([\w-]+)/)
-  if (projectMatch?.index !== undefined) {
-    const foundProjectId = findProjectByName(projectMatch[1], projects)
+  // Project: +work. Unresolved "+foo" stays in the title.
+  for (const run of findMarkerRuns(input, PROJECT_PATTERN)) {
+    if (isInsideLink(noteLinks, run.start)) continue
+    const foundProjectId = findProjectByName(run.value, projects)
     if (foundProjectId) {
       projectId = foundProjectId
-      spans.push({
-        start: projectMatch.index,
-        end: projectMatch.index + projectMatch[0].length,
-        kind: 'project'
-      })
+      spans.push({ start: run.start, end: run.end, kind: 'project' })
+      break
     }
+  }
+
+  // Tags: unlike the other markers, every one counts — a task takes several.
+  const tags: string[] = []
+  for (const run of findMarkerRuns(input, TAG_PATTERN)) {
+    if (isInsideLink(noteLinks, run.start)) continue
+    tags.push(run.value)
+    spans.push({ start: run.start, end: run.end, kind: 'tag' })
   }
 
   // A repeat only rolls forward from a due date, so give an undated repeating
@@ -387,7 +334,9 @@ export const parseQuickAdd = (input: string, projects: Project[]): ParsedQuickAd
     dueTime,
     priority,
     projectId,
-    repeat
+    repeat,
+    tags,
+    noteTitles: noteLinks.map((link) => link.title).filter(Boolean)
   }
 }
 
@@ -399,26 +348,33 @@ export const parseQuickAdd = (input: string, projects: Project[]): ParsedQuickAd
 export const findQuickAddSpans = (input: string): QuickAddSpan[] => {
   const spans: QuickAddSpan[] = []
 
+  const noteLinks = findNoteLinks(input)
+  for (const link of noteLinks) {
+    spans.push({ start: link.start, end: link.end, kind: 'noteLink' })
+  }
+
   const datePhrase = findDatePhrase(input)
-  if (datePhrase) {
+  if (datePhrase && !isInsideLink(noteLinks, datePhrase.start)) {
     spans.push({ start: datePhrase.start, end: datePhrase.end, kind: 'datePhrase' })
   }
 
   const repeatPhrase = findRepeatPhrase(input)
-  if (repeatPhrase) {
+  if (repeatPhrase && !isInsideLink(noteLinks, repeatPhrase.start)) {
     spans.push({ start: repeatPhrase.start, end: repeatPhrase.end, kind: 'repeat' })
   }
 
   // The sigil forms are painted as soon as they are typed, parseable or not —
-  // an unfinished "!tom" or an unknown "#foo" still reads as syntax.
-  for (const match of input.matchAll(/(!![a-zA-Z]+|(?<![!])![a-zA-Z0-9]+|#[\w-]+)/g)) {
-    const raw = match[0]
-    const kind: QuickAddSpanKind = raw.startsWith('!!')
-      ? 'priority'
-      : raw.startsWith('!')
-        ? 'date'
-        : 'project'
-    spans.push({ start: match.index, end: match.index + raw.length, kind })
+  // an unfinished "!hi" or an unknown "+foo" still reads as syntax.
+  const sigilKinds: [RegExp, QuickAddSpanKind][] = [
+    [PRIORITY_PATTERN, 'priority'],
+    [PROJECT_PATTERN, 'project'],
+    [TAG_PATTERN, 'tag']
+  ]
+  for (const [pattern, kind] of sigilKinds) {
+    for (const run of findMarkerRuns(input, pattern)) {
+      if (isInsideLink(noteLinks, run.start)) continue
+      spans.push({ start: run.start, end: run.end, kind })
+    }
   }
 
   return dropOverlaps(spans)
@@ -432,10 +388,13 @@ export const findQuickAddSpans = (input: string): QuickAddSpan[] => {
  * Check if input has any special syntax
  */
 export const hasSpecialSyntax = (input: string): boolean => {
+  // Scanned with matchAll rather than `.test()`: these patterns are global and
+  // module-level, so `.test()` would carry `lastIndex` between calls.
   return (
-    /(?<![!])![a-zA-Z0-9]+/.test(input) || // date
-    /!![a-zA-Z]+/.test(input) || // priority
-    /#[\w-]+/.test(input) || // project
+    findMarkerRuns(input, PRIORITY_PATTERN).length > 0 ||
+    findMarkerRuns(input, PROJECT_PATTERN).length > 0 ||
+    findMarkerRuns(input, TAG_PATTERN).length > 0 ||
+    findNoteLinks(input).length > 0 ||
     findDatePhrase(input) !== null || // @tomorrow
     findRepeatPhrase(input) !== null // every monday
   )
@@ -481,37 +440,6 @@ export interface AutocompleteOption {
 }
 
 /**
- * Get date options for autocomplete, filtered by query
- */
-export const getDateOptions = (query: string): AutocompleteOption[] => {
-  const keywords = [
-    { keyword: 'today', label: 'Today' },
-    { keyword: 'tomorrow', label: 'Tomorrow' },
-    { keyword: 'nextweek', label: 'Next Week' },
-    { keyword: 'monday', label: 'Monday' },
-    { keyword: 'tuesday', label: 'Tuesday' },
-    { keyword: 'wednesday', label: 'Wednesday' },
-    { keyword: 'thursday', label: 'Thursday' },
-    { keyword: 'friday', label: 'Friday' },
-    { keyword: 'saturday', label: 'Saturday' },
-    { keyword: 'sunday', label: 'Sunday' }
-  ]
-
-  const options: AutocompleteOption[] = keywords.map(({ keyword, label }) => ({
-    value: `!${keyword}`,
-    label
-  }))
-
-  if (!query) return options.slice(0, 5)
-
-  const lowerQuery = query.toLowerCase()
-  return options.filter(
-    (opt) =>
-      opt.value.toLowerCase().includes(lowerQuery) || opt.label.toLowerCase().includes(lowerQuery)
-  )
-}
-
-/**
  * The cadences the ghost completes to. Ordered so the shortest useful phrase
  * wins an ambiguous prefix ("every w" → weekday, the commonest routine).
  */
@@ -539,10 +467,10 @@ export const predictRepeatCompletion = (query: string): string | null => {
  */
 export const getPriorityOptions = (query: string): AutocompleteOption[] => {
   const options: AutocompleteOption[] = [
-    { value: '!!urgent', label: 'Urgent' },
-    { value: '!!high', label: 'High' },
-    { value: '!!medium', label: 'Medium' },
-    { value: '!!low', label: 'Low' }
+    { value: '!urgent', label: 'Urgent' },
+    { value: '!high', label: 'High' },
+    { value: '!medium', label: 'Medium' },
+    { value: '!low', label: 'Low' }
   ]
 
   if (!query) return options
@@ -562,7 +490,7 @@ export const getProjectOptions = (query: string, projects: Project[]): Autocompl
 
   if (!query) {
     return activeProjects.map((p) => ({
-      value: `#${p.name}`,
+      value: `+${p.name}`,
       label: p.name
     }))
   }
@@ -573,7 +501,20 @@ export const getProjectOptions = (query: string, projects: Project[]): Autocompl
       (p) => p.name.toLowerCase().includes(lowerQuery) || p.id.toLowerCase().includes(lowerQuery)
     )
     .map((p) => ({
-      value: `#${p.name}`,
+      value: `+${p.name}`,
       label: p.name
     }))
+}
+
+/**
+ * Get tag options for autocomplete, filtered by query. The pool is the app's
+ * existing tags (notes and tasks share it), in the order the caller supplies.
+ */
+export const getTagOptions = (query: string, tags: string[]): AutocompleteOption[] => {
+  const options: AutocompleteOption[] = tags.map((tag) => ({ value: `#${tag}`, label: tag }))
+
+  if (!query) return options
+
+  const lowerQuery = query.toLowerCase()
+  return options.filter((opt) => opt.label.toLowerCase().includes(lowerQuery))
 }

--- a/apps/desktop/src/renderer/src/pages/project/index.tsx
+++ b/apps/desktop/src/renderer/src/pages/project/index.tsx
@@ -142,6 +142,8 @@ export const ProjectPage = ({ projectId, className }: ProjectPageProps): React.J
         priority: Priority
         projectId: string | null
         repeat?: RepeatConfig | null
+        tags?: string[]
+        linkedNoteIds?: string[]
       }
     ) => {
       if (!project) return
@@ -154,6 +156,8 @@ export const ProjectPage = ({ projectId, className }: ProjectPageProps): React.J
         newTask.isRepeating = true
         newTask.repeatConfig = parsedData.repeat
       }
+      newTask.tags = parsedData?.tags ?? []
+      newTask.linkedNoteIds = parsedData?.linkedNoteIds ?? []
       undoable.createTask(newTask)
     },
     [project, undoable]

--- a/apps/desktop/src/renderer/src/pages/project/project-capture-input.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/project/project-capture-input.test.tsx
@@ -139,7 +139,7 @@ describe('ProjectCaptureInput — text capture', () => {
     const user = userEvent.setup()
     const { props } = setup()
 
-    await user.type(field(), 'Draft the brief !!high')
+    await user.type(field(), 'Draft the brief !high')
     await user.keyboard('{Enter}')
 
     expect(props.onAddTask).toHaveBeenCalledWith(

--- a/apps/desktop/src/renderer/src/pages/tasks.tsx
+++ b/apps/desktop/src/renderer/src/pages/tasks.tsx
@@ -667,6 +667,8 @@ export const TasksPage = ({
         projectId: string | null
         statusId?: string | null
         repeat?: RepeatConfig | null
+        tags?: string[]
+        linkedNoteIds?: string[]
       }
     ): void => {
       const projectId = resolveQuickAddProject(
@@ -702,6 +704,8 @@ export const TasksPage = ({
         newTask.isRepeating = true
         newTask.repeatConfig = parsedData.repeat
       }
+      newTask.tags = parsedData?.tags ?? []
+      newTask.linkedNoteIds = parsedData?.linkedNoteIds ?? []
 
       undoable.createTask(newTask)
     },

--- a/apps/docs/src/user-guide/tasks/capturing.md
+++ b/apps/docs/src/user-guide/tasks/capturing.md
@@ -34,11 +34,9 @@ Start a date with `@` — the same `@` phrases the note editor understands — a
 
 The phrase turns into a pill inside the input as soon as it is recognised, so you can see what will be captured before you press <kbd>Enter</kbd>. Text that doesn't read as a date — `Ping @bob` — stays part of the title.
 
-`!today`, `!mon` and `!dec20` still work as single-word shorthands.
-
 ### Finishing What You Type
 
-The rest of the phrase appears greyed out ahead of the cursor as you type — `@tomo` shows `@tomorrow`. Press <kbd>Tab</kbd> or <kbd>→</kbd> to take it, or keep typing to ignore it. The same completion works for `!today`, `!!high`, `#project` and the repeat phrases below.
+The rest of the phrase appears greyed out ahead of the cursor as you type — `@tomo` shows `@tomorrow`. Press <kbd>Tab</kbd> or <kbd>→</kbd> to take it, or keep typing to ignore it. The same completion works for `!high`, `+project`, `#tag` and the repeat phrases below.
 
 <kbd>Enter</kbd> never takes the suggestion — it captures exactly what is on screen.
 
@@ -60,22 +58,51 @@ If you didn't give the task a due date of its own, it starts on the first matchi
 
 Repeats are English-only for now.
 
-## Priority and Project Inline
+## The Whole Grammar
 
-You can set priority and project inline during quick-add:
+Quick-add speaks the same shorthand as the note editor, so a marker means the same thing wherever you type it:
 
-- `!!high` — double exclamation for priority (`!!urgent`, `!!high`, `!!medium`, `!!low`)
-- `#project-name` — hash prefix for project assignment
+```
+Ship the beta @next friday !high +Memry #launch [[Roadmap]] every 2 weeks
+```
 
-(These map to the same UI pickers used for editing existing tasks.)
+| Marker    | Sets          | Notes                                                              |
+| --------- | ------------- | ------------------------------------------------------------------ |
+| `@…`      | Due date      | Any phrase from [Natural Language Dates](#natural-language-dates)  |
+| `!…`      | Priority      | `!urgent`, `!high`, `!medium`, `!low` — `!u`, `!h`, `!m`, `!l` too |
+| `+…`      | Project       | `+work`, `+Personal`, `+project-alpha`                             |
+| `#…`      | Tag           | Every `#tag` counts, so a task can take several                    |
+| `[[…]]`   | A linked note | Opens a note picker as you type                                    |
+| `every …` | Repeat        | See [Repeats](#repeats)                                            |
+
+Each marker has to start a word, so ordinary writing is safe: `Ship it!`, `Learn C++`, `Compute 1+2` and `Close issue#12` are captured exactly as typed. A marker the app cannot resolve — `+nowhere` for a project that doesn't exist — stays in the title rather than disappearing.
+
+::: tip Changed in this release
+`#` used to mean **project**. It now means **tag**, matching the note editor. Use `+` for projects: `#Work` files a `Work` tag, `+Work` files into the Work project. Priority is a single `!` — `!high`, not `!!high` — and the old `!today` date shorthand is gone; `@today` does more.
+:::
+
+Every marker sets the same field the pickers in the task drawer set — quick-add is a shortcut, not a separate system.
+
+## Linking a Note
+
+Type `[[` and a note picker opens straight away, showing your most recently edited notes and narrowing as you type:
+
+- <kbd>↑</kbd> / <kbd>↓</kbd> to move
+- <kbd>Enter</kbd> or <kbd>Tab</kbd> to pick — the title is written in as `[[Note title]]`
+- <kbd>Esc</kbd> to close the list and keep what you typed (a second <kbd>Esc</kbd> clears the field)
+
+The `[[…]]` run leaves the task title, and the note shows up under **Related** on the task. You can type the title yourself, too — `[[Roadmap]]` links the note called _Roadmap_. A title that matches no note is simply dropped from the title with nothing linked.
+
+This is the one marker with a list instead of greyed-out completion: note titles are yours, so showing them beats guessing at them.
 
 ## Tags
 
 Tasks take tags from the same pool as your notes — one tag means one thing across the app,
 and it keeps whatever colour and icon you gave it.
 
-You can tag a task in two places:
+You can tag a task in three places:
 
+- **Quick-add** — type `#launch` in the capture field, as many as you like
 - **The add-task dialog** — tag it as you create it
 - **The task detail drawer** — add or remove tags on an existing task
 
@@ -88,8 +115,8 @@ something `mit` later files it under the same tag.
 A common use is marking your Most Important Tasks — tag them `MIT`, then filter to that tag
 to see just today's short list.
 
-Quick-add has no tag shortcut yet: `#` there means **project**, not tag. Use the add dialog
-or the drawer.
+Nested tags work the same way they do in notes: `#work/client` files under `work`. A brand-new
+tag typed in quick-add is created on the spot and picks up a colour like any other.
 
 ## From a Project View
 

--- a/packages/i18n/src/locales/en/tasks.json
+++ b/packages/i18n/src/locales/en/tasks.json
@@ -89,7 +89,7 @@
   },
   "quickAdd": {
     "label": "Quick add task",
-    "placeholder": "Add a task…    @tomorrow  every monday  !!high  #project"
+    "placeholder": "Add a task…    @tomorrow  !high  +project  #tag  [[note]]  every monday"
   },
   "drawer": {
     "close": "Close task details",


### PR DESCRIPTION
Stacked on #1387 (`issue-129`) — review that first.

Quick-add used `#` for **project** while the note editor uses `#` for **tag**. The two surfaces now agree:

```
Ship the beta @next friday !high +Memry #launch [[Roadmap]] every 2 weeks
```

| Marker | Sets | Status |
| --- | --- | --- |
| `@…` | due date (+ time) | unchanged |
| `!…` | priority | changed — was `!!`, and `!today` no longer means a date |
| `+…` | project | changed — was `#` |
| `#…` | tag | new — every `#tag` in the input counts |
| `[[…]]` | links a note | new |
| `every …` | repeat | unchanged |

Every marker must start a word, so ordinary writing survives: `Ship it!`, `Learn C++`, `Compute 1+2` and `issue#12` are captured verbatim. A marker inside `[[…]]` is part of the note title, never syntax. An unresolved `+foo` stays in the title, exactly as an unresolved `#foo` did before.

`[[` is the one completion with a list instead of ghost text — note titles are user data, so showing them beats guessing. It reuses the existing (previously unreferenced) `autocomplete-dropdown.tsx`, which gained an optional controlled `selectedIndex`: the textarea's key handler runs before the dropdown's window listener, so without it Enter submitted the task instead of picking the note.

## Migration

`#Work` used to file into the **Work project** and now creates a **Work tag**. Use `+Work` for the project. Priority is a single `!` (`!high`, not `!!high`), and `!today` no longer sets a date — `@today` covers more.

`!!high` is **not** accepted as a silent alias: it stays in the title. The "did you mean the project?" hint for a `#X` that matches a project name is not built — happy to add it if we want a softer landing.

## Two decisions worth a look

- **`#123` parses as a tag.** The brief asked for both "charset must match the note editor exactly" (`HASH_TAG_PATTERN` allows a leading digit) *and* a `#123` guard. Those conflict; editor-exactness won, so the only guard is word-start. Easy to flip to "must start with a letter".
- **Task tags need no `ensureTagDefinitions`.** The suspicion was that a brand-new tag typed on a task would end up colourless and invisible in the tag hub. It doesn't: `getAllTagsWithCounts` back-fills the definition through `getOrCreateTag` on read. Pinned by a new test rather than taken on trust.

One knock-on outside quick-add: `ContentArea`'s checkbox→task conversion already called `parseQuickAdd`, so `#urgent` on a checklist line now leaves the title. It passes `tags` through instead of dropping them. The editor's own grammar is untouched.

## Verification

- `pnpm lint` — 0 errors, 0 warnings in touched files
- `pnpm typecheck` — green
- Renderer suite — 6935 passed, 1 failed: `component-major-surfaces > ListView`, the inherited `useUpdateInboxItem` mock gap from `24e6b6fce` (#808)
- `tags.test.ts` (main) — 30 passed
- `i18n:check` (English only, no new locales) · `docs:impact --strict` · `docs:build` — all green