### PR TITLE
fix(crdt): defer a concurrent pending-note drain instead of dropping it

### DIFF
--- a/apps/desktop/src/main/sync/crdt-pending-notes.test.ts
+++ b/apps/desktop/src/main/sync/crdt-pending-notes.test.ts
@@ -109,6 +109,135 @@ describe('crdt pending note store', () => {
     expect(pushSnapshot.mock.calls.map((call) => call[0])).toEqual(['note-a', 'note-b'])
   })
 
+  it('defers a trigger that arrives mid-drain instead of dropping it', async () => {
+    // The startup replay can still be pulling note-a when the network monitor
+    // reports online, and an edit made in between is recorded after the running
+    // drain already read the store. Dropping that trigger left the new id
+    // waiting for some later event; deferring replays it as soon as the running
+    // drain is done.
+    const { drainPendingCrdtNotes, readPendingCrdtNotes, recordPendingCrdtNotes } =
+      await import('./crdt-pending-notes')
+    recordPendingCrdtNotes(['note-a'])
+
+    let release: (() => void) | undefined
+    const inFlight = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const pushed: string[] = []
+    let concurrent = 0
+    let maxConcurrent = 0
+    const deps = {
+      isSyncable: () => true,
+      mergeRemote: async (_noteId: string) => {
+        concurrent++
+        maxConcurrent = Math.max(maxConcurrent, concurrent)
+        await Promise.resolve()
+        concurrent--
+        return true
+      },
+      pushSnapshot: async (noteId: string) => {
+        if (noteId === 'note-a') await inFlight
+        pushed.push(noteId)
+        return true
+      }
+    }
+
+    const startup = drainPendingCrdtNotes(deps)
+    recordPendingCrdtNotes(['note-b'])
+    const onReconnect = drainPendingCrdtNotes(deps)
+    release!()
+    const [startupResult, deferredResult] = await Promise.all([startup, onReconnect])
+
+    expect(pushed).toEqual(['note-a', 'note-b'])
+    expect(readPendingCrdtNotes()).toEqual([])
+    // The deferred caller gets the numbers for the run it actually caused, not
+    // the "nothing to do" a dropped trigger used to be told.
+    expect(startupResult).toEqual({ cleared: 1, retained: 0 })
+    expect(deferredResult).toEqual({ cleared: 1, retained: 0 })
+    // Deferred, not parallel: two runs must never share the durable store.
+    expect(maxConcurrent).toBe(1)
+  })
+
+  it('coalesces three overlapping triggers into one deferred run', async () => {
+    // A third trigger asks for nothing the second has not already asked for, so
+    // it joins that run. note-b stays unpushed here precisely so an extra pass
+    // would be visible as a second attempt at it.
+    const { drainPendingCrdtNotes, readPendingCrdtNotes, recordPendingCrdtNotes } =
+      await import('./crdt-pending-notes')
+    recordPendingCrdtNotes(['note-a'])
+
+    let release: (() => void) | undefined
+    const inFlight = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const pushed: string[] = []
+    const deps = {
+      isSyncable: () => true,
+      mergeRemote: async () => true,
+      pushSnapshot: async (noteId: string) => {
+        if (noteId === 'note-a') await inFlight
+        pushed.push(noteId)
+        return noteId === 'note-a'
+      }
+    }
+
+    const startup = drainPendingCrdtNotes(deps)
+    recordPendingCrdtNotes(['note-b'])
+    const second = drainPendingCrdtNotes(deps)
+    const third = drainPendingCrdtNotes(deps)
+    release!()
+    const [, secondResult, thirdResult] = await Promise.all([startup, second, third])
+
+    expect(pushed).toEqual(['note-a', 'note-b'])
+    expect(secondResult).toEqual({ cleared: 0, retained: 1 })
+    expect(thirdResult).toEqual(secondResult)
+    expect(readPendingCrdtNotes()).toEqual(['note-b'])
+  })
+
+  it('hands the deferred run the newest deps, not a torn-down session', async () => {
+    // `deps` closes over one runtime's engine and crdtProvider, and neither
+    // survives stopSyncRuntime. If a session is torn down and a new one starts
+    // while a drain is still running, the deferred run must belong to the live
+    // session — replaying the dead one's closure would pull and merge against a
+    // destroyed provider.
+    const { drainPendingCrdtNotes, recordPendingCrdtNotes } = await import('./crdt-pending-notes')
+    recordPendingCrdtNotes(['note-a'])
+
+    let release: (() => void) | undefined
+    const inFlight = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const running = {
+      isSyncable: () => true,
+      mergeRemote: async () => true,
+      pushSnapshot: async (noteId: string) => {
+        if (noteId === 'note-a') await inFlight
+        return true
+      }
+    }
+    const tornDown = {
+      isSyncable: () => true,
+      mergeRemote: vi.fn(async (_noteId: string) => true),
+      pushSnapshot: vi.fn(async (_noteId: string) => true)
+    }
+    const live = {
+      isSyncable: () => true,
+      mergeRemote: vi.fn(async (_noteId: string) => true),
+      pushSnapshot: vi.fn(async (_noteId: string) => true)
+    }
+
+    const startup = drainPendingCrdtNotes(running)
+    recordPendingCrdtNotes(['note-b'])
+    const fromDeadSession = drainPendingCrdtNotes(tornDown)
+    const fromNewSession = drainPendingCrdtNotes(live)
+    release!()
+    await Promise.all([startup, fromDeadSession, fromNewSession])
+
+    expect(tornDown.mergeRemote).not.toHaveBeenCalled()
+    expect(tornDown.pushSnapshot).not.toHaveBeenCalled()
+    expect(live.pushSnapshot.mock.calls.map((call) => call[0])).toEqual(['note-b'])
+  })
+
   it('leaves a note pending and unpushed when its pre-push pull fails', async () => {
     // Pushing a snapshot makes the server prune every crdt_updates row at or
     // below it. A device that could not pull first does not know what those

--- a/apps/desktop/src/main/sync/crdt-pending-notes.ts
+++ b/apps/desktop/src/main/sync/crdt-pending-notes.ts
@@ -96,12 +96,54 @@ export interface PendingCrdtDrainDeps {
   isSyncable: (noteId: string) => boolean
 }
 
-let draining = false
+interface PendingCrdtDrainResult {
+  cleared: number
+  retained: number
+}
+
+/**
+ * Serialisation state for the replay. Two runs must never overlap: each one
+ * re-reads the durable store at the top and rewrites it at the end, so a second
+ * run started mid-flight would re-push notes the first one is already pushing
+ * and could write its own id set over the first run's result.
+ *
+ * The guard used to *drop* the concurrent trigger and return "nothing to do".
+ * That leaned on both triggers being idempotent and on something firing the
+ * replay again later, and `2d6afbd95` widened the window a trigger can be lost
+ * in by making every note pull before it pushes. It defers instead.
+ *
+ * Deferral *coalesces*: at most one run waits behind the running one. A third
+ * trigger asks for nothing the second has not already asked for — every run is
+ * "replay whatever the store holds when you start", and that is re-read per run
+ * — so a queue of N would be one real pass and N-1 passes over an empty store.
+ *
+ * The queued run uses the *newest* caller's deps. `deps` closes over one
+ * runtime's `engine` and `crdtProvider` (runtime.ts's `replayPendingCrdtNotes`)
+ * and neither instance survives `stopSyncRuntime`, so if a session is torn down
+ * and a new one starts while a drain is still running, the new session's
+ * trigger replaces the dead session's closure rather than queueing behind it.
+ *
+ * A teardown with nothing replacing it leaves the queued run holding the dead
+ * runtime's deps — the same exposure a drain already in flight has, since
+ * teardown does not await it. It fails closed: `CrdtProvider.destroy()` nulls
+ * `snapshotPushFn`, and `pushSnapshotForNote` returns false without one, so
+ * nothing is cleared and every id stays in the durable store for next session.
+ */
+let inFlight: Promise<PendingCrdtDrainResult> | null = null
+let deferredRun: Promise<PendingCrdtDrainResult> | null = null
+let deferredDeps: PendingCrdtDrainDeps | null = null
 
 /**
  * Replay the recorded notes. An entry is cleared only once its state has
  * actually reached the server, so a still-offline start leaves it queued for
  * the next attempt rather than losing it.
+ *
+ * Triggered from two places, both in runtime.ts: the tail of `startSyncRuntime`
+ * (cold start and sign-in alike) and the network monitor going online. Coming
+ * back from offline does both within the same second, so the returned promise
+ * may be for a run deferred behind one already in flight — `{cleared, retained}`
+ * always describes the run this call is responsible for, never a run it merely
+ * waited on.
  *
  * **Merge before push, and fail closed.** A snapshot push is an assertion that
  * the pushed state contains everything the server has: `storeSnapshot` is
@@ -126,15 +168,43 @@ let draining = false
  * answers it by sending the same doc state to the incremental endpoint, which
  * prunes nothing — see the endpoint choice in `runtime.ts`.
  */
-export async function drainPendingCrdtNotes(
-  deps: PendingCrdtDrainDeps
-): Promise<{ cleared: number; retained: number }> {
-  if (draining) return { cleared: 0, retained: 0 }
+export function drainPendingCrdtNotes(deps: PendingCrdtDrainDeps): Promise<PendingCrdtDrainResult> {
+  if (!inFlight) return startDrain(deps)
 
+  deferredDeps = deps
+  deferredRun ??= runAfter(inFlight)
+  return deferredRun
+}
+
+async function runAfter(
+  previous: Promise<PendingCrdtDrainResult>
+): Promise<PendingCrdtDrainResult> {
+  // A predecessor that threw is not a reason to skip this run: the trigger
+  // behind it is an independent attempt, not a retry of that one.
+  await previous.catch(() => undefined)
+  const deps = deferredDeps!
+  deferredDeps = null
+  deferredRun = null
+  return startDrain(deps)
+}
+
+function startDrain(deps: PendingCrdtDrainDeps): Promise<PendingCrdtDrainResult> {
+  const run = drainOnce(deps).finally(() => {
+    // Stay marked in-flight while a run is queued behind this one. The handoff
+    // in `runAfter` is asynchronous, and a trigger landing inside it has to join
+    // that run rather than start a third drain alongside it.
+    if (inFlight === run && !deferredRun) inFlight = null
+  })
+  inFlight = run
+  return run
+}
+
+async function drainOnce(deps: PendingCrdtDrainDeps): Promise<PendingCrdtDrainResult> {
+  // Re-read per run, so a run deferred behind another one picks up the ids that
+  // one recorded while it was working as well as the ones it could not clear.
   const pending = readPendingCrdtNotes()
   if (pending.length === 0) return { cleared: 0, retained: 0 }
 
-  draining = true
   const cleared: string[] = []
   try {
     for (const noteId of pending) {
@@ -153,7 +223,6 @@ export async function drainPendingCrdtNotes(
       }
     }
   } finally {
-    draining = false
     clearPendingCrdtNotes(cleared)
   }
 

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -617,10 +617,32 @@ installed the snapshot push function and after `engine.start()` has awaited the
 first full sync. Signing in runs `startSyncRuntime`, which is what makes a
 signed-out backlog reach the server **with no further user input**; leaving the
 replay to `NetworkMonitor` alone was not enough, because signing in is not a
-network transition. `drainPendingCrdtNotes` is re-entrant-safe and clears an id
-only once its state has actually reached the server, so the startup replay and a
-network-transition replay firing together cannot double-push, and a
-still-offline start leaves the entry queued for the next attempt.
+network transition. `drainPendingCrdtNotes` clears an id only once its state has
+actually reached the server, so the startup replay and a network-transition
+replay firing together cannot double-push, and a still-offline start leaves the
+entry queued for the next attempt.
+
+Those two triggers can arrive within the same second — coming back from offline
+does both — so the replay serialises itself: two runs must never overlap,
+because each one re-reads the durable store at the top and rewrites it at the
+end. A trigger that lands mid-drain is **deferred, not dropped**. Dropping it
+was safe in the sense that nothing was lost, but the running drain had already
+read the store, so an id recorded in between waited on some unrelated later
+event to be replayed — and pulling before pushing made each drain slow enough
+for that to matter.
+
+Deferral **coalesces**: at most one run waits behind the running one. Every run
+is "replay whatever the store holds when you start", and that is re-read per
+run, so a third trigger asks for nothing the second has not already asked for,
+and a deferred run naturally picks up ids recorded while its predecessor was
+working. The queued run uses the **newest** trigger's dependencies: those close
+over one runtime's `SyncEngine` and `CrdtProvider`, and neither survives
+`stopSyncRuntime`, so a session torn down and replaced mid-drain hands the
+deferred run to the live session rather than replaying the dead one's closure. A
+teardown with nothing replacing it fails closed the same way an already-running
+drain does — `CrdtProvider.destroy()` nulls the snapshot push function, and
+`pushSnapshotForNote` returns `false` without one, so nothing is cleared and
+every id stays in the store for the next session.
 
 Notes that no longer exist, or never sync via CRDT (binaries), are dropped at
 drain time rather than retried forever, and a doc with no content is not pushed


### PR DESCRIPTION
Closes #1494. Part of EPIC #1499.

`drainPendingCrdtNotes` had a module-level `draining` guard that **dropped** a concurrent trigger and returned `{cleared: 0, retained: 0}` — a fabricated "nothing to do". It now defers.

Safe before, but only by leaning on both triggers being idempotent and on something firing the replay again later. `2d6afbd95` widened the window a trigger can be lost in by making every drained note pull before it pushes.

## The triggers do overlap, routinely

Two, both in `runtime.ts`, both calling the same `replayPendingCrdtNotes` closure:
- `runtime.ts:879` — tail of `startSyncRuntime` (cold start *and* sign-in)
- `runtime.ts:736` — `NetworkMonitor` `status-changed` → online

Coming back from offline fires both within the same second.

## Semantics: coalesce, not queue

At most one run waits behind the running one. Every run is "replay whatever the store holds when you start", and `drainOnce` re-reads `readPendingCrdtNotes()` as its first statement — so an id recorded *while* the running drain works is seen by the deferred run. A third trigger therefore asks for nothing the second has not already asked for; a queue of N would be one real pass and N−1 passes over an empty store.

Mutation B2 proves the difference: an N-deep queue pushes `note-b` twice.

**Return value:** a deferred caller now gets the real `{cleared, retained}` of the run it caused, instead of the fabricated `{0, 0}`. The numbers keep their meaning ("the run this call is responsible for"). The only production caller voids the result.

## Teardown

`deps` closes over one runtime's `engine` and `crdtProvider`; neither survives `stopSyncRuntime` (`resetCrdtProvider()` at `runtime.ts:1006`). Two mitigations:

1. **Newest deps win** — `deferredDeps = deps` is an unconditional assign, not `??=`. A session torn down and replaced mid-drain hands the deferred run to the *live* session's closure. Mutation C (`??=`) fails the test.
2. **Fail-closed otherwise** — `CrdtProvider.destroy()` nulls `snapshotPushFn` and `pushSnapshotForNote` returns `false` without one. Nothing is cleared; every id stays durable for the next session.

**Stated plainly: this does not eliminate stale-`deps` exposure, and does not add any.** `stopSyncRuntime` never awaited the drain, so an already-running drain has always been able to outlive its runtime. That pre-existing hole is filed as its own issue (see below) — it needs an abort signal owned by `runtime.ts`.

## Merge-before-push is untouched

The loop body is **byte-identical**. The entire diff to that function is: the signature loses `async`, the guard and `draining = false` lines go, and the loop moves verbatim into `drainOnce`. `mergeRemote` still gates `pushSnapshot`, still fails closed, still per note. The existing tests `leaves a note pending and unpushed when its pre-push pull fails` and `does not push when the pre-push pull throws` pass unchanged.

## Compat

No compat surface touched: no DB schema, migration, IPC contract, sync protocol, vault file format or settings shape. `crdt-pending-notes.json` is unchanged (array of note-id strings) and old and new versions read/write it identically. Same three exports, same `PendingCrdtDrainDeps`, same result shape. The only behaviour change is what a second *in-process* concurrent call does — no persisted or cross-version consequence. Editing signed out / offline / with no account is untouched.

## Tests — mutation-verified, and the key test fails on `origin/main`

Proven by swapping in `git show origin/main:...crdt-pending-notes.ts` while keeping the new tests — all 3 new tests failed, all 8 pre-existing passed:

    × defers a trigger that arrives mid-drain instead of dropping it
      → expected [ 'note-a' ] to deeply equal [ 'note-a', 'note-b' ]
    × coalesces three overlapping triggers into one deferred run
    × hands the deferred run the newest deps, not a torn-down session
      → expected [] to deeply equal [ 'note-b' ]

| Mutation | Result |
| --- | --- |
| A — defer reverts to drop | 3 failed |
| B2 — coalesce → N-deep queue | 2 failed (`[ 'note-a', 'note-b', 'note-b' ]`) |
| C — newest deps → first-deferrer's deps (`??=`) | 1 failed |
| D — re-read per run → read once | 5 failed |
| E — serialisation removed | 4 failed |

Every mutation was applied by a script that asserts the target string exists before replacing, then greps it back, so a silent no-op aborts. All tests drive the real exported `drainPendingCrdtNotes` against a real temp-dir JSON store — no rewrapped copy of the logic.

**Independent re-verification by the main session:** I mutated `runAfter` to defer and then never run — returning `{cleared: 0, retained: 0}` instead of calling `startDrain`, the silent-success shape rather than the drop. Confirmed applied via `git diff --stat`. **3 tests failed** (`expected [ 'note-a' ] to deeply equal [ 'note-a', 'note-b' ]`). Restored: 11/11 green. I also traced the coalescing state machine by hand, including the handoff window where `inFlight` briefly points at a settled promise.

## Verification

Baseline: `test:main` fully green on `origin/main` @ 255d23878.

- `pnpm --filter @memry/desktop test:main` — 528 passed / 3 skipped files; **6769 passed**, 1 expected fail
- `pnpm typecheck` — 17/17 · `pnpm lint` — 0 errors, 91 warnings (down from 92; zero in either owned file)
- `git diff --check` — clean · `docs:impact --strict` — covered · `docs:build` — complete

## Note for review

Expect a trivial textual conflict with #1489 (PR #1510) in the `drainPendingCrdtNotes` doc comment — both add a paragraph to the same block. Comment-only on both sides; no logic overlap.
