### PR TITLE
fix(editor): a spec must be registered under its own node type

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -22,7 +22,12 @@ import {
   serializeCalloutBlock,
   serializeYoutubeEmbed
 } from '@memry/editor-schema/blocks'
-import { createInlineContentSpec } from '@blocknote/core'
+import {
+  BlockNoteSchema,
+  createInlineContentSpec,
+  defaultBlockSpecs,
+  defaultInlineContentSpecs
+} from '@blocknote/core'
 import { createWikiLinkInlineContent, wikiLinkToText } from '@memry/editor-schema/inline'
 import { createServerBlockSpecs, createServerInlineSpecs } from '@memry/editor-schema/server'
 import { serializeDateMentionToken } from '@memry/shared/date-mention'
@@ -785,6 +790,119 @@ describe('findUnrepresentableNodes', () => {
 
     // #then
     expect(unknown).toEqual([])
+  })
+})
+
+/**
+ * The hole `findUnrepresentableNodes` does NOT cover, and what closed it (#1455).
+ *
+ * The guard asks whether this build can CONSTRUCT a node name, because that is
+ * the question y-prosemirror's delete depends on. It is not the question "will
+ * this node survive serialization", and the difference is a whole class of
+ * silent loss: a spec registered under a key that is not its `config.type`
+ * builds fine (the node name comes from `config.type`) and serializes to
+ * nothing (BlockNote resolves nodes against a schema keyed by the REGISTRATION
+ * key). Every guard reads green while the text leaves the vault file.
+ *
+ * The first test measures that, with the mis-keyed schema built the only way it
+ * still can be — `BlockNoteSchema.create` directly. The second shows the door it
+ * came through is shut: `createMemrySchema` refuses the same divergence.
+ */
+describe('a spec registered under a key that is not its config.type', () => {
+  /** `See [[Wiki Link]] for details.` as the renderer puts it in the shared doc. */
+  function wikiLinkDoc(): Y.Doc {
+    const doc = new Y.Doc()
+    const ok = blocksToYFragment(
+      [
+        {
+          id: 'p1',
+          type: 'paragraph',
+          props: {},
+          children: [],
+          content: [
+            { type: 'text', text: 'See ', styles: {} },
+            { type: 'wikiLink', props: { target: 'Wiki Link', alias: '' } },
+            { type: 'text', text: ' for details.', styles: {} }
+          ]
+        }
+      ] as unknown as Parameters<typeof blocksToYFragment>[0],
+      doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+    expect(ok).toBe(true)
+    return doc
+  }
+
+  it('drops the node while every constructibility check stays green', async () => {
+    // #given the shipped schema writes the note, and reads it back whole
+    const doc = wikiLinkDoc()
+    expect(await yDocToMarkdown(doc)).toBe('See [[Wiki Link]] for details.')
+    expect(findUnrepresentableNodes(doc)).toEqual([])
+
+    // #given a schema whose wikiLink spec sits under the wrong key. Built
+    // through `BlockNoteSchema.create` because `createMemrySchema` no longer
+    // permits it — this is the shape that shipped-adjacent code could have had.
+    const inline = createServerInlineSpecs()
+    const misKeyed = ServerBlockNoteEditor.create({
+      schema: BlockNoteSchema.create({
+        blockSpecs: { ...defaultBlockSpecs, ...createServerBlockSpecs() },
+        inlineContentSpecs: {
+          ...defaultInlineContentSpecs,
+          wikiLinkRenamed: inline.wikiLink,
+          linkMention: inline.linkMention,
+          hashTag: inline.hashTag,
+          dateMention: inline.dateMention
+        }
+      })
+      // Through `unknown`: with `wikiLink` gone from the inline map the schema
+      // no longer overlaps the default-parameterised `ServerBlockNoteEditor` at
+      // all, which is the type system noticing the same divergence this test is
+      // about. Only the runtime behaviour is under test here.
+    }) as unknown as ServerBlockNoteEditor
+
+    // #then the node name ProseMirror knows is `config.type`, NOT the key — so
+    // y-prosemirror builds the element instead of deleting it, and a
+    // constructibility scan of this schema reports nothing wrong
+    const pmNodes = misKeyed.editor.pmSchema.nodes
+    expect('wikiLink' in pmNodes).toBe(true)
+    expect('wikiLinkRenamed' in pmNodes).toBe(false)
+
+    // …while BlockNote's own map is keyed by the registration key, so it cannot
+    // resolve the node it just built
+    expect(Object.keys(misKeyed.editor.schema.inlineContentSchema)).toContain('wikiLinkRenamed')
+    expect(Object.keys(misKeyed.editor.schema.inlineContentSchema)).not.toContain('wikiLink')
+
+    // #when the note is written back through that schema. `trimEnd` only
+    // removes the serializer's trailing newline, which `yDocToMarkdown`
+    // normalizes away before the vault file is written.
+    const blocks = misKeyed.yXmlFragmentToBlocks(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    const written = (await misKeyed.blocksToMarkdownLossy(blocks)).trimEnd()
+
+    // #then the link is gone from the bytes — 30 down to 16. BlockNote logs
+    // `unrecognized inline content type wikiLink` on the way past (visible in
+    // this run's stderr) and returns normally, so nothing rejects the write and
+    // the guard has nothing to refuse.
+    expect(written).toBe('See for details.')
+    expect('See [[Wiki Link]] for details.'.length).toBe(30)
+    expect(written.length).toBe(16)
+  })
+
+  it('cannot be built through createMemrySchema', () => {
+    // #given the same divergence, in the one map a caller still supplies
+    // free-form: `createMemrySchema` takes block specs as they come, so the
+    // renderer's React blocks reach no factory that could key them. The cast is
+    // what the mistake now costs — the parameter's mapped type makes a mis-keyed
+    // entry `never`, so this does not compile without one.
+    const blocks = createServerBlockSpecs()
+    const misKeyed = {
+      ...blocks,
+      bookmarkRenamed: blocks.bookmark
+    } as unknown as ReturnType<typeof createServerBlockSpecs>
+
+    // #when / #then the schema build throws, naming the slot and the node name,
+    // so no editor exists to reach `yDocToMarkdown` with
+    expect(() =>
+      createMemrySchema({ blocks: misKeyed, inline: createServerInlineSpecs() })
+    ).toThrowError(/blockSpecs\["bookmarkRenamed"\].*config\.type is "bookmark"/s)
   })
 })
 

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -96,12 +96,25 @@ export async function yDocToMarkdown(
 }
 
 /**
- * Node names in the CRDT fragment that this build's schema cannot construct.
+ * Node names in the CRDT fragment that this build's schema cannot CONSTRUCT.
  *
- * y-prosemirror answers an unknown node name by DELETING the element
+ * Constructibility is the exact question y-prosemirror's repair heuristic asks:
+ * it answers a node name its schema cannot build by DELETING the element
  * (`createNodeFromYElement`, dist/y-prosemirror.cjs:878-885), so a doc holding
  * one can only ever serialize to markdown that is missing it. Callers use this
  * to refuse the write rather than persist the loss.
+ *
+ * It does NOT answer "will this node survive serialization" — the converse of
+ * the sentence above does not hold, and reading it as though it does is what
+ * #1455 is about. A node this build can construct can still be dropped on the
+ * way to markdown; the case that does it is a spec registered under a key that
+ * is not its `config.type`. ProseMirror builds the node (its name comes from
+ * `config.type`, so nothing is reported here and the write is allowed) while
+ * BlockNote's own schema — keyed by the registration key — cannot resolve it
+ * and drops it. Measured: `See [[Wiki Link]] for details.` → `See for
+ * details.`, guard silent. That invariant is not gated here; it is asserted at
+ * construction, in `@memry/editor-schema`'s `assertSpecKeysMatchNodeTypes`, so
+ * a mis-keyed spec fails the schema build instead of reaching this function.
  *
  * The oracle is the ProseMirror schema itself, not a hand-written list: node
  * names are not block type names, and a list would miss the ones that never

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -98,17 +98,24 @@ export async function yDocToMarkdown(
 /**
  * Node names in the CRDT fragment that this build's schema cannot CONSTRUCT.
  *
- * Constructibility is the exact question y-prosemirror's repair heuristic asks:
+ * Constructibility is the question y-prosemirror's repair heuristic asks first:
  * it answers a node name its schema cannot build by DELETING the element
  * (`createNodeFromYElement`, dist/y-prosemirror.cjs:878-885), so a doc holding
  * one can only ever serialize to markdown that is missing it. Callers use this
  * to refuse the write rather than persist the loss.
  *
- * It does NOT answer "will this node survive serialization" — the converse of
- * the sentence above does not hold, and reading it as though it does is what
- * #1455 is about. A node this build can construct can still be dropped on the
- * way to markdown; the case that does it is a spec registered under a key that
- * is not its `config.type`. ProseMirror builds the node (its name comes from
+ * It does NOT answer "will this node survive serialization", and reading it as
+ * though it does is what #1455 is about. A node this build can construct can
+ * still be dropped on the way to markdown, in more than one way.
+ *
+ * It is also narrower than y-prosemirror's own test: this asks whether the NAME
+ * is registered, while `schema.node(name, attrs, children)` additionally throws
+ * on invalid content and on a required attribute with no default. Measured: a
+ * childless `tableRow` is a registered name, so nothing is reported here, and
+ * `yDocToMarkdown` returns `''` for the whole document.
+ *
+ * One case worth naming, because it is the one this guard reads as safe: a spec
+ * registered under a key that is not its `config.type`. ProseMirror builds the node (its name comes from
  * `config.type`, so nothing is reported here and the write is allowed) while
  * BlockNote's own schema — keyed by the registration key — cannot resolve it
  * and drops it. Measured: `See [[Wiki Link]] for details.` → `See for

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -229,6 +229,13 @@ document to its vault `.md` file and re-indexes it for search.
   exactly as it is and the pass reports `writeback_unrepresentable_node` rather than
   writing a version with that content missing. The note resumes normal write-back as soon
   as the document no longer holds such a node; the refusal does not latch.
+- **Constructible is not the same as serializable** — the scan above answers "can this
+  build construct this node name", which is exactly the question the converter's delete
+  depends on. It is not "will this node survive serialization". A node whose spec is
+  registered under a key that is not its `config.type` builds fine and serializes to
+  nothing, and the scan cannot see it. That invariant is enforced where it can be, at
+  schema construction in `@memry/editor-schema`: a mis-keyed spec fails the schema build
+  in both processes instead of quietly dropping content on the next write-back.
 
 While a write-back is queued or mid-write the `.md` file is knowingly behind the Y.Doc, so
 markdown-as-truth readers (task checkbox reconciliation) stand down for that window. Search

--- a/packages/editor-schema/src/blocks/server-specs.ts
+++ b/packages/editor-schema/src/blocks/server-specs.ts
@@ -35,6 +35,7 @@ import {
   youtubeEmbedConfig
 } from './configs'
 import { fileBlockCommentData, type FileBlockProps } from './markdown'
+import { assertSpecKeysMatchNodeTypes } from '../spec-keys'
 
 /**
  * A block whose markdown is a plain `![alt](url)` embed. A real `<img>` is what
@@ -118,8 +119,13 @@ function taskBlockDom(block: { props: unknown }): { dom: HTMLElement } {
   return { dom }
 }
 
+/**
+ * The keys below are what BlockNote keys its `blockSchema` by; each spec's
+ * `config.type` is what ProseMirror builds. Asserted equal rather than assumed
+ * — see spec-keys.ts (#1455).
+ */
 export function createServerBlockSpecs() {
-  return {
+  const registered = {
     taskBlock: createBlockSpec(taskBlockConfig, {
       render: taskBlockDom,
       toExternalHTML: taskBlockDom
@@ -141,4 +147,6 @@ export function createServerBlockSpecs() {
       toExternalHTML: bookmarkDom
     })()
   }
+  assertSpecKeysMatchNodeTypes('blockSpecs', registered)
+  return registered
 }

--- a/packages/editor-schema/src/blocks/server-specs.ts
+++ b/packages/editor-schema/src/blocks/server-specs.ts
@@ -147,6 +147,6 @@ export function createServerBlockSpecs() {
       toExternalHTML: bookmarkDom
     })()
   }
-  assertSpecKeysMatchNodeTypes('blockSpecs', registered)
+  assertSpecKeysMatchNodeTypes('blockSpecs (createServerBlockSpecs)', registered)
   return registered
 }

--- a/packages/editor-schema/src/inline/index.ts
+++ b/packages/editor-schema/src/inline/index.ts
@@ -55,7 +55,7 @@ export function createMemryInlineContentSpecs(specs: MemryInlineSpecs) {
     hashTag: specs.hashTag,
     dateMention: specs.dateMention
   }
-  assertSpecKeysMatchNodeTypes('inlineContentSpecs', registered)
+  assertSpecKeysMatchNodeTypes('inlineContentSpecs (createMemryInlineContentSpecs)', registered)
   return registered
 }
 

--- a/packages/editor-schema/src/inline/index.ts
+++ b/packages/editor-schema/src/inline/index.ts
@@ -1,4 +1,5 @@
 import type { InlineContentSpec } from '@blocknote/core'
+import { assertSpecKeysMatchNodeTypes } from '../spec-keys'
 import { linkMentionConfig } from './link-mention'
 import { wikiLinkConfig } from './wiki-link'
 import { hashTagConfig } from './hash-tag'
@@ -42,14 +43,20 @@ export interface MemryInlineSpecs {
  * Every custom inline node type Memry can put in a document, ready to spread
  * into `BlockNoteSchema.create`. Both processes build from this one list, so a
  * spec cannot exist on one side only.
+ *
+ * The keys below are the node names BlockNote will key its `inlineContentSchema`
+ * by; each spec's `config.type` is the node name ProseMirror will build. They
+ * are asserted equal here rather than assumed — see spec-keys.ts (#1455).
  */
 export function createMemryInlineContentSpecs(specs: MemryInlineSpecs) {
-  return {
+  const registered = {
     wikiLink: specs.wikiLink,
     linkMention: specs.linkMention,
     hashTag: specs.hashTag,
     dateMention: specs.dateMention
   }
+  assertSpecKeysMatchNodeTypes('inlineContentSpecs', registered)
+  return registered
 }
 
 /** Node names of every custom inline spec — the parity gate reads this. */

--- a/packages/editor-schema/src/schema-contract.test.ts
+++ b/packages/editor-schema/src/schema-contract.test.ts
@@ -40,7 +40,8 @@ import {
   dateMentionConfig,
   hashTagConfig,
   linkMentionConfig,
-  wikiLinkConfig
+  wikiLinkConfig,
+  type MemryInlineSpecs
 } from './inline'
 import {
   MEMRY_BLOCK_TYPES,
@@ -329,5 +330,105 @@ describe('every server implementation emits exactly what it serializes', () => {
 
     // #when / #then
     expect(() => impl.render({ type, props }, null)).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Gate 4 — every spec is registered under its own node name (#1455)
+// ---------------------------------------------------------------------------
+
+/**
+ * The registration key and `config.type` are two different names for the same
+ * node, and BlockNote does not make them agree. When they diverge, every guard
+ * in this epic reads healthy and the content is lost anyway: ProseMirror builds
+ * `config.type`, so y-prosemirror keeps the element and
+ * `findUnrepresentableNodes` returns `[]`, while BlockNote — whose
+ * `inlineContentSchema`/`blockSchema` is keyed by the REGISTRATION key — cannot
+ * resolve the node when serializing and drops it. Measured on a schema keyed
+ * `wikiLinkRenamed`: `See [[Wiki Link]] for details.` → `See for details.`
+ *
+ * Gates 1-3 above compare names, propSchemas and behaviour of the specs; this
+ * one compares each spec's name to the slot it was put in.
+ */
+describe('every spec is registered under its own node type', () => {
+  /** `config.type` for a spec object; the string itself for `text` / `link`. */
+  function nodeTypeOf(config: unknown): unknown {
+    return typeof config === 'string' ? config : (config as { type?: unknown }).type
+  }
+
+  it.each(MEMRY_BLOCK_TYPES)('the %s block spec is keyed by its config.type', (type) => {
+    // #given / #when / #then derived from the exported list, so a spec added
+    // under a mismatched key is covered without anyone remembering to add a case
+    expect(serverBlockSpecs()[type].config.type).toBe(type)
+  })
+
+  it.each(MEMRY_INLINE_CONTENT_TYPES)('the %s inline spec is keyed by its config.type', (type) => {
+    expect(serverInlineSpecs()[type].config.type).toBe(type)
+  })
+
+  it('every key in the assembled blockSchema is that block’s own type', () => {
+    // #given the WHOLE assembled map, BlockNote's defaults and the factory's
+    // syntax-highlighting `codeBlock` included — not just Memry's five
+    const schema = serverSchema().blockSchema as Record<string, unknown>
+
+    // #when / #then
+    for (const [key, config] of Object.entries(schema)) {
+      expect(nodeTypeOf(config)).toBe(key)
+    }
+  })
+
+  it('every key in the assembled inlineContentSchema is that node’s own type', () => {
+    // #given `text` and `link` are bare strings here rather than configs, and
+    // the string IS the node name — so they are checked, not skipped
+    const schema = serverSchema().inlineContentSchema as unknown as Record<string, unknown>
+
+    // #when / #then
+    for (const [key, config] of Object.entries(schema)) {
+      expect(nodeTypeOf(config)).toBe(key)
+    }
+  })
+
+  it('refuses a block spec registered under another name', () => {
+    // #given the issue's exact shape: a real spec put in the wrong slot. This is
+    // reachable for blocks because `createMemrySchema` takes them free-form —
+    // the renderer's React blocks reach no factory in this package. The cast is
+    // what a real mistake needs now: the parameter's mapped type maps a
+    // mis-keyed entry to `never`, so this is a compile error without it.
+    const blocks = createServerBlockSpecs()
+    const misKeyed = {
+      ...blocks,
+      bookmarkRenamed: blocks.bookmark
+    } as unknown as ReturnType<typeof createServerBlockSpecs>
+
+    // #when / #then the schema build fails, naming the slot and the node name
+    expect(() =>
+      createMemrySchema({ blocks: misKeyed, inline: createServerInlineSpecs() })
+    ).toThrowError(/blockSpecs\["bookmarkRenamed"\].*config\.type is "bookmark"/s)
+  })
+
+  it('refuses an inline spec registered under another name', () => {
+    // #given the same divergence on the inline half: the wikiLink slot holding a
+    // spec that builds some other node. `createMemryInlineContentSpecs` writes
+    // the four keys itself, so this is the only direction a mis-key can take
+    // here — and it is the one that made y-prosemirror delete the element.
+    const inline = createServerInlineSpecs()
+    const renamed = {
+      ...inline.wikiLink,
+      config: { ...inline.wikiLink.config, type: 'wikiLinkRenamed' }
+    } as unknown as MemryInlineSpecs['wikiLink']
+
+    // #when / #then it throws at the factory, before any schema exists
+    expect(() => createMemryInlineContentSpecs({ ...inline, wikiLink: renamed })).toThrowError(
+      /inlineContentSpecs\["wikiLink"\].*config\.type is "wikiLinkRenamed"/s
+    )
+  })
+
+  it('builds the shipped schema without throwing', () => {
+    // #given both processes call `createMemrySchema` at MODULE SCOPE, so this
+    // assertion firing on a shipped spec is a launch failure, not a test failure
+    // #when / #then
+    expect(() => serverSchema()).not.toThrow()
+    expect(() => createServerBlockSpecs()).not.toThrow()
+    expect(() => createMemryInlineContentSpecs(createServerInlineSpecs())).not.toThrow()
   })
 })

--- a/packages/editor-schema/src/schema-contract.test.ts
+++ b/packages/editor-schema/src/schema-contract.test.ts
@@ -403,7 +403,7 @@ describe('every spec is registered under its own node type', () => {
     // #when / #then the schema build fails, naming the slot and the node name
     expect(() =>
       createMemrySchema({ blocks: misKeyed, inline: createServerInlineSpecs() })
-    ).toThrowError(/blockSpecs\["bookmarkRenamed"\].*config\.type is "bookmark"/s)
+    ).toThrowError(/blockSpecs.*\["bookmarkRenamed"\].*config\.type is "bookmark"/s)
   })
 
   it('refuses an inline spec registered under another name', () => {
@@ -419,7 +419,7 @@ describe('every spec is registered under its own node type', () => {
 
     // #when / #then it throws at the factory, before any schema exists
     expect(() => createMemryInlineContentSpecs({ ...inline, wikiLink: renamed })).toThrowError(
-      /inlineContentSpecs\["wikiLink"\].*config\.type is "wikiLinkRenamed"/s
+      /inlineContentSpecs.*\["wikiLink"\].*config\.type is "wikiLinkRenamed"/s
     )
   })
 

--- a/packages/editor-schema/src/schema.ts
+++ b/packages/editor-schema/src/schema.ts
@@ -7,6 +7,7 @@ import {
 } from '@blocknote/core'
 import { codeBlockOptions } from '@blocknote/code-block'
 import { createMemryInlineContentSpecs, type MemryInlineSpecs } from './inline'
+import { assertSpecKeysMatchNodeTypes, type SpecKeysMatchNodeTypes } from './spec-keys'
 
 /**
  * The one place a Memry BlockNote schema is built.
@@ -19,20 +20,32 @@ import { createMemryInlineContentSpecs, type MemryInlineSpecs } from './inline'
  *
  * Callers pass presentation only. `blocks` is generic so the renderer keeps the
  * precise schema type its typed block helpers depend on.
+ *
+ * It is also the last place both processes' FULL spec maps exist — the
+ * renderer's React blocks reach no factory in this package — so it is where
+ * `key ≡ config.type` is checked for blocks and inline content alike (#1455).
+ * The factories check their own maps as well, to name the one that is wrong;
+ * this is the check nothing can route around.
  */
 export function createMemrySchema<Blocks extends BlockSpecs>(impl: {
-  blocks: Blocks
+  blocks: Blocks & SpecKeysMatchNodeTypes<Blocks>
   inline: MemryInlineSpecs
 }) {
-  return BlockNoteSchema.create({
-    blockSpecs: {
-      ...defaultBlockSpecs,
-      codeBlock: createCodeBlockSpec(codeBlockOptions),
-      ...impl.blocks
-    },
-    inlineContentSpecs: {
-      ...defaultInlineContentSpecs,
-      ...createMemryInlineContentSpecs(impl.inline)
-    }
-  })
+  const blockSpecs = {
+    ...defaultBlockSpecs,
+    codeBlock: createCodeBlockSpec(codeBlockOptions),
+    ...impl.blocks
+  }
+  const inlineContentSpecs = {
+    ...defaultInlineContentSpecs,
+    ...createMemryInlineContentSpecs(impl.inline)
+  }
+
+  // Once, at construction. Both processes call this at module scope, so a
+  // mis-keyed spec is a failed schema build — not a note that quietly loses a
+  // wiki link on its next write-back.
+  assertSpecKeysMatchNodeTypes('blockSpecs', blockSpecs)
+  assertSpecKeysMatchNodeTypes('inlineContentSpecs', inlineContentSpecs)
+
+  return BlockNoteSchema.create({ blockSpecs, inlineContentSpecs })
 }

--- a/packages/editor-schema/src/schema.ts
+++ b/packages/editor-schema/src/schema.ts
@@ -36,16 +36,20 @@ export function createMemrySchema<Blocks extends BlockSpecs>(impl: {
     codeBlock: createCodeBlockSpec(codeBlockOptions),
     ...impl.blocks
   }
-  const inlineContentSpecs = {
-    ...defaultInlineContentSpecs,
-    ...createMemryInlineContentSpecs(impl.inline)
-  }
+  const memryInlineSpecs = createMemryInlineContentSpecs(impl.inline)
+  const inlineContentSpecs = { ...defaultInlineContentSpecs, ...memryInlineSpecs }
 
   // Once, at construction. Both processes call this at module scope, so a
   // mis-keyed spec is a failed schema build — not a note that quietly loses a
   // wiki link on its next write-back.
-  assertSpecKeysMatchNodeTypes('blockSpecs', blockSpecs)
-  assertSpecKeysMatchNodeTypes('inlineContentSpecs', inlineContentSpecs)
+  //
+  // Deliberately over what WE supply, not over the merged maps. Memry cannot
+  // mis-key BlockNote's own defaults, so asserting them buys nothing — but it
+  // would turn a future BlockNote minor that ships an aliased default into an
+  // app that does not launch, in both processes, at module scope. Same
+  // protection, none of that exposure.
+  assertSpecKeysMatchNodeTypes('blockSpecs', impl.blocks)
+  assertSpecKeysMatchNodeTypes('inlineContentSpecs', memryInlineSpecs)
 
   return BlockNoteSchema.create({ blockSpecs, inlineContentSpecs })
 }

--- a/packages/editor-schema/src/spec-keys.ts
+++ b/packages/editor-schema/src/spec-keys.ts
@@ -60,6 +60,9 @@ function nodeTypeOf(spec: unknown): string | null {
 export function assertSpecKeysMatchNodeTypes(mapName: string, specs: SpecMap): void {
   for (const key of Object.keys(specs)) {
     const nodeType = nodeTypeOf(specs[key])
+    // Compared exactly, case included: `wikilink` under `wikiLink` is the
+    // likeliest real typo and is exactly the one a lenient compare would wave
+    // through.
     if (nodeType === null || nodeType === key) continue
 
     throw new Error(
@@ -81,18 +84,24 @@ export function assertSpecKeysMatchNodeTypes(mapName: string, specs: SpecMap): v
  * Intersecting the parameter with this maps a mis-keyed entry to `never`, which
  * makes the whole argument unassignable at the call site.
  *
- * It is a partial carry on purpose. A spec whose `config.type` is widened to
- * `string` — a shape BlockNote's own `BlockSpecs` allows — cannot be checked
- * here, so it falls through to the runtime assertion; that is why the runtime
- * assertion is the backstop and not the other way round. The inline half needs
- * none of this: `MemryInlineSpecs` names each spec's config by hand
- * (`InlineContentSpec<typeof wikiLinkConfig>`), which already binds key to
- * config.
+ * It is a partial carry on purpose, and the fall-through is explicit. A spec
+ * whose `config.type` is widened to `string` — a shape BlockNote's own
+ * `BlockSpecs` allows, and what you get from a config written without
+ * `as const` — carries no literal to compare, so it is passed through to the
+ * runtime assertion rather than rejected here. Without that branch, correct
+ * code fails to compile with `not assignable to type 'never'` and no
+ * explanation, which is a worse trade than the check is worth.
+ *
+ * The inline half needs none of this: `MemryInlineSpecs` names each spec's
+ * config by hand (`InlineContentSpec<typeof wikiLinkConfig>`), which already
+ * binds key to config.
  */
 export type SpecKeysMatchNodeTypes<Specs> = {
   [Key in keyof Specs]: Specs[Key] extends { config: { type: infer NodeType } }
     ? [NodeType] extends [Key]
       ? Specs[Key]
-      : never
+      : string extends NodeType
+        ? Specs[Key]
+        : never
     : Specs[Key]
 }

--- a/packages/editor-schema/src/spec-keys.ts
+++ b/packages/editor-schema/src/spec-keys.ts
@@ -1,0 +1,98 @@
+/**
+ * Registration key ≡ `config.type` (#1455).
+ *
+ * A BlockNote spec's ProseMirror node name is its `config.type`. The key it is
+ * registered under is what BlockNote's own `blockSchema` / `inlineContentSchema`
+ * ends up keyed by. Nothing in BlockNote forces the two to agree, and when they
+ * disagree the failure is silent content loss that every guard we have reads as
+ * healthy:
+ *
+ *   - ProseMirror CAN build `config.type`, so y-prosemirror does not delete the
+ *     element out of the shared Y.Doc — the loud failure never happens
+ *   - `findUnrepresentableNodes` asks the ProseMirror schema, finds the name,
+ *     and returns `[]`, so the fail-closed write guard lets the write through
+ *   - BlockNote cannot resolve the node against a schema keyed by the OTHER
+ *     name, so it drops it while serializing
+ *
+ * Measured on the mis-keyed schema in the issue: `See [[Wiki Link]] for
+ * details.` came back `See for details.` — 30 bytes to 16, written to the vault
+ * with no error raised anywhere.
+ *
+ * So the invariant is made structural rather than gated: it is asserted once,
+ * at construction, in every place this package assembles a spec map. That is
+ * module scope in both processes, and never a serialization path — a mis-keyed
+ * spec fails the schema build (and therefore every suite that builds one)
+ * instead of quietly deleting text from someone's notes.
+ */
+
+/** A spec map as BlockNote takes it: registration key → spec. */
+type SpecMap = Record<string, unknown>
+
+/**
+ * The ProseMirror node name a spec registers, or `null` when the value is not a
+ * shape this package recognises.
+ *
+ * Two shapes are recognised, because BlockNote ships both: a spec object whose
+ * `config.type` is the node name, and a bare string config — that is what
+ * `defaultInlineContentSpecs` holds for `text` and `link`, and there the string
+ * IS the node name, so those pass the check rather than skipping it.
+ *
+ * `null` deliberately does not throw. A dependency growing a third spec shape
+ * must not stop the app from building a schema whose own specs are all correct;
+ * every spec Memry ships is checked by name in the contract suite as well.
+ */
+function nodeTypeOf(spec: unknown): string | null {
+  const config = (spec as { config?: unknown } | null | undefined)?.config
+  if (typeof config === 'string') return config
+  if (typeof config === 'object' && config !== null) {
+    const { type } = config as { type?: unknown }
+    if (typeof type === 'string') return type
+  }
+  return null
+}
+
+/**
+ * Throws unless every spec in `specs` is registered under its own node name.
+ *
+ * `mapName` is the BlockNote option the map feeds (`blockSpecs` /
+ * `inlineContentSpecs`) so the message points at something greppable.
+ */
+export function assertSpecKeysMatchNodeTypes(mapName: string, specs: SpecMap): void {
+  for (const key of Object.keys(specs)) {
+    const nodeType = nodeTypeOf(specs[key])
+    if (nodeType === null || nodeType === key) continue
+
+    throw new Error(
+      `@memry/editor-schema: ${mapName}["${key}"] registers a spec whose config.type is "${nodeType}". ` +
+        "A BlockNote spec's ProseMirror node name comes from config.type, not from the key it is " +
+        `registered under, so this spec builds "${nodeType}" nodes that a schema keyed "${key}" cannot ` +
+        'resolve when serializing: the node is dropped from the vault file, and findUnrepresentableNodes ' +
+        'cannot see it because ProseMirror can still build the name (#1455). ' +
+        `Register it as "${nodeType}", or set config.type to "${key}".`
+    )
+  }
+}
+
+/**
+ * The same invariant in the type system, for the one map that is generic.
+ *
+ * `createMemrySchema` takes the renderer's block specs as a free-form
+ * `BlockSpecs`, so a block registered under the wrong key type-checks today.
+ * Intersecting the parameter with this maps a mis-keyed entry to `never`, which
+ * makes the whole argument unassignable at the call site.
+ *
+ * It is a partial carry on purpose. A spec whose `config.type` is widened to
+ * `string` — a shape BlockNote's own `BlockSpecs` allows — cannot be checked
+ * here, so it falls through to the runtime assertion; that is why the runtime
+ * assertion is the backstop and not the other way round. The inline half needs
+ * none of this: `MemryInlineSpecs` names each spec's config by hand
+ * (`InlineContentSpec<typeof wikiLinkConfig>`), which already binds key to
+ * config.
+ */
+export type SpecKeysMatchNodeTypes<Specs> = {
+  [Key in keyof Specs]: Specs[Key] extends { config: { type: infer NodeType } }
+    ? [NodeType] extends [Key]
+      ? Specs[Key]
+      : never
+    : Specs[Key]
+}


### PR DESCRIPTION
Closes #1455 with option 2 — make the invariant structural instead of gated.

## The gap

A BlockNote spec's ProseMirror node name comes from `spec.config.type`, **not** from the key it is registered under:

```
BlockNoteSchema.create({ inlineContentSpecs: { …defaults, wikiLinkRenamed: WikiLinkSerializationOnly } })

pm has wikiLink        : true
pm has wikiLinkRenamed : false
schema map keys        : text,link,wikiLinkRenamed
```

So with the two out of step, ProseMirror builds the node (y-prosemirror does not delete it, `findUnrepresentableNodes` returns `[]`, the write is allowed) while BlockNote's own schema — keyed by the registration key — cannot resolve it and drops it. Measured: `See [[Wiki Link]] for details.` → `See for details.`, guard silent, and BlockNote logs `unrecognized inline content type wikiLink` to stderr and returns normally.

Not live today — #1433's parity gate catches mis-keying — so this is defence in depth, and a docstring that promised more than it delivered.

## The fix

`assertSpecKeysMatchNodeTypes` throws at construction, plus a `SpecKeysMatchNodeTypes<Specs>` mapped type that catches the same mistake at compile time. A mis-keyed spec now fails the schema build instead of losing content at runtime, with a message naming the map, the key, the `config.type` and both fixes.

## Review findings, all addressed

**The mapped type was stricter than its own docstring.** A config written without `as const` widens `config.type` to `string`, and `[string] extends ['widget']` is false — so runtime-**correct** code failed to compile with `not assignable to type 'never'` and no explanation. The widened case now falls through to the runtime assertion, which is what the docstring always claimed. Verified: that exact shape compiles again.

**The assertion policed BlockNote's own defaults.** It ran over the merged maps, so it covered all 14 default block specs. Memry cannot mis-key those, so it bought nothing — but a future BlockNote minor shipping an aliased default (`orderedListItem: createNumberedListItemBlockSpec()`) would have thrown **at module scope in both processes**, i.e. an app that does not launch. It now asserts only what we supply. Same protection, none of the exposure.

**Both factory call sites passed the same `mapName`,** so the thrown message could not say which fired. They name themselves now.

**The `findUnrepresentableNodes` docstring still overclaimed** — it said constructibility is "the exact question" y-prosemirror asks. It is narrower: this checks whether the **name** is registered, while `schema.node(name, attrs, children)` also throws on invalid content and on a required attribute with no default. Measured on the shipped schema: a childless `tableRow` is a registered name, so nothing is reported and `yDocToMarkdown` returns `''` for the **whole document**. Corrected, with the measurement in the docstring. Since write-back handles `null` but not `''`, that hole is filed as **#1475**.

Worth noting for the record: the docstring is the last line of defence for this epic's bug class, and an overclaiming docstring is what created #1455 in the first place. Fixing one by writing another would have been a poor trade.

## Verification

- `@memry/editor-schema` — 55 tests · typecheck (src + test projects)
- `test:main` — 513 files / 6547 tests
- `test:renderer` — 611 files / 7050 tests
- `typecheck` 17/17 · `check:architecture` · `check:contracts` · eslint 0
- `docs:impact --strict` (no `MEMRY_DOCS_IMPACT_SKIP`) · `docs:build`

Mutation-tested: neutering the assertion fails 3 tests; a case-insensitive compare used to slip through entirely and is now called out at the comparison itself. No spec in the repo is mis-keyed — all 14 BlockNote defaults, `codeBlock`, Memry's 5 blocks and 4 inline specs, and `text`/`link` verified by execution, not by reading.

## Known limits

- Style specs are outside the guard: `createMemrySchema` passes no `styleSpecs`, so `defaultStyleSpecs` is never asserted. No live risk (Memry ships no custom styles).
- The inline runtime assertion is close to dead code — `MemryInlineSpecs` already binds each key to a named config, so no type-checked caller can reach it. Kept because its live inputs are BlockNote's `text`/`link`.
