### PR TITLE
fix(sync): an integrity teardown reopens the CRDT store instead of leaving the editor dead

### DIFF
--- a/apps/desktop/src/main/sync/session-teardown.test.ts
+++ b/apps/desktop/src/main/sync/session-teardown.test.ts
@@ -8,10 +8,6 @@ const mocks = vi.hoisted(() => ({
   clearPendingSession: vi.fn(),
   clearPendingLinkCompletion: vi.fn(),
   clearInMemoryAuthState: vi.fn(),
-  initPersistence: vi.fn(),
-  // Not a method the provider has any more — kept on the mock so a re-added
-  // sign-out wipe fails here loudly instead of silently deleting history.
-  wipeStorage: vi.fn(),
   isDatabaseInitialized: vi.fn(),
   getDatabase: vi.fn(),
   storeSet: vi.fn(),
@@ -27,6 +23,47 @@ const mocks = vi.hoisted(() => ({
   dbDelete: vi.fn(),
   transaction: vi.fn()
 }))
+
+// stopSyncRuntime() destroys the CRDT provider and drops the singleton, so the
+// reopen at the end of teardown has to land on the *replacement* instance. A
+// bare vi.fn() cannot tell the two apart — a reopen aimed at the provider that
+// was already destroyed records an identical call, which is exactly how #1456's
+// rebind passed its tests while failing 100% of the time in production. So the
+// fake mints a new instance on every reset and records which one each
+// initPersistence() call actually reached.
+const crdtProvider = vi.hoisted(() => {
+  const initPersistence = vi.fn()
+  // Not a method the provider has any more — kept on the fake so a re-added
+  // sign-out wipe fails here loudly instead of silently deleting history.
+  const wipeStorage = vi.fn()
+  let generation = 0
+  const openedGenerations: number[] = []
+
+  return {
+    initPersistence,
+    wipeStorage,
+    openedGenerations,
+    liveGeneration: () => generation,
+    /** What stopSyncRuntime() does to the provider: destroy it, drop the singleton. */
+    destroyAndReset: () => {
+      generation += 1
+    },
+    reset: () => {
+      generation = 0
+      openedGenerations.length = 0
+    },
+    get: () => {
+      const instance = generation
+      return {
+        initPersistence: (...args: unknown[]) => {
+          openedGenerations.push(instance)
+          return initPersistence(...args)
+        },
+        wipeStorage: (...args: unknown[]) => wipeStorage(...args)
+      }
+    }
+  }
+})
 
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn((left, right) => ({ left, right }))
@@ -51,10 +88,7 @@ vi.mock('./linking-service', () => ({
 }))
 
 vi.mock('./crdt-provider', () => ({
-  getCrdtProvider: () => ({
-    initPersistence: mocks.initPersistence,
-    wipeStorage: mocks.wipeStorage
-  })
+  getCrdtProvider: () => crdtProvider.get()
 }))
 
 vi.mock('../ipc/sync-core-handlers', () => ({
@@ -113,20 +147,33 @@ async function importModule() {
   return import('./session-teardown')
 }
 
+/** The store came back up, on the instance that replaced the destroyed one. */
+function expectStoreReopened() {
+  expect(crdtProvider.initPersistence).toHaveBeenCalledTimes(1)
+  expect(crdtProvider.openedGenerations).toEqual([crdtProvider.liveGeneration()])
+}
+
+function expectStoreLeftClosed() {
+  expect(crdtProvider.initPersistence).not.toHaveBeenCalled()
+}
+
 describe('session teardown', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
     setupDb()
-    mocks.stopSyncRuntime.mockResolvedValue(undefined)
+    crdtProvider.reset()
+    mocks.stopSyncRuntime.mockImplementation(async () => {
+      crdtProvider.destroyAndReset()
+    })
     mocks.getValidAccessToken.mockResolvedValue('access-token')
     mocks.postToServer.mockResolvedValue({})
     mocks.isDatabaseInitialized.mockReturnValue(true)
     mocks.listGoogleAccountIds.mockReturnValue(['calendar-a', 'calendar-b'])
     mocks.disconnectGoogleCalendar.mockResolvedValue(undefined)
     mocks.deleteKey.mockResolvedValue(undefined)
-    mocks.initPersistence.mockResolvedValue(undefined)
-    mocks.wipeStorage.mockResolvedValue(undefined)
+    crdtProvider.initPersistence.mockResolvedValue(undefined)
+    crdtProvider.wipeStorage.mockResolvedValue(undefined)
   })
 
   it('logs out by revoking the server session, clearing keychain state, and wiping local sync state', async () => {
@@ -152,21 +199,7 @@ describe('session teardown', () => {
     expect(mocks.storeSet).toHaveBeenCalledWith('sync', {})
   })
 
-  // The store used to be deleted here. It held the only local record of how
-  // each note got to its current state, so a note edited while signed out had
-  // nothing to merge against on sign-in: the other device's version replaced it
-  // outright. Editing is never gated on a session, so the provider has to come
-  // back up too — stopSyncRuntime() destroyed it on the way in.
-  it('keeps the CRDT store on sign-out and reopens it', async () => {
-    const { teardownSession } = await importModule()
-
-    await teardownSession('logout')
-
-    expect(mocks.wipeStorage).not.toHaveBeenCalled()
-    expect(mocks.initPersistence).toHaveBeenCalled()
-  })
-
-  it('handles integrity teardown without revoking the server session or touching CRDT storage', async () => {
+  it('handles integrity teardown without revoking the server session or wiping CRDT storage', async () => {
     const { teardownSession } = await importModule()
 
     await teardownSession('integrity')
@@ -177,8 +210,51 @@ describe('session teardown', () => {
     expect(mocks.dbDelete).toHaveBeenCalled()
     expect(mocks.deleteWhere).toHaveBeenCalled()
     expect(mocks.transaction).not.toHaveBeenCalled()
-    expect(mocks.wipeStorage).not.toHaveBeenCalled()
-    expect(mocks.initPersistence).not.toHaveBeenCalled()
+    expect(crdtProvider.wipeStorage).not.toHaveBeenCalled()
+  })
+
+  // Which reasons put the CRDT store back, and which must not. stopSyncRuntime()
+  // destroys and resets the provider on the way in, so anything that leaves the
+  // app running has to reopen it or the editor stays unbound to any Y.Doc until
+  // the next launch. Editing is never gated on session state.
+  describe('CRDT store reopen', () => {
+    // The store used to be deleted here. It held the only local record of how
+    // each note got to its current state, so a note edited while signed out had
+    // nothing to merge against on sign-in: the other device's version replaced
+    // it outright.
+    it('reopens the store on sign-out, and never wipes it', async () => {
+      const { teardownSession } = await importModule()
+
+      await teardownSession('logout')
+
+      expect(crdtProvider.wipeStorage).not.toHaveBeenCalled()
+      expectStoreReopened()
+    })
+
+    // An integrity teardown is an involuntary sign-out, triggered by one
+    // keychain read that may itself be wrong. The user did not ask for it and
+    // is not told the editor went read-only, so leaving the provider dead here
+    // is worse than leaving it dead on an explicit sign-out.
+    it('reopens the store after an integrity teardown', async () => {
+      const { teardownSession } = await importModule()
+
+      await teardownSession('integrity')
+
+      expect(crdtProvider.wipeStorage).not.toHaveBeenCalled()
+      expectStoreReopened()
+    })
+
+    // The one reason that must not. The app is quitting: there is no editor
+    // left to serve, the vault uuid the store is scoped to is read from a data
+    // DB closeVault() is about to close, and a reopen would leave a freshly
+    // opened LevelDB store behind on the way out.
+    it('leaves the store closed on shutdown', async () => {
+      const { teardownSession } = await importModule()
+
+      await teardownSession('shutdown')
+
+      expectStoreLeftClosed()
+    })
   })
 
   it('reuses an in-flight teardown promise', async () => {

--- a/apps/desktop/src/main/sync/session-teardown.ts
+++ b/apps/desktop/src/main/sync/session-teardown.ts
@@ -108,24 +108,36 @@ async function performTeardown(reason: TeardownReason): Promise<TeardownResult> 
 
   store.set('sync', {})
 
-  if (reason === 'logout') {
-    // Sign-out used to delete the whole CRDT store here. It no longer does.
-    //
-    // The store was global — one directory for every vault, keyed by note id —
-    // so the wipe was containment for a collision that per-vault store paths
-    // now make impossible (see crdt-store-path.ts). What it cost was the merge
-    // history: the vault markdown survived a wipe, but with no local history
-    // left, a note edited while signed out could not *merge* with the server's
-    // version on sign-in — it could only be replaced by it, or re-seeded from
-    // markdown as an independent insertion, which duplicates the body. Signing
-    // out, editing, and signing back in silently lost the edit.
-    //
-    // stopSyncRuntime() above already destroyed and reset the provider, so the
-    // store has to be reopened or the editor stays unbound until the app
-    // restarts. Editing is never gated on being signed in.
+  // Sign-out used to delete the whole CRDT store here. It no longer does.
+  //
+  // The store was global — one directory for every vault, keyed by note id —
+  // so the wipe was containment for a collision that per-vault store paths now
+  // make impossible (see crdt-store-path.ts). What it cost was the merge
+  // history: the vault markdown survived a wipe, but with no local history
+  // left, a note edited while signed out could not *merge* with the server's
+  // version on sign-in — it could only be replaced by it, or re-seeded from
+  // markdown as an independent insertion, which duplicates the body. Signing
+  // out, editing, and signing back in silently lost the edit.
+  //
+  // stopSyncRuntime() above already destroyed and reset the provider, so the
+  // store has to be reopened or the editor stays unbound to any Y.Doc until the
+  // app restarts. Editing is never gated on session state — it stays fully
+  // available signed out, offline, and with no account at all — so every reason
+  // that leaves the app running has to put the store back. That is 'logout' and
+  // 'integrity' alike: an integrity teardown is an involuntary sign-out the user
+  // did not ask for, so leaving *it* with a dead provider is the worse of the
+  // two. Note that getCrdtProvider() is called here, after stopSyncRuntime()
+  // reset the singleton, so this opens the fresh instance rather than reviving
+  // the destroyed one.
+  //
+  // 'shutdown' is the exception, and the only one: the app is quitting, so
+  // there is no editor left to serve, and reopening would resolve the vault
+  // uuid out of a data DB that closeVault() is about to close and leave a
+  // freshly opened LevelDB store behind on the way out.
+  if (reason !== 'shutdown') {
     void getCrdtProvider()
       .initPersistence()
-      .catch((err) => log.warn('CRDT persistence re-init after sign-out failed', err))
+      .catch((err) => log.warn('CRDT persistence re-init after session teardown failed', err))
   }
 
   log.info('Session teardown complete', { reason, keychainFailures: keychainFailures.length })

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -526,6 +526,21 @@ the destroyed provider rebind on `crdt:provider-ready`, exactly as they do after
 any other reset (see
 [Rebinding After a Provider Reset](#rebinding-after-a-provider-reset)).
 
+That is a property of teardown, not of sign-out. `teardownSession` takes a
+reason, and every reason that leaves the app running reopens the store:
+
+| Reason      | Reopens the store | Why                                                                                                                                                                                                              |
+| ----------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `logout`    | yes               | The user signed out and kept working. Editing is never gated on a session.                                                                                                                                       |
+| `integrity` | yes               | An involuntary sign-out, triggered when the device signing key reads back absent. The user did not ask for it and is not told the editor went read-only, so leaving the provider dead here is worse, not better. |
+| `shutdown`  | no                | The app is quitting: no editor is left to serve, and the vault uuid the store is scoped to is read from a data DB that `closeVault()` is about to close.                                                         |
+
+The store path resolves through `getOrCreateVaultUuid` against the open data DB,
+which is why `shutdown` is the exception rather than a harmless no-op — a reopen
+racing the close would leave a freshly opened LevelDB store behind on the way
+out. Nothing routes an app quit through `teardownSession` today; `before-quit`
+calls `stopSyncRuntime()` directly and then `closeVault()`.
+
 The editor keeps the same Y.Doc across that whole cycle. A reset marks the
 binding stale, which is a statement about main, not about the doc: unbinding the
 fragment would tear the editor's collaboration extension off a document it can


### PR DESCRIPTION
Closes #1492. Part of EPIC #1499.

`stopSyncRuntime()` destroys and resets the CRDT provider. The `logout` path reopened the store afterwards so editing kept working; `integrity` did not, so after an integrity teardown the editor stayed unbound to any Y.Doc **until the app restarted**.

Same shape as the sign-out bug fixed in `a6178a35a`. The reopen was scoped to `logout` deliberately while that change was in flight; this widens it.

## The change

One condition — `reason === 'logout'` → `reason !== 'shutdown'` — plus a rewritten comment block that reasons about the whole reason set rather than sign-out alone.

An integrity teardown is an *involuntary* sign-out the user did not ask for, so leaving that one with a dead provider is the worse of the two. Editing is never gated on session state: it stays fully available signed out, offline, and with no account.

## Why `shutdown` stays excluded — established, not assumed

- **`teardownSession('shutdown')` has zero production callers.** The quit path (`index.ts:2150/2153`) calls `stopSyncRuntime()` directly, then `closeVault()`. `'shutdown'` appears only in the type union and in tests.
- **A reopen there would race a closing database.** `initPersistence` → `prepareVaultCrdtStore` → `resolveVaultCrdtStore` → `getOrCreateVaultUuid(getDatabase())`, while `closeVault()` runs `stopSyncRuntime()` then `closeAllDatabases()`. `crdt-provider.ts` already documents this exact hazard for the vault-switch case.
- **Ordering is safe.** Every module touched between `stopSyncRuntime()` and the reopen was grepped for CRDT access — none. `store.set('sync', {})` writes a different key than the legacy-store claim the reopen reads.

## Tests — mutation-verified

The test pins **all three** reasons individually. The provider fake is not a bare `vi.fn()`: it mints a new provider generation each time `stopSyncRuntime` resets the singleton and records which generation each `initPersistence()` reached, so a reopen aimed at the already-destroyed instance is caught rather than counted as a success — the exact shape that let #1456's rebind pass its tests while failing 100% in production.

| Mutation | Result |
| --- | --- |
| Revert to `reason === 'logout'` | only `reopens the store after an integrity teardown` fails — 1 failed, 5 passed |
| Make `shutdown` reopen too | only `leaves the store closed on shutdown` fails — 1 failed, 5 passed |
| Hoist the reopen above `stopSyncRuntime()` (call count unchanged) | 2 failed — a plain `toHaveBeenCalled()` would have passed |

**Independently re-run by the main session:** reverting to `reason === 'logout'` was confirmed applied via `git diff --stat` (exactly 1 line), then produced `expected "vi.fn()" to be called 1 times, but got 0 times` on the integrity test alone — 1 failed, 5 passed. Restored: 6/6 green.

## Verification

Baseline established separately: clean `origin/main` (255d23878) desktop main suite is **fully green**, so nothing here is written off as pre-existing.

- `pnpm --filter @memry/desktop test:main` — 528 passed | 3 skipped (531 files), 6768 tests passed
- `pnpm typecheck` — 17/17
- `pnpm lint` — 0 errors, no warnings in either touched file
- `git diff --check` — clean
- `pnpm docs:impact --base 255d23878 --strict` — was `missing-docs`, now covered
- `pnpm docs:build` — complete

Docs: `apps/docs/src/architecture/crdt.md` gains a table under "Sign-Out Keeps the Store" pinning all three reasons and why `shutdown` is the exception.

## Compat

No schema, contract, protocol or on-disk format change. Pure control flow inside a teardown path.

## Found, not fixed

`'shutdown'` is a dead teardown reason — no production caller, and the quit path bypasses `teardownSession` entirely. Either wire the quit path through it or drop the reason. Filing separately.