### PR TITLE
perf(ingest): a sidebar row from stat alone, metadata on idle

### DIFF
--- a/apps/desktop/src/main/projections/projectors/embedding-projector.ts
+++ b/apps/desktop/src/main/projections/projectors/embedding-projector.ts
@@ -225,6 +225,13 @@ export function createEmbeddingProjector(
         return
       }
 
+      // Body not read yet (tier 0 of ingest); the idle backfill republishes the
+      // note with its body. Embedding the title alone would be worse than
+      // waiting, and it would drop any embedding the note already has.
+      if (note.parsedContent === null) {
+        return
+      }
+
       // During the initial index pass, embedding is deferred: indexVault awaits
       // this projector per file (before the vault is marked open), and loading the
       // ~23MB model + running CPU inference here is what stranded vault-open for

--- a/apps/desktop/src/main/projections/projectors/note-derived-state-projector.ts
+++ b/apps/desktop/src/main/projections/projectors/note-derived-state-projector.ts
@@ -32,19 +32,29 @@ const RECONCILE_STAT_CONCURRENCY = 8
 function persistMarkdownNote(note: Extract<NoteProjectionRecord, { kind: 'markdown' }>): void {
   const db = getIndexDatabase()
   const existing = getNoteCacheById(db, note.noteId)
+  // Tier 0 of ingest publishes identity only. Its null measurements mean
+  // "not read yet", so they must not be written over a row that already
+  // carries real ones, and no body-derived state can be rebuilt from them.
+  const bodyUnread = note.parsedContent === null
 
   if (existing) {
-    updateNoteCache(db, note.noteId, {
-      path: note.path,
-      title: note.title,
-      emoji: note.emoji,
-      localOnly: note.localOnly,
-      contentHash: note.contentHash,
-      wordCount: note.wordCount,
-      characterCount: note.characterCount,
-      snippet: note.snippet,
-      modifiedAt: note.modifiedAt
-    })
+    updateNoteCache(
+      db,
+      note.noteId,
+      bodyUnread
+        ? { path: note.path, title: note.title, modifiedAt: note.modifiedAt }
+        : {
+            path: note.path,
+            title: note.title,
+            emoji: note.emoji,
+            localOnly: note.localOnly,
+            contentHash: note.contentHash,
+            wordCount: note.wordCount,
+            characterCount: note.characterCount,
+            snippet: note.snippet,
+            modifiedAt: note.modifiedAt
+          }
+    )
   } else {
     insertNoteCache(db, {
       id: note.noteId,
@@ -53,6 +63,7 @@ function persistMarkdownNote(note: Extract<NoteProjectionRecord, { kind: 'markdo
       emoji: note.emoji,
       localOnly: note.localOnly,
       fileType: 'markdown',
+      fileSize: note.fileSize ?? null,
       contentHash: note.contentHash,
       wordCount: note.wordCount,
       characterCount: note.characterCount,
@@ -62,6 +73,8 @@ function persistMarkdownNote(note: Extract<NoteProjectionRecord, { kind: 'markdo
       modifiedAt: note.modifiedAt
     })
   }
+
+  if (bodyUnread) return
 
   setNoteTags(db, note.noteId, note.tags)
   setNoteProperties(db, note.noteId, note.properties, (name, value) =>

--- a/apps/desktop/src/main/projections/projectors/search-projector.test.ts
+++ b/apps/desktop/src/main/projections/projectors/search-projector.test.ts
@@ -274,6 +274,54 @@ describe('search projector', () => {
     ).toHaveLength(0)
   })
 
+  it('leaves a note out of the index until its body has been read', async () => {
+    // #given the projection vault ingest publishes from `stat` alone: identity
+    // only, every body-derived field null
+    const projector = createSearchProjector(() => vaultDir)
+    const statOnlyEvent = {
+      type: 'note.upserted',
+      note: {
+        kind: 'markdown',
+        noteId: 'note-1',
+        path: 'notes/pasted.md',
+        title: 'Pasted',
+        fileType: 'markdown',
+        localOnly: false,
+        contentHash: null,
+        wordCount: null,
+        characterCount: null,
+        snippet: null,
+        date: null,
+        emoji: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        modifiedAt: '2026-01-01T00:00:00.000Z',
+        parsedContent: null,
+        tags: [],
+        properties: {},
+        wikiLinks: []
+      }
+    } as const
+
+    // #when
+    await projector.project(statOnlyEvent)
+
+    // #then no FTS write happens on the add path at all
+    expect(getFtsCount(indexDb.db as never)).toBe(0)
+
+    // #when the backfill republishes the same note with its body
+    await projector.project({
+      ...statOnlyEvent,
+      note: { ...statOnlyEvent.note, parsedContent: 'measured at last', wordCount: 3 }
+    })
+
+    // #then it becomes searchable
+    expect(
+      indexDb.db.all<{ id: string }>(
+        sql`SELECT id FROM fts_notes WHERE fts_notes MATCH ${'measured'}`
+      )
+    ).toHaveLength(1)
+  })
+
   it('reconcile sweeps duplicate rows left behind by earlier versions', async () => {
     seedMarkdownNote('note-1', 'notes/searchable.md', 'Disk content', ['alpha'])
     seedTask('task-1')

--- a/apps/desktop/src/main/projections/projectors/search-projector.ts
+++ b/apps/desktop/src/main/projections/projectors/search-projector.ts
@@ -484,6 +484,13 @@ export function createSearchProjector(getVaultPath: () => string | null): Projec
             return
           }
 
+          // Body not read yet (tier 0 of ingest). The idle backfill republishes
+          // the note with its body and that is what reaches the index; writing
+          // an empty row here would put an FTS write back on the add path.
+          if (event.note.parsedContent === null) {
+            return
+          }
+
           insertFtsNote(
             getIndexDatabase(),
             event.note.noteId,

--- a/apps/desktop/src/main/projections/types.ts
+++ b/apps/desktop/src/main/projections/types.ts
@@ -7,15 +7,24 @@ export interface MarkdownNoteProjection {
   title: string
   fileType: 'markdown'
   localOnly: boolean
-  contentHash: string
-  wordCount: number
-  characterCount: number
-  snippet: string
+  contentHash: string | null
+  wordCount: number | null
+  characterCount: number | null
+  snippet: string | null
   date: string | null
   emoji: string | null
   createdAt: string
   modifiedAt: string
-  parsedContent: string
+  /**
+   * Null when the body has not been read. Tier 0 of vault ingest builds a row
+   * from `stat`, path and title alone, so a 250 MB paste costs one `stat`
+   * rather than a multi-hundred-megabyte allocation; the idle backfill then
+   * republishes the same note with its body. Consumers that derive state from
+   * the body must skip a null rather than treat it as an empty note.
+   */
+  parsedContent: string | null
+  /** Only set by tier 0, where it is the one thing `stat` knows about the body. */
+  fileSize?: number | null
   tags: string[]
   properties: Record<string, unknown>
   wikiLinks: string[]

--- a/apps/desktop/src/main/vault/file-scan.test.ts
+++ b/apps/desktop/src/main/vault/file-scan.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { generateContentHash } from './frontmatter'
+import { scanMarkdownFile } from './file-scan'
+
+describe('scanMarkdownFile', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-file-scan-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  function write(name: string, content: string): string {
+    const filePath = path.join(dir, name)
+    fs.writeFileSync(filePath, content, 'utf8')
+    return filePath
+  }
+
+  it('hashes a multi-chunk file to the same value as hashing it whole', async () => {
+    // #given a file several read chunks long. Rename detection matches the
+    // hash of a newly added file against the hash cached for a deleted one,
+    // and only one of those two can come from a stream — so the streaming
+    // hash has to equal the whole-string hash exactly or renames break.
+    const content = 'alpha beta gamma delta\n'.repeat(40_000)
+    const filePath = write('big.md', content)
+
+    // #when
+    const scan = await scanMarkdownFile(filePath)
+
+    // #then
+    expect(scan).not.toBeNull()
+    expect(scan!.contentHash).toBe(generateContentHash(content))
+  })
+
+  it('counts words and characters across chunk boundaries', async () => {
+    // #given a word deliberately long enough to straddle several chunks
+    const content = `${'a'.repeat(200_000)} second third`
+    const filePath = write('straddle.md', content)
+
+    // #when
+    const scan = await scanMarkdownFile(filePath)
+
+    // #then the split word is counted once, not once per chunk
+    expect(scan!.wordCount).toBe(3)
+    expect(scan!.characterCount).toBe(content.length)
+  })
+
+  it('keeps only the requested head in memory', async () => {
+    // #given a file far larger than the head budget
+    const content = 'head text here\n'.repeat(50_000)
+    const filePath = write('head.md', content)
+
+    // #when
+    const scan = await scanMarkdownFile(filePath, 1_024)
+
+    // #then the head is bounded, while the counts still describe the whole file
+    expect(scan!.head.length).toBeLessThan(1_024 + 128 * 1024)
+    expect(scan!.head.startsWith('head text here')).toBe(true)
+    expect(scan!.wordCount).toBe(3 * 50_000)
+  })
+
+  it('returns null for a file that is gone', async () => {
+    // #given nothing at the path — the watcher can enqueue a backfill for a
+    // file the user deletes a moment later
+    const scan = await scanMarkdownFile(path.join(dir, 'missing.md'))
+
+    // #then
+    expect(scan).toBeNull()
+  })
+
+  it('handles an empty file', async () => {
+    const filePath = write('empty.md', '')
+
+    const scan = await scanMarkdownFile(filePath)
+
+    expect(scan).toEqual({
+      wordCount: 0,
+      characterCount: 0,
+      contentHash: generateContentHash(''),
+      head: ''
+    })
+  })
+})

--- a/apps/desktop/src/main/vault/file-scan.ts
+++ b/apps/desktop/src/main/vault/file-scan.ts
@@ -1,0 +1,82 @@
+/**
+ * Streaming measurement of a markdown file.
+ *
+ * Nothing here ever holds the file as one string. `readFile(…, 'utf-8')` throws
+ * `ERR_STRING_TOO_LONG` above V8's 536 870 888-character ceiling, and well
+ * before that a single allocation of a few hundred megabytes is a main-process
+ * GC pause on its own. A vault file can be either, so the counts, the hash and
+ * the indexed head are all built chunk by chunk.
+ *
+ * @module vault/file-scan
+ */
+
+import { createReadStream } from 'fs'
+import { createContentHasher } from './frontmatter'
+
+/** Bytes pulled from disk per chunk. The stream decodes UTF-8 across them. */
+const READ_CHUNK_BYTES = 64 * 1024
+
+/** How much of a file is kept for the snippet and the search index. */
+export const DEFAULT_HEAD_CHARS = 256 * 1024
+
+export interface MarkdownFileScan {
+  /** Whitespace-delimited tokens across the whole file. */
+  wordCount: number
+  characterCount: number
+  /** Identical to `generateContentHash` over the same bytes. */
+  contentHash: string
+  /** The first `headChars` characters, at most. */
+  head: string
+}
+
+function isWhitespace(code: number): boolean {
+  // space, tab, LF, CR, form feed, vertical tab
+  return code === 0x20 || (code >= 0x09 && code <= 0x0d)
+}
+
+/**
+ * Read a file in chunks, measuring it as it goes.
+ *
+ * @returns null when the file is gone — the backfill queue can outlive a file
+ *   the user deletes a moment after pasting it.
+ */
+export async function scanMarkdownFile(
+  absolutePath: string,
+  headChars: number = DEFAULT_HEAD_CHARS
+): Promise<MarkdownFileScan | null> {
+  const hasher = createContentHasher()
+  let wordCount = 0
+  let characterCount = 0
+  let head = ''
+  // Carried across chunks so a word split by a chunk boundary is counted once.
+  let previousWasWhitespace = true
+
+  const stream = createReadStream(absolutePath, {
+    encoding: 'utf-8',
+    highWaterMark: READ_CHUNK_BYTES
+  })
+
+  try {
+    for await (const chunk of stream) {
+      const text = chunk as string
+      hasher.update(text)
+      characterCount += text.length
+
+      if (head.length < headChars) {
+        head += text.slice(0, headChars - head.length)
+      }
+
+      for (let i = 0; i < text.length; i++) {
+        const whitespace = isWhitespace(text.charCodeAt(i))
+        if (previousWasWhitespace && !whitespace) wordCount++
+        previousWasWhitespace = whitespace
+      }
+    }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT' || code === 'ENOTDIR' || code === 'EISDIR') return null
+    throw error
+  }
+
+  return { wordCount, characterCount, contentHash: hasher.digest(), head }
+}

--- a/apps/desktop/src/main/vault/frontmatter.ts
+++ b/apps/desktop/src/main/vault/frontmatter.ts
@@ -306,13 +306,34 @@ export function calculateWordCount(content: string): number {
  * @param content - Full file content including frontmatter
  * @returns Hash string
  */
-export function generateContentHash(content: string): string {
+/**
+ * Incremental form of {@link generateContentHash}.
+ *
+ * djb2 folds one character at a time, so a file read in chunks hashes to the
+ * same value as the same file read whole. Rename detection compares the hash of
+ * a newly added file against the hash cached for a deleted one, and a file too
+ * big to hold as one string can only be hashed by streaming — the two have to
+ * agree or a rename reads as a delete plus a new note.
+ */
+export function createContentHasher(): { update: (chunk: string) => void; digest: () => string } {
   // Simple djb2 hash - fast and sufficient for change detection
   let hash = 5381
-  for (let i = 0; i < content.length; i++) {
-    hash = (hash * 33) ^ content.charCodeAt(i)
+  return {
+    update(chunk: string): void {
+      for (let i = 0; i < chunk.length; i++) {
+        hash = (hash * 33) ^ chunk.charCodeAt(i)
+      }
+    },
+    digest(): string {
+      return (hash >>> 0).toString(16).padStart(8, '0')
+    }
   }
-  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+export function generateContentHash(content: string): string {
+  const hasher = createContentHasher()
+  hasher.update(content)
+  return hasher.digest()
 }
 
 // ============================================================================

--- a/apps/desktop/src/main/vault/ingest-backfill.ts
+++ b/apps/desktop/src/main/vault/ingest-backfill.ts
@@ -1,0 +1,301 @@
+/**
+ * Tier 1 of vault ingest: the idle metadata and search backfill.
+ *
+ * Tier 0 puts a row in the sidebar from `stat`, the path and the filename, and
+ * reads nothing. This is where the body is finally measured — off the add path,
+ * smallest file first, so a queued 250 MB paste never holds up the notes the
+ * user is actually looking at.
+ *
+ * Two shapes of work, decided by `stat`:
+ *
+ * - Note class (under `NOTE_MAX_BYTES`) is cheap to read whole, so it takes the
+ *   ordinary parse-and-sync path and, if its largest block is also within
+ *   bounds, gets its CRDT doc here. That decision cannot be made at `add` time:
+ *   the block bound needs the content, and the add path never reads it.
+ * - Large-file class is streamed. Nothing is held as one string, so a file past
+ *   V8's 536 870 888-character ceiling is measured rather than thrown at.
+ *
+ * @module vault/ingest-backfill
+ */
+
+import fs from 'fs/promises'
+import type { Stats } from 'fs'
+import { classifyMarkdownContent, classifyMarkdownStat } from '@memry/shared/markdown-class'
+import { JournalChannels, NotesChannels } from '@memry/contracts/ipc-channels'
+import {
+  ensureTagDefinitions,
+  extractDateFromPath,
+  getNoteCacheById,
+  isJournalEntry
+} from '@main/database/queries/notes'
+import { getDatabase, getIndexDatabase } from '../database'
+import { broadcastToAllWindows } from '../lib/window-broadcast'
+import { createLogger } from '../lib/logger'
+import { flushProjectionEvents } from '../projections'
+import { syncNoteCreate } from '../notes/runtime-effects'
+import { enqueueJournalCreate, initializeJournalCrdt } from '../journal/runtime-effects'
+import { createSnippet, extractProperties, extractTags, parseNote } from './frontmatter'
+import { safeRead } from './file-ops'
+import { scanMarkdownFile } from './file-scan'
+import { syncLargeFileBodyToCache, syncNoteToCache } from './note-sync'
+
+const logger = createLogger('IngestBackfill')
+
+/**
+ * Quiet period after the last `add` before the queue is worked. Paste and
+ * import both arrive as bursts, and the point of the tier is to stay off the
+ * critical path while they land.
+ */
+const IDLE_DELAY_MS = 500
+
+/**
+ * How much of a large-file-class file reaches the search index and the snippet.
+ * The whole body cannot: a 250 MB file would put 250 MB in the FTS index for a
+ * file that is read-only and never edited.
+ */
+const LARGE_FILE_INDEX_CHARS = 256 * 1024
+
+export interface IngestBackfillEntry {
+  noteId: string
+  absolutePath: string
+  relativePath: string
+  /** From `stat` at ingest. Only used to order the queue. */
+  fileBytes: number
+}
+
+const queue = new Map<string, IngestBackfillEntry>()
+let idleTimer: NodeJS.Timeout | null = null
+let inFlight: Promise<void> | null = null
+
+export function enqueueIngestBackfill(entry: IngestBackfillEntry): void {
+  queue.set(entry.noteId, entry)
+  scheduleDrain()
+}
+
+export function clearIngestBackfill(): void {
+  queue.clear()
+  if (idleTimer) {
+    clearTimeout(idleTimer)
+    idleTimer = null
+  }
+}
+
+// Deliberately not conditional on a run being in flight. A file queued in the
+// window between the drain loop finding the queue empty and the run clearing
+// itself would then never be scheduled at all, and would sit unmeasured until
+// something else was added. Arming the timer regardless costs nothing: the
+// callback joins the run in flight instead of starting a second one.
+function scheduleDrain(): void {
+  if (idleTimer) return
+  idleTimer = setTimeout(() => {
+    idleTimer = null
+    void drainIngestBackfill().catch((error: unknown) => {
+      logger.error('Ingest backfill drain failed', { error })
+    })
+  }, IDLE_DELAY_MS)
+  idleTimer.unref?.()
+}
+
+/**
+ * Work the queue to empty. Concurrent callers join the run in flight rather
+ * than starting a second one.
+ */
+export async function drainIngestBackfill(): Promise<void> {
+  if (inFlight) {
+    await inFlight
+    return
+  }
+
+  inFlight = runQueue()
+  try {
+    await inFlight
+  } finally {
+    inFlight = null
+  }
+}
+
+async function runQueue(): Promise<void> {
+  for (let next = takeSmallest(); next !== null; next = takeSmallest()) {
+    try {
+      await backfillOne(next)
+    } catch (error) {
+      // One unreadable file must not strand every other queued note.
+      logger.warn('Failed to backfill vault file', { path: next.relativePath, error })
+    }
+  }
+}
+
+function takeSmallest(): IngestBackfillEntry | null {
+  let smallest: IngestBackfillEntry | null = null
+  for (const entry of queue.values()) {
+    if (smallest === null || entry.fileBytes < smallest.fileBytes) smallest = entry
+  }
+  if (smallest) queue.delete(smallest.noteId)
+  return smallest
+}
+
+async function backfillOne(entry: IngestBackfillEntry): Promise<void> {
+  const db = getIndexDatabase()
+  const cached = getNoteCacheById(db, entry.noteId)
+
+  // Deleted, or renamed and re-queued under its new path, between `add` and
+  // now. Either way this entry is stale and writing it back would resurrect a
+  // path that no longer exists.
+  if (!cached || cached.path !== entry.relativePath) return
+
+  const stats = await fs.stat(entry.absolutePath).catch(() => null)
+  if (!stats) return
+
+  const statClass = classifyMarkdownStat(stats.size)
+  if (statClass !== null) {
+    await backfillLargeFile(entry, cached, stats.mtime)
+    return
+  }
+
+  await backfillNote(entry, cached, stats)
+}
+
+type CachedNote = NonNullable<ReturnType<typeof getNoteCacheById>>
+
+async function backfillNote(
+  entry: IngestBackfillEntry,
+  cached: CachedNote,
+  stats: Stats
+): Promise<void> {
+  const content = await safeRead(entry.absolutePath)
+  if (content === null) return
+
+  const parsed = parseNote(content, entry.relativePath, stats)
+  const db = getIndexDatabase()
+
+  const syncResult = syncNoteToCache(
+    db,
+    {
+      id: cached.id,
+      path: entry.relativePath,
+      fileContent: content,
+      frontmatter: parsed.frontmatter,
+      parsedContent: parsed.content,
+      title: cached.title,
+      createdAt: cached.createdAt,
+      modifiedAt: parsed.modified,
+      localOnly: cached.localOnly ?? false,
+      emoji: cached.emoji ?? null
+    },
+    { isNew: false }
+  )
+  await flushProjectionEvents()
+
+  const tags = syncResult.tags
+  if (tags.length > 0) {
+    ensureTagDefinitions(getDatabase(), tags)
+  }
+
+  // The first point at which the file's size class is known: it needs the
+  // largest block, and the add path never reads the file. Both the sync item
+  // and the CRDT doc are gated on it, so both are decided here.
+  const classification = classifyMarkdownContent(content)
+  const isLargeFile = classification.sizeClass === 'large-file'
+  const isJournal = isJournalEntry(entry.relativePath)
+
+  if (isLargeFile) {
+    // Under the byte ceiling but holding one block too big to parse — the log
+    // dump shape. Listed and searchable, but never seeded and never synced.
+    logger.warn('Backfilled file is large-file class; not seeding or syncing it', {
+      path: entry.relativePath,
+      reason: classification.reason,
+      fileBytes: classification.fileBytes,
+      largestBlockBytes: classification.largestBlockBytes
+    })
+  }
+
+  // The CRDT tag array is what write-back serializes back into the file's
+  // `tags:` block, so it may only carry tags the file itself declares.
+  // `syncResult.tags` merges the body's `#hashtag`s in for the index; seeding
+  // those would inject a `tags:` block into a note that never had one, the
+  // first time it is opened — "opening a note modified it" (#1454).
+  const declaredTags = extractTags(parsed.frontmatter)
+
+  if (isJournal) {
+    if (!isLargeFile) {
+      const journalDate = extractDateFromPath(entry.relativePath) ?? ''
+      enqueueJournalCreate(cached.id, journalDate)
+      void initializeJournalCrdt(cached.id, journalDate, declaredTags)
+    }
+  } else {
+    syncNoteCreate(cached.id, cached.title, declaredTags, {
+      sizeClass: classification.sizeClass
+    })
+  }
+
+  broadcastToAllWindows(NotesChannels.events.UPDATED, {
+    id: cached.id,
+    changes: {
+      title: cached.title,
+      content: parsed.content,
+      tags,
+      properties: extractProperties(parsed.frontmatter),
+      modified: new Date(parsed.modified),
+      wordCount: syncResult.wordCount,
+      snippet: syncResult.snippet
+    },
+    source: 'external'
+  })
+
+  if (isJournal) {
+    const journalDate = extractDateFromPath(entry.relativePath) ?? ''
+    broadcastToAllWindows(JournalChannels.events.ENTRY_CREATED, {
+      date: journalDate,
+      entry: {
+        date: journalDate,
+        content: parsed.content,
+        tags,
+        wordCount: syncResult.wordCount,
+        characterCount: syncResult.characterCount,
+        modified: new Date(parsed.modified),
+        created: new Date(cached.createdAt)
+      },
+      source: 'external'
+    })
+  }
+}
+
+async function backfillLargeFile(
+  entry: IngestBackfillEntry,
+  cached: CachedNote,
+  modifiedAt: Date
+): Promise<void> {
+  const scan = await scanMarkdownFile(entry.absolutePath, LARGE_FILE_INDEX_CHARS)
+  if (scan === null) return
+
+  syncLargeFileBodyToCache(getIndexDatabase(), {
+    id: cached.id,
+    path: entry.relativePath,
+    title: cached.title,
+    createdAt: cached.createdAt,
+    modifiedAt: modifiedAt.toISOString(),
+    localOnly: cached.localOnly ?? false,
+    emoji: cached.emoji ?? null,
+    wordCount: scan.wordCount,
+    characterCount: scan.characterCount,
+    contentHash: scan.contentHash,
+    indexedHead: scan.head
+  })
+  await flushProjectionEvents()
+
+  logger.info('Backfilled large-file-class vault file', {
+    path: entry.relativePath,
+    characterCount: scan.characterCount,
+    indexedChars: scan.head.length
+  })
+
+  broadcastToAllWindows(NotesChannels.events.UPDATED, {
+    id: cached.id,
+    changes: {
+      modified: modifiedAt,
+      wordCount: scan.wordCount,
+      snippet: createSnippet(scan.head)
+    },
+    source: 'external'
+  })
+}

--- a/apps/desktop/src/main/vault/note-sync.ts
+++ b/apps/desktop/src/main/vault/note-sync.ts
@@ -26,7 +26,10 @@ import {
   saveCanonicalNote,
   saveCanonicalPropertyDefinition
 } from '@memry/domain-notes'
-import { getPropertyDefinition as getCanonicalPropertyDefinition } from '@memry/storage-data'
+import {
+  getPropertyDefinition as getCanonicalPropertyDefinition,
+  updateNoteMetadata
+} from '@memry/storage-data'
 import { publishProjectionEvent } from '../projections'
 import type { FileNoteProjection, MarkdownNoteProjection } from '../projections/types'
 
@@ -245,6 +248,154 @@ export function syncNoteToCache(
   })
 
   return metadata
+}
+
+/**
+ * Tier 0 of vault ingest: everything the sidebar needs, from `stat`, the path
+ * and the filename.
+ *
+ * The file is not read, so every content-derived field is published as null —
+ * "not known yet", not "empty". {@link syncNoteToCache} replaces the row once
+ * the idle backfill has measured the body.
+ */
+export interface NoteStatSyncInput {
+  id: string
+  path: string
+  title: string
+  createdAt: string
+  modifiedAt: string
+  /** Kept so a rename of a not-yet-backfilled row can still be matched. */
+  fileSize: number
+  localOnly?: boolean
+  emoji?: string | null
+}
+
+export interface NoteStatSyncOptions {
+  /**
+   * False for a rename, where the row already exists and only its identity
+   * moved. The canonical upsert writes every column it is given, so a
+   * stat-only full save erases bookkeeping a `stat` cannot reconstruct —
+   * `propertyDefinitionNames` most visibly, which is how the note's properties
+   * reach other devices.
+   */
+  isNew: boolean
+}
+
+export function syncNoteStatToCache(
+  _db: IndexDb,
+  input: NoteStatSyncInput,
+  options: NoteStatSyncOptions
+): void {
+  const { id, path, title, createdAt, modifiedAt, fileSize } = input
+  const localOnly = input.localOnly ?? false
+  const emoji = input.emoji ?? null
+  const date = extractDateFromPath(path)
+
+  if (options.isNew) {
+    syncCanonicalMetadata({
+      id,
+      path,
+      title,
+      emoji,
+      localOnly,
+      journalDate: date,
+      createdAt,
+      modifiedAt
+    })
+  } else {
+    const dataDb = getCanonicalDb()
+    if (dataDb) {
+      updateNoteMetadata(dataDb, id, { path, title, journalDate: date, modifiedAt })
+    }
+  }
+
+  const note: MarkdownNoteProjection = {
+    kind: 'markdown',
+    noteId: id,
+    path,
+    title,
+    fileType: 'markdown',
+    localOnly,
+    contentHash: null,
+    wordCount: null,
+    characterCount: null,
+    snippet: null,
+    date,
+    emoji,
+    createdAt,
+    modifiedAt,
+    parsedContent: null,
+    fileSize,
+    tags: [],
+    properties: {},
+    wikiLinks: []
+  }
+
+  publishProjectionEvent({ type: 'note.upserted', note })
+}
+
+/**
+ * Tier 1 for a large-file-class file, whose body is never held as one string.
+ *
+ * The counts and the hash describe the whole file and come from a streaming
+ * scan; only `indexedHead` is materialised, and it is what reaches search and
+ * the snippet. Tags, properties and links stay empty on purpose: a log dump's
+ * `#hashtags` and `[[brackets]]` are not the user's vault structure, and the
+ * file is read-only anyway.
+ */
+export interface LargeFileBodySyncInput {
+  id: string
+  path: string
+  title: string
+  createdAt: string
+  modifiedAt: string
+  localOnly?: boolean
+  emoji?: string | null
+  wordCount: number
+  characterCount: number
+  contentHash: string
+  indexedHead: string
+}
+
+export function syncLargeFileBodyToCache(_db: IndexDb, input: LargeFileBodySyncInput): void {
+  const { id, path, title, createdAt, modifiedAt, wordCount, characterCount, contentHash } = input
+  const localOnly = input.localOnly ?? false
+  const emoji = input.emoji ?? null
+  const date = extractDateFromPath(path)
+
+  syncCanonicalMetadata({
+    id,
+    path,
+    title,
+    emoji,
+    localOnly,
+    journalDate: date,
+    createdAt,
+    modifiedAt
+  })
+
+  const note: MarkdownNoteProjection = {
+    kind: 'markdown',
+    noteId: id,
+    path,
+    title,
+    fileType: 'markdown',
+    localOnly,
+    contentHash,
+    wordCount,
+    characterCount,
+    snippet: createSnippet(input.indexedHead),
+    date,
+    emoji,
+    createdAt,
+    modifiedAt,
+    parsedContent: input.indexedHead,
+    tags: [],
+    properties: {},
+    wikiLinks: []
+  }
+
+  publishProjectionEvent({ type: 'note.upserted', note })
 }
 
 /**

--- a/apps/desktop/src/main/vault/notes-crud.ts
+++ b/apps/desktop/src/main/vault/notes-crud.ts
@@ -114,8 +114,12 @@ export interface NoteListItem {
   created: Date
   modified: Date
   tags: string[]
-  wordCount: number
-  snippet?: string
+  /**
+   * Null until the file's body has been read. Vault ingest lists a new file
+   * from `stat` alone, so a freshly added row is not measured yet.
+   */
+  wordCount: number | null
+  snippet?: string | null
   emoji?: string | null
   localOnly?: boolean
   properties?: Record<string, unknown>

--- a/apps/desktop/src/main/vault/notes-queries.ts
+++ b/apps/desktop/src/main/vault/notes-queries.ts
@@ -83,7 +83,9 @@ export function listNotes(options: NoteListOptions = {}): NoteListResponse {
     created: new Date(c.createdAt),
     modified: new Date(c.modifiedAt),
     tags: tagsMap.get(c.id) ?? [],
-    wordCount: c.wordCount ?? 0,
+    // Null, not zero: a row the ingest backfill has not reached yet has no
+    // measurement, and a file with no words is a different thing.
+    wordCount: c.wordCount ?? null,
     ...(treeShape ? {} : { snippet: c.snippet ?? undefined }),
     emoji: c.emoji,
     localOnly: c.localOnly ?? false,

--- a/apps/desktop/src/main/vault/rename-tracker.ts
+++ b/apps/desktop/src/main/vault/rename-tracker.ts
@@ -37,6 +37,11 @@ interface PendingDelete {
   id: string
   /** Content hash of the deleted file (from the cache row) */
   contentHash: string
+  /**
+   * Size + mtime of the deleted file, for a row whose body has not been read
+   * yet and therefore has no cached content hash. Null when a hash exists.
+   */
+  statKey: string | null
   /** Old file path (relative to vault) */
   path: string
   /** Timestamp when delete was detected */
@@ -58,6 +63,14 @@ interface PendingDelete {
  * the oldest pending delete matches first.
  */
 const pendingDeletes = new Map<string, PendingDelete[]>()
+
+/**
+ * The same pending deletes, keyed by `statKey`, for rows the tier-1 backfill
+ * has not reached yet. Those carry no content hash, and the new file cannot be
+ * hashed for free either — but a rename changes neither size nor mtime, and
+ * both are already on the cache row and in the `add` event's `stat`.
+ */
+const pendingDeletesByStat = new Map<string, PendingDelete[]>()
 
 let onRenameSyncCallback: ((id: string) => void) | null = null
 
@@ -87,12 +100,39 @@ function emitNoteRenamed(event: NoteRenamedEvent): void {
 // Public API
 // ============================================================================
 
-function removePending(entry: PendingDelete): void {
-  const bucket = pendingDeletes.get(entry.contentHash)
+function removeFromIndex(
+  index: Map<string, PendingDelete[]>,
+  key: string,
+  entry: PendingDelete
+): void {
+  const bucket = index.get(key)
   if (!bucket) return
-  const index = bucket.indexOf(entry)
-  if (index !== -1) bucket.splice(index, 1)
-  if (bucket.length === 0) pendingDeletes.delete(entry.contentHash)
+  const position = bucket.indexOf(entry)
+  if (position !== -1) bucket.splice(position, 1)
+  if (bucket.length === 0) index.delete(key)
+}
+
+function removePending(entry: PendingDelete): void {
+  removeFromIndex(pendingDeletes, entry.contentHash, entry)
+  if (entry.statKey !== null) removeFromIndex(pendingDeletesByStat, entry.statKey, entry)
+}
+
+function addToIndex(index: Map<string, PendingDelete[]>, key: string, entry: PendingDelete): void {
+  const bucket = index.get(key)
+  if (bucket) {
+    bucket.push(entry)
+  } else {
+    index.set(key, [entry])
+  }
+}
+
+function takeMatch(index: Map<string, PendingDelete[]>, key: string): PendingDelete | null {
+  const bucket = index.get(key)
+  if (!bucket || bucket.length === 0) return null
+  // FIFO: oldest pending delete wins.
+  const pending = bucket[0]
+  removePending(pending)
+  return pending
 }
 
 /**
@@ -103,12 +143,15 @@ function removePending(entry: PendingDelete): void {
  * @param contentHash - Content hash from the cache row
  * @param relativePath - Relative path of the deleted file
  * @param onRealDelete - Callback to execute if this is a real delete
+ * @param statKey - Size + mtime of the deleted file, for a row that has no
+ *   cached content hash yet. Ignored when a hash is available.
  */
 export function trackPendingDelete(
   id: string,
   contentHash: string,
   relativePath: string,
-  onRealDelete: () => Promise<void>
+  onRealDelete: () => Promise<void>,
+  statKey?: string | null
 ): void {
   // Clear any existing pending for this id (shouldn't happen, but be safe)
   clearPendingDelete(id)
@@ -118,6 +161,7 @@ export function trackPendingDelete(
   const entry: PendingDelete = {
     id,
     contentHash,
+    statKey: statKey ?? null,
     path: relativePath,
     timestamp: Date.now(),
     timeout: setTimeout(() => {
@@ -129,12 +173,8 @@ export function trackPendingDelete(
     onRealDelete
   }
 
-  const bucket = pendingDeletes.get(contentHash)
-  if (bucket) {
-    bucket.push(entry)
-  } else {
-    pendingDeletes.set(contentHash, [entry])
-  }
+  addToIndex(pendingDeletes, contentHash, entry)
+  if (entry.statKey !== null) addToIndex(pendingDeletesByStat, entry.statKey, entry)
 }
 
 /**
@@ -143,24 +183,26 @@ export function trackPendingDelete(
  * match is found, the pending delete is cleared and the caller is responsible
  * for replaying the rename through projection-safe write paths.
  *
- * @param contentHash - Content hash of the newly added file
+ * @param contentHash - Content hash of the newly added file, or null when it
+ *   was not worth computing (no delete was in flight, so no rename is possible)
  * @param newPath - Relative path of the new file
+ * @param statKey - Size + mtime of the new file, which matches a pending delete
+ *   whose body was never read and therefore has no hash to compare
  * @returns The matched note id and old path if this was a rename, null if new
  */
 export function checkForRename(
-  contentHash: string,
-  newPath: string
+  contentHash: string | null,
+  newPath: string,
+  statKey?: string | null
 ): { id: string; oldPath: string } | null {
-  const bucket = pendingDeletes.get(contentHash)
+  const pending =
+    (contentHash !== null ? takeMatch(pendingDeletes, contentHash) : null) ??
+    (statKey ? takeMatch(pendingDeletesByStat, statKey) : null)
 
-  if (!bucket || bucket.length === 0) {
+  if (!pending) {
     // No pending delete with this content - it's a new file
     return null
   }
-
-  // Found a match! This is a rename. FIFO: oldest pending delete wins.
-  const pending = bucket.shift() as PendingDelete
-  if (bucket.length === 0) pendingDeletes.delete(contentHash)
 
   logger.info(`Rename detected: ${pending.path} -> ${newPath}`)
   clearTimeout(pending.timeout)
@@ -196,6 +238,22 @@ export function clearAllPendingDeletes(): void {
     }
   }
   pendingDeletes.clear()
+  pendingDeletesByStat.clear()
+}
+
+/**
+ * Rename key for a file whose body has not been read. A rename changes neither
+ * size nor mtime, so the pair identifies the same bytes at a new path without
+ * opening the file.
+ */
+export function buildStatRenameKey(
+  fileSize: number | null,
+  modifiedAt: string | null
+): string | null {
+  if (fileSize === null || modifiedAt === null) return null
+  const modifiedMs = new Date(modifiedAt).getTime()
+  if (Number.isNaN(modifiedMs)) return null
+  return `${fileSize}:${modifiedMs}`
 }
 
 /**

--- a/apps/desktop/src/main/vault/watcher.test.ts
+++ b/apps/desktop/src/main/vault/watcher.test.ts
@@ -62,6 +62,19 @@ vi.mock('../notes/runtime-effects', () => ({
   syncNoteUpdate: vi.fn()
 }))
 
+// Both readers are spied through to the real implementation: the add path must
+// not open the file at all, by either route, and only a spy can tell "did not
+// read" from "read and ignored".
+vi.mock('./file-ops', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./file-ops')>()
+  return { ...actual, safeRead: vi.fn(actual.safeRead) }
+})
+
+vi.mock('./file-scan', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./file-scan')>()
+  return { ...actual, scanMarkdownFile: vi.fn(actual.scanMarkdownFile) }
+})
+
 vi.mock('../sync/crdt-provider', () => ({
   ORIGIN_LOCAL: 'local',
   getCrdtProvider: vi.fn(() => ({ getDoc: vi.fn(() => null) }))
@@ -76,6 +89,9 @@ import { enqueueJournalCreate, initializeJournalCrdt } from '../journal/runtime-
 import { syncNoteCreate } from '../notes/runtime-effects'
 import { updateNoteEmbedding } from '../inbox/suggestions'
 import { getConfig } from './index'
+import { safeRead } from './file-ops'
+import { scanMarkdownFile } from './file-scan'
+import { clearIngestBackfill, drainIngestBackfill } from './ingest-backfill'
 import { VaultWatcher, getWatcher, startWatcher, stopWatcher } from './watcher'
 
 describe('vault watcher', () => {
@@ -105,6 +121,7 @@ describe('vault watcher', () => {
 
   afterEach(async () => {
     await stopProjectionRuntime({ drain: true })
+    clearIngestBackfill()
     clearAllPendingDeletes()
     indexDb.close()
     dataDb.close()
@@ -195,6 +212,7 @@ describe('vault watcher', () => {
     })
 
     await watcher.handleFileAdd(notePath)
+    await drainIngestBackfill()
 
     // Fresh internal id assigned on add — resolve it via the path
     const cached = indexDb.db
@@ -276,6 +294,7 @@ describe('vault watcher', () => {
     })
 
     await watcher.handleFileAdd(notePath)
+    await drainIngestBackfill()
 
     const cached = indexDb.db
       .select()
@@ -311,6 +330,7 @@ describe('vault watcher', () => {
     })
 
     await watcher.handleFileAdd(notePath)
+    await drainIngestBackfill()
 
     const noteId = indexDb.db
       .select()
@@ -536,6 +556,7 @@ describe('vault watcher', () => {
     )
 
     await watcher.handleFileAdd(journalPath)
+    await drainIngestBackfill()
 
     expect(window.webContents.send).toHaveBeenCalledWith(
       JournalChannels.events.ENTRY_CREATED,
@@ -656,6 +677,7 @@ describe('vault watcher', () => {
 
     // #when
     await watcher.handleFileAdd(dumpPath)
+    await drainIngestBackfill()
 
     // #then — the row still appears, so the file is not hidden from the user
     const cached = indexDb.db
@@ -665,7 +687,9 @@ describe('vault watcher', () => {
       .get()
     expect(cached).toBeDefined()
 
-    // ...but ingest asks for no CRDT doc, so the BlockNote parse never starts
+    // ...and it is classified large-file, so it gets neither a CRDT doc nor a
+    // sync item. The call happens in the backfill, which is the first point
+    // that has measured the block bound.
     expect(syncNoteCreate).toHaveBeenCalledWith(cached!.id, expect.any(String), expect.any(Array), {
       sizeClass: 'large-file'
     })
@@ -684,6 +708,7 @@ describe('vault watcher', () => {
 
     // #when
     await watcher.handleFileAdd(journalPath)
+    await drainIngestBackfill()
 
     // #then — listed locally, but nothing leaves this device and nothing seeds
     expect(enqueueJournalCreate).not.toHaveBeenCalled()
@@ -701,6 +726,7 @@ describe('vault watcher', () => {
 
     // #when
     await watcher.handleFileAdd(journalPath)
+    await drainIngestBackfill()
 
     // #then
     expect(enqueueJournalCreate).toHaveBeenCalledWith(expect.any(String), '2026-05-12')
@@ -718,13 +744,270 @@ describe('vault watcher', () => {
 
     // #when
     await watcher.handleFileAdd(notePath)
+    await drainIngestBackfill()
 
-    // #then — the guard must not cost note-class files their CRDT doc
-    expect(syncNoteCreate).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
-      expect.any(Array),
-      { sizeClass: 'note' }
+    // #then — the guard must not cost note-class files their CRDT doc. It is
+    // the backfill that asks for it now: the add path never reads the file, so
+    // the block bound cannot be measured there.
+    const cached = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/ordinary.md'))
+      .get()
+    expect(syncNoteCreate).toHaveBeenCalledWith(cached!.id, 'ordinary', expect.any(Array), {
+      sizeClass: 'note'
+    })
+  })
+
+  // ==========================================================================
+  // Tier 0: the sidebar row comes from `stat`, path and title alone
+  // ==========================================================================
+
+  it('lists a newly added file without reading it', async () => {
+    // #given a file whose body is expensive to touch at ingest
+    const body = Array.from({ length: 5_000 }, (_, i) => `2026-08-15 line ${i} payload`).join('\n')
+    const notePath = createTestNote(vault, { title: 'pasted-dump', content: body })
+
+    const watcher = new VaultWatcher() as any
+    watcher.vaultPath = vault.path
+    vi.mocked(safeRead).mockClear()
+    vi.mocked(scanMarkdownFile).mockClear()
+    window.webContents.send.mockClear()
+
+    // #when
+    await watcher.handleFileAdd(notePath)
+
+    // #then the row is there, so the user sees the file immediately...
+    const cached = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/pasted-dump.md'))
+      .get()
+    expect(cached).toBeDefined()
+    expect(cached!.title).toBe('pasted-dump')
+
+    // ...and nothing on the add path opened the file, by either route: no
+    // whole-file read and no streaming pass over its bytes
+    expect(safeRead).not.toHaveBeenCalled()
+    expect(scanMarkdownFile).not.toHaveBeenCalled()
+
+    // ...so every content-derived field is unknown rather than wrong
+    expect(cached!.contentHash).toBeNull()
+    expect(cached!.wordCount).toBeNull()
+    expect(cached!.snippet).toBeNull()
+
+    const created = window.webContents.send.mock.calls.find(
+      ([channel]) => channel === NotesChannels.events.CREATED
     )
+    expect(created).toBeDefined()
+    const createdNote = (created![1] as { note: { wordCount: number | null; snippet?: string } })
+      .note
+    expect(createdNote.wordCount).toBeNull()
+    expect(createdNote.snippet).toBeUndefined()
+  })
+
+  // ==========================================================================
+  // Tier 1: the idle backfill fills in what tier 0 left unknown
+  // ==========================================================================
+
+  it('fills in word count, snippet, tags and search on the backfill', async () => {
+    const notePath = createTestNote(vault, {
+      title: 'later',
+      content: 'Some words here',
+      tags: ['alpha']
+    })
+
+    const watcher = new VaultWatcher() as any
+    watcher.vaultPath = vault.path
+
+    await watcher.handleFileAdd(notePath)
+    const before = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/later.md'))
+      .get()
+    expect(before!.wordCount).toBeNull()
+
+    window.webContents.send.mockClear()
+
+    // #when
+    await drainIngestBackfill()
+
+    // #then
+    const after = indexDb.db.select().from(noteCache).where(eq(noteCache.id, before!.id)).get()
+    expect(after!.wordCount).toBe(3)
+    expect(after!.snippet).toContain('Some words here')
+    expect(after!.contentHash).not.toBeNull()
+
+    const tags = indexDb.db
+      .select()
+      .from(noteTags)
+      .where(eq(noteTags.noteId, before!.id))
+      .all()
+      .map((row) => row.tag)
+    expect(tags).toEqual(['alpha'])
+
+    // the renderer's row is corrected in place
+    expect(window.webContents.send).toHaveBeenCalledWith(
+      NotesChannels.events.UPDATED,
+      expect.objectContaining({
+        id: before!.id,
+        changes: expect.objectContaining({ wordCount: 3 })
+      })
+    )
+  })
+
+  it('backfills the smallest file first', async () => {
+    // #given two files queued largest-first
+    const bigPath = createTestNote(vault, { title: 'big', content: 'word '.repeat(20_000) })
+    const smallPath = createTestNote(vault, { title: 'small', content: 'tiny' })
+
+    const watcher = new VaultWatcher() as any
+    watcher.vaultPath = vault.path
+    await watcher.handleFileAdd(bigPath)
+    await watcher.handleFileAdd(smallPath)
+
+    const bigId = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/big.md'))
+      .get()?.id
+    const smallId = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/small.md'))
+      .get()?.id
+
+    window.webContents.send.mockClear()
+
+    // #when
+    await drainIngestBackfill()
+
+    // #then the cheap row is corrected first, so a queued 250 MB file never
+    // holds up the notes the user is actually looking at
+    const updatedIds = window.webContents.send.mock.calls
+      .filter(([channel]) => channel === NotesChannels.events.UPDATED)
+      .map(([, payload]) => (payload as { id: string }).id)
+    expect(updatedIds).toEqual([smallId, bigId])
+  })
+
+  it('measures a file over the note ceiling without reading it as one string', async () => {
+    // #given a file past NOTE_MAX_BYTES. Reading one of these whole is what
+    // throws ERR_STRING_TOO_LONG once a file passes the V8 string ceiling.
+    const hugePath = path.join(vault.notesDir, 'huge.md')
+    fs.writeFileSync(hugePath, 'alpha beta gamma delta epsilon\n'.repeat(90_000), 'utf8')
+
+    const watcher = new VaultWatcher() as any
+    watcher.vaultPath = vault.path
+    vi.mocked(syncNoteCreate).mockClear()
+
+    await watcher.handleFileAdd(hugePath)
+    vi.mocked(safeRead).mockClear()
+
+    // #when
+    await drainIngestBackfill()
+
+    // #then the whole file was measured, but never held as one string
+    expect(safeRead).not.toHaveBeenCalled()
+
+    const after = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/huge.md'))
+      .get()
+    expect(after!.wordCount).toBe(5 * 90_000)
+    expect(after!.snippet).toContain('alpha beta gamma')
+    expect(after!.contentHash).not.toBeNull()
+
+    // large-file class by `stat` alone: no CRDT doc and no sync item, at
+    // either tier
+    expect(syncNoteCreate).not.toHaveBeenCalled()
+  })
+
+  it('detects a rename of a file whose body was never read', async () => {
+    // #given a file added but not yet backfilled, so the cache row carries no
+    // content hash for the rename tracker to match on
+    vi.useFakeTimers()
+    const oldPath = createTestNote(vault, { title: 'fresh', content: 'Not yet backfilled' })
+
+    const watcher = new VaultWatcher() as any
+    watcher.vaultPath = vault.path
+    await watcher.handleFileAdd(oldPath)
+
+    const cached = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/fresh.md'))
+      .get()
+    expect(cached!.contentHash).toBeNull()
+    const noteId = cached!.id
+
+    window.webContents.send.mockClear()
+
+    // #when Finder renames it before the backfill has run
+    const newPath = path.join(vault.notesDir, 'renamed.md')
+    fs.renameSync(oldPath, newPath)
+    await watcher.handleFileDelete(oldPath)
+    await watcher.handleFileAdd(newPath)
+    await vi.advanceTimersByTimeAsync(500)
+
+    // #then it is still the same note, not a delete plus a new one
+    const renamed = indexDb.db.select().from(noteCache).where(eq(noteCache.id, noteId)).get()
+    expect(renamed?.path).toBe('notes/renamed.md')
+    expect(renamed?.title).toBe('renamed')
+    expect(window.webContents.send).toHaveBeenCalledWith(
+      NotesChannels.events.RENAMED,
+      expect.objectContaining({ id: noteId, newPath: 'notes/renamed.md' })
+    )
+  })
+
+  it('keeps the measurements a rename cannot have changed', async () => {
+    // #given a note the backfill has already measured, carrying a property
+    const oldPath = createTestNote(vault, {
+      title: 'measured',
+      content: 'One two three four',
+      properties: { status: 'open' }
+    })
+
+    const watcher = new VaultWatcher() as any
+    watcher.vaultPath = vault.path
+    await watcher.handleFileAdd(oldPath)
+    await drainIngestBackfill()
+
+    const before = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/measured.md'))
+      .get()
+    expect(before!.wordCount).toBe(4)
+    const canonicalBefore = dataDb.db
+      .select()
+      .from(noteMetadata)
+      .where(eq(noteMetadata.id, before!.id))
+      .get()
+    expect(canonicalBefore?.propertyDefinitionNames).toEqual(['id', 'status', 'title'])
+
+    // #when the file is renamed, which changes no byte of its body. Asserted
+    // before the re-queued backfill runs: that is the window in which a
+    // stat-only write could erase state it knows nothing about.
+    const newPath = path.join(vault.notesDir, 'measured-renamed.md')
+    fs.renameSync(oldPath, newPath)
+    await watcher.handleFileDelete(oldPath)
+    await watcher.handleFileAdd(newPath)
+
+    // #then nothing the rename cannot have changed is blanked out
+    const after = indexDb.db.select().from(noteCache).where(eq(noteCache.id, before!.id)).get()
+    expect(after!.path).toBe('notes/measured-renamed.md')
+    expect(after!.wordCount).toBe(4)
+    expect(after!.snippet).toBe(before!.snippet)
+    expect(after!.contentHash).toBe(before!.contentHash)
+
+    const canonicalAfter = dataDb.db
+      .select()
+      .from(noteMetadata)
+      .where(eq(noteMetadata.id, before!.id))
+      .get()
+    expect(canonicalAfter?.path).toBe('notes/measured-renamed.md')
+    expect(canonicalAfter?.propertyDefinitionNames).toEqual(['id', 'status', 'title'])
   })
 })

--- a/apps/desktop/src/main/vault/watcher.ts
+++ b/apps/desktop/src/main/vault/watcher.ts
@@ -9,14 +9,27 @@
 
 import path from 'path'
 import fs from 'fs/promises'
+import type { Stats } from 'fs'
 import chokidar from 'chokidar'
 import type { FSWatcher } from 'chokidar'
 import { broadcastToAllWindows } from '../lib/window-broadcast'
 import { getConfig } from './index'
-import { parseNote, generateContentHash, extractProperties, extractTags } from './frontmatter'
+import {
+  parseNote,
+  generateContentHash,
+  extractProperties,
+  extractTitleFromPath
+} from './frontmatter'
 import { safeRead } from './file-ops'
+import { scanMarkdownFile } from './file-scan'
+import { enqueueIngestBackfill, clearIngestBackfill } from './ingest-backfill'
 import { generateNoteId } from '../lib/id'
-import { syncNoteToCache, syncFileToCache, deleteNoteFromCache } from './note-sync'
+import {
+  syncNoteToCache,
+  syncNoteStatToCache,
+  syncFileToCache,
+  deleteNoteFromCache
+} from './note-sync'
 import {
   getNoteCacheByPath,
   getNoteCacheById,
@@ -30,10 +43,11 @@ import {
   trackPendingDelete,
   checkForRename,
   clearAllPendingDeletes,
+  hasPendingDeletes,
+  buildStatRenameKey,
   processRename
 } from './rename-tracker'
 import { isSupportedPath, getFileType, getMimeType, getExtension } from '@memry/shared/file-types'
-import { classifyMarkdownContent } from '@memry/shared/markdown-class'
 import { createLogger } from '../lib/logger'
 import { trackMainError } from '../telemetry/diagnostics'
 import { isWritebackIgnored, wasRecentNetworkUpdate } from '../sync/crdt-writeback'
@@ -42,11 +56,7 @@ import { flushProjectionEvents } from '../projections'
 import { getCrdtProvider } from '../sync/crdt-provider'
 import { replaceNoteBodyInCrdt } from '../sync/crdt-feed'
 import { reconcileTaskCheckboxesFromMarkdown } from '../tasks/reconcile-markdown-tasks'
-import {
-  enqueueJournalCreate,
-  enqueueJournalDelete,
-  initializeJournalCrdt
-} from '../journal/runtime-effects'
+import { enqueueJournalDelete } from '../journal/runtime-effects'
 import { syncNoteCreate, syncNoteDelete, syncNoteUpdate } from '../notes/runtime-effects'
 import { normalizeRelativePath } from '../lib/paths'
 
@@ -63,8 +73,9 @@ interface NoteListItem {
   created: Date
   modified: Date
   tags: string[]
-  wordCount: number
-  snippet?: string
+  /** Null until the tier-1 backfill has measured the body. */
+  wordCount: number | null
+  snippet?: string | null
   localOnly?: boolean
 }
 
@@ -131,6 +142,12 @@ function isJournalPath(relativePath: string): boolean {
  */
 function extractJournalDate(relativePath: string): string {
   return extractDateFromPath(relativePath) ?? ''
+}
+
+/** Cache timestamps come back as an ISO string or a Date, depending on driver. */
+function toIsoOrNull(value: string | Date | null | undefined): string | null {
+  if (!value) return null
+  return value instanceof Date ? value.toISOString() : value
 }
 
 // Full fragment replace on external edits: lossy but acceptable since
@@ -266,6 +283,8 @@ export class VaultWatcher {
   async stop(): Promise<void> {
     // Clear any pending rename detections
     clearAllPendingDeletes()
+    // Drop queued backfills: they belong to the vault being closed.
+    clearIngestBackfill()
 
     if (this.watcher) {
       await this.watcher.close()
@@ -323,165 +342,143 @@ export class VaultWatcher {
   }
 
   /**
-   * Handle markdown file creation with full frontmatter parsing.
+   * Tier 0 of ingest: list the file from `stat`, the path and the filename.
+   *
+   * The file is not read. Everything a sidebar row needs is here, and reading
+   * the body to get the rest cost a multi-hundred-megabyte allocation and a
+   * main-process GC pause for a large paste. The idle backfill fills in word
+   * count, snippet, tags and search, and decides whether the file may have a
+   * CRDT doc — a decision that needs its largest block, which needs the body.
    */
   private async handleMarkdownFileAdd(
     absolutePath: string,
     relativePath: string,
     db: ReturnType<typeof getIndexDatabase>
   ): Promise<void> {
-    // Read and parse the file
-    const content = await safeRead(absolutePath)
-    if (!content) {
+    const stats = await fs.stat(absolutePath).catch(() => null)
+    if (!stats) {
       return
     }
 
-    const stats = await fs.stat(absolutePath).catch(() => null)
-    const parsed = parseNote(content, relativePath, stats ?? undefined)
-
-    // Check if this is a rename (content hash matches a pending delete);
-    // the internal id comes from the matched sidecar entry
-    const renameMatch = checkForRename(generateContentHash(content), relativePath)
+    const renameMatch = await this.matchPendingRename(absolutePath, relativePath, stats)
     if (renameMatch !== null) {
-      await this.applyMarkdownRename(db, content, parsed, relativePath, renameMatch)
+      await this.applyMarkdownRename(db, relativePath, stats, renameMatch)
       return
     }
 
     // Genuinely new external file: fresh internal id, fs-stat dates.
     // No watcher path writes files.
-    const noteId = parsed.id
+    const noteId = generateNoteId()
+    const title = extractTitleFromPath(relativePath)
+    const createdAt = stats.birthtime.toISOString()
+    const modifiedAt = stats.mtime.toISOString()
 
-    // Sync to cache using NoteSyncService (handles tags, properties, FTS, links)
-    const syncResult = syncNoteToCache(
+    syncNoteStatToCache(
       db,
       {
         id: noteId,
         path: relativePath,
-        fileContent: content,
-        frontmatter: parsed.frontmatter,
-        parsedContent: parsed.content,
-        title: parsed.title,
-        createdAt: parsed.created,
-        modifiedAt: parsed.modified
+        title,
+        createdAt,
+        modifiedAt,
+        fileSize: stats.size
       },
       { isNew: true }
     )
     void flushProjectionEvents()
 
-    const tags = syncResult.tags
-    // The CRDT tag array is what write-back serializes back into the file's
-    // `tags:` block, so it may only carry tags the file itself declares.
-    // `syncResult.tags` merges the body's `#hashtag`s in for the index; seeding
-    // those would inject a `tags:` block into a note that never had one, the
-    // first time it is opened — "opening a note modified it" (#1454).
-    const declaredTags = extractTags(parsed.frontmatter)
-    const properties = extractProperties(parsed.frontmatter)
-
-    if (tags.length > 0) {
-      ensureTagDefinitions(getDatabase(), tags)
-    }
-
     const noteListItem: NoteListItem = {
       id: noteId,
       path: relativePath,
-      title: parsed.title,
-      created: new Date(parsed.created),
-      modified: new Date(parsed.modified),
-      tags,
-      wordCount: syncResult.wordCount,
-      snippet: syncResult.snippet,
+      title,
+      created: new Date(createdAt),
+      modified: new Date(modifiedAt),
+      tags: [],
+      // Null, not zero: the body has not been read, so the count is unknown
+      // rather than empty. The backfill's UPDATED event replaces it.
+      wordCount: null,
       localOnly: false
     }
 
-    // A large-file-class file still gets a sidebar row here, but never a Y.Doc
-    // and never a sync item. No Y.Doc, because seeding one runs the BlockNote
-    // markdown parse over the whole file on the main process with no yield
-    // point, and that parse is the freeze: its cost tracks single-block size,
-    // so a blank-line-free dump costs 14x the same bytes shaped as paragraphs.
-    // No sync item, because the body only travels in that Y.Doc — the other
-    // device would get a row with nothing behind it.
-    const classification = classifyMarkdownContent(content)
-    const isLargeFile = classification.sizeClass === 'large-file'
-    if (isLargeFile) {
-      logger.warn('Ingested file is large-file class; not seeding or syncing it', {
-        path: relativePath,
-        reason: classification.reason,
-        fileBytes: classification.fileBytes,
-        largestBlockBytes: classification.largestBlockBytes
-      })
-    }
-
-    // Enqueue sync push so other devices learn about the new file
-    if (isJournalPath(relativePath)) {
-      const journalDate = extractJournalDate(relativePath)
-      if (!isLargeFile) {
-        enqueueJournalCreate(noteId, journalDate)
-        void initializeJournalCrdt(noteId, journalDate, declaredTags)
-      }
-    } else {
-      syncNoteCreate(noteId, parsed.title, declaredTags, {
-        sizeClass: classification.sizeClass
-      })
-    }
+    // No sync item and no Y.Doc here. Both are gated on the file's size class,
+    // and the class is not known yet: it needs the largest block, which needs
+    // the body, which this path deliberately never reads. The backfill measures
+    // the file and makes both calls once the answer is in — so a large file is
+    // never even transiently given a sync item to withdraw.
 
     // Emit event to renderer
     emitEvent(NotesChannels.events.CREATED, {
       note: noteListItem,
-      properties, // T012: Include properties in event
+      properties: {},
       source: 'external'
     })
 
-    // Also emit journal event if this is a journal entry
-    if (isJournalPath(relativePath)) {
-      const journalDate = extractJournalDate(relativePath)
-      emitEvent(JournalChannels.events.ENTRY_CREATED, {
-        date: journalDate,
-        entry: {
-          date: journalDate,
-          content: parsed.content,
-          tags,
-          wordCount: syncResult.wordCount,
-          characterCount: syncResult.characterCount,
-          modified: new Date(parsed.modified),
-          created: new Date(parsed.created)
-        },
-        source: 'external'
-      })
-    }
+    enqueueIngestBackfill({ noteId, absolutePath, relativePath, fileBytes: stats.size })
+  }
+
+  /**
+   * Rename detection is the one thing on the add path that still needs the
+   * file's content hash — chokidar reports a rename as `unlink` then `add`, and
+   * the hash is what ties the two together.
+   *
+   * It is only computed while a delete is actually in flight, so an ordinary
+   * paste pays nothing for it, and it is computed by streaming, so even a file
+   * past V8's string ceiling is hashable. A pending delete whose own row was
+   * never backfilled has no cached hash to compare against; that one matches on
+   * size and mtime instead, which a rename leaves untouched.
+   */
+  private async matchPendingRename(
+    absolutePath: string,
+    relativePath: string,
+    stats: Stats
+  ): Promise<{ id: string; oldPath: string } | null> {
+    if (!hasPendingDeletes()) return null
+
+    const scan = await scanMarkdownFile(absolutePath, 0)
+    const statKey = buildStatRenameKey(stats.size, stats.mtime.toISOString())
+
+    return checkForRename(scan?.contentHash ?? null, relativePath, statKey)
   }
 
   private async applyMarkdownRename(
     db: ReturnType<typeof getIndexDatabase>,
-    fileContent: string,
-    parsed: ReturnType<typeof parseNote>,
     relativePath: string,
+    stats: Stats,
     renameMatch: { id: string; oldPath: string }
   ): Promise<void> {
     const { id, oldPath } = renameMatch
     const cached = getNoteCacheById(db, id)
 
-    const syncResult = syncNoteToCache(
+    // A rename changes the path and the title and nothing else, so the row's
+    // body-derived state stays valid and is left alone — a stat-only update
+    // never writes nulls over it. The backfill re-measures at the new path,
+    // which is what the journal date and the search row are keyed off.
+    syncNoteStatToCache(
       db,
       {
         id,
         path: relativePath,
-        fileContent,
-        frontmatter: parsed.frontmatter,
-        parsedContent: parsed.content,
-        title: parsed.title,
-        createdAt: cached?.createdAt ?? parsed.created,
-        modifiedAt: parsed.modified,
+        title: extractTitleFromPath(relativePath),
+        createdAt: cached?.createdAt ?? stats.birthtime.toISOString(),
+        modifiedAt: stats.mtime.toISOString(),
+        fileSize: stats.size,
         localOnly: cached?.localOnly ?? false,
         emoji: cached?.emoji ?? null
       },
       { isNew: false }
     )
-
-    if (syncResult.tags.length > 0) {
-      ensureTagDefinitions(getDatabase(), syncResult.tags)
-    }
+    await flushProjectionEvents()
 
     processRename(id, oldPath, relativePath)
+
+    if (this.vaultPath) {
+      enqueueIngestBackfill({
+        noteId: id,
+        absolutePath: path.join(this.vaultPath, relativePath),
+        relativePath,
+        fileBytes: stats.size
+      })
+    }
   }
 
   /**
@@ -740,36 +737,49 @@ export class VaultWatcher {
       const journalDate = isJournal ? extractJournalDate(relativePath) : null
 
       // Track as pending delete - wait for potential rename (matching 'add'
-      // event with the same content hash). A missing hash never matches, so
-      // it degrades to a real delete after the window.
-      trackPendingDelete(cached.id, cached.contentHash ?? '', relativePath, async () => {
-        // Enqueue sync delete BEFORE cache removal (enqueue reads cache for vector clock)
-        if (isJournal && journalDate) {
-          enqueueJournalDelete(cached.id, journalDate)
-        } else {
-          syncNoteDelete(cached.id)
-        }
+      // event with the same content hash). A row the tier-1 backfill has not
+      // reached yet has no hash, so it carries size + mtime instead; without
+      // that, renaming a just-pasted file would read as a delete plus a new
+      // note. A row with neither never matches and degrades to a real delete
+      // after the window.
+      const statKey = cached.contentHash
+        ? null
+        : buildStatRenameKey(cached.fileSize ?? null, toIsoOrNull(cached.modifiedAt))
 
-        deleteNoteFromCache(db, cached.id)
-        void flushProjectionEvents()
+      trackPendingDelete(
+        cached.id,
+        cached.contentHash ?? '',
+        relativePath,
+        async () => {
+          // Enqueue sync delete BEFORE cache removal (enqueue reads cache for vector clock)
+          if (isJournal && journalDate) {
+            enqueueJournalDelete(cached.id, journalDate)
+          } else {
+            syncNoteDelete(cached.id)
+          }
 
-        // Emit delete event
-        emitEvent(NotesChannels.events.DELETED, {
-          id: cached.id,
-          path: relativePath,
-          source: 'external'
-        })
+          deleteNoteFromCache(db, cached.id)
+          void flushProjectionEvents()
 
-        // Also emit journal event if this is a journal entry
-        if (isJournal && journalDate) {
-          emitEvent(JournalChannels.events.ENTRY_DELETED, {
-            date: journalDate,
+          // Emit delete event
+          emitEvent(NotesChannels.events.DELETED, {
+            id: cached.id,
+            path: relativePath,
             source: 'external'
           })
-        }
 
-        await Promise.resolve()
-      })
+          // Also emit journal event if this is a journal entry
+          if (isJournal && journalDate) {
+            emitEvent(JournalChannels.events.ENTRY_DELETED, {
+              date: journalDate,
+              source: 'external'
+            })
+          }
+
+          await Promise.resolve()
+        },
+        statKey
+      )
     } catch (error) {
       this.onError?.(error instanceof Error ? error : new Error(String(error)))
     }

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -232,3 +232,26 @@ but opens it read-only rather than in the editor, exactly as if you had dropped 
 
 Notes you already have keep working exactly as before — nothing is re-scanned or re-indexed, and
 existing notes under these limits are unaffected.
+
+## When a New File Appears in the Sidebar
+
+Dropping a file into your vault folder from Finder or Explorer shows it in the sidebar
+straight away, whatever its size. To draw that row memrynote reads only the filename and the
+file's timestamps — not the file itself. A quarter-gigabyte paste costs the same as a one-line
+note.
+
+Everything that needs the file's contents happens a moment later, in the background, smallest
+file first:
+
+- word count
+- the preview snippet under the note title
+- search
+
+So a brand-new row can briefly show no word count and no snippet. That is the measurement not
+having arrived yet, not an empty note — it fills itself in within a second or two for ordinary
+notes, and a little later for very large ones. Nothing is lost if you quit before it finishes;
+the file is measured again next time it changes.
+
+Very large files are measured in pieces rather than loaded all at once, so even a file too big
+to fit in memory gets a word count and becomes searchable. For those, search covers the
+beginning of the file rather than all of it.

--- a/packages/contracts/src/notes-api.ts
+++ b/packages/contracts/src/notes-api.ts
@@ -81,6 +81,11 @@ export interface Note {
  * per note across IPC on every list invalidation. Every field a caller can
  * rely on unconditionally stays required, so `'tree'` rows are still ordinary
  * `NoteListItem`s and no existing consumer needs a guard.
+ *
+ * `wordCount` and `snippet` are separately nullable, for a different reason:
+ * vault ingest lists a new file from `stat` alone and reads it later, so a
+ * freshly added row carries no measurements yet. Null means "not measured",
+ * never "empty".
  */
 export interface NoteListItem {
   id: string
@@ -89,8 +94,9 @@ export interface NoteListItem {
   created: Date
   modified: Date
   tags: string[]
-  wordCount: number
-  snippet?: string // First 200 chars of content — omitted when fields: 'tree'
+  /** Null until the file's body has been read. */
+  wordCount: number | null
+  snippet?: string | null // First 200 chars of content — omitted when fields: 'tree'
   emoji?: string | null // Emoji icon for visual identification
   localOnly?: boolean
 }

--- a/packages/rpc/src/notes.ts
+++ b/packages/rpc/src/notes.ts
@@ -50,8 +50,12 @@ export interface NoteListItem {
   created: Date
   modified: Date
   tags: string[]
-  wordCount: number
-  snippet?: string
+  /**
+   * Null until the file's body has been read. Vault ingest lists a new file
+   * from `stat` alone, so a freshly added row is not measured yet.
+   */
+  wordCount: number | null
+  snippet?: string | null
   emoji?: string | null
   localOnly?: boolean
   fileType?: 'markdown' | 'pdf' | 'image' | 'audio' | 'video'


### PR DESCRIPTION
Closes #1460. Part of EPIC #1468. Builds on #1474.

## What was still on the add path

The CRDT seed is gone from ingest (#1459), but `handleMarkdownFileAdd` still did all of this before emitting the sidebar row:

1. `safeRead` — the whole file into one JS string
2. `parseNote` / gray-matter over it
3. `generateContentHash`, char by char
4. the full parsed body onto a projection event
5. `flushProjectionEvents` → FTS insert

At 250 MB that is a multi-hundred-megabyte allocation and a major GC pause, to draw one row. Everything the row actually needs is a `stat` and a filename.

## Tiers

**T0, on `add`, O(1).** `stat` + path + title produce the row. The file is not read, for either file class. `wordCount` is published as `null` — unknown, not zero.

**T1, on idle, smallest file first.** `vault/ingest-backfill.ts`. Metadata, tags, links, search, and the CRDT decision, which has to live here: note class needs the *largest block* measured, and the add path never reads the file.

- Note class (≤ `NOTE_MAX_BYTES`) is cheap to read whole and takes the ordinary parse-and-sync path — identical output to before.
- Large-file class is streamed through `vault/file-scan.ts` in 64 KB chunks. Nothing is ever held as one string, so a file past V8's 536,870,888-character ceiling is measured instead of throwing `ERR_STRING_TOO_LONG`. The first 256 KB reach search and the snippet; the counts and the hash describe the whole file.

Tags, properties and links stay empty for large-file class on purpose — a log dump's `#hashtags` are not the user's vault structure, and the file is read-only anyway.

## Keeping rename detection

Rename detection is the one thing on the add path that still needs a content hash: chokidar reports a Finder rename as `unlink` then `add`, and the hash ties them together. Two changes:

- **The hash is computed only while a delete is in flight** (`hasPendingDeletes()`), so an ordinary paste pays nothing — and it is computed by *streaming*. `createContentHasher` folds djb2 chunk by chunk to exactly the value `generateContentHash` returns for the whole string (asserted in `file-scan.test.ts`). A file too big to read is now hashable where it previously was not.
- **A pending delete whose own row was never backfilled has no cached hash to match against.** Renaming a just-pasted file would have read as a delete plus a new note, losing its id. Those rows also register under size + mtime, which a rename leaves untouched.

## Contract

`NoteListItem.wordCount` becomes `number | null` and `snippet` becomes `string | null` in `packages/contracts`, `packages/rpc`, `vault/notes-crud.ts` and the watcher's local copy. Null means "not measured yet". `pnpm ipc:generate` then `pnpm ipc:check` are green; no renderer surface dereferences the field (folder views use `NoteWithProperties`, a separate contract, unchanged).

## Backward compatibility

No migration, no reindex, no FTS rebuild, no `FileType` change. The cache columns were already nullable — `persistFileNote` has always written nulls into them.

The one hazard is a stat-only projection landing on a row that already has real measurements: it updates identity only and never writes nulls over them. Covered by *"keeps the measurements a rename cannot have changed"*.

## Mutation checks

Every guard was reverted and the suite re-run; each went red on the test that owns it.

| # | reverted | test that went red |
|---|---|---|
| M1 | `hasPendingDeletes()` guard | lists a newly added file without reading it |
| M2 | tier-0 nulls → zeros | lists a newly added file… (+2) |
| M3 | `bodyUnread` update guard | keeps the measurements a rename cannot have changed |
| M4 | search-projector null skip | leaves a note out of the index until its body has been read |
| M5 | streaming hash → head only | hashes a multi-chunk file to the same value as hashing it whole |
| M6 | smallest-first ordering | backfills the smallest file first |
| M7 | stat-key rename fallback | detects a rename of a file whose body was never read (+1) |
| M8 | bounded head | keeps only the requested head in memory |
| M9 | word count across chunks | counts words and characters across chunk boundaries (+2) |
| M10 | backfill CRDT seed | still initiates a CRDT seed for a well-formed note |

## Verification

`pnpm lint` · `pnpm typecheck --force` · `typecheck:test` · `check:architecture` · `check:contracts` · `i18n:check` · `ipc:generate` + `ipc:check` · `git diff --check` — all exit 0.

Suites run per project from `apps/desktop`: shared 2497 · main 6589 · main-integration 9 · preload 30 · renderer 7058, all passing.

`pnpm docs:impact --strict` green after the docs update; `pnpm docs:build` green.