### PR TITLE
fix(canvas): announce a too-large-to-sync scene once, not on every autosave

### DIFF
--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
@@ -80,7 +80,9 @@ const mocks = vi.hoisted(() => ({
   fileGet: vi.fn(),
   taskGet: vi.fn(),
   eventGet: vi.fn(),
-  windowOpen: vi.fn()
+  windowOpen: vi.fn(),
+  /** Live `canvas:too-large` subscribers, so a test can fire the event. */
+  tooLargeListeners: new Set<(event: { id: string }) => void>()
 }))
 
 vi.mock('@excalidraw/excalidraw', () => ({
@@ -148,7 +150,10 @@ vi.mock('@/services/canvas-service', () => ({
     uploadAsset: vi.fn(),
     canUploadAsset: vi.fn(async () => ({ canUpload: true }))
   },
-  onCanvasTooLarge: () => () => {}
+  onCanvasTooLarge: (callback: (event: { id: string }) => void) => {
+    mocks.tooLargeListeners.add(callback)
+    return () => mocks.tooLargeListeners.delete(callback)
+  }
 }))
 vi.mock('./canvas-card-overlay', () => ({ CanvasCardLayer: () => null }))
 vi.mock('@/contexts/tabs', () => ({
@@ -388,6 +393,100 @@ describe('CanvasEditor persistence safety', () => {
     expect(mocks.excalidrawProps.UIOptions).toEqual({
       canvasActions: { export: false, loadScene: false, saveToActiveFile: false }
     })
+  })
+})
+
+/**
+ * The too-large-to-sync notice (#1625/C2).
+ *
+ * The scene autosaves on every change, and main emits `canvas:too-large` for
+ * each oversized save — so a per-event toast reappeared every time the user
+ * nudged an element. The notice is edge-triggered instead: announced when the
+ * canvas stops syncing, re-armed only once a save syncs again.
+ */
+describe('CanvasEditor too-large-to-sync notice', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.update.mockReset().mockResolvedValue({ id: 'c1', tooLarge: true })
+    mocks.toastError.mockReset()
+    mocks.serializeAsJSON.mockClear()
+    mocks.api.elements = []
+    mocks.api.isLoading = true
+    mocks.api.selectedElementIds = {}
+    mocks.api.showHyperlinkPopup = false
+    mocks.onChange = null
+    mocks.tooLargeListeners.clear()
+    mocks.liveOpened.mockReset().mockResolvedValue({ ok: true })
+    mocks.liveClosed.mockReset().mockResolvedValue({ ok: true })
+    installWindowApi()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /** Fires main's `canvas:too-large` broadcast at the mounted editor. */
+  function emitTooLarge(id: string): void {
+    act(() => {
+      for (const listener of mocks.tooLargeListeners) {
+        listener({ id })
+      }
+    })
+  }
+
+  /** Drives one autosave with a changed scene, so the persister actually writes. */
+  async function saveOnce(elements: unknown[]): Promise<void> {
+    mocks.api.elements = elements
+    mocks.api.isLoading = false
+    act(() => {
+      mocks.onChange?.()
+    })
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+  }
+
+  it('announces an oversized scene once across repeated autosaves', async () => {
+    render(<CanvasEditor canvasId="c1" initialScene="" />)
+
+    await saveOnce([{ id: 'a' }])
+    await saveOnce([{ id: 'a' }, { id: 'b' }])
+    await saveOnce([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
+
+    expect(mocks.update).toHaveBeenCalledTimes(3)
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+    expect(mocks.toastError).toHaveBeenCalledWith('canvas.tooLargeToSync', {
+      id: 'canvas-too-large-c1'
+    })
+  })
+
+  it('collapses repeated too-large events into the one notice', () => {
+    render(<CanvasEditor canvasId="c1" initialScene="" />)
+
+    emitTooLarge('c1')
+    emitTooLarge('c1')
+    emitTooLarge('c1')
+
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a too-large event for a different canvas', () => {
+    render(<CanvasEditor canvasId="c1" initialScene="" />)
+
+    emitTooLarge('other')
+
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('re-announces after a save syncs again', async () => {
+    render(<CanvasEditor canvasId="c1" initialScene="" />)
+
+    emitTooLarge('c1')
+    mocks.update.mockResolvedValue({ id: 'c1', tooLarge: false })
+    await saveOnce([{ id: 'a' }])
+    emitTooLarge('c1')
+
+    expect(mocks.toastError).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
@@ -250,13 +250,44 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
 
   // §5.6: a save whose scene is too large to sync is kept locally but never
   // pushed; surface it so the divergence is never silent.
+  //
+  // The signal fires on EVERY oversized save, and the scene is auto-saved
+  // whenever anything on the canvas moves — so announcing it per event buried
+  // the user under an endless stack of identical toasts while they worked
+  // (#1625/C2). The announcement is therefore edge-triggered: once when the
+  // canvas stops syncing, re-armed only after a save syncs again. The stable
+  // toast id is the second line of defence — sonner replaces rather than
+  // stacks, so even a repeat announcement can never pile up.
+  const tooLargeAnnouncedRef = useRef(false)
+  const announceSyncability = useCallback(
+    (tooLarge: boolean): void => {
+      if (!tooLarge) {
+        tooLargeAnnouncedRef.current = false
+        return
+      }
+      if (tooLargeAnnouncedRef.current) {
+        return
+      }
+      tooLargeAnnouncedRef.current = true
+      toast.error(t('canvas.tooLargeToSync'), { id: `canvas-too-large-${canvasId}` })
+    },
+    [canvasId, t]
+  )
+  // The persister's save closure is built once per canvas, so it reads the
+  // announcer through a ref rather than re-creating the persister on every
+  // language change.
+  const announceSyncabilityRef = useRef(announceSyncability)
+  useEffect(() => {
+    announceSyncabilityRef.current = announceSyncability
+  }, [announceSyncability])
+
   useEffect(() => {
     return onCanvasTooLarge((event) => {
       if (event.id === canvasId) {
-        toast.error(t('canvas.tooLargeToSync'))
+        announceSyncabilityRef.current(true)
       }
     })
-  }, [canvasId, t])
+  }, [canvasId])
 
   const persisterRef = useRef<{ notifyChange: () => void; flush: () => Promise<void> } | null>(null)
 
@@ -355,11 +386,15 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
           trackRendererError('canvas_asset_externalize', err)
           // Fall back to the original scene — the pre-push size guard surfaces oversize saves.
         }
-        await canvasService.update({
+        const saved = await canvasService.update({
           id: canvasId,
           scene: sceneToSave,
           entityRefs: extractEntityRefs(elements)
         })
+        // The only signal that carries BOTH edges: the too-large event fires
+        // for oversized saves only, so a save that syncs again is what re-arms
+        // the announcement above.
+        announceSyncabilityRef.current(saved.tooLarge)
       },
       debounceMs: SCENE_SAVE_DEBOUNCE_MS,
       lastSavedScene: initialScene,

--- a/apps/docs/src/user-guide/canvas/sync-and-limits.md
+++ b/apps/docs/src/user-guide/canvas/sync-and-limits.md
@@ -53,6 +53,11 @@ device, but stops syncing until it gets smaller, and memrynote tells you so
 rather than failing silently. Splitting a very large board into several
 canvases is the usual fix.
 
+The warning appears once, when the board crosses the limit — not again on every
+edit while you keep working. It comes back when there is something new to say:
+after you reopen the board and it is still too large, or after a save that
+synced is followed by one that is too large again.
+
 ## Known limitations
 
 - Real-time co-editing of one canvas is not supported (see conflict copies).


### PR DESCRIPTION
Fixes the C2 report from the 18–20 Aug feedback sweep (EPIC #1625): _"every time I move something on that canvas in question, the same toast message reappears, over and over while I am working."_

## Root cause

`apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx` subscribed to `canvas:too-large` and called `toast.error()` per event. Main emits that event on **every** oversized save, and the scene autosaves whenever anything on the board moves — so the notice fired on a timer-driven loop rather than on a state change. No toast `id` was passed either, so sonner had nothing to dedupe on and the toasts stacked.

The user understands the message. The complaint is the repetition.

## Fix

- **Edge-triggered.** A `tooLargeAnnouncedRef` gates the announcement: it fires when the canvas goes syncable → not syncable, and stays quiet for every subsequent oversized save.
- **Re-armed on the other edge.** The event only fires for oversized saves, so it cannot report recovery. The `canvas:update` response already carries `tooLarge`, and the save path now feeds that back — a save that syncs re-arms the notice.
- **Stable toast id** (`canvas-too-large-${canvasId}`) as the second line of defence: sonner replaces rather than stacks.
- The persister's save closure is built once per canvas, so it reads the announcer through a ref instead of re-creating the persister on every language change.

Not silenced: §5.6 wants the divergence visible, so reopening the canvas re-announces once on the first oversized save.

## Verification

- 4 new tests in `canvas-editor.test.tsx`: 3 consecutive oversized saves → 1 toast; repeated events → 1 toast; another canvas's event → no toast; re-announces after a save syncs again.
- Mutation-tested 3/3: removing the edge guard → 2 red; removing the stable id → 1 red; removing the response-driven re-arm → 2 red.
- `pages/canvas` suite 416/416 · `typecheck:web` + `typecheck:test:web` clean · eslint clean · `docs:impact --strict` covered · `docs:build` green.
