### PR TITLE
fix(sidebar): give the Projects section a "+" so a second project is reachable

### DIFF
--- a/apps/desktop/src/renderer/src/components/app-sidebar.projects.test.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.projects.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { forwardRef, useEffect, useImperativeHandle, type ReactNode } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AppSidebar } from './app-sidebar'
 
@@ -53,18 +53,31 @@ vi.mock('@/components/sidebar-section', () => ({
   SidebarSection: ({
     label,
     actions,
+    actionsAlwaysVisible,
     children
   }: {
     label: string
     actions?: ReactNode
+    actionsAlwaysVisible?: boolean
     children: ReactNode
   }) => (
-    <section>
+    // `actionsAlwaysVisible` surfaces as an attribute because the real reveal is
+    // a Tailwind class the sidebar never sees; whether it is on screen is the
+    // section's own test (sidebar-section.focus-reveal.test.tsx). What belongs
+    // here is only that the sidebar asks for it in the empty case.
+    <section aria-label={label} data-actions-pinned={actionsAlwaysVisible ? 'true' : 'false'}>
       <h2>{label}</h2>
       {actions}
       {children}
     </section>
   )
+}))
+
+vi.mock('@/components/tasks/project-modal', () => ({
+  ProjectModal: ({ isOpen, project }: { isOpen: boolean; project?: { id: string } | null }) =>
+    isOpen ? (
+      <div data-testid="project-modal">{project ? `edit:${project.id}` : 'create'}</div>
+    ) : null
 }))
 
 vi.mock('@/components/notes-tree', () => ({
@@ -190,7 +203,46 @@ vi.mock('@/components/sidebar/sortable-project-list', () => ({
   )
 }))
 
+const DEFAULT_PROJECTS = [{ id: 'p1', name: 'Launch', color: '#f00', isArchived: false }]
+
 describe('AppSidebar projects section', () => {
+  beforeEach(() => {
+    mocks.projects = DEFAULT_PROJECTS.map((project) => ({ ...project }))
+    mocks.openSidebarItem.mockClear()
+  })
+
+  // The section header "+" is the only project entry point that does not go
+  // through the Tasks page: the empty-state CTA disappears after the first
+  // project, and nothing else in the sidebar creates one.
+  it('opens the project modal in create mode from the section header', () => {
+    render(<AppSidebar currentPage="inbox" viewCounts={{}} />)
+
+    expect(screen.queryByTestId('project-modal')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('newProject'))
+
+    expect(screen.getByTestId('project-modal')).toHaveTextContent('create')
+  })
+
+  it('pins the header actions open while there are no projects', () => {
+    mocks.projects = []
+    render(<AppSidebar currentPage="inbox" viewCounts={{}} />)
+
+    expect(screen.getByRole('region', { name: 'projects' })).toHaveAttribute(
+      'data-actions-pinned',
+      'true'
+    )
+  })
+
+  it('lets the header actions fall back to hover once a project exists', () => {
+    render(<AppSidebar currentPage="inbox" viewCounts={{}} />)
+
+    expect(screen.getByRole('region', { name: 'projects' })).toHaveAttribute(
+      'data-actions-pinned',
+      'false'
+    )
+  })
+
   it('renders active projects and opens Project Home on click', () => {
     render(<AppSidebar currentPage="inbox" viewCounts={{}} />)
 

--- a/apps/desktop/src/renderer/src/components/app-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.tsx
@@ -564,6 +564,28 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
           id="projects"
           label={tPhaseF('phaseF.componentsAppSidebar.projects')}
           defaultExpanded={false}
+          totalCount={activeProjects.length}
+          // With no projects the section body is an empty-state CTA nobody sees
+          // while the section is collapsed — which it is by default. Pinning the
+          // "+" open is then the only entry point on screen.
+          actionsAlwaysVisible={activeProjects.length === 0}
+          actions={
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleCreateProject}
+                  className="p-0.5 rounded cursor-pointer hover:bg-sidebar-accent transition-colors"
+                  aria-label={tPhaseF('phaseF.componentsAppSidebar.newProject')}
+                >
+                  <Plus className="size-3.5 text-sidebar-muted hover:text-sidebar-foreground" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">
+                {tPhaseF('phaseF.componentsAppSidebar.newProject')}
+              </TooltipContent>
+            </Tooltip>
+          }
         >
           <SortableProjectList
             projects={activeProjects}

--- a/apps/desktop/src/renderer/src/components/sidebar-section.focus-reveal.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar-section.focus-reveal.test.tsx
@@ -36,6 +36,36 @@ beforeEach(() => {
   localStorage.clear()
 })
 
+describe('sidebar section pinned actions', () => {
+  // An empty section has nothing in its body to click, and every section starts
+  // collapsed, so hover-only actions leave a section with no entry point at all.
+  it('keeps the actions on screen without hover or focus when pinned', () => {
+    render(
+      <SidebarProvider>
+        <SidebarSection
+          id="pinned"
+          label="Projects"
+          actionsAlwaysVisible
+          actions={<button type="button">New project</button>}
+        >
+          <div>child</div>
+        </SidebarSection>
+      </SidebarProvider>
+    )
+
+    const actions = screen.getByRole('button', { name: 'New project' }).parentElement
+    expect(actions).not.toBeNull()
+    expect(isRevealed(actions!)).toBe(true)
+  })
+
+  it('falls back to the hover reveal when not pinned', () => {
+    renderSection()
+
+    const actions = screen.getByRole('button', { name: 'New canvas' }).parentElement
+    expect(isRevealed(actions!)).toBe(false)
+  })
+})
+
 describe('sidebar section focus reveal', () => {
   it('keeps the actions hidden while nothing in the section has focus', () => {
     renderSection()

--- a/apps/desktop/src/renderer/src/components/sidebar-section.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar-section.tsx
@@ -14,6 +14,12 @@ interface SidebarSectionProps {
   children: React.ReactNode
   className?: string
   actions?: React.ReactNode
+  /**
+   * Pins the actions open instead of revealing them on hover. Only for the case
+   * where the section body has nothing in it to point at: an empty section whose
+   * one way in is a hover-only control is a section with no way in at all.
+   */
+  actionsAlwaysVisible?: boolean
 }
 
 function SectionChevron({ expanded }: { expanded: boolean }): React.JSX.Element {
@@ -40,7 +46,8 @@ export const SidebarSection = ({
   totalCount,
   children,
   className,
-  actions
+  actions,
+  actionsAlwaysVisible = false
 }: SidebarSectionProps): React.JSX.Element => {
   const { state } = useSidebar()
   const isCollapsed = state === 'collapsed'
@@ -158,7 +165,11 @@ export const SidebarSection = ({
               // Every action in here is in the tab order, so hover cannot be
               // the only thing that reveals them — a keyboard user would land
               // on a control painted at `opacity-0` (WCAG 2.4.7).
-              className="flex shrink-0 items-center gap-0.5 pe-2 opacity-0 group-hover/section:opacity-100 group-focus-within/section:opacity-100 transition-opacity duration-150"
+              className={cn(
+                'flex shrink-0 items-center gap-0.5 pe-2 transition-opacity duration-150',
+                !actionsAlwaysVisible &&
+                  'opacity-0 group-hover/section:opacity-100 group-focus-within/section:opacity-100'
+              )}
               onClick={(e) => e.stopPropagation()}
             >
               {actions}

--- a/apps/docs/src/user-guide/projects.md
+++ b/apps/docs/src/user-guide/projects.md
@@ -10,7 +10,7 @@ Projects appear in the sidebar with incomplete-task counts. Drag to reorder. Use
 
 ## Creating a Project
 
-The **+** affordance in the sidebar Projects section opens a creation dialog:
+The **+** affordance sits in the sidebar **PROJECTS** section header. It appears when you hover the header — except while you have no projects yet, when it stays visible so the section is never a dead end. It opens a creation dialog:
 
 - **Name** — display title
 - **Color** — accent for the sidebar entry and project header

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -356,6 +356,7 @@
       "newNote2": "New note",
       "newFolder": "New folder",
       "newFolder2": "New folder",
+      "newProject": "New project",
       "bookmarks": "Bookmarks",
       "tags": "Tags",
       "dropFilesToImport": "Drop files to import",


### PR DESCRIPTION
Reported by Paul Norris (12 Aug, v2026-08-11): after the first project there is no way to create another one from the sidebar.

## What was actually true

The Projects section was the only collection section without header actions. Project creation from the sidebar ran entirely through `ProjectsEmptyState`, which renders only while there are zero projects — and only while the section is expanded, which it is not by default. So the first project made the CTA disappear and left the sidebar with no entry point.

Two corrections to the report worth recording:

- **Creating a project was still possible**, just never from the sidebar: the Tasks page scope dropdown and every task's project pill both render `ProjectPicker`, whose footer opens the same dialog (`project-picker.tsx:240`).
- **The collapsed-by-default behaviour is not Projects-specific** — all five sections pass `defaultExpanded={false}`. Not touched here; changing it would also be a no-op for anyone whose `sidebar-section-projects-expanded` key is already set.

`apps/docs/src/user-guide/projects.md` has described this **+** for a while. The docs were right; the code had not caught up.

## The change

The wiring already existed — `handleCreateProject` (`app-sidebar.tsx:420`) and a mounted `ProjectModal` (`:804`) landed with the edit gear. Only the button was missing.

Hover parity alone would not have fixed the case that matters. With no projects the section body is an empty state nobody sees while the section is collapsed, so a `+` at `opacity-0` leaves nothing on screen. `SidebarSection` takes an additive `actionsAlwaysVisible` prop (default off — the other four sections are untouched), and the sidebar pins the actions open only while the project list is empty. Once there is a project the hover reveal takes over and parity with Collections and Canvases returns.

Also passes `totalCount={activeProjects.length}` so the collapsed header carries a count like Canvases does.

## Out of scope

`onProjectArchive`, `onProjectDelete` and `onProjectsReorder` are still `noopProjectAction` (`app-sidebar.tsx:466-471`) — a `SortableProjectList` inside a live `SortableContext` whose reorder persists nothing, and docs that promise both drag-to-reorder and a right-click context menu. Tracked in #1517 rather than widened into this PR.

## Verification

- `vitest --project renderer app-sidebar.projects.test.tsx sidebar-section.focus-reveal.test.tsx` — 10 passed
- `typecheck:web`, `typecheck:test` — clean
- `i18n:check` — ok (new `phaseF.componentsAppSidebar.newProject` key, English only; other locales fall back)
- `docs:impact --strict` — covered · `docs:build` — clean

New tests: the `+` opens the modal in create mode; the actions are pinned open at zero projects and fall back to hover once a project exists (the negative case is what makes the assertion mean anything); and `sidebar-section.focus-reveal.test.tsx` checks the pinned row is genuinely on screen with no pointer and no focus, via the existing `isRevealed` helper.

Manual check still owed: run the app with an empty project list and confirm the pinned **+** reads right against the paper sidebar.