### PR TITLE
fix(editor): start a marquee only outside selectable text

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.test.tsx
@@ -191,7 +191,7 @@ describe('useBlockMarqueeSelection', () => {
     trigger.remove()
   })
 
-  it('ignores disabled, interactive, opted-out, and mostly-horizontal editable drags', () => {
+  it('ignores disabled, interactive, opted-out, and in-text drags', () => {
     const { trigger, blockContainerRef } = setupDom()
     const button = document.createElement('button')
     trigger.append(button)
@@ -209,9 +209,13 @@ describe('useBlockMarqueeSelection', () => {
     // Icons render as SVG, which is an Element but not an HTMLElement.
     const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
     trigger.append(icon)
-    const editable = document.createElement('div')
-    editable.setAttribute('contenteditable', 'true')
-    trigger.append(editable)
+    // The bug this rule exists to kill (#1441): a press inside a line of text
+    // followed by a long straight-down drag. The class name is BlockNote's own
+    // and is spelled out here on purpose — it is the tripwire that fires if an
+    // upgrade renames the inline content element out from under the predicate.
+    const inlineContent = document.createElement('div')
+    inlineContent.className = 'bn-inline-content'
+    trigger.append(inlineContent)
     const editor = { prosemirrorView: { dom: { blur: vi.fn() } } }
 
     const { result, rerender, unmount } = renderHook(
@@ -250,12 +254,145 @@ describe('useBlockMarqueeSelection', () => {
       expect(result.current.selectedBlockIds.size).toBe(0)
     }
 
+    // Straight down the whole note — under the old direction heuristic this was
+    // the gesture that selected blocks. It must now select nothing.
     act(() => {
-      editable.dispatchEvent(mouse('mousedown', { clientX: 0, clientY: 0 }))
-      document.dispatchEvent(mouse('mousemove', { clientX: 40, clientY: 16 }))
-      document.dispatchEvent(mouse('mouseup', { clientX: 40, clientY: 16 }))
+      inlineContent.dispatchEvent(mouse('mousedown', { clientX: 60, clientY: 0 }))
+      document.dispatchEvent(mouse('mousemove', { clientX: 60, clientY: 190 }))
+      document.dispatchEvent(mouse('mouseup', { clientX: 60, clientY: 190 }))
     })
     expect(result.current.selectedBlockIds.size).toBe(0)
+
+    unmount()
+    trigger.remove()
+  })
+
+  it('starts a marquee everywhere except on selectable text', () => {
+    // The decision table from #1441, one press location per row.
+    const { trigger, blockContainerRef } = setupDom()
+    const editor = { prosemirrorView: { dom: { blur: vi.fn() } } }
+
+    // The gray margin beside the text column: nothing above it is inline content.
+    const margin = document.createElement('div')
+    trigger.append(margin)
+    // A list marker, and any block holding no editable text (task, file,
+    // bookmark, YouTube embed). Markers are a ::before on the block content
+    // element and pseudo-elements are never event targets, so both press
+    // locations report a `.bn-block-content` with no inline content inside it.
+    const blockContentWithoutText = document.createElement('div')
+    blockContentWithoutText.className = 'bn-block-content'
+    trigger.append(blockContentWithoutText)
+    // The empty area below the last block.
+    const belowLastBlock = document.createElement('div')
+    belowLastBlock.className = 'editor-click-area'
+    trigger.append(belowLastBlock)
+    // A line of text, plus a bold run nested inside it — the rule is about the
+    // nearest inline content ancestor, not about the target itself.
+    const line = document.createElement('div')
+    line.className = 'bn-inline-content'
+    trigger.append(line)
+    const boldRun = document.createElement('strong')
+    line.append(boldRun)
+
+    const { result, unmount } = renderHook(() =>
+      useBlockMarqueeSelection({
+        editor,
+        blockContainerRef,
+        triggerContainerEl: trigger
+      })
+    )
+
+    for (const outsideText of [margin, blockContentWithoutText, belowLastBlock]) {
+      act(() => {
+        outsideText.dispatchEvent(mouse('mousedown', { clientX: 0, clientY: 0 }))
+        document.dispatchEvent(mouse('mousemove', { clientX: 150, clientY: 70 }))
+        document.dispatchEvent(mouse('mouseup', { clientX: 150, clientY: 70 }))
+      })
+      expect([...result.current.selectedBlockIds]).toEqual(['a', 'b'])
+      act(() => {
+        result.current.clearSelection()
+      })
+    }
+
+    for (const insideText of [line, boldRun]) {
+      act(() => {
+        insideText.dispatchEvent(mouse('mousedown', { clientX: 0, clientY: 0 }))
+        document.dispatchEvent(mouse('mousemove', { clientX: 150, clientY: 70 }))
+        document.dispatchEvent(mouse('mouseup', { clientX: 150, clientY: 70 }))
+      })
+      expect(result.current.selectedBlockIds.size).toBe(0)
+    }
+
+    unmount()
+    trigger.remove()
+  })
+
+  it('needs a real drag rather than a click, in any direction', () => {
+    const { trigger, blockContainerRef } = setupDom()
+    const editor = { prosemirrorView: { dom: { blur: vi.fn() } } }
+
+    const { result, unmount } = renderHook(() =>
+      useBlockMarqueeSelection({
+        editor,
+        blockContainerRef,
+        triggerContainerEl: trigger
+      })
+    )
+
+    // Same press, same geometry over block 'a' — only the travel differs.
+    // 4px is a click with a shaky hand and must not flash a selection box.
+    act(() => {
+      trigger.dispatchEvent(mouse('mousedown', { clientX: 10, clientY: 20 }))
+      document.dispatchEvent(mouse('mousemove', { clientX: 14, clientY: 20 }))
+      document.dispatchEvent(mouse('mouseup', { clientX: 14, clientY: 20 }))
+    })
+    expect(result.current.selectedBlockIds.size).toBe(0)
+    expect(result.current.marqueeRect).toBeNull()
+
+    // 6px of the same purely horizontal motion is a drag. Direction carries no
+    // meaning any more, so sideways travel starts a marquee just as down does.
+    act(() => {
+      trigger.dispatchEvent(mouse('mousedown', { clientX: 10, clientY: 20 }))
+      document.dispatchEvent(mouse('mousemove', { clientX: 16, clientY: 20 }))
+      document.dispatchEvent(mouse('mouseup', { clientX: 16, clientY: 20 }))
+    })
+    expect([...result.current.selectedBlockIds]).toEqual(['a'])
+
+    unmount()
+    trigger.remove()
+  })
+
+  it('clears a live marquee selection when the press lands in text, without starting a new one', () => {
+    const { trigger, blockContainerRef } = setupDom()
+    const editor = { prosemirrorView: { dom: { blur: vi.fn() } } }
+    const line = document.createElement('div')
+    line.className = 'bn-inline-content'
+    trigger.append(line)
+
+    const { result, unmount } = renderHook(() =>
+      useBlockMarqueeSelection({
+        editor,
+        blockContainerRef,
+        triggerContainerEl: trigger
+      })
+    )
+
+    act(() => {
+      trigger.dispatchEvent(mouse('mousedown', { clientX: 0, clientY: 0 }))
+      document.dispatchEvent(mouse('mousemove', { clientX: 150, clientY: 70 }))
+      document.dispatchEvent(mouse('mouseup', { clientX: 150, clientY: 70 }))
+    })
+    expect([...result.current.selectedBlockIds]).toEqual(['a', 'b'])
+
+    // Declining to start a marquee must not also decline to clear the old one:
+    // a stale block highlight competing with the caret is its own bug.
+    act(() => {
+      line.dispatchEvent(mouse('mousedown', { clientX: 60, clientY: 0 }))
+      document.dispatchEvent(mouse('mousemove', { clientX: 60, clientY: 190 }))
+      document.dispatchEvent(mouse('mouseup', { clientX: 60, clientY: 190 }))
+    })
+    expect(result.current.selectedBlockIds.size).toBe(0)
+    expect(result.current.highlightRects).toEqual([])
 
     unmount()
     trigger.remove()

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.ts
@@ -2,13 +2,18 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createLogger } from '@/lib/logger'
-import { shouldStartMarquee } from '../marquee-hit-test'
+import { hasSelectableTextAt, shouldStartMarquee } from '../marquee-hit-test'
 import { classifyBlocks, indentTaskBlock, outdentTaskBlock } from './task-block-marquee-indent'
 
 const log = createLogger('Hook:Marquee')
 
-const VERTICAL_PROMOTE_PX = 15
-const HORIZONTAL_LIMIT_PX = 8
+/**
+ * How far the pointer must travel before a press becomes a drag. Direction-
+ * agnostic on purpose: whether this gesture may be a marquee at all was already
+ * settled at mousedown by `hasSelectableTextAt`, so all this threshold does is
+ * keep a plain click from flashing a selection box.
+ */
+const DRAG_THRESHOLD_PX = 5
 const ACTIVE_ATTR = 'data-marquee-active'
 
 export interface MarqueeRect {
@@ -358,12 +363,6 @@ export function useBlockMarqueeSelection({
       if (event.button !== 0) return
       if (!shouldStartMarquee(event.target)) return
 
-      // Whether this gesture started inside editable text. Affects the promotion
-      // gate: text-selection-preservation only matters when there is text to
-      // select. Drags that start in the gutter promote on any vertical motion.
-      const startedInsideEditableText =
-        event.target instanceof Element && event.target.closest('[contenteditable="true"]') !== null
-
       const blockContainer = blockContainerRef.current
       if (!blockContainer) return
 
@@ -376,6 +375,13 @@ export function useBlockMarqueeSelection({
         setHighlightRects([])
         hasSelectionRef.current = false
       }
+
+      // The marquee start rule (#1444), and its position here is load-bearing.
+      // A press on text is a text selection, so we decline — but only AFTER the
+      // clearing above, so pressing into text still dismisses a stale block
+      // highlight instead of leaving it competing with the caret; and BEFORE the
+      // document listeners below, so declining registers nothing at all.
+      if (hasSelectableTextAt(event.target)) return
 
       const origin: OriginPoint = { clientX: event.clientX, clientY: event.clientY }
       let lastMove: OriginPoint = { clientX: event.clientX, clientY: event.clientY }
@@ -456,13 +462,20 @@ export function useBlockMarqueeSelection({
         lastMove = { clientX: moveEvent.clientX, clientY: moveEvent.clientY }
 
         if (!isMarquee) {
-          const dx = Math.abs(moveEvent.clientX - origin.clientX)
-          const dy = Math.abs(moveEvent.clientY - origin.clientY)
-          // Drags that start inside editable text must be clearly vertical so we
-          // don't steal "drag right to highlight a word" gestures. Drags that start
-          // in the gutter (no text to select) promote on any vertical motion.
-          if (dy < VERTICAL_PROMOTE_PX) return
-          if (startedInsideEditableText && dx > HORIZONTAL_LIMIT_PX && dx > dy) return
+          // Straight-line distance from the press, and nothing else. This gesture
+          // already earned the right to be a marquee at mousedown by starting
+          // outside selectable text, so the only question left is click or drag.
+          //
+          // Direction used to be decided here instead — a minimum vertical
+          // travel plus an exemption for mostly-horizontal drags that began in
+          // editable text — and that is precisely what made the outcome depend
+          // on the drag angle: from one press inside a paragraph, straight down
+          // selected blocks and down-and-right selected text, with nothing on
+          // screen to tell the user which they were about to get. Re-introducing
+          // any direction test here brings that back (#1441).
+          const dx = moveEvent.clientX - origin.clientX
+          const dy = moveEvent.clientY - origin.clientY
+          if (Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return
           promote()
         }
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/marquee-hit-test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/marquee-hit-test.ts
@@ -1,10 +1,13 @@
 /**
  * Marquee hit-testing — one home for "what did this press land on?".
  *
- * Two call sites ask a location question about a mousedown in the editor:
+ * Three call sites ask a location question about a mousedown in the editor:
  *
  *   - the marquee selection hook: "may this press start a marquee at all?"
  *     (`shouldStartMarquee`)
+ *   - the same hook, once that is settled: "is there selectable text at this
+ *     press?" (`hasSelectableTextAt`) — the gate that stops a marquee starting
+ *     from inside a line of text
  *   - the note page's and the journal page's click-to-focus-end handlers:
  *     "is this press outside every block?" (`isOutsideAllBlocks`)
  *
@@ -12,11 +15,8 @@
  * hook and both pages, where two of the copies were byte-identical and the
  * third was a different rule entirely. Co-locating them is the point: they are
  * deliberately NOT the same test, and the only way that stays deliberate rather
- * than accidental is for a change to one to sit next to the other.
- *
- * #1444 adds a third question here — "is there selectable text at this press?",
- * the gate that stops a marquee starting from inside a line of text. Read
- * `isOutsideAllBlocks` below before assuming it can answer that one too.
+ * than accidental is for a change to one to sit next to the other. The last two
+ * in particular sound like one question and answer differently on a task block.
  *
  * This module is pure DOM inspection — no editor, no React, no state. Every
  * function takes the raw `event.target` and answers from ancestry alone.
@@ -24,6 +24,9 @@
 
 /** BlockNote's block content element: the box a single block's content lives in. */
 const BLOCK_CONTENT_SELECTOR = '.bn-block-content'
+
+/** BlockNote's inline content element: the run of editable text inside a block. */
+const INLINE_CONTENT_SELECTOR = '.bn-inline-content'
 
 /**
  * Is this press outside every block — i.e. in the margin, the gutter, or the
@@ -49,13 +52,14 @@ const BLOCK_CONTENT_SELECTOR = '.bn-block-content'
  *
  * ## Why the marquee start rule (#1444) cannot reuse this
  *
- * "Outside every block" and "no selectable text here" sound like the same
- * question and have different answers. A task block sits inside
- * `.bn-block-content` but holds no editable text at all, so answering the
- * marquee question with this predicate would classify a press on a task row as
- * "inside a block" and refuse to start a marquee there — and answering THIS
- * question with the marquee's predicate would classify a click on a task row
- * as "outside every block", firing `preventDefault()` + `focusAtEnd()` on it,
+ * `hasSelectableTextAt` below is the marquee's question, and it is a separate
+ * function for a reason: "outside every block" and "no selectable text here"
+ * sound like the same question and have different answers. A task block sits
+ * inside `.bn-block-content` but holds no editable text at all, so answering
+ * the marquee question with this predicate would classify a press on a task row
+ * as "inside a block" and refuse to start a marquee there — and answering THIS
+ * question with `hasSelectableTextAt` would classify a click on a task row as
+ * "outside every block", firing `preventDefault()` + `focusAtEnd()` on it,
  * jumping the caret to the end of the document and suppressing the row's own
  * focus handling so the task title could no longer be opened for inline
  * editing. The two stay separate on purpose.
@@ -85,7 +89,7 @@ export function isOutsideAllBlocks(target: Element): boolean {
  * body. Clicking it should open the link; selecting it is reached from the
  * margin instead.
  */
-export function shouldStartMarquee(target: EventTarget | null): boolean {
+export function shouldStartMarquee(target: EventTarget | null): target is HTMLElement {
   if (!(target instanceof HTMLElement)) return false
   if (target.closest('[data-marquee-ignore]')) return false
   if (target.closest('button, a, input, textarea, select, [role="button"]')) return false
@@ -97,4 +101,56 @@ export function shouldStartMarquee(target: EventTarget | null): boolean {
     return false
   }
   return true
+}
+
+/**
+ * Is there selectable text at this press?
+ *
+ * The marquee start rule (#1444): a press that lands on text begins a text
+ * selection and never a marquee, however far the following drag travels and in
+ * whatever direction. A marquee begins only outside text — the gray margin, the
+ * list-marker strip, the strip left of an indented block, a block holding no
+ * editable text, or the empty area below the last block. Deciding once, from the
+ * press location, is the whole point: the rule this replaced decided *during*
+ * the drag from its direction, so the same starting point produced blocks when
+ * the user dragged straight down and text when they drifted right.
+ *
+ * ## Why `.bn-inline-content` and not `contenteditable`
+ *
+ * "Is the press inside a `contenteditable="true"` subtree" is the obvious test
+ * and the wrong one here. `base.css` sets `padding-inline: 0px` on `.bn-editor`
+ * globally, so the contenteditable root spans the entire text column rather
+ * than sitting inside it. Anchored there, the list-marker strip, the
+ * nested-block indent strip and every non-editable custom block (task, file,
+ * bookmark, YouTube embed) all sit inside the contenteditable root and would
+ * report "text" — which is every marquee entry point except the outer margin.
+ *
+ * ## Why list markers fall outside it
+ *
+ * A bullet or a number is a `::before` pseudo-element owned by
+ * `.bn-block-content`, and pseudo-elements are never event targets, so a press
+ * on the marker reports `.bn-block-content` itself. That element has no
+ * `.bn-inline-content` ancestor, so the marker strip classifies as margin with
+ * no coordinate arithmetic anywhere.
+ *
+ * ## Why the empty space right of a short line is still text
+ *
+ * `.bn-inline-content` is block-level, so for a paragraph it spans the full
+ * column width regardless of how far the text itself reaches. Granularity here
+ * is deliberately the block box, not the line box: reclassifying the tail of a
+ * short line would mean measuring line boxes on every mousedown, and users have
+ * no reliable sense of where a line ended. The practical consequence, stated so
+ * it is not later filed as a bug: the only place to begin a right-side marquee
+ * is the gray margin outside the column.
+ *
+ * TRIPWIRE, read this before upgrading BlockNote. `.bn-inline-content` is a
+ * BlockNote-internal class name, not a contract. If an upgrade renames it, this
+ * function silently answers "no text anywhere", every press starts a marquee,
+ * and text selection in the editor dies — with no type error and no crash. The
+ * hook test catches it only because its fixture spells the same class name;
+ * that fixture is the tripwire, so do not "modernise" it into a helper that
+ * derives the name from here.
+ */
+export function hasSelectableTextAt(target: Element): boolean {
+  return target.closest(INLINE_CONTENT_SELECTOR) !== null
 }

--- a/apps/desktop/tests/e2e/marquee-selection.e2e.ts
+++ b/apps/desktop/tests/e2e/marquee-selection.e2e.ts
@@ -205,6 +205,45 @@ test.describe('Block marquee selection', () => {
     await expect(page.locator(HIGHLIGHTED_SELECTOR)).toHaveCount(0)
   })
 
+  test('regression: vertical drag inside text selects text, never blocks', async ({ page }) => {
+    // #1441: the reported bug. Pressing inside a line and dragging straight down
+    // used to flip into a block selection and destroy the text selection the
+    // user was building — while the same press dragged down-and-right selected
+    // text. Mirror image of expectNoNativeTextSelection: this gesture must leave
+    // a real native selection behind and no marquee at all.
+    await createNote(page, `Marquee Vertical Text ${Date.now()}`)
+    await focusEditor(page)
+    await typeBlocks(page, [
+      'First paragraph of the vertical drag regression',
+      'Second paragraph of the vertical drag regression',
+      'Third paragraph of the vertical drag regression'
+    ])
+    await page.waitForTimeout(400)
+
+    expect(await getBlockCount(page)).toBeGreaterThanOrEqual(3)
+
+    const first = await getBlockBox(page, 0)
+    const third = await getBlockBox(page, 2)
+
+    // Start a few characters into the first line and end inside the third,
+    // with no horizontal travel whatsoever.
+    const startX = first.x + Math.min(60, first.width / 2)
+    const startY = first.y + first.height / 2
+    const endY = third.y + third.height / 2
+
+    await page.mouse.move(startX, startY)
+    await page.mouse.down()
+    await page.mouse.move(startX, endY, { steps: 14 })
+    await page.mouse.up()
+    await page.waitForTimeout(150)
+
+    await expect(page.locator(OVERLAY_SELECTOR)).toHaveCount(0)
+    await expect(page.locator(HIGHLIGHTED_SELECTOR)).toHaveCount(0)
+
+    const selectedText = await page.evaluate(() => window.getSelection()?.toString() ?? '')
+    expect(selectedText.length).toBeGreaterThan(0)
+  })
+
   test('regression: single click in block does NOT trigger marquee', async ({ page }) => {
     await createNote(page, `Marquee Click ${Date.now()}`)
     await focusEditor(page)

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -104,6 +104,26 @@ Hover the gutter on the left to reveal the block handle. Drag a block to:
 - Reorder within the note
 - Move out into a different note (drop on a sidebar item or another open tab)
 
+## Selecting Text and Blocks
+
+Dragging that **starts inside a line** always selects text, however far it travels and in whatever direction. Dragging straight down across several paragraphs selects the text between the two points, exactly as dragging diagonally does.
+
+To select whole blocks instead, start the drag **outside the text column**:
+
+- the gray margin to the left or right of the column
+- the bullet or number in front of a list item
+- the strip to the left of an indented block
+- a block with no editable text of its own — a task, a file or a video
+- the empty area below the last block
+
+A selection box follows the pointer and every block it touches is highlighted, the same way selecting files works in a file manager. The box only appears once you have moved a few pixels, so a plain click in the margin still just puts the cursor at the end of the note.
+
+A bookmark card is the one exception: its whole surface is a link, so clicking it opens the link and a drag has to begin in the margin beside it instead.
+
+With blocks selected, <kbd>Backspace</kbd> deletes them, <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> indent and outdent them, and <kbd>Esc</kbd> clears the selection.
+
+One consequence worth knowing: the empty space to the right of a short line still counts as that line's text, so the right-hand margin outside the column is the place to begin a right-side block selection.
+
 ## Saving
 
 Saves are **automatic and debounced** (default ~1 second). Changes also flush on:


### PR DESCRIPTION
Closes #1444. Closes #1441. Follows #1447 and #1448.

## The bug

Pressing inside a line and dragging straight down stopped selecting text and selected whole blocks instead. The same press dragged down-and-right selected text. The outcome depended on the drag *angle*, which the user has no way to see — and since a multi-line text selection is almost always a mostly-vertical gesture, the wrong outcome was the common one. It also destroyed the cross-block text selection that the list-conversion toolbar (#1224) reads.

## The rule

A press that lands on text is always the start of a text selection, however far the drag travels and in whatever direction. A marquee begins only where there is no selectable text:

- the gray margin left or right of the text column
- the list-marker strip in front of a list item
- the strip left of an indented block
- a block holding no editable text — task, file, YouTube embed
- the empty area below the last block

The decision happens once, at mousedown, from the press location. The two direction-sensitive thresholds are replaced by one 5px straight-line distance whose only job is separating a click from a drag.

## Why the anchor is `.bn-inline-content`

`contenteditable` is the obvious anchor and the wrong one here: the app zeroes `.bn-editor`'s `padding-inline` globally, so the contenteditable root spans the whole text column and would classify every marquee entry point except the outer margin as text. Inline content is block-level (so the tail of a short line stays text — deliberate, granularity is the block box not the line box), and list markers are a `::before` on `.bn-block-content`, which pseudo-elements make unreachable as event targets — so the marker strip falls outside with no coordinate arithmetic anywhere.

The class name is BlockNote-internal, so the module carries a tripwire note and the hook test's fixture spells the same name on purpose.

## Two placement details that are load-bearing

The gate sits **after** the handler's selection-clearing step, so pressing into text still dismisses a stale block highlight; and **before** the document listeners, so declining registers nothing.

## Verification

- `typecheck:web`, `typecheck:test`, `lint` (0 errors) clean
- Renderer: 48 passed across hook + note + journal; 83 passed across 6 adjacent marquee-touching suites
- `marquee-selection.e2e.ts`: 19 passed, no retries. Journal and block-types specs: 16 passed (journal re-run serially after the known Electron lifecycle flake at 2 workers — the failures were `Target page … has been closed` inside `waitForAppReady`, not assertions)
- `docs:impact --strict` covered, `docs:build` clean
- Patch coverage checked locally before pushing: zero uncovered statements in `marquee-hit-test.ts`, and every line this diff adds to the hook is exercised
- Mutation-checked so the tests are not decorative: forcing the predicate to `false` fails 3 tests; moving the threshold to 3px or 8px fails the boundary test

## One correction to the issue's acceptance criteria

#1444 lists "a drag beginning on a task, file, bookmark, or YouTube block starts a marquee". **Bookmark does not**, and should not: its whole surface is a link, and the interactive-element exclusion this change deliberately leaves alone means clicking it opens the link. That was the accepted, documented consequence in #1441 rather than an oversight, and the user guide now states it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)