### PR TITLE
fix(crdt): pace the vault-wide CRDT sweep and pay its failures

### DIFF
--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
@@ -380,6 +380,8 @@ describe('CrdtSyncCoordinator', () => {
     const open = vi.fn().mockResolvedValue({})
     const ctx = {
       deps: {
+        getAccessToken: vi.fn(async () => 'token-1'),
+        getVaultKey: vi.fn(async () => new Uint8Array([9])),
         crdtProvider: {
           inactiveDocCapacity: 32,
           getDoc: vi.fn().mockReturnValue(undefined),
@@ -395,6 +397,109 @@ describe('CrdtSyncCoordinator', () => {
 
     return { ctx, open }
   }
+
+  // A rate limit is what the desktop actually hits: the vault-wide sweep used to
+  // fire two GETs per note, so 121 notes meant 242 requests in about four
+  // seconds against a limit of 300/60s shared with the account's other devices,
+  // and 92 of those notes came back "Too many requests".
+  const rateLimited = (): Error => {
+    const err = new Error('Too many requests')
+    err.name = 'RateLimitError'
+    return err
+  }
+
+  it('re-queues every note in a chunk the server rate-limited', async () => {
+    // #given the batch POST for the chunk is refused
+    const { ctx } = createBatchContext()
+    postToServerMock.mockRejectedValue(rateLimited())
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.applyCrdtBatch(['note-1', 'note-2'], 'token-1', new Uint8Array([4]))
+
+    // #then the chunk failed as a unit, so every note in it is owed a retry.
+    // Dropping them (a log.warn and nothing else) left those bodies stale until
+    // the NEXT vault-wide sweep — a 60s reconnect floor or a 15-minute interval
+    // away — and opening the note did not help, because that reads main's Y.Doc
+    // rather than the server.
+    expect(coordinator.drainPendingPulls()).toEqual(['note-1', 'note-2'])
+  })
+
+  it('re-queues only the note whose snapshot baseline was rate-limited', async () => {
+    // #given note-2's baseline is refused; note-1 and note-3 are fine
+    const { ctx } = createBatchContext()
+    fetchCrdtSnapshotMock
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(rateLimited())
+      .mockResolvedValueOnce(null)
+    postToServerMock.mockResolvedValue({
+      notes: {
+        'note-1': { updates: [], hasMore: false },
+        'note-3': { updates: [], hasMore: false }
+      }
+    })
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.applyCrdtBatch(['note-1', 'note-2', 'note-3'], 'token-1', new Uint8Array([4]))
+
+    // #then the baselines are still one GET per note even on the batch path, so
+    // they are the bulk of a sweep's requests and the first thing a rate limit
+    // sheds. Only the note that actually failed is owed — re-queueing the whole
+    // chunk would re-pull notes that already succeeded.
+    expect(coordinator.drainPendingPulls()).toEqual(['note-2'])
+  })
+
+  it('re-queues a single-note pull the server rate-limited', async () => {
+    // #given the `crdt_updated` / open-editor path, not the sweep
+    const { ctx } = createBatchContext()
+    getFromServerMock.mockRejectedValue(rateLimited())
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4]))
+
+    // #then the debt is not batch-specific: any pull that did not complete owes
+    // the note to the next cycle. Retrying in place is what `retryOn429: false`
+    // exists to prevent — three Retry-Afters of up to 60s inside a serial loop
+    // stalls every remaining note behind one.
+    expect(coordinator.drainPendingPulls()).toEqual(['note-1'])
+  })
+
+  it('owes the whole group when a batch pull cannot get credentials', async () => {
+    // #given a sign-out / locked-vault window mid-sweep
+    const { ctx } = createBatchContext()
+    ;(ctx.deps.getAccessToken as ReturnType<typeof vi.fn>).mockResolvedValue(null)
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.pullCrdtForNotes(['note-1', 'note-2'])
+
+    // #then the sweep hands this method the whole vault; returning silently
+    // would strand every stale body until the next sweep.
+    expect(coordinator.drainPendingPulls()).toEqual(['note-1', 'note-2'])
+  })
+
+  it('batches a pull issued outside a sync cycle, when the engine holds no abort controller', async () => {
+    // #given the paced sweep runs between cycles, and the engine only holds an
+    // AbortController for the duration of a pull or a push
+    const { ctx } = createBatchContext()
+    ;(ctx as unknown as { abortController: AbortController | null }).abortController = null
+    postToServerMock.mockResolvedValue({ notes: { 'note-1': { updates: [], hasMore: false } } })
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.pullCrdtForNotes(['note-1'])
+
+    // #then reading ctx.abortController unconditionally made every out-of-cycle
+    // batch return having done nothing, which would have made the whole paced
+    // sweep a silent no-op.
+    expect(postToServerMock).toHaveBeenCalledWith(
+      '/sync/crdt/updates/batch',
+      { notes: [{ noteId: 'note-1', since: 0 }], limit: 100 },
+      'token-1'
+    )
+  })
 
   it('does not retry 429s inside the serial pull loop', async () => {
     // #given a normal batch pass

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -32,6 +32,27 @@ export class CrdtSyncCoordinator {
     this.pendingPulls.add(noteId)
   }
 
+  /**
+   * Re-queue a note whose pull did not complete, so the NEXT cycle retries it.
+   *
+   * Every failure path below used to end at a `log.warn`, which meant a note the
+   * server rate-limited kept its stale body until the next vault-wide sweep —
+   * gated at a 60s reconnect floor or a 15-minute interval — and opening the
+   * note did not help, because that reads main's Y.Doc rather than the server.
+   * A whole-vault sweep that trips the limit therefore lost most of its notes
+   * silently.
+   *
+   * The debt is deliberately paid by the next cycle rather than in place. The
+   * pull loops are serial and run with `retryOn429: false` on purpose: honouring
+   * a `Retry-After` of up to 60s three times over would stall every remaining
+   * note in the pass on one rate-limited note. Nor is this failure-kind-specific
+   * — a transient 5xx, an unreachable server and a 429 all leave the same stale
+   * body, and "failed, so retry next cycle" needs no taxonomy to be correct.
+   */
+  private owePendingPull(noteId: string): void {
+    this.pendingPulls.add(noteId)
+  }
+
   drainPendingPulls(): string[] {
     const ids = Array.from(this.pendingPulls)
     this.pendingPulls.clear()
@@ -187,6 +208,7 @@ export class CrdtSyncCoordinator {
         noteId,
         error: err instanceof Error ? err.message : String(err)
       })
+      this.owePendingPull(noteId)
       // Persistent note-body divergence (stale bodies across devices)
       // otherwise never reaches telemetry.
       if (!this.applyFailureReported.has(noteId)) {
@@ -200,9 +222,20 @@ export class CrdtSyncCoordinator {
     }
   }
 
-  async applyCrdtBatch(noteIds: string[], token: string, vaultKey: Uint8Array): Promise<void> {
+  async applyCrdtBatch(
+    noteIds: string[],
+    token: string,
+    vaultKey: Uint8Array,
+    signal?: AbortSignal
+  ): Promise<void> {
     const crdtProvider = this.ctx.deps.crdtProvider
-    if (!crdtProvider || !this.ctx.abortController) return
+    // The engine only holds an AbortController for the duration of a pull or a
+    // push, so a caller outside one (the paced sweep) has to bring its own —
+    // exactly as `pullCrdtForNote` does for the single-note path. Reading
+    // `ctx.abortController` unconditionally here made every out-of-cycle batch
+    // return without doing anything.
+    const effectiveSignal = signal ?? this.ctx.abortController?.signal
+    if (!crdtProvider || !effectiveSignal) return
 
     // A pass holds every one of its notes open from before the request is sent
     // until that note's updates are applied, so it must never open more than
@@ -216,18 +249,24 @@ export class CrdtSyncCoordinator {
     // /sync/crdt/updates/batch, which a whole-vault pass otherwise blows past.
     const chunkSize = crdtProvider.inactiveDocCapacity
     for (let i = 0; i < noteIds.length; i += chunkSize) {
-      if (this.ctx.abortController.signal.aborted) return
-      await this.applyCrdtBatchChunk(noteIds.slice(i, i + chunkSize), token, vaultKey)
+      if (effectiveSignal.aborted) return
+      await this.applyCrdtBatchChunk(
+        noteIds.slice(i, i + chunkSize),
+        token,
+        vaultKey,
+        effectiveSignal
+      )
     }
   }
 
   private async applyCrdtBatchChunk(
     noteIds: string[],
     token: string,
-    vaultKey: Uint8Array
+    vaultKey: Uint8Array,
+    signal: AbortSignal
   ): Promise<void> {
     const crdtProvider = this.ctx.deps.crdtProvider
-    if (!crdtProvider || !this.ctx.abortController) return
+    if (!crdtProvider) return
 
     const syncOpenedNoteIds = new Set<string>()
     try {
@@ -252,11 +291,15 @@ export class CrdtSyncCoordinator {
         } catch (err) {
           if (err instanceof DOMException && err.name === 'AbortError') throw err
           // A single note's baseline failure must not abandon every note left in
-          // the pass. Skip it; the next pass retries it.
+          // the pass. Skip it; the next pass retries it — which only holds
+          // because it is re-queued here. This is the hottest failure path under
+          // a rate limit: the baselines are one GET per note, so they are the
+          // bulk of a sweep's requests and the first thing the server sheds.
           log.warn('Failed to apply CRDT snapshot baseline, skipping note in batch', {
             noteId,
             error: err instanceof Error ? err.message : String(err)
           })
+          this.owePendingPull(noteId)
         }
       }
 
@@ -265,7 +308,7 @@ export class CrdtSyncCoordinator {
       const activeSince = new Map(sinceMap)
 
       while (activeSince.size > 0) {
-        if (this.ctx.abortController.signal.aborted) return
+        if (signal.aborted) return
 
         const notes = Array.from(activeSince, ([noteId, since]) => ({ noteId, since }))
 
@@ -279,7 +322,7 @@ export class CrdtSyncCoordinator {
           {
             maxRetries: 3,
             baseDelayMs: 2000,
-            signal: this.ctx.abortController.signal,
+            signal,
             retryOn429: false
           }
         ).then((r) => r.value)
@@ -353,6 +396,9 @@ export class CrdtSyncCoordinator {
       log.warn('Failed to apply CRDT batch', {
         error: err instanceof Error ? err.message : String(err)
       })
+      // The chunk failed as a unit (a rate-limited or dead-lettered batch POST
+      // takes every note in it), so every note in it is owed a retry.
+      for (const noteId of noteIds) this.owePendingPull(noteId)
       // One undecryptable update aborts the remaining notes in the pass —
       // engine-level sync_run_completed still reports success without this.
       if (!this.applyFailureReported.has('__batch__')) {
@@ -378,6 +424,49 @@ export class CrdtSyncCoordinator {
     try {
       await this.applyCrdtIncrementals(noteId, token, vaultKey, localAbort.signal)
       log.debug('pullCrdtForNote completed', { noteId })
+    } finally {
+      secureCleanup(vaultKey)
+    }
+  }
+
+  /**
+   * Group sibling of `pullCrdtForNote`, and the entry point the vault-wide
+   * sweep uses.
+   *
+   * The single-note path costs two HTTP GETs per note (snapshot baseline, then
+   * incrementals), which is what turned a 121-note sweep into 242 requests in
+   * about four seconds. This path shares one incrementals POST across the whole
+   * group, so the same 121 notes cost roughly 125 requests — the snapshot
+   * baselines are still one GET per note inside `applyCrdtBatch`, so this halves
+   * the traffic rather than collapsing it to a handful of calls. Pacing, not
+   * batching, is what actually keeps a sweep under the limit; see
+   * CRDT_SWEEP_CHUNK_NOTES.
+   *
+   * Credentials are resolved once per group instead of once per note, which also
+   * removes a keychain read per note. A group that cannot get them is owed a
+   * retry rather than dropped: the sweep hands this method the whole vault, so
+   * silently returning would strand every stale body until the next sweep.
+   */
+  async pullCrdtForNotes(noteIds: string[]): Promise<void> {
+    if (noteIds.length === 0) return
+    log.debug('pullCrdtForNotes entered', { count: noteIds.length })
+
+    const token = await this.ctx.deps.getAccessToken()
+    if (!token) {
+      for (const noteId of noteIds) this.owePendingPull(noteId)
+      return
+    }
+
+    const vaultKey = await this.ctx.deps.getVaultKey()
+    if (!vaultKey) {
+      for (const noteId of noteIds) this.owePendingPull(noteId)
+      return
+    }
+
+    const localAbort = new AbortController()
+    try {
+      await this.applyCrdtBatch(noteIds, token, vaultKey, localAbort.signal)
+      log.debug('pullCrdtForNotes completed', { count: noteIds.length })
     } finally {
       secureCleanup(vaultKey)
     }

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -447,7 +447,7 @@ export class CrdtSyncCoordinator {
    * retry rather than dropped: the sweep hands this method the whole vault, so
    * silently returning would strand every stale body until the next sweep.
    */
-  async pullCrdtForNotes(noteIds: string[]): Promise<void> {
+  async pullCrdtForNotes(noteIds: string[], signal?: AbortSignal): Promise<void> {
     if (noteIds.length === 0) return
     log.debug('pullCrdtForNotes entered', { count: noteIds.length })
 
@@ -463,9 +463,14 @@ export class CrdtSyncCoordinator {
       return
     }
 
-    const localAbort = new AbortController()
+    // A caller that can outlive this group passes its own signal: the paced
+    // sweep spans minutes, so without one a group already in flight would keep
+    // pulling after the engine was disposed, against a provider and vault it no
+    // longer owns. Callers that cannot be torn down mid-group get a signal that
+    // never fires, which is the behaviour the engine's own controller gave.
+    const effectiveSignal = signal ?? new AbortController().signal
     try {
-      await this.applyCrdtBatch(noteIds, token, vaultKey, localAbort.signal)
+      await this.applyCrdtBatch(noteIds, token, vaultKey, effectiveSignal)
       log.debug('pullCrdtForNotes completed', { count: noteIds.length })
     } finally {
       secureCleanup(vaultKey)

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
@@ -54,7 +54,7 @@ vi.mock('../../database/client', () => ({
 class FakeCrdtSync {
   private pending = new Set<string>()
   pullCrdtForNote = vi.fn(async () => {})
-  pullCrdtForNotes = vi.fn(async (_noteIds: string[]) => {})
+  pullCrdtForNotes = vi.fn(async (_noteIds: string[], _signal?: AbortSignal) => {})
 
   addPendingPull(noteId: string): void {
     this.pending.add(noteId)
@@ -517,7 +517,10 @@ describe('FullSyncRunner', () => {
 
       await expect(h.runner.run()).rejects.toThrow('boom')
 
-      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledWith(['note-1', 'note-2'])
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledWith(
+        ['note-1', 'note-2'],
+        expect.any(AbortSignal)
+      )
       expect(h.crdtSync.pendingPullCount).toBe(0)
     })
 
@@ -563,7 +566,7 @@ describe('FullSyncRunner', () => {
       await h.runner.run()
       await scheduled[0]()
 
-      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledWith(['note-7'])
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledWith(['note-7'], expect.any(AbortSignal))
     })
 
     it('#then the index DB is not touched while it is uninitialized', async () => {
@@ -992,7 +995,7 @@ describe('FullSyncRunner', () => {
     }
 
     function pulledNoteIds(h: Harness): string[] {
-      return h.crdtSync.pullCrdtForNotes.mock.calls.flatMap(([ids]: [string[]]) => ids)
+      return h.crdtSync.pullCrdtForNotes.mock.calls.flatMap(([ids]) => ids)
     }
 
     it('#then the chunk size and interval stay inside BOTH server rate limits', () => {
@@ -1019,7 +1022,10 @@ describe('FullSyncRunner', () => {
 
       await h.runner.run()
 
-      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledWith(['note-0', 'note-1', 'note-2'])
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledWith(
+        ['note-0', 'note-1', 'note-2'],
+        expect.any(AbortSignal)
+      )
       // The single-note path is two GETs per note (snapshot, then incrementals).
       // The batch path shares one incrementals POST across the group — the
       // snapshot baselines are still one GET each, so this halves the traffic
@@ -1113,6 +1119,39 @@ describe('FullSyncRunner', () => {
       await vi.advanceTimersByTimeAsync(CRDT_SWEEP_CHUNK_INTERVAL_MS * 10)
 
       expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(1)
+    })
+
+    it('#then disposing the runner aborts the chunk already in flight', async () => {
+      // Clearing the queue and the timer only stops the NEXT chunk. A paced
+      // sweep spans minutes, so at teardown there is almost always one in
+      // flight, and it would otherwise keep pulling into a provider and vault
+      // this engine no longer owns.
+      const h = sweepingHarness(60)
+
+      await h.runner.run()
+      const [, signal] = h.crdtSync.pullCrdtForNotes.mock.calls[0] as [string[], AbortSignal]
+      expect(signal.aborted).toBe(false)
+
+      h.runner.dispose()
+
+      expect(signal.aborted).toBe(true)
+    })
+
+    it('#then a later sweep does not inherit the aborted signal', async () => {
+      // An aborted controller stays aborted, so reusing it would leave every
+      // pull of the next engine cancelled before it started.
+      const h = sweepingHarness(60)
+
+      await h.runner.run()
+      const [, first] = h.crdtSync.pullCrdtForNotes.mock.calls[0] as [string[], AbortSignal]
+      h.runner.dispose()
+      expect(first.aborted).toBe(true)
+
+      h.crdtSync.addPendingPull('note-later')
+      await h.runner.run()
+
+      const [, latest] = h.crdtSync.pullCrdtForNotes.mock.calls.at(-1) as [string[], AbortSignal]
+      expect(latest.aborted).toBe(false)
     })
   })
 })

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
@@ -4,6 +4,8 @@ import { FullSyncRunner, type FullSyncActions } from './full-sync-runner'
 import {
   CRDT_FULL_SWEEP_MIN_INTERVAL_MS,
   CRDT_RECONNECT_SWEEP_FLOOR_MS,
+  CRDT_SWEEP_CHUNK_INTERVAL_MS,
+  CRDT_SWEEP_CHUNK_NOTES,
   SYNC_STATE_KEYS,
   type SyncContext
 } from './sync-context'
@@ -52,6 +54,7 @@ vi.mock('../../database/client', () => ({
 class FakeCrdtSync {
   private pending = new Set<string>()
   pullCrdtForNote = vi.fn(async () => {})
+  pullCrdtForNotes = vi.fn(async (_noteIds: string[]) => {})
 
   addPendingPull(noteId: string): void {
     this.pending.add(noteId)
@@ -65,6 +68,22 @@ class FakeCrdtSync {
     const ids = [...this.pending]
     this.pending.clear()
     return ids
+  }
+}
+
+/**
+ * The runner asks the provider two things: which notes still have a live editor
+ * (those skip the paced queue, because that is the note the user is looking at),
+ * and how many docs it can hold open at once (so a paced chunk never outgrows
+ * the LRU and gets its docs closed underneath it).
+ */
+function fakeCrdtProvider({ activeNoteIds = [] as string[], inactiveDocCapacity = 32 } = {}): {
+  getOpenNoteIds: ReturnType<typeof vi.fn>
+  inactiveDocCapacity: number
+} {
+  return {
+    getOpenNoteIds: vi.fn(() => activeNoteIds),
+    inactiveDocCapacity
   }
 }
 
@@ -176,9 +195,13 @@ function createHarness(
     push: vi.fn(async () => {
       calls.push('push')
     }),
+    // The real SyncEngine.scheduleSync runs the callback (chained onto any
+    // in-flight sync). The paced CRDT drain arms its next chunk from the
+    // previous one's completion, so a harness that only recorded the call would
+    // wedge the pump after the first chunk and hide every later one.
     scheduleSync: vi.fn((fn: () => Promise<void>) => {
       calls.push('scheduleSync')
-      void fn
+      void fn().catch(() => {})
     })
   }
 
@@ -487,14 +510,14 @@ describe('FullSyncRunner', () => {
     })
 
     it('#then CRDT pulls queued before the failure are still flushed', async () => {
-      const h = createHarness()
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       h.crdtSync.addPendingPull('note-1')
       h.crdtSync.addPendingPull('note-2')
       h.actions.pull.mockRejectedValue(new Error('boom'))
 
       await expect(h.runner.run()).rejects.toThrow('boom')
 
-      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledWith(['note-1', 'note-2'])
       expect(h.crdtSync.pendingPullCount).toBe(0)
     })
 
@@ -514,19 +537,22 @@ describe('FullSyncRunner', () => {
 
   describe('#given CRDT-backed notes #when the cycle ends', () => {
     it('#then every CRDT note is re-queued and scheduled for a pull', async () => {
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
 
       await h.runner.run()
 
       expect(mocks.getAllCrdtNoteIds).toHaveBeenCalledWith({ __db: 'index' })
-      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+      // One scheduled chunk for both notes, not one per note: the single-note
+      // path costs two GETs each, which is what put 242 requests on the wire in
+      // four seconds for a 121-note vault.
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(1)
       expect(h.crdtSync.pendingPullCount).toBe(0)
     })
 
     it('#then the scheduled work pulls the specific note', async () => {
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-7'])
       const scheduled: Array<() => Promise<void>> = []
@@ -537,13 +563,13 @@ describe('FullSyncRunner', () => {
       await h.runner.run()
       await scheduled[0]()
 
-      expect(h.crdtSync.pullCrdtForNote).toHaveBeenCalledWith('note-7')
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledWith(['note-7'])
     })
 
     it('#then the index DB is not touched while it is uninitialized', async () => {
       // Vault switch / teardown: reading an unopened index DB throws inside a
       // finally block, which would replace the real sync error.
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(false)
 
       await h.runner.run()
@@ -562,7 +588,7 @@ describe('FullSyncRunner', () => {
     })
 
     it('#then a completed sweep is stamped so the next cycle can throttle it', async () => {
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1'])
 
@@ -579,7 +605,7 @@ describe('FullSyncRunner', () => {
       // `crdt_updated` broadcast and was pulled per note, so a sweep can only
       // re-discover what this device already has. A clock cannot see that: the
       // liveness signal must win over the interval, not the other way round.
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
 
@@ -605,7 +631,7 @@ describe('FullSyncRunner', () => {
       // The gate only covers the blanket safety-net sweep. A `crdt_updated`
       // broadcast is a positive signal that THIS note changed remotely and must
       // never be swallowed.
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
 
@@ -627,7 +653,7 @@ describe('FullSyncRunner', () => {
       // This is the one case where broadcasts were provably missed, and the
       // case where the user is most likely staring at a stale note. Deferring
       // it by the fallback interval would be exactly backwards.
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
 
@@ -644,7 +670,7 @@ describe('FullSyncRunner', () => {
 
       await h.runner.run()
 
-      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(1)
     })
 
     it('#then a sweep that ran moments ago for another reason does not hold it back', async () => {
@@ -655,7 +681,7 @@ describe('FullSyncRunner', () => {
       // even though this was its first reconnect and nothing needed collapsing.
       // The two-device body-CRDT E2E specs caught it as "the other device's
       // edit never arrives".
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
 
@@ -671,14 +697,14 @@ describe('FullSyncRunner', () => {
       await h.runner.run()
 
       expect(mocks.getAllCrdtNoteIds).toHaveBeenCalledTimes(1)
-      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(1)
     })
 
     it('#then a socket that is still down falls back to the interval', async () => {
       // Down-and-not-yet-back is not a completed reconnect. Sweeping on every
       // cycle here would reinstate the storm for anyone whose socket is blocked
       // outright, so the interval bounds it instead.
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
 
@@ -703,7 +729,7 @@ describe('FullSyncRunner', () => {
 
       await h.runner.run()
 
-      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -721,7 +747,7 @@ describe('FullSyncRunner', () => {
     })
 
     async function reconnectInsideFloor(): Promise<Harness> {
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
 
@@ -757,7 +783,7 @@ describe('FullSyncRunner', () => {
       await vi.advanceTimersByTimeAsync(CRDT_RECONNECT_SWEEP_FLOOR_MS)
 
       expect(mocks.getAllCrdtNoteIds).toHaveBeenCalledTimes(1)
-      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(1)
     })
 
     it('#then repeated flaps inside the floor still cost exactly one sweep', async () => {
@@ -825,7 +851,7 @@ describe('FullSyncRunner', () => {
       // retry). An instance-only signal that re-armed an immediate sweep would
       // repeat the lastManifestCheckAt bug: a retry loop would sweep the whole
       // vault on every single cycle. The persisted stamp is the authority here.
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
       h.getStateValue.mockImplementation((key: string) =>
@@ -840,7 +866,7 @@ describe('FullSyncRunner', () => {
     it('#then a stamp older than the interval sweeps', async () => {
       // A device that was offline for weeks discovers body-only remote edits
       // (which never enter the record change feed) only through this sweep.
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
       h.getStateValue.mockImplementation((key: string) =>
@@ -851,11 +877,11 @@ describe('FullSyncRunner', () => {
 
       await h.runner.run()
 
-      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(1)
     })
 
     it('#then a missing websocket manager falls back to the interval', async () => {
-      const h = createHarness({ crdtProvider: {}, ws: null })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider(), ws: null })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1'])
 
@@ -875,7 +901,7 @@ describe('FullSyncRunner', () => {
       // Clock skew or a machine migration can leave a stamp 30 days ahead.
       // Trusting it would disable the only discovery path for body-only remote
       // edits for a month.
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1'])
       h.getStateValue.mockImplementation((key: string) =>
@@ -890,7 +916,7 @@ describe('FullSyncRunner', () => {
     })
 
     it('#then a non-numeric stamp is treated as never swept', async () => {
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1'])
       h.getStateValue.mockImplementation((key: string) =>
@@ -908,7 +934,7 @@ describe('FullSyncRunner', () => {
       // Server rows this device has never seen (fresh install, restored vault,
       // index rebuild) mean local CRDT state cannot be trusted, whatever the
       // socket did.
-      const h = createHarness({ crdtProvider: {} })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
 
@@ -924,13 +950,13 @@ describe('FullSyncRunner', () => {
 
       await h.runner.run()
 
-      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(1)
     })
 
     it('#then an offline cycle neither sweeps nor burns the throttle window', async () => {
       // Pulls scheduled while offline are guaranteed to fail; stamping the
       // sweep there would hide real remote edits for a whole interval.
-      const h = createHarness({ crdtProvider: {}, online: false })
+      const h = createHarness({ crdtProvider: fakeCrdtProvider(), online: false })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
 
@@ -938,6 +964,155 @@ describe('FullSyncRunner', () => {
 
       expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
       expect(h.calls).not.toContain(`setState:${SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT}`)
+    })
+  })
+
+  describe('#given a vault bigger than one chunk #when the sweep runs', () => {
+    // The sweep is a catch-up, not a race. Fired all at once down the
+    // single-note path it cost two GETs per note — 242 requests in about four
+    // seconds for a 121-note vault, against a server limit of 300 per 60s shared
+    // with the account's other devices — and 92 of those 121 notes came back
+    // "Too many requests" and silently kept their stale bodies.
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    const noteIds = (count: number): string[] =>
+      Array.from({ length: count }, (_, index) => `note-${index}`)
+
+    function sweepingHarness(count: number, provider = fakeCrdtProvider()): Harness {
+      const h = createHarness({ crdtProvider: provider })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(noteIds(count))
+      return h
+    }
+
+    function pulledNoteIds(h: Harness): string[] {
+      return h.crdtSync.pullCrdtForNotes.mock.calls.flatMap(([ids]: [string[]]) => ids)
+    }
+
+    it('#then the chunk size and interval stay inside BOTH server rate limits', () => {
+      // The server meters these two paths in separate buckets, and both are
+      // shared by every device on the account:
+      //   GET  /sync/crdt/snapshot/:noteId + /sync/crdt/updates -> 300 / 60s
+      //   POST /sync/crdt/updates/batch                         ->  30 / 60s
+      // A chunk of N notes costs N snapshot GETs (the batch endpoint batches the
+      // incrementals, not the baselines) plus at least one batch POST, so tuning
+      // either constant has to be checked against both ceilings — the batch
+      // bucket is ten times tighter and easy to miss.
+      const chunksPerMinute = 60_000 / CRDT_SWEEP_CHUNK_INTERVAL_MS
+      const snapshotGetsPerMinute = CRDT_SWEEP_CHUNK_NOTES * chunksPerMinute
+      const batchPostsPerMinute = chunksPerMinute
+
+      // Two devices sweeping at once, and still room left for the record-change
+      // pull, pushes and attachment fetches drawing on the same buckets.
+      expect(snapshotGetsPerMinute * 2).toBeLessThan(300)
+      expect(batchPostsPerMinute * 2).toBeLessThan(30)
+    })
+
+    it('#then the whole sweep leaves through the batch path, never one pull per note', async () => {
+      const h = sweepingHarness(3)
+
+      await h.runner.run()
+
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledWith(['note-0', 'note-1', 'note-2'])
+      // The single-note path is two GETs per note (snapshot, then incrementals).
+      // The batch path shares one incrementals POST across the group — the
+      // snapshot baselines are still one GET each, so this halves the traffic
+      // rather than collapsing it.
+      expect(h.crdtSync.pullCrdtForNote).not.toHaveBeenCalled()
+    })
+
+    it('#then only one chunk goes out per interval, whatever the vault size', async () => {
+      const h = sweepingHarness(60)
+
+      await h.runner.run()
+
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(1)
+      expect(h.crdtSync.pullCrdtForNotes.mock.calls[0][0]).toHaveLength(CRDT_SWEEP_CHUNK_NOTES)
+
+      // Nothing more may go out before the interval elapses: 25 notes is 25
+      // snapshot GETs plus one batch POST, and four of those per minute is what
+      // keeps a sweeping device near 104 requests/minute.
+      await vi.advanceTimersByTimeAsync(CRDT_SWEEP_CHUNK_INTERVAL_MS - 1)
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(2)
+
+      await vi.advanceTimersByTimeAsync(CRDT_SWEEP_CHUNK_INTERVAL_MS)
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(3)
+
+      // Paced, not sampled: every note is still covered, exactly once.
+      const pulled = pulledNoteIds(h)
+      expect(pulled).toHaveLength(60)
+      expect(new Set(pulled)).toEqual(new Set(noteIds(60)))
+    })
+
+    it('#then a chunk never outgrows the provider doc cache', async () => {
+      // Handing applyCrdtBatch more notes than it can hold open makes it split
+      // the chunk internally and spend an extra batch POST doing it — the exact
+      // request the pacing arithmetic budgets for.
+      const h = sweepingHarness(60, fakeCrdtProvider({ inactiveDocCapacity: 4 }))
+
+      await h.runner.run()
+
+      expect(h.crdtSync.pullCrdtForNotes.mock.calls[0][0]).toHaveLength(4)
+    })
+
+    it('#then a note with a live editor is pulled before the paced queue', async () => {
+      const h = sweepingHarness(60, fakeCrdtProvider({ activeNoteIds: ['note-40'] }))
+
+      await h.runner.run()
+
+      // The note the user is looking at is the one whose stale body is the bug.
+      // It must not queue behind a catch-up that takes minutes on a large vault,
+      // so it leaves in its own batch first; the cost is bounded by the number
+      // of open editors.
+      expect(h.crdtSync.pullCrdtForNotes.mock.calls[0][0]).toEqual(['note-40'])
+      expect(h.crdtSync.pullCrdtForNotes.mock.calls[1][0]).not.toContain('note-40')
+    })
+
+    it('#then a second sweep joins the running drain instead of starting its own', async () => {
+      const h = sweepingHarness(60)
+
+      await h.runner.run()
+      // A reconnect past the floor, so the gate sweeps the vault again while the
+      // first drain is still working through it.
+      h.ws.connectionGeneration += 1
+      await h.runner.run()
+
+      // Two drains in parallel double the request rate and put the arithmetic
+      // straight back over the server's limit.
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(CRDT_SWEEP_CHUNK_INTERVAL_MS)
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(2)
+
+      // ...and the second sweep re-queues the vault once, not once per copy
+      // already waiting. 25 pulled by the first chunk, then the 60 the second
+      // sweep queued — the 35 still waiting were deduped into it. An array queue
+      // would have carried those 35 twice and pulled 120.
+      await vi.advanceTimersByTimeAsync(CRDT_SWEEP_CHUNK_INTERVAL_MS * 5)
+      expect(pulledNoteIds(h)).toHaveLength(CRDT_SWEEP_CHUNK_NOTES + 60)
+    })
+
+    it('#then disposing the runner cancels the rest of the paced sweep', async () => {
+      // Engine teardown (vault switch, sign-out): a timer left armed keeps
+      // pulling against a vault this engine no longer owns.
+      const h = sweepingHarness(60)
+
+      await h.runner.run()
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(1)
+
+      h.runner.dispose()
+      await vi.advanceTimersByTimeAsync(CRDT_SWEEP_CHUNK_INTERVAL_MS * 10)
+
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.ts
@@ -8,6 +8,8 @@ import type { SyncContext } from './sync-context'
 import {
   CRDT_FULL_SWEEP_MIN_INTERVAL_MS,
   CRDT_RECONNECT_SWEEP_FLOOR_MS,
+  CRDT_SWEEP_CHUNK_INTERVAL_MS,
+  CRDT_SWEEP_CHUNK_NOTES,
   SYNC_STATE_KEYS
 } from './sync-context'
 import type { SyncStateManager } from './sync-state-manager'
@@ -65,6 +67,20 @@ export class FullSyncRunner {
    */
   private crdtSweepOwed = false
   private owedSweepTimer: ReturnType<typeof setTimeout> | null = null
+  /**
+   * Notes drained from the pending-pull set that are waiting their turn in a
+   * paced catch-up chunk.
+   *
+   * A Set, so a note re-queued by a failed chunk cannot accumulate duplicates
+   * across cycles — the queue stays bounded by the vault, not by how many times
+   * the server has said no. Insertion order is preserved, so it still drains
+   * FIFO. In-memory by design: this queue is a plan for the current engine's
+   * catch-up, and the persisted sweep stamp is what carries the work across a
+   * restart.
+   */
+  private pacedCrdtPullQueue = new Set<string>()
+  private pacedCrdtPullTimer: ReturnType<typeof setTimeout> | null = null
+  private pacedCrdtChunkInFlight = false
 
   constructor(
     ctx: SyncContext,
@@ -194,12 +210,20 @@ export class FullSyncRunner {
     this.flushPendingCrdtPulls()
   }
 
-  /** Clears the deferred sweep timer. Call on engine teardown. */
+  /** Clears the deferred sweep and paced-pull timers. Call on engine teardown. */
   dispose(): void {
     if (this.owedSweepTimer) {
       clearTimeout(this.owedSweepTimer)
       this.owedSweepTimer = null
     }
+    if (this.pacedCrdtPullTimer) {
+      clearTimeout(this.pacedCrdtPullTimer)
+      this.pacedCrdtPullTimer = null
+    }
+    // Drop the plan with the engine that made it. Leaving ids here would let a
+    // chunk still in flight re-arm the pace timer from its `finally` and keep a
+    // dead engine pulling against a vault it no longer owns.
+    this.pacedCrdtPullQueue.clear()
   }
 
   private sweepAllCrdtNotes(): void {
@@ -336,17 +360,119 @@ export class FullSyncRunner {
   }
 
   /**
-   * Always runs, gate or no gate: these are notes the server named in a
+   * Always runs, gate or no gate: the set holds notes the server named in a
    * `crdt_updated` broadcast, which is a positive signal about that specific
-   * note rather than the blanket safety net.
+   * note rather than the blanket safety net, alongside whatever the sweep just
+   * queued and whatever a failed chunk owes.
+   *
+   * Everything leaves through the batch path rather than one
+   * `pullCrdtForNote` per note. The single-note path costs two GETs per note, so
+   * a 121-note sweep fired 242 requests in about four seconds against the
+   * server's `crdt_pull` bucket of 300 per 60s, shared with the account's other
+   * devices — 92 of those 121 notes came back "Too many requests" and, before
+   * the re-queue above, kept a stale body until the next sweep.
+   *
+   * Batching alone does not fix that; it only halves it, because the batch
+   * endpoint batches the incrementals and not the per-note snapshot baselines.
+   * The pacing below is what keeps a sweep inside both of the server's buckets.
+   * See CRDT_SWEEP_CHUNK_NOTES for the arithmetic on each.
    */
   private flushPendingCrdtPulls(): void {
-    if (this.crdtSync.pendingPullCount === 0) return
-    log.debug('fullSync: flushing pending CRDT pulls', {
-      count: this.crdtSync.pendingPullCount
-    })
-    for (const noteId of this.crdtSync.drainPendingPulls()) {
-      this.actions.scheduleSync(() => this.crdtSync.pullCrdtForNote(noteId))
+    if (this.crdtSync.pendingPullCount > 0) {
+      log.debug('fullSync: flushing pending CRDT pulls', {
+        count: this.crdtSync.pendingPullCount
+      })
+
+      // A note with a live editor is the one the user is looking at, and a stale
+      // body there is the whole bug. It must not queue behind a catch-up that
+      // takes minutes on a large vault, so it skips the pace entirely. The cost
+      // is bounded by the number of open editors — a handful — which is what the
+      // headroom described on CRDT_SWEEP_CHUNK_NOTES is for.
+      // SyncEngine.handleWsConnected reads the same set for the same reason.
+      const activeNoteIds = new Set(
+        this.ctx.deps.crdtProvider?.getOpenNoteIds({ active: true }) ?? []
+      )
+
+      const priority: string[] = []
+      for (const noteId of this.crdtSync.drainPendingPulls()) {
+        if (activeNoteIds.has(noteId)) priority.push(noteId)
+        else this.pacedCrdtPullQueue.add(noteId)
+      }
+
+      if (priority.length > 0) {
+        this.actions.scheduleSync(() => this.crdtSync.pullCrdtForNotes(priority))
+      }
     }
+
+    this.pumpPacedCrdtPulls()
+  }
+
+  /**
+   * Start or continue the paced drain of the CRDT catch-up queue.
+   *
+   * At most one chunk is in flight and at most one timer is armed at any moment.
+   * Both matter: a second fullSync landing mid-drain that started its own pass,
+   * or a flapping socket arming a timer per reconnect, would multiply the
+   * request rate by however many drains were running and put the arithmetic on
+   * CRDT_SWEEP_CHUNK_NOTES straight back over the server's limit — which is the
+   * storm this pacing exists to remove, not a new one to introduce.
+   */
+  private pumpPacedCrdtPulls(): void {
+    if (this.pacedCrdtPullTimer || this.pacedCrdtChunkInFlight) return
+    if (this.pacedCrdtPullQueue.size === 0) return
+
+    const crdtProvider = this.ctx.deps.crdtProvider
+    // The same wall `payOwedSweep` refuses to run into: `scheduleSync` silently
+    // drops its callback while a fullSync is active, and pulls issued offline
+    // are guaranteed to fail. Keep the queue intact and look again next tick
+    // rather than spending a chunk on a request that cannot land.
+    if (this.ctx.fullSyncActive || !this.ctx.deps.network.online || !crdtProvider) {
+      this.armPacedCrdtPullTimer()
+      return
+    }
+
+    // Never hand `applyCrdtBatch` more notes than the provider can hold open at
+    // once: it would split the chunk internally and spend an extra batch POST
+    // doing so, which is exactly the request the pacing arithmetic budgets for.
+    const chunkSize = Math.max(
+      1,
+      Math.min(CRDT_SWEEP_CHUNK_NOTES, crdtProvider.inactiveDocCapacity)
+    )
+    const chunk: string[] = []
+    for (const noteId of this.pacedCrdtPullQueue) {
+      if (chunk.length >= chunkSize) break
+      chunk.push(noteId)
+    }
+    for (const noteId of chunk) this.pacedCrdtPullQueue.delete(noteId)
+
+    log.debug('fullSync: paced CRDT pull chunk', {
+      chunk: chunk.length,
+      remaining: this.pacedCrdtPullQueue.size
+    })
+
+    this.pacedCrdtChunkInFlight = true
+    this.actions.scheduleSync(async () => {
+      try {
+        await this.crdtSync.pullCrdtForNotes(chunk)
+      } finally {
+        // Re-arm from the chunk's completion, not from when it was issued, so a
+        // slow chunk stretches the interval instead of overlapping the next one.
+        // Notes this chunk failed are back in the pending set by now, not in the
+        // queue: they are owed to the next cycle, deliberately, because retrying
+        // them here would just re-run into whatever refused them.
+        this.pacedCrdtChunkInFlight = false
+        this.armPacedCrdtPullTimer()
+      }
+    })
+  }
+
+  private armPacedCrdtPullTimer(): void {
+    if (this.pacedCrdtPullTimer || this.pacedCrdtPullQueue.size === 0) return
+
+    this.pacedCrdtPullTimer = setTimeout(() => {
+      this.pacedCrdtPullTimer = null
+      this.pumpPacedCrdtPulls()
+    }, CRDT_SWEEP_CHUNK_INTERVAL_MS)
+    this.pacedCrdtPullTimer.unref?.()
   }
 }

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.ts
@@ -81,6 +81,17 @@ export class FullSyncRunner {
   private pacedCrdtPullQueue = new Set<string>()
   private pacedCrdtPullTimer: ReturnType<typeof setTimeout> | null = null
   private pacedCrdtChunkInFlight = false
+  /**
+   * Cancels the sweep's in-flight pulls when the engine goes away.
+   *
+   * Dropping the queue and the timer stops the NEXT chunk, but a paced sweep
+   * spans minutes, so there is almost always a chunk already in flight — and
+   * that one would run to completion against a provider and a vault this engine
+   * no longer owns, opening docs on a discarded provider and spending request
+   * budget for a session that is over. Rebuilt on demand, because an aborted
+   * controller stays aborted and a later engine must not inherit it.
+   */
+  private pacedCrdtPullAbort: AbortController | null = null
 
   constructor(
     ctx: SyncContext,
@@ -224,6 +235,16 @@ export class FullSyncRunner {
     // chunk still in flight re-arm the pace timer from its `finally` and keep a
     // dead engine pulling against a vault it no longer owns.
     this.pacedCrdtPullQueue.clear()
+    this.pacedCrdtPullAbort?.abort()
+    this.pacedCrdtPullAbort = null
+  }
+
+  /** Signal for sweep-issued pulls, live until `dispose()` cancels them. */
+  private sweepPullSignal(): AbortSignal {
+    if (!this.pacedCrdtPullAbort || this.pacedCrdtPullAbort.signal.aborted) {
+      this.pacedCrdtPullAbort = new AbortController()
+    }
+    return this.pacedCrdtPullAbort.signal
   }
 
   private sweepAllCrdtNotes(): void {
@@ -400,7 +421,9 @@ export class FullSyncRunner {
       }
 
       if (priority.length > 0) {
-        this.actions.scheduleSync(() => this.crdtSync.pullCrdtForNotes(priority))
+        this.actions.scheduleSync(() =>
+          this.crdtSync.pullCrdtForNotes(priority, this.sweepPullSignal())
+        )
       }
     }
 
@@ -453,7 +476,7 @@ export class FullSyncRunner {
     this.pacedCrdtChunkInFlight = true
     this.actions.scheduleSync(async () => {
       try {
-        await this.crdtSync.pullCrdtForNotes(chunk)
+        await this.crdtSync.pullCrdtForNotes(chunk, this.sweepPullSignal())
       } finally {
         // Re-arm from the chunk's completion, not from when it was issued, so a
         // slow chunk stretches the interval instead of overlapping the next one.

--- a/apps/desktop/src/main/sync/engine/sync-context.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.ts
@@ -158,6 +158,48 @@ export const CRDT_FULL_SWEEP_MIN_INTERVAL_MS = 15 * 60 * 1000
 // edits inside a minute. Unlike the fallback interval this one is only ever
 // paid once per burst, so it does not need to be conservative.
 export const CRDT_RECONNECT_SWEEP_FLOOR_MS = 60 * 1000
+// How many notes one paced CRDT catch-up chunk pulls, and how long the next
+// chunk waits. Together these are the only thing keeping a whole-vault sweep
+// under the server's rate limits, so they are set from those limits backwards.
+//
+// There are TWO independent budgets, and a sweep has to fit inside both:
+//
+//   GET  /sync/crdt/snapshot/:noteId  }  one `crdt_pull` bucket,
+//   GET  /sync/crdt/updates           }  300 requests / 60 s
+//   POST /sync/crdt/updates/batch        `crdt_batch_pull`, 30 requests / 60 s
+//
+// Both are shared by every device on the account. One chunk of N notes through
+// applyCrdtBatch costs N snapshot GETs — the batch endpoint batches the
+// incrementals, NOT the snapshot baselines, which are still fetched one note at
+// a time — plus at least one batch POST.
+//
+//   25 notes per chunk, 60_000 / 15_000 = 4 chunks per minute
+//   GET  budget: 25 x 4 = 100/min per sweeping device, 200 for two devices,
+//                against 300 — the binding constraint, ~30% spare
+//   POST budget:  1 x 4 =   4/min per sweeping device,   8 for two devices,
+//                against 30 — 7.5x headroom on a single device
+//
+// Only the RATE matters, not the total: a 1,000-note vault is 40 chunks and 40
+// batch POSTs, which would blow the 30/60s batch bucket if fired at once but is
+// 4/min spread across the ten minutes the paced sweep takes. That is the whole
+// point of pacing — cost per minute is CONSTANT in vault size, only the duration
+// grows, so no vault can reproduce the 242-requests-in-4-seconds storm that had
+// 92 of 121 notes coming back "Too many requests" and silently keeping stale
+// bodies. Slow is the correct trade: this is a catch-up, not a race, and the
+// notes the user actually has open skip the queue entirely.
+//
+// The POST figure is a floor, not an exact count: applyCrdtBatchChunk loops
+// while any note reports `hasMore`, so a chunk costs one POST per round. The
+// batch budget only binds if chunks average more than seven rounds — i.e. over
+// 700 queued updates spread across one chunk's notes, which is a first-sync
+// backlog, not steady state. It is also no longer destructive if it happens: a
+// rate-limited batch re-queues its whole chunk for the next cycle instead of
+// dropping it.
+//
+// The GET headroom is not spare either — the record-change pull, pushes,
+// attachment fetches and the un-paced priority batch all draw on the same 300.
+export const CRDT_SWEEP_CHUNK_NOTES = 25
+export const CRDT_SWEEP_CHUNK_INTERVAL_MS = 15 * 1000
 export const PUSH_DEBOUNCE_MS = 2000
 
 export const yieldToEventLoop = (): Promise<void> => new Promise((r) => setImmediate(r))

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -101,6 +101,14 @@ pass, which is what a sign-in or a reconnect sweep produces, is several times th
 Chunking also keeps each request under the server's 100-note limit on
 `/sync/crdt/updates/batch`.
 
+The vault-wide sweep hands its work to that same batch path rather than pulling one note
+at a time, and sizes its own chunks at `min(CRDT_SWEEP_CHUNK_NOTES, inactiveDocCapacity)`
+so a paced chunk is one batch request rather than several. Batching alone is not a fix for
+request volume, though: the batch endpoint batches the **incrementals**, not the snapshot
+baselines, which are still fetched one note at a time inside the pass. A 121-note sweep
+goes from 242 requests to roughly 125 — half, not a handful. What keeps it under the
+server's limits is the pacing described in [Reconnect Recovery](#reconnect-recovery).
+
 For the same reason, "this doc has no state" and "this doc is not open" are treated as
 different answers when the pass decides whether to seed a note from local markdown. A
 doc the provider closed mid-pass reports no state vector at all; seeding on that would
@@ -264,6 +272,42 @@ not from any sweep — measuring it against the startup or interval sweep made t
 reconnect after app start wait out the whole floor, which left the device showing a stale
 body for that window.
 
+### Pacing the sweep
+
+Deciding _whether_ to sweep is not enough, because a sweep that runs fires against every
+note in the vault at once. Down the one-note-at-a-time path that was two GETs per note:
+121 notes meant 242 requests in about four seconds, and the server refused most of them.
+
+The sweep is therefore drained in chunks — `CRDT_SWEEP_CHUNK_NOTES` notes every
+`CRDT_SWEEP_CHUNK_INTERVAL_MS` — against **two independent server budgets**, both shared
+by every device on the account:
+
+| Endpoint                                                    | Bucket            | Limit      | Cost per chunk    |
+| ----------------------------------------------------------- | ----------------- | ---------- | ----------------- |
+| `GET /sync/crdt/snapshot/:noteId`, `GET /sync/crdt/updates` | `crdt_pull`       | 300 / 60 s | one GET per note  |
+| `POST /sync/crdt/updates/batch`                             | `crdt_batch_pull` | 30 / 60 s  | at least one POST |
+
+At 25 notes every 15 seconds that is 100 snapshot GETs and 4 batch POSTs per minute per
+sweeping device — 200 and 8 with two devices sweeping at once, inside both ceilings with
+room left for the record-change pull, pushes and attachment fetches, which draw on the
+same buckets. Only the _rate_ matters, not the total: a 1,000-note vault is 40 batch
+POSTs, which would blow the 30-per-minute bucket fired at once but is 4 per minute spread
+over the ten minutes the paced sweep takes. Cost per minute is constant in vault size;
+only the duration grows.
+
+The batch POST figure is a floor rather than an exact count, because a chunk loops while
+any of its notes still reports `hasMore`. That only binds on a first-sync backlog, and it
+is no longer destructive when it happens — see below.
+
+**Notes with a live editor skip the queue.** They are pulled in their own batch ahead of
+the paced drain, because the note the user is looking at is the one whose stale body is
+the bug, and a large vault's catch-up takes minutes. Their cost is bounded by the number
+of open editors.
+
+One drain runs at a time and one timer is armed at a time. A second sweep landing
+mid-drain re-queues into the running one instead of starting its own, which would double
+the request rate; engine teardown cancels the timer and drops the queue.
+
 ## Snapshot Failure Handling
 
 A snapshot is a **compaction optimization**, not the source of truth: the authoritative
@@ -291,6 +335,18 @@ The client mirrors this. CRDT pulls run in a **serial loop over notes**, so they
 retry `429`s inline — honouring `Retry-After` per note would stall the whole pass, and the
 sync cadence is the retry instead. A single note that fails its snapshot baseline is
 skipped and retried on the next pass rather than abandoning the remaining notes.
+
+"Retried on the next pass" is a property of the code, not an assumption: a pull that does
+not complete puts its notes back into the pending-pull set, which the next cycle drains.
+That covers a rate-limited chunk (all of its notes), a rate-limited snapshot baseline (only
+that note), a failed single-note pull, and a batch that could not obtain credentials. The
+rule is deliberately not 429-specific — a transient 5xx, an unreachable server and a rate
+limit all leave the same stale body, so "failed, retry next cycle" needs no taxonomy.
+
+Without that, a rate-limited note was logged and dropped, and its body stayed stale until
+the _next_ vault-wide sweep — a 60-second reconnect floor or a 15-minute interval away.
+Opening the note did not help, because that reads the main process's Y.Doc rather than the
+server.
 
 Whether a note still owes the server a snapshot is tracked per open doc as a byte count of
 the local updates applied since the last successful push; closing a note and the push-all

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -308,6 +308,13 @@ One drain runs at a time and one timer is armed at a time. A second sweep landin
 mid-drain re-queues into the running one instead of starting its own, which would double
 the request rate; engine teardown cancels the timer and drops the queue.
 
+Teardown also aborts the chunk already in flight. Cancelling the timer only stops the
+_next_ one, and a paced sweep spans minutes, so at teardown there is almost always one
+running — it would otherwise pull into a provider and a vault the engine no longer owns,
+and spend request budget for a session that is over. The abort signal is rebuilt per
+drain rather than reused, because an aborted controller stays aborted and the next
+engine's pulls must not start cancelled.
+
 ## Snapshot Failure Handling
 
 A snapshot is a **compaction optimization**, not the source of truth: the authoritative


### PR DESCRIPTION
## Problem

The vault-wide CRDT sweep is the only way a body-only edit made while this device was disconnected is ever discovered — note bodies never travel in the record change feed. Three things were wrong with how it ran:

1. **It used the single-note path**, 2 GETs per note. A 121-note vault = 242 requests in ~4 seconds against a 300/60s server bucket shared with the account's other devices.
2. **A rate-limited note was silently dropped.** `withRetry(..., { retryOn429: false })` and a catch that only logged: no retry, no re-queue, no debt. That body then stayed stale until the *next* sweep — a 60s reconnect floor or a 15-minute interval away. Opening the note did not help; that reads main's Y.Doc, not the server.
3. **It fired everything at once**, though it is a catch-up, not a race.

Observed on a real device: 92 of 121 notes returned `Too many requests` in one sweep.

## Changes

**Pay the debt.** A pull that does not complete puts its notes back in the pending-pull set for the next cycle. Four paths: a failed chunk (all its notes), a failed snapshot baseline (just that note), a failed single-note pull, and a group that could not get credentials. Deliberately not 429-specific — a transient 5xx, an unreachable server and a rate limit all leave the same stale body. The debt is paid by the *next* cycle, never retried in place: `retryOn429: false` is correct, because honouring a 60s `Retry-After` three times inside a serial loop would stall every remaining note behind one.

**Route the sweep through the batch path.** New `pullCrdtForNotes`, resolving credentials once per group instead of once per note. This **halves** the traffic (242 → ~125 for 121 notes); it does not collapse it, because the batch endpoint batches the incrementals and not the per-note snapshot baselines.

**Pace it, editors first.** 25 notes per chunk, one chunk per 15s, one drain and one timer at a time. Notes with a live editor skip the queue entirely — that is the note whose stale body is the actual bug.

## The arithmetic (two independent budgets)

| Bucket | Endpoints | Limit | Per min, 1 device | 2 devices |
|---|---|---|---|---|
| `crdt_pull` | snapshot + updates GETs | 300/60s | 100 | **200** |
| `crdt_batch_pull` | batch POST | 30/60s | 4 | **8** |

Only the **rate** matters, not the total. A 1000-note vault is 40 chunks and 40 batch POSTs — which would blow the 30/min bucket fired at once, but is 4/min across the ten minutes a paced sweep takes. Cost per minute is constant in vault size; only duration grows. That is what makes this work at any vault size without depending on the server ceiling being raised.

## Verification

- Desktop main process: **505 files / 6462 tests pass**. Baseline on `origin/main` was 6448 — nothing was failing before.
- `pnpm typecheck` 17/17, lint clean on the changed files, `git diff --check` clean.
- `docs:impact --strict` covered, `docs:build` passes.
- **17 mutations run across the two commits, 0 survivors.** Including deliberately adding a mutation (chunk 2 / interval 2s) whose only killer is the batch-POST ceiling assertion — without it that assertion would have been dead weight, since the GET assertion always trips first.

## Two findings worth calling out

**`applyCrdtBatch` read `ctx.abortController` unconditionally.** The engine only holds one for the duration of a pull or a push, so an out-of-cycle sweep would have returned without doing anything — the whole pacing change would have been a silent no-op. It now takes the caller's signal.

**Second commit, found in review:** clearing the queue and timer on `dispose()` only stops the *next* chunk. A paced sweep spans minutes, so at teardown there is almost always one in flight, and it kept pulling into a provider and vault the engine no longer owned. The runner now owns the signal for every pull it issues and aborts it in `dispose()`, rebuilt per drain because an aborted controller stays aborted.

Also fixed as collateral: the test harness's `scheduleSync` mock did `void fn` and never invoked the callback. Harmless before; with a pump that arms the next chunk from the previous one's completion it would have wedged after chunk 1 and hidden every later chunk.

## Left open, deliberately

`pullCrdtForNote` (single-note) still returns silently on a missing token without owing the note. Same class, but pre-existing and only reachable via a `crdt_updated` broadcast.

No protocol, contract, IPC or schema change. Does **not** assume the companion server-side PR has shipped — the pacing keeps a sweep under the current 300/60s on its own.