### PR TITLE
fix(sidebar): an empty folder accepts a dropped folder

### DIFF
--- a/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.test.tsx
+++ b/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, createEvent, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { forwardRef } from 'react'
 
@@ -182,6 +182,17 @@ function dataTransfer(types: string[] = []) {
   }
 }
 
+/**
+ * jsdom's `DragEvent` drops mouse coordinates, so `fireEvent.dragOver(row, {
+ * clientY })` hands the tree `undefined` and every drop band comparison fails.
+ * Set the coordinate on the event itself to test the geometry for real.
+ */
+function dragOverAt(row: HTMLElement, clientY: number, transfer: unknown) {
+  const event = createEvent.dragOver(row, { dataTransfer: transfer })
+  Object.defineProperty(event, 'clientY', { value: clientY })
+  fireEvent(row, event)
+}
+
 describe('TreeProvider and tree primitives', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -276,6 +287,48 @@ describe('TreeProvider and tree primitives', () => {
 
     fireEvent.dragLeave(childB, { relatedTarget: document.body })
     fireEvent.dragEnd(root)
+  })
+
+  it('drops a node inside an empty folder row', () => {
+    // #given — a folder with nothing in it yet. The virtualized copy of this
+    // tree used to infer "takes children" from "has children" and refused the
+    // drop; both trees now share `resolveDropPosition`.
+    const onMove = vi.fn()
+    render(
+      <TreeProvider persistKey="tree-empty-folder" draggable onMove={onMove}>
+        <TreeView>
+          <TreeNode nodeId="note">
+            <TreeNodeTrigger>
+              <span>Loose Note</span>
+            </TreeNodeTrigger>
+          </TreeNode>
+          <TreeNode nodeId="folder-empty" acceptsDropInside>
+            <TreeNodeTrigger>
+              <span>Empty Folder</span>
+            </TreeNodeTrigger>
+          </TreeNode>
+        </TreeView>
+      </TreeProvider>
+    )
+
+    const source = screen.getByText('Loose Note').closest('[data-tree-node-id]') as HTMLElement
+    const target = screen.getByText('Empty Folder').closest('[data-tree-node-id]') as HTMLElement
+    target.getBoundingClientRect = vi.fn(
+      () => ({ top: 0, height: 28, right: 100, left: 0 }) as DOMRect
+    )
+
+    // #when — the drag hovers the middle of the row
+    const transfer = dataTransfer()
+    fireEvent.dragStart(source, { dataTransfer: transfer })
+    dragOverAt(target, 14, transfer)
+    fireEvent.drop(target, { dataTransfer: transfer })
+
+    // #then
+    expect(onMove).toHaveBeenCalledWith({
+      draggedId: 'note',
+      targetId: 'folder-empty',
+      position: 'inside'
+    })
   })
 
   it('lets a file dragged in from the OS reach the sidebar instead of swallowing it', () => {

--- a/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.tsx
+++ b/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/context-menu'
 import { IconPicker, getIconByName } from '@/components/icon-picker'
 import { remapExpandedFolderIds } from '@/components/notes-tree-utils'
+import { resolveDropPosition, type DropPosition } from '@/lib/tree-drop-position'
 import { CANVAS_ITEM_DRAG_MIME, canvasDragPayload } from '@/pages/canvas/canvas-cards'
 import { useT } from '@memry/i18n/renderer'
 
@@ -35,7 +36,7 @@ type NodeInfo = {
   inheritedIcon?: string
 }
 
-export type DropPosition = 'before' | 'after' | 'inside'
+export type { DropPosition }
 
 export type DragState = {
   draggedId: string | null
@@ -760,19 +761,11 @@ export const TreeNodeTrigger = ({
       const rect = triggerRef.current?.getBoundingClientRect()
       if (!rect) return
 
-      const y = e.clientY - rect.top
-      const height = rect.height
-      const canDropInside = hasChildren || acceptsDropInside
-      const threshold = canDropInside ? height / 4 : height / 2
-
-      let position: DropPosition
-      if (y < threshold) {
-        position = 'before'
-      } else if (y > height - threshold) {
-        position = 'after'
-      } else {
-        position = canDropInside ? 'inside' : 'after'
-      }
+      const position = resolveDropPosition(
+        e.clientY - rect.top,
+        rect.height,
+        hasChildren || acceptsDropInside
+      )
 
       setDragState({ dropTargetId: nodeId, dropPosition: position })
     },

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.test.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.test.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import { createRef } from 'react'
-import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import { act, createEvent, fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -159,6 +159,48 @@ const noteMap = new Map([
   [workNote.id, workNote],
   [rootNote.id, rootNote]
 ])
+
+// A folder with nothing in it yet — the shape a user gets straight out of "New
+// folder", and the one that used to refuse every drop.
+const emptyFolderTree: TreeStructure = {
+  folders: [
+    { name: 'Work', path: 'Work', icon: null, children: [], notes: [workNote] },
+    { name: 'Archive', path: 'Archive', icon: null, children: [], notes: [] }
+  ],
+  rootNotes: [rootNote]
+}
+
+const ROW_HEIGHT = 28
+
+const stubRowRect = (row: HTMLElement) => {
+  Object.defineProperty(row, 'getBoundingClientRect', {
+    configurable: true,
+    value: () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: ROW_HEIGHT,
+        width: 100,
+        height: ROW_HEIGHT,
+        toJSON: () => ({})
+      }) as DOMRect
+  })
+}
+
+/**
+ * jsdom's `DragEvent` drops mouse coordinates, so `fireEvent.dragOver(row, {
+ * clientY })` hands the tree `undefined` — every geometry comparison then fails
+ * and whatever the row falls back to wins, which is how a test can "pass" while
+ * proving nothing about the drop bands. Set the coordinate on the event itself.
+ */
+const dragOverAt = (row: HTMLElement, clientY: number, dataTransfer: unknown) => {
+  const event = createEvent.dragOver(row, { dataTransfer })
+  Object.defineProperty(event, 'clientY', { value: clientY })
+  fireEvent(row, event)
+}
 
 const renderTree = (overrides: Partial<React.ComponentProps<typeof VirtualizedNotesTree>> = {}) => {
   const props: React.ComponentProps<typeof VirtualizedNotesTree> = {
@@ -449,6 +491,78 @@ describe('VirtualizedNotesTree', () => {
 
     getItemSpy.mockRestore()
     setItemSpy.mockRestore()
+  })
+
+  it('drops a folder inside an empty folder, which has no children to infer it from', () => {
+    const onMove = vi.fn<(operation: MoveOperation) => void>()
+    renderTree({ tree: emptyFolderTree, onMove })
+
+    const dataTransfer = {
+      effectAllowed: '',
+      dropEffect: '',
+      types: [] as string[],
+      setData: vi.fn(),
+      getData: vi.fn()
+    }
+    const source = screen.getByText('Work').closest('[role="treeitem"]') as HTMLElement
+    const target = screen.getByText('Archive').closest('[role="treeitem"]') as HTMLElement
+    stubRowRect(target)
+
+    fireEvent.dragStart(source, { dataTransfer })
+    dragOverAt(target, ROW_HEIGHT / 2, dataTransfer)
+    fireEvent.drop(target, { dataTransfer })
+
+    expect(onMove).toHaveBeenCalledWith({
+      draggedId: 'folder-Work',
+      targetId: 'folder-Archive',
+      position: 'inside'
+    })
+  })
+
+  it('keeps the reorder bands at the edges of a folder row and off a note row', () => {
+    const onMove = vi.fn<(operation: MoveOperation) => void>()
+    renderTree({ tree: emptyFolderTree, onMove })
+
+    const dataTransfer = {
+      effectAllowed: '',
+      dropEffect: '',
+      types: [] as string[],
+      setData: vi.fn(),
+      getData: vi.fn()
+    }
+    const source = screen.getByText('Work').closest('[role="treeitem"]') as HTMLElement
+    const folderTarget = screen.getByText('Archive').closest('[role="treeitem"]') as HTMLElement
+    const noteTarget = screen.getByText('Root').closest('[role="treeitem"]') as HTMLElement
+    stubRowRect(folderTarget)
+    stubRowRect(noteTarget)
+
+    fireEvent.dragStart(source, { dataTransfer })
+    dragOverAt(folderTarget, 1, dataTransfer)
+    fireEvent.drop(folderTarget, { dataTransfer })
+    expect(onMove).toHaveBeenLastCalledWith({
+      draggedId: 'folder-Work',
+      targetId: 'folder-Archive',
+      position: 'before'
+    })
+
+    fireEvent.dragStart(source, { dataTransfer })
+    dragOverAt(folderTarget, ROW_HEIGHT - 1, dataTransfer)
+    fireEvent.drop(folderTarget, { dataTransfer })
+    expect(onMove).toHaveBeenLastCalledWith({
+      draggedId: 'folder-Work',
+      targetId: 'folder-Archive',
+      position: 'after'
+    })
+
+    // A note takes no children, so its middle is a reorder, never an "inside".
+    fireEvent.dragStart(source, { dataTransfer })
+    dragOverAt(noteTarget, ROW_HEIGHT / 2, dataTransfer)
+    fireEvent.drop(noteTarget, { dataTransfer })
+    expect(onMove).toHaveBeenLastCalledWith({
+      draggedId: 'folder-Work',
+      targetId: 'note-root',
+      position: 'after'
+    })
   })
 
   it('handles external scroll, imperative node expansion, ctrl selection, and folder drop edges', () => {

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
@@ -62,13 +62,14 @@ import { FILE_DROP_FOLDER_ATTR } from '@/hooks/use-file-drop'
 import { BookmarkMenuItem } from '@/components/sidebar/bookmark-menu-item'
 import { OpenTargetMenuItems } from '@/components/sidebar/open-target-menu-items'
 import { noteTabData, folderTabData } from '@/lib/sidebar-tab-data'
+import { resolveDropPosition, type DropPosition } from '@/lib/tree-drop-position'
 import { useT } from '@memry/i18n/renderer'
 
 // ============================================================================
 // Types
 // ============================================================================
 
-export type DropPosition = 'before' | 'after' | 'inside'
+export type { DropPosition }
 
 export type MoveOperation = {
   draggedId: string
@@ -295,7 +296,7 @@ interface FolderRowProps {
   onBulkDelete?: () => void
   onDragStart: (e: React.DragEvent, itemId: string) => void
   onDragEnd: () => void
-  onDragOver: (e: React.DragEvent, itemId: string, hasChildren: boolean) => void
+  onDragOver: (e: React.DragEvent, itemId: string, canDropInside: boolean) => void
   onDragLeave: (e: React.DragEvent) => void
   onDrop: (e: React.DragEvent) => void
   folderTemplateName?: string
@@ -391,9 +392,12 @@ function FolderRow({
 
   const handleDragOver = useCallback(
     (e: React.DragEvent) => {
-      onDragOver(e, item.id, item.hasChildren)
+      // `true` regardless of `item.hasChildren` — an empty folder is still a
+      // folder, and reading emptiness here is what made a newly created one
+      // refuse every drop until it had a child.
+      onDragOver(e, item.id, true)
     },
-    [item.id, item.hasChildren, onDragOver]
+    [item.id, onDragOver]
   )
 
   return (
@@ -616,7 +620,7 @@ interface NoteRowProps {
   onBulkDelete?: () => void
   onDragStart: (e: React.DragEvent, itemId: string) => void
   onDragEnd: () => void
-  onDragOver: (e: React.DragEvent, itemId: string, hasChildren: boolean) => void
+  onDragOver: (e: React.DragEvent, itemId: string, canDropInside: boolean) => void
   onDragLeave: (e: React.DragEvent) => void
   onDrop: (e: React.DragEvent) => void
 }
@@ -1168,7 +1172,7 @@ export function VirtualizedNotesTree({
   }, [])
 
   const handleDragOver = useCallback(
-    (e: React.DragEvent, itemId: string, hasChildren: boolean) => {
+    (e: React.DragEvent, itemId: string, canDropInside: boolean) => {
       // A file coming from outside the app is not a reorder — the sidebar's file
       // drop zone handles it, and a before/after indicator would lie about it.
       if (e.dataTransfer.types.includes('Files')) return
@@ -1178,18 +1182,7 @@ export function VirtualizedNotesTree({
       e.dataTransfer.dropEffect = 'move'
 
       const rect = e.currentTarget.getBoundingClientRect()
-      const y = e.clientY - rect.top
-      const height = rect.height
-      const threshold = height / 3
-
-      let position: DropPosition
-      if (y < threshold) {
-        position = 'before'
-      } else if (y > height - threshold) {
-        position = 'after'
-      } else {
-        position = hasChildren ? 'inside' : 'after'
-      }
+      const position = resolveDropPosition(e.clientY - rect.top, rect.height, canDropInside)
 
       setDragState((prev) => ({
         ...prev,

--- a/apps/desktop/src/renderer/src/lib/tree-drop-position.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tree-drop-position.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveDropPosition } from './tree-drop-position'
+
+const HEIGHT = 28
+
+describe('resolveDropPosition', () => {
+  it('drops inside a row that takes children, whether or not it has any', () => {
+    // The empty case is the regression: the virtualized tree used to read
+    // "has children" as "takes children", so a folder created a moment ago
+    // could not receive a drop until something else was put in it first.
+    expect(resolveDropPosition(HEIGHT / 2, HEIGHT, true)).toBe('inside')
+    expect(resolveDropPosition(HEIGHT / 2 + 1, HEIGHT, true)).toBe('inside')
+  })
+
+  it('keeps a narrow reorder band at each edge of a row that takes children', () => {
+    expect(resolveDropPosition(1, HEIGHT, true)).toBe('before')
+    expect(resolveDropPosition(HEIGHT - 1, HEIGHT, true)).toBe('after')
+    // Just inside the quarter bands, so still a drop into the row.
+    expect(resolveDropPosition(HEIGHT / 4 + 1, HEIGHT, true)).toBe('inside')
+    expect(resolveDropPosition((HEIGHT * 3) / 4 - 1, HEIGHT, true)).toBe('inside')
+  })
+
+  it('splits a row that takes no children in half, never offering inside', () => {
+    expect(resolveDropPosition(1, HEIGHT, false)).toBe('before')
+    expect(resolveDropPosition(HEIGHT / 2 - 1, HEIGHT, false)).toBe('before')
+    expect(resolveDropPosition(HEIGHT / 2, HEIGHT, false)).toBe('after')
+    expect(resolveDropPosition(HEIGHT - 1, HEIGHT, false)).toBe('after')
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/tree-drop-position.ts
+++ b/apps/desktop/src/renderer/src/lib/tree-drop-position.ts
@@ -1,0 +1,36 @@
+/**
+ * The single drop contract for both sidebar trees.
+ *
+ * The sidebar swaps between two implementations of the same tree — the
+ * kibo `TreeNode` one and `VirtualizedNotesTree`, once the vault passes the
+ * virtualization threshold — so the geometry that decides before/after/inside
+ * has to live in one place. It did not: the virtualized copy resolved the
+ * middle band from `hasChildren`, so a freshly created (empty) folder never
+ * offered "inside" and could not take a dropped folder until it already had
+ * one child.
+ */
+
+export type DropPosition = 'before' | 'after' | 'inside'
+
+/**
+ * Resolve where a drag hovering over a row should land.
+ *
+ * `canDropInside` is a property of the row itself (a folder accepts children,
+ * a note does not) — never of whether the row currently has any.
+ *
+ * @param offsetY pointer position relative to the row's top edge
+ * @param height the row's height
+ */
+export function resolveDropPosition(
+  offsetY: number,
+  height: number,
+  canDropInside: boolean
+): DropPosition {
+  // A row that takes children keeps a narrow reorder band at each edge so the
+  // bulk of it drops inside; one that cannot just splits in half.
+  const threshold = canDropInside ? height / 4 : height / 2
+
+  if (offsetY < threshold) return 'before'
+  if (offsetY > height - threshold) return 'after'
+  return canDropInside ? 'inside' : 'after'
+}

--- a/apps/docs/src/guide/tour.md
+++ b/apps/docs/src/guide/tour.md
@@ -24,6 +24,8 @@ Sections from top to bottom:
 
 Drag any section item to reorder, or right-click for a context menu.
 
+Inside the **Notes** tree, drag a note or folder to move it. Where you drop on a row decides what happens: the top and bottom edges reorder around that row, while the middle of a folder row drops the item **into** that folder. An empty folder takes a drop the same as a full one, so a folder you just created is ready to receive notes immediately. Notes hold no children, so dropping on a note always reorders.
+
 The **Notes** tree loads 10,000 notes at a time, most recently modified first. If your vault holds more than that, a footer row under the tree says how many older notes it is not showing and offers **Load more** to pull in the next batch. Notes past the ceiling are never hidden silently — and they stay reachable through search either way.
 
 At the bottom of the sidebar, a footer row holds three controls, left to right:


### PR DESCRIPTION
Closes C1 of #1625.

## The bug

Create a folder, drag another folder onto it, and the drop is refused. The user found the workaround themselves: create a subfolder inside it first, and from then on the drag works.

`virtualized-notes-tree.tsx` resolved a row's middle band from `hasChildren`:

```
position = hasChildren ? 'inside' : 'after'
```

An empty folder has `hasChildren === false`, so its middle band resolved to `'after'` and "drop into this folder" was never offered. Adding a child flipped the flag, which is exactly the workaround.

The non-virtualized tree never had the bug: `kibo-ui/tree/index.tsx` reads `canDropInside = hasChildren || acceptsDropInside`, and `notes-tree.tsx` passes `acceptsDropInside` on every folder row. The virtualized tree is a second, drifted implementation of the same tree and never picked that escape hatch up — same family as A1 of #1563.

## The fix

One drop contract for both trees: `resolveDropPosition(offsetY, height, canDropInside)` in `apps/desktop/src/renderer/src/lib/tree-drop-position.ts`. Both trees call it; neither computes drop geometry on its own any more.

- Folder rows pass `canDropInside: true` whether or not they currently hold anything. Emptiness is not a property of what a folder accepts.
- Note rows pass `false`.
- The virtualized tree's edge bands narrow from `h/3` to `h/4`, matching the other tree. Both sides of the virtualization threshold now behave identically.

## Tests

Regression tests on both sides of the threshold, plus a unit test for the shared contract:

- `virtualized-notes-tree.test.tsx` — dropping a folder into an empty folder resolves `'inside'`; edge bands still reorder; a note row never offers `'inside'`.
- `kibo-ui/tree/index.test.tsx` — same empty-folder drop on the non-virtualized tree.
- `lib/tree-drop-position.test.ts` — the contract itself.

Mutation-checked, both directions: restoring `item.hasChildren` on the folder row turns the new virtualized test red; flipping the helper's final branch to `'after'` turns 5 tests red across all three files.

**Worth knowing:** both suites' pre-existing drag tests were geometry-blind. jsdom's `DragEvent` carries no mouse coordinates, so `fireEvent.dragOver(row, { clientY })` delivered `undefined`, `y` was `NaN`, every comparison failed, and the code fell through to its final `else`. The tests passed while asserting nothing about the drop bands — which is how this bug lived inside tested code. The new tests set `clientY` on the event itself via `createEvent` + `Object.defineProperty`.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors
- 7 renderer suites covering both trees — 90 tests pass (re-run after merging `origin/main`)
- `pnpm docs:impact --base origin/main --strict` — pass
- `pnpm docs:build` — pass
