### PR TITLE
fix(crdt): stop churning the CRDT store when the binding is what is broken, and tell the user when history stops being kept

### DIFF
--- a/apps/desktop/src/main/ipc/crdt-handlers.ts
+++ b/apps/desktop/src/main/ipc/crdt-handlers.ts
@@ -7,9 +7,11 @@ import {
   CrdtOpenDocSchema,
   CrdtSyncStep1Schema,
   CrdtSyncStep2Schema,
+  type CrdtHealth,
   type CrdtSyncStep1Result
 } from '@memry/contracts/ipc-crdt'
 import { getCrdtProvider } from '../sync/crdt-provider'
+import { getCrdtInMemorySessions } from '../store'
 import { createLogger } from '../lib/logger'
 import { trackNoteBodyEditThrottled } from '../telemetry/diagnostics'
 import { createValidatedHandler } from './validate'
@@ -154,4 +156,20 @@ export function registerCrdtIpcHandlers(): void {
       getCrdtProvider().applyIpcSyncStep2(input.noteId, input.diff)
     })
   )
+
+  // Pulled, not pushed: the verdict lands while the window is still loading, so
+  // a broadcast would routinely have no listener. Joins an init already in
+  // flight — never starts one, for the same reason open-doc does not: this
+  // caller must not be what decides which vault the store belongs to.
+  ipcMain.handle(CRDT_CHANNELS.GET_HEALTH, async (): Promise<CrdtHealth> => {
+    const provider = getCrdtProvider()
+    if (!provider.isInitialized()) await provider.awaitPendingInit()
+    const inMemorySessions = getCrdtInMemorySessions()
+    return {
+      // Before this launch's verdict exists, the persisted streak is the best
+      // available answer: it is exactly what the previous launches decided.
+      persistent: provider.isInitialized() ? provider.hasPersistence() : inMemorySessions === 0,
+      inMemorySessions
+    }
+  })
 }

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -94,6 +94,7 @@ export interface MainIpcInvokeHandlers {
   "context-menu:show": (...args: [{ id: string; label: string; accelerator?: string | undefined; disabled?: boolean | undefined; type?: "normal" | "separator" | undefined; }[]]) => Awaited<Promise<string | null>>
   "crdt:apply-update": (...args: [unknown]) => Awaited<Promise<void>>
   "crdt:close-doc": (...args: [unknown]) => Awaited<Promise<{ success: boolean; }>>
+  "crdt:get-health": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crdt").CrdtHealth>>
   "crdt:open-doc": (...args: [unknown]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
   "crdt:sync-step-1": (...args: [{ noteId: string; stateVector: Uint8Array<ArrayBuffer>; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crdt").CrdtSyncStep1Result | null>>
   "crdt:sync-step-2": (...args: [{ noteId: string; diff: Uint8Array<ArrayBuffer>; }]) => Awaited<Promise<void>>

--- a/apps/desktop/src/main/store.test.ts
+++ b/apps/desktop/src/main/store.test.ts
@@ -27,7 +27,9 @@ import {
   getStoredLocale,
   setStoredLocale,
   getWindowBounds,
-  setWindowBounds
+  setWindowBounds,
+  getCrdtInMemorySessions,
+  recordCrdtPersistenceOutcome
 } from './store'
 
 describe('store', () => {
@@ -201,5 +203,33 @@ describe('store', () => {
     expect(findVault('/vaults/personal')?.isDefault).toBe(false)
     expect(findVault('/vaults/work')?.isDefault).toBe(true)
     expect(setDefaultVaultPath('/vaults/missing')).toBeNull()
+  })
+
+  // A whole Windows population ran CRDT state in memory for six releases with a
+  // log line as the only signal (issue #1583). This streak is what the
+  // user-facing notice is thresholded on, so it has to survive quitting.
+  describe('CRDT persistence streak', () => {
+    beforeEach(() => {
+      recordCrdtPersistenceOutcome(true)
+    })
+
+    it('reads as healthy on an install that has never degraded', () => {
+      expect(getCrdtInMemorySessions()).toBe(0)
+    })
+
+    it('counts consecutive degraded launches', () => {
+      expect(recordCrdtPersistenceOutcome(false)).toBe(1)
+      expect(recordCrdtPersistenceOutcome(false)).toBe(2)
+      expect(recordCrdtPersistenceOutcome(false)).toBe(3)
+      expect(getCrdtInMemorySessions()).toBe(3)
+    })
+
+    it('forgets the streak the moment the store opens again', () => {
+      recordCrdtPersistenceOutcome(false)
+      recordCrdtPersistenceOutcome(false)
+
+      expect(recordCrdtPersistenceOutcome(true)).toBe(0)
+      expect(getCrdtInMemorySessions()).toBe(0)
+    })
   })
 })

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -141,6 +141,21 @@ export interface CrdtStoreData {
    * every install that has not linked under a build that records this.
    */
   pendingRenames?: Record<string, string>
+  /**
+   * Consecutive launches that ended with no on-disk CRDT store, reset to 0 the
+   * moment one opens.
+   *
+   * Persisted because the thing worth telling the user about is not one bad
+   * launch — the store recovers from those on its own — but a machine that has
+   * been running CRDT state in memory for a while and has no idea. A whole
+   * Windows population did exactly that with a single log line as the only
+   * signal (issue #1583); this is what the notice counts.
+   *
+   * Optional for the same reason as the keys above: stores written by older app
+   * versions have no `crdtStore` key at all, which reads as 0 — the correct
+   * starting state for an install that has never degraded.
+   */
+  inMemorySessions?: number
 }
 
 /**
@@ -530,6 +545,29 @@ export function clearPendingCrdtStoreRename(vaultUuid: string): void {
   if (current.pendingRenames?.[vaultUuid] === undefined) return
   const { [vaultUuid]: _settled, ...rest } = current.pendingRenames
   store.set('crdtStore', { ...current, pendingRenames: rest })
+}
+
+/**
+ * How many launches in a row have had no on-disk CRDT store. 0 = healthy.
+ */
+export function getCrdtInMemorySessions(): number {
+  return store.get('crdtStore').inMemorySessions ?? 0
+}
+
+/**
+ * Record this launch's CRDT persistence outcome and return the resulting streak.
+ *
+ * Idempotent when nothing changed (a healthy install at 0 writes no config), so
+ * the common path costs a read.
+ */
+export function recordCrdtPersistenceOutcome(healthy: boolean): number {
+  const current = store.get('crdtStore')
+  const previous = current.inMemorySessions ?? 0
+  const next = healthy ? 0 : previous + 1
+  if (next !== previous) {
+    store.set('crdtStore', { ...current, inMemorySessions: next })
+  }
+  return next
 }
 
 /**

--- a/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
+++ b/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
@@ -49,7 +49,9 @@ vi.mock('../store', () => ({
   getLegacyCrdtStorePartitionPending: () => undefined,
   clearLegacyCrdtStorePartitionPending: vi.fn(),
   getPendingCrdtStoreRename: () => undefined,
-  clearPendingCrdtStoreRename: vi.fn()
+  clearPendingCrdtStoreRename: vi.fn(),
+  getCrdtInMemorySessions: () => 0,
+  recordCrdtPersistenceOutcome: vi.fn(() => 0)
 }))
 
 vi.mock('../vault/notes', () => ({ toAbsolutePath: vi.fn() }))

--- a/apps/desktop/src/main/sync/crdt-persistence.test.ts
+++ b/apps/desktop/src/main/sync/crdt-persistence.test.ts
@@ -141,7 +141,32 @@ describe('openCrdtPersistence telemetry', () => {
     })
   })
 
-  it('re-probes a fresh directory before blaming the binding', async () => {
+  it('probes an empty control directory before blaming the store data', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockPreflight
+      .mockResolvedValueOnce(failed('store', 'utility'))
+      .mockResolvedValueOnce({ ok: true, transport: 'utility' } as CrdtPreflightResult)
+
+    await openCrdtPersistence(STORE)
+
+    // The control runs against its own directory, never against the user's.
+    expect(mockPreflight).toHaveBeenNthCalledWith(1, STORE)
+    expect(mockPreflight).toHaveBeenNthCalledWith(2, `${STORE}.probe`)
+    // A control that passes means the data IS at fault: quarantine it, and
+    // never move it back — a fresh store is the recovery.
+    expect(mockMoveStoreDir).toHaveBeenCalledTimes(1)
+    expect(mockMoveStoreDir).toHaveBeenCalledWith(STORE, expect.stringContaining('.broken-'))
+    // The control directory is cleared before use and after, so a machine that
+    // takes this path every launch strands at most one directory.
+    expect(mockRmSync).toHaveBeenCalledWith(`${STORE}.probe`, { recursive: true, force: true })
+    expect(mockRmSync).not.toHaveBeenCalledWith(STORE, expect.anything())
+  })
+
+  // The whole Windows population in issue #1583: the binding access-violates
+  // against an empty directory as readily as against the user's data, so the
+  // store was moved aside, rm'd and moved back on every launch, forever, and
+  // not one install ever came out of it with a working store.
+  it('never touches the store when the empty control directory fails too', async () => {
     mockExistsSync.mockReturnValue(true)
     mockPreflight
       .mockResolvedValueOnce(failed('store', 'utility'))
@@ -150,14 +175,27 @@ describe('openCrdtPersistence telemetry', () => {
     expect(await openCrdtPersistence(STORE)).toBeNull()
 
     expect(mockPreflight).toHaveBeenCalledTimes(2)
-    // Quarantined, re-probed, then restored — the fresh directory the failed
-    // re-probe left behind is cleared first, or the restore fails EPERM.
-    expect(mockMoveStoreDir).toHaveBeenNthCalledWith(1, STORE, expect.stringContaining('.broken-'))
-    expect(mockRmSync).toHaveBeenCalledWith(STORE, { recursive: true, force: true })
-    expect(mockMoveStoreDir).toHaveBeenNthCalledWith(2, expect.stringContaining('.broken-'), STORE)
+    expect(mockMoveStoreDir).not.toHaveBeenCalled()
+    expect(mockRmSync).not.toHaveBeenCalledWith(STORE, expect.anything())
+    // Restaged, because 'store' claims the data is a suspect and it is not.
     expect(reportedEvent()).toMatchObject({
-      errorCode: 'CRDT_PERSISTENCE_UNAVAILABLE:store',
+      errorCode: 'CRDT_PERSISTENCE_UNAVAILABLE:binding-in-use',
       dimensions: { transport: 'node' }
     })
+  })
+
+  it('leaves the store alone when the control directory cannot be cleared', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockRmSync.mockImplementation(() => {
+      throw new Error('EPERM: operation not permitted')
+    })
+    mockPreflight.mockResolvedValue(failed('store', 'utility'))
+
+    expect(await openCrdtPersistence(STORE)).toBeNull()
+
+    // No clean control means no evidence, and evidence is the only thing that
+    // may move a user's CRDT history.
+    expect(mockPreflight).toHaveBeenCalledTimes(1)
+    expect(mockMoveStoreDir).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/main/sync/crdt-persistence.ts
+++ b/apps/desktop/src/main/sync/crdt-persistence.ts
@@ -1,6 +1,7 @@
 import * as Y from 'yjs'
 import { LeveldbPersistence } from 'y-leveldb'
 import { existsSync, rmSync } from 'fs'
+import os from 'os'
 import { createLogger } from '../lib/logger'
 import { runCrdtPreflight, type CrdtPreflightResult } from './crdt-preflight'
 import { moveStoreDir } from './crdt-store-move'
@@ -89,46 +90,8 @@ export async function openCrdtPersistence(storagePath: string): Promise<CrdtPers
     // quarantining on that verdict only churned the store dir every launch —
     // with the restore then failing EPERM under AV. See crdt-preflight.ts.
     if (!preflight.ok && preflight.stage === 'store' && existsSync(storagePath)) {
-      // The abort may be the store's data (torn LDB/MANIFEST from a past
-      // crash or full disk), not the binding. Quarantine the store and give
-      // the binding one clean shot at a fresh directory: pass → the data was
-      // the problem, keep the quarantine and start fresh (vault markdown is
-      // the source of truth; only CRDT history moves aside). Fail → the
-      // binding is the problem, so restore the store for a future launch
-      // with a working binding and fall through to in-memory mode.
-      const quarantinePath = `${storagePath}.broken-${Date.now()}`
-      const quarantined = await moveStoreDir(storagePath, quarantinePath)
-      if (!quarantined) {
-        log.warn('Could not quarantine the CRDT store — leaving it in place', { storagePath })
-      } else {
-        preflight = await runCrdtPreflight(storagePath)
-        lastPreflight = preflight
-        if (preflight.ok) {
-          log.warn(
-            'CRDT store quarantined after failed preflight — continuing with a fresh store',
-            {
-              storagePath,
-              quarantinePath
-            }
-          )
-        } else {
-          // The failed re-probe can leave a partial fresh store behind, and
-          // on Windows renaming onto an existing directory fails EPERM —
-          // exactly what production logs show. That directory holds nothing
-          // (the probe never completed), so clear it before restoring.
-          try {
-            rmSync(storagePath, { recursive: true, force: true })
-          } catch (err) {
-            log.warn('Could not clear the fresh CRDT store before restoring', {
-              storagePath,
-              error: err
-            })
-          }
-          if (!(await moveStoreDir(quarantinePath, storagePath))) {
-            log.warn('Failed to restore quarantined CRDT store', { quarantinePath, storagePath })
-          }
-        }
-      }
+      preflight = await settleStoreStageFailure(storagePath, preflight)
+      lastPreflight = preflight
     }
     if (!preflight.ok) {
       throw new Error(`CRDT store preflight failed: ${preflight.reason ?? 'unknown'}`)
@@ -149,6 +112,87 @@ export async function openCrdtPersistence(storagePath: string): Promise<CrdtPers
     )
     reportPersistenceUnavailable(lastPreflight)
     return null
+  }
+}
+
+/**
+ * Decide what a `store`-stage preflight failure actually means, and act on it.
+ *
+ * The child died using the store, which has exactly two causes: the store's own
+ * data (torn LDB/MANIFEST from a past crash, a full disk) or the binding. They
+ * are told apart by a control: probe a directory that is guaranteed EMPTY and
+ * therefore cannot be at fault.
+ *
+ * - control passes → the data is the cause. Quarantine the store; LevelDB
+ *   recreates the directory, vault markdown reseeds the notes, and only CRDT
+ *   history moves aside. This is the darwin/linux case, and it self-heals.
+ * - control fails → the binding is the cause and the data is innocent. Restage
+ *   as `binding-in-use` and leave the store completely alone.
+ *
+ * The control runs BEFORE anything is moved, which is the whole point. The
+ * previous order quarantined first and re-probed the (now empty) real path, so
+ * every Windows install in issue #1583 paid a rename → failed re-probe →
+ * `rmSync` → rename-back cycle on its CRDT store on EVERY launch, forever, and
+ * not one of them ever came out of it with a working store: zero win32 rows for
+ * "quarantined ... continuing with a fresh store" across the whole window.
+ */
+async function settleStoreStageFailure(
+  storagePath: string,
+  preflight: CrdtPreflightResult
+): Promise<CrdtPreflightResult> {
+  // A fixed name, not a timestamped one: on the machines this runs for, every
+  // launch would otherwise strand another directory next to the store. One
+  // directory, cleared before use and after.
+  const controlPath = `${storagePath}.probe`
+  if (!clearPath(controlPath, 'CRDT preflight control directory')) {
+    // Inconclusive: no clean control means no evidence, and evidence is the
+    // only thing that may move a user's store.
+    log.warn('Could not clear the CRDT preflight control directory — leaving the store alone', {
+      controlPath
+    })
+    return preflight
+  }
+
+  const control = await runCrdtPreflight(controlPath)
+  clearPath(controlPath, 'CRDT preflight control directory')
+
+  if (!control.ok) {
+    log.warn('CRDT preflight fails on an empty directory too — the store data is not at fault', {
+      storagePath,
+      reason: control.reason,
+      stage: control.stage,
+      storeOp: control.storeOp,
+      transport: control.transport,
+      platform: process.platform,
+      osRelease: os.release(),
+      osVersion: os.version(),
+      arch: process.arch
+    })
+    // Restage so telemetry stops reporting a data problem that does not exist.
+    // Never derived from stderr — only a second child's verdict can say this.
+    return { ...control, stage: 'binding-in-use' }
+  }
+
+  const quarantinePath = `${storagePath}.broken-${Date.now()}`
+  if (!(await moveStoreDir(storagePath, quarantinePath))) {
+    log.warn('Could not quarantine the CRDT store — leaving it in place', { storagePath })
+    return preflight
+  }
+  log.warn('CRDT store quarantined after failed preflight — continuing with a fresh store', {
+    storagePath,
+    quarantinePath
+  })
+  return control
+}
+
+/** Remove a path if it exists. False means it is still there. */
+function clearPath(target: string, label: string): boolean {
+  try {
+    rmSync(target, { recursive: true, force: true })
+    return true
+  } catch (err) {
+    log.warn(`Could not remove ${label}`, { target, error: err })
+    return !existsSync(target)
   }
 }
 

--- a/apps/desktop/src/main/sync/crdt-preflight-child.test.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight-child.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
-import { PREFLIGHT_MARK_BINDING_LOADED, PREFLIGHT_MARK_STARTED } from './crdt-preflight-protocol'
+import {
+  PREFLIGHT_MARK_BINDING_LOADED,
+  PREFLIGHT_MARK_STARTED,
+  PREFLIGHT_MARK_STORE_OPS
+} from './crdt-preflight-protocol'
 
 const mockWriteSync = vi.hoisted(() => vi.fn())
 const mockRmSync = vi.hoisted(() => vi.fn())
@@ -170,7 +174,10 @@ describe('crdt-preflight-child', () => {
     it('writes "started" to fd 2 before the native binding is touched', async () => {
       await runChild()
 
-      expect(marks()).toEqual([`${PREFLIGHT_MARK_STARTED}\n`, `${PREFLIGHT_MARK_BINDING_LOADED}\n`])
+      expect(marks().slice(0, 2)).toEqual([
+        `${PREFLIGHT_MARK_STARTED}\n`,
+        `${PREFLIGHT_MARK_BINDING_LOADED}\n`
+      ])
       // The ordering is the whole point of the staging protocol: a child that
       // dies before `started` never ran, which is no verdict on the store.
       expect(mockWriteSync.mock.invocationCallOrder[0]).toBeLessThan(
@@ -183,8 +190,34 @@ describe('crdt-preflight-child', () => {
       // exactly when the parent needs the marker.
       await runChild()
 
-      expect(mockWriteSync).toHaveBeenCalledTimes(2)
+      expect(mockWriteSync.mock.calls.length).toBeGreaterThan(0)
       for (const [fd] of mockWriteSync.mock.calls) expect(fd).toBe(2)
+    })
+
+    // Production could only ever say "somewhere in the store": issue #1583 has
+    // both stage markers out and five candidate operations behind them.
+    it('announces every store operation, in order, before running it', async () => {
+      await runChild()
+
+      expect(marks()).toEqual([
+        `${PREFLIGHT_MARK_STARTED}\n`,
+        `${PREFLIGHT_MARK_BINDING_LOADED}\n`,
+        `${PREFLIGHT_MARK_STORE_OPS.open}\n`,
+        `${PREFLIGHT_MARK_STORE_OPS.write}\n`,
+        `${PREFLIGHT_MARK_STORE_OPS.read}\n`,
+        `${PREFLIGHT_MARK_STORE_OPS.clear}\n`,
+        `${PREFLIGHT_MARK_STORE_OPS.close}\n`
+      ])
+    })
+
+    it('stops at the operation that failed, so the last marker names the suspect', async () => {
+      persistence.getYDoc.mockRejectedValue(new Error('IO error: torn LDB'))
+
+      await runChild()
+
+      // Read announced, clear never was: an abort unwinds nothing, so the only
+      // attribution that survives is the one written before the call.
+      expect(marks().at(-1)).toBe(`${PREFLIGHT_MARK_STORE_OPS.read}\n`)
     })
   })
 
@@ -212,7 +245,10 @@ describe('crdt-preflight-child', () => {
       expect(code).toBe(1)
       // Both markers out => the parent stages this 'store', the only stage
       // worth quarantining for.
-      expect(marks()).toEqual([`${PREFLIGHT_MARK_STARTED}\n`, `${PREFLIGHT_MARK_BINDING_LOADED}\n`])
+      expect(marks().slice(0, 2)).toEqual([
+        `${PREFLIGHT_MARK_STARTED}\n`,
+        `${PREFLIGHT_MARK_BINDING_LOADED}\n`
+      ])
       expect(errorSpy).toHaveBeenCalled()
     })
 

--- a/apps/desktop/src/main/sync/crdt-preflight-child.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight-child.ts
@@ -23,7 +23,11 @@
 import { writeSync } from 'fs'
 import { createRequire } from 'module'
 import * as Y from 'yjs'
-import { PREFLIGHT_MARK_BINDING_LOADED, PREFLIGHT_MARK_STARTED } from './crdt-preflight-protocol'
+import {
+  PREFLIGHT_MARK_BINDING_LOADED,
+  PREFLIGHT_MARK_STARTED,
+  PREFLIGHT_MARK_STORE_OPS
+} from './crdt-preflight-protocol'
 
 const PROBE_DOC = '__memry_preflight__'
 
@@ -62,16 +66,25 @@ async function main(): Promise<void> {
   // This is the user's real store: round-trip a throwaway probe doc, clear it,
   // and close cleanly (releasing the LevelDB LOCK for main). Never delete the
   // directory — quarantine decisions belong to the provider in main.
+  //
+  // Each operation announces itself BEFORE it runs: a native access violation
+  // unwinds nothing, so the only way to name the failing operation is to have
+  // already said which one is starting.
+  mark(PREFLIGHT_MARK_STORE_OPS.open)
   const persistence = new LeveldbPersistence(probeDir)
   const doc = new Y.Doc()
   doc.getMap('probe').set('ok', true)
+  mark(PREFLIGHT_MARK_STORE_OPS.write)
   await persistence.storeUpdate(PROBE_DOC, Y.encodeStateAsUpdate(doc))
   doc.destroy()
 
+  mark(PREFLIGHT_MARK_STORE_OPS.read)
   const loaded = await persistence.getYDoc(PROBE_DOC)
   loaded.destroy()
 
+  mark(PREFLIGHT_MARK_STORE_OPS.clear)
   await persistence.clearDocument(PROBE_DOC)
+  mark(PREFLIGHT_MARK_STORE_OPS.close)
   await persistence.destroy()
 }
 

--- a/apps/desktop/src/main/sync/crdt-preflight-protocol.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight-protocol.ts
@@ -17,6 +17,30 @@ export const PREFLIGHT_MARK_STARTED = '@@memry-preflight:started@@'
 export const PREFLIGHT_MARK_BINDING_LOADED = '@@memry-preflight:binding-loaded@@'
 
 /**
+ * Written immediately BEFORE each store operation — so the LAST one on stderr
+ * names the operation that was in flight when the child died, not one that
+ * completed. (The two markers above report a step that finished; these cannot,
+ * because the thing they exist to attribute is an abort with no unwinding.)
+ *
+ * Windows installs access-violate here with both markers above already out and
+ * nothing to narrow it further: `store` covers opening the store, writing,
+ * reading back, clearing and closing, and the fix for each is different. These
+ * are the diagnostic that tells them apart.
+ */
+export const PREFLIGHT_MARK_STORE_OPS = {
+  open: '@@memry-preflight:store-open@@',
+  write: '@@memry-preflight:store-write@@',
+  read: '@@memry-preflight:store-read@@',
+  clear: '@@memry-preflight:store-clear@@',
+  close: '@@memry-preflight:store-close@@'
+} as const
+
+/** The store operations the child performs, in the order it performs them. */
+export const PREFLIGHT_STORE_OP_ORDER = ['open', 'write', 'read', 'clear', 'close'] as const
+
+export type CrdtPreflightStoreOp = (typeof PREFLIGHT_STORE_OP_ORDER)[number]
+
+/**
  * How far the child got before it died — the parent reads this off the markers
  * and it decides whether the store is a suspect at all:
  *
@@ -28,5 +52,9 @@ export const PREFLIGHT_MARK_BINDING_LOADED = '@@memry-preflight:binding-loaded@@
  * - `store` — the binding loaded and the probe died using it. Either the
  *   on-disk state or the binding-in-use is bad; only this stage is worth
  *   quarantining for.
+ * - `binding-in-use` — a `store` failure that reproduced against a fresh, EMPTY
+ *   directory, so the data cannot be the cause. Never derived from the markers
+ *   (the child cannot know what a second child found); the provider reclassifies
+ *   `store` into it after the control probe. See crdt-persistence.ts.
  */
-export type CrdtPreflightStage = 'bootstrap' | 'binding' | 'store'
+export type CrdtPreflightStage = 'bootstrap' | 'binding' | 'store' | 'binding-in-use'

--- a/apps/desktop/src/main/sync/crdt-preflight.test.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight.test.ts
@@ -1,6 +1,10 @@
 import { EventEmitter } from 'events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { PREFLIGHT_MARK_BINDING_LOADED, PREFLIGHT_MARK_STARTED } from './crdt-preflight-protocol'
+import {
+  PREFLIGHT_MARK_BINDING_LOADED,
+  PREFLIGHT_MARK_STARTED,
+  PREFLIGHT_MARK_STORE_OPS
+} from './crdt-preflight-protocol'
 
 const mockFork = vi.hoisted(() => vi.fn())
 const mockSpawn = vi.hoisted(() => vi.fn())
@@ -69,11 +73,27 @@ describe('runCrdtPreflight', () => {
     expect(mockSpawn).not.toHaveBeenCalled()
   })
 
+  /**
+   * Drive the Chromium-free retry the parent now runs for store failures too.
+   * The retry's verdict is the one that is returned, so it has to reproduce the
+   * markers of the failure under test.
+   */
+  async function failNodeRetry(
+    options: { code?: number; storeOps?: Array<keyof typeof PREFLIGHT_MARK_STORE_OPS> } = {}
+  ): Promise<void> {
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled())
+    nodeChild.say(PREFLIGHT_MARK_STARTED)
+    nodeChild.say(PREFLIGHT_MARK_BINDING_LOADED)
+    for (const op of options.storeOps ?? []) nodeChild.say(PREFLIGHT_MARK_STORE_OPS[op])
+    nodeChild.emit('exit', options.code ?? 134)
+  }
+
   it('fails when the child dies with a non-zero code (native abort)', async () => {
     const pending = runCrdtPreflight(STORE_DIR)
     child.say(PREFLIGHT_MARK_STARTED)
     child.say(PREFLIGHT_MARK_BINDING_LOADED)
     child.emit('exit', 134)
+    await failNodeRetry()
 
     const result = await pending
     expect(result.ok).toBe(false)
@@ -87,10 +107,11 @@ describe('runCrdtPreflight', () => {
     child.say(PREFLIGHT_MARK_BINDING_LOADED)
 
     await vi.advanceTimersByTimeAsync(11_000)
+    expect(mockSpawn).toHaveBeenCalled()
+    nodeChild.emit('exit', 134)
 
     const result = await pending
     expect(result.ok).toBe(false)
-    expect(result.reason).toContain('timed out')
     expect(child.kill).toHaveBeenCalled()
   })
 
@@ -112,6 +133,7 @@ describe('runCrdtPreflight', () => {
     child.say(PREFLIGHT_MARK_STARTED)
     child.say(PREFLIGHT_MARK_BINDING_LOADED)
     child.emit('exit', 134)
+    await failNodeRetry()
     await first
 
     const second = runCrdtPreflight(STORE_DIR)
@@ -130,8 +152,38 @@ describe('runCrdtPreflight', () => {
       child.say(PREFLIGHT_MARK_STARTED)
       child.say(PREFLIGHT_MARK_BINDING_LOADED)
       child.emit('exit', 134)
+      await failNodeRetry()
 
       await expect(pending).resolves.toMatchObject({ ok: false, stage: 'store' })
+    })
+
+    // Production (issue #1583) could only ever say "somewhere in the store" —
+    // opening, writing, reading back, clearing and closing all landed on the
+    // same token, and each has a different cause.
+    it('names the store operation that was in flight when the child died', async () => {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.say(PREFLIGHT_MARK_STARTED)
+      child.say(PREFLIGHT_MARK_BINDING_LOADED)
+      child.say(PREFLIGHT_MARK_STORE_OPS.open)
+      child.say(PREFLIGHT_MARK_STORE_OPS.write)
+      child.emit('exit', -1073741819)
+      await failNodeRetry({ storeOps: ['open', 'write'] })
+
+      // The LAST marker, not the first: each is written before its operation
+      // runs, so the newest one names the operation that never came back.
+      const result = await pending
+      expect(result.stage).toBe('store')
+      expect(result.storeOp).toBe('write')
+    })
+
+    it('leaves the store operation unset when the child died before announcing one', async () => {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.say(PREFLIGHT_MARK_STARTED)
+      child.say(PREFLIGHT_MARK_BINDING_LOADED)
+      child.emit('exit', -1073741819)
+      await failNodeRetry()
+
+      expect((await pending).storeOp).toBeUndefined()
     })
 
     it('reports stage "binding" when the child started but never loaded the binding', async () => {
@@ -200,6 +252,58 @@ describe('runCrdtPreflight', () => {
       nodeChild.emit('exit', 134)
 
       await expect(pending).resolves.toMatchObject({ ok: false, stage: 'store' })
+    })
+  })
+
+  // On 2026.817.1 the utility child reached the store and access-violated there
+  // on 19/19 win32 installs, and the fallback was gated on 'bootstrap' — so for
+  // 7 of 8 installs it was dead code. Whether a Chromium-free child clears the
+  // access violation is unknown and must be measured; that it now RUNS is the
+  // part this pins.
+  describe('plain-node fallback when the utility child dies inside the store', () => {
+    it('retries a store-stage failure and takes the fallback verdict when it passes', async () => {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.say(PREFLIGHT_MARK_STARTED)
+      child.say(PREFLIGHT_MARK_BINDING_LOADED)
+      child.say(PREFLIGHT_MARK_STORE_OPS.open)
+      child.emit('exit', -1073741819)
+
+      await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(1))
+      expect((mockSpawn.mock.calls[0] as [string, string[]])[1][1]).toBe(STORE_DIR)
+      nodeChild.emit('exit', 0)
+
+      await expect(pending).resolves.toEqual({ ok: true, transport: 'node' })
+    })
+
+    it('reports the fallback transport when it access-violates too', async () => {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.say(PREFLIGHT_MARK_STARTED)
+      child.say(PREFLIGHT_MARK_BINDING_LOADED)
+      child.emit('exit', -1073741819)
+
+      await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(1))
+      nodeChild.say(PREFLIGHT_MARK_STARTED)
+      nodeChild.say(PREFLIGHT_MARK_BINDING_LOADED)
+      nodeChild.say(PREFLIGHT_MARK_STORE_OPS.open)
+      nodeChild.emit('exit', -1073741819)
+
+      // 'node' is the field that says the binding is broken on this machine
+      // rather than the utility process being unable to start.
+      await expect(pending).resolves.toMatchObject({
+        ok: false,
+        stage: 'store',
+        storeOp: 'open',
+        transport: 'node'
+      })
+    })
+
+    it('does not retry a binding-stage failure, which never opened the store', async () => {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.say(PREFLIGHT_MARK_STARTED)
+      child.emit('exit', 1)
+
+      await expect(pending).resolves.toMatchObject({ ok: false, stage: 'binding' })
+      expect(mockSpawn).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/desktop/src/main/sync/crdt-preflight.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight.ts
@@ -6,10 +6,30 @@ import { createLogger } from '../lib/logger'
 import {
   PREFLIGHT_MARK_BINDING_LOADED,
   PREFLIGHT_MARK_STARTED,
-  type CrdtPreflightStage
+  PREFLIGHT_MARK_STORE_OPS,
+  PREFLIGHT_STORE_OP_ORDER,
+  type CrdtPreflightStage,
+  type CrdtPreflightStoreOp
 } from './crdt-preflight-protocol'
 
 const log = createLogger('CrdtPreflight')
+
+/**
+ * What this machine is, in the two fields that separate the candidate causes of
+ * a native abort in the binding: an OS build (Windows ships LevelDB-hostile
+ * behaviour per build — `os.release()` is `10.0.<build>` there, and
+ * `os.version()` names the edition) and the CPU target the prebuilt binary was
+ * chosen for. Attached to every failure line so the fleet query can group by
+ * them instead of guessing.
+ */
+function machineFields(): Record<string, string> {
+  return {
+    platform: process.platform,
+    osRelease: os.release(),
+    osVersion: os.version(),
+    arch: process.arch
+  }
+}
 
 const PREFLIGHT_TIMEOUT_MS = 10_000
 // The interesting part of a native abort is the first crash banner; keep
@@ -23,6 +43,12 @@ export interface CrdtPreflightResult {
   reason?: string
   /** How far the child got before failing. Only meaningful when `ok` is false. */
   stage?: CrdtPreflightStage
+  /**
+   * Which store operation was in flight when a `store`-stage child died.
+   * Undefined at every other stage, and for a child that died between loading
+   * the binding and announcing its first operation.
+   */
+  storeOp?: CrdtPreflightStoreOp
   /**
    * Which child transport produced this verdict. Reported as telemetry: a
    * `node` verdict means the Chromium-free fallback ALSO failed, which is the
@@ -52,10 +78,10 @@ interface ProbeChild {
  * Two transports, because the utilityProcess itself can be the thing that
  * fails: on a set of Windows installs it dies during Chromium/crashpad init
  * (exit `0xFFFF7003`) before any of our JS runs, which used to read as "the
- * store is bad" and left those machines in-memory forever. When the child
- * never reaches its `started` marker, the same probe is retried as a plain
- * node child (`ELECTRON_RUN_AS_NODE`), which boots no Chromium and no crash
- * handler — same process isolation, none of the Chromium startup surface.
+ * store is bad" and left those machines in-memory forever. Whenever the child
+ * dies before starting OR while using the store, the same probe is retried as a
+ * plain node child (`ELECTRON_RUN_AS_NODE`), which boots no Chromium and no
+ * crash handler — same process isolation, none of the Chromium startup surface.
  *
  * No verdict cache: the provider latches init (persistenceReady) so a verdict
  * is only ever requested again after it quarantined the store — and that retry
@@ -76,11 +102,25 @@ async function probeWithFallback(storeDir: string): Promise<CrdtPreflightResult>
   const startedAt = Date.now()
   let result = await execPreflight(storeDir, 'utility')
 
-  if (!result.ok && result.stage === 'bootstrap') {
-    log.warn('CRDT preflight child never started — retrying without Chromium', {
+  // Both stages the fallback can plausibly answer, not just `bootstrap`.
+  //
+  // `bootstrap` is the case it was built for: the utility child dies in
+  // Chromium/crashpad init, so booting the same probe without Chromium is a
+  // straight retry of a question that was never asked.
+  //
+  // `store` is the dominant Windows failure today (19/19 installs, issue #1583)
+  // and the gate locked it out entirely: those children reach the store and
+  // access-violate inside it, so they stage `store` and never reached here. It
+  // is genuinely unknown whether a Chromium-free child clears that — the one
+  // install that reached the fallback also failed there — so this is a
+  // measurable attempt, not a claimed fix. It costs one extra child process on
+  // a launch that was already headed for in-memory mode.
+  if (!result.ok && (result.stage === 'bootstrap' || result.stage === 'store')) {
+    log.warn('CRDT preflight child failed — retrying without Chromium', {
       reason: result.reason,
-      platform: process.platform,
-      osRelease: os.release()
+      stage: result.stage,
+      storeOp: result.storeOp,
+      ...machineFields()
     })
     result = await execPreflight(storeDir, 'node')
   }
@@ -92,8 +132,8 @@ async function probeWithFallback(storeDir: string): Promise<CrdtPreflightResult>
       storeDir,
       reason: result.reason,
       stage: result.stage,
-      platform: process.platform,
-      osRelease: os.release(),
+      storeOp: result.storeOp,
+      ...machineFields(),
       elapsedMs: Date.now() - startedAt
     })
   }
@@ -116,6 +156,24 @@ async function execPreflight(storeDir: string, transport: Transport): Promise<Cr
       return 'bootstrap'
     }
 
+    // The child announces each store operation before running it, so the LAST
+    // one it announced is the one that was in flight when it died.
+    const storeOpFromMarkers = (): CrdtPreflightStoreOp | undefined => {
+      for (let i = PREFLIGHT_STORE_OP_ORDER.length - 1; i >= 0; i--) {
+        const op = PREFLIGHT_STORE_OP_ORDER[i]
+        if (stderr.includes(PREFLIGHT_MARK_STORE_OPS[op])) return op
+      }
+      return undefined
+    }
+
+    /** A failure verdict, staged and attributed from whatever stderr carried. */
+    const failure = (reason: string): CrdtPreflightResult => ({
+      ok: false,
+      stage: stageFromMarkers(),
+      storeOp: storeOpFromMarkers(),
+      reason
+    })
+
     const settle = (result: CrdtPreflightResult): void => {
       if (settled) return
       settled = true
@@ -126,6 +184,8 @@ async function execPreflight(storeDir: string, transport: Transport): Promise<Cr
           storeDir,
           reason: result.reason,
           stage: result.stage,
+          storeOp: result.storeOp,
+          ...machineFields(),
           stderr: stderr.slice(0, STDERR_CAPTURE_CHARS)
         })
       }
@@ -151,11 +211,7 @@ async function execPreflight(storeDir: string, transport: Transport): Promise<Cr
       } catch {
         // already gone
       }
-      settle({
-        ok: false,
-        stage: stageFromMarkers(),
-        reason: `timed out after ${PREFLIGHT_TIMEOUT_MS}ms`
-      })
+      settle(failure(`timed out after ${PREFLIGHT_TIMEOUT_MS}ms`))
     }, PREFLIGHT_TIMEOUT_MS)
 
     child.stderr?.on('data', (chunk: Buffer) => {
@@ -163,7 +219,7 @@ async function execPreflight(storeDir: string, transport: Transport): Promise<Cr
     })
 
     child.on('error', (err: Error) => {
-      settle({ ok: false, stage: stageFromMarkers(), reason: err.message })
+      settle(failure(err.message))
     })
 
     child.once('exit', (code: number | null) => {
@@ -174,11 +230,7 @@ async function execPreflight(storeDir: string, transport: Transport): Promise<Cr
       // Log the code in hex too: Windows reports these as huge unsigned
       // values (0xFFFF7003 = 4294930435) that are meaningless in decimal.
       const hex = typeof code === 'number' ? ` (0x${(code >>> 0).toString(16).toUpperCase()})` : ''
-      settle({
-        ok: false,
-        stage: stageFromMarkers(),
-        reason: `child exited with code ${code}${hex}`
-      })
+      settle(failure(`child exited with code ${code}${hex}`))
     })
   })
 

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -69,6 +69,8 @@ const mocks = vi.hoisted(() => {
     dataDb: {} as object | null,
     vaultUuid: '11111111-2222-3333-4444-555555555555',
     legacyStoreClaim: undefined as string | undefined,
+    /** Persisted streak the degraded-persistence notice is thresholded on. */
+    recordPersistenceOutcome: vi.fn((..._args: unknown[]) => 0),
     // Verdict of the disposable utilityProcess preflight (see crdt-preflight.ts).
     // preflightQueue serves per-call verdicts (quarantine retry = second call);
     // when empty, preflightResult is the standing answer.
@@ -168,7 +170,9 @@ vi.mock('../store', () => ({
   getLegacyCrdtStorePartitionPending: () => undefined,
   clearLegacyCrdtStorePartitionPending: vi.fn(),
   getPendingCrdtStoreRename: () => undefined,
-  clearPendingCrdtStoreRename: vi.fn()
+  clearPendingCrdtStoreRename: vi.fn(),
+  getCrdtInMemorySessions: () => 0,
+  recordCrdtPersistenceOutcome: (...args: unknown[]) => mocks.recordPersistenceOutcome(...args)
 }))
 
 vi.mock('@main/database/queries/notes', () => ({
@@ -2076,7 +2080,9 @@ describe('CrdtProvider persistence resilience', () => {
   // The preflight child probes the REAL crdt-store dir, so it also dies on a
   // store whose on-disk state (torn LDB/MANIFEST from a past crash or full
   // disk) aborts the binding — not just on a binding that is broken outright.
-  // The two are told apart empirically: quarantine the store, re-probe fresh.
+  // The two are told apart empirically, by a control the store cannot be
+  // blamed for: probe a directory that is guaranteed empty, BEFORE anything is
+  // moved.
   describe('store quarantine', () => {
     const userDataDir = mocks.userDataDir
     const storeDir = vaultStoreDir()
@@ -2093,7 +2099,7 @@ describe('CrdtProvider persistence resilience', () => {
       fs.rmSync(userDataDir, { recursive: true, force: true })
     })
 
-    it('quarantines a corrupt store and continues on a fresh one when the re-probe passes', async () => {
+    it('quarantines a corrupt store and continues on a fresh one when the control passes', async () => {
       fs.mkdirSync(storeDir, { recursive: true })
       fs.writeFileSync(`${storeDir}/MANIFEST-000001`, 'torn')
       mocks.preflightQueue.push(
@@ -2105,15 +2111,20 @@ describe('CrdtProvider persistence resilience', () => {
       await expect(provider.init()).resolves.toBeUndefined()
 
       // Corrupt store moved aside (preserved, not deleted), fresh store adopted.
-      expect(mocks.preflightCalls).toEqual([storeDir, storeDir])
+      expect(mocks.preflightCalls).toEqual([storeDir, `${storeDir}.probe`])
       expect(fs.existsSync(storeDir)).toBe(false)
       const quarantined = quarantinedDirs()
       expect(quarantined).toHaveLength(1)
       expect(fs.existsSync(`${storeRoot}/${quarantined[0]}/MANIFEST-000001`)).toBe(true)
       expect(mocks.persistenceInstances).toHaveLength(1)
+      // The control directory does not outlive the probe.
+      expect(fs.existsSync(`${storeDir}.probe`)).toBe(false)
     })
 
-    it('restores the quarantined store when the re-probe also fails (broken binding)', async () => {
+    // Issue #1583: on 19/19 win32 installs the binding access-violated against
+    // an empty directory as readily as against the user's data, and the store
+    // was moved aside, rm'd and moved back for it — every launch, forever.
+    it('never moves the store when the empty control directory fails too', async () => {
       fs.mkdirSync(storeDir, { recursive: true })
       fs.writeFileSync(`${storeDir}/MANIFEST-000001`, 'healthy-but-binding-broken')
       mocks.preflightQueue.push(
@@ -2124,11 +2135,12 @@ describe('CrdtProvider persistence resilience', () => {
       const provider = new CrdtProvider()
       await expect(provider.init()).resolves.toBeUndefined()
 
-      // Binding is the problem, not the data: put the store back so a future
-      // launch with a working binding finds the user's CRDT history intact.
-      expect(mocks.preflightCalls).toEqual([storeDir, storeDir])
+      // The binding is the problem, not the data — so the user's CRDT history
+      // is never touched at all, rather than moved aside and moved back.
+      expect(mocks.preflightCalls).toEqual([storeDir, `${storeDir}.probe`])
       expect(fs.existsSync(`${storeDir}/MANIFEST-000001`)).toBe(true)
       expect(quarantinedDirs()).toHaveLength(0)
+      expect(fs.existsSync(`${storeDir}.probe`)).toBe(false)
       expect(mocks.persistenceInstances).toHaveLength(0)
       expect(provider.isInitialized()).toBe(true)
     })

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -15,6 +15,7 @@ import {
   resetWritebackState
 } from './crdt-writeback'
 import { openCrdtPersistence, type CrdtPersistence } from './crdt-persistence'
+import { recordCrdtPersistenceOutcome } from '../store'
 import { recordPendingCrdtNotes } from './crdt-pending-notes'
 import { prepareVaultCrdtStore } from './crdt-store-path'
 import { toAbsolutePath } from '../vault/notes'
@@ -187,6 +188,7 @@ export class CrdtProvider {
     // the store could not be trusted and this provider runs in-memory.
     this.persistence = await openCrdtPersistence(target.storagePath)
     this.persistenceReady = true
+    recordSessionPersistenceOutcome(this.persistence !== null)
 
     // The readiness signal a stranded editor waits on, announced from the exact
     // assignment that makes crdt:open-doc stop rejecting — the IPC handler gates
@@ -202,6 +204,16 @@ export class CrdtProvider {
 
   isInitialized(): boolean {
     return this.persistenceReady
+  }
+
+  /**
+   * Whether this provider is backed by the on-disk store. False means CRDT
+   * state lives only in this process: notes are still read from and written
+   * back to vault markdown, but edit history and the local state vector are
+   * gone at quit. Only meaningful once `isInitialized()` is true.
+   */
+  hasPersistence(): boolean {
+    return this.persistence !== null
   }
 
   /**
@@ -1224,6 +1236,44 @@ function isIpcOrigin(origin: unknown): origin is IpcOrigin {
     'source' in origin &&
     (origin as IpcOrigin).source === 'ipc'
   )
+}
+
+let sessionOutcomeRecorded = false
+
+/**
+ * Count this LAUNCH once, not each store this launch opens.
+ *
+ * A vault switch brings up a second provider, and a user who switches five
+ * times would otherwise look like five degraded launches — which is the number
+ * the user-facing notice is thresholded on. The first verdict of the process is
+ * the honest one; the rest of the session is the same binary and the same
+ * machine.
+ *
+ * There is deliberately no bounded retry behind this. The failure it counts is
+ * a native abort in the binding, which issue #1583 shows is deterministic per
+ * machine (19/19 win32 installs, every launch, six releases) rather than
+ * transient, and every retry costs a multi-second child process on the launch
+ * path. The one transient-shaped cause — a utility process that cannot boot —
+ * already gets its retry inside a single `openCrdtPersistence` call, on the
+ * Chromium-free transport.
+ */
+function recordSessionPersistenceOutcome(healthy: boolean): void {
+  if (sessionOutcomeRecorded) return
+  sessionOutcomeRecorded = true
+  try {
+    const sessions = recordCrdtPersistenceOutcome(healthy)
+    if (sessions > 0) {
+      log.warn('CRDT persistence has been unavailable for consecutive launches', { sessions })
+    }
+  } catch (err) {
+    // Bookkeeping for a notice must never be what stops the store from opening.
+    log.warn('Could not record the CRDT persistence outcome', { error: err })
+  }
+}
+
+/** Test seam for the once-per-launch latch above. */
+export function _resetCrdtSessionOutcomeForTests(): void {
+  sessionOutcomeRecorded = false
 }
 
 let instance: CrdtProvider | null = null

--- a/apps/desktop/src/preload/api/sync-ops.ts
+++ b/apps/desktop/src/preload/api/sync-ops.ts
@@ -64,7 +64,8 @@ export const syncCrdt = {
   syncStep1: (input: { noteId: string; stateVector: Uint8Array }) =>
     invoke(SYNC_CHANNELS.SYNC_STEP_1, input),
   syncStep2: (input: { noteId: string; diff: Uint8Array }) =>
-    invoke(SYNC_CHANNELS.SYNC_STEP_2, input)
+    invoke(SYNC_CHANNELS.SYNC_STEP_2, input),
+  getHealth: () => invoke(SYNC_CHANNELS.GET_HEALTH)
 }
 
 type CrdtStateChangedPayload = { noteId: string; update: Uint8Array; origin: string }

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -64,7 +64,7 @@ import type {
   CertificatePinFailedEvent,
   VaultRecoveryNeededEvent
 } from '../shared/contracts/ipc-sync'
-import type { CrdtOpenDocResult, CrdtSyncStep1Result } from '@memry/contracts/ipc-crdt'
+import type { CrdtHealth, CrdtOpenDocResult, CrdtSyncStep1Result } from '@memry/contracts/ipc-crdt'
 import type {
   FolderViewClientAPI as ContractFolderViewClientAPI,
   ConfigUpdatedEvent as FolderViewConfigUpdatedEvent
@@ -1778,6 +1778,8 @@ interface API extends WindowAPI, GeneratedRpcApi {
       stateVector: Uint8Array
     }) => Promise<CrdtSyncStep1Result | null>
     syncStep2: (input: { noteId: string; diff: Uint8Array }) => Promise<void>
+    /** Whether CRDT state is durable on this install, and for how long it has not been. */
+    getHealth: () => Promise<CrdtHealth>
   }
   /** Show a native OS context menu and return the selected item id, or null if dismissed */
   showContextMenu: (items: ContextMenuItem[]) => Promise<string | null>

--- a/apps/desktop/src/renderer/src/components/crdt-persistence-notice.test.tsx
+++ b/apps/desktop/src/renderer/src/components/crdt-persistence-notice.test.tsx
@@ -1,0 +1,71 @@
+import { render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const toastFn = vi.hoisted(() => vi.fn())
+
+vi.mock('sonner', () => ({ toast: toastFn }))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { CrdtPersistenceNotice } from './crdt-persistence-notice'
+
+const getHealth = vi.fn()
+const api = window.api as unknown as { syncCrdt: { getHealth: typeof getHealth } }
+const realSyncCrdt = api.syncCrdt
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  api.syncCrdt = { getHealth }
+})
+
+afterEach(() => {
+  api.syncCrdt = realSyncCrdt
+})
+
+describe('CrdtPersistenceNotice', () => {
+  it('says nothing while the store is healthy', async () => {
+    getHealth.mockResolvedValue({ persistent: true, inMemorySessions: 0 })
+
+    render(<CrdtPersistenceNotice />)
+
+    await waitFor(() => expect(getHealth).toHaveBeenCalled())
+    expect(toastFn).not.toHaveBeenCalled()
+  })
+
+  // One degraded launch is usually a store that quarantined itself and will be
+  // fine next time; saying anything then is noise.
+  it('stays quiet below the consecutive-session threshold', async () => {
+    getHealth.mockResolvedValue({ persistent: false, inMemorySessions: 2 })
+
+    render(<CrdtPersistenceNotice />)
+
+    await waitFor(() => expect(getHealth).toHaveBeenCalled())
+    expect(toastFn).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the notice once the device has degraded for three launches', async () => {
+    getHealth.mockResolvedValue({ persistent: false, inMemorySessions: 3 })
+
+    render(<CrdtPersistenceNotice />)
+
+    await waitFor(() => expect(toastFn).toHaveBeenCalledTimes(1))
+    const [title, options] = toastFn.mock.calls[0] as [string, { description: string }]
+    expect(title).toBe('crdt.persistenceDegradedTitle')
+    expect(options.description).toBe('crdt.persistenceDegradedBody')
+  })
+
+  it('stays quiet when the health query fails, rather than nagging blindly', async () => {
+    getHealth.mockRejectedValue(new Error('no handler'))
+
+    render(<CrdtPersistenceNotice />)
+
+    await waitFor(() => expect(getHealth).toHaveBeenCalled())
+    expect(toastFn).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/crdt-persistence-notice.tsx
+++ b/apps/desktop/src/renderer/src/components/crdt-persistence-notice.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+import { useT } from '@memry/i18n/renderer'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('CrdtPersistenceNotice')
+
+/**
+ * Consecutive in-memory launches before the notice is worth interrupting for.
+ *
+ * Not 1: a single degraded launch is usually a store that quarantined itself
+ * and will be healthy next time, and saying anything then would be noise. Three
+ * is a machine that is not recovering on its own.
+ */
+const DEGRADED_SESSION_THRESHOLD = 3
+
+/**
+ * Tell the user, calmly and once per launch, when this device has stopped
+ * keeping CRDT state on disk.
+ *
+ * Until this existed an install could run in memory forever — a whole Windows
+ * population did (issue #1583) — with a log line as the only signal. The
+ * wording is deliberately not alarming, because nothing the user wrote is at
+ * risk: vault markdown is the source of truth and still loads and saves. What
+ * is actually lost is durable CRDT state — edit history and the local Yjs state
+ * vector that lets an offline device merge cleanly instead of resolving against
+ * a from-scratch document.
+ *
+ * Renders nothing. Mounted next to the app rather than inside it so a partially
+ * mocked `window.api` in a component test cannot reach it, and so the query
+ * resolves after the app's Toaster is mounted.
+ */
+export function CrdtPersistenceNotice(): null {
+  const { t } = useT('errors')
+  const announced = useRef(false)
+
+  useEffect(() => {
+    if (announced.current) return
+    announced.current = true
+
+    let cancelled = false
+    void (async () => {
+      try {
+        const health = await window.api.syncCrdt.getHealth()
+        if (cancelled) return
+        if (health.persistent) return
+        if (health.inMemorySessions < DEGRADED_SESSION_THRESHOLD) return
+
+        toast(t('crdt.persistenceDegradedTitle'), {
+          description: t('crdt.persistenceDegradedBody'),
+          duration: 15000
+        })
+      } catch (error) {
+        // A device with no answer here is not a device to nag; the main-process
+        // telemetry already carries the failure.
+        log.warn('Could not read CRDT persistence health', error)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [t])
+
+  return null
+}

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -24,6 +24,7 @@ import { type Locale } from '@memry/i18n/shared'
 import App from './App'
 import { setActiveLocale } from './lib/active-locale'
 import QuickCapture from './components/quick-capture'
+import { CrdtPersistenceNotice } from './components/crdt-persistence-notice'
 import { AuthProvider } from './contexts/auth-context'
 import { SyncProvider } from './contexts/sync-context'
 import { AISettingsProvider } from './contexts/ai-settings-context'
@@ -126,6 +127,8 @@ async function boot(): Promise<void> {
           <AuthProvider>
             <SyncProvider>
               <App />
+              {/* After <App />, so the Toaster it renders is already mounted. */}
+              <CrdtPersistenceNotice />
             </SyncProvider>
           </AuthProvider>
         </QueryClientProvider>

--- a/apps/desktop/tests/setup-dom.ts
+++ b/apps/desktop/tests/setup-dom.ts
@@ -545,7 +545,14 @@ const createMockApi = () => ({
   onReminderSnoozed: vi.fn().mockReturnValue(() => {}),
   onReminderClicked: vi.fn().mockReturnValue(() => {}),
   onInboxOpenItem: vi.fn().mockReturnValue(() => {}),
-  onUpdaterStateChanged: vi.fn().mockReturnValue(() => {})
+  onUpdaterStateChanged: vi.fn().mockReturnValue(() => {}),
+
+  // CRDT bridge. Only the health query is mocked here: it is the one call the
+  // app makes on mount without an editor, and a healthy answer keeps the
+  // degraded-persistence notice silent for every other suite.
+  syncCrdt: {
+    getHealth: vi.fn().mockResolvedValue({ persistent: true, inMemorySessions: 0 })
+  }
 })
 
 if (typeof window === 'undefined') {

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -210,22 +210,39 @@ The child reports how far it got by writing **stage markers** to stderr
 store from a machine that cannot start a child at all:
 
 - `bootstrap` — the child never reached JS. Observed on Windows, where the
-  utility process dies in Chromium/crashpad init with exit `0xFFFF7003`. The
-  same probe is then retried as a plain node child
-  (`ELECTRON_RUN_AS_NODE`), which starts no Chromium and no crash handler.
+  utility process dies in Chromium/crashpad init with exit `0xFFFF7003`.
 - `binding` — the child ran but the native binding failed to load. The store
   was never opened.
-- `store` — the binding loaded and the probe died using it.
+- `store` — the binding loaded and the probe died using it. The child also
+  announces each store operation *before* running it (`open`, `write`, `read`,
+  `clear`, `close`), so a native abort — which unwinds nothing — still names
+  the operation that was in flight.
+- `binding-in-use` — a `store` failure that reproduced against an empty
+  directory. Not a marker the child can write; the provider assigns it (below).
 
-Only a `store` verdict implicates the store. When it fails and a store
-exists, the store is **quarantined** (renamed to
-`<vault uuid>.broken-<timestamp>`, next to the store it came from) and the preflight retried once against a
-fresh directory: a pass means the data was at fault, so the app continues
-with a fresh store; a second failure means the binding itself is broken, so
-the original store is restored for a future launch and the provider goes
-in-memory. Restoring first clears the partial fresh store the failed re-probe
-left behind (renaming onto an existing directory is `EPERM` on Windows), and
-falls back to retries and then copy+delete if the directory is still locked.
+A `bootstrap` **or** `store` failure is retried once as a plain node child
+(`ELECTRON_RUN_AS_NODE`), which starts no Chromium and no crash handler. A
+verdict reported with `transport: node` therefore means the Chromium-free
+fallback failed too — the binding is broken on that machine rather than the
+utility process being unable to start.
+
+Only a `store` verdict implicates the store, and it has to prove it. Before
+anything is moved, the same probe is run against an **empty control directory**
+(`<store>.probe`, cleared before and after use) that the user's data cannot be
+responsible for:
+
+- **Control passes** — the data was at fault. The store is **quarantined**
+  (renamed to `<vault uuid>.broken-<timestamp>`, next to the store it came
+  from) and the app continues on a fresh store, reseeded from vault markdown.
+  Moving falls back to retries and then copy+delete if the directory is locked.
+- **Control fails** — the binding is at fault and the data is innocent. The
+  store is **not touched at all**, and the failure is restaged as
+  `binding-in-use` so telemetry stops reporting a data problem that does not
+  exist.
+
+If the control directory cannot be cleared, no control is run and the store is
+left alone: no evidence means no reason to move a user's CRDT history.
+
 Only after the child survives is the y-leveldb store probed
 in-process (a write/read/clear round-trip with a timeout) before it is
 trusted. A broken `classic-level` native binding doesn't
@@ -236,6 +253,31 @@ disk, and the editor keeps working; only CRDT history persistence across
 restarts is lost for that session. A mid-session load failure for a single doc
 falls back to seeding from the vault file instead of blocking the note from
 opening.
+
+### Telling the user
+
+In-memory mode is silent by design for one launch — a store that quarantined
+itself is usually healthy on the next one. It is not silent forever. Each
+launch records its outcome once (the first store it opens; a vault switch does
+not count again) as a consecutive-degraded-launch streak in
+`memry-config.json` under `crdtStore.inMemorySessions`, reset to `0` the moment
+a store opens. After **three consecutive launches with no durable store**, the
+app shows one calm notice: notes are safe — vault markdown is the source of
+truth and still loads and saves — but this device's edit history and merge
+state are running in memory and start fresh each launch.
+
+The renderer **pulls** this over `crdt:get-health`
+(`window.api.syncCrdt.getHealth()`) rather than being pushed it: the store's
+verdict lands while the window is still loading, so a broadcast would routinely
+arrive before anything was listening. The streak is persisted, so the answer is
+correct whenever it is asked.
+
+There is deliberately no bounded retry of a failed store open within a session.
+The failure it guards against is a native abort in the binding, which in the
+field is deterministic per machine rather than transient, and every retry costs
+a multi-second child process on the launch path. The one transient-shaped cause
+— a utility process that cannot boot — already gets its retry on the
+Chromium-free transport inside a single open.
 
 ## Why the Main Process Owns Y.Docs
 

--- a/packages/contracts/src/ipc-crdt.ts
+++ b/packages/contracts/src/ipc-crdt.ts
@@ -5,7 +5,8 @@ export const CRDT_CHANNELS = {
   CLOSE_DOC: 'crdt:close-doc',
   APPLY_UPDATE: 'crdt:apply-update',
   SYNC_STEP_1: 'crdt:sync-step-1',
-  SYNC_STEP_2: 'crdt:sync-step-2'
+  SYNC_STEP_2: 'crdt:sync-step-2',
+  GET_HEALTH: 'crdt:get-health'
 } as const
 
 export const CRDT_EVENTS = {
@@ -33,6 +34,25 @@ export const CRDT_EVENTS = {
    */
   PROVIDER_READY: 'crdt:provider-ready'
 } as const
+
+/**
+ * Whether this install has a durable CRDT store, and for how long it has not.
+ *
+ * Pulled by the renderer rather than pushed: the verdict lands while the window
+ * is still loading (the store is opened from `openVault`, which runs moments
+ * after the window is created), so a broadcast would routinely arrive before
+ * anything is listening. The count is persisted across launches, so the answer
+ * is correct whenever it is asked.
+ */
+export interface CrdtHealth {
+  /** False when the store could not be opened and CRDT state lives only in memory. */
+  persistent: boolean
+  /**
+   * Consecutive launches — this one included, once its verdict has landed —
+   * that ran without a durable store. Zero whenever the store last opened.
+   */
+  inMemorySessions: number
+}
 
 export const CRDT_FRAGMENT_NAME = 'prosemirror' as const
 

--- a/packages/i18n/src/locales/en/errors.json
+++ b/packages/i18n/src/locales/en/errors.json
@@ -62,6 +62,10 @@
     "exceedsPlanLimit": "File is larger than your plan allows: {size} exceeds {limit}",
     "emptyFile": "Cannot upload empty file"
   },
+  "crdt": {
+    "persistenceDegradedTitle": "Edit history isn't being kept on this device",
+    "persistenceDegradedBody": "Your notes are safe — they live in your vault as plain files, and they still open and save normally. Only this device's local edit history and merge state are running in memory, so they start fresh each time memrynote opens."
+  },
   "encryption": {
     "failed": "Failed to encrypt data. Your keys may need to be regenerated.",
     "decryptionFailed": "Failed to decrypt data. Your encryption keys may be out of date.",


### PR DESCRIPTION
## What was broken

On Windows the `CrdtPreflight` child access-violates (`0xC0000005`) **after** the native binding loads, on every launch. In the 12-day window on issue #1583: **19 of 19 win32 installs** that reported any telemetry hit it, and on the newest release (2026.817.1) **8 of 8** also logged `CRDT persistence unavailable — continuing in-memory`. So effectively the entire Windows population runs CRDT persistence in memory, forever, with a log line as the only signal.

Two things made it worse than it had to be:

1. The failure staged as `store`, which the provider read as "the user's data is corrupt". It quarantined the store, re-probed, failed again, `rmSync`'d and moved it back — **every launch, forever, for nothing**. Zero win32 rows for `CRDT store quarantined ... continuing with a fresh store` across the whole window: not one machine ever came out of that cycle with a working store.
2. #852's Chromium-free `node`-transport retry is gated on `stage === 'bootstrap'`, so it could not run for the dominant failure mode at all — dead code for 7 of 8 installs on the latest release.

## What changed

**Real fixes**

- **A control probe replaces the quarantine gamble.** A `store`-stage failure now runs the same probe against an empty control directory (`<store>.probe`) that the user's data cannot be responsible for, **before anything is moved**. Control passes → the data was at fault, quarantine as before. Control fails → the binding is at fault, the store is **not touched at all**, and the verdict is restaged as `binding-in-use`. If the control directory cannot be cleared, no control runs and the store is still left alone: no evidence, no reason to move a user's CRDT history. This ends the per-launch churn outright.
- **A user-facing notice.** Each launch records its persistence outcome once as a consecutive-degraded streak in `memry-config.json` (`crdtStore.inMemorySessions`), reset to 0 the moment a store opens. After three consecutive in-memory launches the app says so, once, calmly: notes are safe — vault markdown is the source of truth and still loads and saves — but this device's edit history and merge state are running in memory and start fresh each launch. Pulled over a new `crdt:get-health` invoke rather than broadcast, because the verdict lands while the window is still loading and a broadcast would routinely have no listener.

**Instrumentation, to be measured next release — not claimed as fixes**

- **The `node`-transport gate now also covers `store`.** It genuinely could not help before; now it runs. **Whether it clears the access violation is unknown.** The single install that reached the `node` transport in the window also failed there, so the honest expectation is that it does not help — and if it does not, the gate was never the fix and the cause is upstream of `y-leveldb`. The `transport: node` field on the verdict is what will say so.
- **Per-operation attribution.** The child now announces each store operation *before* running it (`open` → `write` → `read` → `clear` → `close`), because an access violation unwinds nothing and only a marker written beforehand survives. The parent derives a `storeOp` field from the last marker. This settles question 1 of the issue on the next release.
- **Machine fields.** Every preflight failure line now carries `osRelease` (the Windows build number), `osVersion` (the edition), `arch` and `platform`.

**Deliberately not done: a bounded retry of the in-memory latch.** The failure is a native abort in the binding, which the data shows is deterministic per machine (19/19 installs, every launch, six releases) rather than transient, and each retry costs a multi-second child process on the launch path. The one transient-shaped cause — a utility process that cannot boot — already gets its retry inside a single open, on the Chromium-free transport. Reasoning is in the code and in `apps/docs/src/architecture/crdt.md`.

## Backward compatibility

- **No on-disk layout change.** The CRDT store is byte-identical; older versions read it unchanged. The control directory is a sibling (`<store>.probe`), created and removed by the probe, never inside the store.
- **Config is additive.** `crdtStore.inMemorySessions` is optional; a config written by an older version has no key, which reads as 0 — the correct starting state. Older versions ignore the key.
- **IPC is additive.** `crdt:get-health` is a new no-arg read-only channel; nothing existing changed shape.
- **Telemetry:** `CRDT_PERSISTENCE_UNAVAILABLE:binding-in-use` is a new bounded token joining the existing `bootstrap` / `binding` / `store` / `probe` set. The `store` token now means what it claims (data implicated) instead of covering both cases.

## Acceptance criterion

`CRDT persistence unavailable — continuing in-memory` drops to near-zero **unique win32 installs** on the release following this. The `Utility:crashed:CrdtPreflight` counter is **not** a valid criterion — as the comment at `crdt-persistence.ts` notes, it also fires in the case we recover from. Secondary signals to read next release: `stage` distribution (`store` vs the new `binding-in-use`), `storeOp` distribution, and whether `transport: node` verdicts appear.

## Verification

| Command | Result |
|---|---|
| `pnpm --filter @memry/desktop typecheck:node` | pass |
| `pnpm --filter @memry/desktop typecheck:web` | pass |
| `pnpm --filter @memry/desktop typecheck:test` | 2 pre-existing errors in `sidebar-nav.test.tsx` (untouched by this branch, from `808a4e431`) |
| `pnpm lint` | pass |
| `pnpm ipc:generate` + `pnpm ipc:check` | pass — RPC bindings and invoke map up to date |
| `pnpm --filter @memry/desktop i18n:check` | pass |
| main suite (full project) | **532 files, 6870 tests, all pass** |
| renderer suite (full project) | 641 files pass; 4 files / 10 tests fail, all pre-existing `onNavMiddleClick` / `useTabActions` breakage on main (`App.test.tsx`, `App.workspace-counts.test.tsx`, `sidebar-nav.test.tsx`, `calendar.test.tsx`) |
| `pnpm docs:impact --base origin/main --strict` | pass |
| `pnpm docs:build` | pass |

New tests: a `store`-stage failure whose empty-directory control **also** fails never quarantines, never renames, never `rmSync`s the store, and reports `binding-in-use` (`crdt-persistence.test.ts`, plus the real-fs equivalent in `crdt-provider.test.ts`); a control that cannot be cleared leaves the store alone; the store-op marker is the last one written, not the first; the `node` retry now runs for store-stage failures; the degraded notice stays silent at 0 and 2 consecutive sessions and fires at 3.

**Not verified, and cannot be from this machine:** the Windows access violation itself is not reproducible on macOS/Linux and has never reproduced in CI. The existing `MEMRY_TEST_CRDT_PREFLIGHT_CRASH` hook aborts at `started`, i.e. `bootstrap` — it does not reproduce this failure. Everything above is verified against the seam, not against a real `0xC0000005`.

Fixes #1583
