### PR TITLE
Open PDFs fitted to the pane, and let the embed's resize handles be seen

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
@@ -215,6 +215,9 @@ describe('file block helpers', () => {
       'phaseF.componentsNoteContentAreaFileBlock.resizePdf'
     )
     expect(resizeHandle).toHaveAttribute('aria-valuenow')
+    // Faint at rest, not hidden: a hover-only handle is one most readers never
+    // discover, which is how the embed came to be reported as unresizable.
+    expect(resizeHandle.className).not.toContain('opacity-0')
     // Alignment controls render for a loaded PDF.
     expect(
       screen.getByLabelText('phaseF.componentsNoteContentAreaFileBlock.alignCenter')

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -417,8 +417,9 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
           )}
         </div>
 
-        {/* Corner resize brackets — sit just outside the bottom corners,
-            revealed on hover or when the embed is selected. */}
+        {/* Corner resize brackets — sit just outside the bottom corners. Faint
+            at rest rather than hidden: a control that only exists on hover is a
+            control most readers never find out about. */}
         {!loading && !error && (
           <>
             <div
@@ -434,7 +435,7 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
               onPointerMove={handleResizePointerMove}
               onPointerUp={handleResizePointerUp}
               onKeyDown={handleResizeKeyDown}
-              className="absolute -bottom-1 -end-1 z-10 h-3.5 w-3.5 cursor-nwse-resize touch-none border-b-2 border-e-2 border-foreground/60 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+              className="absolute -bottom-1 -end-1 z-10 h-3.5 w-3.5 cursor-nwse-resize touch-none border-b-2 border-e-2 border-foreground/60 opacity-40 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
             />
             <div
               role="button"
@@ -445,7 +446,7 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
               onPointerMove={handleResizePointerMove}
               onPointerUp={handleResizePointerUp}
               onKeyDown={handleResizeKeyDown}
-              className="absolute -bottom-1 -start-1 z-10 h-3.5 w-3.5 cursor-nesw-resize touch-none border-b-2 border-s-2 border-foreground/60 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+              className="absolute -bottom-1 -start-1 z-10 h-3.5 w-3.5 cursor-nesw-resize touch-none border-b-2 border-s-2 border-foreground/60 opacity-40 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
             />
           </>
         )}

--- a/apps/desktop/src/renderer/src/components/viewers/pdf-viewer.test.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/pdf-viewer.test.tsx
@@ -12,7 +12,7 @@
  * `react-pdf/dist/Document.js` -> `loadDocument`), and `Page` holds a canvas
  * for as long as it stays mounted.
  */
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -20,10 +20,18 @@ import { PdfViewer } from './pdf-viewer'
 
 const NUM_PAGES = 400
 const RAIL_VIEWPORT_HEIGHT = 600
+/** Width of the pane the page renders into, minus its `p-4` gutter. */
+const PAGE_VIEW_WIDTH = 1224
+const PAGE_VIEW_PADDING = 32
+/** US Letter portrait at scale 1, in PDF points. */
+const LETTER_WIDTH = 612
+const LETTER_HEIGHT = 792
 
 const pdfMocks = vi.hoisted(() => ({
   loadedDocuments: [] as { file: string; destroyed: boolean }[],
-  liveCanvases: new Set<{ page: number; kind: 'main' | 'thumbnail' }>()
+  liveCanvases: new Set<{ page: number; kind: 'main' | 'thumbnail' }>(),
+  pageWidth: 612,
+  pageHeight: 792
 }))
 
 vi.mock('@memry/i18n/renderer', () => ({
@@ -50,7 +58,12 @@ vi.mock('react-pdf', async () => {
       children?: React.ReactNode
       className?: string
       loading?: React.ReactNode
-      onLoadSuccess?: (result: { numPages: number }) => void
+      onLoadSuccess?: (result: {
+        numPages: number
+        getPage: (page: number) => Promise<{
+          getViewport: (params: { scale: number }) => { width: number; height: number }
+        }>
+      }) => void
     }) => {
       const [ready, setReady] = useState(false)
 
@@ -58,7 +71,16 @@ vi.mock('react-pdf', async () => {
         const proxy = { file, destroyed: false }
         pdfMocks.loadedDocuments.push(proxy)
         setReady(true)
-        onLoadSuccess?.({ numPages: NUM_PAGES })
+        onLoadSuccess?.({
+          numPages: NUM_PAGES,
+          getPage: () =>
+            Promise.resolve({
+              getViewport: ({ scale }: { scale: number }) => ({
+                width: pdfMocks.pageWidth * scale,
+                height: pdfMocks.pageHeight * scale
+              })
+            })
+        })
         return () => {
           proxy.destroyed = true
         }
@@ -70,7 +92,15 @@ vi.mock('react-pdf', async () => {
         </div>
       )
     },
-    Page: ({ pageNumber, width }: { pageNumber: number; width?: number }) => {
+    Page: ({
+      pageNumber,
+      width,
+      scale
+    }: {
+      pageNumber: number
+      width?: number
+      scale?: number
+    }) => {
       useEffect(() => {
         const canvas = {
           page: pageNumber,
@@ -86,6 +116,7 @@ vi.mock('react-pdf', async () => {
         <div
           data-testid={width ? 'pdf-thumbnail-canvas' : 'pdf-main-canvas'}
           data-page={pageNumber}
+          data-scale={scale}
         >
           page {pageNumber}
         </div>
@@ -118,14 +149,32 @@ const scrollRailTo = (offset: number): void => {
 const rowHeight = (): number =>
   Number.parseFloat(screen.getByTestId('pdf-thumbnail-sizer').style.height) / NUM_PAGES
 
+/** What the viewer should settle on for a page that is `across` points wide. */
+const fitScaleFor = (across: number): number => (PAGE_VIEW_WIDTH - PAGE_VIEW_PADDING) / across
+
+const mainCanvasScale = (): number =>
+  Number(screen.getByTestId('pdf-main-canvas').getAttribute('data-scale'))
+
 describe('PdfViewer document loading and thumbnail windowing', () => {
   let scrollToSpy: ReturnType<typeof vi.fn>
   let originalScrollTo: unknown
   let originalOffsetHeight: PropertyDescriptor | undefined
+  let originalClientWidth: PropertyDescriptor | undefined
 
   beforeEach(() => {
     pdfMocks.loadedDocuments.length = 0
     pdfMocks.liveCanvases.clear()
+    pdfMocks.pageWidth = LETTER_WIDTH
+    pdfMocks.pageHeight = LETTER_HEIGHT
+
+    originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth')
+    // jsdom lays nothing out, so the pane the page fits into has no width.
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.dataset.testid === 'pdf-page-view' ? PAGE_VIEW_WIDTH : 0
+      }
+    })
 
     originalOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')
     // @tanstack/react-virtual sizes its viewport from `offsetHeight`, which
@@ -147,6 +196,11 @@ describe('PdfViewer document loading and thumbnail windowing', () => {
       Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight)
     } else {
       delete (HTMLElement.prototype as unknown as Record<string, unknown>).offsetHeight
+    }
+    if (originalClientWidth) {
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth)
+    } else {
+      delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientWidth
     }
     ;(Element.prototype as unknown as { scrollTo?: unknown }).scrollTo = originalScrollTo
   })
@@ -215,6 +269,51 @@ describe('PdfViewer document loading and thumbnail windowing', () => {
     // Applying the rail scroll the viewer asked for brings page 2 back.
     scrollRailTo(requestedTop)
     expect(renderedPages()).toContain(2)
+  })
+
+  it('opens fitted to the pane instead of at a fixed 100%', async () => {
+    render(<PdfViewer src="memry-file://spec.pdf" />)
+
+    await screen.findByTestId('pdf-main-canvas')
+    await waitFor(() => expect(mainCanvasScale()).toBeCloseTo(fitScaleFor(LETTER_WIDTH), 3))
+    expect(mainCanvasScale()).toBeGreaterThan(1)
+  })
+
+  it('fits a landscape page across its own width, not a Letter assumption', async () => {
+    pdfMocks.pageWidth = LETTER_HEIGHT
+    pdfMocks.pageHeight = LETTER_WIDTH
+    render(<PdfViewer src="memry-file://spec.pdf" />)
+
+    await screen.findByTestId('pdf-main-canvas')
+    await waitFor(() => expect(mainCanvasScale()).toBeCloseTo(fitScaleFor(LETTER_HEIGHT), 3))
+  })
+
+  it('stops auto-fitting once the user has chosen a zoom', async () => {
+    const user = userEvent.setup()
+    render(<PdfViewer src="memry-file://spec.pdf" />)
+
+    await screen.findByTestId('pdf-main-canvas')
+    await waitFor(() => expect(mainCanvasScale()).toBeCloseTo(fitScaleFor(LETTER_WIDTH), 3))
+
+    await user.click(screen.getByTitle('phaseF.componentsViewersPdfViewer.zoomOut'))
+    const chosen = mainCanvasScale()
+    expect(chosen).toBeCloseTo(fitScaleFor(LETTER_WIDTH) - 0.25, 3)
+
+    // Rotating re-derives the fit; the zoom the user picked must survive it.
+    await user.click(screen.getByTitle('phaseF.componentsViewersPdfViewer.rotate'))
+    await waitFor(() => expect(mainCanvasScale()).toBeCloseTo(chosen, 3))
+  })
+
+  it('refits on demand after a manual zoom', async () => {
+    const user = userEvent.setup()
+    render(<PdfViewer src="memry-file://spec.pdf" />)
+
+    await screen.findByTestId('pdf-main-canvas')
+    await user.click(screen.getByTitle('phaseF.componentsViewersPdfViewer.zoomIn'))
+    expect(mainCanvasScale()).not.toBeCloseTo(fitScaleFor(LETTER_WIDTH), 3)
+
+    await user.click(screen.getByTitle('phaseF.componentsViewersPdfViewer.fitToWidth'))
+    expect(mainCanvasScale()).toBeCloseTo(fitScaleFor(LETTER_WIDTH), 3)
   })
 
   it('releases the document proxy and every page canvas on unmount', async () => {

--- a/apps/desktop/src/renderer/src/components/viewers/pdf-viewer.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/pdf-viewer.tsx
@@ -6,10 +6,11 @@ import { getI18n } from 'react-i18next'
  * @module components/viewers/pdf-viewer
  */
 
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { Document, Page, pdfjs } from 'react-pdf'
+import type { PDFDocumentProxy as PdfDocumentProxy } from 'pdfjs-dist'
 import 'react-pdf/dist/Page/AnnotationLayer.css'
 import 'react-pdf/dist/Page/TextLayer.css'
 import {
@@ -25,13 +26,14 @@ import {
 } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { mayAutoPositionFor } from '@/hooks/use-tab-auto-position'
 import { useTabEntityViewState } from '@/hooks/use-tab-entity-view-state'
 import { useTabScrollRestore } from '@/hooks/use-tab-scroll-restore'
 import {
   FILE_VIEW_STATE_KEYS,
+  parseNullableScale,
   parsePdfPage,
   parseRotation,
-  parseScale,
   parseViewerBoolean,
   pdfPageScrollKey
 } from '@/pages/file-view-state'
@@ -57,6 +59,15 @@ const PDF_LOADING = (
     <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
   </div>
 )
+
+/** Zoom bounds shared by the buttons and by fit-to-width. */
+const MIN_SCALE = 0.5
+const MAX_SCALE = 3
+const ZOOM_STEP = 0.25
+/** The `p-4` gutter around the page — width fit-to-width must not render under. */
+const PAGE_VIEW_PADDING = 32
+
+const clampScale = (value: number): number => Math.min(Math.max(value, MIN_SCALE), MAX_SCALE)
 
 // ============================================================================
 // Thumbnail Rail
@@ -169,7 +180,6 @@ function PdfThumbnailRail({
 
 export function PdfViewer({ src, className }: PdfViewerProps) {
   const { t: tPhaseF } = useT('notes')
-  const containerRef = useRef<HTMLDivElement>(null)
   const pageScrollRef = useRef<HTMLDivElement>(null)
   const [numPages, setNumPages] = useState<number>(0)
   // The main pane shows one page at a time, so the page number IS the reading
@@ -179,11 +189,23 @@ export function PdfViewer({ src, className }: PdfViewerProps) {
     defaultValue: 1,
     parse: parsePdfPage
   })
-  const [scale, setScale] = useTabEntityViewState<number>({
+  // `null` is "the user has never zoomed this document", which is what lets
+  // fit-to-width run. See `hooks/use-tab-auto-position.ts`.
+  const [storedScale, setStoredScale] = useTabEntityViewState<number | null>({
     key: FILE_VIEW_STATE_KEYS.pdfScale,
-    defaultValue: 1.0,
-    parse: parseScale
+    defaultValue: null,
+    parse: parseNullableScale
   })
+  const [scale, setScale] = useState(storedScale ?? 1)
+  const storedScaleRef = useRef(storedScale)
+  const scaleRef = useRef(scale)
+  useLayoutEffect(() => {
+    storedScaleRef.current = storedScale
+    scaleRef.current = scale
+  })
+  /** Size of the current page at scale 1, straight from pdf.js. */
+  const [pageSize, setPageSize] = useState<{ width: number; height: number } | null>(null)
+  const pdfRef = useRef<PdfDocumentProxy | null>(null)
   const [rotation, setRotation] = useTabEntityViewState<number>({
     key: FILE_VIEW_STATE_KEYS.pdfRotation,
     defaultValue: 0,
@@ -202,8 +224,9 @@ export function PdfViewer({ src, className }: PdfViewerProps) {
     key: pdfPageScrollKey(currentPage)
   })
 
-  const handleLoadSuccess = useCallback(({ numPages }: { numPages: number }) => {
-    setNumPages(numPages)
+  const handleLoadSuccess = useCallback((pdf: PdfDocumentProxy) => {
+    setNumPages(pdf.numPages)
+    pdfRef.current = pdf
   }, [])
 
   const handleLoadError = useCallback((err: Error) => {
@@ -224,26 +247,89 @@ export function PdfViewer({ src, className }: PdfViewerProps) {
     [numPages, setCurrentPage]
   )
 
+  // Measure the page pdf.js actually holds rather than assuming Letter: a page
+  // that is A4, landscape or a mix of sizes fits to the wrong width otherwise.
+  useEffect(() => {
+    const pdf = pdfRef.current
+    if (!pdf || typeof pdf.getPage !== 'function') return
+    let cancelled = false
+    void pdf
+      .getPage(currentPage)
+      .then((page) => {
+        if (cancelled) return
+        const viewport = page.getViewport({ scale: 1 })
+        setPageSize({ width: viewport.width, height: viewport.height })
+      })
+      .catch(() => {
+        // A page that cannot be measured just keeps the current zoom.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [currentPage, numPages])
+
+  /**
+   * Every zoom write goes through here. Fitting to the pane is auto-positioning
+   * rather than a choice, so it does NOT persist: storing it would freeze one
+   * pane's width into the tab and stop the document fitting the next time it is
+   * opened somewhere narrower.
+   */
+  const applyScale = useCallback(
+    (raw: number, options?: { persist?: boolean }) => {
+      const next = clampScale(raw)
+      scaleRef.current = next
+      setScale(next)
+      if (options?.persist !== false) setStoredScale(next)
+    },
+    [setStoredScale]
+  )
+
+  /** The scale at which the current page fills the pane, or `null` if unmeasurable. */
+  const computeFitScale = useCallback((): number | null => {
+    const el = pageScrollRef.current
+    if (!el || !pageSize) return null
+    const available = el.clientWidth - PAGE_VIEW_PADDING
+    if (available <= 0) return null
+    // A quarter turn swaps the axis the page is measured across.
+    const acrossPane = rotation % 180 === 0 ? pageSize.width : pageSize.height
+    if (acrossPane <= 0) return null
+    return clampScale(available / acrossPane)
+  }, [pageSize, rotation])
+
+  // Fit on open, and keep fitting while the tab has no zoom of its own — the
+  // pane changes width when the window resizes or the thumbnail rail toggles.
+  useEffect(() => {
+    const el = pageScrollRef.current
+    if (!el) return
+    const fit = () => {
+      if (!mayAutoPositionFor(storedScaleRef.current)) return
+      const fitted = computeFitScale()
+      if (fitted !== null) applyScale(fitted, { persist: false })
+    }
+    fit()
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(fit)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [computeFitScale, applyScale])
+
   const zoomIn = useCallback(() => {
-    setScale((s) => Math.min(s + 0.25, 3))
-  }, [setScale])
+    applyScale(scaleRef.current + ZOOM_STEP)
+  }, [applyScale])
 
   const zoomOut = useCallback(() => {
-    setScale((s) => Math.max(s - 0.25, 0.5))
-  }, [setScale])
+    applyScale(scaleRef.current - ZOOM_STEP)
+  }, [applyScale])
 
   const rotate = useCallback(() => {
     setRotation((r) => (r + 90) % 360)
   }, [setRotation])
 
   const fitToWidth = useCallback(() => {
-    if (containerRef.current) {
-      const containerWidth = containerRef.current.clientWidth - (sidebarOpen ? 160 : 0) - 48
-      // Assuming standard PDF width of 612 points (8.5 inches)
-      const newScale = containerWidth / 612
-      setScale(Math.min(Math.max(newScale, 0.5), 3))
-    }
-  }, [setScale, sidebarOpen])
+    const fitted = computeFitScale()
+    // Pressing the button IS a choice, so unlike the automatic fit it persists.
+    if (fitted !== null) applyScale(fitted)
+  }, [computeFitScale, applyScale])
 
   if (error) {
     return (
@@ -261,10 +347,7 @@ export function PdfViewer({ src, className }: PdfViewerProps) {
   }
 
   return (
-    <div
-      ref={containerRef}
-      className={cn('flex h-full flex-col bg-muted/20 min-h-0 overflow-hidden', className)}
-    >
+    <div className={cn('flex h-full flex-col bg-muted/20 min-h-0 overflow-hidden', className)}>
       {/* Toolbar - fixed at top */}
       <div className="flex items-center justify-between gap-1 sm:gap-2 px-2 sm:px-4 py-2 border-b border-border bg-background/80 backdrop-blur-sm flex-shrink-0">
         <div className="flex items-center gap-1 sm:gap-2">
@@ -380,7 +463,11 @@ export function PdfViewer({ src, className }: PdfViewerProps) {
           )}
 
           {/* PDF content - with both horizontal and vertical scrolling */}
-          <div ref={pageScrollRef} className="flex-1 overflow-auto min-h-0">
+          <div
+            ref={pageScrollRef}
+            data-testid="pdf-page-view"
+            className="flex-1 overflow-auto min-h-0"
+          >
             <div className="inline-flex justify-center min-w-full p-4">
               <Page
                 pageNumber={currentPage}

--- a/apps/desktop/src/renderer/src/components/viewers/viewers.test.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/viewers.test.tsx
@@ -69,14 +69,34 @@ vi.mock('react-pdf', () => ({
     file
   }: {
     children: React.ReactNode
-    onLoadSuccess?: (result: { numPages: number }) => void
+    onLoadSuccess?: (result: {
+      numPages: number
+      getPage: (page: number) => Promise<{
+        getViewport: (params: { scale: number }) => { width: number; height: number }
+      }>
+    }) => void
     onLoadError?: (error: Error) => void
     loading?: React.ReactNode
     file: string
   }) => (
     <section data-testid="pdf-document" data-file={file}>
       {loading}
-      <button type="button" onClick={() => onLoadSuccess?.({ numPages: 3 })}>
+      <button
+        type="button"
+        onClick={() =>
+          onLoadSuccess?.({
+            numPages: 3,
+            // Letter portrait, the size fit-to-width measures against.
+            getPage: () =>
+              Promise.resolve({
+                getViewport: ({ scale }: { scale: number }) => ({
+                  width: 612 * scale,
+                  height: 792 * scale
+                })
+              })
+          })
+        }
+      >
         load pdf
       </button>
       <button type="button" onClick={() => onLoadError?.(new Error('pdf failed'))}>
@@ -468,12 +488,10 @@ describe('viewer components', () => {
 
   it('loads PDFs, navigates pages, changes zoom/sidebar/rotation, and reports load errors', async () => {
     const user = userEvent.setup()
-    const { container } = render(<PdfViewer src="memry-file://spec.pdf" />)
-    Object.defineProperty(container.firstElementChild, 'clientWidth', {
-      value: 1156,
-      configurable: true
-    })
+    render(<PdfViewer src="memry-file://spec.pdf" />)
 
+    // jsdom gives the page pane no width, so the automatic fit cannot run and
+    // the zoom steps below start from a plain 100%.
     await user.click(screen.getAllByRole('button', { name: 'load pdf' })[0])
     expect(screen.getByText('1 / 3')).toBeInTheDocument()
     expect(screen.getByText(/page 1 scale 1 rotate 0/)).toBeInTheDocument()
@@ -490,8 +508,15 @@ describe('viewer components', () => {
     await user.click(screen.getByTitle('phaseF.componentsViewersPdfViewer.rotate'))
     expect(screen.getByText(/rotate 90/)).toBeInTheDocument()
 
+    // Give the pane a width so fit-to-width has something to measure against.
+    // The page is rotated a quarter turn, so it is fitted across its 792pt
+    // height rather than its 612pt width: (1156 - 32) / 792 = 1.4192 -> 142%.
+    Object.defineProperty(screen.getByTestId('pdf-page-view'), 'clientWidth', {
+      value: 1156,
+      configurable: true
+    })
     await user.click(screen.getByTitle('phaseF.componentsViewersPdfViewer.fitToWidth'))
-    expect(screen.getAllByText((_, node) => node?.textContent === '155%').length).toBeGreaterThan(0)
+    expect(screen.getAllByText((_, node) => node?.textContent === '142%').length).toBeGreaterThan(0)
     await user.click(screen.getByTitle('Hide thumbnails'))
     expect(screen.getByTitle('Show thumbnails')).toBeInTheDocument()
 

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -29,11 +29,13 @@ Each attachment renders as a block with:
 
 PDFs render inline as a clean first-page preview — no viewer chrome — so a note reads as a document with its source embedded. Open the file page (double-click the sidebar item) for the full multi-page viewer with zoom and find-in-page.
 
-The file page viewer has a thumbnail sidebar for jumping between pages. It draws only the thumbnails currently scrolled into view, so a several-hundred-page PDF opens without rendering every page up front.
+The file page viewer opens **fitted to the width of its pane**, so a document is readable straight away rather than at a fixed 100%. It keeps fitting as you resize the window or toggle the thumbnail sidebar — until you set a zoom yourself, after which your zoom is kept and restored with the tab. **Fit to width** puts it back. Fitting measures the real page, so A4 and landscape pages fit correctly too.
 
-Hover the preview, or click to select it, to reveal its controls:
+The viewer also has a thumbnail sidebar for jumping between pages. It draws only the thumbnails currently scrolled into view, so a several-hundred-page PDF opens without rendering every page up front.
 
-- **Resize** — drag either bottom corner. Width scales the whole embed like an image; dragging upward shortens it, cropping the first page from the top so only the opening shows (no inner scroll).
+The embed's controls sit on the preview itself. The resize corners are faintly visible at rest; hovering the preview, or clicking to select it, brings out the full set:
+
+- **Resize** — drag either bottom corner. Width scales the whole embed like an image; dragging upward shortens it, cropping the first page from the top so only the opening shows (no inner scroll). The embed can be widened up to the note column.
 - **Align** — the top-right toolbar aligns the embed **left**, **center**, or **right** within the note column.
 
 Size, crop, and alignment are **saved with the note** and restored when you reopen it.


### PR DESCRIPTION
Reported by adwamsley on 18 Aug against v2026-08-17:

> I'd request for us to be able to adjust the sizing of the embedded PDF. In its current state, I believe the sizing is too small. It is challenging to scroll through and review.

The report is real, but not because sizing is missing — it is because of where it starts and whether it can be seen. Two surfaces, two separate causes.

## The file page viewer opened at a fixed 100%

`scale` defaulted to `1.0`, so a Letter page rendered 612 CSS px into a pane several times that width. Fitting existed but was manual, behind a `Maximize2` button whose only label is a tooltip, and the viewer shows one page at a time — small page plus per-page navigation is exactly "too small and hard to review".

Zoom now follows the rule the image viewer already obeys (`hooks/use-tab-auto-position.ts`): the stored scale is nullable, `null` means "the user has never zoomed this document", and only then does the viewer fit itself to the pane. A zoom the user picked always wins. The automatic fit is deliberately **not** persisted — storing it would freeze one pane's width into the tab and stop the document fitting the next time it is opened somewhere narrower — and because it is automatic it also tracks the pane, so resizing the window or toggling the thumbnail rail refits.

Fit-to-width also stops assuming Letter. It measured against a hardcoded 612 points and a hardcoded 160px rail, which fits an A4 or landscape page to the wrong width. It now measures the page pdf.js actually holds, across the axis the current rotation puts on screen, and the pane's own width instead of the container minus magic numbers.

## The inline embed's resize handles were invisible

The embed has been resizable since #763 — two corner brackets that drag width and crop height, with keyboard steps — but they render at `opacity-0` and appear only on hover, so the affordance does not exist for anyone who has not already been told about it. They now sit at `opacity-40` and still go fully opaque on hover or focus. This is a restoration: the handle was persistent when it first shipped and went hidden when it became a corner bracket.

## Compatibility

`parseNullableScale` still accepts the plain number the previous build wrote to `filePdfScale`, so a zoom stored by an older version is restored exactly as before. No contract, schema or marker format changes.

## Verification

- `pnpm --filter @memry/desktop test:renderer` — 7649 passed. Four new PDF viewer tests (fits on open, fits a landscape page across its own width, stops auto-fitting once the user picks a zoom, refits on demand) and one asserting the handle is not `opacity-0`.
- `pnpm --filter @memry/desktop typecheck:web` / `typecheck:test` — clean.
- `pnpm lint` — 0 errors.
- `pnpm docs:impact --strict` — covered; `pnpm docs:build` — clean.

### Pre-existing failure, not from this branch

`App.test.tsx` and `App.workspace-counts.test.tsx` (7 tests) fail on `origin/main` as well: `4e9873c71` added `useCloseTabsOnEntityDelete`, which calls `useTabActions()`, but the `@/contexts/tabs` mock in those files has not been updated since `80fb06c39`. Untouched here.

### Not addressed

The inline embed still cannot be widened past the note column and still has no inner scroll (both deliberate in #763). If reviewing long documents inside a note is the real need, that is a larger change than this.