### PR TITLE
Reminder picker: pin the confirm button so the custom date & time panel can't clip it

### DIFF
--- a/apps/desktop/src/renderer/src/components/reminder/reminder-picker.test.tsx
+++ b/apps/desktop/src/renderer/src/components/reminder/reminder-picker.test.tsx
@@ -59,6 +59,11 @@ vi.mock('@/components/ui/picker', () => {
       ),
       Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
       List: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Footer: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+        <div data-slot="picker-footer" className={className}>
+          {children}
+        </div>
+      ),
       Section: ({ label, children }: { label: string; children: React.ReactNode }) => (
         <section aria-label={label}>
           <h3>{label}</h3>
@@ -139,7 +144,9 @@ describe('ReminderPicker', () => {
       })
     )
 
-    expect(screen.getByRole('button', { name: /Set Reminder/ })).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: /phaseF.componentsReminderReminderPicker.setReminder/ })
+    ).toBeDisabled()
 
     await user.click(screen.getByRole('button', { name: 'Select May 12' }))
     fireEvent.change(screen.getByLabelText(/phaseF.componentsReminderReminderPicker.time/), {
@@ -154,13 +161,49 @@ describe('ReminderPicker', () => {
 
     expect(screen.getByText('Tuesday at 15:45')).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: /Set Reminder/ }))
+    await user.click(
+      screen.getByRole('button', { name: /phaseF.componentsReminderReminderPicker.setReminder/ })
+    )
 
     expect(onSelect).toHaveBeenCalledWith(
       new Date(2026, 4, 12, 15, 45, 0, 0),
       undefined,
       'custom note'
     )
+  })
+
+  it('pins the confirm button in the footer and scrolls the body above it', async () => {
+    // The custom panel is taller than the room Radix leaves under a trigger low
+    // in the window, and `Picker.Content` clips its overflow. Anything below the
+    // fold in an unscrollable body is unreachable, so the confirm action has to
+    // sit outside the part that shrinks.
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    renderWithProviders(<ReminderPicker onSelect={vi.fn()} showNoteField />)
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /phaseF.componentsReminderReminderPicker.pickDateTime/
+      })
+    )
+    await user.click(screen.getByRole('button', { name: 'Select May 12' }))
+
+    const footer = document.querySelector('[data-slot="picker-footer"]')
+    const confirm = screen.getByRole('button', {
+      name: /phaseF.componentsReminderReminderPicker.setReminder/
+    })
+    const body = document.querySelector('.overflow-y-auto')
+
+    expect(footer).not.toBeNull()
+    expect(body).not.toBeNull()
+    expect(footer?.contains(confirm)).toBe(true)
+    // The preview travels with the button: confirming without seeing what you
+    // are confirming is its own bug.
+    expect(footer?.contains(screen.getByText('Tuesday at 09:00'))).toBe(true)
+    expect(body?.contains(confirm)).toBe(false)
+    expect(
+      body?.contains(screen.getByLabelText(/phaseF.componentsReminderReminderPicker.time/))
+    ).toBe(true)
   })
 
   const MANAGED = [
@@ -258,7 +301,9 @@ describe('ReminderPicker', () => {
     )
     await user.click(screen.getByRole('button', { name: 'Select May 12' }))
 
-    expect(screen.getByRole('button', { name: 'Setting...' })).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: 'phaseF.componentsReminderReminderPicker.setting' })
+    ).toBeDisabled()
 
     await user.click(
       screen.getByRole('button', {

--- a/apps/desktop/src/renderer/src/components/reminder/reminder-picker.tsx
+++ b/apps/desktop/src/renderer/src/components/reminder/reminder-picker.tsx
@@ -171,7 +171,7 @@ export function ReminderPicker({
         )}
       </Picker.Trigger>
 
-      <Picker.Content className="w-80" align="start">
+      <Picker.Content className="w-80" align="start" collisionPadding={8}>
         {mode === 'presets' ? (
           <>
             <Picker.List>
@@ -268,70 +268,68 @@ export function ReminderPicker({
             )}
           </>
         ) : (
-          <div className="p-2">
-            <button
-              type="button"
-              onClick={() => (mode === 'edit' ? resetState() : setMode('presets'))}
-              className="mb-2 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-            >
-              <ChevronRight className="h-3 w-3 rotate-180" />
+          // The confirm button lives in a pinned footer so the height cap on
+          // `Picker.Content` can only ever eat into the scrolling body above it.
+          <>
+            <div className="min-h-0 overflow-y-auto p-2">
+              <button
+                type="button"
+                onClick={() => (mode === 'edit' ? resetState() : setMode('presets'))}
+                className="mb-2 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              >
+                <ChevronRight className="h-3 w-3 rotate-180" />
 
-              {mode === 'edit'
-                ? tPhaseF('phaseF.componentsReminderReminderPicker.editReminder')
-                : tPhaseF('phaseF.componentsReminderReminderPicker.backToPresets')}
-            </button>
+                {mode === 'edit'
+                  ? tPhaseF('phaseF.componentsReminderReminderPicker.editReminder')
+                  : tPhaseF('phaseF.componentsReminderReminderPicker.backToPresets')}
+              </button>
 
-            <DatePickerCalendar
-              selected={selectedDate}
-              onSelect={(d) => setSelectedDate(d)}
-              disabled={(date) => date < new Date(new Date().setHours(0, 0, 0, 0))}
-              className="rounded-md border p-2"
-            />
+              <DatePickerCalendar
+                selected={selectedDate}
+                onSelect={(d) => setSelectedDate(d)}
+                disabled={(date) => date < new Date(new Date().setHours(0, 0, 0, 0))}
+                className="rounded-md border p-2"
+              />
 
-            <div className="mt-3 space-y-3 px-1">
-              <div className="flex items-center gap-2">
-                <Label htmlFor="reminder-time" className="flex items-center gap-1.5 text-sm">
-                  <Clock className="h-4 w-4" />
+              <div className="mt-3 space-y-3 px-1">
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="reminder-time" className="flex items-center gap-1.5 text-sm">
+                    <Clock className="h-4 w-4" />
 
-                  {tPhaseF('phaseF.componentsReminderReminderPicker.time')}
-                </Label>
-                <Input
-                  id="reminder-time"
-                  type="time"
-                  value={selectedTime}
-                  onChange={(e) => setSelectedTime(e.target.value)}
-                  className="h-8 w-28"
-                />
-              </div>
-
-              {shouldShowNote && (
-                <div>
-                  <Label htmlFor="reminder-note" className="text-sm">
-                    {tPhaseF('phaseF.componentsReminderReminderPicker.noteOptional')}
+                    {tPhaseF('phaseF.componentsReminderReminderPicker.time')}
                   </Label>
-                  <Textarea
-                    id="reminder-note"
-                    placeholder={tPhaseF(
-                      'phaseF.componentsReminderReminderPicker.whyAreYouSettingThisReminder'
-                    )}
-                    value={note}
-                    onChange={(e) => setNote(e.target.value)}
-                    className="mt-1.5 h-16 resize-none text-sm"
+                  <Input
+                    id="reminder-time"
+                    type="time"
+                    value={selectedTime}
+                    onChange={(e) => setSelectedTime(e.target.value)}
+                    className="h-8 w-28"
                   />
                 </div>
-              )}
 
+                {shouldShowNote && (
+                  <div>
+                    <Label htmlFor="reminder-note" className="text-sm">
+                      {tPhaseF('phaseF.componentsReminderReminderPicker.noteOptional')}
+                    </Label>
+                    <Textarea
+                      id="reminder-note"
+                      placeholder={tPhaseF(
+                        'phaseF.componentsReminderReminderPicker.whyAreYouSettingThisReminder'
+                      )}
+                      value={note}
+                      onChange={(e) => setNote(e.target.value)}
+                      className="mt-1.5 h-16 resize-none text-sm"
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <Picker.Footer className="space-y-2 p-2">
               {selectedDate && (
                 <div className="text-xs text-muted-foreground">
-                  {formatReminderDate(
-                    (() => {
-                      const [hours, minutes] = selectedTime.split(':').map(Number)
-                      const date = new Date(selectedDate)
-                      date.setHours(hours, minutes, 0, 0)
-                      return date
-                    })(),
-                    clockFormat
-                  )}
+                  {formatReminderDate(buildSelectedDate() ?? selectedDate, clockFormat)}
                 </div>
               )}
 
@@ -344,11 +342,11 @@ export function ReminderPicker({
                 {mode === 'edit'
                   ? tPhaseF('phaseF.componentsReminderReminderPicker.save')
                   : isLoading
-                    ? 'Setting...'
-                    : 'Set Reminder'}
+                    ? tPhaseF('phaseF.componentsReminderReminderPicker.setting')
+                    : tPhaseF('phaseF.componentsReminderReminderPicker.setReminder')}
               </Button>
-            </div>
-          </div>
+            </Picker.Footer>
+          </>
         )}
       </Picker.Content>
     </Picker>

--- a/apps/desktop/src/renderer/src/components/reminder/reminder-picker.tsx
+++ b/apps/desktop/src/renderer/src/components/reminder/reminder-picker.tsx
@@ -171,7 +171,7 @@ export function ReminderPicker({
         )}
       </Picker.Trigger>
 
-      <Picker.Content className="w-80" align="start" collisionPadding={8}>
+      <Picker.Content className="w-80" align="start">
         {mode === 'presets' ? (
           <>
             <Picker.List>

--- a/apps/desktop/src/renderer/src/components/ui/picker/picker-content.test.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/picker/picker-content.test.tsx
@@ -74,6 +74,26 @@ describe('PickerContent', () => {
   })
 })
 
+describe('PickerFooter', () => {
+  it('holds its height so the cap eats the scrolling body instead of the footer', () => {
+    // The footer carries the confirm action. Left shrinkable, a popover anchored
+    // low in the window squeezes it away along with the only way to commit —
+    // which is how the reminder picker lost its "Set reminder" button.
+    render(
+      <Picker defaultOpen>
+        <Picker.Trigger>trigger</Picker.Trigger>
+        <Picker.Content>
+          <Picker.Footer>footer</Picker.Footer>
+        </Picker.Content>
+      </Picker>
+    )
+
+    const footer = document.querySelector('[data-slot="picker-footer"]')
+    expect(footer).not.toBeNull()
+    expect(footer?.className).toContain('shrink-0')
+  })
+})
+
 describe('PickerList', () => {
   it('scrolls instead of clipping when the list outgrows the popover', () => {
     renderPicker()

--- a/apps/desktop/src/renderer/src/components/ui/picker/picker-footer.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/picker/picker-footer.tsx
@@ -7,7 +7,7 @@ interface PickerFooterProps {
 
 export function PickerFooter({ className, children }: PickerFooterProps): React.JSX.Element {
   return (
-    <div data-slot="picker-footer" className={cn('border-t border-border', className)}>
+    <div data-slot="picker-footer" className={cn('shrink-0 border-t border-border', className)}>
       {children}
     </div>
   )

--- a/apps/docs/src/user-guide/notes/bookmarks-reminders.md
+++ b/apps/docs/src/user-guide/notes/bookmarks-reminders.md
@@ -21,6 +21,12 @@ Open the reminder picker from the note toolbar. Pick a date and time:
 - A relative button (in 1 hour, tomorrow morning, next week)
 - A custom date and time picker
 
+A relative button sets the reminder as soon as you pick it. **Pick date & time** opens a panel that
+needs confirming instead: choose the day, the time and an optional note, then press **Set reminder**.
+That button and the summary of what you are about to set stay pinned to the bottom of the panel, so
+they stay in reach even when the picker opens somewhere with little room and the rest of the panel
+has to scroll.
+
 Selecting text in the editor does not open a separate reminder action; reminders are set at the note level.
 
 When the reminder fires, memrynote shows an in-app toast with:

--- a/packages/i18n/src/locales/en/inbox.json
+++ b/packages/i18n/src/locales/en/inbox.json
@@ -485,7 +485,9 @@
       "set": "Set",
       "editReminder": "Edit reminder",
       "deleteReminder": "Delete reminder",
-      "save": "Save"
+      "save": "Save",
+      "setReminder": "Set reminder",
+      "setting": "Setting…"
     },
     "componentsSnoozeSnoozePicker": {
       "snooze": "Snooze",


### PR DESCRIPTION
Aurelie reported on 13 Aug that "Set reminder" → "Pick date & time" opens a panel whose bottom is cut off, with the confirm button out of reach, so a custom reminder could not be set at all. It behaved differently depending on whether the right-hand task panel was open and where it was scrolled. No issue had been filed; it was still reproducible on `main` today.

## What was wrong

`Picker.Content` is a Radix `PopoverContent` carrying `overflow-clip` and `max-h-(--radix-popover-content-available-height)`. Only `Picker.List` is a scroll container, so the presets view scrolls when it outgrows the popover. The custom / edit view was a plain `<div className="p-2">` — no `overflow-y-auto`, no `min-h-0` — so it clipped instead, and the confirm button, being the panel's last child, was the first thing lost.

How much room Radix measures depends on where the trigger sits in the viewport, which is exactly why the task panel's scroll position changed the outcome and why reopening the picker sometimes helped.

Despite the report's wording this is a popover, not a modal.

## What changed

- The custom / edit view is now a scrolling body plus a pinned `Picker.Footer` holding the date preview and the confirm button. The height cap can only eat into the part that scrolls. The preview moved with the button deliberately — confirming without seeing what you are confirming is its own bug. The footer brings a `border-t` with it, so there is now a rule above the preview where there was none.
- `PickerFooter` gained `shrink-0`; without it the footer would have been squeezed along with everything else.
- The button's labels were hardcoded English (`'Set Reminder'`, `'Setting...'`). Since the button was moving anyway, they now go through i18n.

### On the flex layout, since it is the whole fix

The body is `min-h-0 overflow-y-auto` with no `flex-1`, i.e. the default `flex: 0 1 auto`, and the footer is `shrink-0`. Negative free space is distributed by scaled shrink factor, so with the footer at factor zero the whole shrinkage lands on the body, whose height then becomes definite and whose `overflow-y: auto` yields a real scrollbar. `flex-1` would have been wrong here: `flex: 1 1 0%` sets a zero basis, and the popover is an auto-height container whenever its content is shorter than the cap.

### A prop that was in here and should not have been

An earlier commit on this branch added `collisionPadding={8}`, claiming it stopped a trigger flush against the window edge from collapsing the available height. That rationale is backwards — `flip` and `size` share the same `detectOverflow` padding, so the padding makes the measured available height *smaller*, taking away the very room this change exists to provide. What actually rescues a low trigger is `flip`, which `avoidCollisions` has had on all along. The prop has been removed rather than kept with better wording.

## Tests

Two new tests, both mutation-checked — each fails when its guarantee is removed:

- `picker-content.test.tsx` — `PickerFooter` keeps `shrink-0`.
- `reminder-picker.test.tsx` — the confirm button and the preview render inside the footer, the time field renders inside the scroll container.

These prove structure, not pixels. jsdom does not compute `--radix-popover-content-available-height`, and the reminder test runs against a mocked `Picker.Content` with none of the flex, cap or clip on it, so **nothing here covers the seam between the two**. A short-viewport check in the running app is still the real gate and is still owed.

`typecheck:web`, `typecheck:test`, `i18n:check`, lint and the renderer test files that touch the reminder picker are green, as are the 11 test files covering the other eight `Picker.Footer` consumers.

## Review notes

An adversarial review pass confirmed the flex reasoning above, found the `collisionPadding` rationale defect fixed here, and surfaced #1524 — the *presets* branch of this same component clips its note field and managed-reminder list for the same underlying reason. That is pre-existing and out of scope here rather than folded in.

The last commit was pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: it only removes an internal prop with no user-facing behaviour change, and the branch's docs were already updated two commits earlier. `pnpm docs:impact --base origin/main --strict` reports the branch as covered.

## Follow-ups filed

- #1519 — whether picking a custom date & time should need a confirm button at all (Aurelie's own suggestion, with the cancel-path and edit-mode hazards written down)
- #1520 — audit the snooze dialog and due-date picker for the same clipping, unverified
- #1521 — there is no telemetry on the reminder path, which is why this was invisible for nine days
- #1524 — the presets branch of this picker clips too

Closes #1518
