### PR TITLE
fix(canvas): restore the tab's camera instead of recentring on every mount

### DIFF
--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
@@ -24,8 +24,22 @@ import { clearCardTitleCache } from './canvas-link-target-title'
 
 interface FakeApi {
   getSceneElements: () => unknown[]
-  getAppState: () => { isLoading: boolean }
+  getAppState: () => { isLoading: boolean; selectedElementIds: Record<string, boolean> }
   getFiles: () => Record<string, unknown>
+  scrollToContent: (...args: unknown[]) => void
+  updateScene: (...args: unknown[]) => void
+}
+
+/**
+ * Installs the slice of the preload API this suite drives. Cast through
+ * `unknown` because `Window['api']` is the full typed surface and these tests
+ * only stand up the two namespaces the editor touches.
+ */
+function installWindowApi(): void {
+  ;(window as unknown as { api: unknown }).api = {
+    canvas: { liveOpened: mocks.liveOpened, liveClosed: mocks.liveClosed },
+    notes: { getFolders: () => Promise.resolve([]) }
+  }
 }
 
 const mocks = vi.hoisted(() => ({
@@ -36,14 +50,25 @@ const mocks = vi.hoisted(() => ({
     elements: [] as unknown[],
     isLoading: true,
     selectedElementIds: {} as Record<string, boolean>,
-    showHyperlinkPopup: false as false | 'info' | 'editor'
+    showHyperlinkPopup: false as false | 'info' | 'editor',
+    /** The camera onChange reports. `null` = pre-init, no camera in appState. */
+    viewport: null as { scrollX: number; scrollY: number; zoom: { value: number } } | null
   },
+  dispatch: vi.fn(),
+  getTab: vi.fn(() => ({ viewState: {} }) as { viewState: Record<string, unknown> }),
+  identity: { tabId: 't1', groupId: 'g1', entityId: 'c1' } as {
+    tabId: string
+    groupId: string
+    entityId?: string
+  } | null,
   linkDialogProps: {} as Record<string, unknown>,
   onChange: null as (() => void) | null,
   excalidrawProps: {} as Record<string, unknown>,
   liveOpened: vi.fn(),
   liveClosed: vi.fn(),
-  serializeAsJSON: vi.fn((elements: unknown[]) => JSON.stringify({ elements })),
+  serializeAsJSON: vi.fn((elements: unknown[], ..._rest: unknown[]) =>
+    JSON.stringify({ elements })
+  ),
   openTab: vi.fn(),
   toastError: vi.fn(),
   scrollToContent: vi.fn(),
@@ -67,7 +92,11 @@ vi.mock('@excalidraw/excalidraw', () => ({
     mocks.onChange = () =>
       (props.onChange as unknown as (e: unknown[], a: unknown, f: unknown) => void)(
         mocks.api.elements,
-        { showHyperlinkPopup: mocks.api.showHyperlinkPopup },
+        {
+          showHyperlinkPopup: mocks.api.showHyperlinkPopup,
+          isLoading: mocks.api.isLoading,
+          ...(mocks.api.viewport ?? {})
+        },
         {}
       )
     // The real Excalidraw hands out its imperative API on mount — long before
@@ -91,9 +120,6 @@ vi.mock('@excalidraw/excalidraw', () => ({
   },
   serializeAsJSON: (elements: unknown[], ...rest: unknown[]) =>
     mocks.serializeAsJSON(elements, ...rest),
-  // The editor installs the vault-backed shape library on mount; this suite is
-  // about scene persistence, so the hook is a no-op here.
-  useHandleLibrary: () => undefined,
   languages: [],
   defaultLang: { code: 'en' },
   // Library persistence is covered by the adapter's own tests; here it only
@@ -121,7 +147,13 @@ vi.mock('@/services/canvas-service', () => ({
   onCanvasTooLarge: () => () => {}
 }))
 vi.mock('./canvas-card-overlay', () => ({ CanvasCardLayer: () => null }))
-vi.mock('@/contexts/tabs', () => ({ useTabActions: () => ({ openTab: mocks.openTab }) }))
+vi.mock('@/contexts/tabs', () => ({
+  useTabActions: () => ({ openTab: mocks.openTab }),
+  // The camera lives in the owning tab's viewState, so the view-state hooks
+  // need a dispatch/getTab pair even in the suites that never look at it.
+  useTabActionsOptional: () => ({ dispatch: mocks.dispatch, getTab: mocks.getTab })
+}))
+vi.mock('@/contexts/tabs/tab-identity', () => ({ useTabIdentity: () => mocks.identity }))
 // The link picker is mounted (closed) alongside Excalidraw, so its data
 // sources have to exist even for the suites that never open it.
 // The picker's own rows are covered by canvas-link-candidates.test.ts; here the
@@ -188,10 +220,7 @@ describe('CanvasEditor persistence safety', () => {
     // routed to this instance (#916); this suite only needs the calls to land.
     mocks.liveOpened.mockReset().mockResolvedValue({ ok: true })
     mocks.liveClosed.mockReset().mockResolvedValue({ ok: true })
-    ;(window as Window & { api: unknown }).api = {
-      canvas: { liveOpened: mocks.liveOpened, liveClosed: mocks.liveClosed },
-      notes: { getFolders: () => Promise.resolve([]) }
-    }
+    installWindowApi()
   })
 
   afterEach(() => {
@@ -394,10 +423,7 @@ describe('CanvasEditor link opening', () => {
     mocks.api.elements = [{ id: 'shape-1', type: 'rectangle' }]
     mocks.api.isLoading = false
     window.open = mocks.windowOpen as unknown as typeof window.open
-    ;(window as Window & { api: unknown }).api = {
-      canvas: { liveOpened: mocks.liveOpened, liveClosed: mocks.liveClosed },
-      notes: { getFolders: () => Promise.resolve([]) }
-    }
+    installWindowApi()
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: { href: PROD_DOC }
@@ -500,10 +526,7 @@ describe('CanvasEditor link picker', () => {
     mocks.linkDialogProps = {}
     mocks.api.isLoading = false
     mocks.api.showHyperlinkPopup = false
-    ;(window as Window & { api: unknown }).api = {
-      canvas: { liveOpened: mocks.liveOpened, liveClosed: mocks.liveClosed },
-      notes: { getFolders: () => Promise.resolve([]) }
-    }
+    installWindowApi()
   })
 
   it('opens the picker for a single selected shape', () => {
@@ -606,10 +629,7 @@ describe('CanvasEditor native link action', () => {
     mocks.api.showHyperlinkPopup = false
     mocks.api.elements = [{ id: 'shape-1', type: 'rectangle' }]
     mocks.api.selectedElementIds = { 'shape-1': true }
-    ;(window as Window & { api: unknown }).api = {
-      canvas: { liveOpened: mocks.liveOpened, liveClosed: mocks.liveClosed },
-      notes: { getFolders: () => Promise.resolve([]) }
-    }
+    installWindowApi()
   })
 
   it('answers the built-in link button with the item picker, and closes its URL box', () => {
@@ -681,10 +701,7 @@ describe('CanvasEditor link bubble label', () => {
   beforeEach(() => {
     mocks.api.isLoading = false
     mocks.api.elements = []
-    ;(window as Window & { api: unknown }).api = {
-      canvas: { liveOpened: mocks.liveOpened, liveClosed: mocks.liveClosed },
-      notes: { getFolders: () => Promise.resolve([]) }
-    }
+    installWindowApi()
   })
 
   it("shows the linked item's name instead of its id", async () => {
@@ -742,10 +759,7 @@ describe('CanvasEditor element link label', () => {
     mocks.noteGet.mockReset().mockResolvedValue({ id: 'n1', title: 'memrynote Launch' })
     mocks.taskGet.mockReset().mockResolvedValue(null)
     mocks.eventGet.mockReset().mockResolvedValue(null)
-    ;(window as Window & { api: unknown }).api = {
-      canvas: { liveOpened: mocks.liveOpened, liveClosed: mocks.liveClosed },
-      notes: { getFolders: () => Promise.resolve([]) }
-    }
+    installWindowApi()
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: { href: PROD_DOC }
@@ -824,5 +838,202 @@ describe('CanvasEditor element link label', () => {
     const anchor = await mountAnchor(container, `${PROD_DOC}?element=r-1`)
 
     expect(anchor.textContent).toBe('canvas.link.missingTarget')
+  })
+})
+
+/**
+ * Viewport restore (#1508 A6, Aurelie): a canvas tab used to come back at 100%
+ * zoom looking at the middle of the drawing, because the stored scene carries no
+ * camera (`serializeAsJSON` drops scrollX/scrollY/zoom) and every mount fell
+ * back to `scrollToContent`.
+ */
+describe('CanvasEditor viewport restore', () => {
+  const CAMERA = { scrollX: -420, scrollY: 96, zoom: 2 }
+
+  interface InitialData {
+    elements?: unknown[]
+    appState?: Record<string, unknown>
+    scrollToContent?: boolean
+  }
+
+  /** The stamped record `useTabEntityViewState` persists under the tab. */
+  function storedCamera(entityId: string | undefined, value: unknown): void {
+    mocks.getTab.mockReturnValue({ viewState: { canvasViewport: { entityId, value } } })
+  }
+
+  function readInitialData(): InitialData | null {
+    return (mocks.excalidrawProps.initialData as () => InitialData | null)()
+  }
+
+  /** Only the writes that carry a camera; the tab has other view-state writers. */
+  function cameraWrites(): unknown[] {
+    return mocks.dispatch.mock.calls
+      .map(
+        ([action]) => action as { type: string; payload: { viewState?: Record<string, unknown> } }
+      )
+      .filter(
+        (action) => action.type === 'SAVE_TAB_STATE' && action.payload.viewState?.canvasViewport
+      )
+      .map((action) => action.payload.viewState?.canvasViewport)
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.update.mockReset().mockResolvedValue({ id: 'c1' })
+    mocks.dispatch.mockReset()
+    mocks.getTab.mockReset().mockReturnValue({ viewState: {} })
+    mocks.identity = { tabId: 't1', groupId: 'g1', entityId: 'c1' }
+    mocks.api.elements = []
+    mocks.api.isLoading = true
+    mocks.api.viewport = null
+    mocks.onChange = null
+    mocks.liveOpened.mockReset().mockResolvedValue({ ok: true })
+    mocks.liveClosed.mockReset().mockResolvedValue({ ok: true })
+    installWindowApi()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('hands the tab camera to initialData and stands scrollToContent down', () => {
+    storedCamera('c1', CAMERA)
+    render(<CanvasEditor canvasId="c1" initialScene={STORED_SCENE} />)
+
+    const data = readInitialData()
+
+    expect(data?.appState).toMatchObject({
+      scrollX: CAMERA.scrollX,
+      scrollY: CAMERA.scrollY,
+      zoom: { value: CAMERA.zoom }
+    })
+    // Excalidraw applies scrollToContent AFTER restoring appState, so leaving it
+    // on would silently undo the camera we just restored.
+    expect(data?.scrollToContent).toBe(false)
+    expect(data?.elements).toEqual([{ id: 'stroke-1', type: 'freedraw' }])
+  })
+
+  it('centres on the drawing when the tab has no camera yet', () => {
+    render(<CanvasEditor canvasId="c1" initialScene={STORED_SCENE} />)
+
+    const data = readInitialData()
+
+    expect(data?.scrollToContent).toBe(true)
+    expect(data?.appState).not.toHaveProperty('scrollX')
+  })
+
+  it('restores the camera on a canvas that was never drawn on', () => {
+    storedCamera('c1', CAMERA)
+    render(<CanvasEditor canvasId="c1" initialScene="" />)
+
+    const data = readInitialData()
+
+    expect(data).not.toBeNull()
+    expect(data?.elements).toEqual([])
+    expect(data?.appState).toMatchObject({ zoom: { value: CAMERA.zoom } })
+    expect(data?.scrollToContent).toBe(false)
+  })
+
+  it('still hands Excalidraw nothing for an untouched empty canvas', () => {
+    render(<CanvasEditor canvasId="c1" initialScene="" />)
+
+    expect(readInitialData()).toBeNull()
+  })
+
+  it('ignores a camera stamped with a different canvas', () => {
+    // A preview tab is reused for the next item the user clicks, so the tab
+    // outlives the entity its camera was measured against.
+    storedCamera('another-canvas', CAMERA)
+    render(<CanvasEditor canvasId="c1" initialScene={STORED_SCENE} />)
+
+    expect(readInitialData()?.scrollToContent).toBe(true)
+  })
+
+  it('ignores a stored camera an older build could have written badly', () => {
+    storedCamera('c1', { scrollX: 10, scrollY: 10, zoom: 900 })
+    render(<CanvasEditor canvasId="c1" initialScene={STORED_SCENE} />)
+
+    expect(readInitialData()?.scrollToContent).toBe(true)
+  })
+
+  it('records a pan/zoom once per throttle window, not once per frame', () => {
+    render(<CanvasEditor canvasId="c1" initialScene={STORED_SCENE} />)
+    finishInit()
+    mocks.api.viewport = { scrollX: -10, scrollY: -20, zoom: { value: 1.5 } }
+
+    act(() => {
+      mocks.onChange?.()
+      mocks.api.viewport = {
+        scrollX: CAMERA.scrollX,
+        scrollY: CAMERA.scrollY,
+        zoom: { value: CAMERA.zoom }
+      }
+      mocks.onChange?.()
+      mocks.onChange?.()
+    })
+    expect(cameraWrites()).toHaveLength(0)
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(cameraWrites()).toEqual([{ entityId: 'c1', value: CAMERA }])
+  })
+
+  it('ignores the camera Excalidraw reports before initialData is applied', () => {
+    render(<CanvasEditor canvasId="c1" initialScene={STORED_SCENE} />)
+    // Still initialising: appState is Excalidraw's default (origin, 100%), and
+    // recording it would overwrite the stored camera with the origin.
+    mocks.api.viewport = { scrollX: 0, scrollY: 0, zoom: { value: 1 } }
+
+    act(() => {
+      mocks.onChange?.()
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(cameraWrites()).toHaveLength(0)
+  })
+
+  it('writes the last camera at teardown', () => {
+    // The fake API exposes no camera at all, so a camera in this write can only
+    // have come from the ref — which is the point: on a tab switch React
+    // destroys the Excalidraw child before this cleanup runs.
+    const { unmount } = render(<CanvasEditor canvasId="c1" initialScene={STORED_SCENE} />)
+    finishInit()
+    mocks.api.viewport = {
+      scrollX: CAMERA.scrollX,
+      scrollY: CAMERA.scrollY,
+      zoom: { value: CAMERA.zoom }
+    }
+
+    act(() => {
+      mocks.onChange?.()
+    })
+    expect(cameraWrites()).toHaveLength(0)
+
+    act(() => {
+      unmount()
+    })
+
+    expect(cameraWrites()).toEqual([{ entityId: 'c1', value: CAMERA }])
+  })
+
+  it('does not rewrite a camera that has not moved', () => {
+    storedCamera('c1', CAMERA)
+    const { unmount } = render(<CanvasEditor canvasId="c1" initialScene={STORED_SCENE} />)
+    finishInit()
+    mocks.api.viewport = {
+      scrollX: CAMERA.scrollX,
+      scrollY: CAMERA.scrollY,
+      zoom: { value: CAMERA.zoom }
+    }
+
+    act(() => {
+      mocks.onChange?.()
+      vi.advanceTimersByTime(500)
+      unmount()
+    })
+
+    expect(cameraWrites()).toHaveLength(0)
   })
 })

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
@@ -6,7 +6,7 @@
  * public/excalidraw-asset-path.js) because the CSP blocks Excalidraw's CDN.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import {
   Excalidraw,
   serializeAsJSON,
@@ -25,6 +25,7 @@ import { getI18n } from 'react-i18next'
 import { toast } from 'sonner'
 import { useT } from '@memry/i18n/renderer'
 import { useTabActions } from '@/contexts/tabs'
+import { useTabEntityViewState } from '@/hooks/use-tab-entity-view-state'
 import { parseMemryHref, tabFromMemryHref } from '@/lib/memry-links'
 import { notesService } from '@/services/notes-service'
 import { canvasService, onCanvasTooLarge } from '@/services/canvas-service'
@@ -53,10 +54,41 @@ import {
   type LiveCanvasHandle
 } from './canvas-live-registry'
 import type { SceneEditElement } from './canvas-scene-edit'
+import {
+  CANVAS_VIEWPORT_KEY,
+  parseCanvasViewport,
+  sameViewport,
+  viewportFromAppState,
+  type CanvasViewport,
+  type ViewportAppState
+} from './canvas-viewport'
 
 const log = createLogger('SpatialCanvas')
 
 const SCENE_SAVE_DEBOUNCE_MS = 800
+/**
+ * How often the camera is committed to tab state while the user pans or zooms.
+ * Excalidraw's onChange fires per frame, and every commit mints a new
+ * tab-system state object and re-renders every `useTabGroup` consumer.
+ */
+const VIEWPORT_SAVE_THROTTLE_MS = 500
+
+/**
+ * The appState slice that positions the camera.
+ *
+ * Cast because `zoom` is typed as a branded `NormalizedZoomValue` that the
+ * library does not export a constructor for. The number is Excalidraw's own,
+ * round-tripped through tab state, and `parseCanvasViewport` has already held it
+ * to the library's range.
+ */
+const viewportAppState = (
+  viewport: CanvasViewport
+): NonNullable<ExcalidrawInitialDataState['appState']> =>
+  ({
+    scrollX: viewport.scrollX,
+    scrollY: viewport.scrollY,
+    zoom: { value: viewport.zoom }
+  }) as NonNullable<ExcalidrawInitialDataState['appState']>
 
 /** A scene element as this file reads it: cards carry `customData`. */
 interface LinkableElement {
@@ -105,9 +137,92 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
     }
   }, [initialScene])
 
+  // Where this TAB was last looking. Stored per tab rather than in the scene:
+  // the scene's exported appState carries no viewport at all (see
+  // `canvas-viewport.ts`), and two split panes on one canvas are two cameras.
+  const [storedViewport, setStoredViewport] = useTabEntityViewState<CanvasViewport | null>({
+    key: CANVAS_VIEWPORT_KEY,
+    defaultValue: null,
+    parse: parseCanvasViewport
+  })
+  /**
+   * Mount-time snapshot of that camera. `initialData` is read once, from
+   * componentDidMount, so reading the live value inside `loadInitialData` would
+   * only churn the callback's identity on every write we make ourselves.
+   */
+  const restoredViewportRef = useRef(storedViewport)
+  /** Live camera, mirrored out of onChange. The only thing teardown may persist. */
+  const viewportRef = useRef(storedViewport)
+  /** Last camera actually written, so a commit that changes nothing is skipped. */
+  const committedViewportRef = useRef(storedViewport)
+  const viewportTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const setStoredViewportRef = useRef(setStoredViewport)
+
+  useLayoutEffect(() => {
+    setStoredViewportRef.current = setStoredViewport
+  }, [setStoredViewport])
+
+  const commitViewport = useCallback((): void => {
+    viewportTimerRef.current = null
+    const next = viewportRef.current
+    if (next === null || sameViewport(next, committedViewportRef.current)) {
+      return
+    }
+    committedViewportRef.current = next
+    setStoredViewportRef.current(next)
+  }, [])
+
+  /**
+   * Mirrors the camera out of onChange, throttled.
+   *
+   * Ignored while `isLoading`: Excalidraw fires onChange during init carrying
+   * its default appState (origin, 100%), and recording that would overwrite the
+   * stored camera with the origin before initialData has even been applied —
+   * the same init-window hazard the serialize guard below exists for.
+   */
+  const recordViewport = useCallback(
+    (appState: ViewportAppState & { isLoading?: boolean }): void => {
+      if (appState.isLoading) {
+        return
+      }
+      const next = viewportFromAppState(appState)
+      if (!next) {
+        return
+      }
+      viewportRef.current = next
+      if (viewportTimerRef.current === null) {
+        viewportTimerRef.current = setTimeout(commitViewport, VIEWPORT_SAVE_THROTTLE_MS)
+      }
+    },
+    [commitViewport]
+  )
+
+  // Final write at teardown, from the REF — never from the API. On a tab switch
+  // React destroys the Excalidraw child before this parent's cleanup runs, so by
+  // then `getAppState()` describes a torn-down editor; that is the same reason
+  // the serialize path checks `wrapperRef.isConnected`.
+  useEffect(() => {
+    return () => {
+      if (viewportTimerRef.current !== null) {
+        clearTimeout(viewportTimerRef.current)
+        viewportTimerRef.current = null
+      }
+      commitViewport()
+    }
+  }, [commitViewport])
+
   const loadInitialData = useCallback((): ExcalidrawInitialDataState | null => {
+    const viewport = restoredViewportRef.current
     if (!initialScene) {
-      return null
+      // Never drawn on — but the user may still have panned or zoomed here, and
+      // an empty canvas is the easiest place of all to get lost in.
+      return viewport
+        ? ({
+            elements: [],
+            appState: viewportAppState(viewport),
+            scrollToContent: false
+          } satisfies ExcalidrawInitialDataState)
+        : null
     }
     // serializeAsJSON output: { elements, appState, files } plus metadata
     // keys initialData ignores. Its exported appState is already cleaned
@@ -118,9 +233,11 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
     const parsed = JSON.parse(initialScene) as ExcalidrawInitialDataState
     return {
       elements: parsed.elements ?? [],
-      appState: parsed.appState ?? {},
+      appState: { ...(parsed.appState ?? {}), ...(viewport ? viewportAppState(viewport) : {}) },
       files: parsed.files,
-      scrollToContent: true
+      // `scrollToContent` runs AFTER the appState restore and would undo it, so
+      // it stays the fallback for a tab that has no camera of its own yet.
+      scrollToContent: viewport === null
     } satisfies ExcalidrawInitialDataState
   }, [initialScene])
 
@@ -624,6 +741,7 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
         }}
         onChange={(_elements, appState) => {
           persisterRef.current?.notifyChange()
+          recordViewport(appState)
           interceptLinkEditor(appState)
         }}
         onLinkOpen={handleLinkOpen}

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-viewport.test.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-viewport.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  parseCanvasViewport,
+  sameViewport,
+  viewportFromAppState,
+  type CanvasViewport
+} from './canvas-viewport'
+
+const VIEWPORT: CanvasViewport = { scrollX: -120.5, scrollY: 340, zoom: 1.75 }
+
+describe('parseCanvasViewport', () => {
+  it('accepts a well-formed record', () => {
+    expect(parseCanvasViewport({ ...VIEWPORT })).toEqual(VIEWPORT)
+  })
+
+  it('keeps the origin at 100%, which is a real camera and not "nothing stored"', () => {
+    expect(parseCanvasViewport({ scrollX: 0, scrollY: 0, zoom: 1 })).toEqual({
+      scrollX: 0,
+      scrollY: 0,
+      zoom: 1
+    })
+  })
+
+  it.each([
+    ['not an object', 42],
+    ['null', null],
+    ['an array', []],
+    ['a missing axis', { scrollX: 10, zoom: 1 }],
+    ['a missing zoom', { scrollX: 10, scrollY: 10 }],
+    ['a stringified number', { scrollX: '10', scrollY: 10, zoom: 1 }],
+    ['NaN', { scrollX: Number.NaN, scrollY: 10, zoom: 1 }],
+    ['Infinity', { scrollX: 10, scrollY: Number.POSITIVE_INFINITY, zoom: 1 }]
+  ])('rejects %s', (_label, raw) => {
+    expect(parseCanvasViewport(raw)).toBeUndefined()
+  })
+
+  it('rejects a zoom outside Excalidraw range rather than clamping it', () => {
+    // Clamping would drop the user at a position they never left the canvas at;
+    // rejecting falls back to first-open behaviour.
+    expect(parseCanvasViewport({ scrollX: 0, scrollY: 0, zoom: 0.05 })).toBeUndefined()
+    expect(parseCanvasViewport({ scrollX: 0, scrollY: 0, zoom: 42 })).toBeUndefined()
+    expect(parseCanvasViewport({ scrollX: 0, scrollY: 0, zoom: -1 })).toBeUndefined()
+  })
+
+  it('accepts the range boundaries themselves', () => {
+    expect(parseCanvasViewport({ scrollX: 0, scrollY: 0, zoom: 0.1 })?.zoom).toBe(0.1)
+    expect(parseCanvasViewport({ scrollX: 0, scrollY: 0, zoom: 30 })?.zoom).toBe(30)
+  })
+
+  it('drops keys it does not know', () => {
+    expect(parseCanvasViewport({ ...VIEWPORT, theme: 'dark' })).toEqual(VIEWPORT)
+  })
+})
+
+describe('viewportFromAppState', () => {
+  it('unwraps the zoom Excalidraw nests', () => {
+    expect(viewportFromAppState({ scrollX: -120.5, scrollY: 340, zoom: { value: 1.75 } })).toEqual(
+      VIEWPORT
+    )
+  })
+
+  it('reads nothing out of a pre-init appState', () => {
+    // Excalidraw hands out an appState before initialData is applied; there is
+    // no camera in it worth recording.
+    expect(viewportFromAppState({})).toBeUndefined()
+  })
+})
+
+describe('sameViewport', () => {
+  it('compares all three axes', () => {
+    expect(sameViewport(VIEWPORT, { ...VIEWPORT })).toBe(true)
+    expect(sameViewport(VIEWPORT, { ...VIEWPORT, zoom: 1.76 })).toBe(false)
+    expect(sameViewport(VIEWPORT, { ...VIEWPORT, scrollX: 0 })).toBe(false)
+    expect(sameViewport(VIEWPORT, { ...VIEWPORT, scrollY: 0 })).toBe(false)
+  })
+
+  it('treats "no camera" as equal only to itself', () => {
+    expect(sameViewport(null, null)).toBe(true)
+    expect(sameViewport(null, VIEWPORT)).toBe(false)
+    expect(sameViewport(VIEWPORT, null)).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-viewport.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-viewport.ts
@@ -1,0 +1,80 @@
+/**
+ * Canvas viewport — the tab's camera.
+ *
+ * Excalidraw's `serializeAsJSON` exports a CLEANED appState, and `scrollX`,
+ * `scrollY` and `zoom` are deliberately not in it. The stored scene has
+ * therefore never carried a viewport, so every mount fell back to
+ * `scrollToContent`: coming back to a canvas tab reset the zoom to 100% and
+ * jumped to whatever happens to sit in the middle of the drawing.
+ *
+ * The camera belongs to the TAB, not to the document. The same canvas open in
+ * two split panes is two viewpoints, and where one device is looking is not
+ * something to push to the others. So it is stored exactly like the PDF page
+ * number and the image zoom: an entity-stamped `Tab.viewState` entry (see
+ * `hooks/use-tab-entity-view-state.ts`), which survives a tab switch and a
+ * session restore without touching the scene payload or the sync protocol.
+ */
+
+/** Slot in `Tab.viewState`. */
+export const CANVAS_VIEWPORT_KEY = 'canvasViewport'
+
+export interface CanvasViewport {
+  scrollX: number
+  scrollY: number
+  /** Excalidraw's `appState.zoom.value`; `1` is 100%. */
+  zoom: number
+}
+
+/**
+ * Excalidraw's own zoom bounds, restated rather than imported: they live in the
+ * library's internal constants, which are not part of its public API.
+ */
+const MIN_ZOOM = 0.1
+const MAX_ZOOM = 30
+
+/** The shape this module needs out of an Excalidraw appState. */
+export interface ViewportAppState {
+  scrollX?: number
+  scrollY?: number
+  zoom?: { value: number }
+}
+
+/**
+ * Total parse for a persisted viewport, as `useTabViewState` requires: tab state
+ * can have been written by an older build, so anything unrecognised has to be
+ * rejected rather than trusted.
+ *
+ * A zoom outside Excalidraw's range is REJECTED, not clamped. Clamping would
+ * drop the user at a position they never left the canvas at; rejecting falls
+ * back to first-open behaviour, which is the honest answer for a record we
+ * cannot trust.
+ */
+export function parseCanvasViewport(raw: unknown): CanvasViewport | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const { scrollX, scrollY, zoom } = raw as Record<string, unknown>
+  if (typeof scrollX !== 'number' || !Number.isFinite(scrollX)) return undefined
+  if (typeof scrollY !== 'number' || !Number.isFinite(scrollY)) return undefined
+  if (typeof zoom !== 'number' || !Number.isFinite(zoom)) return undefined
+  if (zoom < MIN_ZOOM || zoom > MAX_ZOOM) return undefined
+  return { scrollX, scrollY, zoom }
+}
+
+/**
+ * The viewport a live appState is showing, or `undefined` while Excalidraw has
+ * not put real numbers there yet. Routed through the same parse as the stored
+ * value so a live reading and a restored one can never disagree about what
+ * counts as a viewport.
+ */
+export function viewportFromAppState(appState: ViewportAppState): CanvasViewport | undefined {
+  return parseCanvasViewport({
+    scrollX: appState.scrollX,
+    scrollY: appState.scrollY,
+    zoom: appState.zoom?.value
+  })
+}
+
+/** Whether two viewports describe the same camera, so a no-op write is skipped. */
+export function sameViewport(a: CanvasViewport | null, b: CanvasViewport | null): boolean {
+  if (a === null || b === null) return a === b
+  return a.scrollX === b.scrollX && a.scrollY === b.scrollY && a.zoom === b.zoom
+}

--- a/apps/desktop/tsconfig.test.web.json
+++ b/apps/desktop/tsconfig.test.web.json
@@ -145,7 +145,6 @@
     "src/renderer/src/lib/virtual-list-utils.test.ts",
     "src/renderer/src/pages/calendar-callbacks.test.tsx",
     "src/renderer/src/pages/calendar.test.tsx",
-    "src/renderer/src/pages/canvas/canvas-editor.test.tsx",
     "src/renderer/src/pages/canvas/index.test.tsx",
     "src/renderer/src/pages/project/project-capture-input.test.tsx",
     "src/renderer/src/pages/project/tabs/list-tab.test.tsx",

--- a/apps/docs/src/user-guide/canvas/overview.md
+++ b/apps/docs/src/user-guide/canvas/overview.md
@@ -29,6 +29,12 @@ canvas you have already made.
 - Canvases open in the normal tab system, so you can split the view and keep a
   canvas beside a note. See [Tabs & Split View](../tabs-split-view.md).
 
+Switching to another tab and back returns the board as you left it: same zoom
+level, same part of the board. That position belongs to the tab, so it comes back
+with your session after a restart, two split panes showing the same canvas each
+keep their own view, and it is never written into the file or sent to your other
+devices. Opening a canvas in a fresh tab starts centred on the drawing.
+
 ## Drawing
 
 The canvas uses a full drawing surface: freehand ink, shapes, arrows, text,
@@ -67,7 +73,8 @@ save by hand. Pressing **Cmd/Ctrl+S** simply confirms this with a short
 
 Only changes to the drawing itself are written. Moving around a board — panning,
 zooming, selecting — leaves the file untouched, so a board you are only reading
-does not keep rewriting itself or churning through sync. Whatever you have drawn
+does not keep rewriting itself or churning through sync; where you were looking
+is remembered by the tab instead. Whatever you have drawn
 is still written when you close the tab, quit, or press **Cmd/Ctrl+S**.
 
 Each canvas is a plain `.excalidraw` file in your vault's `canvases/` folder,


### PR DESCRIPTION
Reported by Aurelie (18 Aug, v2026-08-17), tracked as #1508 A6:

> It not only zoom back to the default 100% (if it was changed). But it brings back to the central items... Thereby the same experience of having to move around for canvases remain.

## Root cause

Two faults stacked:

1. **The camera was never stored.** In Excalidraw 0.18.1, `scrollX`, `scrollY` and `zoom` are all `export: false` in `APP_STATE_STORAGE_CONF`, so `serializeAsJSON` omits them. A canvas file has never carried a viewport — this was not a failure to restore, there was nothing to restore.
2. **`scrollToContent: true` ran on every mount.** Confirmed against the library source: `initializeScene` applies `calculateScrollCenter` *after* `restoreAppState`, so it overrides any camera in `initialData.appState`. That is the "jumps back to the central items" half.

`useTabScrollRestore` covers note-layout, tasks, calendar, inbox and folder views, but a canvas does not scroll — it pans and zooms — so it was never a candidate.

## Change

The camera belongs to the **tab**, not to the document, and is stored in the entity-stamped `Tab.viewState` slot that the PDF page number, image zoom and media positions already use (`useTabEntityViewState`). No new abstraction: canvas was the one surface in that family that had never been wired up.

- **Restore** through `initialData.appState`, read from a mount-time ref snapshot. Excalidraw applies `initialData` once from `componentDidMount`, so this sidesteps the `isLoading` race entirely rather than managing it a second time. `scrollToContent` now fires only for a tab with no camera of its own — which stays the right default on first open.
- **Capture** from `onChange` into a ref, committed on a 500 ms throttle. `onChange` fires per frame while panning, and every commit mints a new tab-system state object.
- **Teardown** writes the last camera from that ref, never from `getAppState()`: on a tab switch React destroys the Excalidraw child before this parent's cleanup runs, the same hazard the serialize path's `isConnected` guard exists for.
- A stored camera whose zoom falls outside Excalidraw's 0.1–30 range is **rejected, not clamped** — clamping would drop the user at a position they never left the canvas at, while rejecting falls back to first-open behaviour.
- A canvas that was never drawn on also gets its camera back; an empty board is the easiest place of all to get lost in.

Two split panes on the same canvas keep their own view, the position returns with the session after a restart, and the scene payload, vault file format and sync protocol are untouched.

## Verification

- `canvas-viewport.test.ts` (12) + a `CanvasEditor viewport restore` suite (10) against the existing fake-Excalidraw harness; whole canvas directory 408/408.
- **Six mutations, each caught by a distinct test**: `scrollToContent` forced true, `isLoading` guard removed, teardown commit removed, throttle removed, camera not merged into `initialData`, dedupe removed.
- `typecheck:web`, `typecheck:test`, eslint, `check:architecture`, `docs:impact --strict`, `docs:build` — all green.
- Full renderer suite: 7576 passed. The one red, `large-file-viewer.test.tsx`, passes 35/35 on its own and shares no module with canvas — load flake from two overlapping runs.

## Backlog

`canvas-editor.test.tsx` was in the `tsconfig.test.web.json` exclude list. Since this PR touches it, it comes off the list, which needed five pre-existing harness type errors fixed (duplicate `useHandleLibrary` key, too-narrow `FakeApi`, `window.api` cast). The backlog shrinks by one.

## Docs

`apps/docs/src/user-guide/canvas/overview.md` — what is remembered, that it is per tab, and that it is never written to the file or sent to other devices.
