### PR TITLE
fix(search): repair a damaged search index instead of returning nothing

### DIFF
--- a/apps/desktop/src/main/database/client.ts
+++ b/apps/desktop/src/main/database/client.ts
@@ -7,6 +7,7 @@ import * as sqliteVec from 'sqlite-vec'
 import { EMBEDDING_DIMENSION } from '../lib/embeddings-constants'
 import { createLogger } from '../lib/logger'
 import { registerDataDbFunctions } from './sqlite-functions'
+import { isSqliteCorruptError } from './sqlite-errors'
 import type { DataDb, IndexDb, RawIndexDb } from './types'
 
 export type { DataDb, IndexDb, RawIndexDb } from './types'
@@ -167,12 +168,41 @@ export function closeAllDatabases(): void {
 /**
  * Index health status
  */
-export type IndexHealth = 'healthy' | 'corrupt' | 'missing' | 'migration_failed'
+export type IndexHealth = 'healthy' | 'corrupt' | 'missing' | 'migration_failed' | 'fts_corrupt'
+
+/**
+ * Reads the fts5 index structures of `fts_notes` without writing anything.
+ *
+ * `PRAGMA integrity_check` never looks inside an fts5 virtual table, and fts5's
+ * own `INSERT INTO fts_notes(fts_notes) VALUES('integrity-check')` is a write —
+ * it fails with SQLITE_READONLY on the readonly connection this health check
+ * opens. A MATCH is the cheapest statement that actually reads the segment
+ * blobs, which is where the corruption lives (#1585).
+ *
+ * A missing `fts_notes` is not corruption: `initializeFts` creates it right
+ * after open, which is how an index DB written before FTS existed upgrades.
+ */
+function isFtsNotesCorrupt(sqlite: Database.Database, existingTables: string[]): boolean {
+  if (!existingTables.includes('fts_notes')) {
+    return false
+  }
+
+  try {
+    sqlite.prepare('SELECT rowid FROM fts_notes WHERE fts_notes MATCH ? LIMIT 1').get('memry')
+    return false
+  } catch (error) {
+    // Only corruption counts. A lock or a transient read failure must not cost
+    // the user a rebuild of their whole search index.
+    return isSqliteCorruptError(error)
+  }
+}
 
 /**
  * Check the health of the index database.
  * Returns 'healthy' if the database exists and has all required tables,
  * 'corrupt' if the database exists but is missing tables or unreadable,
+ * 'fts_corrupt' if the tables are all there but the fts5 search index inside
+ * `fts_notes` is unreadable (repairable in place — the rest of the file is fine),
  * 'missing' if the database file doesn't exist.
  *
  * @param indexDbPath - Absolute path to index.db
@@ -198,10 +228,20 @@ export function checkIndexHealth(indexDbPath: string): IndexHealth {
       const existingTables = tables.map((t) => t.name)
 
       const hasAllTables = requiredTables.every((t) => existingTables.includes(t))
+      if (!hasAllTables) {
+        sqlite.close()
+        return 'corrupt'
+      }
+
+      // sqlite_master only proves `fts_notes` was declared. Its index lives in
+      // shadow tables nothing above opens, so an install whose fts5 content was
+      // internally corrupt used to read as 'healthy' — the auto-rebuild never
+      // fired and note search returned zero results forever (#1585).
+      const ftsCorrupt = isFtsNotesCorrupt(sqlite, existingTables)
 
       sqlite.close()
 
-      return hasAllTables ? 'healthy' : 'corrupt'
+      return ftsCorrupt ? 'fts_corrupt' : 'healthy'
     } catch {
       sqlite.close()
       return 'corrupt'

--- a/apps/desktop/src/main/database/fts-corruption.test.ts
+++ b/apps/desktop/src/main/database/fts-corruption.test.ts
@@ -1,0 +1,238 @@
+/**
+ * On-disk corruption of an fts5 index, and the way back from it (#1585).
+ *
+ * The corruption is genuine, not simulated: fts5 keeps its index in shadow
+ * tables (`fts_notes_data` and friends), and overwriting the blobs there is
+ * what a torn write or a bad sector looks like from SQLite's side. fts5 refuses
+ * shadow-table writes unless defensive mode is off, hence `unsafeMode`.
+ *
+ * Two shapes are exercised, because they are detected by different probes and
+ * between them they cover both statements the reported install failed on:
+ *
+ * - garbled segment blobs: every read of the index throws, including a MATCH —
+ *   this is what the cheap open-time probe catches.
+ * - a garbled structure record: MATCH still answers, but fts5's own integrity
+ *   check and `DELETE FROM fts_notes` both throw. Nothing an open-time read
+ *   probe can see; it only surfaces when the reconcile pass touches the table.
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { sql } from 'drizzle-orm'
+
+vi.mock('../projections', () => ({
+  rebuildProjections: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: () => []
+  }
+}))
+
+import { runIndexMigrations } from './migrate'
+import { checkIndexHealth } from './client'
+import { createFtsTable, insertFtsNoteUnchecked, getFtsCount, resetFtsTable } from './fts'
+import { createFtsTasksTable } from './fts-tasks'
+import { createFtsInboxTable } from './fts-inbox'
+import { detectCorruption } from './fts-rebuild'
+import { isSqliteCorruptError } from './sqlite-errors'
+import type { DataDb, IndexDb } from './client'
+
+type AnyDb = IndexDb & DataDb
+
+function seedFtsNotes(db: AnyDb, count: number): void {
+  for (let i = 0; i < count; i++) {
+    insertFtsNoteUnchecked(db, `note-${i}`, `Title ${i}`, `alpha beta gamma ${i}`, [`tag${i}`])
+  }
+}
+
+/** Garble the segment blobs: every read of the index now fails. */
+function garbleSegments(sqlite: Database.Database): void {
+  sqlite.unsafeMode(true)
+  sqlite.prepare('UPDATE fts_notes_data SET block = randomblob(64) WHERE id > 10').run()
+  sqlite.unsafeMode(false)
+}
+
+/** Garble the structure record: reads still answer, writes and checks fail. */
+function garbleStructure(sqlite: Database.Database): void {
+  sqlite.unsafeMode(true)
+  sqlite.prepare('UPDATE fts_notes_data SET block = randomblob(20) WHERE id = 1').run()
+  sqlite.unsafeMode(false)
+}
+
+function matchNotes(db: AnyDb): { id: string }[] {
+  return db.all<{ id: string }>(sql`SELECT id FROM fts_notes WHERE fts_notes MATCH 'alpha'`)
+}
+
+describe('fts5 index corruption', () => {
+  let tempDir: string
+  let indexDbPath: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-fts-corrupt-'))
+    indexDbPath = path.join(tempDir, 'index.db')
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  describe('checkIndexHealth', () => {
+    it('reports fts_corrupt when the search index inside a sound file is unreadable', () => {
+      // #given an index DB that passes every structural check the old health
+      // check made — the file opens, and note_cache/note_tags/note_links exist
+      runIndexMigrations(indexDbPath)
+      const sqlite = new Database(indexDbPath)
+      const db = drizzle(sqlite) as unknown as AnyDb
+      createFtsTable(db)
+      seedFtsNotes(db, 300)
+
+      expect(checkIndexHealth(indexDbPath)).toBe('healthy')
+
+      // #when its fts5 segments are damaged on disk
+      garbleSegments(sqlite)
+      sqlite.close()
+
+      // #then the vault-open gate sees it, instead of reading 'healthy' and
+      // leaving note search returning zero results forever
+      expect(checkIndexHealth(indexDbPath)).toBe('fts_corrupt')
+    })
+
+    it('still reports healthy for an index DB written before fts_notes existed', () => {
+      // A missing virtual table is not corruption: initializeFts creates it on
+      // open, which is how an older install upgrades.
+      runIndexMigrations(indexDbPath)
+
+      expect(checkIndexHealth(indexDbPath)).toBe('healthy')
+    })
+  })
+
+  describe('detectCorruption', () => {
+    let indexSqlite: Database.Database
+    let dataSqlite: Database.Database
+    let indexDb: AnyDb
+    let dataDb: AnyDb
+
+    beforeEach(() => {
+      indexSqlite = new Database(':memory:')
+      dataSqlite = new Database(':memory:')
+      indexDb = drizzle(indexSqlite) as unknown as AnyDb
+      dataDb = drizzle(dataSqlite) as unknown as AnyDb
+      createFtsTable(indexDb)
+      createFtsTasksTable(dataDb)
+      createFtsInboxTable(dataDb)
+      seedFtsNotes(indexDb, 300)
+    })
+
+    afterEach(() => {
+      indexSqlite.close()
+      dataSqlite.close()
+    })
+
+    it('names nothing while the indexes are intact', () => {
+      expect(detectCorruption(indexDb, dataDb)).toEqual([])
+    })
+
+    it('names fts_notes for damage no read probe can see', () => {
+      // #given the shape the reported install is in: reads still answer …
+      garbleStructure(indexSqlite)
+      expect(matchNotes(indexDb)).toHaveLength(300)
+
+      // #then … but fts5's own verification pass finds it
+      expect(detectCorruption(indexDb, dataDb)).toEqual(['fts_notes'])
+    })
+
+    it('names fts_notes for damaged segments too, and leaves the healthy tables alone', () => {
+      garbleSegments(indexSqlite)
+
+      expect(detectCorruption(indexDb, dataDb)).toEqual(['fts_notes'])
+    })
+  })
+
+  describe('recovery', () => {
+    let sqlite: Database.Database
+    let db: AnyDb
+
+    beforeEach(() => {
+      sqlite = new Database(':memory:')
+      db = drizzle(sqlite) as unknown as AnyDb
+      createFtsTable(db)
+      seedFtsNotes(db, 300)
+    })
+
+    afterEach(() => {
+      sqlite.close()
+    })
+
+    it('cannot empty a corrupt table, but can drop and re-create it', () => {
+      garbleStructure(sqlite)
+
+      // #given the statement every rebuild used to start with — the reason the
+      // user's "Rebuild search index" button failed at its first step
+      let deleteError: unknown
+      try {
+        db.run(sql`DELETE FROM fts_notes`)
+      } catch (error) {
+        deleteError = error
+      }
+      expect(deleteError).toBeDefined()
+      expect(isSqliteCorruptError(deleteError)).toBe(true)
+
+      // #when the repair drops the virtual table instead of emptying it
+      resetFtsTable(db)
+
+      // #then the index is gone, sound, and writable again
+      expect(getFtsCount(db)).toBe(0)
+      expect(detectCorruption(db, db)).toEqual([])
+    })
+
+    it('restores working search after the index was unreadable', () => {
+      garbleSegments(sqlite)
+
+      // #given search is broken: this is the throw the user never saw
+      expect(() => matchNotes(db)).toThrow()
+
+      // #when the index is rebuilt from its canonical source
+      resetFtsTable(db)
+      insertFtsNoteUnchecked(db, 'note-1', 'Title', 'alpha beta', ['alpha'])
+
+      // #then queries answer again
+      expect(matchNotes(db)).toEqual([{ id: 'note-1' }])
+    })
+  })
+
+  describe('isSqliteCorruptError', () => {
+    it('accepts corruption through a driver wrapper, and nothing else', () => {
+      const sqlite = new Database(':memory:')
+      const db = drizzle(sqlite) as unknown as AnyDb
+      createFtsTable(db)
+      seedFtsNotes(db, 300)
+      garbleSegments(sqlite)
+
+      // Drizzle wraps the driver error, so the SQLITE_CORRUPT_VTAB code is only
+      // reachable through the cause chain — a check that reads `.code` off the
+      // top-level error alone would miss every one of these.
+      let wrapped: unknown
+      try {
+        db.run(sql`DELETE FROM fts_notes`)
+      } catch (error) {
+        wrapped = error
+      }
+      expect(isSqliteCorruptError(wrapped)).toBe(true)
+
+      sqlite.close()
+
+      // A busy database is a transient condition; treating it as corruption
+      // would buy the user a needless full reindex.
+      expect(isSqliteCorruptError(Object.assign(new Error('locked'), { code: 'SQLITE_BUSY' }))).toBe(
+        false
+      )
+      expect(isSqliteCorruptError(new Error('something went wrong'))).toBe(false)
+    })
+  })
+})

--- a/apps/desktop/src/main/database/fts-inbox.ts
+++ b/apps/desktop/src/main/database/fts-inbox.ts
@@ -80,6 +80,17 @@ export function clearFtsInboxTable(db: DataDb): void {
   db.run(sql`DELETE FROM fts_inbox`)
 }
 
+/**
+ * Drops the virtual table and re-creates it empty — the repair for a corrupt
+ * fts5 index, which `DELETE FROM fts_inbox` cannot perform. See `resetFtsTable`
+ * in fts.ts for why. Derived from the `inbox_items` rows in the same database,
+ * so a reset costs a re-index and nothing else.
+ */
+export function resetFtsInboxTable(db: DataDb): void {
+  db.run(sql`DROP TABLE IF EXISTS fts_inbox`)
+  createFtsInboxTable(db)
+}
+
 export function getFtsInboxCount(db: DataDb): number {
   const result = db.get<{ count: number }>(sql`SELECT COUNT(*) as count FROM fts_inbox`)
   return result?.count ?? 0

--- a/apps/desktop/src/main/database/fts-rebuild.test.ts
+++ b/apps/desktop/src/main/database/fts-rebuild.test.ts
@@ -49,20 +49,25 @@ describe('fts rebuild recovery', () => {
     expect(rebuildProjections).toHaveBeenCalledWith(['search'])
   })
 
+  const corruptError = (table: string): Error =>
+    Object.assign(new Error(`fts5: corruption found in ${table}`), {
+      code: 'SQLITE_CORRUPT_VTAB'
+    })
+
   it('detectCorruption reports every corrupt FTS table', () => {
     const failingIndexDb = {
-      all: vi.fn(() => {
-        throw new Error('fts_notes corrupt')
+      run: vi.fn(() => {
+        throw corruptError('fts_notes')
       })
     }
     const failingDataDb = {
-      all: vi
+      run: vi
         .fn()
         .mockImplementationOnce(() => {
-          throw new Error('fts_tasks corrupt')
+          throw corruptError('fts_tasks')
         })
         .mockImplementationOnce(() => {
-          throw new Error('fts_inbox corrupt')
+          throw corruptError('fts_inbox')
         })
     }
 
@@ -71,5 +76,17 @@ describe('fts rebuild recovery', () => {
       'fts_tasks',
       'fts_inbox'
     ])
+  })
+
+  it('detectCorruption ignores a failure that is not corruption', () => {
+    // A locked database is transient. Reporting it would cost the user a full
+    // rebuild of an index that is perfectly fine.
+    const busy = () => {
+      throw Object.assign(new Error('database is locked'), { code: 'SQLITE_BUSY' })
+    }
+
+    expect(detectCorruption({ run: vi.fn(busy) } as never, { run: vi.fn(busy) } as never)).toEqual(
+      []
+    )
   })
 })

--- a/apps/desktop/src/main/database/fts-rebuild.ts
+++ b/apps/desktop/src/main/database/fts-rebuild.ts
@@ -4,6 +4,7 @@ import { SearchChannels } from '@memry/contracts/ipc-channels'
 import { createLogger } from '../lib/logger'
 import { broadcastToAllWindows } from '../lib/window-broadcast'
 import { rebuildProjections } from '../projections'
+import { isSqliteCorruptError } from './sqlite-errors'
 
 const logger = createLogger('FtsRebuild')
 
@@ -11,15 +12,39 @@ function broadcast(channel: string, data: unknown): void {
   broadcastToAllWindows(channel, data)
 }
 
+/**
+ * fts5's own verification pass over a table's index.
+ *
+ * Stronger than the MATCH probe `checkIndexHealth` runs: a single query only
+ * reads the segments that query happens to touch, whereas 'integrity-check'
+ * walks the whole index. It is written as an INSERT but stores nothing, so it
+ * needs a writable connection — which is why the open-time gate uses MATCH and
+ * this one only runs after the databases are open.
+ *
+ * Narrowed to SQLITE_CORRUPT (and its extended forms). This used to swallow
+ * every exception, which would have turned a lock or a closed connection into a
+ * full index rebuild (#1585).
+ */
 function isTableCorrupt(db: DataDb | IndexDb, tableName: string): boolean {
   try {
-    db.all(sql.raw(`SELECT * FROM ${tableName} WHERE ${tableName} MATCH 'test' LIMIT 1`))
+    db.run(sql.raw(`INSERT INTO ${tableName}(${tableName}) VALUES('integrity-check')`))
     return false
-  } catch {
+  } catch (error) {
+    if (!isSqliteCorruptError(error)) {
+      logger.warn(`FTS integrity check for ${tableName} could not run`, error)
+      return false
+    }
     return true
   }
 }
 
+/**
+ * Names every FTS table whose index is corrupt, and tells the renderer.
+ *
+ * Runs only once something else already suspects corruption (the vault-open
+ * health verdict, or a reconcile pass that threw SQLITE_CORRUPT) — a full fts5
+ * verification of three tables is too expensive to put on every launch.
+ */
 export function detectCorruption(indexDb: IndexDb, dataDb: DataDb): string[] {
   const corrupt: string[] = []
 

--- a/apps/desktop/src/main/database/fts-tasks.ts
+++ b/apps/desktop/src/main/database/fts-tasks.ts
@@ -79,6 +79,17 @@ export function clearFtsTasksTable(db: DataDb): void {
   db.run(sql`DELETE FROM fts_tasks`)
 }
 
+/**
+ * Drops the virtual table and re-creates it empty — the repair for a corrupt
+ * fts5 index, which `DELETE FROM fts_tasks` cannot perform. See `resetFtsTable`
+ * in fts.ts for why. Derived from the `tasks` rows in the same database, so a
+ * reset costs a re-index and nothing else.
+ */
+export function resetFtsTasksTable(db: DataDb): void {
+  db.run(sql`DROP TABLE IF EXISTS fts_tasks`)
+  createFtsTasksTable(db)
+}
+
 export function initializeFtsTasks(db: DataDb): void {
   createFtsTasksTable(db)
   createFtsTasksTriggers(db)

--- a/apps/desktop/src/main/database/fts.ts
+++ b/apps/desktop/src/main/database/fts.ts
@@ -165,6 +165,25 @@ export function clearFtsTable(db: IndexDb): void {
 }
 
 /**
+ * Drops the virtual table and re-creates it empty.
+ *
+ * The repair for an fts5 index that is internally corrupt. `DELETE FROM
+ * fts_notes` cannot do it: emptying the table means reading the very structures
+ * that are broken, so it raises SQLITE_CORRUPT and the rebuild that was
+ * supposed to fix the install fails at its first statement (#1585). DROP only
+ * unlinks the shadow tables, which stays readable however damaged their
+ * contents are.
+ *
+ * Safe for callers to reach for unconditionally: this table is derived from
+ * `note_cache` plus the markdown on disk, and every caller repopulates from
+ * those. Nothing user-authored lives here.
+ */
+export function resetFtsTable(db: IndexDb): void {
+  db.run(sql`DROP TABLE IF EXISTS fts_notes`)
+  createFtsTable(db)
+}
+
+/**
  * Gets the count of entries in the FTS index.
  *
  * @param db - Drizzle database instance

--- a/apps/desktop/src/main/database/sqlite-errors.ts
+++ b/apps/desktop/src/main/database/sqlite-errors.ts
@@ -1,0 +1,21 @@
+import { toErrorCode } from '@memry/contracts/telemetry-api'
+
+/**
+ * True only for SQLite's corruption result codes.
+ *
+ * Covers the extended forms too: an fts5 index that fails its own checks
+ * surfaces as `SQLITE_CORRUPT_VTAB` ("fts5: corruption found reading blob …"),
+ * not the bare `SQLITE_CORRUPT`.
+ *
+ * Deliberately narrow. Every caller treats a positive as "this derived index is
+ * unusable, drop and rebuild it", so a lock (`SQLITE_BUSY`), a readonly refusal
+ * or a closed connection must never qualify — that would cost the user a full
+ * reindex for a transient failure (#1585).
+ *
+ * Drizzle wraps driver errors in a `DrizzleError` and hangs the original on
+ * `.cause`, so the code has to be read through the cause chain; `toErrorCode`
+ * already walks it.
+ */
+export function isSqliteCorruptError(error: unknown): boolean {
+  return toErrorCode(error).startsWith('SQLITE_CORRUPT')
+}

--- a/apps/desktop/src/main/projections/index.ts
+++ b/apps/desktop/src/main/projections/index.ts
@@ -81,4 +81,9 @@ export async function stopProjectionRuntime(options?: ProjectionStopOptions): Pr
 }
 
 export type { ProjectionEvent, ProjectionLogger, ProjectionProjector } from './types'
-export type { ProjectionRuntime, ProjectionStopOptions } from './runtime'
+export type {
+  ProjectionRuntime,
+  ProjectionStopOptions,
+  ProjectorReconcileFailure
+} from './runtime'
+export { isReconcileFailure } from './runtime'

--- a/apps/desktop/src/main/projections/projectors/search-projector.test.ts
+++ b/apps/desktop/src/main/projections/projectors/search-projector.test.ts
@@ -193,6 +193,45 @@ describe('search projector', () => {
     ).toBe(1)
   })
 
+  it('rebuild recovers an index whose fts5 content is corrupt', async () => {
+    seedMarkdownNote('note-1', 'notes/searchable.md', 'Projection rebuild content', ['alpha'])
+    seedTask('task-1')
+    seedInboxItem('inbox-1')
+
+    // #given a genuinely corrupt fts5 index: the segment blobs are garbled, the
+    // way a torn write leaves them. fts5 guards its shadow tables, hence
+    // unsafeMode.
+    for (let i = 0; i < 300; i++) {
+      indexDb.db.run(sql`
+        INSERT INTO fts_notes (id, title, content, tags)
+        VALUES (${`filler-${i}`}, ${'Filler'}, ${`alpha beta gamma ${i}`}, ${'alpha'})
+      `)
+    }
+    indexDb.sqlite.unsafeMode(true)
+    indexDb.sqlite.prepare('UPDATE fts_notes_data SET block = randomblob(64) WHERE id > 10').run()
+    indexDb.sqlite.unsafeMode(false)
+
+    // #given search is dead: every query the renderer sends now throws, and the
+    // statement rebuild used to start with (DELETE FROM fts_notes) throws too
+    expect(() =>
+      indexDb.db.all(sql`SELECT id FROM fts_notes WHERE fts_notes MATCH 'alpha'`)
+    ).toThrow()
+    expect(() => indexDb.db.run(sql`DELETE FROM fts_notes`)).toThrow()
+
+    const projector = createSearchProjector(() => vaultDir)
+
+    // #when the user presses "Rebuild search index"
+    await expect(projector.rebuild()).resolves.toEqual(
+      expect.objectContaining({ notes: 1, tasks: 1, inbox: 1 })
+    )
+
+    // #then the index is sound and search answers again
+    expect(getFtsCount(indexDb.db as never)).toBe(1)
+    expect(indexDb.db.all(sql`SELECT id FROM fts_notes WHERE fts_notes MATCH 'rebuild'`)).toEqual([
+      { id: 'note-1' }
+    ])
+  })
+
   it('reconcile replaces stale FTS rows with rebuilt state', async () => {
     seedMarkdownNote('note-1', 'notes/searchable.md', 'Fresh rebuilt content', ['alpha'])
     seedTask('task-1')

--- a/apps/desktop/src/main/projections/projectors/search-projector.ts
+++ b/apps/desktop/src/main/projections/projectors/search-projector.ts
@@ -4,23 +4,23 @@ import { sql } from 'drizzle-orm'
 import { SearchChannels } from '@memry/contracts/ipc-channels'
 import { getDatabase, getIndexDatabase } from '../../database'
 import {
-  clearFtsTable,
   dedupeFtsNotes,
   deleteFtsNote,
   insertFtsNote,
-  insertFtsNoteUnchecked
+  insertFtsNoteUnchecked,
+  resetFtsTable
 } from '../../database/fts'
 import {
-  clearFtsTasksTable,
   dedupeFtsTasks,
   deleteFtsTask,
-  insertFtsTask
+  insertFtsTask,
+  resetFtsTasksTable
 } from '../../database/fts-tasks'
 import {
-  clearFtsInboxTable,
   dedupeFtsInbox,
   deleteFtsInboxItem,
-  insertFtsInboxItem
+  insertFtsInboxItem,
+  resetFtsInboxTable
 } from '../../database/fts-inbox'
 import { getSetting, setSetting } from '../../database/queries/settings'
 import { parseNote } from '../../vault/frontmatter'
@@ -94,7 +94,12 @@ function upsertInboxItem(itemId: string): void {
 
 async function rebuildNotes(getVaultPath: () => string | null): Promise<number> {
   const indexDb = getIndexDatabase()
-  clearFtsTable(indexDb)
+  // Drop-and-recreate, not `DELETE FROM fts_notes`. Rebuild is the escape hatch
+  // for an index that is already broken, and emptying a corrupt fts5 table
+  // means reading the structures that are broken: the delete threw
+  // SQLITE_CORRUPT and the user's "Rebuild search index" button failed at its
+  // very first statement, leaving them stuck (#1585).
+  resetFtsTable(indexDb)
 
   const vaultPath = getVaultPath()
   if (!vaultPath) {
@@ -130,7 +135,7 @@ async function rebuildNotes(getVaultPath: () => string | null): Promise<number> 
     try {
       const raw = await fs.readFile(absolutePath, 'utf-8')
       const parsed = parseNote(raw, row.path)
-      // clearFtsTable above emptied the table, so every id here is absent.
+      // resetFtsTable above left the table empty, so every id here is absent.
       insertFtsNoteUnchecked(
         indexDb,
         row.id,
@@ -157,7 +162,8 @@ async function rebuildNotes(getVaultPath: () => string | null): Promise<number> 
 
 function rebuildTasks(): number {
   const dataDb = getDatabase()
-  clearFtsTasksTable(dataDb)
+  // Drop-and-recreate for the same reason as rebuildNotes above.
+  resetFtsTasksTable(dataDb)
 
   const rows = dataDb.all<{ id: string }>(sql`SELECT id FROM tasks`)
   for (let i = 0; i < rows.length; i++) {
@@ -176,7 +182,8 @@ function rebuildTasks(): number {
 
 function rebuildInbox(): number {
   const dataDb = getDatabase()
-  clearFtsInboxTable(dataDb)
+  // Drop-and-recreate for the same reason as rebuildNotes above.
+  resetFtsInboxTable(dataDb)
 
   const rows = dataDb.all<{ id: string }>(sql`SELECT id FROM inbox_items`)
   for (let i = 0; i < rows.length; i++) {

--- a/apps/desktop/src/main/projections/runtime.test.ts
+++ b/apps/desktop/src/main/projections/runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createProjectionRuntime } from './runtime'
+import { createProjectionRuntime, isReconcileFailure } from './runtime'
 import type { ProjectionEvent, ProjectionProjector } from './types'
 
 function markdownEvent(noteId: string, parsedContent: string): ProjectionEvent {
@@ -344,6 +344,42 @@ describe('projection runtime', () => {
     expect(second.reconcile).toHaveBeenCalledOnce()
   })
 
+  it('keeps reconciling the other projectors after one of them throws', async () => {
+    // #given the search projector's position in the real list: one before the
+    // three that self-repair embeddings, inbox counts and note↔project links
+    const failure = new Error('fts_notes is corrupt')
+    const first = createProjector('noteDerivedState', { reconcile: vi.fn() })
+    const broken = createProjector('search', {
+      reconcile: vi.fn(() => Promise.reject(failure))
+    })
+    const third = createProjector('embedding', { reconcile: vi.fn() })
+    const fourth = createProjector('inboxStats', { reconcile: vi.fn() })
+    const logger = { error: vi.fn(), warn: vi.fn() }
+    const runtime = createProjectionRuntime({
+      projectors: [first, broken, third, fourth],
+      logger
+    })
+
+    // #when the second projector throws — the pass used to abandon everything
+    // behind it, silently, on every launch
+    const results = await runtime.reconcile()
+
+    // #then every sibling still ran
+    expect(first.reconcile).toHaveBeenCalledOnce()
+    expect(third.reconcile).toHaveBeenCalledOnce()
+    expect(fourth.reconcile).toHaveBeenCalledOnce()
+
+    // #then the failure is recorded rather than swallowed, so the caller can
+    // report it and repair what it points at
+    expect(isReconcileFailure(results.search)).toBe(true)
+    expect(results.search).toMatchObject({ projector: 'search', error: failure })
+    expect(isReconcileFailure(results.embedding)).toBe(false)
+    expect(logger.error).toHaveBeenCalledWith(
+      'Projection reconcile failed',
+      expect.objectContaining({ projector: 'search', error: failure })
+    )
+  })
+
   it('stop aborts an in-flight reconcile and waits for it to unwind', async () => {
     const steps: number[] = []
     let unwound = false
@@ -505,7 +541,9 @@ describe('projection runtime', () => {
     const failing = runtime.reconcile()
     const next = runtime.reconcile()
 
-    await expect(failing).rejects.toThrow('reconcile exploded')
+    // The pass records the failure instead of rejecting: projectors are
+    // isolated from each other, so one throwing no longer ends the pass.
+    expect(isReconcileFailure((await failing).search)).toBe(true)
     await next
     expect(seen).toHaveLength(2)
 

--- a/apps/desktop/src/main/projections/runtime.ts
+++ b/apps/desktop/src/main/projections/runtime.ts
@@ -38,6 +38,31 @@ export interface ProjectionRuntime {
  */
 export const DEFAULT_STOP_DRAIN_TIMEOUT_MS = 5_000
 
+/**
+ * What a reconcile pass records for a projector whose own pass threw.
+ *
+ * The loop used to have no guard, so the first projector to throw abandoned
+ * every projector behind it. On an install whose search index was corrupt that
+ * meant embeddings, inbox counts and note↔project links silently stopped
+ * self-repairing too — on every launch, forever (#1585).
+ *
+ * The failure is recorded rather than swallowed: `openVault` reads it to tell a
+ * corrupt FTS index apart from any other reconcile failure and repair it.
+ */
+export interface ProjectorReconcileFailure {
+  readonly reconcileFailed: true
+  readonly projector: string
+  readonly error: unknown
+}
+
+export function isReconcileFailure(value: unknown): value is ProjectorReconcileFailure {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Partial<ProjectorReconcileFailure>).reconcileFailed === true
+  )
+}
+
 function selectProjectors(
   projectors: ProjectionProjector[],
   names?: string[]
@@ -119,7 +144,21 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
         break
       }
 
-      results[projector.name] = await projector.reconcile(controller.signal)
+      try {
+        results[projector.name] = await projector.reconcile(controller.signal)
+      } catch (error) {
+        // Isolated on purpose: the projectors are independent repairs, and one
+        // of them failing is no reason to skip the rest of the pass.
+        results[projector.name] = {
+          reconcileFailed: true,
+          projector: projector.name,
+          error
+        } satisfies ProjectorReconcileFailure
+        logger?.error?.('Projection reconcile failed', {
+          projector: projector.name,
+          error
+        })
+      }
     }
 
     return results

--- a/apps/desktop/src/main/vault/index.test.ts
+++ b/apps/desktop/src/main/vault/index.test.ts
@@ -53,6 +53,8 @@ const mocks = vi.hoisted(() => ({
   startProjectionRuntime: vi.fn(),
   stopProjectionRuntime: vi.fn(),
   reconcileProjections: vi.fn(),
+  rebuildProjections: vi.fn(),
+  detectCorruption: vi.fn(),
   trackMainError: vi.fn(),
   initEmbeddingModel: vi.fn(),
   isModelLoaded: vi.fn(),
@@ -181,10 +183,20 @@ vi.mock('../telemetry/diagnostics', () => ({
   trackMainLog: vi.fn()
 }))
 
-vi.mock('../projections', () => ({
-  reconcileProjections: (...args: unknown[]) => mocks.reconcileProjections(...args),
-  startProjectionRuntime: (...args: unknown[]) => mocks.startProjectionRuntime(...args),
-  stopProjectionRuntime: (...args: unknown[]) => mocks.stopProjectionRuntime(...args)
+vi.mock('../projections', async () => {
+  const actual = await vi.importActual<typeof import('../projections')>('../projections')
+  return {
+    // The real predicate: a mocked one would let a broken failure marker pass.
+    isReconcileFailure: actual.isReconcileFailure,
+    rebuildProjections: (...args: unknown[]) => mocks.rebuildProjections(...args),
+    reconcileProjections: (...args: unknown[]) => mocks.reconcileProjections(...args),
+    startProjectionRuntime: (...args: unknown[]) => mocks.startProjectionRuntime(...args),
+    stopProjectionRuntime: (...args: unknown[]) => mocks.stopProjectionRuntime(...args)
+  }
+})
+
+vi.mock('../database/fts-rebuild', () => ({
+  detectCorruption: (...args: unknown[]) => mocks.detectCorruption(...args)
 }))
 
 vi.mock('../projections/projectors/note-derived-state-projector', () => ({
@@ -292,7 +304,9 @@ describe('vault lifecycle', () => {
     mocks.stopSyncRuntime.mockResolvedValue(undefined)
     mocks.initCrdtPersistence.mockResolvedValue(undefined)
     mocks.stopProjectionRuntime.mockResolvedValue(undefined)
-    mocks.reconcileProjections.mockResolvedValue(undefined)
+    mocks.reconcileProjections.mockResolvedValue({})
+    mocks.rebuildProjections.mockResolvedValue({ search: { notes: 5, tasks: 0, inbox: 0 } })
+    mocks.detectCorruption.mockReturnValue([])
     mocks.applyProjectFrontmatterBackfill.mockResolvedValue(undefined)
     mocks.initEmbeddingModel.mockResolvedValue(undefined)
     mocks.isModelLoaded.mockReturnValue(false)
@@ -425,6 +439,60 @@ describe('vault lifecycle', () => {
       channel: 'vault:index-recovered',
       payload: { reason: 'missing', filesIndexed: 3, duration: 42 }
     })
+  })
+
+  it('repairs a corrupt search index in place instead of deleting the index database', async () => {
+    mocks.checkIndexHealth.mockReturnValue('fts_corrupt')
+    mocks.detectCorruption.mockReturnValue(['fts_notes'])
+
+    await selectVault({ path: '/vault/fts' })
+
+    // #then the index DB file survives: only the fts5 tables are rebuilt, so
+    // every note embedding in it is kept
+    expect(mocks.rebuildIndex).not.toHaveBeenCalled()
+    expect(mocks.runIndexMigrations).toHaveBeenCalledWith('/vault/fts/index.db')
+    expect(mocks.rebuildProjections).toHaveBeenCalledWith(['search'])
+
+    // #then the user is told the repair happened
+    expect(mocks.sent).toContainEqual({
+      channel: 'vault:index-recovered',
+      payload: { reason: 'fts_corrupt', filesIndexed: 5, duration: expect.any(Number) }
+    })
+  })
+
+  it('leaves the index alone when fts5 says the suspicion was wrong', async () => {
+    mocks.checkIndexHealth.mockReturnValue('fts_corrupt')
+    mocks.detectCorruption.mockReturnValue([])
+
+    await selectVault({ path: '/vault/fts-ok' })
+
+    // A transient read failure must not cost the user a rebuild.
+    expect(mocks.rebuildProjections).not.toHaveBeenCalled()
+    expect(mocks.rebuildIndex).not.toHaveBeenCalled()
+  })
+
+  it('repairs the search index when a reconcile pass reports corruption', async () => {
+    mocks.reconcileProjections.mockResolvedValue({
+      search: {
+        reconcileFailed: true,
+        projector: 'search',
+        error: Object.assign(new Error('fts5: corruption found'), {
+          code: 'SQLITE_CORRUPT_VTAB'
+        })
+      }
+    })
+    mocks.detectCorruption.mockReturnValue(['fts_notes'])
+
+    await selectVault({ path: '/vault/reconcile-corrupt' })
+    // The reconcile is deliberately backgrounded; let its continuation land.
+    await vi.waitFor(() => expect(mocks.rebuildProjections).toHaveBeenCalledWith(['search']))
+
+    // The failure still reaches telemetry under its original action name.
+    expect(mocks.trackMainError).toHaveBeenCalledWith(
+      'vault',
+      'projection_reconcile',
+      expect.any(Error)
+    )
   })
 
   it('restarts the watcher when exclude patterns change and supports manual reindex', async () => {

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -46,6 +46,8 @@ import {
   type IndexHealth
 } from '../database'
 import { ensureDefaultTaskProject } from '../database/defaults'
+import { detectCorruption } from '../database/fts-rebuild'
+import { isSqliteCorruptError } from '../database/sqlite-errors'
 import { VaultChannels } from '@memry/contracts/ipc-channels'
 import { VaultError, VaultErrorCode } from '../lib/errors'
 import { startWatcher, stopWatcher } from './watcher'
@@ -56,7 +58,13 @@ import { trackMainEvent } from '../telemetry/track'
 import { getMainI18n } from '../lib/main-i18n'
 import { startSyncRuntime, stopSyncRuntime } from '../sync/runtime'
 import { getCrdtProvider } from '../sync/crdt-provider'
-import { reconcileProjections, startProjectionRuntime, stopProjectionRuntime } from '../projections'
+import {
+  isReconcileFailure,
+  rebuildProjections,
+  reconcileProjections,
+  startProjectionRuntime,
+  stopProjectionRuntime
+} from '../projections'
 import { createNoteDerivedStateProjector } from '../projections/projectors/note-derived-state-projector'
 import { createSearchProjector } from '../projections/projectors/search-projector'
 import { createEmbeddingProjector } from '../projections/projectors/embedding-projector'
@@ -275,6 +283,81 @@ export function emitIndexRecovered(event: IndexRecoveredEvent): void {
 }
 
 /**
+ * Rebuild the full-text indexes when — and only when — fts5 says they are corrupt.
+ *
+ * Derived state only. `fts_notes` lives in the index DB; `fts_tasks` and
+ * `fts_inbox` live in data.db but are projections of the `tasks` / `inbox_items`
+ * rows beside them. Every one of the three is dropped, re-created and
+ * repopulated from `note_cache` plus the markdown on disk, so a repair costs a
+ * re-index and cannot lose anything the user wrote. No vault file, no
+ * user-authored row and no schema is touched.
+ *
+ * The verdict is re-taken here with fts5's own integrity check rather than
+ * trusting the caller's suspicion: a rebuild is expensive, and a lock or a
+ * one-off read failure must not buy the user one (#1585).
+ */
+async function repairCorruptFtsIndexes(vaultPath: string): Promise<void> {
+  // The callers are backgrounded, so this can land after a vault switch or
+  // during shutdown — both of which close the databases underneath it.
+  if (isShuttingDown || currentStatus.path !== vaultPath) {
+    return
+  }
+
+  try {
+    const corruptTables = detectCorruption(getIndexDatabase(), getDatabase())
+    if (corruptTables.length === 0) {
+      logger.info('FTS integrity check found nothing to repair')
+      return
+    }
+
+    logger.warn('Rebuilding corrupt FTS indexes', { tables: corruptTables })
+
+    const startedAt = Date.now()
+    const results = await rebuildProjections(['search'])
+    const rebuilt = results.search as { notes: number } | undefined
+
+    emitIndexRecovered({
+      reason: 'fts_corrupt',
+      filesIndexed: rebuilt?.notes ?? 0,
+      duration: Date.now() - startedAt
+    })
+  } catch (error) {
+    logger.error('FTS index repair failed:', error)
+    trackMainError('vault', 'fts_index_repair', error)
+  }
+}
+
+/**
+ * Report every projector that failed its reconcile pass, and repair the one
+ * failure the app can fix by itself.
+ *
+ * `runReconcilePass` now isolates projectors instead of abandoning the pass at
+ * the first throw, so failures arrive as records instead of a rejection. They
+ * still have to reach telemetry under the same action name — that is the signal
+ * this whole class of problem was found through.
+ */
+async function reportAndRepairReconcileFailures(
+  vaultPath: string,
+  results: Record<string, unknown>
+): Promise<void> {
+  let sawCorruption = false
+
+  for (const outcome of Object.values(results)) {
+    if (!isReconcileFailure(outcome)) {
+      continue
+    }
+
+    logger.error(`Projection reconcile failed: ${outcome.projector}`, outcome.error)
+    trackMainError('vault', 'projection_reconcile', outcome.error)
+    sawCorruption = sawCorruption || isSqliteCorruptError(outcome.error)
+  }
+
+  if (sawCorruption) {
+    await repairCorruptFtsIndexes(vaultPath)
+  }
+}
+
+/**
  * Open a vault: initialize structure, run migrations, start database, index notes
  */
 async function openVault(vaultPath: string): Promise<void> {
@@ -342,6 +425,12 @@ async function openVault(vaultPath: string): Promise<void> {
     logger.warn(`Index health check: ${indexHealth}`)
   }
 
+  // 'fts_corrupt' says the index DB file itself is sound and only the fts5
+  // search index inside it is unreadable. Deleting the whole file for that
+  // would also throw away every note embedding, which is minutes of CPU the
+  // user does not owe — it opens normally and is repaired in place below.
+  const needsFullIndexRebuild = indexHealth !== 'healthy' && indexHealth !== 'fts_corrupt'
+
   // Initialize property definitions service BEFORE indexing
   // so getPropertyType() finds correct types during note sync
   const propDefService = PropertyDefinitionsService.init(vaultPath)
@@ -363,7 +452,7 @@ async function openVault(vaultPath: string): Promise<void> {
   updateStatus({ isIndexing: true, indexProgress: 0, path: vaultPath })
 
   try {
-    if (indexHealth !== 'healthy') {
+    if (needsFullIndexRebuild) {
       // Index is corrupt or missing - rebuild from source files
       logger.warn(`Index ${indexHealth}, triggering rebuild...`)
       const rebuildResult = await rebuildIndex(vaultPath)
@@ -387,6 +476,12 @@ async function openVault(vaultPath: string): Promise<void> {
         // Run indexing to pick up any new/missing notes
         // This will skip files already in cache, so it's fast for subsequent opens
         await indexVault(vaultPath)
+
+        // Repair before the renderer can run its first search. After
+        // indexVault, so the rebuild reads a populated note_cache.
+        if (indexHealth === 'fts_corrupt') {
+          await repairCorruptFtsIndexes(vaultPath)
+        }
       } catch (migrationError) {
         // Migration failed (e.g., table already exists) - rebuild index from scratch
         logger.error('Migration failed, rebuilding index:', migrationError)
@@ -441,10 +536,12 @@ async function openVault(vaultPath: string): Promise<void> {
     error: null
   })
 
-  void reconcileProjections().catch((error) => {
-    logger.error('Background projection reconcile failed:', error)
-    trackMainError('vault', 'projection_reconcile', error)
-  })
+  void reconcileProjections()
+    .then((results) => reportAndRepairReconcileFailures(vaultPath, results))
+    .catch((error) => {
+      logger.error('Background projection reconcile failed:', error)
+      trackMainError('vault', 'projection_reconcile', error)
+    })
 
   // Register the agent IPC handlers before the sync runtime starts: agent chat
   // does not depend on sync, and if startSyncRuntime throws or stalls the agent

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -225,7 +225,8 @@ export type NoteMovedEvent = NotesRpc.NoteMovedEvent
 export type NoteExternalChangeEvent = NotesRpc.NoteExternalChangeEvent
 
 export interface IndexRecoveredEvent {
-  reason: 'corrupt' | 'missing' | 'healthy'
+  /** Mirrors main's `IndexHealth`. 'missing' is the ordinary first-open case. */
+  reason: 'corrupt' | 'missing' | 'healthy' | 'migration_failed' | 'fts_corrupt'
   filesIndexed: number
   duration: number
 }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -51,6 +51,7 @@ import { CommandPalette } from '@/components/search/command-palette'
 import { SettingsModalProvider, useSettingsModal } from '@/contexts/settings-modal-context'
 import { SettingsModal } from '@/components/settings-modal'
 import { useFolderViewEvents } from '@/hooks/use-folder-view-events'
+import { useIndexRecoveryNotice } from '@/hooks/use-index-recovery-notice'
 import { useCloseTabsOnEntityDelete } from '@/hooks/use-close-tabs-on-entity-delete'
 import { useFlushOnQuit } from '@/hooks/use-flush-on-quit'
 import { useMenuCommands } from '@/hooks/use-menu-commands'
@@ -220,6 +221,7 @@ const AppContent = (): React.JSX.Element => {
   useUndoKeyboardShortcut() // T051-T054: Cmd+Z for task undo
   useReminderNotifications() // T231-T233: In-app toast notifications for reminders
   useInboxReviewNotifications() // Daily inbox review nudge: toast + open-inbox on click
+  useIndexRecoveryNotice() // Says so when Memry repaired its own search index
   useFolderViewEvents() // Global cache invalidation for folder-view tabs
   useCloseTabsOnEntityDelete() // A deleted canvas takes its tabs with it, in every group
   const toggleSearch = useCallback(() => setSearchOpen((prev) => !prev), [])

--- a/apps/desktop/src/renderer/src/hooks/use-index-recovery-notice.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-index-recovery-notice.test.tsx
@@ -1,0 +1,58 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IndexRecoveredEvent } from '../../../preload/index.d'
+import { useIndexRecoveryNotice } from './use-index-recovery-notice'
+
+const toastFn = vi.fn()
+vi.mock('sonner', () => ({ toast: (...a: unknown[]) => toastFn(...a) }))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key })
+}))
+
+let recoveredCb: ((event: IndexRecoveredEvent) => void) | null = null
+const unsubscribe = vi.fn()
+
+describe('useIndexRecoveryNotice', () => {
+  beforeEach(() => {
+    toastFn.mockClear()
+    unsubscribe.mockClear()
+    recoveredCb = null
+    window.api = {
+      onVaultIndexRecovered: vi.fn((cb: (event: IndexRecoveredEvent) => void) => {
+        recoveredCb = cb
+        return unsubscribe
+      })
+    } as never
+  })
+
+  it('says so, calmly, once the corrupt search index has been rebuilt', () => {
+    renderHook(() => useIndexRecoveryNotice())
+
+    // #when the main process reports it repaired the fts5 index by itself
+    recoveredCb?.({ reason: 'fts_corrupt', filesIndexed: 42, duration: 1200 })
+
+    // #then the user finally learns why search went quiet — instead of zero
+    // results forever with no explanation
+    expect(toastFn).toHaveBeenCalledWith('toast.searchIndexRepaired', {
+      description: 'toast.searchIndexRepairedHint'
+    })
+  })
+
+  it('stays quiet while a brand-new vault builds its first index', () => {
+    renderHook(() => useIndexRecoveryNotice())
+
+    // 'missing' is the ordinary first-open case: nothing was damaged, so there
+    // is nothing to reassure anyone about.
+    recoveredCb?.({ reason: 'missing', filesIndexed: 3, duration: 40 })
+
+    expect(toastFn).not.toHaveBeenCalled()
+  })
+
+  it('unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useIndexRecoveryNotice())
+    unmount()
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-index-recovery-notice.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-index-recovery-notice.ts
@@ -1,0 +1,38 @@
+/**
+ * Index Recovery Notice Hook
+ *
+ * Tells the user, once and calmly, that Memry repaired its own search index.
+ *
+ * Before this, a damaged index was completely silent: search returned zero
+ * results forever and nothing said why (#1585). The repair is automatic, so
+ * this is a statement of fact rather than a request — there is nothing for the
+ * user to do, and the notice says so.
+ *
+ * @module hooks/use-index-recovery-notice
+ */
+
+import { useEffect } from 'react'
+import { toast } from 'sonner'
+import { useT } from '@memry/i18n/renderer'
+import { onVaultIndexRecovered } from '@/services/vault-service'
+
+/**
+ * Listens for automatic index recovery. Should be used once at the app level.
+ */
+export function useIndexRecoveryNotice(): void {
+  const { t } = useT('common')
+
+  useEffect(() => {
+    return onVaultIndexRecovered((event) => {
+      // 'missing' is a brand-new vault building its index for the first time.
+      // Nothing was repaired, so saying so would only worry people.
+      if (event.reason === 'missing') {
+        return
+      }
+
+      toast(t('toast.searchIndexRepaired'), {
+        description: t('toast.searchIndexRepairedHint')
+      })
+    })
+  }, [t])
+}

--- a/apps/docs/src/user-guide/search.md
+++ b/apps/docs/src/user-guide/search.md
@@ -79,3 +79,11 @@ For each result row:
 Search runs against the **index DB** for keyword match. Embedding-based ranking happens on the **device**, not the server. Even with semantic search enabled, queries don't leave your machine.
 
 For large vaults, the keyword index is FTS5-backed and stays sub-100ms even with 10k+ documents.
+
+## If the Search Index Is Damaged
+
+The search index is a cache. It is rebuilt from your notes, so it can be thrown away and re-derived at any time — your notes, tasks and vault files are never at risk.
+
+A disk fault or an unclean shutdown can still leave it unreadable. Memry checks the index when it opens a vault, and again whenever a background repair pass touches it. If the index turns out to be damaged, Memry drops it, rebuilds it from your notes, and tells you it did so with a short "Search index repaired" notice. There is nothing to do — search works again once the rebuild finishes.
+
+Reopening the vault is enough to trigger the check by hand.

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -93,7 +93,9 @@
     "filesImported": "{count, plural, one {Imported # file} other {Imported # files}}",
     "filesImportFailed": "{count, plural, one {Failed to import # file} other {Failed to import # files}}",
     "moreRemindersDue": "{count, plural, one {# more reminder due} other {# more reminders due}}",
-    "moreRemindersDueHint": "Check the reminders panel for details"
+    "moreRemindersDueHint": "Check the reminders panel for details",
+    "searchIndexRepaired": "Search index repaired",
+    "searchIndexRepairedHint": "Part of the search index was damaged, so Memry rebuilt it. Your notes were not touched."
   },
   "dateRelative": {
     "today": "Today",


### PR DESCRIPTION
## What was broken

On one Linux install, `SQLITE_CORRUPT` fired on every launch while the search projector reconciled its FTS5 index. The `fts_notes` virtual table in the index database was internally corrupt, so note search returned zero results — silently, forever, with no error and no way back.

All three candidate recovery paths were dead:

1. **`detectCorruption()` had zero production callers.** Written in 2025-12, never wired. The renderer half (`INDEX_CORRUPT` → `onSearchIndexCorrupt` → `onIndexCorrupt`) was equally unsubscribed.
2. **`checkIndexHealth()` could not see this corruption.** It only asserted `note_cache` / `note_tags` / `note_links` exist in `sqlite_master`. It never opened `fts_notes` or its fts5 shadow tables, so a broken index read as `'healthy'` and the existing auto-rebuild never fired.
3. **Rebuild started with the statement that throws.** `rebuildNotes` began with `clearFtsTable` = `DELETE FROM fts_notes`, which is exactly what telemetry proves fails on this install. The escape hatch failed at its first statement.

On top of that, `runReconcilePass` had no per-projector `try/catch`, so the search projector throwing also stopped `embedding`, `inboxStats` and `noteProjectLinks` from reconciling — on every launch.

## What this changes

**Detection now runs.** `checkIndexHealth` reads the fts5 index with a `MATCH` probe and returns a new `'fts_corrupt'` verdict. On the writable connection after open, `detectCorruption` runs fts5's own `INSERT INTO fts_notes(fts_notes) VALUES('integrity-check')` — which `PRAGMA integrity_check` never does, and which cannot run on the readonly health-check connection (it fails `SQLITE_READONLY`). Both probes are narrowed to SQLite's corruption codes via a new `isSqliteCorruptError`; `isTableCorrupt` used to swallow *every* exception, which would have turned a lock into a full reindex. Drizzle wraps driver errors, so the code is read through the `.cause` chain.

Two triggers, one repair:
- the open-time verdict is `'fts_corrupt'`, or
- a reconcile pass records a projector failure whose error is corruption.

Both call the same repair, which re-confirms with the integrity check before rebuilding anything.

**Repair now works.** `resetFtsTable` / `resetFtsTasksTable` / `resetFtsInboxTable` drop and re-create the virtual table instead of deleting rows out of it, and the three `rebuild*` functions start there. `DROP` only unlinks the shadow tables, so it succeeds however damaged their contents are — verified against three distinct on-disk corruption shapes.

**Projectors are isolated.** `runReconcilePass` catches per projector, records a `ProjectorReconcileFailure` and continues. The failure is recorded rather than swallowed: `openVault` reads it to report each failure to telemetry under the same `projection_reconcile` action name, and to spot the one it can repair.

**The user is told.** The repair is automatic, so the notice is a statement, not a request: a calm "Search index repaired / Part of the search index was damaged, so Memry rebuilt it. Your notes were not touched." toast, driven by the existing `INDEX_RECOVERED` event (which already carries telemetry). It stays quiet for `reason: 'missing'`, which is just a brand-new vault building its first index.

## Index DB vs data DB

- `fts_notes` lives in the **index DB**, which is derived and rebuildable by design. A corrupt one is dropped, re-created and repopulated from `note_cache` plus the markdown on disk.
- `fts_tasks` and `fts_inbox` live in **data.db**, but they are projections of the `tasks` / `inbox_items` rows beside them. Dropping and re-creating them costs a re-index and nothing else — no user-authored row is read or written.
- **No schema change, no migration, no reset.** The data DB is never deleted and never rewritten on this path. Vault files stay the source of truth throughout.
- Backward compatible: an index DB written before `fts_notes` existed still reads as `'healthy'` (a missing virtual table is not corruption — `initializeFts` creates it on open).
- `'fts_corrupt'` deliberately does **not** take the existing "delete index.db and rebuild" branch: that file also holds every note embedding, and this corruption does not justify minutes of CPU re-embedding.

## Verification

| Command | Result |
| --- | --- |
| `pnpm --filter @memry/desktop typecheck:node` | pass |
| `pnpm --filter @memry/desktop typecheck:web` | pass |
| `pnpm --filter @memry/desktop typecheck:test:node` | pass |
| `pnpm --filter @memry/desktop typecheck:test:web` | 2 pre-existing failures in `sidebar-nav.test.tsx` (`onNavMiddleClick`), untouched by this branch |
| `pnpm lint` | 0 errors (98 pre-existing warnings, none in changed files) |
| `pnpm --filter @memry/desktop i18n:check` | `ok: i18n check passed` |
| `pnpm check:architecture` / `pnpm check:contracts` / `pnpm ipc:check` | pass |
| `pnpm --filter @memry/desktop test:main` | 531 files / 6867 tests pass; 2 timeout flakes (`index.phase2`, `sync/runtime`) that pass in isolation |
| `pnpm docs:impact --base origin/main --strict` | `covered` |
| `pnpm docs:build` | `build complete` |

New tests, all against real SQLite with genuinely corrupt fts5 shadow tables (`unsafeMode` + garbled `fts_notes_data` blobs):

- `fts-corruption.test.ts` — `checkIndexHealth` returns `fts_corrupt`; a pre-FTS index DB still reads healthy; `detectCorruption` catches damage no read probe can see; `DELETE FROM fts_notes` throws where `resetFtsTable` succeeds; search answers again afterwards; `isSqliteCorruptError` accepts wrapped corruption and rejects `SQLITE_BUSY`.
- `search-projector.test.ts` — `rebuild()` recovers an index where both `MATCH` and `DELETE FROM fts_notes` throw.
- `runtime.test.ts` — a throwing projector no longer skips its three siblings, and the failure is recorded.
- `vault/index.test.ts` — `fts_corrupt` repairs in place and never calls `rebuildIndex`; a false alarm rebuilds nothing; a reconcile-reported corruption triggers the repair and still reports to telemetry.

Mutation-checked: reverting `resetFtsTable` to `DELETE FROM fts_notes` turns 3 of these red.

## Not done

- The origin of the corruption (Linux AppImage `/tmp` mount, unclean shutdown, filesystem event) is still unknown — issue item 6 says the fix should not wait on that answer, and it does not.
- The `search:rebuild-index` IPC handler is reachable but **no UI calls it** today (`searchService.rebuildIndex` has no callers). Its implementation is fixed either way, so the button works whenever it is wired; the docs describe only the automatic path that actually exists.
- `clearFtsTable` / `clearFtsTasksTable` / `clearFtsInboxTable` are now unused by production code but kept, since they are exported and covered by existing tests.

Fixes #1585
