### PR TITLE
docs(canvas): say what the note-card edit lock actually guards now

### DIFF
--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.tsx
@@ -548,9 +548,12 @@ export const CanvasCardLayer = ({
       if (hit) {
         e.preventDefault()
         e.stopPropagation()
-        // Unauthenticated + the note already live elsewhere => stay read-only.
-        // Two non-collaborative editors on one note clobber each other and both
-        // run ContentArea's task auto-conversion (M6 design §12/6).
+        // No live sync session + the note already live elsewhere => stay
+        // read-only. Not because a second editor would be non-collaborative —
+        // it shares the tab's Y.Doc now — but because these are the statuses
+        // main's CRDT provider can be down under, and an editor that opens a
+        // note while it is down saves whole markdown for the life of its mount
+        // and clobbers the other one (M6 design §12/6; canvas-note-lock.ts).
         if (lockReasonForCard(lockCtxRef.current, hit)) {
           return
         }

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-note-lock.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-note-lock.ts
@@ -38,7 +38,7 @@
  * "this window holds no fragment for this note", and it is not reachable from
  * here — asking the registry for it would register a second consumer and make
  * the sole editor report non-owner (see `useYjsSideEffectOwner`). Swapping the
- * conjunct for it is a design change owing its own E2E, not a cleanup: #1495.
+ * conjunct for it is a design change owing its own E2E, not a cleanup: #1504.
  *
  * The rule is "the tab always wins": a card refuses to activate and stays a
  * read-only preview with an open-in-tab affordance.

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-note-lock.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-note-lock.ts
@@ -1,16 +1,47 @@
 /**
- * Why a canvas note card sometimes refuses to become editable.
+ * Why a canvas note card sometimes refuses to become editable — and why the
+ * reason is no longer the one it was built for.
  *
- * ContentArea only engages Yjs collaboration for an authenticated sync session.
- * Unauthenticated users therefore edit through a NON-collaborative BlockNote
- * that debounce-saves whole markdown. Two such editors on one note (a note tab
- * in one pane + an active canvas card in another) clobber each other
- * last-save-wins, and each independently runs ContentArea's task
- * auto-conversion, so a checkbox can become two tasks.
+ * As built (M7 §3.1): ContentArea engaged Yjs only for an authenticated sync
+ * session, so an unauthenticated user edited through a NON-collaborative
+ * BlockNote that debounce-saved whole markdown. Two of those on one note — a
+ * note tab in one pane, an active canvas card in another — clobbered each other
+ * last-save-wins, and each ran ContentArea's task auto-conversion on its own
+ * onChange, so one checkbox became two tasks.
+ *
+ * `f89d23ed5` deleted that premise. ContentArea binds the local Y.Doc for every
+ * note, session or none, so a tab and a card in one window acquire ONE entry
+ * from the registry in sync/use-yjs-collaboration.ts and share its doc, exactly
+ * as an authenticated pair already did. Both halves close with it: the shared
+ * fragment suppresses the whole-markdown save (`!yjsFragment`, in
+ * content-area/hooks/use-editor-sync.ts), and the registry names exactly one
+ * `isSideEffectOwner` — the duplicate conversion only ever existed because a
+ * DISABLED mount defaulted that flag to true.
+ *
+ * What survives is the binding FAILING. `crdt:open-doc` answers
+ * `success: false` while main's provider is uninitialized; the entry then
+ * destroys its provider and publishes a null fragment for the life of the slot
+ * (use-yjs-collaboration.ts, "fails open") with no rebind — so the first editor
+ * to open that note, and every editor that later joins it, is a whole-markdown
+ * saver again. That is the original clobber, unchanged. Main is uninitialized
+ * only after `resetCrdtProvider()`, which nothing but the sync runtime's stop
+ * and start-failure paths calls: `teardownSession('integrity')` never re-inits
+ * (#1492), sign-out re-inits asynchronously, a failed `startSyncRuntime` leaves
+ * it dead. No such state reports idle/syncing/offline.
+ *
+ * So the first conjunct no longer says "there is no shared doc"; it
+ * over-approximates "there may not be one". The contrapositive is what carries
+ * it — a live session means `startSyncRuntime` awaited `initPersistence()`, so
+ * the doc is there and co-editing stays unlocked, as it always did. The cost of
+ * over-approximating is a healthy never-signed-in user locked out for no hazard
+ * at all: that user never reaches a provider reset. The tight predicate is
+ * "this window holds no fragment for this note", and it is not reachable from
+ * here — asking the registry for it would register a second consumer and make
+ * the sole editor report non-owner (see `useYjsSideEffectOwner`). Swapping the
+ * conjunct for it is a design change owing its own E2E, not a cleanup: #1495.
  *
  * The rule is "the tab always wins": a card refuses to activate and stays a
- * read-only preview with an open-in-tab affordance. Authenticated users never
- * satisfy the first conjunct, so their shared-Y.Doc co-editing is untouched.
+ * read-only preview with an open-in-tab affordance.
  *
  * Excalidraw-free and React-free so it unit-tests in jsdom, matching
  * canvas-active.ts.
@@ -20,7 +51,11 @@ import type { TabGroup } from '@/contexts/tabs'
 export type NoteLockReason = 'note-open-in-tab' | 'note-active-on-another-card'
 
 export interface NoteLockInput {
-  /** From isCollaborationActive(syncStatus). True => authenticated shared Y.Doc. */
+  /**
+   * From isCollaborationActive(syncStatus). No longer "this user has a shared
+   * Y.Doc" — every note has one now. Read it as "main's CRDT provider is
+   * provably up", which is the only thing still making a second editor safe.
+   */
   collaborationActive: boolean
   /** Note ids that are the ACTIVE tab of some pane (see collectVisibleNoteTabIds). */
   visibleNoteTabIds: ReadonlySet<string>

--- a/apps/desktop/src/renderer/src/pages/canvas/use-note-edit-lock.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/use-note-edit-lock.ts
@@ -1,7 +1,9 @@
 /**
- * Live inputs for the canvas note-edit lock: whether Yjs collaboration is
- * engaged (authenticated) and which notes are currently editable in a visible
- * pane. Kept separate from canvas-note-lock.ts so the decision stays pure.
+ * Live inputs for the canvas note-edit lock: whether a remote sync session is
+ * live — which is now a proxy for "main's CRDT provider is up", not for "this
+ * editor is collaborative"; see canvas-note-lock.ts — and which notes are
+ * currently editable in a visible pane. Kept separate from canvas-note-lock.ts
+ * so the decision stays pure.
  */
 import { useMemo } from 'react'
 import { useSync } from '@/contexts/sync-context'

--- a/apps/desktop/src/renderer/src/sync/collaboration-status.ts
+++ b/apps/desktop/src/renderer/src/sync/collaboration-status.ts
@@ -16,10 +16,18 @@ export type SyncStatus = 'idle' | 'syncing' | 'paused' | 'error' | 'offline' | '
  * Is a remote sync session available?
  *
  * The canvas note-card lock (pages/canvas/canvas-note-lock.ts) gates on its
- * NEGATION and must keep reading this one predicate: if two copies drift, the
- * canvas guard silently stops matching the condition it exists to guard, and
- * unauthenticated split-view body clobber comes back without any test going
- * red. These statuses are produced in contexts/sync-context.tsx.
+ * NEGATION, and still must — but not for the reason it was written. It no
+ * longer means "this user has no shared Y.Doc": since `f89d23ed5` every note
+ * has one, signed in or not, so a note tab and a canvas card in one window
+ * share it either way. What the negation now selects is "main's CRDT provider
+ * may be down", because the only thing that leaves it uninitialized is
+ * `resetCrdtProvider()` from the sync runtime's stop and start-failure paths —
+ * and an editor that opens a note while main is down falls open to a
+ * whole-markdown saver for the life of its mount, which is the original
+ * clobber. Still one predicate, then: a second copy that drifts stops matching
+ * a live data-loss path with no test going red. The full argument, and what
+ * would replace this, is in canvas-note-lock.ts. These statuses are produced in
+ * contexts/sync-context.tsx.
  *
  * NOT the editor's gate. ContentArea used to call this and no longer does — see
  * `isLocalCrdtDocLive`.

--- a/apps/docs/src/user-guide/canvas/cards-and-links.md
+++ b/apps/docs/src/user-guide/canvas/cards-and-links.md
@@ -91,16 +91,17 @@ If a note card shows **Open in tab to edit**, in-place editing is unavailable
 for it right now. That happens when the same note is already open in another
 visible pane, or is already being edited on another canvas card.
 
-Editing the same note in two places at once, on a device without an active,
-authenticated sync session, would let the two editors overwrite each other's
-text. Rather than risk losing what you typed, the card stays a read-only
-preview and points you at the surface that owns the edit. Click **Open in tab
-to edit** to jump there.
+Editing one note in two places at once is only safe when both surfaces are
+backed by the same live document. An active, authenticated sync session is the
+signal Memry uses to be sure of that — so without one it will not take the
+chance that two editors end up overwriting each other's text. The card stays a
+read-only preview and points you at the surface that owns the edit. Click
+**Open in tab to edit** to jump there.
 
-On a device with an active sync session, both surfaces share a single live
-document, so this does not apply and you can edit in either place. This
-read-only fallback applies to note cards only — task and event cards always
-edit in place.
+On a device with an active sync session, both surfaces are known to share a
+single live document, so this does not apply and you can edit in either place.
+This read-only fallback applies to note cards only — task and event cards
+always edit in place.
 
 ## Opening an item in a tab
 


### PR DESCRIPTION
Closes #1495. Part of EPIC #1499.

**Comment-only. No functional change** — the lock behaves exactly as it did.

#1495 asked whether the canvas note-card edit lock is dead weight now that `f89d23ed5` made the local Y.Doc live with no session. Answer: **its stated premise is dead, the lock is not.** Relaxing it would reopen a live data-loss path, so this PR corrects the four comments that assert the false premise and leaves the code alone.

## The premise really is dead

As built (M7 §3.1), ContentArea engaged Yjs only for an authenticated session, so unauthenticated users edited through a non-collaborative BlockNote that debounce-saved whole markdown. Two of those on one note clobbered each other, and each ran task auto-conversion independently.

Both legs are gone:
- **Sharing:** `ContentArea.tsx:1502` → `isLocalCrdtDocLive(noteId)` = `Boolean(noteId)` → `useYjsCollaboration({enabled: true})` → `docRegistry.acquire(noteId, ...)` against the module-level registry. A note tab and a canvas card in one window are the same renderer module instance, so one slot, one `Y.Doc`.
- **Auto-conversion:** it existed *only* because `enabled: false` made the hook early-return with `setIsSideEffectOwner(true)` for both mounts. With `enabled` unconditional, the registry names exactly one owner. This holds even on the fail-open path, since `acquire` succeeds regardless of `connect()`'s outcome.

## What still makes it necessary

The binding can **fail**, and the failure is permanent for that slot:

- `crdt:open-doc` answers `success: false` while main's provider is uninitialized (`ipc/crdt-handlers.ts:92`).
- The renderer entry then destroys its provider and publishes `{fragment: null, isReady: true}` with **no rebind** (`use-yjs-collaboration.ts:99-106`, already pinned by `use-yjs-collaboration.test.tsx:121` "fails open").
- `ContentArea.tsx:1516,1529` passes that wait gate and renders with `yjsFragment={undefined}`, re-arming the debounce save at `hooks/use-editor-sync.ts:349`. That is the original clobber, unchanged.
- Main is uninitialized only after `resetCrdtProvider()` — called from nothing but `sync/runtime.ts:910, 987, 1006`.

The contrapositive is what carries the guard: `isCollaborationActive` true ⇒ `startSyncRuntime` ran ⇒ `crdtProvider.init(...)` ⇒ `await this.initPersistence()` ⇒ provider up. **When the lock does not fire, co-editing is provably safe.** It over-approximates; it never under-fires.

## Cross-window, for the record

Mediated by main and equally session-independent (`broadcastToWindows` skips only the source window; no session on that path). But the lock **cannot see cross-window at all** — `collectVisibleNoteTabIds` reads this window's tab state and `noteCardClaims` is a per-renderer singleton. It was always a same-window guard, and the cross-window case is neither guarded nor newly at risk.

## What changed

Four comment sites carrying the falsified premise — `canvas-note-lock.ts` (header + the `collaborationActive` field doc), `sync/collaboration-status.ts`, `use-note-edit-lock.ts`, `canvas-card-overlay.tsx:551` — plus `apps/docs/src/user-guide/canvas/cards-and-links.md`, which told users outright that two editors "would overwrite each other's text" without a session. Behaviour unchanged, reason corrected.

## Tests

None written or changed: there is no behaviour change to mutate, so mutation verification does not apply and inventing a test here would be theatre. The relevant facts are already pinned by `collaboration-status.test.ts:27`, `ContentArea.test.tsx`, and `use-yjs-collaboration.test.tsx:121`.

## Verification

- `pnpm --filter @memry/desktop test:renderer` — 614 files, 7137 passed, 7 skipped, **0 failed**
- `pnpm typecheck` — 17/17
- `pnpm lint` — 0 errors; the 91 warnings are pre-existing and none are in a touched file
- `git diff --check` — clean
- `pnpm docs:impact --base 255d23878 --strict` — covered; `pnpm docs:build` — complete

Main-session re-verification: I independently confirmed the fail-open publish at `use-yjs-collaboration.ts:99-106`, the `success: false` guard at `crdt-handlers.ts:92`, and that `resetCrdtProvider` has exactly three callers, all in the sync runtime. I also diffed every touched file to confirm the change is comment-only.

## Follow-ups filed

- **#1504** — re-key the lock on the fragment rather than the session. Tighter (stops locking healthy signed-out users) and wider (starts guarding the signed-in fail-open, which nothing covers today). Needs a read-only registry query plus E2E, so it is a design change, not a cleanup.
- **#1492 is worse than its description says.** While the provider is dead, every note opened fresh falls open to a whole-markdown saver permanently — so split-view clobber is reachable, and this lock is currently the only thing standing in front of it. Noted on that issue.