### PR TITLE
perf(home): drop the blur-in mount animation from the home board

### DIFF
--- a/apps/desktop/src/renderer/src/components/home/board-empty-state.tsx
+++ b/apps/desktop/src/renderer/src/components/home/board-empty-state.tsx
@@ -1,4 +1,3 @@
-import { motion, useReducedMotion } from 'motion/react'
 import { Button } from '@/components/ui/button'
 import { Plus } from '@/lib/icons/icon-map'
 import { useT } from '@memry/i18n/renderer'
@@ -14,14 +13,10 @@ interface BoardEmptyStateProps {
  */
 export function BoardEmptyState({ onAddFirstWidget }: BoardEmptyStateProps): React.JSX.Element {
   const { t } = useT('common')
-  const reduceMotion = useReducedMotion()
   return (
-    <motion.div
+    <div
       data-testid="board-empty-state"
       className="mx-auto flex max-w-sm flex-col items-center gap-3 px-6 py-20 text-center"
-      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.97, filter: 'blur(6px)' }}
-      animate={reduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1, filter: 'blur(0px)' }}
-      transition={{ type: 'spring', bounce: 0, duration: 0.5 }}
     >
       <div
         aria-hidden="true"
@@ -43,6 +38,6 @@ export function BoardEmptyState({ onAddFirstWidget }: BoardEmptyStateProps): Rea
         <Plus className="size-4" aria-hidden="true" />
         {t('home.empty.cta')}
       </Button>
-    </motion.div>
+    </div>
   )
 }

--- a/apps/desktop/src/renderer/src/components/home/board-grid.tsx
+++ b/apps/desktop/src/renderer/src/components/home/board-grid.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useRef } from 'react'
-import { motion, useReducedMotion } from 'motion/react'
 import GridLayout, { WidthProvider, type Layout } from 'react-grid-layout/legacy'
 import 'react-grid-layout/css/styles.css'
 import './home-grid.css'
@@ -42,7 +41,6 @@ function unchanged(board: HomePage, next: Layout): boolean {
 
 export function BoardGrid({ board, onChange }: BoardGridProps): React.JSX.Element {
   const { t } = useT('common')
-  const reduceMotion = useReducedMotion()
 
   const layout: Layout = useMemo(
     () =>
@@ -105,31 +103,15 @@ export function BoardGrid({ board, onChange }: BoardGridProps): React.JSX.Elemen
       onResizeStop={endInteraction}
       onLayoutChange={handleLayoutChange}
     >
-      {board.widgets.map((w, index) => {
+      {board.widgets.map((w) => {
         const def = WIDGET_REGISTRY[w.type]
         const size = sizeTier(w.w, w.h)
         // react-grid-layout clones this plain wrapper div (injecting position styles, drag handlers,
         // and appending the resize handle). Keeping it a vanilla element — rather than letting RGL
-        // clone WidgetFrame directly — is what makes drag/resize wiring reliable. The materialize
-        // animation therefore lives on an inner motion.div: RGL owns the wrapper's transform for
-        // positioning, so the two never fight over the same element.
+        // clone WidgetFrame directly — is what makes drag/resize wiring reliable.
         return (
           <div key={w.id} className="overflow-visible">
-            <motion.div
-              className="h-full w-full"
-              initial={
-                reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96, filter: 'blur(6px)' }
-              }
-              animate={
-                reduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1, filter: 'blur(0px)' }
-              }
-              transition={{
-                type: 'spring',
-                bounce: 0,
-                duration: 0.45,
-                delay: Math.min(index * 0.04, 0.32)
-              }}
-            >
+            <div className="h-full w-full">
               {def ? (
                 <WidgetFrame
                   widget={w}
@@ -157,7 +139,7 @@ export function BoardGrid({ board, onChange }: BoardGridProps): React.JSX.Elemen
                   }
                 />
               )}
-            </motion.div>
+            </div>
           </div>
         )
       })}

--- a/apps/desktop/src/renderer/src/components/home/home-header.tsx
+++ b/apps/desktop/src/renderer/src/components/home/home-header.tsx
@@ -1,5 +1,4 @@
 import { Fragment } from 'react'
-import { motion, useReducedMotion } from 'motion/react'
 import { useT } from '@memry/i18n/renderer'
 import { useTaskWorkspaceData } from '@/features/tasks/use-task-queries'
 import { getTaskCounts } from '@/lib/task-utils/task-view-helpers'
@@ -54,7 +53,6 @@ export function HomeHeader({
   onAddWidget
 }: HomeHeaderProps): React.JSX.Element {
   const { t, i18n } = useT('common')
-  const reduceMotion = useReducedMotion()
 
   const { tasks, projects } = useTaskWorkspaceData({ enabled: true })
   const tasksDue = getTaskCounts(tasks, 'today', 'view', projects).dueToday
@@ -75,12 +73,7 @@ export function HomeHeader({
 
   return (
     <div className="flex items-end justify-between px-6 pt-7 pb-5.5 [font-synthesis:none] antialiased">
-      <motion.div
-        className="flex flex-col gap-2"
-        initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 10, filter: 'blur(6px)' }}
-        animate={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0, filter: 'blur(0px)' }}
-        transition={{ type: 'spring', bounce: 0, duration: 0.55 }}
-      >
+      <div className="flex flex-col gap-2">
         <h1 className="font-serif font-semibold tracking-[-0.022em] text-foreground text-[34px]/10">
           {greeting}
         </h1>
@@ -98,7 +91,7 @@ export function HomeHeader({
             </Fragment>
           ))}
         </div>
-      </motion.div>
+      </div>
       <div className="flex items-center gap-2">
         <DropdownMenu>
           <DropdownMenuTrigger

--- a/apps/docs/src/user-guide/home-dashboard.md
+++ b/apps/docs/src/user-guide/home-dashboard.md
@@ -2,6 +2,8 @@
 
 Your landing surface when a vault opens: one or more **boards** of resizable **widgets** that surface what matters — recent notes, bookmarks, tasks, the inbox, and more.
 
+Opening a board paints it in one pass — no entrance animation, so a full board arrives at once instead of blurring and settling into place.
+
 <!-- screenshot: home dashboard with a board of widgets -->
 
 ## Boards


### PR DESCRIPTION
## What

Opening Home ran a staggered `blur(6px) → blur(0)` entrance on every widget, plus the same treatment on the greeting header and the board empty state. One `filter: blur()` per widget forces a separate rasterized layer, so a board full of widgets janked on every open — the page visibly froze while it sharpened.

The three mount animations are gone. Widgets, header and empty state render plainly on first paint.

- `board-grid.tsx` — per-widget `motion.div` (blur + `scale .96→1`, 40ms/index stagger up to 0.32s) → plain `div`
- `home-header.tsx` — greeting block (blur + `y:10`) → plain `div`
- `board-empty-state.tsx` — empty board (blur + `scale .97`) → plain `div`

The now-unused `motion/react` imports and their `useReducedMotion` branches went with them. Nothing else changed: drag/resize, the RGL reflow transition, and the pickup lift in `home-grid.css` are untouched.

Not touched here: widget list rows still stagger in (`widgets/widget-list.tsx`, opacity + `y:4`, no blur — much cheaper). Easy follow-up if it still reads as slow.

## Verification

- `pnpm --filter @memry/desktop typecheck:web` — clean
- home renderer tests — 11 files / 37 tests pass
- `eslint` on the three changed files — clean
- `pnpm docs:impact --base e2f601a57 --strict` — covered
- `pnpm docs:build` — pass

Not verified: no manual run of the packaged app to time the open before/after.