### PR TITLE
test(notes): opening a note is a fixed point — for unmarked links

### DIFF
--- a/apps/desktop/src/main/sync/note-open-byte-stability.test.ts
+++ b/apps/desktop/src/main/sync/note-open-byte-stability.test.ts
@@ -171,10 +171,10 @@ const REL_PATH = path.join('notes', 'Byte Stability.md')
  * the sharp edge in #1428: a wiki link is one element inside a list item, a
  * quote and a table cell, and a text-matching parse claims the whole element.
  *
- * Deliberately absent: a wiki link inside a longer MARKED phrase
- * (`~~Cancelled: [[Meeting]]~~`). That one does not round-trip — see the
- * `#1439` case at the bottom of this file, which pins the current behaviour
- * without asserting it is correct.
+ * Deliberately absent: any wiki link carrying an inline MARK. That whole class
+ * does not round-trip — see the `#1439` cases at the bottom of this file, which
+ * pin the current behaviour without asserting it is correct. The fixtures here
+ * gate the cases that DO converge; do not read their green as covering marks.
  */
 const FIXTURES: ReadonlyArray<readonly [string, string]> = [
   ['a wiki link in a sentence', 'See [[Wiki Link]] for details.'],
@@ -455,13 +455,72 @@ describe('write-back does not delete a wiki link from the shared doc', () => {
 
 describe('known non-convergence, pinned not endorsed', () => {
   /**
-   * #1439. A wiki link inside a longer struck-through phrase does not survive
-   * the first open: the promotion splits the marked run, and the mark's closing
-   * delimiter lands before the link instead of after it. It is blocked on a
-   * product decision (which of the two forms is right), so this asserts what
-   * happens today rather than what should — and it is deliberately kept out of
-   * the fixtures above, whose job is to gate the cases that DO converge.
+   * #1439, and it is a CLASS, not one shape. BlockNote's
+   * `CustomInlineContentFromConfig` has no `styles` field, so the promotion has
+   * nowhere to put a mark and drops it. Verified against a control run with the
+   * promotion step removed — every one of these is flat without it:
+   *
+   *   `**[[Meeting]]**`             -> `[[Meeting]]`                 mark DELETED
+   *   `~~[[Meeting]]~~`             -> `[[Meeting]]`                 mark DELETED
+   *   `*[[A]]*`                     -> `[[A]]`                       mark DELETED
+   *   `~~Cancelled: [[Meeting]]~~`  -> `~~Cancelled: ~~[[Meeting]]`  mark BROKEN
+   *
+   * The last one is worse than its byte count suggests: GFM requires a closing
+   * `~~` not be preceded by whitespace, so `~~Cancelled: ~~` is strikethrough
+   * nowhere and the note ends up showing four literal tildes. Bold survives the
+   * same shape only because the serializer emits `&#x20;` entities around it.
+   *
+   * Each is a single rewrite and stable afterwards. Blocked on a product
+   * decision, so these assert what happens today, not what should.
    */
+  it('a note carrying CriticMarkup review marks is rewritten on first open', async () => {
+    // #given review marks live in the Y.Doc, not in the fragment, and write-back
+    // re-serializes them onto the body. That round trip is not byte-identical.
+    let current = 'Plain {==marked==} and {>>note<<} with [[A]].'
+    const absolutePath = seedVaultNote(current)
+    const lengths: number[] = [current.length]
+
+    // #when opened five times
+    for (let pass = 0; pass < 5; pass++) {
+      const doc = await openNote(absolutePath)
+      await applyRendererPromotion(doc)
+      await runWriteback(doc)
+      current = fs.readFileSync(absolutePath, 'utf8')
+      lengths.push(current.length)
+    }
+
+    // #then one rewrite, then a fixed point. Pinned so that dropping
+    // `serializeCriticMarkup` from write-back — which deletes every review
+    // comment from the note — cannot pass unnoticed the way it did before.
+    expect(lengths).toEqual([45, 93, 93, 93, 93, 93])
+    expect(current).toContain('marked')
+    expect(current).toContain('note')
+  })
+
+  it.each([
+    ['bold around the whole link', '**[[Meeting]]**', '[[Meeting]]'],
+    ['strikethrough around the whole link', '~~[[Meeting]]~~', '[[Meeting]]'],
+    ['italic around the whole link', '*[[A]]*', '[[A]]']
+  ])('%s loses the mark on first open, then holds', async (_name, seed, expected) => {
+    // #given a note whose wiki link carries a mark
+    let current = seed
+    const absolutePath = seedVaultNote(current)
+
+    // #when opened five times
+    const results: string[] = []
+    for (let pass = 0; pass < 5; pass++) {
+      const doc = await openNote(absolutePath)
+      await applyRendererPromotion(doc)
+      await runWriteback(doc)
+      current = fs.readFileSync(absolutePath, 'utf8')
+      results.push(current)
+    }
+
+    // #then the mark is gone after the first open and never comes back
+    expect(results[0]).toBe(expected)
+    expect(new Set(results).size).toBe(1)
+  })
+
   it('a wiki link inside a marked phrase is rewritten once, then holds', async () => {
     // #given
     let current = '~~Cancelled: [[Meeting]]~~'

--- a/apps/desktop/src/main/sync/note-open-byte-stability.test.ts
+++ b/apps/desktop/src/main/sync/note-open-byte-stability.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Opening a note must not rewrite it (#1434, phase 3 of #1427).
+ *
+ * ## The loop this file exists to close
+ *
+ * On the collaborative path the two processes hold different ideas of what a
+ * wiki link IS. Main parses the vault file into the shared Y.Doc
+ * (`crdt-provider.seedFromMarkdown` -> `markdownToYFragment`) with a `wikiLink`
+ * spec that has NO `parse` rule, so `[[X]]` arrives as plain TEXT. The renderer
+ * then promotes that text into a `wikiLink` NODE on the first change event
+ * (`normalizeWikiLinks`, called from `use-editor-sync.ts`'s `handleChange`,
+ * which is not gated on collaboration). Write-back serializes the node back to
+ * `[[X]]` text. Before #1428 this "stabilised" only because main's schema had
+ * no `wikiLink` at all and y-prosemirror deleted the node outright; now that
+ * main can represent it, the round trip has to be shown to CONVERGE.
+ *
+ * Byte stability is the user-visible contract — opening a note may not modify
+ * it — and it is what protects Obsidian fidelity.
+ *
+ * ## What this file drives for real, and what it stands in for
+ *
+ * REAL: `markdownToYFragment` (the parser the collaborative path actually
+ * uses), `yFragmentToBlocks` / `blocksToYFragment`, `yDocToMarkdown`, the
+ * renderer's own `normalizeWikiLinks`, and the whole of `performWriteback` —
+ * including its byte-compare — against real `vault/frontmatter`,
+ * `vault/file-ops` and real files in a temp vault.
+ *
+ * STOOD IN FOR: the BlockNote editor instance and y-prosemirror's ProseMirror
+ * <-> Y.Doc binding. `applyRendererPromotion` below reads the fragment as
+ * blocks, runs the renderer's normalizer, and writes the result back — which is
+ * what `editor.replaceBlocks(editor.document, normalized.blocks)` does through
+ * the binding, minus the minimal-delta diffing (irrelevant to the resulting
+ * bytes). The other half of that seam — that a REAL mounted editor bound to a
+ * REAL Y.Doc promotes exactly once and leaves the node in the doc — is driven
+ * in the renderer suite, in
+ * `renderer/src/components/note/content-area/wiki-link-collab-promotion.test.ts`.
+ *
+ * ## Why the renderer import is here rather than the other way round
+ *
+ * `pnpm check:architecture` scans renderer SOURCE files for `@main/*` imports;
+ * it never scans main for renderer imports, and it skips `*.test.ts` in both
+ * directions (`getFilesForRoot` filters `isTestFile`). So the choice is not
+ * "allowed vs forbidden" but "which import keeps the type-check honest". Only
+ * this one does: `tsconfig.test.node.json` compiles `wiki-link-utils.ts` (three
+ * DOM-free modules and `@memry/editor-schema/inline`) without complaint, while
+ * a renderer test importing `blocknote-converter` would drag `node:crypto`,
+ * `electron-log` and the databases into `tsconfig.test.web.json`, which carries
+ * neither the node types nor the includes for them.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
+import type { Block } from '@blocknote/core'
+import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
+
+// The renderer's promotion rule. Imported from source on purpose: a copy of it
+// here would converge with itself and prove nothing.
+import { normalizeWikiLinks } from '../../renderer/src/components/note/content-area/wiki-link-utils'
+
+const mocks = vi.hoisted(() => ({
+  vaultRoot: '',
+  noteRow: null as Record<string, unknown> | null,
+  sent: [] as Array<{ channel: string; payload: unknown }>,
+  atomicWrites: [] as Array<{ absolutePath: string; content: string }>,
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: () => [
+      {
+        isDestroyed: () => false,
+        webContents: {
+          send: (channel: string, payload: unknown) => mocks.sent.push({ channel, payload })
+        }
+      }
+    ]
+  }
+}))
+
+vi.mock('../lib/logger', () => ({ createLogger: () => mocks.logger }))
+
+// crdt-provider itself reaches for `app.getPath` and the CRDT store; write-back
+// only ever asks it "is there a newer doc for this note?".
+vi.mock('./crdt-provider', () => ({
+  getCrdtProvider: () => ({ getDoc: () => undefined, close: vi.fn() })
+}))
+
+vi.mock('../telemetry/diagnostics', () => ({ trackMainError: vi.fn(), trackMainLog: vi.fn() }))
+
+vi.mock('../database/client', () => ({
+  getIndexDatabase: () => ({ kind: 'index-db' }),
+  getDatabase: () => ({ kind: 'data-db' })
+}))
+
+vi.mock('@main/database/queries/notes', () => ({
+  getNoteCacheById: () => mocks.noteRow,
+  getNoteCacheByPath: () => mocks.noteRow
+}))
+
+vi.mock('@memry/storage-data', () => ({ getNoteMetadataById: () => null }))
+
+vi.mock('../vault/note-sync', () => ({
+  syncNoteToCache: vi.fn(),
+  deleteNoteFromCache: vi.fn()
+}))
+
+vi.mock('../projections', () => ({ flushProjectionEvents: vi.fn() }))
+
+vi.mock('@memry/app-core/reminders', () => ({ createRemindersService: () => ({}) }))
+
+vi.mock('../notes/note-date-reminders', () => ({
+  syncNoteDateReminders: vi.fn(),
+  clearNoteDateReminders: vi.fn()
+}))
+
+vi.mock('./local-mutations', () => ({
+  enqueueLocalSyncCreate: vi.fn(),
+  enqueueLocalSyncDelete: vi.fn(),
+  enqueueLocalSyncUpdate: vi.fn()
+}))
+
+// Real path math and real snapshots would need the vault singleton and the
+// index DB; the note's absolute path is the only thing write-back needs here.
+vi.mock('../vault/notes', () => ({
+  getDefaultNoteDir: () => path.join(mocks.vaultRoot, 'notes'),
+  toRelativePath: (absolute: string) => path.relative(mocks.vaultRoot, absolute),
+  toAbsolutePath: (relative: string) => path.join(mocks.vaultRoot, relative),
+  maybeCreateSignificantSnapshot: () => null
+}))
+
+// REAL file ops, wrapped so the suite can assert that write-back never wrote —
+// "the file is byte-identical" and "no write happened" are different claims,
+// and the second is the one the user feels (no mtime churn, no snapshot, no
+// sync push).
+vi.mock('../vault/file-ops', async () => {
+  const actual = await vi.importActual<typeof import('../vault/file-ops')>('../vault/file-ops')
+  return {
+    ...actual,
+    atomicWrite: async (absolutePath: string, content: string) => {
+      mocks.atomicWrites.push({ absolutePath, content })
+      return actual.atomicWrite(absolutePath, content)
+    }
+  }
+})
+
+import {
+  blocksToYFragment,
+  findUnrepresentableNodes,
+  markdownToYFragment,
+  yDocToMarkdown,
+  yFragmentToBlocks
+} from './blocknote-converter'
+import { parseNote } from '../vault/frontmatter'
+import {
+  cancelPendingWritebacks,
+  flushPendingWritebacks,
+  getWritebackDebugState,
+  resetWritebackState,
+  scheduleWriteback
+} from './crdt-writeback'
+
+const NOTE_ID = 'byte-stability-note'
+const REL_PATH = path.join('notes', 'Byte Stability.md')
+
+/**
+ * Every fixture the issue names, plus the block shapes whose `parse` rules were
+ * the sharp edge in #1428: a wiki link is one element inside a list item, a
+ * quote and a table cell, and a text-matching parse claims the whole element.
+ *
+ * Deliberately absent: a wiki link inside a longer MARKED phrase
+ * (`~~Cancelled: [[Meeting]]~~`). That one does not round-trip — see the
+ * `#1439` case at the bottom of this file, which pins the current behaviour
+ * without asserting it is correct.
+ */
+const FIXTURES: ReadonlyArray<readonly [string, string]> = [
+  ['a wiki link in a sentence', 'See [[Wiki Link]] for details.'],
+  ['a wiki link alone in its block', '[[Wiki Link]]'],
+  ['an aliased wiki link', 'See [[Roadmap|the plan]] today.'],
+  ['a wiki link per list item', '- [[A]]\n- [[B]]'],
+  ['a wiki link in a quote', '> [[Quoted]]'],
+  // Table cells are the case the server spec's `render` has to get right —
+  // BlockNote serializes inline content inside a table through `render`, not
+  // `toExternalHTML`. The separator row is written pre-padded because remark
+  // normalizes `| --- |` to the column width on the way out; that is a
+  // pre-existing normalization of the markdown serializer, not this loop.
+  ['a wiki link in a table cell', '| [[A]] | b |\n| ----- | - |\n| c     | d |'],
+  ['a hash tag', 'Tagged #hashtag here.'],
+  ['a date mention token', '((date:eyJhbmNob3JJZCI6ImExIn0)) leftover token.'],
+  ['a callout', '> [!info]\n> Heads up'],
+  [
+    'the whole set in one note',
+    [
+      '# Weekly',
+      '',
+      'See [[Wiki Link]] and #hashtag on ((date:eyJhbmNob3JJZCI6ImExIn0)).',
+      '',
+      '- [[A]]',
+      '- [[B]]',
+      '',
+      '> [!info]',
+      '> Heads up'
+    ].join('\n')
+  ]
+]
+
+function fragmentOf(doc: Y.Doc): Y.XmlFragment {
+  return doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+}
+
+/** How many `wikiLink` elements the LIVE doc holds right now. */
+function countWikiLinkNodes(doc: Y.Doc): number {
+  let count = 0
+  const visit = (node: Y.XmlFragment | Y.XmlElement): void => {
+    for (const child of node.toArray()) {
+      const element = child as Y.XmlElement
+      if (typeof element.nodeName !== 'string') continue
+      if (element.nodeName === 'wikiLink') count++
+      visit(element)
+    }
+  }
+  visit(fragmentOf(doc))
+  return count
+}
+
+/**
+ * `handleChange`'s first act, applied to the shared doc.
+ *
+ * `use-editor-sync.ts` runs `normalizeWikiLinks(editor.document)` on every
+ * change and, when it changed anything, calls `editor.replaceBlocks` — which
+ * y-prosemirror turns into a write on the bound fragment. Returns whether the
+ * renderer would have replaced the document, which is the "did it promote"
+ * signal the convergence question is about.
+ */
+async function applyRendererPromotion(doc: Y.Doc): Promise<boolean> {
+  const fragment = fragmentOf(doc)
+  const blocks = await yFragmentToBlocks(fragment)
+  expect(blocks).not.toBeNull()
+
+  const normalized = normalizeWikiLinks(blocks as Block[])
+  if (!normalized.didChange) return false
+
+  doc.transact(() => {
+    fragment.delete(0, fragment.length)
+    blocksToYFragment(normalized.blocks, fragment)
+  })
+  return true
+}
+
+/** `crdt-provider.seedFromMarkdown`: parse the vault file, but only once. */
+async function openNote(absolutePath: string): Promise<Y.Doc> {
+  const doc = new Y.Doc()
+  const raw = fs.readFileSync(absolutePath, 'utf8')
+  const parsed = parseNote(raw, absolutePath)
+  const ok = await markdownToYFragment(parsed.content, fragmentOf(doc), REL_PATH)
+  expect(ok).toBe(true)
+  return doc
+}
+
+/** Arm the real debounced write-back and run it now. */
+async function runWriteback(doc: Y.Doc): Promise<void> {
+  scheduleWriteback(NOTE_ID, doc)
+  await flushPendingWritebacks()
+}
+
+function seedVaultNote(body: string): string {
+  const absolutePath = path.join(mocks.vaultRoot, REL_PATH)
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true })
+  fs.writeFileSync(absolutePath, body, 'utf8')
+  return absolutePath
+}
+
+beforeEach(() => {
+  mocks.vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-byte-stability-'))
+  mocks.sent.length = 0
+  mocks.atomicWrites.length = 0
+  mocks.noteRow = {
+    id: NOTE_ID,
+    path: REL_PATH,
+    title: 'Byte Stability',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    localOnly: false,
+    emoji: null,
+    fileType: 'md',
+    date: null
+  }
+  vi.stubEnv('NODE_ENV', 'test')
+})
+
+afterEach(() => {
+  cancelPendingWritebacks()
+  resetWritebackState()
+  vi.unstubAllEnvs()
+  fs.rmSync(mocks.vaultRoot, { recursive: true, force: true })
+})
+
+describe('opening a note with collaboration active does not rewrite it', () => {
+  it.each(FIXTURES)('%s', async (_name, body) => {
+    // #given a vault note as it exists on disk today
+    const absolutePath = seedVaultNote(body)
+
+    // #when it is opened on the collaborative path and write-back runs
+    const doc = await openNote(absolutePath)
+    await applyRendererPromotion(doc)
+    await runWriteback(doc)
+
+    // #then the file was not written at all, and its bytes are unchanged
+    expect(mocks.atomicWrites).toEqual([])
+    expect(fs.readFileSync(absolutePath, 'utf8')).toBe(body)
+    expect(getWritebackDebugState(NOTE_ID)?.lastMarkdown).toBe(body)
+  })
+})
+
+describe('repeated open -> write-back cycles converge', () => {
+  /**
+   * Five, not two. Two passes cannot tell "converged" apart from "grows by a
+   * constant", and a length that repeats once can still be the second term of a
+   * sequence that moves again on the third.
+   */
+  const PASSES = 5
+
+  it.each(FIXTURES)('%s is a fixed point from the first pass', async (_name, body) => {
+    // #given
+    const absolutePath = seedVaultNote(body)
+    const lengths: number[] = [body.length]
+
+    // #when the note is closed and reopened five times, each open re-seeding the
+    // shared doc from the file exactly as a fresh device would
+    for (let pass = 0; pass < PASSES; pass++) {
+      const doc = await openNote(absolutePath)
+      await applyRendererPromotion(doc)
+      await runWriteback(doc)
+      lengths.push(fs.readFileSync(absolutePath, 'utf8').length)
+    }
+
+    // #then every pass produced the same bytes, and none of them wrote
+    expect(lengths).toEqual(Array<number>(PASSES + 1).fill(body.length))
+    expect(fs.readFileSync(absolutePath, 'utf8')).toBe(body)
+    expect(mocks.atomicWrites).toEqual([])
+  })
+
+  it('a doc that stays open converges after one promotion', async () => {
+    // #given a note held open, with the renderer firing change after change —
+    // the tab is never closed, so the doc is seeded once
+    const body = 'See [[Wiki Link]] and #hashtag today.'
+    const absolutePath = seedVaultNote(body)
+    const doc = await openNote(absolutePath)
+
+    // #when
+    const promotions: boolean[] = []
+    for (let pass = 0; pass < PASSES; pass++) {
+      promotions.push(await applyRendererPromotion(doc))
+      await runWriteback(doc)
+    }
+
+    // #then only the first change promotes; the rest find a document that is
+    // already in canonical form, so the loop terminates instead of ping-ponging
+    expect(promotions).toEqual([true, false, false, false, false])
+    expect(fs.readFileSync(absolutePath, 'utf8')).toBe(body)
+    expect(mocks.atomicWrites).toEqual([])
+  })
+})
+
+describe('the canonical form of a wiki link inside the CRDT', () => {
+  it('main seeds the shared doc with TEXT, not a node', async () => {
+    // #given / #when main parses the vault file for the collaborative path
+    const absolutePath = seedVaultNote('See [[Wiki Link]] for details.')
+    const doc = await openNote(absolutePath)
+
+    // #then the doc holds no wikiLink node — main's spec has no `parse` rule,
+    // and giving it one would let a text-matching rule claim the whole `<li>` /
+    // `<blockquote>` / `<td>` around the link (#1428)
+    expect(countWikiLinkNodes(doc)).toBe(0)
+    const blocks = (await yFragmentToBlocks(fragmentOf(doc))) as Block[]
+    expect(JSON.stringify(blocks)).toContain('[[Wiki Link]]')
+  })
+
+  it('the renderer promotes it to a node, and that is what the doc keeps', async () => {
+    // #given
+    const absolutePath = seedVaultNote('See [[Wiki Link]] for details.')
+    const doc = await openNote(absolutePath)
+
+    // #when
+    expect(await applyRendererPromotion(doc)).toBe(true)
+
+    // #then the NODE is the doc's canonical form and the TEXT is the file's
+    expect(countWikiLinkNodes(doc)).toBe(1)
+    expect(await yDocToMarkdown(doc)).toBe('See [[Wiki Link]] for details.')
+  })
+
+  it('reopening a doc that already holds the node does not re-promote it', async () => {
+    // #given a note whose shared doc survived the close (the CRDT store keeps
+    // it, so `seedFromMarkdown` early-returns on a non-empty fragment)
+    const absolutePath = seedVaultNote('See [[Wiki Link]] for details.')
+    const doc = await openNote(absolutePath)
+    await applyRendererPromotion(doc)
+
+    // #when the note is reopened and the editor fires its first change
+    const reopened = new Y.Doc()
+    Y.applyUpdate(reopened, Y.encodeStateAsUpdate(doc))
+    expect(fragmentOf(reopened).length).toBeGreaterThan(0)
+
+    // #then there is nothing left to promote: a `wikiLink` node carries its
+    // target in props, so `[[` never reappears in the document JSON
+    expect(await applyRendererPromotion(reopened)).toBe(false)
+    await runWriteback(reopened)
+    expect(mocks.atomicWrites).toEqual([])
+  })
+})
+
+describe('write-back does not delete a wiki link from the shared doc', () => {
+  it('serializing leaves the live doc untouched', async () => {
+    // #given a doc in the state the renderer leaves it in
+    const absolutePath = seedVaultNote('See [[Wiki Link]] for details.')
+    const doc = await openNote(absolutePath)
+    await applyRendererPromotion(doc)
+    expect(countWikiLinkNodes(doc)).toBe(1)
+
+    // #when the whole write-back path runs, twice
+    const updates: Uint8Array[] = []
+    doc.on('update', (update: Uint8Array) => updates.push(update))
+    await runWriteback(doc)
+    expect(countWikiLinkNodes(doc)).toBe(1)
+    await runWriteback(doc)
+
+    // #then the node is still there and the doc emitted nothing at all. This is
+    // the #1428 regression in its exact shape: y-prosemirror answers a node name
+    // its schema cannot build by DELETING the element from the doc, and that
+    // delete replicates to every device.
+    expect(countWikiLinkNodes(doc)).toBe(1)
+    expect(updates).toEqual([])
+    expect(findUnrepresentableNodes(doc)).toEqual([])
+  })
+
+  it('reading the live fragment as blocks leaves the node in place', async () => {
+    // #given — `yFragmentToBlocks` is the one converter entry point that reads
+    // the LIVE fragment rather than a detached snapshot, so it is where a schema
+    // gap would do its damage
+    const absolutePath = seedVaultNote('- [[A]]\n- [[B]]')
+    const doc = await openNote(absolutePath)
+    await applyRendererPromotion(doc)
+    expect(countWikiLinkNodes(doc)).toBe(2)
+
+    // #when
+    const blocks = await yFragmentToBlocks(fragmentOf(doc))
+
+    // #then
+    expect(blocks).toHaveLength(2)
+    expect(countWikiLinkNodes(doc)).toBe(2)
+  })
+})
+
+describe('known non-convergence, pinned not endorsed', () => {
+  /**
+   * #1439. A wiki link inside a longer struck-through phrase does not survive
+   * the first open: the promotion splits the marked run, and the mark's closing
+   * delimiter lands before the link instead of after it. It is blocked on a
+   * product decision (which of the two forms is right), so this asserts what
+   * happens today rather than what should — and it is deliberately kept out of
+   * the fixtures above, whose job is to gate the cases that DO converge.
+   */
+  it('a wiki link inside a marked phrase is rewritten once, then holds', async () => {
+    // #given
+    let current = '~~Cancelled: [[Meeting]]~~'
+    const lengths: number[] = [current.length]
+
+    // #when
+    const absolutePath = seedVaultNote(current)
+    for (let pass = 0; pass < 5; pass++) {
+      const doc = await openNote(absolutePath)
+      await applyRendererPromotion(doc)
+      await runWriteback(doc)
+      current = fs.readFileSync(absolutePath, 'utf8')
+      lengths.push(current.length)
+    }
+
+    // #then the first open rewrites the file, and every open after it is a
+    // no-op — the damage is a single rewrite, not unbounded growth
+    expect(current).toBe('~~Cancelled: ~~[[Meeting]]')
+    expect(lengths).toEqual([26, 26, 26, 26, 26, 26])
+    expect(mocks.atomicWrites).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-collab-promotion.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-collab-promotion.test.ts
@@ -1,0 +1,207 @@
+/**
+ * The renderer half of "opening a note must not rewrite it" (#1434).
+ *
+ * Main parses the vault file into the shared Y.Doc with a `wikiLink` spec that
+ * has no `parse` rule, so `[[X]]` reaches the doc as plain TEXT. This side then
+ * promotes it: `use-editor-sync.ts`'s `handleChange` runs `normalizeWikiLinks`
+ * on every change — it is NOT gated on collaboration — and replaces the
+ * document when anything changed. That write lands in the shared Y.Doc through
+ * y-prosemirror, and main serializes it back to `[[X]]` text. The loop only
+ * exists because this step exists, so this file drives it with nothing faked
+ * between the editor and the CRDT:
+ *
+ * - a REAL `BlockNoteEditor` built from the REAL `editorSchema`, mounted,
+ * - REAL Yjs collaboration against a REAL `Y.Doc` fragment,
+ * - the REAL `useEditorSync` hook, whose real `handleChange` does the promoting.
+ *
+ * What is stood in for: main's `markdownToYFragment` — the fragment is seeded
+ * with the block shape that parser produces for `[[X]]` (one plain text run),
+ * because importing `src/main` here would drag `node:crypto`, `electron-log`
+ * and both databases into the renderer's jsdom project. That main really leaves
+ * `[[X]]` as plain text, and that its write-back turns the promoted node back
+ * into the identical bytes, is asserted on the other side in
+ * `src/main/sync/note-open-byte-stability.test.ts`.
+ */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BlockNoteEditor, type Block } from '@blocknote/core'
+import * as Y from 'yjs'
+import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
+
+// The file block's PDF preview pulls pdf.js, which touches `DOMMatrix` at
+// import time and jsdom has none. Everything else in the schema is real.
+vi.mock('react-pdf', () => ({
+  Document: () => null,
+  Page: () => null,
+  pdfjs: { GlobalWorkerOptions: { workerSrc: '' } }
+}))
+
+// `hydrateLinkMentionFavicons` fires on the load path; no fixture here has a
+// link mention, but the module is imported either way.
+vi.mock('@/lib/url-metadata', () => ({
+  fetchLinkPreview: vi.fn().mockResolvedValue({ domain: '', title: '', favicon: '' })
+}))
+
+import { editorSchema } from './editor-schema'
+import { useEditorSync } from './hooks/use-editor-sync'
+
+const mounted: Array<{ editor: BlockNoteEditor; el: HTMLElement; doc: Y.Doc }> = []
+
+afterEach(() => {
+  for (const { editor, el, doc } of mounted.splice(0)) {
+    // `mount()` with no element is BlockNote's unmount; its type only admits an
+    // element, so the call has to say so.
+    ;(editor as unknown as { mount: (element?: HTMLElement) => void }).mount()
+    el.remove()
+    doc.destroy()
+  }
+})
+
+interface CollabEditor {
+  editor: BlockNoteEditor
+  doc: Y.Doc
+  fragment: Y.XmlFragment
+}
+
+function createCollaborativeEditor(): CollabEditor {
+  const doc = new Y.Doc()
+  const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+
+  // Exactly how ContentArea builds it when `isCollaborationActive(...)` is true.
+  const editor = BlockNoteEditor.create({
+    schema: editorSchema,
+    collaboration: { fragment, user: { name: 'Local User', color: '#3b82f6' } }
+  } as never) as unknown as BlockNoteEditor
+
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  editor.mount(el)
+  mounted.push({ editor, el, doc })
+
+  return { editor, doc, fragment }
+}
+
+/** Seed the shared doc the way main's parser leaves it: `[[X]]` as plain text. */
+function seedWithPlainText(editor: BlockNoteEditor, text: string): void {
+  editor.replaceBlocks(editor.document, [
+    {
+      type: 'paragraph',
+      content: [{ type: 'text', text, styles: {} }]
+    } as never
+  ])
+}
+
+function nodeNames(fragment: Y.XmlFragment): string[] {
+  const names: string[] = []
+  const visit = (node: Y.XmlFragment | Y.XmlElement): void => {
+    for (const child of node.toArray()) {
+      const element = child as Y.XmlElement
+      if (typeof element.nodeName !== 'string') continue
+      names.push(element.nodeName)
+      visit(element)
+    }
+  }
+  visit(fragment)
+  return names
+}
+
+/** Renders the real hook and hands back its real `handleChange`. */
+function mountEditorSync(editor: BlockNoteEditor, fragment: Y.XmlFragment): () => void {
+  const { result } = renderHook(() =>
+    useEditorSync({
+      editor,
+      noteId: 'collab-promotion-note',
+      yjsFragment: fragment
+    })
+  )
+  return result.current.handleChange
+}
+
+describe('the renderer promotes [[X]] inside a collaborative document', () => {
+  it('writes a wikiLink node into the shared Y.Doc', () => {
+    // #given a shared doc holding what main's parser produces for `[[X]]`
+    const { editor, fragment } = createCollaborativeEditor()
+    seedWithPlainText(editor, 'See [[Wiki Link]] for details.')
+    expect(nodeNames(fragment)).not.toContain('wikiLink')
+
+    // #when the editor fires its first change
+    const handleChange = mountEditorSync(editor, fragment)
+    act(() => handleChange())
+
+    // #then the promotion reached the CRDT, not just the local editor state
+    expect(nodeNames(fragment)).toContain('wikiLink')
+    const paragraph = editor.document[0] as Block
+    const content = paragraph.content as Array<{ type: string; props?: { target?: string } }>
+    expect(content.map((run) => run.type)).toEqual(['text', 'wikiLink', 'text'])
+    expect(content[1].props?.target).toBe('Wiki Link')
+  })
+
+  it('promotes once and then stops — the loop terminates', () => {
+    // #given
+    const { editor, doc, fragment } = createCollaborativeEditor()
+    seedWithPlainText(editor, 'See [[Wiki Link]] for details.')
+    const handleChange = mountEditorSync(editor, fragment)
+    act(() => handleChange())
+
+    // #when every later change event runs the same normalizer
+    const updates: Uint8Array[] = []
+    doc.on('update', (update: Uint8Array) => updates.push(update))
+    act(() => handleChange())
+    act(() => handleChange())
+    act(() => handleChange())
+
+    // #then nothing more is written: a `wikiLink` node carries its target in
+    // props, so `[[` never reappears in the document and `normalizeWikiLinks`
+    // stops matching. This is what makes the round trip a fixed point rather
+    // than a rewrite on every open.
+    expect(updates).toEqual([])
+    expect(nodeNames(fragment).filter((name) => name === 'wikiLink')).toHaveLength(1)
+  })
+
+  it('keeps the block around the link — a list item stays a list item', () => {
+    // #given the shape a text-matching `parse` rule destroys: the whole element
+    // reads `[[A]]`, so a rule that promotes "any element whose text is a wiki
+    // link" swallows the `<li>` with it (#1428)
+    const { editor, fragment } = createCollaborativeEditor()
+    editor.replaceBlocks(editor.document, [
+      { type: 'bulletListItem', content: [{ type: 'text', text: '[[A]]', styles: {} }] } as never,
+      { type: 'bulletListItem', content: [{ type: 'text', text: '[[B]]', styles: {} }] } as never
+    ])
+
+    // #when
+    const handleChange = mountEditorSync(editor, fragment)
+    act(() => handleChange())
+
+    // #then — the trailing empty paragraph is BlockNote's own, not ours
+    const authored = editor.document.filter(
+      (block) => (block.content as unknown[] | undefined)?.length
+    )
+    expect(authored.map((block) => block.type)).toEqual(['bulletListItem', 'bulletListItem'])
+    expect(
+      authored.map(
+        (block) => (block.content as Array<{ props?: { target?: string } }>)[0].props?.target
+      )
+    ).toEqual(['A', 'B'])
+    expect(nodeNames(fragment).filter((name) => name === 'wikiLink')).toHaveLength(2)
+  })
+
+  it('leaves a hash tag and a date mention token as plain text', () => {
+    // #given — neither has a promoter on the collaborative path
+    // (`normalizeHashTags` runs only in the non-collaborative load branch, and
+    // the hash-tag plugin is keystroke-driven), so both must survive untouched
+    const { editor, doc, fragment } = createCollaborativeEditor()
+    seedWithPlainText(editor, 'Tagged #hashtag on ((date:eyJhbmNob3JJZCI6ImExIn0)).')
+    const handleChange = mountEditorSync(editor, fragment)
+
+    // #when
+    const updates: Uint8Array[] = []
+    doc.on('update', (update: Uint8Array) => updates.push(update))
+    act(() => handleChange())
+
+    // #then
+    expect(updates).toEqual([])
+    expect(nodeNames(fragment)).not.toContain('hashTag')
+    expect(nodeNames(fragment)).not.toContain('dateMention')
+  })
+})

--- a/apps/desktop/tests/e2e/note-open-byte-stability.e2e.ts
+++ b/apps/desktop/tests/e2e/note-open-byte-stability.e2e.ts
@@ -100,6 +100,11 @@ async function openInEditor(page, title: string): Promise<void> {
   await page.locator(SELECTORS.noteEditor).first().waitFor({ state: 'visible', timeout: 15_000 })
 }
 
+/** How many times write-back has run for this note so far. */
+async function getWritebackRuns(electronApp, noteId: string): Promise<number> {
+  return (await getWritebackDebugById(electronApp, noteId))?.performedCount ?? 0
+}
+
 /** Wait until write-back has actually run for this note at least `count` times. */
 async function waitForWritebackRuns(electronApp, noteId: string, count: number): Promise<void> {
   await expect
@@ -181,6 +186,11 @@ test.describe('Note open byte stability', () => {
       .poll(() => stripFrontmatter(fs.readFileSync(absPath, 'utf8')), { timeout: 20_000 })
       .toBe(stripFrontmatter(first.bytes))
     const afterFirstOpen = fs.readFileSync(absPath, 'utf8')
+    // `performedCount` lives in the MAIN process and is only cleared by
+    // `CrdtProvider.destroy()`, which a renderer reload does not trigger — so
+    // waiting for `>= 1` again would return immediately and this test would
+    // measure the first cycle twice. Capture the count and wait past it.
+    const runsAfterFirstOpen = await getWritebackRuns(electronAppA, first.id)
 
     // #when the app is reloaded and the note opened again — a cold open, with
     // the shared doc rebuilt from the CRDT store
@@ -188,7 +198,7 @@ test.describe('Note open byte stability', () => {
     await pageA.waitForLoadState('domcontentloaded')
     await waitForSyncOnline(pageA, 60_000)
     await openInEditor(pageA, title)
-    await waitForWritebackRuns(electronAppA, first.id, 1)
+    await waitForWritebackRuns(electronAppA, first.id, runsAfterFirstOpen + 1)
 
     // #then the second cycle is a fixed point — whole file this time, since the
     // first open already settled the frontmatter

--- a/apps/desktop/tests/e2e/note-open-byte-stability.e2e.ts
+++ b/apps/desktop/tests/e2e/note-open-byte-stability.e2e.ts
@@ -1,0 +1,231 @@
+// @ts-nocheck - E2E test; window.api typing lives in the renderer bundle
+/**
+ * Opening a note must not rewrite it — the real app (#1434, phase 3 of #1427).
+ *
+ * The unit suites cover the two halves of the loop separately
+ * (`src/main/sync/note-open-byte-stability.test.ts` and
+ * `src/renderer/.../wiki-link-collab-promotion.test.ts`). Neither can run the
+ * whole thing: the renderer's promotion only happens inside a real editor, and
+ * the editor only binds to the shared Y.Doc when collaboration is live — which
+ * `ContentArea` gates on `isCollaborationActive(syncStatus)`, i.e. on an
+ * AUTHENTICATED sync session. That is why this file uses the sync-auth fixture
+ * rather than the single-app one: without a bootstrapped device the editor
+ * takes the non-collaborative path and the loop under test never runs.
+ *
+ * The note is seeded as BYTES on disk, not through the app, because the whole
+ * claim is about bytes the user (or Obsidian) wrote.
+ *
+ * ## One thing this suite found, and does not fix
+ *
+ * Opening a note whose body contains a plain `#hashtag` INJECTS a `tags:` block
+ * into its frontmatter — `extractInlineTags` reads hash tags out of plain text,
+ * not just out of `hashTag` nodes, the tag reaches the CRDT tag array, and
+ * write-back's `mergeFrontmatter` writes it to the file. That is a real
+ * "opening a note modified it", but it is the inline-tag pipeline rather than
+ * the wiki-link round trip this issue is about, and whether inline tags should
+ * promote themselves into frontmatter at all is a product decision. It is
+ * pinned by its own test at the bottom of this file instead of being papered
+ * over, and the body-stability tests strip frontmatter so they measure the loop
+ * they are named for.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { test, expect } from './fixtures/sync-auth-fixtures'
+import {
+  getNoteHandleByTitle,
+  getWritebackDebugById,
+  openNoteByTitle
+} from './utils/note-sync-helpers'
+import { waitForSyncOnline } from './utils/network-control'
+import { SELECTORS } from './utils/electron-helpers'
+
+/** Everything the issue names, in one note. */
+const BODY = [
+  '# Weekly',
+  '',
+  'See [[Wiki Link]] and #hashtag on ((date:eyJhbmNob3JJZCI6ImExIn0)).',
+  '',
+  '- [[A]]',
+  '- [[B]]',
+  '',
+  '> [!info]',
+  '> Heads up'
+].join('\n')
+
+/** The same note with no inline hash tag, so nothing touches its frontmatter. */
+const BODY_WITHOUT_HASH_TAG = BODY.replace(' and #hashtag', '')
+
+function seedVaultFile(vaultPath: string, title: string, body: string): string {
+  const absPath = path.join(vaultPath, 'notes', `${title}.md`)
+  fs.mkdirSync(path.dirname(absPath), { recursive: true })
+  fs.writeFileSync(absPath, body, 'utf8')
+  return absPath
+}
+
+/** Drop the YAML frontmatter block, leaving the body this loop actually owns. */
+function stripFrontmatter(markdown: string): string {
+  const match = markdown.match(/^---\n[\s\S]*?\n---\n?/)
+  return match ? markdown.slice(match[0].length) : markdown
+}
+
+/**
+ * The bytes the file settles on once the indexer has claimed it.
+ *
+ * Indexing a file that has never been seen can rewrite it before any editor
+ * exists, which is not what this test is about. The baseline is taken after the
+ * note is in the index and the file has stopped moving, so what is measured is
+ * exactly "did OPENING it change anything".
+ */
+async function indexedBaseline(page, title: string, absPath: string) {
+  const note = await getNoteHandleByTitle(page, title)
+  let bytes = fs.readFileSync(absPath, 'utf8')
+  // Two consecutive identical reads a second apart: the file has stopped moving.
+  await expect
+    .poll(
+      () => {
+        const next = fs.readFileSync(absPath, 'utf8')
+        const settled = next === bytes
+        bytes = next
+        return settled
+      },
+      { timeout: 20_000, intervals: [1000] }
+    )
+    .toBe(true)
+  return { id: note.id, bytes }
+}
+
+async function openInEditor(page, title: string): Promise<void> {
+  await openNoteByTitle(page, title)
+  await page.locator(SELECTORS.noteEditor).first().waitFor({ state: 'visible', timeout: 15_000 })
+}
+
+/** Wait until write-back has actually run for this note at least `count` times. */
+async function waitForWritebackRuns(electronApp, noteId: string, count: number): Promise<void> {
+  await expect
+    .poll(async () => (await getWritebackDebugById(electronApp, noteId))?.performedCount ?? 0, {
+      timeout: 30_000
+    })
+    .toBeGreaterThanOrEqual(count)
+}
+
+test.describe('Note open byte stability', () => {
+  test('opening a seeded note with collaboration active leaves its body untouched', async ({
+    pageA,
+    electronAppA,
+    vaultPathA,
+    bootstrappedSyncPair
+  }) => {
+    void bootstrappedSyncPair
+    await waitForSyncOnline(pageA)
+
+    // #given a vault note written straight to disk
+    const title = `Byte Stability ${Date.now()}`
+    const absPath = seedVaultFile(vaultPathA, title, BODY)
+    const baseline = await indexedBaseline(pageA, title, absPath)
+    expect(baseline.bytes).toContain('[[Wiki Link]]')
+
+    // #when it is opened in the real editor, on the collaborative path…
+    await openInEditor(pageA, title)
+    // …and write-back has genuinely run (otherwise this test passes vacuously)
+    await waitForWritebackRuns(electronAppA, baseline.id, 1)
+
+    // #then the body is byte-identical: the wiki links the renderer promoted to
+    // nodes came back as the same `[[…]]` text, in the same blocks, and the
+    // callout and date-mention token were never parsed at all
+    expect(stripFrontmatter(fs.readFileSync(absPath, 'utf8'))).toBe(
+      stripFrontmatter(baseline.bytes)
+    )
+    expect((await getWritebackDebugById(electronAppA, baseline.id))?.lastError).toBeNull()
+  })
+
+  test('a note with no inline tag is byte-identical, frontmatter included', async ({
+    pageA,
+    electronAppA,
+    vaultPathA,
+    bootstrappedSyncPair
+  }) => {
+    void bootstrappedSyncPair
+    await waitForSyncOnline(pageA)
+
+    // #given
+    const title = `Byte Stability Whole File ${Date.now()}`
+    const absPath = seedVaultFile(vaultPathA, title, BODY_WITHOUT_HASH_TAG)
+    const baseline = await indexedBaseline(pageA, title, absPath)
+
+    // #when
+    await openInEditor(pageA, title)
+    await waitForWritebackRuns(electronAppA, baseline.id, 1)
+
+    // #then nothing about the file changed at all
+    expect(fs.readFileSync(absPath, 'utf8')).toBe(baseline.bytes)
+  })
+
+  test('a second open -> write-back cycle produces the same bytes', async ({
+    pageA,
+    electronAppA,
+    vaultPathA,
+    bootstrappedSyncPair
+  }) => {
+    void bootstrappedSyncPair
+    await waitForSyncOnline(pageA)
+
+    // #given a note that has already been opened once, so whatever the first
+    // open was going to do to it has happened
+    const title = `Byte Stability Twice ${Date.now()}`
+    const absPath = seedVaultFile(vaultPathA, title, BODY)
+    const first = await indexedBaseline(pageA, title, absPath)
+    await openInEditor(pageA, title)
+    await waitForWritebackRuns(electronAppA, first.id, 1)
+    await expect
+      .poll(() => stripFrontmatter(fs.readFileSync(absPath, 'utf8')), { timeout: 20_000 })
+      .toBe(stripFrontmatter(first.bytes))
+    const afterFirstOpen = fs.readFileSync(absPath, 'utf8')
+
+    // #when the app is reloaded and the note opened again — a cold open, with
+    // the shared doc rebuilt from the CRDT store
+    await pageA.reload()
+    await pageA.waitForLoadState('domcontentloaded')
+    await waitForSyncOnline(pageA, 60_000)
+    await openInEditor(pageA, title)
+    await waitForWritebackRuns(electronAppA, first.id, 1)
+
+    // #then the second cycle is a fixed point — whole file this time, since the
+    // first open already settled the frontmatter
+    await expect
+      .poll(() => fs.readFileSync(absPath, 'utf8'), { timeout: 20_000 })
+      .toBe(afterFirstOpen)
+  })
+
+  test('REGRESSION PIN: an inline #hashtag adds a tags: block on first open', async ({
+    pageA,
+    electronAppA,
+    vaultPathA,
+    bootstrappedSyncPair
+  }) => {
+    void bootstrappedSyncPair
+    await waitForSyncOnline(pageA)
+
+    // #given a note with no frontmatter and one inline hash tag in its body
+    const title = `Inline Tag Frontmatter ${Date.now()}`
+    const absPath = seedVaultFile(vaultPathA, title, 'Tagged #hashtag here.')
+    const baseline = await indexedBaseline(pageA, title, absPath)
+    expect(baseline.bytes).not.toContain('tags:')
+
+    // #when it is opened
+    await openInEditor(pageA, title)
+    await waitForWritebackRuns(electronAppA, baseline.id, 1)
+
+    // #then opening it modified the file. This is NOT the wiki-link loop — the
+    // body below the frontmatter is untouched — it is `extractInlineTags`
+    // reading hash tags out of plain text and write-back's `mergeFrontmatter`
+    // persisting them. Asserted as current behaviour, not as correct behaviour;
+    // deciding whether inline tags belong in frontmatter is its own change.
+    await expect
+      .poll(() => fs.readFileSync(absPath, 'utf8'), { timeout: 20_000 })
+      .toContain('tags:')
+    const rewritten = fs.readFileSync(absPath, 'utf8')
+    expect(rewritten).toContain('- hashtag')
+    expect(stripFrontmatter(rewritten)).toBe('Tagged #hashtag here.')
+  })
+})

--- a/packages/editor-schema/README.md
+++ b/packages/editor-schema/README.md
@@ -24,6 +24,43 @@ return `null` so the note stops writing back at all.
 Presentation stays with each process (main has no React). Everything that
 decides what reaches disk is shared.
 
+## The canonical form of a wiki link
+
+**In the CRDT it is a `wikiLink` NODE. On disk it is `[[target]]` TEXT.**
+
+The two ends reach that agreement from opposite directions, which is why it has
+to be stated rather than inferred:
+
+- **Main never parses `[[X]]`.** `WikiLinkSerializationOnly` carries no `parse`
+  rule, so the parser that seeds a note's shared Y.Doc from its vault file
+  (`crdt-provider.seedFromMarkdown` → `markdownToYFragment`) leaves the brackets
+  as plain text. It cannot do otherwise: the editor's `parse` rule promotes any
+  element whose whole text reads `[[X]]`, and in a markdown importer that
+  swallows the `<li>`, `<blockquote>` or `<td>` around the link.
+- **The renderer always promotes.** `normalizeWikiLinks`, called from
+  `use-editor-sync.ts`'s `handleChange`, is not gated on collaboration, so the
+  first change event after a note opens replaces the text with the node — and
+  that write lands in the shared doc through y-prosemirror.
+- **Write-back turns the node back into the same bytes** (`wikiLinkToText`).
+
+So a note's first open converts text → node exactly once, and the round trip is
+a fixed point from then on: a `wikiLink` node carries its target in props, so
+`[[` never reappears in the document and the normalizer stops matching. Opening
+a note does not modify it, which is both the user-visible contract and what
+protects Obsidian fidelity.
+
+Do not "fix" the asymmetry by giving main a `parse` rule or by dropping the
+renderer's promotion. Each end is the way it is for its own reason, and the
+convergence is gated by test —
+`apps/desktop/src/main/sync/note-open-byte-stability.test.ts` (five open →
+write-back cycles per fixture, byte-identical, no write) and
+`apps/desktop/src/renderer/src/components/note/content-area/wiki-link-collab-promotion.test.ts`
+(a real editor on a real Y.Doc promotes once and then stops).
+
+One shape does **not** converge and is tracked separately: a wiki link inside a
+longer marked phrase (`~~Cancelled: [[Meeting]]~~`) is rewritten once, to
+`~~Cancelled: ~~[[Meeting]]`. See #1439.
+
 ## The gate
 
 `src/schema-contract.test.ts` (`pnpm --filter @memry/editor-schema test`) checks

--- a/packages/editor-schema/README.md
+++ b/packages/editor-schema/README.md
@@ -57,9 +57,31 @@ write-back cycles per fixture, byte-identical, no write) and
 `apps/desktop/src/renderer/src/components/note/content-area/wiki-link-collab-promotion.test.ts`
 (a real editor on a real Y.Doc promotes once and then stops).
 
-One shape does **not** converge and is tracked separately: a wiki link inside a
-longer marked phrase (`~~Cancelled: [[Meeting]]~~`) is rewritten once, to
-`~~Cancelled: ~~[[Meeting]]`. See #1439.
+### Where it does not hold: a wiki link that carries an inline mark
+
+The fixed point above is true of an _unmarked_ link. A link carrying bold,
+italic or strikethrough does not round-trip, because BlockNote's
+`CustomInlineContentFromConfig` has no `styles` field — the promotion has
+nowhere to put the mark, so it drops it. Measured on this branch, with the
+promotion step removed as a control:
+
+| on disk                      | after one open               | control (no promotion) |
+| ---------------------------- | ---------------------------- | ---------------------- |
+| `**[[Meeting]]**`            | `[[Meeting]]`                | unchanged              |
+| `~~[[Meeting]]~~`            | `[[Meeting]]`                | unchanged              |
+| `*[[A]]*`                    | `[[A]]`                      | unchanged              |
+| `~~Cancelled: [[Meeting]]~~` | `~~Cancelled: ~~[[Meeting]]` | unchanged              |
+
+The first three **delete the mark from the vault file**. The fourth is worse
+than it looks: GFM requires a closing `~~` not be preceded by whitespace, so
+`~~Cancelled: ~~` is strikethrough nowhere — the note ends up showing four
+literal tildes. Bold survives the same shape only because the serializer emits
+`&#x20;` entities around it; strike gets no such escape.
+
+Each is a single rewrite, not unbounded growth, and each is stable afterwards.
+Tracked as #1439. Until it is fixed, **"opening a note does not modify it" holds
+for unmarked links only** — do not read the contract above more widely than
+that.
 
 ## The gate
 


### PR DESCRIPTION
Phase 3 of #1427. Tests and README only — **no production source changed** (`git diff origin/main...HEAD -- ':!*test*' ':!*README*'` is empty).

Refs #1434.

## Does the loop converge? Yes — for unmarked links.

The renderer promotes `[[X]]` text to a `wikiLink` node on every change; main serializes it back to `[[X]]`. Until Phase 1 that only "stabilised" because main deleted the node. Six open → write-back cycles per fixture, each re-seeding the Y.Doc from the file the way a cold device would:

| fixture | lengths |
|---|---|
| `See [[Wiki Link]] for details.` | 30 ×7 |
| `See [[Roadmap\|the plan]] today.` | 31 ×7 |
| `- [[A]]\n- [[B]]` · `> [[Quoted]]` | flat |
| `#hashtag` · date-mention token · `> [!info]` callout | flat |
| all of the above in one note | 99 ×7 |

Promotion fires **exactly once** (`[true, false, false, false, false]`) — a `wikiLink` node carries its target in props, so `[[` never reappears and the normalizer stops matching. Canonical form is now written down in the package README: **node in the CRDT, `[[target]]` text on disk.**

## Where it does not hold — and this is the finding

Review's fixture set found what mine missed: the contract fails for **any wiki link carrying an inline mark**. Measured with the promotion step removed as a control, so the cause is not in doubt:

| on disk | after one open | control (no promotion) |
|---|---|---|
| `**[[Meeting]]**` | `[[Meeting]]` | unchanged |
| `~~[[Meeting]]~~` | `[[Meeting]]` | unchanged |
| `*[[A]]*` | `[[A]]` | unchanged |
| `~~Cancelled: [[Meeting]]~~` | `~~Cancelled: ~~[[Meeting]]` | unchanged |

The first three **delete the mark from the vault file**. The fourth is worse than its byte count suggests — GFM wants no whitespace before a closing `~~`, so `~~Cancelled: ~~` is strikethrough nowhere and the note ends up showing four literal tildes. Bold survives that shape only because the serializer emits `&#x20;` entities; strike gets no such escape.

Cause: `CustomInlineContentFromConfig` has no `styles` field, so the promotion has nowhere to put the mark. This is #1439 — and it reframes it: not "the editor forgets the bold" but **opening a note deletes formatting from the file**, on `main`, today. All are one rewrite then stable. Pinned as a class, not endorsed.

Also pinned: a note carrying CriticMarkup review marks is rewritten 45 → 93 bytes on first open. It went in because dropping `serializeCriticMarkup` from write-back **deletes every review comment from the note** and no test noticed.

## Corrections review forced

- The README claimed one non-converging shape. It is a class; the table above is now in the README, with the contract explicitly narrowed to unmarked links.
- The E2E's second-cycle test measured the first cycle twice: `performedCount` lives in the main process and survives a renderer reload, so waiting for `>= 1` again returned immediately. It now captures the count and waits past it.
- The brief I wrote asserted `check:architecture` forbids main importing renderer. It does not — the script only scans renderer source for `@main/*` and filters `*.test.ts` in both directions. The main-side test importing `wiki-link-utils.ts` is legitimate; the header records why that direction was chosen (it typechecks under `tsconfig.test.node.json`; the reverse would drag `node:crypto`, `electron-log` and both DBs into the web test program).

## What the tests actually drive

Main suite: real `markdownToYFragment`, real `normalizeWikiLinks` imported from renderer source, real `performWriteback` including its byte-compare, real `vault/file-ops` against a real temp vault, with `atomicWrite` wrapped so the assertion is **no write happened**, not merely "bytes match". Faked: the BlockNote editor instance and the y-prosemirror binding, plus DBs/telemetry/electron.

A renderer-project test closes that seam — a real mounted `BlockNoteEditor` on the real `editorSchema`, real Yjs collaboration, the real `useEditorSync`.

E2E uses the sync-auth fixture because `ContentArea` gates collaboration on an authenticated session; on the single-app fixture the loop under test never runs.

## Mutation proof

- Drift `wikiLinkToText` to emit `[[X]].` → **18 of 31 fail**, per-pass lengths `30 → 31 → 32 → 33 → 34 → 35`. The growth signature is why six passes, not two.
- Register main's `wikiLink` under a different node name (the #1428 shape) → **18 fail**, y-prosemirror deletes the elements from the live doc.

## Verification

- `test:main` — 513 files / 6473 tests
- `test:renderer` — 611 files / 7009 tests
- `@memry/editor-schema` — 41
- `typecheck` (node/web/test), `check:architecture`, `check:contracts`
- E2E — 4 passed (needs `pnpm --filter @memry/desktop build` first; `pretest:e2e` does not build). Note E2E flips native ABI to Electron — `rebuild:node` before re-running unit suites.
- `docs:impact --strict` — no docs-relevant changes

## Known limits, stated not papered over

`findUnrepresentableNodes` fails **open** for a mis-keyed inline spec: the ProseMirror node name comes from `spec.config.type`, not the `inlineContentSpecs` map key, so a spec registered under the wrong key still resolves and the guard returns `[]`. Worth its own fix. An aliased wiki link in a table cell is also rewritten twice (pre-existing, not promotion-caused) — the table fixture here does not expose it.
