### PR TITLE
fix(wiki-links): promote `[[…]]` when a collaborative note is opened (#1642)

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
@@ -65,6 +65,47 @@ function replaceInitialBlocksWithoutHistory(editor: any, blocks: Block[]): void 
   })
 }
 
+/**
+ * Promote the raw `[[…]]` text a collaborative document opens with (#1642).
+ *
+ * Main parses the vault file into the shared Y.Doc with a `wikiLink` spec that
+ * has no `parse` rule, so `[[X]]` reaches the doc as plain TEXT — the renderer
+ * is the only thing that promotes it (`wiki-link-collab-promotion.test.ts`).
+ * The load effect below never did: it returns early for a collaborative
+ * document, so `normalizeNoteBlocks` runs on the markdown path only. Promotion
+ * on this path was left entirely to `handleChange`, which fires on a change
+ * EVENT — in practice the transaction y-prosemirror dispatches when the shared
+ * content reaches the editor, which is why opening a note usually does show
+ * chips. But nothing guarantees that event: it has to land after BlockNote's
+ * `onChange` subscriber is registered, and when it does not there is no second
+ * chance, because a document that is merely READ never changes again. That is
+ * the reported failure — a page of links that opens as plain, unclickable text
+ * and stays that way until the user types into it.
+ *
+ * So the open path promotes for itself, and stops depending on the event.
+ *
+ * A NORMAL `replaceBlocks`, deliberately: this is a CRDT mutation like any
+ * other, so y-prosemirror diffs it into the shared doc and it converges with
+ * every other device. `replaceInitialBlocksWithoutHistory` must not be used
+ * here — it removes and re-inserts the whole document, which on a shared doc is
+ * one device overwriting another's body.
+ *
+ * Idempotent by construction: a promoted `wikiLink` node carries its target in
+ * props, so `[[` never reappears and `normalizeWikiLinks` stops matching. A
+ * second open writes no CRDT update at all, which is what keeps "opening a note
+ * must not rewrite it" (#1434) true. Only wiki links promote here — hash tags
+ * and date mentions have no promoter on the collaborative path and must stay
+ * the bytes they were opened with.
+ */
+function promoteWikiLinksInSharedDoc(editor: any): void {
+  const normalized = normalizeWikiLinks(editor.document as Block[], {
+    skipBlockId: editingWikiLinkBlockId(editor)
+  })
+  if (!normalized.didChange) return
+
+  editor.replaceBlocks(editor.document, normalized.blocks)
+}
+
 function clearYjsUndoHistory(editor: any): void {
   const state = editor?._tiptapEditor?.state
   if (!state) return
@@ -256,6 +297,10 @@ export function useEditorSync({
     }
 
     if (yjsFragment) {
+      // Before the history is cleared, so opening a note never leaves an
+      // undoable step: Cmd+Z here would turn the chips back into raw text and
+      // push that to every device.
+      promoteWikiLinksInSharedDoc(editor)
       clearYjsUndoHistory(editor)
       isContentReadyRef.current = true
       if (onHeadingsChange) {

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-collab-promotion.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-collab-promotion.test.ts
@@ -27,6 +27,7 @@ import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { BlockNoteEditor, type Block } from '@blocknote/core'
 import * as Y from 'yjs'
+import { TextSelection } from '@tiptap/pm/state'
 import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 
 // The file block's PDF preview pulls pdf.js, which touches `DOMMatrix` at
@@ -64,8 +65,8 @@ interface CollabEditor {
   fragment: Y.XmlFragment
 }
 
-function createCollaborativeEditor(): CollabEditor {
-  const doc = new Y.Doc()
+function createCollaborativeEditor(existingDoc?: Y.Doc): CollabEditor {
+  const doc = existingDoc ?? new Y.Doc()
   const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
 
   // Exactly how ContentArea builds it when `isCollaborationActive(...)` is true.
@@ -106,7 +107,13 @@ function nodeNames(fragment: Y.XmlFragment): string[] {
   return names
 }
 
-/** Renders the real hook and hands back its real `handleChange`. */
+/**
+ * Renders the real hook and hands back its real `handleChange`.
+ *
+ * Rendering it IS opening the note: the hook's load effect is what runs on
+ * mount, and for the #1642 tests below that effect is the whole subject —
+ * `handleChange` is deliberately never called there.
+ */
 function mountEditorSync(editor: BlockNoteEditor, fragment: Y.XmlFragment): () => void {
   const { result } = renderHook(() =>
     useEditorSync({
@@ -116,6 +123,23 @@ function mountEditorSync(editor: BlockNoteEditor, fragment: Y.XmlFragment): () =
     })
   )
   return result.current.handleChange
+}
+
+/** The `target` of every `wikiLink` run in one block, in order. */
+function wikiLinkTargets(editor: BlockNoteEditor, blockIndex = 0): string[] {
+  const content = (editor.document[blockIndex] as Block).content as Array<{
+    type: string
+    props?: { target?: string }
+  }>
+  return content.filter((run) => run.type === 'wikiLink').map((run) => run.props?.target ?? '')
+}
+
+/** Park the caret inside the raw `[[…]]` run of the first paragraph. */
+function putCaretInsideRawRun(editor: BlockNoteEditor, text: string): void {
+  const tiptap = (editor as unknown as { _tiptapEditor: any })._tiptapEditor
+  const offset = text.indexOf('[[') + 3
+  const { state, dispatch } = tiptap.view
+  dispatch(state.tr.setSelection(TextSelection.create(state.doc, 1 + offset)))
 }
 
 describe('the renderer promotes [[X]] inside a collaborative document', () => {
@@ -203,5 +227,150 @@ describe('the renderer promotes [[X]] inside a collaborative document', () => {
     expect(updates).toEqual([])
     expect(nodeNames(fragment)).not.toContain('hashTag')
     expect(nodeNames(fragment)).not.toContain('dateMention')
+  })
+})
+
+/**
+ * #1642. The tests above drive `handleChange`, which fires on an EDIT. That was
+ * the ONLY promoter on the collaborative path, and it is the whole bug: a note
+ * whose Y.Doc holds raw `[[X]]` — pulled from another device, seeded from a
+ * file written outside Memry, or written by a pre-#1457 build — opened as
+ * plain, unclickable text and stayed that way until the user typed into it.
+ *
+ * Nothing below ever calls `handleChange`. Mounting the hook is the whole act:
+ * that is what opening a note does.
+ */
+describe('opening a collaborative note promotes its links without an edit', () => {
+  it('turns raw [[X]] into a chip on open', () => {
+    // #given a shared doc holding what main's parser leaves behind
+    const { editor, fragment } = createCollaborativeEditor()
+    seedWithPlainText(editor, 'See [[Wiki Link]] for details.')
+    expect(nodeNames(fragment)).not.toContain('wikiLink')
+
+    // #when the note is opened and nothing else happens — no keystroke
+    mountEditorSync(editor, fragment)
+
+    // #then the link is a node, in the editor and in the shared doc
+    expect(wikiLinkTargets(editor)).toEqual(['Wiki Link'])
+    expect(nodeNames(fragment).filter((name) => name === 'wikiLink')).toHaveLength(1)
+  })
+
+  it('shows the chip on a device that never touched the note', () => {
+    // #given device A, which wrote the raw text, and its update on the wire
+    const deviceA = createCollaborativeEditor()
+    seedWithPlainText(deviceA.editor, 'See [[Wiki Link]] for details.')
+    const fromA = Y.encodeStateAsUpdate(deviceA.doc)
+
+    // #when device B receives it and opens the note — the reported case: the
+    // user reads a page of links they did not write
+    const docB = new Y.Doc()
+    Y.applyUpdate(docB, fromA)
+    const deviceB = createCollaborativeEditor(docB)
+    expect(nodeNames(deviceB.fragment)).not.toContain('wikiLink')
+
+    mountEditorSync(deviceB.editor, deviceB.fragment)
+
+    // #then B sees a chip…
+    expect(wikiLinkTargets(deviceB.editor)).toEqual(['Wiki Link'])
+
+    // …and the promotion converges back onto A as one node rather than
+    // clobbering A's body, because it went in as an ordinary CRDT mutation and
+    // not as a whole-document replace
+    Y.applyUpdate(deviceA.doc, Y.encodeStateAsUpdate(docB))
+    expect(nodeNames(deviceA.fragment).filter((name) => name === 'wikiLink')).toHaveLength(1)
+    expect(wikiLinkTargets(deviceA.editor)).toEqual(['Wiki Link'])
+  })
+
+  it('promotes every link in the document, not just the first block', () => {
+    // #given the shape the report describes: a page that is a list of links
+    const { editor, fragment } = createCollaborativeEditor()
+    editor.replaceBlocks(editor.document, [
+      { type: 'bulletListItem', content: [{ type: 'text', text: '[[A]]', styles: {} }] } as never,
+      { type: 'bulletListItem', content: [{ type: 'text', text: '[[B]]', styles: {} }] } as never,
+      { type: 'paragraph', content: [{ type: 'text', text: 'and [[C]]', styles: {} }] } as never
+    ])
+
+    // #when
+    mountEditorSync(editor, fragment)
+
+    // #then all three, and the blocks around them are untouched
+    const authored = editor.document.filter(
+      (block) => (block.content as unknown[] | undefined)?.length
+    )
+    expect(authored.map((block) => block.type)).toEqual([
+      'bulletListItem',
+      'bulletListItem',
+      'paragraph'
+    ])
+    expect(
+      authored.map(
+        (block) => (block.content as Array<{ props?: { target?: string } }>).at(-1)?.props?.target
+      )
+    ).toEqual(['A', 'B', 'C'])
+  })
+
+  it('reopening a doc that already holds the node writes nothing', () => {
+    // #given a note opened once, so the promotion has happened
+    const { editor, doc, fragment } = createCollaborativeEditor()
+    seedWithPlainText(editor, 'See [[Wiki Link]] for details.')
+    mountEditorSync(editor, fragment)
+    expect(nodeNames(fragment)).toContain('wikiLink')
+
+    // #when it is opened again — the cold reopen, doc rebuilt from the store
+    const updates: Uint8Array[] = []
+    doc.on('update', (update: Uint8Array) => updates.push(update))
+    mountEditorSync(editor, fragment)
+    mountEditorSync(editor, fragment)
+
+    // #then no CRDT update at all. Opening a note must not rewrite it (#1434),
+    // and a promotion that ran on every open would push a doc update — and a
+    // write-back — to every device, every time anyone read the note.
+    expect(updates).toEqual([])
+    expect(nodeNames(fragment).filter((name) => name === 'wikiLink')).toHaveLength(1)
+  })
+
+  it('leaves a hash tag and a date mention token as plain text', () => {
+    // #given the same guarantee the edit path carries: only wiki links have a
+    // promoter here, and the open path must not quietly acquire more
+    const { editor, doc, fragment } = createCollaborativeEditor()
+    seedWithPlainText(editor, 'Tagged #hashtag on ((date:eyJhbmNob3JJZCI6ImExIn0)).')
+    const updates: Uint8Array[] = []
+    doc.on('update', (update: Uint8Array) => updates.push(update))
+
+    // #when
+    mountEditorSync(editor, fragment)
+
+    // #then
+    expect(updates).toEqual([])
+    expect(nodeNames(fragment)).not.toContain('hashTag')
+    expect(nodeNames(fragment)).not.toContain('dateMention')
+  })
+
+  it('leaves the block whose raw run holds the caret alone, and promotes the rest', () => {
+    // #given a caret parked inside a raw `[[…]]` run — what un-promoting a chip
+    // to edit it leaves behind (`wiki-link-edit-plugin.ts`). Re-promoting under
+    // that caret is the one case normalization must decline, and the open path
+    // carries the same exemption the edit path does.
+    const caretText = 'See [[Wiki Link]] and [[Sibling Run]].'
+    const { editor, fragment } = createCollaborativeEditor()
+    editor.replaceBlocks(editor.document, [
+      { type: 'paragraph', content: [{ type: 'text', text: caretText, styles: {} }] } as never,
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Also [[Other Block]].', styles: {} }]
+      } as never
+    ])
+    putCaretInsideRawRun(editor, caretText)
+
+    // #when
+    mountEditorSync(editor, fragment)
+
+    // #then the caret's whole block is skipped — the sibling run inside it too,
+    // which is what makes this exemption coarse and safe rather than clever…
+    expect(wikiLinkTargets(editor, 0)).toEqual([])
+    // …while every other block promotes as usual, so the exemption is a skip
+    // and not an excuse to do nothing
+    expect(wikiLinkTargets(editor, 1)).toEqual(['Other Block'])
+    expect(nodeNames(fragment).filter((name) => name === 'wikiLink')).toHaveLength(1)
   })
 })

--- a/apps/desktop/tests/e2e/wiki-link-open-promotion.e2e.ts
+++ b/apps/desktop/tests/e2e/wiki-link-open-promotion.e2e.ts
@@ -1,0 +1,242 @@
+/**
+ * #1642 — "I'll open a page with a list of links and they will all be plain
+ * text and not highlighted and can't click on them."
+ *
+ * The renderer is the only thing that turns `[[X]]` into a chip: main parses a
+ * vault file into the shared Y.Doc with a `wikiLink` spec that has no `parse`
+ * rule, so the link reaches the doc as plain TEXT. Until this fix the only
+ * promoter was `handleChange`, which fires on an EDIT — so a note read and not
+ * typed into stayed plain text, and "close and reopen a few times" only helped
+ * when the reopen happened to lose the race to the CRDT doc and fell to the
+ * markdown load path instead.
+ *
+ * This is E2E rather than a renderer test because the claim is about the whole
+ * chain — a real vault file, main's parser, the CRDT store, a real editor bound
+ * to the shared doc — and about a chip a user can actually click. The unit
+ * sibling (`src/renderer/.../wiki-link-collab-promotion.test.ts`) drives the
+ * same promotion against a real `Y.Doc`, including the two-device case; what it
+ * cannot do is prove that main really hands the renderer raw text in the first
+ * place, which is the premise the whole bug rests on.
+ *
+ * Nothing here types into the editor before asserting. A keystroke would
+ * trigger `handleChange` and the assertions would say nothing.
+ *
+ * ## What this suite does and does not prove
+ *
+ * It passes on the build BEFORE #1642 as well, and that is worth stating rather
+ * than discovering later. `handleChange` promotes from a change event, and on
+ * every path reachable from a single machine — first open, an edit made to the
+ * file from outside, a restart with the tab restored — an event does arrive:
+ * y-prosemirror dispatches one when the shared content reaches the editor. The
+ * failure the report describes is that event not arriving, which is a race, not
+ * a path. So what these tests pin is the OUTCOME a reader cares about — links
+ * are chips, and clicking one goes somewhere — on a surface that had no E2E
+ * coverage at all. The discriminating tests for the open-path promotion itself
+ * are in the renderer suite (`wiki-link-collab-promotion.test.ts`), where
+ * mounting the hook is the whole act and no change event exists to lean on.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { ready, uniqueLabel } from './utils/desktop-test-helpers'
+import {
+  getNoteFileBodyByTitle,
+  getNoteHandleByTitle,
+  getWritebackDebugById,
+  openNoteByTitle
+} from './utils/note-sync-helpers'
+import { SELECTORS } from './utils/electron-helpers'
+
+interface SeededLinkNote {
+  sourceTitle: string
+  targets: string[]
+  /**
+   * The body as it sits in the vault BEFORE the note is opened.
+   *
+   * Read back rather than assumed: what `notes.create` writes is the baseline
+   * this suite measures "did opening it change anything" against, and pinning a
+   * hand-written string here would turn any unrelated formatting choice into a
+   * failure of the wiki-link path.
+   */
+  body: string
+}
+
+/** A page that is a list of links — the exact shape the report describes. */
+async function seedLinkList(page: Page): Promise<SeededLinkNote> {
+  const targets = [uniqueLabel('Alpha'), uniqueLabel('Beta'), uniqueLabel('Gamma')]
+  const sourceTitle = uniqueLabel('Reading List')
+  const body = ['Everything to read:', '', ...targets.map((t) => `- [[${t}]]`), ''].join('\n')
+
+  await page.evaluate(
+    async ({ sourceTitle, targets, body }) => {
+      for (const title of targets) {
+        const created = await window.api.notes.create({ title, content: 'A target.\n' })
+        if (!created.success) throw new Error(`failed to seed target "${title}"`)
+      }
+      const source = await window.api.notes.create({ title: sourceTitle, content: body })
+      if (!source.success) throw new Error('failed to seed the link list')
+    },
+    { sourceTitle, targets, body }
+  )
+
+  const stored = await getNoteFileBodyByTitle(page, sourceTitle)
+  if (!stored?.includes('[[')) {
+    throw new Error(`seeded note does not hold raw wiki links: ${stored}`)
+  }
+
+  return { sourceTitle, targets, body: stored }
+}
+
+/** The vault file backing a note, found by name rather than assumed. */
+function noteFilePath(vaultPath: string, title: string): string {
+  const stack = [vaultPath]
+  while (stack.length) {
+    const dir = stack.pop() as string
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name !== '.memry') stack.push(full)
+      } else if (entry.name === `${title}.md`) {
+        return full
+      }
+    }
+  }
+  throw new Error(`no vault file for "${title}"`)
+}
+
+/** How many times CRDT write-back has run for this note so far. */
+async function writebackRuns(
+  electronApp: ElectronApplication,
+  page: Page,
+  title: string
+): Promise<number> {
+  const note = await getNoteHandleByTitle(page, title)
+  return (await getWritebackDebugById(electronApp, note.id))?.performedCount ?? 0
+}
+
+async function openWithoutTyping(page: Page, title: string): Promise<void> {
+  await openNoteByTitle(page, title)
+  await page.locator(SELECTORS.noteEditor).first().waitFor({ state: 'visible', timeout: 15_000 })
+}
+
+test.describe('Wiki links on open', () => {
+  test('a note opened and never typed into shows its links as chips', async ({
+    page,
+    electronApp
+  }) => {
+    await ready(page)
+
+    // #given a note whose body is nothing but `[[…]]` links, written to the
+    // vault and never opened — so its Y.Doc gets built from those bytes
+    const { sourceTitle, targets, body } = await seedLinkList(page)
+
+    // #when it is opened, and that is all that happens
+    await openWithoutTyping(page, sourceTitle)
+
+    // #then every link is a chip, not plain text
+    const chips = page.locator('[data-wiki-link]')
+    await expect(chips).toHaveCount(targets.length)
+    for (const target of targets) {
+      await expect(page.locator(`[data-wiki-link][data-target="${target}"]`)).toBeVisible()
+    }
+
+    // …and once the promotion has genuinely reached disk — write-back runs off
+    // a CRDT doc update, so this only settles because the promotion happened —
+    // the body is unchanged: a `wikiLink` node serializes back to the same
+    // `[[…]]` bytes it was parsed from (#1434)
+    await expect
+      .poll(() => writebackRuns(electronApp, page, sourceTitle), { timeout: 30_000 })
+      .toBeGreaterThanOrEqual(1)
+    expect(await getNoteFileBodyByTitle(page, sourceTitle)).toBe(body)
+  })
+
+  test('the chip is clickable — it opens the note it points at', async ({ page }) => {
+    await ready(page)
+
+    // #given
+    const { sourceTitle, targets } = await seedLinkList(page)
+    await openWithoutTyping(page, sourceTitle)
+
+    // #when the user clicks the link they came to follow. "Can't click on them"
+    // is the half of the report a chip-count assertion does not cover: plain
+    // text renders fine and simply does nothing when clicked.
+    await page.locator(`[data-wiki-link][data-target="${targets[1]}"]`).click()
+
+    // #then
+    await expect(page.locator(SELECTORS.noteTitle).first()).toHaveValue(targets[1])
+  })
+
+  /**
+   * The case the report is actually made of, and the one `handleChange` cannot
+   * reach. `handleChange` promotes on a change EVENT, and it gets one on a
+   * first open only because the content arrives after the editor is listening.
+   * When the shared doc already holds the text at editor-creation time there is
+   * no event at all — and that is exactly the state an edit made outside Memry
+   * leaves behind: main feeds the file into the Y.Doc (`feedExternalEditToCrdt`)
+   * with no editor mounted, and its `wikiLink` spec has no `parse` rule, so what
+   * lands is raw `[[X]]` text. Another device pushing a note is the same shape.
+   */
+  test('links written into the file from outside are chips when the note is reopened', async ({
+    page,
+    testVaultPath
+  }) => {
+    await ready(page)
+
+    // #given a note already known to the app, opened once and then left
+    const title = uniqueLabel('External Edit')
+    const target = uniqueLabel('External Target')
+    await page.evaluate(
+      async ({ title, target }) => {
+        const seeded = await window.api.notes.create({ title, content: 'Nothing here yet.\n' })
+        const linked = await window.api.notes.create({ title: target, content: 'A target.\n' })
+        if (!seeded.success || !linked.success) throw new Error('failed to seed the external case')
+      },
+      { title, target }
+    )
+    await openWithoutTyping(page, title)
+    await expect(page.locator('[data-wiki-link]')).toHaveCount(0)
+
+    // switch away so no editor is bound to the note while it changes on disk
+    await openWithoutTyping(page, target)
+
+    // #when the file grows a link behind the app's back — Obsidian, a script,
+    // a sync client, anything that is not this editor
+    const absPath = noteFilePath(testVaultPath, title)
+    const before = fs.readFileSync(absPath, 'utf8')
+    fs.writeFileSync(absPath, `${before.trimEnd()}\n\n- [[${target}]]\n`, 'utf8')
+    await expect
+      .poll(() => getNoteFileBodyByTitle(page, title), { timeout: 30_000 })
+      .toContain(`[[${target}]]`)
+
+    // …and the note is opened again, still without a keystroke
+    await openWithoutTyping(page, title)
+
+    // #then the link is a chip. Before #1642 it was plain text here, and stayed
+    // plain until the user typed into the note — which is the whole report.
+    await expect(page.locator(`[data-wiki-link][data-target="${target}"]`)).toBeVisible()
+  })
+
+  test('the chips survive a reload, and the second open rewrites nothing', async ({ page }) => {
+    await ready(page)
+
+    // #given a note opened once, so the promotion has already run and reached
+    // the CRDT store
+    const { sourceTitle, targets, body } = await seedLinkList(page)
+    await openWithoutTyping(page, sourceTitle)
+    await expect(page.locator('[data-wiki-link]')).toHaveCount(targets.length)
+
+    // #when the app restarts and the note is opened cold, with the shared doc
+    // rebuilt from the store rather than from markdown
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+    await ready(page)
+    await openWithoutTyping(page, sourceTitle)
+
+    // #then the chips are there because the doc already holds the nodes —
+    // nothing to promote, so nothing is written and the file still matches
+    await expect(page.locator('[data-wiki-link]')).toHaveCount(targets.length)
+    expect(await getNoteFileBodyByTitle(page, sourceTitle)).toBe(body)
+  })
+})

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -183,6 +183,16 @@ The rewritten link is **relative to the note**, so it keeps working after the no
 your other devices, and the vault stays readable by Obsidian.
 :::
 
+## Links Written Outside memrynote
+
+A `[[wiki link]]` typed into a note file by something other than memrynote — Obsidian, a
+script, another editor, or a note arriving from one of your other devices — is a chip as
+soon as you open the note. You do not have to edit the note to wake the links up, and
+opening it does not change the file: a link is stored as `[[Target]]` either way.
+
+Earlier builds could show such a page as plain, unclickable text until you typed into the
+note or reopened it a few times. Opening the note is now enough.
+
 ## Backlinks Panel
 
 The collapsible **Backlinks** section at the bottom of every note lists every other note that links to it — including notes that point to it through a `[[wiki link]]` or through a


### PR DESCRIPTION
Closes #1642.

## The gap

Main parses a vault file into the shared Y.Doc with a `wikiLink` spec that has **no `parse` rule**, so `[[X]]` reaches the doc as plain text — the renderer is the only thing that promotes it into a chip.

`use-editor-sync.ts`'s load effect returns early for a collaborative document, so `normalizeNoteBlocks` → `normalizeWikiLinks` only ever ran on the markdown path. Promotion on the CRDT path was left entirely to `handleChange`, which fires on a change **event**. A note that is only *read* never changes again — so when that event does not arrive, the links stay plain, unclickable text until the user types into the note.

## The change

The open path promotes for itself:

- an ordinary `replaceBlocks`, so the promotion goes into the shared doc as a normal CRDT mutation and converges. `replaceInitialBlocksWithoutHistory` is deliberately **not** used — it removes and re-inserts the whole document, which on a shared doc is one device overwriting another's body.
- run **before** `clearYjsUndoHistory`, so opening a note leaves no undoable step. Otherwise ⌘Z right after open would turn the chips back into raw text and push that to every device.
- idempotent: a promoted node carries its target in props, so `[[` never reappears and a second open writes **no CRDT update at all** — which is what keeps "opening a note must not rewrite it" (#1434) true.
- keeps the caret-block exemption (`skipBlockId`) the edit path carries, so a raw run being edited is still left alone.
- wiki links only. Hash tags and date mentions have no promoter on the collaborative path and must stay the bytes they were opened with.

## Tests

**`wiki-link-collab-promotion.test.ts`** — real `BlockNoteEditor` on the real schema, mounted, real Yjs collaboration against a real `Y.Doc`, the real hook. Mounting the hook *is* opening the note; none of the new cases call `handleChange`:

- raw `[[X]]` becomes a chip on open
- the two-device case from the issue: A writes the raw text, B receives the update and opens the note without touching it → B sees a chip, and the promotion converges back onto A as **one** node rather than clobbering A's body
- every link in the document, not just the first block
- reopening a doc that already holds the node writes nothing
- hash tags and date mentions stay plain
- the caret's block is skipped while every other block promotes

Mutation-checked both ways: removing the call fails 4 of these; replacing `skipBlockId` with `undefined` fails the exemption case.

**`wiki-link-open-promotion.e2e.ts`** (new) — real app, real vault, real CRDT store: links are chips on open with no keystroke, the chip is clickable and navigates, a link written into the file from **outside** the app is a chip when the note is reopened, and the chips survive a restart while the file stays byte-identical.

### One thing worth being explicit about

**The E2E suite passes on the build before this change as well.** On every path reachable from a single machine — first open, an external edit to the file, a restart with the tab restored — `handleChange` does get a change event (y-prosemirror dispatches one when the shared content reaches the editor) and promotes from there. I could not reproduce the reported plain-text state locally; the failure is that event not arriving, which is a race rather than a path.

So the E2E pins the outcome a reader cares about on a surface that had **no** E2E coverage at all, and the discriminating tests for the open-path promotion live in the renderer suite, where no change event exists to lean on. What this PR buys is that promotion at open no longer *depends* on that event.

## Verification

- `pnpm lint` — 0 errors
- `pnpm typecheck` — green (17/17, test projects included)
- renderer suite — 648 files, 7766 passed
- `note-open-byte-stability.test.ts` + `blocknote-converter.test.ts` (main) — 234 passed
- `wiki-link-open-promotion.e2e.ts` — 4/4 passed against a fresh build
- `pnpm docs:impact --base origin/main --strict` — covered · `pnpm docs:build` — green
