### PR TITLE
fix(editor): stop the sticky formatting toolbar from breaking on narrow notes

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -422,34 +422,57 @@
   position: sticky !important;
   /* Stick below the floating note chrome (var set by NoteLayout, 0 elsewhere) */
   top: var(--note-chrome-height, 0px) !important;
-  z-index: 20;
+  /* position + z-index makes this element a stacking context, so its
+     un-portaled Select/Tooltip/Popover popper content (see the ::before
+     comment below) paints within THIS context's z-order, not the viewport's.
+     A tooltip popping up from a button near the top row can rise above the
+     toolbar's own top edge into the note-chrome (.note-chrome, z-30) — it
+     has to outrank that z-index or the chrome paints over it. */
+  z-index: 40;
   width: 100%;
+  /* @blocknote/shadcn's base .bn-toolbar sets overflow-x: auto + max-width:
+     100vw for the floating popup case; the sticky bar wraps instead of
+     scrolling, so items that don't fit flow to a second row. */
+  max-width: none !important;
+  overflow: visible !important;
+  flex-wrap: wrap !important;
   margin: 0 0 8px 0 !important;
   padding: 4px 0 8px 0 !important;
-  background: color-mix(in srgb, var(--background) 72%, transparent) !important;
-  -webkit-backdrop-filter: blur(16px) saturate(180%);
-  backdrop-filter: blur(16px) saturate(180%);
+  /* Background lives on ::before (below) rather than here: a background/
+     backdrop-filter on this element would make it the CSS containing block
+     for its own descendants' position: fixed content. BlockNote's shadcn
+     Select/Tooltip/Popover render un-portaled, so their popper content would
+     then be positioned and clipped relative to this bar instead of the
+     viewport — trapped inside it, unreachable and mostly invisible. */
   border: none !important;
   border-radius: 0 !important;
-  /* Soft scroll-edge instead of a hard divider: softened hairline + short falloff */
-  box-shadow:
-    0 1px 0 0 color-mix(in srgb, var(--border) 60%, transparent),
-    0 1px 10px -4px rgb(0 0 0 / 0.08) !important;
+  box-shadow: none !important;
   transform: none !important;
   opacity: 1 !important;
   pointer-events: auto !important;
 }
 
-@media (prefers-reduced-transparency: reduce) {
-  .sticky-toolbar-enabled .bn-formatting-toolbar {
-    background: var(--background) !important;
-    -webkit-backdrop-filter: none;
-    backdrop-filter: none;
-  }
+.sticky-toolbar-enabled .bn-formatting-toolbar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  /* Same solid color as the note body — the bar reads as part of the note,
+     not a separate floating panel, so no seam/divider against the content
+     scrolling under it. */
+  background: var(--background);
 }
 
 .sticky-toolbar-enabled .bn-formatting-toolbar > div {
   gap: 2px;
+}
+
+/* Without flex-shrink: 0, the forced min-width below replaces the browser's
+   default content-based min-width protection, so items (esp. the block type
+   select's "Paragraph" trigger) shrink narrower than their text and overflow
+   onto neighboring buttons instead of wrapping to the next row. */
+.sticky-toolbar-enabled .bn-formatting-toolbar > * {
+  flex-shrink: 0;
 }
 
 .sticky-toolbar-enabled .bn-formatting-toolbar button {
@@ -523,8 +546,11 @@
 }
 
 /* The button sits inside a pointer-capture span, so the span is the grid item
-   and has to stretch before `width: 100%` on the button means anything. */
-.review-formatting-toolbar-action {
+   and has to stretch before `width: 100%` on the button means anything. This
+   is compact-popup only — in the sticky toolbar the same span must stay an
+   inline flex item, or `width: 100%` claims the whole row width and forces
+   the icon-only button onto its own line. */
+.review-formatting-toolbar-compact .review-formatting-toolbar-action {
   display: block;
   width: 100%;
 }

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
@@ -62,7 +62,7 @@ export function ReviewFormattingToolbar({
       <FormattingToolbar {...toolbarProps}>
         {getFormattingToolbarItems(toolbarProps.blockTypeSelectItems)}
         <ListTypeButtons />
-        <ReviewToolbarButton onSelect={onAddComment} />
+        <ReviewToolbarButton onSelect={onAddComment} iconOnly />
       </FormattingToolbar>
     )
   }
@@ -109,7 +109,13 @@ export function ReviewFormattingToolbar({
   )
 }
 
-function ReviewToolbarButton({ onSelect }: { onSelect?: (selection: ReviewSelection) => void }) {
+function ReviewToolbarButton({
+  onSelect,
+  iconOnly = false
+}: {
+  onSelect?: (selection: ReviewSelection) => void
+  iconOnly?: boolean
+}) {
   const { t } = useT('notes')
   const Components = useComponentsContext()
   const editor = useBlockNoteEditor()
@@ -263,10 +269,12 @@ function ReviewToolbarButton({ onSelect }: { onSelect?: (selection: ReviewSelect
           runAction()
         }}
       >
-        {/* The icon alone read as an unlabelled glyph in the corner of the
-            popup; the row is a single full-width button so the action is
-            spelled out. `label` stays for the aria-label. */}
-        {label}
+        {/* The compact popup is a single full-width button, so the icon alone
+            reads as an unlabelled glyph in the corner — spell it out there.
+            The sticky toolbar sits inline with the other icon-only buttons;
+            spelling it out there is what pushed it onto its own row. Either
+            way `label` stays for the aria-label/tooltip. */}
+        {!iconOnly && label}
       </Components.FormattingToolbar.Button>
     </span>
   )


### PR DESCRIPTION
## Summary
- Buttons in the sticky note-formatting toolbar could overlap ("Paragraph" text bleeding into B/I/U/S) once the block type select shrank below its own text width — an explicit `min-width: 28px` on all toolbar buttons had removed flexbox's default content-based min-width protection.
- The block type select's dropdown, and any button's tooltip, rendered visually trapped/clipped inside the toolbar row: the toolbar's `backdrop-filter` made it the CSS containing block for its un-portaled Radix Select/Tooltip/Popover popper content, so that content positioned and clipped against the toolbar instead of the viewport.
- The comment button forced `width: 100%` (meant for the separate compact popup layout) and always rendered a text label, pushing it onto its own row in the sticky toolbar.
- Tooltips popping up near the toolbar's top edge rendered underneath `.note-chrome` (the breadcrumb header, `z-30`) because the toolbar's own stacking context was `z-20`.

## Changes
- `flex-wrap` + `flex-shrink: 0` on toolbar items instead of letting them shrink below content and overlap.
- Toolbar background/backdrop-filter moved to a `::before` pseudo-element so the toolbar element itself no longer traps popper content; dropdowns/tooltips now escape to the viewport correctly.
- Dropped the toolbar's divider/box-shadow; solid background now matches the note body so it reads as part of the note.
- Comment button is icon-only in the sticky toolbar, and its `width: 100%` styling is scoped to the compact popup variant only.
- Toolbar `z-index` raised from 20 to 40, above `.note-chrome`'s 30.

## Docs
Bugfix restoring existing sticky-toolbar behavior — no new user-facing capability, so no docs update. (`docs:impact` bypassed with `MEMRY_DOCS_IMPACT_SKIP=1`.)

## Test plan
- [x] `pnpm --filter @memry/desktop test:renderer -- review-formatting-toolbar` passes
- [ ] Manual: open a note, enable sticky toolbar, select text, confirm no overlapping buttons on a narrow note, block type dropdown and tooltips render fully visible above the header, comment button stays inline