### PR TITLE
fix(calendar): week column width and marquee edge auto-scroll (#972)

### DIFF
--- a/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
@@ -66,6 +66,7 @@ export function CalendarDayView({
   const dateForColumn = useCallback(() => anchorDate, [anchorDate])
   const { selection, isDragging, handlers, clearSelection } = useTimeGridMarquee({
     gridRef,
+    scrollRef,
     dateForColumn
   })
   const { drag, startMove, startResize, wasDragged } = useEventDrag({

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
@@ -106,7 +106,6 @@ export function CalendarWeekView({
   const { scrollContainerRef, virtualizer, visibleDayStart, scrollToDate, dateForDayIndex } =
     useWeekInfiniteScroll({
       initialDate: anchorDate,
-      gutterWidth: GUTTER_WIDTH,
       onVisibleDayStartChange: notifyVisibleStart
     })
 
@@ -162,6 +161,7 @@ export function CalendarWeekView({
 
   const { selection, isDragging, handlers, clearSelection } = useTimeGridMarquee({
     gridRef,
+    scrollRef: scrollContainerRef,
     dateForColumn,
     columnCount: virtualizer.options.count,
     getColumnElement

--- a/apps/desktop/src/renderer/src/components/calendar/use-time-grid-marquee.test.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/use-time-grid-marquee.test.ts
@@ -103,11 +103,39 @@ function createMockGridRef(rect: Partial<DOMRect> = {}): RefObject<HTMLDivElemen
   return { current: element }
 }
 
+/**
+ * The scrolling ancestor of the grid. Defaults to the same box as
+ * `createMockGridRef` so tests that do not exercise auto-scroll behave as
+ * before.
+ */
+function createMockScrollRef(rect: Partial<DOMRect> = {}): RefObject<HTMLElement | null> {
+  const element = {
+    getBoundingClientRect: () => ({
+      top: 0,
+      left: 0,
+      right: 500,
+      bottom: 2304,
+      width: 500,
+      height: 2304,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+      ...rect
+    }),
+    scrollTop: 0
+  } as unknown as HTMLElement
+  return { current: element }
+}
+
 describe('useTimeGridMarquee', () => {
   it('starts with no selection', () => {
     const ref = createMockGridRef()
     const { result } = renderHook(() =>
-      useTimeGridMarquee({ gridRef: ref, dateForColumn: () => '2026-04-14' })
+      useTimeGridMarquee({
+        gridRef: ref,
+        scrollRef: createMockScrollRef(),
+        dateForColumn: () => '2026-04-14'
+      })
     )
     expect(result.current.selection).toBeNull()
     expect(result.current.isDragging).toBe(false)
@@ -116,7 +144,11 @@ describe('useTimeGridMarquee', () => {
   it('creates 1-hour selection on double-click', () => {
     const ref = createMockGridRef()
     const { result } = renderHook(() =>
-      useTimeGridMarquee({ gridRef: ref, dateForColumn: () => '2026-04-14' })
+      useTimeGridMarquee({
+        gridRef: ref,
+        scrollRef: createMockScrollRef(),
+        dateForColumn: () => '2026-04-14'
+      })
     )
     // 432px = 9 hours * 48px/hour = 9:00 AM
     const event = {
@@ -136,7 +168,11 @@ describe('useTimeGridMarquee', () => {
   it('clears selection via clearSelection()', () => {
     const ref = createMockGridRef()
     const { result } = renderHook(() =>
-      useTimeGridMarquee({ gridRef: ref, dateForColumn: () => '2026-04-14' })
+      useTimeGridMarquee({
+        gridRef: ref,
+        scrollRef: createMockScrollRef(),
+        dateForColumn: () => '2026-04-14'
+      })
     )
     const event = {
       clientY: 864,
@@ -157,7 +193,11 @@ describe('useTimeGridMarquee', () => {
   it('ignores non-left clicks and clicks starting on event chips', () => {
     const ref = createMockGridRef()
     const { result } = renderHook(() =>
-      useTimeGridMarquee({ gridRef: ref, dateForColumn: () => '2026-04-14' })
+      useTimeGridMarquee({
+        gridRef: ref,
+        scrollRef: createMockScrollRef(),
+        dateForColumn: () => '2026-04-14'
+      })
     )
     const chip = document.createElement('button')
     chip.dataset.visualType = 'event'
@@ -223,9 +263,11 @@ describe('useTimeGridMarquee', () => {
     )
     grid.append(gutter, column)
     const ref = { current: grid } as React.RefObject<HTMLDivElement | null>
+    const scrollRef = createMockScrollRef({ top: 100, bottom: 300, height: 200 })
     const { result, unmount } = renderHook(() =>
       useTimeGridMarquee({
         gridRef: ref,
+        scrollRef,
         dateForColumn: (index) => `2026-04-${String(14 + index).padStart(2, '0')}`,
         columnCount: 2
       })
@@ -262,6 +304,10 @@ describe('useTimeGridMarquee', () => {
       rafCallbacks.at(-1)?.(0)
       document.dispatchEvent(new MouseEvent('mouseup'))
     })
+    // The scroll container moves; the grid, which has no overflow of its own,
+    // is left untouched.
+    expect(scrollRef.current!.scrollTop).toBeGreaterThan(0)
+    expect(grid.scrollTop).toBe(10)
     expect(result.current.isDragging).toBe(false)
     expect(result.current.selection).not.toBeNull()
 
@@ -300,6 +346,7 @@ describe('useTimeGridMarquee', () => {
     const { result } = renderHook(() =>
       useTimeGridMarquee({
         gridRef: ref,
+        scrollRef: createMockScrollRef(),
         dateForColumn: () => '2026-08-06',
         columnCount: COLUMN_COUNT,
         // The virtualizer had not rendered this column yet.
@@ -319,10 +366,169 @@ describe('useTimeGridMarquee', () => {
     )
   })
 
+  /**
+   * A realistically shaped time grid: a 24-hour strip (1152px at 48px/hour)
+   * inside a viewport that shows four hours, scrolled to 08:00. The grid's own
+   * rect therefore starts above the viewport and ends far below it — measuring
+   * auto-scroll against that rect never comes within the edge threshold.
+   */
+  function createScrollingRig(initialScrollTop: number): {
+    grid: HTMLDivElement
+    scroller: HTMLElement
+    gridRef: RefObject<HTMLDivElement | null>
+    scrollRef: RefObject<HTMLElement | null>
+  } {
+    const VIEWPORT_TOP = 100
+    const VIEWPORT_HEIGHT = 192
+    const GRID_HEIGHT = 1152
+
+    const scroller = document.createElement('div')
+    scroller.scrollTop = initialScrollTop
+    scroller.getBoundingClientRect = () =>
+      ({
+        top: VIEWPORT_TOP,
+        bottom: VIEWPORT_TOP + VIEWPORT_HEIGHT,
+        left: 0,
+        right: 400,
+        width: 400,
+        height: VIEWPORT_HEIGHT,
+        x: 0,
+        y: VIEWPORT_TOP,
+        toJSON: () => ({})
+      }) as DOMRect
+
+    const grid = document.createElement('div')
+    // The grid rides the scroll: its viewport-relative top moves as the
+    // container scrolls, which is what lets the selection follow along.
+    grid.getBoundingClientRect = () =>
+      ({
+        top: VIEWPORT_TOP - scroller.scrollTop,
+        bottom: VIEWPORT_TOP - scroller.scrollTop + GRID_HEIGHT,
+        left: 0,
+        right: 400,
+        width: 400,
+        height: GRID_HEIGHT,
+        x: 0,
+        y: VIEWPORT_TOP - scroller.scrollTop,
+        toJSON: () => ({})
+      }) as DOMRect
+
+    return {
+      grid,
+      scroller,
+      gridRef: { current: grid } as RefObject<HTMLDivElement | null>,
+      scrollRef: { current: scroller } as RefObject<HTMLElement | null>
+    }
+  }
+
+  function stubRaf(): FrameRequestCallback[] {
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      rafCallbacks.push(callback)
+      return rafCallbacks.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    return rafCallbacks
+  }
+
+  it('auto-scrolls the container at the bottom edge and extends the selection past the visible hours', () => {
+    const rafCallbacks = stubRaf()
+    // Scrolled to 08:00 (8h * 48px), so the viewport shows 08:00–12:00.
+    const { grid, scroller, gridRef, scrollRef } = createScrollingRig(384)
+    const { result, unmount } = renderHook(() =>
+      useTimeGridMarquee({ gridRef, scrollRef, dateForColumn: () => '2026-04-14' })
+    )
+
+    act(() => {
+      result.current.handlers.onMouseDown(
+        {
+          button: 0,
+          clientY: 148,
+          target: grid,
+          preventDefault: vi.fn()
+        } as unknown as React.MouseEvent,
+        0
+      )
+    })
+
+    // Drag to 2px above the viewport's bottom edge: 09:00–12:00 so far.
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientY: 290 }))
+    })
+    expect(result.current.selection).toMatchObject({
+      startAt: '2026-04-14T09:00',
+      endAt: '2026-04-14T12:00'
+    })
+    expect(rafCallbacks.length).toBeGreaterThan(0)
+
+    // Hold the pointer still and let auto-scroll run: 8 frames * 12px = 96px,
+    // two more hours of grid.
+    act(() => {
+      for (let i = 0; i < 8; i++) rafCallbacks.at(-1)?.(0)
+    })
+
+    expect(scroller.scrollTop).toBe(480)
+    expect(grid.scrollTop).toBe(0)
+    expect(result.current.selection).toMatchObject({
+      startAt: '2026-04-14T09:00',
+      endAt: '2026-04-14T14:00'
+    })
+
+    unmount()
+    vi.unstubAllGlobals()
+  })
+
+  it('auto-scrolls the container at the top edge', () => {
+    const rafCallbacks = stubRaf()
+    const { grid, scroller, gridRef, scrollRef } = createScrollingRig(384)
+    const { result, unmount } = renderHook(() =>
+      useTimeGridMarquee({ gridRef, scrollRef, dateForColumn: () => '2026-04-14' })
+    )
+
+    act(() => {
+      result.current.handlers.onMouseDown(
+        {
+          button: 0,
+          clientY: 280,
+          target: grid,
+          preventDefault: vi.fn()
+        } as unknown as React.MouseEvent,
+        0
+      )
+    })
+
+    // Drag up to 2px below the viewport's top edge.
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientY: 102 }))
+    })
+    expect(result.current.selection).toMatchObject({
+      startAt: '2026-04-14T08:00',
+      endAt: '2026-04-14T11:45'
+    })
+
+    act(() => {
+      for (let i = 0; i < 8; i++) rafCallbacks.at(-1)?.(0)
+    })
+
+    expect(scroller.scrollTop).toBe(288)
+    expect(grid.scrollTop).toBe(0)
+    expect(result.current.selection).toMatchObject({
+      startAt: '2026-04-14T06:00',
+      endAt: '2026-04-14T11:45'
+    })
+
+    unmount()
+    vi.unstubAllGlobals()
+  })
+
   it('clears click-only drags on mouseup', () => {
     const ref = createMockGridRef()
     const { result } = renderHook(() =>
-      useTimeGridMarquee({ gridRef: ref, dateForColumn: () => '2026-04-14' })
+      useTimeGridMarquee({
+        gridRef: ref,
+        scrollRef: createMockScrollRef(),
+        dateForColumn: () => '2026-04-14'
+      })
     )
 
     act(() => {

--- a/apps/desktop/src/renderer/src/components/calendar/use-time-grid-marquee.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/use-time-grid-marquee.ts
@@ -64,6 +64,12 @@ export interface TimeGridSelection {
 
 interface UseTimeGridMarqueeOptions {
   gridRef: RefObject<HTMLDivElement | null>
+  /**
+   * The scrolling ancestor of `gridRef` (the element carrying `overflow-y`).
+   * The grid itself is the full 24-hour strip and never scrolls, so edge
+   * auto-scroll has to measure and move this element instead.
+   */
+  scrollRef: RefObject<HTMLElement | null>
   dateForColumn: (columnIndex: number) => string
   columnCount?: number
   hourHeight?: number
@@ -89,6 +95,9 @@ function isEventChip(target: EventTarget | null): boolean {
 function getMouseY(clientY: number, gridRef: RefObject<HTMLDivElement | null>): number {
   const el = gridRef.current
   if (!el) return 0
+  // The grid is not the scroll container, so `rect.top` already travels with
+  // the scroll and `el.scrollTop` is 0. Reading the scroller here instead would
+  // double-count the offset — this stays on the grid deliberately.
   const rect = el.getBoundingClientRect()
   return clientY - rect.top + el.scrollTop
 }
@@ -138,6 +147,7 @@ function buildSelection(
 
 export function useTimeGridMarquee({
   gridRef,
+  scrollRef,
   dateForColumn,
   columnCount = 1,
   hourHeight = HOUR_HEIGHT,
@@ -152,6 +162,7 @@ export function useTimeGridMarquee({
     columnIndex: number
     rafId: number | null
     hasMoved: boolean
+    lastClientY: number
   } | null>(null)
 
   const clearSelection = useCallback(() => setSelection(null), [])
@@ -164,12 +175,13 @@ export function useTimeGridMarquee({
     setIsDragging(false)
   }, [])
 
-  const handleMouseMove = useCallback(
-    (e: MouseEvent) => {
+  // Re-derived from the pointer's viewport position, so it also picks up
+  // movement caused by auto-scroll while the pointer is held still.
+  const updateSelection = useCallback(
+    (clientY: number) => {
       if (!dragState.current) return
-      dragState.current.hasMoved = true
       const { anchorY, columnIndex } = dragState.current
-      const currentY = getMouseY(e.clientY, gridRef)
+      const currentY = getMouseY(clientY, gridRef)
       const geo = selectionFromDrag(anchorY, currentY, hourHeight, snapMinutes)
       const date = dateForColumn(columnIndex)
       setSelection(
@@ -184,8 +196,23 @@ export function useTimeGridMarquee({
           getColumnElement
         )
       )
+    },
+    [gridRef, dateForColumn, hourHeight, snapMinutes, columnCount, getColumnElement]
+  )
 
-      const el = gridRef.current
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!dragState.current) return
+      dragState.current.hasMoved = true
+      dragState.current.lastClientY = e.clientY
+      updateSelection(e.clientY)
+
+      // Auto-scroll is measured against the scroll container's visible box. The
+      // grid's own rect is the whole 24-hour strip, which extends far past both
+      // edges of the viewport once scrolled, so its `top`/`bottom` never came
+      // within the threshold and the drag could not be extended past the hours
+      // already on screen.
+      const el = scrollRef.current
       if (!el) return
       const rect = el.getBoundingClientRect()
       const distFromTop = e.clientY - rect.top
@@ -196,25 +223,28 @@ export function useTimeGridMarquee({
         dragState.current.rafId = null
       }
 
+      const startAutoScroll = (delta: number): void => {
+        const scroll = (): void => {
+          if (!dragState.current) return
+          el.scrollTop += delta
+          // The pointer has not moved, but the hours under it have.
+          updateSelection(dragState.current.lastClientY)
+          dragState.current.rafId = requestAnimationFrame(scroll)
+        }
+        if (dragState.current) dragState.current.rafId = requestAnimationFrame(scroll)
+      }
+
       if (distFromTop < AUTO_SCROLL_THRESHOLD) {
         const speed = Math.round(AUTO_SCROLL_MAX_SPEED * (1 - distFromTop / AUTO_SCROLL_THRESHOLD))
-        const scroll = () => {
-          el.scrollTop -= speed
-          if (dragState.current) dragState.current.rafId = requestAnimationFrame(scroll)
-        }
-        dragState.current.rafId = requestAnimationFrame(scroll)
+        startAutoScroll(-speed)
       } else if (distFromBottom < AUTO_SCROLL_THRESHOLD) {
         const speed = Math.round(
           AUTO_SCROLL_MAX_SPEED * (1 - distFromBottom / AUTO_SCROLL_THRESHOLD)
         )
-        const scroll = () => {
-          el.scrollTop += speed
-          if (dragState.current) dragState.current.rafId = requestAnimationFrame(scroll)
-        }
-        dragState.current.rafId = requestAnimationFrame(scroll)
+        startAutoScroll(speed)
       }
     },
-    [gridRef, dateForColumn, hourHeight, snapMinutes, columnCount, getColumnElement]
+    [scrollRef, updateSelection]
   )
 
   const handleMouseUp = useCallback(() => {
@@ -240,7 +270,13 @@ export function useTimeGridMarquee({
       if (isEventChip(e.target)) return
       e.preventDefault()
       const anchorY = getMouseY(e.clientY, gridRef)
-      dragState.current = { anchorY, columnIndex, rafId: null, hasMoved: false }
+      dragState.current = {
+        anchorY,
+        columnIndex,
+        rafId: null,
+        hasMoved: false,
+        lastClientY: e.clientY
+      }
       setIsDragging(true)
       setSelection(null)
     },

--- a/apps/desktop/src/renderer/src/components/calendar/use-week-infinite-scroll.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/use-week-infinite-scroll.test.tsx
@@ -59,7 +59,6 @@ describe('useWeekInfiniteScroll', () => {
     function Harness(): React.JSX.Element {
       current = useWeekInfiniteScroll({
         initialDate: '2026-05-14',
-        gutterWidth: 48,
         totalDays: 90,
         onVisibleDayStartChange
       })
@@ -68,7 +67,7 @@ describe('useWeekInfiniteScroll', () => {
 
     const { getByTestId } = render(<Harness />)
     const scroller = getByTestId('week-scroller') as HTMLDivElement
-    defineReadonlyNumber(scroller, 'clientWidth', 748)
+    defineReadonlyNumber(scroller, 'clientWidth', 700)
     scroller.scrollTo = vi.fn(({ left }) => {
       scroller.scrollLeft = Number(left)
     })
@@ -144,7 +143,6 @@ describe('useWeekInfiniteScroll', () => {
     function Harness(): React.JSX.Element {
       current = useWeekInfiniteScroll({
         initialDate: '2026-05-14',
-        gutterWidth: 48,
         totalDays: 36_525
       })
       return <div data-testid="week-scroller" ref={current.scrollContainerRef} />
@@ -153,8 +151,8 @@ describe('useWeekInfiniteScroll', () => {
     const { getByTestId } = render(<Harness />)
     const scroller = getByTestId('week-scroller') as HTMLDivElement
 
-    // First real layout: (748 - 48 gutter) / 7 = 100px columns.
-    defineReadonlyNumber(scroller, 'clientWidth', 748)
+    // First real layout: 700 / 7 = 100px columns.
+    defineReadonlyNumber(scroller, 'clientWidth', 700)
     act(() => {
       ResizeObserverMock.instances[0].trigger()
     })
@@ -163,14 +161,37 @@ describe('useWeekInfiniteScroll', () => {
     expect(pinnedScrollLeft).toBeGreaterThan(0)
     const pinnedDay = pinnedScrollLeft / 100
 
-    // Window widened: (1098 - 48) / 7 = 150px columns. The same day must stay
+    // Window widened: 1050 / 7 = 150px columns. The same day must stay
     // pinned — scrollLeft is re-derived from the day position, not left at the
     // stale pixel offset (which would jump hundreds of days into the past/future).
-    defineReadonlyNumber(scroller, 'clientWidth', 1098)
+    defineReadonlyNumber(scroller, 'clientWidth', 1050)
     act(() => {
       ResizeObserverMock.instances[0].trigger()
     })
     expect(current?.columnWidth).toBe(150)
     expect(scroller.scrollLeft).toBe(pinnedDay * 150)
+  })
+
+  it('fits exactly seven columns in the scroll container, leaving no partial eighth day', () => {
+    let current: UseWeekInfiniteScrollResult | null = null
+
+    function Harness(): React.JSX.Element {
+      current = useWeekInfiniteScroll({ initialDate: '2026-05-14', totalDays: 90 })
+      return <div data-testid="week-scroller" ref={current.scrollContainerRef} />
+    }
+
+    const { getByTestId } = render(<Harness />)
+    const scroller = getByTestId('week-scroller') as HTMLDivElement
+
+    // The hour gutter is a sibling of this element, so its width is already
+    // excluded. Subtracting it a second time narrowed every column and left a
+    // gutter-wide strip at the end of the week for a partial 8th day.
+    defineReadonlyNumber(scroller, 'clientWidth', 1000)
+    act(() => {
+      ResizeObserverMock.instances[0].trigger()
+    })
+
+    expect(current?.columnWidth).toBeCloseTo(1000 / 7, 6)
+    expect((current?.columnWidth ?? 0) * 7).toBeCloseTo(1000, 6)
   })
 })

--- a/apps/desktop/src/renderer/src/components/calendar/use-week-infinite-scroll.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/use-week-infinite-scroll.ts
@@ -17,7 +17,6 @@ const INSTANT_JUMP_THRESHOLD_DAYS = 14
 
 interface UseWeekInfiniteScrollOptions {
   initialDate: string
-  gutterWidth: number
   totalDays?: number
   onVisibleDayStartChange?: (dayIndex: number) => void
 }
@@ -34,17 +33,21 @@ export interface UseWeekInfiniteScrollResult {
 
 export function useWeekInfiniteScroll({
   initialDate,
-  gutterWidth,
   totalDays = DEFAULT_TOTAL_DAYS,
   onVisibleDayStartChange
 }: UseWeekInfiniteScrollOptions): UseWeekInfiniteScrollResult {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const [containerWidth, setContainerWidth] = useState(0)
 
-  const columnWidth = useMemo(() => {
-    if (containerWidth <= gutterWidth) return MIN_COLUMN_WIDTH
-    return Math.max(MIN_COLUMN_WIDTH, (containerWidth - gutterWidth) / COLUMNS_PER_PAGE)
-  }, [containerWidth, gutterWidth])
+  // `containerWidth` is the scroll container's own width, and that element is a
+  // sibling of the hour gutter rather than its parent — the gutter is already
+  // excluded. Subtracting it again shaved a seventh of the gutter off every
+  // column and left a gutter-wide strip at the end of the week for the
+  // virtualizer to fill with a partial 8th day.
+  const columnWidth = useMemo(
+    () => Math.max(MIN_COLUMN_WIDTH, containerWidth / COLUMNS_PER_PAGE),
+    [containerWidth]
+  )
 
   const initialIndex = useMemo(() => dayIndexFromDate(initialDate), [initialDate])
   const [visibleDayStart, setVisibleDayStart] = useState(initialIndex)

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -50,6 +50,11 @@ Click an empty time slot (day / week views) or a date cell (month) to create an 
 - Notes / description
 - Recurrence (one-off, daily, weekly, monthly)
 
+On the day and week timelines you can also drag across a range of hours instead of clicking.
+Drag to the top or bottom edge of the grid and it scrolls on its own, so a selection can run
+past the hours currently on screen — hold the pointer at the edge and the range keeps growing
+as the grid scrolls.
+
 ## Event Detail Popover
 
 Click an event to open the popover. Edit title, time, and description in place. The popover has a "Open in tab" action for full editing.


### PR DESCRIPTION
Closes #972.

Both defects filed in #972 were verified at the source before being fixed; both were real.

## 1. Week view double-counted the hour gutter

`use-week-infinite-scroll.ts` computed `(containerWidth - gutterWidth) / 7`, but the element it measures (`calendar-week-view.tsx:376`) is a **sibling** of the gutter column, not its parent — the gutter is already excluded from `clientWidth`.

At a 1000px calendar area: columns came out `(952 - 48) / 7 = 129.1px` instead of `952 / 7 = 136px`. Seven columns covered 904 of the 952px strip, and the virtualizer filled the leftover 48px with a partial 8th day that showed in the header, all-day, and time-grid rows at once.

The `gutterWidth` option is gone — the hook has no business knowing about it.

## 2. Marquee auto-scroll never fired, and would have been a no-op if it had

`use-time-grid-marquee.ts` measured the edge threshold against `gridRef`'s rect and wrote `scrollTop` on the same element. Two problems:

- **The threshold never matched.** The grid's rect is the whole 24-hour strip (1152px), which extends past both edges of the viewport once scrolled, so `distFromTop` / `distFromBottom` never came within the 48px threshold.
- **The write went nowhere.** The grid carries no `overflow-y`; the scrolling ancestor does (`calendar-week-view.tsx:377`, `calendar-day-view.tsx:119`). `el.scrollTop -= speed` on a non-scrolling div is silently discarded.

Symptom: dragging a marquee selection to the top or bottom edge did not scroll, so a selection could not be extended past the hours already on screen, in either day or week view.

Both now take an explicit `scrollRef`. The selection is also re-derived inside the auto-scroll frame loop — otherwise the grid would scroll under a stationary pointer without the range following it, and the reported symptom would have survived the fix.

The `el.scrollTop` **reads** in `getMouseY` / `buildSelection` deliberately stay on the grid: its rect already travels with the scroll, so reading the scroller there would double-count the offset. Commented in place so the next reader does not "fix" it.

## Verification

- `use-time-grid-marquee.test.ts`, `use-week-infinite-scroll.test.tsx` — new coverage for both defects, including a realistically shaped rig (24h strip inside a 4-hour viewport scrolled to 08:00) where the old threshold provably cannot fire.
- Mutation-tested: reverting each fix in place fails 6 tests, including the pre-existing auto-scroll test, which now catches the wrong-element write. Mutations reverted, suite re-run green.
- `vitest --project renderer src/renderer/src/components/calendar` — 285 passed (38 files)
- `calendar-quick-create.test.tsx` — 5 passed
- `typecheck:web`, `typecheck:test`, `eslint` on changed files, `docs:impact --strict` (covered), `docs:build` — all clean

## Not verified

No manual run in the real app. The geometry is asserted in jsdom against hand-built rects, not measured in Electron.
