### PR TITLE
fix(sync): a note that crosses the sync ceiling says so, by name (#1465)

### DIFF
--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -330,6 +330,7 @@ export interface MainIpcInvokeHandlers {
   "sync:get-devices": (...args: []) => Awaited<Promise<{ devices: { id: string; name: string; platform: "macos" | "windows" | "linux" | "ios" | "android"; linkedAt: number; lastSyncAt: number | undefined; isCurrentDevice: boolean; }[]; email: string | undefined; needsRecoveryConfirmation: boolean; }>>
   "sync:get-download-progress": (...args: [{ attachmentId: string; }]) => Awaited<{ progress: number; downloadedChunks: number; totalChunks: number; status: "downloading"; } | null | { success: false; error: string }>
   "sync:get-history": (...args: [{ limit?: number | undefined; offset?: number | undefined; }]) => Awaited<{ entries: { id: string; type: "error" | "push" | "pull"; itemCount: number; direction: string | undefined; details: unknown; durationMs: number | undefined; createdAt: number; }[]; total: number; } | { success: false; error: string }>
+  "sync:get-large-notes": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-sync-ops").LargeNotesResult>
   "sync:get-linking-sas": (...args: [{ sessionId: string; }]) => Awaited<Promise<{ verificationCode?: string | undefined; error?: string | undefined; }> | { success: false; error: string }>
   "sync:get-quarantined-items": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-events").QuarantinedItemInfo[]>
   "sync:get-queue-size": (...args: []) => Awaited<{ pending: number; failed: number; }>

--- a/apps/desktop/src/main/ipc/sync-core-handlers.ts
+++ b/apps/desktop/src/main/ipc/sync-core-handlers.ts
@@ -12,6 +12,7 @@ import {
   UpdateSyncedSettingSchema
 } from '@memry/contracts/ipc-sync-ops'
 import { getSettingsSyncManager } from '../sync/settings-sync'
+import { listLargeNotes } from '../sync/large-notes'
 import { syncHistory } from '@memry/db-schema/schema/sync-history'
 
 import { eq, desc, count } from 'drizzle-orm'
@@ -315,6 +316,10 @@ export function registerSyncHandlers(syncEngine?: SyncEngine): void {
     if (!token) return null
     return getFromServer<StorageBreakdownResult>('/sync/storage', token)
   })
+
+  // Purely local: reads the note cache and stats the files, so it answers with
+  // no server round-trip and works for an existing vault with no reindex.
+  ipcMain.handle(SYNC_CHANNELS.GET_LARGE_NOTES, () => listLargeNotes())
 
   ipcMain.handle(SYNC_CHANNELS.GET_QUARANTINED_ITEMS, () => {
     const engine = resolveSyncEngine()

--- a/apps/desktop/src/main/sync/encrypt.test.ts
+++ b/apps/desktop/src/main/sync/encrypt.test.ts
@@ -6,6 +6,7 @@ import { verifySignature } from '../crypto/signatures'
 import { CBOR_FIELD_ORDER } from '@memry/contracts/cbor-ordering'
 import { encryptItemForPush, type EncryptItemInput } from './encrypt'
 import { decompressPayload } from './compress'
+import { ItemTooLargeError, NOTE_SYNC_MAX_BYTES, SYNC_ITEM_MAX_ENCRYPT_BYTES } from './note-size'
 
 beforeAll(async () => {
   await initCrypto()
@@ -193,5 +194,26 @@ describe('encryptItemForPush', () => {
 
       spy.mockRestore()
     })
+  })
+})
+
+describe('#given a payload over the sync ceiling #when encryptItemForPush', () => {
+  it('#then it throws a typed ItemTooLargeError naming the item', () => {
+    const oversized = new Uint8Array(NOTE_SYNC_MAX_BYTES + 1)
+    let thrown: unknown
+    try {
+      encryptItemForPush(makeInput({ id: 'note-oversized', content: oversized }))
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(thrown).toBeInstanceOf(ItemTooLargeError)
+    expect((thrown as ItemTooLargeError).itemId).toBe('note-oversized')
+    expect((thrown as ItemTooLargeError).maxBytes).toBe(SYNC_ITEM_MAX_ENCRYPT_BYTES)
+  })
+
+  it('#then a payload exactly at the ceiling still encrypts', () => {
+    const atCeiling = new Uint8Array(NOTE_SYNC_MAX_BYTES)
+    expect(() => encryptItemForPush(makeInput({ content: atCeiling }))).not.toThrow()
   })
 })

--- a/apps/desktop/src/main/sync/encrypt.ts
+++ b/apps/desktop/src/main/sync/encrypt.ts
@@ -8,6 +8,11 @@ import type { PushItem, SyncItemType, SyncOperation, VectorClock } from '@memry/
 // have low entropy variance (attacker can't adaptively probe content) and all crypto
 // operations use constant-time primitives (no timing side-channel)
 import { compressPayload } from './compress'
+import {
+  ItemTooLargeError,
+  SYNC_ITEM_ENCRYPT_OVERHEAD,
+  SYNC_ITEM_MAX_ENCRYPT_BYTES
+} from './note-size'
 
 export interface EncryptItemInput {
   id: string
@@ -28,12 +33,12 @@ export interface EncryptItemResult {
 }
 
 export function encryptItemForPush(input: EncryptItemInput): EncryptItemResult {
-  const MAX_SYNC_SIZE = 5 * 1024 * 1024
-  const BASE64_CRYPTO_OVERHEAD = 1.37
-  const estimatedSize = input.content.byteLength * BASE64_CRYPTO_OVERHEAD
-  if (estimatedSize > MAX_SYNC_SIZE) {
-    const estimatedMB = (estimatedSize / (1024 * 1024)).toFixed(1)
-    throw new Error(`Item too large for sync (estimated ${estimatedMB}MB, max 5MB)`)
+  const estimatedSize = input.content.byteLength * SYNC_ITEM_ENCRYPT_OVERHEAD
+  if (estimatedSize > SYNC_ITEM_MAX_ENCRYPT_BYTES) {
+    // Typed, so the batch layers can tell this apart from a crypto failure and
+    // tell the user which note stopped syncing instead of only writing the
+    // reason onto a queue row (#1465).
+    throw new ItemTooLargeError(input.id, estimatedSize, SYNC_ITEM_MAX_ENCRYPT_BYTES)
   }
 
   const fileKey = generateFileKey()

--- a/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
@@ -185,6 +185,78 @@ describe('PushCoordinator', () => {
     getRemoteSyncAdapterMock.mockReturnValue(undefined)
   })
 
+  describe('#given a queued note over the client encrypt cap #when it is pushed', () => {
+    function rejectEncryptAsTooLarge(): void {
+      encryptPushBatchMock.mockImplementation(
+        async (
+          items: QueueRow[],
+          vaultKey: Uint8Array,
+          _signingKey: Uint8Array,
+          deviceId: string,
+          deps: {
+            queue: SyncQueueManager
+            resolvePushPayload: (item: QueueRow, deviceId: string, vaultKey: Uint8Array) => string
+            onItemTooLarge?: (item: { itemId: string; type: string; payload: string }) => void
+          }
+        ) => {
+          for (const item of items) {
+            deps.queue.markFailed(item.id, 'Encrypt failed: Item too large for sync')
+            deps.onItemTooLarge?.({
+              itemId: item.itemId,
+              type: item.type,
+              payload: deps.resolvePushPayload(item, deviceId, vaultKey)
+            })
+          }
+          return []
+        }
+      )
+    }
+
+    it('#then the renderer is told which note stopped syncing', async () => {
+      const { coordinator, queue, emitToRenderer } = createHarness(getDb())
+      acceptAll()
+      rejectEncryptAsTooLarge()
+
+      queue.enqueue({
+        type: 'note',
+        itemId: 'note-big',
+        operation: 'create',
+        payload: JSON.stringify({ title: 'Server log dump' })
+      })
+
+      await coordinator.push()
+
+      expect(emitToRenderer).toHaveBeenCalledWith(
+        EVENT_CHANNELS.STATUS_CHANGED,
+        expect.objectContaining({
+          status: 'error',
+          errorCategory: 'note_too_large',
+          errorNoteTitle: 'Server log dump'
+        })
+      )
+    })
+
+    it('#then a non-note item over the cap raises no note-too-large error', async () => {
+      const { coordinator, queue, emitToRenderer } = createHarness(getDb())
+      acceptAll()
+      rejectEncryptAsTooLarge()
+
+      queue.enqueue({
+        type: 'settings',
+        itemId: 'settings-1',
+        operation: 'update',
+        payload: JSON.stringify({ theme: 'dark' })
+      })
+
+      await coordinator.push()
+
+      expect(emitToRenderer).not.toHaveBeenCalledWith(
+        EVENT_CHANNELS.STATUS_CHANGED,
+        expect.objectContaining({ errorCategory: 'note_too_large' })
+      )
+    })
+  })
+
   describe('#given a queued local mutation #when the server accepts it', () => {
     it('#then it is pushed, dropped from the queue, and marked synced locally', async () => {
       const { coordinator, queue, stateManager, emitToRenderer } = createHarness(getDb())

--- a/apps/desktop/src/main/sync/engine/push-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../lib/logger'
 import { EVENT_CHANNELS } from '@memry/contracts/ipc-events'
-import type { QueueClearedEvent } from '@memry/contracts/ipc-events'
+import type { QueueClearedEvent, SyncStatusChangedEvent } from '@memry/contracts/ipc-events'
 import type { PushResponse, SyncItemType } from '@memry/contracts/sync-api'
 import { secureCleanup } from '../../crypto/index'
 import { encryptPushBatch } from '../sync-crypto-batch'
@@ -178,7 +178,8 @@ export class PushCoordinator {
               queue: this.ctx.deps.queue,
               extractPayloadMetadata: (p) => this.extractPayloadMetadata(p),
               resolvePushPayload: (item, deviceId, key) =>
-                this.resolvePushPayload(item, deviceId, key)
+                this.resolvePushPayload(item, deviceId, key),
+              onItemTooLarge: (item) => this.reportItemTooLarge(item)
             }
           )
           timer.endPhase(dedupedItems.length)
@@ -446,6 +447,53 @@ export class PushCoordinator {
     }
 
     return Array.from(seen.values())
+  }
+
+  /**
+   * The client encrypt cap rejects a note before any HTTP request, so the
+   * server's 413 path — the one that raises the note-too-large toast — is never
+   * reached. Without this the rejection lived only on the sync-queue row and
+   * the note simply stopped syncing (#1465). Deliberately does not move the
+   * engine's own state or pause the queue: one oversized note must not stall
+   * every other note, which is how the server-413 path already behaves.
+   */
+  private reportItemTooLarge(item: { itemId: string; type: string; payload: string }): void {
+    if (item.type !== 'note' && item.type !== 'journal') {
+      log.warn('Push: item over the sync size cap', { itemId: item.itemId, type: item.type })
+      return
+    }
+
+    const title = this.extractPayloadTitle(item.payload)
+    log.error('Push: note over the sync size cap, it will not sync', {
+      itemId: item.itemId,
+      type: item.type,
+      title
+    })
+    trackMainEvent('sync_error', {
+      surface: 'sync',
+      action: 'push_note_too_large',
+      result: 'failed',
+      errorCode: 'note_too_large',
+      source: 'push',
+      dimensions: { transport: 'record' }
+    })
+    const event: SyncStatusChangedEvent = {
+      status: 'error',
+      pendingCount: this.ctx.deps.queue.getPendingCount(),
+      error: 'A note is too large to sync',
+      errorCategory: 'note_too_large',
+      ...(title ? { errorNoteTitle: title } : {})
+    }
+    this.ctx.deps.emitToRenderer(EVENT_CHANNELS.STATUS_CHANGED, event)
+  }
+
+  private extractPayloadTitle(payload: string): string | undefined {
+    try {
+      const parsed = JSON.parse(payload) as { title?: unknown }
+      return typeof parsed.title === 'string' && parsed.title ? parsed.title : undefined
+    } catch {
+      return undefined
+    }
   }
 
   private extractPayloadMetadata(payload: string): {

--- a/apps/desktop/src/main/sync/large-notes.test.ts
+++ b/apps/desktop/src/main/sync/large-notes.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { selectLargeNotes, type LargeNoteRow } from './large-notes'
+import { NOTE_SYNC_MAX_BYTES, NOTE_SYNC_WARN_BYTES } from './note-size'
+
+function row(overrides: Partial<LargeNoteRow> & { id: string }): LargeNoteRow {
+  return {
+    title: overrides.id,
+    path: `${overrides.id}.md`,
+    fileType: 'markdown',
+    localOnly: false,
+    ...overrides
+  }
+}
+
+describe('selectLargeNotes', () => {
+  it('#then it reports a note over the ceiling as already broken', () => {
+    const sizes = new Map([['big.md', NOTE_SYNC_MAX_BYTES + 1]])
+
+    const result = selectLargeNotes(
+      [row({ id: 'big', title: 'Server log dump', path: 'big.md' })],
+      (p) => sizes.get(p) ?? null
+    )
+
+    expect(result).toEqual([
+      {
+        id: 'big',
+        title: 'Server log dump',
+        path: 'big.md',
+        sizeBytes: NOTE_SYNC_MAX_BYTES + 1,
+        status: 'over'
+      }
+    ])
+  })
+
+  it('#then it warns about a note still under the ceiling', () => {
+    const result = selectLargeNotes([row({ id: 'growing' })], () => NOTE_SYNC_WARN_BYTES)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].status).toBe('approaching')
+  })
+
+  it('#then an ordinary note is not listed', () => {
+    const result = selectLargeNotes([row({ id: 'normal' })], () => 2_048)
+
+    expect(result).toEqual([])
+  })
+
+  it('#then it ranks the largest note first', () => {
+    const sizes = new Map([
+      ['a.md', NOTE_SYNC_WARN_BYTES],
+      ['b.md', NOTE_SYNC_MAX_BYTES + 5_000],
+      ['c.md', NOTE_SYNC_MAX_BYTES]
+    ])
+
+    const result = selectLargeNotes(
+      [
+        row({ id: 'a', path: 'a.md' }),
+        row({ id: 'b', path: 'b.md' }),
+        row({ id: 'c', path: 'c.md' })
+      ],
+      (p) => sizes.get(p) ?? null
+    )
+
+    expect(result.map((n) => n.id)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('#then attachments are excluded — the plan file limit governs those, not this ceiling', () => {
+    const result = selectLargeNotes(
+      [row({ id: 'movie', path: 'movie.mp4', fileType: 'video' })],
+      () => NOTE_SYNC_MAX_BYTES * 2
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it('#then a local-only note is excluded because it never syncs', () => {
+    const result = selectLargeNotes(
+      [row({ id: 'scratch', localOnly: true })],
+      () => NOTE_SYNC_MAX_BYTES + 1
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it('#then a note whose file cannot be measured is skipped rather than guessed at', () => {
+    const result = selectLargeNotes([row({ id: 'gone' })], () => null)
+
+    expect(result).toEqual([])
+  })
+})

--- a/apps/desktop/src/main/sync/large-notes.ts
+++ b/apps/desktop/src/main/sync/large-notes.ts
@@ -1,0 +1,86 @@
+import fs from 'fs'
+import { noteCache } from '@memry/db-schema/schema/notes-cache'
+import { isBinaryFileType } from '@memry/shared/file-types'
+import type { FileType } from '@memry/shared/file-types'
+import type { LargeNoteEntry, LargeNotesResult } from '@memry/contracts/ipc-sync-ops'
+import { getIndexDatabase } from '../database/client'
+import { createLogger } from '../lib/logger'
+import { toAbsolutePath } from '../vault/notes-io'
+import { classifyNoteSyncSize, NOTE_SYNC_MAX_BYTES } from './note-size'
+
+const log = createLogger('LargeNotes')
+
+/**
+ * A long list here would be a different problem than the one this answers, so
+ * it is capped: the point is "which notes are about to stop syncing", not a
+ * full inventory.
+ */
+const MAX_ENTRIES = 50
+
+export interface LargeNoteRow {
+  id: string
+  title: string
+  path: string
+  fileType: FileType | null
+  localOnly: boolean | null
+}
+
+export function selectLargeNotes(
+  rows: LargeNoteRow[],
+  measure: (relativePath: string) => number | null
+): LargeNoteEntry[] {
+  const entries: LargeNoteEntry[] = []
+
+  for (const row of rows) {
+    // Attachments ride the blob routes, which the plan's per-file limit
+    // governs. This ceiling is only about note bodies.
+    if (row.fileType && isBinaryFileType(row.fileType)) continue
+    if (row.localOnly) continue
+
+    const sizeBytes = measure(row.path)
+    if (sizeBytes === null) continue
+
+    const status = classifyNoteSyncSize(sizeBytes)
+    if (status === 'ok') continue
+
+    entries.push({ id: row.id, title: row.title, path: row.path, sizeBytes, status })
+  }
+
+  entries.sort((a, b) => b.sizeBytes - a.sizeBytes)
+  return entries.slice(0, MAX_ENTRIES)
+}
+
+/**
+ * Sizes come from `stat` rather than a stored column so an existing vault
+ * answers correctly with no reindex and no migration.
+ */
+export function listLargeNotes(): LargeNotesResult {
+  const rows = getIndexDatabase()
+    .select({
+      id: noteCache.id,
+      title: noteCache.title,
+      path: noteCache.path,
+      fileType: noteCache.fileType,
+      localOnly: noteCache.localOnly
+    })
+    .from(noteCache)
+    .all()
+
+  const notes = selectLargeNotes(rows, (relativePath) => {
+    try {
+      return fs.statSync(toAbsolutePath(relativePath)).size
+    } catch {
+      // Deleted, moved, or on an unmounted volume — nothing to report.
+      return null
+    }
+  })
+
+  if (notes.length > 0) {
+    log.info('Notes at or over the sync ceiling', {
+      count: notes.length,
+      over: notes.filter((n) => n.status === 'over').length
+    })
+  }
+
+  return { maxBytes: NOTE_SYNC_MAX_BYTES, notes }
+}

--- a/apps/desktop/src/main/sync/note-size.test.ts
+++ b/apps/desktop/src/main/sync/note-size.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyNoteSyncSize,
+  ItemTooLargeError,
+  NOTE_SYNC_MAX_BYTES,
+  NOTE_SYNC_WARN_BYTES,
+  SYNC_ITEM_ENCRYPT_OVERHEAD,
+  SYNC_ITEM_MAX_ENCRYPT_BYTES
+} from './note-size'
+
+describe('note sync size ceiling', () => {
+  it('#then the ceiling is the largest payload the encrypt cap still accepts', () => {
+    expect(NOTE_SYNC_MAX_BYTES * SYNC_ITEM_ENCRYPT_OVERHEAD).toBeLessThanOrEqual(
+      SYNC_ITEM_MAX_ENCRYPT_BYTES
+    )
+    expect((NOTE_SYNC_MAX_BYTES + 1) * SYNC_ITEM_ENCRYPT_OVERHEAD).toBeGreaterThan(
+      SYNC_ITEM_MAX_ENCRYPT_BYTES
+    )
+  })
+
+  it('#then a note over the ceiling is "over"', () => {
+    expect(classifyNoteSyncSize(NOTE_SYNC_MAX_BYTES + 1)).toBe('over')
+  })
+
+  it('#then a note exactly at the ceiling still syncs', () => {
+    expect(classifyNoteSyncSize(NOTE_SYNC_MAX_BYTES)).toBe('approaching')
+  })
+
+  it('#then a note in the warn band is "approaching"', () => {
+    expect(classifyNoteSyncSize(NOTE_SYNC_WARN_BYTES)).toBe('approaching')
+    expect(classifyNoteSyncSize(NOTE_SYNC_MAX_BYTES - 1)).toBe('approaching')
+  })
+
+  it('#then an ordinary note is "ok"', () => {
+    expect(classifyNoteSyncSize(0)).toBe('ok')
+    expect(classifyNoteSyncSize(2_048)).toBe('ok')
+    expect(classifyNoteSyncSize(NOTE_SYNC_WARN_BYTES - 1)).toBe('ok')
+  })
+
+  it('#then ItemTooLargeError reports the item and keeps the logged message shape', () => {
+    const err = new ItemTooLargeError('note-1', 24_000_000, SYNC_ITEM_MAX_ENCRYPT_BYTES)
+    expect(err).toBeInstanceOf(Error)
+    expect(err.itemId).toBe('note-1')
+    expect(err.code).toBe('item_too_large')
+    expect(err.message).toBe('Item too large for sync (estimated 22.9MB, max 5MB)')
+  })
+})

--- a/apps/desktop/src/main/sync/note-size.ts
+++ b/apps/desktop/src/main/sync/note-size.ts
@@ -1,0 +1,58 @@
+/**
+ * The per-item sync ceiling, in one place.
+ *
+ * `encryptItemForPush` rejects a push payload whose byte length, multiplied by
+ * the base64 + crypto overhead factor, is over the 5 MiB cap. For a note that
+ * cap lands on the JSON push payload, which carries the whole markdown body on
+ * `create` — so the real limit a user experiences is roughly 3.7 MB of note
+ * text, well below the server's 8 MiB `/sync/*` body cap. That makes this the
+ * ceiling that actually fires, which is why it needs a user-visible signal
+ * rather than a queue row (#1465).
+ *
+ * Kept free of Electron and DB imports: the sync worker thread imports it
+ * through `encrypt.ts`.
+ */
+
+export const SYNC_ITEM_MAX_ENCRYPT_BYTES = 5 * 1024 * 1024
+
+export const SYNC_ITEM_ENCRYPT_OVERHEAD = 1.37
+
+/**
+ * Largest payload that still encrypts. Derived from the cap rather than
+ * restated, so the two can never drift apart.
+ */
+export const NOTE_SYNC_MAX_BYTES = Math.floor(
+  SYNC_ITEM_MAX_ENCRYPT_BYTES / SYNC_ITEM_ENCRYPT_OVERHEAD
+)
+
+/** Fraction of the ceiling at which a note is called out while it still syncs. */
+export const NOTE_SYNC_WARN_RATIO = 0.8
+
+export const NOTE_SYNC_WARN_BYTES = Math.floor(NOTE_SYNC_MAX_BYTES * NOTE_SYNC_WARN_RATIO)
+
+export type NoteSyncSizeStatus = 'ok' | 'approaching' | 'over'
+
+export function classifyNoteSyncSize(bytes: number): NoteSyncSizeStatus {
+  if (bytes > NOTE_SYNC_MAX_BYTES) return 'over'
+  if (bytes >= NOTE_SYNC_WARN_BYTES) return 'approaching'
+  return 'ok'
+}
+
+/**
+ * Thrown by `encryptItemForPush` for a payload over the cap. A distinct type
+ * because the batch layers have to tell it apart from a genuine crypto failure:
+ * it is not retryable and it is the one push failure a user can act on.
+ */
+export class ItemTooLargeError extends Error {
+  readonly code = 'item_too_large' as const
+
+  constructor(
+    readonly itemId: string,
+    readonly estimatedBytes: number,
+    readonly maxBytes: number
+  ) {
+    const estimatedMB = (estimatedBytes / (1024 * 1024)).toFixed(1)
+    super(`Item too large for sync (estimated ${estimatedMB}MB, max ${maxBytes / (1024 * 1024)}MB)`)
+    this.name = 'ItemTooLargeError'
+  }
+}

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -135,12 +135,26 @@ function emitQuotaExceeded(): void {
   })
 }
 
-function emitNoteTooLarge(): void {
+function emitNoteTooLarge(noteId: string): void {
+  // "A note is too large" with no name leaves the user nothing to act on, and
+  // the note id is meaningless to them (#1465).
+  let noteTitle: string | undefined
+  try {
+    noteTitle = getIndexDatabase()
+      .select({ title: noteCache.title })
+      .from(noteCache)
+      .where(eq(noteCache.id, noteId))
+      .get()?.title
+  } catch (err) {
+    log.debug('Could not resolve the note title for a too-large error', { noteId, error: err })
+  }
+
   emitSyncStatus({
     status: 'error',
     pendingCount: 0,
     error: 'A note is too large to sync',
-    errorCategory: 'note_too_large'
+    errorCategory: 'note_too_large',
+    ...(noteTitle ? { errorNoteTitle: noteTitle } : {})
   })
 }
 
@@ -571,7 +585,7 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
             } else {
               // Body-limit 413: one oversized note must not stall the queue
               // for every other note.
-              emitNoteTooLarge()
+              emitNoteTooLarge(noteId)
             }
           }
           throw err
@@ -629,7 +643,7 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
             } else {
               // Body-limit 413: one oversized note must not stall the queue
               // for every other note.
-              emitNoteTooLarge()
+              emitNoteTooLarge(noteId)
             }
           }
           throw err

--- a/apps/desktop/src/main/sync/sync-crypto-batch.test.ts
+++ b/apps/desktop/src/main/sync/sync-crypto-batch.test.ts
@@ -30,6 +30,7 @@ vi.mock('./decrypt-item', () => ({
 }))
 
 import { decryptPullBatch, encryptPushBatch } from './sync-crypto-batch'
+import { ItemTooLargeError } from './note-size'
 
 const vaultKey = new Uint8Array([1, 2, 3])
 const signingSecretKey = new Uint8Array([4, 5, 6])
@@ -132,6 +133,102 @@ describe('sync crypto batch', () => {
       error: 'boom'
     })
     expect(result).toEqual([{ queueId: 'queue-ok', pushItem: { ok: true } }])
+  })
+
+  it('reports a worker encrypt-cap rejection to the caller, not just to the queue row', async () => {
+    const onItemTooLarge = vi.fn()
+    const workerBridge = {
+      isRunning: true,
+      encryptBatch: vi.fn().mockResolvedValue({
+        results: [],
+        errors: [
+          {
+            queueId: 'queue-1',
+            itemId: 'note-1',
+            error: 'Item too large for sync (estimated 22.9MB, max 5MB)',
+            code: 'item_too_large'
+          }
+        ]
+      })
+    }
+
+    const result = await encryptPushBatch([queueRow], vaultKey, signingSecretKey, 'device-1', {
+      workerBridge: workerBridge as never,
+      queue: { markFailed: mocks.markFailed } as never,
+      extractPayloadMetadata: () => ({}),
+      resolvePushPayload: (item) => item.payload,
+      onItemTooLarge
+    })
+
+    expect(onItemTooLarge).toHaveBeenCalledWith({
+      itemId: 'note-1',
+      type: 'note',
+      payload: '{"title":"Note"}'
+    })
+    expect(mocks.markFailed).toHaveBeenCalledWith(
+      'queue-1',
+      'Encrypt failed: Item too large for sync (estimated 22.9MB, max 5MB)'
+    )
+    expect(result).toEqual([])
+  })
+
+  it('leaves an ordinary worker encrypt failure unreported to the caller', async () => {
+    const onItemTooLarge = vi.fn()
+    const workerBridge = {
+      isRunning: true,
+      encryptBatch: vi.fn().mockResolvedValue({
+        results: [],
+        errors: [{ queueId: 'queue-1', itemId: 'note-1', error: 'boom' }]
+      })
+    }
+
+    await encryptPushBatch([queueRow], vaultKey, signingSecretKey, 'device-1', {
+      workerBridge: workerBridge as never,
+      queue: { markFailed: mocks.markFailed } as never,
+      extractPayloadMetadata: () => ({}),
+      resolvePushPayload: (item) => item.payload,
+      onItemTooLarge
+    })
+
+    expect(onItemTooLarge).not.toHaveBeenCalled()
+    expect(mocks.markFailed).toHaveBeenCalledWith('queue-1', 'Encrypt failed: boom')
+  })
+
+  it('isolates a main-thread encrypt-cap rejection so the rest of the batch still pushes', async () => {
+    const onItemTooLarge = vi.fn()
+    mocks.encryptItemForPush.mockImplementation((input: { id: string }) => {
+      if (input.id === 'note-big') {
+        throw new ItemTooLargeError('note-big', 24_000_000, 5 * 1024 * 1024)
+      }
+      return { pushItem: { encrypted: true } }
+    })
+
+    const result = await encryptPushBatch(
+      [
+        { ...queueRow, id: 'queue-big', itemId: 'note-big', payload: '{"title":"Log dump"}' },
+        queueRow
+      ],
+      vaultKey,
+      signingSecretKey,
+      'device-1',
+      {
+        queue: { markFailed: mocks.markFailed } as never,
+        extractPayloadMetadata: () => ({}),
+        resolvePushPayload: (item) => item.payload,
+        onItemTooLarge
+      }
+    )
+
+    expect(onItemTooLarge).toHaveBeenCalledWith({
+      itemId: 'note-big',
+      type: 'note',
+      payload: '{"title":"Log dump"}'
+    })
+    expect(mocks.markFailed).toHaveBeenCalledWith(
+      'queue-big',
+      expect.stringContaining('Item too large for sync')
+    )
+    expect(result).toEqual([{ queueId: 'queue-1', pushItem: { encrypted: true } }])
   })
 
   it('decrypts on the main thread and records missing signer keys and crypto failures', async () => {

--- a/apps/desktop/src/main/sync/sync-crypto-batch.ts
+++ b/apps/desktop/src/main/sync/sync-crypto-batch.ts
@@ -2,6 +2,7 @@ import sodium from 'libsodium-wrappers-sumo'
 import { createLogger } from '../lib/logger'
 import { encryptItemForPush } from './encrypt'
 import { decryptSingleItem } from './decrypt-item'
+import { ItemTooLargeError } from './note-size'
 import type { SyncQueueManager } from './queue'
 import type { SyncWorkerBridge } from './worker-bridge'
 import type {
@@ -31,6 +32,12 @@ export interface EncryptBatchDeps {
     deviceId: string,
     vaultKey: Uint8Array
   ) => string
+  /**
+   * Called for an item the encrypt cap rejected. `markFailed` still runs — this
+   * is the extra hop that lets the caller tell the user which note stopped
+   * syncing, instead of the rejection living only on the queue row (#1465).
+   */
+  onItemTooLarge?: (item: { itemId: string; type: string; payload: string }) => void
 }
 
 type QueueRow = {
@@ -77,9 +84,18 @@ export async function encryptPushBatch(
         signerDeviceId
       )
 
+      const byQueueId = new Map(rawItems.map((item) => [item.queueId, item]))
       for (const err of errors) {
         log.error('Push: worker encrypt failed', { itemId: err.itemId, error: err.error })
         deps.queue.markFailed(err.queueId, `Encrypt failed: ${err.error}`)
+        const source = byQueueId.get(err.queueId)
+        if (err.code === 'item_too_large' && source) {
+          deps.onItemTooLarge?.({
+            itemId: source.itemId,
+            type: source.type,
+            payload: source.payload
+          })
+        }
       }
 
       return results.map((r) => ({ queueId: r.queueId, pushItem: r.pushItem }))
@@ -98,21 +114,37 @@ export async function encryptPushBatch(
     }
   }
 
-  return rawItems.map((item) => {
-    const result = encryptItemForPush({
-      id: item.itemId,
-      type: item.type,
-      operation: item.operation,
-      content: new TextEncoder().encode(item.payload),
-      vaultKey,
-      ['signingSecretKey']: signingKeyBytes,
-      signerDeviceId,
-      clock: item.clock,
-      stateVector: item.stateVector,
-      deletedAt: item.deletedAt
-    })
-    return { queueId: item.queueId, pushItem: result.pushItem }
-  })
+  const encrypted: Array<{ queueId: string; pushItem: PushItem }> = []
+  for (const item of rawItems) {
+    try {
+      const result = encryptItemForPush({
+        id: item.itemId,
+        type: item.type,
+        operation: item.operation,
+        content: new TextEncoder().encode(item.payload),
+        vaultKey,
+        ['signingSecretKey']: signingKeyBytes,
+        signerDeviceId,
+        clock: item.clock,
+        stateVector: item.stateVector,
+        deletedAt: item.deletedAt
+      })
+      encrypted.push({ queueId: item.queueId, pushItem: result.pushItem })
+    } catch (err) {
+      // Only the size cap is handled here. It is per-item and permanent, so
+      // letting it abort the whole batch would keep every other queued edit
+      // from pushing. Any other failure still propagates, exactly as before.
+      if (!(err instanceof ItemTooLargeError)) throw err
+      log.error('Push: item over the sync size cap', {
+        itemId: item.itemId,
+        type: item.type,
+        error: err.message
+      })
+      deps.queue.markFailed(item.queueId, `Encrypt failed: ${err.message}`)
+      deps.onItemTooLarge?.({ itemId: item.itemId, type: item.type, payload: item.payload })
+    }
+  }
+  return encrypted
 }
 
 export interface DecryptBatchDeps {

--- a/apps/desktop/src/main/sync/worker-bridge.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.ts
@@ -338,7 +338,7 @@ export class SyncWorkerBridge {
     signerDeviceId: string
   ): Promise<{
     results: EncryptedPushResult[]
-    errors: Array<{ queueId: string; itemId: string; error: string }>
+    errors: Array<{ queueId: string; itemId: string; error: string; code?: 'item_too_large' }>
   }> {
     const requestId = this.nextRequestId()
     try {

--- a/apps/desktop/src/main/sync/worker-protocol.ts
+++ b/apps/desktop/src/main/sync/worker-protocol.ts
@@ -85,7 +85,15 @@ export type WorkerToMainMessage =
       type: 'encrypt-batch-result'
       requestId: string
       results: EncryptedPushResult[]
-      errors: Array<{ queueId: string; itemId: string; error: string }>
+      // `code` marks the failures the main thread must handle specifically.
+      // An Error subclass cannot cross the worker boundary, so the
+      // discriminator has to travel as data.
+      errors: Array<{
+        queueId: string
+        itemId: string
+        error: string
+        code?: 'item_too_large'
+      }>
     }
   | {
       type: 'decrypt-batch-result'

--- a/apps/desktop/src/main/sync/worker.ts
+++ b/apps/desktop/src/main/sync/worker.ts
@@ -2,6 +2,7 @@ import { parentPort } from 'worker_threads'
 import sodium from 'libsodium-wrappers-sumo'
 import { encryptItemForPush } from './encrypt'
 import { decryptSingleItem } from './decrypt-item'
+import { ItemTooLargeError } from './note-size'
 import { secureCleanup } from '../crypto/primitives'
 import { createLogger } from '../lib/logger'
 import type {
@@ -84,7 +85,12 @@ function handleUnknownMessage(msg: never): void {
 
 function handleEncryptBatch(msg: Extract<MainToWorkerMessage, { type: 'encrypt-batch' }>): void {
   const results: EncryptedPushResult[] = []
-  const errors: Array<{ queueId: string; itemId: string; error: string }> = []
+  const errors: Array<{
+    queueId: string
+    itemId: string
+    error: string
+    code?: 'item_too_large'
+  }> = []
 
   try {
     for (const item of msg.items) {
@@ -111,7 +117,8 @@ function handleEncryptBatch(msg: Extract<MainToWorkerMessage, { type: 'encrypt-b
         errors.push({
           queueId: item.queueId,
           itemId: item.itemId,
-          error: err instanceof Error ? err.message : String(err)
+          error: err instanceof Error ? err.message : String(err),
+          ...(err instanceof ItemTooLargeError ? { code: 'item_too_large' as const } : {})
         })
       }
     }

--- a/apps/desktop/src/preload/api/sync-ops.ts
+++ b/apps/desktop/src/preload/api/sync-ops.ts
@@ -12,7 +12,8 @@ export const syncOps = {
   updateSyncedSetting: (fieldPath: string, value: unknown) =>
     invoke(SYNC_CHANNELS.UPDATE_SYNCED_SETTING, { fieldPath, value }),
   getSyncedSettings: () => invoke(SYNC_CHANNELS.GET_SYNCED_SETTINGS),
-  getStorageBreakdown: () => invoke(SYNC_CHANNELS.GET_STORAGE_BREAKDOWN)
+  getStorageBreakdown: () => invoke(SYNC_CHANNELS.GET_STORAGE_BREAKDOWN),
+  getLargeNotes: () => invoke(SYNC_CHANNELS.GET_LARGE_NOTES)
 }
 
 type CryptoItemType = 'note' | 'task' | 'project' | 'settings'

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1583,6 +1583,7 @@ interface SyncOpsClientAPI {
       other: number
     }
   } | null>
+  getLargeNotes: () => Promise<import('@memry/contracts/ipc-sync-ops').LargeNotesResult>
 }
 
 // Crypto API

--- a/apps/desktop/src/renderer/src/components/settings/large-notes-warning.test.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/large-notes-warning.test.tsx
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@tests/utils/render'
+import type { LargeNotesResult } from '@memry/contracts/ipc-sync-ops'
+import { LargeNotesWarning } from './large-notes-warning'
+
+const getLargeNotes = vi.fn<() => Promise<LargeNotesResult>>()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  const api = window.api as typeof window.api & {
+    syncOps?: { getLargeNotes?: typeof getLargeNotes }
+  }
+  api.syncOps = api.syncOps ?? {}
+  api.syncOps.getLargeNotes = getLargeNotes
+})
+
+describe('LargeNotesWarning', () => {
+  it('#given no large notes #then it renders nothing', async () => {
+    getLargeNotes.mockResolvedValue({ maxBytes: 3_826_189, notes: [] })
+
+    const { container } = renderWithProviders(<LargeNotesWarning />)
+
+    await waitFor(() => expect(getLargeNotes).toHaveBeenCalled())
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('#given a note already over the ceiling #then it names the note and says it is not syncing', async () => {
+    getLargeNotes.mockResolvedValue({
+      maxBytes: 3_826_189,
+      notes: [
+        {
+          id: 'note-big',
+          title: 'Server log dump',
+          path: 'logs/server.md',
+          sizeBytes: 4_000_000,
+          status: 'over'
+        }
+      ]
+    })
+
+    renderWithProviders(<LargeNotesWarning />)
+
+    expect(await screen.findByText('Server log dump')).toBeInTheDocument()
+    expect(screen.getByText('Not syncing')).toBeInTheDocument()
+  })
+
+  it('#given a note still under the ceiling #then it warns while the note still syncs', async () => {
+    getLargeNotes.mockResolvedValue({
+      maxBytes: 3_826_189,
+      notes: [
+        {
+          id: 'note-growing',
+          title: 'Meeting log',
+          path: 'Meeting log.md',
+          sizeBytes: 3_200_000,
+          status: 'approaching'
+        }
+      ]
+    })
+
+    renderWithProviders(<LargeNotesWarning />)
+
+    expect(await screen.findByText('Meeting log')).toBeInTheDocument()
+    expect(screen.getByText('Approaching the limit')).toBeInTheDocument()
+    expect(screen.queryByText('Not syncing')).not.toBeInTheDocument()
+  })
+
+  it('#given the lookup fails #then it renders nothing rather than an error', async () => {
+    getLargeNotes.mockRejectedValue(new Error('no vault'))
+
+    const { container } = renderWithProviders(<LargeNotesWarning />)
+
+    await waitFor(() => expect(getLargeNotes).toHaveBeenCalled())
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/settings/large-notes-warning.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/large-notes-warning.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+import type { LargeNotesResult } from '@memry/contracts/ipc-sync-ops'
+import { useT } from '@memry/i18n/renderer'
+import { formatBytes } from '@/lib/format'
+import { SettingsGroup } from '@/components/settings/settings-primitives'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('LargeNotesWarning')
+
+/**
+ * The storage bar answers "how much am I using". It cannot answer "which note
+ * is about to stop syncing", because a note body only ever moves the aggregate
+ * number. This names them, before the ceiling is reached and after (#1465).
+ */
+export function LargeNotesWarning(): React.JSX.Element | null {
+  const { t } = useT('settings')
+  const [data, setData] = useState<LargeNotesResult | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    window.api.syncOps
+      .getLargeNotes()
+      .then((result) => {
+        if (!cancelled) setData(result)
+      })
+      .catch((err) => {
+        // Nothing to warn about is the common case; a failure here must not
+        // push an error into a settings screen the user opened for something
+        // else.
+        log.warn('Could not list notes near the sync limit', err)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (!data || data.notes.length === 0) return null
+
+  return (
+    <SettingsGroup label={t('vault.groups.largeNotes')}>
+      <div className="py-3 px-4 space-y-3">
+        <p className="text-xs/4 text-muted-foreground">
+          {t('vault.largeNotes.description', { limit: formatBytes(data.maxBytes) })}
+        </p>
+
+        <ul className="space-y-2">
+          {data.notes.map((note) => (
+            <li key={note.id} className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-[13px]/4 text-foreground truncate">{note.title}</p>
+                <p className="text-xs/4 text-muted-foreground truncate">{note.path}</p>
+              </div>
+              <div className="shrink-0 text-end">
+                <p className="text-xs/4 tabular-nums text-muted-foreground">
+                  {formatBytes(note.sizeBytes)}
+                </p>
+                <p
+                  className={
+                    note.status === 'over'
+                      ? 'text-xs/4 text-destructive'
+                      : 'text-xs/4 text-muted-foreground'
+                  }
+                >
+                  {note.status === 'over'
+                    ? t('vault.largeNotes.over')
+                    : t('vault.largeNotes.approaching')}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </SettingsGroup>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/zero-leaf-surfaces.test.tsx
+++ b/apps/desktop/src/renderer/src/components/zero-leaf-surfaces.test.tsx
@@ -157,6 +157,9 @@ describe('zero-covered leaf surfaces', () => {
       vault: {
         getStatus: vi.fn().mockResolvedValue({ path: '/Users/kaan/Vault' }),
         reveal: vi.fn().mockResolvedValue(undefined)
+      },
+      syncOps: {
+        getLargeNotes: vi.fn().mockResolvedValue({ maxBytes: 3_826_189, notes: [] })
       }
     }
   })

--- a/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
@@ -476,6 +476,28 @@ describe('SyncProvider', () => {
       )
     })
 
+    it('#then names the note when the main process reports which one is too large', async () => {
+      // "A note is too large" with no name leaves the user nothing to act on.
+      renderHook(() => useSync(), { wrapper })
+      await vi.waitFor(() => expect(syncStatusListeners.length).toBeGreaterThan(0))
+
+      act(() => {
+        for (const cb of syncStatusListeners) {
+          cb({
+            status: 'error',
+            pendingCount: 0,
+            errorCategory: 'note_too_large',
+            errorNoteTitle: 'Server log dump'
+          })
+        }
+      })
+
+      expect(toastMock.error).toHaveBeenCalledWith(
+        '"Server log dump" is too large to sync. Splitting it into smaller notes will fix this.',
+        { duration: 10000 }
+      )
+    })
+
     it('#then translates session and device revoked state errors', async () => {
       const { result } = renderHook(() => useSync(), { wrapper })
       await vi.waitFor(() => expect(sessionExpiredListeners.length).toBeGreaterThan(0))

--- a/apps/desktop/src/renderer/src/contexts/sync-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.tsx
@@ -364,7 +364,14 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
           toast.error(t('sync.fileTooLarge'), { duration: 10000 })
         }
         if (event.errorCategory === 'note_too_large') {
-          toast.error(t('sync.noteTooLarge'), { duration: 10000 })
+          // An older main process sends no title; the unnamed message is the
+          // fallback, not the default.
+          toast.error(
+            event.errorNoteTitle
+              ? t('sync.noteTooLargeNamed', { title: event.errorNoteTitle })
+              : t('sync.noteTooLarge'),
+            { duration: 10000 }
+          )
         }
       })
     )

--- a/apps/desktop/src/renderer/src/pages/settings/vault-section.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/vault-section.test.tsx
@@ -33,6 +33,11 @@ describe('VaultSettings account vaults', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     window.api.vault.getStatus = vi.fn().mockResolvedValue({ path: '/vaults/Active' })
+    const api = window.api as typeof window.api & {
+      syncOps?: { getLargeNotes?: ReturnType<typeof vi.fn> }
+    }
+    api.syncOps = api.syncOps ?? {}
+    api.syncOps.getLargeNotes = vi.fn().mockResolvedValue({ maxBytes: 3_826_189, notes: [] })
   })
 
   it('lists every vault in the account', async () => {

--- a/apps/desktop/src/renderer/src/pages/settings/vault-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/vault-section.tsx
@@ -10,6 +10,7 @@ import {
   SettingsGroup,
   SettingRow
 } from '@/components/settings/settings-primitives'
+import { LargeNotesWarning } from '@/components/settings/large-notes-warning'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -147,6 +148,9 @@ export function VaultSettings() {
           </div>
         )}
       </SettingsGroup>
+
+      {/* Renders nothing unless a note is at or over the per-note sync ceiling. */}
+      <LargeNotesWarning />
 
       <SettingsGroup label={t('vault.groups.accountVaults')}>
         {accountVaults.length === 0 ? (

--- a/apps/docs/src/user-guide/sync/conflict-health.md
+++ b/apps/docs/src/user-guide/sync/conflict-health.md
@@ -93,16 +93,39 @@ This is the actionable punch list — fix everything here and sync should be cle
 
 ## Common Sync Errors
 
-| Error                            | Likely cause                                                                                             | Fix                                                                                                             |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| "Authentication expired"         | Refresh token expired                                                                                    | Sign in again                                                                                                   |
-| "Quota exceeded"                 | Vault size hit storage limit                                                                             | Upgrade plan or clean attachments                                                                               |
-| "A note is too large to sync"    | One note's encrypted sync payload is over the per-request limit — a payload problem, not account storage | Split the note into smaller notes, or move large pasted content into attachments; other notes keep syncing      |
-| "Network unreachable"            | Offline                                                                                                  | Reconnect; sync auto-resumes                                                                                    |
-| "Server temporarily unavailable" | Cloudflare hiccup                                                                                        | Wait; backoff retries automatically                                                                             |
-| "Blob hash mismatch"             | Corruption (rare)                                                                                        | Push the affected item again from the source device                                                             |
-| "Crypto version mismatch"        | Sync server behind a desktop release                                                                     | Wait for server to update or downgrade desktop                                                                  |
-| "All items failed to decrypt"    | This device's vault key no longer matches the account                                                    | The app signs you out and prompts recovery — sign in and enter your recovery phrase; your server data is intact |
+| Error                            | Likely cause                                                                                           | Fix                                                                                                             |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| "Authentication expired"         | Refresh token expired                                                                                  | Sign in again                                                                                                   |
+| "Quota exceeded"                 | Vault size hit storage limit                                                                           | Upgrade plan or clean attachments                                                                               |
+| "'<name>' is too large to sync"  | That note's encrypted sync payload is over the per-note limit — a payload problem, not account storage | Split the note into smaller notes, or move large pasted content into attachments; other notes keep syncing      |
+| "Network unreachable"            | Offline                                                                                                | Reconnect; sync auto-resumes                                                                                    |
+| "Server temporarily unavailable" | Cloudflare hiccup                                                                                      | Wait; backoff retries automatically                                                                             |
+| "Blob hash mismatch"             | Corruption (rare)                                                                                      | Push the affected item again from the source device                                                             |
+| "Crypto version mismatch"        | Sync server behind a desktop release                                                                   | Wait for server to update or downgrade desktop                                                                  |
+| "All items failed to decrypt"    | This device's vault key no longer matches the account                                                  | The app signs you out and prompts recovery — sign in and enter your recovery phrase; your server data is intact |
+
+## When a Note Gets Too Big to Sync
+
+A note body has its own size ceiling, separate from your plan's storage quota and
+separate from the per-file limit that governs attachments. Past roughly 3.7 MB of
+text, a note's sync payload no longer fits in a single request and that note stops
+syncing. Every other note keeps syncing normally.
+
+This used to be silent. It is not any more:
+
+- **Before it breaks.** **Settings → Vault → Notes near the sync limit** lists any
+  note that is close to the ceiling, with its name, its location in the vault, and
+  its size. A note marked _Approaching the limit_ still syncs. The section is
+  hidden entirely when no note is near the ceiling, which is the normal case.
+- **When it breaks.** The note is named in the error, so you know which one to
+  split, and it is marked _Not syncing_ in the same list.
+- **In an existing vault.** A note that was already over the ceiling shows up in
+  that list too, rather than staying quietly broken.
+
+The fix is to split the note, or move the bulk of it out — a large pasted log or
+transcript usually belongs in an attachment rather than in the note body. Nothing
+is lost while a note is over the ceiling: the text is safe on the device you typed
+it on, and it syncs again once the note is small enough.
 
 ## Recovering an Overwritten Edit
 

--- a/apps/docs/src/user-guide/sync/conflict-health.md
+++ b/apps/docs/src/user-guide/sync/conflict-health.md
@@ -93,16 +93,16 @@ This is the actionable punch list — fix everything here and sync should be cle
 
 ## Common Sync Errors
 
-| Error                            | Likely cause                                                                                           | Fix                                                                                                             |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| "Authentication expired"         | Refresh token expired                                                                                  | Sign in again                                                                                                   |
-| "Quota exceeded"                 | Vault size hit storage limit                                                                           | Upgrade plan or clean attachments                                                                               |
-| "'<name>' is too large to sync"  | That note's encrypted sync payload is over the per-note limit — a payload problem, not account storage | Split the note into smaller notes, or move large pasted content into attachments; other notes keep syncing      |
-| "Network unreachable"            | Offline                                                                                                | Reconnect; sync auto-resumes                                                                                    |
-| "Server temporarily unavailable" | Cloudflare hiccup                                                                                      | Wait; backoff retries automatically                                                                             |
-| "Blob hash mismatch"             | Corruption (rare)                                                                                      | Push the affected item again from the source device                                                             |
-| "Crypto version mismatch"        | Sync server behind a desktop release                                                                   | Wait for server to update or downgrade desktop                                                                  |
-| "All items failed to decrypt"    | This device's vault key no longer matches the account                                                  | The app signs you out and prompts recovery — sign in and enter your recovery phrase; your server data is intact |
+| Error                              | Likely cause                                                                                           | Fix                                                                                                             |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| "Authentication expired"           | Refresh token expired                                                                                  | Sign in again                                                                                                   |
+| "Quota exceeded"                   | Vault size hit storage limit                                                                           | Upgrade plan or clean attachments                                                                               |
+| "_note name_ is too large to sync" | That note's encrypted sync payload is over the per-note limit — a payload problem, not account storage | Split the note into smaller notes, or move large pasted content into attachments; other notes keep syncing      |
+| "Network unreachable"              | Offline                                                                                                | Reconnect; sync auto-resumes                                                                                    |
+| "Server temporarily unavailable"   | Cloudflare hiccup                                                                                      | Wait; backoff retries automatically                                                                             |
+| "Blob hash mismatch"               | Corruption (rare)                                                                                      | Push the affected item again from the source device                                                             |
+| "Crypto version mismatch"          | Sync server behind a desktop release                                                                   | Wait for server to update or downgrade desktop                                                                  |
+| "All items failed to decrypt"      | This device's vault key no longer matches the account                                                  | The app signs you out and prompts recovery — sign in and enter your recovery phrase; your server data is intact |
 
 ## When a Note Gets Too Big to Sync
 

--- a/packages/contracts/src/ipc-events.ts
+++ b/packages/contracts/src/ipc-events.ts
@@ -44,6 +44,13 @@ export interface SyncStatusChangedEvent {
   error?: string
   errorCategory?: SyncErrorCategory
   offlineSince?: number
+  /**
+   * Name of the note the error is about. Only set for `note_too_large`, where
+   * an unnamed "a note is too large" leaves the user with nothing to act on.
+   * Optional: an older main process sends none and the renderer falls back to
+   * the unnamed message.
+   */
+  errorNoteTitle?: string
 }
 
 export interface ItemSyncedEvent {
@@ -121,10 +128,7 @@ export interface SyncResumedEvent {
  * own: the client stops refreshing entirely and the user must sign in again.
  */
 export type SessionExpiredReason =
-  | 'token_expired'
-  | 'device_revoked'
-  | 'server_error'
-  | 'refresh_rejected'
+  'token_expired' | 'device_revoked' | 'server_error' | 'refresh_rejected'
 
 export interface SessionExpiredEvent {
   reason: SessionExpiredReason

--- a/packages/contracts/src/ipc-sync-ops.ts
+++ b/packages/contracts/src/ipc-sync-ops.ts
@@ -14,6 +14,7 @@ export const SYNC_OP_CHANNELS = {
   UPDATE_SYNCED_SETTING: 'sync:update-synced-setting',
   GET_SYNCED_SETTINGS: 'sync:get-synced-settings',
   GET_STORAGE_BREAKDOWN: 'sync:get-storage-breakdown',
+  GET_LARGE_NOTES: 'sync:get-large-notes',
   GET_QUARANTINED_ITEMS: 'sync:get-quarantined-items',
   CHECK_DEVICE_STATUS: 'sync:check-device-status',
   EMERGENCY_WIPE: 'sync:emergency-wipe'
@@ -113,6 +114,26 @@ export interface StorageBreakdownResult {
     crdt: number
     other: number
   }
+}
+
+/**
+ * A note at or over the per-note sync ceiling. The storage breakdown answers
+ * "how much am I using"; this answers "which note is about to stop syncing",
+ * which the four aggregate categories cannot express.
+ */
+export interface LargeNoteEntry {
+  id: string
+  title: string
+  path: string
+  sizeBytes: number
+  /** `over` has already stopped syncing; `approaching` still syncs. */
+  status: 'approaching' | 'over'
+}
+
+export interface LargeNotesResult {
+  /** Largest note the sync path accepts, so the renderer need not restate it. */
+  maxBytes: number
+  notes: LargeNoteEntry[]
 }
 
 // ============================================================================

--- a/packages/i18n/src/locales/en/errors.json
+++ b/packages/i18n/src/locales/en/errors.json
@@ -84,6 +84,7 @@
     "storageQuotaExceeded": "Your sync storage is full. Free up space or upgrade your plan.",
     "fileTooLarge": "This file is larger than your plan allows. Upgrade your plan to sync larger files.",
     "noteTooLarge": "A note is too large to sync. Splitting it into smaller notes will fix this.",
+    "noteTooLargeNamed": "\"{title}\" is too large to sync. Splitting it into smaller notes will fix this.",
     "attachmentUploadFailed": "Couldn't sync attachment \"{filename}\". It stays on this device.",
     "paymentRequired": "A paid Sync plan is required to use hosted encrypted sync.",
     "certificatePinFailed": "Secure connection failed. Check your network connection.",

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -1176,7 +1176,8 @@
     "groups": {
       "storageUsage": "Storage Usage",
       "location": "Location",
-      "accountVaults": "Vaults in your account"
+      "accountVaults": "Vaults in your account",
+      "largeNotes": "Notes near the sync limit"
     },
     "loadingStorage": "Loading storage info...",
     "signInStorage": "Sign in to view storage usage",
@@ -1208,6 +1209,11 @@
       },
       "warningTitle": "Storage almost full",
       "warningDescription": "Free up space or upgrade your plan to avoid sync issues."
+    },
+    "largeNotes": {
+      "description": "Notes larger than {limit} stop syncing. Split these into smaller notes to keep them in sync.",
+      "over": "Not syncing",
+      "approaching": "Approaching the limit"
     }
   },
   "tags": {


### PR DESCRIPTION
Closes #1465. Track B of #1468 — independent of the #1458–#1464 ingest series.

## What was wrong

A note that grows past roughly 3.7 MB of markdown stops syncing, and nothing tells the user. Two separate gaps.

**The failure was silent, and the one visible path was unreachable.** `encryptItemForPush` rejects a push payload whose byte length times the base64/crypto overhead (1.37) exceeds 5 MiB. A note's record payload carries the whole markdown body on `create`, so that client cap binds well before the server's 8 MiB `/sync/*` body cap — which means the `note_too_large` toast, built for exactly this condition, was effectively dead code for a note push. The throw happens before any HTTP request, so the rejection only wrote a message onto the sync-queue row, bumped the attempt count, and dead-lettered after the retry budget.

**The growth was invisible.** Storage is reported as four aggregate categories behind one usage bar. Note bodies do consume quota, so the number moves — it just cannot be attributed to a note.

## What changed

Error path:
- `encryptItemForPush` throws a typed `ItemTooLargeError` instead of a bare `Error`. The cap value is unchanged.
- The sync worker carries a `code: 'item_too_large'` discriminator across the thread boundary (an `Error` subclass cannot survive it).
- `encryptPushBatch` reports the rejection to its caller in addition to `markFailed`, on both the worker and the main-thread fallback path. The fallback no longer aborts the whole batch for one oversized item — every other queued edit still pushes.
- `PushCoordinator` turns that into the existing `note_too_large` category with the note's title attached. It deliberately does not pause the queue or move engine state, matching how the server-413 path already behaves.
- The server-413 path gains the same name.
- The renderer toast names the note; the unnamed string stays as the fallback for an older main process.

Visibility:
- New `sync:get-large-notes` IPC returns notes at or over the ceiling with name, path, size and `approaching`/`over` status.
- **Settings → Vault → Notes near the sync limit** renders that list, and renders nothing at all when no note is near the ceiling. A note already over the ceiling in an existing vault appears here rather than staying quietly broken.

No new error category — `note_too_large` is reused. Storage breakdown is untouched, so it still reconciles with the aggregate figure.

## Compatibility

- No DB migration, no schema change, no reindex, no FTS rebuild. Sizes come from `stat` over the note cache, so an existing vault answers correctly on first open.
- `SyncStatusChangedEvent.errorNoteTitle` is optional and additive; `sync:get-large-notes` is a new channel an older renderer never calls.
- The ceiling itself is unchanged. This surfaces the limit, it does not raise it. `assertFileSizeAllowed` (plan `maxFileSize`) still governs blob routes only and was not touched.

## How tested

TDD throughout — each test was written first, run red for the right reason, then made green, then mutation-checked by reverting the production change and confirming it went red again.

New coverage:
- `note-size.test.ts` — the ceiling is exactly the largest payload the encrypt cap accepts; boundary classification.
- `encrypt.test.ts` — an oversized payload throws `ItemTooLargeError` naming the item; a payload exactly at the ceiling still encrypts.
- `sync-crypto-batch.test.ts` — a worker encrypt-cap rejection reaches the caller, not just the queue row; an ordinary encrypt failure does not; a main-thread rejection is isolated so the rest of the batch still pushes.
- `push-coordinator.test.ts` — **the regression test for this issue**: a push above the client cap produces a renderer-visible `note_too_large` naming the note; a non-note item over the cap raises no note error.
- `sync-context.test.tsx` — the toast names the note.
- `large-notes.test.ts` / `large-notes-warning.test.tsx` — over/approaching/ordinary classification, ranking, attachment and local-only exclusion, unmeasurable files skipped, and the UI renders nothing when there is nothing to warn about.

Two pre-existing renderer harnesses (`vault-section.test.tsx`, `zero-leaf-surfaces.test.tsx`) build a partial `window.api`; they now stub the new call. No assertion was weakened.

Full block, all green: `pnpm lint`, `pnpm typecheck`, `pnpm --filter @memry/desktop typecheck:test`, `pnpm test:desktop` (16098 passed), `pnpm test:sync-server` (941 passed), `pnpm check:architecture`, `pnpm check:contracts`, `pnpm --filter @memry/desktop i18n:check`, `pnpm ipc:generate && pnpm ipc:check`, `pnpm docs:impact --strict`, `pnpm docs:build`, `git diff --check`.