### PR TITLE
fix(wiki-links): previews and exports read the note half, not `Note#Heading`

### DIFF
--- a/apps/desktop/src/main/lib/export-utils.test.ts
+++ b/apps/desktop/src/main/lib/export-utils.test.ts
@@ -14,6 +14,14 @@ describe('export-utils', () => {
     const html = markdownToHtml(markdown)
     expect(html).toContain('<span class="wiki-link">Note Title</span>')
     expect(html).toContain('<span class="wiki-link">Display</span>')
+  })
+
+  it('markdownToHtml drops the heading half of a heading link (issue #1556)', () => {
+    const html = markdownToHtml('see [[Sprint Notes#Retro]] and [[Sprint Notes|retro]]')
+    expect(html).toContain('<span class="wiki-link">Sprint Notes</span>')
+    expect(html).toContain('<span class="wiki-link">retro</span>')
+    expect(html).not.toContain('#Retro')
+    expect(html).not.toContain('retroSprint Notes')
     expect(html).not.toContain('file:{id:123}')
     expect(html).toContain('<p>')
   })

--- a/apps/desktop/src/main/lib/export-utils.ts
+++ b/apps/desktop/src/main/lib/export-utils.ts
@@ -7,6 +7,7 @@
  */
 
 import { marked } from 'marked'
+import { replaceWikiLinks } from '@memry/shared/wiki-target'
 
 // ============================================================================
 // Types
@@ -46,12 +47,11 @@ marked.setOptions({
  * Handles wiki-links by converting them to plain text spans.
  */
 export function markdownToHtml(markdown: string): string {
-  // Pre-process: Convert wiki-links [[Title]] or [[Title|Display]] to plain text
-  const processedMarkdown = markdown
-    // [[Title|Display]] -> Display
-    .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '<span class="wiki-link">$2</span>')
-    // [[Title]] -> Title
-    .replace(/\[\[([^\]]+)\]\]/g, '<span class="wiki-link">$1</span>')
+  // Pre-process: wiki-links become plain spans labelled the way a chip would be
+  const processedMarkdown = replaceWikiLinks(
+    markdown,
+    (label) => `<span class="wiki-link">${label}</span>`
+  )
     // Strip file block comments <!-- file:{...} -->
     .replace(/<!--\s*file:\{[^}]+\}\s*-->/g, '')
 

--- a/apps/desktop/src/main/vault/frontmatter.test.ts
+++ b/apps/desktop/src/main/vault/frontmatter.test.ts
@@ -439,3 +439,13 @@ describe('resolvePropertyType — the shared precedence ladder', () => {
     expect(resolvePropertyType('father', [], undefined, infer)).toBe('text')
   })
 })
+
+describe('createSnippet wiki links (issue #1556)', () => {
+  it('reads a heading link as its note half', () => {
+    expect(createSnippet('see [[Sprint Notes#Retro]] today')).toBe('see Sprint Notes today')
+  })
+
+  it('reads an aliased link as its alias, not alias-welded-to-target', () => {
+    expect(createSnippet('see [[Sprint Notes|retro]] today')).toBe('see retro today')
+  })
+})

--- a/apps/desktop/src/main/vault/frontmatter.ts
+++ b/apps/desktop/src/main/vault/frontmatter.ts
@@ -15,7 +15,7 @@ import {
 } from '@memry/app-core/markdown'
 import { generateNoteId, isValidNoteId } from '../lib/id'
 import { isRelationValue } from '@memry/contracts/relation-uri'
-import { splitWikiTarget } from '@memry/shared/wiki-target'
+import { replaceWikiLinks, splitWikiTarget } from '@memry/shared/wiki-target'
 
 // ============================================================================
 // Types
@@ -601,7 +601,7 @@ export function createSnippet(content: string, maxLength = 200): string {
 
   // Remove links but keep text
   cleaned = cleaned.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-  cleaned = cleaned.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, '$2$1')
+  cleaned = replaceWikiLinks(cleaned)
 
   // Remove images
   cleaned = cleaned.replace(/!\[[^\]]*\]\([^)]+\)/g, '')

--- a/apps/desktop/src/main/vault/journal.test.ts
+++ b/apps/desktop/src/main/vault/journal.test.ts
@@ -604,3 +604,13 @@ describe('extractPreview', () => {
     expect(preview).toBe('Multiple spaces and newlines')
   })
 })
+
+describe('extractPreview wiki links (issue #1556)', () => {
+  it('reads a heading link as its note half', () => {
+    expect(extractPreview('see [[Sprint Notes#Retro]] today')).toBe('see Sprint Notes today')
+  })
+
+  it('reads an aliased link as its alias, not alias-welded-to-target', () => {
+    expect(extractPreview('see [[Sprint Notes|retro]] today')).toBe('see retro today')
+  })
+})

--- a/apps/desktop/src/main/vault/journal.ts
+++ b/apps/desktop/src/main/vault/journal.ts
@@ -11,6 +11,7 @@
 import path from 'path'
 import matter from 'gray-matter'
 import { createNoteContentStore } from '@memry/storage-vault'
+import { replaceWikiLinks } from '@memry/shared/wiki-target'
 import { getStatus, getConfig } from './index'
 import { ensureDirectory } from './file-ops'
 import { VaultError, VaultErrorCode } from '../lib/errors'
@@ -412,7 +413,7 @@ export function extractPreview(content: string, maxLength = 100): string {
 
   // Remove links but keep text
   cleaned = cleaned.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-  cleaned = cleaned.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, '$2$1')
+  cleaned = replaceWikiLinks(cleaned)
 
   // Remove images
   cleaned = cleaned.replace(/!\[[^\]]*\]\([^)]+\)/g, '')

--- a/apps/desktop/src/renderer/src/lib/home/journal-widget-data.test.ts
+++ b/apps/desktop/src/renderer/src/lib/home/journal-widget-data.test.ts
@@ -89,3 +89,13 @@ describe('entrySnippet', () => {
     expect(entrySnippet('---\ndate: 2026-06-23\n---\nBody text')).toBe('Body text')
   })
 })
+
+describe('entrySnippet wiki links (issue #1556)', () => {
+  it('reads a heading link as its note half', () => {
+    expect(entrySnippet('see [[Sprint Notes#Retro]] today')).toBe('see Sprint Notes today')
+  })
+
+  it('reads an aliased link as its alias, not the raw target|alias run', () => {
+    expect(entrySnippet('see [[Sprint Notes|retro]] today')).toBe('see retro today')
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/home/journal-widget-data.ts
+++ b/apps/desktop/src/renderer/src/lib/home/journal-widget-data.ts
@@ -1,3 +1,4 @@
+import { replaceWikiLinks } from '@memry/shared/wiki-target'
 import type { HeatmapEntry } from '../../../../preload/index.d'
 
 export interface WeekDay {
@@ -64,12 +65,13 @@ export function relativeDayLabel(iso: string, todayIso: string, lang: string): R
 // ponytail: light markdown strip — drop frontmatter/markers, collapse whitespace, slice.
 // Upgrade to the shared snippet util if entries need richer formatting.
 export function entrySnippet(content: string, max = 140): string {
-  const text = content
-    .replace(/^---\n[\s\S]*?\n---\n?/, '')
-    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
-    // The heading half goes with the brackets. Keeping it left `Note#Heading`,
-    // and the `#` strip two lines down then welded that into `NoteHeading`.
-    .replace(/\[\[([^\]#]*)(?:#[^\]]*)?\]\]/g, '$1')
+  const withoutLinks = replaceWikiLinks(
+    content.replace(/^---\n[\s\S]*?\n---\n?/, '').replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+  )
+  const text = withoutLinks
+    // The heading half went with the brackets above. Keeping it left
+    // `Note#Heading`, and the `#` strip below then welded that into
+    // `NoteHeading`.
     .replace(/[#>*_`~]/g, '')
     .replace(/\s+/g, ' ')
     .trim()

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -102,6 +102,18 @@ A note whose title genuinely contains `#` still works: `[[Sprint #4]]` opens the
 Backlinks and the graph treat `[[Meeting#Decisions]]` as a link to **Meeting** — the heading
 narrows where you land, not what the link points at.
 
+### Where a link cannot be a chip
+
+Search results, note and journal previews, the Home journal widget, and HTML or PDF export
+are plain text, so a link is shown as its label rather than as a chip. The label is the
+alias when the link has one, and the note's title otherwise: `[[Meeting#Decisions]]` reads
+"Meeting" and `[[Meeting#Decisions|the outcome]]` reads "the outcome". The heading half is
+dropped rather than shown, because a preview has no note to scroll.
+
+One consequence is worth knowing: these previews cannot tell `Sprint #4` the title apart
+from a heading link, so `[[Sprint #4]]` reads "Sprint" in a search snippet even though the
+link itself still opens the note called "Sprint #4". Nothing in the file changes.
+
 ::: warning Block references are not supported
 `[[Meeting#^block-id]]` opens **Meeting** at the top rather than jumping to the block.
 memrynote does not assign persistent block ids, so there is nothing to scroll to.

--- a/packages/app-core/src/markdown.test.ts
+++ b/packages/app-core/src/markdown.test.ts
@@ -47,3 +47,8 @@ test('snippet: collapses whitespace and caps length at 180 chars', () => {
   assert.ok(result.length <= 180)
   assert.ok(!/\s{2,}/.test(result))
 })
+
+test('snippet: a wiki link reads as its note half, or its alias (issue #1556)', () => {
+  const content = 'see [[Sprint Notes#Retro]], [[Sprint Notes|retro]] and [[Plain]]'
+  assert.equal(snippet(content), 'see Sprint Notes, retro and Plain')
+})

--- a/packages/app-core/src/markdown.ts
+++ b/packages/app-core/src/markdown.ts
@@ -1,4 +1,5 @@
 import matter from 'gray-matter'
+import { replaceWikiLinks } from '@memry/shared/wiki-target'
 
 export type Eol = '\n' | '\r\n'
 
@@ -157,9 +158,7 @@ function stripMarkup(markdown: string): string {
     withoutComments = withoutComments.replace(/<!--[\s\S]*?-->/g, '') // memry block/colors/file markers + any HTML comment
   } while (withoutComments !== previous)
 
-  return withoutComments
-    .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '$2') // wiki link w/ alias → alias
-    .replace(/\[\[([^\]]+)\]\]/g, '$1') // wiki link → target
+  return replaceWikiLinks(withoutComments) // wiki link → alias, else the note half
     .replace(/```[\s\S]*?```/g, (block) => block.replace(/```/g, '')) // fenced code → inner text
     .replace(/`([^`]+)`/g, '$1') // inline code
     .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1') // image → alt

--- a/packages/app-core/src/note-files.ts
+++ b/packages/app-core/src/note-files.ts
@@ -4,6 +4,7 @@ import { marked } from 'marked'
 import { saveCanonicalNote } from '@memry/domain-notes'
 import { getNoteMetadataByPath } from '@memry/storage-data'
 import type { FileType } from '@memry/shared/file-types'
+import { replaceWikiLinks } from '@memry/shared/wiki-target'
 import { createId } from './ids.ts'
 import type { DataDb } from './database.ts'
 import { parseMarkdownNote } from './markdown.ts'
@@ -185,10 +186,7 @@ function escapeHtml(text: string): string {
 }
 
 function wikiLinksToText(markdown: string): string {
-  return markdown
-    .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '$2')
-    .replace(/\[\[([^\]]+)\]\]/g, '$1')
-    .replace(/<!--\s*file:\{[^}]+\}\s*-->/g, '')
+  return replaceWikiLinks(markdown).replace(/<!--\s*file:\{[^}]+\}\s*-->/g, '')
 }
 
 function markdownToPlainText(markdown: string): string {

--- a/packages/shared/src/wiki-target.test.ts
+++ b/packages/shared/src/wiki-target.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { splitWikiTarget, isBlockReference, normalizeHeading } from './wiki-target'
+import {
+  splitWikiTarget,
+  isBlockReference,
+  normalizeHeading,
+  wikiLinkLabel,
+  replaceWikiLinks
+} from './wiki-target'
 
 describe('splitWikiTarget', () => {
   it('leaves a plain target alone', () => {
@@ -64,5 +70,49 @@ describe('isBlockReference', () => {
 describe('normalizeHeading', () => {
   it('folds case and trims', () => {
     expect(normalizeHeading('  Decisions ')).toBe(normalizeHeading('decisions'))
+  })
+})
+
+describe('wikiLinkLabel', () => {
+  it('drops the heading half, keeping the note (#1556)', () => {
+    expect(wikiLinkLabel('Sprint Notes#Retro')).toBe('Sprint Notes')
+  })
+
+  it('prefers the alias over either half', () => {
+    expect(wikiLinkLabel('Sprint Notes#Retro', 'retro')).toBe('retro')
+  })
+
+  it('ignores a blank alias', () => {
+    expect(wikiLinkLabel('Sprint Notes', '   ')).toBe('Sprint Notes')
+  })
+
+  it('reads a self-link as its heading, the only text it carries', () => {
+    expect(wikiLinkLabel('#Decisions')).toBe('Decisions')
+  })
+
+  it('keeps the note half of a block reference', () => {
+    expect(wikiLinkLabel('Meeting#^abc123')).toBe('Meeting')
+  })
+})
+
+describe('replaceWikiLinks', () => {
+  it('renders every run in a sentence', () => {
+    expect(replaceWikiLinks('see [[A#B]], [[C|see it]] and [[D]]')).toBe('see A, see it and D')
+  })
+
+  // The two `'$2$1'` sites concatenated instead of choosing, so an aliased link
+  // came out as alias-then-target welded together.
+  it('does not weld the alias onto the target', () => {
+    expect(replaceWikiLinks('[[Sprint Notes|retro]]')).toBe('retro')
+  })
+
+  it('wraps each label when a renderer is given', () => {
+    expect(replaceWikiLinks('[[A#B]] x', (label) => `<i>${label}</i>`)).toBe('<i>A</i> x')
+  })
+
+  it('leaves text that is not a link alone', () => {
+    expect(replaceWikiLinks('an [[ unclosed and a [link](url)')).toBe(
+      'an [[ unclosed and a [link](url)'
+    )
   })
 })

--- a/packages/shared/src/wiki-target.ts
+++ b/packages/shared/src/wiki-target.ts
@@ -71,3 +71,47 @@ export function isBlockReference(heading: string): boolean {
 export function normalizeHeading(heading: string): string {
   return heading.trim().toLowerCase()
 }
+
+/**
+ * The text a wiki-link reads as once the brackets are gone.
+ *
+ * Six plain-text surfaces — search snippets, journal previews, note excerpts,
+ * the home journal widget and HTML/PDF export — cannot render a chip, so they
+ * strip the brackets and keep what is inside. Keeping the whole target leaks
+ * the heading half (`Note#Heading`), and the alias, when there is one, is the
+ * label the user chose and the only thing they expect to read.
+ *
+ * The heading half goes because these callers have no note table to consult:
+ * `resolveWikiLink`'s split-first-then-raw order needs a lookup, and a string
+ * pass cannot do one. The cost is `[[Sprint #4]]`, a title that really carries
+ * a `#`, reading as `Sprint` in a preview — cosmetic, and confined to text that
+ * was never the link itself.
+ */
+export function wikiLinkLabel(target: string, alias?: string | null): string {
+  const chosen = alias?.trim() ?? ''
+  if (chosen) return chosen
+
+  const { note, heading } = splitWikiTarget(target)
+  // `[[#Heading]]` addresses the note it sits in, so the heading is the whole
+  // of what it says; anything else would leave the sentence with a hole in it.
+  return note || (heading ?? '')
+}
+
+/** Matches `[[target]]` and `[[target|alias]]`. */
+const WIKI_LINK_RUN = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g
+
+/**
+ * Replace every `[[…]]` run with its label, optionally wrapped by `render`.
+ *
+ * The one place all six strippers now agree. They used to each carry their own
+ * pair of regexes, and two of them replaced with `'$2$1'` — which concatenates
+ * rather than chooses, so `[[Sprint Notes|retro]]` came out `retroSprint Notes`.
+ */
+export function replaceWikiLinks(
+  markdown: string,
+  render: (label: string) => string = (label) => label
+): string {
+  return markdown.replace(WIKI_LINK_RUN, (_run, target: string, alias?: string) =>
+    render(wikiLinkLabel(target, alias))
+  )
+}


### PR DESCRIPTION
Closes #1556.

## What was wrong

Six plain-text surfaces strip `[[…]]` down to what is inside the brackets, each with its own pair of regexes, and each kept the whole target. An Obsidian-style heading link therefore read as `Note#Heading` everywhere a chip could not be drawn:

- search snippets — `packages/app-core/src/markdown.ts`
- note excerpts / PDF text — `packages/app-core/src/note-files.ts`
- journal previews — `apps/desktop/src/main/vault/journal.ts`
- frontmatter snippets — `apps/desktop/src/main/vault/frontmatter.ts`
- HTML & PDF export — `apps/desktop/src/main/lib/export-utils.ts`
- Home journal widget — `apps/desktop/src/renderer/src/lib/home/journal-widget-data.ts`

Two of them turned out to be worse than cosmetic, which the issue did not record. `extractPreview` and `createSnippet` replaced with `'$2$1'` — that concatenates the two capture groups rather than choosing between them, so `[[Sprint Notes|retro]]` came out as **`retroSprint Notes`** in every journal preview and frontmatter snippet.

The widget's own strip, fixed with A15, had the matching hole on the other side: its character class excluded `#` but not `|`, so an alias leaked out raw as `Sprint Notes|retro`.

## What changed

All six now share `replaceWikiLinks` in `@memry/shared/wiki-target`, next to the `splitWikiTarget` they should have been reading the target through. The label is:

| link | reads as |
|---|---|
| `[[Sprint Notes#Retro]]` | `Sprint Notes` |
| `[[Sprint Notes\|retro]]` | `retro` |
| `[[#Decisions]]` | `Decisions` |
| `[[Meeting#^block-id]]` | `Meeting` |

## The trade-off, stated

Dropping the heading half is a reading, not a resolution. These callers have no note table, so `resolveWikiLink`'s split-first-then-raw fallback is unavailable to them, and a title that really contains a `#` reads as `Sprint` in a preview instead of `Sprint #4`. The link itself is untouched and still opens the right note; only the plain-text label is affected. Documented in `apps/docs/src/user-guide/notes/wiki-links.md`.

Nothing on disk changes: `target` stays the raw string in the document, the vault file and the Y.Doc.

## Verification

| gate | result |
|---|---|
| `pnpm typecheck` | pass |
| `pnpm lint` | pass, no new warnings in touched files |
| `pnpm check:architecture` / `check:contracts` | pass |
| `test:main` | 548 files, 7147 passed |
| `test:renderer` | 644 files, 7731 passed |
| `test:shared` | 145 files, 2547 passed |
| `@memry/app-core test` | 15 passed |
| `docs:impact --strict` + `docs:build` | pass |

New tests cover the label rules in `wiki-target.test.ts` and each call site: `snippet`, `extractPreview`, `createSnippet`, `markdownToHtml`, `entrySnippet` — including an explicit regression test that the alias is no longer welded onto the target.

`note-files.ts` has no test file and its strippers are private behind service factories that need a live `NotesService`; its one line now delegates to the tested helper, so I did not build that harness.

Note: `test:main` is only trustworthy after `pnpm --filter @memry/desktop rebuild:node` in a fresh worktree — the first run showed 2287 native-ABI failures unrelated to this change.