### PR TITLE
fix(notes): moving a note rewrites the refs its body carries, so its embeds keep resolving

### DIFF
--- a/apps/desktop/src/main/vault/notes-rename.ts
+++ b/apps/desktop/src/main/vault/notes-rename.ts
@@ -1,7 +1,12 @@
 /**
- * Note rename and move operations — pure filesystem rename plus cache resync;
- * file bytes are never touched. Pulled from notes.ts during the Phase 3.1
- * split (.claude/plans/tech-debt-remediation.md).
+ * Note rename and move operations — a filesystem rename plus cache resync.
+ *
+ * A rename leaves the bytes alone: the title lives in the DBs, not in the file.
+ * A move to a different folder cannot, because the note's body carries refs that
+ * are relative to the folder the note was in — see `rewrite-note-refs.ts`.
+ *
+ * Pulled from notes.ts during the Phase 3.1 split
+ * (.claude/plans/tech-debt-remediation.md).
  *
  * @module vault/notes-rename
  */
@@ -10,7 +15,16 @@ import path from 'path'
 import fs from 'fs/promises'
 import { parseNote } from './frontmatter'
 import { syncNoteToCache, syncFileToCache } from './note-sync'
-import { ensureDirectory, sanitizeFilename, generateUniquePath, safeRead } from './file-ops'
+import {
+  ensureDirectory,
+  sanitizeFilename,
+  generateUniquePath,
+  safeRead,
+  atomicWrite
+} from './file-ops'
+import { rewriteNoteRefsForMove } from './rewrite-note-refs'
+import { replaceNoteBodyInCrdt } from '../sync/crdt-feed'
+import { markWritebackIgnored } from '../sync/crdt-writeback'
 import { getNoteCacheById } from '@main/database/queries/notes'
 import { getDatabase, getIndexDatabase } from '../database'
 import { NoteError, NoteErrorCode } from '../lib/errors'
@@ -131,7 +145,9 @@ export async function moveNote(id: string, newFolder: string): Promise<Note> {
 
   const now = new Date().toISOString()
 
-  // Pure filesystem rename — file bytes untouched; dates live in the DBs
+  // Filesystem rename first; the body, if it needs re-pointing, is rewritten in
+  // place below rather than during the move, so a failed write cannot strand the
+  // file between two folders.
   await fs.rename(oldPath, newPath)
 
   if (isBinary) {
@@ -150,7 +166,19 @@ export async function moveNote(id: string, newFolder: string): Promise<Note> {
       modifiedAt: now
     })
   } else {
-    const fileContent = (await safeRead(newPath)) ?? ''
+    const original = (await safeRead(newPath)) ?? ''
+    // Null means every ref still resolves from the new folder, which is the
+    // common case (same depth, or a note with no relative refs at all): nothing
+    // is written, so the file keeps its mtime and its sync state.
+    const rewritten = rewriteNoteRefsForMove(original, existing.path, newRelativePath)
+    if (rewritten !== null) {
+      // The watcher's external-edit feed must not race the CRDT push below; the
+      // sync note handler marks its own writes the same way before touching a
+      // file it is about to reconcile itself.
+      markWritebackIgnored(newPath)
+      await atomicWrite(newPath, rewritten)
+    }
+    const fileContent = rewritten ?? original
     const parsed = parseNote(fileContent, newRelativePath)
     syncNoteToCache(
       db,
@@ -168,6 +196,17 @@ export async function moveNote(id: string, newFolder: string): Promise<Note> {
       },
       { isNew: false }
     )
+
+    if (rewritten !== null) {
+      // Mandatory, not bookkeeping. Main owns the Y.Doc and it is keyed by note
+      // id, so a move never invalidates it; the doc still holds the pre-move
+      // body and the next write-back would serialize that straight back over the
+      // file we just corrected — and persist it, so closing the note would not
+      // undo the loss. The cache row already points at the new path, so the
+      // embed resolution inside this call reads the note from where it now
+      // lives. Same order `applyTemplateToNote` uses: file first, then the doc.
+      await replaceNoteBodyInCrdt(id, parsed.content)
+    }
   }
 
   const note: Note = {

--- a/apps/desktop/src/main/vault/notes.test.ts
+++ b/apps/desktop/src/main/vault/notes.test.ts
@@ -900,6 +900,35 @@ describe('notes operations', () => {
       )
     })
 
+    it('re-points the refs the body carries so embeds survive the move', async () => {
+      const created = await notes.createNote({
+        title: 'Embed Move Test',
+        content: '![shot](../attachments/n1/shot.png)'
+      })
+
+      // `newFolder` is vault-relative: notes/Embed-Move-Test.md →
+      // notes/archive/2026/Embed-Move-Test.md, two folders deeper.
+      const moved = await notes.moveNote(created.id, 'notes/archive/2026')
+
+      const onDisk = fs.readFileSync(path.join(tempVault.path, moved.path), 'utf8')
+      expect(onDisk).toContain('![shot](../../../attachments/n1/shot.png)')
+    })
+
+    it('writes nothing when the move leaves every ref resolving', async () => {
+      const created = await notes.createNote({
+        title: 'Same Depth Move',
+        content: '![shot](../attachments/n1/shot.png)'
+      })
+
+      const before = fs.readFileSync(path.join(tempVault.path, created.path), 'utf8')
+
+      // notes/Same-Depth-Move.md → sibling/Same-Depth-Move.md: same depth, so
+      // `../attachments/...` is still correct and the file must not be rewritten.
+      const moved = await notes.moveNote(created.id, 'sibling')
+
+      expect(fs.readFileSync(path.join(tempVault.path, moved.path), 'utf8')).toBe(before)
+    })
+
     it('preserves binary content on move (no frontmatter injection)', async () => {
       // #given — a binary file in the vault
       const binaryContent = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])

--- a/apps/desktop/src/main/vault/notes.test.ts
+++ b/apps/desktop/src/main/vault/notes.test.ts
@@ -40,6 +40,18 @@ vi.mock('../inbox/suggestions', () => ({
   updateNoteEmbedding: vi.fn(() => Promise.resolve())
 }))
 
+// The move path has to hand the rewritten body to the note's Y.Doc, and there is
+// no doc open in these tests, so the call is only observable as a call. It is
+// load-bearing rather than bookkeeping: the doc is keyed by note id and survives
+// the move holding the pre-move body, so without this the next write-back
+// serializes the stale refs straight back over the file the move just corrected
+// — and persists them.
+const crdtMocks = vi.hoisted(() => ({ replaceNoteBodyInCrdt: vi.fn(async () => false) }))
+vi.mock('../sync/crdt-feed', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../sync/crdt-feed')>()),
+  replaceNoteBodyInCrdt: crdtMocks.replaceNoteBodyInCrdt
+}))
+
 // ============================================================================
 // Test Suite
 // ============================================================================
@@ -927,6 +939,34 @@ describe('notes operations', () => {
       const moved = await notes.moveNote(created.id, 'sibling')
 
       expect(fs.readFileSync(path.join(tempVault.path, moved.path), 'utf8')).toBe(before)
+    })
+
+    it('hands the rewritten body to the note Y.Doc, not just to the file', async () => {
+      crdtMocks.replaceNoteBodyInCrdt.mockClear()
+      const created = await notes.createNote({
+        title: 'Crdt Push On Move',
+        content: '![shot](../attachments/n1/shot.png)'
+      })
+
+      await notes.moveNote(created.id, 'notes/archive/2026')
+
+      expect(crdtMocks.replaceNoteBodyInCrdt).toHaveBeenCalledTimes(1)
+      const [noteId, body] = crdtMocks.replaceNoteBodyInCrdt.mock.calls[0]
+      expect(noteId).toBe(created.id)
+      // The corrected ref, not the one that was on disk before the move.
+      expect(body).toContain('../../../attachments/n1/shot.png')
+    })
+
+    it('leaves the Y.Doc alone when the move rewrote nothing', async () => {
+      crdtMocks.replaceNoteBodyInCrdt.mockClear()
+      const created = await notes.createNote({
+        title: 'No Crdt Push On Move',
+        content: '![shot](../attachments/n1/shot.png)'
+      })
+
+      await notes.moveNote(created.id, 'sibling')
+
+      expect(crdtMocks.replaceNoteBodyInCrdt).not.toHaveBeenCalled()
     })
 
     it('preserves binary content on move (no frontmatter injection)', async () => {

--- a/apps/desktop/src/main/vault/rewrite-note-refs.test.ts
+++ b/apps/desktop/src/main/vault/rewrite-note-refs.test.ts
@@ -1,0 +1,173 @@
+/**
+ * The ref arithmetic a note move depends on: every relative ref in the body has
+ * to keep naming the same file after the note lands somewhere else, and a move
+ * that changes nothing has to change no bytes.
+ *
+ * @module vault/rewrite-note-refs.test
+ */
+
+import { describe, it, expect } from 'vitest'
+import { rewriteNoteRefsForMove } from './rewrite-note-refs'
+
+describe('rewriteNoteRefsForMove', () => {
+  it('returns null for a move that keeps the note in the same folder', () => {
+    const body = '![photo](../attachments/n1/photo.png)\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/Foo.md', 'notes/Foo-1.md')).toBeNull()
+  })
+
+  it('returns null when the recomputed ref is identical to the one on disk', () => {
+    // Same depth, different prefix: `../../attachments/...` is correct from both.
+    const body = '![photo](../../attachments/n1/photo.png)\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/a/Foo.md', 'notes/b/Foo.md')).toBeNull()
+  })
+
+  it('adds one `../` per folder the note moved down into', () => {
+    const body = '![photo](../attachments/n1/photo.png)\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/Foo.md', 'notes/archive/2026/Foo.md')).toBe(
+      '![photo](../../../attachments/n1/photo.png)\n'
+    )
+  })
+
+  it('drops the `../` the note no longer needs when it moves up', () => {
+    const body = '![photo](../../../attachments/n1/photo.png)\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/archive/2026/Foo.md', 'notes/Foo.md')).toBe(
+      '![photo](../attachments/n1/photo.png)\n'
+    )
+  })
+
+  it('writes a bare path when the note moves to the vault root', () => {
+    const body = '![photo](../attachments/n1/photo.png)\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/Foo.md', 'Foo.md')).toBe(
+      '![photo](attachments/n1/photo.png)\n'
+    )
+  })
+
+  it('re-points a ref at another vault file, not just at an attachment', () => {
+    const body = '![photo](images/photo.png)\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/Foo.md', 'notes/archive/Foo.md')).toBe(
+      '![photo](../images/photo.png)\n'
+    )
+  })
+
+  it('rewrites only the url member of a file marker, byte for byte otherwise', () => {
+    const marker =
+      '<!-- file:{"url":"../attachments/n1/plan.pdf","name":"plan.pdf","size":1024,' +
+      '"mimeType":"application/pdf","width":720,"height":300,"align":"center"} -->'
+
+    const result = rewriteNoteRefsForMove(marker, 'notes/Foo.md', 'notes/archive/2026/Foo.md')
+
+    expect(result).toBe(
+      '<!-- file:{"url":"../../../attachments/n1/plan.pdf","name":"plan.pdf","size":1024,' +
+        '"mimeType":"application/pdf","width":720,"height":300,"align":"center"} -->'
+    )
+  })
+
+  it('keeps a file marker escape intact when the filename ends a comment', () => {
+    const marker =
+      '<!-- file:{"url":"../attachments/n1/a--\\u003eb.pdf","name":"a--\\u003eb.pdf",' +
+      '"size":1,"mimeType":"application/pdf"} -->'
+
+    expect(rewriteNoteRefsForMove(marker, 'notes/Foo.md', 'notes/archive/Foo.md')).toBe(
+      '<!-- file:{"url":"../../attachments/n1/a--\\u003eb.pdf","name":"a--\\u003eb.pdf",' +
+        '"size":1,"mimeType":"application/pdf"} -->'
+    )
+  })
+
+  it('leaves an absolute memry-file url alone', () => {
+    const body =
+      '![photo](memry-file://local/Users/k/vault/attachments/n1/photo.png)\n' +
+      '<!-- file:{"url":"memry-file://local/Users/k/vault/attachments/n1/p.pdf","name":"p.pdf",' +
+      '"size":1,"mimeType":"application/pdf"} -->\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/Foo.md', 'notes/archive/Foo.md')).toBeNull()
+  })
+
+  it('leaves remote and data urls alone', () => {
+    const body =
+      '![remote](https://example.com/photo.png)\n' +
+      '![inline](data:image/png;base64,AAAA)\n' +
+      '[link](https://example.com/page)\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/Foo.md', 'notes/archive/Foo.md')).toBeNull()
+  })
+
+  it('leaves wiki-links alone — they resolve by title, not by path', () => {
+    const body = '[[Other Note]]\n![[photo.png]]\n[[Folder/Other|alias]]\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/Foo.md', 'notes/archive/2026/Foo.md')).toBeNull()
+  })
+
+  it('keeps a percent-encoded ref encoded after the move', () => {
+    const body = '![photo](../attachments/n1/my%20photo%281%29.png)\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/Foo.md', 'notes/archive/Foo.md')).toBe(
+      '![photo](../../attachments/n1/my%20photo%281%29.png)\n'
+    )
+  })
+
+  it('leaves a percent-encoded ref byte-identical when the path math is a no-op', () => {
+    // `%C3%A9` re-encodes to a bare `é`, so a naive decode/encode round trip would
+    // rewrite this note on a move that changes nothing about where the ref points.
+    const body = '![photo](../../attachments/n1/caf%C3%A9.png)\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/a/Foo.md', 'notes/b/Foo.md')).toBeNull()
+  })
+
+  it('leaves a ref that climbs above the vault root alone', () => {
+    const body = '![escape](../../outside.png)\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/Foo.md', 'notes/archive/2026/Foo.md')).toBeNull()
+  })
+
+  it('leaves a root-anchored ref alone', () => {
+    const body = '![abs](/attachments/n1/photo.png)\n![unc](\\\\server\\share\\photo.png)\n'
+
+    expect(rewriteNoteRefsForMove(body, 'notes/Foo.md', 'notes/archive/Foo.md')).toBeNull()
+  })
+
+  it('rewrites every ref in a body and leaves the rest of the markdown untouched', () => {
+    const body = [
+      '---',
+      'title: Foo',
+      '---',
+      '',
+      '# Heading',
+      '',
+      '![one](../attachments/n1/one.png)',
+      '',
+      'Some prose with a [[Wiki Link]] and a [link](https://example.com).',
+      '',
+      '<!-- file:{"url":"../attachments/n1/two.pdf","name":"two.pdf","size":2,' +
+        '"mimeType":"application/pdf"} -->',
+      ''
+    ].join('\n')
+
+    expect(rewriteNoteRefsForMove(body, 'notes/Foo.md', 'notes/archive/Foo.md')).toBe(
+      [
+        '---',
+        'title: Foo',
+        '---',
+        '',
+        '# Heading',
+        '',
+        '![one](../../attachments/n1/one.png)',
+        '',
+        'Some prose with a [[Wiki Link]] and a [link](https://example.com).',
+        '',
+        '<!-- file:{"url":"../../attachments/n1/two.pdf","name":"two.pdf","size":2,' +
+          '"mimeType":"application/pdf"} -->',
+        ''
+      ].join('\n')
+    )
+  })
+
+  it('returns null for an empty body', () => {
+    expect(rewriteNoteRefsForMove('', 'notes/Foo.md', 'notes/archive/Foo.md')).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/vault/rewrite-note-refs.ts
+++ b/apps/desktop/src/main/vault/rewrite-note-refs.ts
@@ -1,0 +1,156 @@
+/**
+ * Re-point a note's relative refs when the note itself moves.
+ *
+ * Attachments are written into a note as a path relative to *the note*
+ * (`../attachments/<noteId>/x.pdf` — see `noteRelativeRef` in `main/lib/paths.ts`
+ * and `saveAttachment`), while the bytes live at `attachments/<noteId>/` and stay
+ * there forever. So the ref is only correct for the folder the note was in when it
+ * was written: move `notes/Foo.md` to `notes/archive/2026/Foo.md` and every
+ * `../attachments/...` in its body is now one level short, the embed goes blank,
+ * and the file is still sitting on disk. The same is true of any plain relative ref
+ * at another vault file — a sidebar drop of `notes/images/photo.png`, or an
+ * Obsidian-authored `../Images/photo.png` — which moves with neither side.
+ *
+ * The fix is arithmetic, not bookkeeping: resolve each ref against the *old* note
+ * directory to get the vault-relative target it always meant, then express that
+ * same target relative to the *new* directory.
+ *
+ * Two things this deliberately does not do:
+ *
+ *  - It never rewrites a ref it does not own. Anything with a URL scheme
+ *    (`https:`, `data:`, `memry-file:`, a Windows `C:`), anything rooted at `/`
+ *    or `\`, and anything that climbs above the vault root is left exactly as
+ *    written. Wiki-links (`[[Title]]`) resolve by title, not by path, so a move
+ *    cannot invalidate them and they are not touched either.
+ *  - It never returns a body that differs only cosmetically. Refs are commonly
+ *    percent-encoded, and decoding for the path math then re-encoding would churn
+ *    every escape we do not reproduce byte-for-byte (`%C3%A9`), so a ref whose
+ *    resolved path is unchanged keeps its original bytes. A move that leaves the
+ *    note's folder alone returns null before reading a single line.
+ */
+
+import path from 'path'
+import { FILE_BLOCK_LINE_REGEX, parseFileBlockMarker } from '@memry/editor-schema/blocks'
+import { noteRelativeRef } from '../lib/paths'
+// The same encoding the importers and `resolve-embed` apply: the ref goes back
+// into markdown as `![alt](ref)`, where a raw space or paren truncates the link.
+import { encodeAttachmentUrl } from '../import/_shared/attachment-markdown'
+
+/** `https:`, `data:`, `memry-file:` — and `C:` on Windows, which we also skip. */
+const HAS_SCHEME = /^[a-zA-Z][a-zA-Z\d+\-.]*:/
+
+/** `![alt](ref)`. The ref stops at whitespace or a paren, both of which are encoded. */
+const IMAGE_EMBED_REGEX = /(!\[[^\]]*\]\()([^()\s]*)(\))/g
+
+/** The `"url":"…"` member of a file marker's JSON payload, escapes included. */
+const MARKER_URL_REGEX = /"url":"(?:[^"\\]|\\.)*"/
+
+/**
+ * A comment terminator inside the payload closes the marker early and spills the
+ * rest of it into the note as a paragraph. Restated from `serializeFileBlock`,
+ * which does not export its escape: a filename like `a-->b.pdf` arrives here
+ * already escaped, `JSON.parse` hands it back raw, and it has to go back escaped.
+ */
+function escapeCommentTerminator(json: string): string {
+  return json.replace(/--(!?)>/g, '--$1\\u003e')
+}
+
+function dirOf(notePath: string): string {
+  const dir = path.posix.dirname(notePath.replace(/\\/g, '/'))
+  return dir === '.' ? '' : dir
+}
+
+/**
+ * The vault-relative file a ref names when read from `noteDir`, or null when the
+ * ref is not a vault-internal relative path.
+ */
+function resolveAgainstNoteDir(noteDir: string, ref: string): string | null {
+  const joined = path.posix.normalize(path.posix.join(noteDir, ref.replace(/\\/g, '/')))
+  // `..`, `../x` — above the vault root. `/x` — a ref that normalized to absolute.
+  if (joined === '..' || joined.startsWith('../') || path.posix.isAbsolute(joined)) return null
+  if (joined === '.' || joined === '') return null
+  return joined
+}
+
+/**
+ * One ref, re-pointed. Returns null when the ref is not ours to rewrite or when
+ * the path math leaves it exactly as written — in both cases the caller keeps the
+ * original bytes rather than a re-encoded equivalent.
+ */
+function rewriteRef(ref: string, oldNoteDir: string, newNotePath: string): string | null {
+  if (!ref) return null
+  if (HAS_SCHEME.test(ref)) return null
+  // A leading separator is ambiguous (vault root? filesystem root? a Windows UNC
+  // share, for `\\server\share`?) — don't guess, the way the renderer's resolver
+  // doesn't either.
+  if (ref.startsWith('/') || ref.startsWith('\\')) return null
+
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(ref)
+  } catch {
+    decoded = ref
+  }
+
+  const target = resolveAgainstNoteDir(oldNoteDir, decoded)
+  if (!target) return null
+
+  const next = noteRelativeRef(newNotePath, target)
+  if (!next || next === decoded) return null
+
+  return encodeAttachmentUrl(next)
+}
+
+/**
+ * The body with every vault-internal relative ref re-pointed at the file it
+ * already named, or null when nothing changed.
+ *
+ * Null is the signal not to write: the move path byte-compares nothing, it simply
+ * skips the write, so a note that carries no refs — or carries only absolute ones
+ * — keeps its `mtime` and its sync state untouched.
+ *
+ * @param body        The note file's contents, frontmatter included.
+ * @param oldNotePath Vault-relative path the note had before the move.
+ * @param newNotePath Vault-relative path the note has after the move.
+ */
+export function rewriteNoteRefsForMove(
+  body: string,
+  oldNotePath: string,
+  newNotePath: string
+): string | null {
+  const oldNoteDir = dirOf(oldNotePath)
+  // Same folder means every ref still resolves; a rename inside one folder, which
+  // is by far the common case, costs one string compare.
+  if (oldNoteDir === dirOf(newNotePath)) return null
+  if (!body) return null
+
+  let changed = false
+
+  const rewritten = body
+    .split('\n')
+    .map((line) => {
+      if (FILE_BLOCK_LINE_REGEX.test(line.trim())) {
+        const props = parseFileBlockMarker(line.trim())
+        if (!props) return line
+        const next = rewriteRef(props.url, oldNoteDir, newNotePath)
+        if (next === null) return line
+        changed = true
+        // Surgical: only the `url` member is replaced, so width/height/align and
+        // any member a newer version writes survive byte-for-byte. A function
+        // replacement keeps `$` in a filename from being read as a backreference.
+        return line.replace(MARKER_URL_REGEX, () =>
+          escapeCommentTerminator(`"url":${JSON.stringify(next)}`)
+        )
+      }
+
+      return line.replace(IMAGE_EMBED_REGEX, (match, open: string, ref: string, close: string) => {
+        const next = rewriteRef(ref, oldNoteDir, newNotePath)
+        if (next === null) return match
+        changed = true
+        return `${open}${next}${close}`
+      })
+    })
+    .join('\n')
+
+  return changed ? rewritten : null
+}

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -253,7 +253,12 @@ The relative ref resolves back to a `memry-file://` URL at render time only, so 
 - The `file` block is a custom spec that renders its own URL, so the same resolver reaches it through `note-file-url-context.tsx`. The resolved URL is never written back to the block's props — that would put the machine path back into the markdown.
 - Only the note page passes the note's path as a prop; the journal, canvas cards and a project's home note look it up by note id, from the same index row the write side reads.
 
-One consequence to know about: because the ref is relative to the note's folder and attachments stay under `attachments/<noteId>/`, moving a note to a different folder depth leaves its existing embeds pointing at the wrong place. Nothing rewrites refs on move yet.
+Because the ref is relative to the note's folder and attachments stay under `attachments/<noteId>/`, moving a note to a different folder would leave its existing embeds pointing at the wrong place. `moveNote` therefore re-points them: every relative ref in the body is resolved against the _old_ note folder and re-expressed relative to the new one (`src/main/vault/rewrite-note-refs.ts`), covering both the `![alt](ref)` image embed and the `<!-- file:{"url":…} -->` marker, whose other members are left byte-identical. Refs with a URL scheme, root-anchored refs, refs that climb above the vault root, and wiki-links (which resolve by title, not by path) are left exactly as written.
+
+Two properties that matter more than the arithmetic:
+
+- **A move that changes nothing writes nothing.** A rename inside one folder, or a move that leaves every ref resolving, skips the file write entirely — no `mtime` churn, no snapshot, no sync traffic. A percent-encoded ref keeps its original escapes rather than being re-encoded.
+- **The open editor is corrected too.** Main owns the note's Y.Doc and keys it by note id, so a move never invalidates it; the doc would still hold the pre-move body and the next CRDT write-back would put it straight back over the corrected file. `moveNote` pushes the rewritten body into the live doc with `replaceNoteBodyInCrdt` right after the write, the same order `applyTemplateToNote` uses.
 
 ### Text colors in markdown
 


### PR DESCRIPTION
Closes #1607

> **Stacked on #1606.** Base is `h4yfans/issue-1488`, not `main` — review that one first. Retarget to `main` once it lands.

## What was wrong

#1606 made attachment embeds note-relative (`../attachments/<noteId>/x.pdf`), which is what makes them work on a second device. But the attachment stays at `attachments/<noteId>/` and moving a note does not move it, so a note at `notes/Foo.md` moved to `notes/archive/2026/Foo.md` needs `../../../attachments/...` and still carries `../attachments/...`. The embed goes blank while the bytes sit on disk. `moveNote` renamed the file and reindexed but never touched the body.

Same for any plain relative ref at another vault file — a sidebar drop of `notes/images/photo.png`, or an Obsidian-authored `../Images/photo.png` — which moves with neither side.

## What changed

`rewrite-note-refs.ts` resolves each ref against the **old** note directory to the vault-relative target it always meant, then expresses that same target relative to the **new** one. Arithmetic, not bookkeeping.

Covers both shapes an attachment takes: the `![alt](ref)` image embed and the `<!-- file:{…} -->` marker, where **only the `url` member is replaced** so width/height/align — and any member a newer version writes — survive byte-for-byte. The marker's comment-terminator escape is reapplied, since `JSON.parse` hands the filename back raw.

Left alone on purpose: anything with a URL scheme (`https:`, `data:`, `memry-file:`, a Windows `C:`), anything rooted at `/` or `\`, anything that climbs above the vault root, and wiki-links — those resolve by title, so a move cannot invalidate them.

**Nothing is written when nothing changes.** A move within the same folder returns before reading a line; a ref whose resolved path is unchanged keeps its original bytes rather than a re-encoded equivalent, so percent-escapes we would not reproduce byte-for-byte (`%C3%A9`) never churn. The file keeps its mtime and its sync state.

## The CRDT half, which is the load-bearing part

A naked file write here would be silently undone. `CrdtProvider.docs` is keyed by **note id**, never by path, so a move never invalidates an open doc; `writebackExisting` re-reads the cached path at write time and overwrites unconditionally, and `persistUpdate` makes that durable across restart. The usual safety net does not fire either: `fs.rename` emits `unlink`+`add`, and the watcher's `handleFileAdd` returns early because the cache row was already repointed, so the external-edit feed never runs.

So the move now does what `applyTemplateToNote` does, in that order: `markWritebackIgnored(newPath)`, write the file, then `replaceNoteBodyInCrdt(id, body)` — a cheap no-op when no doc is open, and `ORIGIN_LOCAL` so it does not re-arm a write-back.

## Compatibility

No format change and no schema change. Notes that need no rewrite are not written at all, so nothing churns in anyone's vault; a note written by an older version is only touched when it is moved, and only its refs change.

## Verification

| Gate | Result |
|---|---|
| `pnpm --filter @memry/desktop test:main` | 7023 passed / 539 files, 0 failed |
| `pnpm --filter @memry/desktop typecheck` | 2 errors |
| `pnpm lint` | 0 errors |
| `pnpm docs:impact --strict` | pass (docs updated) |
| `git diff --check` | clean |

The 2 type errors are the pre-existing `sidebar-nav.test.tsx` `onNavMiddleClick` ones, unrelated and present on `main`.

19 tests: 17 unit over `rewriteNoteRefsForMove` (deeper/shallower/root moves, marker byte-identity, escapes, percent-encoding round trip and its no-op case, scheme/root/above-root refusals, wiki-links) and 4 integration over `moveNote`.

**Mutation-checked, and the first pass found a real hole.** Breaking the ref rewrite turns 9 tests red; removing the no-op guard turns 2 red; dropping the scheme guard turns 2 red. But **deleting the `replaceNoteBodyInCrdt` call left the whole suite green** — the single line protecting against durable data loss had no coverage at all. That gap is closed by the second commit, and re-running the same mutation now fails the test that names it.
