### PR TITLE
fix(sync): carry the unmerged-CRDT-note debt across a session boundary

### DIFF
--- a/apps/desktop/src/main/sync/crdt-snapshot-endpoint-seam.test.ts
+++ b/apps/desktop/src/main/sync/crdt-snapshot-endpoint-seam.test.ts
@@ -128,6 +128,7 @@ const runtimeMocks = vi.hoisted(() => {
     db: null as any,
     indexRows: [] as Array<{ id: string; title: string; date: string | null }>,
     currentDevice: { id: 'device-1', signingPublicKey: null as string | null },
+    syncStateRows: [] as Array<{ value: string }>,
     getDatabase: vi.fn(),
     getIndexDatabase: vi.fn(),
     retrieveToken: vi.fn(),
@@ -461,14 +462,26 @@ vi.mock('./key-verification', () => ({
 
 function createDb() {
   const updateRun = vi.fn()
+  // `sync_state` rows, read through SyncStateManager.getStateValue (`.all()`)
+  // rather than the device lookup (`.get()`). The endpoint choice reads one of
+  // them — `crdtUnmergedDebt`, the record that a previous session ended holding
+  // notes it had not merged — so this is on the path, not scenery.
+  const stateInsertRun = vi.fn()
   return {
     updateRun,
+    stateInsertRun,
     db: {
       select: vi.fn(() => ({
         from: vi.fn(() => ({
           where: vi.fn(() => ({
-            get: vi.fn(() => runtimeMocks.currentDevice)
+            get: vi.fn(() => runtimeMocks.currentDevice),
+            all: vi.fn(() => runtimeMocks.syncStateRows)
           }))
+        }))
+      })),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          onConflictDoUpdate: vi.fn(() => ({ run: stateInsertRun }))
         }))
       })),
       update: vi.fn(() => ({
@@ -512,6 +525,7 @@ describe('CRDT snapshot push endpoint choice, coordinator to wire', () => {
     runtimeMocks.workerStartError = null
     runtimeMocks.indexRows = [{ id: 'note-1', title: 'Note 1', date: null }]
     runtimeMocks.currentDevice = { id: 'device-1', signingPublicKey: null }
+    runtimeMocks.syncStateRows = []
     runtimeMocks.db = createDb()
     runtimeMocks.getDatabase.mockReturnValue(runtimeMocks.db.db)
     runtimeMocks.getIndexDatabase.mockReturnValue(createIndexDb())
@@ -620,6 +634,53 @@ describe('CRDT snapshot push endpoint choice, coordinator to wire', () => {
     expect(runtimeMocks.pushCrdtFullUpdate).not.toHaveBeenCalled()
     expect(runtimeMocks.pushCrdtSnapshot).toHaveBeenCalledWith(
       'note-merged',
+      new Uint8Array([10, 11]),
+      'access-token'
+    )
+
+    await stop()
+  })
+
+  it('routes every note away from the prune when the last session ended holding debt', async () => {
+    // #given the previous session quit with a note it had not merged. The set
+    // naming that note is per session and `clearCaches()` emptied it, and this
+    // launch is inside the sweep interval, so `shouldSweepAllCrdtNotes` queues
+    // nothing that would re-raise it. All that survives is the `sync_state`
+    // record that debt existed.
+    runtimeMocks.syncStateRows = [{ value: '1' }]
+    const { snapshotPush, stop } = await bootRuntime()
+
+    // #when the user edits a note this session has never pulled, merged or even
+    // heard of, and the 30s quiet period pushes its full state
+    await snapshotPush('note-from-last-session', new Uint8Array([1, 2, 3]))
+
+    // #then it still must not reach /sync/crdt/snapshot. That note may be the
+    // one the last session failed to merge — this session cannot tell — and with
+    // no snapshot stored the prune's watermark is `currentSeq`, so it would
+    // delete every peer row the note has.
+    expect(runtimeMocks.pushCrdtSnapshot).not.toHaveBeenCalled()
+    expect(runtimeMocks.pushCrdtFullUpdate).toHaveBeenCalledWith(
+      'note-from-last-session',
+      new Uint8Array([10, 11]),
+      'access-token'
+    )
+
+    await stop()
+  })
+
+  it('snapshots normally when the last session ended with nothing outstanding', async () => {
+    // #given no carried-over debt — the ordinary case, and the one that keeps
+    // the blanket from quietly costing every install its compaction point
+    runtimeMocks.syncStateRows = []
+    const { snapshotPush, stop } = await bootRuntime()
+
+    // #when
+    await snapshotPush('note-untouched', new Uint8Array([1, 2, 3]))
+
+    // #then
+    expect(runtimeMocks.pushCrdtFullUpdate).not.toHaveBeenCalled()
+    expect(runtimeMocks.pushCrdtSnapshot).toHaveBeenCalledWith(
+      'note-untouched',
       new Uint8Array([10, 11]),
       'access-token'
     )

--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -184,6 +184,11 @@ export class SyncEngine extends EventEmitter {
       },
       (itemId, itemType) => this.quarantine.isQuarantined(itemId, itemType)
     )
+    // Wired after the runner exists, for the same reason the coordinators above
+    // are: the coordinator raises the debt and the runner is what persists it,
+    // and neither can be constructed holding the other.
+    this.crdtSync.onUnmergedDebtChange = (hasDebt) =>
+      this.fullSyncRunner.recordCrdtUnmergedDebt(hasDebt)
     this.ctx.doPush = () => this.push()
     SyncEngine.activeInstance = this
   }
@@ -405,9 +410,16 @@ export class SyncEngine extends EventEmitter {
    * queued and has not run — so a snapshot push would delete or overwrite that
    * state. The CRDT snapshot push fn asks this before choosing an endpoint; see
    * `CrdtSyncCoordinator.hasUnmergedRemoteState`.
+   *
+   * It is also `true` for every note while this session cannot yet name them:
+   * the per-note set does not survive a quit, so a session that starts after one
+   * that ended holding debt has to answer for the whole vault until a sweep
+   * rebuilds the flags. See `FullSyncRunner.crdtUnmergedStateUnknown`.
    */
   hasUnmergedRemoteCrdtState(noteId: string): boolean {
-    return this.crdtSync.hasUnmergedRemoteState(noteId)
+    return (
+      this.fullSyncRunner.crdtUnmergedStateUnknown || this.crdtSync.hasUnmergedRemoteState(noteId)
+    )
   }
 
   async fullSync(options: { forceCrdtSweep?: boolean } = {}): Promise<void> {

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
@@ -959,6 +959,57 @@ describe('CrdtSyncCoordinator', () => {
     // merely stale, and the next pass has nothing left to reconcile against.
     expect(seedFromMarkdownPublic).not.toHaveBeenCalled()
   })
+
+  it('reports unmerged debt on the empty/non-empty edges only, and never on teardown', async () => {
+    // #given the set is per session: `clearCaches()` empties it, so a note left
+    // unmerged at quit came back on the next launch looking merged — and merged
+    // is the answer that lets a snapshot push prune a peer's rows. Only the
+    // *fact* of debt is durable, so only its edges are worth reporting.
+    const { ctx } = createBatchContext()
+    postToServerMock.mockResolvedValue({ notes: { 'note-1': { updates: [], hasMore: false } } })
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+    const onUnmergedDebtChange = vi.fn()
+    coordinator.onUnmergedDebtChange = onUnmergedDebtChange
+
+    // #when a second flagged note joins the first
+    coordinator.markRemoteStateUnmerged('note-1')
+    coordinator.markRemoteStateUnmerged('note-2')
+
+    // #then one report, not one per note
+    expect(onUnmergedDebtChange.mock.calls).toEqual([[true]])
+    expect(coordinator.hasUnmergedNotes).toBe(true)
+
+    // #when a pass walks one of them end to end, leaving the other flagged
+    await coordinator.applyCrdtBatch(['note-1'], 'token-1', new Uint8Array([4]))
+
+    // #then still nothing to say: debt outstanding is debt outstanding
+    expect(onUnmergedDebtChange.mock.calls).toEqual([[true]])
+    expect(coordinator.hasUnmergedNotes).toBe(true)
+
+    // #when the last one clears
+    postToServerMock.mockResolvedValue({ notes: { 'note-2': { updates: [], hasMore: false } } })
+    await coordinator.applyCrdtBatch(['note-2'], 'token-1', new Uint8Array([4]))
+
+    // #then the durable record can be dropped
+    expect(onUnmergedDebtChange.mock.calls).toEqual([[true], [false]])
+    expect(coordinator.hasUnmergedNotes).toBe(false)
+  })
+
+  it('does not report the emptying of the set at teardown as debt paid', async () => {
+    // #given a vault close or sign-out with a note still unmerged
+    const { ctx } = createBatchContext()
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+    const onUnmergedDebtChange = vi.fn()
+    coordinator.markRemoteStateUnmerged('note-1')
+    coordinator.onUnmergedDebtChange = onUnmergedDebtChange
+
+    // #when
+    coordinator.clearCaches()
+
+    // #then reporting "no debt" here would erase the one record that survives
+    // the session — which is exactly the note the next launch must not snapshot.
+    expect(onUnmergedDebtChange).not.toHaveBeenCalled()
+  })
 })
 
 describe('CrdtSyncCoordinator.clearCaches', () => {

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -63,6 +63,26 @@ export class CrdtSyncCoordinator {
    */
   private unmergedRemoteNotes = new Set<string>()
 
+  /**
+   * Told when the set above goes from empty to non-empty and back.
+   *
+   * The set cannot be its own durable record: it is per session and
+   * `clearCaches()` empties it at teardown, so a note left unmerged at quit came
+   * back unflagged on the next launch — and unflagged is the answer that lets a
+   * snapshot push prune the peer rows this device never read. Nor does the next
+   * launch necessarily re-raise it: the vault-wide sweep is throttled against a
+   * *persisted* stamp, so a restart inside that interval queues nothing.
+   *
+   * Only the fact that debt exists travels; which notes it was does not.
+   * `FullSyncRunner` persists this and answers every note conservatively until
+   * a sweep has flagged them individually again, which is both cheaper than a
+   * durable id set and strictly safer than one — an id set could still be
+   * missing whatever the crash did not get to write.
+   */
+  onUnmergedDebtChange?: (hasDebt: boolean) => void
+  /** Last value handed to `onUnmergedDebtChange`, so only transitions are sent. */
+  private reportedUnmergedDebt = false
+
   constructor(ctx: SyncContext, resolveDeviceKey: ResolveDeviceKey) {
     this.ctx = ctx
     this.resolveDeviceKey = resolveDeviceKey
@@ -89,6 +109,19 @@ export class CrdtSyncCoordinator {
    */
   markRemoteStateUnmerged(noteId: string): void {
     this.unmergedRemoteNotes.add(noteId)
+    this.reportUnmergedDebt()
+  }
+
+  /** Does this device hold debt for any note at all? */
+  get hasUnmergedNotes(): boolean {
+    return this.unmergedRemoteNotes.size > 0
+  }
+
+  private reportUnmergedDebt(): void {
+    const hasDebt = this.unmergedRemoteNotes.size > 0
+    if (hasDebt === this.reportedUnmergedDebt) return
+    this.reportedUnmergedDebt = hasDebt
+    this.onUnmergedDebtChange?.(hasDebt)
   }
 
   /**
@@ -137,6 +170,10 @@ export class CrdtSyncCoordinator {
     this.pendingPulls.clear()
     this.lastAppliedSequence.clear()
     this.applyFailureReported.clear()
+    // Deliberately silent: `reportUnmergedDebt` is not called here. This is a
+    // teardown, not a note that finished merging, and reporting "no debt" for it
+    // would erase the durable record of debt that outlives the session — which
+    // is the whole thing that record exists to carry.
     this.unmergedRemoteNotes.clear()
   }
 
@@ -167,7 +204,8 @@ export class CrdtSyncCoordinator {
    * the pass's own clean result alone would call such a note safe to snapshot.
    */
   private clearUnmergedIfClean(noteId: string, sawUnmerged: boolean): void {
-    if (!sawUnmerged && !this.pendingPulls.has(noteId)) this.unmergedRemoteNotes.delete(noteId)
+    if (sawUnmerged || this.pendingPulls.has(noteId)) return
+    if (this.unmergedRemoteNotes.delete(noteId)) this.reportUnmergedDebt()
   }
 
   private rememberAppliedSequence(noteId: string, sequenceNum: number): number {

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
@@ -53,11 +53,22 @@ vi.mock('../../database/client', () => ({
 
 class FakeCrdtSync {
   private pending = new Set<string>()
+  /**
+   * Mirrors the real coordinator: a note queued for a pull is by definition one
+   * whose server state is not in the local doc yet, so it is flagged too. The
+   * runner reads this back after a sweep to re-state the persisted debt.
+   */
+  unmerged = new Set<string>()
   pullCrdtForNote = vi.fn(async () => {})
   pullCrdtForNotes = vi.fn(async (_noteIds: string[], _signal?: AbortSignal) => {})
 
+  get hasUnmergedNotes(): boolean {
+    return this.unmerged.size > 0
+  }
+
   addPendingPull(noteId: string): void {
     this.pending.add(noteId)
+    this.unmerged.add(noteId)
   }
 
   get pendingPullCount(): number {
@@ -598,6 +609,84 @@ describe('FullSyncRunner', () => {
       await h.runner.run()
 
       expect(h.calls).toContain(`setState:${SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT}`)
+    })
+  })
+
+  // The per-note unmerged set is in-memory and per session, so a note left
+  // unmerged at quit came back on the next launch looking merged — and a launch
+  // inside the sweep interval queues nothing that would re-raise it. One edit
+  // 30 s later then pushed a snapshot, and the server prunes every `crdt_updates`
+  // row at or below the new watermark, including the peer rows this device never
+  // read. Only the fact that debt existed is persisted; the ids are re-derived.
+  describe('#given the previous session ended holding unmerged notes', () => {
+    it('#then every note reads as unmerged until a sweep rebuilds the flags', () => {
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.CRDT_UNMERGED_DEBT ? '1' : undefined
+      )
+
+      expect(h.runner.crdtUnmergedStateUnknown).toBe(true)
+    })
+
+    it('#then a clean set cannot clear the persisted debt before that sweep', () => {
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.CRDT_UNMERGED_DEBT ? '1' : undefined
+      )
+
+      // An empty set here is the emptiness this session started with, not an
+      // answer about what the last one left behind.
+      h.runner.recordCrdtUnmergedDebt(false)
+
+      expect(h.setStateValue).not.toHaveBeenCalledWith(SYNC_STATE_KEYS.CRDT_UNMERGED_DEBT, '0')
+      expect(h.runner.crdtUnmergedStateUnknown).toBe(true)
+    })
+
+    it('#then the sweep drops the blanket only once every note carries its own flag', async () => {
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.CRDT_UNMERGED_DEBT ? '1' : undefined
+      )
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+
+      await h.runner.run()
+
+      expect(h.runner.crdtUnmergedStateUnknown).toBe(false)
+      expect(h.crdtSync.unmerged).toEqual(new Set(['note-1', 'note-2']))
+      // The vault's own set is authoritative from here, so the key is re-stated
+      // from it rather than left holding the previous session's answer.
+      expect(h.setStateValue).toHaveBeenCalledWith(SYNC_STATE_KEYS.CRDT_UNMERGED_DEBT, '1')
+    })
+
+    it('#then a sweep that finds nothing to flag clears the carried-over debt', async () => {
+      // Otherwise an empty vault — or one whose notes all cleared before the key
+      // was written — blankets every launch from here on, forever.
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.CRDT_UNMERGED_DEBT ? '1' : undefined
+      )
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue([])
+
+      await h.runner.run()
+
+      expect(h.setStateValue).toHaveBeenCalledWith(SYNC_STATE_KEYS.CRDT_UNMERGED_DEBT, '0')
+      expect(h.runner.crdtUnmergedStateUnknown).toBe(false)
+    })
+  })
+
+  describe('#given no carried-over debt #when the coordinator reports a transition', () => {
+    it('#then it is persisted as it happens, not at teardown', () => {
+      // A session that is killed rather than stopped never runs a teardown, and
+      // that is exactly the session whose debt has to survive.
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
+
+      h.runner.recordCrdtUnmergedDebt(true)
+      h.runner.recordCrdtUnmergedDebt(false)
+
+      expect(h.setStateValue).toHaveBeenNthCalledWith(1, SYNC_STATE_KEYS.CRDT_UNMERGED_DEBT, '1')
+      expect(h.setStateValue).toHaveBeenNthCalledWith(2, SYNC_STATE_KEYS.CRDT_UNMERGED_DEBT, '0')
     })
   })
 

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.ts
@@ -92,6 +92,15 @@ export class FullSyncRunner {
    * controller stays aborted and a later engine must not inherit it.
    */
   private pacedCrdtPullAbort: AbortController | null = null
+  /**
+   * Did the *previous* session end holding notes whose server state it had not
+   * merged? Null until the persisted answer is read.
+   *
+   * Read lazily rather than in the constructor: this runner is built inside the
+   * SyncEngine constructor, and a `sync_state` lookup belongs to the first cycle
+   * that needs it rather than to construction.
+   */
+  private carriedUnmergedDebt: boolean | null = null
 
   constructor(
     ctx: SyncContext,
@@ -126,6 +135,57 @@ export class FullSyncRunner {
    * most likely looking at a stale note, so it must not wait out the interval.
    * Only when the trigger is unknowable does the interval decide.
    */
+  /**
+   * Can this session still not name the notes whose server state it has not
+   * merged?
+   *
+   * `CrdtSyncCoordinator.unmergedRemoteNotes` is per session and `clearCaches()`
+   * empties it at teardown, so an unmerged note came back on the next launch
+   * looking merged — and "merged" is the answer that routes its push to the
+   * endpoint that prunes every peer row at or below the new snapshot's
+   * watermark. Nor did the launch necessarily re-raise the flag on its own:
+   * `shouldSweepAllCrdtNotes` falls through to a *persisted* interval stamp, so
+   * a restart inside that interval with no reconnect gap queues no pulls at all.
+   * A single edit 30 s later was then enough to destroy a peer's updates.
+   *
+   * While this is true the answer for **every** note is "unmerged", which is the
+   * same conservative answer the per-note flag gives, applied vault-wide until
+   * the flags exist again. It costs those pushes the snapshot endpoint — they go
+   * to `/sync/crdt/updates`, which stores and broadcasts the same bytes and
+   * prunes nothing — and nothing else.
+   *
+   * It is dropped by the first vault-wide sweep, which queues a pull for every
+   * note in the vault and so flags every one of them individually: the blanket
+   * is retired because it has been made redundant, not because it went stale.
+   * That sweep is at most `CRDT_FULL_SWEEP_MIN_INTERVAL_MS` away.
+   *
+   * Persisting the note ids instead was the obvious alternative and is worse on
+   * both counts: it needs a new on-disk format in a live beta, and a crash can
+   * still leave it missing whatever it had not written yet, while a boolean that
+   * is already `'1'` cannot become wrong by not being written again.
+   */
+  get crdtUnmergedStateUnknown(): boolean {
+    this.carriedUnmergedDebt ??=
+      this.stateManager.getStateValue(SYNC_STATE_KEYS.CRDT_UNMERGED_DEBT) === '1'
+    return this.carriedUnmergedDebt
+  }
+
+  /**
+   * Persist the coordinator's empty ↔ non-empty transitions.
+   *
+   * Written as they happen rather than at teardown, because the case this has to
+   * survive is a session that never runs its teardown at all — a crash, a kill,
+   * a power cut. A transition is two writes per sweep cycle at worst: one when
+   * the sweep queues the vault, one when the paced drain finishes it.
+   */
+  recordCrdtUnmergedDebt(hasDebt: boolean): void {
+    // An empty set is not an answer while the flags have not been rebuilt — it
+    // is the emptiness this session *started* with, and clearing the key on it
+    // would hand the next launch the same false "everything is merged".
+    if (!hasDebt && this.crdtUnmergedStateUnknown) return
+    this.stateManager.setStateValue(SYNC_STATE_KEYS.CRDT_UNMERGED_DEBT, hasDebt ? '1' : '0')
+  }
+
   private shouldSweepAllCrdtNotes(force: boolean): boolean {
     // Nothing is fetchable while offline. Sweeping here would schedule pulls
     // that are guaranteed to fail and then stamp the interval, hiding real
@@ -254,6 +314,16 @@ export class FullSyncRunner {
     for (const noteId of getAllCrdtNoteIds(getIndexDatabase())) {
       this.crdtSync.addPendingPull(noteId)
     }
+    // Every note in the vault now carries its own flag, so the vault-wide
+    // blanket a carried-over debt raised has nothing left to cover. Dropped
+    // after the loop and never before it: in between, a push would read a
+    // not-yet-flagged note as safe to snapshot.
+    this.carriedUnmergedDebt = false
+    // Re-state the key from this session's own set now that it is authoritative.
+    // Without this, a sweep that flags nothing — an empty vault, or one whose
+    // notes all cleared before the key was ever written — would leave the
+    // previous session's `'1'` standing and blanket every launch from here on.
+    this.recordCrdtUnmergedDebt(this.crdtSync.hasUnmergedNotes)
     this.lastSweepConnectionGeneration = this.ctx.deps.ws?.connectionGeneration ?? null
     this.crdtSweepOwed = false
     this.stateManager.setStateValue(SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT, String(Date.now()))

--- a/apps/desktop/src/main/sync/engine/sync-context.test.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.test.ts
@@ -77,7 +77,11 @@ describe('SYNC_STATE_KEYS', () => {
         LAST_MANIFEST_CHECK_AT: 'lastManifestCheckAt',
         // Additive: absent on installs written by older builds, which reads
         // back as 0 and simply runs the vault-wide CRDT sweep once.
-        LAST_CRDT_SWEEP_AT: 'lastCrdtSweepAt'
+        LAST_CRDT_SWEEP_AT: 'lastCrdtSweepAt',
+        // Additive too: absent reads as '0' — "the last session ended with
+        // every note merged" — which is both what an older build's install
+        // means and the answer that changes nothing.
+        CRDT_UNMERGED_DEBT: 'crdtUnmergedDebt'
       })
     })
 

--- a/apps/desktop/src/main/sync/engine/sync-context.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.ts
@@ -85,7 +85,21 @@ export const SYNC_STATE_KEYS = {
   INITIAL_SEED_DONE: 'initialSeedDone',
   QUARANTINED_ITEMS: 'quarantinedItems',
   LAST_MANIFEST_CHECK_AT: 'lastManifestCheckAt',
-  LAST_CRDT_SWEEP_AT: 'lastCrdtSweepAt'
+  LAST_CRDT_SWEEP_AT: 'lastCrdtSweepAt',
+  /**
+   * `'1'` while some note's server state is known-unmerged, `'0'` once none is.
+   *
+   * The set of *which* notes lives in `CrdtSyncCoordinator.unmergedRemoteNotes`
+   * and is per session — `clearCaches()` empties it at teardown — so a quit
+   * between a failed merge and the next launch used to leave the note looking
+   * merged and therefore safe to snapshot. Only the boolean is persisted; the
+   * ids are re-derived by the next vault-wide sweep, which flags every note it
+   * queues. See `FullSyncRunner.crdtUnmergedStateUnknown`.
+   *
+   * A missing row reads as `'0'`, which is what every install written before
+   * this key existed has and what a vault with nothing outstanding means.
+   */
+  CRDT_UNMERGED_DEBT: 'crdtUnmergedDebt'
 } as const
 
 // Item ids are NOT unique across item types (default project id 'inbox', tag

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -1027,12 +1027,43 @@ pending and retried rather than snapshotted — a stall, not a loss, its content
 already durable in the local CRDT store — and it ends as soon as the note merges
 and the snapshot route reopens.
 
+### The flag does not survive a session; the fact that debt existed does
+
 The set is in-memory and per session; `clearCaches()` empties it on vault switch
-and teardown. A note whose pull failed in one session carries no flag in the
-next, and a restart does not necessarily re-flag it: `shouldSweepAllCrdtNotes`
-reads the _persisted_ `LAST_CRDT_SWEEP_AT`, so a restart inside the sweep
-interval with no reconnect gap sweeps nothing. Closing that would need the flag
-on disk, which is a new format and a migration.
+and teardown. A note whose pull failed in one session therefore carried no flag
+in the next, and the next launch did not necessarily re-raise it:
+`shouldSweepAllCrdtNotes` reads the _persisted_ `LAST_CRDT_SWEEP_AT`, so a
+restart inside the sweep interval with no reconnect gap sweeps nothing. Edit
+that note, wait out the 30 s quiet period, and its snapshot push prunes at
+`currentSeq` — the peer rows the last session failed to merge, gone.
+
+What is persisted is one boolean, `sync_state.crdtUnmergedDebt`, written on the
+set's empty ↔ non-empty edges (`CrdtSyncCoordinator.onUnmergedDebtChange` →
+`FullSyncRunner.recordCrdtUnmergedDebt`). Written as the edges happen rather
+than at teardown, because the session this has to survive is one that never runs
+a teardown at all.
+
+While it reads `'1'`, `FullSyncRunner.crdtUnmergedStateUnknown` is true and
+`SyncEngine.hasUnmergedRemoteCrdtState` answers `true` for **every** note — the
+same conservative answer the per-note flag gives, applied vault-wide because
+this session cannot yet name the notes the last one left behind. It is dropped
+by the first vault-wide sweep, which queues a pull for every note in the vault
+and so flags each one individually: the blanket retires because it has been made
+redundant, not because it went stale. That sweep is at most
+`CRDT_FULL_SWEEP_MIN_INTERVAL_MS` away, and it re-states the key from this
+session's own set so an empty or already-clean vault cannot carry a stale `'1'`
+into every launch from then on.
+
+Cost while the blanket is up: those pushes take the update endpoint instead of
+the snapshot one, with the request count and the `MAX_CRDT_UPDATE_PAYLOAD_CHARS`
+stall described above, and nothing else. A missing row reads as `'0'`, which is
+what every install written before the key existed has and what a vault with
+nothing outstanding means, so no migration is involved.
+
+Persisting the note ids instead is worse on both counts: a new on-disk format in
+a live beta, and a crash can still leave it missing whatever it had not written
+yet, while a boolean already at `'1'` cannot become wrong by not being written
+again.
 
 ## Sign-Out / Sign-In Ordering
 


### PR DESCRIPTION
Closes #1532. Follow-up to #1503 / #1533 (EPIC #1516).

## The hole

`CrdtSyncCoordinator.unmergedRemoteNotes` — the set that keeps a snapshot push off the pruning endpoint — is in-memory and per session, and `clearCaches()` empties it at teardown.

1. Peer A pushes incrementals for note N. This device fails to merge them (rate-limited baseline, failed pull, dropped batch). N is flagged.
2. The user quits. The flag is gone.
3. The next launch does not necessarily re-raise it. A fresh `FullSyncRunner` has `lastSweepConnectionGeneration === null`, so `shouldSweepAllCrdtNotes` falls through to the **persisted** `LAST_CRDT_SWEEP_AT` — a restart inside `CRDT_FULL_SWEEP_MIN_INTERVAL_MS` with no reconnect gap queues nothing.
4. The user edits N. 30 s quiet → snapshot push → `storeSnapshot` computes `sequenceNum = existingSnapshot?.sequence_num ?? currentSeq`, so for a note with no snapshot yet the watermark is `currentSeq` and `pruneUpdatesBeforeSnapshot` deletes every row A wrote. Gone from the server, absent from the snapshot replacing them, destroyed for every device.

Narrower than #1503 — it needs a quit between the failed merge and the edit, and a restart inside the sweep interval — but the same permanent loss.

## The fix

One boolean, `sync_state.crdtUnmergedDebt`, written on the set's empty ↔ non-empty edges (`CrdtSyncCoordinator.onUnmergedDebtChange` → `FullSyncRunner.recordCrdtUnmergedDebt`). Written as the edges happen rather than at teardown, because the session this has to survive is one that never runs a teardown at all.

While it reads `'1'`, `FullSyncRunner.crdtUnmergedStateUnknown` is true and `SyncEngine.hasUnmergedRemoteCrdtState` answers `true` for **every** note — the same conservative answer the per-note flag gives, applied vault-wide because this session cannot yet name the notes the last one left behind. Those pushes take `/sync/crdt/updates`, which stores and broadcasts the same bytes and prunes nothing.

The first vault-wide sweep drops the blanket: it queues a pull for every note in the vault and so flags each one individually, so the blanket retires because it has been made redundant, not because it went stale. That sweep is at most `CRDT_FULL_SWEEP_MIN_INTERVAL_MS` away, and it re-states the key from this session's own set so an empty or already-clean vault cannot carry a stale `'1'` into every launch from then on.

## Why not the alternatives on the issue

- **Persist the note ids.** A new on-disk format in a live beta, and a crash can still leave it missing whatever it had not written yet. A boolean already at `'1'` cannot become wrong by not being written again. (The issue's caveat that `crdt-pending-notes.ts` is an unsafe carrier is also stale — #1512 made it atomic.)
- **Force a sweep on the first fullSync after a launch.** One O(vault) pass per app start whether or not there is debt — ~10 minutes of paced pulls on a 1000-note vault, every launch. It also cuts against the reasoning already on `lastSweepConnectionGeneration`: "no sweep recorded yet" deliberately does not mean "sweep now".
- **Server refuses to prune below a first snapshot.** Removes the class, but the watermark is what the client's `since` cursor reads, so a first snapshot that prunes nothing either re-pulls the whole history forever or defers the same destructive prune to the next push. The principled version is the client sending its merged watermark — a protocol change, its own PR.

## Compat

Additive key in the existing `sync_state` table. A missing row reads as `'0'` — "the last session ended with every note merged" — which is both what every install written by an older build has and the answer that changes nothing. No migration, no format change.

## Cost

While the blanket is up, pushes take the update endpoint instead of the snapshot one: same request count (both on the `crdt_push` bucket), one full-state `crdt_updates` row instead of an R2 blob upsert, reclaimed by the first unflagged snapshot push. A note over `MAX_CRDT_UPDATE_PAYLOAD_CHARS` stays pending and retried rather than snapshotted — a stall, not a loss, its content already durable locally — and it ends when the sweep runs. Two `sync_state` upserts per sweep cycle at worst.

## Verification

- `vitest --project main src/main/sync` — 158 files, 2335 tests green
- End-to-end seam coverage in `crdt-snapshot-endpoint-seam.test.ts`: a real coordinator inside a real engine inside the real runtime, only HTTP mocked. Removing `crdtUnmergedStateUnknown ||` from `hasUnmergedRemoteCrdtState` turns "routes every note away from the prune when the last session ended holding debt" red, and nothing else.
- `eslint` 0 errors · `typecheck:node` 0 errors · `docs:impact --base origin/main --strict` covered · `docs:build` ok

Pre-existing on `main`, untouched here: `sidebar-nav.test.tsx` (missing `onNavMiddleClick`, 2 errors) and `apps/sync-server/src/services/posthog-transform.test.ts:315` (missing `failure`) both fail `pnpm typecheck`.

Refs #1503, #1516, #1512, #1533