### PR TITLE
feat(sync): persist the per-note CRDT snapshot watermark inside the per-vault store

### DIFF
--- a/apps/desktop/src/main/sync/crdt-persistence.ts
+++ b/apps/desktop/src/main/sync/crdt-persistence.ts
@@ -21,6 +21,15 @@ export interface CrdtPersistence {
   destroy(): Promise<void> | void
   storeUpdate(noteId: string, update: Uint8Array): Promise<void>
   flushDocument(noteId: string): Promise<void>
+  /**
+   * y-leveldb's per-document metadata, keyed under `['v1', noteId, 'meta', …]`
+   * — inside the range `clearDocument` wipes, so anything stored here is
+   * dropped with the document rather than surviving it. That is what makes it
+   * the only correct home for the snapshot watermark; see
+   * `crdt-snapshot-watermark.ts`.
+   */
+  getMeta(noteId: string, metaKey: string): Promise<unknown>
+  setMeta(noteId: string, metaKey: string, value: unknown): Promise<void>
 }
 
 /**

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -1,5 +1,6 @@
 import * as Y from 'yjs'
 import fsp from 'fs/promises'
+import { randomUUID } from 'crypto'
 import { BrowserWindow } from 'electron'
 import { CRDT_EVENTS, CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 import { createLogger } from '../lib/logger'
@@ -15,6 +16,11 @@ import {
   resetWritebackState
 } from './crdt-writeback'
 import { openCrdtPersistence, type CrdtPersistence } from './crdt-persistence'
+import {
+  readSnapshotWatermark,
+  writeSnapshotWatermark,
+  type CrdtSnapshotWatermark
+} from './crdt-snapshot-watermark'
 import { recordCrdtPersistenceOutcome } from '../store'
 import { recordPendingCrdtNotes } from './crdt-pending-notes'
 import { prepareVaultCrdtStore } from './crdt-store-path'
@@ -98,6 +104,8 @@ export class CrdtProvider {
   private docs = new Map<string, ActiveDoc>()
   private openLocks = new Map<string, Promise<Y.Doc>>()
   private persistence: CrdtPersistence | null = null
+  /** See `storeId`. Minted on every successful open, dropped on `destroy()`. */
+  private storeIdentity: string | null = null
   private persistenceReady = false
   private persistenceInitPromise: Promise<void> | null = null
   private updateQueue: CrdtUpdateQueue | null = null
@@ -187,6 +195,12 @@ export class CrdtProvider {
     // Preflight, quarantine and probe live in crdt-persistence.ts; null means
     // the store could not be trusted and this provider runs in-memory.
     this.persistence = await openCrdtPersistence(target.storagePath)
+    // Minted per successful open, never derived from the path: two opens of the
+    // same directory are still two store lifetimes, and anything holding state
+    // that describes the first one must not carry it into the second. A store
+    // that could not be opened leaves this null, which is what makes in-memory
+    // mode read as "no store" rather than as "an empty one".
+    this.storeIdentity = this.persistence ? randomUUID() : null
     this.persistenceReady = true
     recordSessionPersistenceOutcome(this.persistence !== null)
 
@@ -214,6 +228,64 @@ export class CrdtProvider {
    */
   hasPersistence(): boolean {
     return this.persistence !== null
+  }
+
+  /**
+   * Opaque identity of the store this provider currently holds open, or `null`
+   * when it holds none — no vault yet, in-memory mode, or after `destroy()`.
+   *
+   * It exists so that anything caching state *derived from* the store can tell
+   * that the store underneath it changed. The durable snapshot watermarks live
+   * inside the store and so cannot outlive it, but the sweep also keeps them in
+   * memory for the length of a pass, and that copy has no such guarantee: a
+   * vault switch, a quarantine-and-reopen or a re-path replaces the store while
+   * the process keeps running. Comparing this value is how that copy gets
+   * dropped in the same operation. A fresh id after a benign reopen costs
+   * nothing — the watermarks are re-read from the store that just opened.
+   */
+  get storeId(): string | null {
+    return this.persistence ? this.storeIdentity : null
+  }
+
+  /**
+   * This note's persisted snapshot watermark, or `null` when there is none to
+   * act on.
+   *
+   * Read through the store handle and nowhere else, which is the point: no
+   * store, no watermark. `null` means *unknown*, and every caller must answer an
+   * unknown with a fetch — a store written by a build that predates this key
+   * lands here, and so does a read that failed.
+   */
+  async getSnapshotWatermark(noteId: string): Promise<CrdtSnapshotWatermark | null> {
+    const persistence = this.persistence
+    if (!persistence) return null
+    try {
+      return await readSnapshotWatermark(persistence, noteId)
+    } catch (err) {
+      // A watermark that cannot be read is a watermark that does not exist, and
+      // that answer only ever costs one extra snapshot GET.
+      log.warn('Could not read the persisted CRDT snapshot watermark', { noteId, error: err })
+      return null
+    }
+  }
+
+  /**
+   * Record this note's snapshot watermark in the store.
+   *
+   * Called after the bytes it describes are already on their way into the same
+   * LevelDB: `applyRemoteUpdate` hands the update to `storeUpdate` before this
+   * runs, and y-leveldb serialises its transactions, so the document write is
+   * queued ahead of the meta write. A crash between them loses the watermark and
+   * keeps the document, which is the direction this whole feature must fail in.
+   */
+  async putSnapshotWatermark(noteId: string, watermark: CrdtSnapshotWatermark): Promise<void> {
+    const persistence = this.persistence
+    if (!persistence) return
+    try {
+      await writeSnapshotWatermark(persistence, noteId, watermark)
+    } catch (err) {
+      log.warn('Could not persist the CRDT snapshot watermark', { noteId, error: err })
+    }
   }
 
   /**
@@ -595,6 +667,10 @@ export class CrdtProvider {
       }
       this.persistence = null
     }
+    // Dropped with the store, in the same operation. Anything still holding
+    // watermarks read out of that store now sees a different `storeId` and has
+    // to throw its copy away — see the getter.
+    this.storeIdentity = null
     this.persistenceReady = false
 
     this.openLocks.clear()

--- a/apps/desktop/src/main/sync/crdt-snapshot-watermark.test.ts
+++ b/apps/desktop/src/main/sync/crdt-snapshot-watermark.test.ts
@@ -1,0 +1,203 @@
+/**
+ * The durable half of FM2 (#1613), against a REAL y-leveldb store.
+ *
+ * The claim this file has to hold up is not "the watermark round-trips" — it is
+ * **"the store is gone" implies "the watermark is gone"**. A watermark that
+ * survives its store makes the sweep skip a snapshot baseline forever against a
+ * document that never had it, and the note keeps a stale body with nothing left
+ * to correct it. So every assertion here is about a store that was quarantined,
+ * rebuilt or re-pathed, and every one of them uses the same on-disk semantics
+ * the product does: a real LevelDB, a real directory rename.
+ *
+ * Nothing is mocked. A mocked store agreeing with a mocked reader is exactly the
+ * green-tests-over-broken-behaviour failure this subsystem is known for (#1499).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import * as Y from 'yjs'
+import { LeveldbPersistence } from 'y-leveldb'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { moveStoreDir } from './crdt-store-move'
+import {
+  SNAPSHOT_WATERMARK_META_KEY,
+  decodeSnapshotWatermark,
+  readSnapshotWatermark,
+  writeSnapshotWatermark
+} from './crdt-snapshot-watermark'
+
+let root: string
+let storeDir: string
+
+const NOTE = 'note-1'
+
+async function withStore<T>(
+  dir: string,
+  fn: (store: LeveldbPersistence) => Promise<T>
+): Promise<T> {
+  const store = new LeveldbPersistence(dir)
+  try {
+    return await fn(store)
+  } finally {
+    await store.destroy()
+  }
+}
+
+/** A note with real CRDT history AND a watermark describing it. */
+async function seedMergedNote(dir: string, appliedSequence: number): Promise<void> {
+  await withStore(dir, async (store) => {
+    const doc = new Y.Doc()
+    doc.getText('body').insert(0, 'remote body')
+    await store.storeUpdate(NOTE, Y.encodeStateAsUpdate(doc))
+    doc.destroy()
+    await writeSnapshotWatermark(store, NOTE, { appliedSequence, snapshotRevision: 'rev-1' })
+  })
+}
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'memry-watermark-'))
+  storeDir = path.join(root, 'crdt-stores', 'vault-a')
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('the persisted CRDT snapshot watermark', () => {
+  it('round-trips through the store the document lives in', async () => {
+    await seedMergedNote(storeDir, 42)
+
+    const read = await withStore(storeDir, (store) => readSnapshotWatermark(store, NOTE))
+    expect(read).toEqual({ appliedSequence: 42, snapshotRevision: 'rev-1' })
+  })
+
+  it('is stored inside the document key range, so clearDocument takes it', async () => {
+    await seedMergedNote(storeDir, 42)
+
+    await withStore(storeDir, async (store) => {
+      // What `CrdtProvider.purge()` and the legacy-store partition call. It is
+      // not given the meta key and does not know one exists — the guarantee is
+      // that a meta key is `['v1', noteId, 'meta', …]`, inside the range
+      // `['v1', noteId] … ['v1', noteId, 'zzzzzzz']` that this clears.
+      await store.clearDocument(NOTE)
+    })
+
+    const read = await withStore(storeDir, (store) => readSnapshotWatermark(store, NOTE))
+    expect(read).toBeNull()
+  })
+
+  // THE MERGE GATE. Removing the watermark drop from the store-teardown path has
+  // to redden this.
+  it('is quarantined with the store, so a rebuilt store starts with no watermarks', async () => {
+    await seedMergedNote(storeDir, 42)
+
+    // Exactly what `settleStoreStageFailure` does when the preflight implicates
+    // the store's own data: move the whole directory aside. LevelDB then
+    // recreates the leaf, vault markdown reseeds the notes, and the CRDT history
+    // is gone — so the watermark describing that history must be gone too.
+    const quarantinePath = `${storeDir}.broken-1`
+    expect(await moveStoreDir(storeDir, quarantinePath)).toBe(true)
+    expect(existsSync(storeDir)).toBe(false)
+
+    const rebuilt = await withStore(storeDir, (store) => readSnapshotWatermark(store, NOTE))
+    expect(rebuilt).toBeNull()
+
+    // And the rebuilt store has no document either — the two vanished in the
+    // same operation, which is the property, not a coincidence of ordering.
+    const body = await withStore(storeDir, async (store) => {
+      const doc = await store.getYDoc(NOTE)
+      const text = doc.getText('body').toString()
+      doc.destroy()
+      return text
+    })
+    expect(body).toBe('')
+  })
+
+  it('travels with the store when the vault re-paths it, never apart from it', async () => {
+    await seedMergedNote(storeDir, 42)
+
+    // `settlePendingCrdtStoreRename`: the vault adopted a new uuid, so the store
+    // directory follows it. The documents move, so the watermarks must move with
+    // them — and the old path must hold neither.
+    const adoptedPath = path.join(root, 'crdt-stores', 'vault-b')
+    expect(await moveStoreDir(storeDir, adoptedPath)).toBe(true)
+
+    expect(await withStore(adoptedPath, (store) => readSnapshotWatermark(store, NOTE))).toEqual({
+      appliedSequence: 42,
+      snapshotRevision: 'rev-1'
+    })
+    // The pre-adoption path is now a fresh, empty store: no document, and
+    // therefore no watermark to skip a baseline on.
+    expect(await withStore(storeDir, (store) => readSnapshotWatermark(store, NOTE))).toBeNull()
+  })
+
+  it('is not readable across vaults: each vault store answers only for itself', async () => {
+    await seedMergedNote(storeDir, 42)
+
+    const otherVault = path.join(root, 'crdt-stores', 'vault-b')
+    expect(await withStore(otherVault, (store) => readSnapshotWatermark(store, NOTE))).toBeNull()
+  })
+
+  it('reads a store written by an older build as unknown, never as sequence 0', async () => {
+    // An older build stored the document and nothing else — no meta key ever
+    // existed. Absent must stay absent all the way up: `null` is what
+    // `snapshotBaselineSkip` needs to fall through to a fetch, and
+    // `{ appliedSequence: 0 }` would be a licence to skip.
+    await withStore(storeDir, async (store) => {
+      const doc = new Y.Doc()
+      doc.getText('body').insert(0, 'written by an older build')
+      await store.storeUpdate(NOTE, Y.encodeStateAsUpdate(doc))
+      doc.destroy()
+    })
+
+    expect(await withStore(storeDir, (store) => readSnapshotWatermark(store, NOTE))).toBeNull()
+  })
+
+  it('drops the revision rather than keeping a stale one when there is none', async () => {
+    await seedMergedNote(storeDir, 42)
+    await withStore(storeDir, (store) =>
+      writeSnapshotWatermark(store, NOTE, { appliedSequence: 50 })
+    )
+
+    // Sequence known, snapshot unknown — which the skip rule cannot match, so
+    // the note fetches its baseline rather than trusting a token nobody holds.
+    expect(await withStore(storeDir, (store) => readSnapshotWatermark(store, NOTE))).toEqual({
+      appliedSequence: 50
+    })
+  })
+
+  it('leaves a downgrade harmless: an older build reads the document and ignores the key', async () => {
+    await seedMergedNote(storeDir, 42)
+
+    // "An older build" is a reader that only ever asks for documents. The key is
+    // additive and namespaced, so it cannot collide with one, and the document
+    // it sits beside is unchanged.
+    const body = await withStore(storeDir, async (store) => {
+      const doc = await store.getYDoc(NOTE)
+      const text = doc.getText('body').toString()
+      doc.destroy()
+      return text
+    })
+    expect(body).toBe('remote body')
+    expect(SNAPSHOT_WATERMARK_META_KEY).toBe('memry.snapshotWatermark.v1')
+  })
+
+  it.each([
+    ['no record', undefined],
+    ['null', null],
+    ['a bare number', 7],
+    ['a string', 'rev-1'],
+    ['no sequence', { snapshotRevision: 'rev-1' }],
+    ['a non-numeric sequence', { appliedSequence: '42', snapshotRevision: 'rev-1' }],
+    ['NaN', { appliedSequence: Number.NaN }],
+    ['a negative sequence', { appliedSequence: -1 }],
+    ['a non-string revision', { appliedSequence: 42, snapshotRevision: 7 }]
+  ])('decodes %s as unknown, so the caller fetches', (_label, raw) => {
+    expect(decodeSnapshotWatermark(raw)).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/sync/crdt-snapshot-watermark.ts
+++ b/apps/desktop/src/main/sync/crdt-snapshot-watermark.ts
@@ -1,0 +1,115 @@
+/**
+ * The per-note snapshot watermark, stored **inside the per-vault CRDT store**.
+ *
+ * The watermark is the sweep's licence to skip a note's snapshot baseline: it
+ * says "this document already holds the server snapshot `snapshotRevision`, and
+ * everything at or below sequence `appliedSequence`". A watermark that outlives
+ * the document it describes therefore makes the sweep skip that baseline
+ * *forever* against a doc that never had it, and the note keeps a stale body
+ * with nothing left to correct it (#1613, FM2).
+ *
+ * So the location is not an implementation detail, it is the whole design:
+ *
+ *  - it is a **y-leveldb doc meta key**, which puts it in the same LevelDB, in
+ *    the same directory, behind the same handle as the note's updates. There is
+ *    no way to read it without the store that holds the document;
+ *  - `LeveldbPersistence.clearDocument(noteId)` clears the key range
+ *    `['v1', noteId] … ['v1', noteId, 'zzzzzzz']`, and a meta key is
+ *    `['v1', noteId, 'meta', …]` — inside it. So `CrdtProvider.purge()` and the
+ *    legacy-store partition drop each document's watermark **in the same
+ *    operation** that drops the document;
+ *  - quarantine (`crdt-persistence.ts` moves the whole directory aside), a
+ *    rebuild (LevelDB recreates an empty directory) and a re-path
+ *    (`settlePendingCrdtStoreRename` renames the directory) all move or destroy
+ *    the watermarks with the documents, because they are the same bytes;
+ *  - a store that could not be opened at all degrades the provider to in-memory
+ *    mode with `persistence === null`, and then there is no handle to read a
+ *    watermark through either.
+ *
+ * It must NOT live in the index DB, in `store` (electron-store), or anywhere
+ * else with an independent lifetime. Losing a watermark costs one extra GET;
+ * keeping a stale one costs a note body.
+ *
+ * Compat: this key is additive and invisible to any build that does not read it.
+ * A store written by an older build simply has no such key, which decodes to
+ * `null` — unknown, therefore fetch, never "sequence 0, therefore skip". A newer
+ * store read by an older build is equally harmless: the older build never asks
+ * for the key, and `clearDocument` still sweeps it away with the document.
+ */
+
+/** Where a note's merge got to, as far as the *store* is concerned. */
+export interface CrdtSnapshotWatermark {
+  /** Highest `crdt_updates.sequence_num` applied to this note's document. */
+  appliedSequence: number
+  /**
+   * `revision` of the server snapshot blob actually decrypted into the document.
+   *
+   * Optional because an older server does not publish one. Absent means the
+   * snapshot half of the watermark is unknown, which the skip rule reads as
+   * "cannot match" — the note falls through to a fetch.
+   */
+  snapshotRevision?: string
+}
+
+/**
+ * The meta key, versioned so a future shape change is a new key rather than a
+ * reinterpretation of bytes an older build wrote.
+ */
+export const SNAPSHOT_WATERMARK_META_KEY = 'memry.snapshotWatermark.v1'
+
+/** The slice of the store this module needs. */
+export interface WatermarkMetaStore {
+  getMeta(docName: string, metaKey: string): Promise<unknown>
+  setMeta(docName: string, metaKey: string, value: unknown): Promise<void>
+}
+
+/**
+ * Parse whatever came back out of the store.
+ *
+ * Every rejection returns `null`, and `null` means *unknown* — which the caller
+ * must answer with a fetch. There is deliberately no default: a malformed or
+ * truncated record read as `{ appliedSequence: 0 }` would be a licence to skip
+ * a baseline on the strength of a record nobody wrote.
+ */
+export function decodeSnapshotWatermark(raw: unknown): CrdtSnapshotWatermark | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const record = raw as Record<string, unknown>
+  const appliedSequence = record.appliedSequence
+  if (typeof appliedSequence !== 'number' || !Number.isFinite(appliedSequence)) return null
+  if (appliedSequence < 0) return null
+  const snapshotRevision = record.snapshotRevision
+  if (snapshotRevision !== undefined && typeof snapshotRevision !== 'string') return null
+  return snapshotRevision ? { appliedSequence, snapshotRevision } : { appliedSequence }
+}
+
+/**
+ * Read a note's watermark out of the store, or `null` when there is not one this
+ * code is willing to act on — no key, an unreadable store, or a record that does
+ * not decode.
+ */
+export async function readSnapshotWatermark(
+  store: WatermarkMetaStore,
+  noteId: string
+): Promise<CrdtSnapshotWatermark | null> {
+  const raw = await store.getMeta(noteId, SNAPSHOT_WATERMARK_META_KEY)
+  return decodeSnapshotWatermark(raw)
+}
+
+/**
+ * Record a note's watermark in the store.
+ *
+ * `snapshotRevision` is written as absent rather than as `undefined` when there
+ * is none, so a note whose revision was dropped (an older server on the snapshot
+ * endpoint) reads back as "sequence known, snapshot unknown" and its next skip
+ * decision falls through to a fetch instead of matching a token nobody holds.
+ */
+export async function writeSnapshotWatermark(
+  store: WatermarkMetaStore,
+  noteId: string,
+  watermark: CrdtSnapshotWatermark
+): Promise<void> {
+  const value: CrdtSnapshotWatermark = watermark.snapshotRevision
+    ? { appliedSequence: watermark.appliedSequence, snapshotRevision: watermark.snapshotRevision }
+    : { appliedSequence: watermark.appliedSequence }
+  await store.setMeta(noteId, SNAPSHOT_WATERMARK_META_KEY, value)
+}

--- a/apps/desktop/src/main/sync/engine/crdt-persisted-snapshot-watermark.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-persisted-snapshot-watermark.test.ts
@@ -1,0 +1,390 @@
+/**
+ * The persisted snapshot watermark, driven through a real `CrdtSyncCoordinator`
+ * (#1613).
+ *
+ * `crdt-snapshot-watermark.test.ts` holds up the durable half against a real
+ * LevelDB: a quarantined, rebuilt or re-pathed store takes its watermarks with
+ * it. This file holds up the half that runs in this process — the working copy
+ * the sweep keeps in memory, which the store's lifetime does NOT bound on its
+ * own, because the app keeps running across a vault switch and a
+ * quarantine-and-reopen.
+ *
+ * Same discipline as the sibling file: nothing mocks the coordinator or its
+ * decision, the HTTP layer is a scripted server, and every assertion is about
+ * which requests were actually issued.
+ *
+ * The mutations this file has to catch:
+ *   1. remove the watermark drop from the store-teardown path — the in-memory
+ *      copy then survives a store swap and skips a baseline against documents
+ *      the new store never had (FM2, the merge gate);
+ *   2. read a store with no record as `{ appliedSequence: 0 }` instead of as
+ *      unknown — a build that predates this key then skips every baseline.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SyncContext } from './sync-context'
+import { CrdtSyncCoordinator } from './crdt-sync-coordinator'
+import type { CrdtSnapshotWatermark } from '../crdt-snapshot-watermark'
+import type { CrdtSnapshotMeta } from '../http-client'
+
+const fetchCrdtSnapshotMock = vi.fn()
+const getFromServerMock = vi.fn()
+const postToServerMock = vi.fn()
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+vi.mock('../http-client', () => ({
+  fetchCrdtSnapshot: (...args: unknown[]) => fetchCrdtSnapshotMock(...args),
+  getFromServer: (...args: unknown[]) => getFromServerMock(...args),
+  postToServer: (...args: unknown[]) => postToServerMock(...args)
+}))
+
+vi.mock('../../crypto/index', () => ({ secureCleanup: vi.fn() }))
+vi.mock('../retry', () => ({
+  withRetry: async (fn: () => Promise<unknown>) => ({ value: await fn() })
+}))
+vi.mock('../crdt-encrypt', () => ({ decryptCrdtUpdate: () => new Uint8Array([9, 9, 9]) }))
+vi.mock('../../telemetry/diagnostics', () => ({ trackMainError: vi.fn() }))
+
+const SIGNER = 'device-a'
+
+interface ServerNote {
+  /** The R2 blob. `null` models a D1 row whose blob is gone (FM5). */
+  snapshot: { sequenceNum: number; revision: string | null } | null
+  /** The D1 row. Absent means the server holds no snapshot for the note at all. */
+  meta?: { sequenceNum: number; revision: string }
+  updates: Array<{ sequenceNum: number; data: string; signerDeviceId: string; createdAt: number }>
+}
+
+interface BatchRequest {
+  notes: Array<{ noteId: string; since: number }>
+  limit: number
+}
+
+/**
+ * One per-vault CRDT store: an identity and the watermarks it holds.
+ *
+ * A store is only ever *replaced*, never edited from outside — quarantine,
+ * rebuild and re-path all produce a new `FakeStore`, which is precisely the
+ * shape the real thing has (a new directory, or the same directory reopened
+ * under a fresh handle).
+ */
+class FakeStore {
+  constructor(
+    readonly id: string,
+    readonly watermarks = new Map<string, CrdtSnapshotWatermark>()
+  ) {}
+}
+
+describe('CRDT sweep: the persisted snapshot watermark', () => {
+  let server: Record<string, ServerNote>
+  let snapshotGets: string[]
+  let batchRequests: BatchRequest[]
+  let openedNotes: string[]
+  let openDocs: Set<string>
+  /** Swapped, not mutated, when the store underneath the provider changes. */
+  let store: FakeStore | null
+
+  /**
+   * A provider over whatever `store` currently is.
+   *
+   * `storeId` and the watermark accessors both read `store` at call time, so a
+   * test can replace the store mid-session exactly as `doInitPersistence` does
+   * after a quarantine, and `null` is in-memory mode.
+   */
+  const makeProvider = (): Record<string, unknown> => ({
+    inactiveDocCapacity: 32,
+    isNoteLocalOnly: () => false,
+    getDoc: (noteId: string) => (openDocs.has(noteId) ? {} : undefined),
+    open: async (noteId: string) => {
+      openedNotes.push(noteId)
+      openDocs.add(noteId)
+      return {}
+    },
+    closeIfInactive: async (noteId: string) => {
+      openDocs.delete(noteId)
+      return true
+    },
+    applyRemoteUpdate: () => {},
+    getStateVector: () => new Uint8Array([1, 2, 3, 4]),
+    seedFromMarkdownPublic: vi.fn(),
+    get storeId(): string | null {
+      return store?.id ?? null
+    },
+    getSnapshotWatermark: async (noteId: string): Promise<CrdtSnapshotWatermark | null> =>
+      store?.watermarks.get(noteId) ?? null,
+    putSnapshotWatermark: async (
+      noteId: string,
+      watermark: CrdtSnapshotWatermark
+    ): Promise<void> => {
+      store?.watermarks.set(noteId, watermark)
+    }
+  })
+
+  /** A coordinator over the current store. A second one models a relaunch. */
+  const newSession = (): CrdtSyncCoordinator => {
+    const ctx = {
+      deps: {
+        crdtProvider: makeProvider(),
+        getAccessToken: async () => 'token-1',
+        getVaultKey: async () => new Uint8Array([1, 2, 3])
+      },
+      abortController: new AbortController()
+    } as unknown as SyncContext
+    return new CrdtSyncCoordinator(ctx, async () => new Uint8Array([4, 5, 6]))
+  }
+
+  const resetTraffic = (): void => {
+    snapshotGets = []
+    batchRequests = []
+    openedNotes = []
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    server = {}
+    openDocs = new Set()
+    store = new FakeStore('store-vault-a')
+    resetTraffic()
+
+    fetchCrdtSnapshotMock.mockImplementation(async (noteId: string) => {
+      snapshotGets.push(noteId)
+      const snapshot = server[noteId]?.snapshot
+      if (!snapshot) return null
+      return {
+        snapshot: new Uint8Array([1, 2]),
+        sequenceNum: snapshot.sequenceNum,
+        signerDeviceId: SIGNER,
+        revision: snapshot.revision
+      }
+    })
+
+    getFromServerMock.mockImplementation(async (path: string) => {
+      const noteId = decodeURIComponent(/note_id=([^&]+)/.exec(path)?.[1] ?? '')
+      const since = Number(/since=(\d+)/.exec(path)?.[1] ?? '0')
+      const above = (server[noteId]?.updates ?? []).filter((u) => u.sequenceNum > since)
+      return { updates: above, hasMore: false }
+    })
+
+    postToServerMock.mockImplementation(async (_path: string, body: unknown) => {
+      const request = body as BatchRequest
+      batchRequests.push(request)
+      const notes: Record<string, { updates: ServerNote['updates']; hasMore: boolean }> = {}
+      const snapshotMeta: Record<string, CrdtSnapshotMeta> = {}
+      for (const { noteId, since } of request.notes) {
+        const above = (server[noteId]?.updates ?? []).filter((u) => u.sequenceNum > since)
+        notes[noteId] = {
+          updates: above.slice(0, request.limit),
+          hasMore: above.length > request.limit
+        }
+        const meta = server[noteId]?.meta
+        if (meta) {
+          snapshotMeta[noteId] = {
+            sequenceNum: meta.sequenceNum,
+            revision: meta.revision,
+            signerDeviceId: SIGNER
+          }
+        }
+      }
+      return { notes, snapshotMeta }
+    })
+  })
+
+  const probeRequests = (): BatchRequest[] => batchRequests.filter((r) => r.limit === 1)
+
+  const twoSettledNotes = (): void => {
+    server = {
+      'note-1': {
+        snapshot: { sequenceNum: 90, revision: 'rev-1' },
+        meta: { sequenceNum: 90, revision: 'rev-1' },
+        updates: []
+      },
+      'note-2': {
+        snapshot: { sequenceNum: 12, revision: 'rev-2' },
+        meta: { sequenceNum: 12, revision: 'rev-2' },
+        updates: []
+      }
+    }
+  }
+
+  it('carries the watermark across a relaunch: the first sweep of the next session issues zero snapshot GETs', async () => {
+    twoSettledNotes()
+
+    // Session 1 — cold. No watermarks anywhere, so no probe is even sent and
+    // both baselines are downloaded.
+    await newSession().pullCrdtForNotes(['note-1', 'note-2'])
+    expect(snapshotGets).toEqual(['note-1', 'note-2'])
+    expect(probeRequests()).toHaveLength(0)
+
+    resetTraffic()
+
+    // Session 2 — a different coordinator over the SAME store, which is what an
+    // app restart and a fresh sign-in both are. This is the ten minutes the
+    // issue is about.
+    await newSession().pullCrdtForNotes(['note-1', 'note-2'])
+
+    expect(snapshotGets).toEqual([])
+    expect(probeRequests()).toHaveLength(1)
+    expect(openedNotes).toEqual([])
+  })
+
+  it('records the sequence and the revision it actually merged, not the ones advertised', async () => {
+    twoSettledNotes()
+    await newSession().pullCrdtForNotes(['note-1'])
+
+    expect(store?.watermarks.get('note-1')).toEqual({
+      appliedSequence: 90,
+      snapshotRevision: 'rev-1'
+    })
+  })
+
+  // THE MERGE GATE, in-process half. Removing the drop from `watermarkStore()`
+  // has to redden this.
+  it('drops the in-memory watermarks when the store underneath them is replaced', async () => {
+    twoSettledNotes()
+
+    const coordinator = newSession()
+    await coordinator.pullCrdtForNotes(['note-1', 'note-2'])
+    expect(snapshotGets).toEqual(['note-1', 'note-2'])
+
+    resetTraffic()
+    // Warm against its own store, so the swap below is the only thing that can
+    // explain the cold sweep that follows.
+    await coordinator.pullCrdtForNotes(['note-1', 'note-2'])
+    expect(snapshotGets).toEqual([])
+
+    resetTraffic()
+    // The store is replaced under the running process: a vault switch, a store
+    // quarantined and reopened, a store re-pathed after device linking. The new
+    // store has never seen these notes. The watermarks the coordinator is still
+    // holding describe documents it does not have, and acting on one would skip
+    // the baseline that is the only thing that could fill them.
+    store = new FakeStore('store-vault-b')
+
+    await coordinator.pullCrdtForNotes(['note-1', 'note-2'])
+
+    expect(snapshotGets).toEqual(['note-1', 'note-2'])
+    expect(probeRequests()).toHaveLength(0)
+    // And nothing from the old store leaked into the new one's records.
+    expect(store.watermarks.get('note-1')).toEqual({
+      appliedSequence: 90,
+      snapshotRevision: 'rev-1'
+    })
+  })
+
+  it('goes cold when a rebuilt store comes back empty, even across a relaunch', async () => {
+    twoSettledNotes()
+    await newSession().pullCrdtForNotes(['note-1', 'note-2'])
+    expect(store?.watermarks.size).toBe(2)
+
+    resetTraffic()
+    // Quarantine: the directory is moved aside and LevelDB recreates an empty
+    // one. Documents and watermarks went together.
+    store = new FakeStore('store-vault-a-rebuilt')
+
+    await newSession().pullCrdtForNotes(['note-1', 'note-2'])
+
+    expect(snapshotGets).toEqual(['note-1', 'note-2'])
+    expect(probeRequests()).toHaveLength(0)
+  })
+
+  // Mutation 2. Defaulting a missing record to sequence 0 has to redden this.
+  it('reads a store with no records as unknown, so an older build sweeps exactly as it did', async () => {
+    twoSettledNotes()
+    // A store written by a build that predates the meta key: the documents are
+    // there, no watermark ever was.
+    expect(store?.watermarks.size).toBe(0)
+
+    await newSession().pullCrdtForNotes(['note-1', 'note-2'])
+
+    expect(snapshotGets).toEqual(['note-1', 'note-2'])
+    // Not even a probe: unknown is unknown, never "sequence 0, therefore skip".
+    expect(probeRequests()).toHaveLength(0)
+  })
+
+  it('FM5: never persists a watermark for a snapshot blob that never arrived', async () => {
+    server = {
+      // The D1 row advertises revision `rev-1`; the R2 blob is gone, so
+      // `getSnapshot` answers null and nothing is applied to the document.
+      'note-1': { snapshot: null, meta: { sequenceNum: 90, revision: 'rev-1' }, updates: [] }
+    }
+
+    await newSession().pullCrdtForNotes(['note-1'])
+    expect(store?.watermarks.has('note-1')).toBe(false)
+
+    resetTraffic()
+    // So the next session is still cold for it, which is the point: a watermark
+    // here would skip the baseline forever against a body that never arrived.
+    await newSession().pullCrdtForNotes(['note-1'])
+    expect(snapshotGets).toEqual(['note-1'])
+  })
+
+  it('persists nothing at all when the provider is running in memory', async () => {
+    twoSettledNotes()
+    // `openCrdtPersistence` returned null — a broken native binding, a store
+    // that could not be trusted. Documents are seeded from vault markdown rather
+    // than restored from CRDT history, so there is no merge state a watermark
+    // could truthfully describe.
+    store = null
+
+    await newSession().pullCrdtForNotes(['note-1', 'note-2'])
+    expect(snapshotGets).toEqual(['note-1', 'note-2'])
+
+    resetTraffic()
+    store = null
+    await newSession().pullCrdtForNotes(['note-1', 'note-2'])
+
+    // Still cold, every session, forever. That is the correct price for a device
+    // with no store.
+    expect(snapshotGets).toEqual(['note-1', 'note-2'])
+    expect(probeRequests()).toHaveLength(0)
+  })
+
+  it('carries a watermark the single-note path moved, without ever consulting one (FM4)', async () => {
+    server = {
+      'note-1': {
+        snapshot: { sequenceNum: 90, revision: 'rev-1' },
+        meta: { sequenceNum: 90, revision: 'rev-1' },
+        updates: [{ sequenceNum: 91, data: 'eA==', signerDeviceId: SIGNER, createdAt: 1 }]
+      }
+    }
+
+    const coordinator = newSession()
+    await coordinator.pullCrdtForNote('note-1')
+
+    // The incremental above the baseline is in the record, so the next sweep
+    // resumes from 91 rather than re-walking from 90.
+    expect(store?.watermarks.get('note-1')).toEqual({
+      appliedSequence: 91,
+      snapshotRevision: 'rev-1'
+    })
+
+    resetTraffic()
+    // And the single-note path itself is still unconditional: a second pull
+    // downloads the baseline again however warm the watermark is.
+    await coordinator.pullCrdtForNote('note-1')
+    expect(snapshotGets).toEqual(['note-1'])
+  })
+
+  it('a watermark below the server prune watermark still fetches, persisted or not (FM3)', async () => {
+    server = {
+      'note-1': {
+        snapshot: { sequenceNum: 90, revision: 'rev-1' },
+        meta: { sequenceNum: 90, revision: 'rev-1' },
+        updates: []
+      }
+    }
+    // A record whose revision matches but whose sequence sits under the server's
+    // prune line: everything at or below 90 has been deleted, so resuming from
+    // 40 would be answered with silence and the note would go quietly stale.
+    store = new FakeStore(
+      'store-vault-a',
+      new Map([['note-1', { appliedSequence: 40, snapshotRevision: 'rev-1' }]])
+    )
+
+    await newSession().pullCrdtForNotes(['note-1'])
+
+    expect(snapshotGets).toEqual(['note-1'])
+  })
+})

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -11,6 +11,7 @@ import {
 import { decryptCrdtUpdate } from '../crdt-encrypt'
 import { trackMainError } from '../../telemetry/diagnostics'
 import type { SyncContext } from './sync-context'
+import type { CrdtProvider } from '../crdt-provider'
 
 const log = createLogger('CrdtSyncCoordinator')
 
@@ -25,12 +26,13 @@ export class CrdtSyncCoordinator {
    * note's doc — half of the watermark the sweep's conditional skip compares
    * against, `lastAppliedSequence` being the other half.
    *
-   * Session-scoped and in memory on purpose. A persisted watermark can outlive
-   * the document it describes (an evicted, quarantined, rebuilt or re-pathed
-   * store), and a watermark that claims a baseline the doc never kept makes the
-   * sweep skip that baseline forever against a note whose body is stale. In
-   * memory the store and the watermark share one lifetime by construction.
-   * Persisting it is a separate change with its own invalidation to carry.
+   * Backed by the store, not by the session. Both halves are read out of, and
+   * written back into, the per-vault CRDT store as a y-leveldb doc meta key —
+   * see `crdt-snapshot-watermark.ts` for why that location is forced rather than
+   * chosen. These two maps are a per-pass working copy of it, and they are
+   * dropped the moment `crdtProvider.storeId` says the store underneath them
+   * changed, so "the store is gone" still implies "the watermark is gone" for
+   * the in-memory half too.
    *
    * Written only where a snapshot was genuinely decrypted and applied, never
    * where one was merely advertised: `getSnapshot` returns null when the D1 row
@@ -38,6 +40,21 @@ export class CrdtSyncCoordinator {
    * never arrived is exactly how a note keeps a stale body forever.
    */
   private mergedSnapshotRevision = new Map<string, string>()
+  /**
+   * The store the two maps above were filled from. A different value — a vault
+   * switch, a quarantine-and-reopen, a re-path, a provider destroyed and rebuilt
+   * — invalidates every watermark held in memory, because they describe
+   * documents that store does not have.
+   */
+  private watermarkStoreId: string | null = null
+  /**
+   * Notes whose persisted watermark this session has already looked for, so a
+   * note absent from the store is asked about once rather than once per chunk.
+   * A miss is remembered as a miss; it must never become a zero.
+   */
+  private hydratedWatermarks = new Set<string>()
+  /** Notes whose in-memory watermark has moved and has not reached the store yet. */
+  private dirtyWatermarks = new Set<string>()
   /**
    * Set once a batch response comes back without `snapshotMeta`, which is how
    * an older server answers.
@@ -197,10 +214,12 @@ export class CrdtSyncCoordinator {
    */
   clearCaches(): void {
     this.pendingPulls.clear()
-    this.lastAppliedSequence.clear()
-    // Cleared with the sequence half, never separately: the two are one
-    // watermark, and half a watermark is a skip decision made on a guess.
-    this.mergedSnapshotRevision.clear()
+    // The in-memory copy only. The durable record lives in the CRDT store and is
+    // deliberately left alone: a restart or a fresh sign-in re-reads it, which is
+    // the entire point of persisting it, and this teardown is not evidence about
+    // any document. Only the store going away is.
+    this.dropWatermarks()
+    this.watermarkStoreId = null
     this.applyFailureReported.clear()
     // Deliberately silent: `reportUnmergedDebt` is not called here. This is a
     // teardown, not a note that finished merging, and reporting "no debt" for it
@@ -243,8 +262,129 @@ export class CrdtSyncCoordinator {
   private rememberAppliedSequence(noteId: string, sequenceNum: number): number {
     const known = this.lastAppliedSequence.get(noteId) ?? 0
     const next = Math.max(known, sequenceNum)
+    if (!this.lastAppliedSequence.has(noteId) || next !== known) {
+      this.dirtyWatermarks.add(noteId)
+    }
     this.lastAppliedSequence.set(noteId, next)
     return next
+  }
+
+  /**
+   * Throw away every watermark held in memory. Never touches the store: the
+   * durable record is dropped by the store's own lifetime, not by this.
+   */
+  private dropWatermarks(): void {
+    // Cleared together, never separately: the two maps are one watermark, and
+    // half a watermark is a skip decision made on a guess.
+    this.lastAppliedSequence.clear()
+    this.mergedSnapshotRevision.clear()
+    this.hydratedWatermarks.clear()
+    this.dirtyWatermarks.clear()
+  }
+
+  /**
+   * The store the watermarks may be read from and written to right now, after
+   * reconciling anything held in memory with it.
+   *
+   * **This is the in-memory half of FM2 and it is not optional.** The durable
+   * watermarks cannot outlive their store — they are keys inside it. The working
+   * copy in `lastAppliedSequence` / `mergedSnapshotRevision` can: this process
+   * keeps running across a vault switch, a store quarantined and reopened, and a
+   * store re-pathed after device linking. Carrying watermarks across one of those
+   * would skip a baseline against documents the new store never had. So every
+   * read and every write goes through here first, and a changed `storeId` drops
+   * the lot in the same operation.
+   *
+   * `null` means there is no store — no vault open yet, or the provider degraded
+   * to in-memory mode because the store could not be trusted. Nothing is read
+   * and nothing is written then, which is correct twice over: an in-memory
+   * document is seeded from vault markdown rather than restored from CRDT
+   * history, so there is no merge state a watermark could truthfully describe.
+   */
+  private watermarkStore(): CrdtProvider | null {
+    const provider = this.ctx.deps.crdtProvider ?? null
+    const storeId = provider?.storeId ?? null
+    if (storeId !== this.watermarkStoreId) {
+      this.dropWatermarks()
+      this.watermarkStoreId = storeId
+    }
+    return storeId === null ? null : provider
+  }
+
+  /**
+   * Fill the in-memory watermarks for a chunk from the store, so the first sweep
+   * after a relaunch or a fresh sign-in is warm instead of cold.
+   *
+   * Runs before the probe, because the probe's `since` values and its
+   * "has anything merged at all" test both read the maps this fills.
+   *
+   * A note the store has no record for is left absent, never zeroed: absent is
+   * what `snapshotBaselineSkip` reads as unknown, and unknown fetches. A build
+   * that predates the meta key wrote no records at all, so every note on such a
+   * store lands there and the sweep costs exactly what it cost before.
+   */
+  private async hydrateWatermarks(noteIds: string[]): Promise<void> {
+    const store = this.watermarkStore()
+    if (!store) return
+
+    for (const noteId of noteIds) {
+      if (this.hydratedWatermarks.has(noteId)) continue
+      // Marked before the await, so a concurrent chunk holding the same note
+      // does not issue a second read for it.
+      this.hydratedWatermarks.add(noteId)
+      // Anything this session merged is newer than anything on disk, and it is
+      // already in the maps.
+      if (this.lastAppliedSequence.has(noteId)) continue
+
+      const watermark = await store.getSnapshotWatermark(noteId)
+      if (!watermark) continue
+      // The store may have been swapped while the read was in flight, which
+      // `dropWatermarks` would have cleared the hydration memo for. Writing this
+      // record in now would put a watermark from the old store into the new
+      // one's working copy.
+      if (store.storeId !== this.watermarkStoreId) return
+
+      this.lastAppliedSequence.set(noteId, watermark.appliedSequence)
+      if (watermark.snapshotRevision) {
+        this.mergedSnapshotRevision.set(noteId, watermark.snapshotRevision)
+      } else {
+        this.mergedSnapshotRevision.delete(noteId)
+      }
+    }
+  }
+
+  /**
+   * Write back the watermarks this pass moved.
+   *
+   * Deferred to the end of the pass rather than written per update: a pass that
+   * throws half way through then persists nothing for the notes it did not
+   * finish, and losing a watermark is the free direction. Ordering against the
+   * document bytes is safe by construction — `applyRemoteUpdate` hands each
+   * update to the store before this runs, and y-leveldb serialises its
+   * transactions — so the document is durable before the watermark that
+   * describes it.
+   */
+  private async flushWatermarks(): Promise<void> {
+    if (this.dirtyWatermarks.size === 0) return
+    const store = this.watermarkStore()
+    if (!store) {
+      // No store to write to. `watermarkStore()` has already dropped the
+      // in-memory copy if the store changed under this pass, which also empties
+      // the dirty set.
+      this.dirtyWatermarks.clear()
+      return
+    }
+
+    const pending = Array.from(this.dirtyWatermarks)
+    this.dirtyWatermarks.clear()
+    for (const noteId of pending) {
+      const appliedSequence = this.lastAppliedSequence.get(noteId)
+      if (appliedSequence === undefined) continue
+      await store.putSnapshotWatermark(noteId, {
+        appliedSequence,
+        snapshotRevision: this.mergedSnapshotRevision.get(noteId)
+      })
+    }
   }
 
   /**
@@ -288,6 +428,9 @@ export class CrdtSyncCoordinator {
     } else {
       this.mergedSnapshotRevision.delete(noteId)
     }
+    // Queued for the store from this one place too, for the same reason: only a
+    // baseline that reached the document may leave a durable record of itself.
+    this.dirtyWatermarks.add(noteId)
     log.debug('Applied CRDT snapshot baseline', {
       noteId,
       mode,
@@ -343,6 +486,13 @@ export class CrdtSyncCoordinator {
       log.debug('Skipping CRDT pull for a local-only note', { noteId })
       return false
     }
+
+    // Reconcile with the store BEFORE this pass records anything, not only in
+    // the flush at the end: the first reconcile of a session drops whatever the
+    // maps held, and doing it after the pass would drop the very watermark this
+    // pass just moved. Deliberately not a hydrate — this path never reads a
+    // watermark (FM4), it only moves one.
+    this.watermarkStore()
 
     const wasOpen = crdtProvider.getDoc(noteId) != null
     try {
@@ -461,6 +611,10 @@ export class CrdtSyncCoordinator {
       }
       return false
     } finally {
+      // The single-note path never *consults* a watermark — that is FM4, and it
+      // stays unconditional — but it does move one, and a move it did not record
+      // is a cold baseline the next sweep pays for.
+      await this.flushWatermarks()
       if (!wasOpen) {
         await crdtProvider.closeIfInactive(noteId)
       }
@@ -533,10 +687,12 @@ export class CrdtSyncCoordinator {
     signal: AbortSignal
   ): Promise<CrdtBatchPullResponse | null> {
     if (this.snapshotMetaUnsupported) return null
-    // Nothing merged this session means nothing can match, so every note would
-    // fall through to a fetch anyway and the probe would be a request spent to
-    // learn nothing. This is the first sweep after launch: it costs exactly
-    // what it cost before this feature existed.
+    // No watermark for any note in the chunk means nothing can match, so every
+    // note would fall through to a fetch anyway and the probe would be a request
+    // spent to learn nothing. Reached on a genuinely cold vault — a first sync,
+    // or a store rebuilt or quarantined under this one — and it costs exactly
+    // what it cost before this feature existed. `hydrateWatermarks` has already
+    // run, so a relaunch over an existing store is NOT cold here.
     if (!noteIds.some((noteId) => this.lastAppliedSequence.has(noteId))) return null
 
     const result = await withRetry(
@@ -600,9 +756,10 @@ export class CrdtSyncCoordinator {
     // this code did before the token existed.
     if (!snapshotMeta) return null
 
-    // A note this session has merged nothing for — never opened, absent from
-    // the local store, or a store rebuilt under it — has no watermark to
-    // compare, so it cannot be shown to already hold the baseline.
+    // A note with no watermark — never merged, absent from the local store, a
+    // store rebuilt or quarantined under it, or a store written by a build that
+    // predates the persisted watermark — cannot be shown to already hold the
+    // baseline. Unknown fetches; it never reads as sequence 0.
     const appliedSequence = this.lastAppliedSequence.get(noteId)
     if (appliedSequence === undefined) return null
 
@@ -651,6 +808,13 @@ export class CrdtSyncCoordinator {
     // broadcast and the pending-note replay call it directly — so a note's own
     // earlier debt would otherwise block its clear forever.
     try {
+      // PHASE 0 — hydrate. Read this chunk's watermarks out of the CRDT store,
+      // so the first sweep after a relaunch or a fresh sign-in can skip the
+      // baselines whose bodies are already sitting in that same store. No
+      // network, no docs opened; a note the store has no record for stays
+      // unknown and therefore takes the full path.
+      await this.hydrateWatermarks(noteIds)
+
       // PHASE 1 — probe. One request for the whole chunk, no docs opened.
       //
       // Every note in the chunk is still visited: this decides what a note
@@ -876,6 +1040,9 @@ export class CrdtSyncCoordinator {
         trackMainError('sync', 'crdt_apply_failed', err)
       }
     } finally {
+      // Before the docs are closed, so the store is still the one these
+      // watermarks describe.
+      await this.flushWatermarks()
       for (const noteId of syncOpenedNoteIds) {
         await crdtProvider.closeIfInactive(noteId)
       }

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -254,6 +254,31 @@ restarts is lost for that session. A mid-session load failure for a single doc
 falls back to seeding from the vault file instead of blocking the note from
 opening.
 
+### What else the store holds
+
+Besides each note's update log and state vector, the store holds one **snapshot
+watermark** per note — `{ appliedSequence, snapshotRevision }`, written as a
+y-leveldb document meta key. It is what lets the vault-wide sweep skip a
+snapshot baseline the document already contains, across app restarts and a fresh
+sign-in (see
+[the sweep's conditional baseline](/architecture/sync-protocol#the-vault-sweep-s-conditional-baseline)).
+
+It lives here rather than in the index DB or in settings because a watermark
+that outlives the document it describes makes the sweep skip that baseline
+forever, leaving a permanently stale body. Inside the store, the two share one
+lifetime by construction:
+
+- a meta key is inside the key range `clearDocument` clears, so purging a note
+  or setting a legacy document aside drops its watermark in the same operation;
+- quarantine, a rebuild and a re-path all move or destroy the whole directory,
+  so watermarks travel with the documents or vanish with them;
+- in-memory mode has no store handle at all, so nothing is read and nothing is
+  written — every note falls back to downloading its baseline.
+
+Losing a watermark costs one extra request. Keeping a stale one costs a note
+body, so every unknown — no record, an unreadable record, a store written by a
+build that predates the key — resolves to "download the baseline".
+
 ### Telling the user
 
 In-memory mode is silent by design for one launch — a store that quarantined

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -615,8 +615,24 @@ Everything else falls through to a fetch: an absent `snapshotMeta` key (an older
 server left out of the response, and any note this session holds no merged revision for. A missed
 skip costs one request; a wrong skip costs a note body.
 
-The bookkeeping is per session and in memory, so a rebuilt or re-pathed CRDT store loses it in the
-same operation and the next sweep re-downloads. Nothing is written to disk and no format changes.
+The bookkeeping — `{ appliedSequence, snapshotRevision }` per note, the **snapshot watermark** — is
+persisted **inside the per-vault CRDT store**, so the warm path survives an app restart and a fresh
+sign-in rather than paying a full cold sweep on every launch. It is a y-leveldb document meta key,
+which puts it in the same LevelDB, in the same directory, behind the same handle as the note's
+updates: there is no way to read a watermark without the store that holds the document it describes.
+
+That location is forced, not chosen. A watermark that outlives its document makes the sweep skip
+that baseline **forever** against a body that never had it. Because a meta key sits inside the key
+range `clearDocument` wipes, purging a note drops its watermark in the same operation; quarantining,
+rebuilding or re-pathing the store moves or destroys every watermark with every document; and a
+store that could not be opened at all leaves the provider in memory-only mode with no handle to read
+a watermark through. The watermark is never written for a snapshot that was not actually received —
+`GET /sync/crdt/snapshot/:noteId` answers `null` when the D1 row exists but its R2 blob is gone.
+
+The key is additive. A store written by a build that predates it has no record, which reads as
+**unknown → fetch**, never as "sequence 0 → skip", so the first sweep on such a store costs exactly
+what it cost before. A newer store read by an older build is inert: the older build never asks for
+the key. No protocol change, no D1 schema change, no IPC contract change.
 
 Two properties this does **not** change. The sweep stays exhaustive — every note in a chunk is still
 named in the probe, because the sweep is the only channel by which a body-only remote edit reaches a


### PR DESCRIPTION
**PR 3 of 5** in #1496. Stacked on **#1619** (`perf/crdt-conditional-snapshot-skip`), which is itself stacked on #1617. **#1541** stacks on top of this one. Base is `perf/crdt-conditional-snapshot-skip`, not `main`.

Closes #1613.

## What changed

#1619 made the sweep's snapshot GET conditional on an **in-session** watermark. Every launch still started with an empty map, so the first sweep of every session was a full cold sweep — 1,000 GETs and ten minutes for a vault whose bodies were already sitting on disk. This persists `{ appliedSequence, snapshotRevision }` per note, so the warm path crosses an app restart and a fresh sign-in.

Nothing about the skip *rule* changes. Both conditions from #1619 still hold, `applyCrdtIncrementals` is still unconditional (FM4), the sweep is still exhaustive, and a note absent from `snapshotMeta` still needs a watermark before it may skip, so `seedFromMarkdownPublic` still runs.

## Where the watermark lives, and why that location is forced

**Inside the per-vault CRDT store, as a y-leveldb document meta key** — the same LevelDB, the same directory, the same handle as the note's updates.

This is FM2 and it is the whole PR. A watermark that outlives the document it describes makes the sweep skip that baseline **forever** against a body that never had it. Losing a watermark costs one extra GET; keeping a stale one costs a note body. So the location has to make "the store is gone" *imply* "the watermark is gone", structurally rather than carefully:

| the store is… | what happens to the watermark | why |
| --- | --- | --- |
| purged for one note (`CrdtProvider.purge`, legacy partition) | dropped with the document | a meta key is `['v1', noteId, 'meta', …]`, inside the range `clearDocument` wipes |
| quarantined (`settleStoreStageFailure`) | moved aside with the directory | the whole directory is renamed; LevelDB recreates an empty leaf |
| rebuilt | absent | there is nothing in a fresh directory |
| re-pathed (`settlePendingCrdtStoreRename`) | travels **with** the documents | a directory rename moves both, and the old path holds neither |
| unopenable → in-memory mode | unreadable | `persistence === null`, so there is no handle to read one through |
| replaced under a running process (vault switch, quarantine-and-reopen) | in-memory copy dropped | `CrdtProvider.storeId` is minted per successful open and nulled on `destroy()`; the coordinator drops its working copy the moment it changes |

It is **not** in the index DB, not in `store` (electron-store), and not in any file with a lifetime of its own. A JSON file next to the store would have been readable in in-memory mode, where documents are seeded from vault markdown rather than restored from CRDT history — a stale watermark against exactly the doc that never had the state.

Carried forward from #1619: the watermark is recorded at the single point *after* the snapshot bytes are decrypted and applied, so a D1 row whose R2 blob is gone (`getSnapshot` → `null`, FM5) leaves no record. Every unknown falls through to **fetch**.

## On-disk format and compat plan

- **Format.** Meta key `memry.snapshotWatermark.v1`, per note, value `{ appliedSequence: number, snapshotRevision?: string }`, encoded by y-leveldb's own `encodeAny`. Versioned in the key, so a future shape change is a new key rather than a reinterpretation of bytes an older build wrote. `snapshotRevision` is written **absent**, never `undefined`, when there is none — sequence known, snapshot unknown, which the skip rule cannot match.
- **Migration.** None, and none is possible to need: the key is additive and there is no prior key to read.
- **Older store, new build.** No record → decodes to `null` → **unknown → fetch**, never "sequence 0 → skip". The probe is not even sent for a chunk with no watermarks, so such a store costs exactly what it cost before this feature existed. Mutation-verified, twice (below).
- **Downgrade — new store, older build.** Harmless. The older build never asks for the key, and `clearDocument` still sweeps it away with the document.
- **Decode is defensive.** A record that is not an object, has no numeric/finite/non-negative `appliedSequence`, or has a non-string `snapshotRevision` decodes to `null`. So does a read that throws. There is deliberately **no default value** anywhere in the path.
- **No protocol change, no D1 schema change, no IPC contract change, no new endpoint, no rate-limit class change.** Editing signed out / offline / with no account is untouched.

## Tests

**`apps/desktop/src/main/sync/crdt-snapshot-watermark.test.ts`** — the durable half against a **real y-leveldb store and real directory renames**, nothing mocked. Round-trip; `clearDocument` takes the watermark with the document; quarantine leaves a rebuilt store with neither; a re-path moves both and leaves the old path with neither; one vault's store never answers for another's; an older build's store reads as unknown; a downgrade still reads the document; and a table of nine malformed records that must all decode to unknown.

**`apps/desktop/src/main/sync/engine/crdt-persisted-snapshot-watermark.test.ts`** — the in-process half through a **real `CrdtSyncCoordinator`** against a scripted server, same discipline as #1619: every assertion is about which requests were actually issued. Relaunch (a second coordinator over the same store) issues **zero snapshot GETs**; the store being replaced under a running coordinator goes cold again; a rebuilt store goes cold; a store with no records goes cold with no probe; FM5 persists nothing; in-memory mode persists nothing, forever; the single-note path records a watermark it moved while still never consulting one (FM4); and a record below the server's prune watermark still fetches (FM3).

### Mutation evidence

Each mutation was applied to the committed source, proved applied with `git diff --stat`, run, then reverted. All 26 tests pass again after the last revert.

**1. THE MERGE GATE — remove the watermark drop from the store-teardown path.**

```
 apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts | 1 -
 1 file changed, 1 deletion(-)

     if (storeId !== this.watermarkStoreId) {
-      this.dropWatermarks()
       this.watermarkStoreId = storeId
```

```
FAIL  src/main/sync/engine/crdt-persisted-snapshot-watermark.test.ts >
  drops the in-memory watermarks when the store underneath them is replaced
Tests  1 failed | 17 passed (18)
```

Exactly its own test, nothing else.

**2. Give the watermark a second lifetime** — a module-level map read before the store, which is the bug the location exists to make impossible.

```
 apps/desktop/src/main/sync/crdt-snapshot-watermark.ts | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)

-  const raw = await store.getMeta(noteId, SNAPSHOT_WATERMARK_META_KEY)
+  const raw = sideChannel.get(noteId) ?? (await store.getMeta(noteId, SNAPSHOT_WATERMARK_META_KEY))
```

```
FAIL  is stored inside the document key range, so clearDocument takes it
FAIL  is quarantined with the store, so a rebuilt store starts with no watermarks
FAIL  travels with the store when the vault re-paths it, never apart from it
FAIL  is not readable across vaults: each vault store answers only for itself
FAIL  reads a store written by an older build as unknown, never as sequence 0
Tests  5 failed | 12 passed (17)
```

**3. An older build's store reads as sequence 0 instead of unknown** — at the hydrate.

```
 apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts | 3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)

-      const watermark = await store.getSnapshotWatermark(noteId)
-      if (!watermark) continue
+      const watermark = (await store.getSnapshotWatermark(noteId)) ?? { appliedSequence: 0 }
```

```
FAIL  reads a store with no records as unknown, so an older build sweeps exactly as it did
FAIL  carries the watermark across a relaunch: … zero snapshot GETs
FAIL  drops the in-memory watermarks when the store underneath them is replaced
FAIL  goes cold when a rebuilt store comes back empty, even across a relaunch
Tests  4 failed | 14 passed (18)
```

**4. The same defaulting one layer down**, in `decodeSnapshotWatermark`.

```
 apps/desktop/src/main/sync/crdt-snapshot-watermark.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

-  if (typeof raw !== 'object' || raw === null) return null
+  if (typeof raw !== 'object' || raw === null) return { appliedSequence: 0 }
```

```
Tests  9 failed | 8 passed (17)
```

## Verification

```
pnpm --filter @memry/desktop test:main   exit 0 — 545 files passed | 3 skipped (548),
                                                 7105 passed | 1 expected fail | 6 skipped (7112)
pnpm typecheck                           exit 0
pnpm lint                                exit 0 — 0 errors, 97 warnings, none in the changed files
git diff --check                         exit 0
pnpm docs:impact --base 2dddbd3a0 --strict   exit 0 — docs changed on this branch
pnpm docs:build                          exit 0
```
