### PR TITLE
fix(inbox): sync everything a filed inbox item produces

### DIFF
--- a/apps/desktop/src/main/inbox/filing.test.ts
+++ b/apps/desktop/src/main/inbox/filing.test.ts
@@ -1988,4 +1988,77 @@ describe('Inbox Filing Operations', () => {
       expect(mockSyncNoteCreate).toHaveBeenCalledWith('note-123', 'Test Note', ['inbox'])
     })
   })
+
+  // ==========================================================================
+  // A filed binary needs BOTH halves. `syncNoteCreate` alone would seed a row
+  // whose `attachmentId` is null forever — the peer would draw a file it can
+  // never download. The vault watcher does both for a binary that lands in the
+  // vault on its own, but `handleFileAdd` bails on a path the index cache
+  // already holds, and `indexFiledBinary` fills that cache first every time.
+  // ==========================================================================
+  describe('filing pushes the binary it files', () => {
+    it('fileToFolder (binary) enqueues the note and queues the blob upload', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'image-1', type: 'image', title: 'Shot' })
+      updateInboxItem(itemId, { attachmentPath: 'attachments/inbox/image-1/shot.png' })
+
+      await fileToFolder(itemId, 'projects')
+
+      expect(mockSyncNoteCreate).toHaveBeenCalledWith('file-note-id', 'Shot', [])
+      expect(mockEmitNoteAttachmentSaved).toHaveBeenCalledWith(
+        'file-note-id',
+        '/mock-vault/projects/Shot.png'
+      )
+    })
+
+    it('linkToNotes (binary) enqueues the note and queues the blob upload', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'image-2', type: 'image', title: 'Shot' })
+      updateInboxItem(itemId, { attachmentPath: 'attachments/inbox/image-2/shot.png' })
+      mockGetNoteById.mockResolvedValue({
+        id: 'target-note',
+        content: '# Target',
+        path: 'notes/target.md'
+      })
+
+      await linkToNotes(itemId, [{ kind: 'note', noteId: 'target-note' }])
+
+      expect(mockSyncNoteCreate).toHaveBeenCalledWith('file-note-id', 'Shot', [])
+      expect(mockEmitNoteAttachmentSaved).toHaveBeenCalledWith(
+        'file-note-id',
+        expect.stringContaining('Shot.png')
+      )
+    })
+
+    it('does not enqueue anything when the binary could not be indexed', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'image-3', type: 'image', title: 'Shot' })
+      updateInboxItem(itemId, { attachmentPath: 'attachments/inbox/image-3/shot.png' })
+      // indexFiledBinary swallows the failure and returns null (#800): filing
+      // still succeeds, but there is no note id to push.
+      mockIndexBinaryFile.mockRejectedValue(new Error('index db down'))
+
+      const result = await fileToFolder(itemId, 'projects')
+
+      expect(result.success).toBe(true)
+      expect(mockSyncNoteCreate).not.toHaveBeenCalled()
+      expect(mockEmitNoteAttachmentSaved).not.toHaveBeenCalled()
+    })
+
+    it('keeps the filing when the binary sync enqueue throws', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'image-4', type: 'image', title: 'Shot' })
+      updateInboxItem(itemId, { attachmentPath: 'attachments/inbox/image-4/shot.png' })
+      mockSyncNoteCreate.mockImplementation(() => {
+        throw new Error('sync service down')
+      })
+
+      const result = await fileToFolder(itemId, 'projects')
+
+      expect(result.success).toBe(true)
+      const row = testDb.db.select().from(inboxItems).where(eq(inboxItems.id, itemId)).get()
+      expect(row?.filedAt).toBeTruthy()
+      expect(mockTrackMainError).toHaveBeenCalledWith(
+        'inbox',
+        'filed_binary_sync_enqueue',
+        expect.any(Error)
+      )
+    })
+  })
 })

--- a/apps/desktop/src/main/inbox/filing.test.ts
+++ b/apps/desktop/src/main/inbox/filing.test.ts
@@ -77,13 +77,22 @@ vi.mock('fs', () => ({
 const mockReadFile = vi.fn()
 const mockSaveAttachment = vi.fn()
 const mockEmitNoteAttachmentSaved = vi.fn()
+const mockSyncNoteCreate = vi.fn()
 
 vi.mock('../vault/attachments', () => ({
   saveAttachment: (...args: unknown[]) => mockSaveAttachment(...args)
 }))
 
+// `../notes/domain` runs for real here: it is the wrapper that turns a vault
+// write into a synced note, so mocking it would hide the very call these tests
+// exist to pin down. Only its sync side effects are stubbed.
 vi.mock('../notes/runtime-effects', () => ({
-  emitNoteAttachmentSaved: (...args: unknown[]) => mockEmitNoteAttachmentSaved(...args)
+  emitNoteAttachmentSaved: (...args: unknown[]) => mockEmitNoteAttachmentSaved(...args),
+  syncNoteCreate: (...args: unknown[]) => mockSyncNoteCreate(...args),
+  syncNoteUpdate: vi.fn(),
+  syncNoteDelete: vi.fn(),
+  setNoteLocalOnlyState: vi.fn(),
+  cleanupProjectLinksForDeletedNote: vi.fn()
 }))
 
 const mockCreateNote = vi.fn()
@@ -225,12 +234,14 @@ describe('Inbox Filing Operations', () => {
     mockReadFile.mockReset().mockResolvedValue(Buffer.from('png-bytes'))
     mockSaveAttachment.mockReset()
     mockEmitNoteAttachmentSaved.mockReset()
+    mockSyncNoteCreate.mockReset()
     vi.mocked(getStatus).mockReturnValue({ isOpen: true, path: '/mock-vault' } as never)
 
     mockCreateNote.mockResolvedValue({
       id: 'note-123',
       path: 'notes/test-note.md',
-      title: 'Test Note'
+      title: 'Test Note',
+      frontmatter: { tags: ['inbox'] }
     })
   })
 
@@ -1501,7 +1512,12 @@ describe('Inbox Filing Operations', () => {
       updateInboxItem(itemId, {
         attachmentPath: 'attachments/inbox/image-embed-4/screenshot.png'
       })
-      mockCreateNote.mockResolvedValue({ id: 'fresh-note', path: 'Trip.md', title: 'Trip' })
+      mockCreateNote.mockResolvedValue({
+        id: 'fresh-note',
+        path: 'Trip.md',
+        title: 'Trip',
+        frontmatter: {}
+      })
       mockGetNoteById.mockResolvedValue({ id: 'fresh-note', content: '', path: 'Trip.md' })
       mockSaveAttachment.mockResolvedValue({
         success: true,
@@ -1571,7 +1587,8 @@ describe('Inbox Filing Operations', () => {
       mockCreateNote.mockResolvedValue({
         id: 'fresh-note',
         path: 'projects/Trip.md',
-        title: 'Trip'
+        title: 'Trip',
+        frontmatter: {}
       })
       mockGetNoteById.mockResolvedValue({
         id: 'fresh-note',
@@ -1736,9 +1753,9 @@ describe('Inbox Filing Operations', () => {
         { id: 'item-3', title: 'Item 3' }
       ])
       mockCreateNote
-        .mockResolvedValueOnce({ id: 'note-1', path: 'p1.md', title: 'N1' })
-        .mockResolvedValueOnce({ id: 'note-2', path: 'p2.md', title: 'N2' })
-        .mockResolvedValueOnce({ id: 'note-3', path: 'p3.md', title: 'N3' })
+        .mockResolvedValueOnce({ id: 'note-1', path: 'p1.md', title: 'N1', frontmatter: {} })
+        .mockResolvedValueOnce({ id: 'note-2', path: 'p2.md', title: 'N2', frontmatter: {} })
+        .mockResolvedValueOnce({ id: 'note-3', path: 'p3.md', title: 'N3', frontmatter: {} })
 
       const result = await bulkFileToFolder(['item-1', 'item-2', 'item-3'], 'archive')
 
@@ -1752,7 +1769,12 @@ describe('Inbox Filing Operations', () => {
         { id: 'item-1', title: 'Item 1' },
         { id: 'item-2', title: 'Item 2' }
       ])
-      mockCreateNote.mockResolvedValue({ id: 'note-1', path: 'p1.md', title: 'N1' })
+      mockCreateNote.mockResolvedValue({
+        id: 'note-1',
+        path: 'p1.md',
+        title: 'N1',
+        frontmatter: {}
+      })
 
       await bulkFileToFolder(['item-1', 'item-2'], 'folder', ['bulk-tag'])
 
@@ -1767,7 +1789,12 @@ describe('Inbox Filing Operations', () => {
         { id: 'item-1', title: 'Item 1' },
         { id: 'item-2', title: 'Item 2', filedAt: new Date().toISOString() }
       ])
-      mockCreateNote.mockResolvedValue({ id: 'note-1', path: 'p1.md', title: 'N1' })
+      mockCreateNote.mockResolvedValue({
+        id: 'note-1',
+        path: 'p1.md',
+        title: 'N1',
+        frontmatter: {}
+      })
 
       const result = await bulkFileToFolder(['item-1', 'item-2', 'nonexistent'], 'folder')
 
@@ -1784,7 +1811,12 @@ describe('Inbox Filing Operations', () => {
         { id: 'item-2', title: 'Item 2', filedAt: new Date().toISOString() },
         { id: 'item-3', title: 'Item 3' }
       ])
-      mockCreateNote.mockResolvedValue({ id: 'note-1', path: 'p1.md', title: 'N1' })
+      mockCreateNote.mockResolvedValue({
+        id: 'note-1',
+        path: 'p1.md',
+        title: 'N1',
+        frontmatter: {}
+      })
 
       const result = await bulkFileToFolder(['item-1', 'item-2', 'item-3'], 'folder')
 
@@ -1899,6 +1931,61 @@ describe('Inbox Filing Operations', () => {
         'filing_sync_enqueue',
         expect.any(Error)
       )
+    })
+  })
+
+  // ==========================================================================
+  // The note filing produces has to reach the other devices too. The inbox row
+  // pushes the moment it is filed, so a note created without its own push is
+  // the worst possible split: the peer hides the item from the Inbox and never
+  // draws the note the item became. Nothing else rescues it inside the session
+  // — `seedUnclockedNotes` only runs from a full sync (app start / reconnect),
+  // and the vault watcher enqueues creates for binaries, not markdown.
+  // ==========================================================================
+  describe('filing pushes the note it creates', () => {
+    it('fileToFolder (text) enqueues a note create', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'item-1', type: 'note', title: 'Test Item' })
+
+      await fileToFolder(itemId, 'projects')
+
+      expect(mockSyncNoteCreate).toHaveBeenCalledWith('note-123', 'Test Note', ['inbox'])
+    })
+
+    it('convertToNote enqueues a note create', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'item-1', type: 'note', title: 'Test Item' })
+
+      await convertToNote(itemId)
+
+      expect(mockSyncNoteCreate).toHaveBeenCalledWith('note-123', 'Test Note', ['inbox'])
+    })
+
+    it('convertToReminder enqueues a note create', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'item-1', type: 'note', title: 'Test Item' })
+
+      await convertToReminder(itemId, { remindAt: '2099-01-02T09:00:00.000Z' })
+
+      expect(mockSyncNoteCreate).toHaveBeenCalledWith('note-123', 'Test Note', ['inbox'])
+    })
+
+    it('linkToNotes enqueues a note create for the note it mints', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'item-1', type: 'note', title: 'Test Item' })
+      mockGetNoteById.mockResolvedValue({
+        id: 'target-note',
+        content: '# Target',
+        path: 'notes/target.md'
+      })
+
+      await linkToNotes(itemId, [{ kind: 'note', noteId: 'target-note' }])
+
+      expect(mockSyncNoteCreate).toHaveBeenCalledWith('note-123', 'Test Note', ['inbox'])
+    })
+
+    it('linkToNotes enqueues a note create for a staged new-note target', async () => {
+      const itemId = seedInboxItem(testDb.db, { id: 'item-1', type: 'note', title: 'Test Item' })
+
+      await linkToNotes(itemId, [{ kind: 'new', title: 'Staged Note' }])
+
+      expect(mockSyncNoteCreate).toHaveBeenCalledWith('note-123', 'Test Note', ['inbox'])
     })
   })
 })

--- a/apps/desktop/src/main/inbox/filing.ts
+++ b/apps/desktop/src/main/inbox/filing.ts
@@ -39,7 +39,7 @@ import {
 import type { FilingAction } from '@memry/contracts/inbox-api'
 import type { FilingTarget, ImageFilingMode } from '@memry/domain-inbox'
 import { saveAttachment } from '../vault/attachments'
-import { emitNoteAttachmentSaved } from '../notes/runtime-effects'
+import { emitNoteAttachmentSaved, syncNoteCreate } from '../notes/runtime-effects'
 import { encodeAttachmentUrl } from '../import/_shared/attachment-markdown'
 import type { NoteListItem } from '@memry/contracts/notes-api'
 import { upsertCalendarEvent } from '../calendar/repositories/calendar-events-repository'
@@ -255,6 +255,43 @@ async function indexFiledBinary(
 function announceFiledBinary(note: NoteListItem | null): void {
   if (!note) return
   broadcastToAllWindows(NotesChannels.events.CREATED, { note, source: 'internal' })
+}
+
+/**
+ * Push a filed binary to the other devices: the note row, and the bytes it
+ * points at.
+ *
+ * The vault watcher does both halves for a binary that appears in the vault on
+ * its own (`handleNonMarkdownFileAdd`), but `handleFileAdd` returns early on a
+ * path the index cache already holds — and `indexFiledBinary` fills that cache
+ * the moment the file lands, so filing always wins that race. Nobody else picks
+ * it up.
+ *
+ * Both calls matter and for different reasons. Without `syncNoteCreate` there
+ * is no sync item, so the peer has no row until this device's next full sync
+ * seeds the clock-less one. Without the saved-attachment event no upload is
+ * ever queued, and a binary's push payload carries `attachmentId` — which stays
+ * null forever — so that seeded row would point the peer at a blob it can never
+ * download. A row for a file that cannot arrive is worse than no row.
+ *
+ * Tags stay behind either way: the binary push payload has no tags field. That
+ * is a protocol gap, not something this call can close.
+ *
+ * Best-effort like the other filing enqueues: the file has already moved, so a
+ * sync outage must not fail a filing that succeeded — but it has to stay
+ * countable.
+ */
+function syncFiledBinary(note: NoteListItem | null, absolutePath: string): void {
+  if (!note) return
+  try {
+    // `[]` for tags mirrors the watcher: a binary has no frontmatter to seed a
+    // CRDT tag array from.
+    syncNoteCreate(note.id, note.title, [])
+    emitNoteAttachmentSaved(note.id, absolutePath)
+  } catch (error) {
+    log.warn('Filed binary sync enqueue failed; the file is filed locally', error)
+    trackMainError('inbox', 'filed_binary_sync_enqueue', error)
+  }
 }
 
 /**
@@ -640,8 +677,11 @@ async function fileBinaryToFolder(
     // Calculate relative path from vault root for storage
     const relativePath = normalizeRelativePath(path.relative(vaultPath, finalPath))
 
-    // Index the filed file and announce it, so the tree picks it up live.
-    announceFiledBinary(await indexFiledBinary(relativePath, finalPath, mergedTags))
+    // Index the filed file, announce it so the tree picks it up live, and push
+    // it — the watcher that would normally do the pushing never sees this file.
+    const filedBinary = await indexFiledBinary(relativePath, finalPath, mergedTags)
+    announceFiledBinary(filedBinary)
+    syncFiledBinary(filedBinary, finalPath)
 
     // Mark inbox item as filed
     markItemAsFiled(itemId, relativePath, 'folder')
@@ -1310,8 +1350,11 @@ async function linkBinaryToNotes(
     // Calculate relative path for storage
     const relativePath = normalizeRelativePath(path.relative(vaultPath, finalPath))
 
-    // Index the filed file and announce it, so the tree picks it up live.
-    announceFiledBinary(await indexFiledBinary(relativePath, finalPath, mergedTags))
+    // Index the filed file, announce it so the tree picks it up live, and push
+    // it — the watcher that would normally do the pushing never sees this file.
+    const filedBinary = await indexFiledBinary(relativePath, finalPath, mergedTags)
+    announceFiledBinary(filedBinary)
+    syncFiledBinary(filedBinary, finalPath)
 
     // Mark inbox item as filed
     markItemAsFiled(itemId, relativePath, 'linked')

--- a/apps/desktop/src/main/inbox/filing.ts
+++ b/apps/desktop/src/main/inbox/filing.ts
@@ -13,7 +13,15 @@ import { existsSync } from 'fs'
 import { createLogger } from '../lib/logger'
 import { broadcastToAllWindows } from '../lib/window-broadcast'
 import { getDatabase, requireDatabase, getIndexDatabase } from '../database'
-import { createNote, getNoteById, updateNote, createFolder, getFolders } from '../vault/notes'
+import { getNoteById, updateNote, createFolder, getFolders } from '../vault/notes'
+// Filing creates notes the user expects on every device, so it goes through the
+// notes domain command rather than the raw vault write. `createNoteCommand` is
+// what enqueues the note's own sync push and seeds its CRDT doc; without it the
+// filed inbox row syncs (markItemAsFiled below) while the note it became stays
+// on this device — the peer hides the item and never draws the note. Nothing
+// rescues it in-session either: `seedUnclockedNotes` runs only from a full sync,
+// and the vault watcher enqueues creates for binaries, not markdown.
+import { createNoteCommand } from '../notes/domain'
 import { setNoteTags } from '../database/queries/notes'
 import { indexBinaryFile } from '../vault/indexer'
 import { getFileType } from '@memry/shared/file-types'
@@ -704,7 +712,7 @@ export async function fileToFolder(
     const content = generateNoteContent(item)
 
     // Create note
-    const note = await createNote({
+    const note = await createNoteCommand({
       title,
       content,
       folder: folderPath || undefined,
@@ -763,7 +771,7 @@ export async function convertToNote(itemId: string): Promise<FileResponse> {
     const content = generateNoteContent(item)
 
     // Create note in root folder
-    const note = await createNote({
+    const note = await createNoteCommand({
       title,
       content,
       tags: mergedTags,
@@ -1008,7 +1016,7 @@ export async function convertToReminder(
     const existingTags = getItemTags(db, itemId)
     const mergedTags = [...new Set([...existingTags, 'inbox'])]
     const title = generateNoteTitle(item)
-    const note = await createNote({
+    const note = await createNoteCommand({
       title,
       content: generateNoteContent(item),
       tags: mergedTags,
@@ -1068,7 +1076,7 @@ async function resolveFilingTargets(
       continue
     }
 
-    const created = await createNote({
+    const created = await createNoteCommand({
       title: target.title,
       content: '',
       folder: folderPath || undefined
@@ -1407,7 +1415,7 @@ export async function linkToNotes(
     const inboxNoteContent = generateNoteContent(item)
 
     // Create the inbox note in the specified folder (we need this so the wikilink has a target)
-    await createNote({
+    await createNoteCommand({
       title: inboxNoteTitle,
       content: inboxNoteContent,
       folder: folderPath || undefined,

--- a/apps/docs/src/user-guide/inbox/triage.md
+++ b/apps/docs/src/user-guide/inbox/triage.md
@@ -68,7 +68,9 @@ If a device is offline when you file, the decision is queued and pushes on its n
 
 Items you filed on an older version of Memry are repaired automatically: the first time each device starts up and syncs after updating, it sends any triage decision that never reached your other devices. You do not need to re-file anything.
 
-The note, task, event, or reminder a triage decision creates syncs the same way. File an item into a folder on your laptop and the note lands in that folder on your desktop too, with its text, tags, and properties.
+Whatever a triage decision creates syncs the same way — a note, a task, an event, a reminder, or the file itself. File an item into a folder on your laptop and the note lands in that folder on your desktop too, with its text, tags, and properties. File an image, PDF, voice memo, or video and the file is uploaded and downloaded onto your other devices, not just listed there.
+
+One limit worth knowing: tags you add to an image, PDF, voice memo, or video while filing it stay on the device that filed it. A file has no text to carry them in. Tags on notes, tasks, and events sync normally.
 
 Notes created by filing on an older version of Memry are repaired the same way as the triage decisions themselves: the next time that device starts up and syncs, it sends them. They arrive in the folder you originally chose. Nothing was lost in the meantime — the note has been on the device that filed it all along.
 

--- a/apps/docs/src/user-guide/inbox/triage.md
+++ b/apps/docs/src/user-guide/inbox/triage.md
@@ -68,6 +68,10 @@ If a device is offline when you file, the decision is queued and pushes on its n
 
 Items you filed on an older version of Memry are repaired automatically: the first time each device starts up and syncs after updating, it sends any triage decision that never reached your other devices. You do not need to re-file anything.
 
+The note, task, event, or reminder a triage decision creates syncs the same way. File an item into a folder on your laptop and the note lands in that folder on your desktop too, with its text, tags, and properties.
+
+Notes created by filing on an older version of Memry are repaired the same way as the triage decisions themselves: the next time that device starts up and syncs, it sends them. They arrive in the folder you originally chose. Nothing was lost in the meantime — the note has been on the device that filed it all along.
+
 ## Keyboard Shortcuts
 
 When the inbox or a triage card has focus:


### PR DESCRIPTION
Every artifact filing produces has to reach the other devices. Two of them didn't. Filing pushed the inbox row and stopped.

## Audit

| Filing action | Artifact | Before |
|---|---|---|
| `fileToFolder` (text/link) | note | **never pushed** |
| `fileToFolder` (binary) | file note + blob | **never pushed** |
| `convertToNote` | note | **never pushed** |
| `convertToReminder` | note + reminder | note **never pushed**, reminder fine |
| `linkToNotes` (text) | new note + target note body | note **never pushed**, body fine (watcher → CRDT) |
| `linkToNotes` (binary) | file note + blob | **never pushed** |
| `bulkFileToFolder` | delegates to `fileToFolder` | inherited both |
| `convertToTask` | task | fine (`syncTaskCreate`) |
| `convertToEvent` | calendar event | fine (`syncCalendarEventCreate`) |
| inbox row | `inboxItems` | fine (`syncInboxUpdate`, #1166) |

## Gap 1 — the note

`filing.ts` called the raw `createNote` from `../vault/notes`. `syncNoteCreate` — which enqueues the note's sync item *and* seeds its CRDT doc — only runs from `createNoteCommand` (`main/notes/domain.ts`). So the note got a file and an index row and nothing else, while the inbox row it came from pushed immediately. The peer hid the item and never drew the note.

Nothing rescued it in-session: `seedUnclockedNotes` runs only from a full sync (app start, reconnect, resume), not the 60s pull tick, and the vault watcher enqueues creates for binary adds, not markdown.

Fix: `fileToFolder`, `convertToNote`, `convertToReminder`, `resolveFilingTargets` and `linkToNotes` go through `createNoteCommand`.

## Gap 2 — the binary, and its bytes

Filing an image, PDF, voice memo or video moves the file into the vault and indexes it. The watcher is what pushes a binary that turns up in the vault (`handleNonMarkdownFileAdd` calls both `syncNoteCreate` and the saved-attachment event), but `handleFileAdd` returns early on a path the index cache already holds — and `indexFiledBinary` fills that cache the moment the file lands. Filing wins that race every time, so neither half ever ran.

The missing upload is the worse half. A binary's push payload carries `attachmentId`, set only once the blob upload completes, so it stayed null forever. The next full sync would seed the clock-less row anyway and hand the peer a row for a file it could never download.

Fix: both binary paths call `syncFiledBinary`, doing what the watcher would have — best-effort and countable like the other filing enqueues.

## Existing installs

No migration, nothing lost. Stranded notes and files still have `clock IS NULL`, so `seedUnclockedNotes` pushes them at the affected device's next full sync — one app restart. Notes arrive in the folder originally chosen.

Binaries filed before this fix are the one case needing care: their row seeds with `attachmentId: null`, so the peer gets a row it cannot download until the bytes are uploaded. This change queues the upload for binaries filed from now on; it does not retroactively upload older ones. Worth a follow-up sweep if it shows up in the wild.

## Known limit

Tags on a filed binary stay local — the binary push payload has no tags field. Protocol gap, not something filing can close. Documented in the user guide.

## Tests

Two new blocks in `filing.test.ts`, 9 cases: `filing pushes the note it creates` (5) and `filing pushes the binary it files` (4), including the null-index path and the throwing-enqueue path.

Mutation-verified both ways. Reverting the note fix fails all 5 note cases. Reverting the binary fix fails 3 of 4 binary cases — the 4th asserts that nothing is enqueued when indexing fails, and correctly passes either way.

The test file mocks `../notes/runtime-effects` (stubbing `syncNoteCreate`) and lets `../notes/domain` run for real, so a mock can't hide the call being tested.

## Verification

- Full inbox suite + `ipc/inbox-handlers.test.ts`: 27 files, **436 pass**
- `typecheck:node`, `typecheck:test:node`, `check:architecture`, eslint: clean
- `docs:impact --base origin/main --strict`: covered · `docs:build`: pass

E2E is push-to-main only, so it says nothing here.

## Follow-up, not fixed here

`main/ipc/tasks-handlers.ts:303` injects the raw `createNote` into `captureUrlToProject`, so a URL captured into a project makes a note that never syncs. Same defect, different feature, wants its own test. Importers use the raw `createNote` on purpose — `ingest-backfill.ts` does their `syncNoteCreate` in bulk.