### PR TITLE
fix(tabs): a note remembers where you were reading when you come back to it

### DIFF
--- a/apps/desktop/src/renderer/src/components/note-sidebar-surfaces.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note-sidebar-surfaces.test.tsx
@@ -64,7 +64,9 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 vi.mock('@/contexts/tabs', () => ({
   useTabs: () => ({
     openTab: mocks.openTab
-  })
+  }),
+  // NoteLayout's scroll-restore hook renders outside a TabProvider here.
+  useTabActionsOptional: () => null
 }))
 
 vi.mock('@/hooks/use-active-heading', () => ({

--- a/apps/desktop/src/renderer/src/components/note/note-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-layout.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react'
 import { cn } from '@/lib/utils'
 import { useActiveHeading } from '@/hooks/use-active-heading'
+import { useTabScrollRestore } from '@/hooks/use-tab-scroll-restore'
 import { useReviewRailShift } from '@/hooks/use-review-rail-shift'
 import { OutlineInfoPanel, type OutlineInfoPanelProps } from '../shared/outline-info-panel'
 
@@ -57,6 +58,10 @@ export function NoteLayout({
     scrollRef.current = el
     setScrollEl(el)
   }, [])
+  // This div — not the tab wrapper — is what the note and template-editor pages
+  // actually scroll, so tab scroll restore has to attach here.
+  const getScrollElement = useCallback(() => scrollRef.current, [])
+  useTabScrollRestore({ getScrollElement })
   const { activeHeadingId, setActiveHeading } = useActiveHeading({
     headings,
     offset: 120,

--- a/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
@@ -12,6 +12,7 @@
 import React, { useRef, useEffect, useMemo } from 'react'
 import type { Tab } from '@/contexts/tabs/types'
 import { useTabActions } from '@/contexts/tabs'
+import { TabIdentityProvider } from '@/contexts/tabs/tab-identity'
 import { useTasksOptional } from '@/contexts/tasks'
 import { cn } from '@/lib/utils'
 import { InboxPage } from '@/pages/inbox'
@@ -270,7 +271,9 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
       className={cn('h-full overflow-y-auto overflow-x-hidden', className)}
       data-tab-content={tab.id}
     >
-      <React.Suspense fallback={null}>{content}</React.Suspense>
+      <TabIdentityProvider tabId={tab.id} groupId={groupId} entityId={tab.entityId}>
+        <React.Suspense fallback={null}>{content}</React.Suspense>
+      </TabIdentityProvider>
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
@@ -9,9 +9,8 @@
  * 3. useMemo with tab.id key ensures content is cached per tab instance
  */
 
-import React, { useRef, useEffect, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import type { Tab } from '@/contexts/tabs/types'
-import { useTabActions } from '@/contexts/tabs'
 import { TabIdentityProvider } from '@/contexts/tabs/tab-identity'
 import { useTasksOptional } from '@/contexts/tasks'
 import { cn } from '@/lib/utils'
@@ -77,40 +76,12 @@ interface TabContentProps {
 }
 
 /**
- * Renders the appropriate view for a tab type
- * PERFORMANCE: Uses useTabActions instead of useTabs to avoid re-renders on state changes
+ * Renders the appropriate view for a tab type, and publishes the tab's identity
+ * so the page inside can scope its own state (scroll offset, view state) to it.
  */
 export const TabContent = ({ tab, groupId, className }: TabContentProps): React.JSX.Element => {
   const { t: tPhaseF } = useT('common')
-  const scrollRef = useRef<HTMLDivElement>(null)
-  // PERFORMANCE: useTabActions returns stable references - doesn't cause re-renders
-  const { dispatch } = useTabActions()
   const tasksContext = useTasksOptional()
-
-  // Save scroll position on unmount or tab change
-  useEffect(() => {
-    const scrollElement = scrollRef.current
-
-    return () => {
-      if (scrollElement) {
-        dispatch({
-          type: 'SAVE_TAB_STATE',
-          payload: {
-            tabId: tab.id,
-            groupId,
-            scrollPosition: scrollElement.scrollTop
-          }
-        })
-      }
-    }
-  }, [tab.id, groupId, dispatch])
-
-  // Restore scroll position on mount
-  useEffect(() => {
-    if (scrollRef.current && tab.scrollPosition) {
-      scrollRef.current.scrollTop = tab.scrollPosition
-    }
-  }, [tab.id, tab.scrollPosition])
 
   // FolderViewPage's `useFolderView` keys its live-refresh subscriptions off
   // scope identity — memoized here (independent of the broader `content`
@@ -266,8 +237,10 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
   ])
 
   return (
+    // Layout only: pages own their scrolling (see `useTabScrollRestore`). The
+    // overflow rules stay because a page that is not `h-full`/`overflow-hidden`
+    // would otherwise spill out of the pane.
     <div
-      ref={scrollRef}
       className={cn('h-full overflow-y-auto overflow-x-hidden', className)}
       data-tab-content={tab.id}
     >

--- a/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
@@ -22,7 +22,8 @@ import type {
   TabSettings,
   OpenTabOptions,
   SidebarItem,
-  SplitDirection
+  SplitDirection,
+  TabScrollState
 } from './types'
 import { tabReducer } from './reducer'
 import { createInitialState, createTabFromSidebarItem, generateId } from './helpers'
@@ -177,9 +178,23 @@ interface TabActionsContextType {
    */
   saveTabState: (
     tabId: string,
-    state: { scrollPosition?: number; viewState?: Record<string, unknown> },
+    state: {
+      scrollPosition?: number
+      scrollState?: TabScrollState
+      viewState?: Record<string, unknown>
+    },
     groupId?: string
   ) => void
+
+  /**
+   * Read a tab out of the current state WITHOUT subscribing to it.
+   *
+   * Backed by a ref, so the returned function is stable and the caller never
+   * re-renders on unrelated tab changes. Callers that need to re-render when the
+   * tab changes should use `useTabs`/`useTabGroup` instead — this exists for
+   * hooks that only need a one-shot read (restore-on-mount, state seeding).
+   */
+  getTab: (tabId: string, groupId?: string) => Tab | null
 
   /**
    * Split the view.
@@ -620,10 +635,19 @@ export const TabProvider = ({
     []
   )
 
+  const getTab = useCallback((tabId: string, groupId?: string): Tab | null => {
+    const actualGroupId = groupId ?? activeGroupIdRef.current
+    return stateRef.current.tabGroups[actualGroupId]?.tabs.find((t) => t.id === tabId) ?? null
+  }, [])
+
   const saveTabState = useCallback(
     (
       tabId: string,
-      tabState: { scrollPosition?: number; viewState?: Record<string, unknown> },
+      tabState: {
+        scrollPosition?: number
+        scrollState?: TabScrollState
+        viewState?: Record<string, unknown>
+      },
       groupId?: string
     ) => {
       const actualGroupId = groupId ?? activeGroupIdRef.current
@@ -761,6 +785,7 @@ export const TabProvider = ({
       reorderTabs,
       moveTabToGroup,
       saveTabState,
+      getTab,
       splitView,
       closeSplit,
       moveTabToNewSplit,
@@ -795,6 +820,7 @@ export const TabProvider = ({
       reorderTabs,
       moveTabToGroup,
       saveTabState,
+      getTab,
       splitView,
       closeSplit,
       moveTabToNewSplit,
@@ -969,4 +995,14 @@ export const useTabActions = (): TabActionsContextType => {
     throw new Error('useTabActions must be used within a TabProvider')
   }
   return context
+}
+
+/**
+ * Tab actions when there is a TabProvider, `null` when there is not.
+ *
+ * For shared components that render both inside a tab and standalone (dialogs,
+ * previews, tests): they must degrade rather than throw.
+ */
+export const useTabActionsOptional = (): TabActionsContextType | null => {
+  return useContext(TabActionsContext)
 }

--- a/apps/desktop/src/renderer/src/contexts/tabs/index.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/index.ts
@@ -55,7 +55,8 @@ export {
   useIsTabActive,
   useTabLayout,
   useTabCounts,
-  useTabActions
+  useTabActions,
+  useTabActionsOptional
 } from './context'
 
 export type { TabCloseGuard } from './close-guard'

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts
@@ -224,6 +224,7 @@ export const useSessionRestore = (
                     isPreview: false,
                     isDeleted: false,
                     scrollPosition: tab.scrollPosition,
+                    scrollState: tab.scrollState,
                     viewState: tab.viewState
                   },
                   background: true

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.ts
@@ -53,6 +53,7 @@ export const serializeTabState = (state: TabSystemState): PersistedTabState => {
         entityId: tab.entityId,
         isPinned: tab.isPinned,
         scrollPosition: tab.scrollPosition,
+        scrollState: tab.scrollState,
         viewState: tab.viewState
       }))
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/types.ts
@@ -3,7 +3,7 @@
  * Serializable types for tab state storage
  */
 
-import type { TabType, TabSettings, SplitLayout } from '@/contexts/tabs/types'
+import type { TabType, TabSettings, SplitLayout, TabScrollState } from '@/contexts/tabs/types'
 
 // =============================================================================
 // STORAGE SCHEMA VERSION
@@ -69,8 +69,10 @@ export interface PersistedTab {
   entityId?: string
   /** Whether pinned */
   isPinned: boolean
-  /** Scroll position */
+  /** Scroll position (legacy, unstamped) */
   scrollPosition?: number
+  /** Scroll offset stamped with the entity it was measured against */
+  scrollState?: TabScrollState
   /** View-specific state */
   viewState?: Record<string, unknown>
 }

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/session-reducer.test.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/session-reducer.test.ts
@@ -1,6 +1,107 @@
 import { describe, it, expect } from 'vitest'
 import { sessionReducer } from './session-reducer'
 import { createInitialState } from '../helpers'
+import type { TabSystemState } from '../types'
+
+/** Initial state with a single known tab carrying the given `viewState`. */
+function stateWithViewState(viewState?: Record<string, unknown>): {
+  state: TabSystemState
+  groupId: string
+  tabId: string
+} {
+  const base = createInitialState()
+  const groupId = Object.keys(base.tabGroups)[0]
+  const group = base.tabGroups[groupId]
+  const tabId = group.tabs[0].id
+
+  return {
+    state: {
+      ...base,
+      tabGroups: {
+        ...base.tabGroups,
+        [groupId]: {
+          ...group,
+          tabs: group.tabs.map((t) => (t.id === tabId ? { ...t, viewState } : t))
+        }
+      }
+    },
+    groupId,
+    tabId
+  }
+}
+
+function readTab(
+  state: TabSystemState,
+  groupId: string,
+  tabId: string
+): TabSystemState['tabGroups'][string]['tabs'][number] {
+  const tab = state.tabGroups[groupId].tabs.find((t) => t.id === tabId)
+  if (!tab) throw new Error(`tab ${tabId} missing`)
+  return tab
+}
+
+describe('sessionReducer SAVE_TAB_STATE viewState merge', () => {
+  it('preserves keys the incoming patch does not mention', () => {
+    const { state, groupId, tabId } = stateWithViewState({ filter: 'open', sort: 'due' })
+
+    const next = sessionReducer(state, {
+      type: 'SAVE_TAB_STATE',
+      payload: { tabId, groupId, viewState: { sort: 'created' } }
+    })
+
+    expect(readTab(next, groupId, tabId).viewState).toEqual({
+      filter: 'open',
+      sort: 'created'
+    })
+  })
+
+  it('deletes a key whose incoming value is undefined', () => {
+    const { state, groupId, tabId } = stateWithViewState({ filter: 'open', sort: 'due' })
+
+    const next = sessionReducer(state, {
+      type: 'SAVE_TAB_STATE',
+      payload: { tabId, groupId, viewState: { filter: undefined } }
+    })
+
+    const viewState = readTab(next, groupId, tabId).viewState
+    expect(viewState).toEqual({ sort: 'due' })
+    expect(viewState && 'filter' in viewState).toBe(false)
+  })
+
+  it('seeds viewState when the tab had none', () => {
+    const { state, groupId, tabId } = stateWithViewState(undefined)
+
+    const next = sessionReducer(state, {
+      type: 'SAVE_TAB_STATE',
+      payload: { tabId, groupId, viewState: { mode: 'preview' } }
+    })
+
+    expect(readTab(next, groupId, tabId).viewState).toEqual({ mode: 'preview' })
+  })
+
+  it('does not mutate the previous viewState object', () => {
+    const previous = { filter: 'open' }
+    const { state, groupId, tabId } = stateWithViewState(previous)
+
+    sessionReducer(state, {
+      type: 'SAVE_TAB_STATE',
+      payload: { tabId, groupId, viewState: { filter: 'done' } }
+    })
+
+    expect(previous).toEqual({ filter: 'open' })
+  })
+
+  it('is a no-op for an unknown groupId', () => {
+    const { state, tabId } = stateWithViewState({ filter: 'open' })
+
+    const next = sessionReducer(state, {
+      type: 'SAVE_TAB_STATE',
+      payload: { tabId, groupId: 'group-that-does-not-exist', viewState: { filter: 'done' } }
+    })
+
+    expect(next).toBe(state)
+  })
+})
 
 describe('sessionReducer UPDATE_SETTINGS', () => {
   it('returns the same state object when the payload changes nothing', () => {

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/session-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/session-reducer.ts
@@ -7,6 +7,30 @@ type SessionAction = Extract<
   { type: 'UPDATE_SETTINGS' | 'RESTORE_SESSION' | 'RESET_TO_DEFAULT' | 'SAVE_TAB_STATE' }
 >
 
+/**
+ * Shallow-merge a `viewState` patch over the tab's existing `viewState`.
+ *
+ * `SAVE_TAB_STATE` used to replace `viewState` wholesale, so two independent
+ * writers on the same tab (say a filter control and a scroll-restore hook)
+ * clobbered each other depending on which dispatched last. A key whose incoming
+ * value is `undefined` is a deletion, which is the only way a caller can drop a
+ * key now that writes are merged.
+ */
+function mergeViewState(
+  current: Record<string, unknown> | undefined,
+  patch: Record<string, unknown>
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...current }
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) {
+      delete next[key]
+    } else {
+      next[key] = value
+    }
+  }
+  return next
+}
+
 export function sessionReducer(state: TabSystemState, action: SessionAction): TabSystemState {
   switch (action.type) {
     case 'SAVE_TAB_STATE': {
@@ -25,7 +49,9 @@ export function sessionReducer(state: TabSystemState, action: SessionAction): Ta
                 ? {
                     ...t,
                     ...(scrollPosition !== undefined && { scrollPosition }),
-                    ...(viewState !== undefined && { viewState })
+                    ...(viewState !== undefined && {
+                      viewState: mergeViewState(t.viewState, viewState)
+                    })
                   }
                 : t
             )

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/session-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/session-reducer.ts
@@ -34,7 +34,7 @@ function mergeViewState(
 export function sessionReducer(state: TabSystemState, action: SessionAction): TabSystemState {
   switch (action.type) {
     case 'SAVE_TAB_STATE': {
-      const { tabId, groupId, scrollPosition, viewState } = action.payload
+      const { tabId, groupId, scrollPosition, scrollState, viewState } = action.payload
       const group = state.tabGroups[groupId]
       if (!group) return state
 
@@ -49,6 +49,7 @@ export function sessionReducer(state: TabSystemState, action: SessionAction): Ta
                 ? {
                     ...t,
                     ...(scrollPosition !== undefined && { scrollPosition }),
+                    ...(scrollState !== undefined && { scrollState }),
                     ...(viewState !== undefined && {
                       viewState: mergeViewState(t.viewState, viewState)
                     })

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
@@ -42,6 +42,7 @@ const snapshotClosedTab = (tab: Tab, groupId: string, index: number): ClosedTabE
     isPreview: false,
     isDeleted: false,
     scrollPosition: tab.scrollPosition,
+    scrollState: tab.scrollState,
     viewState: tab.viewState
   },
   groupId,

--- a/apps/desktop/src/renderer/src/contexts/tabs/tab-identity.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/tab-identity.tsx
@@ -1,0 +1,49 @@
+/**
+ * Tab Identity Context
+ *
+ * Published by `TabContent` so anything rendered inside a tab can learn WHICH
+ * tab it is in. `useActiveTab()` answers a different question — it returns the
+ * globally active tab — and is therefore wrong for a page living in the inactive
+ * pane of a split view. New tab-scoped state (scroll restore, view state) must
+ * key off this context instead.
+ */
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
+
+export interface TabIdentity {
+  /** Id of the tab this subtree is rendered inside */
+  tabId: string
+  /** Id of the tab group (pane) that owns the tab */
+  groupId: string
+  /** Entity the tab currently points at, if any (note id, canvas id, …) */
+  entityId?: string
+}
+
+const TabIdentityContext = createContext<TabIdentity | null>(null)
+
+interface TabIdentityProviderProps extends TabIdentity {
+  children: ReactNode
+}
+
+export function TabIdentityProvider({
+  tabId,
+  groupId,
+  entityId,
+  children
+}: TabIdentityProviderProps): React.JSX.Element {
+  const value = useMemo<TabIdentity>(
+    () => ({ tabId, groupId, entityId }),
+    [tabId, groupId, entityId]
+  )
+
+  return <TabIdentityContext.Provider value={value}>{children}</TabIdentityContext.Provider>
+}
+
+/**
+ * Identity of the tab the caller is rendered in, or `null` outside a tab
+ * (settings panes, dialogs, tests). Consumers must treat `null` as "no tab-scoped
+ * state available" and degrade rather than throw.
+ */
+export function useTabIdentity(): TabIdentity | null {
+  return useContext(TabIdentityContext)
+}

--- a/apps/desktop/src/renderer/src/contexts/tabs/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/types.ts
@@ -62,6 +62,20 @@ export const isSingletonTabType = (type: TabType): boolean => {
 // =============================================================================
 
 /**
+ * A tab's saved scroll offset, stamped with the entity it was measured against.
+ *
+ * The stamp is what makes the record safe to restore: a tab keeps its identity
+ * when it navigates to another note, so an offset saved against the previous
+ * entity must be discarded rather than applied to the new content.
+ */
+export interface TabScrollState {
+  /** Saved scroll offset in pixels. `0` is a valid, restorable value. */
+  offset: number
+  /** `Tab.entityId` at the moment the offset was recorded. */
+  entityId?: string
+}
+
+/**
  * Individual tab interface
  */
 export interface Tab {
@@ -91,8 +105,10 @@ export interface Tab {
   isDeleted: boolean
 
   // Preserved state
-  /** Scroll position to restore */
+  /** Scroll position to restore (legacy, unstamped) */
   scrollPosition?: number
+  /** Scroll offset to restore, stamped with the entity it was measured against */
+  scrollState?: TabScrollState
   /** View-specific state (filters, expanded sections, etc.) */
   viewState?: Record<string, unknown>
 
@@ -280,6 +296,7 @@ export type TabAction =
         tabId: string
         groupId: string
         scrollPosition?: number
+        scrollState?: TabScrollState
         viewState?: Record<string, unknown>
       }
     }

--- a/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.test.tsx
@@ -67,12 +67,18 @@ class TestResizeObserver {
 // ---------------------------------------------------------------------------
 // Scroller stub: `scrollTop` clamps to the currently reachable range, which is
 // the only thing that makes "content has not loaded yet" observable in jsdom.
+// `scrollHeight`/`clientHeight` are modelled too, because the scrollable range
+// is how the hook tells a user scroll from a content collapse.
 // ---------------------------------------------------------------------------
+
+/** Fixed viewport height; only the content height moves in these tests. */
+const VIEWPORT_HEIGHT = 400
 
 function makeScroller(maxScroll: number): {
   element: HTMLElement
   setMaxScroll: (next: number) => void
   userScrollTo: (offset: number) => void
+  collapseContentTo: (nextMax: number) => void
 } {
   const element = document.createElement('div')
   element.append(document.createElement('div'))
@@ -88,6 +94,14 @@ function makeScroller(maxScroll: number): {
       offset = Math.max(0, Math.min(next, max))
     }
   })
+  Object.defineProperty(element, 'clientHeight', {
+    configurable: true,
+    get: () => VIEWPORT_HEIGHT
+  })
+  Object.defineProperty(element, 'scrollHeight', {
+    configurable: true,
+    get: () => max + VIEWPORT_HEIGHT
+  })
 
   return {
     element,
@@ -97,6 +111,17 @@ function makeScroller(maxScroll: number): {
     userScrollTo: (next) => {
       offset = Math.max(0, Math.min(next, max))
       element.dispatchEvent(new Event('scroll'))
+    },
+    /**
+     * What a page body remounting under a surviving scroller does: the content
+     * height collapses, the browser clamps `scrollTop` into the new range and
+     * emits a scroll event carrying the clamped value.
+     */
+    collapseContentTo: (nextMax) => {
+      const previous = Math.min(offset, max)
+      max = nextMax
+      offset = Math.max(0, Math.min(offset, nextMax))
+      if (offset !== previous) element.dispatchEvent(new Event('scroll'))
     }
   }
 }
@@ -168,6 +193,91 @@ describe('useTabScrollRestore', () => {
     unmount()
 
     expect(savedPayloads()).toEqual([{ tabId: 'tab-a', offset: 250, entityId: 'note-1' }])
+  })
+
+  it('keeps the user offset when a content collapse clamps the scroller', () => {
+    const scroller = makeScroller(1000)
+    const { unmount } = renderHook(() =>
+      useTabScrollRestore({ getScrollElement: () => scroller.element })
+    )
+
+    scroller.userScrollTo(250)
+    // Switching to an already-cached note: the scroller survives, but the page
+    // body remounts, its height collapses, and the browser clamps `scrollTop`
+    // to 0 and fires a scroll event for it. That is not the user scrolling.
+    scroller.collapseContentTo(0)
+
+    unmount()
+
+    expect(savedPayloads()).toEqual([{ tabId: 'tab-a', offset: 250, entityId: 'note-1' }])
+  })
+
+  it('does not commit a content-collapse clamp as the live offset', () => {
+    const scroller = makeScroller(1000)
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    scroller.userScrollTo(250)
+    scroller.collapseContentTo(0)
+    vi.advanceTimersByTime(500)
+
+    // The throttled save that was already pending must still carry the user's
+    // offset, not the value the clamp wrote over it.
+    expect(savedPayloads()).toEqual([{ tabId: 'tab-a', offset: 250, entityId: 'note-1' }])
+  })
+
+  it('still saves a genuine user scroll back to the top', () => {
+    const scroller = makeScroller(1000)
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    scroller.userScrollTo(250)
+    vi.advanceTimersByTime(500)
+    // Range unchanged: this is the user, not a clamp.
+    scroller.userScrollTo(0)
+    vi.advanceTimersByTime(500)
+
+    expect(savedPayloads()).toEqual([
+      { tabId: 'tab-a', offset: 250, entityId: 'note-1' },
+      { tabId: 'tab-a', offset: 0, entityId: 'note-1' }
+    ])
+  })
+
+  it('does not re-dispatch an offset already in tab state', () => {
+    const scroller = makeScroller(1000)
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    scroller.userScrollTo(250)
+    vi.advanceTimersByTime(500)
+    // A scroll that ends where the last committed save already left it.
+    scroller.userScrollTo(300)
+    scroller.userScrollTo(250)
+    vi.advanceTimersByTime(500)
+
+    expect(savedPayloads()).toEqual([{ tabId: 'tab-a', offset: 250, entityId: 'note-1' }])
+  })
+
+  it('writes nothing at teardown for a tab that was never scrolled', () => {
+    const scroller = makeScroller(1000)
+    const { unmount } = renderHook(() =>
+      useTabScrollRestore({ getScrollElement: () => scroller.element })
+    )
+
+    unmount()
+
+    expect(mocks.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('still writes at teardown when a previous record exists', () => {
+    const scroller = makeScroller(1000)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 400, entityId: 'note-old' }))
+
+    const { unmount } = renderHook(() =>
+      useTabScrollRestore({ getScrollElement: () => scroller.element })
+    )
+
+    unmount()
+
+    // The stale record has to be corrected, not left pointing at gone content.
+    expect(savedPayloads()).toEqual([{ tabId: 'tab-a', offset: 0, entityId: 'note-1' }])
   })
 
   it('flushes under the previous tab identity when the tab changes', () => {
@@ -263,14 +373,98 @@ describe('useTabScrollRestore', () => {
     expect(TestResizeObserver.live).toHaveLength(0)
   })
 
-  it('gives up re-applying after the restore timeout', () => {
+  it('gives up once the content has settled short of the target', () => {
     const scroller = makeScroller(0)
     mocks.getTab.mockReturnValue(tabWith({ offset: 500, entityId: 'note-1' }))
 
     renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
     expect(TestResizeObserver.live).toHaveLength(1)
 
-    vi.advanceTimersByTime(1000)
+    // RESTORE_SETTLE_MS with no growth: the target is provably unreachable.
+    vi.advanceTimersByTime(2000)
+    expect(TestResizeObserver.live).toHaveLength(0)
+
+    scroller.setMaxScroll(1000)
+    TestResizeObserver.fireAll()
+
+    expect(scroller.element.scrollTop).toBe(0)
+  })
+
+  it('keeps chasing a slow note well past a one-second deadline', () => {
+    const scroller = makeScroller(0)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 500, entityId: 'note-1' }))
+
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    // Lazy chunk + note fetch: nothing for well over a second.
+    vi.advanceTimersByTime(1500)
+    // Editor mounts and lays out in stages; each growth buys another window.
+    scroller.setMaxScroll(120)
+    TestResizeObserver.fireAll()
+    vi.advanceTimersByTime(1500)
+    scroller.setMaxScroll(1000)
+    TestResizeObserver.fireAll()
+
+    expect(scroller.element.scrollTop).toBe(500)
+    expect(TestResizeObserver.live).toHaveLength(0)
+  })
+
+  it('stops at the hard cap even while content keeps growing', () => {
+    const scroller = makeScroller(0)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 5000, entityId: 'note-1' }))
+
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    // Growth every second keeps resetting the settle window; RESTORE_MAX_MS is
+    // the only thing that can end this.
+    for (let elapsed = 0; elapsed < 15000; elapsed += 1000) {
+      scroller.setMaxScroll(10 + elapsed / 100)
+      TestResizeObserver.fireAll()
+      vi.advanceTimersByTime(1000)
+    }
+
+    expect(TestResizeObserver.live).toHaveLength(0)
+    scroller.setMaxScroll(9000)
+    TestResizeObserver.fireAll()
+    // Frozen at the last clamp the abandoned restore produced (10 + 14000/100).
+    expect(scroller.element.scrollTop).toBe(150)
+  })
+
+  it('persists the target, not the clamp, when a tab is left mid-restore', () => {
+    // Content never arrives before the user switches away again.
+    const scroller = makeScroller(0)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 500, entityId: 'note-1' }))
+
+    const { unmount } = renderHook(() =>
+      useTabScrollRestore({ getScrollElement: () => scroller.element })
+    )
+    expect(scroller.element.scrollTop).toBe(0)
+
+    unmount()
+
+    expect(savedPayloads()).toEqual([{ tabId: 'tab-a', offset: 500, entityId: 'note-1' }])
+  })
+
+  it('ignores typing while a restore is in flight', () => {
+    const scroller = makeScroller(0)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 500, entityId: 'note-1' }))
+
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    scroller.element.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }))
+    scroller.setMaxScroll(1000)
+    TestResizeObserver.fireAll()
+
+    expect(scroller.element.scrollTop).toBe(500)
+  })
+
+  it('cancels re-application on a key that scrolls', () => {
+    const scroller = makeScroller(0)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 500, entityId: 'note-1' }))
+
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    scroller.element.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageDown' }))
     scroller.setMaxScroll(1000)
     TestResizeObserver.fireAll()
 

--- a/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.test.tsx
@@ -1,0 +1,324 @@
+/**
+ * jsdom has no layout: `scrollHeight` is always 0 and `scrollTop` is a plain
+ * writable property, so a "render a page and assert the scroll position" test
+ * would pass against the broken mechanism this hook replaces. These tests drive
+ * the hook's decision logic against an explicitly stubbed scroller whose
+ * clamping behaviour is modelled by hand.
+ */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTabScrollRestore } from './use-tab-scroll-restore'
+import type { Tab } from '@/contexts/tabs/types'
+import type { TabIdentity } from '@/contexts/tabs/tab-identity'
+
+const mocks = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  getTab: vi.fn(),
+  identity: { current: null as TabIdentity | null }
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabActionsOptional: () => ({ dispatch: mocks.dispatch, getTab: mocks.getTab })
+}))
+
+vi.mock('@/contexts/tabs/tab-identity', () => ({
+  useTabIdentity: () => mocks.identity.current
+}))
+
+// ---------------------------------------------------------------------------
+// Controllable ResizeObserver
+// ---------------------------------------------------------------------------
+
+class TestResizeObserver {
+  static instances: TestResizeObserver[] = []
+  private readonly callback: ResizeObserverCallback
+  targets: Element[] = []
+  disconnected = false
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    TestResizeObserver.instances.push(this)
+  }
+
+  observe(target: Element): void {
+    this.targets.push(target)
+  }
+
+  unobserve(): void {}
+
+  disconnect(): void {
+    this.disconnected = true
+    this.targets = []
+  }
+
+  static fireAll(): void {
+    for (const instance of TestResizeObserver.instances) {
+      instance.callback([], instance as unknown as ResizeObserver)
+    }
+  }
+
+  static get live(): TestResizeObserver[] {
+    return TestResizeObserver.instances.filter((i) => !i.disconnected)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scroller stub: `scrollTop` clamps to the currently reachable range, which is
+// the only thing that makes "content has not loaded yet" observable in jsdom.
+// ---------------------------------------------------------------------------
+
+function makeScroller(maxScroll: number): {
+  element: HTMLElement
+  setMaxScroll: (next: number) => void
+  userScrollTo: (offset: number) => void
+} {
+  const element = document.createElement('div')
+  element.append(document.createElement('div'))
+  document.body.append(element)
+
+  let offset = 0
+  let max = maxScroll
+
+  Object.defineProperty(element, 'scrollTop', {
+    configurable: true,
+    get: () => Math.min(offset, max),
+    set: (next: number) => {
+      offset = Math.max(0, Math.min(next, max))
+    }
+  })
+
+  return {
+    element,
+    setMaxScroll: (next) => {
+      max = next
+    },
+    userScrollTo: (next) => {
+      offset = Math.max(0, Math.min(next, max))
+      element.dispatchEvent(new Event('scroll'))
+    }
+  }
+}
+
+function tabWith(scrollState: Tab['scrollState']): Tab {
+  return { id: 'tab-a', scrollState } as Tab
+}
+
+function savedPayloads(): Array<{ tabId: string; offset: number; entityId?: string }> {
+  return mocks.dispatch.mock.calls
+    .map(([action]) => action as { type: string; payload: Record<string, unknown> })
+    .filter((action) => action.type === 'SAVE_TAB_STATE' && 'scrollState' in action.payload)
+    .map((action) => {
+      const scrollState = action.payload.scrollState as { offset: number; entityId?: string }
+      return {
+        tabId: action.payload.tabId as string,
+        offset: scrollState.offset,
+        entityId: scrollState.entityId
+      }
+    })
+}
+
+describe('useTabScrollRestore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.dispatch.mockClear()
+    mocks.getTab.mockReset()
+    mocks.getTab.mockReturnValue(null)
+    mocks.identity.current = { tabId: 'tab-a', groupId: 'group-1', entityId: 'note-1' }
+    TestResizeObserver.instances = []
+    vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    document.body.innerHTML = ''
+  })
+
+  // -------------------------------------------------------------------------
+  // Save path
+  // -------------------------------------------------------------------------
+
+  it('throttles saves instead of dispatching per scroll event', () => {
+    const scroller = makeScroller(1000)
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    scroller.userScrollTo(120)
+    scroller.userScrollTo(250)
+    expect(savedPayloads()).toEqual([])
+
+    vi.advanceTimersByTime(500)
+
+    expect(savedPayloads()).toEqual([{ tabId: 'tab-a', offset: 250, entityId: 'note-1' }])
+  })
+
+  it('saves the offset from the ref, not from the DOM, at teardown', () => {
+    const scroller = makeScroller(1000)
+    const { unmount } = renderHook(() =>
+      useTabScrollRestore({ getScrollElement: () => scroller.element })
+    )
+
+    scroller.userScrollTo(250)
+    // What the old mechanism saw: by cleanup time the container has been emptied
+    // by the Suspense swap and the browser has clamped `scrollTop` to 0.
+    scroller.setMaxScroll(0)
+    expect(scroller.element.scrollTop).toBe(0)
+
+    unmount()
+
+    expect(savedPayloads()).toEqual([{ tabId: 'tab-a', offset: 250, entityId: 'note-1' }])
+  })
+
+  it('flushes under the previous tab identity when the tab changes', () => {
+    const scroller = makeScroller(1000)
+    const { rerender } = renderHook(() =>
+      useTabScrollRestore({ getScrollElement: () => scroller.element })
+    )
+
+    scroller.userScrollTo(310)
+    mocks.identity.current = { tabId: 'tab-b', groupId: 'group-1', entityId: 'note-2' }
+    rerender()
+
+    expect(savedPayloads()).toEqual([{ tabId: 'tab-a', offset: 310, entityId: 'note-1' }])
+  })
+
+  it('does nothing without a tab identity', () => {
+    mocks.identity.current = null
+    const scroller = makeScroller(1000)
+    const { unmount } = renderHook(() =>
+      useTabScrollRestore({ getScrollElement: () => scroller.element })
+    )
+
+    scroller.userScrollTo(120)
+    vi.advanceTimersByTime(500)
+    unmount()
+
+    expect(mocks.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when disabled', () => {
+    const scroller = makeScroller(1000)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 400, entityId: 'note-1' }))
+
+    const { unmount } = renderHook(() =>
+      useTabScrollRestore({ getScrollElement: () => scroller.element, enabled: false })
+    )
+
+    expect(scroller.element.scrollTop).toBe(0)
+    unmount()
+    expect(mocks.dispatch).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // Restore path
+  // -------------------------------------------------------------------------
+
+  it('restores a saved offset stamped with the current entity', () => {
+    const scroller = makeScroller(1000)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 400, entityId: 'note-1' }))
+
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    expect(scroller.element.scrollTop).toBe(400)
+    // Target reached on the first pass — nothing left to observe.
+    expect(TestResizeObserver.live).toHaveLength(0)
+  })
+
+  it('discards a record stamped with a different entity', () => {
+    const scroller = makeScroller(1000)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 400, entityId: 'note-old' }))
+
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    expect(scroller.element.scrollTop).toBe(0)
+    expect(TestResizeObserver.live).toHaveLength(0)
+  })
+
+  it('restores an offset of 0 (0 is a value, not "absent")', () => {
+    const scroller = makeScroller(1000)
+    // A reused scroll container that still holds the previous view's offset.
+    scroller.element.scrollTop = 300
+    mocks.getTab.mockReturnValue(tabWith({ offset: 0, entityId: 'note-1' }))
+
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    expect(scroller.element.scrollTop).toBe(0)
+  })
+
+  it('re-applies the target as async content grows the container', () => {
+    // Content has not arrived: the write clamps to 0 on the first pass.
+    const scroller = makeScroller(0)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 500, entityId: 'note-1' }))
+
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    expect(scroller.element.scrollTop).toBe(0)
+    expect(TestResizeObserver.live).toHaveLength(1)
+
+    scroller.setMaxScroll(1000)
+    TestResizeObserver.fireAll()
+
+    expect(scroller.element.scrollTop).toBe(500)
+    expect(TestResizeObserver.live).toHaveLength(0)
+  })
+
+  it('gives up re-applying after the restore timeout', () => {
+    const scroller = makeScroller(0)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 500, entityId: 'note-1' }))
+
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+    expect(TestResizeObserver.live).toHaveLength(1)
+
+    vi.advanceTimersByTime(1000)
+    scroller.setMaxScroll(1000)
+    TestResizeObserver.fireAll()
+
+    expect(scroller.element.scrollTop).toBe(0)
+  })
+
+  it('cancels re-application once the user scrolls themselves', () => {
+    const scroller = makeScroller(0)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 500, entityId: 'note-1' }))
+
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+    expect(scroller.element.scrollTop).toBe(0)
+
+    // Content arrives and the user immediately scrolls somewhere else.
+    scroller.setMaxScroll(1000)
+    scroller.userScrollTo(120)
+    TestResizeObserver.fireAll()
+
+    expect(scroller.element.scrollTop).toBe(120)
+  })
+
+  it('cancels re-application on a wheel gesture before its scroll lands', () => {
+    const scroller = makeScroller(0)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 500, entityId: 'note-1' }))
+
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    scroller.element.dispatchEvent(new Event('wheel'))
+    scroller.setMaxScroll(1000)
+    TestResizeObserver.fireAll()
+
+    expect(scroller.element.scrollTop).toBe(0)
+  })
+
+  it('keeps re-applying while only our own programmatic writes are observed', () => {
+    const scroller = makeScroller(200)
+    mocks.getTab.mockReturnValue(tabWith({ offset: 500, entityId: 'note-1' }))
+
+    renderHook(() => useTabScrollRestore({ getScrollElement: () => scroller.element }))
+
+    // Partial restore: the write clamped to 200 and the browser echoes a scroll
+    // event carrying that same value. That is ours, not the user's.
+    expect(scroller.element.scrollTop).toBe(200)
+    scroller.element.dispatchEvent(new Event('scroll'))
+
+    scroller.setMaxScroll(1000)
+    TestResizeObserver.fireAll()
+
+    expect(scroller.element.scrollTop).toBe(500)
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.ts
@@ -1,0 +1,194 @@
+/**
+ * Tab scroll restore
+ *
+ * Saves and restores a tab's scroll offset against the element the page actually
+ * scrolls, which is never the tab wrapper: every page renders an `h-full`
+ * `overflow-hidden` root and owns an inner scroller.
+ *
+ * Two rules the previous mechanism broke, and this one must not:
+ *
+ * 1. NEVER read the scroll offset from the DOM at teardown. Only the active tab
+ *    is rendered, and `TabContent` reuses its page instance across a tab switch,
+ *    so a passive-effect cleanup runs AFTER the new DOM is committed — by then
+ *    `scrollTop` has already been clamped to 0. The live offset is mirrored into
+ *    a ref by the scroll listener and the ref is what gets persisted.
+ * 2. `0` is a valid offset. Restore must not be guarded on truthiness.
+ */
+
+import { useEffect, useLayoutEffect, useRef } from 'react'
+import { useTabActionsOptional } from '@/contexts/tabs'
+import { useTabIdentity } from '@/contexts/tabs/tab-identity'
+
+/** How often the live offset is committed to tab state while scrolling. */
+const SAVE_THROTTLE_MS = 500
+/** How long re-application keeps chasing content that is still loading. */
+const RESTORE_TIMEOUT_MS = 1000
+/** Sub-pixel tolerance when deciding whether a target offset was reached. */
+const OFFSET_EPSILON = 1
+
+export interface UseTabScrollRestoreOptions {
+  /**
+   * Returns the scrolling element. A getter rather than a ref so callers can
+   * resolve a Radix ScrollArea viewport (`[data-radix-scroll-area-viewport]`)
+   * or any other element they do not hold a ref to directly.
+   */
+  getScrollElement: () => HTMLElement | null
+  /** Set false to leave scrolling alone entirely (default true). */
+  enabled?: boolean
+  /**
+   * Extra identity discriminator. Changing it flushes the current offset and
+   * re-runs restore, exactly like a tab or entity change does.
+   */
+  key?: string
+}
+
+export function useTabScrollRestore({
+  getScrollElement,
+  enabled = true,
+  key
+}: UseTabScrollRestoreOptions): void {
+  const identity = useTabIdentity()
+  // Optional: `NoteLayout` and friends also render outside a tab (previews,
+  // standalone tests), where there is no tab state to save into.
+  const actions = useTabActionsOptional()
+  const dispatch = actions?.dispatch
+  const getTab = actions?.getTab
+
+  /** Live scroll offset. The single source of truth for every save. */
+  const offsetRef = useRef(0)
+  const getScrollElementRef = useRef(getScrollElement)
+
+  // Layout effects all run before any passive effect in the same commit, so the
+  // main effect below always sees the current render's getter.
+  useLayoutEffect(() => {
+    getScrollElementRef.current = getScrollElement
+  }, [getScrollElement])
+
+  const tabId = identity?.tabId
+  const groupId = identity?.groupId
+  const entityId = identity?.entityId
+
+  useEffect(() => {
+    if (!enabled || !tabId || !groupId || !dispatch || !getTab) return undefined
+
+    const element = getScrollElementRef.current()
+    if (!element) return undefined
+
+    let saveTimer: ReturnType<typeof setTimeout> | null = null
+    let pendingSave = false
+    /** The offset our own programmatic write actually produced. */
+    let lastWrittenOffset: number | null = null
+    let restoring = false
+    let restoreObserver: ResizeObserver | null = null
+    let restoreDeadline: ReturnType<typeof setTimeout> | null = null
+
+    const commit = (): void => {
+      saveTimer = null
+      if (!pendingSave) return
+      pendingSave = false
+      dispatch({
+        type: 'SAVE_TAB_STATE',
+        payload: { tabId, groupId, scrollState: { offset: offsetRef.current, entityId } }
+      })
+    }
+
+    const scheduleSave = (): void => {
+      pendingSave = true
+      if (saveTimer === null) saveTimer = setTimeout(commit, SAVE_THROTTLE_MS)
+    }
+
+    const stopRestoring = (): void => {
+      restoring = false
+      restoreObserver?.disconnect()
+      restoreObserver = null
+      if (restoreDeadline !== null) {
+        clearTimeout(restoreDeadline)
+        restoreDeadline = null
+      }
+    }
+
+    /**
+     * Writes `target` and reports whether it stuck. The browser clamps the write
+     * to the currently available scroll range, so the value read back is the
+     * only truth about whether the content is tall enough yet.
+     */
+    const applyOffset = (target: number): boolean => {
+      const scroller = getScrollElementRef.current()
+      if (!scroller) return false
+      scroller.scrollTop = target
+      lastWrittenOffset = scroller.scrollTop
+      offsetRef.current = lastWrittenOffset
+      return Math.abs(lastWrittenOffset - target) <= OFFSET_EPSILON
+    }
+
+    const handleScroll = (): void => {
+      const scroller = getScrollElementRef.current()
+      if (!scroller) return
+      const next = scroller.scrollTop
+      // Anything that is not the value our own write produced came from the
+      // user (scrollbar drag, momentum, keyboard) — stop chasing the target or
+      // we would undo their scroll.
+      if (restoring && next !== lastWrittenOffset) stopRestoring()
+      offsetRef.current = next
+      scheduleSave()
+    }
+
+    // Intent events fire before the scroll they cause, so cancelling here beats
+    // waiting for the resulting scroll event.
+    const handleUserIntent = (): void => {
+      if (restoring) stopRestoring()
+    }
+
+    element.addEventListener('scroll', handleScroll, { passive: true })
+    element.addEventListener('wheel', handleUserIntent, { passive: true })
+    element.addEventListener('touchmove', handleUserIntent, { passive: true })
+    element.addEventListener('keydown', handleUserIntent)
+
+    const saved = getTab(tabId, groupId)?.scrollState
+    // A tab keeps its identity when it navigates to another note, so an offset
+    // stamped with a different entity describes content that is gone.
+    const restorable =
+      saved !== undefined && saved.entityId === entityId && Number.isFinite(saved.offset)
+
+    if (restorable) {
+      const target = saved.offset
+      offsetRef.current = target
+      restoring = true
+
+      const tryApply = (): void => {
+        if (!restoring) return
+        if (applyOffset(target)) stopRestoring()
+      }
+
+      tryApply()
+
+      if (restoring) {
+        // Content arrives async (lazy chunk, note fetch, editor mount): the
+        // container has almost no height on the first pass, so keep re-applying
+        // as it grows. Observing the child too — the scroller itself is `h-full`
+        // and never resizes when its content does.
+        restoreObserver = new ResizeObserver(tryApply)
+        restoreObserver.observe(element)
+        if (element.firstElementChild) restoreObserver.observe(element.firstElementChild)
+        restoreDeadline = setTimeout(stopRestoring, RESTORE_TIMEOUT_MS)
+      }
+    }
+
+    return () => {
+      stopRestoring()
+      element.removeEventListener('scroll', handleScroll)
+      element.removeEventListener('wheel', handleUserIntent)
+      element.removeEventListener('touchmove', handleUserIntent)
+      element.removeEventListener('keydown', handleUserIntent)
+      if (saveTimer !== null) clearTimeout(saveTimer)
+
+      // Final save under THIS effect's identity, read from the ref. Reading the
+      // DOM here is exactly the bug this hook replaces.
+      dispatch({
+        type: 'SAVE_TAB_STATE',
+        payload: { tabId, groupId, scrollState: { offset: offsetRef.current, entityId } }
+      })
+      offsetRef.current = 0
+    }
+  }, [enabled, tabId, groupId, entityId, key, dispatch, getTab])
+}

--- a/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.ts
@@ -5,7 +5,7 @@
  * scrolls, which is never the tab wrapper: every page renders an `h-full`
  * `overflow-hidden` root and owns an inner scroller.
  *
- * Two rules the previous mechanism broke, and this one must not:
+ * Three rules the previous mechanism broke, and this one must not:
  *
  * 1. NEVER read the scroll offset from the DOM at teardown. Only the active tab
  *    is rendered, and `TabContent` reuses its page instance across a tab switch,
@@ -13,6 +13,11 @@
  *    `scrollTop` has already been clamped to 0. The live offset is mirrored into
  *    a ref by the scroll listener and the ref is what gets persisted.
  * 2. `0` is a valid offset. Restore must not be guarded on truthiness.
+ * 3. Not every scroll event is the user scrolling. When a page's content
+ *    remounts, the scroller can survive while its content height collapses; the
+ *    browser then clamps `scrollTop` and fires a scroll event carrying the
+ *    clamped value. Recording that value poisons the ref before teardown even
+ *    runs, which is rule 1's bug travelling through the ref instead of the DOM.
  */
 
 import { useEffect, useLayoutEffect, useRef } from 'react'
@@ -21,10 +26,38 @@ import { useTabIdentity } from '@/contexts/tabs/tab-identity'
 
 /** How often the live offset is committed to tab state while scrolling. */
 const SAVE_THROTTLE_MS = 500
-/** How long re-application keeps chasing content that is still loading. */
-const RESTORE_TIMEOUT_MS = 1000
+/**
+ * How long re-application waits for the content to grow again before concluding
+ * it has settled. A range that stopped growing short of the target means the
+ * target is unreachable, which is a better exit than a wall-clock deadline: a
+ * large note's lazy chunk, note fetch and editor mount routinely take seconds.
+ */
+const RESTORE_SETTLE_MS = 2000
+/** Hard upper bound on re-application, so the observer can never leak. */
+const RESTORE_MAX_MS = 15000
 /** Sub-pixel tolerance when deciding whether a target offset was reached. */
 const OFFSET_EPSILON = 1
+/**
+ * Keys that scroll. Anything else is typing — cancelling a pending restore on
+ * every keypress would abort it the moment the user starts editing the note
+ * they just came back to.
+ */
+const SCROLL_KEYS = new Set([
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'PageUp',
+  'PageDown',
+  'Home',
+  'End',
+  ' '
+])
+
+/** How far the element can scroll right now. `0` while content is still empty. */
+function scrollRangeOf(element: HTMLElement): number {
+  return Math.max(0, element.scrollHeight - element.clientHeight)
+}
 
 export interface UseTabScrollRestoreOptions {
   /**
@@ -78,17 +111,30 @@ export function useTabScrollRestore({
     let pendingSave = false
     /** The offset our own programmatic write actually produced. */
     let lastWrittenOffset: number | null = null
+    /** The scrollable range as of the last scroll event we looked at. */
+    let lastRange = scrollRangeOf(element)
+    /** The offset the last dispatch actually put into tab state. */
+    let lastDispatchedOffset: number | null = null
+    /** Whether anything happened that is worth persisting at teardown. */
+    let touched = false
     let restoring = false
     let restoreObserver: ResizeObserver | null = null
     let restoreDeadline: ReturnType<typeof setTimeout> | null = null
+    let restoreSettle: ReturnType<typeof setTimeout> | null = null
 
     const commit = (): void => {
       saveTimer = null
       if (!pendingSave) return
       pendingSave = false
+      const offset = offsetRef.current
+      // Every dispatch mints a new tab-system state object and re-renders the
+      // tab bar plus every `useTabGroup` consumer. A throttled save that would
+      // write the value already in state is pure churn.
+      if (offset === lastDispatchedOffset) return
+      lastDispatchedOffset = offset
       dispatch({
         type: 'SAVE_TAB_STATE',
-        payload: { tabId, groupId, scrollState: { offset: offsetRef.current, entityId } }
+        payload: { tabId, groupId, scrollState: { offset, entityId } }
       })
     }
 
@@ -105,19 +151,25 @@ export function useTabScrollRestore({
         clearTimeout(restoreDeadline)
         restoreDeadline = null
       }
+      if (restoreSettle !== null) {
+        clearTimeout(restoreSettle)
+        restoreSettle = null
+      }
     }
 
     /**
      * Writes `target` and reports whether it stuck. The browser clamps the write
      * to the currently available scroll range, so the value read back is the
-     * only truth about whether the content is tall enough yet.
+     * only truth about whether the content is tall enough yet. The ref keeps the
+     * target rather than the clamp: a partial write is our failure to restore,
+     * not the user choosing a new position, and tearing down mid-restore must
+     * persist what they asked for.
      */
     const applyOffset = (target: number): boolean => {
       const scroller = getScrollElementRef.current()
       if (!scroller) return false
       scroller.scrollTop = target
       lastWrittenOffset = scroller.scrollTop
-      offsetRef.current = lastWrittenOffset
       return Math.abs(lastWrittenOffset - target) <= OFFSET_EPSILON
     }
 
@@ -125,11 +177,30 @@ export function useTabScrollRestore({
       const scroller = getScrollElementRef.current()
       if (!scroller) return
       const next = scroller.scrollTop
-      // Anything that is not the value our own write produced came from the
-      // user (scrollbar drag, momentum, keyboard) — stop chasing the target or
-      // we would undo their scroll.
-      if (restoring && next !== lastWrittenOffset) stopRestoring()
+      const range = scrollRangeOf(scroller)
+      const previousRange = lastRange
+      lastRange = range
+
+      // The echo of our own restore write. Scroll events are delivered
+      // asynchronously, so one can still land after re-application stopped.
+      if (next === lastWrittenOffset) return
+
+      // A shrinking scrollable range that has fallen to the incoming offset is
+      // the browser clamping `scrollTop` because the content collapsed — a page
+      // body remounting under a surviving scroller, a Suspense swap — not the
+      // user scrolling. The stored offset has to survive that untouched. A real
+      // scroll (including one to the very top) happens while the range is stable
+      // or growing, or lands short of the range's new ceiling.
+      if (previousRange > range && next >= range - OFFSET_EPSILON && next < offsetRef.current) {
+        return
+      }
+
+      // Anything else came from the user (scrollbar drag, momentum, keyboard) —
+      // stop chasing the target or we would undo their scroll.
+      lastWrittenOffset = null
+      if (restoring) stopRestoring()
       offsetRef.current = next
+      touched = true
       scheduleSave()
     }
 
@@ -139,10 +210,15 @@ export function useTabScrollRestore({
       if (restoring) stopRestoring()
     }
 
+    const handleKeyDown = (event: Event): void => {
+      if (!SCROLL_KEYS.has((event as KeyboardEvent).key)) return
+      handleUserIntent()
+    }
+
     element.addEventListener('scroll', handleScroll, { passive: true })
     element.addEventListener('wheel', handleUserIntent, { passive: true })
     element.addEventListener('touchmove', handleUserIntent, { passive: true })
-    element.addEventListener('keydown', handleUserIntent)
+    element.addEventListener('keydown', handleKeyDown, { passive: true })
 
     const saved = getTab(tabId, groupId)?.scrollState
     // A tab keeps its identity when it navigates to another note, so an offset
@@ -153,10 +229,26 @@ export function useTabScrollRestore({
     if (restorable) {
       const target = saved.offset
       offsetRef.current = target
+      // Tab state already holds exactly this record, so a save that reproduces
+      // it is a no-op re-render.
+      lastDispatchedOffset = target
       restoring = true
+
+      /** Largest scrollable range seen since re-application began. */
+      let grownTo = -1
 
       const tryApply = (): void => {
         if (!restoring) return
+        const scroller = getScrollElementRef.current()
+        if (!scroller) return
+        const range = scrollRangeOf(scroller)
+        if (range > grownTo) {
+          // Content is still arriving, so the target is not yet unreachable:
+          // give it another settle window.
+          grownTo = range
+          if (restoreSettle !== null) clearTimeout(restoreSettle)
+          restoreSettle = setTimeout(stopRestoring, RESTORE_SETTLE_MS)
+        }
         if (applyOffset(target)) stopRestoring()
       }
 
@@ -170,7 +262,7 @@ export function useTabScrollRestore({
         restoreObserver = new ResizeObserver(tryApply)
         restoreObserver.observe(element)
         if (element.firstElementChild) restoreObserver.observe(element.firstElementChild)
-        restoreDeadline = setTimeout(stopRestoring, RESTORE_TIMEOUT_MS)
+        restoreDeadline = setTimeout(stopRestoring, RESTORE_MAX_MS)
       }
     }
 
@@ -179,15 +271,20 @@ export function useTabScrollRestore({
       element.removeEventListener('scroll', handleScroll)
       element.removeEventListener('wheel', handleUserIntent)
       element.removeEventListener('touchmove', handleUserIntent)
-      element.removeEventListener('keydown', handleUserIntent)
+      element.removeEventListener('keydown', handleKeyDown)
       if (saveTimer !== null) clearTimeout(saveTimer)
 
       // Final save under THIS effect's identity, read from the ref. Reading the
-      // DOM here is exactly the bug this hook replaces.
-      dispatch({
-        type: 'SAVE_TAB_STATE',
-        payload: { tabId, groupId, scrollState: { offset: offsetRef.current, entityId } }
-      })
+      // DOM here is exactly the bug this hook replaces. A tab that was never
+      // scrolled and has no record to correct has nothing to persist — writing
+      // `{ offset: 0 }` for every tab the user merely opens is churn in state
+      // that gets serialised to disk.
+      if (touched || saved !== undefined) {
+        dispatch({
+          type: 'SAVE_TAB_STATE',
+          payload: { tabId, groupId, scrollState: { offset: offsetRef.current, entityId } }
+        })
+      }
       offsetRef.current = 0
     }
   }, [enabled, tabId, groupId, entityId, key, dispatch, getTab])

--- a/apps/desktop/src/renderer/src/hooks/use-tab-view-state.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-view-state.test.tsx
@@ -1,0 +1,145 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTabViewState } from './use-tab-view-state'
+import type { Tab } from '@/contexts/tabs/types'
+import type { TabIdentity } from '@/contexts/tabs/tab-identity'
+
+const mocks = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  getTab: vi.fn(),
+  identity: { current: null as TabIdentity | null }
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabActionsOptional: () => ({ dispatch: mocks.dispatch, getTab: mocks.getTab })
+}))
+
+vi.mock('@/contexts/tabs/tab-identity', () => ({
+  useTabIdentity: () => mocks.identity.current
+}))
+
+function tabWith(viewState: Record<string, unknown> | undefined): Tab {
+  return { id: 'tab-a', viewState } as Tab
+}
+
+/** Accepts only the two strings this fixture considers valid. */
+const parseMode = (raw: unknown): 'list' | 'board' | undefined =>
+  raw === 'list' || raw === 'board' ? raw : undefined
+
+describe('useTabViewState', () => {
+  beforeEach(() => {
+    mocks.dispatch.mockClear()
+    mocks.getTab.mockReset()
+    mocks.getTab.mockReturnValue(null)
+    mocks.identity.current = { tabId: 'tab-a', groupId: 'group-1', entityId: 'note-1' }
+  })
+
+  it('seeds from the tab viewState through parse', () => {
+    mocks.getTab.mockReturnValue(tabWith({ mode: 'board' }))
+
+    const { result } = renderHook(() =>
+      useTabViewState({ key: 'mode', defaultValue: 'list' as const, parse: parseMode })
+    )
+
+    expect(result.current[0]).toBe('board')
+  })
+
+  it('falls back to the default when the key is absent', () => {
+    mocks.getTab.mockReturnValue(tabWith({ other: 1 }))
+
+    const { result } = renderHook(() =>
+      useTabViewState({ key: 'mode', defaultValue: 'list' as const, parse: parseMode })
+    )
+
+    expect(result.current[0]).toBe('list')
+  })
+
+  it('falls back to the default when parse rejects the stored value', () => {
+    mocks.getTab.mockReturnValue(tabWith({ mode: 'gallery' }))
+
+    const { result } = renderHook(() =>
+      useTabViewState({ key: 'mode', defaultValue: 'list' as const, parse: parseMode })
+    )
+
+    expect(result.current[0]).toBe('list')
+  })
+
+  it('falls back to the default instead of throwing when parse throws', () => {
+    mocks.getTab.mockReturnValue(tabWith({ mode: 'gallery' }))
+    const throwingParse = (): 'list' => {
+      throw new Error('unsupported mode')
+    }
+
+    const { result } = renderHook(() =>
+      useTabViewState({ key: 'mode', defaultValue: 'list' as const, parse: throwingParse })
+    )
+
+    expect(result.current[0]).toBe('list')
+  })
+
+  it('writes only its own key so other writers are not clobbered', () => {
+    mocks.getTab.mockReturnValue(tabWith({ mode: 'list', filter: 'open' }))
+
+    const { result } = renderHook(() =>
+      useTabViewState({ key: 'mode', defaultValue: 'list' as const, parse: parseMode })
+    )
+
+    act(() => result.current[1]('board'))
+
+    expect(result.current[0]).toBe('board')
+    expect(mocks.dispatch).toHaveBeenCalledWith({
+      type: 'SAVE_TAB_STATE',
+      payload: { tabId: 'tab-a', groupId: 'group-1', viewState: { mode: 'board' } }
+    })
+  })
+
+  it('supports a functional updater', () => {
+    mocks.getTab.mockReturnValue(tabWith({ count: 2 }))
+
+    const { result } = renderHook(() =>
+      useTabViewState({
+        key: 'count',
+        defaultValue: 0,
+        parse: (raw) => (typeof raw === 'number' ? raw : undefined)
+      })
+    )
+
+    act(() => result.current[1]((previous) => previous + 3))
+
+    expect(result.current[0]).toBe(5)
+    expect(mocks.dispatch).toHaveBeenCalledWith({
+      type: 'SAVE_TAB_STATE',
+      payload: { tabId: 'tab-a', groupId: 'group-1', viewState: { count: 5 } }
+    })
+  })
+
+  it('re-seeds when the tab identity changes under a reused page instance', () => {
+    mocks.getTab.mockImplementation((tabId: string) =>
+      tabId === 'tab-a' ? tabWith({ mode: 'board' }) : tabWith({ mode: 'list' })
+    )
+
+    const { result, rerender } = renderHook(() =>
+      useTabViewState({ key: 'mode', defaultValue: 'list' as const, parse: parseMode })
+    )
+    expect(result.current[0]).toBe('board')
+
+    mocks.identity.current = { tabId: 'tab-b', groupId: 'group-1', entityId: 'note-2' }
+    rerender()
+
+    expect(result.current[0]).toBe('list')
+  })
+
+  it('degrades to plain local state outside a tab', () => {
+    mocks.identity.current = null
+
+    const { result } = renderHook(() =>
+      useTabViewState({ key: 'mode', defaultValue: 'list' as const, parse: parseMode })
+    )
+
+    act(() => result.current[1]('board'))
+
+    expect(result.current[0]).toBe('board')
+    expect(mocks.dispatch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-tab-view-state.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-view-state.ts
@@ -1,0 +1,112 @@
+/**
+ * Tab-scoped view state
+ *
+ * A `useState`-like API whose value lives in the owning tab's `viewState`, so it
+ * survives a tab switch (which keeps the page instance alive but swaps its tab)
+ * and a session restore.
+ *
+ * Keyed off `useTabIdentity`, not `useActiveTab`: the latter returns the
+ * GLOBALLY active tab and would read/write the wrong tab for a page rendered in
+ * the inactive pane of a split view.
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useTabActionsOptional } from '@/contexts/tabs'
+import { useTabIdentity } from '@/contexts/tabs/tab-identity'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('Hook:TabViewState')
+
+export interface UseTabViewStateOptions<T> {
+  /** Key inside the tab's `viewState` record. */
+  key: string
+  /** Value used when nothing is stored, or when the stored value fails to parse. */
+  defaultValue: T
+  /**
+   * Validates/narrows the persisted value. Persisted tab state can have been
+   * written by an older app version, so this must be total: return `undefined`
+   * (or throw — a throw is caught) to reject the stored value and fall back to
+   * `defaultValue`.
+   */
+  parse: (raw: unknown) => T | undefined
+}
+
+export type TabViewStateSetter<T> = (next: T | ((previous: T) => T)) => void
+
+export function useTabViewState<T>({
+  key,
+  defaultValue,
+  parse
+}: UseTabViewStateOptions<T>): [T, TabViewStateSetter<T>] {
+  const identity = useTabIdentity()
+  const actions = useTabActionsOptional()
+  const dispatch = actions?.dispatch
+  const getTab = actions?.getTab
+
+  const parseRef = useRef(parse)
+  const defaultValueRef = useRef(defaultValue)
+  const identityRef = useRef(identity)
+
+  useLayoutEffect(() => {
+    parseRef.current = parse
+    defaultValueRef.current = defaultValue
+    identityRef.current = identity
+  })
+
+  const read = useCallback((): T => {
+    const current = identityRef.current
+    if (!current) return defaultValueRef.current
+
+    const raw = getTab?.(current.tabId, current.groupId)?.viewState?.[key]
+    if (raw === undefined) return defaultValueRef.current
+
+    try {
+      const parsed = parseRef.current(raw)
+      return parsed === undefined ? defaultValueRef.current : parsed
+    } catch (err) {
+      // Diagnostic only — a rejected view-state value is never surfaced to the
+      // user, the hook just falls back to the default.
+      log.warn('discarding unparseable tab view state', { key, error: String(err) })
+      return defaultValueRef.current
+    }
+  }, [getTab, key])
+
+  const [value, setValue] = useState<T>(read)
+  const valueRef = useRef(value)
+
+  // Re-seed when the tab this component is rendered for changes. `TabContent`
+  // reuses its page instance across a tab switch, so without this the new tab
+  // would inherit the previous tab's state.
+  const identityKey = identity ? `${identity.groupId}:${identity.tabId}` : ''
+  const seededForRef = useRef(identityKey)
+  useEffect(() => {
+    if (seededForRef.current === identityKey) return
+    seededForRef.current = identityKey
+    const seeded = read()
+    valueRef.current = seeded
+    setValue(seeded)
+  }, [identityKey, read])
+
+  const setTabViewState = useCallback<TabViewStateSetter<T>>(
+    (next) => {
+      const resolved =
+        typeof next === 'function' ? (next as (previous: T) => T)(valueRef.current) : next
+      valueRef.current = resolved
+      setValue(resolved)
+
+      const current = identityRef.current
+      if (!current || !dispatch) return
+      dispatch({
+        type: 'SAVE_TAB_STATE',
+        payload: {
+          tabId: current.tabId,
+          groupId: current.groupId,
+          viewState: { [key]: resolved }
+        }
+      })
+    },
+    [dispatch, key]
+  )
+
+  return [value, setTabViewState]
+}

--- a/apps/desktop/src/renderer/src/pages/virtual-note.tsx
+++ b/apps/desktop/src/renderer/src/pages/virtual-note.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import { ContentArea } from '@/components/note/content-area'
+import { useTabScrollRestore } from '@/hooks/use-tab-scroll-restore'
 
 interface VirtualNotePageProps {
   /** Tab title, rendered as the note heading (e.g. "MemryNote 2026.708.1"). */
@@ -21,15 +22,24 @@ export function VirtualNotePage({ title, content, contentType }: VirtualNotePage
     window.open(href, '_blank', 'noopener,noreferrer')
   }, [])
 
+  // This page used to lean on TabContent's wrapper as its scroller, which is why
+  // it was the only tab type the old scroll-restore mechanism actually served.
+  // It now owns its scroll container, like every other page.
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const getScrollElement = useCallback(() => scrollRef.current, [])
+  useTabScrollRestore({ getScrollElement })
+
   return (
-    <div className="mx-auto w-full max-w-3xl px-8 py-10">
-      <h1 className="mb-6 text-2xl font-semibold text-foreground">{title}</h1>
-      <ContentArea
-        initialContent={content}
-        contentType={contentType}
-        editable={false}
-        onLinkClick={handleLinkClick}
-      />
+    <div ref={scrollRef} className="h-full overflow-y-auto overflow-x-hidden">
+      <div className="mx-auto w-full max-w-3xl px-8 py-10">
+        <h1 className="mb-6 text-2xl font-semibold text-foreground">{title}</h1>
+        <ContentArea
+          initialContent={content}
+          contentType={contentType}
+          editable={false}
+          onLinkClick={handleLinkClick}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -126,8 +126,17 @@ If **Restore Session** is on, the entire tab and split layout restores on app la
 - Pinned state
 - Split layout and ratios
 - Active tab per pane
+- Scroll position in note tabs
 
 The layout is written only when one of those things actually changes. Activity that leaves the layout alone — a note picking up and losing its modified dot, moving back and forward inside a tab — no longer triggers a rewrite. Quitting still writes the current layout either way, so nothing is lost by the skipped writes.
+
+### Scroll Position
+
+Note tabs — including the template editor and release-notes tabs — remember where you were reading. Switch to another tab and back, or restart with **Restore Session** on, and the note returns to the same place.
+
+If the tab navigates to a different note, the saved position is discarded rather than applied to the new content. Scrolling yourself while a position is being restored cancels the restore, so the app never fights you for control of the page.
+
+Other surfaces — Tasks, Inbox, Calendar, folder views — do not restore scroll yet.
 
 ### If the layout can't be saved
 


### PR DESCRIPTION
Reported by Aurelie (13 Aug, v2026-08-07.2): open note A, scroll down, switch to note B, come back to A — you land at the top. Every note, every time, regardless of restart.

## The report's diagnosis was wrong

The report pointed at `tab-content.tsx:100-112` and asked whether the save was late or the restore early. It was neither: **the mechanism was attached to the wrong element.**

`TabContent`'s wrapper is `h-full overflow-y-auto`, but `NoteLayout`'s root is `h-full overflow-hidden` and the real scroller is its inner `flex-1 overflow-y-auto` div. So `scrollRef.current.scrollTop` was permanently `0` — the save wrote 0 and the restore skipped it (`0` is falsy). Auditing every tab type showed the same for all but one: `virtual-note` (release notes) is the only page that genuinely scrolled that wrapper.

Two further defects would have kept it broken even with the right element:

- `TabPane` renders only the active tab and `TabContent` is reused without a key, so the save ran in a passive-effect cleanup — after the new DOM was committed and the `Suspense fallback={null}` swap had emptied the container. `scrollTop` was already clamped to 0 by then. **Scroll offset must never be read from the DOM at teardown.**
- The restore ran once, on mount, against a container whose content (lazy chunk, note fetch, editor mount) had not arrived, so the write clamped to 0 and never retried.

## What this PR does

- **`SAVE_TAB_STATE` merges `viewState` instead of replacing it.** It previously overwrote wholesale, so two independent writers clobbered each other. Prerequisite for anything else writing per-tab state.
- **Tab identity context.** Pages reach for `useActiveTab()`, which returns the *globally* active tab and is wrong for a page in the inactive pane of a split view. `TabContent` now provides `{tabId, groupId, entityId}`. Existing callers are left alone; new code just doesn't build on the footgun.
- **`useTabScrollRestore`.** Live offset is mirrored into a ref by a passive listener; saves are throttled and read from the ref, never from the DOM. Restore is gated on an `entityId` stamp, so a tab that navigates to a different note discards the old offset instead of applying it to new content. `0` is a valid offset. The target is re-applied through a `ResizeObserver` as async content grows, and re-application cancels the instant the user scrolls.
- **A content collapse cannot poison the saved offset.** When a page body remounts under a surviving scroller the browser clamps `scrollTop` and emits a scroll event; recording that as a user scroll reintroduces the original bug through the ref. Classified and ignored.
- **`useTabViewState`.** Typed `useState`-like API over the tab's `viewState`. Not wired to any page here; follow-ups build on it.
- **`virtual-note` migrated onto its own scroll container first, then `tab-content.tsx:89-112` deleted.** Deleting before migrating would have regressed the one tab type the old code actually served.

## Compatibility

`Tab.scrollState` is a new optional field, deliberately not a reuse of `scrollPosition`. Sessions written by older versions restore unchanged; a legacy `scrollPosition` carries no entity stamp and is simply never matched. Legacy read/write paths are untouched.

## Verification

`typecheck:web`, `typecheck:test`, `lint`, `test:renderer` (623 files / 7222 tests), `docs:impact --strict`, `docs:build` — all green on the current `main`.

jsdom has no layout, so `scrollTop`/`scrollHeight` are fakes and a naive DOM test would have passed against the *original broken code* too. The suite therefore drives the hook's decision logic against a hand-stubbed scroller that models clamping, and every test was mutation-checked: reverting the fix fails it. Killed mutations include teardown-reads-DOM, entityId-mismatch-restores-anyway, `0`-treated-as-absent, user-scroll-doesn't-cancel, no-ResizeObserver, no-throttle, and the reducer replacing `viewState`.

**Not yet proven:** the content-collapse case (F1) is real-browser behaviour that jsdom cannot produce, so its test is a model, not a reproduction. This needs a manual pass in Electron — note A, scroll, note B, back to A — and an E2E spec. Note that E2E jobs only run on push to main, so a green PR here says nothing about them.

## Scope

Notes and the template editor only. Follow-ups cover Inbox / Tasks / Project / folder views, then Journal / Calendar / Agent Chat / Tags / file viewers. Canvas and Graph are deliberately excluded: canvas viewport restore risks scene loss given `initialData` is consumed once at mount under an entity-keyed remount, and graph camera restore is meaningless while node positions are randomised on every mount.