### PR TITLE
fix(notes): opening a note leaves its frontmatter alone

### DIFF
--- a/apps/desktop/src/main/notes/domain.test.ts
+++ b/apps/desktop/src/main/notes/domain.test.ts
@@ -34,10 +34,14 @@ describe('notes domain adapter', () => {
   })
 
   it('dispatches sync and CRDT side effects after creating a note', async () => {
+    // `tags` is what the index holds — the frontmatter tag PLUS the body's
+    // `#inline`. Only the declared one may reach the CRDT tag array, which
+    // write-back serializes back into the file's `tags:` block (#1454).
     const note = {
       id: 'note-1',
       title: 'Test Note',
-      tags: ['focus']
+      tags: ['focus', 'inline'],
+      frontmatter: { tags: ['focus'] }
     }
     vi.mocked(noteVault.createNote).mockResolvedValue(
       note as Awaited<ReturnType<typeof noteVault.createNote>>
@@ -45,13 +49,13 @@ describe('notes domain adapter', () => {
 
     const result = await createNoteCommand({
       title: 'Test Note',
-      content: 'Hello world'
+      content: 'Hello world #inline'
     })
 
     expect(result).toBe(note)
     expect(noteVault.createNote).toHaveBeenCalledWith({
       title: 'Test Note',
-      content: 'Hello world'
+      content: 'Hello world #inline'
     })
     expect(runtimeEffects.syncNoteCreate).toHaveBeenCalledWith('note-1', 'Test Note', ['focus'])
   })

--- a/apps/desktop/src/main/notes/domain.ts
+++ b/apps/desktop/src/main/notes/domain.ts
@@ -9,6 +9,7 @@ import {
   type NoteCreateInput,
   type NoteUpdateInput
 } from '../vault/notes'
+import { extractTags } from '../vault/frontmatter'
 import { NoteError, NoteErrorCode } from '../lib/errors'
 import {
   syncNoteCreate,
@@ -20,7 +21,10 @@ import {
 
 export async function createNoteCommand(input: NoteCreateInput): Promise<Note> {
   const note = await createNote(input)
-  syncNoteCreate(note.id, note.title, note.tags)
+  // Frontmatter tags only. `note.tags` merges the body's `#hashtag`s in for the
+  // index, and the CRDT tag array they would land in is what write-back writes
+  // back into the file's `tags:` block (#1454).
+  syncNoteCreate(note.id, note.title, extractTags(note.frontmatter))
   return note
 }
 

--- a/apps/desktop/src/main/sync/note-open-byte-stability.test.ts
+++ b/apps/desktop/src/main/sync/note-open-byte-stability.test.ts
@@ -380,6 +380,66 @@ describe('repeated open -> write-back cycles converge', () => {
   })
 })
 
+/**
+ * #1454. The fixtures above pass because nothing puts a tag in the doc's tag
+ * array; the app used to, and that is where the rewrite came from. Write-back
+ * treats `doc.getArray('tags')` as authoritative for the file's `tags:` block
+ * (`mergeFrontmatter`), and the watcher used to seed it with `syncResult.tags`
+ * — the INDEX's tag list, which merges the body's `#hashtag`s in. So a note
+ * whose only tag was in its body gained a frontmatter block on first open.
+ *
+ * These two tests pin both halves: what a seeded array does to the file, and
+ * that the file's own `tags:` block round-trips through it untouched.
+ */
+describe('the tag array decides whether opening a note rewrites its frontmatter', () => {
+  /** What `CrdtProvider.initForNote` does with the tags it is handed. */
+  function seedTagArray(doc: Y.Doc, tags: string[]): void {
+    const tagArray = doc.getArray('tags')
+    doc.transact(() => {
+      if (tags.length > 0) tagArray.push(tags)
+    })
+  }
+
+  it('a body tag in the array injects a tags: block into a file that had none', async () => {
+    // #given the note from the issue: one inline hash tag, no frontmatter
+    const body = 'Tagged #hashtag here.'
+    const absolutePath = seedVaultNote(body)
+    const doc = await openNote(absolutePath)
+
+    // #when the doc is seeded the way the merged index tag list would seed it
+    seedTagArray(doc, ['hashtag'])
+    await runWriteback(doc)
+
+    // #then opening the note modified it. This is the mechanism #1454 removes —
+    // kept here because the fix is "never put a body tag in this array", and
+    // that is only meaningful if what the array does is on record.
+    expect(mocks.atomicWrites).toHaveLength(1)
+    const rewritten = fs.readFileSync(absolutePath, 'utf8')
+    expect(rewritten).toContain('tags:')
+    expect(rewritten).toContain('- hashtag')
+    expect(rewritten).not.toBe(body)
+  })
+
+  it('a tags: block the file already declares survives a round trip unwritten', async () => {
+    // #given a note that declares its own tags — the array is seeded from the
+    // frontmatter, which is exactly what it holds after the fix
+    // No blank line after the closing `---`: that is the form `serializeNote`
+    // writes, and this test is about tags, not about frontmatter spacing.
+    const body = ['---', 'tags:', '  - Declared', '---', 'Tagged #hashtag here.'].join('\n')
+    const absolutePath = seedVaultNote(body)
+    const doc = await openNote(absolutePath)
+
+    // #when
+    seedTagArray(doc, ['Declared'])
+    await runWriteback(doc)
+
+    // #then nothing was written: the declared tag is already in the file, and
+    // the body tag never entered the array to be promoted
+    expect(mocks.atomicWrites).toEqual([])
+    expect(fs.readFileSync(absolutePath, 'utf8')).toBe(body)
+  })
+})
+
 describe('the canonical form of a wiki link inside the CRDT', () => {
   it('main seeds the shared doc with TEXT, not a node', async () => {
     // #given / #when main parses the vault file for the collaborative path

--- a/apps/desktop/src/main/vault/watcher.test.ts
+++ b/apps/desktop/src/main/vault/watcher.test.ts
@@ -94,7 +94,7 @@ describe('vault watcher', () => {
     vi.mocked(getIndexDatabase).mockReturnValue(indexDb.db)
     vi.mocked(updateFtsContent).mockImplementation(() => false)
     vi.mocked(updateNoteEmbedding).mockResolvedValue(false)
-    vi.mocked(getConfig).mockReturnValue(baseConfig)
+    vi.mocked(getConfig).mockReturnValue(baseConfig as never)
 
     window = new MockBrowserWindow()
     vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([window as never])
@@ -296,7 +296,9 @@ describe('vault watcher', () => {
     expect(indexedTags).toEqual(['Declared', 'hashtag'])
 
     // …but only what the file itself declares is handed to the CRDT
-    expect(syncNoteCreate).toHaveBeenCalledWith(noteId, 'inline-tag-note', ['Declared'])
+    expect(syncNoteCreate).toHaveBeenCalledWith(noteId, 'inline-tag-note', ['Declared'], {
+      sizeClass: expect.any(String)
+    })
   })
 
   it('hands the CRDT no tags at all for a note whose only tag is in its body', async () => {
@@ -318,7 +320,9 @@ describe('vault watcher', () => {
 
     // An empty array is the whole fix: `mergeFrontmatter` only forces `tags:`
     // onto the file when the doc's tag array is non-empty.
-    expect(syncNoteCreate).toHaveBeenCalledWith(noteId, 'body-only-tag-note', [])
+    expect(syncNoteCreate).toHaveBeenCalledWith(noteId, 'body-only-tag-note', [], {
+      sizeClass: expect.any(String)
+    })
   })
 
   // ==========================================================================

--- a/apps/desktop/src/main/vault/watcher.test.ts
+++ b/apps/desktop/src/main/vault/watcher.test.ts
@@ -260,6 +260,68 @@ describe('vault watcher', () => {
   })
 
   // ==========================================================================
+  // #1454: a body `#hashtag` is index-only — it may not reach the file's
+  // frontmatter. The CRDT tag array is authoritative for write-back's `tags:`
+  // block, so seeding it from the merged tag list rewrites the user's file the
+  // first time they open the note.
+  // ==========================================================================
+  it('seeds the CRDT with the declared tags only, never the body hash tags', async () => {
+    const watcher = new VaultWatcher() as any
+    watcher.vaultPath = vault.path
+
+    const notePath = createTestNote(vault, {
+      title: 'inline-tag-note',
+      content: 'Tagged #hashtag here.',
+      tags: ['Declared']
+    })
+
+    await watcher.handleFileAdd(notePath)
+
+    const cached = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/inline-tag-note.md'))
+      .get()
+    const noteId = cached!.id
+
+    // the index still merges the body tag in — search, the tag hub and the
+    // graph all depend on that, and none of them touch the file
+    const indexedTags = indexDb.db
+      .select()
+      .from(noteTags)
+      .where(eq(noteTags.noteId, noteId))
+      .all()
+      .map((tag) => tag.tag)
+      .sort()
+    expect(indexedTags).toEqual(['Declared', 'hashtag'])
+
+    // …but only what the file itself declares is handed to the CRDT
+    expect(syncNoteCreate).toHaveBeenCalledWith(noteId, 'inline-tag-note', ['Declared'])
+  })
+
+  it('hands the CRDT no tags at all for a note whose only tag is in its body', async () => {
+    const watcher = new VaultWatcher() as any
+    watcher.vaultPath = vault.path
+
+    const notePath = createTestNote(vault, {
+      title: 'body-only-tag-note',
+      content: 'Tagged #hashtag here.'
+    })
+
+    await watcher.handleFileAdd(notePath)
+
+    const noteId = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/body-only-tag-note.md'))
+      .get()!.id
+
+    // An empty array is the whole fix: `mergeFrontmatter` only forces `tags:`
+    // onto the file when the doc's tag array is non-empty.
+    expect(syncNoteCreate).toHaveBeenCalledWith(noteId, 'body-only-tag-note', [])
+  })
+
+  // ==========================================================================
   // T602: rename flow integration
   // ==========================================================================
   it('processes rename flow via rename-tracker (content-hash match)', async () => {

--- a/apps/desktop/src/main/vault/watcher.ts
+++ b/apps/desktop/src/main/vault/watcher.ts
@@ -13,7 +13,7 @@ import chokidar from 'chokidar'
 import type { FSWatcher } from 'chokidar'
 import { broadcastToAllWindows } from '../lib/window-broadcast'
 import { getConfig } from './index'
-import { parseNote, generateContentHash, extractProperties } from './frontmatter'
+import { parseNote, generateContentHash, extractProperties, extractTags } from './frontmatter'
 import { safeRead } from './file-ops'
 import { generateNoteId } from '../lib/id'
 import { syncNoteToCache, syncFileToCache, deleteNoteFromCache } from './note-sync'
@@ -369,6 +369,12 @@ export class VaultWatcher {
     void flushProjectionEvents()
 
     const tags = syncResult.tags
+    // The CRDT tag array is what write-back serializes back into the file's
+    // `tags:` block, so it may only carry tags the file itself declares.
+    // `syncResult.tags` merges the body's `#hashtag`s in for the index; seeding
+    // those would inject a `tags:` block into a note that never had one, the
+    // first time it is opened — "opening a note modified it" (#1454).
+    const declaredTags = extractTags(parsed.frontmatter)
     const properties = extractProperties(parsed.frontmatter)
 
     if (tags.length > 0) {
@@ -410,10 +416,12 @@ export class VaultWatcher {
       const journalDate = extractJournalDate(relativePath)
       if (!isLargeFile) {
         enqueueJournalCreate(noteId, journalDate)
-        void initializeJournalCrdt(noteId, journalDate, tags)
+        void initializeJournalCrdt(noteId, journalDate, declaredTags)
       }
     } else {
-      syncNoteCreate(noteId, parsed.title, tags, { sizeClass: classification.sizeClass })
+      syncNoteCreate(noteId, parsed.title, declaredTags, {
+        sizeClass: classification.sizeClass
+      })
     }
 
     // Emit event to renderer

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx
@@ -305,6 +305,9 @@ describe('useEditorSync', () => {
     )
 
     await waitFor(() => expect(result.current.isContentReadyRef.current).toBe(true))
+    // Loading reports the tag the body ALREADY had, flagged as the baseline —
+    // opening a note must not write to it (#1454).
+    expect(onInlineTagsChange).toHaveBeenCalledWith(['Focus'], 'load')
     onHeadingsChange.mockClear()
     onInlineTagsChange.mockClear()
     ;(editor.document[1].content as string[]) = ['Ship #Focus #Build']
@@ -332,8 +335,76 @@ describe('useEditorSync', () => {
     act(() => {
       vi.advanceTimersByTime(100)
     })
-    expect(onInlineTagsChange).toHaveBeenCalledWith(['Build', 'Focus'])
+    expect(onInlineTagsChange).toHaveBeenCalledWith(['Build', 'Focus'], 'edit')
     expect(result.current.prevInlineTagsRef.current).toEqual(['Build', 'Focus'])
+  })
+
+  it('reports the loaded tags as a baseline, and only a real edit as an edit', async () => {
+    // #given a note whose body already carries a hash tag
+    const onInlineTagsChange = vi.fn()
+    const editor = createEditor()
+    const initialBlocks = [
+      {
+        id: 'paragraph-1',
+        type: 'paragraph',
+        props: {},
+        content: ['Tagged #hashtag here.'],
+        children: []
+      }
+    ]
+
+    const { result } = renderHook(() =>
+      useEditorSync({
+        editor,
+        initialContent: initialBlocks as never,
+        contentType: 'blocks',
+        onInlineTagsChange
+      })
+    )
+
+    // #when it is opened
+    await waitFor(() => expect(result.current.isContentReadyRef.current).toBe(true))
+
+    // #then the only report is the baseline, and it carries the tag the file
+    // already had — nothing for the owner to persist
+    expect(onInlineTagsChange.mock.calls).toEqual([[['hashtag'], 'load']])
+    expect(result.current.prevInlineTagsRef.current).toEqual(['hashtag'])
+
+    // #when the user then deletes that tag from the body
+    vi.useFakeTimers()
+    ;(editor.document[0].content as string[]) = ['Tagged here.']
+    act(() => {
+      result.current.handleChange()
+      vi.advanceTimersByTime(300)
+    })
+
+    // #then THAT is an edit — removing the last inline tag still reaches the owner
+    expect(onInlineTagsChange).toHaveBeenLastCalledWith([], 'edit')
+  })
+
+  it('reports a baseline on the collaborative path too, where content is already bound', async () => {
+    // #given the collaborative branch: the shared fragment is bound to the
+    // editor before this hook runs, so there is nothing to parse — but the tags
+    // in that body are just as much "what the note was opened with" (#1454)
+    const onInlineTagsChange = vi.fn()
+    const undoManager = { clear: vi.fn(), stopCapturing: vi.fn() }
+    yUndoMocks.getState.mockReturnValue({ undoManager })
+    const editor = createEditor()
+    ;(editor.document[0].content as unknown as string[]) = ['Tagged #hashtag here.']
+
+    // #when
+    const { result } = renderHook(() =>
+      useEditorSync({
+        editor,
+        yjsFragment: {} as never,
+        onInlineTagsChange
+      })
+    )
+
+    // #then
+    await waitFor(() => expect(onInlineTagsChange).toHaveBeenCalled())
+    expect(onInlineTagsChange.mock.calls).toEqual([[['hashtag'], 'load']])
+    expect(result.current.prevInlineTagsRef.current).toEqual(['hashtag'])
   })
 
   it('re-applies external content in place when the external revision changes', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx
@@ -42,7 +42,7 @@ function createEditor(parsedBlocks: any[] = []) {
   const transact = vi.fn((callback: (tr: any) => unknown) => {
     const tr = {
       setMeta: vi.fn().mockReturnThis()
-    }
+    } as { setMeta: ReturnType<typeof vi.fn>; __nextBlocks?: unknown }
     const result = callback(tr)
     if (Array.isArray(tr.__nextBlocks)) {
       document = tr.__nextBlocks
@@ -546,7 +546,7 @@ describe('useEditorSync', () => {
           initialContent: 'Body',
           contentType: 'markdown',
           isRemoteUpdateRef,
-          yjsFragment,
+          yjsFragment: yjsFragment as never,
           onContentChange,
           onMarkdownChange
         }),

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
@@ -18,7 +18,7 @@ import {
 } from '../markdown-utils'
 import { createLinkMentionContent } from '../link-mention'
 import { fetchLinkPreview } from '@/lib/url-metadata'
-import type { HeadingInfo } from '../types'
+import type { HeadingInfo, InlineTagsOrigin } from '../types'
 import { createLogger } from '@/lib/logger'
 import { trackRendererError } from '@/lib/telemetry-diagnostics'
 
@@ -124,7 +124,13 @@ interface EditorSyncParams {
   onContentChange?: (blocks: Block[]) => void
   onMarkdownChange?: (markdown: string) => void
   onHeadingsChange?: (headings: HeadingInfo[]) => void
-  onInlineTagsChange?: (tags: string[]) => void
+  /**
+   * Reports the inline `#tags` in the body. `origin` separates the tag set the
+   * note was OPENED with (`'load'`) from one the user just typed (`'edit'`):
+   * opening a note must not modify it, so the load report is a baseline to diff
+   * against and never something to persist (#1454).
+   */
+  onInlineTagsChange?: (tags: string[], origin: InlineTagsOrigin) => void
 }
 
 interface EditorSyncResult {
@@ -203,6 +209,19 @@ export function useEditorSync({
 
     let cancelled = false
 
+    /**
+     * Report the tag set the note was opened with as the baseline for later
+     * edits, without asking anyone to persist it. Opening a note must not
+     * modify it (#1454), and every hash tag in the body reads as "new" until
+     * this baseline exists.
+     */
+    const reportLoadedInlineTags = (): void => {
+      if (!onInlineTagsChange) return
+      const tags = extractInlineTags(editor.document as Block[])
+      prevInlineTagsRef.current = tags
+      onInlineTagsChange(tags, 'load')
+    }
+
     // Collaboration owns the document: the main process feeds an external edit
     // into the shared Y.Doc (`feedExternalEditToCrdt`), the IPC provider applies
     // it here, and y-prosemirror merges it into this editor in place. Replacing
@@ -219,6 +238,9 @@ export function useEditorSync({
         const headings = extractHeadings(editor.document as Block[])
         if (!cancelled) onHeadingsChange(headings)
       }
+      // The shared fragment is already bound to the editor here (that is what
+      // `extractHeadings` above reads), so this is the note's opening tag set.
+      if (!cancelled) reportLoadedInlineTags()
       return () => {
         cancelled = true
       }
@@ -296,11 +318,7 @@ export function useEditorSync({
             const headings = extractHeadings(editor.document as Block[])
             onHeadingsChange(headings)
           }
-          if (onInlineTagsChange) {
-            const tags = extractInlineTags(editor.document as Block[])
-            prevInlineTagsRef.current = tags
-            onInlineTagsChange(tags)
-          }
+          reportLoadedInlineTags()
         }
       }
     }
@@ -370,7 +388,7 @@ export function useEditorSync({
         const prevKey = [...prevInlineTagsRef.current].sort().join(',')
         if (tagsKey !== prevKey) {
           prevInlineTagsRef.current = tags
-          onInlineTagsChange(tags)
+          onInlineTagsChange(tags, 'edit')
         }
       }, 300)
     }

--- a/apps/desktop/src/renderer/src/components/note/content-area/index.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/index.ts
@@ -14,6 +14,7 @@ export type {
   ContentAreaProps,
   HeadingInfo,
   HighlightInfo,
+  InlineTagsOrigin,
   SelectionInfo,
   ReviewSelection,
   Block

--- a/apps/desktop/src/renderer/src/components/note/content-area/types.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/types.ts
@@ -25,6 +25,19 @@ export interface HeadingInfo {
 }
 
 // =============================================================================
+// INLINE TAG TYPES
+// =============================================================================
+
+/**
+ * Where an inline-tag report came from.
+ *
+ * `'load'` — the tag set the editor opened with. It is the baseline later
+ * reports are diffed against; persisting it would rewrite the file on open.
+ * `'edit'` — the user changed the body, so the note's tags follow.
+ */
+export type InlineTagsOrigin = 'load' | 'edit'
+
+// =============================================================================
 // SELECTION TYPES
 // =============================================================================
 
@@ -138,8 +151,15 @@ export interface ContentAreaProps {
   tagColorMap?: Map<string, string>
   /** Map of tag name to icon (raw emoji or "icon:Name") for inline hash tag display */
   tagIconMap?: Map<string, string>
-  /** Callback when inline #tags change in editor content */
-  onInlineTagsChange?: (tags: string[]) => void
+  /**
+   * Callback when inline #tags change in editor content.
+   *
+   * `origin` says where the report came from: `'load'` is the tag set the note
+   * was OPENED with — a baseline to diff later edits against, never something
+   * to persist — and `'edit'` is a real change the user made. Opening a note
+   * must not modify it (#1454), so only `'edit'` may write.
+   */
+  onInlineTagsChange?: (tags: string[], origin: InlineTagsOrigin) => void
   /** Ref that receives a focusAtEnd function to focus the editor at the end of the document */
   focusAtEndRef?: React.RefObject<(() => void) | null>
   /**

--- a/apps/desktop/src/renderer/src/components/note/index.ts
+++ b/apps/desktop/src/renderer/src/components/note/index.ts
@@ -4,7 +4,13 @@ export type { HeadingItem } from './note-layout'
 
 // Content Area
 export { ContentArea } from './content-area'
-export type { ContentAreaProps, HeadingInfo, SelectionInfo, Block } from './content-area'
+export type {
+  ContentAreaProps,
+  HeadingInfo,
+  InlineTagsOrigin,
+  SelectionInfo,
+  Block
+} from './content-area'
 
 // Re-export shared outline panel for convenience
 export { OutlineInfoPanel, type DocumentStats } from '@/components/shared'

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -311,7 +311,7 @@ vi.mock('@/components/note', () => ({
     ) => void
     onLinkClick: (href: string) => void
     onInternalLinkClick: (target: string) => void
-    onInlineTagsChange: (tags: string[]) => void
+    onInlineTagsChange: (tags: string[], origin: 'load' | 'edit') => void
     focusAtEndRef: React.MutableRefObject<(() => void) | null>
   }) => {
     const [content] = useState(initialContent)
@@ -357,10 +357,14 @@ vi.mock('@/components/note', () => ({
         <button type="button" onClick={() => onInternalLinkClick('Missing.png')}>
           Internal missing file
         </button>
-        <button type="button" onClick={() => onInlineTagsChange(['work', 'urgent'])}>
+        {/* What opening the note reports: the tags the body already carried. */}
+        <button type="button" onClick={() => onInlineTagsChange(['work'], 'load')}>
+          Load inline tags
+        </button>
+        <button type="button" onClick={() => onInlineTagsChange(['work', 'urgent'], 'edit')}>
           Sync inline tags
         </button>
-        <button type="button" onClick={() => onInlineTagsChange([])}>
+        <button type="button" onClick={() => onInlineTagsChange([], 'edit')}>
           Clear inline tags
         </button>
       </div>
@@ -795,6 +799,39 @@ describe('NotePage', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear inline tags' }))
+    await waitFor(() => expect(mocks.updateNote).toHaveBeenCalledWith({ id: 'note-1', tags: [] }))
+  })
+
+  it('does not write the note when opening it reports its inline tags', async () => {
+    // #given a note opened with `#work` in its body (#1454)
+    renderWithProviders(<NotePage noteId="note-1" />)
+    await screen.findByRole('button', { name: 'Load inline tags' })
+
+    // #when the editor reports the tag set it loaded with
+    fireEvent.click(screen.getByRole('button', { name: 'Load inline tags' }))
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // #then nothing is persisted — opening a note may not modify it
+    const tagWrites = mocks.updateNote.mock.calls.filter(
+      ([input]) => (input as { tags?: string[] }).tags !== undefined
+    )
+    expect(tagWrites).toEqual([])
+  })
+
+  it('still removes a tag when the user deletes the last inline tag after opening', async () => {
+    // #given a note opened with `#work` in its body, so the baseline is set by
+    // the load report rather than by a write
+    renderWithProviders(<NotePage noteId="note-1" />)
+    await screen.findByRole('button', { name: 'Load inline tags' })
+    fireEvent.click(screen.getByRole('button', { name: 'Load inline tags' }))
+
+    // #when the user deletes it
+    fireEvent.click(screen.getByRole('button', { name: 'Clear inline tags' }))
+
+    // #then the tag comes off the note. Without the load baseline the page
+    // would have no record of `work` ever being inline and would drop this.
     await waitFor(() => expect(mocks.updateNote).toHaveBeenCalledWith({ id: 'note-1', tags: [] }))
   })
 

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -361,6 +361,9 @@ vi.mock('@/components/note', () => ({
         <button type="button" onClick={() => onInlineTagsChange(['work'], 'load')}>
           Load inline tags
         </button>
+        <button type="button" onClick={() => onInlineTagsChange(['Work'], 'load')}>
+          Load cased inline tags
+        </button>
         <button type="button" onClick={() => onInlineTagsChange(['work', 'urgent'], 'edit')}>
           Sync inline tags
         </button>
@@ -818,6 +821,25 @@ describe('NotePage', () => {
       ([input]) => (input as { tags?: string[] }).tags !== undefined
     )
     expect(tagWrites).toEqual([])
+  })
+
+  it('does not rewrite the note when a loaded tag differs only in case', async () => {
+    // #given the index keeps the frontmatter spelling ('work') while the body
+    // says '#Work'. Before the origin was threaded through, `tagsToAdd` saw
+    // 'Work' as new and merely OPENING the note wrote tags: ['work', 'Work'].
+    renderWithProviders(<NotePage noteId="note-1" />)
+    await screen.findByRole('button', { name: 'Load cased inline tags' })
+
+    // #when the editor reports what it loaded
+    fireEvent.click(screen.getByRole('button', { name: 'Load cased inline tags' }))
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // #then nothing is written — a load is not an edit
+    expect(mocks.updateNote).not.toHaveBeenCalledWith(
+      expect.objectContaining({ tags: expect.anything() })
+    )
   })
 
   it('still removes a tag when the user deletes the last inline tag after opening', async () => {

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -15,7 +15,14 @@ import { VersionHistory } from '@/components/note/version-history'
 import { ApplyTemplateToNoteDialog } from '@/components/note/apply-template-to-note-dialog'
 import { EditorErrorBoundary } from '@/components/note/editor-error-boundary'
 import { LargeFileNotice } from '@/components/note/large-file-notice'
-import { NoteLayout, HeadingItem, ContentArea, HeadingInfo, Block } from '@/components/note'
+import {
+  NoteLayout,
+  HeadingItem,
+  ContentArea,
+  HeadingInfo,
+  InlineTagsOrigin,
+  Block
+} from '@/components/note'
 import { isOutsideAllBlocks } from '@/components/note/content-area/marquee-hit-test'
 import { NoteTitle } from '@/components/note/note-title'
 import { TagsRow, Tag } from '@/components/note/tags-row'
@@ -790,8 +797,17 @@ export function NotePage({ noteId }: NotePageProps) {
   const pendingTagsRef = useRef<string[] | null>(null)
 
   const handleInlineTagsChange = useCallback(
-    async (currentInlineTags: string[]) => {
+    async (currentInlineTags: string[], origin: InlineTagsOrigin) => {
       if (!noteId || !note || isDeleted) return
+
+      // Opening a note must not modify it (#1454). A load report is the tag set
+      // the body already carried, so it only seeds the baseline later edits are
+      // diffed against: a tag that lives only in the body stays there — the
+      // index still indexes it — until the user actually adds or removes one.
+      if (origin === 'load') {
+        inlineTagsRef.current = new Set(currentInlineTags)
+        return
+      }
 
       const prev = inlineTagsRef.current
       const current = new Set(currentInlineTags)

--- a/apps/desktop/tests/e2e/note-open-byte-stability.e2e.ts
+++ b/apps/desktop/tests/e2e/note-open-byte-stability.e2e.ts
@@ -187,10 +187,6 @@ test.describe('Note open byte stability', () => {
       .poll(() => stripFrontmatter(fs.readFileSync(absPath, 'utf8')), { timeout: 20_000 })
       .toBe(stripFrontmatter(first.bytes))
     const afterFirstOpen = fs.readFileSync(absPath, 'utf8')
-    // `performedCount` lives in the MAIN process and is only cleared by
-    // `CrdtProvider.destroy()`, which a renderer reload does not trigger — so
-    // waiting for `>= 1` again would return immediately and this test would
-    // measure the first cycle twice. Capture the count and wait past it.
     const runsAfterFirstOpen = await getWritebackRuns(electronAppA, first.id)
 
     // #when the app is reloaded and the note opened again — a cold open, with
@@ -199,13 +195,20 @@ test.describe('Note open byte stability', () => {
     await pageA.waitForLoadState('domcontentloaded')
     await waitForSyncOnline(pageA, 60_000)
     await openInEditor(pageA, title)
-    await waitForWritebackRuns(electronAppA, first.id, runsAfterFirstOpen + 1)
 
-    // #then the second cycle is a fixed point — whole file this time, since the
-    // first open already settled the frontmatter
-    await expect
-      .poll(() => fs.readFileSync(absPath, 'utf8'), { timeout: 20_000 })
-      .toBe(afterFirstOpen)
+    // #then nothing happens at all, and that IS the convergence proof.
+    //
+    // This test used to wait for a second write-back before checking the bytes,
+    // which can never arrive: `scheduleWriteback` has one production caller,
+    // `onDocUpdate`. The second open rebuilds the doc from the CRDT store with
+    // the `wikiLink` nodes already promoted, so `normalizeWikiLinks` finds
+    // nothing to change, the doc never updates, and write-back never runs. The
+    // suite's own unit sibling asserts exactly that ("reopening a doc that
+    // already holds the node does not re-promote it") — the old assertion
+    // contradicted the property the rest of the file exists to prove.
+    await pageA.waitForTimeout(3_000)
+    expect(await getWritebackRuns(electronAppA, first.id)).toBe(runsAfterFirstOpen)
+    expect(fs.readFileSync(absPath, 'utf8')).toBe(afterFirstOpen)
   })
 
   test('an inline #hashtag does not add a tags: block on first open', async ({

--- a/apps/desktop/tests/e2e/note-open-byte-stability.e2e.ts
+++ b/apps/desktop/tests/e2e/note-open-byte-stability.e2e.ts
@@ -15,18 +15,19 @@
  * The note is seeded as BYTES on disk, not through the app, because the whole
  * claim is about bytes the user (or Obsidian) wrote.
  *
- * ## One thing this suite found, and does not fix
+ * ## The one this suite found, now fixed (#1454)
  *
- * Opening a note whose body contains a plain `#hashtag` INJECTS a `tags:` block
- * into its frontmatter — `extractInlineTags` reads hash tags out of plain text,
- * not just out of `hashTag` nodes, the tag reaches the CRDT tag array, and
- * write-back's `mergeFrontmatter` writes it to the file. That is a real
- * "opening a note modified it", but it is the inline-tag pipeline rather than
- * the wiki-link round trip this issue is about, and whether inline tags should
- * promote themselves into frontmatter at all is a product decision. It is
- * pinned by its own test at the bottom of this file instead of being papered
- * over, and the body-stability tests strip frontmatter so they measure the loop
- * they are named for.
+ * Opening a note whose body contained a plain `#hashtag` used to INJECT a
+ * `tags:` block into its frontmatter. A body tag is index-only — search and the
+ * tag hub merge it in (`extractNoteMetadata`) without touching the file — but
+ * that merged list was also handed to `CrdtProvider.initForNote`, and
+ * write-back treats the doc's tag array as authoritative for `tags:`
+ * (`mergeFrontmatter`). The last test in this file asserts the file is now
+ * byte-identical; the mechanism is pinned in
+ * `src/main/sync/note-open-byte-stability.test.ts`.
+ *
+ * The body-stability tests above still strip frontmatter, so they measure the
+ * wiki-link loop they are named for rather than this.
  */
 
 import * as fs from 'fs'
@@ -207,7 +208,7 @@ test.describe('Note open byte stability', () => {
       .toBe(afterFirstOpen)
   })
 
-  test('REGRESSION PIN: an inline #hashtag adds a tags: block on first open', async ({
+  test('an inline #hashtag does not add a tags: block on first open', async ({
     pageA,
     electronAppA,
     vaultPathA,
@@ -216,26 +217,29 @@ test.describe('Note open byte stability', () => {
     void bootstrappedSyncPair
     await waitForSyncOnline(pageA)
 
-    // #given a note with no frontmatter and one inline hash tag in its body
+    // #given a note with no frontmatter and one inline hash tag in its body —
+    // an Obsidian user who keeps tags in the body and not in frontmatter
     const title = `Inline Tag Frontmatter ${Date.now()}`
     const absPath = seedVaultFile(vaultPathA, title, 'Tagged #hashtag here.')
     const baseline = await indexedBaseline(pageA, title, absPath)
     expect(baseline.bytes).not.toContain('tags:')
 
-    // #when it is opened
+    // #when it is opened, and write-back has genuinely run
     await openInEditor(pageA, title)
     await waitForWritebackRuns(electronAppA, baseline.id, 1)
 
-    // #then opening it modified the file. This is NOT the wiki-link loop — the
-    // body below the frontmatter is untouched — it is `extractInlineTags`
-    // reading hash tags out of plain text and write-back's `mergeFrontmatter`
-    // persisting them. Asserted as current behaviour, not as correct behaviour;
-    // deciding whether inline tags belong in frontmatter is its own change.
-    await expect
-      .poll(() => fs.readFileSync(absPath, 'utf8'), { timeout: 20_000 })
-      .toContain('tags:')
-    const rewritten = fs.readFileSync(absPath, 'utf8')
-    expect(rewritten).toContain('- hashtag')
-    expect(stripFrontmatter(rewritten)).toBe('Tagged #hashtag here.')
+    // #then the whole file is byte-identical: the tag stays where the user put
+    // it. It reaches search and the tag hub through the index (#1454), not by
+    // rewriting the file. This test used to assert the opposite, as a pin.
+    expect(fs.readFileSync(absPath, 'utf8')).toBe(baseline.bytes)
+    expect(fs.readFileSync(absPath, 'utf8')).not.toContain('tags:')
+
+    // and the note really does carry the tag, so this is not a lost feature
+    const note = await getNoteHandleByTitle(pageA, title)
+    const tags = await pageA.evaluate(
+      (id) => window.api.notes.get(id).then((loaded) => loaded?.tags ?? []),
+      note.id
+    )
+    expect(tags).toContain('hashtag')
   })
 })

--- a/apps/desktop/tsconfig.test.web.json
+++ b/apps/desktop/tsconfig.test.web.json
@@ -60,7 +60,6 @@
     "src/renderer/src/components/note/content-area/hooks/coverage-hooks.test.tsx",
     "src/renderer/src/components/note/content-area/hooks/task-block-marquee-indent.test.ts",
     "src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.test.tsx",
-    "src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx",
     "src/renderer/src/components/note/content-area/list-type-conversion.integration.test.ts",
     "src/renderer/src/components/note/content-area/tag-suggestion-popover.test.tsx",
     "src/renderer/src/components/note/content-area/task-block/task-block-renderer.test.tsx",

--- a/apps/docs/src/user-guide/notes/properties-tags.md
+++ b/apps/docs/src/user-guide/notes/properties-tags.md
@@ -177,4 +177,20 @@ In the vault's markdown files, a note's frontmatter contains only your own prope
 
 Frontmatter in your `.md` files is treated as yours: memrynote re-emits the original block byte-for-byte (comments, key order, and quoting included) unless you actually edit a property, tag, or alias in the app. Saving a note without changing anything writes nothing to disk at all.
 
+### A `#tag` in the body stays in the body
+
+A tag written inline in a note's text is indexed like any other — it shows in the sidebar, in
+search, and on the tag's own page — but **opening that note does not lift it into the
+`tags:` frontmatter**. The file is left exactly as you wrote it, which matters if you keep
+your tags in the body the way an Obsidian vault often does.
+
+Adding or removing an inline tag while editing still updates the note's tags, as it always
+has. Only _opening_ a note is now a read.
+
+::: tip
+Notes that already had a `tags:` block added by an earlier version keep it. An injected block
+is indistinguishable from one you wrote yourself, so nothing tries to unpick it — delete the
+block by hand if you would rather the tag lived only in the body.
+:::
+
 If a note's frontmatter isn't valid YAML — an unterminated quote, an unclosed list — the note is still indexed. Its text stays searchable and its links still show up in the graph; only its properties, tags, and aliases are unavailable until the YAML is fixed. The broken block is left on disk untouched, so you can repair it in memrynote or any other editor.


### PR DESCRIPTION
Closes #1454. Opening a note no longer rewrites its frontmatter.

## What was writing the file — the issue traced it wrong, and the reviewer traced it wrong too

**The main chain** is not the renderer:

```
watcher.handleMarkdownFileAdd → syncNoteCreate(id, title, syncResult.tags)   ← the INDEX's merged list
  → CrdtProvider.initForNote → doc.getArray('tags').push(['hashtag'])
  → first renderer update on open → scheduleWriteback → mergeFrontmatter → writes `tags:`
```

`watcher.ts` and `notes/domain.ts` now seed from `extractTags(parsed.frontmatter)` — what the file itself declares. The index still merges body tags, so search, the tag hub and the graph are unchanged; the merged list just never round-trips back into the file.

**But the issue's chain is real too**, in a case it did not name. `extractNoteMetadata` merges case-insensitively with frontmatter spelling winning, so with body `#Work` and frontmatter `tags: [work]` the index keeps only `work` — `tagsToAdd` saw `Work` as new and merely *opening* the note wrote `tags: ['work', 'Work']`. `onInlineTagsChange` now carries an origin: `'load'` seeds the baseline and returns, `'edit'` behaves exactly as before.

The load report is kept **deliberately** — it is what tells the page the body *had* the tag. Drop it and deleting the last inline tag silently stops working.

## Blast radius is smaller than the issue claimed

`chokidar` runs with `ignoreInitial: true`, and startup seeding goes through `seedExistingCrdtDocs`, which passes no tags. Notes already in the vault at startup were never rewritten — only notes discovered while the app runs, or created through it.

## Review findings, addressed

- **The renderer half was completely unpinned.** Deleting the `origin === 'load'` guard left the full renderer suite green, because the only fixture had matching case. The case-mismatch test added here goes **red** on that mutation — verified.
- `watcher.test.ts` and `use-editor-sync.test.tsx` come off the `tsconfig.test.*` exclude backlogs (four pre-existing type errors fixed), so the files carrying these tests actually compile.

## My own regression from #1453, fixed here

The E2E second-cycle test waited for a second write-back **that can never arrive**. `scheduleWriteback` has one production caller, `onDocUpdate`; a cold second open rebuilds the doc from the CRDT store with the `wikiLink` nodes already promoted, so `normalizeWikiLinks` finds nothing, the doc never updates, and write-back never runs. That absence *is* the convergence proof, and is now what the test asserts.

**It has been red on `main` since #1453.** E2E jobs are gated on `github.ref == 'refs/heads/main'`, so PR #1453 showed all four as `skipping` and I read a local run as green. Desktop CI run `31850475505` on `e7b617e40` shows shards 11/16 and 15/16 failing on exactly that line. Worth remembering: **a green PR says nothing about E2E.**

## Deliberately not in this PR

**#1471** — `buildNotePushPayload` reads frontmatter tags only, so a body-only `#hashtag` never leaves the sending device, and `applyUpsert`'s straight replace wipes it from the receiving device's index. Before this fix the injected `tags:` block carried it; now it doesn't. I implemented the re-derive fix and it typechecks, but the unit test I wrote did not actually observe the merge, and a sync-path change whose test doesn't exercise it is worse than a filed issue.

Three more the reviewer named, tracked not fixed: `apply-template` still seeds merged tags into the doc array; `initForNote` short-circuits on an existing doc so notes seeded by an older build keep their array; `updateNote` does not refresh the CRDT tag array.

## Not un-injecting history

Notes already rewritten by an older build keep their `tags:` block. An injected block is indistinguishable from a user-authored one, so nothing tries to unpick it. Documented in `properties-tags.md`.

## Verification

- `test:main` — 513 files / 6479 tests
- `test:renderer` — 611 files / 7016 tests
- `typecheck` (node/web/test) · `check:architecture` · lint
- E2E: the inverted pin `an inline #hashtag does not add a tags: block on first open` **passed** (whole-file byte identity), and fails with 4 added lines when `watcher.ts` is reverted
- `docs:impact --strict` · `docs:build`
