### PR TITLE
fix(snooze): cap the custom snooze dialog so its confirm button stays reachable

### DIFF
--- a/apps/desktop/src/renderer/src/components/snooze/snooze-picker.test.tsx
+++ b/apps/desktop/src/renderer/src/components/snooze/snooze-picker.test.tsx
@@ -134,6 +134,43 @@ describe('SnoozePicker', () => {
     expect(onSnooze).toHaveBeenCalledWith(new Date(2026, 4, 11, 10, 30, 0, 0).toISOString())
   })
 
+  it('caps the custom dialog and keeps the snooze action out of the scrolling body', async () => {
+    // `DialogContent` sets no height of its own, so a dialog taller than the
+    // window hangs off both edges of a fixed, unscrollable box — and the snooze
+    // button, being last, is the first thing to leave. jsdom computes no layout,
+    // so this asserts the structure that makes an overflow survivable (a capped
+    // shell, a scrolling body, the action outside it), not that any pixel is on
+    // screen.
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    renderWithProviders(
+      <SnoozePicker onSnooze={vi.fn()} trigger={<button>Custom trigger</button>} />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Custom trigger' }))
+    await user.click(
+      screen.getByRole('menuitem', {
+        name: /phaseF.componentsSnoozeSnoozePicker.pickDateTime/
+      })
+    )
+
+    const content = screen.getByRole('dialog').firstElementChild
+    expect(content?.className).toContain('max-h-[85vh]')
+    expect(content?.className).toContain('overflow-hidden')
+
+    const body = content?.querySelector('.overflow-y-auto')
+    const snooze = screen.getByRole('button', {
+      name: 'phaseF.componentsSnoozeSnoozePicker.snooze3'
+    })
+
+    expect(body).not.toBeNull()
+    expect(body?.contains(screen.getByRole('button', { name: 'Select May 11' }))).toBe(true)
+    expect(body?.contains(screen.getByDisplayValue('09:00'))).toBe(true)
+    expect(body?.contains(snooze)).toBe(false)
+    // The error explaining the disabled button rides with the button.
+    expect(body?.contains(screen.getByText('Please select a future time'))).toBe(false)
+  })
+
   it('renders quick snooze button label and icon-only tooltip variants', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     const onSnooze = vi.fn()

--- a/apps/desktop/src/renderer/src/components/snooze/snooze-picker.tsx
+++ b/apps/desktop/src/renderer/src/components/snooze/snooze-picker.tsx
@@ -238,7 +238,13 @@ function SnoozeCustomDialog({
       modal
     >
       <DialogContent
-        className="sm:max-w-[400px] z-[10000]"
+        // `DialogContent` is a fixed, viewport-centred box with no height cap of
+        // its own, so a dialog taller than the window simply hangs off both
+        // edges with nothing to scroll. The calendar alone makes this one about
+        // 570px tall, which a 150%-scaled 768px display cannot fit — and the
+        // snooze button, being last, is the first thing to go. Cap the dialog,
+        // give the tall part a scrollbar and keep the action out of it.
+        className="sm:max-w-[400px] z-[10000] grid-rows-[auto_1fr] max-h-[85vh] overflow-hidden"
         onClick={(e) => e.stopPropagation()}
         onPointerDown={(e) => e.stopPropagation()}
         onMouseDown={(e) => e.stopPropagation()}
@@ -256,49 +262,56 @@ function SnoozeCustomDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
-          {/* Calendar - properly sized with larger cells */}
-          <DatePickerCalendar
-            selected={selectedDate}
-            onSelect={(d) => setSelectedDate(d)}
-            disabled={(date) => {
-              const today = new Date()
-              today.setHours(0, 0, 0, 0)
-              const compareDate = new Date(date)
-              compareDate.setHours(0, 0, 0, 0)
-              return compareDate < today
-            }}
-            className="rounded-md border mx-auto"
-          />
-
-          {/* Time Picker */}
-          <div className="flex items-center gap-2 px-2">
-            <Clock className="h-4 w-4 text-muted-foreground" />
-            <Input
-              type="time"
-              value={selectedTime}
-              onChange={(e) => setSelectedTime(e.target.value)}
-              className="flex-1"
+        <div className="flex min-h-0 flex-col gap-4">
+          <div className="min-h-0 space-y-4 overflow-y-auto">
+            {/* Calendar - properly sized with larger cells */}
+            <DatePickerCalendar
+              selected={selectedDate}
+              onSelect={(d) => setSelectedDate(d)}
+              disabled={(date) => {
+                const today = new Date()
+                today.setHours(0, 0, 0, 0)
+                const compareDate = new Date(date)
+                compareDate.setHours(0, 0, 0, 0)
+                return compareDate < today
+              }}
+              className="rounded-md border mx-auto"
             />
+
+            {/* Time Picker */}
+            <div className="flex items-center gap-2 px-2">
+              <Clock className="h-4 w-4 text-muted-foreground" />
+              <Input
+                type="time"
+                value={selectedTime}
+                onChange={(e) => setSelectedTime(e.target.value)}
+                className="flex-1"
+              />
+            </div>
           </div>
 
-          {/* Preview & Error */}
-          {selectedDate ? (
-            <div
-              className={`text-xs text-center ${timeError ? 'text-destructive' : 'text-muted-foreground'}`}
-            >
-              {timeError || (previewDate ? formatSnoozeTime(previewDate, clockFormat) : '')}
-            </div>
-          ) : null}
+          {/* The preview travels with the button it explains: it is the only
+              place the "past time" error appears, so scrolling it away would
+              leave a disabled button with no stated reason. */}
+          <div className="shrink-0 space-y-4">
+            {/* Preview & Error */}
+            {selectedDate ? (
+              <div
+                className={`text-xs text-center ${timeError ? 'text-destructive' : 'text-muted-foreground'}`}
+              >
+                {timeError || (previewDate ? formatSnoozeTime(previewDate, clockFormat) : '')}
+              </div>
+            ) : null}
 
-          {/* Snooze Button */}
-          <Button
-            onClick={handleCustomSnooze}
-            disabled={!selectedDate || !!timeError}
-            className="w-full"
-          >
-            {tPhaseF('phaseF.componentsSnoozeSnoozePicker.snooze3')}
-          </Button>
+            {/* Snooze Button */}
+            <Button
+              onClick={handleCustomSnooze}
+              disabled={!selectedDate || !!timeError}
+              className="w-full"
+            >
+              {tPhaseF('phaseF.componentsSnoozeSnoozePicker.snooze3')}
+            </Button>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/docs/src/user-guide/inbox/snooze-archive.md
+++ b/apps/docs/src/user-guide/inbox/snooze-archive.md
@@ -20,7 +20,9 @@ Snoozing an inbox item hides it until the wake time arrives. The item leaves the
 
 ### Custom Snooze
 
-The custom dialog accepts any future date and time. Past times are rejected.
+The custom dialog accepts any future date and time. Past times are rejected. When the window is too
+short for the whole dialog, the calendar and time field scroll while the **Snooze** button stays
+pinned below them.
 
 ### Snoozed View
 

--- a/apps/docs/src/user-guide/snooze-reminders.md
+++ b/apps/docs/src/user-guide/snooze-reminders.md
@@ -22,6 +22,10 @@ Snoozing an inbox item, task, or note's reminder hides it until the wake time ar
 
 The custom dialog lets you pick any future date and time. Past times are rejected with a clear error.
 
+On a short window the calendar and the time field scroll inside the dialog. The chosen time and the
+**Snooze** button stay pinned below them, so the action — and the error explaining a disabled
+button — never scrolls out of reach.
+
 ### Where Snooze Is Available
 
 | Surface       | Snooze                                                      |


### PR DESCRIPTION
Closes #1520.

#1520 asked whether two other surfaces share the reminder picker's clipping bug: content taller
than its container, no scroll path, trailing controls unreachable. Both were flagged unverified, so
this started as an audit. One of the two turned out to be real, the other turned out not to be a
user-facing surface at all.

## Snooze dialog — real, fixed

`SnoozeCustomDialog` renders its calendar, time field, preview and **Snooze** button into a
`DialogContent`. The repo's `DialogContent` is a fixed, viewport-centred box with `grid gap-4 p-6`
and no height cap and no overflow rule of its own — height management is left to each caller, and
six other dialogs in the app do exactly that (`max-h-[85vh]`/`max-h-[90vh]` plus an overflow rule in
`add-task-modal`, `project-modal`, `keyboard-shortcuts-dialog`, `settings-modal` and others). The
snooze dialog was the outlier that never opted in.

Adding up the compiled classes, the dialog is about 570px tall on a six-week month: a 336px calendar
(`max-h-10` day cells at the 400px dialog width), a 30px time row, the preview, a 36px button, the
44px header and 24px of padding on each side. Nothing about that fits a short window, and because
the box is `position: fixed` and centred, overflow leaves the viewport at both ends with nothing to
scroll — the button, being last, is the first thing to go. The window has no `minHeight`, so the app
can simply be resized under 570px; a 150%-scaled 768px display, which is a common Windows laptop
configuration, leaves roughly 480 CSS px of viewport before anyone touches the window at all.

The fix follows the same shape as the reminder picker: cap the dialog at `max-h-[85vh]`, lay it out
as `grid-rows-[auto_1fr]` so the body row is the one that shrinks, scroll the calendar and time
field, and keep the preview and the **Snooze** button pinned below the scroll. The preview travels
with the button deliberately: it is the only place the "please select a future time" error appears,
so scrolling it away would leave a disabled button with no stated reason.

## Due-date picker — not a user-facing surface, no change

`components/tasks/due-date-picker.tsx` does use a raw `PopoverContent` rather than `Picker.Content`,
and a raw `PopoverContent` really does have no height management: Radix's popper sets
`--radix-popper-available-height` through its `size` middleware but never applies it, and its
`shift` middleware runs with `crossAxis: false`, so a too-tall popover on a bottom or top placement
is never pulled back into the viewport. So the mechanism the issue suspected is genuinely there.

But `DueDatePicker` is not rendered anywhere. Its only importer is its own test file — `pages/tasks.tsx`
uses `BulkDueDatePicker`, which is a different component. There is no user-facing surface to fix, so
this PR leaves the file alone rather than editing dead code. Worth noting separately that it is dead:
this PR does not delete it.

For the record, in that dead component's calendar panel nothing sits below the calendar anyway — the
action is selecting a day, inside the calendar itself — so the "trailing control unreachable" shape
would have applied to its default panel (where "Clear date" sits last), not to the calendar panel the
issue pointed at.

## Sweep of the rest

Every other `Picker.Content` in the renderer was checked for the same shape — a non-scrolling
hand-rolled div holding tall content with an action at the bottom. None qualify: they are all
`Picker.List` (which scrolls) plus an optional `Picker.Footer`, or short fixed-size menus.
`filter-dropdown` is the one that carries a lot of content and it already opts into
`max-h-[calc(100vh-120px)] overflow-y-auto` on the content itself.

One live analogue does exist outside `Picker.Content` and is **not** changed here:
`DatePickerContent` (presets, calendar, and a time row at the bottom) is hosted by raw
`PopoverContent` in `interactive-due-date-badge.tsx` and `calendar-event-form.tsx`. Same family, same
missing height cap, and its trailing "Add time" row is the part that would go. It is out of scope for
this issue, but it is the surface most likely to reproduce the original report, and deserves its own
follow-up.

## Verification

The new test asserts structure, not pixels. jsdom computes no layout and never resolves
`--radix-popover-content-available-height`, so no renderer test can claim a button is visibly on
screen. What it can assert is that the dialog carries the cap, that a scroll container exists, that
the calendar and time field are inside it, and that the button and its error are not. All three
mutations were tried and each turned the test red: removing `overflow-y-auto` from the body
(scroll container disappears), removing `max-h-[85vh]` from the dialog (cap assertion fails), and
moving `overflow-y-auto` up one level so the whole body scrolls including the button (the button
lands back inside the scroll container). Restored and green after each.

`typecheck:web`, `typecheck:test`, `i18n:check`, eslint on the changed files, `git diff --check`,
`docs:impact --strict` and `docs:build` all pass. The 15 renderer test files covering the snooze
picker and its four consumers (bulk action bar, calendar inbox popover, reminder detail, quick
actions) are green.

## Merge order

Independent of #1523 — this touches a dialog, not the picker primitive, and needs nothing from that
branch. Either order is fine.
