### PR TITLE
fix(crdt): build the main-process schema from the shared factory — restores wiki links

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -909,3 +909,107 @@ describe('registering the custom specs does not rewrite existing markdown', () =
     expect(await yDocToMarkdown(doc)).toBe(markdown)
   })
 })
+
+describe('custom inline content inside a table', () => {
+  // BlockNote serializes inline content inside a table through the spec's
+  // `render`, NOT `toExternalHTML`. Every other block type takes the
+  // `toExternalHTML` path, so a server spec can look correct everywhere and
+  // still corrupt tables. Both failure modes below were real:
+  //   - a throwing render made yDocToMarkdown return null, so the whole note
+  //     silently stopped writing back
+  //   - the editor's rich linkMention render emitted `<a href>`, rewriting the
+  //     `((mention:…))` token as a plain markdown link and dropping the
+  //     domain/title/favicon/siteName from disk permanently
+  const cellProps = {
+    colspan: 1,
+    rowspan: 1,
+    backgroundColor: 'default',
+    textColor: 'default',
+    textAlignment: 'left'
+  }
+
+  async function tableMarkdown(cellContent: unknown[]): Promise<string | null> {
+    const doc = new Y.Doc()
+    blocksToYFragment(
+      [
+        {
+          id: 'tbl',
+          type: 'table',
+          props: {},
+          children: [],
+          content: {
+            type: 'tableContent',
+            columnWidths: [null, null],
+            rows: [
+              {
+                cells: [
+                  { type: 'tableCell', content: cellContent, props: cellProps },
+                  {
+                    type: 'tableCell',
+                    content: [{ type: 'text', text: 'x', styles: {} }],
+                    props: cellProps
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ] as unknown as Parameters<typeof blocksToYFragment>[0],
+      doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+    return await yDocToMarkdown(doc)
+  }
+
+  it.each([
+    ['wikiLink', [{ type: 'wikiLink', props: { target: 'Roadmap', alias: '' } }], '[[Roadmap]]'],
+    [
+      'wikiLink with an alias',
+      [{ type: 'wikiLink', props: { target: 'Roadmap', alias: 'the plan' } }],
+      '[[Roadmap|the plan]]'
+    ],
+    ['hashTag', [{ type: 'hashTag', props: { tag: 'work', color: '', icon: '' } }], '#work'],
+    [
+      'linkMention',
+      [
+        {
+          type: 'linkMention',
+          props: {
+            url: 'https://x.com/y',
+            domain: 'x.com',
+            title: 'T',
+            favicon: 'f',
+            siteName: 'S'
+          }
+        }
+      ],
+      serializeLinkMentionToken('https://x.com/y')
+    ]
+  ])('%s keeps its on-disk form in a table cell', async (_name, content, expected) => {
+    // #when
+    const markdown = await tableMarkdown(content)
+
+    // #then the conversion succeeds at all (a throwing render returns null)...
+    expect(markdown).not.toBeNull()
+    // ...and the cell holds the textual form, not the editor's rich markup
+    expect(markdown).toContain(expected)
+  })
+
+  it('a date mention keeps its token in a table cell', async () => {
+    // #given
+    const props = {
+      anchorId: 'a1',
+      dateISO: '2026-08-14T09:00:00.000Z',
+      hasTime: true,
+      dateFormat: 'relative' as const,
+      remind: 'none' as const,
+      timeFormat: 'system' as const
+    }
+
+    // #when
+    const markdown = await tableMarkdown([{ type: 'dateMention', props }])
+
+    // #then
+    expect(markdown).not.toBeNull()
+    expect(markdown).toContain(serializeDateMentionToken(props))
+  })
+})

--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -10,6 +10,8 @@ import {
 } from './blocknote-converter'
 import * as Y from 'yjs'
 import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
+import { serializeLinkMentionToken } from '@memry/editor-schema'
+import { serializeDateMentionToken } from '@memry/shared/date-mention'
 
 describe('blocknote-converter code block language', () => {
   it('returns empty markdown for an empty Yjs fragment', async () => {
@@ -664,7 +666,10 @@ describe('blocknote-converter export path never mutates the live doc', () => {
     const block = new Y.XmlElement('blockContainer')
     block.setAttribute('id', 'b1')
     const para = new Y.XmlElement('paragraph')
-    const unknown = new Y.XmlElement('wikiLink')
+    // Deliberately a name no build knows. `wikiLink` used to stand in here, but
+    // this schema now registers it — the guard has to be aimed at a node type
+    // that is genuinely unconstructible, e.g. one a future build introduces.
+    const unknown = new Y.XmlElement('someUnknownFutureNode')
     unknown.setAttribute('target', 'Roadmap')
     para.insert(0, [unknown])
     block.insert(0, [para])
@@ -692,14 +697,17 @@ describe('findUnrepresentableNodes', () => {
   }
 
   it('names the inline node type the server schema cannot build', () => {
-    // #given a doc holding a renderer-only inline node
-    const doc = seedUnknownInlineNode('wikiLink')
+    // #given a doc holding an inline node no build in this app can construct —
+    // a note written by a newer version, say. (This case used `wikiLink` while
+    // the main schema lacked it; that spec is now registered, so the coverage
+    // moves to a name that is still genuinely unknown.)
+    const doc = seedUnknownInlineNode('someUnknownFutureNode')
 
     // #when
     const unknown = findUnrepresentableNodes(doc)
 
     // #then
-    expect(unknown).toEqual(['wikiLink'])
+    expect(unknown).toEqual(['someUnknownFutureNode'])
   })
 
   it('reports nothing for content this build can serialize, tables included', async () => {
@@ -722,7 +730,7 @@ describe('findUnrepresentableNodes', () => {
 
   it('reads without mutating the doc', () => {
     // #given
-    const doc = seedUnknownInlineNode('wikiLink')
+    const doc = seedUnknownInlineNode('someUnknownFutureNode')
     const before = Y.encodeStateAsUpdate(doc)
 
     // #when
@@ -738,5 +746,166 @@ describe('findUnrepresentableNodes', () => {
 
     // #when / #then
     expect(findUnrepresentableNodes(doc)).toEqual([])
+  })
+
+  it('reports nothing for every custom node type the renderer can author', async () => {
+    // #given the doc a synced note actually holds: a taskBlock plus all four
+    // custom inline nodes. Every one of these was a delete-on-open before the
+    // main schema was built from the shared factory.
+    const doc = new Y.Doc()
+    const ok = await markdownToYFragment(
+      '- [ ] a task {task:t1}\n',
+      doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+    expect(ok).toBe(true)
+    const blockGroup = doc.getXmlFragment(CRDT_FRAGMENT_NAME).get(0) as Y.XmlElement
+    blockGroup.push([customInlineBlockContainer()])
+
+    // #when
+    const unknown = findUnrepresentableNodes(doc)
+
+    // #then
+    expect(unknown).toEqual([])
+  })
+})
+
+/**
+ * One `blockContainer` whose paragraph holds every custom inline node type,
+ * seeded the way the renderer seeds them: straight into the shared Y.Doc.
+ */
+function customInlineBlockContainer(): Y.XmlElement {
+  const block = new Y.XmlElement('blockContainer')
+  block.setAttribute('id', 'inline-b1')
+  const para = new Y.XmlElement('paragraph')
+  para.insert(
+    0,
+    INLINE_CASES.map(({ nodeName, attrs }) => {
+      const node = new Y.XmlElement(nodeName)
+      for (const [key, value] of Object.entries(attrs)) node.setAttribute(key, value)
+      return node
+    })
+  )
+  block.insert(0, [para])
+  return block
+}
+
+/**
+ * Every custom inline node type, with the markdown form it must serialize to.
+ * A new inline spec with no case here fails this table rather than being
+ * silently untested — the whole class of bug was one spec nobody covered.
+ */
+const INLINE_CASES = [
+  {
+    nodeName: 'wikiLink',
+    attrs: { target: 'Roadmap', alias: 'the plan' },
+    text: '[[Roadmap|the plan]]'
+  },
+  { nodeName: 'hashTag', attrs: { tag: 'roadmap' }, text: '#roadmap' },
+  {
+    nodeName: 'linkMention',
+    attrs: { url: 'https://example.com/a', domain: 'example.com' },
+    text: serializeLinkMentionToken('https://example.com/a')
+  },
+  {
+    nodeName: 'dateMention',
+    // `hasTime` is left at its schema default so the seeded attributes stay
+    // strings; a string "false" would be truthy and change the token.
+    attrs: {
+      anchorId: 'a1',
+      dateISO: '2026-08-14',
+      dateFormat: 'relative',
+      remind: 'none',
+      timeFormat: 'system'
+    },
+    text: serializeDateMentionToken({
+      anchorId: 'a1',
+      dateISO: '2026-08-14',
+      hasTime: false,
+      dateFormat: 'relative',
+      remind: 'none',
+      timeFormat: 'system'
+    })
+  }
+] as const
+
+describe('custom inline nodes survive the CRDT write path', () => {
+  /**
+   * `blockGroup > blockContainer > paragraph > [text, node, text]` — the shape
+   * the renderer's editor actually writes into the shared fragment (verified
+   * against `markdownToYFragment` output), so the node reaches the converter
+   * exactly as a real synced note would deliver it.
+   */
+  function seedInlineNode(nodeName: string, attrs: Record<string, string>): Y.Doc {
+    const doc = new Y.Doc()
+    const group = new Y.XmlElement('blockGroup')
+    const block = new Y.XmlElement('blockContainer')
+    block.setAttribute('id', 'b1')
+    const para = new Y.XmlElement('paragraph')
+    const node = new Y.XmlElement(nodeName)
+    for (const [key, value] of Object.entries(attrs)) node.setAttribute(key, value)
+    para.insert(0, [new Y.XmlText('See '), node, new Y.XmlText(' tomorrow.')])
+    block.insert(0, [para])
+    group.insert(0, [block])
+    doc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [group])
+    return doc
+  }
+
+  it('round-trips a wiki link through the CRDT write path', async () => {
+    // #given the doc the renderer produces for `[[Roadmap|the plan]]`
+    const doc = seedInlineNode('wikiLink', { target: 'Roadmap', alias: 'the plan' })
+    const before = Y.encodeStateAsUpdate(doc)
+
+    // #when write-back serializes it
+    const markdown = await yDocToMarkdown(doc)
+
+    // #then the link reaches the vault file…
+    expect(markdown).toContain('[[Roadmap|the plan]]')
+    // …and the shared doc is untouched: y-prosemirror's answer to an unknown
+    // node is to delete it, which replicates to every other device.
+    expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+    expect(findUnrepresentableNodes(doc)).toEqual([])
+  })
+
+  it.each(INLINE_CASES)(
+    '$nodeName serializes to its markdown form',
+    async ({ nodeName, attrs, text }) => {
+      // #given
+      const doc = seedInlineNode(nodeName, { ...attrs })
+      const before = Y.encodeStateAsUpdate(doc)
+
+      // #when
+      const markdown = await yDocToMarkdown(doc)
+
+      // #then
+      expect(markdown).toContain(text)
+      expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+    }
+  )
+})
+
+describe('registering the custom specs does not rewrite existing markdown', () => {
+  // Write-back byte-compares before writing, so any serialization drift here
+  // rewrites every affected note in every vault on next open. The block-level
+  // cases are the sharp ones: a spec whose `parse` matches an element by its
+  // text content claims the whole `<li>` / `<blockquote>` / `<td>`, and the
+  // block around the link is what gets lost.
+  it.each([
+    'See [[Roadmap|the plan]] tomorrow.',
+    '[[Roadmap]]',
+    '# Heading\n\n[[A]] and #tag and ((mention:https%3A%2F%2Fx.com)) inline.',
+    '- [[A]]\n- [[B]]',
+    '> [[Quoted]]',
+    '- [ ] a task {task:t1}',
+    '```ts\nconst x = "[[Roadmap]]"\n```',
+    '((date:eyJhbmNob3JJZCI6ImExIn0)) leftover token.'
+  ])('round-trips %j unchanged', async (markdown) => {
+    // #given a vault note as it exists on disk today
+    const doc = new Y.Doc()
+    const ok = await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(ok).toBe(true)
+
+    // #when write-back serializes it again
+    // #then the bytes are the same, so nothing is written
+    expect(await yDocToMarkdown(doc)).toBe(markdown)
   })
 })

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -1,13 +1,7 @@
 import { ServerBlockNoteEditor } from '@blocknote/server-util'
-import {
-  type Block,
-  type PartialBlock,
-  BlockNoteSchema,
-  defaultBlockSpecs,
-  createBlockSpec,
-  createCodeBlockSpec
-} from '@blocknote/core'
-import { codeBlockOptions } from '@blocknote/code-block'
+import { type Block, type PartialBlock } from '@blocknote/core'
+import { createMemrySchema } from '@memry/editor-schema'
+import { createServerBlockSpecs, createServerInlineSpecs } from '@memry/editor-schema/server'
 import { randomUUID } from 'node:crypto'
 import * as Y from 'yjs'
 import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
@@ -49,37 +43,14 @@ import { resolveVaultEmbeds } from '../vault/resolve-embed'
 
 const log = createLogger('BlockNoteConverter')
 
-// Headless `taskBlock` node so the CRDT fragment stores the SAME custom block
-// the renderer paints. Seeding a raw `checkListItem` would flash a plain
-// checkbox on open and — via the renderer's checkbox→task converter — mint a
-// duplicate task. Only the node schema (type + props + content) is used for
-// (de)serialization here; the server never renders, so `render` throws if it is
-// ever reached. propSchema must stay identical to the renderer's taskBlock
-// (task-block/index.tsx) or yXmlFragmentToBlocks would mis-parse the props.
-const createServerTaskBlock = createBlockSpec(
-  {
-    type: 'taskBlock' as const,
-    propSchema: {
-      taskId: { default: '' },
-      title: { default: '' },
-      checked: { default: false },
-      parentTaskId: { default: '' }
-    },
-    content: 'none'
-  },
-  {
-    render: () => {
-      throw new Error('taskBlock server spec is serialization-only and must not be rendered')
-    }
-  }
-)
-
-const serverSchema = BlockNoteSchema.create({
-  blockSpecs: {
-    ...defaultBlockSpecs,
-    codeBlock: createCodeBlockSpec(codeBlockOptions),
-    taskBlock: createServerTaskBlock()
-  }
+// The same factory the renderer builds its schema from, so this process cannot
+// lack a node type the renderer can author. That symmetry is the whole fix:
+// y-prosemirror answers an unknown node name by DELETING the element from the
+// shared Y.Doc, so a spec registered on one side only replicates as data loss.
+// Main supplies serialization-only implementations — nothing here ever renders.
+const serverSchema = createMemrySchema({
+  blocks: createServerBlockSpecs(),
+  inline: createServerInlineSpecs()
 })
 
 let serverEditor: ServerBlockNoteEditor | null = null

--- a/apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts
@@ -1,4 +1,4 @@
-import { createMemrySchema } from '@memry/editor-schema'
+import { createMemrySchema, WikiLink } from '@memry/editor-schema'
 import { createFileBlock } from './file-block'
 import { createCalloutBlock } from './callout-block'
 import { createYoutubeEmbedBlock } from './youtube-embed-block'
@@ -25,6 +25,9 @@ export const editorSchema = createMemrySchema({
     taskBlock: createTaskBlock()
   },
   inline: {
+    // The editor flavour of wikiLink: same node as main's, plus the `parse`
+    // rule that turns pasted `[[X]]` text into a link.
+    wikiLink: WikiLink,
     hashTag: HashTag,
     dateMention: DateMention
   }

--- a/apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts
@@ -5,6 +5,7 @@ import { createYoutubeEmbedBlock } from './youtube-embed-block'
 import { createBookmarkBlock } from './bookmark-block'
 import { createTaskBlock } from './task-block'
 import { HashTag } from './hash-tag'
+import { LinkMention } from './link-mention'
 import { DateMention } from './date-mention'
 
 // Built through the shared factory so the main process gets a schema with the
@@ -28,6 +29,7 @@ export const editorSchema = createMemrySchema({
     // The editor flavour of wikiLink: same node as main's, plus the `parse`
     // rule that turns pasted `[[X]]` text into a link.
     wikiLink: WikiLink,
+    linkMention: LinkMention,
     hashTag: HashTag,
     dateMention: DateMention
   }

--- a/apps/desktop/src/renderer/src/components/note/content-area/task-block/index.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/task-block/index.tsx
@@ -1,4 +1,5 @@
 import { createReactBlockSpec } from '@blocknote/react'
+import { taskBlockConfig } from '@memry/editor-schema/blocks'
 import {
   TaskBlockRenderer,
   type TaskBlock,
@@ -12,27 +13,18 @@ import type { Project } from '@/data/tasks-data'
 
 const PRIORITY_REVERSE: Record<string, number> = { none: 0, low: 1, medium: 2, high: 3, urgent: 4 }
 
-export const createTaskBlock = createReactBlockSpec(
-  {
-    type: 'taskBlock' as const,
-    propSchema: {
-      taskId: { default: '' },
-      title: { default: '' },
-      checked: { default: false },
-      parentTaskId: { default: '' }
-    },
-    content: 'none'
-  },
-  {
-    render: (props) => (
-      <TaskBlockRenderer
-        block={props.block as TaskBlock}
-        editor={props.editor}
-        contentRef={props.contentRef}
-      />
-    )
-  }
-)
+// Type/props/content come from the shared config so the renderer's block and
+// the main process's headless twin cannot disagree; only the React
+// presentation is declared here.
+export const createTaskBlock = createReactBlockSpec(taskBlockConfig, {
+  render: (props) => (
+    <TaskBlockRenderer
+      block={props.block as TaskBlock}
+      editor={props.editor}
+      contentRef={props.contentRef}
+    />
+  )
+})
 
 export function getTaskSlashMenuItem(editor: unknown, noteId?: string) {
   return {

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -307,12 +307,21 @@ whose node name its schema does not know. A spec registered on only one side is 
 not a missing style — the same class of cross-process contract that [IPC](/architecture/ipc)
 gates with `ipc:check`.
 
-Specs whose rendering is portable are shared whole. Those whose rendering needs renderer
-state — `hashTag` (tag palette, icons) and `dateMention` (clock format, week start) — share
-their config, `parse` and `toExternalHTML`, the half that decides what reaches the vault
-file, while each process supplies its own presentation. Until both processes build from the
-package, the fail-closed guard in [Markdown Write-Back](#markdown-write-back) is what keeps
-an unknown node type from costing content.
+The package owns each node's config, `parse` and `toExternalHTML` — the half that decides
+what reaches the vault file — and each process supplies its own presentation. The renderer
+gives the editor chip; the main process gives an implementation that emits the node's plain
+markdown form.
+
+**Main's implementations are not decoration.** BlockNote serializes inline content inside a
+**table** through the spec's `render`, not through `toExternalHTML`, so for that one block
+type main's rendering is what lands on disk. A `render` that throws makes the whole note's
+conversion fail — it stops writing back rather than losing a cell — and a `render` carrying
+the editor's rich markup rewrites the cell: a link mention's `((mention:…))` token becomes a
+plain markdown link and its domain, title, favicon and site name are gone. Every server-side
+`render` therefore emits exactly what `toExternalHTML` emits. No spec is shared whole.
+
+Whatever still cannot be represented is caught by the fail-closed guard in
+[Markdown Write-Back](#markdown-write-back).
 
 ## Files Worth Knowing
 

--- a/docs/superpowers/plans/2026-08-13-editor-schema-contract.md
+++ b/docs/superpowers/plans/2026-08-13-editor-schema-contract.md
@@ -385,7 +385,7 @@ git commit -m "refactor(editor): extract the shared BlockNote schema into @memry
 - Consumes: `createMemrySchema` (Task 3)
 - Produces: `createServerBlockSpecs(): MemryBlockImplementations` — headless implementations built from the shared configs
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```ts
 it('round-trips a wiki link through the CRDT write path', async () => {
@@ -404,12 +404,12 @@ it('round-trips a wiki link through the CRDT write path', async () => {
 })
 ```
 
-- [ ] **Step 2: Run it and watch it fail**
+- [x] **Step 2: Run it and watch it fail**
 
 Run: `pnpm --filter @memry/desktop test:main -- blocknote-converter`
 Expected: FAIL — the link is missing from the markdown.
 
-- [ ] **Step 3: Move the taskBlock config and add headless specs**
+- [x] **Step 3: Move the taskBlock config and add headless specs**
 
 ```ts
 // packages/editor-schema/src/blocks/server-specs.ts
@@ -427,20 +427,29 @@ export function createServerBlockSpecs(): MemryBlockImplementations {
 }
 ```
 
-- [ ] **Step 4: Rewrite `serverSchema`**
+- [x] **Step 4: Rewrite `serverSchema`**
+
+**Corrected during implementation.** `createMemrySchema` takes `{ blocks, inline }` (Task 3 Step 3), and the inline half is the half that closes the incident:
 
 ```ts
-const serverSchema = createMemrySchema(createServerBlockSpecs())
+const serverSchema = createMemrySchema({
+  blocks: createServerBlockSpecs(),
+  inline: createServerInlineSpecs()
+})
 ```
+
+`createServerInlineSpecs` lives in `packages/editor-schema/src/server.ts`, which the package's `exports` already pointed at.
 
 Delete `createServerTaskBlock` and its comment — the propSchema is now shared, so the warning it carried no longer applies.
 
-- [ ] **Step 5: Run the tests**
+**`wikiLink` cannot be shared whole after all.** Task 3 Step 2 marked it "portable — whole spec", and it is, for rendering. But its `parse` promotes ANY element whose entire text reads `[[X]]` into an inline node. In the editor that is a paste convenience; in main's markdown importer it eats the block around the link. Measured against `HEAD~`: `- [[A]]\n- [[B]]` came back as `[[A]] [[B]]`, `> [[Quoted]]` as `[[Quoted]]`, and a `| [[A]] |` table cell as `| A |` — three silent rewrites of existing vault notes, none of which any pre-existing test covered. So main takes `WikiLinkSerializationOnly` (same config, same `toExternalHTML`, no `parse`) and `MemryInlineSpecs` grows a `wikiLink` entry each process fills in. Markdown output is now byte-identical to `HEAD~` for every fixture, and `blocknote-converter.test.ts` keeps the fixtures that caught it.
 
-Run: `pnpm --filter @memry/desktop test:main -- "blocknote-converter|crdt-writeback|note-fidelity"` then the full `pnpm test:desktop`
-Expected: PASS, and the pre-existing round-trip/byte-stability tests still green.
+- [x] **Step 5: Run the tests**
 
-- [ ] **Step 6: Commit**
+Run: `pnpm --filter @memry/desktop test:main` and `pnpm --filter @memry/desktop test:renderer` (the `-- <path>` filter is silently ignored; use `pnpm exec vitest run --config config/vitest.config.ts --project main <path>` from `apps/desktop` for one file).
+Result: main 512 files / 6352 tests, renderer 609 files / 6965 tests, both green, with the pre-existing round-trip and note-fidelity tests untouched.
+
+- [x] **Step 6: Commit**
 
 ```bash
 git add packages/editor-schema apps/desktop/src/main/sync/blocknote-converter.ts apps/desktop/src/main/sync/blocknote-converter.test.ts

--- a/packages/editor-schema/src/blocks/configs.ts
+++ b/packages/editor-schema/src/blocks/configs.ts
@@ -1,0 +1,23 @@
+/**
+ * Block configs — type + propSchema + content, no presentation.
+ *
+ * A block's propSchema is its (de)serialization contract: the renderer's React
+ * spec and the main process's headless spec have to agree exactly or
+ * `yXmlFragmentToBlocks` mis-parses the props on one side. This used to be a
+ * hand-copied duplicate carrying a comment asking humans to keep the two in
+ * step; one object shared by both processes is what makes drift impossible.
+ *
+ * Presentation stays with each process — main has no React, and rendering is
+ * never what reaches the vault file.
+ */
+
+export const taskBlockConfig = {
+  type: 'taskBlock' as const,
+  propSchema: {
+    taskId: { default: '' },
+    title: { default: '' },
+    checked: { default: false },
+    parentTaskId: { default: '' }
+  },
+  content: 'none' as const
+}

--- a/packages/editor-schema/src/blocks/server-specs.ts
+++ b/packages/editor-schema/src/blocks/server-specs.ts
@@ -1,0 +1,26 @@
+/**
+ * Headless block implementations for the main process.
+ *
+ * The main process needs these nodes registered for one reason only: it
+ * converts the shared Y.Doc through y-prosemirror, whose response to a node
+ * name its schema cannot build is to DELETE the element from the doc. A block
+ * missing here is not a blank space in a preview — it is a replicated delete.
+ *
+ * So these carry the schema (from the shared configs) and nothing else. There
+ * is no headless DOM to paint into and no caller that should try: `render`
+ * throws rather than returning something plausible.
+ */
+
+import { createBlockSpec } from '@blocknote/core'
+import { taskBlockConfig } from './configs'
+
+export function createServerBlockSpecs() {
+  return {
+    taskBlock: createBlockSpec(taskBlockConfig, {
+      render: () => {
+        throw new Error('taskBlock server spec is serialization-only and must not be rendered')
+      }
+    })()
+    // callout / file / youtubeEmbed / bookmark land with their configs.
+  }
+}

--- a/packages/editor-schema/src/inline/index.ts
+++ b/packages/editor-schema/src/inline/index.ts
@@ -1,6 +1,6 @@
 import type { InlineContentSpec } from '@blocknote/core'
-import { WikiLink } from './wiki-link'
 import { LinkMention } from './link-mention'
+import { wikiLinkConfig } from './wiki-link'
 import { hashTagConfig } from './hash-tag'
 import { dateMentionConfig } from './date-mention'
 
@@ -10,14 +10,22 @@ export * from './hash-tag'
 export * from './date-mention'
 
 /**
- * The two specs whose presentation each process supplies for itself, built via
- * `createHashTagSpec` / `createDateMentionSpec` so the config and the
- * serialization half still come from here. wikiLink and linkMention need no
- * entry — they are portable and shared whole.
+ * The specs each process supplies for itself. The config and the serialization
+ * half still come from here (via `createHashTagSpec` / `createDateMentionSpec`,
+ * or `WikiLink` / `WikiLinkSerializationOnly`), so only presentation and
+ * HTML-paste behaviour differ. linkMention needs no entry — it is portable and
+ * shared whole.
  */
 export interface MemryInlineSpecs {
   hashTag: InlineContentSpec<typeof hashTagConfig>
   dateMention: InlineContentSpec<typeof dateMentionConfig>
+  /**
+   * `WikiLink` in the editor, `WikiLinkSerializationOnly` in main: the editor
+   * spec's `parse` promotes any element whose whole text is `[[X]]`, which is
+   * useful on paste and destructive in a markdown importer. Same node either
+   * way — see wiki-link.ts.
+   */
+  wikiLink: InlineContentSpec<typeof wikiLinkConfig>
 }
 
 /**
@@ -27,7 +35,7 @@ export interface MemryInlineSpecs {
  */
 export function createMemryInlineContentSpecs(specs: MemryInlineSpecs) {
   return {
-    wikiLink: WikiLink,
+    wikiLink: specs.wikiLink,
     linkMention: LinkMention,
     hashTag: specs.hashTag,
     dateMention: specs.dateMention

--- a/packages/editor-schema/src/inline/index.ts
+++ b/packages/editor-schema/src/inline/index.ts
@@ -1,5 +1,5 @@
 import type { InlineContentSpec } from '@blocknote/core'
-import { LinkMention } from './link-mention'
+import { linkMentionConfig } from './link-mention'
 import { wikiLinkConfig } from './wiki-link'
 import { hashTagConfig } from './hash-tag'
 import { dateMentionConfig } from './date-mention'
@@ -13,8 +13,11 @@ export * from './date-mention'
  * The specs each process supplies for itself. The config and the serialization
  * half still come from here (via `createHashTagSpec` / `createDateMentionSpec`,
  * or `WikiLink` / `WikiLinkSerializationOnly`), so only presentation and
- * HTML-paste behaviour differ. linkMention needs no entry — it is portable and
- * shared whole.
+ * HTML-paste behaviour differ.
+ *
+ * Every one of the four is listed. None can be "shared whole": BlockNote
+ * serializes inline content inside a TABLE through `render`, so the editor's
+ * rich implementation reaching the main process rewrites that cell's markdown.
  */
 export interface MemryInlineSpecs {
   hashTag: InlineContentSpec<typeof hashTagConfig>
@@ -26,6 +29,13 @@ export interface MemryInlineSpecs {
    * way — see wiki-link.ts.
    */
   wikiLink: InlineContentSpec<typeof wikiLinkConfig>
+  /**
+   * `LinkMention` in the editor, `LinkMentionSerializationOnly` in main. The
+   * editor chip renders an `<a>`; in a table cell that `<a>` is what gets
+   * serialized, turning the `((mention:…))` token into a plain markdown link
+   * and dropping domain/title/favicon/siteName from disk.
+   */
+  linkMention: InlineContentSpec<typeof linkMentionConfig>
 }
 
 /**
@@ -36,7 +46,7 @@ export interface MemryInlineSpecs {
 export function createMemryInlineContentSpecs(specs: MemryInlineSpecs) {
   return {
     wikiLink: specs.wikiLink,
-    linkMention: LinkMention,
+    linkMention: specs.linkMention,
     hashTag: specs.hashTag,
     dateMention: specs.dateMention
   }

--- a/packages/editor-schema/src/inline/link-mention.ts
+++ b/packages/editor-schema/src/inline/link-mention.ts
@@ -4,7 +4,7 @@
  * why main needs the spec at all.
  */
 
-import { createInlineContentSpec } from '@blocknote/core'
+import { createInlineContentSpec, type InlineContentSpec } from '@blocknote/core'
 
 /**
  * Markdown persistence token for link mentions. A mention is serialized to
@@ -56,6 +56,34 @@ export const linkMentionConfig = {
   content: 'none' as const
 }
 
+/** Matches only the editor's own markup — no text heuristic, so it is safe on both sides. */
+const linkMentionParse = (element: HTMLElement) => {
+  if (element.hasAttribute('data-link-mention')) {
+    const url = element.getAttribute('data-url') || ''
+    const domain = element.getAttribute('data-domain') || ''
+    const title = element.getAttribute('data-title') || ''
+    const favicon = element.getAttribute('data-favicon') || ''
+    const siteName = element.getAttribute('data-site-name') || ''
+    if (!url) return undefined
+    return { url, domain, title, favicon, siteName }
+  }
+
+  return undefined
+}
+
+/**
+ * The node's on-disk form. Emits the markdown persistence token as plain text
+ * (not an `<a>`, which BlockNote's link mark would reclaim on reload);
+ * normalizeLinkMentions rebuilds the rich inline content from it on load.
+ */
+const linkMentionToExternalHTML = (inlineContent: {
+  props: { url: string }
+}): { dom: HTMLElement } => {
+  const dom = document.createElement('span')
+  dom.textContent = serializeLinkMentionToken(inlineContent.props.url)
+  return { dom }
+}
+
 export const LinkMention = createInlineContentSpec(linkMentionConfig, {
   render: (inlineContent) => {
     const { url, domain, title, favicon, siteName } = inlineContent.props
@@ -100,26 +128,26 @@ export const LinkMention = createInlineContentSpec(linkMentionConfig, {
     return { dom }
   },
 
-  parse: (element) => {
-    if (element.hasAttribute('data-link-mention')) {
-      const url = element.getAttribute('data-url') || ''
-      const domain = element.getAttribute('data-domain') || ''
-      const title = element.getAttribute('data-title') || ''
-      const favicon = element.getAttribute('data-favicon') || ''
-      const siteName = element.getAttribute('data-site-name') || ''
-      if (!url) return undefined
-      return { url, domain, title, favicon, siteName }
-    }
+  parse: linkMentionParse,
 
-    return undefined
-  },
-
-  toExternalHTML: (inlineContent) => {
-    // Emit the markdown persistence token as plain text (not an <a>, which
-    // BlockNote's link mark would reclaim on reload). normalizeLinkMentions
-    // rebuilds the rich inline content from this token on load.
-    const dom = document.createElement('span')
-    dom.textContent = serializeLinkMentionToken(inlineContent.props.url)
-    return { dom }
-  }
+  toExternalHTML: linkMentionToExternalHTML
 })
+
+/**
+ * The same node for the main process — same type, same props, same on-disk
+ * form — but rendering the token instead of the rich `<a>` chip.
+ *
+ * `render` is not dead weight on the server: BlockNote serializes inline
+ * content inside a TABLE through `render`, not `toExternalHTML`. With the
+ * editor's implementation registered, a mention in a table cell came out as
+ * `| [x.com](https://x.com/y) |` — the token, domain, title, favicon and
+ * siteName gone from disk for good. A server render must therefore emit
+ * exactly what `toExternalHTML` emits; it must never be rich, and it must
+ * never throw.
+ */
+export const LinkMentionSerializationOnly: InlineContentSpec<typeof linkMentionConfig> =
+  createInlineContentSpec(linkMentionConfig, {
+    render: linkMentionToExternalHTML,
+    parse: linkMentionParse,
+    toExternalHTML: linkMentionToExternalHTML
+  })

--- a/packages/editor-schema/src/inline/wiki-link.ts
+++ b/packages/editor-schema/src/inline/wiki-link.ts
@@ -5,10 +5,11 @@
  * same node: a spec the main-process schema does not carry is not a rendering
  * gap, it is data loss — y-prosemirror deletes any element it cannot build,
  * straight out of the shared Y.Doc. Fully portable (vanilla DOM, no renderer
- * imports), so both processes use this spec unchanged.
+ * imports); the node, its props and its on-disk form are shared, and only the
+ * HTML-paste `parse` rule differs (see `WikiLinkSerializationOnly` below).
  */
 
-import { createInlineContentSpec } from '@blocknote/core'
+import { createInlineContentSpec, type InlineContentSpec } from '@blocknote/core'
 
 const WIKI_LINK_FULL_PATTERN = /^\[\[([^\]|]+)(?:\|([^\]]+))?\]\]$/
 
@@ -49,6 +50,18 @@ export function wikiLinkToText(target: string, alias: string): string {
   return alias && alias !== target ? `[[${target}|${alias}]]` : `[[${target}]]`
 }
 
+/** The node's on-disk form. Identical in both processes — this is the contract. */
+const wikiLinkToExternalHTML = (inlineContent: {
+  props: { target: string; alias: string }
+}): { dom: HTMLElement } => {
+  const dom = document.createElement('span')
+  dom.textContent = wikiLinkToText(
+    inlineContent.props.target || '',
+    inlineContent.props.alias || ''
+  )
+  return { dom }
+}
+
 export const WikiLink = createInlineContentSpec(wikiLinkConfig, {
   render: (inlineContent) => {
     const dom = document.createElement('span')
@@ -75,12 +88,25 @@ export const WikiLink = createInlineContentSpec(wikiLinkConfig, {
     if (!parsed) return undefined
     return { target: parsed.target, alias: parsed.alias }
   },
-  toExternalHTML: (inlineContent) => {
-    const dom = document.createElement('span')
-    dom.textContent = wikiLinkToText(
-      inlineContent.props.target || '',
-      inlineContent.props.alias || ''
-    )
-    return { dom }
-  }
+  toExternalHTML: wikiLinkToExternalHTML
 })
+
+/**
+ * The same node for the main process — same type, same props, same on-disk
+ * form — but with no `parse` rule.
+ *
+ * The rule above is an editor paste convenience: it promotes ANY element whose
+ * whole text reads `[[X]]` into an inline node. In a markdown importer that is
+ * structural damage — a `- [[A]]` list item, a `> [[A]]` quote and a `| [[A]] |`
+ * table cell each parse as one such element, and the block around the link is
+ * lost. Main only ever needs to READ these nodes out of the shared Y.Doc and
+ * write them back, so it takes the node without the heuristic and keeps
+ * markdown parsing byte-for-byte what it is today.
+ */
+export const WikiLinkSerializationOnly: InlineContentSpec<typeof wikiLinkConfig> =
+  createInlineContentSpec(wikiLinkConfig, {
+    render: () => {
+      throw new Error('wikiLink server spec is serialization-only and must not be rendered')
+    },
+    toExternalHTML: wikiLinkToExternalHTML
+  })

--- a/packages/editor-schema/src/inline/wiki-link.ts
+++ b/packages/editor-schema/src/inline/wiki-link.ts
@@ -102,11 +102,14 @@ export const WikiLink = createInlineContentSpec(wikiLinkConfig, {
  * lost. Main only ever needs to READ these nodes out of the shared Y.Doc and
  * write them back, so it takes the node without the heuristic and keeps
  * markdown parsing byte-for-byte what it is today.
+ *
+ * `render` emits the same text as `toExternalHTML` rather than throwing:
+ * BlockNote serializes inline content inside a TABLE through `render`, so a
+ * throwing render made `yDocToMarkdown` return null for any note with a wiki
+ * link in a table — that note then stopped writing back entirely.
  */
 export const WikiLinkSerializationOnly: InlineContentSpec<typeof wikiLinkConfig> =
   createInlineContentSpec(wikiLinkConfig, {
-    render: () => {
-      throw new Error('wikiLink server spec is serialization-only and must not be rendered')
-    },
+    render: wikiLinkToExternalHTML,
     toExternalHTML: wikiLinkToExternalHTML
   })

--- a/packages/editor-schema/src/server.ts
+++ b/packages/editor-schema/src/server.ts
@@ -3,15 +3,25 @@
  *
  * Everything reachable from here runs under Node + jsdom: no React, no
  * renderer imports. What it supplies is the presentation half the package
- * deliberately leaves to each process — except that main never presents
- * anything, so every `render` throws. The parse/`toExternalHTML` halves, which
- * are what actually decide the bytes written to the vault, come from the same
- * modules the renderer uses.
+ * deliberately leaves to each process — and for main that half must emit
+ * exactly what `toExternalHTML` emits.
+ *
+ * It is tempting to make these renders throw, on the reasoning that a
+ * serialization-only schema never presents anything. That is wrong: BlockNote
+ * serializes inline content inside a TABLE through `render`, not
+ * `toExternalHTML`. A throwing render made `yDocToMarkdown` return null for
+ * any note holding a wiki link, hash tag or date mention in a table, which
+ * stopped that note's write-back completely; and leaving the editor's rich
+ * `linkMention` render in place rewrote `((mention:…))` as a plain markdown
+ * link, losing the token and its metadata from disk.
  */
 
 import {
   createHashTagSpec,
   createDateMentionSpec,
+  dateMentionSerialization,
+  hashTagSerialization,
+  LinkMentionSerializationOnly,
   WikiLinkSerializationOnly,
   type MemryInlineSpecs
 } from './inline'
@@ -21,11 +31,12 @@ export { createServerBlockSpecs } from './blocks/server-specs'
 export function createServerInlineSpecs(): MemryInlineSpecs {
   return {
     wikiLink: WikiLinkSerializationOnly,
-    hashTag: createHashTagSpec(() => {
-      throw new Error('hashTag server spec is serialization-only and must not be rendered')
-    }),
-    dateMention: createDateMentionSpec(() => {
-      throw new Error('dateMention server spec is serialization-only and must not be rendered')
-    })
+    linkMention: LinkMentionSerializationOnly,
+    hashTag: createHashTagSpec((inlineContent) =>
+      hashTagSerialization.toExternalHTML(inlineContent)
+    ),
+    dateMention: createDateMentionSpec((inlineContent) =>
+      dateMentionSerialization.toExternalHTML(inlineContent)
+    )
   }
 }

--- a/packages/editor-schema/src/server.ts
+++ b/packages/editor-schema/src/server.ts
@@ -1,0 +1,31 @@
+/**
+ * The main process's entry point into the shared schema.
+ *
+ * Everything reachable from here runs under Node + jsdom: no React, no
+ * renderer imports. What it supplies is the presentation half the package
+ * deliberately leaves to each process — except that main never presents
+ * anything, so every `render` throws. The parse/`toExternalHTML` halves, which
+ * are what actually decide the bytes written to the vault, come from the same
+ * modules the renderer uses.
+ */
+
+import {
+  createHashTagSpec,
+  createDateMentionSpec,
+  WikiLinkSerializationOnly,
+  type MemryInlineSpecs
+} from './inline'
+
+export { createServerBlockSpecs } from './blocks/server-specs'
+
+export function createServerInlineSpecs(): MemryInlineSpecs {
+  return {
+    wikiLink: WikiLinkSerializationOnly,
+    hashTag: createHashTagSpec(() => {
+      throw new Error('hashTag server spec is serialization-only and must not be rendered')
+    }),
+    dateMention: createDateMentionSpec(() => {
+      throw new Error('dateMention server spec is serialization-only and must not be rendered')
+    })
+  }
+}


### PR DESCRIPTION
Phase 1b of #1427, stacked on #1436. **Base is `h4yfans/wiki-link-deleted-on-sync`, not `main`** — review the top four commits only; merge #1436 first.

Refs #1431. Left open deliberately.

## What this closes

Main's `serverSchema` registered no custom inline content specs. It now builds from the same `@memry/editor-schema` factory the renderer uses, so `wikiLink`, `hashTag`, `linkMention` and `dateMention` survive the CRDT→markdown path and serialize back to their on-disk form. **This is the commit that restores wiki links.** The hand-mirrored `createServerTaskBlock` and its "keep this identical to the renderer's, forever" comment are gone — `taskBlockConfig` now has exactly one definition.

## Two bugs found in review, both would have hit real vaults

Neither had any test coverage. Both come from the same fact, which is not in BlockNote's docs: **BlockNote serializes inline content inside a table through the spec's `render`, not `toExternalHTML`.** For that one block type, main's rendering is what lands on disk.

**1. `linkMention` was shared whole**, so main used the editor's rich `<a>` chip. Verified output before the fix:

```
| ((mention:https%3A%2F%2Fx.com%2Fy)) |   →   | [x.com](https://x.com/y) |
```

The token, domain, title, favicon and siteName are destroyed on disk, permanently, for any note with a mention in a table.

**2. `wikiLink` / `hashTag` / `dateMention` rendered a `throw`** — my own guidance in the plan, on the reasoning that a serialization-only schema never presents anything. In a table that throw propagates: `yDocToMarkdown` returns `null` and the note **stops writing back entirely**.

```
wikiLink in a table  →  null
hashTag  in a table  →  null
```

Fix: every server `render` emits exactly what `toExternalHTML` emits, and all four inline types go through `MemryInlineSpecs`. None can be shared whole. After:

```
| [[Roadmap]] |     | ((mention:https%3A%2F%2Fx.com%2Fy)) |     | #work |
```

Five table cases are now a permanent test.

**3. `wikiLink`'s `parse` cannot be shared.** It promotes *any* element whose entire text reads `[[X]]` — a paste convenience in the editor, structural damage in a markdown importer. Measured against the parent commit over a 78-fixture corpus, 13 regressed: `- [[A]]\n- [[B]]` → `[[A]] [[B]]`, `> [[Quoted]]` → `[[Quoted]]`, `# [[Heading]]` → bare text, `- [ ] [[Roadmap]]` → checkbox destroyed, and a code fence containing only a link → bare text. Main takes `WikiLinkSerializationOnly`: same node, same props, same `toExternalHTML`, no `parse`.

## Byte stability

markdown → Y.Doc → markdown is byte-identical to the parent commit across a 78-fixture corpus (wiki links inline / alone / in lists / quotes / tables / headings / code fences / with aliases, hash tags, mentions, date mentions, task blocks with subtasks, nested lists, block colors, CriticMarkup, images, and mixed notes). Zero diffs. No pre-existing round-trip or note-fidelity test was edited.

## Known, not fixed here

`**[[A]]**` loses its bold. The renderer's `normalizeWikiLinks` promotes the text to a node and BlockNote's `CustomInlineContentFromConfig` has no `styles` field, so the mark is dropped **in the renderer, before main sees the document** — verified directly. It affects non-sync users identically and predates this epic; main is serializing the document faithfully. Worth its own issue; it is not something main can fix.

`callout`, `youtubeEmbed`, `bookmark` and `file` are still renderer-only — #1432. `findUnrepresentableNodes` fails write-back closed for them, so they are stranded-but-safe rather than deleted.

## Verification

- `test:main` — 512 files / 6357 tests
- `test:renderer` — 609 files / 6965 tests
- `typecheck` (node/web/test), `@memry/editor-schema typecheck`
- `check:architecture`, lint, `docs:impact --strict`, `docs:build`

No vault format, DB, sync protocol or IPC change. `pnpm-lock.yaml` untouched.
