### PR TITLE
fix(sync): a pending-note drain stops when the runtime that started it does

### DIFF
--- a/apps/desktop/src/main/sync/crdt-drain-teardown-seam.test.ts
+++ b/apps/desktop/src/main/sync/crdt-drain-teardown-seam.test.ts
@@ -1,0 +1,551 @@
+/**
+ * The teardown abort, driven end to end.
+ *
+ * The #1514 fix spans three layers: `stopSyncRuntime` trips an AbortController,
+ * `PendingCrdtDrainDeps.signal` carries it, and `drainOnce` short-circuits its
+ * loop on it. Each half is trivially testable against a mock of the other, and
+ * #1489 already showed where that ends — its two halves were each tested against
+ * a mock of the other, and a mutation that disabled the fix outright left 2217
+ * tests green.
+ *
+ * So nothing between the ends is mocked here: a REAL `stopSyncRuntime` on the
+ * REAL runtime, tripping a REAL `drainPendingCrdtNotes` that is genuinely
+ * in flight against the REAL on-disk store, with a REAL SyncEngine and
+ * CrdtSyncCoordinator doing the merge. Only the HTTP layer, the CrdtProvider's
+ * Y.Doc mechanics and the process-level infrastructure are mocked — and
+ * `crdtProvider.open` is the assertion target precisely because it is the call
+ * the issue is about: after `destroy()` the provider has no persistence, so
+ * every server update it applies lands in a doc nothing will ever save.
+ *
+ * Modelled on crdt-snapshot-endpoint-seam.test.ts, which stands the same runtime
+ * up for #1503.
+ */
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const runtimeMocks = vi.hoisted(() => {
+  class SyncServerError extends Error {
+    statusCode: number
+    constructor(statusCode: number, message = 'sync server error') {
+      super(message)
+      this.statusCode = statusCode
+    }
+  }
+
+  class SyncQueueManager {
+    onItemEnqueued: (() => void) | null = null
+    constructor(public db: unknown) {}
+    setOnItemEnqueued = vi.fn((cb: () => void) => {
+      this.onItemEnqueued = cb
+    })
+  }
+
+  class CrdtUpdateQueue {
+    onBatch: ((noteId: string, updates: Uint8Array[]) => Promise<void>) | null = null
+    start = vi.fn((cb: (noteId: string, updates: Uint8Array[]) => Promise<void>) => {
+      this.onBatch = cb
+    })
+    pause = vi.fn()
+    resume = vi.fn()
+    stop = vi.fn()
+  }
+
+  class NetworkMonitor {
+    online = true
+    listeners = new Map<string, (event: { online: boolean }) => void>()
+    start = vi.fn()
+    stop = vi.fn()
+    on = vi.fn((event: string, cb: (payload: { online: boolean }) => void) => {
+      this.listeners.set(event, cb)
+    })
+    removeListener = vi.fn((event: string, cb: (payload: { online: boolean }) => void) => {
+      if (this.listeners.get(event) === cb) this.listeners.delete(event)
+    })
+  }
+
+  class WebSocketManager {
+    disconnect = vi.fn()
+    refreshAuth = vi.fn(async () => undefined)
+    constructor(public options: unknown) {}
+  }
+
+  class SyncWorkerBridge {
+    start = vi.fn(async () => undefined)
+    stop = vi.fn(async () => undefined)
+  }
+
+  const service = (name: string) => ({
+    init: vi.fn(() => ({ name })),
+    reset: vi.fn()
+  })
+
+  return {
+    SyncServerError,
+    SyncQueueManager,
+    CrdtUpdateQueue,
+    NetworkMonitor,
+    WebSocketManager,
+    SyncWorkerBridge,
+    taskSync: service('task'),
+    inboxSync: service('inbox'),
+    filterSync: service('filter'),
+    taskActivitySync: service('taskActivity'),
+    bookmarkSync: service('bookmark'),
+    reminderSync: service('reminder'),
+    templateSync: service('template'),
+    homePageSync: service('home_page'),
+    projectSync: service('project'),
+    settingsSync: service('settings'),
+    noteSync: service('note'),
+    journalSync: service('journal'),
+    tagDefinitionSync: service('tag_definition'),
+    tagCategorySync: service('tag_category'),
+    folderConfigSync: service('folder_config'),
+    calendarEventSync: service('calendar_event'),
+    calendarSourceSync: service('calendar_source'),
+    calendarBindingSync: service('calendar_binding'),
+    calendarExternalEventSync: service('calendar_external_event'),
+    /** Where the real pending-note store writes; a fresh temp dir per test. */
+    userDataDir: '',
+    indexRows: [] as Array<{ id: string; title: string; date: string | null }>,
+    currentDevice: { id: 'device-1', signingPublicKey: null as string | null },
+    db: null as any,
+    getDatabase: vi.fn(),
+    getIndexDatabase: vi.fn(),
+    retrieveToken: vi.fn(),
+    getValidAccessToken: vi.fn(),
+    refreshAccessToken: vi.fn(),
+    retrieveKey: vi.fn(),
+    storeGet: vi.fn(),
+    getOrInitializeLocalVaultKey: vi.fn(),
+    getOrCreateVaultUuid: vi.fn(() => 'vault-1'),
+    deriveDevicePublicKey: vi.fn(),
+    secureCleanup: vi.fn(),
+    encryptCrdtUpdate: vi.fn(),
+    postToServer: vi.fn(),
+    pushCrdtSnapshot: vi.fn(),
+    pushCrdtFullUpdate: vi.fn(),
+    withRetry: vi.fn(async (fn: () => Promise<unknown>) => ({ value: await fn() })),
+    getFromServer: vi.fn(),
+    fetchCrdtSnapshot: vi.fn(),
+    trackMainError: vi.fn(),
+    emitSessionExpired: vi.fn(),
+    setOnTokenRefreshed: vi.fn(),
+    trackMainEvent: vi.fn(),
+    logDebug: vi.fn(),
+    logInfo: vi.fn(),
+    logWarn: vi.fn(),
+    logError: vi.fn(),
+    recoverDirtyItems: vi.fn(),
+    createSyncAdapterRegistry: vi.fn((adapters: unknown[]) => adapters),
+    createCrdtSyncAdapter: vi.fn((type: string, options: unknown) => ({ type, options })),
+    getRemoteSyncAdapter: vi.fn((type: string) => ({ remote: type })),
+    getDeviceSigningKey: vi.fn(),
+    resetCrdtProvider: vi.fn(),
+    syncGoogleCalendarSource: vi.fn(),
+    crdtProvider: {
+      init: vi.fn(),
+      seedExistingDocs: vi.fn(),
+      // `open` is what the issue is about, so it is a plain spy on a fake doc
+      // rather than real Y.Doc machinery: the question is WHICH notes it is
+      // called for after teardown, not what the doc ends up holding.
+      open: vi.fn(async () => ({})),
+      pushSnapshotForNote: vi.fn(async () => true),
+      validateNoteForCrdt: vi.fn(() => ({ ok: true })),
+      pushAllSnapshots: vi.fn(),
+      destroy: vi.fn(),
+      inactiveDocCapacity: 32,
+      getDoc: vi.fn(() => undefined),
+      closeIfInactive: vi.fn(async () => true),
+      applyRemoteUpdate: vi.fn(),
+      getStateVector: vi.fn(() => new Uint8Array([1, 2, 3, 4])),
+      seedFromMarkdownPublic: vi.fn(async () => undefined),
+      getOpenNoteIds: vi.fn(() => [])
+    },
+    browserSend: vi.fn(),
+    sodiumToBase64: vi.fn(() => 'derived-public-key'),
+    resolveEntitlementForSyncStart: vi.fn()
+  }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: vi.fn(() => '1.2.3'),
+    // The real crdt-pending-notes store, on a real temp directory.
+    getPath: vi.fn(() => runtimeMocks.userDataDir)
+  },
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => [
+      {
+        isDestroyed: () => false,
+        webContents: { isDestroyed: () => false, send: runtimeMocks.browserSend }
+      }
+    ])
+  }
+}))
+
+vi.mock('libsodium-wrappers-sumo', () => ({
+  default: {
+    to_base64: runtimeMocks.sodiumToBase64,
+    base64_variants: { ORIGINAL: 'original' }
+  }
+}))
+
+vi.mock('@memry/sync-core', () => ({
+  createCrdtSyncAdapter: runtimeMocks.createCrdtSyncAdapter,
+  createSyncAdapterRegistry: runtimeMocks.createSyncAdapterRegistry
+}))
+
+vi.mock('../database', () => ({ getDatabase: runtimeMocks.getDatabase }))
+vi.mock('../database/client', () => ({ getIndexDatabase: runtimeMocks.getIndexDatabase }))
+
+vi.mock('../crypto', () => ({
+  getDevicePublicKey: runtimeMocks.deriveDevicePublicKey,
+  getOrInitializeLocalVaultKey: runtimeMocks.getOrInitializeLocalVaultKey,
+  retrieveKey: runtimeMocks.retrieveKey,
+  secureCleanup: runtimeMocks.secureCleanup
+}))
+
+vi.mock('../store', () => ({ store: { get: runtimeMocks.storeGet } }))
+
+vi.mock('../agent/storage/vault-id', () => ({
+  getOrCreateVaultUuid: runtimeMocks.getOrCreateVaultUuid
+}))
+
+vi.mock('../calendar/google/sync-service', () => ({
+  syncGoogleCalendarSource: runtimeMocks.syncGoogleCalendarSource
+}))
+
+vi.mock('../telemetry/track', () => ({ trackMainEvent: runtimeMocks.trackMainEvent }))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    debug: (...args: unknown[]) => runtimeMocks.logDebug(...args),
+    info: (...args: unknown[]) => runtimeMocks.logInfo(...args),
+    warn: (...args: unknown[]) => runtimeMocks.logWarn(...args),
+    error: (...args: unknown[]) => runtimeMocks.logError(...args)
+  })
+}))
+
+vi.mock('./queue', () => ({ SyncQueueManager: runtimeMocks.SyncQueueManager }))
+vi.mock('./network', () => ({ NetworkMonitor: runtimeMocks.NetworkMonitor }))
+vi.mock('./websocket', () => ({ WebSocketManager: runtimeMocks.WebSocketManager }))
+
+/**
+ * The real SyncEngine, with only `start`/`stop` neutered — same trade as the
+ * endpoint seam file. `mergeRemoteCrdtForNote` and the CrdtSyncCoordinator it
+ * delegates to are the shipped implementation, which is what makes
+ * `crdtProvider.open` a real observation of the dangerous call.
+ */
+vi.mock('./engine', async () => {
+  const actual = await vi.importActual<typeof import('./engine')>('./engine')
+  class TestSyncEngine extends actual.SyncEngine {
+    async start(): Promise<void> {}
+    async stop(): Promise<void> {}
+  }
+  return { SyncEngine: TestSyncEngine }
+})
+
+vi.mock('../telemetry/diagnostics', () => ({ trackMainError: runtimeMocks.trackMainError }))
+vi.mock('./worker-bridge', () => ({ SyncWorkerBridge: runtimeMocks.SyncWorkerBridge }))
+vi.mock('./crdt-queue', () => ({ CrdtUpdateQueue: runtimeMocks.CrdtUpdateQueue }))
+
+vi.mock('./task-sync', () => ({
+  initTaskSyncService: runtimeMocks.taskSync.init,
+  resetTaskSyncService: runtimeMocks.taskSync.reset
+}))
+vi.mock('./inbox-sync', () => ({
+  initInboxSyncService: runtimeMocks.inboxSync.init,
+  resetInboxSyncService: runtimeMocks.inboxSync.reset
+}))
+vi.mock('./filter-sync', () => ({
+  initFilterSyncService: runtimeMocks.filterSync.init,
+  resetFilterSyncService: runtimeMocks.filterSync.reset
+}))
+vi.mock('./task-activity-sync', () => ({
+  initTaskActivitySyncService: runtimeMocks.taskActivitySync.init,
+  resetTaskActivitySyncService: runtimeMocks.taskActivitySync.reset
+}))
+vi.mock('./bookmark-sync', () => ({
+  initBookmarkSyncService: runtimeMocks.bookmarkSync.init,
+  resetBookmarkSyncService: runtimeMocks.bookmarkSync.reset
+}))
+vi.mock('./template-sync', () => ({
+  initTemplateSyncService: runtimeMocks.templateSync.init,
+  resetTemplateSyncService: runtimeMocks.templateSync.reset
+}))
+vi.mock('./home-page-sync', () => ({
+  initHomePageSyncService: runtimeMocks.homePageSync.init,
+  resetHomePageSyncService: runtimeMocks.homePageSync.reset
+}))
+vi.mock('./reminder-sync', () => ({
+  initReminderSyncService: runtimeMocks.reminderSync.init,
+  resetReminderSyncService: runtimeMocks.reminderSync.reset
+}))
+vi.mock('./canvas-sync', () => ({
+  initCanvasSyncService: vi.fn(() => ({})),
+  resetCanvasSyncService: vi.fn(),
+  getCanvasSyncService: vi.fn(() => null)
+}))
+vi.mock('./canvas-folder-sync', () => ({
+  initCanvasFolderSyncService: vi.fn(() => ({})),
+  resetCanvasFolderSyncService: vi.fn(),
+  getCanvasFolderSyncService: vi.fn(() => null)
+}))
+vi.mock('./project-sync', () => ({
+  initProjectSyncService: runtimeMocks.projectSync.init,
+  resetProjectSyncService: runtimeMocks.projectSync.reset
+}))
+vi.mock('./settings-sync', () => ({
+  initSettingsSyncManager: runtimeMocks.settingsSync.init,
+  resetSettingsSyncManager: runtimeMocks.settingsSync.reset
+}))
+vi.mock('./note-sync', () => ({
+  initNoteSyncService: runtimeMocks.noteSync.init,
+  resetNoteSyncService: runtimeMocks.noteSync.reset
+}))
+vi.mock('./journal-sync', () => ({
+  initJournalSyncService: runtimeMocks.journalSync.init,
+  resetJournalSyncService: runtimeMocks.journalSync.reset
+}))
+vi.mock('./tag-definition-sync', () => ({
+  initTagDefinitionSyncService: runtimeMocks.tagDefinitionSync.init,
+  resetTagDefinitionSyncService: runtimeMocks.tagDefinitionSync.reset
+}))
+vi.mock('./tag-category-sync', () => ({
+  initTagCategorySyncService: runtimeMocks.tagCategorySync.init,
+  resetTagCategorySyncService: runtimeMocks.tagCategorySync.reset
+}))
+vi.mock('./folder-config-sync', () => ({
+  initFolderConfigSyncService: runtimeMocks.folderConfigSync.init,
+  resetFolderConfigSyncService: runtimeMocks.folderConfigSync.reset
+}))
+vi.mock('./calendar-event-sync', () => ({
+  initCalendarEventSyncService: runtimeMocks.calendarEventSync.init,
+  resetCalendarEventSyncService: runtimeMocks.calendarEventSync.reset
+}))
+vi.mock('./calendar-source-sync', () => ({
+  initCalendarSourceSyncService: runtimeMocks.calendarSourceSync.init,
+  resetCalendarSourceSyncService: runtimeMocks.calendarSourceSync.reset
+}))
+vi.mock('./calendar-binding-sync', () => ({
+  initCalendarBindingSyncService: runtimeMocks.calendarBindingSync.init,
+  resetCalendarBindingSyncService: runtimeMocks.calendarBindingSync.reset
+}))
+vi.mock('./calendar-external-event-sync', () => ({
+  initCalendarExternalEventSyncService: runtimeMocks.calendarExternalEventSync.init,
+  resetCalendarExternalEventSyncService: runtimeMocks.calendarExternalEventSync.reset
+}))
+
+vi.mock('./item-handlers', () => ({ getRemoteSyncAdapter: runtimeMocks.getRemoteSyncAdapter }))
+vi.mock('./device-keys', () => ({ getDeviceSigningKey: runtimeMocks.getDeviceSigningKey }))
+
+vi.mock('./crdt-provider', () => ({
+  getCrdtProvider: vi.fn(() => runtimeMocks.crdtProvider),
+  resetCrdtProvider: runtimeMocks.resetCrdtProvider
+}))
+
+// NOTE: './crdt-pending-notes' is deliberately NOT mocked. It is one half of the
+// seam under test, and it is the durable store the other assertions read.
+
+vi.mock('./dirty-recovery', () => ({ recoverDirtyItems: runtimeMocks.recoverDirtyItems }))
+
+vi.mock('../billing/paddle-billing', () => ({
+  resolveEntitlementForSyncStart: (...args: unknown[]) =>
+    runtimeMocks.resolveEntitlementForSyncStart(...args)
+}))
+
+vi.mock('./crdt-encrypt', () => ({ encryptCrdtUpdate: runtimeMocks.encryptCrdtUpdate }))
+
+vi.mock('./http-client', () => ({
+  postToServer: runtimeMocks.postToServer,
+  pushCrdtSnapshot: runtimeMocks.pushCrdtSnapshot,
+  pushCrdtFullUpdate: runtimeMocks.pushCrdtFullUpdate,
+  getFromServer: runtimeMocks.getFromServer,
+  fetchCrdtSnapshot: runtimeMocks.fetchCrdtSnapshot,
+  SyncServerError: runtimeMocks.SyncServerError,
+  NetworkError: class NetworkError extends Error {},
+  RateLimitError: class RateLimitError extends Error {},
+  AttachmentTooLargeError: class AttachmentTooLargeError extends Error {}
+}))
+
+vi.mock('./retry', () => ({
+  withRetry: runtimeMocks.withRetry,
+  DeadLetterError: class DeadLetterError extends Error {
+    constructor(public lastError: unknown) {
+      super('dead letter')
+    }
+  }
+}))
+
+vi.mock('./token-manager', () => ({
+  emitSessionExpired: runtimeMocks.emitSessionExpired,
+  getValidAccessToken: runtimeMocks.getValidAccessToken,
+  refreshAccessToken: runtimeMocks.refreshAccessToken,
+  retrieveToken: runtimeMocks.retrieveToken,
+  setOnTokenRefreshed: runtimeMocks.setOnTokenRefreshed
+}))
+
+vi.mock('./key-verification', () => ({
+  checkLocalKeyAgainstAccount: vi.fn().mockResolvedValue('unknown'),
+  isKeyMaterialActivityRecent: vi.fn().mockReturnValue(false)
+}))
+
+function createDb() {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ get: vi.fn(() => runtimeMocks.currentDevice) }))
+      }))
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: vi.fn(() => ({ run: vi.fn() })) }))
+    }))
+  }
+}
+
+function createIndexDb() {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ all: vi.fn(() => runtimeMocks.indexRows) }))
+      }))
+    }))
+  }
+}
+
+/** Note ids `crdtProvider.open` was actually called for, in order. */
+function openedNotes(): string[] {
+  return runtimeMocks.crdtProvider.open.mock.calls.map((call) => (call as unknown[])[0] as string)
+}
+
+describe('pending CRDT drain liveness, stopSyncRuntime to the durable store', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    runtimeMocks.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-drain-seam-'))
+    runtimeMocks.indexRows = [{ id: 'note-a', title: 'Note A', date: null }]
+    runtimeMocks.currentDevice = { id: 'device-1', signingPublicKey: null }
+    runtimeMocks.db = createDb()
+    runtimeMocks.getDatabase.mockReturnValue(runtimeMocks.db)
+    runtimeMocks.getIndexDatabase.mockReturnValue(createIndexDb())
+    runtimeMocks.retrieveToken.mockResolvedValue('refresh-token')
+    runtimeMocks.storeGet.mockReturnValue({})
+    runtimeMocks.getValidAccessToken.mockResolvedValue('access-token')
+    runtimeMocks.getOrInitializeLocalVaultKey.mockResolvedValue(new Uint8Array([1, 2, 3]))
+    runtimeMocks.retrieveKey.mockResolvedValue(new Uint8Array([4, 5, 6]))
+    runtimeMocks.deriveDevicePublicKey.mockReturnValue(new Uint8Array([7, 8, 9]))
+    runtimeMocks.encryptCrdtUpdate.mockReturnValue(new Uint8Array([10, 11]))
+    runtimeMocks.postToServer.mockResolvedValue({ ok: true })
+    runtimeMocks.pushCrdtSnapshot.mockResolvedValue({ ok: true })
+    runtimeMocks.pushCrdtFullUpdate.mockResolvedValue({ ok: true })
+    runtimeMocks.crdtProvider.init.mockResolvedValue(undefined)
+    runtimeMocks.crdtProvider.seedExistingDocs.mockResolvedValue(0)
+    runtimeMocks.crdtProvider.open.mockResolvedValue({})
+    runtimeMocks.crdtProvider.pushSnapshotForNote.mockResolvedValue(true)
+    runtimeMocks.crdtProvider.validateNoteForCrdt.mockReturnValue({ ok: true })
+    runtimeMocks.crdtProvider.pushAllSnapshots.mockResolvedValue(0)
+    runtimeMocks.crdtProvider.destroy.mockResolvedValue(undefined)
+    runtimeMocks.crdtProvider.getDoc.mockReturnValue(undefined)
+    runtimeMocks.crdtProvider.closeIfInactive.mockResolvedValue(true)
+    runtimeMocks.crdtProvider.getStateVector.mockReturnValue(new Uint8Array([1, 2, 3, 4]))
+    runtimeMocks.syncGoogleCalendarSource.mockResolvedValue(undefined)
+    runtimeMocks.resolveEntitlementForSyncStart.mockResolvedValue({
+      isPaid: true,
+      plan: 'plus',
+      status: 'active'
+    })
+    runtimeMocks.getFromServer.mockResolvedValue({ updates: [], hasMore: false })
+    runtimeMocks.fetchCrdtSnapshot.mockResolvedValue(null)
+  })
+
+  afterEach(() => {
+    fs.rmSync(runtimeMocks.userDataDir, { recursive: true, force: true })
+  })
+
+  /**
+   * Hold the very first per-note snapshot baseline GET. That call sits inside
+   * `applyCrdtIncrementals`, immediately after the note is opened, so the drain
+   * parks mid-merge on its first note with the rest of the backlog untouched —
+   * the exact state a quit or a vault switch catches it in.
+   */
+  function holdFirstPull(): { reached: Promise<void>; release: () => void } {
+    let sawIt!: () => void
+    let letGo!: () => void
+    const reached = new Promise<void>((resolve) => {
+      sawIt = resolve
+    })
+    const held = new Promise<void>((resolve) => {
+      letGo = resolve
+    })
+    let holding = false
+    runtimeMocks.fetchCrdtSnapshot.mockImplementation(async () => {
+      if (!holding) {
+        holding = true
+        sawIt()
+        await held
+      }
+      return null
+    })
+    return { reached, release: letGo }
+  }
+
+  it('stops merging the rest of the backlog the moment its runtime is torn down', async () => {
+    const { readPendingCrdtNotes, recordPendingCrdtNotes } = await import('./crdt-pending-notes')
+    // Two notes recorded by an earlier session: edits made while signed out or
+    // offline, whose ids are the only record that the server is owed them.
+    recordPendingCrdtNotes(['note-a', 'note-b'])
+
+    const gate = holdFirstPull()
+    const runtime = await import('./runtime')
+
+    // #given a runtime whose startup replay is mid-pull on note-a
+    await runtime.startSyncRuntime()
+    await gate.reached
+    expect(openedNotes()).toEqual(['note-a'])
+
+    // #when the session is torn down — sign-out, vault switch, quit — which does
+    // NOT await the replay
+    await runtime.stopSyncRuntime()
+    gate.release()
+    await vi.waitFor(() => expect(readPendingCrdtNotes()).toEqual(['note-b']))
+
+    // #then note-b is never opened on the destroyed provider. `destroy()` nulls
+    // persistence, so `open` would build a doc from markdown, apply the server's
+    // updates to it and save none of it — into a vault this session may no
+    // longer own.
+    expect(openedNotes()).toEqual(['note-a'])
+
+    // #and its id survives in the durable store. An aborted drain must not clear
+    // what it did not push; leaving note-b for the next session is the point.
+    expect(readPendingCrdtNotes()).toEqual(['note-b'])
+  })
+
+  it('replays the surviving backlog under the next runtime, which the old signal must not abort', async () => {
+    const { readPendingCrdtNotes, recordPendingCrdtNotes } = await import('./crdt-pending-notes')
+    recordPendingCrdtNotes(['note-a', 'note-b'])
+
+    const gate = holdFirstPull()
+    const runtime = await import('./runtime')
+    await runtime.startSyncRuntime()
+    await gate.reached
+    await runtime.stopSyncRuntime()
+    gate.release()
+    await vi.waitFor(() => expect(readPendingCrdtNotes()).toEqual(['note-b']))
+    runtimeMocks.crdtProvider.open.mockClear()
+
+    // #when the user signs back in, or the next launch starts sync
+    await runtime.startSyncRuntime()
+
+    // #then note-b is picked up and pushed. A liveness flag kept in module state
+    // rather than on the deps would latch on the first teardown and silently
+    // strand every backlog for the rest of the process — a fix that looks like
+    // this one and never syncs anything again.
+    await vi.waitFor(() => expect(readPendingCrdtNotes()).toEqual([]))
+    expect(openedNotes()).toEqual(['note-b'])
+
+    await runtime.stopSyncRuntime()
+  })
+})

--- a/apps/desktop/src/main/sync/crdt-drain-teardown-seam.test.ts
+++ b/apps/desktop/src/main/sync/crdt-drain-teardown-seam.test.ts
@@ -53,6 +53,7 @@ const runtimeMocks = vi.hoisted(() => {
   }
 
   class NetworkMonitor {
+    static instances: NetworkMonitor[] = []
     online = true
     listeners = new Map<string, (event: { online: boolean }) => void>()
     start = vi.fn()
@@ -63,6 +64,9 @@ const runtimeMocks = vi.hoisted(() => {
     removeListener = vi.fn((event: string, cb: (payload: { online: boolean }) => void) => {
       if (this.listeners.get(event) === cb) this.listeners.delete(event)
     })
+    constructor() {
+      NetworkMonitor.instances.push(this)
+    }
   }
 
   class WebSocketManager {
@@ -421,10 +425,23 @@ function openedNotes(): string[] {
   return runtimeMocks.crdtProvider.open.mock.calls.map((call) => (call as unknown[])[0] as string)
 }
 
+/**
+ * Let every pending microtask AND macrotask turn run out.
+ *
+ * Needed for the negative assertions: "the drain never opened this note" is only
+ * worth anything once the drain has had every chance to. A drain that is not
+ * aborted reaches `crdtProvider.open` in a handful of turns, so this is far more
+ * headroom than it needs.
+ */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 25; i++) await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
 describe('pending CRDT drain liveness, stopSyncRuntime to the durable store', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    runtimeMocks.NetworkMonitor.instances = []
     runtimeMocks.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-drain-seam-'))
     runtimeMocks.indexRows = [{ id: 'note-a', title: 'Note A', date: null }]
     runtimeMocks.currentDevice = { id: 'device-1', signingPublicKey: null }
@@ -521,6 +538,52 @@ describe('pending CRDT drain liveness, stopSyncRuntime to the durable store', ()
     // #and its id survives in the durable store. An aborted drain must not clear
     // what it did not push; leaving note-b for the next session is the point.
     expect(readPendingCrdtNotes()).toEqual(['note-b'])
+  })
+
+  it('aborts a replay triggered by a reconnect that lands mid-teardown', async () => {
+    // The window is real, and it is wide. `stopSyncRuntime` clears the module
+    // slot early — `runtimeAbortController = null`, before it destroys anything
+    // — but it does not remove the network listener until the very end, after
+    // `await pushAllSnapshots()`, `await engine.stop()` and
+    // `await workerBridge.stop()`. NetworkMonitor's poll timer is still running
+    // for that whole stretch (`network.stop()` is the line after
+    // `removeListener`), and a pre-shutdown snapshot push is a real R2 round
+    // trip per dirty note — seconds on a flaky connection, which is exactly the
+    // connection an offline→online transition comes from.
+    //
+    // So `replayPendingCrdtNotes` CAN be invoked with the slot already null. It
+    // rebuilds its deps object on every call, so reading the slot instead of the
+    // captured local would hand the drain `signal: undefined` — no liveness
+    // check at all — and it would merge the whole backlog into a provider this
+    // same teardown destroys three lines later.
+    const { readPendingCrdtNotes, recordPendingCrdtNotes } = await import('./crdt-pending-notes')
+    const runtime = await import('./runtime')
+
+    // #given a session that started with nothing owed, so the startup replay is
+    // a no-op and this test observes only the teardown-window drain
+    await runtime.startSyncRuntime()
+    await settle()
+    expect(openedNotes()).toEqual([])
+
+    // #and an edit recorded during the session with no queue to take it
+    recordPendingCrdtNotes(['note-x'])
+
+    // #when the device comes back online while teardown is awaiting the
+    // pre-shutdown snapshot push
+    const network = runtimeMocks.NetworkMonitor.instances.at(-1)!
+    runtimeMocks.crdtProvider.pushAllSnapshots.mockImplementation(async () => {
+      const onStatusChanged = network.listeners.get('status-changed')
+      expect(onStatusChanged).toBeDefined()
+      onStatusChanged!({ online: true })
+      return 0
+    })
+    await runtime.stopSyncRuntime()
+    await settle()
+
+    // #then the replay that reconnect triggered reads the torn-down runtime's
+    // own signal — already tripped — and never opens the note.
+    expect(openedNotes()).toEqual([])
+    expect(readPendingCrdtNotes()).toEqual(['note-x'])
   })
 
   it('replays the surviving backlog under the next runtime, which the old signal must not abort', async () => {

--- a/apps/desktop/src/main/sync/crdt-pending-notes.test.ts
+++ b/apps/desktop/src/main/sync/crdt-pending-notes.test.ts
@@ -404,6 +404,120 @@ describe('crdt pending note store', () => {
     expect(readPendingCrdtNotes()).toEqual(['note-a'])
   })
 
+  it('stops before merging the next note once its runtime is torn down', async () => {
+    // Nothing awaits this drain — stopSyncRuntime fires it and moves on — so a
+    // run started by a dying session can still be walking the backlog while the
+    // provider is destroyed underneath it. `mergeRemote` is the dangerous half:
+    // it opens the note on that provider, whose persistence is now null, so the
+    // server state it applies goes into a doc nothing will ever save.
+    const { drainPendingCrdtNotes, readPendingCrdtNotes, recordPendingCrdtNotes } =
+      await import('./crdt-pending-notes')
+    recordPendingCrdtNotes(['note-a', 'note-b', 'note-c'])
+
+    const controller = new AbortController()
+    const merged: string[] = []
+    const result = await drainPendingCrdtNotes({
+      isSyncable: () => true,
+      mergeRemote: async (noteId) => {
+        merged.push(noteId)
+        // Teardown lands while the first note's pull is in flight.
+        controller.abort()
+        return true
+      },
+      pushSnapshot: async () => true,
+      signal: controller.signal
+    })
+
+    expect(merged).toEqual(['note-a'])
+    expect(result).toEqual({ cleared: 1, retained: 2 })
+    // Only the note that genuinely reached the server is cleared. The two the
+    // run never got to stay owed, for the next session to replay.
+    expect(readPendingCrdtNotes()).toEqual(['note-b', 'note-c'])
+  })
+
+  it('clears nothing when a deferred run starts after its session is already gone', async () => {
+    // The queued run holds the newest caller's deps, and a teardown with nothing
+    // replacing it leaves those pointing at the dead session. It starts anyway —
+    // the deferral queue has no idea a session ended — and must find itself
+    // aborted before it touches anything.
+    const { drainPendingCrdtNotes, readPendingCrdtNotes, recordPendingCrdtNotes } =
+      await import('./crdt-pending-notes')
+    recordPendingCrdtNotes(['note-a', 'note-b'])
+
+    const controller = new AbortController()
+    controller.abort()
+    const mergeRemote = vi.fn(async (_noteId: string) => true)
+    const pushSnapshot = vi.fn(async (_noteId: string) => true)
+
+    const result = await drainPendingCrdtNotes({
+      isSyncable: () => true,
+      mergeRemote,
+      pushSnapshot,
+      signal: controller.signal
+    })
+
+    expect(mergeRemote).not.toHaveBeenCalled()
+    expect(pushSnapshot).not.toHaveBeenCalled()
+    expect(result).toEqual({ cleared: 0, retained: 2 })
+    expect(readPendingCrdtNotes()).toEqual(['note-a', 'note-b'])
+  })
+
+  it('issues no merge for a note whose signal tripped after the loop looked', async () => {
+    // The top-of-iteration check is a whole loop body away from the merge, and
+    // everything in between is the caller's code: `isSyncable` is
+    // `crdtProvider.validateNoteForCrdt`, which reaches the index database. The
+    // merge is the half that opens the note on a provider teardown has already
+    // destroyed, so it re-reads the signal for itself rather than trusting a
+    // read taken before arbitrary caller code ran.
+    const { drainPendingCrdtNotes, readPendingCrdtNotes, recordPendingCrdtNotes } =
+      await import('./crdt-pending-notes')
+    recordPendingCrdtNotes(['note-a'])
+
+    const controller = new AbortController()
+    const mergeRemote = vi.fn(async (_noteId: string) => true)
+
+    await drainPendingCrdtNotes({
+      isSyncable: () => {
+        controller.abort()
+        return true
+      },
+      mergeRemote,
+      pushSnapshot: async () => true,
+      signal: controller.signal
+    })
+
+    expect(mergeRemote).not.toHaveBeenCalled()
+    expect(readPendingCrdtNotes()).toEqual(['note-a'])
+  })
+
+  it('keeps draining after a note whose syncability check throws', async () => {
+    // `isSyncable` is `crdtProvider.validateNoteForCrdt`, which reaches the index
+    // database — and `closeVault` calls `closeAllDatabases()`. Outside the
+    // per-note try that throw abandoned the whole pass, so every remaining note
+    // was skipped for that run even though the databases might be back.
+    const { drainPendingCrdtNotes, readPendingCrdtNotes, recordPendingCrdtNotes } =
+      await import('./crdt-pending-notes')
+    recordPendingCrdtNotes(['note-a', 'note-boom', 'note-c'])
+
+    const pushed: string[] = []
+    const result = await drainPendingCrdtNotes({
+      isSyncable: (noteId) => {
+        if (noteId === 'note-boom') throw new Error('The index database is closed')
+        return true
+      },
+      mergeRemote: async () => true,
+      pushSnapshot: async (noteId) => {
+        pushed.push(noteId)
+        return true
+      }
+    })
+
+    expect(pushed).toEqual(['note-a', 'note-c'])
+    expect(result).toEqual({ cleared: 2, retained: 1 })
+    // The note that threw is not cleared, so the next pass retries it.
+    expect(readPendingCrdtNotes()).toEqual(['note-boom'])
+  })
+
   it('drops notes that no longer exist instead of retrying them forever', async () => {
     const { drainPendingCrdtNotes, readPendingCrdtNotes, recordPendingCrdtNotes } =
       await import('./crdt-pending-notes')

--- a/apps/desktop/src/main/sync/crdt-pending-notes.ts
+++ b/apps/desktop/src/main/sync/crdt-pending-notes.ts
@@ -223,6 +223,22 @@ export interface PendingCrdtDrainDeps {
   pushSnapshot: (noteId: string) => Promise<boolean>
   /** `false` for notes that no longer exist or never sync via CRDT (binaries). */
   isSyncable: (noteId: string) => boolean
+  /**
+   * Tripped when the runtime that supplied these deps is torn down.
+   *
+   * `mergeRemote` and `pushSnapshot` both close over one `SyncEngine` and one
+   * `CrdtProvider`, and neither survives `stopSyncRuntime`. Nothing awaits this
+   * drain — `replayPendingCrdtNotes` is fire-and-forget — so without a liveness
+   * signal a run started by a dying session keeps merging server state into a
+   * destroyed provider: `destroy()` nulls its persistence, so `open()` builds a
+   * fresh doc from markdown and applies the server's updates to something
+   * nothing will ever save, possibly against a vault the session no longer owns.
+   *
+   * Optional so the contract stays "no signal means the caller cannot be torn
+   * down mid-drain" — the shape `pullCrdtForNotes` already uses for the same
+   * problem. runtime.ts is the only production caller and always passes one.
+   */
+  signal?: AbortSignal
 }
 
 interface PendingCrdtDrainResult {
@@ -252,11 +268,21 @@ interface PendingCrdtDrainResult {
  * and a new one starts while a drain is still running, the new session's
  * trigger replaces the dead session's closure rather than queueing behind it.
  *
- * A teardown with nothing replacing it leaves the queued run holding the dead
- * runtime's deps — the same exposure a drain already in flight has, since
- * teardown does not await it. It fails closed: `CrdtProvider.destroy()` nulls
- * `snapshotPushFn`, and `pushSnapshotForNote` returns false without one, so
- * nothing is cleared and every id stays in the durable store for next session.
+ * Abort travels with the deps rather than with this module's state, and that is
+ * what settles the remaining case. A teardown with nothing replacing it leaves
+ * the queued run holding the dead runtime's deps — but that same teardown has
+ * already tripped their `signal`, so the deferred run starts, finds itself
+ * aborted at its first note and clears nothing. A teardown that *is* followed by
+ * a new session has had `deferredDeps` swapped for the live session's, and the
+ * live signal is the one that run reads. Aborting the in-flight run while a
+ * deferred run begins with a fresh signal is the intended outcome, not a race:
+ * every run is "replay whatever the store holds when you start", and the ids the
+ * aborted run did not reach are still in the store for the new one to take.
+ *
+ * The old argument here was that a dead session's queued run fails closed on
+ * `snapshotPushFn` being nulled by `CrdtProvider.destroy()`. That is still true
+ * of the push, and it is still not enough: the merge runs first and had no
+ * equivalent guard, which is exactly what the signal supplies.
  */
 let inFlight: Promise<PendingCrdtDrainResult> | null = null
 let deferredRun: Promise<PendingCrdtDrainResult> | null = null
@@ -335,28 +361,63 @@ async function drainOnce(deps: PendingCrdtDrainDeps): Promise<PendingCrdtDrainRe
   if (pending.length === 0) return { cleared: 0, retained: 0 }
 
   const cleared: string[] = []
+  let aborted = false
   try {
     for (const noteId of pending) {
-      if (!deps.isSyncable(noteId)) {
-        cleared.push(noteId)
-        continue
+      // The runtime whose engine and provider these deps close over is gone.
+      // Stop here rather than at the end of the pass: every remaining note would
+      // be worked against destroyed objects, and the ids stay in the store.
+      if (deps.signal?.aborted) {
+        aborted = true
+        break
       }
       try {
+        if (!deps.isSyncable(noteId)) {
+          cleared.push(noteId)
+          continue
+        }
+        // Checked again, and this is the check that matters. `isSyncable` is the
+        // caller's code — today it reaches the index database, which `closeVault`
+        // closes — so control can spend real time between the top of the
+        // iteration and here, and the loop awaits twice per note besides. The
+        // merge is the destructive half: it opens the note on the caller's
+        // CrdtProvider, and a destroyed provider has no persistence, so the
+        // server state it applies lands in a doc nothing will ever save.
+        if (deps.signal?.aborted) {
+          aborted = true
+          break
+        }
         if (!(await deps.mergeRemote(noteId))) {
           log.warn('Not replaying a CRDT note whose server state did not merge', { noteId })
           continue
         }
         if (await deps.pushSnapshot(noteId)) cleared.push(noteId)
       } catch (err) {
+        // Per note, not per pass — the shape `applyCrdtBatchChunk` already uses.
+        // `isSyncable` is inside this try on purpose: `closeVault` calls
+        // `closeAllDatabases()`, after which `validateNoteForCrdt` throws for
+        // every remaining id, and one throw used to abandon the whole drain.
+        // A note that threw is not cleared, so the next pass retries it.
         log.warn('Failed to replay a pending CRDT note', { noteId, error: err })
       }
     }
   } finally {
+    // Abort or not, only ids whose state actually reached the server — or that
+    // resolve to nothing to send — are cleared. Everything this run did not get
+    // to stays in the durable store for the next session, which is the whole
+    // reason stopping early is safe.
     clearPendingCrdtNotes(cleared)
   }
 
   const retained = pending.length - cleared.length
-  if (retained > 0) {
+  if (aborted) {
+    // Distinct from the warning below on purpose: this is an expected teardown,
+    // not a device that cannot reach the server, and log triage greps these.
+    log.info('Stopped replaying CRDT notes: the sync runtime that started the replay is gone', {
+      cleared: cleared.length,
+      retained
+    })
+  } else if (retained > 0) {
     log.warn('Some CRDT notes buffered at shutdown still have not synced', {
       cleared: cleared.length,
       retained

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -165,7 +165,18 @@ function emitLocalOnly(): void {
 
 let runtime: SyncRuntimeState | null = null
 let startPromise: Promise<SyncEngine | null> | null = null
-let seedAbortController: AbortController | null = null
+/**
+ * Liveness for the work this runtime starts and then does not await.
+ *
+ * Two things hang off it and neither is awaited by `stopSyncRuntime`: the
+ * initial CRDT seed, and the pending-note replay. A replay that outlives its
+ * runtime calls `crdtProvider.open` on a destroyed provider, whose persistence
+ * is null — so it builds a doc from markdown, applies the server's updates to
+ * it, and nothing ever saves the result, against a vault this session may no
+ * longer own. One signal stops both, and it is tripped before teardown touches
+ * the provider.
+ */
+let runtimeAbortController: AbortController | null = null
 let deferredStartTimer: NodeJS.Timeout | null = null
 
 const DEFERRED_START_GRACE_MS = 2_000
@@ -730,6 +741,15 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
       const crdtProvider = getCrdtProvider()
       await crdtProvider.init(crdtQueue, snapshotPushFn)
 
+      // Created here rather than beside `engine.start()`, where it used to be:
+      // the replay below is also triggered by the network monitor, whose
+      // listener is attached further down, so the signal has to exist before
+      // anything can fire. Held in a local as well as the module slot — the
+      // closures below belong to THIS runtime and must carry this runtime's
+      // signal even after teardown has cleared the slot or a new session has
+      // filled it.
+      const runtimeAbort = (runtimeAbortController = new AbortController())
+
       // Notes the server is owed and has no other way to learn about:
       //
       //   - updates still buffered when the app last quit paused (offline /
@@ -751,11 +771,17 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
       // referenced lazily: this closure only ever runs after the const below
       // is initialised (startup calls it at the end, and no network event can
       // be delivered between `network.on` and that assignment).
+      //
+      // Nothing awaits the returned promise, here or at either call site, so the
+      // drain is handed this runtime's abort signal as its liveness check. Both
+      // of the fns above are bound to objects `stopSyncRuntime` destroys, and
+      // the merge is the one that does damage after that point — see #1514.
       const replayPendingCrdtNotes = (): void => {
         void drainPendingCrdtNotes({
           mergeRemote: (noteId) => engine.mergeRemoteCrdtForNote(noteId),
           pushSnapshot: (noteId) => crdtProvider.pushSnapshotForNote(noteId),
-          isSyncable: (noteId) => crdtProvider.validateNoteForCrdt(noteId).ok
+          isSyncable: (noteId) => crdtProvider.validateNoteForCrdt(noteId).ok,
+          signal: runtimeAbort.signal
         }).catch((err) => log.warn('Pending CRDT note replay failed', err))
       }
 
@@ -900,8 +926,6 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
       }
       runtime = pendingRuntime
 
-      seedAbortController = new AbortController()
-
       await engine.start()
       log.info('Sync runtime started')
 
@@ -933,7 +957,7 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
         result: 'success'
       })
 
-      seedPromise = seedExistingCrdtDocs(crdtProvider, seedAbortController.signal).catch((err) => {
+      seedPromise = seedExistingCrdtDocs(crdtProvider, runtimeAbort.signal).catch((err) => {
         log.warn('Post-engine CRDT seed failed (non-fatal)', err)
       })
 
@@ -951,6 +975,11 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
         await pendingRuntime.workerBridge.stop().catch(() => {})
         await pendingRuntime.engine.stop().catch(() => {})
       }
+      // Same reason as the teardown path: this branch destroys the provider, and
+      // the network monitor can have fired a pending-note replay at any point
+      // after `network.on` above. That replay must not keep merging into it.
+      runtimeAbortController?.abort()
+      runtimeAbortController = null
       await getCrdtProvider()
         .destroy()
         .catch((err) => {
@@ -989,10 +1018,13 @@ export async function stopSyncRuntime(options?: { skipFinalSync?: boolean }): Pr
     await startPromise.catch(() => {})
   }
 
-  if (seedAbortController) {
-    seedAbortController.abort()
-    seedAbortController = null
-  }
+  // After the in-flight start is awaited, so this is the controller belonging to
+  // the runtime being stopped — and before everything else, in particular before
+  // the provider is destroyed below. The seed and the pending-note replay both
+  // run unawaited, and the replay's next `mergeRemote` is the call that would
+  // open a note on a provider with no persistence left.
+  runtimeAbortController?.abort()
+  runtimeAbortController = null
   if (seedPromise) {
     await seedPromise.catch(() => {})
     seedPromise = null

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -744,10 +744,20 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
       // Created here rather than beside `engine.start()`, where it used to be:
       // the replay below is also triggered by the network monitor, whose
       // listener is attached further down, so the signal has to exist before
-      // anything can fire. Held in a local as well as the module slot — the
-      // closures below belong to THIS runtime and must carry this runtime's
-      // signal even after teardown has cleared the slot or a new session has
-      // filled it.
+      // anything can fire.
+      //
+      // Held in a local as well as the module slot, and the closures below read
+      // the LOCAL. They belong to this runtime and must carry this runtime's
+      // signal, which the module slot stops holding well before those closures
+      // stop being reachable: `stopSyncRuntime` nulls the slot up front, then
+      // awaits `pushAllSnapshots`, `engine.stop` and `workerBridge.stop` before
+      // it finally calls `network.removeListener`. NetworkMonitor's poll timer
+      // is live for all of it, so an offline→online transition landing in that
+      // window invokes `replayPendingCrdtNotes` again — and it rebuilds its deps
+      // per call. Reading the slot there would hand the drain `undefined` (no
+      // liveness check at all), or, if a new session had already filled the
+      // slot, the NEW session's live signal — either way the old runtime's drain
+      // would keep merging into the provider this teardown is about to destroy.
       const runtimeAbort = (runtimeAbortController = new AbortController())
 
       // Notes the server is owed and has no other way to learn about:

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -461,13 +461,13 @@ rather than the next time the note is closed and reopened.
 
 Five paths send a body, and each refuses independently:
 
-| Path                             | Guard                             |
-| -------------------------------- | --------------------------------- |
-| `onDocUpdate` → `CrdtUpdateQueue` | cached flag on the doc            |
-| `close()` snapshot                | cached flag on the doc            |
-| `pushAllSnapshots()` at shutdown  | cached flag on the doc            |
-| `compactDoc()` snapshot           | cached flag on the doc            |
-| `pushSnapshotForNote()`           | re-reads the `note_cache` row     |
+| Path                              | Guard                         |
+| --------------------------------- | ----------------------------- |
+| `onDocUpdate` → `CrdtUpdateQueue` | cached flag on the doc        |
+| `close()` snapshot                | cached flag on the doc        |
+| `pushAllSnapshots()` at shutdown  | cached flag on the doc        |
+| `compactDoc()` snapshot           | cached flag on the doc        |
+| `pushSnapshotForNote()`           | re-reads the `note_cache` row |
 
 `pushSnapshotForNote` re-reads the row because it is the one push path reached for a note with
 no open doc — the pending-note replay and the push coordinator's `create` both land there.
@@ -495,7 +495,7 @@ that record instead, the CRDT twin of the `removePendingNoteSyncItems` call besi
 lost, because the updates stay in the local store and a later clear re-records the note, whose
 replay pushes full state anyway.
 
-Either direction also drops the doc's snapshot debt, so the next `close()` cannot fire a *blind*
+Either direction also drops the doc's snapshot debt, so the next `close()` cannot fire a _blind_
 snapshot ahead of the merge-first replay. A snapshot asserts completeness and the server prunes
 every incremental below it, and a note that has just stopped being local-only is the population
 most likely to have diverged from a peer.
@@ -774,15 +774,57 @@ working. The queued run uses the **newest** trigger's dependencies: those close
 over one runtime's `SyncEngine` and `CrdtProvider`, and neither survives
 `stopSyncRuntime`, so a session torn down and replaced mid-drain hands the
 deferred run to the live session rather than replaying the dead one's closure. A
-teardown with nothing replacing it fails closed the same way an already-running
-drain does — `CrdtProvider.destroy()` nulls the snapshot push function, and
-`pushSnapshotForNote` returns `false` without one, so nothing is cleared and
-every id stays in the store for the next session.
+teardown with nothing replacing it leaves the queued run holding the dead
+session's dependencies — which is safe for the reason the next subsection
+describes, not because the queue knows a session ended.
 
 Notes that no longer exist, or never sync via CRDT (binaries), are dropped at
 drain time rather than retried forever, and a doc with no content is not pushed
 at all — a snapshot is a full note body and an R2 write, so the replay only pays
 for notes that need it.
+
+### A drain stops when the runtime that started it does
+
+Nothing awaits the replay. `startSyncRuntime` fires it and returns, the network
+monitor fires it from an event handler, and `stopSyncRuntime` does not wait for
+it — so a drain can still be walking the backlog while the session that owns its
+`SyncEngine` and `CrdtProvider` is torn down underneath it.
+
+The push half of each note already failed closed: `CrdtProvider.destroy()` nulls
+the snapshot push function, and `pushSnapshotForNote` returns `false` without
+one. The **merge runs first**, and it had no equivalent guard. It reaches
+`crdtProvider.open(noteId)` on the destroyed provider, whose persistence is now
+`null`, so the provider builds a fresh doc, seeds it from markdown and applies
+the server's merged updates to something nothing will ever save — and can drive
+a markdown write-back into a vault the session no longer owns.
+
+So the runtime owns a liveness signal. One `AbortController` per session covers
+both pieces of work started and not awaited — the initial CRDT seed and the
+pending-note replay — and it is created before the network listener that can
+trigger a replay exists. `stopSyncRuntime` trips it **before** it destroys the
+provider, and the start-failure path trips it too, because that path destroys the
+provider as well. The drain checks it at the top of each note and again
+immediately before the merge, since `isSyncable` runs the caller's code in
+between and the merge is the destructive half.
+
+The signal travels **with the drain's dependencies**, not in the drain module's
+own state, and that is what makes the deferral queue correct without teaching it
+about sessions. A queued run holding a dead session's dependencies reads that
+session's tripped signal and clears nothing; a queued run whose dependencies were
+replaced by a new session reads the new session's live signal and runs in full.
+Liveness kept as module state would latch on the first teardown and silently
+strand every backlog for the rest of the process.
+
+An aborted drain still clears only the ids whose state actually reached the
+server. Everything it did not get to stays in `crdt-pending-notes.json` for the
+next session, which is what makes stopping early a delay rather than a loss.
+
+One note's failure also no longer abandons the rest of the pass. `isSyncable` is
+`CrdtProvider.validateNoteForCrdt`, which reads the index database, and
+`closeVault` closes it — so it throws for every remaining id. It is inside the
+per-note `try` now, the same shape the CRDT batch pull uses: a note that throws
+is not cleared and is retried next pass, and the notes behind it are still
+attempted.
 
 ### Merge before push, and fail closed
 


### PR DESCRIPTION
Closes #1514. Part of EPIC #1516 — the last child.

`stopSyncRuntime` never awaits the pending-note drain — `replayPendingCrdtNotes` is fire-and-forget — so a drain can outlive the runtime that started it. When it does, `mergeRemote` → `SyncEngine.mergeRemoteCrdtForNote` → `CrdtSyncCoordinator.pullCrdtForNote` calls `crdtProvider.open(noteId)` on the **old** instance. After `destroy()`, `persistence` is `null`, so `doOpen` builds a fresh doc, seeds it from markdown, and applies merged server updates to a doc **nothing will ever persist** — and can drive a write-back to a vault the session no longer owns.

Pre-existing, and not introduced by #1494 (PR #1513). That PR's fail-closed path covers the **push** — `CrdtProvider.destroy()` nulls `snapshotPushFn`, so `pushSnapshotForNote` returns `false`. But the **merge runs first** and had no equivalent guard. That asymmetry is the whole issue.

## The fix

An `AbortSignal` on `PendingCrdtDrainDeps`, owned by `runtime.ts` and tripped by `stopSyncRuntime` — and by the start-failure `catch`, which also destroys the provider.

The runtime's existing `seedAbortController` is reused rather than adding a second, renamed `runtimeAbortController` since it now covers both unawaited jobs: the initial CRDT seed and the pending-note replay. It is created earlier (right after `crdtProvider.init`) because the replay is also triggered by the network monitor, whose listener is attached further down, so the signal has to exist before anything can fire.

`drainOnce` checks it at the top of each iteration **and again immediately before `mergeRemote`**. The second check is the one that matters: `isSyncable` is the caller's code and reaches the index database, the loop awaits twice per note, and the merge is the destructive half.

Optional on the interface, so the contract stays "no signal means the caller cannot be torn down mid-drain" — the shape `pullCrdtForNotes` already uses.

### Deferred runs

No extra machinery: abort travels with the deps, not with the module's state. A queued run holding a dead session's deps reads that session's tripped signal and clears nothing. A queued run whose `deferredDeps` were swapped for a live session's reads the live signal and runs in full. The old docstring argued a dead session's queued run fails closed on `snapshotPushFn` — still true of the push, still not enough, and it is now corrected rather than left stale.

### Second defect in the same file

`deps.isSyncable` was called **outside** the per-note `try`. On `closeVault` (which calls `closeAllDatabases()`), `validateNoteForCrdt` → `getIndexDatabase()` throws and abandoned the entire drain, skipping every remaining note. Moved inside, matching the per-note shape `applyCrdtBatchChunk` already uses.

**Compat:** no migration. `PendingCrdtDrainDeps` is internal with one production caller, the signal is process-local and never serialised, and nothing changes about `crdt-pending-notes.json`, the wire protocol, IPC contracts or settings. An aborted drain writes strictly *fewer* clears than before, never more, so an older build reading the store afterwards sees a superset of what it would have seen.

## Verification

- `pnpm --filter @memry/desktop test:main` — 531 passed / 3 skipped files, 6841 passed / 1 expected fail / 6 skipped (re-run in full after rebasing onto current main)
- `pnpm typecheck` 17/17 · `pnpm lint` 0 errors · `pnpm docs:impact --strict` covered · `pnpm docs:build` ok · `git diff --check` clean

**Seam coverage.** `crdt-drain-teardown-seam.test.ts` stands up the real `startSyncRuntime`/`stopSyncRuntime` with a real `SyncEngine` and `CrdtSyncCoordinator`, writing to a real temp `userData`; only HTTP, Y.Doc mechanics and process infrastructure are mocked. It holds the first snapshot baseline GET so the drain parks mid-merge, calls the real `stopSyncRuntime`, releases, and asserts `crdtProvider.open` — the exact call from the issue — is never made for the next note, which stays in the durable store.

This mattered: **M2 (drop `signal:` from the runtime deps) and M6 (`stopSyncRuntime` no longer trips it) are invisible to all 21 unit tests.** Without the seam file, a change that fully disabled the fix in production would have shipped green — the #1489 failure mode, caught this time.

7 mutations, each proven applied, all killed.

**Reviewer mutation that initially survived, and the commit that closes it.** I mutated the deps to read the module slot instead of the captured local — `signal: runtimeAbortController?.signal` — and all 23 tests passed. The local capture is load-bearing and was asserted only by a comment. It is **reachable**, not dead defensive code: `stopSyncRuntime` nulls the slot at line 1026, but `network.removeListener` is at line 1089 — 63 lines and three awaits later, with `pushAllSnapshots` (a per-dirty-note R2 round trip) in between. A reconnect landing in that window rebuilds the deps, reads `undefined`, and runs with no liveness check at all against the provider destroyed at line 1082. The same flakiness that widens the window is what produces the offline→online transition. `018978bff` adds a test firing the real `status-changed` handler from inside `pushAllSnapshots`; under the mutation it fails alone, with `expected [ 'note-x' ] to deeply equal []`.

## Follow-up worth filing (not acted on)

`apps/desktop/src/main/sync/runtime.ts` is now at **exactly 800 code lines** against `max-lines: 800` (`eslint.config.mjs:146`). Zero headroom — the next added statement is a hard lint error. `crdt-provider.ts` hit the same wall in #1534 and was added to the `phase-tbd` exemption list.