### PR TITLE
feat(notes): a wiki link can name a heading while you are writing it

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -26,6 +26,7 @@ const contentAreaMocks = vi.hoisted(() => ({
   fetchLinkPreview: vi.fn(),
   toastError: vi.fn(),
   defaultFileItemClick: vi.fn(),
+  openSuggestionMenu: vi.fn(),
   createLinkMentionContent: vi.fn(
     (url: string, domain: string, title?: string, favicon?: string) => ({
       type: 'linkMention',
@@ -344,6 +345,7 @@ function resetEditor(): void {
       if ('props' in update) block.props = { ...block.props, ...(update.props as object) }
     }),
     insertBlocks: vi.fn(),
+    getExtension: vi.fn(() => ({ openSuggestionMenu: contentAreaMocks.openSuggestionMenu })),
     getTextCursorPosition: vi.fn(() => ({ block: urlBlock })),
     prosemirrorView: { focus: vi.fn(), dom: { blur: vi.fn() } },
     _tiptapEditor: {
@@ -832,6 +834,23 @@ describe('ContentArea', () => {
     await expect(slashController.getItems('photo')).resolves.toEqual([
       expect.objectContaining({ key: 'image' })
     ])
+  })
+
+  it('offers a "link to note" slash item that hands over to the [[ menu', async () => {
+    render(<ContentArea noteId="note-1" />)
+
+    const slashController = contentAreaMocks.suggestionControllers.find(
+      (controller) => controller.triggerCharacter === '/'
+    )
+    const items = await slashController.getItems('wikilink')
+    expect(items).toHaveLength(1)
+
+    items[0].onItemClick()
+    // Through the suggestion plugin's own opener, so `[[` reaches the doc with
+    // the plugin state that makes the wiki-link menu open.
+    expect(contentAreaMocks.openSuggestionMenu).toHaveBeenCalledWith('[[', {
+      deleteTriggerCharacter: true
+    })
   })
 
   it('debounces standalone checkbox conversion and clears pending conversion on unmount', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -13,6 +13,7 @@ import {
   type FilePanelProps,
   type SuggestionMenuProps
 } from '@blocknote/react'
+import { SuggestionMenu } from '@blocknote/core/extensions'
 import { BlockNoteView } from '@blocknote/shadcn'
 import { useTheme } from 'next-themes'
 import { AIMenuController, getAISlashMenuItems } from '@blocknote/xl-ai'
@@ -1364,12 +1365,29 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
                     }
                   ]
                 : []
+              // `/link` types `[[` for you and hands over to the wiki-link
+              // menu that trigger already owns — one search UI, one place `#`
+              // heading support lives, and the row teaches the shortcut. The
+              // trigger characters have to enter the doc through the suggestion
+              // plugin's own opener; inserting the text some other way leaves
+              // the plugin with no state and no menu.
+              const linkToNoteItem = {
+                title: t('editor.slashMenu.linkToNote.title'),
+                onItemClick: () =>
+                  editor
+                    .getExtension(SuggestionMenu)
+                    ?.openSuggestionMenu('[[', { deleteTriggerCharacter: true }),
+                aliases: ['link', 'wiki', 'wikilink', 'note', 'backlink'],
+                group: 'Basic blocks',
+                subtext: t('editor.slashMenu.linkToNote.subtext')
+              }
               const all = orderSlashMenuItemsByGroup([
                 ...defaults,
                 ...pdfItems,
                 calloutItem,
                 ...(taskItem ? [taskItem] : []),
                 ...dateItems,
+                linkToNoteItem,
                 ...aiItems
               ])
               if (!query) return all

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.test.tsx
@@ -5,6 +5,7 @@ import { useWikiLinkSuggestions } from './use-wiki-link-suggestions'
 const mocks = vi.hoisted(() => ({
   listNotes: vi.fn(),
   getFile: vi.fn(),
+  getByPath: vi.fn(),
   logger: {
     error: vi.fn()
   }
@@ -13,7 +14,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/services/notes-service', () => ({
   notesService: {
     list: (...args: unknown[]) => mocks.listNotes(...args),
-    getFile: (...args: unknown[]) => mocks.getFile(...args)
+    getFile: (...args: unknown[]) => mocks.getFile(...args),
+    getByPath: (...args: unknown[]) => mocks.getByPath(...args)
   }
 }))
 
@@ -28,8 +30,18 @@ describe('useWikiLinkSuggestions', () => {
     vi.setSystemTime(new Date('2026-05-10T12:00:00.000Z'))
     mocks.listNotes.mockResolvedValue({
       notes: [
-        { id: 'note-1', title: 'Daily Note', modified: new Date('2026-05-09T00:00:00.000Z') },
-        { id: 'note-2', title: 'Roadmap', modified: '2026-05-08T00:00:00.000Z' }
+        {
+          id: 'note-1',
+          title: 'Daily Note',
+          path: 'notes/Daily Note.md',
+          modified: new Date('2026-05-09T00:00:00.000Z')
+        },
+        {
+          id: 'note-2',
+          title: 'Roadmap',
+          path: 'notes/Roadmap.md',
+          modified: '2026-05-08T00:00:00.000Z'
+        }
       ]
     })
   })
@@ -146,6 +158,185 @@ describe('useWikiLinkSuggestions', () => {
     })
     expect(editor.insertInlineContent).not.toHaveBeenCalled()
     expect(editor.insertBlocks).not.toHaveBeenCalled()
+  })
+
+  describe('# heading mode', () => {
+    const body = [
+      '# Daily Note',
+      '',
+      '## **Kararlar** alındı',
+      '',
+      '```md',
+      '## not a heading',
+      '```',
+      '',
+      '### Sonraki adımlar'
+    ].join('\n')
+
+    it('lists the target note headings once the note half matches exactly', async () => {
+      mocks.getByPath.mockResolvedValue({ content: body })
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Daily Note#')
+      })
+
+      // By path, so the id lookup's `note_opened` telemetry never fires.
+      expect(mocks.getByPath).toHaveBeenCalledWith('notes/Daily Note.md')
+      expect(items).toEqual([
+        {
+          id: 'heading:note-1:0',
+          title: 'Daily Note',
+          target: 'Daily Note#Daily Note',
+          alias: '',
+          exists: true,
+          type: 'heading',
+          headingLevel: 1
+        },
+        {
+          id: 'heading:note-1:1',
+          title: 'Kararlar alındı',
+          target: 'Daily Note#Kararlar alındı',
+          alias: '',
+          exists: true,
+          type: 'heading',
+          headingLevel: 2
+        },
+        {
+          id: 'heading:note-1:2',
+          title: 'Sonraki adımlar',
+          target: 'Daily Note#Sonraki adımlar',
+          alias: '',
+          exists: true,
+          type: 'heading',
+          headingLevel: 3
+        }
+      ])
+    })
+
+    it('filters headings, keeps the alias, and caches the body for 5 seconds', async () => {
+      mocks.getByPath.mockResolvedValue({ content: body })
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        await result.current.getWikiLinkItems('Daily Note#')
+        items = await result.current.getWikiLinkItems('Daily Note#Kararlar|dün')
+      })
+
+      expect(mocks.getByPath).toHaveBeenCalledTimes(1)
+      expect(items).toEqual([
+        {
+          id: 'heading:note-1:0',
+          title: 'Kararlar alındı',
+          target: 'Daily Note#Kararlar alındı',
+          alias: 'dün',
+          exists: true,
+          type: 'heading',
+          headingLevel: 2
+        }
+      ])
+    })
+
+    it('keeps listing notes while the note half is only a prefix', async () => {
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Daily#')
+      })
+
+      expect(mocks.getByPath).not.toHaveBeenCalled()
+      expect(items.map((item) => item.type)).toEqual(['create'])
+      expect(items[0]).toMatchObject({ target: 'Daily#' })
+    })
+
+    it('does not offer headings for a block reference', async () => {
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      await act(async () => {
+        await result.current.getWikiLinkItems('Daily Note#^abc123')
+      })
+
+      expect(mocks.getByPath).not.toHaveBeenCalled()
+    })
+
+    it('says so when the note has no headings, and when none match', async () => {
+      mocks.getByPath.mockResolvedValue({ content: 'Just a paragraph.' })
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      let empty = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        empty = await result.current.getWikiLinkItems('Daily Note#')
+      })
+      expect(empty).toEqual([
+        {
+          id: 'headings:note-1',
+          title: 'Daily Note',
+          target: '',
+          alias: '',
+          exists: true,
+          type: 'headingEmpty',
+          filtered: false
+        }
+      ])
+
+      vi.setSystemTime(new Date('2026-05-10T12:00:06.000Z'))
+      mocks.getByPath.mockResolvedValue({ content: body })
+
+      let noMatch = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        noMatch = await result.current.getWikiLinkItems('Daily Note#zzz')
+      })
+      expect(noMatch).toEqual([
+        {
+          id: 'headings:note-1',
+          title: 'Daily Note',
+          target: '',
+          alias: '',
+          exists: true,
+          type: 'headingEmpty',
+          filtered: true
+        }
+      ])
+    })
+
+    it('logs and shows the empty row when the body cannot be read', async () => {
+      mocks.getByPath.mockRejectedValueOnce(new Error('read failed'))
+      const { result } = renderHook(() => useWikiLinkSuggestions({ insertInlineContent: vi.fn() }))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Daily Note#')
+      })
+
+      expect(mocks.logger.error).toHaveBeenCalledWith(
+        'Failed to load wiki link heading suggestions',
+        expect.any(Error)
+      )
+      expect(items).toEqual([expect.objectContaining({ type: 'headingEmpty' })])
+    })
+
+    it('inserts one wiki link node carrying the note#heading target', async () => {
+      mocks.getByPath.mockResolvedValue({ content: body })
+      const editor = { insertInlineContent: vi.fn() }
+      const { result } = renderHook(() => useWikiLinkSuggestions(editor))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Daily Note#Kararlar|dün')
+      })
+      await act(async () => {
+        await result.current.handleWikiLinkSelect(items[0])
+      })
+
+      expect(editor.insertInlineContent).toHaveBeenNthCalledWith(
+        1,
+        [{ type: 'wikiLink', props: { target: 'Daily Note#Kararlar alındı', alias: 'dün' } }],
+        { updateSelection: true }
+      )
+    })
   })
 
   it('refreshes stale cache and falls back to create suggestions on list failures', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.ts
@@ -1,19 +1,24 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { useCallback, useRef } from 'react'
+import { extractMarkdownHeadings, type MarkdownHeading } from '@memry/shared/markdown-headings'
+import { isBlockReference } from '@memry/shared/wiki-target'
 import { fuzzySearch } from '@/lib/fuzzy-search'
 import { toMemryFileUrl } from '@/lib/memry-file-url'
 import { notesService } from '@/services/notes-service'
 import { createWikiLinkInlineContent } from '../wiki-link'
-import { splitWikiLinkQuery } from '../wiki-link-utils'
+import { parseWikiLinkQuery } from '../wiki-link-utils'
 import type { WikiLinkSuggestionItem } from '../wiki-link-menu'
 import { createLogger } from '@/lib/logger'
 
 const log = createLogger('Hook:WikiLinkSuggestions')
 
+const CACHE_TTL_MS = 5000
+
 type NoteSuggestion = {
   id: string
   title: string
+  path: string
   modified?: Date | string
   fileType?: 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
   mimeType?: string | null
@@ -46,66 +51,139 @@ function createAudioFileBlockContent(props: {
 
 export function useWikiLinkSuggestions(editor: any) {
   const notesCacheRef = useRef<{ notes: NoteSuggestion[]; fetchedAt: number } | null>(null)
+  // Headings have no index in either database, so `#` reads the target note's
+  // body on demand. Cached per note, same 5s window as the note list.
+  const headingsCacheRef = useRef(
+    new Map<string, { headings: MarkdownHeading[]; fetchedAt: number }>()
+  )
 
-  const getWikiLinkItems = useCallback(async (query: string): Promise<WikiLinkSuggestionItem[]> => {
-    const now = Date.now()
-    const cache = notesCacheRef.current
-    const shouldRefresh = !cache || now - cache.fetchedAt > 5000
-    if (shouldRefresh) {
+  const loadHeadings = useCallback(
+    async (note: NoteSuggestion, now: number): Promise<MarkdownHeading[]> => {
+      const cached = headingsCacheRef.current.get(note.id)
+      if (cached && now - cached.fetchedAt <= CACHE_TTL_MS) return cached.headings
+
+      let headings: MarkdownHeading[] = []
       try {
-        const result = await notesService.list({ limit: 500, sortBy: 'modified' })
-        notesCacheRef.current = {
-          notes: result.notes.map((note) => ({
-            id: note.id,
-            title: note.title,
-            modified: note.modified,
-            fileType: note.fileType,
-            mimeType: note.mimeType,
-            fileSize: note.fileSize
-          })),
-          fetchedAt: now
-        }
+        // By path, not by id: `notes:get` counts as opening the note and emits
+        // `note_opened`, and typing `#` in someone else's link is not that.
+        const full = note.path ? await notesService.getByPath(note.path) : null
+        headings = full?.content ? extractMarkdownHeadings(full.content) : []
       } catch (error) {
-        log.error('Failed to load wiki link suggestions', error)
-        notesCacheRef.current = { notes: [], fetchedAt: now }
+        log.error('Failed to load wiki link heading suggestions', error)
       }
-    }
 
-    const notes = notesCacheRef.current?.notes ?? []
-    const { search, alias } = splitWikiLinkQuery(query)
-    const filtered = search ? fuzzySearch(notes, search, ['title']) : notes
-    const sorted = filtered.slice(0, 10)
+      headingsCacheRef.current.set(note.id, { headings, fetchedAt: now })
+      return headings
+    },
+    []
+  )
 
-    const suggestions: WikiLinkSuggestionItem[] = sorted.map((note) => ({
-      id: note.id,
-      title: note.title,
-      target: note.title,
-      alias,
-      exists: true,
-      type: 'note',
-      lastEdited: note.modified instanceof Date ? note.modified.toISOString() : note.modified,
-      ...(note.fileType && note.fileType !== 'markdown' ? { fileType: note.fileType } : {}),
-      ...(note.mimeType ? { mimeType: note.mimeType } : {}),
-      ...(note.fileSize != null ? { fileSize: note.fileSize } : {})
-    }))
+  const getWikiLinkItems = useCallback(
+    async (query: string): Promise<WikiLinkSuggestionItem[]> => {
+      const now = Date.now()
+      const cache = notesCacheRef.current
+      const shouldRefresh = !cache || now - cache.fetchedAt > CACHE_TTL_MS
+      if (shouldRefresh) {
+        try {
+          const result = await notesService.list({ limit: 500, sortBy: 'modified' })
+          notesCacheRef.current = {
+            notes: result.notes.map((note) => ({
+              id: note.id,
+              title: note.title,
+              path: note.path,
+              modified: note.modified,
+              fileType: note.fileType,
+              mimeType: note.mimeType,
+              fileSize: note.fileSize
+            })),
+            fetchedAt: now
+          }
+        } catch (error) {
+          log.error('Failed to load wiki link suggestions', error)
+          notesCacheRef.current = { notes: [], fetchedAt: now }
+        }
+      }
 
-    const hasExactMatch = search
-      ? filtered.some((note) => note.title.toLowerCase() === search.toLowerCase())
-      : true
+      const notes = notesCacheRef.current?.notes ?? []
+      const { search, note: notePart, heading, alias } = parseWikiLinkQuery(query)
 
-    if (search && !hasExactMatch) {
-      suggestions.push({
-        id: `create:${search}`,
-        title: search,
-        target: search,
+      // `#` is a separator, not a trigger. It switches the menu to the note's
+      // headings only once the note half names a note EXACTLY — `[[Topl#` still
+      // lists notes, `[[Toplantı#` lists Toplantı's headings — which is also what
+      // keeps `[[Sprint #4]]` (a real title) reaching the note list. Backspacing
+      // over the `#` needs no unwinding: the query is re-parsed on every keystroke.
+      // Block references (`#^id`) are not a heading Memry can offer, so they fall
+      // through to the note list rather than showing an empty heading menu.
+      const headingTarget =
+        heading !== null && !isBlockReference(heading)
+          ? notes.find((note) => note.title.toLowerCase() === notePart.toLowerCase())
+          : undefined
+
+      if (headingTarget) {
+        const headings = await loadHeadings(headingTarget, now)
+        const matches = heading ? fuzzySearch(headings, heading, ['text']) : headings
+
+        if (matches.length === 0) {
+          return [
+            {
+              id: `headings:${headingTarget.id}`,
+              title: headingTarget.title,
+              target: '',
+              alias,
+              exists: true,
+              type: 'headingEmpty',
+              filtered: headings.length > 0
+            }
+          ]
+        }
+
+        return matches.slice(0, 10).map((match, index) => ({
+          id: `heading:${headingTarget.id}:${index}`,
+          title: match.text,
+          // One raw string, exactly as a hand-typed link would be written.
+          target: `${headingTarget.title}#${match.text}`,
+          alias,
+          exists: true,
+          type: 'heading',
+          headingLevel: match.level
+        }))
+      }
+
+      const filtered = search ? fuzzySearch(notes, search, ['title']) : notes
+      const sorted = filtered.slice(0, 10)
+
+      const suggestions: WikiLinkSuggestionItem[] = sorted.map((note) => ({
+        id: note.id,
+        title: note.title,
+        target: note.title,
         alias,
-        exists: false,
-        type: 'create'
-      })
-    }
+        exists: true,
+        type: 'note',
+        lastEdited: note.modified instanceof Date ? note.modified.toISOString() : note.modified,
+        ...(note.fileType && note.fileType !== 'markdown' ? { fileType: note.fileType } : {}),
+        ...(note.mimeType ? { mimeType: note.mimeType } : {}),
+        ...(note.fileSize != null ? { fileSize: note.fileSize } : {})
+      }))
 
-    return suggestions
-  }, [])
+      const hasExactMatch = search
+        ? filtered.some((note) => note.title.toLowerCase() === search.toLowerCase())
+        : true
+
+      if (search && !hasExactMatch) {
+        suggestions.push({
+          id: `create:${search}`,
+          title: search,
+          target: search,
+          alias,
+          exists: false,
+          type: 'create'
+        })
+      }
+
+      return suggestions
+    },
+    [loadHeadings]
+  )
 
   const insertWikiLink = useCallback(
     (item: WikiLinkSuggestionItem) => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.test.tsx
@@ -9,7 +9,9 @@ vi.mock('@memry/i18n/renderer', () => ({
         'menus.wiki.embed': 'Embed',
         'menus.wiki.wikiLink': 'Wiki link',
         'menus.wiki.embedAria': `Embed ${values?.title ?? ''}`.trim(),
-        'menus.wiki.wikiLinkAria': `Wiki link ${values?.title ?? ''}`.trim()
+        'menus.wiki.wikiLinkAria': `Wiki link ${values?.title ?? ''}`.trim(),
+        'menus.wiki.noHeadings': `${values?.title ?? ''} has no headings`.trim(),
+        'menus.wiki.noMatchingHeadings': `No headings in ${values?.title ?? ''} match`.trim()
       }
       return messages[key] ?? key
     }
@@ -44,5 +46,65 @@ describe('WikiLinkMenu', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Wiki link Voice memo' }))
     expect(onItemClick).toHaveBeenCalledWith({ ...item, insertMode: 'wikiLink' })
+  })
+
+  it('renders heading rows that insert a note#heading target', () => {
+    const onItemClick = vi.fn()
+    const heading: WikiLinkSuggestionItem = {
+      id: 'heading:note-1:0',
+      title: 'Kararlar',
+      target: 'Toplantı#Kararlar',
+      alias: '',
+      exists: true,
+      type: 'heading',
+      headingLevel: 2
+    }
+
+    render(
+      <WikiLinkMenu
+        items={[heading]}
+        loadingState="loaded"
+        selectedIndex={0}
+        onItemClick={onItemClick}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('option', { name: 'Kararlar' }))
+    expect(onItemClick).toHaveBeenCalledWith({ ...heading, insertMode: 'wikiLink' })
+  })
+
+  it('says the note has no headings, and cannot be picked', () => {
+    const onItemClick = vi.fn()
+    const empty: WikiLinkSuggestionItem = {
+      id: 'headings:note-1',
+      title: 'Toplantı',
+      target: '',
+      exists: true,
+      type: 'headingEmpty',
+      filtered: false
+    }
+
+    const { rerender } = render(
+      <WikiLinkMenu
+        items={[empty]}
+        loadingState="loaded"
+        selectedIndex={0}
+        onItemClick={onItemClick}
+      />
+    )
+
+    expect(screen.getByText('Toplantı has no headings')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('option'))
+    expect(onItemClick).not.toHaveBeenCalled()
+
+    rerender(
+      <WikiLinkMenu
+        items={[{ ...empty, filtered: true }]}
+        loadingState="loaded"
+        selectedIndex={0}
+        onItemClick={onItemClick}
+      />
+    )
+    expect(screen.getByText('No headings in Toplantı match')).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.tsx
@@ -3,7 +3,7 @@
  */
 
 import type { SuggestionMenuProps } from '@blocknote/react'
-import { FileAudio, FileText, Plus } from '@/lib/icons'
+import { FileAudio, FileText, Hash, Plus } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
 
@@ -16,12 +16,28 @@ export type WikiLinkSuggestionItem = {
   target: string
   alias?: string
   exists: boolean
-  type: 'note' | 'create'
+  /**
+   * `heading` is a heading inside the note the query already named exactly.
+   * `headingEmpty` is that note having no heading to offer — a row rather than
+   * a separate empty state so the menu stays open while the user backspaces
+   * over the `#`, and it carries no target, so picking it does nothing.
+   */
+  type: 'note' | 'create' | 'heading' | 'headingEmpty'
   lastEdited?: string
   fileType?: WikiLinkFileType
   mimeType?: string | null
   fileSize?: number | null
   insertMode?: WikiLinkInsertMode
+  /** Heading rows only: indents the row so the note's outline is readable. */
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6
+  /** `headingEmpty` only: whether a heading filter is what emptied the list. */
+  filtered?: boolean
+}
+
+const HEADING_INDENTS = ['', 'ms-2', 'ms-4', 'ms-6', 'ms-6', 'ms-6'] as const
+
+function headingIndent(level: WikiLinkSuggestionItem['headingLevel']): string {
+  return HEADING_INDENTS[(level ?? 1) - 1] ?? ''
 }
 
 export function WikiLinkMenu({
@@ -72,6 +88,45 @@ export function WikiLinkMenu({
           'hover:bg-accent hover:text-accent-foreground',
           isSelected && 'bg-accent text-accent-foreground'
         )
+
+        if (item.type === 'headingEmpty') {
+          return (
+            <div
+              key={`${item.type}-${item.id}`}
+              className="flex items-center gap-2 px-2 py-1.5 text-sm text-muted-foreground"
+              role="option"
+              aria-selected={false}
+              aria-disabled
+            >
+              <Hash className="h-4 w-4 shrink-0 opacity-70" />
+              <span className="truncate">
+                {item.filtered
+                  ? t('menus.wiki.noMatchingHeadings', { title: item.title })
+                  : t('menus.wiki.noHeadings', { title: item.title })}
+              </span>
+            </div>
+          )
+        }
+
+        if (item.type === 'heading') {
+          return (
+            <button
+              type="button"
+              key={`${item.type}-${item.id}`}
+              className={itemClassName}
+              onClick={() => onItemClick?.({ ...item, insertMode: 'wikiLink' })}
+              role="option"
+              aria-selected={isSelected}
+            >
+              <Hash className="h-4 w-4 shrink-0 opacity-70" />
+              {/* Indent on the label, not the row: the row's own `px-2` and a
+                  logical `ps-*` would be two competing padding rules. */}
+              <span className={cn('truncate text-start', headingIndent(item.headingLevel))}>
+                {item.title}
+              </span>
+            </button>
+          )
+        }
 
         if (isAudio) {
           return (

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeMarkdownHardBreaks,
   normalizeTableContent,
   normalizeWikiLinks,
+  parseWikiLinkQuery,
   splitTextWithWikiLinks,
   splitWikiLinkQuery
 } from './wiki-link-utils'
@@ -33,6 +34,51 @@ describe('wiki-link utils', () => {
       { id: 'h1', text: 'Plan', level: 2, position: 0 },
       { id: 'h2', text: 'Next', level: 3, position: 40 }
     ])
+  })
+
+  describe('parseWikiLinkQuery', () => {
+    it('reads the note, heading and alias halves', () => {
+      expect(parseWikiLinkQuery('Toplantı#Kararlar|notlar')).toEqual({
+        search: 'Toplantı#Kararlar',
+        note: 'Toplantı',
+        heading: 'Kararlar',
+        alias: 'notlar'
+      })
+    })
+
+    it('reports no heading at all when no # was typed', () => {
+      expect(parseWikiLinkQuery('Toplantı')).toEqual({
+        search: 'Toplantı',
+        note: 'Toplantı',
+        heading: null,
+        alias: ''
+      })
+    })
+
+    it('reports an empty heading the moment # is typed', () => {
+      expect(parseWikiLinkQuery('Toplantı#')).toEqual({
+        search: 'Toplantı#',
+        note: 'Toplantı',
+        heading: '',
+        alias: ''
+      })
+    })
+
+    it('keeps the raw search so a # inside a title can still be looked up', () => {
+      expect(parseWikiLinkQuery('Sprint #4')).toEqual({
+        search: 'Sprint #4',
+        note: 'Sprint',
+        heading: '4',
+        alias: ''
+      })
+    })
+
+    it('takes the last segment of a nested heading path', () => {
+      expect(parseWikiLinkQuery('Note#One#Two')).toMatchObject({
+        note: 'Note',
+        heading: 'Two'
+      })
+    })
   })
 
   it('splits wiki link queries and inline text segments', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { Block } from '@blocknote/core'
+import { splitWikiTarget } from '@memry/shared/wiki-target'
 import type { HeadingInfo } from './types'
 import { createWikiLinkInlineContent, hasWikiLinkMarks } from './wiki-link'
 
@@ -57,6 +58,32 @@ export function splitWikiLinkQuery(query: string): { search: string; alias: stri
     search: rawTarget?.trim() ?? '',
     alias: rawAlias?.trim() ?? ''
   }
+}
+
+export interface WikiLinkQueryParts {
+  /** The whole target as typed, `#` and all — what the note list searches on. */
+  search: string
+  /** The note half of `note#heading`; equal to `search` when no `#` was typed. */
+  note: string
+  /** The heading half: `null` when no `#` was typed, `''` immediately after one. */
+  heading: string | null
+  alias: string
+}
+
+/**
+ * `Note#Heading|alias` → its three parts.
+ *
+ * `#` binds tighter than `|` because that is the order the grammar reads in,
+ * and `search` is kept alongside the split so the caller can fall back to it.
+ * That fallback is not optional: `#` is legal in a note title, so `Sprint #4`
+ * splits into note `Sprint` + heading `4`, and only an EXACT match on the note
+ * half may switch the menu into heading mode — everything else keeps searching
+ * titles for the raw string, exactly as before.
+ */
+export function parseWikiLinkQuery(query: string): WikiLinkQueryParts {
+  const { search, alias } = splitWikiLinkQuery(query)
+  const { note, heading } = splitWikiTarget(search)
+  return { search, note, heading, alias }
 }
 
 function createStyledText(

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -12,6 +12,8 @@ Type `[[` and start typing the title. An autocomplete dropdown appears with matc
 - **No match**: pressing <kbd>Enter</kbd> creates a new note with that title and links it.
 - **Audio file found**: pick **Link** for a normal reference or **Embed** for an inline audio block.
 
+The slash menu's **Link to note** item types the `[[` for you and opens the same dropdown.
+
 The link displays the target's current title, but the underlying reference uses a stable ID — renaming the target doesn't break the link.
 
 ## Following a Link
@@ -26,6 +28,16 @@ A link can name a heading inside its target, the way an Obsidian vault writes it
 - `[[#Decisions]]` — stays in the note you're reading and scrolls to that heading
 - `[[Meeting#Q3#Decisions]]` — a nested heading path; the last part names the heading
 - `[[Meeting#Decisions|the outcome]]` — an alias works exactly as it does elsewhere
+
+You don't have to remember the heading. Once the part before the `#` is a note's title
+**exactly**, typing `#` swaps the dropdown for that note's headings, indented as an outline;
+keep typing to filter them, and pick one to write the whole `[[Note#Heading]]` link. Delete
+the `#` and the note list comes back. If the note has no headings, the dropdown says so —
+memrynote will not add a heading to someone else's note.
+
+Because an exact title is what switches modes, `[[Sprint #` still lists notes: `Sprint` is
+not a note here, so nothing about `[[Sprint #4]]` changes. Block references (`#^`) are never
+offered.
 
 Heading matching ignores case and surrounding spaces, and the first heading with that text
 wins — the link records the heading's text, not its level or its position. If the heading

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -180,6 +180,10 @@
       "pdf": {
         "title": "PDF",
         "subtext": "Attach a PDF and read it inline"
+      },
+      "linkToNote": {
+        "title": "Link to note",
+        "subtext": "Search notes — or type [[ anywhere"
       }
     },
     "filePanel": {
@@ -207,7 +211,9 @@
       "embed": "Embed",
       "wikiLink": "Wiki link",
       "embedAria": "Embed {title}",
-      "wikiLinkAria": "Wiki link {title}"
+      "wikiLinkAria": "Wiki link {title}",
+      "noHeadings": "{title} has no headings",
+      "noMatchingHeadings": "No headings in {title} match"
     },
     "mention": {
       "aria": "Date and note suggestions",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,7 +16,8 @@
     "./youtube": "./src/youtube.ts",
     "./task-block": "./src/task-block.ts",
     "./markdown-class": "./src/markdown-class.ts",
-    "./wiki-target": "./src/wiki-target.ts"
+    "./wiki-target": "./src/wiki-target.ts",
+    "./markdown-headings": "./src/markdown-headings.ts"
   },
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/shared/src/markdown-headings.test.ts
+++ b/packages/shared/src/markdown-headings.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { extractMarkdownHeadings, stripInlineMarkdown } from './markdown-headings'
+
+describe('extractMarkdownHeadings', () => {
+  it('reads every ATX level in document order', () => {
+    const markdown = ['# One', '## Two', '### Three', '#### Four', '##### Five', '###### Six'].join(
+      '\n'
+    )
+
+    expect(extractMarkdownHeadings(markdown)).toEqual([
+      { text: 'One', level: 1 },
+      { text: 'Two', level: 2 },
+      { text: 'Three', level: 3 },
+      { text: 'Four', level: 4 },
+      { text: 'Five', level: 5 },
+      { text: 'Six', level: 6 }
+    ])
+  })
+
+  it('ignores hashes inside fenced code blocks', () => {
+    const markdown = [
+      '# Real',
+      '',
+      '```bash',
+      '# not a heading',
+      '```',
+      '',
+      '~~~',
+      '## also not a heading',
+      '```',
+      '~~~',
+      '',
+      '## Real again'
+    ].join('\n')
+
+    expect(extractMarkdownHeadings(markdown)).toEqual([
+      { text: 'Real', level: 1 },
+      { text: 'Real again', level: 2 }
+    ])
+  })
+
+  it('ignores lines that only look like headings', () => {
+    const markdown = ['#NoSpace', '    # indented four spaces', '###', 'plain text', '#'].join('\n')
+
+    expect(extractMarkdownHeadings(markdown)).toEqual([])
+  })
+
+  it('drops a closing hash sequence but keeps a trailing hash in a word', () => {
+    expect(extractMarkdownHeadings('## Sprint ##')).toEqual([{ text: 'Sprint', level: 2 }])
+    expect(extractMarkdownHeadings('## C#')).toEqual([{ text: 'C#', level: 2 }])
+  })
+
+  it('strips inline markdown so the text matches what the editor renders', () => {
+    const markdown = ['## **Kalın** başlık', '## `code` and [link](https://x.dev)'].join('\n')
+
+    expect(extractMarkdownHeadings(markdown)).toEqual([
+      { text: 'Kalın başlık', level: 2 },
+      { text: 'code and link', level: 2 }
+    ])
+  })
+
+  it('handles CRLF line endings', () => {
+    expect(extractMarkdownHeadings('# One\r\n\r\n## Two\r\n')).toEqual([
+      { text: 'One', level: 1 },
+      { text: 'Two', level: 2 }
+    ])
+  })
+})
+
+describe('stripInlineMarkdown', () => {
+  it('unwraps emphasis, strike and inline code', () => {
+    expect(stripInlineMarkdown('***all*** **bold** *em* ~~gone~~ `code`')).toBe(
+      'all bold em gone code'
+    )
+    expect(stripInlineMarkdown('_em_ and __strong__')).toBe('em and strong')
+  })
+
+  it('leaves intraword underscores alone', () => {
+    expect(stripInlineMarkdown('snake_case_name')).toBe('snake_case_name')
+  })
+
+  it('reduces links, wiki links and images to their text', () => {
+    expect(stripInlineMarkdown('[text](https://x.dev)')).toBe('text')
+    expect(stripInlineMarkdown('[[Note|Alias]] and [[Other]]')).toBe('Alias and Other')
+    expect(stripInlineMarkdown('Before ![alt](img.png) after')).toBe('Before after')
+  })
+
+  it('collapses whitespace the way the editor does', () => {
+    expect(stripInlineMarkdown('  two   spaces  ')).toBe('two spaces')
+  })
+})

--- a/packages/shared/src/markdown-headings.ts
+++ b/packages/shared/src/markdown-headings.ts
@@ -1,0 +1,106 @@
+/**
+ * Reading a note's headings out of its markdown.
+ *
+ * `[[Note#Heading]]` carries the heading's TEXT, and the click side resolves it
+ * by comparing that text against BlockNote's plain text of each heading block
+ * (`extractHeadings`). So a heading offered by the `[[` autocomplete has to be
+ * written in the SAME form the click side will see, or the link the user just
+ * picked lands nowhere.
+ *
+ * That is the whole reason this file exists rather than a one-line regex. The
+ * only heading source available at authoring time is the target note's markdown
+ * on disk — there is no heading index in either database — and markdown is not
+ * plain text: `## **Kalın** başlık` reads as `**Kalın** başlık` in the file and
+ * as `Kalın başlık` in the editor. Offering the raw markdown form would write a
+ * link that can never match.
+ *
+ * Deliberately NOT handled:
+ * - Setext headings (`Title` over `===`). `---` is also a thematic break and a
+ *   frontmatter fence, so recognising them costs false positives — and a false
+ *   positive is a heading the user can pick but the click side will never find,
+ *   while a false negative is only a heading missing from a menu.
+ * - Block references (`^id`). Memry has no persistent block ids; see
+ *   `isBlockReference` in `./wiki-target`.
+ */
+
+export interface MarkdownHeading {
+  /** The heading's plain text, in the form the click-side matcher compares. */
+  text: string
+  level: 1 | 2 | 3 | 4 | 5 | 6
+}
+
+const ATX_HEADING = /^ {0,3}(#{1,6})(?:[ \t]+(.*))?$/
+const FENCE = /^ {0,3}(```|~~~)/
+
+/**
+ * Every ATX heading in a markdown body, in document order, with inline markdown
+ * stripped from each heading's text.
+ *
+ * Headings that are empty once stripped are dropped, because the click side
+ * drops them too: `extractHeadings` only records blocks whose text survives a
+ * trim, so a `###` on its own is not a target anything can point at.
+ */
+export function extractMarkdownHeadings(markdown: string): MarkdownHeading[] {
+  const headings: MarkdownHeading[] = []
+  let openFence: string | null = null
+
+  for (const rawLine of markdown.split('\n')) {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
+
+    // A `#` inside a fenced code block is code, not a heading. Only a fence of
+    // the same character closes the block, so ``` inside a ~~~ block is text.
+    const fence = line.match(FENCE)
+    if (fence) {
+      if (openFence === null) {
+        openFence = fence[1][0]
+        continue
+      }
+      if (fence[1][0] === openFence) {
+        openFence = null
+      }
+      continue
+    }
+    if (openFence !== null) continue
+
+    const match = line.match(ATX_HEADING)
+    if (!match) continue
+
+    // `## Heading ##` — a closing sequence must be preceded by whitespace, so
+    // `## C#` keeps its `#`.
+    const withoutClosing = (match[2] ?? '').replace(/[ \t]+#+[ \t]*$/, '')
+    const text = stripInlineMarkdown(withoutClosing)
+    if (!text) continue
+
+    headings.push({ text, level: match[1].length as MarkdownHeading['level'] })
+  }
+
+  return headings
+}
+
+/**
+ * A single line of markdown reduced to the plain text BlockNote would render.
+ *
+ * Whitespace is collapsed because the editor's is: markdown reaches BlockNote
+ * through HTML, where a run of spaces renders as one.
+ */
+export function stripInlineMarkdown(text: string): string {
+  return (
+    text
+      .replace(/<!--[\s\S]*?-->/g, '')
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // image: a heading has no inline image node, so it contributes no text
+      .replace(/\[\[[^\]|]+\|([^\]]+)\]\]/g, '$1') // wiki link w/ alias → alias
+      .replace(/\[\[([^\]]+)\]\]/g, '$1') // wiki link → target
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // link → text
+      .replace(/`+([^`]*)`+/g, '$1') // inline code
+      .replace(/\*\*\*(.+?)\*\*\*/g, '$1')
+      .replace(/\*\*(.+?)\*\*/g, '$1')
+      .replace(/\*(.+?)\*/g, '$1')
+      .replace(/~~(.+?)~~/g, '$1')
+      // Underscore emphasis only at word boundaries: `snake_case` is literal
+      // text in GFM and stays literal in the editor, so a blunt strip would
+      // write a link text the click side can never match.
+      .replace(/(?<![\p{L}\p{N}])_{1,3}(.+?)_{1,3}(?![\p{L}\p{N}])/gu, '$1')
+      .replace(/\s+/g, ' ')
+      .trim()
+  )
+}


### PR DESCRIPTION
> **Stacked on #1558.** Base is `fix/wiki-heading-links`, not `main`. Review that one first; this diff is only the authoring half.

## What this adds

PR #1558 made an existing `[[Note#Heading]]` link *work*. It left the other half of Aurelie's report untouched: there is no way to author one. The `[[` autocomplete searches titles, and `#` just fell into the title search and matched nothing.

**1. `#` mode in the `[[` menu.** Type `[[Meeting#` and the menu lists Meeting's headings; pick one and you get a single link token.

`#` is an ordinary separator, not a magic trigger — the menu only switches to headings once the note part is an **exact** title match, so `[[Meet#` still shows notes and backspacing over the `#` returns to the note list. Alias still works (`[[Meeting#Decisions|the outcome]]`). No "create heading" option: writing into another note is a different authority. Block references are not offered.

**2. A "Link to note" slash entry.** It inserts `[[` and hands over to the menu above rather than opening a second dialog — one search UI, `#` support not written twice, and it teaches the `[[` shortcut instead of competing with it.

## The trap this had to avoid

There is no heading index in either database, so the menu reads the target note's body on demand and caches it. That body is **markdown**, but the click side (#1558) matches against BlockNote's **plain text** of the heading block. A heading written `## **Q3** review` gives `**Q3** review` from markdown and `Q3 review` from the editor — so the link would have been written in a form that could never land.

`extractMarkdownHeadings` therefore strips inline markdown (emphasis, code, links, wiki links), skips fenced code blocks, drops closing `##` sequences, and collapses whitespace the way HTML rendering does. Two details worth a look in review:

- **Underscore emphasis is stripped only at word boundaries.** The blunt `[*_~]` strip that `app-core`'s `stripMarkup` uses would turn `snake_case` into `snakecase` and write an unmatchable link.
- **Setext headings (`===`/`---` underlines) are deliberately skipped.** `---` is also a thematic break and a frontmatter fence; a false positive is a heading you can pick that the click side can never find, whereas a false negative is just a missing row.

## Notes on the implementation

- **Body read goes through `notes:get-by-path`, not `notes:get`** — the latter emits a `note_opened` telemetry event (`notes-handlers.ts:215`), and typing `#` in a link is not opening a note.
- **Two empty states**, not one: "this note has no headings" and "no headings match your filter" would otherwise both read as a lie in one of the two cases.
- No contracts/preload change, so no `ipc:generate`. No schema change; `target` stays one raw string, exactly as on disk.

## Verification

Re-run after rebasing onto #1558's current head (`842196bc3`), not inherited from the pre-rebase run:

```
pnpm typecheck                          → Tasks: 17 successful, 17 total
pnpm lint                               → 0 errors, 98 warnings (same count as the base — this adds none)
pnpm --filter @memry/desktop test:renderer
                                        → Test Files  635 passed (635)
                                               Tests  7397 passed | 7 skipped (7404)
pnpm --filter @memry/desktop i18n:check → ok: i18n check passed
pnpm check:architecture                 → architecture boundary check passed
pnpm check:contracts                    → contracts boundary check passed
git diff --check                        → clean
```

## Not verified

**The slash-menu handover has not been exercised in a running Electron app.** It goes through BlockNote's own `openSuggestionMenu('[[', { deleteTriggerCharacter: true })`, which inserts the trigger inside the same transaction that sets the plugin meta, so the plugin state cannot be missed — but that is reading the library's source, not clicking the item. A unit test asserts the exact call. Worth a manual pass before this leaves draft.

No E2E was added here. Given that #1558's E2E caught a defect the entire renderer suite was blind to, an E2E for the `#` menu is worth adding before merge rather than after.

## Out of scope

The journal keeps its own hand-rolled Tiptap `[[` suggestion; doing this there means writing it twice against two APIs, and it waits for #1547 (scope note added there). Junk-note cleanup #1555, snippet strippers #1556, CLI/MCP resolution #1557.
