### PR TITLE
fix(sync): a local-only note's body no longer reaches the server via the CRDT path

### DIFF
--- a/apps/desktop/src/main/notes/runtime-effects.test.ts
+++ b/apps/desktop/src/main/notes/runtime-effects.test.ts
@@ -2,18 +2,31 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   initForNote: vi.fn(async () => ({}) as never),
-  enqueueLocalSyncCreate: vi.fn()
+  setNoteLocalOnly: vi.fn(),
+  enqueueLocalSyncCreate: vi.fn(),
+  enqueueLocalSyncUpdate: vi.fn(),
+  removePendingNoteSyncItems: vi.fn(),
+  recordPendingCrdtNotes: vi.fn(),
+  clearPendingCrdtNotes: vi.fn()
 }))
 
 vi.mock('../sync/crdt-provider', () => ({
-  getCrdtProvider: () => ({ initForNote: mocks.initForNote })
+  getCrdtProvider: () => ({
+    initForNote: mocks.initForNote,
+    setNoteLocalOnly: mocks.setNoteLocalOnly
+  })
+}))
+
+vi.mock('../sync/crdt-pending-notes', () => ({
+  recordPendingCrdtNotes: mocks.recordPendingCrdtNotes,
+  clearPendingCrdtNotes: mocks.clearPendingCrdtNotes
 }))
 
 vi.mock('../sync/local-mutations', () => ({
   enqueueLocalSyncCreate: mocks.enqueueLocalSyncCreate,
   enqueueLocalSyncDelete: vi.fn(),
-  enqueueLocalSyncUpdate: vi.fn(),
-  removePendingNoteSyncItems: vi.fn()
+  enqueueLocalSyncUpdate: mocks.enqueueLocalSyncUpdate,
+  removePendingNoteSyncItems: mocks.removePendingNoteSyncItems
 }))
 
 vi.mock('@memry/storage-data', () => ({ updateNoteMetadata: vi.fn() }))
@@ -25,7 +38,7 @@ vi.mock('../tasks/publisher', () => ({ createTasksPublisher: vi.fn() }))
 vi.mock('../lib/id', () => ({ generateId: vi.fn(() => 'generated-id') }))
 vi.mock('../telemetry/diagnostics', () => ({ trackMainError: vi.fn() }))
 
-import { syncNoteCreate } from './runtime-effects'
+import { setNoteLocalOnlyState, syncNoteCreate } from './runtime-effects'
 
 describe('syncNoteCreate', () => {
   beforeEach(() => {
@@ -65,5 +78,36 @@ describe('syncNoteCreate', () => {
 
     expect(mocks.enqueueLocalSyncCreate).toHaveBeenCalledWith('note', 'note-1')
     expect(mocks.initForNote).toHaveBeenCalledWith('note-1', { title: 'Title' }, ['alpha'])
+  })
+})
+
+describe('setNoteLocalOnlyState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('tells the CRDT provider, so an open doc stops pushing its body immediately', () => {
+    // The provider caches the flag per open doc — `onDocUpdate` runs per
+    // keystroke and cannot afford a database read — so without this the note
+    // keeps pushing until it is closed and reopened.
+    setNoteLocalOnlyState('note-1', true)
+
+    expect(mocks.setNoteLocalOnly).toHaveBeenCalledWith('note-1', true)
+    expect(mocks.removePendingNoteSyncItems).toHaveBeenCalledWith('note-1')
+    expect(mocks.clearPendingCrdtNotes).toHaveBeenCalledWith(['note-1'])
+    expect(mocks.recordPendingCrdtNotes).not.toHaveBeenCalled()
+  })
+
+  it('owes the server the whole body again when local-only is cleared', () => {
+    // The metadata `update` this raises carries `content: null`, and the push
+    // coordinator only pushes a CRDT snapshot for `operation === 'create'`. So
+    // without the pending record the note would resume syncing its metadata
+    // with its body frozen wherever the server last saw it.
+    setNoteLocalOnlyState('note-1', false)
+
+    expect(mocks.setNoteLocalOnly).toHaveBeenCalledWith('note-1', false)
+    expect(mocks.enqueueLocalSyncUpdate).toHaveBeenCalledWith('note', 'note-1')
+    expect(mocks.recordPendingCrdtNotes).toHaveBeenCalledWith(['note-1'])
+    expect(mocks.clearPendingCrdtNotes).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/main/notes/runtime-effects.ts
+++ b/apps/desktop/src/main/notes/runtime-effects.ts
@@ -4,6 +4,7 @@ import { updateNoteCache } from '@main/database/queries/notes'
 import { getDatabase, getIndexDatabase } from '../database'
 import { attachmentEvents } from '../sync/attachment-events'
 import { getCrdtProvider } from '../sync/crdt-provider'
+import { clearPendingCrdtNotes, recordPendingCrdtNotes } from '../sync/crdt-pending-notes'
 import {
   enqueueLocalSyncCreate,
   enqueueLocalSyncDelete,
@@ -76,6 +77,29 @@ export function emitNoteAttachmentSaved(noteId: string, diskPath: string): void 
   attachmentEvents.emitSaved({ noteId, diskPath })
 }
 
+/**
+ * Flip a note between "syncs" and "never leaves this device".
+ *
+ * Both feeds have to be told, and they are told differently. The record feed is
+ * pull-based — `buildNotePushPayload` and `seedUnclockedNotes` re-read
+ * `localOnly` every time they run — so it only needs its queue cleaned up here.
+ * The CRDT body feed is push-based: `onDocUpdate` fires per keystroke and reads
+ * a flag the provider cached when it opened the doc, so that flag has to be
+ * corrected in place or the note keeps pushing its body until it is closed and
+ * reopened.
+ *
+ * The two branches are deliberately symmetric about the durable pending-CRDT
+ * store, because turning the flag off is where a body could otherwise go
+ * missing for good. Nothing else pushes an existing note's body: the push
+ * coordinator's snapshot is gated on `operation === 'create'` and this raises an
+ * `update`, `buildSnapshotPayload` sends `content: null` for an update, and the
+ * vault sweep only pulls. So a note whose body stopped going up while it was
+ * local-only would sync its metadata again and leave its body frozen at the
+ * state the server last saw — divergence, and worse than the leak this closes.
+ * Recording it hands the whole doc to `drainPendingCrdtNotes`, which pulls and
+ * merges the server's state before pushing, and keeps the id until that push
+ * actually lands.
+ */
 export function setNoteLocalOnlyState(noteId: string, localOnly: boolean): void {
   updateNoteMetadata(getDatabase(), noteId, {
     localOnly,
@@ -84,9 +108,18 @@ export function setNoteLocalOnlyState(noteId: string, localOnly: boolean): void 
   // localOnly is sidecar-only state — keep the index cache in step too
   updateNoteCache(getIndexDatabase(), noteId, { localOnly })
 
+  // After both writes, so a doc opened concurrently resolves the same value.
+  getCrdtProvider()?.setNoteLocalOnly(noteId, localOnly)
+
   if (localOnly) {
     removePendingNoteSyncItems(noteId)
+    // The CRDT-side twin of the line above: a backlog owed to the server is not
+    // owed any more. Nothing is lost by dropping it — the updates themselves
+    // stay in the local store, and clearing the flag re-records the note, whose
+    // replay pushes full doc state and therefore supersedes them anyway.
+    clearPendingCrdtNotes([noteId])
   } else {
     enqueueLocalSyncUpdate('note', noteId)
+    recordPendingCrdtNotes([noteId])
   }
 }

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -81,6 +81,10 @@ const mocks = vi.hoisted(() => {
       { isDestroyed: ReturnType<typeof vi.fn>; webContents: { send: ReturnType<typeof vi.fn> } }
     >(),
     getNoteCacheById: vi.fn(),
+    updateNoteCache: vi.fn(),
+    updateNoteMetadata: vi.fn(),
+    enqueueLocalSyncUpdate: vi.fn(),
+    removePendingNoteSyncItems: vi.fn(),
     /** Overridden by the one test that needs a path a real `stat` can reach. */
     toAbsolutePath: vi.fn((path: string) => `/vault/${path}`),
     safeRead: vi.fn(),
@@ -168,8 +172,34 @@ vi.mock('../store', () => ({
 }))
 
 vi.mock('@main/database/queries/notes', () => ({
-  getNoteCacheById: (...args: unknown[]) => mocks.getNoteCacheById(...args)
+  getNoteCacheById: (...args: unknown[]) => mocks.getNoteCacheById(...args),
+  updateNoteCache: (...args: unknown[]) => mocks.updateNoteCache(...args)
 }))
+
+// Everything below stands up `setNoteLocalOnlyState` — the real toggle — so the
+// local-only suite can drive the whole chain rather than two mocks of each
+// other. Only the two databases and the record feed are faked; the provider and
+// the durable pending store on the other side of the seam are real. None of
+// these modules is reachable from crdt-provider.ts, so they are inert for every
+// other test in this file.
+vi.mock('../database', () => ({
+  getDatabase: () => mocks.dataDb,
+  getIndexDatabase: () => ({ kind: 'index-db' })
+}))
+vi.mock('@memry/storage-data', () => ({
+  updateNoteMetadata: (...args: unknown[]) => mocks.updateNoteMetadata(...args)
+}))
+vi.mock('./local-mutations', () => ({
+  enqueueLocalSyncCreate: vi.fn(),
+  enqueueLocalSyncDelete: vi.fn(),
+  enqueueLocalSyncUpdate: (...args: unknown[]) => mocks.enqueueLocalSyncUpdate(...args),
+  removePendingNoteSyncItems: (...args: unknown[]) => mocks.removePendingNoteSyncItems(...args)
+}))
+vi.mock('./attachment-events', () => ({ attachmentEvents: { emitSaved: vi.fn() } }))
+vi.mock('../tasks/domain', () => ({ createDesktopTasksDomain: vi.fn() }))
+vi.mock('../tasks/publisher', () => ({ createTasksPublisher: vi.fn() }))
+vi.mock('../lib/id', () => ({ generateId: vi.fn(() => 'generated-id') }))
+vi.mock('../telemetry/diagnostics', () => ({ trackMainError: vi.fn() }))
 
 vi.mock('../vault/notes', () => ({
   toAbsolutePath: (path: string) => mocks.toAbsolutePath(path)
@@ -234,6 +264,8 @@ import type { SnapshotPushFn } from './crdt-provider'
 // recorder and the replay meet on the same durable store, so both halves run
 // for real against the temp userData dir.
 import { drainPendingCrdtNotes, readPendingCrdtNotes } from './crdt-pending-notes'
+// The real toggle, so the local-only suite crosses the seam for real.
+import { setNoteLocalOnlyState } from '../notes/runtime-effects'
 
 mocks.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-crdt-'))
 
@@ -1566,6 +1598,239 @@ describe('CrdtProvider', () => {
       expect(readPendingCrdtNotes()).toEqual(['note-2'])
 
       await signedOut.destroy()
+    })
+  })
+
+  // The record feed has always honoured this — `seedUnclockedNotes` excludes
+  // `localOnly IS NOT 1`, and so does the offline clock — but the CRDT body
+  // path did not, so a note the user marked local-only went on pushing its
+  // *body* while its metadata stayed put. E2E-encrypted, so never a
+  // confidentiality breach, but "local-only" reads as a promise, and the UI hid
+  // the gap because the metadata genuinely did not sync.
+  describe('a local-only note', () => {
+    const pendingStoreFile = (): string => path.join(mocks.userDataDir, 'crdt-pending-notes.json')
+
+    const noteRow = (localOnly: boolean): Record<string, unknown> => ({
+      id: 'note-1',
+      path: 'notes/Note.md',
+      title: 'Note',
+      fileType: 'markdown',
+      localOnly
+    })
+
+    beforeEach(() => {
+      fs.rmSync(pendingStoreFile(), { force: true })
+    })
+
+    afterEach(() => {
+      fs.rmSync(pendingStoreFile(), { force: true })
+    })
+
+    it('never hands an edit to the update queue', async () => {
+      mocks.getNoteCacheById.mockReturnValue(noteRow(true))
+      createWindow(1)
+      const doc = await provider.open('note-1', 1, { skipSeed: true })
+
+      doc.getMap('meta').set('title', 'typed in a local-only note')
+
+      expect(queue.enqueue).not.toHaveBeenCalled()
+    })
+
+    it('records no CRDT backlog when there is no update queue to take the edit', async () => {
+      // The queue-less recorder exists to get a body to the server later. A
+      // local-only note owes the server nothing, so there is nothing to record.
+      mocks.getNoteCacheById.mockReturnValue(noteRow(true))
+      const signedOut = new CrdtProvider()
+      await signedOut.init()
+      const doc = await signedOut.open('note-1', undefined, { skipSeed: true })
+
+      doc.getMap('meta').set('title', 'typed while signed out')
+
+      expect(readPendingCrdtNotes()).toEqual([])
+      await signedOut.destroy()
+    })
+
+    it('refuses a snapshot push, from any caller', async () => {
+      mocks.getNoteCacheById.mockReturnValue(noteRow(true))
+
+      // The one push path reached for a note with no open doc — the pending
+      // replay and the push coordinator's create both land here.
+      expect(await provider.pushSnapshotForNote('note-1')).toBe(false)
+      expect(pushSnapshot).not.toHaveBeenCalled()
+    })
+
+    it('pushes no snapshot when its last editor closes, nor at shutdown', async () => {
+      // The debt is deliberately real — pendingSnapshotBytes counts what was
+      // written and not pushed, for every note — so these two doors have to
+      // refuse on the flag itself and nothing else can be doing the work.
+      mocks.getNoteCacheById.mockReturnValue(noteRow(true))
+      createWindow(1)
+      const doc = await provider.open('note-1', 1, { skipSeed: true })
+      doc.getMap('meta').set('title', 'typed in a local-only note')
+      expect(provider.getDocSizeMetrics()[0]!.pendingSnapshotBytes).toBeGreaterThan(0)
+
+      // Shutdown flush first: close() would otherwise consume the debt.
+      expect(await provider.pushAllSnapshots()).toBe(0)
+      await provider.close('note-1', 1)
+
+      expect(pushSnapshot).not.toHaveBeenCalled()
+    })
+
+    it('pushes no snapshot when the compaction pass reaches it', async () => {
+      // Third door, and the one that fires without any user action: the doc is
+      // editor-less by definition here, so nothing on screen hints at a push.
+      mocks.getNoteCacheById.mockReturnValue(noteRow(true))
+      const compactedDoc = new Y.Doc()
+      compactedDoc.getXmlFragment(CRDT_FRAGMENT_NAME).insert(0, [new Y.XmlText('compact')])
+      mocks.compactYDoc.mockReturnValue({
+        compacted: Y.encodeStateAsUpdate(compactedDoc),
+        savedBytes: 120
+      })
+
+      await provider.open('note-1', undefined, { skipSeed: true })
+      provider.updateMeta('note-1', { title: 'Needs compaction' })
+      await provider.compactDoc('note-1')
+
+      // Compaction itself still happens — it is a local win — and only the push
+      // is refused.
+      expect(pushSnapshot).not.toHaveBeenCalled()
+      expect(mocks.persistenceInstances[0].storeUpdate).toHaveBeenCalled()
+    })
+
+    it('still reaches the local doc, the local store, every window and the vault file', async () => {
+      // The whole point: editing is untouched. Nothing here may depend on a
+      // session, a plan or a network — only what leaves the machine changes.
+      mocks.getNoteCacheById.mockReturnValue(noteRow(true))
+      createWindow(1)
+      createWindow(2)
+      await provider.open('note-1', 1, { skipSeed: true })
+      await provider.open('note-1', 2, { skipSeed: true })
+
+      provider.applyIpcUpdate('note-1', makeRemoteUpdate('typed in a local-only note'), 1)
+
+      expect(provider.getDoc('note-1')!.getMap('meta').get('title')).toBe(
+        'typed in a local-only note'
+      )
+      expect(mocks.persistenceInstances[0].storeUpdate).toHaveBeenCalled()
+      expect(mocks.sent).toHaveLength(1)
+      expect(mocks.sent[0]).toMatchObject({
+        windowId: 2,
+        channel: CRDT_EVENTS.STATE_CHANGED,
+        payload: { noteId: 'note-1', origin: 'ipc' }
+      })
+      expect(mocks.scheduleWriteback).toHaveBeenCalledWith('note-1', expect.any(Y.Doc))
+    })
+
+    it('costs an ordinary note nothing', async () => {
+      mocks.getNoteCacheById.mockReturnValue(noteRow(false))
+      createWindow(1)
+      const doc = await provider.open('note-1', 1, { skipSeed: true })
+
+      doc.getMap('meta').set('title', 'typed in a syncing note')
+      expect(queue.enqueue).toHaveBeenCalledTimes(1)
+
+      await provider.close('note-1', 1)
+      expect(pushSnapshot).toHaveBeenCalledWith('note-1', expect.any(Uint8Array))
+    })
+
+    // Crosses the seam for real: the toggle is the shipped function, the flag
+    // is resolved by the shipped doOpen, the edit is a real Yjs transaction and
+    // the assertion is on what the update queue actually received. Both halves
+    // mocked against each other is exactly what nearly shipped a broken #1489.
+    it('starts pushing again the moment the real toggle clears it, with no reopen', async () => {
+      // #given the singleton the toggle reaches, not this suite's instance
+      const singleton = getCrdtProvider()
+      await singleton.init(queue as never, pushSnapshot)
+
+      // #and an index cache the toggle genuinely writes through
+      const row = noteRow(true)
+      mocks.getNoteCacheById.mockImplementation(() => row)
+      mocks.updateNoteCache.mockImplementation((...args: unknown[]) =>
+        Object.assign(row, args[2] as object)
+      )
+
+      createWindow(1)
+      const doc = await singleton.open('note-1', 1, { skipSeed: true })
+      doc.getMap('meta').set('title', 'written while local-only')
+      expect(queue.enqueue).not.toHaveBeenCalled()
+
+      // #when the user turns local-only off
+      setNoteLocalOnlyState('note-1', false)
+
+      // #then the very next keystroke goes up, without closing and reopening
+      doc.getMap('meta').set('title', 'written after un-toggling')
+      expect(queue.enqueue).toHaveBeenCalledTimes(1)
+      expect(queue.enqueue.mock.calls[0]![0]).toBe('note-1')
+
+      // #and the body written while it was local-only is not stranded. Nothing
+      // else would push it: the push coordinator's snapshot is gated on
+      // `operation === 'create'` and this raised an `update`, an update payload
+      // carries `content: null`, and the vault sweep only pulls — so an
+      // incremental carrying the last keystroke alone would leave every peer
+      // with a body frozen where the server last saw it.
+      expect(readPendingCrdtNotes()).toEqual(['note-1'])
+      const replayed = await drainPendingCrdtNotes({
+        mergeRemote: async () => true,
+        pushSnapshot: (noteId) => singleton.pushSnapshotForNote(noteId),
+        isSyncable: (noteId) => singleton.validateNoteForCrdt(noteId).ok
+      })
+
+      expect(replayed).toEqual({ cleared: 1, retained: 0 })
+      const received = new Y.Doc()
+      Y.applyUpdate(received, pushSnapshot.mock.calls.at(-1)![1])
+      expect(received.getMap('meta').get('title')).toBe('written after un-toggling')
+
+      await singleton.destroy()
+    })
+
+    it('hands its body to the merge-first replay when the toggle clears, not to a blind close()', async () => {
+      const singleton = getCrdtProvider()
+      await singleton.init(queue as never, pushSnapshot)
+      const row = noteRow(true)
+      mocks.getNoteCacheById.mockImplementation(() => row)
+      mocks.updateNoteCache.mockImplementation((...args: unknown[]) =>
+        Object.assign(row, args[2] as object)
+      )
+
+      createWindow(1)
+      const doc = await singleton.open('note-1', 1, { skipSeed: true })
+      doc.getMap('meta').set('title', 'written while local-only')
+
+      setNoteLocalOnlyState('note-1', false)
+      await singleton.close('note-1', 1)
+
+      // close() pushes blind — it never pulls first — and a snapshot asserts
+      // completeness, so the server prunes every incremental below it. A note
+      // that has just stopped being local-only is the population most likely to
+      // have diverged from a peer, so its body goes up through
+      // drainPendingCrdtNotes, which merges before it pushes.
+      expect(pushSnapshot).not.toHaveBeenCalled()
+      expect(readPendingCrdtNotes()).toEqual(['note-1'])
+      await singleton.destroy()
+    })
+
+    it('drops a CRDT backlog the server is no longer owed when the real toggle sets it', async () => {
+      // The CRDT twin of `removePendingNoteSyncItems`. Nothing is lost: the
+      // updates stay in the local store, and clearing the flag re-records the
+      // note, whose replay pushes full doc state and supersedes them.
+      const singleton = getCrdtProvider()
+      await singleton.init()
+
+      const row = noteRow(false)
+      mocks.getNoteCacheById.mockImplementation(() => row)
+      mocks.updateNoteCache.mockImplementation((...args: unknown[]) =>
+        Object.assign(row, args[2] as object)
+      )
+
+      const doc = await singleton.open('note-1', undefined, { skipSeed: true })
+      doc.getMap('meta').set('title', 'typed while signed out')
+      expect(readPendingCrdtNotes()).toEqual(['note-1'])
+
+      setNoteLocalOnlyState('note-1', true)
+
+      expect(readPendingCrdtNotes()).toEqual([])
+      expect(mocks.removePendingNoteSyncItems).toHaveBeenCalledWith('note-1')
+      await singleton.destroy()
     })
   })
 })

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -71,6 +71,25 @@ interface ActiveDoc {
   lastEncodedSize: number
   lastSizeCheckAt: number
   lastTouchedAt: number
+  /**
+   * "This note never leaves the device", cached off the index row at doOpen.
+   *
+   * Cached rather than read per update because the only reader that matters is
+   * `onDocUpdate`, which runs on every keystroke: a `getIndexDatabase()` lookup
+   * there would put a synchronous SQLite round-trip on the typing path. Opening
+   * a doc already pays an async store read plus (usually) a file stat, read and
+   * markdown parse, so one more primary-key SELECT there is noise.
+   *
+   * Kept in step by `setNoteLocalOnly`, which the note runtime calls from the
+   * same function that writes the flag to both databases. A doc that is closed
+   * when the toggle happens needs nothing: its next doOpen re-reads the row.
+   *
+   * Every path that would send this doc's bytes to the server reads it: the
+   * update-queue branch of `onDocUpdate`, and the three snapshot pushes in
+   * `close`, `pushAllSnapshots` and `compactDoc`. `pushSnapshotForNote` is
+   * reached for notes with no open doc at all and re-reads the row instead.
+   */
+  localOnly: boolean
   closing?: boolean
 }
 
@@ -290,7 +309,8 @@ export class CrdtProvider {
       pendingSnapshotBytes: 0,
       lastEncodedSize: 0,
       lastSizeCheckAt: 0,
-      lastTouchedAt: this.now()
+      lastTouchedAt: this.now(),
+      localOnly: this.resolveLocalOnly(noteId)
     }
     this.docs.set(noteId, entry)
 
@@ -301,6 +321,52 @@ export class CrdtProvider {
     await this.evictInactiveDocsIfNeeded()
 
     return doc
+  }
+
+  /**
+   * Read the note's "never leaves this device" flag off the index row.
+   *
+   * Falls back to "not local-only" when the row cannot be read at all — an
+   * index database that is closed or missing, which `doOpen` can hit on the
+   * `skipSeed` path that otherwise never touches it. That is the behaviour this
+   * provider has always had, so an unreadable row costs sync nothing; the
+   * authoritative check for the payload that actually carries a body — the
+   * snapshot — re-reads the row live in `pushSnapshotForNote`.
+   */
+  private resolveLocalOnly(noteId: string): boolean {
+    try {
+      return getNoteCacheById(getIndexDatabase(), noteId)?.localOnly === true
+    } catch (err) {
+      log.warn('Could not read the local-only flag for a note; treating it as syncable', {
+        noteId,
+        error: err
+      })
+      return false
+    }
+  }
+
+  /**
+   * Point the open doc's cached flag at the value both databases now hold.
+   *
+   * Called by `setNoteLocalOnlyState` — the single place the toggle is written
+   * — immediately after the two writes, so a doc opened concurrently and this
+   * doc agree. A note with no open doc needs nothing: `doOpen` re-reads.
+   *
+   * Either direction also hands the doc's snapshot debt to the pending-note
+   * replay, by clearing it here. Clearing it going ON is obvious. Going OFF
+   * matters more: `setNoteLocalOnlyState` records the note for
+   * `drainPendingCrdtNotes`, which pulls and merges the server's state before
+   * it pushes, and a note that has just stopped being local-only is precisely
+   * the population most likely to have diverged from a peer. Leaving the debt
+   * would let the next `close()` fire a *blind* snapshot first — and a snapshot
+   * asserts completeness, so the server prunes the peer edits it does not
+   * contain. The replay is the carrier for this body; close() must not race it.
+   */
+  setNoteLocalOnly(noteId: string, localOnly: boolean): void {
+    const entry = this.docs.get(noteId)
+    if (!entry) return
+    entry.localOnly = localOnly
+    entry.pendingSnapshotBytes = 0
   }
 
   async close(noteId: string, windowId?: number): Promise<void> {
@@ -316,7 +382,7 @@ export class CrdtProvider {
 
     this.flushNetworkBroadcast(noteId)
 
-    if (this.snapshotPushFn && entry.pendingSnapshotBytes > 0) {
+    if (this.snapshotPushFn && entry.pendingSnapshotBytes > 0 && !entry.localOnly) {
       const state = Y.encodeStateAsUpdate(entry.doc)
       await this.snapshotPushFn(noteId, state).catch((err) => {
         log.warn('Failed to push snapshot on close', { noteId, error: err })
@@ -549,6 +615,7 @@ export class CrdtProvider {
 
     let pushed = 0
     for (const [noteId, entry] of this.docs) {
+      if (entry.localOnly) continue
       if (entry.pendingSnapshotBytes <= 0) continue
       try {
         const state = Y.encodeStateAsUpdate(entry.doc)
@@ -574,6 +641,19 @@ export class CrdtProvider {
         noteId,
         fileType: cached.fileType
       })
+      return false
+    }
+
+    // The row is already in hand, so the authoritative read costs nothing here
+    // — and this is the one push path that is reached for a note with no open
+    // doc (the pending-note replay, and the push coordinator's create), so it
+    // cannot lean on the per-doc cached flag.
+    //
+    // `false` is honest to both callers: the replay reads it as "not settled"
+    // and keeps the id, which is what a note that may be un-toggled later wants
+    // — a `true` here would be the provider claiming a push it refused to make.
+    if (cached?.localOnly) {
+      log.debug('Skipping CRDT snapshot push for a local-only note', { noteId })
       return false
     }
 
@@ -775,6 +855,11 @@ export class CrdtProvider {
     if (!entry) return
 
     this.touchDoc(entry)
+    // Both counters stay honest for a local-only note. accumulatedBytes drives
+    // local compaction, which a local-only doc needs like any other; and
+    // pendingSnapshotBytes means "written locally, not yet on the server", which
+    // is exactly true here. Suppressing the debt would make the guards below
+    // read as redundant when they are the only thing holding the body back.
     entry.accumulatedBytes += update.byteLength
     if (origin !== ORIGIN_NETWORK) {
       entry.pendingSnapshotBytes += update.byteLength
@@ -791,7 +876,14 @@ export class CrdtProvider {
     this.persistUpdate(noteId, update)
     this.maybeCompact(noteId)
 
-    if (origin !== ORIGIN_NETWORK) {
+    // Everything above this line is local — the doc, the local CRDT store, the
+    // window broadcast, the markdown write-back scheduled below — and stays
+    // exactly the same for a local-only note. This is the only branch that
+    // sends bytes off the machine, and it is the one the record feed already
+    // refuses for the same notes (`seedUnclockedNotes`, `offline-clock`).
+    // Recording the note for later replay is skipped for the same reason the
+    // push is: the pending store exists to get a body to the server.
+    if (origin !== ORIGIN_NETWORK && !entry.localOnly) {
       if (this.updateQueue) {
         this.updateQueue.enqueue(noteId, update)
       } else {
@@ -992,7 +1084,7 @@ export class CrdtProvider {
     this.compactionBuffers.set(noteId, [])
 
     try {
-      if (this.snapshotPushFn && entry.pendingSnapshotBytes > 0) {
+      if (this.snapshotPushFn && entry.pendingSnapshotBytes > 0 && !entry.localOnly) {
         // Credit only the bytes this payload actually covers. result.compacted
         // was encoded before the await, and applyIpcUpdate writes straight to
         // entry.doc with no compaction guard (only remote updates are

--- a/apps/desktop/src/main/zero-runtime-effects.test.ts
+++ b/apps/desktop/src/main/zero-runtime-effects.test.ts
@@ -97,8 +97,16 @@ vi.mock('./sync/attachment-events', () => ({
 vi.mock('./sync/crdt-provider', () => ({
   getCrdtProvider: () => ({
     initForNote: mocks.initForNote,
-    updateMeta: mocks.updateMeta
+    updateMeta: mocks.updateMeta,
+    setNoteLocalOnly: vi.fn()
   })
+}))
+
+// The CRDT half of the local-only toggle: a body that stopped going up while
+// the flag was set is owed to the server as a whole document once it clears.
+vi.mock('./sync/crdt-pending-notes', () => ({
+  recordPendingCrdtNotes: vi.fn(),
+  clearPendingCrdtNotes: vi.fn()
 }))
 
 vi.mock('./sync/local-mutations', () => ({

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -446,6 +446,64 @@ Notes flow through **both** sync paths:
 
 Snapshots are pushed **pre-batch** so other devices receive correct state before the sync notification reaches them.
 
+## Local-Only Notes Keep Their Body
+
+A note marked **Local only** never sends its body to the server. The record feed has always
+honoured this — `seedUnclockedNotes` excludes `localOnly IS NOT 1`, `incrementNoteClockOffline`
+returns early, `buildNotePushPayload` returns `null` — and the CRDT body path now does too.
+
+The flag is cached on the open doc, read once from the `note_cache` row in `doOpen`.
+`onDocUpdate` runs on every keystroke and cannot afford a database round-trip; opening a doc
+already pays an async store read plus, usually, a file stat, read and markdown parse, so one
+more primary-key lookup there is not measurable. `setNoteLocalOnlyState` corrects the cached
+flag in place after it writes both databases, so toggling takes effect on the next keystroke
+rather than the next time the note is closed and reopened.
+
+Five paths send a body, and each refuses independently:
+
+| Path                             | Guard                             |
+| -------------------------------- | --------------------------------- |
+| `onDocUpdate` → `CrdtUpdateQueue` | cached flag on the doc            |
+| `close()` snapshot                | cached flag on the doc            |
+| `pushAllSnapshots()` at shutdown  | cached flag on the doc            |
+| `compactDoc()` snapshot           | cached flag on the doc            |
+| `pushSnapshotForNote()`           | re-reads the `note_cache` row     |
+
+`pushSnapshotForNote` re-reads the row because it is the one push path reached for a note with
+no open doc — the pending-note replay and the push coordinator's `create` both land there.
+
+`pendingSnapshotBytes` keeps counting for a local-only note. It means "written locally, not yet
+on the server", which stays true, and suppressing it would make three of the guards above look
+redundant when they are the only thing holding the body back.
+
+Nothing local changes. The Y.Doc, the local CRDT store, the window broadcast and the markdown
+write-back all sit upstream of the single branch that sends bytes, so a local-only note edits
+exactly like any other — signed out, offline, or with no account.
+
+### Clearing the flag owes the server the whole document
+
+Turning **Local only** off is the case that would otherwise lose data. Nothing else pushes an
+existing note's body: the push coordinator's CRDT snapshot is gated on `operation === 'create'`
+and clearing the flag raises an `update`, an update payload carries `content: null`, and the
+vault sweep only pulls. The note would resume syncing its metadata with its body frozen wherever
+the server last saw it.
+
+So `setNoteLocalOnlyState` records the note in the durable pending-CRDT store when the flag
+clears. `drainPendingCrdtNotes` then pushes full document state — pulling and merging the
+server's state first, and keeping the id until that push actually lands. Setting the flag clears
+that record instead, the CRDT twin of the `removePendingNoteSyncItems` call beside it; nothing is
+lost, because the updates stay in the local store and a later clear re-records the note, whose
+replay pushes full state anyway.
+
+Either direction also drops the doc's snapshot debt, so the next `close()` cannot fire a *blind*
+snapshot ahead of the merge-first replay. A snapshot asserts completeness and the server prunes
+every incremental below it, and a note that has just stopped being local-only is the population
+most likely to have diverged from a peer.
+
+Two asymmetries remain, deliberately: a local-only note is still **pulled** from the server by
+the vault sweep, and updates already buffered in `CrdtUpdateQueue` when the flag is set can still
+flush within that queue's 1 s window.
+
 ## Reconnect Recovery
 
 A note body only ever travels as a CRDT update, so a remote body edit reaches a device

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -93,7 +93,9 @@ The **⋯ button** in the top-right of a note (the _More actions_ menu) collects
 - **Reveal in navigation** — highlight the note in the sidebar
 - **Open in default app** — open the `.md` file in your system's default editor
 
-**Local only** keeps the note on this device (never synced).
+**Local only** keeps the note on this device (never synced). Both halves stay put — the note's
+details and its text — and editing is unaffected. Turning it back off uploads the note again,
+including everything you wrote while it was local only.
 
 **Delete note** moves the note to the trash after a confirmation, then closes its tab. This does the same thing as deleting from the note list — you no longer need to close the note first.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -215,6 +215,10 @@ export default defineConfig(
       'apps/desktop/src/main/inbox/filing.ts',
       'apps/desktop/src/main/inbox/suggestions.ts',
       'apps/desktop/src/main/sync/attachments.ts',
+      // Sat at exactly 800 countable lines, so the local-only body guard (#1511)
+      // could not land without either this or a speculative split of the CRDT
+      // provider — the wrong refactor to attach to a privacy fix.
+      'apps/desktop/src/main/sync/crdt-provider.ts',
       'apps/desktop/src/main/vault/watcher.ts'
     ],
     rules: {


### PR DESCRIPTION
Closes #1511. Part of EPIC #1516.

The record feed honours "never leaves this device" — `seedUnclockedNotes` excludes `localOnly IS NOT 1`, and `offline-clock.ts` does the same. **The CRDT body path did not.** `onDocUpdate` enqueued unconditionally and `pushSnapshotForNote` filtered only binaries, so a note the user marked local-only had its *body* pushed to the server as CRDT updates and snapshots while its metadata record never synced.

End-to-end encrypted, so not a confidentiality breach — but "local-only" reads as a promise that the content does not leave the machine, and it did. The gap was invisible from the UI, because the note's metadata genuinely does not sync.

## What changed

A `localOnly` flag cached on `ActiveDoc`, resolved from the index row once at `doOpen`. Cached rather than read per update because the only reader that matters is `onDocUpdate`, which runs on **every keystroke** — a `getIndexDatabase()` lookup there would put a synchronous SQLite round-trip on the typing path. `doOpen` already pays an async store read plus usually a stat, a file read and a markdown parse, so one primary-key SELECT there is noise. Net cost on the typing path is one boolean property read on an object the function already holds.

Four guards, one per path that sends bytes off the machine: the update-queue branch of `onDocUpdate`, and the snapshot pushes in `close()`, `pushAllSnapshots()` and `compactDoc()`. `pushSnapshotForNote` is reached for notes with no open doc, so it re-reads the row live — the row is already in hand there for the existing binary check.

**Everything local is untouched**: the Y.Doc, the local CRDT store, the window broadcast, and the markdown write-back all behave exactly as before. Editing stays fully available signed out, offline and with no account.

## The un-toggle trade — it was real, and it is fixed here

Reviewing this required answering whether a note that *stops* being local-only would then have no server history. It would have. Three independent facts on `origin/main`:

1. `setNoteLocalOnlyState(id, false)` raises an **`update`** queue row.
2. `push-coordinator.ts:143-156` fires `pushSnapshotForNote` only when `operation === 'create'`.
3. `note-sync.ts` `buildSnapshotPayload` sends `content: null` for an update.

And the vault sweep is pull-only. So the guard alone would have left an un-toggled note syncing metadata with its body frozen at whatever the server last saw — divergence, and worse than the leak being closed.

`setNoteLocalOnlyState` now hands the note to `drainPendingCrdtNotes` via `recordPendingCrdtNotes` when the flag clears. That replay pulls and merges the server's state *before* pushing full doc state, and keeps the id until the push lands. The symmetric `clearPendingCrdtNotes` when the flag is set is the CRDT twin of the existing `removePendingNoteSyncItems`.

`setNoteLocalOnly` also zeroes `pendingSnapshotBytes` in both directions — otherwise the next `close()` fires a *blind* snapshot ahead of the merge-first replay, and a just-un-toggled note is exactly the divergence-prone population that replay exists for. A snapshot asserts completeness, so that race would prune peer edits.

## ESLint config

`crdt-provider.ts` sat at exactly 800 countable lines — the `max-lines` cap — so no code addition fits. The file joins the **existing** `phase-tbd` exemption list (alongside `filing.ts`, `suggestions.ts`, `attachments.ts`, `watcher.ts`) with a comment. A trimmed extraction only reached ~803 lines, so the alternative is a real split of the CRDT provider, which is its own PR and the wrong refactor to attach to a privacy fix.

## Verification

- `pnpm --filter @memry/desktop test:main` — 529 passed / 3 skipped files, 6819 passed / 1 expected fail / 6 skipped
- `pnpm typecheck` 17/17 · `pnpm lint` 0 errors · `pnpm check:architecture` passed · `pnpm docs:impact --strict` covered · `pnpm docs:build` ok · `git diff --check` clean
- 10 of 11 new tests fail against `origin/main`. The two that pass both ways are the "must not change" half (the editor stays untouched; a non-local-only note still pushes) and were kept deliberately — M13 proves they earn it, since an over-broad fix that short-circuits `onDocUpdate` is caught only by them.
- 13 author mutations, each proven applied. **M3 was not caught, and the implementation changed because of it**: the first version also suppressed `pendingSnapshotBytes` for local-only docs, which made three guards mutually redundant and individually undetectable. Dropping that guard keeps the counter honest and makes `close`, `pushAllSnapshots` and `compactDoc` each independently mutation-detectable. Fewer guards, stronger tests.
- Independent reviewer mutation (not run by the author): `pushSnapshotForNote` still refuses the push but returns `true` — "report success while doing nothing", which would silently clear the note from the pending store and lose an un-toggled body. Killed; the test pins both the return value and the absence of the call.

## Residuals, noted not fixed

- A local-only note is still **pulled** from the server — nothing filters `localOnly` in `applyCrdtIncrementals`. Worth its own issue.
- `CrdtUpdateQueue` may flush already-buffered updates for a note toggled local-only mid-window (=<1 s). Closing that needs a `dropNote(noteId)` on the queue wired through `runtime.ts`.
- If that race records the id, `drainPendingCrdtNotes` will retain it indefinitely (the push correctly returns `false`), costing a warn line per session. Log noise, not data loss.