### PR TITLE
feat(notes): heading links — resolve them, scroll to them, and write them

### DIFF
--- a/apps/desktop/src/main/vault/frontmatter.test.ts
+++ b/apps/desktop/src/main/vault/frontmatter.test.ts
@@ -163,6 +163,23 @@ describe('frontmatter utilities', () => {
     expect(links).toEqual(['Same Note', 'Other'])
   })
 
+  // A15: the whole `Note#Heading` string used to go in as a title, resolved to
+  // nothing, and the note it named never listed the link as a backlink.
+  it('extractWikiLinks indexes a heading link under its note', () => {
+    const links = extractWikiLinks('See [[Meeting#Decisions]]')
+    expect(links).toEqual(['Meeting'])
+  })
+
+  it('extractWikiLinks collapses heading links onto the note they share', () => {
+    const links = extractWikiLinks('[[Meeting#Decisions]] and [[Meeting#Actions]] and [[Meeting]]')
+    expect(links).toEqual(['Meeting'])
+  })
+
+  it('extractWikiLinks ignores a same-note heading link', () => {
+    const links = extractWikiLinks('Jump to [[#Decisions]] and see [[Other]]')
+    expect(links).toEqual(['Other'])
+  })
+
   it('extractTags trims and preserves case', () => {
     const frontmatter: NoteFrontmatter = {
       id: 'abc123def456',

--- a/apps/desktop/src/main/vault/frontmatter.ts
+++ b/apps/desktop/src/main/vault/frontmatter.ts
@@ -15,6 +15,7 @@ import {
 } from '@memry/app-core/markdown'
 import { generateNoteId, isValidNoteId } from '../lib/id'
 import { isRelationValue } from '@memry/contracts/relation-uri'
+import { splitWikiTarget } from '@memry/shared/wiki-target'
 
 // ============================================================================
 // Types
@@ -214,6 +215,20 @@ export function validateNoteId(id: string): boolean {
  * Extract all wiki-style links from markdown content.
  * Matches [[Link Title]] and [[Link Title|Display Text]] patterns.
  *
+ * `[[Note#Heading]]` yields `Note`: this table answers "which notes does this
+ * note point at", and a heading link points at the note. Before that, the whole
+ * string went in as a title, resolved to nothing, and the note it named never
+ * listed the link as a backlink. The graph view has always read these targets
+ * this way (`wikilinks` in @memry/app-core/graph), so this makes the two link
+ * pipelines agree rather than introducing a second reading.
+ *
+ * The cost is the `Sprint #4` case: a note really called that is indexed here
+ * under `Sprint`. Navigation and hover still reach it — they fall back to the
+ * raw title against the database, which this function has no access to.
+ *
+ * Existing vaults keep their old rows until each note is next projected; no
+ * reindex is forced for a backlink row.
+ *
  * @param content - Markdown content
  * @returns Array of link targets
  */
@@ -223,7 +238,10 @@ export function extractWikiLinks(content: string): string[] {
   let match
 
   while ((match = linkPattern.exec(content)) !== null) {
-    links.add(match[1].trim())
+    const { note, heading } = splitWikiTarget(match[1])
+    // `[[#Heading]]` addresses the note it sits in — a self-link, not an edge.
+    if (heading !== null && !note) continue
+    links.add(heading !== null ? note : match[1].trim())
   }
 
   return Array.from(links)

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -2647,6 +2647,13 @@ del.bn-inline-content {
   color: rgb(251, 191, 36) !important;
 }
 
+/* A wiki link opened for editing: the `[[` and `]]` are real characters the
+   user can delete, so they are dimmed rather than hidden — the text still reads
+   as a link without the brackets shouting. */
+.wiki-link-bracket {
+  opacity: 0.4;
+}
+
 /* Inline hash tag styles — needs .dark .bn-editor prefix to beat the wildcard rule */
 .dark .bn-editor .inline-hash-tag,
 .dark .bn-container .inline-hash-tag,

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders as render } from '@tests/utils/render'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
+import { WIKI_LINK_EDIT_PLUGIN_KEY } from './wiki-link-edit-plugin'
 
 const contentAreaMocks = vi.hoisted(() => ({
   editor: null as any,
@@ -27,6 +28,7 @@ const contentAreaMocks = vi.hoisted(() => ({
   toastError: vi.fn(),
   defaultFileItemClick: vi.fn(),
   openSuggestionMenu: vi.fn(),
+  registerPlugin: vi.fn(),
   createLinkMentionContent: vi.fn(
     (url: string, domain: string, title?: string, favicon?: string) => ({
       type: 'linkMention',
@@ -350,7 +352,9 @@ function resetEditor(): void {
     prosemirrorView: { focus: vi.fn(), dom: { blur: vi.fn() } },
     _tiptapEditor: {
       state: { selection: { empty: true, $from: { parentOffset: 0 } } },
-      destroy: vi.fn()
+      destroy: vi.fn(),
+      registerPlugin: contentAreaMocks.registerPlugin,
+      unregisterPlugin: vi.fn()
     }
   }
 }
@@ -834,6 +838,20 @@ describe('ContentArea', () => {
     await expect(slashController.getItems('photo')).resolves.toEqual([
       expect.objectContaining({ key: 'image' })
     ])
+  })
+
+  it('registers the wiki-link edit plugin, prepended, through the undo-safe wrapper', () => {
+    render(<ContentArea noteId="note-1" />)
+
+    const call = contentAreaMocks.registerPlugin.mock.calls.find(
+      ([plugin]) => plugin?.spec?.key === WIKI_LINK_EDIT_PLUGIN_KEY
+    )
+    expect(call).toBeDefined()
+
+    // Prepended, or the default Backspace keymap deletes the chip before the
+    // plugin ever sees the key.
+    const [plugin, handlePlugins] = call!
+    expect(handlePlugins(plugin, ['existing'])).toEqual([plugin, 'existing'])
   })
 
   it('offers a "link to note" slash item that hands over to the [[ menu', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -26,6 +26,7 @@ const contentAreaMocks = vi.hoisted(() => ({
   fetchLinkPreview: vi.fn(),
   toastError: vi.fn(),
   defaultFileItemClick: vi.fn(),
+  openSuggestionMenu: vi.fn(),
   createLinkMentionContent: vi.fn(
     (url: string, domain: string, title?: string, favicon?: string) => ({
       type: 'linkMention',
@@ -344,6 +345,7 @@ function resetEditor(): void {
       if ('props' in update) block.props = { ...block.props, ...(update.props as object) }
     }),
     insertBlocks: vi.fn(),
+    getExtension: vi.fn(() => ({ openSuggestionMenu: contentAreaMocks.openSuggestionMenu })),
     getTextCursorPosition: vi.fn(() => ({ block: urlBlock })),
     prosemirrorView: { focus: vi.fn(), dom: { blur: vi.fn() } },
     _tiptapEditor: {
@@ -832,6 +834,23 @@ describe('ContentArea', () => {
     await expect(slashController.getItems('photo')).resolves.toEqual([
       expect.objectContaining({ key: 'image' })
     ])
+  })
+
+  it('offers a "link to note" slash item that hands over to the [[ menu', async () => {
+    render(<ContentArea noteId="note-1" />)
+
+    const slashController = contentAreaMocks.suggestionControllers.find(
+      (controller) => controller.triggerCharacter === '/'
+    )
+    const items = await slashController.getItems('wikilink')
+    expect(items).toHaveLength(1)
+
+    items[0].onItemClick()
+    // Through the suggestion plugin's own opener, so `[[` reaches the doc with
+    // the plugin state that makes the wiki-link menu open.
+    expect(contentAreaMocks.openSuggestionMenu).toHaveBeenCalledWith('[[', {
+      deleteTriggerCharacter: true
+    })
   })
 
   it('debounces standalone checkbox conversion and clears pending conversion on unmount', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -13,6 +13,7 @@ import {
   type FilePanelProps,
   type SuggestionMenuProps
 } from '@blocknote/react'
+import { SuggestionMenu } from '@blocknote/core/extensions'
 import { BlockNoteView } from '@blocknote/shadcn'
 import { useTheme } from 'next-themes'
 import { AIMenuController, getAISlashMenuItems } from '@blocknote/xl-ai'
@@ -1364,12 +1365,29 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
                     }
                   ]
                 : []
+              // `/link` types `[[` for you and hands over to the wiki-link
+              // menu that trigger already owns — one search UI, one place `#`
+              // heading support lives, and the row teaches the shortcut. The
+              // trigger characters have to enter the doc through the suggestion
+              // plugin's own opener; inserting the text some other way leaves
+              // the plugin with no state and no menu.
+              const linkToNoteItem = {
+                title: t('editor.slashMenu.linkToNote.title'),
+                onItemClick: () =>
+                  editor
+                    .getExtension(SuggestionMenu)
+                    ?.openSuggestionMenu('[[', { deleteTriggerCharacter: true }),
+                aliases: ['link', 'wiki', 'wikilink', 'note', 'backlink'],
+                group: 'Basic blocks',
+                subtext: t('editor.slashMenu.linkToNote.subtext')
+              }
               const all = orderSlashMenuItemsByGroup([
                 ...defaults,
                 ...pdfItems,
                 calloutItem,
                 ...(taskItem ? [taskItem] : []),
                 ...dateItems,
+                linkToNoteItem,
                 ...aiItems
               ])
               if (!query) return all

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -712,7 +712,17 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
   // a heading can be typed into it. Prepended for the same reason as above: the
   // default Backspace keymap would delete the chip before we saw the key.
   useEffect(() => {
-    return registerEditorPlugin(editor, createWikiLinkEditPlugin(), (p, plugins) => [p, ...plugins])
+    const plugin = createWikiLinkEditPlugin({
+      // `deleteTriggerCharacter: false` because the `[[` is already in the
+      // document — the slash item above passes `true` precisely because there it
+      // is not. Without this the heading picker is unreachable from the path
+      // users actually take: pick a note from the dropdown, then try to add `#`.
+      openMenu: () =>
+        editor.getExtension(SuggestionMenu)?.openSuggestionMenu('[[', {
+          deleteTriggerCharacter: false
+        })
+    })
+    return registerEditorPlugin(editor, plugin, (p, plugins) => [p, ...plugins])
   }, [editor])
 
   // `@` quick-insert menu: a Date group (date + remind) when the query parses

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -88,6 +88,7 @@ import {
   isDateMentionActive,
   dateMentionHasGhostFill
 } from './date-mention-ghost-plugin'
+import { createWikiLinkEditPlugin } from './wiki-link-edit-plugin'
 import { useFiredDatePillAnchors, useTriggeredDatePills } from './use-triggered-date-pills'
 import { useDateMentionPrefs } from '@/hooks/use-date-mention-prefs'
 import { DateMentionPopover, type DateMentionValue } from './date-mention-popover'
@@ -706,6 +707,13 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     const plugin = createDateMentionGhostPlugin({ onAcceptPill: insertDatePillAtRange })
     return registerEditorPlugin(editor, plugin, (p, plugins) => [p, ...plugins])
   }, [editor, insertDatePillAtRange])
+
+  // Backspace/ArrowLeft next to a wiki-link chip opens it as raw `[[…]]` text so
+  // a heading can be typed into it. Prepended for the same reason as above: the
+  // default Backspace keymap would delete the chip before we saw the key.
+  useEffect(() => {
+    return registerEditorPlugin(editor, createWikiLinkEditPlugin(), (p, plugins) => [p, ...plugins])
+  }, [editor])
 
   // `@` quick-insert menu: a Date group (date + remind) when the query parses
   // as a date, plus recent notes (insert as wiki links). The bound menu is

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx
@@ -37,6 +37,26 @@ vi.mock('@/lib/url-metadata', () => ({
   })
 }))
 
+/**
+ * The smallest ProseMirror-shaped state `isEditingWikiLinkText` can read: one
+ * text block and a collapsed caret at `offset`. Enough to say whether the caret
+ * is inside a raw `[[…]]` run, which is the only question asked of it here.
+ */
+function caretState(text: string, offset: number): any {
+  const parent = {
+    isTextblock: true,
+    type: { spec: {} },
+    content: { size: text.length },
+    textBetween: () => text
+  }
+  return {
+    selection: {
+      empty: true,
+      $from: { parent, parentOffset: offset, start: () => 1 }
+    }
+  }
+}
+
 function createEditor(parsedBlocks: any[] = []) {
   let document = [{ id: 'initial', type: 'paragraph', props: {}, content: [], children: [] }]
   const transact = vi.fn((callback: (tr: any) => unknown) => {
@@ -189,6 +209,47 @@ describe('useEditorSync', () => {
     await waitFor(() =>
       expect(editor.updateBlock).toHaveBeenCalledWith(nestedMention, expect.anything())
     )
+  })
+
+  it('does not promote the wiki link the caret is inside, and promotes the others', async () => {
+    const editor = createEditor() as any
+    const { result } = renderHook(() =>
+      useEditorSync({ editor, initialContent: '', contentType: 'markdown' })
+    )
+    await waitFor(() => expect(result.current.isContentReadyRef.current).toBe(true))
+
+    editor.replaceBlocks(
+      [],
+      [
+        {
+          id: 'editing',
+          type: 'paragraph',
+          props: {},
+          content: 'Read [[Daily Note]]',
+          children: []
+        }
+      ]
+    )
+    editor.replaceBlocks.mockClear()
+
+    // Caret inside the run: a whole-document replace here would yank the text
+    // out from under it mid-edit (`wiki-link-edit-plugin.ts`).
+    editor.getTextCursorPosition = vi.fn(() => ({ block: { id: 'editing' } }))
+    editor._tiptapEditor.state = caretState('Read [[Daily Note]]', 10)
+    act(() => {
+      result.current.handleChange()
+    })
+    expect(editor.replaceBlocks).not.toHaveBeenCalled()
+
+    // Caret in the same block but OUTSIDE the brackets: the exemption is the
+    // link run, not the block the user happens to be standing in. A hand-typed
+    // `[[Note]]` still becomes a chip the moment it is complete.
+    editor._tiptapEditor.state = caretState('Read [[Daily Note]]', 0)
+    act(() => {
+      result.current.handleChange()
+    })
+    expect(editor.replaceBlocks).toHaveBeenCalledTimes(1)
+    expect(JSON.stringify(editor.document)).toContain('wikiLink')
   })
 
   it('does not mark markdown content ready when parsing fails', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
@@ -21,9 +21,33 @@ import { fetchLinkPreview } from '@/lib/url-metadata'
 import type { HeadingInfo, InlineTagsOrigin } from '../types'
 import { createLogger } from '@/lib/logger'
 import { trackRendererError } from '@/lib/telemetry-diagnostics'
+import { isEditingWikiLinkText } from '../wiki-link-edit-plugin'
 
 const log = createLogger('Hook:EditorSync')
 const activeNoteEditors = new Map<string, any>()
+
+/**
+ * The block to exempt from wiki-link promotion, or undefined when there is none.
+ *
+ * Narrow on purpose: ONLY while the caret sits inside a raw `[[…]]` run that the
+ * user is editing (`wiki-link-edit-plugin.ts`). Exempting the caret's block
+ * unconditionally would also stop a hand-typed `[[Note]]` from becoming a chip
+ * until the caret left the block — that promotion is immediate today and there
+ * is no reason for this to change it.
+ *
+ * Every lookup is defensive. BlockNote throws rather than returning null when the
+ * selection is not in a block with content (an image block, a fresh editor), and
+ * a normalization pass is not the place to care.
+ */
+function editingWikiLinkBlockId(editor: any): string | undefined {
+  const state = editor?._tiptapEditor?.state
+  if (!state || !isEditingWikiLinkText(state)) return undefined
+  try {
+    return editor.getTextCursorPosition?.()?.block?.id as string | undefined
+  } catch {
+    return undefined
+  }
+}
 
 function replaceInitialBlocksWithoutHistory(editor: any, blocks: Block[]): void {
   if (typeof editor.transact !== 'function') {
@@ -333,7 +357,12 @@ export function useEditorSync({
   const handleChange = useCallback(() => {
     const blocks = editor.document
 
-    const normalized = normalizeWikiLinks(blocks as Block[])
+    // The block under the caret is exempt from wiki-link promotion while the
+    // user is editing a link's raw `[[…]]` text — see `wiki-link-edit-plugin.ts`
+    // and `NormalizeWikiLinksOptions`.
+    const normalized = normalizeWikiLinks(blocks as Block[], {
+      skipBlockId: editingWikiLinkBlockId(editor)
+    })
     if (normalized.didChange) {
       editor.replaceBlocks(editor.document, normalized.blocks)
       return

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.test.tsx
@@ -249,7 +249,22 @@ describe('useWikiLinkSuggestions', () => {
 
       expect(mocks.getByPath).not.toHaveBeenCalled()
       expect(items.map((item) => item.type)).toEqual(['create'])
-      expect(items[0]).toMatchObject({ target: 'Daily#' })
+      // The row names the note that would actually be created, and the trailing
+      // `#` — a half-typed separator, not a heading — is dropped rather than
+      // written into the link as `[[Daily#]]`.
+      expect(items[0]).toMatchObject({ title: 'Daily', target: 'Daily' })
+    })
+
+    it('keeps a real heading on the create row while naming only the note', async () => {
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Daily#Standup')
+      })
+
+      expect(items.map((item) => item.type)).toEqual(['create'])
+      expect(items[0]).toMatchObject({ title: 'Daily', target: 'Daily#Standup' })
     })
 
     it('does not offer headings for a block reference', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.test.tsx
@@ -5,6 +5,7 @@ import { useWikiLinkSuggestions } from './use-wiki-link-suggestions'
 const mocks = vi.hoisted(() => ({
   listNotes: vi.fn(),
   getFile: vi.fn(),
+  getByPath: vi.fn(),
   logger: {
     error: vi.fn()
   }
@@ -13,7 +14,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/services/notes-service', () => ({
   notesService: {
     list: (...args: unknown[]) => mocks.listNotes(...args),
-    getFile: (...args: unknown[]) => mocks.getFile(...args)
+    getFile: (...args: unknown[]) => mocks.getFile(...args),
+    getByPath: (...args: unknown[]) => mocks.getByPath(...args)
   }
 }))
 
@@ -28,8 +30,18 @@ describe('useWikiLinkSuggestions', () => {
     vi.setSystemTime(new Date('2026-05-10T12:00:00.000Z'))
     mocks.listNotes.mockResolvedValue({
       notes: [
-        { id: 'note-1', title: 'Daily Note', modified: new Date('2026-05-09T00:00:00.000Z') },
-        { id: 'note-2', title: 'Roadmap', modified: '2026-05-08T00:00:00.000Z' }
+        {
+          id: 'note-1',
+          title: 'Daily Note',
+          path: 'notes/Daily Note.md',
+          modified: new Date('2026-05-09T00:00:00.000Z')
+        },
+        {
+          id: 'note-2',
+          title: 'Roadmap',
+          path: 'notes/Roadmap.md',
+          modified: '2026-05-08T00:00:00.000Z'
+        }
       ]
     })
   })
@@ -146,6 +158,185 @@ describe('useWikiLinkSuggestions', () => {
     })
     expect(editor.insertInlineContent).not.toHaveBeenCalled()
     expect(editor.insertBlocks).not.toHaveBeenCalled()
+  })
+
+  describe('# heading mode', () => {
+    const body = [
+      '# Daily Note',
+      '',
+      '## **Kararlar** alındı',
+      '',
+      '```md',
+      '## not a heading',
+      '```',
+      '',
+      '### Sonraki adımlar'
+    ].join('\n')
+
+    it('lists the target note headings once the note half matches exactly', async () => {
+      mocks.getByPath.mockResolvedValue({ content: body })
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Daily Note#')
+      })
+
+      // By path, so the id lookup's `note_opened` telemetry never fires.
+      expect(mocks.getByPath).toHaveBeenCalledWith('notes/Daily Note.md')
+      expect(items).toEqual([
+        {
+          id: 'heading:note-1:0',
+          title: 'Daily Note',
+          target: 'Daily Note#Daily Note',
+          alias: '',
+          exists: true,
+          type: 'heading',
+          headingLevel: 1
+        },
+        {
+          id: 'heading:note-1:1',
+          title: 'Kararlar alındı',
+          target: 'Daily Note#Kararlar alındı',
+          alias: '',
+          exists: true,
+          type: 'heading',
+          headingLevel: 2
+        },
+        {
+          id: 'heading:note-1:2',
+          title: 'Sonraki adımlar',
+          target: 'Daily Note#Sonraki adımlar',
+          alias: '',
+          exists: true,
+          type: 'heading',
+          headingLevel: 3
+        }
+      ])
+    })
+
+    it('filters headings, keeps the alias, and caches the body for 5 seconds', async () => {
+      mocks.getByPath.mockResolvedValue({ content: body })
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        await result.current.getWikiLinkItems('Daily Note#')
+        items = await result.current.getWikiLinkItems('Daily Note#Kararlar|dün')
+      })
+
+      expect(mocks.getByPath).toHaveBeenCalledTimes(1)
+      expect(items).toEqual([
+        {
+          id: 'heading:note-1:0',
+          title: 'Kararlar alındı',
+          target: 'Daily Note#Kararlar alındı',
+          alias: 'dün',
+          exists: true,
+          type: 'heading',
+          headingLevel: 2
+        }
+      ])
+    })
+
+    it('keeps listing notes while the note half is only a prefix', async () => {
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Daily#')
+      })
+
+      expect(mocks.getByPath).not.toHaveBeenCalled()
+      expect(items.map((item) => item.type)).toEqual(['create'])
+      expect(items[0]).toMatchObject({ target: 'Daily#' })
+    })
+
+    it('does not offer headings for a block reference', async () => {
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      await act(async () => {
+        await result.current.getWikiLinkItems('Daily Note#^abc123')
+      })
+
+      expect(mocks.getByPath).not.toHaveBeenCalled()
+    })
+
+    it('says so when the note has no headings, and when none match', async () => {
+      mocks.getByPath.mockResolvedValue({ content: 'Just a paragraph.' })
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      let empty = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        empty = await result.current.getWikiLinkItems('Daily Note#')
+      })
+      expect(empty).toEqual([
+        {
+          id: 'headings:note-1',
+          title: 'Daily Note',
+          target: '',
+          alias: '',
+          exists: true,
+          type: 'headingEmpty',
+          filtered: false
+        }
+      ])
+
+      vi.setSystemTime(new Date('2026-05-10T12:00:06.000Z'))
+      mocks.getByPath.mockResolvedValue({ content: body })
+
+      let noMatch = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        noMatch = await result.current.getWikiLinkItems('Daily Note#zzz')
+      })
+      expect(noMatch).toEqual([
+        {
+          id: 'headings:note-1',
+          title: 'Daily Note',
+          target: '',
+          alias: '',
+          exists: true,
+          type: 'headingEmpty',
+          filtered: true
+        }
+      ])
+    })
+
+    it('logs and shows the empty row when the body cannot be read', async () => {
+      mocks.getByPath.mockRejectedValueOnce(new Error('read failed'))
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Daily Note#')
+      })
+
+      expect(mocks.logger.error).toHaveBeenCalledWith(
+        'Failed to load wiki link heading suggestions',
+        expect.any(Error)
+      )
+      expect(items).toEqual([expect.objectContaining({ type: 'headingEmpty' })])
+    })
+
+    it('inserts one wiki link node carrying the note#heading target', async () => {
+      mocks.getByPath.mockResolvedValue({ content: body })
+      const editor = { insertInlineContent: vi.fn() }
+      const { result } = renderHook(() => useWikiLinkSuggestions(editor))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Daily Note#Kararlar|dün')
+      })
+      await act(async () => {
+        await result.current.handleWikiLinkSelect(items[0])
+      })
+
+      expect(editor.insertInlineContent).toHaveBeenNthCalledWith(
+        1,
+        [{ type: 'wikiLink', props: { target: 'Daily Note#Kararlar alındı', alias: 'dün' } }],
+        { updateSelection: true }
+      )
+    })
   })
 
   it('refreshes stale cache and falls back to create suggestions on list failures', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.ts
@@ -8,6 +8,7 @@ import { toMemryFileUrl } from '@/lib/memry-file-url'
 import { notesService } from '@/services/notes-service'
 import { createWikiLinkInlineContent } from '../wiki-link'
 import { parseWikiLinkQuery } from '../wiki-link-utils'
+import { replaceActiveRunWithWikiLink } from '../wiki-link-edit-plugin'
 import type { WikiLinkSuggestionItem } from '../wiki-link-menu'
 import { createLogger } from '@/lib/logger'
 
@@ -170,14 +171,23 @@ export function useWikiLinkSuggestions(editor: any) {
         : true
 
       if (search && !hasExactMatch) {
-        suggestions.push({
-          id: `create:${search}`,
-          title: search,
-          target: search,
-          alias,
-          exists: false,
-          type: 'create'
-        })
+        // The row names the note that will actually be created, which is the
+        // note half — `resolveWikiLink` never mints a filename carrying a `#`.
+        // A trailing `#` with nothing after it is a half-typed separator rather
+        // than a heading, so it is dropped from the link text too instead of
+        // being written to the file as `[[tokyo tip#]]`.
+        const createTitle = heading !== null ? notePart : search
+        const createTarget = heading ? search : createTitle
+        if (createTitle) {
+          suggestions.push({
+            id: `create:${createTitle}`,
+            title: createTitle,
+            target: createTarget,
+            alias,
+            exists: false,
+            type: 'create'
+          })
+        }
       }
 
       return suggestions
@@ -188,9 +198,16 @@ export function useWikiLinkSuggestions(editor: any) {
   const insertWikiLink = useCallback(
     (item: WikiLinkSuggestionItem) => {
       if (!item.target) return
-      editor.insertInlineContent([createWikiLinkInlineContent(item.target, item.alias ?? '')], {
-        updateSelection: true
-      })
+
+      const content = createWikiLinkInlineContent(item.target, item.alias ?? '')
+
+      // Editing an existing link: the menu's `clearQuery` removed the query text
+      // but left the `[[` and `]]` around it, so inserting here would produce
+      // `[[<chip>]]`. Replace the whole run instead. Also no trailing space —
+      // that belongs to the from-scratch path, where the user is still writing.
+      if (replaceActiveRunWithWikiLink(editor, content.props)) return
+
+      editor.insertInlineContent([content], { updateSelection: true })
       editor.insertInlineContent([' '], { updateSelection: true })
     },
     [editor]

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.ts
@@ -1,19 +1,24 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { useCallback, useRef } from 'react'
+import { extractMarkdownHeadings, type MarkdownHeading } from '@memry/shared/markdown-headings'
+import { isBlockReference } from '@memry/shared/wiki-target'
 import { fuzzySearch } from '@/lib/fuzzy-search'
 import { toMemryFileUrl } from '@/lib/memry-file-url'
 import { notesService } from '@/services/notes-service'
 import { createWikiLinkInlineContent } from '../wiki-link'
-import { splitWikiLinkQuery } from '../wiki-link-utils'
+import { parseWikiLinkQuery } from '../wiki-link-utils'
 import type { WikiLinkSuggestionItem } from '../wiki-link-menu'
 import { createLogger } from '@/lib/logger'
 
 const log = createLogger('Hook:WikiLinkSuggestions')
 
+const CACHE_TTL_MS = 5000
+
 type NoteSuggestion = {
   id: string
   title: string
+  path: string
   modified?: Date | string
   fileType?: 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
   mimeType?: string | null
@@ -46,66 +51,139 @@ function createAudioFileBlockContent(props: {
 
 export function useWikiLinkSuggestions(editor: any) {
   const notesCacheRef = useRef<{ notes: NoteSuggestion[]; fetchedAt: number } | null>(null)
+  // Headings have no index in either database, so `#` reads the target note's
+  // body on demand. Cached per note, same 5s window as the note list.
+  const headingsCacheRef = useRef(
+    new Map<string, { headings: MarkdownHeading[]; fetchedAt: number }>()
+  )
 
-  const getWikiLinkItems = useCallback(async (query: string): Promise<WikiLinkSuggestionItem[]> => {
-    const now = Date.now()
-    const cache = notesCacheRef.current
-    const shouldRefresh = !cache || now - cache.fetchedAt > 5000
-    if (shouldRefresh) {
+  const loadHeadings = useCallback(
+    async (note: NoteSuggestion, now: number): Promise<MarkdownHeading[]> => {
+      const cached = headingsCacheRef.current.get(note.id)
+      if (cached && now - cached.fetchedAt <= CACHE_TTL_MS) return cached.headings
+
+      let headings: MarkdownHeading[] = []
       try {
-        const result = await notesService.list({ limit: 500, sortBy: 'modified' })
-        notesCacheRef.current = {
-          notes: result.notes.map((note) => ({
-            id: note.id,
-            title: note.title,
-            modified: note.modified,
-            fileType: note.fileType,
-            mimeType: note.mimeType,
-            fileSize: note.fileSize
-          })),
-          fetchedAt: now
-        }
+        // By path, not by id: `notes:get` counts as opening the note and emits
+        // `note_opened`, and typing `#` in someone else's link is not that.
+        const full = note.path ? await notesService.getByPath(note.path) : null
+        headings = full?.content ? extractMarkdownHeadings(full.content) : []
       } catch (error) {
-        log.error('Failed to load wiki link suggestions', error)
-        notesCacheRef.current = { notes: [], fetchedAt: now }
+        log.error('Failed to load wiki link heading suggestions', error)
       }
-    }
 
-    const notes = notesCacheRef.current?.notes ?? []
-    const { search, alias } = splitWikiLinkQuery(query)
-    const filtered = search ? fuzzySearch(notes, search, ['title']) : notes
-    const sorted = filtered.slice(0, 10)
+      headingsCacheRef.current.set(note.id, { headings, fetchedAt: now })
+      return headings
+    },
+    []
+  )
 
-    const suggestions: WikiLinkSuggestionItem[] = sorted.map((note) => ({
-      id: note.id,
-      title: note.title,
-      target: note.title,
-      alias,
-      exists: true,
-      type: 'note',
-      lastEdited: note.modified instanceof Date ? note.modified.toISOString() : note.modified,
-      ...(note.fileType && note.fileType !== 'markdown' ? { fileType: note.fileType } : {}),
-      ...(note.mimeType ? { mimeType: note.mimeType } : {}),
-      ...(note.fileSize != null ? { fileSize: note.fileSize } : {})
-    }))
+  const getWikiLinkItems = useCallback(
+    async (query: string): Promise<WikiLinkSuggestionItem[]> => {
+      const now = Date.now()
+      const cache = notesCacheRef.current
+      const shouldRefresh = !cache || now - cache.fetchedAt > CACHE_TTL_MS
+      if (shouldRefresh) {
+        try {
+          const result = await notesService.list({ limit: 500, sortBy: 'modified' })
+          notesCacheRef.current = {
+            notes: result.notes.map((note) => ({
+              id: note.id,
+              title: note.title,
+              path: note.path,
+              modified: note.modified,
+              fileType: note.fileType,
+              mimeType: note.mimeType,
+              fileSize: note.fileSize
+            })),
+            fetchedAt: now
+          }
+        } catch (error) {
+          log.error('Failed to load wiki link suggestions', error)
+          notesCacheRef.current = { notes: [], fetchedAt: now }
+        }
+      }
 
-    const hasExactMatch = search
-      ? filtered.some((note) => note.title.toLowerCase() === search.toLowerCase())
-      : true
+      const notes = notesCacheRef.current?.notes ?? []
+      const { search, note: notePart, heading, alias } = parseWikiLinkQuery(query)
 
-    if (search && !hasExactMatch) {
-      suggestions.push({
-        id: `create:${search}`,
-        title: search,
-        target: search,
+      // `#` is a separator, not a trigger. It switches the menu to the note's
+      // headings only once the note half names a note EXACTLY — `[[Topl#` still
+      // lists notes, `[[Toplantı#` lists Toplantı's headings — which is also what
+      // keeps `[[Sprint #4]]` (a real title) reaching the note list. Backspacing
+      // over the `#` needs no unwinding: the query is re-parsed on every keystroke.
+      // Block references (`#^id`) are not a heading Memry can offer, so they fall
+      // through to the note list rather than showing an empty heading menu.
+      const headingTarget =
+        heading !== null && !isBlockReference(heading)
+          ? notes.find((note) => note.title.toLowerCase() === notePart.toLowerCase())
+          : undefined
+
+      if (headingTarget) {
+        const headings = await loadHeadings(headingTarget, now)
+        const matches = heading ? fuzzySearch(headings, heading, ['text']) : headings
+
+        if (matches.length === 0) {
+          return [
+            {
+              id: `headings:${headingTarget.id}`,
+              title: headingTarget.title,
+              target: '',
+              alias,
+              exists: true,
+              type: 'headingEmpty',
+              filtered: headings.length > 0
+            }
+          ]
+        }
+
+        return matches.slice(0, 10).map((match, index) => ({
+          id: `heading:${headingTarget.id}:${index}`,
+          title: match.text,
+          // One raw string, exactly as a hand-typed link would be written.
+          target: `${headingTarget.title}#${match.text}`,
+          alias,
+          exists: true,
+          type: 'heading',
+          headingLevel: match.level
+        }))
+      }
+
+      const filtered = search ? fuzzySearch(notes, search, ['title']) : notes
+      const sorted = filtered.slice(0, 10)
+
+      const suggestions: WikiLinkSuggestionItem[] = sorted.map((note) => ({
+        id: note.id,
+        title: note.title,
+        target: note.title,
         alias,
-        exists: false,
-        type: 'create'
-      })
-    }
+        exists: true,
+        type: 'note',
+        lastEdited: note.modified instanceof Date ? note.modified.toISOString() : note.modified,
+        ...(note.fileType && note.fileType !== 'markdown' ? { fileType: note.fileType } : {}),
+        ...(note.mimeType ? { mimeType: note.mimeType } : {}),
+        ...(note.fileSize != null ? { fileSize: note.fileSize } : {})
+      }))
 
-    return suggestions
-  }, [])
+      const hasExactMatch = search
+        ? filtered.some((note) => note.title.toLowerCase() === search.toLowerCase())
+        : true
+
+      if (search && !hasExactMatch) {
+        suggestions.push({
+          id: `create:${search}`,
+          title: search,
+          target: search,
+          alias,
+          exists: false,
+          type: 'create'
+        })
+      }
+
+      return suggestions
+    },
+    [loadHeadings]
+  )
 
   const insertWikiLink = useCallback(
     (item: WikiLinkSuggestionItem) => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.test.ts
@@ -1,0 +1,236 @@
+/**
+ * The un-promote/re-promote round trip, driven through a real ProseMirror state.
+ *
+ * A hand-built schema rather than BlockNote's: the plugin only ever asks for a
+ * `wikiLink` node type, the mark types it carries, and text — and a real state
+ * is what makes `appendTransaction` (the re-promotion) run for real, which is
+ * the half no assertion on a helper could reach.
+ */
+
+import { Schema } from '@tiptap/pm/model'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import { EditorState, TextSelection } from '@tiptap/pm/state'
+import type { Transaction } from '@tiptap/pm/state'
+import { describe, expect, it } from 'vitest'
+import {
+  createWikiLinkEditPlugin,
+  findWikiLinkRunAt,
+  isEditingWikiLinkText
+} from './wiki-link-edit-plugin'
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*', toDOM: () => ['p', 0] },
+    wikiLink: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {
+        target: { default: '' },
+        alias: { default: '' },
+        bold: { default: false },
+        textColor: { default: 'default' }
+      },
+      toDOM: () => ['span']
+    },
+    text: { group: 'inline' }
+  },
+  marks: {
+    bold: { toDOM: () => ['strong', 0] },
+    textColor: { attrs: { stringValue: { default: 'default' } }, toDOM: () => ['span', 0] }
+  }
+})
+
+function stateWith(nodes: ProseMirrorNode[], cursorAt: number): EditorState {
+  const doc = schema.node('doc', null, [schema.node('paragraph', null, nodes)])
+  const state = EditorState.create({ doc, plugins: [createWikiLinkEditPlugin()] })
+  return state.apply(state.tr.setSelection(TextSelection.create(state.doc, cursorAt)))
+}
+
+function chip(attrs: Record<string, unknown>): ProseMirrorNode {
+  return schema.node('wikiLink', attrs)
+}
+
+/** A stand-in for `EditorView` carrying only what the plugin touches. */
+function viewOf(state: EditorState) {
+  const view = {
+    state,
+    dispatch(tr: Transaction) {
+      view.state = view.state.apply(tr)
+    }
+  }
+  return view
+}
+
+function keyDown(state: EditorState, key: string, modifiers: Partial<KeyboardEvent> = {}) {
+  const plugin = createWikiLinkEditPlugin()
+  const view = viewOf(state)
+  const handled = plugin.props.handleKeyDown!.call(
+    plugin,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    view as any,
+    { key, shiftKey: false, metaKey: false, ctrlKey: false, altKey: false, ...modifiers } as any
+  )
+  return { handled, state: view.state }
+}
+
+function paragraphText(state: EditorState): string {
+  return state.doc.firstChild!.textBetween(0, state.doc.firstChild!.content.size, undefined, '￼')
+}
+
+function firstWikiLink(state: EditorState): ProseMirrorNode | null {
+  let found: ProseMirrorNode | null = null
+  state.doc.descendants((node) => {
+    if (!found && node.type.name === 'wikiLink') found = node
+  })
+  return found
+}
+
+describe('findWikiLinkRunAt', () => {
+  it('finds the run the offset is strictly inside', () => {
+    //          0123456789
+    const text = 'a [[Note]] b'
+    expect(findWikiLinkRunAt(text, 5)).toEqual({ start: 2, end: 10 })
+    expect(findWikiLinkRunAt(text, 3)).toEqual({ start: 2, end: 10 })
+    expect(findWikiLinkRunAt(text, 9)).toEqual({ start: 2, end: 10 })
+  })
+
+  it('treats both outer edges as outside, which is what re-promotes the run', () => {
+    const text = 'a [[Note]] b'
+    expect(findWikiLinkRunAt(text, 2)).toBeNull()
+    expect(findWikiLinkRunAt(text, 10)).toBeNull()
+  })
+
+  it('handles targets with spaces, headings and aliases', () => {
+    const text = '[[Toplantı Notları#Kararlar|dün]]'
+    expect(findWikiLinkRunAt(text, 20)).toEqual({ start: 0, end: text.length })
+  })
+
+  it('finds nothing in unbracketed or half-deleted text', () => {
+    expect(findWikiLinkRunAt('[[Note', 3)).toBeNull()
+    expect(findWikiLinkRunAt('Note]]', 3)).toBeNull()
+    expect(findWikiLinkRunAt('plain text', 3)).toBeNull()
+  })
+
+  it('picks the run the caret is in when a block holds several', () => {
+    const text = '[[A]] and [[B]]'
+    expect(findWikiLinkRunAt(text, 2)).toEqual({ start: 0, end: 5 })
+    expect(findWikiLinkRunAt(text, 12)).toEqual({ start: 10, end: 15 })
+    expect(findWikiLinkRunAt(text, 7)).toBeNull()
+  })
+})
+
+describe('wiki-link edit plugin', () => {
+  it('un-promotes the chip before the caret on Backspace, caret before the `]]`', () => {
+    const { handled, state } = keyDown(stateWith([chip({ target: 'Toplantı' })], 2), 'Backspace')
+
+    expect(handled).toBe(true)
+    expect(paragraphText(state)).toBe('[[Toplantı]]')
+    expect(firstWikiLink(state)).toBeNull()
+    // `[[Toplantı]]` is 12 characters; the caret sits at 10, before the `]]`.
+    expect(state.selection.from).toBe(1 + 10)
+  })
+
+  it('un-promotes on ArrowLeft too', () => {
+    const { handled, state } = keyDown(stateWith([chip({ target: 'Toplantı' })], 2), 'ArrowLeft')
+
+    expect(handled).toBe(true)
+    expect(paragraphText(state)).toBe('[[Toplantı]]')
+  })
+
+  it('leaves modified keys alone', () => {
+    for (const modifiers of [{ shiftKey: true }, { altKey: true }, { metaKey: true }]) {
+      const { handled } = keyDown(stateWith([chip({ target: 'A' })], 2), 'ArrowLeft', modifiers)
+      expect(handled).toBe(false)
+    }
+  })
+
+  it('does nothing when the node before the caret is not a wiki link', () => {
+    const { handled } = keyDown(stateWith([schema.text('plain')], 6), 'Backspace')
+    expect(handled).toBe(false)
+  })
+
+  it('round-trips an alias: open, edit, and close back into one chip', () => {
+    const opened = keyDown(stateWith([chip({ target: 'A', alias: 'B' })], 2), 'Backspace').state
+    expect(paragraphText(opened)).toBe('[[A|B]]')
+    // The caret lands at the end of the TARGET, not after the alias, so a typed
+    // `#` names a heading rather than becoming part of the alias.
+    expect(opened.selection.from).toBe(1 + 3)
+
+    const typed = opened.apply(opened.tr.insertText('#Kararlar', opened.selection.from))
+    expect(paragraphText(typed)).toBe('[[A#Kararlar|B]]')
+    expect(firstWikiLink(typed)).toBeNull()
+
+    // Move the caret out of the run: the plugin's appendTransaction closes it.
+    const closed = typed.apply(
+      typed.tr.setSelection(TextSelection.create(typed.doc, typed.doc.content.size - 1))
+    )
+    const link = firstWikiLink(closed)
+    expect(link?.attrs).toMatchObject({ target: 'A#Kararlar', alias: 'B' })
+    expect(paragraphText(closed)).toBe('￼')
+  })
+
+  it('keeps the caret inside the run from promoting it', () => {
+    const opened = keyDown(stateWith([chip({ target: 'A' })], 2), 'Backspace').state
+    const typed = opened.apply(opened.tr.insertText('#H', opened.selection.from))
+
+    expect(isEditingWikiLinkText(typed)).toBe(true)
+    expect(firstWikiLink(typed)).toBeNull()
+    expect(paragraphText(typed)).toBe('[[A#H]]')
+  })
+
+  it('carries the chip marks out into the text and back in again', () => {
+    const opened = keyDown(
+      stateWith([chip({ target: 'A', bold: true, textColor: 'red' })], 2),
+      'Backspace'
+    ).state
+
+    const marks = opened.doc.resolve(3).marks()
+    expect(marks.map((mark) => mark.type.name).sort()).toEqual(['bold', 'textColor'])
+
+    const closed = opened.apply(
+      opened.tr.setSelection(TextSelection.create(opened.doc, opened.doc.content.size - 1))
+    )
+    expect(firstWikiLink(closed)?.attrs).toMatchObject({
+      target: 'A',
+      bold: true,
+      textColor: 'red'
+    })
+  })
+
+  it('leaves brackets the user deleted as prose instead of restoring the chip', () => {
+    const opened = keyDown(stateWith([chip({ target: 'A' })], 2), 'Backspace').state
+    // Delete the leading `[[` — a deliberate "this is not a link any more".
+    const stripped = opened.apply(opened.tr.delete(1, 3))
+    const moved = stripped.apply(
+      stripped.tr.setSelection(TextSelection.create(stripped.doc, stripped.doc.content.size - 1))
+    )
+
+    expect(firstWikiLink(moved)).toBeNull()
+    expect(paragraphText(moved)).toBe('A]]')
+  })
+
+  it('dims both bracket pairs while the caret is inside the run', () => {
+    const opened = keyDown(stateWith([chip({ target: 'A' })], 2), 'Backspace').state
+    const plugin = createWikiLinkEditPlugin()
+
+    const decorations = plugin.props.decorations!.call(plugin, opened)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const found = (decorations as any).find().map((d: any) => [d.from, d.to, d.type.attrs.class])
+
+    // `[[A]]` occupies 1..6, so the bracket pairs are 1..3 and 4..6.
+    expect(found).toEqual([
+      [1, 3, 'wiki-link-bracket'],
+      [4, 6, 'wiki-link-bracket']
+    ])
+  })
+
+  it('paints nothing once the caret leaves the run', () => {
+    const state = stateWith([schema.text('[[A]] tail')], 8)
+    const plugin = createWikiLinkEditPlugin()
+
+    expect(isEditingWikiLinkText(state)).toBe(false)
+    expect(plugin.props.decorations!.call(plugin, state)).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.test.ts
@@ -132,6 +132,40 @@ describe('wiki-link edit plugin', () => {
     expect(state.selection.from).toBe(1 + 10)
   })
 
+  // The bug this pins: the menu anchors its query window wherever the caret is
+  // when it opens. Opened at the END of the target, the query starts empty, so
+  // typing `#` yields the query `#`, the note half is empty, heading mode never
+  // engages and the picker reports "no notes found" for a note that plainly
+  // exists. Only the ORDER was wrong — the caret ends up in the same place
+  // either way, which is why every other assertion here stayed green.
+  it('opens the menu while the caret is still just after the `[[`', () => {
+    const caretAtOpen: number[] = []
+    const view = viewOf(stateWith([chip({ target: 'Toplantı' })], 2))
+    const plugin = createWikiLinkEditPlugin({
+      openMenu: () => caretAtOpen.push(view.state.selection.from)
+    })
+
+    plugin.props.handleKeyDown!.call(
+      plugin,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      view as any,
+      {
+        key: 'Backspace',
+        shiftKey: false,
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any
+    )
+
+    // Right after the `[[`, so the menu's query window starts where a
+    // hand-typed link's would.
+    expect(caretAtOpen).toEqual([1 + 2])
+    // And only then to the end of the target, which makes the query the target.
+    expect(view.state.selection.from).toBe(1 + 2 + 'Toplantı'.length)
+  })
+
   it('un-promotes on ArrowLeft too', () => {
     const { handled, state } = keyDown(stateWith([chip({ target: 'Toplantı' })], 2), 'ArrowLeft')
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.ts
@@ -1,0 +1,270 @@
+/**
+ * Editing a wiki link that is already a chip.
+ *
+ * The `[[` autocomplete can write `[[Note#Heading]]` from scratch, but the
+ * common path does not go that way: the user types `[[`, picks a note from the
+ * dropdown, and now a chip exists. The chip is an atom (`content: 'none'`,
+ * rendered `contenteditable="false"`), so the caret cannot get inside it, a `#`
+ * typed after it is a separate word, and one Backspace deletes the whole thing.
+ * There was no way to add a heading to a link you had just inserted.
+ *
+ * So editing UN-PROMOTES the chip back to its raw markdown — `[[Target]]`, or
+ * `[[Target|Alias]]` — with the caret at the end of the target, which is where
+ * a `#` belongs. From there it is plain text: spaces, `#`, anything, and the
+ * `[[` suggestion menu (which keys off exactly this text) works unchanged,
+ * heading mode included. When the caret leaves the run, the text becomes a chip
+ * again.
+ *
+ * Raw text rather than the `hashTag` shrink/extend-the-attribute pattern
+ * (`hash-tag-inline-plugin.ts`, still the precedent for HOW to intercept a key
+ * next to an inline node): that plugin absorbs characters by class,
+ * `[a-zA-Z0-9_\-/]`, which stops at the first space — and note titles and
+ * headings are mostly spaces.
+ *
+ * Two things this deliberately does not do:
+ * - Click is navigation, and stays navigation. Edit mode is keyboard-only.
+ * - The `[[` and `]]` are REAL characters here, so "ghost brackets" means a
+ *   decoration that dims them, not invented ones. Deleting them is allowed:
+ *   a user who removes the brackets is turning the link back into prose, which
+ *   is a legitimate thing to want.
+ *
+ * If the editor loses focus while a run is still raw, the run stays raw — and
+ * that is safe, because `[[Target]]` is exactly what the chip serializes to.
+ * The bytes on disk are identical either way, and opening the note promotes it.
+ */
+
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
+import type { EditorState, Transaction } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+import type { EditorView } from '@tiptap/pm/view'
+import type { Mark, Node as ProseMirrorNode, Schema } from '@tiptap/pm/model'
+import { parseWikiLinkText, wikiLinkToText } from './wiki-link'
+
+export const WIKI_LINK_EDIT_PLUGIN_KEY = new PluginKey('wikiLinkEdit')
+
+/** A leaf inline node counts as one character, so text offsets stay aligned. */
+const LEAF_PLACEHOLDER = '￼'
+
+const RAW_WIKI_LINK = /\[\[[^[\]]*\]\]/g
+
+/**
+ * The `[[…]]` run the offset sits INSIDE, or null.
+ *
+ * Strictly inside: an offset on either outer edge is a caret that has left the
+ * link, which is what turns the text back into a chip.
+ */
+export function findWikiLinkRunAt(
+  text: string,
+  offset: number
+): { start: number; end: number } | null {
+  const pattern = new RegExp(RAW_WIKI_LINK)
+  let match: RegExpExecArray | null
+
+  while ((match = pattern.exec(text)) !== null) {
+    const start = match.index
+    const end = start + match[0].length
+    if (offset > start && offset < end) return { start, end }
+    if (start > offset) break
+  }
+
+  return null
+}
+
+/**
+ * The chip's marks travel with it into the raw text and back.
+ *
+ * A wiki link carries its marks as PROPS (#1439 — BlockNote gives custom inline
+ * content no `styles` field), while the raw text carries them as ProseMirror
+ * marks, so the round trip has to translate. Every lookup is defensive: a mark
+ * this schema does not have is simply not carried, never a throw inside a
+ * keystroke handler.
+ */
+const BOOLEAN_MARKS = ['bold', 'italic', 'underline', 'strike', 'code'] as const
+const COLOR_MARKS = ['textColor', 'backgroundColor'] as const
+
+function marksFromProps(schema: Schema, attrs: Record<string, unknown>): Mark[] {
+  const marks: Mark[] = []
+
+  for (const name of BOOLEAN_MARKS) {
+    if (attrs[name] !== true) continue
+    const type = schema.marks[name]
+    if (type) marks.push(type.create())
+  }
+
+  for (const name of COLOR_MARKS) {
+    const value = attrs[name]
+    if (typeof value !== 'string' || value === '' || value === 'default') continue
+    const type = schema.marks[name]
+    if (type) marks.push(type.create({ stringValue: value }))
+  }
+
+  return marks
+}
+
+function propsFromMarks(marks: readonly Mark[]): Record<string, string | boolean> {
+  const props: Record<string, string | boolean> = {}
+
+  for (const mark of marks) {
+    const name = mark.type.name
+    if ((BOOLEAN_MARKS as readonly string[]).includes(name)) {
+      props[name] = true
+      continue
+    }
+    if ((COLOR_MARKS as readonly string[]).includes(name)) {
+      const value = (mark.attrs as { stringValue?: unknown } | undefined)?.stringValue
+      if (typeof value === 'string' && value !== '' && value !== 'default') props[name] = value
+    }
+  }
+
+  return props
+}
+
+function wikiLinkBeforeCursor(state: EditorState): { node: ProseMirrorNode; pos: number } | null {
+  const selection = state?.selection
+  if (!selection?.empty) return null
+
+  const $from = selection.$from
+  if ($from.parentOffset === 0) return null
+
+  const nodeBefore = $from.nodeBefore
+  if (nodeBefore?.type.name !== 'wikiLink') return null
+
+  return { node: nodeBefore, pos: $from.pos - nodeBefore.nodeSize }
+}
+
+/**
+ * The raw `[[…]]` run the caret is inside, in absolute document positions.
+ *
+ * Reads the selection defensively. This runs on the keystroke path and, through
+ * `isEditingWikiLinkText`, on every content change from `use-editor-sync` — where
+ * the editor may not have a ProseMirror selection at all yet. Throwing there
+ * would take the whole change handler down with it, so a state without a
+ * selection is simply "not editing a link".
+ */
+function activeRun(state: EditorState): { from: number; to: number } | null {
+  const selection = state?.selection
+  if (!selection?.empty) return null
+
+  const $from = selection.$from
+  const parent = $from.parent
+  if (!parent.isTextblock || parent.type.spec.code) return null
+
+  const text = parent.textBetween(0, parent.content.size, undefined, LEAF_PLACEHOLDER)
+  const run = findWikiLinkRunAt(text, $from.parentOffset)
+  if (!run) return null
+
+  return { from: $from.start() + run.start, to: $from.start() + run.end }
+}
+
+/**
+ * True when the caret is inside a raw `[[…]]` run — the state in which
+ * whole-document wiki-link normalization must leave this block alone. See
+ * `use-editor-sync.ts`, which would otherwise promote the run back into a chip
+ * on the very next keystroke, through a full-document `replaceBlocks` under a
+ * typing caret.
+ */
+export function isEditingWikiLinkText(state: EditorState): boolean {
+  return activeRun(state) !== null
+}
+
+function unpromote(state: EditorState, node: ProseMirrorNode, pos: number): Transaction | null {
+  const target = typeof node.attrs.target === 'string' ? node.attrs.target : ''
+  if (!target) return null
+
+  const alias = typeof node.attrs.alias === 'string' ? node.attrs.alias : ''
+  const text = wikiLinkToText(target, alias)
+
+  const tr = state.tr.replaceWith(
+    pos,
+    pos + node.nodeSize,
+    state.schema.text(text, marksFromProps(state.schema, node.attrs))
+  )
+  // At the END OF THE TARGET, which for `[[Target]]` is "just before the `]]`"
+  // and for `[[Target|Alias]]` is just before the `|`. Both are the same spot
+  // for the common case, and the alias case is the reason not to say "before
+  // the `]]`" and leave it there: a `#` typed after an alias reads as part of
+  // the ALIAS, so the link would point at a heading nobody can resolve.
+  tr.setSelection(TextSelection.create(tr.doc, pos + 2 + target.length))
+  tr.setMeta(WIKI_LINK_EDIT_PLUGIN_KEY, true)
+  return tr
+}
+
+function hasPlainModifiers(event: KeyboardEvent): boolean {
+  return !event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey
+}
+
+export function createWikiLinkEditPlugin(): Plugin {
+  return new Plugin({
+    key: WIKI_LINK_EDIT_PLUGIN_KEY,
+
+    props: {
+      decorations(state) {
+        const run = activeRun(state)
+        if (!run) return null
+
+        return DecorationSet.create(state.doc, [
+          Decoration.inline(run.from, run.from + 2, { class: 'wiki-link-bracket' }),
+          Decoration.inline(run.to - 2, run.to, { class: 'wiki-link-bracket' })
+        ])
+      },
+
+      handleKeyDown(view: EditorView, event: KeyboardEvent): boolean {
+        // Backspace on a chip used to delete it outright; now it opens it. That
+        // is a deliberate change for EVERY wiki link, not only heading ones —
+        // the chip is still one more Backspace away once the text is raw.
+        if (event.key !== 'Backspace' && event.key !== 'ArrowLeft') return false
+        if (!hasPlainModifiers(event)) return false
+
+        const before = wikiLinkBeforeCursor(view.state)
+        if (!before) return false
+
+        const tr = unpromote(view.state, before.node, before.pos)
+        if (!tr) return false
+
+        view.dispatch(tr)
+        return true
+      }
+    },
+
+    /**
+     * Promote the run back into a chip once the caret leaves it.
+     *
+     * This has to live here rather than in the document-wide normalizer: a user
+     * who clicks away without typing produces no document change at all, so
+     * nothing else would ever run.
+     */
+    appendTransaction(transactions, oldState, newState) {
+      if (transactions.some((tr) => tr.getMeta(WIKI_LINK_EDIT_PLUGIN_KEY))) return null
+      if (!transactions.some((tr) => tr.docChanged || tr.selectionSet)) return null
+
+      const previous = activeRun(oldState)
+      if (!previous) return null
+
+      let from = previous.from
+      let to = previous.to
+      for (const tr of transactions) {
+        from = tr.mapping.map(from)
+        to = tr.mapping.map(to, -1)
+      }
+      if (to <= from) return null
+
+      const current = activeRun(newState)
+      if (current && current.from === from) return null
+
+      const parsed = parseWikiLinkText(newState.doc.textBetween(from, to))
+      if (!parsed) return null
+
+      const type = newState.schema.nodes.wikiLink
+      if (!type) return null
+
+      const marks = propsFromMarks(newState.doc.resolve(from + 2).marks())
+      const tr = newState.tr.replaceWith(
+        from,
+        to,
+        type.create({ target: parsed.target, alias: parsed.alias, ...marks })
+      )
+      tr.setMeta(WIKI_LINK_EDIT_PLUGIN_KEY, true)
+      return tr
+    }
+  })
+}

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.ts
@@ -193,7 +193,53 @@ function hasPlainModifiers(event: KeyboardEvent): boolean {
   return !event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey
 }
 
-export function createWikiLinkEditPlugin(): Plugin {
+/**
+ * Replaces the raw `[[…]]` run the caret is in with a finished chip.
+ *
+ * Used when a suggestion is picked while editing an existing link. The menu's
+ * own `clearQuery` has already removed the query TEXT by then, but it knows
+ * nothing about the brackets around it — with `deleteTriggerCharacter: false`
+ * they are left behind, so inserting a chip at the caret would produce
+ * `[[<chip>]]`. Replacing the whole run instead leaves exactly the chip.
+ *
+ * Returns false when the caret is not in a run, so the caller can fall back to
+ * an ordinary insert (the from-scratch path, where the menu owns the brackets).
+ */
+export function replaceActiveRunWithWikiLink(
+  editor: { _tiptapEditor?: { state?: EditorState; view?: EditorView } } | undefined,
+  attrs: Record<string, unknown>
+): boolean {
+  const view = editor?._tiptapEditor?.view
+  const state = view?.state
+  if (!view || !state) return false
+
+  const run = activeRun(state)
+  if (!run) return false
+
+  const type = state.schema.nodes.wikiLink
+  if (!type) return false
+
+  const tr = state.tr.replaceWith(run.from, run.to, type.create(attrs))
+  tr.setMeta(WIKI_LINK_EDIT_PLUGIN_KEY, true)
+  view.dispatch(tr)
+  return true
+}
+
+export interface WikiLinkEditPluginOptions {
+  /**
+   * Opens the `[[` suggestion menu at the caret WITHOUT inserting a trigger.
+   *
+   * The menu is a live plugin session, not something derived from document text
+   * — a claim this file's header used to get wrong. Un-promoting a chip left
+   * well-formed `[[…]]` text with no session attached, so typing `#` inside it
+   * opened nothing and the heading picker was unreachable from the path users
+   * actually take. The caret is parked right after the `[[` before this runs, so
+   * the menu's query window starts where a hand-typed link's would.
+   */
+  openMenu?: () => void
+}
+
+export function createWikiLinkEditPlugin(options: WikiLinkEditPluginOptions = {}): Plugin {
   return new Plugin({
     key: WIKI_LINK_EDIT_PLUGIN_KEY,
 
@@ -218,10 +264,29 @@ export function createWikiLinkEditPlugin(): Plugin {
         const before = wikiLinkBeforeCursor(view.state)
         if (!before) return false
 
+        const target = typeof before.node.attrs.target === 'string' ? before.node.attrs.target : ''
         const tr = unpromote(view.state, before.node, before.pos)
         if (!tr) return false
 
         view.dispatch(tr)
+
+        // Bind the raw text to a live suggestion session, in three steps that
+        // have to stay in this order. `unpromote` leaves the caret immediately
+        // after the `[[`, which is where the menu anchors its query window;
+        // opening it there and only then moving the caret to the end of the
+        // target makes the query the target itself. Typing `#` from there
+        // extends that query, so the heading picker opens on a note whose title
+        // is exact by construction — no guessing, no typo to get wrong.
+        if (options.openMenu) {
+          options.openMenu()
+          const end = before.pos + 2 + target.length
+          if (end <= view.state.doc.content.size) {
+            const move = view.state.tr.setSelection(TextSelection.create(view.state.doc, end))
+            move.setMeta(WIKI_LINK_EDIT_PLUGIN_KEY, true)
+            view.dispatch(move)
+          }
+        }
+
         return true
       }
     },

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.ts
@@ -179,12 +179,16 @@ function unpromote(state: EditorState, node: ProseMirrorNode, pos: number): Tran
     pos + node.nodeSize,
     state.schema.text(text, marksFromProps(state.schema, node.attrs))
   )
-  // At the END OF THE TARGET, which for `[[Target]]` is "just before the `]]`"
-  // and for `[[Target|Alias]]` is just before the `|`. Both are the same spot
-  // for the common case, and the alias case is the reason not to say "before
-  // the `]]`" and leave it there: a `#` typed after an alias reads as part of
-  // the ALIAS, so the link would point at a heading nobody can resolve.
-  tr.setSelection(TextSelection.create(tr.doc, pos + 2 + target.length))
+  // Immediately after the `[[`, NOT at the end of the target — the caller opens
+  // the suggestion menu here and the menu anchors its query window wherever the
+  // caret is at that moment, then moves the caret to the end of the target so
+  // the query becomes the target itself.
+  //
+  // Getting this backwards is not a subtle failure: anchoring at the end of the
+  // target makes the query start empty, so typing `#` produces the query `#`,
+  // the note half is empty, heading mode never engages and the menu reports "no
+  // notes found" on a link whose note plainly exists.
+  tr.setSelection(TextSelection.create(tr.doc, pos + 2))
   tr.setMeta(WIKI_LINK_EDIT_PLUGIN_KEY, true)
   return tr
 }
@@ -270,21 +274,22 @@ export function createWikiLinkEditPlugin(options: WikiLinkEditPluginOptions = {}
 
         view.dispatch(tr)
 
-        // Bind the raw text to a live suggestion session, in three steps that
-        // have to stay in this order. `unpromote` leaves the caret immediately
-        // after the `[[`, which is where the menu anchors its query window;
-        // opening it there and only then moving the caret to the end of the
-        // target makes the query the target itself. Typing `#` from there
-        // extends that query, so the heading picker opens on a note whose title
-        // is exact by construction — no guessing, no typo to get wrong.
-        if (options.openMenu) {
-          options.openMenu()
-          const end = before.pos + 2 + target.length
-          if (end <= view.state.doc.content.size) {
-            const move = view.state.tr.setSelection(TextSelection.create(view.state.doc, end))
-            move.setMeta(WIKI_LINK_EDIT_PLUGIN_KEY, true)
-            view.dispatch(move)
-          }
+        // Bind the raw text to a live suggestion session. Three steps, and the
+        // order is the whole trick: `unpromote` left the caret right after the
+        // `[[`, the menu anchors its query window at the caret, and only then
+        // does the caret move to the end of the target — which makes the query
+        // the target itself. Typing `#` extends that query, so the heading
+        // picker opens on a note whose title is exact by construction, with no
+        // typing it out and no typo to get wrong.
+        if (options.openMenu) options.openMenu()
+
+        // Unconditional: with no menu to open, the caret still belongs at the
+        // end of the target rather than parked between the brackets.
+        const end = before.pos + 2 + target.length
+        if (end <= view.state.doc.content.size) {
+          const move = view.state.tr.setSelection(TextSelection.create(view.state.doc, end))
+          move.setMeta(WIKI_LINK_EDIT_PLUGIN_KEY, true)
+          view.dispatch(move)
         }
 
         return true

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.test.tsx
@@ -9,7 +9,9 @@ vi.mock('@memry/i18n/renderer', () => ({
         'menus.wiki.embed': 'Embed',
         'menus.wiki.wikiLink': 'Wiki link',
         'menus.wiki.embedAria': `Embed ${values?.title ?? ''}`.trim(),
-        'menus.wiki.wikiLinkAria': `Wiki link ${values?.title ?? ''}`.trim()
+        'menus.wiki.wikiLinkAria': `Wiki link ${values?.title ?? ''}`.trim(),
+        'menus.wiki.noHeadings': `${values?.title ?? ''} has no headings`.trim(),
+        'menus.wiki.noMatchingHeadings': `No headings in ${values?.title ?? ''} match`.trim()
       }
       return messages[key] ?? key
     }
@@ -44,5 +46,65 @@ describe('WikiLinkMenu', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Wiki link Voice memo' }))
     expect(onItemClick).toHaveBeenCalledWith({ ...item, insertMode: 'wikiLink' })
+  })
+
+  it('renders heading rows that insert a note#heading target', () => {
+    const onItemClick = vi.fn()
+    const heading: WikiLinkSuggestionItem = {
+      id: 'heading:note-1:0',
+      title: 'Kararlar',
+      target: 'Toplantı#Kararlar',
+      alias: '',
+      exists: true,
+      type: 'heading',
+      headingLevel: 2
+    }
+
+    render(
+      <WikiLinkMenu
+        items={[heading]}
+        loadingState="loaded"
+        selectedIndex={0}
+        onItemClick={onItemClick}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('option', { name: 'Kararlar' }))
+    expect(onItemClick).toHaveBeenCalledWith({ ...heading, insertMode: 'wikiLink' })
+  })
+
+  it('says the note has no headings, and cannot be picked', () => {
+    const onItemClick = vi.fn()
+    const empty: WikiLinkSuggestionItem = {
+      id: 'headings:note-1',
+      title: 'Toplantı',
+      target: '',
+      exists: true,
+      type: 'headingEmpty',
+      filtered: false
+    }
+
+    const { rerender } = render(
+      <WikiLinkMenu
+        items={[empty]}
+        loadingState="loaded"
+        selectedIndex={0}
+        onItemClick={onItemClick}
+      />
+    )
+
+    expect(screen.getByText('Toplantı has no headings')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('option'))
+    expect(onItemClick).not.toHaveBeenCalled()
+
+    rerender(
+      <WikiLinkMenu
+        items={[{ ...empty, filtered: true }]}
+        loadingState="loaded"
+        selectedIndex={0}
+        onItemClick={onItemClick}
+      />
+    )
+    expect(screen.getByText('No headings in Toplantı match')).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.tsx
@@ -3,7 +3,7 @@
  */
 
 import type { SuggestionMenuProps } from '@blocknote/react'
-import { FileAudio, FileText, Plus } from '@/lib/icons'
+import { FileAudio, FileText, Hash, Plus } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
 
@@ -16,12 +16,28 @@ export type WikiLinkSuggestionItem = {
   target: string
   alias?: string
   exists: boolean
-  type: 'note' | 'create'
+  /**
+   * `heading` is a heading inside the note the query already named exactly.
+   * `headingEmpty` is that note having no heading to offer — a row rather than
+   * a separate empty state so the menu stays open while the user backspaces
+   * over the `#`, and it carries no target, so picking it does nothing.
+   */
+  type: 'note' | 'create' | 'heading' | 'headingEmpty'
   lastEdited?: string
   fileType?: WikiLinkFileType
   mimeType?: string | null
   fileSize?: number | null
   insertMode?: WikiLinkInsertMode
+  /** Heading rows only: indents the row so the note's outline is readable. */
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6
+  /** `headingEmpty` only: whether a heading filter is what emptied the list. */
+  filtered?: boolean
+}
+
+const HEADING_INDENTS = ['', 'ms-2', 'ms-4', 'ms-6', 'ms-6', 'ms-6'] as const
+
+function headingIndent(level: WikiLinkSuggestionItem['headingLevel']): string {
+  return HEADING_INDENTS[(level ?? 1) - 1] ?? ''
 }
 
 export function WikiLinkMenu({
@@ -72,6 +88,45 @@ export function WikiLinkMenu({
           'hover:bg-accent hover:text-accent-foreground',
           isSelected && 'bg-accent text-accent-foreground'
         )
+
+        if (item.type === 'headingEmpty') {
+          return (
+            <div
+              key={`${item.type}-${item.id}`}
+              className="flex items-center gap-2 px-2 py-1.5 text-sm text-muted-foreground"
+              role="option"
+              aria-selected={false}
+              aria-disabled
+            >
+              <Hash className="h-4 w-4 shrink-0 opacity-70" />
+              <span className="truncate">
+                {item.filtered
+                  ? t('menus.wiki.noMatchingHeadings', { title: item.title })
+                  : t('menus.wiki.noHeadings', { title: item.title })}
+              </span>
+            </div>
+          )
+        }
+
+        if (item.type === 'heading') {
+          return (
+            <button
+              type="button"
+              key={`${item.type}-${item.id}`}
+              className={itemClassName}
+              onClick={() => onItemClick?.({ ...item, insertMode: 'wikiLink' })}
+              role="option"
+              aria-selected={isSelected}
+            >
+              <Hash className="h-4 w-4 shrink-0 opacity-70" />
+              {/* Indent on the label, not the row: the row's own `px-2` and a
+                  logical `ps-*` would be two competing padding rules. */}
+              <span className={cn('truncate text-start', headingIndent(item.headingLevel))}>
+                {item.title}
+              </span>
+            </button>
+          )
+        }
 
         if (isAudio) {
           return (

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeMarkdownHardBreaks,
   normalizeTableContent,
   normalizeWikiLinks,
+  parseWikiLinkQuery,
   splitTextWithWikiLinks,
   splitWikiLinkQuery
 } from './wiki-link-utils'
@@ -33,6 +34,51 @@ describe('wiki-link utils', () => {
       { id: 'h1', text: 'Plan', level: 2, position: 0 },
       { id: 'h2', text: 'Next', level: 3, position: 40 }
     ])
+  })
+
+  describe('parseWikiLinkQuery', () => {
+    it('reads the note, heading and alias halves', () => {
+      expect(parseWikiLinkQuery('Toplantı#Kararlar|notlar')).toEqual({
+        search: 'Toplantı#Kararlar',
+        note: 'Toplantı',
+        heading: 'Kararlar',
+        alias: 'notlar'
+      })
+    })
+
+    it('reports no heading at all when no # was typed', () => {
+      expect(parseWikiLinkQuery('Toplantı')).toEqual({
+        search: 'Toplantı',
+        note: 'Toplantı',
+        heading: null,
+        alias: ''
+      })
+    })
+
+    it('reports an empty heading the moment # is typed', () => {
+      expect(parseWikiLinkQuery('Toplantı#')).toEqual({
+        search: 'Toplantı#',
+        note: 'Toplantı',
+        heading: '',
+        alias: ''
+      })
+    })
+
+    it('keeps the raw search so a # inside a title can still be looked up', () => {
+      expect(parseWikiLinkQuery('Sprint #4')).toEqual({
+        search: 'Sprint #4',
+        note: 'Sprint',
+        heading: '4',
+        alias: ''
+      })
+    })
+
+    it('takes the last segment of a nested heading path', () => {
+      expect(parseWikiLinkQuery('Note#One#Two')).toMatchObject({
+        note: 'Note',
+        heading: 'Two'
+      })
+    })
   })
 
   it('splits wiki link queries and inline text segments', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.test.ts
@@ -81,6 +81,59 @@ describe('wiki-link utils', () => {
     })
   })
 
+  describe('the caret block is exempt from promotion', () => {
+    const blocks = () =>
+      [
+        { id: 'editing', type: 'paragraph', content: 'Read [[Daily Note]] now' },
+        { id: 'other', type: 'paragraph', content: 'Also [[Roadmap]]' }
+      ] as any
+
+    it('promotes every block when no block is skipped', () => {
+      const result = normalizeWikiLinks(blocks())
+      expect(result.didChange).toBe(true)
+      expect(JSON.stringify(result.blocks)).not.toContain('[[')
+    })
+
+    it('leaves the skipped block as raw text and still promotes the others', () => {
+      const result = normalizeWikiLinks(blocks(), { skipBlockId: 'editing' })
+
+      expect(result.didChange).toBe(true)
+      expect(result.blocks[0].content).toBe('Read [[Daily Note]] now')
+      expect(result.blocks[1].content).toEqual([
+        'Also ',
+        { type: 'wikiLink', props: { target: 'Roadmap', alias: '' } }
+      ])
+    })
+
+    it('reports no change at all when the skipped block holds the only link', () => {
+      const result = normalizeWikiLinks(
+        [{ id: 'editing', type: 'paragraph', content: 'Read [[Daily Note]] now' }] as any,
+        { skipBlockId: 'editing' }
+      )
+
+      expect(result.didChange).toBe(false)
+    })
+
+    it('still promotes a child block nested under the skipped one', () => {
+      const result = normalizeWikiLinks(
+        [
+          {
+            id: 'editing',
+            type: 'paragraph',
+            content: '[[Daily Note]]',
+            children: [{ id: 'child', type: 'paragraph', content: '[[Roadmap]]' }]
+          }
+        ] as any,
+        { skipBlockId: 'editing' }
+      )
+
+      expect(result.blocks[0].content).toBe('[[Daily Note]]')
+      expect(result.blocks[0].children?.[0].content).toEqual([
+        { type: 'wikiLink', props: { target: 'Roadmap', alias: '' } }
+      ])
+    })
+  })
+
   it('splits wiki link queries and inline text segments', () => {
     expect(splitWikiLinkQuery('Target | Alias')).toEqual({ search: 'Target', alias: 'Alias' })
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.ts
@@ -254,7 +254,25 @@ export function normalizeTableContent(tableContent: any): { content: any; didCha
   return { content: { ...tableContent, rows }, didChange: true }
 }
 
-export function normalizeWikiLinks(blocks: Block[]): { blocks: Block[]; didChange: boolean } {
+export interface NormalizeWikiLinksOptions {
+  /**
+   * The block holding the caret, left alone.
+   *
+   * Promotion is what makes a wiki link a chip, and normally that is exactly
+   * right. It is wrong for the one block the user is editing IN: un-promoting a
+   * chip (`wiki-link-edit-plugin.ts`) leaves real `[[…]]` text under the caret,
+   * which this would promote straight back on the next keystroke — through a
+   * whole-document `replaceBlocks`, under a caret, mid-word. Skipping the whole
+   * block is coarser than skipping the run, and enough: leaving the block
+   * promotes it, and so does the plugin the moment the caret leaves the run.
+   */
+  skipBlockId?: string
+}
+
+export function normalizeWikiLinks(
+  blocks: Block[],
+  options?: NormalizeWikiLinksOptions
+): { blocks: Block[]; didChange: boolean } {
   const blockStr = JSON.stringify(blocks)
   if (!blockStr.includes('[[')) {
     return { blocks, didChange: false }
@@ -270,7 +288,9 @@ export function normalizeWikiLinks(blocks: Block[]): { blocks: Block[]; didChang
     let blockChanged = false
     let nextBlock: Block = block
 
-    if (block.content) {
+    // Children are still walked: a sibling block nested under the caret's block
+    // is a different block, and its links promote as usual.
+    if (block.content && block.id !== options?.skipBlockId) {
       if (typeof block.content === 'string' || Array.isArray(block.content)) {
         const normalized = normalizeInlineContent(block.content as any)
         if (normalized.didChange) {
@@ -287,7 +307,7 @@ export function normalizeWikiLinks(blocks: Block[]): { blocks: Block[]; didChang
     }
 
     if (block.children?.length) {
-      const normalizedChildren = normalizeWikiLinks(block.children as Block[])
+      const normalizedChildren = normalizeWikiLinks(block.children as Block[], options)
       if (normalizedChildren.didChange) {
         blockChanged = true
         nextBlock = { ...nextBlock, children: normalizedChildren.blocks }

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { Block } from '@blocknote/core'
+import { splitWikiTarget } from '@memry/shared/wiki-target'
 import type { HeadingInfo } from './types'
 import { createWikiLinkInlineContent, hasWikiLinkMarks } from './wiki-link'
 
@@ -57,6 +58,32 @@ export function splitWikiLinkQuery(query: string): { search: string; alias: stri
     search: rawTarget?.trim() ?? '',
     alias: rawAlias?.trim() ?? ''
   }
+}
+
+export interface WikiLinkQueryParts {
+  /** The whole target as typed, `#` and all — what the note list searches on. */
+  search: string
+  /** The note half of `note#heading`; equal to `search` when no `#` was typed. */
+  note: string
+  /** The heading half: `null` when no `#` was typed, `''` immediately after one. */
+  heading: string | null
+  alias: string
+}
+
+/**
+ * `Note#Heading|alias` → its three parts.
+ *
+ * `#` binds tighter than `|` because that is the order the grammar reads in,
+ * and `search` is kept alongside the split so the caller can fall back to it.
+ * That fallback is not optional: `#` is legal in a note title, so `Sprint #4`
+ * splits into note `Sprint` + heading `4`, and only an EXACT match on the note
+ * half may switch the menu into heading mode — everything else keeps searching
+ * titles for the raw string, exactly as before.
+ */
+export function parseWikiLinkQuery(query: string): WikiLinkQueryParts {
+  const { search, alias } = splitWikiLinkQuery(query)
+  const { note, heading } = splitWikiTarget(search)
+  return { search, note, heading, alias }
 }
 
 function createStyledText(

--- a/apps/desktop/src/renderer/src/components/note/note-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-layout.tsx
@@ -33,6 +33,12 @@ interface NoteLayoutProps {
   contentWidth?: string
   marqueeZoneRef?: (el: HTMLDivElement | null) => void
   onRailHiddenChange?: (hidden: boolean) => void
+  /**
+   * Set while the page has a heading to jump to (`[[Note#Heading]]`). Scroll
+   * restore keeps saving, but does not re-apply the saved offset on this mount:
+   * the user named a destination, which is the fresher intent.
+   */
+  suppressScrollRestore?: boolean
 }
 
 const EMPTY_HEADINGS: HeadingItem[] = []
@@ -50,7 +56,8 @@ export function NoteLayout({
   sideRail,
   contentWidth,
   marqueeZoneRef,
-  onRailHiddenChange
+  onRailHiddenChange,
+  suppressScrollRestore = false
 }: NoteLayoutProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null)
@@ -61,7 +68,7 @@ export function NoteLayout({
   // This div — not the tab wrapper — is what the note and template-editor pages
   // actually scroll, so tab scroll restore has to attach here.
   const getScrollElement = useCallback(() => scrollRef.current, [])
-  useTabScrollRestore({ getScrollElement })
+  useTabScrollRestore({ getScrollElement, restore: !suppressScrollRestore })
   const { activeHeadingId, setActiveHeading } = useActiveHeading({
     headings,
     offset: 120,

--- a/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.ts
@@ -34,8 +34,15 @@ const SAVE_THROTTLE_MS = 500
  * large note's lazy chunk, note fetch and editor mount routinely take seconds.
  */
 const RESTORE_SETTLE_MS = 2000
-/** Hard upper bound on re-application, so the observer can never leak. */
-const RESTORE_MAX_MS = 15000
+/**
+ * Hard upper bound on re-application, so the observer can never leak.
+ *
+ * Exported because anything else that positions the same scroller while content
+ * is still arriving — a `[[Note#Heading]]` jump, say — has to give up on the
+ * same schedule. Two mechanisms racing the same element on different deadlines
+ * is how "it only sometimes lands on the heading" gets built.
+ */
+export const RESTORE_MAX_MS = 15000
 /** Sub-pixel tolerance when deciding whether a target offset was reached. */
 const OFFSET_EPSILON = 1
 /**
@@ -81,6 +88,17 @@ export interface UseTabScrollRestoreOptions {
   /** Set false to leave scrolling alone entirely (default true). */
   enabled?: boolean
   /**
+   * Set false to keep SAVING the offset but never re-apply the saved one on
+   * this mount (default true).
+   *
+   * The caller then owns the initial position — the case being a heading link,
+   * where the user just named a destination and "where you left off" is the
+   * staler intent of the two. Read once, when the effect arms: flipping it back
+   * after the jump has landed must not re-arm restore and yank the user away
+   * from the heading they asked for.
+   */
+  restore?: boolean
+  /**
    * Extra identity discriminator. Changing it flushes the current offset and
    * re-runs restore, exactly like a tab or entity change does. It also names
    * the pane's own slot in the tab's scroll record, so a page with several
@@ -101,7 +119,8 @@ export function useTabScrollRestore({
   getScrollElement,
   enabled = true,
   key,
-  virtualizer
+  virtualizer,
+  restore = true
 }: UseTabScrollRestoreOptions): void {
   const identity = useTabIdentity()
   // Optional: `NoteLayout` and friends also render outside a tab (previews,
@@ -114,6 +133,8 @@ export function useTabScrollRestore({
   const offsetRef = useRef(0)
   const getScrollElementRef = useRef(getScrollElement)
   const virtualizerRef = useRef(virtualizer)
+  // A ref, and deliberately NOT an effect dependency: see the option's docs.
+  const restoreRef = useRef(restore)
 
   // Layout effects all run before any passive effect in the same commit, so the
   // main effect below always sees the current render's getter.
@@ -126,6 +147,10 @@ export function useTabScrollRestore({
   useLayoutEffect(() => {
     virtualizerRef.current = virtualizer
   }, [virtualizer])
+
+  useLayoutEffect(() => {
+    restoreRef.current = restore
+  }, [restore])
 
   const tabId = identity?.tabId
   const groupId = identity?.groupId
@@ -281,12 +306,46 @@ export function useTabScrollRestore({
     // disagree.
     const saved = readScrollPane(getTab(tabId, groupId) ?? undefined, key)
 
+    const teardown = (): void => {
+      stopRestoring()
+      element.removeEventListener('scroll', handleScroll)
+      element.removeEventListener('wheel', handleUserIntent)
+      element.removeEventListener('touchmove', handleUserIntent)
+      element.removeEventListener('keydown', handleKeyDown)
+      if (saveTimer !== null) clearTimeout(saveTimer)
+
+      // Final save under THIS effect's identity, read from the ref. Reading the
+      // DOM here is exactly the bug this hook replaces. A pane that was never
+      // scrolled and has no entry of its own to correct has nothing to persist —
+      // writing `{ offset: 0 }` for every tab the user merely opens is churn in
+      // state that gets serialised to disk. `saved` is already this pane's entry
+      // alone, so merely opening the insights pane cannot touch the list pane's.
+      if (touched || saved !== undefined) {
+        dispatch({
+          type: 'SAVE_TAB_STATE',
+          payload: {
+            tabId,
+            groupId,
+            scrollPanes: { [paneKey]: { offset: offsetRef.current, entityId } }
+          }
+        })
+      }
+      offsetRef.current = 0
+    }
+
     if (isRestorableEntry(saved, entityId)) {
       const target = saved.offset
       offsetRef.current = target
       // Tab state already holds exactly this record, so a save that reproduces
       // it is a no-op re-render.
       lastDispatchedOffset = target
+
+      // Someone else owns the initial position on this mount. The offset is
+      // still seeded from the saved entry so that a teardown which sees no
+      // scroll at all re-writes the value that was already there, rather than
+      // reporting `0` and erasing where the user actually was.
+      if (!restoreRef.current) return teardown
+
       restoring = true
 
       /** Largest scrollable range seen since re-application began. */
@@ -324,31 +383,6 @@ export function useTabScrollRestore({
       }
     }
 
-    return () => {
-      stopRestoring()
-      element.removeEventListener('scroll', handleScroll)
-      element.removeEventListener('wheel', handleUserIntent)
-      element.removeEventListener('touchmove', handleUserIntent)
-      element.removeEventListener('keydown', handleKeyDown)
-      if (saveTimer !== null) clearTimeout(saveTimer)
-
-      // Final save under THIS effect's identity, read from the ref. Reading the
-      // DOM here is exactly the bug this hook replaces. A pane that was never
-      // scrolled and has no entry of its own to correct has nothing to persist —
-      // writing `{ offset: 0 }` for every tab the user merely opens is churn in
-      // state that gets serialised to disk. `saved` is already this pane's entry
-      // alone, so merely opening the insights pane cannot touch the list pane's.
-      if (touched || saved !== undefined) {
-        dispatch({
-          type: 'SAVE_TAB_STATE',
-          payload: {
-            tabId,
-            groupId,
-            scrollPanes: { [paneKey]: { offset: offsetRef.current, entityId } }
-          }
-        })
-      }
-      offsetRef.current = 0
-    }
+    return teardown
   }, [enabled, tabId, groupId, entityId, key, dispatch, getTab])
 }

--- a/apps/desktop/src/renderer/src/hooks/use-wiki-link-hover.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-wiki-link-hover.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { WikiLinkPreview } from '@/services/notes-service'
 import { notesService } from '@/services/notes-service'
+import { splitWikiTarget } from '@memry/shared/wiki-target'
 
 interface HoverPosition {
   top: number
@@ -94,7 +95,16 @@ export function useWikiLinkHover(
       }
 
       try {
-        const preview = await notesService.previewByTitle(target)
+        // Split first, raw second — the same order `resolveWikiLink` uses, so
+        // the card previews the note the click would open. Without it a
+        // `[[Note#Heading]]` looked up `Note#Heading`, found nothing, and the
+        // link silently had no preview at all.
+        const { note, heading } = splitWikiTarget(target)
+        const preview =
+          heading !== null && note
+            ? ((await notesService.previewByTitle(note)) ??
+              (await notesService.previewByTitle(target)))
+            : await notesService.previewByTitle(target)
         if (cache.size >= CACHE_LIMIT) {
           const firstKey = cache.keys().next().value
           if (firstKey !== undefined) cache.delete(firstKey)

--- a/apps/desktop/src/renderer/src/lib/home/journal-widget-data.ts
+++ b/apps/desktop/src/renderer/src/lib/home/journal-widget-data.ts
@@ -9,9 +9,7 @@ export interface WeekDay {
 }
 
 export type RelativeDayLabel =
-  | { kind: 'today' }
-  | { kind: 'yesterday' }
-  | { kind: 'date'; text: string }
+  { kind: 'today' } | { kind: 'yesterday' } | { kind: 'date'; text: string }
 
 function toLocalIso(d: Date): string {
   const y = d.getFullYear()
@@ -69,7 +67,9 @@ export function entrySnippet(content: string, max = 140): string {
   const text = content
     .replace(/^---\n[\s\S]*?\n---\n?/, '')
     .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
-    .replace(/\[\[([^\]]*)\]\]/g, '$1')
+    // The heading half goes with the brackets. Keeping it left `Note#Heading`,
+    // and the `#` strip two lines down then welded that into `NoteHeading`.
+    .replace(/\[\[([^\]#]*)(?:#[^\]]*)?\]\]/g, '$1')
     .replace(/[#>*_`~]/g, '')
     .replace(/\s+/g, ' ')
     .trim()

--- a/apps/desktop/src/renderer/src/lib/scroll-to-heading.ts
+++ b/apps/desktop/src/renderer/src/lib/scroll-to-heading.ts
@@ -1,0 +1,26 @@
+/**
+ * Scrolling a heading block into view inside ONE editor pane.
+ *
+ * The lookup is scoped to the pane's own container rather than the document.
+ * Split view renders the same note's block ids in both panes, and
+ * `document.querySelector` returns whichever comes first in the DOM — so the
+ * outline used to scroll the pane the user was not looking at. A heading link
+ * lands on exactly the same trap, which is why both now come through here.
+ *
+ * `scrollIntoView` is guarded: jsdom does not implement it, and a renderer test
+ * that merely renders a note should not throw on that account.
+ */
+export function scrollToHeadingBlock(
+  container: HTMLElement | null,
+  headingId: string,
+  options: { smooth: boolean }
+): boolean {
+  const root: ParentNode = container ?? document
+  const element = root.querySelector(`[data-id="${headingId}"]`)
+  if (!element) return false
+  element.scrollIntoView?.({
+    behavior: options.smooth ? 'smooth' : 'auto',
+    block: 'start'
+  })
+  return true
+}

--- a/apps/desktop/src/renderer/src/lib/scroll-to-heading.ts
+++ b/apps/desktop/src/renderer/src/lib/scroll-to-heading.ts
@@ -24,3 +24,92 @@ export function scrollToHeadingBlock(
   })
   return true
 }
+
+/** Frames the offset must hold still before the jump counts as landed. */
+const SETTLE_FRAMES = 3
+/** Sub-pixel tolerance when deciding whether the offset stopped moving. */
+const OFFSET_EPSILON = 1
+
+/**
+ * Scrolls to a heading that does not exist in the DOM yet, and keeps it in view
+ * until the page stops moving underneath it.
+ *
+ * Both halves are load-bearing, and the first one is why the E2E for this failed
+ * the first time it ran:
+ *
+ * - **The block may not be rendered.** `ContentArea` holds its render behind a
+ *   placeholder until the CRDT binding settles, while `onHeadingsChange` fires
+ *   as soon as the fragment binds. So there is a window where the heading is in
+ *   the page's `headings` state and its `[data-id]` node is not in the document.
+ *   A single lookup loses that race, and for a note nobody then edits there is
+ *   no second heading emission to retry on — the jump simply never happens.
+ * - **The page keeps growing after the jump.** Lazy chunks, the note fetch and
+ *   the editor mount all land at their own pace, so an offset written early
+ *   drifts. Re-applying until it holds still for a few frames is the same shape
+ *   `use-tab-scroll-restore` uses, for the same reason.
+ *
+ * Returns a cancel function. `getHeadingId` is a getter so the caller can hand
+ * over a target that only becomes known once the headings arrive.
+ */
+export function scrollToHeadingWhenReady(options: {
+  getContainer: () => HTMLElement | null
+  getHeadingId: () => string | null
+  smooth: boolean
+  timeoutMs: number
+  onSettled: () => void
+}): () => void {
+  const { getContainer, getHeadingId, smooth, timeoutMs, onSettled } = options
+
+  let frame: number | null = null
+  let cancelled = false
+  let settledFrames = 0
+  let lastOffset: number | null = null
+
+  const deadline = setTimeout(() => {
+    // The heading never arrived — renamed, deleted, or a target we cannot
+    // address. Give up and let the caller drop the anchor, or scroll restore
+    // stays suppressed for every later visit to this tab.
+    cancel()
+    onSettled()
+  }, timeoutMs)
+
+  function cancel(): void {
+    cancelled = true
+    if (frame !== null) cancelAnimationFrame(frame)
+    frame = null
+    clearTimeout(deadline)
+  }
+
+  function step(): void {
+    if (cancelled) return
+    frame = null
+
+    const container = getContainer()
+    const headingId = getHeadingId()
+    if (headingId) {
+      const root: ParentNode = container ?? document
+      const element = root.querySelector(`[data-id="${headingId}"]`)
+      if (element) {
+        element.scrollIntoView?.({ behavior: smooth ? 'smooth' : 'auto', block: 'start' })
+
+        const offset = element.getBoundingClientRect().top
+        settledFrames =
+          lastOffset !== null && Math.abs(offset - lastOffset) <= OFFSET_EPSILON
+            ? settledFrames + 1
+            : 0
+        lastOffset = offset
+
+        if (settledFrames >= SETTLE_FRAMES) {
+          cancel()
+          onSettled()
+          return
+        }
+      }
+    }
+
+    frame = requestAnimationFrame(step)
+  }
+
+  frame = requestAnimationFrame(step)
+  return cancel
+}

--- a/apps/desktop/src/renderer/src/lib/wikilink-resolver.test.ts
+++ b/apps/desktop/src/renderer/src/lib/wikilink-resolver.test.ts
@@ -27,7 +27,8 @@ describe('wikilink-resolver', () => {
         id: '',
         title: '   ',
         fileType: 'markdown',
-        icon: 'file-text'
+        icon: 'file-text',
+        heading: null
       })
     })
 
@@ -42,7 +43,8 @@ describe('wikilink-resolver', () => {
         id: '',
         title: 'New Note',
         fileType: 'markdown',
-        icon: 'file-text'
+        icon: 'file-text',
+        heading: null
       })
     })
 
@@ -61,7 +63,8 @@ describe('wikilink-resolver', () => {
         id: 'note-1',
         title: 'Daily Note',
         fileType: 'markdown',
-        icon: 'file-text'
+        icon: 'file-text',
+        heading: null
       })
     })
 
@@ -80,7 +83,8 @@ describe('wikilink-resolver', () => {
         id: 'file-1',
         title: 'Cover Image',
         fileType: 'image',
-        icon: 'file-image'
+        icon: 'file-image',
+        heading: null
       })
     })
 
@@ -100,8 +104,124 @@ describe('wikilink-resolver', () => {
         id: '',
         title: target,
         fileType,
-        icon
+        icon,
+        heading: null
       })
+    })
+  })
+
+  // A15. Every case here used to end in `type: 'create'` with the whole
+  // `Note#Heading` string as the title, which wrote a real file into the vault.
+  describe('resolveWikiLink with a heading', () => {
+    const meeting = {
+      id: 'note-1',
+      path: 'Meeting.md',
+      title: 'Meeting',
+      fileType: 'markdown' as const
+    }
+
+    it('resolves the note half and reports the heading', async () => {
+      resolveByTitle.mockImplementation(async (title) => (title === 'Meeting' ? meeting : null))
+
+      const result = await resolveWikiLink('Meeting#Decisions')
+
+      expect(result).toEqual({
+        type: 'note',
+        id: 'note-1',
+        title: 'Meeting',
+        fileType: 'markdown',
+        icon: 'file-text',
+        heading: 'Decisions'
+      })
+    })
+
+    it('looks the note half up BEFORE the raw string', async () => {
+      // Both exist: the junk note this bug created, and the real note. The
+      // real one has to win, or the fix does nothing for the people it hurt.
+      resolveByTitle.mockImplementation(async (title) =>
+        title === 'Meeting'
+          ? meeting
+          : {
+              id: 'junk-1',
+              path: 'Meeting#Decisions.md',
+              title: 'Meeting#Decisions',
+              fileType: 'markdown' as const
+            }
+      )
+
+      const result = await resolveWikiLink('Meeting#Decisions')
+
+      expect(result.id).toBe('note-1')
+      expect(result.heading).toBe('Decisions')
+    })
+
+    it('falls back to the raw title when the note half misses', async () => {
+      // `#` is legal in a filename, so `Sprint #4` may be a note somebody has.
+      resolveByTitle.mockImplementation(async (title) =>
+        title === 'Sprint #4'
+          ? {
+              id: 'note-2',
+              path: 'Sprint #4.md',
+              title: 'Sprint #4',
+              fileType: 'markdown' as const
+            }
+          : null
+      )
+
+      const result = await resolveWikiLink('Sprint #4')
+
+      expect(result).toEqual({
+        type: 'note',
+        id: 'note-2',
+        title: 'Sprint #4',
+        fileType: 'markdown',
+        icon: 'file-text',
+        // The `#` was part of the name, so it names no heading to scroll to.
+        heading: null
+      })
+    })
+
+    it('takes the last segment of a nested heading path', async () => {
+      resolveByTitle.mockImplementation(async (title) => (title === 'Meeting' ? meeting : null))
+
+      const result = await resolveWikiLink('Meeting#Q3#Decisions')
+
+      expect(result.heading).toBe('Decisions')
+    })
+
+    it('opens the note at the top for a block reference, and creates nothing', async () => {
+      resolveByTitle.mockImplementation(async (title) => (title === 'Meeting' ? meeting : null))
+
+      const result = await resolveWikiLink('Meeting#^abc123')
+
+      expect(result.type).toBe('note')
+      expect(result.id).toBe('note-1')
+      expect(result.heading).toBeNull()
+    })
+
+    it('creates the NOTE half when nothing matches, never the raw target', async () => {
+      resolveByTitle.mockResolvedValue(null)
+
+      const result = await resolveWikiLink('Meeting#Decisions')
+
+      expect(result).toEqual({
+        type: 'create',
+        id: '',
+        title: 'Meeting',
+        fileType: 'markdown',
+        icon: 'file-text',
+        heading: 'Decisions'
+      })
+    })
+
+    it('does not look up a same-note link', async () => {
+      resolveByTitle.mockResolvedValue(null)
+
+      const result = await resolveWikiLink('#Decisions')
+
+      expect(resolveByTitle).not.toHaveBeenCalled()
+      expect(result.type).toBe('not-found')
+      expect(result.heading).toBe('Decisions')
     })
   })
 

--- a/apps/desktop/src/renderer/src/lib/wikilink-resolver.ts
+++ b/apps/desktop/src/renderer/src/lib/wikilink-resolver.ts
@@ -9,6 +9,7 @@
 
 import { notesService } from '@/services/notes-service'
 import { getFileType, getExtension, isSupported } from '@memry/shared/file-types'
+import { splitWikiTarget, isBlockReference } from '@memry/shared/wiki-target'
 
 // ============================================================================
 // Types
@@ -22,6 +23,13 @@ export interface ResolvedWikiLink {
   title: string
   fileType: 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
   icon: string
+  /**
+   * The heading `[[Note#Heading]]` addresses, or `null` when the link names no
+   * heading — or names one we cannot scroll to (a `#^block-id` reference).
+   * Callers use it to position the note they just opened; it never affects
+   * WHICH note is opened.
+   */
+  heading: string | null
 }
 
 // ============================================================================
@@ -40,18 +48,38 @@ const FILE_TYPE_ICONS: Record<string, string> = {
 // Main Resolution Function
 // ============================================================================
 
+/** Shapes a resolved metadata row as a resolution, note or file. */
+function resolvedRecord(
+  resolved: { id: string; title: string; fileType: ResolvedWikiLink['fileType'] },
+  heading: string | null
+): ResolvedWikiLink {
+  const isFile = resolved.fileType !== 'markdown'
+  return {
+    type: isFile ? 'file' : 'note',
+    id: resolved.id,
+    title: resolved.title,
+    fileType: resolved.fileType,
+    icon: FILE_TYPE_ICONS[resolved.fileType] || 'file-text',
+    heading
+  }
+}
+
 /**
  * Resolve a WikiLink target to determine how it should be opened.
  *
  * Resolution strategy:
- * 1. Check if target has a known file extension
- * 2. Query the database for a matching title
- * 3. Based on fileType, determine if it's a note or file
- * 4. If not found and has file extension, return 'not-found'
- * 5. If not found and no extension, return 'create' to make a new note
+ * 1. Split `[[Note#Heading]]` and look the NOTE half up first
+ * 2. Fall back to the raw string, so a note really called `Sprint #4` wins
+ * 3. Check if target has a known file extension
+ * 4. Based on fileType, determine if it's a note or file
+ * 5. If not found and has file extension, return 'not-found'
+ * 6. If not found and no extension, return 'create' to make a new note
+ *
+ * Step 1 before step 2 is the whole fix for A15, and the order is load-bearing
+ * in both directions — see `@memry/shared/wiki-target` for why.
  *
  * @param target - The WikiLink target text (e.g., "My Note" or "photo.png")
- * @returns Resolution result with type, id, title, fileType, and icon
+ * @returns Resolution result with type, id, title, fileType, icon and heading
  */
 export async function resolveWikiLink(target: string): Promise<ResolvedWikiLink> {
   const trimmedTarget = target.trim()
@@ -61,7 +89,27 @@ export async function resolveWikiLink(target: string): Promise<ResolvedWikiLink>
       id: '',
       title: target,
       fileType: 'markdown',
-      icon: 'file-text'
+      icon: 'file-text',
+      heading: null
+    }
+  }
+
+  const { note, heading } = splitWikiTarget(trimmedTarget)
+  const hasHeading = heading !== null
+  // A block reference names a heading we can never find, so it is carried as
+  // "no heading": the note still opens, at the top.
+  const anchor = heading !== null && !isBlockReference(heading) && heading !== '' ? heading : null
+
+  // `[[#Heading]]` addresses the note it is written in. The page answers that
+  // without a lookup, so there is nothing here to resolve.
+  if (hasHeading && !note) {
+    return {
+      type: 'not-found',
+      id: '',
+      title: trimmedTarget,
+      fileType: 'markdown',
+      icon: 'file-text',
+      heading: anchor
     }
   }
 
@@ -69,20 +117,16 @@ export async function resolveWikiLink(target: string): Promise<ResolvedWikiLink>
   const extension = getExtension(trimmedTarget)
   const hasKnownExtension = extension !== '' && isSupported(extension)
 
-  // Query the database for a matching title
-  const resolved = await notesService.resolveByTitle(trimmedTarget)
-
-  if (resolved) {
-    // Found a match - determine if it's a note or file
-    const isFile = resolved.fileType !== 'markdown'
-    return {
-      type: isFile ? 'file' : 'note',
-      id: resolved.id,
-      title: resolved.title,
-      fileType: resolved.fileType,
-      icon: FILE_TYPE_ICONS[resolved.fileType] || 'file-text'
-    }
+  // Split first: `[[Note#Heading]]` must reach `Note`, never the
+  // `Note#Heading.md` this bug used to create.
+  if (hasHeading) {
+    const bySplit = await notesService.resolveByTitle(note)
+    if (bySplit) return resolvedRecord(bySplit, anchor)
   }
+
+  // Raw second: the `#` was part of the name after all, so it names no heading.
+  const resolved = await notesService.resolveByTitle(trimmedTarget)
+  if (resolved) return resolvedRecord(resolved, null)
 
   // Not found in database
   if (hasKnownExtension) {
@@ -94,17 +138,21 @@ export async function resolveWikiLink(target: string): Promise<ResolvedWikiLink>
       id: '',
       title: trimmedTarget,
       fileType: detectedFileType as ResolvedWikiLink['fileType'],
-      icon: FILE_TYPE_ICONS[detectedFileType] || 'file'
+      icon: FILE_TYPE_ICONS[detectedFileType] || 'file',
+      heading: anchor
     }
   }
 
-  // No extension and not found - this will create a new note
+  // No extension and not found - this will create a new note. It is created
+  // under the NOTE half: minting `Note#Heading.md` is the bug itself, and a
+  // heading separator has no business in a filename.
   return {
     type: 'create',
     id: '',
-    title: trimmedTarget,
+    title: hasHeading ? note : trimmedTarget,
     fileType: 'markdown',
-    icon: 'file-text'
+    icon: 'file-text',
+    heading: anchor
   }
 }
 

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -668,6 +668,10 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
             })
             break
           case 'note':
+            // The heading rides along; the note page does the positioning. A
+            // `[[#Heading]]` written IN a journal entry stays unhandled — the
+            // journal is a separate Tiptap editor with no heading anchor of its
+            // own, and that waits on the BlockNote migration (#1547).
             openTab({
               type: 'note',
               title: resolution.title,
@@ -677,7 +681,8 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
               isPinned: false,
               isModified: false,
               isPreview: false,
-              isDeleted: false
+              isDeleted: false,
+              ...(resolution.heading && { viewState: { headingText: resolution.heading } })
             })
             break
           case 'create':

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -6,7 +6,15 @@ import { getI18n } from 'react-i18next'
  * Loads real note data via useNotes() hook and saves changes via updateNote().
  */
 
-import { useState, useCallback, useEffect, useRef, useMemo, type RefObject } from 'react'
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useMemo,
+  type RefObject
+} from 'react'
 import { cn } from '@/lib/utils'
 import { motion, useReducedMotion } from 'motion/react'
 import { useQueryClient } from '@tanstack/react-query'
@@ -42,7 +50,7 @@ import { usePropertiesCollapsed } from '@/hooks/use-properties-collapsed'
 import { useTasksLinkedToNote } from '@/hooks/use-tasks-linked-to-note'
 import { notesService, onNoteDeleted, onNoteUpdated, onNoteRenamed } from '@/services/notes-service'
 import { resolveWikiLink } from '@/lib/wikilink-resolver'
-import { scrollToHeadingBlock } from '@/lib/scroll-to-heading'
+import { scrollToHeadingBlock, scrollToHeadingWhenReady } from '@/lib/scroll-to-heading'
 import { RESTORE_MAX_MS } from '@/hooks/use-tab-scroll-restore'
 import { splitWikiTarget, normalizeHeading } from '@memry/shared/wiki-target'
 import { useTabs, useActiveTab } from '@/contexts/tabs'
@@ -683,29 +691,39 @@ export function NotePage({ noteId }: NotePageProps) {
     saveTabState(activeTab.id, { viewState: { headingText: undefined } })
   }, [activeTab?.id, saveTabState])
 
-  // Consume the heading anchor once the editor has actually produced headings.
-  // `headings` starts empty and fills in after the note loads and the editor
-  // mounts, so this re-runs on every change until the jump lands.
+  // The block id the anchor names, or null until the editor has emitted headings.
+  const headingAnchorId = useMemo(() => {
+    if (!initialHeadingText) return null
+    const wanted = normalizeHeading(initialHeadingText)
+    return headings.find((heading) => normalizeHeading(heading.text) === wanted)?.id ?? null
+  }, [initialHeadingText, headings])
+
+  // Read through a ref so headings arriving late are picked up without
+  // restarting the wait below — restarting it would also restart its deadline.
+  const headingAnchorIdRef = useRef(headingAnchorId)
+  useLayoutEffect(() => {
+    headingAnchorIdRef.current = headingAnchorId
+  }, [headingAnchorId])
+
+  // Consume the heading anchor. This waits rather than looking once: the block's
+  // `[data-id]` node is not in the document at the moment `headings` lands,
+  // because ContentArea holds its render behind a placeholder until the CRDT
+  // binding settles. A single lookup loses that race, and a note nobody edits
+  // emits no second set of headings to retry on.
   useEffect(() => {
-    if (!initialHeadingText) return
+    if (!initialHeadingText) return undefined
     // Never smooth: the note has only just appeared, so there is no starting
     // position for an animation to be relative to.
-    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler -- the
-    // click happens in the SOURCE note's page; this page does not exist yet when
-    // it fires. What is being waited on is `headings`, which arrives after the
-    // note loads and the editor mounts, so there is no handler to fold this into.
-    if (!scrollToHeadingText(initialHeadingText, false)) return
-    clearHeadingAnchor()
-  }, [initialHeadingText, scrollToHeadingText, clearHeadingAnchor])
-
-  // A heading that never arrives — deleted, renamed, or a `#^block-id` we cannot
-  // address — must not pin the anchor to the tab forever, which would also keep
-  // scroll restore suppressed on every later visit. Same deadline restore uses,
-  // so the two can never disagree about when content has settled.
-  useEffect(() => {
-    if (!initialHeadingText) return
-    const timer = setTimeout(clearHeadingAnchor, RESTORE_MAX_MS)
-    return () => clearTimeout(timer)
+    return scrollToHeadingWhenReady({
+      getContainer: () => editorContainerRef.current,
+      getHeadingId: () => headingAnchorIdRef.current,
+      smooth: false,
+      // Same deadline scroll restore uses, so the two can never disagree about
+      // when content has settled — and so a heading that never arrives stops
+      // suppressing restore instead of pinning the anchor to the tab forever.
+      timeoutMs: RESTORE_MAX_MS,
+      onSettled: clearHeadingAnchor
+    })
   }, [initialHeadingText, clearHeadingAnchor])
 
   const handleHeadingsChange = useCallback((newHeadings: HeadingInfo[]) => {

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -42,6 +42,9 @@ import { usePropertiesCollapsed } from '@/hooks/use-properties-collapsed'
 import { useTasksLinkedToNote } from '@/hooks/use-tasks-linked-to-note'
 import { notesService, onNoteDeleted, onNoteUpdated, onNoteRenamed } from '@/services/notes-service'
 import { resolveWikiLink } from '@/lib/wikilink-resolver'
+import { scrollToHeadingBlock } from '@/lib/scroll-to-heading'
+import { RESTORE_MAX_MS } from '@/hooks/use-tab-scroll-restore'
+import { splitWikiTarget, normalizeHeading } from '@memry/shared/wiki-target'
 import { useTabs, useActiveTab } from '@/contexts/tabs'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
 import { ReminderPicker } from '@/components/reminder'
@@ -157,7 +160,7 @@ export function NotePage({ noteId }: NotePageProps) {
   const { incoming: rawBacklinks, isLoading: backlinksLoading } = useNoteLinksQuery(noteId ?? null)
   const { tasks: linkedTasks, isLoading: linkedTasksLoading } = useTasksLinkedToNote(noteId ?? null)
   const { tags: allAvailableTags } = useNoteTagsQuery()
-  const { openTab, setTabDeleted, updateTabTitleByEntityId, closeTab } = useTabs()
+  const { openTab, setTabDeleted, updateTabTitleByEntityId, closeTab, saveTabState } = useTabs()
   const activeTab = useActiveTab()
   const { openSidebarItem } = useSidebarNavigation()
   const queryClient = useQueryClient()
@@ -187,6 +190,14 @@ export function NotePage({ noteId }: NotePageProps) {
   const initialAnchorId = useMemo(() => {
     const viewState = activeTab?.viewState as { anchorId?: string } | undefined
     return viewState?.anchorId
+  }, [activeTab?.viewState])
+
+  // The heading half of the `[[Note#Heading]]` that opened this tab. Carried
+  // as text because that is all the link stores — never a block id, which is
+  // minted per document and means nothing to the note that wrote the link.
+  const initialHeadingText = useMemo(() => {
+    const viewState = activeTab?.viewState as { headingText?: string } | undefined
+    return viewState?.headingText
   }, [activeTab?.viewState])
 
   // Convert query error to string
@@ -634,12 +645,68 @@ export function NotePage({ noteId }: NotePageProps) {
   // Handlers
   // ============================================================================
 
-  const handleHeadingClick = useCallback((headingId: string) => {
-    const element = document.querySelector(`[data-id="${headingId}"]`)
-    if (element) {
-      element.scrollIntoView({ behavior: 'smooth', block: 'start' })
-    }
-  }, [])
+  const handleHeadingClick = useCallback(
+    (headingId: string) => {
+      // Scoped to this pane. `document.querySelector` returns whichever pane is
+      // first in the DOM, so in split view the outline scrolled the pane the
+      // user was not looking at. Smooth is right here — the jump happens inside
+      // content already on screen — unless the user asked for less motion.
+      scrollToHeadingBlock(editorContainerRef.current, headingId, {
+        smooth: !prefersReducedMotion
+      })
+    },
+    [prefersReducedMotion]
+  )
+
+  /**
+   * Scrolls to a heading by TEXT, which is all `[[Note#Heading]]` carries — a
+   * block id is minted per document and means nothing to the note that wrote
+   * the link. Matching is trimmed and case-folded, and the first heading that
+   * matches wins: the link records no level and no ordinal, so there is nothing
+   * to tell two identically-worded headings apart with.
+   */
+  const scrollToHeadingText = useCallback(
+    (headingText: string, smooth: boolean): boolean => {
+      const wanted = normalizeHeading(headingText)
+      const match = headings.find((heading) => normalizeHeading(heading.text) === wanted)
+      if (!match) return false
+      return scrollToHeadingBlock(editorContainerRef.current, match.id, { smooth })
+    },
+    [headings]
+  )
+
+  const clearHeadingAnchor = useCallback(() => {
+    if (!activeTab?.id) return
+    // `undefined` deletes a `viewState` key — the only way to drop one now that
+    // writes are merged (see `mergeViewState`). Leaving it set would re-fire the
+    // jump every time the user came back to this tab.
+    saveTabState(activeTab.id, { viewState: { headingText: undefined } })
+  }, [activeTab?.id, saveTabState])
+
+  // Consume the heading anchor once the editor has actually produced headings.
+  // `headings` starts empty and fills in after the note loads and the editor
+  // mounts, so this re-runs on every change until the jump lands.
+  useEffect(() => {
+    if (!initialHeadingText) return
+    // Never smooth: the note has only just appeared, so there is no starting
+    // position for an animation to be relative to.
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler -- the
+    // click happens in the SOURCE note's page; this page does not exist yet when
+    // it fires. What is being waited on is `headings`, which arrives after the
+    // note loads and the editor mounts, so there is no handler to fold this into.
+    if (!scrollToHeadingText(initialHeadingText, false)) return
+    clearHeadingAnchor()
+  }, [initialHeadingText, scrollToHeadingText, clearHeadingAnchor])
+
+  // A heading that never arrives — deleted, renamed, or a `#^block-id` we cannot
+  // address — must not pin the anchor to the tab forever, which would also keep
+  // scroll restore suppressed on every later visit. Same deadline restore uses,
+  // so the two can never disagree about when content has settled.
+  useEffect(() => {
+    if (!initialHeadingText) return
+    const timer = setTimeout(clearHeadingAnchor, RESTORE_MAX_MS)
+    return () => clearTimeout(timer)
+  }, [initialHeadingText, clearHeadingAnchor])
 
   const handleHeadingsChange = useCallback((newHeadings: HeadingInfo[]) => {
     setHeadings(
@@ -992,6 +1059,14 @@ export function NotePage({ noteId }: NotePageProps) {
       const target = linkedNoteIdOrTitle?.trim()
       if (!target) return
 
+      // `[[#Heading]]` addresses the note it is written in: no tab, no lookup,
+      // just a jump inside content already on screen.
+      const sameNote = splitWikiTarget(target)
+      if (sameNote.heading && !sameNote.note) {
+        scrollToHeadingText(sameNote.heading, !prefersReducedMotion)
+        return
+      }
+
       try {
         // Use format-aware resolution to handle notes and files
         const resolution = await resolveWikiLink(target)
@@ -1013,7 +1088,9 @@ export function NotePage({ noteId }: NotePageProps) {
             break
 
           case 'note':
-            // Open note in editor
+            // Open note in editor, carrying the heading the link named. The
+            // target page consumes it once its own editor has produced headings
+            // — text is all we have, and block ids only exist over there.
             openTab({
               type: 'note',
               title: resolution.title,
@@ -1023,13 +1100,17 @@ export function NotePage({ noteId }: NotePageProps) {
               isPinned: false,
               isModified: false,
               isPreview: false,
-              isDeleted: false
+              isDeleted: false,
+              ...(resolution.heading && { viewState: { headingText: resolution.heading } })
             })
             break
 
           case 'create': {
-            // Create new note with this title
-            const result = await createNote.mutateAsync({ title: target })
+            // Create new note under the resolution's title, NOT the raw target:
+            // for `[[Note#Heading]]` that is `Note`. Minting `Note#Heading.md`
+            // is the bug this fixes — a heading separator has no business in a
+            // filename, and the file was written to the vault and synced.
+            const result = await createNote.mutateAsync({ title: resolution.title })
             if (!result.success || !result.note) {
               toast.error(t('page.toast.createLinkedFailed'))
               return
@@ -1058,7 +1139,7 @@ export function NotePage({ noteId }: NotePageProps) {
         toast.error(t('page.toast.openLinkedFailed'))
       }
     },
-    [openTab, createNote, t]
+    [openTab, createNote, t, scrollToHeadingText, prefersReducedMotion]
   )
 
   const handleBacklinkClick = useCallback(
@@ -1320,6 +1401,7 @@ export function NotePage({ noteId }: NotePageProps) {
 
   return (
     <NoteLayout
+      suppressScrollRestore={Boolean(initialHeadingText)}
       headings={headings}
       onHeadingClick={handleHeadingClick}
       actions={actionIcons}

--- a/apps/desktop/tests/e2e/wiki-heading-links.e2e.ts
+++ b/apps/desktop/tests/e2e/wiki-heading-links.e2e.ts
@@ -14,10 +14,22 @@ import { ready, uniqueLabel } from './utils/desktop-test-helpers'
 import { openNoteByTitle } from './utils/note-sync-helpers'
 import { SELECTORS } from './utils/electron-helpers'
 
-/** Enough filler above the heading that reaching it requires real scrolling. */
+/**
+ * A heading far enough down to need real scrolling, and with a viewport's worth
+ * of content BELOW it.
+ *
+ * The filler after the heading is not padding. `scrollIntoView({block: 'start'})`
+ * can only bring the heading to the top if there is enough content beneath it to
+ * scroll past; otherwise the browser clamps at maximum scroll and the heading
+ * stops partway down. The first version of this fixture put the heading at the
+ * end of the note, so the page scrolled to its very bottom — `scrollTop` came
+ * back as exactly `scrollHeight - clientHeight` — and the assertion read that
+ * correct behaviour as a failure.
+ */
 function bodyWithHeadingFarDown(heading: string): string {
-  const filler = Array.from({ length: 60 }, (_, i) => `Filler paragraph ${i + 1}.`).join('\n\n')
-  return `Intro paragraph.\n\n${filler}\n\n## ${heading}\n\nThe section body.\n`
+  const filler = (label: string): string =>
+    Array.from({ length: 60 }, (_, i) => `${label} paragraph ${i + 1}.`).join('\n\n')
+  return `Intro paragraph.\n\n${filler('Before')}\n\n## ${heading}\n\n${filler('After')}\n`
 }
 
 test.describe('Wiki heading links', () => {

--- a/apps/desktop/tests/e2e/wiki-heading-links.e2e.ts
+++ b/apps/desktop/tests/e2e/wiki-heading-links.e2e.ts
@@ -53,9 +53,14 @@ test.describe('Wiki heading links', () => {
     // 1. The link opened the TARGET note — not a new one named after the link.
     await expect(page.locator(SELECTORS.noteTitle).first()).toHaveValue(targetTitle)
 
-    // 2. It landed on the heading rather than the top of the note. Asserted
-    //    against the heading's own position, not a raw scroll offset: the
-    //    latter would pass for any scroll at all.
+    // 2. It landed on the heading rather than the top of the note.
+    //
+    // Measured against the VIEWPORT, and cross-checked against the scroller's
+    // own offset. An earlier version of this subtracted the editor wrapper's
+    // rect from the heading's — but both move together when the page scrolls,
+    // so the difference is the heading's offset within the content and is the
+    // same number scrolled or not. It reported an identical 2095 across two
+    // builds, which is what a scroll-invariant measurement looks like.
     await expect
       .poll(
         async () =>
@@ -66,15 +71,26 @@ test.describe('Wiki heading links', () => {
               (el) => el.textContent?.trim() === headingText
             )
             if (!node) return null
-            const scroller = node.closest('.bn-editor')?.parentElement ?? null
-            const top = node.getBoundingClientRect().top
-            const frame = scroller?.getBoundingClientRect().top ?? 0
-            return Math.round(top - frame)
+
+            // The page's real scroller. Every surface here is `h-full`
+            // `overflow-hidden` wrapping an inner element that actually
+            // scrolls, so walk up until one of them can.
+            let scroller: HTMLElement | null = editor as HTMLElement
+            while (scroller && scroller.scrollHeight - scroller.clientHeight <= 1) {
+              scroller = scroller.parentElement
+            }
+
+            return {
+              // Two independent signals: the page moved, and the heading is
+              // where the user would look for it.
+              scrolled: (scroller?.scrollTop ?? 0) > 0,
+              // Near the top of the window, allowing for the note's own chrome.
+              nearTop: node.getBoundingClientRect().top < 300
+            }
           }, heading),
         { timeout: 20_000 }
       )
-      // Near the top of the visible frame, in either direction by a line or so.
-      .toBeLessThan(120)
+      .toEqual({ scrolled: true, nearTop: true })
 
     // 3. No note was created for the raw target. This is the file that used to
     //    be written into the vault and synced to every device.

--- a/apps/desktop/tests/e2e/wiki-heading-links.e2e.ts
+++ b/apps/desktop/tests/e2e/wiki-heading-links.e2e.ts
@@ -1,0 +1,119 @@
+/**
+ * A15 — `[[Note#Heading]]`, the shape every Obsidian vault is full of.
+ *
+ * This lives in E2E rather than the renderer suite on purpose. The claim that
+ * matters most here is "the target note is scrolled to the heading", and jsdom
+ * cannot measure that: it has no layout, so `scrollTop`, `scrollHeight` and
+ * `scrollIntoView` are all inert. A renderer test would report green while the
+ * page sat at the top. The same lesson cost a round of scroll-restore work
+ * (#1549); it is not repeated here.
+ */
+
+import { test, expect } from './fixtures'
+import { ready, uniqueLabel } from './utils/desktop-test-helpers'
+import { openNoteByTitle } from './utils/note-sync-helpers'
+import { SELECTORS } from './utils/electron-helpers'
+
+/** Enough filler above the heading that reaching it requires real scrolling. */
+function bodyWithHeadingFarDown(heading: string): string {
+  const filler = Array.from({ length: 60 }, (_, i) => `Filler paragraph ${i + 1}.`).join('\n\n')
+  return `Intro paragraph.\n\n${filler}\n\n## ${heading}\n\nThe section body.\n`
+}
+
+test.describe('Wiki heading links', () => {
+  test('opens the note and scrolls to the heading instead of creating a note', async ({ page }) => {
+    await ready(page)
+
+    const targetTitle = uniqueLabel('Heading Target')
+    const sourceTitle = uniqueLabel('Heading Source')
+    const heading = 'Decisions'
+
+    const seeded = await page.evaluate(
+      async ({ sourceTitle, targetTitle, body }) => {
+        const api = window.api
+        const target = await api.notes.create({ title: targetTitle, content: body })
+        const source = await api.notes.create({
+          title: sourceTitle,
+          content: `Jump to [[${targetTitle}#Decisions]].`
+        })
+        if (!target.success || !target.note || !source.success || !source.note) {
+          throw new Error('failed to seed heading-link notes')
+        }
+        return { targetId: target.note.id, sourceId: source.note.id }
+      },
+      { sourceTitle, targetTitle, body: bodyWithHeadingFarDown(heading) }
+    )
+
+    await openNoteByTitle(page, sourceTitle)
+
+    const chip = page.locator('[data-wiki-link]').first()
+    await expect(chip).toBeVisible()
+    await chip.click()
+
+    // 1. The link opened the TARGET note — not a new one named after the link.
+    await expect(page.locator(SELECTORS.noteTitle).first()).toHaveValue(targetTitle)
+
+    // 2. It landed on the heading rather than the top of the note. Asserted
+    //    against the heading's own position, not a raw scroll offset: the
+    //    latter would pass for any scroll at all.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate((headingText) => {
+            const editor = document.querySelector('.bn-editor')
+            if (!editor) return null
+            const node = Array.from(editor.querySelectorAll('h2')).find(
+              (el) => el.textContent?.trim() === headingText
+            )
+            if (!node) return null
+            const scroller = node.closest('.bn-editor')?.parentElement ?? null
+            const top = node.getBoundingClientRect().top
+            const frame = scroller?.getBoundingClientRect().top ?? 0
+            return Math.round(top - frame)
+          }, heading),
+        { timeout: 20_000 }
+      )
+      // Near the top of the visible frame, in either direction by a line or so.
+      .toBeLessThan(120)
+
+    // 3. No note was created for the raw target. This is the file that used to
+    //    be written into the vault and synced to every device.
+    const junk = await page.evaluate(
+      (title) => window.api.notes.resolveByTitle(title),
+      `${targetTitle}#${heading}`
+    )
+    expect(junk).toBeNull()
+
+    expect(seeded.targetId).toBeTruthy()
+  })
+
+  test('still opens a note whose title really contains a hash', async ({ page }) => {
+    await ready(page)
+
+    // `#` is legal in a filename, so split-only resolution would read this as
+    // "heading `4` of note `Sprint …`" and strand a note that works today.
+    const hashTitle = uniqueLabel('Sprint #4')
+    const sourceTitle = uniqueLabel('Hash Source')
+
+    await page.evaluate(
+      async ({ hashTitle, sourceTitle }) => {
+        const api = window.api
+        const target = await api.notes.create({ title: hashTitle, content: 'Sprint body.' })
+        const source = await api.notes.create({
+          title: sourceTitle,
+          content: `See [[${hashTitle}]].`
+        })
+        if (!target.success || !source.success) throw new Error('failed to seed hash-title notes')
+      },
+      { hashTitle, sourceTitle }
+    )
+
+    await openNoteByTitle(page, sourceTitle)
+
+    const chip = page.locator('[data-wiki-link]').first()
+    await expect(chip).toBeVisible()
+    await chip.click()
+
+    await expect(page.locator(SELECTORS.noteTitle).first()).toHaveValue(hashTitle)
+  })
+})

--- a/apps/desktop/tests/e2e/wiki-heading-links.e2e.ts
+++ b/apps/desktop/tests/e2e/wiki-heading-links.e2e.ts
@@ -80,17 +80,31 @@ test.describe('Wiki heading links', () => {
               scroller = scroller.parentElement
             }
 
+            const headingTop = node.getBoundingClientRect().top
+            const scrollerTop = scroller?.getBoundingClientRect().top ?? 0
+
             return {
               // Two independent signals: the page moved, and the heading is
               // where the user would look for it.
               scrolled: (scroller?.scrollTop ?? 0) > 0,
-              // Near the top of the window, allowing for the note's own chrome.
-              nearTop: node.getBoundingClientRect().top < 300
+              // Within a line or two of the top of the scrolling area. Measured
+              // against the scroller's own top rather than the window's,
+              // because the app chrome above it is not part of the note.
+              nearTop: headingTop - scrollerTop < 120,
+              // Reported, not asserted. A boolean-only failure says "it landed
+              // in the wrong place" and nothing about where, which cost a
+              // 30-minute CI cycle to learn once already.
+              headingTop: Math.round(headingTop),
+              scrollerTop: Math.round(scrollerTop),
+              scrollTop: Math.round(scroller?.scrollTop ?? 0),
+              scrollerTag: scroller
+                ? `${scroller.tagName}.${scroller.className}`.slice(0, 80)
+                : null
             }
           }, heading),
         { timeout: 20_000 }
       )
-      .toEqual({ scrolled: true, nearTop: true })
+      .toMatchObject({ scrolled: true, nearTop: true })
 
     // 3. No note was created for the raw target. This is the file that used to
     //    be written into the vault and synced to every device.

--- a/apps/desktop/tests/e2e/wiki-heading-links.e2e.ts
+++ b/apps/desktop/tests/e2e/wiki-heading-links.e2e.ts
@@ -104,7 +104,34 @@ test.describe('Wiki heading links', () => {
           }, heading),
         { timeout: 20_000 }
       )
-      .toMatchObject({ scrolled: true, nearTop: true })
+      .toMatchObject({ scrolled: true })
+
+    // The offset is asserted on its own, and every input to it is carried in the
+    // failure message. `toMatchObject` prints only the keys it compared, so the
+    // diagnostic fields added for this went unreported and cost another cycle.
+    const landed = await page.evaluate((headingText) => {
+      const editor = document.querySelector('.bn-editor')
+      const node = Array.from(editor?.querySelectorAll('h2') ?? []).find(
+        (el) => el.textContent?.trim() === headingText
+      )
+      let scroller: HTMLElement | null = (editor as HTMLElement) ?? null
+      while (scroller && scroller.scrollHeight - scroller.clientHeight <= 1) {
+        scroller = scroller.parentElement
+      }
+      return {
+        headingTop: Math.round(node?.getBoundingClientRect().top ?? Number.NaN),
+        scrollerTop: Math.round(scroller?.getBoundingClientRect().top ?? Number.NaN),
+        scrollTop: Math.round(scroller?.scrollTop ?? Number.NaN),
+        scrollHeight: Math.round(scroller?.scrollHeight ?? Number.NaN),
+        clientHeight: Math.round(scroller?.clientHeight ?? Number.NaN),
+        scroller: scroller ? `${scroller.tagName}.${scroller.className}`.slice(0, 100) : null
+      }
+    }, heading)
+
+    expect(
+      landed.headingTop - landed.scrollerTop,
+      `heading offset inside the scroller — ${JSON.stringify(landed)}`
+    ).toBeLessThan(120)
 
     // 3. No note was created for the raw target. This is the file that used to
     //    be written into the vault and synced to every device.

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -39,6 +39,22 @@ Because an exact title is what switches modes, `[[Sprint #` still lists notes: `
 not a note here, so nothing about `[[Sprint #4]]` changes. Block references (`#^`) are never
 offered.
 
+### Adding a heading to a link you already inserted
+
+A finished link is a single chip, so there is nothing to type a `#` into. Press
+<kbd>Backspace</kbd> (or <kbd>←</kbd>) right after one and it opens back up as its plain text
+— `[[Meeting]]`, or `[[Meeting|the outcome]]` — with the cursor at the end of the title and
+the `[[` `]]` dimmed. Type `#` and the heading dropdown appears, exactly as when writing the
+link from scratch. Move the cursor out of the brackets, or click elsewhere, and it becomes a
+chip again.
+
+::: warning Backspace next to a link now opens it instead of deleting it
+This applies to **every** wiki link, not only ones with a heading. To delete a link, press
+<kbd>Backspace</kbd> a second time once it is plain text, or select it and delete. Removing
+the `[[` or `]]` yourself is also allowed — that turns the link back into ordinary prose,
+which is sometimes what you want.
+:::
+
 Heading matching ignores case and surrounding spaces, and the first heading with that text
 wins — the link records the heading's text, not its level or its position. If the heading
 has since been renamed or deleted, the note still opens, at the top.

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -12,6 +12,8 @@ Type `[[` and start typing the title. An autocomplete dropdown appears with matc
 - **No match**: pressing <kbd>Enter</kbd> creates a new note with that title and links it.
 - **Audio file found**: pick **Link** for a normal reference or **Embed** for an inline audio block.
 
+The slash menu's **Link to note** item types the `[[` for you and opens the same dropdown.
+
 The link displays the target's current title, but the underlying reference uses a stable ID — renaming the target doesn't break the link.
 
 ## Following a Link
@@ -26,6 +28,16 @@ A link can name a heading inside its target, the way an Obsidian vault writes it
 - `[[#Decisions]]` — stays in the note you're reading and scrolls to that heading
 - `[[Meeting#Q3#Decisions]]` — a nested heading path; the last part names the heading
 - `[[Meeting#Decisions|the outcome]]` — an alias works exactly as it does elsewhere
+
+You don't have to remember the heading. Once the part before the `#` is a note's title
+**exactly**, typing `#` swaps the dropdown for that note's headings, indented as an outline;
+keep typing to filter them, and pick one to write the whole `[[Note#Heading]]` link. Delete
+the `#` and the note list comes back. If the note has no headings, the dropdown says so —
+memrynote will not add a heading to someone else's note.
+
+Because an exact title is what switches modes, `[[Sprint #` still lists notes: `Sprint` is
+not a note here, so nothing about `[[Sprint #4]]` changes. Block references (`#^`) are never
+offered.
 
 Heading matching ignores case and surrounding spaces, and the first heading with that text
 wins — the link records the heading's text, not its level or its position. If the heading

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -18,6 +18,36 @@ The link displays the target's current title, but the underlying reference uses 
 
 Click any wiki link to open the target in a new tab. <kbd>⌘</kbd>+click to open in the background; <kbd>⌥</kbd>+click to open in a split pane.
 
+## Linking to a Heading
+
+A link can name a heading inside its target, the way an Obsidian vault writes it:
+
+- `[[Meeting#Decisions]]` — opens **Meeting** and scrolls to its "Decisions" heading
+- `[[#Decisions]]` — stays in the note you're reading and scrolls to that heading
+- `[[Meeting#Q3#Decisions]]` — a nested heading path; the last part names the heading
+- `[[Meeting#Decisions|the outcome]]` — an alias works exactly as it does elsewhere
+
+Heading matching ignores case and surrounding spaces, and the first heading with that text
+wins — the link records the heading's text, not its level or its position. If the heading
+has since been renamed or deleted, the note still opens, at the top.
+
+A note whose title genuinely contains `#` still works: `[[Sprint #4]]` opens the note called
+"Sprint #4" if there is one, and is only read as a heading link when there isn't.
+
+Backlinks and the graph treat `[[Meeting#Decisions]]` as a link to **Meeting** — the heading
+narrows where you land, not what the link points at.
+
+::: warning Block references are not supported
+`[[Meeting#^block-id]]` opens **Meeting** at the top rather than jumping to the block.
+memrynote does not assign persistent block ids, so there is nothing to scroll to.
+:::
+
+::: tip Journal entries
+Clicking a heading link written in a journal entry opens the target note and scrolls to the
+heading as usual. `[[#Heading]]` inside a journal entry does not scroll — the journal uses a
+different editor, and that is tracked with its migration.
+:::
+
 ## Formatting a Link
 
 Write the formatting around the link **in markdown** and it is kept, on screen and in the
@@ -134,6 +164,6 @@ If you need to repair broken links, use the inline link menu: it lets you re-tar
 
 ## Power Tip
 
-Wiki link autocomplete also matches on tags and audio files. Typing `[[#topic]]` searches notes that
-carry that tag. (Tags themselves are tracked separately — see
-[Properties & Tags](/user-guide/notes/properties-tags).)
+Wiki link autocomplete matches note titles, including audio and other attached files. It
+does not search tags — `[[#topic]]` is a heading link, not a tag search. Tags are tracked
+separately; see [Properties & Tags](/user-guide/notes/properties-tags).

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -180,6 +180,10 @@
       "pdf": {
         "title": "PDF",
         "subtext": "Attach a PDF and read it inline"
+      },
+      "linkToNote": {
+        "title": "Link to note",
+        "subtext": "Search notes — or type [[ anywhere"
       }
     },
     "filePanel": {
@@ -207,7 +211,9 @@
       "embed": "Embed",
       "wikiLink": "Wiki link",
       "embedAria": "Embed {title}",
-      "wikiLinkAria": "Wiki link {title}"
+      "wikiLinkAria": "Wiki link {title}",
+      "noHeadings": "{title} has no headings",
+      "noMatchingHeadings": "No headings in {title} match"
     },
     "mention": {
       "aria": "Date and note suggestions",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,7 +15,8 @@
     "./block-nesting": "./src/block-nesting.ts",
     "./youtube": "./src/youtube.ts",
     "./task-block": "./src/task-block.ts",
-    "./markdown-class": "./src/markdown-class.ts"
+    "./markdown-class": "./src/markdown-class.ts",
+    "./wiki-target": "./src/wiki-target.ts"
   },
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,7 +16,8 @@
     "./youtube": "./src/youtube.ts",
     "./task-block": "./src/task-block.ts",
     "./markdown-class": "./src/markdown-class.ts",
-    "./wiki-target": "./src/wiki-target.ts"
+    "./wiki-target": "./src/wiki-target.ts",
+    "./markdown-headings": "./src/markdown-headings.ts"
   },
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/shared/src/markdown-headings.test.ts
+++ b/packages/shared/src/markdown-headings.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { extractMarkdownHeadings, stripInlineMarkdown } from './markdown-headings'
+
+describe('extractMarkdownHeadings', () => {
+  it('reads every ATX level in document order', () => {
+    const markdown = ['# One', '## Two', '### Three', '#### Four', '##### Five', '###### Six'].join(
+      '\n'
+    )
+
+    expect(extractMarkdownHeadings(markdown)).toEqual([
+      { text: 'One', level: 1 },
+      { text: 'Two', level: 2 },
+      { text: 'Three', level: 3 },
+      { text: 'Four', level: 4 },
+      { text: 'Five', level: 5 },
+      { text: 'Six', level: 6 }
+    ])
+  })
+
+  it('ignores hashes inside fenced code blocks', () => {
+    const markdown = [
+      '# Real',
+      '',
+      '```bash',
+      '# not a heading',
+      '```',
+      '',
+      '~~~',
+      '## also not a heading',
+      '```',
+      '~~~',
+      '',
+      '## Real again'
+    ].join('\n')
+
+    expect(extractMarkdownHeadings(markdown)).toEqual([
+      { text: 'Real', level: 1 },
+      { text: 'Real again', level: 2 }
+    ])
+  })
+
+  it('ignores lines that only look like headings', () => {
+    const markdown = ['#NoSpace', '    # indented four spaces', '###', 'plain text', '#'].join('\n')
+
+    expect(extractMarkdownHeadings(markdown)).toEqual([])
+  })
+
+  it('drops a closing hash sequence but keeps a trailing hash in a word', () => {
+    expect(extractMarkdownHeadings('## Sprint ##')).toEqual([{ text: 'Sprint', level: 2 }])
+    expect(extractMarkdownHeadings('## C#')).toEqual([{ text: 'C#', level: 2 }])
+  })
+
+  it('strips inline markdown so the text matches what the editor renders', () => {
+    const markdown = ['## **Kalın** başlık', '## `code` and [link](https://x.dev)'].join('\n')
+
+    expect(extractMarkdownHeadings(markdown)).toEqual([
+      { text: 'Kalın başlık', level: 2 },
+      { text: 'code and link', level: 2 }
+    ])
+  })
+
+  it('handles CRLF line endings', () => {
+    expect(extractMarkdownHeadings('# One\r\n\r\n## Two\r\n')).toEqual([
+      { text: 'One', level: 1 },
+      { text: 'Two', level: 2 }
+    ])
+  })
+})
+
+describe('stripInlineMarkdown', () => {
+  it('unwraps emphasis, strike and inline code', () => {
+    expect(stripInlineMarkdown('***all*** **bold** *em* ~~gone~~ `code`')).toBe(
+      'all bold em gone code'
+    )
+    expect(stripInlineMarkdown('_em_ and __strong__')).toBe('em and strong')
+  })
+
+  it('leaves intraword underscores alone', () => {
+    expect(stripInlineMarkdown('snake_case_name')).toBe('snake_case_name')
+  })
+
+  it('reduces links, wiki links and images to their text', () => {
+    expect(stripInlineMarkdown('[text](https://x.dev)')).toBe('text')
+    expect(stripInlineMarkdown('[[Note|Alias]] and [[Other]]')).toBe('Alias and Other')
+    expect(stripInlineMarkdown('Before ![alt](img.png) after')).toBe('Before after')
+  })
+
+  it('collapses whitespace the way the editor does', () => {
+    expect(stripInlineMarkdown('  two   spaces  ')).toBe('two spaces')
+  })
+})

--- a/packages/shared/src/markdown-headings.ts
+++ b/packages/shared/src/markdown-headings.ts
@@ -1,0 +1,106 @@
+/**
+ * Reading a note's headings out of its markdown.
+ *
+ * `[[Note#Heading]]` carries the heading's TEXT, and the click side resolves it
+ * by comparing that text against BlockNote's plain text of each heading block
+ * (`extractHeadings`). So a heading offered by the `[[` autocomplete has to be
+ * written in the SAME form the click side will see, or the link the user just
+ * picked lands nowhere.
+ *
+ * That is the whole reason this file exists rather than a one-line regex. The
+ * only heading source available at authoring time is the target note's markdown
+ * on disk — there is no heading index in either database — and markdown is not
+ * plain text: `## **Kalın** başlık` reads as `**Kalın** başlık` in the file and
+ * as `Kalın başlık` in the editor. Offering the raw markdown form would write a
+ * link that can never match.
+ *
+ * Deliberately NOT handled:
+ * - Setext headings (`Title` over `===`). `---` is also a thematic break and a
+ *   frontmatter fence, so recognising them costs false positives — and a false
+ *   positive is a heading the user can pick but the click side will never find,
+ *   while a false negative is only a heading missing from a menu.
+ * - Block references (`^id`). Memry has no persistent block ids; see
+ *   `isBlockReference` in `./wiki-target`.
+ */
+
+export interface MarkdownHeading {
+  /** The heading's plain text, in the form the click-side matcher compares. */
+  text: string
+  level: 1 | 2 | 3 | 4 | 5 | 6
+}
+
+const ATX_HEADING = /^ {0,3}(#{1,6})(?:[ \t]+(.*))?$/
+const FENCE = /^ {0,3}(```|~~~)/
+
+/**
+ * Every ATX heading in a markdown body, in document order, with inline markdown
+ * stripped from each heading's text.
+ *
+ * Headings that are empty once stripped are dropped, because the click side
+ * drops them too: `extractHeadings` only records blocks whose text survives a
+ * trim, so a `###` on its own is not a target anything can point at.
+ */
+export function extractMarkdownHeadings(markdown: string): MarkdownHeading[] {
+  const headings: MarkdownHeading[] = []
+  let openFence: string | null = null
+
+  for (const rawLine of markdown.split('\n')) {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
+
+    // A `#` inside a fenced code block is code, not a heading. Only a fence of
+    // the same character closes the block, so ``` inside a ~~~ block is text.
+    const fence = line.match(FENCE)
+    if (fence) {
+      if (openFence === null) {
+        openFence = fence[1][0]
+        continue
+      }
+      if (fence[1][0] === openFence) {
+        openFence = null
+      }
+      continue
+    }
+    if (openFence !== null) continue
+
+    const match = line.match(ATX_HEADING)
+    if (!match) continue
+
+    // `## Heading ##` — a closing sequence must be preceded by whitespace, so
+    // `## C#` keeps its `#`.
+    const withoutClosing = (match[2] ?? '').replace(/[ \t]+#+[ \t]*$/, '')
+    const text = stripInlineMarkdown(withoutClosing)
+    if (!text) continue
+
+    headings.push({ text, level: match[1].length as MarkdownHeading['level'] })
+  }
+
+  return headings
+}
+
+/**
+ * A single line of markdown reduced to the plain text BlockNote would render.
+ *
+ * Whitespace is collapsed because the editor's is: markdown reaches BlockNote
+ * through HTML, where a run of spaces renders as one.
+ */
+export function stripInlineMarkdown(text: string): string {
+  return (
+    text
+      .replace(/<!--[\s\S]*?-->/g, '')
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // image: a heading has no inline image node, so it contributes no text
+      .replace(/\[\[[^\]|]+\|([^\]]+)\]\]/g, '$1') // wiki link w/ alias → alias
+      .replace(/\[\[([^\]]+)\]\]/g, '$1') // wiki link → target
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // link → text
+      .replace(/`+([^`]*)`+/g, '$1') // inline code
+      .replace(/\*\*\*(.+?)\*\*\*/g, '$1')
+      .replace(/\*\*(.+?)\*\*/g, '$1')
+      .replace(/\*(.+?)\*/g, '$1')
+      .replace(/~~(.+?)~~/g, '$1')
+      // Underscore emphasis only at word boundaries: `snake_case` is literal
+      // text in GFM and stays literal in the editor, so a blunt strip would
+      // write a link text the click side can never match.
+      .replace(/(?<![\p{L}\p{N}])_{1,3}(.+?)_{1,3}(?![\p{L}\p{N}])/gu, '$1')
+      .replace(/\s+/g, ' ')
+      .trim()
+  )
+}

--- a/packages/shared/src/wiki-target.test.ts
+++ b/packages/shared/src/wiki-target.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { splitWikiTarget, isBlockReference, normalizeHeading } from './wiki-target'
+
+describe('splitWikiTarget', () => {
+  it('leaves a plain target alone', () => {
+    expect(splitWikiTarget('My Note')).toEqual({ note: 'My Note', heading: null })
+  })
+
+  it('splits note and heading', () => {
+    expect(splitWikiTarget('Meeting#Decisions')).toEqual({
+      note: 'Meeting',
+      heading: 'Decisions'
+    })
+  })
+
+  it('trims either half', () => {
+    expect(splitWikiTarget('  Meeting # Decisions  ')).toEqual({
+      note: 'Meeting',
+      heading: 'Decisions'
+    })
+  })
+
+  it('takes the last segment of a nested heading path', () => {
+    expect(splitWikiTarget('Meeting#Q3#Decisions')).toEqual({
+      note: 'Meeting',
+      heading: 'Decisions'
+    })
+  })
+
+  it('reports an empty note half for a same-note link', () => {
+    expect(splitWikiTarget('#Decisions')).toEqual({ note: '', heading: 'Decisions' })
+  })
+
+  it('keeps a block reference in the heading half rather than the note half', () => {
+    expect(splitWikiTarget('Meeting#^abc123')).toEqual({
+      note: 'Meeting',
+      heading: '^abc123'
+    })
+  })
+
+  it('distinguishes "no heading" from "empty heading"', () => {
+    expect(splitWikiTarget('Meeting').heading).toBeNull()
+    expect(splitWikiTarget('Meeting#').heading).toBe('')
+  })
+
+  // The `Sprint #4` case: splitting alone is wrong, which is why callers keep
+  // the raw string as a fallback. This asserts what the split reports, not what
+  // the caller concludes.
+  it('splits a title that merely contains a hash', () => {
+    expect(splitWikiTarget('Sprint #4')).toEqual({ note: 'Sprint', heading: '4' })
+  })
+})
+
+describe('isBlockReference', () => {
+  it('recognises a block reference', () => {
+    expect(isBlockReference('^abc123')).toBe(true)
+  })
+
+  it('does not mistake a heading for one', () => {
+    expect(isBlockReference('Decisions')).toBe(false)
+  })
+})
+
+describe('normalizeHeading', () => {
+  it('folds case and trims', () => {
+    expect(normalizeHeading('  Decisions ')).toBe(normalizeHeading('decisions'))
+  })
+})

--- a/packages/shared/src/wiki-target.ts
+++ b/packages/shared/src/wiki-target.ts
@@ -1,0 +1,73 @@
+/**
+ * Splitting a wiki-link target into its note and heading halves.
+ *
+ * `[[Note#Heading]]` is Obsidian's syntax for "that heading inside that note",
+ * and a vault imported from Obsidian is full of them. Memry kept the whole
+ * string as the link's `target` and looked it up as a note title, so the lookup
+ * missed and the note page cheerfully created `Note#Heading.md` — a real file,
+ * written into the vault and synced to every device (A15). The same missed
+ * lookup is why those links have no hover preview and why the note they point
+ * at never lists them as a backlink.
+ *
+ * Splitting is deliberately NOT the whole answer. `#` is legal in a filename,
+ * so `Sprint #4` is a note somebody may really have, and a split-only reading
+ * would turn its links into "heading `4` of note `Sprint`". Callers therefore
+ * resolve SPLIT FIRST and fall back to the raw string — see `resolveWikiLink`.
+ * That order is what lets `[[Note#Heading]]` reach `Note` while `[[Sprint #4]]`
+ * still reaches `Sprint #4`, and it is also what makes the junk notes this bug
+ * already created harmless: they are simply never consulted.
+ *
+ * Nothing here touches the on-disk form. `target` stays the raw string in the
+ * document, in the vault file and in the shared Y.Doc; this is a reading of it,
+ * not a rewrite of it.
+ */
+
+export interface WikiTargetParts {
+  /** The note half. Empty when the link addresses the note it sits in. */
+  note: string
+  /** The heading half, or `null` when the target carries no `#` at all. */
+  heading: string | null
+}
+
+/**
+ * `Note#Heading` → `{ note: 'Note', heading: 'Heading' }`.
+ *
+ * `Note#H1#H2` addresses a heading nested under another one. Only the last
+ * segment names something a text match can find, and the intermediate ones add
+ * nothing, so the last one is the heading.
+ */
+export function splitWikiTarget(target: string): WikiTargetParts {
+  const raw = target.trim()
+  const hash = raw.indexOf('#')
+  if (hash === -1) return { note: raw, heading: null }
+
+  const segments = raw.slice(hash + 1).split('#')
+  return {
+    note: raw.slice(0, hash).trim(),
+    heading: (segments[segments.length - 1] ?? '').trim()
+  }
+}
+
+/**
+ * Whether a heading half is really a block reference (`[[Note#^block-id]]`).
+ *
+ * Block references need a persistent `^id` on every block, serialized to
+ * markdown and carried through the CRDT — a feature Memry does not have. They
+ * are recognised here only so the link still OPENS the note instead of being
+ * mistaken for a heading nobody will ever find (and, before this, instead of
+ * minting a file named after the block id).
+ */
+export function isBlockReference(heading: string): boolean {
+  return heading.startsWith('^')
+}
+
+/**
+ * The form two heading strings are compared in: trimmed and case-folded.
+ *
+ * A link carries a heading's TEXT, never its id or its level, so matching can
+ * only ever be a text match — `## Notes` and `### notes` are the same target
+ * and the first one in the document wins.
+ */
+export function normalizeHeading(heading: string): string {
+  return heading.trim().toLowerCase()
+}


### PR DESCRIPTION
> Single PR. #1559 was folded into this branch and closed.

## The bug

`[[Note#Heading]]` is what an Obsidian vault is full of. Memry looked the whole string up as a note title, the lookup missed, and clicking the link took the `create` branch — writing `Note#Heading.md` into the vault and syncing it to every device.

One missed lookup, three faces:

| Surface | Before |
|---|---|
| Click | Creates a junk note named after the link |
| Hover | No preview card at all (`previewByTitle` → null) |
| Backlinks | Target note never lists the link (`setNoteLinks` writes an unresolved row) |

The graph view was the exception — it has always stripped `#` (`app-core/graph.ts:43`). "Backlinks already work" was true only of the graph; notes and the graph were two link pipelines disagreeing.

Reported by Aurelie, 8 Aug. Everyone migrating from Obsidian is affected. And once resolution was fixed, a second half of the report surfaced: there was no way to *write* one of these links either.

## 1 · Resolving them

`splitWikiTarget` (`@memry/shared/wiki-target`), and resolution that looks the **note half up first, falling back to the raw string**. The order carries weight both ways:

- **split-first** reaches `Meeting` instead of the junk `Meeting#Decisions` note this bug already created — without it the fix does nothing for the people it hurt
- **raw fallback** keeps `[[Sprint #4]]` reaching a note really called that; `#` is legal in a filename

The only losing case is a vault holding both `Sprint` and `Sprint #4`, where Obsidian also picks `Sprint`. When nothing matches, the note is created under the **note half** — a heading separator has no business in a filename.

`resolveByTitle` is deliberately untouched: burying wiki-link grammar in "is there a note with this title" would make a note genuinely called `Sprint #4` unresolvable, which is data going invisible. CLI and MCP tracked in #1557.

## 2 · Scrolling to them

The heading rides to the target page as tab view state and is consumed once that editor has produced headings, matched on trimmed, case-folded text — all a link carries. Scroll restore keeps saving but stands down for that mount: the user just named a destination, the fresher of the two intents. It re-arms next visit.

`[[#Heading]]` scrolls in place · `[[A#H1#H2]]` uses the last segment · `[[A#^block-id]]` opens at the top, since block references do not exist here · a heading that never arrives gives up on **the same deadline scroll restore uses**.

Also fixes the outline's `document.querySelector`, which returned whichever pane was first in the DOM — in split view it scrolled the pane the user was not looking at, and a heading link lands on the identical trap. Both now go through one helper that also respects `prefers-reduced-motion`.

## 3 · Writing them

**`#` in the `[[` menu.** Type `[[Meeting#` and the menu lists Meeting's headings. `#` is an ordinary separator, not a magic trigger — headings appear only once the note part is an **exact** title match, so `[[Sprint #` still lists notes and nothing about `[[Sprint #4]]` changes. No "create heading": writing into someone else's note is a different authority.

There is no heading index in either database, so the menu reads the target's body on demand and caches it. That body is markdown while the click side matches BlockNote's plain text, so `## **Q3** review` would have been written in a form that could never land. `extractMarkdownHeadings` strips inline markdown, skips fenced code, drops closing `##`, collapses whitespace. Two details worth review: underscore emphasis is stripped only at word boundaries (the blunt `[*_~]` strip in `app-core` turns `snake_case` into `snakecase`), and setext headings are skipped on purpose (`---` is also a thematic break and a frontmatter fence; a false positive is a pickable heading that can never be found).

**A "Link to note" slash entry** that types `[[` and hands over to the same menu — one search UI, `#` support not written twice.

**Editing a link you already inserted.** This is the case a real user hits: type `[[`, pick from the dropdown, and now the chip is an atom — the caret cannot get inside, a `#` after it is a separate word, one Backspace deletes the whole thing. Backspace or ArrowLeft next to a chip now un-promotes it to `[[Target]]` with the caret at the end of the target, where a `#` belongs. From there it is plain text, so the menu above works unchanged. The caret leaving promotes it back.

Raw text rather than the `hashTag` shrink-the-attribute pattern, which is still the precedent for intercepting a key next to an inline node: that plugin absorbs by character class, and titles and headings are mostly spaces.

Two landmines avoided: the plugin registers through `register-editor-plugin` (a direct `registerPlugin` destroys the Yjs UndoManager — `f0fb0048c`), and `use-editor-sync`'s normalization exempts the caret's block **only** while the caret is inside a raw run. Exempting it unconditionally also stopped a hand-typed `[[Note]]` from becoming a chip until the caret left; without any exemption the run is promoted back on the next keystroke through a whole-document `replaceBlocks` under a typing caret.

⚠️ **Backspace next to a link no longer deletes it outright.** That is a deliberate change for every wiki link, not only heading ones, and it is documented as one.

## Compatibility

No schema change, no migration, no IPC contract change. `target` stays the raw string in the document, the vault file and the shared Y.Doc — this reads it, never rewrites it. Existing junk notes are not touched (deleting from a vault over sync is not reversible); #1555 proposes an opt-in cleanup. Link extraction now indexes heading links under the note, matching the graph; existing vaults keep their rows until each note is next projected — no forced reindex.

## Verification

`typecheck` 17/17 · `lint` 0 errors (98 warnings, unchanged from main) · renderer **636 files / 7418 tests** · shared 145 / 2527 · `i18n:check` · `check:architecture` · `check:contracts` · `docs:impact --strict` · `docs:build` — all green.

**The E2E is the interesting part of this PR's history.** Four runs, four different lessons, none of which the 7400-test renderer suite could have taught:

1. Failed at 2095 → I read it as a real defect and fixed a genuine race (`ContentArea` renders a placeholder until the CRDT binding settles while `onHeadingsChange` fires earlier, so a single lookup misses and never retries). Worth having, but not what the test was hitting.
2. Failed at **exactly 2095 again** — identical to the pixel across two builds, the signature of a measurement scroll cannot affect. It was: subtracting the editor wrapper's rect from the heading's, both inside the scroller.
3. Rewrote it viewport-relative: `scrolled: true, nearTop: false`. Real signal at last — but `toMatchObject` prints only the keys it compared, so the diagnostic fields went unreported.
4. Numbers finally printed: `scrollTop 1950` against `scrollHeight 2813` and `clientHeight 863` — exactly maximum scroll. **The feature had been right all along.** The fixture put the heading at the end of the note, so `scrollIntoView({block: 'start'})` had nothing beneath it to scroll past. Filler now runs on both sides.

E2E jobs are gated on `refs/heads/main`, so these ran via `workflow_dispatch`.

**Both specs now pass** ([run 32040527449](https://github.com/memrynote/memry/actions/runs/32040527449), shard 16):

```
✓ 24 wiki-heading-links.e2e.ts:36 › opens the note and scrolls to the heading instead of creating a note (15.3s)
✓ 25 wiki-heading-links.e2e.ts:159 › still opens a note whose title really contains a hash (15.1s)
```

That run is red overall, but both failing jobs (`E2E full (2/16)`, `E2E smoke (Windows)`) failed at **"Set up job"** — runner provisioning, before any code executes.

## Manually verified

Part 3 has now been exercised in a running app:

- Backspace next to a chip opens it as `[[Target]]` with the brackets dimmed
- typing `#` there opens the heading picker on that note's real headings
- picking one leaves a single chip

Two bugs were found that way and only that way, both from one root — the suggestion menu is a live plugin session, not something derived from text that happens to look like a trigger:

1. Nothing re-opened the menu when editing existing raw text, so `#` did nothing (`11322ffe8`).
2. The menu was then anchored at the end of the target instead of just after the `[[`, so its query began empty and `#` produced the query `#` — no note half, no heading mode, "No notes found" on a note with two headings (`e68e8fcd0`). The final caret position is identical either way, which is exactly why the unit suite stayed green through it; the new test observes the caret from inside the `openMenu` callback, so the order is pinned rather than the outcome.

## Still not covered by E2E

Part 3 has unit tests and a manual pass, but no E2E: the un-promotion, the dimmed brackets, the `#` menu in edit mode. Both bugs above were invisible to 7,400 renderer tests, so a spec for that path is worth adding.

## Follow-ups

#1555 junk-note cleanup · #1556 five remaining snippet/export strippers · #1557 CLI + MCP resolution · #1547 updated with the journal's scope (its click already works; only authoring and in-journal `[[#Heading]]` wait on the BlockNote migration)

