### PR TITLE
fix(tabs): keep a canvas tab's title on the canvas's real name

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -82,6 +82,7 @@ import { useAgentMcpDesktopApiResponder } from '@/agent-mcp/desktop-api-handler'
 import { useAgentMcpCanvasWriteResponder } from '@/agent-mcp/canvas-write-handler'
 import { AgentFeatureProvider } from '@/agent-chat/agent-feature-provider'
 import { AgentTabTitleSync } from '@/agent-chat/agent-tab-title-sync'
+import { CanvasTabTitleSync } from '@/components/tabs/canvas-tab-title-sync'
 
 const log = createLogger('App')
 const startupTheme = getStartupTheme()
@@ -336,6 +337,7 @@ const AppContent = (): React.JSX.Element => {
   return (
     <TabDragProvider>
       <AgentTabTitleSync />
+      <CanvasTabTitleSync />
       <div className="flex flex-1 overflow-hidden bg-background" id="main-content">
         <SplitViewContainer />
       </div>

--- a/apps/desktop/src/renderer/src/components/tabs/canvas-tab-title-sync.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/canvas-tab-title-sync.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * The seam under test is the real one: a real `TabProvider`, the real reducer,
+ * and the real `updateTabTitleByEntityId`. Only `window.api.onCanvasUpdated` —
+ * the IPC boundary the renderer cannot own — is a mock, so an assertion here is
+ * about the tab state a user would see and not about a spy having been called.
+ */
+
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TabProvider, useTabs } from '@/contexts/tabs/context'
+import type { Tab, TabGroup, TabSystemState } from '@/contexts/tabs/types'
+import { CanvasTabTitleSync } from './canvas-tab-title-sync'
+
+interface CanvasUpdatedPayload {
+  canvas?: { id?: string; title?: string }
+}
+
+/** The listener the component hands to the preload bridge. */
+let emitCanvasUpdated: ((event: CanvasUpdatedPayload) => void) | null = null
+const unsubscribe = vi.fn()
+
+const canvasTab = (overrides: Partial<Tab> = {}): Tab => ({
+  id: overrides.id ?? 'tab-canvas',
+  type: 'canvas',
+  title: overrides.title ?? 'Old name',
+  icon: 'pen-tool',
+  path: `/canvas/${overrides.entityId ?? 'canvas-1'}`,
+  entityId: overrides.entityId ?? 'canvas-1',
+  isPinned: false,
+  isModified: false,
+  isPreview: false,
+  isDeleted: false,
+  openedAt: 1,
+  lastAccessedAt: 1,
+  ...overrides
+})
+
+const makeGroup = (id: string, tabs: Tab[]): TabGroup => ({
+  id,
+  tabs,
+  activeTabId: tabs[0]?.id ?? null,
+  isActive: true,
+  back: [],
+  forward: []
+})
+
+const makeState = (groups: TabGroup[]): TabSystemState => ({
+  tabGroups: Object.fromEntries(groups.map((group) => [group.id, group])),
+  layout: { type: 'leaf', tabGroupId: groups[0].id },
+  activeGroupId: groups[0].id,
+  settings: { restoreSessionOnStart: true, tabCloseButton: 'hover' },
+  recentlyClosed: []
+})
+
+function mount(initialState: TabSystemState) {
+  let latest: ReturnType<typeof useTabs> | null = null
+
+  const Probe = (): null => {
+    latest = useTabs()
+    return null
+  }
+
+  const view = render(
+    <TabProvider initialState={initialState}>
+      <CanvasTabTitleSync />
+      <Probe />
+    </TabProvider>
+  )
+
+  return {
+    ...view,
+    titleOf: (groupId: string, tabId: string): string | undefined =>
+      latest?.state.tabGroups[groupId]?.tabs.find((tab) => tab.id === tabId)?.title,
+    get groups() {
+      return latest?.state.tabGroups
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  emitCanvasUpdated = null
+  window.api.onSettingsChanged = vi.fn(() => vi.fn())
+  window.api.onCanvasUpdated = vi.fn((callback: (event: CanvasUpdatedPayload) => void) => {
+    emitCanvasUpdated = callback
+    return unsubscribe
+  }) as unknown as typeof window.api.onCanvasUpdated
+})
+
+describe('CanvasTabTitleSync', () => {
+  it('retitles the open tab when its canvas is renamed', () => {
+    const view = mount(makeState([makeGroup('main', [canvasTab()])]))
+
+    act(() => emitCanvasUpdated?.({ canvas: { id: 'canvas-1', title: 'New name' } }))
+
+    expect(view.titleOf('main', 'tab-canvas')).toBe('New name')
+  })
+
+  it('retitles a canvas tab the user is not looking at', () => {
+    const view = mount(
+      makeState([
+        makeGroup('main', [
+          canvasTab({ id: 'tab-active', entityId: 'canvas-active', title: 'Active' }),
+          canvasTab({ id: 'tab-background', entityId: 'canvas-1' })
+        ])
+      ])
+    )
+
+    act(() => emitCanvasUpdated?.({ canvas: { id: 'canvas-1', title: 'New name' } }))
+
+    expect(view.titleOf('main', 'tab-background')).toBe('New name')
+    expect(view.titleOf('main', 'tab-active')).toBe('Active')
+  })
+
+  it('retitles the same canvas in every pane it is open in', () => {
+    const view = mount(
+      makeState([
+        makeGroup('main', [canvasTab({ id: 'tab-left' })]),
+        makeGroup('side', [canvasTab({ id: 'tab-right' })])
+      ])
+    )
+
+    act(() => emitCanvasUpdated?.({ canvas: { id: 'canvas-1', title: 'New name' } }))
+
+    expect(view.titleOf('main', 'tab-left')).toBe('New name')
+    expect(view.titleOf('side', 'tab-right')).toBe('New name')
+  })
+
+  it('leaves tab state untouched when a save carries the title the tab already has', () => {
+    // `canvas:updated` fires on every scene save, so this is the common case,
+    // not the edge one: it must not churn state the persistence layer writes.
+    const view = mount(makeState([makeGroup('main', [canvasTab({ title: 'Same name' })])]))
+    const before = view.groups
+
+    act(() => emitCanvasUpdated?.({ canvas: { id: 'canvas-1', title: 'Same name' } }))
+
+    expect(view.groups).toBe(before)
+  })
+
+  it('falls back to the untitled label when a write clears the title', () => {
+    const view = mount(makeState([makeGroup('main', [canvasTab()])]))
+
+    act(() => emitCanvasUpdated?.({ canvas: { id: 'canvas-1', title: '' } }))
+
+    expect(view.titleOf('main', 'tab-canvas')).toBe('Untitled canvas')
+  })
+
+  it('ignores an update for a canvas that has no tab open', () => {
+    const view = mount(makeState([makeGroup('main', [canvasTab()])]))
+    const before = view.groups
+
+    act(() => emitCanvasUpdated?.({ canvas: { id: 'canvas-other', title: 'New name' } }))
+
+    expect(view.groups).toBe(before)
+    expect(view.titleOf('main', 'tab-canvas')).toBe('Old name')
+  })
+
+  it('survives an event that carries no canvas', () => {
+    const view = mount(makeState([makeGroup('main', [canvasTab()])]))
+
+    act(() => emitCanvasUpdated?.({}))
+
+    expect(view.titleOf('main', 'tab-canvas')).toBe('Old name')
+  })
+
+  it('unsubscribes on unmount', () => {
+    const view = mount(makeState([makeGroup('main', [canvasTab()])]))
+
+    view.unmount()
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/tabs/canvas-tab-title-sync.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/canvas-tab-title-sync.tsx
@@ -1,0 +1,51 @@
+/**
+ * Keeps an open canvas tab's title on the canvas's real name.
+ *
+ * A tab's title is a SNAPSHOT taken when the tab opens (`handleCanvasOpen` in
+ * `app-sidebar`), so a rename anywhere else leaves the tab reading the old name
+ * until it is closed and reopened.
+ *
+ * It lives here, above the tab tree, rather than in the canvas page: only the
+ * ACTIVE tab is mounted, so a page-level listener would never hear the rename
+ * of a canvas sitting in a background tab — which is the case being fixed.
+ *
+ * Event-driven, where `AgentTabTitleSync` diffs tab state against a list it
+ * already has: agent conversations live in a context in memory, canvas
+ * summaries do not, so the diffing shape would mean holding a second copy of
+ * the canvas list at App level and keeping it fresh.
+ *
+ * One subscription covers every way a canvas can be renamed, because they all
+ * end at the same broadcast: the sidebar, an agent write, a pull from another
+ * device (`sync/item-handlers/canvas-handler`), and vault reconcile.
+ *
+ * @module components/tabs/canvas-tab-title-sync
+ */
+
+import * as React from 'react'
+
+import { useTabActions } from '@/contexts/tabs'
+import { onCanvasUpdated } from '@/services/canvas-service'
+import { useT } from '@memry/i18n/renderer'
+
+export function CanvasTabTitleSync(): null {
+  const { updateTabTitleByEntityId } = useTabActions()
+  const { t } = useT('common')
+
+  React.useEffect(() => {
+    // `canvas:updated` carries every SAVE, not just renames — a scene autosave
+    // fires it too. Nothing is filtered here: `updateTabTitleByEntityId` drops
+    // a retitle to the name a tab already carries, which is where that guard
+    // belongs, since a background canvas can be saved by sync just as often.
+    return onCanvasUpdated((event) => {
+      const canvas = event?.canvas
+      if (!canvas?.id) return
+      // The fallback `openTab` uses, so a title cleared by a remote write reads
+      // as "Untitled canvas" rather than leaving the tab blank.
+      updateTabTitleByEntityId(canvas.id, canvas.title || t('canvas.untitled'))
+    })
+  }, [t, updateTabTitleByEntityId])
+
+  return null
+}
+
+export default CanvasTabTitleSync

--- a/apps/desktop/src/renderer/src/contexts/tabs/context.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/context.test.tsx
@@ -244,6 +244,39 @@ describe('TabProvider context', () => {
     expect(rendered.ctx.state.tabGroups.main.tabs[0].type).toBe('home')
   })
 
+  it('retitles every tab showing the entity, in every group', () => {
+    const left = makeTab({ id: 'left', entityId: 'canvas-1', title: 'Old name' })
+    const right = makeTab({ id: 'right', entityId: 'canvas-1', title: 'Old name' })
+    const other = makeTab({ id: 'other', entityId: 'canvas-2', title: 'Untouched' })
+    const rendered = captureContext(
+      makeState([makeGroup('main', [left, other]), makeGroup('side', [right])])
+    )
+
+    act(() => {
+      rendered.ctx.updateTabTitleByEntityId('canvas-1', 'New name')
+    })
+
+    const titleOf = (groupId: string, tabId: string): string | undefined =>
+      rendered.ctx.state.tabGroups[groupId].tabs.find((tab) => tab.id === tabId)?.title
+
+    expect(titleOf('main', 'left')).toBe('New name')
+    expect(titleOf('side', 'right')).toBe('New name')
+    expect(titleOf('main', 'other')).toBe('Untouched')
+  })
+
+  it('returns the same state when a retitle names a tab what it is already called', () => {
+    const rendered = captureContext(
+      makeState([makeGroup('main', [makeTab({ id: 'only', title: 'Same name' })])])
+    )
+    const before = rendered.ctx.state.tabGroups
+
+    act(() => {
+      rendered.ctx.updateTabTitle('only', 'Same name')
+    })
+
+    expect(rendered.ctx.state.tabGroups).toBe(before)
+  })
+
   it('opens sidebar tabs, splits panes, moves tabs, restores sessions, and resets', async () => {
     const first = makeTab({ id: 'first', entityId: 'first' })
     const second = makeTab({ id: 'second', entityId: 'second' })

--- a/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
@@ -595,15 +595,26 @@ export const TabProvider = ({
     })
   }, [])
 
+  /**
+   * Retitles EVERY tab showing `entityId`, in every group.
+   *
+   * Every tab, not the first one found: an entity can be open in more than one
+   * pane, and retitling one of them leaves the other reading a name the entity
+   * no longer has — the same bug this function exists to prevent, one pane over.
+   *
+   * A tab that already carries the title is skipped, because the loudest caller
+   * hears an event on every SAVE and not only on a rename: dispatching per
+   * autosave would re-render the tab tree and re-arm the debounced write of tab
+   * state to disk, for a title that did not change.
+   */
   const updateTabTitleByEntityId = useCallback((entityId: string, title: string) => {
     for (const [groupId, group] of Object.entries(tabGroupsRef.current)) {
-      const tab = group.tabs.find((t) => t.entityId === entityId)
-      if (tab) {
+      for (const tab of group.tabs) {
+        if (tab.entityId !== entityId || tab.title === title) continue
         dispatch({
           type: 'UPDATE_TAB_TITLE',
           payload: { tabId: tab.id, groupId, title }
         })
-        return
       }
     }
   }, [])

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-modify-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-modify-reducer.ts
@@ -102,6 +102,11 @@ export function tabModifyReducer(state: TabSystemState, action: ModifyAction): T
       const group = state.tabGroups[groupId]
       if (!group) return state
 
+      // A retitle to the name the tab already has returns the SAME state object,
+      // so the context value stays referentially stable: a redundant dispatch
+      // cannot re-render the tab tree or re-arm the debounced save of tab state.
+      if (!group.tabs.some((t) => t.id === tabId && t.title !== title)) return state
+
       return {
         ...state,
         tabGroups: {

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -197,6 +197,8 @@ A small dot appears on a tab title when there are unsaved changes (rare — memr
 
 Canvases open as tabs too, so you can keep a board in one pane and a note in the other. Note that a note open in a visible pane is edited there, not on the canvas card — see [Cards & Links](./canvas/cards-and-links.md).
 
+Renaming a canvas retitles its tab as soon as the new name is saved. It does not matter where the rename came from — the sidebar, an agent, or another device syncing the change — or whether the tab is the one you are looking at: a canvas sitting in a background tab is retitled too, so you never have to close and reopen a tab to see its real name.
+
 ## Links in Split Panes
 
 Each pane handles its own links. Clicking an external link or a `[[wiki link]]` in either pane opens it from that pane, and closing one pane leaves the other pane's links working.


### PR DESCRIPTION
Fixes **#1563 · C3** — "Canvas yeniden adlandırılınca sekme başlığı güncellenmiyor" (Aurelie, 18 Ağu, `v2026-08-17`).

## The report's file pointers were wrong

The epic pointed at `canvas-row-name-input.tsx` and `use-canvas-tree.ts`. Neither touches tab state: the first is a dumb input, the second only refreshes the tree's two lists. I corrected the item in #1563.

The real cause: a tab's title is a **snapshot taken when the tab opens** (`app-sidebar.tsx:349`, `openTab`), and nothing ever refreshes it from the canvas. The rename itself writes at `canvas-tree.tsx:571` (`canvasService.update`). Notes solve this with `updateTabTitleByEntityId`, Agent Chat with `agent-tab-title-sync.tsx`; canvas had neither.

## The fix

**`CanvasTabTitleSync`** subscribes to `canvas:updated` above the tab tree.

- **Not in the canvas page**, because only the ACTIVE tab is mounted — a page-level listener would never hear the rename of a canvas in a background tab, which is exactly the reported case.
- **One subscription covers every writer**, because they all end at the same `broadcastToAllWindows`: the sidebar, an agent write, a pull from another device (`sync/item-handlers/canvas-handler.ts:320`), and vault reconcile.
- Event-driven rather than the diffing shape `AgentTabTitleSync` uses: agent conversations already live in a context in memory, canvas summaries do not.

**The churn guard is not optional.** `canvas:updated` fires on every canvas SAVE, not just renames (`canvas-handlers.ts:151` — one handler writes both title and scene), and tab state is written to disk on a 1s debounce (`persistence/hooks.ts:47`). So:

- `updateTabTitleByEntityId` skips a retitle to the name a tab already carries;
- `UPDATE_TAB_TITLE` returns the same state object for a no-op, keeping the context value referentially stable.

Without both, every stroke autosave would re-render the tab tree and re-arm that write.

`updateTabTitleByEntityId` also stops at the first match today; it now retitles every matching tab. That is latent rather than live — see "Out of scope" — but the function is being edited for the guard anyway, and leaving it would be a mine for whoever re-wires the menus.

## Out of scope, deliberately

- **#1563 C4** (deleted canvas keeps its tab) — tracked separately; it is its own product decision (strikethrough vs. close vs. unsaved-changes handling).
- **Unifying notes / agent / canvas** onto one mechanism — three patterns exist today. Folding them together in the same PR would put working production paths at risk.
- **#1564** — while checking whether "the same canvas open in two panes" is reachable, I found it is not: `SidebarNavItem` and `SidebarItemContextMenu` hold the app's only "Open in New Tab" / "Open to the Side" affordances and are imported **only by tests**. Filed, not touched.

## Verification

- `pnpm exec vitest --project renderer` over `contexts/tabs`, `components/tabs`, `components/split-view`, `use-tree-rename`, `use-note-tree-actions`, `notes-tree`, `notes-tree-virtualized-rename`, `note` — **33 files / 315 tests passed**. That set is deliberately wider than canvas: `updateTabTitleByEntityId` is shared with the note paths.
- `pnpm --filter @memry/desktop typecheck:test` ✅ · full `pnpm typecheck` node+web ✅
- `pnpm lint` — 0 errors (97 pre-existing warnings, none in touched files)
- `pnpm docs:impact --base origin/main --strict` ✅ · `pnpm docs:build` ✅
- No E2E: those jobs only run on push-to-main, so they would give no signal here.

The full 641-file renderer suite was attempted twice locally and is not a usable signal on this machine — one run was polluted by a concurrent typecheck (5 files failed, all timeouts, in calendar/settings surfaces this PR does not touch), the second was killed by SIGTERM part-way. CI is the honest gate for it.

## Tests

Real `TabProvider` and real reducer; only `window.api.onCanvasUpdated` is mocked, so the assertions are about tab state a user would see rather than about a spy being called: rename retitles · a background tab is retitled · every pane is retitled · an unchanged title leaves state untouched (identity check) · a cleared title falls back to "Untitled canvas" · unknown canvas and empty payload are no-ops · unsubscribes on unmount.