### PR TITLE
fix(sync): key the CRDT rate limits per device and size the pull budget for a sweep

### DIFF
--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -539,6 +539,22 @@ them, and every client version already applies the snapshot as its baseline befo
 incrementals. If that fallback fails the push rejects, leaving the batch buffered for the next flush
 and — on quit — recorded for replay. No path discards an update.
 
+### CRDT rate limits
+
+The three CRDT limiters (`crdt_push`, `crdt_pull`, `crdt_batch_pull`) key their buckets by
+**deviceId**, not by account. Body sync is device-local work: each device pulls the note bodies it
+does not already hold, so a second device on the same account is normal use rather than contention.
+Under the default per-user key the two devices split one budget, and a legitimate first sync on
+device B made device A's ordinary syncing start failing with 429s. A request that arrives without a
+deviceId keeps the existing userId → IP fallback, so nothing becomes less strict.
+
+`crdt_pull` allows 600 requests per 60 seconds, which is sized for one device pulling an entire
+vault's bodies after a fresh sign-in. That sweep costs two GETs per note — snapshot plus
+incrementals — so a 121-note vault spends roughly 242 requests within a few seconds, and the ceiling
+leaves room for a vault twice that size plus the editing traffic running alongside it. The client
+paces and batches the sweep itself; this limit is the safety margin for when that pacing is wrong or
+missing, not the mechanism that shapes the traffic.
+
 ### Server base URL
 
 Every path above is appended to a single resolved base URL. `resolveSyncServerUrl()`

--- a/apps/sync-server/src/middleware/rate-limit.test.ts
+++ b/apps/sync-server/src/middleware/rate-limit.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { AppError } from '../lib/errors'
 
-import { createRateLimiter } from './rate-limit'
+import { createRateLimiter, deviceIdentifier } from './rate-limit'
 
 // ============================================================================
 // Hono context / D1 mock helpers
@@ -208,5 +208,135 @@ describe('createRateLimiter', () => {
       expect.any(Number),
       expect.any(Number)
     )
+  })
+})
+
+// ============================================================================
+// Stateful D1 stand-in — the fixed-count mock above cannot show one caller
+// spending another caller's budget, which is the whole point of a bucket key.
+// ============================================================================
+
+interface RateLimitRow {
+  count: number
+  window_start: number
+}
+
+interface RecordingStatement {
+  args: unknown[]
+  bind: (...args: unknown[]) => RecordingStatement
+}
+
+const createRateLimitDb = () => {
+  const rows = new Map<string, RateLimitRow>()
+
+  const prepare = vi.fn(() => {
+    const stmt: RecordingStatement = {
+      args: [],
+      bind: (...args: unknown[]) => {
+        stmt.args = args
+        return stmt
+      }
+    }
+    return stmt
+  })
+
+  const batch = vi.fn(async (stmts: RecordingStatement[]) => {
+    const [insert, select] = stmts
+    const [key, now, windowStart] = insert.args as [string, number, number]
+    const existing = rows.get(key)
+    if (!existing || existing.window_start < windowStart) {
+      rows.set(key, { count: 1, window_start: now })
+    } else {
+      existing.count += 1
+    }
+    const row = rows.get(select.args[0] as string)
+    return [{ success: true }, { results: row ? [row] : [] }]
+  })
+
+  return { db: { prepare, batch }, rows }
+}
+
+const createDeviceContext = (
+  db: ReturnType<typeof createRateLimitDb>['db'],
+  vars: { userId?: string; deviceId?: string }
+) => {
+  const headers: Record<string, string> = {}
+  const c = {
+    env: { DB: db },
+    get: vi.fn((key: string) => (key === 'userId' ? vars.userId : vars.deviceId)),
+    req: {
+      header: vi.fn((name: string) => (name === 'CF-Connecting-IP' ? '1.2.3.4' : undefined))
+    },
+    header: vi.fn((name: string, value: string) => {
+      headers[name] = value
+    }),
+    _headers: headers
+  }
+  return { c, next: vi.fn().mockResolvedValue(undefined) }
+}
+
+// ============================================================================
+// Tests: deviceIdentifier
+// ============================================================================
+
+describe('deviceIdentifier', () => {
+  const limiterOptions = {
+    maxRequests: 3,
+    windowSeconds: 60,
+    keyPrefix: 'crdt_pull',
+    identifier: deviceIdentifier
+  }
+
+  it('should give two devices on the same account independent budgets', async () => {
+    // #given — device A spends its entire budget on a legitimate body sweep
+    const { db, rows } = createRateLimitDb()
+    const middleware = createRateLimiter(limiterOptions)
+    for (let i = 0; i < 3; i++) {
+      const { c, next } = createDeviceContext(db, { userId: 'user-1', deviceId: 'device-a' })
+      await middleware(c as never, next)
+    }
+    const exhausted = createDeviceContext(db, { userId: 'user-1', deviceId: 'device-a' })
+    await expect(middleware(exhausted.c as never, exhausted.next)).rejects.toThrow(AppError)
+
+    // #when — device B on the SAME account makes its first request
+    const deviceB = createDeviceContext(db, { userId: 'user-1', deviceId: 'device-b' })
+    await middleware(deviceB.c as never, deviceB.next)
+
+    // #then — device B is untouched by device A's spending
+    expect(deviceB.next).toHaveBeenCalled()
+    expect(deviceB.c._headers['X-RateLimit-Remaining']).toBe('2')
+    expect([...rows.keys()].sort()).toEqual([
+      'crdt_pull:device:device-a',
+      'crdt_pull:device:device-b'
+    ])
+  })
+
+  it('should fall back to the user bucket when the request has no deviceId', async () => {
+    // #given
+    const { db, rows } = createRateLimitDb()
+    const middleware = createRateLimiter(limiterOptions)
+    const { c, next } = createDeviceContext(db, { userId: 'user-1' })
+
+    // #when
+    await middleware(c as never, next)
+
+    // #then — the userId/IP chain still applies; no invented placeholder key
+    expect(next).toHaveBeenCalled()
+    expect([...rows.keys()]).toEqual(['crdt_pull:user-1'])
+  })
+
+  it('should not collapse deviceless requests from different users into one bucket', async () => {
+    // #given
+    const { db, rows } = createRateLimitDb()
+    const middleware = createRateLimiter(limiterOptions)
+
+    // #when — two accounts, neither carrying a deviceId
+    for (const userId of ['user-1', 'user-2']) {
+      const { c, next } = createDeviceContext(db, { userId })
+      await middleware(c as never, next)
+    }
+
+    // #then
+    expect([...rows.keys()].sort()).toEqual(['crdt_pull:user-1', 'crdt_pull:user-2'])
   })
 })

--- a/apps/sync-server/src/middleware/rate-limit.ts
+++ b/apps/sync-server/src/middleware/rate-limit.ts
@@ -15,6 +15,18 @@ export interface RateLimitOptions {
   identifier?: (c: Context<AppContext>) => Promise<string | null> | string | null
 }
 
+// Keys a bucket by the requesting device instead of the account. A second
+// device on the same account is normal use, not contention: with a per-user
+// bucket, a legitimate sign-in sweep on device B spent device A's budget and
+// both devices started collecting 429s for work neither of them did wrong.
+// Returns null when the request carries no deviceId so the userId/IP chain in
+// the limiter still applies — a placeholder key would put every anonymous
+// request into one shared bucket, which is worse than the per-user default.
+export const deviceIdentifier = (c: Context<AppContext>): string | null => {
+  const deviceId = c.get('deviceId')
+  return deviceId ? `device:${deviceId}` : null
+}
+
 export const createRateLimiter = (options: RateLimitOptions): MiddlewareHandler<AppContext> => {
   const { maxRequests, windowSeconds, keyPrefix } = options
 
@@ -44,8 +56,7 @@ export const createRateLimiter = (options: RateLimitOptions): MiddlewareHandler<
     ])
 
     const row = (result[1] as D1Result).results?.[0] as
-      | { count: number; window_start: number }
-      | undefined
+      { count: number; window_start: number } | undefined
     const count = row?.count ?? 0
 
     if (count > maxRequests) {

--- a/apps/sync-server/src/routes/diagnostics.test.ts
+++ b/apps/sync-server/src/routes/diagnostics.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('../middleware/rate-limit', () => ({
+vi.mock('../middleware/rate-limit', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../middleware/rate-limit')>()),
   createRateLimiter: vi.fn(() => async (_c: unknown, next: () => Promise<void>) => next())
 }))
 

--- a/apps/sync-server/src/routes/feedback.test.ts
+++ b/apps/sync-server/src/routes/feedback.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
-vi.mock('../middleware/rate-limit', () => ({
+vi.mock('../middleware/rate-limit', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../middleware/rate-limit')>()),
   createRateLimiter: vi.fn(() => async (_c: unknown, next: () => Promise<void>) => next())
 }))
 

--- a/apps/sync-server/src/routes/sync.test.ts
+++ b/apps/sync-server/src/routes/sync.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { AppError, ErrorCodes, errorHandler } from '../lib/errors'
 import { LEGACY_RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+import { deviceIdentifier, type RateLimitOptions } from '../middleware/rate-limit'
 import type { AppContext } from '../types'
 
 // ============================================================================
@@ -96,13 +97,25 @@ vi.mock('../middleware/paid-sync', () => ({
   })
 }))
 
-vi.mock('../middleware/rate-limit', () => ({
-  createRateLimiter: vi.fn().mockReturnValue(
-    vi.fn().mockImplementation(async (_c: any, next: any) => {
-      await next()
-    })
-  )
+// Records what each limiter was built with. The array is plain state, so it
+// survives the vi.clearAllMocks() below — the limiters are created once, at
+// module load, long before any test runs.
+const { rateLimiterOptions } = vi.hoisted(() => ({
+  rateLimiterOptions: [] as RateLimitOptions[]
 }))
+
+vi.mock('../middleware/rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../middleware/rate-limit')>()
+  return {
+    ...actual,
+    createRateLimiter: vi.fn().mockImplementation((options: RateLimitOptions) => {
+      rateLimiterOptions.push(options)
+      return vi.fn().mockImplementation(async (_c: any, next: any) => {
+        await next()
+      })
+    })
+  }
+})
 
 vi.mock('../services/storage', () => ({
   getStorageBreakdown: vi.fn().mockResolvedValue({
@@ -1475,5 +1488,36 @@ describe('sync routes', () => {
       // #then
       expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 0, undefined, 'vault-1', ['note'])
     })
+  })
+})
+
+// ============================================================================
+// CRDT rate limit wiring
+//
+// The limiter itself is mocked out in this file, so its behaviour is covered in
+// middleware/rate-limit.test.ts. What is asserted here is the wiring: which
+// bucket key each CRDT route was built with, and how big the pull budget is.
+// ============================================================================
+
+describe('CRDT rate limit wiring', () => {
+  const optionsFor = (keyPrefix: string) =>
+    rateLimiterOptions.find((o) => o.keyPrefix === keyPrefix)
+
+  it('keys every CRDT limiter by device, not by account', () => {
+    // #then — a second device on one account is normal use, not contention
+    for (const keyPrefix of ['crdt_push', 'crdt_pull', 'crdt_batch_pull']) {
+      expect(optionsFor(keyPrefix)?.identifier).toBe(deviceIdentifier)
+    }
+  })
+
+  it('gives the CRDT pull budget room for a whole-vault body sweep', () => {
+    // #then — two GETs per note, so ~242 requests for a 121-note vault
+    expect(optionsFor('crdt_pull')).toMatchObject({ maxRequests: 600, windowSeconds: 60 })
+  })
+
+  it('leaves the non-CRDT limiters keyed by the default user/IP chain', () => {
+    // #then — out of scope for this change
+    expect(optionsFor('sync_pull')?.identifier).toBeUndefined()
+    expect(optionsFor('sync_push')?.identifier).toBeUndefined()
   })
 })

--- a/apps/sync-server/src/routes/sync.ts
+++ b/apps/sync-server/src/routes/sync.ts
@@ -7,7 +7,7 @@ import { safeBase64Decode } from '../lib/encoding'
 import { AppError, ErrorCodes } from '../lib/errors'
 import { authMiddleware } from '../middleware/auth'
 import { paidSyncMiddleware } from '../middleware/paid-sync'
-import { createRateLimiter } from '../middleware/rate-limit'
+import { createRateLimiter, deviceIdentifier } from '../middleware/rate-limit'
 import { syncTypesMiddleware } from '../middleware/sync-types'
 import {
   getChanges,
@@ -467,22 +467,37 @@ const NoteIdSchema = z
   .regex(/^[a-zA-Z0-9_-]+$/)
   .max(128)
 
+// The CRDT budgets are per device, not per account. Body sync is device-local
+// work: each device pulls the note bodies it does not have yet, and a second
+// device on the same account is normal use rather than contention. Under the
+// default per-user bucket the two devices split one budget, so signing in on
+// device B made device A's ordinary syncing start failing with 429s. Requests
+// without a deviceId keep the userId/IP fallback, so nothing gets less strict.
 const crdtPushRateLimit = createRateLimiter({
   keyPrefix: 'crdt_push',
   maxRequests: 300,
-  windowSeconds: 60
+  windowSeconds: 60,
+  identifier: deviceIdentifier
 })
 
+// Sized for one device pulling an entire vault's bodies after a fresh sign-in.
+// That sweep costs two GETs per note (snapshot + updates), so a 121-note vault
+// spends ~242 requests in a few seconds; 600/min leaves room for a vault twice
+// that size plus the normal editing traffic running alongside it. The client
+// paces and batches its sweep, so treat this ceiling as the safety margin for
+// when that pacing is wrong or missing, not as the thing shaping the traffic.
 const crdtPullRateLimit = createRateLimiter({
   keyPrefix: 'crdt_pull',
-  maxRequests: 300,
-  windowSeconds: 60
+  maxRequests: 600,
+  windowSeconds: 60,
+  identifier: deviceIdentifier
 })
 
 const crdtBatchPullRateLimit = createRateLimiter({
   keyPrefix: 'crdt_batch_pull',
   maxRequests: 30,
-  windowSeconds: 60
+  windowSeconds: 60,
+  identifier: deviceIdentifier
 })
 
 const CrdtBatchPullSchema = z.object({

--- a/apps/sync-server/src/routes/telemetry-identity.test.ts
+++ b/apps/sync-server/src/routes/telemetry-identity.test.ts
@@ -8,7 +8,8 @@
 import { exportPKCS8, exportSPKI, generateKeyPair, importPKCS8, SignJWT } from 'jose'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
-vi.mock('../middleware/rate-limit', () => ({
+vi.mock('../middleware/rate-limit', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../middleware/rate-limit')>()),
   createRateLimiter: vi.fn(() => async (_c: unknown, next: () => Promise<void>) => next())
 }))
 

--- a/apps/sync-server/src/routes/telemetry.test.ts
+++ b/apps/sync-server/src/routes/telemetry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('../middleware/rate-limit', () => ({
+vi.mock('../middleware/rate-limit', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../middleware/rate-limit')>()),
   createRateLimiter: vi.fn(() => async (_c: unknown, next: () => Promise<void>) => next())
 }))
 


### PR DESCRIPTION
## Problem

A device signing in runs a vault-wide CRDT sweep — the only way a body-only edit made while it was disconnected is ever discovered. Today that costs 2 GETs per note (`snapshot/:noteId` + `updates`), so a 121-note vault fires ~242 requests in about four seconds.

Both routes share `crdtPullRateLimit`: 300 requests / 60s. And `createRateLimiter` keys its bucket by **`userId`**, so two devices on one account halve each other's budget while doing entirely legitimate, independent work. Real device logs: **92 of 121 notes** came back `Too many requests` in a single sweep, 1442 occurrences overall.

## Changes

**Key the CRDT limiters by device.** New `deviceIdentifier` helper using the `identifier` override `createRateLimiter` already supports (the linking routes use it); `deviceId` is already on the context from `authMiddleware`. Applied to `crdt_push`, `crdt_pull` and `crdt_batch_pull`. A request without a `deviceId` returns `null` so the existing `userId → IP` fallback still runs — a placeholder key would collapse every deviceless request into one shared bucket, which is worse than the per-user default. Non-CRDT limiters are untouched.

**Raise `crdt_pull` from 300 to 600 / 60s.** Sized for one device pulling a whole vault's bodies after a fresh sign-in, with room for a vault twice that size plus concurrent editing traffic.

Note this ceiling is a **safety margin, not the mechanism**. The client is separately being changed to pace and batch its sweep so that cost-per-minute is constant in vault size; without that, no fixed ceiling works, because a vault of N+1 notes always breaks a limit set for N.

## Verification

- 62 files / **947 tests pass** (baseline on main: 941).
- `pnpm typecheck` 17/17. `git diff --check` clean. Note `apps/sync-server` is eslint-ignored by the root `lint` script, so these files were linted directly with eslint + prettier instead.
- **6 new tests, each individually mutation-verified** — 4 mutations run, every new test killed by at least one, none passing both before and after.
- `docs:impact --strict` covered, `docs:build` passes.

The behavioural proof lives in `middleware/rate-limit.test.ts`, not `routes/sync.test.ts` — the latter mocks the limiter out entirely and can only assert wiring. The existing D1 mock returns a fixed count and structurally cannot show one caller spending another's budget, so the new tests run against a stateful stand-in that reproduces the `ON CONFLICT ... CASE WHEN window_start <` semantics.

## Compatibility

No migration. Existing per-user rows in `rate_limits` simply go stale and age out with the window; new `crdt_*:device:<id>` rows start alongside them. Old clients send the same JWT and get a `deviceId` either way, so nothing gets stricter for anyone.

Deploy order: sync-server before desktop, as usual. This PR is safe to deploy on its own and gives immediate relief before the client change lands.

## Open question for review

`crdt_batch_pull` stays at 30 / 60s. The paced client sweep works out to ~4 batch POSTs per minute per device, so it fits — but that number was checked against the client change in the companion PR, not chosen here.