### PR TITLE
Cap the date picker popover so its trailing time row stays reachable

### DIFF
--- a/apps/desktop/src/renderer/src/components/calendar/calendar-event-form.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-event-form.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { CalendarEventForm } from './calendar-event-form'
+import type { CalendarEventDraft } from './types'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en-US' }
+  })
+}))
+
+vi.mock('react-i18next', () => ({
+  getI18n: () => ({ getFixedT: () => (key: string) => key })
+}))
+
+vi.mock('@/hooks/use-general-settings', () => ({
+  useGeneralSettings: () => ({ settings: { clockFormat: '12h' } })
+}))
+
+vi.mock('@/hooks/use-google-calendars', () => ({
+  useGoogleCalendars: () => ({ data: { calendars: [], currentDefaultId: null }, isLoading: false })
+}))
+
+vi.mock('./calendar-picker', () => ({
+  CalendarPicker: () => <div>calendar picker</div>
+}))
+
+vi.mock('./calendar-event-metadata', () => ({
+  CalendarEventMetadata: () => <div>metadata</div>
+}))
+
+vi.mock('./event-project-field', () => ({
+  EventProjectField: () => <div>project field</div>
+}))
+
+const AVAILABLE_HEIGHT = '--radix-popover-content-available-height'
+
+const draft: CalendarEventDraft = {
+  title: 'Planning',
+  description: '',
+  startAt: '2026-03-16T09:00',
+  endAt: '2026-03-16T10:00',
+  isAllDay: false,
+  targetCalendarId: null,
+  projectId: null
+}
+
+const openStartDatePopover = (): HTMLElement => {
+  render(
+    <CalendarEventForm
+      mode="create"
+      draft={draft}
+      isSaving={false}
+      onDraftChange={vi.fn()}
+      onSave={vi.fn()}
+      onDismiss={vi.fn()}
+      autoFocus={false}
+    />
+  )
+  fireEvent.click(screen.getByText('form.start'))
+  const content = document.querySelector<HTMLElement>('[data-radix-popper-content-wrapper] > *')
+  expect(content).not.toBeNull()
+  return content!
+}
+
+/**
+ * Structural only, like `picker-content.test.tsx`: jsdom computes no layout and
+ * never resolves the Radix variable, so this cannot show the panel is on
+ * screen — only that the popover asks to be bounded and can shrink.
+ */
+describe('CalendarEventForm date popover height', () => {
+  it('caps the date panel at the height Radix measured', () => {
+    // This form is hosted by an event popover that can itself sit low in the
+    // calendar grid, and a raw `PopoverContent` never applies the available
+    // height the popper measures.
+    const content = openStartDatePopover()
+
+    expect(content.className).not.toContain(`max-h-[${AVAILABLE_HEIGHT}]`)
+    expect(content.className).toMatch(
+      new RegExp(`max-h-(?:\\(${AVAILABLE_HEIGHT}\\)|\\[var\\(${AVAILABLE_HEIGHT}\\)\\])`)
+    )
+  })
+
+  it('lays out as a column so the cap reaches the scrolling body', () => {
+    const content = openStartDatePopover()
+
+    expect(content.className).toContain('flex')
+    expect(content.className).toContain('flex-col')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-event-form.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-event-form.tsx
@@ -124,7 +124,14 @@ function DateTimeField({
           </span>
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="end" sideOffset={6}>
+      {/* Same cap as the due-date badge: a raw `PopoverContent` never applies
+          the available height Radix measures, and this field is reached from an
+          event popover that can itself sit low in the calendar grid. */}
+      <PopoverContent
+        className="w-auto p-0 overflow-clip flex flex-col max-h-(--radix-popover-content-available-height)"
+        align="end"
+        sideOffset={6}
+      >
         <DatePickerContent
           selected={date ?? undefined}
           onSelect={(next) => {

--- a/apps/desktop/src/renderer/src/components/tasks/date-picker-content.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/date-picker-content.test.tsx
@@ -208,4 +208,45 @@ describe('DatePickerContent', () => {
       expect(onTimeChange).toHaveBeenCalledWith('09:15')
     })
   })
+
+  /**
+   * These assert structure, not pixels. jsdom computes no layout and never
+   * resolves `--radix-popover-content-available-height`, so no test here can
+   * claim any of this is visibly on screen — only that the panel is laid out so
+   * a host that caps its height shrinks the scroller and not the time row.
+   * A short-viewport check in the running app remains the real gate.
+   */
+  describe('height management', () => {
+    const scrollerFor = (el: HTMLElement): HTMLElement | null =>
+      el.closest<HTMLElement>('.overflow-y-auto')
+
+    it('can shrink inside a host that caps its height', () => {
+      // Without `min-h-0` a flex item keeps its content height no matter what
+      // the cap says, and the overflow leaves the popover instead of scrolling.
+      const { container } = renderPicker({ selected: new Date(2026, 2, 16) })
+
+      expect((container.firstElementChild as HTMLElement).className).toContain('min-h-0')
+    })
+
+    it('puts the presets and the calendar in one scroll container', () => {
+      renderPicker({ selected: new Date(2026, 2, 16) })
+
+      const scroller = scrollerFor(screen.getByText('Today'))
+      expect(scroller).not.toBeNull()
+      expect(scroller?.className).toContain('min-h-0')
+      expect(scroller).toContainElement(screen.getByText('March 2026'))
+    })
+
+    it('pins the time row below the scroll container', () => {
+      // The time row is the panel's last child, so it is the first thing lost
+      // when the popover runs out of room. It has to sit outside the scroller
+      // and refuse to shrink, or the cap eats the only way to set a time.
+      renderPicker({ selected: new Date(2026, 2, 16), onTimeChange: vi.fn() })
+
+      const timeRow = screen.getByText('Add time').closest('button')?.parentElement
+      expect(timeRow).not.toBeNull()
+      expect(timeRow?.className).toContain('shrink-0')
+      expect(scrollerFor(timeRow!)).toBeNull()
+    })
+  })
 })

--- a/apps/desktop/src/renderer/src/components/tasks/date-picker-content.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/date-picker-content.tsx
@@ -101,54 +101,59 @@ export function DatePickerContent({
   const showTimeSection = !!onTimeChange && !!selected
 
   return (
-    <div className={cn('flex flex-col', className)}>
-      <div className="flex flex-col border-b border-border p-1">
-        {presets.map((preset) => {
-          const isActive = selected ? isSameDay(selected, preset.date) : false
-          return (
-            <button
-              key={preset.label}
-              type="button"
-              onClick={() => onSelect(preset.date)}
-              className={cn(
-                'flex items-center rounded-[5px] py-1.5 px-2 gap-2 transition-colors',
-                isActive ? 'bg-accent' : 'hover:bg-accent'
-              )}
-            >
-              <span
+    // `min-h-0` so this panel is allowed to shrink when its host caps the
+    // height; the presets and the calendar scroll and the time row below them
+    // is pinned, so the cap can never eat the way to set a time.
+    <div className={cn('flex flex-col min-h-0', className)}>
+      <div className="flex flex-col min-h-0 overflow-y-auto">
+        <div className="flex flex-col border-b border-border p-1 shrink-0">
+          {presets.map((preset) => {
+            const isActive = selected ? isSameDay(selected, preset.date) : false
+            return (
+              <button
+                key={preset.label}
+                type="button"
+                onClick={() => onSelect(preset.date)}
                 className={cn(
-                  'text-[12px] leading-4',
-                  isActive ? 'text-foreground' : 'text-text-secondary'
+                  'flex items-center rounded-[5px] py-1.5 px-2 gap-2 transition-colors',
+                  isActive ? 'bg-accent' : 'hover:bg-accent'
                 )}
               >
-                {preset.label}
-              </span>
-              <span className="text-[11px] ms-auto text-text-tertiary leading-3.5">
-                {preset.dateLabel}
+                <span
+                  className={cn(
+                    'text-[12px] leading-4',
+                    isActive ? 'text-foreground' : 'text-text-secondary'
+                  )}
+                >
+                  {preset.label}
+                </span>
+                <span className="text-[11px] ms-auto text-text-tertiary leading-3.5">
+                  {preset.dateLabel}
+                </span>
+              </button>
+            )
+          })}
+          {showRemoveDate && (
+            <button
+              type="button"
+              onClick={() => onSelect(null)}
+              className="flex items-center rounded-[5px] py-1.5 px-2 gap-2 hover:bg-accent transition-colors"
+            >
+              <span className="text-[12px] text-destructive leading-4">
+                {tPhaseF('phaseF.componentsTasksDatePickerContent.removeDate')}
               </span>
             </button>
-          )
-        })}
-        {showRemoveDate && (
-          <button
-            type="button"
-            onClick={() => onSelect(null)}
-            className="flex items-center rounded-[5px] py-1.5 px-2 gap-2 hover:bg-accent transition-colors"
-          >
-            <span className="text-[12px] text-destructive leading-4">
-              {tPhaseF('phaseF.componentsTasksDatePickerContent.removeDate')}
-            </span>
-          </button>
-        )}
+          )}
+        </div>
+        <DatePickerCalendar
+          selected={selected ?? undefined}
+          onSelect={handleCalendarSelect}
+          weekStartsOn={weekStartsOn}
+          className="px-3 shrink-0"
+        />
       </div>
-      <DatePickerCalendar
-        selected={selected ?? undefined}
-        onSelect={handleCalendarSelect}
-        weekStartsOn={weekStartsOn}
-        className="px-3"
-      />
       {showTimeSection && (
-        <div className="flex items-center border-t border-border p-1">
+        <div className="flex items-center border-t border-border p-1 shrink-0">
           {time || editing ? (
             <>
               <div className="flex items-center flex-1 rounded-[5px] py-1 px-2 gap-2">

--- a/apps/desktop/src/renderer/src/components/tasks/interactive-due-date-badge.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/interactive-due-date-badge.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { InteractiveDueDateBadge } from './interactive-due-date-badge'
+
+vi.mock('@/hooks/use-general-settings', () => ({
+  useGeneralSettings: () => ({ settings: { clockFormat: '12h' } })
+}))
+
+/**
+ * Tailwind v4 dropped v3's implicit `var()` wrapping inside square brackets, so
+ * `max-h-[--x]` compiles to a bare custom-property name where a length belongs
+ * and the browser drops the declaration — while tailwind-merge still counts it
+ * as a `max-h` utility. Only `max-h-(--x)` and `max-h-[var(--x)]` survive.
+ * Same guard as `picker-content.test.tsx`.
+ */
+const AVAILABLE_HEIGHT = '--radix-popover-content-available-height'
+
+const openPopover = (): HTMLElement => {
+  render(
+    <InteractiveDueDateBadge
+      dueDate={new Date(2026, 2, 16)}
+      dueTime={null}
+      onDateChange={vi.fn()}
+      onTimeChange={vi.fn()}
+    />
+  )
+  fireEvent.click(screen.getByRole('button', { name: /Click to change/ }))
+  const content = document.querySelector<HTMLElement>('[data-radix-popper-content-wrapper] > *')
+  expect(content).not.toBeNull()
+  return content!
+}
+
+/**
+ * Structural only. jsdom computes no layout and never resolves the Radix
+ * variable, so this proves the popover asks for a cap — not that the panel is
+ * on screen. That still needs a short-viewport check in the running app.
+ */
+describe('InteractiveDueDateBadge popover height', () => {
+  it('caps the panel at the height Radix measured', () => {
+    // A raw `PopoverContent` has no height management of its own: the popper
+    // `size` middleware only sets the variable, and `shift` runs with
+    // `crossAxis: false`. This badge sits in scrolling task lists, so its
+    // trigger can be anywhere in the window.
+    const content = openPopover()
+
+    expect(content.className).not.toContain(`max-h-[${AVAILABLE_HEIGHT}]`)
+    expect(content.className).toMatch(
+      new RegExp(`max-h-(?:\\(${AVAILABLE_HEIGHT}\\)|\\[var\\(${AVAILABLE_HEIGHT}\\)\\])`)
+    )
+  })
+
+  it('lays out as a column so the cap reaches the scrolling body', () => {
+    // The cap alone would just clip: this content also carries `overflow-clip`,
+    // so the panel has to be a shrinkable flex child to scroll instead.
+    const content = openPopover()
+
+    expect(content.className).toContain('flex')
+    expect(content.className).toContain('flex-col')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/tasks/interactive-due-date-badge.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/interactive-due-date-badge.tsx
@@ -84,8 +84,16 @@ export const InteractiveDueDateBadge = ({
           <div className="text-[12px] leading-4">{dateLabel}</div>
         </button>
       </PopoverTrigger>
+      {/* A raw `PopoverContent` has no height management: Radix's popper sets
+          `--radix-popover-content-available-height` but never applies it, and
+          its `shift` runs with `crossAxis: false`, so a panel taller than the
+          room beside its trigger is never pulled back. This badge sits in
+          scrolling task lists, so the trigger can be anywhere in the window.
+          Cap at the height Radix measured and lay out as a column so
+          `DatePickerContent` can shrink and scroll instead of being swallowed
+          by `overflow-clip`. */}
       <PopoverContent
-        className="w-auto p-0 rounded-md overflow-clip"
+        className="w-auto p-0 rounded-md overflow-clip flex flex-col max-h-(--radix-popover-content-available-height)"
         align="end"
         onClick={handleTriggerClick}
       >

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -50,6 +50,10 @@ Click an empty time slot (day / week views) or a date cell (month) to create an 
 - Notes / description
 - Recurrence (one-off, daily, weekly, monthly)
 
+The start and end fields open a date picker with presets, a month calendar, and a time row. When
+the event popover sits low in the grid there may not be room for the whole picker; the presets and
+calendar scroll and the time row stays pinned below them.
+
 On the day and week timelines you can also drag across a range of hours instead of clicking.
 Drag to the top or bottom edge of the grid and it scrolls on its own, so a selection can run
 past the hours currently on screen — hold the pointer at the edge and the range keeps growing

--- a/apps/docs/src/user-guide/tasks/list-vs-kanban.md
+++ b/apps/docs/src/user-guide/tasks/list-vs-kanban.md
@@ -21,6 +21,11 @@ the note or file viewer. When a task has multiple related items, the indicator o
 
 Click the row body to open the task detail drawer. Inline status and priority controls open their own pickers without opening the drawer.
 
+The due-date chip opens its own picker too: quick presets, a month calendar, and an **Add time**
+row below them. On a short window, or for a row near the bottom of the list, the presets and the
+calendar scroll inside the picker while the time row stays pinned at its foot, so adding a time is
+always reachable.
+
 Drag the drawer's left edge to resize it; double-click the edge to reset to the default width. The width is remembered across restarts.
 
 Rows can be drag-reordered. Multi-select with shift-click for bulk actions.


### PR DESCRIPTION
Closes #1528.

#1528 was filed on code reading, so this started as a verification. Two of the three call sites it
lists are real; the third is not a raw `PopoverContent` at all and is left alone.

## The mechanism, confirmed

`@radix-ui/react-popover@1.1.15` resolves to `@radix-ui/react-popper@1.2.8` in this workspace. In
`dist/index.mjs`, `shift` is configured with `crossAxis: false` (line 108) and the `size` middleware
only writes `--radix-popper-available-height` into a custom property (line 119) — nothing applies
it. So a raw `PopoverContent` is never bounded and never pulled back into the viewport. What does
rescue a low trigger is `flip`, which picks whichever side has more room; the panel only truly runs
off-screen when *neither* side fits, which is roughly "panel taller than half the viewport".

## How tall the panel actually is

Measured rather than estimated: the component's compiled Tailwind classes were rendered in Chrome
inside a replica of Radix's popper wrapper (`position: fixed`, `min-width: max-content`, content at
`w-auto`), at each of the three root font sizes `useThemeSync` writes.

| Panel | 14px root | 16px (default) | 20px ("large") |
| --- | --- | --- | --- |
| Due-date badge — date set, **Remove date** + time row | 332px | **363px** | **426px** |
| …with a time already chosen | 357px | 388px | 453px |
| Event form — timed event | 308px | 335px | 391px |
| Event form — all-day | 275px | 298px | 345px |
| Filter due-date panel | 300px | 326px | 380px |

363px is more than half the viewport of a 1366×768 display at 150% scale (~512 CSS px), which is
the same common Windows laptop configuration #1520 turned on. The window has no `minHeight` either,
so any short window reproduces it. The trailing **Add time** row is the panel's last child, so it
is the first thing to go — and with no time row the last week of the month goes instead.

## Per-consumer verdict

**`interactive-due-date-badge.tsx` — real, fixed.** Raw `PopoverContent` with
`w-auto p-0 rounded-md overflow-clip` and no cap. It is the tallest of the three because it is the
only one that shows both **Remove date** and the time row. Its triggers are in scrolling task lists
(`today-task-row`), the task detail drawer, the add-task dialog, the inbox convert panel and the
canvas task editor — the trigger can be anywhere in the window, including the last row of a long
list. Note that `overflow-clip` was doing nothing before this change: with no height constraint the
box is content-height, so there was never anything to clip.

**`calendar-event-form.tsx` — real, fixed.** Raw `PopoverContent` with `w-auto p-0`, no cap and no
overflow rule. Its host `calendar-event-popover` is positioned next to the event in the grid, so a
late-afternoon event puts the **Starts** / **Ends** fields low in the window; `canvas-event-editor`
mounts the same form.

**`due-date-panel.tsx` — not a raw `PopoverContent`; left alone.** The issue has this one wrong.
Line 117 renders `DatePickerContent` inside a fragment whose host is `filter-dropdown.tsx`'s
`Picker.Content`, which already carries `flex flex-col`, a `min-h-0` body and `overflow-clip`, and
the call site adds `max-h-[calc(100vh-120px)] overflow-y-auto` on top. It also never passes
`onTimeChange`, so `showTimeSection` is false and nothing sits below the calendar. There is no
trailing control to lose and there is already a scroll path, so this PR changes nothing there.

Worth writing down for whoever looks next: `max-h-[calc(100vh-120px)]` wins the tailwind-merge
conflict against `Picker.Content`'s `max-h-(--radix-popover-content-available-height)`, so that
dropdown is capped against the whole viewport rather than the room beside its trigger. It is
harmless *there* — the filter button lives in the tasks toolbar near the top of the window, which is
exactly what the 120px encodes — but it is a footgun if that trigger ever moves. Not touched here.

## What changed

- Both raw call sites now carry `flex flex-col max-h-(--radix-popover-content-available-height)`
  (and the event form gains `overflow-clip`, which the badge already had).
- `DatePickerContent` puts the presets and the calendar in one `min-h-0 overflow-y-auto` body and
  pins the time row below it with `shrink-0`. Its root gets `min-h-0` so it can shrink at all.

On the flex layout, since it is the whole fix: the body is the default `flex: 0 1 auto` plus
`min-h-0`, and the time row is `shrink-0`. Negative free space is distributed by scaled shrink
factor, so with the time row at factor zero all of the shrinkage lands on the body, whose height
becomes definite and whose `overflow-y: auto` yields a real scrollbar. `flex-1` would have been
wrong: `flex: 1 1 0%` sets a zero basis, and this popover is an auto-height container whenever its
content is shorter than the cap.

Verified in the browser rather than argued: with the cap at 220px the panel is 220px tall, the time
row keeps its full 37px and its bottom sits flush with the box, and the body reports
`scrollHeight > clientHeight`. With the cap at 600px the panel stays at its natural 363px and does
not scroll — the auto-height case that rules out `flex-1`.

## Should the cap live in `PopoverContent`?

No, and the reason is specific rather than general caution.

A bare `max-h` on the shared primitive would be worse than nothing. `PopoverContent` has no default
overflow rule, so a capped box whose content is taller keeps painting outside it: the border and
background stop early and the content runs straight through them. To be useful the cap has to be
paired with an overflow rule, and defaulting `PopoverContent` to `overflow-y-auto` is its own
change — it makes every popover a scroll container, which alters `position: sticky` inside them,
and because `overflow-x` stays `visible` the used value becomes `auto` too, so consumers can get
horizontal scrollbars they never asked for.

The blast radius is 28 files that render `PopoverContent`, and exactly one of them sets a `max-h`
near the call today. So the change would be silent for 27 surfaces — icon and emoji pickers, the
folder-view selectors, sync status, the relation and date editors in the note info panel — none of
which were audited here.

`Picker.Content` gets away with it because it is a composite that owns its internal structure: it
supplies the `flex flex-col`, the `min-h-0` body wrapper, `overflow-clip`, and a `Picker.List` that
is a designed scroller. `PopoverContent` is a bare primitive with no such contract, and it cannot
gain one without either owning its children's layout or dictating it.

So the honest shared answer already exists — it is `Picker.Content`, and the real long-term move is
migrating these three surfaces onto it. That is a larger change (it needs a `Picker` root for
`usePickerContext`, and it brings its own `onClick` stop-propagation and `data-slot`), and it is not
this bug. Filed as a note here rather than done half-way.

## Tests

Three structural tests on `DatePickerContent` and two each on the two call sites, in the house style
of `picker-content.test.tsx`. jsdom computes no layout and never resolves
`--radix-popover-content-available-height`, so **none of these can claim anything is visibly on
screen** — they assert that the panel asks to be bounded and is laid out so the cap reaches the
scroller. The comments in the files say so. The browser measurement above is what covers the
geometry, and a short-viewport check in the running app is still the real gate.

Every assertion was mutation-tested — the change that should break it was applied, the test
confirmed red, and the source restored:

| Mutation | Result |
| --- | --- |
| root loses `min-h-0` | RED |
| body loses `overflow-y-auto` | RED |
| time row loses `shrink-0` | RED |
| time row moved inside the scroller | RED |
| badge popover loses the cap | RED |
| badge popover loses `flex flex-col` | RED |
| event form popover loses the cap | RED |
| event form popover loses `flex flex-col` | RED |

The cap assertions reject the non-compiling `max-h-[--radix-…]` form outright, for the Tailwind v4
reason documented in `picker-content.test.tsx`.

## Verification

`typecheck:web`, `typecheck:test`, `i18n:check`, `eslint --max-warnings 0` on the six changed files
and `git diff --check` are all clean. 13 renderer test files covering every consumer of the two
changed components — the badge and event form themselves, `date-picker-content`,
`date-picker-calendar`, `picker-content`, `more-leaf-surfaces` (the filter due-date panel),
`task-filters-extra`, `calendar-event-popover`, `canvas-task-editor`, `canvas-event-editor`,
`task-detail-drawer`, `add-task-modal`, `cold-major-components` — pass: 144 tests.
`pnpm docs:impact --base origin/main --strict` reports covered and `pnpm docs:build` is green.
