### PR TITLE
fix(sync): a snapshot push routes off the pruning endpoint for any note with unmerged server state

### DIFF
--- a/apps/desktop/src/main/sync/crdt-snapshot-endpoint-seam.test.ts
+++ b/apps/desktop/src/main/sync/crdt-snapshot-endpoint-seam.test.ts
@@ -1,0 +1,656 @@
+/**
+ * The seam, driven end to end.
+ *
+ * The #1503 fix spans four layers: `CrdtSyncCoordinator` decides a note's
+ * server state is unmerged, `SyncEngine.hasUnmergedRemoteCrdtState` carries
+ * that answer out, and `snapshotPushFn` in `runtime.ts` turns it into an
+ * endpoint — `/sync/crdt/updates` (appends, prunes nothing) instead of
+ * `/sync/crdt/snapshot` (whose `pruneUpdatesBeforeSnapshot` deletes every
+ * device's rows at or below the watermark).
+ *
+ * #1489 shipped a first revision where each half was tested against a mock of
+ * the other: `crdt-sync-coordinator.test.ts` asserts the flag is raised,
+ * `runtime.test.ts` asserts the endpoint given a flag through a stubbed
+ * `SyncEngine`, and a mutation that disabled the fix outright left every sync
+ * test green. So this file mocks nothing between the two: a REAL coordinator
+ * inside a REAL engine inside the REAL runtime, with a genuinely failing pull,
+ * asserted against which HTTP function the push actually called. Only the HTTP
+ * layer and the process-level infrastructure are mocked.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const runtimeMocks = vi.hoisted(() => {
+  class SyncServerError extends Error {
+    statusCode: number
+    constructor(statusCode: number, message = 'sync server error') {
+      super(message)
+      this.statusCode = statusCode
+    }
+  }
+
+  class SyncQueueManager {
+    static instances: SyncQueueManager[] = []
+    onItemEnqueued: (() => void) | null = null
+    constructor(public db: unknown) {
+      SyncQueueManager.instances.push(this)
+    }
+    setOnItemEnqueued = vi.fn((cb: () => void) => {
+      this.onItemEnqueued = cb
+    })
+  }
+
+  class CrdtUpdateQueue {
+    static instances: CrdtUpdateQueue[] = []
+    onBatch: ((noteId: string, updates: Uint8Array[]) => Promise<void>) | null = null
+    start = vi.fn((cb: (noteId: string, updates: Uint8Array[]) => Promise<void>) => {
+      this.onBatch = cb
+    })
+    pause = vi.fn()
+    resume = vi.fn()
+    stop = vi.fn()
+    constructor() {
+      CrdtUpdateQueue.instances.push(this)
+    }
+  }
+
+  class NetworkMonitor {
+    static instances: NetworkMonitor[] = []
+    online = true
+    listeners = new Map<string, (event: { online: boolean }) => void>()
+    start = vi.fn()
+    stop = vi.fn()
+    on = vi.fn((event: string, cb: (payload: { online: boolean }) => void) => {
+      this.listeners.set(event, cb)
+    })
+    removeListener = vi.fn((event: string, cb: (payload: { online: boolean }) => void) => {
+      if (this.listeners.get(event) === cb) this.listeners.delete(event)
+    })
+    constructor() {
+      NetworkMonitor.instances.push(this)
+      this.online = runtimeMocks.networkOnline
+    }
+  }
+
+  class WebSocketManager {
+    static instances: WebSocketManager[] = []
+    disconnect = vi.fn()
+    refreshAuth = vi.fn(async () => undefined)
+    constructor(public options: unknown) {
+      WebSocketManager.instances.push(this)
+    }
+  }
+
+  class SyncWorkerBridge {
+    static instances: SyncWorkerBridge[] = []
+    start = vi.fn(async () => {
+      if (runtimeMocks.workerStartError) throw runtimeMocks.workerStartError
+    })
+    stop = vi.fn(async () => undefined)
+    constructor() {
+      SyncWorkerBridge.instances.push(this)
+    }
+  }
+
+  const service = (name: string) => ({
+    init: vi.fn(() => ({ name })),
+    reset: vi.fn()
+  })
+
+  return {
+    SyncServerError,
+    SyncQueueManager,
+    CrdtUpdateQueue,
+    NetworkMonitor,
+    WebSocketManager,
+    SyncWorkerBridge,
+    taskSync: service('task'),
+    inboxSync: service('inbox'),
+    filterSync: service('filter'),
+    taskActivitySync: service('taskActivity'),
+    bookmarkSync: service('bookmark'),
+    reminderSync: service('reminder'),
+    templateSync: service('template'),
+    homePageSync: service('home_page'),
+    projectSync: service('project'),
+    settingsSync: service('settings'),
+    noteSync: service('note'),
+    journalSync: service('journal'),
+    tagDefinitionSync: service('tag_definition'),
+    tagCategorySync: service('tag_category'),
+    folderConfigSync: service('folder_config'),
+    calendarEventSync: service('calendar_event'),
+    calendarSourceSync: service('calendar_source'),
+    calendarBindingSync: service('calendar_binding'),
+    calendarExternalEventSync: service('calendar_external_event'),
+    networkOnline: true,
+    engineStartError: null as Error | null,
+    workerStartError: null as Error | null,
+    db: null as any,
+    indexRows: [] as Array<{ id: string; title: string; date: string | null }>,
+    currentDevice: { id: 'device-1', signingPublicKey: null as string | null },
+    getDatabase: vi.fn(),
+    getIndexDatabase: vi.fn(),
+    retrieveToken: vi.fn(),
+    getValidAccessToken: vi.fn(),
+    refreshAccessToken: vi.fn(),
+    retrieveKey: vi.fn(),
+    storeGet: vi.fn(),
+    getOrInitializeLocalVaultKey: vi.fn(),
+    getOrCreateVaultUuid: vi.fn(() => 'vault-1'),
+    deriveDevicePublicKey: vi.fn(),
+    secureCleanup: vi.fn(),
+    encryptCrdtUpdate: vi.fn(),
+    postToServer: vi.fn(),
+    pushCrdtSnapshot: vi.fn(),
+    pushCrdtFullUpdate: vi.fn(),
+    withRetry: vi.fn(async (fn: () => Promise<unknown>) => ({ value: await fn() })),
+    getFromServer: vi.fn(),
+    fetchCrdtSnapshot: vi.fn(),
+    trackMainError: vi.fn(),
+    emitSessionExpired: vi.fn(),
+    // token-manager keeps exactly one callback slot, and a refresh invokes
+    // whatever is in it. Model that instead of a bare spy so "who does a token
+    // refresh actually reach after teardown" is observable.
+    tokenRefreshedCallback: null as (() => void) | null,
+    setOnTokenRefreshed: vi.fn((cb: (() => void) | null) => {
+      runtimeMocks.tokenRefreshedCallback = cb
+    }),
+    trackMainEvent: vi.fn(),
+    logDebug: vi.fn(),
+    logInfo: vi.fn(),
+    logWarn: vi.fn(),
+    logError: vi.fn(),
+    recoverDirtyItems: vi.fn(),
+    createSyncAdapterRegistry: vi.fn((adapters: unknown[]) => adapters),
+    createCrdtSyncAdapter: vi.fn((type: string, options: unknown) => ({ type, options })),
+    getRemoteSyncAdapter: vi.fn((type: string) => ({ remote: type })),
+    getDeviceSigningKey: vi.fn(),
+    recordPendingCrdtNotes: vi.fn(),
+    drainPendingCrdtNotes: vi.fn(
+      async (_deps: {
+        mergeRemote: (noteId: string) => Promise<boolean>
+        pushSnapshot: (noteId: string) => Promise<boolean>
+        isSyncable: (noteId: string) => boolean
+      }) => ({ cleared: 0, retained: 0 })
+    ),
+    resetCrdtProvider: vi.fn(),
+    /** Notes the engine reports as holding server state it could not verify. */
+    unverifiedCrdtNotes: new Set<string>(),
+    syncGoogleCalendarSource: vi.fn(),
+    crdtProvider: {
+      init: vi.fn(),
+      seedExistingDocs: vi.fn(),
+      pushSnapshotForNote: vi.fn(),
+      pushAllSnapshots: vi.fn(),
+      destroy: vi.fn(),
+      // The surface the real CrdtSyncCoordinator drives. Y.Doc mechanics are
+      // not what this file is testing; which endpoint the push reaches is.
+      inactiveDocCapacity: 32,
+      getDoc: vi.fn(() => undefined),
+      open: vi.fn(async () => ({})),
+      closeIfInactive: vi.fn(async () => true),
+      applyRemoteUpdate: vi.fn(),
+      getStateVector: vi.fn(() => new Uint8Array([1, 2, 3, 4])),
+      seedFromMarkdownPublic: vi.fn(async () => undefined),
+      getOpenNoteIds: vi.fn(() => [])
+    },
+    browserSend: vi.fn(),
+    sodiumToBase64: vi.fn(() => 'derived-public-key'),
+    resolveEntitlementForSyncStart: vi.fn()
+  }
+})
+
+vi.mock('electron', () => ({
+  app: { getVersion: vi.fn(() => '1.2.3') },
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => [
+      {
+        isDestroyed: () => false,
+        webContents: { isDestroyed: () => false, send: runtimeMocks.browserSend }
+      }
+    ])
+  }
+}))
+
+vi.mock('libsodium-wrappers-sumo', () => ({
+  default: {
+    to_base64: runtimeMocks.sodiumToBase64,
+    base64_variants: { ORIGINAL: 'original' }
+  }
+}))
+
+vi.mock('@memry/sync-core', () => ({
+  createCrdtSyncAdapter: runtimeMocks.createCrdtSyncAdapter,
+  createSyncAdapterRegistry: runtimeMocks.createSyncAdapterRegistry
+}))
+
+vi.mock('../database', () => ({
+  getDatabase: runtimeMocks.getDatabase
+}))
+
+vi.mock('../database/client', () => ({
+  getIndexDatabase: runtimeMocks.getIndexDatabase
+}))
+
+vi.mock('../crypto', () => ({
+  getDevicePublicKey: runtimeMocks.deriveDevicePublicKey,
+  getOrInitializeLocalVaultKey: runtimeMocks.getOrInitializeLocalVaultKey,
+  retrieveKey: runtimeMocks.retrieveKey,
+  secureCleanup: runtimeMocks.secureCleanup
+}))
+
+vi.mock('../store', () => ({
+  store: {
+    get: runtimeMocks.storeGet
+  }
+}))
+
+vi.mock('../agent/storage/vault-id', () => ({
+  getOrCreateVaultUuid: runtimeMocks.getOrCreateVaultUuid
+}))
+
+vi.mock('../calendar/google/sync-service', () => ({
+  syncGoogleCalendarSource: runtimeMocks.syncGoogleCalendarSource
+}))
+
+vi.mock('../telemetry/track', () => ({
+  trackMainEvent: runtimeMocks.trackMainEvent
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    debug: (...args: unknown[]) => runtimeMocks.logDebug(...args),
+    info: (...args: unknown[]) => runtimeMocks.logInfo(...args),
+    warn: (...args: unknown[]) => runtimeMocks.logWarn(...args),
+    error: (...args: unknown[]) => runtimeMocks.logError(...args)
+  })
+}))
+
+vi.mock('./queue', () => ({ SyncQueueManager: runtimeMocks.SyncQueueManager }))
+vi.mock('./network', () => ({ NetworkMonitor: runtimeMocks.NetworkMonitor }))
+vi.mock('./websocket', () => ({ WebSocketManager: runtimeMocks.WebSocketManager }))
+/**
+ * The real SyncEngine, with only `start`/`stop` neutered.
+ *
+ * Those two bring up the websocket, the network monitor and a full sync — none
+ * of which the endpoint choice depends on, and all of which would drag half the
+ * process into this file. Everything the fix runs through — the coordinator it
+ * constructs, `mergeRemoteCrdtForNote`, `hasUnmergedRemoteCrdtState` — is the
+ * shipped implementation.
+ */
+vi.mock('./engine', async () => {
+  const actual = await vi.importActual<typeof import('./engine')>('./engine')
+  class TestSyncEngine extends actual.SyncEngine {
+    static instances: TestSyncEngine[] = []
+    constructor(deps: ConstructorParameters<typeof actual.SyncEngine>[0]) {
+      super(deps)
+      TestSyncEngine.instances.push(this)
+    }
+    async start(): Promise<void> {
+      if (runtimeMocks.engineStartError) throw runtimeMocks.engineStartError
+    }
+    async stop(): Promise<void> {}
+  }
+  return { SyncEngine: TestSyncEngine }
+})
+
+vi.mock('../telemetry/diagnostics', () => ({
+  trackMainError: runtimeMocks.trackMainError
+}))
+vi.mock('./worker-bridge', () => ({ SyncWorkerBridge: runtimeMocks.SyncWorkerBridge }))
+vi.mock('./crdt-queue', () => ({ CrdtUpdateQueue: runtimeMocks.CrdtUpdateQueue }))
+
+vi.mock('./task-sync', () => ({
+  initTaskSyncService: runtimeMocks.taskSync.init,
+  resetTaskSyncService: runtimeMocks.taskSync.reset
+}))
+vi.mock('./inbox-sync', () => ({
+  initInboxSyncService: runtimeMocks.inboxSync.init,
+  resetInboxSyncService: runtimeMocks.inboxSync.reset
+}))
+vi.mock('./filter-sync', () => ({
+  initFilterSyncService: runtimeMocks.filterSync.init,
+  resetFilterSyncService: runtimeMocks.filterSync.reset
+}))
+vi.mock('./task-activity-sync', () => ({
+  initTaskActivitySyncService: runtimeMocks.taskActivitySync.init,
+  resetTaskActivitySyncService: runtimeMocks.taskActivitySync.reset
+}))
+vi.mock('./bookmark-sync', () => ({
+  initBookmarkSyncService: runtimeMocks.bookmarkSync.init,
+  resetBookmarkSyncService: runtimeMocks.bookmarkSync.reset
+}))
+
+vi.mock('./template-sync', () => ({
+  initTemplateSyncService: runtimeMocks.templateSync.init,
+  resetTemplateSyncService: runtimeMocks.templateSync.reset
+}))
+vi.mock('./home-page-sync', () => ({
+  initHomePageSyncService: runtimeMocks.homePageSync.init,
+  resetHomePageSyncService: runtimeMocks.homePageSync.reset
+}))
+vi.mock('./reminder-sync', () => ({
+  initReminderSyncService: runtimeMocks.reminderSync.init,
+  resetReminderSyncService: runtimeMocks.reminderSync.reset
+}))
+vi.mock('./canvas-sync', () => ({
+  initCanvasSyncService: vi.fn(() => ({})),
+  resetCanvasSyncService: vi.fn(),
+  getCanvasSyncService: vi.fn(() => null)
+}))
+vi.mock('./canvas-folder-sync', () => ({
+  initCanvasFolderSyncService: vi.fn(() => ({})),
+  resetCanvasFolderSyncService: vi.fn(),
+  getCanvasFolderSyncService: vi.fn(() => null)
+}))
+vi.mock('./project-sync', () => ({
+  initProjectSyncService: runtimeMocks.projectSync.init,
+  resetProjectSyncService: runtimeMocks.projectSync.reset
+}))
+vi.mock('./settings-sync', () => ({
+  initSettingsSyncManager: runtimeMocks.settingsSync.init,
+  resetSettingsSyncManager: runtimeMocks.settingsSync.reset
+}))
+vi.mock('./note-sync', () => ({
+  initNoteSyncService: runtimeMocks.noteSync.init,
+  resetNoteSyncService: runtimeMocks.noteSync.reset
+}))
+vi.mock('./journal-sync', () => ({
+  initJournalSyncService: runtimeMocks.journalSync.init,
+  resetJournalSyncService: runtimeMocks.journalSync.reset
+}))
+vi.mock('./tag-definition-sync', () => ({
+  initTagDefinitionSyncService: runtimeMocks.tagDefinitionSync.init,
+  resetTagDefinitionSyncService: runtimeMocks.tagDefinitionSync.reset
+}))
+vi.mock('./tag-category-sync', () => ({
+  initTagCategorySyncService: runtimeMocks.tagCategorySync.init,
+  resetTagCategorySyncService: runtimeMocks.tagCategorySync.reset
+}))
+vi.mock('./folder-config-sync', () => ({
+  initFolderConfigSyncService: runtimeMocks.folderConfigSync.init,
+  resetFolderConfigSyncService: runtimeMocks.folderConfigSync.reset
+}))
+vi.mock('./calendar-event-sync', () => ({
+  initCalendarEventSyncService: runtimeMocks.calendarEventSync.init,
+  resetCalendarEventSyncService: runtimeMocks.calendarEventSync.reset
+}))
+vi.mock('./calendar-source-sync', () => ({
+  initCalendarSourceSyncService: runtimeMocks.calendarSourceSync.init,
+  resetCalendarSourceSyncService: runtimeMocks.calendarSourceSync.reset
+}))
+vi.mock('./calendar-binding-sync', () => ({
+  initCalendarBindingSyncService: runtimeMocks.calendarBindingSync.init,
+  resetCalendarBindingSyncService: runtimeMocks.calendarBindingSync.reset
+}))
+vi.mock('./calendar-external-event-sync', () => ({
+  initCalendarExternalEventSyncService: runtimeMocks.calendarExternalEventSync.init,
+  resetCalendarExternalEventSyncService: runtimeMocks.calendarExternalEventSync.reset
+}))
+
+vi.mock('./item-handlers', () => ({
+  getRemoteSyncAdapter: runtimeMocks.getRemoteSyncAdapter
+}))
+
+vi.mock('./device-keys', () => ({
+  getDeviceSigningKey: runtimeMocks.getDeviceSigningKey
+}))
+
+vi.mock('./crdt-provider', () => ({
+  getCrdtProvider: vi.fn(() => runtimeMocks.crdtProvider),
+  resetCrdtProvider: runtimeMocks.resetCrdtProvider
+}))
+
+vi.mock('./crdt-pending-notes', () => ({
+  recordPendingCrdtNotes: runtimeMocks.recordPendingCrdtNotes,
+  drainPendingCrdtNotes: runtimeMocks.drainPendingCrdtNotes
+}))
+
+vi.mock('./dirty-recovery', () => ({
+  recoverDirtyItems: runtimeMocks.recoverDirtyItems
+}))
+
+vi.mock('../billing/paddle-billing', () => ({
+  resolveEntitlementForSyncStart: (...args: unknown[]) =>
+    runtimeMocks.resolveEntitlementForSyncStart(...args)
+}))
+
+vi.mock('./crdt-encrypt', () => ({
+  encryptCrdtUpdate: runtimeMocks.encryptCrdtUpdate
+}))
+
+vi.mock('./http-client', () => ({
+  postToServer: runtimeMocks.postToServer,
+  pushCrdtSnapshot: runtimeMocks.pushCrdtSnapshot,
+  pushCrdtFullUpdate: runtimeMocks.pushCrdtFullUpdate,
+  // Mocking stops here: everything between these calls and the endpoint choice
+  // is the real code path.
+  getFromServer: runtimeMocks.getFromServer,
+  fetchCrdtSnapshot: runtimeMocks.fetchCrdtSnapshot,
+  SyncServerError: runtimeMocks.SyncServerError,
+  // runtime.ts → sync-errors.ts imports these; they only need to exist here.
+  NetworkError: class NetworkError extends Error {},
+  RateLimitError: class RateLimitError extends Error {},
+  AttachmentTooLargeError: class AttachmentTooLargeError extends Error {}
+}))
+
+vi.mock('./retry', () => ({
+  withRetry: runtimeMocks.withRetry,
+  // runtime.ts → sync-errors.ts imports this; the class itself is exercised in
+  // sync-errors.test.ts, here it only needs to exist.
+  DeadLetterError: class DeadLetterError extends Error {
+    constructor(public lastError: unknown) {
+      super('dead letter')
+    }
+  }
+}))
+
+vi.mock('./token-manager', () => ({
+  emitSessionExpired: runtimeMocks.emitSessionExpired,
+  getValidAccessToken: runtimeMocks.getValidAccessToken,
+  refreshAccessToken: runtimeMocks.refreshAccessToken,
+  retrieveToken: runtimeMocks.retrieveToken,
+  setOnTokenRefreshed: runtimeMocks.setOnTokenRefreshed
+}))
+
+vi.mock('./key-verification', () => ({
+  // 'unknown' = account verifier unavailable → runtime proceeds as before.
+  checkLocalKeyAgainstAccount: vi.fn().mockResolvedValue('unknown'),
+  isKeyMaterialActivityRecent: vi.fn().mockReturnValue(false)
+}))
+
+function createDb() {
+  const updateRun = vi.fn()
+  return {
+    updateRun,
+    db: {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            get: vi.fn(() => runtimeMocks.currentDevice)
+          }))
+        }))
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            run: updateRun
+          }))
+        }))
+      }))
+    }
+  }
+}
+
+function createIndexDb() {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          all: vi.fn(() => runtimeMocks.indexRows)
+        }))
+      }))
+    }))
+  }
+}
+
+async function loadRuntime() {
+  return import('./runtime')
+}
+
+describe('CRDT snapshot push endpoint choice, coordinator to wire', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    runtimeMocks.SyncQueueManager.instances = []
+    runtimeMocks.CrdtUpdateQueue.instances = []
+    runtimeMocks.NetworkMonitor.instances = []
+    runtimeMocks.WebSocketManager.instances = []
+    runtimeMocks.SyncWorkerBridge.instances = []
+    runtimeMocks.networkOnline = true
+    runtimeMocks.engineStartError = null
+    runtimeMocks.workerStartError = null
+    runtimeMocks.indexRows = [{ id: 'note-1', title: 'Note 1', date: null }]
+    runtimeMocks.currentDevice = { id: 'device-1', signingPublicKey: null }
+    runtimeMocks.db = createDb()
+    runtimeMocks.getDatabase.mockReturnValue(runtimeMocks.db.db)
+    runtimeMocks.getIndexDatabase.mockReturnValue(createIndexDb())
+    runtimeMocks.retrieveToken.mockResolvedValue('refresh-token')
+    runtimeMocks.storeGet.mockReturnValue({})
+    runtimeMocks.getValidAccessToken.mockResolvedValue('access-token')
+    runtimeMocks.getOrInitializeLocalVaultKey.mockResolvedValue(new Uint8Array([1, 2, 3]))
+    runtimeMocks.retrieveKey.mockResolvedValue(new Uint8Array([4, 5, 6]))
+    runtimeMocks.deriveDevicePublicKey.mockReturnValue(new Uint8Array([7, 8, 9]))
+    runtimeMocks.encryptCrdtUpdate.mockReturnValue(new Uint8Array([10, 11]))
+    runtimeMocks.postToServer.mockResolvedValue({ ok: true })
+    runtimeMocks.pushCrdtSnapshot.mockResolvedValue({ ok: true })
+    runtimeMocks.pushCrdtFullUpdate.mockResolvedValue({ ok: true })
+    runtimeMocks.crdtProvider.init.mockResolvedValue(undefined)
+    runtimeMocks.crdtProvider.seedExistingDocs.mockResolvedValue(1)
+    runtimeMocks.crdtProvider.pushSnapshotForNote.mockResolvedValue(undefined)
+    runtimeMocks.crdtProvider.pushAllSnapshots.mockResolvedValue(2)
+    runtimeMocks.crdtProvider.destroy.mockResolvedValue(undefined)
+    runtimeMocks.crdtProvider.getDoc.mockReturnValue(undefined)
+    runtimeMocks.crdtProvider.open.mockResolvedValue({})
+    runtimeMocks.crdtProvider.closeIfInactive.mockResolvedValue(true)
+    runtimeMocks.crdtProvider.getStateVector.mockReturnValue(new Uint8Array([1, 2, 3, 4]))
+    runtimeMocks.syncGoogleCalendarSource.mockResolvedValue(undefined)
+    runtimeMocks.resolveEntitlementForSyncStart.mockResolvedValue({
+      isPaid: true,
+      plan: 'plus',
+      status: 'active'
+    })
+    // No server snapshot for these notes — the state every note is in until its
+    // first snapshot lands, and the only window in which the prune is
+    // destructive (`storeSnapshot` freezes the watermark thereafter).
+    runtimeMocks.fetchCrdtSnapshot.mockResolvedValue(null)
+  })
+
+  async function bootRuntime(): Promise<{
+    engine: { mergeRemoteCrdtForNote: (noteId: string) => Promise<boolean> }
+    snapshotPush: (noteId: string, state: Uint8Array) => Promise<void>
+    stop: () => Promise<void>
+  }> {
+    const runtime = await loadRuntime()
+    await runtime.startSyncRuntime()
+    const engine = runtime.getSyncEngine()
+    if (!engine) throw new Error('sync runtime did not start')
+    return {
+      engine,
+      snapshotPush: runtimeMocks.crdtProvider.init.mock.calls[0][1] as (
+        noteId: string,
+        state: Uint8Array
+      ) => Promise<void>,
+      stop: () => runtime.stopSyncRuntime()
+    }
+  }
+
+  it('sends a note whose pull genuinely failed to the endpoint that prunes nothing', async () => {
+    const { engine, snapshotPush, stop } = await bootRuntime()
+
+    // #given the server sheds this note's incrementals. A rate-limited pull is
+    // the ordinary way step 2 of #1503 happens: the sweep's per-note baselines
+    // are the bulk of its requests and the first thing the server refuses, and
+    // `retryOn429: false` means the pass gives up rather than waiting it out.
+    runtimeMocks.getFromServer.mockRejectedValue(new runtimeMocks.SyncServerError(429))
+
+    // #when the real CrdtSyncCoordinator tries to merge, through the real
+    // SyncEngine, and cannot
+    await expect(engine.mergeRemoteCrdtForNote('note-unmerged')).resolves.toBe(false)
+
+    runtimeMocks.pushCrdtSnapshot.mockClear()
+    runtimeMocks.pushCrdtFullUpdate.mockClear()
+
+    // #and the 30s quiet period then asks for this note's full state
+    await snapshotPush('note-unmerged', new Uint8Array([1, 2, 3]))
+
+    // #then it must not reach /sync/crdt/snapshot. That route runs
+    // pruneUpdatesBeforeSnapshot, and with no snapshot stored yet the watermark
+    // is `currentSeq` — so it deletes EVERY crdt_updates row for the note,
+    // including the peer incrementals this device just failed to read. They
+    // would be gone from the server and absent from the snapshot replacing
+    // them: destroyed for every device.
+    expect(runtimeMocks.pushCrdtSnapshot).not.toHaveBeenCalled()
+    expect(runtimeMocks.pushCrdtFullUpdate).toHaveBeenCalledWith(
+      'note-unmerged',
+      new Uint8Array([10, 11]),
+      'access-token'
+    )
+
+    await stop()
+  })
+
+  it('still snapshots a note whose pull merged end to end', async () => {
+    const { engine, snapshotPush, stop } = await bootRuntime()
+
+    // #given the pull completes
+    runtimeMocks.getFromServer.mockResolvedValue({ updates: [], hasMore: false })
+
+    // #when
+    await expect(engine.mergeRemoteCrdtForNote('note-merged')).resolves.toBe(true)
+
+    runtimeMocks.pushCrdtSnapshot.mockClear()
+    runtimeMocks.pushCrdtFullUpdate.mockClear()
+    await snapshotPush('note-merged', new Uint8Array([1, 2, 3]))
+
+    // #then the safe route has to stay the exception. A predicate hard-wired to
+    // `true` would cost every note in the vault its compaction point and leave
+    // the server accumulating full-state rows forever, which is a real cost
+    // dressed up as a passing test.
+    expect(runtimeMocks.pushCrdtFullUpdate).not.toHaveBeenCalled()
+    expect(runtimeMocks.pushCrdtSnapshot).toHaveBeenCalledWith(
+      'note-merged',
+      new Uint8Array([10, 11]),
+      'access-token'
+    )
+
+    await stop()
+  })
+
+  it('returns the note to the snapshot endpoint once a later pass does merge it', async () => {
+    const { engine, snapshotPush, stop } = await bootRuntime()
+
+    // #given a pull that failed, so the note is routed away from the prune
+    runtimeMocks.getFromServer.mockRejectedValueOnce(new runtimeMocks.SyncServerError(429))
+    await engine.mergeRemoteCrdtForNote('note-retried')
+    await snapshotPush('note-retried', new Uint8Array([1, 2, 3]))
+    expect(runtimeMocks.pushCrdtFullUpdate).toHaveBeenCalledTimes(1)
+
+    // #when the next pass succeeds — the transient case, which is what a 429 or
+    // a briefly expired token looks like from here
+    runtimeMocks.getFromServer.mockResolvedValue({ updates: [], hasMore: false })
+    await expect(engine.mergeRemoteCrdtForNote('note-retried')).resolves.toBe(true)
+
+    runtimeMocks.pushCrdtSnapshot.mockClear()
+    runtimeMocks.pushCrdtFullUpdate.mockClear()
+    await snapshotPush('note-retried', new Uint8Array([1, 2, 3]))
+
+    // #then compaction resumes. A flag that only ever latched would be safe but
+    // permanently expensive: the note would never get a snapshot again for the
+    // life of the session.
+    expect(runtimeMocks.pushCrdtFullUpdate).not.toHaveBeenCalled()
+    expect(runtimeMocks.pushCrdtSnapshot).toHaveBeenCalledTimes(1)
+
+    await stop()
+  })
+})

--- a/apps/desktop/src/main/sync/engine-crdt.test.ts
+++ b/apps/desktop/src/main/sync/engine-crdt.test.ts
@@ -332,7 +332,7 @@ describe('SyncEngine', () => {
    * The wire between the two halves of the #1489 fix.
    *
    * `CrdtSyncCoordinator` raises the flag and the CRDT snapshot push fn reads it
-   * through `SyncEngine.hasUnverifiedRemoteCrdtUpdate` to pick an endpoint. Both
+   * through `SyncEngine.hasUnmergedRemoteCrdtState` to pick an endpoint. Both
    * halves had tests, and both suites stubbed the other side — so replacing the
    * engine method with `return false` disabled the entire fix in production and
    * left all 151 sync test files green. These drive a real coordinator, a real
@@ -360,9 +360,7 @@ describe('SyncEngine', () => {
 
       vi.spyOn(await import('./http-client'), 'fetchCrdtSnapshot').mockResolvedValue(null)
       vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
-        updates: [
-          { sequenceNum: 7, data: 'eA==', createdAt: 1, signerDeviceId: 'revoked-device' }
-        ],
+        updates: [{ sequenceNum: 7, data: 'eA==', createdAt: 1, signerDeviceId: 'revoked-device' }],
         hasMore: false
       })
 
@@ -372,7 +370,30 @@ describe('SyncEngine', () => {
 
       // #then a `return false` here sends the note back to /sync/crdt/snapshot,
       // whose pruneUpdatesBeforeSnapshot deletes the row that was just skipped.
-      expect(engine.hasUnverifiedRemoteCrdtUpdate('note-1')).toBe(true)
+      expect(engine.hasUnmergedRemoteCrdtState('note-1')).toBe(true)
+
+      vi.restoreAllMocks()
+    })
+
+    it('#then a `crdt_updated` broadcast marks the note before its pull runs', async () => {
+      const deps = createMockDeps(getDb(), {
+        crdtProvider: crdtProviderStub() as unknown as SyncEngineDeps['crdtProvider']
+      })
+      const engine = new SyncEngine(deps)
+
+      // #when the server tells this device a peer wrote the note. The handler is
+      // private and only bound inside `start()`, which brings up the socket, so
+      // this drives the branch directly rather than standing the socket up.
+      ;(engine as unknown as { handleWsMessage: (message: unknown) => void }).handleWsMessage({
+        type: 'crdt_updated',
+        payload: { noteId: 'note-ws' }
+      })
+
+      // #then the note is unmerged from this moment, not from whenever
+      // `scheduleSync` gets around to the pull. In between, the 30s snapshot
+      // scheduler would otherwise push a snapshot and prune the very update the
+      // broadcast announced — #1503 with the server itself as the witness.
+      expect(engine.hasUnmergedRemoteCrdtState('note-ws')).toBe(true)
 
       vi.restoreAllMocks()
     })
@@ -398,7 +419,7 @@ describe('SyncEngine', () => {
 
       // #then the safe route has to stay the exception — a bridge hard-wired to
       // `true` would cost every note in the vault its compaction point.
-      expect(engine.hasUnverifiedRemoteCrdtUpdate('note-2')).toBe(false)
+      expect(engine.hasUnmergedRemoteCrdtState('note-2')).toBe(false)
 
       vi.restoreAllMocks()
     })

--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -408,13 +408,14 @@ export class SyncEngine extends EventEmitter {
   }
 
   /**
-   * `true` when a merge pass left server state for this note out of the local
-   * doc because it could not verify the signer, so a snapshot push would delete
-   * or overwrite it. The CRDT snapshot push fn asks this before choosing an
-   * endpoint; see `CrdtSyncCoordinator.hasUnverifiedRemoteUpdate`.
+   * `true` when this device knows it has not merged the server's state for this
+   * note — an unverifiable signer, a failed or aborted pass, or a pull that is
+   * queued and has not run — so a snapshot push would delete or overwrite that
+   * state. The CRDT snapshot push fn asks this before choosing an endpoint; see
+   * `CrdtSyncCoordinator.hasUnmergedRemoteState`.
    */
-  hasUnverifiedRemoteCrdtUpdate(noteId: string): boolean {
-    return this.crdtSync.hasUnverifiedRemoteUpdate(noteId)
+  hasUnmergedRemoteCrdtState(noteId: string): boolean {
+    return this.crdtSync.hasUnmergedRemoteState(noteId)
   }
 
   async fullSync(): Promise<void> {
@@ -760,6 +761,13 @@ export class SyncEngine extends EventEmitter {
         if (this.ctx.fullSyncActive) {
           this.crdtSync.addPendingPull(noteId)
         } else {
+          // Marked before the pull is even scheduled. The broadcast is the
+          // server telling us a peer's state for this note is not in our doc,
+          // and `scheduleSync` may not run the callback for a while — that
+          // whole span is time in which the 30s snapshot scheduler would
+          // otherwise push a snapshot and prune the very update we were just
+          // told about. A clean pull clears it.
+          this.crdtSync.markRemoteStateUnmerged(noteId)
           // The merged/failed answer is the replay's concern; a broadcast-driven
           // pull that fails is already owed a retry by the coordinator.
           this.scheduleSync(async () => {

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
@@ -709,11 +709,7 @@ describe('CrdtSyncCoordinator', () => {
     const coordinator = new CrdtSyncCoordinator(ctx, resolveDeviceKey)
 
     // #when
-    const merged = await coordinator.applyCrdtIncrementals(
-      'note-1',
-      'token-1',
-      new Uint8Array([4])
-    )
+    const merged = await coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4]))
 
     // #then the pass still reports merged, so the pending-note replay is not
     // held back — an unresolvable signer can be permanent, and refusing to push
@@ -721,7 +717,7 @@ describe('CrdtSyncCoordinator', () => {
     // carried as a flag instead, and the push path answers it by choosing the
     // endpoint that does not prune.
     expect(merged).toBe(true)
-    expect(coordinator.hasUnverifiedRemoteUpdate('note-1')).toBe(true)
+    expect(coordinator.hasUnmergedRemoteState('note-1')).toBe(true)
     // And it is owed a pull, so a signer that was only transiently unresolvable
     // (an expired token, say) is retried rather than flagged forever.
     expect(coordinator.drainPendingPulls()).toEqual(['note-1'])
@@ -744,7 +740,7 @@ describe('CrdtSyncCoordinator', () => {
     // #then a snapshot push would overwrite the single R2 blob this pass just
     // declined to read — a larger loss than a pruned incremental, and equally
     // permanent.
-    expect(coordinator.hasUnverifiedRemoteUpdate('note-1')).toBe(true)
+    expect(coordinator.hasUnmergedRemoteState('note-1')).toBe(true)
   })
 
   it('flags only the batched note that skipped an unverifiable update', async () => {
@@ -774,8 +770,8 @@ describe('CrdtSyncCoordinator', () => {
     // #then the flag is per note. Flagging the whole chunk would push every
     // note in a sweep onto the non-pruning path and leave the server with no
     // compaction point anywhere in the vault.
-    expect(coordinator.hasUnverifiedRemoteUpdate('note-2')).toBe(true)
-    expect(coordinator.hasUnverifiedRemoteUpdate('note-1')).toBe(false)
+    expect(coordinator.hasUnmergedRemoteState('note-2')).toBe(true)
+    expect(coordinator.hasUnmergedRemoteState('note-1')).toBe(false)
   })
 
   it('clears the flag once a later pass verifies every signer', async () => {
@@ -787,13 +783,11 @@ describe('CrdtSyncCoordinator', () => {
     })
     decryptCrdtUpdateMock.mockReturnValue(new Uint8Array([7]))
     let signerResolves = false
-    const resolveDeviceKey = vi.fn(async () =>
-      signerResolves ? new Uint8Array([1, 2, 3]) : null
-    )
+    const resolveDeviceKey = vi.fn(async () => (signerResolves ? new Uint8Array([1, 2, 3]) : null))
     const coordinator = new CrdtSyncCoordinator(ctx, resolveDeviceKey)
 
     await coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4]))
-    expect(coordinator.hasUnverifiedRemoteUpdate('note-1')).toBe(true)
+    expect(coordinator.hasUnmergedRemoteState('note-1')).toBe(true)
 
     // #when the signer resolves on a later pass — the transient case, which is
     // what a missing access token or an un-refreshed device list looks like.
@@ -804,7 +798,7 @@ describe('CrdtSyncCoordinator', () => {
 
     // #then the note goes back to the snapshot path. A flag that only ever
     // latched would permanently cost this note its compaction point.
-    expect(coordinator.hasUnverifiedRemoteUpdate('note-1')).toBe(false)
+    expect(coordinator.hasUnmergedRemoteState('note-1')).toBe(false)
   })
 
   it('keeps the flag when a pass throws after skipping an unverifiable update', async () => {
@@ -826,7 +820,104 @@ describe('CrdtSyncCoordinator', () => {
     // #then the flag has to survive the throw. Computing it only at the end of
     // a clean pass would leave a note that skipped an update looking safe to
     // snapshot the moment anything later in the same pass failed.
-    expect(coordinator.hasUnverifiedRemoteUpdate('note-1')).toBe(true)
+    expect(coordinator.hasUnmergedRemoteState('note-1')).toBe(true)
+  })
+
+  /**
+   * #1503 — the general case of #1489. The flag is not "an unverifiable signer
+   * was skipped", it is "this device has not merged the server's state for this
+   * note", because that is the whole set of conditions under which a snapshot
+   * push asserts a completeness it does not have.
+   */
+  it('flags a note whose incrementals pull was rate-limited', async () => {
+    // #given the server sheds the pull — the routine way #1503 step 2 happens.
+    // The per-note baselines are the bulk of a sweep's requests and the first
+    // thing a rate limit takes, and `retryOn429: false` means the pass gives up
+    // rather than waiting it out.
+    const { ctx } = createBatchContext()
+    getFromServerMock.mockRejectedValue(rateLimited())
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4]))
+
+    // #then a snapshot push now would run pruneUpdatesBeforeSnapshot over rows
+    // this device never read. With no stored snapshot the watermark is
+    // `currentSeq`, so that is every row the note has.
+    expect(coordinator.hasUnmergedRemoteState('note-1')).toBe(true)
+  })
+
+  it('flags every note in a chunk whose batch pull failed', async () => {
+    // #given the chunk POST is refused, which takes every note in it
+    const { ctx } = createBatchContext()
+    postToServerMock.mockRejectedValue(rateLimited())
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.applyCrdtBatch(['note-1', 'note-2'], 'token-1', new Uint8Array([4]))
+
+    // #then both, unlike the unresolvable-signer case which is per note: here
+    // the failure really is the whole chunk's, so scoping it narrower would
+    // leave notes looking merged that were never fetched.
+    expect(coordinator.hasUnmergedRemoteState('note-1')).toBe(true)
+    expect(coordinator.hasUnmergedRemoteState('note-2')).toBe(true)
+  })
+
+  it('keeps a queued note flagged across the drain that hands it to the paced sweep', async () => {
+    // #given a note the vault sweep queued, or a `crdt_updated` broadcast named
+    const { ctx } = createBatchContext()
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+    coordinator.addPendingPull('note-1')
+
+    // #when the cycle drains the queue — `flushPendingCrdtPulls` empties it up
+    // front and then paces the actual pulls at 25 notes / 15s, so a large vault
+    // spends minutes here
+    expect(coordinator.drainPendingPulls()).toEqual(['note-1'])
+
+    // #then the note is in NEITHER pendingPulls nor a completed merge, and that
+    // gap is exactly where #1503 loses data: the user edits the note, the 30s
+    // scheduler fires, and the snapshot prunes updates whose pull has not run.
+    // Reading `pendingPulls` as the predicate would call this note safe.
+    expect(coordinator.hasUnmergedRemoteState('note-1')).toBe(true)
+  })
+
+  it('clears the flag once a pass merges the note end to end', async () => {
+    // #given a note flagged by a failed pull
+    const { ctx } = createBatchContext()
+    getFromServerMock.mockRejectedValueOnce(rateLimited())
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+    await coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4]))
+    expect(coordinator.hasUnmergedRemoteState('note-1')).toBe(true)
+
+    // #when the next pass completes
+    getFromServerMock.mockResolvedValue({ updates: [], hasMore: false })
+    await coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4]))
+
+    // #then compaction resumes. A flag that only latched would be safe and
+    // permanently expensive — the note would never be snapshotted again this
+    // session, so the server would keep every full-state row it ever received.
+    expect(coordinator.hasUnmergedRemoteState('note-1')).toBe(false)
+  })
+
+  it('does not clear the flag when a new pull is owed while the pass runs', async () => {
+    // #given a pass that walks the note cleanly, but a `crdt_updated` broadcast
+    // for the same note lands while its incrementals are in flight
+    const { ctx } = createBatchContext()
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+    getFromServerMock.mockImplementation(async () => {
+      coordinator.addPendingPull('note-1')
+      return { updates: [], hasMore: false }
+    })
+
+    // #when
+    await coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4]))
+
+    // #then the payload that broadcast announced is by definition not in the
+    // doc this pass just finished walking, so the pass may not call the note
+    // merged. Clearing on its own clean result alone reopens #1503 through the
+    // narrowest door in the file.
+    expect(coordinator.hasUnmergedRemoteState('note-1')).toBe(true)
+    getFromServerMock.mockReset()
   })
 
   it('does not seed from markdown when a doc was closed underneath the pass', async () => {

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -23,26 +23,45 @@ export class CrdtSyncCoordinator {
   /** Once per key per session — CRDT apply failures recur every pass and would storm otherwise. */
   private applyFailureReported = new Set<string>()
   /**
-   * Notes whose last pass left a server payload this device could not verify,
-   * because `resolveDeviceKey` had no public key for its signer.
+   * Notes this device knows it has NOT merged the server's state for.
    *
-   * Refusing to push at all is not an option: an unresolvable signer can be
-   * permanent — `GET /auth/devices` only lists non-revoked devices, so a
-   * revoked or deleted peer's key never comes back — and a note held back
-   * forever strands this device's own offline backlog forever. It is also not
-   * reliably transient: `getDeviceSigningKey` already refetches the device list
-   * on a cache miss, so the stale-list case largely self-heals and a `null`
-   * that survives that is more often permanent than not.
+   * A snapshot push is an assertion that the pushed doc contains everything the
+   * server holds: `storeSnapshot` overwrites the note's single R2 blob and
+   * `pruneUpdatesBeforeSnapshot` then deletes every `crdt_updates` row at or
+   * below the stored watermark — every device's rows, not just this one's. So
+   * the assertion is a lie for any note whose remote state this device has not
+   * actually taken in, and the peer edits it destroys are absent from the
+   * snapshot replacing them. That is #1503, and #1489 is one slice of it.
    *
-   * The signer key is only ever a *signature* check — the payload itself is
-   * sealed with a file key wrapped by the vault key (`crdt-encrypt.ts`) — so a
-   * skipped update still holds real, still-decryptable user content. Deleting
-   * it server-side is a real loss, not the disposal of already-dead bytes.
+   * Membership is therefore "known-unmerged", not "unverifiable signer":
    *
-   * So the note is flagged instead, and the push path routes it away from the
-   * snapshot endpoint, which is the only thing that prunes.
+   *   - a merge pass that skipped a payload whose signer could not be resolved
+   *     (#1489 — the payload is sealed with a file key wrapped by the vault
+   *     key, so the signer key is only ever a *signature* check and a skipped
+   *     update still holds recoverable user content);
+   *   - a merge pass that failed outright — rate-limited or failed baseline,
+   *     failed or dead-lettered incrementals, an aborted pass, missing token or
+   *     vault key, a doc that would not open;
+   *   - a note the server named in a `crdt_updated` broadcast, or that a
+   *     vault-wide sweep queued, before its pull has run.
+   *
+   * Refusing to push at all is not an option for any of them. An unresolvable
+   * signer can be permanent — `GET /auth/devices` only lists non-revoked
+   * devices, so a revoked peer's key never comes back — and an unmergeable note
+   * held back forever strands this device's own edits forever, trading a rare
+   * loss for a certain one. So the note is flagged instead and the push path
+   * routes it away from the snapshot endpoint, which is the only thing that
+   * prunes. `/sync/crdt/updates` stores and broadcasts the same doc state and
+   * prunes nothing.
+   *
+   * This is deliberately NOT `pendingPulls`. That set is emptied by
+   * `drainPendingPulls()` at the top of a cycle and refilled only when a pull
+   * fails, so a note is in it for neither the seconds nor the minutes it spends
+   * queued in the paced sweep and actually being pulled — precisely the window
+   * #1503 loses data in. This set is raised whenever a note enters `pendingPulls`
+   * and cleared only by a pass that walked the note end to end.
    */
-  private unverifiedRemoteNotes = new Set<string>()
+  private unmergedRemoteNotes = new Set<string>()
 
   constructor(ctx: SyncContext, resolveDeviceKey: ResolveDeviceKey) {
     this.ctx = ctx
@@ -51,6 +70,25 @@ export class CrdtSyncCoordinator {
 
   addPendingPull(noteId: string): void {
     this.pendingPulls.add(noteId)
+    // A note queued for a pull is by definition a note whose server state is
+    // not in the local doc yet. It stays flagged across the drain into the
+    // paced sweep queue and across the pull itself, because that whole span is
+    // time in which a snapshot push would prune rows this device never read.
+    this.markRemoteStateUnmerged(noteId)
+  }
+
+  /**
+   * Record that this note holds server state the local doc does not, without
+   * queueing a pull.
+   *
+   * For the `crdt_updated` broadcast that is pulled immediately rather than
+   * queued: the server has just named the note, so the state is unmerged from
+   * that moment until that pull completes cleanly. Going through
+   * `addPendingPull` there instead would buy the note a redundant second pull
+   * in the next sweep.
+   */
+  markRemoteStateUnmerged(noteId: string): void {
+    this.unmergedRemoteNotes.add(noteId)
   }
 
   /**
@@ -69,9 +107,13 @@ export class CrdtSyncCoordinator {
    * note in the pass on one rate-limited note. Nor is this failure-kind-specific
    * — a transient 5xx, an unreachable server and a 429 all leave the same stale
    * body, and "failed, so retry next cycle" needs no taxonomy to be correct.
+   *
+   * It also raises `unmergedRemoteNotes`, via `addPendingPull`: a failed merge
+   * is the state #1503 destroys data from, and the flag is what keeps the note's
+   * pushes off the pruning endpoint until a pass actually completes.
    */
   private owePendingPull(noteId: string): void {
-    this.pendingPulls.add(noteId)
+    this.addPendingPull(noteId)
   }
 
   drainPendingPulls(): string[] {
@@ -95,32 +137,37 @@ export class CrdtSyncCoordinator {
     this.pendingPulls.clear()
     this.lastAppliedSequence.clear()
     this.applyFailureReported.clear()
-    this.unverifiedRemoteNotes.clear()
+    this.unmergedRemoteNotes.clear()
   }
 
   /**
-   * Does this note hold server state this device merged around rather than into
-   * its doc?
+   * Does this note hold server state this device has not merged into its doc?
    *
    * `true` means a snapshot push for this note would destroy that state:
    * `storeSnapshot` overwrites the note's single R2 snapshot blob and
    * `pruneUpdatesBeforeSnapshot` then deletes every `crdt_updates` row at or
-   * below the stored watermark — including the row this device skipped, which
-   * is by definition absent from the snapshot replacing it. Pushing the same
-   * doc state to `/sync/crdt/updates` instead has neither effect.
+   * below the stored watermark — including the rows this device never read,
+   * which are by definition absent from the snapshot replacing them. Pushing
+   * the same doc state to `/sync/crdt/updates` instead has neither effect.
    */
-  hasUnverifiedRemoteUpdate(noteId: string): boolean {
-    return this.unverifiedRemoteNotes.has(noteId)
+  hasUnmergedRemoteState(noteId: string): boolean {
+    return this.unmergedRemoteNotes.has(noteId)
   }
 
   /**
-   * A pass is only allowed to clear the flag it did not raise. Skips are
-   * recorded the moment they happen and cleared only once a pass has walked a
-   * note end to end without one, so a pass that throws half-way leaves the
-   * conservative answer standing rather than a stale "safe".
+   * A pass is only allowed to clear the flag it did not raise. Skips and
+   * failures are recorded the moment they happen and cleared only once a pass
+   * has walked a note end to end without one, so a pass that throws half-way
+   * leaves the conservative answer standing rather than a stale "safe".
+   *
+   * `pendingPulls` is consulted too, and it closes the last window: something
+   * else — a `crdt_updated` broadcast, a sibling failure path — may have owed
+   * this note a pull while the pass was in flight, and that pull's payload is
+   * by definition not in the doc this pass just finished walking. Clearing on
+   * the pass's own clean result alone would call such a note safe to snapshot.
    */
-  private clearUnverifiedIfClean(noteId: string, sawUnverified: boolean): void {
-    if (!sawUnverified) this.unverifiedRemoteNotes.delete(noteId)
+  private clearUnmergedIfClean(noteId: string, sawUnmerged: boolean): void {
+    if (!sawUnmerged && !this.pendingPulls.has(noteId)) this.unmergedRemoteNotes.delete(noteId)
   }
 
   private rememberAppliedSequence(noteId: string, sequenceNum: number): number {
@@ -178,8 +225,13 @@ export class CrdtSyncCoordinator {
    * An update skipped for an unresolvable signer is deliberately NOT a `false`.
    * That skip can be permanent, so `false` would hold this note back forever and
    * trade a rare loss for a certain one. It is recorded in
-   * `unverifiedRemoteNotes` instead, and the push path answers it by sending the
+   * `unmergedRemoteNotes` instead, and the push path answers it by sending the
    * doc state to the incremental endpoint, which prunes nothing.
+   *
+   * Every `false` below is recorded there too. Failing closed only protects the
+   * one caller that reads the return value (the pending-note replay); the 30s
+   * snapshot scheduler and every other push path never see it, so the flag is
+   * what carries an incomplete merge to them.
    */
   async applyCrdtIncrementals(
     noteId: string,
@@ -196,18 +248,33 @@ export class CrdtSyncCoordinator {
     const wasOpen = crdtProvider.getDoc(noteId) != null
     try {
       const doc = await crdtProvider.open(noteId, undefined, { skipSeed: true })
-      if (!doc) return false
+      if (!doc) {
+        this.owePendingPull(noteId)
+        return false
+      }
+
+      // This pass IS the pull the note may already have been owed, so the debt
+      // is settled here rather than at the end. That is what lets
+      // `clearUnmergedIfClean` tell "still owed from before" from "owed again
+      // while this pass ran": a `crdt_updated` broadcast or a sibling failure
+      // landing mid-pass leaves an entry this pass did not put there, and the
+      // note stays flagged. Every failure path below re-owes it.
+      this.pendingPulls.delete(noteId)
 
       const baseline = await this.applySnapshotBaseline(noteId, token, vaultKey, 'single')
       let since = baseline.since
-      let sawUnverified = !baseline.verified
-      if (sawUnverified) this.unverifiedRemoteNotes.add(noteId)
+      let sawUnmerged = !baseline.verified
+      // Owed a pull as well as flagged, matching the batch path: a signer that
+      // was only transiently unresolvable then clears the flag on a later pass
+      // rather than costing this note its compaction point for the session.
+      if (sawUnmerged) this.owePendingPull(noteId)
 
       let hasMore = true
 
       while (hasMore) {
         if (effectiveSignal.aborted) {
           log.debug('applyCrdtIncrementals aborted', { noteId, lastSeq: since })
+          this.owePendingPull(noteId)
           return false
         }
 
@@ -253,8 +320,7 @@ export class CrdtSyncCoordinator {
             // Flagged before the loop can throw, and the note is owed another
             // pull: a signer that becomes resolvable (a token that was simply
             // expired here) clears the flag on the next pass.
-            sawUnverified = true
-            this.unverifiedRemoteNotes.add(noteId)
+            sawUnmerged = true
             this.owePendingPull(noteId)
             since = entry.sequenceNum
             continue
@@ -268,7 +334,7 @@ export class CrdtSyncCoordinator {
         hasMore = result.hasMore
       }
 
-      this.clearUnverifiedIfClean(noteId, sawUnverified)
+      this.clearUnmergedIfClean(noteId, sawUnmerged)
 
       const postVector = crdtProvider.getStateVector(noteId)
       if (!postVector || postVector.length <= 2) {
@@ -351,7 +417,16 @@ export class CrdtSyncCoordinator {
     const syncOpenedNoteIds = new Set<string>()
     // Per-pass record, so only a note this pass walked cleanly may have its
     // standing flag cleared at the end.
-    const sawUnverified = new Set<string>()
+    const sawUnmerged = new Set<string>()
+    // No `pendingPulls.delete` here, deliberately — the single-note path needs
+    // one and this does not. Every caller of this path (the priority pull and
+    // the paced sweep chunks) is handed notes that `drainPendingPulls()` has
+    // already emptied out of the set, so a note that IS in it at this point was
+    // put back by something running concurrently, and its payload is not in
+    // this chunk. Keeping the flag standing is the right answer there.
+    // `pullCrdtForNote` has no drain in front of it — the `crdt_updated`
+    // broadcast and the pending-note replay call it directly — so a note's own
+    // earlier debt would otherwise block its clear forever.
     try {
       const sinceMap = new Map<string, number>()
 
@@ -365,6 +440,10 @@ export class CrdtSyncCoordinator {
             noteId,
             error: err instanceof Error ? err.message : String(err)
           })
+          // Owed like every other failure in this pass. Without it this note is
+          // never retried, so the unmerged flag it is carrying never clears and
+          // it spends the rest of the session off the snapshot endpoint.
+          this.owePendingPull(noteId)
           continue
         }
 
@@ -372,8 +451,7 @@ export class CrdtSyncCoordinator {
           const baseline = await this.applySnapshotBaseline(noteId, token, vaultKey, 'batch')
           sinceMap.set(noteId, baseline.since)
           if (!baseline.verified) {
-            sawUnverified.add(noteId)
-            this.unverifiedRemoteNotes.add(noteId)
+            sawUnmerged.add(noteId)
             this.owePendingPull(noteId)
           }
         } catch (err) {
@@ -396,7 +474,12 @@ export class CrdtSyncCoordinator {
       const activeSince = new Map(sinceMap)
 
       while (activeSince.size > 0) {
-        if (signal.aborted) return
+        if (signal.aborted) {
+          // Same reason as the open failure above: the notes still in flight
+          // were never walked to the end, so they must stay owed and flagged.
+          for (const noteId of activeSince.keys()) this.owePendingPull(noteId)
+          return
+        }
 
         const notes = Array.from(activeSince, ([noteId, since]) => ({ noteId, since }))
 
@@ -437,8 +520,7 @@ export class CrdtSyncCoordinator {
               // Same reasoning as the single-note path: flag now so a throw
               // later in the chunk cannot leave a stale "safe to snapshot",
               // and owe the note a pull so a transient signer self-heals.
-              sawUnverified.add(noteId)
-              this.unverifiedRemoteNotes.add(noteId)
+              sawUnmerged.add(noteId)
               this.owePendingPull(noteId)
               activeSince.set(noteId, entry.sequenceNum)
               continue
@@ -454,13 +536,16 @@ export class CrdtSyncCoordinator {
         for (const [noteId] of activeSince) {
           if (!result.notes[noteId]) {
             log.warn('Server omitted noteId from batch response, removing', { noteId })
+            // Dropped without its updates ever arriving, so this pass did not
+            // walk it to the end and may not clear its flag.
+            sawUnmerged.add(noteId)
             activeSince.delete(noteId)
           }
         }
       }
 
       for (const noteId of sinceMap.keys()) {
-        this.clearUnverifiedIfClean(noteId, sawUnverified.has(noteId))
+        this.clearUnmergedIfClean(noteId, sawUnmerged.has(noteId))
       }
 
       // Seed only notes whose snapshot baseline succeeded. A note skipped at :205
@@ -513,11 +598,20 @@ export class CrdtSyncCoordinator {
   /** `false` = this note's server state was NOT fully merged; see `applyCrdtIncrementals`. */
   async pullCrdtForNote(noteId: string): Promise<boolean> {
     log.debug('pullCrdtForNote entered', { noteId })
+    // Owed on both misses, exactly as the group sibling does. This is the entry
+    // point a `crdt_updated` broadcast uses, so returning silently here left a
+    // note the server had just named unpulled, unflagged and unretried.
     const token = await this.ctx.deps.getAccessToken()
-    if (!token) return false
+    if (!token) {
+      this.owePendingPull(noteId)
+      return false
+    }
 
     const vaultKey = await this.ctx.deps.getVaultKey()
-    if (!vaultKey) return false
+    if (!vaultKey) {
+      this.owePendingPull(noteId)
+      return false
+    }
 
     const localAbort = new AbortController()
     try {

--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -69,7 +69,7 @@ const runtimeMocks = vi.hoisted(() => {
     stop = vi.fn(async () => undefined)
     requestPush = vi.fn()
     mergeRemoteCrdtForNote = vi.fn(async (_noteId: string) => true)
-    hasUnverifiedRemoteCrdtUpdate = vi.fn((noteId: string) =>
+    hasUnmergedRemoteCrdtState = vi.fn((noteId: string) =>
       runtimeMocks.unverifiedCrdtNotes.has(noteId)
     )
     constructor(public deps: Record<string, unknown>) {

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -642,32 +642,42 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
           // The snapshot endpoint is the only destructive one. `storeSnapshot`
           // overwrites the note's single R2 blob and `pruneUpdatesBeforeSnapshot`
           // then deletes every `crdt_updates` row at or below the stored
-          // watermark. That is correct when this device really does contain
-          // everything the server has — and a lie when a merge pass skipped a
-          // payload it could not verify, because that payload is by definition
-          // absent from the snapshot replacing it. It is then gone for every
-          // device, permanently, and the vault key that could still decrypt it
-          // no longer has anything to decrypt.
+          // watermark — every device's rows, not just this one's. That is
+          // correct when this device really does contain everything the server
+          // has, and a lie whenever it does not: a merge pass that skipped a
+          // payload it could not verify (#1489), and equally a pull that failed,
+          // was rate-limited, was aborted, or has simply not run yet for a note
+          // the server has already told us a peer wrote (#1503). The rows it
+          // deletes are by definition absent from the snapshot replacing them.
+          // They are then gone for every device, permanently, and the vault key
+          // that could still decrypt them no longer has anything to decrypt.
           //
-          // Failing closed instead — holding the note back until the signer
-          // resolves — is not available: `GET /auth/devices` lists only
-          // non-revoked devices, so a revoked peer's key never returns and the
-          // note would be held forever, stranding this device's own offline
-          // backlog. So the same doc state goes to the incremental endpoint,
-          // which stores and broadcasts it exactly like any other update and
-          // prunes nothing. This device's edits reach every peer; the skipped
-          // payload stays on the server for a later pass — or a later app
-          // version — to make sense of.
+          // Every one of those funnels through this single choke point, so the
+          // routing decision belongs here rather than at each caller: the 30s
+          // `CrdtSnapshotScheduler`, the pending-note replay, `close()`,
+          // `pushAllSnapshots`, `compactDoc` and the push coordinator all reach
+          // the server through this fn.
+          //
+          // Failing closed instead — holding the note back until it merges — is
+          // not available: `GET /auth/devices` lists only non-revoked devices,
+          // so a revoked peer's key never returns, and a device that is offline
+          // or rate-limited may not merge for a long time. Either way the note
+          // would be held indefinitely, stranding this device's own edits. So
+          // the same doc state goes to the incremental endpoint, which stores
+          // and broadcasts it exactly like any other update and prunes nothing.
+          // This device's edits reach every peer; the unmerged payload stays on
+          // the server for a later pass to take in.
           //
           // The incremental route has a size ceiling the snapshot's R2 blob does
-          // not (`pushCrdtFullUpdate` throws past it), which keeps that one
-          // note pending and retried — a stall, not a loss, since its content is
-          // already durable in the local CRDT store.
+          // not (`pushCrdtFullUpdate` throws past MAX_CRDT_UPDATE_PAYLOAD_CHARS),
+          // which keeps that one note pending and retried — a stall, not a loss,
+          // since its content is already durable in the local CRDT store, and it
+          // ends as soon as the note merges and the snapshot route reopens.
           //
           // `engine` is referenced lazily for the same reason
           // `replayPendingCrdtNotes` does: nothing invokes this fn between
           // `crdtProvider.init` below and the `const engine` assignment.
-          const viaUpdates = engine.hasUnverifiedRemoteCrdtUpdate(noteId)
+          const viaUpdates = engine.hasUnmergedRemoteCrdtState(noteId)
           await withRetry(
             () =>
               withAuthRetry(

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -739,58 +739,85 @@ note, both on the `crdt_pull` bucket (600 / 60 s per device). The pending list i
 tens of notes in practice, so ~40–50 GETs, alongside the paced sweep's 100/min —
 comfortably inside the budget, and no pacing is added.
 
-### An unverifiable signer routes the push away from the snapshot endpoint
+### Unmerged server state routes the push away from the snapshot endpoint
 
-Failing closed covers a pull that did not complete. It does **not** cover a pull
-that completed while stepping over something. Every apply path — the single-note
-incrementals loop, the batch chunk, and the snapshot baseline — verifies each
-payload's Ed25519 signature against its signer device's public key, and skips
-the payload when `resolveDeviceKey` returns no key for that device.
+Failing closed covers the one caller that reads a merge's return value — the
+pending-note replay. Nothing else does. The 30 s snapshot scheduler, `close()`,
+`pushAllSnapshots`, `compactDoc` and the push coordinator never see it, so a
+snapshot push can still assert a completeness this device does not have.
 
-Treating that skip as "not merged" would be wrong, because the skip can be
-**permanent**. `GET /auth/devices` returns only non-revoked devices, so once a
-peer device is revoked its key never comes back, and a note held back until the
-signer resolves would be held forever — stranding this device's own offline
-backlog. Nor can the client tell the two apart: `getDeviceSigningKey` already
-refetches the device list on a cache miss, so a surviving `null` carries no
-signal about whether it will ever clear.
+The condition that makes a push destructive is **known-unmerged server state**,
+not any one cause of it. `CrdtSyncCoordinator` keeps a per-note set,
+`unmergedRemoteNotes`, read through `hasUnmergedRemoteState` and surfaced as
+`SyncEngine.hasUnmergedRemoteCrdtState`. A note is in it when:
 
-Treating it as "merged" is what the fix replaces. It let the note's next
-snapshot push destroy the skipped payload: `storeSnapshot` upserts the note's
-one R2 blob, and `pruneUpdatesBeforeSnapshot` then deletes the `crdt_updates`
-rows the snapshot claims to contain — including the row the device could not
-verify and therefore could not have included. The signer key is only ever a
-signature check; the payload itself is sealed with a file key wrapped by the
-vault key, so what is deleted is still-decryptable user content.
+- a merge pass skipped a payload whose signer `resolveDeviceKey` could not
+  resolve;
+- a merge pass failed — a rate-limited or failed snapshot baseline, failed or
+  dead-lettered incrementals, an aborted pass, a missing token or vault key, a
+  doc that would not open;
+- the server named the note in a `crdt_updated` broadcast, or a vault-wide
+  sweep queued it, and its pull has not run yet.
 
-The endpoint is what resolves this. `pruneUpdatesBeforeSnapshot` has exactly one
-caller, `POST /sync/crdt/snapshot`. `POST /sync/crdt/updates` appends, prunes
-nothing, and wakes peers the same way. So:
+Every one of those is destructive at the same moment, and the moment is
+**before a note's first snapshot**. `storeSnapshot` computes
+`sequenceNum = existingSnapshot?.sequence_num ?? currentSeq`, so the watermark
+freezes at the first snapshot: the first prune deletes every row the note has,
+and every later one deletes nothing new. Until its first snapshot lands, every
+note is in that window.
 
-- `CrdtSyncCoordinator` records the notes a pass merged _around_
-  (`hasUnverifiedRemoteUpdate`, surfaced as
-  `SyncEngine.hasUnverifiedRemoteCrdtUpdate`).
-- The snapshot push fn sends those notes' full doc state through
-  `pushCrdtFullUpdate` — the same encrypted bytes, on the update endpoint —
-  instead of `pushCrdtSnapshot`.
+Failing closed is not available for any of them. `GET /auth/devices` returns
+only non-revoked devices, so once a peer is revoked its key never comes back and
+a note held until the signer resolves is held forever; a device that is offline
+or rate-limited may not merge for a long time either. Holding the note back
+strands this device's own edits to protect a peer's — a certain loss traded for
+a possible one. The client also cannot tell transient from permanent:
+`getDeviceSigningKey` already refetches the device list on a cache miss, so a
+surviving `null` carries no signal.
 
-Every push path inherits this, because they all funnel through that one
-function: the pending-note replay, the 30 s snapshot scheduler, the push
-coordinator's create-time snapshots, and the oversized-update fallback.
+Nor is a skipped payload dead bytes. The signer key is only ever a signature
+check; the payload itself is sealed with a file key wrapped by the vault key, so
+what a prune deletes is still-decryptable user content.
 
-The flag is per note and per pass. It is raised the moment a skip happens, so a
-failure later in the same pass cannot leave a stale "safe to snapshot", and it
-is cleared only by a pass that walks the note end to end without one. A skip
-also re-queues the note for a pull, so a transiently unresolvable signer — an
-expired access token is the case that actually occurs — clears the flag on the
-next pass and the note resumes normal compaction.
+The endpoint resolves it. `pruneUpdatesBeforeSnapshot` has exactly one caller,
+`POST /sync/crdt/snapshot`. `POST /sync/crdt/updates` appends, prunes nothing,
+and wakes peers the same way. So the snapshot push fn sends a flagged note's
+full doc state through `pushCrdtFullUpdate` — the same encrypted bytes, on the
+update endpoint — instead of `pushCrdtSnapshot`. Every push path inherits this,
+because they all funnel through that one function.
 
-One narrow cost: `pushCrdtFullUpdate` throws above
+The flag is deliberately **not** `pendingPulls`. That set is emptied by
+`drainPendingPulls()` at the top of a cycle and refilled only on failure, so a
+note is in it for neither the minutes it waits in the paced sweep queue (25
+notes / 15 s) nor the seconds it is actually being pulled — which is exactly the
+window the bug loses data in. `unmergedRemoteNotes` is instead raised whenever a
+note enters `pendingPulls` and cleared only by a pass that walked the note end
+to end. A pass settles its own debt up front, so an entry still standing at the
+end was raised _while_ the pass ran — a broadcast, a concurrent failure — and
+its payload is by definition not in the doc that pass walked, so the flag
+survives.
+
+Cost. Routing does not change the request count: both endpoints share the
+`crdt_push` bucket (300 / 60 s per device), one request either way. It changes
+what the server stores — a flagged push writes one full-state `crdt_updates` row
+instead of upserting one R2 blob, at most one per note per 30 s quiet period,
+and only for notes edited while flagged. For a note with no snapshot yet, every
+such row is reclaimed by the first unflagged snapshot push, which prunes at
+`currentSeq`. Pull cost rises by at most one 100-row page.
+
+One narrow failure mode: `pushCrdtFullUpdate` throws above
 `MAX_CRDT_UPDATE_PAYLOAD_CHARS`, because the update endpoint stores each payload
-in a D1 row rather than an R2 object. A note that is both over that ceiling and
-holding an unverifiable payload stays pending and retried rather than
-snapshotted. That is a stall, not a loss — its content is already durable in the
-local CRDT store — whereas snapshotting it would be a loss.
+in a D1 row rather than an R2 object. A flagged note over that ceiling stays
+pending and retried rather than snapshotted — a stall, not a loss, its content
+already durable in the local CRDT store — and it ends as soon as the note merges
+and the snapshot route reopens.
+
+The set is in-memory and per session; `clearCaches()` empties it on vault switch
+and teardown. A note whose pull failed in one session carries no flag in the
+next, and a restart does not necessarily re-flag it: `shouldSweepAllCrdtNotes`
+reads the _persisted_ `LAST_CRDT_SWEEP_AT`, so a restart inside the sweep
+interval with no reconnect gap sweeps nothing. Closing that would need the flag
+on disk, which is a new format and a migration.
 
 ## Sign-Out / Sign-In Ordering
 


### PR DESCRIPTION
Closes #1503. Part of EPIC #1516. Follow-up filed as #1532.

A snapshot push is an assertion that the pushed doc contains everything the server holds. `storeSnapshot` overwrites the note's single R2 blob and `pruneUpdatesBeforeSnapshot` then deletes every `crdt_updates` row at or below the stored watermark — **every device's rows, not just the pusher's**. So the assertion is a lie for any note whose remote state this device has not actually taken in, and the peer edits it destroys are absent from the snapshot replacing them.

`b640e7368` (#1489) fixed one slice: a merge pass that skipped a payload whose signer could not be resolved. But the general shape is broader — *any* snapshot push asserts a completeness the pushing device has not verified. The 30s quiet scheduler, `close()`, `pushAllSnapshots` and `compactDoc` all pushed with no pull first.

## The fix — widening the existing mechanism, not a parallel one

`snapshotPushFn` (`runtime.ts:623`) is already the single choke point every push path funnels through, and it already asks the engine which endpoint to use. Only the *predicate* changed:

- `unverifiedRemoteNotes` → `unmergedRemoteNotes`
- `hasUnverifiedRemoteUpdate` → `hasUnmergedRemoteState`
- `SyncEngine.hasUnverifiedRemoteCrdtUpdate` → `hasUnmergedRemoteCrdtState`

Routing is untouched, so `crdt-provider.ts`, `crdt-snapshot-scheduler.ts` and `push-coordinator.ts` are not in this diff.

Membership is now "known-unmerged": an unverifiable signer (#1489), **a merge pass that failed outright** (rate-limited or failed baseline, failed or dead-lettered incrementals, an aborted pass, missing token or vault key, a doc that would not open), and **a note queued for a pull that has not run yet**.

### Why not just read `pendingPulls`

This is the load-bearing decision. `drainPendingPulls()` empties that set at the top of a cycle and it refills only on failure — so a note is in it for neither the minutes it waits in the paced sweep queue (25 notes / 15 s) nor the seconds it is actually being pulled. That is precisely the window #1503 loses data in. The new set is raised whenever a note *enters* `pendingPulls` and cleared only by a pass that walked the note end to end.

`clearUnmergedIfClean` also requires `!pendingPulls.has(noteId)`, so a debt raised *while* a pass ran — a `crdt_updated` broadcast, a concurrent failure — keeps the flag, since that payload is by definition not in the doc the pass just walked. To keep that distinguishable from a note's own stale debt, `applyCrdtIncrementals` settles its own debt up front. `applyCrdtBatchChunk` deliberately does not: every caller of the batch path is handed notes `drainPendingPulls()` already emptied, so a note in the set at chunk start was put back by something concurrent.

Three failure paths that silently dropped a note are now owed a pull like their siblings (`pullCrdtForNote` with no token or vault key, a doc that will not open in a batch, an aborted batch chunk). Without those the flag they now carry could never clear and the note would leave the snapshot path for the whole session.

**Not fixed by failing closed** — that is the trap #1489 already rejected. An unresolvable or unmergeable state can be permanent, and a note held back forever strands this device's own edits forever, trading a rare loss for a certain one.

## Cost

- **Request rate unchanged.** Both endpoints register `crdtPushRateLimit` (`sync.ts:823,826`), 300/60 s per device. One request either way.
- **Rows.** A flagged push writes one full-state `crdt_updates` row instead of upserting one R2 blob — ~67 KB base64 for a 50 KB note — capped at one per note per 30 s quiet period, and only for notes edited while flagged. For a note with no snapshot yet, which is the population this fix exists for, every such row is reclaimed by the first unflagged snapshot push, which prunes at `currentSeq`.
- **Size ceiling.** `pushCrdtFullUpdate` throws above `MAX_CRDT_UPDATE_PAYLOAD_CHARS` (1.2M base64 chars); the R2 blob has no such cap. `pushSnapshotForNote` catches, restores `pendingSnapshotBytes` and returns `false`, so a flagged oversized note stalls and retries rather than losing anything, and it clears the moment the note merges. This is #1489's existing failure mode reaching more notes, not a new one.

**Compat:** no protocol, schema, contract or on-disk format change; nothing is persisted, so there is no migration. Both endpoints, payload shapes and request bodies already exist. An older client pulling a full-state update applies it as an ordinary Yjs update.

## Residual — #1532

The set is in-memory and per session. Quit with a note unmerged, reopen, edit it, and the 30s snapshot can still prune: `shouldSweepAllCrdtNotes` reads the persisted `LAST_CRDT_SWEEP_AT`, so a restart inside `CRDT_FULL_SWEEP_MIN_INTERVAL_MS` with no reconnect gap re-queues nothing. Narrower than #1503 but the same permanent loss. Closing it needs the flag on disk — new format plus migration — so it is filed as **#1532** rather than widened into this PR.

## Verification

- `pnpm --filter @memry/desktop test:main` — 530 passed / 3 skipped files, 6816 passed / 1 expected fail / 6 skipped
- `pnpm typecheck` 17/17 · `pnpm lint` 0 errors · `pnpm docs:impact --strict` covered · `pnpm docs:build` ok · `git diff --check` clean

**Seam coverage.** `crdt-snapshot-endpoint-seam.test.ts` runs a real `CrdtSyncCoordinator` inside a real `SyncEngine` (`importActual`, subclassed with only `start`/`stop` neutered) inside the real `startSyncRuntime`, mocking only HTTP. A 429 drives a genuine merge failure and the assertion is on which of `pushCrdtFullUpdate` / `pushCrdtSnapshot` was actually called — the thing #1489's two-halves-mocked-against-each-other tests could not do.

9 author mutations, each proven applied by `git diff --stat`; 8 killed. **M9 survived** — a `pendingPulls.delete` in the batch path — and on inspection it was making that path strictly less conservative for no benefit and would have wiped a concurrent priority pull's retry debt, so **the line was deleted rather than blessed with a test**.

Two independent reviewer mutations, both proven applied and both killed:
- `drainPendingPulls()` also clears the unmerged flags — i.e. reintroducing the rejected `pendingPulls` design. Killed by `keeps a queued note flagged across the drain that hands it to the paced sweep`.
- `viaUpdates = ... && false` — disabling the routing entirely. Killed 2 of 3 seam tests.