### PR TITLE
feat(menu): check for updates from the app menu on every platform

### DIFF
--- a/apps/desktop/src/main/menu.test.ts
+++ b/apps/desktop/src/main/menu.test.ts
@@ -118,6 +118,26 @@ describe('buildAppMenu', () => {
     expect(openExternal).toHaveBeenCalledWith('https://docs.memrynote.com')
   })
 
+  it('offers Check for Updates… on every platform and routes it to the renderer', async () => {
+    const i18n = await createMainI18n({ locale: 'en' })
+    const send = vi.fn()
+    vi.mocked(BrowserWindow.getFocusedWindow).mockReturnValue({
+      webContents: { isDestroyed: () => false, send }
+    } as unknown as Electron.BrowserWindow)
+
+    buildAppMenu(i18n)
+
+    // macOS puts it in the app menu, Windows/Linux in Help — either way it sits
+    // in the built template and dispatches the same renderer command.
+    const item = findMenuItem('Check for Updates…')
+    expect(item).toMatchObject({ id: 'app.checkForUpdates' })
+
+    item?.click?.()
+    expect(send).toHaveBeenCalledWith(AppChannels.events.MENU_COMMAND, {
+      command: 'app.checkForUpdates'
+    })
+  })
+
   it('routes Edit undo/redo through the renderer instead of native roles', async () => {
     const i18n = await createMainI18n({ locale: 'en' })
     const send = vi.fn()

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -85,6 +85,11 @@ export function buildAppMenu(i18n: I18nInstance): Menu {
         }
       : { role: 'about', label: t('help.about') }
 
+  // Lives in the app menu on macOS and in Help elsewhere, next to About in both —
+  // the platform-native home for it. The renderer runs the check so the result
+  // reuses the in-app toast/prompt surfaces instead of a native dialog.
+  const checkForUpdatesItem = cmd('app.checkForUpdates', t('app.checkForUpdates'))
+
   const template: MenuItemConstructorOptions[] = [
     ...(isMac
       ? [
@@ -92,6 +97,7 @@ export function buildAppMenu(i18n: I18nInstance): Menu {
             label: 'MemryNote',
             submenu: [
               { role: 'about' as const, label: t('help.about') },
+              checkForUpdatesItem,
               { type: 'separator' as const },
               cmd('app.preferences', t('app.preferences')),
               { type: 'separator' as const },
@@ -263,7 +269,7 @@ export function buildAppMenu(i18n: I18nInstance): Menu {
       role: 'help',
       label: t('help.label'),
       submenu: [
-        ...(isMac ? [] : [aboutItem, { type: 'separator' as const }]),
+        ...(isMac ? [] : [aboutItem, checkForUpdatesItem, { type: 'separator' as const }]),
         // F1 registers as a real accelerator (default registerAccelerator: true):
         // the action lives here in the main process, so unlike the renderer-owned
         // cmd() items there is no editor keydown to swallow. Opening the docs is

--- a/apps/desktop/src/renderer/src/hooks/use-menu-commands.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-menu-commands.ts
@@ -10,6 +10,7 @@ import {
   runEditorMenuCommand,
   runHistoryMenuCommand
 } from '@/lib/menu-commands'
+import { runMenuUpdateCheck } from '@/lib/menu-update-check'
 
 interface MenuCommandHandlers {
   onNewNote: () => void
@@ -44,6 +45,7 @@ export function useMenuCommands({ onNewNote, onOpenSearch }: MenuCommandHandlers
     'edit.redo': () => runHistoryMenuCommand('redo'),
     'edit.find': () => window.dispatchEvent(new CustomEvent('memry:menu-find')),
     'app.preferences': () => openSettings(),
+    'app.checkForUpdates': () => void runMenuUpdateCheck(),
     'view.toggleSidebar': toggleSidebar,
     'view.toggleDayPanel': toggleDayPanel,
     'view.shortcuts': () => window.dispatchEvent(new CustomEvent('memry:open-shortcuts')),

--- a/apps/desktop/src/renderer/src/lib/menu-update-check.test.ts
+++ b/apps/desktop/src/renderer/src/lib/menu-update-check.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppUpdateState } from '@memry/contracts/ipc-updater'
+
+const { toast } = vi.hoisted(() => ({
+  toast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('sonner', () => ({ toast }))
+vi.mock('react-i18next', () => ({
+  getI18n: () => ({ getFixedT: () => (key: string) => key })
+}))
+
+import { runMenuUpdateCheck } from './menu-update-check'
+
+const baseState: AppUpdateState = {
+  currentVersion: '1.0.0',
+  status: 'up-to-date',
+  updateSupported: true,
+  availableVersion: null,
+  releaseName: null,
+  releaseDate: null,
+  releaseNotes: null,
+  releaseNotesHtml: null,
+  downloadProgressPercent: null,
+  lastCheckedAt: null,
+  error: null,
+  autoDownloadEnabled: false,
+  autoCheckEnabled: true
+}
+
+let checkForUpdates: ReturnType<typeof vi.fn>
+
+function mockUpdaterResult(result: Partial<AppUpdateState>): void {
+  checkForUpdates.mockResolvedValue({ ...baseState, ...result })
+}
+
+describe('runMenuUpdateCheck', () => {
+  beforeEach(() => {
+    toast.info.mockClear()
+    toast.success.mockClear()
+    toast.error.mockClear()
+    checkForUpdates = vi.fn()
+    ;(window.api.updater as Record<string, unknown>).checkForUpdates = checkForUpdates
+  })
+
+  it('confirms an up-to-date install', async () => {
+    mockUpdaterResult({ status: 'up-to-date' })
+
+    await runMenuUpdateCheck()
+
+    expect(checkForUpdates).toHaveBeenCalledTimes(1)
+    expect(toast.success).toHaveBeenCalledWith('general.updates.upToDateToast')
+  })
+
+  it('says so in dev builds, where updates are unsupported', async () => {
+    mockUpdaterResult({ status: 'unavailable', updateSupported: false })
+
+    await runMenuUpdateCheck()
+
+    expect(toast.info).toHaveBeenCalledWith('general.updates.unsupportedToast')
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('reports an available update even when the in-app prompt stays silent', async () => {
+    // Auto-download suppresses UpdatePromptDialog, so the toast is the only
+    // feedback an explicit menu click gets.
+    mockUpdaterResult({ status: 'available', availableVersion: '1.1.0', autoDownloadEnabled: true })
+
+    await runMenuUpdateCheck()
+
+    expect(toast.info).toHaveBeenCalledWith('general.updates.available')
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the updater error from state', async () => {
+    mockUpdaterResult({ status: 'error', error: 'feed unreachable' })
+
+    await runMenuUpdateCheck()
+
+    expect(toast.error).toHaveBeenCalledWith('feed unreachable')
+  })
+
+  it('surfaces a failed IPC call', async () => {
+    checkForUpdates.mockRejectedValue(new Error('ipc exploded'))
+
+    await runMenuUpdateCheck()
+
+    expect(toast.error).toHaveBeenCalledWith('ipc exploded')
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/menu-update-check.ts
+++ b/apps/desktop/src/renderer/src/lib/menu-update-check.ts
@@ -1,0 +1,48 @@
+import { toast } from 'sonner'
+import { getI18n } from 'react-i18next'
+import { extractErrorMessage } from '@/lib/ipc-error'
+
+/**
+ * Menu-bar "Check for Updates…" (macOS app menu, Help menu on Windows/Linux).
+ *
+ * Runs the same check as the Settings button and always reports the outcome as a
+ * toast. An available or downloaded update also raises `UpdatePromptDialog` from
+ * the broadcast state, but that prompt stays silent when auto-download is on or
+ * the user dismissed it this session — the toast is what keeps an explicit menu
+ * click from looking dead.
+ */
+export async function runMenuUpdateCheck(): Promise<void> {
+  const t = getI18n().getFixedT(null, 'settings')
+
+  try {
+    const state = await window.api.updater.checkForUpdates()
+
+    if (!state.updateSupported) {
+      toast.info(t('general.updates.unsupportedToast'))
+      return
+    }
+
+    const version = state.availableVersion ?? ''
+
+    switch (state.status) {
+      case 'available':
+        toast.info(t('general.updates.available', { version }))
+        break
+      case 'downloading':
+        toast.info(t('general.updates.downloadingLatest'))
+        break
+      case 'downloaded':
+        toast.info(t('general.updates.downloaded', { version }))
+        break
+      case 'error':
+        toast.error(state.error ?? t('general.updates.actionFailed'))
+        break
+      // The check resolves only once it settles, so anything else means there is
+      // no newer release to offer.
+      default:
+        toast.success(t('general.updates.upToDateToast', { version: state.currentVersion }))
+    }
+  } catch (err) {
+    toast.error(extractErrorMessage(err, t('general.updates.actionFailed')))
+  }
+}

--- a/apps/docs/src/user-guide/menu-bar.md
+++ b/apps/docs/src/user-guide/menu-bar.md
@@ -7,8 +7,8 @@ palette, or the editor's slash menu.
 
 ## Menus
 
-- **App menu** (macOS only, named “memrynote”) — About, Settings, Hide/Show,
-  and Quit.
+- **App menu** (macOS only, named “memrynote”) — About, Check for Updates,
+  Settings, Hide/Show, and Quit.
 - **File** — New Note, Open Quickly (the command palette), Export to PDF, Close
   Tab, and Close Window. On Windows and Linux this menu also contains Quit.
 - **Edit** — Undo / Redo, Cut / Copy / Paste (including Paste and Match Style),
@@ -21,12 +21,22 @@ palette, or the editor's slash menu.
 - **View** — Reload, Developer Tools, zoom, full screen, Toggle Sidebar, Toggle
   Day Panel, and a Theme submenu (Light, Dark, Paper, System).
 - **Window** — standard window controls (minimize, zoom, front).
-- **Help** — About, Documentation (<kbd>F1</kbd>), and Keyboard Shortcuts.
+- **Help** — on Windows and Linux, About and Check for Updates; on every
+  platform, Documentation (<kbd>F1</kbd>) and Keyboard Shortcuts.
 
 ## About
 
 The **About** entry opens the operating system's native about panel on macOS
 and Linux, and a simple dialog showing the version on Windows.
+
+## Check for Updates
+
+**Check for Updates…** sits next to About — in the app menu on macOS, in Help on
+Windows and Linux. It runs the same check as the button in
+[Settings → General → Updates](/user-guide/settings), and always reports the
+result as a toast, so the click is never silent even when automatic downloads
+are on. When a new version is found the usual update prompt opens with the
+release notes.
 
 ## Insert and Format act on the focused note
 

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -73,6 +73,8 @@ When memrynote finds an update it opens an in-app **update prompt** showing the 
 - **Skip This Version** — never prompt automatically for this version again. A manual check clears the skip so the version can surface again.
 - **Automatically download & install updates** — when enabled, future updates download in the background and install on the next quit without prompting.
 
+You can also run the same check from the menu bar without opening Settings: **memrynote → Check for Updates…** on macOS, **Help → Check for Updates…** on Windows and Linux. The result is always reported as a toast — up to date, an available or ready-to-install version, or the error — and an available update still opens the update prompt unless automatic downloads are on. In a development build the toast says updates are packaged-release only.
+
 ### Language & Region
 
 - **Language** — UI locale dropdown, 32 languages

--- a/packages/i18n/src/locales/ar/menu.json
+++ b/packages/i18n/src/locales/ar/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "إنهاء",
     "preferences": "الإعدادات…",
+    "checkForUpdates": "التحقق من وجود تحديثات…",
     "exit": "خروج",
     "hide": "إخفاء MemryNote",
     "hideOthers": "إخفاء الأخرى",

--- a/packages/i18n/src/locales/cs/menu.json
+++ b/packages/i18n/src/locales/cs/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Ukončit",
     "preferences": "Nastavení…",
+    "checkForUpdates": "Zkontrolovat aktualizace…",
     "exit": "Konec",
     "hide": "Skrýt MemryNote",
     "hideOthers": "Skrýt ostatní",

--- a/packages/i18n/src/locales/da/menu.json
+++ b/packages/i18n/src/locales/da/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Slut",
     "preferences": "Indstillinger…",
+    "checkForUpdates": "Søg efter opdateringer…",
     "exit": "Afslut",
     "hide": "Skjul MemryNote",
     "hideOthers": "Skjul andre",

--- a/packages/i18n/src/locales/de/menu.json
+++ b/packages/i18n/src/locales/de/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "MemryNote beenden",
     "preferences": "Einstellungen…",
+    "checkForUpdates": "Nach Updates suchen…",
     "exit": "Beenden",
     "hide": "MemryNote ausblenden",
     "hideOthers": "Andere ausblenden",

--- a/packages/i18n/src/locales/el/menu.json
+++ b/packages/i18n/src/locales/el/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Τερματισμός",
     "preferences": "Ρυθμίσεις…",
+    "checkForUpdates": "Έλεγχος για ενημερώσεις…",
     "exit": "Έξοδος",
     "hide": "Απόκρυψη MemryNote",
     "hideOthers": "Απόκρυψη άλλων",

--- a/packages/i18n/src/locales/en/menu.json
+++ b/packages/i18n/src/locales/en/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Quit",
     "preferences": "Settings…",
+    "checkForUpdates": "Check for Updates…",
     "services": "Services",
     "hide": "Hide MemryNote",
     "hideOthers": "Hide Others",

--- a/packages/i18n/src/locales/es/menu.json
+++ b/packages/i18n/src/locales/es/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Salir de MemryNote",
     "preferences": "Ajustes…",
+    "checkForUpdates": "Buscar actualizaciones…",
     "exit": "Salir",
     "hide": "Ocultar MemryNote",
     "hideOthers": "Ocultar otros",

--- a/packages/i18n/src/locales/fi/menu.json
+++ b/packages/i18n/src/locales/fi/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Lopeta",
     "preferences": "Asetukset…",
+    "checkForUpdates": "Tarkista päivitykset…",
     "exit": "Lopeta",
     "hide": "Kätke MemryNote",
     "hideOthers": "Kätke muut",

--- a/packages/i18n/src/locales/fil/menu.json
+++ b/packages/i18n/src/locales/fil/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "I-quit",
     "preferences": "Mga Setting…",
+    "checkForUpdates": "Maghanap ng Mga Update…",
     "exit": "Lumabas",
     "hide": "Itago ang MemryNote",
     "hideOthers": "Itago ang Iba",

--- a/packages/i18n/src/locales/fr/menu.json
+++ b/packages/i18n/src/locales/fr/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Quitter",
     "preferences": "Paramètres…",
+    "checkForUpdates": "Rechercher les mises à jour…",
     "exit": "Quitter",
     "hide": "Masquer MemryNote",
     "hideOthers": "Masquer les autres",

--- a/packages/i18n/src/locales/he/menu.json
+++ b/packages/i18n/src/locales/he/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "צא",
     "preferences": "הגדרות…",
+    "checkForUpdates": "חיפוש עדכונים…",
     "exit": "יציאה",
     "hide": "הסתר את MemryNote",
     "hideOthers": "הסתר אחרים",

--- a/packages/i18n/src/locales/hr/menu.json
+++ b/packages/i18n/src/locales/hr/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Izađi",
     "preferences": "Postavke…",
+    "checkForUpdates": "Provjeri ima li ažuriranja…",
     "exit": "Izlaz",
     "hide": "Sakrij MemryNote",
     "hideOthers": "Sakrij ostale",

--- a/packages/i18n/src/locales/hu/menu.json
+++ b/packages/i18n/src/locales/hu/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Kilépés a MemryNote-ból",
     "preferences": "Beállítások…",
+    "checkForUpdates": "Frissítések keresése…",
     "exit": "Kilépés",
     "hide": "MemryNote elrejtése",
     "hideOthers": "Egyebek elrejtése",

--- a/packages/i18n/src/locales/id/menu.json
+++ b/packages/i18n/src/locales/id/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Keluar dari MemryNote",
     "preferences": "Pengaturan…",
+    "checkForUpdates": "Periksa Pembaruan…",
     "exit": "Keluar",
     "hide": "Sembunyikan MemryNote",
     "hideOthers": "Sembunyikan Lainnya",

--- a/packages/i18n/src/locales/it/menu.json
+++ b/packages/i18n/src/locales/it/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Esci",
     "preferences": "Impostazioni…",
+    "checkForUpdates": "Cerca aggiornamenti…",
     "exit": "Esci",
     "hide": "Nascondi MemryNote",
     "hideOthers": "Nascondi altre",

--- a/packages/i18n/src/locales/ja/menu.json
+++ b/packages/i18n/src/locales/ja/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "終了",
     "preferences": "設定…",
+    "checkForUpdates": "アップデートを確認…",
     "exit": "終了",
     "hide": "MemryNote を隠す",
     "hideOthers": "ほかを隠す",

--- a/packages/i18n/src/locales/ko/menu.json
+++ b/packages/i18n/src/locales/ko/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "종료",
     "preferences": "설정…",
+    "checkForUpdates": "업데이트 확인…",
     "exit": "끝내기",
     "hide": "MemryNote 가리기",
     "hideOthers": "기타 가리기",

--- a/packages/i18n/src/locales/ms/menu.json
+++ b/packages/i18n/src/locales/ms/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Berhenti",
     "preferences": "Tetapan…",
+    "checkForUpdates": "Semak Kemas Kini…",
     "exit": "Keluar",
     "hide": "Sembunyikan MemryNote",
     "hideOthers": "Sembunyikan Yang Lain",

--- a/packages/i18n/src/locales/nl/menu.json
+++ b/packages/i18n/src/locales/nl/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Stoppen",
     "preferences": "Instellingen…",
+    "checkForUpdates": "Zoeken naar updates…",
     "exit": "Afsluiten",
     "hide": "Verberg MemryNote",
     "hideOthers": "Verberg andere",

--- a/packages/i18n/src/locales/no/menu.json
+++ b/packages/i18n/src/locales/no/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Avslutt",
     "preferences": "Innstillinger…",
+    "checkForUpdates": "Se etter oppdateringer…",
     "exit": "Avslutt",
     "hide": "Skjul MemryNote",
     "hideOthers": "Skjul andre",

--- a/packages/i18n/src/locales/pl/menu.json
+++ b/packages/i18n/src/locales/pl/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Zakończ",
     "preferences": "Ustawienia…",
+    "checkForUpdates": "Sprawdź aktualizacje…",
     "exit": "Wyjdź",
     "hide": "Ukryj MemryNote",
     "hideOthers": "Ukryj pozostałe",

--- a/packages/i18n/src/locales/pt/menu.json
+++ b/packages/i18n/src/locales/pt/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Encerrar",
     "preferences": "Definições…",
+    "checkForUpdates": "Procurar atualizações…",
     "exit": "Sair",
     "hide": "Ocultar MemryNote",
     "hideOthers": "Ocultar outros",

--- a/packages/i18n/src/locales/ro/menu.json
+++ b/packages/i18n/src/locales/ro/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Ieșire din MemryNote",
     "preferences": "Setări…",
+    "checkForUpdates": "Caută actualizări…",
     "exit": "Ieșire",
     "hide": "Ascunde MemryNote",
     "hideOthers": "Ascunde celelalte",

--- a/packages/i18n/src/locales/ru/menu.json
+++ b/packages/i18n/src/locales/ru/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Завершить",
     "preferences": "Настройки…",
+    "checkForUpdates": "Проверить обновления…",
     "exit": "Выход",
     "hide": "Скрыть MemryNote",
     "hideOthers": "Скрыть остальные",

--- a/packages/i18n/src/locales/sk/menu.json
+++ b/packages/i18n/src/locales/sk/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Ukončiť",
     "preferences": "Nastavenia…",
+    "checkForUpdates": "Skontrolovať aktualizácie…",
     "exit": "Ukončiť",
     "hide": "Skryť MemryNote",
     "hideOthers": "Skryť ostatné",

--- a/packages/i18n/src/locales/sv/menu.json
+++ b/packages/i18n/src/locales/sv/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Avsluta",
     "preferences": "Inställningar…",
+    "checkForUpdates": "Sök efter uppdateringar…",
     "exit": "Avsluta",
     "hide": "Göm MemryNote",
     "hideOthers": "Göm övriga",

--- a/packages/i18n/src/locales/th/menu.json
+++ b/packages/i18n/src/locales/th/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "ออก",
     "preferences": "การตั้งค่า…",
+    "checkForUpdates": "ตรวจสอบการอัปเดต…",
     "exit": "ออก",
     "hide": "ซ่อน MemryNote",
     "hideOthers": "ซ่อนรายการอื่น",

--- a/packages/i18n/src/locales/tr/menu.json
+++ b/packages/i18n/src/locales/tr/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Çık",
     "preferences": "Ayarlar…",
+    "checkForUpdates": "Güncellemeleri Denetle…",
     "exit": "Çıkış",
     "hide": "MemryNote'u Gizle",
     "hideOthers": "Diğerlerini Gizle",

--- a/packages/i18n/src/locales/uk/menu.json
+++ b/packages/i18n/src/locales/uk/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Завершити",
     "preferences": "Налаштування…",
+    "checkForUpdates": "Перевірити оновлення…",
     "exit": "Вихід",
     "hide": "Сховати MemryNote",
     "hideOthers": "Сховати інші",

--- a/packages/i18n/src/locales/vi/menu.json
+++ b/packages/i18n/src/locales/vi/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "Thoát",
     "preferences": "Cài đặt…",
+    "checkForUpdates": "Kiểm tra bản cập nhật…",
     "exit": "Thoát",
     "hide": "Ẩn MemryNote",
     "hideOthers": "Ẩn ứng dụng khác",

--- a/packages/i18n/src/locales/zh-CN/menu.json
+++ b/packages/i18n/src/locales/zh-CN/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "退出",
     "preferences": "设置…",
+    "checkForUpdates": "检查更新…",
     "exit": "退出",
     "hide": "隐藏 MemryNote",
     "hideOthers": "隐藏其他",

--- a/packages/i18n/src/locales/zh-TW/menu.json
+++ b/packages/i18n/src/locales/zh-TW/menu.json
@@ -2,6 +2,7 @@
   "app": {
     "quit": "結束",
     "preferences": "設定…",
+    "checkForUpdates": "檢查更新…",
     "exit": "離開",
     "hide": "隱藏 MemryNote",
     "hideOthers": "隱藏其他",


### PR DESCRIPTION
## What

Adds **Check for Updates…** to the native menu bar on all platforms:

- **macOS** — app menu, right under About (before Settings)
- **Windows / Linux** — Help menu, right under About

Until now the updater could only be triggered from Settings → General → Updates, which is two navigations away and invisible unless you already know it's there.

## How

- `src/main/menu.ts` builds one `cmd('app.checkForUpdates', …)` item and places it in the platform-appropriate submenu. No native dialog in main — the renderer runs the check, so the result reuses the in-app surfaces.
- New `src/renderer/src/lib/menu-update-check.ts` calls `window.api.updater.checkForUpdates()` and always toasts the outcome: up to date, available, downloading, ready to install, error, or "packaged releases only" in a dev build.
- An available update still opens the existing `UpdatePromptDialog` from the broadcast state. The toast is the point: that prompt stays silent when auto-download is on or it was dismissed this session, and an explicit menu click must never look dead.
- No new IPC and no new renderer i18n keys — the existing `settings:general.updates.*` strings cover every outcome.
- New `menu.app.checkForUpdates` key added to all 32 locales (menu.json has full key parity; no English leaking into a translated menu bar).

## Tests

- `src/main/menu.test.ts` — the item exists in the built template on every platform and dispatches `app.checkForUpdates` to the focused window.
- `src/renderer/src/lib/menu-update-check.test.ts` (new) — up-to-date, unsupported dev build, available while auto-download suppresses the prompt, updater error from state, failed IPC call.

## Verification

- `pnpm typecheck` (17 tasks) — green
- desktop `main` project — 532 files / 6856 tests green; renderer suite green
- `pnpm lint` — 0 errors
- `pnpm --filter @memry/desktop i18n:check` — ok
- `pnpm docs:impact --base <base> --strict` + `pnpm docs:build` — green (docs updated: menu-bar + settings)

Unrelated pre-existing red: `packages/i18n` ICU tests fail on `en/common.json → canvas.link.useUrl` (`{{url}}`), same on `origin/main`.