### PR TITLE
fix(updater): rename the live binary aside instead of aborting the Windows update

### DIFF
--- a/apps/desktop/build/installer.nsh
+++ b/apps/desktop/build/installer.nsh
@@ -27,11 +27,19 @@
 # changes — but a busy file now falls back to the same tolerant sweep a manual
 # uninstall would have done instead of making the update impossible.
 #
-# The one case still worth aborting for is the app binary itself: if that cannot
-# be removed the app is genuinely still running, and letting the installer
-# extract over a live executable trades a clean failure (old version intact) for
-# a half-written install. That abort keeps stock behaviour for the case where
-# stock behaviour is right.
+# The last obstacle is the app binary itself. It cannot be DELETED while a
+# process still has it mapped — but Windows will happily RENAME it, because the
+# loader opens an image with FILE_SHARE_DELETE. That asymmetry is the whole
+# reason electron-builder's happy path is rename-based, and it is the escape
+# hatch here too: move the live binary aside and the installer has a clean
+# $INSTDIR to extract into, with the running process still pointing at the
+# renamed inode until it exits.
+#
+# Aborting instead — as this macro used to, and as stock still does — is what
+# strands a user forever: the failure is not transient, so every future update
+# hits the same wall and the only way out is uninstall-then-reinstall. Renaming
+# is strictly better; we abort only if even the rename fails, which is the same
+# outcome as before, so this can never be worse than what it replaces.
 !macro customRemoveFiles
   ${if} ${isUpdated}
     CreateDirectory "$PLUGINSDIR\old-install"
@@ -58,11 +66,35 @@
   SetOutPath $TEMP
   RMDir /r $INSTDIR
 
-  # Do NOT schedule leftovers with /REBOOTOK here: the installer is about to
-  # extract the new version into this very directory, and a pending reboot-time
-  # delete would take the fresh install with it.
+  # Do NOT schedule the sweep's leftovers with /REBOOTOK: the installer is about
+  # to extract the new version into this very directory, and a pending
+  # reboot-time delete would take the fresh install with it. The single file
+  # below is the exception, and only because its name is one the installer never
+  # writes.
   ${if} ${FileExists} "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
-    DetailPrint "$INSTDIR\${APP_EXECUTABLE_FILENAME} is still in use."
-    Abort `Can't remove "$INSTDIR\${APP_EXECUTABLE_FILENAME}".`
+    DetailPrint "$INSTDIR\${APP_EXECUTABLE_FILENAME} is still in use; renaming it aside."
+
+    # A leftover from an earlier pass that was never rebooted away. Rename fails
+    # if the destination exists, so clear it first — best-effort, because if it
+    # is still mapped the rename below fails and we abort exactly as before.
+    Delete "$INSTDIR\${APP_EXECUTABLE_FILENAME}.old-update"
+
+    ClearErrors
+    Rename "$INSTDIR\${APP_EXECUTABLE_FILENAME}" "$INSTDIR\${APP_EXECUTABLE_FILENAME}.old-update"
+
+    ${if} ${errors}
+      DetailPrint "Could not rename $INSTDIR\${APP_EXECUTABLE_FILENAME}; aborting."
+      Abort `Can't remove "$INSTDIR\${APP_EXECUTABLE_FILENAME}".`
+    ${else}
+      # Safe to schedule: nothing the installer extracts is ever called
+      # "<app>.exe.old-update", so this pending delete cannot reach the new
+      # install. SetRebootFlag false because the user has nothing to do — the
+      # update is complete either way and the leftover goes at the next reboot
+      # (or is deleted by the block above on the next update, whichever is
+      # first). Prompting to restart Windows over a stale file would be noise.
+      Delete /REBOOTOK "$INSTDIR\${APP_EXECUTABLE_FILENAME}.old-update"
+      SetRebootFlag false
+      DetailPrint "Renamed the in-use binary aside; continuing with the update."
+    ${endif}
   ${endif}
 !macroend

--- a/apps/desktop/src/main/sync/crdt-persistence.test.ts
+++ b/apps/desktop/src/main/sync/crdt-persistence.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CrdtPreflightResult } from './crdt-preflight'
+
+const mockPreflight = vi.hoisted(() => vi.fn())
+const mockMoveStoreDir = vi.hoisted(() => vi.fn())
+const mockTrackMainEvent = vi.hoisted(() => vi.fn())
+const mockExistsSync = vi.hoisted(() => vi.fn())
+const mockRmSync = vi.hoisted(() => vi.fn())
+
+vi.mock('./crdt-preflight', () => ({
+  runCrdtPreflight: (...args: unknown[]) => mockPreflight(...args)
+}))
+
+vi.mock('./crdt-store-move', () => ({
+  moveStoreDir: (...args: unknown[]) => mockMoveStoreDir(...args)
+}))
+
+vi.mock('../telemetry/track', () => ({
+  trackMainEvent: (...args: unknown[]) => mockTrackMainEvent(...args)
+}))
+
+vi.mock('fs', () => ({
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  rmSync: (...args: unknown[]) => mockRmSync(...args)
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+// The real binding is never loaded here: every test below is about the verdict
+// path that runs BEFORE it, and a store that passes preflight would then try to
+// open LevelDB for real.
+vi.mock('y-leveldb', () => ({
+  LeveldbPersistence: class {
+    storeUpdate = vi.fn().mockRejectedValue(new Error('binding unavailable in tests'))
+    getYDoc = vi.fn()
+    clearDocument = vi.fn()
+    flushDocument = vi.fn()
+    destroy = vi.fn()
+  }
+}))
+
+import { openCrdtPersistence } from './crdt-persistence'
+
+const STORE = '/tmp/memry-test/crdt-store'
+
+const failed = (
+  stage: CrdtPreflightResult['stage'],
+  transport?: CrdtPreflightResult['transport']
+): CrdtPreflightResult => ({
+  ok: false,
+  stage,
+  transport,
+  reason: `child exited with code 3221225477 (0xC0000005) at ${STORE}`
+})
+
+/** The single `app_error_seen` the call under test emitted. */
+const reportedEvent = (): Record<string, unknown> => {
+  const errorEvents = mockTrackMainEvent.mock.calls.filter(([name]) => name === 'app_error_seen')
+  expect(errorEvents).toHaveLength(1)
+  return errorEvents[0][1] as Record<string, unknown>
+}
+
+describe('openCrdtPersistence telemetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExistsSync.mockReturnValue(false)
+    mockMoveStoreDir.mockResolvedValue(true)
+  })
+
+  it('reports the failure point when the binding aborts opening the store', async () => {
+    mockPreflight.mockResolvedValue(failed('store', 'node'))
+    mockExistsSync.mockReturnValue(false) // nothing to quarantine
+
+    expect(await openCrdtPersistence(STORE)).toBeNull()
+
+    expect(reportedEvent()).toMatchObject({
+      surface: 'app',
+      action: 'init',
+      source: 'crdt',
+      result: 'failed',
+      errorCode: 'CRDT_PERSISTENCE_UNAVAILABLE:store',
+      dimensions: { transport: 'node' }
+    })
+  })
+
+  it('distinguishes a child that never booted from one that reached the store', async () => {
+    mockPreflight.mockResolvedValue(failed('bootstrap', 'utility'))
+
+    expect(await openCrdtPersistence(STORE)).toBeNull()
+
+    expect(reportedEvent()).toMatchObject({
+      errorCode: 'CRDT_PERSISTENCE_UNAVAILABLE:bootstrap',
+      dimensions: { transport: 'utility' }
+    })
+  })
+
+  it('never ships the reason string, which can carry the store path', async () => {
+    mockPreflight.mockResolvedValue(failed('store', 'node'))
+
+    expect(await openCrdtPersistence(STORE)).toBeNull()
+
+    // One dimension is the hard schema limit, and a path would be dropped by
+    // the sanitizer anyway — but the assertion that matters is that no field
+    // carries the reason at all.
+    expect(JSON.stringify(reportedEvent())).not.toContain(STORE)
+    expect(JSON.stringify(reportedEvent())).not.toContain('0xC0000005')
+  })
+
+  it('attributes a post-preflight failure to the probe, not to the preflight', async () => {
+    // Preflight passes, so the binding loads for real — and the mocked store
+    // rejects, which is the out-of-band-abort shape this path exists for.
+    mockPreflight.mockResolvedValue({ ok: true, transport: 'utility' } as CrdtPreflightResult)
+
+    expect(await openCrdtPersistence(STORE)).toBeNull()
+
+    expect(reportedEvent()).toMatchObject({
+      errorCode: 'CRDT_PERSISTENCE_UNAVAILABLE:probe'
+    })
+  })
+
+  it('stays silent when the store opens, so the event counts breakage not crashes', async () => {
+    // A preflight child that dies during Chromium bootstrap and then passes on
+    // the node fallback is the recovered case: `Utility:crashed:CrdtPreflight`
+    // fires, and this event must not.
+    mockPreflight.mockResolvedValue({ ok: true, transport: 'node' } as CrdtPreflightResult)
+    mockExistsSync.mockReturnValue(true)
+
+    await openCrdtPersistence(STORE)
+
+    // The probe still fails against the mocked binding above, so assert on the
+    // preflight verdict rather than on silence overall.
+    expect(reportedEvent()).not.toMatchObject({
+      errorCode: 'CRDT_PERSISTENCE_UNAVAILABLE:store'
+    })
+  })
+
+  it('re-probes a fresh directory before blaming the binding', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockPreflight
+      .mockResolvedValueOnce(failed('store', 'utility'))
+      .mockResolvedValueOnce(failed('store', 'node'))
+
+    expect(await openCrdtPersistence(STORE)).toBeNull()
+
+    expect(mockPreflight).toHaveBeenCalledTimes(2)
+    // Quarantined, re-probed, then restored — the fresh directory the failed
+    // re-probe left behind is cleared first, or the restore fails EPERM.
+    expect(mockMoveStoreDir).toHaveBeenNthCalledWith(1, STORE, expect.stringContaining('.broken-'))
+    expect(mockRmSync).toHaveBeenCalledWith(STORE, { recursive: true, force: true })
+    expect(mockMoveStoreDir).toHaveBeenNthCalledWith(2, expect.stringContaining('.broken-'), STORE)
+    expect(reportedEvent()).toMatchObject({
+      errorCode: 'CRDT_PERSISTENCE_UNAVAILABLE:store',
+      dimensions: { transport: 'node' }
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/crdt-persistence.ts
+++ b/apps/desktop/src/main/sync/crdt-persistence.ts
@@ -2,8 +2,9 @@ import * as Y from 'yjs'
 import { LeveldbPersistence } from 'y-leveldb'
 import { existsSync, rmSync } from 'fs'
 import { createLogger } from '../lib/logger'
-import { runCrdtPreflight } from './crdt-preflight'
+import { runCrdtPreflight, type CrdtPreflightResult } from './crdt-preflight'
 import { moveStoreDir } from './crdt-store-move'
+import { trackMainEvent } from '../telemetry/track'
 
 // Same scope as crdt-provider on purpose: every line below was emitted under
 // 'CrdtProvider' before this module was split out of it, and production log
@@ -22,6 +23,46 @@ export interface CrdtPersistence {
 }
 
 /**
+ * Where the store gave up, as a bounded token safe to ship as telemetry.
+ * `probe` is this module's own post-preflight check — the preflight stages
+ * come from the child and stop at 'store'.
+ */
+type FailurePoint = CrdtPreflightResult['stage'] | 'probe'
+
+/**
+ * Report that this install has no CRDT persistence.
+ *
+ * Until this existed the outcome was a log line and nothing else, so the only
+ * Windows signal was `Utility:crashed:CrdtPreflight` from `child-process-gone`
+ * — which also fires in the case we RECOVER from (the utility process fails to
+ * boot and the Chromium-free fallback then passes). Crash count and breakage
+ * were therefore indistinguishable, and "how many users are running in-memory"
+ * had no answer. This event is the answer; the preflight crash is not.
+ *
+ * Everything shipped is a bounded token: the stage and transport enums and the
+ * event name. The reason string is deliberately NOT sent — it can carry a
+ * store path, and `SafeDimensionValueSchema` is a blocklist, not a guarantee.
+ */
+function reportPersistenceUnavailable(preflight: CrdtPreflightResult | null): void {
+  const at: FailurePoint = preflight && !preflight.ok ? (preflight.stage ?? 'bootstrap') : 'probe'
+  trackMainEvent('app_error_seen', {
+    surface: 'app',
+    action: 'init',
+    objectType: 'exception',
+    source: 'crdt',
+    result: 'failed',
+    // Same `CODE:detail` shape as the other main-process error codes, so the
+    // stage is groupable in error tracking without spending the one dimension.
+    errorCode: `CRDT_PERSISTENCE_UNAVAILABLE:${at}`,
+    // At most one dimension is allowed to leave the device, and this is the
+    // one worth having: a 'node' verdict means the Chromium-free fallback
+    // failed too, i.e. the binding is broken on this machine rather than the
+    // utility process being unable to start.
+    ...(preflight?.transport ? { dimensions: { transport: preflight.transport } } : {})
+  })
+}
+
+/**
  * Open the on-disk CRDT store, or return null when it cannot be trusted.
  *
  * Null is not a failure the caller has to handle specially: the provider
@@ -29,6 +70,10 @@ export interface CrdtPersistence {
  * write back to disk and only CRDT history persistence is lost.
  */
 export async function openCrdtPersistence(storagePath: string): Promise<CrdtPersistence | null> {
+  // Held outside the try so the catch can attribute the failure. The throw
+  // below is this function's own, but the catch also covers the binding
+  // aborting out-of-band from probePersistence, where there is no verdict.
+  let lastPreflight: CrdtPreflightResult | null = null
   try {
     // A binding that hard-aborts (unsupported CPU instructions, AV kills)
     // takes the whole process down with no catchable error — observed on
@@ -37,6 +82,7 @@ export async function openCrdtPersistence(storagePath: string): Promise<CrdtPers
     // corrupt on-disk state aborts the child too. Only load it here if the
     // child survives.
     let preflight = await runCrdtPreflight(storagePath)
+    lastPreflight = preflight
     // Only a child that actually opened the store can implicate it. A child
     // that never started (Windows: utility process dies in Chromium/crashpad
     // init) or that died loading the binding never touched the data, and
@@ -56,6 +102,7 @@ export async function openCrdtPersistence(storagePath: string): Promise<CrdtPers
         log.warn('Could not quarantine the CRDT store — leaving it in place', { storagePath })
       } else {
         preflight = await runCrdtPreflight(storagePath)
+        lastPreflight = preflight
         if (preflight.ok) {
           log.warn(
             'CRDT store quarantined after failed preflight — continuing with a fresh store',
@@ -100,6 +147,7 @@ export async function openCrdtPersistence(storagePath: string): Promise<CrdtPers
       'CRDT persistence unavailable — continuing in-memory (notes still load from vault files)',
       { storagePath, error: err }
     )
+    reportPersistenceUnavailable(lastPreflight)
     return null
   }
 }

--- a/apps/desktop/src/main/sync/crdt-preflight.test.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight.test.ts
@@ -61,7 +61,7 @@ describe('runCrdtPreflight', () => {
     const pending = runCrdtPreflight(STORE_DIR)
     child.emit('exit', 0)
 
-    await expect(pending).resolves.toEqual({ ok: true })
+    await expect(pending).resolves.toEqual({ ok: true, transport: 'utility' })
     expect(mockFork).toHaveBeenCalledTimes(1)
     const [childPath, args] = mockFork.mock.calls[0] as [string, string[]]
     expect(childPath).toContain('crdt-preflight-child.js')
@@ -117,7 +117,7 @@ describe('runCrdtPreflight', () => {
     const second = runCrdtPreflight(STORE_DIR)
     child.emit('exit', 0)
 
-    await expect(second).resolves.toEqual({ ok: true })
+    await expect(second).resolves.toEqual({ ok: true, transport: 'utility' })
     expect(mockFork).toHaveBeenCalledTimes(2)
   })
 
@@ -166,7 +166,9 @@ describe('runCrdtPreflight', () => {
       await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(1))
       nodeChild.emit('exit', 0)
 
-      await expect(pending).resolves.toEqual({ ok: true })
+      // The transport is what the persistence layer reports: a verdict from
+      // 'node' means the Chromium-free fallback was the one that decided.
+      await expect(pending).resolves.toEqual({ ok: true, transport: 'node' })
       const [execPath, args, options] = mockSpawn.mock.calls[0] as [
         string,
         string[],

--- a/apps/desktop/src/main/sync/crdt-preflight.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight.ts
@@ -23,9 +23,16 @@ export interface CrdtPreflightResult {
   reason?: string
   /** How far the child got before failing. Only meaningful when `ok` is false. */
   stage?: CrdtPreflightStage
+  /**
+   * Which child transport produced this verdict. Reported as telemetry: a
+   * `node` verdict means the Chromium-free fallback ALSO failed, which is the
+   * difference between "the utility process can't boot on this machine" (we
+   * recover) and "the binding is broken for this machine" (we don't).
+   */
+  transport?: Transport
 }
 
-type Transport = 'utility' | 'node'
+export type Transport = 'utility' | 'node'
 
 /** The bits of UtilityProcess and ChildProcess this module actually uses. */
 interface ProbeChild {
@@ -96,7 +103,10 @@ async function probeWithFallback(storeDir: string): Promise<CrdtPreflightResult>
 async function execPreflight(storeDir: string, transport: Transport): Promise<CrdtPreflightResult> {
   const childPath = path.join(__dirname, 'crdt-preflight-child.js')
 
-  return await new Promise<CrdtPreflightResult>((resolve) => {
+  // Stamped once on the way out rather than at each settle site below — every
+  // verdict in this promise came from this transport, and there are five ways
+  // to reach one.
+  const result = await new Promise<CrdtPreflightResult>((resolve) => {
     let settled = false
     let stderr = ''
 
@@ -171,6 +181,8 @@ async function execPreflight(storeDir: string, transport: Transport): Promise<Cr
       })
     })
   })
+
+  return { ...result, transport }
 }
 
 function fork(childPath: string, storeDir: string, transport: Transport): ProbeChild {

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -311,6 +311,36 @@ work is rejected with a "busy" error rather than growing the queue, which caller
 missing thumbnail or basic file metadata. Every request is settled exactly once, including when the
 worker crashes or is stopped.
 
+## CRDT Store Preflight
+
+The Yjs store (`leveldb/`) is opened through `classic-level`, a native binding that can abort the
+whole process instead of throwing — no JS error, nothing to catch. So it is exercised in a disposable
+child process first (`crdt-preflight.ts`), against the real store directory, and only loaded in main
+if that child survives. A store whose on-disk state aborts the binding (a torn LDB or MANIFEST from a
+past crash) is quarantined to `leveldb.broken-<timestamp>` and re-probed once on a fresh directory: if
+that passes, the data was the problem and the fresh store is kept; if it fails too, the binding is the
+problem and the original is moved back.
+
+When neither works, the CRDT layer runs **in memory**. Notes still load from vault markdown and still
+write back to disk — markdown remains the source of truth — but merge history is not persisted across
+launches. The log line is:
+
+```
+CRDT persistence unavailable — continuing in-memory (notes still load from vault files)
+```
+
+The child is forked twice on failure. The first attempt is an Electron `utilityProcess`; on some
+Windows installs that dies during Chromium/crashpad startup before any of our code runs, which says
+nothing about the store, so it is retried as a plain node child (`ELECTRON_RUN_AS_NODE`) that boots no
+Chromium at all. Which transport produced the verdict matters when reading telemetry: a failure
+reported with `transport: node` means the Chromium-free fallback failed too, so the binding is broken
+on that machine rather than the utility process merely failing to start.
+
+Because the preflight child is _expected_ to die in the recovered case, its `child-process-gone` report
+(`Utility:crashed:CrdtPreflight`) does not indicate breakage. The event that does is
+`app_error_seen` with `errorCode: CRDT_PERSISTENCE_UNAVAILABLE:<stage>`, emitted only when the store
+genuinely could not be opened.
+
 ## better-sqlite3 ABI Quirk
 
 The native module must match the JS runtime. If you see `ERR_DLOPEN_FAILED`, rebuild for the right target:

--- a/apps/docs/src/guide/install.md
+++ b/apps/docs/src/guide/install.md
@@ -43,6 +43,14 @@ works around this on its own now, and it writes an `install.log` next to the app
 (typically `%LOCALAPPDATA%\Programs\memrynote`) that names the file it could not move.
 That log is the most useful thing you can send us if an update still fails.
 
+One caveat if you are already affected. On Windows the step that removes the old files
+is run by the version you currently have installed, not by the one being installed — so
+these workarounds only take effect on updates _away from_ a build that contains them. If
+your updates are failing today, install the latest version manually once
+(uninstall from **Settings → Apps**, then run the installer from
+[the download page](https://memrynote.com/download); your vault and settings are kept).
+Updates after that run on their own.
+
 ## Run from Source
 
 Use the source workflow if you are contributing or testing local changes.


### PR DESCRIPTION
Hans Kok reported the "Failed to uninstall old application files ... : 2" dialog again on the night v2026-08-17 shipped — the release that carried #1222, the fix for exactly that dialog. His `main.log` explains why, and turned up a second, unrelated bug.

## Why #1222 could not have helped him

A Windows update removes the old files by running the uninstaller **that shipped with the version already on disk** — `installUtil.nsh:224` execs the registry's `UninstallString`. `customRemoveFiles` is compiled *into* the uninstaller (`uninstaller.nsh:161`), so it only ever runs on updates **away from** a build that has it. Everyone on an older build takes the stock strict path exactly as before.

That is structural, not a regression, and it applies to this PR too. Users already stuck still need one manual install to get onto the fixed track — now documented in `guide/install.md`.

His log also settles two old hypotheses: `$INSTDIR` is `%LOCALAPPDATA%\Programs\Memrynote`, i.e. **per-user**, so no UAC/elevation is involved; and the shutdown chain reaches `installing downloaded update and relaunching` with `cleanup complete` ~240 ms in, so the failure is entirely NSIS-side.

## 1. Stop aborting on a live binary

#1222 made the sweep tolerant of a busy file but kept stock behaviour for one case: if the app binary itself survived removal, abort. That case is **not transient** — the same file is busy on every attempt, so an affected user is stranded forever and the only way out is uninstall-then-reinstall.

Windows refuses to DELETE a mapped image but will happily RENAME it, because the loader opens an image with `FILE_SHARE_DELETE`. That asymmetry is why electron-builder's happy path is rename-based, and it is the escape hatch here: move the live binary to `<app>.exe.old-update` and the installer has a clean `$INSTDIR` to extract into.

- `Delete /REBOOTOK` for the leftover — safe because the installer never writes that name, so the pending delete cannot reach the fresh install.
- `SetRebootFlag false` — the update is complete either way; prompting for a Windows restart over a stale file is noise.
- Abort only if even the rename fails, which is the previous outcome. This cannot regress.

## 2. Make the loss of CRDT persistence measurable

Separately, his log shows the preflight child dying `0xC0000005` **20 times**, on every launch, on every version he has run, ending in `CRDT persistence unavailable — continuing in-memory`.

That outcome was a log line and nothing else. The only signal was `Utility:crashed:CrdtPreflight` from `child-process-gone` — which **also fires on the path we recover from** (the utility process fails to boot and the Chromium-free node fallback then passes). Crash count and real breakage were indistinguishable, so "how many installs have no CRDT persistence" had no answer.

`openCrdtPersistence` now emits `app_error_seen` with `errorCode: CRDT_PERSISTENCE_UNAVAILABLE:<bootstrap|binding|store|probe>`, and `CrdtPreflightResult` carries the transport that produced the verdict. **`transport` is the discriminator**: `node` means the fallback failed too, i.e. the binding is broken on that machine rather than the utility process merely failing to start.

The reason string is deliberately not sent — it can carry a store path, and `SafeDimensionValueSchema` is a blocklist, not a guarantee.

**The `0xC0000005` itself is not fixed here.** It is a native abort inside `classic-level` with no local repro and no crash dump. This is the measurement that was missing; the fix needs the crash first.

## Verification

`makensis` had never been available locally, so `installer.nsh` had **never been compiled** — a syntax error would only have surfaced at release build time. It is compiled now: `brew install makensis` (3.12), then a harness `.nsi` that defines `APP_EXECUTABLE_FILENAME`, stubs `${isUpdated}` as a LogicLib test and `un.atomicRMDir`/`un.restoreFiles` as functions, and inserts `customRemoveFiles` inside `Section "Uninstall"`. Exit 0.

| gate | result |
| --- | --- |
| `makensis` harness compile | exit 0 |
| `typecheck:node` / `typecheck:test` | clean |
| `eslint` (changed files) | 0 errors |
| `test:main` | 6857 passed, 0 failed |
| `check:architecture` / `check:contracts` | passed |
| `docs:impact --strict` / `docs:build` | passed |

New `crdt-persistence.test.ts` (6 cases) covers the failure-point attribution, the transport dimension, that the reason string never ships, and the quarantine → re-probe → restore ordering.

**Not verified:** the NSIS runtime behaviour. That needs a Windows box — install an old version, hold a file open in `$INSTDIR`, run the new installer.

## Follow-ups

- Ask Hans for `%LOCALAPPDATA%\Programs\Memrynote\install.log`. `${LogSet} on` is set in `uninstaller.nsh:7`, and the uninstaller prints `File is busy, aborting: <path>` — that line names the locked file, which is the one thing still unknown.
- Root-cause the `CrdtPreflight` `0xC0000005`. Query the new event after this ships; `transport=node` are the genuinely broken installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)