### PR TITLE
feat(notes): a heading link reads as its heading, and any link can be named

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -2737,6 +2737,19 @@ del.bn-inline-content {
   opacity: 0.4;
 }
 
+/* A chip the caret is parked beside shows its markdown instead — the same thing
+   the vault file holds, so what you edit and what you wrote line up. The chip is
+   hidden and the source text is a decoration widget: putting the caret next to a
+   link must stay a cursor movement, not a document edit that syncs to every
+   device and lands on the undo stack. */
+.wiki-link-hidden {
+  display: none;
+}
+
+.wiki-link-source {
+  font-weight: 500;
+}
+
 /* Inline hash tag styles — needs .dark .bn-editor prefix to beat the wildcard rule */
 .dark .bn-editor .inline-hash-tag,
 .dark .bn-container .inline-hash-tag,

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.test.tsx
@@ -55,15 +55,17 @@ describe('useWikiLinkSuggestions', () => {
       exact = await result.current.getWikiLinkItems('Daily Note | today')
     })
     expect(mocks.listNotes).toHaveBeenCalledWith({ limit: 500, sortBy: 'modified' })
+    // Both halves are settled — the target names a note exactly and a label was
+    // typed after the `|` — so the menu is the one row that commits the label
+    // rather than a note list with nothing left to choose from.
     expect(exact).toEqual([
       {
-        id: 'note-1',
-        title: 'Daily Note',
+        id: 'alias:Daily Note',
+        title: 'today',
         target: 'Daily Note',
         alias: 'today',
         exists: true,
-        type: 'note',
-        lastEdited: '2026-05-09T00:00:00.000Z'
+        type: 'alias'
       }
     ])
 
@@ -213,6 +215,54 @@ describe('useWikiLinkSuggestions', () => {
           headingLevel: 3
         }
       ])
+    })
+
+    // #1563 D2. The chip renders `alias || target`, and the alias is the only
+    // channel a display name survives a markdown round trip in — so the label is
+    // decided here, when the link is written, and never derived at render time
+    // (where `[[Sprint #4]]`, a real title, is indistinguishable from a split).
+    it('labels a picked heading with the heading text instead of `Note#Heading`', async () => {
+      mocks.getByPath.mockResolvedValue({ content: body })
+      const editor = { insertInlineContent: vi.fn() }
+      const { result } = renderHook(() => useWikiLinkSuggestions(editor))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Daily Note#Sonraki')
+      })
+      await act(async () => {
+        await result.current.handleWikiLinkSelect(items[0])
+      })
+
+      expect(editor.insertInlineContent).toHaveBeenNthCalledWith(
+        1,
+        [
+          {
+            type: 'wikiLink',
+            props: { target: 'Daily Note#Sonraki adımlar', alias: 'Sonraki adımlar' }
+          }
+        ],
+        { updateSelection: true }
+      )
+    })
+
+    it('does not label a note whose own title carries a `#`', async () => {
+      const editor = { insertInlineContent: vi.fn() }
+      const { result } = renderHook(() => useWikiLinkSuggestions(editor))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Daily Note')
+      })
+      await act(async () => {
+        await result.current.handleWikiLinkSelect(items[0])
+      })
+
+      expect(editor.insertInlineContent).toHaveBeenNthCalledWith(
+        1,
+        [{ type: 'wikiLink', props: { target: 'Daily Note', alias: '' } }],
+        { updateSelection: true }
+      )
     })
 
     it('filters headings, keeps the alias, and caches the body for 5 seconds', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.ts
@@ -7,8 +7,8 @@ import { fuzzySearch } from '@/lib/fuzzy-search'
 import { toMemryFileUrl } from '@/lib/memry-file-url'
 import { notesService } from '@/services/notes-service'
 import { createWikiLinkInlineContent } from '../wiki-link'
-import { parseWikiLinkQuery } from '../wiki-link-utils'
-import { replaceActiveRunWithWikiLink } from '../wiki-link-edit-plugin'
+import { parseWikiLinkQuery, pickAlias } from '../wiki-link-utils'
+import { activeRunWikiLink, replaceActiveRunWithWikiLink } from '../wiki-link-edit-plugin'
 import type { WikiLinkSuggestionItem } from '../wiki-link-menu'
 import { createLogger } from '@/lib/logger'
 
@@ -36,6 +36,22 @@ function blockHasContent(block: any): boolean {
     if (item?.type === 'text') return Boolean((item.text ?? '').trim())
     return Boolean(item)
   })
+}
+
+/**
+ * The single row the menu becomes once BOTH halves of `[[target|alias]]` are
+ * settled — the target names something exactly and a label was typed after the
+ * `|`. Picking anything else at that point would be picking a target again.
+ */
+function aliasRow(target: string, alias: string): WikiLinkSuggestionItem {
+  return {
+    id: `alias:${target}`,
+    title: alias,
+    target,
+    alias,
+    exists: true,
+    type: 'alias'
+  }
 }
 
 function createAudioFileBlockContent(props: {
@@ -124,6 +140,13 @@ export function useWikiLinkSuggestions(editor: any) {
         const headings = await loadHeadings(headingTarget, now)
         const matches = heading ? fuzzySearch(headings, heading, ['text']) : headings
 
+        // Target already settled and a label typed after `|`: there is nothing
+        // left to choose, so the menu becomes the one row that commits it.
+        const exactHeading = heading ? headings.find((item) => item.text === heading) : undefined
+        if (alias && exactHeading) {
+          return [aliasRow(`${headingTarget.title}#${exactHeading.text}`, alias)]
+        }
+
         if (matches.length === 0) {
           return [
             {
@@ -151,6 +174,14 @@ export function useWikiLinkSuggestions(editor: any) {
       }
 
       const filtered = search ? fuzzySearch(notes, search, ['title']) : notes
+
+      const exactNote = search
+        ? filtered.find((note) => note.title.toLowerCase() === search.toLowerCase())
+        : undefined
+      if (alias && exactNote) {
+        return [aliasRow(exactNote.title, alias)]
+      }
+
       const sorted = filtered.slice(0, 10)
 
       const suggestions: WikiLinkSuggestionItem[] = sorted.map((note) => ({
@@ -166,9 +197,7 @@ export function useWikiLinkSuggestions(editor: any) {
         ...(note.fileSize != null ? { fileSize: note.fileSize } : {})
       }))
 
-      const hasExactMatch = search
-        ? filtered.some((note) => note.title.toLowerCase() === search.toLowerCase())
-        : true
+      const hasExactMatch = search ? Boolean(exactNote) : true
 
       if (search && !hasExactMatch) {
         // The row names the note that will actually be created, which is the
@@ -199,7 +228,13 @@ export function useWikiLinkSuggestions(editor: any) {
     (item: WikiLinkSuggestionItem) => {
       if (!item.target) return
 
-      const content = createWikiLinkInlineContent(item.target, item.alias ?? '')
+      // The raw run holds the half the query cannot see — an edited chip's own
+      // label, or the text "link this selection" parked there. Read it before
+      // the run is replaced.
+      const content = createWikiLinkInlineContent(
+        item.target,
+        pickAlias(item, activeRunWikiLink(editor))
+      )
 
       // Editing an existing link: the menu's `clearQuery` removed the query text
       // but left the `[[` and `]]` around it, so inserting here would produce

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ReviewFormattingToolbar } from './review-formatting-toolbar'
+import { openWikiLinkForSelection } from './wiki-link-edit-plugin'
 
 const toolbarMocks = vi.hoisted(() => ({
   editor: {
@@ -31,8 +32,16 @@ const toolbarMocks = vi.hoisted(() => ({
 const listLabels: Record<string, string> = {
   'editor.list.bulleted': 'Bulleted list',
   'editor.list.numbered': 'Numbered list',
-  'editor.list.checklist': 'Check list'
+  'editor.list.checklist': 'Check list',
+  'editor.toolbar.linkToNote': 'Link to note'
 }
+
+// The link itself is covered against a real ProseMirror state in
+// `wiki-link-edit-plugin.test.ts`; what this file owns is the wiring — whether
+// the button is offered, and whether it acts while the selection still exists.
+vi.mock('./wiki-link-edit-plugin', () => ({
+  openWikiLinkForSelection: vi.fn(() => true)
+}))
 
 vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({
@@ -44,6 +53,7 @@ vi.mock('@memry/i18n/renderer', () => ({
 }))
 
 vi.mock('@/lib/icons', () => ({
+  Link2: () => <span data-testid="link-to-note-icon" />,
   MessageCircle: () => <span data-testid="comment-icon" />,
   List: () => <span data-testid="bulleted-icon" />,
   ListOrdered: () => <span data-testid="numbered-icon" />,
@@ -116,6 +126,43 @@ describe('ReviewFormattingToolbar', () => {
     ]
     toolbarMocks.editor.updateBlock.mockClear()
     ;(toolbarMocks.editor as { _tiptapEditor?: unknown })._tiptapEditor = undefined
+    const selection = toolbarMocks.editor.prosemirrorState.selection as Record<string, unknown>
+    delete selection.$from
+    delete selection.$to
+    vi.mocked(openWikiLinkForSelection).mockClear()
+  })
+
+  it('offers Link to note only once a single-block selection exists', () => {
+    const { rerender } = render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+    // Resolved positions absent: nothing to read a single block off yet.
+    expect(screen.getByLabelText('Link to note')).toBeDisabled()
+
+    const parent = { name: 'paragraph' }
+    const selection = toolbarMocks.editor.prosemirrorState.selection as Record<string, unknown>
+    selection.$from = { parent }
+    selection.$to = { parent: { name: 'other' } }
+    rerender(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+    // Two blocks: a selection crossing a block boundary has no single place to
+    // put the link.
+    expect(screen.getByLabelText('Link to note')).toBeDisabled()
+
+    selection.$to = { parent }
+    rerender(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+    expect(screen.getByLabelText('Link to note')).toBeEnabled()
+  })
+
+  // Same reason the Comment button captures pointer events: by the time `click`
+  // fires the toolbar button has taken focus and ProseMirror's selection is gone.
+  it('links the selection on pointer-down, not on click', () => {
+    const parent = { name: 'paragraph' }
+    const selection = toolbarMocks.editor.prosemirrorState.selection as Record<string, unknown>
+    selection.$from = { parent }
+    selection.$to = { parent }
+
+    render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+    fireEvent.pointerDown(screen.getByLabelText('Link to note'))
+
+    expect(openWikiLinkForSelection).toHaveBeenCalledTimes(1)
   })
 
   it('adds Comment to the selected text toolbar', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
@@ -18,9 +18,11 @@ import {
   useEditorState,
   type FormattingToolbarProps
 } from '@blocknote/react'
-import { MessageCircle } from '@/lib/icons'
+import { SuggestionMenu } from '@blocknote/core/extensions'
+import { Link2, MessageCircle } from '@/lib/icons'
 import type { ReviewSelection } from './types'
 import { ListTypeButtons } from './list-type-buttons'
+import { openWikiLinkForSelection } from './wiki-link-edit-plugin'
 import { useT } from '@memry/i18n/renderer'
 
 interface ReviewFormattingToolbarProps {
@@ -62,6 +64,7 @@ export function ReviewFormattingToolbar({
       <FormattingToolbar {...toolbarProps}>
         {getFormattingToolbarItems(toolbarProps.blockTypeSelectItems)}
         <ListTypeButtons />
+        <LinkToNoteButton />
         <ReviewToolbarButton onSelect={onAddComment} iconOnly />
       </FormattingToolbar>
     )
@@ -100,12 +103,91 @@ export function ReviewFormattingToolbar({
           <NestBlockButton />
           <UnnestBlockButton />
           <CreateLinkButton />
+          <LinkToNoteButton />
         </div>
         <div className="review-formatting-toolbar-actions">
           <ReviewToolbarButton onSelect={onAddComment} />
         </div>
       </div>
     </FormattingToolbar>
+  )
+}
+
+/**
+ * "Link this selection to a note or heading" (#1563 E2) — the internal
+ * counterpart to `CreateLinkButton`, which only ever offered an external URL.
+ *
+ * It hands the selection to the wiki-link edit plugin, which turns it into the
+ * same raw `[[…]]` run an edited chip becomes and binds the `[[` suggestion
+ * menu to it. One search UI, one place heading support lives.
+ *
+ * The work happens on pointer-down, before the toolbar button takes focus and
+ * ProseMirror's selection collapses — the same reason `ReviewToolbarButton`
+ * below captures pointer events.
+ */
+function LinkToNoteButton() {
+  const { t } = useT('notes')
+  const Components = useComponentsContext()
+  const editor = useBlockNoteEditor()
+  const handledRef = useRef(false)
+
+  const hasSelection = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      const selection = getProseMirrorState(editor as BlockNoteEditor)?.selection
+      if (!selection || selection.empty || (selection as { node?: unknown }).node) return false
+      // Read the resolved positions defensively, like everything else that
+      // reaches into the editor from this file: this selector runs on every
+      // editor state, including ones from before the view is mounted.
+      const { $from, $to } = selection as {
+        $from?: { parent?: unknown }
+        $to?: { parent?: unknown }
+      }
+      return Boolean($from?.parent) && $from?.parent === $to?.parent
+    }
+  })
+
+  if (!Components) return null
+
+  const label = t('editor.toolbar.linkToNote')
+
+  const run = (event: PointerEvent<HTMLElement> | MouseEvent<HTMLElement>): void => {
+    event.preventDefault()
+    if (handledRef.current) return
+
+    const opened = openWikiLinkForSelection(editor as never, {
+      openMenu: () =>
+        editor.getExtension(SuggestionMenu)?.openSuggestionMenu('[[', {
+          // The `[[` is already in the document — this button wrote it.
+          deleteTriggerCharacter: false
+        })
+    })
+    if (!opened) return
+
+    handledRef.current = true
+    window.setTimeout(() => {
+      handledRef.current = false
+    }, 0)
+  }
+
+  return (
+    <span
+      className="review-formatting-toolbar-action"
+      onPointerDownCapture={run}
+      onMouseDownCapture={run}
+    >
+      <Components.FormattingToolbar.Button
+        className="bn-button"
+        data-test="link-to-note"
+        label={label}
+        mainTooltip={label}
+        isDisabled={!hasSelection}
+        icon={<Link2 size={16} />}
+        onClick={() => {
+          handledRef.current = false
+        }}
+      />
+    </span>
   )
 }
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.test.ts
@@ -13,9 +13,11 @@ import { EditorState, TextSelection } from '@tiptap/pm/state'
 import type { Transaction } from '@tiptap/pm/state'
 import { describe, expect, it } from 'vitest'
 import {
+  activeRunWikiLink,
   createWikiLinkEditPlugin,
   findWikiLinkRunAt,
-  isEditingWikiLinkText
+  isEditingWikiLinkText,
+  openWikiLinkForSelection
 } from './wiki-link-edit-plugin'
 
 const schema = new Schema({
@@ -266,5 +268,192 @@ describe('wiki-link edit plugin', () => {
 
     expect(isEditingWikiLinkText(state)).toBe(false)
     expect(plugin.props.decorations!.call(plugin, state)).toBeNull()
+  })
+
+  // The label a heading link carries is written when the link is, so editing one
+  // starts from `[[A#B|B]]` with the caret at the end of the TARGET — typing a
+  // new label there necessarily leaves the old one trailing behind it.
+  it('drops the stale label when a new one is typed in front of it', () => {
+    const opened = keyDown(stateWith([chip({ target: 'A#B', alias: 'B' })], 2), 'Backspace').state
+    expect(paragraphText(opened)).toBe('[[A#B|B]]')
+
+    const typed = opened.apply(opened.tr.insertText('|Yeni', opened.selection.from))
+    expect(paragraphText(typed)).toBe('[[A#B|Yeni|B]]')
+
+    const closed = typed.apply(
+      typed.tr.setSelection(TextSelection.create(typed.doc, typed.doc.content.size - 1))
+    )
+    expect(firstWikiLink(closed)?.attrs).toMatchObject({ target: 'A#B', alias: 'Yeni' })
+  })
+})
+
+/**
+ * A chip reads as its markdown while the caret is parked beside it — either
+ * side, arrow key or mouse click, since this keys off the SELECTION and not off
+ * a keystroke.
+ *
+ * Every assertion here is about decorations, and that is the point: the document
+ * is untouched. Swapping the node for text on caret movement would push a Y.Doc
+ * update to every device and put the cursor move on the Yjs undo stack, so the
+ * next Cmd+Z would undo the caret instead of the paragraph the user deleted.
+ */
+describe('markdown shown beside the caret', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function decorationsOf(state: EditorState): any[] {
+    const plugin = createWikiLinkEditPlugin()
+    const set = plugin.props.decorations!.call(plugin, state)
+    if (!set) return []
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (
+      (set as any)
+        .find()
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .map((d: any) => ({ from: d.from, to: d.to, class: d.type.attrs?.class, raw: d.spec?.raw }))
+    )
+  }
+
+  // `a ` is 1..3, the chip 3..4, ` b` 4..6.
+  function sentence(attrs: Record<string, unknown>, cursorAt: number): EditorState {
+    return stateWith([schema.text('a '), chip(attrs), schema.text(' b')], cursorAt)
+  }
+
+  it('shows the markdown when the caret sits on the right of the chip', () => {
+    const found = decorationsOf(sentence({ target: 'Toplantı' }, 4))
+
+    // The widget sorts ahead of the node decoration: it sits at the chip's
+    // start with `side: -1`, so the markdown renders where the chip was.
+    expect(found).toEqual([
+      { from: 3, to: 3, class: undefined, raw: '[[Toplantı]]' },
+      { from: 3, to: 4, class: 'wiki-link-hidden', raw: undefined }
+    ])
+  })
+
+  it('shows it on the left of the chip too — the old flow only worked from the right', () => {
+    const found = decorationsOf(sentence({ target: 'Toplantı' }, 3))
+
+    expect(found.map((d) => d.raw ?? d.class)).toEqual(['[[Toplantı]]', 'wiki-link-hidden'])
+  })
+
+  it('writes the alias out, exactly as the vault file holds it', () => {
+    const found = decorationsOf(
+      sentence({ target: 'Continent#North America', alias: 'the north' }, 4)
+    )
+
+    expect(found.find((d) => d.raw)?.raw).toBe('[[Continent#North America|the north]]')
+  })
+
+  it('paints nothing once the caret is a character away', () => {
+    expect(decorationsOf(sentence({ target: 'Toplantı' }, 2))).toEqual([])
+    expect(decorationsOf(sentence({ target: 'Toplantı' }, 5))).toEqual([])
+  })
+
+  it('paints nothing while text is selected — that is a selection, not a caret', () => {
+    const state = sentence({ target: 'Toplantı' }, 4)
+    const selected = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 1, 4)))
+
+    expect(decorationsOf(selected)).toEqual([])
+  })
+
+  it('shows both when the caret sits between two chips', () => {
+    const state = stateWith([chip({ target: 'A' }), chip({ target: 'B' })], 2)
+    const raws = decorationsOf(state)
+      .map((d) => d.raw)
+      .filter(Boolean)
+
+    expect(raws).toEqual(['[[A]]', '[[B]]'])
+  })
+})
+
+describe('openWikiLinkForSelection', () => {
+  function selectionState(text: string, from: number, to: number): EditorState {
+    const doc = schema.node('doc', null, [schema.node('paragraph', null, [schema.text(text)])])
+    const state = EditorState.create({ doc, plugins: [createWikiLinkEditPlugin()] })
+    return state.apply(state.tr.setSelection(TextSelection.create(state.doc, from, to)))
+  }
+
+  function editorOf(view: ReturnType<typeof viewOf>) {
+    return {
+      _tiptapEditor: {
+        view,
+        get state() {
+          return view.state
+        }
+      }
+    }
+  }
+
+  it('turns the selection into a link whose target is still unchosen', () => {
+    // `Kuzey Amerika` is characters 3..16 of the paragraph (doc offsets 4..17).
+    const view = viewOf(selectionState('bkz Kuzey Amerika ve', 5, 18))
+    expect(openWikiLinkForSelection(editorOf(view) as never)).toBe(true)
+
+    expect(paragraphText(view.state)).toBe('bkz [[|Kuzey Amerika]] ve')
+    // The caret is right after the `[[`, which is where the suggestion menu
+    // anchors its query window — the `|alias` sits behind it, invisible to the
+    // query and untouched by typing.
+    expect(view.state.selection.from).toBe(5 + 2)
+    expect(activeRunWikiLink(editorOf(view) as never)).toEqual({
+      target: '',
+      alias: 'Kuzey Amerika'
+    })
+  })
+
+  it('opens the menu only after the text and caret are in place', () => {
+    const view = viewOf(selectionState('bir cümle', 1, 4))
+    const seen: Array<{ text: string; caret: number }> = []
+
+    openWikiLinkForSelection(editorOf(view) as never, {
+      openMenu: () =>
+        seen.push({ text: paragraphText(view.state), caret: view.state.selection.from })
+    })
+
+    expect(seen).toEqual([{ text: '[[|bir]] cümle', caret: 3 }])
+  })
+
+  it('strips the characters that would break the grammar out of the label', () => {
+    const view = viewOf(selectionState('a [x|y] b', 3, 8))
+    expect(openWikiLinkForSelection(editorOf(view) as never)).toBe(true)
+    expect(paragraphText(view.state)).toBe('a [[|xy]] b')
+  })
+
+  it('declines a collapsed selection and one that is only syntax characters', () => {
+    const collapsed = viewOf(selectionState('metin', 2, 2))
+    expect(openWikiLinkForSelection(editorOf(collapsed) as never)).toBe(false)
+
+    const unusable = viewOf(selectionState('a || b', 3, 5))
+    expect(openWikiLinkForSelection(editorOf(unusable) as never)).toBe(false)
+    expect(paragraphText(unusable.state)).toBe('a || b')
+  })
+
+  it('carries the selection marks so the finished chip keeps them', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('kalın', [schema.marks.bold.create()])])
+    ])
+    const base = EditorState.create({ doc, plugins: [createWikiLinkEditPlugin()] })
+    const view = viewOf(base.apply(base.tr.setSelection(TextSelection.create(base.doc, 1, 6))))
+
+    expect(openWikiLinkForSelection(editorOf(view) as never)).toBe(true)
+    expect(
+      view.state.doc
+        .resolve(3)
+        .marks()
+        .map((mark) => mark.type.name)
+    ).toEqual(['bold'])
+  })
+
+  // Abandoning the picker must not leave `[[|Kuzey Amerika]]` behind: that text
+  // is what would be written to the vault file, verbatim.
+  it('unwraps back to the plain text when no target is ever picked', () => {
+    const view = viewOf(selectionState('bkz Kuzey Amerika ve', 5, 18))
+    openWikiLinkForSelection(editorOf(view) as never)
+
+    const closed = view.state.apply(
+      view.state.tr.setSelection(
+        TextSelection.create(view.state.doc, view.state.doc.content.size - 1)
+      )
+    )
+
+    expect(firstWikiLink(closed)).toBeNull()
+    expect(paragraphText(closed)).toBe('bkz Kuzey Amerika ve')
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-edit-plugin.ts
@@ -22,11 +22,20 @@
  * headings are mostly spaces.
  *
  * Two things this deliberately does not do:
- * - Click is navigation, and stays navigation. Edit mode is keyboard-only.
+ * - Click ON a link is navigation, and stays navigation.
  * - The `[[` and `]]` are REAL characters here, so "ghost brackets" means a
  *   decoration that dims them, not invented ones. Deleting them is allowed:
  *   a user who removes the brackets is turning the link back into prose, which
  *   is a legitimate thing to want.
+ *
+ * SHOWING the markdown and EDITING it are separate, and the split is the whole
+ * design. A caret parked beside a chip — either side, arrow key or mouse —
+ * merely PAINTS the markdown (`wikiLinksBesideCursor`, decorations only). The
+ * document is not touched, because a cursor movement must not become an edit:
+ * that would push a Y.Doc update to every device and land on the Yjs undo
+ * stack, so the next Cmd+Z would undo the caret instead of the paragraph the
+ * user just deleted. Backspace/ArrowLeft is still the gesture that turns the
+ * painted markdown into real, editable text.
  *
  * If the editor loses focus while a run is still raw, the run stays raw — and
  * that is safe, because `[[Target]]` is exactly what the chip serializes to.
@@ -38,7 +47,7 @@ import type { EditorState, Transaction } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
 import type { EditorView } from '@tiptap/pm/view'
 import type { Mark, Node as ProseMirrorNode, Schema } from '@tiptap/pm/model'
-import { parseWikiLinkText, wikiLinkToText } from './wiki-link'
+import { wikiLinkToText } from './wiki-link'
 
 export const WIKI_LINK_EDIT_PLUGIN_KEY = new PluginKey('wikiLinkEdit')
 
@@ -46,6 +55,33 @@ export const WIKI_LINK_EDIT_PLUGIN_KEY = new PluginKey('wikiLinkEdit')
 const LEAF_PLACEHOLDER = '￼'
 
 const RAW_WIKI_LINK = /\[\[[^[\]]*\]\]/g
+
+const RAW_WIKI_LINK_FULL = /^\[\[([^[\]]*)\]\]$/
+
+/** Characters that would break the `[[target|alias]]` grammar from the inside. */
+const ALIAS_UNSAFE = /[[\]|\n\r]+/g
+
+/**
+ * `[[…]]` as the EDIT path reads it, which differs from the on-disk reading in
+ * two deliberate ways.
+ *
+ * The first `|` wins and any further pipe segment is dropped. The caret parks at
+ * the end of the TARGET, so typing a label into a link that already carries one
+ * writes `[[A#B|New|B]]`; the stale tail has to go somewhere and dropping it is
+ * plainly what was meant. Only this path normalizes — `parseWikiLinkText` still
+ * reads a vault file exactly as it always has, so an existing `[[A|B|C]]` is
+ * never rewritten.
+ *
+ * An EMPTY target parses rather than failing: `[[|Selected text]]` is the state
+ * `openWikiLinkForSelection` creates and has to be able to read back.
+ */
+function parseEditedWikiLinkText(text: string): { target: string; alias: string } | null {
+  const match = text.trim().match(RAW_WIKI_LINK_FULL)
+  if (!match) return null
+
+  const [rawTarget, rawAlias] = (match[1] ?? '').split('|', 2)
+  return { target: rawTarget?.trim() ?? '', alias: rawAlias?.trim() ?? '' }
+}
 
 /**
  * The `[[…]]` run the offset sits INSIDE, or null.
@@ -117,6 +153,62 @@ function propsFromMarks(marks: readonly Mark[]): Record<string, string | boolean
   }
 
   return props
+}
+
+/**
+ * Every wiki-link chip the caret is sitting immediately beside — on either side,
+ * however the caret got there.
+ *
+ * This is what shows a link's markdown while you are next to it. It reads the
+ * SELECTION only and never touches the document: the raw form is painted by a
+ * decoration, so putting the caret next to a link stays a cursor movement. The
+ * alternative — swapping the node for text the way `unpromote` does — would make
+ * a click near a link a real edit: a Y.Doc update to every device, and an entry
+ * on the Yjs undo stack, so the next Cmd+Z would undo the caret rather than the
+ * paragraph the user just deleted.
+ *
+ * Both sides can hit at once (`[[A]][[B]]` with the caret between them), so this
+ * returns a list rather than the first match.
+ */
+function wikiLinksBesideCursor(state: EditorState): Array<{ node: ProseMirrorNode; pos: number }> {
+  const selection = state?.selection
+  if (!selection?.empty) return []
+
+  const $from = selection.$from
+  const found: Array<{ node: ProseMirrorNode; pos: number }> = []
+
+  const before = $from.nodeBefore
+  if (before?.type.name === 'wikiLink')
+    found.push({ node: before, pos: $from.pos - before.nodeSize })
+
+  const after = $from.nodeAfter
+  if (after?.type.name === 'wikiLink') found.push({ node: after, pos: $from.pos })
+
+  return found
+}
+
+/** The chip's markdown, split so the brackets can be dimmed on their own. */
+function sourceTextOf(node: ProseMirrorNode): string {
+  const target = typeof node.attrs.target === 'string' ? node.attrs.target : ''
+  const alias = typeof node.attrs.alias === 'string' ? node.attrs.alias : ''
+  return wikiLinkToText(target, alias)
+}
+
+function renderSourceWidget(text: string): HTMLElement {
+  const dom = document.createElement('span')
+  dom.className = 'wiki-link-source'
+  dom.setAttribute('data-wiki-link-source', '')
+
+  const open = document.createElement('span')
+  open.className = 'wiki-link-bracket'
+  open.textContent = '[['
+
+  const close = document.createElement('span')
+  close.className = 'wiki-link-bracket'
+  close.textContent = ']]'
+
+  dom.append(open, document.createTextNode(text.slice(2, -2)), close)
+  return dom
 }
 
 function wikiLinkBeforeCursor(state: EditorState): { node: ProseMirrorNode; pos: number } | null {
@@ -229,6 +321,72 @@ export function replaceActiveRunWithWikiLink(
   return true
 }
 
+type TiptapHost = { _tiptapEditor?: { state?: EditorState; view?: EditorView } }
+
+/**
+ * The `{ target, alias }` of the raw run the caret is in, or null.
+ *
+ * The alias is the half the suggestion query cannot see: the caret sits before
+ * the `|`, so a label already on the link — or the text `openWikiLinkForSelection`
+ * parked there — never reaches `getItems`. `pickAlias` reads it from here.
+ */
+export function activeRunWikiLink(
+  editor: TiptapHost | undefined
+): { target: string; alias: string } | null {
+  const state = editor?._tiptapEditor?.state
+  if (!state) return null
+
+  const run = activeRun(state)
+  if (!run) return null
+
+  return parseEditedWikiLinkText(state.doc.textBetween(run.from, run.to))
+}
+
+/**
+ * Turns the selected text into a link whose target has not been chosen yet:
+ * `[[|Selected text]]`, caret right after the `[[`, suggestion menu bound to it.
+ *
+ * This is "link this selection to a note or heading" (#1563 E2), and it goes
+ * through the same raw-run state a chip being edited does rather than opening a
+ * second insertion path. The selection becomes the ALIAS, so picking a target
+ * leaves the sentence reading exactly as it did — `pickAlias` carries it over.
+ *
+ * The step order is the same load-bearing one as the chip-edit path: the caret
+ * must be immediately after the `[[` when the menu opens, because that is where
+ * the menu anchors its query window. The `|alias` sits AFTER the caret, so it is
+ * invisible to the query and untouched by typing.
+ */
+export function openWikiLinkForSelection(
+  editor: TiptapHost | undefined,
+  options: WikiLinkEditPluginOptions = {}
+): boolean {
+  const view = editor?._tiptapEditor?.view
+  const state = view?.state
+  if (!view || !state) return false
+
+  const { from, to, $from, $to } = state.selection
+  if (from === to) return false
+  if (!$from?.parent?.isTextblock || $from.parent.type.spec.code) return false
+  // One block only: a selection crossing a block boundary has no single place to
+  // put the link, and its text is not one run to use as a label.
+  if ($from.parent !== $to?.parent) return false
+
+  const alias = state.doc.textBetween(from, to, ' ').replace(ALIAS_UNSAFE, '').trim()
+  if (!alias) return false
+
+  const tr = state.tr.replaceWith(
+    from,
+    to,
+    state.schema.text(`[[|${alias}]]`, $from.marksAcross($to) ?? [])
+  )
+  tr.setSelection(TextSelection.create(tr.doc, from + 2))
+  tr.setMeta(WIKI_LINK_EDIT_PLUGIN_KEY, true)
+  view.dispatch(tr)
+
+  options.openMenu?.()
+  return true
+}
+
 export interface WikiLinkEditPluginOptions {
   /**
    * Opens the `[[` suggestion menu at the caret WITHOUT inserting a trigger.
@@ -249,13 +407,36 @@ export function createWikiLinkEditPlugin(options: WikiLinkEditPluginOptions = {}
 
     props: {
       decorations(state) {
-        const run = activeRun(state)
-        if (!run) return null
+        const decorations: Decoration[] = []
 
-        return DecorationSet.create(state.doc, [
-          Decoration.inline(run.from, run.from + 2, { class: 'wiki-link-bracket' }),
-          Decoration.inline(run.to - 2, run.to, { class: 'wiki-link-bracket' })
-        ])
+        const run = activeRun(state)
+        if (run) {
+          decorations.push(
+            Decoration.inline(run.from, run.from + 2, { class: 'wiki-link-bracket' }),
+            Decoration.inline(run.to - 2, run.to, { class: 'wiki-link-bracket' })
+          )
+        }
+
+        // A chip the caret is beside reads as its markdown for as long as the
+        // caret stays there. The chip is hidden rather than replaced, and the
+        // markdown is a widget, so nothing here reaches the document.
+        for (const beside of wikiLinksBesideCursor(state)) {
+          const text = sourceTextOf(beside.node)
+          if (!text) continue
+
+          decorations.push(
+            Decoration.node(beside.pos, beside.pos + beside.node.nodeSize, {
+              class: 'wiki-link-hidden'
+            }),
+            Decoration.widget(beside.pos, () => renderSourceWidget(text), {
+              side: -1,
+              key: `wiki-link-source:${text}`,
+              raw: text
+            })
+          )
+        }
+
+        return decorations.length > 0 ? DecorationSet.create(state.doc, decorations) : null
       },
 
       handleKeyDown(view: EditorView, event: KeyboardEvent): boolean {
@@ -321,11 +502,27 @@ export function createWikiLinkEditPlugin(options: WikiLinkEditPluginOptions = {}
       const current = activeRun(newState)
       if (current && current.from === from) return null
 
-      const parsed = parseWikiLinkText(newState.doc.textBetween(from, to))
+      const parsed = parseEditedWikiLinkText(newState.doc.textBetween(from, to))
       if (!parsed) return null
 
       const type = newState.schema.nodes.wikiLink
       if (!type) return null
+
+      // A run with no target is "link this selection", abandoned before a target
+      // was picked (or a target backspaced away). Unwrap it back to the plain
+      // text it was made from rather than leaving `[[|Selected text]]` behind —
+      // that would be written to the vault verbatim.
+      if (!parsed.target) {
+        const cancel = parsed.alias
+          ? newState.tr.replaceWith(
+              from,
+              to,
+              newState.schema.text(parsed.alias, newState.doc.resolve(from + 2).marks())
+            )
+          : newState.tr.delete(from, to)
+        cancel.setMeta(WIKI_LINK_EDIT_PLUGIN_KEY, true)
+        return cancel
+      }
 
       const marks = propsFromMarks(newState.doc.resolve(from + 2).marks())
       const tr = newState.tr.replaceWith(

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.test.tsx
@@ -11,7 +11,9 @@ vi.mock('@memry/i18n/renderer', () => ({
         'menus.wiki.embedAria': `Embed ${values?.title ?? ''}`.trim(),
         'menus.wiki.wikiLinkAria': `Wiki link ${values?.title ?? ''}`.trim(),
         'menus.wiki.noHeadings': `${values?.title ?? ''} has no headings`.trim(),
-        'menus.wiki.noMatchingHeadings': `No headings in ${values?.title ?? ''} match`.trim()
+        'menus.wiki.noMatchingHeadings': `No headings in ${values?.title ?? ''} match`.trim(),
+        'menus.wiki.displayAs': 'Display as',
+        'menus.wiki.aliasHint': 'Type | to name the link'
       }
       return messages[key] ?? key
     }
@@ -106,5 +108,50 @@ describe('WikiLinkMenu', () => {
       />
     )
     expect(screen.getByText('No headings in Toplantı match')).toBeInTheDocument()
+  })
+
+  it('commits the display name once both halves are settled', () => {
+    const onItemClick = vi.fn()
+    const item: WikiLinkSuggestionItem = {
+      id: 'alias:Continent#North America',
+      title: 'North of America',
+      target: 'Continent#North America',
+      alias: 'North of America',
+      exists: true,
+      type: 'alias'
+    }
+
+    render(
+      <WikiLinkMenu
+        items={[item]}
+        loadingState="loaded"
+        selectedIndex={0}
+        onItemClick={onItemClick}
+      />
+    )
+
+    expect(screen.getByText('Display as')).toBeInTheDocument()
+    expect(screen.getByText('North of America → Continent#North America')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('option'))
+    expect(onItemClick).toHaveBeenCalledWith(expect.objectContaining({ alias: 'North of America' }))
+  })
+
+  // The `|` grammar has always worked; nothing ever said so, which is why every
+  // heading link read `Note#Heading` (#1563 D2).
+  it('teaches the alias grammar in a footer rather than per row', () => {
+    render(
+      <WikiLinkMenu
+        items={[
+          { id: 'n1', title: 'Toplantı', target: 'Toplantı', exists: true, type: 'note' },
+          { id: 'n2', title: 'Roadmap', target: 'Roadmap', exists: true, type: 'note' }
+        ]}
+        loadingState="loaded"
+        selectedIndex={0}
+        onItemClick={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByText('Type | to name the link')).toHaveLength(1)
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.tsx
@@ -3,7 +3,7 @@
  */
 
 import type { SuggestionMenuProps } from '@blocknote/react'
-import { FileAudio, FileText, Hash, Plus } from '@/lib/icons'
+import { FileAudio, FileText, Hash, Plus, Type } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
 
@@ -21,8 +21,10 @@ export type WikiLinkSuggestionItem = {
    * `headingEmpty` is that note having no heading to offer — a row rather than
    * a separate empty state so the menu stays open while the user backspaces
    * over the `#`, and it carries no target, so picking it does nothing.
+   * `alias` is the whole menu once both halves of `[[target|alias]]` are
+   * settled: one row that commits the display name.
    */
-  type: 'note' | 'create' | 'heading' | 'headingEmpty'
+  type: 'note' | 'create' | 'heading' | 'headingEmpty' | 'alias'
   lastEdited?: string
   fileType?: WikiLinkFileType
   mimeType?: string | null
@@ -105,6 +107,27 @@ export function WikiLinkMenu({
                   : t('menus.wiki.noHeadings', { title: item.title })}
               </span>
             </div>
+          )
+        }
+
+        if (item.type === 'alias') {
+          return (
+            <button
+              type="button"
+              key={`${item.type}-${item.id}`}
+              className={itemClassName}
+              onClick={() => onItemClick?.({ ...item, insertMode: 'wikiLink' })}
+              role="option"
+              aria-selected={isSelected}
+            >
+              <Type className="mt-0.5 h-4 w-4 shrink-0" />
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5 text-start">
+                <div className="font-medium">{t('menus.wiki.displayAs')}</div>
+                <div className="truncate text-xs text-muted-foreground">
+                  {item.alias} → {item.target}
+                </div>
+              </div>
+            </button>
           )
         }
 
@@ -198,6 +221,13 @@ export function WikiLinkMenu({
           </button>
         )
       })}
+      {/* The `|` grammar works and always has, but nothing ever said so — a
+          heading link's label was only reachable by knowing to type it. One
+          quiet footer line rather than a hint per row, which would turn the
+          list into noise. */}
+      <div className="mt-1 border-t px-2 pb-0.5 pt-1.5 text-[11px] text-muted-foreground">
+        {t('menus.wiki.aliasHint')}
+      </div>
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.test.ts
@@ -5,7 +5,9 @@ import {
   normalizeMarkdownHardBreaks,
   normalizeTableContent,
   normalizeWikiLinks,
+  isDerivedAlias,
   parseWikiLinkQuery,
+  pickAlias,
   splitTextWithWikiLinks,
   splitWikiLinkQuery
 } from './wiki-link-utils'
@@ -308,5 +310,57 @@ describe('wiki-link utils', () => {
     expect(normalizeMarkdownHardBreaks('one\\\ntwo')).toBe('one\ntwo')
     expect(normalizeMarkdownHardBreaks('```\\\ncode\\\n```')).toBe('```\\\ncode\\\n```')
     expect(normalizeMarkdownHardBreaks('keep\\\\\nnext')).toBe('keep\\\\\nnext')
+  })
+})
+
+describe('isDerivedAlias', () => {
+  it('recognizes the label the heading picker writes', () => {
+    expect(isDerivedAlias('Continent#North America', 'North America')).toBe(true)
+    expect(isDerivedAlias('#Kararlar', 'Kararlar')).toBe(true)
+  })
+
+  it('leaves a label the user wrote alone', () => {
+    expect(isDerivedAlias('Continent#North America', 'North of America')).toBe(false)
+    expect(isDerivedAlias('Continent', 'North America')).toBe(false)
+    expect(isDerivedAlias('Continent#North America', '')).toBe(false)
+  })
+
+  // `#` is legal in a note title, so a note link's target can look split without
+  // being one. It carries no alias, and nothing here may invent it one.
+  it('does not read a `#` in a real note title as a heading label', () => {
+    expect(isDerivedAlias('Sprint #4', '4')).toBe(true)
+    expect(isDerivedAlias('Sprint #4', '')).toBe(false)
+  })
+})
+
+describe('pickAlias', () => {
+  const heading = { type: 'heading', title: 'North America' }
+  const note = { type: 'note', title: 'Sprint #4' }
+
+  it('prefers what was typed after the `|`', () => {
+    expect(pickAlias({ ...heading, alias: 'North of America' }, null)).toBe('North of America')
+    expect(
+      pickAlias({ ...heading, alias: 'Typed' }, { target: 'Continent', alias: 'Carried' })
+    ).toBe('Typed')
+  })
+
+  it('carries a label the run already holds — an edited chip, or a linked selection', () => {
+    expect(pickAlias(heading, { target: 'Continent', alias: 'North of America' })).toBe(
+      'North of America'
+    )
+    expect(pickAlias(note, { target: '', alias: 'this sprint' })).toBe('this sprint')
+  })
+
+  // The auto label is indistinguishable from a typed one on disk, so keeping it
+  // across a retarget would leave `[[A#New|Old]]` — a label naming a heading the
+  // link no longer points at.
+  it('refreshes a derived label instead of carrying it to the new heading', () => {
+    expect(pickAlias(heading, { target: 'Continent#Asia', alias: 'Asia' })).toBe('North America')
+  })
+
+  it('labels a heading row with its heading text and a note row with nothing', () => {
+    expect(pickAlias(heading, null)).toBe('North America')
+    expect(pickAlias(note, null)).toBe('')
+    expect(pickAlias({ type: 'create', title: 'Missing' }, null)).toBe('')
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-utils.ts
@@ -86,6 +86,57 @@ export function parseWikiLinkQuery(query: string): WikiLinkQueryParts {
   return { search, note, heading, alias }
 }
 
+/**
+ * Whether an alias is one the heading picker wrote rather than one a person did.
+ *
+ * The two are indistinguishable on disk — the alias is the ONLY channel a
+ * display name survives a markdown round trip in, so a heading link's label and
+ * a hand-written one are the same bytes. The test is therefore structural: an
+ * alias that is exactly its own target's heading text is derived, and follows
+ * the heading when the link is retargeted. Anything else is the user's words.
+ */
+export function isDerivedAlias(target: string, alias: string): boolean {
+  if (!alias) return false
+  const { heading } = splitWikiTarget(target)
+  return heading !== null && heading === alias
+}
+
+export interface WikiLinkAliasItem {
+  type: string
+  /** Heading rows: the heading text, which is also the row's label. */
+  title: string
+  alias?: string
+}
+
+/**
+ * The display name a picked suggestion should carry, highest priority first:
+ *
+ * 1. What was typed after `|` in the query — the user just wrote it.
+ * 2. The alias already sitting in the raw `[[…]]` run, when it is not derived.
+ *    That is where an edited chip's own label lives, and where "link this
+ *    selection" parks the selected text; neither reaches the query, because the
+ *    caret sits before the `|`.
+ * 3. A heading row labels itself with its heading text, so `[[A#B]]` reads `B`
+ *    rather than `A#B` (#1563 D2). Note rows deliberately do NOT: their target
+ *    may legitimately BE a title carrying a `#` (`Sprint #4`), and nothing here
+ *    can tell those apart — which is also why this is decided when the link is
+ *    written and never derived at render time.
+ */
+export function pickAlias(
+  item: WikiLinkAliasItem,
+  run: { target: string; alias: string } | null
+): string {
+  const typed = item.alias?.trim()
+  if (typed) return typed
+
+  if (run) {
+    const carried = run.alias.trim()
+    if (carried && !isDerivedAlias(run.target, carried)) return carried
+  }
+
+  return item.type === 'heading' ? item.title : ''
+}
+
 function createStyledText(
   text: string,
   styles: Record<string, boolean | string>

--- a/apps/desktop/tests/e2e/wiki-heading-links.e2e.ts
+++ b/apps/desktop/tests/e2e/wiki-heading-links.e2e.ts
@@ -32,6 +32,70 @@ function bodyWithHeadingFarDown(heading: string): string {
   return `Intro paragraph.\n\n${filler('Before')}\n\n## ${heading}\n\n${filler('After')}\n`
 }
 
+/**
+ * #1563 E2 — selected text becomes the link's display name.
+ *
+ * The selection is the half the suggestion query cannot see: it is parked in the
+ * raw `[[|…]]` run behind the caret, so this only holds if the run survives the
+ * menu round trip. Nothing in jsdom exercises the selection toolbar's
+ * pointer-down handoff either, which is the other reason this is here.
+ */
+test.describe('Linking selected text', () => {
+  test('keeps the selected words as the label and links them to a note', async ({ page }) => {
+    await ready(page)
+
+    const targetTitle = uniqueLabel('Continent')
+    const sourceTitle = uniqueLabel('Selection Source')
+    const selected = 'kuzeyde bir yer'
+
+    await page.evaluate(
+      async ({ sourceTitle, targetTitle, selected }) => {
+        const api = window.api
+        const target = await api.notes.create({ title: targetTitle, content: 'Bir kıta.\n' })
+        const source = await api.notes.create({ title: sourceTitle, content: `${selected}\n` })
+        if (!target.success || !source.success) throw new Error('failed to seed selection notes')
+      },
+      { sourceTitle, targetTitle, selected }
+    )
+
+    await openNoteByTitle(page, sourceTitle)
+
+    const editor = page.locator(SELECTORS.noteEditor).first()
+    await editor.click()
+    await page.keyboard.press('Home')
+    await page.keyboard.press('Shift+End')
+
+    const linkButton = page.locator('[data-test="link-to-note"]').first()
+    await expect(linkButton).toBeEnabled()
+    // Pointer-down, not click: by the time `click` fires the button has focus
+    // and ProseMirror's selection is gone. Playwright's click sends both.
+    await linkButton.click()
+
+    await page.keyboard.type(targetTitle)
+    const noteRow = page.locator('.wiki-link-menu [role="option"]').first()
+    await expect(noteRow).toHaveText(targetTitle)
+    await noteRow.click()
+
+    const chip = page.locator('[data-wiki-link]').first()
+    await expect(chip).toBeVisible()
+    await expect(chip).toHaveText(selected)
+    await expect(chip).toHaveAttribute('data-target', targetTitle)
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async (title) => {
+            const found = await window.api.notes.resolveByTitle(title)
+            if (!found?.id) return null
+            const note = await window.api.notes.get(found.id)
+            return note?.content ?? null
+          }, sourceTitle),
+        { message: 'source note body on disk', timeout: 15000 }
+      )
+      .toContain(`[[${targetTitle}|${selected}]]`)
+  })
+})
+
 test.describe('Wiki heading links', () => {
   test('opens the note and scrolls to the heading instead of creating a note', async ({ page }) => {
     await ready(page)
@@ -154,6 +218,70 @@ test.describe('Wiki heading links', () => {
     expect(junk).toBeNull()
 
     expect(seeded.targetId).toBeTruthy()
+  })
+
+  /**
+   * #1563 D2 — a heading link picked from the dropdown labels itself with the
+   * heading, and says so in the file.
+   *
+   * The label rides in the alias because that is the only channel a display name
+   * survives a markdown round trip in; deriving it at render time would read
+   * `[[Sprint #4]]` (a real title, covered by the test below) as a split. So the
+   * assertion has two halves and both matter: what the chip shows, and what the
+   * vault file holds.
+   */
+  test('labels a heading picked from the dropdown with the heading alone', async ({ page }) => {
+    await ready(page)
+
+    const targetTitle = uniqueLabel('Continent')
+    const sourceTitle = uniqueLabel('Label Source')
+    const heading = 'North America'
+
+    await page.evaluate(
+      async ({ sourceTitle, targetTitle, body }) => {
+        const api = window.api
+        const target = await api.notes.create({ title: targetTitle, content: body })
+        const source = await api.notes.create({ title: sourceTitle, content: 'Bkz ' })
+        if (!target.success || !source.success) throw new Error('failed to seed label notes')
+      },
+      { sourceTitle, targetTitle, body: bodyWithHeadingFarDown(heading) }
+    )
+
+    await openNoteByTitle(page, sourceTitle)
+
+    const editor = page.locator(SELECTORS.noteEditor).first()
+    await editor.click()
+    await page.keyboard.press('End')
+    // The `[[` has to enter the document through the suggestion plugin's own
+    // trigger, so type it rather than pasting.
+    await page.keyboard.type(`[[${targetTitle}`)
+    // An exact title is what switches the dropdown into heading mode.
+    await page.keyboard.type('#North')
+
+    const headingRow = page.locator('.wiki-link-menu [role="option"]').first()
+    await expect(headingRow).toHaveText(heading)
+    await headingRow.click()
+
+    const chip = page.locator('[data-wiki-link]').first()
+    await expect(chip).toBeVisible()
+    // The chip reads the heading alone — not `Continent#North America`.
+    await expect(chip).toHaveText(heading)
+    await expect(chip).toHaveAttribute('data-target', `${targetTitle}#${heading}`)
+    await expect(chip).toHaveAttribute('data-alias', heading)
+
+    // And the file says exactly what the screen does.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async (title) => {
+            const found = await window.api.notes.resolveByTitle(title)
+            if (!found?.id) return null
+            const note = await window.api.notes.get(found.id)
+            return note?.content ?? null
+          }, sourceTitle),
+        { message: 'source note body on disk', timeout: 15000 }
+      )
+      .toContain(`[[${targetTitle}#${heading}|${heading}]]`)
   })
 
   test('still opens a note whose title really contains a hash', async ({ page }) => {

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -14,6 +14,20 @@ Type `[[` and start typing the title. An autocomplete dropdown appears with matc
 
 The slash menu's **Link to note** item types the `[[` for you and opens the same dropdown.
 
+Every row in that dropdown can be given a **display name**: type `|` after the title and
+write the words you want in the sentence — `[[Continent#North America|North of America]]`.
+Once both halves are settled the dropdown becomes a single **Display as** row that commits
+it. The link still points at the note; only the visible text changes.
+
+## Linking Selected Text
+
+Select a word or a sentence and press **Link to note** in the selection toolbar (next to the
+external-link button). The selected text becomes the link's display name and the dropdown
+opens for you to choose the target — any note, or a heading inside one by typing `#`. The
+sentence reads exactly as it did before; the words are now a link.
+
+Pick nothing and click away, and the text goes back to being ordinary text.
+
 The link displays the target's current title, but the underlying reference uses a stable ID — renaming the target doesn't break the link.
 
 ## Following a Link
@@ -35,9 +49,29 @@ keep typing to filter them, and pick one to write the whole `[[Note#Heading]]` l
 the `#` and the note list comes back. If the note has no headings, the dropdown says so —
 memrynote will not add a heading to someone else's note.
 
+**A heading picked this way labels itself with the heading.** `[[Continent#North America]]`
+reads "North America" in the note rather than the whole `Continent#North America`; hovering
+it still names the note it points at. The label is written into the link as an alias —
+`[[Continent#North America|North America]]` — so the file says exactly what you see, and
+Obsidian shows the same thing. Change the heading later and the label follows it; write your
+own and yours is kept.
+
+Links you wrote before this are left as they are. Open one (below) and pick its heading again
+to give it a label.
+
 Because an exact title is what switches modes, `[[Sprint #` still lists notes: `Sprint` is
 not a note here, so nothing about `[[Sprint #4]]` changes. Block references (`#^`) are never
 offered.
+
+### Seeing a link's markdown
+
+Put the cursor immediately before or after a link — by arrow key or by clicking there —
+and that link shows its markdown for as long as the cursor stays beside it:
+`[[Continent#North America|North America]]`, exactly what the vault file holds. Move the
+cursor away and it goes back to reading as a link.
+
+This is display only. Nothing is written, so moving the cursor around a note never marks it
+edited and never lands on the undo stack. To actually change the link, open it:
 
 ### Adding a heading to a link you already inserted
 
@@ -47,6 +81,9 @@ A finished link is a single chip, so there is nothing to type a `#` into. Press
 the `[[` `]]` dimmed. Type `#` and the heading dropdown appears, exactly as when writing the
 link from scratch. Move the cursor out of the brackets, or click elsewhere, and it becomes a
 chip again.
+
+This is also where a link's display name is edited: type `|` and the words you want. If the
+link already carried a label the heading picker wrote, the new one replaces it.
 
 ::: warning Backspace next to a link now opens it instead of deleting it
 This applies to **every** wiki link, not only ones with a heading. To delete a link, press

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -132,6 +132,7 @@
       "checklist": "Check list"
     },
     "toolbar": {
+      "linkToNote": "Link to note",
       "reminderSet": "Reminder set",
       "setReminder": "Set reminder",
       "removeBookmark": "Remove bookmark",
@@ -213,7 +214,9 @@
       "embedAria": "Embed {title}",
       "wikiLinkAria": "Wiki link {title}",
       "noHeadings": "{title} has no headings",
-      "noMatchingHeadings": "No headings in {title} match"
+      "noMatchingHeadings": "No headings in {title} match",
+      "displayAs": "Display as",
+      "aliasHint": "Type | to name the link"
     },
     "mention": {
       "aria": "Date and note suggestions",


### PR DESCRIPTION
Closes #1563 D2 and E2.

## The report

Aurelie, 18 Aug, `v2026-08-17`: writing `[[Note#Heading]]` drops the brackets but keeps the
`#Heading` tail, so the link reads as machinery in the middle of a sentence. Her preference
was to be able to name the link herself (`Continent#North America` -> "North of America"),
with a good reason: *"hovering a link shows the name of the actual note is already great and
tells us where this is coming from."* Second choice: show the heading text alone.

E2 is the same family and the epic says to solve them together — display text that is not
the target. Selected text could only take an external URL; there was no way to point it at a
note or a heading.

## What decided the design

**The alias is the only channel a display name survives in.** A new node prop would be gone
the next time the note is read back, because the bytes on disk are just `[[A#B]]`. So the
label has to be decided when the link is written.

**It cannot be derived at render time.** The chip renders vanilla DOM with no access to the
note index, and `[[Sprint #4]]` is a real note title — a render-time split on `#` would show
it as "4". That is a visible regression the repo already went out of its way to protect
(raw-target fallback in `wikilink-resolver.ts`, plus an E2E test).

So: picking a heading from the dropdown writes `[[Continent#North America|North America]]`,
and the chip reads **North America**. Unambiguous by construction — heading mode only engages
once the note half matches a title exactly, and the heading text was read out of that note's
body. A note row never gets a label, for the `Sprint #4` reason above.

## What changed

**One rule for the label** (`pickAlias`, `wiki-link-utils.ts`): what was typed after `|` wins,
then a label already in the raw run that is *not derived* (an edited chip's own words, or the
text "link this selection" parked there), then the heading text for a heading row.
`isDerivedAlias` is what makes an auto label follow its heading while leaving a hand-written
one alone — carrying the auto one across a retarget would leave `[[A#New|Old]]`, a label
naming a heading the link no longer points at.

**The `|` grammar is now reachable.** It always worked; nothing ever said so. The dropdown
falls to a single **Display as** row once both halves are settled, and carries a footer that
teaches the syntax.

**Link the selected text** (E2): a new toolbar button next to the external-link one. The
selection becomes `[[|selected text]]` — the same raw-run state an edited chip becomes, not a
second insertion path — and picking a target keeps the words: `[[Note|selected text]]`, or a
heading by typing `#`. Abandoning the picker unwraps back to plain text rather than leaving
`[[|...]]` in the vault. The button fires on pointer-down, because by `click` the button has
focus and ProseMirror's selection is gone.

**A link shows its markdown while the caret is beside it** — either side, arrow key or mouse.
This is decorations only: the chip is hidden and the source text is a widget. Moving the
caret must not become an edit — that would push a Y.Doc update to every device and land on
the Yjs undo stack, so the next Cmd+Z would undo the caret instead of the paragraph the user
just deleted. Backspace/ArrowLeft is still the gesture that turns it into real editable text.

Also fixed on the edit path: typing a label into a link that already carried one wrote
`[[A#B|New|B]]`. The first `|` now wins there. Files loaded from disk are read exactly as
before, so an existing `[[A|B|C]]` is never rewritten.

## Compatibility

No schema change, no migration, no DB reset. `alias` has been a node prop since #1439 and has
a default, so an older build reading `[[A#B|B]]` displays "B" too — alias is understood in
parse, render and serialize alike.

- **Existing links are left exactly as they are.** No pass rewrites anything.
- **Backlinks and the graph are untouched:** `extractWikiLinks` discards the alias and indexes
  the note half.
- **Expected side effect:** plain-text strippers prefer the alias, so backlink snippets and
  previews now read "North America" instead of "Continent#North America".

## Verification

```
pnpm typecheck            17/17 tasks
pnpm lint                 0 errors (97 warnings, all pre-existing — count unchanged)
pnpm check:architecture   passed
pnpm --filter @memry/desktop i18n:check   passed
pnpm docs:impact --base 36401cf3b --strict / pnpm docs:build   passed
```

Targeted renderer suites, **173 passed**, 8 files: the `pickAlias` decision table; a
regression lock that a `Sprint #4` note row gets **no** label; `[[A#B|New|B]]` -> first pipe
wins; `openWikiLinkForSelection` (caret at `from+2`, marks carried, unwrap on abandon); the
caret-beside-chip markdown decorations on both sides and their absence a character away; the
Display-as row and footer; the toolbar button's enabled state and pointer-down handoff.

Two new E2E specs (not run locally — Playwright/Electron E2E is push-to-main only): picking a
heading asserts both the chip text and the bytes in the vault file; the selection flow asserts
the chip text and `[[Note|selected]]` on disk.

### Pre-existing red, not from this branch

`App.test.tsx` and `App.workspace-counts.test.tsx` fail on `main` with `No "useTabActions"
export is defined on the "@/contexts/tabs" mock`. `useTabActions` landed in `b04e9009d` /
`6bb7a3c81` and those files' mock was never updated. This branch touches neither file
(`git diff --cached | grep -c 'useTabActions\|contexts/tabs'` = 0). Worth a one-line fix in a
separate PR.

## Not in scope

Bulk-aliasing the `[[Note#Heading]]` links already in people's vaults (that writes bytes).
A context menu on the chip — clicking a link stays navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
