### PR TITLE
Reminder picker: scroll the presets panel so its note field and reminder list stay reachable

### DIFF
--- a/apps/desktop/src/renderer/src/components/reminder/reminder-picker.test.tsx
+++ b/apps/desktop/src/renderer/src/components/reminder/reminder-picker.test.tsx
@@ -211,6 +211,48 @@ describe('ReminderPicker', () => {
     { id: 'r2', remindAt: '2026-05-20T08:00:00.000Z', status: 'pending', note: undefined }
   ]
 
+  it('keeps the presets, the note field and the managed list in one scrolling body', () => {
+    // `Picker.Content` caps its height and clips its overflow, so anything that
+    // can outgrow the popover has to sit inside something that scrolls. When
+    // `Picker.List` was the only scroller the note field and the managed list
+    // hung outside it: the list collapsed first and the tail was clipped, with
+    // the last reminder's edit and delete buttons going with it.
+    //
+    // jsdom computes no layout and never resolves
+    // `--radix-popover-content-available-height`, and `Picker.Content` is mocked
+    // here without its cap or its clip, so this asserts the structure that makes
+    // scrolling possible — it cannot claim anything is visible on screen.
+    renderWithProviders(
+      <ReminderPicker
+        onSelect={vi.fn()}
+        showNote
+        reminders={MANAGED}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    const body = document.querySelector('.overflow-y-auto')
+    expect(body).not.toBeNull()
+    // Without `min-h-0` the body keeps its content height and the cap never
+    // reaches it; with `flex-1` it would collapse whenever the popover is
+    // shorter than its cap.
+    expect(body?.className).toContain('min-h-0')
+    expect(body?.className).not.toContain('flex-1')
+
+    expect(body?.contains(screen.getByRole('button', { name: /Later Today/ }))).toBe(true)
+    expect(
+      body?.contains(
+        screen.getByPlaceholderText('phaseF.componentsReminderReminderPicker.addANoteOptional')
+      )
+    ).toBe(true)
+    const deleteButtons = screen.getAllByRole('button', {
+      name: /phaseF.componentsReminderReminderPicker.deleteReminder/
+    })
+    expect(deleteButtons).toHaveLength(2)
+    expect(deleteButtons.every((button) => body?.contains(button))).toBe(true)
+  })
+
   it('lists existing reminders with edit and delete actions', () => {
     renderWithProviders(
       <ReminderPicker onSelect={vi.fn()} reminders={MANAGED} onEdit={vi.fn()} onDelete={vi.fn()} />

--- a/apps/desktop/src/renderer/src/components/reminder/reminder-picker.tsx
+++ b/apps/desktop/src/renderer/src/components/reminder/reminder-picker.tsx
@@ -173,7 +173,17 @@ export function ReminderPicker({
 
       <Picker.Content className="w-80" align="start">
         {mode === 'presets' ? (
-          <>
+          // The presets, the optional note and the managed-reminder list share a
+          // single scrolling body. `Picker.Content` caps its height and clips its
+          // overflow, and only an item that can shrink absorbs that cap: with
+          // `Picker.List` the sole shrinkable sibling it collapsed to nothing and
+          // the two trailing blocks were clipped anyway, taking the per-reminder
+          // edit and delete buttons with them. `Picker.List` keeps its own
+          // overflow rule but never uses it here — as a block child of this
+          // scroller it lays out at its content height. `overflow-x-hidden` stops
+          // the separators' `-mx-1` full-bleed from turning the vertical
+          // scroll container into a horizontal one as well.
+          <div className="min-h-0 overflow-y-auto overflow-x-hidden">
             <Picker.List>
               <Picker.Section label={tPhaseF('phaseF.componentsReminderReminderPicker.remindMe')}>
                 {presets.map((preset) => (
@@ -266,7 +276,7 @@ export function ReminderPicker({
                 </div>
               </>
             )}
-          </>
+          </div>
         ) : (
           // The confirm button lives in a pinned footer so the height cap on
           // `Picker.Content` can only ever eat into the scrolling body above it.

--- a/apps/docs/src/user-guide/notes/bookmarks-reminders.md
+++ b/apps/docs/src/user-guide/notes/bookmarks-reminders.md
@@ -27,6 +27,11 @@ That button and the summary of what you are about to set stay pinned to the bott
 they stay in reach even when the picker opens somewhere with little room and the rest of the panel
 has to scroll.
 
+The first panel holds the relative buttons, the optional note, and — once a note has reminders — the
+list of the ones already set, each with its own edit and delete button. All of it scrolls together
+when the panel is taller than the room the picker has, so the reminders at the end of the list stay
+editable however low in the window you opened it from.
+
 Selecting text in the editor does not open a separate reminder action; reminders are set at the note level.
 
 When the reminder fires, memrynote shows an in-app toast with:


### PR DESCRIPTION
Closes #1524. Fourth sighting of the clipping class behind #1518, #1520 and #1528; this is the sibling defect #1523 left behind in the same component.

## What was wrong

The presets branch of `ReminderPicker` rendered three blocks side by side under `Picker.Content`: the `Picker.List` of relative buttons, the optional note `Textarea`, and the "Set (n)" list of existing reminders whose rows carry the edit and delete buttons.

`Picker.Content` caps its height at `--radix-popover-content-available-height` and carries `overflow-clip`, and negative free space in a flex column only lands on items that can actually shrink. A plain `<div>` flex item has `min-height: auto`, so its content height is its floor; `Picker.List` has `min-h-0`, so its floor is zero. The whole cap therefore went to the list, which collapsed toward nothing, and once the two trailing blocks alone exceeded the cap they were clipped with no scroll path — taking the last reminders' edit and delete buttons off the bottom of the popover. A note with roughly eight reminders and the note field enabled reproduces it; how much room Radix measures depends on where the trigger sits, which is why it comes and goes.

## What changed

All three blocks now sit in one scrolling body — `min-h-0 overflow-y-auto`, no `flex-1` — which is the shape #1523 gave the custom panel, for the same reason: the body is `flex: 0 1 auto`, so it takes the whole shrinkage and its height becomes definite, and `flex: 1 1 0%` would be wrong because the popover is an auto-height container whenever its content is shorter than the cap. This branch has no confirm action, so it needs no pinned footer; everything scrolls.

Two details worth naming. `Picker.List` keeps its own `min-h-0 overflow-y-auto`, but as a block child of the new scroller it lays out at its content height and that rule never engages — there is no live nested scroller here. And the body is `overflow-x-hidden` as well as `overflow-y-auto`: `Picker.Separator` is `-mx-1` so it can bleed full width inside `Picker.List`'s `p-1`, and against a scroller with no padding that 8px would have made a vertical scroll container a horizontal one too, since a non-`visible` value on one axis forces the other off `visible`.

## Primitive or per-panel: why this is per-panel

This is the fourth instance, so the real question is whether `Picker.Content` should simply guarantee that its content scrolls. I went looking for that change and did not find a safe one.

The wrapper inside `Picker.Content` is the parent of *everything* a panel passes, including `Picker.Footer` and `Picker.Search`. Making it `overflow-y-auto` scrolls those away too, which un-pins the confirm button #1523 just pinned across the eight `Picker.Footer` consumers and un-pins the search field in every searchable picker. Sticky positioning could claw that back, but both slots are transparent today, so it would also mean giving them backgrounds — a visual change to roughly thirty call sites in service of a bug in one.

It would not even fix this panel. `Picker.List` carries `min-h-0`, so it remains the sole sink for negative free space; the list still collapses to zero before the wrapper ever overflows, and the outer scroller only engages after the list has already become unusable. Nested scrollers are not harmless here, they are ordered — the inner one wins. Getting a real guarantee therefore means taking the scroll *off* `Picker.List` and putting it on the wrapper, which changes behaviour for every `Picker.List` consumer in the app.

The remaining route — having `Picker.Content` inspect its children and wrap the non-footer ones in a scroller — fails on this very component. `React.Children` does not descend into fragments, and both branches of this ternary are a single fragment, as is anything rendered through `Picker.Panel`. It would compile, do nothing here, and silently do nothing again for the next panel written the same way.

So the honest position is that `Picker.Content` cannot know which of its children must stay put and which may scroll; only the panel knows. The primitive already has the vocabulary for saying so — `Picker.Footer` means "must stay", `Picker.List` means "may scroll" — and this bug was a panel with scrollable content in neither. The change that would actually deliver the guarantee is the one-scroller-plus-sticky-chrome redesign of the primitive, and that is its own piece of work: it needs visual verification on every picker, which jsdom cannot give. If #1528 turns into a fifth instance, that is the thing to do rather than a fifth local patch.

## Tests

One test in `reminder-picker.test.tsx`: the presets branch renders a `min-h-0 overflow-y-auto` body, without `flex-1`, that contains a preset button, the note field and both delete buttons.

Four mutations, each confirmed red and then restored:

| Mutation | Result |
| --- | --- |
| Body reverted to a fragment | fails — `expected null not to be null` |
| `min-h-0` dropped | fails — className does not contain `min-h-0` |
| Body wrapped only the trailing blocks | fails — the preset button is outside it |
| `flex-1` added | fails — className contains `flex-1` |

The test asserts structure, not pixels, and says so in a comment: jsdom computes no layout and never resolves `--radix-popover-content-available-height`, and `Picker.Content` is mocked in this file without its cap or its clip. A short-viewport check in the running app is still the real gate.

`typecheck:web`, `typecheck:test`, `i18n:check`, eslint, prettier and `git diff --check` are clean. The reminder, picker, journal, task-reminder, zero-surfaces and note-page renderer suites pass — 69 tests. `pnpm docs:impact --base origin/main --strict` reports covered and `pnpm docs:build` succeeds.