### PR TITLE
fix(tables): plain text pasted into a cell stays text

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -83,6 +83,7 @@ import {
 } from './hooks'
 import { BlockMarqueeOverlay } from './block-marquee-overlay'
 import { PasteLinkMenu } from './paste-link-menu'
+import { handleEditorPaste } from './table-cell-paste'
 import { extractYouTubeVideoId } from '@/lib/youtube-utils'
 import { extractDomain, fetchLinkPreview } from '@/lib/url-metadata'
 import { createLinkMentionContent } from './link-mention'
@@ -404,6 +405,7 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
       checkListItem: t('editor.content.todoPlaceholder')
     },
     dictionary: { ...coreEn, ai: aiEn } as any,
+    pasteHandler: handleEditorPaste,
     ...(yjsFragment
       ? {
           collaboration: {

--- a/apps/desktop/src/renderer/src/components/note/content-area/table-cell-paste.integration.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/table-cell-paste.integration.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { BlockNoteEditor } from '@blocknote/core'
+import { TextSelection } from '@tiptap/pm/state'
+import { handleEditorPaste, isSelectionInTableCell } from './table-cell-paste'
+import { parseMarkdownPreservingBlanks, serializeBlocksPreservingBlanks } from './markdown-utils'
+import type { Block } from './types'
+
+// Issue #1641: "I can't even cut and paste the text into the row and have to
+// re-write it." These run against a real mounted BlockNote editor and a real
+// clipboard payload, because the damage happens inside ProseMirror's paste
+// pipeline — a mocked editor would report success either way.
+//
+// Uses the default BlockNote schema: it already carries the table blocks, and
+// the custom schema's extra specs drag react-pdf into jsdom.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// jsdom ships neither, and BlockNote's paste path constructs both.
+class FakeDataTransfer {
+  private readonly store = new Map<string, string>()
+  readonly files: unknown[] = []
+
+  clearData(): void {
+    this.store.clear()
+  }
+
+  setData(type: string, value: string): void {
+    this.store.set(type, value)
+  }
+
+  getData(type: string): string {
+    return this.store.get(type) ?? ''
+  }
+
+  get types(): string[] {
+    return [...this.store.keys()]
+  }
+}
+
+beforeEach(() => {
+  if ((globalThis as any).ClipboardEvent) return
+  class StubClipboardEvent extends Event {
+    clipboardData = new FakeDataTransfer()
+  }
+  ;(globalThis as any).ClipboardEvent = StubClipboardEvent
+})
+
+const mounted: Array<{ editor: BlockNoteEditor; el: HTMLElement }> = []
+
+afterEach(() => {
+  for (const { editor, el } of mounted.splice(0)) {
+    editor.unmount()
+    el.remove()
+  }
+})
+
+function mountEditor(): BlockNoteEditor {
+  const editor = BlockNoteEditor.create({
+    pasteHandler: handleEditorPaste,
+    initialContent: [
+      { type: 'paragraph', content: 'Intro' },
+      {
+        type: 'table',
+        content: {
+          type: 'tableContent',
+          headerRows: 1,
+          rows: [
+            { cells: ['Task', 'Owner'] },
+            { cells: ['Ship it', 'Kaan'] },
+            { cells: ['Review', 'Nobody'] }
+          ]
+        }
+      }
+    ] as any
+  })
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  editor.mount(el)
+  mounted.push({ editor, el })
+  return editor
+}
+
+function view(editor: BlockNoteEditor): any {
+  return (editor as any).prosemirrorView
+}
+
+/** Document position of a run of text, so a test can aim at one cell by name. */
+function findText(editor: BlockNoteEditor, needle: string): { from: number; to: number } {
+  let found: { from: number; to: number } | null = null
+  view(editor).state.doc.descendants((node: any, pos: number) => {
+    if (found || !node.isText || node.text !== needle) return
+    found = { from: pos, to: pos + needle.length }
+  })
+  if (!found) throw new Error(`no text node reads "${needle}"`)
+  return found
+}
+
+function placeCursorAfter(editor: BlockNoteEditor, cellText: string): void {
+  const { to } = findText(editor, cellText)
+  select(editor, to, to)
+}
+
+function select(editor: BlockNoteEditor, from: number, to: number): void {
+  const v = view(editor)
+  v.dispatch(v.state.tr.setSelection(TextSelection.create(v.state.doc, from, to)))
+}
+
+function dispatchClipboardEvent(
+  editor: BlockNoteEditor,
+  type: 'copy' | 'cut' | 'paste',
+  data: FakeDataTransfer
+): void {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', { value: data })
+
+  if (type === 'paste') {
+    view(editor).dom.dispatchEvent(event)
+    return
+  }
+
+  // BlockNote's copy handler bails out when the DOM selection is collapsed,
+  // which under jsdom it always is — the real selection lives in ProseMirror.
+  const realGetSelection = window.getSelection
+  window.getSelection = (() => ({ isCollapsed: false, focusNode: null })) as any
+  try {
+    view(editor).dom.dispatchEvent(event)
+  } finally {
+    window.getSelection = realGetSelection
+  }
+}
+
+function pastePlainText(editor: BlockNoteEditor, text: string): void {
+  const data = new FakeDataTransfer()
+  data.setData('text/plain', text)
+  dispatchClipboardEvent(editor, 'paste', data)
+}
+
+/** The table's cells as plain strings, row by row. */
+function tableCells(editor: BlockNoteEditor): string[][] {
+  const table = editor.document.find((block) => block.type === 'table') as any
+  if (!table) throw new Error('the document lost its table')
+  return table.content.rows.map((row: any) =>
+    row.cells.map((cell: any) =>
+      (cell.content ?? [])
+        .map((inline: any) => (inline.type === 'text' ? inline.text : `<${inline.type}>`))
+        .join('')
+    )
+  )
+}
+
+describe('pasting into a table cell', () => {
+  it('drops a plain sentence into the cell holding the cursor', () => {
+    const editor = mountEditor()
+    placeCursorAfter(editor, 'Ship it')
+
+    pastePlainText(editor, ' today')
+
+    expect(tableCells(editor)).toEqual([
+      ['Task', 'Owner'],
+      ['Ship it today', 'Kaan'],
+      ['Review', 'Nobody']
+    ])
+  })
+
+  it('keeps multi-line text inside the one cell instead of splitting the row', () => {
+    const editor = mountEditor()
+    placeCursorAfter(editor, 'Review')
+
+    pastePlainText(editor, 'first line\nsecond line')
+
+    const cells = tableCells(editor)
+    expect(cells).toHaveLength(3)
+    expect(cells.every((row) => row.length === 2)).toBe(true)
+    expect(cells[2][0]).toContain('first line')
+    expect(cells[2][0]).toContain('second line')
+  })
+
+  it('pastes text that looks like a markdown table as text, leaving the row alone', () => {
+    const editor = mountEditor()
+    placeCursorAfter(editor, 'Nobody')
+
+    // Read as markdown this is a 2x2 table, and prosemirror-tables used to
+    // splice its cells over the row — wiping "Nobody" and growing a column.
+    pastePlainText(editor, '| a | b |\n| - | - |\n| 1 | 2 |')
+
+    const cells = tableCells(editor)
+    expect(cells.every((row) => row.length === 2)).toBe(true)
+    expect(cells[2][1]).toContain('Nobody')
+    expect(cells[2][1]).toContain('| a | b |')
+  })
+
+  it('pastes text that looks like a markdown list as text', () => {
+    const editor = mountEditor()
+    placeCursorAfter(editor, 'Nobody')
+
+    pastePlainText(editor, '- one\n- two')
+
+    const cells = tableCells(editor)
+    expect(cells.every((row) => row.length === 2)).toBe(true)
+    expect(cells[2][1]).toContain('- one')
+    expect(cells[2][1]).toContain('- two')
+  })
+
+  it('leaves the default handler untouched outside a table', () => {
+    const editor = mountEditor()
+    const intro = findText(editor, 'Intro')
+    select(editor, intro.to, intro.to)
+
+    expect(isSelectionInTableCell(editor)).toBe(false)
+
+    // Outside a cell the handler must forward with no options at all, so
+    // BlockNote keeps reading pasted text as markdown everywhere else.
+    const calls: Array<unknown> = []
+    handleEditorPaste({
+      editor,
+      defaultPasteHandler: (options) => {
+        calls.push(options)
+        return true
+      }
+    } as any)
+    expect(calls).toEqual([undefined])
+  })
+
+  it('turns markdown parsing off inside a cell', () => {
+    const editor = mountEditor()
+    placeCursorAfter(editor, 'Nobody')
+
+    expect(isSelectionInTableCell(editor)).toBe(true)
+
+    const calls: Array<unknown> = []
+    handleEditorPaste({
+      editor,
+      defaultPasteHandler: (options) => {
+        calls.push(options)
+        return true
+      }
+    } as any)
+    expect(calls).toEqual([{ prioritizeMarkdownOverHTML: false, plainTextAsMarkdown: false }])
+  })
+
+  it('moves text from one cell to another on cut and paste', () => {
+    const editor = mountEditor()
+    const source = findText(editor, 'Nobody')
+    select(editor, source.from, source.to)
+
+    const clipboard = new FakeDataTransfer()
+    dispatchClipboardEvent(editor, 'cut', clipboard)
+    expect(tableCells(editor)[2][1]).toBe('')
+
+    placeCursorAfter(editor, 'Kaan')
+    dispatchClipboardEvent(editor, 'paste', clipboard)
+
+    expect(tableCells(editor)).toEqual([
+      ['Task', 'Owner'],
+      ['Ship it', 'KaanNobody'],
+      ['Review', '']
+    ])
+  })
+
+  it('still pastes a copied cell range as a range', () => {
+    const editor = mountEditor()
+    const start = findText(editor, 'Ship it')
+    const end = findText(editor, 'Kaan')
+    select(editor, start.from, end.to)
+
+    const clipboard = new FakeDataTransfer()
+    dispatchClipboardEvent(editor, 'copy', clipboard)
+    expect(clipboard.types).toContain('blocknote/html')
+
+    placeCursorAfter(editor, 'Review')
+    dispatchClipboardEvent(editor, 'paste', clipboard)
+
+    // A range keeps its shape: the two copied cells land side by side.
+    expect(tableCells(editor)[2].slice(0, 2)).toEqual(['Ship it', 'Kaan'])
+  })
+
+  it('keeps the pasted text through a save and reopen', async () => {
+    const editor = mountEditor()
+    placeCursorAfter(editor, 'Nobody')
+    pastePlainText(editor, ' (unassigned)')
+
+    const markdown = await serializeBlocksPreservingBlanks(editor, editor.document as Block[])
+    expect(markdown).toContain('(unassigned)')
+
+    const reopened = await parseMarkdownPreservingBlanks(editor, markdown)
+    const table = reopened.find((block) => block.type === 'table') as any
+    const reopenedCells = table.content.rows.map((row: any) =>
+      row.cells.map((cell: any) =>
+        (cell.content ?? []).map((inline: any) => inline.text ?? '').join('')
+      )
+    )
+    expect(reopenedCells.at(-1)).toEqual(['Review', 'Nobody (unassigned)'])
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/table-cell-paste.integration.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/table-cell-paste.integration.test.ts
@@ -238,6 +238,29 @@ describe('pasting into a table cell', () => {
     expect(calls).toEqual([{ prioritizeMarkdownOverHTML: false, plainTextAsMarkdown: false }])
   })
 
+  it('defers to the default handler when the editor cannot answer', () => {
+    // A paste landing mid-teardown: `transact` has no view to read a selection
+    // from. That must not escape into the DOM paste handler, which would take
+    // pasting down with it — the answer is simply "not in a cell".
+    const tornDownEditor = {
+      transact: () => {
+        throw new Error('editor view is gone')
+      }
+    } as never as BlockNoteEditor
+
+    expect(isSelectionInTableCell(tornDownEditor)).toBe(false)
+
+    const calls: Array<unknown> = []
+    handleEditorPaste({
+      editor: tornDownEditor,
+      defaultPasteHandler: (options) => {
+        calls.push(options)
+        return true
+      }
+    } as any)
+    expect(calls).toEqual([undefined])
+  })
+
   it('moves text from one cell to another on cut and paste', () => {
     const editor = mountEditor()
     const source = findText(editor, 'Nobody')

--- a/apps/desktop/src/renderer/src/components/note/content-area/table-cell-paste.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/table-cell-paste.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { BlockNoteEditor } from '@blocknote/core'
+
+/**
+ * BlockNote reads `text/plain` off the clipboard as markdown. Everywhere else
+ * that is what people want, but a table cell holds inline content only: text
+ * that merely *looks* like a markdown table (`| a | b |`) is parsed into a real
+ * table, and prosemirror-tables then splices that table's cells over the row
+ * the cursor sits in — the cell's own text is gone and columns appear that
+ * nobody asked for. The user has to retype the row.
+ *
+ * So inside a cell, plain text stays plain text. Richer clipboard flavours are
+ * untouched: `blocknote/html` (a cell or cell range copied inside the app) and
+ * `text/html` are picked ahead of `text/plain` by the default handler and both
+ * still paste as structure.
+ *
+ * See issue #1641.
+ */
+
+// The two node names BlockNote gives a table cell — a header cell is its own
+// node type, not a `tableCell` with a flag.
+const TABLE_CELL_NODES = new Set(['tableCell', 'tableHeader'])
+
+export function isSelectionInTableCell(editor: BlockNoteEditor<any, any, any>): boolean {
+  try {
+    return editor.transact((tr) => {
+      const { $from } = tr.selection
+      for (let depth = $from.depth; depth > 0; depth--) {
+        if (TABLE_CELL_NODES.has($from.node(depth).type.name)) return true
+      }
+      return false
+    })
+  } catch {
+    // No editor view yet (or a selection shape without a resolved position) —
+    // let the default handler decide.
+    return false
+  }
+}
+
+interface PasteContext {
+  editor: BlockNoteEditor<any, any, any>
+  defaultPasteHandler: (options?: {
+    prioritizeMarkdownOverHTML?: boolean
+    plainTextAsMarkdown?: boolean
+  }) => boolean | undefined
+}
+
+export function handleEditorPaste({
+  editor,
+  defaultPasteHandler
+}: PasteContext): boolean | undefined {
+  if (!isSelectionInTableCell(editor)) return defaultPasteHandler()
+
+  // Both flags gate a markdown reading of `text/plain`: the first sniffs the
+  // text for markdown syntax, the second is the fallback when `text/plain` is
+  // the only flavour on the clipboard. Turning off just one still leaves the
+  // other reading a pasted `| a | b |` as a table.
+  return defaultPasteHandler({
+    prioritizeMarkdownOverHTML: false,
+    plainTextAsMarkdown: false
+  })
+}

--- a/apps/desktop/tests/e2e/table-cell-paste.e2e.ts
+++ b/apps/desktop/tests/e2e/table-cell-paste.e2e.ts
@@ -1,0 +1,255 @@
+/**
+ * G4 (#1641) — "I can't even cut and paste the text into the row and have to
+ * re-write it."
+ *
+ * This lives in E2E rather than the renderer suite because the damage happens
+ * inside a real clipboard round trip. jsdom has no `DataTransfer`, and its
+ * HTML-paste path is inert, so a renderer test can pin the decision we make
+ * (see `table-cell-paste.integration.test.ts`) but not the result a user sees.
+ * Here the paste is a real `ClipboardEvent` carrying a real `DataTransfer`,
+ * against the real editor, and the row is read back off disk afterwards.
+ *
+ * Everything here happens with the cursor inside a cell. A synthetic paste
+ * aimed at an ordinary paragraph is a no-op — the default handler's markdown
+ * path wants a trusted clipboard event — so the "outside a cell nothing
+ * changes" half is asserted in the renderer test, where the handler's decision
+ * can be read directly rather than inferred from the document.
+ */
+
+import type { Locator, Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { ready, uniqueLabel } from './utils/desktop-test-helpers'
+import { openNoteByTitle } from './utils/note-sync-helpers'
+import { SELECTORS } from './utils/electron-helpers'
+
+const TABLE_NOTE_BODY = [
+  'Intro',
+  '',
+  '| Task    | Owner  |',
+  '| ------- | ------ |',
+  '| Ship it | Kaan   |',
+  '| Review  | Nobody |',
+  ''
+].join('\n')
+
+async function seedTableNote(page: Page, title: string): Promise<string> {
+  const created = await page.evaluate(
+    async ({ t, c }) => window.api.notes.create({ title: t, content: c }),
+    { t: title, c: TABLE_NOTE_BODY }
+  )
+  const id = created?.note?.id
+  if (!id) throw new Error(`could not seed "${title}"`)
+  return id
+}
+
+async function openTableNote(page: Page, title: string): Promise<void> {
+  await openNoteByTitle(page, title)
+  await page.locator(SELECTORS.noteEditor).first().waitFor({ state: 'visible', timeout: 20_000 })
+  // The table has to be in the editor's own document, not just the DOM, before
+  // a paste can be aimed at one of its cells.
+  await expect
+    .poll(() => tableCells(page), { timeout: 20_000 })
+    .toEqual([
+      ['Task', 'Owner'],
+      ['Ship it', 'Kaan'],
+      ['Review', 'Nobody']
+    ])
+}
+
+/** The table's cells as plain strings, row by row. */
+async function tableCells(page: Page): Promise<string[][] | null> {
+  return page.evaluate(() => {
+    const editor = (window as any).__memryEditor
+    if (!editor) return null
+    const table = editor.document.find((block: any) => block.type === 'table')
+    if (!table) return null
+    return table.content.rows.map((row: any) =>
+      row.cells.map((cell: any) =>
+        (cell.content ?? [])
+          .map((inline: any) => (inline.type === 'text' ? inline.text : `<${inline.type}>`))
+          .join('')
+      )
+    )
+  })
+}
+
+/**
+ * Drive the cursor the way a user does — click the cell, then walk to the end
+ * of its line. Reaching into ProseMirror to set a position would skip the very
+ * layer (focus, DOM selection) that the paste handler reads.
+ */
+function cell(page: Page, text: string): Locator {
+  return page
+    .locator(`${SELECTORS.noteEditor} td, ${SELECTORS.noteEditor} th`)
+    .filter({ hasText: text })
+    .first()
+}
+
+async function placeCursorAtEndOf(page: Page, cellText: string): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        await cell(page, cellText).click()
+        await page.keyboard.press('End')
+        return page.evaluate(() => {
+          const view = (window as any).__memryEditor?.prosemirrorView
+          return view ? (view.state.selection.$from.parent.textContent as string) : ''
+        })
+      },
+      { message: `cursor inside the "${cellText}" cell`, timeout: 10_000 }
+    )
+    .toBe(cellText)
+}
+
+/**
+ * BlockNote's copy handler bails out when the DOM selection is collapsed, so a
+ * cut fired before the selection lands is silently a no-op. Repeat the gesture
+ * until the browser agrees the text is selected.
+ */
+async function selectCellText(page: Page, cellText: string): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        await cell(page, cellText).click()
+        await page.keyboard.press('Home')
+        await page.keyboard.press('Shift+End')
+        return page.evaluate(() => window.getSelection()?.toString() ?? '')
+      },
+      { message: `DOM selection over "${cellText}"`, timeout: 10_000 }
+    )
+    .toBe(cellText)
+}
+
+async function pastePlainText(page: Page, text: string): Promise<void> {
+  await page.evaluate((value) => {
+    const view = (window as any).__memryEditor?.prosemirrorView
+    if (!view) throw new Error('window.__memryEditor not exposed')
+    const clipboardData = new DataTransfer()
+    clipboardData.setData('text/plain', value)
+    view.dom.dispatchEvent(
+      new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData })
+    )
+  }, text)
+}
+
+/**
+ * Cut whatever is selected, then paste it at the current cursor. Both events
+ * carry the same `DataTransfer`, which is exactly how the browser hands the
+ * clipboard from one to the other.
+ */
+async function cutSelection(page: Page): Promise<void> {
+  const flavours = await page.evaluate(() => {
+    const view = (window as any).__memryEditor?.prosemirrorView
+    const clipboardData = new DataTransfer()
+    ;(window as any).__memryE2EClipboard = clipboardData
+    view.dom.dispatchEvent(
+      new ClipboardEvent('cut', { bubbles: true, cancelable: true, clipboardData })
+    )
+    return [...clipboardData.types]
+  })
+  // An empty clipboard here means the cut never fired, and the paste that
+  // follows would then assert against an unchanged table.
+  expect(flavours).toContain('blocknote/html')
+}
+
+async function pasteCutSelection(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const view = (window as any).__memryEditor?.prosemirrorView
+    const clipboardData = (window as any).__memryE2EClipboard
+    if (!clipboardData) throw new Error('nothing was cut')
+    view.dom.dispatchEvent(
+      new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData })
+    )
+  })
+}
+
+async function savedBody(page: Page, noteId: string): Promise<string> {
+  const note = await page.evaluate(async (id) => window.api.notes.get(id), noteId)
+  return note?.content ?? ''
+}
+
+/** How many columns the markdown row starting with `prefix` carries. */
+function columnCount(markdown: string, prefix: string): number {
+  const row = markdown.split('\n').find((line) => line.trimStart().startsWith(prefix))
+  if (!row) throw new Error(`no markdown row starts with "${prefix}"`)
+  return row.split('|').slice(1, -1).length
+}
+
+test.describe('Pasting into a table cell', () => {
+  test.beforeEach(async ({ page }) => {
+    await ready(page)
+  })
+
+  test('keeps the row when the pasted text looks like a markdown table', async ({ page }) => {
+    const title = uniqueLabel('Table Paste Markdown')
+    const noteId = await seedTableNote(page, title)
+    await openTableNote(page, title)
+
+    await placeCursorAtEndOf(page, 'Nobody')
+    // Read as markdown this is a 2x2 table of its own. Before #1641 it was
+    // spliced into the row: "Nobody" vanished and a third column appeared.
+    await pastePlainText(page, '| alpha | beta |\n| - | - |\n| 1 | 2 |')
+
+    const cells = await tableCells(page)
+    expect(cells).toHaveLength(3)
+    expect(cells?.every((row) => row.length === 2)).toBe(true)
+    expect(cells?.[2][1]).toContain('Nobody')
+    expect(cells?.[2][1]).toContain('| alpha | beta |')
+
+    // And it is still a two-column table once it lands on disk.
+    await expect
+      .poll(() => savedBody(page, noteId), { message: 'note body on disk', timeout: 20_000 })
+      .toContain('alpha')
+    const body = await savedBody(page, noteId)
+    expect(body).toContain('Nobody')
+    expect(columnCount(body, '| Task')).toBe(2)
+  })
+
+  test('keeps multi-line text inside the one cell', async ({ page }) => {
+    const title = uniqueLabel('Table Paste Multiline')
+    const noteId = await seedTableNote(page, title)
+    await openTableNote(page, title)
+
+    await placeCursorAtEndOf(page, 'Review')
+    await pastePlainText(page, ' first\nsecond')
+
+    const cells = await tableCells(page)
+    expect(cells).toHaveLength(3)
+    expect(cells?.every((row) => row.length === 2)).toBe(true)
+    expect(cells?.[2][0]).toContain('first')
+    expect(cells?.[2][0]).toContain('second')
+
+    // A markdown row is one line, so the newline becomes a space on disk —
+    // lossy, but the text is all still there and the table is still a table.
+    await expect
+      .poll(() => savedBody(page, noteId), { message: 'note body on disk', timeout: 20_000 })
+      .toContain('second')
+    const body = await savedBody(page, noteId)
+    expect(body).toMatch(/\|\s*Review first second\s*\|\s*Nobody\s*\|/)
+  })
+
+  test('moves text from one cell into another on cut and paste', async ({ page }) => {
+    const title = uniqueLabel('Table Paste Cut')
+    const noteId = await seedTableNote(page, title)
+    await openTableNote(page, title)
+
+    await selectCellText(page, 'Nobody')
+    await cutSelection(page)
+    await expect.poll(async () => (await tableCells(page))?.[2][1], { timeout: 10_000 }).toBe('')
+
+    await placeCursorAtEndOf(page, 'Kaan')
+    await pasteCutSelection(page)
+
+    await expect
+      .poll(() => tableCells(page), { timeout: 10_000 })
+      .toEqual([
+        ['Task', 'Owner'],
+        ['Ship it', 'KaanNobody'],
+        ['Review', '']
+      ])
+
+    await expect
+      .poll(() => savedBody(page, noteId), { message: 'note body on disk', timeout: 20_000 })
+      .toContain('KaanNobody')
+  })
+})

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -200,6 +200,15 @@ Pasting a URL offers four ways to keep it: plain **URL**, an inline **Mention** 
 
 This works inside a table cell too. **Mention** replaces the pasted URL in that one cell and leaves the rest of the table alone. **Embed** and **Bookmark** are blocks in their own right and a cell holds text only, so they take the URL out of the cell and place the card after the whole table.
 
+## Pasting into a Table Cell
+
+Pasted text is normally read as Markdown, so a pasted `# Heading` becomes a heading and a pasted `| a | b |` becomes a table. Inside a table cell that reading is switched off: a cell holds text, and text is what you get. Paste a row of pipes into a cell and you get a row of pipes, not a second table spliced over the one you are editing.
+
+Two things follow from a cell holding text only:
+
+- Pasted line breaks stay inside the one cell. A Markdown table row is a single line, so they are saved as spaces — the words all survive, the line breaks do not.
+- Copying **cells** rather than text still pastes as cells. A cell or a range of cells copied from a table in memrynote keeps its shape and fills the grid from wherever the cursor is, the way a spreadsheet does.
+
 ## Link Previews
 
 Links in a note are enriched with the page title, site name and favicon, both for inline link mentions and for bookmark blocks. The lookup runs once per URL and the result is kept in memory, so reopening a note with the same links does not refetch them.


### PR DESCRIPTION
Closes #1641 (EPIC #1625, item **G4**).

## What the user hit

> "…and then I can't even cut and paste the text into the row and have to re-write it."

`12d59c99a` fixed the **URL** half of G4 (a URL pasted into a cell no longer throws). The issue asked to verify the **plain text** half on top of that fix. Five scenarios were checked against a real mounted editor; four were already fine and one destroyed data.

| Scenario | Before this PR |
| --- | --- |
| Plain single-line text → cell | fine |
| Multi-line text → cell | fine (stays in the one cell) |
| Cell → cell cut/paste | fine |
| Cell range → paste | fine (keeps its shape) |
| **Text that looks like a markdown table → cell** | **the row is destroyed** |

The last one, reproduced on a `Task \| Owner` table, pasting `\| a \| b \|…` at the end of cell `B1`:

```
before  [["Task","Owner"], ["A1","B1"], ["A2","B2"]]
after   [["Task","Owner",""], ["A1","x","y"], ["A2","1","2"]]
```

`B1` and `B2` are gone, replaced by the pasted table's cells, and a third column has appeared. That is the "have to re-write it" the report describes.

## Why

BlockNote reads `text/plain` off the clipboard as markdown (`prioritizeMarkdownOverHTML` sniffs the text for markdown syntax, `plainTextAsMarkdown` is the fallback when `text/plain` is the only flavour on the clipboard — both default on). A cell holds inline content only, so once the pasted text has been parsed into a real table, prosemirror-tables splices its cells over the grid at the cursor instead of typing into it.

## The change

`table-cell-paste.ts` turns **both** markdown readings off while the selection is inside a `tableCell` or `tableHeader` — turning off only one still leaves the other reading a pasted `| a | b |` as a table. Everything else is untouched:

- Outside a cell, the handler forwards with no options at all, so pasted markdown still becomes markdown.
- `blocknote/html` (a cell or a cell range copied inside the app) and `text/html` both outrank `text/plain` in the default handler, so a copied range still pastes as a range.

Newlines inside a cell are still saved as spaces — a markdown table row is one line — which is lossy but keeps every word and keeps the table a table. Documented rather than changed.

## Tests

Covered from both sides, because neither side can see the whole thing.

- `table-cell-paste.integration.test.ts` — 9 tests against a real mounted BlockNote editor: the decision the handler makes, the resulting cells for each paste shape, cut/paste between cells, a copied range keeping its shape, and a save/reopen round trip through the app's own markdown serializer.
- `table-cell-paste.e2e.ts` — 3 tests in real Electron: a real `ClipboardEvent` carrying a real `DataTransfer`, cursor placed by clicking the cell, and the row read back **off disk** afterwards. jsdom has no `DataTransfer` and its HTML-paste path is inert, so this half cannot live in the renderer suite.

Every E2E case puts the cursor inside a cell. A synthetic paste aimed at an ordinary paragraph is a no-op — the default handler's markdown path wants a trusted clipboard event — so the "outside a cell nothing changes" half is asserted in the renderer test, where the handler's decision is read directly rather than inferred from the document.

Mutation-checked: reverting the fix to always call the default handler turns 5 of the 9 renderer tests red.

## Verification

- `table-cell-paste.integration.test.ts` — 9/9
- `table-cell-paste.e2e.ts` — 3/3 (real Electron, and again under `--repeat-each=2`)
- content-area renderer suite — 49 files, 629 tests
- `pnpm typecheck` (node + web + test), `pnpm build`, eslint on the changed files
- `pnpm docs:impact --base origin/main --strict` — covered; `pnpm docs:build`
