### PR TITLE
docs(sync): list every CRDT route in the sync-protocol endpoint table

### DIFF
--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -520,17 +520,33 @@ list.
 
 ## Endpoints
 
-| Path                      | Direction | Purpose                                                                        |
-| ------------------------- | --------- | ------------------------------------------------------------------------------ |
-| `POST /sync/push`         | up        | Upload new sync items (metadata + blob refs)                                   |
-| `POST /sync/pull`         | down      | Fetch updates since cursor                                                     |
-| `POST /sync/crdt/updates` | both      | Incremental Yjs binary updates                                                 |
-| `GET /sync/vaults`        | down      | List the account's registered vaults                                           |
-| `POST /sync/vaults`       | up        | Register or update a vault's encrypted name                                    |
-| `POST /auth/*`            | mixed     | OTP, sign-in, refresh, sign-out                                                |
-| `GET /auth/key-verifier`  | down      | Account key verifier for an established session (vault-key mismatch detection) |
-| `POST /devices/*`         | mixed     | Linking, listing, revoking                                                     |
-| `POST /keys/*`            | mixed     | Key sealing during link, rotation                                              |
+| Path                              | Direction | Purpose                                                                          |
+| --------------------------------- | --------- | -------------------------------------------------------------------------------- |
+| `POST /sync/push`                 | up        | Upload new sync items (metadata + blob refs)                                     |
+| `POST /sync/pull`                 | down      | Fetch updates since cursor                                                       |
+| `POST /sync/crdt/updates`         | up        | Incremental Yjs binary updates                                                   |
+| `GET /sync/crdt/updates`          | down      | One note's incremental updates (`note_id`, `since`, `limit` query params)        |
+| `POST /sync/crdt/updates/batch`   | down      | Incremental updates for up to 100 notes in one request; never snapshot baselines |
+| `POST /sync/crdt/snapshot`        | up        | Full Yjs document baseline; prunes the note's stored updates at or below it      |
+| `GET /sync/crdt/snapshot/:noteId` | down      | The note's snapshot baseline, applied before its incrementals                    |
+| `GET /sync/vaults`                | down      | List the account's registered vaults                                             |
+| `POST /sync/vaults`               | up        | Register or update a vault's encrypted name                                      |
+| `POST /auth/*`                    | mixed     | OTP, sign-in, refresh, sign-out                                                  |
+| `GET /auth/key-verifier`          | down      | Account key verifier for an established session (vault-key mismatch detection)   |
+| `POST /devices/*`                 | mixed     | Linking, listing, revoking                                                       |
+| `POST /keys/*`                    | mixed     | Key sealing during link, rotation                                                |
+
+The five `/sync/crdt/*` routes are the only ones that carry a note body; the record feed above them
+moves metadata only. A device reads a body by applying the baseline from
+`GET /sync/crdt/snapshot/:noteId` and then replaying incrementals from `GET /sync/crdt/updates`.
+`POST /sync/crdt/updates/batch` is the whole-vault form of that second step — up to 100 notes per
+request, each with its own `since` — but it batches incrementals only, so the baselines stay one GET
+per note and dominate a first-sync sweep's request count.
+
+Pushing a snapshot is an assertion, not just a write: once the snapshot is stored,
+`pruneUpdatesBeforeSnapshot` deletes every `crdt_updates` row for that note at or below the
+snapshot's sequence number. A snapshot that does not already contain those updates does not merely
+fail to add them — it removes them from the server.
 
 ### CRDT update sizing
 


### PR DESCRIPTION
Closes #1497. Part of EPIC #1499.

The Endpoints table in `apps/docs/src/architecture/sync-protocol.md` carried `POST /sync/crdt/updates` and nothing else from the CRDT transport, even though the four missing routes are what actually move note bodies and the prose below the table already named three of them.

Adds the pull, batch-pull, snapshot-push and snapshot-pull rows, plus two paragraphs covering the properties that are easy to get wrong.

## Verified against the server, not the client

Every row was checked against `crdtSync` in `apps/sync-server/src/routes/sync.ts` (mounted at `sync.route('/crdt', crdtSync)`):

| Registered | Limiter |
| --- | --- |
| `POST /sync/crdt/updates` | `crdt_push` |
| `GET /sync/crdt/updates` | `crdt_pull` |
| `POST /sync/crdt/updates/batch` | `crdt_batch_pull` |
| `POST /sync/crdt/snapshot` | `crdt_push` |
| `GET /sync/crdt/snapshot/:noteId` | `crdt_pull` |

## One correction beyond adding rows

`POST /sync/crdt/updates` was listed as direction **both**. `handleCrdtUpdatePush` only ever returns the stored sequence numbers — it is purely an upload. "both" read as shorthand for "the CRDT transport is bidirectional", which stops working as shorthand once the GET has its own row. Corrected to **up**.

## Two properties now stated explicitly

- **A snapshot push is an assertion, not an addition.** `pruneUpdatesBeforeSnapshot` (`apps/sync-server/src/services/crdt.ts:288`) deletes every `crdt_updates` row for the note at or below the snapshot's sequence number — all devices' rows, not just the pusher's. A snapshot that does not already contain those updates removes them from the server. This is the invariant behind #1489.
- **The batch route batches incrementals only**, capped at 100 notes per request. Snapshot baselines stay one GET per note, which is why a first-sync sweep is dominated by `crdt_pull` GETs rather than batch POSTs.

## Verification

- `pnpm docs:build` — build complete, no errors (re-run independently by the main session)
- `pnpm docs:impact --base 255d2387 --strict` — no desktop/sync-server docs-relevant changes detected
- `git diff --check` — clean
- No unit tests apply to a docs-only change.

## Found while verifying — not fixed here

Two places still carry a stale `crdt_pull` budget of 300/60s where the server says **600**:
- `apps/docs/src/architecture/crdt.md:427` — also contradicts its own line 615
- `apps/desktop/src/main/sync/engine/sync-context.ts:167-169` — the comment engineers read while pacing the sweep

Left alone to keep this diff docs-table-only; filing separately.