### PR TITLE
test(editor): start marquee e2e drags from the gray margin

### DIFF
--- a/apps/desktop/tests/e2e/marquee-selection-block-types.e2e.ts
+++ b/apps/desktop/tests/e2e/marquee-selection-block-types.e2e.ts
@@ -26,13 +26,13 @@
 
 import { test, expect, type Page } from './fixtures'
 import { waitForAppReady, waitForVaultReady, createNote } from './utils/electron-helpers'
+import { marqueeGutterX } from './utils/marquee-helpers'
 
 const EDITOR_CONTAINER = '.bn-container'
 const EDITABLE_SELECTOR = `${EDITOR_CONTAINER} [contenteditable="true"]`
 const BLOCK_SELECTOR = '.bn-block[data-id]'
 const HIGHLIGHTED_SELECTOR = '.marquee-block-highlight'
 const OVERLAY_SELECTOR = '.marquee-overlay'
-const MARQUEE_ZONE_SELECTOR = '.marquee-zone'
 const TASK_BLOCK_SELECTOR = '[data-content-type="taskBlock"]'
 
 async function focusEditor(page: Page) {
@@ -59,12 +59,6 @@ async function getBlockBox(page: Page, index: number) {
 
 async function getBlockCount(page: Page): Promise<number> {
   return page.locator(BLOCK_SELECTOR).count()
-}
-
-async function getMarqueeZoneBox(page: Page) {
-  const box = await page.locator(MARQUEE_ZONE_SELECTOR).first().boundingBox()
-  if (!box) throw new Error('marquee zone not found')
-  return box
 }
 
 // Pattern from inline-subtasks.e2e.ts:77 — provision a real DB task via IPC
@@ -175,16 +169,15 @@ async function withTasksUpdateSpy<T>(
   }
 }
 
-// Drag from the gutter (start outside any contenteditable so the marquee
-// promotion gate at use-block-marquee-selection.ts:226-228 fires on pure
-// vertical motion) past block `fromIdx` down to block `toIdx`. End the drag
-// just inside the editor so the rect intersects every block in between.
+// Drag from the gray margin beside the text column (start outside any block,
+// so the gesture is unambiguously a block selection) past block `fromIdx` down
+// to block `toIdx`. End the drag just inside the editor so the rect intersects
+// every block in between.
 async function marqueeAcross(page: Page, fromIdx: number, toIdx: number) {
-  const zone = await getMarqueeZoneBox(page)
   const first = await getBlockBox(page, fromIdx)
   const last = await getBlockBox(page, toIdx)
 
-  const startX = zone.x + 8
+  const startX = await marqueeGutterX(page, fromIdx)
   const startY = first.y + 4
   const endX = first.x + Math.min(40, first.width / 2)
   const endY = last.y + last.height - 4

--- a/apps/desktop/tests/e2e/marquee-selection-journal.e2e.ts
+++ b/apps/desktop/tests/e2e/marquee-selection-journal.e2e.ts
@@ -11,13 +11,13 @@
 
 import { test, expect, type Page } from './fixtures'
 import { waitForAppReady, waitForVaultReady, navigateTo } from './utils/electron-helpers'
+import { marqueeGutterX } from './utils/marquee-helpers'
 
 const EDITOR_CONTAINER = '.bn-container'
 const EDITABLE_SELECTOR = `${EDITOR_CONTAINER} [contenteditable="true"]`
 const BLOCK_SELECTOR = '.bn-block[data-id]'
 const HIGHLIGHTED_SELECTOR = '.marquee-block-highlight'
 const OVERLAY_SELECTOR = '.marquee-overlay'
-const MARQUEE_ZONE_SELECTOR = '.marquee-zone'
 const METADATA_IGNORE_SELECTOR = '[data-marquee-ignore]'
 
 async function focusJournalEditor(page: Page) {
@@ -44,12 +44,6 @@ async function getBlockBox(page: Page, index: number) {
 
 async function getBlockCount(page: Page): Promise<number> {
   return page.locator(BLOCK_SELECTOR).count()
-}
-
-async function getMarqueeZoneBox(page: Page) {
-  const box = await page.locator(MARQUEE_ZONE_SELECTOR).first().boundingBox()
-  if (!box) throw new Error('marquee zone not found')
-  return box
 }
 
 async function expectNoNativeTextSelection(page: Page): Promise<void> {
@@ -88,9 +82,11 @@ test.describe('Journal block marquee selection', () => {
     const first = await getBlockBox(page, 0)
     const third = await getBlockBox(page, 2)
 
-    const startX = first.x + first.width / 2
+    // Start in the gray margin beside the column — block selection is a
+    // gesture that begins outside text — and drag down into block 2.
+    const startX = await marqueeGutterX(page, 0)
     const startY = first.y + 4
-    const endX = startX
+    const endX = first.x + first.width / 2
     const endY = third.y + third.height - 4
 
     await page.mouse.move(startX, startY)
@@ -128,9 +124,9 @@ test.describe('Journal block marquee selection', () => {
     const second = await getBlockBox(page, 1)
     const third = await getBlockBox(page, 2)
 
-    const startX = second.x + second.width / 2
+    const startX = await marqueeGutterX(page, 1)
     const startY = second.y + 4
-    const endX = startX
+    const endX = second.x + second.width / 2
     const endY = third.y + third.height - 4
 
     await page.mouse.move(startX, startY)
@@ -188,13 +184,13 @@ test.describe('Journal block marquee selection', () => {
     ])
     await page.waitForTimeout(400)
 
-    await getMarqueeZoneBox(page)
     const first = await getBlockBox(page, 0)
     const last = await getBlockBox(page, 2)
 
+    // Start in the gray margin left of the column; end point unchanged.
+    const startX = await marqueeGutterX(page, 0)
     const startY = first.y + first.height / 2
-    const startX = first.x + 2
-    const endX = startX
+    const endX = first.x + 2
     const endY = last.y + last.height - 4
 
     await page.mouse.move(startX, startY)

--- a/apps/desktop/tests/e2e/marquee-selection.e2e.ts
+++ b/apps/desktop/tests/e2e/marquee-selection.e2e.ts
@@ -9,6 +9,7 @@
 
 import { test, expect, type Page } from './fixtures'
 import { waitForAppReady, waitForVaultReady, createNote } from './utils/electron-helpers'
+import { marqueeGutterX } from './utils/marquee-helpers'
 
 const EDITOR_CONTAINER = '.bn-container'
 const EDITABLE_SELECTOR = `${EDITOR_CONTAINER} [contenteditable="true"]`
@@ -84,10 +85,11 @@ test.describe('Block marquee selection', () => {
     const first = await getBlockBox(page, 0)
     const third = await getBlockBox(page, 2)
 
-    // Vertical drag from block 0 to block 2 — promotes to marquee.
-    const startX = first.x + first.width / 2
+    // Start in the gray margin beside the column — block selection is a
+    // gesture that begins outside text — and drag down into block 2.
+    const startX = await marqueeGutterX(page, 0)
     const startY = first.y + 4
-    const endX = startX
+    const endX = first.x + first.width / 2
     const endY = third.y + third.height - 4
 
     await page.mouse.move(startX, startY)
@@ -120,9 +122,9 @@ test.describe('Block marquee selection', () => {
     const first = await getBlockBox(page, 0)
     const last = await getBlockBox(page, 2)
 
-    const startX = first.x + first.width / 2
+    const startX = await marqueeGutterX(page, 0)
     const startY = first.y + 4
-    const endX = startX
+    const endX = first.x + first.width / 2
     const endY = last.y + last.height - 4
 
     await page.mouse.move(startX, startY)
@@ -155,9 +157,9 @@ test.describe('Block marquee selection', () => {
     const second = await getBlockBox(page, 1)
     const third = await getBlockBox(page, 2)
 
-    const startX = second.x + second.width / 2
+    const startX = await marqueeGutterX(page, 1)
     const startY = second.y + 4
-    const endX = startX
+    const endX = second.x + second.width / 2
     const endY = third.y + third.height - 4
 
     await page.mouse.move(startX, startY)
@@ -544,9 +546,10 @@ test.describe('Block marquee selection', () => {
   async function marqueeSelectBlocks(page: Page, fromIndex: number, toIndex: number) {
     const from = await getBlockBox(page, fromIndex)
     const to = await getBlockBox(page, toIndex)
-    const startX = from.x + from.width / 2
+    // Start in the gray margin beside `from`; end point unchanged.
+    const startX = await marqueeGutterX(page, fromIndex)
     const startY = from.y + 4
-    const endX = startX
+    const endX = from.x + from.width / 2
     const endY = to.y + to.height - 4
     await page.mouse.move(startX, startY)
     await page.mouse.down()

--- a/apps/desktop/tests/e2e/utils/marquee-helpers.ts
+++ b/apps/desktop/tests/e2e/utils/marquee-helpers.ts
@@ -1,0 +1,52 @@
+/**
+ * Marquee-selection E2E geometry helpers.
+ *
+ * Shared by marquee-selection.e2e.ts (note), marquee-selection-journal.e2e.ts
+ * (journal) and marquee-selection-block-types.e2e.ts (block-type matrix).
+ *
+ * A drag that is meant to produce a BLOCK selection must START outside the
+ * text column — in the gray margin the marquee zone leaves beside it. A drag
+ * that starts at the horizontal centre of a block starts inside text, which is
+ * the gesture for selecting text, not blocks.
+ *
+ * The x is DERIVED, never hardcoded. Both surfaces wrap their scroll area in a
+ * `.marquee-zone` that spans the full width (note-layout.tsx, journal.tsx) and
+ * centre a narrower text column inside it, so the midpoint of the gap between
+ * the zone's leading edge and the block's leading edge is the middle of the
+ * margin on either surface, at any window width and any content-width setting.
+ */
+
+import type { Page } from '@playwright/test'
+
+const MARQUEE_ZONE_SELECTOR = '.marquee-zone'
+const BLOCK_SELECTOR = '.bn-block[data-id]'
+
+// A margin narrower than this leaves nothing to aim at: the midpoint would sit
+// a few pixels from the text column and a drag "in the margin" would silently
+// start inside text instead — which is exactly the failure mode these helpers
+// exist to prevent. Fail loudly so a layout change (padding dropped, column
+// widened, zone no longer full-width) is reported as itself.
+const MIN_GUTTER_PX = 24
+
+/**
+ * X coordinate inside the gray margin beside the text column, measured against
+ * the block the drag is meant to start next to.
+ */
+export async function marqueeGutterX(page: Page, blockIndex = 0): Promise<number> {
+  const zone = await page.locator(MARQUEE_ZONE_SELECTOR).first().boundingBox()
+  if (!zone) throw new Error(`marquee zone (${MARQUEE_ZONE_SELECTOR}) has no bounding box`)
+
+  const block = await page.locator(BLOCK_SELECTOR).nth(blockIndex).boundingBox()
+  if (!block) throw new Error(`block at index ${blockIndex} has no bounding box`)
+
+  const gutter = block.x - zone.x
+  if (gutter < MIN_GUTTER_PX) {
+    throw new Error(
+      `marquee margin is ${gutter.toFixed(1)}px wide ` +
+        `(zone.x=${zone.x.toFixed(1)}, block[${blockIndex}].x=${block.x.toFixed(1)}), ` +
+        `need at least ${MIN_GUTTER_PX}px to start a drag beside the text column`
+    )
+  }
+
+  return zone.x + gutter / 2
+}


### PR DESCRIPTION
Closes #1443. Part of #1441.

Test files only — no renderer or main-process source touched.

Every marquee e2e drag currently starts at the horizontal centre of a block, i.e. **inside text**, and relies on the current promotion heuristic to produce a block selection. #1444 removes that heuristic, which would break ~8 scenarios at once.

A drag from the gray margin produces the same result under today's rule, so this lands green on its own against the unmodified selection rule — moving the blast radius out of the behaviour change so #1444 stays a small, reviewable diff.

The premise was verified in the code rather than assumed: a margin press leaves `startedInsideEditableText` false, so promotion needs only the vertical threshold, exactly as a text start did.

## The helper

`marqueeGutterX(page, blockIndex)` measures the marquee zone and the target block, and returns the midpoint of the gap between them. Nothing hardcoded per test. If that gap falls under 24px it throws with both measured coordinates, so a layout change (padding dropped, column widened, zone no longer full-width) is reported as itself instead of silently starting the drag inside text.

Only drag **start** points moved. Unchanged: every drag end point, click-based assertions, the note-title field scenarios, the journal metadata-box start, the click-area scenario, the negative "short drag inside text does not marquee" test, and the two tests whose subject is the zone's extreme edge.

## Verification

- `typecheck:test` clean, `lint` 0 errors, `git diff --check` clean
- Marquee e2e suite after a fresh build: **34 passed**, against the current unmodified selection rule

One note for whoever runs this in CI: the first run at 2 workers hit 3 Electron lifecycle failures (target closed, hook timeout, teardown timeout), two of them in tests this PR never touches; a serial re-run was 34/34. A second agent was building concurrently on the same machine, so resource contention is at least as likely an explanation as worker count — flagging it rather than concluding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)