### PR TITLE
fix(desktop): quitting saves your latest edits instead of dropping them

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -65,6 +65,9 @@ const getCrdtProviderMock = vi.fn(() => ({
   getDoc: getProviderDocMock
 }))
 const stopSyncRuntimeMock = vi.fn(async () => undefined)
+const flushPendingWritebacksMock = vi.fn(async () => undefined)
+const closeAllDatabasesMock = vi.fn()
+const markShutdownFailureMock = vi.fn()
 const stopEmbeddingModelMock = vi.fn(async () => undefined)
 const startGoogleCalendarSyncRunnerMock = vi.fn(async () => undefined)
 const stopGoogleCalendarSyncRunnerMock = vi.fn()
@@ -277,7 +280,19 @@ vi.mock('./sync/runtime', () => ({
 }))
 
 vi.mock('./database/client', () => ({
-  getIndexDatabase: vi.fn(() => ({}))
+  getIndexDatabase: vi.fn(() => ({})),
+  closeAllDatabases: closeAllDatabasesMock
+}))
+
+vi.mock('./sync/crdt-writeback', () => ({
+  flushPendingWritebacks: flushPendingWritebacksMock
+}))
+
+vi.mock('./telemetry/crash-marker', () => ({
+  clearCrashMarker: vi.fn(),
+  detectUncleanShutdown: vi.fn(),
+  installCrashMarker: vi.fn(),
+  markShutdownFailure: markShutdownFailureMock
 }))
 
 vi.mock('@main/database/queries/notes', () => ({
@@ -2004,7 +2019,40 @@ describe('main index phase2 exports', () => {
     expect(createSnapshotMock).toHaveBeenCalledTimes(2)
   })
 
-  it('forces exit on graceful shutdown timeout', async () => {
+  it('flushes pending write-backs and closes the databases before the forced exit', async () => {
+    // #given a vault close that never settles, so the budget runs out on the
+    // last teardown step (#1586)
+    vi.useFakeTimers()
+    whenReadyMock.mockResolvedValue(undefined)
+    closeVaultMock.mockImplementationOnce(() => new Promise(() => {}))
+
+    await importMainModule()
+    await flushReadyWork()
+    const { app } = await import('electron')
+    const { SHUTDOWN_BUDGET_MS } = await import('./shutdown-sequence')
+
+    const beforeQuitHandler = appOnMock.mock.calls.find(
+      ([event]) => event === 'before-quit'
+    )?.[1] as (event: { preventDefault: () => void }) => void
+    beforeQuitHandler({ preventDefault: vi.fn() })
+
+    completeFlush(browserWindows[0])
+    await flushUntil(() => closeVaultMock.mock.calls.length > 0)
+
+    // #when the shutdown budget expires
+    await vi.advanceTimersByTimeAsync(SHUTDOWN_BUDGET_MS)
+
+    // #then the marker names the step that overran, and the last chance to make
+    // the user's data durable runs BEFORE the process is killed
+    expect(markShutdownFailureMock).toHaveBeenCalledWith('timeout', 'close-vault')
+    await flushUntil(() => vi.mocked(app.exit).mock.calls.length > 0)
+    expect(flushPendingWritebacksMock).toHaveBeenCalled()
+    expect(closeAllDatabasesMock).toHaveBeenCalled()
+    expect(app.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('does not force-exit before the graceful budget is spent', async () => {
+    // #given the same wedged vault close
     vi.useFakeTimers()
     whenReadyMock.mockResolvedValue(undefined)
     closeVaultMock.mockImplementationOnce(() => new Promise(() => {}))
@@ -2019,12 +2067,14 @@ describe('main index phase2 exports', () => {
     beforeQuitHandler({ preventDefault: vi.fn() })
 
     completeFlush(browserWindows[0])
-    for (let i = 0; i < 20; i++) {
-      await Promise.resolve()
-    }
-    vi.advanceTimersByTime(5000)
+    await flushUntil(() => closeVaultMock.mock.calls.length > 0)
 
-    expect(app.exit).toHaveBeenCalledWith(1)
+    // #when the old 5s deadline passes — the point at which the app used to be
+    // killed with write-back timers still armed
+    await vi.advanceTimersByTimeAsync(5000)
+
+    // #then the chain is still allowed to finish
+    expect(app.exit).not.toHaveBeenCalled()
   })
 
   it('exits with failure when graceful cleanup rejects', async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -103,11 +103,19 @@ import {
   warnPinningUnconfiguredOnce
 } from './sync/certificate-pinning'
 import { getCrdtProvider } from './sync/crdt-provider'
+import { flushPendingWritebacks } from './sync/crdt-writeback'
 import { stopSyncRuntime } from './sync/runtime'
 import { beginAppShutdown, isAppShuttingDown } from './app-shutdown'
+import {
+  completeWithin,
+  runShutdownSequence,
+  SHUTDOWN_HARD_BACKSTOP_MS,
+  SHUTDOWN_LAST_CHANCE_MS,
+  type ShutdownStep
+} from './shutdown-sequence'
 import { getValidAccessToken } from './sync/token-manager'
 import { getNoteCacheById } from '@main/database/queries/notes'
-import { getIndexDatabase } from './database/client'
+import { closeAllDatabases, getIndexDatabase } from './database/client'
 import { toAbsolutePath, createSnapshot } from './vault/notes'
 import { safeRead } from './vault/file-ops'
 import { SnapshotReasons } from '@memry/db-schema/schema/notes-cache'
@@ -609,8 +617,7 @@ const DEFAULT_MAIN_WINDOW_SIZE = { width: 1550, height: 900 } as const
 const VAULT_PICKER_WINDOW_SIZE = { width: 760, height: 560 } as const
 
 function getInitialMainWindowSize():
-  | typeof DEFAULT_MAIN_WINDOW_SIZE
-  | typeof VAULT_PICKER_WINDOW_SIZE {
+  typeof DEFAULT_MAIN_WINDOW_SIZE | typeof VAULT_PICKER_WINDOW_SIZE {
   if (process.env.MEMRY_FORCE_VAULT_PICKER === '1') return VAULT_PICKER_WINDOW_SIZE
   return getCurrentVaultPath() ? DEFAULT_MAIN_WINDOW_SIZE : VAULT_PICKER_WINDOW_SIZE
 }
@@ -1983,7 +1990,12 @@ function removePendingFlush(requestId: string): void {
   flushDoneListenerAttached = false
 }
 
-function flushWindow(win: BrowserWindow, timeoutMs = 2000): Promise<void> {
+// How long one window gets to answer the save handshake. On the quit path this
+// is clamped further by the shared shutdown deadline, so the handshake can never
+// spend budget the rest of the chain still needs.
+const FLUSH_WINDOW_TIMEOUT_MS = 2000
+
+function flushWindow(win: BrowserWindow, timeoutMs = FLUSH_WINDOW_TIMEOUT_MS): Promise<void> {
   return new Promise<void>((resolve) => {
     if (win.isDestroyed() || !win.webContents) {
       shutdownLog.info('flushWindow: window already destroyed', win.id)
@@ -2014,11 +2026,11 @@ function flushWindow(win: BrowserWindow, timeoutMs = 2000): Promise<void> {
   })
 }
 
-async function flushAllWindows(): Promise<void> {
+async function flushAllWindows(timeoutMs = FLUSH_WINDOW_TIMEOUT_MS): Promise<void> {
   const windows = BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed())
   if (windows.length === 0) return
   shutdownLog.info(`flushing ${windows.length} window(s)...`)
-  await Promise.allSettled(windows.map((w) => flushWindow(w)))
+  await Promise.allSettled(windows.map((w) => flushWindow(w, timeoutMs)))
   shutdownLog.info('flush complete')
 }
 
@@ -2053,6 +2065,35 @@ async function createCloseSnapshots(): Promise<void> {
   }
 }
 
+/**
+ * Last chance to make the user's data durable once the graceful chain has run
+ * out of budget.
+ *
+ * The forced exit below is what used to lose edits (#1586): the debounced CRDT
+ * write-back timers were still armed — up to 5s of typing that had never
+ * reached the markdown file — and the SQLite WAL had never been checkpointed,
+ * because both only happened at the very END of the chain. Neither depends on
+ * whichever step is wedged, and both are cheap, so they run even now that the
+ * budget is gone. A hung teardown degrades to a slow quit, not to lost work.
+ */
+async function flushDurabilityBeforeForcedExit(): Promise<void> {
+  const flushed = await completeWithin(
+    flushPendingWritebacks().catch((error) => {
+      shutdownLog.error('last-chance write-back flush failed', error)
+    }),
+    SHUTDOWN_LAST_CHANCE_MS
+  )
+  if (!flushed) shutdownLog.error('last-chance write-back flush did not finish in time')
+
+  // `synchronous = NORMAL` defers durability to the checkpoint that close()
+  // performs, so an exit without it leaves an un-checkpointed WAL behind.
+  try {
+    closeAllDatabases()
+  } catch (error) {
+    shutdownLog.error('last-chance database close failed', error)
+  }
+}
+
 // Graceful shutdown: close vault and databases before quitting
 app.on('before-quit', (event) => {
   if (headlessCliArgs) return
@@ -2075,90 +2116,155 @@ app.on('before-quit', (event) => {
 
   shutdownLog.info('starting graceful shutdown...')
 
-  // Set timeout to force exit if shutdown takes too long
-  const shutdownTimeout = setTimeout(() => {
-    // If the user asked to install an update, still hand off to Squirrel/NSIS
-    // rather than app.exit() — a hard exit skips the install (and bypasses
-    // autoInstallOnAppQuit), so the update never applies and the app re-prompts.
-    // The forced exit below never flushes the log queue; the crash marker is
-    // what carries this failure to the next launch (SHUTDOWN_TIMEOUT).
-    markShutdownFailure('timeout')
+  // If the user asked to install an update, hand off to Squirrel/NSIS rather
+  // than app.exit() — a hard exit skips the install (and bypasses
+  // autoInstallOnAppQuit), so the update never applies and the app re-prompts.
+  const forceExit = (): void => {
     if (isQuitAndInstallRequested()) {
-      shutdownLog.error('cleanup timed out; installing downloaded update anyway')
+      shutdownLog.error('cleanup did not finish; installing downloaded update anyway')
       performQuitAndInstall()
     } else {
-      shutdownLog.error('timeout - forcing exit')
+      shutdownLog.error('forcing exit')
       app.exit(1)
     }
-  }, 5000) // 5 second timeout
+  }
 
-  // Flush pending saves from all renderer windows before closing vault
-  flushAllWindows()
-    .then(() => createCloseSnapshots())
-    .then(() => {
-      shutdownLog.info('stopping snooze scheduler...')
-      stopSnoozeScheduler()
+  // Hard backstop. Every path below is individually bounded, but a quit that
+  // never ends is a visibly broken quit, so one timer outside the sequence
+  // guarantees the process always exits.
+  const hardBackstop = setTimeout(() => {
+    shutdownLog.error('hard backstop reached')
+    forceExit()
+  }, SHUTDOWN_HARD_BACKSTOP_MS)
 
-      shutdownLog.info('stopping reminder scheduler...')
-      stopReminderScheduler()
+  // Ordered by durability, not by convenience. The two steps that make the
+  // user's most recent edits durable run FIRST, so a wedged teardown step can no
+  // longer eat the budget ahead of them (#1586).
+  const steps: ShutdownStep[] = [
+    {
+      // Renderer edits still sitting in an editor -> main's Y.Docs.
+      name: 'flush-windows',
+      run: (deadline) => flushAllWindows(deadline.cap(FLUSH_WINDOW_TIMEOUT_MS))
+    },
+    {
+      // Main's Y.Docs -> the markdown files. The write-back is debounced by
+      // 500ms, stretched to 5s under back-pressure, and this used to happen only
+      // inside CrdtProvider.destroy() at the very end of the chain — which is
+      // exactly why a timed-out quit dropped the last seconds of typing.
+      name: 'flush-writebacks',
+      run: () => flushPendingWritebacks()
+    },
+    { name: 'close-snapshots', run: () => createCloseSnapshots() },
+    {
+      name: 'stop-schedulers',
+      run: () => {
+        shutdownLog.info('stopping snooze scheduler...')
+        stopSnoozeScheduler()
 
-      shutdownLog.info('stopping inbox review scheduler...')
-      stopInboxReviewScheduler()
+        shutdownLog.info('stopping reminder scheduler...')
+        stopReminderScheduler()
 
-      shutdownLog.info('stopping Google Calendar sync runner...')
-      stopGoogleCalendarSyncRunner()
-    })
-    .then(() => {
-      shutdownLog.info('stopping capture server...')
-      return stopCaptureServer()
-    })
-    .then(() => {
-      shutdownLog.info('stopping AI inline chat server...')
-      return stopChatServer()
-    })
-    .then(() => {
-      shutdownLog.info('stopping voice transcription utility...')
-      return stopVoiceModel()
-    })
-    .then(() => {
-      shutdownLog.info('stopping image processing utility...')
-      return stopImageProcessing()
-    })
-    .then(() => {
-      // Terminate the embeddings utilityProcess explicitly. On Windows it runs
-      // as the app binary (Memrynote.exe); if left to its 30s idle self-exit it
-      // can outlive the NSIS CHECK_APP_RUNNING window and block the update
-      // install ("MemryNote cannot be closed", #805).
-      shutdownLog.info('stopping embeddings utility...')
-      return stopEmbeddingModel()
-    })
-    .then(async () => {
-      shutdownLog.info('stopping active heartbeat...')
-      stopActiveHeartbeat()
-      shutdownLog.info('flushing log-ship transport...')
-      await getLogShip()?.dispose()
-      shutdownLog.info('flushing telemetry runtime...')
-      return disposeTelemetryRuntime()
-    })
-    .then(() => {
-      // When installing an update, skip the final CRDT snapshot push: it's an
-      // unbounded network round-trip that can stall shutdown for tens of seconds
-      // (and the installer is about to swap the binary anyway). The next launch
-      // syncs. A normal quit still pushes so nothing is left unsynced.
-      if (isQuitAndInstallRequested()) {
-        shutdownLog.info('stopping sync runtime (skip final push for update)...')
-        return stopSyncRuntime({ skipFinalSync: true })
+        shutdownLog.info('stopping inbox review scheduler...')
+        stopInboxReviewScheduler()
+
+        shutdownLog.info('stopping Google Calendar sync runner...')
+        stopGoogleCalendarSyncRunner()
       }
-      shutdownLog.info('stopping sync runtime...')
-      return stopSyncRuntime()
-    })
-    .then(() => {
-      shutdownLog.info('closing vault and stopping watcher...')
-      return closeVault()
-    })
-    .then(() => {
-      shutdownLog.info('cleanup complete')
-      clearTimeout(shutdownTimeout)
+    },
+    {
+      name: 'stop-capture-server',
+      run: () => {
+        shutdownLog.info('stopping capture server...')
+        return stopCaptureServer()
+      }
+    },
+    {
+      name: 'stop-chat-server',
+      run: () => {
+        shutdownLog.info('stopping AI inline chat server...')
+        return stopChatServer()
+      }
+    },
+    {
+      // Concurrent, not sequential: three independent utility processes with a
+      // 3,000ms stop timeout each cost 9,000ms in a row and 3,000ms together —
+      // on their own more than the whole shutdown budget used to be.
+      // Terminating embeddings explicitly still matters on Windows, where it
+      // runs as the app binary (Memrynote.exe) and its 30s idle self-exit can
+      // outlive the NSIS CHECK_APP_RUNNING window and block the install (#805).
+      name: 'stop-utility-processes',
+      run: async () => {
+        const utilities: Array<[string, () => Promise<void>]> = [
+          ['voice transcription', stopVoiceModel],
+          ['image processing', stopImageProcessing],
+          ['embeddings', stopEmbeddingModel]
+        ]
+        shutdownLog.info('stopping utility processes...')
+        const results = await Promise.allSettled(utilities.map(([, stop]) => stop()))
+        results.forEach((result, index) => {
+          if (result.status === 'rejected') {
+            shutdownLog.error(`failed to stop ${utilities[index][0]} utility`, result.reason)
+          }
+        })
+      }
+    },
+    {
+      name: 'flush-telemetry',
+      run: async () => {
+        shutdownLog.info('stopping active heartbeat...')
+        stopActiveHeartbeat()
+        shutdownLog.info('flushing log-ship transport...')
+        await getLogShip()?.dispose()
+        shutdownLog.info('flushing telemetry runtime...')
+        return disposeTelemetryRuntime()
+      }
+    },
+    {
+      name: 'stop-sync-runtime',
+      run: () => {
+        // When installing an update, skip the final CRDT snapshot push: it's an
+        // unbounded network round-trip that can stall shutdown for tens of
+        // seconds (and the installer is about to swap the binary anyway). The
+        // next launch syncs. A normal quit still pushes so nothing is left
+        // unsynced.
+        if (isQuitAndInstallRequested()) {
+          shutdownLog.info('stopping sync runtime (skip final push for update)...')
+          return stopSyncRuntime({ skipFinalSync: true })
+        }
+        shutdownLog.info('stopping sync runtime...')
+        return stopSyncRuntime()
+      }
+    },
+    {
+      name: 'close-vault',
+      run: () => {
+        shutdownLog.info('closing vault and stopping watcher...')
+        return closeVault()
+      }
+    }
+  ]
+
+  runShutdownSequence(steps)
+    .then(async (outcome) => {
+      if (outcome.status === 'timeout') {
+        // Stamped before anything else: whatever happens next, the next launch
+        // has to be able to name the step that overran, so a recurring timeout
+        // is diagnosable instead of landing as a bare SHUTDOWN_TIMEOUT. The
+        // forced exit never flushes the log queue; the marker survives it.
+        markShutdownFailure('timeout', outcome.overrunStep ?? undefined)
+        shutdownLog.error('cleanup ran out of budget', {
+          step: outcome.overrunStep,
+          stepMs: outcome.overrunStepMs,
+          elapsedMs: outcome.elapsedMs
+        })
+        await flushDurabilityBeforeForcedExit()
+        clearTimeout(hardBackstop)
+        forceExit()
+        return
+      }
+
+      shutdownLog.info('cleanup complete', { elapsedMs: outcome.elapsedMs })
+      clearTimeout(hardBackstop)
       // Cleanup finished: this shutdown is clean, so the next launch must not
       // report app_crashed. The timeout/failed-cleanup paths deliberately keep
       // the marker — a hung or failed shutdown IS an unclean exit worth seeing.
@@ -2178,20 +2284,18 @@ app.on('before-quit', (event) => {
         app.quit()
       }
     })
-    .catch((error) => {
+    .catch(async (error) => {
       shutdownLog.error('error during cleanup:', error)
-      clearTimeout(shutdownTimeout)
       // Same as the timeout path: the exit below outruns any log flush, so the
       // marker reports this shutdown failure on the next launch.
       markShutdownFailure('cleanup_error')
+      // A rejected step is exactly the case where the durability tail never
+      // ran, so the same last-chance flush applies before the hard exit.
+      await flushDurabilityBeforeForcedExit()
+      clearTimeout(hardBackstop)
       // Same as the timeout path: a pending install must survive a failed
       // cleanup, otherwise the hard exit drops the update and the loop returns.
-      if (isQuitAndInstallRequested()) {
-        shutdownLog.error('cleanup failed; installing downloaded update anyway')
-        performQuitAndInstall()
-      } else {
-        app.exit(1)
-      }
+      forceExit()
     })
 })
 

--- a/apps/desktop/src/main/shutdown-sequence.test.ts
+++ b/apps/desktop/src/main/shutdown-sequence.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+import {
+  completeWithin,
+  runShutdownSequence,
+  SHUTDOWN_BUDGET_MS,
+  SHUTDOWN_HARD_BACKSTOP_MS,
+  SHUTDOWN_LAST_CHANCE_MS,
+  type ShutdownStep
+} from './shutdown-sequence'
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+const never = (): Promise<void> => new Promise<void>(() => {})
+
+describe('runShutdownSequence', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('runs every step in order and reports how long the quit took', async () => {
+    // #given two steps that each take 100ms
+    const ran: string[] = []
+    const steps: ShutdownStep[] = [
+      {
+        name: 'flush-writebacks',
+        run: async () => {
+          ran.push('flush-writebacks')
+          await delay(100)
+        }
+      },
+      {
+        name: 'close-vault',
+        run: async () => {
+          ran.push('close-vault')
+          await delay(100)
+        }
+      }
+    ]
+
+    // #when the sequence runs inside a budget that comfortably fits them
+    const sequence = runShutdownSequence(steps, { budgetMs: 1000 })
+    await vi.advanceTimersByTimeAsync(200)
+    const outcome = await sequence
+
+    // #then both ran, in order, and the quit is reported as clean
+    expect(ran).toEqual(['flush-writebacks', 'close-vault'])
+    expect(outcome).toEqual({
+      status: 'complete',
+      overrunStep: null,
+      overrunStepMs: 0,
+      elapsedMs: 200
+    })
+  })
+
+  it('names the step that was still running when the budget ran out', async () => {
+    // #given a teardown step that never settles
+    const steps: ShutdownStep[] = [
+      { name: 'flush-windows', run: () => delay(100) },
+      { name: 'stop-sync-runtime', run: () => never() }
+    ]
+
+    // #when the budget expires
+    const sequence = runShutdownSequence(steps, { budgetMs: 1000 })
+    await vi.advanceTimersByTimeAsync(1000)
+    const outcome = await sequence
+
+    // #then the failure is attributable to a step, not to "shutdown was slow"
+    expect(outcome.status).toBe('timeout')
+    expect(outcome.overrunStep).toBe('stop-sync-runtime')
+    expect(outcome.overrunStepMs).toBe(900)
+    expect(outcome.elapsedMs).toBe(1000)
+  })
+
+  it('lets the durability work finish even when a later step hangs forever', async () => {
+    // #given the write-back flush ordered ahead of a wedged teardown step —
+    // the exact shape of #1586, where a hung step consumed the whole budget and
+    // the forced exit dropped the user's pending note write-backs
+    let writebacksFlushed = false
+    const steps: ShutdownStep[] = [
+      {
+        name: 'flush-writebacks',
+        run: async () => {
+          await delay(50)
+          writebacksFlushed = true
+        }
+      },
+      { name: 'stop-utility-processes', run: () => never() }
+    ]
+
+    // #when the budget expires on the hung step
+    const sequence = runShutdownSequence(steps, { budgetMs: 1000 })
+    await vi.advanceTimersByTimeAsync(1000)
+    const outcome = await sequence
+
+    // #then the pending writes had already landed
+    expect(writebacksFlushed).toBe(true)
+    expect(outcome.overrunStep).toBe('stop-utility-processes')
+  })
+
+  it('caps a bounded wait to what is left of the shared deadline', async () => {
+    // #given two steps that each want a 2,000ms bounded wait
+    const requested: number[] = []
+    const steps: ShutdownStep[] = [
+      {
+        name: 'flush-windows',
+        run: async (deadline) => {
+          requested.push(deadline.cap(2000))
+          await delay(900)
+        }
+      },
+      {
+        name: 'stop-capture-server',
+        run: (deadline) => {
+          requested.push(deadline.cap(2000))
+        }
+      }
+    ]
+
+    // #when they run under a 1,000ms budget
+    const sequence = runShutdownSequence(steps, { budgetMs: 1000 })
+    await vi.advanceTimersByTimeAsync(900)
+    await sequence
+
+    // #then neither could ask for more than the budget still holds, so their
+    // waits can never sum past it
+    expect(requested).toEqual([1000, 100])
+  })
+
+  it('holds the whole chain to the budget however many steps overrun', async () => {
+    // #given four steps that each want 3,000ms — 12,000ms in a row
+    const steps: ShutdownStep[] = [1, 2, 3, 4].map((n) => ({
+      name: `step-${n}`,
+      run: () => delay(3000)
+    }))
+
+    // #when the budget is 1,000ms
+    const sequence = runShutdownSequence(steps, { budgetMs: 1000 })
+    await vi.advanceTimersByTimeAsync(1000)
+    const outcome = await sequence
+
+    // #then the quit still ends at the budget, on the first step
+    expect(outcome.status).toBe('timeout')
+    expect(outcome.elapsedMs).toBe(1000)
+    expect(outcome.overrunStep).toBe('step-1')
+  })
+
+  it('rejects when a step rejects, so "cleanup failed" stays its own signal', async () => {
+    // #given a step that throws
+    const boom = new Error('boom')
+
+    // #when the sequence runs
+    const sequence = runShutdownSequence(
+      [{ name: 'close-vault', run: () => Promise.reject(boom) }],
+      {
+        budgetMs: 1000
+      }
+    )
+
+    // #then the rejection propagates rather than reading as a timeout
+    await expect(sequence).rejects.toBe(boom)
+  })
+
+  it('does not surface a step that rejects after the budget already expired', async () => {
+    // #given a step that fails late, long after the forced exit path is taken
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    const steps: ShutdownStep[] = [
+      {
+        name: 'stop-sync-runtime',
+        run: async () => {
+          await delay(2000)
+          throw new Error('late failure')
+        }
+      }
+    ]
+
+    try {
+      // #when the budget expires first and the step fails afterwards
+      const sequence = runShutdownSequence(steps, { budgetMs: 1000 })
+      await vi.advanceTimersByTimeAsync(1000)
+      const outcome = await sequence
+      expect(outcome.status).toBe('timeout')
+
+      await vi.advanceTimersByTimeAsync(2000)
+      vi.useRealTimers()
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+
+    // #then the late rejection was absorbed rather than left unhandled while
+    // the process is already on its way out
+    expect(unhandled).toEqual([])
+  })
+})
+
+describe('completeWithin', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reports success when the work finishes inside the window', async () => {
+    const race = completeWithin(delay(100), 500)
+    await vi.advanceTimersByTimeAsync(100)
+    await expect(race).resolves.toBe(true)
+  })
+
+  it('gives up when the work does not finish, so the exit is never blocked', async () => {
+    const race = completeWithin(never(), 500)
+    await vi.advanceTimersByTimeAsync(500)
+    await expect(race).resolves.toBe(false)
+  })
+})
+
+describe('shutdown budget arithmetic', () => {
+  it('fits the bounded waits the chain contains', () => {
+    // Before #1586 these summed to 11,000ms against a 5,000ms budget: a 2,000ms
+    // renderer flush handshake plus THREE sequential 3,000ms utility-process
+    // stops. The stops now run concurrently, so they cost 3,000ms once.
+    const RENDERER_FLUSH_HANDSHAKE_MS = 2_000
+    const UTILITY_PROCESS_STOPS_MS = 3_000
+    expect(RENDERER_FLUSH_HANDSHAKE_MS + UTILITY_PROCESS_STOPS_MS).toBeLessThan(SHUTDOWN_BUDGET_MS)
+  })
+
+  it('keeps the hard backstop beyond the budget and its last-chance flush', () => {
+    // The backstop has to be the LAST thing that can fire, or a quit could be
+    // force-exited while the durability flush is still writing.
+    expect(SHUTDOWN_HARD_BACKSTOP_MS).toBeGreaterThan(SHUTDOWN_BUDGET_MS + SHUTDOWN_LAST_CHANCE_MS)
+  })
+})

--- a/apps/desktop/src/main/shutdown-sequence.ts
+++ b/apps/desktop/src/main/shutdown-sequence.ts
@@ -1,0 +1,175 @@
+// Graceful-shutdown orchestration for `before-quit` (#1586).
+//
+// The chain used to race a flat 5,000 ms timer while its own bounded waits
+// summed to 11,000 ms — 2,000 ms for the renderer flush handshake plus 3,000 ms
+// for each of the three utility-process stops, run one after another. A quit
+// with those utility processes alive therefore could not finish inside its own
+// budget, and the forced `app.exit(1)` landed with the CRDT write-back timers
+// still armed, dropping up to 5s of the user's most recent edits.
+//
+// Two rules fix that, and this module exists to make both of them structural:
+//
+//   * ONE SHARED DEADLINE. The sequence races the whole chain against a single
+//     budget, and hands every step a `cap()` that clamps its own bounded wait to
+//     what is left. No set of waits can collectively overrun the budget, however
+//     many of them there are.
+//   * ORDER BY DURABILITY. Steps run strictly in order, so the caller putting
+//     the write-back flush at the front is what guarantees it the budget. A
+//     wedged teardown step behind it degrades a quit to "slow", not to "lost
+//     edits".
+//
+// It also answers "which step overran": the step in flight when the budget
+// expires is reported, so the next occurrence is diagnosable instead of landing
+// as an undifferentiated SHUTDOWN_TIMEOUT.
+
+import { createLogger } from './lib/logger'
+
+const log = createLogger('ShutdownSequence')
+
+/**
+ * Budget for the whole graceful chain.
+ *
+ * Derived from the bounded waits it contains rather than guessed:
+ *   2,000 ms  renderer flush handshake (windows are flushed in parallel)
+ * + 3,000 ms  voice + image + embeddings utility stops (now run concurrently,
+ *             so 3,000 ms together instead of 9,000 ms in a row)
+ * = 5,000 ms  of bounded waiting, leaving 3,000 ms of headroom for the
+ *             unbounded steps (close snapshots, local servers, telemetry flush,
+ *             final sync push, vault close).
+ *
+ * A quit where nothing is wedged still finishes in milliseconds; this ceiling is
+ * only ever reached when a teardown step is genuinely stuck.
+ */
+export const SHUTDOWN_BUDGET_MS = 8_000
+
+/**
+ * Time granted AFTER the budget is gone, purely to make data durable — flushing
+ * pending CRDT write-backs and checkpointing SQLite. Bounded, because the whole
+ * point of a budget is that quitting must always end.
+ */
+export const SHUTDOWN_LAST_CHANCE_MS = 1_500
+
+/**
+ * Hard ceiling on a quit. The paths above are each bounded, but a quit that
+ * never ends is a visibly broken quit, so one timer outside the sequence
+ * guarantees the process exits. Sits 500 ms past the latest moment the timeout
+ * path can exit on its own (8,000 + 1,500).
+ */
+export const SHUTDOWN_HARD_BACKSTOP_MS = 10_000
+
+export interface ShutdownDeadline {
+  /** Milliseconds left in the shared budget. Never negative. */
+  remainingMs: () => number
+  /**
+   * `preferredMs`, clamped to what is left of the shared budget. A bounded wait
+   * must never be allowed to outlive the deadline it is running under.
+   */
+  cap: (preferredMs: number) => number
+}
+
+export interface ShutdownStep {
+  /**
+   * Stable kebab-case id. It reaches the crash marker and, on the next launch,
+   * the `app_crashed` errorCode — so it must stay a bounded, enumerable token.
+   */
+  name: string
+  run: (deadline: ShutdownDeadline) => void | Promise<void>
+}
+
+export interface ShutdownOutcome {
+  status: 'complete' | 'timeout'
+  /** The step still in flight when the budget ran out. */
+  overrunStep: string | null
+  /** How long that step alone had been running. */
+  overrunStepMs: number
+  elapsedMs: number
+}
+
+/**
+ * Run `steps` in order under one shared budget.
+ *
+ * Resolves `complete` when every step finished, or `timeout` at exactly
+ * `budgetMs` naming the step that was still running. Rejects only when a step
+ * itself rejected — that stays the caller's "cleanup failed" path, which is a
+ * different signal from "cleanup did not finish in time".
+ */
+export async function runShutdownSequence(
+  steps: readonly ShutdownStep[],
+  options: { budgetMs?: number } = {}
+): Promise<ShutdownOutcome> {
+  const budgetMs = options.budgetMs ?? SHUTDOWN_BUDGET_MS
+  const startedAt = Date.now()
+  const deadlineAt = startedAt + budgetMs
+
+  const deadline: ShutdownDeadline = {
+    remainingMs: () => Math.max(0, deadlineAt - Date.now()),
+    cap: (preferredMs) => Math.max(0, Math.min(preferredMs, deadlineAt - Date.now()))
+  }
+
+  let inFlight: { name: string; startedAt: number } | null = null
+  // Read through a call: the assignments below happen inside a closure, so a
+  // direct read narrows to `null` and the step name is lost at compile time.
+  const currentStep = (): { name: string; startedAt: number } | null => inFlight
+
+  const chain = (async () => {
+    for (const step of steps) {
+      const stepStartedAt = Date.now()
+      inFlight = { name: step.name, startedAt: stepStartedAt }
+      await step.run(deadline)
+      log.info('step complete', { step: step.name, elapsedMs: Date.now() - stepStartedAt })
+      inFlight = null
+    }
+  })()
+
+  // The chain must never reject the race directly: once the budget has won,
+  // nothing is left to handle a late rejection and it would surface as an
+  // unhandled rejection while the process is already on its way out.
+  const settled = chain.then(
+    () => ({ kind: 'complete' as const }),
+    (error: unknown) => ({ kind: 'error' as const, error })
+  )
+
+  let expiry: ReturnType<typeof setTimeout> | undefined
+  const expired = new Promise<'timeout'>((resolve) => {
+    expiry = setTimeout(() => resolve('timeout'), budgetMs)
+  })
+
+  const winner = await Promise.race([settled, expired])
+  clearTimeout(expiry)
+
+  if (winner === 'timeout') {
+    const step = currentStep()
+    const outcome: ShutdownOutcome = {
+      status: 'timeout',
+      overrunStep: step?.name ?? null,
+      overrunStepMs: step ? Date.now() - step.startedAt : 0,
+      elapsedMs: Date.now() - startedAt
+    }
+    log.error('shutdown budget exhausted', outcome)
+    return outcome
+  }
+
+  if (winner.kind === 'error') throw winner.error
+
+  return {
+    status: 'complete',
+    overrunStep: null,
+    overrunStepMs: 0,
+    elapsedMs: Date.now() - startedAt
+  }
+}
+
+/**
+ * Await `work`, but give up after `ms`. Returns whether it finished in time.
+ * `work` keeps running — the caller is about to exit the process anyway; this
+ * only bounds how long the exit waits for it.
+ */
+export async function completeWithin(work: Promise<unknown>, ms: number): Promise<boolean> {
+  let expiry: ReturnType<typeof setTimeout> | undefined
+  const expired = new Promise<false>((resolve) => {
+    expiry = setTimeout(() => resolve(false), ms)
+  })
+  const finished = await Promise.race([work.then(() => true), expired])
+  clearTimeout(expiry)
+  return finished
+}

--- a/apps/desktop/src/main/telemetry/crash-marker.test.ts
+++ b/apps/desktop/src/main/telemetry/crash-marker.test.ts
@@ -124,6 +124,69 @@ describe('crash marker', () => {
     )
   })
 
+  it('names the overrunning step in the errorCode so a timeout is diagnosable', () => {
+    // #given a shutdown whose budget ran out while the sync runtime was stopping
+    installCrashMarker('session-1', '1.2.3')
+    markShutdownFailure('timeout', 'stop-sync-runtime')
+
+    // #when the next launch detects the leftover marker
+    detectUncleanShutdown()
+
+    // #then the code still starts with SHUTDOWN_TIMEOUT (dashboards keep
+    // matching) but says which step overran
+    expect(trackMainEvent).toHaveBeenCalledWith(
+      'app_crashed',
+      expect.objectContaining({ errorCode: 'SHUTDOWN_TIMEOUT_STOP_SYNC_RUNTIME' })
+    )
+  })
+
+  it('falls back to the plain code when the stamped step is not a known token', () => {
+    // #given a marker whose step field did not survive intact
+    const startedAt = new Date('2026-08-06T10:00:00.000Z').toISOString()
+    fs.writeFileSync(
+      markerFile(),
+      JSON.stringify({
+        sessionId: 'prior',
+        startedAt,
+        lastAliveAt: startedAt,
+        shutdownFailure: 'timeout',
+        shutdownStep: '/Users/someone/Notes/secret plan.md'
+      })
+    )
+
+    // #when the next launch detects it
+    detectUncleanShutdown()
+
+    // #then nothing unbounded reaches the errorCode
+    expect(trackMainEvent).toHaveBeenCalledWith(
+      'app_crashed',
+      expect.objectContaining({ errorCode: 'SHUTDOWN_TIMEOUT' })
+    )
+  })
+
+  it('reads a marker written before shutdown steps were recorded', () => {
+    // #given a marker from an older build: timeout stamped, no step field
+    const startedAt = new Date('2026-08-06T10:00:00.000Z').toISOString()
+    fs.writeFileSync(
+      markerFile(),
+      JSON.stringify({
+        sessionId: 'prior',
+        startedAt,
+        lastAliveAt: startedAt,
+        shutdownFailure: 'timeout'
+      })
+    )
+
+    // #when the next launch detects it
+    detectUncleanShutdown()
+
+    // #then it still reports the timeout it always did
+    expect(trackMainEvent).toHaveBeenCalledWith(
+      'app_crashed',
+      expect.objectContaining({ errorCode: 'SHUTDOWN_TIMEOUT' })
+    )
+  })
+
   it('survives an unwritable userData without throwing', () => {
     // #given a userData path that cannot be written
     mockApp.getPath.mockImplementation(() => path.join(tempDir, 'missing', 'nested'))

--- a/apps/desktop/src/main/telemetry/crash-marker.ts
+++ b/apps/desktop/src/main/telemetry/crash-marker.ts
@@ -24,11 +24,27 @@ interface SessionMarker {
   startedAt: string
   lastAliveAt: string
   appVersion?: string
-  // Set when a shutdown was ATTEMPTED but failed (5s timeout / cleanup chain
-  // rejected) before the forced exit — distinguishes "shutdown hung" from a
-  // hard crash on the next launch's report.
+  // Set when a shutdown was ATTEMPTED but failed (budget exhausted / cleanup
+  // chain rejected) before the forced exit — distinguishes "shutdown hung" from
+  // a hard crash on the next launch's report.
   shutdownFailure?: ShutdownFailureReason
+  // The shutdown step that was still running when the budget ran out. Without
+  // it every timeout landed as one undifferentiated SHUTDOWN_TIMEOUT and there
+  // was no way to tell "the chain as a whole was too slow" from "this one step
+  // hangs on this user's machine" (#1586). Optional: markers written by older
+  // builds simply do not carry it.
+  shutdownStep?: string
 }
+
+// Guards what may become part of an errorCode. Step names are ours and bounded,
+// but the marker is a file on disk: anything that survived a hand edit or a torn
+// write must degrade to the plain code rather than ship as a dimension value.
+const SHUTDOWN_STEP_TOKEN = /^[a-z][a-z0-9-]{0,39}$/
+
+const shutdownTimeoutCode = (step: string | undefined): string =>
+  step && SHUTDOWN_STEP_TOKEN.test(step)
+    ? `SHUTDOWN_TIMEOUT_${step.replace(/-/g, '_').toUpperCase()}`
+    : 'SHUTDOWN_TIMEOUT'
 
 let aliveTimer: ReturnType<typeof setInterval> | null = null
 // Only the process that WROTE a marker may remove one: a short-lived second
@@ -72,9 +88,13 @@ export const detectUncleanShutdown = (): void => {
   // observed-uptime metric.
   const marker = parseMarker(raw)
   const durationMs = marker ? priorSessionDurationMs(marker) : undefined
+  // The overrunning step rides in the errorCode, not in a dimension: telemetry
+  // ships at most ONE dimension per event, and that slot already carries
+  // prior_app_version. The SHUTDOWN_TIMEOUT prefix is preserved so existing
+  // dashboards keep matching.
   const errorCode =
     marker?.shutdownFailure === 'timeout'
-      ? 'SHUTDOWN_TIMEOUT'
+      ? shutdownTimeoutCode(marker.shutdownStep)
       : marker?.shutdownFailure === 'cleanup_error'
         ? 'SHUTDOWN_CLEANUP_FAILED'
         : 'UNCLEAN_SHUTDOWN'
@@ -130,14 +150,18 @@ export const installCrashMarker = (sessionId: string, appVersion?: string): void
  * exit, so the next launch's app_crashed says "shutdown hung/failed" instead
  * of a generic unclean exit. The process is about to app.exit(); the shipped
  * log line for this failure never flushes, but the marker survives.
+ *
+ * `step` names the shutdown step that was still running, which is what turns
+ * "shutdown was slow somewhere" into an answer.
  */
-export const markShutdownFailure = (reason: ShutdownFailureReason): void => {
+export const markShutdownFailure = (reason: ShutdownFailureReason, step?: string): void => {
   if (!installedThisSession) return
   try {
     const raw = fs.readFileSync(markerPath(), 'utf-8')
     const marker = parseMarker(raw)
     if (!marker) return
     marker.shutdownFailure = reason
+    if (step) marker.shutdownStep = step
     marker.lastAliveAt = new Date().toISOString()
     fs.writeFileSync(markerPath(), JSON.stringify(marker), 'utf-8')
   } catch {

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -423,7 +423,15 @@ document to its vault `.md` file and re-indexes it for search.
   at roughly a tenth of wall clock instead of saturating a core while the user types.
 - **Nothing is deferred indefinitely** — the trailing pass always runs, and
   `flushPendingWritebacks()` forces any pending pass through before the CRDT provider is
-  destroyed, which covers app quit and vault switch.
+  destroyed, which covers vault switch.
+- **A quit flushes write-backs first, not last** — the provider is destroyed at the _end_
+  of the shutdown chain, so relying on `destroy()` alone meant a slow teardown step could
+  spend the whole shutdown budget and the forced exit would kill the process with the
+  debounce timers still armed, losing up to 5 s of typing. `before-quit` therefore runs
+  the window flush and `flushPendingWritebacks()` as its first two steps, and runs the
+  write-back flush again — followed by `closeAllDatabases()` — on the timeout and
+  cleanup-error paths before it force-exits. See
+  [Shutdown Budget](/architecture/observability#shutdown-budget).
 - **The doc is resolved when the pass runs, not when it is scheduled** — a note closed and
   reopened inside the debounce window gets a fresh Y.Doc, so the pass looks the note id up
   in the provider's map at fire time rather than serializing the doc it captured. Otherwise

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -254,17 +254,54 @@ dimension.
 
 `errorCode` separates the failure modes:
 
-| `errorCode`               | Meaning                                                                      |
-| ------------------------- | ---------------------------------------------------------------------------- |
-| `UNCLEAN_SHUTDOWN`        | no shutdown was attempted — hard crash, OOM kill, force quit                 |
-| `SHUTDOWN_TIMEOUT`        | shutdown ran but the 5s cleanup timeout fired before the forced `app.exit()` |
-| `SHUTDOWN_CLEANUP_FAILED` | the cleanup chain rejected                                                   |
+| `errorCode`               | Meaning                                                              |
+| ------------------------- | -------------------------------------------------------------------- |
+| `UNCLEAN_SHUTDOWN`        | no shutdown was attempted — hard crash, OOM kill, force quit         |
+| `SHUTDOWN_TIMEOUT_<STEP>` | shutdown ran but its budget expired while `<STEP>` was still running |
+| `SHUTDOWN_TIMEOUT`        | same, but the marker carries no step (written by an older build)     |
+| `SHUTDOWN_CLEANUP_FAILED` | the cleanup chain rejected                                           |
 
-The last two are stamped by `markShutdownFailure()` immediately before the forced exit: the log
+The last three are stamped by `markShutdownFailure()` immediately before the forced exit: the log
 line for that failure never flushes, but the marker survives to the next launch. Only the process
 that wrote a marker may remove one — a second instance that loses the single-instance lock shares
 `userData` and must not erase the primary's marker on its way out. Marker write failures are
 logged and swallowed; a read-only disk must never break startup.
+
+The overrunning step rides in the `errorCode` rather than in a dimension, because an event ships
+at most one dimension and that slot already carries `prior_app_version`. The `SHUTDOWN_TIMEOUT`
+prefix is preserved so a query written against the old code still matches. Only a bounded
+kebab-case token is accepted from the marker; anything else degrades to the plain code.
+
+### Shutdown Budget
+
+`before-quit` runs its cleanup as an ordered list of named steps under **one shared deadline**
+(`apps/desktop/src/main/shutdown-sequence.ts`):
+
+| Constant                    | Value     | Role                                                         |
+| --------------------------- | --------- | ------------------------------------------------------------ |
+| `SHUTDOWN_BUDGET_MS`        | 8,000 ms  | the whole graceful chain                                     |
+| `SHUTDOWN_LAST_CHANCE_MS`   | 1,500 ms  | durability flush granted after the budget is gone            |
+| `SHUTDOWN_HARD_BACKSTOP_MS` | 10,000 ms | timer outside the sequence; the process always exits by then |
+
+The budget is derived from the bounded waits the chain contains, not guessed: 2,000 ms for the
+renderer flush handshake (windows in parallel) plus 3,000 ms for the voice, image-processing and
+embeddings utility stops — which run **concurrently**, so 3,000 ms together rather than 9,000 ms
+in a row — leaves 3,000 ms of headroom for the unbounded steps. Every step is also handed a
+`cap()` that clamps its own bounded wait to what is left of the shared deadline, so no set of
+waits can collectively overrun it.
+
+Two rules keep a slow quit from becoming a lossy one:
+
+- **Order by durability.** The window flush and `flushPendingWritebacks()` run first, so a wedged
+  teardown step behind them degrades a quit to slow rather than to lost edits.
+- **Never force-exit with pending writes.** When the budget expires, the step that overran is
+  stamped into the marker, then `flushPendingWritebacks()` and `closeAllDatabases()` run inside
+  the last-chance window before `app.exit(1)`. `closeAllDatabases()` matters because both SQLite
+  files run `synchronous = NORMAL`, which defers durability to the checkpoint that `close()`
+  performs. The cleanup-error path does the same.
+
+A quit where nothing is wedged still completes in milliseconds; these ceilings are only reached
+when a teardown step is genuinely stuck.
 
 ### Durable Queues
 


### PR DESCRIPTION
Fixes #1586

## The problem, in arithmetic

`before-quit` raced a flat 5,000 ms timer. The bounded waits inside the chain it was racing:

| Step | Own bounded wait |
|---|---|
| `flushAllWindows()` renderer handshake | 2,000 ms (windows in parallel) |
| `stopVoiceModel()` | 3,000 ms |
| `stopImageProcessing()` | 3,000 ms |
| `stopEmbeddingModel()` | 3,000 ms |
| **total, run sequentially** | **11,000 ms** |

**11,000 ms of bounded waiting against a 5,000 ms budget** — before counting the unbounded steps (close snapshots, capture/chat servers, telemetry flush, final sync push, `closeVault()`). The budget was arithmetically impossible whenever the three utility processes were alive and slow to acknowledge. That matches the telemetry exactly: 24 `SHUTDOWN_TIMEOUT` events, zero `SHUTDOWN_CLEANUP_FAILED`.

And because `flushPendingWritebacks()` was reachable only through `CrdtProvider.destroy()` at the very *end* of the chain, the forced `app.exit(1)` killed the process with the debounced write-back timers still armed — 500 ms to 5,000 ms of the user's most recent typing that had never reached the markdown file.

## After

| Constant | Value | Role |
|---|---|---|
| `SHUTDOWN_BUDGET_MS` | 8,000 ms | the whole graceful chain |
| `SHUTDOWN_LAST_CHANCE_MS` | 1,500 ms | durability flush after the budget is gone |
| `SHUTDOWN_HARD_BACKSTOP_MS` | 10,000 ms | timer outside the sequence; the process always exits by then |

Bounded waits now sum to **5,000 ms**: 2,000 ms window handshake + 3,000 ms for the three utility stops, which run **concurrently** instead of one after another (3,000 ms together, not 9,000 ms in a row). That leaves 3,000 ms of headroom inside the 8,000 ms budget for the unbounded steps.

The budget is not just larger, it is **shared**. `runShutdownSequence` races the whole chain against one deadline and hands every step a `cap()` that clamps its own bounded wait to what is left. No set of waits can collectively overrun the budget however many are added later — so this cannot silently go back out of balance.

**Why 8,000 / 10,000 and not more.** A quit where nothing is wedged still finishes in single-digit milliseconds; these ceilings are only ever reached when a teardown step is genuinely stuck. 10,000 ms is the absolute worst case a user can observe, and it buys back the last 5 s of their edits. The backstop is unconditional and lives outside the sequence, so a quit always ends.

## Data-safety ordering

The chain is now ordered by durability rather than by convenience:

1. `flush-windows` — renderer edits → main's Y.Docs
2. `flush-writebacks` — **new**: main's Y.Docs → the markdown files, up front instead of at the end
3. `close-snapshots`
4. `stop-schedulers`
5. `stop-capture-server`
6. `stop-chat-server`
7. `stop-utility-processes` — voice + image + embeddings, concurrent
8. `flush-telemetry`
9. `stop-sync-runtime`
10. `close-vault`

The two steps that can lose user edits now run ahead of the steps most likely to hang, so a wedged teardown degrades a quit to *slow*, not to *lossy*.

On the timeout path — and on the cleanup-error path — the app no longer exits with timers armed. It stamps the marker, then runs `flushPendingWritebacks()` inside the last-chance window and `closeAllDatabases()` (both SQLite files run `synchronous = NORMAL`, so `close()` is what checkpoints the WAL), and only then force-exits.

## Diagnosing the next occurrence

The step in flight when the budget expires is stamped into `session-marker.json` and becomes the next launch's `errorCode`: `SHUTDOWN_TIMEOUT_STOP_SYNC_RUNTIME` rather than a bare `SHUTDOWN_TIMEOUT`. "Shutdown was slow somewhere" becomes "this step hangs on this user's machine" — and if the step varies across events, the budget is merely tight rather than one step being wedged.

It rides in the `errorCode`, not in a dimension, because an event ships **at most one** dimension (`sanitizeTelemetryDimensions`) and that slot already carries `prior_app_version`. The `SHUTDOWN_TIMEOUT` prefix is preserved so existing dashboard queries keep matching. Only a bounded kebab-case token is accepted from the marker file; anything else degrades to the plain code.

## Backward compatibility

- **No on-disk format changes.** The CRDT store, the vault markdown/frontmatter format, and both SQLite schemas are untouched.
- **The crash marker gains one optional field** (`shutdownStep`). A marker written by 2026.817.1 and read by this build has no step and reports the plain `SHUTDOWN_TIMEOUT` exactly as before (covered by a test). A marker written by this build and read by an older build parses fine — the field is simply ignored.
- **No IPC contract, sync protocol or settings shape changes.**
- The `app_crashed` event keeps its name, surface, action and `SHUTDOWN_TIMEOUT` prefix.

## Verification

Run in `.worktrees/shutdown-budget-and-writeback`:

| Command | Result |
|---|---|
| `pnpm --filter @memry/desktop typecheck:node` | pass |
| `pnpm --filter @memry/desktop typecheck:test:node` | pass |
| `pnpm --filter @memry/desktop typecheck:test:web` | **fails, pre-existing on `origin/main`** — `sidebar-nav.test.tsx` is missing the `onNavMiddleClick` prop added by 808a4e431. This branch touches zero renderer files. |
| `pnpm lint` | pass, 0 errors |
| `pnpm exec vitest run --project main` (full main suite) | 533 files passed / 3 skipped, 6873 tests passed |
| `pnpm exec vitest run --project main src/main/shutdown-sequence.test.ts src/main/telemetry/crash-marker.test.ts` | 20 passed |
| `pnpm exec vitest run --project main src/main/index.phase2.test.ts` | 63 passed |
| `pnpm check:architecture` / `pnpm check:contracts` / `pnpm ipc:check` | pass |
| `pnpm docs:impact --base origin/main --strict` | `covered` |
| `pnpm docs:build` | pass |

Tests added, at the seams that own the behaviour:

- `shutdown-sequence.test.ts` (fake timers) — a hung step cannot outlive the budget however many steps overrun; the durability step ahead of an infinitely-hanging step still completes; the overrunning step is named with its own elapsed time; `cap()` clamps a later step to what the deadline still holds; a rejecting step stays a *separate* signal from a timeout; a step that rejects *after* the budget expired does not become an unhandled rejection (asserted via a real `process.on('unhandledRejection')` listener); the backstop sits beyond budget + last-chance.
- `index.phase2.test.ts` — with a `closeVault()` that never settles: the app is **not** force-exited at the old 5,000 ms mark, and when the budget does expire the marker is stamped `('timeout', 'close-vault')` and `flushPendingWritebacks()` + `closeAllDatabases()` both run before `app.exit(1)`.
- `crash-marker.test.ts` — the step name becomes `SHUTDOWN_TIMEOUT_STOP_SYNC_RUNTIME`; a non-token step degrades to the plain code; a marker from an older build still reports `SHUTDOWN_TIMEOUT`.

## Deliberately not done

- **Issue item 5 (telemetry plumbing for `durationMs` / `prior_app_version`)** — out of scope for this change and worth its own issue. Working around it is *why* the step name ships in the `errorCode` instead of a dimension.
- **Issue item 7 (the `SQLITE_CORRUPT` correlation)** — an investigation, not a code change. This PR does remove the un-checkpointed-WAL-on-every-timed-out-quit condition that made it plausible.
- **Moving `closeAllDatabases()` to the front of the *graceful* chain** — closing the databases before the watcher, schedulers and servers stop would have them running against a closed connection. The durability prefix (window flush + write-back flush) plus the forced close on the timeout path achieves the same guarantee without that hazard.
- **Lowering the three utility processes' own 3,000 ms internal timeouts** — unnecessary once they run concurrently, and the shared deadline bounds them structurally regardless.