### PR TITLE
feat(sync-server): add a snapshot revision token and return snapshotMeta on the batch CRDT pull

### DIFF
--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -548,9 +548,9 @@ list.
 | `POST /sync/pull`                 | down      | Fetch updates since cursor                                                       |
 | `POST /sync/crdt/updates`         | up        | Incremental Yjs binary updates                                                   |
 | `GET /sync/crdt/updates`          | down      | One note's incremental updates (`note_id`, `since`, `limit` query params)        |
-| `POST /sync/crdt/updates/batch`   | down      | Incremental updates for up to 100 notes in one request; never snapshot baselines |
+| `POST /sync/crdt/updates/batch`   | down      | Incremental updates for up to 100 notes in one request, plus `snapshotMeta`      |
 | `POST /sync/crdt/snapshot`        | up        | Full Yjs document baseline; prunes the note's stored updates at or below it      |
-| `GET /sync/crdt/snapshot/:noteId` | down      | The note's snapshot baseline, applied before its incrementals                    |
+| `GET /sync/crdt/snapshot/:noteId` | down      | The note's snapshot baseline and its `revision`, applied before its incrementals |
 | `GET /sync/vaults`                | down      | List the account's registered vaults                                             |
 | `POST /sync/vaults`               | up        | Register or update a vault's encrypted name                                      |
 | `POST /auth/*`                    | mixed     | OTP, sign-in, refresh, sign-out                                                  |
@@ -564,6 +564,31 @@ moves metadata only. A device reads a body by applying the baseline from
 `POST /sync/crdt/updates/batch` is the whole-vault form of that second step — up to 100 notes per
 request, each with its own `since` — but it batches incrementals only, so the baselines stay one GET
 per note and dominate a first-sync sweep's request count.
+
+### Snapshot revisions
+
+A snapshot baseline carries a `revision`: an opaque token the server replaces on every snapshot
+write, so a client can tell whether the server's baseline moved without downloading it.
+
+- `GET /sync/crdt/snapshot/:noteId` returns `revision` alongside `snapshot`, `sequenceNum` and
+  `signerDeviceId`, so a device learns the token for the baseline it just merged. When the note has
+  no server snapshot the response is `{ snapshot: null, sequenceNum: 0, signerDeviceId: null, revision: null }`.
+- `POST /sync/crdt/updates/batch` returns a top-level `snapshotMeta` map beside `notes`:
+  `{ "<noteId>": { "sequenceNum": 42, "revision": "…", "signerDeviceId": "…" } }`. A note absent from
+  a present map has no server snapshot at all; an absent `snapshotMeta` key means the server predates
+  this field.
+
+The token is deliberately not `sequenceNum`. A replacement snapshot keeps the note's existing
+sequence number so later incrementals stay pullable, so the number does not move when the blob does.
+It is random per write rather than a counter, so a row deleted and recreated — vault deletion,
+account recreation — cannot reuse a token a client still holds.
+
+Rows written before the field existed are not backfilled; the server derives a deterministic token
+for them at read time from the row's identity, creation time and size, and the next snapshot push
+replaces it with a real one. Both read paths return the same token for the same row.
+
+Both fields are additive: an older client reads these responses through an unvalidated cast and
+ignores the extra keys.
 
 Pushing a snapshot is an assertion, not just a write: once the snapshot is stored,
 `pruneUpdatesBeforeSnapshot` deletes every `crdt_updates` row for that note at or below the

--- a/apps/sync-server/migrations/0005_crdt_snapshot_revision.sql
+++ b/apps/sync-server/migrations/0005_crdt_snapshot_revision.sql
@@ -1,0 +1,31 @@
+-- A change token for the snapshot blob, so a client can learn whether the
+-- SERVER's snapshot moved without downloading it. The vault sweep currently
+-- spends one unconditional `GET /sync/crdt/snapshot/:noteId` per note per pass
+-- on a baseline it almost always already holds; this column is what makes that
+-- GET conditional.
+--
+-- Nothing we already store can play this role:
+--
+--   * `sequence_num` is PINNED on rewrite -- `storeSnapshot` keeps
+--     `existingSnapshot?.sequence_num` so later incrementals stay pullable, so
+--     the second and every later snapshot for a note keeps the same number
+--     while replacing the blob. Using it would pin every device to the first
+--     snapshot a note ever had.
+--   * `created_at` has 1-second resolution, and (created_at, size_bytes,
+--     signer_device_id) can collide for two pushes of the same note, in the
+--     same second, from the same device, at the same ciphertext length. The
+--     consequence of a collision is a permanently stale note body.
+--
+-- Random per write rather than a counter, so a row deleted and recreated (vault
+-- deletion, account recreation) cannot collide with a token a client still holds.
+--
+-- Additive with a default and deliberately NOT backfilled. '' is the signal that
+-- a row predates this column; `getSnapshot` and the batch metadata read coalesce
+-- it to `legacy:<id>:<created_at>:<size_bytes>`, which is deterministic per row
+-- and changes on any rewrite -- and any rewrite also assigns a real random
+-- revision, so a row is legacy at most until its next snapshot push. That avoids
+-- a single UPDATE over what could be millions of rows inside a D1 migration.
+--
+-- A Worker deployed before this migration (or rolled back after it) never reads
+-- or writes the column, so old server code is unaffected.
+ALTER TABLE crdt_snapshots ADD COLUMN revision TEXT NOT NULL DEFAULT '';

--- a/apps/sync-server/schema/d1.test.ts
+++ b/apps/sync-server/schema/d1.test.ts
@@ -199,6 +199,7 @@ describe('D1 schema', () => {
     expect(cursorColumns.map((column) => column.name)).toContain('vault_id')
     expect(crdtUpdateColumns.map((column) => column.name)).toContain('vault_id')
     expect(crdtSnapshotColumns.map((column) => column.name)).toContain('vault_id')
+    expect(crdtSnapshotColumns.map((column) => column.name)).toContain('revision')
     expect(uploadSessionColumns.map((column) => column.name)).toContain('vault_id')
     expect(blobChunkColumns.map((column) => column.name)).toContain('vault_id')
   })
@@ -273,6 +274,38 @@ describe('D1 schema', () => {
 
       // #and the refund still pays back only the PLAINTEXT that was actually reserved
       expect(row.encrypted_size ?? row.total_size).toBe(5_000)
+    })
+  })
+
+  // The revision token is what lets a client skip a snapshot download it does not
+  // need. Existing rows must survive the migration with '' — the server coalesces
+  // that at read time — rather than being rewritten by a backfill UPDATE over what
+  // could be millions of rows inside a D1 migration.
+  describe('0005_crdt_snapshot_revision', () => {
+    it('leaves rows written before the column existed with an empty revision', () => {
+      // #given a database at 0004 with a snapshot the old server wrote
+      const db = new Database(':memory:')
+      for (const file of migrationFiles().filter((name) => name < '0005')) {
+        db.exec(loadMigrationSql(file))
+      }
+      db.prepare(
+        `INSERT INTO users (id, email, auth_method, created_at, updated_at)
+         VALUES ('user-1', 'a@b.com', 'otp', 1, 1)`
+      ).run()
+      db.prepare(
+        `INSERT INTO crdt_snapshots
+           (id, user_id, vault_id, note_id, blob_key, sequence_num, size_bytes, signer_device_id, created_at)
+         VALUES ('snap-1', 'user-1', 'vault-1', 'note-1', 'user-1/k', 7, 42, 'device-a', 1700000000)`
+      ).run()
+
+      // #when 0005 is applied
+      db.exec(loadMigrationSql('0005_crdt_snapshot_revision.sql'))
+
+      // #then the row is untouched apart from the defaulted column, so the read-time
+      // coalesce is what gives it a token
+      expect(
+        db.prepare('SELECT id, created_at, size_bytes, revision FROM crdt_snapshots').get()
+      ).toEqual({ id: 'snap-1', created_at: 1700000000, size_bytes: 42, revision: '' })
     })
   })
 })

--- a/apps/sync-server/src/routes/sync.test.ts
+++ b/apps/sync-server/src/routes/sync.test.ts
@@ -1250,20 +1250,25 @@ describe('sync routes', () => {
 
     it('returns encoded batch CRDT updates', async () => {
       vi.mocked(getBatchUpdates).mockResolvedValueOnce({
-        note_1: {
-          updates: [
-            {
-              id: 'update-8',
-              user_id: 'user-1',
-              vault_id: 'vault-1',
-              note_id: 'note_1',
-              sequence_num: 8,
-              update_data: bytes('batch'),
-              signer_device_id: 'device-2',
-              created_at: 222
-            }
-          ],
-          hasMore: false
+        notes: {
+          note_1: {
+            updates: [
+              {
+                id: 'update-8',
+                user_id: 'user-1',
+                vault_id: 'vault-1',
+                note_id: 'note_1',
+                sequence_num: 8,
+                update_data: bytes('batch'),
+                signer_device_id: 'device-2',
+                created_at: 222
+              }
+            ],
+            hasMore: false
+          }
+        },
+        snapshotMeta: {
+          note_1: { sequenceNum: 4, revision: 'rev-1', signerDeviceId: 'device-2' }
         }
       })
 
@@ -1291,6 +1296,12 @@ describe('sync routes', () => {
             ],
             hasMore: false
           }
+        },
+        // Additive top-level key. A client that gets no `snapshotMeta` at all is
+        // talking to a server that predates it; a note absent from a present map
+        // has no server snapshot.
+        snapshotMeta: {
+          note_1: { sequenceNum: 4, revision: 'rev-1', signerDeviceId: 'device-2' }
         }
       })
       expect(getBatchUpdates).toHaveBeenCalledWith(
@@ -1484,14 +1495,20 @@ describe('sync routes', () => {
       )
 
       expect(res.status).toBe(200)
-      expect(await res.json()).toEqual({ snapshot: null, sequenceNum: 0, signerDeviceId: null })
+      expect(await res.json()).toEqual({
+        snapshot: null,
+        sequenceNum: 0,
+        signerDeviceId: null,
+        revision: null
+      })
     })
 
     it('returns encoded CRDT snapshots and validates snapshot ids', async () => {
       vi.mocked(getSnapshot).mockResolvedValueOnce({
         snapshotData: bytes('snapshot'),
         sequenceNum: 20,
-        signerDeviceId: 'device-2'
+        signerDeviceId: 'device-2',
+        revision: 'rev-1'
       })
 
       let res = await app.request(
@@ -1502,10 +1519,13 @@ describe('sync routes', () => {
       )
 
       expect(res.status).toBe(200)
+      // The revision the client just merged, so the next batch pull can tell it
+      // this baseline is still current.
       expect(await res.json()).toEqual({
         snapshot: btoa('snapshot'),
         sequenceNum: 20,
-        signerDeviceId: 'device-2'
+        signerDeviceId: 'device-2',
+        revision: 'rev-1'
       })
 
       res = await app.request(

--- a/apps/sync-server/src/routes/sync.ts
+++ b/apps/sync-server/src/routes/sync.ts
@@ -661,7 +661,7 @@ const handleCrdtBatchPull = async (c: Context<AppContext>): Promise<Response> =>
   const batchResult = await getBatchUpdates(c.env.DB, userId, vaultId, parsed.notes, parsed.limit)
 
   const response: Record<string, { updates: unknown[]; hasMore: boolean }> = {}
-  for (const [noteId, result] of Object.entries(batchResult)) {
+  for (const [noteId, result] of Object.entries(batchResult.notes)) {
     response[noteId] = {
       updates: result.updates.map((update) => ({
         sequenceNum: update.sequence_num,
@@ -677,8 +677,11 @@ const handleCrdtBatchPull = async (c: Context<AppContext>): Promise<Response> =>
     endpoint,
     event: 'batch_fetched',
     noteCount: parsed.notes.length,
-    updateCount: Object.values(batchResult).reduce((sum, result) => sum + result.updates.length, 0),
-    totalBytes: Object.values(batchResult).reduce(
+    updateCount: Object.values(batchResult.notes).reduce(
+      (sum, result) => sum + result.updates.length,
+      0
+    ),
+    totalBytes: Object.values(batchResult.notes).reduce(
       (sum, result) =>
         sum +
         result.updates.reduce((noteSum, update) => noteSum + update.update_data.byteLength, 0),
@@ -687,7 +690,12 @@ const handleCrdtBatchPull = async (c: Context<AppContext>): Promise<Response> =>
     latencyMs: Date.now() - startedAt
   })
 
-  return c.json({ notes: response })
+  // `snapshotMeta` is additive and present on every response from a server that
+  // supports it, so a client can tell "the server is old" (key absent) from "the
+  // server has no snapshot for this note" (key present, note absent). Old
+  // clients read this response through an unvalidated TypeScript cast, so the
+  // extra key is ignored.
+  return c.json({ notes: response, snapshotMeta: batchResult.snapshotMeta })
 }
 
 const handleCrdtSnapshotPush = async (c: Context<AppContext>): Promise<Response> => {
@@ -799,7 +807,7 @@ const handleCrdtSnapshotPull = async (c: Context<AppContext>): Promise<Response>
       sequenceNum: 0,
       latencyMs: Date.now() - startedAt
     })
-    return c.json({ snapshot: null, sequenceNum: 0, signerDeviceId: null })
+    return c.json({ snapshot: null, sequenceNum: 0, signerDeviceId: null, revision: null })
   }
 
   logCrdtTraffic({
@@ -811,10 +819,13 @@ const handleCrdtSnapshotPull = async (c: Context<AppContext>): Promise<Response>
     latencyMs: Date.now() - startedAt
   })
 
+  // The revision the client just merged, so the next batch pull can tell it this
+  // baseline is still current and skip the download.
   return c.json({
     snapshot: safeBase64Encode(result.snapshotData),
     sequenceNum: result.sequenceNum,
-    signerDeviceId: result.signerDeviceId
+    signerDeviceId: result.signerDeviceId,
+    revision: result.revision
   })
 }
 

--- a/apps/sync-server/src/services/crdt.test.ts
+++ b/apps/sync-server/src/services/crdt.test.ts
@@ -31,6 +31,7 @@ interface FakeSnapshotRow {
   size_bytes: number
   signer_device_id: string
   created_at: number
+  revision: string
 }
 
 interface PreparedCall {
@@ -107,17 +108,19 @@ function createD1Database(): D1Database {
             return { sequence_num: row.sequence_num } as T
           }
 
-          if (
-            sql.startsWith('SELECT blob_key, sequence_num, signer_device_id FROM crdt_snapshots')
-          ) {
+          if (sql.startsWith('SELECT id, blob_key, sequence_num, signer_device_id')) {
             const row = snapshots.get(
               snapshotKey(params[0] as string, params[1] as string, params[2] as string)
             )
             if (!row) return null
             return {
+              id: row.id,
               blob_key: row.blob_key,
               sequence_num: row.sequence_num,
-              signer_device_id: row.signer_device_id
+              signer_device_id: row.signer_device_id,
+              created_at: row.created_at,
+              size_bytes: row.size_bytes,
+              revision: row.revision
             } as T
           }
 
@@ -156,11 +159,20 @@ function createD1Database(): D1Database {
             return { results: rows as T[] }
           }
 
+          if (sql.startsWith('SELECT id, note_id, sequence_num, revision')) {
+            const [userId, vaultId, ...noteIds] = params as string[]
+            const rows = noteIds
+              .map((noteId) => snapshots.get(snapshotKey(userId, vaultId, noteId)))
+              .filter((row): row is FakeSnapshotRow => row !== undefined)
+            return { results: rows as T[] }
+          }
+
           return { results: [] as T[] }
         },
         async run() {
           if (sql.startsWith('INSERT INTO crdt_snapshots')) {
-            const row: FakeSnapshotRow = {
+            const key = snapshotKey(params[1] as string, params[2] as string, params[3] as string)
+            const incoming: FakeSnapshotRow = {
               id: params[0] as string,
               user_id: params[1] as string,
               vault_id: params[2] as string,
@@ -169,9 +181,39 @@ function createD1Database(): D1Database {
               sequence_num: params[5] as number,
               size_bytes: params[6] as number,
               signer_device_id: params[7] as string,
-              created_at: params[8] as number
+              created_at: params[8] as number,
+              revision: params[9] as string
             }
-            snapshots.set(snapshotKey(row.user_id, row.vault_id, row.note_id), row)
+
+            const existing = snapshots.get(key)
+            if (!existing) {
+              snapshots.set(key, incoming)
+              return { meta: { changes: 1 } }
+            }
+
+            // On conflict SQLite applies ONLY the columns named in DO UPDATE SET,
+            // and `id` is deliberately not one of them. Modelling the clause
+            // rather than overwriting the whole row is what lets the revision-bump
+            // assertion actually fail: a SET clause that forgets `revision` leaves
+            // the stored one behind, which is the failure this token exists to
+            // prevent.
+            const setClause = sql.slice(sql.indexOf('DO UPDATE SET'))
+            const updated: FakeSnapshotRow = { ...existing }
+            const target = updated as unknown as Record<string, unknown>
+            const source = incoming as unknown as Record<string, unknown>
+            for (const column of [
+              'blob_key',
+              'sequence_num',
+              'size_bytes',
+              'signer_device_id',
+              'created_at',
+              'revision'
+            ]) {
+              if (setClause.includes(`${column} = excluded.${column}`)) {
+                target[column] = source[column]
+              }
+            }
+            snapshots.set(key, updated)
             return { meta: { changes: 1 } }
           }
 
@@ -373,16 +415,148 @@ describe('CRDT service sequencing', () => {
       2
     )
 
-    expect(result['note-1'].hasMore).toBe(true)
-    expect(result['note-1'].updates.map((update) => update.sequence_num)).toEqual([1, 2])
-    expect(result['note-2'].hasMore).toBe(false)
-    expect(result['note-2'].updates.map((update) => update.sequence_num)).toEqual([1])
+    expect(result.notes['note-1'].hasMore).toBe(true)
+    expect(result.notes['note-1'].updates.map((update) => update.sequence_num)).toEqual([1, 2])
+    expect(result.notes['note-2'].hasMore).toBe(false)
+    expect(result.notes['note-2'].updates.map((update) => update.sequence_num)).toEqual([1])
   })
 
   it('returns an empty batch result when no notes are requested', async () => {
     const db = createD1Database()
 
-    await expect(getBatchUpdates(db, 'user-1', 'vault-1', [], 10)).resolves.toEqual({})
+    await expect(getBatchUpdates(db, 'user-1', 'vault-1', [], 10)).resolves.toEqual({
+      notes: {},
+      snapshotMeta: {}
+    })
+  })
+
+  it('assigns a revision on the first snapshot for a note', async () => {
+    // #given
+    const db = createD1Database()
+    const storage = createMemoryBucket()
+
+    // #when
+    await storeSnapshot(db, storage, 'user-1', 'vault-1', 'note-1', 'device-a', bytes('snap-a'))
+
+    // #then a real token, not the '' the column defaults to and not the legacy fallback
+    const snapshot = await getSnapshot(db, storage, 'user-1', 'vault-1', 'note-1')
+    expect(snapshot?.revision).toEqual(expect.any(String))
+    expect(snapshot?.revision).not.toBe('')
+    expect(snapshot?.revision.startsWith('legacy:')).toBe(false)
+  })
+
+  // FM1. A revision that fails to move when the blob does is the whole design's
+  // central risk: the client skips a snapshot it needed and keeps a stale body
+  // forever. The replacement path is where it goes wrong, because the row already
+  // exists and `sequence_num` is deliberately PINNED across it — so the revision
+  // is the only thing left that can say "this changed".
+  it('assigns a NEW revision when a snapshot is replaced, even though the sequence stays pinned', async () => {
+    // #given a note with a snapshot already stored
+    const db = createD1Database()
+    const storage = createMemoryBucket()
+
+    await storeUpdates(db, 'user-1', 'vault-1', 'note-1', 'device-a', [bytes('a1')])
+    await storeSnapshot(db, storage, 'user-1', 'vault-1', 'note-1', 'device-a', bytes('snap-a'))
+    const first = await getSnapshot(db, storage, 'user-1', 'vault-1', 'note-1')
+
+    // #when the blob is replaced through the ON CONFLICT path
+    await storeSnapshot(db, storage, 'user-1', 'vault-1', 'note-1', 'device-b', bytes('snap-b'))
+    const second = await getSnapshot(db, storage, 'user-1', 'vault-1', 'note-1')
+
+    // #then the revision moved
+    expect(second?.revision).not.toBe(first?.revision)
+    expect(second?.revision).not.toBe('')
+
+    // #and the sequence number did NOT, which is exactly why it cannot be the token
+    expect(second?.sequenceNum).toBe(first?.sequenceNum)
+    expect(new TextDecoder().decode(second!.snapshotData)).toBe('snap-b')
+  })
+
+  it('advertises on the batch pull the same revision the snapshot read returns', async () => {
+    // #given two notes with snapshots and a third with none
+    const db = createD1Database()
+    const storage = createMemoryBucket()
+
+    await storeSnapshot(db, storage, 'user-1', 'vault-1', 'note-1', 'device-a', bytes('snap-1'))
+    await storeSnapshot(db, storage, 'user-1', 'vault-1', 'note-2', 'device-b', bytes('snap-2'))
+
+    // #when the batch pull names all three
+    const result = await getBatchUpdates(
+      db,
+      'user-1',
+      'vault-1',
+      [
+        { noteId: 'note-1', since: 0 },
+        { noteId: 'note-2', since: 0 },
+        { noteId: 'note-3', since: 0 }
+      ],
+      10
+    )
+
+    // #then the metadata matches the per-note read a client would otherwise make
+    const snapshot1 = await getSnapshot(db, storage, 'user-1', 'vault-1', 'note-1')
+    expect(result.snapshotMeta['note-1']).toEqual({
+      sequenceNum: snapshot1!.sequenceNum,
+      revision: snapshot1!.revision,
+      signerDeviceId: 'device-a'
+    })
+    expect(result.snapshotMeta['note-2'].signerDeviceId).toBe('device-b')
+
+    // #and a note the server has no snapshot for is simply absent
+    expect(result.snapshotMeta['note-3']).toBeUndefined()
+    expect(result.notes['note-3']).toEqual({ updates: [], hasMore: false })
+  })
+
+  // Rows written before the column existed carry '' — the migration deliberately
+  // does not backfill. Both read paths must coalesce to the SAME string, or a
+  // client comparing what it merged from the GET against what the batch
+  // advertises would re-download every legacy snapshot forever.
+  it('coalesces a pre-migration row to the same legacy revision on both read paths', async () => {
+    // #given a row the old server wrote, so revision is the column default
+    const legacyRow = {
+      id: 'snap-legacy',
+      note_id: 'note-1',
+      blob_key: 'user-1/vaults/vault-1/crdt/note-1/snapshot',
+      sequence_num: 7,
+      signer_device_id: 'device-a',
+      created_at: 1_700_000_000,
+      size_bytes: 42,
+      revision: ''
+    }
+    const db = {
+      prepare(sql: string) {
+        const prepared = {
+          bind: () => prepared,
+          async first() {
+            return sql.startsWith('SELECT id, blob_key, sequence_num, signer_device_id')
+              ? legacyRow
+              : null
+          },
+          async all() {
+            return {
+              results: sql.startsWith('SELECT id, note_id, sequence_num, revision')
+                ? [legacyRow]
+                : []
+            }
+          }
+        }
+        return prepared as unknown as D1PreparedStatement
+      },
+      async batch(statements: D1PreparedStatement[]) {
+        return Promise.all(statements.map((statement) => statement.all()))
+      }
+    } as unknown as D1Database
+
+    const storage = createMemoryBucket()
+    await storage.put(legacyRow.blob_key, bytes('legacy'))
+
+    // #when both paths read it
+    const snapshot = await getSnapshot(db, storage, 'user-1', 'vault-1', 'note-1')
+    const batch = await getBatchUpdates(db, 'user-1', 'vault-1', [{ noteId: 'note-1', since: 0 }], 10)
+
+    // #then the token is derived from the row and is identical across them
+    expect(snapshot?.revision).toBe('legacy:snap-legacy:1700000000:42')
+    expect(batch.snapshotMeta['note-1'].revision).toBe(snapshot?.revision)
   })
 
   it('returns null when a snapshot row or object is missing', async () => {

--- a/apps/sync-server/src/services/crdt.ts
+++ b/apps/sync-server/src/services/crdt.ts
@@ -51,7 +51,40 @@ interface CrdtSnapshot {
   size_bytes: number
   signer_device_id: string
   created_at: number
+  revision: string
 }
+
+/**
+ * What a client needs to decide whether the server's snapshot for a note moved,
+ * without downloading it.
+ */
+export interface CrdtSnapshotMeta {
+  sequenceNum: number
+  revision: string
+  signerDeviceId: string
+}
+
+interface SnapshotRevisionRow {
+  id: string
+  created_at: number
+  size_bytes: number
+  revision: string
+}
+
+/**
+ * Rows written before `revision` existed carry '' (the column default; the
+ * migration deliberately does not backfill). They coalesce at READ time to a
+ * token derived from the row itself: `id` is never rewritten by the upsert, so
+ * it discriminates a deleted-and-recreated row, while `created_at` and
+ * `size_bytes` move whenever the blob is replaced.
+ *
+ * Both read paths -- `getSnapshot` and the batch metadata read -- must produce
+ * the SAME string for the same row, or a client comparing the token it merged
+ * from the GET against the token the batch advertises would never match, and
+ * would re-download every legacy snapshot forever.
+ */
+const coalesceRevision = (row: SnapshotRevisionRow): string =>
+  row.revision !== '' ? row.revision : `legacy:${row.id}:${row.created_at}:${row.size_bytes}`
 
 const getMaxSequenceNumber = async (
   db: D1Database,
@@ -159,14 +192,38 @@ export const getUpdates = async (
   }
 }
 
+/**
+ * The one statement that reads snapshot metadata for a whole batch of notes.
+ *
+ * Handed back as a prepared statement rather than executed here so
+ * `getBatchUpdates` can append it to the `db.batch()` it already sends: this is
+ * one extra statement on an existing round trip, not a second round trip.
+ */
+const getBatchSnapshotMeta = (
+  db: D1Database,
+  userId: string,
+  vaultId: string,
+  noteIds: string[]
+): D1PreparedStatement =>
+  db
+    .prepare(
+      `SELECT id, note_id, sequence_num, revision, created_at, size_bytes, signer_device_id
+       FROM crdt_snapshots
+       WHERE user_id = ? AND vault_id = ? AND note_id IN (${noteIds.map(() => '?').join(', ')})`
+    )
+    .bind(userId, vaultId, ...noteIds)
+
 export const getBatchUpdates = async (
   db: D1Database,
   userId: string,
   vaultId: string,
   notes: Array<{ noteId: string; since: number }>,
   limitPerNote: number
-): Promise<Record<string, { updates: CrdtUpdate[]; hasMore: boolean }>> => {
-  if (notes.length === 0) return {}
+): Promise<{
+  notes: Record<string, { updates: CrdtUpdate[]; hasMore: boolean }>
+  snapshotMeta: Record<string, CrdtSnapshotMeta>
+}> => {
+  if (notes.length === 0) return { notes: {}, snapshotMeta: {} }
 
   const statements = notes.map((n) =>
     db
@@ -175,18 +232,39 @@ export const getBatchUpdates = async (
       )
       .bind(userId, vaultId, n.noteId, n.since, limitPerNote + 1)
   )
+  statements.push(
+    getBatchSnapshotMeta(
+      db,
+      userId,
+      vaultId,
+      notes.map((n) => n.noteId)
+    )
+  )
 
   const batchResults = await db.batch(statements)
 
-  const result: Record<string, { updates: CrdtUpdate[]; hasMore: boolean }> = {}
+  const noteResults: Record<string, { updates: CrdtUpdate[]; hasMore: boolean }> = {}
   for (let i = 0; i < notes.length; i++) {
     const rows = (batchResults[i] as D1Result<CrdtUpdate>).results ?? []
-    result[notes[i].noteId] = {
+    noteResults[notes[i].noteId] = {
       updates: rows.slice(0, limitPerNote),
       hasMore: rows.length > limitPerNote
     }
   }
-  return result
+
+  // A note absent from this map has no server snapshot at all.
+  const snapshotMeta: Record<string, CrdtSnapshotMeta> = {}
+  const metaRows =
+    (batchResults[notes.length] as D1Result<CrdtSnapshot> | undefined)?.results ?? []
+  for (const row of metaRows) {
+    snapshotMeta[row.note_id] = {
+      sequenceNum: row.sequence_num,
+      revision: coalesceRevision(row),
+      signerDeviceId: row.signer_device_id
+    }
+  }
+
+  return { notes: noteResults, snapshotMeta }
 }
 
 export const storeSnapshot = async (
@@ -199,6 +277,11 @@ export const storeSnapshot = async (
   snapshotData: ArrayBuffer
 ): Promise<{ sequenceNum: number }> => {
   const id = crypto.randomUUID()
+  // Fresh on EVERY write, insert and conflict alike, and never conditional on
+  // whether the bytes look different. A revision that fails to move when the
+  // blob does leaves a client skipping a snapshot it needed, with a stale body
+  // forever -- the one failure this token exists to prevent.
+  const revision = crypto.randomUUID()
   const now = Math.floor(Date.now() / 1000)
   const blobKey = generateCrdtKey(userId, noteId, vaultId)
   const currentSeq = await getMaxSequenceNumber(db, userId, vaultId, noteId)
@@ -227,10 +310,10 @@ export const storeSnapshot = async (
 
     await db
       .prepare(
-        `INSERT INTO crdt_snapshots (id, user_id, vault_id, note_id, blob_key, sequence_num, size_bytes, signer_device_id, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `INSERT INTO crdt_snapshots (id, user_id, vault_id, note_id, blob_key, sequence_num, size_bytes, signer_device_id, created_at, revision)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT (user_id, vault_id, note_id)
-         DO UPDATE SET blob_key = excluded.blob_key, sequence_num = excluded.sequence_num, size_bytes = excluded.size_bytes, signer_device_id = excluded.signer_device_id, created_at = excluded.created_at`
+         DO UPDATE SET blob_key = excluded.blob_key, sequence_num = excluded.sequence_num, size_bytes = excluded.size_bytes, signer_device_id = excluded.signer_device_id, created_at = excluded.created_at, revision = excluded.revision`
       )
       .bind(
         id,
@@ -241,7 +324,8 @@ export const storeSnapshot = async (
         sequenceNum,
         snapshotData.byteLength,
         signerDeviceId,
-        now
+        now,
+        revision
       )
       .run()
   } catch (error) {
@@ -266,13 +350,20 @@ export const getSnapshot = async (
   userId: string,
   vaultId: string,
   noteId: string
-): Promise<{ snapshotData: ArrayBuffer; sequenceNum: number; signerDeviceId: string } | null> => {
+): Promise<{
+  snapshotData: ArrayBuffer
+  sequenceNum: number
+  signerDeviceId: string
+  revision: string
+} | null> => {
   const row = await db
     .prepare(
-      'SELECT blob_key, sequence_num, signer_device_id FROM crdt_snapshots WHERE user_id = ? AND vault_id = ? AND note_id = ?'
+      'SELECT id, blob_key, sequence_num, signer_device_id, created_at, size_bytes, revision FROM crdt_snapshots WHERE user_id = ? AND vault_id = ? AND note_id = ?'
     )
     .bind(userId, vaultId, noteId)
-    .first<{ blob_key: string; sequence_num: number; signer_device_id: string }>()
+    .first<
+      SnapshotRevisionRow & { blob_key: string; sequence_num: number; signer_device_id: string }
+    >()
 
   if (!row) return null
 
@@ -282,7 +373,12 @@ export const getSnapshot = async (
   if (!obj) return null
 
   const snapshotData = await obj.arrayBuffer()
-  return { snapshotData, sequenceNum: row.sequence_num, signerDeviceId: row.signer_device_id }
+  return {
+    snapshotData,
+    sequenceNum: row.sequence_num,
+    signerDeviceId: row.signer_device_id,
+    revision: coalesceRevision(row)
+  }
 }
 
 export const pruneUpdatesBeforeSnapshot = async (


### PR DESCRIPTION
**PR 1 of 5** in #1496. #1612 stacks on this branch.

## What changed

The vault sweep spends one unconditional `GET /sync/crdt/snapshot/:noteId` per note per pass on a baseline it almost always already holds — ~1,000 GETs and ~1,000 R2 Class B reads every 15 minutes on a 1,000-note vault. The client cannot know the GET is redundant, because it has no way to learn whether the **server's** snapshot changed without downloading it. This PR adds that token.

- **`migrations/0005_crdt_snapshot_revision.sql`** — `ALTER TABLE crdt_snapshots ADD COLUMN revision TEXT NOT NULL DEFAULT ''`. Additive, no backfill.
- **`storeSnapshot`** assigns a fresh `crypto.randomUUID()` to `revision` on insert **and** in the `ON CONFLICT DO UPDATE SET` branch — both paths, unconditionally.
- **`getSnapshot`** returns `revision`, coalescing `''` at read time to `legacy:${id}:${created_at}:${size_bytes}`.
- **`getBatchSnapshotMeta`** folds one extra statement into the `db.batch()` `getBatchUpdates` already sends — one extra statement, **no extra round trip**. `getBatchUpdates` now returns `{ notes, snapshotMeta }`.
- **`POST /sync/crdt/updates/batch`** gains a top-level `snapshotMeta` map; **`GET /sync/crdt/snapshot/:noteId`** gains `revision`.

```jsonc
{
  "notes": { "<noteId>": { "updates": [...], "hasMore": false } },
  // NEW. Present on every response from a server that supports this.
  // A noteId absent from this map has no server snapshot at all.
  "snapshotMeta": {
    "<noteId>": { "sequenceNum": 42, "revision": "b1c9…", "signerDeviceId": "dev_…" }
  }
}
```

**This PR is inert.** No client reads either field yet. It lives entirely inside `apps/sync-server` and respects the fixed sync-server-before-desktop deploy order; it can sit deployed and unused indefinitely.

### One deviation from the issue, called out

The issue lists the batch metadata read as `(note_id, sequence_num, revision, created_at, size_bytes, signer_device_id)`. It also selects `id`, because the legacy coalesce is `legacy:${id}:…` and **both read paths have to produce the same string for the same row**. Without `id` in the batch select, a client that merged `legacy:<id>:…` from the GET would compare it against `legacy:<note_id>:…` from the batch, never match, and re-download every pre-migration snapshot forever. A single shared `coalesceRevision` helper now serves both paths, and a test asserts they agree.

## Why not something we already have

**`sequence_num` cannot be the token.** `storeSnapshot` pins it (`existingSnapshot?.sequence_num ?? currentSeq`) so later incrementals stay pullable — the second and every later snapshot keeps the same number while replacing the blob. Using it would silently pin every device to the first snapshot a note ever had. The FM1 test asserts the revision moves *while the sequence number does not*, in the same test, so a future "simplification" to `sequence_num` fails loudly.

**`created_at` cannot be either** — 1-second resolution, and `(created_at, size_bytes, signer_device_id)` can collide for two pushes of the same note, in the same second, from the same device, at the same ciphertext length. The consequence of a collision is a permanently stale body.

**Random, not a counter**, so a row deleted and recreated (vault deletion, account recreation) cannot collide with a token a client still holds.

**Rejected zero-migration alternative**, recorded so it is not re-proposed: reuse `id` as the revision via `id = excluded.id`. Rejected because it silently changes `id` from a row identity into a version token, which the next reader of that table will not expect.

## Compat plan

- **PRODUCTION, real users.** Additive column **with a default** and **no backfill `UPDATE`** over the table — this avoids a single `UPDATE` over what could be millions of rows inside a D1 migration. Existing rows keep `''` and the server coalesces at read time; the legacy token is deterministic per row and changes on any rewrite, and any rewrite also assigns a real random revision, so a row is legacy at most until its next snapshot push.
- **New server + old client** (the window the deploy order creates). Request shape unchanged. `snapshotMeta` and `revision` are additive response fields; the desktop client reads batch responses through `postToServer<CrdtBatchPullResponse>`, a TypeScript cast with no runtime schema validation (the server's zod covers requests only), so extra keys are ignored.
- **Old server code** never reads or writes the column, so a rollback after the migration is a no-op.
- **Rate-limit classes** unchanged. No new bucket, no changed limit.
- `GET /sync/crdt/snapshot/:noteId` returns `revision: null` on its no-snapshot branch, matching the existing `signerDeviceId: null`, so the response shape is uniform.

## FM1 — mutation evidence

**FM1: the token fails to change when the blob does.** A client then skips a snapshot it needed and keeps a stale body forever. The `ON CONFLICT` branch is where it goes wrong, because the row already exists and `sequence_num` is pinned across it.

The fake D1 in `crdt.test.ts` was changed to model `DO UPDATE SET` **column by column** rather than overwriting the whole row — without that, the mutation below would not have been observable at all, and the test would have been green over broken behaviour (the documented failure mode of this subsystem, #1499).

Mutation applied (`git diff --stat`: `apps/sync-server/src/services/crdt.ts | 2 +-`):

```diff
-         DO UPDATE SET blob_key = excluded.blob_key, sequence_num = excluded.sequence_num, size_bytes = excluded.size_bytes, signer_device_id = excluded.signer_device_id, created_at = excluded.created_at, revision = excluded.revision`
+         DO UPDATE SET blob_key = excluded.blob_key, sequence_num = excluded.sequence_num, size_bytes = excluded.size_bytes, signer_device_id = excluded.signer_device_id, created_at = excluded.created_at`
```

Result — exactly the FM1 test goes red, nothing else:

```
 × assigns a NEW revision when a snapshot is replaced, even though the sequence stays pinned 3ms
AssertionError: expected '6d60d664-5c1e-430a-98c1-b0dcf484ccf1' not to be '6d60d664-5c1e-430a-98c1-b0dcf484ccf1'
 Test Files  1 failed (1)
      Tests  1 failed | 18 passed (19)
```

The mutation was then reverted and the full suite re-run green.

## Verification

| gate | result |
| --- | --- |
| `pnpm test:sync-server` | **PASS** — 62 files, 963 tests, 0 failed |
| `pnpm lint` | **PASS** — 0 errors, 97 warnings, none in `apps/sync-server` |
| `git diff --check` | **PASS** — clean |
| `pnpm docs:impact --base 6cc0dd83f --strict` | **PASS** — `covered` |
| `pnpm docs:build` | **PASS** |
| `pnpm typecheck` | **FAIL, pre-existing** — see below |

`pnpm typecheck` fails with one error, `apps/sync-server/src/services/posthog-transform.test.ts(315,9): error TS2741: Property 'failure' is missing…`. It is not from this branch: that file is byte-identical to the base commit (`git diff --quiet 6cc0dd83f -- <file>` is clean), and the fix for exactly this error is 81354bfa2 ("fix(sync): stop re-asking the server for attachments it does not have", #1598), which is on `main` but landed after this branch's base. It resolves on rebase or merge. No other typecheck errors anywhere in the repo.

Docs updated in `apps/docs/src/architecture/sync-protocol.md` (endpoint table + a new "Snapshot revisions" section), which also closes part of #1497.

Closes #1611.
