### PR TITLE
fix(telemetry): an IPC rejection names its channel, and expected conditions stop reading as failures

### DIFF
--- a/apps/desktop/src/main/ipc/index.test.ts
+++ b/apps/desktop/src/main/ipc/index.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// This suite mocks every handler module rather than the Electron runtime, but
+// registerAllHandlers itself now touches ipcMain to label handlers with their
+// channel.
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() }
+}))
+
 const hoisted = vi.hoisted(() => ({
   registerVaultHandlers: vi.fn(),
   unregisterVaultHandlers: vi.fn(),

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -40,6 +40,7 @@ import { registerAgentMcpHandlers, unregisterAgentMcpHandlers } from './agent-mc
 import { registerImportHandlers, unregisterImportHandlers } from './import-handlers'
 import { registerHomePageHandlers, unregisterHomePageHandlers } from './home-page-handlers'
 import { registerLocaleHandlers, type RebuildMenuFn } from './locale-handler'
+import { installIpcChannelLabels } from './lib/ipc-channel-labels'
 import type { I18nInstance } from '@memry/i18n/main'
 import { createLogger } from '../lib/logger'
 
@@ -72,6 +73,11 @@ export function registerAllHandlers(deps?: IpcDeps): void {
     ipcLog.warn('handlers already registered, skipping')
     return
   }
+
+  // Must run before the first registration: it labels each handler with the
+  // channel it is registered on, which is what lets an IPC failure name a
+  // channel instead of the generic `validated_handler`.
+  installIpcChannelLabels()
 
   // Register vault handlers
   registerVaultHandlers()

--- a/apps/desktop/src/main/ipc/lib/ipc-channel-labels.test.ts
+++ b/apps/desktop/src/main/ipc/lib/ipc-channel-labels.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { z } from 'zod'
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() }
+}))
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+vi.mock('../../database', () => ({
+  getDatabase: vi.fn(),
+  requireDatabase: vi.fn()
+}))
+
+vi.mock('../../telemetry/diagnostics', () => ({
+  trackMainError: vi.fn()
+}))
+
+import { ipcMain, type IpcMainInvokeEvent } from 'electron'
+import { trackMainError } from '../../telemetry/diagnostics'
+import { createValidatedHandler } from '../validate'
+import { installIpcChannelLabels } from './ipc-channel-labels'
+
+const mockTrackMainError = vi.mocked(trackMainError)
+// Captured before the install replaces the property, so the pass-through is
+// still assertable afterwards.
+const realHandle = vi.mocked(ipcMain.handle)
+
+const invokeEvent = {} as IpcMainInvokeEvent
+const TitleSchema = z.object({ title: z.string().min(1) })
+
+describe('installIpcChannelLabels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('#given a handler registered through ipcMain.handle #then its failures name the channel', async () => {
+    // #given
+    installIpcChannelLabels()
+    const listener = createValidatedHandler(TitleSchema, async (input) => input)
+    ipcMain.handle('tasks:create', listener)
+
+    // #when the contract schema rejects the input
+    await expect(listener(invokeEvent, { title: '' })).rejects.toThrow('Validation failed')
+
+    // #then telemetry can pin the ZodError to a channel
+    expect(mockTrackMainError).toHaveBeenCalledWith('ipc', 'tasks:create', expect.anything())
+  })
+
+  it('#then registration still reaches the real ipcMain.handle', () => {
+    installIpcChannelLabels()
+    const listener = createValidatedHandler(TitleSchema, async (input) => input)
+
+    ipcMain.handle('notes:list', listener)
+
+    expect(realHandle).toHaveBeenCalledTimes(1)
+    expect(realHandle).toHaveBeenCalledWith('notes:list', listener)
+  })
+
+  it('#given a second install #then handle is not wrapped twice', () => {
+    installIpcChannelLabels()
+    installIpcChannelLabels()
+
+    ipcMain.handle(
+      'vault:status',
+      createValidatedHandler(TitleSchema, async (i) => i)
+    )
+
+    // A double wrap would register the same handler with Electron twice.
+    expect(realHandle).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/main/ipc/lib/ipc-channel-labels.ts
+++ b/apps/desktop/src/main/ipc/lib/ipc-channel-labels.ts
@@ -1,0 +1,35 @@
+import { ipcMain } from 'electron'
+import { setIpcHandlerChannel } from '../validate'
+
+type IpcHandleListener = Parameters<typeof ipcMain.handle>[1]
+
+let installed = false
+
+/**
+ * Make every IPC failure name the channel it came from.
+ *
+ * `createValidatedHandler` / `createHandler` wrap an anonymous arrow, so the
+ * only label they could report was the generic `validated_handler` — which
+ * collapsed every inline handler in the app into one telemetry action. A
+ * `ZodError` from a contract schema was therefore unattributable: the captured
+ * stack names the bundled wrapper and Zod strips its own frames, so nothing on
+ * the wire identified the handler.
+ *
+ * `ipcMain.handle(channel, listener)` is the one place that knows both halves.
+ * Wrapping it records the pairing once, centrally, instead of threading a
+ * channel argument through 175 registration sites. Behaviour is untouched: the
+ * real `handle` is always called with the same arguments.
+ *
+ * Call this before any handler registers (`registerAllHandlers` does).
+ * Registrations that happen earlier simply keep the old generic label.
+ */
+export function installIpcChannelLabels(): void {
+  if (installed) return
+  installed = true
+
+  const originalHandle = ipcMain.handle.bind(ipcMain)
+  ipcMain.handle = (channel: string, listener: IpcHandleListener): void => {
+    setIpcHandlerChannel(listener, channel)
+    originalHandle(channel, listener)
+  }
+}

--- a/apps/desktop/src/main/ipc/validate.test.ts
+++ b/apps/desktop/src/main/ipc/validate.test.ts
@@ -21,7 +21,15 @@ vi.mock('../telemetry/diagnostics', () => ({
 import { getDatabase } from '../database'
 import { trackMainError } from '../telemetry/diagnostics'
 import { markExpectedCondition } from '../telemetry/expected-conditions'
-import { withErrorHandler, withDb, ipcErrorThrottleKeyCount } from './validate'
+import { z } from 'zod'
+import {
+  withErrorHandler,
+  withDb,
+  ipcErrorThrottleKeyCount,
+  createValidatedHandler,
+  setIpcHandlerChannel
+} from './validate'
+import type { IpcMainInvokeEvent } from 'electron'
 
 const mockGetDatabase = vi.mocked(getDatabase)
 const mockTrackMainError = vi.mocked(trackMainError)
@@ -455,5 +463,57 @@ describe('IPC error telemetry', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe('validated handler attribution', () => {
+  const invokeEvent = {} as IpcMainInvokeEvent
+  const TitleSchema = z.object({ title: z.string().min(1) })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('#given a handler labelled with its channel #then a ZodError names that channel', async () => {
+    // #given the exact production shape: an inline arrow, so `handler.name` is ''
+    const listener = createValidatedHandler(TitleSchema, async (input) => input)
+    setIpcHandlerChannel(listener, 'notes:create')
+
+    // #when the renderer submits a blank title
+    await expect(listener(invokeEvent, { title: '' })).rejects.toThrow('Validation failed: title:')
+
+    // #then the failure is pinned to a handler instead of collapsing to a
+    // single label shared by every inline handler in the app
+    expect(mockTrackMainError).toHaveBeenCalledWith('ipc', 'notes:create', expect.anything())
+  })
+
+  it('#given two labelled handlers #then each reports its own channel', async () => {
+    const notes = createValidatedHandler(TitleSchema, async (input) => input)
+    const tasks = createValidatedHandler(TitleSchema, async (input) => input)
+    setIpcHandlerChannel(notes, 'notes:create:distinct')
+    setIpcHandlerChannel(tasks, 'tasks:create:distinct')
+
+    await expect(notes(invokeEvent, { title: '' })).rejects.toThrow()
+    await expect(tasks(invokeEvent, { title: '' })).rejects.toThrow()
+
+    // Not one throttled event under a shared key — two, one per channel.
+    expect(mockTrackMainError.mock.calls.map((call) => call[1])).toEqual([
+      'notes:create:distinct',
+      'tasks:create:distinct'
+    ])
+  })
+
+  it('#given an unlabelled handler #then it still reports the generic label', async () => {
+    // Registration paths that never reach ipcMain.handle keep the old behaviour.
+    const listener = createValidatedHandler(TitleSchema, async (input) => input)
+
+    await expect(listener(invokeEvent, { title: '' })).rejects.toThrow()
+
+    expect(mockTrackMainError).toHaveBeenCalledWith('ipc', 'validated_handler', expect.anything())
+  })
+
+  it('#given a non-function or empty channel #then labelling is a no-op', () => {
+    expect(() => setIpcHandlerChannel(undefined, 'notes:create')).not.toThrow()
+    expect(() => setIpcHandlerChannel(() => undefined, '')).not.toThrow()
   })
 })

--- a/apps/desktop/src/main/ipc/validate.ts
+++ b/apps/desktop/src/main/ipc/validate.ts
@@ -41,6 +41,36 @@ const sweepTrackedErrorKeys = (now: number): void => {
  */
 export const ipcErrorThrottleKeyCount = (): number => lastTrackedByCode.size
 
+// Handlers are registered as `ipcMain.handle(Channel, createValidatedHandler(
+// Schema, async (input) => ...))`. An arrow passed straight in as an argument
+// has `name === ''`, so EVERY inline handler used to report the same literal
+// action (`validated_handler`) and a ZodError could not be pinned to a channel
+// — the captured stack only names the bundled wrapper. The channel is known at
+// the `ipcMain.handle` registration site and nowhere else, so
+// `installIpcChannelLabels` (ipc/lib/ipc-channel-labels.ts) records it here,
+// keyed by the wrapper function it was registered with. Weakly held: a listener
+// that is removed must not be kept alive by its own label.
+const channelByListener = new WeakMap<object, string>()
+
+/**
+ * Associate an IPC channel with the wrapper registered on it, so a failure
+ * inside that wrapper reports the channel instead of an anonymous label.
+ * Called from the `ipcMain.handle` boundary; a no-op for anything else.
+ */
+export const setIpcHandlerChannel = (listener: unknown, channel: unknown): void => {
+  if (typeof listener !== 'function') return
+  if (typeof channel !== 'string' || channel.length === 0) return
+  channelByListener.set(listener, channel)
+}
+
+// Channel first, then the inner handler's own name (named handlers already
+// report usefully), then the generic label the wrapper had before.
+const handlerAction = (
+  listener: object,
+  handler: { readonly name: string },
+  fallback: string
+): string => channelByListener.get(listener) ?? (handler.name || fallback)
+
 const trackIpcError = (action: string, error: unknown): void => {
   try {
     // An expected condition (Ollama not running, an abandoned OAuth flow) is
@@ -91,7 +121,10 @@ export function createValidatedHandler<TSchema extends z.ZodSchema, TResult>(
   schema: TSchema,
   handler: (input: z.infer<TSchema>, event: IpcMainInvokeEvent) => TResult | Promise<TResult>
 ): (event: IpcMainInvokeEvent, rawInput: z.input<TSchema>) => Promise<TResult> {
-  return async (event: IpcMainInvokeEvent, rawInput: z.input<TSchema>): Promise<TResult> => {
+  const listener = async (
+    event: IpcMainInvokeEvent,
+    rawInput: z.input<TSchema>
+  ): Promise<TResult> => {
     try {
       const validated = schema.parse(rawInput)
       return await handler(validated, event)
@@ -104,16 +137,17 @@ export function createValidatedHandler<TSchema extends z.ZodSchema, TResult>(
         // A validation failure is a renderer↔main contract drift, not user
         // error — worth counting. Only the ZodError name/stack ship, never the
         // issue messages, which can echo input values.
-        trackIpcError(handler.name || 'validated_handler', error)
+        trackIpcError(handlerAction(listener, handler, 'validated_handler'), error)
         throw new Error(`Validation failed: ${messages}`)
       }
       ipcLog.error('handler error:', error)
       // Handlers on this wrapper (canvas, calendar reads) never pass withDb/
       // withErrorHandler, so this rethrow used to be their ONLY trace.
-      trackIpcError(handler.name || 'validated_handler', error)
+      trackIpcError(handlerAction(listener, handler, 'validated_handler'), error)
       throw error instanceof Error ? new Error(error.message) : new Error('Something went wrong')
     }
   }
+  return listener
 }
 
 /**
@@ -135,15 +169,16 @@ export function createValidatedHandler<TSchema extends z.ZodSchema, TResult>(
 export function createHandler<TResult>(
   handler: () => TResult | Promise<TResult>
 ): (event: IpcMainInvokeEvent) => Promise<TResult> {
-  return async (_event: IpcMainInvokeEvent): Promise<TResult> => {
+  const listener = async (_event: IpcMainInvokeEvent): Promise<TResult> => {
     try {
       return await handler()
     } catch (error) {
       ipcLog.error('handler error:', error)
-      trackIpcError(handler.name || 'handler', error)
+      trackIpcError(handlerAction(listener, handler, 'handler'), error)
       throw error
     }
   }
+  return listener
 }
 
 /**

--- a/apps/desktop/src/main/vault/index.test.ts
+++ b/apps/desktop/src/main/vault/index.test.ts
@@ -63,7 +63,8 @@ const mocks = vi.hoisted(() => ({
   registerLazyAgentHandlers: vi.fn(),
   unregisterLazyAgentHandlers: vi.fn(),
   startAgent: vi.fn(),
-  agentShutdown: vi.fn()
+  agentShutdown: vi.fn(),
+  trackMainLog: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -178,7 +179,7 @@ vi.mock('../sync/crdt-provider', () => ({
 
 vi.mock('../telemetry/diagnostics', () => ({
   trackMainError: (...args: unknown[]) => mocks.trackMainError(...args),
-  trackMainLog: vi.fn()
+  trackMainLog: (...args: unknown[]) => mocks.trackMainLog(...args)
 }))
 
 vi.mock('../projections', () => ({
@@ -249,6 +250,7 @@ import {
   autoOpenLastVault,
   closeVault,
   emitIndexProgress,
+  emitIndexRecovered,
   emitVaultError,
   getAllVaults,
   getConfig,
@@ -792,4 +794,37 @@ describe('vault lifecycle', () => {
     expect(mocks.sent).toContainEqual({ channel: 'vault:index-progress', payload: 55 })
     expect(mocks.sent).toContainEqual({ channel: 'vault:error', payload: 'boom' })
   })
+})
+
+describe('index recovery severity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('#given a missing index #then the rebuild is reported at info, not warn', () => {
+    // #given the index DB was simply absent — the expected first open of a vault
+    emitIndexRecovered({ reason: 'missing', filesIndexed: 12, duration: 340 })
+
+    // #then it stays queryable, but out of the error dashboard
+    expect(mocks.trackMainLog).toHaveBeenCalledWith('info', {
+      scope: 'vault',
+      action: 'index_recovered',
+      errorCode: 'missing',
+      metrics: { durationMs: 340, itemCount: 12 }
+    })
+  })
+
+  it.each(['corrupt', 'migration_failed'] as const)(
+    '#given a %s index #then the rebuild is still a warning',
+    (reason) => {
+      // #given genuine data-corruption recovery
+      emitIndexRecovered({ reason, filesIndexed: 5, duration: 90 })
+
+      // #then the level someone triages is unchanged
+      expect(mocks.trackMainLog).toHaveBeenCalledWith(
+        'warn',
+        expect.objectContaining({ action: 'index_recovered', errorCode: reason })
+      )
+    }
+  )
 })

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -263,9 +263,19 @@ export interface IndexRecoveredEvent {
  * Sent after automatic recovery from corrupt or missing index.
  */
 export function emitIndexRecovered(event: IndexRecoveredEvent): void {
-  // Automatic recovery from a corrupt/missing index (or a failed index
-  // migration) is user-visible data-corruption recovery — count it in telemetry.
-  trackMainLog('warn', {
+  // Automatic recovery from a corrupt index or a failed index migration is
+  // user-visible data-corruption recovery — count it, at `warn`.
+  //
+  // `missing` is not that. `checkIndexHealth` reports it when index.db is simply
+  // not on disk, which is the expected first open of a vault: fresh install,
+  // newly linked device, or a user who deleted the file. The index is a fully
+  // derived cache — data.db and the markdown are untouched — so rebuilding it is
+  // the healthy path, with no user impact. Logged at `warn` it landed in the
+  // error dashboard and, spread across ~24 installs, read as the most widespread
+  // problem in the release while being no problem at all. Still emitted, with the
+  // same action and errorCode, so the event stays queryable; only the level moves.
+  const level = event.reason === 'missing' ? 'info' : 'warn'
+  trackMainLog(level, {
     scope: 'vault',
     action: 'index_recovered',
     errorCode: event.reason,

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -41,6 +41,12 @@ steady states at `debug`:
 - Vector-clock bumps the `increment*ClockOffline` helpers make while the sync runtime is down
   (`main/sync/offline-clock.ts`) — the normal offline-edit path, one call per edited row (per
   changed field for tasks and projects).
+- An index rebuild triggered by a **missing** index DB (`emitIndexRecovered` in
+  `main/vault/index.ts`) — `checkIndexHealth` reports `missing` when `index.db` is not on disk,
+  which is the expected first open of a vault: fresh install, newly linked device, or a deleted
+  file. The index is a derived cache, so rebuilding it costs nothing but time. It is emitted at
+  `info`, with the same `index_recovered` action and `errorCode` as before. `corrupt` and
+  `migration_failed` stay at `warn` — those are genuine data-corruption recovery.
 
 A log payload is built before the transport decides whether to keep it, so a hot path pays for
 its arguments at every level. Keep these lines to identifiers: log the row id and the changed
@@ -529,6 +535,14 @@ traffic does not go through `/telemetry/batch`. The old `POST /telemetry/web` en
   `VITE_VERCEL_ENV` when present, otherwise a production/development split on Vite's build
   `MODE` — so landing traffic is filterable apart from desktop/server events in the same PostHog
   project.
+- **Scanner noise**: a `before_send` filter drops one `$exception` fingerprint —
+  `Object Not Found Matching Id:N, MethodName:update, ParamCount:4`. That is Microsoft Office /
+  Outlook **SafeLinks** pre-fetching a link out of an email, injecting its own scanner into the
+  page, and then losing its own object handle; `MethodName` / `ParamCount` are a COM bridge's
+  idioms and appear nowhere in this repo. It arrives in same-day bursts from a handful of readers a
+  few times a quarter and has no type and no usable stack, so it is pure noise in the error list.
+  The match is deliberately narrow — only that exact COM signature. A broad "drop every non-Error
+  rejection" rule would hide real bugs.
 
 ## Error Reporting
 
@@ -589,6 +603,17 @@ files); any home-directory prefix (`/Users/<name>`, `C:\Users\<name>`) is rewrit
 emails, UUIDs, JWTs, and bearer tokens are scrubbed from anything that ships.
 
 ### IPC Error Throttling
+
+The `action` an IPC error reports is the **channel it was registered on** (`notes:create`), not the
+handler's function name. Handlers are registered as
+`ipcMain.handle(Channel, createValidatedHandler(Schema, async (input) => …))`, and an arrow passed
+straight in as an argument has an empty `name` — so every inline handler in the app used to collapse
+into one literal action, `validated_handler`, and a schema rejection could not be attributed to a
+channel from the wire data alone (the captured stack names only the bundled wrapper, and Zod strips
+its own frames). `installIpcChannelLabels` (`main/ipc/lib/ipc-channel-labels.ts`) records the pairing
+once at the `ipcMain.handle` boundary — the only place that knows both halves — and
+`registerAllHandlers` calls it before the first registration. A handler registered without it keeps
+the old generic label.
 
 Every IPC envelope error becomes a telemetry event, so a handler stuck in a failure loop could
 flood the queue. `trackIpcError` (`main/ipc/validate.ts`) therefore emits at most one event per
@@ -843,11 +868,31 @@ POSTHOG_KEY=...                          # wrangler secret (PostHog project toke
 POSTHOG_HOST=https://us.i.posthog.com    # wrangler var (staging and production)
 ```
 
-`GITHUB_TOKEN` is optional and only used by the daily
-[release download-count](#release-download-counts) cron. Without it the pull is unauthenticated
-and shares the 60-requests-per-hour-per-IP limit with every other Worker on the same egress
-address; a public-repo read token lifts that. A failed pull throws and is reported as a
-`release_download_counts` cron failure rather than silently skewing the numbers.
+`GITHUB_TOKEN` is only used by the daily [release download-count](#release-download-counts) cron,
+and in practice it is **required in staging and production**. Without it the pull is
+unauthenticated and shares the 60-requests-per-hour-per-IP budget with every other Worker on the
+same Cloudflare egress address, which other tenants routinely exhaust before our one daily request
+arrives — GitHub then answers 403 and no `release_asset_downloaded` event is emitted that day. A
+fine-grained PAT with public-repo read access is enough (this reads a public repo's Releases API and
+needs no write scope), and authenticated calls get 5,000/hour:
+
+```bash
+wrangler secret put GITHUB_TOKEN --env staging
+wrangler secret put GITHUB_TOKEN --env production
+```
+
+No workflow uploads it; it is set by hand, like every other Worker secret. It is deliberately not in
+the `requiredSecrets` fail-fast list — a missing token must not take the whole Worker down for a
+once-a-day measurement.
+
+A failed pull throws and is reported as a `release_download_counts` cron failure rather than silently
+skewing the numbers, and the two failure shapes are separable. GitHub's own 403/429 raises
+`GitHubReleasesRefusedError`, which carries `code: 'GITHUB_RELEASES_REFUSED'` and the upstream status,
+so it reports as a handled 4xx logged at `warn` — expected upstream backpressure, with the message
+recording whether a token was in play. Anything else stays an unhandled 500. Nothing is corrupted
+either way: the throw happens before the D1 read/write, so the stored baseline is untouched and the
+next successful run emits the accumulated delta. The distortion is in the daily series (a zero, then
+a spike), not the running total.
 
 ### Diagnostic Log Endpoints
 

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -566,6 +566,16 @@ them, and every client version already applies the snapshot as its baseline befo
 incrementals. If that fallback fails the push rejects, leaving the batch buffered for the next flush
 and — on quit — recorded for replay. No path discards an update.
 
+The two caps do not compose cleanly at the top end. A payload the route would reject with the
+precise `Snapshot exceeds 5MB limit` never reaches the route once its encoded body passes 8 MiB: the
+body-limit middleware answers 413 first, and with it the route's `snapshot_rejected` event — the one
+carrying `totalBytes` — was lost. The middleware therefore emits that event itself for
+`/sync/crdt/snapshot` and `/sync/crdt/updates`, with `reason: 'body_limit_exceeded'` and the
+observed **encoded** body size (base64 plus the JSON envelope, roughly 4/3 of the decoded payload).
+An oversized CRDT payload is diagnosable whichever check catches it. On the client a bare 413 with
+no storage code maps to `note_too_large`, which names the note in its toast — it is not, and must
+not read as, a storage-quota problem.
+
 ### CRDT write notifications
 
 Both CRDT write paths notify peers the same way. Once the write is durable, the server broadcasts

--- a/apps/landing/src/lib/analytics.test.ts
+++ b/apps/landing/src/lib/analytics.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test'
 import {
   createLandingEventData,
   createLandingPageViewData,
+  isSafeLinksScannerException,
   readLandingCampaignParams,
   trackLandingEvent,
   trackLandingPageView
@@ -62,5 +63,78 @@ describe('landing analytics send path', () => {
       trackLandingPageView('/')
       trackLandingEvent('landing_nav_click', 'nav:logo')
     })
+  })
+})
+
+describe('SafeLinks scanner noise', () => {
+  const scannerRejection = (id: number): string =>
+    `Non-Error promise rejection captured with value: Object Not Found Matching Id:${id}, MethodName:update, ParamCount:4`
+
+  it('drops the Outlook SafeLinks rejection on every Id fingerprint', () => {
+    for (const id of [1, 2, 3]) {
+      assert.equal(
+        isSafeLinksScannerException({
+          event: '$exception',
+          properties: { $exception_values: [scannerRejection(id)] }
+        }),
+        true
+      )
+    }
+  })
+
+  it('matches the message wherever posthog-js puts it', () => {
+    assert.equal(
+      isSafeLinksScannerException({
+        event: '$exception',
+        properties: { $exception_message: scannerRejection(1) }
+      }),
+      true
+    )
+    assert.equal(
+      isSafeLinksScannerException({
+        event: '$exception',
+        properties: { $exception_list: [{ type: null, value: scannerRejection(1) }] }
+      }),
+      true
+    )
+  })
+
+  it('keeps genuine exceptions, including other non-Error rejections', () => {
+    assert.equal(
+      isSafeLinksScannerException({
+        event: '$exception',
+        properties: { $exception_values: ['TypeError: x is not a function'] }
+      }),
+      false
+    )
+    assert.equal(
+      isSafeLinksScannerException({
+        event: '$exception',
+        properties: {
+          $exception_values: ['Non-Error promise rejection captured with value: undefined']
+        }
+      }),
+      false
+    )
+  })
+
+  it('never drops a non-exception event, whatever it contains', () => {
+    assert.equal(
+      isSafeLinksScannerException({
+        event: '$pageview',
+        properties: { page: scannerRejection(1) }
+      }),
+      false
+    )
+  })
+
+  it('tolerates a null, empty, or property-less event', () => {
+    assert.equal(isSafeLinksScannerException(null), false)
+    assert.equal(isSafeLinksScannerException(undefined), false)
+    assert.equal(isSafeLinksScannerException({ event: '$exception' }), false)
+    assert.equal(
+      isSafeLinksScannerException({ event: '$exception', properties: { $exception_values: null } }),
+      false
+    )
   })
 })

--- a/apps/landing/src/lib/analytics.ts
+++ b/apps/landing/src/lib/analytics.ts
@@ -35,11 +35,7 @@ export type LandingEventName =
   | 'landing_account_signout'
 
 export type LandingCampaignKey =
-  | 'utm_source'
-  | 'utm_medium'
-  | 'utm_campaign'
-  | 'utm_content'
-  | 'utm_term'
+  'utm_source' | 'utm_medium' | 'utm_campaign' | 'utm_content' | 'utm_term'
 
 export type LandingCampaignData = Partial<Record<LandingCampaignKey, string>>
 
@@ -105,6 +101,50 @@ export function createLandingPageViewData(pathname: string, search = ''): Landin
   }
 }
 
+// Microsoft Office / Outlook SafeLinks pre-fetches links out of email and
+// injects its own scanner into the page. When the scanner loses the object
+// handle it is holding, it rejects a non-Error COM value, which posthog-js
+// reports as an `$exception` with no type and no usable stack:
+//
+//   Non-Error promise rejection captured with value:
+//   Object Not Found Matching Id:1, MethodName:update, ParamCount:4
+//
+// It is not our code: `MethodName` / `ParamCount` are a COM bridge's idioms and
+// appear nowhere in this repo, the `Id:N` counter is the scanner's own object
+// handle, and it arrives in same-day bursts from a handful of readers a few
+// times a quarter. Dropped here so it never reaches the error list.
+//
+// Deliberately narrow — matching only this exact COM signature. A broad "drop
+// every non-Error rejection" rule would hide real bugs.
+const SAFELINKS_SCANNER_REJECTION = /Object Not Found Matching Id:\d+, MethodName:update/
+
+// Only the exception fields, never the whole property bag: it can be large and
+// carries no other place this string could legitimately appear.
+const EXCEPTION_MESSAGE_KEYS = ['$exception_values', '$exception_list', '$exception_message']
+
+function asSearchableText(value: unknown): string {
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+export function isSafeLinksScannerException(
+  event: { event?: string; properties?: Record<string, unknown> } | null | undefined
+): boolean {
+  if (!event || event.event !== '$exception') return false
+  const properties = event.properties
+  if (!properties) return false
+
+  return EXCEPTION_MESSAGE_KEYS.some((key) => {
+    const value = properties[key]
+    if (value === undefined || value === null) return false
+    return SAFELINKS_SCANNER_REJECTION.test(asSearchableText(value))
+  })
+}
+
 // Product analytics + session replay via posthog-js, direct to PostHog's
 // reverse-proxy subdomain. Session replay cannot be server-proxied, so this
 // replaces the old sendBeacon/fetch pipe into sync-server. `init` no-ops when
@@ -123,6 +163,9 @@ function init(): boolean {
     person_profiles: 'identified_only',
     disable_external_dependency_loading: true,
     capture_pageview: false,
+    // Returning null drops the event before it is queued. Everything else is
+    // passed through untouched.
+    before_send: (event) => (isSafeLinksScannerException(event) ? null : event),
     session_recording: {
       maskAllInputs: true,
       // maskAllInputs only covers <input>/<textarea> values; account, login

--- a/apps/sync-server/src/index.test.ts
+++ b/apps/sync-server/src/index.test.ts
@@ -28,6 +28,12 @@ function createEnv(overrides?: Partial<Record<string, unknown>>) {
 }
 
 describe('sync-server app entry point', () => {
+  // Several tests here silence console output; without this the spies would
+  // outlive them and swallow the next describe's assertions.
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('returns health metadata in development even when secrets are missing', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const response = await app.request('http://localhost/health', {}, createEnv())
@@ -224,6 +230,65 @@ describe('sync-server app entry point', () => {
         message: 'Request body too large'
       }
     })
+  })
+
+  // The route's own snapshot_rejected event is unreachable here: the body dies in
+  // the middleware, so without this the only trace of an oversized CRDT payload
+  // was a bare 413 carrying no size at all.
+  it('reports the observed size of an oversized CRDT snapshot body', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    const request = new Request('http://localhost/sync/crdt/snapshot', {
+      method: 'POST',
+      body: new Uint8Array(8 * ONE_MB + 1)
+    })
+
+    const response = await app.request(request, {}, createEnv())
+    expect(response.status).toBe(413)
+
+    const emitted = infoSpy.mock.calls
+      .map(([line]) => JSON.parse(String(line)) as Record<string, unknown>)
+      .filter((line) => line.event === 'snapshot_rejected')
+
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0].endpoint).toBe('/sync/crdt/snapshot')
+    expect(emitted[0].reason).toBe('body_limit_exceeded')
+    expect(emitted[0].transport).toBe('crdt')
+    expect(Number(emitted[0].totalBytes)).toBeGreaterThan(8 * ONE_MB)
+  })
+
+  it('reports an oversized CRDT update batch as updates_rejected', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    const request = new Request('http://localhost/sync/crdt/updates', {
+      method: 'POST',
+      body: new Uint8Array(8 * ONE_MB + 1)
+    })
+
+    const response = await app.request(request, {}, createEnv())
+    expect(response.status).toBe(413)
+
+    const events = infoSpy.mock.calls
+      .map(([line]) => JSON.parse(String(line)) as Record<string, unknown>)
+      .map((line) => line.event)
+
+    expect(events).toContain('updates_rejected')
+    expect(events).not.toContain('snapshot_rejected')
+  })
+
+  it('stays quiet for oversized non-CRDT bodies', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    const request = new Request('http://localhost/sync/blob/blob-key', {
+      method: 'PUT',
+      body: new Uint8Array(TEN_MB + 1)
+    })
+
+    const response = await app.request(request, {}, createEnv())
+    expect(response.status).toBe(413)
+
+    const crdtEvents = infoSpy.mock.calls
+      .map(([line]) => JSON.parse(String(line)) as Record<string, unknown>)
+      .filter((line) => line.transport === 'crdt')
+
+    expect(crdtEvents).toEqual([])
   })
 })
 

--- a/apps/sync-server/src/index.ts
+++ b/apps/sync-server/src/index.ts
@@ -30,6 +30,7 @@ import {
 import { createLogger } from './lib/logger'
 import { captureServerError } from './services/analytics'
 import { syncReleaseDownloadCounts } from './services/release-downloads'
+import { logCrdtTraffic } from './services/sync-telemetry'
 import type { Bindings, AppContext } from './types'
 
 const logger = createLogger('Server')
@@ -55,7 +56,34 @@ const MAX_BODY_BYTES_SYNC = 8 * 1024 * 1024
 const MAX_BODY_BYTES_BLOB = 10 * 1024 * 1024
 const MAX_BODY_BYTES_TELEMETRY = 128 * 1024
 
-const bodyLimitError = () => {
+// A body over the cap dies HERE, before any route runs. For `/sync/crdt/*` that
+// meant the route's own `snapshot_rejected` / `updates_rejected` event — the one
+// carrying `totalBytes`, the single most useful number for diagnosing an
+// oversized CRDT payload — was never emitted, and the only trace left was a bare
+// 413 with no size in it. Emit the route's event here instead, with the size we
+// observed, so a rejection stays diagnosable wherever it is caught. `totalBytes`
+// is the ENCODED request body (base64 + JSON envelope), roughly 4/3 of the
+// decoded snapshot the route would have measured.
+const CRDT_REJECTION_EVENT: Record<string, 'snapshot_rejected' | 'updates_rejected'> = {
+  '/sync/crdt/snapshot': 'snapshot_rejected',
+  '/sync/crdt/updates': 'updates_rejected'
+}
+
+const logOversizedCrdtBody = (path: string, observedBytes: number): void => {
+  const event = CRDT_REJECTION_EVENT[path]
+  if (!event) return
+
+  logCrdtTraffic({
+    endpoint: path,
+    event,
+    totalBytes: observedBytes,
+    latencyMs: 0,
+    reason: 'body_limit_exceeded'
+  })
+}
+
+const bodyLimitError = (path: string, observedBytes: number) => {
+  logOversizedCrdtBody(path, observedBytes)
   throw new AppError(ErrorCodes.VALIDATION_BODY_TOO_LARGE, 'Request body too large', 413)
 }
 
@@ -74,14 +102,26 @@ const getMaxBodyBytes = (path: string): number => {
   return path.startsWith('/sync/') ? MAX_BODY_BYTES_SYNC : MAX_BODY_BYTES_API
 }
 
-const isBodyWithinLimit = async (request: Request, maxBodyBytes: number): Promise<boolean> => {
+// `observedBytes` is what was counted before the read stopped: exact when the
+// body fits, and a lower bound (just past the cap) when it does not — the stream
+// is deliberately abandoned rather than buffered to measure a payload we are
+// about to reject.
+interface BodyLimitCheck {
+  withinLimit: boolean
+  observedBytes: number
+}
+
+const isBodyWithinLimit = async (
+  request: Request,
+  maxBodyBytes: number
+): Promise<BodyLimitCheck> => {
   if (!request.body) {
-    return true
+    return { withinLimit: true, observedBytes: 0 }
   }
 
   const reader = request.clone().body?.getReader()
   if (!reader) {
-    return true
+    return { withinLimit: true, observedBytes: 0 }
   }
 
   let totalBytes = 0
@@ -89,12 +129,12 @@ const isBodyWithinLimit = async (request: Request, maxBodyBytes: number): Promis
     while (true) {
       const { done, value } = await reader.read()
       if (done) {
-        return true
+        return { withinLimit: true, observedBytes: totalBytes }
       }
 
       totalBytes += value.byteLength
       if (totalBytes > maxBodyBytes) {
-        return false
+        return { withinLimit: false, observedBytes: totalBytes }
       }
     }
   } finally {
@@ -107,13 +147,13 @@ app.use('*', async (c, next) => {
 
   const contentLength = c.req.header('Content-Length')
   if (contentLength && Number(contentLength) > maxBodyBytes) {
-    bodyLimitError()
+    bodyLimitError(c.req.path, Number(contentLength))
   }
 
   if (!METHOD_WITHOUT_BODY.has(c.req.method)) {
-    const withinLimit = await isBodyWithinLimit(c.req.raw, maxBodyBytes)
+    const { withinLimit, observedBytes } = await isBodyWithinLimit(c.req.raw, maxBodyBytes)
     if (!withinLimit) {
-      bodyLimitError()
+      bodyLimitError(c.req.path, observedBytes)
     }
   }
 
@@ -212,7 +252,10 @@ const scheduled: ExportedHandlerScheduledHandler<Bindings> = async (event, env, 
         error: result.reason,
         source: 'cron',
         action: tasks[i][0],
-        statusCode: 500,
+        // No hardcoded 500 any more: an error that carries its own status says
+        // so (GitHub's rate limiter answering the release pull is a handled
+        // 403, not a server fault), and everything else still defaults to 500
+        // inside captureServerError.
         handled: true
       })
     }

--- a/apps/sync-server/src/services/release-downloads.test.ts
+++ b/apps/sync-server/src/services/release-downloads.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { syncReleaseDownloadCounts, type ReleaseDownloadsEnv } from './release-downloads'
+import {
+  GitHubReleasesRefusedError,
+  syncReleaseDownloadCounts,
+  type ReleaseDownloadsEnv
+} from './release-downloads'
 
 interface GithubAsset {
   id: number
@@ -288,13 +292,48 @@ describe('syncReleaseDownloadCounts', () => {
     expect(headers.authorization).toBeUndefined()
   })
 
-  it('throws when the GitHub API rejects the request so the cron reports it', async () => {
+  it("reports GitHub's rate limit as a handled 403, naming the missing token", async () => {
     const { db } = createDb([])
     const githubFetch = vi.fn().mockResolvedValue(new Response('rate limited', { status: 403 }))
 
-    await expect(syncReleaseDownloadCounts(createEnv(db, githubFetch))).rejects.toThrow(
-      'GitHub releases request failed with status 403'
+    // #when the shared-IP budget is spent and no token is configured
+    const error = await syncReleaseDownloadCounts(createEnv(db, githubFetch)).catch(
+      (err: unknown) => err
     )
+
+    // #then the cron reports expected upstream backpressure, not a 500
+    expect(error).toBeInstanceOf(GitHubReleasesRefusedError)
+    const refused = error as GitHubReleasesRefusedError
+    expect(refused.statusCode).toBe(403)
+    expect(refused.code).toBe('GITHUB_RELEASES_REFUSED')
+    expect(refused.message).toContain('GITHUB_TOKEN is not set')
+  })
+
+  it("reports GitHub's secondary limit the same way when a token IS configured", async () => {
+    const { db } = createDb([])
+    const githubFetch = vi.fn().mockResolvedValue(new Response('slow down', { status: 429 }))
+
+    const error = await syncReleaseDownloadCounts(
+      createEnv(db, githubFetch, { GITHUB_TOKEN: 'ghp_test' })
+    ).catch((err: unknown) => err)
+
+    expect(error).toBeInstanceOf(GitHubReleasesRefusedError)
+    expect((error as GitHubReleasesRefusedError).statusCode).toBe(429)
+    // The remedy already applied, so triage must not be pointed at the token again.
+    expect((error as GitHubReleasesRefusedError).message).toContain('authenticated')
+    expect((error as GitHubReleasesRefusedError).message).not.toContain('GITHUB_TOKEN is not set')
+  })
+
+  it('keeps an unexpected GitHub failure a plain 500-level error', async () => {
+    const { db } = createDb([])
+    const githubFetch = vi.fn().mockResolvedValue(new Response('boom', { status: 500 }))
+
+    const error = await syncReleaseDownloadCounts(createEnv(db, githubFetch)).catch(
+      (err: unknown) => err
+    )
+
+    expect(error).not.toBeInstanceOf(GitHubReleasesRefusedError)
+    expect((error as Error).message).toBe('GitHub releases request failed with status 500')
   })
 
   it('does nothing when the API returns no usable assets', async () => {

--- a/apps/sync-server/src/services/release-downloads.ts
+++ b/apps/sync-server/src/services/release-downloads.ts
@@ -35,6 +35,35 @@ export interface ReleaseDownloadsEnv {
   fetch?: typeof fetch
 }
 
+/**
+ * GitHub answered and refused the read.
+ *
+ * A 403/429 from the Releases API is upstream backpressure, not a bug in this
+ * cron: unauthenticated calls are capped at 60 requests/hour PER IP and Workers
+ * egress from shared addresses, so other tenants spend the budget before our one
+ * daily request arrives. Configure the `GITHUB_TOKEN` worker secret (public-repo
+ * read scope is enough) for the authenticated 5,000/hour budget.
+ *
+ * `code` and `statusCode` are read by `captureServerError`, so this reports as a
+ * handled 4xx with its own error code instead of a 500-level `UNHANDLED_ERROR`
+ * every day. The message records whether a token was in play, which is the one
+ * thing triage needs to know first.
+ */
+export class GitHubReleasesRefusedError extends Error {
+  readonly code = 'GITHUB_RELEASES_REFUSED'
+  readonly statusCode: number
+
+  constructor(status: number, authenticated: boolean) {
+    super(
+      `GitHub releases request refused with status ${status} (${
+        authenticated ? 'authenticated' : 'unauthenticated — GITHUB_TOKEN is not set'
+      })`
+    )
+    this.name = 'GitHubReleasesRefusedError'
+    this.statusCode = status
+  }
+}
+
 interface AssetSnapshot {
   assetId: string
   releaseTag: string
@@ -94,6 +123,7 @@ const parseAssets = (payload: unknown): AssetSnapshot[] => {
 }
 
 const fetchReleaseAssets = async (env: ReleaseDownloadsEnv): Promise<AssetSnapshot[]> => {
+  const authenticated = Boolean(env.GITHUB_TOKEN)
   const response = await (env.fetch ?? fetch)(
     `${GITHUB_API}/repos/${RELEASES_REPO}/releases?per_page=${RELEASES_PER_PAGE}`,
     {
@@ -102,12 +132,19 @@ const fetchReleaseAssets = async (env: ReleaseDownloadsEnv): Promise<AssetSnapsh
         'user-agent': USER_AGENT,
         // Optional: unauthenticated GitHub API calls are limited to 60/hour per IP,
         // and Workers egress from shared addresses.
-        ...(env.GITHUB_TOKEN ? { authorization: `Bearer ${env.GITHUB_TOKEN}` } : {})
+        ...(authenticated ? { authorization: `Bearer ${env.GITHUB_TOKEN}` } : {})
       }
     }
   )
 
   if (!response.ok) {
+    // GitHub's own rate limiter answers 403 (budget spent) or 429 (secondary
+    // limit). Both are expected upstream conditions with a known remedy, so they
+    // get their own quiet code — see GitHubReleasesRefusedError. Anything else is
+    // a genuine unexpected failure and stays a 500.
+    if (response.status === 403 || response.status === 429) {
+      throw new GitHubReleasesRefusedError(response.status, authenticated)
+    }
     throw new Error(`GitHub releases request failed with status ${response.status}`)
   }
 


### PR DESCRIPTION
Tail of the 2026-08-09 → 08-19 production telemetry sweep. Five self-contained items; one hunk group per item, so they can be reviewed (or reverted) independently. The eight items the issue deliberately dismissed are left alone.

---

## 1. Empty `title` ZodError — an inline handler can now be named

**Was wrong.** `trackIpcError(handler.name || 'validated_handler', error)` labelled the event with the *inner handler's* function name. Handlers are registered as `ipcMain.handle(Channel, createValidatedHandler(Schema, async (input) => …))`, and an arrow passed straight in as an argument has `name === ''` — so **every** inline handler in the app collapsed into the single literal action `validated_handler`. The captured stack only names the bundled wrapper and Zod strips its own frames, so no amount of querying the existing events could name the channel.

**Changed.** The channel is known at exactly one place — the `ipcMain.handle` registration site — so that is where it is recorded. `installIpcChannelLabels()` (`apps/desktop/src/main/ipc/lib/ipc-channel-labels.ts`) wraps `ipcMain.handle` once, storing `listener → channel` in a `WeakMap` inside `validate.ts`; the wrapper reports that channel instead. `registerAllHandlers` installs it before the first registration. Behaviour is otherwise untouched — the real `handle` is always called with the same arguments — and a handler registered without the install keeps the old generic label.

This covers both registration styles (125 direct `createValidatedHandler` sites and 53 `registerCommand` sites) with one change instead of threading a channel argument through 178 call sites.

**Not fixed: the empty-title rejection itself.** It cannot honestly be fixed yet. Five contract schemas carry a bare `title: z.string().min(1)` (notes create/update, tasks create, calendar event create, inbox convert) and nothing on the wire distinguishes them. Guessing would mean changing a submit path at random. The next occurrence now reports e.g. `notes:create`, and the UI fix is a one-line follow-up once it does.

## 2. `release_download_counts` cron → GitHub 403

**Was wrong.** `GITHUB_TOKEN` is optional and is not set anywhere. Unauthenticated GitHub API calls are capped at 60/hour **per IP** and Workers egress from shared addresses, so other tenants spend the budget first. Every failure was reported as `UNHANDLED_ERROR` / `status_code: 500` / logged at `error` — a daily 500-level alarm for an expected upstream condition.

**Changed (code side).** A 403/429 from the Releases API now raises `GitHubReleasesRefusedError`, carrying `code: 'GITHUB_RELEASES_REFUSED'` and the upstream status, with a message recording whether a token was in play. The cron's `captureServerError` call no longer hardcodes `statusCode: 500`, so the error's own status is used and this lands as a handled 4xx logged at `warn`. Any other non-OK status stays a plain 500. Nothing else changes: the throw still happens before the D1 read/write, so the baseline is untouched and the next successful run emits the accumulated delta.

**⚠️ Needs configuration outside this repo — this is what actually stops the 403s.** A fine-grained PAT with public-repo read access only (no write scope), added as a Worker secret:

```bash
wrangler secret put GITHUB_TOKEN --env staging
wrangler secret put GITHUB_TOKEN --env production
```

No workflow uploads it — sync-server secrets are set by hand, which is the existing convention here. It is deliberately **not** added to the `requiredSecrets` fail-fast list: a missing token must not take the whole Worker down for a once-a-day measurement. Authenticated calls get 5,000/hour, so one daily request has enormous headroom.

## 3. CRDT snapshot 413

**Investigated first.** The snapshot is not a note that should never have grown that big — `SYNC_ITEM_MAX_ENCRYPT_BYTES` already caps note payloads at 5 MB, and a CRDT snapshot is full Y.Doc state (history and tombstones included), so it can legitimately exceed the note text by a wide margin. The defect is not the cap; it is that the two caps do not compose. `MAX_BODY_BYTES_SYNC` is 8 MiB and base64 inflates by 4/3, so any snapshot over ~6 MB decoded dies in the body-limit middleware **before** the route runs — and with it `handleCrdtSnapshotPush`'s `snapshot_rejected` event, the one carrying `totalBytes`. The only trace left was a bare 413 with no size in it.

**Changed.** The middleware emits that event itself for `/sync/crdt/snapshot` and `/sync/crdt/updates`, with `reason: 'body_limit_exceeded'` and the observed **encoded** body size. `isBodyWithinLimit` now returns the byte count it reached alongside the verdict — it still abandons the stream at the cap rather than buffering a payload it is about to reject, so for the streaming path the size is a lower bound. No limit was changed (raising one is safe, lowering is not; both are unchanged, so field clients are unaffected).

**User-facing message checked, no change needed.** The earlier "storage full" false-toast fix is intact: a bare `VALIDATION_BODY_TOO_LARGE` falls through both storage codes to `note_too_large`, and `emitNoteTooLarge(noteId)` already resolves the note title so the toast names the document (`sync.noteTooLargeNamed`). The prior art held.

## 4. Outlook SafeLinks noise

**Was wrong.** `Object Not Found Matching Id:N, MethodName:update, ParamCount:4` is Microsoft Office / Outlook SafeLinks pre-fetching a link out of an email, injecting its own scanner into the page, and then losing its own object handle. `MethodName` / `ParamCount` are COM bridge idioms that appear nowhere in this repo, and the event has no type and no usable stack.

**Changed.** A `before_send` filter on the landing site's posthog-js init drops it before it is queued. The issue's preferred option is a PostHog-side suppression rule (no deploy, reversible) — that is still worth adding and is not something the repo can do; this is the client-side fallback the issue names as option 2, and it is durable regardless. The match is deliberately narrow: only `/Object Not Found Matching Id:\d+, MethodName:update/`, checked against `$exception_values` / `$exception_list` / `$exception_message` on `$exception` events only. Other non-Error rejections, and every non-exception event, pass through untouched.

## 5. Vault `missing` severity

**Was wrong.** `emitIndexRecovered` logged at `warn` for all four `IndexHealth` reasons. `checkIndexHealth` returns `missing` when `index.db` simply is not on disk — the expected first open of a vault (fresh install, newly linked device, deleted file). The index is a fully derived cache, so the rebuild is the healthy path with no user impact. At `warn` it landed in the error dashboard and, across ~24 installs, read as the most widespread problem in the release.

**Changed.** `missing` emits at `info`; `corrupt` and `migration_failed` stay at `warn` — those genuinely are data-corruption recovery. The event is still emitted, with the same `index_recovered` action and the same `errorCode`, so anything querying it keeps working; only the level moves. `checkIndexHealth`'s rebuild trigger is untouched, as the issue requires.

---

## Backward compatibility

Telemetry-only or additive throughout. No schema, contract, protocol, vault-format or settings change. `snapshot_rejected` / `updates_rejected` keep their names and gain a new `reason` value; `index_recovered` keeps its action and error code; the IPC event's `action` becomes a channel name rather than the constant `validated_handler` (an insight filtering on that literal will need updating — that is the entire point of the change). No sync limit was raised or lowered, so payloads written by older app versions are accepted exactly as before.

## Verification

| Command | Result |
| --- | --- |
| `pnpm test:sync-server` | ✅ 62 files, 955 tests passed |
| `pnpm --filter @memry/desktop test:main` (full main project) | ✅ 533 files passed, 3 skipped; 6868 tests passed |
| `pnpm --filter @memry/landing test` | ✅ 65 tests passed |
| `pnpm --filter @memry/desktop typecheck:node` | ✅ pass |
| `pnpm --filter @memry/desktop typecheck:web` (via `pnpm typecheck`) | ✅ pass |
| `pnpm typecheck:sync-server` | ✅ pass |
| `pnpm --filter @memry/landing typecheck` | ✅ pass |
| `pnpm lint` | ✅ exit 0 (targeted `eslint --no-cache` on all changed files: 0 errors) |
| `pnpm check:architecture` / `pnpm check:contracts` | ✅ both pass |
| `pnpm docs:impact --base origin/main --strict` | ✅ covered |
| `pnpm docs:build` | ✅ build complete |

New tests, one group per item: channel attribution and its fallbacks (`validate.test.ts`, `ipc-channel-labels.test.ts`), the 403/429/500 split (`release-downloads.test.ts`), the body-limit diagnostic for snapshot / updates / non-CRDT paths (`sync-server/src/index.test.ts`), the SafeLinks predicate including its narrowness (`analytics.test.ts`), and the severity split by reason (`vault/index.test.ts`).

**Known red on `main`, not from this branch:** `pnpm typecheck` also reports two `onNavMiddleClick` errors in `apps/desktop/src/renderer/src/components/sidebar/sidebar-nav.test.tsx`. That file and its component are byte-identical to `origin/main` here and are untouched by this PR.

**One unrelated formatting line:** the pre-commit `lint-staged` prettier pass collapsed the `LandingCampaignKey` union in `analytics.ts`. That file already failed `prettier --check` on `origin/main`; the hook normalised it on the way in.

Fixes #1590