### PR TITLE
fix(sync): route a note's push away from the pruning endpoint when its merge skipped an unverifiable payload

### DIFF
--- a/apps/desktop/src/main/sync/crdt-pending-notes.ts
+++ b/apps/desktop/src/main/sync/crdt-pending-notes.ts
@@ -119,6 +119,12 @@ let draining = false
  *
  * A merge that does not complete leaves the note pending and unpushed. Delaying
  * one device's backlog is recoverable; deleting another device's edits is not.
+ *
+ * A merge that completed but skipped a payload whose signer could not be
+ * resolved is a third case, and it is NOT held back here: that skip can be
+ * permanent, so waiting for it would delay the backlog forever. `pushSnapshot`
+ * answers it by sending the same doc state to the incremental endpoint, which
+ * prunes nothing — see the endpoint choice in `runtime.ts`.
  */
 export async function drainPendingCrdtNotes(
   deps: PendingCrdtDrainDeps

--- a/apps/desktop/src/main/sync/engine-crdt.test.ts
+++ b/apps/desktop/src/main/sync/engine-crdt.test.ts
@@ -327,4 +327,80 @@ describe('SyncEngine', () => {
       vi.restoreAllMocks()
     })
   })
+
+  /**
+   * The wire between the two halves of the #1489 fix.
+   *
+   * `CrdtSyncCoordinator` raises the flag and the CRDT snapshot push fn reads it
+   * through `SyncEngine.hasUnverifiedRemoteCrdtUpdate` to pick an endpoint. Both
+   * halves had tests, and both suites stubbed the other side — so replacing the
+   * engine method with `return false` disabled the entire fix in production and
+   * left all 151 sync test files green. These drive a real coordinator, a real
+   * `PullCoordinator.resolveDeviceKey` and the real bridge, with no mock
+   * standing between the flag being raised and the flag being read.
+   */
+  describe('#given a CRDT pull whose signer device key cannot be resolved', () => {
+    const crdtProviderStub = (): Record<string, ReturnType<typeof vi.fn>> => ({
+      getDoc: vi.fn().mockReturnValue(undefined),
+      open: vi.fn().mockResolvedValue({}),
+      closeIfInactive: vi.fn().mockResolvedValue(true),
+      applyRemoteUpdate: vi.fn(),
+      getStateVector: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4])),
+      seedFromMarkdownPublic: vi.fn()
+    })
+
+    it('#then the engine reports the note as holding unverified server state', async () => {
+      const deps = createMockDeps(getDb(), {
+        crdtProvider: crdtProviderStub() as unknown as SyncEngineDeps['crdtProvider'],
+        // The production trigger, unmocked from here down: a revoked peer is
+        // absent from GET /auth/devices, so its key resolves to null forever.
+        getDevicePublicKey: vi.fn().mockResolvedValue(null)
+      })
+      const engine = new SyncEngine(deps)
+
+      vi.spyOn(await import('./http-client'), 'fetchCrdtSnapshot').mockResolvedValue(null)
+      vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
+        updates: [
+          { sequenceNum: 7, data: 'eA==', createdAt: 1, signerDeviceId: 'revoked-device' }
+        ],
+        hasMore: false
+      })
+
+      // #when — the exact entry point drainPendingCrdtNotes uses before it
+      // decides to push
+      await engine.mergeRemoteCrdtForNote('note-1')
+
+      // #then a `return false` here sends the note back to /sync/crdt/snapshot,
+      // whose pruneUpdatesBeforeSnapshot deletes the row that was just skipped.
+      expect(engine.hasUnverifiedRemoteCrdtUpdate('note-1')).toBe(true)
+
+      vi.restoreAllMocks()
+    })
+
+    it('#then a note whose signers all resolve is not flagged', async () => {
+      const deps = createMockDeps(getDb(), {
+        crdtProvider: crdtProviderStub() as unknown as SyncEngineDeps['crdtProvider'],
+        getDevicePublicKey: vi.fn().mockResolvedValue(new Uint8Array(32))
+      })
+      const engine = new SyncEngine(deps)
+
+      vi.spyOn(await import('./http-client'), 'fetchCrdtSnapshot').mockResolvedValue(null)
+      vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
+        updates: [{ sequenceNum: 7, data: 'eA==', createdAt: 1, signerDeviceId: 'device-1' }],
+        hasMore: false
+      })
+      vi.spyOn(await import('./crdt-encrypt'), 'decryptCrdtUpdate').mockReturnValue(
+        new Uint8Array([9])
+      )
+
+      // #when
+      await engine.mergeRemoteCrdtForNote('note-2')
+
+      // #then the safe route has to stay the exception — a bridge hard-wired to
+      // `true` would cost every note in the vault its compaction point.
+      expect(engine.hasUnverifiedRemoteCrdtUpdate('note-2')).toBe(false)
+
+      vi.restoreAllMocks()
+    })
+  })
 })

--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -407,6 +407,16 @@ export class SyncEngine extends EventEmitter {
     return this.crdtSync.pullCrdtForNote(noteId)
   }
 
+  /**
+   * `true` when a merge pass left server state for this note out of the local
+   * doc because it could not verify the signer, so a snapshot push would delete
+   * or overwrite it. The CRDT snapshot push fn asks this before choosing an
+   * endpoint; see `CrdtSyncCoordinator.hasUnverifiedRemoteUpdate`.
+   */
+  hasUnverifiedRemoteCrdtUpdate(noteId: string): boolean {
+    return this.crdtSync.hasUnverifiedRemoteUpdate(noteId)
+  }
+
   async fullSync(): Promise<void> {
     const start = Date.now()
     try {

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
@@ -691,6 +691,144 @@ describe('CrdtSyncCoordinator', () => {
     expect(batched).toEqual([['n1', 'n2'], ['n3', 'n4'], ['n5']])
   })
 
+  it('flags a note whose single-note pass skipped an update it could not verify', async () => {
+    // #given one of two updates is signed by a device this client has no key
+    // for — a revoked peer, or a device list it could not refresh
+    const { ctx } = createBatchContext()
+    getFromServerMock.mockResolvedValue({
+      updates: [
+        { sequenceNum: 4, data: 'eA==', createdAt: 1, signerDeviceId: 'gone-device' },
+        { sequenceNum: 5, data: 'eQ==', createdAt: 2, signerDeviceId: 'device-a' }
+      ],
+      hasMore: false
+    })
+    decryptCrdtUpdateMock.mockReturnValue(new Uint8Array([7]))
+    const resolveDeviceKey = vi.fn(async (id: string) =>
+      id === 'gone-device' ? null : new Uint8Array([1, 2, 3])
+    )
+    const coordinator = new CrdtSyncCoordinator(ctx, resolveDeviceKey)
+
+    // #when
+    const merged = await coordinator.applyCrdtIncrementals(
+      'note-1',
+      'token-1',
+      new Uint8Array([4])
+    )
+
+    // #then the pass still reports merged, so the pending-note replay is not
+    // held back — an unresolvable signer can be permanent, and refusing to push
+    // would strand this device's own offline backlog forever. The hazard is
+    // carried as a flag instead, and the push path answers it by choosing the
+    // endpoint that does not prune.
+    expect(merged).toBe(true)
+    expect(coordinator.hasUnverifiedRemoteUpdate('note-1')).toBe(true)
+    // And it is owed a pull, so a signer that was only transiently unresolvable
+    // (an expired token, say) is retried rather than flagged forever.
+    expect(coordinator.drainPendingPulls()).toEqual(['note-1'])
+  })
+
+  it('flags a note whose server snapshot baseline could not be verified', async () => {
+    // #given the note's stored snapshot is signed by an unresolvable device
+    const { ctx } = createBatchContext()
+    fetchCrdtSnapshotMock.mockResolvedValue({
+      snapshot: new Uint8Array([9]),
+      sequenceNum: 12,
+      signerDeviceId: 'gone-device'
+    })
+    postToServerMock.mockResolvedValue({ notes: { 'note-1': { updates: [], hasMore: false } } })
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn().mockResolvedValue(null))
+
+    // #when
+    await coordinator.applyCrdtBatch(['note-1'], 'token-1', new Uint8Array([4]))
+
+    // #then a snapshot push would overwrite the single R2 blob this pass just
+    // declined to read — a larger loss than a pruned incremental, and equally
+    // permanent.
+    expect(coordinator.hasUnverifiedRemoteUpdate('note-1')).toBe(true)
+  })
+
+  it('flags only the batched note that skipped an unverifiable update', async () => {
+    // #given note-2 carries an update from a signer this client cannot resolve
+    const { ctx } = createBatchContext()
+    postToServerMock.mockResolvedValue({
+      notes: {
+        'note-1': {
+          updates: [{ sequenceNum: 3, data: 'eA==', createdAt: 1, signerDeviceId: 'device-a' }],
+          hasMore: false
+        },
+        'note-2': {
+          updates: [{ sequenceNum: 4, data: 'eQ==', createdAt: 1, signerDeviceId: 'gone-device' }],
+          hasMore: false
+        }
+      }
+    })
+    decryptCrdtUpdateMock.mockReturnValue(new Uint8Array([7]))
+    const resolveDeviceKey = vi.fn(async (id: string) =>
+      id === 'gone-device' ? null : new Uint8Array([1, 2, 3])
+    )
+    const coordinator = new CrdtSyncCoordinator(ctx, resolveDeviceKey)
+
+    // #when
+    await coordinator.applyCrdtBatch(['note-1', 'note-2'], 'token-1', new Uint8Array([4]))
+
+    // #then the flag is per note. Flagging the whole chunk would push every
+    // note in a sweep onto the non-pruning path and leave the server with no
+    // compaction point anywhere in the vault.
+    expect(coordinator.hasUnverifiedRemoteUpdate('note-2')).toBe(true)
+    expect(coordinator.hasUnverifiedRemoteUpdate('note-1')).toBe(false)
+  })
+
+  it('clears the flag once a later pass verifies every signer', async () => {
+    // #given a pass that skipped an update because the signer was unresolvable
+    const { ctx } = createBatchContext()
+    getFromServerMock.mockResolvedValue({
+      updates: [{ sequenceNum: 4, data: 'eA==', createdAt: 1, signerDeviceId: 'flaky-device' }],
+      hasMore: false
+    })
+    decryptCrdtUpdateMock.mockReturnValue(new Uint8Array([7]))
+    let signerResolves = false
+    const resolveDeviceKey = vi.fn(async () =>
+      signerResolves ? new Uint8Array([1, 2, 3]) : null
+    )
+    const coordinator = new CrdtSyncCoordinator(ctx, resolveDeviceKey)
+
+    await coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4]))
+    expect(coordinator.hasUnverifiedRemoteUpdate('note-1')).toBe(true)
+
+    // #when the signer resolves on a later pass — the transient case, which is
+    // what a missing access token or an un-refreshed device list looks like.
+    // Deliberately NOT via clearCaches(): that drops the flag wholesale, so a
+    // test that used it would assert nothing about the clean pass.
+    signerResolves = true
+    await coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4]))
+
+    // #then the note goes back to the snapshot path. A flag that only ever
+    // latched would permanently cost this note its compaction point.
+    expect(coordinator.hasUnverifiedRemoteUpdate('note-1')).toBe(false)
+  })
+
+  it('keeps the flag when a pass throws after skipping an unverifiable update', async () => {
+    // #given the first page skips an update, and the second page fails
+    const { ctx } = createBatchContext()
+    getFromServerMock
+      .mockResolvedValueOnce({
+        updates: [{ sequenceNum: 4, data: 'eA==', createdAt: 1, signerDeviceId: 'gone-device' }],
+        hasMore: true
+      })
+      .mockRejectedValueOnce(rateLimited())
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn().mockResolvedValue(null))
+
+    // #when
+    await expect(
+      coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4]))
+    ).resolves.toBe(false)
+
+    // #then the flag has to survive the throw. Computing it only at the end of
+    // a clean pass would leave a note that skipped an update looking safe to
+    // snapshot the moment anything later in the same pass failed.
+    expect(coordinator.hasUnverifiedRemoteUpdate('note-1')).toBe(true)
+  })
+
   it('does not seed from markdown when a doc was closed underneath the pass', async () => {
     // #given note-2's doc is gone by the time the pass checks it: getStateVector
     // reports null (no doc) rather than an empty vector (open but empty doc)

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -22,6 +22,27 @@ export class CrdtSyncCoordinator {
   private resolveDeviceKey: ResolveDeviceKey
   /** Once per key per session — CRDT apply failures recur every pass and would storm otherwise. */
   private applyFailureReported = new Set<string>()
+  /**
+   * Notes whose last pass left a server payload this device could not verify,
+   * because `resolveDeviceKey` had no public key for its signer.
+   *
+   * Refusing to push at all is not an option: an unresolvable signer can be
+   * permanent — `GET /auth/devices` only lists non-revoked devices, so a
+   * revoked or deleted peer's key never comes back — and a note held back
+   * forever strands this device's own offline backlog forever. It is also not
+   * reliably transient: `getDeviceSigningKey` already refetches the device list
+   * on a cache miss, so the stale-list case largely self-heals and a `null`
+   * that survives that is more often permanent than not.
+   *
+   * The signer key is only ever a *signature* check — the payload itself is
+   * sealed with a file key wrapped by the vault key (`crdt-encrypt.ts`) — so a
+   * skipped update still holds real, still-decryptable user content. Deleting
+   * it server-side is a real loss, not the disposal of already-dead bytes.
+   *
+   * So the note is flagged instead, and the push path routes it away from the
+   * snapshot endpoint, which is the only thing that prunes.
+   */
+  private unverifiedRemoteNotes = new Set<string>()
 
   constructor(ctx: SyncContext, resolveDeviceKey: ResolveDeviceKey) {
     this.ctx = ctx
@@ -74,6 +95,32 @@ export class CrdtSyncCoordinator {
     this.pendingPulls.clear()
     this.lastAppliedSequence.clear()
     this.applyFailureReported.clear()
+    this.unverifiedRemoteNotes.clear()
+  }
+
+  /**
+   * Does this note hold server state this device merged around rather than into
+   * its doc?
+   *
+   * `true` means a snapshot push for this note would destroy that state:
+   * `storeSnapshot` overwrites the note's single R2 snapshot blob and
+   * `pruneUpdatesBeforeSnapshot` then deletes every `crdt_updates` row at or
+   * below the stored watermark — including the row this device skipped, which
+   * is by definition absent from the snapshot replacing it. Pushing the same
+   * doc state to `/sync/crdt/updates` instead has neither effect.
+   */
+  hasUnverifiedRemoteUpdate(noteId: string): boolean {
+    return this.unverifiedRemoteNotes.has(noteId)
+  }
+
+  /**
+   * A pass is only allowed to clear the flag it did not raise. Skips are
+   * recorded the moment they happen and cleared only once a pass has walked a
+   * note end to end without one, so a pass that throws half-way leaves the
+   * conservative answer standing rather than a stale "safe".
+   */
+  private clearUnverifiedIfClean(noteId: string, sawUnverified: boolean): void {
+    if (!sawUnverified) this.unverifiedRemoteNotes.delete(noteId)
   }
 
   private rememberAppliedSequence(noteId: string, sequenceNum: number): number {
@@ -83,15 +130,20 @@ export class CrdtSyncCoordinator {
     return next
   }
 
+  /**
+   * `verified: false` means the server's snapshot for this note was left out of
+   * the local doc. The caller has to carry that up: a snapshot push would
+   * overwrite the very blob that was skipped.
+   */
   private async applySnapshotBaseline(
     noteId: string,
     token: string,
     vaultKey: Uint8Array,
     mode: 'single' | 'batch'
-  ): Promise<number> {
+  ): Promise<{ since: number; verified: boolean }> {
     const snapshotResult = await fetchCrdtSnapshot(noteId, token)
     if (!snapshotResult || !this.ctx.deps.crdtProvider) {
-      return 0
+      return { since: 0, verified: true }
     }
 
     const signerPubKey = await this.resolveDeviceKey(snapshotResult.signerDeviceId)
@@ -100,7 +152,7 @@ export class CrdtSyncCoordinator {
         noteId,
         signerDeviceId: snapshotResult.signerDeviceId
       })
-      return 0
+      return { since: 0, verified: false }
     }
 
     const decrypted = decryptCrdtUpdate(snapshotResult.snapshot, vaultKey, noteId, signerPubKey)
@@ -111,7 +163,7 @@ export class CrdtSyncCoordinator {
       mode,
       sequenceNum: snapshotResult.sequenceNum
     })
-    return baselineSequence
+    return { since: baselineSequence, verified: true }
   }
 
   /**
@@ -122,6 +174,12 @@ export class CrdtSyncCoordinator {
    * up to here" and it acts on that by deleting the peer's incrementals, so a
    * push on top of an incomplete merge destroys them. `false` therefore has to
    * mean "do not push", which makes every early return below a `false` too.
+   *
+   * An update skipped for an unresolvable signer is deliberately NOT a `false`.
+   * That skip can be permanent, so `false` would hold this note back forever and
+   * trade a rare loss for a certain one. It is recorded in
+   * `unverifiedRemoteNotes` instead, and the push path answers it by sending the
+   * doc state to the incremental endpoint, which prunes nothing.
    */
   async applyCrdtIncrementals(
     noteId: string,
@@ -140,7 +198,10 @@ export class CrdtSyncCoordinator {
       const doc = await crdtProvider.open(noteId, undefined, { skipSeed: true })
       if (!doc) return false
 
-      let since = await this.applySnapshotBaseline(noteId, token, vaultKey, 'single')
+      const baseline = await this.applySnapshotBaseline(noteId, token, vaultKey, 'single')
+      let since = baseline.since
+      let sawUnverified = !baseline.verified
+      if (sawUnverified) this.unverifiedRemoteNotes.add(noteId)
 
       let hasMore = true
 
@@ -189,6 +250,12 @@ export class CrdtSyncCoordinator {
               signerDeviceId: entry.signerDeviceId,
               sequenceNum: entry.sequenceNum
             })
+            // Flagged before the loop can throw, and the note is owed another
+            // pull: a signer that becomes resolvable (a token that was simply
+            // expired here) clears the flag on the next pass.
+            sawUnverified = true
+            this.unverifiedRemoteNotes.add(noteId)
+            this.owePendingPull(noteId)
             since = entry.sequenceNum
             continue
           }
@@ -200,6 +267,8 @@ export class CrdtSyncCoordinator {
 
         hasMore = result.hasMore
       }
+
+      this.clearUnverifiedIfClean(noteId, sawUnverified)
 
       const postVector = crdtProvider.getStateVector(noteId)
       if (!postVector || postVector.length <= 2) {
@@ -280,6 +349,9 @@ export class CrdtSyncCoordinator {
     if (!crdtProvider) return
 
     const syncOpenedNoteIds = new Set<string>()
+    // Per-pass record, so only a note this pass walked cleanly may have its
+    // standing flag cleared at the end.
+    const sawUnverified = new Set<string>()
     try {
       const sinceMap = new Map<string, number>()
 
@@ -297,8 +369,13 @@ export class CrdtSyncCoordinator {
         }
 
         try {
-          const since = await this.applySnapshotBaseline(noteId, token, vaultKey, 'batch')
-          sinceMap.set(noteId, since)
+          const baseline = await this.applySnapshotBaseline(noteId, token, vaultKey, 'batch')
+          sinceMap.set(noteId, baseline.since)
+          if (!baseline.verified) {
+            sawUnverified.add(noteId)
+            this.unverifiedRemoteNotes.add(noteId)
+            this.owePendingPull(noteId)
+          }
         } catch (err) {
           if (err instanceof DOMException && err.name === 'AbortError') throw err
           // A single note's baseline failure must not abandon every note left in
@@ -357,6 +434,12 @@ export class CrdtSyncCoordinator {
                 signerDeviceId: entry.signerDeviceId,
                 sequenceNum: entry.sequenceNum
               })
+              // Same reasoning as the single-note path: flag now so a throw
+              // later in the chunk cannot leave a stale "safe to snapshot",
+              // and owe the note a pull so a transient signer self-heals.
+              sawUnverified.add(noteId)
+              this.unverifiedRemoteNotes.add(noteId)
+              this.owePendingPull(noteId)
               activeSince.set(noteId, entry.sequenceNum)
               continue
             }
@@ -374,6 +457,10 @@ export class CrdtSyncCoordinator {
             activeSince.delete(noteId)
           }
         }
+      }
+
+      for (const noteId of sinceMap.keys()) {
+        this.clearUnverifiedIfClean(noteId, sawUnverified.has(noteId))
       }
 
       // Seed only notes whose snapshot baseline succeeded. A note skipped at :205

--- a/apps/desktop/src/main/sync/http-client.test.ts
+++ b/apps/desktop/src/main/sync/http-client.test.ts
@@ -39,11 +39,13 @@ import {
   postToServer,
   getFromServer,
   deleteFromServer,
+  pushCrdtFullUpdate,
   SyncServerError,
   NetworkError,
   RateLimitError,
   parseRetryAfterHeader
 } from './http-client'
+import { MAX_CRDT_UPDATE_PAYLOAD_CHARS } from './crdt-payload'
 import { resetVaultUuidCache } from '../agent/storage/vault-id'
 
 /** A real data.db handle carrying the vault_metadata singleton. */
@@ -316,6 +318,45 @@ describe('http-client', () => {
         // its own message rather than the generic unreachable one.
         message: 'errors:sync.requestTimedOut'
       })
+    })
+  })
+
+  describe('pushCrdtFullUpdate', () => {
+    it('sends the doc state to the non-pruning endpoint', async () => {
+      // #given a full document state that must reach the server WITHOUT the
+      // server deleting anything: only /sync/crdt/snapshot runs
+      // pruneUpdatesBeforeSnapshot (apps/sync-server/src/routes/sync.ts).
+      mockFetch.mockResolvedValue(createJsonResponse({ ok: true }))
+
+      // #when
+      await pushCrdtFullUpdate('note-1', new Uint8Array([1, 2, 3]), 'token-1')
+
+      // #then the URL is the load-bearing assertion here. Sending these same
+      // bytes one path over deletes every crdt_updates row at or below the
+      // stored watermark, including one this device could not verify and
+      // therefore could not have included.
+      const [url, init] = mockFetch.mock.calls[0] as [string, { body: string }]
+      expect(url).toContain('/sync/crdt/updates')
+      expect(url).not.toContain('/sync/crdt/snapshot')
+      expect(JSON.parse(init.body)).toEqual({
+        noteId: 'note-1',
+        updates: [Buffer.from([1, 2, 3]).toString('base64')]
+      })
+    })
+
+    it('refuses a state too large for a D1 row instead of silently falling back', async () => {
+      // #given the incremental route stores each update as a D1 blob, so it has
+      // a ceiling the snapshot's R2 object does not
+      mockFetch.mockResolvedValue(createJsonResponse({ ok: true }))
+      const tooBig = new Uint8Array(MAX_CRDT_UPDATE_PAYLOAD_CHARS)
+
+      // #when / #then throwing stalls this one note — its content is already
+      // durable in the local CRDT store — where a snapshot fallback would
+      // destroy the peer payload the caller is protecting.
+      await expect(pushCrdtFullUpdate('note-1', tooBig, 'token-1')).rejects.toThrow(
+        'CRDT state too large'
+      )
+      expect(mockFetch).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/desktop/src/main/sync/http-client.ts
+++ b/apps/desktop/src/main/sync/http-client.ts
@@ -3,6 +3,7 @@ import { RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
 import { getMainI18n } from '../lib/main-i18n'
 import { resolveSyncServerUrl } from './sync-server-url'
 import { withRetry } from './retry'
+import { MAX_CRDT_UPDATE_PAYLOAD_CHARS } from './crdt-payload'
 
 // Declared to the server so it never sends this build an item type our
 // RecordPullResponseSchema would reject — one unknown type fails the whole-page
@@ -241,6 +242,34 @@ export async function pushCrdtSnapshot(
     { noteId, snapshot: b64 },
     token
   )
+}
+
+/**
+ * Push a full document state to the INCREMENTAL endpoint.
+ *
+ * The same bytes `pushCrdtSnapshot` would send, with a different consequence.
+ * `/sync/crdt/snapshot` overwrites the note's one snapshot blob and then runs
+ * `pruneUpdatesBeforeSnapshot`, which deletes every `crdt_updates` row at or
+ * below the stored watermark. `/sync/crdt/updates` appends and prunes nothing.
+ *
+ * That difference is the whole point: a device that merged *around* server
+ * state it could not verify must not assert "I contain everything up to here",
+ * because the payload it skipped is by definition absent from the snapshot
+ * replacing it. See the endpoint choice in `runtime.ts`.
+ *
+ * The ceiling is the incremental path's rather than the snapshot's — the server
+ * stores each update as a D1 blob, not an R2 object.
+ */
+export async function pushCrdtFullUpdate(
+  noteId: string,
+  encryptedState: Uint8Array,
+  token: string
+): Promise<unknown> {
+  const b64 = Buffer.from(encryptedState).toString('base64')
+  if (b64.length > MAX_CRDT_UPDATE_PAYLOAD_CHARS) {
+    throw new Error(`CRDT state too large for the non-pruning push path: ${b64.length}`)
+  }
+  return postToServer('/sync/crdt/updates', { noteId, updates: [b64] }, token)
 }
 
 export async function fetchCrdtSnapshot(

--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -69,6 +69,9 @@ const runtimeMocks = vi.hoisted(() => {
     stop = vi.fn(async () => undefined)
     requestPush = vi.fn()
     mergeRemoteCrdtForNote = vi.fn(async (_noteId: string) => true)
+    hasUnverifiedRemoteCrdtUpdate = vi.fn((noteId: string) =>
+      runtimeMocks.unverifiedCrdtNotes.has(noteId)
+    )
     constructor(public deps: Record<string, unknown>) {
       SyncEngine.instances.push(this)
     }
@@ -137,6 +140,7 @@ const runtimeMocks = vi.hoisted(() => {
     encryptCrdtUpdate: vi.fn(),
     postToServer: vi.fn(),
     pushCrdtSnapshot: vi.fn(),
+    pushCrdtFullUpdate: vi.fn(),
     withRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
     emitSessionExpired: vi.fn(),
     // token-manager keeps exactly one callback slot, and a refresh invokes
@@ -165,6 +169,8 @@ const runtimeMocks = vi.hoisted(() => {
       }) => ({ cleared: 0, retained: 0 })
     ),
     resetCrdtProvider: vi.fn(),
+    /** Notes the engine reports as holding server state it could not verify. */
+    unverifiedCrdtNotes: new Set<string>(),
     syncGoogleCalendarSource: vi.fn(),
     crdtProvider: {
       init: vi.fn(),
@@ -374,6 +380,7 @@ vi.mock('./crdt-encrypt', () => ({
 vi.mock('./http-client', () => ({
   postToServer: runtimeMocks.postToServer,
   pushCrdtSnapshot: runtimeMocks.pushCrdtSnapshot,
+  pushCrdtFullUpdate: runtimeMocks.pushCrdtFullUpdate,
   SyncServerError: runtimeMocks.SyncServerError,
   // runtime.ts → sync-errors.ts imports these; they only need to exist here.
   NetworkError: class NetworkError extends Error {},
@@ -459,6 +466,7 @@ describe('sync runtime', () => {
     runtimeMocks.engineStartError = null
     runtimeMocks.workerStartError = null
     runtimeMocks.indexRows = [{ id: 'note-1', title: 'Note 1', date: null }]
+    runtimeMocks.unverifiedCrdtNotes.clear()
     runtimeMocks.currentDevice = { id: 'device-1', signingPublicKey: null }
     runtimeMocks.db = createDb()
     runtimeMocks.getDatabase.mockReturnValue(runtimeMocks.db.db)
@@ -472,6 +480,7 @@ describe('sync runtime', () => {
     runtimeMocks.encryptCrdtUpdate.mockReturnValue(new Uint8Array([10, 11]))
     runtimeMocks.postToServer.mockResolvedValue({ ok: true })
     runtimeMocks.pushCrdtSnapshot.mockResolvedValue({ ok: true })
+    runtimeMocks.pushCrdtFullUpdate.mockResolvedValue({ ok: true })
     runtimeMocks.crdtProvider.init.mockResolvedValue(undefined)
     runtimeMocks.crdtProvider.seedExistingDocs.mockResolvedValue(1)
     runtimeMocks.crdtProvider.pushSnapshotForNote.mockResolvedValue(undefined)
@@ -846,6 +855,64 @@ describe('sync runtime', () => {
       expect.objectContaining({ errorCategory: 'storage_quota_exceeded' })
     )
     expect(queue.pause.mock.calls.length).toBe(pauseCallsBeforeSnapshot + 1)
+  })
+
+  it('sends the doc state to the incremental endpoint for a note holding unverified server state', async () => {
+    // #given a note whose merge pass skipped a payload it could not verify —
+    // the signer device is revoked, or the device list could not be refreshed.
+    const runtime = await loadRuntime()
+    await runtime.startSyncRuntime()
+    const snapshotPush = runtimeMocks.crdtProvider.init.mock.calls[0][1] as (
+      noteId: string,
+      state: Uint8Array
+    ) => Promise<void>
+    runtimeMocks.unverifiedCrdtNotes.add('note-unverified')
+    runtimeMocks.encryptCrdtUpdate.mockReturnValue(new Uint8Array([10, 11]))
+    runtimeMocks.pushCrdtFullUpdate.mockClear()
+    runtimeMocks.pushCrdtSnapshot.mockClear()
+
+    // #when the snapshot scheduler, the pending-note replay, or the push
+    // coordinator asks for this note's full state to be pushed
+    await snapshotPush('note-unverified', new Uint8Array([1, 2, 3]))
+
+    // #then it must NOT reach /sync/crdt/snapshot. That route runs
+    // pruneUpdatesBeforeSnapshot, which deletes every crdt_updates row at or
+    // below the stored watermark — including the row this device skipped, which
+    // is absent from the snapshot replacing it. The peer's edit would be gone
+    // for every device, permanently. The incremental route carries the same
+    // bytes and prunes nothing.
+    expect(runtimeMocks.pushCrdtSnapshot).not.toHaveBeenCalled()
+    expect(runtimeMocks.pushCrdtFullUpdate).toHaveBeenCalledWith(
+      'note-unverified',
+      new Uint8Array([10, 11]),
+      'access-token'
+    )
+  })
+
+  it('still snapshots a note whose server state merged cleanly', async () => {
+    // #given nothing was skipped for this note
+    const runtime = await loadRuntime()
+    await runtime.startSyncRuntime()
+    const snapshotPush = runtimeMocks.crdtProvider.init.mock.calls[0][1] as (
+      noteId: string,
+      state: Uint8Array
+    ) => Promise<void>
+    runtimeMocks.encryptCrdtUpdate.mockReturnValue(new Uint8Array([10, 11]))
+    runtimeMocks.pushCrdtFullUpdate.mockClear()
+    runtimeMocks.pushCrdtSnapshot.mockClear()
+
+    // #when
+    await snapshotPush('note-1', new Uint8Array([1, 2, 3]))
+
+    // #then the safe route must stay the exception. Routing every push through
+    // the incremental endpoint would leave the server with an unbounded tail of
+    // full-document updates and no compaction point at all.
+    expect(runtimeMocks.pushCrdtSnapshot).toHaveBeenCalledWith(
+      'note-1',
+      new Uint8Array([10, 11]),
+      'access-token'
+    )
+    expect(runtimeMocks.pushCrdtFullUpdate).not.toHaveBeenCalled()
   })
 
   it('splits a CRDT batch too big for one request across several requests', async () => {

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -686,7 +686,13 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
               baseDelayMs: 2000
             }
           )
-          log.debug('Pushed CRDT snapshot', { noteId, size: state.byteLength, viaUpdates })
+          // Distinct message per endpoint on purpose: log triage greps these
+          // strings, and the notes someone is grepping for are exactly the ones
+          // that did not take the snapshot route.
+          log.debug(viaUpdates ? 'Pushed CRDT full state as an update' : 'Pushed CRDT snapshot', {
+            noteId,
+            size: state.byteLength
+          })
         } catch (err) {
           if (err instanceof SyncServerError && err.statusCode === 401) {
             // withAuthRetry already attempted a refresh — see the update-batch

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -66,7 +66,7 @@ import { planCrdtUpdatePush } from './crdt-payload'
 import { drainPendingCrdtNotes, recordPendingCrdtNotes } from './crdt-pending-notes'
 import { recoverDirtyItems } from './dirty-recovery'
 import { encryptCrdtUpdate } from './crdt-encrypt'
-import { postToServer, pushCrdtSnapshot, SyncServerError } from './http-client'
+import { postToServer, pushCrdtSnapshot, pushCrdtFullUpdate, SyncServerError } from './http-client'
 import { classifyError } from './sync-errors'
 import {
   EVENT_CHANNELS,
@@ -638,10 +638,43 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
 
         try {
           const encrypted = encryptCrdtUpdate(state, vaultKey, noteId, signingSecretKey)
+
+          // The snapshot endpoint is the only destructive one. `storeSnapshot`
+          // overwrites the note's single R2 blob and `pruneUpdatesBeforeSnapshot`
+          // then deletes every `crdt_updates` row at or below the stored
+          // watermark. That is correct when this device really does contain
+          // everything the server has — and a lie when a merge pass skipped a
+          // payload it could not verify, because that payload is by definition
+          // absent from the snapshot replacing it. It is then gone for every
+          // device, permanently, and the vault key that could still decrypt it
+          // no longer has anything to decrypt.
+          //
+          // Failing closed instead — holding the note back until the signer
+          // resolves — is not available: `GET /auth/devices` lists only
+          // non-revoked devices, so a revoked peer's key never returns and the
+          // note would be held forever, stranding this device's own offline
+          // backlog. So the same doc state goes to the incremental endpoint,
+          // which stores and broadcasts it exactly like any other update and
+          // prunes nothing. This device's edits reach every peer; the skipped
+          // payload stays on the server for a later pass — or a later app
+          // version — to make sense of.
+          //
+          // The incremental route has a size ceiling the snapshot's R2 blob does
+          // not (`pushCrdtFullUpdate` throws past it), which keeps that one
+          // note pending and retried — a stall, not a loss, since its content is
+          // already durable in the local CRDT store.
+          //
+          // `engine` is referenced lazily for the same reason
+          // `replayPendingCrdtNotes` does: nothing invokes this fn between
+          // `crdtProvider.init` below and the `const engine` assignment.
+          const viaUpdates = engine.hasUnverifiedRemoteCrdtUpdate(noteId)
           await withRetry(
             () =>
               withAuthRetry(
-                (authToken) => pushCrdtSnapshot(noteId, encrypted, authToken),
+                (authToken) =>
+                  viaUpdates
+                    ? pushCrdtFullUpdate(noteId, encrypted, authToken)
+                    : pushCrdtSnapshot(noteId, encrypted, authToken),
                 token!,
                 crdtAuthRetryDeps,
                 (fresh) => {
@@ -653,7 +686,7 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
               baseDelayMs: 2000
             }
           )
-          log.debug('Pushed CRDT snapshot', { noteId, size: state.byteLength })
+          log.debug('Pushed CRDT snapshot', { noteId, size: state.byteLength, viaUpdates })
         } catch (err) {
           if (err instanceof SyncServerError && err.statusCode === 401) {
             // withAuthRetry already attempted a refresh — see the update-batch

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -616,6 +616,59 @@ note, both on the `crdt_pull` bucket (600 / 60 s per device). The pending list i
 tens of notes in practice, so ~40–50 GETs, alongside the paced sweep's 100/min —
 comfortably inside the budget, and no pacing is added.
 
+### An unverifiable signer routes the push away from the snapshot endpoint
+
+Failing closed covers a pull that did not complete. It does **not** cover a pull
+that completed while stepping over something. Every apply path — the single-note
+incrementals loop, the batch chunk, and the snapshot baseline — verifies each
+payload's Ed25519 signature against its signer device's public key, and skips
+the payload when `resolveDeviceKey` returns no key for that device.
+
+Treating that skip as "not merged" would be wrong, because the skip can be
+**permanent**. `GET /auth/devices` returns only non-revoked devices, so once a
+peer device is revoked its key never comes back, and a note held back until the
+signer resolves would be held forever — stranding this device's own offline
+backlog. Nor can the client tell the two apart: `getDeviceSigningKey` already
+refetches the device list on a cache miss, so a surviving `null` carries no
+signal about whether it will ever clear.
+
+Treating it as "merged" is what the fix replaces. It let the note's next
+snapshot push destroy the skipped payload: `storeSnapshot` upserts the note's
+one R2 blob, and `pruneUpdatesBeforeSnapshot` then deletes the `crdt_updates`
+rows the snapshot claims to contain — including the row the device could not
+verify and therefore could not have included. The signer key is only ever a
+signature check; the payload itself is sealed with a file key wrapped by the
+vault key, so what is deleted is still-decryptable user content.
+
+The endpoint is what resolves this. `pruneUpdatesBeforeSnapshot` has exactly one
+caller, `POST /sync/crdt/snapshot`. `POST /sync/crdt/updates` appends, prunes
+nothing, and wakes peers the same way. So:
+
+- `CrdtSyncCoordinator` records the notes a pass merged _around_
+  (`hasUnverifiedRemoteUpdate`, surfaced as
+  `SyncEngine.hasUnverifiedRemoteCrdtUpdate`).
+- The snapshot push fn sends those notes' full doc state through
+  `pushCrdtFullUpdate` — the same encrypted bytes, on the update endpoint —
+  instead of `pushCrdtSnapshot`.
+
+Every push path inherits this, because they all funnel through that one
+function: the pending-note replay, the 30 s snapshot scheduler, the push
+coordinator's create-time snapshots, and the oversized-update fallback.
+
+The flag is per note and per pass. It is raised the moment a skip happens, so a
+failure later in the same pass cannot leave a stale "safe to snapshot", and it
+is cleared only by a pass that walks the note end to end without one. A skip
+also re-queues the note for a pull, so a transiently unresolvable signer — an
+expired access token is the case that actually occurs — clears the flag on the
+next pass and the note resumes normal compaction.
+
+One narrow cost: `pushCrdtFullUpdate` throws above
+`MAX_CRDT_UPDATE_PAYLOAD_CHARS`, because the update endpoint stores each payload
+in a D1 row rather than an R2 object. A note that is both over that ceiling and
+holding an unverifiable payload stays pending and retried rather than
+snapshotted. That is a stall, not a loss — its content is already durable in the
+local CRDT store — whereas snapshotting it would be a loss.
+
 ## Sign-Out / Sign-In Ordering
 
 A sign out → sign in cycle has a sharp ordering rule:


### PR DESCRIPTION
Closes #1489. Part of EPIC #1499. **This is the data-loss vector the epic flags as the one to do first.**

`applyCrdtIncrementals` skipped an update whose signer device key could not be resolved — logged, advanced `since`, continued — and still returned `true`. `true` tells `drainPendingCrdtNotes` it is safe to push the note's snapshot, and `storeSnapshot` is followed by `pruneUpdatesBeforeSnapshot`, which deletes every `crdt_updates` row at or below the watermark. The skipped update is deleted server-side while absent from the snapshot replacing it. **That peer's edit is gone for every device.**

## Why not fail closed

An unresolvable signer can be **permanent** — `GET /auth/devices` lists only non-revoked devices, so a revoked peer's key never comes back. Returning `false` would hold the note forever and strand this device's own offline backlog. That trades a rare loss for a certain one.

Option (a), distinguishing transient from permanent, was investigated and rejected: `getDeviceSigningKey` already refetches the device list on a cache miss, so the stale-list case self-heals inside it, and transport failures *throw* (already handled). A surviving `null` carries no signal about permanence.

## The fix — option (b): change the endpoint, not the answer

`pruneUpdatesBeforeSnapshot` has exactly one production caller, `handleCrdtSnapshotPush` (`routes/sync.ts:733`). `POST /sync/crdt/updates` appends and prunes nothing, and **both endpoints broadcast to peers**. So the endpoint, not the return value, is the safety lever.

The coordinator records which notes a pass merged *around* (`unverifiedRemoteNotes`, surfaced as `SyncEngine.hasUnverifiedRemoteCrdtUpdate`), and `snapshotPushFn` sends those notes' full doc state via the new `pushCrdtFullUpdate` instead of `pushCrdtSnapshot`. **Same encrypted bytes, different endpoint.**

- **Rare loss avoided:** the skipped row is never pruned and the note's R2 blob is never overwritten.
- **Certain loss avoided:** `applyCrdtIncrementals` still returns `true`, so the drain still pushes. Nothing is held back for a signer that may never resolve.

### Why the skipped payload is worth saving

`decryptCrdtUpdate` uses the signer key **only** for `crypto_sign_verify_detached`; the payload is sealed with a file key wrapped by the *vault* key. So an unverifiable update still holds recoverable user content — **pruning it destroys data, not already-dead bytes.** This was the load-bearing check for choosing (b) over "it is dead anyway".

### All three skip sites are covered

`applySnapshotBaseline` is the worst of them: `storeSnapshot` upserts the note's single R2 blob `ON CONFLICT (user_id, vault_id, note_id)`, so a snapshot push overwrites the very blob the pass declined to read — a larger loss than a pruned incremental, and one the **frozen watermark does not protect against**.

Flag semantics: per note, per pass. Raised the instant a skip happens (so a later throw cannot leave a stale "safe"), cleared only by a pass that walks the note end to end clean. A skip also calls `owePendingPull`, so a transient signer self-heals next pass.

## Compat

**No protocol change.** Both endpoints, payload shapes and request bodies already exist and are unchanged. No server deploy, no deploy ordering. An older client pulling a full-state update applies it as an ordinary Yjs update (idempotent, commutative). No DB or settings shape touched. Purely additive on the desktop side.

One new failure mode, documented: a note whose encrypted state exceeds `MAX_CRDT_UPDATE_PAYLOAD_CHARS` **and** holds an unverifiable payload now throws instead of snapshotting — it stays pending and retried. A stall, not a loss; content is already durable in the local CRDT store.

## Tests — 9 mutations, 9 killed

Including inverse mutations: "still snapshots a clean note" survives the always-snapshot mutation, so it needs the always-incremental mutation to be worth anything.

### The one that mattered

**The main session found a real gap and this PR would not have shipped without the fix.** The first revision had the coordinator half and the routing half each tested against a mock of the other. Mutating the bridge:

```ts
hasUnverifiedRemoteCrdtUpdate(_noteId: string): boolean {
  return false // MUTATION: bridge always reports clean
}
```

**completely disables the fix in production** — every flagged note goes back to the pruning endpoint — and left **all 2217 sync tests green**. That is the exact shape that let four fixes ship green over broken behaviour last week.

Closed by `engine-crdt.test.ts`, which drives the real chain: real `SyncEngine` → real `PullCoordinator.resolveDeviceKey` → real `CrdtSyncCoordinator` → real bridge, triggered the way production triggers it (`getDevicePublicKey` → `null`, what a revoked peer looks like), entered through `engine.mergeRemoteCrdtForNote()` — the exact call the drain makes. **No mock between the flag being raised and the flag being read.** An inverse test catches a bridge hard-wired to `true`.

Re-verified by the main session: the same mutation, confirmed applied via `git diff --stat`, now yields

    FAIL src/main/sync/engine-crdt.test.ts > ... > the engine reports the note as holding unverified server state
    AssertionError: expected false to be true
    Test Files  1 failed | 150 passed | 1 skipped (152)

Restored → 151 passed, 2219 tests.

## Verification

Baseline: `test:main` fully green on `origin/main` @ 255d23878, so nothing is written off as pre-existing.

- `pnpm --filter @memry/desktop test:main` — 528 passed / 3 skipped files; **6777 passed**, 1 expected fail
- `pnpm typecheck` — 17/17 · `pnpm lint` — 0 errors, none in touched files
- `git diff --check` — clean · `docs:impact --strict` — covered · `docs:build` — complete

Independently confirmed by the main session: the signature-only use of the signer key, the single-blob upsert in `storeSnapshot`, that `storeUpdates` prunes nothing, and that `MAX_CRDT_UPDATE_PAYLOAD_CHARS` (1,200,000) is the correct per-update ceiling — deliberately stricter than the server's 5 MB because **D1's 1 MB row limit is the real wall**, and the server applies its check per array element.

## Relationship to #1503

This generalises cleanly to #1503 (the snapshot scheduler pushes without merging first). The choke point already covers every push path; only the predicate needs widening from "skipped an unverifiable payload" to "known-unmerged remote state". Worth merging the two.

Touches `snapshotPushFn` in `runtime.ts` only — **not** `crdt-provider.ts`'s `pushSnapshotForNote` or `crdt-snapshot-scheduler.ts`.

## Residual, filed or flagged

- `runtime.ts` is at 796/800 `max-lines`; the next person to touch it hits the cap.
- A permanently-unresolvable signer means that note never snapshots again, so every scheduled push appends a full-state row with no compaction point. Bounded by edit activity, strictly preferable to data loss, but unbounded and untelemetered.
- The flag is in-memory at engine lifetime, so after a restart there is a window before the note is next pulled — narrow, and only for a note with no server snapshot yet (the frozen watermark covers the rest).