### PR TITLE
fix(embeddings): name the worker behind a crash instead of losing it

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -53,7 +53,7 @@ import { configureSessionPermissions } from './session-permissions'
 import { startSnoozeScheduler, stopSnoozeScheduler, checkDueItemsOnStartup } from './inbox/snooze'
 import { stopVoiceModel } from './inbox/voice-model'
 import { stopImageProcessing } from './image-processing/bridge'
-import { getEmbeddingWorkerPhase, stopEmbeddingModel } from './lib/embeddings'
+import { getEmbeddingWorkerCrashContext, stopEmbeddingModel } from './lib/embeddings'
 import { startReminderScheduler, stopReminderScheduler } from './lib/reminders'
 import { startInboxReviewScheduler, stopInboxReviewScheduler } from './inbox/review-scheduler'
 import { disposeTelemetryRuntime, initializeTelemetryRuntime } from './telemetry/runtime'
@@ -224,11 +224,14 @@ function registerMainDiagnostics(): void {
     //
     // This is also the ONLY report a native worker crash produces: the worker's
     // own 'exit' event never fires for one, so the owning module never learns it
-    // died. Resolving the lifecycle phase here is what lets that surviving report
-    // say whether the user lost an embedding or the worker died tearing down.
+    // died. Resolving the worker's context here is what lets that surviving
+    // report say whether the user lost an embedding or the worker died tearing
+    // down — and, now, on which pid, after how long, and with what on stderr.
+    const embeddingCrash = getEmbeddingWorkerCrashContext(details.name, details.reason)
     trackChildProcessGone({
       ...details,
-      phase: getEmbeddingWorkerPhase(details.name) ?? undefined
+      phase: embeddingCrash?.phase,
+      context: embeddingCrash ?? undefined
     })
     // A dead GPU process means this launch may already be painting nothing.
     // Record it so the next launch disables hardware acceleration (see
@@ -609,8 +612,7 @@ const DEFAULT_MAIN_WINDOW_SIZE = { width: 1550, height: 900 } as const
 const VAULT_PICKER_WINDOW_SIZE = { width: 760, height: 560 } as const
 
 function getInitialMainWindowSize():
-  | typeof DEFAULT_MAIN_WINDOW_SIZE
-  | typeof VAULT_PICKER_WINDOW_SIZE {
+  typeof DEFAULT_MAIN_WINDOW_SIZE | typeof VAULT_PICKER_WINDOW_SIZE {
   if (process.env.MEMRY_FORCE_VAULT_PICKER === '1') return VAULT_PICKER_WINDOW_SIZE
   return getCurrentVaultPath() ? DEFAULT_MAIN_WINDOW_SIZE : VAULT_PICKER_WINDOW_SIZE
 }

--- a/apps/desktop/src/main/lib/embedding-worker.ts
+++ b/apps/desktop/src/main/lib/embedding-worker.ts
@@ -1,8 +1,10 @@
-import path from 'path'
-
 import { createLogger } from './logger'
 import { installWorkerLogForwarding } from './log-forward'
-import { EMBEDDING_DIMENSION } from './embeddings-constants'
+import {
+  EMBEDDING_DIMENSION,
+  EMBEDDING_MODEL_REPO,
+  transformersCacheDir
+} from './embeddings-constants'
 import type {
   EmbeddingMainToWorkerMessage,
   EmbeddingProgressPhase,
@@ -11,7 +13,6 @@ import type {
 
 const logger = createLogger('Embeddings:Worker')
 
-const MODEL_NAME = 'Xenova/all-MiniLM-L6-v2'
 const MAX_CONTENT_LENGTH = 2000
 
 interface ModelProgress {
@@ -43,7 +44,7 @@ function getUserDataPath(): string {
 }
 
 function getTransformersCacheDir(): string {
-  return path.join(getUserDataPath(), 'models', 'transformers')
+  return transformersCacheDir(getUserDataPath())
 }
 
 function emitProgress(phase: EmbeddingProgressPhase, progress: number, status: string): void {
@@ -70,7 +71,7 @@ async function loadEmbeddingPipeline() {
     const { pipeline, env } = await import('@huggingface/transformers')
     env.cacheDir = getTransformersCacheDir()
 
-    extractor = await pipeline('feature-extraction', MODEL_NAME, {
+    extractor = await pipeline('feature-extraction', EMBEDDING_MODEL_REPO, {
       dtype: 'fp32',
       progress_callback: (progress: ModelProgress) => {
         if (progress.status === 'progress') {

--- a/apps/desktop/src/main/lib/embeddings-constants.ts
+++ b/apps/desktop/src/main/lib/embeddings-constants.ts
@@ -2,4 +2,26 @@
  * Shared embedding constants that must be safe to import in non-Electron contexts
  * (for example database initialization in tests).
  */
+import path from 'path'
+
 export const EMBEDDING_DIMENSION = 384
+
+/** transformers.js repo id the worker loads. */
+export const EMBEDDING_MODEL_REPO = 'Xenova/all-MiniLM-L6-v2'
+
+/**
+ * Where the worker points transformers.js `env.cacheDir`. Shared with the bridge
+ * so the crash report's model-cache probe reads the SAME directory the worker
+ * downloads into — a probe that drifts from the worker's cache dir would report
+ * "absent" forever and quietly answer the wrong question.
+ */
+export const transformersCacheDir = (userDataPath: string): string =>
+  path.join(userDataPath, 'models', 'transformers')
+
+/** Directory transformers.js writes this model's files into. */
+export const embeddingModelCacheDir = (userDataPath: string): string =>
+  path.join(transformersCacheDir(userDataPath), EMBEDDING_MODEL_REPO)
+
+/** The weights file transformers.js writes for `dtype: 'fp32'`. */
+export const embeddingModelWeightsPath = (userDataPath: string): string =>
+  path.join(embeddingModelCacheDir(userDataPath), 'onnx', 'model.onnx')

--- a/apps/desktop/src/main/lib/embeddings.test.ts
+++ b/apps/desktop/src/main/lib/embeddings.test.ts
@@ -11,7 +11,11 @@ const mockFork = vi.hoisted(() => vi.fn())
 const trackMainLogMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../telemetry/diagnostics', () => ({
-  trackMainLog: trackMainLogMock
+  trackMainLog: trackMainLogMock,
+  // Mirrors the real predicate: a clean idle-shutdown / OS memory eviction is
+  // lifecycle, not a crash, and must not reach the crash-context resolver.
+  isChildProcessFault: (reason: string): boolean =>
+    reason !== 'clean-exit' && reason !== 'memory-eviction'
 }))
 
 class MockUtilityProcess extends EventEmitter {
@@ -28,8 +32,11 @@ class MockUtilityProcess extends EventEmitter {
     }
     return true
   })
-  stdout = null
-  stderr = null
+  stdout = new EventEmitter()
+  // Real, not null: the abort message a native crash writes here is the only
+  // "what happened" the crash report can ever carry, so the tail capture has to
+  // be exercisable.
+  stderr = new EventEmitter()
   pid = 1234
 
   simulateMessage(message: unknown): void {
@@ -68,8 +75,9 @@ vi.mock('@huggingface/transformers', () => {
 import { resetTelemetryThrottle } from '../telemetry/throttle'
 import {
   EMBEDDING_DIMENSION,
+  formatWorkerStderrTail,
   generateEmbedding,
-  getEmbeddingWorkerPhase,
+  getEmbeddingWorkerCrashContext,
   getModelInfo,
   initEmbeddingModel,
   isInformationalWorkerStderr,
@@ -540,7 +548,7 @@ describe('embeddings', () => {
   // too — the bridge never observes the death at all. `app.on('child-process-
   // gone')` is the path that does fire (107/107), so the phase has to be
   // readable from outside the exit handler for that report to carry it.
-  describe('getEmbeddingWorkerPhase', () => {
+  describe('getEmbeddingWorkerCrashContext', () => {
     // Wrapped in an object, never returned bare: an async function flattens a
     // returned promise, so `await startWorker()` would block on the embedding
     // itself instead of on the worker being up.
@@ -554,23 +562,37 @@ describe('embeddings', () => {
       return { pending }
     }
 
+    /** Drive a worker that never answers, up to and past the 10s start timeout. */
+    const timeOutStartingWorker = async (): Promise<MockUtilityProcess> => {
+      const load = initEmbeddingModel()
+      void load.catch(() => {})
+      const worker = mockUtilityProcessInstance
+      await vi.advanceTimersByTimeAsync(10_000)
+      await expect(load).resolves.toBe(false)
+      return worker
+    }
+
     it('returns null when no worker has been forked', () => {
-      expect(getEmbeddingWorkerPhase('Embeddings')).toBeNull()
+      expect(getEmbeddingWorkerCrashContext('Embeddings', 'crashed')).toBeNull()
     })
 
     it('ignores a crash reported for a different utility worker', async () => {
       await startWorker()
 
       // #then CrdtPreflight's crash must not inherit the embedding worker's phase
-      expect(getEmbeddingWorkerPhase('CrdtPreflight')).toBeNull()
-      expect(getEmbeddingWorkerPhase(undefined)).toBeNull()
+      expect(getEmbeddingWorkerCrashContext('CrdtPreflight', 'crashed')).toBeNull()
+      expect(getEmbeddingWorkerCrashContext(undefined, 'crashed')).toBeNull()
     })
 
     it('reports in_flight while a request is outstanding', async () => {
       await startWorker()
 
       // #then a crash here costs the user this note's semantic-search indexing
-      expect(getEmbeddingWorkerPhase('Embeddings')).toBe('in_flight')
+      expect(getEmbeddingWorkerCrashContext('Embeddings', 'crashed')).toMatchObject({
+        phase: 'in_flight',
+        release: 'live',
+        pid: 1234
+      })
     })
 
     it('reports idle once the embedding has been delivered', async () => {
@@ -585,7 +607,7 @@ describe('embeddings', () => {
       })
       await expect(pending).resolves.toBeInstanceOf(Float32Array)
 
-      expect(getEmbeddingWorkerPhase('Embeddings')).toBe('idle')
+      expect(getEmbeddingWorkerCrashContext('Embeddings', 'crashed')?.phase).toBe('idle')
     })
 
     it('keeps the latched teardown phase after a force-kill clears the handle', async () => {
@@ -596,18 +618,156 @@ describe('embeddings', () => {
       unloadModel()
 
       // #then the crash still reads as a teardown death, not a spontaneous one
-      expect(getEmbeddingWorkerPhase('Embeddings')).toBe('idle_shutdown')
+      expect(getEmbeddingWorkerCrashContext('Embeddings', 'crashed')).toMatchObject({
+        phase: 'idle_shutdown',
+        release: 'teardown'
+      })
     })
 
-    it('does not leak a teardown latch into the next worker generation', async () => {
+    // THE bug this whole file exists for. In production `child-process-gone` has
+    // never once arrived while the bridge still owned the worker: 76 events on
+    // 2026.817.1, all with no phase, plus zero `EmbeddingWorkerExit` events (which
+    // rules out both 'exit' handlers) and zero phase-suffixed events (which rules
+    // out stop()/reset()'s never-cleared idle_shutdown latch). What is left is
+    // failProcess() — it forgets a worker that is STILL RUNNING, so the report
+    // lands with `process` and `pendingExitPhase` both already null.
+    it('attributes a crash that lands after the start timeout forgot the worker', async () => {
+      vi.useFakeTimers()
+      await timeOutStartingWorker()
+
+      // #given the bridge has fully let go — the next load would fork afresh
+      expect(mockFork).toHaveBeenCalledOnce()
+
+      // #when the OS crash report finally lands, as production's always does
+      const context = getEmbeddingWorkerCrashContext('Embeddings', 'crashed')
+
+      // #then it names the worker it belongs to instead of resolving to nothing
+      expect(context).toMatchObject({
+        phase: 'starting',
+        release: 'start_timeout',
+        pid: 1234,
+        load: 'first',
+        modelCache: 'absent'
+      })
+    })
+
+    it('does not leak a teardown record into the next worker generation', async () => {
+      vi.useFakeTimers()
       await startWorker()
       unloadModel()
 
       // #given a second reset with no live worker to kill
       unloadModel()
 
-      // #then a later unrelated crash must not inherit the stale latch
-      expect(getEmbeddingWorkerPhase('Embeddings')).toBeNull()
+      // #then a later unrelated crash must not inherit the stale record
+      expect(getEmbeddingWorkerCrashContext('Embeddings', 'crashed')).toBeNull()
+    })
+
+    it('reports how long the dead worker had been alive', async () => {
+      vi.useFakeTimers()
+      const load = initEmbeddingModel()
+      void load.catch(() => {})
+
+      // #given a worker that never became ready, abandoned at the 10s timeout,
+      // whose crash report lands 2s later
+      await vi.advanceTimersByTimeAsync(10_000)
+      await expect(load).resolves.toBe(false)
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      // #then "died during startup" is separable from "ran fine for minutes"
+      expect(getEmbeddingWorkerCrashContext('Embeddings', 'crashed')?.uptimeMs).toBe(12_000)
+    })
+
+    it('stops attributing once the record goes stale', async () => {
+      vi.useFakeTimers()
+      await timeOutStartingWorker()
+
+      // #when more than a minute passes before any report arrives
+      await vi.advanceTimersByTimeAsync(61_000)
+
+      // #then a later, unrelated crash cannot inherit the stale record
+      expect(getEmbeddingWorkerCrashContext('Embeddings', 'crashed')).toBeNull()
+    })
+
+    it('prefers the live worker over the released record', async () => {
+      vi.useFakeTimers()
+      await timeOutStartingWorker()
+
+      // #given a fresh worker forked after the abandoned one
+      resetEmbeddingModelFailure()
+      await startWorker()
+
+      // #then the report describes the generation that is actually running
+      expect(getEmbeddingWorkerCrashContext('Embeddings', 'crashed')).toMatchObject({
+        phase: 'in_flight',
+        release: 'live'
+      })
+    })
+
+    it('counts crash reports across the session but never a clean exit', async () => {
+      vi.useFakeTimers()
+      await timeOutStartingWorker()
+
+      // #given a lifecycle report, not a fault (the counter is a module-lifetime
+      // session counter, so the assertion is relative, not absolute)
+      const baseline = getEmbeddingWorkerCrashContext('Embeddings', 'crashed')?.crashCount ?? 0
+      expect(getEmbeddingWorkerCrashContext('Embeddings', 'clean-exit')).toBeNull()
+      expect(getEmbeddingWorkerCrashContext('Embeddings', 'memory-eviction')).toBeNull()
+
+      // #then only real crashes advance the counter, so a burst on one install is
+      // distinguishable from a slow drip without post-hoc SQL
+      expect(getEmbeddingWorkerCrashContext('Embeddings', 'crashed')?.crashCount).toBe(baseline + 1)
+    })
+
+    it('carries the dead worker stderr tail', async () => {
+      vi.useFakeTimers()
+      const load = initEmbeddingModel()
+      void load.catch(() => {})
+      mockUtilityProcessInstance.stderr.emit(
+        'data',
+        'libc++abi: terminating due to uncaught exception\n'
+      )
+      await vi.advanceTimersByTimeAsync(10_000)
+      await expect(load).resolves.toBe(false)
+
+      // #then the abort message survives the worker it came from
+      expect(getEmbeddingWorkerCrashContext('Embeddings', 'crashed')?.stderrTail).toBe(
+        'worker stderr tail:\n| libc++abi: terminating due to uncaught exception'
+      )
+    })
+
+    // failProcess() used to null the handle and walk away. The orphan was
+    // unreachable (every request goes through `this.process`) yet kept a whole
+    // onnxruntime alive to abort later — producing exactly the un-attributable
+    // report this issue is about — and its late `ready` would re-attach handlers
+    // and flip `loaded` on for a worker the bridge no longer owned.
+    it('kills the worker it gives up on instead of leaving it running', async () => {
+      vi.useFakeTimers()
+      const worker = await timeOutStartingWorker()
+
+      expect(worker.kill).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('worker stderr tail', () => {
+    it('redacts the home path out of native runtime output', () => {
+      expect(formatWorkerStderrTail('dlopen failed: /Users/kaan/Library/onnx.dylib')).toBe(
+        'worker stderr tail:\n| dlopen failed: ~/Library/onnx.dylib'
+      )
+    })
+
+    // The tail ships in `error.stack`, which the sync-server parses back into
+    // PostHog Error Tracking frames by matching /^\s*at\s/ per line. An abort
+    // message starting with "at " would otherwise become a fabricated frame.
+    it('keeps a line that looks like a stack frame from parsing as one', () => {
+      const tail = formatWorkerStderrTail('at Ort::Throw (onnxruntime.cc:120)')
+
+      expect(tail).toBe('worker stderr tail:\n| at Ort::Throw (onnxruntime.cc:120)')
+      expect(tail?.split('\n').some((line) => /^\s*at\s/.test(line))).toBe(false)
+    })
+
+    it('returns nothing for empty output', () => {
+      expect(formatWorkerStderrTail('   \n  ')).toBeUndefined()
     })
   })
 

--- a/apps/desktop/src/main/lib/embeddings.ts
+++ b/apps/desktop/src/main/lib/embeddings.ts
@@ -9,19 +9,26 @@
  */
 
 import { app, utilityProcess } from 'electron'
+import fs from 'fs'
 import path from 'path'
 import { SettingsChannels } from '@memry/contracts/ipc-channels'
+import { redactText } from '@memry/contracts/redact'
 import type {
   EmbeddingMainToWorkerMessage,
   EmbeddingProgressMessage,
   EmbeddingProgressPhase,
   EmbeddingWorkerToMainMessage
 } from './embedding-model-protocol'
-import { EMBEDDING_DIMENSION } from './embeddings-constants'
+import {
+  EMBEDDING_DIMENSION,
+  embeddingModelCacheDir,
+  embeddingModelWeightsPath
+} from './embeddings-constants'
 import { createLogger } from './logger'
 import { broadcastToAllWindows } from './window-broadcast'
-import { trackMainLog } from '../telemetry/diagnostics'
+import { isChildProcessFault, trackMainLog } from '../telemetry/diagnostics'
 import { getLogShip } from '../telemetry/log-ship'
+import { getMainRedactOptions } from '../telemetry/redact-options'
 import { shouldEmitThrottled } from '../telemetry/throttle'
 
 const logger = createLogger('Embeddings')
@@ -33,6 +40,40 @@ const logger = createLogger('Embeddings')
  * semantic-search indexing for that note.
  */
 export type WorkerExitPhase = 'starting' | 'in_flight' | 'idle_shutdown' | 'idle'
+
+/**
+ * How the bridge stopped tracking a worker. `live` means it still owns it;
+ * everything else is a worker it has already let go of, which is the state
+ * every production crash report has arrived in.
+ */
+export type WorkerRelease =
+  'live' | 'teardown' | 'start_timeout' | 'fatal_error' | 'exit' | 'graceful_stop'
+
+/** Whether the model was already on disk when this worker was forked. */
+export type ModelCacheState = 'present' | 'partial' | 'absent' | 'unknown'
+
+/**
+ * Everything the main process knows about the worker a `child-process-gone`
+ * report belongs to. Every field is a number, a bounded enum, or output the
+ * caller redacts — no user content.
+ */
+export interface EmbeddingWorkerCrashContext {
+  phase: WorkerExitPhase
+  /** OS pid, so two reports can be tied to one fork (or told apart). */
+  pid?: number
+  /** ms between the fork and this report. Separates "died loading" from "died after running fine". */
+  uptimeMs: number
+  release: WorkerRelease
+  modelCache: ModelCacheState
+  /** Size of the cached weights file, when there is one. */
+  modelCacheBytes?: number
+  /** `reload` when a model load had already failed this session before this fork. */
+  load: 'first' | 'reload'
+  /** Embedding-worker crash reports seen this session, including this one. */
+  crashCount: number
+  /** Redacted tail of the worker's own stderr — the abort message, if it wrote one. */
+  stderrTail?: string
+}
 
 export interface ModelInfo {
   name: string
@@ -84,6 +125,23 @@ const IDLE_SHUTDOWN_MS = 30_000
 const LOAD_RETRY_BASE_DELAY_MS = 60_000
 const MAX_CONSECUTIVE_LOAD_FAILURES = 5
 
+/**
+ * How long a released worker stays attributable. `child-process-gone` is
+ * dispatched by the browser process as soon as it reaps the child, so a report
+ * that has not arrived within a minute of the bridge letting go is not about
+ * that worker. Long enough to cover the 10s start timeout plus scheduling slack,
+ * short enough that a later, unrelated crash cannot inherit a stale record.
+ */
+const LAST_WORKER_TTL_MS = 60_000
+
+/**
+ * Bytes of worker stderr kept for the crash report. A native abort out of
+ * onnxruntime/libc writes its message to fd 2 and then dies, so the TAIL is the
+ * part worth keeping. Hard-capped: this is unbounded native output and it has to
+ * fit inside TelemetryErrorDetailSchema.stack (4000).
+ */
+const STDERR_TAIL_LIMIT = 2000
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -92,6 +150,20 @@ type PendingRequest = {
   resolve: (value: EmbeddingWorkerToMainMessage) => void
   reject: (error: Error) => void
   timer: ReturnType<typeof setTimeout>
+}
+
+/** Facts about one forked worker, captured at fork time. */
+type WorkerGeneration = {
+  pid?: number
+  forkedAt: number
+  ready: boolean
+  modelCache: ModelCacheState
+  modelCacheBytes?: number
+  load: 'first' | 'reload'
+  /** Bounded tail of everything this worker wrote to stderr. */
+  stderrTail: string
+  /** Phase at the moment the bridge released it; null while it is still live. */
+  releasePhase: WorkerExitPhase | null
 }
 
 /**
@@ -114,6 +186,52 @@ export function isInformationalWorkerStderr(output: string): boolean {
     .filter(Boolean)
   if (lines.length === 0) return false
   return lines.every((line) => INFORMATIONAL_WORKER_STDERR.some((pattern) => pattern.test(line)))
+}
+
+/**
+ * Whether the ~23MB model was already on disk when a worker was forked, and how
+ * big it was. A torn/partially-written cache file aborts deterministically on
+ * every load, which is the shape a per-install repeat crash would have; nothing
+ * in the crash payload could distinguish it before.
+ *
+ * Never throws and never awaits: it runs on the fork path, so a stat failure has
+ * to degrade to `unknown` rather than take the worker down with it.
+ */
+export function probeModelCache(userDataPath: string): {
+  state: ModelCacheState
+  bytes?: number
+} {
+  try {
+    const stat = fs.statSync(embeddingModelWeightsPath(userDataPath), { throwIfNoEntry: false })
+    if (stat?.isFile()) return { state: 'present', bytes: stat.size }
+    // Weights missing but the model dir exists: an interrupted or partially
+    // written download, which is a different bug from "never downloaded".
+    const dir = fs.statSync(embeddingModelCacheDir(userDataPath), { throwIfNoEntry: false })
+    return { state: dir?.isDirectory() ? 'partial' : 'absent' }
+  } catch {
+    return { state: 'unknown' }
+  }
+}
+
+/**
+ * Prepare captured worker stderr for the crash event: redact it, cap it, and
+ * make sure no line can be mistaken for a JS stack frame.
+ *
+ * The frame guard matters. The tail ships in `error.stack`, and the sync-server
+ * parses that field back into PostHog Error Tracking frames by matching
+ * `/^\s*at\s/` per line (posthog-transform.ts). A native abort message that
+ * happened to start with "at " would become a fabricated frame pointing at
+ * nothing, so every line is prefixed out of that shape.
+ */
+export function formatWorkerStderrTail(tail: string): string | undefined {
+  const redacted = redactText(tail, getMainRedactOptions()).trim()
+  if (!redacted) return undefined
+  const lines = redacted
+    .split('\n')
+    .map((line) => `| ${line.trim()}`)
+    .filter((line) => line !== '| ')
+  if (lines.length === 0) return undefined
+  return `worker stderr tail:\n${lines.join('\n')}`.slice(0, STDERR_TAIL_LIMIT)
 }
 
 /**
@@ -156,6 +274,19 @@ class EmbeddingModelBridge {
   // without this latch a wedged teardown is misreported as `idle` ("died doing
   // nothing") instead of `idle_shutdown` ("died tearing down").
   private pendingExitPhase: WorkerExitPhase | null = null
+  // Per-generation facts about the CURRENT worker, all captured at fork time so a
+  // crash report can be read without guessing. Reset on every fork.
+  private worker: WorkerGeneration | null = null
+  // The worker the bridge most recently let go of. Production's crash reports all
+  // arrive in this state — `process` and `pendingExitPhase` both already null —
+  // so without this record every report resolves to no phase at all. TTL'd, so a
+  // late unrelated crash cannot inherit it.
+  private lastWorker: (WorkerGeneration & { release: WorkerRelease; releasedAt: number }) | null =
+    null
+  // Crash reports attributed to an embedding worker this session. A burst on one
+  // install and a slow drip across many are different bugs; today they are only
+  // separable with post-hoc SQL.
+  private crashCount = 0
 
   get isLoaded(): boolean {
     return this.loaded
@@ -327,6 +458,10 @@ class EmbeddingModelBridge {
       })
     })
 
+    // Whether it exited on its own or had to be force-killed, the bridge is done
+    // with this worker here. Record it so a crash report landing after the handle
+    // is gone is still attributed — a no-op when an exit handler already did.
+    this.releaseWorker('teardown', 'idle_shutdown')
     this.process = null
     this.readyPromise = null
     this.shuttingDown = false
@@ -341,6 +476,12 @@ class EmbeddingModelBridge {
     // outlives the exit handler (which never runs for a native crash), so a stale
     // one would make the NEXT worker's crash read as a teardown it never had.
     this.pendingExitPhase = this.process ? 'idle_shutdown' : null
+    // Same rule as the latch above, for the same reason: a live worker is
+    // recorded so a crash report can still find it, while a reset with nothing
+    // to kill wipes the record — a stale one would make an unrelated later crash
+    // read as a teardown it never had.
+    if (this.process) this.releaseWorker('teardown', 'idle_shutdown')
+    else this.lastWorker = null
     this.process?.kill()
     this.process = null
     this.readyPromise = null
@@ -400,12 +541,14 @@ class EmbeddingModelBridge {
     }
 
     const workerPath = path.join(__dirname, 'embedding-worker.js')
+    const userDataPath = app.getPath('userData')
+    const modelCache = probeModelCache(userDataPath)
     const child = utilityProcess.fork(workerPath, [], {
       serviceName: WORKER_SERVICE_NAME,
       stdio: 'pipe',
       env: {
         ...process.env,
-        MEMRY_USER_DATA_PATH: app.getPath('userData')
+        MEMRY_USER_DATA_PATH: userDataPath
       },
       allowLoadingUnsignedLibraries: process.platform === 'darwin'
     })
@@ -413,6 +556,19 @@ class EmbeddingModelBridge {
     this.process = child
     // A fresh worker must never inherit a force-kill phase latched for a prior one.
     this.pendingExitPhase = null
+    const generation: WorkerGeneration = {
+      pid: child.pid,
+      forkedAt: Date.now(),
+      ready: false,
+      modelCache: modelCache.state,
+      modelCacheBytes: modelCache.bytes,
+      // Read BEFORE this attempt can fail, so it describes the state the fork was
+      // made in: `reload` means a load had already failed before this worker.
+      load: this.consecutiveFailures > 0 ? 'reload' : 'first',
+      stderrTail: '',
+      releasePhase: null
+    }
+    this.worker = generation
     child.stdout?.on('data', (chunk: Buffer | string) => {
       const output = chunk.toString().trim()
       if (output) {
@@ -422,6 +578,10 @@ class EmbeddingModelBridge {
     child.stderr?.on('data', (chunk: Buffer | string) => {
       const output = chunk.toString().trim()
       if (!output) return
+      // Kept for THIS generation even when the line is benign: a native abort is
+      // usually preceded by the runtime's own progress notes, and the tail is the
+      // only "what happened" a crash report can ever carry. Bounded from the end.
+      generation.stderrTail = `${generation.stderrTail}${output}\n`.slice(-STDERR_TAIL_LIMIT)
       if (isInformationalWorkerStderr(output)) {
         logger.debug(`Embedding utility stderr: ${output}`)
         return
@@ -436,7 +596,7 @@ class EmbeddingModelBridge {
           workerPath,
           pid: child.pid
         })
-        this.failProcess(error)
+        this.failProcess(error, 'start_timeout')
         reject(error)
       }, START_TIMEOUT_MS)
 
@@ -456,6 +616,7 @@ class EmbeddingModelBridge {
         if (message.type !== 'ready') return
 
         cleanup()
+        generation.ready = true
         this.setupProcessHandlers(child)
         logger.info('Embedding utility ready')
         resolve()
@@ -465,7 +626,7 @@ class EmbeddingModelBridge {
         cleanup()
         const error = new Error(`Embedding utility fatal error: ${type} at ${location}`)
         logger.error('Embedding utility fatal error', { type, location, report })
-        this.failProcess(error)
+        this.failProcess(error, 'fatal_error')
         reject(error)
       }
 
@@ -476,11 +637,12 @@ class EmbeddingModelBridge {
         // A clean exit during shutdown is lifecycle, not a fault (mirrors the
         // ready-state guard below). Without this, quitting the app mid-bootstrap
         // emits a spurious error-level worker_exit_starting with exit code 0.
+        const phase = forcedPhase ?? 'starting'
         if (!(forcedPhase === null && this.shuttingDown && code === 0)) {
-          this.trackWorkerExit(forcedPhase ?? 'starting', code)
+          this.trackWorkerExit(phase, code)
         }
         const error = new Error(`Embedding utility exited unexpectedly (code ${code})`)
-        this.failProcess(error)
+        this.failProcess(error, 'exit', phase)
         reject(error)
       }
 
@@ -533,7 +695,7 @@ class EmbeddingModelBridge {
     child.on('error', (type: string, location: string, report: string) => {
       const error = new Error(`Embedding utility fatal error: ${type} at ${location}`)
       logger.error('Embedding utility fatal error', { type, location, report })
-      this.failProcess(error)
+      this.failProcess(error, 'fatal_error')
     })
 
     child.on('exit', (code: number) => {
@@ -546,40 +708,29 @@ class EmbeddingModelBridge {
       // already be cleared by the time its async 'exit' lands.
       if (forcedPhase === null && this.shuttingDown && code === 0) {
         this.process = null
+        // Still recorded: a runtime that aborts while unwinding after exit(0)
+        // produces a crash report AFTER this clean exit, and the teardown-abort
+        // hypothesis is only testable if that report can still find the worker.
+        this.releaseWorker('graceful_stop')
         this.readyPromise = null
         return
       }
 
       // Phase must be read before failProcess(), which rejects and clears the
       // pending requests this classification depends on.
-      this.trackWorkerExit(forcedPhase ?? this.currentPhase(), code)
+      const phase = forcedPhase ?? this.currentPhase()
+      this.trackWorkerExit(phase, code)
       const error = new Error(`Embedding utility exited unexpectedly (code ${code})`)
-      this.failProcess(error)
+      this.failProcess(error, 'exit', phase)
     })
   }
 
   private currentPhase(): WorkerExitPhase {
     if (this.shuttingDown) return 'idle_shutdown'
     if (this.pendingRequests.size > 0) return 'in_flight'
+    // A worker that never sent 'ready' died bootstrapping, not sitting idle.
+    if (this.worker && !this.worker.ready) return 'starting'
     return 'idle'
-  }
-
-  /**
-   * The phase to attribute a death to when it is reported by
-   * `app.on('child-process-gone')` rather than by the worker's own 'exit' event.
-   *
-   * Production says that is the only report we get: across 107 consecutive
-   * `Utility:crashed:Embeddings` events, `trackWorkerExit` below emitted nothing
-   * and neither did `embed_failed` — a native SIGABRT out of the model runtime is
-   * neither a graceful exit nor a V8 fatal error, so no instance event fires and
-   * this bridge never learns its worker died. Reading the phase from outside the
-   * handler is what makes that surviving report answer the only question that
-   * matters: did the user lose an embedding, or did the worker just die tearing
-   * down after already delivering one?
-   */
-  liveWorkerPhase(): WorkerExitPhase | null {
-    if (this.pendingExitPhase) return this.pendingExitPhase
-    return this.process ? this.currentPhase() : null
   }
 
   /**
@@ -639,16 +790,98 @@ class EmbeddingModelBridge {
     return `embedding_${this.requestCounter}_${Date.now()}`
   }
 
-  private failProcess(error: Error): void {
+  /**
+   * Stop tracking the worker after a fault.
+   *
+   * This is the path every production crash report arrives behind. It nulls
+   * `process` without latching `pendingExitPhase`, so before the last-worker
+   * record existed the phase resolver had nothing left to read — which is why
+   * 100% of `Utility:crashed:Embeddings` events shipped with no phase.
+   *
+   * It also used to abandon a still-LIVE child (`start_timeout` / `fatal_error`
+   * reach here with the process running): the orphan was unreachable — every
+   * request goes through `this.process` — yet kept a whole onnxruntime alive to
+   * abort later, and its late `ready` message would re-attach handlers and flip
+   * `loaded` on for a worker the bridge no longer owned. It is killed now.
+   */
+  private failProcess(error: Error, release: WorkerRelease, phase?: WorkerExitPhase): void {
     this.clearIdleShutdown()
-    if (this.process) {
+    const orphan = this.process
+    // Read before rejectAll(), which clears the pending requests the phase
+    // classification depends on.
+    this.releaseWorker(release, phase)
+    if (orphan) {
       this.process = null
+      orphan.kill()
     }
     this.readyPromise = null
     this.loaded = false
     this.loading = false
     this.error = error.message
     this.rejectAll(error)
+  }
+
+  /**
+   * Remember the worker the bridge is letting go of, so a `child-process-gone`
+   * report that lands afterwards can still be attributed to it.
+   */
+  private releaseWorker(release: WorkerRelease, phase?: WorkerExitPhase): void {
+    const generation = this.worker
+    if (!generation) return
+    generation.releasePhase = phase ?? this.currentPhase()
+    this.lastWorker = { ...generation, release, releasedAt: Date.now() }
+    this.worker = null
+  }
+
+  /**
+   * The worker a `child-process-gone` report belongs to, with everything the
+   * main process knows about it.
+   *
+   * Reads, in order: the live worker, a force-kill latch (`stop()`/`reset()`
+   * kill and null the handle in the same tick), then the last worker the bridge
+   * released — the state every production report has actually arrived in.
+   */
+  crashContext(): EmbeddingWorkerCrashContext | null {
+    const now = Date.now()
+    if (this.worker) {
+      const live = this.worker
+      return {
+        phase: this.pendingExitPhase ?? this.currentPhase(),
+        release: this.pendingExitPhase ? 'teardown' : 'live',
+        uptimeMs: Math.max(0, now - live.forkedAt),
+        ...this.describeGeneration(live)
+      }
+    }
+
+    const last = this.lastWorker
+    if (!last || now - last.releasedAt > LAST_WORKER_TTL_MS) return null
+    return {
+      phase: last.releasePhase ?? 'idle',
+      release: last.release,
+      uptimeMs: Math.max(0, now - last.forkedAt),
+      ...this.describeGeneration(last)
+    }
+  }
+
+  private describeGeneration(generation: WorkerGeneration): Omit<
+    EmbeddingWorkerCrashContext,
+    'phase' | 'release' | 'uptimeMs' | 'crashCount'
+  > & {
+    crashCount: number
+  } {
+    return {
+      pid: generation.pid,
+      modelCache: generation.modelCache,
+      modelCacheBytes: generation.modelCacheBytes,
+      load: generation.load,
+      crashCount: this.crashCount,
+      stderrTail: formatWorkerStderrTail(generation.stderrTail)
+    }
+  }
+
+  /** Count a crash report before it is described, so the event includes itself. */
+  countCrashReport(): void {
+    this.crashCount += 1
   }
 
   private rejectAll(error: Error): void {
@@ -763,14 +996,40 @@ export function resetEmbeddingModelFailure(): void {
 }
 
 /**
- * Lifecycle phase to attribute a `child-process-gone` report to.
+ * What the main process knows about the worker a `child-process-gone` report is
+ * about: its lifecycle phase, pid, uptime, the model-cache state it was forked
+ * with, how the bridge last saw it, and the tail of its stderr.
  *
- * Returns null when the report is not about our embedding worker, or when no
- * worker was live — so an unrelated crash never inherits a phase.
+ * This is the ONLY report a native worker crash produces. The worker's own
+ * 'exit' event does not fire for one — a SIGABRT out of the model runtime is
+ * neither a graceful exit nor a V8 fatal error — so the bridge never learns its
+ * worker died, and production proved it: across 107 consecutive
+ * `Utility:crashed:Embeddings` events, `worker_exit_<phase>` emitted zero and so
+ * did `embed_failed`.
+ *
+ * It also never arrives while the bridge still owns the worker. Every path that
+ * nulls `process` either latches a teardown phase (`stop()`/`reset()`) or runs
+ * inside an 'exit' handler that emits `EmbeddingWorkerExit` — and production has
+ * neither a phase-suffixed event nor an `EmbeddingWorkerExit` on the affected
+ * release. What is left is `failProcess()`, which forgets a worker that is still
+ * running (start timeout / fatal error) and leaves nothing behind to read. So
+ * the answer has to survive the bridge moving on: hence the last-worker record,
+ * bounded by LAST_WORKER_TTL_MS so an unrelated later crash cannot inherit it.
+ *
+ * Returns null when the report is not about our embedding worker, when the
+ * reason is lifecycle rather than a fault, or when no worker is attributable.
  *
  * @param workerName - `details.name` from `app.on('child-process-gone')`
+ * @param reason - `details.reason` from the same report
  */
-export function getEmbeddingWorkerPhase(workerName: string | undefined): WorkerExitPhase | null {
+export function getEmbeddingWorkerCrashContext(
+  workerName: string | undefined,
+  reason: string
+): EmbeddingWorkerCrashContext | null {
   if (workerName !== WORKER_SERVICE_NAME) return null
-  return bridge.liveWorkerPhase()
+  // A clean idle-shutdown (or an OS memory-pressure eviction) is lifecycle, not a
+  // crash: counting it would make the session crash counter meaningless.
+  if (!isChildProcessFault(reason)) return null
+  bridge.countCrashReport()
+  return bridge.crashContext()
 }

--- a/apps/desktop/src/main/telemetry/diagnostics.test.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.test.ts
@@ -146,6 +146,49 @@ describe('telemetry diagnostics', () => {
       )
     })
 
+    // The crash payload used to ship error_code, message, log_action and exit_code
+    // and nothing else useful, so 76 events on one release were indistinguishable
+    // from each other. Events carry at most ONE dimension, and log_action holds
+    // the phase, so the rest rides in the message and the numeric metrics — both
+    // additive, no contract change, no sync-server deploy.
+    it('carries the dead worker context the crash report used to throw away', () => {
+      trackChildProcessGone({
+        type: 'Utility',
+        reason: 'crashed',
+        name: 'Embeddings',
+        exitCode: 6,
+        phase: 'in_flight',
+        context: {
+          pid: 4821,
+          uptimeMs: 12_345.6,
+          release: 'start_timeout',
+          modelCache: 'partial',
+          modelCacheBytes: 90_112,
+          load: 'reload',
+          crashCount: 3,
+          stderrTail: 'worker stderr tail:\n| libc++abi: terminating'
+        }
+      })
+
+      expect(trackMainEventMock).toHaveBeenCalledWith(
+        'app_log_recorded',
+        expect.objectContaining({
+          errorCode: 'Utility:crashed:Embeddings',
+          dimensions: { log_action: 'child_process_gone_in_flight' },
+          error: {
+            message:
+              'Embeddings utility process crashed (exit 6, in_flight) ' +
+              '[reason=crashed pid=4821 uptime=12346ms release=start_timeout ' +
+              'cache=partial cache_bytes=90112 load=reload crashes=3]',
+            // A dead child leaves no JS stack in this process, so its own stderr
+            // is the closest thing to one this family can ever carry.
+            stack: 'worker stderr tail:\n| libc++abi: terminating'
+          },
+          metrics: { value: 6, durationMs: 12_346, retryCount: 3, byteCount: 90_112 }
+        })
+      )
+    })
+
     it('reports exactly as before when no phase is available', () => {
       trackChildProcessGone({
         type: 'Utility',

--- a/apps/desktop/src/main/telemetry/diagnostics.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.ts
@@ -16,6 +16,38 @@ type DiagnosticLevel = 'debug' | 'info' | 'warn' | 'error'
 const resultForLevel = (level: DiagnosticLevel): TelemetryResult =>
   level === 'error' || level === 'warn' ? 'failed' : 'success'
 
+/**
+ * What the module that owned the dead worker knows about it. Everything here is
+ * a number, a bounded enum, or text the OWNER has already redacted — this module
+ * only formats it.
+ *
+ * Additive by construction: every field is optional and rides inside the
+ * existing `message` / `metrics` fields of `app_log_recorded`. No new event
+ * name, no new dimension key, no contract change — so it needs no sync-server
+ * deploy and cannot break an existing dashboard query.
+ */
+export interface ChildProcessGoneContext {
+  /** OS pid of the dead worker, so reports can be tied to one fork. */
+  pid?: number
+  /** ms between the fork and this report. */
+  uptimeMs?: number
+  /** How the owning module last saw the worker (live, teardown, start_timeout, …). */
+  release?: string
+  /** Whether the worker's model was cached on disk when it was forked. */
+  modelCache?: string
+  modelCacheBytes?: number
+  /** Whether the fork was a first load or a re-load after a prior failure. */
+  load?: string
+  /** Crash reports for this worker family this session, including this one. */
+  crashCount?: number
+  /**
+   * Redacted tail of the dead worker's stderr. For a native abort this is the
+   * closest thing to a stack trace this family can ever produce: the process
+   * that died is not the one reporting, so `stack` is otherwise always empty.
+   */
+  stderrTail?: string
+}
+
 export interface ChildProcessGoneDetails {
   type: string
   reason: string
@@ -33,6 +65,8 @@ export interface ChildProcessGoneDetails {
   // rather than looked up here: the worker modules already import this one, so
   // reaching back into them would close an import cycle.
   phase?: string
+  // Resolved by the same caller, for the same reason.
+  context?: ChildProcessGoneContext
 }
 
 // Utility workers (embeddings, image-processing, voice-model) idle-shutdown
@@ -40,10 +74,39 @@ export interface ChildProcessGoneDetails {
 // (OS memory-pressure kill) — is lifecycle, not a fault, so it must not become an
 // error event. Real faults get a composite code that stays inside the safe-token
 // rules (no '@', '://', '/', '\', ≤64 chars).
+export const isChildProcessFault = (reason: string): boolean =>
+  reason !== 'clean-exit' && reason !== 'memory-eviction'
+
 export const childProcessGoneErrorCode = (details: ChildProcessGoneDetails): string | null => {
-  if (details.reason === 'clean-exit' || details.reason === 'memory-eviction') return null
+  if (!isChildProcessFault(details.reason)) return null
   const worker = details.name ?? details.serviceName ?? ''
   return toSafeToken(`${details.type}:${details.reason}:${worker}`, 'ChildProcessGone')
+}
+
+// Telemetry events carry at most ONE dimension (TelemetryDimensionsSchema), and
+// `log_action` already holds the phase — so the rest of the crash context rides
+// in the message as `key=value` pairs. Bounded enums and numbers only; the
+// owning module supplies them and no user content can reach here.
+const contextSummary = (
+  reason: string,
+  context: ChildProcessGoneContext | undefined
+): string | null => {
+  // No context resolved (GPU, an unowned utility fork) → the message stays byte
+  // identical to what it has always been. This is purely additive.
+  if (!context) return null
+  const parts = [
+    // Baked into the error code as `type:reason:worker`, repeated here so it can
+    // be read without string-splitting the fingerprint.
+    `reason=${reason}`,
+    context.pid !== undefined ? `pid=${context.pid}` : null,
+    context.uptimeMs !== undefined ? `uptime=${Math.round(context.uptimeMs)}ms` : null,
+    context.release ? `release=${context.release}` : null,
+    context.modelCache ? `cache=${context.modelCache}` : null,
+    context.modelCacheBytes !== undefined ? `cache_bytes=${context.modelCacheBytes}` : null,
+    context.load ? `load=${context.load}` : null,
+    context.crashCount !== undefined ? `crashes=${context.crashCount}` : null
+  ].filter((part): part is string => part !== null)
+  return `[${parts.join(' ')}]`
 }
 
 // Reports a `child-process-gone` fault as an error log event, or nothing at all
@@ -66,14 +129,38 @@ export const trackChildProcessGone = (details: ChildProcessGoneDetails): void =>
     details.phase ?? null
   ].filter((part): part is string => part !== null)
   const exit = detail.length > 0 ? ` (${detail.join(', ')})` : ''
+  const summary = contextSummary(details.reason, details.context)
+  // Bounded by TelemetryErrorDetailSchema.message (512). Every part is an
+  // Electron constant, our own worker label, or a number, so it cannot overflow
+  // in practice — the cap is there so a future field can never 400 a whole batch.
+  const message = `${worker} utility process ${details.reason}${exit}${
+    summary ? ` ${summary}` : ''
+  }`.slice(0, 512)
+  // The crash context's numbers ride as metrics so they are queryable without
+  // parsing the message. All four keys already exist in TelemetryMetricsSchema.
+  const metrics: NonNullable<Parameters<typeof trackMainLog>[1]['metrics']> = {}
+  if (typeof details.exitCode === 'number') metrics.value = details.exitCode
+  if (typeof details.context?.uptimeMs === 'number') {
+    metrics.durationMs = Math.max(0, Math.round(details.context.uptimeMs))
+  }
+  if (typeof details.context?.crashCount === 'number') {
+    metrics.retryCount = Math.max(0, details.context.crashCount)
+  }
+  if (typeof details.context?.modelCacheBytes === 'number') {
+    metrics.byteCount = Math.max(0, details.context.modelCacheBytes)
+  }
+  const error: TelemetryErrorDetail = { message }
+  // The dead worker's own stderr. Capped again here (schema max 4000) because
+  // this is native-runtime output and the owner's cap is the only other guard.
+  if (details.context?.stderrTail) error.stack = details.context.stderrTail.slice(0, 4000)
   // errorCode stays stable (no exit code baked in) so the issue grouping counts
   // crashes per worker; the exit status rides along as a metric instead.
   trackMainLog('error', {
     scope: 'Electron',
     action: details.phase ? `child_process_gone_${details.phase}` : 'child_process_gone',
     errorCode,
-    error: { message: `${worker} utility process ${details.reason}${exit}` },
-    metrics: typeof details.exitCode === 'number' ? { value: details.exitCode } : undefined
+    error,
+    metrics: Object.keys(metrics).length > 0 ? metrics : undefined
   })
 }
 
@@ -114,6 +201,7 @@ export const trackMainLog = (
     metrics?: {
       durationMs?: number
       itemCount?: number
+      byteCount?: number
       queueCount?: number
       retryCount?: number
       value?: number

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -731,21 +731,59 @@ reason, phase, mode, status, kind, result`, plus numeric metric keys like
   separates a harmless teardown crash (`idle_shutdown` — the embedding was already delivered) from
   real user impact (`in_flight` — the user silently lost semantic-search indexing for that note).
 
-  The phase is resolved by `getEmbeddingWorkerPhase(details.name)` at the `child-process-gone` call
-  site, **not** inside the worker's own `exit` handler. Electron's `UtilityProcess` `exit` event
-  does not fire for a native crash — a SIGABRT out of the model runtime is neither a graceful exit
-  nor the V8 `FatalError` the instance `error` event covers — so the bridge never learns its worker
-  died. Production proved it: across 107 consecutive `Utility:crashed:Embeddings` events the
-  bridge's own `worker_exit_<phase>` breadcrumb emitted **zero**, and so did `embed_failed`, while
-  `child-process-gone` fired for all 107. Resolving the phase at the report that does arrive is
-  what makes those events answerable. The `worker_exit_<phase>` breadcrumb is kept for the paths
-  where `exit` does fire (a non-crash abnormal exit, a force-kill), and carries a different error
-  code (`EmbeddingWorkerExit`) so the two are never confused.
+  The phase is resolved by `getEmbeddingWorkerCrashContext(details.name, details.reason)` at the
+  `child-process-gone` call site, **not** inside the worker's own `exit` handler. Electron's
+  `UtilityProcess` `exit` event does not fire for a native crash — a SIGABRT out of the model
+  runtime is neither a graceful exit nor the V8 `FatalError` the instance `error` event covers — so
+  the bridge never learns its worker died. Production proved it: across 107 consecutive
+  `Utility:crashed:Embeddings` events the bridge's own `worker_exit_<phase>` breadcrumb emitted
+  **zero**, and so did `embed_failed`, while `child-process-gone` fired for all 107. Resolving the
+  phase at the report that does arrive is what makes those events answerable. The
+  `worker_exit_<phase>` breadcrumb is kept for the paths where `exit` does fire (a non-crash
+  abnormal exit, a force-kill), and carries a different error code (`EmbeddingWorkerExit`) so the
+  two are never confused.
+
+  **The report never arrives while the bridge still owns the worker.** Resolving the phase from the
+  live handle alone therefore answered `null` in 100% of production crashes (issue #1582): 76 events
+  on `2026.817.1`, none of them phase-suffixed. Every path that nulls the process handle either
+  latches a teardown phase (`stop()` / `reset()`) or runs inside an `exit` handler that emits
+  `EmbeddingWorkerExit` — and production has neither on that release. What remains is
+  `failProcess()`, which forgets a worker that is **still running** (10s start timeout, fatal
+  error). So the bridge keeps a **last-worker record** — pid, phase, how it was released, fork
+  timestamp, model-cache state, stderr tail — bounded by a 60s TTL so an unrelated later crash
+  cannot inherit it. `failProcess()` now also kills the worker it gives up on: the orphan was
+  unreachable (every request goes through the process handle) yet kept a whole onnxruntime alive to
+  abort later.
 
   Anything reading the phase from outside the exit handler must also survive the force-kill race:
-  `reset()` latches `idle_shutdown` before killing, then nulls the process handle, so the latch is
-  cleared when there is no process to kill — the latch now outlives the exit handler that used to
-  clear it, and a stale one would make the next worker's crash read as a teardown it never had.
+  `reset()` latches `idle_shutdown` before killing, then nulls the process handle, so both the latch
+  and the last-worker record are cleared when there is no process to kill — the latch now outlives
+  the exit handler that used to clear it, and a stale one would make the next worker's crash read as
+  a teardown it never had.
+
+  The crash report also carries what the main process knew about that worker. Telemetry events
+  accept **at most one dimension** (`TelemetryDimensionsSchema`) and `log_action` holds the phase,
+  so the rest ships inside fields that already exist — no new event name, no new dimension key, no
+  contract change, and therefore no sync-server deploy:
+
+  | Fact                                                    | Where it ships          | Query it as                  |
+  | ------------------------------------------------------- | ----------------------- | ---------------------------- |
+  | lifecycle phase                                         | `dimensions.log_action` | `log_action` (logs + events) |
+  | platform exit status                                    | `metrics.value`         | `exit_code` (logs) / `value` |
+  | worker uptime at death                                  | `metrics.durationMs`    | `duration_ms` (events)       |
+  | crashes this session                                    | `metrics.retryCount`    | `retry_count` (events)       |
+  | cached model size                                       | `metrics.byteCount`     | `byte_count` (events)        |
+  | pid, reason, release, cache state, first-load vs reload | `error.message` suffix  | `message` (logs)             |
+  | worker stderr tail                                      | `error.stack`           | `stack` (logs)               |
+
+  The message suffix is a bounded `[reason=… pid=… uptime=…ms release=… cache=… cache_bytes=…
+load=… crashes=…]` block appended only when a context was resolved, so every other
+  `child-process-gone` family's message is byte-identical to before. The stderr tail is the closest
+  thing to a stack trace this family can produce — the process that died is not the one reporting,
+  so `stack` is otherwise always empty. It is captured into a bounded per-worker ring buffer,
+  redacted on the device with the same salted `redactText` setup as Path A log shipping, capped at
+  2000 bytes, and every line is prefixed so it can never be mis-parsed back into a fabricated
+  PostHog Error Tracking frame.
 
   Embedding generation failures emit `embed_failed`, throttled to one event per 5-minute window
   because a broken worker would otherwise fail once per note edit.


### PR DESCRIPTION
Fixes #1582

## What this is honest about

The root cause is still a **native abort inside onnxruntime / `@huggingface/transformers`**. This PR does **not** fix that — nothing in the current telemetry can even say which of the three candidate bugs it is. What it fixes is the reason we cannot tell: the crash report arrived with no phase, no pid, no uptime, and no stderr, so 76 events on `2026.817.1` were indistinguishable from each other.

| | Status |
| --- | --- |
| Crash reports resolve a lifecycle phase | **Fixed** |
| `failProcess()` orphaning a live worker | **Fixed** (it is killed now) |
| Report carries pid / uptime / cache state / reason / crash counter / stderr tail | **Added** |
| Why onnxruntime aborts | **Now diagnosable**, not fixed |
| Retrying a lost in-flight embed | **Deliberately not done** — see below |

## Which path produced the null phase

`liveWorkerPhase()` returned `pendingExitPhase ?? (process ? currentPhase() : null)` and production resolved `null` in 100% of crashes, so **both** were already null when `child-process-gone` fired. Ruling the candidates out from the code plus the production counters in the issue:

- **`stop()` / `reset()` teardown — RULED OUT.** Both latch `pendingExitPhase = 'idle_shutdown'` before killing, and that latch is only ever cleared by the worker's `'exit'` handler — which does not fire for a native crash. A crash report landing after a teardown would therefore have shipped `child_process_gone_idle_shutdown`. **Zero phase-suffixed events exist on any version.**
- **Both `'exit'` handlers — RULED OUT.** Every non-lifecycle exit calls `trackWorkerExit`, which emits `EmbeddingWorkerExit`. Production has **4 of those in total** (one install, one older release, all `worker_exit_idle_shutdown` code 0) and **zero on `2026.817.1`**.
- **`details.name` mismatch — RULED OUT.** Electron's own types (`electron.d.ts:21513`) document the fork's `serviceName` option as landing in the `name` property of `child-process-gone`, so the resolver's `workerName !== 'Embeddings'` guard was not the thing returning early.
- **`failProcess()` — the surviving path.** It is the only one that nulls `this.process` while latching nothing and emitting nothing. It is reached from the 10s `START_TIMEOUT_MS` and from the fatal-`'error'` handlers. Crucially it also **did not kill the child**: the orphan was unreachable (every request goes through `this.process`) but stayed alive holding a whole onnxruntime, free to abort minutes later — landing exactly the un-attributable report we see.

## What changed

**1. The resolver stops losing the answer.** The bridge keeps a last-worker record (pid, phase at release, how it was released, fork timestamp, model-cache state, stderr tail), bounded by a 60s TTL so an unrelated later crash cannot inherit it. `getEmbeddingWorkerPhase(name)` becomes `getEmbeddingWorkerCrashContext(name, reason)`. `currentPhase()` now returns `starting` for a worker that never sent `ready` instead of mislabelling it `idle`.

**2. The defensive fix.** `failProcess()` kills the worker it gives up on. This also closes a second bug: the orphan's late `ready` message re-attached handlers and could flip `loaded = true` for a process the bridge no longer owned, so `isModelLoaded()` could lie.

**3. The missing dimensions.** Telemetry events accept **at most one dimension** (`TelemetryDimensionsSchema`) and `log_action` holds the phase, so the rest rides in fields that already exist — no new event name, no new dimension key, no contract change, **no sync-server deploy**, and every existing dashboard query keeps working:

| Fact | Ships in | Query as |
| --- | --- | --- |
| lifecycle phase | `dimensions.log_action` | `log_action` (logs + events) |
| exit status | `metrics.value` | `exit_code` (logs) |
| uptime at death | `metrics.durationMs` | `duration_ms` (events) |
| crashes this session | `metrics.retryCount` | `retry_count` (events) |
| cached model size | `metrics.byteCount` | `byte_count` (events) |
| pid, reason, release, cache state, first-load vs reload | `error.message` suffix | `message` (logs) |
| worker stderr tail | `error.stack` | `stack` (logs) |

Non-embedding families (GPU, `CrdtPreflight`) get a byte-identical message to today — the suffix is only appended when a context was resolved.

**4. The stderr tail.** Captured into a bounded per-worker ring buffer, redacted on-device with the same salted `redactText` setup Path A log shipping uses, capped at 2000 bytes client-side and 4000 again at the telemetry boundary. Every line is prefixed so it can never be parsed back into a fabricated PostHog Error Tracking frame (`posthog-transform.ts` matches `/^\s*at\s/` per line on `error.stack`).

## What I deliberately did not do

- **No retry for a lost in-flight embed.** Whether `in_flight` is even the common phase is exactly what this PR makes measurable; adding a retry now would be guessing at a rate we are about to learn.
- **No model-cache validation/repair.** Same reason — the `cache=` dimension exists to test that hypothesis first.
- **`details.reason` is not a real dimension.** It cannot be: events are capped at one dimension and `log_action` is load-bearing. It ships as `reason=` inside the message suffix instead.
- **Crash counter is per session, not per install.** Per-install would need persistence; the session counter already separates a burst from a drip.

## Read the new dimensions on the release after this ships

PostHog project 412311. First, does the phase resolve at all:

```sql
SELECT properties.log_action, count() AS events, uniq(distinct_id) AS installs
FROM events
WHERE event = 'app_log_recorded'
  AND properties.error_code = 'Utility:crashed:Embeddings'
  AND properties.app_version = '<next release>'
  AND timestamp > now() - INTERVAL 7 DAY
GROUP BY 1 ORDER BY events DESC
```

Any `child_process_gone_<phase>` row means the resolver works. `in_flight` = users are losing indexing; `idle_shutdown` / `graceful_stop` = free.

Then the new dimensions:

```sql
SELECT properties.log_action,
       quantile(0.5)(properties.duration_ms) AS median_uptime_ms,
       max(properties.retry_count) AS max_crashes_per_session,
       quantile(0.5)(properties.byte_count) AS median_cache_bytes,
       count() AS events
FROM events
WHERE event = 'app_log_recorded'
  AND properties.error_code = 'Utility:crashed:Embeddings'
  AND timestamp > now() - INTERVAL 7 DAY
GROUP BY 1
```

And the text fields, in the `logs` table:

```sql
SELECT body FROM logs
WHERE service_name = 'desktop'
  AND JSONExtractString(body, 'error_code') = 'Utility:crashed:Embeddings'
  AND timestamp > now() - INTERVAL 7 DAY
ORDER BY timestamp DESC LIMIT 50
```

`message` carries `[reason=… pid=… uptime=…ms release=… cache=… cache_bytes=… load=… crashes=…]`; `stack` carries the stderr tail. Three reads that decide the next fix: `release=start_timeout` confirms the orphan path; `cache=partial` on repeat-crashing installs confirms the torn-download hypothesis; a `libc++abi:` / onnxruntime line in `stack` names the abort.

## Verification

| Command | Result |
| --- | --- |
| `pnpm --filter @memry/desktop typecheck:node` | **pass** (exit 0) |
| `pnpm --filter @memry/desktop typecheck:test` | **exit 2** — 2 errors, both pre-existing in `sidebar-nav.test.tsx` (untouched here; `onNavMiddleClick` added by `808a4e431` on main) |
| `pnpm lint` | **pass** (exit 0); changed files contribute zero warnings |
| `vitest --project main src/main/lib/embeddings.test.ts src/main/telemetry/diagnostics.test.ts` | **72 passed** |
| full `test:main` suite | 531 files / 6868 tests passed; 1 unrelated flake (`notion-importer` `beforeEach` 30s hook timeout under load) which **passes in isolation** |
| `pnpm check:architecture` / `pnpm check:contracts` | **pass** |
| `pnpm docs:impact --base origin/main --strict` | **covered** |
| `pnpm docs:build` | **pass** |

New tests prove the thing that is easy to fake: `attributes a crash that lands after the start timeout forgot the worker` drives a real 10s start timeout, asserts the bridge has fully let go, and only then resolves the report — with `release: 'start_timeout'`, a state reachable *only* through the last-worker record. Plus: TTL expiry, live-worker precedence over the record, crash counter vs lifecycle reasons, uptime, stderr tail capture, orphan kill, and the stack-frame guard.

## Backward compatibility

Additive only. `errorCode` (`Utility:crashed:Embeddings`) is unchanged, so PostHog Error Tracking issue history is not orphaned. `log_action` gains phase-suffixed values, which is the shipped-but-dead mechanism from `e2cdf5b74` finally producing output. All four metric keys already exist in `TelemetryMetricsSchema`; the sync-server validates batches with the unchanged schema.