### PR TITLE
fix(sync): keep large-file class off sync, on both sides

### DIFF
--- a/apps/desktop/src/main/notes/runtime-effects.test.ts
+++ b/apps/desktop/src/main/notes/runtime-effects.test.ts
@@ -32,28 +32,38 @@ describe('syncNoteCreate', () => {
     vi.clearAllMocks()
   })
 
-  it('gives a new note a CRDT doc by default', () => {
+  it('gives a new note a CRDT doc and a sync item by default', () => {
     // #when
     syncNoteCreate('note-1', 'Title', ['alpha'])
 
     // #then
     expect(mocks.initForNote).toHaveBeenCalledWith('note-1', { title: 'Title' }, ['alpha'])
+    expect(mocks.enqueueLocalSyncCreate).toHaveBeenCalledWith('note', 'note-1')
   })
 
   it('skips the CRDT doc when the caller says the file is large-file class', () => {
     // #when — what the vault watcher does for a log dump
-    syncNoteCreate('big-note', 'Server Log', [], { initCrdt: false })
+    syncNoteCreate('big-note', 'Server Log', [], { sizeClass: 'large-file' })
 
     // #then — no Y.Doc, so the BlockNote markdown parse never starts
     expect(mocks.initForNote).not.toHaveBeenCalled()
   })
 
-  it('still enqueues the note for sync when the CRDT doc is skipped', () => {
-    // #given large-file class is a body decision, not a "forget this file"
-    // decision — #1461 is what stops it syncing.
-    syncNoteCreate('big-note', 'Server Log', [], { initCrdt: false })
+  it('enqueues no sync item for a large-file-class file', () => {
+    // #given a large-file-class file has no CRDT body, so the row another
+    // device would draw from a note sync item could never be opened there. A
+    // row that cannot be opened is worse than no row at all.
+    syncNoteCreate('big-note', 'Server Log', [], { sizeClass: 'large-file' })
 
     // #then
-    expect(mocks.enqueueLocalSyncCreate).toHaveBeenCalledWith('note', 'big-note')
+    expect(mocks.enqueueLocalSyncCreate).not.toHaveBeenCalled()
+  })
+
+  it('still enqueues a note-class file for sync', () => {
+    // #then the guard must cost note-class files nothing
+    syncNoteCreate('note-1', 'Title', ['alpha'], { sizeClass: 'note' })
+
+    expect(mocks.enqueueLocalSyncCreate).toHaveBeenCalledWith('note', 'note-1')
+    expect(mocks.initForNote).toHaveBeenCalledWith('note-1', { title: 'Title' }, ['alpha'])
   })
 })

--- a/apps/desktop/src/main/notes/runtime-effects.ts
+++ b/apps/desktop/src/main/notes/runtime-effects.ts
@@ -1,4 +1,5 @@
 import { updateNoteMetadata } from '@memry/storage-data'
+import type { MarkdownSizeClass } from '@memry/shared/markdown-class'
 import { updateNoteCache } from '@main/database/queries/notes'
 import { getDatabase, getIndexDatabase } from '../database'
 import { attachmentEvents } from '../sync/attachment-events'
@@ -19,11 +20,15 @@ const logger = createLogger('NoteRuntimeEffects')
 
 export interface SyncNoteCreateOptions {
   /**
-   * Whether to give the note a CRDT doc. False for a large-file-class file: it
-   * is listed and tracked, but seeding it would run the BlockNote markdown
-   * parse over the whole file on the main process, which is the freeze.
+   * Defaults to note class, which is every caller that does not classify.
+   *
+   * A large-file-class file gets neither a CRDT doc nor a sync item. No doc,
+   * because seeding one runs the BlockNote markdown parse over the whole file
+   * on the main process, which is the freeze. No sync item, because the body
+   * lives only in that doc — a receiving device would draw a sidebar row it
+   * could never open, which is worse than drawing nothing.
    */
-  initCrdt?: boolean
+  sizeClass?: MarkdownSizeClass
 }
 
 export function syncNoteCreate(
@@ -32,8 +37,9 @@ export function syncNoteCreate(
   tags: string[],
   options?: SyncNoteCreateOptions
 ): void {
+  if (options?.sizeClass === 'large-file') return
+
   enqueueLocalSyncCreate('note', noteId)
-  if (options?.initCrdt === false) return
 
   getCrdtProvider()
     ?.initForNote(noteId, { title }, tags)

--- a/apps/desktop/src/main/sync/crdt-feed.test.ts
+++ b/apps/desktop/src/main/sync/crdt-feed.test.ts
@@ -56,6 +56,23 @@ describe('replaceNoteBodyInCrdt', () => {
     expect(await replaceNoteBodyInCrdt('n1', '')).toBe(false)
   })
 
+  it('refuses markdown over the note-class bounds', async () => {
+    // #given the body a receiver writes back after an oversized note arrives
+    // over sync: one blank-line-free block far over NOTE_MAX_BLOCK_BYTES. The
+    // watcher feeds the file it just wrote straight back in here, so without
+    // this guard the receiver pays the very parse the write-back avoided.
+    const doc = makeDoc()
+    getDoc.mockReturnValue(doc)
+    const dump = Array.from({ length: 8_000 }, (_, i) => `2026-08-15 worker payload ${i}`).join(
+      '\n'
+    )
+
+    // #then no parse, no transaction, and the live doc is left alone
+    expect(await replaceNoteBodyInCrdt('n1', dump)).toBe(false)
+    expect(markdownToBlocks).not.toHaveBeenCalled()
+    expect(doc.transact).not.toHaveBeenCalled()
+  })
+
   it('clears the fragment then rebuilds it once when a doc is open', async () => {
     const doc = makeDoc()
     getDoc.mockReturnValue(doc)

--- a/apps/desktop/src/main/sync/crdt-feed.ts
+++ b/apps/desktop/src/main/sync/crdt-feed.ts
@@ -8,8 +8,12 @@
 import { getCrdtProvider, ORIGIN_LOCAL } from './crdt-provider'
 import { markdownToBlocks, blocksToYFragment } from './blocknote-converter'
 import { normalizeTaskBlocks } from '@memry/shared/task-block'
+import { classifyMarkdownContent } from '@memry/shared/markdown-class'
 import { getIndexDatabase } from '../database'
 import { getNoteCacheById } from '@main/database/queries/notes'
+import { createLogger } from '../lib/logger'
+
+const log = createLogger('CrdtFeed')
 
 /**
  * The note's vault-relative path, so embed targets are rewritten relative to it
@@ -26,13 +30,30 @@ function noteCachePath(noteId: string): string | undefined {
 
 /**
  * Full XML-fragment replace of a note's body inside its live Y.Doc.
- * No-op (returns false) when the doc is not open or the markdown is unparseable.
+ * No-op (returns false) when the doc is not open, the markdown is large-file
+ * class, or the markdown is unparseable.
  * Lossy re: Yjs history, but round-tripping through markdown discards it anyway.
  */
 export async function replaceNoteBodyInCrdt(noteId: string, markdown: string): Promise<boolean> {
   const provider = getCrdtProvider()
   const doc = provider.getDoc(noteId)
   if (!doc) return false
+
+  // The other markdown → Y.Doc door, alongside the seed in `crdt-provider`, and
+  // the one a receiver walks through: an oversized note arriving over sync gets
+  // written back to disk, the watcher sees that write and feeds the file
+  // straight back in here. `markdownToBlocks` below is the parse that froze the
+  // sending device, so the receiver must refuse it for the same reason.
+  const classification = classifyMarkdownContent(markdown)
+  if (classification.sizeClass === 'large-file') {
+    log.warn('Refusing to replace a note body with large-file-class markdown', {
+      noteId,
+      reason: classification.reason,
+      fileBytes: classification.fileBytes,
+      largestBlockBytes: classification.largestBlockBytes
+    })
+    return false
+  }
 
   const blocks = await markdownToBlocks(markdown, noteCachePath(noteId))
   if (!blocks) return false

--- a/apps/desktop/src/main/sync/crdt-writeback.test.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.test.ts
@@ -783,6 +783,85 @@ describe('crdt writeback', () => {
       expect(mocks.atomicWrite).not.toHaveBeenCalled()
     })
   })
+
+  // ==========================================================================
+  // An inbound body that grew past the note-class bounds
+  // ==========================================================================
+
+  /**
+   * One blank-line-free block far over `NOTE_MAX_BLOCK_BYTES` and well under
+   * `NOTE_MAX_BYTES` — the shape a log dump has, and the shape that reaches a
+   * receiver even when the sender's snapshot push is refused at the encrypt
+   * cap, because each incremental CRDT update is individually under the
+   * 256 KB merge cap.
+   */
+  const oversizedBody = Array.from(
+    { length: 8_000 },
+    (_, i) => `2026-08-15T09:14:${String(i % 60).padStart(2, '0')} worker payload ${i}`
+  ).join('\n')
+
+  it('degrades an inbound body over the note-class bounds to large-file class', async () => {
+    // #given the body the incremental updates added up to
+    mocks.yDocToMarkdown.mockResolvedValue(oversizedBody)
+
+    // #when
+    scheduleWriteback('note-1', makeDoc('Server log'))
+    await vi.advanceTimersByTimeAsync(500)
+
+    // #then the file still lands on disk — it is the user's data, and the
+    // read-only viewer reads it from there
+    expect(mocks.atomicWrite).toHaveBeenCalledWith(
+      '/vault/notes/Existing.md',
+      expect.stringContaining('worker payload 0')
+    )
+
+    // ...but the renderer is told the note degraded rather than handed the
+    // body. `note.tsx` feeds `changes.content` straight into the editor, so
+    // shipping it would run the BlockNote parse that froze the sender.
+    const updated = mocks.sent.find((s) => s.channel === NotesChannels.events.UPDATED)
+    expect(updated?.payload).toEqual({
+      id: 'note-1',
+      changes: { sizeClass: 'large-file', contentOmitted: true },
+      source: 'sync'
+    })
+  })
+
+  it('still hands the renderer the body of a note-class inbound edit', async () => {
+    // #then the guard must cost note-class notes nothing — this is the shape
+    // every synced note has today
+    scheduleWriteback('note-1', makeDoc('Yjs title'))
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(mocks.sent).toContainEqual({
+      channel: NotesChannels.events.UPDATED,
+      payload: { id: 'note-1', changes: { content: 'updated markdown' }, source: 'sync' }
+    })
+  })
+
+  it('degrades an inbound body that creates a new note, without seeding it', async () => {
+    // #given a note this device has never seen, arriving over sync from a peer
+    // running a build with no large-file class
+    mocks.getNoteCacheById.mockReturnValue(undefined)
+    mocks.yDocToMarkdown.mockResolvedValue(oversizedBody)
+
+    // #when
+    scheduleWriteback('note-2', makeDoc('Server log'))
+    await vi.advanceTimersByTimeAsync(500)
+
+    // #then the file is created, so nothing the peer sent is lost...
+    expect(mocks.atomicWrite).toHaveBeenCalledWith(
+      '/vault/notes/New.md',
+      expect.stringContaining('worker payload 0')
+    )
+
+    // ...and the row appears, but flagged large-file class so the renderer
+    // opens the read-only viewer instead of seeding an editor from it
+    const created = mocks.sent.find((s) => s.channel === NotesChannels.events.CREATED)
+    expect(created?.payload).toMatchObject({
+      note: { id: 'note-2', sizeClass: 'large-file', contentOmitted: true },
+      source: 'sync'
+    })
+  })
 })
 
 describe('crdt-writeback per-vault state reset', () => {

--- a/apps/desktop/src/main/sync/crdt-writeback.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.ts
@@ -6,6 +6,7 @@ import { getCrdtProvider } from './crdt-provider'
 import { findUnrepresentableNodes, yDocToMarkdown } from './blocknote-converter'
 import { emitNoteUpdated } from './note-events'
 import { readCriticMarkupMarksFromYDoc, serializeCriticMarkup } from '@memry/shared'
+import { classifyMarkdownContent } from '@memry/shared/markdown-class'
 import { utcNow } from '@memry/shared/utc'
 import {
   atomicWrite,
@@ -445,6 +446,22 @@ async function performWriteback(noteId: string, doc: Y.Doc): Promise<void> {
     return
   }
 
+  // The receiving half of the large-file class. A peer running an older build,
+  // or one whose oversized snapshot push was refused at the encrypt cap, still
+  // sends the body as incremental CRDT updates — those are individually under
+  // the merge cap and pass freely, so the ingest-side guard never sees them.
+  // The body lands on disk either way; what degrades is how it is handed on.
+  const bodyClass = classifyMarkdownContent(markdown)
+  const isLargeFileBody = bodyClass.sizeClass === 'large-file'
+  if (isLargeFileBody) {
+    log.warn('Inbound body is large-file class; degrading the note', {
+      noteId,
+      reason: bodyClass.reason,
+      fileBytes: bodyClass.fileBytes,
+      largestBlockBytes: bodyClass.largestBlockBytes
+    })
+  }
+
   const indexDb = getIndexDatabase()
   const cached = getNoteCacheById(indexDb, noteId) ?? resolveFromCanonicalMetadata(noteId)
 
@@ -452,9 +469,9 @@ async function performWriteback(noteId: string, doc: Y.Doc): Promise<void> {
     await writebackJournal(noteId, doc, markdown, cached, indexDb)
   } else {
     if (cached) {
-      await writebackExisting(noteId, cached, doc, markdown, indexDb)
+      await writebackExisting(noteId, cached, doc, markdown, indexDb, isLargeFileBody)
     } else {
-      await writebackNewNote(noteId, doc, markdown, indexDb)
+      await writebackNewNote(noteId, doc, markdown, indexDb, isLargeFileBody)
     }
     try {
       await syncNoteDateReminders(
@@ -473,7 +490,8 @@ async function writebackExisting(
   cached: NonNullable<ReturnType<typeof getNoteCacheById>>,
   doc: Y.Doc,
   markdown: string,
-  indexDb: ReturnType<typeof getIndexDatabase>
+  indexDb: ReturnType<typeof getIndexDatabase>,
+  isLargeFileBody: boolean
 ): Promise<void> {
   const relativePath = cached.path
   const absolutePath = toAbsolutePath(relativePath)
@@ -535,10 +553,17 @@ async function writebackExisting(
 
   // The body genuinely changed here, so `content` has to ride along: it is what
   // makes an open editor pick up a remote edit instead of showing stale text
-  // until the tab is reopened.
+  // until the tab is reopened. Except when the body is large-file class, where
+  // that is exactly the harm: `note.tsx` feeds `changes.content` into the
+  // editor, so shipping it runs the parse this whole class exists to avoid —
+  // and every window pays a structured clone of the whole body to get it.
+  // The class rides along instead, so the renderer degrades to the read-only
+  // view it would have shown had the file been opened fresh.
   emitNoteUpdated(emitToRenderer, {
     id: noteId,
-    changes: { content: markdown },
+    changes: isLargeFileBody
+      ? { sizeClass: 'large-file', contentOmitted: true }
+      : { content: markdown },
     source: 'sync'
   })
   log.debug('Write-back complete', { noteId })
@@ -548,7 +573,8 @@ async function writebackNewNote(
   noteId: string,
   doc: Y.Doc,
   markdown: string,
-  indexDb: ReturnType<typeof getIndexDatabase>
+  indexDb: ReturnType<typeof getIndexDatabase>,
+  isLargeFileBody: boolean
 ): Promise<void> {
   const meta = doc.getMap('meta')
   const title = (meta.get('title') as string) || 'Untitled'
@@ -582,8 +608,13 @@ async function writebackNewNote(
   )
   void flushProjectionEvents()
 
+  // The row appears either way — the file is on disk and hiding it would strand
+  // the user's data — but a large-file-class row is flagged as such, so the
+  // renderer opens the read-only view instead of seeding an editor from it.
   emitToRenderer(NotesChannels.events.CREATED, {
-    note: { id: noteId, path: relativePath, title },
+    note: isLargeFileBody
+      ? { id: noteId, path: relativePath, title, sizeClass: 'large-file', contentOmitted: true }
+      : { id: noteId, path: relativePath, title },
     source: 'sync'
   })
 

--- a/apps/desktop/src/main/vault/watcher.test.ts
+++ b/apps/desktop/src/main/vault/watcher.test.ts
@@ -72,6 +72,7 @@ vi.mock('./index', () => ({
 }))
 
 import { getIndexDatabase, getDatabase, updateFtsContent } from '../database'
+import { enqueueJournalCreate, initializeJournalCrdt } from '../journal/runtime-effects'
 import { syncNoteCreate } from '../notes/runtime-effects'
 import { updateNoteEmbedding } from '../inbox/suggestions'
 import { getConfig } from './index'
@@ -600,8 +601,44 @@ describe('vault watcher', () => {
 
     // ...but ingest asks for no CRDT doc, so the BlockNote parse never starts
     expect(syncNoteCreate).toHaveBeenCalledWith(cached!.id, expect.any(String), expect.any(Array), {
-      initCrdt: false
+      sizeClass: 'large-file'
     })
+  })
+
+  it('enqueues no journal sync item for a large-file-class journal entry', async () => {
+    // #given a dump dropped straight into the journal folder. It has no CRDT
+    // body, so a sync item would only draw a row another device cannot open.
+    const watcher = new VaultWatcher() as any
+    watcher.vaultPath = vault.path
+    const journalPath = path.join(vault.journalDir, '2026-05-11.md')
+    const dump = Array.from({ length: 20_000 }, (_, i) => `2026-05-11 line ${i} payload`).join('\n')
+    fs.writeFileSync(journalPath, `---\nid: "journal-dump"\n---\n\n${dump}`, 'utf8')
+    vi.mocked(enqueueJournalCreate).mockClear()
+    vi.mocked(initializeJournalCrdt).mockClear()
+
+    // #when
+    await watcher.handleFileAdd(journalPath)
+
+    // #then — listed locally, but nothing leaves this device and nothing seeds
+    expect(enqueueJournalCreate).not.toHaveBeenCalled()
+    expect(initializeJournalCrdt).not.toHaveBeenCalled()
+  })
+
+  it('still enqueues a note-class journal entry for sync', async () => {
+    // #then the guard must cost note-class journal entries nothing
+    const watcher = new VaultWatcher() as any
+    watcher.vaultPath = vault.path
+    const journalPath = path.join(vault.journalDir, '2026-05-12.md')
+    fs.writeFileSync(journalPath, '---\nid: "journal-small"\n---\n\nFirst entry', 'utf8')
+    vi.mocked(enqueueJournalCreate).mockClear()
+    vi.mocked(initializeJournalCrdt).mockClear()
+
+    // #when
+    await watcher.handleFileAdd(journalPath)
+
+    // #then
+    expect(enqueueJournalCreate).toHaveBeenCalledWith(expect.any(String), '2026-05-12')
+    expect(initializeJournalCrdt).toHaveBeenCalled()
   })
 
   it('still initiates a CRDT seed for a well-formed note', async () => {
@@ -621,7 +658,7 @@ describe('vault watcher', () => {
       expect.any(String),
       expect.any(String),
       expect.any(Array),
-      { initCrdt: true }
+      { sizeClass: 'note' }
     )
   })
 })

--- a/apps/desktop/src/main/vault/watcher.ts
+++ b/apps/desktop/src/main/vault/watcher.ts
@@ -387,15 +387,17 @@ export class VaultWatcher {
       localOnly: false
     }
 
-    // A large-file-class file still gets a sidebar row, but never a Y.Doc.
-    // Seeding one runs the BlockNote markdown parse over the whole file on the
-    // main process with no yield point, and that parse is the freeze: its cost
-    // tracks single-block size, so a blank-line-free dump costs 14x the same
-    // bytes shaped as paragraphs.
+    // A large-file-class file still gets a sidebar row here, but never a Y.Doc
+    // and never a sync item. No Y.Doc, because seeding one runs the BlockNote
+    // markdown parse over the whole file on the main process with no yield
+    // point, and that parse is the freeze: its cost tracks single-block size,
+    // so a blank-line-free dump costs 14x the same bytes shaped as paragraphs.
+    // No sync item, because the body only travels in that Y.Doc — the other
+    // device would get a row with nothing behind it.
     const classification = classifyMarkdownContent(content)
     const isLargeFile = classification.sizeClass === 'large-file'
     if (isLargeFile) {
-      logger.warn('Ingested file is large-file class; skipping CRDT seed', {
+      logger.warn('Ingested file is large-file class; not seeding or syncing it', {
         path: relativePath,
         reason: classification.reason,
         fileBytes: classification.fileBytes,
@@ -406,10 +408,12 @@ export class VaultWatcher {
     // Enqueue sync push so other devices learn about the new file
     if (isJournalPath(relativePath)) {
       const journalDate = extractJournalDate(relativePath)
-      enqueueJournalCreate(noteId, journalDate)
-      if (!isLargeFile) void initializeJournalCrdt(noteId, journalDate, tags)
+      if (!isLargeFile) {
+        enqueueJournalCreate(noteId, journalDate)
+        void initializeJournalCrdt(noteId, journalDate, tags)
+      }
     } else {
-      syncNoteCreate(noteId, parsed.title, tags, { initCrdt: !isLargeFile })
+      syncNoteCreate(noteId, parsed.title, tags, { sizeClass: classification.sizeClass })
     }
 
     // Emit event to renderer

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -225,5 +225,9 @@ size and the limit it passed, marked **read-only · not synced**:
 - **The file on disk is not touched.** Nothing is truncated, rewritten or deleted, and you can
   still open it in any other editor.
 
+The limits apply to notes arriving over sync too. A device still running an older version can send
+you a note that is over them; memrynote keeps every byte of it and writes the file to your vault,
+but opens it read-only rather than in the editor, exactly as if you had dropped it in yourself.
+
 Notes you already have keep working exactly as before — nothing is re-scanned or re-indexed, and
 existing notes under these limits are unaffected.


### PR DESCRIPTION
Closes #1461. Part of EPIC #1468. Follows #1474 (#1459), now on `main`.

## The gap

#1459 stopped a large-file-class file from getting a CRDT doc, but deliberately left `enqueueLocalSyncCreate` alone — that was this ticket. It also only guarded the *sending* device.

One of the two devices that froze never touched Finder. It received the note over sync (`CrdtWriteback: Created new note from sync`) and paid the same BlockNote parse locally. The sender's snapshot push had been refused at the client encrypt cap (#1445), so the body arrived as **incremental CRDT updates**, which are capped at 256 KB merged / 512 KB per flush and therefore pass freely. An ingest-side guard would never have seen them.

## Sending side

A large-file-class file now enqueues **no sync item at all**, journal entries included. Its body lives only in a Y.Doc it does not have, so a note item would draw a sidebar row on the other device that could never be opened — worse than drawing nothing. Syncing metadata without a body is more correct but opens a new class of inconsistency for materially more work, and is out of scope per the design.

`SyncNoteCreateOptions.initCrdt` becomes `sizeClass`, because "no CRDT doc" and "no sync item" are now one decision, not two booleans that always move together.

## Receiving side

`performWriteback` classifies the body it just serialized. The file still lands on disk — it is the user's data, and the read-only view reads it from there — but:

- the renderer is told the note degraded (`sizeClass: 'large-file'`, `contentOmitted: true`) instead of being handed the body. `note.tsx` feeds `changes.content` straight into the editor, and every window pays a structured clone of the whole body just to receive it.
- `replaceNoteBodyInCrdt` refuses large-file-class markdown. That is the other markdown → Y.Doc door beside the seed #1459 guarded, and the one a receiver walks through: it writes the oversized file out, the watcher sees that write, and feeds the file straight back in.

## Older peers

No protocol, schema or contract change — `sizeClass` / `contentOmitted` are the optional `Note` fields #1459 already added. An older peer keeps sending oversized notes; a new receiver keeps every byte, writes the file, and opens it read-only instead of freezing. An older receiver is unaffected, since a new sender simply never sends it one. No reindex, no migration.

## Known limitation

A file that is large-file class at ingest stays unsynced even if it is later edited down under the limits — the markdown change path syncs bodies through the CRDT doc it never got. Rejoining sync on shrink is a separate concern from this issue.

## Verification

Re-run in full after rebasing onto `main`:

`pnpm lint` (0 errors) · `pnpm typecheck` · `pnpm --filter @memry/desktop typecheck:test` · `pnpm test:sync-server` (947) · `pnpm check:architecture` · `pnpm check:contracts` · `pnpm --filter @memry/desktop i18n:check` · `pnpm ipc:generate && pnpm ipc:check` (no drift) · `git diff --check` · `pnpm docs:impact --strict` · `pnpm docs:build`

Desktop suites run per project: shared 2497, main 6584, main-integration 9, preload 30, renderer 7058 — all passing.

Every guard was mutation-checked: reverting it turns exactly one new test red, and only that one.