### PR TITLE
perf(sync): order the CRDT catch-up sweep — open docs first, then modifiedAt DESC

### DIFF
--- a/apps/desktop/src/main/database/queries/notes/crdt-sweep-order.test.ts
+++ b/apps/desktop/src/main/database/queries/notes/crdt-sweep-order.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { TestDatabaseResult, TestDb } from '@tests/utils/test-db'
+import { createTestIndexDb } from '@tests/utils/test-db'
+import type { NewNoteCache } from '@memry/db-schema/schema/notes-cache'
+import { getAllCrdtNoteIds, insertNoteCache } from '.'
+
+// getAllCrdtNoteIds is the source of the CRDT catch-up sweep's work list, and
+// the order it returns is the order the sweep pulls in — the paced queue drains
+// FIFO, so this SELECT decides which stale note a user sees fixed first. It used
+// to be unordered, i.e. rowid/index-build order, which correlates with nothing.
+// #1614 makes it modifiedAt DESC. The order is a priority and must never become
+// a filter: the sweep is the only channel by which a body-only remote edit
+// reaches a device that missed the `crdt_updated` broadcast.
+
+describe('getAllCrdtNoteIds — sweep priority order', () => {
+  let dbResult: TestDatabaseResult
+  let db: TestDb
+
+  const createNote = (id: string, overrides: Partial<NewNoteCache> = {}): void => {
+    insertNoteCache(db, {
+      id,
+      path: overrides.path ?? `notes/${id}.md`,
+      title: overrides.title ?? `Note ${id}`,
+      contentHash: `hash-${id}`,
+      createdAt: '2026-01-10T00:00:00.000Z',
+      modifiedAt: overrides.modifiedAt ?? '2026-01-12T00:00:00.000Z',
+      ...(overrides.fileType !== undefined && { fileType: overrides.fileType })
+    })
+  }
+
+  beforeEach(() => {
+    dbResult = createTestIndexDb()
+    db = dbResult.db
+  })
+
+  afterEach(() => {
+    dbResult.close()
+  })
+
+  it('returns the most recently modified note first', () => {
+    // Inserted oldest-first so rowid order is the exact opposite of the answer:
+    // an unordered SELECT passes only by accident, and not this way round.
+    createNote('oldest', { modifiedAt: '2026-01-01T00:00:00.000Z' })
+    createNote('middle', { modifiedAt: '2026-02-01T00:00:00.000Z' })
+    createNote('newest', { modifiedAt: '2026-03-01T00:00:00.000Z' })
+
+    expect(getAllCrdtNoteIds(db)).toEqual(['newest', 'middle', 'oldest'])
+  })
+
+  it('still returns every markdown note, whatever the order', () => {
+    // The invariant. Ordering may shuffle the work list; it may never shorten
+    // it. A note dropped here keeps a stale body with no other path to discover
+    // the remote edit, which turns a slow catch-up into a silent one.
+    const ids = Array.from({ length: 40 }, (_, index) => `note-${index}`)
+    for (const [index, id] of ids.entries()) {
+      createNote(id, {
+        modifiedAt: `2026-01-${String((index % 28) + 1).padStart(2, '0')}T00:00:00.000Z`
+      })
+    }
+
+    const swept = getAllCrdtNoteIds(db)
+
+    expect(swept).toHaveLength(ids.length)
+    expect(new Set(swept)).toEqual(new Set(ids))
+  })
+
+  it('keeps notes whose mtimes are identical rather than collapsing them', () => {
+    // A vault restored from backup, freshly cloned or bulk-imported has uniform
+    // mtimes. Ordering degrades to arbitrary — exactly the behaviour before the
+    // ORDER BY — but every note must still be swept.
+    createNote('a', { modifiedAt: '2026-01-12T00:00:00.000Z' })
+    createNote('b', { modifiedAt: '2026-01-12T00:00:00.000Z' })
+    createNote('c', { modifiedAt: '2026-01-12T00:00:00.000Z' })
+
+    expect(getAllCrdtNoteIds(db).sort()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('leaves non-markdown files out, as before', () => {
+    // Only markdown notes are CRDT-backed. The ORDER BY must not widen the
+    // WHERE: a PDF in the sweep is a pull for a doc that does not exist.
+    createNote('note', { modifiedAt: '2026-01-01T00:00:00.000Z' })
+    createNote('scan', {
+      fileType: 'pdf',
+      path: 'notes/scan.pdf',
+      modifiedAt: '2026-06-01T00:00:00.000Z'
+    })
+
+    expect(getAllCrdtNoteIds(db)).toEqual(['note'])
+  })
+})

--- a/apps/desktop/src/main/database/queries/notes/note-crud.ts
+++ b/apps/desktop/src/main/database/queries/notes/note-crud.ts
@@ -274,11 +274,30 @@ export function getAllNoteIds(db: IndexDb): string[] {
     .map((r) => r.id)
 }
 
+/**
+ * Every CRDT-backed note in the vault, most recently modified first.
+ *
+ * The order is the paced catch-up sweep's priority. `FullSyncRunner` queues
+ * these ids in the order they arrive and the queue drains FIFO, so a note that
+ * changed recently — by this user, or by the device this one is catching up
+ * with — is both the note most likely to actually be stale and the note most
+ * likely to be opened next. Unordered, this returned rowid order, which is
+ * index-build order and says nothing about either. `idx_note_cache_modified`
+ * already covers the sort.
+ *
+ * Ordering only, never filtering. The sweep is the sole channel by which a
+ * body-only remote edit reaches a device that missed the `crdt_updated`
+ * broadcast — bodies never travel in the record change feed — so it stays
+ * exhaustive and every markdown note is still returned. A vault with uniform
+ * mtimes (restored from backup, freshly cloned, bulk-imported) simply falls
+ * back to an arbitrary order, which is what it had before.
+ */
 export function getAllCrdtNoteIds(db: IndexDb): string[] {
   return db
     .select({ id: noteCache.id })
     .from(noteCache)
     .where(eq(noteCache.fileType, 'markdown'))
+    .orderBy(desc(noteCache.modifiedAt))
     .all()
     .map((r) => r.id)
 }

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
@@ -1307,14 +1307,16 @@ describe('FullSyncRunner', () => {
     // nothing may ever be dropped to make room for a higher tier.
     it('#then open-but-inactive docs lead the paced queue', async () => {
       // The 32-doc LRU is a recently-opened list, already in memory. Those notes
-      // are one click away and today they get no priority at all — note-50 would
-      // wait out two chunks purely because of where it sits in the vault.
-      const h = sweepingHarness(60, fakeCrdtProvider({ openNoteIds: ['note-50', 'note-55'] }))
+      // are one click away and today they get no priority at all — note-150 would
+      // wait out a whole chunk purely because of where it sits in the vault.
+      // The vault must outrun one chunk and the open notes must sit past the
+      // first one, or the tier buys nothing here and the test passes for free.
+      const h = sweepingHarness(250, fakeCrdtProvider({ openNoteIds: ['note-150', 'note-200'] }))
 
       await h.runner.run()
 
       const firstChunk = h.crdtSync.pullCrdtForNotes.mock.calls[0][0]
-      expect(firstChunk.slice(0, 2)).toEqual(['note-50', 'note-55'])
+      expect(firstChunk.slice(0, 2)).toEqual(['note-150', 'note-200'])
       expect(firstChunk).toHaveLength(CRDT_SWEEP_CHUNK_NOTES)
     })
 

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
@@ -99,17 +99,31 @@ class FakeCrdtSync {
 }
 
 /**
- * The runner asks the provider two things: which notes still have a live editor
- * (those skip the paced queue, because that is the note the user is looking at),
- * and how many docs it can hold open at once (so a paced chunk never outgrows
- * the LRU and gets its docs closed underneath it).
+ * The runner asks the provider three things: which notes still have a live
+ * editor (those skip the paced queue, because that is the note the user is
+ * looking at), every doc it is holding at all (the LRU keeps up to 32 after
+ * their editors closed — those lead the paced queue), and how many docs it can
+ * hold open at once (so a paced chunk never outgrows the LRU and gets its docs
+ * closed underneath it).
+ *
+ * `openNoteIds` defaults to the active set because the real `getOpenNoteIds()`
+ * returns a superset of `getOpenNoteIds({ active: true })`.
  */
-function fakeCrdtProvider({ activeNoteIds = [] as string[], inactiveDocCapacity = 32 } = {}): {
+function fakeCrdtProvider({
+  activeNoteIds = [] as string[],
+  openNoteIds,
+  inactiveDocCapacity = 32
+}: {
+  activeNoteIds?: string[]
+  openNoteIds?: string[]
+  inactiveDocCapacity?: number
+} = {}): {
   getOpenNoteIds: ReturnType<typeof vi.fn>
   inactiveDocCapacity: number
 } {
+  const open = openNoteIds ?? activeNoteIds
   return {
-    getOpenNoteIds: vi.fn(() => activeNoteIds),
+    getOpenNoteIds: vi.fn(({ active = false } = {}) => (active ? activeNoteIds : open)),
     inactiveDocCapacity
   }
 }
@@ -1284,6 +1298,89 @@ describe('FullSyncRunner', () => {
       // of open editors.
       expect(h.crdtSync.pullCrdtForNotes.mock.calls[0][0]).toEqual(['note-40'])
       expect(h.crdtSync.pullCrdtForNotes.mock.calls[1][0]).not.toContain('note-40')
+    })
+
+    // #1614: three tiers, not two. Live editors bypass the pace (above), the
+    // provider's LRU leads the paced queue, and the vault tail arrives from
+    // getAllCrdtNoteIds in modifiedAt DESC. All of it is ordering: the sweep is
+    // the only channel a body-only remote edit reaches this device through, so
+    // nothing may ever be dropped to make room for a higher tier.
+    it('#then open-but-inactive docs lead the paced queue', async () => {
+      // The 32-doc LRU is a recently-opened list, already in memory. Those notes
+      // are one click away and today they get no priority at all — note-50 would
+      // wait out two chunks purely because of where it sits in the vault.
+      const h = sweepingHarness(60, fakeCrdtProvider({ openNoteIds: ['note-50', 'note-55'] }))
+
+      await h.runner.run()
+
+      const firstChunk = h.crdtSync.pullCrdtForNotes.mock.calls[0][0]
+      expect(firstChunk.slice(0, 2)).toEqual(['note-50', 'note-55'])
+      expect(firstChunk).toHaveLength(CRDT_SWEEP_CHUNK_NOTES)
+    })
+
+    it('#then a live editor still outranks an open-but-inactive doc', async () => {
+      const h = sweepingHarness(
+        60,
+        fakeCrdtProvider({ activeNoteIds: ['note-40'], openNoteIds: ['note-40', 'note-50'] })
+      )
+
+      await h.runner.run()
+
+      // The active note leaves un-paced in its own batch; the cached-but-closed
+      // one only leads the paced queue.
+      expect(h.crdtSync.pullCrdtForNotes.mock.calls[0][0]).toEqual(['note-40'])
+      expect(h.crdtSync.pullCrdtForNotes.mock.calls[1][0][0]).toBe('note-50')
+    })
+
+    it('#then the order the sweep supplies is the order the queue drains', async () => {
+      // getAllCrdtNoteIds now returns modifiedAt DESC, and nothing between it
+      // and the wire may re-sort: pendingPulls is a Set drained with Array.from
+      // and the paced queue is a Set read by iteration, so insertion order IS
+      // the priority. If that ever stops holding, the ORDER BY buys nothing.
+      const h = createHarness({ crdtProvider: fakeCrdtProvider() })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['newest', 'middle', 'oldest'])
+
+      await h.runner.run()
+
+      expect(h.crdtSync.pullCrdtForNotes.mock.calls[0][0]).toEqual(['newest', 'middle', 'oldest'])
+    })
+
+    it('#then open docs jump ahead of a drain already in progress', async () => {
+      // A sweep landing mid-catch-up is the case that matters: appending would
+      // put a note the user just opened behind everything the previous pass has
+      // left waiting, which on a large vault is minutes.
+      const open: string[] = []
+      const h = sweepingHarness(60, fakeCrdtProvider({ openNoteIds: open }))
+
+      await h.runner.run()
+      expect(h.crdtSync.pullCrdtForNotes.mock.calls[0][0][0]).toBe('note-0')
+
+      open.push('note-59')
+      h.ws.connectionGeneration += 1
+      await h.runner.run()
+
+      await vi.advanceTimersByTimeAsync(CRDT_SWEEP_CHUNK_INTERVAL_MS)
+      expect(h.crdtSync.pullCrdtForNotes.mock.calls[1][0][0]).toBe('note-59')
+    })
+
+    it('#then prioritising never drops a note from the sweep', async () => {
+      // The invariant the whole ordering change is subordinate to. Note bodies
+      // never travel in the record change feed, so a note the sweep skips keeps
+      // a stale body until some later sweep happens to include it — a slow
+      // catch-up turned into a silent one. Priority, never filtering.
+      const h = sweepingHarness(
+        60,
+        fakeCrdtProvider({ activeNoteIds: ['note-3'], openNoteIds: ['note-3', 'note-50'] })
+      )
+
+      await h.runner.run()
+      await vi.advanceTimersByTimeAsync(CRDT_SWEEP_CHUNK_INTERVAL_MS * 5)
+
+      const pulled = pulledNoteIds(h)
+      expect(new Set(pulled)).toEqual(new Set(noteIds(60)))
+      // Exactly once, too: re-ordering must not duplicate work either.
+      expect(pulled).toHaveLength(60)
     })
 
     it('#then a second sweep joins the running drain instead of starting its own', async () => {

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.ts
@@ -75,7 +75,10 @@ export class FullSyncRunner {
    * A Set, so a note re-queued by a failed chunk cannot accumulate duplicates
    * across cycles — the queue stays bounded by the vault, not by how many times
    * the server has said no. Insertion order is preserved, so it still drains
-   * FIFO. In-memory by design: this queue is a plan for the current engine's
+   * FIFO — which makes insertion order the catch-up's priority: open-but-
+   * inactive docs are spliced in at the front by `flushPendingCrdtPulls`, and
+   * `getAllCrdtNoteIds` supplies the rest of the vault in `modifiedAt DESC`.
+   * In-memory by design: this queue is a plan for the current engine's
    * catch-up, and the persisted sweep stamp is what carries the work across a
    * restart.
    */
@@ -496,12 +499,33 @@ export class FullSyncRunner {
       const activeNoteIds = new Set(
         this.ctx.deps.crdtProvider?.getOpenNoteIds({ active: true }) ?? []
       )
+      // Tier 2: docs the provider still holds without a window attached. The
+      // 32-doc LRU IS a recently-opened list, already in memory and free to
+      // read, and those are the notes the user is one click from — so they lead
+      // the paced queue instead of taking whatever position the vault-wide
+      // ordering gave them.
+      const openNoteIds = new Set(this.ctx.deps.crdtProvider?.getOpenNoteIds() ?? [])
 
       const priority: string[] = []
+      const openInactive: string[] = []
+      const rest: string[] = []
       for (const noteId of this.crdtSync.drainPendingPulls()) {
         if (activeNoteIds.has(noteId)) priority.push(noteId)
-        else this.pacedCrdtPullQueue.add(noteId)
+        else if (openNoteIds.has(noteId)) openInactive.push(noteId)
+        else rest.push(noteId)
       }
+
+      // Rebuilt rather than appended to, because a sweep that lands mid-drain
+      // would otherwise put the open docs behind however many thousand notes
+      // the previous pass has left waiting. Re-inserting the old ids after them
+      // keeps the queue deduped and keeps the tail in its established order.
+      // This is a reordering and nothing else: every drained id still enters the
+      // queue, because priority must never become filtering — a note skipped
+      // here is a body-only remote edit this device never learns about.
+      if (openInactive.length > 0) {
+        this.pacedCrdtPullQueue = new Set([...openInactive, ...this.pacedCrdtPullQueue])
+      }
+      for (const noteId of rest) this.pacedCrdtPullQueue.add(noteId)
 
       if (priority.length > 0) {
         this.actions.scheduleSync(async () => {

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -780,6 +780,37 @@ the paced drain, because the note the user is looking at is the one whose stale 
 the bug, and a large vault's catch-up takes minutes. Their cost is bounded by the number
 of open editors.
 
+#### Sweep priority
+
+A paced drain on a large vault takes minutes, and it is FIFO, so the order the work list
+arrives in decides which stale body a user watches get repaired first. There are three
+tiers:
+
+1. **Notes with a live editor** — pulled in their own batch, outside the pace, as above.
+2. **Open-but-inactive docs** — everything `crdtProvider.getOpenNoteIds()` reports minus
+   the active set, spliced in at the _front_ of the paced queue. The provider's LRU is
+   already a list of up to 32 recently-opened notes held in memory, so this costs nothing
+   to read and names exactly the notes the user is one click away from. It is front-
+   inserted rather than appended because a sweep landing mid-drain would otherwise put
+   those notes behind everything the previous pass still had waiting.
+3. **The rest of the vault**, `modifiedAt DESC` — `getAllCrdtNoteIds` orders by
+   `note_cache.modified_at`, covered by the existing `idx_note_cache_modified`. A note
+   that changed recently, by this user or by the device being caught up with, is both the
+   likeliest to actually be stale and the likeliest to be opened next.
+
+Priority is never filtering. The sweep is the only channel by which a body-only remote
+edit reaches a device that missed the `crdt_updated` broadcast — bodies do not travel in
+the record change feed — so every markdown note still enters the queue, exactly once, and
+only its position changes. A vault whose mtimes are uniform (restored from backup,
+freshly cloned, bulk-imported) simply falls back to an arbitrary tail order.
+
+Notes a chunk failed are re-added to the pending set by `owePendingPull`, so they rejoin
+at the _end_ of the next drain rather than at the front: a note that just failed is the
+worst candidate for an immediate retry.
+
+Ordering changes perceived latency only. It does not change the request count, the
+request rate, or how long a full catch-up takes — the budgets above are untouched.
+
 One drain runs at a time and one timer is armed at a time. A second sweep landing
 mid-drain re-queues into the running one instead of starting its own, which would double
 the request rate; engine teardown cancels the timer and drops the queue.


### PR DESCRIPTION
Closes #1614. PR **5 of 5** in the design merged as #1509 (epic #1496) — but **independent of the other four**. No blockers, no ordering constraint: it can merge at any point, including first.

## What changed

The paced CRDT sweep drains FIFO, so the order its work list arrives in *is* the order a user watches stale bodies get repaired in. Today that order comes from an unordered `SELECT id FROM note_cache WHERE file_type = 'markdown'` — rowid order, i.e. index-build order, which correlates with nothing.

Three tiers instead of two:

1. **Live editors** — unchanged. Still pulled in their own batch outside the pace.
2. **Open-but-inactive docs** — `crdtProvider.getOpenNoteIds()` minus the active set, spliced in at the **front** of the paced queue. The 32-doc LRU already is a recently-opened list, in memory and free to read; those are the notes the user is one click from, and today they get no priority at all. Front-inserted rather than appended, because a sweep landing mid-drain would otherwise put them behind everything the previous pass left waiting — which on a large vault is minutes.
3. **The rest of the vault, `modifiedAt DESC`** — one `ORDER BY` on `getAllCrdtNoteIds`, covered by the existing `idx_note_cache_modified`.

Nothing else had to change: `pendingPulls` is a `Set`, `drainPendingPulls` is `Array.from` on it, `pacedCrdtPullQueue` is a `Set`, and the chunk is taken by iteration. Insertion order already *is* priority end to end — verified in the code, and now pinned by a test.

Files: `note-crud.ts`, `full-sync-runner.ts`. That is the whole surface.

## Why the ordering is safe

**Priority must never become filtering.** The vault-wide sweep is the only channel by which a body-only remote edit reaches a device that missed the `crdt_updated` broadcast — note bodies never travel in the record change feed (`NoteSync` sends `content: null` on update; see the invariant comment at `full-sync-runner.ts:112-128`). A note skipped by a heuristic would keep a stale body with nothing else to discover the edit, turning a slow catch-up into a **silent** one.

So this is a reordering and nothing else, and that is asserted rather than assumed:

- `full-sync-runner.test.ts` → `#then prioritising never drops a note from the sweep`: a 60-note vault with both an active editor and an open-but-inactive doc drains completely — `new Set(pulled)` equals the full vault, and `pulled` has length 60, so exactly once, no duplicates either.
- `crdt-sweep-order.test.ts` → `still returns every markdown note, whatever the order`: the query itself stays exhaustive at the source.

**Failed notes still go to the back.** `owePendingPull` re-adds to `pendingPulls`, so a re-queued note lands at the end of the *next* drain. Deliberately left alone — a note that just failed is the worst candidate for a front-of-queue retry.

**Not** `searchReasons.visitedAt` as the recency source: search-only, capped at 20 rows, different DB.

## Failure modes

- **Uniform mtimes** — a vault restored from backup, freshly cloned or bulk-imported. Ordering degrades to arbitrary, i.e. **exactly today's behaviour**. No regression. Covered by `keeps notes whose mtimes are identical rather than collapsing them`.
- **Correctness unaffected** — the sweep stays exhaustive; only positions change.
- **`ORDER BY` must not widen the `WHERE`** — a PDF in the sweep is a pull for a doc that does not exist. Covered by `leaves non-markdown files out, as before`.

## Arithmetic and compat

**None, and none.** Zero change to request count, request rate or duration; every rate-limit budget is untouched. Client-only: no protocol, no schema, no persisted state, no migration. This changes *perceived* latency and nothing else.

## Tests added (9)

`apps/desktop/src/main/sync/engine/full-sync-runner.test.ts`
- open-but-inactive docs lead the paced queue
- a live editor still outranks an open-but-inactive doc
- the order the sweep supplies is the order the queue drains (pins the end-to-end order preservation the whole change rests on)
- open docs jump ahead of a drain already in progress
- prioritising never drops a note from the sweep

`apps/desktop/src/main/database/queries/notes/crdt-sweep-order.test.ts` (new)
- returns the most recently modified note first (inserted oldest-first, so rowid order is the exact opposite of the answer)
- still returns every markdown note, whatever the order
- keeps notes whose mtimes are identical rather than collapsing them
- leaves non-markdown files out, as before

New test file rather than an addition to `notes.test.ts` because that file is on the `tsconfig.test.*` exclude backlog, and the backlog only shrinks.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm --filter @memry/desktop test:main` | **PASS** — 541 files, 7032 passed, 1 expected fail, 6 skipped |
| `pnpm lint` | **PASS** — 0 errors (97 pre-existing warnings in untouched files); changed source files clean |
| `pnpm exec prettier --check` on all 5 changed files | **PASS** |
| `git diff --check` | **PASS** |
| `pnpm docs:impact --base 6cc0dd83f --strict` | **PASS** — `covered` |
| `pnpm docs:build` | **PASS** |
| `pnpm typecheck` | **FAIL — pre-existing, not this branch** (see below) |

`pnpm typecheck` fails on two files this branch does not touch, both already red at the base commit `6cc0dd83f`:

- `apps/desktop/src/renderer/src/components/sidebar/sidebar-nav.test.tsx` — 2× `TS2741: Property 'onNavMiddleClick' is missing`
- `apps/sync-server/src/services/posthog-transform.test.ts` — 1× `TS2741: Property 'failure' is missing`

`git status` on this branch lists only the 5 files in this diff; neither of those appears. Both have since been fixed on `origin/main` (this branch is based on `6cc0dd83f`, which `origin/main` has moved past), so they resolve on merge.

The `test:main` number above was taken **after** `bash apps/desktop/scripts/ensure-native.sh node`, so `better-sqlite3` was on the Node ABI (the worktree install's postinstall only builds the Electron ABI, and a wrong ABI can return quietly wrong SQLite answers rather than failing loudly). The result was byte-identical before and after the rebuild — 541 files / 7032 passed / 1 expected fail / 6 skipped both times — so nothing was masked, and the four new SQLite-backed `crdt-sweep-order.test.ts` cases pass on the correct ABI.

Also re-verified: `crdt-sync-coordinator.test.ts` failed once on the very first full run with `Error: Electron failed to install correctly` — a race against the worktree's `electron-rebuild` postinstall, not a test failure. It passes standalone (36/36) and in both clean full runs above.

## Docs

`apps/docs/src/architecture/crdt.md` gains a **Sweep priority** subsection under *Pacing the sweep*: the three tiers, why tier 2 is front-inserted, the exhaustiveness invariant, the failed-notes-to-the-back rule, and the uniform-mtime degradation.
