### PR TITLE
fix(editor): a wiki link keeps its formatting, when the formatting is the link

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -22,6 +22,8 @@ import {
   serializeCalloutBlock,
   serializeYoutubeEmbed
 } from '@memry/editor-schema/blocks'
+import { createInlineContentSpec } from '@blocknote/core'
+import { createWikiLinkInlineContent, wikiLinkToText } from '@memry/editor-schema/inline'
 import { createServerBlockSpecs, createServerInlineSpecs } from '@memry/editor-schema/server'
 import { serializeDateMentionToken } from '@memry/shared/date-mention'
 import { fileBlockCommentData, parseFileBlockMarker } from '@memry/editor-schema/blocks'
@@ -901,6 +903,358 @@ describe('custom inline nodes survive the CRDT write path', () => {
 })
 
 /**
+ * #1439: `**[[A]]**` lost its bold the moment the note was opened.
+ *
+ * The renderer promotes the styled run into a `wikiLink` node, and BlockNote's
+ * data model gives custom inline content no `styles` field — so the marks now
+ * ride in the node's PROPS and are re-emitted from `toExternalHTML`. These
+ * assert the exact bytes, because write-back byte-compares: a single character
+ * of drift here rewrites every note with a wiki link in every vault.
+ */
+describe('a wiki link carries its marks to disk', () => {
+  /** A doc holding one paragraph whose only content is the wiki link. */
+  async function markdownForProps(props: Record<string, unknown>): Promise<string | null> {
+    const doc = new Y.Doc()
+    blocksToYFragment(
+      [
+        {
+          id: 'b1',
+          type: 'paragraph',
+          props: {},
+          children: [],
+          content: [{ type: 'wikiLink', props }]
+        }
+      ] as unknown as Parameters<typeof blocksToYFragment>[0],
+      doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+    return await yDocToMarkdown(doc)
+  }
+
+  // THE byte-stability guard. Every wiki link already in every vault takes this
+  // path; if it moves by one character, every one of those notes is rewritten
+  // on next open. Asserted as an exact string, never `toContain`.
+  it.each([
+    [{ target: 'A', alias: '' }, '[[A]]'],
+    [{ target: 'A', alias: 'b' }, '[[A|b]]'],
+    // Marks explicitly at their schema defaults are the same as no marks.
+    [
+      {
+        target: 'A',
+        alias: '',
+        bold: false,
+        italic: false,
+        underline: false,
+        strike: false,
+        code: false,
+        textColor: 'default',
+        backgroundColor: 'default'
+      },
+      '[[A]]'
+    ]
+  ])('an unmarked link serializes to exactly %j -> %j', async (props, expected) => {
+    expect(await markdownForProps(props)).toBe(expected)
+  })
+
+  // The marked forms are byte-identical to what BlockNote emits for the marked
+  // `[[A]]` TEXT run the link was promoted from — verified by the sibling test
+  // below, which serializes both and compares.
+  it.each([
+    [{ bold: true }, '**[[A]]**'],
+    [{ italic: true }, '*[[A]]*'],
+    [{ strike: true }, '~~[[A]]~~'],
+    [{ code: true }, '`[[A]]`'],
+    [{ bold: true, italic: true }, '***[[A]]***'],
+    [{ bold: true, italic: true, strike: true, code: true }, '***~~`[[A]]`~~***']
+  ])('a link marked %j serializes to %j', async (marks, expected) => {
+    expect(await markdownForProps({ target: 'A', alias: '', ...marks })).toBe(expected)
+  })
+
+  it('an aliased link keeps its marks', async () => {
+    expect(await markdownForProps({ target: 'A', alias: 'b', bold: true })).toBe('**[[A|b]]**')
+  })
+
+  // The seam between the two processes. `createWikiLinkInlineContent` is the
+  // shared factory the renderer's `normalizeWikiLinks` calls when it promotes a
+  // styled run, so building the node through it here means a change to the
+  // promotion's output shape fails on this side too.
+  it.each([
+    [{ bold: true }, '**[[A]]**'],
+    [{ italic: true }, '*[[A]]*'],
+    [{ bold: true, italic: true, strike: true, code: true }, '***~~`[[A]]`~~***'],
+    [{}, '[[A]]']
+  ])('serializes the node the renderer promotion builds for %j', async (styles, expected) => {
+    // #given exactly what the renderer puts in the shared doc
+    const promoted = createWikiLinkInlineContent('A', '', styles)
+
+    // #then
+    expect(await markdownForProps(promoted.props)).toBe(expected)
+  })
+
+  // The bar the whole fix is measured against: whatever BlockNote writes for a
+  // marked text run is what the promoted link must write, or opening a note
+  // rewrites it.
+  it.each([
+    [{ bold: true }],
+    [{ italic: true }],
+    [{ strike: true }],
+    [{ code: true }],
+    [{ bold: true, italic: true, strike: true, code: true }]
+  ])('marked %j serializes the same as the marked text it was promoted from', async (marks) => {
+    // #given the same paragraph twice: once as a styled text run, once as a
+    // promoted wikiLink node carrying the same marks
+    const textDoc = new Y.Doc()
+    blocksToYFragment(
+      [
+        {
+          id: 'b1',
+          type: 'paragraph',
+          props: {},
+          children: [],
+          content: [{ type: 'text', text: '[[A]]', styles: marks }]
+        }
+      ] as unknown as Parameters<typeof blocksToYFragment>[0],
+      textDoc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+
+    // #then
+    expect(await markdownForProps({ target: 'A', alias: '', ...marks })).toBe(
+      await yDocToMarkdown(textDoc)
+    )
+  })
+
+  // Colours and underline have no markdown syntax. A coloured TEXT run reaches
+  // disk as `<span style="color:red">` via the token masking in
+  // @memry/shared/inline-colors; a coloured link takes the same road.
+  it.each([
+    [{ textColor: 'red' }, '<span style="color:red">[[A]]</span>'],
+    [{ backgroundColor: 'blue' }, '<span style="background-color:blue">[[A]]</span>'],
+    [{ underline: true }, '<span style="text-decoration:underline">[[A]]</span>'],
+    [{ textColor: 'red', bold: true }, '<span style="color:red">**[[A]]**</span>']
+  ])('a link marked %j serializes to %j', async (marks, expected) => {
+    expect(await markdownForProps({ target: 'A', alias: '', ...marks })).toBe(expected)
+  })
+
+  // BlockNote serializes inline content inside a TABLE through the spec's
+  // `render`, not `toExternalHTML` — a marked link in a table cell would lose
+  // its marks if only one of the two emitted them.
+  it('keeps its marks inside a table cell', async () => {
+    // #given
+    const doc = new Y.Doc()
+    blocksToYFragment(
+      [
+        {
+          id: 'tbl',
+          type: 'table',
+          props: {},
+          children: [],
+          content: {
+            type: 'tableContent',
+            columnWidths: [null],
+            rows: [
+              {
+                cells: [
+                  {
+                    type: 'tableCell',
+                    content: [{ type: 'wikiLink', props: { target: 'A', alias: '', bold: true } }],
+                    props: {
+                      colspan: 1,
+                      rowspan: 1,
+                      backgroundColor: 'default',
+                      textColor: 'default',
+                      textAlignment: 'left'
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ] as unknown as Parameters<typeof blocksToYFragment>[0],
+      doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+
+    // #when
+    const markdown = await yDocToMarkdown(doc)
+
+    // #then the conversion succeeds at all (a throwing render returns null)…
+    expect(markdown).not.toBeNull()
+    // …and the cell holds the marked form
+    expect(markdown).toContain('**[[A]]**')
+  })
+
+  /**
+   * The compat case, and the one that decides whether this may ship to a live
+   * beta. A `wikiLink` written by a build that predates the mark props carries
+   * `target`/`alias` and nothing else. ProseMirror's `computeAttrs` walks the
+   * SCHEMA's attributes and fills a default for every key the element lacks, so
+   * the node still builds and still serializes to the bytes it always did — no
+   * migration, no rewrite.
+   */
+  it('a node persisted by an older build, with no mark props, still serializes', async () => {
+    // #given the element shape an older build wrote: two attributes, no marks
+    const doc = new Y.Doc()
+    const group = new Y.XmlElement('blockGroup')
+    const block = new Y.XmlElement('blockContainer')
+    block.setAttribute('id', 'b1')
+    const para = new Y.XmlElement('paragraph')
+    const node = new Y.XmlElement('wikiLink')
+    node.setAttribute('target', 'Roadmap')
+    node.setAttribute('alias', 'the plan')
+    para.insert(0, [new Y.XmlText('See '), node, new Y.XmlText(' tomorrow.')])
+    block.insert(0, [para])
+    group.insert(0, [block])
+    doc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [group])
+    const before = Y.encodeStateAsUpdate(doc)
+
+    // #when
+    const markdown = await yDocToMarkdown(doc)
+
+    // #then it converts to exactly the bytes it did before the props existed…
+    expect(markdown).toBe('See [[Roadmap|the plan]] tomorrow.')
+    // …the schema can still build it (an unbuildable node is DELETED)…
+    expect(findUnrepresentableNodes(doc)).toEqual([])
+    // …and reading it did not touch the shared doc
+    expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+  })
+
+  // The other half of the same compat question: an old element read back as
+  // BLOCKS carries the schema defaults, which is what makes it serialize
+  // unchanged. Measured rather than reasoned about.
+  it('an older build’s node reads back with the mark props at their defaults', async () => {
+    // #given
+    const doc = new Y.Doc()
+    const group = new Y.XmlElement('blockGroup')
+    const block = new Y.XmlElement('blockContainer')
+    block.setAttribute('id', 'b1')
+    const para = new Y.XmlElement('paragraph')
+    const node = new Y.XmlElement('wikiLink')
+    node.setAttribute('target', 'Old')
+    para.insert(0, [node])
+    block.insert(0, [para])
+    group.insert(0, [block])
+    doc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [group])
+
+    // #when
+    const blocks = await yFragmentToBlocks(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+    // #then
+    expect((blocks![0] as { content: unknown[] }).content).toEqual([
+      {
+        type: 'wikiLink',
+        props: {
+          target: 'Old',
+          alias: '',
+          bold: false,
+          italic: false,
+          underline: false,
+          strike: false,
+          code: false,
+          textColor: 'default',
+          backgroundColor: 'default'
+        }
+      }
+    ])
+  })
+
+  /**
+   * The downgrade direction, which is the half a live beta actually risks: a
+   * released build that has never heard of the mark props meets a document a
+   * NEWER build wrote with them.
+   *
+   * Run for real, not reasoned about — the `wikiLink` spec below is rebuilt with
+   * the pre-#1439 two-attribute propSchema and put in a live server editor, so
+   * the assertions below are ProseMirror actually executing the old schema
+   * against the new bytes. `_computeAttrs` iterates the SCHEMA's attrs, so keys
+   * it has never heard of are dropped; `_checkAttrs`, which does throw on an
+   * unknown key, is not on the `NodeType.create` path y-prosemirror uses.
+   */
+  it('an older build reads a node carrying the new props without throwing or deleting it', async () => {
+    // #given a document this build wrote: a marked wiki link, mark props and all
+    const doc = new Y.Doc()
+    blocksToYFragment(
+      [
+        {
+          id: 'b1',
+          type: 'paragraph',
+          props: {},
+          children: [],
+          content: [
+            {
+              type: 'wikiLink',
+              props: { target: 'Roadmap', alias: 'the plan', bold: true, textColor: 'red' }
+            }
+          ]
+        }
+      ] as unknown as Parameters<typeof blocksToYFragment>[0],
+      doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+    const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    expect(fragment.toString()).toContain('bold="true"')
+    const before = Y.encodeStateAsUpdate(doc)
+
+    // #when the build that predates the props reads it. Same spec, same
+    // implementation — only the propSchema is rolled back.
+    const oldSpec = createInlineContentSpec(
+      {
+        type: 'wikiLink' as const,
+        propSchema: { target: { default: '' }, alias: { default: '' } },
+        content: 'none' as const
+      },
+      {
+        render: (inlineContent) => {
+          const dom = document.createElement('span')
+          const props = inlineContent.props as unknown as { target: string; alias: string }
+          dom.textContent = wikiLinkToText(props.target || '', props.alias || '')
+          return { dom }
+        }
+      }
+    )
+    const oldEditor = ServerBlockNoteEditor.create({
+      schema: createMemrySchema({
+        blocks: createServerBlockSpecs(),
+        inline: {
+          ...createServerInlineSpecs(),
+          // The whole point: a spec whose propSchema is two keys short.
+          wikiLink: oldSpec as unknown as ReturnType<typeof createServerInlineSpecs>['wikiLink']
+        }
+      })
+    }) as ServerBlockNoteEditor
+
+    const blocks = oldEditor.yXmlFragmentToBlocks(fragment)
+
+    // #then the node is THERE — an unbuildable node is deleted from the shared
+    // doc by y-prosemirror, which replicates to every device — and it carries
+    // exactly the two props the old schema knows about
+    expect((blocks[0] as { content: unknown[] }).content).toEqual([
+      { type: 'wikiLink', props: { target: 'Roadmap', alias: 'the plan' } }
+    ])
+
+    // …it serializes to the pre-#1439 bytes: the mark is forgotten, never
+    // corrupted, which is exactly what that build did before this change…
+    expect(await oldEditor.blocksToMarkdownLossy(blocks)).toContain('[[Roadmap|the plan]]')
+
+    // …and reading it left the shared document byte-identical, so an old client
+    // merely OPENING the note does not strip the marks for everyone else.
+    expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+  })
+
+  /**
+   * `code` combined with any of bold/italic/strike is write-only, and has been
+   * since long before this node existed: BlockNote's markdown PARSER drops the
+   * emphasis off any run that also carries inline code — ``**`x`**`` parses to
+   * `{ code: true }` for plain text, no wiki link involved. The serializer
+   * above emits the combination faithfully; the read-back is what flattens it.
+   * Asserted so the limitation is recorded rather than rediscovered.
+   */
+  it('code combined with emphasis is a pre-existing parser limitation, not ours', async () => {
+    const blocks = await markdownToBlocks('**`x`**')
+    expect((blocks![0] as { content: unknown[] }).content).toEqual([
+      { type: 'text', text: 'x', styles: { code: true } }
+    ])
+  })
+})
+
+/**
  * The textual form each custom inline type takes on disk.
  *
  * Typed against `MEMRY_INLINE_CONTENT_TYPES`, so a new inline spec with no
@@ -985,6 +1339,20 @@ describe('registering the custom specs does not rewrite existing markdown', () =
   it.each([
     'See [[Roadmap|the plan]] tomorrow.',
     '[[Roadmap]]',
+    // Marked links, the #1439 shapes. Main has no wikiLink `parse` rule, so
+    // these stay styled TEXT runs on this path — which is exactly why the bytes
+    // must not move: the renderer promotes them to nodes on open, and the node
+    // has to serialize back to these same bytes.
+    '**[[Roadmap]]**',
+    '*[[A]]*',
+    '~~[[A]]~~',
+    '`[[A]]`',
+    '**[[A|b]]**',
+    'See **[[A]]** and *[[B]]* today.',
+    // The shape the narrowing declines to promote — it has to survive main's
+    // own round trip untouched, or declining would not help.
+    '~~Cancelled: [[Meeting]]~~',
+    '**See [[Roadmap]] for details**',
     '# Heading\n\n[[A]] and #tag and ((mention:https%3A%2F%2Fx.com)) inline.',
     '- [[A]]\n- [[B]]',
     '> [[Quoted]]',

--- a/apps/desktop/src/main/sync/note-open-byte-stability.test.ts
+++ b/apps/desktop/src/main/sync/note-open-byte-stability.test.ts
@@ -171,17 +171,32 @@ const REL_PATH = path.join('notes', 'Byte Stability.md')
  * the sharp edge in #1428: a wiki link is one element inside a list item, a
  * quote and a table cell, and a text-matching parse claims the whole element.
  *
- * Deliberately absent: any wiki link carrying an inline MARK. That whole class
- * does not round-trip — see the `#1439` cases at the bottom of this file, which
- * pin the current behaviour without asserting it is correct. The fixtures here
- * gate the cases that DO converge; do not read their green as covering marks.
+ * Wiki links carrying an inline MARK are in here as of #1439. They used to be
+ * deliberately absent, because opening the note DELETED the mark from the vault
+ * file; the marks now ride in the node's props when the link is the whole
+ * styled run, and the promotion declines outright when it is not. Both halves
+ * are fixtures below — the acceptance table of #1439 is rows 1-5 of this list
+ * plus the unmarked `[[Wiki Link]]` guard.
  */
 const FIXTURES: ReadonlyArray<readonly [string, string]> = [
+  // #1439's acceptance table, in order. The first three promote and carry the
+  // mark in props; the fourth is the narrowing — the link sits inside a longer
+  // marked phrase, so it is left as literal text and the file is untouched.
+  ['bold around the whole link', '**[[Meeting]]**'],
+  ['strikethrough around the whole link', '~~[[Meeting]]~~'],
+  ['italic around the whole link', '*[[A]]*'],
+  ['a wiki link inside a marked phrase', '~~Cancelled: [[Meeting]]~~'],
+  ['a wiki link inside a bolded sentence', '**See [[Roadmap]] for details**'],
+  ['an aliased link, marked', '**[[Roadmap|the plan]]**'],
   ['a wiki link in a sentence', 'See [[Wiki Link]] for details.'],
   ['a wiki link alone in its block', '[[Wiki Link]]'],
   ['an aliased wiki link', 'See [[Roadmap|the plan]] today.'],
   ['a wiki link per list item', '- [[A]]\n- [[B]]'],
   ['a wiki link in a quote', '> [[Quoted]]'],
+  // BlockNote serializes inline content inside a TABLE through the spec's
+  // `render`, not `toExternalHTML`, so main's serialization-only variant has to
+  // emit the marks from both halves or a marked link in a cell loses them.
+  ['a marked wiki link in a table cell', '| **[[A]]** | b |\n| --------- | - |\n| c         | d |'],
   // Table cells are the case the server spec's `render` has to get right —
   // BlockNote serializes inline content inside a table through `render`, not
   // `toExternalHTML`. The separator row is written pre-padded because remark
@@ -316,11 +331,12 @@ describe('opening a note with collaboration active does not rewrite it', () => {
 
 describe('repeated open -> write-back cycles converge', () => {
   /**
-   * Five, not two. Two passes cannot tell "converged" apart from "grows by a
+   * Six, not two. Two passes cannot tell "converged" apart from "grows by a
    * constant", and a length that repeats once can still be the second term of a
-   * sequence that moves again on the third.
+   * sequence that moves again on the third. The #1439 attempt this one replaces
+   * grew by exactly four characters per pass (26→30→34→38→42→46).
    */
-  const PASSES = 5
+  const PASSES = 6
 
   it.each(FIXTURES)('%s is a fixed point from the first pass', async (_name, body) => {
     // #given
@@ -358,7 +374,7 @@ describe('repeated open -> write-back cycles converge', () => {
 
     // #then only the first change promotes; the rest find a document that is
     // already in canonical form, so the loop terminates instead of ping-ponging
-    expect(promotions).toEqual([true, false, false, false, false])
+    expect(promotions).toEqual([true, false, false, false, false, false])
     expect(fs.readFileSync(absolutePath, 'utf8')).toBe(body)
     expect(mocks.atomicWrites).toEqual([])
   })
@@ -453,26 +469,90 @@ describe('write-back does not delete a wiki link from the shared doc', () => {
   })
 })
 
+/**
+ * #1439's acceptance table, driven end to end and asserted as exact strings.
+ *
+ * Before this landed, a mark on a wiki link was DELETED from the vault file the
+ * first time the note was opened — verified at the time against a control run
+ * with the promotion step removed, which was flat in every row:
+ *
+ *   `**[[Meeting]]**`             -> `[[Meeting]]`                 bold DELETED
+ *   `~~[[Meeting]]~~`             -> `[[Meeting]]`                 strike DELETED
+ *   `*[[A]]*`                     -> `[[A]]`                       italic DELETED
+ *   `~~Cancelled: [[Meeting]]~~`  -> `~~Cancelled: ~~[[Meeting]]`  mark BROKEN
+ *
+ * The fourth was worse than its byte count suggested: GFM requires a closing
+ * `~~` not be preceded by whitespace, so `~~Cancelled: ~~` is strikethrough
+ * nowhere and the note showed four literal tildes.
+ *
+ * All five rows are now fixed points from pass zero. The cost is deliberate:
+ * the link inside a longer marked phrase gets no chip, because promoting it
+ * there is what produced markdown GFM cannot parse.
+ */
+describe('a marked wiki link is a fixed point (#1439)', () => {
+  const PASSES = 6
+
+  it.each([
+    ['bold around the whole link', '**[[Meeting]]**'],
+    ['strikethrough around the whole link', '~~[[Meeting]]~~'],
+    ['italic around the whole link', '*[[A]]*'],
+    ['a link inside a longer struck phrase', '~~Cancelled: [[Meeting]]~~'],
+    // The byte-stability guard: the unmarked link is what every existing vault
+    // is full of, and it must be untouched by all of the above.
+    ['an unmarked link', '[[A]]']
+  ])('%s is unchanged after six opens', async (_name, body) => {
+    // #given the note as it sits on disk
+    const absolutePath = seedVaultNote(body)
+    const lengths: number[] = [body.length]
+    const contents: string[] = []
+
+    // #when it is opened and written back six times
+    for (let pass = 0; pass < PASSES; pass++) {
+      const doc = await openNote(absolutePath)
+      await applyRendererPromotion(doc)
+      await runWriteback(doc)
+      const current = fs.readFileSync(absolutePath, 'utf8')
+      lengths.push(current.length)
+      contents.push(current)
+    }
+
+    // #then every pass produced the seed bytes exactly, and nothing was written
+    expect(contents).toEqual(Array<string>(PASSES).fill(body))
+    expect(lengths).toEqual(Array<number>(PASSES + 1).fill(body.length))
+    expect(mocks.atomicWrites).toEqual([])
+  })
+
+  it('the link is still a chip when the mark covers the whole run', async () => {
+    // #given
+    const absolutePath = seedVaultNote('**[[Meeting]]**')
+
+    // #when
+    const doc = await openNote(absolutePath)
+    expect(await applyRendererPromotion(doc)).toBe(true)
+
+    // #then the doc holds a real node — the point of carrying the marks in
+    // props rather than declining everywhere — and it writes the seed bytes
+    expect(countWikiLinkNodes(doc)).toBe(1)
+    expect(await yDocToMarkdown(doc)).toBe('**[[Meeting]]**')
+  })
+
+  it('the link inside a longer marked phrase is deliberately NOT promoted', async () => {
+    // #given
+    const absolutePath = seedVaultNote('~~Cancelled: [[Meeting]]~~')
+
+    // #when
+    const doc = await openNote(absolutePath)
+
+    // #then nothing to promote: splitting the strike run is what emitted
+    // `~~Cancelled: ~~~~[[Meeting]]~~`, four more characters on every pass. The
+    // file wins over the chip.
+    expect(await applyRendererPromotion(doc)).toBe(false)
+    expect(countWikiLinkNodes(doc)).toBe(0)
+    expect(await yDocToMarkdown(doc)).toBe('~~Cancelled: [[Meeting]]~~')
+  })
+})
+
 describe('known non-convergence, pinned not endorsed', () => {
-  /**
-   * #1439, and it is a CLASS, not one shape. BlockNote's
-   * `CustomInlineContentFromConfig` has no `styles` field, so the promotion has
-   * nowhere to put a mark and drops it. Verified against a control run with the
-   * promotion step removed — every one of these is flat without it:
-   *
-   *   `**[[Meeting]]**`             -> `[[Meeting]]`                 mark DELETED
-   *   `~~[[Meeting]]~~`             -> `[[Meeting]]`                 mark DELETED
-   *   `*[[A]]*`                     -> `[[A]]`                       mark DELETED
-   *   `~~Cancelled: [[Meeting]]~~`  -> `~~Cancelled: ~~[[Meeting]]`  mark BROKEN
-   *
-   * The last one is worse than its byte count suggests: GFM requires a closing
-   * `~~` not be preceded by whitespace, so `~~Cancelled: ~~` is strikethrough
-   * nowhere and the note ends up showing four literal tildes. Bold survives the
-   * same shape only because the serializer emits `&#x20;` entities around it.
-   *
-   * Each is a single rewrite and stable afterwards. Blocked on a product
-   * decision, so these assert what happens today, not what should.
-   */
   it('a note carrying CriticMarkup review marks is rewritten on first open', async () => {
     // #given review marks live in the Y.Doc, not in the fragment, and write-back
     // re-serializes them onto the body. That round trip is not byte-identical.
@@ -497,49 +577,37 @@ describe('known non-convergence, pinned not endorsed', () => {
     expect(current).toContain('note')
   })
 
-  it.each([
-    ['bold around the whole link', '**[[Meeting]]**', '[[Meeting]]'],
-    ['strikethrough around the whole link', '~~[[Meeting]]~~', '[[Meeting]]'],
-    ['italic around the whole link', '*[[A]]*', '[[A]]']
-  ])('%s loses the mark on first open, then holds', async (_name, seed, expected) => {
-    // #given a note whose wiki link carries a mark
-    let current = seed
-    const absolutePath = seedVaultNote(current)
-
-    // #when opened five times
-    const results: string[] = []
-    for (let pass = 0; pass < 5; pass++) {
-      const doc = await openNote(absolutePath)
-      await applyRendererPromotion(doc)
-      await runWriteback(doc)
-      current = fs.readFileSync(absolutePath, 'utf8')
-      results.push(current)
-    }
-
-    // #then the mark is gone after the first open and never comes back
-    expect(results[0]).toBe(expected)
-    expect(new Set(results).size).toBe(1)
-  })
-
-  it('a wiki link inside a marked phrase is rewritten once, then holds', async () => {
+  /**
+   * `code` on a wiki link is the one mark that cannot round-trip, and the cause
+   * predates this node: BlockNote's markdown PARSER drops every other mark off
+   * a run that also carries inline code, so `` `[[A]]` `` parses back as a run
+   * of `{ code: true }` and the outer emphasis is gone before promotion ever
+   * runs. `` `[[A]]` `` alone is stable; combined with emphasis it is not.
+   * Pinned as a limitation, not endorsed as correct.
+   */
+  it('inline code around a link is stable; code combined with bold is not', async () => {
     // #given
-    let current = '~~Cancelled: [[Meeting]]~~'
-    const lengths: number[] = [current.length]
+    const stable = seedVaultNote('`[[A]]`')
+    const stableDoc = await openNote(stable)
+    await applyRendererPromotion(stableDoc)
+    await runWriteback(stableDoc)
 
-    // #when
-    const absolutePath = seedVaultNote(current)
-    for (let pass = 0; pass < 5; pass++) {
-      const doc = await openNote(absolutePath)
-      await applyRendererPromotion(doc)
-      await runWriteback(doc)
-      current = fs.readFileSync(absolutePath, 'utf8')
-      lengths.push(current.length)
-    }
+    // #then code alone holds its bytes
+    expect(fs.readFileSync(stable, 'utf8')).toBe('`[[A]]`')
+    expect(mocks.atomicWrites).toEqual([])
 
-    // #then the first open rewrites the file, and every open after it is a
-    // no-op — the damage is a single rewrite, not unbounded growth
-    expect(current).toBe('~~Cancelled: ~~[[Meeting]]')
-    expect(lengths).toEqual([26, 26, 26, 26, 26, 26])
-    expect(mocks.atomicWrites).toHaveLength(1)
+    // #when the same link also carries bold — the parser flattens it on the way
+    // IN, so what reaches the doc is already `{ code: true }` only
+    const flattened = seedVaultNote('**`[[A]]`**')
+    const doc = await openNote(flattened)
+    await applyRendererPromotion(doc)
+    await runWriteback(doc)
+
+    // #then one rewrite that drops the bold, then a fixed point
+    expect(fs.readFileSync(flattened, 'utf8')).toBe('`[[A]]`')
+    const second = await openNote(flattened)
+    await applyRendererPromotion(second)
+    await runWriteback(second)
+    expect(fs.readFileSync(flattened, 'utf8')).toBe('`[[A]]`')
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.test.ts
@@ -57,14 +57,24 @@ describe('wiki-link utils', () => {
     ])
 
     const inline = normalizeInlineContent([
-      { type: 'text', text: 'See [[Roadmap]]', styles: { italic: true } },
+      { type: 'text', text: 'See [[Roadmap]]', styles: {} },
       { type: 'wikiLink', props: { target: 'Existing', alias: '' } }
     ])
     expect(inline.didChange).toBe(true)
     expect(inline.content).toEqual([
-      { type: 'text', text: 'See ', styles: { italic: true } },
+      { type: 'text', text: 'See ', styles: {} },
       { type: 'wikiLink', props: { target: 'Roadmap', alias: '' } },
       { type: 'wikiLink', props: { target: 'Existing', alias: '' } }
+    ])
+
+    // The same run with a mark on it is left alone (#1439): the link is not the
+    // whole styled run, and splitting it emits markdown GFM cannot parse.
+    const marked = normalizeInlineContent([
+      { type: 'text', text: 'See [[Roadmap]]', styles: { italic: true } }
+    ])
+    expect(marked.didChange).toBe(false)
+    expect(marked.content).toEqual([
+      { type: 'text', text: 'See [[Roadmap]]', styles: { italic: true } }
     ])
 
     const table = normalizeTableContent({
@@ -90,6 +100,109 @@ describe('wiki-link utils', () => {
     expect((blocks.blocks[1] as any).children[0].content).toEqual([
       { type: 'wikiLink', props: { target: 'Child', alias: '' } }
     ])
+  })
+
+  // #1439. Promotion runs on every change, so this fires on mere open: before
+  // the marks moved into the node's props, `**[[A]]**` became `[[A]]` on disk
+  // the first time anyone looked at the note.
+  describe('promotion carries the run’s marks into the node', () => {
+    const promote = (styles: Record<string, unknown>): unknown =>
+      (splitTextWithWikiLinks('[[A]]', styles as any).segments[0] as any).props
+
+    it.each([
+      [{ bold: true }, { bold: true }],
+      [{ italic: true }, { italic: true }],
+      [{ strike: true }, { strike: true }],
+      [{ code: true }, { code: true }],
+      [{ underline: true }, { underline: true }],
+      [{ textColor: 'red' }, { textColor: 'red' }],
+      [{ backgroundColor: 'blue' }, { backgroundColor: 'blue' }],
+      [
+        { bold: true, italic: true, strike: true, code: true },
+        { bold: true, italic: true, strike: true, code: true }
+      ]
+    ])('carries %j', (styles, expected) => {
+      expect(promote(styles)).toEqual({ target: 'A', alias: '', ...expected })
+    })
+
+    // Defaults are omitted rather than written out, so an unstyled link is the
+    // same two-key object it has always been — the shape every already-synced
+    // document holds.
+    it.each([
+      [{}],
+      [{ bold: false }],
+      [{ textColor: 'default' }],
+      [{ backgroundColor: 'default' }]
+    ])('writes no mark props for %j', (styles) => {
+      expect(promote(styles)).toEqual({ target: 'A', alias: '' })
+    })
+
+    it('carries marks through an aliased link that is the whole run', () => {
+      const { segments, didChange } = splitTextWithWikiLinks('[[A|b]]', { bold: true } as any)
+      expect(didChange).toBe(true)
+      expect(segments).toEqual([
+        { type: 'wikiLink', props: { target: 'A', alias: 'b', bold: true } }
+      ])
+    })
+  })
+
+  /**
+   * The narrowing (#1439). A marked run promotes ONLY when the link is the
+   * whole of it. Splitting a marked run puts the node's own `<s>`/`<strong>`
+   * wrapper next to the run's, BlockNote cannot merge marks across an element
+   * boundary, and the file grows by four characters on every single open —
+   * `~~Cancelled: [[Meeting]]~~` went 26→30→34→38→42→46 and never converged.
+   *
+   * Declining costs a link chip inside a marked sentence. It buys the user's
+   * bytes, which is the trade this issue settled on.
+   */
+  describe('a marked run that is more than the link does not promote at all', () => {
+    it.each([
+      ['text before the link', 'Cancelled: [[Meeting]]'],
+      ['text after the link', '[[Meeting]] cancelled'],
+      ['text on both sides', 'See [[Roadmap]] for details'],
+      ['two links in one run', '[[A]] and [[B]]'],
+      ['a trailing space inside the run', '[[A]] '],
+      ['a leading space inside the run', ' [[A]]']
+    ])('%s', (_name, text) => {
+      for (const styles of [
+        { bold: true },
+        { italic: true },
+        { strike: true },
+        { code: true },
+        { underline: true },
+        { textColor: 'red' },
+        { backgroundColor: 'blue' }
+      ]) {
+        const result = splitTextWithWikiLinks(text, styles as any)
+        expect(result.didChange).toBe(false)
+        expect(result.segments).toEqual([{ type: 'text', text, styles }])
+      }
+    })
+
+    // Without marks there is nothing to lose, so the same shapes promote
+    // exactly as they always have. This is the line the narrowing must not
+    // cross: every unmarked wiki link in every vault takes this path.
+    it('an UNMARKED run still promotes everywhere it used to', () => {
+      const result = splitTextWithWikiLinks('See [[Roadmap]] for details', { bold: false } as any)
+      expect(result.didChange).toBe(true)
+      expect(result.segments).toEqual([
+        { type: 'text', text: 'See ', styles: { bold: false } },
+        { type: 'wikiLink', props: { target: 'Roadmap', alias: '' } },
+        { type: 'text', text: ' for details', styles: { bold: false } }
+      ])
+    })
+
+    it('normalizeWikiLinks leaves a whole block alone when the only link is inside a marked phrase', () => {
+      const blocks = normalizeWikiLinks([
+        {
+          id: 'p1',
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Cancelled: [[Meeting]]', styles: { strike: true } }]
+        }
+      ] as any)
+      expect(blocks.didChange).toBe(false)
+    })
   })
 
   it('normalizes markdown hard breaks outside fenced code blocks', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.ts
@@ -99,7 +99,9 @@ export function splitTextWithWikiLinks(
       continue
     }
 
-    if (wholeRunOnly && (match.index !== 0 || full.length !== text.length)) {
+    // `full.length === text.length` alone implies the match starts at 0, so
+    // that is the whole test: does this link cover the entire styled run?
+    if (wholeRunOnly && full.length !== text.length) {
       return { segments: [createStyledText(text, styles ?? {})], didChange: false }
     }
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.ts
@@ -2,7 +2,7 @@
 
 import type { Block } from '@blocknote/core'
 import type { HeadingInfo } from './types'
-import { createWikiLinkInlineContent } from './wiki-link'
+import { createWikiLinkInlineContent, hasWikiLinkMarks } from './wiki-link'
 
 // =============================================================================
 // HEADING EXTRACTION
@@ -76,6 +76,20 @@ export function splitTextWithWikiLinks(
   let lastIndex = 0
   let match: RegExpExecArray | null
 
+  // #1439, the narrowing. A marked run promotes ONLY when the link is the whole
+  // of it. `**[[A]]**` becomes a node carrying `bold`, which serializes back to
+  // `**[[A]]**`; `~~Cancelled: [[A]]~~` does not promote at all and stays
+  // literal text inside the strike run.
+  //
+  // Splitting a marked run is what makes the bytes unrepresentable: the node
+  // emits its own `<s>`/`<strong>` wrapper, and BlockNote merges adjacent
+  // identical marks across text runs but not across an element boundary. The
+  // result is `~~Cancelled: ~~~~[[A]]~~`, which GFM cannot parse (a closing `~~`
+  // may not follow whitespace) and which grows by four characters on every pass.
+  // The cost of declining is one missing link chip inside a marked sentence;
+  // the file, which is the thing the user owns, is left exactly as written.
+  const wholeRunOnly = hasWikiLinkMarks(styles)
+
   while ((match = pattern.exec(text)) !== null) {
     const [full, rawTarget, rawAlias] = match
     const target = rawTarget?.trim()
@@ -85,6 +99,10 @@ export function splitTextWithWikiLinks(
       continue
     }
 
+    if (wholeRunOnly && (match.index !== 0 || full.length !== text.length)) {
+      return { segments: [createStyledText(text, styles ?? {})], didChange: false }
+    }
+
     if (match.index > lastIndex) {
       const before = text.slice(lastIndex, match.index)
       if (before) {
@@ -92,7 +110,11 @@ export function splitTextWithWikiLinks(
       }
     }
 
-    segments.push(createWikiLinkInlineContent(target, alias))
+    // The run's marks go WITH the link. A custom inline node has no `styles`
+    // field in BlockNote's data model, so before #1439 they stopped here: the
+    // surrounding text segments kept them, the link silently did not, and
+    // `**[[A]]**` became `[[A]]` on disk the first time the note was opened.
+    segments.push(createWikiLinkInlineContent(target, alias, styles))
     didChange = true
     lastIndex = match.index + full.length
   }

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { WikiLink, createWikiLinkInlineContent, parseWikiLinkText } from './wiki-link'
+import {
+  WikiLink,
+  createWikiLinkInlineContent,
+  hasWikiLinkMarks,
+  parseWikiLinkText
+} from './wiki-link'
 
 describe('wiki-link inline content spec', () => {
   it('parses wiki text and creates inline content payloads', () => {
@@ -55,5 +60,99 @@ describe('wiki-link inline content spec', () => {
       props: { target: 'Daily Note', alias: 'Daily Note' }
     })
     expect(externalWithoutAlias.dom.textContent).toBe('[[Daily Note]]')
+  })
+
+  // #1439 — the marks live in the node's props, and both halves of the spec
+  // have to emit them. `render` is not decoration here: BlockNote serializes
+  // inline content inside a TABLE through `render`, not `toExternalHTML`.
+  describe('marks carried in props', () => {
+    const external = (props: Record<string, unknown>): HTMLElement =>
+      (WikiLink as any).implementation.toExternalHTML({ props }).dom
+
+    // The unmarked shape is the byte-stability guard: a bare span holding the
+    // text, exactly as before the props existed.
+    it('emits a bare span when nothing is marked', () => {
+      expect(external({ target: 'A', alias: '' }).outerHTML).toBe('<span>[[A]]</span>')
+      expect(
+        external({
+          target: 'A',
+          alias: '',
+          bold: false,
+          italic: false,
+          underline: false,
+          strike: false,
+          code: false,
+          textColor: 'default',
+          backgroundColor: 'default'
+        }).outerHTML
+      ).toBe('<span>[[A]]</span>')
+    })
+
+    it.each([
+      [{ bold: true }, '<span><strong>[[A]]</strong></span>'],
+      [{ italic: true }, '<span><em>[[A]]</em></span>'],
+      [{ strike: true }, '<span><s>[[A]]</s></span>'],
+      [{ code: true }, '<span><code>[[A]]</code></span>'],
+      [{ underline: true }, '<span><u>[[A]]</u></span>'],
+      // Outer-to-inner in BlockNote's own mark order, which is what makes the
+      // markdown match a styled text run byte for byte.
+      [
+        { bold: true, italic: true, underline: true, strike: true, code: true },
+        '<span><strong><em><u><s><code>[[A]]</code></s></u></em></strong></span>'
+      ]
+    ])('wraps %j', (marks, expected) => {
+      expect(external({ target: 'A', alias: '', ...marks }).outerHTML).toBe(expected)
+    })
+
+    it('keeps the chip attributes and applies the marks inside it', () => {
+      const dom = (WikiLink as any).implementation.render({
+        props: { target: 'A', alias: 'b', bold: true, code: true, textColor: 'red' }
+      }).dom
+
+      // The chip stays the outer element — the editor keys click handling and
+      // the hover card off these attributes.
+      expect(dom).toHaveAttribute('data-wiki-link', '')
+      expect(dom).toHaveAttribute('data-target', 'A')
+      expect(dom).toHaveAttribute('contenteditable', 'false')
+      // BlockNote's stylesheet colours it off this attribute.
+      expect(dom).toHaveAttribute('data-text-color', 'red')
+      expect(dom.textContent).toBe('b')
+      expect(dom.innerHTML).toBe('<strong><code>b</code></strong>')
+    })
+
+    it('sets no colour attributes when the link is not coloured', () => {
+      const dom = (WikiLink as any).implementation.render({
+        props: { target: 'A', alias: '', textColor: 'default', backgroundColor: 'default' }
+      }).dom
+      expect(dom).not.toHaveAttribute('data-text-color')
+      expect(dom).not.toHaveAttribute('data-background-color')
+    })
+
+    it('reads marks off a styles object, ignoring defaults', () => {
+      expect(createWikiLinkInlineContent('A', '', { bold: true, textColor: 'default' })).toEqual({
+        type: 'wikiLink',
+        props: { target: 'A', alias: '', bold: true }
+      })
+      expect(createWikiLinkInlineContent('A', '', {})).toEqual({
+        type: 'wikiLink',
+        props: { target: 'A', alias: '' }
+      })
+    })
+
+    // The narrowing reads this, so it has to agree with `wikiLinkMarkProps`
+    // exactly: a run whose marks are all at their defaults promotes as before.
+    it.each([
+      [{ bold: true }, true],
+      [{ strike: true }, true],
+      [{ underline: true }, true],
+      [{ textColor: 'red' }, true],
+      [{ backgroundColor: 'blue' }, true],
+      [{}, false],
+      [{ bold: false, italic: false }, false],
+      [{ textColor: 'default', backgroundColor: 'default' }, false]
+    ])('hasWikiLinkMarks(%j) is %s', (styles, expected) => {
+      expect(hasWikiLinkMarks(styles)).toBe(expected)
+      expect(hasWikiLinkMarks(undefined)).toBe(false)
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link.tsx
@@ -14,5 +14,8 @@ export {
   wikiLinkToText,
   parseWikiLinkText,
   createWikiLinkInlineContent,
+  hasWikiLinkMarks,
+  wikiLinkMarkProps,
+  type WikiLinkMarkProps,
   type WikiLinkParts
 } from '@memry/editor-schema/inline'

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -18,6 +18,32 @@ The link displays the target's current title, but the underlying reference uses 
 
 Click any wiki link to open the target in a new tab. <kbd>⌘</kbd>+click to open in the background; <kbd>⌥</kbd>+click to open in a split pane.
 
+## Formatting a Link
+
+Format a wiki link on its own — select just the link, or write the formatting around it in
+markdown — and the formatting is kept, on screen and in the vault file:
+
+- `**[[Roadmap]]**` stays bold
+- `*[[Roadmap|the plan]]*` keeps both the alias and the italics
+- strikethrough, inline code, underline and text or highlight colour work the same way
+
+Colour and underline have no markdown syntax, so they are written the way memrynote writes
+every coloured run — as a `<span style="…">` around the link, which Obsidian renders too.
+
+::: warning A link inside a formatted sentence stays plain text
+When the formatting covers more than the link — `~~Cancelled: [[Meeting]]~~`, or
+`**See [[Roadmap]] for details**` — the link is left as plain `[[…]]` text rather than
+turned into a clickable chip. Splitting the formatted run around the link produces markdown
+that neither memrynote nor Obsidian can read back, so the file is left exactly as written
+instead. Put the formatting on the link alone to get the chip.
+:::
+
+::: warning
+Inline code combined with bold, italic or strikethrough on the same link is displayed and
+written correctly, but reading the file back keeps only the code formatting. This is a
+limitation of the markdown parser and applies to ordinary text the same way.
+:::
+
 ## Image Embeds
 
 A wiki link written with a leading `!` and pointing at an image embeds the picture instead

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -20,8 +20,8 @@ Click any wiki link to open the target in a new tab. <kbd>⌘</kbd>+click to ope
 
 ## Formatting a Link
 
-Format a wiki link on its own — select just the link, or write the formatting around it in
-markdown — and the formatting is kept, on screen and in the vault file:
+Write the formatting around the link **in markdown** and it is kept, on screen and in the
+vault file:
 
 - `**[[Roadmap]]**` stays bold
 - `*[[Roadmap|the plan]]*` keeps both the alias and the italics
@@ -30,11 +30,19 @@ markdown — and the formatting is kept, on screen and in the vault file:
 Colour and underline have no markdown syntax, so they are written the way memrynote writes
 every coloured run — as a `<span style="…">` around the link, which Obsidian renders too.
 
+::: warning Formatting applied to an existing link chip is not saved
+Selecting a link chip in the editor and pressing <kbd>⌘</kbd>+<kbd>B</kbd> styles it on
+screen, but the change reaches neither the synced document nor the file — the same is true
+of a link inserted through the `[[` autocomplete inside already-bold text. Formatting is
+carried only when the markdown is written or pasted with the link already inside it, as
+above. Tracked as a known gap.
+:::
+
 ::: warning A link inside a formatted sentence stays plain text
 When the formatting covers more than the link — `~~Cancelled: [[Meeting]]~~`, or
 `**See [[Roadmap]] for details**` — the link is left as plain `[[…]]` text rather than
 turned into a clickable chip. Splitting the formatted run around the link produces markdown
-that neither memrynote nor Obsidian can read back, so the file is left exactly as written
+whose delimiters GFM reads as literal characters, so the file is left exactly as written
 instead. Put the formatting on the link alone to get the chip.
 :::
 

--- a/packages/editor-schema/src/inline/wiki-link.ts
+++ b/packages/editor-schema/src/inline/wiki-link.ts
@@ -29,18 +29,100 @@ export function parseWikiLinkText(text: string): WikiLinkParts | null {
   return { target, alias }
 }
 
-export function createWikiLinkInlineContent(target: string, alias: string) {
+/**
+ * The marks a wiki link can carry, named exactly as BlockNote names them in its
+ * style schema — `bold` / `italic` / `underline` / `strike` / `code` /
+ * `textColor` / `backgroundColor`. That is the whole of `defaultStyleSpecs`;
+ * read it there, not from a brief (it is `strike`, never `strikethrough`, and
+ * `underline` is real).
+ *
+ * They are PROPS rather than styles because BlockNote's data model gives custom
+ * inline content no `styles` field at all — `CustomInlineContentFromConfig` is
+ * `{ type, props, content }`. Promoting `**[[A]]**` into a node therefore had
+ * nowhere to put the bold, and the mark was lost in the shared document before
+ * the vault file was ever written (#1439).
+ */
+export interface WikiLinkMarkProps {
+  bold: boolean
+  italic: boolean
+  underline: boolean
+  strike: boolean
+  code: boolean
+  textColor: string
+  backgroundColor: string
+}
+
+/**
+ * Reads a BlockNote `styles` object as wiki-link mark props, keeping only the
+ * marks that are actually set. Defaults are omitted rather than written out, so
+ * a link promoted from unstyled text is `{ target, alias }` exactly as before.
+ */
+export function wikiLinkMarkProps(
+  styles?: Record<string, unknown> | null
+): Partial<WikiLinkMarkProps> {
+  if (!styles) return {}
+
+  const props: Partial<WikiLinkMarkProps> = {}
+  if (styles.bold === true) props.bold = true
+  if (styles.italic === true) props.italic = true
+  if (styles.underline === true) props.underline = true
+  if (styles.strike === true) props.strike = true
+  if (styles.code === true) props.code = true
+  if (typeof styles.textColor === 'string' && styles.textColor !== 'default') {
+    props.textColor = styles.textColor
+  }
+  if (typeof styles.backgroundColor === 'string' && styles.backgroundColor !== 'default') {
+    props.backgroundColor = styles.backgroundColor
+  }
+  return props
+}
+
+/** Whether a run's styles carry any mark a wiki link would have to take with it. */
+export function hasWikiLinkMarks(styles?: Record<string, unknown> | null): boolean {
+  return Object.keys(wikiLinkMarkProps(styles)).length > 0
+}
+
+export function createWikiLinkInlineContent(
+  target: string,
+  alias: string,
+  styles?: Record<string, unknown> | null
+) {
   return {
     type: 'wikiLink',
-    props: { target, alias: alias ?? '' }
+    props: { target, alias: alias ?? '', ...wikiLinkMarkProps(styles) }
   }
 }
 
+/**
+ * The mark props are ADDITIVE and every one of them has a default, which is the
+ * whole compat plan for a node type already sitting in production documents:
+ *
+ * - A `wikiLink` element persisted by an older build carries no mark attributes
+ *   at all. ProseMirror's `computeAttrs` walks the SCHEMA's attrs and fills a
+ *   default for every key the element lacks, so the node still builds and still
+ *   serializes to `[[target]]` — no migration, no rewrite.
+ * - An older build meeting a node that DOES carry them ignores them the same
+ *   way: `computeAttrs` iterates the schema, so keys it has never heard of are
+ *   dropped on the floor rather than throwing (`_checkAttrs`, which does throw,
+ *   is not on the `NodeType.create` path y-prosemirror uses). The link renders
+ *   as it always has. Editing that paragraph on the old build then strips the
+ *   attributes from the shared doc — y-prosemirror's `updateYFragment` removes
+ *   any Y attribute absent from the ProseMirror node — which lands exactly on
+ *   the pre-#1439 behaviour: the mark is forgotten. A downgrade cannot corrupt,
+ *   only forget.
+ */
 export const wikiLinkConfig = {
   type: 'wikiLink' as const,
   propSchema: {
     target: { default: '' },
-    alias: { default: '' }
+    alias: { default: '' },
+    bold: { default: false },
+    italic: { default: false },
+    underline: { default: false },
+    strike: { default: false },
+    code: { default: false },
+    textColor: { default: 'default' },
+    backgroundColor: { default: 'default' }
   },
   content: 'none' as const
 }
@@ -50,28 +132,81 @@ export function wikiLinkToText(target: string, alias: string): string {
   return alias && alias !== target ? `[[${target}|${alias}]]` : `[[${target}]]`
 }
 
+/**
+ * Outer-to-inner in the order BlockNote nests its OWN marks on a styled text
+ * run — measured, not assumed: a run styled `{bold, italic, strike, code}`
+ * serializes to `<strong><em><s><code>…`, and `{bold, underline}` to
+ * `<strong><u>…`. Matching that order is what makes a marked link serialize
+ * byte-identically to the marked `[[A]]` text it was promoted from.
+ *
+ * `underline` is in the list for the editor chip only: rehype-remark drops
+ * `<u>` on the way to markdown, so underline reaches the vault the same way an
+ * underlined text run does — through the `<span style="text-decoration:…">`
+ * masking in @memry/shared/inline-colors. Colours travel that same road, which
+ * is why no colour is emitted here.
+ */
+const MARK_TAGS: ReadonlyArray<readonly [keyof WikiLinkMarkProps, string]> = [
+  ['bold', 'strong'],
+  ['italic', 'em'],
+  ['underline', 'u'],
+  ['strike', 's'],
+  ['code', 'code']
+]
+
+/**
+ * `text` nested inside the mark elements `props` carries. With no marks set
+ * this is a bare text node, so an unmarked link's DOM — and therefore its
+ * bytes — stay exactly what they are today.
+ */
+function renderMarkedText(text: string, props: Partial<WikiLinkMarkProps>): Node {
+  let node: Node = document.createTextNode(text)
+  for (let i = MARK_TAGS.length - 1; i >= 0; i--) {
+    const [prop, tag] = MARK_TAGS[i]
+    if (props[prop] !== true) continue
+    const el = document.createElement(tag)
+    el.appendChild(node)
+    node = el
+  }
+  return node
+}
+
+type WikiLinkProps = { target: string; alias: string } & Partial<WikiLinkMarkProps>
+
 /** The node's on-disk form. Identical in both processes — this is the contract. */
-const wikiLinkToExternalHTML = (inlineContent: {
-  props: { target: string; alias: string }
-}): { dom: HTMLElement } => {
+const wikiLinkToExternalHTML = (inlineContent: { props: WikiLinkProps }): { dom: HTMLElement } => {
   const dom = document.createElement('span')
-  dom.textContent = wikiLinkToText(
-    inlineContent.props.target || '',
-    inlineContent.props.alias || ''
+  dom.appendChild(
+    renderMarkedText(
+      wikiLinkToText(inlineContent.props.target || '', inlineContent.props.alias || ''),
+      inlineContent.props
+    )
   )
   return { dom }
 }
 
 export const WikiLink = createInlineContentSpec(wikiLinkConfig, {
   render: (inlineContent) => {
+    const props = inlineContent.props as WikiLinkProps
     const dom = document.createElement('span')
     dom.className = 'wiki-link'
     dom.setAttribute('data-wiki-link', '')
-    dom.setAttribute('data-target', inlineContent.props.target || '')
-    dom.setAttribute('data-alias', inlineContent.props.alias || '')
-    dom.setAttribute('title', inlineContent.props.target || '')
+    dom.setAttribute('data-target', props.target || '')
+    dom.setAttribute('data-alias', props.alias || '')
+    dom.setAttribute('title', props.target || '')
     dom.setAttribute('contenteditable', 'false')
-    dom.textContent = inlineContent.props.alias || inlineContent.props.target || ''
+    // BlockNote's own stylesheet keys colours off these two attributes
+    // (`[data-text-color=red]`), so the chip picks up the same palette value
+    // the surrounding text does. Background colour lands; text colour is
+    // currently outranked by `.wiki-link { color: … !important }` in base.css,
+    // which is a stylesheet question, not a data one — the prop still has to be
+    // carried or the colour is deleted from the vault file.
+    if (props.textColor && props.textColor !== 'default') {
+      dom.setAttribute('data-text-color', props.textColor)
+    }
+    if (props.backgroundColor && props.backgroundColor !== 'default') {
+      dom.setAttribute('data-background-color', props.backgroundColor)
+    }
+    dom.appendChild(renderMarkedText(props.alias || props.target || '', props))
 
     return { dom }
   },
@@ -106,7 +241,8 @@ export const WikiLink = createInlineContentSpec(wikiLinkConfig, {
  * `render` emits the same text as `toExternalHTML` rather than throwing:
  * BlockNote serializes inline content inside a TABLE through `render`, so a
  * throwing render made `yDocToMarkdown` return null for any note with a wiki
- * link in a table — that note then stopped writing back entirely.
+ * link in a table — that note then stopped writing back entirely. The marks
+ * ride along in both, or a link in a table cell would lose them.
  */
 export const WikiLinkSerializationOnly: InlineContentSpec<typeof wikiLinkConfig> =
   createInlineContentSpec(wikiLinkConfig, {

--- a/packages/shared/src/inline-colors.ts
+++ b/packages/shared/src/inline-colors.ts
@@ -222,9 +222,10 @@ export function extractInlineColorRuns(blocks: BlockNode[]): {
         }
       }
       if (nodeStyles) {
-        // The node's colours live in its props, which ARE the document — strip
-        // them and the link loses them on the next read. The token spans around
-        // it carry them to disk; its own props carry them in the doc.
+        // Pass the node through untouched. Its colours live in its props, and
+        // this function builds a new array for the serialization copy — the
+        // props are the document's own record, while the token spans emitted
+        // around the node are what carries the colour to disk.
         out.push(item)
       } else {
         const {

--- a/packages/shared/src/inline-colors.ts
+++ b/packages/shared/src/inline-colors.ts
@@ -45,6 +45,7 @@ interface InlineNode {
   text?: string
   content?: InlineNode[]
   styles?: Record<string, unknown>
+  props?: Record<string, unknown>
 }
 
 interface BlockNode {
@@ -81,6 +82,16 @@ function pickColorStyles(styles: Record<string, unknown>): InlineColorStyles | n
     colors.backgroundColor = styles.backgroundColor
   }
   return colors.textColor || colors.backgroundColor ? colors : null
+}
+
+// `default` is BlockNote's "no colour" value, so a node whose props sit at
+// their schema defaults is not coloured and must not be wrapped in anything.
+function hasColorOrUnderline(props: Record<string, unknown>): boolean {
+  return (
+    (typeof props.textColor === 'string' && props.textColor !== 'default') ||
+    (typeof props.backgroundColor === 'string' && props.backgroundColor !== 'default') ||
+    props.underline === true
+  )
 }
 
 // Palette values are plain names; reject anything that could break out of the
@@ -165,8 +176,19 @@ export function extractInlineColorRuns(blocks: BlockNode[]): {
         }
         continue
       }
+      // A custom inline node (`wikiLink`) carries its marks in `props`: BlockNote
+      // gives custom inline content no `styles` field at all. Colour and
+      // underline are the marks markdown cannot express, so the node reaches
+      // disk down the same road a coloured text run does — wrapped in token
+      // spans — while bold/italic/strike/code ride its own toExternalHTML.
+      const nodeStyles =
+        typeof item.text !== 'string' && item.props && hasColorOrUnderline(item.props)
+          ? item.props
+          : null
       const styled =
-        typeof item.text === 'string' && item.text.length > 0 && item.styles ? item.styles : null
+        typeof item.text === 'string' && item.text.length > 0 && item.styles
+          ? item.styles
+          : nodeStyles
       const picked = styled ? pickColorStyles(styled) : null
       // An unsafe color value drops only the color span — underline is a
       // hardcoded literal, so it still round-trips on the same run.
@@ -199,13 +221,20 @@ export function extractInlineColorRuns(blocks: BlockNode[]): {
           closeUnderline()
         }
       }
-      const {
-        textColor: _t,
-        backgroundColor: _b,
-        underline: _u,
-        ...rest
-      } = styled as InlineColorStyles & Record<string, unknown>
-      out.push({ ...item, styles: rest })
+      if (nodeStyles) {
+        // The node's colours live in its props, which ARE the document — strip
+        // them and the link loses them on the next read. The token spans around
+        // it carry them to disk; its own props carry them in the doc.
+        out.push(item)
+      } else {
+        const {
+          textColor: _t,
+          backgroundColor: _b,
+          underline: _u,
+          ...rest
+        } = styled as InlineColorStyles & Record<string, unknown>
+        out.push({ ...item, styles: rest })
+      }
       changed = true
     }
     closeGroup()


### PR DESCRIPTION
Closes #1439 with the **narrowed** version of option 2 — Kaan's call.

## The bug, restated

`normalizeWikiLinks` promotes `[[X]]` text into a `wikiLink` node. BlockNote's `CustomInlineContentFromConfig` has no `styles` field, so the mark had nowhere to go and was dropped **in the renderer, in the shared document**. Main then faithfully wrote the unmarked form. Measured on `main` with the promotion removed as a control (control flat in every row):

| on disk | `main` today | this PR |
|---|---|---|
| `**[[Meeting]]**` | `[[Meeting]]` — bold deleted | `**[[Meeting]]**` |
| `~~[[Meeting]]~~` | `[[Meeting]]` — strike deleted | `~~[[Meeting]]~~` |
| `*[[A]]*` | `[[A]]` — italic deleted | `*[[A]]*` |
| `~~Cancelled: [[Meeting]]~~` | `~~Cancelled: ~~[[Meeting]]` — four literal tildes | `~~Cancelled: [[Meeting]]~~` |
| `[[A]]` | `[[A]]` | `[[A]]` |

Flat over six passes, `atomicWrites === []` — no write at all, not merely identical bytes.

## Why narrowed, and not plain option 2

Plain option 2 (always carry the marks) was implemented first and rejected: the node emits its own mark wrapper, BlockNote cannot merge marks across an element boundary, and a link inside a longer marked phrase produced GFM-invalid markdown that **grew on every pass** (`26→30→34→38→42→46`, never converging).

So marks are carried **only when the link covers the entire styled run**. Inside a longer marked phrase the link is not promoted at all — it stays literal `[[…]]` text. Cost: no chip there. That case already wrote broken markdown today, so it is strictly better.

## The release bar

Unmarked wiki links must be byte-identical to the parent. Review built a 40-fixture unmarked corpus and diffed against a real parent worktree: **39 byte-identical, 1 improvement** (`` a `[[A]]` b `` no longer has its backticks deleted). Every fixture that moves on this branch moves identically on the parent.

## Compat — verified against the parent's real code

This is a propSchema change on a node type already in production documents. Additive props with defaults, no migration:

- **Old doc → new build:** missing attrs get defaults; bytes unchanged; `findUnrepresentableNodes` empty; the read leaves the doc byte-identical.
- **New props → old build:** run against the parent's actual code in a worktree, on a fragment this build wrote with `bold="true" textColor="red"` — **no throw, node not deleted**, reads back `{target, alias}`, serializes to the pre-#1439 bytes.
- **Old build edits the paragraph:** `updateYFragment` strips the unknown attrs — the mark is forgotten, never corrupted.

## Review findings, addressed

- **The docs promised a path the build does not have.** Proven on a real mounted editor: selecting a chip and toggling bold puts a ProseMirror mark on the node, but `editor.document` still says `bold:false` and the Y fragment still says `bold="false"`. Same for the `[[` autocomplete inside bold text, and for copy/paste. Marks are carried only when the markdown is written or pasted with the link already inside the formatting. Documented as the known gap it is, rather than left as a promise.
- The guard's `match.index !== 0` was a dead condition; removed.
- An `inline-colors.ts` comment described a mutation that does not happen; corrected.

## Known, tracked, not fixed here

- **Adjacent-run delimiter escaping.** `**[[A]]*b***` → `**[[A]]*****b***`, which GFM renders as literal asterisks. The narrowing eliminates *intra-run* splits only; it does not look at the neighbouring run. Verified **pre-existing and wiki-link-independent** — the control `**x*b***` → `**x*****x***` is byte-identical on both branches — but this PR newly routes marked links into it. Converges after one rewrite. The parent loses the mark instead and stays clean, so for this narrow shape the parent's output is tidier.
- **Yjs growth.** Every `wikiLink` now writes 9 attrs, 7 of them defaults: 50 unmarked links `3951 → 11596` bytes, a one-time ~2.9×. `default: null` would fix it (`updateYFragment` skips null attrs) but BlockNote's `PropSpec` type collapses `Props<typeof wikiLinkConfig>` to `never` under the required cast. Worth a follow-up with that constraint stated.
- **Text colour on a link is dead CSS** — `base.css`'s `.wiki-link { color: … !important }` outranks BlockNote's `[data-text-color]`. The prop is still carried, or the colour would be deleted from the file. Background colour does render.
- ``**`[[A]]`**`` flattens to `` `[[A]]` `` — BlockNote's markdown parser drops emphasis off any run carrying inline code, pre-existing and true of ordinary text.

## Verification

- `test:main` — 513 files / 6527 tests
- `test:renderer` — 611 files / 7048 tests
- `@memry/editor-schema` — 41 · typecheck 17/17 · architecture + contracts
- eslint 0 · docs gate covered · `docs:build` clean

The pinned regressions in `note-open-byte-stability.test.ts` that asserted the marks are deleted are **inverted, not removed** — coverage goes 5 → 6 cases.
