### PR TITLE
fix(crdt): the store follows the vault uuid a linked device adopts

### DIFF
--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -122,6 +122,25 @@ export interface CrdtStoreData {
    * key at all, which reads as "nothing pending" — the correct starting state.
    */
   legacyStorePartitionPendingFor?: string
+  /**
+   * Store directories left behind by a vault uuid that changed, as
+   * `adopted uuid -> uuid the directory is still named after`.
+   *
+   * A store is named after its vault's uuid, and that uuid is resolved once —
+   * when the provider opens the store. Device linking rewrites it afterwards
+   * (`adoptVaultLocally`), so from the *next* open onwards the vault looks for a
+   * directory that does not exist and its whole merge history is orphaned under
+   * the old name. This is what the next open reads to find it.
+   *
+   * A map rather than a single record because the rename is per vault and an
+   * install has many; entries are removed as they settle, so it holds one key
+   * per vault that linked and has not been opened since.
+   *
+   * Optional for the same reason as the two above: older stores have no
+   * `crdtStore` key at all, which reads as "nothing pending" — correct for
+   * every install that has not linked under a build that records this.
+   */
+  pendingRenames?: Record<string, string>
 }
 
 /**
@@ -447,6 +466,70 @@ export function clearLegacyCrdtStorePartitionPending(): void {
   if (current.legacyStorePartitionPendingFor === undefined) return
   const { legacyStorePartitionPendingFor: _cleared, ...rest } = current
   store.set('crdtStore', rest)
+}
+
+/**
+ * Which directory, if any, still holds `vaultUuid`'s CRDT store under the name
+ * it had before this vault adopted that uuid.
+ */
+export function getPendingCrdtStoreRename(vaultUuid: string): string | undefined {
+  return store.get('crdtStore').pendingRenames?.[vaultUuid]
+}
+
+/**
+ * Record that the store named after `from` now belongs to the vault identified
+ * as `to`.
+ *
+ * Written BEFORE the uuid itself is rewritten, for the same reason the legacy
+ * claim is written before its move: the failure that matters is a crash between
+ * the two. Recorded-but-not-rewritten leaves an entry for a uuid no vault has,
+ * which is inert and is re-recorded identically when the link is retried;
+ * rewritten-but-not-recorded is the orphan this exists to prevent.
+ *
+ * A uuid that changes twice before the store is next opened (link, unlink,
+ * relink) must still name the directory that was actually written, so a chain
+ * collapses onto its origin rather than pointing at a middle name no directory
+ * ever had. Adopting back to where the store already sits cancels the rename
+ * outright.
+ *
+ * The legacy claim and the partition it owes name a vault by uuid too, and that
+ * uuid is exactly what is changing — so they move with it, in the same write.
+ * Left behind they would name nobody: the legacy store could never be inherited
+ * and its ambiguous documents could never be set aside.
+ */
+export function recordCrdtStoreRename(from: string, to: string): void {
+  const current = store.get('crdtStore')
+  const pending = { ...(current.pendingRenames ?? {}) }
+
+  const origin = pending[from] ?? from
+  delete pending[from]
+  if (origin === to) {
+    delete pending[to]
+  } else {
+    pending[to] = origin
+  }
+
+  store.set('crdtStore', {
+    ...current,
+    pendingRenames: pending,
+    ...(current.legacyStoreClaimedBy === from ? { legacyStoreClaimedBy: to } : {}),
+    ...(current.legacyStorePartitionPendingFor === from
+      ? { legacyStorePartitionPendingFor: to }
+      : {})
+  })
+}
+
+/**
+ * Record that `vaultUuid`'s store now sits under its own name.
+ *
+ * Cleared only once the directory is where it belongs (or provably never
+ * existed), so an interrupted move is simply retried on the next open.
+ */
+export function clearPendingCrdtStoreRename(vaultUuid: string): void {
+  const current = store.get('crdtStore')
+  if (current.pendingRenames?.[vaultUuid] === undefined) return
+  const { [vaultUuid]: _settled, ...rest } = current.pendingRenames
+  store.set('crdtStore', { ...current, pendingRenames: rest })
 }
 
 /**

--- a/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
+++ b/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
@@ -47,7 +47,9 @@ vi.mock('../store', () => ({
   recordLegacyCrdtStoreClaim: vi.fn(),
   getVaults: () => [],
   getLegacyCrdtStorePartitionPending: () => undefined,
-  clearLegacyCrdtStorePartitionPending: vi.fn()
+  clearLegacyCrdtStorePartitionPending: vi.fn(),
+  getPendingCrdtStoreRename: () => undefined,
+  clearPendingCrdtStoreRename: vi.fn()
 }))
 
 vi.mock('../vault/notes', () => ({ toAbsolutePath: vi.fn() }))

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -162,7 +162,9 @@ vi.mock('../store', () => ({
   },
   getVaults: () => [],
   getLegacyCrdtStorePartitionPending: () => undefined,
-  clearLegacyCrdtStorePartitionPending: vi.fn()
+  clearLegacyCrdtStorePartitionPending: vi.fn(),
+  getPendingCrdtStoreRename: () => undefined,
+  clearPendingCrdtStoreRename: vi.fn()
 }))
 
 vi.mock('@main/database/queries/notes', () => ({

--- a/apps/desktop/src/main/sync/crdt-store-path.test.ts
+++ b/apps/desktop/src/main/sync/crdt-store-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { existsSync, mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import path from 'path'
 import * as Y from 'yjs'
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   vaultCount: 1,
   claim: undefined as string | undefined,
   partitionPending: undefined as string | undefined,
+  pendingRenames: {} as Record<string, string>,
   openStore: null as ((storagePath: string) => Promise<unknown>) | null
 }))
 
@@ -42,6 +43,10 @@ vi.mock('../store', () => ({
   getLegacyCrdtStorePartitionPending: () => mocks.partitionPending,
   clearLegacyCrdtStorePartitionPending: () => {
     mocks.partitionPending = undefined
+  },
+  getPendingCrdtStoreRename: (vaultUuid: string) => mocks.pendingRenames[vaultUuid],
+  clearPendingCrdtStoreRename: (vaultUuid: string) => {
+    delete mocks.pendingRenames[vaultUuid]
   }
 }))
 
@@ -57,6 +62,33 @@ vi.mock('./crdt-persistence', () => ({
 
 import { prepareVaultCrdtStore, resolveVaultCrdtStore } from './crdt-store-path'
 import { UNATTRIBUTABLE_DOC_PREFIX } from './crdt-legacy-partition'
+
+async function withStore<T>(dir: string, fn: (store: LeveldbPersistence) => Promise<T>) {
+  const store = new LeveldbPersistence(dir)
+  try {
+    return await fn(store)
+  } finally {
+    await store.destroy()
+  }
+}
+
+async function writeDoc(dir: string, docName: string, text: string): Promise<void> {
+  await withStore(dir, async (store) => {
+    const doc = new Y.Doc()
+    doc.getText('body').insert(0, text)
+    await store.storeUpdate(docName, Y.encodeStateAsUpdate(doc))
+    doc.destroy()
+  })
+}
+
+async function readDoc(dir: string, docName: string): Promise<string> {
+  return await withStore(dir, async (store) => {
+    const doc = await store.getYDoc(docName)
+    const text = doc.getText('body').toString()
+    doc.destroy()
+    return text
+  })
+}
 
 describe('vault CRDT store path', () => {
   beforeEach(() => {
@@ -110,33 +142,6 @@ describe('inheriting the legacy global CRDT store', () => {
   const vaultStorePath = (vaultUuid = VAULT_A): string =>
     path.join(userData, 'crdt-stores', vaultUuid)
 
-  async function withStore<T>(dir: string, fn: (store: LeveldbPersistence) => Promise<T>) {
-    const store = new LeveldbPersistence(dir)
-    try {
-      return await fn(store)
-    } finally {
-      await store.destroy()
-    }
-  }
-
-  async function writeDoc(dir: string, docName: string, text: string): Promise<void> {
-    await withStore(dir, async (store) => {
-      const doc = new Y.Doc()
-      doc.getText('body').insert(0, text)
-      await store.storeUpdate(docName, Y.encodeStateAsUpdate(doc))
-      doc.destroy()
-    })
-  }
-
-  async function readDoc(dir: string, docName: string): Promise<string> {
-    return await withStore(dir, async (store) => {
-      const doc = await store.getYDoc(docName)
-      const text = doc.getText('body').toString()
-      doc.destroy()
-      return text
-    })
-  }
-
   beforeEach(async () => {
     userData = mkdtempSync(path.join(tmpdir(), 'memry-crdt-store-path-'))
     mocks.userDataDir = userData
@@ -145,6 +150,7 @@ describe('inheriting the legacy global CRDT store', () => {
     mocks.vaultCount = 1
     mocks.claim = undefined
     mocks.partitionPending = undefined
+    mocks.pendingRenames = {}
     mocks.openStore = null
 
     // One store, keyed by note id, written by every vault on this install: the
@@ -230,5 +236,104 @@ describe('inheriting the legacy global CRDT store', () => {
     expect(await readDoc(vaultStorePath(), JOURNAL_ID)).toBe('this vault’s own journal')
     // And the legacy store is still whole, waiting for the vault that claimed it.
     expect(await readDoc(legacyPath(), JOURNAL_ID)).toBe('the other vault’s journal')
+  })
+})
+
+describe('a CRDT store whose vault adopted another uuid', () => {
+  // The joiner's own uuid, minted locally, and the account vault's, adopted from
+  // the server when the device linked.
+  const OWN_UUID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
+  const ADOPTED_UUID = '8945f5fd-0e05-45f5-bae5-2979737aa0d0'
+  const NOTE_ID = 'abcdefabcdef'
+
+  let userData: string
+
+  const storePath = (vaultUuid: string): string => path.join(userData, 'crdt-stores', vaultUuid)
+
+  beforeEach(() => {
+    userData = mkdtempSync(path.join(tmpdir(), 'memry-crdt-store-rename-'))
+    mocks.userDataDir = userData
+    mocks.dataDb = {}
+    // Restart state: the vault answers with the uuid it adopted, and the store
+    // it actually wrote is still named after the one it had before.
+    mocks.vaultUuid = ADOPTED_UUID
+    mocks.vaultCount = 1
+    mocks.claim = undefined
+    mocks.partitionPending = undefined
+    mocks.pendingRenames = { [ADOPTED_UUID]: OWN_UUID }
+    mocks.openStore = null
+  })
+
+  afterEach(() => {
+    rmSync(userData, { recursive: true, force: true })
+  })
+
+  it('opens the history the device wrote before it linked', async () => {
+    // The reported scenario end to end: a device with local CRDT history joins
+    // an existing vault, restarts, and must still merge with its own history
+    // rather than re-seed every note from markdown as a fresh insertion.
+    await writeDoc(storePath(OWN_UUID), NOTE_ID, 'written before linking')
+
+    const target = await prepareVaultCrdtStore()
+
+    expect(target?.storagePath).toBe(storePath(ADOPTED_UUID))
+    expect(await readDoc(storePath(ADOPTED_UUID), NOTE_ID)).toBe('written before linking')
+    expect(existsSync(storePath(OWN_UUID))).toBe(false)
+    expect(mocks.pendingRenames).toEqual({})
+  })
+
+  it('does not move the pre-adoption store on top of one the adopted uuid has', async () => {
+    // Reachable when two local vaults end up claiming one uuid, or when a
+    // previous move fell back to copy+delete and only the delete failed. The
+    // destination is somebody's history either way, so neither side is deleted
+    // and the record stays pending for a hand recovery.
+    await writeDoc(storePath(OWN_UUID), NOTE_ID, 'written before linking')
+    await writeDoc(storePath(ADOPTED_UUID), NOTE_ID, 'already under the adopted name')
+
+    await prepareVaultCrdtStore()
+
+    expect(await readDoc(storePath(ADOPTED_UUID), NOTE_ID)).toBe('already under the adopted name')
+    expect(await readDoc(storePath(OWN_UUID), NOTE_ID)).toBe('written before linking')
+    expect(mocks.pendingRenames).toEqual({ [ADOPTED_UUID]: OWN_UUID })
+  })
+
+  it('settles a vault that adopted a uuid before it ever opened a store', async () => {
+    // What `createDormantVault` produces: a vault provisioned for linking has no
+    // history to follow it. Nothing to move, and nothing to keep retrying.
+    await prepareVaultCrdtStore()
+
+    expect(existsSync(storePath(OWN_UUID))).toBe(false)
+    expect(mocks.pendingRenames).toEqual({})
+  })
+
+  it('leaves the store of a vault that adopted nothing where it is', async () => {
+    // The pass is reached on every vault open, so the record it reads is the
+    // only thing keeping it off stores it was never asked about.
+    mocks.pendingRenames = {}
+    await writeDoc(storePath(ADOPTED_UUID), NOTE_ID, 'this vault’s own history')
+    await writeDoc(storePath(OWN_UUID), NOTE_ID, 'another vault’s history')
+
+    await prepareVaultCrdtStore()
+
+    expect(await readDoc(storePath(ADOPTED_UUID), NOTE_ID)).toBe('this vault’s own history')
+    expect(await readDoc(storePath(OWN_UUID), NOTE_ID)).toBe('another vault’s history')
+  })
+
+  it('claims its own history ahead of the legacy store when both want the name', async () => {
+    // Only reachable when a legacy move already failed once and left the claim
+    // standing. Both migrations move a directory into this vault's name and only
+    // one can: the pre-adoption store is history this vault provably wrote, the
+    // legacy store is history it can only claim.
+    await writeDoc(storePath(OWN_UUID), NOTE_ID, 'written before linking')
+    await writeDoc(path.join(userData, 'crdt-store'), NOTE_ID, 'the legacy global store')
+    mocks.claim = ADOPTED_UUID
+
+    await prepareVaultCrdtStore()
+
+    expect(await readDoc(storePath(ADOPTED_UUID), NOTE_ID)).toBe('written before linking')
+    // And the legacy store is not deleted on the way past — it is still on disk.
+    expect(await readDoc(path.join(userData, 'crdt-store'), NOTE_ID)).toBe(
+      'the legacy global store'
+    )
   })
 })

--- a/apps/desktop/src/main/sync/crdt-store-path.ts
+++ b/apps/desktop/src/main/sync/crdt-store-path.ts
@@ -7,8 +7,10 @@ import { moveStoreDir } from './crdt-store-move'
 import { setAsideAmbiguousLegacyDocs } from './crdt-legacy-partition'
 import {
   clearLegacyCrdtStorePartitionPending,
+  clearPendingCrdtStoreRename,
   getLegacyCrdtStoreClaim,
   getLegacyCrdtStorePartitionPending,
+  getPendingCrdtStoreRename,
   getVaults,
   recordLegacyCrdtStoreClaim
 } from '../store'
@@ -51,6 +53,11 @@ function storeDirName(vaultUuid: string): string {
   return createHash('sha256').update(vaultUuid).digest('hex').slice(0, 32)
 }
 
+/** Where the store for `vaultUuid` lives, whether or not any vault holds it now. */
+function vaultCrdtStorePath(vaultUuid: string): string {
+  return path.join(app.getPath('userData'), STORE_ROOT_DIRNAME, storeDirName(vaultUuid))
+}
+
 /**
  * Where the currently open vault's CRDT store lives, or null when there is no
  * vault to scope it to.
@@ -65,10 +72,7 @@ export function resolveVaultCrdtStore(): VaultCrdtStore | null {
   try {
     const vaultUuid = getOrCreateVaultUuid(getDatabase())
     if (!vaultUuid) return null
-    return {
-      vaultUuid,
-      storagePath: path.join(app.getPath('userData'), STORE_ROOT_DIRNAME, storeDirName(vaultUuid))
-    }
+    return { vaultUuid, storagePath: vaultCrdtStorePath(vaultUuid) }
   } catch (err) {
     log.error('Could not resolve the vault CRDT store path', { error: err })
     return null
@@ -191,6 +195,86 @@ export async function partitionInheritedLegacyStore({
 }
 
 /**
+ * Rename this vault's store to match a uuid it has adopted since the store was
+ * last opened.
+ *
+ * The uuid is resolved once, when the provider opens the store, and device
+ * linking rewrites it in place afterwards (`adoptVaultLocally`) — so nothing
+ * breaks for the rest of that session, and then the *next* open looks under the
+ * adopted name, finds nothing, and every note re-seeds from markdown as an
+ * independent insertion instead of merging with the history it already had.
+ * `resetVaultUuidCache()` exists in that same function for exactly this class of
+ * reason; the store directory is the same problem one layer out.
+ *
+ * Safe to do here and nowhere else: this runs immediately before the store is
+ * opened, and the provider that held the previous directory has always been
+ * destroyed by then — `closeVault` awaits `destroy()` (which closes LevelDB)
+ * before `resetCrdtProvider()`, and a still-initialized provider never re-enters
+ * `initPersistence`. Moving the directory underneath an open LevelDB lock, which
+ * is what doing it inside the linking flow would mean, is never attempted.
+ *
+ * Crash safety is the same shape as the legacy claim's. The record is written
+ * before the uuid it describes, and it — not the directory, which the failed
+ * launch may or may not have moved — is what drives this:
+ *
+ *  - crash after the record, before the uuid rewrite → the vault still has its
+ *    old uuid, so this never fires and the store opens where it always was;
+ *  - crash after the rewrite, before or during the move → the record still
+ *    names the old directory, so the next open finishes the move;
+ *  - crash after both → the record is cleared and there is nothing to redo.
+ *
+ * A half-move cannot lose data: `moveStoreDir` is a rename, and its copy
+ * fallback deletes the destination rather than leaving two halves.
+ */
+export async function settlePendingCrdtStoreRename({
+  vaultUuid,
+  storagePath
+}: VaultCrdtStore): Promise<void> {
+  const previousUuid = getPendingCrdtStoreRename(vaultUuid)
+  if (previousUuid === undefined) return
+
+  const previousPath = vaultCrdtStorePath(previousUuid)
+  if (!existsSync(previousPath)) {
+    // The vault adopted a uuid without ever having opened a store under its own
+    // — a vault provisioned for linking (`createDormantVault`) is the ordinary
+    // way to get here. There is nothing to move and never will be.
+    clearPendingCrdtStoreRename(vaultUuid)
+    return
+  }
+
+  if (existsSync(storagePath)) {
+    // Two local vaults have ended up claiming one uuid, or a previous move fell
+    // back to copy+delete and the delete failed. Either way the destination is
+    // somebody's history: moving on top of it would destroy that instead of the
+    // duplicate. Stay pending — deleting the leftover by hand is a recovery, and
+    // this then completes on the next open.
+    log.warn('Pre-adoption CRDT store left in place: the adopted uuid already has a store', {
+      vaultUuid,
+      previousPath,
+      storagePath
+    })
+    return
+  }
+
+  if (await moveStoreDir(previousPath, storagePath)) {
+    clearPendingCrdtStoreRename(vaultUuid)
+    log.info('CRDT store followed the vault uuid it adopted', {
+      vaultUuid,
+      previousUuid,
+      storagePath
+    })
+  } else {
+    // The record stands, so the next open retries rather than opening an empty
+    // store next to a full one.
+    log.warn('Could not move the pre-adoption CRDT store; will retry on the next open', {
+      vaultUuid,
+      previousPath,
+      storagePath
+    })
+  }
+}
+
+/**
  * Resolve the open vault's store, create its parent directory, and settle the
  * legacy-store migration — everything that has to happen before the store is
  * opened. Null when no vault is open yet.
@@ -210,6 +294,13 @@ export async function prepareVaultCrdtStore(): Promise<VaultCrdtStore | null> {
     })
   }
 
+  // Before the legacy inherit, because both want to move a directory into this
+  // vault's name and only one can. The pre-adoption store is history this vault
+  // provably wrote itself; the legacy store is history it can only *claim*, and
+  // whose ownership is ambiguous enough that half of it may have to be set
+  // aside. When the two collide — only reachable when a legacy move already
+  // failed once — the unambiguous one wins and the legacy store stays put.
+  await settlePendingCrdtStoreRename(target)
   await inheritLegacyCrdtStore(target)
   await partitionInheritedLegacyStore(target)
   return target

--- a/apps/desktop/src/main/sync/vault-adoption.test.ts
+++ b/apps/desktop/src/main/sync/vault-adoption.test.ts
@@ -1,12 +1,44 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { existsSync, mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
 import Database from 'better-sqlite3'
 import { eq } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
+import * as Y from 'yjs'
+import { LeveldbPersistence } from 'y-leveldb'
 
 import * as schema from '@memry/db-schema/data-schema'
-import { getOrCreateVaultUuid } from '../agent/storage/vault-id'
 import { VAULT_KEY_VERIFIER_SETTING } from '../crypto/vault-key-state'
-import { adoptVaultLocally } from './vault-adoption'
+
+const mocks = vi.hoisted(() => ({
+  dataDb: null as object | null,
+  userData: '/userData'
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: (name: string) => (name === 'userData' ? mocks.userData : `/mock/${name}`) }
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+// The real module pulls the telemetry runtime, whose electron import ('net')
+// the mock above does not provide.
+vi.mock('../telemetry/diagnostics', () => ({ trackMainError: vi.fn() }))
+
+vi.mock('../database/client', () => ({
+  getDatabase: () => mocks.dataDb,
+  isDatabaseInitialized: () => mocks.dataDb !== null
+}))
+
+// The real one forks a preflight child through electron's utilityProcess, which
+// does not exist under vitest. The store it hands back is a real y-leveldb one,
+// so the assertions below run against real on-disk CRDT documents.
+vi.mock('./crdt-persistence', () => ({
+  openCrdtPersistence: (storagePath: string) => Promise.resolve(new LeveldbPersistence(storagePath))
+}))
 
 function createTestDataDb() {
   const sqlite = new Database(':memory:')
@@ -31,10 +63,60 @@ const INITIATOR_UUID = '8945f5fd-0e05-45f5-bae5-2979737aa0d0'
 
 describe('adoptVaultLocally', () => {
   let db: ReturnType<typeof createTestDataDb>
+  let userData: string
 
-  beforeEach(() => {
+  // Re-imported per test: `store.ts` caches the config file in a module-level
+  // variable, and every test gets its own userData directory.
+  let adoptVaultLocally: typeof import('./vault-adoption').adoptVaultLocally
+  let getOrCreateVaultUuid: typeof import('../agent/storage/vault-id').getOrCreateVaultUuid
+  let resetVaultUuidCache: typeof import('../agent/storage/vault-id').resetVaultUuidCache
+  let getPendingCrdtStoreRename: typeof import('../store').getPendingCrdtStoreRename
+  let recordLegacyCrdtStoreClaim: typeof import('../store').recordLegacyCrdtStoreClaim
+  let getLegacyCrdtStoreClaim: typeof import('../store').getLegacyCrdtStoreClaim
+  let getLegacyCrdtStorePartitionPending: typeof import('../store').getLegacyCrdtStorePartitionPending
+  let prepareVaultCrdtStore: typeof import('./crdt-store-path').prepareVaultCrdtStore
+
+  beforeEach(async () => {
+    vi.resetModules()
+    userData = mkdtempSync(path.join(tmpdir(), 'memry-vault-adoption-'))
+    mocks.userData = userData
     db = createTestDataDb()
+    mocks.dataDb = db
+
+    ;({ adoptVaultLocally } = await import('./vault-adoption'))
+    ;({ getOrCreateVaultUuid, resetVaultUuidCache } = await import('../agent/storage/vault-id'))
+    ;({
+      getPendingCrdtStoreRename,
+      recordLegacyCrdtStoreClaim,
+      getLegacyCrdtStoreClaim,
+      getLegacyCrdtStorePartitionPending
+    } = await import('../store'))
+    ;({ prepareVaultCrdtStore } = await import('./crdt-store-path'))
   })
+
+  afterEach(() => {
+    rmSync(userData, { recursive: true, force: true })
+  })
+
+  const storePath = (vaultUuid: string): string => path.join(userData, 'crdt-stores', vaultUuid)
+
+  async function writeDoc(dir: string, docName: string, text: string): Promise<void> {
+    const store = new LeveldbPersistence(dir)
+    const doc = new Y.Doc()
+    doc.getText('body').insert(0, text)
+    await store.storeUpdate(docName, Y.encodeStateAsUpdate(doc))
+    doc.destroy()
+    await store.destroy()
+  }
+
+  async function readDoc(dir: string, docName: string): Promise<string> {
+    const store = new LeveldbPersistence(dir)
+    const doc = await store.getYDoc(docName)
+    const text = doc.getText('body').toString()
+    doc.destroy()
+    await store.destroy()
+    return text
+  }
 
   it('binds the joiner to the initiator vault uuid instead of a fresh one', () => {
     // Joiner opened a fresh local vault first → its own random uuid + a stale
@@ -61,5 +143,106 @@ describe('adoptVaultLocally', () => {
       .where(eq(schema.settings.key, VAULT_KEY_VERIFIER_SETTING))
       .get()
     expect(verifier).toBeUndefined()
+  })
+
+  it('records where this vault’s CRDT store is, under the uuid it is moving to', () => {
+    const joinerOwnUuid = getOrCreateVaultUuid(db)
+
+    adoptVaultLocally(db, INITIATOR_UUID)
+
+    expect(getPendingCrdtStoreRename(INITIATOR_UUID)).toBe(joinerOwnUuid)
+  })
+
+  it('records nothing for a vault that has never had a uuid', () => {
+    // `createDormantVault` adopts into a data.db it has just created, before
+    // anything asks for its identity — there is no store to follow it, and
+    // minting a predecessor here would invent one.
+    adoptVaultLocally(db, INITIATOR_UUID)
+
+    expect(getPendingCrdtStoreRename(INITIATOR_UUID)).toBeUndefined()
+  })
+
+  it('records nothing when the vault already holds the adopted uuid', () => {
+    // The multi-vault linking flow adopts into the primary vault twice:
+    // `createDormantVault` first, then `finalizeLinking` once it is open.
+    adoptVaultLocally(db, INITIATOR_UUID)
+    resetVaultUuidCache()
+
+    adoptVaultLocally(db, INITIATOR_UUID)
+
+    expect(getPendingCrdtStoreRename(INITIATOR_UUID)).toBeUndefined()
+  })
+
+  it('records the store’s whereabouts before the uuid it depends on is rewritten', () => {
+    // Crash safety: recorded-but-not-rewritten is inert and re-recorded
+    // identically when the link is retried; rewritten-but-not-recorded is the
+    // orphan this exists to prevent. Standing in for the crash: a rewrite that
+    // throws, because the settings table this vault's db does not have.
+    const joinerOwnUuid = getOrCreateVaultUuid(db)
+    db.run('DROP TABLE settings')
+
+    expect(() => adoptVaultLocally(db, INITIATOR_UUID)).toThrow()
+
+    expect(getPendingCrdtStoreRename(INITIATOR_UUID)).toBe(joinerOwnUuid)
+  })
+
+  it('still points at the directory it wrote after adopting twice in a row', () => {
+    // Link, unlink, relink without the store being opened in between. The middle
+    // uuid never named a directory, so a record pointing at it would move
+    // nothing and the history would be orphaned exactly as before.
+    const joinerOwnUuid = getOrCreateVaultUuid(db)
+    const OTHER_ACCOUNT_UUID = 'c0ffee00-dead-4bee-8fed-0123456789ab'
+
+    adoptVaultLocally(db, INITIATOR_UUID)
+    resetVaultUuidCache()
+    adoptVaultLocally(db, OTHER_ACCOUNT_UUID)
+
+    expect(getPendingCrdtStoreRename(OTHER_ACCOUNT_UUID)).toBe(joinerOwnUuid)
+    expect(getPendingCrdtStoreRename(INITIATOR_UUID)).toBeUndefined()
+  })
+
+  it('cancels the rename when the vault adopts its way back to its own uuid', () => {
+    const joinerOwnUuid = getOrCreateVaultUuid(db)
+
+    adoptVaultLocally(db, INITIATOR_UUID)
+    resetVaultUuidCache()
+    adoptVaultLocally(db, joinerOwnUuid)
+
+    expect(getPendingCrdtStoreRename(joinerOwnUuid)).toBeUndefined()
+    expect(getPendingCrdtStoreRename(INITIATOR_UUID)).toBeUndefined()
+  })
+
+  it('carries the legacy-store claim and its unfinished partition to the new uuid', () => {
+    // Both name a vault by uuid, and that uuid is exactly what is changing. Left
+    // behind they would name nobody: the legacy store could never be inherited
+    // and its ambiguous documents could never be set aside.
+    const joinerOwnUuid = getOrCreateVaultUuid(db)
+    recordLegacyCrdtStoreClaim(joinerOwnUuid, { partitionPending: true })
+
+    adoptVaultLocally(db, INITIATOR_UUID)
+
+    expect(getLegacyCrdtStoreClaim()).toBe(INITIATOR_UUID)
+    expect(getLegacyCrdtStorePartitionPending()).toBe(INITIATOR_UUID)
+  })
+
+  it('still has the pre-link history after the device links and restarts', async () => {
+    // The reported scenario, end to end and on real disk: the joiner opens its
+    // own vault and writes CRDT history, links (which rewrites the uuid the
+    // store is named after), and the next launch must reach that history rather
+    // than open an empty store and re-seed every note from markdown.
+    const joinerOwnUuid = getOrCreateVaultUuid(db)
+    const beforeLinking = await prepareVaultCrdtStore()
+    expect(beforeLinking?.storagePath).toBe(storePath(joinerOwnUuid))
+    await writeDoc(beforeLinking!.storagePath, 'abcdefabcdef', 'written before linking')
+
+    adoptVaultLocally(db, INITIATOR_UUID)
+
+    // Restart: the store is closed and the path resolved again from scratch.
+    resetVaultUuidCache()
+    const afterRestart = await prepareVaultCrdtStore()
+
+    expect(afterRestart?.storagePath).toBe(storePath(INITIATOR_UUID))
+    expect(await readDoc(afterRestart!.storagePath, 'abcdefabcdef')).toBe('written before linking')
+    expect(existsSync(storePath(joinerOwnUuid))).toBe(false)
   })
 })

--- a/apps/desktop/src/main/sync/vault-adoption.ts
+++ b/apps/desktop/src/main/sync/vault-adoption.ts
@@ -1,11 +1,30 @@
-import { sql } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 
+import * as schema from '@memry/db-schema/data-schema'
 import type { DataDb } from '../database/types'
 import { VAULT_KEY_VERIFIER_SETTING } from '../crypto/vault-key-state'
 import { resetVaultUuidCache } from '../agent/storage/vault-id'
 import { createLogger } from '../lib/logger'
+import { recordCrdtStoreRename } from '../store'
 
 const logger = createLogger('Sync:VaultAdoption')
+
+/**
+ * The uuid currently in vault_metadata, or undefined when the vault has never
+ * had one.
+ *
+ * Deliberately not `getOrCreateVaultUuid`: a vault provisioned for linking
+ * (`createDormantVault`) adopts before anything has ever asked for its
+ * identity, and minting one here just to overwrite it a line later would invent
+ * a predecessor that no store was ever named after.
+ */
+function readVaultUuid(db: DataDb): string | undefined {
+  return db
+    .select()
+    .from(schema.vaultMetadata)
+    .where(eq(schema.vaultMetadata.id, 'singleton'))
+    .get()?.vaultUuid
+}
 
 /**
  * Adopt a shared vault identity on the local (joiner) device before device
@@ -16,6 +35,18 @@ const logger = createLogger('Sync:VaultAdoption')
  * to the initiator's vault and the first sync pulls that vault's items.
  */
 export function adoptVaultLocally(db: DataDb, vaultUuid: string): void {
+  // The vault's CRDT store is a directory named after this uuid, resolved once
+  // when the provider opened it — which, on the joiner, is long before the user
+  // scanned a QR code. So the rewrite below silently renames the vault out from
+  // under its own history: nothing breaks in-session (the directory is already
+  // open) and then the next open looks for a store that does not exist. Leave a
+  // note for it, BEFORE the rewrite, so a crash in between costs an inert entry
+  // rather than the history. See `settlePendingCrdtStoreRename`.
+  const previousUuid = readVaultUuid(db)
+  if (previousUuid !== undefined && previousUuid !== vaultUuid) {
+    recordCrdtStoreRename(previousUuid, vaultUuid)
+  }
+
   const now = Date.now()
   db.transaction((tx) => {
     tx.run(sql`DELETE FROM settings WHERE key = ${VAULT_KEY_VERIFIER_SETTING}`)

--- a/apps/desktop/src/main/sync/vault-provisioning.test.ts
+++ b/apps/desktop/src/main/sync/vault-provisioning.test.ts
@@ -4,8 +4,9 @@ import path from 'path'
 import Database from 'better-sqlite3'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockUpsertVault, mockCreateVaultInfo } = vi.hoisted(() => ({
+const { mockUpsertVault, mockCreateVaultInfo, mockRecordCrdtStoreRename } = vi.hoisted(() => ({
   mockUpsertVault: vi.fn(),
+  mockRecordCrdtStoreRename: vi.fn(),
   mockCreateVaultInfo: vi.fn((vaultPath: string) => ({
     path: vaultPath,
     name: path.basename(vaultPath),
@@ -17,7 +18,8 @@ const { mockUpsertVault, mockCreateVaultInfo } = vi.hoisted(() => ({
 }))
 
 vi.mock('../store', () => ({
-  upsertVault: mockUpsertVault
+  upsertVault: mockUpsertVault,
+  recordCrdtStoreRename: mockRecordCrdtStoreRename
 }))
 
 vi.mock('../vault', () => ({
@@ -59,5 +61,8 @@ describe('vault-provisioning', () => {
 
     // The vault was registered in the store.
     expect(mockUpsertVault).toHaveBeenCalledWith(expect.objectContaining({ path: dir }))
+    // And nothing is owed to the CRDT store: a vault provisioned here has no
+    // history under a previous uuid for the next open to go looking for.
+    expect(mockRecordCrdtStoreRename).not.toHaveBeenCalled()
   })
 })

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -140,6 +140,57 @@ store still goes through the full preflight, quarantine and probe — the
 partition pass opens it through `openCrdtPersistence` for exactly that reason,
 at the cost of one extra preflight child on the single launch that migrates.
 
+### When the vault's uuid changes
+
+A vault's uuid is stable for as long as it stays open, with one exception:
+**device linking**. A device joining an existing vault adopts the account's uuid
+(`adoptVaultLocally`), rewriting the `vault_metadata` singleton in place — and
+the store directory is named after the value that function replaces.
+
+Nothing breaks in the session where it happens; the directory is already open
+and stays open. The next open is the problem: it resolves the adopted uuid,
+finds no directory, and every note re-seeds from markdown as an independent
+insertion instead of merging with the history the device already had.
+
+So the adoption records where the store is (`crdtStore.pendingRenames`, adopted
+uuid → the name the directory still has), and `prepareVaultCrdtStore()` moves it
+before the store is opened. Doing it there rather than inside the linking flow
+is deliberate: at that point the previous provider has always been destroyed
+(`closeVault` awaits `destroy()`, which closes LevelDB, before
+`resetCrdtProvider()`), so the directory is never moved out from under an open
+LevelDB lock.
+
+The record is written **before** the uuid it describes, for the same reason the
+legacy claim is written before its move:
+
+- crash after the record, before the rewrite → the vault still has its old uuid,
+  so nothing fires and the store opens where it always was. The entry names a
+  uuid no vault holds and is inert; retrying the link records it again,
+  identically;
+- crash after the rewrite, before or during the move → the record still names
+  the old directory, so the next open finishes the move;
+- crash after both → the record is cleared and there is nothing to redo.
+
+Two edges are handled by leaving things alone rather than guessing. If the
+adopted uuid **already** has a store — two local vaults claiming one uuid, or a
+copy+delete whose delete failed — neither directory is touched and the record
+stays pending, because the destination is somebody's history too. And a uuid
+that changes twice before the store is next opened collapses onto the directory
+that was actually written, rather than pointing at a middle name no directory
+ever had.
+
+The rename settles **before** the legacy inherit above. Both want to move a
+directory into this vault's name and only one can: the pre-adoption store is
+history this vault provably wrote, while the legacy store is history it can only
+claim.
+
+A device that linked under a build without this has an orphaned directory under
+`<userData>/crdt-stores/<old uuid>`. Nothing recovers it automatically — the old
+uuid was never recorded, and guessing from the directory listing is how the
+wrong vault's history gets attached. No note content is at risk (markdown is the
+source of truth); what is lost is the merge history, so those notes behave like
+notes the account has never seen.
+
 ## Persistence Resilience
 
 Opening the store is a self-contained step that lives in `crdt-persistence.ts`,


### PR DESCRIPTION
Closes #1490. Part of EPIC #1499.

> **Stacked on #1491 (PR #1506).** Base branch is `fix/crdt-legacy-store-partition`, not `main`, because both rewrite `crdt-store-path.ts`. `git log --oneline origin/main..HEAD` shows exactly one commit beneath this one. **Merge #1506 first**, then retarget this to `main`.

The CRDT store is scoped per vault at `userData/crdt-stores/<vaultUuid>`, and the uuid is resolved **once**, at provider init. `adoptVaultLocally` rewrites that uuid in place when a device joins an existing vault. Nothing breaks in-session because the path was already resolved — but after the next restart the joining device's **pre-adoption** history sits under the old uuid's directory and is never read again. Those notes re-seed from markdown, losing their CRDT merge history.

## When the uuid changes relative to the open store

**The store is open.** `finalizeLinking` (`linking-service.ts:501`) calls `adoptVaultLocally` with `getDatabase()` — the *currently open* vault's data db — and `openVault` fires `initPersistence()` long before the user can reach any linking UI. So `crdt-stores/<localUuid>` has held a LevelDB lock for the whole session by the time the QR is scanned.

The session never re-resolves: `startSyncRuntime`, fired right after linking, calls `initPersistence()`, which returns immediately because `persistenceReady` is true. The orphan therefore only appears at the *next* open — exactly as the issue describes.

**`createDormantVault` needs nothing and is unchanged.** It adopts into a data.db it has just created, and `vault_metadata` has no seeding migration — the row is minted lazily by `getOrCreateVaultUuid`. A dormant vault has no predecessor uuid and no store.

## Design — record the whereabouts, settle it at the next open

No mid-session move and no provider surgery, so **`crdt-provider.ts` is untouched**.

- `adoptVaultLocally` reads the existing uuid via `readVaultUuid` — a plain select, deliberately **not** `getOrCreateVaultUuid`, which would mint a predecessor for a dormant vault — and, **before** the rewrite, records `crdtStore.pendingRenames[adopted] = previous`.
- `prepareVaultCrdtStore` calls the new `settlePendingCrdtStoreRename` **before** `inheritLegacyCrdtStore`, immediately before the store is opened.
- **No open LevelDB directory is ever moved.** By that point the previous provider is always destroyed: `stopSyncRuntime` does `await getCrdtProvider().destroy()` — which awaits `persistence.destroy()` — *before* `resetCrdtProvider()`, and `closeVault` awaits `stopSyncRuntime()` before `closeAllDatabases()`. Verified independently by the main session.
- The record also carries `legacyStoreClaimedBy` / `legacyStorePartitionPendingFor` to the new uuid **in the same write** — they name a vault by uuid, and that uuid is what changed. Left behind, #1491's partition would never run.
- Ordering rationale: both migrations want to move a directory into this vault's name. The pre-adoption store is history the vault provably wrote; the legacy store is only *claimed*. Only reachable when a legacy move already failed once.
- Chain collapse (`L→S` then `S→T` records `T→L`) and cancel-on-return (`L→S→L` clears).

## Crash safety

- **record, then crash** → the vault still has its old uuid, nothing fires, the store opens where it was. The entry names a uuid no vault holds: inert, and re-recorded identically on retry.
- **rewrite, then crash before/during the move** → the record still names the old directory and is what drives the move, so the next open finishes it.
- **both done** → record cleared, nothing to redo.
- **half-move is impossible** — `moveStoreDir` is a rename whose copy fallback deletes the destination on failure.

Editing is untouched: nothing closes the provider, nothing is gated on session state.

## Migration / compat — live beta, real data on disk

- Old configs have no `crdtStore.pendingRenames` key → reads as "nothing pending", the correct starting state. Same optional-key shape #1491 established.
- **A device that already linked under the broken behaviour is not recovered automatically, deliberately.** The old uuid was never recorded, and the vault registry's `vaultUuid` is re-stamped on every `selectVault`, so it holds the adopted value by the first restart. Inferring the predecessor from the `crdt-stores/` listing is *precisely* how the wrong vault's history gets attached — #1491's failure mode. The directory is still on disk at `<userData>/crdt-stores/<old uuid>`; no note content was ever at risk (markdown is the source of truth). What is unreachable is merge history, so those notes behave like notes the account has never seen.
- If the adopted uuid already has a store, **neither side is touched** and the record stays pending (retried every open, logged). Deleting the leftover by hand is a recovery path.

## Tests — 14 mutations

Real on-disk y-leveldb stores in tmpdirs, and in `vault-adoption.test.ts` the **real** `store.ts` writing a real `memry-config.json`. The end-to-end test `still has the pre-link history after the device links and restarts` drives the reported scenario.

| # | Mutation | Result |
|---|---|---|
| M1 | drop `settlePendingCrdtStoreRename` from `prepareVaultCrdtStore` | 4 fail |
| M2 | drop the `recordCrdtStoreRename` call | 5 fail |
| M3 | move the record *after* the transaction | 1 fail — exactly the ordering test |
| M4 | drop the destination-exists guard | 1 fail |
| M5 | don't clear when there is nothing to move | 1 fail |
| M6 | run legacy inherit before the rename | 1 fail |
| M7 | drop chain collapse | 2 fail |
| M8 | drop cancel-on-return | 1 fail |
| M9 | drop claim/partition carry-forward | 1 fail |
| M10 | mint a predecessor instead of reading | 3 fail |
| M11 | drop the `previousUuid !== vaultUuid` early-out | **passed both ways — see below** |
| M12 | never clear after a successful move | 1 fail |
| M13 | settle clears the record without moving ("reports success, did nothing") | 3 fail |
| M14 | settle acts on a vault with no record | 8 fail |

**M11, stated honestly rather than buried:** that guard is behaviourally redundant — `recordCrdtStoreRename(S, S)` already cancels itself. It survives only to avoid a pointless config write on the multi-vault path. **No test guards it, and none is claimed to.** The test covering that scenario is not worthless — it caught M10.

All source files were byte-compared against snapshots after the run.

**Independent re-verification by the main session:** I probed the seam between this PR and #1506 with a mutation neither ledger covers — carrying the legacy *claim* forward while dropping only the *partition-pending* carry. Confirmed applied via `git diff --stat`; caught by `carries the legacy-store claim and its unfinished partition to the new uuid`. Restored: 30/30 green. I also verified the base has exactly one commit beneath it, and the `destroy()` → `resetCrdtProvider()` ordering that makes the move safe.

## Verification

Baseline: `test:main` fully green on `origin/main` @ 255d23878.

- `pnpm --filter @memry/desktop test:main` — 529 passed / 3 skipped files; **6791 passed**, 1 expected fail. Zero failures.
- `pnpm typecheck` — 17/17 · `pnpm lint` — 0 errors, none in touched files
- `git diff --check` — clean · `docs:impact --base 6d9f638ac --strict` — covered · `docs:build` — complete

## Ownership notes for review

- `store.ts` is the only durable home for this (its own `CrdtStoreData` comment says so) and #1491 established the pattern.
- Two lines each were added to `crdt-provider.test.ts` and `crdt-ipc-handlers.test.ts` — their `vi.mock('../store', …)` factories need the new exports or the suite goes red with 78 failures. The `crdt-provider.ts` **source** is untouched. Expect a trivial two-line conflict with #1510 if it touches the same test file.

## Found, not fixed

1. **`inheritLegacyCrdtStore` and the rename can deadlock after a failed legacy move.** If a legacy move fails (Windows lock) and the vault then links, the rename wins the name and the legacy store stays claimed-but-unmovable, logging every launch. Narrow, strictly better than today, but it never self-clears.
2. **Orphan telemetry.** A `crdt-stores/<uuid>` directory matching no vault in the registry is a strong signal of a device orphaned by the pre-fix behaviour — a count would size the affected fleet without guessing at recovery.
3. **Two local vaults sharing one uuid** is broken well below this fix. The destination-exists branch fails safe, but the underlying state has no owner.
