### PR TITLE
fix(updater): report being offline as a warning, not an app error

### DIFF
--- a/apps/desktop/src/main/telemetry/diagnostics.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.ts
@@ -94,6 +94,30 @@ export const trackMainError = (source: string, action: string, error: unknown): 
   })
 }
 
+/**
+ * Report a failure that is a normal condition rather than a defect: it stays
+ * fully queryable as an `app_log_recorded` `warn`, but never lands in Error
+ * Tracking. Same error-code derivation and same on-device redaction as
+ * trackMainError — only the severity moves, so nothing is lost by the demotion
+ * and the volume itself is still the diagnostic (issue #1587).
+ */
+export const trackMainWarning = (
+  source: string,
+  action: string,
+  error: unknown,
+  metrics?: { retryCount?: number }
+): void => {
+  if (isExpectedConditionError(error)) return
+
+  trackMainLog('warn', {
+    scope: source,
+    action,
+    errorCode: toErrorCode(error),
+    error: buildErrorDetail(error, undefined, getMainRedactOptions()),
+    metrics
+  })
+}
+
 // A rejection reason can be any value — a string, a plain object, or a
 // cross-realm Error that fails `instanceof Error` — and those carry no stack,
 // landing in telemetry as an unactionable bare `Error` with an empty stack.

--- a/apps/desktop/src/main/updater-error-severity.test.ts
+++ b/apps/desktop/src/main/updater-error-severity.test.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { UpdaterErrorPhase } from './updater'
+import {
+  classifyUpdaterError,
+  isUpdaterCheckPhase,
+  recordUpdaterCheckFailure,
+  recordUpdaterCheckSuccess,
+  resetUpdaterCheckHealth,
+  type UpdaterErrorSeverity
+} from './updater-error-severity'
+
+// Every message below is the verbatim production shape from issue #1587's
+// PostHog window (2026-08-09 → 2026-08-19), not an invented sample.
+const netError = (code: string): Error => new Error(code)
+
+const invalidReleaseFeed = (cause: string): Error =>
+  Object.assign(
+    new Error(
+      `Cannot parse releases feed: Error: Unable to find latest version on GitHub ` +
+        `(https://github.com/memrynote/memry/releases/latest), please ensure a production ` +
+        `release exists: Error: ${cause}`
+    ),
+    { code: 'ERR_UPDATER_INVALID_RELEASE_FEED' }
+  )
+
+interface Case {
+  name: string
+  error: unknown
+  expected: UpdaterErrorSeverity
+}
+
+const CHECK_PHASE: UpdaterErrorPhase = 'check'
+
+describe('classifyUpdaterError', () => {
+  // 917 of the 1,043 noisy production events were a bare code from this list.
+  const transient: Case[] = [
+    'net::ERR_NAME_NOT_RESOLVED',
+    'net::ERR_INTERNET_DISCONNECTED',
+    'net::ERR_NETWORK_CHANGED',
+    'net::ERR_TIMED_OUT',
+    'net::ERR_CONNECTION_TIMED_OUT',
+    'net::ERR_CONNECTION_RESET',
+    'net::ERR_CONNECTION_CLOSED',
+    'net::ERR_CONNECTION_REFUSED',
+    'net::ERR_NETWORK_IO_SUSPENDED',
+    'net::ERR_HTTP2_PROTOCOL_ERROR',
+    'net::ERR_HTTP2_SERVER_REFUSED_STREAM'
+  ].map((code) => ({ name: code, error: netError(code), expected: 'warn' as const }))
+
+  const wrapped: Case[] = [
+    {
+      // 30 of 30 ERR_UPDATER_INVALID_RELEASE_FEED events carried a network cause:
+      // GitHubProvider wraps a transport failure in a parse-shaped message.
+      name: 'ERR_UPDATER_INVALID_RELEASE_FEED wrapping net::ERR_NETWORK_CHANGED',
+      error: invalidReleaseFeed('net::ERR_NETWORK_CHANGED'),
+      expected: 'warn'
+    },
+    {
+      name: 'ERR_UPDATER_INVALID_RELEASE_FEED wrapping net::ERR_TIMED_OUT',
+      error: invalidReleaseFeed('net::ERR_TIMED_OUT'),
+      expected: 'warn'
+    },
+    {
+      name: 'transport failure carried on the cause chain instead of the message',
+      error: Object.assign(new Error('Cannot parse releases feed'), {
+        code: 'ERR_UPDATER_INVALID_RELEASE_FEED',
+        cause: new Error('net::ERR_INTERNET_DISCONNECTED')
+      }),
+      expected: 'warn'
+    },
+    {
+      // The load-bearing negative: a feed that is genuinely malformed has no
+      // network cause anywhere in the chain and must stay an exception.
+      name: 'ERR_UPDATER_INVALID_RELEASE_FEED with a parse-only cause',
+      error: Object.assign(new Error('Cannot parse releases feed'), {
+        code: 'ERR_UPDATER_INVALID_RELEASE_FEED',
+        cause: new SyntaxError('end of the stream or a document separator is expected')
+      }),
+      expected: 'error'
+    }
+  ]
+
+  const stillErrors: Case[] = [
+    {
+      // 27 of 27 were `jwt:expired` on GitHub's pre-signed asset URLs. Delivery
+      // side, not the user's link — it must stay visible in Error Tracking.
+      name: 'HTTP_ERROR_618 jwt:expired on a signed release-asset URL',
+      error: Object.assign(
+        new Error(
+          'Cannot download "https://release-assets.githubusercontent.com/github-production-release-asset/x", status 618: jwt:expired'
+        ),
+        { name: 'HttpError', code: 'HTTP_ERROR_618', statusCode: 618 }
+      ),
+      expected: 'error'
+    },
+    {
+      name: 'a 404 release feed',
+      error: Object.assign(new Error('Cannot download "https://x.test/latest.yml", status 404'), {
+        name: 'HttpError',
+        code: 'ERR_UPDATER_LATEST_VERSION_NOT_FOUND',
+        statusCode: 404
+      }),
+      expected: 'error'
+    },
+    {
+      // A server that answered is never "the user is offline", even when a
+      // retry wrapper stitched a transport code into the same message.
+      name: 'a 5xx that also mentions a transient transport code',
+      error: Object.assign(new Error('status 503, retry after net::ERR_CONNECTION_RESET'), {
+        name: 'HttpError',
+        statusCode: 503
+      }),
+      expected: 'error'
+    },
+    {
+      // A certificate failure is a security signal, never noise — the reason the
+      // transient set is an allowlist and not a `net::ERR_` prefix test.
+      name: 'net::ERR_CERT_AUTHORITY_INVALID',
+      error: netError('net::ERR_CERT_AUTHORITY_INVALID'),
+      expected: 'error'
+    },
+    {
+      name: 'net::ERR_SSL_PROTOCOL_ERROR',
+      error: netError('net::ERR_SSL_PROTOCOL_ERROR'),
+      expected: 'error'
+    },
+    {
+      // Fail closed: a code we have never reasoned about is not "normal".
+      name: 'an unrecognised net::ERR_SOMETHING_NEW',
+      error: netError('net::ERR_SOMETHING_NEW'),
+      expected: 'error'
+    },
+    {
+      name: 'a transient code accompanied by a certificate failure in the chain',
+      error: Object.assign(new Error('net::ERR_TIMED_OUT'), {
+        cause: new Error('net::ERR_CERT_DATE_INVALID')
+      }),
+      expected: 'error'
+    },
+    {
+      name: 'signature verification failure',
+      error: new Error('New version is not signed by the application owner'),
+      expected: 'error'
+    },
+    {
+      name: 'ENOENT app-update.yml (a repackaged build with no update config)',
+      error: Object.assign(
+        new Error("ENOENT: no such file or directory, open '/Applications/X.app/app-update.yml'"),
+        { code: 'ENOENT' }
+      ),
+      expected: 'error'
+    },
+    {
+      name: 'a failed install copy',
+      error: new Error('ditto: Could not lstat /Library/Caches/memry.ShipIt/update.HcExUK'),
+      expected: 'error'
+    },
+    { name: 'a non-Error rejection value', error: 'boom', expected: 'error' },
+    { name: 'null', error: null, expected: 'error' }
+  ]
+
+  it.each([...transient, ...wrapped, ...stillErrors])(
+    'reports $name as $expected in the check phase',
+    ({ error, expected }) => {
+      expect(classifyUpdaterError(error, CHECK_PHASE)).toBe(expected)
+    }
+  )
+
+  const checkPhases: UpdaterErrorPhase[] = [
+    'check',
+    'startup-check',
+    'scheduled-check',
+    'auto-check-enable'
+  ]
+  const otherPhases: UpdaterErrorPhase[] = [
+    'download',
+    'downloaded',
+    'install',
+    'auto-download-enable',
+    'idle'
+  ]
+
+  it.each(checkPhases)('demotes a transient failure in the %s phase', (phase) => {
+    expect(isUpdaterCheckPhase(phase)).toBe(true)
+    expect(classifyUpdaterError(netError('net::ERR_INTERNET_DISCONNECTED'), phase)).toBe('warn')
+  })
+
+  // Deliberate narrowing: a network drop mid-download or mid-install can leave a
+  // half-applied update, so it keeps error severity even for a transient code.
+  it.each(otherPhases)('keeps the same failure at error in the %s phase', (phase) => {
+    expect(isUpdaterCheckPhase(phase)).toBe(false)
+    expect(classifyUpdaterError(netError('net::ERR_INTERNET_DISCONNECTED'), phase)).toBe('error')
+  })
+})
+
+describe('stuck-updater escalation', () => {
+  const start = Date.UTC(2026, 7, 19, 9, 0, 0)
+  const DAY = 24 * 60 * 60 * 1000
+
+  beforeEach(() => {
+    resetUpdaterCheckHealth(start)
+  })
+
+  it('stays quiet for one laptop that is offline for an afternoon', () => {
+    // #given six failed checks an hour apart — the 10-minute poll while awake
+    for (let index = 1; index <= 5; index += 1) {
+      expect(recordUpdaterCheckFailure(start + index * 60 * 60 * 1000).stuck).toBe(false)
+    }
+    expect(recordUpdaterCheckFailure(start + 6 * 60 * 60 * 1000)).toEqual({
+      consecutiveFailures: 6,
+      stuck: false
+    })
+  })
+
+  it('escalates once when an install has not completed a check in a day', () => {
+    for (let index = 1; index <= 5; index += 1) {
+      expect(recordUpdaterCheckFailure(start + DAY + index).stuck).toBe(false)
+    }
+    // #then the sixth failure past the 24h window is the one exception raised…
+    expect(recordUpdaterCheckFailure(start + DAY + 6)).toEqual({
+      consecutiveFailures: 6,
+      stuck: true
+    })
+    // #and the streak never floods Error Tracking again
+    expect(recordUpdaterCheckFailure(start + DAY + 7).stuck).toBe(false)
+    expect(recordUpdaterCheckFailure(start + 2 * DAY).stuck).toBe(false)
+  })
+
+  it('does not escalate on the first failed check after a long sleep', () => {
+    // #given a laptop closed for a week, whose first wake-up check fails
+    expect(recordUpdaterCheckFailure(start + 7 * DAY)).toEqual({
+      consecutiveFailures: 1,
+      stuck: false
+    })
+  })
+
+  it('a successful check clears the streak and re-arms the escalation', () => {
+    for (let index = 1; index <= 6; index += 1) {
+      recordUpdaterCheckFailure(start + DAY + index)
+    }
+    recordUpdaterCheckSuccess(start + DAY + 10)
+
+    expect(recordUpdaterCheckFailure(start + DAY + 11)).toEqual({
+      consecutiveFailures: 1,
+      stuck: false
+    })
+    for (let index = 2; index <= 5; index += 1) {
+      expect(recordUpdaterCheckFailure(start + 2 * DAY + index).stuck).toBe(false)
+    }
+    expect(recordUpdaterCheckFailure(start + 2 * DAY + 20).stuck).toBe(true)
+  })
+})

--- a/apps/desktop/src/main/updater-error-severity.ts
+++ b/apps/desktop/src/main/updater-error-severity.ts
@@ -1,0 +1,151 @@
+// Which updater failures are defects and which are just "this laptop is on a
+// train". Every electron-updater `error` event used to become an `app_error_seen`
+// exception, so ordinary connectivity drops made the updater the second-largest
+// error source in the product — 33.2 % of all exception events in the
+// 2026-08-09 → 2026-08-19 window, 88 % of them a bare Chromium `net::ERR_*`
+// (issue #1587). The decision lives here as a pure predicate rather than inline
+// at the reporting site, same precedent as telemetry/expected-conditions.ts.
+//
+// Nothing is dropped: a demoted failure still ships as `app_log_recorded` at
+// `warn`, with the same error code, redacted message and stack. Only the
+// severity — and therefore the Error Tracking membership — moves.
+
+import type { UpdaterErrorPhase } from './updater'
+
+export type UpdaterErrorSeverity = 'warn' | 'error'
+
+/**
+ * Chromium transport codes that mean the device could not reach the network.
+ * An allowlist, never a `net::ERR_` prefix test: a prefix match would also
+ * swallow `net::ERR_CERT_*` / `net::ERR_SSL_*` (a certificate failure is a
+ * security signal) and any future code we have not reasoned about.
+ */
+const TRANSIENT_NETWORK_ERRORS: ReadonlySet<string> = new Set([
+  'net::ERR_NAME_NOT_RESOLVED',
+  'net::ERR_INTERNET_DISCONNECTED',
+  'net::ERR_NETWORK_CHANGED',
+  'net::ERR_TIMED_OUT',
+  'net::ERR_CONNECTION_TIMED_OUT',
+  'net::ERR_CONNECTION_RESET',
+  'net::ERR_CONNECTION_CLOSED',
+  'net::ERR_CONNECTION_REFUSED',
+  // Laptop sleep: the network stack is suspended mid-request.
+  'net::ERR_NETWORK_IO_SUSPENDED',
+  'net::ERR_HTTP2_PROTOCOL_ERROR',
+  'net::ERR_HTTP2_SERVER_REFUSED_STREAM'
+])
+
+/**
+ * Only a background/manual *check* can be demoted. A transport failure during
+ * `download` or `install` is materially worse than one during a poll — it can
+ * leave a half-applied update — so it keeps error severity even when the code
+ * is in the transient set. Deliberate narrowing, not an accident of the data:
+ * 1,038 of the 1,043 noisy production events fired in the check phase.
+ */
+const CHECK_PHASES: ReadonlySet<UpdaterErrorPhase> = new Set<UpdaterErrorPhase>([
+  'check',
+  'startup-check',
+  'scheduled-check',
+  'auto-check-enable'
+])
+
+export const isUpdaterCheckPhase = (phase: UpdaterErrorPhase): boolean => CHECK_PHASES.has(phase)
+
+const NET_ERROR_TOKEN = /net::ERR_[A-Z0-9_]+/g
+const MAX_CAUSE_DEPTH = 4
+
+const errorText = (value: unknown): string => {
+  if (typeof value === 'string') return value
+  if (!value || typeof value !== 'object') return ''
+  const { message, code } = value as { message?: unknown; code?: unknown }
+  return `${typeof message === 'string' ? message : ''} ${typeof code === 'string' ? code : ''}`
+}
+
+/**
+ * Every `net::ERR_*` token in the error and its cause chain. electron-updater's
+ * GitHubProvider wraps a transport failure in a parse-shaped message
+ * (`ERR_UPDATER_INVALID_RELEASE_FEED`: "Cannot parse releases feed: … Error:
+ * net::ERR_NETWORK_CHANGED"), so the outer code says nothing about the real
+ * cause — 30 of 30 in production carried a network cause. Reading the whole
+ * chain is what lets that code be demoted without demoting a feed that is
+ * genuinely malformed.
+ */
+const collectNetErrorTokens = (error: unknown, depth = 0): string[] => {
+  if (!error || depth > MAX_CAUSE_DEPTH) return []
+  const text = errorText(error)
+  const own = text ? [...text.matchAll(NET_ERROR_TOKEN)].map((match) => match[0]) : []
+  const cause = typeof error === 'object' ? (error as { cause?: unknown }).cause : undefined
+  return [...own, ...collectNetErrorTokens(cause, depth + 1)]
+}
+
+/**
+ * `warn` only for a check that failed to reach the network. Fails closed:
+ * anything with no recognised transport code, an unknown `net::ERR_*`, an HTTP
+ * status (a 404 feed, a 618 `jwt:expired` asset URL), a signature failure or an
+ * install-phase errno stays `error`.
+ */
+export const classifyUpdaterError = (
+  error: unknown,
+  phase: UpdaterErrorPhase
+): UpdaterErrorSeverity => {
+  if (!isUpdaterCheckPhase(phase)) return 'error'
+  // A response arrived, so this is not a connectivity drop: the server said no.
+  const status =
+    error && typeof error === 'object' ? (error as { statusCode?: unknown }).statusCode : undefined
+  if (typeof status === 'number') return 'error'
+  const tokens = collectNetErrorTokens(error)
+  if (tokens.length === 0) return 'error'
+  return tokens.every((token) => TRANSIENT_NETWORK_ERRORS.has(token)) ? 'warn' : 'error'
+}
+
+/**
+ * A demoted failure must not make a genuinely stuck updater invisible. One
+ * offline laptop is noise; an install that has not completed a single update
+ * check in a day, while awake and retrying, can no longer receive a fix and is
+ * worth an exception.
+ *
+ * Both conditions are required. Time alone would fire for a machine that slept
+ * through the window and failed its first wake-up check; the failure count
+ * alone would fire for an hour-long coffee-shop outage.
+ */
+const STUCK_CHECK_WINDOW_MS = 24 * 60 * 60 * 1000
+const STUCK_CHECK_FAILURES = 6
+
+interface UpdaterCheckHealth {
+  /** Init time until the first successful check, so a never-succeeding install still ages. */
+  lastSuccessAt: number
+  consecutiveFailures: number
+  stuckReported: boolean
+}
+
+let health: UpdaterCheckHealth = {
+  lastSuccessAt: Date.now(),
+  consecutiveFailures: 0,
+  stuckReported: false
+}
+
+/** Start the stuck-updater clock. Called from initializeUpdater(). */
+export const resetUpdaterCheckHealth = (now = Date.now()): void => {
+  health = { lastSuccessAt: now, consecutiveFailures: 0, stuckReported: false }
+}
+
+/** A check that reached the feed — update available or not — clears the streak. */
+export const recordUpdaterCheckSuccess = (now = Date.now()): void => {
+  health = { lastSuccessAt: now, consecutiveFailures: 0, stuckReported: false }
+}
+
+/**
+ * Count a failed check. `stuck` is true exactly once per streak (latched until
+ * the next success) so the escalation is one exception, not a second flood.
+ */
+export const recordUpdaterCheckFailure = (
+  now = Date.now()
+): { consecutiveFailures: number; stuck: boolean } => {
+  health.consecutiveFailures += 1
+  const stuck =
+    !health.stuckReported &&
+    health.consecutiveFailures >= STUCK_CHECK_FAILURES &&
+    now - health.lastSuccessAt >= STUCK_CHECK_WINDOW_MS
+  if (stuck) health.stuckReported = true
+  return { consecutiveFailures: health.consecutiveFailures, stuck }
+}

--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -118,7 +118,8 @@ vi.mock('./lib/app-version-display', () => ({
 // The real modules pull the telemetry runtime, whose electron import ('net')
 // the mock above does not provide.
 vi.mock('./telemetry/diagnostics', () => ({
-  trackMainError: vi.fn()
+  trackMainError: vi.fn(),
+  trackMainWarning: vi.fn()
 }))
 vi.mock('./telemetry/track', () => ({
   trackMainEvent: vi.fn()
@@ -128,6 +129,7 @@ vi.mock('./telemetry/update-install-marker', () => ({
 }))
 
 import { markUpdateInstallStarted } from './telemetry/update-install-marker'
+import { trackMainError, trackMainWarning } from './telemetry/diagnostics'
 
 async function loadUpdater() {
   vi.resetModules()
@@ -604,6 +606,83 @@ describe('updater', () => {
       } finally {
         vi.useRealTimers()
       }
+    })
+  })
+
+  // Issue #1587: ordinary connectivity drops were 33.2% of every app_error_seen
+  // event in the product. They are reclassified, never dropped — and the local
+  // log line, the user-facing state and every non-transient failure are unmoved.
+  describe('telemetry severity classification (#1587)', () => {
+    it('reports an offline background check as a warning, not an exception', async () => {
+      const updater = await loadUpdater()
+      updater.initializeUpdater()
+
+      mocks.autoUpdater.emit('checking-for-update')
+      const offline = new Error('net::ERR_INTERNET_DISCONNECTED')
+      mocks.autoUpdater.emit('error', offline)
+
+      expect(trackMainWarning).toHaveBeenCalledWith('updater', 'check', offline, { retryCount: 1 })
+      expect(trackMainError).not.toHaveBeenCalled()
+      // The user still sees the failure, and main.log still records it at error.
+      expect(updater.getUpdateState()).toMatchObject({
+        status: 'error',
+        error: 'net::ERR_INTERNET_DISCONNECTED'
+      })
+      expect(mocks.logger.error).toHaveBeenCalledWith(
+        'updater error',
+        offline,
+        expect.objectContaining({ phase: 'check' })
+      )
+    })
+
+    it('keeps a jwt-expired release-asset download in error tracking', async () => {
+      const updater = await loadUpdater()
+      updater.initializeUpdater()
+
+      mocks.autoUpdater.emit('checking-for-update')
+      const expired = Object.assign(
+        new Error(
+          'Cannot download "https://release-assets.githubusercontent.com/x", status 618: jwt:expired'
+        ),
+        { name: 'HttpError', code: 'HTTP_ERROR_618', statusCode: 618 }
+      )
+      mocks.autoUpdater.emit('error', expired)
+
+      expect(trackMainError).toHaveBeenCalledWith('updater', 'check', expired)
+      expect(trackMainWarning).not.toHaveBeenCalled()
+    })
+
+    it('keeps a network drop during a download in error tracking', async () => {
+      const updater = await loadUpdater()
+      updater.initializeUpdater()
+
+      void updater.downloadUpdate()
+      const dropped = new Error('net::ERR_NETWORK_CHANGED')
+      mocks.autoUpdater.emit('error', dropped)
+
+      expect(trackMainError).toHaveBeenCalledWith('updater', 'download', dropped)
+      expect(trackMainWarning).not.toHaveBeenCalled()
+    })
+
+    it('counts a streak of failed checks so a stuck updater stays measurable', async () => {
+      const updater = await loadUpdater()
+      updater.initializeUpdater()
+
+      for (const attempt of [1, 2, 3]) {
+        mocks.autoUpdater.emit('checking-for-update')
+        mocks.autoUpdater.emit('error', new Error('net::ERR_NAME_NOT_RESOLVED'))
+        expect(trackMainWarning).toHaveBeenLastCalledWith('updater', 'check', expect.any(Error), {
+          retryCount: attempt
+        })
+      }
+
+      // A check that reaches the feed clears the streak.
+      mocks.autoUpdater.emit('update-not-available')
+      mocks.autoUpdater.emit('checking-for-update')
+      mocks.autoUpdater.emit('error', new Error('net::ERR_NAME_NOT_RESOLVED'))
+      expect(trackMainWarning).toHaveBeenLastCalledWith('updater', 'check', expect.any(Error), {
+        retryCount: 1
+      })
     })
   })
 

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -8,9 +8,16 @@ import { getMainI18n } from './lib/main-i18n'
 import { formatAppVersionForDisplay } from './lib/app-version-display'
 import { htmlToPlainText } from './lib/html-to-plain-text'
 import { getUpdaterPrefs, setAutoCheckPref, setAutoDownloadPref, setSkippedVersion } from './store'
-import { trackMainError } from './telemetry/diagnostics'
+import { trackMainError, trackMainWarning } from './telemetry/diagnostics'
 import { trackMainEvent } from './telemetry/track'
 import { markUpdateInstallStarted } from './telemetry/update-install-marker'
+import {
+  classifyUpdaterError,
+  isUpdaterCheckPhase,
+  recordUpdaterCheckFailure,
+  recordUpdaterCheckSuccess,
+  resetUpdaterCheckHealth
+} from './updater-error-severity'
 
 const logger = createLogger('Updater')
 
@@ -138,6 +145,30 @@ export function describeUpdaterError(
  * electron-updater's `error` event carries no phase of its own, so derive it from the
  * status the updater was in when it fired.
  */
+/**
+ * Route a failure to the telemetry severity it deserves. A background check that
+ * could not reach the network is the user being offline, not a defect, so it
+ * ships as a `warn` log line — queryable, but out of Error Tracking. Everything
+ * else, plus an install whose checks have been failing for a day straight, stays
+ * an exception: those users cannot receive a fix. See updater-error-severity.ts.
+ */
+function reportUpdaterFailure(error: unknown, phase: UpdaterErrorPhase): void {
+  if (!isUpdaterCheckPhase(phase)) {
+    trackMainError('updater', phase, error)
+    return
+  }
+  // Every failed check advances the streak, including the ones already reported
+  // as errors — the streak measures "this install cannot update", not severity.
+  const { consecutiveFailures, stuck } = recordUpdaterCheckFailure()
+  if (stuck || classifyUpdaterError(error, phase) === 'error') {
+    trackMainError('updater', phase, error)
+    return
+  }
+  // retryCount carries the streak length so a cross-install signal can separate
+  // one laptop failing 40 times from 40 laptops failing 3 times in a row.
+  trackMainWarning('updater', phase, error, { retryCount: consecutiveFailures })
+}
+
 function currentErrorPhase(): UpdaterErrorPhase {
   switch (state.status) {
     case 'checking':
@@ -196,6 +227,7 @@ export function initializeUpdater(): void {
   }
 
   initialized = true
+  resetUpdaterCheckHealth()
   autoUpdater.logger = updaterLibraryLogger
   const prefs = getUpdaterPrefs()
   const autoDownloadEnabled = prefs.autoDownload ?? false
@@ -215,6 +247,7 @@ export function initializeUpdater(): void {
   })
 
   autoUpdater.on('update-available', (info) => {
+    recordUpdaterCheckSuccess()
     const displayVersion = formatUpdateVersion(info)
 
     // Honor "Skip This Version": suppress the prompt for a version the user
@@ -251,6 +284,7 @@ export function initializeUpdater(): void {
   })
 
   autoUpdater.on('update-not-available', () => {
+    recordUpdaterCheckSuccess()
     logger.info('no update available')
     setState({
       status: 'up-to-date',
@@ -291,10 +325,13 @@ export function initializeUpdater(): void {
   autoUpdater.on('error', (error) => {
     const message =
       error instanceof Error ? error.message : getMainI18n().t('system:error.updateFailed')
-    logger.error('updater error', error, describeUpdaterError(error, currentErrorPhase()))
+    const phase = currentErrorPhase()
+    // The local main.log line and the user-facing state stay at error severity:
+    // only the telemetry severity is classified.
+    logger.error('updater error', error, describeUpdaterError(error, phase))
     // Update-pipeline breakage (feed 404s, signature failures, disk-full
     // downloads) must reach error tracking: affected users cannot update to a fix.
-    trackMainError('updater', currentErrorPhase(), error)
+    reportUpdaterFailure(error, phase)
     setState({
       status: 'error',
       error: message

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -710,6 +710,30 @@ reason, phase, mode, status, kind, result`, plus numeric metric keys like
   stack frames as `errorStack`. The field names are chosen against the redaction allowlist above:
   `phase` and `errorCode` ship verbatim, `url` is path-redacted (query string stripped), the rest
   are text-redacted and capped.
+- **Updater severity classification**: the local `main.log` line and the user-facing error state are
+  unchanged — every updater failure is still logged at `error` and still flips the UI to the error
+  state. What is classified is the **telemetry** severity
+  (`apps/desktop/src/main/updater-error-severity.ts`). A failure during a _check_
+  (`check` / `startup-check` / `scheduled-check` / `auto-check-enable`) whose message **or cause
+  chain** carries only allowlisted Chromium transport codes — `net::ERR_NAME_NOT_RESOLVED`,
+  `ERR_INTERNET_DISCONNECTED`, `ERR_NETWORK_CHANGED`, `ERR_TIMED_OUT`, `ERR_CONNECTION_TIMED_OUT`,
+  `ERR_CONNECTION_RESET`, `ERR_CONNECTION_CLOSED`, `ERR_CONNECTION_REFUSED`,
+  `ERR_NETWORK_IO_SUSPENDED`, `ERR_HTTP2_PROTOCOL_ERROR`, `ERR_HTTP2_SERVER_REFUSED_STREAM` — ships
+  as an `app_log_recorded` `warn` instead of an `app_error_seen` exception. Being offline is a
+  normal state for an offline-first app, and those events were 33.2 % of every exception in the
+  product. The cause chain matters because electron-updater's `GitHubProvider` wraps a transport
+  failure in a parse-shaped `ERR_UPDATER_INVALID_RELEASE_FEED`; a feed that is genuinely malformed
+  has no network cause and stays an exception. The set is an **allowlist, never a `net::ERR_`
+  prefix test**: `net::ERR_CERT_*` / `net::ERR_SSL_*` are security signals, and anything
+  unrecognised fails closed to `error`. Everything else is untouched — HTTP 4xx/5xx (including the
+  `HTTP_ERROR_618` `jwt:expired` on GitHub's pre-signed asset URLs), signature failures,
+  install-phase errnos, `ENOENT … app-update.yml`, and **any** failure in the `download` /
+  `downloaded` / `install` phases, where a network drop can leave a half-applied update.
+  Reclassified events are never dropped: same error code, same redacted message and stack, and each
+  one carries `retryCount` — the consecutive-failed-check streak — so a cross-install signal can
+  separate one laptop on a train from many installs failing in a row. An install that has not
+  completed a single check in 24 hours _and_ has failed at least 6 checks in that time raises one
+  exception (latched until the next successful check), so a genuinely stuck updater is still loud.
 - **Process lifecycle**: the main process reports a `child-process-gone` fault with a composite
   `type:reason:name` error code (e.g. `Utility:crashed:Embeddings`). The worker label comes from
   Electron's `details.name`, **not** `details.serviceName`: Electron routes a fork's `serviceName`


### PR DESCRIPTION
## Why

The auto-updater reported ordinary client-side connectivity failures as `app_error_seen` exceptions. In the 2026-08-09 → 2026-08-19 window that was **1,043 events = 33.2 % of every exception event in the product** — the second-largest error source, 88 % of it a bare Chromium `net::ERR_*` from 19 installs, and 92 of them on the latest release `2026.817.1`. A laptop that sleeps, changes Wi-Fi, or is simply offline when the 10-minute background check fires produced one `error`-severity exception per check, and those drowned out real crashes in Error Tracking.

Updates themselves work. This is observability hygiene, not an update-delivery bug.

## What changed

`apps/desktop/src/main/updater-error-severity.ts` (new) is a pure predicate: given the error and the lifecycle phase it returns `warn` or `error`. `updater.ts` routes the `autoUpdater.on('error')` report through it — `warn` goes to `trackMainWarning` (a new sibling of `trackMainError` in `telemetry/diagnostics.ts` that emits `app_log_recorded` at `warn` with the same error code, the same on-device redaction, and the same message/stack detail).

**The local `main.log` line and the user-facing error state are unchanged.** Every failure is still `logger.error('updater error', …)` with the full `describeUpdaterError()` field bag, and still flips the UI to `status: 'error'`. Only the telemetry severity moves.

### Per-code severity table

| Code / condition | Before | After | Why |
| --- | --- | --- | --- |
| `net::ERR_NAME_NOT_RESOLVED` | error | **warn** | 330 events / 9 installs — DNS unavailable |
| `net::ERR_INTERNET_DISCONNECTED` | error | **warn** | 262 events — no link |
| `net::ERR_NETWORK_CHANGED` | error | **warn** | 163 events — Wi-Fi handoff |
| `net::ERR_TIMED_OUT` | error | **warn** | 90 events |
| `net::ERR_CONNECTION_CLOSED` / `_RESET` / `_REFUSED` / `_TIMED_OUT` | error | **warn** | transport, no response |
| `net::ERR_NETWORK_IO_SUSPENDED` | error | **warn** | laptop sleep |
| `net::ERR_HTTP2_PROTOCOL_ERROR` / `_SERVER_REFUSED_STREAM` | error | **warn** | transport-level HTTP/2 |
| `ERR_UPDATER_INVALID_RELEASE_FEED` **with a `net::ERR_*` in its cause chain** | error | **warn** | 30/30 in production carried a network cause — `GitHubProvider` wraps a transport failure in a parse-shaped message |
| `ERR_UPDATER_INVALID_RELEASE_FEED` **with no network cause** | error | error | a genuinely malformed feed |
| `HTTP_ERROR_618` (`jwt:expired`) | error | **error — deliberately unmoved** | 27/27 delivery-side, our CDN path, not the user's link |
| `net::ERR_CERT_*` / `net::ERR_SSL_*` | error | error | a certificate failure is a security signal, never noise |
| HTTP 4xx/5xx from the feed or an asset | error | error | the server answered |
| signature / checksum failures | error | error | pipeline breakage |
| `ENOENT … app-update.yml`, `ditto: Could not lstat …`, `EACCES` / `EPERM` / `ENOSPC` | error | error | install-phase |
| unrecognised `net::ERR_SOMETHING_NEW` | error | error | **fails closed** |
| any of the above during `download` / `downloaded` / `install` | error | error | see phase narrowing |

The transient set is an **allowlist, never a `net::ERR_` prefix test** — a prefix match would swallow `net::ERR_CERT_*` and every future code we have not reasoned about. Matching runs over the message *and* the flattened cause chain (bounded depth 4), which is what lets `ERR_UPDATER_INVALID_RELEASE_FEED` be split on its real cause rather than its outer code. An error carrying an HTTP `statusCode` is never demoted.

### Phase narrowing — decided explicitly

Only `check` / `startup-check` / `scheduled-check` / `auto-check-enable` can be demoted. A network drop during `download` or `install` can leave a half-applied update and stays an exception even for a transient code. This is not an accident of the data: 1,038 of the 1,043 noisy events fired in the check phase, so the narrowing costs ~0.5 % of the noise reduction.

### A stuck updater is still loud

Turning the volume down would be the wrong fix on its own, so severity is not the only axis:

- Every reclassified event carries `retryCount` — the **consecutive-failed-check streak**, reset by any check that reaches the feed. That is the ingredient for the cross-install ratio signal: one laptop failing 40 times is noise, 40 installs each failing 3 times in a row is an outage, and the query needs no severity at all.
- An install that has **not completed a single check in 24 hours _and_ has failed at least 6 checks** in that stretch raises one `app_error_seen`, latched until the next success. Both conditions are required: time alone would fire for a machine that slept through the window and failed its first wake-up check; the count alone would fire for an hour-long coffee-shop outage.
- Events are reclassified, never dropped — the volume is itself the diagnostic.

### 📉 Dashboard note (read this if you watch `app_error_seen`)

**`app_error_seen` volume will drop by roughly a third** once this ships, and the updater will fall out of the top-2 exception sources. That is the intended effect, not an ingest failure. The same events are still fully queryable as `app_log_recorded` with `action = 'warn'`, `source = 'updater'`, `log_action` = the phase. Any dashboard that counts total exceptions will show a step change at the release that carries this; anything scoped to a specific error code is unaffected. No event names, no dimension keys, and no schema shapes changed — the change is additive.

## On `HTTP_ERROR_618` — is the expiry itself fixable?

Investigated, and there is a real root cause, but the fix does not belong in this PR.

`node_modules/electron-updater/out/differentialDownloader/DifferentialDownloader.js:216-220` builds **one** `requestOptions` object for the whole differential download, and on the first redirect mutates it in place:

```js
request.on('redirect', (statusCode, method, redirectUrl) => {
  actualUrl = redirectUrl
  configureRequestUrl(new URL(actualUrl), requestOptions)   // ← mutates the shared options
  request.followRedirect()
})
```

After that, every subsequent range request goes straight to the already-signed `release-assets.githubusercontent.com/…?jwt=…` URL and **reuses the same short-lived JWT for the entire download** — hundreds of range requests, with a deliberate 1s pause every 100 operations. On a slow link the token expires mid-download and GitHub answers `618 jwt:expired`. That matches the evidence exactly: uniform across `2026.808.2` / `2026.811.1` / `2026.817.1` (not a packaging regression), only 27 events across 6 installs (only slow downloads hit it). `builder-util-runtime` ships a `retryOnServerError` helper that would cover a 618 (`isServerError()` is `500–599`), but **nothing in electron-updater ever calls it**, so there is no retry either.

Two possible fixes — patch `DifferentialDownloader` to re-resolve the redirect per range request (the repo already has a `patchedDependencies` mechanism), or set `autoUpdater.disableDifferentialDownload = true` and trade bandwidth for reliability. Both change update-delivery behaviour for every user on a production app, which is well outside a severity-classification change. **Not done here, deliberately** — it deserves its own issue with its own rollout, and until then `HTTP_ERROR_618` staying at `error` is exactly what keeps it visible.

## Verification

| Command | Result |
| --- | --- |
| `pnpm exec vitest run --config config/vitest.config.ts --project main src/main/updater-error-severity.test.ts src/main/updater.test.ts src/main/telemetry/diagnostics.test.ts` | ✅ 3 files, **102 tests passed** |
| `pnpm --filter @memry/desktop test:main` (full main suite) | ✅ 6,847 passed — 1 unrelated suite fails to load in this worktree with `Error: Electron failed to install correctly` (missing Electron binary, not a test failure) |
| `pnpm --filter @memry/desktop typecheck:node` | ✅ clean |
| `pnpm --filter @memry/desktop exec tsc -p tsconfig.test.node.json` | ✅ clean (the new test file is **not** on the exclude backlog) |
| `pnpm --filter @memry/desktop typecheck:test` | ⚠️ fails only on `renderer/src/components/sidebar/sidebar-nav.test.tsx` (missing `onNavMiddleClick`) — **pre-existing red on `origin/main`**, untouched by this branch |
| `pnpm lint` | ✅ 0 errors; 0 new warnings from the changed files |
| `pnpm check:architecture` / `pnpm check:contracts` / `git diff --check` | ✅ pass |
| `pnpm docs:impact --base origin/main --strict` | ✅ covered |
| `pnpm docs:build` | ✅ build complete |

**Mutation-tested at the seam** (3 mutations, all killed):

| Mutation | Result |
| --- | --- |
| `classifyUpdaterError` → always `warn` | 🔴 18 tests fail |
| `recordUpdaterCheckFailure` → never reports `stuck` | 🔴 2 tests fail |
| HTTP `statusCode` guard neutered | 🔴 1 test fails |

The table-driven suite covers every code the issue names — including `HTTP_ERROR_618` asserting `error`, a wrapped `ERR_UPDATER_INVALID_RELEASE_FEED` both ways, `net::ERR_CERT_AUTHORITY_INVALID`, and an unknown `net::ERR_SOMETHING_NEW` failing closed.

## Follow-ups (not in scope)

- The `HTTP_ERROR_618` root cause above.
- The 66 `ENOENT … app-update.yml` events are all **one install** running rebranded copies (`记点.app`, `Memry Agenda.app`, `Jidian.app`, all reporting `1.0.0`) with no `app-update.yml`. They stay at `error`.
- Re-measure after the release that carries this: target is the updater's share of `app_error_seen` falling from 33.2 % to low single digits, with `HTTP_ERROR_618`, install-phase failures and the `ENOENT` family still visible.

Fixes #1587
