### PR TITLE
fix(notes): a URL pasted into a table cell becomes a mention instead of erroring

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -9,7 +9,8 @@ const contentAreaMocks = vi.hoisted(() => ({
   blockNoteOptions: null as any,
   blocks: new Map<string, any>(),
   suggestionControllers: [] as any[],
-  pasteSelect: null as null | ((option: 'url' | 'mention' | 'embed', url: string) => void),
+  pasteSelect: null as
+    null | ((option: 'url' | 'mention' | 'embed' | 'bookmark', url: string) => void),
   handleChange: vi.fn(),
   retryAI: vi.fn(),
   openSidebarItem: vi.fn(),
@@ -306,6 +307,28 @@ function createBlock(id: string, overrides: Record<string, unknown> = {}) {
   }
   contentAreaMocks.blocks.set(id, block)
   return block
+}
+
+function textCell(text: string): any[] {
+  return [{ type: 'text', text, styles: {} }]
+}
+
+// A table block's content is `{ type: 'tableContent', rows }`, not the inline
+// array every other block carries.
+function createTableBlock(id: string, rows: any[][]): any {
+  return createBlock(id, {
+    type: 'table',
+    content: { type: 'tableContent', rows: rows.map((cells) => ({ cells })) }
+  })
+}
+
+// `editor.document` is a getter over a fixed block list; swap in a document the
+// test owns so the link-preview walk has something to find.
+function setDocument(blocks: any[]): void {
+  Object.defineProperty(contentAreaMocks.editor, 'document', {
+    value: blocks,
+    configurable: true
+  })
 }
 
 function resetEditor(): void {
@@ -742,6 +765,111 @@ describe('ContentArea', () => {
     contentAreaMocks.editor.getTextCursorPosition.mockReturnValueOnce({ block: plainBlock })
     contentAreaMocks.pasteSelect?.('url', 'https://example.com')
     expect(contentAreaMocks.editor.insertBlocks).toHaveBeenCalledTimes(1)
+  })
+
+  it('turns a URL pasted into a table cell into a mention without touching the rest of the table', async () => {
+    const tableBlock = createTableBlock('table-mention', [
+      [textCell('Docs')],
+      [textCell('see https://youtu.be/video-1 for more')]
+    ])
+    setDocument([tableBlock])
+
+    render(<ContentArea noteId="note-1" />)
+
+    contentAreaMocks.editor.getTextCursorPosition.mockReturnValue({ block: tableBlock })
+    contentAreaMocks.pasteSelect?.('mention', 'https://youtu.be/video-1')
+
+    expect(contentAreaMocks.editor.updateBlock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'table-mention' }),
+      {
+        content: {
+          type: 'tableContent',
+          rows: [
+            { cells: [textCell('Docs')] },
+            { cells: [[expect.objectContaining({ type: 'linkMention' })]] }
+          ]
+        }
+      }
+    )
+
+    // The preview fetch re-finds the mention by walking the document, which
+    // also has to see into the table, and enriches it in place.
+    await waitFor(() =>
+      expect(contentAreaMocks.createLinkMentionContent).toHaveBeenCalledWith(
+        'https://youtu.be/video-1',
+        'youtu.be',
+        'Video',
+        'icon.png',
+        'YouTube'
+      )
+    )
+    expect(tableBlock.content.rows[1].cells[0][0]).toMatchObject({
+      type: 'linkMention',
+      props: { title: 'Video' }
+    })
+    expect(tableBlock.content.rows[0].cells[0]).toEqual(textCell('Docs'))
+  })
+
+  it('drops the URL from its table cell and puts the embed or bookmark after the table', async () => {
+    const tableBlock = createTableBlock('table-embed', [
+      [
+        { type: 'tableCell', props: { colspan: 1 }, content: [] },
+        {
+          type: 'tableCell',
+          props: { colspan: 1 },
+          content: [{ type: 'text', text: 'https://youtu.be/video-1', styles: {} }]
+        }
+      ]
+    ])
+    setDocument([tableBlock])
+
+    render(<ContentArea noteId="note-1" />)
+
+    contentAreaMocks.editor.getTextCursorPosition.mockReturnValue({ block: tableBlock })
+    contentAreaMocks.pasteSelect?.('embed', 'https://youtu.be/video-1')
+
+    expect(tableBlock.content.rows[0].cells[1]).toEqual({
+      type: 'tableCell',
+      props: { colspan: 1 },
+      content: []
+    })
+    expect(contentAreaMocks.editor.insertBlocks).toHaveBeenCalledWith(
+      [
+        {
+          type: 'youtubeEmbed',
+          props: { videoId: 'video-1', videoUrl: 'https://youtu.be/video-1' }
+        }
+      ],
+      expect.objectContaining({ id: 'table-embed' }),
+      'after'
+    )
+
+    const bookmarkTable = createTableBlock('table-bookmark', [
+      [textCell('https://example.com/post')]
+    ])
+    setDocument([bookmarkTable])
+    contentAreaMocks.editor.getTextCursorPosition.mockReturnValue({ block: bookmarkTable })
+    contentAreaMocks.pasteSelect?.('bookmark', 'https://example.com/post')
+
+    expect(bookmarkTable.content.rows[0].cells[0]).toEqual([])
+    expect(contentAreaMocks.editor.insertBlocks).toHaveBeenLastCalledWith(
+      [{ type: 'bookmark', props: { url: 'https://example.com/post', domain: 'example.com' } }],
+      expect.objectContaining({ id: 'table-bookmark' }),
+      'after'
+    )
+  })
+
+  it('leaves a table alone when the pasted URL is in none of its cells', () => {
+    const tableBlock = createTableBlock('table-miss', [[textCell('nothing here')]])
+    setDocument([tableBlock])
+
+    render(<ContentArea noteId="note-1" />)
+
+    contentAreaMocks.editor.getTextCursorPosition.mockReturnValue({ block: tableBlock })
+    contentAreaMocks.pasteSelect?.('mention', 'https://example.com/post')
+
+    expect(contentAreaMocks.editor.updateBlock).not.toHaveBeenCalled()
+    expect(tableBlock.content.rows[0].cells[0]).toEqual(textCell('nothing here'))
   })
 
   it('exposes upload handling success and failure through the BlockNote config', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -101,16 +101,70 @@ import { useT } from '@memry/i18n/renderer'
 
 const PRIORITY_REVERSE: Record<string, number> = { none: 0, low: 1, medium: 2, high: 3, urgent: 4 }
 
-function findBlockWithLinkMention(
+/**
+ * Rewrite the first inline node in `content` that `match` accepts.
+ *
+ * A text block's content is a flat inline-content array, but a table block's is
+ * `{ type: 'tableContent', rows: [{ cells: [...] }] }` — the inline content
+ * lives one level down, per cell. Reading `content.findIndex` on a table throws,
+ * and spreading it silently yields `[]`, which would wipe the table. Both
+ * shapes are walked here so callers never touch `block.content` directly.
+ *
+ * Returns the block content to write back, or null when nothing matched.
+ */
+function rewriteInlineContent(
+  content: any,
+  match: (node: any) => boolean,
+  rewrite: (inline: any[], index: number) => any[]
+): any {
+  if (Array.isArray(content)) {
+    const index = content.findIndex((c: any) => match(c))
+    return index === -1 ? null : rewrite(content, index)
+  }
+
+  if (content?.type !== 'tableContent' || !Array.isArray(content.rows)) return null
+
+  let matched = false
+  const rows = content.rows.map((row: any) => {
+    if (matched || !Array.isArray(row?.cells)) return row
+
+    let rowMatched = false
+    const cells = row.cells.map((cell: any) => {
+      if (matched) return cell
+      // A cell is a bare inline array in older documents and a `tableCell`
+      // object (with props) in newer ones; both still have to round-trip.
+      const inline = Array.isArray(cell) ? cell : Array.isArray(cell?.content) ? cell.content : null
+      if (!inline) return cell
+
+      const index = inline.findIndex((c: any) => match(c))
+      if (index === -1) return cell
+
+      matched = true
+      rowMatched = true
+      const next = rewrite(inline, index)
+      return Array.isArray(cell) ? next : { ...cell, content: next }
+    })
+
+    return rowMatched ? { ...row, cells } : row
+  })
+
+  return matched ? { ...content, rows } : null
+}
+
+function rewriteBlockWithLinkMention(
   blocks: any[],
-  url: string
-): { block: any; index: number } | null {
+  url: string,
+  rewrite: (inline: any[], index: number) => any[]
+): { block: any; content: any } | null {
   for (const block of blocks) {
-    const content = (block.content ?? []) as any[]
-    const idx = content.findIndex((c: any) => c.type === 'linkMention' && c.props?.url === url)
-    if (idx !== -1) return { block, index: idx }
+    const content = rewriteInlineContent(
+      block.content,
+      (c: any) => c?.type === 'linkMention' && c.props?.url === url,
+      rewrite
+    )
+    if (content !== null) return { block, content }
     if (block.children?.length) {
-      const found = findBlockWithLinkMention(block.children, url)
+      const found = rewriteBlockWithLinkMention(block.children, url, rewrite)
       if (found) return found
     }
   }
@@ -461,48 +515,58 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     (option: PasteLinkOption, url: string) => {
       const block = editor.getTextCursorPosition()?.block
       if (!block) return
-      const inlineContent = (block.content ?? []) as any[]
-
-      const urlNodeIndex = inlineContent.findIndex(
-        (c: any) =>
-          (c.type === 'link' && c.href === url) ||
-          (c.type === 'text' && typeof c.text === 'string' && c.text.includes(url))
-      )
 
       if (option === 'url') return
 
+      // The pasted URL sits in the block as either a link node or plain text
+      // containing it. Inside a table it sits in one of the cells instead.
+      const isPastedUrl = (c: any): boolean =>
+        (c?.type === 'link' && c.href === url) ||
+        (c?.type === 'text' && typeof c.text === 'string' && c.text.includes(url))
+
+      const dropPastedUrl = (inline: any[], index: number): any[] =>
+        inline.filter((_: any, i: number) => i !== index)
+
       if (option === 'mention') {
-        if (urlNodeIndex === -1) return
         const domain = extractDomain(url)
-        const newContent = [...inlineContent]
-        newContent[urlNodeIndex] = createLinkMentionContent(url, domain)
+        const newContent = rewriteInlineContent(block.content, isPastedUrl, (inline, index) => {
+          const next = [...inline]
+          next[index] = createLinkMentionContent(url, domain)
+          return next
+        })
+        if (newContent === null) return
         editor.updateBlock(block, { content: newContent })
 
         fetchLinkPreview(url)
           .then((metadata) => {
-            const found = findBlockWithLinkMention(editor.document, url)
+            const found = rewriteBlockWithLinkMention(editor.document, url, (inline, index) => {
+              const updated = [...inline]
+              updated[index] = createLinkMentionContent(
+                url,
+                metadata.domain || domain,
+                metadata.title,
+                metadata.favicon,
+                metadata.siteName
+              )
+              return updated
+            })
             if (!found) return
-            const updatedContent = [...((found.block.content ?? []) as any[])]
-            updatedContent[found.index] = createLinkMentionContent(
-              url,
-              metadata.domain || domain,
-              metadata.title,
-              metadata.favicon,
-              metadata.siteName
-            )
-            editor.updateBlock(found.block, { content: updatedContent })
+            editor.updateBlock(found.block, { content: found.content })
           })
           .catch(() => {})
         return
       }
 
+      // Embeds and bookmarks are blocks of their own, so they land after the
+      // cursor's block — after the whole table when the paste happened in a
+      // cell, since a table cell holds inline content only.
       if (option === 'embed') {
         const videoId = extractYouTubeVideoId(url)
         if (!videoId) return
 
-        if (urlNodeIndex !== -1) {
-          const newContent = inlineContent.filter((_: any, i: number) => i !== urlNodeIndex)
-          editor.updateBlock(block, { content: newContent.length > 0 ? newContent : [] })
+        const newContent = rewriteInlineContent(block.content, isPastedUrl, dropPastedUrl)
+        if (newContent !== null) {
+          editor.updateBlock(block, { content: newContent })
         }
         editor.insertBlocks(
           [{ type: 'youtubeEmbed' as any, props: { videoId, videoUrl: url } }],
@@ -514,9 +578,9 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
 
       if (option === 'bookmark') {
         const domain = extractDomain(url)
-        if (urlNodeIndex !== -1) {
-          const newContent = inlineContent.filter((_: any, i: number) => i !== urlNodeIndex)
-          editor.updateBlock(block, { content: newContent.length > 0 ? newContent : [] })
+        const newContent = rewriteInlineContent(block.content, isPastedUrl, dropPastedUrl)
+        if (newContent !== null) {
+          editor.updateBlock(block, { content: newContent })
         }
         editor.insertBlocks([{ type: 'bookmark' as any, props: { url, domain } }], block, 'after')
 
@@ -574,7 +638,7 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
   }, [dateMentionState.anchorId])
 
   // Walk the (nested) block tree — a pill can live inside a list item's
-  // children[], so recurse like findBlockWithLinkMention does — find the
+  // children[], so recurse like rewriteBlockWithLinkMention does — find the
   // dateMention with `anchorId`, and write back the content `mutate` returns.
   // Stops at the first match.
   const mutateDateMention = useCallback(

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -184,6 +184,12 @@ Two consequences worth knowing:
 
 Colours are stored by name, not as a fixed shade, so notes you coloured in an earlier version pick up the current tuning when you open them. Highlight (background) colours are unchanged — a filled background does not need the same treatment to stay readable.
 
+## Pasting a Link
+
+Pasting a URL offers four ways to keep it: plain **URL**, an inline **Mention** pill, an **Embed** (for a video the app recognises), or a **Bookmark** card.
+
+This works inside a table cell too. **Mention** replaces the pasted URL in that one cell and leaves the rest of the table alone. **Embed** and **Bookmark** are blocks in their own right and a cell holds text only, so they take the URL out of the cell and place the card after the whole table.
+
 ## Link Previews
 
 Links in a note are enriched with the page title, site name and favicon, both for inline link mentions and for bookmark blocks. The lookup runs once per URL and the result is kept in memory, so reopening a note with the same links does not refetch them.


### PR DESCRIPTION
Part of #1589 — this closes **Symptom B** only. Symptom A (`Cannot read properties of undefined (reading 'id')`, still live on 2026.817.1) and the renderer sourcemap work are untouched, so the issue should stay open.

## What threw, and on which block shape

`handlePasteLinkSelect` in `ContentArea.tsx` read the cursor block's content as a flat inline array:

```ts
const inlineContent = (block.content ?? []) as any[]
const urlNodeIndex = inlineContent.findIndex(...)
```

`?? []` substitutes for `null`/`undefined` only. A table block's content is `{ type: 'tableContent', rows: [...] }` — an object — and the `as any[]` cast stopped TypeScript from noticing. Put the cursor in a table cell, paste a URL, pick anything from the menu, and `.findIndex is not a function` threw out of the click handler; the choice was silently lost.

Two more sites in the same feature had the same defect:

- `findBlockWithLinkMention` (the walk that re-finds the new mention once the preview fetch resolves) ran `content.findIndex` over every block in the document, so it threw — swallowed by the trailing `.catch(() => {})` — for **any** note containing a table. Title/favicon enrichment never landed in those notes.
- `[...((found.block.content ?? []) as any[])]` did not throw at all: spreading the table object yields `[]`, and the following `updateBlock` would have written that empty content over the table.

## What the feature now does for table content

A single `rewriteInlineContent(content, match, rewrite)` handles both shapes, so no caller touches `block.content` directly any more. For a table it walks `rows[].cells[]` — cells that are a bare inline array (older documents) and `tableCell` objects with props (newer ones) both round-trip — rewrites the one cell holding the pasted URL, and returns the whole `tableContent` object to write back. Every other cell is returned by identity. It returns `null` when nothing matched, which is what callers key their early return off.

- **Mention** — replaces the URL in that cell with the mention pill, then enriches it in place when the preview resolves.
- **Embed** / **Bookmark** — these are blocks of their own and a cell holds inline content only, so the URL is dropped from its cell and the card is inserted after the whole table, which is where `insertBlocks(..., block, 'after')` already put it.

Behaviour for non-table blocks is unchanged. No schema, contract or file-format change; nothing here reads or writes anything an older version wrote differently.

## The `inlineContent.findIndex` sibling error

Same root cause, and the same call site — not a different one. The epic's earlier figure (13 occurrences / 4 users, last seen 2026-08-19) was retracted in #1589 itself: re-querying gives 5 occurrences / 1 install on `2026.808.1` linux, 2026-08-09, and nothing after. It stopped being hit but was never fixed; that unguarded line is exactly what this PR replaces. Symptom A's `.id` error is unrelated to this file — single-frame `HTMLDivElement.<anonymous>`, no sourcemaps, and #1589 spells out that locating it needs the released bundle read at `index-BWaMlYGi.js:175892`. Not attempted here.

## Verification

| Command | Result |
| --- | --- |
| `pnpm --filter @memry/desktop typecheck:web` | pass |
| `pnpm lint` | pass (0 errors; no findings in the changed files) |
| `vitest --project renderer ContentArea.test.tsx` | 21 passed |
| `pnpm --filter @memry/desktop test:renderer` (full) | 7682 passed, 10 failed — all pre-existing on `main` |
| `pnpm docs:impact --base origin/main --strict` | covered |
| `pnpm docs:build` | pass |

Three new tests drive the real `handlePasteLinkSelect` with a table block under the cursor: mention (both the initial rewrite and the preview enrichment, asserting the untouched cells stay identical), embed and bookmark on a `tableCell`-shaped table, and a table that does not contain the URL at all. Mutated both ways to prove they bite — restoring the flat-array read reproduces `findIndex is not a function` in all three; making the table branch bail out early keeps the no-throw property but fails the two behaviour tests.

**Known red, not from this branch.** `pnpm --filter @memry/desktop typecheck:test` fails on `sidebar-nav.test.tsx` (`onNavMiddleClick` missing), and the 10 renderer failures come from exactly two causes — `No "useTabActions" export is defined on the "@/contexts/tabs" mock` (`App.test.tsx`, `App.workspace-counts.test.tsx`, `calendar.test.tsx`) and `onNavMiddleClick is not a function` (`sidebar-nav.test.tsx`). Both are on `main`; this branch changes only `ContentArea.tsx` and its test.