### PR TITLE
fix(tasks): refresh the task list without an app restart

### DIFF
--- a/apps/desktop/src/renderer/src/features/tasks/use-task-queries.test.tsx
+++ b/apps/desktop/src/renderer/src/features/tasks/use-task-queries.test.tsx
@@ -1,7 +1,7 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { focusManager, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { taskKeys, useTaskWorkspaceData, useTaskWorkspaceMutations } from './use-task-queries'
 import { tasksService } from '@/services/tasks-service'
 
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
     error: vi.fn()
   },
   listeners: {} as Record<string, () => void>,
+  syncStatusListener: null as ((event: { status: string }) => void) | null,
   unsubscribe: vi.fn()
 }))
 
@@ -81,9 +82,21 @@ function makeTask(overrides: Record<string, unknown> = {}) {
 }
 
 describe('useTaskWorkspaceData', () => {
+  // focusManager is module-global. Leaving it explicitly focused would follow
+  // this file out and change refetch behaviour for whatever runs next.
+  afterEach(() => {
+    focusManager.setFocused(undefined)
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.listeners = {}
+    mocks.syncStatusListener = null
+    focusManager.setFocused(undefined)
+    window.api.onSyncStatusChanged = vi.fn((callback) => {
+      mocks.syncStatusListener = callback as (event: { status: string }) => void
+      return mocks.unsubscribe
+    }) as typeof window.api.onSyncStatusChanged
     window.api.onItemSynced = vi.fn((callback) => {
       mocks.listeners.itemSyncedTask = () => callback({ type: 'task', id: 'task-1' } as never)
       mocks.listeners.itemSyncedProject = () =>
@@ -183,6 +196,69 @@ describe('useTaskWorkspaceData', () => {
 
     unmount()
     expect(mocks.unsubscribe).toHaveBeenCalled()
+  })
+
+  // A pull on the other machine emits one ITEM_SYNCED per item. If that event
+  // is dropped, nothing else refreshes this list: the app-wide default is
+  // refetchOnWindowFocus: false and there is no interval, so the user has to
+  // restart the app to see the other machine's tasks. Settling out of `syncing`
+  // is the reconcile point that does not depend on the window losing focus.
+  it('reconciles the workspace when a sync settles', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { result } = renderHook(() => useTaskWorkspaceData({ enabled: true }), {
+      wrapper: createWrapper(queryClient)
+    })
+
+    await waitFor(() => expect(result.current.tasks).toHaveLength(3))
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+    // Entering `syncing` is not a completion — reconciling here would refetch
+    // against rows the pull has not written yet.
+    act(() => mocks.syncStatusListener?.({ status: 'syncing' }))
+    expect(invalidate).not.toHaveBeenCalled()
+
+    act(() => mocks.syncStatusListener?.({ status: 'idle' }))
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: taskKeys.tasks() })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: taskKeys.projects() })
+  })
+
+  it('does not reconcile on status events that never entered a sync', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { result } = renderHook(() => useTaskWorkspaceData({ enabled: true }), {
+      wrapper: createWrapper(queryClient)
+    })
+
+    await waitFor(() => expect(result.current.tasks).toHaveLength(3))
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+    // Status churn without a sync (offline flapping, pause/resume) must not
+    // refetch a 1000-row list on every event.
+    act(() => mocks.syncStatusListener?.({ status: 'offline' }))
+    act(() => mocks.syncStatusListener?.({ status: 'idle' }))
+    act(() => mocks.syncStatusListener?.({ status: 'error' }))
+    expect(invalidate).not.toHaveBeenCalled()
+  })
+
+  // The client here mirrors main.tsx's app-wide `refetchOnWindowFocus: false`.
+  // Without the per-query override this list never refetches on focus, which is
+  // how a second machine stayed stale until the app was restarted.
+  it('refetches on window focus despite the app-wide refetchOnWindowFocus: false', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } }
+    })
+    const { result } = renderHook(() => useTaskWorkspaceData({ enabled: true }), {
+      wrapper: createWrapper(queryClient)
+    })
+
+    await waitFor(() => expect(result.current.tasks).toHaveLength(3))
+    const callsAfterLoad = vi.mocked(tasksService.list).mock.calls.length
+
+    act(() => focusManager.setFocused(false))
+    act(() => focusManager.setFocused(true))
+
+    await waitFor(() =>
+      expect(vi.mocked(tasksService.list).mock.calls.length).toBeGreaterThan(callsAfterLoad)
+    )
   })
 
   it('does not load or subscribe when disabled', () => {

--- a/apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts
+++ b/apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts
@@ -191,6 +191,9 @@ export function useTaskWorkspaceData({ enabled = true }: { enabled?: boolean }) 
   const projectsQuery = useQuery({
     queryKey: taskKeys.projects(),
     enabled,
+    // Opted out of the app-wide `refetchOnWindowFocus: false` default for the
+    // same reason as the tasks query below.
+    refetchOnWindowFocus: true,
     queryFn: async (): Promise<UiProject[]> => {
       const projectsResponse = await tasksService.listProjects()
       const baseProjects = projectsResponse.projects.map(dbProjectToUiProject)
@@ -216,6 +219,12 @@ export function useTaskWorkspaceData({ enabled = true }: { enabled?: boolean }) 
   const tasksQuery = useQuery({
     queryKey: taskKeys.tasks(),
     enabled,
+    // This list is refreshed purely by events, and a pull on a second machine
+    // is the only writer the user cannot see. One dropped ITEM_SYNCED leaves it
+    // stale forever, because the app-wide default is `refetchOnWindowFocus:
+    // false` and there is no interval. Coming back to the window is the cheapest
+    // reconcile point we have; the query reads local SQLite.
+    refetchOnWindowFocus: true,
     queryFn: async (): Promise<UiTask[]> => {
       const tasksResponse = await tasksService.list({
         includeCompleted: true,
@@ -257,7 +266,19 @@ export function useTaskWorkspaceData({ enabled = true }: { enabled?: boolean }) 
           })
         : () => {}
 
+    // A window that never loses focus never reaches the refetchOnWindowFocus
+    // reconcile above, so a dropped ITEM_SYNCED would still strand the list
+    // until restart. A sync leaving the `syncing` state is the other reconcile
+    // point, and it fires at most once per sync rather than once per item.
+    let wasSyncing = false
+    const unsubscribeSyncSettled = window.api.onSyncStatusChanged((event) => {
+      const syncing = event.status === 'syncing'
+      if (wasSyncing && !syncing) invalidateAll()
+      wasSyncing = syncing
+    })
+
     const unsubscribers = [
+      unsubscribeSyncSettled,
       onTaskCreated(invalidateAll),
       onTaskUpdated(invalidateAll),
       onTaskDeleted(invalidateAll),

--- a/apps/docs/src/user-guide/sync/how-sync-works.md
+++ b/apps/docs/src/user-guide/sync/how-sync-works.md
@@ -135,6 +135,13 @@ Linking another device requires a one-time approval from a currently-signed-in d
 
 See [Linking Another Device](/user-guide/sync/linking-devices).
 
+### When Lists Refresh
+
+Tasks and projects that arrive from another device appear as sync applies them — nothing to click. If a
+device has been sitting untouched for a long time, returning to its window refreshes those lists as well,
+so coming back to a machine you left alone is enough to see the other one's changes. Restarting the app
+is never required to pick up tasks or completed tasks from another device.
+
 ## Deleting a Vault
 
 Remove a vault you no longer want from **Settings -> Vault** or the sidebar vault switcher.


### PR DESCRIPTION
## What

A user reported that a second machine needs a full app restart before it shows tasks and Done tasks made on the first one — with no parallel use, just an hour of leaving the second machine alone.

Reading the refresh path first killed the obvious theory: the plumbing is intact and is **not** tab-scoped. A pull emits `emitItemSynced(..., 'pull', ...)` at four sites in `main/sync/engine/pull-coordinator.ts`, through `EVENT_CHANNELS.ITEM_SYNCED`, into `use-task-queries.ts`'s `onItemSynced`, which invalidates `taskKeys.tasks()`. It's subscribed app-wide via `App.tsx` (`enabled: isVaultOpen`).

The real fragility is that this was the **only** refresh path. `main.tsx` sets `refetchOnWindowFocus: false` app-wide and neither task query has an interval, so one dropped `ITEM_SYNCED` stranded the list permanently — restart was the only recovery.

## Change

Renderer only, ~21 lines:

- `refetchOnWindowFocus: true` on the tasks and projects queries, opting back out of the app-wide default. Follows existing precedent in `use-folder-view.ts` and `use-sync-status.ts`. The query reads local SQLite, so it's cheap.
- A single reconcile when sync leaves the `syncing` state, for a window that never loses focus and so never reaches the focus path. Entering `syncing` deliberately does *not* reconcile — the pull hasn't written its rows yet, and this list is 1000 rows wide.

## What this does not fix

It does not establish whether the pull ran at all on the idle machine. If the rows never reached SQLite, this changes nothing for that user.

Two live suspects on the pull side, both untouched here:

- `engine.ts` `runPullTick()` **skips** the pull when the WS generation is unchanged, `connected === true`, and the last pull was under `PERIODIC_PULL_MAX_QUIET_MS` (5 min).
- There is no `powerMonitor` anywhere under `main/sync/**` (only under `main/calendar/google/`), so nothing invalidates a half-open socket on wake. WS liveness is `PING_INTERVAL_MS` 25s + `HEARTBEAT_TIMEOUT_MS` 31s — both timers, both frozen during OS sleep.

Splitting them off is deliberate: this half is low-risk and independently correct, and shipping it makes the symptom itself a discriminator.

## Verification

Both changes mutation-tested — each mutation reds a specific test:

| Mutation | Test that fails |
| --- | --- |
| drop both `refetchOnWindowFocus` overrides | `refetches on window focus despite the app-wide refetchOnWindowFocus: false` |
| `wasSyncing && !syncing` → `!syncing` | `does not reconcile on status events that never entered a sync` |

- `typecheck:web` clean, `eslint` 0 errors
- `use-task-queries.test.tsx` 19/19
- full `test:renderer` **639 passed**, back to baseline

One caught along the way: the first full run went `4 failed | 636 passed` while the file passed in isolation. `focusManager` is module-global, and the new focus test was leaving it explicitly set for every file that ran after it. Fixed with `afterEach(() => focusManager.setFocused(undefined))`. The one remaining red in the final run, `large-file-viewer.test.tsx`, passes in isolation both with and without this change — pre-existing ordering flake, unrelated.

## Next

Asking the reporter for `main.log`. `pull-coordinator.ts:351` logs `Pull timing` at **info**, so their file shows a timestamp for every pull that actually ran — a gap through the idle hour separates "pull stopped" from "UI stale" directly. Note `engine.ts:632`'s `Periodic pull skipped` is `log.debug` and so is absent from production logs; worth promoting separately.