### PR TITLE
Fix a red main: the reminder telemetry test looks for a label i18n replaced

### DIFF
--- a/apps/desktop/src/renderer/src/components/reminder/reminder-picker.test.tsx
+++ b/apps/desktop/src/renderer/src/components/reminder/reminder-picker.test.tsx
@@ -356,7 +356,9 @@ describe('ReminderPicker', () => {
         })
       )
       await user.click(screen.getByRole('button', { name: 'Select May 12' }))
-      await user.click(screen.getByRole('button', { name: /Set Reminder/ }))
+      await user.click(
+        screen.getByRole('button', { name: /phaseF.componentsReminderReminderPicker.setReminder/ })
+      )
 
       expect(trackTelemetry).toHaveBeenCalledWith('reminder_created', {
         surface: 'journal',


### PR DESCRIPTION
`reminder-picker.test.tsx` > telemetry > "reports a custom date & time reminder as created" is failing on `main` as of 7ff3f3e18.

The test finds the confirm button by the literal `/Set Reminder/`. #1523 routed that button's label through i18n, and this file mocks `useT` to return raw keys, so the accessible name is now `phaseF.componentsReminderReminderPicker.setReminder` and the query can never match. Repointed at the key, matching the seven other lookups in the file.

## Why CI missed it

#1525 branched before #1523 merged, so its CI ran against a tree where the literal was still correct. #1523's CI ran against a tree that had no telemetry test in it. The two changes touch different lines, so git merged them without a conflict, and `main` went red on a combination no CI run had ever built. Worth remembering that a green PR only proves the merge base was green.

Docs gate skipped on the push: this is a one-line test-only change with no user-facing surface.

Not draft — this unblocks `main`.