### PR TITLE
fix(crdt): teach the main-process schema the custom block types

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -15,6 +15,7 @@ import { createMemrySchema, serializeLinkMentionToken } from '@memry/editor-sche
 import { MEMRY_BLOCK_TYPES } from '@memry/editor-schema/blocks'
 import { createServerBlockSpecs, createServerInlineSpecs } from '@memry/editor-schema/server'
 import { serializeDateMentionToken } from '@memry/shared/date-mention'
+import { fileBlockCommentData, parseFileBlockMarker } from '@memry/editor-schema/blocks'
 
 describe('blocknote-converter code block language', () => {
   it('returns empty markdown for an empty Yjs fragment', async () => {
@@ -1290,5 +1291,96 @@ describe('custom inline content inside a table', () => {
     // #then
     expect(markdown).not.toBeNull()
     expect(markdown).toContain(serializeDateMentionToken(props))
+  })
+})
+
+describe('custom block markers are not claimed out of context', () => {
+  const FENCE3 = '`'.repeat(3)
+  const FENCE4 = '`'.repeat(4)
+  const FILE_MARKER =
+    '<!-- file:{"url":"memry-file://local/v/a/x.pdf","name":"x.pdf","size":1234,"mimeType":"application/pdf"} -->'
+
+  async function roundTrip(markdown: string): Promise<string | null> {
+    const doc = new Y.Doc()
+    await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    return await yDocToMarkdown(doc)
+  }
+
+  it('a marker quoted inside a nested code fence stays text', async () => {
+    // #given a note documenting the marker format — a four-backtick fence
+    // wrapping a three-backtick one. A fence tracker that only toggles on
+    // /^```/ reads the inner fence as the closing one, and everything after it
+    // as live markdown: the code block is torn in two and the *example* marker
+    // becomes a real file block pointing at a PDF.
+    const markdown = `How the marker looks:\n\n${FENCE4}md\n${FENCE3}\n${FILE_MARKER}\n${FENCE3}\n${FENCE4}\n\nThat is all.`
+
+    // #when
+    const result = await roundTrip(markdown)
+
+    // #then
+    expect(result).toBe(markdown)
+  })
+
+  it('a tilde fence does not close a backtick fence', async () => {
+    // #given ~~~ inside a ``` block is content, not a delimiter
+    const markdown = `${FENCE3}md\n~~~\n${FILE_MARKER}\n~~~\n${FENCE3}`
+
+    // #when / #then
+    expect(await roundTrip(markdown)).toBe(markdown)
+  })
+
+  it('keeps a block-colour marker that follows a nested fence', async () => {
+    // #given colours are parsed on a path that predates custom blocks. Guarding
+    // it on fence state made a marker after a fence the tracker read wrong
+    // vanish from the vault file — data loss on a path this work never touched.
+    const markdown = `${FENCE4}\n${FENCE3}\n${FENCE4}\n\n<!-- colors:{"backgroundColor":"blue"} -->\ntinted`
+
+    // #when
+    const result = await roundTrip(markdown)
+
+    // #then the colour survives (the fence's language tag is normalized by
+    // remark on both sides of this change, so compare the part that matters)
+    expect(result).toContain('<!-- colors:{"backgroundColor":"blue"} -->\ntinted')
+  })
+
+  it('leaves an embed marker indented under a list item nested', async () => {
+    // #given the renderer matches the two image markers on the RAW line, so a
+    // marker indented under a list item is content. Trimming first claims it
+    // and the nesting is lost — the same file would then parse to a different
+    // document depending on which process read it.
+    const markdown = '- item\n\n  ![embed](https://youtu.be/dQw4w9WgXcQ)'
+
+    // #when
+    const result = await roundTrip(markdown)
+
+    // #then the nesting marker is still there
+    expect(result).toContain('block-nesting-level=1')
+  })
+
+  it('leaves a real image whose alt text happens to be bookmark alone', async () => {
+    // #given someone's screenshot, not a bookmark card. The embed branch has
+    // extractYouTubeVideoId for this; the bookmark branch needs its own check.
+    const markdown = '![bookmark](assets/photo.png)'
+
+    // #when / #then
+    expect(await roundTrip(markdown)).toBe(markdown)
+  })
+
+  it('a file name containing --> does not truncate the marker', async () => {
+    // #given `-->` closes an HTML comment, so an unescaped one splits the
+    // marker and spills the rest of the JSON into the note as a paragraph
+    const props = {
+      url: 'memry-file://x/y.pdf',
+      name: 'a-->b.pdf',
+      size: 5,
+      mimeType: 'application/pdf'
+    }
+
+    // #when
+    const marker = `<!--${fileBlockCommentData(props as never)}-->`
+
+    // #then the comment has exactly one terminator, and the name survives it
+    expect(marker.match(/-->/g)).toHaveLength(1)
+    expect(parseFileBlockMarker(marker)).toMatchObject({ name: 'a-->b.pdf' })
   })
 })

--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -9,8 +9,11 @@ import {
   findUnrepresentableNodes
 } from './blocknote-converter'
 import * as Y from 'yjs'
+import { ServerBlockNoteEditor } from '@blocknote/server-util'
 import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
-import { serializeLinkMentionToken } from '@memry/editor-schema'
+import { createMemrySchema, serializeLinkMentionToken } from '@memry/editor-schema'
+import { MEMRY_BLOCK_TYPES } from '@memry/editor-schema/blocks'
+import { createServerBlockSpecs, createServerInlineSpecs } from '@memry/editor-schema/server'
 import { serializeDateMentionToken } from '@memry/shared/date-mention'
 
 describe('blocknote-converter code block language', () => {
@@ -897,7 +900,17 @@ describe('registering the custom specs does not rewrite existing markdown', () =
     '> [[Quoted]]',
     '- [ ] a task {task:t1}',
     '```ts\nconst x = "[[Roadmap]]"\n```',
-    '((date:eyJhbmNob3JJZCI6ImExIn0)) leftover token.'
+    '((date:eyJhbmNob3JJZCI6ImExIn0)) leftover token.',
+    // Callouts stay quote blocks on this path: their marker line carries a type
+    // and an optional title the callout schema cannot hold, so parsing them
+    // would rewrite `> [!note]` as `> [!info]` in every Obsidian vault.
+    '> [!info]\n> Heads up',
+    '> [!note]\n> An Obsidian type this schema has no value for',
+    '> [!info] A title on the marker line\n> and a body',
+    // A marker inside a fence is the author's text, not a marker.
+    '```md\n![bookmark](https://example.com)\n<!-- file:{"url":"u","name":"n","size":1,"mimeType":"m"} -->\n```',
+    // `![embed](…)` only becomes a video when there is a video to play.
+    '![embed](https://example.com/not-a-video)'
   ])('round-trips %j unchanged', async (markdown) => {
     // #given a vault note as it exists on disk today
     const doc = new Y.Doc()
@@ -907,6 +920,272 @@ describe('registering the custom specs does not rewrite existing markdown', () =
     // #when write-back serializes it again
     // #then the bytes are the same, so nothing is written
     expect(await yDocToMarkdown(doc)).toBe(markdown)
+  })
+})
+
+/**
+ * Every custom BLOCK type, with the markdown form it must serialize to and the
+ * block the renderer authors for it. A new block spec with no case here fails
+ * this table rather than being silently untested — the whole class of bug was
+ * one spec nobody covered.
+ *
+ * The markdown is the form already on disk today, read from the functions that
+ * write it: `serializeCalloutBlock`, `serializeYoutubeEmbed`,
+ * `serializeBookmark`, `serializeFileBlock` and `serializeTaskBlock`.
+ */
+const BLOCK_CASES = [
+  {
+    type: 'callout',
+    markdown: '> [!info]\n> Heads up',
+    block: {
+      id: 'blk',
+      type: 'callout',
+      props: { type: 'info', textAlignment: 'left', textColor: 'default' },
+      content: [{ type: 'text', text: 'Heads up', styles: {} }],
+      children: []
+    }
+  },
+  {
+    type: 'youtubeEmbed',
+    markdown: '![embed](https://www.youtube.com/watch?v=dQw4w9WgXcQ)',
+    block: {
+      id: 'blk',
+      type: 'youtubeEmbed',
+      props: { videoId: 'dQw4w9WgXcQ', videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+      children: []
+    }
+  },
+  {
+    type: 'bookmark',
+    markdown: '![bookmark](https://example.com/a)',
+    block: {
+      id: 'blk',
+      type: 'bookmark',
+      props: {
+        url: 'https://example.com/a',
+        domain: 'example.com',
+        title: '',
+        description: '',
+        image: '',
+        favicon: '',
+        siteName: ''
+      },
+      children: []
+    }
+  },
+  {
+    type: 'file',
+    markdown:
+      '<!-- file:{"url":"memry-file://local/v/a/x.pdf","name":"x.pdf","size":1234,"mimeType":"application/pdf"} -->',
+    block: {
+      id: 'blk',
+      type: 'file',
+      props: {
+        url: 'memry-file://local/v/a/x.pdf',
+        name: 'x.pdf',
+        size: 1234,
+        mimeType: 'application/pdf',
+        width: 0,
+        height: 0,
+        align: 'left'
+      },
+      children: []
+    }
+  },
+  {
+    type: 'taskBlock',
+    markdown: '- [ ] a task {task:t1}',
+    block: {
+      id: 'blk',
+      type: 'taskBlock',
+      props: { taskId: 't1', title: 'a task', checked: false, parentTaskId: '' },
+      children: []
+    }
+  }
+] as const
+
+function docHolding(block: unknown): Y.Doc {
+  const doc = new Y.Doc()
+  blocksToYFragment(
+    [block] as unknown as Parameters<typeof blocksToYFragment>[0],
+    doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+  )
+  return doc
+}
+
+describe('custom blocks survive the CRDT write path', () => {
+  it.each(BLOCK_CASES.filter((c) => c.type !== 'taskBlock'))(
+    '$type survives markdown → doc → markdown unchanged',
+    async ({ markdown }) => {
+      // #given a vault note as it exists on disk today
+      const doc = new Y.Doc()
+      const ok = await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+      expect(ok).toBe(true)
+
+      // #when write-back serializes it again
+      // #then the bytes are identical, so nothing is written
+      expect(await yDocToMarkdown(doc)).toBe(markdown)
+    }
+  )
+
+  it.each(BLOCK_CASES)(
+    '$type serializes to its on-disk form without touching the doc',
+    async ({ block, markdown }) => {
+      // #given the doc the renderer produces when the user authors the block
+      const doc = docHolding(block)
+      const before = Y.encodeStateAsUpdate(doc)
+
+      // #when write-back serializes it
+      const result = await yDocToMarkdown(doc)
+
+      // #then the vault file gets the exact marker it holds today…
+      expect(result).toBe(markdown)
+      // …and the shared doc is untouched: y-prosemirror's answer to a node it
+      // cannot build is to DELETE it, which replicates to every other device.
+      expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+    }
+  )
+
+  it.each(BLOCK_CASES)('$type is representable by this build', ({ block }) => {
+    // #given / #when / #then — a name missing from the schema is a replicated
+    // delete, and write-back refuses the whole file when it sees one.
+    expect(findUnrepresentableNodes(docHolding(block))).toEqual([])
+  })
+
+  it.each(BLOCK_CASES)(
+    '$type keeps its marker nested under a list item',
+    async ({ block, markdown }) => {
+      // #given a block indented under a bullet. This path does NOT take the
+      // converter's top-level branch — it goes through the spec's own HTML,
+      // which is where a `render` that throws stops the note writing back.
+      const doc = docHolding({
+        id: 'parent',
+        type: 'bulletListItem',
+        props: { textAlignment: 'left', textColor: 'default', backgroundColor: 'default' },
+        content: [{ type: 'text', text: 'parent', styles: {} }],
+        children: [block]
+      })
+
+      // #when
+      const result = await yDocToMarkdown(doc)
+
+      // #then the conversion succeeds at all (a throwing render returns null)…
+      expect(result).not.toBeNull()
+      // …and the nested block still carries its own marker, not editor markup
+      expect(result).toContain('parent')
+      expect(result).toContain(markdown)
+    }
+  )
+})
+
+describe('custom blocks and table cells', () => {
+  // The inline specs have to survive a table cell because BlockNote serializes
+  // inline content through `render` there. Blocks cannot: a cell holds inline
+  // content only, so no block spec's `render` is reachable that way. That is a
+  // property of the schema, so it is proven rather than assumed — if a future
+  // BlockNote lets a block into a cell, this fails and the block specs need the
+  // same treatment the inline ones got.
+  it('a table cell admits inline content only, so no block spec renders inside one', () => {
+    const pmSchema = serverEditorForSchemaInspection().editor.pmSchema
+
+    for (const cellNode of ['tableCell', 'tableHeader', 'tableParagraph']) {
+      const content = pmSchema.nodes[cellNode]?.spec.content ?? ''
+      for (const blockType of MEMRY_BLOCK_TYPES) {
+        expect(content).not.toContain(blockType)
+      }
+    }
+  })
+
+  it.each(BLOCK_CASES)(
+    '$type serializes next to a table without breaking it',
+    async ({ block, markdown }) => {
+      // #given a note that holds both — the combination that made a throwing spec
+      // return null for the whole document rather than for one block
+      const doc = new Y.Doc()
+      blocksToYFragment(
+        [
+          block,
+          {
+            id: 'tbl',
+            type: 'table',
+            props: {},
+            children: [],
+            content: {
+              type: 'tableContent',
+              columnWidths: [null],
+              rows: [
+                {
+                  cells: [
+                    {
+                      type: 'tableCell',
+                      content: [{ type: 'text', text: 'x', styles: {} }],
+                      props: {
+                        colspan: 1,
+                        rowspan: 1,
+                        backgroundColor: 'default',
+                        textColor: 'default',
+                        textAlignment: 'left'
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ] as unknown as Parameters<typeof blocksToYFragment>[0],
+        doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+      )
+
+      // #when / #then
+      const result = await yDocToMarkdown(doc)
+      expect(result).not.toBeNull()
+      expect(result).toContain(markdown)
+    }
+  )
+})
+
+/**
+ * The same schema `blocknote-converter` builds, in an editor of its own, purely
+ * so a test can look at the ProseMirror schema and call the specs directly.
+ */
+function serverEditorForSchemaInspection(): ServerBlockNoteEditor {
+  return ServerBlockNoteEditor.create({
+    schema: createMemrySchema({
+      blocks: createServerBlockSpecs(),
+      inline: createServerInlineSpecs()
+    })
+  }) as ServerBlockNoteEditor
+}
+
+describe('server block specs never present anything render-only', () => {
+  // `render` is not presentation in the main process: BlockNote reaches it for
+  // anything it serializes without a `toExternalHTML`, and one throw there makes
+  // `yDocToMarkdown` return null — the note stops writing back entirely. So the
+  // two have to be the same DOM, and neither may throw.
+  it.each(BLOCK_CASES)('$type renders exactly what it serializes', async ({ block, type }) => {
+    const specs = createServerBlockSpecs() as unknown as Record<
+      string,
+      {
+        implementation: {
+          render: (block: unknown, editor: unknown) => { dom: HTMLElement }
+          toExternalHTML?: (
+            block: unknown,
+            editor: unknown,
+            context: { nestingLevel: number }
+          ) => { dom: HTMLElement } | undefined
+        }
+      }
+    >
+    const impl = specs[type].implementation
+
+    // The specs build real DOM, which only exists inside server-util's JSDOM.
+    await serverEditorForSchemaInspection()._withJSDOM(async () => {
+      const rendered = impl.render(block, null)
+      const external = impl.toExternalHTML?.(block, null, { nestingLevel: 0 })
+
+      expect(external).toBeDefined()
+      expect(rendered.dom.outerHTML).toBe(external!.dom.outerHTML)
+    })
   })
 })
 

--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -1366,21 +1366,37 @@ describe('custom block markers are not claimed out of context', () => {
     expect(await roundTrip(markdown)).toBe(markdown)
   })
 
-  it('a file name containing --> does not truncate the marker', async () => {
-    // #given `-->` closes an HTML comment, so an unescaped one splits the
-    // marker and spills the rest of the JSON into the note as a paragraph
-    const props = {
-      url: 'memry-file://x/y.pdf',
-      name: 'a-->b.pdf',
-      size: 5,
-      mimeType: 'application/pdf'
+  // HTML closes a comment on `-->` and on `--!>` (the spec's comment-end-bang
+  // state). Either one inside the payload splits the marker and spills the rest
+  // of the JSON into the note as a paragraph — a file named `a-->b.pdf` is
+  // enough. Only the `>` is escaped: escaping every `--` would change the bytes
+  // of every marker whose filename contains one.
+  it.each([['a-->b.pdf'], ['a--!>b.pdf'], ['a--b--c.pdf']])(
+    'a file named %s survives the marker round-trip',
+    (name) => {
+      // #given
+      const props = { url: 'memry-file://x/y.pdf', name, size: 5, mimeType: 'application/pdf' }
+
+      // #when
+      const marker = `<!--${fileBlockCommentData(props as never)}-->`
+
+      // #then exactly one terminator — the one that closes the marker
+      expect(marker.match(/--!?>/g)).toHaveLength(1)
+      expect(parseFileBlockMarker(marker)).toMatchObject({ name })
     }
+  )
+
+  it('does not scan quadratically over a line that only looks like a marker', () => {
+    // #given note bodies arrive over sync, so an unanchored scan here is
+    // reachable input. Unanchored this took 392ms at 8k repetitions.
+    const decoy = '<!-- file:{'.repeat(8000)
 
     // #when
-    const marker = `<!--${fileBlockCommentData(props as never)}-->`
+    const started = performance.now()
+    const parsed = parseFileBlockMarker(decoy)
 
-    // #then the comment has exactly one terminator, and the name survives it
-    expect(marker.match(/-->/g)).toHaveLength(1)
-    expect(parseFileBlockMarker(marker)).toMatchObject({ name: 'a-->b.pdf' })
+    // #then rejected, and in constant-ish time rather than seconds
+    expect(parsed).toBeNull()
+    expect(performance.now() - started).toBeLessThan(50)
   })
 })

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -1,7 +1,14 @@
 import { ServerBlockNoteEditor } from '@blocknote/server-util'
 import { type Block, type PartialBlock } from '@blocknote/core'
 import { createMemrySchema } from '@memry/editor-schema'
+import {
+  BOOKMARK_LINE_REGEX,
+  EMBED_LINE_REGEX,
+  FILE_BLOCK_LINE_REGEX,
+  parseFileBlockMarker
+} from '@memry/editor-schema/blocks'
 import { createServerBlockSpecs, createServerInlineSpecs } from '@memry/editor-schema/server'
+import { extractYouTubeVideoId } from '@memry/shared/youtube'
 import { randomUUID } from 'node:crypto'
 import * as Y from 'yjs'
 import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
@@ -389,20 +396,90 @@ async function parseContentWithColorMarkers(
     buffer = []
   }
 
+  let insideFence = false
+
   for (const line of text.split('\n')) {
-    if (BLOCK_COLORS_LINE_REGEX.test(line.trim())) {
-      const colors = parseBlockColorsMarker(line.trim())
+    const trimmed = line.trim()
+    // A marker inside a code fence is the author's text, not a marker.
+    if (CODE_FENCE_LINE_REGEX.test(trimmed)) insideFence = !insideFence
+
+    if (!insideFence && BLOCK_COLORS_LINE_REGEX.test(trimmed)) {
+      const colors = parseBlockColorsMarker(trimmed)
       if (colors) {
         await flushBuffer()
         pendingColors = colors
         continue
       }
     }
+
+    const marker = insideFence ? null : parseCustomBlockMarkerLine(trimmed)
+    if (marker) {
+      await flushBuffer()
+      pendingColors = null
+      blocks.push(marker)
+      continue
+    }
+
     buffer.push(line)
   }
   await flushBuffer()
 
   return blocks
+}
+
+const CODE_FENCE_LINE_REGEX = /^(?:```|~~~)/
+
+/**
+ * The three custom blocks whose on-disk form is a single marker line.
+ *
+ * Without this, the main process — which is what seeds a note's shared Y.Doc
+ * from the vault file — parses each marker as something else and the block is
+ * gone before the editor ever sees it: `<!-- file:{…} -->` is dropped outright
+ * (an HTML comment BlockNote has no block for), and both `![…](url)` markers
+ * become plain image blocks pointing at a page rather than an image.
+ *
+ * The renderer's own parser does exactly this (`splitByEmbedMarkers` in
+ * markdown-utils.ts); it only ever runs on the non-collaborative path, so this
+ * is the same rule applied where the collaborative path actually parses.
+ *
+ * Callouts deliberately have no case here. Their marker line carries a type and
+ * an optional title that this schema cannot hold — `> [!note]` and `> [!tip]`
+ * are not among the four values `calloutConfig` allows, and a title after the
+ * marker moves onto its own line on the way back out. Parsing them would
+ * rewrite `> [!note]` as `> [!info]` in every Obsidian vault; left alone they
+ * stay quote blocks and their bytes stay untouched.
+ */
+function parseCustomBlockMarkerLine(line: string): Block | null {
+  if (FILE_BLOCK_LINE_REGEX.test(line)) {
+    const props = parseFileBlockMarker(line)
+    if (props) return { type: 'file', props } as unknown as Block
+  }
+
+  const embed = line.match(EMBED_LINE_REGEX)
+  if (embed) {
+    const videoId = extractYouTubeVideoId(embed[1])
+    // A non-YouTube `![embed](…)` has no video to play; it stays an image.
+    if (videoId) {
+      return { type: 'youtubeEmbed', props: { videoId, videoUrl: embed[1] } } as unknown as Block
+    }
+  }
+
+  const bookmark = line.match(BOOKMARK_LINE_REGEX)
+  if (bookmark) {
+    const url = bookmark[1]
+    return { type: 'bookmark', props: { url, domain: bookmarkDomain(url) } } as unknown as Block
+  }
+
+  return null
+}
+
+/** Display-only host label; never reaches the vault file. */
+function bookmarkDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace('www.', '')
+  } catch {
+    return url
+  }
 }
 
 async function blocksToMarkdownPreserving(

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -396,14 +396,18 @@ async function parseContentWithColorMarkers(
     buffer = []
   }
 
-  let insideFence = false
+  const fence = createFenceTracker()
 
   for (const line of text.split('\n')) {
     const trimmed = line.trim()
     // A marker inside a code fence is the author's text, not a marker.
-    if (CODE_FENCE_LINE_REGEX.test(trimmed)) insideFence = !insideFence
+    const insideFence = fence.consume(line)
 
-    if (!insideFence && BLOCK_COLORS_LINE_REGEX.test(trimmed)) {
+    // Deliberately NOT fence-guarded: this branch predates custom-block parsing
+    // and guarding it would drop a colour marker that follows a fence this
+    // tracker read differently, which is data loss on a path #1432 never
+    // touched. The renderer's twin (markdown-utils.ts) is unguarded too.
+    if (BLOCK_COLORS_LINE_REGEX.test(trimmed)) {
       const colors = parseBlockColorsMarker(trimmed)
       if (colors) {
         await flushBuffer()
@@ -412,7 +416,7 @@ async function parseContentWithColorMarkers(
       }
     }
 
-    const marker = insideFence ? null : parseCustomBlockMarkerLine(trimmed)
+    const marker = insideFence ? null : parseCustomBlockMarkerLine(line)
     if (marker) {
       await flushBuffer()
       pendingColors = null
@@ -427,7 +431,42 @@ async function parseContentWithColorMarkers(
   return blocks
 }
 
-const CODE_FENCE_LINE_REGEX = /^(?:```|~~~)/
+/**
+ * CommonMark fence tracking, not a parity toggle.
+ *
+ * A boolean flipped by /^(?:```|~~~)/ is wrong in the way that matters here: it
+ * tracks neither the fence character nor its length, so a ```` ```` ```` block
+ * quoting an inner ``` — the shape of any note that documents this very marker
+ * format — reads as closed halfway through. The example marker inside it then
+ * parses as a real block and write-back rewrites the file around it.
+ *
+ * A fence opens with 3+ of ` or ~ (up to 3 leading spaces) and closes only on
+ * the SAME character, at least as long, with nothing after it.
+ */
+function createFenceTracker(): { consume: (line: string) => boolean } {
+  let open: { char: string; length: number } | null = null
+
+  return {
+    /** True when `line` is inside a fence — the opening/closing lines included. */
+    consume: (line) => {
+      const match = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/)
+      if (!match) return open !== null
+
+      const char = match[1][0]
+      const length = match[1].length
+      if (open === null) {
+        // An info string may not contain a backtick (CommonMark 4.5).
+        if (char === '`' && match[2].includes('`')) return false
+        open = { char, length }
+        return true
+      }
+      if (char === open.char && length >= open.length && match[2].trim() === '') {
+        open = null
+      }
+      return true
+    }
+  }
+}
 
 /**
  * The three custom blocks whose on-disk form is a single marker line.
@@ -450,8 +489,14 @@ const CODE_FENCE_LINE_REGEX = /^(?:```|~~~)/
  * stay quote blocks and their bytes stay untouched.
  */
 function parseCustomBlockMarkerLine(line: string): Block | null {
-  if (FILE_BLOCK_LINE_REGEX.test(line)) {
-    const props = parseFileBlockMarker(line)
+  // Matched exactly the way the renderer matches (markdown-utils.ts): `file` on
+  // the trimmed line, the two image markers on the raw one. Trimming those two
+  // as well would claim a marker indented under a list item, dropping the
+  // nesting the parent preserved — and would make the same file parse to a
+  // different document depending on which process read it.
+  const trimmed = line.trim()
+  if (FILE_BLOCK_LINE_REGEX.test(trimmed)) {
+    const props = parseFileBlockMarker(trimmed)
     if (props) return { type: 'file', props } as unknown as Block
   }
 
@@ -467,18 +512,27 @@ function parseCustomBlockMarkerLine(line: string): Block | null {
   const bookmark = line.match(BOOKMARK_LINE_REGEX)
   if (bookmark) {
     const url = bookmark[1]
-    return { type: 'bookmark', props: { url, domain: bookmarkDomain(url) } } as unknown as Block
+    // `![bookmark](assets/photo.png)` is someone's image with an unlucky alt
+    // text, not a bookmark card. The embed branch has `extractYouTubeVideoId`
+    // for the same reason; this is its counterpart.
+    const parsed = parseHttpUrl(url)
+    if (parsed) {
+      return {
+        type: 'bookmark',
+        props: { url, domain: parsed.hostname.replace(/^www\./, '') }
+      } as unknown as Block
+    }
   }
 
   return null
 }
 
-/** Display-only host label; never reaches the vault file. */
-function bookmarkDomain(url: string): string {
+function parseHttpUrl(url: string): URL | null {
   try {
-    return new URL(url).hostname.replace('www.', '')
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed : null
   } catch {
-    return url
+    return null
   }
 }
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/bookmark-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/bookmark-block.tsx
@@ -9,4 +9,4 @@ export const createBookmarkBlock = createReactBlockSpec(bookmarkConfig, {
   render: BookmarkBlockRender
 })
 
-export { BOOKMARK_BLOCK_REGEX, serializeBookmark } from '@memry/editor-schema/blocks'
+export { serializeBookmark } from '@memry/editor-schema/blocks'

--- a/apps/desktop/src/renderer/src/components/note/content-area/bookmark-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/bookmark-block.tsx
@@ -1,27 +1,12 @@
 import { createReactBlockSpec } from '@blocknote/react'
+import { bookmarkConfig } from '@memry/editor-schema/blocks'
 import { BookmarkBlockRender } from './bookmark-block-render'
 
-export const createBookmarkBlock = createReactBlockSpec(
-  {
-    type: 'bookmark' as const,
-    propSchema: {
-      url: { default: '' },
-      domain: { default: '' },
-      title: { default: '' },
-      description: { default: '' },
-      image: { default: '' },
-      favicon: { default: '' },
-      siteName: { default: '' }
-    },
-    content: 'none'
-  },
-  {
-    render: BookmarkBlockRender
-  }
-)
+// Type/props/content and the `![bookmark](url)` on-disk form come from the
+// shared package so the main process registers the same node and writes the
+// same bytes.
+export const createBookmarkBlock = createReactBlockSpec(bookmarkConfig, {
+  render: BookmarkBlockRender
+})
 
-export const BOOKMARK_BLOCK_REGEX = /!\[bookmark\]\(([^)]+)\)/g
-
-export function serializeBookmark(url: string): string {
-  return `![bookmark](${url})`
-}
+export { BOOKMARK_BLOCK_REGEX, serializeBookmark } from '@memry/editor-schema/blocks'

--- a/apps/desktop/src/renderer/src/components/note/content-area/callout-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/callout-block.tsx
@@ -1,5 +1,5 @@
-import { defaultProps } from '@blocknote/core'
 import { createReactBlockSpec } from '@blocknote/react'
+import { calloutConfig, CALLOUT_LINE_REGEX } from '@memry/editor-schema/blocks'
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -140,29 +140,17 @@ function CalloutBlockRenderer({ block, editor, contentRef }: CalloutBlockRendere
   )
 }
 
-export const createCalloutBlock = createReactBlockSpec(
-  {
-    type: 'callout' as const,
-    propSchema: {
-      textAlignment: defaultProps.textAlignment,
-      textColor: defaultProps.textColor,
-      type: {
-        default: 'info' as const,
-        values: ['info', 'warning', 'error', 'success'] as const
-      }
-    },
-    content: 'inline'
-  },
-  {
-    render: (props) => (
-      <CalloutBlockRenderer
-        block={props.block as CalloutBlock}
-        editor={props.editor}
-        contentRef={props.contentRef}
-      />
-    )
-  }
-)
+// Type/props/content come from the shared config so this block and the main
+// process's headless twin cannot disagree; only the React presentation is here.
+export const createCalloutBlock = createReactBlockSpec(calloutConfig, {
+  render: (props) => (
+    <CalloutBlockRenderer
+      block={props.block as CalloutBlock}
+      editor={props.editor}
+      contentRef={props.contentRef}
+    />
+  )
+})
 
 export function getCalloutSlashMenuItem(
   editor: unknown,
@@ -188,15 +176,12 @@ export function getCalloutSlashMenuItem(
 // Callout Block Serialization (> [!type]\n> content)
 // ============================================================================
 
-// Matches a callout block: starts with > [!type], followed by consecutive > lines
-const CALLOUT_LINE_REGEX = /^> \[!(\w+)\](.*)/
-
-export function serializeCalloutBlock(type: string, contentMarkdown: string): string {
-  const lines = contentMarkdown.split('\n').filter((l) => l.length > 0)
-  if (lines.length === 0) return `> [!${type}]`
-  const quoted = lines.map((line) => `> ${line}`).join('\n')
-  return `> [!${type}]\n${quoted}`
-}
+// The `> [!type]` form lives in @memry/editor-schema/blocks so the main process
+// writes the same bytes. The splitter below stays here: it is the editor's
+// lenient reader (an unknown type falls back to `info`, a title on the marker
+// line moves into the body), which is fine for a paste but would rewrite every
+// `> [!note]` in an Obsidian vault if the CRDT parser used it.
+export { serializeCalloutBlock } from '@memry/editor-schema/blocks'
 
 export type CalloutSegment = { kind: 'callout'; type: CalloutTypeValue; content: string }
 export type MarkdownSegment = { kind: 'markdown'; text: string }

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block-markers.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block-markers.ts
@@ -1,68 +1,11 @@
-export interface FileBlockProps {
-  url: string
-  name: string
-  size: number
-  mimeType: string
-  /**
-   * User-set display width in px for the inline PDF preview. `0`/undefined means
-   * "use the default width" and is omitted from the marker so legacy markers stay
-   * byte-for-byte identical on re-save.
-   */
-  width?: number
-  /**
-   * User-set crop height in px for the inline PDF preview. `0`/undefined means
-   * "fit the first page" (no crop) and is omitted from the marker, so markers
-   * that were never height-resized stay byte-for-byte identical on re-save.
-   */
-  height?: number
-  /**
-   * Alignment of the embed within the note column. `'left'` is the default and is
-   * omitted from the marker so markers that were never aligned stay byte-identical.
-   */
-  align?: 'left' | 'center' | 'right'
-}
-
 /**
- * Regex to match file block markers in markdown
- * Format: <!-- file:{"url":"...","name":"...","size":123,"mimeType":"...","width":720} -->
+ * The file block's on-disk form now lives in `@memry/editor-schema/blocks`, so
+ * the main process writes the exact same marker bytes this editor does. Kept as
+ * a re-export because the marker is imported from here all over the renderer.
  */
-export const FILE_BLOCK_REGEX = /<!-- file:(\{[^}]+\}) -->/g
-
-/**
- * Serialize file block props to markdown marker.
- *
- * Keys are written in a fixed order and the default `width`/`height` (0) are
- * dropped, so a block that was never resized produces the exact same marker
- * bytes as before the width/height props existed.
- */
-export function serializeFileBlock(props: FileBlockProps): string {
-  const payload: FileBlockProps = {
-    url: props.url,
-    name: props.name,
-    size: props.size,
-    mimeType: props.mimeType
-  }
-  if (typeof props.width === 'number' && props.width > 0) {
-    payload.width = props.width
-  }
-  if (typeof props.height === 'number' && props.height > 0) {
-    payload.height = props.height
-  }
-  if (props.align && props.align !== 'left') {
-    payload.align = props.align
-  }
-  return `<!-- file:${JSON.stringify(payload)} -->`
-}
-
-/**
- * Parse file block marker from markdown
- */
-export function parseFileBlockMarker(marker: string): FileBlockProps | null {
-  const match = marker.match(/<!-- file:(\{[^}]+\}) -->/)
-  if (!match) return null
-  try {
-    return JSON.parse(match[1])
-  } catch {
-    return null
-  }
-}
+export {
+  FILE_BLOCK_REGEX,
+  serializeFileBlock,
+  parseFileBlockMarker,
+  type FileBlockProps
+} from '@memry/editor-schema/blocks'

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block-markers.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block-markers.ts
@@ -4,7 +4,6 @@
  * a re-export because the marker is imported from here all over the renderer.
  */
 export {
-  FILE_BLOCK_REGEX,
   serializeFileBlock,
   parseFileBlockMarker,
   type FileBlockProps

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -32,7 +32,7 @@ import { useSync } from '@/contexts/sync-context'
 import { useT } from '@memry/i18n/renderer'
 import type { FileBlockProps } from './file-block-markers'
 
-export { FILE_BLOCK_REGEX, parseFileBlockMarker, serializeFileBlock } from './file-block-markers'
+export { parseFileBlockMarker, serializeFileBlock } from './file-block-markers'
 export type { FileBlockProps } from './file-block-markers'
 
 // Configure PDF.js worker

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -9,6 +9,7 @@ import { getI18n } from 'react-i18next'
 import { useState, useCallback, useRef, useLayoutEffect } from 'react'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { createReactBlockSpec } from '@blocknote/react'
+import { fileBlockConfig } from '@memry/editor-schema/blocks'
 import { Document, Page, pdfjs } from 'react-pdf'
 import 'react-pdf/dist/Page/AnnotationLayer.css'
 import 'react-pdf/dist/Page/TextLayer.css'
@@ -684,24 +685,13 @@ function FileBlockRender({
   )
 }
 
-export const createFileBlock = createReactBlockSpec(
-  {
-    type: 'file',
-    propSchema: {
-      url: { default: '' },
-      name: { default: '' },
-      size: { default: 0 },
-      mimeType: { default: '' },
-      width: { default: 0 },
-      height: { default: 0 },
-      align: { default: 'left' as const, values: ['left', 'center', 'right'] as const }
-    },
-    content: 'none'
-  },
-  {
-    render: FileBlockRender
-  }
-)
+// Type/props/content come from the shared config so this block and the main
+// process's headless twin cannot disagree. `file` is the one that shadows a
+// BlockNote DEFAULT block: before the config was shared, main built the default
+// spec and silently dropped size/mimeType/width/height/align on the way to disk.
+export const createFileBlock = createReactBlockSpec(fileBlockConfig, {
+  render: FileBlockRender
+})
 
 // ============================================================================
 // File Block Serialization Helpers

--- a/apps/desktop/src/renderer/src/components/note/content-area/youtube-embed-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/youtube-embed-block.tsx
@@ -83,4 +83,4 @@ export const createYoutubeEmbedBlock = createReactBlockSpec(youtubeEmbedConfig, 
   render: YoutubeEmbedBlockRender
 })
 
-export { EMBED_BLOCK_REGEX, serializeYoutubeEmbed } from '@memry/editor-schema/blocks'
+export { serializeYoutubeEmbed } from '@memry/editor-schema/blocks'

--- a/apps/desktop/src/renderer/src/components/note/content-area/youtube-embed-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/youtube-embed-block.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { createReactBlockSpec } from '@blocknote/react'
+import { youtubeEmbedConfig } from '@memry/editor-schema/blocks'
 import { Play } from '@/lib/icons'
 import { getYouTubeThumbnailUrl, getYouTubeEmbedUrl } from '@/lib/youtube-utils'
 import { useT } from '@memry/i18n/renderer'
@@ -34,7 +35,7 @@ function YouTubePlayer({ videoId, title }: { videoId: string; title?: string }) 
       />
       <div className="absolute inset-0 flex items-center justify-center bg-black/20 group-hover:bg-black/30 transition-colors">
         <div className="flex items-center justify-center size-14 rounded-full bg-red-600 group-hover:bg-red-500 transition-colors shadow-lg">
-          <Play className="size-6 text-white ml-0.5" />
+          <Play className="size-6 text-white ms-0.5" />
         </div>
       </div>
     </button>
@@ -76,22 +77,10 @@ function YoutubeEmbedBlockRender({
   )
 }
 
-export const createYoutubeEmbedBlock = createReactBlockSpec(
-  {
-    type: 'youtubeEmbed' as const,
-    propSchema: {
-      videoId: { default: '' },
-      videoUrl: { default: '' }
-    },
-    content: 'none'
-  },
-  {
-    render: YoutubeEmbedBlockRender
-  }
-)
+// Type/props/content and the `![embed](url)` on-disk form come from the shared
+// package so the main process registers the same node and writes the same bytes.
+export const createYoutubeEmbedBlock = createReactBlockSpec(youtubeEmbedConfig, {
+  render: YoutubeEmbedBlockRender
+})
 
-export const EMBED_BLOCK_REGEX = /!\[embed\]\(([^)]+)\)/g
-
-export function serializeYoutubeEmbed(videoUrl: string): string {
-  return `![embed](${videoUrl})`
-}
+export { EMBED_BLOCK_REGEX, serializeYoutubeEmbed } from '@memry/editor-schema/blocks'

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -323,6 +323,25 @@ plain markdown link and its domain, title, favicon and site name are gone. Every
 Whatever still cannot be represented is caught by the fail-closed guard in
 [Markdown Write-Back](#markdown-write-back).
 
+The custom **blocks** — `callout`, `youtubeEmbed`, `bookmark`, `file` and `taskBlock` — work
+the same way. `file` is worth calling out: the renderer overrides BlockNote's default `file`
+spec, so before the config was shared the main process built the _default_ one and wrote
+`[name.pdf](url)` where the vault file held `<!-- file:{…} -->`, dropping size, MIME type and
+any width/height/alignment.
+
+Main is also the parser. A note's Y.Doc is seeded from its vault file in the main process
+(`crdt-provider.ts`), and the renderer does not parse markdown when a Yjs fragment is
+present — so the `<!-- file:… -->`, `![embed](…)` and `![bookmark](…)` marker lines are
+recognised there, using the same rules the renderer uses on its own save path. Markers
+inside a code fence are the author's text and stay text; the fence tracker follows
+CommonMark, so a longer fence quoting a shorter one is not mistaken for a closing one.
+
+Callouts are deliberately **not** parsed back. Their marker carries a type and an optional
+title that the block config cannot hold, and the renderer's parser coerces any unrecognised
+type to `info`. Parsing them on this path would rewrite `> [!note]` as `> [!info]` in every
+Obsidian-authored vault, so a callout read from a file stays a quote block and its bytes stay
+untouched. A callout created in the editor round-trips through the live document normally.
+
 ## Files Worth Knowing
 
 ```

--- a/packages/editor-schema/package.json
+++ b/packages/editor-schema/package.json
@@ -7,7 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./inline": "./src/inline/index.ts",
-    "./blocks": "./src/blocks/configs.ts",
+    "./blocks": "./src/blocks/index.ts",
     "./server": "./src/server.ts"
   },
   "types": "./src/index.ts",

--- a/packages/editor-schema/src/blocks/configs.ts
+++ b/packages/editor-schema/src/blocks/configs.ts
@@ -83,7 +83,7 @@ export const bookmarkConfig = {
   content: 'none' as const
 }
 
-/** Node names of every custom block spec — the parity gate reads this. */
+/** Node names of every custom block spec. The parity gate (#1433) will read this. */
 export const MEMRY_BLOCK_TYPES = [
   'taskBlock',
   'callout',

--- a/packages/editor-schema/src/blocks/configs.ts
+++ b/packages/editor-schema/src/blocks/configs.ts
@@ -11,6 +11,9 @@
  * never what reaches the vault file.
  */
 
+import { defaultProps } from '@blocknote/core'
+import { CALLOUT_TYPE_VALUES } from './markdown'
+
 export const taskBlockConfig = {
   type: 'taskBlock' as const,
   propSchema: {
@@ -21,3 +24,70 @@ export const taskBlockConfig = {
   },
   content: 'none' as const
 }
+
+export const calloutConfig = {
+  type: 'callout' as const,
+  propSchema: {
+    textAlignment: defaultProps.textAlignment,
+    textColor: defaultProps.textColor,
+    type: {
+      default: 'info' as const,
+      values: CALLOUT_TYPE_VALUES
+    }
+  },
+  content: 'inline' as const
+}
+
+/**
+ * `file` shadows a BlockNote DEFAULT block of the same name, and the two have
+ * nothing in common but the name: BlockNote's carries caption/showPreview/
+ * previewWidth, Memry's carries the attachment's size/mimeType plus the PDF
+ * embed's width/height/align. Registering this config is what stops the main
+ * process from parsing a Memry file block against BlockNote's propSchema and
+ * dropping every prop the default does not declare.
+ */
+export const fileBlockConfig = {
+  type: 'file' as const,
+  propSchema: {
+    url: { default: '' },
+    name: { default: '' },
+    size: { default: 0 },
+    mimeType: { default: '' },
+    width: { default: 0 },
+    height: { default: 0 },
+    align: { default: 'left' as const, values: ['left', 'center', 'right'] as const }
+  },
+  content: 'none' as const
+}
+
+export const youtubeEmbedConfig = {
+  type: 'youtubeEmbed' as const,
+  propSchema: {
+    videoId: { default: '' },
+    videoUrl: { default: '' }
+  },
+  content: 'none' as const
+}
+
+export const bookmarkConfig = {
+  type: 'bookmark' as const,
+  propSchema: {
+    url: { default: '' },
+    domain: { default: '' },
+    title: { default: '' },
+    description: { default: '' },
+    image: { default: '' },
+    favicon: { default: '' },
+    siteName: { default: '' }
+  },
+  content: 'none' as const
+}
+
+/** Node names of every custom block spec — the parity gate reads this. */
+export const MEMRY_BLOCK_TYPES = [
+  'taskBlock',
+  'callout',
+  'file',
+  'youtubeEmbed',
+  'bookmark'
+] as const

--- a/packages/editor-schema/src/blocks/index.ts
+++ b/packages/editor-schema/src/blocks/index.ts
@@ -1,0 +1,2 @@
+export * from './configs'
+export * from './markdown'

--- a/packages/editor-schema/src/blocks/markdown.ts
+++ b/packages/editor-schema/src/blocks/markdown.ts
@@ -4,9 +4,12 @@
  * This is a contract, not a preference. Write-back byte-compares the serialized
  * document against the file before writing, so a single character of drift here
  * rewrites every note holding one of these blocks, in every vault, on next open.
- * Both processes serialize through these functions for exactly that reason:
- * main's headless spec and the renderer's React spec cannot produce different
- * bytes if neither one owns the format.
+ * The renderer serializes through these functions directly. Main cannot: a
+ * server spec returns DOM and BlockNote converts that to markdown, so main
+ * builds DOM shaped to serialize to the identical bytes. Two implementations
+ * that must agree is exactly the drift this package exists to prevent, so the
+ * agreement is asserted by test (see `blocknote-converter.test.ts`), not left
+ * to reading.
  *
  * Each form below is the one already on disk today — see the git history of
  * `callout-block.tsx`, `youtube-embed-block.tsx`, `bookmark-block.tsx` and
@@ -34,9 +37,6 @@ export function serializeCalloutBlock(type: string, contentMarkdown: string): st
 // ---------------------------------------------------------------------------
 // youtubeEmbed / bookmark — an image embed whose alt text names the block
 // ---------------------------------------------------------------------------
-
-export const EMBED_BLOCK_REGEX = /!\[embed\]\(([^)]+)\)/g
-export const BOOKMARK_BLOCK_REGEX = /!\[bookmark\]\(([^)]+)\)/g
 
 /** A whole line that is nothing but an embed / bookmark marker. */
 export const EMBED_LINE_REGEX = /^!\[embed\]\(([^)]+)\)$/
@@ -82,7 +82,6 @@ export interface FileBlockProps {
  * Regex to match file block markers in markdown
  * Format: <!-- file:{"url":"...","name":"...","size":123,"mimeType":"...","width":720} -->
  */
-export const FILE_BLOCK_REGEX = /<!-- file:(\{[^}]+\}) -->/g
 
 /** A whole line that is nothing but a file marker. */
 export const FILE_BLOCK_LINE_REGEX = /^<!-- file:\{[^}]+\} -->$/
@@ -96,6 +95,17 @@ export const FILE_BLOCK_LINE_REGEX = /^<!-- file:\{[^}]+\} -->$/
  */
 export function serializeFileBlock(props: FileBlockProps): string {
   return `<!--${fileBlockCommentData(props)}-->`
+}
+
+/**
+ * `-->` anywhere in the payload would close the HTML comment early, splitting
+ * the marker and spilling the rest into the note as a paragraph. A file named
+ * `a-->b.pdf` is enough. Escaping it as `\u003e` keeps the JSON byte-for-byte
+ * equivalent — `JSON.parse` gives the original string back — while removing the
+ * only sequence the comment syntax reserves.
+ */
+function escapeCommentTerminator(json: string): string {
+  return json.replace(/-->/g, '--\\u003e')
 }
 
 /**
@@ -120,7 +130,7 @@ export function fileBlockCommentData(props: FileBlockProps): string {
   if (props.align && props.align !== 'left') {
     payload.align = props.align
   }
-  return ` file:${JSON.stringify(payload)} `
+  return ` file:${escapeCommentTerminator(JSON.stringify(payload))} `
 }
 
 /**

--- a/packages/editor-schema/src/blocks/markdown.ts
+++ b/packages/editor-schema/src/blocks/markdown.ts
@@ -98,14 +98,18 @@ export function serializeFileBlock(props: FileBlockProps): string {
 }
 
 /**
- * `-->` anywhere in the payload would close the HTML comment early, splitting
- * the marker and spilling the rest into the note as a paragraph. A file named
- * `a-->b.pdf` is enough. Escaping it as `\u003e` keeps the JSON byte-for-byte
- * equivalent — `JSON.parse` gives the original string back — while removing the
- * only sequence the comment syntax reserves.
+ * A comment terminator anywhere in the payload closes the marker early,
+ * splitting it and spilling the rest into the note as a paragraph. A file
+ * named `a-->b.pdf` is enough.
+ *
+ * HTML ends a comment on `-->` AND on `--!>` (the spec's comment-end-bang
+ * state), so both are escaped. Only the `>` is replaced: escaping every `--`
+ * would change the bytes of every marker whose filename contains one, and
+ * write-back byte-compares. `\u003e` is JSON-equivalent, so `JSON.parse`
+ * returns the original string unchanged.
  */
 function escapeCommentTerminator(json: string): string {
-  return json.replace(/-->/g, '--\\u003e')
+  return json.replace(/--(!?)>/g, '--$1\\u003e')
 }
 
 /**
@@ -137,7 +141,11 @@ export function fileBlockCommentData(props: FileBlockProps): string {
  * Parse file block marker from markdown
  */
 export function parseFileBlockMarker(marker: string): FileBlockProps | null {
-  const match = marker.match(/<!-- file:(\{[^}]+\}) -->/)
+  // Anchored: every caller passes one already-trimmed marker line, and leaving
+  // it unanchored made the scan quadratic in the line's length — `<!-- file:{`
+  // repeated a few thousand times is a note body, i.e. attacker-reachable
+  // through sync. Measured 24ms at 2k repetitions, 392ms at 8k.
+  const match = marker.match(/^<!-- file:(\{[^}]+\}) -->$/)
   if (!match) return null
   try {
     return JSON.parse(match[1])

--- a/packages/editor-schema/src/blocks/markdown.ts
+++ b/packages/editor-schema/src/blocks/markdown.ts
@@ -1,0 +1,137 @@
+/**
+ * The on-disk form of every custom block — the bytes that reach the vault file.
+ *
+ * This is a contract, not a preference. Write-back byte-compares the serialized
+ * document against the file before writing, so a single character of drift here
+ * rewrites every note holding one of these blocks, in every vault, on next open.
+ * Both processes serialize through these functions for exactly that reason:
+ * main's headless spec and the renderer's React spec cannot produce different
+ * bytes if neither one owns the format.
+ *
+ * Each form below is the one already on disk today — see the git history of
+ * `callout-block.tsx`, `youtube-embed-block.tsx`, `bookmark-block.tsx` and
+ * `file-block-markers.ts`, from which these moved verbatim.
+ */
+
+// ---------------------------------------------------------------------------
+// callout — `> [!type]` followed by the content, one `> ` per line
+// ---------------------------------------------------------------------------
+
+export const CALLOUT_TYPE_VALUES = ['info', 'warning', 'error', 'success'] as const
+
+export type CalloutTypeValue = (typeof CALLOUT_TYPE_VALUES)[number]
+
+/** Matches a callout's opening line: `> [!type]`, with any trailing title text. */
+export const CALLOUT_LINE_REGEX = /^> \[!(\w+)\](.*)/
+
+export function serializeCalloutBlock(type: string, contentMarkdown: string): string {
+  const lines = contentMarkdown.split('\n').filter((l) => l.length > 0)
+  if (lines.length === 0) return `> [!${type}]`
+  const quoted = lines.map((line) => `> ${line}`).join('\n')
+  return `> [!${type}]\n${quoted}`
+}
+
+// ---------------------------------------------------------------------------
+// youtubeEmbed / bookmark — an image embed whose alt text names the block
+// ---------------------------------------------------------------------------
+
+export const EMBED_BLOCK_REGEX = /!\[embed\]\(([^)]+)\)/g
+export const BOOKMARK_BLOCK_REGEX = /!\[bookmark\]\(([^)]+)\)/g
+
+/** A whole line that is nothing but an embed / bookmark marker. */
+export const EMBED_LINE_REGEX = /^!\[embed\]\(([^)]+)\)$/
+export const BOOKMARK_LINE_REGEX = /^!\[bookmark\]\(([^)]+)\)$/
+
+export function serializeYoutubeEmbed(videoUrl: string): string {
+  return `![embed](${videoUrl})`
+}
+
+export function serializeBookmark(url: string): string {
+  return `![bookmark](${url})`
+}
+
+// ---------------------------------------------------------------------------
+// file — an HTML comment carrying the props as JSON
+// ---------------------------------------------------------------------------
+
+export interface FileBlockProps {
+  url: string
+  name: string
+  size: number
+  mimeType: string
+  /**
+   * User-set display width in px for the inline PDF preview. `0`/undefined means
+   * "use the default width" and is omitted from the marker so legacy markers stay
+   * byte-for-byte identical on re-save.
+   */
+  width?: number
+  /**
+   * User-set crop height in px for the inline PDF preview. `0`/undefined means
+   * "fit the first page" (no crop) and is omitted from the marker, so markers
+   * that were never height-resized stay byte-for-byte identical on re-save.
+   */
+  height?: number
+  /**
+   * Alignment of the embed within the note column. `'left'` is the default and is
+   * omitted from the marker so markers that were never aligned stay byte-identical.
+   */
+  align?: 'left' | 'center' | 'right'
+}
+
+/**
+ * Regex to match file block markers in markdown
+ * Format: <!-- file:{"url":"...","name":"...","size":123,"mimeType":"...","width":720} -->
+ */
+export const FILE_BLOCK_REGEX = /<!-- file:(\{[^}]+\}) -->/g
+
+/** A whole line that is nothing but a file marker. */
+export const FILE_BLOCK_LINE_REGEX = /^<!-- file:\{[^}]+\} -->$/
+
+/**
+ * Serialize file block props to markdown marker.
+ *
+ * Keys are written in a fixed order and the default `width`/`height` (0) are
+ * dropped, so a block that was never resized produces the exact same marker
+ * bytes as before the width/height props existed.
+ */
+export function serializeFileBlock(props: FileBlockProps): string {
+  return `<!--${fileBlockCommentData(props)}-->`
+}
+
+/**
+ * The marker's comment data — everything between `<!--` and `-->`, spaces
+ * included. The main process needs this half on its own: its headless spec
+ * builds a real DOM comment node, which is the only shape BlockNote's
+ * HTML→markdown step passes through to the vault file untouched.
+ */
+export function fileBlockCommentData(props: FileBlockProps): string {
+  const payload: FileBlockProps = {
+    url: props.url,
+    name: props.name,
+    size: props.size,
+    mimeType: props.mimeType
+  }
+  if (typeof props.width === 'number' && props.width > 0) {
+    payload.width = props.width
+  }
+  if (typeof props.height === 'number' && props.height > 0) {
+    payload.height = props.height
+  }
+  if (props.align && props.align !== 'left') {
+    payload.align = props.align
+  }
+  return ` file:${JSON.stringify(payload)} `
+}
+
+/**
+ * Parse file block marker from markdown
+ */
+export function parseFileBlockMarker(marker: string): FileBlockProps | null {
+  const match = marker.match(/<!-- file:(\{[^}]+\}) -->/)
+  if (!match) return null
+  try {
+    return JSON.parse(match[1])
+  } catch {
+    return null
+  }
+}

--- a/packages/editor-schema/src/blocks/server-specs.ts
+++ b/packages/editor-schema/src/blocks/server-specs.ts
@@ -6,21 +6,139 @@
  * name its schema cannot build is to DELETE the element from the doc. A block
  * missing here is not a blank space in a preview — it is a replicated delete.
  *
- * So these carry the schema (from the shared configs) and nothing else. There
- * is no headless DOM to paint into and no caller that should try: `render`
- * throws rather than returning something plausible.
+ * So these carry the schema (from the shared configs) and the on-disk form
+ * (from `./markdown`) — nothing else. `render` is not presentation here: it
+ * emits exactly what `toExternalHTML` emits, and it never throws. A throwing
+ * render is not a safe assertion, it is a note that silently stops writing
+ * back — `blocksToMarkdownLossy` reaches `render` for anything BlockNote
+ * serializes without a `toExternalHTML`, and one throw makes `yDocToMarkdown`
+ * return null for the whole document.
+ *
+ * Every DOM below is chosen for what BlockNote's HTML→markdown step turns it
+ * into, verified byte-for-byte against the marker each block already has on
+ * disk (see blocknote-converter.test.ts):
+ *
+ *   img[alt=embed]    → `![embed](url)`
+ *   img[alt=bookmark] → `![bookmark](url)`
+ *   comment node      → `<!-- file:{…} -->`, passed through raw
+ *   blockquote        → `> [!type]` + one `> ` per content line
+ *   checkbox li       → `- [ ] title {task:id}`
  */
 
 import { createBlockSpec } from '@blocknote/core'
-import { taskBlockConfig } from './configs'
+import { serializeTaskBlock, type TaskBlockProps } from '@memry/shared/task-block'
+import {
+  bookmarkConfig,
+  calloutConfig,
+  fileBlockConfig,
+  taskBlockConfig,
+  youtubeEmbedConfig
+} from './configs'
+import { fileBlockCommentData, type FileBlockProps } from './markdown'
+
+/**
+ * A block whose markdown is a plain `![alt](url)` embed. A real `<img>` is what
+ * makes the HTML→markdown step emit the marker byte-for-byte; a `<p>` holding
+ * the same text would come back escaped (`!\[embed]\(…\)`).
+ */
+function imageEmbedDom(url: string, alt: string): { dom: HTMLElement } {
+  const dom = document.createElement('div')
+  const img = document.createElement('img')
+  img.setAttribute('src', url)
+  img.setAttribute('alt', alt)
+  dom.appendChild(img)
+  return { dom }
+}
+
+function youtubeEmbedDom(block: { props: { videoUrl: string } }): { dom: HTMLElement } {
+  return imageEmbedDom(block.props.videoUrl || '', 'embed')
+}
+
+function bookmarkDom(block: { props: { url: string } }): { dom: HTMLElement } {
+  return imageEmbedDom(block.props.url || '', 'bookmark')
+}
+
+/**
+ * The file marker is an HTML comment, so it is emitted as a real comment node:
+ * the serializer passes comments through as raw HTML and escapes everything
+ * else, which is the difference between `<!-- file:{…} -->` reaching the vault
+ * file and `\<!-- file:...` doing so.
+ */
+function fileDom(block: { props: Record<string, unknown> }): { dom: HTMLElement } {
+  const props: FileBlockProps = {
+    url: String(block.props.url ?? ''),
+    name: String(block.props.name ?? ''),
+    size: Number(block.props.size ?? 0),
+    mimeType: String(block.props.mimeType ?? ''),
+    width: Number(block.props.width ?? 0),
+    height: Number(block.props.height ?? 0),
+    align: block.props.align as FileBlockProps['align']
+  }
+  const dom = document.createElement('div')
+  dom.appendChild(document.createComment(fileBlockCommentData(props)))
+  return { dom }
+}
+
+/**
+ * `> [!type]` on the first line, then the content — the shape the editor's own
+ * save path writes (`serializeCalloutBlock`). The marker and the content share
+ * ONE paragraph, separated by a `<br>`: a second `<p>` would serialize as a
+ * blank `>` line between them and rewrite every callout on disk.
+ */
+function calloutDom(block: { props: { type: string } }): {
+  dom: HTMLElement
+  contentDOM: HTMLElement
+} {
+  const dom = document.createElement('blockquote')
+  const paragraph = document.createElement('p')
+  paragraph.appendChild(document.createTextNode(`[!${block.props.type || 'info'}]`))
+  paragraph.appendChild(document.createElement('br'))
+  const content = document.createElement('span')
+  paragraph.appendChild(content)
+  dom.appendChild(paragraph)
+  return { dom, contentDOM: content }
+}
+
+/**
+ * A GFM task-list item, which is exactly the `- [ ] title {task:id}` line the
+ * vault already holds. Top-level task blocks never reach this — the converter
+ * serializes those itself — but a task nested under a list item does, and this
+ * spec's `render` used to throw there, taking the whole note's write-back with it.
+ */
+function taskBlockDom(block: { props: unknown }): { dom: HTMLElement } {
+  const props = block.props as TaskBlockProps
+  const dom = document.createElement('ul')
+  const item = document.createElement('li')
+  const checkbox = document.createElement('input')
+  checkbox.setAttribute('type', 'checkbox')
+  if (props.checked) checkbox.setAttribute('checked', '')
+  item.appendChild(checkbox)
+  item.appendChild(document.createTextNode(serializeTaskBlock(props).replace(/^- \[[ x]\] /, '')))
+  dom.appendChild(item)
+  return { dom }
+}
 
 export function createServerBlockSpecs() {
   return {
     taskBlock: createBlockSpec(taskBlockConfig, {
-      render: () => {
-        throw new Error('taskBlock server spec is serialization-only and must not be rendered')
-      }
+      render: taskBlockDom,
+      toExternalHTML: taskBlockDom
+    })(),
+    callout: createBlockSpec(calloutConfig, {
+      render: calloutDom,
+      toExternalHTML: calloutDom
+    })(),
+    file: createBlockSpec(fileBlockConfig, {
+      render: fileDom,
+      toExternalHTML: fileDom
+    })(),
+    youtubeEmbed: createBlockSpec(youtubeEmbedConfig, {
+      render: youtubeEmbedDom,
+      toExternalHTML: youtubeEmbedDom
+    })(),
+    bookmark: createBlockSpec(bookmarkConfig, {
+      render: bookmarkDom,
+      toExternalHTML: bookmarkDom
     })()
-    // callout / file / youtubeEmbed / bookmark land with their configs.
   }
 }

--- a/packages/editor-schema/src/blocks/server-specs.ts
+++ b/packages/editor-schema/src/blocks/server-specs.ts
@@ -64,15 +64,15 @@ function bookmarkDom(block: { props: { url: string } }): { dom: HTMLElement } {
  * else, which is the difference between `<!-- file:{…} -->` reaching the vault
  * file and `\<!-- file:...` doing so.
  */
-function fileDom(block: { props: Record<string, unknown> }): { dom: HTMLElement } {
+function fileDom(block: { props: Partial<FileBlockProps> }): { dom: HTMLElement } {
   const props: FileBlockProps = {
-    url: String(block.props.url ?? ''),
-    name: String(block.props.name ?? ''),
-    size: Number(block.props.size ?? 0),
-    mimeType: String(block.props.mimeType ?? ''),
-    width: Number(block.props.width ?? 0),
-    height: Number(block.props.height ?? 0),
-    align: block.props.align as FileBlockProps['align']
+    url: block.props.url ?? '',
+    name: block.props.name ?? '',
+    size: block.props.size ?? 0,
+    mimeType: block.props.mimeType ?? '',
+    width: block.props.width ?? 0,
+    height: block.props.height ?? 0,
+    align: block.props.align
   }
   const dom = document.createElement('div')
   dom.appendChild(document.createComment(fileBlockCommentData(props)))


### PR DESCRIPTION
Phase 2 of #1427, stacked on #1437. **Base is `h4yfans/main-schema-from-shared-factory`** — merge #1436 → #1437 → this.

Refs #1432. Left open deliberately.

## What this closes

`callout`, `youtubeEmbed` and `bookmark` exist in no BlockNote default, so main deleted them out of the shared CRDT doc the way it deleted wiki links. `file` failed differently: the renderer *overrides* BlockNote's default `file` spec, so main built the default and wrote `[x.pdf](url)` where the vault file held `<!-- file:{…} -->` — dropping size, MIME type, width, height and alignment. Verified on the parent commit; that loss was being written.

All five block configs now live in `@memry/editor-schema` with headless server implementations.

## Main is the parser — the scope had to grow

`crdt-provider.ts` seeds a note's Y.Doc from its vault file, and `use-editor-sync.ts` returns early when a Yjs fragment is present, so the renderer never parses markdown on the collaborative path. Registering the spec alone could not make the round-trip test pass: main was dropping `<!-- file:{…} -->` outright. Marker parsing for `file`, `youtubeEmbed` and `bookmark` is now in main, using the renderer's own rules.

**Callouts are deliberately not parsed back.** The renderer's parser coerces any unrecognised type to `info` and moves a title off the marker line; porting it would rewrite `> [!note]` as `> [!info]` in every Obsidian vault. A callout read from a file stays a quote block and its bytes stay untouched.

## Four bugs found in review, all in the parser I added

**Release-blocking, both verified by reproduction:**

1. **The fence guard was a parity toggle.** `/^(?:```|~~~)/` flipping a boolean tracks neither the fence character nor its length. A four-backtick block quoting an inner three — the shape of any note documenting this marker format — read as closed halfway through. The code block was torn in two and the *example* marker became a live `file` block pointing at a PDF, then write-back rewrote the file. A `~~~` inside a ``` fence did the same. Now CommonMark: same character, at least as long, empty info string.

2. **The same commit put the pre-existing block-colour branch behind that toggle**, so a colour marker following such a fence was deleted from the vault file — new data loss on a path #1432 never touched. Reverted to unguarded, matching the renderer.

**Should-fix, also fixed:**

3. **Trim divergence.** It matched all three markers on the trimmed line; the renderer trims only `file`. `- item\n\n  ![embed](…)` lost its nesting — the same file parsing to a different document depending on which process read it, which is the exact class this epic exists to close.

4. **`-->` in any file prop closed the comment early**, splitting the marker and spilling JSON into the note as a paragraph. A file named `a-->b.pdf` was enough. Escaped as `>` in the shared serializer, so the renderer's identical hole is fixed too.

Plus `![bookmark](assets/photo.png)` — someone's screenshot with an unlucky alt text — became a bookmark card. The embed branch has `extractYouTubeVideoId` for this; bookmark now requires an http(s) URL.

Every one of these is now a test.

## A regression from #1436, fixed at its source

`createMemrySchema` spreads `defaultBlockSpecs` and *then* installs the syntax-highlighting `codeBlock`, so the renderer respreading `defaultBlockSpecs` in its own overrides put BlockNote's plain `codeBlock` back — losing highlighting the editor had before the schema moved into the package. The one-line fix is committed on **#1436's branch** (`8c4eb4bf5`), not here, so that PR is correct standalone; #1437 and this branch were rebased onto it.

## Byte stability

The reviewer's independent 79-input corpus, `markdown → Y.Doc → markdown`, diffed against the parent. After these fixes the only changed outputs are restorations of content the parent destroyed — chiefly the `file` marker coming back instead of `[x.pdf](url)`. The `taskBlock` server `render` also stopped throwing: on the parent, a task nested under a list item made `yDocToMarkdown` return `null`, silently stopping write-back for that note.

## Known, not fixed here

- A callout authored in the editor writes `> [!info]\n> body`; if that note's Y.Doc is discarded and re-seeded from markdown it returns as a quote. Bytes are stable throughout. Holding the full Obsidian type set plus a title is a schema change — #1434 territory.
- Registering these five specs means their data lives entirely in props, which `findUnrepresentableNodes` does not inspect. It still catches unknown *node names*; unknown *props* on a known node are dropped. Worth a note in #1433's gate.
- An older build now meets `bookmark` / `youtubeEmbed` nodes in docs seeded from ordinary vault files and will refuse write-back for them. Fail-closed, so no loss — but it widens the stale-file population until the fleet updates.

## Verification

- `test:main` — 512 files / 6398 tests
- `test:renderer` — 609 files / 6965 tests
- `typecheck` (node/web/test), `@memry/editor-schema typecheck`
- `check:architecture`, lint (0 new), `docs:impact --strict`, `docs:build`
- `pnpm-lock.yaml` untouched

No vault format, DB, sync protocol or IPC change.
