### PR TITLE
fix(crdt): stop the export path destroying nodes, and share one BlockNote schema

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -149,6 +149,7 @@
     "@memry/cli": "workspace:*",
     "@memry/contracts": "workspace:*",
     "@memry/db-schema": "workspace:*",
+    "@memry/editor-schema": "workspace:*",
     "@memry/domain-inbox": "workspace:*",
     "@memry/domain-notes": "workspace:*",
     "@memry/domain-tasks": "workspace:*",

--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -5,7 +5,8 @@ import {
   blocksToYFragment,
   markdownToYFragment,
   yFragmentToBlocks,
-  repairEmptyBlockIds
+  repairEmptyBlockIds,
+  findUnrepresentableNodes
 } from './blocknote-converter'
 import * as Y from 'yjs'
 import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
@@ -673,5 +674,69 @@ describe('blocknote-converter export path never mutates the live doc', () => {
     await yDocToMarkdown(doc)
 
     expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+  })
+})
+
+describe('findUnrepresentableNodes', () => {
+  function seedUnknownInlineNode(nodeName: string): Y.Doc {
+    const doc = new Y.Doc()
+    const block = new Y.XmlElement('blockContainer')
+    block.setAttribute('id', 'b1')
+    const para = new Y.XmlElement('paragraph')
+    const unknown = new Y.XmlElement(nodeName)
+    unknown.setAttribute('target', 'Roadmap')
+    para.insert(0, [unknown])
+    block.insert(0, [para])
+    doc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [block])
+    return doc
+  }
+
+  it('names the inline node type the server schema cannot build', () => {
+    // #given a doc holding a renderer-only inline node
+    const doc = seedUnknownInlineNode('wikiLink')
+
+    // #when
+    const unknown = findUnrepresentableNodes(doc)
+
+    // #then
+    expect(unknown).toEqual(['wikiLink'])
+  })
+
+  it('reports nothing for content this build can serialize, tables included', async () => {
+    // #given the node names a real vault note produces — tables expand into
+    // tableRow/tableCell/tableHeader/tableParagraph, none of which are block
+    // types, so a hand-written "known types" list would flag them
+    const doc = new Y.Doc()
+    const ok = await markdownToYFragment(
+      '| a | b |\n| --- | --- |\n| 1 | 2 |\n\n> quote\n\n- [ ] a task {task:t1}\n\n```ts\nconst x = 1\n```\n',
+      doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+    expect(ok).toBe(true)
+
+    // #when
+    const unknown = findUnrepresentableNodes(doc)
+
+    // #then
+    expect(unknown).toEqual([])
+  })
+
+  it('reads without mutating the doc', () => {
+    // #given
+    const doc = seedUnknownInlineNode('wikiLink')
+    const before = Y.encodeStateAsUpdate(doc)
+
+    // #when
+    findUnrepresentableNodes(doc)
+
+    // #then
+    expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+  })
+
+  it('reports an empty doc as representable', () => {
+    // #given a note that has never been edited
+    const doc = new Y.Doc()
+
+    // #when / #then
+    expect(findUnrepresentableNodes(doc)).toEqual([])
   })
 })

--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -654,3 +654,24 @@ describe('inline underline persistence through the real markdown pipeline', () =
     expect(md).not.toContain('MEMRYICC')
   })
 })
+
+describe('blocknote-converter export path never mutates the live doc', () => {
+  it('never mutates the live doc, even for a node type the schema does not know', async () => {
+    const doc = new Y.Doc()
+    const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    // A block containing an inline node the server schema cannot build.
+    const block = new Y.XmlElement('blockContainer')
+    block.setAttribute('id', 'b1')
+    const para = new Y.XmlElement('paragraph')
+    const unknown = new Y.XmlElement('wikiLink')
+    unknown.setAttribute('target', 'Roadmap')
+    para.insert(0, [unknown])
+    block.insert(0, [para])
+    fragment.insert(0, [block])
+
+    const before = Y.encodeStateAsUpdate(doc)
+    await yDocToMarkdown(doc)
+
+    expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+  })
+})

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -9,7 +9,7 @@ import {
 } from '@blocknote/core'
 import { codeBlockOptions } from '@blocknote/code-block'
 import { randomUUID } from 'node:crypto'
-import type * as Y from 'yjs'
+import * as Y from 'yjs'
 import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 import { parseCriticMarkup, writeCriticMarkupMarksToYDoc } from '@memry/shared'
 import {
@@ -101,9 +101,14 @@ export async function yDocToMarkdown(
   fragmentName = CRDT_FRAGMENT_NAME
 ): Promise<string | null> {
   try {
+    // y-prosemirror's `createNodeFromYElement` DELETES any element it cannot
+    // build (dist/y-prosemirror.cjs:878-885) — a repair heuristic that, run on
+    // the live doc, turns a serialization gap into replicated data loss. Read
+    // from a detached copy so this path can only ever read.
+    const snapshot = new Y.Doc()
+    Y.applyUpdate(snapshot, Y.encodeStateAsUpdate(doc))
     const editor = getEditor()
-    const fragment = doc.getXmlFragment(fragmentName)
-    const blocks = editor.yXmlFragmentToBlocks(fragment)
+    const blocks = editor.yXmlFragmentToBlocks(snapshot.getXmlFragment(fragmentName))
     if (blocks.length === 0) return ''
     return await blocksToMarkdownPreserving(editor, blocks as Block[])
   } catch (err) {

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -117,6 +117,44 @@ export async function yDocToMarkdown(
   }
 }
 
+/**
+ * Node names in the CRDT fragment that this build's schema cannot construct.
+ *
+ * y-prosemirror answers an unknown node name by DELETING the element
+ * (`createNodeFromYElement`, dist/y-prosemirror.cjs:878-885), so a doc holding
+ * one can only ever serialize to markdown that is missing it. Callers use this
+ * to refuse the write rather than persist the loss.
+ *
+ * The oracle is the ProseMirror schema itself, not a hand-written list: node
+ * names are not block type names, and a list would miss the ones that never
+ * appear in `blockSchema` (a table expands into `tableRow` / `tableCell` /
+ * `tableHeader` / `tableParagraph`) — flagging those would strand every note
+ * with a table. Reads only; never mutates `doc`.
+ */
+export function findUnrepresentableNodes(doc: Y.Doc, fragmentName = CRDT_FRAGMENT_NAME): string[] {
+  try {
+    const known = getEditor().editor.pmSchema.nodes
+    const unknown = new Set<string>()
+    const visit = (node: Y.XmlFragment | Y.XmlElement): void => {
+      for (const child of node.toArray()) {
+        const el = child as Y.XmlElement
+        // Y.XmlText carries no nodeName — its runs are marks, and the schema
+        // holds every mark both processes use.
+        if (typeof el.nodeName !== 'string') continue
+        if (!(el.nodeName in known)) unknown.add(el.nodeName)
+        visit(el)
+      }
+    }
+    visit(doc.getXmlFragment(fragmentName))
+    return [...unknown]
+  } catch (err) {
+    // A schema this broken also fails `yDocToMarkdown`, whose null return keeps
+    // the file anyway. Reporting "nothing unknown" here can't cause a write.
+    log.error('Unrepresentable-node scan failed', err)
+    return []
+  }
+}
+
 export async function markdownToBlocks(
   markdown: string,
   notePath?: string

--- a/apps/desktop/src/main/sync/crdt-writeback.test.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.test.ts
@@ -4,6 +4,9 @@ import { JournalChannels, NotesChannels } from '@memry/contracts/ipc-channels'
 
 const mocks = vi.hoisted(() => ({
   yDocToMarkdown: vi.fn(),
+  findUnrepresentableNodes: vi.fn(),
+  trackMainError: vi.fn(),
+  trackMainLog: vi.fn(),
   getNoteCacheById: vi.fn(),
   getNoteCacheByPath: vi.fn(),
   getNoteMetadataById: vi.fn(),
@@ -61,7 +64,13 @@ vi.mock('./crdt-provider', () => ({
 }))
 
 vi.mock('./blocknote-converter', () => ({
-  yDocToMarkdown: (...args: unknown[]) => mocks.yDocToMarkdown(...args)
+  yDocToMarkdown: (...args: unknown[]) => mocks.yDocToMarkdown(...args),
+  findUnrepresentableNodes: (...args: unknown[]) => mocks.findUnrepresentableNodes(...args)
+}))
+
+vi.mock('../telemetry/diagnostics', () => ({
+  trackMainError: (...args: unknown[]) => mocks.trackMainError(...args),
+  trackMainLog: (...args: unknown[]) => mocks.trackMainLog(...args)
 }))
 
 vi.mock('@memry/shared/utc', () => ({
@@ -141,6 +150,7 @@ import {
   scheduleWriteback,
   wasRecentNetworkUpdate
 } from './crdt-writeback'
+import { resetTelemetryThrottle } from '../telemetry/throttle'
 
 function makeDoc(title = 'Synced title', tags: string[] = []): Y.Doc {
   const doc = new Y.Doc()
@@ -156,8 +166,12 @@ describe('crdt writeback', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
     vi.clearAllMocks()
+    // Module-level and keyed per note; the fixed fake clock means a second test
+    // reusing a note id would otherwise land inside the first one's window.
+    resetTelemetryThrottle()
     mocks.sent = []
     mocks.yDocToMarkdown.mockResolvedValue('updated markdown')
+    mocks.findUnrepresentableNodes.mockReturnValue([])
     mocks.getNoteCacheById.mockReturnValue({
       id: 'note-1',
       path: 'notes/Existing.md',
@@ -256,6 +270,65 @@ describe('crdt writeback', () => {
       performedCount: 1,
       lastMarkdown: 'updated markdown'
     })
+  })
+
+  it('keeps the file and reports when the doc holds a node the schema cannot represent', async () => {
+    // #given the live doc carries an inline node this build has no spec for
+    mocks.findUnrepresentableNodes.mockReturnValue(['wikiLink'])
+
+    // #when
+    scheduleWriteback('note-1', makeDoc('Yjs title'))
+    await vi.advanceTimersByTimeAsync(500)
+
+    // #then the vault file is left exactly as the user last saw it — a lossy
+    // serialization written here would be the permanent copy
+    expect(mocks.atomicWrite).not.toHaveBeenCalled()
+    expect(mocks.yDocToMarkdown).not.toHaveBeenCalled()
+    expect(mocks.maybeCreateSignificantSnapshot).not.toHaveBeenCalled()
+    expect(mocks.syncNoteToCache).not.toHaveBeenCalled()
+    expect(mocks.trackMainLog).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({
+        scope: 'CrdtWriteback',
+        action: 'writeback_unrepresentable_node',
+        errorCode: 'wikiLink'
+      })
+    )
+  })
+
+  it('resumes writing back once the doc is representable again', async () => {
+    // #given a pass that was refused
+    mocks.findUnrepresentableNodes.mockReturnValue(['wikiLink'])
+    scheduleWriteback('note-1', makeDoc('Yjs title'))
+    await vi.advanceTimersByTimeAsync(500)
+    expect(mocks.atomicWrite).not.toHaveBeenCalled()
+
+    // #when the next edit leaves nothing unrepresentable
+    mocks.findUnrepresentableNodes.mockReturnValue([])
+    scheduleWriteback('note-1', makeDoc('Later title'))
+    await vi.advanceTimersByTimeAsync(500)
+
+    // #then the refusal did not latch — the note writes normally
+    expect(mocks.atomicWrite).toHaveBeenCalledWith(
+      '/vault/notes/Existing.md',
+      expect.stringContaining('updated markdown')
+    )
+  })
+
+  it('reports and keeps the stale file when conversion returns null', async () => {
+    // #given the serializer failed outright
+    mocks.yDocToMarkdown.mockResolvedValue(null)
+
+    // #when
+    scheduleWriteback('note-1', makeDoc('Yjs title'))
+    await vi.advanceTimersByTimeAsync(500)
+
+    // #then
+    expect(mocks.atomicWrite).not.toHaveBeenCalled()
+    expect(mocks.trackMainLog).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({ scope: 'CrdtWriteback', action: 'conversion_null' })
+    )
   })
 
   it('keeps no debug state (and no note markdown) outside test mode', async () => {

--- a/apps/desktop/src/main/sync/crdt-writeback.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.ts
@@ -3,7 +3,7 @@ import { createLogger } from '../lib/logger'
 import { trackMainError, trackMainLog } from '../telemetry/diagnostics'
 import { shouldEmitThrottled } from '../telemetry/throttle'
 import { getCrdtProvider } from './crdt-provider'
-import { yDocToMarkdown } from './blocknote-converter'
+import { findUnrepresentableNodes, yDocToMarkdown } from './blocknote-converter'
 import { emitNoteUpdated } from './note-events'
 import { readCriticMarkupMarksFromYDoc, serializeCriticMarkup } from '@memry/shared'
 import { utcNow } from '@memry/shared/utc'
@@ -398,6 +398,32 @@ function resolveFromCanonicalMetadata(
 }
 
 async function performWriteback(noteId: string, doc: Y.Doc): Promise<void> {
+  // Fail closed. If the doc holds a node type this build has no schema spec
+  // for, every serialization of it is missing that node — writing the result
+  // would make the loss the file's permanent content, and the next index pass
+  // would push it to every other device. Keeping the file costs the user a
+  // stale body until a build that knows the type runs; writing costs them the
+  // content. Checked before serializing, since the answer decides nothing else.
+  const unrepresentable = findUnrepresentableNodes(doc)
+  if (unrepresentable.length > 0) {
+    updateDebugState(noteId, {
+      pending: false,
+      lastError: `unrepresentable: ${unrepresentable.join(',')}`
+    })
+    log.error('Doc holds node types this build cannot serialize, keeping the file', {
+      noteId,
+      nodes: unrepresentable
+    })
+    if (shouldEmitThrottled(`writeback_unrepresentable:${noteId}`)) {
+      trackMainLog('error', {
+        scope: 'CrdtWriteback',
+        action: 'writeback_unrepresentable_node',
+        errorCode: unrepresentable.join(',')
+      })
+    }
+    return
+  }
+
   const plainMarkdown = await yDocToMarkdown(doc)
   const markdown =
     plainMarkdown === null

--- a/apps/desktop/src/renderer/src/components/note/content-area/date-mention.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/date-mention.tsx
@@ -1,7 +1,6 @@
-import { createInlineContentSpec } from '@blocknote/core'
+import { createDateMentionSpec } from '@memry/editor-schema/inline'
 import { isSameWeek, addWeeks, subWeeks } from 'date-fns'
 import {
-  serializeDateMentionToken,
   type DateMentionData,
   type DateMentionDateFormat,
   type DateMentionTimeFormat,
@@ -150,61 +149,18 @@ export function createDateMentionContent(data: DateMentionData) {
   }
 }
 
-export const DateMention = createInlineContentSpec(
-  {
-    type: 'dateMention',
-    propSchema: {
-      anchorId: { default: '' },
-      dateISO: { default: '' },
-      hasTime: { default: false },
-      dateFormat: { default: 'relative' },
-      remind: { default: 'none' },
-      timeFormat: { default: 'system' }
-    },
-    content: 'none'
-  },
-  {
-    render: (inlineContent) => {
-      const { anchorId, dateISO, hasTime, dateFormat, remind, timeFormat } = inlineContent.props
-      const dom = createDateMentionPillDom({
-        anchorId,
-        dateISO,
-        hasTime,
-        dateFormat: dateFormat as DateMentionDateFormat,
-        remind: remind as RemindOffset,
-        timeFormat: timeFormat as DateMentionTimeFormat
-      })
-      return { dom }
-    },
-
-    parse: (element) => {
-      if (!element.hasAttribute('data-date-mention')) return undefined
-      const anchorId = element.getAttribute('data-anchor-id') || ''
-      const dateISO = element.getAttribute('data-date-iso') || ''
-      if (!anchorId || !dateISO) return undefined
-      return {
-        anchorId,
-        dateISO,
-        hasTime: element.getAttribute('data-has-time') === 'true',
-        dateFormat: (element.getAttribute('data-date-format') ||
-          'relative') as DateMentionDateFormat,
-        remind: (element.getAttribute('data-remind') || 'none') as RemindOffset,
-        timeFormat: (element.getAttribute('data-time-format') || 'system') as DateMentionTimeFormat
-      }
-    },
-
-    toExternalHTML: (inlineContent) => {
-      const { anchorId, dateISO, hasTime, dateFormat, remind, timeFormat } = inlineContent.props
-      const dom = document.createElement('span')
-      dom.textContent = serializeDateMentionToken({
-        anchorId,
-        dateISO,
-        hasTime,
-        dateFormat: dateFormat as DateMentionDateFormat,
-        remind: remind as RemindOffset,
-        timeFormat: timeFormat as DateMentionTimeFormat
-      })
-      return { dom }
-    }
-  }
-)
+// Presentation only — the pill formats against the user's week-start and clock
+// settings, which are renderer state. The config, `parse` and `toExternalHTML`
+// live in @memry/editor-schema so the main process registers the same node.
+export const DateMention = createDateMentionSpec((inlineContent) => {
+  const { anchorId, dateISO, hasTime, dateFormat, remind, timeFormat } = inlineContent.props
+  const dom = createDateMentionPillDom({
+    anchorId,
+    dateISO,
+    hasTime,
+    dateFormat: dateFormat as DateMentionDateFormat,
+    remind: remind as RemindOffset,
+    timeFormat: timeFormat as DateMentionTimeFormat
+  })
+  return { dom }
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts
@@ -1,35 +1,30 @@
-import {
-  BlockNoteSchema,
-  defaultInlineContentSpecs,
-  defaultBlockSpecs,
-  createCodeBlockSpec
-} from '@blocknote/core'
-import { codeBlockOptions } from '@blocknote/code-block'
+import { defaultBlockSpecs } from '@blocknote/core'
+import { createMemrySchema } from '@memry/editor-schema'
 import { createFileBlock } from './file-block'
 import { createCalloutBlock } from './callout-block'
 import { createYoutubeEmbedBlock } from './youtube-embed-block'
 import { createBookmarkBlock } from './bookmark-block'
 import { createTaskBlock } from './task-block'
-import { WikiLink } from './wiki-link'
 import { HashTag } from './hash-tag'
-import { LinkMention } from './link-mention'
 import { DateMention } from './date-mention'
 
-export const editorSchema = BlockNoteSchema.create({
-  blockSpecs: {
+// Built through the shared factory so the main process gets a schema with the
+// same node types. Main converts the shared Y.Doc through y-prosemirror, which
+// DELETES any element its schema cannot build — a spec registered on one side
+// only replicates as data loss, not as a missing style. The inline specs come
+// from the factory; only the two whose presentation needs renderer state
+// (tag palette, clock/week-start settings) are passed in.
+export const editorSchema = createMemrySchema({
+  blocks: {
     ...defaultBlockSpecs,
-    codeBlock: createCodeBlockSpec(codeBlockOptions),
     file: createFileBlock(),
     callout: createCalloutBlock(),
     youtubeEmbed: createYoutubeEmbedBlock(),
     bookmark: createBookmarkBlock(),
     taskBlock: createTaskBlock()
   },
-  inlineContentSpecs: {
-    ...defaultInlineContentSpecs,
-    wikiLink: WikiLink,
+  inline: {
     hashTag: HashTag,
-    linkMention: LinkMention,
     dateMention: DateMention
   }
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts
@@ -1,4 +1,3 @@
-import { defaultBlockSpecs } from '@blocknote/core'
 import { createMemrySchema } from '@memry/editor-schema'
 import { createFileBlock } from './file-block'
 import { createCalloutBlock } from './callout-block'
@@ -15,8 +14,10 @@ import { DateMention } from './date-mention'
 // from the factory; only the two whose presentation needs renderer state
 // (tag palette, clock/week-start settings) are passed in.
 export const editorSchema = createMemrySchema({
+  // No `...defaultBlockSpecs` here: the factory already spreads them, and
+  // respreading them after it would put BlockNote's plain `codeBlock` back over
+  // the syntax-highlighting one the factory installs. Pass overrides only.
   blocks: {
-    ...defaultBlockSpecs,
     file: createFileBlock(),
     callout: createCalloutBlock(),
     youtubeEmbed: createYoutubeEmbedBlock(),

--- a/apps/desktop/src/renderer/src/components/note/content-area/hash-tag.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hash-tag.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { createInlineContentSpec, type Block } from '@blocknote/core'
+import { type Block } from '@blocknote/core'
+import { createHashTagSpec } from '@memry/editor-schema/inline'
 import { getTagColors, withAlpha } from '@/components/note/tags-row/tag-colors'
 import { isIconValue, parseIconName } from '@/components/note/note-title/emoji-icon-utils'
 import { loadAllIcons } from '@/lib/hugeicon-renderer'
@@ -60,65 +61,39 @@ function prependTagIcon(dom: HTMLElement, iconValue: string, colorHex: string): 
   }
 }
 
-export const HashTag = createInlineContentSpec(
-  {
-    type: 'hashTag' as const,
-    propSchema: {
-      tag: { default: '' },
-      color: { default: '' },
-      icon: { default: '' }
-    },
-    content: 'none'
-  },
-  {
-    render: (inlineContent) => {
-      const tag = inlineContent.props.tag || ''
-      const colorName = inlineContent.props.color || ''
-      const icon = inlineContent.props.icon || ''
-      const colors = getTagColors(colorName, tag)
+// Presentation only. The config, `parse` and `toExternalHTML` — everything that
+// decides what reaches the vault file — live in @memry/editor-schema, so the
+// main process registers the identical node instead of deleting it.
+export const HashTag = createHashTagSpec((inlineContent) => {
+  const tag = inlineContent.props.tag || ''
+  const colorName = inlineContent.props.color || ''
+  const icon = inlineContent.props.icon || ''
+  const colors = getTagColors(colorName, tag)
 
-      const dom = document.createElement('span')
-      dom.className = 'inline-hash-tag'
-      dom.setAttribute('data-hash-tag', tag)
-      dom.setAttribute('data-hash-tag-color', colorName)
-      if (icon) dom.setAttribute('data-hash-tag-icon', icon)
-      dom.setAttribute('contenteditable', 'false')
-      dom.textContent = `#${tag}`
-      if (icon) prependTagIcon(dom, icon, colors.text)
+  const dom = document.createElement('span')
+  dom.className = 'inline-hash-tag'
+  dom.setAttribute('data-hash-tag', tag)
+  dom.setAttribute('data-hash-tag-color', colorName)
+  if (icon) dom.setAttribute('data-hash-tag-icon', icon)
+  dom.setAttribute('contenteditable', 'false')
+  dom.textContent = `#${tag}`
+  if (icon) prependTagIcon(dom, icon, colors.text)
 
-      dom.style.backgroundColor = withAlpha(colors.text, 0.12)
-      dom.style.setProperty('--hash-tag-color', colors.text)
-      dom.style.padding = '1px 8px'
-      dom.style.borderRadius = '10px'
-      dom.style.fontSize = '0.9em'
-      dom.style.fontWeight = '500'
-      dom.style.cursor = 'pointer'
-      dom.style.whiteSpace = 'nowrap'
-      dom.style.display = 'inline'
-      dom.style.margin = '0 1px'
-      dom.style.userSelect = 'none'
-      dom.style.transition = 'opacity 150ms ease'
+  dom.style.backgroundColor = withAlpha(colors.text, 0.12)
+  dom.style.setProperty('--hash-tag-color', colors.text)
+  dom.style.padding = '1px 8px'
+  dom.style.borderRadius = '10px'
+  dom.style.fontSize = '0.9em'
+  dom.style.fontWeight = '500'
+  dom.style.cursor = 'pointer'
+  dom.style.whiteSpace = 'nowrap'
+  dom.style.display = 'inline'
+  dom.style.margin = '0 1px'
+  dom.style.userSelect = 'none'
+  dom.style.transition = 'opacity 150ms ease'
 
-      return { dom }
-    },
-    parse: (element) => {
-      if (element.hasAttribute('data-hash-tag')) {
-        const tag = element.getAttribute('data-hash-tag')?.trim() || ''
-        if (tag) {
-          const color = element.getAttribute('data-hash-tag-color')?.trim() || ''
-          const icon = element.getAttribute('data-hash-tag-icon')?.trim() || ''
-          return { tag, color, icon }
-        }
-      }
-      return undefined
-    },
-    toExternalHTML: (inlineContent) => {
-      const dom = document.createElement('span')
-      dom.textContent = `#${inlineContent.props.tag || ''}`
-      return { dom }
-    }
-  }
-)
+  return { dom }
+})
 
 // =============================================================================
 // HASH TAG TEXT SPLITTING (for normalization on load)

--- a/apps/desktop/src/renderer/src/components/note/content-area/link-mention.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/link-mention.ts
@@ -1,120 +1,15 @@
-import { createInlineContentSpec } from '@blocknote/core'
-
 /**
- * Markdown persistence token for link mentions. A mention is serialized to
- * literal text `((mention:<encodeURIComponent(url)>))` so it survives the
- * markdown round-trip as a single text node (a raw URL would be GFM
- * auto-linkified and fragmented; an <a> would be claimed by BlockNote's
- * built-in link mark). Reconstructed on load by normalizeLinkMentions.
+ * LinkMention inline content spec for BlockNote.
+ *
+ * The spec and its markdown token live in @memry/editor-schema so the main
+ * process registers the identical node. See wiki-link.tsx for why.
  */
-export const MENTION_TOKEN_REGEX = /\(\(mention:([^)\s]+)\)\)/g
 
-export function serializeLinkMentionToken(url: string): string {
-  // encodeURIComponent leaves `(` and `)` raw, which would break the `))`
-  // delimiter for URLs containing parens — escape them explicitly.
-  const encoded = encodeURIComponent(url).replace(/\(/g, '%28').replace(/\)/g, '%29')
-  return `((mention:${encoded}))`
-}
-
-export function parseLinkMentionToken(encoded: string): string | null {
-  try {
-    const url = decodeURIComponent(encoded)
-    return url || null
-  } catch {
-    return null
-  }
-}
-
-export function createLinkMentionContent(
-  url: string,
-  domain: string,
-  title?: string,
-  favicon?: string,
-  siteName?: string
-) {
-  return {
-    type: 'linkMention' as const,
-    props: { url, domain, title: title ?? '', favicon: favicon ?? '', siteName: siteName ?? '' }
-  }
-}
-
-export const LinkMention = createInlineContentSpec(
-  {
-    type: 'linkMention',
-    propSchema: {
-      url: { default: '' },
-      domain: { default: '' },
-      title: { default: '' },
-      favicon: { default: '' },
-      siteName: { default: '' }
-    },
-    content: 'none'
-  },
-  {
-    render: (inlineContent) => {
-      const { url, domain, title, favicon, siteName } = inlineContent.props
-      const siteLabel = siteName || domain || url
-
-      const dom = document.createElement('a')
-      dom.className = 'link-mention'
-      dom.href = url
-      dom.target = '_blank'
-      dom.rel = 'noopener noreferrer'
-      dom.setAttribute('data-link-mention', '')
-      dom.setAttribute('data-url', url)
-      dom.setAttribute('data-domain', domain)
-      dom.setAttribute('data-title', title)
-      dom.setAttribute('data-favicon', favicon)
-      dom.setAttribute('data-site-name', siteName)
-      dom.setAttribute('contenteditable', 'false')
-
-      if (favicon) {
-        const img = document.createElement('img')
-        img.className = 'link-mention-favicon'
-        img.src = favicon
-        img.alt = ''
-        img.onerror = () => {
-          img.style.display = 'none'
-        }
-        dom.appendChild(img)
-      }
-
-      const siteSpan = document.createElement('span')
-      siteSpan.className = 'link-mention-site'
-      siteSpan.textContent = siteLabel
-      dom.appendChild(siteSpan)
-
-      if (title) {
-        const titleSpan = document.createElement('span')
-        titleSpan.className = 'link-mention-title'
-        titleSpan.textContent = title
-        dom.appendChild(titleSpan)
-      }
-
-      return { dom }
-    },
-
-    parse: (element) => {
-      if (element.hasAttribute('data-link-mention')) {
-        const url = element.getAttribute('data-url') || ''
-        const domain = element.getAttribute('data-domain') || ''
-        const title = element.getAttribute('data-title') || ''
-        const favicon = element.getAttribute('data-favicon') || ''
-        const siteName = element.getAttribute('data-site-name') || ''
-        if (!url) return undefined
-        return { url, domain, title, favicon, siteName }
-      }
-
-      return undefined
-    },
-
-    toExternalHTML: (inlineContent) => {
-      // Emit the markdown persistence token as plain text (not an <a>, which
-      // BlockNote's link mark would reclaim on reload). normalizeLinkMentions
-      // rebuilds the rich inline content from this token on load.
-      const dom = document.createElement('span')
-      dom.textContent = serializeLinkMentionToken(inlineContent.props.url)
-      return { dom }
-    }
-  }
-)
+export {
+  LinkMention,
+  linkMentionConfig,
+  MENTION_TOKEN_REGEX,
+  serializeLinkMentionToken,
+  parseLinkMentionToken,
+  createLinkMentionContent
+} from '@memry/editor-schema/inline'

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link.tsx
@@ -1,77 +1,18 @@
 /**
  * WikiLink inline content spec for BlockNote.
+ *
+ * The spec itself lives in @memry/editor-schema so the main process registers
+ * the identical node — a spec only one process knows is data loss, not a
+ * rendering gap (y-prosemirror deletes elements it cannot build). Re-exported
+ * here because the editor's menus, hover cards and normalizers import it from
+ * this path.
  */
 
-import { createInlineContentSpec } from '@blocknote/core'
-
-const WIKI_LINK_FULL_PATTERN = /^\[\[([^\]|]+)(?:\|([^\]]+))?\]\]$/
-
-export interface WikiLinkParts {
-  target: string
-  alias: string
-}
-
-export function parseWikiLinkText(text: string): WikiLinkParts | null {
-  const match = text.trim().match(WIKI_LINK_FULL_PATTERN)
-  if (!match) return null
-
-  const target = match[1]?.trim()
-  const alias = match[2]?.trim() ?? ''
-
-  if (!target) return null
-  return { target, alias }
-}
-
-export function createWikiLinkInlineContent(target: string, alias: string) {
-  return {
-    type: 'wikiLink',
-    props: { target, alias: alias ?? '' }
-  }
-}
-
-export const WikiLink = createInlineContentSpec(
-  {
-    type: 'wikiLink',
-    propSchema: {
-      target: { default: '' },
-      alias: { default: '' }
-    },
-    content: 'none'
-  },
-  {
-    render: (inlineContent) => {
-      const dom = document.createElement('span')
-      dom.className = 'wiki-link'
-      dom.setAttribute('data-wiki-link', '')
-      dom.setAttribute('data-target', inlineContent.props.target || '')
-      dom.setAttribute('data-alias', inlineContent.props.alias || '')
-      dom.setAttribute('title', inlineContent.props.target || '')
-      dom.setAttribute('contenteditable', 'false')
-      dom.textContent = inlineContent.props.alias || inlineContent.props.target || ''
-
-      return { dom }
-    },
-    parse: (element) => {
-      if (element.hasAttribute('data-wiki-link') || element.hasAttribute('data-target')) {
-        const target = element.getAttribute('data-target')?.trim() || ''
-        const alias = element.getAttribute('data-alias')?.trim() || ''
-        if (target) {
-          return { target, alias }
-        }
-      }
-
-      const parsed = parseWikiLinkText(element.textContent ?? '')
-      if (!parsed) return undefined
-      return { target: parsed.target, alias: parsed.alias }
-    },
-    toExternalHTML: (inlineContent) => {
-      const target = inlineContent.props.target || ''
-      const alias = inlineContent.props.alias || ''
-      const text = alias && alias !== target ? `[[${target}|${alias}]]` : `[[${target}]]`
-
-      const dom = document.createElement('span')
-      dom.textContent = text
-      return { dom }
-    }
-  }
-)
+export {
+  WikiLink,
+  wikiLinkConfig,
+  wikiLinkToText,
+  parseWikiLinkText,
+  createWikiLinkInlineContent,
+  type WikiLinkParts
+} from '@memry/editor-schema/inline'

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -172,6 +172,17 @@ document to its vault `.md` file and re-indexes it for search.
   `CrdtProvider.destroy()` clears the maps outright, so no vault's note ids or file paths
   survive into the next one.
 
+- **The export path cannot write** — a pass serializes from a detached copy of the Y.Doc,
+  never the live one. The BlockNote/Yjs converter answers a node type its schema cannot
+  build by _deleting_ that element; run against the live doc that turns a serialization
+  gap into a real CRDT delete which replicates to every device. Reading from a copy keeps
+  any such repair inside a throwaway document.
+- **Write-back fails closed** — before serializing, the pass scans the fragment for node
+  types this build's schema cannot construct. If it finds any, the `.md` file is left
+  exactly as it is and the pass reports `writeback_unrepresentable_node` rather than
+  writing a version with that content missing. The note resumes normal write-back as soon
+  as the document no longer holds such a node; the refusal does not latch.
+
 While a write-back is queued or mid-write the `.md` file is knowingly behind the Y.Doc, so
 markdown-as-truth readers (task checkbox reconciliation) stand down for that window. Search
 results and the file on disk catch up when the pass runs.
@@ -285,6 +296,23 @@ BlockNote uses Yjs natively. The renderer's BlockNote editor binds to the render
 
 Markdown cannot represent arbitrary nested BlockNote paragraphs. Note markdown export and CRDT writeback preserve those unsupported child blocks with hidden nesting markers, then restore them when a note reloads. Inbox note reload also reads BlockNote's saved `data-nesting-level` HTML metadata so captured note indentation round-trips through the editor.
 Marker parsing trims imported markdown with a linear scan so malformed or very large note bodies cannot trigger regex backtracking during reload.
+
+### The schema is a cross-process contract
+
+The custom node types memrynote adds to BlockNote — wiki links, hash tags, link and date
+mentions, and the custom blocks — live in the `@memry/editor-schema` workspace package so
+both processes can build from one definition. This matters more than a shared-code tidy-up:
+the main process converts the shared Y.Doc through y-prosemirror, which deletes any element
+whose node name its schema does not know. A spec registered on only one side is data loss,
+not a missing style — the same class of cross-process contract that [IPC](/architecture/ipc)
+gates with `ipc:check`.
+
+Specs whose rendering is portable are shared whole. Those whose rendering needs renderer
+state — `hashTag` (tag palette, icons) and `dateMention` (clock format, week start) — share
+their config, `parse` and `toExternalHTML`, the half that decides what reaches the vault
+file, while each process supplies its own presentation. Until both processes build from the
+package, the fail-closed guard in [Markdown Write-Back](#markdown-write-back) is what keeps
+an unknown node type from costing content.
 
 ## Files Worth Knowing
 

--- a/apps/docs/src/user-guide/sync/conflict-health.md
+++ b/apps/docs/src/user-guide/sync/conflict-health.md
@@ -113,6 +113,19 @@ There is no undo for an auto-resolved conflict, and no conflict log to read back
 
 A side-by-side compare with **Keep mine** / **Keep remote** does not exist in memrynote. If you want one, that is a feature request, not a setting you have missed.
 
+## A Note That Stops Updating Its File
+
+memrynote will pause writing a note's `.md` file rather than write a copy with content
+missing from it. If the note's document contains something this app version cannot
+represent — most often a newer note type opened on an older build — the file is left
+exactly as it was and the app records the reason.
+
+What you see: the note is correct in the editor and on every synced device, but its file on
+disk stops changing.
+
+What to do: update memrynote on that device. The note writes its file again on the next
+edit, with nothing lost — the pause is what protected the content.
+
 ## What memrynote Won't Do
 
 memrynote doesn't auto-merge **across record types** — e.g. it won't combine two competing project structures. The vector clock comparison stays within a single record.

--- a/docs/superpowers/plans/2026-08-13-editor-schema-contract.md
+++ b/docs/superpowers/plans/2026-08-13-editor-schema-contract.md
@@ -1,0 +1,629 @@
+# Editor Schema as a Cross-Process Contract — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make it structurally impossible for the main process to destroy a document node type that the renderer can produce.
+
+**Architecture:** One BlockNote schema, defined once in a new `@memry/editor-schema` workspace package and built by both processes through a single factory. The renderer supplies React presentation; the main process gets headless serialization-only implementations generated from the _same_ configs. Independently, the CRDT→markdown export path stops operating on the live `Y.Doc` and stops writing the vault file when it cannot represent the document.
+
+**Tech Stack:** TypeScript, `@blocknote/core` 0.47.1 (+ `@blocknote/react`, `@blocknote/server-util`), Yjs / y-prosemirror 1.3.7, Vitest, pnpm workspaces.
+
+**Spec:** This document (the incident analysis below is the spec). Epic: see the GitHub epic that links this plan.
+
+---
+
+## The incident this exists to prevent
+
+Opening a note containing `[[Wiki Link]]` on a sync-enabled device destroyed the link — in the editor, in the vault markdown, and on every other device.
+
+1. `apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts:28-34` registers custom **inline content specs**: `wikiLink`, `hashTag`, `linkMention`, `dateMention`.
+2. `apps/desktop/src/main/sync/blocknote-converter.ts:77-83` (`serverSchema`) registers **no `inlineContentSpecs` at all**, and only `taskBlock` of the five custom block specs.
+3. In collab mode `use-editor-sync.ts:318` runs `normalizeWikiLinks` on every change, so `[[X]]` becomes a `wikiLink` node inside the shared `Y.Doc`.
+4. Write-back (`crdt-writeback.ts:401`) calls `yDocToMarkdown(doc)` **on the live doc** → `@blocknote/core/yjs` → y-prosemirror `createNodeFromYElement` → `schema.node('wikiLink', …)` throws.
+5. y-prosemirror's catch is a destructive repair: `el._item.delete(transaction)` (`y-prosemirror@1.3.7/dist/y-prosemirror.cjs:878-885`). The node is deleted **from the shared doc**, producing a real CRDT delete that replicates everywhere; the markdown is then serialized from the already-mutated doc and written over the vault file.
+
+Only sync users are affected: `ContentArea.tsx:1391-1396` gates collaboration on `isCollaborationActive(state.status)`, and the renderer's own save path knows `wikiLink` (its `toExternalHTML` re-emits `[[target|alias]]`).
+
+**Node types main can currently destroy** (present in the renderer schema, absent from `serverSchema`):
+
+| Kind             | Types                                                                                                                                                |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Inline content   | `wikiLink`, `hashTag`, `linkMention`, `dateMention`                                                                                                  |
+| Blocks           | `callout`, `youtubeEmbed`, `bookmark`                                                                                                                |
+| Props-only drift | `file` — renderer overrides the default `file` spec, main uses BlockNote's default, so renderer-only props are dropped rather than the block deleted |
+
+`taskBlock` is already hand-mirrored in `blocknote-converter.ts:52-97`, whose own comment says the propSchema "must stay identical to the renderer's" — i.e. this class of bug already happened once and was patched per-instance.
+
+## Global Constraints
+
+- **Live beta, backward compatibility mandatory.** No vault format change, no DB migration, no sync protocol change. Every change must be correct for notes written by older app versions and for docs already in the CRDT store.
+- **No behaviour change to markdown output** except restoring content that is currently being dropped. Write-back is byte-compared (`crdt-writeback.ts:469`); a serialization change that alters bytes rewrites every note in every vault on next open.
+- **`@memry/shared` stays dependency-free.** It types blocks structurally on purpose (`packages/shared/src/task-block.ts:4`). The new package is where `@blocknote/core` may be depended on.
+- **Main process has no React.** Everything main imports must run under Node + jsdom (`@blocknote/server-util`); block _presentation_ stays in the renderer.
+- Renderer↔main schema parity is a contract like IPC: it needs a test gate, not a comment.
+- Architecture boundaries: main must not import from `apps/desktop/src/renderer/**` (`pnpm check:architecture`).
+- Adding a workspace package touches the lockfile — expect renderer suite churn; run the full desktop suite, not a filtered one.
+
+## File Structure
+
+**Create — `packages/editor-schema/`**
+
+| File                         | Responsibility                                                                                                                            |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `package.json`               | `@memry/editor-schema`, private, `exports` per entry point, dependency on `@blocknote/core` + `@blocknote/code-block`                     |
+| `tsconfig.json`              | mirrors `packages/shared/tsconfig.json`                                                                                                   |
+| `src/inline/wiki-link.ts`    | `wikiLink` spec — config + DOM render/parse/`toExternalHTML` (moved verbatim from the renderer)                                           |
+| `src/inline/hash-tag.ts`     | `hashTag` spec (spec only; the tag-colour normalization stays in the renderer)                                                            |
+| `src/inline/link-mention.ts` | `linkMention` spec                                                                                                                        |
+| `src/inline/date-mention.ts` | `dateMention` spec                                                                                                                        |
+| `src/inline/index.ts`        | `memryInlineContentSpecs` — the four, ready to spread                                                                                     |
+| `src/blocks/configs.ts`      | `calloutConfig`, `fileConfig`, `youtubeEmbedConfig`, `bookmarkConfig`, `taskBlockConfig` — type + propSchema + content only, no rendering |
+| `src/blocks/server-specs.ts` | `createServerBlockSpecs()` — headless `createBlockSpec(config, { render: throws, toExternalHTML })` per config                            |
+| `src/schema.ts`              | `createMemrySchema(blockImplementations)` — the single factory both processes call                                                        |
+| `src/index.ts`               | re-exports                                                                                                                                |
+| `src/schema.test.ts`         | parity test: renderer-shaped schema vs server-shaped schema have identical node names and propSchemas                                     |
+
+**Modify**
+
+| File                                                                                                                                 | Change                                                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/desktop/src/main/sync/blocknote-converter.ts:52-97`                                                                            | drop the hand-mirrored `createServerTaskBlock` and the local `BlockNoteSchema.create`; build via `createMemrySchema(createServerBlockSpecs())` |
+| `apps/desktop/src/main/sync/blocknote-converter.ts:99-113`                                                                           | `yDocToMarkdown` converts a snapshot copy, never the live doc                                                                                  |
+| `apps/desktop/src/main/sync/crdt-writeback.ts:400-420`                                                                               | fail closed on unrepresentable content                                                                                                         |
+| `apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts`                                                        | build via `createMemrySchema({ …React block impls })`; import inline specs from the package                                                    |
+| `apps/desktop/src/renderer/src/components/note/content-area/{wiki-link,hash-tag,link-mention,date-mention}.ts(x)`                    | keep renderer-only helpers, re-export the spec from the package                                                                                |
+| `apps/desktop/src/renderer/src/components/note/content-area/{callout,file,youtube-embed,bookmark}-block.tsx`, `task-block/index.tsx` | take their config from the package instead of declaring it inline                                                                              |
+
+---
+
+### Task 1: Export path must never mutate the live doc
+
+**Files:**
+
+- Modify: `apps/desktop/src/main/sync/blocknote-converter.ts:99-113`
+- Test: `apps/desktop/src/main/sync/blocknote-converter.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing
+- Produces: `yDocToMarkdown(doc: Y.Doc, fragmentName?: string): Promise<string | null>` — unchanged signature, now guaranteed side-effect-free on `doc`
+
+- [x] **Step 1: Write the failing test**
+
+```ts
+it('never mutates the live doc, even for a node type the schema does not know', async () => {
+  const doc = new Y.Doc()
+  const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+  // A block containing an inline node the server schema cannot build.
+  const block = new Y.XmlElement('blockContainer')
+  block.setAttribute('id', 'b1')
+  const para = new Y.XmlElement('paragraph')
+  const unknown = new Y.XmlElement('wikiLink')
+  unknown.setAttribute('target', 'Roadmap')
+  para.insert(0, [unknown])
+  block.insert(0, [para])
+  fragment.insert(0, [block])
+
+  const before = Y.encodeStateAsUpdate(doc)
+  await yDocToMarkdown(doc)
+
+  expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+})
+```
+
+- [x] **Step 2: Run it and watch it fail**
+
+Run: `pnpm --filter @memry/desktop test:main -- blocknote-converter`
+Expected: FAIL — the encoded state differs, because y-prosemirror deleted the `wikiLink` item.
+
+- [x] **Step 3: Convert on a snapshot copy**
+
+```ts
+export async function yDocToMarkdown(
+  doc: Y.Doc,
+  fragmentName = CRDT_FRAGMENT_NAME
+): Promise<string | null> {
+  try {
+    // y-prosemirror's `createNodeFromYElement` DELETES any element it cannot
+    // build (dist/y-prosemirror.cjs:878-885) — a repair heuristic that, run on
+    // the live doc, turns a serialization gap into replicated data loss. Read
+    // from a detached copy so this path can only ever read.
+    const snapshot = new Y.Doc()
+    Y.applyUpdate(snapshot, Y.encodeStateAsUpdate(doc))
+    const editor = getEditor()
+    const blocks = editor.yXmlFragmentToBlocks(snapshot.getXmlFragment(fragmentName))
+    if (blocks.length === 0) return ''
+    return await blocksToMarkdownPreserving(editor, blocks as Block[])
+  } catch (err) {
+    log.error('Yjs-to-markdown conversion failed', err)
+    return null
+  }
+}
+```
+
+- [x] **Step 4: Run the test again**
+
+Run: `pnpm --filter @memry/desktop test:main -- blocknote-converter`
+Expected: PASS.
+
+- [x] **Step 5: Guard the cost**
+
+The copy is one `encodeStateAsUpdate` + `applyUpdate` per write-back pass. Write-back is already paced by its own cost (`WRITEBACK_COOLDOWN_FACTOR`), so measure a 49KB note before/after and record the delta in the PR body. If it is material, cache the copy per (noteId, stateVector).
+
+**Measured** (38KB markdown / 104KB Y update, Node + jsdom, mean of 10): `yDocToMarkdown` 21.6ms, of which the snapshot copy is 1.79ms (~8%); `findUnrepresentableNodes` 0.11ms. Not material against a 9× cooldown — no caching needed.
+
+- [x] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/main/sync/blocknote-converter.ts apps/desktop/src/main/sync/blocknote-converter.test.ts
+git commit -m "fix(crdt): serialize markdown from a doc snapshot, never the live doc"
+```
+
+---
+
+### Task 2: Fail closed — never overwrite the vault file with a lossy serialization
+
+**Files:**
+
+- Modify: `apps/desktop/src/main/sync/blocknote-converter.ts` (new export), `apps/desktop/src/main/sync/crdt-writeback.ts:400-420`
+- Test: `apps/desktop/src/main/sync/crdt-writeback.test.ts`
+
+**Interfaces:**
+
+- Consumes: `yDocToMarkdown` from Task 1
+- Produces: `findUnrepresentableNodes(doc: Y.Doc, fragmentName?: string): string[]` — node names present in the fragment that the server schema cannot build
+
+- [x] **Step 1: Write the failing test**
+
+```ts
+it('keeps the file and reports when the doc holds a node the schema cannot represent', async () => {
+  const { doc } = seedDocWithUnknownInlineNode('wikiLink')
+  const before = await readFile(notePath, 'utf8')
+
+  await performWritebackForTest('note-1', doc)
+
+  expect(await readFile(notePath, 'utf8')).toBe(before)
+  expect(trackMainLog).toHaveBeenCalledWith(
+    'error',
+    expect.objectContaining({
+      action: 'writeback_unrepresentable_node'
+    })
+  )
+})
+```
+
+- [x] **Step 2: Run it and watch it fail**
+
+Run: `pnpm --filter @memry/desktop test:main -- crdt-writeback`
+Expected: FAIL — the file is rewritten without the node.
+
+- [x] **Step 3: Implement the check**
+
+**Corrected during implementation.** The hand-written set this step originally sketched (blockSchema keys + inlineContentSchema keys + `BLOCK_CONTAINER_NODES` + `blockGroup`) is wrong: PM node names are not block type names. A real fragment also carries `tableRow`, `tableCell`, `tableHeader` and `tableParagraph`, none of which appear in `blockSchema` — the list would flag them and strand every note containing a table. Verified by mutation: swapping the list back in turns the table case RED with `['tableRow','tableHeader','tableCell','tableParagraph']`.
+
+Ask the ProseMirror schema instead — it is the same object `createNodeFromYElement` calls `schema.node(name, …)` on, so it cannot drift from what is actually constructible:
+
+```ts
+export function findUnrepresentableNodes(doc: Y.Doc, fragmentName = CRDT_FRAGMENT_NAME): string[] {
+  try {
+    const known = getEditor().editor.pmSchema.nodes
+    const unknown = new Set<string>()
+    const visit = (node: Y.XmlFragment | Y.XmlElement): void => {
+      for (const child of node.toArray()) {
+        const el = child as Y.XmlElement
+        if (typeof el.nodeName !== 'string') continue
+        if (!(el.nodeName in known)) unknown.add(el.nodeName)
+        visit(el)
+      }
+    }
+    visit(doc.getXmlFragment(fragmentName))
+    return [...unknown]
+  } catch (err) {
+    log.error('Unrepresentable-node scan failed', err)
+    return []
+  }
+}
+```
+
+Marks need no equivalent check today: neither schema passes `styleSpecs`, so both carry exactly the default mark set (`bold`, `italic`, `underline`, `strike`, `code`, `link`, `textColor`, `backgroundColor`, plus the CriticMarkup three). A custom style spec added to the renderer later would reopen this — `createTextNodesFromYText` drops the whole `Y.Text` on an unknown mark.
+
+`trackMainLog` takes no free-form fields, so the node list rides on `errorCode` (sanitized by `toSafeToken`), not a `nodes` key.
+
+In `performWriteback`, before writing:
+
+```ts
+const unrepresentable = findUnrepresentableNodes(doc)
+if (unrepresentable.length > 0) {
+  log.error('Doc holds node types this build cannot serialize; keeping the file', {
+    noteId,
+    nodes: unrepresentable
+  })
+  if (shouldEmitThrottled(`writeback_unrepresentable:${noteId}`)) {
+    trackMainLog('error', {
+      scope: 'CrdtWriteback',
+      action: 'writeback_unrepresentable_node',
+      nodes: unrepresentable.join(',')
+    })
+  }
+  return
+}
+```
+
+- [x] **Step 4: Run the test again**
+
+Run: `pnpm --filter @memry/desktop test:main -- crdt-writeback`
+Expected: PASS.
+
+- [x] **Step 5: Verify the stale-file path is honest**
+
+Confirm the existing `markdown === null` branch (`crdt-writeback.ts:412-420`) still fires its telemetry, and that neither branch clears `pendingTimers` in a way that suppresses the next legitimate write-back. Add an assertion that a subsequent representable edit does write.
+
+- [x] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/main/sync/blocknote-converter.ts apps/desktop/src/main/sync/crdt-writeback.ts apps/desktop/src/main/sync/crdt-writeback.test.ts
+git commit -m "fix(crdt): keep the vault file when write-back cannot represent the doc"
+```
+
+---
+
+### Task 3: Create `@memry/editor-schema` and move the four inline specs into it
+
+**Files:**
+
+- Create: `packages/editor-schema/{package.json,tsconfig.json}`, `packages/editor-schema/src/inline/{wiki-link,hash-tag,link-mention,date-mention,index}.ts`, `packages/editor-schema/src/schema.ts`, `packages/editor-schema/src/index.ts`
+- Modify: `apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts`, and the four renderer spec files (keep helpers, re-export the spec)
+- Test: `packages/editor-schema/src/inline/wiki-link.test.ts` (move the existing renderer spec tests that cover the spec itself)
+
+**Interfaces:**
+
+- Consumes: nothing
+- Produces:
+  - `memryInlineContentSpecs` — `{ wikiLink, hashTag, linkMention, dateMention }`
+  - `createMemrySchema(blockImplementations: Record<'callout'|'file'|'youtubeEmbed'|'bookmark'|'taskBlock', BlockSpec>): BlockNoteSchema`
+
+- [x] **Step 1: Scaffold the package**
+
+`packages/editor-schema/package.json`, mirroring `packages/shared/package.json` but with a real dependency:
+
+```json
+{
+  "name": "@memry/editor-schema",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./inline": "./src/inline/index.ts",
+    "./blocks": "./src/blocks/configs.ts",
+    "./server": "./src/blocks/server-specs.ts"
+  },
+  "types": "./src/index.ts",
+  "scripts": { "typecheck": "tsc --noEmit -p tsconfig.json" },
+  "dependencies": {
+    "@blocknote/core": "0.47.1",
+    "@blocknote/code-block": "*"
+  },
+  "devDependencies": { "@memry/typescript-config": "workspace:*" }
+}
+```
+
+Pin `@blocknote/*` to the exact versions already in `apps/desktop/package.json` — two copies of `@blocknote/core` in one process would produce two different schema identities.
+
+- [x] **Step 2: Move the specs verbatim**
+
+**Corrected during implementation.** They are all `createInlineContentSpec` with vanilla-DOM renders, but only two are _portable_:
+
+| Spec          | `render` imports                                                                                                    | Moves?                                   |
+| ------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `wikiLink`    | none                                                                                                                | whole spec                               |
+| `linkMention` | none                                                                                                                | whole spec                               |
+| `dateMention` | `@/lib/time-format`, `@/lib/week-start`, `date-fns`, module-level `prefClockFormat`                                 | config + `parse` + `toExternalHTML` only |
+| `hashTag`     | `@/components/note/tags-row/tag-colors`, `@/components/note/note-title/emoji-icon-utils`, `@/lib/hugeicon-renderer` | config + `parse` + `toExternalHTML` only |
+
+So inline specs take the same shape the plan already uses for blocks — the package owns the serialization contract, each process supplies presentation:
+
+```ts
+export const hashTagConfig = { type: 'hashTag', propSchema: { … }, content: 'none' } as const
+export const hashTagSerialization = { parse, toExternalHTML }   // both portable
+export const createHashTagSpec = (render) =>
+  createInlineContentSpec(hashTagConfig, { render, ...hashTagSerialization })
+```
+
+`toExternalHTML` is what main actually needs, and it is portable for all four (`dateMention`'s token comes from `@memry/shared/date-mention`, which main already imports). Keep `normalizeWikiLinks`, the suggestion menus, hover cards, `setDateMentionPrefs` and the tag colour map in the renderer.
+
+**Mechanism verified before building any of this** (throwaway spike, since the whole package rests on it): register a server-side `wikiLink` inline spec whose `render` throws and whose `toExternalHTML` emits the `[[…]]` text, then run a doc holding a `wikiLink` node through `yXmlFragmentToBlocks` → `blocksToMarkdownLossy`. Result: the node survives as inline content (`{"type":"wikiLink","props":{"target":"Roadmap","alias":"the plan"}}`), the markdown is `See [[Roadmap|the plan]] tomorrow.`, `render` is never reached, and `Y.encodeStateAsUpdate` is byte-identical before and after. Registering the spec is both necessary and sufficient.
+
+- [x] **Step 3: Write the factory**
+
+```ts
+// packages/editor-schema/src/schema.ts
+export function createMemrySchema(blockImplementations: MemryBlockImplementations) {
+  return BlockNoteSchema.create({
+    blockSpecs: {
+      ...defaultBlockSpecs,
+      codeBlock: createCodeBlockSpec(codeBlockOptions),
+      ...blockImplementations
+    },
+    inlineContentSpecs: {
+      ...defaultInlineContentSpecs,
+      ...memryInlineContentSpecs
+    }
+  })
+}
+```
+
+- [x] **Step 4: Point the renderer at it**
+
+`editor-schema.ts` becomes `createMemrySchema({ file: createFileBlock(), callout: createCalloutBlock(), youtubeEmbed: createYoutubeEmbedBlock(), bookmark: createBookmarkBlock(), taskBlock: createTaskBlock() })`, with the inline specs no longer listed there at all.
+
+- [x] **Step 5: Prove the renderer is unchanged**
+
+Run: `pnpm --filter @memry/desktop test:renderer` and `pnpm --filter @memry/desktop typecheck`
+Expected: PASS with no snapshot churn. Renderer behaviour must be byte-identical; this task is a move, not a change.
+
+- [x] **Step 6: Commit**
+
+```bash
+git add packages/editor-schema apps/desktop/src/renderer/src/components/note/content-area pnpm-lock.yaml
+git commit -m "refactor(editor): extract the shared BlockNote schema into @memry/editor-schema"
+```
+
+---
+
+### Task 4: Main builds its schema from the same factory
+
+**Files:**
+
+- Create: `packages/editor-schema/src/blocks/{configs.ts,server-specs.ts}`
+- Modify: `apps/desktop/src/main/sync/blocknote-converter.ts:52-97`
+- Test: `apps/desktop/src/main/sync/blocknote-converter.test.ts`
+
+**Interfaces:**
+
+- Consumes: `createMemrySchema` (Task 3)
+- Produces: `createServerBlockSpecs(): MemryBlockImplementations` — headless implementations built from the shared configs
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('round-trips a wiki link through the CRDT write path', async () => {
+  const doc = new Y.Doc()
+  await markdownToYFragment(
+    'See [[Roadmap|the plan]] tomorrow.',
+    doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+  )
+  // Simulate the renderer promoting the text to a node.
+  promoteWikiLinksInFragment(doc, CRDT_FRAGMENT_NAME)
+
+  const markdown = await yDocToMarkdown(doc)
+
+  expect(markdown).toContain('[[Roadmap|the plan]]')
+  expect(findUnrepresentableNodes(doc)).toEqual([])
+})
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `pnpm --filter @memry/desktop test:main -- blocknote-converter`
+Expected: FAIL — the link is missing from the markdown.
+
+- [ ] **Step 3: Move the taskBlock config and add headless specs**
+
+```ts
+// packages/editor-schema/src/blocks/server-specs.ts
+const serverImplementation = (config: BlockConfig) => ({
+  render: () => {
+    throw new Error(`${config.type} server spec is serialization-only and must not be rendered`)
+  }
+})
+
+export function createServerBlockSpecs(): MemryBlockImplementations {
+  return {
+    taskBlock: createBlockSpec(taskBlockConfig, serverImplementation(taskBlockConfig))()
+    // callout / file / youtubeEmbed / bookmark land in Task 5
+  }
+}
+```
+
+- [ ] **Step 4: Rewrite `serverSchema`**
+
+```ts
+const serverSchema = createMemrySchema(createServerBlockSpecs())
+```
+
+Delete `createServerTaskBlock` and its comment — the propSchema is now shared, so the warning it carried no longer applies.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `pnpm --filter @memry/desktop test:main -- "blocknote-converter|crdt-writeback|note-fidelity"` then the full `pnpm test:desktop`
+Expected: PASS, and the pre-existing round-trip/byte-stability tests still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/editor-schema apps/desktop/src/main/sync/blocknote-converter.ts apps/desktop/src/main/sync/blocknote-converter.test.ts
+git commit -m "fix(crdt): build the main-process schema from the shared factory"
+```
+
+---
+
+### Task 5: Custom blocks — callout, youtubeEmbed, bookmark, file
+
+**Files:**
+
+- Modify: `packages/editor-schema/src/blocks/{configs.ts,server-specs.ts}`, the four renderer block files, `apps/desktop/src/main/sync/blocknote-converter.ts`
+- Test: `packages/editor-schema/src/blocks/server-specs.test.ts`, `apps/desktop/src/main/sync/blocknote-converter.test.ts`
+
+**Interfaces:**
+
+- Consumes: `createServerBlockSpecs` (Task 4)
+- Produces: the same function, now returning all five implementations
+
+- [ ] **Step 1: Establish each block's markdown form from the current renderer save path**
+
+For each of `callout`, `youtubeEmbed`, `bookmark`, `file`, write down what the renderer writes to disk today (see `file-block-markers.ts`, `@memry/shared/youtube`, and the existing round-trip tests). That output is the contract — the server `toExternalHTML` must reproduce it byte-for-byte, or every note holding one of these blocks gets rewritten on next open.
+
+- [ ] **Step 2: Write the failing round-trip test, one case per block type**
+
+```ts
+it.each(['callout', 'youtubeEmbed', 'bookmark', 'file'])(
+  '%s survives markdown → doc → markdown unchanged',
+  async (type) => {
+    const markdown = fixtureFor(type)
+    const doc = new Y.Doc()
+    await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(await yDocToMarkdown(doc)).toBe(markdown)
+  }
+)
+```
+
+- [ ] **Step 3: Run it and watch it fail**
+
+Run: `pnpm --filter @memry/desktop test:main -- blocknote-converter`
+Expected: FAIL for every case.
+
+- [ ] **Step 4: Move each config into the package and add its server implementation**
+
+One block at a time, each with its own `toExternalHTML`. The renderer keeps `createReactBlockSpec` but takes `type`/`propSchema`/`content` from the shared config, so the two can no longer disagree.
+
+Note `file`: the renderer _overrides_ BlockNote's default `file` spec. Once the config is shared, main stops using the default and stops silently dropping renderer-only props.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `pnpm --filter @memry/desktop test:main` and `pnpm --filter @memry/desktop test:renderer`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/editor-schema apps/desktop/src/renderer/src/components/note/content-area apps/desktop/src/main/sync/blocknote-converter.ts
+git commit -m "fix(crdt): teach the main-process schema the custom block types"
+```
+
+---
+
+### Task 6: The contract gate
+
+**Files:**
+
+- Create: `packages/editor-schema/src/schema.test.ts`
+- Test: also `apps/desktop/src/main/sync/blocknote-converter.test.ts`
+
+**Interfaces:**
+
+- Consumes: `createMemrySchema`, `createServerBlockSpecs`
+- Produces: a failing test the moment a spec exists on one side only
+
+- [ ] **Step 1: Write the parity test**
+
+```ts
+it('renderer and server schemas expose the same node types', () => {
+  const server = createMemrySchema(createServerBlockSpecs())
+  expect(Object.keys(server.blockSchema).sort()).toEqual(
+    Object.keys(rendererLikeSchema.blockSchema).sort()
+  )
+  expect(Object.keys(server.inlineContentSchema).sort()).toEqual(
+    Object.keys(rendererLikeSchema.inlineContentSchema).sort()
+  )
+})
+
+it('shared configs are the single source of propSchemas', () => {
+  for (const type of Object.keys(MEMRY_BLOCK_CONFIGS)) {
+    expect(server.blockSchema[type].propSchema).toEqual(MEMRY_BLOCK_CONFIGS[type].propSchema)
+  }
+})
+```
+
+- [ ] **Step 2: Write the enumerated round-trip test**
+
+Table-driven over every custom type: build a doc holding one, run `yDocToMarkdown`, assert (a) the doc is unchanged, (b) the markdown carries the node's textual form. A new spec with no fixture must fail the test rather than be skipped.
+
+- [ ] **Step 3: Verify the gate actually catches the regression**
+
+Temporarily delete `wikiLink` from `memryInlineContentSpecs`, run the suite, confirm RED, restore. Record the observed failure output in the PR body — a gate nobody has seen fail is not a gate.
+
+- [ ] **Step 4: Wire it into CI**
+
+The package needs to be part of `pnpm test` / `pnpm typecheck` via turbo like `@memry/shared`. Confirm with a deliberate failure that CI reports it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/editor-schema apps/desktop/src/main/sync/blocknote-converter.test.ts turbo.json
+git commit -m "test(editor): gate renderer↔main schema parity"
+```
+
+---
+
+### Task 7: Opening a note must not rewrite it
+
+**Files:**
+
+- Test: `apps/desktop/src/main/sync/note-fidelity-roundtrip.test.ts`, plus an E2E in `apps/desktop/e2e`
+
+**Interfaces:**
+
+- Consumes: everything above
+- Produces: byte-stability coverage for the open→write-back cycle
+
+- [ ] **Step 1: Write the failing test**
+
+Seed a vault note whose markdown contains `[[Wiki Link]]`, a `#hashtag`, a date mention and a callout. Open it with collaboration active, let write-back run, assert the file is byte-identical.
+
+- [ ] **Step 2: Cover the oscillation explicitly**
+
+`use-editor-sync.ts:318` promotes `[[X]]` text to a `wikiLink` node on every change, including in collab mode, while main serializes the node back to text. Assert this converges: two consecutive open→write-back cycles produce identical bytes and no CRDT delete of a wiki link. If it does not converge, the canonical form must be decided in this task and documented in the package README.
+
+- [ ] **Step 3: Run it**
+
+Run: `pnpm --filter @memry/desktop test:main -- note-fidelity` and `pnpm test:e2e`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/desktop/src/main/sync/note-fidelity-roundtrip.test.ts apps/desktop/e2e
+git commit -m "test(notes): opening a note with wiki links is a no-op write-back"
+```
+
+---
+
+### Task 8: Size and repair the damage already done
+
+**Files:**
+
+- Create: a one-off audit script under `apps/desktop/scripts/`
+- Modify: telemetry only; no user-facing UI unless the audit says it is warranted
+
+**Interfaces:**
+
+- Consumes: `findUnrepresentableNodes` (Task 2)
+- Produces: a count of affected notes and a documented recovery path
+
+- [ ] **Step 1: Measure the blast radius**
+
+Notes were losing wiki links, callouts, bookmarks and YouTube embeds on every open, for every sync-enabled device, for as long as the mismatch existed. Establish when each spec was added to the renderer schema (`git log` on `editor-schema.ts`) — that dates the start of each type's loss.
+
+- [ ] **Step 2: Establish what is recoverable**
+
+Two sources: note snapshots created during write-back (`maybeCreateSignificantSnapshot`, `crdt-writeback.ts:476`), and the CRDT update history on the sync server, where the original insert still exists behind a tombstone. Write the audit script against a copy of a real vault, never in place.
+
+- [ ] **Step 3: Decide the user-facing response**
+
+Options, to be decided with Kaan once the count is known: silent repair on next open, a one-time "we found N notes with removed links" review surface, or documentation only. Do not ship a repair that rewrites notes automatically before the count is known.
+
+- [ ] **Step 4: Commit the findings**
+
+Record the numbers in the epic, not only in a commit message.
+
+---
+
+## Self-Review
+
+**Spec coverage:** every node type named in the incident table is covered — inline by Tasks 3–4, blocks by Task 5, `file` props by Task 5 Step 4. The two mechanism-level faults (live-doc mutation, silent lossy overwrite) are Tasks 1–2 and land before any schema work. The drift that caused it is gated by Task 6, the oscillation by Task 7, the existing damage by Task 8.
+
+**Ordering:** Tasks 1 and 2 are independent of the package and must ship first — together they downgrade this class from "permanent replicated data loss" to "a note stops write-back until the app can represent it".
+
+**Type consistency:** `createMemrySchema`, `createServerBlockSpecs`, `memryInlineContentSpecs`, `MEMRY_BLOCK_CONFIGS` and `findUnrepresentableNodes` are used with the same names and signatures in every task that references them.

--- a/packages/editor-schema/package.json
+++ b/packages/editor-schema/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@memry/editor-schema",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./inline": "./src/inline/index.ts",
+    "./blocks": "./src/blocks/configs.ts",
+    "./server": "./src/server.ts"
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@blocknote/code-block": "^0.47.1",
+    "@blocknote/core": "^0.47.1",
+    "@memry/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@memry/typescript-config": "workspace:*"
+  }
+}

--- a/packages/editor-schema/src/index.ts
+++ b/packages/editor-schema/src/index.ts
@@ -1,0 +1,2 @@
+export * from './inline'
+export * from './schema'

--- a/packages/editor-schema/src/inline/date-mention.ts
+++ b/packages/editor-schema/src/inline/date-mention.ts
@@ -1,0 +1,83 @@
+/**
+ * `dateMention` inline content spec — serialization half only.
+ *
+ * The pill's `render` formats relative days against the user's week-start and
+ * clock-format settings, so it stays in the renderer. The token that reaches
+ * the vault file comes from @memry/shared/date-mention, which both processes
+ * already depend on, so parse/toExternalHTML live here. See hash-tag.ts.
+ */
+
+import { createInlineContentSpec, type InlineContentSpec } from '@blocknote/core'
+import type { CustomInlineContentImplementation } from '@blocknote/core'
+import {
+  serializeDateMentionToken,
+  type DateMentionDateFormat,
+  type DateMentionTimeFormat,
+  type RemindOffset
+} from '@memry/shared/date-mention'
+
+export const dateMentionConfig = {
+  type: 'dateMention' as const,
+  propSchema: {
+    anchorId: { default: '' },
+    dateISO: { default: '' },
+    hasTime: { default: false },
+    dateFormat: { default: 'relative' },
+    remind: { default: 'none' },
+    timeFormat: { default: 'system' }
+  },
+  content: 'none' as const
+}
+
+type DateMentionRender = CustomInlineContentImplementation<
+  typeof dateMentionConfig,
+  never
+>['render']
+
+interface DateMentionProps {
+  anchorId: string
+  dateISO: string
+  hasTime: boolean
+  dateFormat: string
+  remind: string
+  timeFormat: string
+}
+
+export const dateMentionSerialization = {
+  parse: (element: HTMLElement) => {
+    if (!element.hasAttribute('data-date-mention')) return undefined
+    const anchorId = element.getAttribute('data-anchor-id') || ''
+    const dateISO = element.getAttribute('data-date-iso') || ''
+    if (!anchorId || !dateISO) return undefined
+    return {
+      anchorId,
+      dateISO,
+      hasTime: element.getAttribute('data-has-time') === 'true',
+      dateFormat: (element.getAttribute('data-date-format') || 'relative') as DateMentionDateFormat,
+      remind: (element.getAttribute('data-remind') || 'none') as RemindOffset,
+      timeFormat: (element.getAttribute('data-time-format') || 'system') as DateMentionTimeFormat
+    }
+  },
+  toExternalHTML: (inlineContent: { props: DateMentionProps }) => {
+    const { anchorId, dateISO, hasTime, dateFormat, remind, timeFormat } = inlineContent.props
+    const dom = document.createElement('span')
+    dom.textContent = serializeDateMentionToken({
+      anchorId,
+      dateISO,
+      hasTime,
+      dateFormat: dateFormat as DateMentionDateFormat,
+      remind: remind as RemindOffset,
+      timeFormat: timeFormat as DateMentionTimeFormat
+    })
+    return { dom }
+  }
+}
+
+export function createDateMentionSpec(
+  render: DateMentionRender
+): InlineContentSpec<typeof dateMentionConfig> {
+  return createInlineContentSpec(dateMentionConfig, {
+    render,
+    ...dateMentionSerialization
+  })
+}

--- a/packages/editor-schema/src/inline/hash-tag.ts
+++ b/packages/editor-schema/src/inline/hash-tag.ts
@@ -1,0 +1,51 @@
+/**
+ * `hashTag` inline content spec — serialization half only.
+ *
+ * Unlike wikiLink/linkMention, this one's `render` is not portable: it reaches
+ * for the renderer's tag palette and HugeIcon loader. So the package owns the
+ * part that decides what reaches the vault file (config + parse +
+ * toExternalHTML) and each process supplies its own presentation. Main needs
+ * the config registered or y-prosemirror deletes the node from the shared doc.
+ */
+
+import { createInlineContentSpec, type InlineContentSpec } from '@blocknote/core'
+import type { CustomInlineContentImplementation } from '@blocknote/core'
+
+export const hashTagConfig = {
+  type: 'hashTag' as const,
+  propSchema: {
+    tag: { default: '' },
+    color: { default: '' },
+    icon: { default: '' }
+  },
+  content: 'none' as const
+}
+
+type HashTagRender = CustomInlineContentImplementation<typeof hashTagConfig, never>['render']
+
+/** Everything that decides the node's on-disk form. Shared by both processes. */
+export const hashTagSerialization = {
+  parse: (element: HTMLElement) => {
+    if (element.hasAttribute('data-hash-tag')) {
+      const tag = element.getAttribute('data-hash-tag')?.trim() || ''
+      if (tag) {
+        const color = element.getAttribute('data-hash-tag-color')?.trim() || ''
+        const icon = element.getAttribute('data-hash-tag-icon')?.trim() || ''
+        return { tag, color, icon }
+      }
+    }
+    return undefined
+  },
+  toExternalHTML: (inlineContent: { props: { tag: string } }) => {
+    const dom = document.createElement('span')
+    dom.textContent = `#${inlineContent.props.tag || ''}`
+    return { dom }
+  }
+}
+
+export function createHashTagSpec(render: HashTagRender): InlineContentSpec<typeof hashTagConfig> {
+  return createInlineContentSpec(hashTagConfig, {
+    render,
+    ...hashTagSerialization
+  })
+}

--- a/packages/editor-schema/src/inline/index.ts
+++ b/packages/editor-schema/src/inline/index.ts
@@ -1,0 +1,43 @@
+import type { InlineContentSpec } from '@blocknote/core'
+import { WikiLink } from './wiki-link'
+import { LinkMention } from './link-mention'
+import { hashTagConfig } from './hash-tag'
+import { dateMentionConfig } from './date-mention'
+
+export * from './wiki-link'
+export * from './link-mention'
+export * from './hash-tag'
+export * from './date-mention'
+
+/**
+ * The two specs whose presentation each process supplies for itself, built via
+ * `createHashTagSpec` / `createDateMentionSpec` so the config and the
+ * serialization half still come from here. wikiLink and linkMention need no
+ * entry — they are portable and shared whole.
+ */
+export interface MemryInlineSpecs {
+  hashTag: InlineContentSpec<typeof hashTagConfig>
+  dateMention: InlineContentSpec<typeof dateMentionConfig>
+}
+
+/**
+ * Every custom inline node type Memry can put in a document, ready to spread
+ * into `BlockNoteSchema.create`. Both processes build from this one list, so a
+ * spec cannot exist on one side only.
+ */
+export function createMemryInlineContentSpecs(specs: MemryInlineSpecs) {
+  return {
+    wikiLink: WikiLink,
+    linkMention: LinkMention,
+    hashTag: specs.hashTag,
+    dateMention: specs.dateMention
+  }
+}
+
+/** Node names of every custom inline spec — the parity gate reads this. */
+export const MEMRY_INLINE_CONTENT_TYPES = [
+  'wikiLink',
+  'linkMention',
+  'hashTag',
+  'dateMention'
+] as const

--- a/packages/editor-schema/src/inline/link-mention.ts
+++ b/packages/editor-schema/src/inline/link-mention.ts
@@ -1,0 +1,125 @@
+/**
+ * `linkMention` inline content spec. Portable in full — vanilla DOM, no
+ * renderer imports — so both processes use it unchanged. See wiki-link.ts for
+ * why main needs the spec at all.
+ */
+
+import { createInlineContentSpec } from '@blocknote/core'
+
+/**
+ * Markdown persistence token for link mentions. A mention is serialized to
+ * literal text `((mention:<encodeURIComponent(url)>))` so it survives the
+ * markdown round-trip as a single text node (a raw URL would be GFM
+ * auto-linkified and fragmented; an <a> would be claimed by BlockNote's
+ * built-in link mark). Reconstructed on load by normalizeLinkMentions.
+ */
+export const MENTION_TOKEN_REGEX = /\(\(mention:([^)\s]+)\)\)/g
+
+export function serializeLinkMentionToken(url: string): string {
+  // encodeURIComponent leaves `(` and `)` raw, which would break the `))`
+  // delimiter for URLs containing parens — escape them explicitly.
+  const encoded = encodeURIComponent(url).replace(/\(/g, '%28').replace(/\)/g, '%29')
+  return `((mention:${encoded}))`
+}
+
+export function parseLinkMentionToken(encoded: string): string | null {
+  try {
+    const url = decodeURIComponent(encoded)
+    return url || null
+  } catch {
+    return null
+  }
+}
+
+export function createLinkMentionContent(
+  url: string,
+  domain: string,
+  title?: string,
+  favicon?: string,
+  siteName?: string
+) {
+  return {
+    type: 'linkMention' as const,
+    props: { url, domain, title: title ?? '', favicon: favicon ?? '', siteName: siteName ?? '' }
+  }
+}
+
+export const linkMentionConfig = {
+  type: 'linkMention' as const,
+  propSchema: {
+    url: { default: '' },
+    domain: { default: '' },
+    title: { default: '' },
+    favicon: { default: '' },
+    siteName: { default: '' }
+  },
+  content: 'none' as const
+}
+
+export const LinkMention = createInlineContentSpec(linkMentionConfig, {
+  render: (inlineContent) => {
+    const { url, domain, title, favicon, siteName } = inlineContent.props
+    const siteLabel = siteName || domain || url
+
+    const dom = document.createElement('a')
+    dom.className = 'link-mention'
+    dom.href = url
+    dom.target = '_blank'
+    dom.rel = 'noopener noreferrer'
+    dom.setAttribute('data-link-mention', '')
+    dom.setAttribute('data-url', url)
+    dom.setAttribute('data-domain', domain)
+    dom.setAttribute('data-title', title)
+    dom.setAttribute('data-favicon', favicon)
+    dom.setAttribute('data-site-name', siteName)
+    dom.setAttribute('contenteditable', 'false')
+
+    if (favicon) {
+      const img = document.createElement('img')
+      img.className = 'link-mention-favicon'
+      img.src = favicon
+      img.alt = ''
+      img.onerror = () => {
+        img.style.display = 'none'
+      }
+      dom.appendChild(img)
+    }
+
+    const siteSpan = document.createElement('span')
+    siteSpan.className = 'link-mention-site'
+    siteSpan.textContent = siteLabel
+    dom.appendChild(siteSpan)
+
+    if (title) {
+      const titleSpan = document.createElement('span')
+      titleSpan.className = 'link-mention-title'
+      titleSpan.textContent = title
+      dom.appendChild(titleSpan)
+    }
+
+    return { dom }
+  },
+
+  parse: (element) => {
+    if (element.hasAttribute('data-link-mention')) {
+      const url = element.getAttribute('data-url') || ''
+      const domain = element.getAttribute('data-domain') || ''
+      const title = element.getAttribute('data-title') || ''
+      const favicon = element.getAttribute('data-favicon') || ''
+      const siteName = element.getAttribute('data-site-name') || ''
+      if (!url) return undefined
+      return { url, domain, title, favicon, siteName }
+    }
+
+    return undefined
+  },
+
+  toExternalHTML: (inlineContent) => {
+    // Emit the markdown persistence token as plain text (not an <a>, which
+    // BlockNote's link mark would reclaim on reload). normalizeLinkMentions
+    // rebuilds the rich inline content from this token on load.
+    const dom = document.createElement('span')
+    dom.textContent = serializeLinkMentionToken(inlineContent.props.url)
+    return { dom }
+  }
+})

--- a/packages/editor-schema/src/inline/wiki-link.ts
+++ b/packages/editor-schema/src/inline/wiki-link.ts
@@ -1,0 +1,86 @@
+/**
+ * `wikiLink` inline content spec.
+ *
+ * Lives here rather than in the renderer because the main process needs the
+ * same node: a spec the main-process schema does not carry is not a rendering
+ * gap, it is data loss — y-prosemirror deletes any element it cannot build,
+ * straight out of the shared Y.Doc. Fully portable (vanilla DOM, no renderer
+ * imports), so both processes use this spec unchanged.
+ */
+
+import { createInlineContentSpec } from '@blocknote/core'
+
+const WIKI_LINK_FULL_PATTERN = /^\[\[([^\]|]+)(?:\|([^\]]+))?\]\]$/
+
+export interface WikiLinkParts {
+  target: string
+  alias: string
+}
+
+export function parseWikiLinkText(text: string): WikiLinkParts | null {
+  const match = text.trim().match(WIKI_LINK_FULL_PATTERN)
+  if (!match) return null
+
+  const target = match[1]?.trim()
+  const alias = match[2]?.trim() ?? ''
+
+  if (!target) return null
+  return { target, alias }
+}
+
+export function createWikiLinkInlineContent(target: string, alias: string) {
+  return {
+    type: 'wikiLink',
+    props: { target, alias: alias ?? '' }
+  }
+}
+
+export const wikiLinkConfig = {
+  type: 'wikiLink' as const,
+  propSchema: {
+    target: { default: '' },
+    alias: { default: '' }
+  },
+  content: 'none' as const
+}
+
+/** The markdown form: `[[target]]`, or `[[target|alias]]` when they differ. */
+export function wikiLinkToText(target: string, alias: string): string {
+  return alias && alias !== target ? `[[${target}|${alias}]]` : `[[${target}]]`
+}
+
+export const WikiLink = createInlineContentSpec(wikiLinkConfig, {
+  render: (inlineContent) => {
+    const dom = document.createElement('span')
+    dom.className = 'wiki-link'
+    dom.setAttribute('data-wiki-link', '')
+    dom.setAttribute('data-target', inlineContent.props.target || '')
+    dom.setAttribute('data-alias', inlineContent.props.alias || '')
+    dom.setAttribute('title', inlineContent.props.target || '')
+    dom.setAttribute('contenteditable', 'false')
+    dom.textContent = inlineContent.props.alias || inlineContent.props.target || ''
+
+    return { dom }
+  },
+  parse: (element) => {
+    if (element.hasAttribute('data-wiki-link') || element.hasAttribute('data-target')) {
+      const target = element.getAttribute('data-target')?.trim() || ''
+      const alias = element.getAttribute('data-alias')?.trim() || ''
+      if (target) {
+        return { target, alias }
+      }
+    }
+
+    const parsed = parseWikiLinkText(element.textContent ?? '')
+    if (!parsed) return undefined
+    return { target: parsed.target, alias: parsed.alias }
+  },
+  toExternalHTML: (inlineContent) => {
+    const dom = document.createElement('span')
+    dom.textContent = wikiLinkToText(
+      inlineContent.props.target || '',
+      inlineContent.props.alias || ''
+    )
+    return { dom }
+  }
+})

--- a/packages/editor-schema/src/schema.ts
+++ b/packages/editor-schema/src/schema.ts
@@ -1,0 +1,38 @@
+import {
+  type BlockSpecs,
+  BlockNoteSchema,
+  defaultBlockSpecs,
+  defaultInlineContentSpecs,
+  createCodeBlockSpec
+} from '@blocknote/core'
+import { codeBlockOptions } from '@blocknote/code-block'
+import { createMemryInlineContentSpecs, type MemryInlineSpecs } from './inline'
+
+/**
+ * The one place a Memry BlockNote schema is built.
+ *
+ * Renderer and main process both call this, so neither can carry a node type
+ * the other lacks. That symmetry is not cosmetic: the main process converts the
+ * shared Y.Doc through y-prosemirror, whose response to an unknown node name is
+ * to DELETE the element from the doc — a missing spec replicates as data loss,
+ * not as a rendering gap.
+ *
+ * Callers pass presentation only. `blocks` is generic so the renderer keeps the
+ * precise schema type its typed block helpers depend on.
+ */
+export function createMemrySchema<Blocks extends BlockSpecs>(impl: {
+  blocks: Blocks
+  inline: MemryInlineSpecs
+}) {
+  return BlockNoteSchema.create({
+    blockSpecs: {
+      ...defaultBlockSpecs,
+      codeBlock: createCodeBlockSpec(codeBlockOptions),
+      ...impl.blocks
+    },
+    inlineContentSpecs: {
+      ...defaultInlineContentSpecs,
+      ...createMemryInlineContentSpecs(impl.inline)
+    }
+  })
+}

--- a/packages/editor-schema/tsconfig.json
+++ b/packages/editor-schema/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@memry/typescript-config/node.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       '@memry/domain-tasks':
         specifier: workspace:*
         version: link:../../packages/domain-tasks
+      '@memry/editor-schema':
+        specifier: workspace:*
+        version: link:../../packages/editor-schema
       '@memry/i18n':
         specifier: workspace:*
         version: link:../../packages/i18n
@@ -1082,6 +1085,22 @@ importers:
         version: link:../typescript-config
 
   packages/domain-tasks:
+    devDependencies:
+      '@memry/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+
+  packages/editor-schema:
+    dependencies:
+      '@blocknote/code-block':
+        specifier: ^0.47.1
+        version: 0.47.1(@blocknote/core@0.47.1(patch_hash=3449fe80e8250449972daaa5e90945cc40086f945ac0ed30c6a3f0d8d89a9848)(@types/hast@3.0.4))
+      '@blocknote/core':
+        specifier: ^0.47.1
+        version: 0.47.1(patch_hash=3449fe80e8250449972daaa5e90945cc40086f945ac0ed30c6a3f0d8d89a9848)(@types/hast@3.0.4)
+      '@memry/shared':
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       '@memry/typescript-config':
         specifier: workspace:*


### PR DESCRIPTION
Phase 0 and Phase 1a of #1427. Stops the data loss and lands the shared schema package. **Wiki links are not restored in main yet** — that is #1431, the next PR.

Refs #1428, #1429, #1430. Left open deliberately; nothing here is auto-closed.

## The bug

Opening a note with `[[Wiki Link]]` on a sync-enabled device deleted the link from the editor, the vault file, and every other device. The renderer's schema knows `wikiLink`; main's `serverSchema` registers no `inlineContentSpecs` at all. Main converted the **live** Y.Doc, y-prosemirror hit a node it could not build, and its catch is a destructive repair — `el._item.delete(transaction)`. That is a real CRDT delete, so it replicated; the markdown was then serialized from the already-mutated doc and written over the file.

## What this PR does

| Commit | Issue | Change |
|---|---|---|
| `9593ab1c1` | #1428 | `yDocToMarkdown` converts a detached copy, never the live doc — the export path loses write authority |
| `01270d4d4` | #1429 | `findUnrepresentableNodes` + write-back fails closed: keep the file, emit `writeback_unrepresentable_node` |
| `d346501e8` | #1430 | New `@memry/editor-schema`; renderer builds via `createMemrySchema({ blocks, inline })` |

Together #1428 + #1429 downgrade the class from *permanent replicated data loss* to *this note stops writing back until the app can represent it*.

## Three corrections to the plan, found by implementing it

**1. Never hand-write the known-node list.** The plan sketched `blockSchema` keys + `inlineContentSchema` keys + block containers. ProseMirror node names are not block type names — a real fragment also carries `tableRow`, `tableCell`, `tableHeader`, `tableParagraph`, none of which appear in `blockSchema`. That list flags them, so **every note containing a table would have stopped writing back**. The oracle is now `pmSchema.nodes` — literally the object `createNodeFromYElement` calls `schema.node(name, …)` on, so it cannot drift from what is constructible.

Mutation-tested rather than asserted. Swapping the plan's list back in:

```
× findUnrepresentableNodes > reports nothing for content this build can serialize, tables included
  → expected [ 'tableRow', 'tableHeader', …(2) ] to deeply equal []
```

**2. Only two of the four inline specs are portable.** `wikiLink` and `linkMention` are vanilla DOM and move whole. `hashTag.render` imports the tag palette and HugeIcon loader; `dateMention.render` imports `@/lib/time-format`, `@/lib/week-start`, `date-fns` and module-level prefs. Those two move as config + `parse` + `toExternalHTML` — the half that decides what reaches the vault file — with each process supplying its own render. So `createMemrySchema` takes `{ blocks, inline }`, not the plan's single `blockImplementations`. `blocks` stays generic (constrained to `BlockSpecs`) so the renderer keeps the precise `EditorSchema` type its typed block helpers depend on.

**3. `trackMainLog` takes no free-form fields** (`{scope, action, errorCode?, error?, metrics?}`), so the node list rides on `errorCode`.

The mechanism was spiked before any of the package was built: registering a server-side inline spec whose `render` throws and whose `toExternalHTML` emits the text form is both necessary and sufficient — the node survives `yXmlFragmentToBlocks`, markdown comes out `See [[Roadmap|the plan]] tomorrow.`, `render` is never reached, doc bytes unchanged.

## Cost

The snapshot copy is one `encodeStateAsUpdate` + `applyUpdate` per pass. Measured on a 38KB note (104KB Y update), mean of 10: `yDocToMarkdown` 21.6ms of which the copy is 1.79ms (~8%); `findUnrepresentableNodes` 0.11ms. Immaterial against the 9× cost-proportional cooldown, so no caching.

## Backward compatibility

No vault format, DB schema, sync protocol or IPC contract change. Markdown output is unchanged — this PR only stops main from destroying nodes, it does not yet teach it to serialize them, so no note is rewritten. The lockfile diff is the new package's own entry only (19 additive lines, same `@blocknote/core` patch hash, so still one schema identity).

## Verification

- `test:renderer` — 609 files / 6965 tests
- `test:main` — 512 files / 6338 tests
- `typecheck:web`, `typecheck:node`, `typecheck:test`
- `check:architecture`, lint, lockfile gate
- `docs:impact --strict`, `docs:build`

## Not in this PR

#1431 (main builds from the factory — restores wiki links), #1432 (custom blocks), #1433 (parity gate), #1434 (byte stability), #1435 (size the damage already done). #1435 matters: notes have been losing links on every open for as long as the mismatch existed, and no repair should ship before the count is known.
