### PR TITLE
fix(notes): rename a folder in a vault big enough to virtualize the sidebar

### DIFF
--- a/apps/desktop/src/renderer/src/components/notes-tree-virtualized-rename.test.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree-virtualized-rename.test.tsx
@@ -1,0 +1,280 @@
+/**
+ * Verification: does the sidebar's rename input survive virtualization?
+ *
+ * The sidebar swaps whole components at `VIRTUALIZATION_THRESHOLD` (100 tree
+ * items). `notes-tree.test.tsx` pins `shouldVirtualize` to false and stubs
+ * `VirtualizedNotesTree` out entirely, so nothing in the suite exercises the
+ * component real users above that threshold actually get.
+ */
+
+import type React from 'react'
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nextProvider } from 'react-i18next'
+import type { i18n as I18nInstance } from 'i18next'
+import { createRendererI18n } from '@memry/i18n/renderer'
+import { NotesTree } from './notes-tree'
+import type { NoteListItem } from '@/hooks/use-notes-query'
+import type { FolderInfo } from '../../../preload/index.d'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+const mocks = vi.hoisted(() => ({
+  scrollToIndex: vi.fn(),
+  renameFolder: vi.fn().mockResolvedValue({})
+}))
+
+vi.mock('@/lib/ipc-error', () => ({
+  extractErrorMessage: (_err: unknown, fallback: string) => fallback
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabs: () => ({ openTab: vi.fn(), closeTab: vi.fn() }),
+  useTabActions: () => ({
+    openTab: vi.fn(),
+    closeTab: vi.fn(),
+    updateTabTitleByEntityId: vi.fn()
+  })
+}))
+
+vi.mock('@/hooks/use-notes-query', () => ({
+  useNotesList: vi.fn(),
+  useNoteFoldersQuery: vi.fn(),
+  useNoteMutations: vi.fn(),
+  notesKeys: { notes: () => ['notes'], note: (id: string) => ['notes', id] }
+}))
+
+vi.mock('@/services/notes-service', () => ({
+  notesService: {
+    getFolderConfig: vi.fn().mockResolvedValue({}),
+    setFolderConfig: vi.fn().mockResolvedValue({}),
+    getFolderTemplate: vi.fn().mockResolvedValue(null),
+    openExternal: vi.fn().mockResolvedValue({}),
+    revealInFinder: vi.fn().mockResolvedValue({}),
+    deleteFolder: vi.fn().mockResolvedValue({}),
+    renameFolder: mocks.renameFolder,
+    getAllPositions: vi.fn().mockResolvedValue({ success: true, positions: {} }),
+    reorder: vi.fn().mockResolvedValue({ success: true })
+  }
+}))
+
+vi.mock('@/hooks/use-general-settings', () => ({
+  useGeneralSettings: () => ({
+    settings: {
+      createInSelectedFolder: true,
+      theme: 'system' as const,
+      fontSize: 'medium' as const,
+      fontFamily: 'system' as const,
+      accentColor: '#6366f1',
+      startOnBoot: false,
+      language: 'en',
+      onboardingCompleted: false
+    },
+    isLoading: false,
+    error: null,
+    updateSettings: vi.fn().mockResolvedValue(true)
+  })
+}))
+
+vi.mock('@/components/note/template-selector', () => ({
+  TemplateSelector: () => <div data-testid="template-selector">Template Selector</div>
+}))
+
+// Radix renders menu content only once opened through a real pointer stack.
+// Flattening it keeps every row's menu in the DOM, so a row can be located and
+// its own Rename item clicked directly. Both trees import this same module.
+vi.mock('@/components/ui/context-menu', () => ({
+  ContextMenu: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="row">{children}</div>
+  ),
+  ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuItem: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  ContextMenuSeparator: () => <hr />
+}))
+
+// jsdom measures every element at 0px, so the real virtualizer would render no
+// rows at all and "no input" would prove nothing. Force every row to mount.
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index,
+        start: index * 28,
+        size: 28
+      })),
+    getTotalSize: () => count * 28,
+    scrollToIndex: mocks.scrollToIndex
+  })
+}))
+
+import { useNotesList, useNoteFoldersQuery, useNoteMutations } from '@/hooks/use-notes-query'
+
+let i18nEn: I18nInstance
+
+beforeAll(async () => {
+  i18nEn = await createRendererI18n({ locale: 'en' })
+})
+
+const renderTree = () =>
+  render(
+    <I18nextProvider i18n={i18nEn}>
+      <QueryClientProvider
+        client={
+          new QueryClient({
+            defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+          })
+        }
+      >
+        <TooltipProvider>
+          <NotesTree />
+        </TooltipProvider>
+      </QueryClientProvider>
+    </I18nextProvider>
+  )
+
+const createNote = (id: string, path: string): NoteListItem => ({
+  id,
+  path,
+  title: path.split('/').pop()?.replace('.md', '') || 'Untitled',
+  emoji: null,
+  created: new Date(),
+  modified: new Date(),
+  wordCount: 100,
+  tags: []
+})
+
+const folders: FolderInfo[] = [{ path: 'Projects', icon: null }]
+
+const setupMocks = (notes: NoteListItem[]) => {
+  ;(useNotesList as ReturnType<typeof vi.fn>).mockReturnValue({
+    notes,
+    isLoading: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
+    total: notes.length,
+    hasMore: false
+  })
+  ;(useNoteFoldersQuery as ReturnType<typeof vi.fn>).mockReturnValue({
+    folders,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+    refreshFolders: vi.fn(),
+    createFolder: vi.fn().mockResolvedValue(true),
+    setFolderIcon: vi.fn().mockResolvedValue(true)
+  })
+  ;(useNoteMutations as ReturnType<typeof vi.fn>).mockReturnValue({
+    createNote: {
+      mutateAsync: vi
+        .fn()
+        .mockResolvedValue({ success: true, note: { id: 'new-note', path: 'Untitled.md' } })
+    },
+    deleteNote: { mutateAsync: vi.fn().mockResolvedValue({ success: true }) },
+    renameNote: { mutateAsync: vi.fn().mockResolvedValue({ success: true, note: {} }) },
+    moveNote: { mutateAsync: vi.fn().mockResolvedValue({ success: true, note: {} }) }
+  })
+}
+
+const clickRenameOnProjectsFolder = async () => {
+  const user = userEvent.setup()
+  const row = screen.getAllByText('Projects')[0].closest('[data-testid="row"]')
+  expect(row).not.toBeNull()
+  await user.click(within(row as HTMLElement).getByRole('button', { name: /rename/i }))
+}
+
+const smallVault = [
+  createNote('n1', 'Projects/Alpha.md'),
+  createNote('n2', 'Projects/Beta.md'),
+  createNote('n3', 'Root.md')
+]
+
+const largeVault = [
+  ...Array.from({ length: 150 }, (_, i) => createNote(`n${i}`, `Note ${i}.md`)),
+  createNote('p1', 'Projects/Alpha.md')
+]
+
+describe('sidebar folder rename across the virtualization threshold', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('below the threshold: Rename opens an inline input', async () => {
+    setupMocks(smallVault)
+    renderTree()
+
+    expect(screen.queryByRole('textbox', { name: /rename/i })).not.toBeInTheDocument()
+    await clickRenameOnProjectsFolder()
+
+    expect(screen.getByRole('textbox', { name: /rename/i })).toBeInTheDocument()
+  })
+
+  it('above the threshold: Rename opens an inline input too', async () => {
+    setupMocks(largeVault)
+    renderTree()
+
+    await clickRenameOnProjectsFolder()
+
+    expect(screen.getByRole('textbox', { name: /rename/i })).toBeInTheDocument()
+  })
+
+  it('above the threshold: renaming a note opens an inline input too', async () => {
+    setupMocks(largeVault)
+    renderTree()
+
+    const user = userEvent.setup()
+    const row = screen.getAllByText('Note 0')[0].closest('[data-testid="row"]')
+    expect(row).not.toBeNull()
+    await user.click(within(row as HTMLElement).getByRole('button', { name: /rename/i }))
+
+    expect(screen.getByRole('textbox', { name: /rename/i })).toBeInTheDocument()
+  })
+
+  // The mock above mounts every row; the real virtualizer mounts only visible
+  // ones. A folder created from the sidebar goes straight into rename mode and
+  // usually sorts off screen, so unless the tree scrolls to it there is still
+  // no input to type into.
+  it('above the threshold: entering rename mode scrolls the row into view', async () => {
+    setupMocks(largeVault)
+    const { container } = renderTree()
+
+    // Rows are mounted in flattened order, so their DOM order is the order the
+    // virtualizer indexes into.
+    const flattenedIds = [...container.querySelectorAll('[data-tree-node-id]')].map((el) =>
+      el.getAttribute('data-tree-node-id')
+    )
+    const expectedIndex = flattenedIds.indexOf('folder-Projects')
+    expect(expectedIndex).toBeGreaterThanOrEqual(0)
+
+    await clickRenameOnProjectsFolder()
+
+    await waitFor(() =>
+      expect(mocks.scrollToIndex).toHaveBeenCalledWith(expectedIndex, { align: 'center' })
+    )
+  })
+
+  it('above the threshold: the inline input commits the rename', async () => {
+    setupMocks(largeVault)
+    renderTree()
+
+    await clickRenameOnProjectsFolder()
+
+    const input = screen.getByRole('textbox', { name: /rename/i })
+    // The input focuses itself a frame after mounting; typing before that lands
+    // its `select()` mid-word.
+    await waitFor(() => expect(input).toHaveFocus())
+
+    const user = userEvent.setup()
+    await user.clear(input)
+    await user.type(input, 'Renamed{Enter}')
+
+    await waitFor(() => expect(mocks.renameFolder).toHaveBeenCalledWith('Projects', 'Renamed'))
+  })
+})

--- a/apps/desktop/src/renderer/src/components/notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree.tsx
@@ -586,6 +586,12 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
           onMove={(...args) => void actions.handleMove(...args)}
           onBulkDelete={actions.handleBulkDelete}
           onRenameNote={actions.handleRenameClick}
+          renamingNoteId={actions.renamingNoteId}
+          renameValue={actions.renameValue}
+          onRenameValueChange={actions.handleRenameInputChange}
+          onRenameSubmit={(...args) => void actions.handleRenameSubmit(...args)}
+          onRenameCancel={actions.handleRenameCancel}
+          isRenaming={actions.isRenaming}
           onApplyTemplateToNote={setApplyTemplateNote}
           onDeleteNote={actions.handleDeleteClick}
           onOpenExternal={(...args) => void actions.handleOpenExternal(...args)}
@@ -594,6 +600,12 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
           onCreateNote={(...args) => void actions.handleCreateNoteInFolder(...args)}
           onCreateFolder={(...args) => void actions.handleCreateSubfolder(...args)}
           onRenameFolder={actions.handleRenameFolderClick}
+          renamingFolderPath={actions.renamingFolderPath}
+          folderRenameValue={actions.folderRenameValue}
+          onFolderRenameValueChange={actions.setFolderRenameValue}
+          onFolderRenameSubmit={(...args) => void actions.handleFolderRenameSubmit(...args)}
+          onFolderRenameCancel={actions.handleFolderRenameCancel}
+          isFolderRenaming={actions.isFolderRenaming}
           onSetFolderTemplate={actions.handleSetFolderTemplate}
           onClearFolderTemplate={(...args) => void actions.handleClearFolderTemplate(...args)}
           folderTemplateNames={data.folderTemplateNames}

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
@@ -120,6 +120,30 @@ interface VirtualizedNotesTreeProps {
   onCreateFolder?: (folderPath: string) => void
   /** Callback when renaming a folder */
   onRenameFolder?: (folderPath: string) => void
+  /** Folder path whose row currently shows the inline rename input, if any */
+  renamingFolderPath?: string | null
+  /** Current text in the folder rename input */
+  folderRenameValue?: string
+  /** Callback when the folder rename input's text changes */
+  onFolderRenameValueChange?: (value: string) => void
+  /** Callback when a folder rename is committed */
+  onFolderRenameSubmit?: (folderPath: string) => void
+  /** Callback when a folder rename is abandoned */
+  onFolderRenameCancel?: () => void
+  /** Whether a folder rename is in flight */
+  isFolderRenaming?: boolean
+  /** Note ID whose row currently shows the inline rename input, if any */
+  renamingNoteId?: string | null
+  /** Current text in the note rename input */
+  renameValue?: string
+  /** Callback when the note rename input's text changes */
+  onRenameValueChange?: (noteId: string, value: string) => void
+  /** Callback when a note rename is committed */
+  onRenameSubmit?: (noteId: string, originalPath: string) => void
+  /** Callback when a note rename is abandoned */
+  onRenameCancel?: (noteId: string) => void
+  /** Whether a note rename is in flight */
+  isRenaming?: boolean
   /** Callback when setting folder template */
   onSetFolderTemplate?: (folderPath: string) => void
   /** Callback when clearing folder template */
@@ -209,6 +233,23 @@ function isFolder(itemId: string): boolean {
   return itemId.startsWith('folder-')
 }
 
+/** Same inline rename input styling the non-virtualized tree uses. */
+const RENAME_INPUT_CLASS =
+  'flex-1 h-5 px-1 text-sm bg-background border border-input rounded focus:outline-none'
+
+/**
+ * Focus and select the inline rename input once it has been laid out. A folder
+ * created from the sidebar drops straight into rename mode, so the input has to
+ * be typable without a click. Module-level for a stable callback-ref identity.
+ */
+function focusRenameInput(el: HTMLInputElement | null): void {
+  if (!el) return
+  requestAnimationFrame(() => {
+    el.focus()
+    el.select()
+  })
+}
+
 // ============================================================================
 // Row Components
 // ============================================================================
@@ -230,6 +271,13 @@ interface FolderRowProps {
   onCreateNote?: (folderPath: string) => void
   onCreateFolder?: (folderPath: string) => void
   onRenameFolder?: (folderPath: string) => void
+  /** True while this row shows the inline rename input instead of its label. */
+  isBeingRenamed: boolean
+  folderRenameValue?: string
+  onFolderRenameValueChange?: (value: string) => void
+  onFolderRenameSubmit?: (folderPath: string) => void
+  onFolderRenameCancel?: () => void
+  isFolderRenaming?: boolean
   onDeleteFolder?: (folderPath: string) => void
   onSetFolderTemplate?: (folderPath: string) => void
   onClearFolderTemplate?: (folderPath: string) => void
@@ -261,6 +309,12 @@ function FolderRow({
   onCreateNote,
   onCreateFolder,
   onRenameFolder,
+  isBeingRenamed,
+  folderRenameValue,
+  onFolderRenameValueChange,
+  onFolderRenameSubmit,
+  onFolderRenameCancel,
+  isFolderRenaming,
   onDeleteFolder,
   onSetFolderTemplate,
   onClearFolderTemplate,
@@ -284,11 +338,14 @@ function FolderRow({
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
+      // A click landing inside the rename input must not collapse or reselect
+      // the row it is sitting in.
+      if (isBeingRenamed) return
       // Toggle expand/collapse when clicking folder row
       onToggleExpand(item.id)
       onSelect(item.id, e)
     },
-    [item.id, onSelect, onToggleExpand]
+    [isBeingRenamed, item.id, onSelect, onToggleExpand]
   )
 
   const _handleExpandClick = useCallback(
@@ -401,30 +458,56 @@ function FolderRow({
             onPickerOpenChange={(open) => onIconPickerOpenChange?.(open ? item.folder.path : null)}
           />
 
-          {/* Folder name */}
-          <span className="sidebar-label-fade text-sm flex-1">{item.folder.name}</span>
+          {isBeingRenamed ? (
+            <input
+              ref={focusRenameInput}
+              type="text"
+              aria-label={t('tree.actions.rename')}
+              value={folderRenameValue ?? ''}
+              onChange={(e) => onFolderRenameValueChange?.(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  onFolderRenameSubmit?.(item.folder.path)
+                } else if (e.key === 'Escape') {
+                  e.preventDefault()
+                  onFolderRenameCancel?.()
+                }
+                e.stopPropagation()
+              }}
+              onBlur={() => onFolderRenameSubmit?.(item.folder.path)}
+              onClick={(e) => e.stopPropagation()}
+              disabled={isFolderRenaming}
+              className={RENAME_INPUT_CLASS}
+            />
+          ) : (
+            <>
+              {/* Folder name */}
+              <span className="sidebar-label-fade text-sm flex-1">{item.folder.name}</span>
 
-          {/* Selection count badge */}
-          {showSelectionBadge && (
-            <span className="text-xs bg-primary text-primary-foreground px-1.5 py-0.5 rounded-full">
-              {selectedCount}
-            </span>
+              {/* Selection count badge */}
+              {showSelectionBadge && (
+                <span className="text-xs bg-primary text-primary-foreground px-1.5 py-0.5 rounded-full">
+                  {selectedCount}
+                </span>
+              )}
+
+              {/* Open-folder-view action. Revealed by focus as well as hover: the
+                  button is in the tab order, and the row itself is `tabIndex={0}`
+                  with `focus-visible:outline-none`, so hover-only left a keyboard
+                  user with nothing on screen (WCAG 2.4.7). */}
+              <div className="flex items-center opacity-0 group-hover/folder:opacity-100 group-focus-within/folder:opacity-100 transition-opacity">
+                <button
+                  type="button"
+                  onClick={handleOpenFolderViewClick}
+                  className="p-1 cursor-pointer rounded hover:bg-accent/80 transition-colors"
+                  aria-label={t('tree.aria.openFolderView')}
+                >
+                  <LayoutGrid className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
+                </button>
+              </div>
+            </>
           )}
-
-          {/* Open-folder-view action. Revealed by focus as well as hover: the
-              button is in the tab order, and the row itself is `tabIndex={0}`
-              with `focus-visible:outline-none`, so hover-only left a keyboard
-              user with nothing on screen (WCAG 2.4.7). */}
-          <div className="flex items-center opacity-0 group-hover/folder:opacity-100 group-focus-within/folder:opacity-100 transition-opacity">
-            <button
-              type="button"
-              onClick={handleOpenFolderViewClick}
-              className="p-1 cursor-pointer rounded hover:bg-accent/80 transition-colors"
-              aria-label={t('tree.aria.openFolderView')}
-            >
-              <LayoutGrid className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
-            </button>
-          </div>
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent>
@@ -506,6 +589,13 @@ interface NoteRowProps {
   onSelect: (noteId: string, event: React.MouseEvent) => void
   onDoubleClick?: (note: NoteListItem) => void
   onRenameNote?: (note: NoteListItem) => void
+  /** True while this row shows the inline rename input instead of its label. */
+  isBeingRenamed: boolean
+  renameValue?: string
+  onRenameValueChange?: (noteId: string, value: string) => void
+  onRenameSubmit?: (noteId: string, originalPath: string) => void
+  onRenameCancel?: (noteId: string) => void
+  isRenaming?: boolean
   onApplyTemplateToNote?: (note: NoteListItem) => void
   onDeleteNote?: (note: NoteListItem) => void
   onOpenExternal?: (note: NoteListItem) => void
@@ -535,6 +625,12 @@ function NoteRow({
   onSelect,
   onDoubleClick,
   onRenameNote,
+  isBeingRenamed,
+  renameValue,
+  onRenameValueChange,
+  onRenameSubmit,
+  onRenameCancel,
+  isRenaming,
   onApplyTemplateToNote,
   onDeleteNote,
   onOpenExternal,
@@ -558,14 +654,18 @@ function NoteRow({
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
+      // A click landing inside the rename input must not reselect the row or
+      // open the note behind it.
+      if (isBeingRenamed) return
       onSelect(item.id, e)
     },
-    [item.id, onSelect]
+    [isBeingRenamed, item.id, onSelect]
   )
 
   const handleDoubleClick = useCallback(() => {
+    if (isBeingRenamed) return
     onDoubleClick?.(item.note)
-  }, [item.note, onDoubleClick])
+  }, [isBeingRenamed, item.note, onDoubleClick])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -647,16 +747,42 @@ function NoteRow({
             {getFileIcon(item.note)}
           </IconPickerButton>
 
-          {/* Note name */}
-          <span className="sidebar-label-fade text-sm flex-1">
-            {getDisplayName(item.note.path)}
-          </span>
+          {isBeingRenamed ? (
+            <input
+              ref={focusRenameInput}
+              type="text"
+              aria-label={t('tree.actions.rename')}
+              value={renameValue ?? ''}
+              onChange={(e) => onRenameValueChange?.(item.note.id, e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  onRenameSubmit?.(item.note.id, item.note.path)
+                } else if (e.key === 'Escape') {
+                  e.preventDefault()
+                  onRenameCancel?.(item.note.id)
+                }
+                e.stopPropagation()
+              }}
+              onBlur={() => onRenameSubmit?.(item.note.id, item.note.path)}
+              onClick={(e) => e.stopPropagation()}
+              disabled={isRenaming}
+              className={RENAME_INPUT_CLASS}
+            />
+          ) : (
+            <>
+              {/* Note name */}
+              <span className="sidebar-label-fade text-sm flex-1">
+                {getDisplayName(item.note.path)}
+              </span>
 
-          {/* Selection count badge */}
-          {showSelectionBadge && (
-            <span className="text-xs bg-primary text-primary-foreground px-1.5 py-0.5 rounded-full">
-              {selectedCount}
-            </span>
+              {/* Selection count badge */}
+              {showSelectionBadge && (
+                <span className="text-xs bg-primary text-primary-foreground px-1.5 py-0.5 rounded-full">
+                  {selectedCount}
+                </span>
+              )}
+            </>
           )}
         </div>
       </ContextMenuTrigger>
@@ -740,6 +866,18 @@ export function VirtualizedNotesTree({
   onCreateNote,
   onCreateFolder,
   onRenameFolder,
+  renamingFolderPath = null,
+  folderRenameValue,
+  onFolderRenameValueChange,
+  onFolderRenameSubmit,
+  onFolderRenameCancel,
+  isFolderRenaming,
+  renamingNoteId = null,
+  renameValue,
+  onRenameValueChange,
+  onRenameSubmit,
+  onRenameCancel,
+  isRenaming,
   onSetFolderTemplate,
   onClearFolderTemplate,
   folderTemplateNames,
@@ -833,6 +971,60 @@ export function VirtualizedNotesTree({
     scrollMargin: usesExternalScroll ? scrollMargin : 0
   })
 
+  /**
+   * Open every folder above `path` and scroll that row into view.
+   *
+   * `withAncestorsExpanded` drops the last segment of the path it is given —
+   * the filename for a note, the folder's own name for a folder — so in both
+   * cases what is left is exactly the parent chain that has to be open for the
+   * row to exist at all.
+   */
+  const revealRow = useCallback(
+    (itemId: string, path: string) => {
+      // Opening the folders is what gives the row an index, so the index has to
+      // come from the flattening those folders produce — not from the one on
+      // screen right now.
+      const nextExpanded = withAncestorsExpanded(expandedIds, path)
+      const index = flattenTree(tree, nextExpanded).findIndex((item) => item.id === itemId)
+      setExpandedIds(nextExpanded)
+
+      // One frame later the virtualizer has been re-rendered with that row in
+      // its count, and can scroll to an index it would otherwise clamp away.
+      if (index !== -1) {
+        requestAnimationFrame(() => virtualizer.scrollToIndex(index, { align: 'center' }))
+      }
+    },
+    [tree, expandedIds, virtualizer]
+  )
+
+  /**
+   * A row outside the virtual window is not mounted, so the inline rename input
+   * on it does not exist either. Creating a folder or a note from the sidebar
+   * drops it straight into rename mode, and past the virtualization threshold
+   * that brand-new row is usually off screen — reveal it, or there is nothing
+   * to type into. Keyed on the id alone: re-running as `renameValue` changes
+   * would yank the list back on every keystroke.
+   */
+  const revealedRenameIdRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const renamingId = renamingFolderPath ? `folder-${renamingFolderPath}` : renamingNoteId
+    if (!renamingId) {
+      revealedRenameIdRef.current = null
+      return
+    }
+    if (revealedRenameIdRef.current === renamingId) return
+
+    // A note created a moment ago may not have reached `noteMap` yet; leaving
+    // the ref alone lets the next render try again.
+    const path = renamingFolderPath ?? (renamingNoteId ? noteMap.get(renamingNoteId)?.path : null)
+    if (!path) return
+
+    revealedRenameIdRef.current = renamingId
+    /* eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-live-state-to-parent, react-you-might-not-need-an-effect/no-pass-ref-to-parent, react-you-might-not-need-an-effect/no-derived-state -- genuine external sync: scrolling the virtualizer is an imperative side effect on a DOM scroll container, not state derivable during render, and rename mode is entered from the parent's action hook rather than from an event this component sees */
+    revealRow(renamingId, path)
+  }, [renamingFolderPath, renamingNoteId, noteMap, revealRow])
+
   // Expose expand/collapse actions to parent
   useImperativeHandle(
     actionsRef,
@@ -856,22 +1048,10 @@ export function VirtualizedNotesTree({
       revealNote: (noteId: string) => {
         const note = noteMap.get(noteId)
         if (!note) return
-
-        // Opening the folders is what gives the note a row, so the index has to
-        // come from the flattening those folders produce — not from the one on
-        // screen right now.
-        const nextExpanded = withAncestorsExpanded(expandedIds, note.path)
-        const index = flattenTree(tree, nextExpanded).findIndex((item) => item.id === noteId)
-        setExpandedIds(nextExpanded)
-
-        // One frame later the virtualizer has been re-rendered with that row in
-        // its count, and can scroll to an index it would otherwise clamp away.
-        if (index !== -1) {
-          requestAnimationFrame(() => virtualizer.scrollToIndex(index, { align: 'center' }))
-        }
+        revealRow(noteId, note.path)
       }
     }),
-    [tree, noteMap, expandedIds, virtualizer]
+    [tree, noteMap, revealRow]
   )
 
   // Toggle folder expand/collapse
@@ -1150,6 +1330,12 @@ export function VirtualizedNotesTree({
                   onCreateNote={onCreateNote}
                   onCreateFolder={onCreateFolder}
                   onRenameFolder={onRenameFolder}
+                  isBeingRenamed={renamingFolderPath === item.folder.path}
+                  folderRenameValue={folderRenameValue}
+                  onFolderRenameValueChange={onFolderRenameValueChange}
+                  onFolderRenameSubmit={onFolderRenameSubmit}
+                  onFolderRenameCancel={onFolderRenameCancel}
+                  isFolderRenaming={isFolderRenaming}
                   onDeleteFolder={onDeleteFolder}
                   onSetFolderTemplate={onSetFolderTemplate}
                   onClearFolderTemplate={onClearFolderTemplate}
@@ -1177,6 +1363,12 @@ export function VirtualizedNotesTree({
                   onSelect={handleSelect}
                   onDoubleClick={handleNoteDoubleClick}
                   onRenameNote={onRenameNote}
+                  isBeingRenamed={renamingNoteId === item.note.id}
+                  renameValue={renameValue}
+                  onRenameValueChange={onRenameValueChange}
+                  onRenameSubmit={onRenameSubmit}
+                  onRenameCancel={onRenameCancel}
+                  isRenaming={isRenaming}
                   onApplyTemplateToNote={onApplyTemplateToNote}
                   onDeleteNote={onDeleteNote}
                   onOpenExternal={onOpenExternal}

--- a/apps/docs/src/contribute/gotchas.md
+++ b/apps/docs/src/contribute/gotchas.md
@@ -123,6 +123,19 @@ Two rules when anchoring floating UI on a virtualized grid:
 
 `computePopoverPosition` in `popover-position.ts` owns the clamp for every calendar popover (task, note, event, inbox-snooze, quick-create).
 
+## The Notes Sidebar Has Two Renderers, and Row Features Must Land in Both
+
+`notes-tree.tsx` swaps components wholesale at `VIRTUALIZATION_THRESHOLD` (100 tree items, `lib/virtualized-tree-utils.ts`): below it a plain `TreeProvider` tree renders every row inline, at or above it `VirtualizedNotesTree` renders its own rows. Any row-level interaction — inline rename, badges, hover actions, drop targets — has to be implemented in **both**, or it silently works only for small vaults.
+
+Inline rename shipped this way: the virtualized tree offered a "Rename" context-menu item that set `renamingFolderPath` / `renamingNoteId` but rendered no input reading them, so above 100 items renaming a folder or note did nothing at all, and a folder created from the sidebar (which enters rename mode immediately) could never be named. Nothing threw, so no telemetry fired either.
+
+Two rules:
+
+1. When adding a row feature, grep both `notes-tree.tsx` and `virtualized-notes-tree.tsx`. Parent-owned state reaches the virtualized rows only if it is prop-drilled through `VirtualizedNotesTreeProps` → `FolderRow` / `NoteRow`.
+2. A virtualized row that is scrolled out of view **is not mounted**. State that expects a row to be on screen (rename mode, focus) must also reveal it — expand ancestors, then `virtualizer.scrollToIndex` on the next frame, the way `revealRow` does.
+
+Tests must exercise the real component: `notes-tree.test.tsx` pins `shouldVirtualize` to `false` **and** stubs `VirtualizedNotesTree`, so it can never catch this class of gap. `notes-tree-virtualized-rename.test.tsx` renders the real tree on both sides of the threshold; follow that shape.
+
 ## Editor-Zone Mousedown Handlers Steal Focus from BlockNote Menus
 
 BlockNote's shadcn menus (drag-handle menu, side menu, toolbars and their nested dropdowns) render **inline inside `.bn-container`, not portaled**. Any editor-zone mousedown handler — such as the "click the marquee zone to focus the editor at end" handler in `note.tsx` / `journal.tsx`, or the marquee selection hook — therefore also sees clicks on menu items. If such a handler focuses the editor on mousedown, the menu unmounts between `pointerdown` and `pointerup`, so the item's click never lands and the action silently does nothing (for example, drag-handle Colors/Delete appear to do nothing).


### PR DESCRIPTION
## The bug

Reported by adwamsley on 14 Aug against `v2026-08-11`: a newly created folder can't be renamed. Reproduced and root-caused on today's `main` — the released build and `main` are both affected.

`notes-tree.tsx` swaps components wholesale at `VIRTUALIZATION_THRESHOLD` (100 tree items). Below it, the plain tree renders an inline rename `<input>`. At or above it, `VirtualizedNotesTree` renders — and that component offered a "Rename" context-menu item that set `renamingFolderPath` / `renamingNoteId` while rendering **nothing that reads them**. It contained no `<input>` at all.

So above 100 items:

- Right-click → Rename on a folder or a note did nothing whatsoever.
- A folder created from the sidebar, which drops straight into rename mode (`handleCreateFolder`), could never be named. That is the reported symptom.

Nothing threw, which is why this was invisible: 90 days of `app_error_seen` telemetry carry **zero** `folder_rename_failed` events. `renameFolder` was simply never reached.

## The fix

- Thread the rename state and handlers that already exist in `useNoteTreeActions` into `VirtualizedNotesTree`, and render the same input its plain-tree twin does — same `aria-label`, same Enter/Escape/blur semantics, same self-focus-and-select ref.
- Entering rename mode now also expands ancestors and scrolls the row into view, reusing the existing `revealNote` machinery (extracted to a shared `revealRow`). Without this the fix would have been incomplete for the reported flow: an off-screen virtualized row is not mounted, and a new folder usually sorts outside the visible window.

Deliberately **not** done here: refactoring the row markup into a component both trees share. That is the right cleanup, but it widens the diff on a production bug fix. Same for `components/hooks/use-tree-rename.ts`, which is dead code (only its own test imports it) and misdirected the initial investigation — both are worth separate issues.

## Why no test caught it

`notes-tree.test.tsx` pins `shouldVirtualize` to `false` **and** stubs `VirtualizedNotesTree` out, so nothing in the suite ever ran the component users above the threshold actually get. `virtualized-notes-tree.test.tsx` tests that component in isolation, where rename state was never a prop, so there was nothing to assert.

`notes-tree-virtualized-rename.test.tsx` drives the real tree on both sides of the line:

| | |
|---|---|
| below the threshold | Rename opens an inline input |
| above the threshold | Rename opens an inline input too (folder) |
| above the threshold | …and for a note |
| above the threshold | entering rename mode scrolls the row into view |
| above the threshold | the input commits — `renameFolder('Projects', 'Renamed')` |

The first three failed before this change and pass after.

## Verification

- `notes-tree-virtualized-rename` + `virtualized-notes-tree` + `notes-tree` + `notes-tree-isolated` — **60 passed**
- `pnpm typecheck` — 17/17
- `pnpm lint` — 0 errors; changed files carry no new warnings
- `pnpm docs:impact --strict` — covered; `pnpm docs:build` green

Not yet exercised in a running app or E2E — the evidence above is renderer-level.