### PR TITLE
test(reminders): render the real ReminderPicker instead of hand-written stubs

### DIFF
--- a/apps/desktop/src/renderer/src/components/journal/journal-reminder-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-reminder-button.test.tsx
@@ -32,39 +32,11 @@ vi.mock('@/components/ui/tooltip', () => ({
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
 }))
 
-// Radix's picker does not open in jsdom; this stand-in keeps the picker's own
-// state machine (note textarea, preset selection, onSelect call) real.
-vi.mock('@/components/ui/picker', () => {
-  const pickerMocks: { onValueChange: ((value: string) => void) | null } = { onValueChange: null }
-
-  const PickerRoot = ({
-    children,
-    onValueChange
-  }: {
-    children: React.ReactNode
-    onValueChange?: (value: string) => void
-  }): React.ReactElement => {
-    pickerMocks.onValueChange = onValueChange ?? null
-    return <div>{children}</div>
-  }
-
-  return {
-    Picker: Object.assign(PickerRoot, {
-      Trigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      List: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      Footer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      Section: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      Separator: () => <hr />,
-      Item: ({ value }: { value: string }) => (
-        <button
-          type="button"
-          data-testid={`preset-${value}`}
-          onClick={() => pickerMocks.onValueChange?.(value)}
-        />
-      )
-    })
-  }
+// Radix's picker does not open in jsdom; the shared stand-in keeps the picker's
+// own state machine (note textarea, preset selection, onSelect call) real.
+vi.mock('@/components/ui/picker', async () => {
+  const { createPickerStub } = await import('@tests/utils/picker-stub')
+  return createPickerStub()
 })
 
 describe('JournalReminderButton', () => {

--- a/apps/desktop/src/renderer/src/components/journal/journal-small-components.test.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-small-components.test.tsx
@@ -33,26 +33,16 @@ vi.mock('@/hooks/use-journal-reminders', () => ({
   })
 }))
 
-vi.mock('@/components/reminder/reminder-presets', () => ({
-  formatReminderDate: (date: Date) => date.toISOString()
-}))
+vi.mock('@/lib/telemetry', () => ({ trackTelemetry: vi.fn() }))
 
-vi.mock('@/components/reminder', () => ({
-  ReminderPicker: ({
-    trigger,
-    onSelect
-  }: {
-    trigger: ReactNode
-    onSelect: (date: Date, note?: string) => void
-  }) => (
-    <div>
-      {trigger}
-      <button type="button" onClick={() => onSelect(new Date('2026-05-10T10:00:00Z'), 'reflect')}>
-        pick reminder
-      </button>
-    </div>
-  )
-}))
+// The real `ReminderPicker` renders here on purpose: a hand-written stub would
+// re-declare `onSelect` from this file's reading of it, which is exactly how the
+// note-dropping bug in #1527 stayed green. Only the Radix primitive underneath
+// is stood in, because it does not open in jsdom.
+vi.mock('@/components/ui/picker', async () => {
+  const { createPickerStub } = await import('@tests/utils/picker-stub')
+  return createPickerStub()
+})
 
 vi.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -174,7 +164,13 @@ describe('journal small components', () => {
     expect(screen.getByText('3')).toBeInTheDocument()
     expect(screen.getAllByText(/reminder.tooltipMore/).length).toBeGreaterThan(0)
 
-    fireEvent.click(screen.getByText('pick reminder'))
-    expect(mocks.setReminder).toHaveBeenCalledWith(new Date('2026-05-10T10:00:00Z'), 'reflect')
+    // The note goes in through the picker's own textarea, so it only reaches
+    // `setReminder` if this button reads the argument the picker actually sends.
+    fireEvent.change(
+      screen.getByPlaceholderText('phaseF.componentsReminderReminderPicker.addANoteOptional'),
+      { target: { value: 'reflect' } }
+    )
+    fireEvent.click(screen.getByTestId('preset-in-one-week'))
+    expect(mocks.setReminder).toHaveBeenCalledWith(expect.any(Date), 'reflect')
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/note-reminder-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-reminder-button.test.tsx
@@ -32,39 +32,11 @@ vi.mock('@/components/ui/tooltip', () => ({
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
 }))
 
-// Radix's picker does not open in jsdom; this stand-in keeps the picker's own
-// state machine (note textarea, preset selection, onSelect call) real.
-vi.mock('@/components/ui/picker', () => {
-  const pickerMocks: { onValueChange: ((value: string) => void) | null } = { onValueChange: null }
-
-  const PickerRoot = ({
-    children,
-    onValueChange
-  }: {
-    children: React.ReactNode
-    onValueChange?: (value: string) => void
-  }): React.ReactElement => {
-    pickerMocks.onValueChange = onValueChange ?? null
-    return <div>{children}</div>
-  }
-
-  return {
-    Picker: Object.assign(PickerRoot, {
-      Trigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      List: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      Footer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      Section: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      Separator: () => <hr />,
-      Item: ({ value }: { value: string }) => (
-        <button
-          type="button"
-          data-testid={`preset-${value}`}
-          onClick={() => pickerMocks.onValueChange?.(value)}
-        />
-      )
-    })
-  }
+// Radix's picker does not open in jsdom; the shared stand-in keeps the picker's
+// own state machine (note textarea, preset selection, onSelect call) real.
+vi.mock('@/components/ui/picker', async () => {
+  const { createPickerStub } = await import('@tests/utils/picker-stub')
+  return createPickerStub()
 })
 
 describe('NoteReminderButton', () => {

--- a/apps/desktop/src/renderer/src/components/reminder/reminder-picker.test.tsx
+++ b/apps/desktop/src/renderer/src/components/reminder/reminder-picker.test.tsx
@@ -7,11 +7,6 @@ import { ReminderPicker } from './reminder-picker'
 
 vi.mock('@/lib/telemetry', () => ({ trackTelemetry: vi.fn() }))
 
-const pickerMocks = vi.hoisted(() => ({
-  onValueChange: null as null | ((value: string) => void),
-  onOpenChange: null as null | ((open: boolean) => void)
-}))
-
 vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({ t: (key: string) => key })
 }))
@@ -40,67 +35,17 @@ vi.mock('@/components/ui/button', () => ({
   )
 }))
 
-vi.mock('@/components/ui/picker', () => {
-  const PickerRoot = ({
-    children,
-    onValueChange,
-    onOpenChange
-  }: {
-    children: React.ReactNode
-    onValueChange?: (value: string) => void
-    onOpenChange?: (open: boolean) => void
-  }) => {
-    pickerMocks.onValueChange = onValueChange ?? null
-    pickerMocks.onOpenChange = onOpenChange ?? null
-    return <div>{children}</div>
-  }
-
-  return {
-    Picker: Object.assign(PickerRoot, {
-      Trigger: ({ children }: { children: React.ReactNode }) => (
-        <div onClick={() => pickerMocks.onOpenChange?.(true)}>{children}</div>
-      ),
-      Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      List: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      Footer: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-        <div data-slot="picker-footer" className={className}>
-          {children}
-        </div>
-      ),
-      Section: ({ label, children }: { label: string; children: React.ReactNode }) => (
-        <section aria-label={label}>
-          <h3>{label}</h3>
-          {children}
-        </section>
-      ),
-      Separator: () => <hr />,
-      Item: ({
-        label,
-        value,
-        icon,
-        trailing
-      }: {
-        label: string
-        value: string
-        icon?: React.ReactNode
-        trailing?: React.ReactNode
-      }) => (
-        <button type="button" onClick={() => pickerMocks.onValueChange?.(value)}>
-          {icon}
-          <span>{label}</span>
-          {trailing}
-        </button>
-      )
-    })
-  }
+// Radix's picker does not open in jsdom; the shared stand-in is the one place
+// this primitive is faked, so no test grows a private copy of it.
+vi.mock('@/components/ui/picker', async () => {
+  const { createPickerStub } = await import('@tests/utils/picker-stub')
+  return createPickerStub()
 })
 
 describe('ReminderPicker', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2026, 4, 10, 10, 0, 0, 0))
-    pickerMocks.onValueChange = null
-    pickerMocks.onOpenChange = null
     vi.mocked(trackTelemetry).mockClear()
   })
 

--- a/apps/desktop/src/renderer/src/components/zero-renderer-surfaces-extra.test.tsx
+++ b/apps/desktop/src/renderer/src/components/zero-renderer-surfaces-extra.test.tsx
@@ -79,16 +79,16 @@ vi.mock('@/hooks/use-note-reminders', () => ({
   })
 }))
 
-vi.mock('@/components/reminder', () => ({
-  ReminderPicker: ({ trigger, onSelect }: any) => (
-    <div>
-      {trigger}
-      <button type="button" onClick={() => onSelect(new Date('2026-05-10T10:00:00.000Z'), 'note')}>
-        select reminder
-      </button>
-    </div>
-  )
-}))
+vi.mock('@/lib/telemetry', () => ({ trackTelemetry: vi.fn() }))
+
+// The real `ReminderPicker` renders here on purpose: a hand-written stub would
+// re-declare `onSelect` from this file's reading of it, which is exactly how the
+// note-dropping bug in #1527 stayed green. Only the Radix primitive underneath
+// is stood in, because it does not open in jsdom.
+vi.mock('@/components/ui/picker', async () => {
+  const { createPickerStub } = await import('@tests/utils/picker-stub')
+  return createPickerStub()
+})
 
 vi.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -194,8 +194,15 @@ describe('extra zero renderer surfaces', () => {
 
     render(<NoteReminderButton noteId="note-1" />)
     expect(screen.getByText('9+')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'select reminder' }))
-    expect(mocks.setReminder).toHaveBeenCalledWith(new Date('2026-05-10T10:00:00.000Z'), 'note')
+
+    // The note goes in through the picker's own textarea, so it only reaches
+    // `setReminder` if this button reads the argument the picker actually sends.
+    fireEvent.change(
+      screen.getByPlaceholderText('phaseF.componentsReminderReminderPicker.addANoteOptional'),
+      { target: { value: 'note' } }
+    )
+    fireEvent.click(screen.getByTestId('preset-tomorrow'))
+    expect(mocks.setReminder).toHaveBeenCalledWith(expect.any(Date), 'note')
   })
 
   it('renders tab bar context actions and title truncation', () => {

--- a/apps/desktop/tests/utils/picker-stub.tsx
+++ b/apps/desktop/tests/utils/picker-stub.tsx
@@ -1,0 +1,106 @@
+/**
+ * Shared stand-in for the `@/components/ui/picker` primitive.
+ *
+ * Radix's picker never opens in jsdom, so a test that has to reach the items
+ * inside a picker stubs the primitive. This is the only piece reminder tests
+ * are allowed to stub: the components built on top of it — `ReminderPicker`
+ * and its consumers — always render for real, so their callback contracts are
+ * read from the source instead of being re-declared per test file.
+ *
+ * That distinction is the point. Hand-written `ReminderPicker` stubs are what
+ * let the argument-order bug in #1527 live behind green tests: each stub called
+ * `onSelect` the way its consumer misread it, so the tests agreed with the bug
+ * for as long as the bug existed.
+ *
+ * Only the subset `ReminderPicker` uses is stubbed (`Trigger`, `Content`,
+ * `List`, `Item`, `Section`, `Separator`, `Footer`); a component that reaches
+ * for `Search`, `Empty` or `Panel` needs them added here.
+ *
+ * @module tests/utils/picker-stub
+ */
+
+import * as React from 'react'
+
+interface PickerRootProps {
+  children: React.ReactNode
+  onValueChange?: (value: string) => void
+  onOpenChange?: (open: boolean) => void
+}
+
+interface ChildrenProps {
+  children: React.ReactNode
+}
+
+interface PickerSectionProps {
+  label: string
+  children: React.ReactNode
+}
+
+interface PickerItemProps {
+  value: string
+  label?: string
+  icon?: React.ReactNode
+  trailing?: React.ReactNode
+}
+
+/**
+ * Build the module replacement for `vi.mock('@/components/ui/picker', ...)`.
+ *
+ * Each item renders as a button carrying both its label and a
+ * `preset-<value>` test id, so a test can click by whichever it cares about.
+ *
+ * @example
+ * vi.mock('@/components/ui/picker', async () => {
+ *   const { createPickerStub } = await import('@tests/utils/picker-stub')
+ *   return createPickerStub()
+ * })
+ */
+export function createPickerStub() {
+  const handlers: {
+    onValueChange: ((value: string) => void) | null
+    onOpenChange: ((open: boolean) => void) | null
+  } = { onValueChange: null, onOpenChange: null }
+
+  const PickerRoot = ({
+    children,
+    onValueChange,
+    onOpenChange
+  }: PickerRootProps): React.ReactElement => {
+    handlers.onValueChange = onValueChange ?? null
+    handlers.onOpenChange = onOpenChange ?? null
+    return <div>{children}</div>
+  }
+
+  return {
+    Picker: Object.assign(PickerRoot, {
+      Trigger: ({ children }: ChildrenProps) => (
+        <div onClick={() => handlers.onOpenChange?.(true)}>{children}</div>
+      ),
+      Content: ({ children }: ChildrenProps) => <div>{children}</div>,
+      List: ({ children }: ChildrenProps) => <div>{children}</div>,
+      Footer: ({ children, className }: ChildrenProps & { className?: string }) => (
+        <div data-slot="picker-footer" className={className}>
+          {children}
+        </div>
+      ),
+      Section: ({ label, children }: PickerSectionProps) => (
+        <section aria-label={label}>
+          <h3>{label}</h3>
+          {children}
+        </section>
+      ),
+      Separator: () => <hr />,
+      Item: ({ value, label, icon, trailing }: PickerItemProps) => (
+        <button
+          type="button"
+          data-testid={`preset-${value}`}
+          onClick={() => handlers.onValueChange?.(value)}
+        >
+          {icon}
+          <span>{label}</span>
+          {trailing}
+        </button>
+      )
+    })
+  }
+}


### PR DESCRIPTION
Closes #1545.

## The problem

`journal-small-components.test.tsx` and `zero-renderer-surfaces-extra.test.tsx` each hand-wrote a `ReminderPicker` stub that called `onSelect` the way its *consumer* misread it. The real picker was passing a middle argument the consumer bound its note variable to, so the user's note was silently dropped — and both test files agreed with the bug, because each had restated the contract from the same misreading. They were green before #1527's fix, green after it, and would have stayed green for as long as the bug lived.

#1536 removed `title` from the signature, so the two-argument stubs became correct by accident. That is the part worth closing: they were duplicates of a contract they did not track.

## The change

Both stubs are deleted. The real `ReminderPicker` renders in their place, so the contract is read from the component instead of being restated per test file — there is now no hand-written `ReminderPicker` double anywhere in the repo.

The one thing still faked is the Radix picker primitive underneath, which does not open in jsdom. That fake moved into a single shared stand-in, `apps/desktop/tests/utils/picker-stub.tsx`, replacing three near-identical private copies (`reminder-picker.test.tsx`, `note-reminder-button.test.tsx`, `journal-reminder-button.test.tsx`). Net −141 lines of duplicated mock.

The two sweep tests now type into the picker's real textarea and click a real preset, so the note only reaches `setReminder` if the consumer reads the argument the picker actually sends.

## Verification

- 6 affected test files: **32 passed**.
- **Mutation test** — reinstating the #1527 middle argument in `reminder-picker.tsx` (`onSelect(date, undefined, note)`) turns **4 tests red, including both sweep tests**. Under the old stubs they stayed green through exactly this bug. Mutation reverted; suite green again.
- `typecheck:test`: no errors in any touched file. The two errors it reports are pre-existing `sidebar-nav.test.tsx` failures from `808a4e431` on main, unrelated to this branch.
- Test-only change; `docs:impact --strict` reports no docs-relevant changes.