### PR TITLE
perf(notes): calibrate the note-class thresholds against a parse budget (#1463)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -81,6 +81,7 @@
     "test:coverage": "pnpm exec vitest run --coverage --config config/vitest.config.ts",
     "test:shared": "pnpm exec vitest run --config config/vitest.config.ts --project shared",
     "test:main": "pnpm exec vitest run --config config/vitest.config.ts --project main",
+    "measure:parse-budget": "MEMRY_PARSE_BUDGET=1 pnpm exec vitest run --config config/vitest.config.ts --project main src/main/sync/markdown-parse-budget.test.ts",
     "test:main-integration": "pnpm exec vitest run --config config/vitest.config.ts --project main-integration",
     "test:renderer": "pnpm exec vitest run --config config/vitest.config.ts --project renderer",
     "test:unit": "pnpm exec vitest run --config config/vitest.config.ts tests/unit",

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -1214,9 +1214,9 @@ describe('CrdtProvider', () => {
     expect(mocks.markdownToYFragment).not.toHaveBeenCalled()
   })
 
-  it('still seeds a well-formed 1.8 MB note, which parses fine', async () => {
+  it('still seeds a well-formed 800 KB note, which parses fine', async () => {
     // #given the measured good case: big, but many blank-line-separated blocks
-    const body = Array.from({ length: 450 }, () => 'x'.repeat(4000)).join('\n\n')
+    const body = Array.from({ length: 200 }, () => 'x'.repeat(4000)).join('\n\n')
     await provider.open('big-but-fine', undefined, { skipSeed: true })
     mocks.getNoteCacheById.mockReturnValueOnce({
       id: 'big-but-fine',

--- a/apps/desktop/src/main/sync/markdown-parse-budget.test.ts
+++ b/apps/desktop/src/main/sync/markdown-parse-budget.test.ts
@@ -22,7 +22,12 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { classifyMarkdownContent, largestBlockByteLength } from '@memry/shared/markdown-class'
+import {
+  NOTE_MAX_BLOCK_BYTES,
+  NOTE_MAX_BYTES,
+  classifyMarkdownContent,
+  largestBlockByteLength
+} from '@memry/shared/markdown-class'
 import { markdownToBlocks } from './blocknote-converter'
 
 const ENABLED = process.env.MEMRY_PARSE_BUDGET === '1'
@@ -352,13 +357,17 @@ describe.skipIf(!ENABLED)('markdown parse budget (#1463)', () => {
       shapes.push(await timeParse('structured doc (2 MB)', structured(2 * MB), 1))
       shapes.push(await timeParse('obsidian vault note (2 MB)', obsidianVault(2 * MB), 1))
 
-      // -- Worst case admitted by a candidate pair of thresholds -------------
+      // -- Worst case the shipped bounds admit -------------------------------
+      // A file sitting on both bounds at once: NOTE_MAX_BYTES of content made
+      // entirely of NOTE_MAX_BLOCK_BYTES blocks. Sized one block short so the
+      // separators do not push it over the byte ceiling and change its class.
+      const worstBlocks = Math.floor(NOTE_MAX_BYTES / NOTE_MAX_BLOCK_BYTES) - 1
       const worst: Sample[] = []
       for (const { name, shape } of shapeSweeps) {
         worst.push(
           await timeParse(
-            `${name}: 2 MB as 16 x 128 KB blocks (current bounds)`,
-            blocksOf(shape, 2 * MB, 128 * KB),
+            `${name}: ${worstBlocks} x ${NOTE_MAX_BLOCK_BYTES / KB} KB blocks`,
+            blocksOf(shape, worstBlocks * NOTE_MAX_BLOCK_BYTES, NOTE_MAX_BLOCK_BYTES),
             1
           )
         )
@@ -393,17 +402,22 @@ describe.skipIf(!ENABLED)('markdown parse budget (#1463)', () => {
       for (const s of shapes) write(row(s))
 
       write('')
-      write('## Worst case admitted by the shipped 2 MB / 128 KB bounds')
+      write('## Worst case the shipped bounds admit (both bounds at once)')
       write(HEADER)
       for (const s of worst) write(row(s))
 
       write('')
-      write('## Predicted worst-case cost of candidate bounds (worst shape)')
+      write('## Additive LOWER BOUND for candidate bounds (worst shape)')
+      write('')
+      write('Read this as a floor, not an estimate. It assumes a file of N blocks')
+      write('costs N x one block, which the additivity table above disproves for')
+      write('tables (5x) and outlines (1.8x). Compare it against the measured')
+      write('worst-case row, not instead of it.')
       const worstShape = blockSweeps.reduce((acc, s) =>
         s.k * 128 ** s.p > acc.k * 128 ** acc.p ? s : acc
       )
       write(`worst shape by fit at 128 KB: ${worstShape.name}`)
-      write('| maxFileBytes | maxBlockBytes | blocks | predicted ms |')
+      write('| maxFileBytes | maxBlockBytes | blocks | lower-bound ms |')
       write('| --- | --- | --- | --- |')
       for (const fileMB of [1, 2, 4]) {
         for (const blockKB of [8, 16, 32, 64, 128]) {

--- a/apps/desktop/src/main/sync/markdown-parse-budget.test.ts
+++ b/apps/desktop/src/main/sync/markdown-parse-budget.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Opt-in parse-budget measurement behind the note-class thresholds (#1463).
+ *
+ * NOT part of `pnpm test`: the whole suite is skipped unless
+ * `MEMRY_PARSE_BUDGET=1`, so the default run collects one skipped file and pays
+ * nothing. Re-run it with:
+ *
+ *   pnpm --filter @memry/desktop measure:parse-budget
+ *
+ * It measures `markdownToBlocks` — the real seeding entry point, the one
+ * `CrdtDocStore.seedFromMarkdown` calls — end to end: the embed rewrite, the
+ * colour masking, the blank-line split and `tryParseMarkdownToBlocks`, not the
+ * parser in isolation.
+ *
+ * The corpus is generated here rather than committed: it is megabytes of
+ * synthetic markdown, and the shapes matter more than the exact bytes. Every
+ * generator is deterministic (fixed-seed PRNG) so two runs on the same machine
+ * are comparable.
+ *
+ * Results, budget and derivation live in
+ * docs/superpowers/specs/2026-08-15-note-class-threshold-calibration.md.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { classifyMarkdownContent, largestBlockByteLength } from '@memry/shared/markdown-class'
+import { markdownToBlocks } from './blocknote-converter'
+
+const ENABLED = process.env.MEMRY_PARSE_BUDGET === '1'
+
+const KB = 1024
+const MB = 1024 * 1024
+
+// Generous: the pathological shapes are measured deliberately far past the
+// thresholds, and one of them takes tens of seconds on purpose.
+const MEASURE_TIMEOUT_MS = 900_000
+
+function write(line: string): void {
+  process.stdout.write(`${line}\n`)
+}
+
+// ---------------------------------------------------------------------------
+// Corpus generation
+// ---------------------------------------------------------------------------
+
+/** mulberry32 — deterministic, so a re-run measures the same bytes. */
+function makeRandom(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const WORDS =
+  'note vault sync editor block parse budget markdown corpus threshold latency device journal task project index search render main renderer memory ingest'.split(
+    ' '
+  )
+
+function makeWords(rand: () => number, count: number): string {
+  const out: string[] = []
+  for (let i = 0; i < count; i++) out.push(WORDS[Math.floor(rand() * WORDS.length)])
+  return out.join(' ')
+}
+
+/** Repeat `next()` until the joined text reaches `bytes`, then trim to size. */
+function fill(bytes: number, sep: string, next: () => string): string {
+  const parts: string[] = []
+  let size = 0
+  while (size < bytes) {
+    const part = next()
+    parts.push(part)
+    size += part.length + sep.length
+  }
+  return parts.join(sep).slice(0, bytes)
+}
+
+/**
+ * The shapes worth measuring, each as a generator for ONE blank-line-separated
+ * block of a requested size. `blocksOf` then tiles a block into a whole file, so
+ * per-block cost and whole-file cost are measured with the same bytes.
+ */
+type BlockShape = (bytes: number, seed: number) => string
+
+/** Ordinary prose: words and spaces, one paragraph. */
+const paragraph: BlockShape = (bytes, seed) =>
+  makeWords(makeRandom(seed), Math.ceil(bytes / 6)).slice(0, bytes)
+
+/** Log dump: timestamped lines, no blank line anywhere — the #1468 file. */
+const logDump: BlockShape = (bytes, seed) => {
+  const rand = makeRandom(seed)
+  let n = 0
+  return fill(bytes, '\n', () => {
+    n++
+    return `2026-08-15 09:${String(n % 60).padStart(2, '0')}:12.${String(n % 1000).padStart(3, '0')} [info] [Sync] ${makeWords(rand, 10)} id=${n}`
+  })
+}
+
+/**
+ * Roam/Bear export shape: a tight, nested bullet list with no blank lines, so
+ * a whole page reads as one block. `convertBlocks` in packages/importers/src/roam
+ * joins with `\n`, which is exactly this.
+ */
+const tightOutline: BlockShape = (bytes, seed) => {
+  const rand = makeRandom(seed)
+  let n = 0
+  return fill(bytes, '\n', () => {
+    n++
+    return `${'  '.repeat(n % 4)}- ${makeWords(rand, 10)}`
+  })
+}
+
+/** A markdown table: one block, many rows. */
+const table: BlockShape = (bytes, seed) => {
+  const rand = makeRandom(seed)
+  const head = '| a | b | c |\n| --- | --- | --- |\n'
+  return (
+    head +
+    fill(
+      Math.max(bytes - head.length, 0),
+      '\n',
+      () => `| ${makeWords(rand, 3)} | ${makeWords(rand, 3)} | ${Math.floor(rand() * 1e6)} |`
+    )
+  )
+}
+
+/** Minified JSON: one line, opening `[`, dense punctuation. */
+const minifiedJson: BlockShape = (bytes, seed) => {
+  const rand = makeRandom(seed)
+  const items: string[] = []
+  let size = 2
+  while (size < bytes) {
+    const item = `{"id":${items.length},"name":"${makeWords(rand, 3).replace(/ /g, '-')}","ok":true}`
+    items.push(item)
+    size += item.length + 1
+  }
+  return `[${items.join(',')}]`.slice(0, bytes)
+}
+
+/** Tile one shape into a `fileBytes` file made of `blockBytes` blocks. */
+function blocksOf(shape: BlockShape, fileBytes: number, blockBytes: number): string {
+  const count = Math.max(1, Math.round(fileBytes / blockBytes))
+  return Array.from({ length: count }, (_, i) => shape(blockBytes, 100 + i)).join('\n\n')
+}
+
+/** Well-formed prose: `paragraphBytes` paragraphs, a heading every eighth. */
+function prose(bytes: number, paragraphBytes: number): string {
+  const rand = makeRandom(1)
+  let n = 0
+  return fill(bytes, '\n\n', () => {
+    n++
+    const body = makeWords(rand, Math.ceil(paragraphBytes / 6)).slice(0, paragraphBytes)
+    return n % 8 === 1 ? `## Section ${n}\n\n${body}` : body
+  })
+}
+
+/** Headings, nested lists, tables, code fences, links — a written-up document. */
+function structured(bytes: number): string {
+  const rand = makeRandom(2)
+  let n = 0
+  return fill(bytes, '\n\n', () => {
+    n++
+    switch (n % 5) {
+      case 0:
+        return `### Heading ${n}\n\n${makeWords(rand, 60)}.`
+      case 1:
+        return [
+          `- ${makeWords(rand, 12)}`,
+          `  - ${makeWords(rand, 12)} \`inline code\``,
+          `  - [${makeWords(rand, 3)}](https://example.com/${n})`,
+          `- **${makeWords(rand, 4)}** and *${makeWords(rand, 4)}*`
+        ].join('\n')
+      case 2:
+        return table(400, n)
+      case 3:
+        return [
+          '```ts',
+          ...Array.from(
+            { length: 8 },
+            (_, i) => `const value${i} = ${makeWords(rand, 3).replace(/ /g, '_')}`
+          ),
+          '```'
+        ].join('\n')
+      default:
+        return `${makeWords(rand, 90)}.`
+    }
+  })
+}
+
+/**
+ * Obsidian-shaped vault note: frontmatter, wikilinks, tags, task checkboxes.
+ * Deliberately no `![[embeds]]` — those reach `resolveVaultEmbeds`, whose cost
+ * is a vault-index lookup and not the parse this is measuring.
+ */
+function obsidianVault(bytes: number): string {
+  const rand = makeRandom(3)
+  let n = 0
+  const head = '---\ntitle: Imported note\ntags: [import, vault]\n---\n\n'
+  return (
+    head +
+    fill(Math.max(bytes - head.length, 0), '\n\n', () => {
+      n++
+      switch (n % 4) {
+        case 0:
+          return `## ${makeWords(rand, 4)}\n\n${makeWords(rand, 70)} [[Another Note]] #topic/${n}.`
+        case 1:
+          return [
+            `- [ ] ${makeWords(rand, 8)}`,
+            `- [x] ${makeWords(rand, 8)}`,
+            `- [ ] ${makeWords(rand, 8)} [[Linked Page]]`
+          ].join('\n')
+        case 2:
+          return `> ${makeWords(rand, 30)}\n> ${makeWords(rand, 30)}`
+        default:
+          return `${makeWords(rand, 80)} [[${makeWords(rand, 2)}]].`
+      }
+    })
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Timing
+// ---------------------------------------------------------------------------
+
+interface Sample {
+  name: string
+  fileBytes: number
+  blockBytes: number
+  ms: number
+  blocks: number
+  sizeClass: string
+}
+
+async function timeParse(name: string, markdown: string, reps = 3): Promise<Sample> {
+  const timings: number[] = []
+  let blocks = 0
+  for (let i = 0; i < reps; i++) {
+    const started = performance.now()
+    const parsed = await markdownToBlocks(markdown)
+    timings.push(performance.now() - started)
+    blocks = parsed?.length ?? 0
+  }
+  timings.sort((x, y) => x - y)
+  return {
+    name,
+    fileBytes: Buffer.byteLength(markdown, 'utf8'),
+    blockBytes: largestBlockByteLength(markdown),
+    ms: timings[Math.floor(timings.length / 2)],
+    blocks,
+    sizeClass: classifyMarkdownContent(markdown).sizeClass
+  }
+}
+
+function row(s: Sample): string {
+  return `| ${s.name} | ${(s.fileBytes / MB).toFixed(3)} | ${(s.blockBytes / KB).toFixed(1)} | ${s.blocks} | ${s.ms.toFixed(0)} | ${s.sizeClass} |`
+}
+
+const HEADER = [
+  '| shape | file MB | largest block KB | blocks | median ms | class |',
+  '| --- | --- | --- | --- | --- | --- |'
+].join('\n')
+
+/** Least-squares slope of `ms = a * fileMB` through the origin. */
+function fitLinear(samples: Sample[]): number {
+  let num = 0
+  let den = 0
+  for (const s of samples) {
+    const x = s.fileBytes / MB
+    num += x * s.ms
+    den += x * x
+  }
+  return num / den
+}
+
+/** Log-log fit of `ms = k * (blockKB ^ p)`; returns the exponent and k. */
+function fitPower(samples: Sample[]): { p: number; k: number } {
+  const xs = samples.map((s) => Math.log(s.blockBytes / KB))
+  const ys = samples.map((s) => Math.log(Math.max(s.ms, 0.5)))
+  const n = xs.length
+  const mx = xs.reduce((t, v) => t + v, 0) / n
+  const my = ys.reduce((t, v) => t + v, 0) / n
+  let num = 0
+  let den = 0
+  for (let i = 0; i < n; i++) {
+    num += (xs[i] - mx) * (ys[i] - my)
+    den += (xs[i] - mx) ** 2
+  }
+  const p = num / den
+  return { p, k: Math.exp(my - p * mx) }
+}
+
+// ---------------------------------------------------------------------------
+// The measurement
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!ENABLED)('markdown parse budget (#1463)', () => {
+  it(
+    'measures the corpus and derives both thresholds',
+    async () => {
+      // Warm-up: the first call builds the server editor and its schema, which
+      // would otherwise be charged to the first sample.
+      await markdownToBlocks(prose(32 * KB, 600))
+
+      // -- Sweep A: file size, well-formed prose (small blocks) -------------
+      const fileSweep: Sample[] = []
+      for (const bytes of [64 * KB, 256 * KB, 512 * KB, 1 * MB, 2 * MB, 3 * MB]) {
+        fileSweep.push(
+          await timeParse(`prose ${(bytes / MB).toFixed(3)} MB, 600 B blocks`, prose(bytes, 600))
+        )
+      }
+      const a = fitLinear(fileSweep)
+
+      // -- Sweep B: one block, growing, per shape ---------------------------
+      // Each sample is a single block, so `ms` is the per-block cost g(B).
+      const shapeSweeps: Array<{ name: string; shape: BlockShape; sizes: number[] }> = [
+        { name: 'paragraph', shape: paragraph, sizes: [8, 16, 32, 64, 128, 256, 512] },
+        { name: 'log dump', shape: logDump, sizes: [8, 16, 32, 64, 128, 256, 512] },
+        { name: 'tight outline', shape: tightOutline, sizes: [8, 16, 32, 64, 128, 256, 512] },
+        { name: 'table', shape: table, sizes: [8, 16, 32, 64, 128, 256] },
+        { name: 'minified json', shape: minifiedJson, sizes: [8, 16, 32, 64, 128, 256] }
+      ]
+
+      const blockSweeps: Array<{ name: string; samples: Sample[]; p: number; k: number }> = []
+      for (const { name, shape, sizes } of shapeSweeps) {
+        const samples: Sample[] = []
+        for (const kb of sizes) {
+          samples.push(await timeParse(`${name} ${kb} KB`, shape(kb * KB, 42), kb >= 128 ? 1 : 3))
+        }
+        blockSweeps.push({ name, samples, ...fitPower(samples) })
+      }
+
+      // -- Additivity: does a file of N blocks cost N x one block? -----------
+      const additivity: Sample[] = []
+      for (const { name, shape } of shapeSweeps) {
+        additivity.push(
+          await timeParse(
+            `${name}: 512 KB as 8 x 64 KB blocks`,
+            blocksOf(shape, 512 * KB, 64 * KB),
+            1
+          )
+        )
+      }
+
+      // -- Shape corpus, comparable sizes -----------------------------------
+      const shapes: Sample[] = []
+      shapes.push(await timeParse('small prose note (4 KB)', prose(4 * KB, 600)))
+      shapes.push(await timeParse('long prose (512 KB)', prose(512 * KB, 600)))
+      shapes.push(await timeParse('structured doc (512 KB)', structured(512 * KB)))
+      shapes.push(await timeParse('obsidian vault note (512 KB)', obsidianVault(512 * KB)))
+      shapes.push(await timeParse('structured doc (2 MB)', structured(2 * MB), 1))
+      shapes.push(await timeParse('obsidian vault note (2 MB)', obsidianVault(2 * MB), 1))
+
+      // -- Worst case admitted by a candidate pair of thresholds -------------
+      const worst: Sample[] = []
+      for (const { name, shape } of shapeSweeps) {
+        worst.push(
+          await timeParse(
+            `${name}: 2 MB as 16 x 128 KB blocks (current bounds)`,
+            blocksOf(shape, 2 * MB, 128 * KB),
+            1
+          )
+        )
+      }
+
+      // -- Report -----------------------------------------------------------
+      write('')
+      write('## Sweep A - file size, well-formed prose')
+      write(HEADER)
+      for (const s of fileSweep) write(row(s))
+      write('')
+      write(`fitted linear rate a = ${a.toFixed(0)} ms/MB`)
+
+      for (const sweep of blockSweeps) {
+        write('')
+        write(`## Sweep B - one ${sweep.name} block, growing`)
+        write(HEADER)
+        for (const s of sweep.samples) write(row(s))
+        write(
+          `fit: ms = ${sweep.k.toFixed(3)} * (blockKB ^ ${sweep.p.toFixed(2)})   [exponent 1 = linear, 2 = quadratic]`
+        )
+      }
+
+      write('')
+      write('## Additivity - 512 KB tiled as 8 x 64 KB blocks')
+      write(HEADER)
+      for (const s of additivity) write(row(s))
+
+      write('')
+      write('## Realistic shapes')
+      write(HEADER)
+      for (const s of shapes) write(row(s))
+
+      write('')
+      write('## Worst case admitted by the shipped 2 MB / 128 KB bounds')
+      write(HEADER)
+      for (const s of worst) write(row(s))
+
+      write('')
+      write('## Predicted worst-case cost of candidate bounds (worst shape)')
+      const worstShape = blockSweeps.reduce((acc, s) =>
+        s.k * 128 ** s.p > acc.k * 128 ** acc.p ? s : acc
+      )
+      write(`worst shape by fit at 128 KB: ${worstShape.name}`)
+      write('| maxFileBytes | maxBlockBytes | blocks | predicted ms |')
+      write('| --- | --- | --- | --- |')
+      for (const fileMB of [1, 2, 4]) {
+        for (const blockKB of [8, 16, 32, 64, 128]) {
+          const count = (fileMB * 1024) / blockKB
+          const ms = a * fileMB + count * worstShape.k * blockKB ** worstShape.p
+          write(`| ${fileMB} MB | ${blockKB} KB | ${count} | ${ms.toFixed(0)} |`)
+        }
+      }
+      write('')
+
+      // The measurement is the deliverable; the assertions only guard against a
+      // run that produced nothing usable.
+      expect(fileSweep).toHaveLength(6)
+      expect(a).toBeGreaterThan(0)
+      expect(blockSweeps.every((s) => Number.isFinite(s.p))).toBe(true)
+    },
+    MEASURE_TIMEOUT_MS
+  )
+})

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -207,15 +207,16 @@ and it uses two limits, not one:
 
 | Limit                                                | Value  |
 | ---------------------------------------------------- | ------ |
-| File size                                            | 2 MB   |
+| File size                                            | 1 MB   |
 | Largest run of lines with no blank line between them | 128 KB |
 
-A file has to clear **both** to open as an editable note.
+A file has to clear **both** to open as an editable note. 1 MB is around 150,000 words — several
+novels — so ordinary notes, however long, are nowhere near it.
 
-The second limit is the one that catches log dumps and exported transcripts. The editor's markdown
-parser gets slower than linearly as a single block grows, so shape matters more than total size: the
-same 1.8 MB costs about half a second split into paragraphs and about seven seconds as one
-unbroken block. A file with no blank lines in it is one block, however long it is.
+The second limit is the one that catches log dumps, exported transcripts and pasted data. What
+makes markdown slow to open is how dense one unbroken run of lines is, not how many bytes the file
+has: 128 KB of paragraphs opens in about 50 ms, while 128 KB of table rows or minified JSON takes a
+full second. A file with no blank lines in it is one block, however long it is.
 
 A file that misses either limit still appears in the sidebar. Opening it shows a panel naming its
 size and the limit it passed, marked **read-only · not synced**:

--- a/docs/superpowers/specs/2026-08-15-large-file-ingest-freeze-design.md
+++ b/docs/superpowers/specs/2026-08-15-large-file-ingest-freeze-design.md
@@ -21,11 +21,11 @@ row appears in the sidebar.**
 
 All on the reporter's machine, against the real files.
 
-| stage | 1.9 MB | 17.8 MB |
-|---|---|---|
-| djb2 content hash + every metadata regex | 20 ms | ~200 ms |
-| FTS5 insert, `tokenize='porter unicode61'` | 14 ms | 93 ms (19.5 MB index) |
-| **`tryParseMarkdownToBlocks`** | **6 594 ms** | see below |
+| stage                                      | 1.9 MB       | 17.8 MB               |
+| ------------------------------------------ | ------------ | --------------------- |
+| djb2 content hash + every metadata regex   | 20 ms        | ~200 ms               |
+| FTS5 insert, `tokenize='porter unicode61'` | 14 ms        | 93 ms (19.5 MB index) |
+| **`tryParseMarkdownToBlocks`**             | **6 594 ms** | see below             |
 
 The first two were the initial suspects and both are cleared by measurement.
 
@@ -52,19 +52,19 @@ SQLite MAX_LENGTH    : 2 147 483 645 bytes (~2 GB)
 
 ## Root cause
 
-`handleMarkdownFileAdd` does not separate *listing a note* from *processing its
-body*. Everything the sidebar row needs is `stat` + filename. What actually runs
+`handleMarkdownFileAdd` does not separate _listing a note_ from _processing its
+body_. Everything the sidebar row needs is `stat` + filename. What actually runs
 before the row is shown:
 
-| # | site | work |
-|---|---|---|
-| 1 | `vault/watcher.ts:333` | `safeRead` — whole file into one JS string |
-| 2 | `:339` | `parseNote` / gray-matter |
-| 3 | `:343` | `generateContentHash`, char-by-char djb2 |
-| 4 | `:354` | `syncNoteToCache`; puts full `parsedContent` on the projection event |
-| 5 | `:368` | `flushProjectionEvents` → FTS insert |
-| 6 | `:395` | `syncNoteCreate` → `initForNote` → `open()` → `seedFromMarkdown` → `markdownToYFragment` |
-| 7 | `:399` | `emitEvent(CREATED)` — sidebar row appears |
+| #   | site                   | work                                                                                     |
+| --- | ---------------------- | ---------------------------------------------------------------------------------------- |
+| 1   | `vault/watcher.ts:333` | `safeRead` — whole file into one JS string                                               |
+| 2   | `:339`                 | `parseNote` / gray-matter                                                                |
+| 3   | `:343`                 | `generateContentHash`, char-by-char djb2                                                 |
+| 4   | `:354`                 | `syncNoteToCache`; puts full `parsedContent` on the projection event                     |
+| 5   | `:368`                 | `flushProjectionEvents` → FTS insert                                                     |
+| 6   | `:395`                 | `syncNoteCreate` → `initForNote` → `open()` → `seedFromMarkdown` → `markdownToYFragment` |
+| 7   | `:399`                 | `emitEvent(CREATED)` — sidebar row appears                                               |
 
 Step 6 is called before step 7 but is not awaited: `initForNote` yields at its
 first `await`, `emitEvent` paints the row, the handler returns, and the
@@ -76,7 +76,7 @@ on the main process with no yield point. That ordering is exactly the reported
 and CRDT-seeds the entire file, on the main process, before the user has touched
 the note.
 
-A size ceiling does not fix this. Any file *under* the ceiling still takes the
+A size ceiling does not fix this. Any file _under_ the ceiling still takes the
 same path. The ceiling only picks which files are excluded; it is not the fix.
 
 ## Design: tiered ingest
@@ -93,8 +93,8 @@ Two classes of vault file, decided at ingest, and three tiers of work.
 Classification, both conditions required for **Note**:
 
 ```
-NOTE_MAX_BYTES       = 2 MB      // 264 ms/MB measured on well-formed markdown -> ~530 ms at 2 MB
-NOTE_MAX_BLOCK_BYTES = 128 KB    // 0.2 MB single block measured at 57 ms -> ~30 ms at 128 KB
+NOTE_MAX_BYTES       = 1 MB      // 830 ms/MB for the worst realistic shape -> 0.83 s
+NOTE_MAX_BLOCK_BYTES = 128 KB    // worst single 128 KB block measured at ~1 s
 ```
 
 Largest block = largest blank-line-separated segment. Files over
@@ -105,10 +105,14 @@ A fixed byte ceiling alone misclassifies both directions: it rejects a
 well-formed 3 MB note that parses fine, and accepts a 900 KB log dump that does
 not. The pair is the point.
 
-`NOTE_MAX_BYTES` is derived from a single measurement (1.81 MB / 124 blocks /
-477 ms). It should be re-tuned against a corpus of real notes before it ships;
-2 MB is generous for prose (~300k words) so the risk is low, but the number is
-not yet well-founded.
+Both numbers were re-derived against a generated corpus in #1463, from a stated
+budget of **1 s of main-process block on a note's first open**. That work moved
+`NOTE_MAX_BYTES` from 2 MB to 1 MB (2 MB measured 1.65 s for an imported vault
+note and 3.0 s for a table-dense document) and confirmed `NOTE_MAX_BLOCK_BYTES`
+at 128 KB. It also found that a plain paragraph parses _linearly_, not
+quadratically — density, not block size alone, is the driver — and that
+table-heavy markdown is superlinear in file size, which neither bound catches.
+See `2026-08-15-note-class-threshold-calibration.md`.
 
 ### Tiers
 
@@ -189,7 +193,10 @@ what a full re-scan cost last time — do not repeat it.
 
 ## Open risks
 
-- `NOTE_MAX_BYTES` rests on one data point; tune against real notes.
+- ~~`NOTE_MAX_BYTES` rests on one data point; tune against real notes.~~ Done in
+  #1463. The residual it exposed: table-dense and punctuation-dense markdown is
+  superlinear in _file_ size, so a file inside both bounds can still cost
+  minutes. Bounding that needs a time-boxed parse, not a third size number.
 - `NoteListItem.wordCount` / `snippet` become nullable — a renderer-visible
   contract change; needs the IPC contract updated and `pnpm ipc:check` run.
 - The viewer is the bulk of the work here and is the piece most likely to want

--- a/docs/superpowers/specs/2026-08-15-note-class-threshold-calibration.md
+++ b/docs/superpowers/specs/2026-08-15-note-class-threshold-calibration.md
@@ -1,0 +1,219 @@
+# Note-class thresholds: parse budget, corpus and calibration
+
+Status: measured and applied
+Date: 2026-08-15
+Issue: #1463 · Epic: #1468 · Follows #1459
+Classifier: `packages/shared/src/markdown-class.ts`
+Harness: `apps/desktop/src/main/sync/markdown-parse-budget.test.ts`
+
+## Result
+
+| constant               | before (#1459) | after                  | why                                                                                                           |
+| ---------------------- | -------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `NOTE_MAX_BYTES`       | 2 MB           | **1 MB**               | 2 MB costs 1.65 s for a realistic imported note and 3.0 s for a table-dense one, against a 1 s budget         |
+| `NOTE_MAX_BLOCK_BYTES` | 128 KB         | **128 KB** (confirmed) | no shape measured costs more than ~1 s for one 128 KB block, and the pathology it exists for is 4–140x larger |
+
+## Re-running the measurement
+
+```bash
+pnpm --filter @memry/desktop measure:parse-budget
+```
+
+It is opt-in: the suite is `describe.skipIf(!process.env.MEMRY_PARSE_BUDGET)`, so
+`pnpm test` collects one skipped file and pays nothing. A full run takes about
+13 minutes, most of it in the deliberately pathological cases.
+
+The corpus is generated at measurement time from fixed-seed PRNGs rather than
+committed — it is megabytes of markdown, and the shapes are what matter. The
+harness measures `markdownToBlocks`, which is what `CrdtDocStore.seedFromMarkdown`
+calls, so the numbers include the embed rewrite, the colour masking and the
+blank-line split, not just `tryParseMarkdownToBlocks`.
+
+Numbers below: median of 3 (1 for samples over ~1 s), Apple Silicon dev machine,
+Node 24, Vitest `main` project.
+
+## The budget
+
+**A note's first open may block the main process for at most 1 second.**
+
+Four things fix that number.
+
+1. **It is a full main-process stall, not a background task.** The BlockNote
+   parse runs synchronously on the main process with no yield point. While it
+   runs, every IPC call queues and every window stops painting — the sidebar,
+   the other note you had open, the menu bar. This is not "one view is slow".
+2. **The OS calls it hung at about 2 s.** On macOS the main process is the UI
+   thread; WindowServer starts the beachball once it stops servicing events for
+   a couple of seconds. 1 s leaves a factor of two before the app looks broken.
+3. **The measuring machine is fast.** Everything below is an Apple Silicon
+   laptop. A 2019 Intel machine or a low-end Windows box runs this parse 2–4x
+   slower, so 1 s here is already 2–4 s there. That headroom is spent, not
+   spare, which is why the budget is not looser.
+4. **It is cheap to hold.** After #1459/#1460 the seed happens on first open and
+   the resulting Y.Doc is persisted, so the cost is paid once per note per
+   install. Buying a smaller ceiling costs almost nothing in practice: 1 MB is
+   still ~150k words, roughly three novels.
+
+A budget is not a guarantee — see "What the bounds do not bound" below.
+
+## Method
+
+Two bounds, so two questions.
+
+- **How does cost grow with file size?** Sweep total bytes with the block shape
+  held constant and small (600 B paragraphs).
+- **How does cost grow with the size of one block?** Sweep the size of a single
+  block, per shape, with the file being exactly that one block.
+
+Then a third question the first two do not answer: **does a file of N blocks
+cost N times one block?** `splitMarkdownPreservingBlanks` only splits on runs of
+3+ newlines, so an ordinary `\n\n`-separated document reaches
+`tryParseMarkdownToBlocks` as **one call**. Blocks are remark's business inside
+that call, and remark is not additive for every shape.
+
+## Corpus
+
+| shape               | stands for                                                                                                 | blank lines?         |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------- |
+| prose               | daily notes, long-form writing                                                                             | yes, every paragraph |
+| structured          | written-up docs: headings, nested lists, tables, code fences, links                                        | yes                  |
+| obsidian vault note | imported vaults: frontmatter, `[[wikilinks]]`, `#tags`, `- [ ]` tasks, quotes                              | yes                  |
+| tight outline       | Roam/Bear exports — `convertBlocks` in `packages/importers/src/roam` joins every bullet with a single `\n` | **no**               |
+| log dump            | the 17.8 MB file that opened #1468                                                                         | **no**               |
+| table               | one wide markdown table                                                                                    | **no**               |
+| minified json       | an API response pasted straight in                                                                         | **no**, one line     |
+
+`![[embeds]]` are deliberately absent: they reach `resolveVaultEmbeds`, whose
+cost is a vault-index lookup, not a parse.
+
+## Sweep A — file size, well-formed prose (600 B blocks)
+
+| file   | blocks | ms    |
+| ------ | ------ | ----- |
+| 64 KB  | 123    | 31    |
+| 256 KB | 490    | 109   |
+| 512 KB | 978    | 210   |
+| 1 MB   | 1 953  | 429   |
+| 2 MB   | 3 906  | 891   |
+| 3 MB   | 5 859  | 1 364 |
+
+Fitted: **450 ms/MB, linear**. Prose is not the problem.
+
+## Sweep B — one block, growing
+
+Each row is a file consisting of exactly one block. `p` is the exponent of a
+log-log fit `ms = k · blockKB^p`; 1 is linear, 2 is quadratic.
+
+| block      | paragraph | log dump  | tight outline | table     | minified json |
+| ---------- | --------- | --------- | ------------- | --------- | ------------- |
+| 8 KB       | 3         | 6         | 20            | 25        | 6             |
+| 16 KB      | 6         | 9         | 32            | 51        | 16            |
+| 32 KB      | 13        | 17        | 63            | 123       | 54            |
+| 64 KB      | 26        | 36        | 129           | 343       | 217           |
+| **128 KB** | **53**    | **74**    | **264**       | **1 017** | **1 026**     |
+| 256 KB     | 103       | 181       | 599           | 4 160     | 4 565         |
+| 512 KB     | 211       | **2 653** | 1 419         | —         | —             |
+| fitted `p` | 1.00      | 1.33      | 1.04          | 1.47      | 1.95          |
+
+Two things here correct the spec's model.
+
+- **A plain paragraph is linear, not quadratic.** 512 KB of words and spaces in
+  one block costs 211 ms — the same rate as the same bytes split into 800
+  paragraphs. The 14x in the original single measurement was not "one block"; it
+  was _what was in_ the block.
+- **Density is the driver, and it is punctuation.** Minified JSON is the only
+  genuinely quadratic shape (`p = 1.95`): it opens with `[` and is wall-to-wall
+  `{`, `"`, `:`, so the inline scanner backtracks over link labels the whole
+  way. Tables are next (`p = 1.47`), then log dumps (`p = 1.33`, with a cliff
+  between 256 KB and 512 KB — 181 ms to 2 653 ms).
+
+## Additivity — 512 KB as 8 × 64 KB blocks
+
+| shape         | measured   | 8 × one 64 KB block | ratio   |
+| ------------- | ---------- | ------------------- | ------- |
+| paragraph     | 216        | 208                 | 1.0     |
+| log dump      | 298        | 288                 | 1.0     |
+| minified json | 1 621      | 1 736               | 0.9     |
+| tight outline | 1 820      | 1 032               | 1.8     |
+| table         | **13 635** | 2 744               | **5.0** |
+
+Tables are strongly super-additive. Eight 64 KB tables in one 512 KB document
+cost five times eight separate 64 KB tables, because they are one parse call and
+remark's table handling is superlinear in _document_ size. That single fact is
+why the block bound cannot be the whole answer.
+
+## Realistic shapes at size
+
+| shape                    | 512 KB | 2 MB  | implied rate              |
+| ------------------------ | ------ | ----- | ------------------------- |
+| prose                    | 210    | 891   | 450 ms/MB                 |
+| obsidian vault note      | 423    | 1 654 | 830 ms/MB                 |
+| structured (table-dense) | 691    | 2 990 | ~1 400 ms/MB, superlinear |
+
+Against a 1 s budget:
+
+| ceiling  | prose      | vault note | structured |
+| -------- | ---------- | ---------- | ---------- |
+| 2 MB     | 891 ✅     | 1 654 ❌   | 2 990 ❌   |
+| **1 MB** | **429 ✅** | **830 ✅** | 1 400 ⚠️   |
+| 512 KB   | 210 ✅     | 423 ✅     | 691 ✅     |
+
+**1 MB** is the landing. It holds the budget for the two shapes that describe
+real notes — written prose and imported vault pages. It is 1.4x over for the
+table-dense synthetic, and 512 KB would cover that too, but a document with
+~1 400 tables in it is not a note anyone writes; paying for it with half the
+remaining headroom on genuine content is the wrong trade.
+
+## Confirming 128 KB
+
+At 128 KB a single block costs 53 ms (prose), 74 ms (log dump), 264 ms
+(outline), ~1 s (table, JSON). Nothing exceeds the budget on its own.
+
+The bound exists to catch documents with **no blank line anywhere**, where the
+block _is_ the file. Those run 500 KB to 18 MB — 4x to 140x above 128 KB — so
+the exact cut point is not delicately placed. Between 64 KB and 128 KB the bound
+only decides the fate of genuine human content: one wide table, one long code
+fence, one exported outline page. Halving it would trim the machine-generated
+tail and take editability from real notes, so 128 KB stays.
+
+## What the bounds do not bound
+
+Two size numbers cannot bound parse time, and pretending otherwise would be
+worse than saying so.
+
+- **Cost per byte varies ~30x by shape** — 450 ms/MB for prose against
+  ~13 600 ms/MB for a table-dense 512 KB document.
+- **Tables and dense punctuation are superlinear in file size, not block size.**
+  A 1 MB file of 8 × 128 KB tables sits inside both bounds and still costs
+  minutes. This is the residual, and it is real.
+
+Neither bound can close that. It needs a different mechanism — a time-boxed
+parse that aborts into large-file class, or the parse moved off the main
+process. The design doc already lists the worker option as a non-goal for this
+epic ("it relocates a ten-minute parse rather than removing it"). Worth its own
+issue; nothing here should be read as claiming the case is handled.
+
+## Backward compatibility
+
+Classification is **derived, never persisted**. `notes-crud.ts` computes it per
+call from `stat` plus content, and `crdt-provider.ts` recomputes it before
+seeding. Nothing writes `sizeClass` to either database, no on-disk format
+carries it, and the vault file is never touched.
+
+So the change is a behaviour change on next open, and only that:
+
+- **No migration, no reindex, no schema change, no re-scan.** Nothing to run.
+- **Fully reversible.** Moving the constant back restores the previous
+  behaviour exactly, on the next open, with no repair step.
+- **Nothing is destroyed by the lowering.** A note between 1 MB and 2 MB that
+  was already seeded keeps its Y.Doc and its persisted CRDT updates; it opens
+  read-only with the large-file notice instead of in the editor, and the file on
+  disk is untouched. Raising the ceiling brings it straight back.
+- **No user is losing a note they edit today.** #1459 (PR #1474) is the first
+  build to have any ceiling at all and has not shipped, so no released version
+  ever treated 1–2 MB as editable-by-threshold. Relative to what users run
+  today, this changes which oversized files stop freezing the app — 1 MB catches
+  a strictly larger set than 2 MB did.
+- **Sync is unaffected by the number.** The client encrypt cap (~3.7 MB of
+  markdown) and the server body cap (8 MiB) are separate ceilings on a separate
+  axis and neither moves. #1465 owns telling the user about those.

--- a/docs/superpowers/specs/2026-08-15-note-class-threshold-calibration.md
+++ b/docs/superpowers/specs/2026-08-15-note-class-threshold-calibration.md
@@ -184,8 +184,11 @@ worse than saying so.
 - **Cost per byte varies ~30x by shape** — 450 ms/MB for prose against
   ~13 600 ms/MB for a table-dense 512 KB document.
 - **Tables and dense punctuation are superlinear in file size, not block size.**
-  A 1 MB file of 8 × 128 KB tables sits inside both bounds and still costs
-  minutes. This is the residual, and it is real.
+  2 MB tiled as 16 × 128 KB tables measured **578 903 ms** — nine and a half
+  minutes — and the same tiling in minified JSON measured 120 126 ms. Halve the
+  file and it is still minutes. Both sit on the block bound, not over it, so
+  only the byte ceiling excludes them, and only at 1 MB rather than 2 MB. This
+  is the residual, and it is real.
 
 Neither bound can close that. It needs a different mechanism — a time-boxed
 parse that aborts into large-file class, or the parse moved off the main

--- a/packages/shared/src/markdown-class.test.ts
+++ b/packages/shared/src/markdown-class.test.ts
@@ -63,7 +63,17 @@ describe('largestBlockByteLength', () => {
     ['trailing blank lines ignored', 'hello\n\n', 5],
     ['no blank lines at all -> whole file is one block', 'a\nb\nc\nd', 7],
     ['multibyte counted as bytes not chars', '日本語', 9],
-    ['first block can be the largest', 'aaaaaaaa\n\nbb', 8]
+    ['first block can be the largest', 'aaaaaaaa\n\nbb', 8],
+    // Shapes the #1463 corpus surfaced. Each is a whole document that reads as
+    // ONE block, which is what the block bound is measuring.
+    ['tight list (roam/bear export) is one block', '- a\n  - b\n- c', 13],
+    ['markdown table is one block', '| a | b |\n| - | - |\n| 1 | 2 |', 29],
+    ['minified json on one line is one block', '[{"id":1},{"id":2}]', 19],
+    ['frontmatter is its own block', '---\ntitle: x\n---\n\nbody', 16],
+    // Deliberate under-report: remark keeps a fence whole, this scan splits it.
+    // Safe, because the cost this bound tracks is inline parsing and a fence
+    // carries no inline nodes.
+    ['blank line inside a code fence still splits', '```\naa\n\nbbbb\n```', 8]
   ]
 
   it.each(cases)('%s', (_name, markdown, largest) => {
@@ -196,14 +206,14 @@ describe('classifyMarkdownContent', () => {
     })
   })
 
-  it('keeps a well-formed 1.8 MB note in note class', () => {
-    // #given the measured well-behaved case: 1.81 MB across many blocks
+  it('keeps a well-formed note just under the ceiling in note class', () => {
+    // #given ~800 KB of ordinary paragraphs — the shape that measured 450 ms/MB
     const paragraph = 'x'.repeat(4000)
-    const markdown = Array.from({ length: 450 }, () => paragraph).join('\n\n')
-    expect(utf8ByteLength(markdown)).toBeGreaterThan(1.7 * 1024 * 1024)
+    const markdown = Array.from({ length: 200 }, () => paragraph).join('\n\n')
+    expect(utf8ByteLength(markdown)).toBeGreaterThan(0.7 * 1024 * 1024)
     expect(utf8ByteLength(markdown)).toBeLessThan(NOTE_MAX_BYTES)
 
-    // #when / #then — parses in ~477 ms, so it stays editable
+    // #when / #then — well inside the 1 s budget, so it stays editable
     expect(classifyMarkdownContent(markdown).sizeClass).toBe('note')
   })
 
@@ -218,6 +228,44 @@ describe('classifyMarkdownContent', () => {
       reason: 'block-bytes'
     })
   })
+
+  // The #1463 corpus turned up three more whole-document-is-one-block shapes.
+  // All three are under the byte ceiling and all three are caught by the block
+  // bound, which is the pairing working as intended.
+  const oneBlockShapes: Array<[name: string, markdown: string]> = [
+    [
+      // packages/importers/src/roam joins every bullet with a single newline,
+      // so an exported page carries no blank line at all.
+      'whole-page outline export (roam/bear)',
+      Array.from({ length: 6000 }, (_, i) => `  - bullet ${i} with a little text`).join('\n')
+    ],
+    [
+      'wide markdown table',
+      ['| id | value | note |', '| --- | --- | --- |']
+        .concat(Array.from({ length: 6000 }, (_, i) => `| ${i} | value ${i} | note ${i} |`))
+        .join('\n')
+    ],
+    [
+      'minified json pasted as one line',
+      `[${Array.from({ length: 8000 }, (_, i) => `{"id":${i},"ok":true}`).join(',')}]`
+    ]
+  ]
+
+  it.each(oneBlockShapes)('%s is large-file class on the block bound', (_name, markdown) => {
+    // #given a file comfortably under the byte ceiling
+    expect(utf8ByteLength(markdown)).toBeLessThan(NOTE_MAX_BYTES)
+    expect(utf8ByteLength(markdown)).toBeGreaterThan(NOTE_MAX_BLOCK_BYTES)
+
+    // #when / #then — no blank line anywhere, so the file is a single block.
+    // For the table and the JSON that is also the right verdict on cost (a
+    // 128 KB block of either measured ~1 s on its own). For the outline it is
+    // the bound being deliberately conservative: a list is cheaper per byte
+    // than a paragraph, and a byte scan cannot tell the two apart.
+    expect(classifyMarkdownContent(markdown)).toMatchObject({
+      sizeClass: 'large-file',
+      reason: 'block-bytes'
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -226,8 +274,11 @@ describe('classifyMarkdownContent', () => {
 
 describe('shipped thresholds', () => {
   it('are the calibrated values', () => {
-    // Changing these is a product decision (#1463), not an implementation detail.
-    expect(NOTE_MAX_BYTES).toBe(2_097_152)
+    // Changing these is a product decision, not an implementation detail. Both
+    // follow from a 1 s parse budget; the corpus, the method and the measured
+    // numbers are in
+    // docs/superpowers/specs/2026-08-15-note-class-threshold-calibration.md.
+    expect(NOTE_MAX_BYTES).toBe(1_048_576)
     expect(NOTE_MAX_BLOCK_BYTES).toBe(131_072)
   })
 })

--- a/packages/shared/src/markdown-class.ts
+++ b/packages/shared/src/markdown-class.ts
@@ -1,26 +1,50 @@
 /**
  * Decides whether a markdown file may become an editable, CRDT-seeded note.
  *
- * The BlockNote markdown parse is roughly quadratic in the size of a single
- * block, not in the size of the file. Measured on real files:
+ * Both bounds are calibrated against a **1 s parse budget** — the longest the
+ * main process may block while seeding a note on first open. The corpus, the
+ * method, the budget's reasoning and the full measurement tables live in
+ * `docs/superpowers/specs/2026-08-15-note-class-threshold-calibration.md`
+ * (#1463). Re-run the measurement with:
  *
- *   1.81 MB, blank-line separated (124 blocks)  ->    477 ms
- *   1.81 MB, as-is                (1 block)     ->  6 594 ms   (14x)
- *   2.73 MB, as-is                (2 blocks)    ->  8 936 ms
+ *   pnpm --filter @memry/desktop measure:parse-budget
  *
- * Identical bytes; only the block shape differs. Log dumps carry no blank
- * lines, so remark parses the whole file as one paragraph holding millions of
- * inline nodes.
+ * Headline numbers, medians through `markdownToBlocks` (the real seeding entry
+ * point) on an Apple Silicon dev machine:
+ *
+ *   well-formed prose                          450 ms/MB   linear in file size
+ *   imported vault note (tasks, wikilinks)     830 ms/MB
+ *   table-dense structured document          1 400 ms/MB   superlinear
+ *   one 128 KB block  prose 53 · log dump 74 · outline 264 · table 1 017 ms
+ *   one 512 KB block  log dump 2 653 ms — 36x the 128 KB cost for 4x the bytes
  *
  * That is why classification needs *both* bounds. A byte ceiling alone
- * misclassifies in both directions: it rejects a well-formed 3 MB note that
- * parses fine, and accepts a 900 KB log dump that does not.
+ * misclassifies in both directions: it rejects a well-formed note that parses
+ * fine, and accepts a 900 KB log dump that does not — a file with no blank
+ * lines is one block however long it is.
  */
 
-/** Files above this never become notes. Checked against `stat`, before any read. */
-export const NOTE_MAX_BYTES = 2 * 1024 * 1024
+/**
+ * Files above this never become notes. Checked against `stat`, before any read.
+ *
+ * 1 MB at the 830 ms/MB measured for the worst *realistic* shape (an imported
+ * vault note: headings, task lists, quotes, wikilinks) is 0.83 s — inside the
+ * budget, and ~150k words, far past any note a person writes. The
+ * pre-calibration 2 MB costs 1.65 s for that same shape and 3.0 s for a
+ * table-dense document, so it did not hold the budget.
+ */
+export const NOTE_MAX_BYTES = 1024 * 1024
 
-/** Largest blank-line-separated block a note may contain. */
+/**
+ * Largest blank-line-separated block a note may contain.
+ *
+ * Calibration confirmed 128 KB. No shape measured costs more than ~1 s for a
+ * single block that size, and the pathology this bound exists for — a file with
+ * no blank lines anywhere — runs 500 KB to 18 MB, orders of magnitude clear of
+ * it. Halving it to 64 KB would buy back only the tail of machine-generated
+ * content while taking editability from real notes that legitimately hold one
+ * wide table, one long code fence, or a whole-page outline export.
+ */
 export const NOTE_MAX_BLOCK_BYTES = 128 * 1024
 
 export type MarkdownSizeClass = 'note' | 'large-file'


### PR DESCRIPTION
Closes #1463. Part of #1468, on top of #1474 (now on main).

Calibration, not a correctness fix. The two note-class thresholds shipped in #1459 rested on a single measurement. This derives both from a **stated budget** against a generated corpus, and moves one of them.

| constant | before | after |
|---|---|---|
| `NOTE_MAX_BYTES` | 2 MB | **1 MB** |
| `NOTE_MAX_BLOCK_BYTES` | 128 KB | **128 KB — confirmed** |

## The budget

**A note's first open may block the main process for at most 1 s.**

1. It is a full main-process stall — the parse is synchronous with no yield point, so every window and every IPC call is frozen, not just one view.
2. macOS beachballs at roughly 2 s. 1 s leaves a factor of two before the app looks broken.
3. The measuring machine is an Apple Silicon laptop. A 2019 Intel or low-end Windows box is 2–4x slower, so 1 s here is already 2–4 s there. That headroom is spent, not spare.
4. It is cheap to hold. After #1459/#1460 the seed happens on first open and the Y.Doc is persisted, so it is paid once per note per install.

## Corpus and method

Generated at measurement time (fixed-seed PRNG, nothing large committed), measured through `markdownToBlocks` — the real seeding entry point — so the numbers include the embed rewrite, colour masking and the blank-line split, not just `tryParseMarkdownToBlocks`.

Shapes: small prose · long prose · structured docs (headings, nested lists, tables, code fences, links) · imported Obsidian vault notes (frontmatter, wikilinks, `#tags`, `- [ ]` tasks) · tight outlines (Roam/Bear — `convertBlocks` joins every bullet with a single `\n`, so a whole page is one block) · log dumps · wide tables · minified JSON.

## What the data says

**Sweep A — file size, well-formed prose**: 31 / 109 / 210 / 429 / 891 / 1 364 ms at 64 KB → 3 MB. **450 ms/MB, linear.**

**Sweep B — one block, growing** (ms; `p` is the log-log exponent, 1 = linear, 2 = quadratic):

| block | paragraph | log dump | tight outline | table | minified json |
|---|---|---|---|---|---|
| 8 KB | 3 | 6 | 20 | 25 | 6 |
| 32 KB | 13 | 17 | 63 | 123 | 54 |
| 64 KB | 26 | 36 | 129 | 343 | 217 |
| **128 KB** | **53** | **74** | **264** | **1 017** | **1 026** |
| 256 KB | 103 | 181 | 599 | 4 160 | 4 565 |
| 512 KB | 211 | **2 653** | 1 419 | — | — |
| `p` | 1.00 | 1.33 | 1.04 | 1.47 | 1.95 |

Two findings that correct the model in the design doc:

- **A plain paragraph parses linearly, not quadratically.** 512 KB of words and spaces in one block costs 211 ms — the same rate as the same bytes split into 800 paragraphs. The 14x in the original data point was not "one block", it was *what was in* the block.
- **Density is the driver, and it is punctuation.** Minified JSON is the only truly quadratic shape (`p = 1.95`); it opens with `[` and is wall-to-wall `{ " :`, so the inline scanner backtracks over link labels the whole way. Tables next, then log dumps.

**Realistic shapes at size** — this is what moved `NOTE_MAX_BYTES`:

| shape | 512 KB | 2 MB | rate |
|---|---|---|---|
| prose | 210 | 891 | 450 ms/MB |
| imported vault note | 423 | 1 654 | 830 ms/MB |
| structured, table-dense | 691 | 2 990 | ~1 400 ms/MB |

Against the 1 s budget: at 2 MB, two of three realistic shapes blow it (1.65 s and 3.0 s). At 1 MB, prose is 429 ms and an imported vault note is 830 ms — both inside. 512 KB would also cover the table-dense synthetic, but a note with ~1 400 tables in it is not a note anyone writes, and paying for it with half the remaining headroom on genuine content is the wrong trade. **1 MB is still ~150k words.**

`NOTE_MAX_BLOCK_BYTES` **survives at 128 KB**: nothing measured exceeds the budget for one block that size, and the pathology the bound exists for — a file with no blank line anywhere — runs 500 KB to 18 MB, 4x to 140x clear of it. Between 64 KB and 128 KB the bound only decides the fate of genuine human content (one wide table, one long code fence, one exported outline page), so halving it would cost capability and buy little.

## Honest residual

Two size numbers cannot bound parse time. Cost per byte varies ~30x by shape, and tables are **super-additive in file size, not block size** — 512 KB as 8 × 64 KB tables costs 13 635 ms against 2 744 ms for eight separate 64 KB tables, because `splitMarkdownPreservingBlanks` only splits on 3+ newlines so an ordinary document reaches the parser as one call. A 1 MB file of 8 × 128 KB tables sits inside both bounds and still costs minutes.

Neither bound can close that. It needs a time-boxed parse that aborts into large-file class, or the parse off the main process. Written up as an open risk rather than papered over; the design doc already lists the worker option as a non-goal for this epic.

## Backward compatibility

Classification is **derived, never persisted**. `notes-crud.ts` computes it per call from `stat` + content; `crdt-provider.ts` recomputes before seeding. Nothing writes `sizeClass` to either database, no on-disk format carries it, the vault file is never touched.

- No migration, no reindex, no schema change, no re-scan.
- Fully reversible — moving the constant back restores the old behaviour on next open, no repair step.
- Nothing destroyed by the lowering: a 1–2 MB note that was already seeded keeps its Y.Doc and persisted CRDT updates and opens read-only with the large-file notice; raising the ceiling brings it straight back.
- **No user loses a note they edit today.** #1459 is the first build with any ceiling at all and has not shipped, so no released version ever treated 1–2 MB as editable-by-threshold. Relative to what users run now, this only widens the set of oversized files that stop freezing the app.
- Sync unaffected: the client encrypt cap (~3.7 MB of markdown) and the server body cap (8 MiB) are separate ceilings on a separate axis and neither moves. #1465 owns telling the user about those.

`FileType` is not widened and the classifier's API is unchanged — only the two constants, their doc comments, and tests.

## Re-running the measurement

```bash
pnpm --filter @memry/desktop measure:parse-budget
```

Opt-in: the suite is `describe.skipIf(!process.env.MEMRY_PARSE_BUDGET)`, so `pnpm test` collects one skipped file and pays nothing. A full run is ~13 minutes, most of it in the deliberately pathological cases. Harness at `apps/desktop/src/main/sync/markdown-parse-budget.test.ts`.

## Also here

- Classifier table tests extended with the one-block shapes the corpus surfaced: tight outline export, wide markdown table, minified JSON on one line, frontmatter as its own block, and the deliberate under-report when a code fence contains a blank line.
- Write-up at `docs/superpowers/specs/2026-08-15-note-class-threshold-calibration.md`, referenced from `markdown-class.ts`. Design doc and the "Very Large Files" user-guide page updated to match.

## Verification

`pnpm lint` (0 errors) · `pnpm typecheck` (17/17, includes `typecheck:test`) · `pnpm check:architecture` · `pnpm check:contracts` · `git diff --check` · `docs:impact --strict` covered · `docs:build`. Vitest per project from `apps/desktop`: shared 181 ✓ · main 6577 ✓ · main-integration 9 ✓ · preload 30 ✓ · renderer 7058 ✓. No file added to the typecheck exclude backlog.
