### PR TITLE
test(ingest): typecheck the vault watcher and CRDT provider suites

### DIFF
--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -65,7 +65,7 @@ const mocks = vi.hoisted(() => {
     safeRead: vi.fn(),
     parseNote: vi.fn(),
     markdownToYFragment: vi.fn(),
-    repairEmptyBlockIds: vi.fn(() => 0),
+    repairEmptyBlockIds: vi.fn((..._args: unknown[]) => 0),
     compactYDoc: vi.fn(),
     scheduleWriteback: vi.fn(),
     flushPendingWritebacks: vi.fn(),
@@ -189,6 +189,7 @@ vi.mock('./microtask-batch-broadcaster', () => ({
 
 import { CRDT_EVENTS, CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 import { CrdtProvider, getCrdtProvider, resetCrdtProvider } from './crdt-provider'
+import type { SnapshotPushFn } from './crdt-provider'
 
 mocks.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-crdt-'))
 
@@ -214,7 +215,7 @@ const makeRemoteUpdate = (text: string): Uint8Array => {
 describe('CrdtProvider', () => {
   let provider: CrdtProvider
   let queue: { enqueue: ReturnType<typeof vi.fn> }
-  let pushSnapshot: ReturnType<typeof vi.fn>
+  let pushSnapshot: ReturnType<typeof vi.fn<SnapshotPushFn>>
 
   beforeEach(async () => {
     vi.clearAllMocks()
@@ -241,7 +242,7 @@ describe('CrdtProvider', () => {
     )
     mocks.compactYDoc.mockReturnValue(null)
     queue = { enqueue: vi.fn() }
-    pushSnapshot = vi.fn().mockResolvedValue(undefined)
+    pushSnapshot = vi.fn<SnapshotPushFn>().mockResolvedValue(undefined)
     provider = new CrdtProvider()
     await provider.init(queue as any, pushSnapshot)
   })

--- a/apps/desktop/src/main/vault/watcher.test.ts
+++ b/apps/desktop/src/main/vault/watcher.test.ts
@@ -6,7 +6,13 @@ import { JournalChannels, NotesChannels } from '@memry/contracts/ipc-channels'
 import { noteCache, noteTags, noteLinks } from '@memry/db-schema/schema/notes-cache'
 import { noteMetadata } from '@memry/db-schema/data-schema'
 import { createTestVault, createTestNote } from '@tests/utils/test-vault'
-import { createTestDataDb, createTestIndexDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import {
+  createTestDataDb,
+  createTestIndexDb,
+  asClientDb,
+  type TestDatabaseResult
+} from '@tests/utils/test-db'
+import type { VaultConfig } from '@memry/contracts/vault-api'
 import { MockBrowserWindow } from '@tests/utils/mock-electron'
 import { BrowserWindow } from 'electron'
 import { parseNote, serializeNote } from './frontmatter'
@@ -15,10 +21,11 @@ import { createNoteDerivedStateProjector } from '../projections/projectors/note-
 import { startProjectionRuntime, stopProjectionRuntime } from '../projections'
 
 const mockWatch = vi.hoisted(() => vi.fn())
-const baseConfig = {
+const baseConfig: VaultConfig = {
   excludePatterns: [],
   defaultNoteFolder: 'notes',
   journalFolder: 'journal',
+  journalDateFormat: 'YYYY-MM-DD',
   attachmentsFolder: 'attachments'
 }
 
@@ -81,7 +88,7 @@ describe('vault watcher', () => {
     indexDb = createTestIndexDb()
     indexDb.sqlite.pragma('foreign_keys = ON')
 
-    vi.mocked(getDatabase).mockReturnValue(dataDb.db)
+    vi.mocked(getDatabase).mockReturnValue(asClientDb(dataDb.db))
     vi.mocked(getIndexDatabase).mockReturnValue(indexDb.db)
     vi.mocked(updateFtsContent).mockImplementation(() => false)
     vi.mocked(updateNoteEmbedding).mockResolvedValue(false)

--- a/apps/desktop/tsconfig.test.node.json
+++ b/apps/desktop/tsconfig.test.node.json
@@ -129,7 +129,6 @@
     "src/main/sync/concurrency.test.ts",
     "src/main/sync/content-sync-base.test.ts",
     "src/main/sync/corrupt-recovery.test.ts",
-    "src/main/sync/crdt-provider.test.ts",
     "src/main/sync/device-keys.test.ts",
     "src/main/sync/device-registration.test.ts",
     "src/main/sync/dirty-recovery.test.ts",
@@ -175,7 +174,6 @@
     "src/main/vault/resolve-embed.test.ts",
     "src/main/vault/templates.test.ts",
     "src/main/vault/vault-preferences.test.ts",
-    "src/main/vault/watcher.test.ts",
     "src/preload/api/preload-api.test.ts",
     "src/preload/generated-rpc.test.ts"
   ],

--- a/docs/superpowers/specs/2026-08-15-large-file-ingest-freeze-design.md
+++ b/docs/superpowers/specs/2026-08-15-large-file-ingest-freeze-design.md
@@ -1,0 +1,196 @@
+# Large-file vault ingest: freeze root cause and tiered-ingest design
+
+Status: design, not implemented
+Date: 2026-08-15
+Epic: #1468
+Children: #1458 (prefactor) · #1459 (the fix) · #1460 (stat-only ingest) · #1461 (no sync, both sides) · #1462 (2 GB read-only viewer) · #1463 (threshold calibration) · #1464 (in-file search) · #1465 (silent sync ceiling)
+Related: #1445 (oversized note never syncs, silently)
+
+## Symptom
+
+A `.md` file pasted into the vault from Finder locks the app. Reproduced on three
+installs: dev A (signed in, synced), dev B (received the same note over sync),
+and a third signed-out install. All three showed a spinner and macOS
+"not responding"; the 1.9 MB case recovered after seconds, the 17.8 MB case was
+force-quit before it recovered.
+
+Reported timing, which turns out to be exact: **the freeze starts the moment the
+row appears in the sidebar.**
+
+## Measurements
+
+All on the reporter's machine, against the real files.
+
+| stage | 1.9 MB | 17.8 MB |
+|---|---|---|
+| djb2 content hash + every metadata regex | 20 ms | ~200 ms |
+| FTS5 insert, `tokenize='porter unicode61'` | 14 ms | 93 ms (19.5 MB index) |
+| **`tryParseMarkdownToBlocks`** | **6 594 ms** | see below |
+
+The first two were the initial suspects and both are cleared by measurement.
+
+Parse cost tracks **single-block size**, not file size:
+
+```
+1.81 MB, blank-line separated (124 blocks)  ->    477 ms
+1.81 MB, as-is                (1 block)     ->  6 594 ms      14x
+2.73 MB, as-is                (2 blocks)    ->  8 936 ms
+```
+
+Identical bytes; the only difference is block shape. Log dumps contain no blank
+lines, so remark parses the whole file as one paragraph with hard breaks — one
+block holding millions of inline nodes, and the inline parse is roughly
+quadratic in block size. Quadratic extrapolation puts the 17.8 MB file near ten
+minutes, before counting GC pressure from the resulting ~18 MB Y.Doc.
+
+Engine ceilings that bound any design here:
+
+```
+V8 max string length : 536 870 888 chars  (~512 MB)  -> readFile(…, 'utf-8') throws ERR_STRING_TOO_LONG above this
+SQLite MAX_LENGTH    : 2 147 483 645 bytes (~2 GB)
+```
+
+## Root cause
+
+`handleMarkdownFileAdd` does not separate *listing a note* from *processing its
+body*. Everything the sidebar row needs is `stat` + filename. What actually runs
+before the row is shown:
+
+| # | site | work |
+|---|---|---|
+| 1 | `vault/watcher.ts:333` | `safeRead` — whole file into one JS string |
+| 2 | `:339` | `parseNote` / gray-matter |
+| 3 | `:343` | `generateContentHash`, char-by-char djb2 |
+| 4 | `:354` | `syncNoteToCache`; puts full `parsedContent` on the projection event |
+| 5 | `:368` | `flushProjectionEvents` → FTS insert |
+| 6 | `:395` | `syncNoteCreate` → `initForNote` → `open()` → `seedFromMarkdown` → `markdownToYFragment` |
+| 7 | `:399` | `emitEvent(CREATED)` — sidebar row appears |
+
+Step 6 is called before step 7 but is not awaited: `initForNote` yields at its
+first `await`, `emitEvent` paints the row, the handler returns, and the
+microtask queue then resumes `seedFromMarkdown` — which runs the BlockNote parse
+on the main process with no yield point. That ordering is exactly the reported
+"freezes the moment I see it in the sidebar".
+
+**One sentence:** to put one row in the sidebar, the app reads, hashes, indexes
+and CRDT-seeds the entire file, on the main process, before the user has touched
+the note.
+
+A size ceiling does not fix this. Any file *under* the ceiling still takes the
+same path. The ceiling only picks which files are excluded; it is not the fix.
+
+## Design: tiered ingest
+
+Two classes of vault file, decided at ingest, and three tiers of work.
+
+### Classes
+
+- **Note** — editable, BlockNote, CRDT-seeded, synced. Today's behaviour.
+- **Large file** — read-only streaming viewer. No BlockNote, no Y.Doc, no sync.
+  Carries a visible "read-only, not synced" badge so it never fails silently
+  the way #1445 does.
+
+Classification, both conditions required for **Note**:
+
+```
+NOTE_MAX_BYTES       = 2 MB      // 264 ms/MB measured on well-formed markdown -> ~530 ms at 2 MB
+NOTE_MAX_BLOCK_BYTES = 128 KB    // 0.2 MB single block measured at 57 ms -> ~30 ms at 128 KB
+```
+
+Largest block = largest blank-line-separated segment. Files over
+`NOTE_MAX_BYTES` are classified on `stat` alone and never read. Files under it
+are cheap to read, so the largest block is computed exactly rather than sampled.
+
+A fixed byte ceiling alone misclassifies both directions: it rejects a
+well-formed 3 MB note that parses fine, and accepts a 900 KB log dump that does
+not. The pair is the point.
+
+`NOTE_MAX_BYTES` is derived from a single measurement (1.81 MB / 124 blocks /
+477 ms). It should be re-tuned against a corpus of real notes before it ships;
+2 MB is generous for prose (~300k words) so the risk is low, but the number is
+not yet well-founded.
+
+### Tiers
+
+- **T0 — on `add`, O(1).** `stat` + path + title → sidebar row. The file is not
+  read. Applies to both classes.
+- **T1 — on idle, smallest file first.** Metadata + FTS, off the main thread,
+  chunked for large files. Fills in `wordCount` / `snippet`.
+- **T2 — on click.** Content loads. Note class → BlockNote + CRDT seed. Large
+  file class → streaming viewer.
+
+**CRDT seeding never runs at ingest.** It moves to the point where a note is
+actually opened for editing. First open of a note pays up to ~500 ms; today that
+cost is paid at ingest while blocking the main process, so a visible 0.5 s
+replaces an invisible 7 s.
+
+### Viewer
+
+Ceiling **2 GB**. 512 MB was considered and rejected: it simplifies nothing,
+because 512 MB cannot be held as a JS string either, so the viewer must read in
+chunks regardless. Once chunked reading exists, 512 MB and 2 GB cost the same.
+
+Requirements: chunked reads via file handle + offset, a line-offset index built
+by one streaming scan on a worker, virtualized rendering (the repo already has
+`virtualized-notes-tree.tsx` / `virtualized-all-tasks-view.tsx` to follow),
+incremental in-file search. Above 2 GB: the row still appears in the sidebar,
+clicking reports why it cannot open rather than a bare "failed to open".
+
+### Sync
+
+Large-file class does not sync at all. On other devices the file does not appear
+in the sidebar. Showing an unopenable row is worse than not showing it. Syncing
+metadata without a body is more correct but opens a new class of inconsistency
+for materially more work; not in this design.
+
+### Receiver side
+
+Device B froze without ever touching Finder — it received the note over sync
+(`memrynote-B/main.old.log:55716`, `CrdtWriteback: Created new note from sync`).
+The snapshot push from A was rejected at the 5 MB encrypt cap (#1445), so the
+body arrived as incremental CRDT updates, which are capped at 256 KB merged /
+512 KB per flush and therefore pass. B then wrote the file back and paid the
+same parse.
+
+An ingest-side guard alone would not have saved B. The classification must also
+apply to notes arriving over sync: a note whose written-back body exceeds the
+Note-class thresholds degrades to large-file class on the receiver too, and is
+not seeded.
+
+### Backward compatibility
+
+No reindex, no migration, no full re-scan. Existing note rows, FTS rows and CRDT
+stores stay valid as they are; the tiered path applies only to new `add` events
+and to new inbound sync writebacks. `search-projector.ts:267` already documents
+what a full re-scan cost last time — do not repeat it.
+
+## Non-goals
+
+- Moving the BlockNote parse to a worker. It relocates a ten-minute parse rather
+  than removing it, and the note would read as empty for the duration. Separate
+  conversation.
+- Editing large files. Not possible at these sizes at any threshold.
+- Fixing #1445. Related and same underlying gap, but a separate issue: this
+  design makes the oversized-note case unreachable going forward, while #1445
+  covers the silent failure for notes already in existing vaults.
+
+## Verification
+
+1. 250 MB `.md` pasted into the vault → row appears, no main-process stall.
+   Assert no `safeRead` on the ingest path for it.
+2. 1.9 MB log dump (no blank lines) → classified large-file, viewer opens,
+   never seeded.
+3. Well-formed 1.8 MB markdown, 124 blocks → stays Note class, opens, seeds,
+   syncs.
+4. Sync: large-file class produces no sync item; receiver sidebar stays clean.
+5. Receiver: inbound writeback over the thresholds degrades to large-file class
+   and does not seed.
+6. Existing vault opens with no reindex and no FTS rebuild.
+
+## Open risks
+
+- `NOTE_MAX_BYTES` rests on one data point; tune against real notes.
+- `NoteListItem.wordCount` / `snippet` become nullable — a renderer-visible
+  contract change; needs the IPC contract updated and `pnpm ipc:check` run.
+- The viewer is the bulk of the work here and is the piece most likely to want
+  its own spec.


### PR DESCRIPTION
Closes #1458. Prefactor for EPIC #1468.

`apps/desktop/src/main/vault/watcher.test.ts` and `apps/desktop/src/main/sync/crdt-provider.test.ts` sat in the `exclude` backlog of `apps/desktop/tsconfig.test.node.json`, so they were never typechecked. Every ticket in the large-file ingest series adds assertions to those two files, and the repo rule is that a touched test file must compile and that the backlog only ever shrinks.

## What changed

Six errors, all in test scaffolding. No assertions changed, no production code touched.

- `repairEmptyBlockIds` was mocked as `vi.fn(() => 0)` — nullary, so the variadic `vi.mock` wrapper could not spread into it (TS2556).
- `pushSnapshot` was declared `ReturnType<typeof vi.fn>`, which is not assignable to `SnapshotPushFn` at the three `init()` call sites (TS2345 x3). Now typed via `vi.fn<SnapshotPushFn>()`.
- The watcher's `getDatabase` mock passed a `TestDb` where `DataDb` was expected. Uses the existing `asClientDb` helper from `tests/utils/test-db.ts`.
- `baseConfig` was missing `journalDateFormat`, so it was not a `VaultConfig`. Now typed as `VaultConfig` with the field present.

Both files removed from the exclude array. No file added to the backlog — it is 158 entries down to 156.

Also lands the design doc for the epic (`docs/superpowers/specs/2026-08-15-large-file-ingest-freeze-design.md`), which the rest of the series references.

## Testing

- `pnpm --filter @memry/desktop typecheck:test` — 0 errors (was 6)
- `pnpm typecheck` — 17/17 tasks green
- `pnpm lint` — 0 errors; neither touched file appears in the 90 pre-existing warnings
- `pnpm check:architecture`, `pnpm check:contracts` — pass
- `git diff --check` — clean
- The two touched suites: 58 passed
- Full desktop suite, run per project to sidestep the known combined-run SIGSEGV flake — all five green, exit 0 each:

  | project | result |
  |---|---|
  | shared | 142 files, 2455 passed |
  | main | 513 files, 6473 passed (1 expected fail, 4 skipped) |
  | main-integration | 1 file, 9 passed |
  | preload | 4 files, 30 passed |
  | renderer | 611 files, 7009 passed (6 skipped) |

  The combined `pnpm test:desktop` run reached 15912 passing tests with zero failures before segfaulting at teardown — the known turbo flake, reproduced as a clean pass when split.