### PR TITLE
fix(canvas): re-key the note-edit lock on the fragment, not the sync session

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -1496,9 +1496,9 @@ export const ContentArea = memo(function ContentArea(props: ContentAreaProps) {
   // `isCollaborationActive(syncState.status)`, which meant no session → no
   // Y.Doc → keystrokes reached markdown and the DB but never became CRDT
   // operations; the sign-in that rebuilt the doc from the server then wrote it
-  // back over the file. The canvas note-card lock still reads the session
-  // predicate — see sync/collaboration-status.ts for why the two must not be
-  // re-merged.
+  // back over the file. The canvas note-card lock reads the fragment this hook
+  // produces (pages/canvas/canvas-note-lock.ts), not the session — see
+  // sync/collaboration-status.ts for why nothing may re-derive this from it.
   const localDocLive = isLocalCrdtDocLive(props.noteId)
   const { fragment, doc, isReady, isRemoteUpdateRef, isSideEffectOwner } = useYjsCollaboration({
     noteId: props.noteId,

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.test.tsx
@@ -59,7 +59,7 @@ vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
 const mocks = vi.hoisted(() => {
   const lockCtxCache = new Map<
     string | null,
-    { collaborationActive: boolean; visibleNoteTabIds: Set<string> }
+    { hasLiveFragment: () => boolean; visibleNoteTabIds: Set<string> }
   >()
   return {
     openTab: vi.fn(),
@@ -73,10 +73,10 @@ const mocks = vi.hoisted(() => {
     // yield-to-tab effect (deps on this reference) re-run on every render
     // regardless of whether the lock actually changed, confounding tests that
     // want to isolate the activation gate from that effect.
-    getLockCtx(): { collaborationActive: boolean; visibleNoteTabIds: Set<string> } {
+    getLockCtx(): { hasLiveFragment: () => boolean; visibleNoteTabIds: Set<string> } {
       const key = this.lockReason
       if (!lockCtxCache.has(key)) {
-        lockCtxCache.set(key, { collaborationActive: key === null, visibleNoteTabIds: new Set() })
+        lockCtxCache.set(key, { hasLiveFragment: () => key === null, visibleNoteTabIds: new Set() })
       }
       return lockCtxCache.get(key)!
     }

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.tsx
@@ -548,12 +548,12 @@ export const CanvasCardLayer = ({
       if (hit) {
         e.preventDefault()
         e.stopPropagation()
-        // No live sync session + the note already live elsewhere => stay
-        // read-only. Not because a second editor would be non-collaborative —
-        // it shares the tab's Y.Doc now — but because these are the statuses
-        // main's CRDT provider can be down under, and an editor that opens a
-        // note while it is down saves whole markdown for the life of its mount
-        // and clobbers the other one (M6 design §12/6; canvas-note-lock.ts).
+        // No live fragment for this note in this window + the note already live
+        // elsewhere => stay read-only. Not because a second editor would be
+        // non-collaborative — with a fragment it shares the tab's Y.Doc — but
+        // because a binding that failed or has not settled makes every editor on
+        // the note a whole-markdown saver for the life of its mount, and two of
+        // those clobber each other (M6 design §12/6; canvas-note-lock.ts).
         if (lockReasonForCard(lockCtxRef.current, hit)) {
           return
         }

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-note-lock.test.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-note-lock.test.ts
@@ -71,18 +71,37 @@ describe('collectVisibleNoteTabIds', () => {
 
 describe('evaluateNoteLock', () => {
   const base = {
-    collaborationActive: false,
+    fragmentLive: false,
     visibleNoteTabIds: new Set<string>(),
     claimedBy: null as string | null,
     cardElementId: 'card-1',
     noteId: 'n1'
   }
 
-  it('never locks when collaboration is active (authenticated co-edit is safe)', () => {
+  it('does not lock against a tab when this window holds a live fragment (co-edit is safe)', () => {
+    // The relax #1504 exists for: both editors bind the same fragment, so the
+    // whole-markdown save is suppressed on both and neither can clobber.
     expect(
-      evaluateNoteLock({ ...base, collaborationActive: true, visibleNoteTabIds: new Set(['n1']) })
+      evaluateNoteLock({ ...base, fragmentLive: true, visibleNoteTabIds: new Set(['n1']) })
     ).toBeNull()
-    expect(evaluateNoteLock({ ...base, collaborationActive: true, claimedBy: 'card-2' })).toBeNull()
+  })
+
+  it('still locks against a tab when the fragment is not live (fail-open / connecting / no slot)', () => {
+    // The signed-in fail-open the session predicate could not see: a live
+    // session, a note whose own connect() rejected, both editors whole-markdown
+    // savers. `fragmentLive: false` is the ONLY input; the session is not asked.
+    expect(
+      evaluateNoteLock({ ...base, fragmentLive: false, visibleNoteTabIds: new Set(['n1']) })
+    ).toBe('note-open-in-tab')
+  })
+
+  it('locks a second card even with a live fragment (the claim is an invariant, not a safety answer)', () => {
+    // canvas-card-overlay refuses the second activation through
+    // noteCardClaims.claim regardless of the fragment, so this reason must not
+    // sit behind the safety short-circuit or the refusal would be silent.
+    expect(evaluateNoteLock({ ...base, fragmentLive: true, claimedBy: 'card-2' })).toBe(
+      'note-active-on-another-card'
+    )
   })
 
   it('locks when the note is the active tab of a visible pane', () => {

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-note-lock.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-note-lock.ts
@@ -1,6 +1,5 @@
 /**
- * Why a canvas note card sometimes refuses to become editable — and why the
- * reason is no longer the one it was built for.
+ * Why a canvas note card sometimes refuses to become editable.
  *
  * As built (M7 §3.1): ContentArea engaged Yjs only for an authenticated sync
  * session, so an unauthenticated user edited through a NON-collaborative
@@ -23,22 +22,26 @@
  * destroys its provider and publishes a null fragment for the life of the slot
  * (use-yjs-collaboration.ts, "fails open") with no rebind — so the first editor
  * to open that note, and every editor that later joins it, is a whole-markdown
- * saver again. That is the original clobber, unchanged. Main is uninitialized
- * only after `resetCrdtProvider()`, which nothing but the sync runtime's stop
- * and start-failure paths calls: `teardownSession('integrity')` never re-inits
- * (#1492), sign-out re-inits asynchronously, a failed `startSyncRuntime` leaves
- * it dead. No such state reports idle/syncing/offline.
+ * saver again. That is the original clobber, unchanged.
  *
- * So the first conjunct no longer says "there is no shared doc"; it
- * over-approximates "there may not be one". The contrapositive is what carries
- * it — a live session means `startSyncRuntime` awaited `initPersistence()`, so
- * the doc is there and co-editing stays unlocked, as it always did. The cost of
- * over-approximating is a healthy never-signed-in user locked out for no hazard
- * at all: that user never reaches a provider reset. The tight predicate is
- * "this window holds no fragment for this note", and it is not reachable from
- * here — asking the registry for it would register a second consumer and make
- * the sole editor report non-owner (see `useYjsSideEffectOwner`). Swapping the
- * conjunct for it is a design change owing its own E2E, not a cleanup: #1504.
+ * Until #1504 this gate asked the SYNC SESSION about that (`!isCollaborationActive`),
+ * because main is uninitialized only after `resetCrdtProvider()` and no such
+ * state reports idle/syncing/offline. That was a conservative over-approximation
+ * and wrong in both directions: it locked every healthy never-signed-in user —
+ * who cannot reach a provider reset at all — out of canvas editing, and it never
+ * saw the signed-in fail-open, where a live `idle` session sits on a note whose
+ * own `connect()` rejected. It asks the fragment directly now:
+ * `fragmentLive` is `useLiveFragmentQuery()` over the registry's read-only
+ * `peek`, which registers no consumer and so does not make the note's sole
+ * editor report non-owner — the hazard that blocked this in #1495.
+ *
+ * Note that `fragmentLive` short-circuits ONLY the tab conjunct. It is a safety
+ * answer ("a second editor cannot clobber the first"), not the one-active-card
+ * invariant: `canvas-card-overlay.tsx` refuses a second activation through
+ * `noteCardClaims.claim` regardless, so leaving the claim conjunct behind the
+ * safety answer would have made that refusal silent — the card would show no
+ * lock badge and simply not activate, and `claimFailedTick` (which exists to
+ * re-evaluate this decision after exactly that refusal) would be dead.
  *
  * The rule is "the tab always wins": a card refuses to activate and stays a
  * read-only preview with an open-in-tab affordance.
@@ -52,11 +55,16 @@ export type NoteLockReason = 'note-open-in-tab' | 'note-active-on-another-card'
 
 export interface NoteLockInput {
   /**
-   * From isCollaborationActive(syncStatus). No longer "this user has a shared
-   * Y.Doc" — every note has one now. Read it as "main's CRDT provider is
-   * provably up", which is the only thing still making a second editor safe.
+   * Does THIS window hold a live Yjs fragment for this note — a settled
+   * `connect()` that produced one? See `useLiveFragmentQuery`. True means every
+   * editor that binds this note here shares that fragment, so a second one
+   * cannot clobber the first. False covers all three unsafe shapes at once: the
+   * fail-open (settled, no fragment), the still-connecting slot, and no slot at
+   * all. Cross-window is out of its reach and always was — the registry and
+   * `visibleNoteTabIds` are both window-local, so a note open in ANOTHER window
+   * has never reached this decision.
    */
-  collaborationActive: boolean
+  fragmentLive: boolean
   /** Note ids that are the ACTIVE tab of some pane (see collectVisibleNoteTabIds). */
   visibleNoteTabIds: ReadonlySet<string>
   /** Card element id currently claiming this note, or null. */
@@ -67,8 +75,7 @@ export interface NoteLockInput {
 }
 
 export function evaluateNoteLock(input: NoteLockInput): NoteLockReason | null {
-  if (input.collaborationActive) return null
-  if (input.visibleNoteTabIds.has(input.noteId)) return 'note-open-in-tab'
+  if (!input.fragmentLive && input.visibleNoteTabIds.has(input.noteId)) return 'note-open-in-tab'
   if (input.claimedBy !== null && input.claimedBy !== input.cardElementId) {
     return 'note-active-on-another-card'
   }

--- a/apps/desktop/src/renderer/src/pages/canvas/use-note-edit-lock.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/use-note-edit-lock.test.tsx
@@ -9,7 +9,7 @@
  * lock now distinguishes.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { screen, waitFor, act } from '@testing-library/react'
 import { TabProvider, useTabActions, useTabs } from '@/contexts/tabs'
 import { renderWithProviders, userEvent } from '@tests/utils/render'
@@ -104,9 +104,19 @@ function Probe({ noteId }: { noteId: string }): React.JSX.Element {
       : noteGroupId === state.activeGroupId
         ? 'focused'
         : 'other'
+  // canvas-card-overlay.tsx memoizes its rendered card list on the lock
+  // context's IDENTITY (`lockCtx` is a dep of that useMemo, and of both the
+  // lockCtxRef sync and the yield-to-tab effect). Mirroring that memo here is
+  // what makes this a test of the BOUNDARY between the hook and its consumer
+  // rather than of the hook alone: the direct `lock` readout below recomputes on
+  // every render, so it stays green even if the context object never takes a new
+  // identity — and a context that keeps its identity across a fragment settle
+  // leaves a stale lock badge on a card that is now perfectly editable.
+  const memoizedLock = useMemo(() => String(lockReasonForCard(ctx, cardFor(noteId))), [ctx, noteId])
   return (
     <div>
       <span data-testid="lock">{String(lockReasonForCard(ctx, cardFor(noteId)))}</span>
+      <span data-testid="lock-memoized">{memoizedLock}</span>
       <span data-testid="group-count">{groupIds.length}</span>
       <span data-testid="note-location">{noteLocation}</span>
       <button type="button" onClick={() => splitView('horizontal', primaryGroupId)}>
@@ -239,6 +249,37 @@ describe('useNoteEditLock', () => {
     // The lock released without any tab or claim change: the only input that
     // moved is the registry's published snapshot, reaching the overlay through
     // useLiveFragmentQuery's subscription.
+    expect(screen.getByTestId('lock')).toHaveTextContent('null')
+  })
+
+  it('hands a consumer memoized on the lock context a NEW context when the fragment settles', async () => {
+    // The overlay does not call lockReasonForCard on every render — it renders
+    // from a useMemo keyed on the lock context. So "the decision changed" is not
+    // enough; the context object itself has to change identity, or the card list
+    // is never rebuilt and the badge never clears. Driving the real overlay
+    // component here would mean un-mocking use-note-edit-lock in a suite that
+    // also stubs Excalidraw, the tabs context and the entity loader — so this
+    // reproduces the exact memo shape (deps include the context) against the
+    // real hook instead, which is the property that memo depends on.
+    const user = userEvent.setup()
+    ipc.mode = 'pending'
+    renderProbe('note-memo')
+    await mountEditor(user, 'connecting')
+    await openNoteInOtherPane(user)
+    expect(screen.getByTestId('lock')).toHaveTextContent('note-open-in-tab')
+    expect(screen.getByTestId('lock-memoized')).toHaveTextContent('note-open-in-tab')
+
+    await act(async () => {
+      ipc.settle.forEach((resolve) => resolve())
+      await Promise.resolve()
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('editor-a-binding')).toHaveTextContent('fragment')
+    )
+    // Nothing about the tabs changed, so `visibleNoteTabIds` keeps its identity:
+    // the ONLY thing that can invalidate this memo is the query function taking a
+    // new identity with the registry's version.
+    await waitFor(() => expect(screen.getByTestId('lock-memoized')).toHaveTextContent('null'))
     expect(screen.getByTestId('lock')).toHaveTextContent('null')
   })
 

--- a/apps/desktop/src/renderer/src/pages/canvas/use-note-edit-lock.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/use-note-edit-lock.test.tsx
@@ -1,31 +1,80 @@
+/**
+ * The lock decision driven end to end, not in halves: the REAL module-level
+ * registry in sync/use-yjs-collaboration.ts, its REAL entry factory (real Y.Doc,
+ * real snapshot publishing), the REAL `useYjsCollaboration` a note tab's
+ * ContentArea mounts, the REAL read-only `useLiveFragmentQuery`, the REAL
+ * TabProvider, and the REAL `evaluateNoteLock`. Only `YjsIpcProvider` is faked,
+ * because it is the actual outside edge (Electron IPC to main's CRDT provider) —
+ * and faking exactly it is what lets a test choose the three settle states the
+ * lock now distinguishes.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen } from '@testing-library/react'
+import { useState } from 'react'
+import { screen, waitFor, act } from '@testing-library/react'
 import { TabProvider, useTabActions, useTabs } from '@/contexts/tabs'
 import { renderWithProviders, userEvent } from '@tests/utils/render'
+import { useYjsCollaboration } from '@/sync/use-yjs-collaboration'
 import { noteCardClaims } from './canvas-note-lock'
 import { useNoteEditLock, lockReasonForCard } from './use-note-edit-lock'
 import type { CanvasCardRef } from './canvas-cards'
 
-const syncStatus = { current: 'unknown' as string }
-vi.mock('@/contexts/sync-context', () => ({
-  useSync: () => ({ state: { status: syncStatus.current } })
+const ipc = vi.hoisted(() => ({
+  mode: 'resolve' as 'resolve' | 'reject' | 'pending',
+  settle: [] as Array<() => void>
 }))
 
-const CARD: CanvasCardRef = {
+// Only the three members the entry factory touches: construct, connect, destroy.
+// `reject` reproduces the fail-open (`crdt:open-doc` answering success:false, a
+// rejecting validateNoteForCrdt, a throwing handshake); `pending` holds the slot
+// in its pre-settle state.
+vi.mock('@/sync/yjs-ipc-provider', () => ({
+  YjsIpcProvider: class {
+    connect(): Promise<void> {
+      if (ipc.mode === 'reject') return Promise.reject(new Error('crdt:open-doc failed'))
+      if (ipc.mode === 'pending') {
+        return new Promise<void>((resolve) => {
+          ipc.settle.push(resolve)
+        })
+      }
+      return Promise.resolve()
+    }
+    destroy(): void {}
+  }
+}))
+
+const cardFor = (noteId: string): CanvasCardRef => ({
   elementId: 'card-1',
   entityType: 'note',
-  entityId: 'note-1',
+  entityId: noteId,
   x: 0,
   y: 0,
   width: 10,
   height: 10,
   angle: 0
+})
+
+/**
+ * Stands in for the note tab's ContentArea: the same `useYjsCollaboration` call,
+ * with the same single registry consumer. Its reported binding is what the lock
+ * is being asked about, so the tests assert on it rather than on timers.
+ */
+function EditorStandIn({ noteId, testId }: { noteId: string; testId: string }): React.JSX.Element {
+  const { isReady, fragment, isSideEffectOwner } = useYjsCollaboration({ noteId })
+  return (
+    <>
+      <span data-testid={`${testId}-binding`}>
+        {!isReady ? 'connecting' : fragment ? 'fragment' : 'fail-open'}
+      </span>
+      <span data-testid={`${testId}-owner`}>{String(isSideEffectOwner)}</span>
+    </>
+  )
 }
 
-function Probe(): React.JSX.Element {
+function Probe({ noteId }: { noteId: string }): React.JSX.Element {
   const ctx = useNoteEditLock()
   const { openTab, splitView, setActiveGroup } = useTabActions()
   const { state } = useTabs()
+  const [editors, setEditors] = useState(0)
   const groupIds = Object.keys(state.tabGroups)
   const primaryGroupId = groupIds[0]
   // SPLIT_VIEW creates the new pane but does not focus it (see
@@ -37,7 +86,7 @@ function Probe(): React.JSX.Element {
   // split-created group explicitly is what makes "note live in the other
   // pane" a real, reachable state instead of a same-group coincidence.
   const secondaryGroupId = groupIds.find((id) => id !== primaryGroupId)
-  // Which group (if any) currently has note-1 as its active tab, relative to
+  // Which group (if any) currently has the note as its active tab, relative to
   // whichever group is focused right now. This is the load-bearing proof:
   // collectVisibleNoteTabIds scans every group regardless of focus, so
   // 'lock' alone can't distinguish "note ended up in the focused group by
@@ -47,7 +96,7 @@ function Probe(): React.JSX.Element {
   const noteGroupId = groupIds.find((id) => {
     const group = state.tabGroups[id]
     const activeTab = group.tabs.find((tab) => tab.id === group.activeTabId)
-    return activeTab?.entityId === 'note-1'
+    return activeTab?.entityId === noteId
   })
   const noteLocation =
     noteGroupId === undefined
@@ -57,7 +106,7 @@ function Probe(): React.JSX.Element {
         : 'other'
   return (
     <div>
-      <span data-testid="lock">{String(lockReasonForCard(ctx, CARD))}</span>
+      <span data-testid="lock">{String(lockReasonForCard(ctx, cardFor(noteId)))}</span>
       <span data-testid="group-count">{groupIds.length}</span>
       <span data-testid="note-location">{noteLocation}</span>
       <button type="button" onClick={() => splitView('horizontal', primaryGroupId)}>
@@ -71,10 +120,10 @@ function Probe(): React.JSX.Element {
           openTab(
             {
               type: 'note',
-              title: 'Note 1',
+              title: 'Note',
               icon: 'FileText',
-              path: '/note-1',
-              entityId: 'note-1',
+              path: `/${noteId}`,
+              entityId: noteId,
               isPinned: false,
               isModified: false,
               isPreview: false,
@@ -89,77 +138,158 @@ function Probe(): React.JSX.Element {
       <button type="button" onClick={() => setActiveGroup(primaryGroupId)}>
         focus-primary
       </button>
+      <button type="button" onClick={() => setEditors((n) => n + 1)}>
+        mount-editor
+      </button>
+      {editors >= 1 && <EditorStandIn noteId={noteId} testId="editor-a" />}
+      {editors >= 2 && <EditorStandIn noteId={noteId} testId="editor-b" />}
     </div>
   )
 }
 
-const renderProbe = (): void => {
+const renderProbe = (noteId: string): void => {
   renderWithProviders(
     <TabProvider>
-      <Probe />
+      <Probe noteId={noteId} />
     </TabProvider>
   )
 }
 
+/**
+ * Split, open the note in the newly-created (non-focused) pane, then focus the
+ * primary pane again — the exact split-view shape the guard exists for: the
+ * canvas is in the focused pane while the note stays mounted and editable in the
+ * sibling pane.
+ */
+async function openNoteInOtherPane(user: ReturnType<typeof userEvent.setup>): Promise<void> {
+  await user.click(screen.getByText('split'))
+  expect(screen.getByTestId('group-count')).toHaveTextContent('2')
+  await user.click(screen.getByText('open-note'))
+  await user.click(screen.getByText('focus-primary'))
+  // Prove the scenario is real: two groups exist, and the note is the active
+  // tab of the group that is NOT currently focused. If the split or the
+  // refocus silently no-op, noteLocation resolves to 'focused' or 'not-open'
+  // instead of 'other', and this assertion fails.
+  expect(screen.getByTestId('note-location')).toHaveTextContent('other')
+}
+
+async function mountEditor(
+  user: ReturnType<typeof userEvent.setup>,
+  binding: 'fragment' | 'fail-open' | 'connecting',
+  testId = 'editor-a'
+): Promise<void> {
+  await user.click(screen.getByText('mount-editor'))
+  await waitFor(() => expect(screen.getByTestId(`${testId}-binding`)).toHaveTextContent(binding))
+}
+
 describe('useNoteEditLock', () => {
   beforeEach(() => {
-    syncStatus.current = 'unknown'
-    noteCardClaims.release('note-1', noteCardClaims.claimedBy('note-1') ?? '')
+    ipc.mode = 'resolve'
+    ipc.settle = []
   })
 
   it('does not lock when the note is not open in any visible pane', () => {
-    renderProbe()
+    renderProbe('note-idle')
     expect(screen.getByTestId('lock')).toHaveTextContent('null')
   })
 
-  it('locks an unauthenticated card when the note is live in the OTHER pane', async () => {
+  it('does not lock a card whose note is live in the OTHER pane once the fragment is live', async () => {
+    // The relax: a never-signed-in user in perfect health. The tab and the card
+    // acquire ONE registry entry, so both bind the same fragment and the
+    // whole-markdown save is suppressed on both — there is nothing to clobber.
     const user = userEvent.setup()
-    renderProbe()
-    // Split, open the note in the newly-created (non-focused) pane, then
-    // focus the primary pane again — the exact split-view shape the guard
-    // exists for: the canvas is in the focused pane while the note stays
-    // mounted and editable in the sibling pane.
-    await user.click(screen.getByText('split'))
-    expect(screen.getByTestId('group-count')).toHaveTextContent('2')
-    await user.click(screen.getByText('open-note'))
-    await user.click(screen.getByText('focus-primary'))
-    // Prove the scenario is real: two groups exist, and note-1 is the active
-    // tab of the group that is NOT currently focused. If the split or the
-    // refocus silently no-op, noteLocation resolves to 'focused' or
-    // 'not-open' instead of 'other', and this assertion fails.
-    expect(screen.getByTestId('note-location')).toHaveTextContent('other')
+    renderProbe('note-live')
+    await mountEditor(user, 'fragment')
+    await openNoteInOtherPane(user)
+    expect(screen.getByTestId('lock')).toHaveTextContent('null')
+  })
+
+  it('locks when the other pane holds the note but its binding FAILED OPEN', async () => {
+    // The signed-in fail-open nothing covered before: connect() rejected, so the
+    // entry published a null fragment for the life of the slot with no rebind
+    // and every editor on this note is a whole-markdown saver again. A session
+    // predicate cannot see this — the session is fine.
+    const user = userEvent.setup()
+    ipc.mode = 'reject'
+    renderProbe('note-failopen')
+    await mountEditor(user, 'fail-open')
+    await openNoteInOtherPane(user)
     expect(screen.getByTestId('lock')).toHaveTextContent('note-open-in-tab')
   })
 
-  it('does not lock an authenticated card even with the note live in the other pane', async () => {
+  it('locks while the binding is still connecting, then releases when it settles live', async () => {
+    // Pending is not yet safe: it may settle into the fail-open above. It is
+    // also not a flap — ContentArea holds its own render behind the same
+    // isReady, so this window is the tab's loading skeleton and it ends in ONE
+    // transition, which this test drives for real.
     const user = userEvent.setup()
-    syncStatus.current = 'idle'
-    renderProbe()
-    await user.click(screen.getByText('split'))
-    await user.click(screen.getByText('open-note'))
-    await user.click(screen.getByText('focus-primary'))
-    // Same real cross-pane state as the unauthenticated case above — the
-    // note genuinely lives in the non-focused group — but collaboration
-    // being active short-circuits the lock regardless.
-    expect(screen.getByTestId('note-location')).toHaveTextContent('other')
+    ipc.mode = 'pending'
+    renderProbe('note-connecting')
+    await mountEditor(user, 'connecting')
+    await openNoteInOtherPane(user)
+    expect(screen.getByTestId('lock')).toHaveTextContent('note-open-in-tab')
+
+    await act(async () => {
+      ipc.settle.forEach((resolve) => resolve())
+      await Promise.resolve()
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('editor-a-binding')).toHaveTextContent('fragment')
+    )
+    // The lock released without any tab or claim change: the only input that
+    // moved is the registry's published snapshot, reaching the overlay through
+    // useLiveFragmentQuery's subscription.
     expect(screen.getByTestId('lock')).toHaveTextContent('null')
   })
 
-  it('locks when another card holds the claim', () => {
-    noteCardClaims.claim('note-1', 'card-2')
-    renderProbe()
+  it('locks when nothing in this window holds the note bound at all', async () => {
+    // No slot: the tab is visible but no editor has bound the note here yet
+    // (mount race), so nothing proves the next editor will not fail open.
+    const user = userEvent.setup()
+    renderProbe('note-noslot')
+    await openNoteInOtherPane(user)
+    expect(screen.getByTestId('lock')).toHaveTextContent('note-open-in-tab')
+  })
+
+  it('locks against another card’s claim even when the fragment is live', async () => {
+    // The claim is the one-active-card invariant, not a safety answer:
+    // canvas-card-overlay refuses the second activation regardless, so this
+    // reason must not sit behind the fragment short-circuit.
+    const user = userEvent.setup()
+    noteCardClaims.claim('note-claimed', 'card-2')
+    renderProbe('note-claimed')
+    await mountEditor(user, 'fragment')
     expect(screen.getByTestId('lock')).toHaveTextContent('note-active-on-another-card')
-    noteCardClaims.release('note-1', 'card-2')
+    noteCardClaims.release('note-claimed', 'card-2')
+  })
+
+  it('asking the lock does not register a second registry consumer (#1495 hazard)', async () => {
+    // useNoteEditLock is mounted from the first render here, BEFORE any editor —
+    // exactly the order the canvas overlay produces. If it acquired instead of
+    // peeking, it would own the slot and the note's sole real editor would
+    // report non-owner, silently killing that editor's task auto-conversion.
+    const user = userEvent.setup()
+    renderProbe('note-owner')
+    await mountEditor(user, 'fragment')
+    expect(screen.getByTestId('editor-a-owner')).toHaveTextContent('true')
+    // Control: ownership CAN be lost here — a genuine second consumer takes the
+    // non-owner slot — so 'true' above is a real property, not a constant.
+    await user.click(screen.getByText('mount-editor'))
+    await waitFor(() =>
+      expect(screen.getByTestId('editor-b-binding')).toHaveTextContent('fragment')
+    )
+    expect(screen.getByTestId('editor-b-owner')).toHaveTextContent('false')
+    expect(screen.getByTestId('editor-a-owner')).toHaveTextContent('true')
   })
 
   it('never locks a non-note card', () => {
     // Same entityId as the "open" note on purpose: only note cards are guarded,
     // because task and event cards autosave field-level patches rather than a
     // whole-body last-write-wins markdown save.
-    const taskCard: CanvasCardRef = { ...CARD, entityType: 'task' }
+    const taskCard: CanvasCardRef = { ...cardFor('note-task'), entityType: 'task' }
     expect(
       lockReasonForCard(
-        { collaborationActive: false, visibleNoteTabIds: new Set(['note-1']) },
+        { hasLiveFragment: () => false, visibleNoteTabIds: new Set(['note-task']) },
         taskCard
       )
     ).toBeNull()

--- a/apps/desktop/src/renderer/src/pages/canvas/use-note-edit-lock.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/use-note-edit-lock.ts
@@ -1,14 +1,13 @@
 /**
- * Live inputs for the canvas note-edit lock: whether a remote sync session is
- * live — which is now a proxy for "main's CRDT provider is up", not for "this
- * editor is collaborative"; see canvas-note-lock.ts — and which notes are
- * currently editable in a visible pane. Kept separate from canvas-note-lock.ts
- * so the decision stays pure.
+ * Live inputs for the canvas note-edit lock: whether this window already holds a
+ * live Yjs fragment for a given note — the thing that actually makes a second
+ * editor safe, see canvas-note-lock.ts — and which notes are currently editable
+ * in a visible pane. Kept separate from canvas-note-lock.ts so the decision
+ * stays pure.
  */
 import { useMemo } from 'react'
-import { useSync } from '@/contexts/sync-context'
 import { useTabs } from '@/contexts/tabs'
-import { isCollaborationActive } from '@/sync/collaboration-status'
+import { useLiveFragmentQuery } from '@/sync/use-yjs-collaboration'
 import type { CanvasCardRef } from './canvas-cards'
 import {
   collectVisibleNoteTabIds,
@@ -18,21 +17,27 @@ import {
 } from './canvas-note-lock'
 
 export interface NoteEditLockContext {
-  collaborationActive: boolean
+  /**
+   * Per-note, because the lock is asked per card. Identity changes only when an
+   * answer could have changed, so this context object — and the card list
+   * memoized on it in canvas-card-overlay.tsx — stays stable between them.
+   */
+  hasLiveFragment: (noteId: string) => boolean
   visibleNoteTabIds: ReadonlySet<string>
 }
 
 export function useNoteEditLock(): NoteEditLockContext {
-  const { state: syncState } = useSync()
   const { state: tabState } = useTabs()
-  const collaborationActive = isCollaborationActive(syncState.status)
+  // Read-only: this registers no registry consumer, so it does not make the
+  // note's sole editor report non-owner (#1495).
+  const hasLiveFragment = useLiveFragmentQuery()
   const visibleNoteTabIds = useMemo(
     () => collectVisibleNoteTabIds(tabState.tabGroups),
     [tabState.tabGroups]
   )
   return useMemo(
-    () => ({ collaborationActive, visibleNoteTabIds }),
-    [collaborationActive, visibleNoteTabIds]
+    () => ({ hasLiveFragment, visibleNoteTabIds }),
+    [hasLiveFragment, visibleNoteTabIds]
   )
 }
 
@@ -47,7 +52,7 @@ export function lockReasonForCard(
 ): NoteLockReason | null {
   if (card.entityType !== 'note') return null
   return evaluateNoteLock({
-    collaborationActive: ctx.collaborationActive,
+    fragmentLive: ctx.hasLiveFragment(card.entityId),
     visibleNoteTabIds: ctx.visibleNoteTabIds,
     claimedBy: noteCardClaims.claimedBy(card.entityId),
     cardElementId: card.elementId,

--- a/apps/desktop/src/renderer/src/sync/collaboration-status.test.ts
+++ b/apps/desktop/src/renderer/src/sync/collaboration-status.test.ts
@@ -1,53 +1,20 @@
 import { describe, it, expect } from 'vitest'
-import { isCollaborationActive, isLocalCrdtDocLive, type SyncStatus } from './collaboration-status'
-import { evaluateNoteLock } from '@/pages/canvas/canvas-note-lock'
+import { isLocalCrdtDocLive, type SyncStatus } from './collaboration-status'
 
 const ALL_STATUSES: SyncStatus[] = ['idle', 'syncing', 'paused', 'error', 'offline', 'unknown']
 
-describe('isCollaborationActive', () => {
-  it('is true only for live sync statuses', () => {
-    expect(isCollaborationActive('idle')).toBe(true)
-    expect(isCollaborationActive('syncing')).toBe(true)
-    expect(isCollaborationActive('offline')).toBe(true)
-  })
-
-  it('is false before a sync session exists or when it has failed', () => {
-    expect(isCollaborationActive('unknown')).toBe(false)
-    expect(isCollaborationActive('paused')).toBe(false)
-    expect(isCollaborationActive('error')).toBe(false)
-  })
-
-  it('covers every SyncStatus member', () => {
-    expect(ALL_STATUSES.filter(isCollaborationActive)).toEqual(['idle', 'syncing', 'offline'])
-  })
-
-  // The canvas note-card lock gates on this predicate's NEGATION. Splitting the
-  // editor gate off must leave it reading the SESSION question, or the guard
-  // silently stops matching the condition it exists to guard.
-  it('still locks an unauthenticated canvas note card whose note is open in a tab', () => {
-    const lockedStatuses = ALL_STATUSES.filter(
-      (status) =>
-        evaluateNoteLock({
-          collaborationActive: isCollaborationActive(status),
-          visibleNoteTabIds: new Set(['note-1']),
-          claimedBy: null,
-          cardElementId: 'card-a',
-          noteId: 'note-1'
-        }) === 'note-open-in-tab'
-    )
-    expect(lockedStatuses).toEqual(['paused', 'error', 'unknown'])
-  })
-})
-
+// `isCollaborationActive` lived here and is gone: its last consumer, the canvas
+// note-card lock, reads the fragment now (#1504). No test replaces it — the
+// lock's own suites (canvas-note-lock.test.ts, use-note-edit-lock.test.tsx) own
+// that decision, and TypeScript pins that no sync status can reach it.
 describe('isLocalCrdtDocLive', () => {
-  it('is true for a note on exactly the statuses collaboration is not', () => {
+  it('is true for a note on every sync status, including having none', () => {
     // The local Y.Doc is the editor's store, not a sync feature: main opens it
     // from this vault's own CRDT store and writes markdown back from it. Gating
     // it on the session is what let a signed-out edit reach markdown alone and
     // be overwritten by the Y.Doc the next sign-in rebuilt from the server.
-    const sessionless = ALL_STATUSES.filter((status) => !isCollaborationActive(status))
-    expect(sessionless).not.toHaveLength(0)
-    expect(sessionless.every(() => isLocalCrdtDocLive('note-1'))).toBe(true)
+    expect(ALL_STATUSES).not.toHaveLength(0)
+    expect(ALL_STATUSES.every(() => isLocalCrdtDocLive('note-1'))).toBe(true)
   })
 
   it('is false with no note, which is the only thing it depends on', () => {

--- a/apps/desktop/src/renderer/src/sync/collaboration-status.ts
+++ b/apps/desktop/src/renderer/src/sync/collaboration-status.ts
@@ -1,40 +1,23 @@
 /**
- * Two questions that used to be one switch.
+ * The sync session's status, and the one predicate that must NOT be derived
+ * from it.
  *
- * `isCollaborationActive` answers "is a REMOTE sync session available?".
- * `isLocalCrdtDocLive` answers "should this window's local Y.Doc be live?".
- * They are not the same question, and answering both with the first one is what
- * destroyed signed-out edits: with no session the editor was never bound to a
- * Y.Doc at all, so keystrokes went to markdown alone and never became CRDT
- * operations — and the Y.Doc is canonical, so the sign-in that rebuilt it from
- * the server wrote it straight back over them. Nothing failed to merge; there
- * was nothing to merge.
+ * There used to be an `isCollaborationActive(status)` here answering "is a
+ * REMOTE sync session available?", and the editor gate was that same call.
+ * Answering both questions with it is what destroyed signed-out edits: with no
+ * session the editor was never bound to a Y.Doc at all, so keystrokes went to
+ * markdown alone and never became CRDT operations — and the Y.Doc is canonical,
+ * so the sign-in that rebuilt it from the server wrote it straight back over
+ * them. Nothing failed to merge; there was nothing to merge.
+ *
+ * Its last caller was the canvas note-card lock, which gated on its NEGATION as
+ * a proxy for "main's CRDT provider may be down". #1504 re-keyed that lock on
+ * the fragment itself (`useLiveFragmentQuery`), which answers the question the
+ * session was only ever approximating, so the predicate is gone rather than
+ * left behind for someone to re-point the editor at. Statuses are produced in
+ * contexts/sync-context.tsx.
  */
 export type SyncStatus = 'idle' | 'syncing' | 'paused' | 'error' | 'offline' | 'unknown'
-
-/**
- * Is a remote sync session available?
- *
- * The canvas note-card lock (pages/canvas/canvas-note-lock.ts) gates on its
- * NEGATION, and still must — but not for the reason it was written. It no
- * longer means "this user has no shared Y.Doc": since `f89d23ed5` every note
- * has one, signed in or not, so a note tab and a canvas card in one window
- * share it either way. What the negation now selects is "main's CRDT provider
- * may be down", because the only thing that leaves it uninitialized is
- * `resetCrdtProvider()` from the sync runtime's stop and start-failure paths —
- * and an editor that opens a note while main is down falls open to a
- * whole-markdown saver for the life of its mount, which is the original
- * clobber. Still one predicate, then: a second copy that drifts stops matching
- * a live data-loss path with no test going red. The full argument, and what
- * would replace this, is in canvas-note-lock.ts. These statuses are produced in
- * contexts/sync-context.tsx.
- *
- * NOT the editor's gate. ContentArea used to call this and no longer does — see
- * `isLocalCrdtDocLive`.
- */
-export function isCollaborationActive(status: SyncStatus): boolean {
-  return status === 'idle' || status === 'syncing' || status === 'offline'
-}
 
 /**
  * Should this window's local Y.Doc be live?
@@ -46,9 +29,9 @@ export function isCollaborationActive(status: SyncStatus): boolean {
  * session must only ever decide whether anything is *synced*.
  *
  * Deliberately not a constant: this is the seam the editor gate lives on, so it
- * is greppable and so nobody re-points ContentArea at `isCollaborationActive`.
- * The note id is the whole input — there is no doc without a note, and a note
- * only exists inside an open vault.
+ * is greppable and so nobody re-derives it from `SyncStatus`. The note id is the
+ * whole input — there is no doc without a note, and a note only exists inside an
+ * open vault.
  */
 export function isLocalCrdtDocLive(noteId: string | undefined): boolean {
   return Boolean(noteId)

--- a/apps/desktop/src/renderer/src/sync/use-yjs-collaboration.ts
+++ b/apps/desktop/src/renderer/src/sync/use-yjs-collaboration.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, type RefObject } from 'react'
+import { useState, useEffect, useMemo, useRef, useSyncExternalStore, type RefObject } from 'react'
 import * as Y from 'yjs'
 import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 import { YjsIpcProvider } from './yjs-ipc-provider'
@@ -65,7 +65,7 @@ interface DocEntry extends DocEntryHandle {
  * hook. Only a second consumer of the SAME note in the SAME window (R17) shares
  * the entry instead of building a diverging second Y.Doc.
  */
-const docRegistry = createYjsDocRegistry<DocEntry>((noteId) => {
+const docRegistry = createYjsDocRegistry<DocEntry>((noteId, notifyChanged) => {
   const doc = new Y.Doc({ guid: noteId })
   const isRemoteUpdateRef: RefObject<boolean> = { current: false }
 
@@ -86,6 +86,9 @@ const docRegistry = createYjsDocRegistry<DocEntry>((noteId) => {
   const publish = (next: EntrySnapshot): void => {
     snapshot = next
     for (const listener of listeners) listener()
+    // Read-only observers (useLiveFragmentQuery) hold no consumer slot, so they
+    // are not in `listeners`; the registry fans out to them instead.
+    notifyChanged()
   }
 
   provider
@@ -224,4 +227,63 @@ export function useYjsCollaboration(
  */
 export function useYjsSideEffectOwner(noteId: string): boolean {
   return useYjsCollaboration({ noteId }).isSideEffectOwner
+}
+
+/**
+ * Does this window hold a LIVE Yjs fragment for `noteId` right now?
+ *
+ * Three states, and the middle one is why this exists:
+ *  - ready + fragment → the doc bound. Every editor on this note in this window
+ *    gets this same fragment, so the whole-markdown debounce save is suppressed
+ *    (`!yjsFragment` in content-area/hooks/use-editor-sync.ts) and a second
+ *    editor cannot clobber the first. SAFE.
+ *  - ready + no fragment → `connect()` REJECTED. The entry destroyed its
+ *    provider and doc and published null for the life of the slot with no
+ *    rebind, so every editor that binds this note is a whole-markdown saver
+ *    again. NOT safe — and this state is reachable with a live, `idle` session
+ *    (a rejecting `validateNoteForCrdt`, a throwing handshake), which is why
+ *    the session predicate this replaced could not see it.
+ *  - not ready → `connect()` has not settled, so which of the two above it will
+ *    be is unknown. Reported NOT live: it may resolve to the null-fragment
+ *    case, and a caller that treated "pending" as safe would under-fire exactly
+ *    there. It does not flap a lock on and off, because ContentArea holds its
+ *    render behind the same `isReady` — the pending window is the tab's own
+ *    loading skeleton, and it ends in one transition, not an oscillation.
+ *
+ * No slot at all is likewise NOT live: nothing in this window has the note
+ * bound, so there is nothing to prove the next editor will not fail open.
+ *
+ * `peek` registers no consumer, so asking this does not make the note's sole
+ * editor report non-owner — the hazard that blocked #1504 in #1495.
+ */
+function hasLiveFragment(noteId: string): boolean {
+  const entry = docRegistry.peek(noteId)
+  if (!entry) return false
+  const { isReady, fragment } = entry.getSnapshot()
+  return isReady && fragment !== null
+}
+
+// Module-level so `useSyncExternalStore` gets one stable subscribe/getSnapshot
+// pair for the life of the window (a fresh subscribe each render would tear the
+// subscription down and rebuild it every time).
+const observeRegistry = (listener: () => void): (() => void) => docRegistry.observe(listener)
+const readRegistryVersion = (): number => docRegistry.version()
+
+/**
+ * Read-only fragment-liveness query, re-rendering the caller whenever an answer
+ * could have changed (slot created/destroyed, `connect()` settled). The returned
+ * function's identity changes with that version and only with it, so consumers
+ * can memoize on it — canvas-card-overlay renders one card per visible element
+ * and must not rebuild that list every render.
+ */
+export function useLiveFragmentQuery(): (noteId: string) => boolean {
+  const version = useSyncExternalStore(observeRegistry, readRegistryVersion, readRegistryVersion)
+  return useMemo(() => {
+    // `version` is referenced (no-op) purely as this memo's cache key — the
+    // answer itself is read through `peek` at call time, so this must be a FRESH
+    // closure per version, not the stable module function. Mirrors
+    // `void claimFailedTick` in pages/canvas/canvas-card-overlay.tsx.
+    void version
+    return (noteId: string) => hasLiveFragment(noteId)
+  }, [version])
 }

--- a/apps/desktop/src/renderer/src/sync/yjs-doc-registry.test.ts
+++ b/apps/desktop/src/renderer/src/sync/yjs-doc-registry.test.ts
@@ -143,6 +143,85 @@ describe('yjs-doc-registry', () => {
     expect(registry.refCount('n1')).toBe(1)
   })
 
+  it('peek returns the live entry without registering a consumer', () => {
+    // The property that unblocked #1504: reading a slot must not change who owns
+    // it. `acquire` here would make `a` a non-owner and keep the entry alive
+    // past its last real consumer.
+    const { registry, destroy } = makeRegistry()
+    const a = Symbol('a')
+    const entry = registry.acquire('note-1', a)
+    expect(registry.peek('note-1')).toBe(entry)
+    expect(registry.refCount('note-1')).toBe(1)
+    expect(registry.isSideEffectOwner('note-1', a)).toBe(true)
+    registry.release('note-1', a)
+    expect(destroy).toHaveBeenCalledTimes(1)
+    expect(registry.peek('note-1')).toBeNull()
+  })
+
+  it('peek is null for a note this window never acquired', () => {
+    const { registry, created } = makeRegistry()
+    expect(registry.peek('never-opened')).toBeNull()
+    expect(created()).toBe(0)
+  })
+
+  it('observes slot creation, entry-reported change, and slot destruction', () => {
+    let notify: (() => void) | undefined
+    const registry = createYjsDocRegistry((_noteId: string, notifyChanged: () => void) => {
+      notify = notifyChanged
+      return { destroy: vi.fn() }
+    })
+    const seen = vi.fn()
+    const unobserve = registry.observe(seen)
+    const a = Symbol('a')
+
+    registry.acquire('n1', a)
+    expect(seen).toHaveBeenCalledTimes(1)
+    // A second consumer changes refCount, not what peek answers — no notify.
+    registry.acquire('n1', Symbol('b'))
+    expect(seen).toHaveBeenCalledTimes(1)
+    // The entry settling its connect() is a change.
+    notify?.()
+    expect(seen).toHaveBeenCalledTimes(2)
+
+    registry.release('n1', a)
+    expect(seen).toHaveBeenCalledTimes(2)
+    unobserve()
+    registry.release('n1', Symbol('unknown'))
+    expect(seen).toHaveBeenCalledTimes(2)
+  })
+
+  it('version advances on every notification so useSyncExternalStore re-reads', () => {
+    let notify: (() => void) | undefined
+    const registry = createYjsDocRegistry((_noteId: string, notifyChanged: () => void) => {
+      notify = notifyChanged
+      return { destroy: vi.fn() }
+    })
+    const a = Symbol('a')
+    const start = registry.version()
+    registry.acquire('n1', a)
+    const afterCreate = registry.version()
+    expect(afterCreate).toBeGreaterThan(start)
+    // Stable between notifications — getSnapshot must not tear.
+    expect(registry.version()).toBe(afterCreate)
+    notify?.()
+    const afterPublish = registry.version()
+    expect(afterPublish).toBeGreaterThan(afterCreate)
+    registry.release('n1', a)
+    expect(registry.version()).toBeGreaterThan(afterPublish)
+  })
+
+  it('the slot exists by the time an observer is told it was created', () => {
+    // Ordering guard: notifying before slots.set would hand every observer a
+    // peek of null for a slot that does exist.
+    const registry = createYjsDocRegistry(() => ({ destroy: vi.fn() }))
+    let peekedAtNotify: unknown = 'not-called'
+    registry.observe(() => {
+      peekedAtNotify = registry.peek('n1')
+    })
+    const entry = registry.acquire('n1', Symbol('a'))
+    expect(peekedAtNotify).toBe(entry)
+  })
+
   it('refCount===1 stays byte-identical to the pre-registry path', () => {
     const destroy = vi.fn()
     const createEntry = vi.fn(() => ({ destroy }))

--- a/apps/desktop/src/renderer/src/sync/yjs-doc-registry.ts
+++ b/apps/desktop/src/renderer/src/sync/yjs-doc-registry.ts
@@ -24,19 +24,46 @@ export interface YjsDocRegistry<T> {
   release(noteId: string, consumerId: symbol): void
   isSideEffectOwner(noteId: string, consumerId: symbol): boolean
   refCount(noteId: string): number
+  /**
+   * The slot's entry, or null if this window holds none — WITHOUT registering a
+   * consumer. That distinction is the whole point: `acquire` would make the sole
+   * editor of the note report non-owner (see `useYjsSideEffectOwner`), which is
+   * why the canvas note-edit lock could not ask this question before (#1495).
+   * A reader that only wants to know whether a doc is live must not change who
+   * owns it, nor keep the entry alive past its last real consumer.
+   */
+  peek(noteId: string): T | null
+  /**
+   * Fires when a slot is created or destroyed, and when a live entry reports its
+   * own state changed (the `notifyChanged` handed to `createEntry`). Paired with
+   * `version` for `useSyncExternalStore`, so a read-only observer re-renders on
+   * exactly the transitions that can change a `peek` answer. Consumer churn
+   * inside an existing slot is deliberately NOT a notification: refCount does
+   * not change what `peek` returns.
+   */
+  observe(listener: () => void): () => void
+  /** Monotonic counter bumped by every `observe` notification. */
+  version(): number
 }
 
 export function createYjsDocRegistry<T extends DocEntryHandle>(
-  createEntry: (noteId: string) => T
+  createEntry: (noteId: string, notifyChanged: () => void) => T
 ): YjsDocRegistry<T> {
   const slots = new Map<string, Slot<T>>()
+  const observers = new Set<() => void>()
+  let changeVersion = 0
+  const notifyChanged = (): void => {
+    changeVersion += 1
+    for (const observer of observers) observer()
+  }
 
   return {
     acquire(noteId, consumerId, onOwnerChange) {
       let slot = slots.get(noteId)
+      const created = slot === undefined
       if (!slot) {
         slot = {
-          entry: createEntry(noteId),
+          entry: createEntry(noteId, notifyChanged),
           consumers: new Set(),
           sideEffectOwner: consumerId,
           onOwnerChangeCallbacks: new Map()
@@ -47,6 +74,9 @@ export function createYjsDocRegistry<T extends DocEntryHandle>(
       if (onOwnerChange) {
         slot.onOwnerChangeCallbacks.set(consumerId, onOwnerChange)
       }
+      // After slots.set, so an observer that re-reads through `peek` sees the
+      // slot it is being told about.
+      if (created) notifyChanged()
       return slot.entry
     },
     release(noteId, consumerId) {
@@ -57,6 +87,7 @@ export function createYjsDocRegistry<T extends DocEntryHandle>(
       if (slot.consumers.size === 0) {
         slot.entry.destroy()
         slots.delete(noteId)
+        notifyChanged()
         return
       }
       if (slot.sideEffectOwner === consumerId) {
@@ -72,6 +103,18 @@ export function createYjsDocRegistry<T extends DocEntryHandle>(
     },
     refCount(noteId) {
       return slots.get(noteId)?.consumers.size ?? 0
+    },
+    peek(noteId) {
+      return slots.get(noteId)?.entry ?? null
+    },
+    observe(listener) {
+      observers.add(listener)
+      return () => {
+        observers.delete(listener)
+      }
+    },
+    version() {
+      return changeVersion
     }
   }
 }

--- a/apps/desktop/tests/e2e/canvas-editing.e2e.ts
+++ b/apps/desktop/tests/e2e/canvas-editing.e2e.ts
@@ -172,15 +172,30 @@ test.describe('Spatial canvas — in-place editing (M6)', () => {
     await expect(card).toHaveAttribute('data-canvas-card-state', 'active', { timeout: 20000 })
   })
 
-  // Positive split-view case, for real. Split with the renderer's own ⌘\ /
-  // Ctrl+\ shortcut (use-tab-keyboard-shortcuts.ts registers a plain
-  // `window` keydown handler for it — nothing native-menu-only about it), open
-  // the seeded note in the newly-created pane so it becomes that pane's ACTIVE
-  // tab (collectVisibleNoteTabIds only counts active tabs — tab-pane.tsx mounts
-  // only each group's active tab), then refocus the canvas pane and confirm
-  // the guard actually engages: the E2E vault is unauthenticated, so this is
-  // exactly the clobber-risk path the M7 guard exists for.
-  test('a note open in the split pane locks the canvas card (M7 guard, real split)', async ({
+  // Split-view co-edit, for real — and since #1504 the assertion is INVERTED.
+  // This used to assert the lock, on the premise that an unauthenticated pair of
+  // editors could not share a Y.Doc. `f89d23ed5` killed that premise and #1504
+  // re-keyed the lock on the fragment: the tab's ContentArea binds the local
+  // Y.Doc with no session at all, the card acquires that same registry entry, so
+  // the whole-markdown save is suppressed on both and there is nothing to
+  // clobber. This E2E vault is exactly the healthy signed-out population that
+  // the old session predicate locked out for no hazard, so what it now pins is
+  // that they can edit.
+  //
+  // Split with the renderer's own ⌘\ / Ctrl+\ shortcut
+  // (use-tab-keyboard-shortcuts.ts registers a plain `window` keydown handler
+  // for it — nothing native-menu-only about it), open the seeded note in the
+  // newly-created pane so it becomes that pane's ACTIVE tab
+  // (collectVisibleNoteTabIds only counts active tabs — tab-pane.tsx mounts only
+  // each group's active tab), then refocus the canvas pane.
+  //
+  // The other side of the predicate — a settled binding with NO fragment, the
+  // signed-in fail-open — is not reachable from here: it needs main's CRDT
+  // provider to be down, which only `resetCrdtProvider()` does and which no
+  // renderer-visible API can trigger. It is covered in
+  // src/renderer/src/pages/canvas/use-note-edit-lock.test.tsx against the real
+  // registry with the IPC provider faked.
+  test('a note open in the split pane no longer locks the canvas card (shared local Y.Doc)', async ({
     page
   }) => {
     await openVault(page)
@@ -251,9 +266,29 @@ test.describe('Spatial canvas — in-place editing (M6)', () => {
     const canvasPane = page.locator(`[data-testid="tab-pane"][data-pane-id="${canvasPaneId}"]`)
     await expect(canvasPane).toHaveAttribute('data-pane-active', 'true')
 
+    // The card is not locked, and double-click really does activate it — both,
+    // because "no lock badge" alone would also be true of a card the overlay
+    // silently refuses to activate.
+    await expect(card).not.toHaveAttribute('data-canvas-card-locked', 'true')
     await dblclickCard(page, `note:${noteId}`)
-    await expect(card).toHaveAttribute('data-canvas-card-locked', 'true', { timeout: 20000 })
-    await expect(card).not.toHaveAttribute('data-canvas-card-state', 'active')
+    await expect(card).toHaveAttribute('data-canvas-card-state', 'active', { timeout: 20000 })
+
+    // And the edit made on the card while the note is live in the other pane
+    // lands exactly once — the clobber the lock existed to prevent would show up
+    // here as a lost or duplicated marker.
+    const marker = `SPLITEDIT_${Date.now()}`
+    const cardEditor = page.locator('[data-canvas-active-card] [contenteditable="true"]').first()
+    await cardEditor.click()
+    await cardEditor.pressSequentially(` ${marker}`, { delay: 20 })
+    await expect
+      .poll(
+        async () => {
+          const note = await page.evaluate(async (id) => window.api.notes.get(id), noteId)
+          return (note?.content?.match(new RegExp(marker, 'g')) ?? []).length
+        },
+        { timeout: 20000 }
+      )
+      .toBe(1)
   })
 
   test('↗ redirect and double-click do not cross-fire (matrix #20)', async ({ page }) => {
@@ -352,12 +387,11 @@ test.describe('Spatial canvas — in-place editing (M6)', () => {
     await expect(card).toBeVisible({ timeout: 20000 })
   })
 
-  // Matrix #19 — sequential consistency, no duplicate/echo. True SIMULTANEOUS
-  // two-editor co-editing is unreachable here: switching to the note tab
-  // unmounts the canvas (tab-content renders only the active tab), and the E2E
-  // vault is unauthenticated so ContentArea's Yjs collaboration is OFF (gated
-  // on syncActive) — both editors use the non-collaborative markdown-save path.
-  // R17's shared-Y.Doc path is covered by unit tests (yjs-doc-registry.test.ts).
+  // Matrix #19 — sequential consistency, no duplicate/echo, in a SINGLE pane:
+  // switching to the note tab unmounts the canvas (tab-content renders only the
+  // active tab), so the two editors here are sequential, not simultaneous. (The
+  // simultaneous split-view case is the co-edit test above; since `f89d23ed5`
+  // both editors bind the local Y.Doc even with no session.)
   // So this asserts the honest, achievable invariant: an edit made on the card
   // is persisted exactly ONCE (no duplicate blocks), and re-opening the same
   // note in a tab shows that edit with no echo or duplication.

--- a/apps/docs/src/user-guide/canvas/cards-and-links.md
+++ b/apps/docs/src/user-guide/canvas/cards-and-links.md
@@ -88,20 +88,24 @@ responsive.
 ### When a note card stays read-only
 
 If a note card shows **Open in tab to edit**, in-place editing is unavailable
-for it right now. That happens when the same note is already open in another
-visible pane, or is already being edited on another canvas card.
+for it right now. Two things cause that:
 
-Editing one note in two places at once is only safe when both surfaces are
-backed by the same live document. An active, authenticated sync session is the
-signal Memry uses to be sure of that — so without one it will not take the
-chance that two editors end up overwriting each other's text. The card stays a
-read-only preview and points you at the surface that owns the edit. Click
-**Open in tab to edit** to jump there.
+- The note is **already being edited on another canvas card**. A note is owned
+  by one card at a time.
+- The note is **open in another visible pane** and Memry cannot confirm that
+  both surfaces are backed by the same live document — because that document is
+  still opening, or failed to open on this device.
 
-On a device with an active sync session, both surfaces are known to share a
-single live document, so this does not apply and you can edit in either place.
-This read-only fallback applies to note cards only — task and event cards
-always edit in place.
+Editing one note in two places at once is only safe when both are backed by the
+same live document, and normally they are: every note has a live document on
+your device whether or not you are signed in, so a note tab and a canvas card
+share it and both stay editable. Signing in is not what unlocks this. The
+read-only fallback appears only in the narrow case where that document is not
+live here, and rather than risk two editors overwriting each other's text the
+card stays a read-only preview and points you at the surface that owns the edit.
+Click **Open in tab to edit** to jump there.
+
+This applies to note cards only — task and event cards always edit in place.
 
 ## Opening an item in a tab
 


### PR DESCRIPTION
Closes #1504. Part of EPIC #1516. Follow-up from #1495.

Since `f89d23ed5` every note has a local Y.Doc, so a note tab and a canvas card in one window share it whether or not there is a session. The lock's first conjunct — `!isCollaborationActive` — therefore stopped meaning "there is no shared doc". What it actually selected was "main's CRDT provider *may* be down", a conservative over-approximation that was wrong in both directions:

- **Over-fired:** a healthy never-signed-in user was locked out of canvas card editing for no hazard at all. They can never reach a provider reset. That is the whole E2E population and likely most of the free tier.
- **Under-fired:** it never guarded the *signed-in fail-open*. A session reporting `idle` can still sit on a note whose `connect()` rejected — `use-yjs-collaboration.ts` then publishes a null fragment for the life of the slot with no rebind, so every editor on that note is a whole-markdown saver again. That is the original clobber, and nothing covered it.

The tight predicate is **"this window holds no live fragment for this note"**, and it now asks the fragment directly.

## Why this was not done in #1495

It was not reachable: calling `useYjsCollaboration` from the lock hook would register a second registry consumer and make the sole editor report non-owner — the exact hazard `useYjsSideEffectOwner` warns about. This adds the read-only path instead: `peek(noteId)` returns a slot's entry **without registering a consumer**, plus `observe`/`version` so `useLiveFragmentQuery` can subscribe through `useSyncExternalStore`. A dedicated test asserts using the lock hook does not change `refCount` and does not demote the sole editor, with a control proving a genuine second consumer *does*.

## The predicate

`(!fragmentLive && tab) || claim`, replacing `!collabActive && (tab || claim)`.

Tri-state, justified in the code: settled-with-fragment is safe; settled-without is the fail-open and locks; still-connecting locks (it may settle into the fail-open, and it does not flap because `ContentArea` holds its own render behind the same `isReady`, so the pending window *is* the tab's loading skeleton); no slot locks.

`fragmentLive` short-circuits **only the tab conjunct**. The claim conjunct is the one-active-card invariant, not a safety answer — `canvas-card-overlay` refuses a second activation through `noteCardClaims.claim` regardless. Leaving the claim behind the safety short-circuit would have made that refusal silent for every healthy user (no badge, double-click does nothing) and left `claimFailedTick`, which exists solely to re-evaluate after that refusal, dead code.

### Never under-fires relative to the old predicate

| State | Old | New |
| --- | --- | --- |
| `!collab`, tab, **fragment live** | lock | **unlock** — the only relaxation; both editors bind the same fragment, so the whole-markdown save is suppressed on both |
| `!collab`, tab, fragment null (settled) | lock | lock |
| `!collab`, tab, connecting / no slot | lock | lock |
| `!collab`, claim | lock | lock |
| **`collab`, tab, fragment null (settled)** | **unlock** | **lock** — the fail-open, new coverage |
| `collab`, tab, connecting / no slot | unlock | lock |
| `collab`, claim | unlock | lock |
| cross-window | unlock | unlock — unchanged; registry and `visibleNoteTabIds` are both window-local |

`isCollaborationActive` is deleted — the lock was its last production caller.

## Verification

- `pnpm --filter @memry/desktop test:renderer` — 614 files, 7144 passed / 7 skipped
- `pnpm typecheck` 17/17 · `pnpm lint` 0 errors · `pnpm docs:impact --strict` covered · `pnpm docs:build` ok · `git diff --check` clean
- 9 author mutations (M0–M8), each proven applied, all killed.

**Reviewer mutation that initially survived, and the commit that closes it.** I mutated `useLiveFragmentQuery` to return the stable module function rather than a fresh closure per version — 37 tests passed, nothing caught it. That is a real user-visible bug: `canvas-card-overlay.tsx:758` memoizes `cards` on `[..., lockCtx, ...]`, so a stable `hasLiveFragment` identity means a fragment settling live never invalidates the memo and **the badge never clears** — for exactly the signed-out population this issue exists to unlock. Every existing assertion called `lockReasonForCard` inline during render, recomputing unconditionally and never crossing the memo boundary; two halves each correct, neither driving the boundary between them. `2b418f019` adds a test mirroring the overlay's memo shape against the real hook across a pending→settled transition. Under the same mutation it now fails, alone; reverted, 38/38 green.

## E2E

- **Covered, green:** `a note open in the split pane no longer locks the canvas card (shared local Y.Doc)` — card not locked, double-click activates, and an edit made while the note is live in the other pane persists exactly once. Single-spec run `1 passed (30.6s)`.
- **Still uncovered:** the settled-no-fragment fail-open, still-connecting, and no-slot states. Reaching them needs main's CRDT provider down (`resetCrdtProvider()`), which no renderer-visible API triggers, and I did not add one just to test it. All three are covered by mutation-verified unit tests (M1–M4).
- No stale E2E asserting the old lock remains — `canvas-editing.e2e.ts`'s split-view test is inverted to the new contract.

Unrelated to this change: 5 later tests in that E2E file failed with `electron.launch: WebSocket error: socket hang up` / `Target page has been closed` — launch infrastructure, no assertion failures, none lock-related.