### PR TITLE
fix(editor): re-cut the BlockNote text colour palette for chroma and AA

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -69,6 +69,63 @@
 :root .bn-container {
   --bn-colors-editor-text: var(--foreground);
   --bn-colors-editor-background: var(--background);
+
+  /* Text-colour palette, re-cut from BlockNote's Notion-legacy stock.
+     Reported: green read as plain grey while blue looked vivid. Measuring the
+     whole palette found three defects, and green had only the second:
+
+       1. AA. gray 2.58, red 3.90, orange 3.00, yellow 1.93 against the paper
+          background — all below the 4.5 WCAG AA floor for text.
+       2. Chroma. green sat at OKLCH hue 186 (teal, not green) with chroma
+          0.028, and brown at 0.045, against ~0.11 for blue. Below roughly 0.05
+          the eye cannot name a hue and the swatch reads as grey. This is why
+          green failed while measuring a comfortable 6.34 contrast: WCAG is
+          luminance-only and blind to it.
+       3. Separation from body text. brown sat 0.105 away in OKLab.
+
+     Re-cut so every swatch clears 4.5 on both light backgrounds, carries at
+     least 0.08 chroma (gray excepted — it is the one deliberate neutral), and
+     stays at least 0.15 from the body text. brown < orange < yellow in
+     lightness is held deliberately: they share the warm hue arc and lightness
+     order is the only thing that keeps brown from reading as dull orange.
+     AA is why yellow lands as gold rather than lemon — a light enough yellow
+     cannot clear 4.5 on white at all.
+
+     Backgrounds stay stock: a fill needs no chroma to be identified, and the
+     reporter confirmed the green background reads fine.
+
+     Presentation only. Colours persist by NAME (`textColor: "green"`, and
+     `<!-- colors:{...} -->` in vault markdown), never as hex, so existing notes
+     re-render under the new palette with no migration. */
+  --bn-colors-highlights-gray-text: #696969;
+  --bn-colors-highlights-brown-text: #824a32;
+  --bn-colors-highlights-red-text: #ba3f38;
+  --bn-colors-highlights-orange-text: #9d5b00;
+  --bn-colors-highlights-yellow-text: #7e7100;
+  --bn-colors-highlights-green-text: #007a44;
+  --bn-colors-highlights-blue-text: #0070a5;
+  --bn-colors-highlights-purple-text: #8550b8;
+  --bn-colors-highlights-pink-text: #b33e74;
+}
+
+/* The dark palette lives on `.bn-container[data-color-scheme=dark]` (0,2,0) in
+   @blocknote/shadcn, so this needs the extra attribute to win on specificity
+   rather than on stylesheet order.
+
+   Same three defects on the dark side: brown 3.69, purple 3.73 and pink 4.09
+   missed AA; green again had no chroma (0.037); and gray #bebdb8 sat 0.009 from
+   the #bcbab6 body text, close enough that "gray" was not a distinguishable
+   colour at all. */
+:root .bn-container[data-color-scheme='dark'] {
+  --bn-colors-highlights-gray-text: #838383;
+  --bn-colors-highlights-brown-text: #aa6f55;
+  --bn-colors-highlights-red-text: #da5c52;
+  --bn-colors-highlights-orange-text: #c07104;
+  --bn-colors-highlights-yellow-text: #998800;
+  --bn-colors-highlights-green-text: #199758;
+  --bn-colors-highlights-blue-text: #008ccd;
+  --bn-colors-highlights-purple-text: #a06cd5;
+  --bn-colors-highlights-pink-text: #d25a8f;
 }
 
 :root .bn-editor,

--- a/apps/desktop/src/renderer/src/assets/blocknote-text-color-css.test.ts
+++ b/apps/desktop/src/renderer/src/assets/blocknote-text-color-css.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  AA_SMALL_TEXT,
+  contrastRatio,
+  resolveColor,
+  type ThemeSelector
+} from '@tests/utils/contrast'
+
+// The renderer suite runs in jsdom, where `import.meta.url` is not a file: URL.
+// Vitest's cwd is apps/desktop.
+const BASE_CSS = join(process.cwd(), 'src/renderer/src/assets/base.css')
+
+const SWATCHES = ['gray', 'brown', 'red', 'orange', 'yellow', 'green', 'blue', 'purple', 'pink']
+
+/**
+ * BlockNote paints text colours from `--bn-colors-highlights-<hue>-text` and
+ * ships Notion's legacy palette. Measured against our backgrounds it carried
+ * three separate defects — swatches below WCAG AA, swatches with so little
+ * chroma they read as grey whatever their name, and swatches sitting on top of
+ * the body text. base.css re-cuts all nine; the floors below are the acceptance
+ * criteria that re-cut was designed to hit.
+ *
+ * jsdom has no cascade, and the palette lives in a third-party stylesheet we
+ * never load in unit tests, so a source-level parse-and-assert is the honest
+ * guard. It catches the override being deleted and, because these are floors
+ * rather than frozen hexes, it also catches a future re-theme that quietly
+ * drops a swatch back toward grey or under AA.
+ */
+const LIGHT_SELECTOR = ':root .bn-container'
+const DARK_SELECTOR = ":root .bn-container[data-color-scheme='dark']"
+
+/** Below this, OKLCH chroma stops reading as a nameable hue and looks grey. */
+const MIN_CHROMA = 0.05
+/** OKLab distance a swatch needs from the body text to look like a choice. */
+const MIN_DISTANCE_FROM_BODY = 0.15
+/** OKLab distance two swatches need from each other to stay tellable apart. */
+const MIN_DISTANCE_BETWEEN_SWATCHES = 0.06
+
+const PARSED = new Map<string, Map<string, string>>()
+
+/**
+ * Every custom property `selector` sets, merged across all of its rules in
+ * document order (last wins, as the cascade would have it). base.css spreads
+ * one selector over several blocks — `:root .bn-container` carries the palette
+ * vars up top and the editor chrome further down — so reading only the last
+ * matching block would miss declarations that are genuinely in effect.
+ *
+ * Memoised: the pairwise checks ask for the same selector ~80 times, and
+ * re-reading and re-parsing a 70 KB stylesheet each time cost ~35s.
+ */
+function customProperties(selector: string): Map<string, string> {
+  const cached = PARSED.get(selector)
+  if (cached) return cached
+
+  const normalize = (value: string): string => value.trim().replace(/\s+/g, ' ')
+  const css = readFileSync(BASE_CSS, 'utf8')
+    // Statement at-rules first, and before comments: `@source
+    // "…/streamdown/dist/*.js";` contains a literal `/*`, so a naive comment
+    // strip reads it as a comment opener and eats every line up to the next
+    // `*/` — about sixty of them, including the rule under test.
+    .replace(/^[ \t]*@[a-z-]+[^;{}\n]*;[ \t]*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+  const merged = new Map<string, string>()
+
+  for (const [, selectorList, body] of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    if (!selectorList.split(',').map(normalize).includes(normalize(selector))) continue
+    for (const [, name, value] of body.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/g)) {
+      merged.set(name, value.trim())
+    }
+  }
+  PARSED.set(selector, merged)
+  return merged
+}
+
+function swatch(selector: string, name: string): string {
+  const value = customProperties(selector).get(`--bn-colors-highlights-${name}-text`)
+
+  expect(value, `\`${selector}\` does not set the ${name} text colour`).toBeDefined()
+  expect(value, `${name} must be a hex literal`).toMatch(/^#[0-9a-f]{6}$/i)
+  return value as string
+}
+
+/** Oklab coordinates of an `#rrggbb`, per the Oklab spec. */
+function oklab(hex: string): { l: number; a: number; b: number } {
+  const [r, g, b] = [1, 3, 5].map((offset) => {
+    const channel = parseInt(hex.slice(offset, offset + 2), 16) / 255
+    return channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+  })
+  const cbrt = (v: number): number => Math.cbrt(v)
+  const l = cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b)
+  const m = cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b)
+  const s = cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b)
+  return {
+    l: 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    a: 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+    b: 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s
+  }
+}
+
+const chroma = (hex: string): number => Math.hypot(oklab(hex).a, oklab(hex).b)
+
+function distance(x: string, y: string): number {
+  const p = oklab(x)
+  const q = oklab(y)
+  return Math.hypot(p.l - q.l, p.a - q.a, p.b - q.b)
+}
+
+// The stock palette, kept so the guard can say "this is BlockNote's, not ours"
+// rather than only checking a shape the stock values might accidentally satisfy.
+const STOCK = {
+  light: [
+    '#9b9a97',
+    '#64473a',
+    '#e03e3e',
+    '#d9730d',
+    '#dfab01',
+    '#4d6461',
+    '#0b6e99',
+    '#6940a5',
+    '#ad1a72'
+  ],
+  dark: [
+    '#bebdb8',
+    '#8e6552',
+    '#ec4040',
+    '#e3790d',
+    '#dfab01',
+    '#6b8b87',
+    '#0e87bc',
+    '#8552d7',
+    '#da208f'
+  ]
+}
+
+const MODES = [
+  {
+    mode: 'light' as const,
+    selector: LIGHT_SELECTOR,
+    // Both light themes share this block, and paper is darker than white, so
+    // paper is the binding constraint. Assert against both anyway.
+    themes: [':root', '.white'] as ThemeSelector[],
+    body: '#37352f'
+  },
+  {
+    mode: 'dark' as const,
+    selector: DARK_SELECTOR,
+    themes: ['.dark'] as ThemeSelector[],
+    body: '#bcbab6'
+  }
+]
+
+describe('BlockNote text colour palette', () => {
+  describe.each(MODES)('$mode', ({ mode, selector, themes, body }) => {
+    it('overrides every swatch rather than inheriting BlockNote stock', () => {
+      const ours = SWATCHES.map((name) => swatch(selector, name).toLowerCase())
+
+      expect(ours).toHaveLength(STOCK[mode].length)
+      for (const [index, hex] of ours.entries()) {
+        expect(hex, `${SWATCHES[index]} is still the stock value`).not.toBe(STOCK[mode][index])
+      }
+    })
+
+    it.each(SWATCHES)('%s carries enough chroma to name a hue', (name) => {
+      // Gray is the one deliberate neutral, so it is the one exemption.
+      if (name === 'gray') {
+        expect(chroma(swatch(selector, name))).toBeLessThan(MIN_CHROMA)
+        return
+      }
+      expect(chroma(swatch(selector, name))).toBeGreaterThanOrEqual(MIN_CHROMA)
+    })
+
+    it.each(SWATCHES)('%s stays clear of the body text', (name) => {
+      expect(distance(swatch(selector, name), body)).toBeGreaterThanOrEqual(MIN_DISTANCE_FROM_BODY)
+    })
+
+    it.each(themes)('every swatch clears AA for small text on %s', (theme) => {
+      const background = resolveColor(theme, '--background')
+
+      for (const name of SWATCHES) {
+        const ratio = contrastRatio(swatch(selector, name), background)
+        expect(ratio, `${name} on ${theme} is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(
+          AA_SMALL_TEXT
+        )
+      }
+    })
+
+    it('keeps every pair of swatches tellable apart', () => {
+      for (let i = 0; i < SWATCHES.length; i++) {
+        for (let j = i + 1; j < SWATCHES.length; j++) {
+          const gap = distance(swatch(selector, SWATCHES[i]), swatch(selector, SWATCHES[j]))
+          expect(
+            gap,
+            `${SWATCHES[i]} and ${SWATCHES[j]} are ${gap.toFixed(4)} apart`
+          ).toBeGreaterThanOrEqual(MIN_DISTANCE_BETWEEN_SWATCHES)
+        }
+      }
+    })
+
+    it('keeps brown darker than orange darker than yellow', () => {
+      // They share the warm hue arc; lightness order is the only thing stopping
+      // brown from reading as a dull orange.
+      const lightness = (name: string): number => oklab(swatch(selector, name)).l
+
+      expect(lightness('brown')).toBeLessThan(lightness('orange'))
+      expect(lightness('orange')).toBeLessThan(lightness('yellow'))
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/assets/excalidraw-context-menu-css.test.ts
+++ b/apps/desktop/src/renderer/src/assets/excalidraw-context-menu-css.test.ts
@@ -20,7 +20,15 @@ const OVERRIDE_SELECTOR = '.excalidraw .context-menu'
  * either half (the cap or the scroll).
  */
 function stripComments(css: string): string {
-  return css.replace(/\/\*[\s\S]*?\*\//g, '')
+  return (
+    css
+      // Statement at-rules go first, and before comments: `@source
+      // "…/streamdown/dist/*.js";` contains a literal `/*`, so stripping
+      // comments straight away reads it as a comment opener and swallows every
+      // line up to the next `*/` — about sixty of them.
+      .replace(/^[ \t]*@[a-z-]+[^;{}\n]*;[ \t]*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+  )
 }
 
 /** Body of the last rule whose selector list contains `selector`, or null. */

--- a/apps/desktop/tests/utils/contrast.ts
+++ b/apps/desktop/tests/utils/contrast.ts
@@ -26,7 +26,13 @@ const BASE_CSS = join(process.cwd(), 'src/renderer/src/assets/base.css')
  * the root element, so `:root` still applies underneath them and seeds both.
  */
 function readPalettes(): Map<ThemeSelector, Map<string, string>> {
-  const css = readFileSync(BASE_CSS, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '')
+  // Statement at-rules go first, and before comments: `@source
+  // "…/streamdown/dist/*.js";` contains a literal `/*`, so stripping comments
+  // straight away reads it as a comment opener and swallows every line up to
+  // the next `*/` — about sixty of them, palette blocks included.
+  const css = readFileSync(BASE_CSS, 'utf8')
+    .replace(/^[ \t]*@[a-z-]+[^;{}\n]*;[ \t]*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
   const palettes = new Map<ThemeSelector, Map<string, string>>(
     THEMES.map((selector) => [selector, new Map<string, string>()])
   )

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -173,6 +173,17 @@ Color and underline are kept on separate nested spans, so an older version of Me
 
 Formatting applied in MemryNote round-trips. Underline written any other way — Obsidian's `<u>` tags, for example — is not read back, and is dropped the next time MemryNote saves the note.
 
+### Text colours
+
+The nine text colours are tuned so each one is legible and tellable apart from the others in every theme. Each clears the WCAG AA contrast floor for small text against the page, carries enough colour to be nameable rather than reading as grey, and stays clear of the default body text. Grey is the deliberate exception: it stays neutral, and reads as a muted colour rather than a hue.
+
+Two consequences worth knowing:
+
+- Yellow is a gold rather than a lemon. A yellow light enough to look like lemon cannot meet the contrast floor against a white page.
+- Brown, orange and yellow share a warm range, so they are separated by how dark they are. Brown is the darkest of the three.
+
+Colours are stored by name, not as a fixed shade, so notes you coloured in an earlier version pick up the current tuning when you open them. Highlight (background) colours are unchanged — a filled background does not need the same treatment to stay readable.
+
 ## Link Previews
 
 Links in a note are enriched with the page title, site name and favicon, both for inline link mentions and for bookmark blocks. The lookup runs once per URL and the result is kept in memory, so reopening a note with the same links does not refetch them.


### PR DESCRIPTION
Aurelie reported the editor's text-colour green as unreadable — "muddy / military green", indistinguishable from dark grey — while blue looked vivid and the green *background* was fine.

Root cause turned out to be **chroma, not contrast**, and it was not limited to green. BlockNote ships Notion's legacy text palette; measured against our backgrounds it carried three separate defects, and the reported one was only the second.

## What was wrong

| defect | light (stock) | dark (stock) |
|---|---|---|
| Below WCAG AA 4.5 | gray 2.58, red 3.90, orange 3.00, yellow 1.93 | brown 3.69, purple 3.73, pink 4.09 |
| OKLCH chroma < 0.05 (reads grey) | green 0.028, brown 0.045 | green 0.037 |
| Sitting on the body text (OKLab ΔE < 0.15) | brown 0.105 | **gray 0.009** |

Two things worth pulling out:

- **Stock green measured 6.34:1 on white and still read as grey.** It sat at OKLCH hue 186 — teal, not green — with chroma 0.028 against ~0.11 for the blue beside it. Below roughly 0.05 chroma the eye cannot name a hue. WCAG is luminance-only and blind to this, so contrast alone would have cleared the swatch.
- **Dark-mode "gray" was ΔE 0.009 from the body text.** It was not a distinguishable colour at all.

## What changed

All nine swatches re-cut in both themes. Every one now clears 4.5 on every theme background, carries at least 0.08 chroma (grey excepted, as the one deliberate neutral), and stays at least 0.15 from the body text. After: **zero** failures in all three categories, both themes.

`brown < orange < yellow` in lightness is held deliberately — they share the warm hue arc, and lightness order is the only thing keeping brown from reading as dull orange.

The override lever is the **CSS variable, not the hex**: `@blocknote/core` hardcodes the colour, but `react` and `shadcn` re-declare the same selector against `--bn-colors-highlights-<hue>-text` later in the sheet, and that wins. The dark block carries an extra attribute so it beats shadcn on specificity rather than on stylesheet order. No `!important`.

Backgrounds stay stock — a fill needs no chroma to be identified, and the reporter confirmed they read fine.

Also fixes the stylesheet parsers in `tests/utils/contrast.ts` and `excalidraw-context-menu-css.test.ts`. `@source ".../dist/*.js"` contains a literal `/*`, so stripping comments before statement at-rules swallowed **61 lines and 8 rules**. Latent in those two (they still resolved the same theme blocks), but active for the new palette guard, whose rule sits inside the swallowed region.

## Tradeoffs, stated plainly

- **This visibly restyles every note that already uses a text colour.** No migration is involved — colours persist by name, never as hex — but users with coloured notes will see them change.
- **Yellow is now gold, not lemon.** A yellow light enough to look like lemon cannot clear 4.5 on a white page. This is forced by AA, not a preference.
- Closest swatch pair tightened slightly: light 0.090 → 0.077, dark 0.105 → 0.071. Still well above the 0.06 floor the guard enforces.

## Compatibility

Presentation only. Colours are stored by name (`textColor: "green"`, and `<!-- colors:{...} -->` in vault markdown), never as hex, so existing notes re-render under the new palette with no schema, contract, or vault-format change.

## Verification

- New guard `blocknote-text-color-css.test.ts` — **45/45**. Thresholds are expressed as floors (AA, chroma, ΔE, pairwise separation, warm-trio lightness order), not frozen hexes, so a future BlockNote upgrade that drifts a swatch back toward grey trips it.
- Mutation: reverting the whole palette to stock fails **10** tests, mapping exactly onto the three defect classes above.
- Full renderer suite: **641 files, 7595 passed, 7 skipped, 0 failed**.
- `typecheck:test`, prettier, `git diff --check`, `docs:impact --strict`, `docs:build` — all green.

An earlier suite run showed 7 unrelated failures (calendar consent, etc.); that run took 767s against a 330s clean baseline because a typecheck was running concurrently. They pass in isolation and the clean run is fully green. Blast radius is bounded anyway: only three files import the contrast util (all green), and `base.css` is never loaded in jsdom.

## Not in scope

#1508 A7 (colour picker scroll / self-closing) is a separate, still-open issue.

Reported by Aurelie, 18 Aug 2026, v2026-08-17.
