### PR TITLE
fix(crdt): rebind open editors after a provider reset

### DIFF
--- a/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
+++ b/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
@@ -18,7 +18,10 @@ vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/crdt-test-userdata' },
   BrowserWindow: {
     fromWebContents: () => senderWindow.current,
-    fromId: () => null
+    fromId: () => null,
+    // resetCrdtProvider fans the rebind event out to every window, so the
+    // teardown cases below reach broadcastToAllWindows.
+    getAllWindows: () => []
   },
   ipcMain: mockIpcMain
 }))

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -1034,6 +1034,40 @@ describe('CrdtProvider', () => {
     ).resolves.toBe(0)
   })
 
+  it('tells every window to rebind its editors when the provider is reset', async () => {
+    // #given two windows and a note an editor holds open in the live singleton
+    createWindow(1)
+    createWindow(2)
+    const singleton = getCrdtProvider()
+    await singleton.init(queue as any, pushSnapshot)
+    await singleton.open('note-open', 1, { skipSeed: true })
+    expect(singleton.strandedEditorDocCount).toBe(1)
+    mocks.sent = []
+
+    // #when the provider is dropped, as sign-out does
+    resetCrdtProvider()
+
+    // #then every window has to hear it, not just the one holding the note: each
+    // renderer provider is bound to a doc this instance owned, and without the
+    // event it keeps that dead binding, so main applies remote updates to the
+    // fresh instance and broadcasts them to a window set the editor is not in.
+    const rebinds = mocks.sent.filter((sent) => sent.channel === CRDT_EVENTS.PROVIDER_RESET)
+    expect(rebinds.map((sent) => sent.windowId).sort()).toEqual([1, 2])
+  })
+
+  it('still reports the editors it stranded after destroy has emptied the doc map', async () => {
+    // #given sign-out wipes storage (which destroys) before it resets the singleton
+    createWindow(1)
+    const singleton = getCrdtProvider()
+    await singleton.init(queue as any, pushSnapshot)
+    await singleton.open('note-open', 1, { skipSeed: true })
+    await singleton.destroy()
+
+    // #then the count must survive that, or the one number saying how many editors
+    // a reset broke is always zero by the time it is read
+    expect(singleton.strandedEditorDocCount).toBe(1)
+  })
+
   it('covers provider singleton, idempotent init, and wipe storage lifecycle', async () => {
     const singleton = getCrdtProvider()
     expect(getCrdtProvider()).toBe(singleton)

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -4,6 +4,7 @@ import { rmSync } from 'fs'
 import { app, BrowserWindow } from 'electron'
 import { CRDT_EVENTS, CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 import { createLogger } from '../lib/logger'
+import { broadcastToAllWindows } from '../lib/window-broadcast'
 import { getIndexDatabase } from '../database/client'
 import { getNoteCacheById } from '@main/database/queries/notes'
 import type { CrdtUpdateQueue } from './crdt-queue'
@@ -385,7 +386,32 @@ export class CrdtProvider {
     return Y.encodeStateAsUpdate(entry.doc, remoteStateVector)
   }
 
+  /**
+   * Open docs an editor window is currently attached to — measured live, or as
+   * of `destroy()` once the map has been emptied.
+   *
+   * Every one of these is an editor whose renderer-side provider is bound to a
+   * doc this instance owns. When the instance is dropped, that binding is dead
+   * and the editor cannot know: main goes on applying remote updates, to the
+   * new instance's docs, and broadcasts them to a window set the editor is no
+   * longer in. So this is the number a provider reset has to bring back — see
+   * `resetCrdtProvider`.
+   */
+  get strandedEditorDocCount(): number {
+    if (this.docs.size === 0) return this.attachedDocsAtDestroy
+    let count = 0
+    for (const entry of this.docs.values()) {
+      if (entry.windowIds.size > 0) count++
+    }
+    return count
+  }
+
+  private attachedDocsAtDestroy = 0
+
   async destroy(): Promise<void> {
+    // Read before the map is cleared below: after that the count is gone, and
+    // the reset that follows destroy() is where it has to be reported.
+    this.attachedDocsAtDestroy = this.strandedEditorDocCount
     await flushPendingWritebacks()
     this.networkBatcher.flushAll()
 
@@ -995,5 +1021,17 @@ export function getCrdtProvider(): CrdtProvider {
 }
 
 export function resetCrdtProvider(): void {
+  const previous = instance
   instance = null
+  if (!previous) return
+
+  // Renderer providers hold a note open against the instance just dropped, and
+  // nothing else tells them it is gone: the next remote update is applied to a
+  // doc in the fresh instance and broadcast to a window set that no longer
+  // contains the editor, so the note silently goes stale until it is closed and
+  // reopened. Ask every window to re-open its notes and redo the handshake.
+  broadcastToAllWindows(CRDT_EVENTS.PROVIDER_RESET)
+  log.info('CRDT provider reset, asked windows to rebind their editors', {
+    strandedEditorDocs: previous.strandedEditorDocCount
+  })
 }

--- a/apps/desktop/src/preload/api/sync-ops.ts
+++ b/apps/desktop/src/preload/api/sync-ops.ts
@@ -94,6 +94,14 @@ const dispatchCrdtStateChanged = (data: CrdtStateChangedPayload): void => {
   }
 }
 
+/**
+ * Main dropped the provider that owned every open doc. Unlike the update
+ * channel this is not note-scoped: every provider in the window is stranded at
+ * once, so each one subscribes for itself and rebinds its own note.
+ */
+export const onCrdtProviderReset = (callback: () => void): (() => void) =>
+  subscribe<void>(SYNC_EVENTS.PROVIDER_RESET, callback)
+
 export const onCrdtStateChanged = (
   noteId: string,
   callback: CrdtStateChangedCallback

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1861,6 +1861,7 @@ interface API extends WindowAPI, GeneratedRpcApi {
     noteId: string,
     callback: (data: { noteId: string; update: Uint8Array; origin: string }) => void
   ) => () => void
+  onCrdtProviderReset: (callback: () => void) => () => void
   onFlushRequested: (callback: (requestId?: string) => void) => () => void
   notifyFlushDone: (requestId?: string) => void
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -22,7 +22,14 @@ import { inboxEvents } from './api/inbox'
 import { folderViewApi, folderViewEvents } from './api/folder-view'
 import { searchApi, graphApi, searchEvents } from './api/search'
 import { syncAuth, syncSetup, syncLinking, accountApi, syncDevices } from './api/sync-identity'
-import { syncOps, cryptoApi, syncAttachments, syncCrdt, onCrdtStateChanged } from './api/sync-ops'
+import {
+  syncOps,
+  cryptoApi,
+  syncAttachments,
+  syncCrdt,
+  onCrdtStateChanged,
+  onCrdtProviderReset
+} from './api/sync-ops'
 import { syncEvents } from './api/sync-events'
 import { updaterApi, updaterEvents } from './api/updater'
 import { agentMcpApi } from './api/agent-mcp'
@@ -113,6 +120,7 @@ export const api = {
   homePages: homePagesApi,
 
   onCrdtStateChanged,
+  onCrdtProviderReset,
   ...syncEvents,
   ...updaterEvents,
   ...importEvents,

--- a/apps/desktop/src/renderer/src/sync/use-yjs-collaboration.test.tsx
+++ b/apps/desktop/src/renderer/src/sync/use-yjs-collaboration.test.tsx
@@ -21,7 +21,9 @@ beforeEach(() => {
       syncStep1: mockSyncStep1,
       syncStep2: mockSyncStep2
     },
-    onCrdtStateChanged: mockOnCrdtStateChanged
+    onCrdtStateChanged: mockOnCrdtStateChanged,
+    // Every provider subscribes to the rebind event on connect.
+    onCrdtProviderReset: () => () => {}
   }
 })
 

--- a/apps/desktop/src/renderer/src/sync/yjs-ipc-provider.test.ts
+++ b/apps/desktop/src/renderer/src/sync/yjs-ipc-provider.test.ts
@@ -33,6 +33,20 @@ function broadcastStateChanged(payload: StateChangedPayload): void {
   for (const callback of [...(noteSubscribers.get(payload.noteId) ?? [])]) callback(payload)
 }
 
+/**
+ * The provider-reset channel carries no note id: main dropped the instance that
+ * owned every doc at once, so every provider in the window hears it.
+ */
+const resetSubscribers = new Set<() => void>()
+const mockOnCrdtProviderReset = vi.fn((callback: () => void) => {
+  resetSubscribers.add(callback)
+  return () => resetSubscribers.delete(callback)
+})
+
+function broadcastProviderReset(): void {
+  for (const callback of [...resetSubscribers]) callback()
+}
+
 beforeEach(() => {
   mockOpenDoc.mockResolvedValue({ success: true })
   mockCloseDoc.mockResolvedValue({ success: true })
@@ -47,7 +61,8 @@ beforeEach(() => {
         syncStep1: mockSyncStep1,
         syncStep2: mockSyncStep2
       },
-      onCrdtStateChanged: mockOnCrdtStateChanged
+      onCrdtStateChanged: mockOnCrdtStateChanged,
+      onCrdtProviderReset: mockOnCrdtProviderReset
     }
   }
 })
@@ -55,6 +70,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.clearAllMocks()
   noteSubscribers.clear()
+  resetSubscribers.clear()
 })
 
 vi.mock('@/lib/logger', () => ({
@@ -242,6 +258,69 @@ describe('YjsIpcProvider note-scoped subscription', () => {
 
     doc.destroy()
     sourceDoc.destroy()
+  })
+})
+
+describe('YjsIpcProvider provider reset', () => {
+  it('re-opens the note and redoes the handshake, carrying edits made while unbound', async () => {
+    // #given a connected editor, then main drops the provider that owned its doc
+    // (sign-out) while the editor stays mounted and the user keeps typing
+    const doc = new Y.Doc()
+    const provider = new YjsIpcProvider({ noteId: 'note-42', doc })
+    await provider.connect()
+
+    doc.getMap('meta').set('title', 'Typed while signed out')
+    mockOpenDoc.mockClear()
+    mockSyncStep1.mockClear()
+    mockSyncStep2.mockClear()
+
+    const rebuiltDoc = new Y.Doc()
+    mockSyncStep1.mockResolvedValueOnce({
+      diff: Y.encodeStateAsUpdate(rebuiltDoc),
+      stateVector: Y.encodeStateVector(rebuiltDoc)
+    })
+
+    // #when
+    broadcastProviderReset()
+    await vi.waitFor(() => expect(mockSyncStep2).toHaveBeenCalled())
+
+    // #then re-opening is what re-attributes this window to the fresh doc; without
+    // it main broadcasts to a window set the editor is not in and the note goes
+    // stale with no further signal. The local doc is merged, not replaced, so the
+    // edit made while unbound is pushed to main instead of being dropped.
+    expect(mockOpenDoc).toHaveBeenCalledWith({ noteId: 'note-42' })
+    expect(mockSyncStep1).toHaveBeenCalledWith({
+      noteId: 'note-42',
+      stateVector: expect.any(Uint8Array)
+    })
+    expect(mockSyncStep2).toHaveBeenCalledWith({
+      noteId: 'note-42',
+      diff: expect.any(Uint8Array)
+    })
+    expect(doc.getMap('meta').get('title')).toBe('Typed while signed out')
+    expect(provider.isSynced).toBe(true)
+
+    provider.destroy()
+    doc.destroy()
+    rebuiltDoc.destroy()
+  })
+
+  it('stops rebinding once destroyed so a closed note cannot reopen itself', async () => {
+    const doc = new Y.Doc()
+    const provider = new YjsIpcProvider({ noteId: 'note-42', doc })
+    await provider.connect()
+    provider.destroy()
+    mockOpenDoc.mockClear()
+
+    broadcastProviderReset()
+    await Promise.resolve()
+
+    // #then a destroyed provider has released its subscription, so a reset must
+    // not resurrect the note in main and pin a doc nothing is looking at.
+    expect(resetSubscribers.size).toBe(0)
+    expect(mockOpenDoc).not.toHaveBeenCalled()
+
+    doc.destroy()
   })
 })
 

--- a/apps/desktop/src/renderer/src/sync/yjs-ipc-provider.ts
+++ b/apps/desktop/src/renderer/src/sync/yjs-ipc-provider.ts
@@ -16,6 +16,9 @@ export class YjsIpcProvider extends Observable<string> {
   private destroyed = false
   private updateHandler: ((update: Uint8Array, origin: unknown) => void) | null = null
   private ipcCleanup: (() => void) | null = null
+  private resetCleanup: (() => void) | null = null
+  /** Serialises rebinds so two resets in a row cannot interleave handshakes. */
+  private rebinding: Promise<void> | null = null
 
   constructor(config: YjsIpcProviderConfig) {
     super()
@@ -43,6 +46,18 @@ export class YjsIpcProvider extends Observable<string> {
       }
     )
 
+    // Main can drop the provider that owns this note's doc — sign-out does, and
+    // so does any other provider reset — while this editor stays mounted. The
+    // binding is dead at that point and nothing else says so: remote updates go
+    // on being applied in main and broadcast to a window set this editor is no
+    // longer in, so the note silently goes stale until it is closed and
+    // reopened. Rebind instead.
+    this.resetCleanup = window.api.onCrdtProviderReset(() => {
+      this.rebinding = (this.rebinding ?? Promise.resolve())
+        .catch(() => {})
+        .then(() => this.rebind())
+    })
+
     await this.openDoc()
     if (this.destroyed) return
     await this.performSyncHandshake()
@@ -57,6 +72,11 @@ export class YjsIpcProvider extends Observable<string> {
     if (this.ipcCleanup) {
       this.ipcCleanup()
       this.ipcCleanup = null
+    }
+
+    if (this.resetCleanup) {
+      this.resetCleanup()
+      this.resetCleanup = null
     }
 
     window.api.syncCrdt.closeDoc({ noteId: this.noteId }).catch((err: unknown) => {
@@ -77,6 +97,32 @@ export class YjsIpcProvider extends Observable<string> {
     this.destroyed = true
     this.disconnect()
     super.destroy()
+  }
+
+  /**
+   * Re-open this note in main and redo the handshake after a provider reset.
+   *
+   * The local doc is merged rather than replaced: a note stays editable while
+   * signed out, so those edits exist only here, and `syncStep1`/`syncStep2`
+   * reconciles them with whatever main now holds. Re-opening is also what
+   * re-attributes this window to the doc, which is what puts the editor back
+   * into main's broadcast set.
+   *
+   * A failure is logged and dropped rather than thrown: this runs from an IPC
+   * event with no caller to receive it, and the provider must stay alive for
+   * the next reset.
+   */
+  private async rebind(): Promise<void> {
+    if (this.destroyed) return
+    this.synced = false
+    try {
+      await this.openDoc()
+      if (this.destroyed) return
+      await this.performSyncHandshake()
+      log.debug('Rebound after provider reset', { noteId: this.noteId })
+    } catch (err) {
+      log.error('Failed to rebind after provider reset', { noteId: this.noteId, error: err })
+    }
   }
 
   private async openDoc(): Promise<void> {

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -122,6 +122,29 @@ pins a doc for the rest of the session: the renderer's `crdt:close-doc` on unmou
 window that turns out to be gone, and provider teardown on vault close or switch. Once
 released, the doc is evictable and compactable again.
 
+### Rebinding After a Provider Reset
+
+Sign-out — and any other provider reset — drops the instance that owned every open doc,
+while renderer editors stay mounted. Their providers are then bound to docs nothing
+serves: main goes on applying remote updates, to the _new_ instance's docs, and
+broadcasts them to a window set the editor is no longer in. Nothing about that is visible
+to the user, so the note silently shows stale content until it is closed and reopened or
+the app restarts.
+
+The reset therefore broadcasts `crdt:provider-reset` to every window, and each provider
+re-opens its note and redoes the sync handshake. Re-opening is the part that matters:
+that is what re-attributes the window to the fresh doc and puts the editor back in the
+broadcast set. The event carries no note id — one reset strands every open doc at once,
+so each provider hears it and rebinds its own note.
+
+The renderer's Y.Doc is merged rather than replaced. A note stays editable while signed
+out, so edits made in that window exist nowhere else; `crdt:sync-step-1` / `-2` reconcile
+them with whatever main now holds instead of discarding them.
+
+The reset also logs how many docs had an editor attached when it happened. That is the
+number the rebind has to bring back, and it is the only signal that this class of failure
+occurred — a stale editor is otherwise indistinguishable from a quiet note.
+
 Local compaction runs under that same condition as closing and eviction — a doc with no
 windows attached — and it is asynchronous for the same reason, so the two can be in flight
 at once for one note. Compaction therefore treats the entry it captured as provisional: it

--- a/packages/contracts/src/ipc-crdt.ts
+++ b/packages/contracts/src/ipc-crdt.ts
@@ -11,7 +11,14 @@ export const CRDT_CHANNELS = {
 export const CRDT_EVENTS = {
   STATE_CHANGED: 'crdt:state-changed',
   DOC_LOADED: 'crdt:doc-loaded',
-  DOC_ERROR: 'crdt:doc-error'
+  DOC_ERROR: 'crdt:doc-error',
+  /**
+   * Main dropped the provider that owned every open Y.Doc, so each renderer
+   * provider is now bound to a doc nothing serves. Sent on sign-out and any
+   * other provider reset; a renderer holding an editor open must re-open its
+   * note and redo the sync handshake, or it goes stale with no further signal.
+   */
+  PROVIDER_RESET: 'crdt:provider-reset'
 } as const
 
 export const CRDT_FRAGMENT_NAME = 'prosemirror' as const


### PR DESCRIPTION
## Problem

Reported after #1449 landed and its repro passed. Same setup, one difference: **the note is open in an editor on device B**.

Sign out on B (the note stays on screen), edit that note's body on A, sign back in on B. The edit does not appear. Closing and reopening the note — or restarting — shows it immediately. "Edit a different note and come back" is the same thing by another route, which is why it looked like a second bug.

## Root cause

Not a sync failure. The body reaches B and is written correctly; the **renderer↔main binding** is what breaks.

- `session-teardown.ts` calls `resetCrdtProvider()` on logout, which drops the `CrdtProvider` singleton and with it every doc's window attribution.
- `YjsIpcProvider.connect()` runs `openDoc` + `syncStep1` exactly once, at mount. There is no listener that would make it re-handshake.

So the editor stays mounted, bound to a doc nothing serves. Main applies the next remote update to the *fresh* instance's doc and broadcasts it to a window set the editor is no longer in.

Device B's log, sign-in batch pass, note open on screen:

```
applyRemoteUpdate { noteId: 'skfe4c9o0z15', bytes: 2819, windows: 0 }
Applied CRDT snapshot baseline { noteId: 'skfe4c9o0z15', mode: 'batch', sequenceNum: 0 }
No windows to broadcast CRDT update { noteId: 'skfe4c9o0z15', origin: 'network' }
```

Three minutes later, after the note was reopened, the same pull:

```
applyRemoteUpdate { noteId: 'skfe4c9o0z15', bytes: 2948, windows: 1 }
YjsIpcProvider: Applied remote update { noteId: 'skfe4c9o0z15', bytes: 233 }
```

## Fix

- New `crdt:provider-reset` event, broadcast from `resetCrdtProvider` — so it covers **every** reset, not just logout; the same hole exists on vault switch.
- Each `YjsIpcProvider` subscribes and, on reset, re-opens its note and redoes the handshake. Re-opening is the part that matters: that is what re-attributes the window and puts the editor back in main's broadcast set. The event carries no note id because one reset strands every open doc at once.
- The renderer's Y.Doc is **merged, not replaced**. A note stays editable while signed out, so those edits exist only in that window; `syncStep1`/`syncStep2` reconcile them with whatever main now holds.
- The reset logs how many docs had an editor attached when it fired. Main cannot distinguish a stale editor from a quiet note, so the count has to be taken at the one moment that knows — it is the number the rebind must bring back, and the only signal this class of failure leaves.

## Verification

- Three regression tests, all **mutation-verified**: dropping the broadcast, dropping the renderer subscription, or dropping the count each fails its own test and nothing else.
- Desktop main: 505 files / 6448 tests pass. Desktop renderer: 611 files / 7011 tests pass. Contracts: 50 files / 1655 tests pass.
- `pnpm typecheck` across all packages, `ipc:generate` + `ipc:check`, eslint, `git diff --check` clean.
- `docs:impact --strict` covered, `docs:build` passes.

Two existing test files had `window.api` / `electron` mocks that predate the new dependency; both were completed rather than worked around.

## Not in this PR

The 429 storm on the vault-wide sweep, still open from #1449: the sweep uses the single-note pull path, 2 requests per note against `crdt_pull` = 300/60s keyed by userId and shared by both devices. That costs freshness, not data.