### PR TITLE
One path to a PDF embed: /pdf, /file, drag and sidebar all produce the same block

### DIFF
--- a/apps/desktop/src/main/ipc/notes-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.test.ts
@@ -703,6 +703,27 @@ describe('notes-handlers', () => {
       expect(result).toEqual(mockResult)
     })
 
+    it('UPLOAD_ATTACHMENT should accept an ArrayBuffer payload', async () => {
+      const mockResult = { success: true, path: 'attachments/note123/file.pdf', type: 'file' }
+      ;(attachmentsVault.saveAttachment as Mock).mockResolvedValue(mockResult)
+      const bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]) // PDF magic bytes
+
+      // The preload sends the file's ArrayBuffer as-is; the number[] shape above
+      // stays supported but is no longer what the renderer produces.
+      const result = await invokeHandler(NotesChannels.invoke.UPLOAD_ATTACHMENT, {
+        noteId: 'note123',
+        filename: 'file.pdf',
+        data: bytes.buffer
+      })
+
+      expect(result).toEqual(mockResult)
+      expect(attachmentsVault.saveAttachment).toHaveBeenCalledWith(
+        'note123',
+        Buffer.from(bytes),
+        'file.pdf'
+      )
+    })
+
     it('LIST_ATTACHMENTS should list attachments', async () => {
       const mockAttachments = [
         { name: 'file1.pdf', size: 1024 },

--- a/apps/desktop/src/main/vault/attachments.test.ts
+++ b/apps/desktop/src/main/vault/attachments.test.ts
@@ -168,6 +168,13 @@ describe('getMimeType', () => {
 })
 
 describe('validateFileSize', () => {
+  it('caps vault attachments at 100MB', () => {
+    // Pinned, not derived: the number is a product decision (a large PDF may be
+    // attached as a local-only file), so a silent drift back toward the sync
+    // limits should fail here.
+    expect(MAX_FILE_SIZE).toBe(100 * 1024 * 1024)
+  })
+
   it('T395: does not throw for valid size', () => {
     expect(() => validateFileSize(1024)).not.toThrow()
     expect(() => validateFileSize(MAX_FILE_SIZE)).not.toThrow()
@@ -295,6 +302,20 @@ describe('attachment operations', () => {
 
       expect(result.success).toBe(false)
       expect(result.error).toContain('too large')
+    })
+
+    it('saves a 60MB PDF that no sync plan would accept', async () => {
+      // The whole point of the 100MB cap: this file is far past every plan's
+      // per-file sync limit, and it still lands in the vault. Sync refuses it
+      // separately (file_too_large, no retry) and it stays on this device.
+      const data = Buffer.alloc(60 * 1024 * 1024)
+
+      const result = await saveAttachment('note123', data, 'thesis.pdf')
+
+      expect(result.success).toBe(true)
+      expect(result.size).toBe(data.length)
+      expect(result.mimeType).toBe('application/pdf')
+      expect(result.type).toBe('file')
     })
   })
 

--- a/apps/desktop/src/main/vault/attachments.ts
+++ b/apps/desktop/src/main/vault/attachments.ts
@@ -54,9 +54,15 @@ export class AttachmentError extends Error {
 // ============================================================================
 
 /**
- * Maximum file size: 10MB
+ * Maximum file size: 100MB.
+ *
+ * Deliberately set above the sync file limits rather than in step with them: a
+ * large PDF is allowed to live in the vault as a local-only attachment. Sync
+ * has its own gate (the plan preflight in sync/attachments.ts, then the 500MB
+ * hard cap), which rejects the file as `file_too_large` without retrying, so it
+ * stays on this device instead of being refused from the note entirely.
  */
-export const MAX_FILE_SIZE = 10 * 1024 * 1024
+export const MAX_FILE_SIZE = 100 * 1024 * 1024
 
 /**
  * Allowed image file extensions

--- a/apps/desktop/src/preload/generated-rpc.test.ts
+++ b/apps/desktop/src/preload/generated-rpc.test.ts
@@ -16,9 +16,11 @@ const sampleInput = {
   title: 'Title'
 }
 
+const attachmentBuffer = new Uint8Array([1, 2, 3]).buffer
+
 const createFileLike = () => ({
   name: 'attachment.bin',
-  arrayBuffer: vi.fn(async () => new Uint8Array([1, 2, 3]).buffer)
+  arrayBuffer: vi.fn(async () => attachmentBuffer)
 })
 
 const collectFunctionPaths = (value: unknown, prefix: string[] = []): string[][] => {
@@ -72,8 +74,15 @@ describe('createGeneratedRpcApi', () => {
     expect(invoke).toHaveBeenCalledWith('notes:upload-attachment', {
       noteId: 'note-1',
       filename: 'attachment.bin',
-      data: [1, 2, 3]
+      data: attachmentBuffer
     })
+    // The ArrayBuffer crosses the IPC boundary untouched. Expanding it into a
+    // number[] here is what made a large attachment cost seconds of parsing and
+    // gigabytes of RSS before it ever reached the main process.
+    const uploadPayload = invoke.mock.calls.find(
+      (call) => call[0] === 'notes:upload-attachment'
+    )?.[1] as { data: unknown } | undefined
+    expect(uploadPayload?.data).toBe(attachmentBuffer)
     expect(invoke).toHaveBeenCalledWith(
       'inbox:track-suggestion',
       'inbox-1',

--- a/apps/desktop/src/preload/generated-rpc.ts
+++ b/apps/desktop/src/preload/generated-rpc.ts
@@ -106,7 +106,7 @@ export function createGeneratedRpcApi({
         invoke("notes:upload-attachment", {
           noteId,
           filename: file.name,
-          data: Array.from(new Uint8Array(await file.arrayBuffer()))
+          data: await file.arrayBuffer()
         })) as GeneratedRpcApi["notes"]["uploadAttachment"],
       "listAttachments": ((noteId) => invoke("notes:list-attachments", noteId)) as GeneratedRpcApi["notes"]["listAttachments"],
       "deleteAttachment": ((noteId, filename) => invoke("notes:delete-attachment", { noteId, filename })) as GeneratedRpcApi["notes"]["deleteAttachment"],

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -24,6 +24,8 @@ const contentAreaMocks = vi.hoisted(() => ({
     uploadAttachment: vi.fn()
   },
   fetchLinkPreview: vi.fn(),
+  toastError: vi.fn(),
+  defaultFileItemClick: vi.fn(),
   createLinkMentionContent: vi.fn(
     (url: string, domain: string, title?: string, favicon?: string) => ({
       type: 'linkMention',
@@ -90,9 +92,24 @@ vi.mock('@blocknote/react', () => ({
     return <div data-testid={`grid-suggestion-${props.triggerCharacter}`} />
   },
   getDefaultReactSlashMenuItems: vi.fn(() => [
-    { title: 'Paragraph', aliases: ['text'] },
-    { title: 'Heading', aliases: ['title'] }
-  ])
+    { key: 'paragraph', title: 'Paragraph', aliases: ['text'] },
+    { key: 'heading', title: 'Heading', aliases: ['title'] },
+    { key: 'image', title: 'Image', aliases: ['image', 'img', 'picture'], group: 'Media' },
+    {
+      key: 'file',
+      title: 'File',
+      subtext: 'Embedded file',
+      aliases: ['file', 'upload'],
+      group: 'Media',
+      onItemClick: contentAreaMocks.defaultFileItemClick
+    }
+  ]),
+  FilePanelController: () => <div data-testid="file-panel-controller" />,
+  UploadTab: () => <div data-testid="upload-tab" />
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: contentAreaMocks.toastError, success: vi.fn() }
 }))
 
 vi.mock('@blocknote/shadcn', () => ({
@@ -561,6 +578,7 @@ describe('ContentArea', () => {
       <ContentArea
         noteId="note-1"
         review={{
+          plainMarkdown: '',
           marks: [
             {
               id: 'add-1',
@@ -690,6 +708,8 @@ describe('ContentArea', () => {
       contentAreaMocks.blockNoteOptions.uploadFile(new File(['b'], 'b.txt'))
     ).rejects.toThrow('blocked')
 
+    expect(contentAreaMocks.toastError).toHaveBeenCalledWith('blocked')
+
     await expect(
       contentAreaMocks.blockNoteOptions.uploadFile(new File(['c'], 'c.txt'))
     ).resolves.toBe('attachments/file.png')
@@ -697,6 +717,73 @@ describe('ContentArea', () => {
       'note-upload',
       expect.any(File)
     )
+  })
+
+  it('returns full file-block props for a file block and a bare url for an image block', async () => {
+    render(<ContentArea noteId="note-upload" />)
+    await waitFor(() => expect(contentAreaMocks.blockNoteOptions).toBeTruthy())
+
+    createBlock('pdf-block', { type: 'file', props: {} })
+    createBlock('image-block', { type: 'image', props: {} })
+
+    contentAreaMocks.notesService.uploadAttachment.mockResolvedValueOnce({
+      success: true,
+      path: 'attachments/manual.pdf',
+      name: 'manual.pdf',
+      size: 4096,
+      mimeType: 'application/pdf',
+      type: 'file'
+    })
+    // Without size + mimeType the block renders the download card instead of
+    // the inline PDF viewer — the whole point of this shape.
+    await expect(
+      contentAreaMocks.blockNoteOptions.uploadFile(
+        new File(['p'], 'manual.pdf', { type: 'application/pdf' }),
+        'pdf-block'
+      )
+    ).resolves.toEqual({
+      props: {
+        url: 'attachments/manual.pdf',
+        name: 'manual.pdf',
+        size: 4096,
+        mimeType: 'application/pdf'
+      }
+    })
+
+    // Image blocks have no size/mimeType props; unknown props break them.
+    contentAreaMocks.notesService.uploadAttachment.mockResolvedValueOnce({
+      success: true,
+      path: 'attachments/shot.png',
+      name: 'shot.png',
+      size: 128,
+      mimeType: 'image/png',
+      type: 'image'
+    })
+    await expect(
+      contentAreaMocks.blockNoteOptions.uploadFile(
+        new File(['i'], 'shot.png', { type: 'image/png' }),
+        'image-block'
+      )
+    ).resolves.toBe('attachments/shot.png')
+  })
+
+  it('offers a PDF slash item that runs the default file item', async () => {
+    render(<ContentArea noteId="note-1" />)
+
+    const slashController = contentAreaMocks.suggestionControllers.find(
+      (controller) => controller.triggerCharacter === '/'
+    )
+    const items = await slashController.getItems('pdf')
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({ key: 'pdf', group: 'Media' })
+
+    items[0].onItemClick()
+    expect(contentAreaMocks.defaultFileItemClick).toHaveBeenCalledTimes(1)
+
+    // `/photo` is a new alias on BlockNote's image item.
+    await expect(slashController.getItems('photo')).resolves.toEqual([
+      expect.objectContaining({ key: 'image' })
+    ])
   })
 
   it('debounces standalone checkbox conversion and clears pending conversion on unmount', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -6,7 +6,11 @@ import {
   SuggestionMenuController,
   GridSuggestionMenuController,
   useCreateBlockNote,
+  useComponentsContext,
   getDefaultReactSlashMenuItems,
+  FilePanelController,
+  UploadTab,
+  type FilePanelProps,
   type SuggestionMenuProps
 } from '@blocknote/react'
 import { BlockNoteView } from '@blocknote/shadcn'
@@ -87,6 +91,8 @@ import { useFiredDatePillAnchors, useTriggeredDatePills } from './use-triggered-
 import { useDateMentionPrefs } from '@/hooks/use-date-mention-prefs'
 import { DateMentionPopover, type DateMentionValue } from './date-mention-popover'
 import { MentionMenu, type MentionSuggestionItem } from './mention-menu'
+import { toast } from 'sonner'
+import { extractErrorMessage } from '@/lib/ipc-error'
 import { useMentionSuggestions } from './hooks/use-mention-suggestions'
 import type { PasteLinkOption } from './hooks/use-paste-link-menu'
 import { useT } from '@memry/i18n/renderer'
@@ -118,6 +124,36 @@ function findBookmarkBlock(blocks: any[], url: string): any {
     }
   }
   return null
+}
+
+/**
+ * BlockNote's file panel with its "Embed" tab removed.
+ *
+ * Embed writes a remote URL onto the block: the content then lives outside the
+ * vault and renders as a broken box offline, which is the opposite of what an
+ * offline-first note app promises. Upload is the only way in.
+ *
+ * This assembles the stock panel rather than reimplementing it — `UploadTab`
+ * and the panel Root both come from BlockNote. Root is used directly instead of
+ * `<FilePanel tabs={...} />` only so the `loading` flag `UploadTab` sets stays
+ * wired to the panel's spinner; `FilePanel` keeps that state private.
+ */
+function UploadOnlyFilePanel({ blockId }: FilePanelProps): React.ReactElement {
+  const Components = useComponentsContext()!
+  const { t } = useT('notes')
+  const [loading, setLoading] = useState(false)
+  const tabName = t('editor.filePanel.uploadTab')
+
+  return (
+    <Components.FilePanel.Root
+      className="bn-panel"
+      defaultOpenTab={tabName}
+      openTab={tabName}
+      setOpenTab={() => {}}
+      tabs={[{ name: tabName, tabPanel: <UploadTab blockId={blockId} setLoading={setLoading} /> }]}
+      loading={loading}
+    />
+  )
 }
 
 // =============================================================================
@@ -200,14 +236,53 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     noteIdRef.current = noteId
   }, [noteId])
 
-  // Upload function — defined before editor creation so BlockNote can use it
-  const uploadFile = useCallback(async (file: File): Promise<string> => {
-    const currentNoteId = noteIdRef.current
-    if (!currentNoteId) throw new Error('Cannot upload: no note selected')
-    const result = await notesService.uploadAttachment(currentNoteId, file)
-    if (!result.success || !result.path) throw new Error(result.error || 'Upload failed')
-    return result.path
-  }, [])
+  // `uploadFile` is handed to BlockNote once, at editor creation, so anything it
+  // needs has to come through a ref or it goes stale (same reason as noteIdRef).
+  const editorRef = useRef<any>(null)
+  const tRef = useRef(t)
+  useEffect(() => {
+    tRef.current = t
+  }, [t])
+
+  // Upload function — defined before editor creation so BlockNote can use it.
+  //
+  // BlockNote passes whatever this resolves to straight to `updateBlock`, and
+  // only wraps it when it is a plain string — as `{ props: { name, url } }`.
+  // For Memry's `file` block that wrapper is lossy: `size` stays 0 and
+  // `mimeType` stays '', so a PDF added through the `/file` panel rendered the
+  // download card while the same PDF dropped from Finder rendered the inline
+  // viewer. Returning the full props for `file` blocks makes both paths agree.
+  // Image/video/audio keep the string: they have no size/mimeType props and
+  // unknown props break them.
+  const uploadFile = useCallback(
+    async (file: File, blockId?: string): Promise<string | Record<string, unknown>> => {
+      const currentNoteId = noteIdRef.current
+      if (!currentNoteId) throw new Error('Cannot upload: no note selected')
+      try {
+        const result = await notesService.uploadAttachment(currentNoteId, file)
+        if (!result.success || !result.path) throw new Error(result.error || 'Upload failed')
+
+        const block = blockId ? editorRef.current?.getBlock?.(blockId) : undefined
+        if (block?.type === 'file') {
+          return {
+            props: {
+              url: result.path,
+              name: result.name || file.name,
+              size: result.size ?? file.size,
+              mimeType: result.mimeType || file.type
+            }
+          }
+        }
+        return result.path
+      } catch (error) {
+        // BlockNote's upload tab only shows a generic "upload failed" line, so
+        // the real reason (too large, type not allowed) never reached the user.
+        toast.error(extractErrorMessage(error, tRef.current('editor.upload.failed')))
+        throw error
+      }
+    },
+    []
+  )
 
   // Vaults written by other apps reference media with a plain relative path
   // (`../Images/Media/photo.png`). Without this, BlockNote hands that string to
@@ -251,6 +326,12 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
         }
       : {})
   })
+
+  // Closes the loop for `uploadFile`, which is built before the editor exists
+  // but needs `getBlock` to know whether it is filling a `file` block.
+  useEffect(() => {
+    editorRef.current = editor
+  }, [editor])
 
   // Hook #1: Editor setup (AI extension, spellcheck, links, highlight scroll)
   const { aiReady } = useBlockNoteSetup({
@@ -1225,6 +1306,7 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
           formattingToolbar={false}
           slashMenu={false}
           emojiPicker={false}
+          filePanel={false}
         >
           {/* Memry's toolbar on every surface, review or not: BlockNote's stock
               one has no list toggles, so the template editor used to be the odd
@@ -1235,10 +1317,32 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
             <ReviewFormattingToolbarController onAddComment={review?.onAddComment} />
           )}
           {aiEnabled && aiReady && <AIMenuController aiMenu={CustomAIMenu} />}
+          <FilePanelController filePanel={UploadOnlyFilePanel} />
           <SuggestionMenuController
             triggerCharacter="/"
             getItems={async (query) => {
-              const defaults = getDefaultReactSlashMenuItems(editor)
+              // `img` and `picture` already ship as image aliases; `photo` did
+              // not, and is what people actually type.
+              const defaults = getDefaultReactSlashMenuItems(editor).map((item) =>
+                (item as { key?: string }).key === 'image'
+                  ? { ...item, aliases: [...(item.aliases ?? []), 'photo'] }
+                  : item
+              )
+              // `/pdf` is the same item as `/file` — same insert, same panel —
+              // relabelled, because "attach a PDF" is what most people are
+              // actually after and `/pdf` matched nothing before.
+              const fileItem = defaults.find((item) => (item as { key?: string }).key === 'file')
+              const pdfItems = fileItem
+                ? [
+                    {
+                      ...fileItem,
+                      key: 'pdf',
+                      title: t('editor.slashMenu.pdf.title'),
+                      subtext: t('editor.slashMenu.pdf.subtext'),
+                      aliases: ['pdf', 'document', 'attachment']
+                    }
+                  ]
+                : []
               const aiItems = aiEnabled && aiReady ? getAISlashMenuItems(editor) : []
               const calloutItem = getCalloutSlashMenuItem(editor, {
                 title: t('editor.callout.title'),
@@ -1273,6 +1377,7 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
                 : []
               const all = orderSlashMenuItemsByGroup([
                 ...defaults,
+                ...pdfItems,
                 calloutItem,
                 ...(taskItem ? [taskItem] : []),
                 ...dateItems,

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createFileBlock,
   createFileBlockContent,
+  FILE_BLOCK_ACCEPT,
   parseFileBlockMarker,
   serializeFileBlock
 } from './file-block'
@@ -30,6 +31,7 @@ vi.mock('@/contexts/sync-context', () => ({
 vi.mock('@blocknote/react', () => ({
   createReactBlockSpec: vi.fn((schema, implementation) => ({
     schema,
+    meta: implementation.meta,
     render: implementation.render
   }))
 }))
@@ -77,6 +79,28 @@ describe('file block helpers', () => {
     expect(parseFileBlockMarker('not a marker')).toBeNull()
     expect(parseFileBlockMarker('<!-- file:{bad json} -->')).toBeNull()
     expect(createFileBlockContent(props)).toEqual({ type: 'file', props })
+  })
+
+  it('declares the vault-allowed extensions so the file picker cannot offer a rejected type', () => {
+    // Mirrors ALLOWED_IMAGE_EXTENSIONS + ALLOWED_FILE_EXTENSIONS in
+    // apps/desktop/src/main/vault/attachments.ts.
+    expect(FILE_BLOCK_ACCEPT).toEqual([
+      '.png',
+      '.jpg',
+      '.jpeg',
+      '.gif',
+      '.webp',
+      '.svg',
+      '.pdf',
+      '.doc',
+      '.docx',
+      '.xls',
+      '.xlsx',
+      '.txt',
+      '.md'
+    ])
+    // BlockNote's upload tab reads the accept list off the spec's meta.
+    expect((createFileBlock as any).meta).toEqual({ fileBlockAccept: FILE_BLOCK_ACCEPT })
   })
 
   it('persists an explicit width and omits the default (byte-stable for legacy markers)', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -685,11 +685,41 @@ function FileBlockRender({
   )
 }
 
+/**
+ * What the file panel's picker offers, and what the paste/drop handler treats
+ * as file-block material.
+ *
+ * Mirrors `ALLOWED_IMAGE_EXTENSIONS` + `ALLOWED_FILE_EXTENSIONS` in
+ * `apps/desktop/src/main/vault/attachments.ts`, which is the source of truth —
+ * the renderer cannot import from main, so the list is restated here. Without
+ * it BlockNote's picker accepts every file type and lets the user choose
+ * something the main process then rejects.
+ *
+ * Extensions, not mime globs, on purpose: `image/*` here would compete with the
+ * built-in `image` block for pasted images.
+ */
+export const FILE_BLOCK_ACCEPT = [
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.svg',
+  '.pdf',
+  '.doc',
+  '.docx',
+  '.xls',
+  '.xlsx',
+  '.txt',
+  '.md'
+]
+
 // Type/props/content come from the shared config so this block and the main
 // process's headless twin cannot disagree. `file` is the one that shadows a
 // BlockNote DEFAULT block: before the config was shared, main built the default
 // spec and silently dropped size/mimeType/width/height/align on the way to disk.
 export const createFileBlock = createReactBlockSpec(fileBlockConfig, {
+  meta: { fileBlockAccept: FILE_BLOCK_ACCEPT },
   render: FileBlockRender
 })
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-file-upload.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-file-upload.test.ts
@@ -6,8 +6,11 @@ const mocks = vi.hoisted(() => ({
   uploadAttachment: vi.fn(),
   getFile: vi.fn(),
   warn: vi.fn(),
-  error: vi.fn()
+  error: vi.fn(),
+  toastError: vi.fn()
 }))
+
+vi.mock('sonner', () => ({ toast: { error: mocks.toastError, success: vi.fn() } }))
 
 vi.mock('@/services/notes-service', () => ({
   notesService: { uploadAttachment: mocks.uploadAttachment, getFile: mocks.getFile }
@@ -163,6 +166,28 @@ describe('useEditorFileUpload', () => {
       'target-block',
       'before'
     )
+  })
+
+  // A rejected drop used to be silent: log + telemetry, nothing on screen.
+  it('tells the user why a dropped file was rejected', async () => {
+    const { result, editor } = setup()
+    mocks.uploadAttachment.mockResolvedValueOnce({
+      success: false,
+      error: 'File too large. Maximum size is 100.0 MB, got 140.2 MB'
+    })
+
+    await act(async () => {
+      await result.current.handleNonImageDrop({
+        dataTransfer: { files: [new File(['x'], 'huge.pdf', { type: 'application/pdf' })] },
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn()
+      } as unknown as React.DragEvent)
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'File too large. Maximum size is 100.0 MB, got 140.2 MB'
+    )
+    expect(editor.insertBlocks).not.toHaveBeenCalled()
   })
 
   it('handles no-note and read-only drops without inserting blocks', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-file-upload.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-file-upload.ts
@@ -6,10 +6,21 @@ import { createFileBlockContent } from '../file-block'
 import type { DropTarget } from '../drop-target-utils'
 import { createLogger } from '@/lib/logger'
 import { trackRendererError } from '@/lib/telemetry-diagnostics'
+import { toast } from 'sonner'
+import { getI18n } from 'react-i18next'
+import { extractErrorMessage } from '@/lib/ipc-error'
 import { toMemryFileUrl } from '@/lib/memry-file-url'
 import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
 
 const log = createLogger('Hook:EditorFileUpload')
+
+// A rejected drop used to be log-only: the file simply never appeared and the
+// user was left guessing. The reasons are ones users hit (over the size cap, an
+// extension the vault does not accept), so they have to be said out loud.
+function reportUploadFailure(error: unknown): void {
+  const t = getI18n().getFixedT(null, 'notes')
+  toast.error(extractErrorMessage(error, t('editor.upload.failed')))
+}
 
 const IMAGE_TYPES = [
   'image/png',
@@ -108,6 +119,7 @@ export function useEditorFileUpload({
               'editor_attachment_upload',
               new Error(result.error || 'Upload failed')
             )
+            reportUploadFailure(result.error)
             continue
           }
 
@@ -145,6 +157,7 @@ export function useEditorFileUpload({
         } catch (error) {
           log.error('Failed to upload file', file.name, error)
           trackRendererError('editor_attachment_upload', error)
+          reportUploadFailure(error)
         }
       }
 

--- a/apps/desktop/tsconfig.test.web.json
+++ b/apps/desktop/tsconfig.test.web.json
@@ -53,7 +53,6 @@
     "src/renderer/src/components/missing-small-components.test.tsx",
     "src/renderer/src/components/more-zero-renderer-surfaces.test.tsx",
     "src/renderer/src/components/note-sidebar-surfaces.test.tsx",
-    "src/renderer/src/components/note/content-area/ContentArea.test.tsx",
     "src/renderer/src/components/note/content-area/ai-surfaces.test.tsx",
     "src/renderer/src/components/note/content-area/delete-at-doc-end.integration.test.ts",
     "src/renderer/src/components/note/content-area/hash-tag-inline-plugin.test.ts",

--- a/apps/docs/src/user-guide/import.md
+++ b/apps/docs/src/user-guide/import.md
@@ -327,4 +327,4 @@ Pages land as one note each under `OneNote/<notebook>/<section group…>/<sectio
 - **Skip previously imported pages** (default on) — imported page ids are remembered per vault (`.memry/import/onenote.json`), so re-running an import only picks up new pages. Turn it off to re-import everything.
 - **Import incompatible attachments** (default off) — also saves file types Memry can't embed natively (presentations, media, archives, and image formats the editor can't render such as EMF/TIFF clipboard art). They render as file blocks and open externally. Executables are never imported, even with this on.
 
-**Limitations:** attachments are capped at 10 MB each (Memry's vault attachment limit); larger files are skipped and counted. Microsoft throttles the OneNote API — large imports may pause for up to a minute at a time and continue automatically.
+**Limitations:** attachments are capped at 100 MB each (Memry's vault attachment limit); larger files are skipped and counted. Microsoft throttles the OneNote API — large imports may pause for up to a minute at a time and continue automatically.

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -175,6 +175,18 @@
       "warning": "Warning",
       "error": "Error",
       "success": "Success"
+    },
+    "slashMenu": {
+      "pdf": {
+        "title": "PDF",
+        "subtext": "Attach a PDF and read it inline"
+      }
+    },
+    "filePanel": {
+      "uploadTab": "Upload"
+    },
+    "upload": {
+      "failed": "Could not attach that file"
     }
   },
   "dateMention": {

--- a/packages/rpc/src/notes.test.ts
+++ b/packages/rpc/src/notes.test.ts
@@ -57,6 +57,15 @@ describe('notesRpc domain shape', () => {
     expect(notesRpc.methods.uploadAttachment.implementation).toContain('arrayBuffer')
   })
 
+  it('uploadAttachment sends the ArrayBuffer instead of expanding it into a number[]', () => {
+    const implementation = notesRpc.methods.uploadAttachment.implementation ?? ''
+    expect(implementation).toContain('data: await file.arrayBuffer()')
+    // A number[] of one element per byte costs seconds and gigabytes of RSS on
+    // a large attachment; the main-side schema takes the ArrayBuffer directly.
+    expect(implementation).not.toContain('Array.from')
+    expect(implementation).not.toContain('Uint8Array')
+  })
+
   it('wires event channels to NotesChannels.events where applicable', () => {
     expect(notesRpc.events.onNoteCreated.channel).toBe(NotesChannels.events.CREATED)
     expect(notesRpc.events.onNoteDeleted.channel).toBe(NotesChannels.events.DELETED)

--- a/packages/rpc/src/notes.ts
+++ b/packages/rpc/src/notes.ts
@@ -579,11 +579,15 @@ export const notesRpc = defineDomain({
     >({
       channel: NotesChannels.invoke.UPLOAD_ATTACHMENT,
       params: ['noteId', 'file'],
+      // The ArrayBuffer goes over IPC as-is. Expanding it into a number[] first
+      // costs seconds and gigabytes of RSS on a large attachment (a 100 MB file
+      // becomes a 100-million-element array to build, clone, and validate); the
+      // main-side schema and handler accept both shapes.
       implementation: `async (noteId, file) =>
         invoke(${JSON.stringify(NotesChannels.invoke.UPLOAD_ATTACHMENT)}, {
           noteId,
           filename: file.name,
-          data: Array.from(new Uint8Array(await file.arrayBuffer()))
+          data: await file.arrayBuffer()
         })`
     }),
     listAttachments: defineMethod<(noteId: string) => Promise<AttachmentInfo[]>>({


### PR DESCRIPTION
Closes part of #1487.

## The bug

A PDF dropped from Finder embeds and opens the inline viewer. The same PDF added through the `/file` slash item lands as a download card. Same file, same note, two outcomes.

BlockNote's file panel writes only `{ name, url }` onto the block when `uploadFile` resolves to a string, so `size` stays `0` and `mimeType` stays `''` — and `file-block.tsx` picks the PDF viewer vs. the download card on `mimeType`. The panel hands an **object** return straight to `updateBlock`, so `uploadFile` now returns the full props for `file` blocks and keeps the bare string for image/video/audio (those have no `size`/`mimeType` props and unknown props break them). Every path now converges on one block.

## What's in here

**Embed paths unified** — `/pdf` is a relabelled copy of the default file item, so both run identical code. `photo` alias on `/image`. An accept list on the block spec so the picker stops offering files the vault will reject. Failed uploads now say why: they were log-only, so a rejected file simply never appeared.

**Embed tab removed from the file panel** — it writes a remote URL onto the block, which renders as a broken box offline. Upload is the only way in. Note this is panel-wide, so image/video/audio lose embed-by-URL too.

**Vault attachment cap 10 MB → 100 MB** — deliberately above the sync limits, not in step with them: a large PDF may live in the vault as a local-only attachment. Sync keeps its own gate (plan preflight + 500 MB hard cap → `file_too_large`, outside any retry wrapper), so an oversized file stays on this device instead of being refused from the note entirely.

**Attachment bytes cross IPC as an `ArrayBuffer`** — preload was expanding the file into `Array.from(new Uint8Array(...))`. Measured for one 100 MB attachment:

| | `number[]` | `ArrayBuffer` |
|---|---|---|
| total blocked | ~6.9 s | ~0.06 s |
| IPC message | 200 MB | 100 MB |
| peak RSS | 3.0–3.4 GB | — |

The main-side schema already accepted both shapes and the handler already branches on them; preload and main ship in the same binary, so there is no mixed-version window.

## How to test

1. Drag a large PDF (50–80 MB) from Finder into a note — embeds, no freeze.
2. `/pdf` → pick a PDF — inline viewer, not a download card.
3. `/file` → PDF, same result; `/file` → `.docx` → download card.
4. `/image` and `/photo` insert an image.
5. Drag a PDF out of the sidebar — embeds by reference, no copy in `attachments/`.
6. Drag a `.zip` — a toast says why it was refused (previously silent).
7. The file panel has no Embed tab.

## Verified

`pnpm typecheck` · `pnpm lint` · `pnpm ipc:check` · `git diff --check` — all clean. `pnpm test:desktop`: **1286 files / 16351 tests passed, 0 failed**. `pnpm docs:impact --strict`: covered. E2E is push-to-main only, so it is not evidence here.

## Not in this PR

- `![[report.pdf]]` still resolves to a markdown image and renders broken — open item on #1487.
- Attachment URLs are written into markdown as absolute `memry-file://`, so embeds break on a second device. Pre-existing for images too — #1488.
- `packages/app-core/src/note-files.ts` is a separate CLI-only attachment implementation, still at 10 MB.
- `task-description-editor`, `inbox-content-editor` and `canvas-note-body` pass no `uploadFile` at all, so their panels are embed-only. Pre-existing.