### PR TITLE
fix(notes): a packaged YouTube embed plays instead of failing with Error 153

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -86,6 +86,7 @@ const readdirSyncMock = vi.fn(() => [])
 const statSyncMock = vi.fn(() => ({ size: 10 }))
 const createReadStreamMock = vi.fn()
 const webRequestOnHeadersReceivedMock = vi.fn()
+const webRequestOnBeforeSendHeadersMock = vi.fn()
 const protocolHandleMock = vi.fn()
 const protocolRegisterSchemesMock = vi.fn()
 const ipcMainOnMock = vi.fn()
@@ -421,7 +422,8 @@ vi.mock('electron', () => ({
   session: {
     defaultSession: {
       webRequest: {
-        onHeadersReceived: webRequestOnHeadersReceivedMock
+        onHeadersReceived: webRequestOnHeadersReceivedMock,
+        onBeforeSendHeaders: webRequestOnBeforeSendHeadersMock
       },
       setCertificateVerifyProc: setCertificateVerifyProcMock,
       setPermissionRequestHandler: setPermissionRequestHandlerMock,
@@ -1149,6 +1151,35 @@ describe('main index phase2 exports', () => {
     const externalCallback = vi.fn()
     cspCallback({ url: 'https://example.com/script.js', responseHeaders: {} }, externalCallback)
     expect(externalCallback).toHaveBeenCalledWith({})
+  })
+
+  it('gives the youtube embed a referrer the file:// document cannot send', async () => {
+    whenReadyMock.mockResolvedValue(undefined)
+
+    await importMainModule()
+    await flushReadyWork()
+
+    const headersCallback = webRequestOnBeforeSendHeadersMock.mock.calls.at(-1)?.[0] as (
+      details: { url: string; requestHeaders: Record<string, string> },
+      callback: (response: { requestHeaders?: Record<string, string> }) => void
+    ) => void
+    expect(headersCallback).toBeTypeOf('function')
+
+    const embedCallback = vi.fn()
+    headersCallback(
+      { url: 'https://www.youtube-nocookie.com/embed/abc', requestHeaders: { Accept: '*/*' } },
+      embedCallback
+    )
+    expect(embedCallback).toHaveBeenCalledWith({
+      requestHeaders: { Accept: '*/*', Referer: 'https://memrynote.com/' }
+    })
+
+    const otherCallback = vi.fn()
+    headersCallback(
+      { url: 'https://api.memrynote.com/sync', requestHeaders: { Accept: '*/*' } },
+      otherCallback
+    )
+    expect(otherCallback).toHaveBeenCalledWith({})
   })
 
   it('configures certificate pinning callbacks when pins are available', async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -94,6 +94,7 @@ import { probeSecretStoreIdentity } from './secrets/secret-storage'
 import { isAllowedExternalUrl, isPathInsideDirs, resolveMemryFilePath } from './lib/external-url'
 import { remapCrossDeviceAttachmentPath } from './lib/attachment-path-remap'
 import { decideFrameNavigation } from './lib/frame-navigation'
+import { decideEmbedRequestHeaders } from './lib/embed-referer'
 import { registerTestHooks } from './test-hooks'
 import {
   computeSpkiHashFromPem,
@@ -559,6 +560,18 @@ function configureCsp(): void {
           }
         : {}
     )
+  })
+}
+
+/**
+ * Give http(s) embeds an identifiable embedder. The packaged renderer's
+ * document is `file://`, from which Chromium sends no `Referer` — see
+ * `lib/embed-referer.ts` for why YouTube then fails with Error 153.
+ */
+function configureEmbedReferer(): void {
+  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    const requestHeaders = decideEmbedRequestHeaders(details.url, details.requestHeaders)
+    callback(requestHeaders ? { requestHeaders } : {})
   })
 }
 
@@ -1633,6 +1646,7 @@ const appReady = app.whenReady().then(async () => {
 
   // Configure CSP, cert pinning, and permission handlers before the window loads
   configureCsp()
+  configureEmbedReferer()
   configureCertificatePinning()
   configureSessionPermissions()
 

--- a/apps/desktop/src/main/lib/embed-referer.test.ts
+++ b/apps/desktop/src/main/lib/embed-referer.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { decideEmbedRequestHeaders, EMBED_REFERER } from './embed-referer'
+
+const EMBED_URL = 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1&rel=0'
+
+describe('decideEmbedRequestHeaders', () => {
+  it('names the app site as embedder when the frame request carries no referrer', () => {
+    expect(decideEmbedRequestHeaders(EMBED_URL, { 'User-Agent': 'MemryNote' })).toEqual({
+      'User-Agent': 'MemryNote',
+      Referer: EMBED_REFERER
+    })
+  })
+
+  it('uses an https referrer (a file:// or empty one is what YouTube rejects)', () => {
+    expect(EMBED_REFERER.startsWith('https://')).toBe(true)
+  })
+
+  it('leaves a request that already has a referrer alone, whatever the header casing', () => {
+    expect(decideEmbedRequestHeaders(EMBED_URL, { Referer: 'http://localhost:5173/' })).toBeNull()
+    expect(decideEmbedRequestHeaders(EMBED_URL, { referer: 'http://localhost:5173/' })).toBeNull()
+  })
+
+  it('touches only the embed origin', () => {
+    expect(decideEmbedRequestHeaders('https://www.youtube.com/embed/abc', {})).toBeNull()
+    expect(decideEmbedRequestHeaders('https://evil.example/embed/abc', {})).toBeNull()
+    expect(decideEmbedRequestHeaders('https://api.memrynote.com/sync', {})).toBeNull()
+    expect(
+      decideEmbedRequestHeaders('https://www.youtube-nocookie.com.evil.example/embed/abc', {})
+    ).toBeNull()
+  })
+
+  it('ignores unparseable urls', () => {
+    expect(decideEmbedRequestHeaders('not a url', {})).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/lib/embed-referer.ts
+++ b/apps/desktop/src/main/lib/embed-referer.ts
@@ -1,0 +1,47 @@
+/**
+ * YouTube refuses to configure its player for an embedder it cannot identify.
+ *
+ * The packaged renderer is loaded with `loadFile()`, so a note's document
+ * origin is `file://`, and Chromium sends no `Referer` at all from a file://
+ * document to an https subframe. The embed HTML then comes back carrying
+ * `ERROR_CODE_EMBEDDER_IDENTITY_MISSING_REFERRER`, which the player renders as
+ * "Error 153 — Video player configuration error".
+ *
+ * Dev never reproduces this: `ELECTRON_RENDERER_URL` gives the document a real
+ * `http://localhost` origin, so Chromium sends a Referer on its own and the
+ * embed plays. The bug is only reachable in a packaged build.
+ *
+ * Until the renderer is served from a real app origin, name the app's own site
+ * as the embedder on the one request that would otherwise arrive bare.
+ */
+
+/** Embed origins that require an identifiable embedder. */
+const IDENTIFIED_EMBED_ORIGINS = new Set(['https://www.youtube-nocookie.com'])
+
+/** The app's own site: what the embed is embedded *by*. */
+export const EMBED_REFERER = 'https://memrynote.com/'
+
+/**
+ * Returns the request headers to send instead of `requestHeaders`, or `null`
+ * to leave the request untouched.
+ */
+export function decideEmbedRequestHeaders(
+  url: string,
+  requestHeaders: Record<string, string>
+): Record<string, string> | null {
+  let origin: string
+  try {
+    origin = new URL(url).origin
+  } catch {
+    return null
+  }
+
+  if (!IDENTIFIED_EMBED_ORIGINS.has(origin)) return null
+
+  // Anything that already carries a referrer keeps it: the dev document's
+  // http://localhost origin, and every request the player itself makes from
+  // inside the loaded frame. Only the file:// frame load arrives bare.
+  if (Object.keys(requestHeaders).some((name) => name.toLowerCase() === 'referer')) return null
+
+  return { ...requestHeaders, Referer: EMBED_REFERER }
+}

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -236,6 +236,12 @@ Attachments and vault media reach the renderer through the custom `memry-file://
 - `window.open` on a memry-file URL never opens a window or reaches `shell.openExternal`: the main process resolves the path with the same rules and, if it passes the directory check, opens the file in the OS default app via `shell.openPath`.
 - In-window navigation is guarded the same way: a `will-frame-navigate` listener on every window's webContents (`src/main/index.ts`, policy in `src/main/lib/frame-navigation.ts`) pins the main frame to the local app document (the packaged `file://` page, or the dev-server origin in dev) plus `memry-file:`. External `http(s)`/`mailto` links cancel the navigation and open in the OS browser; `javascript:`, `data:`, `file:` and unknown schemes are denied outright. Subframes stay permissive for `http(s)` — the CSP `frame-src` directive is the origin gate for embeds like youtube-nocookie — while local and script schemes remain blocked there too.
 
+### Identifying the embedder for http(s) embeds
+
+The packaged renderer is loaded with `loadFile()`, so the note document's origin is `file://`, and Chromium sends no `Referer` from a `file://` document to an https subframe. YouTube refuses to configure its player for an embedder it cannot identify: the embed HTML comes back carrying `ERROR_CODE_EMBEDDER_IDENTITY_MISSING_REFERRER`, and the player renders "Error 153 — Video player configuration error" instead of the video.
+
+An `onBeforeSendHeaders` handler (`src/main/index.ts`, policy in `src/main/lib/embed-referer.ts`) names the app's own site as the embedder — `Referer: https://memrynote.com/` — on a youtube-nocookie request that carries no referrer of its own. Only the `file://` subframe load arrives bare: the dev-server document's `http://localhost` origin, and every request the player itself makes from inside the loaded frame, keep their own referrer and are left untouched. That asymmetry is also why the bug is unreachable in dev.
+
 ### What a note stores for an attachment
 
 A note never stores the absolute `memry-file://` URL — that carries one machine's vault path, so the same note on a second device resolves it to nothing. What lands in the markdown is a path relative to the note itself:


### PR DESCRIPTION
Part of #1625 (C3). Reported 19 Aug 2026, Windows, with a screenshot.

## The bug

A YouTube embed in a note refuses to play. The player loads and then renders its own error: **Error 153 — Video player configuration error**.

We are not the ones blocking it. CSP `frame-src https://www.youtube-nocookie.com` allows the origin, and the embed URL is fine.

## Root cause

The packaged renderer is loaded with `loadFile()`, so the note document's origin is `file://`, and **Chromium sends no `Referer` from a `file://` document to an https subframe**. YouTube refuses to configure its player for an embedder it cannot identify: the embed HTML comes back carrying `ERROR_CODE_EMBEDDER_IDENTITY_MISSING_REFERRER`, which the player renders as Error 153.

Dev never reproduces it: `ELECTRON_RENDERER_URL` gives the document a real `http://localhost` origin, so Chromium sends a Referer on its own. The bug is only reachable in a packaged build — "works on my machine" was a symptom here, not evidence.

The referrer dimension isolated, same UA, one header apart:

| `Referer` | embed response |
| --- | --- |
| absent | `ERROR_CODE_EMBEDDER_IDENTITY_MISSING_REFERRER`, body carries the literal "Error 153 / Video player configuration error" copy |
| `https://memrynote.com/` | clean player config (137 KB → 145 KB) |

The usual web fix for 153 — `referrerpolicy="strict-origin-when-cross-origin"` on the iframe, or a `<meta name="referrer">` — cannot work from `file://`: there is no referrer to relax. The `sandbox` attribute on the block is cleared of suspicion; the video plays with it unchanged.

## The fix

`onBeforeSendHeaders` names the app's own site as the embedder — `Referer: https://memrynote.com/` — on a youtube-nocookie request that carries no referrer of its own.

Only the `file://` subframe load arrives bare. Once the frame is up, every request the player itself makes carries its own referrer, and the dev document's `http://localhost` origin carries one too, so both are left untouched by the same rule:

```
[REQ] subFrame   referer= (none)          <- the only one we touch
[REQ] stylesheet referer= https://www.youtube-nocookie.com/embed/...
[REQ] script     referer= https://www.youtube-nocookie.com/embed/...
[REQ] xhr        referer= https://www.youtube-nocookie.com/embed/...
```

**Why not a real app origin.** Serving the renderer from a custom scheme is the structurally correct fix, but changing the origin resets everything the current `file://` origin holds in `localStorage` on existing installs — open tabs, tree expansion, local settings. That needs its own backward-compatible migration and should be designed alongside the tab-loss item, which looks at the same root condition. This change needs neither an origin migration nor a second render path, and keeps playback inline.

## Verification

End to end in a standalone Electron window — `loadFile()` document (so a real `file://` origin) and the block's exact iframe markup, screenshotted with `capturePage()`:

- without the header: "Error 153 — Video player configuration error"
- with the header: the video plays

Gates: `typecheck:node`, `typecheck:test`, eslint, `docs:impact --strict`, `docs:build` all green. Main suite green including 6 new tests (5 unit + 1 wiring). Two suites fail in this worktree on `Electron failed to install correctly` — a missing native binary here, unrelated to this change.
