### PR TITLE
docs(crdt): the crdt_pull budget is 600/60s per device, not 300 shared

### DIFF
--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
@@ -403,8 +403,10 @@ describe('CrdtSyncCoordinator', () => {
 
   // A rate limit is what the desktop actually hits: the vault-wide sweep used to
   // fire two GETs per note, so 121 notes meant 242 requests in about four
-  // seconds against a limit of 300/60s shared with the account's other devices,
-  // and 92 of those notes came back "Too many requests".
+  // seconds against what was then a limit of 300/60s shared with the account's
+  // other devices, and 92 of those notes came back "Too many requests". The
+  // bucket is now 600/60s and keyed per device, but a large enough vault still
+  // reaches it, so the re-queue below is still what stops the data loss.
   const rateLimited = (): Error => {
     const err = new Error('Too many requests')
     err.name = 'RateLimitError'

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
@@ -973,9 +973,11 @@ describe('FullSyncRunner', () => {
   describe('#given a vault bigger than one chunk #when the sweep runs', () => {
     // The sweep is a catch-up, not a race. Fired all at once down the
     // single-note path it cost two GETs per note — 242 requests in about four
-    // seconds for a 121-note vault, against a server limit of 300 per 60s shared
-    // with the account's other devices — and 92 of those 121 notes came back
-    // "Too many requests" and silently kept their stale bodies.
+    // seconds for a 121-note vault, against what was then a limit of 300 per 60s
+    // shared with the account's other devices — and 92 of those 121 notes came
+    // back "Too many requests" and silently kept their stale bodies. That bucket
+    // is now 600 per 60s and per device, but the pacing still has to hold for
+    // vaults large enough to blow the wider ceiling.
     beforeEach(() => {
       vi.useFakeTimers()
     })
@@ -999,22 +1001,22 @@ describe('FullSyncRunner', () => {
     }
 
     it('#then the chunk size and interval stay inside BOTH server rate limits', () => {
-      // The server meters these two paths in separate buckets, and both are
-      // shared by every device on the account:
-      //   GET  /sync/crdt/snapshot/:noteId + /sync/crdt/updates -> 300 / 60s
+      // The server meters these two paths in separate buckets, both keyed by
+      // deviceId rather than by account (sync-server routes/sync.ts:476-501):
+      //   GET  /sync/crdt/snapshot/:noteId + /sync/crdt/updates -> 600 / 60s
       //   POST /sync/crdt/updates/batch                         ->  30 / 60s
       // A chunk of N notes costs N snapshot GETs (the batch endpoint batches the
       // incrementals, not the baselines) plus at least one batch POST, so tuning
       // either constant has to be checked against both ceilings — the batch
-      // bucket is ten times tighter and easy to miss.
+      // bucket is twenty times tighter and easy to miss.
       const chunksPerMinute = 60_000 / CRDT_SWEEP_CHUNK_INTERVAL_MS
       const snapshotGetsPerMinute = CRDT_SWEEP_CHUNK_NOTES * chunksPerMinute
       const batchPostsPerMinute = chunksPerMinute
 
-      // Two devices sweeping at once, and still room left for the record-change
-      // pull, pushes and attachment fetches drawing on the same buckets.
-      expect(snapshotGetsPerMinute * 2).toBeLessThan(300)
-      expect(batchPostsPerMinute * 2).toBeLessThan(30)
+      // No doubling for a second device: the buckets are per device, so a second
+      // device sweeping at the same time spends its own.
+      expect(snapshotGetsPerMinute).toBeLessThan(600)
+      expect(batchPostsPerMinute).toBeLessThan(30)
     })
 
     it('#then the whole sweep leaves through the batch path, never one pull per note', async () => {

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.ts
@@ -389,9 +389,12 @@ export class FullSyncRunner {
    * Everything leaves through the batch path rather than one
    * `pullCrdtForNote` per note. The single-note path costs two GETs per note, so
    * a 121-note sweep fired 242 requests in about four seconds against the
-   * server's `crdt_pull` bucket of 300 per 60s, shared with the account's other
-   * devices — 92 of those 121 notes came back "Too many requests" and, before
-   * the re-queue above, kept a stale body until the next sweep.
+   * server's `crdt_pull` bucket — then 300 per 60s and shared across the
+   * account's devices — and 92 of those 121 notes came back "Too many requests"
+   * and, before the re-queue above, kept a stale body until the next sweep.
+   * #1466 has since raised that bucket to 600 per 60s and keyed it per device,
+   * so that exact burst would fit today; the pacing stays because a vault twice
+   * the size still would not.
    *
    * Batching alone does not fix that; it only halves it, because the batch
    * endpoint batches the incrementals and not the per-note snapshot baselines.

--- a/apps/desktop/src/main/sync/engine/sync-context.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.ts
@@ -165,19 +165,27 @@ export const CRDT_RECONNECT_SWEEP_FLOOR_MS = 60 * 1000
 // There are TWO independent budgets, and a sweep has to fit inside both:
 //
 //   GET  /sync/crdt/snapshot/:noteId  }  one `crdt_pull` bucket,
-//   GET  /sync/crdt/updates           }  300 requests / 60 s
+//   GET  /sync/crdt/updates           }  600 requests / 60 s
 //   POST /sync/crdt/updates/batch        `crdt_batch_pull`, 30 requests / 60 s
 //
-// Both are shared by every device on the account. One chunk of N notes through
-// applyCrdtBatch costs N snapshot GETs — the batch endpoint batches the
-// incrementals, NOT the snapshot baselines, which are still fetched one note at
-// a time — plus at least one batch POST.
+// Both are keyed by deviceId, NOT by account (sync.ts:476-501), so a second
+// device sweeping at the same time spends its own budget instead of eating into
+// this one. One chunk of N notes through applyCrdtBatch costs N snapshot GETs —
+// the batch endpoint batches the incrementals, NOT the snapshot baselines,
+// which are still fetched one note at a time — plus at least one batch POST.
 //
 //   25 notes per chunk, 60_000 / 15_000 = 4 chunks per minute
-//   GET  budget: 25 x 4 = 100/min per sweeping device, 200 for two devices,
-//                against 300 — the binding constraint, ~30% spare
-//   POST budget:  1 x 4 =   4/min per sweeping device,   8 for two devices,
-//                against 30 — 7.5x headroom on a single device
+//   GET  budget: 25 x 4 = 100/min against 600 — 16.7% of the bucket
+//   POST budget:  1 x 4 =   4/min against  30 — 13.3% of the bucket
+//
+// The GET bucket is still the tighter of the two, but only just, and only when
+// the cadence is scaled: 600 GETs buy 24 chunks a minute at 25 notes each,
+// against the batch bucket's 30. Neither is close to binding at the current
+// pacing. These constants were derived when this comment read 300 and doubled
+// the cost for a second device, i.e. against an effective 150 — which is where
+// the old "~30% spare" came from. The real figure is a sixth of one bucket and
+// an eighth of the other. Re-tuning the pacing is its own change with its own
+// arithmetic; this note only records where the ceilings actually are.
 //
 // Only the RATE matters, not the total: a 1,000-note vault is 40 chunks and 40
 // batch POSTs, which would blow the 30/60s batch bucket if fired at once but is
@@ -196,8 +204,11 @@ export const CRDT_RECONNECT_SWEEP_FLOOR_MS = 60 * 1000
 // rate-limited batch re-queues its whole chunk for the next cycle instead of
 // dropping it.
 //
-// The GET headroom is not spare either — the record-change pull, pushes,
-// attachment fetches and the un-paced priority batch all draw on the same 300.
+// Not all of the GET headroom is spare: the un-paced priority batch and the
+// single-note pull path fetch snapshot baselines too, and those are `crdt_pull`
+// GETs on this same bucket. The record-change pull, record pushes and
+// attachment fetches are not — they meter under `sync_changes`, `sync_pull`,
+// `sync_push` and `crdt_push`, which are separate keys with separate budgets.
 export const CRDT_SWEEP_CHUNK_NOTES = 25
 export const CRDT_SWEEP_CHUNK_INTERVAL_MS = 15 * 1000
 export const PUSH_DEBOUNCE_MS = 2000

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -563,21 +563,23 @@ note in the vault at once. Down the one-note-at-a-time path that was two GETs pe
 121 notes meant 242 requests in about four seconds, and the server refused most of them.
 
 The sweep is therefore drained in chunks — `CRDT_SWEEP_CHUNK_NOTES` notes every
-`CRDT_SWEEP_CHUNK_INTERVAL_MS` — against **two independent server budgets**, both shared
-by every device on the account:
+`CRDT_SWEEP_CHUNK_INTERVAL_MS` — against **two independent server budgets**, both keyed by
+device rather than by account:
 
 | Endpoint                                                    | Bucket            | Limit      | Cost per chunk    |
 | ----------------------------------------------------------- | ----------------- | ---------- | ----------------- |
-| `GET /sync/crdt/snapshot/:noteId`, `GET /sync/crdt/updates` | `crdt_pull`       | 300 / 60 s | one GET per note  |
+| `GET /sync/crdt/snapshot/:noteId`, `GET /sync/crdt/updates` | `crdt_pull`       | 600 / 60 s | one GET per note  |
 | `POST /sync/crdt/updates/batch`                             | `crdt_batch_pull` | 30 / 60 s  | at least one POST |
 
-At 25 notes every 15 seconds that is 100 snapshot GETs and 4 batch POSTs per minute per
-sweeping device — 200 and 8 with two devices sweeping at once, inside both ceilings with
-room left for the record-change pull, pushes and attachment fetches, which draw on the
-same buckets. Only the _rate_ matters, not the total: a 1,000-note vault is 40 batch
-POSTs, which would blow the 30-per-minute bucket fired at once but is 4 per minute spread
-over the ten minutes the paced sweep takes. Cost per minute is constant in vault size;
-only the duration grows.
+At 25 notes every 15 seconds that is 100 snapshot GETs and 4 batch POSTs per minute —
+16.7 % of the pull bucket and 13.3 % of the batch bucket. Because both buckets are per
+device, a second device sweeping at the same time spends its own rather than eating into
+this one. The pull bucket is still the tighter of the two if the cadence is raised — 600
+GETs buy 24 chunks a minute at 25 notes each, against the batch bucket's 30 — but the
+sweep sits a sixth of the way into it, not against the edge. Only the _rate_ matters, not
+the total: a 1,000-note vault is 40 batch POSTs, which would blow the 30-per-minute bucket
+fired at once but is 4 per minute spread over the ten minutes the paced sweep takes. Cost
+per minute is constant in vault size; only the duration grows.
 
 The batch POST figure is a floor rather than an exact count, because a chunk loops while
 any of its notes still reports `hasMore`. That only binds on a first-sync backlog, and it


### PR DESCRIPTION
Closes #1507. Part of EPIC #1516.

`crdt_pull` is **600 / 60 s, keyed by `deviceIdentifier`** (`apps/sync-server/src/routes/sync.ts:489-494`, wired at `:824` and `:827`). Several places still documented it as 300 shared across the account's devices. Both halves of that were wrong, and they compounded: the sweep's cost was measured as 100 GETs/min doubled for a second device against 300 — i.e. against an effective 150 — which is where the old "~30% spare" came from.

`bae95d34b` (#1466) raised the limit and added per-device keying in one commit; the docs and comments only ever tracked the old shape.

## Five stale places, not the two in the issue

| where | what it was |
| --- | --- |
| `apps/docs/src/architecture/crdt.md:513` | table row `crdt_pull \| 300 / 60 s`, contradicting line 738 in the same file |
| `apps/desktop/src/main/sync/engine/sync-context.ts:168` | the comment read while reasoning about sweep pacing |
| `apps/desktop/src/main/sync/engine/full-sync-runner.ts:392` | "bucket of 300 per 60s, shared with the account's other devices" |
| `apps/desktop/src/main/sync/engine/full-sync-runner.test.ts:1004-1017` | **a live assertion**: `expect(snapshotGetsPerMinute * 2).toBeLessThan(300)` |
| `apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts:406` | same stale claim in a comment |

The test assertion is the one that mattered. It passed only because 200 < 300, while encoding both errors at once.

## Corrected arithmetic

```
25 notes per chunk, 60_000 / 15_000 = 4 chunks per minute
GET  budget: 25 x 4 = 100/min against 600 — 16.7% of the bucket
POST budget:  1 x 4 =   4/min against  30 — 13.3% of the bucket
```

The pull bucket is still the tighter of the two under cadence scaling — 600 GETs buy 24 chunks/min at 25 notes each, against the batch bucket's 30 — so it binds first if the cadence is raised, and is the only constraint if chunk size grows. Neither is close to binding today.

Also corrected an adjacent claim the wrong figure was propping up: that the record-change pull, pushes and attachment fetches draw on the same bucket. They do not — those meter under `sync_changes`, `sync_pull`, `sync_push` and `crdt_push`. Only the un-paced priority batch and the single-note pull path spend `crdt_pull`, via their snapshot baselines.

## Not in scope

**No pacing constant changed.** `CRDT_SWEEP_CHUNK_NOTES`, `CRDT_SWEEP_CHUNK_INTERVAL_MS` and `CRDT_RECONNECT_SWEEP_FLOOR_MS` are untouched. The constants were tuned against an effective 150 GETs/min and the real ceiling is 600, so there is roughly 6x more headroom than they were set for — that is worth its own issue with its own arithmetic, not a drive-by retune here.

## Verification

- `pnpm --filter @memry/desktop test:main` — 529 passed / 3 skipped files, 6807 passed / 1 expected fail / 6 skipped
- `pnpm typecheck` 17/17 · `pnpm lint` 0 errors · `pnpm docs:build` ok · `pnpm docs:impact --strict` covered · `git diff --check` clean
- Mutation check on the corrected assertion: `CRDT_SWEEP_CHUNK_NOTES` 25 -> 200 (mutation confirmed applied via `git diff --stat`) fails with `expected 800 to be less than 600`; restored, 53/53 green.