### PR TITLE
perf(sync): make the warm CRDT sweep's snapshot baseline conditional, in-session

### DIFF
--- a/apps/desktop/src/main/sync/engine/crdt-conditional-snapshot-skip.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-conditional-snapshot-skip.test.ts
@@ -1,0 +1,473 @@
+/**
+ * The conditional snapshot skip, driven through a real `CrdtSyncCoordinator`.
+ *
+ * This subsystem's documented failure mode is green tests over broken
+ * behaviour: two mocked halves agreeing with each other while the seam between
+ * them is wrong (#1499). So nothing here mocks the coordinator or its decision.
+ * The HTTP layer is a scripted server — a note has updates, a snapshot blob and
+ * a snapshot metadata row, independently — and every assertion is about which
+ * requests the coordinator actually issued.
+ *
+ * The two mutations this file has to catch:
+ *   1. deleting `appliedSequence >= meta.sequenceNum` from the skip rule (FM3);
+ *   2. giving `applyCrdtIncrementals` the same shortcut (FM4).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SyncContext } from './sync-context'
+import { CrdtSyncCoordinator } from './crdt-sync-coordinator'
+import type { CrdtSnapshotMeta } from '../http-client'
+
+const fetchCrdtSnapshotMock = vi.fn()
+const getFromServerMock = vi.fn()
+const postToServerMock = vi.fn()
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+vi.mock('../http-client', () => ({
+  fetchCrdtSnapshot: (...args: unknown[]) => fetchCrdtSnapshotMock(...args),
+  getFromServer: (...args: unknown[]) => getFromServerMock(...args),
+  postToServer: (...args: unknown[]) => postToServerMock(...args)
+}))
+
+vi.mock('../../crypto/index', () => ({
+  secureCleanup: vi.fn()
+}))
+
+vi.mock('../retry', () => ({
+  withRetry: async (fn: () => Promise<unknown>) => ({ value: await fn() })
+}))
+
+vi.mock('../crdt-encrypt', () => ({
+  decryptCrdtUpdate: () => new Uint8Array([9, 9, 9])
+}))
+
+vi.mock('../../telemetry/diagnostics', () => ({
+  trackMainError: vi.fn()
+}))
+
+const SIGNER = 'device-a'
+
+interface ServerUpdate {
+  sequenceNum: number
+  data: string
+  signerDeviceId: string
+  createdAt: number
+}
+
+interface ServerNote {
+  /** The R2 blob. `null` models a D1 row whose blob is gone (FM5). */
+  snapshot: { sequenceNum: number; revision: string | null } | null
+  /** The D1 row. Absent means the server holds no snapshot for the note at all. */
+  meta?: { sequenceNum: number; revision: string }
+  updates: ServerUpdate[]
+}
+
+interface BatchRequest {
+  notes: Array<{ noteId: string; since: number }>
+  limit: number
+}
+
+const update = (sequenceNum: number): ServerUpdate => ({
+  sequenceNum,
+  data: 'eA==',
+  signerDeviceId: SIGNER,
+  createdAt: 1
+})
+
+describe('CRDT sweep: conditional snapshot baseline', () => {
+  let server: Record<string, ServerNote>
+  let sendSnapshotMeta: boolean
+  let snapshotGets: string[]
+  let batchRequests: BatchRequest[]
+  let openedNotes: string[]
+  let appliedUpdates: string[]
+  let openDocs: Set<string>
+
+  const setup = (): {
+    coordinator: CrdtSyncCoordinator
+    seedFromMarkdownPublic: ReturnType<typeof vi.fn>
+  } => {
+    const seedFromMarkdownPublic = vi.fn()
+    const crdtProvider = {
+      inactiveDocCapacity: 32,
+      isNoteLocalOnly: () => false,
+      getDoc: (noteId: string) => (openDocs.has(noteId) ? {} : undefined),
+      open: async (noteId: string) => {
+        openedNotes.push(noteId)
+        openDocs.add(noteId)
+        return {}
+      },
+      closeIfInactive: async (noteId: string) => {
+        openDocs.delete(noteId)
+        return true
+      },
+      applyRemoteUpdate: (noteId: string) => {
+        appliedUpdates.push(noteId)
+      },
+      // Non-empty for every note, so the markdown seed fallback never fires and
+      // cannot mask a missing baseline.
+      getStateVector: () => new Uint8Array([1, 2, 3, 4]),
+      seedFromMarkdownPublic
+    }
+
+    const ctx = {
+      deps: {
+        crdtProvider,
+        getAccessToken: async () => 'token-1',
+        getVaultKey: async () => new Uint8Array([1, 2, 3])
+      },
+      abortController: new AbortController()
+    } as unknown as SyncContext
+
+    const coordinator = new CrdtSyncCoordinator(ctx, async () => new Uint8Array([4, 5, 6]))
+    return { coordinator, seedFromMarkdownPublic }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    server = {}
+    sendSnapshotMeta = true
+    snapshotGets = []
+    batchRequests = []
+    openedNotes = []
+    appliedUpdates = []
+    openDocs = new Set()
+
+    fetchCrdtSnapshotMock.mockImplementation(async (noteId: string) => {
+      snapshotGets.push(noteId)
+      const snapshot = server[noteId]?.snapshot
+      if (!snapshot) return null
+      return {
+        snapshot: new Uint8Array([1, 2]),
+        sequenceNum: snapshot.sequenceNum,
+        signerDeviceId: SIGNER,
+        revision: snapshot.revision
+      }
+    })
+
+    getFromServerMock.mockImplementation(async (path: string) => {
+      const noteId = decodeURIComponent(/note_id=([^&]+)/.exec(path)?.[1] ?? '')
+      const since = Number(/since=(\d+)/.exec(path)?.[1] ?? '0')
+      const above = (server[noteId]?.updates ?? []).filter((u) => u.sequenceNum > since)
+      return { updates: above, hasMore: false }
+    })
+
+    postToServerMock.mockImplementation(async (_path: string, body: unknown) => {
+      const request = body as BatchRequest
+      batchRequests.push(request)
+
+      const notes: Record<string, { updates: ServerUpdate[]; hasMore: boolean }> = {}
+      for (const { noteId, since } of request.notes) {
+        const above = (server[noteId]?.updates ?? []).filter((u) => u.sequenceNum > since)
+        notes[noteId] = {
+          updates: above.slice(0, request.limit),
+          hasMore: above.length > request.limit
+        }
+      }
+
+      // An old server omits the key entirely. Built by omission rather than by
+      // assigning `undefined`, because that is what arrives over the wire and
+      // this response is read through an unvalidated cast.
+      if (!sendSnapshotMeta) return { notes }
+
+      const snapshotMeta: Record<string, CrdtSnapshotMeta> = {}
+      for (const { noteId } of request.notes) {
+        const meta = server[noteId]?.meta
+        if (meta) {
+          snapshotMeta[noteId] = {
+            sequenceNum: meta.sequenceNum,
+            revision: meta.revision,
+            signerDeviceId: SIGNER
+          }
+        }
+      }
+      return { notes, snapshotMeta }
+    })
+  })
+
+  const probeRequests = (): BatchRequest[] => batchRequests.filter((r) => r.limit === 1)
+  const applyRequests = (): BatchRequest[] => batchRequests.filter((r) => r.limit !== 1)
+
+  it('warm sweep: a second pass costs one probe POST and zero snapshot GETs', async () => {
+    server = {
+      'note-1': {
+        snapshot: { sequenceNum: 90, revision: 'rev-1' },
+        meta: { sequenceNum: 90, revision: 'rev-1' },
+        updates: []
+      },
+      'note-2': {
+        snapshot: { sequenceNum: 12, revision: 'rev-2' },
+        meta: { sequenceNum: 12, revision: 'rev-2' },
+        updates: []
+      }
+    }
+    const { coordinator, seedFromMarkdownPublic } = setup()
+
+    // Cold pass: no watermarks yet, so no probe is even sent and the cost is
+    // exactly what it was before this feature existed.
+    await coordinator.pullCrdtForNotes(['note-1', 'note-2'])
+    expect(snapshotGets).toEqual(['note-1', 'note-2'])
+    expect(probeRequests()).toHaveLength(0)
+
+    batchRequests = []
+    snapshotGets = []
+    openedNotes = []
+
+    await coordinator.pullCrdtForNotes(['note-1', 'note-2'])
+
+    expect(snapshotGets).toEqual([])
+    expect(probeRequests()).toHaveLength(1)
+    expect(applyRequests()).toHaveLength(0)
+    // A note settled at the probe is never opened, which is what makes the
+    // probe unbound by the 32-doc LRU.
+    expect(openedNotes).toEqual([])
+    expect(seedFromMarkdownPublic).not.toHaveBeenCalled()
+  })
+
+  it('the sweep stays exhaustive: every note is probed, and a body-only remote edit is still applied', async () => {
+    server = {
+      'note-1': {
+        snapshot: { sequenceNum: 90, revision: 'rev-1' },
+        meta: { sequenceNum: 90, revision: 'rev-1' },
+        updates: []
+      },
+      'note-2': {
+        snapshot: { sequenceNum: 12, revision: 'rev-2' },
+        meta: { sequenceNum: 12, revision: 'rev-2' },
+        updates: []
+      },
+      'note-3': {
+        snapshot: { sequenceNum: 5, revision: 'rev-3' },
+        meta: { sequenceNum: 5, revision: 'rev-3' },
+        updates: []
+      }
+    }
+    const { coordinator } = setup()
+    await coordinator.pullCrdtForNotes(['note-1', 'note-2', 'note-3'])
+
+    // A peer edits note-2's body only. Nothing about that reaches this device
+    // through the record change feed — the sweep is the only channel.
+    server['note-2'].updates = [update(13)]
+
+    batchRequests = []
+    snapshotGets = []
+    appliedUpdates = []
+    openedNotes = []
+
+    await coordinator.pullCrdtForNotes(['note-1', 'note-2', 'note-3'])
+
+    // Visited: every note in the chunk is named in the probe. This is the
+    // invariant that keeps "cheaper" from turning into "filtered".
+    expect(probeRequests()).toHaveLength(1)
+    expect(
+      probeRequests()[0]
+        .notes.map((n) => n.noteId)
+        .sort()
+    ).toEqual(['note-1', 'note-2', 'note-3'])
+    // Cheap: only the changed note costs anything beyond the probe, and even it
+    // does not re-download its unchanged baseline.
+    expect(snapshotGets).toEqual([])
+    expect(openedNotes).toEqual(['note-2'])
+    expect(appliedUpdates).toEqual(['note-2'])
+  })
+
+  it('FM3: a matching revision does NOT license a `since` below the server prune watermark', async () => {
+    // The device merged snapshot rev-1 when the note sat at sequence 40, so its
+    // watermark is 40 with revision rev-1. The server now reports the SAME
+    // revision against prune watermark 90 — everything at or below 90 has been
+    // deleted, so a pull from 40 would be answered with silence and the note
+    // would go quietly stale. Only condition (2) forbids that.
+    server = {
+      'note-1': {
+        snapshot: { sequenceNum: 40, revision: 'rev-1' },
+        meta: { sequenceNum: 40, revision: 'rev-1' },
+        updates: []
+      }
+    }
+    const { coordinator } = setup()
+    await coordinator.pullCrdtForNotes(['note-1'])
+    expect(snapshotGets).toEqual(['note-1'])
+
+    server['note-1'].meta = { sequenceNum: 90, revision: 'rev-1' }
+    server['note-1'].snapshot = { sequenceNum: 90, revision: 'rev-1' }
+
+    batchRequests = []
+    snapshotGets = []
+
+    await coordinator.pullCrdtForNotes(['note-1'])
+
+    expect(snapshotGets).toEqual(['note-1'])
+    // And nothing was ever asked for from below the watermark the server pruned
+    // to, other than the probe itself, which is what discovered the gap.
+    expect(applyRequests().every((r) => r.notes.every((n) => n.since >= 90))).toBe(true)
+  })
+
+  it('FM4: the single-note path never takes the shortcut, whatever the watermark says', async () => {
+    server = {
+      'note-1': {
+        snapshot: { sequenceNum: 90, revision: 'rev-1' },
+        meta: { sequenceNum: 90, revision: 'rev-1' },
+        updates: []
+      }
+    }
+    const { coordinator } = setup()
+
+    // Two sweeps, so the watermark is not just present but has already proved
+    // itself good enough for the batch path to skip on.
+    await coordinator.pullCrdtForNotes(['note-1'])
+    snapshotGets = []
+    await coordinator.pullCrdtForNotes(['note-1'])
+    expect(snapshotGets).toEqual([])
+
+    // `applyCrdtIncrementals` returns whether the server's state was fully
+    // merged, and the pending-note replay turns a `true` into a SNAPSHOT push,
+    // which makes the server delete every peer's incrementals. A `true` reached
+    // by a shortcut destroys another device's edits, so this path must earn its
+    // answer by actually downloading the baseline every time.
+    const merged = await coordinator.pullCrdtForNote('note-1')
+
+    expect(merged).toBe(true)
+    expect(snapshotGets).toEqual(['note-1'])
+  })
+
+  it('FM5: a snapshot whose blob never arrived leaves no watermark behind', async () => {
+    server = {
+      // Anchor note, so the chunk has a watermark and the probe is sent at all.
+      'note-1': {
+        snapshot: { sequenceNum: 10, revision: 'rev-1' },
+        meta: { sequenceNum: 10, revision: 'rev-1' },
+        updates: []
+      },
+      // D1 row present and advertised, R2 blob gone: `getSnapshot` returns null.
+      'note-2': {
+        snapshot: null,
+        meta: { sequenceNum: 90, revision: 'rev-2' },
+        updates: [update(95)]
+      }
+    }
+    const { coordinator } = setup()
+    await coordinator.pullCrdtForNotes(['note-1', 'note-2'])
+    // note-2 reached sequence 95 from its incrementals, which clears condition
+    // (2) on its own — only the missing revision keeps it honest.
+    expect(snapshotGets).toEqual(['note-1', 'note-2'])
+
+    batchRequests = []
+    snapshotGets = []
+
+    await coordinator.pullCrdtForNotes(['note-1', 'note-2'])
+
+    expect(snapshotGets).toEqual(['note-2'])
+  })
+
+  it('FM6: a note with no local watermark is fetched even when everything else matches', async () => {
+    server = {
+      'note-1': {
+        snapshot: { sequenceNum: 10, revision: 'rev-1' },
+        meta: { sequenceNum: 10, revision: 'rev-1' },
+        updates: []
+      },
+      'note-3': {
+        snapshot: { sequenceNum: 7, revision: 'rev-3' },
+        meta: { sequenceNum: 7, revision: 'rev-3' },
+        updates: []
+      }
+    }
+    const { coordinator } = setup()
+    await coordinator.pullCrdtForNotes(['note-1'])
+
+    batchRequests = []
+    snapshotGets = []
+    openedNotes = []
+
+    // note-3 has never been merged on this device — a note absent from the
+    // local CRDT store. The default is fetch.
+    await coordinator.pullCrdtForNotes(['note-1', 'note-3'])
+
+    expect(snapshotGets).toEqual(['note-3'])
+    expect(openedNotes).toEqual(['note-3'])
+  })
+
+  it('a note the server holds no snapshot for is settled from the watermark, not from a GET', async () => {
+    // No `meta`: the note is absent from `snapshotMeta` while the map itself is
+    // present, which means "no server snapshot", not "old server".
+    server = {
+      'note-1': { snapshot: null, meta: undefined, updates: [update(3)] }
+    }
+    const { coordinator } = setup()
+    await coordinator.pullCrdtForNotes(['note-1'])
+    expect(snapshotGets).toEqual(['note-1'])
+
+    batchRequests = []
+    snapshotGets = []
+
+    await coordinator.pullCrdtForNotes(['note-1'])
+
+    expect(snapshotGets).toEqual([])
+    expect(probeRequests()).toHaveLength(1)
+    expect(probeRequests()[0].notes).toEqual([{ noteId: 'note-1', since: 3 }])
+  })
+
+  it('old server: a response without snapshotMeta never skips, and stops costing a probe', async () => {
+    server = {
+      'note-1': {
+        snapshot: { sequenceNum: 90, revision: 'rev-1' },
+        meta: { sequenceNum: 90, revision: 'rev-1' },
+        updates: []
+      }
+    }
+    const { coordinator } = setup()
+
+    // Warm the watermark against a server that does publish the token, so the
+    // only thing under test afterwards is the rollback itself.
+    await coordinator.pullCrdtForNotes(['note-1'])
+
+    // Server rolled back — staging, self-hosted, or a reverted deploy.
+    sendSnapshotMeta = false
+    batchRequests = []
+    snapshotGets = []
+
+    await coordinator.pullCrdtForNotes(['note-1'])
+
+    expect(snapshotGets).toEqual(['note-1'])
+    expect(probeRequests()).toHaveLength(1)
+
+    batchRequests = []
+    snapshotGets = []
+
+    // From here on the requests are exactly the ones this code issued before
+    // the feature existed: one baseline GET per note, one apply POST, no probe.
+    await coordinator.pullCrdtForNotes(['note-1'])
+
+    expect(snapshotGets).toEqual(['note-1'])
+    expect(probeRequests()).toHaveLength(0)
+    expect(applyRequests()).toHaveLength(1)
+  })
+
+  it('clearing caches drops both halves of the watermark, so the next sweep fetches again', async () => {
+    server = {
+      'note-1': {
+        snapshot: { sequenceNum: 90, revision: 'rev-1' },
+        meta: { sequenceNum: 90, revision: 'rev-1' },
+        updates: []
+      }
+    }
+    const { coordinator } = setup()
+    await coordinator.pullCrdtForNotes(['note-1'])
+
+    coordinator.clearCaches()
+    batchRequests = []
+    snapshotGets = []
+
+    await coordinator.pullCrdtForNotes(['note-1'])
+
+    expect(snapshotGets).toEqual(['note-1'])
+    expect(probeRequests()).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
@@ -329,7 +329,9 @@ describe('CrdtSyncCoordinator', () => {
           }
         }
       })
-      .mockResolvedValueOnce({
+      // No `snapshotMeta` on any response: this models a server that predates
+      // the revision token, so every baseline below stays unconditional.
+      .mockResolvedValue({
         notes: {
           'note-1': {
             updates: [],
@@ -370,8 +372,21 @@ describe('CrdtSyncCoordinator', () => {
       },
       'token-1'
     )
+    // The second pass opens with a probe, and the sequence it carries is the
+    // same highest-applied one — this is where the carry-over is now visible.
     expect(postToServerMock).toHaveBeenNthCalledWith(
       2,
+      '/sync/crdt/updates/batch',
+      {
+        notes: [{ noteId: 'note-1', since: 6 }],
+        limit: 1
+      },
+      'token-1'
+    )
+    // The probe came back without `snapshotMeta`, so the baseline is fetched
+    // exactly as before and the apply pull resumes from the same sequence.
+    expect(postToServerMock).toHaveBeenNthCalledWith(
+      3,
       '/sync/crdt/updates/batch',
       {
         notes: [{ noteId: 'note-1', since: 6 }],

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -5,7 +5,8 @@ import {
   getFromServer,
   postToServer,
   fetchCrdtSnapshot,
-  type CrdtBatchPullResponse
+  type CrdtBatchPullResponse,
+  type CrdtSnapshotMeta
 } from '../http-client'
 import { decryptCrdtUpdate } from '../crdt-encrypt'
 import { trackMainError } from '../../telemetry/diagnostics'
@@ -19,6 +20,34 @@ export class CrdtSyncCoordinator {
   private ctx: SyncContext
   private pendingPulls = new Set<string>()
   private lastAppliedSequence = new Map<string, number>()
+  /**
+   * The `revision` of the server snapshot this session actually merged into the
+   * note's doc — half of the watermark the sweep's conditional skip compares
+   * against, `lastAppliedSequence` being the other half.
+   *
+   * Session-scoped and in memory on purpose. A persisted watermark can outlive
+   * the document it describes (an evicted, quarantined, rebuilt or re-pathed
+   * store), and a watermark that claims a baseline the doc never kept makes the
+   * sweep skip that baseline forever against a note whose body is stale. In
+   * memory the store and the watermark share one lifetime by construction.
+   * Persisting it is a separate change with its own invalidation to carry.
+   *
+   * Written only where a snapshot was genuinely decrypted and applied, never
+   * where one was merely advertised: `getSnapshot` returns null when the D1 row
+   * exists but its R2 blob is gone, and recording a watermark for a blob that
+   * never arrived is exactly how a note keeps a stale body forever.
+   */
+  private mergedSnapshotRevision = new Map<string, string>()
+  /**
+   * Set once a batch response comes back without `snapshotMeta`, which is how
+   * an older server answers.
+   *
+   * Without it, every chunk against such a server would pay for a probe that
+   * can never let anything be skipped — staging, self-hosted deployments and a
+   * rolled-back server all live here. With it, the second chunk onwards issues
+   * exactly the requests this code issued before this feature existed.
+   */
+  private snapshotMetaUnsupported = false
   private resolveDeviceKey: ResolveDeviceKey
   /** Once per key per session — CRDT apply failures recur every pass and would storm otherwise. */
   private applyFailureReported = new Set<string>()
@@ -169,6 +198,9 @@ export class CrdtSyncCoordinator {
   clearCaches(): void {
     this.pendingPulls.clear()
     this.lastAppliedSequence.clear()
+    // Cleared with the sequence half, never separately: the two are one
+    // watermark, and half a watermark is a skip decision made on a guess.
+    this.mergedSnapshotRevision.clear()
     this.applyFailureReported.clear()
     // Deliberately silent: `reportUnmergedDebt` is not called here. This is a
     // teardown, not a note that finished merging, and reporting "no debt" for it
@@ -243,6 +275,19 @@ export class CrdtSyncCoordinator {
     const decrypted = decryptCrdtUpdate(snapshotResult.snapshot, vaultKey, noteId, signerPubKey)
     this.ctx.deps.crdtProvider.applyRemoteUpdate(noteId, decrypted)
     const baselineSequence = this.rememberAppliedSequence(noteId, snapshotResult.sequenceNum)
+    // Recorded here and nowhere else, after the bytes are in the doc: every
+    // early return above left the baseline out, and a watermark for a baseline
+    // that was never applied is a skip of the download that would have fixed it.
+    //
+    // An absent token — an older server on this endpoint — DELETES any token
+    // held for the note rather than leaving one standing. The blob just merged
+    // is not the one the old token names, so keeping it would compare a future
+    // batch response against a baseline this doc no longer has.
+    if (snapshotResult.revision) {
+      this.mergedSnapshotRevision.set(noteId, snapshotResult.revision)
+    } else {
+      this.mergedSnapshotRevision.delete(noteId)
+    }
     log.debug('Applied CRDT snapshot baseline', {
       noteId,
       mode,
@@ -471,6 +516,118 @@ export class CrdtSyncCoordinator {
     }
   }
 
+  /**
+   * One `POST /sync/crdt/updates/batch` that asks the server what moved, before
+   * a single doc is opened or a single snapshot downloaded.
+   *
+   * `null` means "decide nothing from a probe" and every note in the chunk then
+   * takes the unconditional path this method fronts — an old server, or a chunk
+   * where a probe could not possibly save anything.
+   *
+   * Deliberately NOT available to `applyCrdtIncrementals`: see the comment on
+   * `snapshotBaselineSkip`.
+   */
+  private async probeBatchChunk(
+    noteIds: string[],
+    token: string,
+    signal: AbortSignal
+  ): Promise<CrdtBatchPullResponse | null> {
+    if (this.snapshotMetaUnsupported) return null
+    // Nothing merged this session means nothing can match, so every note would
+    // fall through to a fetch anyway and the probe would be a request spent to
+    // learn nothing. This is the first sweep after launch: it costs exactly
+    // what it cost before this feature existed.
+    if (!noteIds.some((noteId) => this.lastAppliedSequence.has(noteId))) return null
+
+    const result = await withRetry(
+      () =>
+        postToServer<CrdtBatchPullResponse>(
+          '/sync/crdt/updates/batch',
+          {
+            notes: noteIds.map((noteId) => ({
+              noteId,
+              since: this.lastAppliedSequence.get(noteId) ?? 0
+            })),
+            // This asks "did anything change", not "give me what changed": a
+            // note whose answer is yes goes to the apply phase, which fetches
+            // its updates from the right `since` — after a baseline, when it
+            // needs one. Asking for 100 here would haul payloads that phase
+            // re-fetches. `hasMore` is still exact at this limit, because the
+            // server reads limit + 1 rows to compute it.
+            limit: 1
+          },
+          token
+        ),
+      { maxRetries: 3, baseDelayMs: 2000, signal, retryOn429: false }
+    ).then((r) => r.value)
+
+    // An absent key, not an empty map: this response is read through a cast
+    // with no runtime validation, so this is the only signal that the server
+    // predates the token. Latched, so the rest of the session stops paying for
+    // a probe whose answer can never be "skip".
+    if (!result.snapshotMeta) {
+      this.snapshotMetaUnsupported = true
+      log.debug('Server returned no snapshotMeta; CRDT snapshot baselines stay unconditional')
+      return null
+    }
+
+    return result
+  }
+
+  /**
+   * The `since` to resume from without downloading this note's snapshot, or
+   * `null` to download it.
+   *
+   * **This is only ever consulted from `applyCrdtBatchChunk`, and that is a
+   * data-loss guard rather than an accident of layering.**
+   * `applyCrdtIncrementals` returns whether the server's state was fully merged,
+   * and the pending-note replay acts on a `true` by pushing a *snapshot* — which
+   * asserts "I contain everything you hold" and makes the server delete every
+   * device's incrementals at or below the watermark. A `true` reached by a
+   * shortcut therefore destroys a peer's edits. The single-note path is low
+   * volume in every one of its callers, so it gives up nothing by staying
+   * unconditional, and staying unconditional is what makes the guarantee
+   * structural instead of careful.
+   *
+   * Every unknown answers `null`. A missed skip costs one GET; a wrong skip
+   * costs a note body.
+   */
+  private snapshotBaselineSkip(
+    noteId: string,
+    snapshotMeta: Record<string, CrdtSnapshotMeta> | undefined
+  ): number | null {
+    // No probe, or a server that does not publish the token. Fetch, exactly as
+    // this code did before the token existed.
+    if (!snapshotMeta) return null
+
+    // A note this session has merged nothing for — never opened, absent from
+    // the local store, or a store rebuilt under it — has no watermark to
+    // compare, so it cannot be shown to already hold the baseline.
+    const appliedSequence = this.lastAppliedSequence.get(noteId)
+    if (appliedSequence === undefined) return null
+
+    const meta = snapshotMeta[noteId]
+    // Map present, note absent: the server holds no snapshot for this note at
+    // all. Nothing to download, and nothing has been pruned, so resuming from
+    // the watermark asks a range the server still has.
+    if (!meta) return appliedSequence
+
+    // (1) The server's snapshot blob is the one already merged into this doc.
+    // `sequence_num` cannot stand in for this: `storeSnapshot` pins it across a
+    // rewrite, so it would report "unchanged" for every replaced blob.
+    if (meta.revision !== this.mergedSnapshotRevision.get(noteId)) return null
+
+    // (2) And the doc has taken in everything at or below the server's prune
+    // watermark. `pruneUpdatesBeforeSnapshot` deletes every update at or below
+    // `sequence_num`, so a `since` under it is answered with silence rather
+    // than an error — the note would go quietly stale. This is a separate
+    // question from (1) and must be asked separately: a matching revision says
+    // which blob the server holds, never how much of it this doc absorbed.
+    if (appliedSequence < meta.sequenceNum) return null
+
+    return appliedSequence
+  }
+
   private async applyCrdtBatchChunk(
     noteIds: string[],
     token: string,
@@ -494,9 +651,63 @@ export class CrdtSyncCoordinator {
     // broadcast and the pending-note replay call it directly — so a note's own
     // earlier debt would otherwise block its clear forever.
     try {
-      const sinceMap = new Map<string, number>()
+      // PHASE 1 — probe. One request for the whole chunk, no docs opened.
+      //
+      // Every note in the chunk is still visited: this decides what a note
+      // costs, never whether it is looked at. The sweep is the only channel a
+      // body-only remote edit reaches a device by — note bodies never travel in
+      // the record change feed — so a note dropped here would go stale with no
+      // second chance.
+      const probe = await this.probeBatchChunk(noteIds, token, signal)
+
+      // Notes whose baseline the probe proved redundant, mapped to the `since`
+      // to resume from in place of the one a baseline would have produced.
+      const skipBaseline = new Map<string, number>()
+      // Notes still needing the open + baseline + apply path below.
+      const activeNoteIds: string[] = []
+      let settledByProbe = 0
 
       for (const noteId of noteIds) {
+        const skipSince = this.snapshotBaselineSkip(noteId, probe?.snapshotMeta)
+        const probed = probe?.notes[noteId]
+        // A note the server left out of its own probe response told us nothing
+        // about its updates, so it takes the full path regardless.
+        if (skipSince !== null && probed) {
+          if (probed.updates.length === 0 && !probed.hasMore) {
+            // Finished here: the baseline is already in the doc and there is
+            // nothing above it. No doc opened, no snapshot GET, no decrypt.
+            // Clearing the flag is the truth this pass established — the
+            // server's state for this note IS in the local doc.
+            //
+            // Not seed-checked at the end, and it does not need to be: a note
+            // only reaches this branch with a watermark, which only exists
+            // because real CRDT state was applied to its doc, so its state
+            // vector is not the empty one the seed fallback exists for.
+            this.clearUnmergedIfClean(noteId, false)
+            settledByProbe++
+            continue
+          }
+          skipBaseline.set(noteId, skipSince)
+        }
+        activeNoteIds.push(noteId)
+      }
+
+      if (probe) {
+        log.debug('CRDT batch chunk probed', {
+          notes: noteIds.length,
+          settledByProbe,
+          baselinesSkipped: skipBaseline.size,
+          baselinesFetched: activeNoteIds.length - skipBaseline.size
+        })
+      }
+
+      if (activeNoteIds.length === 0) return
+
+      // PHASE 2 — apply. Unchanged from the unconditional path, over the notes
+      // that actually have work.
+      const sinceMap = new Map<string, number>()
+
+      for (const noteId of activeNoteIds) {
         const wasOpen = crdtProvider.getDoc(noteId) != null
         try {
           await crdtProvider.open(noteId, undefined, { skipSeed: true })
@@ -510,6 +721,16 @@ export class CrdtSyncCoordinator {
           // never retried, so the unmerged flag it is carrying never clears and
           // it spends the rest of the session off the snapshot endpoint.
           this.owePendingPull(noteId)
+          continue
+        }
+
+        const skipSince = skipBaseline.get(noteId)
+        if (skipSince !== undefined) {
+          // The GET this whole change exists to avoid. The doc already holds
+          // this exact snapshot blob and everything the server pruned behind
+          // it, so resuming from the watermark is the same `since` a download
+          // would have produced.
+          sinceMap.set(noteId, skipSince)
           continue
         }
 

--- a/apps/desktop/src/main/sync/http-client.ts
+++ b/apps/desktop/src/main/sync/http-client.ts
@@ -214,6 +214,29 @@ export interface CrdtSnapshotResponse {
   snapshot: string | null
   sequenceNum: number
   signerDeviceId: string | null
+  /**
+   * Opaque token identifying which snapshot blob this is, so a later batch pull
+   * can say "still that one" and the client can skip re-downloading it.
+   *
+   * Optional because a server that predates the token omits the key entirely,
+   * and these responses are read through an unvalidated cast — an absent key is
+   * `undefined` at runtime, which must read as "unknown", never as a match.
+   */
+  revision?: string | null
+}
+
+/**
+ * What the batch pull says about the server's snapshot for one note, so a
+ * client can decide whether to download it without downloading it.
+ *
+ * `sequenceNum` is the server's prune watermark for the note:
+ * `pruneUpdatesBeforeSnapshot` deletes every update at or below it, so asking
+ * for a range starting under it is answered with silence, not an error.
+ */
+export interface CrdtSnapshotMeta {
+  sequenceNum: number
+  revision: string
+  signerDeviceId: string
 }
 
 export interface CrdtBatchPullResponse {
@@ -229,6 +252,16 @@ export interface CrdtBatchPullResponse {
       hasMore: boolean
     }
   >
+  /**
+   * Present on every response from a server that supports it, which is what
+   * lets a client tell "this server is old" (key absent) from "this server has
+   * no snapshot for that note" (key present, note absent from the map).
+   *
+   * Optional, and deliberately so: `postToServer` is a TypeScript cast with no
+   * runtime schema validation, so against an old server this is `undefined` at
+   * runtime however the type reads. Every consumer must default to fetching.
+   */
+  snapshotMeta?: Record<string, CrdtSnapshotMeta>
 }
 
 export async function pushCrdtSnapshot(
@@ -275,7 +308,12 @@ export async function pushCrdtFullUpdate(
 export async function fetchCrdtSnapshot(
   noteId: string,
   token: string
-): Promise<{ snapshot: Uint8Array; sequenceNum: number; signerDeviceId: string } | null> {
+): Promise<{
+  snapshot: Uint8Array
+  sequenceNum: number
+  signerDeviceId: string
+  revision: string | null
+} | null> {
   const { value: result } = await withRetry(
     () =>
       getFromServer<CrdtSnapshotResponse>(
@@ -292,5 +330,13 @@ export async function fetchCrdtSnapshot(
 
   const bytes = new Uint8Array(Buffer.from(result.snapshot, 'base64'))
 
-  return { snapshot: bytes, sequenceNum: result.sequenceNum, signerDeviceId: result.signerDeviceId }
+  return {
+    snapshot: bytes,
+    sequenceNum: result.sequenceNum,
+    signerDeviceId: result.signerDeviceId,
+    // `null` for a server that does not send one. Normalising the absent key to
+    // `null` here keeps "no token" a single value at the one place that decides
+    // whether to remember it.
+    revision: result.revision ?? null
+  }
 }

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -590,6 +590,41 @@ replaces it with a real one. Both read paths return the same token for the same 
 Both fields are additive: an older client reads these responses through an unvalidated cast and
 ignores the extra keys.
 
+### The vault sweep's conditional baseline
+
+The vault-wide sweep uses `snapshotMeta` to stop re-downloading baselines a device already holds. It
+runs each chunk in two phases:
+
+- **Probe.** One `POST /sync/crdt/updates/batch` for the chunk with `limit: 1`, asking only whether
+  anything moved. No document is opened, no snapshot is fetched, nothing is decrypted. A note whose
+  baseline is unchanged and whose update list comes back empty is finished here.
+- **Apply.** Only the notes with work take the existing open-document, baseline, apply path, and a
+  note whose baseline the probe proved redundant skips the `GET /sync/crdt/snapshot/:noteId` and
+  resumes its incrementals from the sequence it already applied.
+
+A baseline is skipped only when **both** of these hold:
+
+1. the note's `revision` in `snapshotMeta` equals the revision this session actually merged, and
+2. the sequence this session applied is at or above the note's `sequenceNum` in `snapshotMeta`.
+
+The second condition is not implied by the first. `sequenceNum` is the server's prune watermark, and
+`pruneUpdatesBeforeSnapshot` has already deleted every update at or below it — a pull starting under
+that line is answered with silence rather than an error, so the note would go quietly stale.
+
+Everything else falls through to a fetch: an absent `snapshotMeta` key (an older server), a note the
+server left out of the response, and any note this session holds no merged revision for. A missed
+skip costs one request; a wrong skip costs a note body.
+
+The bookkeeping is per session and in memory, so a rebuilt or re-pathed CRDT store loses it in the
+same operation and the next sweep re-downloads. Nothing is written to disk and no format changes.
+
+Two properties this does **not** change. The sweep stays exhaustive — every note in a chunk is still
+named in the probe, because the sweep is the only channel by which a body-only remote edit reaches a
+device that missed the broadcast; this changes what a note costs, never whether it is visited. And
+the single-note pull path (`GET /sync/crdt/snapshot/:noteId` then `GET /sync/crdt/updates`) stays
+unconditional: it reports whether the server's state was fully merged, and the pending-note replay
+turns that report into a snapshot push, which prunes peers' updates.
+
 Pushing a snapshot is an assertion, not just a write: once the snapshot is stored,
 `pruneUpdatesBeforeSnapshot` deletes every `crdt_updates` row for that note at or below the
 snapshot's sequence number. A snapshot that does not already contain those updates does not merely


### PR DESCRIPTION
**PR 2 of 5** in #1496. Stacked on **#1617** (`feat/crdt-snapshot-revision-meta`), which added the server's `revision` token and the batch `snapshotMeta` map. **#1613** (the persisted watermark) stacks on top of this one.

Closes #1612.

## What changed

The sweep spent one unconditional `GET /sync/crdt/snapshot/:noteId` per note per pass on a baseline the local doc almost always already held, because the client had no way to learn whether the *server's* snapshot moved without downloading it. #1617 published the token; this consumes it.

`applyCrdtBatchChunk` now runs in two phases:

- **Probe** — one `POST /sync/crdt/updates/batch` for the whole chunk, `since` from the in-session watermark, `limit: 1`. It asks "did anything change", not "give me what changed", so the apply phase re-fetches from the right `since` and the probe hauls no payloads it would discard. `hasMore` is still exact at that limit because the server reads `limit + 1` rows. **No document is opened, no snapshot fetched, nothing decrypted.**
- **Apply** — only the notes with real work take today's open + baseline + apply path, byte-for-byte unchanged. A note whose baseline the probe proved redundant skips the GET and resumes from its watermark.

The skip requires **both**:

1. `snapshotMeta[noteId].revision === ` the revision this session actually merged, **and**
2. the applied sequence is `>=` `snapshotMeta[noteId].sequenceNum`.

Everything else falls through to a fetch.

## Measured request reduction

Counted at the seam, from the tests themselves (`crdt-conditional-snapshot-skip.test.ts`), for a chunk of the sweep's current 32-note size:

| Chunk | Before | After |
| --- | --- | --- |
| Cold (first pass, no watermarks) | 32 GETs + 1 POST | 32 GETs + 1 POST — no probe is sent at all when nothing in the chunk has a watermark |
| Warm, nothing changed | 32 GETs + 1 POST | **1 POST, 0 GETs, 0 documents opened** |
| Warm, k notes changed | 32 GETs + POSTs | 1 probe POST + apply POSTs, **0 GETs** |
| Old server | 32 GETs + 1 POST | 32 GETs + 1 POST — one probe on the first chunk, then the flag latches |

For a 1,000-note warm sweep at today's chunk size that is **~32 POSTs and zero snapshot GETs against 1,000 GETs + 32 POSTs**. Raising the probe to the server's 100-note cap is the re-pace work, which is a later PR in #1496 and deliberately not here.

## Failure modes

**FM3 — `since` below the prune watermark.** `pruneUpdatesBeforeSnapshot` deletes every update at or below `snapshot.sequence_num`, and a pull starting under that line is answered with *silence*, not an error, so the note goes quietly stale. Condition (2) is what forbids it, and it is **not** implied by condition (1): a matching revision says which blob the server holds, never how much of it this document absorbed. It has its own dedicated test and its own mutation below.

**FM4 — a wrong "merged" answer reaching the snapshot push.** `applyCrdtIncrementals` reports whether the server's state was fully merged, and the pending-note replay turns a `true` into a **snapshot** push, which makes the server delete every peer's incrementals. A `true` reached by a shortcut destroys another device's edits. **The conditional skip lives only inside `applyCrdtBatchChunk`; `applyCrdtIncrementals` is untouched and stays unconditional.** Structural, not careful — and free, because every caller of the single-note path is low volume. `snapshotBaselineSkip` carries that reasoning in its doc comment so the next person does not "unify" the two.

**FM5 — a snapshot row whose blob is missing.** `getSnapshot` returns `null` when the D1 row exists but the R2 object is gone, so `snapshotMeta` can advertise a revision the GET never delivers. The revision is recorded at exactly one place, *after* the bytes are decrypted and applied to the document — every early return in `applySnapshotBaseline` leaves it unrecorded. An absent token on the GET (an older server on that endpoint) *deletes* any token held for the note rather than leaving a stale one standing.

**FM6 — a note the local document never had.** No watermark → condition (1) cannot match → fetch. Every unknown answers "fetch": no probe, no `snapshotMeta` key, a note the server omitted from its own response, no local watermark. A missed skip costs one request; a wrong skip costs a note body.

**Scope guard — the sweep stays exhaustive.** Every note in a chunk is still named in the probe. This changes *what a note costs*, never *whether it is visited*, because the sweep is the only channel by which a body-only remote edit reaches a device that missed the broadcast — note bodies never travel in the record change feed. Asserted in `the sweep stays exhaustive…` with a peer body-only edit that must still be fetched and applied.

## Compat

- **New client + old server** — a real, tested code path, not a theoretical one. The batch response is read through a TypeScript cast with **no runtime schema validation**, so an old server's response has `snapshotMeta === undefined` at runtime. The test builds that response *by omitting the key*, not by assigning `undefined`, because that is what arrives over the wire. Result: never skip, today's behaviour exactly. The flag latches after the first such response, so the rest of the session issues exactly the requests this code issued before the feature existed — staging, self-hosted deployments and a rolled-back server deploy all live here.
- **New client, first run against a new server** — no watermarks yet, so the first sweep is a full cold sweep. Expected, once. It costs no probe either.
- **Nothing is persisted.** The watermark is session-scoped and in memory, so the CRDT store and the watermark share one lifetime by construction and a rebuilt or re-pathed store cannot be skipped against. **No migration, no schema change, no contract change, no on-disk format change.** `clearCaches()` drops both halves together, with a test.
- No protocol change, no new endpoint, no rate-limit class change. Editing signed out / offline / with no account is untouched — this is all inside the sweep.

## Testing

New seam test `apps/desktop/src/main/sync/engine/crdt-conditional-snapshot-skip.test.ts`: a **real `CrdtSyncCoordinator`** against a scripted HTTP layer where a note has updates, a snapshot blob and a snapshot metadata row *independently* — so FM5 (row without blob) and "no snapshot at all" are distinct states. Every assertion is about **which requests were actually issued**, never about two mocks agreeing.

Nine cases: warm sweep, exhaustiveness with a peer body-only edit, FM3, FM4, FM5, FM6, a note the server holds no snapshot for, old-server rollback plus the latch, and `clearCaches`.

One pre-existing test (`reuses the highest applied CRDT sequence as the next batch baseline`) was updated: its second pass now opens with the probe, so the sequence carry-over it asserts is visible one call earlier. Its server mock returns no `snapshotMeta`, so it also covers the unconditional path.

### Mutation evidence

Both mutations applied to the committed source, proved applied with `git diff --stat`, then reverted from the index.

**1. Delete condition (2) — FM3.**

```
 apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts | 2 --
 1 file changed, 2 deletions(-)

-    if (appliedSequence < meta.sequenceNum) return null
-
     return appliedSequence
```

```
FAIL  src/main/sync/engine/crdt-conditional-snapshot-skip.test.ts >
  FM3: a matching revision does NOT license a `since` below the server prune watermark
Tests  1 failed | 8 passed (9)
```

**2. Move the skip into `applyCrdtIncrementals` — FM4.**

```
 apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts | 6 +++++-
 1 file changed, 5 insertions(+), 1 deletion(-)

-      const baseline = await this.applySnapshotBaseline(noteId, token, vaultKey, 'single')
+      const knownSequence = this.lastAppliedSequence.get(noteId)
+      const baseline =
+        knownSequence !== undefined && this.mergedSnapshotRevision.has(noteId)
+          ? { since: knownSequence, verified: true }
+          : await this.applySnapshotBaseline(noteId, token, vaultKey, 'single')
```

```
FAIL  src/main/sync/engine/crdt-conditional-snapshot-skip.test.ts >
  FM4: the single-note path never takes the shortcut, whatever the watermark says
Tests  1 failed | 8 passed (9)
```

Each mutation reddened exactly its own test and nothing else.

## Verification

```
pnpm --filter @memry/desktop test:main   exit 0 — 543 files passed | 3 skipped, 7079 tests passed | 1 expected fail | 6 skipped
pnpm typecheck                           exit 0
pnpm lint                                exit 0 — 0 errors, 97 warnings, none in the changed files
git diff --check                         exit 0
pnpm docs:impact --base fa930715b --strict   exit 0 — covered
pnpm docs:build                          exit 0
```
