### PR TITLE
fix(tabs): your tabs come back after a restart instead of collapsing to Home

### DIFF
--- a/apps/desktop/src/renderer/src/App.test.tsx
+++ b/apps/desktop/src/renderer/src/App.test.tsx
@@ -185,7 +185,8 @@ vi.mock('@/contexts/tabs', () => ({
 vi.mock('@/contexts/tabs/persistence', () => ({
   STORAGE_KEY: 'tabs-state',
   useTabPersistence: vi.fn(),
-  useSessionRestore: vi.fn()
+  useSessionRestore: vi.fn(),
+  useTabSessionPersistence: vi.fn()
 }))
 
 vi.mock('@/contexts/tasks', () => ({

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -22,7 +22,7 @@ import { ThemeProvider } from 'next-themes'
 
 // Tab System imports
 import { TabProvider, useTabs } from '@/contexts/tabs'
-import { useTabPersistence, useSessionRestore, STORAGE_KEY } from '@/contexts/tabs/persistence'
+import { useTabSessionPersistence, STORAGE_KEY } from '@/contexts/tabs/persistence'
 import { TasksProvider } from '@/contexts/tasks'
 import { TabDragProvider, TabErrorBoundary } from '@/components/tabs'
 import { SplitViewContainer } from '@/components/split-view'
@@ -123,11 +123,10 @@ function ThemeSyncManager({ children }: { children: React.ReactNode }): React.JS
  * Must be rendered inside TabProvider.
  */
 function TabPersistenceManager({ children }: { children: React.ReactNode }): React.JSX.Element {
-  // Auto-save tab state on changes (debounced)
-  useTabPersistence()
-
-  // Restore session on mount
-  useSessionRestore()
+  // Restore the stored session on mount, and hold the debounced auto-save until
+  // that restore has landed — otherwise the save writes the provider's default
+  // Home tab over the session the restore is still on its way to read.
+  useTabSessionPersistence()
 
   return <>{children}</>
 }

--- a/apps/desktop/src/renderer/src/App.workspace-counts.test.tsx
+++ b/apps/desktop/src/renderer/src/App.workspace-counts.test.tsx
@@ -199,7 +199,8 @@ vi.mock('@/contexts/tabs', () => ({
 vi.mock('@/contexts/tabs/persistence', () => ({
   STORAGE_KEY: 'tabs-state',
   useTabPersistence: vi.fn(),
-  useSessionRestore: vi.fn()
+  useSessionRestore: vi.fn(),
+  useTabSessionPersistence: vi.fn()
 }))
 
 vi.mock('@/contexts/tasks', () => ({

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts
@@ -318,6 +318,45 @@ export const useSessionRestore = (
 }
 
 // =============================================================================
+// STARTUP WIRING
+// =============================================================================
+
+interface UseTabSessionPersistenceOptions extends UseTabPersistenceOptions {
+  /** Auto-restore on mount (default: true) */
+  autoRestore?: boolean
+}
+
+/**
+ * Restore the stored session, then keep saving it.
+ *
+ * Mounting the two halves next to each other is not the same as ordering them.
+ * `useTabPersistence` starts its debounce from whatever the provider built at
+ * mount — one Home tab — while `useSessionRestore` cannot read storage until
+ * the feature-flag IPC answers, because the flags decide which tab types are
+ * still restorable. On a cold start with a busy main process that round trip
+ * routinely outlasts the debounce, so the auto-save wrote the default state
+ * over the real session and the restore then read back the single Home tab it
+ * had just destroyed. Holding auto-save until the restore settles is what makes
+ * that order deterministic instead of a race the user loses more often as their
+ * vault grows.
+ */
+export const useTabSessionPersistence = (
+  options: UseTabSessionPersistenceOptions = {}
+): UseSessionRestoreResult => {
+  const { storage, debounceMs, enabled = true, autoRestore } = options
+
+  const restore = useSessionRestore({ storage, autoRestore })
+
+  useTabPersistence({
+    storage,
+    debounceMs,
+    enabled: enabled && !restore.isRestoring
+  })
+
+  return restore
+}
+
+// =============================================================================
 // MANUAL SAVE/LOAD
 // =============================================================================
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/index.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/index.ts
@@ -17,4 +17,9 @@ export type { SyncSaveFailure, SyncSaveResult } from './storage'
 export { migratePersistedState, needsMigration, getMigrationDescription } from './migrations'
 
 // Hooks
-export { useTabPersistence, useSessionRestore, useManualPersistence } from './hooks'
+export {
+  useTabPersistence,
+  useSessionRestore,
+  useTabSessionPersistence,
+  useManualPersistence
+} from './hooks'

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
@@ -2,7 +2,12 @@ import { act, render, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { useManualPersistence, useSessionRestore, useTabPersistence } from './hooks'
+import {
+  useManualPersistence,
+  useSessionRestore,
+  useTabPersistence,
+  useTabSessionPersistence
+} from './hooks'
 import {
   consumeSyncSaveFailure,
   isQuotaExceededError,
@@ -24,7 +29,19 @@ const mocks = vi.hoisted(() => ({
   unregisterPendingSave: vi.fn(),
   toastError: vi.fn(),
   toastWarning: vi.fn(),
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  // The restore reads storage only once the flag IPC has answered; holding this
+  // true is how a test stands in for a cold start whose main process is busy.
+  flagsLoading: false,
+  flags: {
+    home: true,
+    inbox: true,
+    journal: true,
+    tasks: true,
+    calendar: true,
+    graph: true,
+    spatialCanvas: true
+  }
 }))
 
 vi.mock('sonner', () => ({
@@ -58,6 +75,16 @@ vi.mock('@/lib/save-registry', () => ({
 
 vi.mock('@/lib/logger', () => ({
   createLogger: () => mocks.logger
+}))
+
+vi.mock('@/hooks/use-feature-flags', () => ({
+  useFeatureFlags: () => ({
+    flags: mocks.flags,
+    isLoading: mocks.flagsLoading,
+    error: null,
+    isEnabled: () => true,
+    setFlag: vi.fn()
+  })
 }))
 
 /**
@@ -269,6 +296,48 @@ function SessionRestoreProbe({
 let manualSnapshot: ReturnType<typeof useManualPersistence> | null = null
 function ManualPersistenceProbe({ storage }: { storage: TabStorage }) {
   manualSnapshot = useManualPersistence(storage)
+  return null
+}
+
+/**
+ * What `createInitialState` hands the provider before anything is restored:
+ * one Home tab, in a group whose id has nothing to do with the stored session.
+ */
+const startupState = (): TabSystemState =>
+  ({
+    activeGroupId: 'startup-group',
+    tabGroups: {
+      'startup-group': {
+        id: 'startup-group',
+        activeTabId: 'home-1',
+        tabs: [
+          {
+            id: 'home-1',
+            type: 'home',
+            title: 'Home',
+            icon: 'home',
+            path: '/home',
+            isPinned: false,
+            isModified: false,
+            isPreview: false,
+            isDeleted: false,
+            openedAt: 1,
+            lastAccessedAt: 1
+          }
+        ],
+        isActive: true,
+        back: [],
+        forward: []
+      }
+    },
+    layout: { type: 'leaf', tabGroupId: 'startup-group' },
+    settings: state().settings,
+    recentlyClosed: []
+  }) as TabSystemState
+
+/** Mounts the pair exactly the way `TabPersistenceManager` does at app start. */
+function StartupProbe({ storage, debounceMs }: { storage: TabStorage; debounceMs: number }) {
+  sessionSnapshot = useTabSessionPersistence({ storage, debounceMs })
   return null
 }
 
@@ -746,5 +815,79 @@ describe('tab persistence hooks', () => {
     )
     await act(async () => manualSnapshot?.clear())
     expect(storage.clear).toHaveBeenCalled()
+  })
+})
+
+describe('tab session persistence startup order', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    localStorage.clear()
+    mocks.tabsState = startupState()
+    mocks.flagsLoading = true
+    sessionSnapshot = null
+
+    // Stand in for the reducer: the real provider swaps its default state for
+    // the restored one, which is what the first post-restore save must write.
+    mocks.dispatch.mockImplementation((action: { type: string; payload?: unknown }) => {
+      if (action.type !== 'RESTORE_SESSION') return
+      mocks.tabsState = {
+        ...(mocks.tabsState as TabSystemState),
+        ...(action.payload as Partial<TabSystemState>)
+      } as TabSystemState
+    })
+  })
+
+  afterEach(() => {
+    mocks.flagsLoading = false
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('does not overwrite the stored session while the restore is still gated on feature flags', async () => {
+    const stored = persisted()
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(stored))
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+    })
+    const tree = () => (
+      <QueryClientProvider client={queryClient}>
+        <StartupProbe storage={localStorageAdapter} debounceMs={25} />
+      </QueryClientProvider>
+    )
+
+    const { rerender } = render(tree())
+
+    // Four debounce windows pass with the flag IPC still unanswered. This gap is
+    // the whole bug: auto-save used to fill it with the Home-only default, and
+    // the restore then read its own damage back as the user's session.
+    act(() => vi.advanceTimersByTime(100))
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null')).toEqual(stored)
+
+    // Flags land; the restore finally gets its read.
+    mocks.flagsLoading = false
+    rerender(tree())
+
+    await waitFor(() =>
+      expect(mocks.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'RESTORE_SESSION' })
+      )
+    )
+
+    const restoreCall = mocks.dispatch.mock.calls.find(
+      (call) => call[0]?.type === 'RESTORE_SESSION'
+    )
+    const payload = restoreCall?.[0].payload as Partial<TabSystemState> | undefined
+    expect(payload?.tabGroups?.['group-1'].tabs.map((item) => item.id)).toEqual(['pin-1', 'note-1'])
+
+    // Saving resumes once the restore has landed, and what it writes is the
+    // restored session rather than the default it started from.
+    await waitFor(() => expect(sessionSnapshot?.isRestoring).toBe(false))
+    act(() => vi.advanceTimersByTime(100))
+
+    const written = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as PersistedTabState
+    expect(Object.keys(written.tabGroups)).toEqual(['group-1'])
+    expect(written.tabGroups['group-1'].tabs.map((item) => item.id)).toEqual(['pin-1', 'note-1'])
   })
 })

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -147,6 +147,12 @@ If **Restore Session** is on, the entire tab and split layout restores on app la
 
 The layout is written only when one of those things actually changes. Activity that leaves the layout alone — a note picking up and losing its modified dot, moving back and forward inside a tab — no longer triggers a rewrite. Quitting still writes the current layout either way, so nothing is lost by the skipped writes.
 
+### The restore goes first
+
+Saving is held until the stored session has been read back. Before that, a slow launch could let the first automatic save run while the window was still showing its opening Home tab, which wrote that single tab over the session waiting in storage — the restore then had nothing left to bring back, and you arrived at a Home tab even if you had closed Home before quitting. Pinned tabs went the same way, since they live in the same stored layout.
+
+The launches most likely to hit it were the slow ones: a large vault, the first open after an update, a cold start on a busy machine. That is also why it tended to show up more often over time rather than all at once. Nothing about your stored layout was ever corrupted, so no cleanup is needed — the first launch after updating restores the session you last quit with.
+
 ### Scroll Position
 
 Note tabs — including the template editor and release-notes tabs — remember where you were reading. Switch to another tab and back, or restart with **Restore Session** on, and the note returns to the same place.


### PR DESCRIPTION
Closes B1 of #1625.

## What users saw

"When coming back the next time the app is launched, opened tabs (including pinned ones) get all closed. It doesn't preserve opened tabs and their layout. Only home tab is opened (even if at a certain point it was closed)." Reported 19 Aug on `v2026-08-17`, Win32, and getting more frequent.

## Root cause

`TabPersistenceManager` mounted the auto-save and the session restore next to each other. That is not the same as ordering them.

| t | what happens |
|---|---|
| 0 | `useTabPersistence` arms its 1000 ms debounce over the state the provider built at mount: one Home tab, from `createInitialState` |
| 0 | `useSessionRestore` stops at the `flagsLoading` guard in `hooks.ts` and does not read storage — the flags decide which tab types are still restorable |
| 1000 ms | the debounce fires and writes the Home-only default over `memry_tab_state` |
| flags land | the restore finally reads, and gets back the single Home tab it just destroyed |

The `flagsLoading` guard arrived in `259d7a7e5` (#629, 30 Jun), which is where the regression starts. On a cold start the main process is busy opening the vault and building the index, so that IPC round trip routinely outlasts the debounce. Bigger vault, slower answer, more often lost — which is exactly the "getting more frequent" the report describes.

## Hypotheses ruled out, with evidence

- **localStorage lost at the origin.** `sidebar-tree-expanded`, the sidebar width and the first-run tour flag live in the same origin and all survive a restart. If the origin were being cleared, the onboarding tour would replay on every launch. It does not. Only this one key was overwritten.
- **Quota.** `saveSync` leaves a marker on a refused write and the next launch raises a toast. Nobody reported one.
- **Settings / the feature-flag filter.** `restoreSessionOnStart` defaults to `true`, and pinned tabs are restored separately even when it is off. Pinned tabs were gone too, so neither explains it.

## The fix

`useTabSessionPersistence` owns the order: restore first, hold auto-save until `isRestoring` clears. Keeping it inside the module means a future caller cannot mis-wire it by mounting the two halves in the wrong order again.

Once the restore lands, the state the provider holds is the restored session, so the first save after that writes it straight back.

## Evidence

The regression test mounts the pair the way the app does and holds the flag IPC open across four debounce windows. Mutating the gate away turns it red on the exact user symptom:

```
- "activeGroupId": "group-1"       (pin-1 Inbox + note-1)
+ "activeGroupId": "startup-group" (home-1)
```

Every existing test mounted the two hooks separately, which is why the race was never visible.

- `persistence.test.tsx` 17/17
- full renderer project: 642 files, 7701 passed, 7 skipped
- `pnpm typecheck` clean across all 17 packages
- `pnpm lint` 0 errors (97 pre-existing warnings, none in touched files)
- `pnpm docs:impact --strict` covered, `pnpm docs:build` green

## Noticed, not fixed

`App.tsx` clears `memry_tab_state` and `sidebar-tree-expanded` when the vault path changes. The `prevVaultPathRef` guard keeps it off the normal launch path, but if a path's representation ever changes mid-session on Windows (casing, trailing slash) it would fire every launch. That would also collapse the whole sidebar tree, which nobody reported, so it is a separate question rather than part of this fix.