### PR TITLE
fix(wiki-links): resolve `Note#Heading` outside the renderer too

### DIFF
--- a/apps/cli/src/run.test.ts
+++ b/apps/cli/src/run.test.ts
@@ -278,6 +278,22 @@ test('runs core commands against a vault and prints JSON output', async () => {
   assert.equal(noteResolveCode, 0)
   assert.equal((JSON.parse(stdout.at(-1) ?? '{}') as { path?: string }).path, linkedNote.path)
 
+  const noteResolveHeadingCode = await runCli(
+    ['--vault', vaultPath, '--json', 'notes', 'resolve', 'Linked Note#Details'],
+    {
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line)
+    }
+  )
+  assert.equal(noteResolveHeadingCode, 0)
+  // #1557: `[[Note#Heading]]` used to resolve to nothing at all here.
+  const resolvedHeading = JSON.parse(stdout.at(-1) ?? '{}') as {
+    path?: string
+    heading?: string | null
+  }
+  assert.equal(resolvedHeading.path, linkedNote.path)
+  assert.equal(resolvedHeading.heading, 'Details')
+
   const noteLinksCode = await runCli(
     ['--vault', vaultPath, '--json', 'notes', 'links', note.id ?? ''],
     {

--- a/apps/cli/src/run.ts
+++ b/apps/cli/src/run.ts
@@ -327,10 +327,12 @@ async function runNotes(app: MemryApp, parsed: ParsedCli, io: CliIo): Promise<vo
       )
       return
     case 'resolve':
+      // Heading-aware on purpose: `[[Meeting#Decisions]]` is a link somebody
+      // can paste here, and it must reach `Meeting` (#1557).
       print(
         io,
         parsed.json,
-        await app.notes.resolveByTitle(requireFirst(parsed.positionals, 'note title'))
+        await app.notes.resolveWikiTarget(requireFirst(parsed.positionals, 'note title'))
       )
       return
     case 'links':
@@ -1936,8 +1938,7 @@ async function runCalendar(app: MemryApp, parsed: ParsedCli, io: CliIo): Promise
           parsed.json,
           await app.calendar.bindings.list({
             sourceType: getFlag(parsed.flags, 'source-type') as
-              | CalendarBindingListOptions['sourceType']
-              | undefined,
+              CalendarBindingListOptions['sourceType'] | undefined,
             sourceId: getFlag(parsed.flags, 'source'),
             provider: getFlag(parsed.flags, 'provider'),
             includeArchived: hasFlag(parsed.flags, 'archived')
@@ -2017,7 +2018,9 @@ async function runCalendar(app: MemryApp, parsed: ParsedCli, io: CliIo): Promise
       })
       return
     default:
-      throw new Error('Usage: memrynote [--vault <path>] calendar events create|get|list|update|delete')
+      throw new Error(
+        'Usage: memrynote [--vault <path>] calendar events create|get|list|update|delete'
+      )
   }
 }
 

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -239,6 +239,7 @@ export interface MainIpcInvokeHandlers {
   "notes:rename-property-option": (...args: [{ propertyName: string; oldValue: string; newValue: string; }]) => Awaited<Promise<{ success: boolean; }>>
   "notes:reorder": (...args: [{ folderPath: string; notePaths: string[]; }]) => Awaited<{ success: true; } | { success: false; error: string }>
   "notes:resolve-by-title": (...args: [string]) => Awaited<Promise<{ id: string; path: string; title: string; fileType: import("../../../../../packages/shared/src/file-types").FileType; } | null>>
+  "notes:resolve-wiki-target": (...args: [string]) => Awaited<Promise<{ id: string; path: string; title: string; fileType: import("../../../../../packages/shared/src/file-types").FileType; heading: string | null; } | null>>
   "notes:restore-version": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; note: import("../vault/notes-crud").Note; }>>
   "notes:reveal-in-finder": (...args: [string]) => Awaited<Promise<void>>
   "notes:set-calendar-property-visibility": (...args: [{ name: string; showOnCalendar: boolean; }]) => Awaited<Promise<{ success: true; }> | { success: false; error: string }>

--- a/apps/desktop/src/main/ipc/notes-handlers-extra.test.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers-extra.test.ts
@@ -283,6 +283,39 @@ describe('notes-handlers extra coverage', () => {
     await expect(invoke(NotesChannels.invoke.PREVIEW_BY_TITLE, 'Asset')).resolves.toBeNull()
   })
 
+  // #1557: `resolveByTitle` is heading-blind by contract, so an agent following
+  // `[[Meeting#Decisions]]` used to get `null`.
+  it('resolves a heading target to its note half, and a `#` title to itself', async () => {
+    const meeting = { id: 'note-m', path: 'Meeting.md', title: 'Meeting', fileType: 'markdown' }
+    mocks.resolveNoteByTitle.mockImplementation((_db: unknown, title: string) =>
+      title === 'Meeting' ? meeting : undefined
+    )
+
+    expect(await invoke(NotesChannels.invoke.RESOLVE_WIKI_TARGET, 'Meeting#Decisions')).toEqual({
+      id: 'note-m',
+      path: 'Meeting.md',
+      title: 'Meeting',
+      fileType: 'markdown',
+      heading: 'Decisions'
+    })
+
+    const sprint = { id: 'note-s', path: 'Sprint #4.md', title: 'Sprint #4', fileType: null }
+    mocks.resolveNoteByTitle.mockImplementation((_db: unknown, title: string) =>
+      title === 'Sprint #4' ? sprint : undefined
+    )
+
+    expect(await invoke(NotesChannels.invoke.RESOLVE_WIKI_TARGET, 'Sprint #4')).toEqual({
+      id: 'note-s',
+      path: 'Sprint #4.md',
+      title: 'Sprint #4',
+      fileType: 'markdown',
+      heading: null
+    })
+
+    mocks.resolveNoteByTitle.mockImplementation(() => undefined)
+    await expect(invoke(NotesChannels.invoke.RESOLVE_WIKI_TARGET, 'Missing#H')).resolves.toBeNull()
+  })
+
   it('handles property definition and option mutation branches', async () => {
     mocks.createPropertyDefinitionRecord.mockReturnValue({ name: 'Rating', type: 'number' })
 

--- a/apps/desktop/src/main/ipc/notes-handlers.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.ts
@@ -87,6 +87,7 @@ import {
   getAllTagDefinitions
 } from '../notes/store'
 import { getIndexDatabase, getDatabase } from '../database'
+import { resolveWikiTarget } from '@memry/shared/wiki-target'
 import { countLocalOnlyNoteMetadata, listPropertyDefinitions } from '@memry/storage-data'
 import { getNotesInFolder, reorderNotesInFolder, getAllNotePositions } from '../notes/store'
 import { emitNoteAttachmentSaved } from '../notes/runtime-effects'
@@ -255,6 +256,26 @@ export function registerNotesHandlers(): void {
         path: result.path,
         title: result.title,
         fileType: result.fileType ?? 'markdown'
+      }
+    })
+  )
+
+  // notes:resolve-wiki-target - Resolve a WikiLink target, heading half and all
+  // `resolveByTitle` is heading-blind by contract, so `[[Meeting#Decisions]]`
+  // misses it; this reads the note half first and falls back to the raw string,
+  // which is what an agent following a link needs (#1557).
+  ipcMain.handle(
+    NotesChannels.invoke.RESOLVE_WIKI_TARGET,
+    createStringHandler(async (target) => {
+      const db = getIndexDatabase()
+      const resolved = await resolveWikiTarget(target, (title) => resolveNoteByTitle(db, title))
+      if (!resolved) return null
+      return {
+        id: resolved.match.id,
+        path: resolved.match.path,
+        title: resolved.match.title,
+        fileType: resolved.match.fileType ?? 'markdown',
+        heading: resolved.heading
       }
     })
   )

--- a/apps/desktop/src/preload/generated-rpc.ts
+++ b/apps/desktop/src/preload/generated-rpc.ts
@@ -74,6 +74,7 @@ export function createGeneratedRpcApi({
       "largeFileClose": ((sessionId) => invoke("notes:large-file-close", sessionId)) as GeneratedRpcApi["notes"]["largeFileClose"],
       "largeFileSearch": ((input) => invoke("notes:large-file-search", input)) as GeneratedRpcApi["notes"]["largeFileSearch"],
       "resolveByTitle": ((title) => invoke("notes:resolve-by-title", title)) as GeneratedRpcApi["notes"]["resolveByTitle"],
+      "resolveWikiTarget": ((target) => invoke("notes:resolve-wiki-target", target)) as GeneratedRpcApi["notes"]["resolveWikiTarget"],
       "previewByTitle": ((title) => invoke("notes:preview-by-title", title)) as GeneratedRpcApi["notes"]["previewByTitle"],
       "update": ((input) => invoke("notes:update", input)) as GeneratedRpcApi["notes"]["update"],
       "rename": ((id, newTitle) => invoke("notes:rename", { id, newTitle })) as GeneratedRpcApi["notes"]["rename"],

--- a/apps/desktop/src/renderer/src/lib/wikilink-resolver.ts
+++ b/apps/desktop/src/renderer/src/lib/wikilink-resolver.ts
@@ -9,7 +9,7 @@
 
 import { notesService } from '@/services/notes-service'
 import { getFileType, getExtension, isSupported } from '@memry/shared/file-types'
-import { splitWikiTarget, isBlockReference } from '@memry/shared/wiki-target'
+import { splitWikiTarget, isBlockReference, resolveWikiTarget } from '@memry/shared/wiki-target'
 
 // ============================================================================
 // Types
@@ -117,16 +117,12 @@ export async function resolveWikiLink(target: string): Promise<ResolvedWikiLink>
   const extension = getExtension(trimmedTarget)
   const hasKnownExtension = extension !== '' && isSupported(extension)
 
-  // Split first: `[[Note#Heading]]` must reach `Note`, never the
-  // `Note#Heading.md` this bug used to create.
-  if (hasHeading) {
-    const bySplit = await notesService.resolveByTitle(note)
-    if (bySplit) return resolvedRecord(bySplit, anchor)
-  }
-
-  // Raw second: the `#` was part of the name after all, so it names no heading.
-  const resolved = await notesService.resolveByTitle(trimmedTarget)
-  if (resolved) return resolvedRecord(resolved, null)
+  // Split first, raw second — the shared rule, so the CLI and the agent MCP
+  // surface read a link exactly the way the editor does (#1557).
+  const resolved = await resolveWikiTarget(trimmedTarget, (title) =>
+    notesService.resolveByTitle(title)
+  )
+  if (resolved) return resolvedRecord(resolved.match, resolved.heading)
 
   // Not found in database
   if (hasKnownExtension) {

--- a/apps/desktop/tests/setup-dom.ts
+++ b/apps/desktop/tests/setup-dom.ts
@@ -130,6 +130,7 @@ const createMockApi = () => ({
     renameFolder: vi.fn().mockResolvedValue({ success: true }),
     deleteFolder: vi.fn().mockResolvedValue({ success: true }),
     resolveByTitle: vi.fn().mockResolvedValue(null),
+    resolveWikiTarget: vi.fn().mockResolvedValue(null),
     previewByTitle: vi.fn().mockResolvedValue(null),
     exists: vi.fn().mockResolvedValue(false),
     openExternal: vi.fn().mockResolvedValue({ success: true }),

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -428,6 +428,11 @@ actions, external open/reveal actions, import dialogs, OS settings panes, teleme
 diagnostics reporting, and raw secret writes. Unsupported or unavailable desktop API operations
 return a structured MCP error instead of falling back to an arbitrary desktop call.
 
+`notes.resolveWikiTarget` follows a wiki link the way the editor does: `Meeting#Decisions` resolves
+to the note `Meeting` and reports `heading: "Decisions"`, while a note genuinely titled `Sprint #4`
+still resolves to itself. `notes.resolveByTitle` stays a plain title lookup and returns nothing for a
+target carrying a heading, so use `notes.resolveWikiTarget` when the string came out of a `[[…]]`.
+
 Inbox items convert through the bridge into any of the four targets the app itself offers:
 `inbox.convertToNote`, `inbox.convertToTask`, `inbox.convertToEvent`, and
 `inbox.convertToReminder`. `notes.applyTemplate` applies a template the agent can already read

--- a/apps/docs/src/user-guide/cli.md
+++ b/apps/docs/src/user-guide/cli.md
@@ -56,6 +56,7 @@ memrynote notes get note_abc123
 memrynote notes exists note_abc123
 memrynote notes preview "Draft"
 memrynote notes resolve "Draft"
+memrynote notes resolve "Draft#Open questions"
 memrynote notes links note_abc123
 memrynote notes update note_abc123 --append "More text" --properties '{"status":"active"}'
 memrynote notes rename note_abc123 "Final Draft"
@@ -81,6 +82,8 @@ memrynote folders create Projects
 memrynote folders rename Projects Archive/Projects
 memrynote folders delete Archive/Projects --yes
 ```
+
+`notes resolve` takes a wiki-link target, so `Draft#Open questions` resolves to the note `Draft` and reports `heading` alongside it. A note whose title really contains a `#` still wins over the split reading, so `Sprint #4` resolves to itself.
 
 Destructive commands require `--yes`.
 Note snapshots use the same version-history storage as the desktop app. Restoring a snapshot creates a backup snapshot of the current note first.

--- a/packages/app-core/src/memry-app.test.ts
+++ b/packages/app-core/src/memry-app.test.ts
@@ -194,6 +194,14 @@ test('opens a standalone vault and exposes core note, journal, task, inbox, and 
   assert.equal(await app.notes.exists(note.id), true)
   assert.equal((await app.notes.previewByTitle('Linked Note'))?.id, linkedNote.id)
   assert.equal((await app.notes.resolveByTitle('Linked Note'))?.path, linkedNote.path)
+  // #1557: a wiki-link target, not a bare title — the note half resolves and
+  // the heading half comes back for the caller to scroll to.
+  assert.equal(await app.notes.resolveByTitle('Linked Note#Details'), null)
+  const headingTarget = await app.notes.resolveWikiTarget('Linked Note#Details')
+  assert.equal(headingTarget?.path, linkedNote.path)
+  assert.equal(headingTarget?.heading, 'Details')
+  assert.equal((await app.notes.resolveWikiTarget('Linked Note'))?.heading, null)
+  assert.equal(await app.notes.resolveWikiTarget('Missing Note#Details'), null)
   const noteLinks = await app.notes.getLinks(note.id)
   assert.equal(
     noteLinks.outgoing.some(

--- a/packages/app-core/src/notes.ts
+++ b/packages/app-core/src/notes.ts
@@ -21,6 +21,7 @@ import {
   writeMarkdownNote
 } from './markdown.ts'
 import { normalizePath, safeFilename, type VaultConfig } from './paths.ts'
+import { resolveWikiTarget as resolveTargetWith } from '@memry/shared/wiki-target'
 
 export interface NoteRecord {
   id: string
@@ -82,6 +83,11 @@ export interface ResolvedNoteRecord {
   fileType: string
 }
 
+export interface ResolvedWikiTargetRecord extends ResolvedNoteRecord {
+  /** The heading `[[Note#Heading]]` addresses, or `null` when it names none. */
+  heading: string | null
+}
+
 interface NoteMetadataRow {
   id: string
   path: string
@@ -105,6 +111,7 @@ export interface NotesService {
   getLinks(idOrPath: string): Promise<NoteLinksResponse>
   previewByTitle(title: string): Promise<NotePreviewRecord | null>
   resolveByTitle(title: string): Promise<ResolvedNoteRecord | null>
+  resolveWikiTarget(target: string): Promise<ResolvedWikiTargetRecord | null>
   setLocalOnly(idOrPath: string, localOnly: boolean): Promise<NoteRecord>
   localOnlyCount(): Promise<{ count: number }>
   delete(idOrPath: string): Promise<boolean>
@@ -460,6 +467,19 @@ export function createNotesService({
         title: row.title,
         fileType: row.fileType ?? 'markdown'
       }
+    },
+
+    /**
+     * Resolve a wiki-link target — `Note`, `Note#Heading` or `Note#^block-id`.
+     *
+     * `resolveByTitle` answers "is there a note with this title" and nothing
+     * else, so `[[Meeting#Decisions]]` misses it and a CLI or agent following
+     * that link gets `null`. This is that lookup with the renderer's
+     * split-first/raw-fallback reading layered on top (#1557).
+     */
+    async resolveWikiTarget(target) {
+      const resolved = await resolveTargetWith(target, (title) => this.resolveByTitle(title))
+      return resolved ? { ...resolved.match, heading: resolved.heading } : null
     },
 
     async setLocalOnly(idOrPath, localOnly) {

--- a/packages/contracts/src/agent-mcp-channels.ts
+++ b/packages/contracts/src/agent-mcp-channels.ts
@@ -24,6 +24,7 @@ export const AgentMcpDesktopReadOperations = [
   'notes.getByPath',
   'notes.getFile',
   'notes.resolveByTitle',
+  'notes.resolveWikiTarget',
   'notes.previewByTitle',
   'notes.list',
   'notes.getTags',
@@ -344,8 +345,7 @@ export const AgentMcpDesktopApiRequestSchema = z.object({
 export type AgentMcpDesktopApiRequest = z.infer<typeof AgentMcpDesktopApiRequestSchema>
 
 export type AgentMcpDesktopApiResponse =
-  | { ok: true; data: unknown }
-  | { ok: false; error: { code: string; message: string } }
+  { ok: true; data: unknown } | { ok: false; error: { code: string; message: string } }
 
 // ============================================================================
 // Canvas item writes (#916)

--- a/packages/contracts/src/notes-channels.ts
+++ b/packages/contracts/src/notes-channels.ts
@@ -105,6 +105,8 @@ export const NotesChannels = {
     GET_FILE: 'notes:get-file',
     /** Resolve a WikiLink target by title (returns note or file metadata) */
     RESOLVE_BY_TITLE: 'notes:resolve-by-title',
+    /** Resolve a WikiLink target, heading half and all (`Note#Heading`) */
+    RESOLVE_WIKI_TARGET: 'notes:resolve-wiki-target',
     /** Get preview data for a WikiLink hover card */
     PREVIEW_BY_TITLE: 'notes:preview-by-title',
     /** Import files from external paths into the vault */

--- a/packages/rpc/src/notes.ts
+++ b/packages/rpc/src/notes.ts
@@ -92,6 +92,18 @@ export interface WikiLinkResolution {
   fileType: 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
 }
 
+/**
+ * A resolution that read the target as wiki-link grammar, not as a bare title.
+ *
+ * `resolveByTitle` is heading-blind by contract, so `[[Meeting#Decisions]]`
+ * misses it entirely; this reads the note half first and falls back to the raw
+ * string, which is what keeps a note really named `Sprint #4` reachable.
+ */
+export interface WikiLinkTargetResolution extends WikiLinkResolution {
+  /** The heading to scroll to, or `null` when the link names none. */
+  heading: string | null
+}
+
 export interface WikiLinkPreview {
   id: string
   title: string
@@ -429,6 +441,14 @@ export const notesRpc = defineDomain({
     resolveByTitle: defineMethod<(title: string) => Promise<WikiLinkResolution | null>>({
       channel: NotesChannels.invoke.RESOLVE_BY_TITLE,
       params: ['title']
+    }),
+    /**
+     * Resolve `Note`, `Note#Heading` or `Note#^block-id` to the note it names.
+     * Agents follow links with this; `resolveByTitle` answers title questions.
+     */
+    resolveWikiTarget: defineMethod<(target: string) => Promise<WikiLinkTargetResolution | null>>({
+      channel: NotesChannels.invoke.RESOLVE_WIKI_TARGET,
+      params: ['target']
     }),
     previewByTitle: defineMethod<(title: string) => Promise<WikiLinkPreview | null>>({
       channel: NotesChannels.invoke.PREVIEW_BY_TITLE,

--- a/packages/shared/src/wiki-target.test.ts
+++ b/packages/shared/src/wiki-target.test.ts
@@ -4,7 +4,8 @@ import {
   isBlockReference,
   normalizeHeading,
   wikiLinkLabel,
-  replaceWikiLinks
+  replaceWikiLinks,
+  resolveWikiTarget
 } from './wiki-target'
 
 describe('splitWikiTarget', () => {
@@ -114,5 +115,91 @@ describe('replaceWikiLinks', () => {
     expect(replaceWikiLinks('an [[ unclosed and a [link](url)')).toBe(
       'an [[ unclosed and a [link](url)'
     )
+  })
+})
+
+describe('resolveWikiTarget', () => {
+  const meeting = { id: 'note_meeting', title: 'Meeting' }
+  const sprint = { id: 'note_sprint', title: 'Sprint #4' }
+
+  /** A title lookup over a fixed set of notes, recording what it was asked. */
+  function vault(...notes: Array<{ id: string; title: string }>) {
+    const asked: string[] = []
+    const lookup = async (title: string) => {
+      asked.push(title)
+      return notes.find((note) => note.title === title) ?? null
+    }
+    return { asked, lookup }
+  }
+
+  it('reaches the note half of `Note#Heading` and reports the heading', async () => {
+    const { lookup } = vault(meeting)
+    expect(await resolveWikiTarget('Meeting#Decisions', lookup)).toEqual({
+      match: meeting,
+      heading: 'Decisions'
+    })
+  })
+
+  it('falls back to the raw string, so a note really named `Sprint #4` wins', async () => {
+    const { asked, lookup } = vault(sprint)
+    expect(await resolveWikiTarget('Sprint #4', lookup)).toEqual({ match: sprint, heading: null })
+    expect(asked).toEqual(['Sprint', 'Sprint #4'])
+  })
+
+  it('prefers the split match when both halves name a note', async () => {
+    const { lookup } = vault(sprint, { id: 'note_sprint_only', title: 'Sprint' })
+    const resolved = await resolveWikiTarget('Sprint #4', lookup)
+    expect(resolved?.match.id).toBe('note_sprint_only')
+    expect(resolved?.heading).toBe('4')
+  })
+
+  it('never looks a title up twice when the target carries no `#`', async () => {
+    const { asked, lookup } = vault(meeting)
+    expect(await resolveWikiTarget('Meeting', lookup)).toEqual({ match: meeting, heading: null })
+    expect(asked).toEqual(['Meeting'])
+  })
+
+  it('opens the note of a block reference, with nothing to scroll to', async () => {
+    const { lookup } = vault(meeting)
+    expect(await resolveWikiTarget('Meeting#^abc123', lookup)).toEqual({
+      match: meeting,
+      heading: null
+    })
+  })
+
+  it('reports no heading when the raw string is what matched', async () => {
+    const { lookup } = vault({ id: 'note_hash', title: 'Meeting#Decisions' })
+    const resolved = await resolveWikiTarget('Meeting#Decisions', lookup)
+    expect(resolved?.heading).toBeNull()
+  })
+
+  it('resolves a nested heading to its last segment', async () => {
+    const { lookup } = vault(meeting)
+    expect((await resolveWikiTarget('Meeting#Q3#Decisions', lookup))?.heading).toBe('Decisions')
+  })
+
+  it('leaves a self-link `[[#Heading]]` to the caller that knows the note', async () => {
+    const { asked, lookup } = vault(meeting)
+    expect(await resolveWikiTarget('#Decisions', lookup)).toBeNull()
+    expect(asked).toEqual([])
+  })
+
+  it('resolves nothing for a blank target, without a lookup', async () => {
+    const { asked, lookup } = vault(meeting)
+    expect(await resolveWikiTarget('   ', lookup)).toBeNull()
+    expect(asked).toEqual([])
+  })
+
+  it('returns null when neither half names a note', async () => {
+    const { lookup } = vault(meeting)
+    expect(await resolveWikiTarget('Missing#Heading', lookup)).toBeNull()
+  })
+
+  it('accepts a synchronous lookup', async () => {
+    expect(
+      await resolveWikiTarget('Meeting#Decisions', (title) =>
+        title === 'Meeting' ? meeting : undefined
+      )
+    ).toEqual({ match: meeting, heading: 'Decisions' })
   })
 })

--- a/packages/shared/src/wiki-target.ts
+++ b/packages/shared/src/wiki-target.ts
@@ -115,3 +115,56 @@ export function replaceWikiLinks(
     render(wikiLinkLabel(target, alias))
   )
 }
+
+/** A wiki-link target matched to a record, plus the heading to scroll to. */
+export interface ResolvedWikiTarget<T> {
+  match: T
+  /**
+   * The heading the link addresses, or `null` when there is nothing to scroll
+   * to — no `#` in the target, a `#^block-id` we cannot find, or a match that
+   * came from the raw string, where the `#` turned out to be part of the title.
+   */
+  heading: string | null
+}
+
+/**
+ * Resolve a wiki-link target through a title lookup, split half first.
+ *
+ * The order is the whole point and it is load-bearing in both directions:
+ * `[[Meeting#Decisions]]` must reach `Meeting`, and `[[Sprint #4]]` must still
+ * reach the note somebody really named `Sprint #4`. `resolveByTitle` itself
+ * stays heading-blind on purpose — its contract is "is there a note with this
+ * title", and folding wiki grammar into it would make `Sprint #4` unfindable
+ * by its own name. So the grammar lives here, one layer up, where every caller
+ * outside the renderer (the CLI, the agent MCP surface) can share it.
+ *
+ * `lookup` is whatever "find a note with this title" means to the caller — a
+ * data-DB row for the CLI, an index-DB row in the main process.
+ */
+export async function resolveWikiTarget<T>(
+  target: string,
+  lookup: (title: string) => T | null | undefined | Promise<T | null | undefined>
+): Promise<ResolvedWikiTarget<T> | null> {
+  const raw = target.trim()
+  if (!raw) return null
+
+  const { note, heading } = splitWikiTarget(raw)
+
+  if (heading !== null) {
+    // `[[#Heading]]` addresses the note it is written in. There is no title to
+    // look up, and the caller — which knows which note that is — answers it.
+    if (!note) return null
+
+    const bySplit = await lookup(note)
+    if (bySplit) return { match: bySplit, heading: headingAnchor(heading) }
+  }
+
+  const byRaw = await lookup(raw)
+  return byRaw ? { match: byRaw, heading: null } : null
+}
+
+/** The heading half as something to scroll to, or `null` when it is not. */
+function headingAnchor(heading: string): string | null {
+  if (!heading || isBlockReference(heading)) return null
+  return heading
+}


### PR DESCRIPTION
Closes #1557.

## The gap

A15 gave the renderer's `resolveWikiLink` a split-first / raw-fallback reading: `[[Meeting#Decisions]]` looks `Meeting` up first, then falls back to the raw string so a note genuinely titled `Sprint #4` still wins. `notes.resolveByTitle` was deliberately left heading-blind — its contract is "is there a note with this title", and burying wiki grammar in it would make `Sprint #4` unfindable by its own name.

So everything resolving titles **outside** the renderer still missed:

- `memrynote notes resolve` (`apps/cli/src/run.ts`)
- the agent MCP bridge, where `notes.resolveByTitle` is the allowlisted read

An agent asked to follow `[[Meeting#Decisions]]` got `null`.

## The change

The grammar goes one layer up, not into `resolveByTitle`. `resolveWikiTarget` in `@memry/shared/wiki-target` is a generic split-first / raw-fallback pass over whatever "find a note with this title" means to its caller:

```ts
resolveWikiTarget(target, lookup) // → { match, heading } | null
```

Three callers share it:

| surface | entry point |
| --- | --- |
| CLI | `app.notes.resolveWikiTarget` (app-core), used by `memrynote notes resolve` |
| agent MCP | `notes:resolve-wiki-target` over the index DB, allowlisted as `notes.resolveWikiTarget` |
| renderer | `resolveWikiLink`'s inline copy of the rule is now the shared one |

The renderer's file-type, `[[#Heading]]` and `create` branches are untouched — only the two lookups in the middle became the shared call.

Behaviour it pins down:

- `Meeting#Decisions` → note `Meeting`, `heading: "Decisions"`
- `Sprint #4` → the note really named `Sprint #4`, `heading: null` (split tried first, missed)
- `Meeting#^abc123` → note `Meeting`, `heading: null` — block refs open the note at the top
- `Meeting#Q3#Decisions` → `heading: "Decisions"`, the only segment a text match can find
- `#Decisions` → `null` without a lookup; only the caller knows which note it sits in

## Compatibility

Additive. `notes:resolve-by-title`, the `resolveByTitle` RPC method and its allowlist entry all keep their current behaviour, so an older renderer against a newer main process, and an agent still calling `notes.resolveByTitle`, both keep working. `notes resolve` gains a `heading` field; every other field is unchanged.

## Verification

- `pnpm typecheck` · `pnpm lint` · `pnpm ipc:check` · `pnpm check:architecture` · `pnpm check:contracts` — green
- `pnpm --filter @memry/shared exec vitest run src/wiki-target.test.ts` — 31 passed (12 new for `resolveWikiTarget`, incl. the `Sprint #4` fallback and the lookup-call order)
- `packages/app-core` — 15 passed; `memry-app.test.ts` now asserts a real vault resolves `Linked Note#Details` while `resolveByTitle` still returns `null` for it
- `apps/cli` — 5 passed; `notes resolve "Linked Note#Details"` end-to-end through a real vault
- desktop main — 7177 passed, incl. a new `notes:resolve-wiki-target` case
- desktop renderer — 7760 passed (existing `wikilink-resolver` suite covers the refactor)
- `pnpm docs:impact --strict` covered · `pnpm docs:build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)