### PR TITLE
Reminder note typed in the note and journal toolbars reaches the reminder again

### DIFF
--- a/apps/desktop/src/renderer/src/components/inbox-detail/convert-actions.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/convert-actions.tsx
@@ -212,7 +212,7 @@ export const ConvertActions = ({
             </PropRow>
             <PropRow label={t('convert.reminder')}>
               <ReminderPicker
-                onSelect={(date, _title, note) => {
+                onSelect={(date, note) => {
                   setRemindAt(date)
                   setRemindNote(note ?? null)
                 }}

--- a/apps/desktop/src/renderer/src/components/journal/journal-reminder-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-reminder-button.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Covers the journal toolbar's reminder path end to end: the note typed into
+ * the real `ReminderPicker` has to survive every hop down to the
+ * `reminders.create` IPC payload. Nothing between the textarea and `window.api`
+ * is stubbed, so a consumer that reads the wrong callback argument fails here
+ * instead of silently dropping what the user wrote.
+ */
+
+import React from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithProviders, getMockApi, userEvent } from '@tests/utils/render'
+import { JournalReminderButton } from './journal-reminder-button'
+
+vi.mock('@/lib/telemetry', () => ({ trackTelemetry: vi.fn() }))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('@/hooks/use-general-settings', () => ({
+  useGeneralSettings: () => ({ settings: { clockFormat: '24h' } })
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+// Radix's picker does not open in jsdom; this stand-in keeps the picker's own
+// state machine (note textarea, preset selection, onSelect call) real.
+vi.mock('@/components/ui/picker', () => {
+  const pickerMocks: { onValueChange: ((value: string) => void) | null } = { onValueChange: null }
+
+  const PickerRoot = ({
+    children,
+    onValueChange
+  }: {
+    children: React.ReactNode
+    onValueChange?: (value: string) => void
+  }): React.ReactElement => {
+    pickerMocks.onValueChange = onValueChange ?? null
+    return <div>{children}</div>
+  }
+
+  return {
+    Picker: Object.assign(PickerRoot, {
+      Trigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      List: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Footer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Section: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Separator: () => <hr />,
+      Item: ({ value }: { value: string }) => (
+        <button
+          type="button"
+          data-testid={`preset-${value}`}
+          onClick={() => pickerMocks.onValueChange?.(value)}
+        />
+      )
+    })
+  }
+})
+
+describe('JournalReminderButton', () => {
+  beforeEach(() => {
+    const api = getMockApi() as unknown as {
+      reminders: Record<string, ReturnType<typeof vi.fn>>
+    }
+    api.reminders.getForTarget = vi.fn().mockResolvedValue([])
+    api.reminders.create.mockClear()
+    api.reminders.create.mockResolvedValue({ success: true })
+  })
+
+  it('sends the note typed in the picker to reminders.create', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<JournalReminderButton journalDate="2026-05-10" />)
+
+    await user.type(
+      screen.getByPlaceholderText('phaseF.componentsReminderReminderPicker.addANoteOptional'),
+      'revisit after the offsite'
+    )
+    await user.click(screen.getByTestId('preset-in-one-week'))
+
+    await waitFor(() => {
+      const api = getMockApi() as unknown as {
+        reminders: { create: ReturnType<typeof vi.fn> }
+      }
+      expect(api.reminders.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetType: 'journal',
+          targetId: '2026-05-10',
+          note: 'revisit after the offsite'
+        })
+      )
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/note-reminder-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-reminder-button.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Covers the note toolbar's reminder path end to end: the note typed into the
+ * real `ReminderPicker` has to survive every hop down to the `reminders.create`
+ * IPC payload. Nothing between the textarea and `window.api` is stubbed, so a
+ * consumer that reads the wrong callback argument fails here instead of
+ * silently dropping what the user wrote.
+ */
+
+import React from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithProviders, getMockApi, userEvent } from '@tests/utils/render'
+import { NoteReminderButton } from './note-reminder-button'
+
+vi.mock('@/lib/telemetry', () => ({ trackTelemetry: vi.fn() }))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('@/hooks/use-general-settings', () => ({
+  useGeneralSettings: () => ({ settings: { clockFormat: '24h' } })
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+// Radix's picker does not open in jsdom; this stand-in keeps the picker's own
+// state machine (note textarea, preset selection, onSelect call) real.
+vi.mock('@/components/ui/picker', () => {
+  const pickerMocks: { onValueChange: ((value: string) => void) | null } = { onValueChange: null }
+
+  const PickerRoot = ({
+    children,
+    onValueChange
+  }: {
+    children: React.ReactNode
+    onValueChange?: (value: string) => void
+  }): React.ReactElement => {
+    pickerMocks.onValueChange = onValueChange ?? null
+    return <div>{children}</div>
+  }
+
+  return {
+    Picker: Object.assign(PickerRoot, {
+      Trigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      List: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Footer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Section: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Separator: () => <hr />,
+      Item: ({ value }: { value: string }) => (
+        <button
+          type="button"
+          data-testid={`preset-${value}`}
+          onClick={() => pickerMocks.onValueChange?.(value)}
+        />
+      )
+    })
+  }
+})
+
+describe('NoteReminderButton', () => {
+  beforeEach(() => {
+    const api = getMockApi() as unknown as {
+      reminders: Record<string, ReturnType<typeof vi.fn>>
+    }
+    api.reminders.getForTarget = vi.fn().mockResolvedValue([])
+    api.reminders.create.mockClear()
+    api.reminders.create.mockResolvedValue({ success: true })
+  })
+
+  it('sends the note typed in the picker to reminders.create', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<NoteReminderButton noteId="note-1" />)
+
+    await user.type(
+      screen.getByPlaceholderText('phaseF.componentsReminderReminderPicker.addANoteOptional'),
+      'check the contract clause'
+    )
+    await user.click(screen.getByTestId('preset-tomorrow'))
+
+    await waitFor(() => {
+      const api = getMockApi() as unknown as {
+        reminders: { create: ReturnType<typeof vi.fn> }
+      }
+      expect(api.reminders.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetType: 'note',
+          targetId: 'note-1',
+          note: 'check the contract clause'
+        })
+      )
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/components/reminder/reminder-picker.test.tsx
+++ b/apps/desktop/src/renderer/src/components/reminder/reminder-picker.test.tsx
@@ -121,11 +121,7 @@ describe('ReminderPicker', () => {
     )
     await user.click(screen.getByRole('button', { name: /Later Today/ }))
 
-    expect(onSelect).toHaveBeenCalledWith(
-      new Date(2026, 4, 10, 14, 0, 0, 0),
-      undefined,
-      'bring account notes'
-    )
+    expect(onSelect).toHaveBeenCalledWith(new Date(2026, 4, 10, 14, 0, 0, 0), 'bring account notes')
   })
 
   it('moves into custom mode, formats the selected time, and submits a custom reminder', async () => {
@@ -169,11 +165,7 @@ describe('ReminderPicker', () => {
       screen.getByRole('button', { name: /phaseF.componentsReminderReminderPicker.setReminder/ })
     )
 
-    expect(onSelect).toHaveBeenCalledWith(
-      new Date(2026, 4, 12, 15, 45, 0, 0),
-      undefined,
-      'custom note'
-    )
+    expect(onSelect).toHaveBeenCalledWith(new Date(2026, 4, 12, 15, 45, 0, 0), 'custom note')
   })
 
   it('pins the confirm button in the footer and scrolls the body above it', async () => {
@@ -356,7 +348,11 @@ describe('ReminderPicker', () => {
         })
       )
       await user.click(screen.getByRole('button', { name: 'Select May 12' }))
-      await user.click(screen.getByRole('button', { name: /Set Reminder/ }))
+      await user.click(
+        screen.getByRole('button', {
+          name: /phaseF.componentsReminderReminderPicker.setReminder/
+        })
+      )
 
       expect(trackTelemetry).toHaveBeenCalledWith('reminder_created', {
         surface: 'journal',

--- a/apps/desktop/src/renderer/src/components/reminder/reminder-picker.tsx
+++ b/apps/desktop/src/renderer/src/components/reminder/reminder-picker.tsx
@@ -28,7 +28,13 @@ export interface ManagedReminder {
 }
 
 export interface ReminderPickerProps {
-  onSelect: (date: Date, title?: string, note?: string) => void
+  /**
+   * Called with the chosen time and the optional note typed into the picker.
+   * There is deliberately no third `title` argument: the picker never collected
+   * one, so a middle parameter that was always `undefined` only ever bound a
+   * consumer's note variable to nothing.
+   */
+  onSelect: (date: Date, note?: string) => void
   presetType?: 'standard' | 'journal'
   trigger?: React.ReactNode
   size?: 'sm' | 'md' | 'lg'
@@ -119,7 +125,7 @@ export function ReminderPicker({
 
   const handlePresetSelect = (preset: ReminderPreset): void => {
     const date = preset.getDate()
-    onSelect(date, undefined, note || undefined)
+    onSelect(date, note || undefined)
     trackReminderCreated('preset', preset.id)
     setOpen(false)
     resetState()
@@ -129,7 +135,7 @@ export function ReminderPicker({
     const date = buildSelectedDate()
     if (!date) return
 
-    onSelect(date, undefined, note || undefined)
+    onSelect(date, note || undefined)
     trackReminderCreated('custom')
     setOpen(false)
     resetState()

--- a/apps/desktop/src/renderer/src/components/tasks/task-reminder-button.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-reminder-button.tsx
@@ -56,7 +56,7 @@ export function TaskReminderButton({
 
   return (
     <ReminderPicker
-      onSelect={(date, _title, note) => void actions.setReminder(date, note)}
+      onSelect={(date, note) => void actions.setReminder(date, note)}
       presetType="standard"
       telemetrySurface="tasks"
       showNote

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -1140,7 +1140,7 @@ export function NotePage({ noteId }: NotePageProps) {
   const actionIcons = (
     <div className="flex items-center gap-0.5">
       <ReminderPicker
-        onSelect={(date, _title, reminderNote) => void handleSetReminder(date, reminderNote)}
+        onSelect={(date, reminderNote) => void handleSetReminder(date, reminderNote)}
         presetType="standard"
         telemetrySurface="notes"
         showNote

--- a/apps/docs/src/user-guide/notes/bookmarks-reminders.md
+++ b/apps/docs/src/user-guide/notes/bookmarks-reminders.md
@@ -27,6 +27,10 @@ That button and the summary of what you are about to set stay pinned to the bott
 they stay in reach even when the picker opens somewhere with little room and the rest of the panel
 has to scroll.
 
+The optional note is available on both paths: type it before you press a relative button and it is
+saved with that reminder too. It is kept everywhere the picker appears — notes, journal entries,
+tasks and inbox items.
+
 Selecting text in the editor does not open a separate reminder action; reminders are set at the note level.
 
 When the reminder fires, memrynote shows an in-app toast with:


### PR DESCRIPTION
Closes #1527.

## The bug

`ReminderPicker` declared its callback as `onSelect(date, title, note)`, but no call site
ever populated `title` — both commit paths passed `onSelect(date, undefined, note || undefined)`,
and always had, going back to the original reminders commit. `git log -S title` on the file
turns up only the monorepo move and last week's telemetry change, whose own comment describes
the title as something that is deliberately never sent. Nothing has ever put a value in that slot.

Two consumers read the callback as `(date, note)` and so bound their note variable to the
always-empty middle argument:

- `note-reminder-button.tsx`
- `journal-reminder-button.tsx`

Both pass `showNote`, so the note field was rendered and inviting input the whole time, and
whatever the user typed arrived at `reminders.create` as `undefined`. TypeScript stayed quiet
because a handler is allowed to declare fewer parameters than the signature supplies, and the
second one happened to be type-compatible.

## Which option, and why

Option (b): drop `title` from `ReminderPickerProps` entirely.

Fixing only the two call sites (option (a)) restores the note but leaves the trap intact for
the next consumer, and this is already the second one to walk into it — three of five call sites
were carrying a `_title` placeholder purely to step over an argument that never existed. Option (c),
populating `title` with something meaningful, has no evidence behind it: there is no title to
collect, the picker has never asked for one, and inventing a value to justify a parameter is the
wrong direction.

The wider diff is what makes it permanent rather than incidental:

- The two broken consumers become correct *as written*. Their two-argument shape was only ever
  wrong relative to a middle parameter that should not have been there.
- The three that were compensating stop compiling until they are updated, because a handler with
  more parameters than the target signature is not assignable. So the compiler, not review,
  enforced completeness across the change.

This is wider than the literal defect, but it is the fix for its cause: a parameter that is
always `undefined` cannot be used correctly, only stepped over, and every consumer has to
independently remember to step over it.

## What the new tests prove

The reason this survived is that the two broken surfaces had no test that followed the note
anywhere, and the tests that do touch them mock `ReminderPicker` itself — so they assert against
a hand-written stub that reproduced the bug's own calling convention and stayed green either way.

The two new tests mock nothing between the textarea and the IPC boundary. They render the real
button, which renders the real `ReminderPicker`, which drives the real `useNoteReminders` /
`useJournalReminders` hook and the real mutation; only `window.api.reminders.create` is a spy,
and the assertion is on the payload it receives. A note typed into the picker has to survive
every hop to pass.

Mutation-tested by restoring the three source files to their pre-fix state and re-running:
both tests fail, each with `note: undefined` in the recorded call. Restored, both pass.

## One unrelated change

`reminder-picker.test.tsx` had a telemetry assertion matching the literal string `Set Reminder`,
which the file's own mocked `useT` never renders — it returns translation keys. That test is red
on `main` today, independent of this change. It is repointed at the key so the file I had to edit
comes back green; flagging it here since it is not mine and not part of the fix.

## Verification

- `pnpm --filter @memry/desktop typecheck:web` / `typecheck:test`
- `pnpm i18n:check`
- renderer suites for every consumer touched, plus the picker's own: 15 files, 109 tests, green
- `pnpm exec eslint --max-warnings 0` on the changed files
- `git diff --check`
- `pnpm docs:impact --base origin/main --strict` (covered) and `pnpm docs:build`