### PR TITLE
fix(editor): give tables a header row instead of one that appears on reload

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -1882,6 +1882,81 @@ describe('custom blocks and table cells', () => {
   )
 })
 
+describe('table header rows', () => {
+  // A header row turns the first row's cells into `tableHeader` nodes. Main
+  // owns the schema y-prosemirror reads the shared doc through, and an unknown
+  // node name there is not an error — it is a DELETE that replicates. So the
+  // header row has to be proven to survive the CRDT, not assumed to.
+  function tableBlock(headerRows: number): unknown {
+    const cell = (text: string) => ({
+      type: 'tableCell',
+      content: [{ type: 'text', text, styles: {} }],
+      props: {
+        colspan: 1,
+        rowspan: 1,
+        backgroundColor: 'default',
+        textColor: 'default',
+        textAlignment: 'left'
+      }
+    })
+    return {
+      id: 'tbl',
+      type: 'table',
+      props: {},
+      children: [],
+      content: {
+        type: 'tableContent',
+        columnWidths: [null, null],
+        headerRows,
+        rows: [{ cells: [cell('Name'), cell('Qty')] }, { cells: [cell('Pear'), cell('3')] }]
+      }
+    }
+  }
+
+  function fragmentWithTable(headerRows: number): Y.Doc {
+    const doc = new Y.Doc()
+    blocksToYFragment(
+      [tableBlock(headerRows)] as unknown as Parameters<typeof blocksToYFragment>[0],
+      doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+    return doc
+  }
+
+  it('keeps the header row through the CRDT and writes it as the GFM header', async () => {
+    // #given a table whose first row is a header
+    const doc = fragmentWithTable(1)
+
+    // #when
+    const markdown = await yDocToMarkdown(doc)
+
+    // #then the header row is the row above the separator, and no phantom row
+    // is bolted on above it
+    expect(markdown).toBe('| Name | Qty |\n| ---- | --- |\n| Pear | 3   |')
+  })
+
+  it('does not treat `tableHeader` as an unrepresentable node', () => {
+    // #given / #when
+    const unknown = findUnrepresentableNodes(fragmentWithTable(1))
+
+    // #then main's schema resolves it, so y-prosemirror will not delete it
+    expect(unknown).toEqual([])
+  })
+
+  it('round-trips a headered table back to the same blocks', async () => {
+    // #given
+    const markdown = await yDocToMarkdown(fragmentWithTable(1))
+
+    // #when
+    const blocks = await markdownToBlocks(markdown!)
+
+    // #then
+    const table = blocks!.find((b) => b.type === 'table')
+    const content = table!.content as unknown as { headerRows?: number; rows: unknown[] }
+    expect(content.headerRows).toBe(1)
+    expect(content.rows).toHaveLength(2)
+  })
+})
+
 /**
  * The same schema `blocknote-converter` builds, in an editor of its own, purely
  * so a test can look at the ProseMirror schema and call the specs directly.

--- a/apps/desktop/src/renderer/src/components/inbox-detail/inbox-content-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/inbox-content-editor.tsx
@@ -66,6 +66,9 @@ export const InboxContentEditor = memo(function InboxContentEditor({
 
   // Create the BlockNote editor
   const editor = useCreateBlockNote({
+    // Same header-row toggle the note body gets — the same markdown round-trip
+    // applies here, so the two surfaces have to agree about tables.
+    tables: { headers: true },
     placeholders: {
       default: placeholder,
       heading: 'Heading',

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders as render } from '@tests/utils/render'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
+import { getDefaultReactSlashMenuItems } from '@blocknote/react'
 import { WIKI_LINK_EDIT_PLUGIN_KEY } from './wiki-link-edit-plugin'
 
 const contentAreaMocks = vi.hoisted(() => ({
@@ -543,6 +544,16 @@ describe('ContentArea', () => {
     expect(screen.queryByTestId('blocknote-view')).not.toBeInTheDocument()
   })
 
+  // BlockNote 0.47 defaults `tables.headers` to false, which removes the table
+  // handle menu's header-row toggle entirely — while the markdown the note is
+  // saved as always writes a header separator. The editor has to offer the row
+  // the file format is going to insist on.
+  it('enables the table header row toggle', () => {
+    render(<ContentArea noteId="note-1" />)
+
+    expect(contentAreaMocks.blockNoteOptions.tables).toMatchObject({ headers: true })
+  })
+
   // The signed-out clobber: with no session the editor was never bound to a
   // Y.Doc, so keystrokes reached markdown alone and the sign-in that rebuilt the
   // doc from the server wrote it back over them. The local doc is the editor's
@@ -966,6 +977,40 @@ describe('ContentArea', () => {
     await expect(slashController.getItems('photo')).resolves.toEqual([
       expect.objectContaining({ key: 'image' })
     ])
+  })
+
+  it('inserts new tables with the header row markdown is going to give them anyway', async () => {
+    const defaultTableClick = vi.fn()
+    const table = {
+      id: 'new-table',
+      type: 'table',
+      content: {
+        type: 'tableContent',
+        columnWidths: [null, null],
+        rows: [{ cells: [{}, {}] }, { cells: [{}, {}] }]
+      }
+    }
+    vi.mocked(getDefaultReactSlashMenuItems).mockReturnValueOnce([
+      { key: 'table', title: 'Table', group: 'Basic blocks', onItemClick: defaultTableClick }
+    ] as never)
+    contentAreaMocks.editor.getTextCursorPosition.mockReturnValue({ block: table })
+
+    render(<ContentArea noteId="note-1" />)
+    const slashController = contentAreaMocks.suggestionControllers.find(
+      (controller) => controller.triggerCharacter === '/'
+    )
+    const items = await slashController.getItems('table')
+
+    items[0].onItemClick()
+
+    expect(defaultTableClick).toHaveBeenCalledTimes(1)
+    expect(contentAreaMocks.editor.updateBlock).toHaveBeenCalledWith(
+      table,
+      expect.objectContaining({
+        type: 'table',
+        content: expect.objectContaining({ headerRows: 1 })
+      })
+    )
   })
 
   it('registers the wiki-link edit plugin, prepended, through the undo-safe wrapper', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -45,7 +45,11 @@ import { WikiLinkPreviewCard } from './wiki-link-preview-card'
 import { LinkMentionPreviewCard } from './link-mention-preview-card'
 import { BlockDropIndicator, EmptyDocumentDropIndicator } from './block-drop-indicator'
 import { getCalloutSlashMenuItem } from './callout-block'
-import { orderSlashMenuItemsByGroup } from './slash-menu-utils'
+import {
+  orderSlashMenuItemsByGroup,
+  withTableHeaderRow,
+  type TableInsertEditor
+} from './slash-menu-utils'
 import { getTaskSlashMenuItem } from './task-block'
 import { TaskPrefetchProvider } from './task-block/task-prefetch-context'
 import { tasksService } from '@/services/tasks-service'
@@ -386,6 +390,10 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
   const editor = useCreateBlockNote({
     schema: editorSchema,
     setIdAttribute: true,
+    // Off by default in BlockNote 0.47, which leaves the table handle menu with
+    // no way to make a header row at all — while markdown storage hands every
+    // table one on the way back in.
+    tables: { headers: true },
     uploadFile,
     resolveFileUrl,
     placeholders: {
@@ -1433,10 +1441,16 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
               getItems={async (query) => {
                 // `img` and `picture` already ship as image aliases; `photo` did
                 // not, and is what people actually type.
-                const defaults = getDefaultReactSlashMenuItems(editor).map((item) =>
-                  (item as { key?: string }).key === 'image'
-                    ? { ...item, aliases: [...(item.aliases ?? []), 'photo'] }
-                    : item
+                const defaults = withTableHeaderRow(
+                  getDefaultReactSlashMenuItems(editor).map((item) =>
+                    (item as { key?: string }).key === 'image'
+                      ? { ...item, aliases: [...(item.aliases ?? []), 'photo'] }
+                      : item
+                  ),
+                  // `updateBlock` is typed against the whole schema union, so a
+                  // helper that only ever writes table content cannot state its
+                  // parameter in terms the editor's own signature accepts.
+                  editor as unknown as TableInsertEditor
                 )
                 // `/pdf` is the same item as `/file` — same insert, same panel —
                 // relabelled, because "attach a PDF" is what most people are

--- a/apps/desktop/src/renderer/src/components/note/content-area/slash-menu-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/slash-menu-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { orderSlashMenuItemsByGroup } from './slash-menu-utils'
+import { orderSlashMenuItemsByGroup, withTableHeaderRow } from './slash-menu-utils'
 
 const groups = <T extends { group?: string }>(items: T[]) => items.map((i) => i.group)
 
@@ -49,5 +49,94 @@ describe('orderSlashMenuItemsByGroup', () => {
 
   it('returns an empty array unchanged', () => {
     expect(orderSlashMenuItemsByGroup([])).toEqual([])
+  })
+})
+
+describe('withTableHeaderRow', () => {
+  // BlockNote's default `/table` inserts a header-less 2x3 table, and the
+  // cursor lands inside it, so the editor reports the table as the cursor block.
+  function editorWithInsertedTable(headerRows?: number, rowCount = 2) {
+    const row = () => ({ cells: [{ text: '' }, { text: '' }, { text: '' }] })
+    const block = {
+      id: 'tbl',
+      type: 'table',
+      content: {
+        type: 'tableContent' as const,
+        columnWidths: [null, null, null],
+        ...(headerRows === undefined ? {} : { headerRows }),
+        rows: Array.from({ length: rowCount }, row)
+      }
+    }
+    const updates: unknown[] = []
+    return {
+      block,
+      updates,
+      editor: {
+        getTextCursorPosition: () => ({ block }),
+        updateBlock: (_target: unknown, update: unknown) => updates.push(update)
+      }
+    }
+  }
+
+  const tableItem = (onItemClick: () => void) => [
+    { key: 'paragraph', onItemClick: () => {} },
+    { key: 'table', onItemClick }
+  ]
+
+  it('gives a freshly inserted table a header row plus the two body rows', () => {
+    const { editor, updates } = editorWithInsertedTable()
+    let inserted = false
+    const items = withTableHeaderRow(
+      tableItem(() => {
+        inserted = true
+      }),
+      editor
+    )
+
+    items.find((i) => i.key === 'table')!.onItemClick!()
+
+    expect(inserted).toBe(true)
+    expect(updates).toHaveLength(1)
+    const content = (updates[0] as { content: { headerRows: number; rows: unknown[] } }).content
+    expect(content.headerRows).toBe(1)
+    // One header row on top of the two body rows BlockNote hands out, so the
+    // table markdown writes and the table markdown reads back are the same one.
+    expect(content.rows).toHaveLength(3)
+  })
+
+  it('leaves every other item untouched', () => {
+    const { editor } = editorWithInsertedTable()
+    const original = tableItem(() => {})
+    const items = withTableHeaderRow(original, editor)
+
+    expect(items.find((i) => i.key === 'paragraph')).toBe(original[0])
+  })
+
+  it('does not re-promote a table that already has a header row', () => {
+    const { editor, updates } = editorWithInsertedTable(1)
+    const items = withTableHeaderRow(
+      tableItem(() => {}),
+      editor
+    )
+
+    items.find((i) => i.key === 'table')!.onItemClick!()
+
+    expect(updates).toEqual([])
+  })
+
+  it('does nothing when the insert did not leave the cursor in a table', () => {
+    const updates: unknown[] = []
+    const editor = {
+      getTextCursorPosition: () => ({ block: { type: 'paragraph', content: [] } }),
+      updateBlock: (_t: unknown, u: unknown) => updates.push(u)
+    }
+    const items = withTableHeaderRow(
+      tableItem(() => {}),
+      editor
+    )
+
+    items.find((i) => i.key === 'table')!.onItemClick!()
+
+    expect(updates).toEqual([])
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/slash-menu-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/slash-menu-utils.ts
@@ -69,9 +69,7 @@ export function withTableHeaderRow<T extends { key?: string; onItemClick?: () =>
               content: {
                 ...content,
                 headerRows: 1,
-                rows: lastRow
-                  ? [...content.rows, JSON.parse(JSON.stringify(lastRow)) as TableRow]
-                  : content.rows
+                rows: lastRow ? [...content.rows, structuredClone(lastRow)] : content.rows
               }
             })
           }

--- a/apps/desktop/src/renderer/src/components/note/content-area/slash-menu-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/slash-menu-utils.ts
@@ -19,3 +19,63 @@ export function orderSlashMenuItemsByGroup<T extends { group?: string }>(items: 
 
   return order.flatMap((group) => byGroup.get(group)!)
 }
+
+type TableRow = { cells: unknown[] }
+
+type TableContent = {
+  type: 'tableContent'
+  headerRows?: number
+  rows: TableRow[]
+}
+
+export type TableInsertEditor = {
+  getTextCursorPosition: () => { block?: { type?: string; content?: unknown } } | undefined
+  updateBlock: (block: unknown, update: { type: 'table'; content: TableContent }) => void
+}
+
+function isTableContent(content: unknown): content is TableContent {
+  return (
+    typeof content === 'object' &&
+    content !== null &&
+    (content as TableContent).type === 'tableContent' &&
+    Array.isArray((content as TableContent).rows)
+  )
+}
+
+// A note body is stored as markdown, and a GFM table cannot exist without a
+// header separator: a table saved with `headerRows: 0` comes back from the file
+// carrying an empty header row that nobody typed, which is the "my table only
+// grows a header once I leave the page and come back" report. BlockNote's own
+// `/table` item inserts a header-less table regardless of `tables.headers`, so
+// insert the header row the storage format is going to add anyway — and keep
+// the two body rows the default hands out by appending one.
+export function withTableHeaderRow<T extends { key?: string; onItemClick?: () => void }>(
+  items: T[],
+  editor: TableInsertEditor
+): T[] {
+  return items.map((item) =>
+    item.key === 'table'
+      ? {
+          ...item,
+          onItemClick: () => {
+            item.onItemClick?.()
+            const block = editor.getTextCursorPosition()?.block
+            if (block?.type !== 'table' || !isTableContent(block.content)) return
+            const content = block.content
+            if (content.headerRows) return
+            const lastRow = content.rows[content.rows.length - 1]
+            editor.updateBlock(block, {
+              type: 'table',
+              content: {
+                ...content,
+                headerRows: 1,
+                rows: lastRow
+                  ? [...content.rows, JSON.parse(JSON.stringify(lastRow)) as TableRow]
+                  : content.rows
+              }
+            })
+          }
+        }
+      : item
+  )
+}

--- a/apps/desktop/src/renderer/src/components/tasks/task-description-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-description-editor.tsx
@@ -49,6 +49,9 @@ export const TaskDescriptionEditor = memo(function TaskDescriptionEditor({
   const isContentReadyRef = useRef(false)
 
   const editor = useCreateBlockNote({
+    // Same header-row toggle the note body gets — the same markdown round-trip
+    // applies here, so the two surfaces have to agree about tables.
+    tables: { headers: true },
     placeholders: {
       default: placeholder,
       heading: 'Heading',

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -40,6 +40,16 @@ Available from the slash menu (`/`) or the block-handle drag-out:
 - Table
 - Wiki-link block (or inline `[[...]]`)
 
+## Tables
+
+`/table` inserts a table with a header row and two body rows. The header row is
+part of the table, not a style: notes are stored as markdown, and a markdown
+table always writes its first row as the header.
+
+Use the row and column handles on the edge of a table to toggle a header row or
+a header column on and off. The same table controls are available in task
+descriptions and in inbox items.
+
 ## Slash Commands
 
 Type `/` anywhere in the editor to insert a block. Filter by typing — `/h2` jumps straight to Heading 2. Press <kbd>Enter</kbd> to confirm.


### PR DESCRIPTION
## Summary

Fixes #1638 — "Any table I make doesn't make a header row until I click a different page and go back."

BlockNote 0.47 defaults every `tables.*` feature to `false` and `useCreateBlockNote` was never passed a `tables` option, so the table handle menu shipped without its header-row toggle. There was no way to make a header row at all.

The reason one appears after a reload is the storage format. A note body is markdown, and a GFM table cannot exist without a header separator, so a table saved with `headerRows: 0` writes an empty header row and comes back carrying a row nobody typed. Measured on `@blocknote/core` 0.47.1:

| `headerRows` | markdown written | parsed back |
| --- | --- | --- |
| `0` (what `/table` inserts) | `\|   \|   \|` + separator + 2 body rows | `headerRows: 1`, **3 rows** — an empty row bolted on top |
| `1` | `\| A \| B \|` + separator + 1 body row | identical, stable |

So the table the user creates and the table they get back are not the same table.

Two changes:

- `tables: { headers: true }` on the note body, task descriptions and inbox content, so the header row can be toggled from the row/column handles.
- `withTableHeaderRow` wraps BlockNote's default `/table` item so a new table is inserted with a header row plus the two body rows the default hands out. `tables.headers` alone does not do this — the default item inserts `headerRows: 0` either way (verified).

Deliberately out of scope:

- `splitCells` stays off. `colspan`/`rowspan` have no GFM representation, so enabling it would lose structure on the way to disk.
- `cellTextColor` / `cellBackgroundColor` belong to #1639.
- `canvas-note-body.tsx` renders `editable={false}`. `tables.headers` only gates menu items, and there are no menus there, so adding it would be dead config.

Backward compatibility: no schema, contract or format change. `tableHeader` is already a node in the schema `blocknote-converter` builds on the main side, so the CRDT carries a header row without y-prosemirror deleting anything — asserted rather than assumed, see the test plan. Existing tables sitting at `headerRows: 1` render exactly as before.

## Release note

Tables now get a header row when you insert them, and you can toggle the header row or header column from the table handles — no more waiting for the note to reload before a header shows up.

## Test plan

New tests:

- `slash-menu-utils.test.ts` — `withTableHeaderRow` promotes a freshly inserted table to one header row plus two body rows, leaves other slash items untouched, and is a no-op on a table that already has a header or when the insert left the cursor outside a table.
- `ContentArea.test.tsx` — the editor is created with `tables.headers`, and the `/table` item runs the default insert and then writes `headerRows: 1`.
- `blocknote-converter.test.ts` (`describe('table header rows')`) — a headered table survives the CRDT and serializes as the GFM header row with no phantom row above it; `findUnrepresentableNodes` returns `[]` for it, proving main's schema resolves `tableHeader`; markdown round-trips back to the same blocks.

Each of these was mutation-checked — reverting `headerRows: 1` to `0`, dropping the `tables` option, and unwrapping `withTableHeaderRow` each turn a test red.

Commands:

- `pnpm typecheck` — pass
- `pnpm lint` — pass, 0 warnings on the changed source files
- desktop renderer suite — 648 files / 7766 tests pass
- desktop main suite — 552 files / 7180 tests pass
- `pnpm check:architecture`, `pnpm check:contracts` — pass
- `pnpm docs:impact --base <merge-base> --strict`, `pnpm docs:build` — pass

E2E not run: those jobs are push-to-main only, and main's E2E is independently red.

## Note on the docs gate

`93190eb9d` swaps a `JSON.parse(JSON.stringify(...))` deep clone for `structuredClone` (React Doctor `no-json-parse-stringify-clone`). It was pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: the pre-push gate scores each push against the previously pushed commit, and that commit on its own touches a renderer file with no user-facing change — same table, same behaviour, different clone call. The branch-wide gate against the merge-base still passes on its own (`pnpm docs:impact --base <merge-base> --strict` → `docs changed on this branch`); the user-facing docs for this PR landed in `d02f43e11`.
