### PR TITLE
fix(sync): the pending-CRDT-note store survives a torn write instead of failing open

### DIFF
--- a/apps/desktop/src/main/sync/crdt-pending-notes.test.ts
+++ b/apps/desktop/src/main/sync/crdt-pending-notes.test.ts
@@ -3,7 +3,7 @@ import os from 'os'
 import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => ({ userDataDir: '' }))
+const mocks = vi.hoisted(() => ({ userDataDir: '', trackMainError: vi.fn() }))
 
 vi.mock('electron', () => ({
   app: { getPath: () => mocks.userDataDir }
@@ -18,15 +18,22 @@ vi.mock('../lib/logger', () => ({
   })
 }))
 
+vi.mock('../telemetry/diagnostics', () => ({
+  trackMainError: (...args: unknown[]) => mocks.trackMainError(...args)
+}))
+
 const storeFile = (): string => path.join(mocks.userDataDir, 'crdt-pending-notes.json')
+const corruptFile = (): string => path.join(mocks.userDataDir, 'crdt-pending-notes.corrupt.json')
 
 describe('crdt pending note store', () => {
   beforeEach(() => {
     mocks.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-crdt-pending-'))
+    mocks.trackMainError.mockClear()
   })
 
   afterEach(() => {
     fs.rmSync(mocks.userDataDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
     vi.resetModules()
   })
 
@@ -39,13 +46,133 @@ describe('crdt pending note store', () => {
     expect(readPendingCrdtNotes()).toEqual(['note-a', 'note-b', 'note-c'])
   })
 
-  it('returns an empty list when nothing was ever recorded or the file is corrupt', async () => {
+  it('returns an empty list when nothing was ever recorded', async () => {
     const { readPendingCrdtNotes } = await import('./crdt-pending-notes')
 
     expect(readPendingCrdtNotes()).toEqual([])
+    expect(mocks.trackMainError).not.toHaveBeenCalled()
+  })
 
-    fs.writeFileSync(storeFile(), '{ not json', 'utf8')
-    expect(readPendingCrdtNotes()).toEqual([])
+  it('reads a store written by an older build byte for byte, and writes one it can read back', async () => {
+    // Live beta: every install already has a plain crdt-pending-notes.json
+    // written by the pre-atomic writer. The format is the contract in both
+    // directions — an older build must still be able to read what this one
+    // leaves behind after an update is rolled back.
+    const { readPendingCrdtNotes, recordPendingCrdtNotes } = await import('./crdt-pending-notes')
+
+    fs.writeFileSync(storeFile(), JSON.stringify(['note-a', 'note-b']), 'utf8')
+
+    expect(readPendingCrdtNotes()).toEqual(['note-a', 'note-b'])
+    expect(fs.existsSync(corruptFile())).toBe(false)
+    expect(mocks.trackMainError).not.toHaveBeenCalled()
+
+    recordPendingCrdtNotes(['note-c'])
+    expect(JSON.parse(fs.readFileSync(storeFile(), 'utf8'))).toEqual(['note-a', 'note-b', 'note-c'])
+  })
+
+  it('salvages the ids a torn write left behind instead of reporting nothing pending', async () => {
+    // This is what a crash mid-write used to leave: a prefix of the JSON array.
+    // Every id before the cut is intact, and this file is the only record that
+    // those notes are owed to the server — the edits themselves are safe in the
+    // local CRDT store, but nothing else knows they were never pushed.
+    //
+    // The id the cut landed inside is genuinely gone: `"note-c` is a prefix, and
+    // a prefix is not an id. Two of three beats none of three.
+    const { readPendingCrdtNotes } = await import('./crdt-pending-notes')
+
+    fs.writeFileSync(storeFile(), '["note-a","note-b","note-c', 'utf8')
+
+    expect(readPendingCrdtNotes()).toEqual(['note-a', 'note-b'])
+  })
+
+  it('preserves an unreadable store and reports it, rather than dropping it with a warning', async () => {
+    const { readPendingCrdtNotes, recordPendingCrdtNotes } = await import('./crdt-pending-notes')
+
+    fs.writeFileSync(storeFile(), '["note-a","note-b","note-c', 'utf8')
+    recordPendingCrdtNotes(['note-d'])
+
+    // The damaged bytes are kept, not clobbered by the next write — the tail the
+    // salvage could not use is still there to be read by a human.
+    expect(fs.readFileSync(corruptFile(), 'utf8')).toBe('["note-a","note-b","note-c')
+    // ...and the salvage is repaired into the live file, so the next reader —
+    // clearPendingCrdtNotes at the tail of a drain — does not find it empty.
+    expect(readPendingCrdtNotes()).toEqual(['note-a', 'note-b', 'note-d'])
+    expect(mocks.trackMainError).toHaveBeenCalledWith(
+      'sync',
+      'crdt_pending_notes_corrupt',
+      expect.anything()
+    )
+  })
+
+  it('replays a salvaged store and still retains what it could not push', async () => {
+    // The drain reads the store, works, then reads it AGAIN through
+    // clearPendingCrdtNotes to remove only what reached the server. A salvage
+    // that lived in memory would be gone by that second read — the file has been
+    // moved aside — and the note that failed to push would be dropped, which is
+    // the same silent loss with an extra step. The salvage is repaired to disk.
+    const { drainPendingCrdtNotes, readPendingCrdtNotes } = await import('./crdt-pending-notes')
+
+    fs.writeFileSync(storeFile(), '["note-ok","note-offline","note-t', 'utf8')
+
+    const result = await drainPendingCrdtNotes({
+      isSyncable: () => true,
+      mergeRemote: async () => true,
+      pushSnapshot: async (noteId) => noteId === 'note-ok'
+    })
+
+    expect(result).toEqual({ cleared: 1, retained: 1 })
+    expect(readPendingCrdtNotes()).toEqual(['note-offline'])
+  })
+
+  it('keeps at most one preserved copy no matter how often the store is damaged', async () => {
+    // The recovery path must not become its own leak: this file is written on
+    // the edit path, so a timestamped copy per corruption would accumulate in
+    // userData forever on a device with a failing disk.
+    const { readPendingCrdtNotes } = await import('./crdt-pending-notes')
+
+    fs.writeFileSync(storeFile(), '["note-a', 'utf8')
+    readPendingCrdtNotes()
+    fs.writeFileSync(storeFile(), '["note-a","note-b', 'utf8')
+    readPendingCrdtNotes()
+
+    expect(fs.readdirSync(mocks.userDataDir).filter((name) => name.includes('corrupt'))).toEqual([
+      'crdt-pending-notes.corrupt.json'
+    ])
+    // The surviving copy is the newest, which is also the one that subsumes the
+    // earlier one: the read that moved that copy aside salvaged its ids forward.
+    expect(fs.readFileSync(corruptFile(), 'utf8')).toBe('["note-a","note-b')
+  })
+
+  it('leaves the previous list intact when a write is cut short', async () => {
+    // A full disk or a power cut mid-write. The live path must never hold a
+    // half-written list: the old bytes stand until a complete replacement is
+    // staged and renamed over them, so there is no window in which the store
+    // parses as "nothing pending".
+    const { readPendingCrdtNotes, recordPendingCrdtNotes } = await import('./crdt-pending-notes')
+    recordPendingCrdtNotes(['note-a', 'note-b'])
+
+    const realWriteFileSync = fs.writeFileSync
+    const spy = vi.spyOn(fs, 'writeFileSync').mockImplementationOnce(((
+      target: fs.PathOrFileDescriptor,
+      data: string
+    ) => {
+      // Half the bytes land, then the write dies — wherever it was aimed.
+      const half = data.slice(0, Math.floor(data.length / 2))
+      if (typeof target === 'number') fs.writeSync(target, half)
+      else realWriteFileSync(target, half, 'utf8')
+      const err = new Error('ENOSPC: no space left on device') as NodeJS.ErrnoException
+      err.code = 'ENOSPC'
+      throw err
+    }) as unknown as typeof fs.writeFileSync)
+
+    recordPendingCrdtNotes(['note-c'])
+    spy.mockRestore()
+
+    expect(readPendingCrdtNotes()).toEqual(['note-a', 'note-b'])
+    // Nothing was corrupt, so nothing was moved aside, and the failed attempt
+    // left no temp file behind.
+    expect(fs.existsSync(corruptFile())).toBe(false)
+    expect(fs.readdirSync(mocks.userDataDir).filter((name) => name.endsWith('.tmp'))).toEqual([])
   })
 
   it('clears only the notes whose state actually reached the server', async () => {

--- a/apps/desktop/src/main/sync/crdt-pending-notes.ts
+++ b/apps/desktop/src/main/sync/crdt-pending-notes.ts
@@ -1,11 +1,26 @@
+import { randomBytes } from 'crypto'
 import fs from 'fs'
 import path from 'path'
 import { app } from 'electron'
 import { createLogger } from '../lib/logger'
+import { trackMainError } from '../telemetry/diagnostics'
 
 const log = createLogger('CrdtPendingNotes')
 
 const FILE_NAME = 'crdt-pending-notes.json'
+
+/**
+ * Where an unreadable store is moved so the next write cannot clobber it.
+ *
+ * One fixed name rather than the `.corrupt-${Date.now()}` scheme used for the
+ * secret store: this file is written on the edit path, so a device that corrupts
+ * it repeatedly would accumulate copies in userData forever — a recovery
+ * mechanism that is its own leak. Rename overwrites, so there is at most one
+ * copy, and it is the newest one. That loses nothing: the read that moved a copy
+ * aside also salvaged its ids back into the live file, so a later copy already
+ * contains everything an earlier one contributed.
+ */
+const CORRUPT_FILE_NAME = 'crdt-pending-notes.corrupt.json'
 
 /**
  * Durable record of notes whose CRDT updates never reached the server.
@@ -32,6 +47,15 @@ function storePath(): string {
   return path.join(app.getPath('userData'), FILE_NAME)
 }
 
+function corruptStorePath(): string {
+  return path.join(app.getPath('userData'), CORRUPT_FILE_NAME)
+}
+
+/**
+ * The on-disk shape has never been anything but a JSON array of note ids, and
+ * this still reads exactly the file the pre-atomic writer produced — same path,
+ * same bytes. Only *how* the file is replaced changed.
+ */
 export function readPendingCrdtNotes(): string[] {
   let raw: string
   try {
@@ -42,23 +66,128 @@ export function readPendingCrdtNotes(): string[] {
   }
   try {
     const parsed: unknown = JSON.parse(raw)
-    if (!Array.isArray(parsed)) return []
-    return parsed.filter((id): id is string => typeof id === 'string' && id.length > 0)
+    if (Array.isArray(parsed)) {
+      return parsed.filter((id): id is string => typeof id === 'string' && id.length > 0)
+    }
   } catch (err) {
-    log.warn('Pending CRDT note store is unreadable, ignoring it', { error: err })
-    return []
+    return recoverCorruptStore(raw, err)
   }
+  // Parsed, but not the array this file has always held. Same treatment: it is
+  // not a shape any version of the writer produced, so it is damage, not a
+  // format to tolerate.
+  return recoverCorruptStore(raw, new Error('Pending CRDT note store is not a JSON array'))
+}
+
+/**
+ * Pull the note ids out of a store that no longer parses.
+ *
+ * A truncated JSON array — the shape a torn write leaves — still holds every
+ * complete `"id"` token before the cut, and those tokens are the entire content
+ * of this file. Returning `[]` instead would report "nothing was pending" for a
+ * device that has a backlog, which is the failure being fixed here: the edits
+ * themselves survive in the local CRDT store, but nothing would ever push them.
+ *
+ * Deliberately permissive about what counts as an id. A salvaged string that is
+ * not really a note id costs nothing — `drainOnce` asks `isSyncable` first and
+ * clears anything that does not resolve — while dropping a real id is silent and
+ * permanent.
+ */
+function salvageNoteIds(raw: string): string[] {
+  const ids = new Set<string>()
+  for (const [token] of raw.matchAll(/"(?:[^"\\]|\\.)*"/g)) {
+    try {
+      const value: unknown = JSON.parse(token)
+      if (typeof value === 'string' && value.length > 0) ids.add(value)
+    } catch {
+      // Not a complete JSON string after all; the cut landed inside an escape.
+    }
+  }
+  return Array.from(ids)
+}
+
+function recoverCorruptStore(raw: string, err: unknown): string[] {
+  const salvaged = salvageNoteIds(raw)
+  // Move the damaged bytes aside BEFORE rewriting the live path, so the two can
+  // never both hold a partial answer — and so a second read does not report the
+  // same corruption again forever.
+  try {
+    fs.renameSync(storePath(), corruptStorePath())
+  } catch (renameErr) {
+    log.error('Could not preserve the unreadable pending CRDT note store', { error: renameErr })
+  }
+  // Repair in place, not just in memory. `drainOnce` reads the store, works,
+  // then reads it *again* through `clearPendingCrdtNotes` to remove only what it
+  // managed to push; without writing the salvage back, that second read would
+  // find the file gone and drop every id the drain had not cleared yet.
+  if (salvaged.length > 0) writePendingCrdtNotes(salvaged)
+  log.error('Pending CRDT note store was unreadable; preserved it and salvaged what it held', {
+    error: err,
+    salvaged: salvaged.length
+  })
+  trackMainError('sync', 'crdt_pending_notes_corrupt', err)
+  return salvaged
 }
 
 function writePendingCrdtNotes(noteIds: string[]): void {
   try {
     if (noteIds.length === 0) {
+      // Unlink stays a plain unlink: it is already atomic, there is no state
+      // between "the file holds ids" and "there is no file", and "there is no
+      // file" is exactly what "nothing pending" has always meant here.
       fs.rmSync(storePath(), { force: true })
       return
     }
-    fs.writeFileSync(storePath(), JSON.stringify(noteIds), 'utf8')
+    writeStoreAtomically(JSON.stringify(noteIds))
   } catch (err) {
     log.error('Failed to write the pending CRDT note store', { error: err })
+    trackMainError('sync', 'crdt_pending_notes_write', err)
+  }
+}
+
+/**
+ * Write to a temp file in the SAME directory, then rename over the live path.
+ *
+ * Same directory is the whole point: `rename` is only atomic within a
+ * filesystem, so a temp under `os.tmpdir()` would degrade to a copy and put the
+ * torn write straight back. Rename replaces the target on all three platforms
+ * (libuv passes MOVEFILE_REPLACE_EXISTING on Windows).
+ *
+ * The temp name is random and opened `wx` with owner-only permissions: a
+ * predictable name in a user-writable directory is a symlink-swap target, and a
+ * leftover temp from a killed run must not be reused. Mirrors
+ * `writeCanvasFileSync`.
+ *
+ * **fsync is paid on purpose.** Rename alone is atomic against a *process*
+ * crash, but after a power cut a filesystem is free to have made the rename
+ * durable while the temp file's bytes are not — which lands exactly the
+ * truncated (or zero-length) live file this is meant to rule out, and this
+ * recorder exists precisely to survive that class of stop. The cost is bounded
+ * by the caller, not by typing speed: `CrdtProvider.recordUnqueuedUpdate`
+ * dedupes per note for the whole queue-less stretch, so this is one flush per
+ * note *touched*, and the payload is a JSON array of ids. On macOS this is
+ * `fsync`, not `F_FULLFSYNC` — Node exposes no way to ask for the latter — so it
+ * orders the bytes ahead of the rename without paying a full drive-cache flush.
+ */
+function writeStoreAtomically(contents: string): void {
+  const tmpPath = `${storePath()}.${randomBytes(6).toString('hex')}.tmp`
+  try {
+    // ONE exclusive handle for write + flush: reopening the path to fsync hands
+    // a window to anything that can swap it in between.
+    const fd = fs.openSync(tmpPath, 'wx', 0o600)
+    try {
+      fs.writeFileSync(fd, contents, 'utf8')
+      fs.fsyncSync(fd)
+    } finally {
+      fs.closeSync(fd)
+    }
+    fs.renameSync(tmpPath, storePath())
+  } catch (err) {
+    try {
+      fs.rmSync(tmpPath, { force: true })
+    } catch {
+      // Cleanup is best effort; the original error is what matters.
+    }
+    throw err
   }
 }
 

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -663,6 +663,30 @@ id has to survive a crash or a kill, and after the first update for a note there
 is nothing left to pay. `CrdtProvider.init()` clears the dedupe set, so the next
 queue-less stretch starts fresh.
 
+That write is **crash-atomic**, because a recorder whose whole purpose is to
+survive a crash cannot be the thing the crash truncates. The full list is staged
+in a fresh temp file in the same directory — `rename` is only atomic within a
+filesystem — flushed, then renamed over the live path, so the previous list
+stands until a complete replacement is in place and there is no moment where the
+store holds half a JSON array. The flush is one `fsync` per note touched, not per
+keystroke, which is what the per-note dedupe buys. Clearing the last id still
+unlinks the file: unlink is already atomic, and "no file" has always meant
+"nothing pending".
+
+A store that does not parse is **preserved, salvaged, and reported** rather than
+treated as an empty backlog. Failing open would be right for a cache; this file
+is the only record that a signed-out edit is owed to the server, so reading it as
+"nothing pending" discards that debt in silence. The damaged bytes are moved to
+`crdt-pending-notes.corrupt.json` — one fixed name, so a device with a failing
+disk cannot accumulate copies in userData forever — every complete `"id"` token
+still in them is recovered, and the recovered list is written back to the live
+store so the drain's second read (`clearPendingCrdtNotes`) does not find it gone.
+An id the damage landed inside is a prefix, not an id, and is lost; a recovered
+string that is not really a note id costs nothing, because the drain checks
+`isSyncable` before it pushes. The on-disk format is unchanged — a plain JSON
+array of note ids at the same path — so stores written by older builds read
+exactly as before.
+
 `startSyncRuntime` drains that store once, after `crdtProvider.init()` has
 installed the snapshot push function and after `engine.start()` has awaited the
 first full sync. Signing in runs `startSyncRuntime`, which is what makes a


### PR DESCRIPTION
Closes #1512. Part of EPIC #1516.

`crdt-pending-notes.json` is the **sole carrier** for a class of edit that exists nowhere else in recoverable form: a local edit made with no update queue — signed out, unpaid, or before the vault opens. `f89d23ed5` and `417013738` made it the mechanism that stops those edits being lost forever. It had two weaknesses for something that load-bearing, and they compounded into silent data loss.

1. **Non-atomic write** — a single `fs.writeFileSync` over the live file. A crash or power cut mid-write left truncated JSON. The recorder is deliberately synchronous *and on the edit path* precisely so the id is durable before a crash, so the durability it was buying was not actually being delivered.
2. **Failed open to `[]`** — an unparseable file was treated as "nothing pending" with a `log.warn`. Together: one torn write silently discarded every recorded signed-out edit on the device, and the only symptom was a warning nobody reads. The edits still sit in the local CRDT store, so they are not gone — but nothing would ever push them, which is the exact bug this file was added to fix.

## What changed

**Temp file + fsync + rename.** Temp lives in the same directory (`rename` is only atomic within a filesystem; an `os.tmpdir()` temp degrades to a copy and reintroduces the torn write). Opened `wx` with `0o600` under a random name — a predictable name in a user-writable directory is a symlink-swap target, and a leftover temp from a killed run must not be reused. One exclusive fd for write + flush, since reopening the path to fsync hands a window to anything that can swap it.

`fsync` is paid deliberately. Rename alone is atomic against a *process* crash, but after a power cut a filesystem may make the rename durable while the temp's bytes are not — landing exactly the truncated file this rules out, and power loss is the stop class this recorder exists to survive. Cost is bounded by the caller, not typing speed: `CrdtProvider.recordUnqueuedUpdate` dedupes per note for the whole queue-less stretch, so it is one flush per note *touched*, over a JSON array of ids.

**Salvage instead of fail-open.** A truncated array still holds every complete `"id"` token before the cut, and those tokens are the file's entire content. The reader extracts them, moves the damaged bytes aside, and **repairs the live file on disk** — not just in memory. That last part matters: `drainOnce` reads the store, works, then reads it *again* via `clearPendingCrdtNotes` to remove only what it pushed. An in-memory-only salvage would find the file moved aside on that second read and drop every note the drain had not yet cleared. That was a real regression found and closed with a test.

Salvage is permissive on purpose — `drainOnce` asks `isSyncable` first and clears anything that does not resolve, so a junk id costs one check while a dropped real id is silent and permanent.

**One fixed `crdt-pending-notes.corrupt.json`**, not the secret store's `.corrupt-${Date.now()}`: this file is written on the edit path, so a timestamped scheme lets a failing disk accumulate copies in userData forever — a recovery mechanism that is its own leak. Rename overwrites, so at most one copy exists and it is the newest, which subsumes any earlier one.

Corruption and write failure now go to `trackMainError` (`crdt_pending_notes_corrupt` / `_write`) rather than only a log line.

`fs.rmSync` on the empty list is kept: unlink is already atomic, and "no file" has always meant "nothing pending".

## Backward compatibility

On-disk format unchanged — same path, same plain JSON array of note ids. A store written by the pre-atomic writer reads byte for byte, and a store this build leaves behind is still readable by an older build after a rollback. Only *how* the file is replaced changed. Valid-JSON-but-not-an-array is now treated as damage rather than tolerated, which is safe because no version of the writer ever produced one. Guarded by a test.

## Verification

- `pnpm --filter @memry/desktop test:main` — 529 passed / 3 skipped files, 6813 passed / 1 expected fail / 6 skipped
- `pnpm typecheck` 17/17 · `pnpm lint` 0 errors · `pnpm docs:impact --strict` covered · `pnpm docs:build` ok · `git diff --check` clean
- 4 of the new tests fail against `origin/main`'s implementation. 8 mutations run, each proven applied by diffing against a pristine copy; 7 were killed. **M6 (dropping the `fsync`) survives** — power-loss durability is not observable from inside the process, so its justification is the reasoning above, not a test. Called out rather than papered over.
- Independent reviewer mutation (not run by the author): repair the disk correctly but `return []` to the caller — "report success while doing nothing" at the seam. Killed by 3 tests including the end-to-end drain.

## Known bound, not fixed here

A crash in the window between `openSync` and `renameSync` leaves one orphan `.tmp` in userData, and nothing sweeps them. The window is sub-millisecond and it is one file per crash-in-window, so this is noted rather than solved.