### PR TITLE
fix(landing): let the sign-in crypto module load instead of aborting on every page

### DIFF
--- a/apps/landing/src/lib/account/auth-error.test.ts
+++ b/apps/landing/src/lib/account/auth-error.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { authErrorMessage } from './auth-error.ts'
+
+describe('authErrorMessage', () => {
+  it('passes a server error through unchanged', () => {
+    assert.equal(
+      authErrorMessage(new Error('Invalid or expired code'), 'Invalid code'),
+      'Invalid or expired code'
+    )
+  })
+
+  it('falls back when the thrown value is not an error', () => {
+    assert.equal(authErrorMessage('boom', 'Sign-in failed'), 'Sign-in failed')
+    assert.equal(authErrorMessage(new Error(''), 'Sign-in failed'), 'Sign-in failed')
+  })
+
+  it('replaces libsodium abort text with something a person can act on', () => {
+    const abort = new Error(
+      'Aborted(CompileError: call to WebAssembly.instantiate() blocked by CSP). Build with -sASSERTIONS for more info.'
+    )
+    const message = authErrorMessage(abort, 'Invalid code')
+    assert.ok(!message.includes('Aborted('), 'raw abort text leaked to the user')
+    assert.match(message, /Secure sign-in could not start/)
+  })
+
+  it('replaces the other engines’ wording for the same abort', () => {
+    const firefox = new Error('Aborted(CompileError: WebAssembly.instantiate(): ...)')
+    const chrome = new Error('Refused to create a WebAssembly object because CSP')
+    assert.match(authErrorMessage(firefox, 'Invalid code'), /Secure sign-in could not start/)
+    assert.match(authErrorMessage(chrome, 'Invalid code'), /Secure sign-in could not start/)
+  })
+})

--- a/apps/landing/src/lib/account/auth-error.ts
+++ b/apps/landing/src/lib/account/auth-error.ts
@@ -1,0 +1,21 @@
+import { trackLandingException } from '../analytics'
+
+// Signing in needs a device keypair, and libsodium compiles a WebAssembly
+// module to make one. When the browser refuses to compile it, emscripten throws
+// its raw abort text — "Aborted(CompileError: …). Build with -sASSERTIONS for
+// more info." — which is no answer for someone waiting to sign in.
+const CRYPTO_UNAVAILABLE =
+  'Secure sign-in could not start in this browser. Reload the page, or try a different browser.'
+
+function isCryptoInitFailure(message: string): boolean {
+  return message.includes('Aborted(') || message.includes('WebAssembly')
+}
+
+export function authErrorMessage(error: unknown, fallback: string): string {
+  const message = error instanceof Error ? error.message : ''
+  if (!message) return fallback
+  if (!isCryptoInitFailure(message)) return message
+
+  trackLandingException(error, 'auth:crypto-init')
+  return CRYPTO_UNAVAILABLE
+}

--- a/apps/landing/src/lib/analytics.ts
+++ b/apps/landing/src/lib/analytics.ts
@@ -35,11 +35,7 @@ export type LandingEventName =
   | 'landing_account_signout'
 
 export type LandingCampaignKey =
-  | 'utm_source'
-  | 'utm_medium'
-  | 'utm_campaign'
-  | 'utm_content'
-  | 'utm_term'
+  'utm_source' | 'utm_medium' | 'utm_campaign' | 'utm_content' | 'utm_term'
 
 export type LandingCampaignData = Partial<Record<LandingCampaignKey, string>>
 
@@ -159,4 +155,12 @@ export function trackLandingEvent(name: LandingEventName, target: string): void 
     name,
     createLandingEventData(target, window.location.pathname, window.location.search)
   )
+}
+
+// Autocapture only sees exceptions that reach the top. Anything we catch and
+// turn into a friendly message has to be reported by hand, or the failure goes
+// dark in Error Tracking.
+export function trackLandingException(error: unknown, context: string): void {
+  if (!init()) return
+  posthog.captureException(error, { context })
 }

--- a/apps/landing/src/lib/csp.test.ts
+++ b/apps/landing/src/lib/csp.test.ts
@@ -6,20 +6,28 @@ import { describe, it } from 'node:test'
 // connect-src must list every external host the browser talks to.
 const REQUIRED_CONNECT_SRC = ['https://sync.memrynote.com', 'https://e.memrynote.com']
 
-function getConnectSrc(): string {
+function getDirective(name: string): string {
   const vercelPath = fileURLToPath(new URL('../../vercel.json', import.meta.url))
   const config = JSON.parse(readFileSync(vercelPath, 'utf8'))
   const csp = config.headers
     .flatMap((entry: { headers: { key: string; value: string }[] }) => entry.headers)
     .find((header: { key: string }) => header.key === 'Content-Security-Policy')?.value as string
-  return csp.split(';').find((directive) => directive.trim().startsWith('connect-src')) ?? ''
+  return csp.split(';').find((directive) => directive.trim().startsWith(name)) ?? ''
 }
 
 describe('landing CSP', () => {
   it('allows every host the browser connects to', () => {
-    const connectSrc = getConnectSrc()
+    const connectSrc = getDirective('connect-src')
     for (const host of REQUIRED_CONNECT_SRC) {
       assert.ok(connectSrc.includes(host), `connect-src is missing ${host}`)
     }
+  })
+
+  // libsodium (the `crypto` chunk) compiles a WebAssembly module; without this
+  // keyword the browser refuses and the bundle aborts on every page.
+  it('lets WebAssembly compile without widening script-src to eval', () => {
+    const scriptSrc = getDirective('script-src')
+    assert.ok(scriptSrc.includes("'wasm-unsafe-eval'"), "script-src is missing 'wasm-unsafe-eval'")
+    assert.ok(!/'unsafe-eval'/.test(scriptSrc), "script-src must not allow 'unsafe-eval'")
   })
 })

--- a/apps/landing/src/pages/AuthCallback.tsx
+++ b/apps/landing/src/pages/AuthCallback.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router'
 import { Container } from '@/components/layout/Container'
 import { useAuth } from '@/contexts/auth-context'
 import { registerWebDevice } from '@/lib/account/auth-client'
+import { authErrorMessage } from '@/lib/account/auth-error'
 import { SYNC_SERVER_URL } from '@/lib/account/config'
 import { OAUTH_NEXT_STORAGE_KEY, safeNextPath } from '@/lib/account/next-path'
 import { trackLandingEvent } from '@/lib/analytics'
@@ -34,7 +35,7 @@ export function AuthCallbackPage() {
         sessionStorage.removeItem(OAUTH_NEXT_STORAGE_KEY)
         navigate(safeNextPath(stored), { replace: true })
       } catch (e) {
-        setCallbackError(e instanceof Error ? e.message : 'Sign-in failed')
+        setCallbackError(authErrorMessage(e, 'Sign-in failed'))
       }
     })()
   }, [missingParams, code, state, api, storage, navigate, refreshSignedIn])

--- a/apps/landing/src/pages/Login.tsx
+++ b/apps/landing/src/pages/Login.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useAuth } from '@/contexts/auth-context'
 import { registerWebDevice } from '@/lib/account/auth-client'
+import { authErrorMessage } from '@/lib/account/auth-error'
 import { SYNC_SERVER_URL, WEB_OAUTH_REDIRECT_PATH } from '@/lib/account/config'
 import { OAUTH_NEXT_STORAGE_KEY, safeNextPath } from '@/lib/account/next-path'
 import { trackLandingEvent } from '@/lib/analytics'
@@ -102,7 +103,7 @@ export function LoginPage() {
       trackLandingEvent('landing_account_signin', 'auth:otp')
       navigate(safeNextPath(next))
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Invalid code')
+      setError(authErrorMessage(e, 'Invalid code'))
     } finally {
       setBusy(false)
     }

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -32,7 +32,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://*.paddle.com; script-src 'self' 'unsafe-inline' https://*.paddle.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' data: https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: https:; connect-src 'self' https://sync.memrynote.com https://e.memrynote.com https://*.paddle.com; frame-src https://*.paddle.com"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://*.paddle.com; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://*.paddle.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' data: https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: https:; connect-src 'self' https://sync.memrynote.com https://e.memrynote.com https://*.paddle.com; frame-src https://*.paddle.com"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },


### PR DESCRIPTION
## What was broken

The landing site's site-wide CSP (`apps/landing/vercel.json`) shipped `script-src 'self' 'unsafe-inline' https://*.paddle.com` — no `'wasm-unsafe-eval'`. libsodium (`libsodium-wrappers-sumo`) needs to compile a WebAssembly module, so the browser refused and the module aborted at evaluation time.

It is not a login-only defect: `crypto: ['libsodium-wrappers-sumo']` is a static `manualChunk`, so `/assets/crypto-*.js` is `modulepreload`ed on **every** page.

PostHog (project 412311, `$exception`, `$lib='web'`), 60 days:

| metric | value |
|---|---|
| occurrences | 60 |
| distinct users | 37 |
| first / last seen | 2026-07-24 / 2026-08-19 (still firing) |

| page | occ | users |
|---|---|---|
| `/pricing` | 23 | 18 |
| `/download/desktop` | 17 | 10 |

Roughly 8% of `/pricing` visitors. Cross-browser (Firefox 153, Chrome 150/151, Brave, Edge 150/151, Opera, Mobile Safari), which is what you'd expect from a policy problem rather than an engine quirk. Every message quoted our own live policy back at us.

## What changed

1. **`apps/landing/vercel.json`** — added `'wasm-unsafe-eval'` to `script-src`. Emitted header, verified by parsing the JSON:

   ```
   script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://*.paddle.com
   ```

2. **`apps/landing/src/lib/csp.test.ts`** — the existing CSP test now also asserts `'wasm-unsafe-eval'` is present *and* that `'unsafe-eval'` is not, so neither half can regress silently.

3. **`apps/landing/src/lib/account/auth-error.ts`** (new) — `authErrorMessage()`. When the thrown error is a libsodium/WebAssembly abort, the sign-in error slot now reads "Secure sign-in could not start in this browser. Reload the page, or try a different browser." instead of emscripten's `Aborted(CompileError: …). Build with -sASSERTIONS for more info.` Every other error still passes through verbatim. Wired into `Login.tsx` (OTP verify) and `AuthCallback.tsx` (OAuth return leg) — the only two `registerWebDevice` call sites. Landing has no i18n layer, so the string is inline English like its neighbours.

4. **`apps/landing/src/lib/analytics.ts`** — `trackLandingException()`, so the raw error still reaches PostHog Error Tracking. Autocapture only sees exceptions that reach the top; anything we catch and prettify has to be reported by hand or the failure goes dark. (The one-line reflow of `LandingCampaignKey` in this file is the repo's own prettier 3.9.6 normalising pre-existing drift via lint-staged, not an intentional edit — `origin/main`'s copy already fails `prettier --check`.)

## Why `'wasm-unsafe-eval'` and not `'unsafe-eval'`

Both unblock WebAssembly. `'unsafe-eval'` also re-enables `eval()` and `new Function()` for **all** script on the origin, which is a genuine XSS-amplification regression and undoes the point of a tight `script-src`. `'wasm-unsafe-eval'` grants wasm compilation and nothing else. Note also that `'unsafe-eval'`, if present, *overrides* `'wasm-unsafe-eval'` — so the two must not be mixed.

## Safari support

Checked against MDN `browser-compat-data` (`http/headers/Content-Security-Policy.json`, key `script-src/wasm-unsafe-eval`) rather than memory:

| browser | version_added |
|---|---|
| Chrome | 97 |
| Firefox | 102 |
| **Safari** | **16** |
| Safari iOS / Edge / Opera / Samsung / WebView | mirror upstream |

WebKit implemented the keyword in r289022 (Feb 2022, [bug 235408](https://bugs.webkit.org/show_bug.cgi?id=235408)), shipping in Safari 16. Every currently-supported Safari honours it, so the fix is not partial in practice. Safari 15 and earlier do not recognise the keyword — but per [bug 197759](https://bugs.webkit.org/show_bug.cgi?id=197759) WebKit had no CSP enforcement for WebAssembly before that work landed, so those versions are not left worse off. No reason to reach for `'unsafe-eval'`.

## Verification

Green locally:

- `pnpm --filter @memry/landing test` — 65 pass / 0 fail, including the 2 CSP assertions and 4 new `authErrorMessage` cases
- `pnpm --filter @memry/landing build` (= `tsc -b` + `vite build` + prerender) — exit 0, 45 routes prerendered
- `pnpm exec tsc -b` in `apps/landing` — exit 0
- `eslint` on all touched files — exit 0 (`src/pages/Checkout.tsx` fails `react-hooks/set-state-in-effect` on `origin/main` already; that file is untouched here)
- `pnpm docs:impact --base origin/main --strict` — exit 0, no docs-relevant changes
- `prettier --check` on all touched files — clean

**The header itself cannot be verified locally.** It comes from `apps/landing/vercel.json`, and `vite preview` does not serve it at all. Post-deploy:

1. `curl -sI https://memrynote.com/pricing | grep -i content-security-policy` — confirm `'wasm-unsafe-eval'` in `script-src`
2. Load `/pricing` and `/download/desktop` in Chrome and Firefox with devtools open; no CSP violation, no `Aborted(CompileError…)`
3. Complete a full sign-in through `/login` end to end
4. 48h after deploy, re-run:

```sql
SELECT toDate(timestamp) AS d, count() AS c, uniq(person_id) AS users
FROM events
WHERE event = '$exception'
  AND timestamp >= now() - INTERVAL 7 DAY
  AND properties.$lib = 'web'
  AND properties.$exception_values ILIKE '%WebAssembly%'
GROUP BY d ORDER BY d DESC
```

and confirm zero rows on dates after the deploy.

## Deliberately not done

- **Chunking cleanup.** `/pricing` and `/download/desktop` still download and evaluate a libsodium wasm bundle they have no use for. Deferring it needs `dynamic import()` plus a `hydrateRoot()` migration — `createRoot` replaces the prerendered DOM, so `React.lazy` would flash a fallback on direct loads. The issue calls this separate follow-up work, not a blocker for the CSP fix, and `vite.config.ts:90-95` already documents why it was left alone.
- **The ~8% question.** Why only some `/pricing` visitors report the abort (asm.js fallback succeeding? autocapture missing some abort shapes?) is still open. Determines whether "the error stopped" is sufficient proof or whether more users were silently degraded than telemetry showed.
- **Other CSP surfaces.** Checked all of them: `apps/desktop/src/renderer/index.html` (Electron renderer, separate bundle), `apps/sync-server/src/middleware/security.ts` (`default-src 'none'`, API only), root and `apps/docs` `vercel.json` (no CSP headers). None serve the landing bundle, so none were touched.

Fixes #1580
