### PR TITLE
fix(shortcuts): keep Ctrl/Cmd+B on Bold in the editor and make settings rebinds apply

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -43,6 +43,8 @@ import {
   useHintActivation,
   isInputFocused
 } from '@/hooks'
+import { matchesShortcut } from '@/hooks/use-keyboard-shortcuts-base'
+import { useShortcutBinding } from '@/lib/shortcut-bindings'
 import { HintModeProvider } from '@/contexts/hint-mode'
 import { HintOverlay, HintIndicator } from '@/components/hint-overlay'
 import { CommandPalette } from '@/components/search/command-palette'
@@ -220,6 +222,7 @@ const AppContent = (): React.JSX.Element => {
   const toggleSearch = useCallback(() => setSearchOpen((prev) => !prev), [])
   const openShortcutsDialog = useCallback(() => setShowShortcutsDialog(true), [])
   const toggleShortcutsDialog = useCallback(() => setShowShortcutsDialog((prev) => !prev), [])
+  const shortcutsHelpBinding = useShortcutBinding('view.shortcuts')
   useSearchShortcut(toggleSearch)
   useHintActivation()
   useMenuCommands({
@@ -242,9 +245,13 @@ const AppContent = (): React.JSX.Element => {
     const handleKeyDown = (event: KeyboardEvent): void => {
       const isQuestionShortcut =
         event.key === '?' && !event.metaKey && !event.ctrlKey && !event.altKey
-      const isSlashShortcut = (event.metaKey || event.ctrlKey) && event.key === '/'
+      const isBoundShortcut = matchesShortcut(
+        event,
+        shortcutsHelpBinding.key,
+        shortcutsHelpBinding.modifiers
+      )
 
-      if (!isQuestionShortcut && !isSlashShortcut) return
+      if (!isQuestionShortcut && !isBoundShortcut) return
       if (isQuestionShortcut && isInputFocused()) return
 
       event.preventDefault()
@@ -254,7 +261,7 @@ const AppContent = (): React.JSX.Element => {
 
     window.addEventListener('keydown', handleKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
-  }, [toggleShortcutsDialog])
+  }, [shortcutsHelpBinding, toggleShortcutsDialog])
 
   useEffect(() => {
     const openTestNote = (

--- a/apps/desktop/src/renderer/src/components/ui/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/sidebar.test.tsx
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { isMac } from '@/hooks/use-keyboard-shortcuts-base'
+import { __setShortcutOverridesForTests } from '@/lib/shortcut-bindings'
 import {
   Sidebar,
   SidebarContent,
@@ -56,6 +57,12 @@ describe('SidebarProvider shortcuts', () => {
     setWindowWidth(1024)
   })
 
+  afterEach(() => {
+    act(() => {
+      __setShortcutOverridesForTests({})
+    })
+  })
+
   it('toggles the desktop sidebar with Meta/Ctrl+B', () => {
     render(
       <SidebarProvider defaultOpen>
@@ -72,6 +79,53 @@ describe('SidebarProvider shortcuts', () => {
     fireEvent.keyDown(window, { key: 'b', ...sidebarToggleShortcutInit() })
 
     expect(screen.getByTestId('sidebar-state')).toHaveTextContent('expanded')
+  })
+
+  it('leaves Meta/Ctrl+B to the editor while the caret is in rich text', () => {
+    render(
+      <SidebarProvider defaultOpen>
+        <SidebarStateProbe />
+        <div
+          data-testid="rich-text"
+          contentEditable="true"
+          suppressContentEditableWarning
+          tabIndex={-1}
+        />
+      </SidebarProvider>
+    )
+
+    const editor = screen.getByTestId('rich-text')
+    editor.focus()
+
+    fireEvent.keyDown(window, { key: 'b', ...sidebarToggleShortcutInit() })
+
+    // Bold owns the chord here — the sidebar must not move too.
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('expanded')
+
+    editor.blur()
+    fireEvent.keyDown(window, { key: 'b', ...sidebarToggleShortcutInit() })
+
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('collapsed')
+  })
+
+  it('toggles on a rebound chord and ignores the replaced one', () => {
+    __setShortcutOverridesForTests({
+      'view.toggleSidebar': { key: 'b', modifiers: { alt: true } }
+    })
+
+    render(
+      <SidebarProvider defaultOpen>
+        <SidebarStateProbe />
+      </SidebarProvider>
+    )
+
+    fireEvent.keyDown(window, { key: 'b', ...sidebarToggleShortcutInit() })
+
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('expanded')
+
+    fireEvent.keyDown(window, { key: 'b', altKey: true })
+
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('collapsed')
   })
 
   it('collapses the desktop sidebar when a resize drag passes below the minimum width', () => {

--- a/apps/desktop/src/renderer/src/components/ui/sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/sidebar.tsx
@@ -18,6 +18,8 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useKeyboardShortcuts, type KeyboardShortcut } from '@/hooks/use-keyboard-shortcuts-base'
+import { isRichTextFocused } from '@/hooks/use-keyboard-shortcuts'
+import { useShortcutBinding } from '@/lib/shortcut-bindings'
 import { useT } from '@memry/i18n/renderer'
 
 const SIDEBAR_COOKIE_NAME = 'sidebar_state'
@@ -117,17 +119,24 @@ function SidebarProvider({
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
   }, [isMobile, setOpen, setOpenMobile])
 
+  const toggleBinding = useShortcutBinding('view.toggleSidebar')
+
   const sidebarShortcuts = React.useMemo<KeyboardShortcut[]>(() => {
+    const { meta, ctrl, alt } = toggleBinding.modifiers
     return [
       {
-        key: 'b',
-        modifiers: { meta: true },
+        key: toggleBinding.key,
+        modifiers: toggleBinding.modifiers,
         action: toggleSidebar,
         description: 'Toggle sidebar',
-        allowInInput: true
+        // Fine in a plain field (⌘B does nothing there), but a chord without a
+        // modifier would swallow the keystroke as the user types.
+        allowInInput: Boolean(meta || ctrl || alt),
+        // In the note editor ⌘B is Bold and nothing else.
+        when: () => !isRichTextFocused()
       }
     ]
-  }, [toggleSidebar])
+  }, [toggleBinding, toggleSidebar])
   useKeyboardShortcuts(sidebarShortcuts)
 
   const state = open ? 'expanded' : 'collapsed'

--- a/apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts-base.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts-base.ts
@@ -10,20 +10,22 @@ import { hintModeActiveRef } from '@/contexts/hint-mode'
 // TYPES
 // =============================================================================
 
+export interface ShortcutModifiers {
+  /** Meta on Mac, Ctrl on Windows/Linux */
+  meta?: boolean
+  /** Always Ctrl (e.g., Ctrl+Tab) */
+  ctrl?: boolean
+  /** Shift key */
+  shift?: boolean
+  /** Alt/Option key */
+  alt?: boolean
+}
+
 export interface KeyboardShortcut {
   /** Key to match (e.g., 'w', 'Tab', 'ArrowRight') */
   key: string
   /** Modifier keys */
-  modifiers?: {
-    /** Meta on Mac, Ctrl on Windows/Linux */
-    meta?: boolean
-    /** Always Ctrl (e.g., Ctrl+Tab) */
-    ctrl?: boolean
-    /** Shift key */
-    shift?: boolean
-    /** Alt/Option key */
-    alt?: boolean
-  }
+  modifiers?: ShortcutModifiers
   /** Action to execute */
   action: () => void
   /** Human-readable description */
@@ -57,6 +59,52 @@ export const getModifierSymbol = (modifier: 'meta' | 'ctrl' | 'shift' | 'alt'): 
     case 'alt':
       return isMac ? '⌥' : 'Alt'
   }
+}
+
+// =============================================================================
+// MATCHING
+// =============================================================================
+
+/**
+ * Does this keydown match the given chord?
+ *
+ * Shared with the raw-listener shortcut owners (new note, search, shortcuts
+ * help) so every surface resolves a rebindable binding the same way.
+ */
+export const matchesShortcut = (
+  e: KeyboardEvent,
+  key: string,
+  modifiers: ShortcutModifiers = {}
+): boolean => {
+  // Key match (case insensitive for letters)
+  if (!key) return false
+  if (e.key.toLowerCase() !== key.toLowerCase()) return false
+
+  // Meta modifier (Cmd on Mac, Ctrl on Windows)
+  const metaOrCtrl = isMac ? e.metaKey : e.ctrlKey
+  if (modifiers.meta && !metaOrCtrl) return false
+  if (!modifiers.meta && metaOrCtrl && !modifiers.ctrl) return false
+
+  // Ctrl modifier (always Ctrl, e.g., Ctrl+Tab)
+  if (modifiers.ctrl && !e.ctrlKey) return false
+
+  // Shift modifier
+  if (modifiers.shift !== undefined) {
+    if (modifiers.shift && !e.shiftKey) return false
+    if (!modifiers.shift && e.shiftKey) return false
+  } else if (e.shiftKey) {
+    return false
+  }
+
+  // Alt modifier
+  if (modifiers.alt !== undefined) {
+    if (modifiers.alt && !e.altKey) return false
+    if (!modifiers.alt && e.altKey) return false
+  } else if (e.altKey) {
+    return false
+  }
+
+  return true
 }
 
 // =============================================================================
@@ -112,34 +160,8 @@ export const useKeyboardShortcuts = (
         // Check condition
         if (when && !when()) continue
 
-        // Check key match (case insensitive for letters)
-        if (e.key.toLowerCase() !== key.toLowerCase()) continue
-
-        // Check modifiers
-        const metaOrCtrl = isMac ? e.metaKey : e.ctrlKey
-
-        // Meta modifier (Cmd on Mac, Ctrl on Windows)
-        if (modifiers.meta && !metaOrCtrl) continue
-        if (!modifiers.meta && metaOrCtrl && !modifiers.ctrl) continue
-
-        // Ctrl modifier (always Ctrl, e.g., Ctrl+Tab)
-        if (modifiers.ctrl && !e.ctrlKey) continue
-
-        // Shift modifier
-        if (modifiers.shift !== undefined) {
-          if (modifiers.shift && !e.shiftKey) continue
-          if (!modifiers.shift && e.shiftKey) continue
-        } else if (e.shiftKey) {
-          continue
-        }
-
-        // Alt modifier
-        if (modifiers.alt !== undefined) {
-          if (modifiers.alt && !e.altKey) continue
-          if (!modifiers.alt && e.altKey) continue
-        } else if (e.altKey) {
-          continue
-        }
+        // Check key and modifiers
+        if (!matchesShortcut(e, key, modifiers)) continue
 
         // All checks passed - execute action
         e.preventDefault()

--- a/apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts.ts
@@ -38,6 +38,26 @@ export const isInputFocused = (): boolean => {
 }
 
 /**
+ * Check if the caret sits in rich text — the note editor, a task description,
+ * or any other contenteditable surface where formatting keys apply.
+ *
+ * App-level shortcuts that share a chord with an editor formatting command
+ * (⌘B is both Bold and Toggle Sidebar) must stand down here: the editor owns
+ * the keystroke, and both firing at once is what users report as a double
+ * action. Plain inputs are not rich text — there is nothing to bold — so they
+ * do not claim the chord.
+ */
+export const isRichTextFocused = (): boolean => {
+  const activeElement = document.activeElement as HTMLElement | null
+  if (!activeElement) return false
+  if (activeElement.isContentEditable) return true
+  // jsdom does not implement isContentEditable; fall back to the attribute.
+  return (
+    activeElement.closest('[contenteditable="true"], [contenteditable="plaintext-only"]') !== null
+  )
+}
+
+/**
  * Check if a specific input element is the Quick-File input
  * Quick-File inputs should still allow certain shortcuts
  */

--- a/apps/desktop/src/renderer/src/hooks/use-new-note-shortcut.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-new-note-shortcut.ts
@@ -1,7 +1,10 @@
 import { useEffect, useCallback } from 'react'
+import { useShortcutBinding } from '@/lib/shortcut-bindings'
+import { matchesShortcut } from './use-keyboard-shortcuts-base'
 
 /**
- * Hook to register global ⌘N (Mac) / Ctrl+N (Windows/Linux) shortcut for creating a new note.
+ * Hook to register the New Note shortcut (⌘N / Ctrl+N by default, rebindable
+ * from Settings → Shortcuts as `nav.newNote`).
  *
  * @param onNewNote - Callback to create and open a new note
  *
@@ -11,18 +14,16 @@ import { useEffect, useCallback } from 'react'
  * ```
  */
 export function useNewNoteShortcut(onNewNote: () => void): void {
+  const binding = useShortcutBinding('nav.newNote')
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      // ⌘N on Mac, Ctrl+N on Windows/Linux
-      const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
-      const modifier = isMac ? e.metaKey : e.ctrlKey
-
-      if (modifier && e.key.toLowerCase() === 'n') {
+      if (matchesShortcut(e, binding.key, binding.modifiers)) {
         e.preventDefault()
         onNewNote()
       }
     },
-    [onNewNote]
+    [binding, onNewNote]
   )
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/hooks/use-search-shortcut.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-search-shortcut.ts
@@ -1,19 +1,27 @@
 import { useEffect, useCallback } from 'react'
+import { useShortcutBinding } from '@/lib/shortcut-bindings'
+import { matchesShortcut } from './use-keyboard-shortcuts-base'
 
+/**
+ * Global search. The primary chord is rebindable (`nav.search`, ⌘K by default);
+ * ⌘P stays as a fixed alias for muscle memory from other editors.
+ */
 export function useSearchShortcut(onToggle: () => void): void {
+  const binding = useShortcutBinding('nav.search')
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
-      const modifier = isMac ? e.metaKey : e.ctrlKey
+      const matches =
+        matchesShortcut(e, binding.key, binding.modifiers) ||
+        matchesShortcut(e, 'p', { meta: true })
 
-      const key = e.key.toLowerCase()
-      if (modifier && (key === 'k' || key === 'p')) {
+      if (matches) {
         e.preventDefault()
         e.stopPropagation()
         onToggle()
       }
     },
-    [onToggle]
+    [binding, onToggle]
   )
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/hooks/use-settings-shortcut.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-settings-shortcut.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { useShortcutBinding } from '@/lib/shortcut-bindings'
 import { useKeyboardShortcuts, type KeyboardShortcut } from './use-keyboard-shortcuts-base'
 
 /**
@@ -12,17 +13,19 @@ import { useKeyboardShortcuts, type KeyboardShortcut } from './use-keyboard-shor
  * ```
  */
 export function useSettingsShortcut(onOpen: () => void): void {
+  const binding = useShortcutBinding('nav.settings')
+
   const shortcuts = useMemo<KeyboardShortcut[]>(
     () => [
       {
-        key: ',',
-        modifiers: { meta: true },
+        key: binding.key,
+        modifiers: binding.modifiers,
         action: onOpen,
         description: 'Open Settings',
         allowInInput: true
       }
     ],
-    [onOpen]
+    [binding, onOpen]
   )
 
   useKeyboardShortcuts(shortcuts)

--- a/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.ts
@@ -6,12 +6,23 @@
 import { useMemo } from 'react'
 import { useTabs } from '@/contexts/tabs'
 import { isLastHomeTab } from '@/contexts/tabs/helpers'
+import { useShortcutBinding } from '@/lib/shortcut-bindings'
 import { useKeyboardShortcuts, type KeyboardShortcut } from './use-keyboard-shortcuts-base'
 
 /**
  * Hook providing all tab-related keyboard shortcuts
+ *
+ * Chords listed in Settings → Shortcuts are read from the binding store so a
+ * rebind applies here; the rest (⌘T, ⌘⇧W, ⌘⇧P, ⌘⇧D, ⌘\) are fixed.
  */
 export const useTabKeyboardShortcuts = (): void => {
+  const closeTabBinding = useShortcutBinding('tabs.closeTab')
+  const reopenTabBinding = useShortcutBinding('tabs.reopenTab')
+  const nextTabBinding = useShortcutBinding('tabs.nextTab')
+  const prevTabBinding = useShortcutBinding('tabs.prevTab')
+  const navBackBinding = useShortcutBinding('tabs.navBack')
+  const navForwardBinding = useShortcutBinding('tabs.navForward')
+
   const {
     state,
     dispatch,
@@ -46,8 +57,8 @@ export const useTabKeyboardShortcuts = (): void => {
 
       // Close tab (⌘W) — closes the window only once Home is all that is left
       {
-        key: 'w',
-        modifiers: { meta: true },
+        key: closeTabBinding.key,
+        modifiers: closeTabBinding.modifiers,
         action: () => {
           if (!activeTab) return
 
@@ -78,8 +89,8 @@ export const useTabKeyboardShortcuts = (): void => {
 
       // Reopen closed tab (⌘⇧T) — like Chrome
       {
-        key: 't',
-        modifiers: { meta: true, shift: true },
+        key: reopenTabBinding.key,
+        modifiers: reopenTabBinding.modifiers,
         action: () => {
           reopenClosedTab()
         },
@@ -92,8 +103,8 @@ export const useTabKeyboardShortcuts = (): void => {
 
       // Next tab (Ctrl+Tab)
       {
-        key: 'Tab',
-        modifiers: { ctrl: true },
+        key: nextTabBinding.key,
+        modifiers: nextTabBinding.modifiers,
         action: () => {
           dispatch({
             type: 'GO_TO_NEXT_TAB',
@@ -105,8 +116,8 @@ export const useTabKeyboardShortcuts = (): void => {
 
       // Previous tab (Ctrl+Shift+Tab)
       {
-        key: 'Tab',
-        modifiers: { ctrl: true, shift: true },
+        key: prevTabBinding.key,
+        modifiers: prevTabBinding.modifiers,
         action: () => {
           dispatch({
             type: 'GO_TO_PREVIOUS_TAB',
@@ -118,16 +129,16 @@ export const useTabKeyboardShortcuts = (): void => {
 
       // Navigate back in tab history (⌘[)
       {
-        key: '[',
-        modifiers: { meta: true },
+        key: navBackBinding.key,
+        modifiers: navBackBinding.modifiers,
         action: () => navBack(state.activeGroupId),
         description: 'Navigate back'
       },
 
       // Navigate forward in tab history (⌘])
       {
-        key: ']',
-        modifiers: { meta: true },
+        key: navForwardBinding.key,
+        modifiers: navForwardBinding.modifiers,
         action: () => navForward(state.activeGroupId),
         description: 'Navigate forward'
       },
@@ -220,6 +231,12 @@ export const useTabKeyboardShortcuts = (): void => {
       }
     ]
   }, [
+    closeTabBinding,
+    reopenTabBinding,
+    nextTabBinding,
+    prevTabBinding,
+    navBackBinding,
+    navForwardBinding,
     state.tabGroups,
     state.activeGroupId,
     dispatch,

--- a/apps/desktop/src/renderer/src/lib/shortcut-bindings.test.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcut-bindings.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  __setShortcutOverridesForTests,
+  getShortcutBinding,
+  useShortcutBinding
+} from './shortcut-bindings'
+
+describe('shortcut bindings store', () => {
+  afterEach(() => {
+    __setShortcutOverridesForTests({})
+  })
+
+  it('falls back to the registry default when nothing is overridden', () => {
+    expect(getShortcutBinding('view.toggleSidebar')).toEqual({
+      key: 'b',
+      modifiers: { meta: true }
+    })
+  })
+
+  it('returns the user override instead of the default', () => {
+    __setShortcutOverridesForTests({
+      'view.toggleSidebar': { key: 'b', modifiers: { alt: true } }
+    })
+
+    expect(getShortcutBinding('view.toggleSidebar')).toEqual({
+      key: 'b',
+      modifiers: { alt: true }
+    })
+  })
+
+  it('returns a stable reference so subscribers do not re-render in a loop', () => {
+    expect(getShortcutBinding('nav.settings')).toBe(getShortcutBinding('nav.settings'))
+  })
+
+  it('pushes a rebind to subscribers without a reload', () => {
+    const { result } = renderHook(() => useShortcutBinding('nav.search'))
+
+    expect(result.current).toEqual({ key: 'k', modifiers: { meta: true } })
+
+    act(() => {
+      __setShortcutOverridesForTests({
+        'nav.search': { key: 'j', modifiers: { meta: true, shift: true } }
+      })
+    })
+
+    expect(result.current).toEqual({ key: 'j', modifiers: { meta: true, shift: true } })
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/shortcut-bindings.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcut-bindings.ts
@@ -1,0 +1,93 @@
+/**
+ * Runtime shortcut bindings
+ *
+ * Settings → Shortcuts writes rebinds into `keyboard.overrides`. This store is
+ * the other half of that contract: every runtime shortcut owner resolves its
+ * chord through `useShortcutBinding(id)`, so a rebind takes effect immediately
+ * and the settings screen can never advertise a shortcut it cannot deliver.
+ *
+ * Module-level (not React context) so `components/ui/sidebar.tsx` and the tab
+ * hooks can read it wherever they are mounted, and so tests without a settings
+ * IPC bridge simply fall back to registry defaults.
+ */
+
+import { useSyncExternalStore } from 'react'
+import type { ShortcutBinding } from '@memry/contracts/settings-schemas'
+import { SHORTCUT_REGISTRY, type ShortcutId } from './shortcut-registry'
+
+const DEFAULT_BINDINGS = new Map<string, ShortcutBinding>(
+  SHORTCUT_REGISTRY.map((entry) => [entry.id, entry.defaultBinding])
+)
+
+/** A chord no keystroke can match — used if an id ever leaves the registry. */
+const NEVER_MATCHES: ShortcutBinding = { key: '', modifiers: {} }
+
+let overrides: Record<string, ShortcutBinding> = {}
+/** Cached per id so `useSyncExternalStore` sees a stable snapshot. */
+let resolved = new Map<string, ShortcutBinding>()
+const listeners = new Set<() => void>()
+let started = false
+
+function setOverrides(next: Record<string, ShortcutBinding>): void {
+  overrides = next
+  resolved = new Map()
+  for (const listener of listeners) listener()
+}
+
+function start(): void {
+  if (started) return
+  started = true
+
+  const api = typeof window !== 'undefined' ? window.api : undefined
+  if (!api) return
+
+  const getKeyboardSettings = api.settings?.getKeyboardSettings
+  if (typeof getKeyboardSettings === 'function') {
+    void Promise.resolve(getKeyboardSettings.call(api.settings))
+      .then((settings) => setOverrides(settings.overrides ?? {}))
+      .catch(() => {
+        // Settings unavailable — registry defaults stay in effect.
+      })
+  }
+
+  api.onSettingsChanged?.((event) => {
+    if (event.key !== 'keyboard') return
+    const value = event.value as { overrides?: Record<string, ShortcutBinding> } | undefined
+    if (value && 'overrides' in value) setOverrides(value.overrides ?? {})
+  })
+}
+
+function subscribe(listener: () => void): () => void {
+  start()
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/**
+ * Effective binding for a shortcut: the user's override, else the default.
+ */
+export function getShortcutBinding(id: ShortcutId): ShortcutBinding {
+  const cached = resolved.get(id)
+  if (cached) return cached
+  const binding = overrides[id] ?? DEFAULT_BINDINGS.get(id) ?? NEVER_MATCHES
+  resolved.set(id, binding)
+  return binding
+}
+
+/**
+ * Subscribe to the effective binding for a shortcut. Re-renders the caller when
+ * the user rebinds it in settings.
+ */
+export function useShortcutBinding(id: ShortcutId): ShortcutBinding {
+  return useSyncExternalStore(
+    subscribe,
+    () => getShortcutBinding(id),
+    () => getShortcutBinding(id)
+  )
+}
+
+/** Test seam: apply overrides without an IPC round trip. */
+export function __setShortcutOverridesForTests(next: Record<string, ShortcutBinding> = {}): void {
+  started = true
+  setOverrides(next)
+}

--- a/apps/desktop/src/renderer/src/lib/shortcut-registry.test.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcut-registry.test.ts
@@ -50,6 +50,31 @@ describe('shortcut-registry', () => {
       }
     })
 
+    it('only lists shortcuts that a runtime owner reads back', () => {
+      // A registry row with no owner is a settings row that silently does
+      // nothing. nav.goTo*/nav.newTask/editor.save were exactly that.
+      const ids = SHORTCUT_REGISTRY.map((e) => e.id)
+
+      expect(ids).not.toContain('nav.newTask')
+      expect(ids).not.toContain('nav.goToInbox')
+      expect(ids).not.toContain('nav.goToNotes')
+      expect(ids).not.toContain('nav.goToTasks')
+      expect(ids).not.toContain('editor.save')
+    })
+
+    it('uses the search chord the app actually listens for', () => {
+      // Meta+F is find-in-page, never global search.
+      const search = SHORTCUT_REGISTRY.find((entry) => entry.id === 'nav.search')
+
+      expect(search?.defaultBinding).toEqual({ key: 'k', modifiers: { meta: true } })
+    })
+
+    it('marks editor formatting keys as owned by the editor', () => {
+      for (const id of ['editor.bold', 'editor.italic', 'editor.underline']) {
+        expect(SHORTCUT_REGISTRY.find((entry) => entry.id === id)?.rebindable).toBe(false)
+      }
+    })
+
     it('uses Meta/Ctrl+B as the default sidebar toggle shortcut', () => {
       const toggleSidebar = SHORTCUT_REGISTRY.find((entry) => entry.id === 'view.toggleSidebar')
 
@@ -103,7 +128,7 @@ describe('shortcut-registry', () => {
 
   describe('resolveBinding', () => {
     const entry: ShortcutEntry = {
-      id: 'test.shortcut',
+      id: 'nav.newNote',
       i18nKey: 'test.shortcut',
       label: 'Test',
       description: 'Test shortcut',
@@ -117,7 +142,7 @@ describe('shortcut-registry', () => {
 
     it('returns override when present', () => {
       const override: ShortcutBinding = { key: 'x', modifiers: { meta: true, shift: true } }
-      expect(resolveBinding(entry, { 'test.shortcut': override })).toEqual(override)
+      expect(resolveBinding(entry, { 'nav.newNote': override })).toEqual(override)
     })
 
     it('ignores overrides for different IDs', () => {
@@ -168,11 +193,18 @@ describe('shortcut-registry', () => {
     })
 
     it('detects conflict with existing default binding', () => {
-      const conflicting: ShortcutBinding = { key: 'f', modifiers: { meta: true } }
+      const conflicting: ShortcutBinding = { key: 'k', modifiers: { meta: true } }
       const conflicts = findConflicts('custom.id', conflicting, {})
       expect(conflicts.length).toBeGreaterThan(0)
       expect(conflicts[0].conflictingId).toBe('nav.search')
       expect(conflicts[0].conflictingLabel).toBe('Search')
+    })
+
+    it('does not flag editor formatting keys, which focus resolves at keypress time', () => {
+      const bold = SHORTCUT_REGISTRY.find((e) => e.id === 'editor.bold')!
+      const conflicts = findConflicts('view.toggleSidebar', bold.defaultBinding, {})
+
+      expect(conflicts.every((c) => c.conflictingId !== 'editor.bold')).toBe(true)
     })
 
     it('excludes self from conflict check', () => {

--- a/apps/desktop/src/renderer/src/lib/shortcut-registry.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcut-registry.ts
@@ -7,13 +7,40 @@
 
 import type { ShortcutBinding } from '@memry/contracts/settings-schemas'
 
+/**
+ * Every id in the registry has a runtime owner that reads its effective binding
+ * through `useShortcutBinding` (see `lib/shortcut-bindings.ts`). Keep the two
+ * in step: an entry with no owner is a settings row that silently does nothing.
+ */
+export type ShortcutId =
+  | 'nav.newNote'
+  | 'nav.search'
+  | 'nav.settings'
+  | 'tabs.closeTab'
+  | 'tabs.nextTab'
+  | 'tabs.prevTab'
+  | 'tabs.reopenTab'
+  | 'tabs.navBack'
+  | 'tabs.navForward'
+  | 'editor.bold'
+  | 'editor.italic'
+  | 'editor.underline'
+  | 'view.toggleSidebar'
+  | 'view.shortcuts'
+
 export interface ShortcutEntry {
-  id: string
+  id: ShortcutId
   i18nKey: string
   label: string
   description: string
   category: string
   defaultBinding: ShortcutBinding
+  /**
+   * Editor formatting keys are owned by the note editor (BlockNote/ProseMirror)
+   * and cannot be remapped from settings. They stay listed for reference and
+   * render read-only rather than offering a rebind that would never apply.
+   */
+  rebindable?: boolean
 }
 
 export interface ShortcutConflict {
@@ -43,44 +70,12 @@ export const SHORTCUT_REGISTRY: ShortcutEntry[] = [
     defaultBinding: { key: 'n', modifiers: { meta: true } }
   },
   {
-    id: 'nav.newTask',
-    i18nKey: 'nav.newTask',
-    label: 'New Task',
-    description: 'Create a new task',
-    category: 'Navigation',
-    defaultBinding: { key: 't', modifiers: { meta: true, shift: true } }
-  },
-  {
-    id: 'nav.goToInbox',
-    i18nKey: 'nav.inbox',
-    label: 'Go to Inbox',
-    description: 'Navigate to the inbox',
-    category: 'Navigation',
-    defaultBinding: { key: 'i', modifiers: { meta: true, shift: true } }
-  },
-  {
-    id: 'nav.goToNotes',
-    i18nKey: 'nav.notes',
-    label: 'Go to Notes',
-    description: 'Navigate to notes',
-    category: 'Navigation',
-    defaultBinding: { key: 'e', modifiers: { meta: true, shift: true } }
-  },
-  {
-    id: 'nav.goToTasks',
-    i18nKey: 'nav.tasks',
-    label: 'Go to Tasks',
-    description: 'Navigate to tasks',
-    category: 'Navigation',
-    defaultBinding: { key: 'k', modifiers: { meta: true, shift: true } }
-  },
-  {
     id: 'nav.search',
     i18nKey: 'nav.search',
     label: 'Search',
     description: 'Open global search',
     category: 'Navigation',
-    defaultBinding: { key: 'f', modifiers: { meta: true } }
+    defaultBinding: { key: 'k', modifiers: { meta: true } }
   },
   {
     id: 'nav.settings',
@@ -141,22 +136,15 @@ export const SHORTCUT_REGISTRY: ShortcutEntry[] = [
     defaultBinding: { key: ']', modifiers: { meta: true } }
   },
 
-  // Editor
-  {
-    id: 'editor.save',
-    i18nKey: 'editor.save',
-    label: 'Save',
-    description: 'Save the current note',
-    category: 'Editor',
-    defaultBinding: { key: 's', modifiers: { meta: true } }
-  },
+  // Editor — owned by the note editor, listed for reference only
   {
     id: 'editor.bold',
     i18nKey: 'editor.bold',
     label: 'Bold',
     description: 'Toggle bold formatting',
     category: 'Editor',
-    defaultBinding: { key: 'b', modifiers: { meta: true } }
+    defaultBinding: { key: 'b', modifiers: { meta: true } },
+    rebindable: false
   },
   {
     id: 'editor.italic',
@@ -164,7 +152,8 @@ export const SHORTCUT_REGISTRY: ShortcutEntry[] = [
     label: 'Italic',
     description: 'Toggle italic formatting',
     category: 'Editor',
-    defaultBinding: { key: 'i', modifiers: { meta: true } }
+    defaultBinding: { key: 'i', modifiers: { meta: true } },
+    rebindable: false
   },
   {
     id: 'editor.underline',
@@ -172,7 +161,8 @@ export const SHORTCUT_REGISTRY: ShortcutEntry[] = [
     label: 'Underline',
     description: 'Toggle underline formatting',
     category: 'Editor',
-    defaultBinding: { key: 'u', modifiers: { meta: true } }
+    defaultBinding: { key: 'u', modifiers: { meta: true } },
+    rebindable: false
   },
 
   // View
@@ -257,7 +247,18 @@ export function bindingsEqual(a: ShortcutBinding, b: ShortcutBinding): boolean {
 }
 
 /**
- * Find conflicts: other shortcuts that use the same binding
+ * Look up an entry's default binding by id
+ */
+export function getDefaultBinding(id: ShortcutId): ShortcutBinding | undefined {
+  return SHORTCUT_REGISTRY.find((entry) => entry.id === id)?.defaultBinding
+}
+
+/**
+ * Find conflicts: other rebindable shortcuts that use the same binding.
+ *
+ * Editor formatting keys are excluded: they only apply while the caret is in
+ * rich text, so sharing a chord with an app-level shortcut (⌘B is both Bold and
+ * Toggle Sidebar) is resolved by focus at keypress time, not a real collision.
  */
 export function findConflicts(
   id: string,
@@ -266,6 +267,7 @@ export function findConflicts(
 ): ShortcutConflict[] {
   return SHORTCUT_REGISTRY.filter((entry) => {
     if (entry.id === id) return false
+    if (entry.rebindable === false) return false
     const effective = resolveBinding(entry, overrides)
     return bindingsEqual(effective, binding)
   }).map((entry) => ({ conflictingId: entry.id, conflictingLabel: entry.label }))

--- a/apps/desktop/src/renderer/src/pages/settings/shortcuts-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/shortcuts-section.tsx
@@ -67,9 +67,10 @@ function ShortcutRow({
   const captureRef = useRef<HTMLDivElement>(null)
 
   const startCapture = useCallback(() => {
+    if (entry.rebindable === false) return
     setIsCapturing(true)
     setConflict(null)
-  }, [])
+  }, [entry.rebindable])
 
   const stopCapture = useCallback(() => {
     setIsCapturing(false)
@@ -119,6 +120,12 @@ function ShortcutRow({
   }, [isCapturing, entry.id, overrides, onRebind, stopCapture, t])
 
   const label = shortcutLabel(t, entry)
+  // Editor formatting keys belong to the note editor; a rebind here would be
+  // recorded and then ignored at runtime, so the row is read-only.
+  const canRebind = entry.rebindable !== false
+  const keyCaps = formatBinding(effectiveBinding)
+    .split(' ')
+    .map((part) => <Kbd key={part}>{part}</Kbd>)
 
   useEffect(() => {
     if (!isCapturing) return
@@ -164,21 +171,24 @@ function ShortcutRow({
             </div>
           ) : (
             <div className="flex items-center gap-1">
-              <button
-                type="button"
-                onClick={startCapture}
-                className="flex items-center gap-0.5 hover:opacity-70 transition-opacity"
-                title={t('shortcuts.rebindTitle')}
-              >
-                <KbdGroup>
-                  {formatBinding(effectiveBinding)
-                    .split(' ')
-                    .map((part) => (
-                      <Kbd key={part}>{part}</Kbd>
-                    ))}
-                </KbdGroup>
-              </button>
-              {!isDefault && (
+              {canRebind ? (
+                <button
+                  type="button"
+                  onClick={startCapture}
+                  className="flex items-center gap-0.5 hover:opacity-70 transition-opacity"
+                  title={t('shortcuts.rebindTitle')}
+                >
+                  <KbdGroup>{keyCaps}</KbdGroup>
+                </button>
+              ) : (
+                <span
+                  className="flex items-center gap-0.5 opacity-60"
+                  title={t('shortcuts.editorManagedTitle')}
+                >
+                  <KbdGroup>{keyCaps}</KbdGroup>
+                </span>
+              )}
+              {canRebind && !isDefault && (
                 <Button
                   variant="ghost"
                   size="sm"

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -1,21 +1,17 @@
 # Keyboard Shortcuts
 
-Default shortcuts. Every entry in the Navigation, Tabs, Editor, and View categories is rebindable in [Settings → Keyboard Shortcuts](/user-guide/settings#keyboard-shortcuts).
+Default shortcuts. Entries in the Navigation, Tabs, and View categories are rebindable in [Settings → Keyboard Shortcuts](/user-guide/settings#keyboard-shortcuts); Editor formatting keys belong to the note editor and are listed there read-only.
 
 > macOS uses <kbd>⌘</kbd>; Windows / Linux use <kbd>Ctrl</kbd> for the same action. <kbd>Ctrl</kbd>+<kbd>Tab</kbd> always uses <kbd>Ctrl</kbd> on every platform.
 
 ## Navigation
 
-| Action                | Shortcut                                              |
-| --------------------- | ----------------------------------------------------- |
-| New note              | <kbd>⌘</kbd>+<kbd>N</kbd>                             |
-| New task              | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>T</kbd>                |
-| Go to Inbox           | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>I</kbd>                |
-| Go to Notes           | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>E</kbd>                |
-| Go to Tasks           | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>K</kbd>                |
-| Go to sidebar section | <kbd>⌘</kbd>+<kbd>1</kbd> … <kbd>⌘</kbd>+<kbd>6</kbd> |
-| Open search           | <kbd>⌘</kbd>+<kbd>F</kbd>                             |
-| Open settings         | <kbd>⌘</kbd>+<kbd>,</kbd>                             |
+| Action                | Shortcut                                               |
+| --------------------- | ------------------------------------------------------ |
+| New note              | <kbd>⌘</kbd>+<kbd>N</kbd>                              |
+| Go to sidebar section | <kbd>⌘</kbd>+<kbd>1</kbd> … <kbd>⌘</kbd>+<kbd>6</kbd>  |
+| Open search           | <kbd>⌘</kbd>+<kbd>K</kbd> or <kbd>⌘</kbd>+<kbd>P</kbd> |
+| Open settings         | <kbd>⌘</kbd>+<kbd>,</kbd>                              |
 
 > Hold <kbd>⌘</kbd> (<kbd>Ctrl</kbd> on Windows / Linux) to reveal the section numbers on the sidebar icons, then press the number to jump — <kbd>⌘</kbd>+<kbd>1</kbd> opens Home, <kbd>⌘</kbd>+<kbd>2</kbd> Inbox, and so on. Numbers follow the sidebar's visible top-to-bottom order (Home is always 1), so they shift if you hide a section. This shortcut works everywhere, including inside the editor, and is fixed rather than rebindable.
 
@@ -54,17 +50,16 @@ A chord indicator briefly flashes when the prefix is active.
 
 ## Editor
 
-| Action              | Shortcut                               |
-| ------------------- | -------------------------------------- |
-| Undo                | <kbd>⌘</kbd>+<kbd>Z</kbd>              |
-| Redo                | <kbd>⇧</kbd>+<kbd>⌘</kbd>+<kbd>Z</kbd> |
-| Save (manual flush) | <kbd>⌘</kbd>+<kbd>S</kbd>              |
-| Bold                | <kbd>⌘</kbd>+<kbd>B</kbd>              |
-| Italic              | <kbd>⌘</kbd>+<kbd>I</kbd>              |
-| Underline           | <kbd>⌘</kbd>+<kbd>U</kbd>              |
-| Insert wiki link    | Type `[[`                              |
-| Open block menu     | Type `/`                               |
-| Find in page        | <kbd>⌘</kbd>+<kbd>F</kbd>              |
+| Action           | Shortcut                               |
+| ---------------- | -------------------------------------- |
+| Undo             | <kbd>⌘</kbd>+<kbd>Z</kbd>              |
+| Redo             | <kbd>⇧</kbd>+<kbd>⌘</kbd>+<kbd>Z</kbd> |
+| Bold             | <kbd>⌘</kbd>+<kbd>B</kbd>              |
+| Italic           | <kbd>⌘</kbd>+<kbd>I</kbd>              |
+| Underline        | <kbd>⌘</kbd>+<kbd>U</kbd>              |
+| Insert wiki link | Type `[[`                              |
+| Open block menu  | Type `/`                               |
+| Find in page     | <kbd>⌘</kbd>+<kbd>F</kbd>              |
 
 ## View
 
@@ -72,6 +67,10 @@ A chord indicator briefly flashes when the prefix is active.
 | ------------------------------ | ----------------------------------------- |
 | Toggle sidebar                 | <kbd>⌘</kbd>+<kbd>B</kbd>                 |
 | Show keyboard shortcuts dialog | <kbd>⌘</kbd>+<kbd>/</kbd> or <kbd>?</kbd> |
+
+> <kbd>⌘</kbd>+<kbd>B</kbd> is shared on purpose: with the caret in a note it bolds
+> the selection and nothing else, and everywhere else it toggles the sidebar. Rebind
+> **Toggle Sidebar** if you would rather keep the two apart.
 
 The same shortcut reference opens from the question-mark button in the sidebar footer.
 It groups shortcuts into General, Tabs & Splits, Inbox, Journal, Notes / Editor, Tasks,
@@ -149,6 +148,8 @@ responsive on screens with a lot of targets.
 
 ## Customizing
 
-Open [Settings → Keyboard Shortcuts](/user-guide/settings#keyboard-shortcuts), find a row, and click to capture a new binding. Conflicts are flagged inline. **Reset All** restores defaults; it's only visible if you've made changes.
+Open [Settings → Keyboard Shortcuts](/user-guide/settings#keyboard-shortcuts), find a row, and click to capture a new binding. A rebind applies immediately — no restart. Conflicts are flagged inline. **Reset All** restores defaults; it's only visible if you've made changes.
+
+Editor formatting rows (Bold, Italic, Underline) are shown for reference and cannot be reassigned: the note editor owns those keys.
 
 You can also set a **Global Capture** hotkey there to bring memrynote to focus from any app (macOS requires Accessibility permission).

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -258,7 +258,9 @@ If your chosen hotkey is already claimed by another app, memrynote keeps its bui
 
 ### Shortcut List
 
-Searchable, grouped by category (Navigation, Tabs, Editor, View). Click any row to capture a new binding. Custom bindings show a badge.
+Searchable, grouped by category (Navigation, Tabs, Editor, View). Click any row to capture a new binding; it takes effect immediately, without a restart. Custom bindings show a badge.
+
+Editor rows (Bold, Italic, Underline) are read-only — those keys are handled by the note editor itself.
 
 ### Reset All
 

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -1343,6 +1343,7 @@
     "pressShortcut": "Press shortcut…",
     "cancelTitle": "Cancel",
     "rebindTitle": "Click to rebind",
+    "editorManagedTitle": "Handled by the note editor — cannot be reassigned",
     "resetTitle": "Reset to default",
     "clearTitle": "Clear shortcut",
     "clickToSet": "Click to set",


### PR DESCRIPTION
Fixes **A8** from #1508 (Aurelie · 8 Aug · v2026-08-07.2).

Two defects in one report, both structural.

## 1. Ctrl+B fired Bold *and* Toggle Sidebar

`components/ui/sidebar.tsx` registered the chord on `window` with `allowInInput: true`. ProseMirror handles the keydown at the editor node first (bold applies), the event then bubbles to the window listener and toggles the sidebar — the hook's `preventDefault()` lands too late to stop what already happened.

The sidebar now stands down while the caret is in rich text (`when: () => !isRichTextFocused()`). A plain `<input>` is not rich text — there is nothing to bold there — so it keeps the chord and today's behaviour.

## 2. Rebinding a shortcut in settings did nothing

`lib/shortcut-registry.ts` had exactly one consumer: the settings screen itself. Every runtime owner hardcoded its chord, so `keyboard.overrides` was write-only storage — it saved, showed the *Custom* badge and survived a reload, and only pressing the key revealed that nobody read it. Only `keyboard.globalCapture` ever reached the OS.

`lib/shortcut-bindings.ts` closes the loop: a module-level `useSyncExternalStore` store (not context — `components/ui/sidebar.tsx` sits outside the app provider tree, and tests without a settings IPC bridge must fall back to defaults). Sidebar, settings, the six tab chords, new note, search and the shortcuts dialog now all read `useShortcutBinding(id)`. A rebind applies immediately, no restart.

## The registry had also drifted from the app

Rows that advertised commands with no handler anywhere:

- **removed** `nav.newTask` (⌘⇧T is Reopen Tab), `nav.goToInbox` / `nav.goToNotes` / `nav.goToTasks`, `editor.save`
- **`nav.search` ⌘F → ⌘K** — ⌘F is find-in-page; real search is ⌘K/⌘P
- **Bold / Italic / Underline** are owned by the note editor, so they render read-only instead of offering a rebind that would be recorded and then ignored

`findConflicts` now skips editor rows: ⌘B on both Bold and Toggle Sidebar is deliberate, and focus resolves it at keypress time.

The new `ShortcutId` union makes the registry and its owners fail typecheck if they drift apart again.

Rather than invent four navigation commands to justify the ghost rows, I deleted them. If Go to Inbox/Notes/Tasks and New Task are wanted, that is separate work.

## Verification

- `pnpm --filter @memry/desktop test:renderer` — **620 files, 7181 passed**, 7 skipped
- `pnpm typecheck` (17 tasks), `typecheck:test`, `pnpm lint` (0 errors), `check:architecture`, `i18n:check`, `docs:build` — all green
- `pnpm docs:impact --base 2171bb04a --strict` — covered
- **Mutation-tested**: replacing the rich-text guard with `when: () => true` turns the new "leaves Meta/Ctrl+B to the editor" test red; restoring it turns it green
- New tests: sidebar rich-text guard, rebound chord (Alt+B works, ⌘B dead), binding store (default / override / live update), registry has no ownerless rows

E2E not run.

Docs updated — `keyboard-shortcuts.md` and `settings.md` repeated the same claims ("every entry is rebindable", search on ⌘F, Go to Inbox…).