### PR TITLE
perf(sync): split the CRDT sweep's probe pace from its apply pace

### DIFF
--- a/apps/desktop/src/main/sync/engine/crdt-sweep-pacing.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sweep-pacing.test.ts
@@ -1,0 +1,340 @@
+/**
+ * The sweep's pacing, measured rather than restated.
+ *
+ * A test that asserts `CRDT_SWEEP_CHUNK_NOTES === 100` is worthless: it passes
+ * for any pair of constants someone later writes down. So every number here is
+ * counted off a scripted HTTP layer driven by a REAL `CrdtSyncCoordinator` —
+ * how many `GET /sync/crdt/snapshot/:noteId` and how many
+ * `POST /sync/crdt/updates/batch` a chunk actually put on the wire — and then
+ * divided by the interval the pacer charges for that chunk. What is asserted is
+ * REQUESTS PER MINUTE against each server bucket, so any future edit to either
+ * constant that busts a budget fails here.
+ *
+ * The two mutations this file has to catch:
+ *   1. sizing the apply phase above `crdtProvider.inactiveDocCapacity` — the
+ *      32-doc LRU closes the docs the pass opened first and their updates are
+ *      dropped as "unopened doc";
+ *   2. shortening the GET pace so the cold sweep exceeds 50% of `crdt_pull` —
+ *      the 242-requests-in-4-seconds regime of #1466.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SyncContext } from './sync-context'
+import { CRDT_SWEEP_CHUNK_NOTES, crdtSweepChunkDelayMs, type CrdtPullCost } from './sync-context'
+import { CrdtSyncCoordinator } from './crdt-sync-coordinator'
+import type { CrdtSnapshotMeta } from '../http-client'
+
+const fetchCrdtSnapshotMock = vi.fn()
+const getFromServerMock = vi.fn()
+const postToServerMock = vi.fn()
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+vi.mock('../http-client', () => ({
+  fetchCrdtSnapshot: (...args: unknown[]) => fetchCrdtSnapshotMock(...args),
+  getFromServer: (...args: unknown[]) => getFromServerMock(...args),
+  postToServer: (...args: unknown[]) => postToServerMock(...args)
+}))
+
+vi.mock('../../crypto/index', () => ({ secureCleanup: vi.fn() }))
+vi.mock('../retry', () => ({
+  withRetry: async (fn: () => Promise<unknown>) => ({ value: await fn() })
+}))
+vi.mock('../crdt-encrypt', () => ({ decryptCrdtUpdate: () => new Uint8Array([9, 9, 9]) }))
+vi.mock('../../telemetry/diagnostics', () => ({ trackMainError: vi.fn() }))
+
+// sync-server routes/sync.ts: both keyed by deviceIdentifier, not by account.
+const CRDT_PULL_BUDGET_PER_MIN = 600
+const CRDT_BATCH_PULL_BUDGET_PER_MIN = 30
+/** §2.2's margin: the other half pays for editors, the priority batch and a second sweep. */
+const MARGIN = 0.5
+const DOC_CACHE = 32
+const SIGNER = 'device-a'
+
+interface BatchRequest {
+  notes: Array<{ noteId: string; since: number }>
+  limit: number
+}
+
+interface Wire {
+  /** One entry per `GET /sync/crdt/snapshot/:noteId` that reached the scripted server. */
+  snapshotGets: string[]
+  /** One entry per `POST /sync/crdt/updates/batch`, probe and apply rounds alike. */
+  batchRequests: BatchRequest[]
+  opened: string[]
+  maxConcurrentOpenDocs: number
+}
+
+/** What one paced chunk cost, and what that buys per minute at the charged pace. */
+interface ChunkRates {
+  cost: CrdtPullCost
+  delayMs: number
+  getsPerMinute: number
+  postsPerMinute: number
+}
+
+const rates = (cost: CrdtPullCost): ChunkRates => {
+  const delayMs = crdtSweepChunkDelayMs(cost)
+  return {
+    cost,
+    delayMs,
+    getsPerMinute: (cost.snapshotGets * 60_000) / delayMs,
+    postsPerMinute: (cost.batchPosts * 60_000) / delayMs
+  }
+}
+
+describe('CRDT sweep pacing', () => {
+  let wire: Wire
+  let openDocs: Set<string>
+  let watermarkStore: Map<string, unknown>
+  let sendSnapshotMeta: boolean
+  let coordinator: CrdtSyncCoordinator
+
+  /**
+   * A vault where every note's body is fully described by its snapshot: the
+   * server holds a snapshot blob and its metadata row, and nothing above it.
+   * That is the steady state a sweep spends almost all of its life in — the
+   * regime the old pacing paid 1,000 snapshot GETs to re-confirm.
+   */
+  const vault = (count: number): string[] => Array.from({ length: count }, (_, i) => `note-${i}`)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wire = { snapshotGets: [], batchRequests: [], opened: [], maxConcurrentOpenDocs: 0 }
+    openDocs = new Set()
+    watermarkStore = new Map()
+    sendSnapshotMeta = true
+
+    fetchCrdtSnapshotMock.mockImplementation(async (noteId: string) => {
+      wire.snapshotGets.push(noteId)
+      return {
+        snapshot: new Uint8Array([1]),
+        sequenceNum: 5,
+        signerDeviceId: SIGNER,
+        revision: 'rev-1'
+      }
+    })
+
+    postToServerMock.mockImplementation(async (_path: string, body: BatchRequest) => {
+      wire.batchRequests.push(body)
+      const notes: Record<
+        string,
+        {
+          updates: Array<{
+            sequenceNum: number
+            data: string
+            signerDeviceId: string
+            createdAt: number
+          }>
+          hasMore: boolean
+        }
+      > = {}
+      const snapshotMeta: Record<string, CrdtSnapshotMeta> = {}
+      for (const { noteId } of body.notes) {
+        notes[noteId] = { updates: [], hasMore: false }
+        snapshotMeta[noteId] = { sequenceNum: 5, revision: 'rev-1', signerDeviceId: SIGNER }
+      }
+      return sendSnapshotMeta ? { notes, snapshotMeta } : { notes }
+    })
+
+    const crdtProvider = {
+      inactiveDocCapacity: DOC_CACHE,
+      storeId: 'store-1',
+      isNoteLocalOnly: () => false,
+      getDoc: (noteId: string) => (openDocs.has(noteId) ? {} : undefined),
+      open: async (noteId: string) => {
+        wire.opened.push(noteId)
+        openDocs.add(noteId)
+        wire.maxConcurrentOpenDocs = Math.max(wire.maxConcurrentOpenDocs, openDocs.size)
+        return {}
+      },
+      closeIfInactive: async (noteId: string) => {
+        openDocs.delete(noteId)
+        return true
+      },
+      applyRemoteUpdate: () => {},
+      // Non-empty, so the markdown seed fallback never fires and cannot mask a
+      // baseline that was never fetched.
+      getStateVector: () => new Uint8Array([1, 2, 3, 4]),
+      seedFromMarkdownPublic: vi.fn(),
+      getSnapshotWatermark: async (noteId: string) => watermarkStore.get(noteId) ?? null,
+      putSnapshotWatermark: async (noteId: string, value: unknown) => {
+        watermarkStore.set(noteId, value)
+      }
+    }
+
+    const ctx = {
+      deps: {
+        crdtProvider,
+        getAccessToken: async () => 'token-1',
+        getVaultKey: async () => new Uint8Array([1, 2, 3])
+      },
+      abortController: new AbortController()
+    } as unknown as SyncContext
+
+    coordinator = new CrdtSyncCoordinator(ctx, async () => new Uint8Array([4, 5, 6]))
+  })
+
+  /**
+   * The drain `FullSyncRunner.pumpPacedCrdtPulls` performs: hand the coordinator
+   * one chunk of `CRDT_SWEEP_CHUNK_NOTES`, charge the interval against what that
+   * chunk actually spent, repeat. Returns one `ChunkRates` per chunk.
+   */
+  const sweep = async (noteIds: string[]): Promise<ChunkRates[]> => {
+    const out: ChunkRates[] = []
+    for (let i = 0; i < noteIds.length; i += CRDT_SWEEP_CHUNK_NOTES) {
+      const cost = await coordinator.pullCrdtForNotes(
+        noteIds.slice(i, i + CRDT_SWEEP_CHUNK_NOTES),
+        new AbortController().signal
+      )
+      out.push(rates(cost))
+    }
+    return out
+  }
+
+  const wallClockMs = (chunks: ChunkRates[]): number =>
+    chunks.slice(0, -1).reduce((ms, c) => ms + c.delayMs, 0)
+
+  const resetWire = (): void => {
+    wire.snapshotGets = []
+    wire.batchRequests = []
+    wire.opened = []
+    wire.maxConcurrentOpenDocs = 0
+  }
+
+  describe('#given a 1,000-note vault #when the sweep drains it', () => {
+    it('#then the cold pass stays inside BOTH buckets and finishes in ~3 min 20 s', async () => {
+      const chunks = await sweep(vault(1000))
+
+      // No note has a watermark yet, so no probe is sent at all — the cold path
+      // costs exactly what it cost before the probe existed. The POSTs here are
+      // the apply rounds: ceil(100 / 32) = 4 sub-chunks per chunk.
+      expect(wire.snapshotGets).toHaveLength(1000)
+      expect(wire.batchRequests).toHaveLength(4 * 10)
+      expect(wire.batchRequests.every((r) => r.limit === 100)).toBe(true)
+
+      for (const chunk of chunks) {
+        // What the pacer charged is what the wire saw, not a number the
+        // coordinator decided on its own.
+        expect(chunk.cost).toEqual({ snapshotGets: 100, batchPosts: 4 })
+        expect(chunk.getsPerMinute).toBeLessThanOrEqual(CRDT_PULL_BUDGET_PER_MIN * MARGIN)
+        expect(chunk.postsPerMinute).toBeLessThanOrEqual(CRDT_BATCH_PULL_BUDGET_PER_MIN * MARGIN)
+      }
+
+      // 100 GETs x 200 ms = 20 s per chunk, nine waits between ten chunks.
+      expect(wallClockMs(chunks)).toBe(9 * 20_000)
+      expect(wallClockMs(chunks)).toBeLessThan(4 * 60_000)
+    })
+
+    it('#then the warm pass costs one POST per 100 notes and finishes in ~40 s', async () => {
+      const notes = vault(1000)
+      await sweep(notes)
+      resetWire()
+
+      const chunks = await sweep(notes)
+
+      // The whole point of the split: the probe is not bound by the doc cache,
+      // so 100 notes are confirmed unchanged for ONE request and no document is
+      // opened at all.
+      expect(wire.snapshotGets).toHaveLength(0)
+      expect(wire.opened).toHaveLength(0)
+      expect(wire.batchRequests).toHaveLength(10)
+      expect(wire.batchRequests.every((r) => r.notes.length === 100 && r.limit === 1)).toBe(true)
+
+      for (const chunk of chunks) {
+        expect(chunk.cost).toEqual({ snapshotGets: 0, batchPosts: 1 })
+        expect(chunk.getsPerMinute).toBe(0)
+        expect(chunk.postsPerMinute).toBeLessThanOrEqual(CRDT_BATCH_PULL_BUDGET_PER_MIN * MARGIN)
+      }
+
+      expect(wallClockMs(chunks)).toBe(9 * 4_000)
+      expect(wallClockMs(chunks)).toBeLessThanOrEqual(60_000)
+    })
+
+    it('#then an old server pays one probe, latches, and costs exactly the cold pass', async () => {
+      const notes = vault(1000)
+      await sweep(notes)
+      // The server rolls back to a build with no `snapshotMeta`. The response is
+      // read through a cast with no runtime validation, so this is the key being
+      // absent on the wire, not assigned `undefined`.
+      sendSnapshotMeta = false
+      resetWire()
+
+      const chunks = await sweep(notes)
+
+      // One probe on the first chunk, then `snapshotMetaUnsupported` latches.
+      expect(wire.batchRequests.filter((r) => r.limit === 1)).toHaveLength(1)
+      expect(wire.snapshotGets).toHaveLength(1000)
+      expect(chunks[0].cost).toEqual({ snapshotGets: 100, batchPosts: 5 })
+      expect(chunks.slice(1).map((c) => c.cost)).toEqual(
+        Array.from({ length: 9 }, () => ({ snapshotGets: 100, batchPosts: 4 }))
+      )
+
+      for (const chunk of chunks) {
+        expect(chunk.getsPerMinute).toBeLessThanOrEqual(CRDT_PULL_BUDGET_PER_MIN * MARGIN)
+        expect(chunk.postsPerMinute).toBeLessThanOrEqual(CRDT_BATCH_PULL_BUDGET_PER_MIN * MARGIN)
+      }
+    })
+
+    it('#then the apply phase never opens more docs than the cache holds', async () => {
+      // MUTATION TARGET 1. The apply phase holds every one of its notes open
+      // from before the request is sent until that note's updates are applied,
+      // so past `inactiveDocCapacity` the LRU closes the ones it opened first
+      // and `applyRemoteUpdate` drops their updates as "unopened doc". The
+      // probe chunk is deliberately three times the cache; the apply sub-chunk
+      // must not be.
+      await sweep(vault(1000))
+
+      expect(wire.maxConcurrentOpenDocs).toBeLessThanOrEqual(DOC_CACHE)
+      // ...and it is the cache that bounds it, not the chunk being small.
+      expect(CRDT_SWEEP_CHUNK_NOTES).toBeGreaterThan(DOC_CACHE)
+    })
+
+    it('#then the sweep is exhaustive: every note is named in every pass', async () => {
+      const notes = vault(1000)
+
+      await sweep(notes)
+      // Cold: every note was opened and had its baseline fetched.
+      expect(new Set(wire.snapshotGets)).toEqual(new Set(notes))
+      resetWire()
+
+      await sweep(notes)
+      // Warm: no note is FILTERED OUT, only made cheap. The sweep is the sole
+      // channel by which a body-only remote edit reaches a device that missed
+      // the broadcast — note bodies never travel in the record change feed — so
+      // a note dropped here would go stale with no second chance.
+      const probed = new Set(wire.batchRequests.flatMap((r) => r.notes.map((n) => n.noteId)))
+      expect(probed).toEqual(new Set(notes))
+    })
+  })
+
+  describe('#given a chunk that needs more than one batch round', () => {
+    it('#then the extra POSTs are charged, so the batch bucket still holds', async () => {
+      // MUTATION TARGET 2's sibling, and the reason the counts are measured
+      // rather than predicted: `applyProbedNotes` loops while any note reports
+      // `hasMore`, so "one POST per chunk" is a FLOOR. A fixed interval would
+      // have multiplied the POST rate by the round count; charging the measured
+      // cost slows the sweep down instead.
+      let round = 0
+      postToServerMock.mockImplementation(async (_path: string, body: BatchRequest) => {
+        wire.batchRequests.push(body)
+        const notes: Record<string, { updates: never[]; hasMore: boolean }> = {}
+        const snapshotMeta: Record<string, CrdtSnapshotMeta> = {}
+        // Three rounds per apply sub-chunk, then done.
+        const hasMore = body.limit === 100 && ++round % 3 !== 0
+        for (const { noteId } of body.notes) {
+          notes[noteId] = { updates: [], hasMore }
+          snapshotMeta[noteId] = { sequenceNum: 5, revision: 'rev-1', signerDeviceId: SIGNER }
+        }
+        return { notes, snapshotMeta }
+      })
+
+      const chunks = await sweep(vault(100))
+
+      expect(chunks[0].cost.batchPosts).toBeGreaterThan(4)
+      expect(chunks[0].postsPerMinute).toBeLessThanOrEqual(CRDT_BATCH_PULL_BUDGET_PER_MIN * MARGIN)
+      expect(chunks[0].getsPerMinute).toBeLessThanOrEqual(CRDT_PULL_BUDGET_PER_MIN * MARGIN)
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -10,10 +10,21 @@ import {
 } from '../http-client'
 import { decryptCrdtUpdate } from '../crdt-encrypt'
 import { trackMainError } from '../../telemetry/diagnostics'
-import type { SyncContext } from './sync-context'
+import type { CrdtPullCost, SyncContext } from './sync-context'
 import type { CrdtProvider } from '../crdt-provider'
 
 const log = createLogger('CrdtSyncCoordinator')
+
+/**
+ * The server's cap on the `notes` array of `POST /sync/crdt/updates/batch`
+ * (`CrdtBatchPullSchema`, sync-server routes/sync.ts). A protocol fact, not a
+ * pacing knob: it bounds the probe, which opens no document and so is not bound
+ * by the doc cache, and it bounds an apply sub-chunk too, for the rare provider
+ * configured to hold more docs open than the server will accept in one request.
+ */
+const CRDT_BATCH_MAX_NOTES = 100
+
+const noCost = (): CrdtPullCost => ({ snapshotGets: 0, batchPosts: 0 })
 
 export type ResolveDeviceKey = (deviceId: string) => Promise<Uint8Array | null>
 
@@ -396,8 +407,12 @@ export class CrdtSyncCoordinator {
     noteId: string,
     token: string,
     vaultKey: Uint8Array,
-    mode: 'single' | 'batch'
+    mode: 'single' | 'batch',
+    cost: CrdtPullCost
   ): Promise<{ since: number; verified: boolean }> {
+    // Charged before the request, not after: a GET that throws still spent the
+    // bucket, and a failure is exactly when the next chunk most needs to wait.
+    cost.snapshotGets++
     const snapshotResult = await fetchCrdtSnapshot(noteId, token)
     if (!snapshotResult || !this.ctx.deps.crdtProvider) {
       return { since: 0, verified: true }
@@ -510,7 +525,10 @@ export class CrdtSyncCoordinator {
       // note stays flagged. Every failure path below re-owes it.
       this.pendingPulls.delete(noteId)
 
-      const baseline = await this.applySnapshotBaseline(noteId, token, vaultKey, 'single')
+      // The single-note path is not paced, so nothing reads this back. It is
+      // still counted rather than made optional, so there is one shape for
+      // "what a baseline costs" instead of two.
+      const baseline = await this.applySnapshotBaseline(noteId, token, vaultKey, 'single', noCost())
       let since = baseline.since
       let sawUnmerged = !baseline.verified
       // Owed a pull as well as flagged, matching the batch path: a signer that
@@ -626,7 +644,8 @@ export class CrdtSyncCoordinator {
     token: string,
     vaultKey: Uint8Array,
     signal?: AbortSignal
-  ): Promise<void> {
+  ): Promise<CrdtPullCost> {
+    const cost = noCost()
     const crdtProvider = this.ctx.deps.crdtProvider
     // The engine only holds an AbortController for the duration of a pull or a
     // push, so a caller outside one (the paced sweep) has to bring its own —
@@ -634,7 +653,7 @@ export class CrdtSyncCoordinator {
     // `ctx.abortController` unconditionally here made every out-of-cycle batch
     // return without doing anything.
     const effectiveSignal = signal ?? this.ctx.abortController?.signal
-    if (!crdtProvider || !effectiveSignal) return
+    if (!crdtProvider || !effectiveSignal) return cost
 
     // Same guard as the single-note path — see `applyCrdtIncrementals` — and
     // applied before the chunking below rather than inside it, so a vault with
@@ -646,28 +665,26 @@ export class CrdtSyncCoordinator {
         skipped: noteIds.length - syncable.length
       })
     }
-    if (syncable.length === 0) return
+    if (syncable.length === 0) return cost
 
-    // A pass holds every one of its notes open from before the request is sent
-    // until that note's updates are applied, so it must never open more than
-    // the provider keeps cached: past the limit the LRU closes the notes it
-    // opened first, applyRemoteUpdate drops their updates as "unopened doc",
-    // and the seed check below then sees no state vector at all. The passes
-    // that matter are exactly the oversized ones — a sign-in or a reconnect
-    // sweep hands over the whole vault, several times the limit.
-    //
-    // Chunking here also keeps each request under the server's 100-note cap on
-    // /sync/crdt/updates/batch, which a whole-vault pass otherwise blows past.
-    const chunkSize = crdtProvider.inactiveDocCapacity
-    for (let i = 0; i < syncable.length; i += chunkSize) {
-      if (effectiveSignal.aborted) return
+    // Chunked at the PROBE's ceiling, which is the server's 100-note cap on
+    // /sync/crdt/updates/batch and nothing else. The probe opens no document,
+    // so the doc cache does not bound it — the apply phase inside each chunk
+    // sub-chunks itself at `inactiveDocCapacity`, which is where that bound
+    // belongs. Sizing this loop at the doc cache instead would spend one probe
+    // POST per 32 notes rather than per 100, and the probe POST is the whole
+    // cost of a warm sweep.
+    for (let i = 0; i < syncable.length; i += CRDT_BATCH_MAX_NOTES) {
+      if (effectiveSignal.aborted) return cost
       await this.applyCrdtBatchChunk(
-        syncable.slice(i, i + chunkSize),
+        syncable.slice(i, i + CRDT_BATCH_MAX_NOTES),
         token,
         vaultKey,
-        effectiveSignal
+        effectiveSignal,
+        cost
       )
     }
+    return cost
   }
 
   /**
@@ -684,7 +701,8 @@ export class CrdtSyncCoordinator {
   private async probeBatchChunk(
     noteIds: string[],
     token: string,
-    signal: AbortSignal
+    signal: AbortSignal,
+    cost: CrdtPullCost
   ): Promise<CrdtBatchPullResponse | null> {
     if (this.snapshotMetaUnsupported) return null
     // No watermark for any note in the chunk means nothing can match, so every
@@ -696,8 +714,11 @@ export class CrdtSyncCoordinator {
     if (!noteIds.some((noteId) => this.lastAppliedSequence.has(noteId))) return null
 
     const result = await withRetry(
-      () =>
-        postToServer<CrdtBatchPullResponse>(
+      () => {
+        // Inside the retry callback, so an attempt the server 5xx'd is charged
+        // like any other: the bucket counts attempts, not successes.
+        cost.batchPosts++
+        return postToServer<CrdtBatchPullResponse>(
           '/sync/crdt/updates/batch',
           {
             notes: noteIds.map((noteId) => ({
@@ -713,7 +734,8 @@ export class CrdtSyncCoordinator {
             limit: 1
           },
           token
-        ),
+        )
+      },
       { maxRetries: 3, baseDelayMs: 2000, signal, retryOn429: false }
     ).then((r) => r.value)
 
@@ -785,28 +807,22 @@ export class CrdtSyncCoordinator {
     return appliedSequence
   }
 
+  /**
+   * One probe-sized chunk: at most `CRDT_BATCH_MAX_NOTES` notes, one probe POST
+   * for all of them, then the apply phase over whatever the probe could not
+   * settle — sub-chunked at the doc cache, because that phase holds its notes
+   * open across an await and the probe does not.
+   */
   private async applyCrdtBatchChunk(
     noteIds: string[],
     token: string,
     vaultKey: Uint8Array,
-    signal: AbortSignal
+    signal: AbortSignal,
+    cost: CrdtPullCost
   ): Promise<void> {
     const crdtProvider = this.ctx.deps.crdtProvider
     if (!crdtProvider) return
 
-    const syncOpenedNoteIds = new Set<string>()
-    // Per-pass record, so only a note this pass walked cleanly may have its
-    // standing flag cleared at the end.
-    const sawUnmerged = new Set<string>()
-    // No `pendingPulls.delete` here, deliberately — the single-note path needs
-    // one and this does not. Every caller of this path (the priority pull and
-    // the paced sweep chunks) is handed notes that `drainPendingPulls()` has
-    // already emptied out of the set, so a note that IS in it at this point was
-    // put back by something running concurrently, and its payload is not in
-    // this chunk. Keeping the flag standing is the right answer there.
-    // `pullCrdtForNote` has no drain in front of it — the `crdt_updated`
-    // broadcast and the pending-note replay call it directly — so a note's own
-    // earlier debt would otherwise block its clear forever.
     try {
       // PHASE 0 — hydrate. Read this chunk's watermarks out of the CRDT store,
       // so the first sweep after a relaunch or a fresh sign-in can skip the
@@ -822,7 +838,7 @@ export class CrdtSyncCoordinator {
       // body-only remote edit reaches a device by — note bodies never travel in
       // the record change feed — so a note dropped here would go stale with no
       // second chance.
-      const probe = await this.probeBatchChunk(noteIds, token, signal)
+      const probe = await this.probeBatchChunk(noteIds, token, signal, cost)
 
       // Notes whose baseline the probe proved redundant, mapped to the `since`
       // to resume from in place of the one a baseline would have produced.
@@ -867,11 +883,92 @@ export class CrdtSyncCoordinator {
 
       if (activeNoteIds.length === 0) return
 
-      // PHASE 2 — apply. Unchanged from the unconditional path, over the notes
-      // that actually have work.
+      // PHASE 2 — apply, in sub-chunks the provider can actually hold open.
+      //
+      // This is the LRU bound, and it is a hard one: a sub-chunk holds every
+      // one of its notes open from before the request is sent until that note's
+      // updates are applied, so past `inactiveDocCapacity` the cache closes the
+      // notes it opened first, `applyRemoteUpdate` drops their updates as
+      // "unopened doc", and the seed check then sees no state vector at all.
+      // Capped at the server's batch limit too, for a provider configured to
+      // hold more docs open than one request may name.
+      const applySize = Math.max(
+        1,
+        Math.min(crdtProvider.inactiveDocCapacity, CRDT_BATCH_MAX_NOTES)
+      )
+      for (let i = 0; i < activeNoteIds.length; i += applySize) {
+        if (signal.aborted) {
+          // The sub-chunks not reached were never walked, so they stay owed.
+          for (const noteId of activeNoteIds.slice(i)) this.owePendingPull(noteId)
+          return
+        }
+        await this.applyProbedNotes(
+          activeNoteIds.slice(i, i + applySize),
+          skipBaseline,
+          token,
+          vaultKey,
+          signal,
+          cost
+        )
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        log.debug('applyCrdtBatch aborted via signal')
+        return
+      }
+      log.warn('Failed to apply CRDT batch', {
+        error: err instanceof Error ? err.message : String(err)
+      })
+      // The chunk failed as a unit (a rate-limited or dead-lettered batch POST
+      // takes every note in it), so every note in it is owed a retry. A
+      // sub-chunk that already finished is re-queued too: re-applying a CRDT
+      // update is a no-op, its watermark is already flushed, and the next pass
+      // settles it from the probe for one request instead of dropping it.
+      for (const noteId of noteIds) this.owePendingPull(noteId)
+      // One undecryptable update aborts the remaining notes in the pass —
+      // engine-level sync_run_completed still reports success without this.
+      if (!this.applyFailureReported.has('__batch__')) {
+        this.applyFailureReported.add('__batch__')
+        trackMainError('sync', 'crdt_apply_failed', err)
+      }
+    }
+  }
+
+  /**
+   * The apply phase over one doc-cache-sized group: open, baseline where the
+   * probe could not rule it out, then loop the batch endpoint for incrementals.
+   *
+   * Its notes are opened and closed inside this call, so a chunk larger than the
+   * doc cache still never holds more than `inactiveDocCapacity` docs at once.
+   */
+  private async applyProbedNotes(
+    noteIds: string[],
+    skipBaseline: Map<string, number>,
+    token: string,
+    vaultKey: Uint8Array,
+    signal: AbortSignal,
+    cost: CrdtPullCost
+  ): Promise<void> {
+    const crdtProvider = this.ctx.deps.crdtProvider
+    if (!crdtProvider) return
+
+    const syncOpenedNoteIds = new Set<string>()
+    // Per-pass record, so only a note this pass walked cleanly may have its
+    // standing flag cleared at the end.
+    const sawUnmerged = new Set<string>()
+    // No `pendingPulls.delete` here, deliberately — the single-note path needs
+    // one and this does not. Every caller of this path (the priority pull and
+    // the paced sweep chunks) is handed notes that `drainPendingPulls()` has
+    // already emptied out of the set, so a note that IS in it at this point was
+    // put back by something running concurrently, and its payload is not in
+    // this chunk. Keeping the flag standing is the right answer there.
+    // `pullCrdtForNote` has no drain in front of it — the `crdt_updated`
+    // broadcast and the pending-note replay call it directly — so a note's own
+    // earlier debt would otherwise block its clear forever.
+    try {
       const sinceMap = new Map<string, number>()
 
-      for (const noteId of activeNoteIds) {
+      for (const noteId of noteIds) {
         const wasOpen = crdtProvider.getDoc(noteId) != null
         try {
           await crdtProvider.open(noteId, undefined, { skipSeed: true })
@@ -899,7 +996,7 @@ export class CrdtSyncCoordinator {
         }
 
         try {
-          const baseline = await this.applySnapshotBaseline(noteId, token, vaultKey, 'batch')
+          const baseline = await this.applySnapshotBaseline(noteId, token, vaultKey, 'batch', cost)
           sinceMap.set(noteId, baseline.since)
           if (!baseline.verified) {
             sawUnmerged.add(noteId)
@@ -911,7 +1008,7 @@ export class CrdtSyncCoordinator {
           // the pass. Skip it; the next pass retries it — which only holds
           // because it is re-queued here. This is the hottest failure path under
           // a rate limit: the baselines are one GET per note, so they are the
-          // bulk of a sweep's requests and the first thing the server sheds.
+          // bulk of a cold sweep's requests and the first thing the server sheds.
           log.warn('Failed to apply CRDT snapshot baseline, skipping note in batch', {
             noteId,
             error: err instanceof Error ? err.message : String(err)
@@ -935,12 +1032,17 @@ export class CrdtSyncCoordinator {
         const notes = Array.from(activeSince, ([noteId, since]) => ({ noteId, since }))
 
         const result = await withRetry(
-          () =>
-            postToServer<CrdtBatchPullResponse>(
+          () => {
+            // Every round of this loop is another POST on `crdt_batch_pull` —
+            // the "one POST per chunk" figure is a floor, so it is counted
+            // here rather than assumed by the pacer.
+            cost.batchPosts++
+            return postToServer<CrdtBatchPullResponse>(
               '/sync/crdt/updates/batch',
               { notes, limit: 100 },
               token
-            ),
+            )
+          },
           {
             maxRetries: 3,
             baseDelayMs: 2000,
@@ -999,11 +1101,12 @@ export class CrdtSyncCoordinator {
         this.clearUnmergedIfClean(noteId, sawUnmerged.has(noteId))
       }
 
-      // Seed only notes whose snapshot baseline succeeded. A note skipped at :205
-      // was opened with { skipSeed: true } and stays open with an empty state
-      // vector; seeding it here would persist local markdown, and the next pass's
-      // real server snapshot would then merge as an independent insertion →
-      // duplicated note body. Its baseline failed transiently; the next pass fetches it.
+      // Seed only notes whose snapshot baseline succeeded. A note whose baseline
+      // threw was opened with { skipSeed: true } and stays open with an empty
+      // state vector; seeding it here would persist local markdown, and the next
+      // pass's real server snapshot would then merge as an independent insertion
+      // → duplicated note body. Its baseline failed transiently; the next pass
+      // fetches it.
       for (const noteId of sinceMap.keys()) {
         const postVector = crdtProvider.getStateVector(noteId)
         // No vector at all means the doc is no longer open, which is not the
@@ -1022,26 +1125,10 @@ export class CrdtSyncCoordinator {
           })
         }
       }
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') {
-        log.debug('applyCrdtBatch aborted via signal')
-        return
-      }
-      log.warn('Failed to apply CRDT batch', {
-        error: err instanceof Error ? err.message : String(err)
-      })
-      // The chunk failed as a unit (a rate-limited or dead-lettered batch POST
-      // takes every note in it), so every note in it is owed a retry.
-      for (const noteId of noteIds) this.owePendingPull(noteId)
-      // One undecryptable update aborts the remaining notes in the pass —
-      // engine-level sync_run_completed still reports success without this.
-      if (!this.applyFailureReported.has('__batch__')) {
-        this.applyFailureReported.add('__batch__')
-        trackMainError('sync', 'crdt_apply_failed', err)
-      }
     } finally {
       // Before the docs are closed, so the store is still the one these
-      // watermarks describe.
+      // watermarks describe — and per sub-chunk rather than per chunk, so a
+      // later sub-chunk failing cannot lose what an earlier one merged.
       await this.flushWatermarks()
       for (const noteId of syncOpenedNoteIds) {
         await crdtProvider.closeIfInactive(noteId)
@@ -1085,30 +1172,31 @@ export class CrdtSyncCoordinator {
    * incrementals), which is what turned a 121-note sweep into 242 requests in
    * about four seconds. This path shares one incrementals POST across the whole
    * group, so the same 121 notes cost roughly 125 requests — the snapshot
-   * baselines are still one GET per note inside `applyCrdtBatch`, so this halves
-   * the traffic rather than collapsing it to a handful of calls. Pacing, not
-   * batching, is what actually keeps a sweep under the limit; see
-   * CRDT_SWEEP_CHUNK_NOTES.
+   * baselines are still one GET per note inside `applyCrdtBatch` whenever a
+   * baseline is actually needed, so on a cold group this halves the traffic
+   * rather than collapsing it to a handful of calls. A warm group costs one
+   * probe POST and nothing else. Pacing, not batching, is what actually keeps a
+   * sweep under the limit; see CRDT_SWEEP_CHUNK_NOTES.
    *
    * Credentials are resolved once per group instead of once per note, which also
    * removes a keychain read per note. A group that cannot get them is owed a
    * retry rather than dropped: the sweep hands this method the whole vault, so
    * silently returning would strand every stale body until the next sweep.
    */
-  async pullCrdtForNotes(noteIds: string[], signal?: AbortSignal): Promise<void> {
-    if (noteIds.length === 0) return
+  async pullCrdtForNotes(noteIds: string[], signal?: AbortSignal): Promise<CrdtPullCost> {
+    if (noteIds.length === 0) return noCost()
     log.debug('pullCrdtForNotes entered', { count: noteIds.length })
 
     const token = await this.ctx.deps.getAccessToken()
     if (!token) {
       for (const noteId of noteIds) this.owePendingPull(noteId)
-      return
+      return noCost()
     }
 
     const vaultKey = await this.ctx.deps.getVaultKey()
     if (!vaultKey) {
       for (const noteId of noteIds) this.owePendingPull(noteId)
-      return
+      return noCost()
     }
 
     // A caller that can outlive this group passes its own signal: the paced
@@ -1118,8 +1206,12 @@ export class CrdtSyncCoordinator {
     // never fires, which is the behaviour the engine's own controller gave.
     const effectiveSignal = signal ?? new AbortController().signal
     try {
-      await this.applyCrdtBatch(noteIds, token, vaultKey, effectiveSignal)
-      log.debug('pullCrdtForNotes completed', { count: noteIds.length })
+      const cost = await this.applyCrdtBatch(noteIds, token, vaultKey, effectiveSignal)
+      log.debug('pullCrdtForNotes completed', { count: noteIds.length, ...cost })
+      // What this group actually spent, per bucket. The paced sweep charges its
+      // next interval against it — see `crdtSweepChunkDelayMs`. Every other
+      // caller (the un-paced priority batch) discards it.
+      return cost
     } finally {
       secureCleanup(vaultKey)
     }

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
@@ -6,7 +6,11 @@ import {
   CRDT_RECONNECT_SWEEP_FLOOR_MS,
   CRDT_SWEEP_CHUNK_INTERVAL_MS,
   CRDT_SWEEP_CHUNK_NOTES,
+  CRDT_SWEEP_MS_PER_BATCH_POST,
+  CRDT_SWEEP_MS_PER_SNAPSHOT_GET,
+  crdtSweepChunkDelayMs,
   SYNC_STATE_KEYS,
+  type CrdtPullCost,
   type SyncContext
 } from './sync-context'
 import type { SyncStateManager } from './sync-state-manager'
@@ -60,7 +64,19 @@ class FakeCrdtSync {
    */
   unmerged = new Set<string>()
   pullCrdtForNote = vi.fn(async () => {})
-  pullCrdtForNotes = vi.fn(async (_noteIds: string[], _signal?: AbortSignal) => {})
+  /**
+   * The real coordinator reports what the chunk spent, per rate-limit bucket,
+   * and the runner charges its next interval against it. A warm chunk — one
+   * probe POST, no snapshot GETs — is the default here, which lands exactly on
+   * CRDT_SWEEP_CHUNK_INTERVAL_MS. Regime-by-regime rates are pinned in
+   * crdt-sweep-pacing.test.ts against a real coordinator.
+   */
+  pullCrdtForNotes = vi.fn(
+    async (_noteIds: string[], _signal?: AbortSignal): Promise<CrdtPullCost> => ({
+      snapshotGets: 0,
+      batchPosts: 1
+    })
+  )
 
   get hasUnmergedNotes(): boolean {
     return this.unmerged.size > 0
@@ -1110,23 +1126,73 @@ describe('FullSyncRunner', () => {
       return h.crdtSync.pullCrdtForNotes.mock.calls.flatMap(([ids]) => ids)
     }
 
-    it('#then the chunk size and interval stay inside BOTH server rate limits', () => {
-      // The server meters these two paths in separate buckets, both keyed by
-      // deviceId rather than by account (sync-server routes/sync.ts:476-501):
-      //   GET  /sync/crdt/snapshot/:noteId + /sync/crdt/updates -> 600 / 60s
-      //   POST /sync/crdt/updates/batch                         ->  30 / 60s
-      // A chunk of N notes costs N snapshot GETs (the batch endpoint batches the
-      // incrementals, not the baselines) plus at least one batch POST, so tuning
-      // either constant has to be checked against both ceilings — the batch
-      // bucket is twenty times tighter and easy to miss.
-      const chunksPerMinute = 60_000 / CRDT_SWEEP_CHUNK_INTERVAL_MS
-      const snapshotGetsPerMinute = CRDT_SWEEP_CHUNK_NOTES * chunksPerMinute
-      const batchPostsPerMinute = chunksPerMinute
+    // The server meters the two phases of a chunk in separate buckets, both
+    // keyed by deviceId rather than by account (sync-server routes/sync.ts):
+    //   GET  /sync/crdt/snapshot/:noteId + /sync/crdt/updates -> 600 / 60s
+    //   POST /sync/crdt/updates/batch                         ->  30 / 60s
+    // The margin is 50% of each, leaving the rest for editor traffic, the
+    // un-paced priority batch, broadcast-driven single-note pulls and a second
+    // sweep a flapping socket may start.
+    const GET_BUDGET_PER_MIN = 600
+    const POST_BUDGET_PER_MIN = 30
+    const MARGIN = 0.5
 
-      // No doubling for a second device: the buckets are per device, so a second
-      // device sweeping at the same time spends its own.
-      expect(snapshotGetsPerMinute).toBeLessThan(600)
-      expect(batchPostsPerMinute).toBeLessThan(30)
+    const ratesFor = (cost: CrdtPullCost): { gets: number; posts: number } => {
+      const chunksPerMinute = 60_000 / crdtSweepChunkDelayMs(cost)
+      return {
+        gets: cost.snapshotGets * chunksPerMinute,
+        posts: cost.batchPosts * chunksPerMinute
+      }
+    }
+
+    it.each([
+      // Warm: the probe settles every note. One POST, no GET, no doc opened.
+      ['warm', { snapshotGets: 0, batchPosts: 1 }],
+      // Cold: no watermark anywhere, so no probe is sent at all — 100 baselines
+      // and ceil(100/32) = 4 apply rounds.
+      ['cold', { snapshotGets: CRDT_SWEEP_CHUNK_NOTES, batchPosts: 4 }],
+      // Old server: one wasted probe on the first chunk, then the flag latches
+      // and the cost is the cold one exactly.
+      ['old server, first chunk', { snapshotGets: CRDT_SWEEP_CHUNK_NOTES, batchPosts: 5 }],
+      // A cold chunk whose notes have a real backlog: applyCrdtBatchChunk loops
+      // while any note reports `hasMore`, so the POST count is a floor. Four
+      // rounds per sub-chunk is the case a fixed interval would have blown the
+      // batch bucket on.
+      ['cold, R = 4 batch rounds', { snapshotGets: CRDT_SWEEP_CHUNK_NOTES, batchPosts: 16 }]
+    ])('#then the %s regime stays inside BOTH buckets', (_name, cost: CrdtPullCost) => {
+      const { gets, posts } = ratesFor(cost)
+
+      expect(gets).toBeLessThanOrEqual(GET_BUDGET_PER_MIN * MARGIN)
+      expect(posts).toBeLessThanOrEqual(POST_BUDGET_PER_MIN * MARGIN)
+    })
+
+    it('#then the two phases are paced by their own bucket, not a shared one', () => {
+      // The point of the split. A warm chunk spends only `crdt_batch_pull`, so
+      // it must not be held back by the GET pace; a cold chunk of the same 100
+      // notes spends `crdt_pull` a hundred times over and must be.
+      const warm = crdtSweepChunkDelayMs({ snapshotGets: 0, batchPosts: 1 })
+      const cold = crdtSweepChunkDelayMs({ snapshotGets: CRDT_SWEEP_CHUNK_NOTES, batchPosts: 4 })
+
+      expect(warm).toBe(CRDT_SWEEP_MS_PER_BATCH_POST)
+      expect(cold).toBe(CRDT_SWEEP_CHUNK_NOTES * CRDT_SWEEP_MS_PER_SNAPSHOT_GET)
+      expect(cold).toBeGreaterThan(warm)
+
+      // 1,000 notes: ten chunks either way, but ~40 s warm against ~3 min 20 s
+      // cold — and ten minutes before this pacing existed.
+      const chunks = Math.ceil(1000 / CRDT_SWEEP_CHUNK_NOTES)
+      expect(chunks * warm).toBeLessThanOrEqual(60_000)
+      expect(chunks * cold).toBeLessThanOrEqual(4 * 60_000)
+    })
+
+    it('#then a chunk that spends more POSTs waits longer instead of bursting', () => {
+      // The R > 1 floor. Every extra `hasMore` round is another POST on the
+      // batch bucket, so the count is measured rather than assumed: the sweep
+      // slows down, it does not overrun.
+      const one = crdtSweepChunkDelayMs({ snapshotGets: 0, batchPosts: 1 })
+      const eight = crdtSweepChunkDelayMs({ snapshotGets: 0, batchPosts: 8 })
+
+      expect(eight).toBe(one * 8)
+      expect((8 * 60_000) / eight).toBeLessThanOrEqual(POST_BUDGET_PER_MIN * MARGIN)
     })
 
     it('#then the whole sweep leaves through the batch path, never one pull per note', async () => {
@@ -1146,16 +1212,16 @@ describe('FullSyncRunner', () => {
     })
 
     it('#then only one chunk goes out per interval, whatever the vault size', async () => {
-      const h = sweepingHarness(60)
+      const h = sweepingHarness(250)
 
       await h.runner.run()
 
       expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(1)
       expect(h.crdtSync.pullCrdtForNotes.mock.calls[0][0]).toHaveLength(CRDT_SWEEP_CHUNK_NOTES)
 
-      // Nothing more may go out before the interval elapses: 25 notes is 25
-      // snapshot GETs plus one batch POST, and four of those per minute is what
-      // keeps a sweeping device near 104 requests/minute.
+      // Nothing more may go out before the charged interval elapses. The fake
+      // reports a warm chunk — one probe POST, no snapshot GETs — which charges
+      // exactly CRDT_SWEEP_CHUNK_INTERVAL_MS.
       await vi.advanceTimersByTimeAsync(CRDT_SWEEP_CHUNK_INTERVAL_MS - 1)
       expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(1)
 
@@ -1167,19 +1233,44 @@ describe('FullSyncRunner', () => {
 
       // Paced, not sampled: every note is still covered, exactly once.
       const pulled = pulledNoteIds(h)
-      expect(pulled).toHaveLength(60)
-      expect(new Set(pulled)).toEqual(new Set(noteIds(60)))
+      expect(pulled).toHaveLength(250)
+      expect(new Set(pulled)).toEqual(new Set(noteIds(250)))
     })
 
-    it('#then a chunk never outgrows the provider doc cache', async () => {
-      // Handing applyCrdtBatch more notes than it can hold open makes it split
-      // the chunk internally and spend an extra batch POST doing it — the exact
-      // request the pacing arithmetic budgets for.
-      const h = sweepingHarness(60, fakeCrdtProvider({ inactiveDocCapacity: 4 }))
+    it('#then the paced chunk is the probe size, NOT the doc cache size', async () => {
+      // The split. The probe opens no document, so the doc cache cannot bound
+      // it — the server's 100-note cap on the batch endpoint is the only
+      // ceiling. Clamping here would spend one probe POST per 32 notes instead
+      // of per 100, and the probe POST is the whole cost of a warm sweep.
+      // The doc-cache bound still exists; it moved to the apply phase inside
+      // applyCrdtBatch, and is pinned in crdt-sweep-pacing.test.ts.
+      const h = sweepingHarness(250, fakeCrdtProvider({ inactiveDocCapacity: 4 }))
 
       await h.runner.run()
 
-      expect(h.crdtSync.pullCrdtForNotes.mock.calls[0][0]).toHaveLength(4)
+      expect(h.crdtSync.pullCrdtForNotes.mock.calls[0][0]).toHaveLength(CRDT_SWEEP_CHUNK_NOTES)
+    })
+
+    it('#then a chunk that spent GETs pushes the next chunk out', async () => {
+      // A cold chunk is charged against `crdt_pull` rather than the floor, so
+      // the next one waits the GET pace, not the probe pace.
+      const h = sweepingHarness(250)
+      h.crdtSync.pullCrdtForNotes.mockResolvedValue({
+        snapshotGets: CRDT_SWEEP_CHUNK_NOTES,
+        batchPosts: 4
+      })
+
+      await h.runner.run()
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(1)
+
+      // The warm pace would have fired a second chunk by now.
+      await vi.advanceTimersByTimeAsync(CRDT_SWEEP_CHUNK_INTERVAL_MS)
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(
+        CRDT_SWEEP_CHUNK_NOTES * CRDT_SWEEP_MS_PER_SNAPSHOT_GET - CRDT_SWEEP_CHUNK_INTERVAL_MS
+      )
+      expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(2)
     })
 
     it('#then a note with a live editor is pulled before the paced queue', async () => {
@@ -1196,7 +1287,7 @@ describe('FullSyncRunner', () => {
     })
 
     it('#then a second sweep joins the running drain instead of starting its own', async () => {
-      const h = sweepingHarness(60)
+      const h = sweepingHarness(250)
 
       await h.runner.run()
       // A reconnect past the floor, so the gate sweeps the vault again while the
@@ -1212,17 +1303,17 @@ describe('FullSyncRunner', () => {
       expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(2)
 
       // ...and the second sweep re-queues the vault once, not once per copy
-      // already waiting. 25 pulled by the first chunk, then the 60 the second
-      // sweep queued — the 35 still waiting were deduped into it. An array queue
-      // would have carried those 35 twice and pulled 120.
+      // already waiting. 100 pulled by the first chunk, then the 250 the second
+      // sweep queued — the 150 still waiting were deduped into it. An array
+      // queue would have carried those 150 twice and pulled 500.
       await vi.advanceTimersByTimeAsync(CRDT_SWEEP_CHUNK_INTERVAL_MS * 5)
-      expect(pulledNoteIds(h)).toHaveLength(CRDT_SWEEP_CHUNK_NOTES + 60)
+      expect(pulledNoteIds(h)).toHaveLength(CRDT_SWEEP_CHUNK_NOTES + 250)
     })
 
     it('#then disposing the runner cancels the rest of the paced sweep', async () => {
       // Engine teardown (vault switch, sign-out): a timer left armed keeps
       // pulling against a vault this engine no longer owns.
-      const h = sweepingHarness(60)
+      const h = sweepingHarness(250)
 
       await h.runner.run()
       expect(h.crdtSync.pullCrdtForNotes).toHaveBeenCalledTimes(1)

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.ts
@@ -10,6 +10,7 @@ import {
   CRDT_RECONNECT_SWEEP_FLOOR_MS,
   CRDT_SWEEP_CHUNK_INTERVAL_MS,
   CRDT_SWEEP_CHUNK_NOTES,
+  crdtSweepChunkDelayMs,
   SYNC_STATE_KEYS
 } from './sync-context'
 import type { SyncStateManager } from './sync-state-manager'
@@ -503,9 +504,13 @@ export class FullSyncRunner {
       }
 
       if (priority.length > 0) {
-        this.actions.scheduleSync(() =>
-          this.crdtSync.pullCrdtForNotes(priority, this.sweepPullSignal())
-        )
+        this.actions.scheduleSync(async () => {
+          // Its cost is deliberately discarded: this batch jumps the pace by
+          // design — the note the user is looking at must not wait behind a
+          // catch-up — and it is bounded by the number of open editors, which
+          // is what the other half of each bucket's margin is reserved for.
+          await this.crdtSync.pullCrdtForNotes(priority, this.sweepPullSignal())
+        })
       }
     }
 
@@ -536,13 +541,13 @@ export class FullSyncRunner {
       return
     }
 
-    // Never hand `applyCrdtBatch` more notes than the provider can hold open at
-    // once: it would split the chunk internally and spend an extra batch POST
-    // doing so, which is exactly the request the pacing arithmetic budgets for.
-    const chunkSize = Math.max(
-      1,
-      Math.min(CRDT_SWEEP_CHUNK_NOTES, crdtProvider.inactiveDocCapacity)
-    )
+    // The PROBE's size, not the apply phase's. One `POST /sync/crdt/updates/batch`
+    // covers the whole chunk without opening a document, so the doc cache does
+    // not bound it — `applyCrdtBatch` sub-chunks the apply phase at
+    // `inactiveDocCapacity` itself, which is where that bound belongs. Clamping
+    // here to the doc cache instead would spend one probe POST per 32 notes,
+    // and the probe POST is the entire cost of a warm sweep.
+    const chunkSize = Math.max(1, CRDT_SWEEP_CHUNK_NOTES)
     const chunk: string[] = []
     for (const noteId of this.pacedCrdtPullQueue) {
       if (chunk.length >= chunkSize) break
@@ -557,8 +562,21 @@ export class FullSyncRunner {
 
     this.pacedCrdtChunkInFlight = true
     this.actions.scheduleSync(async () => {
+      // The floor covers the throw: a chunk that failed part-way still spent
+      // whatever it spent, and the count is lost with the rejection. Waiting the
+      // minimum is the conservative reading, and every note in it is owed to the
+      // next cycle anyway.
+      let delayMs = CRDT_SWEEP_CHUNK_INTERVAL_MS
       try {
-        await this.crdtSync.pullCrdtForNotes(chunk, this.sweepPullSignal())
+        // The interval is CHARGED, not fixed. A warm chunk of 100 costs one
+        // probe POST and waits 4 s; the same 100 notes cold cost 100 snapshot
+        // GETs and four apply rounds and wait 20 s. One constant cannot be
+        // right for both, and the client cannot know which it is in until the
+        // chunk has run — that is what the probe is for. See
+        // `crdtSweepChunkDelayMs` for the full derivation.
+        delayMs = crdtSweepChunkDelayMs(
+          await this.crdtSync.pullCrdtForNotes(chunk, this.sweepPullSignal())
+        )
       } finally {
         // Re-arm from the chunk's completion, not from when it was issued, so a
         // slow chunk stretches the interval instead of overlapping the next one.
@@ -566,18 +584,23 @@ export class FullSyncRunner {
         // queue: they are owed to the next cycle, deliberately, because retrying
         // them here would just re-run into whatever refused them.
         this.pacedCrdtChunkInFlight = false
-        this.armPacedCrdtPullTimer()
+        this.armPacedCrdtPullTimer(delayMs)
       }
     })
   }
 
-  private armPacedCrdtPullTimer(): void {
+  /**
+   * `delayMs` defaults to the floor, which is what the blocked-drain path wants:
+   * offline, or a fullSync holding `scheduleSync`, spent no request budget, so
+   * it only needs to look again soon.
+   */
+  private armPacedCrdtPullTimer(delayMs: number = CRDT_SWEEP_CHUNK_INTERVAL_MS): void {
     if (this.pacedCrdtPullTimer || this.pacedCrdtPullQueue.size === 0) return
 
     this.pacedCrdtPullTimer = setTimeout(() => {
       this.pacedCrdtPullTimer = null
       this.pumpPacedCrdtPulls()
-    }, CRDT_SWEEP_CHUNK_INTERVAL_MS)
+    }, delayMs)
     this.pacedCrdtPullTimer.unref?.()
   }
 }

--- a/apps/desktop/src/main/sync/engine/sync-context.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.ts
@@ -172,9 +172,9 @@ export const CRDT_FULL_SWEEP_MIN_INTERVAL_MS = 15 * 60 * 1000
 // edits inside a minute. Unlike the fallback interval this one is only ever
 // paid once per burst, so it does not need to be conservative.
 export const CRDT_RECONNECT_SWEEP_FLOOR_MS = 60 * 1000
-// How many notes one paced CRDT catch-up chunk pulls, and how long the next
-// chunk waits. Together these are the only thing keeping a whole-vault sweep
-// under the server's rate limits, so they are set from those limits backwards.
+// The pacing of the vault-wide CRDT catch-up sweep. These are the only thing
+// keeping a whole-vault sweep under the server's rate limits, so they are set
+// from those limits backwards.
 //
 // There are TWO independent budgets, and a sweep has to fit inside both:
 //
@@ -182,49 +182,134 @@ export const CRDT_RECONNECT_SWEEP_FLOOR_MS = 60 * 1000
 //   GET  /sync/crdt/updates           }  600 requests / 60 s
 //   POST /sync/crdt/updates/batch        `crdt_batch_pull`, 30 requests / 60 s
 //
-// Both are keyed by deviceId, NOT by account (sync.ts:476-501), so a second
+// Both are keyed by deviceId, NOT by account (sync.ts:489-501), so a second
 // device sweeping at the same time spends its own budget instead of eating into
-// this one. One chunk of N notes through applyCrdtBatch costs N snapshot GETs —
-// the batch endpoint batches the incrementals, NOT the snapshot baselines,
-// which are still fetched one note at a time — plus at least one batch POST.
+// this one.
 //
-//   25 notes per chunk, 60_000 / 15_000 = 4 chunks per minute
-//   GET  budget: 25 x 4 = 100/min against 600 — 16.7% of the bucket
-//   POST budget:  1 x 4 =   4/min against  30 — 13.3% of the bucket
+// MARGIN: never more than 50% of either bucket. The other half pays for editor
+// traffic, the un-paced priority batch that jumps the queue for notes with a
+// live editor, broadcast-driven single-note pulls, and a second sweep a flapping
+// socket may start before the first has drained. So the ceilings this pacing is
+// derived against are 300 GET/min and 15 POST/min, and the per-request time
+// slices that produce them are
 //
-// The GET bucket is still the tighter of the two, but only just, and only when
-// the cadence is scaled: 600 GETs buy 24 chunks a minute at 25 notes each,
-// against the batch bucket's 30. Neither is close to binding at the current
-// pacing. These constants were derived when this comment read 300 and doubled
-// the cost for a second device, i.e. against an effective 150 — which is where
-// the old "~30% spare" came from. The real figure is a sixth of one bucket and
-// an eighth of the other. Re-tuning the pacing is its own change with its own
-// arithmetic; this note only records where the ceilings actually are.
+//   60_000 / 300 = 200 ms per snapshot GET   -> CRDT_SWEEP_MS_PER_SNAPSHOT_GET
+//   60_000 /  15 =   4_000 ms per batch POST -> CRDT_SWEEP_MS_PER_BATCH_POST
 //
-// Only the RATE matters, not the total: a 1,000-note vault is 40 chunks and 40
-// batch POSTs, which would blow the 30/60s batch bucket if fired at once but is
-// 4/min spread across the ten minutes the paced sweep takes. That is the whole
-// point of pacing — cost per minute is CONSTANT in vault size, only the duration
-// grows, so no vault can reproduce the 242-requests-in-4-seconds storm that had
-// 92 of 121 notes coming back "Too many requests" and silently keeping stale
-// bodies. Slow is the correct trade: this is a catch-up, not a race, and the
-// notes the user actually has open skip the queue entirely.
+// TWO PACES, NOT ONE. A chunk now runs in two phases that spend different
+// buckets, and they cannot share a cadence:
 //
-// The POST figure is a floor, not an exact count: applyCrdtBatchChunk loops
-// while any note reports `hasMore`, so a chunk costs one POST per round. The
-// batch budget only binds if chunks average more than seven rounds — i.e. over
-// 700 queued updates spread across one chunk's notes, which is a first-sync
-// backlog, not steady state. It is also no longer destructive if it happens: a
-// rate-limited batch re-queues its whole chunk for the next cycle instead of
-// dropping it.
+//   - PROBE: one POST /sync/crdt/updates/batch for the whole chunk, `limit: 1`.
+//     Spends `crdt_batch_pull` only. It opens no document and downloads no
+//     snapshot, so the 32-doc LRU does not bound it and the only ceiling on its
+//     size is the server's own 100-note cap on that endpoint's `notes` array
+//     (CrdtBatchPullSchema, sync.ts). Hence CRDT_SWEEP_CHUNK_NOTES = 100.
+//   - APPLY: for the notes the probe could not settle, open the doc, fetch the
+//     snapshot baseline if it is not already the one in the doc, then loop the
+//     batch endpoint for incrementals. Spends `crdt_pull` (one GET per note) and
+//     `crdt_batch_pull` (one POST per round). It holds every one of its notes
+//     open across an await, so it is hard-bounded by
+//     `crdtProvider.inactiveDocCapacity` — 32 — and sub-chunks inside
+//     `applyCrdtBatch` at that size.
+//
+// A single (chunk, interval) pair cannot serve both. 100 notes every 4 s is the
+// right warm pace and 1,500 GET/min if the chunk turns out to be cold; 32 notes
+// every 6.4 s is the right cold pace and takes a warm 1,000-note vault three and
+// a half minutes to confirm nothing changed. So the interval is not fixed: a
+// chunk is CHARGED for what it actually spent, and the next chunk waits until
+// both buckets have earned it back —
+//
+//   delay = max(CRDT_SWEEP_CHUNK_INTERVAL_MS,
+//               batchPosts    * CRDT_SWEEP_MS_PER_BATCH_POST,
+//               snapshotGets  * CRDT_SWEEP_MS_PER_SNAPSHOT_GET)
+//
+// which is `crdtSweepChunkDelayMs` below, fed by the request counts
+// `pullCrdtForNotes` returns. Both rates are then <= 50% by construction, in
+// every regime, without the client having to know in advance which regime it is
+// in — which it cannot, because that is what the probe is for.
+//
+// THE THREE REGIMES, V = 1,000 notes.
+//
+//   Warm (watermarks present, nothing changed remotely):
+//     10 chunks x 100 notes. Each: 1 probe POST, 0 GETs, 0 docs opened.
+//     delay = max(4_000, 1 x 4_000, 0) = 4 s
+//     -> 15 POST/min = 50% of 30, 0 GET/min = 0% of 600, ~40 s wall clock.
+//
+//   Cold (first sync, or a store rebuilt/quarantined under this one):
+//     10 chunks x 100 notes. No note has a watermark, so NO probe is sent at
+//     all — that path costs exactly what it cost before the probe existed.
+//     Each: 100 GETs + ceil(100/32) = 4 apply POSTs (at R = 1 round each).
+//     delay = max(4_000, 4 x 4_000, 100 x 200) = 20 s
+//     -> 300 GET/min = 50% of 600, 12 POST/min = 40% of 30, ~3 min 20 s.
+//
+//   Old server (no `snapshotMeta` in the batch response):
+//     one wasted probe on the first chunk, then `snapshotMetaUnsupported`
+//     latches and the arithmetic is the cold one exactly.
+//
+// Before this, at 25 notes / 15 s with an unconditional baseline, all three
+// regimes were 100 GET/min, 4 POST/min and TEN MINUTES.
+//
+// THE POST COUNT IS A FLOOR, NOT AN EXACT COUNT, and that is why the counts are
+// measured rather than predicted. `applyCrdtBatchChunk` loops while any note
+// reports `hasMore`, so an apply sub-chunk costs one POST per round R. At R = 1
+// the GET slice binds (20 s > 16 s); from R = 2 the POST slice binds
+// (4R x 4_000 > 20_000 once R > 1.25) and the sweep slows down instead of
+// bursting through the batch bucket. A fixed 6.4 s interval with R = 2 would
+// have been 64 POSTs across 200 s = 19.2/min = 64% of the bucket — over the
+// margin, silently. Charging the measured cost is what makes R > 1 safe.
+//
+// Only the RATE matters, not the total: cost per minute is CONSTANT in vault
+// size, only the duration grows, so no vault can reproduce the
+// 242-requests-in-4-seconds storm that had 92 of 121 notes come back "Too many
+// requests" and silently keep stale bodies. For the same reason the per-note
+// snapshot GETs inside a chunk stay SERIAL. Firing them in parallel is that
+// storm, whatever the chunk size.
 //
 // Not all of the GET headroom is spare: the un-paced priority batch and the
 // single-note pull path fetch snapshot baselines too, and those are `crdt_pull`
 // GETs on this same bucket. The record-change pull, record pushes and
 // attachment fetches are not — they meter under `sync_changes`, `sync_pull`,
 // `sync_push` and `crdt_push`, which are separate keys with separate budgets.
-export const CRDT_SWEEP_CHUNK_NOTES = 25
-export const CRDT_SWEEP_CHUNK_INTERVAL_MS = 15 * 1000
+//
+// The sweep is PACED, never SELECTIVE. Every note in the vault is still named in
+// every pass; these numbers decide what a note costs, never whether it is looked
+// at. Note bodies never travel in the record change feed, so the sweep is the
+// only channel by which a body-only remote edit reaches a device that missed the
+// broadcast, and a note filtered out here would go stale with no second chance.
+
+/** Notes per paced sweep chunk = the server's cap on the probe POST's `notes` array. */
+export const CRDT_SWEEP_CHUNK_NOTES = 100
+/** Floor between chunks, and the poll interval while the drain is blocked (offline, fullSync active). */
+export const CRDT_SWEEP_CHUNK_INTERVAL_MS = 4 * 1000
+/** 60_000 / 200 = 300 GET/min = 50% of `crdt_pull`. */
+export const CRDT_SWEEP_MS_PER_SNAPSHOT_GET = 200
+/** 60_000 / 4_000 = 15 POST/min = 50% of `crdt_batch_pull`. */
+export const CRDT_SWEEP_MS_PER_BATCH_POST = 4 * 1000
+
+/** What one paced sweep chunk actually spent, per server rate-limit bucket. */
+export interface CrdtPullCost {
+  /** `GET /sync/crdt/snapshot/:noteId` attempts — the `crdt_pull` bucket. */
+  snapshotGets: number
+  /** `POST /sync/crdt/updates/batch` attempts, probe and apply rounds alike — `crdt_batch_pull`. */
+  batchPosts: number
+}
+
+/**
+ * How long the drain must wait after a chunk that spent `cost`.
+ *
+ * The chunk is charged to both buckets and the next one waits for the slower of
+ * the two to earn it back, so neither rate can exceed its 50% margin whatever
+ * mix of probe, baseline and apply rounds the chunk turned out to need. The
+ * delay is measured from the chunk's COMPLETION, so the real period is the
+ * chunk's own duration plus this — the rates below are ceilings, not targets.
+ */
+export const crdtSweepChunkDelayMs = (cost: CrdtPullCost): number =>
+  Math.max(
+    CRDT_SWEEP_CHUNK_INTERVAL_MS,
+    cost.batchPosts * CRDT_SWEEP_MS_PER_BATCH_POST,
+    cost.snapshotGets * CRDT_SWEEP_MS_PER_SNAPSHOT_GET
+  )
+
 export const PUSH_DEBOUNCE_MS = 2000
 
 export const yieldToEventLoop = (): Promise<void> => new Promise((r) => setImmediate(r))

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -356,22 +356,28 @@ targets docs with zero attached windows, so active editor docs are never evicted
 provider metrics expose the open doc count, encoded size, and per-doc `windowCount`
 so memory growth can be observed without inspecting private provider state.
 
-That cap bounds how many notes one sync pass may hold at a time. The batch CRDT pull
-opens every note it is about to fetch before it sends the request and keeps them open
-until their updates are applied, so it splits its work into chunks of
-`CrdtProvider.inactiveDocCapacity`. An unsplit pass larger than the cap evicts the notes
-it opened first, and their updates are then dropped as "unopened doc" — a whole-vault
-pass, which is what a sign-in or a reconnect sweep produces, is several times the cap.
-Chunking also keeps each request under the server's 100-note limit on
-`/sync/crdt/updates/batch`.
+That cap bounds how many notes one sync pass may hold at a time — but only the **apply**
+phase of it. The apply phase opens every note it is about to fetch before it sends the
+request and keeps them open until their updates are applied, so it splits into sub-chunks
+of `CrdtProvider.inactiveDocCapacity`. An unsplit pass larger than the cap evicts the
+notes it opened first, and their updates are then dropped as "unopened doc" — a
+whole-vault pass, which is what a sign-in or a reconnect sweep produces, is several times
+the cap.
+
+The **probe** phase is not bound by it, because it opens no document at all. Its only
+ceiling is the server's 100-note limit on the `notes` array of
+`/sync/crdt/updates/batch`, so `applyCrdtBatch` chunks at 100 and sub-chunks the apply
+phase at the doc cache inside each one. Sizing the outer loop at the doc cache instead
+would spend one probe request per 32 notes rather than per 100, and the probe request is
+the entire cost of a warm sweep.
 
 The vault-wide sweep hands its work to that same batch path rather than pulling one note
-at a time, and sizes its own chunks at `min(CRDT_SWEEP_CHUNK_NOTES, inactiveDocCapacity)`
-so a paced chunk is one batch request rather than several. Batching alone is not a fix for
-request volume, though: the batch endpoint batches the **incrementals**, not the snapshot
-baselines, which are still fetched one note at a time inside the pass. A 121-note sweep
-goes from 242 requests to roughly 125 — half, not a handful. What keeps it under the
-server's limits is the pacing described in [Reconnect Recovery](#reconnect-recovery).
+at a time, and sizes its own chunks at `CRDT_SWEEP_CHUNK_NOTES` — the probe's size.
+Batching alone is not a fix for request volume: the batch endpoint batches the
+**incrementals**, not the snapshot baselines, which are still fetched one note at a time
+whenever a baseline is actually needed. A cold 121-note sweep goes from 242 requests to
+roughly 125 — half, not a handful. What keeps it under the server's limits is the pacing
+described in [Reconnect Recovery](#reconnect-recovery).
 
 For the same reason, "this doc has no state" and "this doc is not open" are treated as
 different answers when the pass decides whether to seed a note from local markdown. A
@@ -703,28 +709,71 @@ Deciding _whether_ to sweep is not enough, because a sweep that runs fires again
 note in the vault at once. Down the one-note-at-a-time path that was two GETs per note:
 121 notes meant 242 requests in about four seconds, and the server refused most of them.
 
-The sweep is therefore drained in chunks — `CRDT_SWEEP_CHUNK_NOTES` notes every
-`CRDT_SWEEP_CHUNK_INTERVAL_MS` — against **two independent server budgets**, both keyed by
-device rather than by account:
+The sweep is therefore drained in **paced chunks of `CRDT_SWEEP_CHUNK_NOTES`** against
+**two independent server budgets**, both keyed by device rather than by account:
 
-| Endpoint                                                    | Bucket            | Limit      | Cost per chunk    |
-| ----------------------------------------------------------- | ----------------- | ---------- | ----------------- |
-| `GET /sync/crdt/snapshot/:noteId`, `GET /sync/crdt/updates` | `crdt_pull`       | 600 / 60 s | one GET per note  |
-| `POST /sync/crdt/updates/batch`                             | `crdt_batch_pull` | 30 / 60 s  | at least one POST |
+| Endpoint                                                    | Bucket            | Limit      | Spent by                         |
+| ----------------------------------------------------------- | ----------------- | ---------- | -------------------------------- |
+| `GET /sync/crdt/snapshot/:noteId`, `GET /sync/crdt/updates` | `crdt_pull`       | 600 / 60 s | the apply phase                  |
+| `POST /sync/crdt/updates/batch`                             | `crdt_batch_pull` | 30 / 60 s  | the probe, and every apply round |
 
-At 25 notes every 15 seconds that is 100 snapshot GETs and 4 batch POSTs per minute —
-16.7 % of the pull bucket and 13.3 % of the batch bucket. Because both buckets are per
-device, a second device sweeping at the same time spends its own rather than eating into
-this one. The pull bucket is still the tighter of the two if the cadence is raised — 600
-GETs buy 24 chunks a minute at 25 notes each, against the batch bucket's 30 — but the
-sweep sits a sixth of the way into it, not against the edge. Only the _rate_ matters, not
-the total: a 1,000-note vault is 40 batch POSTs, which would blow the 30-per-minute bucket
-fired at once but is 4 per minute spread over the ten minutes the paced sweep takes. Cost
-per minute is constant in vault size; only the duration grows.
+The margin is **never more than 50 % of either bucket**. The other half pays for editor
+traffic, the un-paced priority batch, broadcast-driven single-note pulls, and a second
+sweep a flapping socket may start before the first has drained. That gives 300 GET/min and
+15 POST/min, or **200 ms per snapshot GET** and **4 s per batch POST**.
 
-The batch POST figure is a floor rather than an exact count, because a chunk loops while
-any of its notes still reports `hasMore`. That only binds on a first-sync backlog, and it
-is no longer destructive when it happens — see below.
+**Two paces, not one.** Since the snapshot baseline became conditional, the two phases of
+a chunk spend different buckets and cannot share a cadence:
+
+- the **probe** is one `POST /sync/crdt/updates/batch` with `limit: 1` for the whole
+  chunk. It opens no document and downloads no snapshot, so the doc cache does not bound
+  it and it is sized at the server's 100-note cap;
+- the **apply** phase opens each remaining note, fetches its baseline if the probe could
+  not rule it out, and loops the batch endpoint for incrementals. It is bounded by
+  `inactiveDocCapacity`.
+
+100 notes every 4 s is the right warm pace and 1,500 GET/min if the chunk turns out to be
+cold; 32 notes every 6.4 s is the right cold pace and takes a warm 1,000-note vault three
+and a half minutes to confirm nothing changed. So the interval is **charged, not fixed**:
+`pullCrdtForNotes` returns what the chunk actually spent per bucket, and the next chunk
+waits for the slower of the two to earn it back —
+
+```
+delay = max(CRDT_SWEEP_CHUNK_INTERVAL_MS,
+            batchPosts   * CRDT_SWEEP_MS_PER_BATCH_POST,
+            snapshotGets * CRDT_SWEEP_MS_PER_SNAPSHOT_GET)
+```
+
+Both rates are then ≤ 50 % by construction, in every regime, without the client having to
+know in advance which regime it is in — which it cannot, because that is what the probe is
+for. For a 1,000-note vault:
+
+| Regime     | Per 100-note chunk                   | Charged delay | GET/min    | POST/min  | Wall clock  |
+| ---------- | ------------------------------------ | ------------- | ---------- | --------- | ----------- |
+| Warm       | 1 probe POST, 0 GETs                 | 4 s           | 0 (0 %)    | 15 (50 %) | ~40 s       |
+| Cold       | 100 GETs, 4 apply POSTs, no probe    | 20 s          | 300 (50 %) | 12 (40 %) | ~3 min 20 s |
+| Old server | one wasted probe, then the cold cost | 20 s          | 300 (50 %) | 12–15     | ~3 min 20 s |
+
+Before this, at 25 notes every 15 s with an unconditional baseline, all three regimes cost
+100 GET/min and 4 POST/min and took **ten minutes**. A cold vault costs no probe at all —
+no note has a watermark, so nothing could be skipped and the request is not sent.
+
+The batch POST figure is a **floor rather than an exact count**, because an apply
+sub-chunk loops while any of its notes still reports `hasMore`. That is precisely why the
+counts are measured rather than predicted: at one round per sub-chunk the GET slice binds,
+and from two rounds the POST slice binds and the sweep slows down instead of bursting
+through the batch bucket. A fixed 6.4 s interval with two rounds would have been 64 POSTs
+across 200 s — 64 % of the bucket, silently.
+
+Only the _rate_ matters, not the total: cost per minute is constant in vault size and only
+the duration grows, so no vault can reproduce the 242-requests-in-4-seconds storm. For the
+same reason the per-note snapshot GETs inside a chunk stay **serial**; firing them in
+parallel is that storm again, whatever the chunk size.
+
+The sweep is paced, never **selective**. Every note in the vault is still named in every
+pass; these numbers decide what a note costs, never whether it is looked at. Note bodies
+never travel in the record change feed, so the sweep is the only channel by which a
+body-only remote edit reaches a device that missed the broadcast.
 
 **Notes with a live editor skip the queue.** They are pulled in their own batch ahead of
 the paced drain, because the note the user is looking at is the one whose stale body is


### PR DESCRIPTION
**PR 4 of 5** in #1496. Stacked on **#1620** (`feat/crdt-persist-snapshot-watermark`), which stacks on #1619, which stacks on #1617. **Base is `feat/crdt-persist-snapshot-watermark`, not `main`.**

Closes #1541.

## What changed

The sweep ran on one constant pair — `CRDT_SWEEP_CHUNK_NOTES = 25`, `CRDT_SWEEP_CHUNK_INTERVAL_MS = 15_000` — sized when every note in a chunk cost an unconditional snapshot GET. Since the baseline became conditional (#1619) and its watermark durable (#1620), a chunk has **two phases that spend two different server buckets**, and one cadence cannot serve both.

| Phase | Request | Bucket | Bounded by |
| --- | --- | --- | --- |
| **Probe** | one `POST /sync/crdt/updates/batch`, `limit: 1`, for the whole chunk | `crdt_batch_pull` 30/60 s | the server's 100-note cap on `notes` — **not** the doc cache, because it opens no document |
| **Apply** | `GET /sync/crdt/snapshot/:noteId` per note that needs one, then one batch POST per `hasMore` round | `crdt_pull` 600/60 s + `crdt_batch_pull` | `crdtProvider.inactiveDocCapacity` (32), because it holds every note open across an await |

So:

- `applyCrdtBatch` now chunks at the **probe's** ceiling (100, the server's cap) instead of at `inactiveDocCapacity`. The old loop spent one probe POST per 32 notes; the probe POST is the entire cost of a warm sweep.
- `applyCrdtBatchChunk` probes once for the whole 100, then hands the unsettled notes to a new `applyProbedNotes` in sub-chunks of `min(inactiveDocCapacity, 100)`. That sub-chunk owns its own open/close scope, so a 100-note chunk never holds more than 32 docs open.
- `FullSyncRunner` no longer clamps its chunk to the doc cache.
- **The interval is charged, not fixed.** `pullCrdtForNotes` returns `{ snapshotGets, batchPosts }` — counted inside the `withRetry` callbacks, so it is HTTP attempts, not a prediction — and the drain waits `crdtSweepChunkDelayMs(cost)`.

## The re-derivation

Budgets, verified in `apps/sync-server/src/routes/sync.ts:489-517`: `crdt_pull` 600/60 s, `crdt_batch_pull` 30/60 s, both keyed by `deviceIdentifier`; `CrdtBatchPullSchema.notes` is `.max(100)`.

§2.2's margin: **never exceed 50 % of any bucket**, leaving the rest for editor traffic, the un-paced priority batch, broadcast-driven single-note pulls, and a second sweep a flapping socket may start.

```
GET  ceiling = 600 x 0.5 = 300/min  ->  60_000 / 300 = 200 ms per snapshot GET
POST ceiling =  30 x 0.5 =  15/min  ->  60_000 /  15 =   4_000 ms per batch POST
```

```
CRDT_SWEEP_CHUNK_NOTES         25 -> 100      (= the server's batch cap; the probe is not LRU-bound)
CRDT_SWEEP_CHUNK_INTERVAL_MS   15_000 -> 4_000  (floor = one batch POST's slice)
CRDT_SWEEP_MS_PER_SNAPSHOT_GET  new = 200
CRDT_SWEEP_MS_PER_BATCH_POST    new = 4_000

delay = max(CRDT_SWEEP_CHUNK_INTERVAL_MS,
            batchPosts   * CRDT_SWEEP_MS_PER_BATCH_POST,
            snapshotGets * CRDT_SWEEP_MS_PER_SNAPSHOT_GET)
```

**Why a single pair cannot work.** 100 notes every 4 s is the right warm pace and **1,500 GET/min** if the chunk turns out cold. 32 notes every 6.4 s is the right cold pace and takes a warm 1,000-note vault **3 min 20 s** to confirm nothing changed. The client cannot know which regime it is in before the chunk runs — that is what the probe is for — so the cost is measured and charged afterwards. Both rates are then <= 50 % by construction, in every regime.

### V = 1,000, per regime

**Warm** (watermarks present, nothing changed remotely) — 10 chunks x 100:

```
per chunk: 1 probe POST, 0 GETs, 0 docs opened
delay    = max(4_000, 1 x 4_000, 0 x 200) = 4_000 ms
GET/min  = 0                    = 0 % of 600
POST/min = 1 x 60_000/4_000 = 15 = 50 % of 30
wall     = 9 x 4 s = 36 s        (~40 s)
```

**Cold** (first sync, or a store rebuilt/quarantined) — 10 chunks x 100:

```
per chunk: 0 probe POSTs (no watermark anywhere -> the probe is not sent at all)
           100 snapshot GETs + ceil(100/32) = 4 apply POSTs, at R = 1 round each
delay    = max(4_000, 4 x 4_000 = 16_000, 100 x 200 = 20_000) = 20_000 ms
GET/min  = 100 x 60_000/20_000 = 300 = 50 % of 600
POST/min =   4 x 60_000/20_000 =  12 = 40 % of 30
wall     = 9 x 20 s = 180 s          (~3 min 20 s)
```

**Old server** (`snapshotMeta` absent) — one wasted probe on chunk 1, then `snapshotMetaUnsupported` latches:

```
chunk 1:  100 GETs + 5 POSTs -> delay 20_000 ms -> 300 GET/min, 15 POST/min
chunk 2+: identical to cold  -> 300 GET/min, 12 POST/min
wall:     ~3 min 20 s
```

**Before**, all three regimes: 25 GETs + >=1 POST per 15 s = 100 GET/min (16.7 %), 4 POST/min (13.3 %), **10 minutes**.

| Regime | Before | After | GET bucket | POST bucket |
| --- | --- | --- | --- | --- |
| Warm | 10 min, 1,000 GETs | **~40 s, 0 GETs** | 0 % | 50 % |
| Cold | 10 min | **~3 min 20 s** | 50 % | 40 % |
| Old server | 10 min | **~3 min 20 s** | 50 % | 40–50 % |

### Why the batch bucket does or does not bind — the R > 1 floor

`applyProbedNotes` loops while any note reports `hasMore`, so a sub-chunk costs **one POST per round R**, and "one POST per chunk" is a floor. Per 100-note cold chunk that is `4R` POSTs:

```
POST slice = 4R x 4_000 = 16_000R ms
GET  slice = 100 x 200  = 20_000  ms
16_000R > 20_000  <=>  R > 1.25
```

So the GET bucket binds at R = 1 and the **batch bucket binds from R = 2 onward** — at which point the sweep *slows down* and the POST rate stays pinned at 15/min by construction, because the delay is computed from the count that was actually spent.

This is the trap §4.2 named. A **fixed** 6.4 s interval with R = 2 would be `2 x 32 = 64` POSTs across 200 s = **19.2/min = 64 % of the bucket**, silently over the margin. Charging the measured cost is what makes R > 1 safe rather than merely unlikely.

### Where I disagree with §2.2

Nowhere on the numbers — my derivation reproduces both worked targets exactly (warm 40 s at the 50 % point; cold 20 s per 100 notes = 300 GET/min = 3 min 20 s, with 32 apply POSTs over 200 s = 9.6/min = 32 %, against §2.2's 31 %). Two extensions:

1. **§2.2's cold arithmetic assumes R = 1 and does not hold its own 50 % margin once R > 1** (64 % at R = 2, above). Its numbers are right; expressing them as a second fixed constant pair would not be.
2. **§2.2's two paces cannot both be constants**, because "32 notes / 6.4 s" and "100 notes / 4–6 s" are the *same drain* in two regimes the client cannot distinguish before the chunk runs. One charged interval derives both from one mechanism.

## What is deliberately unchanged

- **Cold and old-server paths cost exactly what they did before.** `probeBatchChunk` still returns `null` when no note in the chunk has a watermark, so a genuinely cold vault sends no probe; the old-server latch still fires after one. Both asserted at the wire.
- **The sweep is paced, never selective.** Every note is still named in every pass — this decides what a note costs, never whether it is looked at. Note bodies never travel in the record change feed, so a filtered note would go stale with no second chance. Asserted with an exhaustiveness test over both the cold and the warm pass.
- **Snapshot GETs inside a chunk stay serial.** Parallelising them is the 242-requests-in-4-seconds burst of #1466/#1467.
- **`applyCrdtIncrementals` is still unconditional** (FM4 from #1619) and still not paced; its cost is counted into a discarded record so there is one shape for "what a baseline costs".
- **The priority batch still jumps the pace**, and its cost is deliberately discarded — it is bounded by the number of open editors, which is what the other half of each margin is reserved for.
- **No server change.** `apps/sync-server` is untouched; the rate limits are not the problem.
- **No protocol, schema, IPC or on-disk format change.** Client-only, inside the sweep.

## Testing

New seam test `apps/desktop/src/main/sync/engine/crdt-sweep-pacing.test.ts` (6 cases) drives a **real `CrdtSyncCoordinator`** over a scripted HTTP layer and asserts **requests per minute**, not constants. Every figure is counted off the wire and cross-checked against the cost the pacer was charged, so a coordinator that under-reports its own spend fails too.

- cold 1,000-note pass: exactly 1,000 GETs and 40 POSTs, `{100, 4}` per chunk, both rates <= 50 %, wall clock 180 s;
- warm pass: **0 GETs, 0 docs opened, 10 POSTs**, all with `limit: 1` and 100 notes, 36 s;
- old server: exactly one `limit: 1` probe across the whole sweep, then the cold cost;
- the apply phase never exceeds the doc cache;
- exhaustiveness across both passes;
- a chunk with three batch rounds per sub-chunk still inside the batch bucket.

`full-sync-runner.test.ts` gains a parameterised four-regime budget test, a "the two phases are paced by their own bucket" test, an R > 1 test, and a "the paced chunk is the probe size, NOT the doc cache size" test replacing the old clamp assertion.

### Mutation evidence

**1 — apply chunk above `inactiveDocCapacity`** (`Math.min(crdtProvider.inactiveDocCapacity, CRDT_BATCH_MAX_NOTES)` -> `CRDT_BATCH_MAX_NOTES`):

```
 apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts | 5 +----
 1 file changed, 1 insertion(+), 4 deletions(-)

 Tests  4 failed | 2 passed (6)
 AssertionError: expected 100 to be less than or equal to 32
   281|  expect(wire.maxConcurrentOpenDocs).toBeLessThanOrEqual(DOC_CACHE)
```

**2 — halve the GET pace** (`CRDT_SWEEP_MS_PER_SNAPSHOT_GET` 200 -> 100, i.e. 600 GET/min = 100 % of the bucket):

```
 apps/desktop/src/main/sync/engine/sync-context.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

 Tests  5 failed | 66 passed (71)
 AssertionError: expected 375 to be less than or equal to 300   (x3)
 AssertionError: expected 16000 to be 10000
```

Both restored to a clean tree afterwards (`git diff --stat` empty).

## Verification

```
pnpm --filter @memry/desktop test:main   546 passed | 3 skipped (549) files
                                         7117 passed | 1 expected fail | 6 skipped (7124)
pnpm typecheck                           17 successful, 17 total
pnpm lint                                0 errors, 97 warnings (pre-existing; was 99 before)
git diff --check                         clean
pnpm docs:impact --base 6c70a32c5 --strict   covered
pnpm docs:build                          build complete
```

Parent-PR baseline was 545 files / 7105 passed / 1 expected fail / 6 skipped; the delta is this PR's own +1 file and +12 tests.

`apps/docs/src/architecture/crdt.md` is updated in both places that carried the old figures: the doc-cache section now separates the probe's ceiling from the apply phase's, and "Pacing the sweep" carries the two paces, the charged interval, the per-regime table and the R > 1 floor.
