### PR TITLE
fix(updater): an update check survives an expired github release-asset url

### DIFF
--- a/apps/desktop/src/main/updater-error-severity.test.ts
+++ b/apps/desktop/src/main/updater-error-severity.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import type { UpdaterErrorPhase } from './updater'
 import {
   classifyUpdaterError,
+  isExpiredSignedAssetError,
   isUpdaterCheckPhase,
   recordUpdaterCheckFailure,
   recordUpdaterCheckSuccess,
@@ -249,5 +250,62 @@ describe('stuck-updater escalation', () => {
       expect(recordUpdaterCheckFailure(start + 2 * DAY + index).stuck).toBe(false)
     }
     expect(recordUpdaterCheckFailure(start + 2 * DAY + 20).stuck).toBe(true)
+  })
+})
+
+// The verbatim production shape: builder-util-runtime's createHttpError() builds
+// `<status> <statusMessage>` plus the request line and GitHub's HTML body.
+const signedAssetError = (statusCode: number, host: string, body: string): Error =>
+  Object.assign(
+    new Error(
+      `${statusCode} \n"method: GET url: https://${host}/1132/releases/assets/x?sha256=y&jwt=z\n\n` +
+        `          Data:\n          \n<html><head><title>${body}</title></head></html>`
+    ),
+    { name: 'HttpError', code: `HTTP_ERROR_${statusCode}`, statusCode }
+  )
+
+describe('isExpiredSignedAssetError', () => {
+  it('recognises the 618 jwt:expired that loses an update check', () => {
+    expect(
+      isExpiredSignedAssetError(
+        signedAssetError(618, 'release-assets.githubusercontent.com', '618 jwt:expired')
+      )
+    ).toBe(true)
+  })
+
+  it('recognises an expired signature reported as 403 on the signed-asset host', () => {
+    expect(
+      isExpiredSignedAssetError(
+        signedAssetError(403, 'release-assets.githubusercontent.com', '403 Forbidden')
+      )
+    ).toBe(true)
+  })
+
+  it('leaves a 403 from anywhere else alone, so a real refusal is not retried', () => {
+    expect(
+      isExpiredSignedAssetError(signedAssetError(403, 'api.github.com', '403 Forbidden'))
+    ).toBe(false)
+  })
+
+  it('leaves every other updater failure alone', () => {
+    expect(isExpiredSignedAssetError(new Error('net::ERR_INTERNET_DISCONNECTED'))).toBe(false)
+    expect(isExpiredSignedAssetError(signedAssetError(404, 'github.com', '404 Not Found'))).toBe(
+      false
+    )
+    expect(
+      isExpiredSignedAssetError(
+        signedAssetError(500, 'release-assets.githubusercontent.com', '500')
+      )
+    ).toBe(false)
+    expect(isExpiredSignedAssetError(undefined)).toBe(false)
+    expect(isExpiredSignedAssetError('618')).toBe(false)
+  })
+
+  // #1595 classified a 618 as a defect worth an exception. That is still true of
+  // the failure that survives the retry — only the recovered attempts are quiet.
+  it('does not change how a surviving 618 is classified', () => {
+    const expired = signedAssetError(618, 'release-assets.githubusercontent.com', '618 jwt:expired')
+    expect(classifyUpdaterError(expired, 'check')).toBe('error')
+    expect(classifyUpdaterError(new Error('net::ERR_TIMED_OUT'), 'check')).toBe('warn')
   })
 })

--- a/apps/desktop/src/main/updater-error-severity.ts
+++ b/apps/desktop/src/main/updater-error-severity.ts
@@ -98,6 +98,39 @@ export const classifyUpdaterError = (
   return tokens.every((token) => TRANSIENT_NETWORK_ERRORS.has(token)) ? 'warn' : 'error'
 }
 
+/** GitHub's signed release-asset host. Every observed 618 came from here. */
+const SIGNED_ASSET_HOST = 'release-assets.githubusercontent.com'
+
+/**
+ * A failure that is worth asking again for, because the thing that failed was a
+ * token rather than the network.
+ *
+ * GitHub serves a release asset by redirecting to a short-lived signed
+ * `release-assets.githubusercontent.com` URL. When the follow-up GET lands after
+ * that token's expiry, GitHub answers with the non-standard status 618
+ * (`jwt:expired`). That is 36 of 36 production `HTTP_ERROR_618` events — every
+ * one in the check phase, on the channel file (`latest-mac.yml`) that
+ * electron-updater's GitHubProvider fetches to learn the latest version.
+ *
+ * electron-updater never retries it. `HttpExecutor.doApiRequest` has no retry at
+ * all on that path, and builder-util-runtime's `retryOnServerError` helper —
+ * which nothing on this path calls — matches `>= 500 && <= 599`, so it would not
+ * catch a 618 even if it were wired in. One expired token therefore loses the
+ * whole update check.
+ *
+ * The token is minted fresh on each redirect, so asking again is the fix.
+ */
+export const isExpiredSignedAssetError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false
+  const { statusCode } = error as { statusCode?: unknown }
+  if (statusCode === 618) return true
+  // A 403 is only read as an expired signature when the failing URL is the
+  // signed-asset host: an unrelated 403 (API rate limit, private repo, proxy)
+  // is a real refusal and must not be retried into a loop.
+  if (statusCode !== 403) return false
+  return errorText(error).includes(SIGNED_ASSET_HOST)
+}
+
 /**
  * A demoted failure must not make a genuinely stuck updater invisible. One
  * offline laptop is noise; an install that has not completed a single update

--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -636,6 +636,10 @@ describe('updater', () => {
     })
 
     it('keeps a jwt-expired release-asset download in error tracking', async () => {
+      // Auto-check off so no check is in flight: an expired signed asset URL
+      // raised *during* a check is retried first (#1622, covered below). This
+      // asserts the unrecoverable case — a 618 is never demoted to a warning.
+      mocks.storeState.prefs = { autoCheck: false }
       const updater = await loadUpdater()
       updater.initializeUpdater()
 
@@ -650,6 +654,128 @@ describe('updater', () => {
 
       expect(trackMainError).toHaveBeenCalledWith('updater', 'check', expired)
       expect(trackMainWarning).not.toHaveBeenCalled()
+    })
+
+    // Issue #1622: GitHub redirects a release asset to a short-lived signed URL
+    // and answers 618 `jwt:expired` when the follow-up GET lands too late.
+    // electron-updater never retries it, so one aged-out token lost the whole
+    // check — 36 production exceptions across four releases, all phase `check`.
+    describe('expired signed release-asset urls (#1622)', () => {
+      const expiredAsset = (): Error =>
+        Object.assign(
+          new Error(
+            '618 \n"method: GET url: https://release-assets.githubusercontent.com/1132/x?jwt=y\n' +
+              '\n          Data:\n          \n<html><title>618 jwt:expired</title></html>'
+          ),
+          { name: 'HttpError', code: 'HTTP_ERROR_618', statusCode: 618 }
+        )
+
+      /** electron-updater emits `error` before checkForUpdates() rejects. */
+      const failWith = (error: Error) =>
+        mocks.autoUpdater.checkForUpdates.mockImplementationOnce(() => {
+          mocks.autoUpdater.emit('checking-for-update')
+          mocks.autoUpdater.emit('error', error)
+          return Promise.reject(error)
+        })
+
+      // Auto-check off: initializeUpdater() would otherwise start its own check
+      // and these tests would be asserting against that one instead.
+      const loadWithoutStartupCheck = async () => {
+        mocks.autoUpdater.checkForUpdates.mockReset()
+        mocks.autoUpdater.checkForUpdates.mockResolvedValue(undefined)
+        mocks.storeState.prefs = { autoCheck: false }
+        const updater = await loadUpdater()
+        updater.initializeUpdater()
+        return updater
+      }
+
+      it('recovers the check on a retry instead of failing the update', async () => {
+        vi.useFakeTimers()
+        try {
+          const updater = await loadWithoutStartupCheck()
+
+          failWith(expiredAsset())
+          mocks.autoUpdater.checkForUpdates.mockImplementationOnce(() => {
+            mocks.autoUpdater.emit('checking-for-update')
+            mocks.autoUpdater.emit('update-not-available')
+            return Promise.resolve(undefined)
+          })
+
+          const check = updater.checkForUpdates()
+          await vi.advanceTimersByTimeAsync(5_000)
+
+          await expect(check).resolves.toMatchObject({ status: 'up-to-date' })
+          expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2)
+          // The recovered attempt is a warning, never an exception, and the user
+          // never sees the update surface flip to an error it recovered from.
+          expect(trackMainError).not.toHaveBeenCalled()
+          expect(trackMainWarning).not.toHaveBeenCalled()
+          expect(mocks.logger.warn).toHaveBeenCalledWith(
+            'update check hit an expired release-asset url, retrying',
+            expect.any(Error),
+            expect.objectContaining({ phase: 'check', errorCode: 'HTTP_ERROR_618' })
+          )
+        } finally {
+          vi.useRealTimers()
+        }
+      })
+
+      it('still reports an exception when every retry expires too', async () => {
+        vi.useFakeTimers()
+        try {
+          const updater = await loadWithoutStartupCheck()
+
+          const last = expiredAsset()
+          failWith(expiredAsset())
+          failWith(expiredAsset())
+          failWith(last)
+
+          const check = updater.checkForUpdates()
+          const settled = check.catch((error: unknown) => error)
+          await vi.advanceTimersByTimeAsync(10_000)
+
+          await expect(settled).resolves.toBe(last)
+          expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(3)
+          // #1595's classification is untouched: a 618 that survives is a defect.
+          expect(trackMainError).toHaveBeenCalledTimes(1)
+          expect(trackMainError).toHaveBeenCalledWith('updater', 'check', last)
+          expect(updater.getUpdateState()).toMatchObject({ status: 'error' })
+        } finally {
+          vi.useRealTimers()
+        }
+      })
+
+      it('never retries an ordinary check failure', async () => {
+        vi.useFakeTimers()
+        try {
+          const updater = await loadWithoutStartupCheck()
+
+          const offline = new Error('net::ERR_INTERNET_DISCONNECTED')
+          failWith(offline)
+
+          const settled = updater.checkForUpdates().catch((error: unknown) => error)
+          await vi.advanceTimersByTimeAsync(10_000)
+
+          await expect(settled).resolves.toBe(offline)
+          expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
+          expect(trackMainWarning).toHaveBeenCalledWith('updater', 'check', offline, {
+            retryCount: 1
+          })
+        } finally {
+          vi.useRealTimers()
+        }
+      })
+
+      it('does not swallow a 618 raised outside an in-flight check', async () => {
+        const updater = await loadWithoutStartupCheck()
+
+        void updater.downloadUpdate()
+        const expired = expiredAsset()
+        mocks.autoUpdater.emit('error', expired)
+
+        expect(trackMainError).toHaveBeenCalledWith('updater', 'download', expired)
+        expect(updater.getUpdateState()).toMatchObject({ status: 'error' })
+      })
     })
 
     it('keeps a network drop during a download in error tracking', async () => {

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -13,6 +13,7 @@ import { trackMainEvent } from './telemetry/track'
 import { markUpdateInstallStarted } from './telemetry/update-install-marker'
 import {
   classifyUpdaterError,
+  isExpiredSignedAssetError,
   isUpdaterCheckPhase,
   recordUpdaterCheckFailure,
   recordUpdaterCheckSuccess,
@@ -184,6 +185,27 @@ function currentErrorPhase(): UpdaterErrorPhase {
   }
 }
 
+/**
+ * Extra attempts for a check that died on an expired GitHub signed-asset URL,
+ * and the pause before each. A check is three small GETs, so asking again is
+ * cheap; the delay is there because the expiry is a timing race, not a state we
+ * can observe. Bounded at two so a genuinely refused asset still fails within
+ * seconds instead of retrying forever.
+ */
+const SIGNED_ASSET_RETRY_ATTEMPTS = 2
+const SIGNED_ASSET_RETRY_DELAY_MS = 2_000
+
+/**
+ * Retries still available for the in-flight check. electron-updater emits its
+ * `error` event *before* checkForUpdates() rejects, so without this the first
+ * attempt would already have flipped the UI to `error` and shipped an exception
+ * for a failure we are about to recover from. Zero whenever no check is running,
+ * so a download- or install-phase failure is never suppressed.
+ */
+let signedAssetRetriesLeft = 0
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
 let initialized = false
 let activeCheck: Promise<AppUpdateState> | null = null
 let activeDownload: Promise<AppUpdateState> | null = null
@@ -326,6 +348,22 @@ export function initializeUpdater(): void {
     const message =
       error instanceof Error ? error.message : getMainI18n().t('system:error.updateFailed')
     const phase = currentErrorPhase()
+    // An expired signed release-asset URL is a token that aged out mid-redirect,
+    // not a broken update. runUpdateCheck() is about to ask GitHub again for a
+    // fresh one, so leave the user-facing state and the telemetry alone —
+    // surfacing a failure we then recover from is the noise, not the signal.
+    if (
+      signedAssetRetriesLeft > 0 &&
+      isUpdaterCheckPhase(phase) &&
+      isExpiredSignedAssetError(error)
+    ) {
+      logger.warn(
+        'update check hit an expired release-asset url, retrying',
+        error,
+        describeUpdaterError(error, phase)
+      )
+      return
+    }
     // The local main.log line and the user-facing state stay at error severity:
     // only the telemetry severity is classified.
     logger.error('updater error', error, describeUpdaterError(error, phase))
@@ -398,14 +436,39 @@ export async function checkForUpdates(options?: {
     return activeCheck
   }
 
-  activeCheck = autoUpdater
-    .checkForUpdates()
+  activeCheck = runUpdateCheck()
     .then(() => getUpdateState())
     .finally(() => {
       activeCheck = null
     })
 
   return activeCheck
+}
+
+/**
+ * Run the check, asking again when GitHub's signed release-asset URL expired
+ * between the redirect and the follow-up GET (status 618, `jwt:expired`).
+ * electron-updater does not retry that itself, so a single aged-out token used
+ * to lose the whole check — 36 production exceptions across four releases, all
+ * in the check phase. Only the final attempt reaches the `error` handler.
+ */
+async function runUpdateCheck(): Promise<void> {
+  try {
+    for (let attempt = 0; ; attempt += 1) {
+      signedAssetRetriesLeft = SIGNED_ASSET_RETRY_ATTEMPTS - attempt
+      try {
+        await autoUpdater.checkForUpdates()
+        return
+      } catch (error) {
+        if (signedAssetRetriesLeft <= 0 || !isExpiredSignedAssetError(error)) {
+          throw error
+        }
+        await delay(SIGNED_ASSET_RETRY_DELAY_MS * (attempt + 1))
+      }
+    }
+  } finally {
+    signedAssetRetriesLeft = 0
+  }
 }
 
 export async function downloadUpdate(): Promise<AppUpdateState> {

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -170,11 +170,11 @@ builds. The allowlist is enforced on the client, where the data still is.
 An event that reports a failed HTTP request may also carry a `failure` object
 (`TelemetryFailureDetailSchema`) with three bounded fields:
 
-| Field        | Shape                                        | PostHog property |
-| ------------ | -------------------------------------------- | ---------------- |
-| `httpStatus` | integer 100–599                              | `http_status`    |
-| `serverCode` | the server's `SCREAMING_SNAKE` `error.code`  | `server_code`    |
-| `retryable`  | boolean — was the failure classified retryable | `retryable`     |
+| Field        | Shape                                          | PostHog property |
+| ------------ | ---------------------------------------------- | ---------------- |
+| `httpStatus` | integer 100–599                                | `http_status`    |
+| `serverCode` | the server's `SCREAMING_SNAKE` `error.code`    | `server_code`    |
+| `retryable`  | boolean — was the failure classified retryable | `retryable`      |
 
 This exists because `sync_error` used to ship one opaque `server_error` label covering 400, 403,
 404, 409 and every 5xx alike (#1584): a permanent client-side contract bug and a transient edge 5xx
@@ -269,7 +269,7 @@ offline quit never stalls the exit.
 | Voice           | `voice_recording_completed` (duration + bytes), `transcription_completed` (success/failure + processing duration)                                                                                                                |
 | Settings        | `setting_changed` — surface only, never the value                                                                                                                                                                                |
 | Agent chat      | `agent_chat_started`, `agent_chat_message_sent`, `ai_action_completed` (turn result + duration)                                                                                                                                  |
-| Sync health     | `sync_enabled`, `sync_run_completed`, `sync_error` (counts/status only, plus the [failure detail](#failure-detail-on-a-failed-request))                                                                                           |
+| Sync health     | `sync_enabled`, `sync_run_completed`, `sync_error` (counts/status only, plus the [failure detail](#failure-detail-on-a-failed-request))                                                                                          |
 | Auth            | `signin_started`, `signin_succeeded`                                                                                                                                                                                             |
 | Diagnostics     | `app_log_recorded`, `app_error_seen`, `app_launch_phase_completed`, `app_crashed` (see [Crash & Unclean-Shutdown Detection](#crash-unclean-shutdown-detection))                                                                  |
 
@@ -835,6 +835,21 @@ reason, phase, mode, status, kind, result`, plus numeric metric keys like
   separate one laptop on a train from many installs failing in a row. An install that has not
   completed a single check in 24 hours _and_ has failed at least 6 checks in that time raises one
   exception (latched until the next successful check), so a genuinely stuck updater is still loud.
+- **Expired GitHub signed asset URLs**: GitHub serves a release asset by redirecting to a
+  short-lived signed `release-assets.githubusercontent.com` URL. When the follow-up GET lands after
+  that token expires, GitHub answers with the non-standard status **618 `jwt:expired`**, and
+  electron-updater has no retry on that path — `builder-util-runtime`'s `retryOnServerError` is
+  never called there, and its `isServerError()` covers `500-599`, so it would not match a 618
+  anyway. One expired token therefore lost the whole update check (36 production exceptions across
+  four releases, all in the `check` phase). The token is minted fresh on each redirect, so
+  `checkForUpdates()` now retries twice, two seconds apart, on a 618 — or a 403 whose URL is the
+  signed-asset host, host-gated so an unrelated 403 is never retried into a loop
+  (`isExpiredSignedAssetError` in `apps/desktop/src/main/updater-error-severity.ts`). Only the
+  attempt that still fails reaches the `error` handler: a recovered check does not flip the update
+  surface to an error, does not advance the stuck-updater streak, and ships one
+  `app_log_recorded` `warn` (`update check hit an expired release-asset url, retrying`) instead of
+  an exception. A 618 that survives every retry is reported exactly as before — the severity
+  classification above is unchanged.
 - **Process lifecycle**: the main process reports a `child-process-gone` fault with a composite
   `type:reason:name` error code (e.g. `Utility:crashed:Embeddings`). The worker label comes from
   Electron's `details.name`, **not** `details.serviceName`: Electron routes a fork's `serviceName`


### PR DESCRIPTION
## Evidence

`HTTP_ERROR_618` in production, PostHog 120-day window, `app_error_seen` where `error_code = 'HTTP_ERROR_618'`:

| field | value |
| --- | --- |
| events | 36 |
| `source` | `updater` (36/36) |
| `action` (phase) | **`check`** (36/36) |
| `platform` | `darwin` (36/36) |
| sessions | 8 |
| app versions | `2026.806.2`, `2026.808.2`, `2026.811.1`, `2026.817.1` |

The paired `$exception` payload:

```
"type":"HTTP_ERROR_618",
"value":"618 \n\"method: GET url: https://release-assets.githubusercontent.com/…
         Data:\n <html><head><title>618 jwt:expired</title></head>…"
```

Resolved top frame: `createHttpError`. Uniform across four shipped releases, so not a regression from any one of them.

## Root cause

GitHub redirects `github.com/<owner>/<repo>/releases/download/<tag>/<file>` to a **short-lived signed** `release-assets.githubusercontent.com/…?…jwt=…` URL. When the follow-up GET lands after that token's `exp`, GitHub answers **618 `jwt:expired`**.

During a *check*, `GitHubProvider.getLatestVersion()` fetches the channel file (`latest-mac.yml`) exactly that way:

- `electron-updater/out/providers/GitHubProvider.js:104-117` — `fetchData()` → `this.executor.request(...)` on the release-download URL.
- `builder-util-runtime/out/httpExecutor.js:148-202` — `handleResponse()` follows the 3xx, then rejects with `createHttpError(response, "method: GET url: …\n\nData:\n…")` for any `statusCode >= 400`. **That message shape is what identifies this path** and rules out the differential downloader.
- `electron-updater/out/AppUpdater.js:264-276` — the rejection is re-emitted as the `error` event and rethrown, so one expired token loses the entire check.

There is **no retry** anywhere on this path. `builder-util-runtime` ships `retryOnServerError` (`httpExecutor.js:346-359`) but nothing on the check path calls it, and its `isServerError()` is `>= 500 && <= 599` (`httpExecutor.js:81-83`) — **618 is outside that range**, so wiring it in would not have helped.

Verified in this worktree: `electron-updater@6.7.3`, `builder-util-runtime@9.7.0` (pinned by the `builder-util-runtime: '>=9.7.0 <10'` override in `pnpm-workspace.yaml`), one copy of each in `node_modules/.pnpm`, no nested duplicates.

### Correcting the original hypothesis

The issue was scoped around `DifferentialDownloader.js` reusing one signed URL for a whole delta download. That weakness **is real** — `:160-224` builds one `requestOptions` and mutates it in place to the signed URL on the first redirect (`:216-221`), reusing that token across hundreds of ranges with a 1s pause every 100 (`:207-210`) — but it is **not** what production is reporting:

1. Its error is `createHttpError(response)` with **no description** (`:197`), so the message would read `618 undefined\nHeaders: …`, not the observed `method: GET url: …`.
2. `AppUpdater.differentialDownloadInstaller()` catches every differential failure, logs `Cannot download differentially, fallback to full download`, and returns `true` (`AppUpdater.js:703-710`) — it falls back to a full download and **never emits the `error` event**. It cannot produce these exceptions.
3. Telemetry says phase `check`, not `download`.

Patching the differential downloader would therefore have fixed a path with zero production evidence and left the actual defect shipping.

## The fix, and why this one

Retry the **check** on an expired signed-asset URL, in our own updater module. The token is minted fresh on each redirect, so asking again is the whole fix.

- `updater-error-severity.ts` — `isExpiredSignedAssetError()`: `statusCode === 618`, or `403` **only when the failing URL is the signed-asset host** (host-gated so an API rate limit or a private-repo refusal is never retried into a loop).
- `updater.ts` — `runUpdateCheck()` wraps `autoUpdater.checkForUpdates()` with two extra attempts, 2s and 4s apart. `signedAssetRetriesLeft` is read by the `error` handler because electron-updater emits `error` *before* `checkForUpdates()` rejects; without it the first attempt would already have flipped the UI to `error` and shipped an exception for a failure we then recover from. The counter is zero whenever no check is in flight, so a download- or install-phase failure is never suppressed.

Rejected alternatives:

- **Patch the dependency** (pnpm `patchedDependencies`). Larger blast radius on the app's most dangerous surface, must survive `pnpm install --frozen-lockfile` (and `desktop-ci.yml:50` installs with `--ignore-scripts`), and needs re-verification on every `electron-updater` bump. An app-level retry needs none of that and cannot be silently dropped by an install flag.
- **`disableDifferentialDownload = true`.** Does not address this defect at all — the failure is in the check, not the download — and would cost every user a full installer on every update.

## What it costs

- At most **two extra check round-trips** (three small GETs each), and only on a check that fails this specific way. The happy path is byte-identical.
- A check that hits this now takes up to ~6s longer before it reports failure.
- Two 618s that would previously have been two exceptions now become up to three attempts reported as one. Recovered attempts ship as `app_log_recorded` `warn`, so the rate is still queryable — the `HTTP_ERROR_618` exception count will drop, and that drop is the intended signal, not lost data.

## What it does not fix

- The latent single-signed-URL reuse in `DifferentialDownloader` (`:216-221`). Untouched, no production evidence, and electron-updater's full-download fallback already absorbs it. Worth its own issue if telemetry ever shows it.
- A network so slow that all three attempts outlive the token. That still fails, and still reports as an exception — correctly.
- The recovered attempts do **not** advance the stuck-updater streak, by design: a check that succeeded on retry did not fail.

## #1595 is unmoved

`classifyUpdaterError` is untouched: `HTTP_ERROR_618` stays `error`, the `net::ERR_*` family stays `warn`. Asserted directly in `updater-error-severity.test.ts` and again at the seam — a 618 that survives every retry still calls `trackMainError('updater', 'check', …)` and still flips the UI to the error state.

## Rollback

Revert the two commits. The change is one module-level counter plus a retry loop in `apps/desktop/src/main/updater.ts` and a pure predicate in `updater-error-severity.ts` — no dependency patch, no lockfile change, no schema, contract, IPC, settings or sync-protocol change, and nothing persisted. Reverting restores byte-identical prior behaviour with no migration and no compatibility window; an older build and a newer build behave identically against the same GitHub feed.

## Verification

Run in `/…/.worktrees/updater-network-error-severity`, after `bash apps/desktop/scripts/ensure-native.sh node` (exit 0):

| command | result |
| --- | --- |
| `pnpm exec vitest run --config config/vitest.config.ts --project main` (from `apps/desktop`) | **542 files passed, 3 skipped; 7079 tests passed** |
| `pnpm exec vitest run … --project main src/main/updater.test.ts src/main/updater-error-severity.test.ts` | **84 passed** |
| `pnpm --filter @memry/desktop typecheck:node` | exit 0 |
| `pnpm --filter @memry/desktop typecheck:test` | exit 0 |
| `pnpm lint` | exit 0 (0 errors; 97 pre-existing warnings, none in the touched files) |
| `pnpm exec prettier --check` on the four touched files | clean |
| `pnpm docs:impact --base origin/main --strict` | `docs changed on this branch` |
| `pnpm docs:build` | exit 0 |

Mutation-tested — each of these turned the suite red, then was reverted:

- `SIGNED_ASSET_RETRY_ATTEMPTS = 2 → 0` → 2 failures
- the `signedAssetRetriesLeft > 0` guard forced to `false` → 2 failures
- `isExpiredSignedAssetError`'s 403 host gate inverted → 1 failure

**A real slow-link JWT expiry cannot be reproduced here, and this PR does not claim to have reproduced one.** The tests exercise the seam: electron-updater's emit-then-reject ordering, driven with a production-shaped `HttpError`. The real proof is telemetry on the release that carries this — `app_error_seen` with `error_code = 'HTTP_ERROR_618'` should fall toward zero while `app_log_recorded` warns named `update check hit an expired release-asset url, retrying` appear in its place.

Fixes #1622
