### PR TITLE
fix(crdt): an empty serialization of a non-empty note no longer empties its file

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -826,6 +826,82 @@ describe('findUnrepresentableNodes', () => {
 })
 
 /**
+ * An empty conversion of a non-empty document (#1475).
+ *
+ * `''` is the body of a note nobody has written in yet, so `yDocToMarkdown`
+ * cannot refuse every empty result — the write-back would then never write an
+ * emptied note. What it can refuse is an empty result from a fragment that
+ * plainly holds blocks: that is the repair pass having deleted the document,
+ * and writing it makes the loss the file's permanent content and replicates it.
+ */
+describe('a document that converts to nothing', () => {
+  /** Empties every `tableRow` in place — a row's cells lost to interleaving. */
+  function emptyTableRows(doc: Y.Doc): void {
+    const visit = (node: Y.XmlFragment | Y.XmlElement): void => {
+      for (const child of node.toArray()) {
+        const el = child as Y.XmlElement
+        if (typeof el.nodeName !== 'string') continue
+        if (el.nodeName === 'tableRow') el.delete(0, el.length)
+        else visit(el)
+      }
+    }
+    visit(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+  }
+
+  it('refuses to serialize a doc whose only block was deleted on the way out', async () => {
+    // #given a note holding one table, whose rows have been emptied — a
+    // childless `tableRow` fails ProseMirror's content check, so y-prosemirror
+    // deletes it, and the table and its container go with it
+    const doc = new Y.Doc()
+    const ok = await markdownToYFragment(
+      '| a | b |\n| --- | --- |\n| 1 | 2 |\n',
+      doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+    expect(ok).toBe(true)
+    emptyTableRows(doc)
+
+    // #when — the constructibility guard is silent here: `tableRow` IS a
+    // registered name, so nothing upstream stops this write
+    expect(findUnrepresentableNodes(doc)).toEqual([])
+    const result = await yDocToMarkdown(doc)
+
+    // #then the caller is told the conversion produced nothing usable, rather
+    // than handed the `''` that would empty the vault file
+    expect(result).toBeNull()
+  })
+
+  it('still returns an empty body for a note that has never been written in', async () => {
+    // #given the two shapes an untouched note actually has: a fragment with
+    // nothing in it, and the fragment an empty markdown file parses to
+    const untouched = new Y.Doc()
+    const emptyFile = new Y.Doc()
+    expect(await markdownToYFragment('', emptyFile.getXmlFragment(CRDT_FRAGMENT_NAME))).toBe(true)
+
+    // #when / #then — neither holds a block, so neither is a loss
+    expect(await yDocToMarkdown(untouched)).toBe('')
+    expect(await yDocToMarkdown(emptyFile)).toBe('')
+  })
+
+  it('leaves the doc untouched when it refuses', async () => {
+    // #given
+    const doc = new Y.Doc()
+    await markdownToYFragment(
+      '| a | b |\n| --- | --- |\n| 1 | 2 |\n',
+      doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+    emptyTableRows(doc)
+    const before = Y.encodeStateAsUpdate(doc)
+
+    // #when
+    expect(await yDocToMarkdown(doc)).toBeNull()
+
+    // #then the refusal is a read — the live doc still holds what it held, so a
+    // build that can serialize it still can
+    expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+  })
+})
+
+/**
  * The hole `findUnrepresentableNodes` does NOT cover, and what closed it (#1455).
  *
  * The guard asks whether this build can CONSTRUCT a node name, because that is

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -87,12 +87,40 @@ export async function yDocToMarkdown(
     Y.applyUpdate(snapshot, Y.encodeStateAsUpdate(doc))
     const editor = getEditor()
     const blocks = editor.yXmlFragmentToBlocks(snapshot.getXmlFragment(fragmentName))
-    if (blocks.length === 0) return ''
+    if (blocks.length === 0) {
+      // `''` is a real body — the body of a note that has never been written —
+      // so an empty result cannot simply be refused. It is only that body when
+      // the fragment is empty too: every block a note holds is a
+      // `blockContainer`, so a fragment that holds one and converts to no
+      // blocks means the repair pass deleted the whole document on the way out
+      // (an emptied `tableRow` fails `createChecked`, and
+      // `findUnrepresentableNodes` stays silent because it only asks whether
+      // the NAME is registered). Writing that empties the user's file and
+      // replicates it, so report it the way a failed conversion is reported.
+      // Read the ORIGINAL doc here, not the snapshot: the repair already ran
+      // over the snapshot and took the evidence with it.
+      if (holdsBlockContainer(doc.getXmlFragment(fragmentName))) {
+        log.error('Fragment holds blocks but converted to none, refusing to serialize')
+        return null
+      }
+      return ''
+    }
     return await blocksToMarkdownPreserving(editor, blocks as Block[])
   } catch (err) {
     log.error('Yjs-to-markdown conversion failed', err)
     return null
   }
+}
+
+/** True when the fragment holds at least one block, at any depth. Reads only. */
+function holdsBlockContainer(node: Y.XmlFragment | Y.XmlElement): boolean {
+  for (const child of node.toArray()) {
+    const el = child as Y.XmlElement
+    if (typeof el.nodeName !== 'string') continue
+    if (el.nodeName === 'blockContainer') return true
+    if (holdsBlockContainer(el)) return true
+  }
+  return false
 }
 
 /**
@@ -112,7 +140,9 @@ export async function yDocToMarkdown(
  * is registered, while `schema.node(name, attrs, children)` additionally throws
  * on invalid content and on a required attribute with no default. Measured: a
  * childless `tableRow` is a registered name, so nothing is reported here, and
- * `yDocToMarkdown` returns `''` for the whole document.
+ * the whole document converts to no blocks. That case is caught downstream
+ * instead — `yDocToMarkdown` refuses an empty conversion of a non-empty
+ * fragment rather than returning the `''` that would empty the file (#1475).
  *
  * One case worth naming, because it is the one this guard reads as safe: a spec
  * registered under a key that is not its `config.type`. ProseMirror builds the node (its name comes from

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -214,7 +214,7 @@ store from a machine that cannot start a child at all:
 - `binding` — the child ran but the native binding failed to load. The store
   was never opened.
 - `store` — the binding loaded and the probe died using it. The child also
-  announces each store operation *before* running it (`open`, `write`, `read`,
+  announces each store operation _before_ running it (`open`, `write`, `read`,
   `clear`, `close`), so a native abort — which unwinds nothing — still names
   the operation that was in flight.
 - `binding-in-use` — a `store` failure that reproduced against an empty
@@ -504,6 +504,14 @@ document to its vault `.md` file and re-indexes it for search.
   nothing, and the scan cannot see it. That invariant is enforced where it can be, at
   schema construction in `@memry/editor-schema`: a mis-keyed spec fails the schema build
   in both processes instead of quietly dropping content on the next write-back.
+- **An empty serialization of a note that is not empty is refused** — empty markdown is a
+  real body, the body of a note nobody has written in, so the pass cannot simply reject
+  every empty result. It uses the document's own emptiness to tell them apart: every block
+  a note holds is a `blockContainer`, so a fragment that holds one and converts to no
+  blocks means the converter's repair deleted the whole document on the way out. The scan
+  above stays silent for that — an emptied table row is still a registered node name — so
+  without this the emptied file would be written and replicated. The pass keeps the file
+  instead, and reports it the way it reports a failed conversion.
 
 While a write-back is queued or mid-write the `.md` file is knowingly behind the Y.Doc, so
 markdown-as-truth readers (task checkbox reconciliation) stand down for that window. Search


### PR DESCRIPTION
Closes #1475.

## What was wrong

`yDocToMarkdown` returned `''` — not `null` — when the whole document failed to convert, and `performWriteback` handles `null` but not `''`. The empty string fell through to the write, the note's `.md` was emptied, and the next index pass replicated that to every device.

## Reproduced first

A table-only note whose `tableRow` has been emptied:

```
findUnrepresentableNodes(doc) -> []       # guard silent
yDocToMarkdown(doc)           -> ""       # was "| a | b |\n| - | - |\n| 1 | 2 |"
```

The guard is silent because it asks whether the node **name** is registered, and `tableRow` is — but a childless one fails ProseMirror's content check, so y-prosemirror deletes it, and the table and its container go with it. Reachable through version skew on a block's `content`, or two devices concurrently deleting a row's cells.

## The fix

`''` is a legitimate body — the body of a note nobody has written in — so the guard cannot refuse every empty result, or an emptied note would never be written. The document's own emptiness is the discriminator: every block a note holds is a `blockContainer`, so a fragment holding one that converts to **zero** blocks means the repair pass deleted the document. That now returns `null`, which `performWriteback` already handles by keeping the file and reporting `conversion_null`.

Two details:

- The check reads the **original** doc, not the snapshot — the repair already ran over the snapshot and took the evidence with it.
- It runs only on the zero-block path, so the write-back hot path is unchanged (no extra traversal per pass).

## Tests

`blocknote-converter.test.ts`, against the real converter — the write-back suite mocks the converter out, so a test there would have proved nothing:

- emptied `tableRow` → `null`, with the constructibility guard asserted silent
- untouched doc **and** empty-markdown-seeded doc (fragment with a bare `blockGroup`, no containers) → still `''`
- the refusal does not mutate the doc

**Mutation check:** reverting to `if (blocks.length === 0) return ''` fails 2 of the 3.

## Verification

- `test:main` (sync + test-hooks): 2328 passed, 1 skipped
- `typecheck:node` 0 · `typecheck:test:node` 0 · eslint 0 · `git diff --check` clean
- `docs:impact --strict`: covered

`typecheck:test`'s web half fails on `sidebar-nav.test.tsx` — pre-existing on main, unrelated to these files.

## Out of scope

The issue's "worth considering" idea — capturing BlockNote's `console.warn` around `yXmlFragmentToBlocks` to catch the whole partial-loss class in one guard — is not here. It is a wider change and overlaps #1455. Also unaddressed, and separate: partial loss where the document still converts to *some* blocks (a broken table inside a longer note drops the table and keeps the rest, measured while investigating this).