### PR TITLE
feat(tabs): the timeline and viewer surfaces come back where you left them

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-feature-provider.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-feature-provider.test.tsx
@@ -7,6 +7,9 @@ const mockUseAISettingsContext = vi.hoisted(() =>
 )
 
 vi.mock('@/contexts/tabs', () => ({
+  // The transcript keeps its scroll position in tab state; these tests render
+  // it outside a tab, where that degrades to no persistence at all.
+  useTabActionsOptional: () => null,
   useActiveTab: () => null,
   useTabs: () => ({ openTab: vi.fn() })
 }))

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-pane.test.tsx
@@ -15,6 +15,9 @@ vi.mock('../agent-context', () => ({
 }))
 
 vi.mock('@/contexts/tabs', () => ({
+  // The transcript keeps its scroll position in tab state; these tests render
+  // it outside a tab, where that degrades to no persistence at all.
+  useTabActionsOptional: () => null,
   useActiveTab: () => null
 }))
 

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-tab-title-sync.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-tab-title-sync.test.tsx
@@ -9,6 +9,9 @@ vi.mock('../agent-context', () => ({
 }))
 
 vi.mock('@/contexts/tabs', () => ({
+  // The transcript keeps its scroll position in tab state; these tests render
+  // it outside a tab, where that degrades to no persistence at all.
+  useTabActionsOptional: () => null,
   useTabs: () => ({
     state: {
       tabGroups: {

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/composer.test.tsx
@@ -14,6 +14,9 @@ vi.mock('../agent-context', () => ({
 }))
 
 vi.mock('@/contexts/tabs', () => ({
+  // The transcript keeps its scroll position in tab state; these tests render
+  // it outside a tab, where that degrades to no persistence at all.
+  useTabActionsOptional: () => null,
   useActiveTab: mockUseActiveTab
 }))
 

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream-render-scoping.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream-render-scoping.test.tsx
@@ -12,6 +12,9 @@ vi.mock('../agent-context', () => ({
 }))
 
 vi.mock('@/contexts/tabs', () => ({
+  // The transcript keeps its scroll position in tab state; these tests render
+  // it outside a tab, where that degrades to no persistence at all.
+  useTabActionsOptional: () => null,
   useTabActions: () => ({ openTab: mockOpenTab })
 }))
 

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
@@ -11,6 +11,9 @@ vi.mock('../agent-context', () => ({
 }))
 
 vi.mock('@/contexts/tabs', () => ({
+  // The transcript keeps its scroll position in tab state; these tests render
+  // it outside a tab, where that degrades to no persistence at all.
+  useTabActionsOptional: () => null,
   useTabActions: () => ({ openTab: mockOpenTab })
 }))
 

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx
@@ -23,6 +23,9 @@ vi.mock('../agent-context', () => ({
 }))
 
 vi.mock('@/contexts/tabs', () => ({
+  // The transcript keeps its scroll position in tab state; these tests render
+  // it outside a tab, where that degrades to no persistence at all.
+  useTabActionsOptional: () => null,
   useActiveTab: () => null,
   useTabs: () => ({ openTab: mockOpenTab })
 }))

--- a/apps/desktop/src/renderer/src/components/ai-elements/conversation.tsx
+++ b/apps/desktop/src/renderer/src/components/ai-elements/conversation.tsx
@@ -1,6 +1,141 @@
-import { useEffect, useRef, type ComponentProps } from 'react'
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type ComponentProps,
+  type ReactNode,
+  type RefObject
+} from 'react'
 
 import { cn } from '@/lib/utils'
+import { useTabIdentity } from '@/contexts/tabs/tab-identity'
+import { useTabEntityViewState } from '@/hooks/use-tab-entity-view-state'
+import {
+  AGENT_CONVERSATION_SCROLL_KEY,
+  conversationScrollAction,
+  parseConversationScroll,
+  scrollStateFor,
+  type ConversationScrollState
+} from './stick-to-bottom'
+
+/** How often the live position is committed to tab state while scrolling. */
+const SAVE_THROTTLE_MS = 500
+/** Sub-pixel tolerance when deciding whether a restore reached its target. */
+const OFFSET_EPSILON = 1
+
+/**
+ * Keeps the transcript pinned to the newest message while the reader is at the
+ * bottom, leaves them alone the moment they scroll up, and puts them back where
+ * they were on the way into the tab.
+ *
+ * The old behaviour was `useEffect(() => scrollTo(bottom), [children])` with no
+ * guard at all: every streamed token, and any re-render that produced a new
+ * children array, dragged the reader back down mid-sentence.
+ */
+function useStickToBottom(scrollRef: RefObject<HTMLDivElement | null>, children: ReactNode): void {
+  const entityId = useTabIdentity()?.entityId
+  const [stored, setStored] = useTabEntityViewState<ConversationScrollState | null>({
+    key: AGENT_CONVERSATION_SCROLL_KEY,
+    defaultValue: null,
+    parse: parseConversationScroll
+  })
+
+  /**
+   * The LIVE policy. Seeded from tab state and then owned by the scroll
+   * listener, because the commit to tab state is throttled: reading `stored`
+   * here would keep saying "bottom" for half a second after the user scrolled
+   * up, and every token arriving in that window would haul them back down.
+   */
+  const storedRef = useRef<ConversationScrollState | null>(stored)
+  const seededEntityRef = useRef<string | undefined>(entityId)
+  /** Whether the stored offset has been applied, or the user has overridden it. */
+  const restoredRef = useRef(false)
+  /** The offset our own programmatic write produced, so its echo is ignored. */
+  const lastWrittenRef = useRef<number | null>(null)
+  const pendingRef = useRef<ConversationScrollState | null>(null)
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const setStoredRef = useRef(setStored)
+
+  useLayoutEffect(() => {
+    setStoredRef.current = setStored
+  })
+
+  // A tab reused for another conversation starts over: its stored position
+  // belongs to the transcript that has just been replaced.
+  useEffect(() => {
+    if (seededEntityRef.current === entityId) return
+    seededEntityRef.current = entityId
+    storedRef.current = stored
+    restoredRef.current = false
+    lastWrittenRef.current = null
+  }, [entityId, stored])
+
+  useEffect(() => {
+    const element = scrollRef.current
+    if (!element) return undefined
+
+    const flush = (): void => {
+      if (saveTimerRef.current !== null) {
+        clearTimeout(saveTimerRef.current)
+        saveTimerRef.current = null
+      }
+      const pending = pendingRef.current
+      pendingRef.current = null
+      if (pending === null) return
+      setStoredRef.current(pending)
+    }
+
+    const handleScroll = (): void => {
+      // The echo of our own stick/restore write, delivered asynchronously.
+      if (element.scrollTop === lastWrittenRef.current) return
+      lastWrittenRef.current = null
+      restoredRef.current = true
+      storedRef.current = scrollStateFor(element)
+      pendingRef.current = storedRef.current
+      if (saveTimerRef.current === null) {
+        saveTimerRef.current = setTimeout(flush, SAVE_THROTTLE_MS)
+      }
+    }
+
+    element.addEventListener('scroll', handleScroll, { passive: true })
+    return () => {
+      element.removeEventListener('scroll', handleScroll)
+      flush()
+    }
+  }, [scrollRef])
+
+  // Runs on mount and on every children change — which, while a turn is
+  // running, is once per streamed token.
+  useEffect(() => {
+    const element = scrollRef.current
+    if (!element) return
+
+    const action = conversationScrollAction({
+      stored: storedRef.current,
+      restored: restoredRef.current
+    })
+
+    if (action.kind === 'none') return
+
+    if (action.kind === 'stick') {
+      // Assignment rather than `scrollTo`: the browser clamps it to the
+      // reachable range exactly the same way, and it is the one form jsdom
+      // implements, so the tests around this component keep running.
+      element.scrollTop = element.scrollHeight
+      lastWrittenRef.current = element.scrollTop
+      return
+    }
+
+    // The transcript arrives asynchronously, so the scroller may still be too
+    // short to reach the target; the browser clamps the write, and the next
+    // batch of children gives it another go.
+    element.scrollTop = action.offset
+    lastWrittenRef.current = element.scrollTop
+    if (Math.abs(element.scrollTop - action.offset) <= OFFSET_EPSILON) {
+      restoredRef.current = true
+    }
+  }, [children, scrollRef])
+}
 
 export type ConversationProps = ComponentProps<'div'>
 
@@ -10,10 +145,7 @@ export function Conversation({
   ...props
 }: ConversationProps): React.JSX.Element {
   const scrollRef = useRef<HTMLDivElement | null>(null)
-
-  useEffect(() => {
-    scrollRef.current?.scrollTo?.({ top: scrollRef.current.scrollHeight })
-  }, [children])
+  useStickToBottom(scrollRef, children)
 
   return (
     <div

--- a/apps/desktop/src/renderer/src/components/ai-elements/stick-to-bottom.test.ts
+++ b/apps/desktop/src/renderer/src/components/ai-elements/stick-to-bottom.test.ts
@@ -1,0 +1,110 @@
+/**
+ * jsdom reports `scrollHeight` as 0 and `scrollTop` as a plain writable number,
+ * so "did the transcript end up at the bottom" is not a question this
+ * environment can answer. These tests drive the decision instead.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  BOTTOM_THRESHOLD_PX,
+  conversationScrollAction,
+  isAtBottom,
+  parseConversationScroll,
+  scrollStateFor
+} from './stick-to-bottom'
+
+const metrics = (
+  scrollTop: number
+): { scrollTop: number; scrollHeight: number; clientHeight: number } => ({
+  scrollTop,
+  scrollHeight: 2000,
+  clientHeight: 500
+})
+
+/** The exact bottom of the scroller modelled above. */
+const BOTTOM = 1500
+
+describe('isAtBottom', () => {
+  it('counts the exact end as the bottom', () => {
+    expect(isAtBottom(metrics(BOTTOM))).toBe(true)
+  })
+
+  it('tolerates the last row being a hair short of flush', () => {
+    // Sub-pixel rounding means an exact comparison never holds, and a reader
+    // one pixel off the end has not scrolled up.
+    expect(isAtBottom(metrics(BOTTOM - BOTTOM_THRESHOLD_PX))).toBe(true)
+  })
+
+  it('treats a deliberate scroll up as not at the bottom', () => {
+    expect(isAtBottom(metrics(BOTTOM - BOTTOM_THRESHOLD_PX - 1))).toBe(false)
+    expect(isAtBottom(metrics(0))).toBe(false)
+  })
+})
+
+describe('scrollStateFor', () => {
+  it('stores a policy at the bottom and a position above it', () => {
+    expect(scrollStateFor(metrics(BOTTOM))).toBe('bottom')
+    expect(scrollStateFor(metrics(300))).toBe(300)
+  })
+
+  it('stores the top as a position, not as "nothing"', () => {
+    // Scrolling all the way up to re-read the start of a conversation is the
+    // clearest possible "stop following the stream".
+    expect(scrollStateFor(metrics(0))).toBe(0)
+  })
+})
+
+describe('conversationScrollAction', () => {
+  it('sticks to the bottom on a first open', () => {
+    expect(conversationScrollAction({ stored: null, restored: false })).toEqual({ kind: 'stick' })
+  })
+
+  it('keeps sticking while the reader is at the bottom', () => {
+    // Live streaming: every token re-renders the transcript and must keep the
+    // newest message in view.
+    expect(conversationScrollAction({ stored: 'bottom', restored: false })).toEqual({
+      kind: 'stick'
+    })
+    expect(conversationScrollAction({ stored: 'bottom', restored: true })).toEqual({
+      kind: 'stick'
+    })
+  })
+
+  it('restores a scrolled-up position on the way into the tab', () => {
+    expect(conversationScrollAction({ stored: 420, restored: false })).toEqual({
+      kind: 'restore',
+      offset: 420
+    })
+  })
+
+  it('stops touching the scroller once the reader is parked', () => {
+    // The bug this replaces: an unconditional jump to the bottom on every
+    // children change hauled the reader down mid-sentence on every token.
+    expect(conversationScrollAction({ stored: 420, restored: true })).toEqual({ kind: 'none' })
+  })
+
+  it('restores a stored `0`, which truthiness would have thrown away', () => {
+    expect(conversationScrollAction({ stored: 0, restored: false })).toEqual({
+      kind: 'restore',
+      offset: 0
+    })
+  })
+})
+
+describe('parseConversationScroll', () => {
+  it('accepts the policy, a position, and "never scrolled"', () => {
+    expect(parseConversationScroll('bottom')).toBe('bottom')
+    expect(parseConversationScroll(420)).toBe(420)
+    expect(parseConversationScroll(0)).toBe(0)
+    expect(parseConversationScroll(null)).toBeNull()
+  })
+
+  it('rejects what an older or broken build could have written', () => {
+    expect(parseConversationScroll(undefined)).toBeUndefined()
+    expect(parseConversationScroll('top')).toBeUndefined()
+    expect(parseConversationScroll(-1)).toBeUndefined()
+    expect(parseConversationScroll(Number.NaN)).toBeUndefined()
+    expect(parseConversationScroll({ offset: 420 })).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/ai-elements/stick-to-bottom.ts
+++ b/apps/desktop/src/renderer/src/components/ai-elements/stick-to-bottom.ts
@@ -1,0 +1,88 @@
+/**
+ * What an agent transcript remembers, and what it does with it.
+ *
+ * The transcript is the one surface where plain restore is the WRONG answer.
+ * A conversation grows from the bottom while it streams, so "the offset you
+ * left" stops meaning anything the moment another token arrives — a reader
+ * sitting at the newest message would be left further and further above it.
+ * What the user actually wants remembered is a POLICY:
+ *
+ * - at the bottom  → stay at the bottom, including through streaming
+ * - scrolled up    → stay exactly there, and stop being dragged down
+ *
+ * That is why this is the documented exception in
+ * `hooks/use-tab-auto-position.ts`: sticking to the bottom is auto-positioning,
+ * and here it is also a thing the tab can store. The rule itself still holds —
+ * a stored numeric offset (the user having scrolled up) beats it, exactly like
+ * a stored offset beats auto-positioning everywhere else.
+ */
+
+/** Tab `viewState` key. Entity-stamped, so one tab reused for another
+ * conversation does not inherit the previous transcript's position. */
+export const AGENT_CONVERSATION_SCROLL_KEY = 'agentConversationScroll'
+
+/**
+ * How close to the end still counts as "at the bottom". Sub-pixel rounding and
+ * a partially visible last row mean an exact comparison never holds, and a
+ * reader one pixel off the end has not scrolled up.
+ */
+export const BOTTOM_THRESHOLD_PX = 24
+
+/** `'bottom'` is a policy, a number is a position. */
+export type ConversationScrollState = 'bottom' | number
+
+export interface ScrollMetrics {
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+}
+
+/**
+ * Total: `viewState` survives a restore and can have been written by an older
+ * build. `null` is a value — "this tab has never been scrolled" — and is what
+ * lets a first open stick to the bottom without claiming the user asked for it.
+ */
+export function parseConversationScroll(raw: unknown): ConversationScrollState | null | undefined {
+  if (raw === null) return null
+  if (raw === 'bottom') return 'bottom'
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) return raw
+  return undefined
+}
+
+export function isAtBottom(metrics: ScrollMetrics): boolean {
+  const distance = metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop
+  return distance <= BOTTOM_THRESHOLD_PX
+}
+
+/** What the user's current position means, as something worth storing. */
+export function scrollStateFor(metrics: ScrollMetrics): ConversationScrollState {
+  return isAtBottom(metrics) ? 'bottom' : metrics.scrollTop
+}
+
+export type ConversationScrollAction =
+  { kind: 'stick' } | { kind: 'restore'; offset: number } | { kind: 'none' }
+
+export interface ConversationScrollInput {
+  /** The live policy: what is stored, updated the moment the user scrolls. */
+  stored: ConversationScrollState | null
+  /** Whether the stored offset has already been applied, or overridden. */
+  restored: boolean
+}
+
+/**
+ * Decided on every re-render of the transcript — which, while a turn is
+ * running, is once per streamed token.
+ *
+ * `none` is the whole point of the exception: once the user is parked at an
+ * offset, every subsequent token must leave the scroller alone. The previous
+ * behaviour was an unconditional jump to the bottom on every children change,
+ * with no notion of the user having scrolled at all.
+ */
+export function conversationScrollAction({
+  stored,
+  restored
+}: ConversationScrollInput): ConversationScrollAction {
+  if (stored === null || stored === 'bottom') return { kind: 'stick' }
+  if (restored) return { kind: 'none' }
+  return { kind: 'restore', offset: stored }
+}

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
@@ -15,6 +15,8 @@ import { useEventDrag, isEventMovable, isEventResizable } from './use-event-drag
 import { MarqueeSelectionOverlay } from './marquee-selection-overlay'
 import { CalendarQuickCreateDialog } from './calendar-quick-create-dialog'
 import { useScrollToCurrentTime } from './use-scroll-to-current-time'
+import { useTabScrollRestore } from '@/hooks/use-tab-scroll-restore'
+import { CALENDAR_SCROLL_KEYS } from '@/pages/calendar-view-state'
 import { useOptionalDragContext } from '@/contexts/drag-context'
 import type { AnchorRect, CalendarEventDraft } from './types'
 import { HOUR_HEIGHT } from './time-grid-constants'
@@ -63,6 +65,7 @@ export function CalendarDayView({
   const isTaskDragInFlight = useOptionalDragContext()?.dragState.isDragging ?? false
   const gridRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
+  const getScrollEl = useCallback(() => scrollRef.current, [])
   const dateForColumn = useCallback(() => anchorDate, [anchorDate])
   const { selection, isDragging, handlers, clearSelection } = useTimeGridMarquee({
     gridRef,
@@ -82,7 +85,10 @@ export function CalendarDayView({
     [onSelectItem, wasDragged]
   )
   const today = isToday(anchorDate)
-  useScrollToCurrentTime(scrollRef, today)
+  useScrollToCurrentTime(scrollRef, today, CALENDAR_SCROLL_KEYS.day)
+  // Deliberately NOT date-keyed: the offset here is a time of day, and the hour
+  // the user reads at is the same hour whatever day they move to.
+  useTabScrollRestore({ getScrollElement: getScrollEl, key: CALENDAR_SCROLL_KEYS.day })
   const dayItems = items.filter((item) => toLocalDateKey(item.startAt) === anchorDate)
   const timedItems = dayItems.filter((item) => !item.isAllDay)
   const allDayItems = dayItems.filter((item) => item.isAllDay)

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
@@ -41,7 +41,10 @@ vi.mock('@/hooks/use-calendar-range', async (importOriginal) => ({
 
 vi.mock('@/contexts/tabs', () => ({
   useActiveTab: mockUseActiveTab,
-  useTabActions: () => ({ openTab: mockOpenTab })
+  useTabActions: () => ({ openTab: mockOpenTab }),
+  // The page keeps its view, anchor and filters in tab state now; these tests
+  // render it outside a tab, where that state degrades to plain component state.
+  useTabActionsOptional: () => null
 }))
 
 vi.mock('@/services/calendar-service', () => {

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
@@ -17,6 +17,8 @@ import { assignLanes } from './overlap-layout'
 import { useTimeGridMarquee } from './use-time-grid-marquee'
 import { useEventDrag, isEventMovable, isEventResizable } from './use-event-drag'
 import { useScrollToCurrentTime } from './use-scroll-to-current-time'
+import { useTabScrollRestore } from '@/hooks/use-tab-scroll-restore'
+import { CALENDAR_SCROLL_KEYS } from '@/pages/calendar-view-state'
 import { useWeekInfiniteScroll } from './use-week-infinite-scroll'
 import { useOptionalDragContext } from '@/contexts/drag-context'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
@@ -108,6 +110,7 @@ export function CalendarWeekView({
       initialDate: anchorDate,
       onVisibleDayStartChange: notifyVisibleStart
     })
+  const getScrollEl = useCallback(() => scrollContainerRef.current, [scrollContainerRef])
 
   useEffect(() => {
     if (anchorDate === lastEmittedAnchorRef.current) return
@@ -202,7 +205,13 @@ export function CalendarWeekView({
     return false
   }, [visibleDayStart])
 
-  useScrollToCurrentTime(scrollContainerRef, weekContainsToday)
+  useScrollToCurrentTime(scrollContainerRef, weekContainsToday, CALENDAR_SCROLL_KEYS.week)
+  // Vertical only, and no virtualizer: this container is virtualized
+  // HORIZONTALLY, so its virtualizer drives scrollLeft — handing it to the
+  // restore would apply a saved hour-of-day offset as a day index. The
+  // horizontal position is restored by the anchor date instead, which is what
+  // `useWeekInfiniteScroll` already positions from on first layout.
+  useTabScrollRestore({ getScrollElement: getScrollEl, key: CALENDAR_SCROLL_KEYS.week })
 
   const { timedByDate, allDayByDate, maxAllDayPerDay } = useMemo(() => {
     const timed = new Map<string, CalendarProjectionItem[]>()

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-year-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-year-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useT } from '@memry/i18n/renderer'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
@@ -18,6 +18,8 @@ import { EVENT_TYPE_COLORS } from '@/lib/event-type-colors'
 import type { CalendarProjectionItem } from '@/services/calendar-service'
 import type { CalendarWorkspaceView } from './calendar-toolbar'
 import type { AnchorRect } from './types'
+import { useTabScrollRestore } from '@/hooks/use-tab-scroll-restore'
+import { CALENDAR_SCROLL_KEYS } from '@/pages/calendar-view-state'
 
 const CLICK_DELAY_MS = 250
 
@@ -51,6 +53,9 @@ export function CalendarYearView({
   const weekStartsOn = useWeekStartsOn()
   const [popoverDay, setPopoverDay] = useState<string | null>(null)
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const scrollRef = useRef<HTMLElement>(null)
+  const getScrollEl = useCallback(() => scrollRef.current, [])
+  useTabScrollRestore({ getScrollElement: getScrollEl, key: CALENDAR_SCROLL_KEYS.year })
 
   function formatPopoverTime(item: CalendarProjectionItem): string {
     if (item.isAllDay) return t('time.all-day-lower')
@@ -129,6 +134,7 @@ export function CalendarYearView({
     >
       {/* pt clears the floating chrome so months scroll beneath its material */}
       <section
+        ref={scrollRef}
         data-calendar-scroll
         className="h-full overflow-y-auto px-3 pb-3 pt-14 @lg:px-6 @lg:pb-4 @3xl:px-8 @3xl:pb-6"
         data-testid="calendar-view"

--- a/apps/desktop/src/renderer/src/components/calendar/use-scroll-to-current-time.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/use-scroll-to-current-time.ts
@@ -1,21 +1,36 @@
 import { useLayoutEffect, type RefObject } from 'react'
+import { useTabAutoPosition } from '@/hooks/use-tab-auto-position'
 
 const HOUR_HEIGHT = 96
 const VIEWPORT_RATIO = 0.4
 const FALLBACK_HOUR = 7
 
+/**
+ * Opens a time grid at the current hour — but only on a tab that has no
+ * position of its own. See `hooks/use-tab-auto-position.ts` for the rule.
+ *
+ * The gate matters twice here. Once on mount, where it would otherwise race the
+ * restore. And once after: this effect re-runs every time its range starts or
+ * stops containing today, which in week view happens as the user scrolls the
+ * weeks past today — so without the gate the grid yanks itself back to the
+ * current hour while they are reading.
+ */
 export function useScrollToCurrentTime(
   scrollRef: RefObject<HTMLDivElement | null>,
-  containsToday: boolean
+  containsToday: boolean,
+  scrollKey: string
 ): void {
+  const mayAutoPosition = useTabAutoPosition(scrollKey)
+
   useLayoutEffect(() => {
     const el = scrollRef.current
     if (!el) return
+    if (!mayAutoPosition()) return
 
     const targetOffset = containsToday ? offsetForNow() : FALLBACK_HOUR * HOUR_HEIGHT
 
     el.scrollTop = Math.max(0, targetOffset - el.clientHeight * VIEWPORT_RATIO)
-  }, [scrollRef, containsToday])
+  }, [scrollRef, containsToday, mayAutoPosition])
 }
 
 function offsetForNow(): number {

--- a/apps/desktop/src/renderer/src/components/viewers/audio-player.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/audio-player.tsx
@@ -5,7 +5,15 @@
  * @module components/viewers/audio-player
  */
 
-import { useState, useCallback, useRef, useEffect, memo, type RefObject } from 'react'
+import {
+  useState,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useEffect,
+  memo,
+  type RefObject
+} from 'react'
 import {
   Play,
   Pause,
@@ -22,6 +30,14 @@ import { Slider } from '@/components/ui/slider'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
 import { useTrackedTimeout } from '@/hooks/use-tracked-timeout'
+import { useTabEntityViewState } from '@/hooks/use-tab-entity-view-state'
+import { useTabScrollRestore } from '@/hooks/use-tab-scroll-restore'
+import {
+  FILE_AUDIO_SCROLL_KEY,
+  FILE_VIEW_STATE_KEYS,
+  parsePlaybackPosition,
+  shouldResumePlayback
+} from '@/pages/file-view-state'
 
 // ============================================================================
 // Types
@@ -122,6 +138,23 @@ export function AudioPlayer({
   const { t: tPhaseF } = useT('notes')
   const { t: tInbox } = useT('inbox')
   const audioRef = useRef<HTMLAudioElement>(null)
+  const contentScrollRef = useRef<HTMLDivElement>(null)
+  const getContentScrollEl = useCallback(() => contentScrollRef.current, [])
+  useTabScrollRestore({ getScrollElement: getContentScrollEl, key: FILE_AUDIO_SCROLL_KEY })
+
+  // The position comes back; playback deliberately does NOT resume. Restoring a
+  // session must never start making noise.
+  const [storedPosition, setStoredPosition] = useTabEntityViewState<number>({
+    key: FILE_VIEW_STATE_KEYS.audioPosition,
+    defaultValue: 0,
+    parse: parsePlaybackPosition
+  })
+  const storedPositionRef = useRef(storedPosition)
+  const livePositionRef = useRef(storedPosition)
+  const setStoredPositionRef = useRef(setStoredPosition)
+  useLayoutEffect(() => {
+    setStoredPositionRef.current = setStoredPosition
+  })
 
   const [isPlaying, setIsPlaying] = useState(false)
   const [duration, setDuration] = useState(0)
@@ -138,18 +171,42 @@ export function AudioPlayer({
     const audio = audioRef.current
     if (!audio) return
 
-    const handleLoadedMetadata = () => setDuration(audio.duration)
+    const commitPosition = (): void => {
+      const next = livePositionRef.current
+      if (next === storedPositionRef.current) return
+      storedPositionRef.current = next
+      setStoredPositionRef.current(next)
+    }
+
+    const handleLoadedMetadata = () => {
+      setDuration(audio.duration)
+      // Seeking is only possible once the duration is known, and only worth
+      // doing when there is something left to play.
+      if (shouldResumePlayback(storedPositionRef.current, audio.duration)) {
+        audio.currentTime = storedPositionRef.current
+      }
+    }
+    const handleTimeUpdate = () => {
+      livePositionRef.current = audio.currentTime
+    }
     const handleEnded = () => setIsPlaying(false)
     const handleError = () => setError(true)
 
     audio.addEventListener('loadedmetadata', handleLoadedMetadata)
+    audio.addEventListener('timeupdate', handleTimeUpdate)
+    // Committed when the transport stops rather than on every `timeupdate`:
+    // the stream is ~4 Hz and each commit is a tab-state dispatch.
+    audio.addEventListener('pause', commitPosition)
     audio.addEventListener('ended', handleEnded)
     audio.addEventListener('error', handleError)
 
     return () => {
       audio.removeEventListener('loadedmetadata', handleLoadedMetadata)
+      audio.removeEventListener('timeupdate', handleTimeUpdate)
+      audio.removeEventListener('pause', commitPosition)
       audio.removeEventListener('ended', handleEnded)
       audio.removeEventListener('error', handleError)
+      commitPosition()
     }
   }, [])
 
@@ -233,7 +290,7 @@ export function AudioPlayer({
       </audio>
 
       {/* Main content - player first, transcript directly below */}
-      <div className="flex-1 min-h-0 overflow-y-auto p-8">
+      <div ref={contentScrollRef} className="flex-1 min-h-0 overflow-y-auto p-8">
         <div className="mx-auto flex min-h-full w-full max-w-lg flex-col gap-6">
           <div className="space-y-8">
             {/* File name */}

--- a/apps/desktop/src/renderer/src/components/viewers/image-viewer.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/image-viewer.tsx
@@ -5,11 +5,19 @@
  * @module components/viewers/image-viewer
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react'
+import { useState, useCallback, useLayoutEffect, useRef, useEffect } from 'react'
 import { ZoomIn, ZoomOut, RotateCw, Maximize2, Move } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
+import { mayAutoPositionFor } from '@/hooks/use-tab-auto-position'
+import { useTabEntityViewState } from '@/hooks/use-tab-entity-view-state'
+import {
+  FILE_VIEW_STATE_KEYS,
+  parseNullableScale,
+  parseRotation,
+  parseViewerPosition
+} from '@/pages/file-view-state'
 
 // ============================================================================
 // Types
@@ -28,6 +36,9 @@ interface Position {
   x: number
   y: number
 }
+
+/** Stable identity, so the tab-state default does not churn on every render. */
+const ORIGIN: Position = { x: 0, y: 0 }
 
 /** Single source of truth for the image transform, shared by React and the imperative pan writes. */
 function buildTransform(position: Position, scale: number, rotation: number): string {
@@ -66,10 +77,29 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
   const containerRef = useRef<HTMLDivElement>(null)
   const imageRef = useRef<HTMLImageElement>(null)
 
-  const [scale, setScale] = useState(1)
-  const [rotation, setRotation] = useState(0)
-  const [position, setPosition] = useState<Position>({ x: 0, y: 0 })
+  // `null` is "the user has never zoomed this image", which is what lets
+  // fit-to-container run. See `hooks/use-tab-auto-position.ts`.
+  const [storedScale, setStoredScale] = useTabEntityViewState<number | null>({
+    key: FILE_VIEW_STATE_KEYS.imageScale,
+    defaultValue: null,
+    parse: parseNullableScale
+  })
+  const [scale, setScale] = useState(storedScale ?? 1)
+  const [rotation, setRotation] = useTabEntityViewState<number>({
+    key: FILE_VIEW_STATE_KEYS.imageRotation,
+    defaultValue: 0,
+    parse: parseRotation
+  })
+  const [position, setPosition] = useTabEntityViewState<Position>({
+    key: FILE_VIEW_STATE_KEYS.imagePosition,
+    defaultValue: ORIGIN,
+    parse: parseViewerPosition
+  })
   const [isDragging, setIsDragging] = useState(false)
+  const storedScaleRef = useRef(storedScale)
+  useLayoutEffect(() => {
+    storedScaleRef.current = storedScale
+  })
   const [loaded, setLoaded] = useState(false)
   const [error, setError] = useState(false)
 
@@ -79,26 +109,33 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
   /** Live scale, so the zoom handlers can compute the next value without a stale closure. */
   const scaleRef = useRef(scale)
 
-  const commitPosition = useCallback((next: Position) => {
-    positionRef.current = next
-    setPosition(next)
-  }, [])
+  const commitPosition = useCallback(
+    (next: Position) => {
+      positionRef.current = next
+      setPosition(next)
+    },
+    [setPosition]
+  )
 
   // Every zoom write goes through here: dropping back to 1x recenters in the same batch as
   // the scale change. Doing it in the render body instead (`if (scale === 1) setPosition(...)`)
   // made React throw the render away and run the component a second time on every zoom-out.
   const applyScale = useCallback(
-    (raw: number) => {
+    (raw: number, options?: { persist?: boolean }) => {
       // Normalise before anything reads it, so the exact `=== 1` below and the `scale > 1`
       // reads downstream cannot disagree with the "100%" the toolbar prints.
       const next = normalizeScale(raw)
       scaleRef.current = next
       setScale(next)
+      // Fit-to-container is auto-positioning, not a choice: persisting its
+      // result would freeze one pane's width into the tab and stop the image
+      // fitting the next time it is opened somewhere narrower.
+      if (options?.persist !== false) setStoredScale(next)
       if (next === 1 && (positionRef.current.x !== 0 || positionRef.current.y !== 0)) {
         commitPosition({ x: 0, y: 0 })
       }
     },
-    [commitPosition]
+    [commitPosition, setStoredScale]
   )
 
   // Attach wheel event with passive: false to allow preventDefault
@@ -128,12 +165,12 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
 
   const resetZoom = useCallback(() => {
     applyScale(1)
-    commitPosition({ x: 0, y: 0 })
+    commitPosition(ORIGIN)
   }, [applyScale, commitPosition])
 
   const rotate = useCallback(() => {
     setRotation((r) => (r + 90) % 360)
-  }, [])
+  }, [setRotation])
 
   const fitToContainer = useCallback(() => {
     if (containerRef.current && imageRef.current) {
@@ -146,8 +183,8 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
       const scaleY = containerHeight / imageHeight
       const newScale = Math.min(scaleX, scaleY, 1)
 
-      applyScale(newScale)
-      commitPosition({ x: 0, y: 0 })
+      applyScale(newScale, { persist: false })
+      commitPosition(ORIGIN)
     }
   }, [applyScale, commitPosition])
 
@@ -197,7 +234,9 @@ export function ImageViewer({ src, alt = 'Image', className }: ImageViewerProps)
   const handleImageLoad = useCallback(() => {
     setLoaded(true)
     setError(false)
-    fitToContainer()
+    // A zoom this tab already holds beats fitting to the container — one rule,
+    // the same one the calendar's jump to "now" obeys.
+    if (mayAutoPositionFor(storedScaleRef.current)) fitToContainer()
   }, [fitToContainer])
 
   const handleImageError = useCallback(() => {

--- a/apps/desktop/src/renderer/src/components/viewers/pdf-viewer.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/pdf-viewer.tsx
@@ -25,6 +25,16 @@ import {
 } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { useTabEntityViewState } from '@/hooks/use-tab-entity-view-state'
+import { useTabScrollRestore } from '@/hooks/use-tab-scroll-restore'
+import {
+  FILE_VIEW_STATE_KEYS,
+  parsePdfPage,
+  parseRotation,
+  parseScale,
+  parseViewerBoolean,
+  pdfPageScrollKey
+} from '@/pages/file-view-state'
 
 // Configure PDF.js worker - import from node_modules for Electron compatibility
 import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.min.mjs?url'
@@ -160,12 +170,37 @@ function PdfThumbnailRail({
 export function PdfViewer({ src, className }: PdfViewerProps) {
   const { t: tPhaseF } = useT('notes')
   const containerRef = useRef<HTMLDivElement>(null)
+  const pageScrollRef = useRef<HTMLDivElement>(null)
   const [numPages, setNumPages] = useState<number>(0)
-  const [currentPage, setCurrentPage] = useState(1)
-  const [scale, setScale] = useState(1.0)
-  const [rotation, setRotation] = useState(0)
-  const [sidebarOpen, setSidebarOpen] = useState(true)
+  // The main pane shows one page at a time, so the page number IS the reading
+  // position — the scroll offset only refines it within that page.
+  const [currentPage, setCurrentPage] = useTabEntityViewState<number>({
+    key: FILE_VIEW_STATE_KEYS.pdfPage,
+    defaultValue: 1,
+    parse: parsePdfPage
+  })
+  const [scale, setScale] = useTabEntityViewState<number>({
+    key: FILE_VIEW_STATE_KEYS.pdfScale,
+    defaultValue: 1.0,
+    parse: parseScale
+  })
+  const [rotation, setRotation] = useTabEntityViewState<number>({
+    key: FILE_VIEW_STATE_KEYS.pdfRotation,
+    defaultValue: 0,
+    parse: parseRotation
+  })
+  const [sidebarOpen, setSidebarOpen] = useTabEntityViewState<boolean>({
+    key: FILE_VIEW_STATE_KEYS.pdfSidebarOpen,
+    defaultValue: true,
+    parse: parseViewerBoolean
+  })
   const [error, setError] = useState<string | null>(null)
+
+  const getPageScrollEl = useCallback(() => pageScrollRef.current, [])
+  useTabScrollRestore({
+    getScrollElement: getPageScrollEl,
+    key: pdfPageScrollKey(currentPage)
+  })
 
   const handleLoadSuccess = useCallback(({ numPages }: { numPages: number }) => {
     setNumPages(numPages)
@@ -186,20 +221,20 @@ export function PdfViewer({ src, className }: PdfViewerProps) {
         setCurrentPage(page)
       }
     },
-    [numPages]
+    [numPages, setCurrentPage]
   )
 
   const zoomIn = useCallback(() => {
     setScale((s) => Math.min(s + 0.25, 3))
-  }, [])
+  }, [setScale])
 
   const zoomOut = useCallback(() => {
     setScale((s) => Math.max(s - 0.25, 0.5))
-  }, [])
+  }, [setScale])
 
   const rotate = useCallback(() => {
     setRotation((r) => (r + 90) % 360)
-  }, [])
+  }, [setRotation])
 
   const fitToWidth = useCallback(() => {
     if (containerRef.current) {
@@ -208,7 +243,7 @@ export function PdfViewer({ src, className }: PdfViewerProps) {
       const newScale = containerWidth / 612
       setScale(Math.min(Math.max(newScale, 0.5), 3))
     }
-  }, [sidebarOpen])
+  }, [setScale, sidebarOpen])
 
   if (error) {
     return (
@@ -345,7 +380,7 @@ export function PdfViewer({ src, className }: PdfViewerProps) {
           )}
 
           {/* PDF content - with both horizontal and vertical scrolling */}
-          <div className="flex-1 overflow-auto min-h-0">
+          <div ref={pageScrollRef} className="flex-1 overflow-auto min-h-0">
             <div className="inline-flex justify-center min-w-full p-4">
               <Page
                 pageNumber={currentPage}

--- a/apps/desktop/src/renderer/src/components/viewers/video-player.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/video-player.tsx
@@ -8,6 +8,7 @@
 import {
   useState,
   useCallback,
+  useEffect,
   useLayoutEffect,
   forwardRef,
   useRef,
@@ -17,6 +18,12 @@ import ReactPlayer from 'react-player'
 import { cn } from '@/lib/utils'
 import { createLogger } from '@/lib/logger'
 import { useT } from '@memry/i18n/renderer'
+import { useTabEntityViewState } from '@/hooks/use-tab-entity-view-state'
+import {
+  FILE_VIEW_STATE_KEYS,
+  parsePlaybackPosition,
+  shouldResumePlayback
+} from '@/pages/file-view-state'
 
 const log = createLogger('Component:VideoPlayer')
 
@@ -207,6 +214,56 @@ ensureCustomPlayerRegistered()
 export function VideoPlayer({ src, className }: VideoPlayerProps) {
   const { t: tPhaseF } = useT('notes')
   const [error, setError] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // The position was only ever read off the element and dropped. It is lifted
+  // here through the CONTAINER rather than through ReactPlayer's props: the
+  // `<video>` is mounted by a custom player ReactPlayer instantiates, so there
+  // is no stable prop contract to hang this on. Media events do not bubble, but
+  // capture-phase listeners on an ancestor still see them.
+  const [storedPosition, setStoredPosition] = useTabEntityViewState<number>({
+    key: FILE_VIEW_STATE_KEYS.videoPosition,
+    defaultValue: 0,
+    parse: parsePlaybackPosition
+  })
+  const storedPositionRef = useRef(storedPosition)
+  const livePositionRef = useRef(storedPosition)
+  const setStoredPositionRef = useRef(setStoredPosition)
+  useLayoutEffect(() => {
+    setStoredPositionRef.current = setStoredPosition
+  })
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return undefined
+
+    const commitPosition = (): void => {
+      const next = livePositionRef.current
+      if (next === storedPositionRef.current) return
+      storedPositionRef.current = next
+      setStoredPositionRef.current(next)
+    }
+
+    const handleLoadedMetadata = (event: Event): void => {
+      const video = event.target as HTMLVideoElement
+      if (shouldResumePlayback(storedPositionRef.current, video.duration)) {
+        video.currentTime = storedPositionRef.current
+      }
+    }
+    const handleTimeUpdate = (event: Event): void => {
+      livePositionRef.current = (event.target as HTMLVideoElement).currentTime
+    }
+
+    container.addEventListener('loadedmetadata', handleLoadedMetadata, true)
+    container.addEventListener('timeupdate', handleTimeUpdate, true)
+    container.addEventListener('pause', commitPosition, true)
+    return () => {
+      container.removeEventListener('loadedmetadata', handleLoadedMetadata, true)
+      container.removeEventListener('timeupdate', handleTimeUpdate, true)
+      container.removeEventListener('pause', commitPosition, true)
+      commitPosition()
+    }
+  }, [])
 
   const handleError = useCallback(() => {
     setError(true)
@@ -231,7 +288,10 @@ export function VideoPlayer({ src, className }: VideoPlayerProps) {
   }
 
   return (
-    <div className={cn('flex h-full flex-col bg-black min-h-0 overflow-hidden', className)}>
+    <div
+      ref={containerRef}
+      className={cn('flex h-full flex-col bg-black min-h-0 overflow-hidden', className)}
+    >
       <div className="flex-1 min-h-0 flex items-center justify-center">
         <ReactPlayer
           src={src}

--- a/apps/desktop/src/renderer/src/contexts/tabs/scroll-panes.test.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/scroll-panes.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { MAX_SCROLL_PANES, mergeScrollPanes, readScrollPane } from './scroll-panes'
+import {
+  MAX_SCROLL_PANES,
+  isRestorableEntry,
+  mergeScrollPanes,
+  readScrollPane
+} from './scroll-panes'
 import type { Tab, TabScrollPanes } from './types'
 
 const entry = (offset: number): { offset: number } => ({ offset })
@@ -62,5 +67,28 @@ describe('readScrollPane', () => {
     expect(readScrollPane(tab, 'list')).toEqual({ offset: 900, entityId: 'note-1' })
     expect(readScrollPane(tab, 'archived')).toBeUndefined()
     expect(readScrollPane(tab)).toBeUndefined()
+  })
+})
+
+describe('isRestorableEntry', () => {
+  it("accepts an entry stamped with the tab's current entity", () => {
+    expect(isRestorableEntry({ offset: 120, entityId: 'note-1' }, 'note-1')).toBe(true)
+    expect(isRestorableEntry({ offset: 120 }, undefined)).toBe(true)
+  })
+
+  it('rejects an entry whose entity the tab has navigated away from', () => {
+    expect(isRestorableEntry({ offset: 120, entityId: 'note-1' }, 'note-2')).toBe(false)
+    expect(isRestorableEntry({ offset: 120 }, 'note-2')).toBe(false)
+    expect(isRestorableEntry({ offset: 120, entityId: 'note-1' }, undefined)).toBe(false)
+  })
+
+  it('accepts `0`, which is a position and not an absence', () => {
+    expect(isRestorableEntry({ offset: 0 }, undefined)).toBe(true)
+  })
+
+  it('rejects nothing stored, and a non-finite offset written by an older build', () => {
+    expect(isRestorableEntry(undefined, undefined)).toBe(false)
+    expect(isRestorableEntry({ offset: Number.NaN }, undefined)).toBe(false)
+    expect(isRestorableEntry({ offset: Number.POSITIVE_INFINITY }, undefined)).toBe(false)
   })
 })

--- a/apps/desktop/src/renderer/src/contexts/tabs/scroll-panes.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/scroll-panes.ts
@@ -52,6 +52,22 @@ export function readScrollPane(
 }
 
 /**
+ * Whether an entry describes a position this pane may restore.
+ *
+ * The single predicate behind BOTH halves of the scroll story: the restore
+ * itself, and the auto-positioning precedence rule (see
+ * `hooks/use-tab-auto-position.ts`). They have to agree — a pane that refuses
+ * to restore a stale-entity entry but still lets that entry suppress
+ * auto-positioning leaves the user staring at the top of the page.
+ */
+export function isRestorableEntry(
+  entry: TabScrollEntry | undefined,
+  entityId: string | undefined
+): entry is TabScrollEntry {
+  return entry !== undefined && entry.entityId === entityId && Number.isFinite(entry.offset)
+}
+
+/**
  * Merge a pane patch over the tab's existing entries, bounded.
  *
  * Insertion order is the recency order eviction reads, so a written pane is

--- a/apps/desktop/src/renderer/src/hooks/use-tab-auto-position.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-auto-position.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * The precedence rule, tested as a decision rather than as a scroll position:
+ * jsdom has no layout, so "did the calendar end up at the current hour" is
+ * unobservable here. What IS observable — and what the rule is — is whether the
+ * surface is allowed to move itself at all.
+ */
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { mayAutoPositionFor, useTabAutoPosition } from './use-tab-auto-position'
+import type { Tab } from '@/contexts/tabs/types'
+import type { TabIdentity } from '@/contexts/tabs/tab-identity'
+
+const mocks = vi.hoisted(() => ({
+  getTab: vi.fn(),
+  actions: { current: null as { getTab: unknown } | null },
+  identity: { current: null as TabIdentity | null }
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabActionsOptional: () => mocks.actions.current
+}))
+
+vi.mock('@/contexts/tabs/tab-identity', () => ({
+  useTabIdentity: () => mocks.identity.current
+}))
+
+function tabWith(partial: Partial<Tab>): Tab {
+  return { id: 'tab-1', ...partial } as Tab
+}
+
+beforeEach(() => {
+  mocks.getTab.mockReset()
+  mocks.actions.current = { getTab: mocks.getTab }
+  mocks.identity.current = { tabId: 'tab-1', groupId: 'group-1' }
+})
+
+describe('useTabAutoPosition', () => {
+  it('lets a first-open tab position itself', () => {
+    mocks.getTab.mockReturnValue(tabWith({ scrollPanes: {} }))
+    const { result } = renderHook(() => useTabAutoPosition('calendar-week'))
+    expect(result.current()).toBe(true)
+  })
+
+  it('stands down once this pane has a stored position', () => {
+    mocks.getTab.mockReturnValue(tabWith({ scrollPanes: { 'calendar-week': { offset: 640 } } }))
+    const { result } = renderHook(() => useTabAutoPosition('calendar-week'))
+    expect(result.current()).toBe(false)
+  })
+
+  it('treats a stored `0` as a position, not as "nothing stored"', () => {
+    // The user scrolling back to the very top is a choice. Auto-positioning
+    // that reads `0` as absence would throw them to the current hour for it.
+    mocks.getTab.mockReturnValue(tabWith({ scrollPanes: { 'calendar-day': { offset: 0 } } }))
+    const { result } = renderHook(() => useTabAutoPosition('calendar-day'))
+    expect(result.current()).toBe(false)
+  })
+
+  it('ignores another pane in the same tab', () => {
+    // Day and week are different scrollers. Having scrolled the day grid must
+    // not stop the week grid opening at the current hour.
+    mocks.getTab.mockReturnValue(tabWith({ scrollPanes: { 'calendar-day': { offset: 640 } } }))
+    const { result } = renderHook(() => useTabAutoPosition('calendar-week'))
+    expect(result.current()).toBe(true)
+  })
+
+  it('ignores an entry stamped with an entity the tab has since left', () => {
+    // Restore refuses this entry, so the gate must too — otherwise the surface
+    // neither restores nor auto-positions and the user lands at the top.
+    mocks.identity.current = { tabId: 'tab-1', groupId: 'group-1', entityId: 'file-b' }
+    mocks.getTab.mockReturnValue(
+      tabWith({ scrollPanes: { 'pdf-page': { offset: 200, entityId: 'file-a' } } })
+    )
+    const { result } = renderHook(() => useTabAutoPosition('pdf-page'))
+    expect(result.current()).toBe(true)
+  })
+
+  it('answers live, not as of the render that created it', () => {
+    // The components that auto-position do not subscribe to tab state, so a
+    // boolean captured at render time would still say "go ahead" after the
+    // user's first scroll had been saved.
+    mocks.getTab.mockReturnValue(tabWith({ scrollPanes: {} }))
+    const { result } = renderHook(() => useTabAutoPosition('calendar-week'))
+    expect(result.current()).toBe(true)
+
+    mocks.getTab.mockReturnValue(tabWith({ scrollPanes: { 'calendar-week': { offset: 12 } } }))
+    expect(result.current()).toBe(false)
+  })
+
+  it('positions freely outside a tab', () => {
+    // The agent side pane and previews render the same components with no tab
+    // to remember anything.
+    mocks.identity.current = null
+    const { result } = renderHook(() => useTabAutoPosition('calendar-week'))
+    expect(result.current()).toBe(true)
+  })
+
+  it('positions freely when there is no tab system at all', () => {
+    mocks.actions.current = null
+    const { result } = renderHook(() => useTabAutoPosition('calendar-week'))
+    expect(result.current()).toBe(true)
+  })
+})
+
+describe('mayAutoPositionFor', () => {
+  it('reads only an explicit null as "nothing stored"', () => {
+    expect(mayAutoPositionFor(null)).toBe(true)
+    expect(mayAutoPositionFor(1)).toBe(false)
+    expect(mayAutoPositionFor(0)).toBe(false)
+    expect(mayAutoPositionFor('bottom')).toBe(false)
+    // `undefined` is not the sentinel: a surface that forgot to store its
+    // default must not silently opt back into auto-positioning.
+    expect(mayAutoPositionFor(undefined)).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-tab-auto-position.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-auto-position.ts
@@ -1,0 +1,74 @@
+/**
+ * Auto-positioning precedence
+ *
+ * Several surfaces put themselves somewhere the moment they mount, without
+ * being asked: the calendar's time grids jump to "now", the image viewer fits
+ * the image to its container, the agent transcript jumps to the newest message.
+ * Restoring a tab's position on top of surfaces that do that is a race, and a
+ * race resolves differently on a fast machine than on a slow one. So it is
+ * settled by ONE rule, written here and applied at every one of those sites:
+ *
+ *   A position stored by THIS tab wins. Auto-positioning runs only when the tab
+ *   has nothing stored for that surface — that is, on first open.
+ *
+ * Two things follow from it, and both matter:
+ *
+ * - Auto-positioning is not merely "first render". `useScrollToCurrentTime`
+ *   re-runs whenever its range starts or stops containing today, which in week
+ *   view happens as the user scrolls the weeks past today. Under this rule the
+ *   re-run is suppressed once the tab has a stored offset, so the grid stops
+ *   yanking itself back to the current hour while the user is reading.
+ * - "Nothing stored" is a real, checkable state, not an absence we guess at.
+ *   For a scroller it is "this pane has no restorable entry", read through the
+ *   very same predicate the restore uses (`isRestorableEntry`), so the two can
+ *   never disagree about whether there is a position. For a value kept in the
+ *   tab's `viewState` it is the explicit `null` default — see
+ *   `mayAutoPositionFor`.
+ *
+ * The ONE deliberate exception is the agent transcript, and it is an exception
+ * to the mechanism rather than to the rule: "stick to the bottom" is not a
+ * position, it is a policy, and it is what the transcript stores when the user
+ * is at the bottom. A stored numeric offset — the user having scrolled up —
+ * still wins there, exactly like everywhere else.
+ */
+
+import { useCallback } from 'react'
+import { useTabActionsOptional } from '@/contexts/tabs'
+import { isRestorableEntry, readScrollPane } from '@/contexts/tabs/scroll-panes'
+import { useTabIdentity } from '@/contexts/tabs/tab-identity'
+
+/**
+ * Asked at the moment the surface wants to move itself, not at render time.
+ *
+ * A getter rather than a boolean on purpose: the answer changes the first time
+ * the user scrolls, and the components that auto-position do not subscribe to
+ * tab state, so a rendered boolean would go stale exactly when it matters.
+ */
+export type TabAutoPositionGate = () => boolean
+
+export function useTabAutoPosition(key?: string): TabAutoPositionGate {
+  const identity = useTabIdentity()
+  // Optional: these surfaces also render outside a tab (the agent side pane,
+  // previews, tests), where there is no stored position to defer to.
+  const getTab = useTabActionsOptional()?.getTab
+
+  const tabId = identity?.tabId
+  const groupId = identity?.groupId
+  const entityId = identity?.entityId
+
+  return useCallback(() => {
+    if (!tabId || !groupId || !getTab) return true
+    return !isRestorableEntry(readScrollPane(getTab(tabId, groupId) ?? undefined, key), entityId)
+  }, [tabId, groupId, entityId, key, getTab])
+}
+
+/**
+ * The `viewState` half of the rule.
+ *
+ * A surface whose position is a value rather than a scroll offset (the image
+ * viewer's zoom, the transcript's stick-to-bottom policy) stores `null` for
+ * "the user has not positioned this yet" and gates its own auto-positioning on
+ * that. Spelled out here so the rule is greppable from every site that obeys
+ * it, and so "nothing stored" cannot quietly become "stored the default".
+ */
+export const mayAutoPositionFor = (stored: unknown): boolean => stored === null

--- a/apps/desktop/src/renderer/src/hooks/use-tab-entity-view-state.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-entity-view-state.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { readStampedTabValue } from './use-tab-entity-view-state'
+
+describe('readStampedTabValue', () => {
+  it('returns the stored value for the entity it was written against', () => {
+    expect(readStampedTabValue({ entityId: 'file-a', value: 5 }, 'file-a', 1)).toBe(5)
+  })
+
+  it('refuses a value stamped with another entity', () => {
+    // A preview file tab keeps its id and its viewState while the file inside
+    // it changes; page 5 of the previous PDF must not be applied to the next.
+    expect(readStampedTabValue({ entityId: 'file-a', value: 5 }, 'file-b', 1)).toBe(1)
+  })
+
+  it('matches an unstamped value only against an entity-less tab', () => {
+    // Journal, Calendar and Tags tabs carry no entityId at all.
+    expect(readStampedTabValue({ value: 5 }, undefined, 1)).toBe(5)
+    expect(readStampedTabValue({ value: 5 }, 'file-a', 1)).toBe(1)
+    expect(readStampedTabValue({ entityId: 'file-a', value: 5 }, undefined, 1)).toBe(1)
+  })
+
+  it('falls back when nothing is stored', () => {
+    expect(readStampedTabValue(undefined, 'file-a', 1)).toBe(1)
+  })
+
+  it('returns a stored falsy value rather than the fallback', () => {
+    // `0` is a real playback position and `false` a real sidebar state; the
+    // read must not be guarded on truthiness.
+    expect(readStampedTabValue({ entityId: 'f', value: 0 }, 'f', 42)).toBe(0)
+    expect(readStampedTabValue({ entityId: 'f', value: false }, 'f', true)).toBe(false)
+    expect(readStampedTabValue({ entityId: 'f', value: null }, 'f', 3)).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-tab-entity-view-state.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-entity-view-state.ts
@@ -1,0 +1,105 @@
+/**
+ * Entity-stamped tab view state.
+ *
+ * `Tab.viewState` belongs to the TAB, and a tab outlives the entity it points
+ * at: a file tab opened as a preview is reused for the next file the user
+ * clicks, keeping its id, its viewState and its mounted page. A PDF's page
+ * number, an image's zoom or an audio track's playback position stored plainly
+ * would then be applied to a completely different file — page 12 of a 3-page
+ * document, a zoom fitted to another image's aspect ratio, a seek past the end.
+ *
+ * `Tab.scrollPanes` already solved this by stamping every offset with the
+ * entity it was measured against (`TabScrollEntry.entityId`). This is the same
+ * stamp for values, so the two halves of "what this tab remembers" reject a
+ * stale entity the same way.
+ *
+ * The check is done on READ rather than by clearing on navigation: the entity
+ * can change without the page remounting, so there is no reliable moment to
+ * clear at, and a read-time comparison is correct in the same render the new
+ * entity arrives.
+ */
+
+import { useCallback, useMemo } from 'react'
+import { useTabIdentity } from '@/contexts/tabs/tab-identity'
+import { useTabViewState, type TabViewStateSetter } from './use-tab-view-state'
+
+export interface StampedTabValue<T> {
+  /** `Tab.entityId` at the moment the value was written. */
+  entityId?: string
+  value: T
+}
+
+/**
+ * The stored value if it belongs to this entity, otherwise the fallback.
+ *
+ * A tab with no entity (Journal, Calendar, Tags) stamps `undefined` and matches
+ * `undefined`, so those surfaces keep working without a special case.
+ */
+export function readStampedTabValue<T>(
+  stored: StampedTabValue<T> | undefined,
+  entityId: string | undefined,
+  fallback: T
+): T {
+  if (stored === undefined) return fallback
+  return stored.entityId === entityId ? stored.value : fallback
+}
+
+export interface UseTabEntityViewStateOptions<T> {
+  key: string
+  defaultValue: T
+  /**
+   * Validates the INNER value. Total, like `useTabViewState`'s: return
+   * `undefined` to reject a value written by an older build.
+   */
+  parse: (raw: unknown) => T | undefined
+}
+
+export function useTabEntityViewState<T>({
+  key,
+  defaultValue,
+  parse
+}: UseTabEntityViewStateOptions<T>): [T, TabViewStateSetter<T>] {
+  const entityId = useTabIdentity()?.entityId
+
+  const parseStamped = useCallback(
+    (raw: unknown): StampedTabValue<T> | undefined => {
+      if (typeof raw !== 'object' || raw === null) return undefined
+      const record = raw as { entityId?: unknown; value?: unknown }
+      if (record.entityId !== undefined && typeof record.entityId !== 'string') return undefined
+      const value = parse(record.value)
+      if (value === undefined) return undefined
+      return { entityId: record.entityId, value }
+    },
+    [parse]
+  )
+
+  const emptyStamp = useMemo<StampedTabValue<T>>(
+    () => ({ entityId, value: defaultValue }),
+    [entityId, defaultValue]
+  )
+
+  const [stored, setStored] = useTabViewState<StampedTabValue<T>>({
+    key,
+    defaultValue: emptyStamp,
+    parse: parseStamped
+  })
+
+  const value = readStampedTabValue(stored, entityId, defaultValue)
+
+  const setValue = useCallback<TabViewStateSetter<T>>(
+    (next) => {
+      setStored((previous) => ({
+        entityId,
+        value:
+          typeof next === 'function'
+            ? (next as (previousValue: T) => T)(
+                readStampedTabValue(previous, entityId, defaultValue)
+              )
+            : next
+      }))
+    },
+    [entityId, defaultValue, setStored]
+  )
+
+  return [value, setValue]
+}

--- a/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.ts
@@ -22,7 +22,7 @@
 
 import { useEffect, useLayoutEffect, useRef } from 'react'
 import { useTabActionsOptional } from '@/contexts/tabs'
-import { readScrollPane, scrollPaneKey } from '@/contexts/tabs/scroll-panes'
+import { isRestorableEntry, readScrollPane, scrollPaneKey } from '@/contexts/tabs/scroll-panes'
 import { useTabIdentity } from '@/contexts/tabs/tab-identity'
 
 /** How often the live offset is committed to tab state while scrolling. */
@@ -276,11 +276,12 @@ export function useTabScrollRestore({
     // let alone applied. A tab keeps its identity when it navigates to another
     // note, so an entry stamped with a different entity describes content that
     // is gone.
+    // The same predicate the auto-positioning gate reads, so "this pane has a
+    // position to restore" and "auto-positioning must stand down" can never
+    // disagree.
     const saved = readScrollPane(getTab(tabId, groupId) ?? undefined, key)
-    const restorable =
-      saved !== undefined && saved.entityId === entityId && Number.isFinite(saved.offset)
 
-    if (restorable) {
+    if (isRestorableEntry(saved, entityId)) {
       const target = saved.offset
       offsetRef.current = target
       // Tab state already holds exactly this record, so a save that reproduces

--- a/apps/desktop/src/renderer/src/pages/calendar-callbacks.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-callbacks.test.tsx
@@ -367,7 +367,9 @@ vi.mock('@/contexts/day-panel-context', () => ({
 
 vi.mock('@/contexts/tabs', () => ({
   useActiveTab: () => null,
-  useTabActions: () => ({ openTab: mocks.openTab })
+  useTabActions: () => ({ openTab: mocks.openTab }),
+  // Rendered outside a tab: view, anchor and filters fall back to plain state.
+  useTabActionsOptional: () => null
 }))
 
 vi.mock('@/services/calendar-service', () => ({

--- a/apps/desktop/src/renderer/src/pages/calendar-event-project.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-event-project.test.tsx
@@ -28,7 +28,9 @@ vi.mock('@/hooks/use-calendar-range', async (importOriginal) => ({
 
 vi.mock('@/contexts/tabs', () => ({
   useActiveTab: () => null,
-  useTabActions: () => ({ openTab: mockOpenTab })
+  useTabActions: () => ({ openTab: mockOpenTab }),
+  // Rendered outside a tab: view, anchor and filters fall back to plain state.
+  useTabActionsOptional: () => null
 }))
 
 vi.mock('@/services/calendar-service', () => ({

--- a/apps/desktop/src/renderer/src/pages/calendar-quick-create.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-quick-create.test.tsx
@@ -31,7 +31,9 @@ vi.mock('@/hooks/use-calendar-range', async (importOriginal) => ({
 
 vi.mock('@/contexts/tabs', () => ({
   useActiveTab: () => null,
-  useTabActions: () => ({ openTab: mockOpenTab })
+  useTabActions: () => ({ openTab: mockOpenTab }),
+  // Rendered outside a tab: view, anchor and filters fall back to plain state.
+  useTabActionsOptional: () => null
 }))
 
 vi.mock('@/services/calendar-service', () => ({

--- a/apps/desktop/src/renderer/src/pages/calendar-view-state.test.ts
+++ b/apps/desktop/src/renderer/src/pages/calendar-view-state.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CALENDAR_SCROLL_KEYS,
+  CALENDAR_VIEW_STATE_KEYS,
+  parseAnchorDate,
+  parseCalendarBoolean,
+  parseCalendarView,
+  parseImportedSourceIds,
+  parseVisualTypes,
+  resolveAnchorSync,
+  resolveSelectedSourceIds
+} from './calendar-view-state'
+
+describe('calendar view-state keys', () => {
+  it('uses a distinct key per persisted value', () => {
+    const keys = Object.values(CALENDAR_VIEW_STATE_KEYS)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('never collides with the navigation nonces other surfaces write', () => {
+    // Agent Chat and the sidebar write `focusCalendarEventId`, `focusDate`,
+    // `focusedAt` and `createEventAt` into a calendar tab's viewState. Reusing
+    // one of those names would make a filter toggle re-fire a navigation.
+    const nonces = ['focusCalendarEventId', 'focusDate', 'focusedAt', 'createEventAt']
+    for (const key of Object.values(CALENDAR_VIEW_STATE_KEYS)) {
+      expect(nonces).not.toContain(key)
+    }
+  })
+
+  it('gives every scrolling view its own pane', () => {
+    const keys = Object.values(CALENDAR_SCROLL_KEYS)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+})
+
+describe('parseCalendarView', () => {
+  it('accepts the four views and nothing else', () => {
+    expect(parseCalendarView('week')).toBe('week')
+    expect(parseCalendarView('year')).toBe('year')
+    expect(parseCalendarView('agenda')).toBeUndefined()
+    expect(parseCalendarView(null)).toBeUndefined()
+    expect(parseCalendarView(2)).toBeUndefined()
+  })
+})
+
+describe('parseAnchorDate', () => {
+  it('accepts only a plain calendar date', () => {
+    // The week virtualizer turns this into a day index and the range query into
+    // a local-midnight ISO string; anything else silently lands centuries away.
+    expect(parseAnchorDate('2026-08-17')).toBe('2026-08-17')
+    expect(parseAnchorDate('2026-08-17T09:00:00.000Z')).toBeUndefined()
+    expect(parseAnchorDate('17/08/2026')).toBeUndefined()
+    expect(parseAnchorDate('2026-8-7')).toBeUndefined()
+    expect(parseAnchorDate(20260817)).toBeUndefined()
+  })
+
+  it('keeps `null`, which means "this tab has no anchor yet"', () => {
+    expect(parseAnchorDate(null)).toBeNull()
+    expect(parseAnchorDate(undefined)).toBeUndefined()
+  })
+})
+
+describe('parseCalendarBoolean / parseVisualTypes', () => {
+  it('takes only real booleans', () => {
+    expect(parseCalendarBoolean(false)).toBe(false)
+    expect(parseCalendarBoolean('false')).toBeUndefined()
+    expect(parseCalendarBoolean(0)).toBeUndefined()
+  })
+
+  it('drops unknown visual types instead of rejecting the whole filter', () => {
+    expect(parseVisualTypes(['event', 'wormhole', 'task'])).toEqual(['event', 'task'])
+    // An empty array is a real filter — the user turned everything off.
+    expect(parseVisualTypes([])).toEqual([])
+    expect(parseVisualTypes('event')).toBeUndefined()
+  })
+})
+
+describe('parseImportedSourceIds', () => {
+  it('tells "has not chosen" apart from "chose nothing"', () => {
+    expect(parseImportedSourceIds(null)).toBeNull()
+    expect(parseImportedSourceIds([])).toEqual([])
+    expect(parseImportedSourceIds(undefined)).toBeUndefined()
+    expect(parseImportedSourceIds('src-1')).toBeUndefined()
+  })
+
+  it('keeps ids it does not recognise', () => {
+    // A source can be absent because its account has not loaded yet; dropping
+    // it here would quietly deselect a calendar the user had switched on.
+    expect(parseImportedSourceIds(['src-1', 7, 'src-2'])).toEqual(['src-1', 'src-2'])
+  })
+})
+
+describe('resolveSelectedSourceIds', () => {
+  it('shows every source until the user picks a subset', () => {
+    expect(resolveSelectedSourceIds(null, ['a', 'b'])).toEqual(['a', 'b'])
+  })
+
+  it('honours "chose nothing" rather than falling back to everything', () => {
+    expect(resolveSelectedSourceIds([], ['a', 'b'])).toEqual([])
+  })
+
+  it('drops a source that has since disappeared', () => {
+    expect(resolveSelectedSourceIds(['a', 'gone'], ['a', 'b'])).toEqual(['a'])
+  })
+
+  it('does not add a source connected after the user chose', () => {
+    // Deriving "all" only applies to a tab that never chose. Once there is a
+    // choice, a newly connected calendar stays off until it is switched on.
+    expect(resolveSelectedSourceIds(['a'], ['a', 'b'])).toEqual(['a'])
+  })
+})
+
+describe('resolveAnchorSync', () => {
+  it('writes the live anchor when the tab has none', () => {
+    expect(
+      resolveAnchorSync({ awaitingSeed: null, anchorDate: '2026-08-17', storedAnchor: null })
+    ).toEqual({ clearAwaiting: false, write: '2026-08-17' })
+  })
+
+  it('writes nothing when the tab already agrees', () => {
+    expect(
+      resolveAnchorSync({
+        awaitingSeed: null,
+        anchorDate: '2026-08-17',
+        storedAnchor: '2026-08-17'
+      })
+    ).toEqual({ clearAwaiting: false, write: null })
+  })
+
+  it('holds the write while a restore is still in flight', () => {
+    // Both effects run in the same commit: the seed has been pushed into the
+    // shared context but this pass still sees the context holding today.
+    // Writing here would overwrite the restored anchor with today, every launch.
+    expect(
+      resolveAnchorSync({
+        awaitingSeed: '2026-01-05',
+        anchorDate: '2026-08-17',
+        storedAnchor: '2026-01-05'
+      })
+    ).toEqual({ clearAwaiting: false, write: null })
+  })
+
+  it('stops waiting once the context carries the seeded anchor', () => {
+    expect(
+      resolveAnchorSync({
+        awaitingSeed: '2026-01-05',
+        anchorDate: '2026-01-05',
+        storedAnchor: '2026-01-05'
+      })
+    ).toEqual({ clearAwaiting: true, write: null })
+  })
+
+  it('resumes mirroring in the same pass the seed lands, if they differ', () => {
+    // The day panel can move the anchor while the seed is still in flight; the
+    // handshake must end, not strand the mirror.
+    expect(
+      resolveAnchorSync({
+        awaitingSeed: '2026-01-05',
+        anchorDate: '2026-01-05',
+        storedAnchor: '2025-12-31'
+      })
+    ).toEqual({ clearAwaiting: true, write: '2026-01-05' })
+  })
+
+  it('mirrors a change the day panel made, which is not in a tab at all', () => {
+    expect(
+      resolveAnchorSync({
+        awaitingSeed: null,
+        anchorDate: '2026-03-02',
+        storedAnchor: '2026-01-05'
+      })
+    ).toEqual({ clearAwaiting: false, write: '2026-03-02' })
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/calendar-view-state.ts
+++ b/apps/desktop/src/renderer/src/pages/calendar-view-state.ts
@@ -1,0 +1,178 @@
+/**
+ * What a Calendar tab remembers, and how it is read back.
+ *
+ * Everything here used to be either global (the view, in one localStorage key
+ * shared by every calendar anywhere) or thrown away on unmount (the filters),
+ * or shared through an app-level context that resets to today on restart (the
+ * anchor date).
+ *
+ * Two things are deliberately NOT owned here:
+ *
+ * - The anchor date is still LIVE in `CalendarViewContext`, because the day
+ *   panel — which is not in a tab at all — sets it. The tab is the durable
+ *   record of that shared value, not a second copy of it. See
+ *   `resolveAnchorSync` for the handshake that keeps the two from overwriting
+ *   each other.
+ * - The selected imported calendars are stored as the user's EXPLICIT choice
+ *   or as `null` for "has not chosen". "All of them" is derived from the
+ *   sources query at read time (`resolveSelectedSourceIds`) rather than
+ *   materialised into tab state, so the page never has to race its own seeding
+ *   effect, and a source that appears later is not silently pre-selected into
+ *   a choice the user did make.
+ */
+
+import type { CalendarWorkspaceView } from '@/components/calendar'
+import { VISUAL_TYPE_ORDER } from '@/components/calendar/visual-type-meta'
+import type { CalendarProjectionVisualType } from '@/services/calendar-service'
+
+/** Pre-existing GLOBAL key. Still read, and still written, so a rollback works. */
+export const CALENDAR_VIEW_STORAGE_KEY = 'calendar-view'
+
+export const CALENDAR_VIEW_STATE_KEYS = {
+  /** Day / week / month / year. */
+  view: 'calendarView',
+  /** The date the view is centred on, as `YYYY-MM-DD`. */
+  anchorDate: 'calendarAnchorDate',
+  /** Whether items memrynote owns are shown. */
+  showMemryItems: 'calendarShowMemryItems',
+  /** Whether imported calendars are shown at all. */
+  showImportedCalendars: 'calendarShowImportedCalendars',
+  /** The user's explicit source selection. `null` means "has not chosen". */
+  importedSourceIds: 'calendarImportedSourceIds',
+  /** Which kinds of item are shown. */
+  visualTypes: 'calendarVisualTypes'
+} as const
+
+/**
+ * One key per scroller. Day, week and year are separate components with
+ * different content heights, so an offset from one is meaningless in another.
+ * Month has no scroller — the grid fits its pane.
+ */
+export const CALENDAR_SCROLL_KEYS = {
+  day: 'calendar-day',
+  week: 'calendar-week',
+  year: 'calendar-year'
+} as const
+
+export const CALENDAR_VIEWS: CalendarWorkspaceView[] = ['day', 'week', 'month', 'year']
+
+export const parseCalendarView = (raw: unknown): CalendarWorkspaceView | undefined =>
+  typeof raw === 'string' && (CALENDAR_VIEWS as string[]).includes(raw)
+    ? (raw as CalendarWorkspaceView)
+    : undefined
+
+/**
+ * The view a NEW calendar tab opens on: whatever view was last used anywhere.
+ *
+ * The global key predates per-tab state, so an upgrading user must find their
+ * calendar exactly where they left it. It stays the fallback rather than the
+ * store: once a tab has its own view, that is what it opens on.
+ */
+export function readGlobalCalendarView(): CalendarWorkspaceView {
+  try {
+    return parseCalendarView(localStorage.getItem(CALENDAR_VIEW_STORAGE_KEY)) ?? 'month'
+  } catch {
+    /* localStorage unavailable */
+    return 'month'
+  }
+}
+
+export function writeGlobalCalendarView(view: CalendarWorkspaceView): void {
+  try {
+    localStorage.setItem(CALENDAR_VIEW_STORAGE_KEY, view)
+  } catch {
+    /* localStorage unavailable */
+  }
+}
+
+/**
+ * `YYYY-MM-DD` only. Everything downstream (`parseLocalDate`, the range query,
+ * the week virtualizer's day index) assumes that shape, and a restored session
+ * can carry anything.
+ */
+export const parseAnchorDate = (raw: unknown): string | null | undefined => {
+  if (raw === null) return null
+  if (typeof raw !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(raw)) return undefined
+  return raw
+}
+
+export const parseCalendarBoolean = (raw: unknown): boolean | undefined =>
+  typeof raw === 'boolean' ? raw : undefined
+
+/**
+ * `null` is a value here — "the user has not chosen any subset" — and must be
+ * told apart from "nothing stored", which also lands on `null` by default.
+ * Unknown entries are kept: a source can be missing because its account is
+ * still loading, and dropping it would quietly deselect it.
+ */
+export const parseImportedSourceIds = (raw: unknown): string[] | null | undefined => {
+  if (raw === null) return null
+  if (!Array.isArray(raw)) return undefined
+  return raw.filter((value): value is string => typeof value === 'string')
+}
+
+/** Unknown visual types are dropped rather than rejecting the whole filter. */
+export const parseVisualTypes = (raw: unknown): CalendarProjectionVisualType[] | undefined =>
+  Array.isArray(raw)
+    ? raw.filter(
+        (value): value is CalendarProjectionVisualType =>
+          typeof value === 'string' && (VISUAL_TYPE_ORDER as string[]).includes(value)
+      )
+    : undefined
+
+/**
+ * The sources actually shown: every available source until the user picks a
+ * subset, then their pick, minus anything that has since disappeared.
+ *
+ * Derived rather than stored so there is no first-load seeding effect to fight,
+ * and so a newly connected calendar cannot be quietly added to a selection the
+ * user made by hand.
+ */
+export function resolveSelectedSourceIds(
+  stored: string[] | null,
+  availableIds: string[]
+): string[] {
+  if (stored === null) return availableIds
+  return stored.filter((id) => availableIds.includes(id))
+}
+
+export interface AnchorSyncInput {
+  /**
+   * The value pushed into the shared context and not yet seen coming back, or
+   * `null` when nothing is in flight.
+   */
+  awaitingSeed: string | null
+  /** The shared context's current anchor. */
+  anchorDate: string
+  /** What the tab currently has stored, or `null` when it has nothing. */
+  storedAnchor: string | null
+}
+
+export interface AnchorSyncDecision {
+  /** The seed has landed; stop waiting for it. */
+  clearAwaiting: boolean
+  /** Value to write into tab state, or `null` to write nothing this pass. */
+  write: string | null
+}
+
+/**
+ * The one-way handshake between the shared anchor and the tab's copy of it.
+ *
+ * Restoring is a two-step: the tab's stored anchor is pushed into the context,
+ * and only the NEXT render sees the context carrying it. In between, the
+ * mirror still sees the context's "today" — and writing that would overwrite
+ * the very anchor being restored with today's date, every single launch. So
+ * while a seed is in flight nothing is written until the context agrees with
+ * it.
+ */
+export function resolveAnchorSync({
+  awaitingSeed,
+  anchorDate,
+  storedAnchor
+}: AnchorSyncInput): AnchorSyncDecision {
+  if (awaitingSeed !== null) {
+    if (anchorDate !== awaitingSeed) return { clearAwaiting: false, write: null }
+    return { clearAwaiting: true, write: anchorDate === storedAnchor ? null : anchorDate }
+  }
+  return { clearAwaiting: false, write: anchorDate === storedAnchor ? null : anchorDate }
+}

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import {
@@ -41,6 +41,20 @@ import { tasksService } from '@/services/tasks-service'
 import { useDayPanel } from '@/contexts/day-panel-context'
 import { useCalendarView } from '@/contexts/calendar-view-context'
 import { useActiveTab, useTabActions } from '@/contexts/tabs'
+import { useTabIdentity } from '@/contexts/tabs/tab-identity'
+import { useTabViewState } from '@/hooks/use-tab-view-state'
+import {
+  CALENDAR_VIEW_STATE_KEYS,
+  parseAnchorDate,
+  parseCalendarBoolean,
+  parseCalendarView,
+  parseImportedSourceIds,
+  parseVisualTypes,
+  readGlobalCalendarView,
+  resolveAnchorSync,
+  resolveSelectedSourceIds,
+  writeGlobalCalendarView
+} from './calendar-view-state'
 import { DeleteCalendarEventDialog } from '@/components/calendar/delete-calendar-event-dialog'
 import { GoogleCalendarConnectPrompt } from '@/components/calendar/google-calendar-connect-prompt'
 import { AddEventToProjectDialog } from '@/components/tasks/projects/add-event-to-project-dialog'
@@ -51,21 +65,6 @@ const log = createLogger('CalendarPage')
 
 interface CalendarPageProps {
   className?: string
-}
-
-const CALENDAR_VIEW_KEY = 'calendar-view'
-const VALID_VIEWS: CalendarWorkspaceView[] = ['day', 'week', 'month', 'year']
-
-function getPersistedView(): CalendarWorkspaceView {
-  try {
-    const stored = localStorage.getItem(CALENDAR_VIEW_KEY)
-    if (stored && VALID_VIEWS.includes(stored as CalendarWorkspaceView)) {
-      return stored as CalendarWorkspaceView
-    }
-  } catch {
-    /* localStorage unavailable */
-  }
-  return 'month'
 }
 
 function getTodayDate(): string {
@@ -185,24 +184,56 @@ function dueDateTimeFromDate(date: Date): { dueDate: string; dueTime: string } {
 
 export function CalendarPage({ className: _className }: CalendarPageProps): React.JSX.Element {
   const queryClient = useQueryClient()
-  const [view, setViewRaw] = useState<CalendarWorkspaceView>(getPersistedView)
-  const setView = useCallback((next: CalendarWorkspaceView) => {
-    setViewRaw(next)
-    try {
-      localStorage.setItem(CALENDAR_VIEW_KEY, next)
-    } catch {
-      /* localStorage unavailable */
-    }
-  }, [])
+  // A NEW calendar tab opens on the view last used anywhere (the pre-existing
+  // global key), then keeps its own from that point on.
+  const [globalViewFallback] = useState(readGlobalCalendarView)
+  const [view, setViewState] = useTabViewState<CalendarWorkspaceView>({
+    key: CALENDAR_VIEW_STATE_KEYS.view,
+    defaultValue: globalViewFallback,
+    parse: parseCalendarView
+  })
+  const setView = useCallback(
+    (next: CalendarWorkspaceView) => {
+      setViewState(next)
+      // Still written: it is what an older build reads, and what the next new
+      // tab opens on.
+      writeGlobalCalendarView(next)
+    },
+    [setViewState]
+  )
   const { anchorDate, setAnchorDate } = useCalendarView()
+  const [storedAnchor, setStoredAnchor] = useTabViewState<string | null>({
+    key: CALENDAR_VIEW_STATE_KEYS.anchorDate,
+    defaultValue: null,
+    parse: parseAnchorDate
+  })
   const weekStartsOn = useWeekStartsOn()
   const [todayRequestKey, setTodayRequestKey] = useState(0)
-  const [showMemryItems, setShowMemryItems] = useState(true)
-  const [showImportedCalendars, setShowImportedCalendars] = useState(true)
-  const [selectedImportedSourceIds, setSelectedImportedSourceIds] = useState<string[]>([])
-  const [selectedVisualTypes, setSelectedVisualTypes] =
-    useState<CalendarProjectionVisualType[]>(VISUAL_TYPE_ORDER)
-  const importedSourcesInitializedRef = useRef(false)
+  const [showMemryItems, setShowMemryItems] = useTabViewState<boolean>({
+    key: CALENDAR_VIEW_STATE_KEYS.showMemryItems,
+    defaultValue: true,
+    parse: parseCalendarBoolean
+  })
+  const [showImportedCalendars, setShowImportedCalendars] = useTabViewState<boolean>({
+    key: CALENDAR_VIEW_STATE_KEYS.showImportedCalendars,
+    defaultValue: true,
+    parse: parseCalendarBoolean
+  })
+  // `null` is "the user has not picked a subset". The effective selection is
+  // derived from the sources query below, so there is no seeding effect to
+  // fight and no pre-selection of a source connected after they chose.
+  const [chosenImportedSourceIds, setChosenImportedSourceIds] = useTabViewState<string[] | null>({
+    key: CALENDAR_VIEW_STATE_KEYS.importedSourceIds,
+    defaultValue: null,
+    parse: parseImportedSourceIds
+  })
+  const [selectedVisualTypes, setSelectedVisualTypes] = useTabViewState<
+    CalendarProjectionVisualType[]
+  >({
+    key: CALENDAR_VIEW_STATE_KEYS.visualTypes,
+    defaultValue: VISUAL_TYPE_ORDER,
+    parse: parseVisualTypes
+  })
   const [popoverState, setPopoverState] = useState<{
     mode: 'create' | 'edit'
     eventId: string | null
@@ -271,6 +302,46 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
     return () => {}
   }, [view, anchorDate, setDayPanelDate])
 
+  // ---------------------------------------------------------------------------
+  // Anchor date: LIVE in the shared context, DURABLE in the tab.
+  //
+  // The context stays the single live value because the day panel — which is
+  // not in a tab — writes it, and Day view reads it back. The tab is where that
+  // value survives a restart, so this page seeds the context from the tab once
+  // and mirrors every later change back. `resolveAnchorSync` owns the ordering:
+  // both effects run in the same commit, so without it the mirror would see the
+  // context still holding today and write today over the anchor being restored.
+  // ---------------------------------------------------------------------------
+  const identity = useTabIdentity()
+  const identityKey = identity ? `${identity.groupId}:${identity.tabId}` : ''
+  const seededForRef = useRef<string | null>(null)
+  const awaitingSeedRef = useRef<string | null>(null)
+  const storedAnchorRef = useRef(storedAnchor)
+  const anchorDateRef = useRef(anchorDate)
+  useLayoutEffect(() => {
+    storedAnchorRef.current = storedAnchor
+    anchorDateRef.current = anchorDate
+  })
+
+  useEffect(() => {
+    if (seededForRef.current === identityKey) return
+    seededForRef.current = identityKey
+    const stored = storedAnchorRef.current
+    if (stored === null || stored === anchorDateRef.current) return
+    awaitingSeedRef.current = stored
+    setAnchorDate(stored)
+  }, [identityKey, setAnchorDate])
+
+  useEffect(() => {
+    const decision = resolveAnchorSync({
+      awaitingSeed: awaitingSeedRef.current,
+      anchorDate,
+      storedAnchor
+    })
+    if (decision.clearAwaiting) awaitingSeedRef.current = null
+    if (decision.write !== null) setStoredAnchor(decision.write)
+  }, [anchorDate, storedAnchor, setStoredAnchor])
+
   const rangeInput = useMemo(
     () => ({
       ...getRangeForView(view, anchorDate, weekStartsOn),
@@ -294,19 +365,28 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
     [sourcesData?.sources]
   )
 
-  useEffect(() => {
-    if (importedSourcesInitializedRef.current) {
-      setSelectedImportedSourceIds((current) =>
-        current.filter((sourceId) => importedSources.some((source) => source.id === sourceId))
+  const selectedImportedSourceIds = useMemo(
+    () =>
+      resolveSelectedSourceIds(
+        chosenImportedSourceIds,
+        importedSources.map((source) => source.id)
+      ),
+    [chosenImportedSourceIds, importedSources]
+  )
+
+  // Toggling records an EXPLICIT selection: the first toggle turns the derived
+  // "all sources" into a real list minus the one just switched off.
+  const handleToggleImportedSource = useCallback(
+    (sourceId: string) => {
+      const current = selectedImportedSourceIds
+      setChosenImportedSourceIds(
+        current.includes(sourceId)
+          ? current.filter((id) => id !== sourceId)
+          : [...current, sourceId]
       )
-      return
-    }
-
-    if (importedSources.length === 0) return
-
-    importedSourcesInitializedRef.current = true
-    setSelectedImportedSourceIds(importedSources.map((source) => source.id))
-  }, [importedSources])
+    },
+    [selectedImportedSourceIds, setChosenImportedSourceIds]
+  )
 
   const filteredItems = useMemo(
     () =>
@@ -336,7 +416,14 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
     setView('day')
     setAnchorDate(calendarFocusDate)
     setShowMemryItems(true)
-  }, [calendarFocusDate, calendarFocusEventId, calendarFocusToken, setAnchorDate, setView])
+  }, [
+    calendarFocusDate,
+    calendarFocusEventId,
+    calendarFocusToken,
+    setAnchorDate,
+    setShowMemryItems,
+    setView
+  ])
 
   useEffect(() => {
     if (!calendarFocusEventId || calendarFocusToken === null) return
@@ -849,13 +936,7 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
         }
         onToggleMemryItems={() => setShowMemryItems((current) => !current)}
         onToggleImportedCalendars={() => setShowImportedCalendars((current) => !current)}
-        onToggleImportedSource={(sourceId) =>
-          setSelectedImportedSourceIds((current) =>
-            current.includes(sourceId)
-              ? current.filter((id) => id !== sourceId)
-              : [...current, sourceId]
-          )
-        }
+        onToggleImportedSource={(sourceId) => handleToggleImportedSource(sourceId)}
         onToggleVisualType={(visualType) =>
           setSelectedVisualTypes((current) =>
             current.includes(visualType)

--- a/apps/desktop/src/renderer/src/pages/file-view-state.test.ts
+++ b/apps/desktop/src/renderer/src/pages/file-view-state.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  FILE_AUDIO_SCROLL_KEY,
+  FILE_VIEW_STATE_KEYS,
+  parseNullableScale,
+  parsePdfPage,
+  parsePlaybackPosition,
+  parseRotation,
+  parseScale,
+  parseViewerBoolean,
+  parseViewerPosition,
+  pdfPageScrollKey,
+  shouldResumePlayback
+} from './file-view-state'
+
+describe('file view-state keys', () => {
+  it('uses a distinct key per persisted value', () => {
+    const keys = Object.values(FILE_VIEW_STATE_KEYS)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('keeps each viewer apart, so a PDF zoom is not an image zoom', () => {
+    expect(FILE_VIEW_STATE_KEYS.pdfScale).not.toBe(FILE_VIEW_STATE_KEYS.imageScale)
+    expect(FILE_VIEW_STATE_KEYS.pdfRotation).not.toBe(FILE_VIEW_STATE_KEYS.imageRotation)
+    expect(FILE_VIEW_STATE_KEYS.audioPosition).not.toBe(FILE_VIEW_STATE_KEYS.videoPosition)
+  })
+
+  it('stores nothing about whether the media is playing', () => {
+    // Restoring a session must not start making noise.
+    for (const key of Object.values(FILE_VIEW_STATE_KEYS)) {
+      expect(key.toLowerCase()).not.toContain('playing')
+    }
+  })
+})
+
+describe('pdfPageScrollKey', () => {
+  it('gives every page its own scroller identity', () => {
+    // The main pane renders ONE page, so an offset only means anything on the
+    // page it was measured on. The entity stamp guards the file, not the page.
+    expect(pdfPageScrollKey(1)).not.toBe(pdfPageScrollKey(2))
+  })
+
+  it('never collides with the audio pane', () => {
+    expect(pdfPageScrollKey(1)).not.toBe(FILE_AUDIO_SCROLL_KEY)
+  })
+})
+
+describe('viewer readers', () => {
+  it('accepts only real 1-based page numbers', () => {
+    expect(parsePdfPage(1)).toBe(1)
+    expect(parsePdfPage(120)).toBe(120)
+    expect(parsePdfPage(0)).toBeUndefined()
+    expect(parsePdfPage(-3)).toBeUndefined()
+    expect(parsePdfPage(1.5)).toBeUndefined()
+    expect(parsePdfPage('2')).toBeUndefined()
+  })
+
+  it('rejects a zoom that would render nothing', () => {
+    expect(parseScale(1.25)).toBe(1.25)
+    expect(parseScale(0)).toBeUndefined()
+    expect(parseScale(-1)).toBeUndefined()
+    expect(parseScale(Number.NaN)).toBeUndefined()
+    expect(parseScale(Number.POSITIVE_INFINITY)).toBeUndefined()
+  })
+
+  it('keeps `null` zoom, which is "never zoomed" and not "zoomed to nothing"', () => {
+    // This is the value fit-to-container is gated on.
+    expect(parseNullableScale(null)).toBeNull()
+    expect(parseNullableScale(2)).toBe(2)
+    expect(parseNullableScale(0)).toBeUndefined()
+    expect(parseNullableScale(undefined)).toBeUndefined()
+  })
+
+  it('accepts only the four quarter turns the button can produce', () => {
+    expect(parseRotation(0)).toBe(0)
+    expect(parseRotation(270)).toBe(270)
+    expect(parseRotation(45)).toBeUndefined()
+    expect(parseRotation(360)).toBeUndefined()
+    expect(parseRotation('90')).toBeUndefined()
+  })
+
+  it('takes only real booleans for the thumbnail rail', () => {
+    expect(parseViewerBoolean(false)).toBe(false)
+    expect(parseViewerBoolean('true')).toBeUndefined()
+  })
+
+  it('requires both pan coordinates to be real numbers', () => {
+    expect(parseViewerPosition({ x: 10, y: -4 })).toEqual({ x: 10, y: -4 })
+    expect(parseViewerPosition({ x: 10 })).toBeUndefined()
+    expect(parseViewerPosition({ x: 10, y: Number.NaN })).toBeUndefined()
+    expect(parseViewerPosition([10, 4])).toBeUndefined()
+    expect(parseViewerPosition(null)).toBeUndefined()
+  })
+
+  it('accepts a playback position of 0, which is the start of the track', () => {
+    expect(parsePlaybackPosition(0)).toBe(0)
+    expect(parsePlaybackPosition(93.5)).toBe(93.5)
+    expect(parsePlaybackPosition(-1)).toBeUndefined()
+    expect(parsePlaybackPosition(Number.NaN)).toBeUndefined()
+  })
+})
+
+describe('shouldResumePlayback', () => {
+  it('seeks to a position with something left to play', () => {
+    expect(shouldResumePlayback(90, 300)).toBe(true)
+  })
+
+  it('does not seek to the very end a finished track leaves behind', () => {
+    // Otherwise reopening the file parks it on the last frame with nothing left.
+    expect(shouldResumePlayback(300, 300)).toBe(false)
+    expect(shouldResumePlayback(299.5, 300)).toBe(false)
+    expect(shouldResumePlayback(400, 300)).toBe(false)
+  })
+
+  it('does not seek when the start is where we already are', () => {
+    expect(shouldResumePlayback(0, 300)).toBe(false)
+  })
+
+  it('does not seek when the duration is unknown or unseekable', () => {
+    // A live stream reports Infinity, and metadata that has not loaded reports 0.
+    expect(shouldResumePlayback(90, 0)).toBe(false)
+    expect(shouldResumePlayback(90, Number.NaN)).toBe(false)
+    expect(shouldResumePlayback(90, Number.POSITIVE_INFINITY)).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/file-view-state.ts
+++ b/apps/desktop/src/renderer/src/pages/file-view-state.ts
@@ -1,0 +1,87 @@
+/**
+ * What a file tab remembers, and how it is read back.
+ *
+ * Every value here is ENTITY-STAMPED (`useTabEntityViewState`): a preview file
+ * tab keeps its id, its viewState and its mounted viewer while the file inside
+ * it changes, so page 12 of a three-page PDF, or a zoom fitted to another
+ * image, would otherwise be applied to the next file the user clicks.
+ *
+ * Deliberately not stored: whether the media is PLAYING. Restoring a tab must
+ * not start making noise, so the position comes back and the transport stays
+ * paused.
+ */
+
+export const FILE_VIEW_STATE_KEYS = {
+  /** PDF: the page the main pane is showing. This IS the reading position. */
+  pdfPage: 'filePdfPage',
+  pdfScale: 'filePdfScale',
+  pdfRotation: 'filePdfRotation',
+  pdfSidebarOpen: 'filePdfSidebarOpen',
+  /** Image zoom. `null` means "never zoomed" — fit to the container instead. */
+  imageScale: 'fileImageScale',
+  imageRotation: 'fileImageRotation',
+  imagePosition: 'fileImagePosition',
+  /** Playback position in seconds. Never auto-resumed. */
+  audioPosition: 'fileAudioPosition',
+  videoPosition: 'fileVideoPosition'
+} as const
+
+/**
+ * The PDF main pane renders ONE page at a time, so an offset inside it only
+ * means anything on the page it was measured on. The entity stamp guards the
+ * file; the page has to be in the key.
+ */
+export const pdfPageScrollKey = (page: number): string => `file-pdf-page:${page}`
+
+/** The audio player's transcript pane. */
+export const FILE_AUDIO_SCROLL_KEY = 'file-audio'
+
+/** Pages are 1-based and there is no such thing as page 0. */
+export const parsePdfPage = (raw: unknown): number | undefined =>
+  typeof raw === 'number' && Number.isInteger(raw) && raw >= 1 ? raw : undefined
+
+/** A zoom factor. `0` and negatives would render nothing at all. */
+export const parseScale = (raw: unknown): number | undefined =>
+  typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? raw : undefined
+
+/** Zoom, or `null` for "the user has never zoomed this". */
+export const parseNullableScale = (raw: unknown): number | null | undefined =>
+  raw === null ? null : parseScale(raw)
+
+/** Only the four quarter turns the rotate button can produce. */
+export const parseRotation = (raw: unknown): number | undefined =>
+  raw === 0 || raw === 90 || raw === 180 || raw === 270 ? raw : undefined
+
+export const parseViewerBoolean = (raw: unknown): boolean | undefined =>
+  typeof raw === 'boolean' ? raw : undefined
+
+export interface ViewerPosition {
+  x: number
+  y: number
+}
+
+export const parseViewerPosition = (raw: unknown): ViewerPosition | undefined => {
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const record = raw as { x?: unknown; y?: unknown }
+  if (typeof record.x !== 'number' || !Number.isFinite(record.x)) return undefined
+  if (typeof record.y !== 'number' || !Number.isFinite(record.y)) return undefined
+  return { x: record.x, y: record.y }
+}
+
+/** Seconds into the track. `0` is the start, which is a position like any other. */
+export const parsePlaybackPosition = (raw: unknown): number | undefined =>
+  typeof raw === 'number' && Number.isFinite(raw) && raw >= 0 ? raw : undefined
+
+/**
+ * Whether a stored playback position is worth seeking to.
+ *
+ * A position at or past the end is what "played to the end" leaves behind, and
+ * seeking there reopens the file on its last frame with nothing left to play.
+ * A duration that is not known yet (0, NaN for a stream) means the media cannot
+ * be seeked reliably at all.
+ */
+export function shouldResumePlayback(position: number, duration: number): boolean {
+  if (!Number.isFinite(duration) || duration <= 0) return false
+  if (position <= 0) return false
+  return position < duration - 1
+}

--- a/apps/desktop/src/renderer/src/pages/journal-view-state.test.ts
+++ b/apps/desktop/src/renderer/src/pages/journal-view-state.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_JOURNAL_DRILL,
+  journalScrollKey,
+  parseJournalDrill,
+  resolveJournalDate,
+  toJournalViewState
+} from './journal-view-state'
+
+describe('parseJournalDrill', () => {
+  it('accepts the three levels the breadcrumb can reach', () => {
+    expect(parseJournalDrill({ type: 'day' })).toEqual({ type: 'day' })
+    expect(parseJournalDrill({ type: 'month', year: 2026, month: 0 })).toEqual({
+      type: 'month',
+      year: 2026,
+      month: 0
+    })
+    expect(parseJournalDrill({ type: 'year', year: 2026 })).toEqual({ type: 'year', year: 2026 })
+  })
+
+  it('keeps month 0, which is January and not "missing"', () => {
+    expect(parseJournalDrill({ type: 'month', year: 2026, month: 0 })?.type).toBe('month')
+    expect(parseJournalDrill({ type: 'month', year: 2026, month: 11 })?.type).toBe('month')
+  })
+
+  it('rejects a month outside the year rather than clamping it', () => {
+    // A clamp would silently show January for a value that means nothing; a
+    // rejection falls back to the day view the user can navigate from.
+    expect(parseJournalDrill({ type: 'month', year: 2026, month: 12 })).toBeUndefined()
+    expect(parseJournalDrill({ type: 'month', year: 2026, month: -1 })).toBeUndefined()
+  })
+
+  it('rejects a level missing the numbers it needs', () => {
+    expect(parseJournalDrill({ type: 'month', year: 2026 })).toBeUndefined()
+    expect(parseJournalDrill({ type: 'month', month: 3 })).toBeUndefined()
+    expect(parseJournalDrill({ type: 'year' })).toBeUndefined()
+    expect(parseJournalDrill({ type: 'year', year: '2026' })).toBeUndefined()
+    expect(parseJournalDrill({ type: 'year', year: 2026.5 })).toBeUndefined()
+  })
+
+  it('rejects anything that is not a drill record', () => {
+    expect(parseJournalDrill(undefined)).toBeUndefined()
+    expect(parseJournalDrill(null)).toBeUndefined()
+    expect(parseJournalDrill('day')).toBeUndefined()
+    expect(parseJournalDrill({ type: 'decade', year: 2020 })).toBeUndefined()
+  })
+
+  it('drops a date smuggled into a day drill', () => {
+    // The tab's own `date` key is the one truth for which day is open. Storing
+    // it twice gives it two owners that disagree the moment `openTab` writes.
+    expect(parseJournalDrill({ type: 'day', date: '2026-01-05' })).toEqual({ type: 'day' })
+  })
+})
+
+describe('toJournalViewState', () => {
+  it('takes the day from the tab, never from the drill record', () => {
+    expect(toJournalViewState(DEFAULT_JOURNAL_DRILL, '2026-01-05')).toEqual({
+      type: 'day',
+      date: '2026-01-05'
+    })
+  })
+
+  it('passes a month or year level straight through', () => {
+    expect(toJournalViewState({ type: 'month', year: 2026, month: 4 }, '2026-01-05')).toEqual({
+      type: 'month',
+      year: 2026,
+      month: 4
+    })
+    expect(toJournalViewState({ type: 'year', year: 2019 }, '2026-01-05')).toEqual({
+      type: 'year',
+      year: 2019
+    })
+  })
+})
+
+describe('resolveJournalDate', () => {
+  it('opens on today when the tab carries no date', () => {
+    expect(resolveJournalDate(undefined, '2026-08-17')).toBe('2026-08-17')
+    // An empty string is not a date either — the first open must still land on
+    // today rather than on a blank entry.
+    expect(resolveJournalDate('', '2026-08-17')).toBe('2026-08-17')
+  })
+
+  it('prefers the tab own date once it has one', () => {
+    expect(resolveJournalDate('2026-01-05', '2026-08-17')).toBe('2026-01-05')
+  })
+})
+
+describe('journalScrollKey', () => {
+  it('gives every day its own scroller identity', () => {
+    // The tab's entityId does not change when the journal moves to the next
+    // day, so the entity stamp cannot discard the previous day's offset. The
+    // key has to.
+    expect(journalScrollKey({ type: 'day', date: '2026-01-05' })).not.toBe(
+      journalScrollKey({ type: 'day', date: '2026-01-06' })
+    )
+  })
+
+  it('separates the three levels from each other', () => {
+    const keys = [
+      journalScrollKey({ type: 'day', date: '2026-01-05' }),
+      journalScrollKey({ type: 'month', year: 2026, month: 0 }),
+      journalScrollKey({ type: 'year', year: 2026 })
+    ]
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('shares one key across months and one across years', () => {
+    // Month and year views are short grids the user pages through; giving each
+    // one its own slot would evict the day offsets that matter.
+    expect(journalScrollKey({ type: 'month', year: 2026, month: 0 })).toBe(
+      journalScrollKey({ type: 'month', year: 2019, month: 7 })
+    )
+    expect(journalScrollKey({ type: 'year', year: 2026 })).toBe(
+      journalScrollKey({ type: 'year', year: 2019 })
+    )
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/journal-view-state.ts
+++ b/apps/desktop/src/renderer/src/pages/journal-view-state.ts
@@ -1,0 +1,83 @@
+/**
+ * What a Journal tab remembers, and how it is read back.
+ *
+ * The DATE already lives in the tab under `date` and is written by `openTab`;
+ * that key is load-bearing for sessions on disk and is not touched here. What
+ * was missing is the DRILL LEVEL: month and year view were local `useState`, so
+ * drilling up to a month and switching tabs dropped the user back on a day.
+ *
+ * The drill is stored WITHOUT the day's date on purpose. A day-level drill
+ * carries no date of its own — the tab's `date` is the one truth for which day
+ * is open, and duplicating it here would give one value two owners that
+ * disagree the moment `openTab` writes the other one.
+ */
+
+import type { JournalViewState } from '@/components/journal'
+
+export const JOURNAL_VIEW_STATE_KEYS = {
+  /** Day, month or year — the level the breadcrumb has drilled to. */
+  drill: 'journalDrill'
+} as const
+
+/** Key written by `openTab`, read by the page. Never written from here. */
+export const JOURNAL_DATE_KEY = 'date'
+
+/**
+ * The persisted drill level. `day` deliberately has no `date`: see the header.
+ */
+export type JournalDrill =
+  { type: 'day' } | { type: 'month'; year: number; month: number } | { type: 'year'; year: number }
+
+export const DEFAULT_JOURNAL_DRILL: JournalDrill = { type: 'day' }
+
+const isInteger = (raw: unknown): raw is number => typeof raw === 'number' && Number.isInteger(raw)
+
+/**
+ * Total, because `viewState` survives a restore and can have been written by an
+ * older build. An out-of-range month is rejected rather than clamped: a clamp
+ * would silently show January for a value that means nothing.
+ */
+export function parseJournalDrill(raw: unknown): JournalDrill | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const record = raw as { type?: unknown; year?: unknown; month?: unknown }
+
+  if (record.type === 'day') return { type: 'day' }
+  if (record.type === 'year') {
+    return isInteger(record.year) ? { type: 'year', year: record.year } : undefined
+  }
+  if (record.type === 'month') {
+    if (!isInteger(record.year) || !isInteger(record.month)) return undefined
+    if (record.month < 0 || record.month > 11) return undefined
+    return { type: 'month', year: record.year, month: record.month }
+  }
+  return undefined
+}
+
+/** The date the page shows, given the tab's stored date and today's. */
+export function resolveJournalDate(tabDate: string | undefined, fallback: string): string {
+  return tabDate || fallback
+}
+
+/**
+ * The view the page renders: the drill level, with the day's date supplied by
+ * the tab rather than by the drill record.
+ */
+export function toJournalViewState(drill: JournalDrill, date: string): JournalViewState {
+  return drill.type === 'day' ? { type: 'day', date } : drill
+}
+
+/**
+ * Which scroller is on screen.
+ *
+ * Day view is keyed by its DATE. The three levels are different content in the
+ * same element, and a day's offset means nothing on another day — but unlike a
+ * note, moving to the next day does not change the tab's `entityId`, so the
+ * entity stamp that normally discards a stale offset cannot see it. Putting the
+ * date in the key does the same job, and the tab's bounded pane map keeps the
+ * last few days rather than every day ever visited.
+ */
+export function journalScrollKey(view: JournalViewState): string {
+  if (view.type === 'month') return 'journal-month'
+  if (view.type === 'year') return 'journal-year'
+  return `journal-day:${view.date}`
+}

--- a/apps/desktop/src/renderer/src/pages/journal.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.test.tsx
@@ -68,8 +68,20 @@ vi.mock('sonner', () => ({
 }))
 
 vi.mock('@/contexts/tabs', () => ({
-  useTabs: () => ({ openTab: mocks.openTab }),
-  useActiveTab: () => mocks.activeTab
+  // The page reads its date off ITS OWN tab now, not off the globally active
+  // one, so the mocked session has to actually contain the tab.
+  useTabs: () => ({
+    openTab: mocks.openTab,
+    state: {
+      tabGroups: { 'group-1': { tabs: [{ id: 'tab-1', ...mocks.activeTab }] } }
+    }
+  }),
+  useActiveTab: () => mocks.activeTab,
+  useTabActionsOptional: () => null
+}))
+
+vi.mock('@/contexts/tabs/tab-identity', () => ({
+  useTabIdentity: () => ({ tabId: 'tab-1', groupId: 'group-1' })
 }))
 
 vi.mock('@/contexts/settings-modal-context', () => ({

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -48,6 +48,19 @@ import { ExportDialog } from '@/components/note/export-dialog'
 import { VersionHistory } from '@/components/note/version-history'
 import { toast } from 'sonner'
 import { useTabs, useActiveTab } from '@/contexts/tabs'
+import { useTabIdentity } from '@/contexts/tabs/tab-identity'
+import { useTabViewState } from '@/hooks/use-tab-view-state'
+import { useTabScrollRestore } from '@/hooks/use-tab-scroll-restore'
+import {
+  DEFAULT_JOURNAL_DRILL,
+  JOURNAL_DATE_KEY,
+  JOURNAL_VIEW_STATE_KEYS,
+  journalScrollKey,
+  parseJournalDrill,
+  resolveJournalDate,
+  toJournalViewState,
+  type JournalDrill
+} from './journal-view-state'
 import { resolveWikiLink } from '@/lib/wikilink-resolver'
 import {
   createJournalDateLabels,
@@ -116,23 +129,36 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
   const { t, i18n: _i18n } = useT('journal')
   const { t: commonT } = useT('common')
   const activeTab = useActiveTab()
-  const { openTab } = useTabs()
+  const { openTab, state: tabState } = useTabs()
+  const identity = useTabIdentity()
   const today = useToday()
   const dateLabels = useMemo(() => createJournalDateLabels(t), [t])
-  const tabDate = activeTab?.viewState?.date as string | undefined
+  // The date is read off THIS tab, not off the globally active one: a journal
+  // sitting in the inactive pane of a split view would otherwise read another
+  // tab's `date` key, or none at all. Reactive, because `openTab` writes the
+  // date into the tab and the page has to follow it.
+  const tabDate = useMemo(() => {
+    if (!identity) return undefined
+    const tab = tabState.tabGroups[identity.groupId]?.tabs.find((t) => t.id === identity.tabId)
+    const raw = tab?.viewState?.[JOURNAL_DATE_KEY]
+    return typeof raw === 'string' ? raw : undefined
+  }, [identity, tabState.tabGroups])
 
   // Get initial date from tab viewState or default to today
-  const initialDate = tabDate || today
+  const initialDate = resolveJournalDate(tabDate, today)
   const [selectedDateState, setSelectedDateState] = useState(initialDate)
-  const [viewState, setViewState] = useState<JournalViewState>({ type: 'day', date: initialDate })
-  const selectedDate = tabDate || selectedDateState
-  const currentViewState = useMemo<JournalViewState>(() => {
-    if (tabDate && viewState.type === 'day' && viewState.date !== tabDate) {
-      return { type: 'day', date: tabDate }
-    }
-
-    return viewState
-  }, [tabDate, viewState])
+  // The drill level lives in the tab: month and year view used to be local
+  // state, so drilling up and switching tabs put the user back on a day.
+  const [drill, setDrill] = useTabViewState<JournalDrill>({
+    key: JOURNAL_VIEW_STATE_KEYS.drill,
+    defaultValue: DEFAULT_JOURNAL_DRILL,
+    parse: parseJournalDrill
+  })
+  const selectedDate = resolveJournalDate(tabDate, selectedDateState)
+  const currentViewState = useMemo<JournalViewState>(
+    () => toJournalViewState(drill, selectedDate),
+    [drill, selectedDate]
+  )
 
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false)
   const [isVersionHistoryOpen, setIsVersionHistoryOpen] = useState(false)
@@ -344,6 +370,17 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
     journalScrollRef.current = el
     setJournalScrollEl(el)
   }, [])
+  const getJournalScrollEl = useCallback(() => journalScrollRef.current, [])
+  // Day view throws the editor away and rebuilds it from a key on every date
+  // change and on every load transition, so an offset applied while the entry
+  // is still pending lands on an empty editor and gets clamped to 0. Waiting
+  // for `loaded` is enough — the hook re-runs when `enabled` flips. Month and
+  // year view have no editor and never wait.
+  useTabScrollRestore({
+    getScrollElement: getJournalScrollEl,
+    enabled: currentViewState.type !== 'day' || editorLoadState === 'loaded',
+    key: journalScrollKey(currentViewState)
+  })
   const prefersReducedMotion = useReducedMotion()
   // Scroll-edge effect for the floating chrome (state only flips at the 0 boundary)
   const [isChromeScrolled, setIsChromeScrolled] = useState(false)
@@ -472,17 +509,17 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
 
   // Navigation
   const navigateToMonth = useCallback((year: number, month: number) => {
-    setViewState({ type: 'month', year, month })
+    setDrill({ type: 'month', year, month })
   }, [])
 
   const navigateToYear = useCallback((year: number) => {
-    setViewState({ type: 'year', year })
+    setDrill({ type: 'year', year })
   }, [])
 
   const navigateToDay = useCallback(
     (date: string) => {
       setSelectedDateState(date)
-      setViewState({ type: 'day', date })
+      setDrill({ type: 'day' })
       openTab({
         type: 'journal',
         title: t('title'),
@@ -523,7 +560,7 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
       const newMonth = currentViewState.month === 0 ? 11 : currentViewState.month - 1
       const newYear =
         currentViewState.month === 0 ? currentViewState.year - 1 : currentViewState.year
-      setViewState({ type: 'month', year: newYear, month: newMonth })
+      setDrill({ type: 'month', year: newYear, month: newMonth })
     }
   }, [currentViewState])
 
@@ -532,19 +569,19 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
       const newMonth = currentViewState.month === 11 ? 0 : currentViewState.month + 1
       const newYear =
         currentViewState.month === 11 ? currentViewState.year + 1 : currentViewState.year
-      setViewState({ type: 'month', year: newYear, month: newMonth })
+      setDrill({ type: 'month', year: newYear, month: newMonth })
     }
   }, [currentViewState])
 
   const handlePreviousYear = useCallback(() => {
     if (currentViewState.type === 'year') {
-      setViewState({ type: 'year', year: currentViewState.year - 1 })
+      setDrill({ type: 'year', year: currentViewState.year - 1 })
     }
   }, [currentViewState])
 
   const handleNextYear = useCallback(() => {
     if (currentViewState.type === 'year') {
-      setViewState({ type: 'year', year: currentViewState.year + 1 })
+      setDrill({ type: 'year', year: currentViewState.year + 1 })
     }
   }, [currentViewState])
 

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -508,13 +508,19 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
   const properties = useMemo(() => rawProperties.filter((p) => p.name !== 'date'), [rawProperties])
 
   // Navigation
-  const navigateToMonth = useCallback((year: number, month: number) => {
-    setDrill({ type: 'month', year, month })
-  }, [])
+  const navigateToMonth = useCallback(
+    (year: number, month: number) => {
+      setDrill({ type: 'month', year, month })
+    },
+    [setDrill]
+  )
 
-  const navigateToYear = useCallback((year: number) => {
-    setDrill({ type: 'year', year })
-  }, [])
+  const navigateToYear = useCallback(
+    (year: number) => {
+      setDrill({ type: 'year', year })
+    },
+    [setDrill]
+  )
 
   const navigateToDay = useCallback(
     (date: string) => {
@@ -532,7 +538,7 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
         viewState: { date }
       })
     },
-    [openTab, t]
+    [openTab, setDrill, t]
   )
 
   const navigateBack = useCallback(() => {
@@ -562,7 +568,7 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
         currentViewState.month === 0 ? currentViewState.year - 1 : currentViewState.year
       setDrill({ type: 'month', year: newYear, month: newMonth })
     }
-  }, [currentViewState])
+  }, [currentViewState, setDrill])
 
   const handleNextMonth = useCallback(() => {
     if (currentViewState.type === 'month') {
@@ -571,19 +577,19 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
         currentViewState.month === 11 ? currentViewState.year + 1 : currentViewState.year
       setDrill({ type: 'month', year: newYear, month: newMonth })
     }
-  }, [currentViewState])
+  }, [currentViewState, setDrill])
 
   const handlePreviousYear = useCallback(() => {
     if (currentViewState.type === 'year') {
       setDrill({ type: 'year', year: currentViewState.year - 1 })
     }
-  }, [currentViewState])
+  }, [currentViewState, setDrill])
 
   const handleNextYear = useCallback(() => {
     if (currentViewState.type === 'year') {
       setDrill({ type: 'year', year: currentViewState.year + 1 })
     }
-  }, [currentViewState])
+  }, [currentViewState, setDrill])
 
   const handleNavigationPrevious = useCallback(() => {
     switch (currentViewState.type) {

--- a/apps/desktop/src/renderer/src/pages/tags-hub-view-state.test.ts
+++ b/apps/desktop/src/renderer/src/pages/tags-hub-view-state.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  TAGS_HUB_SCROLL_KEY,
+  TAGS_HUB_VIEW_STATE_KEYS,
+  parseTagsHubQuery
+} from './tags-hub-view-state'
+
+describe('tags hub view state', () => {
+  it('persists nothing the hub already owns as data', () => {
+    // Categories, their order and every tag's placement round-trip through IPC.
+    // Mirroring any of them into tab state gives one value two owners.
+    const owned = ['categories', 'uncategorized', 'order', 'tags']
+    for (const key of Object.values(TAGS_HUB_VIEW_STATE_KEYS)) {
+      expect(owned).not.toContain(key)
+    }
+  })
+
+  it('keeps the search key and the scroll key apart', () => {
+    expect(Object.values(TAGS_HUB_VIEW_STATE_KEYS)).not.toContain(TAGS_HUB_SCROLL_KEY)
+  })
+
+  it('keeps an empty query, which is not the same as unset', () => {
+    expect(parseTagsHubQuery('proj')).toBe('proj')
+    expect(parseTagsHubQuery('')).toBe('')
+    expect(parseTagsHubQuery(null)).toBeUndefined()
+    expect(parseTagsHubQuery(3)).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/tags-hub-view-state.ts
+++ b/apps/desktop/src/renderer/src/pages/tags-hub-view-state.ts
@@ -1,0 +1,23 @@
+/**
+ * What a Tags hub tab remembers.
+ *
+ * Narrow on purpose. The categories, their order and every tag's placement are
+ * the hub's DATA — owned by `useTagCategories` and written back through IPC.
+ * The only thing the tab has to hold is the transient in-page search, which is
+ * a lens over that data rather than part of it.
+ */
+
+export const TAGS_HUB_VIEW_STATE_KEYS = {
+  /** In-page search text. */
+  query: 'tagsHubQuery'
+} as const
+
+/** One scroller, so the unkeyed slot would do — named for readability. */
+export const TAGS_HUB_SCROLL_KEY = 'tags-hub'
+
+/**
+ * Total, like every other view-state reader: an empty string is a real value
+ * ("the user cleared the box") and is not the same as nothing stored.
+ */
+export const parseTagsHubQuery = (raw: unknown): string | undefined =>
+  typeof raw === 'string' ? raw : undefined

--- a/apps/desktop/src/renderer/src/pages/tags-hub.tsx
+++ b/apps/desktop/src/renderer/src/pages/tags-hub.tsx
@@ -27,6 +27,13 @@ import {
   verticalListSortingStrategy
 } from '@dnd-kit/sortable'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { useTabScrollRestore } from '@/hooks/use-tab-scroll-restore'
+import { useTabViewState } from '@/hooks/use-tab-view-state'
+import {
+  TAGS_HUB_SCROLL_KEY,
+  TAGS_HUB_VIEW_STATE_KEYS,
+  parseTagsHubQuery
+} from './tags-hub-view-state'
 import { Search } from '@/lib/icons'
 import { useTagCategories, type HubTag } from '@/hooks/use-tag-categories'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
@@ -148,8 +155,25 @@ export function TagsHubPage(): React.JSX.Element {
   const dragSessionRef = useRef<TagDragSession | null>(null)
   const [activeDrag, setActiveDrag] = useState<ActiveDrag | null>(null)
 
-  const [query, setQuery] = useState('')
+  const [query, setQuery] = useTabViewState<string>({
+    key: TAGS_HUB_VIEW_STATE_KEYS.query,
+    defaultValue: '',
+    parse: parseTagsHubQuery
+  })
   const isSearching = query.trim().length > 0
+
+  // Radix puts the scrolling element INSIDE the root: `ScrollArea` renders a
+  // viewport that owns the overflow, and the root never scrolls. The restore
+  // hook takes a getter for exactly this — a ref on the root would attach the
+  // listener to an element whose scrollTop is always 0.
+  const scrollRootRef = useRef<HTMLDivElement>(null)
+  const getScrollViewport = useCallback(
+    () =>
+      scrollRootRef.current?.querySelector<HTMLElement>('[data-radix-scroll-area-viewport]') ??
+      null,
+    []
+  )
+  useTabScrollRestore({ getScrollElement: getScrollViewport, key: TAGS_HUB_SCROLL_KEY })
 
   const displayCategories = override?.categories ?? categories
   const displayUncategorized = override?.uncategorized ?? uncategorized
@@ -341,7 +365,7 @@ export function TagsHubPage(): React.JSX.Element {
   }
 
   return (
-    <ScrollArea className="h-full">
+    <ScrollArea ref={scrollRootRef} className="h-full">
       {/* Full-bleed, not a centred measure: the column spans the window so
           section rules run the full width, while the content inside it stays
           on the start edge. Vertical rhythm comes from each section's own

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -126,7 +126,7 @@ If **Restore Session** is on, the entire tab and split layout restores on app la
 - Pinned state
 - Split layout and ratios
 - Active tab per pane
-- Scroll position in note tabs
+- Scroll position, and what each tab was looking at
 
 The layout is written only when one of those things actually changes. Activity that leaves the layout alone — a note picking up and losing its modified dot, moving back and forward inside a tab — no longer triggers a rewrite. Quitting still writes the current layout either way, so nothing is lost by the skipped writes.
 
@@ -136,9 +136,44 @@ Note tabs — including the template editor and release-notes tabs — remember 
 
 If the tab navigates to a different note, the saved position is discarded rather than applied to the new content. Scrolling yourself while a position is being restored cancels the restore, so the app never fights you for control of the page.
 
-Pages that hold several scrolling areas — the Inbox's sub-views, a project's Overview, Notes, Files and Events tabs, a folder's list, table and gallery layouts — keep a position for each one. Going Overview → Notes → Overview returns to where you left Overview, not to the top, and the Notes position is still waiting for you as well. A tab remembers a handful of these areas at a time; if you visit more than that, the ones you have not been back to longest are forgotten first.
+Pages that hold several scrolling areas — the Inbox's sub-views, a project's Overview, Notes, Files and Events tabs, a folder's list, table and gallery layouts, Calendar's Day, Week and Year grids — keep a position for each one. Going Overview → Notes → Overview returns to where you left Overview, not to the top, and the Notes position is still waiting for you as well. A tab remembers a handful of these areas at a time; if you visit more than that, the ones you have not been back to longest are forgotten first.
 
-Calendar does not restore scroll yet.
+### When a Page Would Rather Put You Somewhere Else
+
+Some pages place themselves when they open: Calendar's Day and Week grids scroll to the current hour, an image is fitted to the pane it opens in, an agent conversation shows the newest message.
+
+One rule decides who wins, everywhere: **your position wins.** A page only places itself when the tab has nothing stored for it — that is, the first time you open it. Once you have scrolled, zoomed, or paged somewhere yourself, that is where the tab comes back to, and the page stops moving on its own.
+
+That also means Week view stops jumping. It used to snap back to the current hour any time you scrolled the weeks past today; now, once the tab has a position of its own, it stays where you put it.
+
+Agent conversations are the one deliberate exception, because "where you were" in a growing transcript is not a fixed place:
+
+- If you are at the bottom, you stay at the bottom — new messages and streamed text keep scrolling into view.
+- If you scroll up, the transcript stops following the stream and leaves you alone, even while a reply is still being written.
+- Whichever of the two you were doing is what you come back to.
+
+### What Each Tab Remembers
+
+| Tab           | Remembers                                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------- |
+| Note          | Reading position                                                                                  |
+| Journal       | The day you were on, whether you had drilled up to a month or a year, and where each day was left |
+| Calendar      | Day / Week / Month / Year, the date you were centred on, and your filters                         |
+| Inbox         | Sub-view, filters, and the item you had open                                                      |
+| Tasks         | View, sub-tab, project scope, and the task you had open                                           |
+| Project       | Sub-tab and rail                                                                                  |
+| Folder        | The named view you were on, and its search                                                        |
+| Tags          | The search box                                                                                    |
+| PDF           | Page, zoom, rotation, and whether the thumbnail rail was open                                     |
+| Image         | Zoom, rotation, and pan                                                                           |
+| Audio / video | Playback position — restored **paused**, never resumed for you                                    |
+| Agent chat    | Whether you were following the stream, or reading further up                                      |
+
+Calendar's view used to be one setting shared by the whole app; it now belongs to the tab, starting from whatever view you last used. Its filters used to reset every time you left the page.
+
+Anything that already has a home of its own is left there rather than copied into the tab: a folder's columns and filters live in the folder, task filters and sort live in Settings, and a project's contents live in the project.
+
+If a tab moves to a different note, file, or conversation, the position saved for the previous one is discarded rather than applied to the new content — including a preview tab that gets reused for the next file you click.
 
 ### If the layout can't be saved
 


### PR DESCRIPTION
Last of the series after #1549 and #1551. Covers **Journal, Calendar, Agent Chat, Tags hub, and the file viewers**.

## One precedence rule, not per-page ad-hockery

Several of these surfaces auto-position on mount — the calendar grid scrolls to "now", the image viewer fits to container, chat jumps to the newest message. A restore must not silently lose to them, and must not silently beat them either.

**A position stored by this tab wins. Auto-positioning runs only when the tab has nothing stored — i.e. first open.** Enforced in `hooks/use-tab-auto-position.ts`, which returns a *getter* rather than a boolean: the components that auto-position do not subscribe to tab state, so a rendered boolean would go stale exactly when it matters, at the user's first scroll. It shares one predicate with the restore path (`isRestorableEntry`), so "there is something to restore" and "stand down" cannot disagree — otherwise a stale-entity entry would suppress auto-positioning *and* be refused by restore, stranding the user at the top.

The calendar gate matters twice: on mount, where it races the restore, and afterwards, because `useScrollToCurrentTime` re-runs whenever its range starts or stops containing today — in week view that happens as the user scrolls weeks past today, so ungated it yanks the grid back to the current hour mid-read.

Agent Chat is the deliberate exception: it stores a **policy** (`'bottom' | number | null`), not an offset, because "where you were" in a growing transcript is not a fixed place. Pinned at the bottom follows the stream; scrolled up is left alone even mid-reply. The live policy is a ref rather than the rendered value — the commit is throttled, and a rendered value would keep reporting "bottom" for half a second after the user scrolls up, hauling them back down on every token in that window. This replaces `conversation.tsx`'s unconditional `scrollTo(bottom)` on every `children` change.

## Per surface

- **Journal** — the month/year drill level is persisted; the day's date stays owned by the tab's existing `date` key. Scroll is gated on `editorLoadState === 'loaded'` (the editor is rebuilt from a key on every date change) and keyed **per date**: moving to the next day does not change the tab's `entityId`, so the stamp cannot separate the days — the key does. Open-on-today is preserved for a first open.
- **Calendar** — `view` moves off the global `localStorage['calendar-view']` (which meant two calendar tabs could never differ) into the tab, still falling back to and writing the global key for rollback. Filters persisted. The imported-source filter now stores the user's explicit choice, with "all of them" *derived* — which deletes the seeding effect rather than racing it, and stops a calendar connected later being silently folded into a hand-made selection.
- **`anchorDate`** — the app-level context stays the single *live* value, the tab becomes the *durable* record. The day panel is not in a tab and writes `setAnchorDate`, so moving the anchor into tab state outright would break it, and a per-tab context would leave the panel with nothing to write to. The trap: both effects run in the same commit, so a naive mirror reads the context still holding *today* and writes today over the anchor it is restoring — on every launch. `resolveAnchorSync` owns that handshake and is unit-tested.
- **Tags hub** — query persisted; scroll wired through a getter onto `[data-radix-scroll-area-viewport]`, since the ScrollArea root's `scrollTop` is always 0. This is why the shared hook takes a getter rather than a ref.
- **File viewers** — PDF page / zoom / rotation / thumbnail rail, with scroll keyed by page since it renders one page at a time. Image zoom / rotation / pan, with fit-to-container running only on a tab that has never been zoomed and the fit result deliberately *not* persisted (otherwise one pane's width freezes into the tab and a narrower pane can never fit again). Audio and video restore position **paused**, and neither seeks to the end a finished track leaves behind.

New shared piece: `hooks/use-tab-entity-view-state.ts`, entity-stamped `viewState` mirroring the scroll entry's stamp. A preview file tab keeps its id, its viewState and its mounted viewer while the file inside it changes — page 12 of a 3-page PDF must not survive that.

## Found, not fixed: a nonce hazard on Calendar

`viewState` is persisted verbatim, the one-shot navigation tokens (`focusCalendarEventId`, `createEventAt`, `focusedAt`) are never cleared, and the refs guarding them reset on every remount rather than only on restart. Click sidebar Calendar, switch tab, switch back — the create-event popover re-opens. **This is broken on `main` today and unchanged by this PR**; the new view-state keys are tested not to collide with the token names. The fix (clear the token when consumed, or keep it out of persisted state) belongs in its own change.

## Verification

`typecheck:web`, `typecheck:test`, `lint` (0 errors; 99 warnings, down from a 108 baseline, none new), `test:renderer` (635 files / 7375 tests), `docs:impact --strict`, `docs:build` — all green.

jsdom has no layout, so DOM-level scroll assertions prove nothing; tests drive decision logic and all 18 new mutants were killed, including the anchor-sync handshake writing mid-seed, a stored `0` being read as nothing, resume seeking past the end of a finished track, and the journal day key dropping its date.

Twelve existing test files mocked `@/contexts/tabs` without `useTabActionsOptional` and were extended to return `null` (renders outside a tab degrade to plain state). No assertions were changed and no test was weakened.

## Known trade

Journal scroll is keyed per date and the per-tab pane map is bounded at 8, so browsing nine days evicts the oldest offset. That is the bound working as designed, and it is the deliberate trade against a single shared journal key that would leak one day's position onto another.