### PR TITLE
fix(crdt): stop another vault's journal attaching when the legacy store is inherited

### DIFF
--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -108,6 +108,20 @@ export interface CrdtStoreData {
   legacyStoreClaimedBy?: string
   /** When the claim was recorded (epoch ms). Diagnostics only. */
   legacyStoreClaimedAt?: number
+  /**
+   * Vault uuid whose inherited legacy store still has to have its
+   * cross-vault-ambiguous documents set aside.
+   *
+   * Only written when the install has known more than one vault, because only
+   * then can the legacy store hold a document that is not this vault's. Written
+   * in the same file write as the claim and cleared only after a complete pass,
+   * so an interrupted migration is resumed rather than silently skipped. See
+   * `inheritLegacyCrdtStore` in sync/crdt-store-path.ts.
+   *
+   * Optional for the same reason as the claim: older stores have no `crdtStore`
+   * key at all, which reads as "nothing pending" — the correct starting state.
+   */
+  legacyStorePartitionPendingFor?: string
 }
 
 /**
@@ -398,13 +412,41 @@ export function getLegacyCrdtStoreClaim(): string | undefined {
  * next launch. The reverse order would leave the store movable by whichever
  * vault opened next, which is exactly the cross-vault history bleed per-vault
  * scoping exists to prevent.
+ *
+ * `partitionPending` rides along in the SAME write rather than in a second one:
+ * a claim recorded without its pending partition would move a store this vault
+ * cannot fully own and never revisit it.
  */
-export function recordLegacyCrdtStoreClaim(vaultUuid: string): void {
+export function recordLegacyCrdtStoreClaim(
+  vaultUuid: string,
+  options?: { partitionPending?: boolean }
+): void {
   store.set('crdtStore', {
     ...store.get('crdtStore'),
     legacyStoreClaimedBy: vaultUuid,
-    legacyStoreClaimedAt: Date.now()
+    legacyStoreClaimedAt: Date.now(),
+    ...(options?.partitionPending ? { legacyStorePartitionPendingFor: vaultUuid } : {})
   })
+}
+
+/**
+ * Which vault, if any, still owes its inherited legacy store a partition pass.
+ */
+export function getLegacyCrdtStorePartitionPending(): string | undefined {
+  return store.get('crdtStore').legacyStorePartitionPendingFor
+}
+
+/**
+ * Record that the partition pass has completed, so it is not run again.
+ *
+ * Cleared only after a full pass: a partial pass leaves the flag set and is
+ * simply re-run, which is safe because setting a document aside is idempotent.
+ */
+export function clearLegacyCrdtStorePartitionPending(): void {
+  const current = store.get('crdtStore')
+  if (current.legacyStorePartitionPendingFor === undefined) return
+  const { legacyStorePartitionPendingFor: _cleared, ...rest } = current
+  store.set('crdtStore', rest)
 }
 
 /**

--- a/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
+++ b/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
@@ -44,7 +44,10 @@ vi.mock('../agent/storage/vault-id', () => ({
 
 vi.mock('../store', () => ({
   getLegacyCrdtStoreClaim: () => 'someone-else',
-  recordLegacyCrdtStoreClaim: vi.fn()
+  recordLegacyCrdtStoreClaim: vi.fn(),
+  getVaults: () => [],
+  getLegacyCrdtStorePartitionPending: () => undefined,
+  clearLegacyCrdtStorePartitionPending: vi.fn()
 }))
 
 vi.mock('../vault/notes', () => ({ toAbsolutePath: vi.fn() }))

--- a/apps/desktop/src/main/sync/crdt-legacy-partition.test.ts
+++ b/apps/desktop/src/main/sync/crdt-legacy-partition.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import * as Y from 'yjs'
+import { LeveldbPersistence } from 'y-leveldb'
+
+const mocks = vi.hoisted(() => ({
+  openStore: null as ((storagePath: string) => Promise<unknown>) | null
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+// The real one forks a preflight child through electron's utilityProcess, which
+// does not exist under vitest. Everything below it — enumeration, the archive
+// write, the clear — runs against a REAL y-leveldb store, because those are the
+// exact semantics this module is betting on.
+vi.mock('./crdt-persistence', () => ({
+  openCrdtPersistence: (storagePath: string) =>
+    mocks.openStore
+      ? mocks.openStore(storagePath)
+      : Promise.resolve(new LeveldbPersistence(storagePath))
+}))
+
+import {
+  UNATTRIBUTABLE_DOC_PREFIX,
+  isCrossVaultAmbiguousDocId,
+  setAsideAmbiguousLegacyDocs
+} from './crdt-legacy-partition'
+
+let storeDir: string
+
+async function withStore<T>(fn: (store: LeveldbPersistence) => Promise<T>): Promise<T> {
+  const store = new LeveldbPersistence(storeDir)
+  try {
+    return await fn(store)
+  } finally {
+    await store.destroy()
+  }
+}
+
+async function writeDoc(docName: string, text: string): Promise<void> {
+  await withStore(async (store) => {
+    const doc = new Y.Doc()
+    doc.getText('body').insert(0, text)
+    await store.storeUpdate(docName, Y.encodeStateAsUpdate(doc))
+    doc.destroy()
+  })
+}
+
+async function readDoc(docName: string): Promise<string> {
+  return await withStore(async (store) => {
+    const doc = await store.getYDoc(docName)
+    const text = doc.getText('body').toString()
+    doc.destroy()
+    return text
+  })
+}
+
+beforeEach(() => {
+  mocks.openStore = null
+  storeDir = mkdtempSync(path.join(tmpdir(), 'memry-crdt-partition-'))
+})
+
+afterEach(() => {
+  rmSync(storeDir, { recursive: true, force: true })
+})
+
+describe('cross-vault ambiguous document ids', () => {
+  it('treats a deterministic journal id as ambiguous and a random note id as not', () => {
+    expect(isCrossVaultAmbiguousDocId('j2026-08-13')).toBe(true)
+    expect(isCrossVaultAmbiguousDocId('abcdefabcdef')).toBe(false)
+    // Already set aside: re-running the pass must not archive the archive.
+    expect(isCrossVaultAmbiguousDocId(`${UNATTRIBUTABLE_DOC_PREFIX}j2026-08-13`)).toBe(false)
+  })
+})
+
+describe('setting aside inherited documents two vaults could both have written', () => {
+  it('stops the other vault’s journal from attaching, and keeps every random id', async () => {
+    // The reported scenario. One global store, two vaults: the day's journal id
+    // is the same string in both, so this document is not the inheriting
+    // vault's to load. The random note id is.
+    await writeDoc('j2026-08-13', 'the other vault’s journal')
+    await writeDoc('abcdefabcdef', 'this vault’s note')
+
+    expect(await setAsideAmbiguousLegacyDocs(storeDir)).toBe(true)
+
+    expect(await readDoc('j2026-08-13')).toBe('')
+    expect(await readDoc('abcdefabcdef')).toBe('this vault’s note')
+  })
+
+  it('sets the ambiguous history aside instead of deleting it', async () => {
+    await writeDoc('j2026-08-13', 'the other vault’s journal')
+
+    await setAsideAmbiguousLegacyDocs(storeDir)
+
+    const names = await withStore((store) => store.getAllDocNames())
+    expect(names).toContain(`${UNATTRIBUTABLE_DOC_PREFIX}j2026-08-13`)
+    expect(await readDoc(`${UNATTRIBUTABLE_DOC_PREFIX}j2026-08-13`)).toBe(
+      'the other vault’s journal'
+    )
+  })
+
+  it('is safe to run again after being interrupted', async () => {
+    // Crash-safety rests on this: an incomplete pass leaves the record pending
+    // and the next launch simply repeats it.
+    await writeDoc('j2026-08-13', 'the other vault’s journal')
+
+    expect(await setAsideAmbiguousLegacyDocs(storeDir)).toBe(true)
+    expect(await setAsideAmbiguousLegacyDocs(storeDir)).toBe(true)
+
+    expect(await readDoc('j2026-08-13')).toBe('')
+    expect(await readDoc(`${UNATTRIBUTABLE_DOC_PREFIX}j2026-08-13`)).toBe(
+      'the other vault’s journal'
+    )
+  })
+
+  it('reports a store it could not open rather than claiming the pass is done', async () => {
+    mocks.openStore = () => Promise.resolve(null)
+    expect(await setAsideAmbiguousLegacyDocs(storeDir)).toBe(false)
+  })
+
+  it('releases the store so the provider can open it straight after', async () => {
+    await writeDoc('j2026-08-13', 'the other vault’s journal')
+    await setAsideAmbiguousLegacyDocs(storeDir)
+
+    // LevelDB holds an exclusive LOCK. y-leveldb swallows a failed transaction
+    // into a null result rather than rejecting, so this has to assert a real
+    // read came back, not merely that the promise settled.
+    const names = await withStore((store) => store.getAllDocNames())
+    expect(names).toEqual([`${UNATTRIBUTABLE_DOC_PREFIX}j2026-08-13`])
+  })
+})

--- a/apps/desktop/src/main/sync/crdt-legacy-partition.ts
+++ b/apps/desktop/src/main/sync/crdt-legacy-partition.ts
@@ -1,0 +1,112 @@
+import * as Y from 'yjs'
+import { createLogger } from '../lib/logger'
+import { openCrdtPersistence, type CrdtPersistence } from './crdt-persistence'
+
+// Same scope as crdt-provider on purpose: production log triage greps for
+// 'CrdtProvider' when it is looking at the CRDT store.
+const log = createLogger('CrdtProvider')
+
+/**
+ * Name prefix for a document that was inherited but cannot be attributed.
+ *
+ * A note id is a bare token — 12 lowercase alphanumerics, or `j` + an ISO date
+ * for a journal — so nothing the app opens can ever collide with this prefix.
+ * Setting a document aside under it therefore takes it out of reach of every
+ * note without deleting a single byte the user might one day want back.
+ */
+export const UNATTRIBUTABLE_DOC_PREFIX = '__memry_unattributable__/'
+
+/**
+ * Is this document's id one that two vaults could genuinely both have written?
+ *
+ * Note ids are random 12-character tokens, so a legacy document under one is
+ * the history of exactly one vault's note even when it is the *wrong* vault's:
+ * the inheriting vault never opens that id, and the entry sits inert. Journal
+ * notes are the exception — their id is derived from the date (`j2026-08-13`),
+ * so every vault names its journal for a given day identically, and the legacy
+ * store holds one document per day for all of them merged together. That is
+ * the only id the app generates deterministically today.
+ */
+export function isCrossVaultAmbiguousDocId(docName: string): boolean {
+  return /^j\d{4}-\d{2}-\d{2}$/.test(docName)
+}
+
+/**
+ * `getAllDocNames` is on y-leveldb's persistence but not on the narrow surface
+ * `CrdtPersistence` declares, because nothing else in the app enumerates the
+ * store. Widening the shared interface for a one-shot migration would put a
+ * method on every consumer's type that only this file calls.
+ */
+type EnumerableCrdtPersistence = CrdtPersistence & {
+  getAllDocNames?: () => Promise<string[]>
+}
+
+/**
+ * Take every cross-vault-ambiguous document in an inherited store out of reach
+ * of the notes that would otherwise load it.
+ *
+ * Each one is copied to a reserved name and then cleared from its own, so the
+ * vault's journal for that day re-seeds from its own markdown — the same path
+ * every non-inheriting vault already takes — while the ambiguous history stays
+ * on disk instead of being deleted. Returns false when the pass did not
+ * complete, so the caller can leave it pending and retry on the next launch.
+ *
+ * The store is opened through `openCrdtPersistence`, not `new
+ * LeveldbPersistence`, because that is where the preflight lives: a native
+ * binding that hard-aborts takes the process down with no catchable error, and
+ * main must never be the first thing to touch the store directory. The cost is
+ * one extra preflight child on the single launch that migrates, which is also
+ * why this runs from the pending flag rather than on every open.
+ */
+export async function setAsideAmbiguousLegacyDocs(storagePath: string): Promise<boolean> {
+  const persistence = (await openCrdtPersistence(storagePath)) as EnumerableCrdtPersistence | null
+  if (!persistence) {
+    // Preflight refused the store, or the binding is unusable. The provider is
+    // about to reach the same verdict and run in-memory, where the ambiguous
+    // documents cannot be loaded either — so nothing is at risk while this
+    // stays pending.
+    log.warn('Could not open the inherited CRDT store to partition it; will retry', { storagePath })
+    return false
+  }
+
+  try {
+    if (typeof persistence.getAllDocNames !== 'function') {
+      log.warn('Inherited CRDT store cannot be enumerated; leaving it whole', { storagePath })
+      return false
+    }
+
+    const ambiguous = (await persistence.getAllDocNames()).filter(isCrossVaultAmbiguousDocId)
+    for (const docName of ambiguous) {
+      const doc = await persistence.getYDoc(docName)
+      try {
+        // Re-running this replays the identical update into the same document,
+        // which Yjs applies as a no-op — so an interrupted pass is safe to
+        // repeat, and so is clearing a document that is already cleared.
+        await persistence.storeUpdate(
+          `${UNATTRIBUTABLE_DOC_PREFIX}${docName}`,
+          Y.encodeStateAsUpdate(doc)
+        )
+      } finally {
+        doc.destroy()
+      }
+      await persistence.clearDocument(docName)
+    }
+
+    if (ambiguous.length > 0) {
+      log.info('Set aside legacy CRDT documents that more than one vault could have written', {
+        storagePath,
+        count: ambiguous.length
+      })
+    }
+    return true
+  } catch (err) {
+    log.warn('Could not partition the inherited CRDT store; will retry', {
+      storagePath,
+      error: err
+    })
+    return false
+  } finally {
+    // Release the LevelDB lock before the provider opens the same directory.
+    await persistence.destroy()
+  }
+}

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -159,7 +159,10 @@ vi.mock('../store', () => ({
   getLegacyCrdtStoreClaim: () => mocks.legacyStoreClaim,
   recordLegacyCrdtStoreClaim: (vaultUuid: string) => {
     mocks.legacyStoreClaim = vaultUuid
-  }
+  },
+  getVaults: () => [],
+  getLegacyCrdtStorePartitionPending: () => undefined,
+  clearLegacyCrdtStorePartitionPending: vi.fn()
 }))
 
 vi.mock('@main/database/queries/notes', () => ({

--- a/apps/desktop/src/main/sync/crdt-store-path.test.ts
+++ b/apps/desktop/src/main/sync/crdt-store-path.test.ts
@@ -1,9 +1,18 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import * as Y from 'yjs'
+import { LeveldbPersistence } from 'y-leveldb'
 
 const mocks = vi.hoisted(() => ({
   userDataDir: '/userData',
   dataDb: {} as object | null,
-  vaultUuid: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
+  vaultUuid: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d',
+  vaultCount: 1,
+  claim: undefined as string | undefined,
+  partitionPending: undefined as string | undefined,
+  openStore: null as ((storagePath: string) => Promise<unknown>) | null
 }))
 
 vi.mock('electron', () => ({
@@ -24,14 +33,34 @@ vi.mock('../agent/storage/vault-id', () => ({
 }))
 
 vi.mock('../store', () => ({
-  getLegacyCrdtStoreClaim: () => undefined,
-  recordLegacyCrdtStoreClaim: vi.fn()
+  getVaults: () => Array.from({ length: mocks.vaultCount }, (_, i) => ({ path: `/vault-${i}` })),
+  getLegacyCrdtStoreClaim: () => mocks.claim,
+  recordLegacyCrdtStoreClaim: (vaultUuid: string, options?: { partitionPending?: boolean }) => {
+    mocks.claim = vaultUuid
+    if (options?.partitionPending) mocks.partitionPending = vaultUuid
+  },
+  getLegacyCrdtStorePartitionPending: () => mocks.partitionPending,
+  clearLegacyCrdtStorePartitionPending: () => {
+    mocks.partitionPending = undefined
+  }
 }))
 
-import { resolveVaultCrdtStore } from './crdt-store-path'
+// The real one forks a preflight child through electron's utilityProcess, which
+// does not exist under vitest. The store it hands back is a real y-leveldb one,
+// so the migration below runs against real on-disk CRDT documents.
+vi.mock('./crdt-persistence', () => ({
+  openCrdtPersistence: (storagePath: string) =>
+    mocks.openStore
+      ? mocks.openStore(storagePath)
+      : Promise.resolve(new LeveldbPersistence(storagePath))
+}))
+
+import { prepareVaultCrdtStore, resolveVaultCrdtStore } from './crdt-store-path'
+import { UNATTRIBUTABLE_DOC_PREFIX } from './crdt-legacy-partition'
 
 describe('vault CRDT store path', () => {
   beforeEach(() => {
+    mocks.userDataDir = '/userData'
     mocks.dataDb = {}
     mocks.vaultUuid = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
   })
@@ -67,5 +96,139 @@ describe('vault CRDT store path', () => {
   it('has no path to resolve while no vault is open', () => {
     mocks.dataDb = null
     expect(resolveVaultCrdtStore()).toBeNull()
+  })
+})
+
+describe('inheriting the legacy global CRDT store', () => {
+  const VAULT_A = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
+  const JOURNAL_ID = 'j2026-08-13'
+  const NOTE_ID = 'abcdefabcdef'
+
+  let userData: string
+
+  const legacyPath = (): string => path.join(userData, 'crdt-store')
+  const vaultStorePath = (vaultUuid = VAULT_A): string =>
+    path.join(userData, 'crdt-stores', vaultUuid)
+
+  async function withStore<T>(dir: string, fn: (store: LeveldbPersistence) => Promise<T>) {
+    const store = new LeveldbPersistence(dir)
+    try {
+      return await fn(store)
+    } finally {
+      await store.destroy()
+    }
+  }
+
+  async function writeDoc(dir: string, docName: string, text: string): Promise<void> {
+    await withStore(dir, async (store) => {
+      const doc = new Y.Doc()
+      doc.getText('body').insert(0, text)
+      await store.storeUpdate(docName, Y.encodeStateAsUpdate(doc))
+      doc.destroy()
+    })
+  }
+
+  async function readDoc(dir: string, docName: string): Promise<string> {
+    return await withStore(dir, async (store) => {
+      const doc = await store.getYDoc(docName)
+      const text = doc.getText('body').toString()
+      doc.destroy()
+      return text
+    })
+  }
+
+  beforeEach(async () => {
+    userData = mkdtempSync(path.join(tmpdir(), 'memry-crdt-store-path-'))
+    mocks.userDataDir = userData
+    mocks.dataDb = {}
+    mocks.vaultUuid = VAULT_A
+    mocks.vaultCount = 1
+    mocks.claim = undefined
+    mocks.partitionPending = undefined
+    mocks.openStore = null
+
+    // One store, keyed by note id, written by every vault on this install: the
+    // day's journal id is the same string in both vaults, the note id is not.
+    await writeDoc(legacyPath(), JOURNAL_ID, 'the other vault’s journal')
+    await writeDoc(legacyPath(), NOTE_ID, 'this vault’s note')
+  })
+
+  afterEach(() => {
+    rmSync(userData, { recursive: true, force: true })
+  })
+
+  it('does not let another vault’s journal attach to this vault’s journal id', async () => {
+    // The reported scenario: two vaults on one install, a colliding
+    // deterministic journal id, and the first vault to open inheriting it.
+    mocks.vaultCount = 2
+
+    await prepareVaultCrdtStore()
+
+    expect(await readDoc(vaultStorePath(), JOURNAL_ID)).toBe('')
+    // An empty document is what makes the provider seed the note from this
+    // vault's own markdown, which is the whole point of clearing it.
+    expect(await readDoc(vaultStorePath(), NOTE_ID)).toBe('this vault’s note')
+  })
+
+  it('keeps the ambiguous history on disk rather than deleting it', async () => {
+    mocks.vaultCount = 2
+
+    await prepareVaultCrdtStore()
+
+    expect(await readDoc(vaultStorePath(), `${UNATTRIBUTABLE_DOC_PREFIX}${JOURNAL_ID}`)).toBe(
+      'the other vault’s journal'
+    )
+  })
+
+  it('inherits the store whole when this install has only ever had one vault', async () => {
+    // Nothing can be ambiguous without a second vault, and journal history is
+    // not something to throw away from the install that owns all of it.
+    mocks.vaultCount = 1
+
+    await prepareVaultCrdtStore()
+
+    expect(await readDoc(vaultStorePath(), JOURNAL_ID)).toBe('the other vault’s journal')
+    expect(mocks.partitionPending).toBeUndefined()
+  })
+
+  it('partitions on the next launch when the move landed but the pass did not', async () => {
+    // Crash-safety: the record is written with the claim, before the move, and
+    // it — not the legacy directory — is what drives the pass. Simulate the
+    // interrupted launch by moving the store by hand and leaving it pending.
+    mocks.vaultCount = 2
+    mocks.claim = VAULT_A
+    mocks.partitionPending = VAULT_A
+    await writeDoc(vaultStorePath(), JOURNAL_ID, 'the other vault’s journal')
+    rmSync(legacyPath(), { recursive: true, force: true })
+
+    await prepareVaultCrdtStore()
+
+    expect(await readDoc(vaultStorePath(), JOURNAL_ID)).toBe('')
+    expect(mocks.partitionPending).toBeUndefined()
+  })
+
+  it('stays pending when the pass could not run', async () => {
+    mocks.vaultCount = 2
+    mocks.openStore = () => Promise.resolve(null)
+
+    await prepareVaultCrdtStore()
+
+    expect(mocks.partitionPending).toBe(VAULT_A)
+  })
+
+  it('does not touch the store of a vault that owes no partition', async () => {
+    // The pass is reached on every vault open, so the record it reads is the
+    // only thing keeping it off stores it was never asked about — including
+    // this vault's own journal, which is not the migration's to clear.
+    mocks.vaultCount = 2
+    mocks.claim = 'some-other-vault-uuid'
+    mocks.partitionPending = 'some-other-vault-uuid'
+    await writeDoc(vaultStorePath(), JOURNAL_ID, 'this vault’s own journal')
+
+    await prepareVaultCrdtStore()
+
+    expect(await readDoc(vaultStorePath(), JOURNAL_ID)).toBe('this vault’s own journal')
+    // And the legacy store is still whole, waiting for the vault that claimed it.
+    expect(await readDoc(legacyPath(), JOURNAL_ID)).toBe('the other vault’s journal')
   })
 })

--- a/apps/desktop/src/main/sync/crdt-store-path.ts
+++ b/apps/desktop/src/main/sync/crdt-store-path.ts
@@ -4,7 +4,14 @@ import { existsSync, mkdirSync } from 'fs'
 import { app } from 'electron'
 import { createLogger } from '../lib/logger'
 import { moveStoreDir } from './crdt-store-move'
-import { getLegacyCrdtStoreClaim, recordLegacyCrdtStoreClaim } from '../store'
+import { setAsideAmbiguousLegacyDocs } from './crdt-legacy-partition'
+import {
+  clearLegacyCrdtStorePartitionPending,
+  getLegacyCrdtStoreClaim,
+  getLegacyCrdtStorePartitionPending,
+  getVaults,
+  recordLegacyCrdtStoreClaim
+} from '../store'
 import { getDatabase, isDatabaseInitialized } from '../database/client'
 import { getOrCreateVaultUuid } from '../agent/storage/vault-id'
 
@@ -69,6 +76,20 @@ export function resolveVaultCrdtStore(): VaultCrdtStore | null {
 }
 
 /**
+ * Could the legacy store hold a document that is not this vault's?
+ *
+ * Only if this install has ever opened more than one vault — that list is the
+ * only record of the fact, because the store itself has no vault dimension to
+ * read. Both ways of being wrong fail safe: an install that lost a vault from
+ * the list reads as single-vault and keeps today's behaviour, and a duplicate
+ * entry for a moved vault reads as multi-vault and only costs the deterministic
+ * ids their history, which markdown re-seeds.
+ */
+function legacyStoreCouldBeAnotherVaults(): boolean {
+  return getVaults().length > 1
+}
+
+/**
  * Hand the legacy global store to the first vault that opens after the upgrade,
  * and to no other.
  *
@@ -81,13 +102,28 @@ export function resolveVaultCrdtStore(): VaultCrdtStore | null {
  * empty and re-seeds from its own markdown — the normal path for a note with no
  * stored history.
  *
- * The claim is written before the move, which makes the whole thing crash-safe:
+ * One claimant is not enough on its own, though. On an install that has opened
+ * more than one vault, the claimant inherits entries for ids it does not own.
+ * Random note ids are inert — nothing ever asks for them. Deterministic ones
+ * are not: the store's `j2026-08-13` is every vault's journal for that day
+ * merged into one document, and a vault that loads it gets another vault's
+ * text, silently, because a document that already has content is never seeded
+ * from markdown. So the claim also records that those documents still have to
+ * be set aside (see `partitionInheritedLegacyStore`), and the pass runs before
+ * the provider opens the store.
+ *
+ * The claim, and the partition it owes, are one file write made before the
+ * move — which is what makes the whole thing crash-safe:
  *
  *  - crash after the claim, before the move → the legacy directory is still
  *    there and still claimed by this vault, so the next launch of the *same*
  *    vault finishes the move and no other vault may touch it;
- *  - crash after the move → the directory is gone, so there is nothing left to
- *    inherit and nothing to double-apply.
+ *  - crash after the move, before or during the partition → the pending record
+ *    still names this vault, and it is what drives the pass, not the legacy
+ *    directory that no longer exists. So the next launch partitions the store
+ *    it now owns;
+ *  - crash after both → the pending record is gone and the claim is settled,
+ *    so there is nothing to double-apply.
  *
  * Nothing here bypasses the store's own integrity handling: the move is a plain
  * directory rename, and `openCrdtPersistence` still runs its preflight,
@@ -116,7 +152,7 @@ export async function inheritLegacyCrdtStore({
   }
 
   if (claimedBy === undefined) {
-    recordLegacyCrdtStoreClaim(vaultUuid)
+    recordLegacyCrdtStoreClaim(vaultUuid, { partitionPending: legacyStoreCouldBeAnotherVaults() })
   }
 
   if (await moveStoreDir(legacyPath, storagePath)) {
@@ -129,6 +165,28 @@ export async function inheritLegacyCrdtStore({
       legacyPath,
       storagePath
     })
+  }
+}
+
+/**
+ * Settle the partition the claim owes, if this vault is the one that owes it.
+ *
+ * Driven by the durable record rather than by the move that preceded it, so a
+ * launch that crashed between the two still gets here. It is deliberately not
+ * gated on the legacy directory: by this point that directory is usually gone,
+ * and the documents to set aside are in this vault's own store.
+ */
+export async function partitionInheritedLegacyStore({
+  vaultUuid,
+  storagePath
+}: VaultCrdtStore): Promise<void> {
+  if (getLegacyCrdtStorePartitionPending() !== vaultUuid) return
+  // The move has not happened yet (it failed, and `inheritLegacyCrdtStore`
+  // logged why). Stay pending: the next launch moves, then partitions.
+  if (!existsSync(storagePath)) return
+
+  if (await setAsideAmbiguousLegacyDocs(storagePath)) {
+    clearLegacyCrdtStorePartitionPending()
   }
 }
 
@@ -153,5 +211,6 @@ export async function prepareVaultCrdtStore(): Promise<VaultCrdtStore | null> {
   }
 
   await inheritLegacyCrdtStore(target)
+  await partitionInheritedLegacyStore(target)
   return target
 }

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -93,17 +93,52 @@ would recreate exactly the cross-vault bleed scoping exists to remove. For the
 overwhelming majority — single-vault installs — the one claimant is their vault,
 and nothing about the upgrade is visible.
 
-The claim is written **before** the move, which is what makes it crash-safe:
+#### Documents two vaults could both have written
+
+One claimant is not enough on its own. On an install that has opened more than
+one vault, the claimant also inherits entries for ids it does not own. Random
+note ids are inert — nothing ever asks for them. Deterministic ids are not: the
+legacy store's `j2026-08-13` is _every_ vault's journal for that day merged into
+one document, and a document that already has content is never seeded from
+markdown, so the claimant would open its journal and silently get another
+vault's text.
+
+So on a multi-vault install the claim also records that those documents still
+have to be set aside (`crdtStore.legacyStorePartitionPendingFor`), and the pass
+runs before the provider opens the store. Each ambiguous document is copied to a
+reserved `__memry_unattributable__/` name — which no note id can collide with —
+and then cleared from its own, so the journal re-seeds from that vault's own
+markdown while the ambiguous history stays on disk rather than being deleted.
+
+Only an install that has known more than one vault pays for this. A single-vault
+install has nothing ambiguous to set aside and inherits its journal history
+whole.
+
+#### Crash safety
+
+The claim, and the partition it owes, are one file write made **before** the
+move:
 
 - crash after the claim, before the move → the directory is still there and
   still claimed, so the same vault finishes the move on its next launch and no
   other vault may take it;
-- crash after the move → the directory is gone, so there is nothing left to
-  inherit and nothing to apply twice.
+- crash after the move, before or during the partition → the pending record
+  still names that vault, and it — not the legacy directory, which by then is
+  gone — is what drives the pass, so the next launch partitions the store the
+  vault now owns;
+- crash after both → the record is gone and the claim is settled, so there is
+  nothing to apply twice.
+
+Setting a document aside is idempotent (re-archiving replays the identical Yjs
+update, which is a no-op, and clearing an already-cleared document does
+nothing), so an interrupted pass is simply repeated. The record is cleared only
+after a complete pass.
 
 The move is a plain directory rename (falling back to copy+delete on a locked
 Windows directory). Nothing about it bypasses the checks below: the inherited
-store still goes through the full preflight, quarantine and probe.
+store still goes through the full preflight, quarantine and probe — the
+partition pass opens it through `openCrdtPersistence` for exactly that reason,
+at the cost of one extra preflight child on the single launch that migrates.
 
 ## Persistence Resilience
 
@@ -707,6 +742,7 @@ untouched. A callout created in the editor round-trips through the live document
 ```
 apps/desktop/src/main/sync/
 ├─ crdt-store-path.ts       # per-vault store path + legacy-store migration
+├─ crdt-legacy-partition.ts # sets aside inherited docs no vault can claim
 ├─ crdt-update-queue.ts
 └─ engine.ts                # ordering: pull → seed → per-batch push
 


### PR DESCRIPTION
Closes #1491. Part of EPIC #1499.

Before per-vault scoping there was one global `userData/crdt-store` shared by every vault, keyed by note id. `a6178a35a` hands it whole to the **first vault opened after the upgrade**. Most note ids are random and therefore inert in the wrong vault — but **journal ids are derived from the date** (`j2026-08-13`), so two vaults' journals for one day are the same document, and the wrong history can attach.

## The mechanism, confirmed

`seedFromMarkdown` returns early when `fragment.length > 0` (`crdt-provider.ts:627`). An inherited document that already has content is therefore **never** seeded from the inheriting vault's own markdown — the other vault's text wins, and write-back then puts it in this vault's file.

## Why not the direction the issue proposed

The issue suggested partitioning by "which note ids each vault's index actually contains". That does not fix the reported harm and is dangerous:

- **It does not fix it.** Both vaults' indexes contain `j2026-08-13`, so the colliding journal survives the filter.
- **It is dangerous.** The index DB is a rebuildable cache. Treating its absence as "this vault does not own that note" would delete the entire inherited store on any launch where the index is empty or mid-rebuild.

The index is not consulted at all.

## The design: partition by what an id can *mean*

- A **random 12-char id** (`generateNoteId` = `customAlphabet('0-9a-z', 12)`) is unique by construction. In the wrong vault it is inert — that vault never opens the id. Left alone.
- A **journal id** is ambiguous by construction. The regex is byte-identical to the app's own `isJournalId` (`crdt-writeback.ts:146`).

On an install that has known **more than one vault**, each ambiguous document is copied to `__memry_unattributable__/<id>` and cleared from its own name — **set aside, not deleted**. That prefix contains a `/`, which no note id can, so nothing can ever open it. A single-vault install has nothing ambiguous and inherits its journal history whole.

The store is opened via `openCrdtPersistence`, never `new LeveldbPersistence`, so the disposable preflight child still touches the directory before main does. The handle is destroyed in a `finally` to release the LevelDB lock before the provider opens the same directory.

## Crash safety

The claim and the pending-partition marker are **one write, before the move**:

- Crash after the write, before the move → directory still there, still claimed → the same vault finishes next launch; no other vault may take it.
- Crash after the move, during the partition → the **pending record** drives the pass, not the legacy directory (gone by then), so the next launch partitions the store the vault now owns.
- Crash after both → record cleared, claim settled, nothing to double-apply.
- Setting aside is idempotent: re-archiving replays an identical Yjs update (a no-op), and clearing an already-cleared document is a no-op.

## Migration / compat — live beta, real data on disk

**`a6178a35a` is itself unreleased** (dated 2026-08-15, in no tag; latest release is `v2026-08-11`), so **no user has run this migration yet** — there is no already-claimed, already-moved field state to retro-repair.

Layout is unchanged; this adds one optional JSON key.

| Older-build state | Behaviour |
|---|---|
| No `crdtStore` key | Unclaimed / nothing pending — correct start |
| Legacy dir, unclaimed | Claim + (multi-vault only) pending recorded, move, partition |
| Legacy dir, claimed by this vault | Move resumes; partition runs iff pending names this vault |
| Legacy dir, claimed by another vault | Untouched, as before |
| Legacy dir absent, claim recorded, pending set | Partition runs against the already-moved store |
| Partial move (delete failed) | Existing `existsSync(storagePath)` branch still returns early |
| **Downgrade to an older build** | Ignores the new key; the claim still reads correctly |

No DB schema, IPC contract or vault file-format change. `recordLegacyCrdtStoreClaim` gained an optional second argument (additive).

## Tests — mutation-verified against a **real** y-leveldb store

All tests use a real store in a tmpdir, not a fake; only `openCrdtPersistence` is mocked (the real one forks an Electron utilityProcess). 11 mutations, each asserted to have applied before running. Highlights:

| Mutation | Caught by |
| --- | --- |
| Never record the pending partition (**exactly `origin/main`'s behaviour**) | 3 tests |
| Multi-vault gate `> 1` → `>= 1` | 1 |
| Partition only when the legacy dir was present (loses crash-safety) | 1 |
| Clear the pending record unconditionally | 1 |
| `isCrossVaultAmbiguousDocId` → `false` / → `true` | 4 / 3 |
| Clear without archiving first | 2 |
| Drop `await persistence.destroy()` (lock left held) | 4 |

**The agent discarded one of its own tests** for passing identically on `origin/main`, and strengthened another that used `resolves.toBeDefined()` — y-leveldb swallows a failed transaction into `null` rather than rejecting, so it passed under the lock-leak mutation.

**Independent re-verification by the main session:** I injected a  at the top of `setAsideAmbiguousLegacyDocs` — a pass that reports success while doing nothing, the exact false-confidence shape that bit this area four times last week. Confirmed applied via `git diff --stat`. **9 tests failed**, including the end-to-end `prepareVaultCrdtStore()` scenario: `expected 'the other vault's journal' to be ''`. Restored: 16/16 green.

I also independently confirmed the `seedFromMarkdown` early return, the `isJournalId` regex match, and `generateNoteId`'s alphabet.

## Verification

Baseline: `test:main` is green on `origin/main` @ `255d23878`, so nothing here is written off as pre-existing.

- `pnpm --filter @memry/desktop test:main` — 529 passed | 3 skipped (532 files), 6778 tests passed. **Zero failures.**
- `pnpm typecheck` — 17/17 · `pnpm lint` — 0 errors, no warnings in any touched file
- `git diff --check` — clean · `docs:impact --strict` — covered · `docs:build` — complete

## Explicitly not fixed

- **Hand-written or imported frontmatter ids** that collide across vaults (e.g. two vaults imported from one Obsidian source). No recognisable shape, so any test has false positives — and a false positive here throws away real history.
- **Pre-existing contamination.** Where two journals already merged, the mixed text is already in markdown. This stops the bleed; it cannot un-mix the past. Matches the issue's own framing.
- **Non-journal documents are still misfiled** into the claimant vault. Inert and non-destructive, and still on disk for a future redistribution.

## Note for review

Touches two test files outside its stated ownership — `crdt-provider.test.ts` and `crdt-ipc-handlers.test.ts`, 3 lines each — solely to add the new `store.ts` exports to their `vi.mock` factories, which otherwise throw on the missing export. Flagging because #1489 is in flight on `crdt-provider.ts`.