### PR TITLE
fix(sync): stamp the orphan tombstone so the server accepts it

### DIFF
--- a/apps/desktop/src/main/sync/engine/orphan-repair.test.ts
+++ b/apps/desktop/src/main/sync/engine/orphan-repair.test.ts
@@ -24,13 +24,16 @@ function makeOrphan(overrides: Partial<OrphanRef> = {}): OrphanRef {
   }
 }
 
-function makeCtx(): SyncContext {
+function makeCtx(signingKeys: { deviceId: string } | null = { deviceId: 'device-B' }): SyncContext {
   return {
     applier: { apply: vi.fn() },
     requestPush: vi.fn(),
     deps: {
       db: {},
-      queue: { enqueue: vi.fn() }
+      queue: { enqueue: vi.fn() },
+      // A tombstone has to be stamped with THIS device's clock to outrank the
+      // server's copy, so the repair needs the signing keys.
+      getSigningKeys: vi.fn(async () => signingKeys)
     }
   } as unknown as SyncContext
 }
@@ -122,10 +125,56 @@ describe('repairOrphans (#837)', () => {
       type: 'task',
       itemId: 'task-1',
       operation: 'delete',
-      payload: '{"title":"Orphan"}',
+      payload: '{"title":"Orphan","clock":{"device-B":1}}',
       priority: 0
     })
     expect(ctx.requestPush).toHaveBeenCalled()
+  })
+
+  it('stamps the tombstone with a clock that outranks the server copy', async () => {
+    // #given an orphan whose content still carries the clock it was pulled with
+    const ctx = makeCtx()
+    fetchLocal.mockReturnValue(undefined)
+    const pulled = { title: 'Orphan', clock: { 'device-A': 4, 'device-B': 2 } }
+
+    await repairOrphans({
+      orphans: [makeOrphan({ item: { ...makeOrphan().item, content: JSON.stringify(pulled) } })],
+      ctx,
+      corruptTracker: makeTracker([]),
+      accessJwt: 'jwt',
+      vaultKey: VAULT_KEY,
+      applyItem: vi.fn()
+    })
+
+    // #then the server rejects any push whose clock has no entry greater than the
+    // one it already holds, and this payload IS the server's own clock — sent back
+    // unchanged the delete comes home SYNC_REPLAY_DETECTED every cycle, the next
+    // pull re-serves the orphan, and this repair runs forever.
+    const [enqueued] = (ctx.deps.queue.enqueue as ReturnType<typeof vi.fn>).mock.calls[0]
+    const clock = JSON.parse(enqueued.payload).clock as Record<string, number>
+    expect(clock['device-B']).toBeGreaterThan(pulled.clock['device-B'])
+    expect(clock['device-A']).toBe(4)
+  })
+
+  it('leaves the orphan for the next pull when there is no device id', async () => {
+    // #given signing keys are unavailable (locked keychain, teardown)
+    const ctx = makeCtx(null)
+    fetchLocal.mockReturnValue(undefined)
+
+    const result = await repairOrphans({
+      orphans: [makeOrphan()],
+      ctx,
+      corruptTracker: makeTracker([]),
+      accessJwt: 'jwt',
+      vaultKey: VAULT_KEY,
+      applyItem: vi.fn()
+    })
+
+    // #then an unstamped tombstone would just be a replay again, so spending a
+    // push proving that is worse than waiting for the next pull.
+    expect(result).toEqual({ repaired: 0, tombstoned: 0 })
+    expect(ctx.deps.queue.enqueue).not.toHaveBeenCalled()
+    expect(ctx.requestPush).not.toHaveBeenCalled()
   })
 
   it('refetches each distinct parent once for many orphans', async () => {

--- a/apps/desktop/src/main/sync/engine/orphan-repair.ts
+++ b/apps/desktop/src/main/sync/engine/orphan-repair.ts
@@ -1,4 +1,5 @@
 import type { SyncItemType } from '@memry/contracts/sync-api'
+import { withIncrementedClock } from '@memry/sync-core'
 import { createLogger } from '../../lib/logger'
 import { decryptPullBatch } from '../sync-crypto-batch'
 import { getHandler } from '../item-handlers'
@@ -90,6 +91,10 @@ export async function repairOrphans(
     }
   }
 
+  // Only needed if something actually turns out to be a confirmed orphan, but
+  // resolved once here rather than per item: it is a keychain read.
+  let tombstoneDeviceId: string | null | undefined
+
   let repaired = 0
   let tombstoned = 0
 
@@ -111,11 +116,38 @@ export async function repairOrphans(
     // Parent confirmed absent locally AND not returned by the server. The child
     // can never be written, so stop the re-pull loop at its source by
     // tombstoning it server-side for every device.
+    //
+    // The clock has to be advanced first. `orphan.item.content` is what this
+    // device just pulled, so its clock is the server's OWN clock for that row,
+    // and the server rejects any push whose clock has no entry greater than what
+    // it already holds (`detectReplay` in services/sync.ts). Sent back unchanged
+    // the tombstone came home as SYNC_REPLAY_DETECTED, the queue row was cleared
+    // as "already applied", the next pull served the same orphan again, and this
+    // repair ran again — the loop it exists to end, running forever. Seven tasks
+    // sat in it for hours on a real device.
+    //
+    // A normal delete does not need this: it is built from a local row by the
+    // domain layer, which stamps the clock on the way out. This one has no local
+    // row — that is what being an orphan means — so nothing stamped it, and the
+    // push path leaves `delete` payloads verbatim by design.
+    if (tombstoneDeviceId === undefined) {
+      tombstoneDeviceId = (await ctx.deps.getSigningKeys())?.deviceId ?? null
+    }
+    if (!tombstoneDeviceId) {
+      // Without a device id the tombstone would be a replay again. Leave the
+      // orphan for the next pull rather than burn a push proving that.
+      log.warn('Cannot tombstone orphaned item without a device id', {
+        itemId: orphan.item.id,
+        type: orphan.item.type
+      })
+      continue
+    }
+
     ctx.deps.queue.enqueue({
       type: orphan.item.type as SyncItemType,
       itemId: orphan.item.id,
       operation: 'delete',
-      payload: orphan.item.content,
+      payload: withIncrementedClock(orphan.item.content, tombstoneDeviceId),
       priority: 0
     })
     tombstoned++

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -258,6 +258,17 @@ Deletion is gated on that second condition alone; a child whose re-apply fails f
 is left untouched and retried on the next cycle. A dangling `status_id` is not an orphan at all — the
 FK is `ON DELETE SET NULL`, so the reference is simply cleared rather than failing the apply.
 
+That tombstone is stamped with this device's clock before it is queued. The payload it is built from
+is the one just pulled, so its clock is the **server's own** clock for that row, and the server
+rejects any push whose clock has no entry greater than the one it already holds. Sent back unchanged
+the delete is answered `SYNC_REPLAY_DETECTED`, the queue row is cleared as already applied, the next
+pull serves the same orphan again, and the repair runs again — the loop it exists to end, running
+forever. A normal delete never hits this: it is built from a local row by the domain layer, which
+stamps the clock on the way out, and the push path sends `delete` payloads verbatim by design. An
+orphan has no local row, which is what makes it an orphan, so nothing else can stamp it. Without
+signing keys the stamp is impossible, and the orphan is left for the next pull rather than spending a
+push that would only be refused again.
+
 ## Sync Type Negotiation
 
 Clients declare the record sync item types they understand via an `X-Memry-Sync-Types` header


### PR DESCRIPTION
## Problem

#837's orphan repair is correct in its reasoning and never actually worked.

When a child's FK parent is gone both locally and server-side, the repair declares it a confirmed orphan and enqueues a `delete` so every device stops re-pulling it. That delete has never landed. From a real device today:

```
OrphanRepair: FK parent gone server-side — tombstoning orphaned item   ×7
OrphanRepair: Orphan repair complete { repaired: 0, tombstoned: 7 }
PushCoordinator: Push entered { queuePending: 7 }
PushCoordinator: Push: server response { accepted: 0, rejected: 7 }
PushCoordinator: Push: replay detected, server already has this or newer   ×7
```

...and on the next pull, the same seven again: `deferred apply retries processed { retried: 7, applied: 0, failed: 7 }`. That ran for hours against one deleted project, twice within two seconds at one point. The loop the repair exists to end was running forever.

## Root cause

The enqueued payload was `orphan.item.content` — the payload this device had **just pulled** — so its clock is the server's *own* clock for that row. `detectReplay` rejects any push whose clock has no entry strictly greater than the one the server holds, so echoing it back is by definition a replay. The delete was refused, the queue row was cleared as "already applied", the next pull re-served the orphan, and the repair fired again.

A normal delete never hits this, which is why it went unnoticed: it is built from a local row by the domain layer, which stamps the clock on the way out, and `resolvePushPayload` deliberately returns `delete` payloads verbatim (`if (item.operation === 'delete') return item.payload`). An orphan has no local row — that is precisely what makes it an orphan — so nothing ever stamped it.

## Fix

Advance the clock with the existing `withIncrementedClock` from `@memry/sync-core` before enqueuing. Signing keys are read once per repair run, not per item, since it is a keychain read.

Without a device id the tombstone would just be a replay again, so the orphan is left for the next pull rather than spending a push to prove that.

## Verification

- `apps/desktop` main sync suites: **145 files / 2101 tests pass**.
- `pnpm typecheck` 17/17, eslint clean on the changed file, `git diff --check` clean, architecture and contract boundary checks pass.
- **Mutation-verified**: dropping the clock bump fails both new tests plus the existing tombstone case, and nothing else.
- `docs:impact --strict` covered, `docs:build` passes.

## Note on severity

These orphans are ghosts of an already-deleted project — no user data is missing, and not showing them is correct. The cost was a permanent re-pull loop: wasted pull work every cycle, a wasted push round trip, and `[error]`-level log noise, on every device on the account, forever.

Server-side rows for already-orphaned items are cleaned up by this the first time a patched client pulls them; no migration and no server change.