### PR TITLE
fix(tasks): close the project modal on delete and confirm first

### DIFF
--- a/apps/desktop/src/renderer/src/components/missing-small-components.test.tsx
+++ b/apps/desktop/src/renderer/src/components/missing-small-components.test.tsx
@@ -428,9 +428,12 @@ describe('missing small component surfaces', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('radio', { name: /deleteAllTasksPermanently/ }))
+    // Tasks always go with the project (main's deleteProject cascades them), so
+    // the dialog states the count instead of offering a move-vs-delete choice.
+    expect(screen.getByText(/thisProjectHas/)).toBeInTheDocument()
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument()
     fireEvent.click(screen.getByText('phaseF.componentsTasksDeleteProjectDialog.deleteProject'))
-    expect(onConfirm).toHaveBeenCalledWith('delete')
+    expect(onConfirm).toHaveBeenCalledTimes(1)
     expect(onClose).toHaveBeenCalled()
 
     rerender(

--- a/apps/desktop/src/renderer/src/components/tasks/delete-project-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/delete-project-dialog.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { AlertTriangle } from '@/lib/icons'
 
 import { Button } from '@/components/ui/button'
@@ -10,7 +9,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle
 } from '@/components/ui/alert-dialog'
-import { cn } from '@/lib/utils'
 import type { Project } from '@/data/tasks-data'
 import { useT } from '@memry/i18n/renderer'
 
@@ -18,12 +16,10 @@ import { useT } from '@memry/i18n/renderer'
 // TYPES
 // ============================================================================
 
-export type DeleteTasksOption = 'move' | 'delete'
-
 interface DeleteProjectDialogProps {
   isOpen: boolean
   onClose: () => void
-  onConfirm: (option: DeleteTasksOption) => void
+  onConfirm: () => void
   project: Project | null
 }
 
@@ -38,28 +34,14 @@ export const DeleteProjectDialog = ({
   project
 }: DeleteProjectDialogProps): React.JSX.Element => {
   const { t: tPhaseF } = useT('tasks')
-  const [selectedOption, setSelectedOption] = useState<DeleteTasksOption>('move')
 
   const taskCount = project?.taskCount || 0
   const hasTasks = taskCount > 0
 
   const handleConfirm = (): void => {
-    onConfirm(selectedOption)
+    onConfirm()
     onClose()
   }
-
-  const handleOptionChange = (option: DeleteTasksOption) => (): void => {
-    setSelectedOption(option)
-  }
-
-  const handleKeyDown =
-    (option: DeleteTasksOption) =>
-    (e: React.KeyboardEvent): void => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault()
-        setSelectedOption(option)
-      }
-    }
 
   if (!project) return <></>
 
@@ -74,85 +56,11 @@ export const DeleteProjectDialog = ({
           <AlertDialogDescription asChild>
             <div className="space-y-4">
               {hasTasks ? (
-                <>
-                  <p>
-                    {tPhaseF('phaseF.componentsTasksDeleteProjectDialog.thisProjectHas')}
-                    {taskCount} {tPhaseF('phaseF.componentsTasksDeleteProjectDialog.task')}
-                    {taskCount !== 1 ? 's' : ''}.{' '}
-                    {tPhaseF(
-                      'phaseF.componentsTasksDeleteProjectDialog.whatWouldYouLikeToDoWithThem'
-                    )}
-                  </p>
-
-                  {/* Radio Options */}
-                  <div className="space-y-2">
-                    {/* Option: Move to Personal */}
-                    <div
-                      className={cn(
-                        'flex cursor-pointer items-center gap-3 rounded-sm border p-3 transition-colors',
-                        selectedOption === 'move'
-                          ? 'border-primary bg-accent/50'
-                          : 'hover:bg-accent/30'
-                      )}
-                      onClick={handleOptionChange('move')}
-                      onKeyDown={handleKeyDown('move')}
-                      tabIndex={0}
-                      role="radio"
-                      aria-checked={selectedOption === 'move'}
-                    >
-                      <div
-                        className={cn(
-                          'size-4 rounded-full border-2 transition-colors',
-                          selectedOption === 'move'
-                            ? 'border-primary bg-primary'
-                            : 'border-muted-foreground'
-                        )}
-                      >
-                        {selectedOption === 'move' && (
-                          <div className="m-0.5 size-2 rounded-full bg-primary-foreground" />
-                        )}
-                      </div>
-                      <span className="text-sm text-foreground">
-                        {tPhaseF(
-                          'phaseF.componentsTasksDeleteProjectDialog.moveTasksToPersonalProject'
-                        )}
-                      </span>
-                    </div>
-
-                    {/* Option: Delete tasks */}
-                    <div
-                      className={cn(
-                        'flex cursor-pointer items-center gap-3 rounded-sm border p-3 transition-colors',
-                        selectedOption === 'delete'
-                          ? 'border-primary bg-accent/50'
-                          : 'hover:bg-accent/30'
-                      )}
-                      onClick={handleOptionChange('delete')}
-                      onKeyDown={handleKeyDown('delete')}
-                      tabIndex={0}
-                      role="radio"
-                      aria-checked={selectedOption === 'delete'}
-                    >
-                      <div
-                        className={cn(
-                          'size-4 rounded-full border-2 transition-colors',
-                          selectedOption === 'delete'
-                            ? 'border-primary bg-primary'
-                            : 'border-muted-foreground'
-                        )}
-                      >
-                        {selectedOption === 'delete' && (
-                          <div className="m-0.5 size-2 rounded-full bg-primary-foreground" />
-                        )}
-                      </div>
-                      <span className="text-sm text-foreground">
-                        {tPhaseF(
-                          'phaseF.componentsTasksDeleteProjectDialog.deleteAllTasksPermanently'
-                        )}
-                      </span>
-                    </div>
-                  </div>
-                </>
+                <p>
+                  {tPhaseF('phaseF.componentsTasksDeleteProjectDialog.thisProjectHas')}
+                  {taskCount} {tPhaseF('phaseF.componentsTasksDeleteProjectDialog.task')}
+                  {taskCount !== 1 ? 's' : ''}.
+                </p>
               ) : (
                 <p>
                   {tPhaseF(

--- a/apps/desktop/src/renderer/src/components/tasks/project-modal.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/project-modal.test.tsx
@@ -36,7 +36,9 @@ vi.mock('@/components/ui/alert-dialog', () => ({
   AlertDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <h3>{children}</h3>,
-  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  // A div, not a p: the real AlertDialogDescription takes `asChild`, and the
+  // delete-confirm passes a <div> body through it.
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   AlertDialogCancel: ({
     children,
@@ -203,6 +205,8 @@ describe('ProjectModal', () => {
     await screen.findByRole('button', { name: 'pick Star' })
     expect(screen.getByText('Edit Project')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'deleteProject' }))
+    // The footer button only opens the confirm step; the second one commits.
+    fireEvent.click(screen.getAllByRole('button', { name: 'deleteProject' })[1])
     expect(onDelete).toHaveBeenCalledWith('project-1')
 
     fireEvent.click(screen.getByRole('button', { name: 'invalid statuses' }))
@@ -225,6 +229,57 @@ describe('ProjectModal', () => {
     fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
     fireEvent.click(screen.getByRole('button', { name: 'discard' }))
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('confirms before deleting and cancelling keeps the project', async () => {
+    const onClose = vi.fn()
+    const onDelete = vi.fn()
+
+    render(
+      <ProjectModal
+        isOpen
+        onClose={onClose}
+        onSave={vi.fn()}
+        onDelete={onDelete}
+        project={makeProject()}
+      />
+    )
+
+    // Flush the lazy-loaded icon picker's Suspense boundary before sync assertions.
+    await screen.findByRole('button', { name: 'pick Star' })
+    fireEvent.click(screen.getByRole('button', { name: 'deleteProject' }))
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    expect(onDelete).not.toHaveBeenCalled()
+
+    // The confirm dialog's own cancel is the second one on screen.
+    fireEvent.click(screen.getAllByRole('button', { name: 'cancel' })[1])
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(onDelete).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('closes the modal after deleting a project', async () => {
+    const onClose = vi.fn()
+    const onDelete = vi.fn()
+
+    render(
+      <ProjectModal
+        isOpen
+        onClose={onClose}
+        onSave={vi.fn()}
+        onDelete={onDelete}
+        project={makeProject()}
+      />
+    )
+
+    // Flush the lazy-loaded icon picker's Suspense boundary before sync assertions.
+    await screen.findByRole('button', { name: 'pick Star' })
+    fireEvent.click(screen.getByRole('button', { name: 'deleteProject' }))
+    fireEvent.click(screen.getAllByRole('button', { name: 'deleteProject' })[1])
+
+    expect(onDelete).toHaveBeenCalledWith('project-1')
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 
   it('hides delete for default projects and closes clean forms immediately', async () => {

--- a/apps/desktop/src/renderer/src/components/tasks/project-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/project-modal.tsx
@@ -25,6 +25,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { ProjectIcon } from '@/components/tasks/project-icon'
 import { ColorPicker } from '@/components/tasks/color-picker'
 import { StatusEditor } from '@/components/tasks/status-editor'
+import { DeleteProjectDialog } from '@/components/tasks/delete-project-dialog'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
 import {
@@ -152,6 +153,7 @@ const ProjectModalDialog = ({
 
   // Unsaved changes dialog
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false)
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
 
   // Check for unsaved changes
   const hasUnsavedChanges = useMemo(
@@ -214,9 +216,17 @@ const ProjectModalDialog = ({
   }
 
   const handleDelete = (): void => {
+    setShowDeleteDialog(true)
+  }
+
+  const handleConfirmDelete = (): void => {
     if (onDelete && project) {
       onDelete(project.id)
     }
+    // Close like handleSave does. Call sites only run the mutation + toast;
+    // without this the modal stayed open on top of the "Project deleted" toast,
+    // still editing a project that no longer exists.
+    onClose()
   }
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
@@ -405,6 +415,13 @@ const ProjectModalDialog = ({
       </Dialog>
 
       {/* Unsaved Changes Confirmation */}
+      <DeleteProjectDialog
+        isOpen={showDeleteDialog}
+        onClose={() => setShowDeleteDialog(false)}
+        onConfirm={handleConfirmDelete}
+        project={project ?? null}
+      />
+
       <AlertDialog open={showUnsavedDialog} onOpenChange={setShowUnsavedDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/apps/docs/src/user-guide/projects.md
+++ b/apps/docs/src/user-guide/projects.md
@@ -6,7 +6,7 @@ Projects group tasks under a custom status workflow.
 
 ## Project Tree
 
-Projects appear in the sidebar with incomplete-task counts. Drag to reorder. Use the right-click context menu to rename, recolor, change icon, or delete.
+Projects appear in the sidebar with incomplete-task counts. Drag to reorder. Use a project's edit gear to rename, recolor, change icon, or delete.
 
 ## Creating a Project
 
@@ -102,13 +102,9 @@ Files and calendar events, which have no frontmatter, show small **project chips
 
 ## Deleting a Project
 
-Deleting asks you to choose what to do with the tasks:
+Open the project in the edit modal and use **Delete Project** in the footer. A confirmation dialog names the project, tells you how many tasks go with it, and states that the action cannot be undone. Cancel leaves everything untouched; confirming deletes the project and closes the modal.
 
-- **Move to another project** — pick from the project list
-- **Move to no project** — keep the tasks, drop the project assignment
-- **Delete with project** — destructive; tasks go too
-
-Each path is reversible via undo within the 10-second window.
+**The project's tasks are deleted with it.** There is no move-the-tasks-elsewhere option, and the deletion is not undoable — move any tasks you want to keep to another project before deleting.
 
 Linked **notes, events, and files are never deleted** with a project — only the project's tasks and its links are removed. Your notes, events, and files stay in your vault and simply lose the project link, so a project is safe to delete without losing the material collected under it.
 


### PR DESCRIPTION
Reported by Aurelie, 8 Aug 2026, v2026-08-07.2: deleting a project shows the "Project deleted" toast, the delete really happens, and the modal stays open.

## Root cause

`ProjectModal.handleDelete` called `onDelete(project.id)` and stopped. Its sibling `handleSave` does `onSave(...)` then `onClose()`. Neither call site closes it either — `pages/tasks.tsx` and `components/app-sidebar.tsx` only run the mutation and show the toast. So nobody closed the modal, and it kept editing a project that no longer existed.

Fix: `onClose()` in the delete path. One place, both call sites.

## Second finding, fixed here too

`DeleteProjectDialog` was dead in production — its only importer was `missing-small-components.test.tsx`. Project delete was a single click on the modal footer, no confirmation, on a cascade delete. It is now wired: the footer button opens the confirm, which names the project, states the task count, and warns that the action cannot be undone.

The dialog's move-vs-delete radio group is removed. Main's `deleteProject` cascades the project's tasks away and there is no move-tasks-to-Personal path behind it, so the choice promised a task rescue that never happens. Adding that rescue means an IPC contract change plus sync-correct bulk task reassignment (field-level vector clocks) — worth doing, but not smuggled into a bug fix.

## Docs

`user-guide/projects.md` documented the move-tasks choice as if it shipped, and a sidebar right-click delete menu. `NavProjects` has no importer and its menu items have no handlers. Both corrected.

## Verification

- Mutation test: removing `onClose()` turns the new test red (`expected "vi.fn()" to be called 1 times, but got 0 times`); restoring it turns it green.
- `project-modal.test.tsx` + `missing-small-components.test.tsx` + `pages/tasks.test.tsx` — 31 passed
- `typecheck:web`, `typecheck:test` (node + web), `eslint` (no cache), `i18n:check`, `git diff --check` — all clean
- `docs:impact --strict` — covered; `docs:build` — complete

Not verified in a running app; jsdom only.