### PR TITLE
fix(notes): a dropped file lands where it was dropped, not one folder deeper each time

### DIFF
--- a/apps/desktop/src/main/vault/notes-crud.ts
+++ b/apps/desktop/src/main/vault/notes-crud.ts
@@ -913,9 +913,14 @@ export async function importFiles(input: ImportFilesInput): Promise<ImportFilesR
     throw new Error('No vault is open')
   }
 
-  const notesPath = path.join(status.path, 'notes', targetFolder)
+  // `targetFolder` is vault-relative, the same contract `createNote` and the
+  // folder APIs have used since #1204. Joining a literal `notes/` here
+  // re-prefixed a path that already carried its own folders, so the import
+  // landed in a folder that did not exist, and the misplaced file's own
+  // vault-relative path fed the next drop — one extra `notes/` per drop.
+  const targetDir = targetFolder ? path.join(status.path, targetFolder) : getDefaultNoteDir()
 
-  await ensureDirectory(notesPath)
+  await ensureDirectory(targetDir)
 
   const errors: string[] = []
   const importedFiles: ImportedFileInfo[] = []
@@ -929,7 +934,7 @@ export async function importFiles(input: ImportFilesInput): Promise<ImportFilesR
       const filename = path.basename(sourcePath)
 
       let destFilename = filename
-      let destPath = path.join(notesPath, destFilename)
+      let destPath = path.join(targetDir, destFilename)
       let counter = 1
 
       while (true) {
@@ -938,7 +943,7 @@ export async function importFiles(input: ImportFilesInput): Promise<ImportFilesR
           const ext = path.extname(filename)
           const base = path.basename(filename, ext)
           destFilename = `${base} (${counter})${ext}`
-          destPath = path.join(notesPath, destFilename)
+          destPath = path.join(targetDir, destFilename)
           counter++
         } catch {
           break

--- a/apps/desktop/src/main/vault/notes.test.ts
+++ b/apps/desktop/src/main/vault/notes.test.ts
@@ -1498,7 +1498,7 @@ describe('notes operations', () => {
 
       const result = await notes.importFiles({
         sourcePaths: [sourcePath, missingPath],
-        targetFolder: 'imports'
+        targetFolder: 'notes/imports'
       })
 
       expect(result.success).toBe(false)
@@ -1510,6 +1510,56 @@ describe('notes operations', () => {
         fileType: 'image'
       })
       expect(result.errors[0]).toContain('missing.png')
+    })
+
+    it('lands a file in the vault-relative folder it was given, inventing no segment', async () => {
+      // #given — a real top-level folder, the shape `getFolders()` hands the sidebar
+      const projectsDir = path.join(tempVault.path, 'projects')
+      fs.mkdirSync(projectsDir, { recursive: true })
+
+      const sourcePath = path.join(tempVault.path, 'sample.pdf')
+      fs.writeFileSync(sourcePath, Buffer.from([0x25, 0x50, 0x44, 0x46]))
+
+      // #when
+      const result = await notes.importFiles({
+        sourcePaths: [sourcePath],
+        targetFolder: 'projects'
+      })
+
+      // #then — no `notes/` prefix invented on top of a path that is already whole
+      expect(result.imported).toBe(1)
+      expect(result.importedFiles[0].destPath).toBe(path.join(projectsDir, 'sample.pdf'))
+      expect(fs.existsSync(path.join(tempVault.path, 'notes', 'projects'))).toBe(false)
+    })
+
+    it('does not nest one level deeper when the target folder came from a prior import', async () => {
+      // #given — the folder a dropped file already lives in, vault-relative
+      const nestedDir = path.join(tempVault.path, 'notes', 'projects')
+      fs.mkdirSync(nestedDir, { recursive: true })
+
+      const sourcePath = path.join(tempVault.path, 'second.pdf')
+      fs.writeFileSync(sourcePath, Buffer.from([0x25, 0x50, 0x44, 0x46]))
+
+      // #when — the sidebar hands back that same vault-relative folder
+      const result = await notes.importFiles({
+        sourcePaths: [sourcePath],
+        targetFolder: 'notes/projects'
+      })
+
+      // #then — it stays put instead of growing another `notes/`
+      expect(result.importedFiles[0].destPath).toBe(path.join(nestedDir, 'second.pdf'))
+      expect(fs.existsSync(path.join(tempVault.path, 'notes', 'notes'))).toBe(false)
+    })
+
+    it('falls back to the default note folder when no target folder is given', async () => {
+      const sourcePath = path.join(tempVault.path, 'loose.pdf')
+      fs.writeFileSync(sourcePath, Buffer.from([0x25, 0x50, 0x44, 0x46]))
+
+      const result = await notes.importFiles({ sourcePaths: [sourcePath] })
+
+      // Fixture config sets `defaultNoteFolder: 'notes'`; an empty vault-relative
+      // target means "wherever a folderless new note would go", not "vault/notes".
+      expect(result.importedFiles[0].destPath).toBe(path.join(tempVault.path, 'notes', 'loose.pdf'))
     })
 
     it('rejects imports when no vault is open', async () => {

--- a/apps/desktop/src/renderer/src/components/app-sidebar.projects.test.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.projects.test.tsx
@@ -151,7 +151,8 @@ vi.mock('@/hooks/use-inbox', () => ({
 }))
 
 vi.mock('@/hooks/use-file-drop', () => ({
-  useFileDrop: () => ({ isDraggingFiles: false, dropHandlers: {} })
+  FILE_DROP_FOLDER_ATTR: 'data-file-drop-folder',
+  useFileDrop: () => ({ isDraggingFiles: false, dropFolder: null, dropHandlers: {} })
 }))
 
 vi.mock('@/components/ui/picker', () => ({

--- a/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
@@ -20,7 +20,9 @@ const mocks = vi.hoisted(() => ({
   notesTreeCreateNote: vi.fn(),
   notesTreeCreateFolder: vi.fn(),
   canvasTreeCreateFolder: vi.fn(),
-  fileDrop: { onDrop: null as ((paths: string[]) => Promise<void> | void) | null },
+  fileDrop: {
+    onDrop: null as ((paths: string[], targetFolder: string) => Promise<void> | void) | null
+  },
   // Keyless calls collapse to the last key segment; interpolated ones append
   // their values so a test can prove the caller passed them through.
   translate: (key: string, values?: Record<string, unknown>): string => {
@@ -278,9 +280,12 @@ vi.mock('@/hooks/use-inbox', () => ({
 }))
 
 vi.mock('@/hooks/use-file-drop', () => ({
-  useFileDrop: (options: { onDrop: (paths: string[]) => Promise<void> | void }) => {
+  FILE_DROP_FOLDER_ATTR: 'data-file-drop-folder',
+  useFileDrop: (options: {
+    onDrop: (paths: string[], targetFolder: string) => Promise<void> | void
+  }) => {
     mocks.fileDrop.onDrop = options.onDrop
-    return { isDraggingFiles: false, dropHandlers: {} }
+    return { isDraggingFiles: false, dropFolder: null, dropHandlers: {} }
   }
 }))
 
@@ -466,12 +471,27 @@ describe('AppSidebar', () => {
     })
 
     await act(async () => {
-      await mocks.fileDrop.onDrop?.(['a.md', 'b.md', 'bad.zip'])
+      await mocks.fileDrop.onDrop?.(['a.md', 'b.md', 'bad.zip'], '')
     })
 
     expect(toast.success).toHaveBeenCalledWith('filesImported:{"count":2}')
     expect(toast.error).toHaveBeenCalledWith('filesImportFailed:{"count":1}', {
       description: 'bad.zip: unsupported'
     })
+  })
+
+  it('imports into the folder the drop landed on, ignoring the selected folder', async () => {
+    // #given — the tree mock reports `Projects` as the selected folder, which is
+    // what used to decide the destination on its own
+    render(<AppSidebar currentPage="inbox" viewCounts={{}} />)
+    mocks.importFiles.mockResolvedValueOnce({ imported: 1, failed: 0, errors: [] })
+
+    // #when — the file is dropped over a different folder row
+    await act(async () => {
+      await mocks.fileDrop.onDrop?.(['/tmp/sample.pdf'], 'movies')
+    })
+
+    // #then — the drop wins over the selection
+    expect(mocks.importFiles).toHaveBeenCalledWith(['/tmp/sample.pdf'], 'movies')
   })
 })

--- a/apps/desktop/src/renderer/src/components/app-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.tsx
@@ -66,7 +66,7 @@ import { BookmarkItemTypes } from '@memry/contracts/bookmarks-api'
 import { getAllSupportedExtensions } from '@memry/shared/file-types'
 import { createLogger } from '@/lib/logger'
 import { trackRendererError } from '@/lib/telemetry-diagnostics'
-import { useFileDrop } from '@/hooks/use-file-drop'
+import { useFileDrop, FILE_DROP_FOLDER_ATTR } from '@/hooks/use-file-drop'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { revealNoteInSidebar } from '@/lib/reveal-in-sidebar'
 import { useT } from '@memry/i18n/renderer'
@@ -115,9 +115,10 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
   const sidebarScrollRef = useRef<HTMLDivElement>(null)
   const targetFolderRef = useRef('')
 
-  const handleFileDrop = useCallback(async (paths: string[]) => {
+  const handleFileDrop = useCallback(async (paths: string[], targetFolder: string) => {
     try {
-      const result = await notesService.importFiles(paths, targetFolderRef.current)
+      // Where the file was dropped, not what happened to be selected.
+      const result = await notesService.importFiles(paths, targetFolder)
       const tCommon = getI18n().getFixedT(null, 'common')
 
       if (result.imported > 0) {
@@ -149,7 +150,7 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
     [setSelectedFolder]
   )
 
-  const { isDraggingFiles, dropHandlers } = useFileDrop({ onDrop: handleFileDrop })
+  const { isDraggingFiles, dropFolder, dropHandlers } = useFileDrop({ onDrop: handleFileDrop })
 
   // Calculate today's tasks count for Tasks badge in sidebar
   const todayTasksCount = useMemo(() => {
@@ -480,6 +481,8 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
         ref={sidebarScrollRef}
         data-tour="sidebar-collections"
         className="relative flex-1 min-h-0 overflow-y-auto scrollbar-thin group-data-[collapsible=icon]:overflow-hidden"
+        // Anything dropped outside a folder row lands in the vault root.
+        {...{ [FILE_DROP_FOLDER_ATTR]: '' }}
         {...dropHandlers}
       >
         {/* COLLECTIONS Section */}
@@ -551,6 +554,7 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
           <NotesTree
             ref={notesActionsRef}
             onTargetFolderChange={handleTargetFolderChange}
+            fileDropFolder={isDraggingFiles ? dropFolder : null}
             scrollContainerRef={sidebarScrollRef as React.RefObject<HTMLElement>}
           />
         </SidebarSection>
@@ -643,19 +647,27 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
           <SidebarTagList maxVisible={6} onActionsReady={setTagsActions} />
         </SidebarSection>
 
-        {/* Drop overlay — covers entire scrollable area, blocks pointer events when visible */}
+        {/*
+          Drop affordance. It never takes pointer events and never covers the
+          tree: the row under the cursor has to stay both the drop target and
+          visible, or there is no way to aim at a folder.
+        */}
         <div
           className={cn(
-            'absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm transition-opacity duration-150',
-            isDraggingFiles ? 'opacity-100' : 'opacity-0 invisible pointer-events-none'
+            'pointer-events-none absolute inset-0 z-50 transition-opacity duration-150',
+            isDraggingFiles ? 'opacity-100' : 'opacity-0 invisible'
           )}
         >
-          <div className="flex flex-col items-center gap-2 rounded-md border-2 border-dashed border-primary/50 px-6 py-4">
-            <Upload className="size-6 text-primary" />
-            <span className="text-sm font-medium">
+          <div className="absolute inset-1 rounded-md border-2 border-dashed border-primary/50" />
+          <div className="absolute inset-x-3 bottom-3 flex flex-col items-center gap-0.5 rounded-md border border-primary/40 bg-background/95 px-3 py-2 shadow-sm">
+            <span className="flex items-center gap-2 text-sm font-medium">
+              <Upload className="size-4 text-primary" />
               {tPhaseF('phaseF.componentsAppSidebar.dropFilesToImport')}
             </span>
-            <span className="text-xs text-muted-foreground">
+            <span className="max-w-full truncate text-xs font-medium text-primary">
+              {dropFolder || tPhaseF('phaseF.componentsAppSidebar.dropFilesIntoVaultRoot')}
+            </span>
+            <span className="line-clamp-2 text-center text-[10px] leading-tight text-muted-foreground">
               {getAllSupportedExtensions().join(', ')}
             </span>
           </div>

--- a/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.test.tsx
+++ b/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.test.tsx
@@ -171,10 +171,13 @@ function renderTree(
   return { onSelectionChange, onMove, onIconChange }
 }
 
-function dataTransfer() {
+function dataTransfer(types: string[] = []) {
   return {
     effectAllowed: '',
     dropEffect: '',
+    // A real DataTransfer always exposes `types`; the tree reads it to tell an
+    // internal reorder from a file dragged in from the OS.
+    types,
     setData: vi.fn()
   }
 }
@@ -273,6 +276,27 @@ describe('TreeProvider and tree primitives', () => {
 
     fireEvent.dragLeave(childB, { relatedTarget: document.body })
     fireEvent.dragEnd(root)
+  })
+
+  it('lets a file dragged in from the OS reach the sidebar instead of swallowing it', () => {
+    // #given — the row's drop handler runs in the capture phase, so stopping
+    // propagation there cancels the bubble phase and the sidebar importer with it
+    const { onMove } = renderTree()
+    const sidebarDrop = vi.fn()
+    const childB = screen.getByText('Child B').closest('[data-tree-node-id]') as HTMLElement
+    document.body.addEventListener('drop', sidebarDrop)
+
+    const transfer = dataTransfer(['Files'])
+
+    // #when
+    fireEvent.dragOver(childB, { dataTransfer: transfer, clientY: 20 })
+    fireEvent.drop(childB, { dataTransfer: transfer })
+
+    // #then — no reorder claimed, and the event still bubbles out of the tree
+    expect(onMove).not.toHaveBeenCalled()
+    expect(sidebarDrop).toHaveBeenCalled()
+
+    document.body.removeEventListener('drop', sidebarDrop)
   })
 
   it('supports controlled selection, disabled selection, hidden chrome, and outside-context errors', () => {

--- a/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.tsx
+++ b/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.tsx
@@ -739,6 +739,10 @@ export const TreeNodeTrigger = ({
 
   const handleDragOver = useCallback(
     (e: React.DragEvent) => {
+      // A file coming from outside the app is not a reorder. Leaving it alone
+      // keeps the before/after/inside indicator off and lets the sidebar's file
+      // drop zone claim the event on the way up.
+      if (e.dataTransfer.types.includes('Files')) return
       if (!draggable || dragState.draggedId === nodeId) return
 
       e.preventDefault()
@@ -778,6 +782,11 @@ export const TreeNodeTrigger = ({
 
   const handleDropEvent = useCallback(
     (e: React.DragEvent) => {
+      // This runs in the capture phase, so stopping propagation here cancels the
+      // bubble phase outright. For an external file that silently swallowed the
+      // drop before the sidebar's importer ever saw it — let those through.
+      if (e.dataTransfer.types.includes('Files')) return
+
       e.preventDefault()
       e.stopPropagation()
       handleDrop()

--- a/apps/desktop/src/renderer/src/components/notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree.tsx
@@ -37,12 +37,15 @@ import {
   type TreeActionsHandle
 } from '@/components/note-tree-internal'
 import {
+  extractFolderFromPath,
   getDisplayName,
   getFileExtensionLabel,
   getFileIcon,
   collectAllFolderIds,
   type FolderNode
 } from '@/components/notes-tree-utils'
+import { FILE_DROP_FOLDER_ATTR } from '@/hooks/use-file-drop'
+import { cn } from '@/lib/utils'
 import { IconPickerButton } from '@/components/icon-picker-button'
 import type { NoteListItem } from '@/hooks/use-notes-query'
 import {
@@ -83,10 +86,16 @@ export interface NotesTreeActions {
 interface NotesTreeProps {
   onTargetFolderChange?: (folder: string) => void
   scrollContainerRef?: React.RefObject<HTMLElement>
+  /**
+   * Vault-relative folder an in-flight external file drag is aimed at, or null
+   * when no file is being dragged. Highlight only — the drop reads its own
+   * destination off `FILE_DROP_FOLDER_ATTR` in the DOM.
+   */
+  fileDropFolder?: string | null
 }
 
 export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function NotesTree(
-  { onTargetFolderChange, scrollContainerRef }: NotesTreeProps = {},
+  { onTargetFolderChange, scrollContainerRef, fileDropFolder = null }: NotesTreeProps = {},
   ref
 ) {
   const { t } = useT('notes')
@@ -302,6 +311,8 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
         canvasNoteId={note.id}
       >
         <TreeNodeTrigger
+          // A file dropped on a note belongs in the folder that note lives in.
+          {...{ [FILE_DROP_FOLDER_ATTR]: extractFolderFromPath(note.path) }}
           contextMenuContent={
             <>
               {!isPartOfSelection && (
@@ -423,7 +434,11 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
         hasChildren={hasChildren}
       >
         <TreeNodeTrigger
-          className=""
+          {...{ [FILE_DROP_FOLDER_ATTR]: folder.path }}
+          className={cn(
+            fileDropFolder === folder.path &&
+              'border-2 border-dashed border-primary bg-primary/10 hover:bg-primary/10'
+          )}
           contextMenuContent={
             <>
               <ContextMenuItem onClick={() => void actions.handleCreateNoteInFolder(folder.path)}>
@@ -590,6 +605,7 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
           isDragDisabled={
             !!actions.renamingNoteId || !!actions.renamingFolderPath || actions.isMoving
           }
+          fileDropFolder={fileDropFolder}
           scrollContainerRef={scrollContainerRef}
         />
       ) : (

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.test.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.test.tsx
@@ -310,6 +310,9 @@ describe('VirtualizedNotesTree', () => {
     const dataTransfer = {
       effectAllowed: '',
       dropEffect: '',
+      // A real DataTransfer always exposes `types`; the tree reads it to tell an
+      // internal reorder from a file dragged in from the OS.
+      types: [] as string[],
       setData: vi.fn(),
       getData: vi.fn()
     }
@@ -419,6 +422,9 @@ describe('VirtualizedNotesTree', () => {
     const dataTransfer = {
       effectAllowed: '',
       dropEffect: '',
+      // A real DataTransfer always exposes `types`; the tree reads it to tell an
+      // internal reorder from a file dragged in from the OS.
+      types: [] as string[],
       setData: vi.fn(),
       getData: vi.fn()
     }
@@ -489,6 +495,9 @@ describe('VirtualizedNotesTree', () => {
     const dataTransfer = {
       effectAllowed: '',
       dropEffect: '',
+      // A real DataTransfer always exposes `types`; the tree reads it to tell an
+      // internal reorder from a file dragged in from the OS.
+      types: [] as string[],
       setData: vi.fn(),
       getData: vi.fn()
     }

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
@@ -53,7 +53,8 @@ import {
 import { getTabIconForFileType, type FileType } from '@memry/shared/file-types'
 import { FolderIconButton } from '@/components/folder-icon-button'
 import { IconPickerButton } from '@/components/icon-picker-button'
-import { getDisplayName, getFileIcon } from '@/components/notes-tree-utils'
+import { extractFolderFromPath, getDisplayName, getFileIcon } from '@/components/notes-tree-utils'
+import { FILE_DROP_FOLDER_ATTR } from '@/hooks/use-file-drop'
 import { BookmarkMenuItem } from '@/components/sidebar/bookmark-menu-item'
 import { useT } from '@memry/i18n/renderer'
 
@@ -133,6 +134,12 @@ interface VirtualizedNotesTreeProps {
   noteMap: Map<string, NoteListItem>
   /** Whether drag operations are disabled */
   isDragDisabled?: boolean
+  /**
+   * Vault-relative folder an in-flight external file drag is aimed at, or null
+   * when no file is being dragged. Only drives the highlight — the drop itself
+   * reads the destination straight off the DOM.
+   */
+  fileDropFolder?: string | null
   /** Custom class name */
   className?: string
   /** Optional scroll container for virtualized rendering */
@@ -212,6 +219,8 @@ interface FolderRowProps {
   isLastSelected: boolean
   isDragging: boolean
   isDropTarget: boolean
+  /** True while an external file drag is aimed at this row's folder. */
+  isFileDropTarget: boolean
   dropPosition: DropPosition | null
   selectedCount: number
   draggable: boolean
@@ -242,6 +251,7 @@ function FolderRow({
   isLastSelected,
   isDragging,
   isDropTarget,
+  isFileDropTarget,
   dropPosition,
   selectedCount,
   draggable,
@@ -331,6 +341,7 @@ function FolderRow({
           aria-selected={isSelected}
           tabIndex={0}
           draggable={draggable}
+          {...{ [FILE_DROP_FOLDER_ATTR]: item.folder.path }}
           className={cn(
             'group/folder relative flex items-center gap-1 px-2 py-1 cursor-pointer rounded-sm transition-colors min-w-0',
             'hover:bg-muted focus-visible:outline-none',
@@ -365,6 +376,14 @@ function FolderRow({
 
           {/* Drop indicator - inside (for folders) */}
           {isDropTarget && dropPosition === 'inside' && (
+            <div
+              className="absolute inset-0 rounded-md border-2 border-primary border-dashed bg-primary/10"
+              aria-hidden="true"
+            />
+          )}
+
+          {/* Drop indicator - external file landing in this folder */}
+          {isFileDropTarget && (
             <div
               className="absolute inset-0 rounded-md border-2 border-primary border-dashed bg-primary/10"
               aria-hidden="true"
@@ -581,6 +600,8 @@ function NoteRow({
           aria-selected={isSelected}
           tabIndex={0}
           draggable={draggable}
+          // A file dropped on a note belongs in the folder that note lives in.
+          {...{ [FILE_DROP_FOLDER_ATTR]: extractFolderFromPath(item.note.path) }}
           className={cn(
             'group/note relative flex items-center gap-1 px-2 py-1 cursor-pointer rounded-sm transition-colors',
             'hover:bg-muted focus-visible:outline-none',
@@ -726,6 +747,7 @@ export function VirtualizedNotesTree({
   onSetNoteIcon,
   noteMap,
   isDragDisabled = false,
+  fileDropFolder = null,
   className,
   scrollContainerRef
 }: VirtualizedNotesTreeProps) {
@@ -992,6 +1014,9 @@ export function VirtualizedNotesTree({
 
   const handleDragOver = useCallback(
     (e: React.DragEvent, itemId: string, hasChildren: boolean) => {
+      // A file coming from outside the app is not a reorder — the sidebar's file
+      // drop zone handles it, and a before/after indicator would lie about it.
+      if (e.dataTransfer.types.includes('Files')) return
       if (isDragDisabled || dragState.draggedId === itemId) return
 
       e.preventDefault()
@@ -1115,6 +1140,7 @@ export function VirtualizedNotesTree({
                   isLastSelected={isLastSelected}
                   isDragging={isDragging}
                   isDropTarget={isDropTarget}
+                  isFileDropTarget={fileDropFolder === item.folder.path}
                   dropPosition={isDropTarget ? dragState.dropPosition : null}
                   selectedCount={selectedCount}
                   draggable={draggable}

--- a/apps/desktop/src/renderer/src/hooks/use-file-drop.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-file-drop.test.ts
@@ -1,6 +1,11 @@
 import { act, renderHook } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { extractValidPaths, useFileDrop } from './use-file-drop'
+import {
+  extractValidPaths,
+  resolveDropFolder,
+  useFileDrop,
+  FILE_DROP_FOLDER_ATTR
+} from './use-file-drop'
 
 vi.mock('@/lib/logger', () => ({
   createLogger: () => ({
@@ -139,10 +144,11 @@ describe('extractValidPaths', () => {
   })
 })
 
-function dragEvent(files: File[], types = ['Files']) {
+function dragEvent(files: File[], types = ['Files'], target?: EventTarget) {
   return {
     preventDefault: vi.fn(),
     stopPropagation: vi.fn(),
+    target,
     dataTransfer: {
       types,
       dropEffect: 'none',
@@ -150,6 +156,56 @@ function dragEvent(files: File[], types = ['Files']) {
     }
   } as unknown as React.DragEvent
 }
+
+/** Sidebar shape: a root zone holding a folder row that holds a label span. */
+function sidebarDom(folder: string) {
+  const root = document.createElement('div')
+  root.setAttribute(FILE_DROP_FOLDER_ATTR, '')
+
+  const row = document.createElement('div')
+  row.setAttribute(FILE_DROP_FOLDER_ATTR, folder)
+
+  const label = document.createElement('span')
+  row.appendChild(label)
+  root.appendChild(row)
+
+  return { root, row, label }
+}
+
+describe('resolveDropFolder', () => {
+  it('reads the folder off the innermost zone under the pointer', () => {
+    // #given — the pointer lands on a label, not on the row that owns the folder
+    const { label } = sidebarDom('projects')
+
+    // #when / #then
+    expect(resolveDropFolder(label)).toBe('projects')
+  })
+
+  it('prefers a nested folder row over the root zone wrapping it', () => {
+    // #given
+    const { label } = sidebarDom('life/travel')
+
+    // #then — a deeper zone wins, so nesting stays aimable
+    expect(resolveDropFolder(label)).toBe('life/travel')
+  })
+
+  it('falls back to the vault root outside any declared zone', () => {
+    // #given
+    const orphan = document.createElement('div')
+
+    // #then
+    expect(resolveDropFolder(orphan)).toBe('')
+    expect(resolveDropFolder(null)).toBe('')
+  })
+
+  it('reads the root zone itself as the vault root, not as a missing zone', () => {
+    // #given — dropped on sidebar empty space
+    const { root } = sidebarDom('projects')
+
+    // #then
+    expect(resolveDropFolder(root)).toBe('')
+  })
+})
 
 describe('useFileDrop', () => {
   it('tracks external file drags, clears the drag state, and drops supported paths', async () => {
@@ -178,7 +234,67 @@ describe('useFileDrop', () => {
     await act(async () => {
       result.current.dropHandlers.onDrop(drop)
     })
-    expect(onDrop).toHaveBeenCalledWith(['/tmp/note.md'])
+    expect(onDrop).toHaveBeenCalledWith(['/tmp/note.md'], '')
+  })
+
+  it('imports into the folder under the pointer, not into the vault root', async () => {
+    // #given — the pointer is over a label inside the `projects` row
+    const onDrop = vi.fn()
+    ;(
+      window.api as typeof window.api & { getFileDropPaths: (files: File[]) => string[] }
+    ).getFileDropPaths = vi.fn(() => ['/tmp/sample.pdf'])
+    const { label } = sidebarDom('projects')
+    const { result } = renderHook(() => useFileDrop({ onDrop }))
+
+    // #when
+    await act(async () => {
+      result.current.dropHandlers.onDrop(
+        dragEvent([new File(['pdf'], 'sample.pdf')], ['Files'], label)
+      )
+    })
+
+    // #then — vault-relative, exactly the shape `importFiles` takes
+    expect(onDrop).toHaveBeenCalledWith(['/tmp/sample.pdf'], 'projects')
+  })
+
+  it('reports the hovered folder while dragging and forgets it when the drag stops', () => {
+    // #given
+    vi.useFakeTimers()
+    const { label } = sidebarDom('life/travel')
+    const { result } = renderHook(() => useFileDrop({ onDrop: vi.fn() }))
+
+    // #when
+    act(() => {
+      result.current.dropHandlers.onDragOver(dragEvent([], ['Files'], label))
+    })
+
+    // #then — drives the row highlight
+    expect(result.current.dropFolder).toBe('life/travel')
+
+    act(() => {
+      vi.advanceTimersByTime(150)
+    })
+    expect(result.current.dropFolder).toBeNull()
+  })
+
+  it('drops into the vault root when nothing under the pointer claims a folder', async () => {
+    // #given — sidebar empty space, below every row
+    const onDrop = vi.fn()
+    ;(
+      window.api as typeof window.api & { getFileDropPaths: (files: File[]) => string[] }
+    ).getFileDropPaths = vi.fn(() => ['/tmp/loose.pdf'])
+    const { root } = sidebarDom('projects')
+    const { result } = renderHook(() => useFileDrop({ onDrop }))
+
+    // #when
+    await act(async () => {
+      result.current.dropHandlers.onDrop(
+        dragEvent([new File(['pdf'], 'loose.pdf')], ['Files'], root)
+      )
+    })
+
+    // #then — selection is irrelevant; empty space means root
+    expect(onDrop).toHaveBeenCalledWith(['/tmp/loose.pdf'], '')
   })
 
   it('ignores non-file drops and falls back to file.path when preload path lookup fails', async () => {
@@ -201,7 +317,7 @@ describe('useFileDrop', () => {
     await act(async () => {
       result.current.dropHandlers.onDrop(dragEvent([file]))
     })
-    expect(onDrop).toHaveBeenCalledWith(['/tmp/report.pdf'])
+    expect(onDrop).toHaveBeenCalledWith(['/tmp/report.pdf'], '')
 
     await act(async () => {
       result.current.dropHandlers.onDrop(dragEvent([new File(['bin'], 'app.exe')]))

--- a/apps/desktop/src/renderer/src/hooks/use-file-drop.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-file-drop.ts
@@ -6,17 +6,26 @@ const log = createLogger('Hook:useFileDrop')
 
 const DRAG_TIMEOUT_MS = 150
 
+/**
+ * Marks an element as the destination for a file dropped anywhere inside it.
+ * The value is a vault-relative folder path, `''` for the vault root — the same
+ * shape `importFiles` and the folder APIs take.
+ */
+export const FILE_DROP_FOLDER_ATTR = 'data-file-drop-folder'
+
 interface FileDropResult {
   validPaths: string[]
   skippedCount: number
 }
 
 interface UseFileDropOptions {
-  onDrop: (paths: string[]) => Promise<void> | void
+  onDrop: (paths: string[], targetFolder: string) => Promise<void> | void
 }
 
 interface UseFileDropReturn {
   isDraggingFiles: boolean
+  /** Folder the pointer is currently over, or null when no file drag is active. */
+  dropFolder: string | null
   dropHandlers: {
     onDragOver: (e: React.DragEvent) => void
     onDrop: (e: React.DragEvent) => void
@@ -25,6 +34,18 @@ interface UseFileDropReturn {
 
 function hasExternalFiles(e: React.DragEvent): boolean {
   return e.dataTransfer.types.includes('Files')
+}
+
+/**
+ * Innermost declared drop folder at `target`, walking up the tree.
+ *
+ * The pointer lands on whatever leaf is under it — a label span, an icon — so
+ * the row that owns the destination is always an ancestor. Anything outside a
+ * declared zone falls back to the vault root rather than to the last selection.
+ */
+export function resolveDropFolder(target: EventTarget | null): string {
+  if (!(target instanceof Element)) return ''
+  return target.closest(`[${FILE_DROP_FOLDER_ATTR}]`)?.getAttribute(FILE_DROP_FOLDER_ATTR) ?? ''
 }
 
 export function extractValidPaths(files: Array<{ path: string; name: string }>): FileDropResult {
@@ -74,6 +95,7 @@ function resolveDroppedFiles(fileList: FileList): Array<{ path: string; name: st
 
 export function useFileDrop({ onDrop }: UseFileDropOptions): UseFileDropReturn {
   const [isDraggingFiles, setIsDraggingFiles] = useState(false)
+  const [dropFolder, setDropFolder] = useState<string | null>(null)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
@@ -83,9 +105,13 @@ export function useFileDrop({ onDrop }: UseFileDropOptions): UseFileDropReturn {
     e.dataTransfer.dropEffect = 'copy'
 
     setIsDraggingFiles(true)
+    setDropFolder(resolveDropFolder(e.target))
 
     if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    timeoutRef.current = setTimeout(() => setIsDraggingFiles(false), DRAG_TIMEOUT_MS)
+    timeoutRef.current = setTimeout(() => {
+      setIsDraggingFiles(false)
+      setDropFolder(null)
+    }, DRAG_TIMEOUT_MS)
   }, [])
 
   const handleDrop = useCallback(
@@ -98,9 +124,13 @@ export function useFileDrop({ onDrop }: UseFileDropOptions): UseFileDropReturn {
         timeoutRef.current = null
       }
       setIsDraggingFiles(false)
+      setDropFolder(null)
 
       if (!hasExternalFiles(e)) return
 
+      // Read the destination off the element under the pointer, not off the
+      // sidebar selection — where the file lands is where it was dropped.
+      const targetFolder = resolveDropFolder(e.target)
       const resolved = resolveDroppedFiles(e.dataTransfer.files)
       const { validPaths, skippedCount } = extractValidPaths(resolved)
 
@@ -112,14 +142,19 @@ export function useFileDrop({ onDrop }: UseFileDropOptions): UseFileDropReturn {
         return
       }
 
-      log.info('Files dropped', { count: validPaths.length, skipped: skippedCount })
-      void onDrop(validPaths)
+      log.info('Files dropped', {
+        count: validPaths.length,
+        skipped: skippedCount,
+        targetFolder: targetFolder || '<vault root>'
+      })
+      void onDrop(validPaths, targetFolder)
     },
     [onDrop]
   )
 
   return {
     isDraggingFiles,
+    dropFolder,
     dropHandlers: {
       onDragOver: handleDragOver,
       onDrop: handleDrop

--- a/apps/docs/src/user-guide/import.md
+++ b/apps/docs/src/user-guide/import.md
@@ -26,6 +26,24 @@ Progress lines, preview warnings and import errors are shown in your selected la
 | Todoist       | Project CSV `.csv`              | Tasks                 | See [Import from Todoist](./tasks/import-todoist.md)   |
 | TickTick      | Backup CSV `.csv`               | Tasks                 | See [Import from TickTick](./tasks/import-ticktick.md) |
 
+## Dropping Files onto the Sidebar
+
+For a handful of files, skip **Settings → Import** entirely: drag them from Finder or Explorer straight onto the sidebar. They are **copied** into your vault, so the originals can be moved or deleted afterwards without breaking anything.
+
+**Where they land is where you drop them:**
+
+| Drop target        | Destination                                               |
+| ------------------ | --------------------------------------------------------- |
+| A folder row       | That folder                                               |
+| A note or file row | The folder that note lives in                             |
+| Empty space        | Your vault root (or your **default note folder**, if set) |
+
+Whatever is currently selected in the sidebar makes no difference — only the drop position counts. While you drag, the target folder is outlined and named at the bottom of the sidebar, so you can confirm the destination before letting go.
+
+A name collision never overwrites: a second `report.pdf` becomes `report (1).pdf`.
+
+Unsupported file types are skipped rather than failing the whole drop; the supported extensions are listed in the sidebar while you drag. To attach a file **inside** a note instead of adding it to the vault, drop it onto the editor — see [Attachments](./notes/attachments.md).
+
 ## Importing from Notion
 
 memrynote imports a Notion **HTML** export (not the Markdown or CSV export).

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -359,6 +359,7 @@
       "bookmarks": "Bookmarks",
       "tags": "Tags",
       "dropFilesToImport": "Drop files to import",
+      "dropFilesIntoVaultRoot": "Vault root",
       "newNoteN": "New note (⌘N)",
       "new": "New",
       "newItemMenu": "Create new…",


### PR DESCRIPTION
Reported: a PDF dragged from Finder onto the sidebar ended up in `<vault>/notes/notes/notes/projects/`. Reproduced against the real vault — that whole `notes/` tree was phantom, invented by the importer.

## The path bug

`importFiles` joined a literal `notes/` onto its `targetFolder`, but every other folder path in the app has been **vault-relative** since #1204:

- `getFolders()` lists from the vault root, so tree ids are `folder-<vault-rel>`
- `createFolder` / `renameFolder` / `deleteFolder` join from it
- `createNote` says so in its own comment: "`input.folder` is vault-relative"
- `note.path` comes from `toRelativePath()`
- `extractFolderFromPath` documents it, citing #1204

`importFiles` was the last holdout on the pre-#1204 convention.

**Why it compounded.** The sidebar hands back the selected note's folder, vault-relative. Drop 1 with `projects` → `notes/projects`, a folder `ensureDirectory` had to invent. The indexer then knows that file as `notes/projects/x.pdf`, so drop 2 is handed `notes/projects` → `notes/notes/projects`. **One extra level per drop, not per file.**

An empty target now means the default note folder — the same fallback a folderless new note gets — instead of a hardcoded `notes/`.

## Drop position now decides the destination

The drop handlers sit on the whole sidebar scroll container, so a file always went to whatever was *selected*. Dropping on a folder row, on a note, or on empty space were the same gesture.

Every row now declares `data-file-drop-folder`, and the drop resolves it with `closest()` from the element under the pointer:

| Drop target | Destination |
| --- | --- |
| Folder row | That folder |
| Note / file row | The folder that note lives in |
| Empty space | Vault root (or `defaultNoteFolder`) |

Selection no longer decides anything. `⌘N` still uses it.

Two things blocked a row from ever being aimable:

- **`onDropCapture` + `stopPropagation()`** in `kibo-ui/tree` runs in the **capture** phase, which cancels the bubble phase outright. A file dropped on a row in the plain tree — the renderer used below 100 items, so most vaults — never reached the importer **at all**. Only empty space worked. Both trees now leave `Files` drags alone, in dragover too, where they were drawing a reorder indicator that could not happen.
- **The drop overlay ate the pointer.** It covered the scroll area at `z-50` without `pointer-events-none`, so the element under the cursor was always the overlay. It no longer takes events or blurs the tree, and it names the resolved destination while you drag.

## Testing

- **Renderer:** 613 files, 7119 passed
- **Main:** 528 files, 6699 passed
- `typecheck` (node + web + test), `lint` (0 errors), `i18n:check`, `docs:impact --strict` (covered), `docs:build` — all green

Mutation-checked both fixes rather than trusting green:

- Restore the `notes/` join → 3 of 4 `importFiles` tests fail
- Remove the capture-phase guard → the new kibo-tree test fails (`expected "vi.fn()" to be called at least once`)

The pre-existing `importFiles` test passed a *notes-relative* `imports`, which is exactly why this survived; it now passes the vault-relative path it would really get. Fake `dataTransfer` objects in the tree tests carried no `types` — a real one always does.

## Notes for the reviewer

- Not run: manual drag-and-drop in the app. Tests cover the resolution and both guards, but the real pointer path is unverified.
- Repo pins `engines: node 24.x`. On node 26 the renderer suite fails at `beforeEach` with `localStorage undefined` (node gates the global behind `--localstorage-file`, shadowing jsdom's) — verified pre-existing at HEAD. All results above are from node 24.16.0.
- Existing installs with a phantom `notes/` tree keep it; this stops new drops from adding to it. Nothing migrates or moves files.
