### PR TITLE
fix(sync): stop the batch CRDT pull from outgrowing the doc cache

### DIFF
--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -92,6 +92,17 @@ export class CrdtProvider {
     this.now = options.now ?? Date.now
   }
 
+  /**
+   * How many editor-less docs stay cached before the LRU starts closing them.
+   *
+   * A caller that holds several docs open across an await — sync's batch CRDT
+   * pull is the one that does — must not open more than this in one pass, or
+   * the docs it opened first are closed underneath it. See applyCrdtBatch.
+   */
+  get inactiveDocCapacity(): number {
+    return this.inactiveDocLimit
+  }
+
   async init(queue?: CrdtUpdateQueue, snapshotPush?: SnapshotPushFn): Promise<void> {
     await this.initPersistence()
 

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
@@ -211,6 +211,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          inactiveDocCapacity: 32,
           getDoc: vi.fn().mockReturnValue(undefined),
           open,
           closeIfInactive,
@@ -262,6 +263,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          inactiveDocCapacity: 32,
           getDoc,
           open: vi.fn().mockResolvedValue({}),
           closeIfInactive,
@@ -333,6 +335,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          inactiveDocCapacity: 32,
           getDoc: vi.fn().mockReturnValue(undefined),
           open,
           closeIfInactive: vi.fn().mockResolvedValue(true),
@@ -378,6 +381,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          inactiveDocCapacity: 32,
           getDoc: vi.fn().mockReturnValue(undefined),
           open,
           closeIfInactive: vi.fn().mockResolvedValue(true),
@@ -469,6 +473,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          inactiveDocCapacity: 32,
           getDoc: vi.fn().mockReturnValue(undefined),
           open: vi.fn().mockResolvedValue({}),
           closeIfInactive: vi.fn().mockResolvedValue(true),
@@ -516,6 +521,84 @@ describe('CrdtSyncCoordinator', () => {
     // #then an abort must propagate, not be swallowed as a skipped note; the pass
     // stops before pulling any updates.
     expect(postToServerMock).not.toHaveBeenCalled()
+  })
+
+  it('splits a pass larger than the provider cache so its docs survive the pull', async () => {
+    // #given five notes and room for two editor-less docs — a sign-in hands the
+    // whole vault over, which is many times the real limit
+    const ctx = {
+      deps: {
+        crdtProvider: {
+          inactiveDocCapacity: 2,
+          getDoc: vi.fn().mockReturnValue(undefined),
+          open: vi.fn().mockResolvedValue({}),
+          closeIfInactive: vi.fn().mockResolvedValue(true),
+          applyRemoteUpdate: vi.fn(),
+          getStateVector: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4])),
+          seedFromMarkdownPublic: vi.fn()
+        }
+      },
+      abortController: new AbortController()
+    } as unknown as SyncContext
+
+    postToServerMock.mockImplementation((_url: string, body: unknown) => ({
+      notes: Object.fromEntries(
+        (body as { notes: Array<{ noteId: string }> }).notes.map((note) => [
+          note.noteId,
+          { updates: [], hasMore: false }
+        ])
+      )
+    }))
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.applyCrdtBatch(['n1', 'n2', 'n3', 'n4', 'n5'], 'token-1', new Uint8Array([4]))
+
+    // #then a pass holds every one of its notes open until their updates land, so
+    // one that outgrows the cache has its earliest notes closed underneath it and
+    // their updates dropped as "unopened doc".
+    const batched = postToServerMock.mock.calls.map(([, body]: [string, unknown]) =>
+      (body as { notes: Array<{ noteId: string }> }).notes.map((note) => note.noteId)
+    )
+    expect(batched).toEqual([['n1', 'n2'], ['n3', 'n4'], ['n5']])
+  })
+
+  it('does not seed from markdown when a doc was closed underneath the pass', async () => {
+    // #given note-2's doc is gone by the time the pass checks it: getStateVector
+    // reports null (no doc) rather than an empty vector (open but empty doc)
+    const seedFromMarkdownPublic = vi.fn()
+    const ctx = {
+      deps: {
+        crdtProvider: {
+          inactiveDocCapacity: 32,
+          getDoc: vi.fn().mockReturnValue(undefined),
+          open: vi.fn().mockResolvedValue({}),
+          closeIfInactive: vi.fn().mockResolvedValue(true),
+          applyRemoteUpdate: vi.fn(),
+          getStateVector: vi.fn((noteId: string) =>
+            noteId === 'note-2' ? null : new Uint8Array([1, 2, 3, 4])
+          ),
+          seedFromMarkdownPublic
+        }
+      },
+      abortController: new AbortController()
+    } as unknown as SyncContext
+
+    postToServerMock.mockResolvedValue({
+      notes: {
+        'note-1': { updates: [], hasMore: false },
+        'note-2': { updates: [], hasMore: false }
+      }
+    })
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.applyCrdtBatch(['note-1', 'note-2'], 'token-1', new Uint8Array([4]))
+
+    // #then treating a closed doc as an empty one writes this device's stale
+    // markdown over a body the pass never applied — the remote edit is lost, not
+    // merely stale, and the next pass has nothing left to reconcile against.
+    expect(seedFromMarkdownPublic).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -204,6 +204,31 @@ export class CrdtSyncCoordinator {
     const crdtProvider = this.ctx.deps.crdtProvider
     if (!crdtProvider || !this.ctx.abortController) return
 
+    // A pass holds every one of its notes open from before the request is sent
+    // until that note's updates are applied, so it must never open more than
+    // the provider keeps cached: past the limit the LRU closes the notes it
+    // opened first, applyRemoteUpdate drops their updates as "unopened doc",
+    // and the seed check below then sees no state vector at all. The passes
+    // that matter are exactly the oversized ones — a sign-in or a reconnect
+    // sweep hands over the whole vault, several times the limit.
+    //
+    // Chunking here also keeps each request under the server's 100-note cap on
+    // /sync/crdt/updates/batch, which a whole-vault pass otherwise blows past.
+    const chunkSize = crdtProvider.inactiveDocCapacity
+    for (let i = 0; i < noteIds.length; i += chunkSize) {
+      if (this.ctx.abortController.signal.aborted) return
+      await this.applyCrdtBatchChunk(noteIds.slice(i, i + chunkSize), token, vaultKey)
+    }
+  }
+
+  private async applyCrdtBatchChunk(
+    noteIds: string[],
+    token: string,
+    vaultKey: Uint8Array
+  ): Promise<void> {
+    const crdtProvider = this.ctx.deps.crdtProvider
+    if (!crdtProvider || !this.ctx.abortController) return
+
     const syncOpenedNoteIds = new Set<string>()
     try {
       const sinceMap = new Map<string, number>()
@@ -304,7 +329,16 @@ export class CrdtSyncCoordinator {
       // duplicated note body. Its baseline failed transiently; the next pass fetches it.
       for (const noteId of sinceMap.keys()) {
         const postVector = crdtProvider.getStateVector(noteId)
-        if (!postVector || postVector.length <= 2) {
+        // No vector at all means the doc is no longer open, which is not the
+        // same as an open doc that turned out to be empty: the provider closed
+        // it while this pass ran, so what the server holds is simply unknown
+        // here. Seeding on that would write local markdown over a note whose
+        // remote body was never applied. Leave it for the next pass.
+        if (!postVector) {
+          log.warn('Skipping markdown seed: CRDT doc closed mid-batch', { noteId })
+          continue
+        }
+        if (postVector.length <= 2) {
           await crdtProvider.seedFromMarkdownPublic(noteId)
           log.debug('applyCrdtBatch: seeded from markdown as fallback (no server CRDT)', {
             noteId

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -92,6 +92,22 @@ targets docs with zero attached windows, so active editor docs are never evicted
 provider metrics expose the open doc count, encoded size, and per-doc `windowCount`
 so memory growth can be observed without inspecting private provider state.
 
+That cap bounds how many notes one sync pass may hold at a time. The batch CRDT pull
+opens every note it is about to fetch before it sends the request and keeps them open
+until their updates are applied, so it splits its work into chunks of
+`CrdtProvider.inactiveDocCapacity`. An unsplit pass larger than the cap evicts the notes
+it opened first, and their updates are then dropped as "unopened doc" — a whole-vault
+pass, which is what a sign-in or a reconnect sweep produces, is several times the cap.
+Chunking also keeps each request under the server's 100-note limit on
+`/sync/crdt/updates/batch`.
+
+For the same reason, "this doc has no state" and "this doc is not open" are treated as
+different answers when the pass decides whether to seed a note from local markdown. A
+doc the provider closed mid-pass reports no state vector at all; seeding on that would
+write this device's markdown over a body the pass never managed to apply, losing the
+other device's edit rather than merely showing it late. Those notes are left for the
+next pass.
+
 Because "attached window" is what makes a doc safe from eviction, every IPC entry point
 that can open a doc attributes it to the sender window — `crdt:open-doc` and the
 `crdt:sync-step-1` handshake alike. The handshake matters because it can be the call that


### PR DESCRIPTION
## Problem

Reported repro: sign out on device B, edit a note **body** on device A, sign back in on B. A's edit never appears on B. Edits B makes afterwards do reach A, so the pair looks half-deaf.

`eb4c3fc1b` (#1120 / #1153) fixed *when* the vault-wide CRDT sweep runs. The sweep's own delivery was still lossy.

## Root cause

`applyCrdtBatch` opened **every** note in a pass before sending the request and held them open until their updates were applied. `CrdtProvider` caps editor-less docs at 32 and runs LRU eviction on every `open()`. A sign-in hands over the whole vault — 121 notes on the reporter's device — so the notes opened first were closed underneath the pass:

1. `applyRemoteUpdate` could no longer find them and dropped their updates. Device B's log: **711×** `Received remote update for unopened doc`.
2. The seed check read `!postVector || postVector.length <= 2`, but `getStateVector` returns `null` for a doc that is not open — so "doc is gone" was treated as "doc is empty" and the note was seeded from **this device's local markdown**. **598×** `seeded from markdown as fallback`.

Step 2 makes it a silent clobber of the other device's edit rather than a stale read. Any vault over 32 notes takes this path on sign-in.

The reporter's test note hit both at 18:00:16: 24 dropped updates, then a markdown seed.

## Fix

- `CrdtProvider` exposes `inactiveDocCapacity`.
- `applyCrdtBatch` chunks by it and delegates to a new private `applyCrdtBatchChunk`. This also keeps each request under the server's 100-note cap on `/sync/crdt/updates/batch`, which a whole-vault pass previously exceeded.
- The seed check now separates `!postVector` (doc closed → skip, leave it for the next pass) from `length <= 2` (open but empty → seed).

No contract, IPC, schema, or protocol change.

## Verification

- Two regression tests, both **mutation-verified**: each fails against the previous behaviour, and the twelve existing batch cases stay green under the mutation.
- `src/main/sync/` — 144 files, 1902 tests pass.
- `typecheck:node`, `typecheck:test`, eslint, `git diff --check` clean.
- `docs:impact --strict` covered, `docs:build` passes.

## Deliberately not in this PR

The vault-wide sweep still uses the single-note pull path: 2 HTTP requests per note, 242 requests in ~4s against `crdt_pull` = 300/60s keyed by **userId**, which both devices share. **92 of 121** notes returned `Too many requests` in one sweep, and `withRetry(..., { retryOn429: false })` plus a catch that only logs means no retry and no re-queue. After this PR that costs freshness, not data. Moving the sweep to the batch endpoint is a separate change.

Unrelated bug found in the same logs: #1445.