### PR TITLE
fix(sync): a body-only #hashtag survives a remote note update

### DIFF
--- a/apps/desktop/src/main/sync/item-handlers/note-handler.body-tags.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.body-tags.test.ts
@@ -1,0 +1,213 @@
+/**
+ * A push payload carries a note's *frontmatter* tags only, while the index it
+ * lands in holds frontmatter ∪ body `#hashtags` — and the receiving side
+ * replaces. Without a merge, a tag that exists only as a body hashtag is wiped
+ * from the second device's index on every remote update: the note silently
+ * drops out of tag search and the tag hub while its file stays intact (#1471).
+ *
+ * These run against real note files and the real frontmatter parser, so the
+ * merge is actually exercised rather than mocked away — `setNoteTags` is the
+ * only seam, because it is the assertion.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import { noteMetadata } from '@memry/db-schema/schema/note-metadata'
+import type { ApplyContext, DrizzleDb } from './types'
+
+const VAULT_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-note-body-tags-'))
+
+let dataDb: TestDatabaseResult
+
+vi.mock('../../database', () => ({ getDatabase: () => dataDb.db }))
+
+vi.mock('../../database/client', () => ({
+  getIndexDatabase: vi.fn(() => ({}))
+}))
+
+const mockGetNoteTags = vi.fn<() => string[]>(() => [])
+vi.mock('@main/database/queries/notes', () => ({
+  getNoteCacheById: vi.fn(() => undefined),
+  getNoteCacheByPath: vi.fn(() => undefined),
+  getNoteTags: () => mockGetNoteTags(),
+  setNoteTags: vi.fn(),
+  updateNoteCache: vi.fn(),
+  setNoteProperties: vi.fn()
+}))
+
+vi.mock('../../vault/notes', () => ({
+  getVaultRoot: vi.fn(() => VAULT_ROOT),
+  toRelativePath: vi.fn((p: string) => path.relative(VAULT_ROOT, p)),
+  toAbsolutePath: vi.fn((p: string) => path.join(VAULT_ROOT, p))
+}))
+
+vi.mock('../../vault/index', () => ({
+  getStatus: vi.fn(() => ({ path: VAULT_ROOT }))
+}))
+
+vi.mock('../../vault/note-sync', () => ({
+  syncNoteToCache: vi.fn(),
+  syncFileToCache: vi.fn(),
+  deleteNoteFromCache: vi.fn()
+}))
+
+vi.mock('../note-sync', () => ({
+  extractFolderFromPath: vi.fn(() => null)
+}))
+
+vi.mock('../crdt-writeback', () => ({ markWritebackIgnored: vi.fn() }))
+
+vi.mock('@memry/domain-notes', () => ({ saveCanonicalPropertyDefinition: vi.fn() }))
+
+vi.mock('../../tasks/runtime-effects', () => ({ syncProjectUpdate: vi.fn() }))
+
+import { noteHandler } from './note-handler'
+import { setNoteTags } from '@main/database/queries/notes'
+import { NotesChannels } from '@memry/contracts/ipc-channels'
+
+const NOTE_PATH = 'n1.md'
+const REMOTE_CLOCK = { 'device-A': 1, 'device-B': 1 }
+
+function seedNote(fileContent: string, indexTags: string[]): void {
+  dataDb.db
+    .insert(noteMetadata)
+    .values({
+      id: 'n1',
+      path: NOTE_PATH,
+      title: 'n1',
+      fileType: 'markdown',
+      clock: { 'device-A': 1 },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      modifiedAt: '2026-01-01T00:00:00.000Z'
+    })
+    .run()
+
+  fs.mkdirSync(VAULT_ROOT, { recursive: true })
+  fs.writeFileSync(path.join(VAULT_ROOT, NOTE_PATH), fileContent, 'utf-8')
+  mockGetNoteTags.mockReturnValue(indexTags)
+}
+
+function readNoteFile(): string {
+  return fs.readFileSync(path.join(VAULT_ROOT, NOTE_PATH), 'utf-8')
+}
+
+/** The note's frontmatter block alone — body hashtags must not be asserted against. */
+function readFrontmatter(): string {
+  return readNoteFile().split('---')[1] ?? ''
+}
+
+describe('noteHandler.applyUpsert — body hashtags on a synced update', () => {
+  let ctx: ApplyContext
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dataDb = createTestDataDb()
+    ctx = { db: dataDb.db as unknown as DrizzleDb, emit: vi.fn() }
+    fs.rmSync(VAULT_ROOT, { recursive: true, force: true })
+  })
+
+  afterEach(() => {
+    dataDb.close()
+  })
+
+  afterAll(() => {
+    fs.rmSync(VAULT_ROOT, { recursive: true, force: true })
+  })
+
+  it('keeps a body-only hashtag in the index when the remote payload carries no tags', () => {
+    // #given — the tag lives only in the body, so the sender's payload is empty
+    seedNote('---\ntitle: n1\n---\n\nsome body with #work in it\n', ['work'])
+
+    // #when
+    const result = noteHandler.applyUpsert(
+      ctx,
+      'n1',
+      { tags: [], clock: REMOTE_CLOCK },
+      REMOTE_CLOCK
+    )
+
+    // #then — the index keeps the tag instead of being replaced with []
+    expect(result).toBe('applied')
+    expect(setNoteTags).toHaveBeenCalledWith({}, 'n1', ['work'])
+    // …and nothing body-derived is written back into frontmatter (#1454)
+    expect(readFrontmatter()).not.toMatch(/tags:/)
+  })
+
+  it('merges remote frontmatter tags with the local body hashtag', () => {
+    // #given
+    seedNote('---\ntitle: n1\n---\n\nsome body with #work in it\n', ['work'])
+
+    // #when — the other device adds a frontmatter tag
+    const result = noteHandler.applyUpsert(
+      ctx,
+      'n1',
+      { tags: ['roadmap'], clock: REMOTE_CLOCK },
+      REMOTE_CLOCK
+    )
+
+    // #then — index carries both; the file's frontmatter carries only the remote half
+    expect(result).toBe('applied')
+    expect(setNoteTags).toHaveBeenCalledWith({}, 'n1', ['roadmap', 'work'])
+    const frontmatter = readFrontmatter()
+    expect(frontmatter).toMatch(/roadmap/)
+    expect(frontmatter).not.toMatch(/work/)
+  })
+
+  it('dedupes case-insensitively with the frontmatter spelling winning', () => {
+    // #given — one tag spelled differently on each side, plus a body-only one
+    seedNote('---\ntitle: n1\n---\n\nbody with #Work and #focus\n', ['Work', 'focus'])
+
+    // #when
+    noteHandler.applyUpsert(ctx, 'n1', { tags: ['work'], clock: REMOTE_CLOCK }, REMOTE_CLOCK)
+
+    // #then — one entry for the shared tag, spelled as the frontmatter has it
+    expect(setNoteTags).toHaveBeenCalledWith({}, 'n1', ['work', 'focus'])
+  })
+
+  it('carries the merged tags on the emitted update, not the remote half alone', () => {
+    // #given — the renderer refreshes its tag list from this payload
+    seedNote('---\ntitle: n1\n---\n\nbody with #work\n', ['work'])
+
+    // #when
+    noteHandler.applyUpsert(ctx, 'n1', { tags: ['roadmap'], clock: REMOTE_CLOCK }, REMOTE_CLOCK)
+
+    // #then
+    expect(ctx.emit).toHaveBeenCalledWith(
+      NotesChannels.events.UPDATED,
+      expect.objectContaining({
+        changes: expect.objectContaining({ tags: ['roadmap', 'work'] })
+      })
+    )
+  })
+
+  it('keeps the body hashtag after a remote rename moves the file', () => {
+    // #given — the merge reads the file, which this update also renames
+    seedNote('---\ntitle: n1\n---\n\nbody with #work\n', ['work'])
+
+    // #when
+    const result = noteHandler.applyUpsert(
+      ctx,
+      'n1',
+      { title: 'Renamed', tags: ['roadmap'], clock: REMOTE_CLOCK },
+      REMOTE_CLOCK
+    )
+
+    // #then — read from the new path, not the unlinked old one
+    expect(result).toBe('applied')
+    expect(setNoteTags).toHaveBeenCalledWith({}, 'n1', ['roadmap', 'work'])
+  })
+
+  it('falls back to the remote tags when the note file cannot be read', () => {
+    // #given — index row without a file on disk
+    seedNote('---\n---\nbody\n', ['stale'])
+    fs.rmSync(path.join(VAULT_ROOT, NOTE_PATH))
+
+    // #when
+    noteHandler.applyUpsert(ctx, 'n1', { tags: ['roadmap'], clock: REMOTE_CLOCK }, REMOTE_CLOCK)
+
+    // #then — no merge is possible, but the remote half still lands
+    expect(setNoteTags).toHaveBeenCalledWith({}, 'n1', ['roadmap'])
+  })
+})

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.test.ts
@@ -24,6 +24,9 @@ vi.mock('../../vault/frontmatter', () => ({
   })),
   serializeNote: vi.fn(() => '---\n---\ncontent'),
   serializeParsedNote: vi.fn(() => '---\n---\ncontent'),
+  // No body hashtags in this suite's fixtures — the real body-tag merge is
+  // covered against real files in note-handler.body-tags.test.ts.
+  extractInlineTagsFromMarkdown: vi.fn(() => []),
   inferPropertyType: vi.fn(() => 'number'),
   resolvePropertyType: vi.fn(
     (

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.ts
@@ -30,6 +30,7 @@ import {
   parseNote,
   serializeNote,
   serializeParsedNote,
+  extractInlineTagsFromMarkdown,
   inferPropertyType,
   resolvePropertyType,
   type NoteFrontmatter
@@ -83,6 +84,35 @@ async function removeEmptyParents(dir: string, stopAt: string): Promise<void> {
       break
     }
   }
+}
+
+/**
+ * Remote frontmatter tags ∪ the body `#hashtags` of this device's copy of the
+ * note, merged case-insensitively with the frontmatter spelling winning — the
+ * same merge `extractNoteMetadata` performs when indexing a note from disk.
+ *
+ * A push payload carries frontmatter tags only, so a tag that exists solely as
+ * a body hashtag never leaves the sending device. Re-deriving that half here is
+ * what keeps the receiving side's replace from wiping it out of the index; the
+ * body is the same on both devices, so nothing has to be asked of the sender —
+ * and nothing body-derived leaks back into frontmatter (#1471).
+ */
+function mergeWithLocalBodyTags(remoteTags: string[], relPath: string): string[] {
+  let bodyTags: string[]
+  try {
+    const parsed = parseNote(fs.readFileSync(toAbsolutePath(relPath), 'utf-8'))
+    bodyTags = extractInlineTagsFromMarkdown(parsed.content)
+  } catch {
+    log.warn('Could not read note body to merge its inline tags', { path: relPath })
+    return remoteTags
+  }
+
+  const byKey = new Map<string, string>()
+  for (const tag of [...remoteTags, ...bodyTags]) {
+    const key = tag.toLowerCase()
+    if (!byKey.has(key)) byKey.set(key, tag)
+  }
+  return [...byKey.values()]
 }
 
 // Session-scoped guard so re-applying the same note (steady-state pulls) does
@@ -418,8 +448,17 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
         }
       }
 
-      if (tagsChanged && remoteTags) {
-        setNoteTags(indexDb, itemId, remoteTags)
+      // The index holds frontmatter ∪ body tags, but the payload only ever
+      // carries the sender's frontmatter half, and `setNoteTags` replaces.
+      // Re-derive the body half from the file (already at its new path if this
+      // update moved it) so a body-only `#hashtag` survives a remote update.
+      const indexTags =
+        tagsChanged && remoteTags
+          ? mergeWithLocalBodyTags(remoteTags, updateFields.path ?? existing.path)
+          : undefined
+
+      if (indexTags) {
+        setNoteTags(indexDb, itemId, indexTags)
       }
 
       if (propertiesPresent) {
@@ -496,7 +535,7 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
         changes: {
           title: newTitle,
           emoji: resolvedEmoji,
-          ...(tagsChanged && remoteTags ? { tags: remoteTags } : {})
+          ...(indexTags ? { tags: indexTags } : {})
         },
         source: 'sync'
       })

--- a/apps/docs/src/user-guide/notes/properties-tags.md
+++ b/apps/docs/src/user-guide/notes/properties-tags.md
@@ -187,6 +187,12 @@ your tags in the body the way an Obsidian vault often does.
 Adding or removing an inline tag while editing still updates the note's tags, as it always
 has. Only _opening_ a note is now a read.
 
+Body tags hold up across devices too. A note's tags sync as its `tags:` frontmatter, so a tag
+that lives only in the body isn't part of what travels — each device reads it back out of the
+note's own text instead, and a note edited elsewhere keeps its inline tags here rather than
+dropping out of the sidebar and tag search until the vault is re-indexed. Nothing is written
+into your frontmatter to make that work.
+
 ::: tip
 Notes that already had a `tags:` block added by an earlier version keep it. An injected block
 is indistinguishable from one you wrote yourself, so nothing tries to unpick it — delete the


### PR DESCRIPTION
Closes #1471.

## The bug

A note's tags sync as its `tags:` frontmatter — `buildNotePushPayload` reads `parsed.frontmatter.tags ?? []` and nothing else. The index those tags land in holds frontmatter ∪ body (`extractNoteMetadata`), and `applyUpsert` replaced it outright:

```ts
setNoteTags(indexDb, itemId, remoteTags)
```

So a tag that exists only as a body `#hashtag` never left the sending device, and every remote update wiped it from the receiving device's index. The note silently dropped out of tag search and the tag hub; the file was untouched, and only a re-index — which nothing prompts — brought it back.

This started biting once #1454 correctly stopped injecting body tags into frontmatter on open: before that, opening a note put the tag where the payload could see it. It hits precisely the Obsidian-style body-tag vaults #1454 exists for.

## The fix

The body is identical on both devices, so the receiving side re-derives that half rather than asking the sender for it. `mergeWithLocalBodyTags` reads the note's own file, runs `extractInlineTagsFromMarkdown` over it, and merges case-insensitively with the frontmatter spelling winning — the same merge `extractNoteMetadata` performs when indexing from disk. If the file can't be read it falls back to the remote tags, so a missing file can't make things worse than today.

The emitted `notes:updated` carries the merged list for the same reason: the renderer refreshes its tag list from it.

The push payload is deliberately left alone. Sending merged tags would be simpler, but it hands the receiving device tags it then writes into *its* frontmatter — reintroducing #1454's bug across devices.

## Compatibility

Payload shape, schema, and the sync protocol are unchanged; this is receive-side derivation only. An older client on the other end is unaffected, and a device that never re-indexes recovers its body tags on the next update it pulls.

## Tests

`note-handler.body-tags.test.ts` — real note files and the real frontmatter parser, with `setNoteTags` as the only seam because it's the assertion. (The existing suite mocks `vault/frontmatter` wholesale, which is why the merge can't be observed there; the issue flagged exactly this.)

- body-only hashtag survives a payload carrying no tags, and nothing lands in frontmatter
- remote frontmatter tag merges with the local body tag; frontmatter still carries only the remote half
- case-insensitive dedupe, frontmatter spelling winning
- the emitted update carries the merged list, not the remote half alone
- the merge reads the new path when the same update renames the file
- unreadable file falls back to the remote tags

Mutating `mergeWithLocalBodyTags(...)` back to `remoteTags` turns 5 of the 6 red.

## Verification

- `vitest --project main src/main/sync` — 158 files, 2323 tests green
- `typecheck:node` green, eslint clean, `docs:impact --strict` covered, `docs:build` green
- `typecheck:test` is red on `sidebar-nav.test.tsx` (`onNavMiddleClick`) and `test:main` has 4 reds in `check-cert-hashes-config` / `fts-corruption` — all pre-existing on main, none touched here
