### PR TITLE
fix(sync): a local-only note no longer pulls, and a mid-flush toggle drops its buffer

### DIFF
--- a/apps/desktop/src/main/sync/crdt-drain-teardown-seam.test.ts
+++ b/apps/desktop/src/main/sync/crdt-drain-teardown-seam.test.ts
@@ -158,6 +158,8 @@ const runtimeMocks = vi.hoisted(() => {
       open: vi.fn(async () => ({})),
       pushSnapshotForNote: vi.fn(async () => true),
       validateNoteForCrdt: vi.fn(() => ({ ok: true })),
+      isNoteSyncable: vi.fn((_noteId: string) => true),
+      isNoteLocalOnly: vi.fn((_noteId: string) => false),
       pushAllSnapshots: vi.fn(),
       destroy: vi.fn(),
       inactiveDocCapacity: 32,
@@ -463,6 +465,8 @@ describe('pending CRDT drain liveness, stopSyncRuntime to the durable store', ()
     runtimeMocks.crdtProvider.open.mockResolvedValue({})
     runtimeMocks.crdtProvider.pushSnapshotForNote.mockResolvedValue(true)
     runtimeMocks.crdtProvider.validateNoteForCrdt.mockReturnValue({ ok: true })
+    runtimeMocks.crdtProvider.isNoteLocalOnly.mockReturnValue(false)
+    runtimeMocks.crdtProvider.isNoteSyncable.mockReturnValue(true)
     runtimeMocks.crdtProvider.pushAllSnapshots.mockResolvedValue(0)
     runtimeMocks.crdtProvider.destroy.mockResolvedValue(undefined)
     runtimeMocks.crdtProvider.getDoc.mockReturnValue(undefined)
@@ -508,6 +512,36 @@ describe('pending CRDT drain liveness, stopSyncRuntime to the durable store', ()
     })
     return { reached, release: letGo }
   }
+
+  it('clears a local-only id from the durable store instead of retaining it every session', async () => {
+    // An id can reach the store and then have its note marked local-only — the
+    // toggle races the queue's ~1s flush, and the queue's shutdown path records
+    // whatever it still holds. `pushSnapshotForNote` correctly refuses a
+    // local-only note, so before this the drain could never clear the id: it was
+    // retained, warned about once per session, and never settled.
+    const { readPendingCrdtNotes, recordPendingCrdtNotes } = await import('./crdt-pending-notes')
+    recordPendingCrdtNotes(['note-local', 'note-a'])
+    runtimeMocks.crdtProvider.isNoteLocalOnly.mockImplementation(
+      (noteId: string) => noteId === 'note-local'
+    )
+    runtimeMocks.crdtProvider.isNoteSyncable.mockImplementation(
+      (noteId: string) => noteId !== 'note-local'
+    )
+
+    const runtime = await import('./runtime')
+
+    // #when the startup replay runs
+    await runtime.startSyncRuntime()
+    await vi.waitFor(() => expect(readPendingCrdtNotes()).toEqual([]))
+
+    // #then the local-only note is neither merged nor pushed — it is simply not
+    // this store's business any more — while the note that can sync is.
+    expect(openedNotes()).toEqual(['note-a'])
+    expect(runtimeMocks.crdtProvider.pushSnapshotForNote).not.toHaveBeenCalledWith('note-local')
+    expect(runtimeMocks.crdtProvider.pushSnapshotForNote).toHaveBeenCalledWith('note-a')
+
+    await runtime.stopSyncRuntime()
+  })
 
   it('stops merging the rest of the backlog the moment its runtime is torn down', async () => {
     const { readPendingCrdtNotes, recordPendingCrdtNotes } = await import('./crdt-pending-notes')

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -299,7 +299,7 @@ const makeRemoteUpdate = (text: string): Uint8Array => {
 
 describe('CrdtProvider', () => {
   let provider: CrdtProvider
-  let queue: { enqueue: ReturnType<typeof vi.fn> }
+  let queue: { enqueue: ReturnType<typeof vi.fn>; dropNote: ReturnType<typeof vi.fn> }
   let pushSnapshot: ReturnType<typeof vi.fn<SnapshotPushFn>>
 
   beforeEach(async () => {
@@ -330,7 +330,7 @@ describe('CrdtProvider', () => {
       }
     )
     mocks.compactYDoc.mockReturnValue(null)
-    queue = { enqueue: vi.fn() }
+    queue = { enqueue: vi.fn(), dropNote: vi.fn() }
     pushSnapshot = vi.fn<SnapshotPushFn>().mockResolvedValue(undefined)
     provider = new CrdtProvider()
     await provider.init(queue as any, pushSnapshot)
@@ -1810,6 +1810,52 @@ describe('CrdtProvider', () => {
       // drainPendingCrdtNotes, which merges before it pushes.
       expect(pushSnapshot).not.toHaveBeenCalled()
       expect(readPendingCrdtNotes()).toEqual(['note-1'])
+      await singleton.destroy()
+    })
+
+    it('empties the update queue buffer the toggle cannot otherwise reach', async () => {
+      // The guard is at enqueue time (`onDocUpdate`) but the queue flushes on a
+      // ~1s loop, so everything typed in the second before the toggle is already
+      // buffered and past it. `setNoteLocalOnlyState` clears the pending-note
+      // store and zeroes the snapshot debt; neither reaches into the buffer.
+      const singleton = getCrdtProvider()
+      await singleton.init(queue as never, pushSnapshot)
+
+      const row = noteRow(false)
+      mocks.getNoteCacheById.mockImplementation(() => row)
+      mocks.updateNoteCache.mockImplementation((...args: unknown[]) =>
+        Object.assign(row, args[2] as object)
+      )
+
+      createWindow(1)
+      const doc = await singleton.open('note-1', 1, { skipSeed: true })
+      doc.getMap('meta').set('title', 'typed a moment before the toggle')
+      expect(queue.enqueue).toHaveBeenCalledTimes(1)
+
+      // #when the user marks it local-only before the flush loop ticks
+      setNoteLocalOnlyState('note-1', true)
+
+      // #then the buffered bytes are dropped rather than pushed on the next tick
+      expect(queue.dropNote).toHaveBeenCalledWith('note-1')
+      await singleton.destroy()
+    })
+
+    it('drops the queue buffer even for a note whose doc the LRU already evicted', async () => {
+      // `setNoteLocalOnly` returns early when there is no open doc, so the drop
+      // has to happen ahead of that lookup: a note can be enqueued and then have
+      // its doc closed underneath it, leaving the buffer as the only holder.
+      const singleton = getCrdtProvider()
+      await singleton.init(queue as never, pushSnapshot)
+
+      const row = noteRow(false)
+      mocks.getNoteCacheById.mockImplementation(() => row)
+      mocks.updateNoteCache.mockImplementation((...args: unknown[]) =>
+        Object.assign(row, args[2] as object)
+      )
+
+      setNoteLocalOnlyState('note-1', true)
+
+      expect(queue.dropNote).toHaveBeenCalledWith('note-1')
       await singleton.destroy()
     })
 

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -322,7 +322,7 @@ export class CrdtProvider {
       lastEncodedSize: 0,
       lastSizeCheckAt: 0,
       lastTouchedAt: this.now(),
-      localOnly: this.resolveLocalOnly(noteId)
+      localOnly: this.isNoteLocalOnly(noteId)
     }
     this.docs.set(noteId, entry)
 
@@ -344,8 +344,13 @@ export class CrdtProvider {
    * provider has always had, so an unreadable row costs sync nothing; the
    * authoritative check for the payload that actually carries a body — the
    * snapshot — re-reads the row live in `pushSnapshotForNote`.
+   *
+   * Public because the flag is not only a push-side concern: `CrdtSyncCoordinator`
+   * asks the same question before it pulls, and the pending-note replay asks it
+   * before it decides a note is syncable at all. Both want the live row rather
+   * than a doc's cached copy — neither is guaranteed to have the doc open.
    */
-  private resolveLocalOnly(noteId: string): boolean {
+  isNoteLocalOnly(noteId: string): boolean {
     try {
       return getNoteCacheById(getIndexDatabase(), noteId)?.localOnly === true
     } catch (err) {
@@ -373,8 +378,19 @@ export class CrdtProvider {
    * would let the next `close()` fire a *blind* snapshot first — and a snapshot
    * asserts completeness, so the server prunes the peer edits it does not
    * contain. The replay is the carrier for this body; close() must not race it.
+   *
+   * Going ON also empties the update queue's buffer for this note, and that is
+   * not the same window as the flag above. `onDocUpdate` reads the flag at
+   * *enqueue* time, but the queue flushes on a ~1s loop, so every update typed
+   * in the second before the toggle is already buffered and would still be
+   * pushed. The queue is the only thing holding those bytes — clearing the
+   * pending-note store cannot reach into it — so the drop has to happen here,
+   * ahead of the `docs` lookup: a doc the LRU has since evicted still leaves a
+   * buffer behind.
    */
   setNoteLocalOnly(noteId: string, localOnly: boolean): void {
+    if (localOnly) this.updateQueue?.dropNote(noteId)
+
     const entry = this.docs.get(noteId)
     if (!entry) return
     entry.localOnly = localOnly
@@ -1210,6 +1226,19 @@ export class CrdtProvider {
       return { ok: false, error: `Binary notes do not use CRDT: ${noteId}` }
     }
     return { ok: true }
+  }
+
+  /**
+   * May the CRDT feed still carry this note's body to the server?
+   *
+   * The union of both refusals, for the pending-note replay — which has to
+   * decide whether an id in the durable store is still owed a push at all. The
+   * two halves stay separate because `validateNoteForCrdt` also gates the
+   * renderer's editor handshake, and a local-only note opens and edits there
+   * like any other; only its *sync* is off.
+   */
+  isNoteSyncable(noteId: string): boolean {
+    return this.validateNoteForCrdt(noteId).ok && !this.isNoteLocalOnly(noteId)
   }
 
   applyIpcUpdate(noteId: string, update: Uint8Array, sourceWindowId: number): void {

--- a/apps/desktop/src/main/sync/crdt-queue.test.ts
+++ b/apps/desktop/src/main/sync/crdt-queue.test.ts
@@ -332,6 +332,60 @@ describe('CrdtUpdateQueue', () => {
     queue.stop()
   })
 
+  it('drops a note buffered when the mid-flush window closes, and never pushes it', async () => {
+    const queue = new CrdtUpdateQueue()
+    const push = vi.fn(async () => undefined)
+
+    queue.start(push)
+    queue.pause()
+    queue.enqueue('going-local', new Uint8Array([1, 2, 3]))
+    queue.enqueue('still-syncing', new Uint8Array([4]))
+
+    queue.dropNote('going-local')
+
+    expect(queue.getPendingCount()).toBe(1)
+    expect(queue.getPendingBytes()).toBe(1)
+
+    queue.resume()
+    await flushPromises()
+
+    expect(push).toHaveBeenCalledTimes(1)
+    expect(push).toHaveBeenCalledWith('still-syncing', [new Uint8Array([4])])
+  })
+
+  it('does not re-buffer a dropped note whose push was already in flight', async () => {
+    let rejectPush!: (err: unknown) => void
+    const push = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectPush = reject
+        })
+    )
+    const queue = new CrdtUpdateQueue()
+
+    queue.start(push)
+    queue.enqueue('note-a', new Uint8Array([1]))
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    expect(push).toHaveBeenCalledTimes(1)
+
+    // The toggle lands while the batch is on the wire. It cannot be recalled,
+    // but a retryable failure must not put it back for the next flush.
+    queue.dropNote('note-a')
+    rejectPush(new SyncServerError('rate limited', 429))
+    await flushPromises()
+
+    expect(queue.getPendingCount()).toBe(0)
+    expect(queue.getPendingBytes()).toBe(0)
+
+    // A later edit on a note that goes back to syncing still flushes normally.
+    queue.enqueue('note-a', new Uint8Array([2]))
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    expect(push).toHaveBeenCalledTimes(2)
+    expect(push).toHaveBeenLastCalledWith('note-a', [new Uint8Array([2])])
+  })
+
   it('does not persist anything when the shutdown flush drains the buffers', async () => {
     const persistUnflushed = vi.fn()
     const queue = new CrdtUpdateQueue({ persistUnflushed })

--- a/apps/desktop/src/main/sync/crdt-queue.ts
+++ b/apps/desktop/src/main/sync/crdt-queue.ts
@@ -51,6 +51,8 @@ export class CrdtUpdateQueue {
   private buffers = new Map<string, BufferedUpdate[]>()
   private flushTimer: ReturnType<typeof setInterval> | null = null
   private flushingNotes = new Set<string>()
+  /** Notes `dropNote` reached mid-push; their batch must not be re-buffered. */
+  private droppedInFlight = new Set<string>()
   private pushFn: ((noteId: string, updates: Uint8Array[]) => Promise<void>) | null = null
   private paused = false
   private bufferedBytes = 0
@@ -131,6 +133,33 @@ export class CrdtUpdateQueue {
     if (this.bufferedBytes >= this.nextBudgetSweepBytes) {
       this.enforceTotalBudget()
     }
+  }
+
+  /**
+   * Forget everything buffered for a note, without pushing it.
+   *
+   * The one caller is `CrdtProvider.setNoteLocalOnly` going ON: the note has
+   * just been told never to leave this device, and the guard that enforces that
+   * sits at `onDocUpdate`, i.e. at enqueue time. Anything the ~1s flush loop had
+   * not taken yet is already past that guard and would go out on the next tick.
+   *
+   * Dropping loses nothing. Every update here is also in the local CRDT store,
+   * which is what the doc is rebuilt from; the queue only ever held a copy bound
+   * for the server, and there is no longer a server for this note.
+   *
+   * A push already in flight cannot be recalled, but its failure path must not
+   * put the batch back — a 429 or a 5xx re-buffers, and the next flush would
+   * then push a note that stopped syncing seconds ago. `flushingNotes` is what
+   * distinguishes "in flight" from "settled", and the entry is cleared when the
+   * push settles.
+   */
+  dropNote(noteId: string): void {
+    const buffer = this.buffers.get(noteId)
+    if (buffer) {
+      this.bufferedBytes -= bytesOf(buffer)
+      this.buffers.delete(noteId)
+    }
+    if (this.flushingNotes.has(noteId)) this.droppedInFlight.add(noteId)
   }
 
   getPendingCount(): number {
@@ -322,6 +351,8 @@ export class CrdtUpdateQueue {
           err.statusCode !== 429 &&
           err.statusCode !== 401
         if (nonRetryable) return
+        // Dropped while this push was in flight — see `dropNote`.
+        if (this.droppedInFlight.has(noteId)) return
 
         let existing = this.buffers.get(noteId)
         if (!existing) {
@@ -333,6 +364,7 @@ export class CrdtUpdateQueue {
       })
       .finally(() => {
         this.flushingNotes.delete(noteId)
+        this.droppedInFlight.delete(noteId)
       })
   }
 }

--- a/apps/desktop/src/main/sync/crdt-snapshot-endpoint-seam.test.ts
+++ b/apps/desktop/src/main/sync/crdt-snapshot-endpoint-seam.test.ts
@@ -178,6 +178,8 @@ const runtimeMocks = vi.hoisted(() => {
     unverifiedCrdtNotes: new Set<string>(),
     syncGoogleCalendarSource: vi.fn(),
     crdtProvider: {
+      isNoteLocalOnly: vi.fn(() => false),
+      isNoteSyncable: vi.fn(() => true),
       init: vi.fn(),
       seedExistingDocs: vi.fn(),
       pushSnapshotForNote: vi.fn(),

--- a/apps/desktop/src/main/sync/engine-crdt.test.ts
+++ b/apps/desktop/src/main/sync/engine-crdt.test.ts
@@ -341,6 +341,7 @@ describe('SyncEngine', () => {
    */
   describe('#given a CRDT pull whose signer device key cannot be resolved', () => {
     const crdtProviderStub = (): Record<string, ReturnType<typeof vi.fn>> => ({
+      isNoteLocalOnly: vi.fn(() => false),
       getDoc: vi.fn().mockReturnValue(undefined),
       open: vi.fn().mockResolvedValue({}),
       closeIfInactive: vi.fn().mockResolvedValue(true),

--- a/apps/desktop/src/main/sync/engine-retries.test.ts
+++ b/apps/desktop/src/main/sync/engine-retries.test.ts
@@ -215,6 +215,7 @@ describe('SyncEngine', () => {
 
       const deps = createMockDeps(getDb(), {
         crdtProvider: {
+          isNoteLocalOnly: vi.fn(() => false),
           getOpenNoteIds: vi.fn(({ active = false } = {}) => (active ? [] : ['note-1', 'note-2']))
         } as unknown as SyncEngineDeps['crdtProvider']
       })
@@ -278,6 +279,7 @@ describe('SyncEngine', () => {
 
       const deps = createMockDeps(getDb(), {
         crdtProvider: {
+          isNoteLocalOnly: vi.fn(() => false),
           getOpenNoteIds: vi.fn(({ active = false } = {}) => (active ? ['editor-1'] : OPEN_IDS))
         } as unknown as SyncEngineDeps['crdtProvider']
       })

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
@@ -85,6 +85,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          isNoteLocalOnly: vi.fn(() => false),
           getDoc,
           open,
           closeIfInactive,
@@ -129,6 +130,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          isNoteLocalOnly: vi.fn(() => false),
           getDoc: vi.fn().mockReturnValue(openDoc),
           open,
           closeIfInactive,
@@ -166,7 +168,7 @@ describe('CrdtSyncCoordinator', () => {
           .fn()
           .mockResolvedValueOnce(null)
           .mockResolvedValueOnce(new Uint8Array([9])),
-        crdtProvider: {}
+        crdtProvider: { isNoteLocalOnly: vi.fn(() => false) }
       }
     } as unknown as SyncContext
     const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
@@ -214,6 +216,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          isNoteLocalOnly: vi.fn(() => false),
           inactiveDocCapacity: 32,
           getDoc: vi.fn().mockReturnValue(undefined),
           open,
@@ -266,6 +269,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          isNoteLocalOnly: vi.fn(() => false),
           inactiveDocCapacity: 32,
           getDoc,
           open: vi.fn().mockResolvedValue({}),
@@ -338,6 +342,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          isNoteLocalOnly: vi.fn(() => false),
           inactiveDocCapacity: 32,
           getDoc: vi.fn().mockReturnValue(undefined),
           open,
@@ -386,6 +391,7 @@ describe('CrdtSyncCoordinator', () => {
         getAccessToken: vi.fn(async () => 'token-1'),
         getVaultKey: vi.fn(async () => new Uint8Array([9])),
         crdtProvider: {
+          isNoteLocalOnly: vi.fn(() => false),
           inactiveDocCapacity: 32,
           getDoc: vi.fn().mockReturnValue(undefined),
           open,
@@ -400,6 +406,72 @@ describe('CrdtSyncCoordinator', () => {
 
     return { ctx, open }
   }
+
+  describe('#given a note the user marked local-only', () => {
+    it('#then a single-note pull never reaches the server, and owes itself nothing', async () => {
+      const { ctx } = createBatchContext()
+      const provider = ctx.deps.crdtProvider as unknown as {
+        isNoteLocalOnly: ReturnType<typeof vi.fn>
+        open: ReturnType<typeof vi.fn>
+      }
+      provider.isNoteLocalOnly.mockImplementation((noteId: string) => noteId === 'note-local')
+      const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+      // #when
+      await expect(coordinator.pullCrdtForNote('note-local')).resolves.toBe(false)
+
+      // #then #1511 closed the push half; the pull half is the same setting
+      // pointing the other way. Nothing is fetched and no doc is even opened.
+      expect(fetchCrdtSnapshotMock).not.toHaveBeenCalled()
+      expect(getFromServerMock).not.toHaveBeenCalled()
+      expect(provider.open).not.toHaveBeenCalled()
+
+      // #and it is not owed a retry: a debt nothing can ever settle would put
+      // the note back in every sweep for the life of the session.
+      expect(coordinator.pendingPullCount).toBe(0)
+    })
+
+    it('#then a batch pull drops it and still pulls the notes that can sync', async () => {
+      const { ctx } = createBatchContext()
+      const provider = ctx.deps.crdtProvider as unknown as {
+        isNoteLocalOnly: ReturnType<typeof vi.fn>
+      }
+      provider.isNoteLocalOnly.mockImplementation((noteId: string) => noteId === 'note-local')
+      postToServerMock.mockResolvedValue({
+        notes: { 'note-1': { updates: [], hasMore: false } }
+      })
+      const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+      // #when the paced vault sweep hands over a chunk holding both
+      await coordinator.applyCrdtBatch(['note-local', 'note-1'], 'token-1', new Uint8Array([4]))
+
+      // #then only the syncable note costs a snapshot baseline GET — the whole
+      // point being that a local-only note stops spending `crdt_pull` budget.
+      expect(fetchCrdtSnapshotMock).toHaveBeenCalledTimes(1)
+      expect(fetchCrdtSnapshotMock).toHaveBeenCalledWith('note-1', 'token-1')
+      expect(postToServerMock).toHaveBeenCalledWith(
+        '/sync/crdt/updates/batch',
+        { notes: [{ noteId: 'note-1', since: 0 }], limit: 100 },
+        'token-1'
+      )
+    })
+
+    it('#then a batch of nothing but local-only notes sends no request at all', async () => {
+      const { ctx } = createBatchContext()
+      const provider = ctx.deps.crdtProvider as unknown as {
+        isNoteLocalOnly: ReturnType<typeof vi.fn>
+      }
+      provider.isNoteLocalOnly.mockReturnValue(true)
+      const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+      // #when
+      await coordinator.applyCrdtBatch(['note-a', 'note-b'], 'token-1', new Uint8Array([4]))
+
+      // #then
+      expect(fetchCrdtSnapshotMock).not.toHaveBeenCalled()
+      expect(postToServerMock).not.toHaveBeenCalled()
+    })
+  })
 
   // A rate limit is what the desktop actually hits: the vault-wide sweep used to
   // fire two GETs per note, so 121 notes meant 242 requests in about four
@@ -603,6 +675,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          isNoteLocalOnly: vi.fn(() => false),
           inactiveDocCapacity: 32,
           getDoc: vi.fn().mockReturnValue(undefined),
           open: vi.fn().mockResolvedValue({}),
@@ -659,6 +732,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          isNoteLocalOnly: vi.fn(() => false),
           inactiveDocCapacity: 2,
           getDoc: vi.fn().mockReturnValue(undefined),
           open: vi.fn().mockResolvedValue({}),
@@ -929,6 +1003,7 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          isNoteLocalOnly: vi.fn(() => false),
           inactiveDocCapacity: 32,
           getDoc: vi.fn().mockReturnValue(undefined),
           open: vi.fn().mockResolvedValue({}),
@@ -969,6 +1044,7 @@ describe('CrdtSyncCoordinator.clearCaches', () => {
   it('drops the per-note applied-sequence cursors so a new vault starts from the server baseline', async () => {
     const applyRemoteUpdate = vi.fn()
     const crdtProvider = {
+      isNoteLocalOnly: vi.fn(() => false),
       applyRemoteUpdate,
       open: vi.fn().mockResolvedValue({}),
       closeIfInactive: vi.fn().mockResolvedValue(true),

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -232,6 +232,17 @@ export class CrdtSyncCoordinator {
    * one caller that reads the return value (the pending-note replay); the 30s
    * snapshot scheduler and every other push path never see it, so the flag is
    * what carries an incomplete merge to them.
+   *
+   * **A local-only note is not pulled at all.** #1511 closed the push half of
+   * "this note never leaves the device"; this is the other half, and the setting
+   * means nothing else: a note that can never push has no business taking the
+   * server's state either, and pulling it spends `crdt_pull` budget the notes
+   * that *can* sync are competing for. The answer is `false` — the contract is
+   * "the server's state is in this doc", and here it deliberately is not — but
+   * NOT an owed pull: a debt nothing will ever settle would re-queue the note in
+   * every sweep forever. Its `unmergedRemoteNotes` flag is left standing on
+   * purpose; it costs nothing while the note cannot push, and if the toggle is
+   * ever turned off it is the conservative answer for that note's first push.
    */
   async applyCrdtIncrementals(
     noteId: string,
@@ -244,6 +255,11 @@ export class CrdtSyncCoordinator {
 
     const effectiveSignal = signal ?? this.ctx.abortController?.signal
     if (!effectiveSignal) return false
+
+    if (crdtProvider.isNoteLocalOnly(noteId)) {
+      log.debug('Skipping CRDT pull for a local-only note', { noteId })
+      return false
+    }
 
     const wasOpen = crdtProvider.getDoc(noteId) != null
     try {
@@ -383,6 +399,18 @@ export class CrdtSyncCoordinator {
     const effectiveSignal = signal ?? this.ctx.abortController?.signal
     if (!crdtProvider || !effectiveSignal) return
 
+    // Same guard as the single-note path — see `applyCrdtIncrementals` — and
+    // applied before the chunking below rather than inside it, so a vault with
+    // many local-only notes still fills each chunk with notes that can sync
+    // instead of spending whole paced chunks on ones that are all skipped.
+    const syncable = noteIds.filter((noteId) => !crdtProvider.isNoteLocalOnly(noteId))
+    if (syncable.length !== noteIds.length) {
+      log.debug('Skipping local-only notes in a CRDT batch pull', {
+        skipped: noteIds.length - syncable.length
+      })
+    }
+    if (syncable.length === 0) return
+
     // A pass holds every one of its notes open from before the request is sent
     // until that note's updates are applied, so it must never open more than
     // the provider keeps cached: past the limit the LRU closes the notes it
@@ -394,10 +422,10 @@ export class CrdtSyncCoordinator {
     // Chunking here also keeps each request under the server's 100-note cap on
     // /sync/crdt/updates/batch, which a whole-vault pass otherwise blows past.
     const chunkSize = crdtProvider.inactiveDocCapacity
-    for (let i = 0; i < noteIds.length; i += chunkSize) {
+    for (let i = 0; i < syncable.length; i += chunkSize) {
       if (effectiveSignal.aborted) return
       await this.applyCrdtBatchChunk(
-        noteIds.slice(i, i + chunkSize),
+        syncable.slice(i, i + chunkSize),
         token,
         vaultKey,
         effectiveSignal

--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -173,6 +173,8 @@ const runtimeMocks = vi.hoisted(() => {
     unverifiedCrdtNotes: new Set<string>(),
     syncGoogleCalendarSource: vi.fn(),
     crdtProvider: {
+      isNoteLocalOnly: vi.fn(() => false),
+      isNoteSyncable: vi.fn(() => true),
       init: vi.fn(),
       seedExistingDocs: vi.fn(),
       pushSnapshotForNote: vi.fn(),

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -801,7 +801,13 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
         void drainPendingCrdtNotes({
           mergeRemote: (noteId) => engine.mergeRemoteCrdtForNote(noteId),
           pushSnapshot: (noteId) => crdtProvider.pushSnapshotForNote(noteId),
-          isSyncable: (noteId) => crdtProvider.validateNoteForCrdt(noteId).ok,
+          // Deliberately `isNoteSyncable` and not `validateNoteForCrdt`: the
+          // latter also gates the renderer's editor handshake, where a
+          // local-only note must still open. Without the local-only half, an id
+          // that reached the store through the toggle race is retained for good
+          // — `pushSnapshotForNote` correctly refuses a local-only note, so the
+          // drain never clears it and warns once per session forever.
+          isSyncable: (noteId) => crdtProvider.isNoteSyncable(noteId),
           signal: runtimeAbort.signal
         }).catch((err) => log.warn('Pending CRDT note replay failed', err))
       }

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -551,6 +551,8 @@ Five paths send a body, and each refuses independently:
 
 `pushSnapshotForNote` re-reads the row because it is the one push path reached for a note with
 no open doc — the pending-note replay and the push coordinator's `create` both land there.
+`CrdtSyncCoordinator` re-reads it as well, through the same `isNoteLocalOnly`, for the pull side
+described below.
 
 `pendingSnapshotBytes` keeps counting for a local-only note. It means "written locally, not yet
 on the server", which stays true, and suppressing it would make three of the guards above look
@@ -580,9 +582,34 @@ snapshot ahead of the merge-first replay. A snapshot asserts completeness and th
 every incremental below it, and a note that has just stopped being local-only is the population
 most likely to have diverged from a peer.
 
-Two asymmetries remain, deliberately: a local-only note is still **pulled** from the server by
-the vault sweep, and updates already buffered in `CrdtUpdateQueue` when the flag is set can still
-flush within that queue's 1 s window.
+### The pull half, and the flush window
+
+The setting reads as "this note and the server have nothing to do with each other", so the pull
+side refuses too. `CrdtSyncCoordinator.applyCrdtIncrementals` returns before it opens the doc,
+and `applyCrdtBatch` filters the list before it chunks it — so the paced vault sweep, the
+`crdt_updated` broadcast and the pending-note drain all skip a local-only note, and none of them
+spends `crdt_pull` budget on a note that can never push. Filtering before the chunking matters:
+each paced chunk stays filled with notes that can actually sync.
+
+A skipped note is deliberately **not** owed a retry. `owePendingPull` there would be a debt
+nothing can ever settle, and the note would be re-queued in every sweep for the life of the
+session. Its `unmergedRemoteNotes` flag is left standing instead — free while the note cannot
+push, and the conservative answer for its first push if the flag is ever cleared.
+
+Setting the flag also empties the update queue's buffer for that note. `onDocUpdate` reads the
+flag at _enqueue_ time but `CrdtUpdateQueue` flushes on a ~1 s loop, so everything typed in the
+second before the toggle is already past the guard. `CrdtUpdateQueue.dropNote` discards it —
+nothing is lost, because those updates are also in the local CRDT store — and
+`CrdtProvider.setNoteLocalOnly` calls it ahead of its `docs` lookup, so a note whose doc the LRU
+has already evicted is covered too. A push already in flight cannot be recalled, but a retryable
+failure no longer re-buffers its batch, which would otherwise have pushed it seconds after the
+note stopped syncing.
+
+Finally, the pending-note replay asks `CrdtProvider.isNoteSyncable` — `validateNoteForCrdt`
+plus the local-only check — rather than `validateNoteForCrdt` alone, so an id that reached the
+durable store through that race is cleared instead of retained forever. The two halves stay
+separate because `validateNoteForCrdt` also gates the renderer's editor handshake, where a
+local-only note must still open and edit like any other.
 
 ## Reconnect Recovery
 


### PR DESCRIPTION
Closes #1542.

#1511 (PR #1534) closed the push half of "this note never leaves the device": a local-only note's body no longer leaves via `onDocUpdate`, `pushSnapshotForNote`, `close()`, `pushAllSnapshots()` or `compactDoc()`. This closes the three residuals it left open.

## 1. The pull half was unguarded

Nothing filtered `localOnly` in `CrdtSyncCoordinator.applyCrdtIncrementals` / `applyCrdtBatch`, so a local-only note was still fetched from the server — by the paced vault sweep (`pullCrdtForNotes`), by the `crdt_updated` broadcast, and by `mergeRemote` in the pending-note drain. If the note had server state from before it was marked local-only, that state was still merged into the local doc, and the pull spent `crdt_pull` budget on a note that can never push.

- `applyCrdtIncrementals` returns before it even opens the doc.
- `applyCrdtBatch` filters the list **before** it chunks it, so each paced chunk stays filled with notes that can actually sync.

Deliberately **not** owed a retry: `owePendingPull` there would be a debt nothing can ever settle, re-queueing the note in every sweep for the life of the session. Its `unmergedRemoteNotes` flag is left standing instead — free while the note cannot push, and the conservative answer for its first push if the toggle is ever cleared.

## 2. The toggle raced the flush loop

`CrdtUpdateQueue` batches on a ~1s flush loop, but the guard sits at `onDocUpdate` (enqueue time), so everything typed in the second before the toggle was already past it and still went out. `setNoteLocalOnlyState` clears the pending-CRDT-note store and zeroes `pendingSnapshotBytes`, but it could not reach into the queue's buffer.

- New `CrdtUpdateQueue.dropNote(noteId)` empties the buffer and its byte counter. Nothing is lost — those updates are also in the local CRDT store.
- Wired from `CrdtProvider.setNoteLocalOnly`, **ahead of** its `docs` lookup, so a note whose doc the LRU already evicted is covered too.
- A push already in flight cannot be recalled, but a retryable failure (429/5xx) no longer re-buffers its batch — that would have pushed it seconds after the note stopped syncing.

## 3. The retained id

`isSyncable` accepted local-only notes, so an id that reached the durable store through that race was retained forever: `pushSnapshotForNote` correctly refuses the push, so the drain never cleared it and warned once per session.

The drain now asks the new `CrdtProvider.isNoteSyncable` — the union of both refusals. Kept separate from `validateNoteForCrdt` on purpose: that method also gates the renderer's editor handshake, where a local-only note must still open and edit like any other.

## Tests

7 new cases: single-note / batch / all-local-only pull skips in the coordinator; `dropNote` emptying the buffer and blocking the in-flight re-buffer in the queue; the real `setNoteLocalOnlyState` → `dropNote` wire for both an open doc and an evicted one; and, in `crdt-drain-teardown-seam.test.ts`, a real runtime proving a local-only id is cleared from the durable store while never being merged or pushed.

## Verify

```
pnpm exec vitest --project main   → 540 files, 7014 tests pass
pnpm lint                          → 0 errors
typecheck:node / typecheck:test:node → clean
pnpm docs:impact --strict          → covered
pnpm docs:build                    → clean
```

`typecheck:test:web` is red on `sidebar-nav.test.tsx` (`onNavMiddleClick`), pre-existing and untouched here — no renderer file is in this diff.
