### PR TITLE
refactor(editor): one home for the marquee start decision

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.test.tsx
@@ -191,10 +191,24 @@ describe('useBlockMarqueeSelection', () => {
     trigger.remove()
   })
 
-  it('ignores disabled, interactive, and mostly-horizontal editable drags', () => {
+  it('ignores disabled, interactive, opted-out, and mostly-horizontal editable drags', () => {
     const { trigger, blockContainerRef } = setupDom()
     const button = document.createElement('button')
     trigger.append(button)
+    // The side rail opts out of marquee entirely (note-layout.tsx marks it
+    // `data-marquee-ignore`), so a drag that starts on it selects nothing.
+    const rail = document.createElement('div')
+    rail.setAttribute('data-marquee-ignore', '')
+    trigger.append(rail)
+    // BlockNote renders its menus inside the marquee zone rather than
+    // portaling them out, so dragging within one must not select blocks
+    // behind it. Also covered end-to-end by editor-drag-handle-menu.e2e.ts.
+    const sideMenu = document.createElement('div')
+    sideMenu.className = 'bn-side-menu'
+    trigger.append(sideMenu)
+    // Icons render as SVG, which is an Element but not an HTMLElement.
+    const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    trigger.append(icon)
     const editable = document.createElement('div')
     editable.setAttribute('contenteditable', 'true')
     trigger.append(editable)
@@ -226,6 +240,15 @@ describe('useBlockMarqueeSelection', () => {
       document.dispatchEvent(mouse('mouseup', { clientX: 150, clientY: 70 }))
     })
     expect(result.current.selectedBlockIds.size).toBe(0)
+
+    for (const optedOut of [rail, sideMenu, icon]) {
+      act(() => {
+        optedOut.dispatchEvent(mouse('mousedown', { clientX: 0, clientY: 0 }))
+        document.dispatchEvent(mouse('mousemove', { clientX: 150, clientY: 70 }))
+        document.dispatchEvent(mouse('mouseup', { clientX: 150, clientY: 70 }))
+      })
+      expect(result.current.selectedBlockIds.size).toBe(0)
+    }
 
     act(() => {
       editable.dispatchEvent(mouse('mousedown', { clientX: 0, clientY: 0 }))

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createLogger } from '@/lib/logger'
+import { shouldStartMarquee } from '../marquee-hit-test'
 import { classifyBlocks, indentTaskBlock, outdentTaskBlock } from './task-block-marquee-indent'
 
 const log = createLogger('Hook:Marquee')
@@ -46,20 +47,6 @@ interface UseBlockMarqueeSelectionReturn {
 interface OriginPoint {
   clientX: number
   clientY: number
-}
-
-function shouldStartMarquee(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false
-  if (target.closest('[data-marquee-ignore]')) return false
-  if (target.closest('button, a, input, textarea, select, [role="button"]')) return false
-  if (
-    target.closest(
-      '.bn-side-menu, .bn-formatting-toolbar, .bn-suggestion-menu, .bn-link-toolbar, .bn-drag-handle-menu'
-    )
-  ) {
-    return false
-  }
-  return true
 }
 
 function rectsIntersect(

--- a/apps/desktop/src/renderer/src/components/note/content-area/marquee-hit-test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/marquee-hit-test.ts
@@ -1,0 +1,100 @@
+/**
+ * Marquee hit-testing — one home for "what did this press land on?".
+ *
+ * Two call sites ask a location question about a mousedown in the editor:
+ *
+ *   - the marquee selection hook: "may this press start a marquee at all?"
+ *     (`shouldStartMarquee`)
+ *   - the note page's and the journal page's click-to-focus-end handlers:
+ *     "is this press outside every block?" (`isOutsideAllBlocks`)
+ *
+ * They used to answer those questions with inline copies scattered across the
+ * hook and both pages, where two of the copies were byte-identical and the
+ * third was a different rule entirely. Co-locating them is the point: they are
+ * deliberately NOT the same test, and the only way that stays deliberate rather
+ * than accidental is for a change to one to sit next to the other.
+ *
+ * #1444 adds a third question here — "is there selectable text at this press?",
+ * the gate that stops a marquee starting from inside a line of text. Read
+ * `isOutsideAllBlocks` below before assuming it can answer that one too.
+ *
+ * This module is pure DOM inspection — no editor, no React, no state. Every
+ * function takes the raw `event.target` and answers from ancestry alone.
+ */
+
+/** BlockNote's block content element: the box a single block's content lives in. */
+const BLOCK_CONTENT_SELECTOR = '.bn-block-content'
+
+/**
+ * Is this press outside every block — i.e. in the margin, the gutter, or the
+ * empty space below the last block?
+ *
+ * This is what the note page's and journal page's click-to-focus-end handlers
+ * ask before calling `preventDefault()` + `focusAtEnd()`. It is the exact
+ * negation of the composite condition those handlers carried inline, moved
+ * here unchanged: a press counts as "inside a block" only when it is inside a
+ * contenteditable subtree AND inside a block content box.
+ *
+ * Do not "simplify" this to a lone `.bn-block-content` lookup. The two halves
+ * are not equivalent: ProseMirror sets `contenteditable="false"` on its root
+ * when the editor is not editable, so a read-only surface renders
+ * `.bn-block-content` with no `contenteditable="true"` ancestor and the
+ * composite still classifies those presses as "outside".
+ *
+ * The `contains()` call is, under standard DOM semantics, always true when
+ * `closest()` returned non-null — `closest` walks up from the target itself.
+ * It is kept byte-for-byte anyway, because this module landed as a pure
+ * prefactor with a zero-behaviour-change promise; dropping it is a separate,
+ * deliberate decision, not a drive-by tidy.
+ *
+ * ## Why the marquee start rule (#1444) cannot reuse this
+ *
+ * "Outside every block" and "no selectable text here" sound like the same
+ * question and have different answers. A task block sits inside
+ * `.bn-block-content` but holds no editable text at all, so answering the
+ * marquee question with this predicate would classify a press on a task row as
+ * "inside a block" and refuse to start a marquee there — and answering THIS
+ * question with the marquee's predicate would classify a click on a task row
+ * as "outside every block", firing `preventDefault()` + `focusAtEnd()` on it,
+ * jumping the caret to the end of the document and suppressing the row's own
+ * focus handling so the task title could no longer be opened for inline
+ * editing. The two stay separate on purpose.
+ *
+ * Note this predicate carries no interactive-element exclusions. The callers
+ * keep their own menu / toolbar / form-control exclusion lists, which are
+ * wider than `shouldStartMarquee`'s (they also exclude `.bn-menu-dropdown` and
+ * `[role="menu"]`, because BlockNote's nested submenus render inside the
+ * marquee zone rather than being portaled out of it).
+ */
+export function isOutsideAllBlocks(target: Element): boolean {
+  const insideBlock =
+    target.closest('[contenteditable="true"]')?.contains(target) === true &&
+    target.closest(BLOCK_CONTENT_SELECTOR) !== null
+  return !insideBlock
+}
+
+/**
+ * May a press on this element begin a marquee drag at all?
+ *
+ * The interactive-element exclusion list: buttons, links, form controls,
+ * anything opted out with `data-marquee-ignore`, and BlockNote's own menus and
+ * toolbars. Moved verbatim out of `use-block-marquee-selection.ts`.
+ *
+ * A consequence worth stating rather than rediscovering: a bookmark card's
+ * whole surface is a link, so a marquee can never start from a bookmark's own
+ * body. Clicking it should open the link; selecting it is reached from the
+ * margin instead.
+ */
+export function shouldStartMarquee(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.closest('[data-marquee-ignore]')) return false
+  if (target.closest('button, a, input, textarea, select, [role="button"]')) return false
+  if (
+    target.closest(
+      '.bn-side-menu, .bn-formatting-toolbar, .bn-suggestion-menu, .bn-link-toolbar, .bn-drag-handle-menu'
+    )
+  ) {
+    return false
+  }
+  return true
+}

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -29,6 +29,7 @@ import {
   type JournalViewState
 } from '@/components/journal'
 import { ContentArea, type Block, type HeadingInfo } from '@/components/note'
+import { isOutsideAllBlocks } from '@/components/note/content-area/marquee-hit-test'
 import { BacklinksSection, type Backlink, backlinkId } from '@/components/note/backlinks'
 
 import { TagsRow, type Tag } from '@/components/note/tags-row'
@@ -373,11 +374,9 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
         )
       )
         return
-      if (
-        target.closest('[contenteditable="true"]')?.contains(target) &&
-        target.closest('.bn-block-content')
-      )
-        return
+      // "Outside every block" — deliberately NOT the same test as the marquee
+      // start rule's "is there text here". See marquee-hit-test.ts.
+      if (!isOutsideAllBlocks(target)) return
       event.preventDefault()
       focusAtEndRef.current?.()
     }

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -15,6 +15,7 @@ import { VersionHistory } from '@/components/note/version-history'
 import { ApplyTemplateToNoteDialog } from '@/components/note/apply-template-to-note-dialog'
 import { EditorErrorBoundary } from '@/components/note/editor-error-boundary'
 import { NoteLayout, HeadingItem, ContentArea, HeadingInfo, Block } from '@/components/note'
+import { isOutsideAllBlocks } from '@/components/note/content-area/marquee-hit-test'
 import { NoteTitle } from '@/components/note/note-title'
 import { TagsRow, Tag } from '@/components/note/tags-row'
 import { InfoSection, type NewProperty } from '@/components/note/info-section'
@@ -351,11 +352,9 @@ export function NotePage({ noteId }: NotePageProps) {
         )
       )
         return
-      if (
-        target.closest('[contenteditable="true"]')?.contains(target) &&
-        target.closest('.bn-block-content')
-      )
-        return
+      // "Outside every block" — deliberately NOT the same test as the marquee
+      // start rule's "is there text here". See marquee-hit-test.ts.
+      if (!isOutsideAllBlocks(target)) return
       event.preventDefault()
       focusAtEndRef.current?.()
     }

--- a/apps/docs/src/contribute/gotchas.md
+++ b/apps/docs/src/contribute/gotchas.md
@@ -138,7 +138,7 @@ if (
   return
 ```
 
-This mirrors `shouldStartMarquee` in `use-block-marquee-selection.ts`. Regression coverage: `tests/e2e/editor-drag-handle-menu.e2e.ts`.
+This mirrors `shouldStartMarquee` in `components/note/content-area/marquee-hit-test.ts`. Regression coverage: `tests/e2e/editor-drag-handle-menu.e2e.ts`.
 
 ## Global Keydown Listeners Must Not Depend on Render State
 


### PR DESCRIPTION
Closes #1442. Part of #1441.

Pure prefactor ahead of the marquee start-rule change. **No behaviour change.**

"Is this press on text?" was answered in three places with two silently diverging rules — the marquee selection hook's own inline exclusion list, and a duplicated composite predicate in the note page's and journal page's click-to-focus-end handlers. This collects them into one module so the rule change in #1444 has one place to plug into.

- `isOutsideAllBlocks` — the note/journal predicate, moved with both halves of its composite condition intact. The `contenteditable` half is load-bearing: ProseMirror sets `contenteditable="false"` on a read-only root, so a read-only surface renders `.bn-block-content` with no `contenteditable="true"` ancestor. The `contains()` call is redundant under standard DOM semantics but kept byte-for-byte, since this promises zero behaviour change.
- `shouldStartMarquee` — the interactive-element exclusion list, moved verbatim out of the hook.

The module documents why #1444 needs a **third** predicate rather than reusing `isOutsideAllBlocks`: a task block sits inside `.bn-block-content` but holds no editable text, so "outside every block" and "no selectable text here" give different answers on it. Merging them either way breaks something — either a marquee can't start on a task row, or clicking one jumps the caret to the end of the document and kills inline title editing.

That third predicate lands in #1444 with its caller and its tests, rather than sitting here uncalled. (An earlier revision of this branch pre-landed it; codecov correctly flagged an exported function with no callers and no coverage.)

## Verification

- `typecheck:web` clean
- `lint` 0 errors (90 pre-existing warnings, none in touched files)
- Renderer tests: 45 passed across the hook, note page and journal page suites — **unchanged and green**, which is the behaviour-preservation evidence
- `docs:impact --strict` covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)