### PR TITLE
fix(notes): an attachment embed is written relative to its note, so it survives a second device

### DIFF
--- a/apps/desktop/src/main/inbox/filing.ts
+++ b/apps/desktop/src/main/inbox/filing.ts
@@ -28,7 +28,7 @@ import { getFileType } from '@memry/shared/file-types'
 import { getStatus } from '../vault/index'
 import { inboxItems, inboxItemTags, filingHistory } from '@memry/db-schema/schema/inbox'
 import { generateId } from '../lib/id'
-import { normalizeRelativePath } from '../lib/paths'
+import { noteRelativeRef, normalizeRelativePath } from '../lib/paths'
 import { eq } from 'drizzle-orm'
 import {
   InboxChannels,
@@ -1143,18 +1143,13 @@ function attachmentFilenameFromUrl(url: string): string {
 }
 
 /**
- * A markdown ref from `notePath` to a file at `targetPath`, both vault-relative.
- *
- * Relative to the *note*, not the vault: that is what the editor resolves at
- * render time (`resolve-note-relative-url.ts`) and what keeps the vault
- * readable by Obsidian. A `memry-file://` URL would render here and break on
- * every other device, since it carries this machine's absolute path.
+ * A markdown-safe ref from `notePath` to a file at `targetPath`, both
+ * vault-relative. The path math is shared with `saveAttachment`; only the
+ * percent-encoding is added here, since this one is spliced straight into
+ * `![alt](...)` where a space or paren would truncate the link.
  */
-function noteRelativeRef(notePath: string, targetPath: string): string {
-  const noteDir = path.posix.dirname(normalizeRelativePath(notePath))
-  const from = noteDir === '.' ? '' : noteDir
-  const relative = path.posix.relative(from, normalizeRelativePath(targetPath))
-  return encodeAttachmentUrl(relative)
+function noteRelativeMarkdownRef(notePath: string, targetPath: string): string {
+  return encodeAttachmentUrl(noteRelativeRef(notePath, targetPath))
 }
 
 /**
@@ -1197,7 +1192,7 @@ async function embedImageInNotes(
   const inboxCapturesRegex = /^## Inbox Captures$/m
 
   for (const targetNote of targetNotes) {
-    const entry = `![${alt}](${noteRelativeRef(targetNote.path, attachmentRelativePath)})\n*(${dateStr})*`
+    const entry = `![${alt}](${noteRelativeMarkdownRef(targetNote.path, attachmentRelativePath)})\n*(${dateStr})*`
     const updatedContent = inboxCapturesRegex.test(targetNote.content)
       ? targetNote.content.replace(/^(## Inbox Captures)$/m, `$1\n\n${entry}`)
       : `${targetNote.content.trimEnd()}\n\n## Inbox Captures\n\n${entry}`

--- a/apps/desktop/src/main/lib/paths.test.ts
+++ b/apps/desktop/src/main/lib/paths.test.ts
@@ -10,6 +10,7 @@ import {
   getTitleFromPath,
   safeJoin,
   ensureMarkdownExtension,
+  noteRelativeRef,
   toMemryFileUrl,
   fromMemryFileUrl
 } from './paths'
@@ -105,5 +106,37 @@ describe('paths utils', () => {
     const url = toMemryFileUrl(original)
     const restored = fromMemryFileUrl(url)
     expect(restored).toBe(original)
+  })
+})
+
+describe('noteRelativeRef', () => {
+  it('climbs out of the note folder to reach the attachments tree', () => {
+    expect(noteRelativeRef('notes/Meeting.md', 'attachments/note123/abc-plan.pdf')).toBe(
+      '../attachments/note123/abc-plan.pdf'
+    )
+  })
+
+  it('needs no climb for a note at the vault root', () => {
+    expect(noteRelativeRef('Meeting.md', 'attachments/note123/abc-plan.pdf')).toBe(
+      'attachments/note123/abc-plan.pdf'
+    )
+  })
+
+  it('climbs once per nested folder', () => {
+    expect(noteRelativeRef('notes/work/q3/Review.md', 'attachments/n/x.png')).toBe(
+      '../../../attachments/n/x.png'
+    )
+  })
+
+  it('keeps the shared prefix instead of climbing past it', () => {
+    expect(noteRelativeRef('notes/Trip.md', 'notes/images/photo.png')).toBe('images/photo.png')
+  })
+
+  // A ref goes into markdown, where a backslash is not a path separator. Windows
+  // hands back `notes\Trip.md` from path APIs, so both sides normalize first.
+  it('emits forward slashes for a Windows-shaped input', () => {
+    expect(noteRelativeRef('notes\\work\\Trip.md', 'attachments\\n\\x.png')).toBe(
+      '../../attachments/n/x.png'
+    )
   })
 })

--- a/apps/desktop/src/main/lib/paths.ts
+++ b/apps/desktop/src/main/lib/paths.ts
@@ -41,6 +41,24 @@ export function getRelativePath(vaultPath: string, filePath: string): string | n
 }
 
 /**
+ * A vault-relative target expressed relative to the note that references it.
+ *
+ * Relative to the *note*, not the vault: that is what the editor resolves at
+ * render time (`renderer/lib/resolve-note-relative-url.ts`) and what keeps the
+ * vault readable by Obsidian. An absolute `memry-file://` URL renders on the
+ * machine that wrote it and nowhere else, since it carries that machine's vault
+ * path — see `resolve-embed.ts`, which picks the same shape for the same reason.
+ *
+ * Both arguments are vault-relative; the result always uses forward slashes,
+ * because it goes into markdown rather than onto a Windows command line.
+ */
+export function noteRelativeRef(notePath: string, targetPath: string): string {
+  const noteDir = path.posix.dirname(normalizeRelativePath(notePath))
+  const from = noteDir === '.' ? '' : noteDir
+  return path.posix.relative(from, normalizeRelativePath(targetPath))
+}
+
+/**
  * Checks if a path is safely within the vault directory.
  */
 export function isPathInVault(vaultPath: string, filePath: string): boolean {

--- a/apps/desktop/src/main/vault/attachments.test.ts
+++ b/apps/desktop/src/main/vault/attachments.test.ts
@@ -17,6 +17,7 @@ import {
   getNoteAttachmentsDir,
   getAttachmentPath,
   getAbsoluteAttachmentUrl,
+  getAttachmentRef,
   generateUniqueFilename,
   saveAttachment,
   deleteAttachment,
@@ -198,6 +199,20 @@ describe('formatFileSize', () => {
 // generateUniqueFilename Tests (T392)
 // ============================================================================
 
+describe('getAttachmentRef', () => {
+  it('returns a note-relative ref when the note path is known', () => {
+    expect(getAttachmentRef('/vault', 'note123', 'x.png', 'notes/Meeting.md')).toBe(
+      '../attachments/note123/x.png'
+    )
+  })
+
+  it('returns an absolute URL when it is not', () => {
+    expect(getAttachmentRef('/vault', 'note123', 'x.png', undefined)).toBe(
+      getAbsoluteAttachmentUrl('/vault', 'note123', 'x.png')
+    )
+  })
+})
+
 describe('generateUniqueFilename', () => {
   it('T392: generates unique filename with prefix', () => {
     const result = generateUniqueFilename('my-image.png')
@@ -304,6 +319,47 @@ describe('attachment operations', () => {
       expect(result.error).toContain('too large')
     })
 
+    it('references the attachment relative to the note that owns it', async () => {
+      // The whole point of #1488: an absolute URL carries this machine's vault
+      // path, so the same note on a second device resolves it to nothing.
+      const result = await saveAttachment('note123', Buffer.from('data'), 'plan.pdf', {
+        notePath: 'notes/Meeting.md'
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.path).toMatch(/^\.\.\/attachments\/note123\/[a-z0-9]{6}-plan\.pdf$/)
+      expect(result.path).not.toContain('memry-file://')
+      expect(result.path).not.toContain(tempVault.path)
+    })
+
+    it('climbs once per folder between the note and the attachments tree', async () => {
+      const result = await saveAttachment('note123', Buffer.from('data'), 'plan.pdf', {
+        notePath: 'notes/work/q3/Review.md'
+      })
+
+      expect(result.path?.startsWith('../../../attachments/note123/')).toBe(true)
+    })
+
+    it('falls back to an absolute URL when the note path is unknown', async () => {
+      // Not a failure: this is what every attachment carried before the ref
+      // became note-relative, so an unindexed note is left no worse off.
+      const result = await saveAttachment('note123', Buffer.from('data'), 'plan.pdf')
+
+      expect(result.success).toBe(true)
+      expect(result.path?.startsWith('memry-file://')).toBe(true)
+    })
+
+    it('writes the bytes under the note folder whichever ref shape it returns', async () => {
+      const result = await saveAttachment('note123', Buffer.from('data'), 'plan.pdf', {
+        notePath: 'notes/Meeting.md'
+      })
+
+      const filename = path.basename(result.path!)
+      expect(fs.existsSync(path.join(tempVault.path, 'attachments', 'note123', filename))).toBe(
+        true
+      )
+    })
+
     it('saves a 60MB PDF that no sync plan would accept', async () => {
       // The whole point of the 100MB cap: this file is far past every plan's
       // per-file sync limit, and it still lands in the vault. Sync refuses it
@@ -368,6 +424,18 @@ describe('attachment operations', () => {
       expect(attachments.length).toBe(2)
       expect(attachments.some((a) => a.type === 'image')).toBe(true)
       expect(attachments.some((a) => a.type === 'file')).toBe(true)
+    })
+
+    it('keeps absolute URLs, unlike the ref a note carries', async () => {
+      // This listing answers "where is this file on this machine" for IPC/MCP
+      // callers; nothing writes it into a note, so it must stay openable as-is.
+      await saveAttachment('note123', Buffer.from('data'), 'image.png', {
+        notePath: 'notes/Meeting.md'
+      })
+
+      const [attachment] = await listNoteAttachments('note123')
+
+      expect(attachment.path.startsWith('memry-file://')).toBe(true)
     })
 
     it('T394: returns empty array for note without attachments', async () => {

--- a/apps/desktop/src/main/vault/attachments.ts
+++ b/apps/desktop/src/main/vault/attachments.ts
@@ -10,7 +10,9 @@ import { existsSync } from 'fs'
 import path from 'path'
 import { customAlphabet } from 'nanoid'
 import { ensureDirectory, sanitizeFilename } from './file-ops'
-import { toMemryFileUrl } from '../lib/paths'
+import { noteRelativeRef, toMemryFileUrl } from '../lib/paths'
+import { getIndexDatabase } from '../database'
+import { getNoteCacheById } from '../database/queries/notes/note-crud'
 import { getStatus } from './index'
 import { VaultError, VaultErrorCode } from '../lib/errors'
 import { createLogger } from '../lib/logger'
@@ -97,11 +99,22 @@ export interface SaveAttachmentOptions {
    * executables.
    */
   extraAllowedExtensions?: string[]
+  /**
+   * The owning note's vault-relative path, for callers that already know it.
+   * Everyone else gets the index lookup in {@link resolveNotePath}; the option
+   * exists for the window where the note is written but not yet indexed.
+   */
+  notePath?: string
 }
 
 export interface AttachmentResult {
   success: boolean
-  /** Relative path from note to attachment (e.g., ../attachments/{noteId}/abc123-image.png) */
+  /**
+   * How the note should reference the file it just saved — see
+   * {@link getAttachmentRef}. Note-relative
+   * (`../attachments/{noteId}/abc123-image.png`) whenever the note's own path is
+   * known, and an absolute `memry-file://` URL when it is not.
+   */
   path?: string
   /** Original filename */
   name?: string
@@ -117,6 +130,12 @@ export interface AttachmentResult {
 
 export interface AttachmentInfo {
   filename: string
+  /**
+   * Absolute `memry-file://` URL, unlike {@link AttachmentResult.path}. Nothing
+   * writes this into a note — it answers "where is this file on this machine"
+   * for the IPC/MCP listing, so it stays directly openable rather than needing
+   * a note to resolve against.
+   */
   path: string
   size: number
   mimeType: string
@@ -233,6 +252,50 @@ export function getAbsoluteAttachmentUrl(
 }
 
 /**
+ * The owning note's vault-relative path, or undefined when nothing knows it.
+ *
+ * The index is the only thing that maps a note id back to a path here, and it
+ * is legitimately empty for a note that has not been indexed yet — an importer
+ * saving assets before the note is written, most of all. That is not an error:
+ * the caller falls back to an absolute URL, which is what every attachment
+ * carried before this became note-relative.
+ */
+function resolveNotePath(noteId: string): string | undefined {
+  try {
+    return getNoteCacheById(getIndexDatabase(), noteId)?.path
+  } catch (error) {
+    logger.warn('Note path lookup failed; attachment stays absolute', { noteId, error })
+    return undefined
+  }
+}
+
+/**
+ * How a note references an attachment that was just saved for it.
+ *
+ * Note-relative when the note's path is known, because that is the only shape
+ * that survives reaching a second device: an absolute `memry-file://` URL
+ * carries this machine's vault path, so on any other install it resolves to
+ * nothing — a broken image, or a PDF card that cannot load.
+ *
+ * The absolute fallback is deliberate rather than a failure: it is exactly what
+ * this returned before, so a note whose path we cannot resolve is left no worse
+ * off than it already was. It is logged so "some attachments are still
+ * absolute" is a question with an answer.
+ */
+export function getAttachmentRef(
+  vaultPath: string,
+  noteId: string,
+  filename: string,
+  notePath: string | undefined
+): string {
+  if (!notePath) {
+    logger.warn('Attachment written with an absolute URL: note path unknown', { noteId })
+    return getAbsoluteAttachmentUrl(vaultPath, noteId, filename)
+  }
+  return noteRelativeRef(notePath, `attachments/${noteId}/${filename}`)
+}
+
+/**
  * Generate a unique filename with prefix
  * Format: {6-char-prefix}-{sanitized-original-name}
  */
@@ -330,10 +393,15 @@ export async function saveAttachment(
     // Write file
     await writeFile(filePath, data)
 
-    // Return success with metadata (using absolute file:// URL for Electron)
+    // Return success with metadata; `path` is the ref the note will carry.
     return {
       success: true,
-      path: getAbsoluteAttachmentUrl(vaultPath, noteId, uniqueFilename),
+      path: getAttachmentRef(
+        vaultPath,
+        noteId,
+        uniqueFilename,
+        options?.notePath ?? resolveNotePath(noteId)
+      ),
       name: originalFilename,
       size: data.length,
       mimeType: getMimeType(originalFilename),

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -59,6 +59,7 @@ import { useEditorTeardown } from '@/hooks/use-editor-teardown'
 import { useFeatureFlags } from '@/hooks/use-feature-flags'
 import { vaultService } from '@/services/vault-service'
 import { createNoteFileUrlResolver } from '@/lib/create-note-file-url-resolver'
+import { NoteFileUrlProvider } from './note-file-url-context'
 import {
   ReviewFormattingToolbar,
   ReviewFormattingToolbarController
@@ -352,10 +353,32 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     notePathRef.current = notePath
   }, [notePath])
 
+  // Only `pages/note.tsx` passes `notePath`; the journal, canvas cards and a
+  // project's home note mount this editor knowing only the note's id. Since
+  // attachments are now written relative to their note wherever they are saved,
+  // those surfaces need the path too — one lookup per note, reused by every
+  // block in it, and re-fetched when the mounted note changes.
+  const notePathLookupRef = useRef<{ noteId: string; path: Promise<string | undefined> } | null>(
+    null
+  )
+  const fetchNotePath = useCallback(async (): Promise<string | undefined> => {
+    const id = noteIdRef.current
+    if (!id) return undefined
+    const cached = notePathLookupRef.current
+    if (cached?.noteId === id) return cached.path
+    const lookup = notesService
+      .get(id)
+      .then((note) => note?.path)
+      .catch(() => undefined)
+    notePathLookupRef.current = { noteId: id, path: lookup }
+    return lookup
+  }, [])
+
   const resolveFileUrl = useRef(
     createNoteFileUrlResolver(
       () => notePathRef.current,
-      async () => (await vaultService.getStatus()).path ?? null
+      async () => (await vaultService.getStatus()).path ?? null,
+      fetchNotePath
     )
   ).current
 
@@ -507,7 +530,8 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     containerRef,
     noteIdRef,
     dropTarget,
-    onDragReset: handleDrop
+    onDragReset: handleDrop,
+    fetchNotePath
   })
 
   // Hook #7: Paste link menu (URL / Mention / Embed)
@@ -1267,313 +1291,328 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     return () => container.removeEventListener('keydown', handleKeyDown, true)
   }, [editor])
 
+  // Memry's `file` block renders its own URL, so BlockNote's resolver never
+  // reaches it. Handing the same resolver down the tree is what lets a
+  // note-relative PDF/attachment ref load — see `note-file-url-context`.
   return (
-    <div
-      ref={containerRef}
-      role="region"
-      aria-label={t('editor.content.regionAria')}
-      className={cn('content-area h-full flex flex-col relative', className)}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
-    >
-      {isDragging && dropTarget && (
-        <BlockDropIndicator dropTarget={dropTarget} containerRef={containerRef} />
-      )}
-      {isDragging && !dropTarget && <EmptyDocumentDropIndicator />}
-
-      {aiEnabled && aiError && (
-        <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800/40">
-          <span className="truncate">{aiError}</span>
-          <button type="button" onClick={retryAI} className="shrink-0 underline hover:no-underline">
-            {tCommon('button.retry')}
-          </button>
-        </div>
-      )}
-
+    <NoteFileUrlProvider resolveFileUrl={resolveFileUrl}>
       <div
-        ref={setEditorContainerRef}
-        className={cn(
-          'bn-container flex-1 min-h-[300px] relative',
-          stickyToolbar && 'sticky-toolbar-enabled'
-        )}
-        role="application"
-        aria-label={t('editor.content.richTextAria')}
-        onContextMenu={handleEditorContextMenu}
+        ref={containerRef}
+        role="region"
+        aria-label={t('editor.content.regionAria')}
+        className={cn('content-area h-full flex flex-col relative', className)}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
       >
-        {!marqueeZoneEl && (
-          <BlockMarqueeOverlay rect={marquee.marqueeRect} highlights={marquee.highlightRects} />
+        {isDragging && dropTarget && (
+          <BlockDropIndicator dropTarget={dropTarget} containerRef={containerRef} />
         )}
-        <BlockNoteView
-          editor={editor}
-          editable={editable}
-          onChange={(): void => {
-            void handleChange()
+        {isDragging && !dropTarget && <EmptyDocumentDropIndicator />}
 
-            // A non-owner editor (a sibling on the same note in this window, R17)
-            // must not run task auto-conversion — exactly one editor owns it.
-            // Rendering + Yjs binding above are unaffected.
-            if (!runSideEffects) return
+        {aiEnabled && aiError && (
+          <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800/40">
+            <span className="truncate">{aiError}</span>
+            <button
+              type="button"
+              onClick={retryAI}
+              className="shrink-0 underline hover:no-underline"
+            >
+              {tCommon('button.retry')}
+            </button>
+          </div>
+        )}
 
-            const intents = analyzeTaskIntents(editor.document as any[], dismissedBlocksRef.current)
-
-            // Subtasks are unambiguous (the user already structured them as
-            // children of a taskBlock) and convert immediately. Standalone
-            // checkboxes are debounced so the user has time to press Tab to
-            // promote them into a subtask before the read-only taskBlock
-            // renderer steals focus.
-            if (intents.subtaskCandidate) {
-              cancelPendingConvert()
-              convertCheckboxToSubtask(
-                intents.subtaskCandidate.blockId,
-                intents.subtaskCandidate.parentTaskId
-              )
-            } else if (intents.standaloneCandidate) {
-              schedulePendingConvert(intents.standaloneCandidate.blockId)
-            } else if (
-              pendingConvertBlockIdRef.current &&
-              !intents.currentTaskIds.has(pendingConvertBlockIdRef.current)
-            ) {
-              cancelPendingConvert()
-            }
-
-            if (intents.draftTaskBlock) {
-              createTaskForDraftBlock(intents.draftTaskBlock.blockId, intents.draftTaskBlock.title)
-            }
-
-            // Tab-indented (demote): a top-level taskBlock that became a
-            // child of another taskBlock via Tab. Wire up parentTaskId in the
-            // block prop AND in the DB row.
-            for (const demoted of intents.demotedTaskBlocks) {
-              const block = editor.getBlock(demoted.blockId)
-              if (!block) continue
-              editor.updateBlock(block, {
-                props: { ...block.props, parentTaskId: demoted.newParentTaskId }
-              })
-              void tasksService.update({
-                id: demoted.taskId,
-                parentId: demoted.newParentTaskId
-              })
-            }
-
-            // Shift+Tab promoted: a top-level taskBlock that still carries a
-            // stale parentTaskId. Clear both block prop and DB linkage.
-            for (const orphan of intents.unindentedTaskBlocks) {
-              const block = editor.getBlock(orphan.blockId)
-              if (!block) continue
-              editor.updateBlock(block, {
-                props: { ...block.props, parentTaskId: '' }
-              })
-              void tasksService.update({ id: orphan.taskId, parentId: null })
-            }
-
-            for (const prevId of knownTaskBlockIdsRef.current) {
-              if (!intents.currentTaskIds.has(prevId)) {
-                void tasksService.delete(prevId)
-              }
-            }
-            knownTaskBlockIdsRef.current = intents.currentTaskIds
-          }}
-          theme={editorTheme}
-          formattingToolbar={false}
-          slashMenu={false}
-          emojiPicker={false}
-          filePanel={false}
+        <div
+          ref={setEditorContainerRef}
+          className={cn(
+            'bn-container flex-1 min-h-[300px] relative',
+            stickyToolbar && 'sticky-toolbar-enabled'
+          )}
+          role="application"
+          aria-label={t('editor.content.richTextAria')}
+          onContextMenu={handleEditorContextMenu}
         >
-          {/* Memry's toolbar on every surface, review or not: BlockNote's stock
+          {!marqueeZoneEl && (
+            <BlockMarqueeOverlay rect={marquee.marqueeRect} highlights={marquee.highlightRects} />
+          )}
+          <BlockNoteView
+            editor={editor}
+            editable={editable}
+            onChange={(): void => {
+              void handleChange()
+
+              // A non-owner editor (a sibling on the same note in this window, R17)
+              // must not run task auto-conversion — exactly one editor owns it.
+              // Rendering + Yjs binding above are unaffected.
+              if (!runSideEffects) return
+
+              const intents = analyzeTaskIntents(
+                editor.document as any[],
+                dismissedBlocksRef.current
+              )
+
+              // Subtasks are unambiguous (the user already structured them as
+              // children of a taskBlock) and convert immediately. Standalone
+              // checkboxes are debounced so the user has time to press Tab to
+              // promote them into a subtask before the read-only taskBlock
+              // renderer steals focus.
+              if (intents.subtaskCandidate) {
+                cancelPendingConvert()
+                convertCheckboxToSubtask(
+                  intents.subtaskCandidate.blockId,
+                  intents.subtaskCandidate.parentTaskId
+                )
+              } else if (intents.standaloneCandidate) {
+                schedulePendingConvert(intents.standaloneCandidate.blockId)
+              } else if (
+                pendingConvertBlockIdRef.current &&
+                !intents.currentTaskIds.has(pendingConvertBlockIdRef.current)
+              ) {
+                cancelPendingConvert()
+              }
+
+              if (intents.draftTaskBlock) {
+                createTaskForDraftBlock(
+                  intents.draftTaskBlock.blockId,
+                  intents.draftTaskBlock.title
+                )
+              }
+
+              // Tab-indented (demote): a top-level taskBlock that became a
+              // child of another taskBlock via Tab. Wire up parentTaskId in the
+              // block prop AND in the DB row.
+              for (const demoted of intents.demotedTaskBlocks) {
+                const block = editor.getBlock(demoted.blockId)
+                if (!block) continue
+                editor.updateBlock(block, {
+                  props: { ...block.props, parentTaskId: demoted.newParentTaskId }
+                })
+                void tasksService.update({
+                  id: demoted.taskId,
+                  parentId: demoted.newParentTaskId
+                })
+              }
+
+              // Shift+Tab promoted: a top-level taskBlock that still carries a
+              // stale parentTaskId. Clear both block prop and DB linkage.
+              for (const orphan of intents.unindentedTaskBlocks) {
+                const block = editor.getBlock(orphan.blockId)
+                if (!block) continue
+                editor.updateBlock(block, {
+                  props: { ...block.props, parentTaskId: '' }
+                })
+                void tasksService.update({ id: orphan.taskId, parentId: null })
+              }
+
+              for (const prevId of knownTaskBlockIdsRef.current) {
+                if (!intents.currentTaskIds.has(prevId)) {
+                  void tasksService.delete(prevId)
+                }
+              }
+              knownTaskBlockIdsRef.current = intents.currentTaskIds
+            }}
+            theme={editorTheme}
+            formattingToolbar={false}
+            slashMenu={false}
+            emojiPicker={false}
+            filePanel={false}
+          >
+            {/* Memry's toolbar on every surface, review or not: BlockNote's stock
               one has no list toggles, so the template editor used to be the odd
               one out with no visible way to turn selected lines into a list. */}
-          {stickyToolbar ? (
-            <ReviewFormattingToolbar variant="sticky" onAddComment={review?.onAddComment} />
-          ) : (
-            <ReviewFormattingToolbarController onAddComment={review?.onAddComment} />
-          )}
-          {aiEnabled && aiReady && <AIMenuController aiMenu={CustomAIMenu} />}
-          <FilePanelController filePanel={UploadOnlyFilePanel} />
-          <SuggestionMenuController
-            triggerCharacter="/"
-            getItems={async (query) => {
-              // `img` and `picture` already ship as image aliases; `photo` did
-              // not, and is what people actually type.
-              const defaults = getDefaultReactSlashMenuItems(editor).map((item) =>
-                (item as { key?: string }).key === 'image'
-                  ? { ...item, aliases: [...(item.aliases ?? []), 'photo'] }
-                  : item
-              )
-              // `/pdf` is the same item as `/file` — same insert, same panel —
-              // relabelled, because "attach a PDF" is what most people are
-              // actually after and `/pdf` matched nothing before.
-              const fileItem = defaults.find((item) => (item as { key?: string }).key === 'file')
-              const pdfItems = fileItem
-                ? [
-                    {
-                      ...fileItem,
-                      key: 'pdf',
-                      title: t('editor.slashMenu.pdf.title'),
-                      subtext: t('editor.slashMenu.pdf.subtext'),
-                      aliases: ['pdf', 'document', 'attachment']
-                    }
-                  ]
-                : []
-              const aiItems = aiEnabled && aiReady ? getAISlashMenuItems(editor) : []
-              const calloutItem = getCalloutSlashMenuItem(editor, {
-                title: t('editor.callout.title'),
-                group: t('editor.callout.group'),
-                subtext: t('editor.callout.subtext')
-              })
-              const taskItem = isFeatureEnabled('tasks')
-                ? getTaskSlashMenuItem(editor, noteId)
-                : null
-              // `/date` and `/remind` both surface the same two-row Date group:
-              // a plain date and a "Remind me — <subtitle>" (aliases overlap so
-              // either trigger shows both). Selecting inserts a configurable pill.
-              const suggestion = buildDateSuggestions('')
-              const dateAliases = ['date', 'remind', 'reminder', 'when']
-              const dateItems = suggestion
-                ? [
-                    {
-                      title: suggestion.dateLabel,
-                      onItemClick: () => insertDatePill(suggestion.dateValue),
-                      aliases: dateAliases,
-                      group: 'Basic blocks',
-                      subtext: 'Insert a date'
-                    },
-                    {
-                      title: 'Remind me',
-                      onItemClick: () => insertDatePill(suggestion.remindValue),
-                      aliases: dateAliases,
-                      group: 'Basic blocks',
-                      subtext: suggestion.remindSubtitle
-                    }
-                  ]
-                : []
-              // `/link` types `[[` for you and hands over to the wiki-link
-              // menu that trigger already owns — one search UI, one place `#`
-              // heading support lives, and the row teaches the shortcut. The
-              // trigger characters have to enter the doc through the suggestion
-              // plugin's own opener; inserting the text some other way leaves
-              // the plugin with no state and no menu.
-              const linkToNoteItem = {
-                title: t('editor.slashMenu.linkToNote.title'),
-                onItemClick: () =>
-                  editor
-                    .getExtension(SuggestionMenu)
-                    ?.openSuggestionMenu('[[', { deleteTriggerCharacter: true }),
-                aliases: ['link', 'wiki', 'wikilink', 'note', 'backlink'],
-                group: 'Basic blocks',
-                subtext: t('editor.slashMenu.linkToNote.subtext')
-              }
-              const all = orderSlashMenuItemsByGroup([
-                ...defaults,
-                ...pdfItems,
-                calloutItem,
-                ...(taskItem ? [taskItem] : []),
-                ...dateItems,
-                linkToNoteItem,
-                ...aiItems
-              ])
-              if (!query) return all
-              const lower = query.toLowerCase()
-              return all.filter(
-                (item) =>
-                  item.title.toLowerCase().includes(lower) ||
-                  item.aliases?.some((a) => a.toLowerCase().includes(lower))
-              )
-            }}
-          />
-          <SuggestionMenuController
-            triggerCharacter="[["
-            getItems={getWikiLinkItems}
-            suggestionMenuComponent={WikiLinkMenu}
-            onItemClick={(item) => void handleWikiLinkSelect(item)}
-          />
-          <SuggestionMenuController
-            triggerCharacter="@"
-            getItems={getMentionItems}
-            suggestionMenuComponent={MentionSuggestionMenu}
-            onItemClick={(item) => handleMentionSelect(item)}
-            // While the inline date ghost still has text to fill (e.g. a time
-            // being typed: `@today 12` → ghost `:00`), keep this menu closed so
-            // Tab is owned by the ghost (which fills the time) instead of the menu
-            // committing a no-time date pill.
-            shouldOpen={(tr) => !dateMentionHasGhostFill(tr)}
-          />
-          {/* Re-add BlockNote's default `:` emoji picker (disabled above via
+            {stickyToolbar ? (
+              <ReviewFormattingToolbar variant="sticky" onAddComment={review?.onAddComment} />
+            ) : (
+              <ReviewFormattingToolbarController onAddComment={review?.onAddComment} />
+            )}
+            {aiEnabled && aiReady && <AIMenuController aiMenu={CustomAIMenu} />}
+            <FilePanelController filePanel={UploadOnlyFilePanel} />
+            <SuggestionMenuController
+              triggerCharacter="/"
+              getItems={async (query) => {
+                // `img` and `picture` already ship as image aliases; `photo` did
+                // not, and is what people actually type.
+                const defaults = getDefaultReactSlashMenuItems(editor).map((item) =>
+                  (item as { key?: string }).key === 'image'
+                    ? { ...item, aliases: [...(item.aliases ?? []), 'photo'] }
+                    : item
+                )
+                // `/pdf` is the same item as `/file` — same insert, same panel —
+                // relabelled, because "attach a PDF" is what most people are
+                // actually after and `/pdf` matched nothing before.
+                const fileItem = defaults.find((item) => (item as { key?: string }).key === 'file')
+                const pdfItems = fileItem
+                  ? [
+                      {
+                        ...fileItem,
+                        key: 'pdf',
+                        title: t('editor.slashMenu.pdf.title'),
+                        subtext: t('editor.slashMenu.pdf.subtext'),
+                        aliases: ['pdf', 'document', 'attachment']
+                      }
+                    ]
+                  : []
+                const aiItems = aiEnabled && aiReady ? getAISlashMenuItems(editor) : []
+                const calloutItem = getCalloutSlashMenuItem(editor, {
+                  title: t('editor.callout.title'),
+                  group: t('editor.callout.group'),
+                  subtext: t('editor.callout.subtext')
+                })
+                const taskItem = isFeatureEnabled('tasks')
+                  ? getTaskSlashMenuItem(editor, noteId)
+                  : null
+                // `/date` and `/remind` both surface the same two-row Date group:
+                // a plain date and a "Remind me — <subtitle>" (aliases overlap so
+                // either trigger shows both). Selecting inserts a configurable pill.
+                const suggestion = buildDateSuggestions('')
+                const dateAliases = ['date', 'remind', 'reminder', 'when']
+                const dateItems = suggestion
+                  ? [
+                      {
+                        title: suggestion.dateLabel,
+                        onItemClick: () => insertDatePill(suggestion.dateValue),
+                        aliases: dateAliases,
+                        group: 'Basic blocks',
+                        subtext: 'Insert a date'
+                      },
+                      {
+                        title: 'Remind me',
+                        onItemClick: () => insertDatePill(suggestion.remindValue),
+                        aliases: dateAliases,
+                        group: 'Basic blocks',
+                        subtext: suggestion.remindSubtitle
+                      }
+                    ]
+                  : []
+                // `/link` types `[[` for you and hands over to the wiki-link
+                // menu that trigger already owns — one search UI, one place `#`
+                // heading support lives, and the row teaches the shortcut. The
+                // trigger characters have to enter the doc through the suggestion
+                // plugin's own opener; inserting the text some other way leaves
+                // the plugin with no state and no menu.
+                const linkToNoteItem = {
+                  title: t('editor.slashMenu.linkToNote.title'),
+                  onItemClick: () =>
+                    editor
+                      .getExtension(SuggestionMenu)
+                      ?.openSuggestionMenu('[[', { deleteTriggerCharacter: true }),
+                  aliases: ['link', 'wiki', 'wikilink', 'note', 'backlink'],
+                  group: 'Basic blocks',
+                  subtext: t('editor.slashMenu.linkToNote.subtext')
+                }
+                const all = orderSlashMenuItemsByGroup([
+                  ...defaults,
+                  ...pdfItems,
+                  calloutItem,
+                  ...(taskItem ? [taskItem] : []),
+                  ...dateItems,
+                  linkToNoteItem,
+                  ...aiItems
+                ])
+                if (!query) return all
+                const lower = query.toLowerCase()
+                return all.filter(
+                  (item) =>
+                    item.title.toLowerCase().includes(lower) ||
+                    item.aliases?.some((a) => a.toLowerCase().includes(lower))
+                )
+              }}
+            />
+            <SuggestionMenuController
+              triggerCharacter="[["
+              getItems={getWikiLinkItems}
+              suggestionMenuComponent={WikiLinkMenu}
+              onItemClick={(item) => void handleWikiLinkSelect(item)}
+            />
+            <SuggestionMenuController
+              triggerCharacter="@"
+              getItems={getMentionItems}
+              suggestionMenuComponent={MentionSuggestionMenu}
+              onItemClick={(item) => handleMentionSelect(item)}
+              // While the inline date ghost still has text to fill (e.g. a time
+              // being typed: `@today 12` → ghost `:00`), keep this menu closed so
+              // Tab is owned by the ghost (which fills the time) instead of the menu
+              // committing a no-time date pill.
+              shouldOpen={(tr) => !dateMentionHasGhostFill(tr)}
+            />
+            {/* Re-add BlockNote's default `:` emoji picker (disabled above via
               emojiPicker={false}), but gated so it never opens while the caret
               is inside an inline date/reminder — the `:` in `@today 23:20` must
               type a time, not pop clock emojis. */}
-          <GridSuggestionMenuController
-            triggerCharacter=":"
-            columns={10}
-            minQueryLength={2}
-            shouldOpen={(tr) => !isDateMentionActive(tr)}
-          />
-        </BlockNoteView>
+            <GridSuggestionMenuController
+              triggerCharacter=":"
+              columns={10}
+              minQueryLength={2}
+              shouldOpen={(tr) => !isDateMentionActive(tr)}
+            />
+          </BlockNoteView>
 
-        {aiEnabled && (
-          <TagSuggestionPopover
-            editor={editor}
-            editorContainerRef={editorContainerRef}
-            onSelect={handleTagSuggestionSelect}
-          />
-        )}
-
-        {wikiLinkHover.isVisible && wikiLinkHover.preview && wikiLinkHover.position && (
-          <WikiLinkPreviewCard
-            preview={wikiLinkHover.preview}
-            position={wikiLinkHover.position}
-            onMouseEnter={wikiLinkHover.handleCardMouseEnter}
-            onMouseLeave={wikiLinkHover.handleCardMouseLeave}
-            onTagClick={(tag, color) =>
-              openSidebarItem({
-                type: 'tag',
-                title: tag,
-                path: '/tags/' + tag,
-                entityId: tag,
-                color
-              })
-            }
-            onNoteClick={onInternalLinkClick}
-          />
-        )}
-
-        {linkMentionHover.isVisible &&
-          linkMentionHover.url &&
-          linkMentionHover.preview &&
-          linkMentionHover.position && (
-            <LinkMentionPreviewCard
-              url={linkMentionHover.url}
-              preview={linkMentionHover.preview}
-              position={linkMentionHover.position}
-              onMouseEnter={linkMentionHover.handleCardMouseEnter}
-              onMouseLeave={linkMentionHover.handleCardMouseLeave}
+          {aiEnabled && (
+            <TagSuggestionPopover
+              editor={editor}
+              editorContainerRef={editorContainerRef}
+              onSelect={handleTagSuggestionSelect}
             />
           )}
 
-        <PasteLinkMenu
-          isOpen={pasteLinkState.isOpen}
-          position={pasteLinkState.position}
-          options={pasteLinkState.options}
-          selectedIndex={pasteLinkState.selectedIndex}
-          onSelect={handlePasteLinkOptionSelect}
-        />
+          {wikiLinkHover.isVisible && wikiLinkHover.preview && wikiLinkHover.position && (
+            <WikiLinkPreviewCard
+              preview={wikiLinkHover.preview}
+              position={wikiLinkHover.position}
+              onMouseEnter={wikiLinkHover.handleCardMouseEnter}
+              onMouseLeave={wikiLinkHover.handleCardMouseLeave}
+              onTagClick={(tag, color) =>
+                openSidebarItem({
+                  type: 'tag',
+                  title: tag,
+                  path: '/tags/' + tag,
+                  entityId: tag,
+                  color
+                })
+              }
+              onNoteClick={onInternalLinkClick}
+            />
+          )}
 
-        <DateMentionPopover
-          open={dateMentionState.open}
-          anchorId={dateMentionState.anchorId}
-          value={dateMentionState.value}
-          clockFormat={dateMentionClockFormat}
-          onChange={handleDateMentionChange}
-          onClear={handleDateMentionClear}
-          onClose={handleDateMentionClose}
-        />
+          {linkMentionHover.isVisible &&
+            linkMentionHover.url &&
+            linkMentionHover.preview &&
+            linkMentionHover.position && (
+              <LinkMentionPreviewCard
+                url={linkMentionHover.url}
+                preview={linkMentionHover.preview}
+                position={linkMentionHover.position}
+                onMouseEnter={linkMentionHover.handleCardMouseEnter}
+                onMouseLeave={linkMentionHover.handleCardMouseLeave}
+              />
+            )}
+
+          <PasteLinkMenu
+            isOpen={pasteLinkState.isOpen}
+            position={pasteLinkState.position}
+            options={pasteLinkState.options}
+            selectedIndex={pasteLinkState.selectedIndex}
+            onSelect={handlePasteLinkOptionSelect}
+          />
+
+          <DateMentionPopover
+            open={dateMentionState.open}
+            anchorId={dateMentionState.anchorId}
+            value={dateMentionState.value}
+            clockFormat={dateMentionClockFormat}
+            onChange={handleDateMentionChange}
+            onClear={handleDateMentionClear}
+            onClose={handleDateMentionClose}
+          />
+        </div>
+        {marqueeZoneEl &&
+          createPortal(
+            <BlockMarqueeOverlay rect={marquee.marqueeRect} highlights={marquee.highlightRects} />,
+            marqueeZoneEl
+          )}
       </div>
-      {marqueeZoneEl &&
-        createPortal(
-          <BlockMarqueeOverlay rect={marquee.marqueeRect} highlights={marquee.highlightRects} />,
-          marqueeZoneEl
-        )}
-    </div>
+    </NoteFileUrlProvider>
   )
 })
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
@@ -7,6 +7,7 @@ import {
   parseFileBlockMarker,
   serializeFileBlock
 } from './file-block'
+import { NoteFileUrlProvider } from './note-file-url-context'
 
 const mocks = vi.hoisted(() => ({
   syncState: {
@@ -39,14 +40,16 @@ vi.mock('@blocknote/react', () => ({
 vi.mock('react-pdf', () => ({
   Document: ({
     children,
+    file,
     onLoadSuccess,
     onLoadError
   }: {
     children: React.ReactNode
+    file: string
     onLoadSuccess?: (payload: { numPages: number }) => void
     onLoadError?: (error: Error) => void
   }) => (
-    <div data-testid="pdf-document">
+    <div data-testid="pdf-document" data-file={file}>
       <button type="button" onClick={() => onLoadSuccess?.({ numPages: mocks.pdfPageCount })}>
         load pdf
       </button>
@@ -333,5 +336,58 @@ describe('file block helpers', () => {
     expect(updateBlock).toHaveBeenCalledWith(block, {
       props: expect.objectContaining({ align: 'right' })
     })
+  })
+})
+
+describe('FileBlock url resolution', () => {
+  // #1488: attachments are stored as a ref relative to the note. The `file`
+  // block is a custom spec, so BlockNote's own resolveFileUrl never reaches it
+  // — without this the PDF viewer fetches `../attachments/...` against the
+  // renderer's base URL and shows a broken card.
+  const RELATIVE = '../attachments/note1/abc123-manual.pdf'
+  const ABSOLUTE = 'memry-file://local/Users/me/vault/attachments/note1/abc123-manual.pdf'
+
+  function renderBlock(url: string, resolveFileUrl?: (url: string) => Promise<string>) {
+    const Render = (createFileBlock as any).render
+    const block = {
+      props: { url, name: 'manual.pdf', size: 2048, mimeType: 'application/pdf' }
+    }
+    const ui = <Render contentRef={vi.fn()} editor={{ updateBlock: vi.fn() }} block={block} />
+    const result = render(
+      resolveFileUrl ? (
+        <NoteFileUrlProvider resolveFileUrl={resolveFileUrl}>{ui}</NoteFileUrlProvider>
+      ) : (
+        ui
+      )
+    )
+    return { ...result, block }
+  }
+
+  it('renders a note-relative ref through the resolver', async () => {
+    const { block } = renderBlock(RELATIVE, async () => ABSOLUTE)
+
+    await vi.waitFor(() =>
+      expect(screen.getByTestId('pdf-document')).toHaveAttribute('data-file', ABSOLUTE)
+    )
+    // Render-time only: writing the resolved URL back would serialize this
+    // machine's vault path into the note's markdown — the bug itself.
+    expect(block.props.url).toBe(RELATIVE)
+  })
+
+  it('renders an absolute URL on the first paint, with no resolver round trip', () => {
+    const resolveFileUrl = vi.fn(async () => 'never used')
+    renderBlock(ABSOLUTE, resolveFileUrl)
+
+    expect(screen.getByTestId('pdf-document')).toHaveAttribute('data-file', ABSOLUTE)
+    expect(resolveFileUrl).not.toHaveBeenCalled()
+  })
+
+  it('leaves the ref alone outside a provider rather than inventing a path', () => {
+    // Read-only surfaces that render a file block without the editor's resolver
+    // get the stored ref verbatim — the same "leave it alone" fallback the
+    // resolver itself uses, not a guess at where the vault lives.
+    renderBlock(RELATIVE)
+
+    expect(screen.getByTestId('pdf-document')).toHaveAttribute('data-file', RELATIVE)
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -30,6 +30,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { useSync } from '@/contexts/sync-context'
 import { useT } from '@memry/i18n/renderer'
+import { useResolvedFileUrl } from './note-file-url-context'
 import type { FileBlockProps } from './file-block-markers'
 
 export { parseFileBlockMarker, serializeFileBlock } from './file-block-markers'
@@ -635,6 +636,12 @@ function FileBlockRender({
   const isPdf = mimeType === 'application/pdf'
   const isAudio = mimeType.startsWith('audio/')
 
+  // Attachments are stored as a ref relative to the note (`../attachments/…`),
+  // which the browser would resolve against the renderer's own base URL. The
+  // result is for rendering only — writing it back to `block.props` would put
+  // this machine's vault path into the note's markdown.
+  const resolvedUrl = useResolvedFileUrl(url)
+
   // Persist the user-chosen PDF width + crop height to the block props
   // (round-trips to the vault marker via serializeFileBlock). Declared before
   // the early return to keep hook order stable.
@@ -665,11 +672,18 @@ function FileBlockRender({
     )
   }
 
+  // Still resolving a note-relative ref: render the frame without a target
+  // rather than letting the viewer fetch the unresolved path and latch its
+  // load error.
+  if (resolvedUrl === null) {
+    return <div ref={contentRef} className="file-block my-2" contentEditable={false} />
+  }
+
   return (
     <div ref={contentRef} className="file-block my-2" contentEditable={false}>
       {isPdf ? (
         <PdfPreview
-          url={url}
+          url={resolvedUrl}
           name={name}
           width={width ?? 0}
           height={height ?? 0}
@@ -678,9 +692,9 @@ function FileBlockRender({
           onAlign={handleAlign}
         />
       ) : isAudio ? (
-        <AudioPreview url={url} name={name} size={size} mimeType={mimeType} />
+        <AudioPreview url={resolvedUrl} name={name} size={size} mimeType={mimeType} />
       ) : (
-        <FilePreview url={url} name={name} size={size} mimeType={mimeType} />
+        <FilePreview url={resolvedUrl} name={name} size={size} mimeType={mimeType} />
       )}
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-file-upload.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-file-upload.test.ts
@@ -99,6 +99,10 @@ describe('useEditorFileUpload', () => {
       noteIdRef: { current: 'note-1' },
       dropTarget: null,
       onDragReset: vi.fn(),
+      // Default to "no note path": the existing drop assertions below then
+      // cover the absolute fallback, and the relative case is asserted
+      // explicitly where a path is supplied.
+      fetchNotePath: vi.fn(async () => undefined as string | undefined),
       ...overrides
     }
 
@@ -252,6 +256,28 @@ describe('useEditorFileUpload', () => {
       'target-block',
       'after'
     )
+  })
+
+  it('references a dropped sidebar file relative to the note that receives it', async () => {
+    // #1488: an absolute URL carries this machine's vault path, so the note
+    // renders the embed here and nowhere else.
+    mocks.getFile.mockResolvedValue({
+      absolutePath: '/vault/notes/report.pdf',
+      path: 'notes/report.pdf',
+      fileType: 'pdf',
+      title: 'report',
+      fileSize: 1234,
+      mimeType: 'application/pdf'
+    })
+    const { result, editor } = setup({
+      fetchNotePath: vi.fn(async () => 'notes/work/Review.md' as string | undefined)
+    })
+
+    await act(async () => {
+      await result.current.handleInternalItemDrop(internalDrop('file-id'))
+    })
+
+    expect(editor.insertBlocks.mock.calls[0][0][0].props.url).toBe('../report.pdf')
   })
 
   it('embeds a dropped sidebar image as an image block at the cursor', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-file-upload.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-file-upload.ts
@@ -10,6 +10,7 @@ import { toast } from 'sonner'
 import { getI18n } from 'react-i18next'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { toMemryFileUrl } from '@/lib/memry-file-url'
+import { noteRelativeRef } from '@/lib/resolve-note-relative-url'
 import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
 
 const log = createLogger('Hook:EditorFileUpload')
@@ -43,6 +44,12 @@ interface EditorFileUploadParams {
   noteIdRef: React.RefObject<string | undefined>
   dropTarget: DropTarget | null
   onDragReset: () => void
+  /**
+   * The note's own vault-relative path, so a dropped vault file can be
+   * referenced relative to it. Resolves to undefined when the note is not in
+   * the index, which drops the embed back to an absolute URL.
+   */
+  fetchNotePath: () => Promise<string | undefined>
 }
 
 interface EditorFileUploadResult {
@@ -58,7 +65,8 @@ export function useEditorFileUpload({
   containerRef,
   noteIdRef,
   dropTarget,
-  onDragReset
+  onDragReset,
+  fetchNotePath
 }: EditorFileUploadParams): EditorFileUploadResult {
   const uploadFile = useCallback(
     async (file: File): Promise<string> => {
@@ -167,8 +175,8 @@ export function useEditorFileUpload({
   )
 
   // Embed a file-type item dragged out of the left sidebar. Unlike an OS file
-  // drop, the bytes already live in the vault, so we reference the item by its
-  // own path (memry-file:// URL) instead of copying into attachments/.
+  // drop, the bytes already live in the vault, so we reference the item where it
+  // already is instead of copying into attachments/.
   const handleInternalItemDrop = useCallback(
     async (dataTransfer: DataTransfer): Promise<void> => {
       const itemId = dataTransfer.getData(MEMRY_NOTE_DRAG_MIME)
@@ -195,7 +203,15 @@ export function useEditorFileUpload({
           return
         }
 
-        const url = toMemryFileUrl(file.absolutePath)
+        // Relative to the note, so the embed survives reaching another device
+        // where the vault sits at a different absolute path. Falls back to the
+        // absolute URL when the note's own path is unknown — the same trade
+        // `saveAttachment` makes in the main process.
+        const notePath = await fetchNotePath()
+        const url =
+          notePath && file.path
+            ? noteRelativeRef(notePath, file.path)
+            : toMemryFileUrl(file.absolutePath)
         const name = file.title || 'file'
         const mimeType = file.mimeType || ''
 
@@ -216,7 +232,7 @@ export function useEditorFileUpload({
         log.error('Failed to embed dropped item', itemId, error)
       }
     },
-    [editable, editor, dropTarget, onDragReset]
+    [editable, editor, dropTarget, onDragReset, fetchNotePath]
   )
 
   // Capture-phase drop handler to intercept before BlockNote

--- a/apps/desktop/src/renderer/src/components/note/content-area/note-file-url-context.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/note-file-url-context.tsx
@@ -1,0 +1,67 @@
+/**
+ * Render-time resolution of a note-relative asset URL, for the blocks BlockNote
+ * does not resolve for us.
+ *
+ * BlockNote applies its own `resolveFileUrl` to the built-in image/video/audio
+ * blocks, so those already load a `../attachments/<noteId>/x.png` ref. Memry's
+ * `file` block is a custom spec and renders `props.url` itself, which meant a
+ * note-relative PDF resolved against the renderer document's base URL and never
+ * loaded. This hands that same resolver down so the two agree.
+ *
+ * **Resolution is render-only.** The resolved absolute URL must never be written
+ * back into the block's props: it would serialize into the note's markdown and
+ * put this machine's vault path back on disk, which is the whole bug this exists
+ * to close.
+ */
+
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type FileUrlResolver = (url: string) => Promise<string>
+
+const NoteFileUrlContext = createContext<FileUrlResolver | null>(null)
+
+export function NoteFileUrlProvider({
+  resolveFileUrl,
+  children
+}: {
+  resolveFileUrl: FileUrlResolver
+  children: React.ReactNode
+}) {
+  return (
+    <NoteFileUrlContext.Provider value={resolveFileUrl}>{children}</NoteFileUrlContext.Provider>
+  )
+}
+
+/** `https:`, `data:`, `memry-file:` — and `C:` on Windows. Mirrors the resolver. */
+const HAS_SCHEME = /^[a-zA-Z][a-zA-Z\d+\-.]*:/
+
+/**
+ * The URL to actually render, or `null` while a note-relative one is still being
+ * resolved.
+ *
+ * A URL that already carries a scheme is returned synchronously, on the first
+ * render: every attachment written before this change is absolute, and making
+ * those wait a tick would remount the PDF viewer — which latches its load error
+ * and never retries — for no gain.
+ */
+export function useResolvedFileUrl(url: string): string | null {
+  const resolve = useContext(NoteFileUrlContext)
+  const isResolved = !url || HAS_SCHEME.test(url)
+  const [resolved, setResolved] = useState<string | null>(isResolved ? url : null)
+
+  useEffect(() => {
+    if (isResolved || !resolve) {
+      setResolved(url)
+      return
+    }
+    let cancelled = false
+    void resolve(url).then((next) => {
+      if (!cancelled) setResolved(next)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [resolve, url, isResolved])
+
+  return resolved
+}

--- a/apps/desktop/src/renderer/src/lib/create-note-file-url-resolver.test.ts
+++ b/apps/desktop/src/renderer/src/lib/create-note-file-url-resolver.test.ts
@@ -74,3 +74,44 @@ describe('createNoteFileUrlResolver', () => {
     expect(await resolve(REF)).toBe(RESOLVED)
   })
 })
+
+describe('createNoteFileUrlResolver without a note path prop', () => {
+  // Only pages/note.tsx passes `notePath`. The journal, canvas cards and a
+  // project's home note mount the editor knowing only the note's id — and
+  // attachments are written relative to their note on every one of those
+  // surfaces, so without the fallback the image a user just dropped into their
+  // journal resolves against the renderer's own base URL and 404s.
+  it('falls back to the looked-up path', async () => {
+    const resolve = createNoteFileUrlResolver(
+      () => undefined,
+      async () => VAULT,
+      async () => NOTE
+    )
+
+    expect(await resolve(REF)).toBe(RESOLVED)
+  })
+
+  it('prefers the prop and never looks anything up when it is there', async () => {
+    const fetchNotePath = vi.fn(async () => 'Other/Note.md')
+    const resolve = createNoteFileUrlResolver(
+      () => NOTE,
+      async () => VAULT,
+      fetchNotePath
+    )
+
+    expect(await resolve(REF)).toBe(RESOLVED)
+    expect(fetchNotePath).not.toHaveBeenCalled()
+  })
+
+  it('hands the URL back untouched when the lookup fails', async () => {
+    const resolve = createNoteFileUrlResolver(
+      () => undefined,
+      async () => VAULT,
+      async () => {
+        throw new Error('no such note')
+      }
+    )
+
+    expect(await resolve(REF)).toBe(REF)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/create-note-file-url-resolver.ts
+++ b/apps/desktop/src/renderer/src/lib/create-note-file-url-resolver.ts
@@ -19,12 +19,23 @@ import { resolveNoteRelativeUrl } from './resolve-note-relative-url'
 
 export function createNoteFileUrlResolver(
   getNotePath: () => string | undefined,
-  fetchVaultPath: () => Promise<string | null>
+  fetchVaultPath: () => Promise<string | null>,
+  /**
+   * Where the note's path comes from on the surfaces that mount the editor
+   * knowing only the note's id — the journal, a canvas card, a project's home
+   * note. Only `pages/note.tsx` passes the path as a prop, and attachments are
+   * now written relative to the note wherever they are saved, so without this
+   * the image a user just dropped into their journal would render against the
+   * renderer's own base URL and 404.
+   *
+   * Caching is the caller's job: it knows which note the fallback belongs to.
+   */
+  fetchNotePath?: () => Promise<string | undefined>
 ): (url: string) => Promise<string> {
   let vaultPath: Promise<string | null> | null = null
 
   return async (url: string) => {
-    const notePath = getNotePath()
+    const notePath = getNotePath() ?? (await fetchNotePath?.().catch(() => undefined))
     if (!notePath) return url
     if (!vaultPath) vaultPath = fetchVaultPath().catch(() => null)
     return resolveNoteRelativeUrl(url, notePath, await vaultPath)

--- a/apps/desktop/src/renderer/src/lib/resolve-note-relative-url.test.ts
+++ b/apps/desktop/src/renderer/src/lib/resolve-note-relative-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveNoteRelativeUrl } from './resolve-note-relative-url'
+import { noteRelativeRef, resolveNoteRelativeUrl } from './resolve-note-relative-url'
 
 const VAULT = '/Users/me/vault'
 const NOTE = 'People (1)/Person.md'
@@ -97,5 +97,45 @@ describe('resolveNoteRelativeUrl', () => {
         '/Users/me/vault/cap'
       )
     ).toBe('memry-file://local/Users/me/vault/cap/Images/Media/01KX65VSYZ9NBBNP9PG7ARJKD2.png')
+  })
+})
+
+describe('noteRelativeRef', () => {
+  // Mirrors `noteRelativeRef` in apps/desktop/src/main/lib/paths.ts, which
+  // covers the same cases — the renderer cannot import from main.
+  it('climbs out of the note folder to reach the attachments tree', () => {
+    expect(noteRelativeRef('notes/Meeting.md', 'attachments/note123/abc-plan.pdf')).toBe(
+      '../attachments/note123/abc-plan.pdf'
+    )
+  })
+
+  it('needs no climb for a note at the vault root', () => {
+    expect(noteRelativeRef('Meeting.md', 'attachments/n/x.png')).toBe('attachments/n/x.png')
+  })
+
+  it('climbs once per nested folder', () => {
+    expect(noteRelativeRef('notes/work/q3/Review.md', 'attachments/n/x.png')).toBe(
+      '../../../attachments/n/x.png'
+    )
+  })
+
+  it('keeps the shared prefix instead of climbing past it', () => {
+    expect(noteRelativeRef('notes/Trip.md', 'notes/images/photo.png')).toBe('images/photo.png')
+  })
+
+  it('emits forward slashes for a Windows-shaped input', () => {
+    expect(noteRelativeRef('notes\\work\\Trip.md', 'attachments\\n\\x.png')).toBe(
+      '../../attachments/n/x.png'
+    )
+  })
+
+  // The round trip that matters: what this writes, the render-time resolver
+  // has to be able to turn back into a file inside the vault.
+  it('round-trips through resolveNoteRelativeUrl', () => {
+    const ref = noteRelativeRef('notes/work/Review.md', 'attachments/n1/abc-plan.pdf')
+
+    expect(resolveNoteRelativeUrl(ref, 'notes/work/Review.md', '/Users/me/vault')).toBe(
+      'memry-file://local/Users/me/vault/attachments/n1/abc-plan.pdf'
+    )
   })
 })

--- a/apps/desktop/src/renderer/src/lib/resolve-note-relative-url.ts
+++ b/apps/desktop/src/renderer/src/lib/resolve-note-relative-url.ts
@@ -77,3 +77,32 @@ export function resolveNoteRelativeUrl(
 
   return toMemryFileUrl(`${vaultPath.replace(/[/\\]+$/, '')}/${resolved}`)
 }
+
+/**
+ * The inverse: a vault-relative target written the way `notePath` should carry
+ * it. Used when the editor embeds a file the renderer already knows the vault
+ * path of (a sidebar drop), where `saveAttachment` — which does this in the main
+ * process — is never involved.
+ *
+ * Restated rather than imported: this is the renderer, and `main/lib/paths.ts`
+ * is not importable from here. Both sides are covered by tests over the same
+ * cases, the way `FILE_BLOCK_ACCEPT` mirrors the main-process extension list.
+ */
+export function noteRelativeRef(notePath: string, targetPath: string): string {
+  const noteSegments = notePath.split(SEPARATOR).filter(Boolean)
+  // Drop the note's own filename: refs are relative to the folder holding it.
+  noteSegments.pop()
+  const targetSegments = targetPath.split(SEPARATOR).filter(Boolean)
+
+  let shared = 0
+  while (
+    shared < noteSegments.length &&
+    shared < targetSegments.length &&
+    noteSegments[shared] === targetSegments[shared]
+  ) {
+    shared++
+  }
+
+  const up = Array(noteSegments.length - shared).fill('..')
+  return [...up, ...targetSegments.slice(shared)].join('/')
+}

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -236,6 +236,25 @@ Attachments and vault media reach the renderer through the custom `memry-file://
 - `window.open` on a memry-file URL never opens a window or reaches `shell.openExternal`: the main process resolves the path with the same rules and, if it passes the directory check, opens the file in the OS default app via `shell.openPath`.
 - In-window navigation is guarded the same way: a `will-frame-navigate` listener on every window's webContents (`src/main/index.ts`, policy in `src/main/lib/frame-navigation.ts`) pins the main frame to the local app document (the packaged `file://` page, or the dev-server origin in dev) plus `memry-file:`. External `http(s)`/`mailto` links cancel the navigation and open in the OS browser; `javascript:`, `data:`, `file:` and unknown schemes are denied outright. Subframes stay permissive for `http(s)` — the CSP `frame-src` directive is the origin gate for embeds like youtube-nocookie — while local and script schemes remain blocked there too.
 
+### What a note stores for an attachment
+
+A note never stores the absolute `memry-file://` URL — that carries one machine's vault path, so the same note on a second device resolves it to nothing. What lands in the markdown is a path relative to the note itself:
+
+- `![caption](../attachments/<noteId>/abc123-photo.png)` for an image
+- `<!-- file:{"url":"../attachments/<noteId>/abc123-plan.pdf", …} -->` for the file block
+
+`saveAttachment` (`src/main/vault/attachments.ts`) builds that ref for every caller — the editor's paste/drop, sidebar drops, and every importer — by looking the note's own path up in the index. A note the index cannot place (an importer writing assets before the note exists) falls back to the absolute URL and logs it; that is the shape attachments had before, so nothing is left worse off. Attachment bytes are unaffected either way: sync moves them by the note's `attachments/<noteId>/` folder, not by parsing URLs.
+
+Reading tolerates both shapes and nothing is rewritten on disk, so notes written by older versions keep their absolute URLs and keep rendering on the device that wrote them.
+
+The relative ref resolves back to a `memry-file://` URL at render time only, so the vault stays readable by Obsidian:
+
+- Built-in image/video/audio blocks go through BlockNote's `resolveFileUrl` (`createNoteFileUrlResolver` → `resolveNoteRelativeUrl`).
+- The `file` block is a custom spec that renders its own URL, so the same resolver reaches it through `note-file-url-context.tsx`. The resolved URL is never written back to the block's props — that would put the machine path back into the markdown.
+- Only the note page passes the note's path as a prop; the journal, canvas cards and a project's home note look it up by note id, from the same index row the write side reads.
+
+One consequence to know about: because the ref is relative to the note's folder and attachments stay under `attachments/<noteId>/`, moving a note to a different folder depth leaves its existing embeds pointing at the wrong place. Nothing rewrites refs on move yet.
+
 ### Text colors in markdown
 
 Editor colors persist in two Obsidian-compatible forms:


### PR DESCRIPTION
Closes #1488

## What was wrong

`saveAttachment` returned an absolute `memry-file://` URL carrying this machine's vault path, and that string was what the editor put in the block props and what got serialized into the note's markdown:

- image block → `![caption](memry-file:///Users/kaan/Vault/attachments/<noteId>/x.png)`
- file block → `<!-- file:{"url":"memry-file:///Users/kaan/..."} -->`

On any other install that path does not exist, so the embed resolved to nothing — a broken image, or a PDF card that could not load. Sidebar drops built the same shape via `toMemryFileUrl(file.absolutePath)`.

This predates the PDF work; images have always been written this way.

## What changed

**The ref is now relative to the note** — `../attachments/<noteId>/x.pdf` — the shape `resolve-embed.ts` and inbox filing already wrote theirs in, and the one that stays valid in Obsidian.

The note's path comes from the index inside `saveAttachment`, so **every caller gets it without changing a line**: the editor's paste/drop, and every importer (OneNote, Apple Notes, Notion, co-located assets). Inbox filing dropped its local copy of the path helper for the shared one. Sidebar drops build the ref in the renderer, since they never touch `saveAttachment`.

A note whose path cannot be resolved — an importer writing assets before the note is indexed — falls back to the absolute URL and logs it. That is exactly the shape attachments already had, so nothing is left worse off; the log is there so "some attachments are still absolute" is a question with an answer.

Attachment bytes are untouched: sync moves them by the note's `attachments/<noteId>/` folder and the signed manifest filename, not by parsing URLs, so the same ref resolves on the receiving device.

## Two things had to move for it to render

- **Memry's `file` block is a custom spec** and renders `props.url` itself, so BlockNote's own `resolveFileUrl` never reached it — a relative PDF ref would have loaded nothing. The same resolver now reaches it through a small context. Resolution is render-time only: writing the resolved URL back to the props would put the machine path straight back into the markdown, which is the bug itself. A URL that already carries a scheme resolves synchronously on first paint, so existing absolute markers do not make the PDF viewer remount and latch its load error.
- **Only `pages/note.tsx` passes the note's path as a prop.** The journal, canvas cards and a project's home note mount the editor knowing only the note id, so they look the path up by id — from the same index row the write side reads. Write and read therefore agree by construction: if main could not place the note, the renderer has nothing to resolve either.

## Compatibility

Additive on write, tolerant on read. Existing notes keep their absolute URLs and keep rendering on the device that wrote them; nothing is rewritten and no migration pass touches the vault. Deliberately **not** rewriting absolute → relative on save: write-back byte-compares the serialized document against the file, so that would rewrite every note holding an attachment, in every vault, on next open.

`listNoteAttachments` deliberately keeps returning absolute URLs — nothing writes it into a note, it answers "where is this file on this machine" for the IPC/MCP listing, so it stays directly openable. Guarded by a test.

## Known trade

The ref is relative to the note's folder while attachments stay under `attachments/<noteId>/`, so moving a note to a different folder depth leaves its existing embeds pointing at the wrong place. Absolute URLs survived that on the same device, so this is a new same-device edge case traded for working on every device. Nothing rewrites refs on move today; filed as a follow-up rather than widened into this PR.

## Verification

| Gate | Result |
|---|---|
| `pnpm test:desktop` | 17285 passed / 10 failed |
| `pnpm typecheck` (desktop) | 2 errors |
| `pnpm lint` | 0 errors |
| `pnpm docs:impact --strict` | pass (docs updated) |
| `pnpm docs:build` | pass |
| `pnpm ipc:check` | up to date |
| `git diff --check` | clean |

**Every red is pre-existing on `main`** — the same 10 tests (`App.test.tsx`, `App.workspace-counts`, `sidebar-nav`, `calendar`) and the same 2 type errors (`sidebar-nav.test.tsx`) reproduce on a clean tree with this branch stashed.

New tests: `paths.test.ts` (5), `attachments.test.ts` (6), `resolve-note-relative-url.test.ts` (6, including the write→render round trip), `create-note-file-url-resolver.test.ts` (3), `file-block.test.tsx` (3), `use-editor-file-upload.test.ts` (1).

Both halves were mutation-checked: reverting `saveAttachment` to write absolute turns 3 tests red, and making the file block ignore the resolver turns 1 red.
