### PR TITLE
fix(sync): a failed sync reports its status code and server reason, not one blank label

### DIFF
--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -14,6 +14,7 @@ import type { WebSocketMessage } from './websocket'
 import { secureCleanup } from '../crypto/index'
 import { getFromServer } from './http-client'
 import { classifyError } from './sync-errors'
+import { syncErrorTelemetryFor } from './sync-error-telemetry'
 import { syncState } from '@memry/db-schema/schema/sync-state'
 import { ItemApplier } from './apply-item'
 import { FullSyncRunner } from './engine/full-sync-runner'
@@ -88,15 +89,6 @@ export const INACTIVE_CRDT_SWEEP_MIN_INTERVAL_MS = 5 * 60 * 1000
 // a bounded worst case. Any drop between ticks bumps the generation and
 // restores the every-tick pull, and the reconnect itself already pulls.
 export const PERIODIC_PULL_MAX_QUIET_MS = 5 * 60 * 1000
-
-const classifySyncErrorCode = (error: unknown): string => {
-  try {
-    const info = classifyError(error)
-    return info?.category ?? 'unknown'
-  } catch {
-    return 'unknown'
-  }
-}
 
 export class SyncEngine extends EventEmitter {
   private static activeInstance: SyncEngine | null = null
@@ -349,7 +341,7 @@ export class SyncEngine extends EventEmitter {
         surface: 'sync',
         action: 'push_failed',
         result: 'failed',
-        errorCode: classifySyncErrorCode(error),
+        ...syncErrorTelemetryFor(error),
         metrics: { durationMs: Date.now() - start },
         source: 'push',
         dimensions: { transport: 'record' }
@@ -378,7 +370,7 @@ export class SyncEngine extends EventEmitter {
         surface: 'sync',
         action: 'pull_failed',
         result: 'failed',
-        errorCode: classifySyncErrorCode(error),
+        ...syncErrorTelemetryFor(error),
         metrics: { durationMs: Date.now() - start },
         source: 'pull',
         dimensions: { transport: 'record' }
@@ -438,7 +430,7 @@ export class SyncEngine extends EventEmitter {
         surface: 'sync',
         action: 'full_failed',
         result: 'failed',
-        errorCode: classifySyncErrorCode(error),
+        ...syncErrorTelemetryFor(error),
         metrics: { durationMs: Date.now() - start },
         source: 'full',
         dimensions: { transport: 'record' }

--- a/apps/desktop/src/main/sync/engine/pull-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/pull-coordinator.ts
@@ -20,6 +20,7 @@ import { withRetry } from '../retry'
 import { engineAuthRetryDeps, withAuthRetry } from '../auth-retry'
 import { postToServer, getFromServer, RateLimitError } from '../http-client'
 import { classifyError } from '../sync-errors'
+import { syncErrorTelemetry } from '../sync-error-telemetry'
 import { isBinaryFileType } from '@memry/shared/file-types'
 import { SyncTimer } from '../sync-timer'
 import { trackMainEvent } from '../../telemetry/track'
@@ -399,7 +400,7 @@ export class PullCoordinator {
       surface: 'sync',
       action: 'pull_failed',
       result: 'failed',
-      errorCode: errorInfo.category,
+      ...syncErrorTelemetry(errorInfo),
       metrics: { durationMs: Date.now() - startedAt },
       source: 'pull',
       dimensions: { transport: 'record' }

--- a/apps/desktop/src/main/sync/engine/push-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.ts
@@ -10,6 +10,7 @@ import { withRetry } from '../retry'
 import { engineAuthRetryDeps, withAuthRetry } from '../auth-retry'
 import { postToServer, RateLimitError } from '../http-client'
 import { classifyError } from '../sync-errors'
+import { syncErrorTelemetry } from '../sync-error-telemetry'
 import { isBinaryFileType } from '@memry/shared/file-types'
 import { parallelWithLimit } from '../concurrency'
 import { SyncTimer } from '../sync-timer'
@@ -325,7 +326,7 @@ export class PushCoordinator {
           surface: 'sync',
           action: 'push_failed',
           result: 'failed',
-          errorCode: errorInfo.category,
+          ...syncErrorTelemetry(errorInfo),
           metrics: { durationMs: Date.now() - startTime },
           source: 'push',
           dimensions: { transport: 'record' }

--- a/apps/desktop/src/main/sync/sync-error-telemetry.test.ts
+++ b/apps/desktop/src/main/sync/sync-error-telemetry.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// http-client reaches for electron's `net` at import time.
+vi.mock('electron', () => ({ net: { fetch: vi.fn() } }))
+
+// Mask-mode redaction (no vault root, no salted hasher) so this suite never
+// touches electron's app paths or the diagnostics salt file. The redaction rules
+// themselves are packages/contracts/src/redact.test.ts' subject.
+vi.mock('../telemetry/redact-options', () => ({
+  getMainRedactOptions: () => ({})
+}))
+
+import { SyncServerError, NetworkError } from './http-client'
+import { syncErrorTelemetry, syncErrorTelemetryFor } from './sync-error-telemetry'
+import { classifyError } from './sync-errors'
+
+// #1584: every one of these used to ship the single event
+// `{error_code: 'server_error', message: ''}` — a permanent 400 and a transient
+// 503 were indistinguishable without hand-joining sync-server logs.
+describe('syncErrorTelemetry', () => {
+  it('#given a 400 VALIDATION_ERROR #then status, code, retryable and a message all ship', () => {
+    const detail =
+      'VALIDATION_ERROR: Invalid push request: Record sync item type "calendar_external_event" requires clock metadata'
+    const fields = syncErrorTelemetryFor(new SyncServerError('Invalid push request', 400, detail))
+
+    expect(fields.errorCode).toBe('server_error')
+    expect(fields.failure).toEqual({
+      httpStatus: 400,
+      serverCode: 'VALIDATION_ERROR',
+      retryable: false
+    })
+    expect(fields.error?.message).toContain('requires clock metadata')
+  })
+
+  it('#given a 503 with no server code #then it is distinguishable from the 400', () => {
+    const client = syncErrorTelemetryFor(new SyncServerError('Bad Request', 400, 'VALIDATION_ERROR: nope'))
+    const server = syncErrorTelemetryFor(new SyncServerError('Server returned 503', 503))
+
+    expect(server.failure).toEqual({ httpStatus: 503, retryable: true })
+    // Same label, different rows: this is what makes an alert threshold possible.
+    expect(server.errorCode).toBe(client.errorCode)
+    expect(server.failure).not.toEqual(client.failure)
+  })
+
+  it('#given a known code on a 413 #then the code lands in its own field', () => {
+    const body = '{"error":{"code":"STORAGE_QUOTA_EXCEEDED","message":"Storage quota exceeded"}}'
+    const fields = syncErrorTelemetryFor(new SyncServerError('Quota', 413, body))
+
+    expect(fields.errorCode).toBe('storage_quota_exceeded')
+    expect(fields.failure).toEqual({
+      httpStatus: 413,
+      serverCode: 'STORAGE_QUOTA_EXCEEDED',
+      retryable: false
+    })
+  })
+
+  it('#given a failure with no HTTP request #then only the retryable verdict ships', () => {
+    const fields = syncErrorTelemetryFor(new NetworkError('fetch failed'))
+
+    expect(fields.errorCode).toBe('network_offline')
+    expect(fields.failure).toEqual({ retryable: true })
+    expect(fields.error?.message).toBe('fetch failed')
+  })
+
+  it('#given a message carrying a home path #then it is redacted before it ships', () => {
+    const fields = syncErrorTelemetryFor(
+      new Error("ENOENT: no such file or directory, open '/Users/kaan/Vault/Secret.md'")
+    )
+
+    expect(fields.error?.message).toBeDefined()
+    expect(fields.error?.message).not.toContain('/Users/kaan')
+    expect(fields.error?.message).not.toContain('Secret.md')
+  })
+
+  it('#given an over-long message #then it is capped at the schema limit', () => {
+    const fields = syncErrorTelemetry(classifyError(new Error('server unavailable '.repeat(100))))
+
+    expect(fields.error?.message?.length).toBe(512)
+  })
+
+  it('#given classification itself throwing #then telemetry degrades instead of throwing', () => {
+    const hostile = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('hostile getter')
+        }
+      }
+    )
+
+    expect(syncErrorTelemetryFor(hostile).errorCode).toBe('unknown')
+  })
+})

--- a/apps/desktop/src/main/sync/sync-error-telemetry.ts
+++ b/apps/desktop/src/main/sync/sync-error-telemetry.ts
@@ -1,0 +1,78 @@
+// The telemetry half of a sync failure.
+//
+// `classifyError` has always computed the status, the server's error code, the
+// retryable verdict and a message — and every emitter forwarded only
+// `category`, so `sync_error` shipped one opaque `server_error` label covering
+// 400, 403, 404, 409 and every 5xx alike, with `"message":""` in the log body.
+// Two unrelated root causes shared that bucket for 48 hours and were only
+// separable by hand-joining sync-server logs (#1584).
+//
+// This module is the one place that turns a classified failure into the fields
+// `trackMainEvent` ships, so a new emitter cannot forget half of them.
+import { redactText } from '@memry/contracts/redact'
+import type { TelemetryEvent } from '@memry/contracts/telemetry-api'
+
+import { getMainRedactOptions } from '../telemetry/redact-options'
+
+import { classifyError, type SyncErrorInfo } from './sync-errors'
+
+// TelemetryErrorDetailSchema.message caps at 512 chars, and the sync-server
+// rejects an ENTIRE batch when one event fails validation — so the cap is
+// applied here, not hoped for.
+const MAX_MESSAGE_CHARS = 512
+
+export interface SyncErrorTelemetryFields {
+  errorCode: string
+  failure?: TelemetryEvent['failure']
+  error?: TelemetryEvent['error']
+}
+
+/**
+ * A sync error message can be anything the sync path threw — a server string, a
+ * filesystem error carrying a vault path, an error naming a note. It therefore
+ * goes through `redactText` with the main process's salted options (the same
+ * ones diagnostics and log shipping use, so placeholders correlate across an
+ * incident) before it can leave the device. Never throws: every caller is
+ * already on an error path.
+ */
+const safeMessage = (message: string): string | undefined => {
+  if (!message) return undefined
+  try {
+    const redacted = redactText(message, getMainRedactOptions())
+    return redacted ? redacted.slice(0, MAX_MESSAGE_CHARS) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Spread into a `trackMainEvent('sync_error', …)` call to ship the category
+ * alongside the facts that make it actionable: the HTTP status, the server's
+ * structured code, whether the failure was classified retryable, and a
+ * redacted message.
+ */
+export const syncErrorTelemetry = (info: SyncErrorInfo): SyncErrorTelemetryFields => {
+  const failure: NonNullable<TelemetryEvent['failure']> = { retryable: info.retryable }
+  if (info.statusCode !== undefined) failure.httpStatus = info.statusCode
+  if (info.serverCode) failure.serverCode = info.serverCode
+
+  const message = safeMessage(info.message)
+  return {
+    errorCode: info.category,
+    failure,
+    ...(message ? { error: { message } } : {})
+  }
+}
+
+/**
+ * Same, for the call sites that hold the raw error rather than a classified
+ * one. Falls back to the bare `unknown` code if classification itself throws —
+ * telemetry must never break the failure path it is reporting on.
+ */
+export const syncErrorTelemetryFor = (error: unknown): SyncErrorTelemetryFields => {
+  try {
+    return syncErrorTelemetry(classifyError(error))
+  } catch {
+    return { errorCode: 'unknown' }
+  }
+}

--- a/apps/desktop/src/main/sync/sync-errors.test.ts
+++ b/apps/desktop/src/main/sync/sync-errors.test.ts
@@ -201,3 +201,58 @@ describe('classifyError', () => {
     expect(result.retryable).toBe(true)
   })
 })
+
+// #1584: `server_error` covered 400, 403, 404, 409 and every 5xx with no status
+// and no server code anywhere in the event, so a permanent client-side contract
+// bug and a transient edge 5xx were the same row in every chart.
+describe('classifyError request detail', () => {
+  it('#given a 400 with a server code #then the status and the code both survive', () => {
+    const err = new SyncServerError(
+      'Invalid push request: Record sync item type "calendar_external_event" requires clock metadata',
+      400,
+      'VALIDATION_ERROR: Invalid push request: Record sync item type "calendar_external_event" requires clock metadata'
+    )
+    const result = classifyError(err)
+
+    expect(result.category).toBe('server_error')
+    expect(result.statusCode).toBe(400)
+    expect(result.serverCode).toBe('VALIDATION_ERROR')
+    expect(result.retryable).toBe(false)
+  })
+
+  it('#given a 503 with no structured body #then the status survives and the code is absent', () => {
+    // A code-less 5xx never reached the Worker's error handler, so the backend
+    // has no record of it. That absence is the signal that says "edge, not us".
+    const err = new SyncServerError('Server returned 503', 503)
+    const result = classifyError(err)
+
+    expect(result.category).toBe('server_error')
+    expect(result.statusCode).toBe(503)
+    expect(result.serverCode).toBeUndefined()
+    expect(result.retryable).toBe(true)
+  })
+
+  it('#given a raw JSON error body #then the code is read out of it', () => {
+    // The attachment upload paths pass the response body through verbatim
+    // instead of the `CODE: message` shape http-client builds.
+    const body = '{"error":{"code":"STORAGE_FILE_TOO_LARGE","message":"File too large"}}'
+    const err = new SyncServerError(`Failed to initiate upload: ${body}`, 413, body)
+    const result = classifyError(err)
+
+    expect(result.statusCode).toBe(413)
+    expect(result.serverCode).toBe('STORAGE_FILE_TOO_LARGE')
+  })
+
+  it('#given a DeadLetterError #then the wrapped request detail is preserved', () => {
+    const inner = new SyncServerError('Bad Gateway', 502)
+    const result = classifyError(new DeadLetterError(inner, 5))
+
+    expect(result.statusCode).toBe(502)
+    expect(result.retryable).toBe(false)
+  })
+
+  it('#given a non-HTTP failure #then no status is invented', () => {
+    expect(classifyError(new NetworkError('fetch failed')).statusCode).toBeUndefined()
+    expect(classifyError(new Error('boom')).statusCode).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/main/sync/sync-errors.ts
+++ b/apps/desktop/src/main/sync/sync-errors.ts
@@ -14,6 +14,26 @@ export interface SyncErrorInfo {
   category: SyncErrorCategory
   message: string
   retryable: boolean
+  /** HTTP status of the failed request, when the failure came from one. */
+  statusCode?: number
+  /**
+   * The sync-server's structured `error.code` (VALIDATION_ERROR,
+   * AUTH_INVALID_TOKEN, …) when the response carried one. Undefined is itself a
+   * signal: a 5xx with no code never reached the Worker's error handler, so it
+   * came from the edge and the backend has no record of it (#1584).
+   */
+  serverCode?: string
+}
+
+// `serverError` is `${code}: ${message}` when http-client read `error.code` off
+// the body; the attachment upload path instead passes the raw JSON body through.
+// Both shapes are read here so a code is never lost to the shape it arrived in.
+const LEADING_SERVER_CODE = /^([A-Z][A-Z0-9_]{0,63}):/
+const BODY_SERVER_CODE = /"code"\s*:\s*"([A-Z][A-Z0-9_]{0,63})"/
+
+const serverErrorCode = (error: SyncServerError): string | undefined => {
+  const source = error.serverError ?? error.message
+  return LEADING_SERVER_CODE.exec(source)?.[1] ?? BODY_SERVER_CODE.exec(source)?.[1]
 }
 
 export function classifyError(error: unknown): SyncErrorInfo {
@@ -41,86 +61,15 @@ export function classifyError(error: unknown): SyncErrorInfo {
   }
 
   if (error instanceof SyncServerError) {
-    if (error.statusCode === 401) {
-      return {
-        category: 'auth_expired',
-        message: 'Session expired',
-        retryable: false
-      }
-    }
-    if (error.statusCode === 403 && error.serverError?.includes('AUTH_DEVICE_REVOKED')) {
-      return {
-        category: 'device_revoked',
-        message: 'This device has been removed',
-        retryable: false
-      }
-    }
-    if (error.statusCode === 402 || error.serverError?.includes('SYNC_PAYMENT_REQUIRED')) {
-      return {
-        category: 'sync_payment_required',
-        message: 'A paid Sync plan is required',
-        retryable: false
-      }
-    }
-    if (error.statusCode === 426) {
-      return {
-        category: 'version_incompatible',
-        message: error.serverError ?? 'App update required',
-        retryable: false
-      }
-    }
-    if (error.statusCode === 413) {
-      // 413 covers three different problems. STORAGE_FILE_TOO_LARGE means this
-      // one file is over the plan's per-file limit; STORAGE_QUOTA_EXCEEDED
-      // means the account is out of storage; anything else (the body-limit
-      // middleware's VALIDATION_BODY_TOO_LARGE, or a bare edge-proxy 413) means
-      // a single payload is too big. Real quota responses always carry their
-      // code, so only they may report "storage full" — anything else would send
-      // the user to free up space, which never fixes a payload problem.
-      if (
-        error.serverError?.includes('STORAGE_FILE_TOO_LARGE') ||
-        error.message.includes('STORAGE_FILE_TOO_LARGE')
-      ) {
-        return {
-          category: 'file_too_large',
-          message: 'This file is larger than your plan allows',
-          retryable: false
-        }
-      }
-      if (
-        error.serverError?.includes('STORAGE_QUOTA_EXCEEDED') ||
-        error.message.includes('STORAGE_QUOTA_EXCEEDED')
-      ) {
-        return {
-          category: 'storage_quota_exceeded',
-          message: 'Storage quota exceeded',
-          retryable: false
-        }
-      }
-      return {
-        category: 'note_too_large',
-        message: 'A note is too large to sync',
-        retryable: false
-      }
-    }
-    if (error.statusCode === 429) {
-      return {
-        category: 'rate_limited',
-        message: error.message,
-        retryable: true
-      }
-    }
-    if (error.statusCode >= 500) {
-      return {
-        category: 'server_error',
-        message: error.serverError ?? error.message,
-        retryable: true
-      }
-    }
+    // The label is deliberately unchanged: `category` drives the renderer's
+    // error banner and every existing telemetry dashboard. What was missing
+    // ships beside it — the exact status and the server's own error code, which
+    // is what separates a permanent 400 VALIDATION_ERROR from a transient 503
+    // and made `server_error` an undiagnosable catch-all (#1584).
     return {
-      category: 'server_error',
-      message: error.serverError ?? error.message,
-      retryable: false
+      ...classifyServerError(error),
+      statusCode: error.statusCode,
+      serverCode: serverErrorCode(error)
     }
   }
 
@@ -145,5 +94,95 @@ export function classifyError(error: unknown): SyncErrorInfo {
     category: 'unknown',
     message,
     retryable: true
+  }
+}
+
+/**
+ * The category/message/retryable half of a server failure. Split out of
+ * `classifyError` so the status and server code can be attached at one place
+ * rather than repeated across every branch; the branch logic itself is
+ * unchanged.
+ */
+function classifyServerError(error: SyncServerError): SyncErrorInfo {
+  if (error.statusCode === 401) {
+    return {
+      category: 'auth_expired',
+      message: 'Session expired',
+      retryable: false
+    }
+  }
+  if (error.statusCode === 403 && error.serverError?.includes('AUTH_DEVICE_REVOKED')) {
+    return {
+      category: 'device_revoked',
+      message: 'This device has been removed',
+      retryable: false
+    }
+  }
+  if (error.statusCode === 402 || error.serverError?.includes('SYNC_PAYMENT_REQUIRED')) {
+    return {
+      category: 'sync_payment_required',
+      message: 'A paid Sync plan is required',
+      retryable: false
+    }
+  }
+  if (error.statusCode === 426) {
+    return {
+      category: 'version_incompatible',
+      message: error.serverError ?? 'App update required',
+      retryable: false
+    }
+  }
+  if (error.statusCode === 413) {
+    // 413 covers three different problems. STORAGE_FILE_TOO_LARGE means this
+    // one file is over the plan's per-file limit; STORAGE_QUOTA_EXCEEDED
+    // means the account is out of storage; anything else (the body-limit
+    // middleware's VALIDATION_BODY_TOO_LARGE, or a bare edge-proxy 413) means
+    // a single payload is too big. Real quota responses always carry their
+    // code, so only they may report "storage full" — anything else would send
+    // the user to free up space, which never fixes a payload problem.
+    if (
+      error.serverError?.includes('STORAGE_FILE_TOO_LARGE') ||
+      error.message.includes('STORAGE_FILE_TOO_LARGE')
+    ) {
+      return {
+        category: 'file_too_large',
+        message: 'This file is larger than your plan allows',
+        retryable: false
+      }
+    }
+    if (
+      error.serverError?.includes('STORAGE_QUOTA_EXCEEDED') ||
+      error.message.includes('STORAGE_QUOTA_EXCEEDED')
+    ) {
+      return {
+        category: 'storage_quota_exceeded',
+        message: 'Storage quota exceeded',
+        retryable: false
+      }
+    }
+    return {
+      category: 'note_too_large',
+      message: 'A note is too large to sync',
+      retryable: false
+    }
+  }
+  if (error.statusCode === 429) {
+    return {
+      category: 'rate_limited',
+      message: error.message,
+      retryable: true
+    }
+  }
+  if (error.statusCode >= 500) {
+    return {
+      category: 'server_error',
+      message: error.serverError ?? error.message,
+      retryable: true
+    }
+  }
+  return {
+    category: 'server_error',
+    message: error.serverError ?? error.message,
+    retryable: false
   }
 }

--- a/apps/desktop/src/main/telemetry/client.ts
+++ b/apps/desktop/src/main/telemetry/client.ts
@@ -6,7 +6,10 @@ import type {
   TelemetryPlatform,
   TelemetrySyncState
 } from '@memry/contracts/telemetry-api'
-import { sanitizeTelemetryDimensions } from '@memry/contracts/telemetry-api'
+import {
+  sanitizeTelemetryDimensions,
+  sanitizeTelemetryFailure
+} from '@memry/contracts/telemetry-api'
 
 import { createLogger } from '../lib/logger'
 import { createQueueStore } from './queue-store'
@@ -126,7 +129,13 @@ export const createTelemetryClient = (deps: TelemetryClientDeps): TelemetryClien
   const track = (event: TelemetryEvent): void => {
     if (!enabled) return
     const dimensions = sanitizeTelemetryDimensions(event.dimensions)
-    const safe = dimensions === event.dimensions ? event : { ...event, dimensions }
+    // Same chokepoint, same reason: a failure detail that would fail schema
+    // validation must lose its own field, never the whole batch it rides in.
+    const failure = sanitizeTelemetryFailure(event.failure)
+    const safe =
+      dimensions === event.dimensions && failure === event.failure
+        ? event
+        : { ...event, dimensions, failure }
     queue.push(safe)
     trimQueue()
     persistAppend(safe)

--- a/apps/desktop/src/main/telemetry/track.ts
+++ b/apps/desktop/src/main/telemetry/track.ts
@@ -37,6 +37,8 @@ export interface TrackMainEventOptions {
   }
   dimensions?: Record<string, string>
   error?: TelemetryEvent['error']
+  /** Bounded HTTP status / server code / retryable for a failed request (#1584). */
+  failure?: TelemetryEvent['failure']
 }
 
 /**
@@ -57,7 +59,8 @@ export const trackMainEvent = (name: TelemetryEventName, options: TrackMainEvent
       errorCode: options.errorCode,
       metrics: options.metrics,
       dimensions: options.dimensions,
-      error: options.error
+      error: options.error,
+      failure: options.failure
     }
     const runtime = getTelemetryRuntime()
     if (!runtime) {

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -159,6 +159,42 @@ validates `/telemetry/batch` with that schema and rejects a whole batch on one b
 narrowing it would make a newly deployed server 400 batches sent by already-shipped desktop
 builds. The allowlist is enforced on the client, where the data still is.
 
+#### Failure detail on a failed request
+
+An event that reports a failed HTTP request may also carry a `failure` object
+(`TelemetryFailureDetailSchema`) with three bounded fields:
+
+| Field        | Shape                                        | PostHog property |
+| ------------ | -------------------------------------------- | ---------------- |
+| `httpStatus` | integer 100–599                              | `http_status`    |
+| `serverCode` | the server's `SCREAMING_SNAKE` `error.code`  | `server_code`    |
+| `retryable`  | boolean — was the failure classified retryable | `retryable`     |
+
+This exists because `sync_error` used to ship one opaque `server_error` label covering 400, 403,
+404, 409 and every 5xx alike (#1584): a permanent client-side contract bug and a transient edge 5xx
+were the same row, so no chart separated them and no alert threshold could be set. The label is
+unchanged — `error_code` still reads `server_error` — and these fields sit beside it, so
+`error_code='server_error' AND http_status >= 500` now answers "is the backend down?" and
+`retryable=false` answers "how many of these will never succeed?".
+
+An absent `server_code` on a 5xx is itself the signal: the response never reached the Worker's
+error handler, so it came from the edge and the backend has no record of it.
+
+It is a field of its own rather than a dimension for two reasons. An event may carry at most **one**
+dimension and `sync_error` already spends it on `transport`; and unlike a dimension value, every
+field here is bounded by construction (a 3-digit range, an anchored enum-ish token, a boolean), so
+it can never become a free-text channel. `sanitizeTelemetryFailure` runs at the same
+`createTelemetryClient.track()` chokepoint as the dimension allowlist and drops any field that
+would fail validation — one bad field must never cost the whole batch.
+
+The schema addition is optional and additive in both directions: an older desktop simply omits it,
+and a sync-server on older contracts strips the unknown key rather than rejecting the batch, so
+neither deploy order can 400 events from an already-shipped build.
+
+On the desktop the fields are assembled in one place —
+`apps/desktop/src/main/sync/sync-error-telemetry.ts` — from what `classifyError` already computed,
+so a new `sync_error` call site cannot forward the category and forget the rest.
+
 Because `warn`/`error` log records ship too (Path A, see [What Ships](#what-ships) and
 [Error & Diagnostic Logs in PostHog](#error-diagnostic-logs-in-posthog)), the same rule applies to
 log lines and thrown error messages in content-handling code: the inbox scraper
@@ -227,7 +263,7 @@ offline quit never stalls the exit.
 | Voice           | `voice_recording_completed` (duration + bytes), `transcription_completed` (success/failure + processing duration)                                                                                                                |
 | Settings        | `setting_changed` — surface only, never the value                                                                                                                                                                                |
 | Agent chat      | `agent_chat_started`, `agent_chat_message_sent`, `ai_action_completed` (turn result + duration)                                                                                                                                  |
-| Sync health     | `sync_enabled`, `sync_run_completed`, `sync_error` (counts/status only)                                                                                                                                                          |
+| Sync health     | `sync_enabled`, `sync_run_completed`, `sync_error` (counts/status only, plus the [failure detail](#failure-detail-on-a-failed-request))                                                                                           |
 | Auth            | `signin_started`, `signin_succeeded`                                                                                                                                                                                             |
 | Diagnostics     | `app_log_recorded`, `app_error_seen`, `app_launch_phase_completed`, `app_crashed` (see [Crash & Unclean-Shutdown Detection](#crash-unclean-shutdown-detection))                                                                  |
 
@@ -653,7 +689,10 @@ detail (stacks, operational messages) that a PostHog _event_ deliberately omits.
   redaction as a backstop) and **redacted stack frames**, `log_action` — the operational
   breadcrumb that keeps log-type error events (which carry no stack of their own) identifiable —
   and `exit_code`, the platform exit status for process-lifecycle events (empty string when
-  absent, since exit code `0` is itself meaningful).
+  absent, since exit code `0` is itself meaningful). A failed request additionally contributes
+  `http_status`, `server_code` and `retryable` (see
+  [Failure detail on a failed request](#failure-detail-on-a-failed-request)) — also empty string
+  when absent, because `retryable: false` is a real answer and must not read as "not reported".
 - **Redacted diagnostic logs (`kind=log`, Path A, always-on)**: a main-process electron-log
   transport (`apps/desktop/src/main/telemetry/log-ship.ts`, installed once from `main/index.ts` —
   never from `logger.ts`, which must stay electron-free for worker bundling) intercepts every

--- a/apps/sync-server/src/services/posthog-logs.test.ts
+++ b/apps/sync-server/src/services/posthog-logs.test.ts
@@ -204,8 +204,35 @@ describe('desktopErrorRecord', () => {
       component_stack: 'at NoteEditor',
       install_hash: 'hash123',
       log_action: '',
-      exit_code: ''
+      exit_code: '',
+      http_status: '',
+      server_code: '',
+      retryable: ''
     })
+  })
+
+  // #1584: `sync_error` shipped `error_code: 'server_error'` with `"message":""`
+  // and nothing else — 296 production rows in one 48-hour window that could only
+  // be split by hand-joining sync-server logs.
+  it('carries the status, the server code and the retryable verdict for a sync failure', () => {
+    const syncEvent: TelemetryEvent = {
+      ...event,
+      name: 'sync_error',
+      surface: 'sync',
+      action: 'push_failed',
+      source: 'push',
+      errorCode: 'server_error',
+      failure: { httpStatus: 400, serverCode: 'VALIDATION_ERROR', retryable: false },
+      error: { message: 'VALIDATION_ERROR: Invalid push request' }
+    }
+    const result = desktopErrorRecord(batch, syncEvent, 'hash123')
+
+    expect(result.line.http_status).toBe(400)
+    expect(result.line.server_code).toBe('VALIDATION_ERROR')
+    // `false` is a real answer — "this push will never succeed" — so it must not
+    // be flattened into the "not reported" empty string.
+    expect(result.line.retryable).toBe(false)
+    expect(result.line.message).toBe('VALIDATION_ERROR: Invalid push request')
   })
 
   it('redacts event.error.message on the line when present, and the raw value does not survive', () => {

--- a/apps/sync-server/src/services/posthog-logs.ts
+++ b/apps/sync-server/src/services/posthog-logs.ts
@@ -112,6 +112,13 @@ export const desktopErrorRecord = (
     stack: event.error?.stack ?? '',
     component_stack: event.error?.componentStack ?? '',
     install_hash: distinctId,
+    // The queryable half of a failed request (#1584). Empty string when absent,
+    // same convention as exit_code — and for `retryable` that matters, because
+    // `false` is a real answer ("this will never succeed") that must not read
+    // as "not reported".
+    http_status: event.failure?.httpStatus ?? '',
+    server_code: event.failure?.serverCode ?? '',
+    retryable: event.failure?.retryable ?? '',
     // Log-type error events (app_log_recorded) have no stack; log_action is
     // what makes them identifiable in Grafana (e.g. child_process_gone).
     log_action: event.dimensions?.log_action ?? '',

--- a/apps/sync-server/src/services/posthog-transform.test.ts
+++ b/apps/sync-server/src/services/posthog-transform.test.ts
@@ -191,6 +191,61 @@ describe('productEvent', () => {
     const result = productEvent(batchFixture(), eventFixture(), ctx)
     expect(result.properties).not.toHaveProperty('error_code')
     expect(result.properties).not.toHaveProperty('object_type')
+    expect(result.properties).not.toHaveProperty('http_status')
+    expect(result.properties).not.toHaveProperty('server_code')
+    expect(result.properties).not.toHaveProperty('retryable')
+  })
+
+  // #1584: a 400 VALIDATION_ERROR and a 503 with no server code both shipped as
+  // the single label `server_error`, so no chart and no alert threshold could
+  // separate "our contract is broken" from "the edge is having a bad day".
+  it('flattens the failure detail so a 4xx and a 5xx are different rows', () => {
+    const clientFailure = productEvent(
+      batchFixture(),
+      eventFixture({
+        name: 'sync_error',
+        surface: 'sync',
+        action: 'push_failed',
+        errorCode: 'server_error',
+        failure: { httpStatus: 400, serverCode: 'VALIDATION_ERROR', retryable: false }
+      }),
+      ctx
+    )
+    const serverFailure = productEvent(
+      batchFixture(),
+      eventFixture({
+        name: 'sync_error',
+        surface: 'sync',
+        action: 'pull_failed',
+        errorCode: 'server_error',
+        failure: { httpStatus: 503, retryable: true }
+      }),
+      ctx
+    )
+
+    expect(clientFailure.properties.http_status).toBe(400)
+    expect(clientFailure.properties.server_code).toBe('VALIDATION_ERROR')
+    expect(clientFailure.properties.retryable).toBe(false)
+
+    expect(serverFailure.properties.http_status).toBe(503)
+    expect(serverFailure.properties).not.toHaveProperty('server_code')
+    expect(serverFailure.properties.retryable).toBe(true)
+
+    // The old label is deliberately unchanged, so dashboards built on it keep working.
+    expect(clientFailure.properties.error_code).toBe('server_error')
+    expect(serverFailure.properties.error_code).toBe('server_error')
+  })
+
+  it('does not let a client dimension override the failure detail', () => {
+    const result = productEvent(
+      batchFixture(),
+      eventFixture({
+        dimensions: { http_status: '200' },
+        failure: { httpStatus: 500, retryable: true }
+      }),
+      ctx
+    )
+    expect(result.properties.http_status).toBe(500)
   })
 
   it('does not let a client-supplied "environment" dimension override ctx.environment', () => {

--- a/apps/sync-server/src/services/posthog-transform.ts
+++ b/apps/sync-server/src/services/posthog-transform.ts
@@ -136,6 +136,22 @@ export const productEvent = (
     if (typeof value === 'number') properties[to] = value
   }
 
+  // Flat properties, not a nested object: PostHog breaks down and thresholds on
+  // top-level properties, and the whole point of #1584 is that
+  // `error_code='server_error'` alone could not answer "was this a permanent
+  // 400 or a transient 503" or "how many of these will never succeed". Written
+  // after the dimensions loop like every other server-derived property, so a
+  // client cannot spoof them.
+  if (event.failure) {
+    if (typeof event.failure.httpStatus === 'number') {
+      properties.http_status = event.failure.httpStatus
+    }
+    if (event.failure.serverCode) properties.server_code = event.failure.serverCode
+    if (typeof event.failure.retryable === 'boolean') {
+      properties.retryable = event.failure.retryable
+    }
+  }
+
   return {
     event: EVENT_NAME_OVERRIDES[event.name] ?? event.name,
     distinct_id: resolveDistinctId(ctx),

--- a/packages/contracts/src/telemetry-api.test.ts
+++ b/packages/contracts/src/telemetry-api.test.ts
@@ -7,11 +7,13 @@ import {
   TelemetryErrorDetailSchema,
   TelemetryEventNameSchema,
   TelemetryEventSchema,
+  TelemetryFailureDetailSchema,
   TelemetrySurfaceSchema,
   buildErrorDetail,
   normalizeRejectionReason,
   normalizeWindowError,
   sanitizeTelemetryDimensions,
+  sanitizeTelemetryFailure,
   toErrorCode
 } from './telemetry-api'
 
@@ -1027,5 +1029,78 @@ describe('sanitizeTelemetryDimensions', () => {
     for (const key of TELEMETRY_DIMENSION_KEYS) {
       expect(TelemetryDimensionsSchema.safeParse({ [key]: 'ok' }).success).toBe(true)
     }
+  })
+})
+
+// #1584: `sync_error` carried one opaque `server_error` label with no status and
+// no server code, so a permanent 400 and a transient edge 5xx were the same row.
+describe('TelemetryFailureDetailSchema', () => {
+  it('accepts a bounded status, server code and retryable verdict', () => {
+    expect(
+      TelemetryFailureDetailSchema.safeParse({
+        httpStatus: 400,
+        serverCode: 'VALIDATION_ERROR',
+        retryable: false
+      }).success
+    ).toBe(true)
+  })
+
+  it('rejects anything that could turn the server code into free text', () => {
+    for (const serverCode of [
+      'Invalid push request',
+      'validation_error',
+      '/Users/kaan/vault/note.md',
+      'kaan@example.com',
+      'A'.repeat(65)
+    ]) {
+      expect(TelemetryFailureDetailSchema.safeParse({ serverCode }).success).toBe(false)
+    }
+  })
+
+  it('rejects a status outside the HTTP range', () => {
+    for (const httpStatus of [0, 99, 600, 4.5]) {
+      expect(TelemetryFailureDetailSchema.safeParse({ httpStatus }).success).toBe(false)
+    }
+  })
+
+  // BACKWARD COMPATIBILITY, both directions. An older desktop omits the field —
+  // it is optional, so the batch stays valid. A newer desktop sends it to a
+  // sync-server on older contracts — z.object STRIPS unknown keys rather than
+  // rejecting, so the whole batch is not 400'd and the other events survive.
+  it('leaves an event without a failure detail valid', () => {
+    expect(TelemetryEventSchema.safeParse(baseEvent).success).toBe(true)
+  })
+
+  it('does not reject an event carrying a key the schema does not know', () => {
+    const parsed = TelemetryEventSchema.safeParse({ ...baseEvent, someFutureField: { a: 1 } })
+    expect(parsed.success).toBe(true)
+    expect(parsed.success && 'someFutureField' in parsed.data).toBe(false)
+  })
+})
+
+describe('sanitizeTelemetryFailure', () => {
+  it('passes a valid detail through untouched', () => {
+    const failure = { httpStatus: 503, retryable: true }
+    expect(sanitizeTelemetryFailure(failure)).toBe(failure)
+  })
+
+  it('passes undefined through so the caller can omit the field', () => {
+    expect(sanitizeTelemetryFailure(undefined)).toBeUndefined()
+  })
+
+  // The sync-server rejects an ENTIRE batch when one event fails validation, so
+  // a malformed field must cost that field, never the 99 events queued with it.
+  it('drops only the offending field', () => {
+    expect(
+      sanitizeTelemetryFailure({
+        httpStatus: 400,
+        serverCode: 'Invalid push request' as string,
+        retryable: false
+      })
+    ).toEqual({ httpStatus: 400, retryable: false })
+  })
+
+  it('returns undefined when nothing survives', () => {
+    expect(sanitizeTelemetryFailure({ httpStatus: 42, serverCode: 'nope' })).toBeUndefined()
   })
 })

--- a/packages/contracts/src/telemetry-api.ts
+++ b/packages/contracts/src/telemetry-api.ts
@@ -236,6 +236,70 @@ export const TelemetryErrorDetailSchema = z.object({
   componentStack: z.string().max(2000).optional()
 })
 
+// The sync-server's structured error codes are SCREAMING_SNAKE tokens
+// (VALIDATION_ERROR, AUTH_INVALID_TOKEN, STORAGE_QUOTA_EXCEEDED). Anchored and
+// length-capped so this can never become a free-text channel.
+const SERVER_ERROR_CODE = /^[A-Z][A-Z0-9_]{0,63}$/
+
+/**
+ * The queryable facts about a failed request, split out of the single opaque
+ * `errorCode` label.
+ *
+ * `sync_error` + `server_error` used to cover 400, 403, 404, 409 AND every 5xx
+ * with no status and no server code anywhere in the event (#1584), so a
+ * permanent client-side contract bug and a transient edge 5xx were the same row
+ * in every chart and no alert threshold could tell them apart.
+ *
+ * Every field is bounded by construction — a status code is a 3-digit range, a
+ * server code is an anchored enum-ish token, `retryable` is a boolean — so this
+ * carries no free text and needs none of the gating TELEMETRY_DIMENSION_KEYS
+ * exists for. It is a field of its own rather than a dimension because
+ * `TelemetryDimensionsSchema` admits at most ONE dimension per event and
+ * `sync_error` already spends it on `transport`.
+ *
+ * ADDITIVE ON PURPOSE: a sync-server running older contracts strips this key
+ * (z.object strips unknown keys, it does not reject), so a desktop build that
+ * sends it never costs the other events in its batch. An older desktop that
+ * omits it stays valid for the same reason — the field is optional.
+ */
+export const TelemetryFailureDetailSchema = z.object({
+  httpStatus: z.number().int().min(100).max(599).optional(),
+  serverCode: z.string().regex(SERVER_ERROR_CODE).optional(),
+  retryable: z.boolean().optional()
+})
+
+/**
+ * Reduce a caller-supplied failure detail to what is allowed to ship: each field
+ * survives only if it still satisfies `TelemetryFailureDetailSchema`.
+ *
+ * Drops rather than rejects, for exactly the reason `sanitizeTelemetryDimensions`
+ * does: the sync-server rejects the ENTIRE batch when one event fails
+ * validation, so a malformed status or code must cost that one field, never the
+ * other 99 events queued behind it. Returns the input untouched when there is
+ * nothing to drop.
+ */
+export const sanitizeTelemetryFailure = (
+  failure: z.infer<typeof TelemetryFailureDetailSchema> | undefined
+): z.infer<typeof TelemetryFailureDetailSchema> | undefined => {
+  if (!failure) return failure
+  if (TelemetryFailureDetailSchema.safeParse(failure).success) return failure
+  const safe: z.infer<typeof TelemetryFailureDetailSchema> = {}
+  const { httpStatus, serverCode, retryable } = failure
+  if (
+    typeof httpStatus === 'number' &&
+    Number.isInteger(httpStatus) &&
+    httpStatus >= 100 &&
+    httpStatus <= 599
+  ) {
+    safe.httpStatus = httpStatus
+  }
+  if (typeof serverCode === 'string' && SERVER_ERROR_CODE.test(serverCode)) {
+    safe.serverCode = serverCode
+  }
+  if (typeof retryable === 'boolean') safe.retryable = retryable
+  return Object.keys(safe).length > 0 ? safe : undefined
+}
+
 export const TelemetryEventSchema = z.object({
   id: z.string().uuid(),
   name: TelemetryEventNameSchema,
@@ -248,7 +312,8 @@ export const TelemetryEventSchema = z.object({
   errorCode: SafeDimensionValueSchema.optional(),
   dimensions: TelemetryDimensionsSchema.optional(),
   metrics: TelemetryMetricsSchema.optional(),
-  error: TelemetryErrorDetailSchema.optional()
+  error: TelemetryErrorDetailSchema.optional(),
+  failure: TelemetryFailureDetailSchema.optional()
 })
 
 export const TelemetryBatchSchema = z.object({
@@ -276,6 +341,7 @@ export type TelemetrySyncState = z.infer<typeof TelemetrySyncStateSchema>
 export type TelemetryPlatform = z.infer<typeof TelemetryPlatformSchema>
 export type TelemetryMetrics = z.infer<typeof TelemetryMetricsSchema>
 export type TelemetryErrorDetail = z.infer<typeof TelemetryErrorDetailSchema>
+export type TelemetryFailureDetail = z.infer<typeof TelemetryFailureDetailSchema>
 export type TelemetryEvent = z.infer<typeof TelemetryEventSchema>
 export type TelemetryBatch = z.infer<typeof TelemetryBatchSchema>
 


### PR DESCRIPTION
## What was undiagnosable, and why

`sync_error` with `error_code: server_error` could not be acted on. `classifyError`
funnelled 400, 403-without-a-code, 404, 409 **and every 5xx** into one label, and all 296
observed production bodies shipped `"message":""`.

Two unrelated root causes shared that bucket in one 48-hour window, and only a hand-join
against sync-server logs separated them: a permanent client-side `400 VALIDATION_ERROR`
(imported Google Calendar events pushed without a clock, `retryable: false`, dead forever)
and 218 client-observed failures the backend has **no record of at all** — edge 5xx that
never reached the Worker's error handler.

The detail was never missing, only discarded. `SyncServerError` carries `statusCode` and
`serverError`; `classifyError` computed a `message` and a `retryable` verdict. Every emitter
forwarded `errorInfo.category` alone, and the message went to `recordHistory` — local,
in-memory, never leaves the device. **That is the root cause of `"message":""`**:
`desktopErrorRecord` (`apps/sync-server/src/services/posthog-logs.ts:111`) writes
`event.error?.message ? redactText(...) : ''`, and no `sync_error` emitter ever populated
`event.error`, so the field defaulted to the empty string on every single row.

## What changed

**Contract (additive)** — `TelemetryFailureDetailSchema`: `httpStatus` (int 100–599),
`serverCode` (anchored `^[A-Z][A-Z0-9_]{0,63}$`), `retryable` (boolean), hung off
`TelemetryEventSchema` as an optional `failure`. Not a dimension: an event may carry at most
**one** dimension and `sync_error` already spends it on `transport`. Every field is bounded
by construction, so it can never become the free-text channel `TELEMETRY_DIMENSION_KEYS`
exists to prevent (#1142).

**Desktop** — `SyncErrorInfo` gains `statusCode` / `serverCode`; the server branch of
`classifyError` was extracted verbatim into `classifyServerError` so the two new facts attach
at one place instead of eight returns. The server code is read from both shapes it arrives in
(`CODE: message` from `http-client`, raw JSON body from the attachment upload paths). New
`sync-error-telemetry.ts` assembles the fields once, so a future emitter cannot ship the
category and forget the rest. Wired into the five emitters that can produce `server_error`
(`push-coordinator`, `pull-coordinator`, and the three in `engine.ts`).

**Message** — `classifyError`'s message now ships as `error.message`, run through `redactText`
with `getMainRedactOptions()` (the same salted options diagnostics and log shipping use, so
placeholders correlate across an incident) and capped at the schema's 512 chars **on the
device**.

**Request leg preserved** — `source` (`push` / `pull` / `full`) and `action`
(`push_failed` / `pull_failed` / `full_failed`) are untouched, so the pull-vs-push split the
issue reports on still works.

**Sync-server** — `productEvent` flattens the detail to `http_status` / `server_code` /
`retryable`, written after the client-dimension loop so it cannot be spoofed;
`desktopErrorRecord` adds the same three to the log line (empty string when absent — `false`
is a real answer and must not read as "not reported").

**Edge attribution** — an edge 5xx already reaches `classifyError` as
`SyncServerError('Server returned 502', 502)` with no `serverError`. It now ships
`http_status: 502` with **no** `server_code`, and that absence is the signal: no structured
code means it never reached our Worker.

## Backward compatibility

- **`error_code` is unchanged.** `server_error` still covers 4xx and 5xx; the new fields sit
  beside it. Every existing dashboard, alert and saved query keeps returning exactly what it
  returned before. Splitting the label would also have meant new `SyncErrorCategory` values in
  the IPC contract and new renderer error-banner branches — out of scope for a diagnosability
  fix.
- **Both deploy orders are safe.** The field is optional, so an older desktop that omits it
  stays valid against a newly deployed server. A newer desktop sending it to a server on older
  contracts is also safe — `z.object` **strips** unknown keys rather than rejecting, so the
  batch is not 400'd and no sibling events are lost. Pinned by a test.
- `sanitizeTelemetryFailure` runs at the same `createTelemetryClient.track()` chokepoint as
  `sanitizeTelemetryDimensions`, dropping any field that would fail validation. One malformed
  value costs that field, never the 99 events queued behind it.

## Reading the new dimensions in PostHog

```sql
-- "how many sync failures were permanent?", split by leg and status class,
-- with no join against sync-server logs
SELECT toDate(timestamp)                                   AS d,
       properties.source                                   AS leg,
       intDiv(toInt32(properties.http_status), 100)        AS status_class,
       properties.server_code                              AS server_code,
       properties.retryable                                AS retryable,
       count()                                             AS c
FROM events
WHERE event = 'sync_error'
  AND properties.error_code = 'server_error'
  AND timestamp >= now() - INTERVAL 14 DAY
GROUP BY d, leg, status_class, server_code, retryable
ORDER BY d, c DESC;
```

The two 2026-08 causes now separate on sight: cause A is
`status_class = 4, server_code = 'VALIDATION_ERROR', retryable = false`; cause B is
`status_class = 5, server_code = '' , retryable = true` — a code-less 5xx the backend never
saw. An alert can finally threshold on `http_status >= 500` alone.

The log line carries the same three fields, so
`JSONExtractInt(body,'http_status')` / `JSONExtractString(body,'server_code')` work in the
`logs` table too, alongside a now non-empty `message`.

## Verification

| Command | Result |
| --- | --- |
| `pnpm --filter @memry/desktop typecheck:node` | pass |
| `pnpm --filter @memry/desktop typecheck:test` | `typecheck:test:node` pass; `typecheck:test:web` fails on `sidebar-nav.test.tsx` (`onNavMiddleClick`) — pre-existing on `main`, no sidebar file in this diff |
| `pnpm lint` | pass — 0 errors, 97 pre-existing warnings, none in the touched files |
| `vitest --project main src/main/sync` | 156 files, 2301 passed |
| `vitest --project main src/main/sync/engine src/main/telemetry` | 29 files, 456 passed |
| `vitest --project shared packages/contracts/src/telemetry-api.test.ts` | 83 passed |
| `pnpm test:sync-server` | 62 files, 953 passed |
| `pnpm ipc:generate` + `pnpm ipc:check` | up to date, no diff |
| `pnpm docs:impact --base origin/main --strict` | pass |
| `pnpm docs:build` | pass |

New tests pin that a 400, a 503 and a known-code 413 produce three distinguishable events,
each with a non-empty message; that a home path in a message is redacted before it ships; that
an over-long message is capped at 512; that a malformed `serverCode` loses only its own field;
and that an unknown key on an event is stripped, not rejected.

## Deliberately not done

- `error-recovery-handler.ts`'s two emitters (`device_revoked`, `certificate_pin_failed`) and
  the seven fixed-code emitters in `websocket` / `runtime` / `queue` / the coordinators keep
  their existing shape. Their codes are already specific and none of them has an HTTP status
  to report.
- No new `sync_error` emitter for requests that never leave the device — those already
  classify as `network_offline`, which is a different bucket, not a missing one.

Fixes #1584
