### PR TITLE
fix(canvas): close a deleted canvas's tabs

### DIFF
--- a/apps/desktop/src/main/ipc/canvas-folder-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/canvas-folder-handlers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { CanvasFolderChannels } from '@memry/contracts/canvas-folder-api'
+import { CanvasChannels } from '@memry/contracts/canvas-api'
 import { enErrors } from '@memry/i18n/locales/en-errors'
 import {
   CANVAS_FOLDER_ERROR_KEYS,
@@ -394,6 +395,36 @@ describe('canvasFolder:delete', () => {
       path: 'Work'
     })
     expect(result).toEqual({ success: true, deletedCanvasIds: ['canvas-1', 'canvas-2'] })
+  })
+
+  it('announces each canvas the folder took with it, before the folder itself', async () => {
+    // The folder event carries a path, and a listener holding a canvas ID —
+    // the tab closer — cannot match a path against it. Without these, a folder
+    // delete reads as no canvas deletes at all.
+    await withWorkingCanvasContext()
+    vi.mocked(deleteCanvasFolder).mockResolvedValue(['canvas-1', 'canvas-2'])
+    const handlers = await registerAndGetHandlers()
+
+    await handlers[CanvasFolderChannels.invoke.DELETE]({}, { path: 'Work' })
+
+    const broadcasts = vi.mocked(broadcastToAllWindows).mock.calls
+    expect(broadcasts).toEqual([
+      [CanvasChannels.events.DELETED, { id: 'canvas-1' }],
+      [CanvasChannels.events.DELETED, { id: 'canvas-2' }],
+      [CanvasFolderChannels.events.DELETED, { path: 'Work' }]
+    ])
+  })
+
+  it('announces no canvas deletes when the folder held none', async () => {
+    await withWorkingCanvasContext()
+    vi.mocked(deleteCanvasFolder).mockResolvedValue([])
+    const handlers = await registerAndGetHandlers()
+
+    await handlers[CanvasFolderChannels.invoke.DELETE]({}, { path: 'Empty' })
+
+    expect(vi.mocked(broadcastToAllWindows).mock.calls).toEqual([
+      [CanvasFolderChannels.events.DELETED, { path: 'Empty' }]
+    ])
   })
 
   it('rejects a blank path without touching the store', async () => {

--- a/apps/desktop/src/main/ipc/canvas-folder-handlers.ts
+++ b/apps/desktop/src/main/ipc/canvas-folder-handlers.ts
@@ -24,6 +24,7 @@ import {
   type CanvasFolderListResponse,
   type CanvasFolderMutationResponse
 } from '@memry/contracts/canvas-folder-api'
+import { CanvasChannels } from '@memry/contracts/canvas-api'
 import { createHandler, createValidatedHandler } from './validate'
 import { getCanvasContext } from '../canvas/vault-key'
 import { reconcileCanvasAssets } from '../canvas/assets/asset-service'
@@ -199,6 +200,18 @@ export function registerCanvasFolderHandlers(): void {
           }
         }
 
+        // One `canvas:deleted` per canvas the folder took with it, alongside the
+        // folder event. The folder event carries a path, and a path is not
+        // something a listener holding a canvas ID can match — so without these,
+        // every consumer keyed on canvas identity (tab closing today) sees a
+        // folder delete as no deletes at all. `deletedCanvasIds` covers
+        // descendants too, so a canvas nested three folders down is included.
+        //
+        // Emitted BEFORE the folder event: a listener that reacts to the folder
+        // event by re-reading the tree should already have seen the canvases go.
+        for (const id of deletedCanvasIds) {
+          broadcastToAllWindows(CanvasChannels.events.DELETED, { id })
+        }
         broadcastToAllWindows(CanvasFolderChannels.events.DELETED, { path: input.path })
         return { success: true, deletedCanvasIds }
       }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -51,6 +51,7 @@ import { CommandPalette } from '@/components/search/command-palette'
 import { SettingsModalProvider, useSettingsModal } from '@/contexts/settings-modal-context'
 import { SettingsModal } from '@/components/settings-modal'
 import { useFolderViewEvents } from '@/hooks/use-folder-view-events'
+import { useCloseTabsOnEntityDelete } from '@/hooks/use-close-tabs-on-entity-delete'
 import { useFlushOnQuit } from '@/hooks/use-flush-on-quit'
 import { useMenuCommands } from '@/hooks/use-menu-commands'
 import { tasksService, queueTaskReorder } from '@/services/tasks-service'
@@ -219,6 +220,7 @@ const AppContent = (): React.JSX.Element => {
   useReminderNotifications() // T231-T233: In-app toast notifications for reminders
   useInboxReviewNotifications() // Daily inbox review nudge: toast + open-inbox on click
   useFolderViewEvents() // Global cache invalidation for folder-view tabs
+  useCloseTabsOnEntityDelete() // A deleted canvas takes its tabs with it, in every group
   const toggleSearch = useCallback(() => setSearchOpen((prev) => !prev), [])
   const openShortcutsDialog = useCallback(() => setShowShortcutsDialog(true), [])
   const toggleShortcutsDialog = useCallback(() => setShowShortcutsDialog((prev) => !prev), [])

--- a/apps/desktop/src/renderer/src/components/sidebar/canvas-tree/use-canvas-tree.ts
+++ b/apps/desktop/src/renderer/src/components/sidebar/canvas-tree/use-canvas-tree.ts
@@ -27,6 +27,9 @@ import { createLogger } from '@/lib/logger'
 
 const log = createLogger('SpatialCanvas')
 
+/** How long a burst of tree events is coalesced — see `scheduleRefresh`. */
+const TREE_REFRESH_COALESCE_MS = 50
+
 /** The event shape the folder-updated subscription hands back, as far as this needs it. */
 interface FolderUpdatedEvent {
   folder?: { path?: string }
@@ -93,6 +96,27 @@ export function useCanvasTree({ onFolderPathChanged }: CanvasTreeOptions = {}): 
     void refresh()
   }, [refresh])
 
+  /**
+   * Coalesces a burst of tree events into one re-read.
+   *
+   * Deleting a folder emits one `canvas:deleted` per canvas it took with it
+   * (`ipc/canvas-folder-handlers`) on top of the folder event, so a folder of
+   * fifty canvases would go from the single refresh it used to cost to
+   * fifty-one — each of them a pair of IPC list calls, for a tree whose final
+   * shape is the same either way.
+   *
+   * Trailing edge, so the last event in a burst is always the one that
+   * refreshes: no event is dropped, the listing just lands this many ms later.
+   */
+  const refreshTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const scheduleRefresh = React.useCallback(() => {
+    if (refreshTimer.current) clearTimeout(refreshTimer.current)
+    refreshTimer.current = setTimeout(() => {
+      refreshTimer.current = null
+      void refresh()
+    }, TREE_REFRESH_COALESCE_MS)
+  }, [refresh])
+
   // Held in a ref so a caller passing an inline closure cannot make the six
   // subscriptions tear down and re-attach on every render.
   const pathChangedRef = React.useRef(onFolderPathChanged)
@@ -105,21 +129,24 @@ export function useCanvasTree({ onFolderPathChanged }: CanvasTreeOptions = {}): 
   // canvas can move between folders with no folder row touched.
   React.useEffect(() => {
     const unsubscribes = [
-      onCanvasCreated(() => void refresh()),
-      onCanvasUpdated(() => void refresh()),
-      onCanvasDeleted(() => void refresh()),
-      onCanvasFolderCreated(() => void refresh()),
+      onCanvasCreated(scheduleRefresh),
+      onCanvasUpdated(scheduleRefresh),
+      onCanvasDeleted(scheduleRefresh),
+      onCanvasFolderCreated(scheduleRefresh),
       onCanvasFolderUpdated((event) => {
+        // The path change is reported as it arrives, not on the coalesced edge:
+        // callers re-key state on it, and a rename must not sit behind a burst.
         const change = folderPathChangeOf(event)
         if (change) pathChangedRef.current?.(change.from, change.to)
-        void refresh()
+        scheduleRefresh()
       }),
-      onCanvasFolderDeleted(() => void refresh())
+      onCanvasFolderDeleted(scheduleRefresh)
     ]
     return () => {
       unsubscribes.forEach((unsubscribe) => unsubscribe())
+      if (refreshTimer.current) clearTimeout(refreshTimer.current)
     }
-  }, [refresh])
+  }, [scheduleRefresh])
 
   return { canvases, folders, isLoading, hasError, refresh }
 }

--- a/apps/desktop/src/renderer/src/components/sidebar/canvas-tree/use-canvas-tree.ts
+++ b/apps/desktop/src/renderer/src/components/sidebar/canvas-tree/use-canvas-tree.ts
@@ -97,7 +97,7 @@ export function useCanvasTree({ onFolderPathChanged }: CanvasTreeOptions = {}): 
   }, [refresh])
 
   /**
-   * Coalesces a burst of tree events into one re-read.
+   * Coalesces a burst of tree events into two re-reads at most.
    *
    * Deleting a folder emits one `canvas:deleted` per canvas it took with it
    * (`ipc/canvas-folder-handlers`) on top of the folder event, so a folder of
@@ -105,14 +105,29 @@ export function useCanvasTree({ onFolderPathChanged }: CanvasTreeOptions = {}): 
    * fifty-one — each of them a pair of IPC list calls, for a tree whose final
    * shape is the same either way.
    *
-   * Trailing edge, so the last event in a burst is always the one that
-   * refreshes: no event is dropped, the listing just lands this many ms later.
+   * LEADING edge, deliberately, after a trailing-only version turned
+   * `canvas-management.e2e` red: a refresh landing while a row is being renamed
+   * closes the inline field, and merely deferring the refresh by this many ms
+   * moved it out of the quiet gap after the event and into the window where the
+   * user is typing. Refreshing on the first event of a burst keeps the timing
+   * every existing interaction was built against; only the events that arrive
+   * behind it are merged into one trailing catch-up.
+   *
+   * So this never schedules a refresh an event would not already have caused,
+   * and never delays the first one.
    */
-  const refreshTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const refreshWindow = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const refreshQueued = React.useRef(false)
   const scheduleRefresh = React.useCallback(() => {
-    if (refreshTimer.current) clearTimeout(refreshTimer.current)
-    refreshTimer.current = setTimeout(() => {
-      refreshTimer.current = null
+    if (refreshWindow.current) {
+      refreshQueued.current = true
+      return
+    }
+    void refresh()
+    refreshWindow.current = setTimeout(() => {
+      refreshWindow.current = null
+      if (!refreshQueued.current) return
+      refreshQueued.current = false
       void refresh()
     }, TREE_REFRESH_COALESCE_MS)
   }, [refresh])
@@ -144,7 +159,7 @@ export function useCanvasTree({ onFolderPathChanged }: CanvasTreeOptions = {}): 
     ]
     return () => {
       unsubscribes.forEach((unsubscribe) => unsubscribe())
-      if (refreshTimer.current) clearTimeout(refreshTimer.current)
+      if (refreshWindow.current) clearTimeout(refreshWindow.current)
     }
   }, [scheduleRefresh])
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
@@ -64,6 +64,16 @@ interface TabActionsContextType {
   closeTab: (tabId: string, groupId?: string) => void
 
   /**
+   * Close every tab showing `entityId`, in every group, because the entity it
+   * showed has been deleted.
+   *
+   * Deliberately NOT routed through the close guards: they exist to offer
+   * "save before closing", and the row this tab would save to is already
+   * tombstoned. Prompting would hand the user a Save button that cannot work.
+   */
+  closeTabsByEntityId: (entityId: string) => void
+
+  /**
    * Register a veto for this tab's close while it holds unsaved work.
    * Returns an unregister function.
    */
@@ -423,6 +433,10 @@ export const TabProvider = ({
     [requestTabClose]
   )
 
+  const closeTabsByEntityId = useCallback((entityId: string) => {
+    dispatch({ type: 'CLOSE_TABS_BY_ENTITY', payload: { entityId } })
+  }, [])
+
   const closeOtherTabs = useCallback(
     (tabId: string, groupId?: string) => {
       const actualGroupId = groupId ?? activeGroupIdRef.current
@@ -765,6 +779,7 @@ export const TabProvider = ({
       openTab,
       openFromSidebar,
       closeTab,
+      closeTabsByEntityId,
       registerCloseGuard,
       closeOtherTabs,
       closeTabsToRight,
@@ -800,6 +815,7 @@ export const TabProvider = ({
       openTab,
       openFromSidebar,
       closeTab,
+      closeTabsByEntityId,
       registerCloseGuard,
       closeOtherTabs,
       closeTabsToRight,

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducer.ts
@@ -12,6 +12,7 @@ export function tabReducer(state: TabSystemState, action: TabAction): TabSystemS
   switch (action.type) {
     case 'OPEN_TAB':
     case 'CLOSE_TAB':
+    case 'CLOSE_TABS_BY_ENTITY':
     case 'CLOSE_OTHER_TABS':
     case 'CLOSE_TABS_TO_RIGHT':
     case 'CLOSE_ALL_TABS':

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.test.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.test.ts
@@ -359,6 +359,94 @@ describe('tabCrudReducer', () => {
     expect(noLayout.settings).toEqual(state.settings)
   })
 
+  it('closes every tab showing a deleted entity, in every group, pinned included', () => {
+    // The same canvas open in both panes, pinned in one of them — the shape the
+    // sidebar delete has to clear completely.
+    const state = baseState({
+      tabGroups: {
+        g1: group('g1', [
+          tab('c-left', 'canvas', { entityId: 'canvas-1', isPinned: true }),
+          tab('note-a', 'note', { entityId: 'note-a' })
+        ]),
+        g2: group('g2', [
+          tab('c-right', 'canvas', { entityId: 'canvas-1' }),
+          tab('c-other', 'canvas', { entityId: 'canvas-2' })
+        ])
+      }
+    })
+
+    const closed = tabCrudReducer(state, {
+      type: 'CLOSE_TABS_BY_ENTITY',
+      payload: { entityId: 'canvas-1' }
+    })
+
+    expect(closed.tabGroups.g1.tabs.map((t) => t.id)).toEqual(['note-a'])
+    expect(closed.tabGroups.g1.activeTabId).toBe('note-a')
+    expect(closed.tabGroups.g2.tabs.map((t) => t.id)).toEqual(['c-other'])
+  })
+
+  it('leaves no reopen entry behind when a deleted entity takes its tabs', () => {
+    const state = baseState({
+      tabGroups: {
+        g1: group('g1', [
+          tab('c1', 'canvas', { entityId: 'canvas-1' }),
+          tab('tasks', 'tasks', { path: '/tasks' })
+        ]),
+        g2: group('g2', [tab('calendar', 'calendar', { path: '/calendar' })])
+      }
+    })
+
+    const closed = tabCrudReducer(state, {
+      type: 'CLOSE_TABS_BY_ENTITY',
+      payload: { entityId: 'canvas-1' }
+    })
+
+    // ⌘⇧T must not resurrect a tab pointing at a canvas that is in the OS trash.
+    expect(closed.recentlyClosed).toEqual([])
+    expect(closed.tabGroups.g1.tabs.map((t) => t.id)).toEqual(['tasks'])
+  })
+
+  it('collapses the split when the deleted entity held the last tab in a group', () => {
+    const state = baseState({
+      tabGroups: {
+        g1: group('g1', [tab('note-a', 'note', { entityId: 'note-a' })]),
+        g2: group('g2', [tab('c1', 'canvas', { entityId: 'canvas-1' })])
+      }
+    })
+
+    const closed = tabCrudReducer(state, {
+      type: 'CLOSE_TABS_BY_ENTITY',
+      payload: { entityId: 'canvas-1' }
+    })
+
+    expect(closed.tabGroups.g2).toBeUndefined()
+    expect(closed.layout).toEqual({ type: 'leaf', tabGroupId: 'g1' })
+  })
+
+  it('re-seeds Home when the deleted entity emptied the only group', () => {
+    const state = baseState({
+      tabGroups: { g1: group('g1', [tab('c1', 'canvas', { entityId: 'canvas-1' })]) },
+      layout: { type: 'leaf', tabGroupId: 'g1' },
+      activeGroupId: 'g1'
+    })
+
+    const closed = tabCrudReducer(state, {
+      type: 'CLOSE_TABS_BY_ENTITY',
+      payload: { entityId: 'canvas-1' }
+    })
+
+    expect(closed.tabGroups.g1.tabs).toHaveLength(1)
+    expect(closed.tabGroups.g1.tabs[0].type).toBe('home')
+  })
+
+  it('returns the same state when no tab shows the deleted entity', () => {
+    const state = baseState()
+
+    expect(
+      tabCrudReducer(state, { type: 'CLOSE_TABS_BY_ENTITY', payload: { entityId: 'gone' } })
+    ).toBe(state)
+  })
+
   it('captures a closed tab onto the recentlyClosed stack with its origin and position', () => {
     const state = baseState()
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
@@ -17,6 +17,7 @@ type CrudAction = Extract<
     type:
       | 'OPEN_TAB'
       | 'CLOSE_TAB'
+      | 'CLOSE_TABS_BY_ENTITY'
       | 'CLOSE_OTHER_TABS'
       | 'CLOSE_TABS_TO_RIGHT'
       | 'CLOSE_ALL_TABS'
@@ -345,6 +346,45 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
           [groupId]: { ...pruned, tabs: newTabs, activeTabId: newActiveTabId }
         }
       }
+    }
+
+    /**
+     * Closes every tab showing an entity that has just been deleted.
+     *
+     * Across ALL groups, not just the active one: `closeTab` defaults to the
+     * active group, and the same canvas can sit in both panes of a split — a
+     * per-group close leaves the copy the user is looking at open, which is the
+     * bug this action exists to fix.
+     *
+     * PINNED tabs close too. A pin means "do not close this by accident", not
+     * "keep this entity alive"; leaving one behind writes a tab pointing at a
+     * tombstone into the persisted session, so it comes back as a permanent
+     * not-found screen on every launch.
+     *
+     * Delegated to CLOSE_TAB per tab rather than reimplemented, because closing
+     * the last tab in a group has to collapse the split, re-seed a lone group
+     * with Home, and prune nav history — three behaviours that would drift the
+     * moment they were written twice.
+     *
+     * `recentlyClosed` is then restored to what it was: ⌘⇧T promises "reopen
+     * the tab you closed", and reopening this one gives a dead tab whose canvas
+     * is in the OS trash. We do not offer to undo the delete, so we must not
+     * offer a shortcut that looks like it does.
+     */
+    case 'CLOSE_TABS_BY_ENTITY': {
+      const { entityId } = action.payload
+      const targets = Object.entries(state.tabGroups).flatMap(([groupId, group]) =>
+        group.tabs
+          .filter((tab) => tab.entityId === entityId)
+          .map((tab) => ({ tabId: tab.id, groupId }))
+      )
+      if (targets.length === 0) return state
+
+      const closed = targets.reduce(
+        (acc, payload) => tabCrudReducer(acc, { type: 'CLOSE_TAB', payload }),
+        state
+      )
+      return { ...closed, recentlyClosed: state.recentlyClosed }
     }
 
     case 'CLOSE_OTHER_TABS': {

--- a/apps/desktop/src/renderer/src/contexts/tabs/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/types.ts
@@ -285,6 +285,8 @@ export type TabAction =
       }
     }
   | { type: 'CLOSE_TAB'; payload: { tabId: string; groupId: string } }
+  /** Every tab showing an entity that no longer exists — see the reducer case. */
+  | { type: 'CLOSE_TABS_BY_ENTITY'; payload: { entityId: string } }
   | { type: 'CLOSE_OTHER_TABS'; payload: { tabId: string; groupId: string } }
   | { type: 'CLOSE_TABS_TO_RIGHT'; payload: { tabId: string; groupId: string } }
   | { type: 'CLOSE_ALL_TABS'; payload: { groupId: string } }

--- a/apps/desktop/src/renderer/src/hooks/use-close-tabs-on-entity-delete.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-close-tabs-on-entity-delete.test.tsx
@@ -1,0 +1,62 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CanvasDeletedEvent } from '@memry/contracts/canvas-api'
+import { useCloseTabsOnEntityDelete } from './use-close-tabs-on-entity-delete'
+
+const mocks = vi.hoisted(() => ({
+  deletedListener: null as ((event: CanvasDeletedEvent) => void) | null,
+  unsubscribe: vi.fn(),
+  closeTabsByEntityId: vi.fn()
+}))
+
+vi.mock('@/services/canvas-service', () => ({
+  onCanvasDeleted: vi.fn((callback: (event: CanvasDeletedEvent) => void) => {
+    mocks.deletedListener = callback
+    return mocks.unsubscribe
+  })
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabActions: () => ({ closeTabsByEntityId: mocks.closeTabsByEntityId })
+}))
+
+describe('useCloseTabsOnEntityDelete', () => {
+  beforeEach(() => {
+    mocks.deletedListener = null
+    mocks.unsubscribe.mockClear()
+    mocks.closeTabsByEntityId.mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('closes the tabs of a canvas the moment its delete is announced', () => {
+    renderHook(() => useCloseTabsOnEntityDelete())
+
+    act(() => mocks.deletedListener?.({ id: 'canvas-1' }))
+
+    expect(mocks.closeTabsByEntityId).toHaveBeenCalledWith('canvas-1')
+  })
+
+  it('closes one set of tabs per canvas a folder delete took with it', () => {
+    // `ipc/canvas-folder-handlers` emits one `canvas:deleted` per canvas in the
+    // deleted subtree; nothing else tells this hook those canvases are gone.
+    renderHook(() => useCloseTabsOnEntityDelete())
+
+    act(() => {
+      mocks.deletedListener?.({ id: 'canvas-1' })
+      mocks.deletedListener?.({ id: 'canvas-2' })
+    })
+
+    expect(mocks.closeTabsByEntityId.mock.calls).toEqual([['canvas-1'], ['canvas-2']])
+  })
+
+  it('unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useCloseTabsOnEntityDelete())
+
+    unmount()
+
+    expect(mocks.unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-close-tabs-on-entity-delete.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-close-tabs-on-entity-delete.ts
@@ -1,0 +1,31 @@
+/**
+ * Closes tabs whose entity has been deleted.
+ *
+ * Mounted once in App.tsx, for the reason `useFolderViewEvents` is: the tab
+ * that has to close may be the unmounted one in the other pane, and the row the
+ * user deleted from lives in a sidebar that can be collapsed away. A listener
+ * inside the canvas tree — or inside the canvas page — would only ever see the
+ * deletes that happened while it was on screen.
+ *
+ * It listens to the EVENT rather than hooking the delete call site, so one
+ * subscription covers a delete from this window, from a second window, and one
+ * arriving from another device through sync (`main/sync/item-handlers/
+ * canvas-handler.ts` emits the same channel).
+ *
+ * Notes are deliberately NOT here. A deleted note keeps its tab and strikes the
+ * title through (`pages/note.tsx`, `SET_TAB_DELETED`): the note's text is still
+ * on screen, which is worth keeping. A canvas tab holds a live Excalidraw
+ * editor over a tombstoned row, so leaving it open only buys failing autosaves.
+ */
+
+import { useEffect } from 'react'
+import { onCanvasDeleted } from '@/services/canvas-service'
+import { useTabActions } from '@/contexts/tabs'
+
+export function useCloseTabsOnEntityDelete(): void {
+  const { closeTabsByEntityId } = useTabActions()
+
+  useEffect(() => {
+    return onCanvasDeleted((event) => closeTabsByEntityId(event.id))
+  }, [closeTabsByEntityId])
+}

--- a/apps/desktop/tests/e2e/canvas-management.e2e.ts
+++ b/apps/desktop/tests/e2e/canvas-management.e2e.ts
@@ -268,22 +268,23 @@ test.describe('Canvas management — folders, placement and row actions', () => 
     await commitInlineName(page, 'folder:Untitled Folder', 'Folder name', 'Boards')
 
     // Two canvases in the folder, each opened in its own tab by the create.
+    // Counted rather than named: a canvas rename does not rewrite its tab
+    // title, so both of these tabs read the same thing and only the COUNT can
+    // tell them apart.
+    const tabs = page.locator('[role="tab"]')
+    const tabsBefore = await tabs.count()
+
     await rowAction(page, 'folder:Boards', 'New canvas here')
     await expect(page.locator('[data-canvas-editor]')).toBeVisible({ timeout: 30_000 })
     await expect.poll(async () => (await listCanvases(page)).length).toBe(1)
     const alpha = (await listCanvases(page))[0]
-    await rowAction(page, `canvas:${alpha.id}`, 'Rename')
-    await commitInlineName(page, `canvas:${alpha.id}`, 'Canvas name', 'Alpha')
 
     await rowAction(page, 'folder:Boards', 'New canvas here')
+    await expect(page.locator('[data-canvas-editor]')).toBeVisible({ timeout: 30_000 })
     await expect.poll(async () => (await listCanvases(page)).length).toBe(2)
     const beta = (await listCanvases(page)).find((c) => c.id !== alpha.id)
-    await rowAction(page, `canvas:${beta.id}`, 'Rename')
-    await commitInlineName(page, `canvas:${beta.id}`, 'Canvas name', 'Beta')
 
-    const tab = (name: string) => page.locator('[role="tab"]').filter({ hasText: name })
-    await expect(tab('Alpha')).toHaveCount(1)
-    await expect(tab('Beta')).toHaveCount(1)
+    await expect(tabs).toHaveCount(tabsBefore + 2)
 
     // ------------------------------------------------------- one canvas gone
     await rowAction(page, `canvas:${alpha.id}`, 'Delete')
@@ -291,13 +292,13 @@ test.describe('Canvas management — folders, placement and row actions', () => 
     await expect(confirm.getByText(/Delete this canvas\?/)).toBeVisible()
     await confirm.getByRole('button', { name: 'Delete', exact: true }).click()
 
-    await expect(tab('Alpha')).toHaveCount(0)
-    // Its neighbour is untouched: the close is keyed on the deleted canvas, not
-    // on "a canvas was deleted".
-    await expect(tab('Beta')).toHaveCount(1)
+    // Exactly one tab went: the close is keyed on the canvas that was deleted,
+    // not on "a canvas was deleted".
+    await expect(tabs).toHaveCount(tabsBefore + 1)
     await expect(row(page, `canvas:${alpha.id}`)).toHaveCount(0)
+    await expect(row(page, `canvas:${beta.id}`)).toBeVisible()
 
-    // ------------------------------------------------------ the folder cascade
+    // ---------------------------------------------------- the folder cascade
     // The folder event carries a path, so the canvases it takes with it are
     // announced one by one — without that, this tab would survive its canvas.
     await rowAction(page, 'folder:Boards', 'Delete')
@@ -305,7 +306,7 @@ test.describe('Canvas management — folders, placement and row actions', () => 
     await expect(folderConfirm.getByText(/Delete this canvas folder\?/)).toBeVisible()
     await folderConfirm.getByRole('button', { name: 'Delete', exact: true }).click()
 
-    await expect(tab('Beta')).toHaveCount(0)
+    await expect(tabs).toHaveCount(tabsBefore)
     await expect.poll(async () => (await listCanvases(page)).length).toBe(0)
   })
 })

--- a/apps/desktop/tests/e2e/canvas-management.e2e.ts
+++ b/apps/desktop/tests/e2e/canvas-management.e2e.ts
@@ -243,4 +243,69 @@ test.describe('Canvas management — folders, placement and row actions', () => 
     await folderRow.click()
     await expect(duplicateRow).toBeVisible()
   })
+
+  /**
+   * Deleting a canvas from the sidebar has to take its open tab with it —
+   * reported against v2026-08-17, where the row vanished and the tab stayed,
+   * holding a live editor over a canvas that no longer existed.
+   *
+   * Only an E2E can see this. The renderer suite can assert that the reducer
+   * closes tabs and that the hook forwards the event, but nothing below this
+   * level proves the delete actually reaches the tab strip through real IPC —
+   * and the two halves were wired to different identifiers for months without
+   * a single test noticing.
+   */
+  test('deleting a canvas closes its tab, and a folder delete closes them all', async ({
+    page
+  }) => {
+    await openVault(page)
+    await expandCanvasSection(page)
+
+    // ---------------------------------------------------------------- set up
+    const header = sectionHeader(page)
+    await header.hover()
+    await page.getByRole('button', { name: 'New canvas folder', exact: true }).click()
+    await commitInlineName(page, 'folder:Untitled Folder', 'Folder name', 'Boards')
+
+    // Two canvases in the folder, each opened in its own tab by the create.
+    await rowAction(page, 'folder:Boards', 'New canvas here')
+    await expect(page.locator('[data-canvas-editor]')).toBeVisible({ timeout: 30_000 })
+    await expect.poll(async () => (await listCanvases(page)).length).toBe(1)
+    const alpha = (await listCanvases(page))[0]
+    await rowAction(page, `canvas:${alpha.id}`, 'Rename')
+    await commitInlineName(page, `canvas:${alpha.id}`, 'Canvas name', 'Alpha')
+
+    await rowAction(page, 'folder:Boards', 'New canvas here')
+    await expect.poll(async () => (await listCanvases(page)).length).toBe(2)
+    const beta = (await listCanvases(page)).find((c) => c.id !== alpha.id)
+    await rowAction(page, `canvas:${beta.id}`, 'Rename')
+    await commitInlineName(page, `canvas:${beta.id}`, 'Canvas name', 'Beta')
+
+    const tab = (name: string) => page.locator('[role="tab"]').filter({ hasText: name })
+    await expect(tab('Alpha')).toHaveCount(1)
+    await expect(tab('Beta')).toHaveCount(1)
+
+    // ------------------------------------------------------- one canvas gone
+    await rowAction(page, `canvas:${alpha.id}`, 'Delete')
+    const confirm = page.getByRole('alertdialog')
+    await expect(confirm.getByText(/Delete this canvas\?/)).toBeVisible()
+    await confirm.getByRole('button', { name: 'Delete', exact: true }).click()
+
+    await expect(tab('Alpha')).toHaveCount(0)
+    // Its neighbour is untouched: the close is keyed on the deleted canvas, not
+    // on "a canvas was deleted".
+    await expect(tab('Beta')).toHaveCount(1)
+    await expect(row(page, `canvas:${alpha.id}`)).toHaveCount(0)
+
+    // ------------------------------------------------------ the folder cascade
+    // The folder event carries a path, so the canvases it takes with it are
+    // announced one by one — without that, this tab would survive its canvas.
+    await rowAction(page, 'folder:Boards', 'Delete')
+    const folderConfirm = page.getByRole('alertdialog')
+    await expect(folderConfirm.getByText(/Delete this canvas folder\?/)).toBeVisible()
+    await folderConfirm.getByRole('button', { name: 'Delete', exact: true }).click()
+
+    await expect(tab('Beta')).toHaveCount(0)
+    await expect.poll(async () => (await listCanvases(page)).length).toBe(0)
+  })
 })

--- a/apps/docs/src/user-guide/canvas/organizing.md
+++ b/apps/docs/src/user-guide/canvas/organizing.md
@@ -131,9 +131,16 @@ application, memrynote picks the change up the next time it opens the vault.
 - Deleting a **folder** takes everything inside it — the confirmation tells you
   how many canvases that is — and sends the whole directory to the trash.
 
-Deletions sync, so a canvas you delete on one device disappears on the others.
-On those other devices the file is removed outright; only the device you deleted
-from keeps a copy in its trash.
+If the canvas was open, its tab closes with it — in both panes of a split view,
+and even if the tab was pinned. Deleting a folder closes the tabs of every
+canvas inside it the same way. The tab does not come back with
+<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>: reopening it would only show a
+canvas that no longer exists.
+
+Deletions sync, so a canvas you delete on one device disappears on the others —
+including its open tab, which closes on those devices too. On those other
+devices the file is removed outright; only the device you deleted from keeps a
+copy in its trash.
 
 That trash copy is a copy of the **file**, not an undo. Putting it back in your
 vault does not bring the canvas back into memrynote: the delete is what every

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -14,7 +14,9 @@ Across the top of the app. Drag to reorder. Drag onto a pane edge to split.
 
 Tabs share the width of the bar evenly. Widen the window and they grow, up to a comfortable maximum; open more tabs, or narrow the window, and they compress — first the close button tucks away, then the title, leaving just the icon. Once tabs reach that icon-only minimum the bar scrolls sideways instead of shrinking further: scroll over it with a trackpad or mouse wheel, or use the chevrons that appear at either end. The active tab is always scrolled into view, so opening a new tab never leaves it hidden off the end. That scroll animates once per tab you activate — the chevrons appearing part-way through it no longer restart the animation, and a tab already fully in view is left where it is. If your system is set to reduce motion (macOS **Reduce motion**, Windows **Animation effects** off, or the equivalent on Linux), the bar jumps straight to the active tab instead of sliding, and the chevrons and wheel scrolling stop animating too — the tab is still brought into view either way. Changing the setting takes effect on the next scroll; no restart needed. The **+** button stays pinned at the end of the bar while it scrolls.
 
-There is no limit on how many tabs you can have open, and memrynote never closes one for you: use the tab context menu (**Close others**, **Close to the right**) when the bar gets long.
+There is no limit on how many tabs you can have open: use the tab context menu (**Close others**, **Close to the right**) when the bar gets long.
+
+The one thing that closes a tab without being asked is deleting what it shows. Delete a canvas — from the sidebar, or on another device — and its tab closes everywhere it was open, in both panes of a split view. Deleted notes keep their tab and show the title struck through instead, because the text is still there to read.
 
 ### Tab Context Menu
 
@@ -36,6 +38,8 @@ Pin a tab to keep it at the front of the bar. Pinned tabs:
 - Don't close on middle-click
 - Survive bulk-close commands
 - Restore first on app launch
+
+A pin keeps a tab from being closed by accident; it does not keep the item alive. Delete the canvas a pinned tab shows and the tab goes with it.
 
 Useful for: today's journal, your "now" note, the shared project.
 


### PR DESCRIPTION
Reported by Aurelie on 18 Aug against v2026-08-17: deleting an open canvas from the sidebar removed the row and left its tab open, holding a live editor over a canvas that no longer exists.

Nothing connected the delete to the tab strip. The reported file (`canvas-row-menu.tsx`) is a pure renderer; the delete actually runs in `canvas-tree.tsx`'s `handleConfirm`.

## What changed

- **`CLOSE_TABS_BY_ENTITY`** closes every tab showing the deleted entity, in **every group** (the same canvas can sit in both panes of a split) and **including pinned tabs** — a pin means "don't close this by accident", not "keep this entity alive". It delegates to `CLOSE_TAB` per tab so collapsing a split, re-seeding Home and pruning nav history stay defined in one place.
- **No reopen entry.** ⌘⇧T promises "reopen the tab you closed"; reopening this one yields a dead tab whose canvas is in the OS trash. We don't offer to undo the delete, so we don't offer a shortcut that looks like it does.
- **Close guards bypassed.** They exist to offer "save before closing", and the row is already tombstoned — the Save button could not work.
- **Event-driven, mounted once in `App.tsx`.** One subscription to `canvas:deleted` covers a delete from this window, a second window, and one arriving from another device through sync. It cannot live in the canvas tree (sidebar collapses) or the canvas page (the tab that must close may be the unmounted one).
- **Folder deletes announce their canvases.** `canvasFolder:deleted` carries a path, which no canvas-id listener can match, so a folder delete read as no deletes at all. The handler already had `deletedCanvasIds` (descendants included) and now broadcasts one `canvas:deleted` each.
- **Leading-edge tree refresh.** Those per-canvas events would have turned one folder delete into N+1 listings. A trailing-only coalesce fixed that but turned `canvas-management.e2e` red — deferring the refresh by 50ms moves it into the window where the inline rename field is open, and the tree reads the resulting blur as a commit. Leading edge keeps the timing every existing interaction was built against and still merges the burst.

**Notes are deliberately untouched.** A deleted note keeps its tab with the title struck through: its text is still readable, a dead canvas editor is not.

## Tradeoffs

- A delete arriving from another device closes the tab with no explanation. Adding a toast only there needs an origin field on the event — a protocol change this fix doesn't justify.
- The closed tab cannot be brought back with ⌘⇧T.
- A canvas save already in flight when the delete lands can log one `canvas_scene_save` error. The window is narrow (the tab closes on the same event, and unmount unregisters the pending save) and the alternative is matching on an error message string with no code contract behind it.

## Known, out of scope

A canvas tree refresh landing while the inline rename field is open closes the field — so a sync event from another device can cancel a rename mid-typing. Pre-existing; surfaced by the coalescing work above.

## Verification

- `tab-crud-reducer` 15/15 · hook + canvas-tree renderer 166/166 · `canvas-folder-handlers` main 37/37
- **E2E 2/2 green** (`canvas-management`) — the new scenario and the pre-existing journey. These jobs only run on push-to-main, so this local run is the only proof.
- `pnpm typecheck` 17/17 · eslint clean · `docs:impact --strict` covered · `docs:build` green