### PR TITLE
feat(home): rename, reorder and delete Home boards from a manager dialog

### DIFF
--- a/apps/desktop/src/renderer/src/components/home/board-manager-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/home/board-manager-dialog.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BoardManagerDialog } from './board-manager-dialog'
+import type { HomePage } from '@/lib/home/types'
+
+const board = (id: string, name: string, position: number): HomePage => ({
+  id,
+  name,
+  position,
+  widgets: []
+})
+
+const boards = [board('b1', 'Home', 0), board('b2', 'Work', 1)]
+
+function setup(overrides: Partial<React.ComponentProps<typeof BoardManagerDialog>> = {}) {
+  const props = {
+    boards,
+    open: true,
+    onOpenChange: vi.fn(),
+    onRename: vi.fn(),
+    onDelete: vi.fn(),
+    onReorder: vi.fn(),
+    ...overrides
+  }
+  render(<BoardManagerDialog {...props} />)
+  return props
+}
+
+describe('BoardManagerDialog', () => {
+  it('lists one row per board, in board order', () => {
+    setup()
+    const rows = screen.getAllByTestId('board-manager-row')
+    expect(rows.map((r) => r.getAttribute('data-board-id'))).toEqual(['b1', 'b2'])
+  })
+
+  it('renames a board on Enter', async () => {
+    const user = userEvent.setup()
+    const { onRename } = setup()
+
+    await user.click(screen.getAllByTestId('board-manager-rename')[1])
+    const input = screen.getByTestId('board-manager-name-input')
+    await user.clear(input)
+    await user.type(input, '  Planning  {Enter}')
+
+    expect(onRename).toHaveBeenCalledWith('b2', 'Planning')
+  })
+
+  it('keeps the dialog open and drops the edit on Escape', async () => {
+    const user = userEvent.setup()
+    const { onRename, onOpenChange } = setup()
+
+    await user.click(screen.getAllByTestId('board-manager-name')[0])
+    await user.type(screen.getByTestId('board-manager-name-input'), 'X{Escape}')
+
+    expect(onRename).not.toHaveBeenCalled()
+    expect(onOpenChange).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('board-manager-name-input')).not.toBeInTheDocument()
+  })
+
+  it('does not call onRename when the name is unchanged or blank', async () => {
+    const user = userEvent.setup()
+    const { onRename } = setup()
+
+    await user.click(screen.getAllByTestId('board-manager-name')[0])
+    await user.type(screen.getByTestId('board-manager-name-input'), '{Enter}')
+    expect(onRename).not.toHaveBeenCalled()
+
+    await user.click(screen.getAllByTestId('board-manager-name')[0])
+    const input = screen.getByTestId('board-manager-name-input')
+    await user.clear(input)
+    await user.type(input, '   {Enter}')
+    expect(onRename).not.toHaveBeenCalled()
+  })
+
+  it('deletes a board, and refuses to delete the last one', async () => {
+    const user = userEvent.setup()
+    const { onDelete } = setup()
+
+    await user.click(screen.getAllByTestId('board-manager-delete')[1])
+    expect(onDelete).toHaveBeenCalledWith('b2')
+
+    screen.getAllByTestId('board-manager-delete').forEach((b) => expect(b).toBeEnabled())
+  })
+
+  it('disables delete when a single board is left', () => {
+    setup({ boards: [board('b1', 'Home', 0)] })
+    expect(screen.getByTestId('board-manager-delete')).toBeDisabled()
+  })
+
+  it('renders nothing while closed', () => {
+    setup({ open: false })
+    expect(screen.queryByTestId('board-manager')).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/home/board-manager-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/home/board-manager-dialog.tsx
@@ -1,0 +1,262 @@
+import { useMemo, useState } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent
+} from '@dnd-kit/core'
+import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers'
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { GripVertical, Pencil, Trash } from '@/lib/icons/icon-map'
+import { cn } from '@/lib/utils'
+import type { HomePage } from '@/lib/home/types'
+import { useT } from '@memry/i18n/renderer'
+
+interface BoardManagerDialogProps {
+  boards: HomePage[]
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onRename: (id: string, name: string) => void
+  onDelete: (id: string) => void
+  onReorder: (ids: string[]) => void
+}
+
+interface BoardRowProps {
+  board: HomePage
+  editing: boolean
+  draft: string
+  canDelete: boolean
+  onDraftChange: (value: string) => void
+  onStartRename: () => void
+  onCommitRename: () => void
+  onDelete: () => void
+}
+
+function BoardRow({
+  board,
+  editing,
+  draft,
+  canDelete,
+  onDraftChange,
+  onStartRename,
+  onCommitRename,
+  onDelete
+}: BoardRowProps): React.JSX.Element {
+  const { t } = useT('common')
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: board.id
+  })
+
+  return (
+    <li
+      ref={setNodeRef}
+      data-testid="board-manager-row"
+      data-board-id={board.id}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        'flex items-center gap-2 rounded-lg px-1.5 py-1 transition-colors hover:bg-muted/50',
+        isDragging && 'relative z-10 bg-muted/60 shadow-sm'
+      )}
+    >
+      <button
+        type="button"
+        data-testid="board-manager-drag"
+        aria-label={t('home.board.reorderAria')}
+        className="inline-flex size-7 shrink-0 cursor-grab items-center justify-center rounded text-text-tertiary transition-colors hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="size-4" aria-hidden="true" />
+      </button>
+
+      {editing ? (
+        <Input
+          data-testid="board-manager-name-input"
+          aria-label={t('home.board.nameLabel')}
+          value={draft}
+          autoFocus
+          onChange={(event) => onDraftChange(event.target.value)}
+          onBlur={onCommitRename}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault()
+              onCommitRename()
+            }
+          }}
+          className="h-7 flex-1 text-sm"
+        />
+      ) : (
+        <button
+          type="button"
+          data-testid="board-manager-name"
+          onDoubleClick={onStartRename}
+          onClick={onStartRename}
+          className="flex-1 truncate rounded px-1 text-start text-sm text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
+        >
+          {board.name}
+        </button>
+      )}
+
+      <button
+        type="button"
+        data-testid="board-manager-rename"
+        aria-label={t('home.board.renameAria')}
+        onClick={onStartRename}
+        className="inline-flex size-7 shrink-0 items-center justify-center rounded text-text-tertiary transition-colors hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
+      >
+        <Pencil className="size-3.5" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        data-testid="board-manager-delete"
+        aria-label={t('home.board.deleteAria')}
+        disabled={!canDelete}
+        onClick={onDelete}
+        className="inline-flex size-7 shrink-0 items-center justify-center rounded text-text-tertiary transition-colors hover:text-destructive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)] disabled:pointer-events-none disabled:opacity-40"
+      >
+        <Trash className="size-3.5" aria-hidden="true" />
+      </button>
+    </li>
+  )
+}
+
+/**
+ * Rename, reorder and delete Home boards.
+ *
+ * Lives in a dialog rather than inside the switcher dropdown on purpose: a Radix menu
+ * restores focus to its trigger when its content unmounts, which blurs any inline field
+ * a menu item just opened (see canvas-row-menu).
+ */
+export function BoardManagerDialog({
+  boards,
+  open,
+  onOpenChange,
+  onRename,
+  onDelete,
+  onReorder
+}: BoardManagerDialogProps): React.JSX.Element {
+  const { t } = useT('common')
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draft, setDraft] = useState('')
+  // Reorder round-trips through the main process and comes back as a refetch, so hold
+  // the dragged order locally until the refreshed list agrees with it.
+  const [pendingIds, setPendingIds] = useState<string[] | null>(null)
+
+  // Reset while closed, during render — no effect needed.
+  const [openSnapshot, setOpenSnapshot] = useState(open)
+  if (open !== openSnapshot) {
+    setOpenSnapshot(open)
+    if (!open) {
+      setEditingId(null)
+      setPendingIds(null)
+    }
+  }
+
+  const orderedBoards = useMemo(() => {
+    if (!pendingIds) return boards
+    const byId = new Map(boards.map((b) => [b.id, b]))
+    const ordered = pendingIds
+      .map((id) => byId.get(id))
+      .filter((b): b is HomePage => b !== undefined)
+    // A peer's create can land while the local order is still in flight.
+    const rest = boards.filter((b) => !pendingIds.includes(b.id))
+    return [...ordered, ...rest]
+  }, [boards, pendingIds])
+
+  if (pendingIds && orderedBoards.every((b, i) => b.id === boards[i]?.id)) setPendingIds(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const commitRename = (): void => {
+    if (!editingId) return
+    const next = draft.trim()
+    const current = boards.find((b) => b.id === editingId)
+    if (next && current && next !== current.name) onRename(editingId, next)
+    setEditingId(null)
+  }
+
+  const handleDragEnd = (event: DragEndEvent): void => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const ids = orderedBoards.map((b) => b.id)
+    const from = ids.indexOf(String(active.id))
+    const to = ids.indexOf(String(over.id))
+    if (from === -1 || to === -1) return
+    const next = arrayMove(ids, from, to)
+    setPendingIds(next)
+    onReorder(next)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        data-testid="board-manager"
+        className="sm:max-w-md"
+        onEscapeKeyDown={(event) => {
+          // Radix dismisses on a document-level keydown, so an inline edit has to
+          // decline it here — a stopPropagation on the input never reaches it.
+          if (!editingId) return
+          event.preventDefault()
+          setEditingId(null)
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{t('home.board.manageTitle')}</DialogTitle>
+          <DialogDescription>{t('home.board.manageDescription')}</DialogDescription>
+        </DialogHeader>
+
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={orderedBoards.map((b) => b.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul className="flex flex-col gap-0.5 py-1">
+              {orderedBoards.map((board) => (
+                <BoardRow
+                  key={board.id}
+                  board={board}
+                  editing={editingId === board.id}
+                  draft={draft}
+                  canDelete={boards.length > 1}
+                  onDraftChange={setDraft}
+                  onStartRename={() => {
+                    setEditingId(board.id)
+                    setDraft(board.name)
+                  }}
+                  onCommitRename={commitRename}
+                  onDelete={() => onDelete(board.id)}
+                />
+              ))}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/home/home-header.tsx
+++ b/apps/desktop/src/renderer/src/components/home/home-header.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react'
+import { Fragment, useRef } from 'react'
 import { useT } from '@memry/i18n/renderer'
 import { useTaskWorkspaceData } from '@/features/tasks/use-task-queries'
 import { getTaskCounts } from '@/lib/task-utils/task-view-helpers'
@@ -13,7 +13,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { WidgetGallery } from '@/components/home/widget-gallery'
-import { Check, ChevronDown, Plus, Trash } from '@/lib/icons/icon-map'
+import { Check, ChevronDown, Plus, Settings2, Trash } from '@/lib/icons/icon-map'
 
 // Start/end of the local day as ISO strings. Stable for the whole day, so the
 // calendar query key doesn't churn between renders.
@@ -31,6 +31,7 @@ interface HomeHeaderProps {
   onSelectBoard: (id: string) => void
   onCreateBoard: () => void
   onDeleteBoard: (id: string) => void
+  onManageBoards: () => void
   showAddWidget: boolean
   galleryOpen: boolean
   onGalleryOpenChange: (open: boolean) => void
@@ -47,12 +48,19 @@ export function HomeHeader({
   onSelectBoard,
   onCreateBoard,
   onDeleteBoard,
+  onManageBoards,
   showAddWidget,
   galleryOpen,
   onGalleryOpenChange,
   onAddWidget
 }: HomeHeaderProps): React.JSX.Element {
   const { t, i18n } = useT('common')
+
+  // A Radix menu restores focus to its trigger when the content UNMOUNTS — after the
+  // exit animation, ~150ms later. The board manager opens an inline rename field, so
+  // that late restore would blur the field and close it (see canvas-row-menu, and the
+  // e2e B7 case). Decline the restore for that one path only.
+  const suppressCloseAutoFocus = useRef(false)
 
   const { tasks, projects } = useTaskWorkspaceData({ enabled: true })
   const tasksDue = getTaskCounts(tasks, 'today', 'view', projects).dueToday
@@ -102,7 +110,15 @@ export function HomeHeader({
             <span className="max-w-40 truncate font-medium">{activeName}</span>
             <ChevronDown className="size-3.5 shrink-0 opacity-70" aria-hidden="true" />
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="min-w-52">
+          <DropdownMenuContent
+            align="end"
+            className="min-w-52"
+            onCloseAutoFocus={(event) => {
+              if (!suppressCloseAutoFocus.current) return
+              suppressCloseAutoFocus.current = false
+              event.preventDefault()
+            }}
+          >
             {boards.map((b) => (
               <DropdownMenuItem
                 key={b.id}
@@ -134,6 +150,16 @@ export function HomeHeader({
             <DropdownMenuItem data-testid="home-layout-new" onSelect={onCreateBoard}>
               <Plus className="size-4 shrink-0" aria-hidden="true" />
               {t('home.board.newName')}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              data-testid="home-layout-manage"
+              onSelect={() => {
+                suppressCloseAutoFocus.current = true
+                onManageBoards()
+              }}
+            >
+              <Settings2 className="size-4 shrink-0" aria-hidden="true" />
+              {t('home.board.manage')}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/apps/desktop/src/renderer/src/hooks/use-home-boards.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-home-boards.test.tsx
@@ -68,6 +68,20 @@ describe('useHomeBoards', () => {
     expect(window.api.homePages.update).toHaveBeenCalledWith({ id: 'b1', widgets: [] })
   })
 
+  it('renameBoard calls api.update with the new name only', async () => {
+    const { result } = renderHook(() => useHomeBoards(), { wrapper })
+    await waitFor(() => expect(result.current.boards).toHaveLength(1))
+    await act(() => result.current.renameBoard('b1', 'Planning'))
+    expect(window.api.homePages.update).toHaveBeenCalledWith({ id: 'b1', name: 'Planning' })
+  })
+
+  it('reorderBoards calls api.reorder with the new id order', async () => {
+    const { result } = renderHook(() => useHomeBoards(), { wrapper })
+    await waitFor(() => expect(result.current.boards).toHaveLength(1))
+    await act(() => result.current.reorderBoards(['b2', 'b1']))
+    expect(window.api.homePages.reorder).toHaveBeenCalledWith(['b2', 'b1'])
+  })
+
   // Boards sync, so a peer's create/rename/drag/delete arrives as an event
   // rather than a local mutation — without these the second device shows a stale
   // board until restart.

--- a/apps/desktop/src/renderer/src/pages/home.tsx
+++ b/apps/desktop/src/renderer/src/pages/home.tsx
@@ -3,6 +3,7 @@ import '@/components/home/widgets'
 import { HomeHeader } from '@/components/home/home-header'
 import { BoardGrid } from '@/components/home/board-grid'
 import { BoardEmptyState } from '@/components/home/board-empty-state'
+import { BoardManagerDialog } from '@/components/home/board-manager-dialog'
 import { HomeDisabledLauncher } from '@/components/home/home-disabled-launcher'
 import { useHomeBoards } from '@/hooks/use-home-boards'
 import { useHomeSeedGate } from '@/hooks/use-home-seed-gate'
@@ -59,6 +60,7 @@ export default function HomePage(): React.JSX.Element {
   }, [openTab])
 
   const [galleryOpen, setGalleryOpen] = useState(false)
+  const [managerOpen, setManagerOpen] = useState(false)
   // The header floats over the board (.home-chrome, sticky); its material (blur + translucent
   // background) only appears once content actually scrolls underneath it.
   const [scrolled, setScrolled] = useState(false)
@@ -69,7 +71,9 @@ export default function HomePage(): React.JSX.Element {
     setActiveBoardId,
     isLoading,
     createBoard,
+    renameBoard,
     deleteBoard,
+    reorderBoards,
     updateWidgets
   } = useHomeBoards()
 
@@ -144,12 +148,21 @@ export default function HomePage(): React.JSX.Element {
           onSelectBoard={setActiveBoardId}
           onCreateBoard={() => void createBoard(t('home.board.newName'))}
           onDeleteBoard={(id) => void deleteBoard(id)}
+          onManageBoards={() => setManagerOpen(true)}
           showAddWidget={!isLoading && !!localActive}
           galleryOpen={galleryOpen}
           onGalleryOpenChange={setGalleryOpen}
           onAddWidget={handleAddWidget}
         />
       </div>
+      <BoardManagerDialog
+        boards={localBoards}
+        open={managerOpen}
+        onOpenChange={setManagerOpen}
+        onRename={(id, name) => void renameBoard(id, name)}
+        onDelete={(id) => void deleteBoard(id)}
+        onReorder={(ids) => void reorderBoards(ids)}
+      />
       {showSkeleton && (
         <output
           data-testid="home-board-loading"

--- a/apps/desktop/tests/e2e/home-dashboard.e2e.ts
+++ b/apps/desktop/tests/e2e/home-dashboard.e2e.ts
@@ -53,7 +53,16 @@ const SEL = {
   // the menu exposes a destructive "Remove" item.
   widgetMenu: '[data-testid="widget-menu"]',
   // Home tab in the main tab strip (regular-tab.tsx sets nav-home on the home tab)
-  homeTab: '[data-testid="nav-home"]'
+  homeTab: '[data-testid="nav-home"]',
+  // Board manager: a dialog opened from the switcher's "Manage boards" item. It owns
+  // rename (inline field), reorder (dnd-kit drag handle) and delete.
+  manageBoards: '[data-testid="home-layout-manage"]',
+  manager: '[data-testid="board-manager"]',
+  managerRow: '[data-testid="board-manager-row"]',
+  managerDrag: '[data-testid="board-manager-drag"]',
+  managerRename: '[data-testid="board-manager-rename"]',
+  managerNameInput: '[data-testid="board-manager-name-input"]',
+  managerDelete: '[data-testid="board-manager-delete"]'
 }
 
 // i18n English strings (packages/i18n/src/locales/en/common.json → "home")
@@ -195,6 +204,26 @@ async function selectBoard(page, boardId) {
   await item.scrollIntoViewIfNeeded()
   await item.click()
   await expect(boardItems(page).first()).toBeHidden({ timeout: 20000 })
+}
+
+/** Open the board manager dialog from the switcher dropdown. */
+async function openBoardManager(page) {
+  await openSwitcher(page)
+  await page.locator(SEL.manageBoards).click()
+  await expect(page.locator(SEL.manager)).toBeVisible({ timeout: 20000 })
+  await expect(page.locator(SEL.managerRow).first()).toBeVisible({ timeout: 20000 })
+}
+
+/** Close the board manager dialog. */
+async function closeBoardManager(page) {
+  await page.keyboard.press('Escape')
+  await expect(page.locator(SEL.manager)).toBeHidden({ timeout: 20000 })
+}
+
+/** Board ids ordered by their persisted position. */
+async function boardIdsInOrder(page) {
+  const boards = await listBoards(page)
+  return [...boards].sort((a, b) => a.position - b.position).map((b) => b.id)
 }
 
 /** The id of the currently active board, read from the data DB + localStorage. */
@@ -380,11 +409,100 @@ test.describe('Home Dashboard — B: board switcher & multi-board', () => {
     await expect(page.locator(SEL.switcher)).toContainText(first.name, { timeout: 20000 })
   })
 
-  test.skip('B7: FUTURE — rename / delete / reorder boards', async () => {
-    // Plan 1 ships only board select + create. useHomeBoards exposes
-    // renameBoard/deleteBoard/reorderBoards, but board-switcher.tsx wires
-    // neither rename, delete, nor reorder controls. Enable once the switcher UI
-    // exposes those actions.
+  test('B7: renaming a board from the manager persists and re-labels the switcher', async ({
+    page
+  }) => {
+    await ready(page)
+    await waitForSeed(page)
+
+    const [board] = await listBoards(page)
+    await openBoardManager(page)
+
+    const row = page.locator(`${SEL.managerRow}[data-board-id="${board.id}"]`)
+    await row.locator(SEL.managerRename).click()
+
+    // The field is opened from a Radix menu selection; a menu restores focus to its
+    // trigger when its content unmounts (~150ms later), which would blur the field
+    // and commit an unchanged name. jsdom cannot see that — assert focus survives.
+    const input = page.locator(SEL.managerNameInput)
+    await expect(input).toBeFocused({ timeout: 20000 })
+    await page.waitForTimeout(600)
+    await expect(input).toBeVisible()
+    await expect(input).toBeFocused()
+
+    await input.fill('Planning')
+    await page.keyboard.press('Enter')
+
+    await expect
+      .poll(async () => (await listBoards(page)).find((b) => b.id === board.id)?.name, {
+        timeout: 20000
+      })
+      .toBe('Planning')
+
+    await closeBoardManager(page)
+    await expect(page.locator(SEL.switcher)).toContainText('Planning', { timeout: 20000 })
+
+    // And it survives a reload — the rename went to the DB, not just local state.
+    await page.reload()
+    await ready(page)
+    await expect(page.locator(SEL.switcher)).toContainText('Planning', { timeout: 20000 })
+  })
+
+  test('B8: dragging a row in the manager reorders the boards', async ({ page }) => {
+    await ready(page)
+    await waitForSeed(page)
+
+    await createBoard(page)
+    await expect.poll(async () => (await listBoards(page)).length, { timeout: 20000 }).toBe(2)
+
+    const before = await boardIdsInOrder(page)
+    await openBoardManager(page)
+
+    const handle = page
+      .locator(`${SEL.managerRow}[data-board-id="${before[1]}"] ${SEL.managerDrag}`)
+      .first()
+    const target = page.locator(`${SEL.managerRow}[data-board-id="${before[0]}"]`).first()
+    const from = await handle.boundingBox()
+    const to = await target.boundingBox()
+
+    // dnd-kit needs a pointer press, movement past its 6px activation distance, and
+    // intermediate moves before the drop lands.
+    await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2 - 12, { steps: 5 })
+    await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2 - 4, { steps: 10 })
+    await page.mouse.up()
+
+    await expect
+      .poll(async () => (await boardIdsInOrder(page)).join(','), { timeout: 20000 })
+      .toBe([before[1], before[0]].join(','))
+
+    await closeBoardManager(page)
+    await page.reload()
+    await ready(page)
+    expect((await boardIdsInOrder(page)).join(',')).toBe([before[1], before[0]].join(','))
+  })
+
+  test('B9: deleting a board from the manager removes it', async ({ page }) => {
+    await ready(page)
+    await waitForSeed(page)
+
+    await createBoard(page)
+    await expect.poll(async () => (await listBoards(page)).length, { timeout: 20000 }).toBe(2)
+
+    const boards = await listBoards(page)
+    const doomed = boards.find((b) => b.name !== 'Home')
+    await openBoardManager(page)
+    await page
+      .locator(`${SEL.managerRow}[data-board-id="${doomed.id}"] ${SEL.managerDelete}`)
+      .click()
+
+    await expect
+      .poll(async () => (await listBoards(page)).map((b) => b.id), { timeout: 20000 })
+      .not.toContain(doomed.id)
+
+    // The last remaining board cannot be deleted.
+    await expect(page.locator(SEL.managerDelete)).toBeDisabled({ timeout: 20000 })
   })
 })
 

--- a/apps/docs/src/user-guide/home-dashboard.md
+++ b/apps/docs/src/user-guide/home-dashboard.md
@@ -11,8 +11,11 @@ Opening a board paints it in one pass — no entrance animation, so a full board
 A fresh vault auto-seeds a single board named **Home**. You can keep just that one or organize work across several boards.
 
 - **Switch boards** — pick a board from the board switcher in the header.
-- **Create a board** — use **New** in the switcher; give it a name (and optional icon).
-- **Reorder** — boards keep a stable position so the switcher order is predictable.
+- **Create a board** — use **New board** in the switcher. It arrives named "New board"; rename it from the manager below.
+- **Manage boards** — **Manage boards** in the switcher opens a dialog listing every board:
+  - **Rename** — click a board's name (or the pencil) and type. **Enter** saves, **Esc** discards the edit and leaves the dialog open.
+  - **Reorder** — drag a row by its handle. The switcher and every synced device follow the new order.
+  - **Delete** — the trash button removes a board and its widgets. The last remaining board can't be deleted.
 
 Each board stores its own set of widgets and their layout in the vault database.
 

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -735,7 +735,13 @@
       "deleteAria": "Delete layout",
       "newAria": "New board",
       "newName": "New board",
-      "defaultName": "Home"
+      "defaultName": "Home",
+      "manage": "Manage boards",
+      "manageTitle": "Manage boards",
+      "manageDescription": "Rename, reorder, or delete your Home boards.",
+      "renameAria": "Rename board",
+      "reorderAria": "Reorder board",
+      "nameLabel": "Board name"
     },
     "greeting": {
       "morning": "Good morning",


### PR DESCRIPTION
## Summary

The Home board switcher only ever wired **select** and **create** (plus an inline delete). `useHomeBoards` has exposed `renameBoard` and `reorderBoards` since Plan 1 — telemetry even distinguishes a `rename` action — but nothing in production code called either, so a board kept its default `New board` name forever and its position was fixed at creation time. The e2e suite recorded the gap explicitly as a skipped `B7: FUTURE — rename / delete / reorder boards`.

This wires the missing UI. The backend (IPC handlers, sync enqueue, cross-window broadcast) was already complete and is untouched.

- New **Manage boards** item in the switcher opens a board manager dialog listing every board:
  - **Rename** — click a board's name (or the pencil) to edit inline. `Enter` saves, `Esc` discards the edit and leaves the dialog open. Blank and unchanged names are no-ops.
  - **Reorder** — drag a row by its handle (dnd-kit, pointer + keyboard sensors). The dragged order is held locally until the refetched list agrees, so the row does not snap back mid-round-trip.
  - **Delete** — removes a board and its widgets; disabled on the last remaining board.
- All three go through the existing `homePages` handlers, so each one enqueues a sync effect and broadcasts to the other windows; a peer's change arrives as `home-pages:updated` and refetches.

### Why a dialog rather than controls inside the switcher menu

A Radix menu restores focus to its trigger when its content *unmounts* — after the exit animation, ~150ms later. An inline rename field opened from a menu item is blurred by that late restore and commits an unchanged value. This bit us before in the canvas sidebar tree, and it bit this change too: the first e2e run of `B7` failed with the field gone 600ms after it opened, and the Radix Dialog focus trap did **not** bounce the focus back. The switcher now declines the restore for that one path (a ref set in the `Manage boards` item's `onSelect`), so every other menu item keeps its normal focus return.

Worth flagging for reviewers: the renderer suite (7709 tests) stayed green through that bug. Only the Electron e2e caught it, which is why `B7` asserts the field is still visible *and focused* 600ms after opening.

### Docs

`apps/docs/src/user-guide/home-dashboard.md` claimed creating a board let you "give it a name" — it never did. That section now describes the real flow (create → `New board`, rename/reorder/delete from the manager).

## Release note

Home boards can now be renamed, reordered and deleted from a new **Manage boards** dialog in the board switcher — and all three sync to your other devices.

## Test plan

- `pnpm test:renderer` — 643 files / 7709 tests passed (includes the new `board-manager-dialog.test.tsx` and two new `use-home-boards` cases for `renameBoard` / `reorderBoards`).
- `pnpm exec playwright test --config config/playwright.config.ts tests/e2e/home-dashboard.e2e.ts -g "B7|B8|B9"` — 3/3 passed against a production build (rename + reload persistence, drag-reorder + reload persistence, delete + last-board guard). The previously skipped `B7` is replaced by these.
- Full `home-dashboard.e2e.ts` run: 26 passed, 2 failed (`C4`, `H2`). Both are pre-existing tests untouched by this change and both pass when re-run on the same build — flake under full-suite load, not a regression.
- `pnpm typecheck:web`, `pnpm typecheck:test`, `pnpm i18n:check`, eslint on the changed files — all clean.
- `pnpm docs:impact --base origin/main --strict` → covered; `pnpm docs:build` → clean.
