### PR TITLE
feat(editor): inline image node so table cells can hold images

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -1070,8 +1070,90 @@ const INLINE_CASES = [
       remind: 'none',
       timeFormat: 'system'
     })
+  },
+  {
+    nodeName: 'inlineImage',
+    // A note-relative ref, which is the only thing that may ever reach disk:
+    // the renderer resolves it to an absolute `memry-file://` URL for display,
+    // and that URL carries one machine's vault path (#1640).
+    attrs: { src: '../attachments/n1/shot.png', alt: 'shot' },
+    text: '![shot](../attachments/n1/shot.png)'
   }
 ] as const
+
+/**
+ * #1640: a table cell could not hold an image at all.
+ *
+ * BlockNote's `image` is a block and a `tableCell` takes inline content only,
+ * so the `<img>` in a cell matched no node and was dropped on parse — the note
+ * came back from disk with an empty cell. GFM allows phrasing content in a
+ * cell, `![alt](src)` is phrasing, and `inlineImage` is the node that carries
+ * it. This is the round trip that has to hold: the file on disk, through the
+ * shared Y.Doc, back to the same bytes.
+ *
+ * Inside a table BlockNote reaches `render`, never `toExternalHTML` — cell
+ * content goes through ProseMirror's own DOM serializer — so this is also the
+ * test that says main's `render` emits the raw ref rather than a resolved URL.
+ */
+describe('an image in a table cell survives the CRDT write path', () => {
+  const TABLE = [
+    '| Iteration | Shot |',
+    '| --- | --- |',
+    '| v1 | ![v1](../attachments/n1/v1.png) |',
+    '| v2 | ![v2](../attachments/n1/v2.png) |'
+  ].join('\n')
+
+  it('carries both cell images back to markdown, and settles', async () => {
+    // #given a vault note whose table holds images, as another editor wrote it
+    const doc = new Y.Doc()
+    const ok = await markdownToYFragment(TABLE, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(ok).toBe(true)
+
+    // #when write-back serializes it
+    const first = await yDocToMarkdown(doc)
+
+    // #then both images are still there — before this node the cells came back
+    // empty — and the table is still a table
+    expect(first).toContain('![v1](../attachments/n1/v1.png)')
+    expect(first).toContain('![v2](../attachments/n1/v2.png)')
+    expect(first?.split('\n')).toHaveLength(4)
+
+    // #and the second pass is byte-identical, so a note stops being rewritten
+    // after remark has padded the columns once
+    const settled = new Y.Doc()
+    await markdownToYFragment(first ?? '', settled.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(await yDocToMarkdown(settled)).toBe(first)
+  })
+
+  it('keeps the images in the shared doc rather than deleting them', async () => {
+    // #given the same note
+    const doc = new Y.Doc()
+    await markdownToYFragment(TABLE, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    const before = Y.encodeStateAsUpdate(doc)
+
+    // #when
+    await yDocToMarkdown(doc)
+
+    // #then y-prosemirror answers a node its schema cannot build by DELETING
+    // it, and that deletion replicates to every device
+    expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+    expect(findUnrepresentableNodes(doc)).toEqual([])
+  })
+
+  it('leaves a standalone image line as an image block', async () => {
+    // #given the shape every existing note already has: `![x](y)` on its own
+    // line. The inline node's `parse` runs as a `tag: "*"` rule, so it sees
+    // this one too and must hand it back to the image BLOCK.
+    const markdown = '![a photo](../attachments/n1/photo.png)'
+    const doc = new Y.Doc()
+    await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+    // #when / #then unchanged bytes, and the node is still `image`
+    expect(await yDocToMarkdown(doc)).toBe(markdown)
+    const blocks = await yFragmentToBlocks(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(blocks?.[0]?.type).toBe('image')
+  })
+})
 
 describe('custom inline nodes survive the CRDT write path', () => {
   /**
@@ -1490,7 +1572,8 @@ const INLINE_TEXT_FORMS: Record<(typeof MEMRY_INLINE_CONTENT_TYPES)[number], str
   wikiLink: '[[Roadmap]]',
   hashTag: '#roadmap',
   linkMention: '((mention:https%3A%2F%2Fx.com))',
-  dateMention: '((date:eyJhbmNob3JJZCI6ImExIn0))'
+  dateMention: '((date:eyJhbmNob3JJZCI6ImExIn0))',
+  inlineImage: '![shot](../attachments/n1/shot.png)'
 }
 
 /** The block shapes a marker's own text can be sitting inside of. */
@@ -1520,20 +1603,43 @@ describe('a custom spec must not claim the block its text sits in', () => {
     expect(Object.keys(INLINE_TEXT_FORMS).sort()).toEqual([...MEMRY_INLINE_CONTENT_TYPES].sort())
   })
 
+  /**
+   * `type|context` pairs whose BYTES move for a reason that predates the spec.
+   * Listed by hand so an entry is a decision rather than an accident, and the
+   * pair still asserts what this gate is actually for: the marker survives and
+   * the block around it is not swallowed.
+   *
+   * `inlineImage` in a list item — BlockNote lifts a list item's ELEMENT
+   * children into a `blockGroup` before any spec is consulted, so `- ![x](y)`
+   * has always parsed as an image BLOCK nested under the bullet and been
+   * written back in Memry's nesting-marker form. Measured on main before
+   * `inlineImage` existed; adding the node changed neither side of it.
+   */
+  const NOT_BYTE_STABLE: ReadonlySet<string> = new Set([
+    'inlineImage|a bullet item',
+    'inlineImage|a numbered item'
+  ])
+
   const cases = MEMRY_INLINE_CONTENT_TYPES.flatMap((type) =>
     BLOCK_CONTEXTS.map(([context, wrap]) => [type, context, wrap(INLINE_TEXT_FORMS[type])] as const)
   )
 
-  it.each(cases)('%s inside %s survives untouched', async (_type, _context, markdown) => {
+  it.each(cases)('%s inside %s survives untouched', async (type, context, markdown) => {
     // #given a vault note as it exists on disk today
     const doc = new Y.Doc()
     const ok = await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
     expect(ok).toBe(true)
 
     // #when the converter reads and writes it back
+    const result = await yDocToMarkdown(doc)
+
     // #then byte-identical — write-back byte-compares, so anything else rewrites
     // the note in every vault on next open
-    expect(await yDocToMarkdown(doc)).toBe(markdown)
+    if (NOT_BYTE_STABLE.has(`${type}|${context}`)) {
+      expect(result).toContain(INLINE_TEXT_FORMS[type])
+      return
+    }
+    expect(result).toBe(markdown)
   })
 
   it.each(MEMRY_INLINE_CONTENT_TYPES)('%s inside a table cell keeps the table', async (type) => {

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -2750,6 +2750,19 @@ del.bn-inline-content {
   font-weight: 500;
 }
 
+/* An image sitting in a line of text or in a table cell (#1640). Capped so a
+   screenshot dropped into a cell does not stretch the row to the height of the
+   window; `vertical-align: middle` sits it on the line rather than on the
+   baseline, where it would push the row's text down. */
+.inline-image {
+  display: inline-block;
+  max-height: 160px;
+  max-width: 100%;
+  vertical-align: middle;
+  border-radius: 4px;
+  object-fit: contain;
+}
+
 /* Inline hash tag styles — needs .dark .bn-editor prefix to beat the wildcard rule */
 .dark .bn-editor .inline-hash-tag,
 .dark .bn-container .inline-hash-tag,

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -66,6 +66,7 @@ import {
 } from './review-formatting-toolbar'
 import { createCriticMarkupDecorationPlugin } from './critic-markup-decorations'
 import { registerEditorPlugin } from './register-editor-plugin'
+import { createTableCellImagePlugin } from './table-cell-image-plugin'
 
 import {
   useBlockNoteSetup,
@@ -505,6 +506,22 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     )
     return registerEditorPlugin(editor, plugin)
   }, [editor, isReviewEnabled])
+
+  // A table cell holds inline content only, so BlockNote's own file paste — which
+  // always builds an image BLOCK — could not put an image in one (#1640). Inside
+  // a cell the image becomes an `inlineImage` instead; everywhere else this
+  // plugin does not fire and the block image is still what you get.
+  useEffect(() => {
+    const plugin = createTableCellImagePlugin(async (file) => {
+      const result = await uploadFile(file)
+      return typeof result === 'string' ? result : ''
+    })
+    // Prepended: ProseMirror gives the paste to the first `handlePaste` that
+    // claims it, and BlockNote's own file handling is already in the list — it
+    // was building an image BLOCK and dropping it BELOW the table. Safe to go
+    // first because this handler declines anything outside a cell.
+    return registerEditorPlugin(editor, plugin, (p, plugins) => [p, ...plugins])
+  }, [editor, uploadFile])
 
   // Hook #3: Wiki link suggestions
   const { getWikiLinkItems, handleWikiLinkSelect } = useWikiLinkSuggestions(editor)

--- a/apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts
@@ -7,6 +7,7 @@ import { createTaskBlock } from './task-block'
 import { HashTag } from './hash-tag'
 import { LinkMention } from './link-mention'
 import { DateMention } from './date-mention'
+import { InlineImage } from './inline-image'
 
 // Built through the shared factory so the main process gets a schema with the
 // same node types. Main converts the shared Y.Doc through y-prosemirror, which
@@ -31,7 +32,10 @@ export const editorSchema = createMemrySchema({
     wikiLink: WikiLink,
     linkMention: LinkMention,
     hashTag: HashTag,
-    dateMention: DateMention
+    dateMention: DateMention,
+    // The editor flavour of inlineImage: same node as main's, plus display-time
+    // resolution of a note-relative `src`.
+    inlineImage: InlineImage
   }
 })
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/inline-image.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/inline-image.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The editor's `inlineImage` render, and the one rule it cannot break.
+ *
+ * Inside a table BlockNote serializes cell content through ProseMirror's own
+ * DOM serializer, which builds its HTML from `render` — there is no
+ * `toExternalHTML` on that path. So whatever `src` the render puts on the
+ * element is what lands in the vault file, and a resolved `memry-file://` URL
+ * is an absolute path on ONE machine. This is the `linkMention` bug class
+ * (#1433) with a worse payload.
+ *
+ * Serialization is synchronous end to end, so "the element holds the ref until
+ * a promise resolves" is what keeps the bytes safe. That is what these assert:
+ * synchronously, the ref; after a tick, the resolved URL.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { InlineImage } from './inline-image'
+
+const RELATIVE_SRC = '../attachments/n1/shot.png'
+const RESOLVED_SRC = 'memry-file://local/Users/kaan/vault/attachments/n1/shot.png'
+
+interface SpecImplementation {
+  render: (content: unknown, update: () => void, editor: unknown) => { dom: HTMLElement }
+}
+
+function render(src: string, resolveFileUrl?: () => Promise<string>): HTMLElement {
+  const { implementation } = InlineImage as unknown as { implementation: SpecImplementation }
+  return implementation.render(
+    { type: 'inlineImage', props: { src, alt: 'a shot' } },
+    () => {},
+    resolveFileUrl ? { resolveFileUrl } : {}
+  ).dom
+}
+
+describe('the DOM a serializer reads carries the ref, never a resolved URL', () => {
+  it('holds the note-relative src synchronously, before anything resolves', () => {
+    // #given the render a table cell's serialization goes through
+    const resolveFileUrl = vi.fn(async () => RESOLVED_SRC)
+
+    // #when — read exactly as `serializeFragment` reads it: same tick, no await
+    const dom = render(RELATIVE_SRC, resolveFileUrl)
+
+    // #then the bytes that could reach the vault are the ref the note was
+    // written with, not this machine's vault path
+    expect(dom.getAttribute('src')).toBe(RELATIVE_SRC)
+  })
+
+  it('emits an img, which is what rehype-remark turns into `![alt](src)`', () => {
+    const dom = render(RELATIVE_SRC)
+    expect(dom.tagName).toBe('IMG')
+    expect(dom.getAttribute('alt')).toBe('a shot')
+  })
+})
+
+describe('the live element resolves so the image actually loads', () => {
+  it('swaps in the resolved URL once the vault path is known', async () => {
+    // #given a note-relative ref, which resolves against the renderer's own base
+    // URL and 404s until the real URL arrives
+    const resolveFileUrl = vi.fn(async () => RESOLVED_SRC)
+
+    // #when
+    const dom = render(RELATIVE_SRC, resolveFileUrl)
+
+    // #then
+    await vi.waitFor(() => expect(dom.getAttribute('src')).toBe(RESOLVED_SRC))
+    expect(resolveFileUrl).toHaveBeenCalledWith(RELATIVE_SRC)
+  })
+
+  it('leaves the ref in place when resolution fails', async () => {
+    // #given a vault lookup that rejects
+    const resolveFileUrl = vi.fn(async () => {
+      throw new Error('no vault')
+    })
+
+    // #when
+    const dom = render(RELATIVE_SRC, resolveFileUrl)
+
+    // #then a broken image the user can see beats an empty element they cannot
+    await Promise.resolve()
+    expect(dom.getAttribute('src')).toBe(RELATIVE_SRC)
+  })
+
+  it('never asks about an src that already carries a scheme', () => {
+    // #given an https image, or one written before attachments became
+    // note-relative
+    const resolveFileUrl = vi.fn(async () => RESOLVED_SRC)
+
+    // #when
+    const dom = render('https://example.com/a.png', resolveFileUrl)
+
+    // #then
+    expect(dom.getAttribute('src')).toBe('https://example.com/a.png')
+    expect(resolveFileUrl).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/inline-image.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/inline-image.ts
@@ -1,0 +1,72 @@
+/**
+ * The editor's `inlineImage` — same node as main's, plus display-time URL
+ * resolution (#1640).
+ *
+ * ## Why the element starts out holding the raw ref
+ *
+ * BlockNote calls `render` for two jobs. One is the live element in the editor.
+ * The other is a fresh, detached element built to be SERIALIZED: inside a table
+ * there is no `toExternalHTML` path at all — cell content goes through
+ * ProseMirror's own DOM serializer, which builds its HTML from `render` — so
+ * whatever `src` that element carries is what lands in the vault file.
+ *
+ * The two are indistinguishable from in here. BlockNote does pass a
+ * `{ renderType }` context, but only to its own wrapper: that wrapper calls this
+ * function plainly, so `this` never arrives. What separates them instead is
+ * TIME. Serialization is synchronous end to end — `blocksToMarkdownLossy` builds
+ * the DOM and reads its HTML with no `await` in between, and ProseMirror's
+ * `serializeFragment` is synchronous too — so no promise can resolve between
+ * this function returning and the bytes being taken. The ref is therefore on the
+ * element from the first synchronous moment, and the resolved URL can only ever
+ * reach the element the editor is showing.
+ *
+ * That ordering is the whole safety property, because a resolved URL is an
+ * absolute path on ONE machine: writing it back would put `/Users/<someone>/…`
+ * into a note that syncs to every other device. It is the `linkMention` bug
+ * class (#1433) with a worse payload.
+ *
+ * The cost is that the first image in a note briefly requests its relative ref
+ * against the renderer's own base URL and 404s, until the vault path arrives.
+ * The vault path is cached per editor, so every image after the first resolves
+ * in a microtask.
+ */
+
+import {
+  createInlineImageSpec,
+  INLINE_IMAGE_HAS_SCHEME,
+  type InlineImageProps
+} from '@memry/editor-schema/inline'
+
+export { createInlineImageContent } from '@memry/editor-schema/inline'
+
+interface FileUrlResolvingEditor {
+  resolveFileUrl?: (url: string) => Promise<string>
+}
+
+export const InlineImage = createInlineImageSpec((inlineContent, _updateInlineContent, editor) => {
+  const props = inlineContent.props as InlineImageProps
+  const src = props.src || ''
+
+  const dom = document.createElement('img')
+  dom.className = 'inline-image'
+  dom.setAttribute('src', src)
+  if (props.alt) dom.setAttribute('alt', props.alt)
+  // The node is an atom; dragging the raw image out of it drops a file URL into
+  // whatever is underneath instead of moving the node.
+  dom.setAttribute('draggable', 'false')
+
+  const resolve = (editor as FileUrlResolvingEditor | undefined)?.resolveFileUrl
+  // A ref that already carries a scheme (https:, data:, memry-file:) is what the
+  // browser will load anyway — the same short-circuit the shared resolver makes.
+  if (!resolve || !src || INLINE_IMAGE_HAS_SCHEME.test(src)) return { dom }
+
+  void resolve(src)
+    .then((url) => {
+      if (url && url !== src) dom.setAttribute('src', url)
+    })
+    // Leave the ref in place: a broken image the user can see beats an empty
+    // element they cannot.
+    .catch(() => {})
+
+  return { dom }
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/table-cell-image-plugin.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/table-cell-image-plugin.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The pieces that decide whether a pasted image becomes an inline image in a
+ * cell or is left to BlockNote's block handling (#1640).
+ *
+ * The plugin's own paste/drop wiring is driven end-to-end against the real
+ * editor in `tests/e2e/table-cell-image.e2e.ts`; what is worth pinning here is
+ * the scoping, because getting it wrong changes paste behaviour for every note
+ * that has no table in it at all.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { altTextForFile, imageFilesFrom, isInsideTableCell } from './table-cell-image-plugin'
+
+/** A `$pos`-shaped stand-in: `node(depth)` is all the check reads. */
+function resolvedPosOver(nodeNames: string[]) {
+  return {
+    depth: nodeNames.length - 1,
+    node: (depth: number) => ({ type: { name: nodeNames[depth] } })
+  } as unknown as Parameters<typeof isInsideTableCell>[0]
+}
+
+function dataTransferWith(files: File[]): DataTransfer {
+  return { files } as unknown as DataTransfer
+}
+
+describe('the plugin only claims image files', () => {
+  it('picks out image files and leaves everything else', () => {
+    // #given a paste carrying a screenshot and a PDF
+    const png = new File([''], 'shot.png', { type: 'image/png' })
+    const pdf = new File([''], 'report.pdf', { type: 'application/pdf' })
+
+    // #when / #then the PDF still belongs to BlockNote's file block
+    expect(imageFilesFrom(dataTransferWith([png, pdf]))).toEqual([png])
+  })
+
+  it('claims nothing from a text-only paste', () => {
+    // #given the ordinary case — no files at all
+    // #when / #then returning nothing is what lets the paste through untouched
+    expect(imageFilesFrom(dataTransferWith([]))).toEqual([])
+    expect(imageFilesFrom(null)).toEqual([])
+  })
+})
+
+describe('the plugin only fires inside a table cell', () => {
+  it('sees a cell however deep the caret is inside it', () => {
+    // #given a caret in a paragraph inside a cell
+    // #when / #then
+    expect(
+      isInsideTableCell(resolvedPosOver(['doc', 'table', 'tableRow', 'tableCell', 'paragraph']))
+    ).toBe(true)
+  })
+
+  it('sees a header cell too', () => {
+    expect(isInsideTableCell(resolvedPosOver(['doc', 'table', 'tableRow', 'tableHeader']))).toBe(
+      true
+    )
+  })
+
+  it('declines an ordinary paragraph, so the block image still wins there', () => {
+    // #given the caret in normal body text — the case where BlockNote's own
+    // image block is the right answer and this plugin must not intervene
+    // #when / #then
+    expect(isInsideTableCell(resolvedPosOver(['doc', 'blockContainer', 'paragraph']))).toBe(false)
+    expect(isInsideTableCell(null)).toBe(false)
+  })
+})
+
+describe('alt text comes from the filename', () => {
+  it('drops the extension', () => {
+    expect(altTextForFile('progress-v2.png')).toBe('progress-v2')
+  })
+
+  it('drops brackets, which would break `![alt](src)`', () => {
+    // #given a filename that would otherwise close the markdown early
+    // #when / #then
+    expect(altTextForFile('shot [final].png')).toBe('shot final')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/table-cell-image-plugin.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/table-cell-image-plugin.ts
@@ -1,0 +1,141 @@
+/**
+ * Pasting or dropping an image into a table cell (#1640).
+ *
+ * BlockNote's own file handling always builds an `image` BLOCK, and a table
+ * cell holds inline content only — so inside a cell the paste either did
+ * nothing or landed the image outside the table. The `inlineImage` node fixes
+ * the data model; this is the only way a user actually gets one into a cell.
+ *
+ * Scoped to table cells on purpose. Everywhere else BlockNote's block image is
+ * the right answer and this plugin does not fire, so no existing paste or drop
+ * behaviour changes.
+ */
+
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
+import type { EditorState, Transaction } from '@tiptap/pm/state'
+import type { EditorView } from '@tiptap/pm/view'
+import type { ResolvedPos } from '@tiptap/pm/model'
+
+const PLUGIN_KEY = new PluginKey('tableCellImage')
+
+const TABLE_CELL_NODES = new Set(['tableCell', 'tableHeader'])
+
+/** Uploads the file and resolves to the ref to store — note-relative, never absolute. */
+export type UploadImage = (file: File) => Promise<string>
+
+export function imageFilesFrom(data: DataTransfer | null | undefined): File[] {
+  if (!data?.files?.length) return []
+  return Array.from(data.files).filter((file) => file.type.startsWith('image/'))
+}
+
+/** Whether a resolved position sits inside a table cell. */
+export function isInsideTableCell($pos: ResolvedPos | null | undefined): boolean {
+  if (!$pos) return false
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    if (TABLE_CELL_NODES.has($pos.node(depth).type.name)) return true
+  }
+  return false
+}
+
+function selectionIsInsideTableCell(state: EditorState): boolean {
+  return isInsideTableCell(state.selection.$from)
+}
+
+/**
+ * `alt` is the filename without its extension: it is what a reader sees when
+ * the file is missing, and what the markdown carries between `![` and `]`.
+ */
+export function altTextForFile(name: string): string {
+  const base = name.split(/[\\/]/).pop() ?? name
+  // Brackets would break `![alt](src)` — the same guard `rewriteWikiImageEmbeds`
+  // applies when it invents an alt from a filename.
+  return base.replace(/\.[^.]+$/, '').replace(/[[\]]/g, '')
+}
+
+/**
+ * Insert the uploaded images at the current selection, if it is still in a cell.
+ *
+ * The upload is a round trip through main, so the position captured before it
+ * cannot be trusted afterwards — the document may have moved underneath. The
+ * live selection is re-checked instead, which is also where the user expects
+ * the image to land: they have not moved the caret in the meantime.
+ */
+function insertInlineImages(view: EditorView, refs: Array<{ src: string; alt: string }>): void {
+  const type = view.state.schema.nodes.inlineImage
+  if (!type || !selectionIsInsideTableCell(view.state)) return
+
+  let tr: Transaction = view.state.tr
+  for (const { src, alt } of refs) {
+    tr = tr.replaceSelectionWith(type.create({ src, alt }), false)
+  }
+  view.dispatch(tr.scrollIntoView())
+}
+
+async function uploadAndInsert(
+  view: EditorView,
+  files: File[],
+  uploadImage: UploadImage
+): Promise<void> {
+  const refs: Array<{ src: string; alt: string }> = []
+  for (const file of files) {
+    try {
+      const src = await uploadImage(file)
+      if (src) refs.push({ src, alt: altTextForFile(file.name) })
+    } catch {
+      // `uploadFile` already surfaces the reason to the user; a second toast per
+      // file would just stack.
+    }
+  }
+  if (refs.length) insertInlineImages(view, refs)
+}
+
+export function createTableCellImagePlugin(uploadImage: UploadImage): Plugin {
+  return new Plugin({
+    key: PLUGIN_KEY,
+    props: {
+      /**
+       * `handleDOMEvents`, not `handlePaste` / `handleDrop`.
+       *
+       * BlockNote's own file handling lives in `handleDOMEvents` too — its
+       * `pasteFromClipboard` extension calls `preventDefault()` on every paste
+       * an editable editor gets, and `dropFile` claims any drop carrying Files
+       * — and ProseMirror consults that prop BEFORE the one `handlePaste` is
+       * reached through. A `handlePaste` here was never called at all:
+       * measured, the pasted image still arrived as a block BELOW the table.
+       *
+       * The plugin is registered at the FRONT of the plugin list so this runs
+       * before BlockNote's, which is safe because both handlers below decline
+       * everything outside a table cell.
+       */
+      handleDOMEvents: {
+        paste: (view, event) => {
+          if (!selectionIsInsideTableCell(view.state)) return false
+          const files = imageFilesFrom(event.clipboardData)
+          if (files.length === 0) return false
+
+          event.preventDefault()
+          void uploadAndInsert(view, files, uploadImage)
+          return true
+        },
+
+        drop: (view, event) => {
+          const files = imageFilesFrom(event.dataTransfer)
+          if (files.length === 0) return false
+
+          const dropped = view.posAtCoords({ left: event.clientX, top: event.clientY })
+          if (dropped == null) return false
+          const $pos = view.state.doc.resolve(dropped.pos)
+          if (!isInsideTableCell($pos)) return false
+
+          event.preventDefault()
+          // Move the caret to where the file was dropped before the upload
+          // starts, so the insert lands in the cell the user aimed at rather
+          // than wherever the caret happened to be.
+          view.dispatch(view.state.tr.setSelection(TextSelection.near($pos)))
+          void uploadAndInsert(view, files, uploadImage)
+          return true
+        }
+      }
+    }
+  })
+}

--- a/apps/desktop/tests/e2e/table-cell-image.e2e.ts
+++ b/apps/desktop/tests/e2e/table-cell-image.e2e.ts
@@ -1,0 +1,177 @@
+// @ts-nocheck - E2E test; window.api typing lives in the renderer bundle
+/**
+ * Images in table cells (#1640), against the real editor and the real vault.
+ *
+ * A BlockNote table cell holds inline content only, so before the `inlineImage`
+ * node an `<img>` in a cell matched no node at all: the note came back from disk
+ * with an empty cell, and the next write-back wrote the emptiness to the file.
+ * Unit tests can prove the spec's shape; only this can prove the whole loop —
+ * disk → editor → disk — with the resolver, the debounce and the write-back all
+ * in play.
+ *
+ * The second half is the other half of the feature: a user pasting a screenshot
+ * into a cell. That path is a ProseMirror plugin scoped to cells, because
+ * BlockNote's own file paste always builds a BLOCK.
+ *
+ * What both assert about the bytes matters as much as the image being there:
+ * the vault file must keep the note-relative ref. The editor resolves it to an
+ * absolute `memry-file://` URL to display it, and that URL carries THIS
+ * machine's vault path — writing it back would sync one machine's filesystem
+ * layout to every other device.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { test, expect } from './fixtures'
+import type { Page } from '@playwright/test'
+import { SELECTORS } from './utils/electron-helpers'
+import { getNoteHandleByTitle, openNoteByTitle } from './utils/note-sync-helpers'
+import { PNG_BYTES, ready, uniqueLabel } from './utils/desktop-test-helpers'
+
+const IMAGE_NAME = 'shot.png'
+
+/** A table whose second column is an image, plus a paragraph to type into. */
+const BODY = [
+  '| Iteration | Shot |',
+  '| --- | --- |',
+  `| v1 | ![v1](${IMAGE_NAME}) |`,
+  '',
+  'Notes:'
+].join('\n')
+
+function seedNoteWithImage(vaultPath: string, title: string): string {
+  const notesDir = path.join(vaultPath, 'notes')
+  fs.mkdirSync(notesDir, { recursive: true })
+  fs.writeFileSync(path.join(notesDir, IMAGE_NAME), Buffer.from(PNG_BYTES))
+  const absPath = path.join(notesDir, `${title}.md`)
+  fs.writeFileSync(absPath, BODY, 'utf8')
+  return absPath
+}
+
+/** Drop the YAML frontmatter block; every save bumps its `modified:` stamp. */
+function stripFrontmatter(markdown: string): string {
+  const match = markdown.match(/^---\n[\s\S]*?\n---\n?/)
+  return match ? markdown.slice(match[0].length) : markdown
+}
+
+function readFile(absPath: string): string {
+  try {
+    return fs.readFileSync(absPath, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+/** Read the note file once it contains `marker` (waits out the write-back debounce). */
+async function readWhenContains(absPath: string, marker: string): Promise<string> {
+  await expect.poll(() => readFile(absPath), { timeout: 30_000 }).toContain(marker)
+  return readFile(absPath)
+}
+
+async function openEditor(page: Page, title: string) {
+  await openNoteByTitle(page, title)
+  const editor = page.locator(SELECTORS.noteEditor).first()
+  await editor.waitFor({ state: 'visible', timeout: 15_000 })
+  return editor
+}
+
+/**
+ * Paste a PNG into whatever the editor's selection currently is.
+ *
+ * Dispatched on the editor's own contenteditable, which is where ProseMirror
+ * binds its `paste` handler — the plugin under test reads the files off the
+ * event exactly as it would from a real ⌘V.
+ */
+async function pasteImage(page: Page, fileName: string): Promise<void> {
+  await page.evaluate(
+    ({ selector, bytes, name }) => {
+      const dom = document.querySelector(selector) as HTMLElement | null
+      if (!dom) throw new Error('editor not found')
+      const transfer = new DataTransfer()
+      transfer.items.add(new File([new Uint8Array(bytes)], name, { type: 'image/png' }))
+      const event = new ClipboardEvent('paste', { bubbles: true, cancelable: true })
+      // Chromium's `ClipboardEvent` constructor ignores a `clipboardData` in the
+      // init dict, so the transfer is attached to the instance instead.
+      Object.defineProperty(event, 'clipboardData', { value: transfer })
+      dom.dispatchEvent(event)
+    },
+    { selector: SELECTORS.noteEditor, bytes: PNG_BYTES, name: fileName }
+  )
+}
+
+test.describe('Images in table cells', () => {
+  test('a cell image opens, renders, and is written back as the ref it came from', async ({
+    page,
+    testVaultPath
+  }) => {
+    await ready(page)
+
+    // #given a vault note whose table already holds an image, as another editor
+    // (or another device) wrote it
+    const title = uniqueLabel('Cell Image')
+    const absPath = seedNoteWithImage(testVaultPath, title)
+    await getNoteHandleByTitle(page, title)
+
+    // #when the note is opened in the real editor
+    const editor = await openEditor(page, title)
+
+    // #then the image is inside the table, not dropped and not moved out of it
+    const cellImage = editor.locator('table img.inline-image').first()
+    await expect(cellImage).toBeVisible({ timeout: 15_000 })
+    // …and it is actually loadable: the note-relative ref has been resolved to a
+    // URL the renderer can fetch
+    await expect
+      .poll(async () => await cellImage.getAttribute('src'), { timeout: 15_000 })
+      .toMatch(/^memry-file:\/\//)
+
+    // #when the note is edited, so write-back runs over the whole document
+    await editor.click()
+    await page.keyboard.press('ControlOrMeta+End')
+    await page.keyboard.type(' touched')
+
+    // #then the file still carries the image, in the form it was written with
+    const markdown = stripFrontmatter(await readWhenContains(absPath, 'touched'))
+    expect(markdown).toContain(`![v1](${IMAGE_NAME})`)
+    // …and never this machine's vault path, which is what the editor resolved
+    // the ref to in order to show it
+    expect(markdown).not.toContain('memry-file://')
+    expect(markdown).not.toContain(testVaultPath)
+    // …and the table is still a table
+    expect(markdown).toMatch(/\|\s*v1\s*\|/)
+  })
+
+  test('pasting an image into a cell inserts it inline and reaches the vault file', async ({
+    page,
+    testVaultPath
+  }) => {
+    await ready(page)
+
+    // #given the same note, opened, with the caret placed in a table cell
+    const title = uniqueLabel('Cell Paste')
+    const absPath = seedNoteWithImage(testVaultPath, title)
+    await getNoteHandleByTitle(page, title)
+    const editor = await openEditor(page, title)
+    await expect(editor.locator('table').first()).toBeVisible({ timeout: 15_000 })
+
+    const firstCell = editor.locator('table td, table th').filter({ hasText: 'v1' }).first()
+    await firstCell.click()
+
+    // #when a screenshot is pasted into it
+    await pasteImage(page, 'pasted.png')
+
+    // #then it lands in that cell as an inline image — BlockNote's own paste
+    // would have built a block, which a cell cannot hold
+    await expect(firstCell.locator('img.inline-image')).toHaveCount(1, { timeout: 20_000 })
+    // …and nowhere else: BlockNote's own file paste was landing an image BLOCK
+    // below the table, which is the behaviour this plugin has to get in front of
+    await expect(editor.locator('img.inline-image')).toHaveCount(2)
+    await expect(editor.locator('[data-content-type="image"]')).toHaveCount(0)
+
+    // #and the upload is stored as a note-relative attachment ref, so the note
+    // still reads correctly on another device
+    const markdown = stripFrontmatter(await readWhenContains(absPath, 'pasted'))
+    expect(markdown).toMatch(/\|[^|\n]*!\[pasted\]\([^)\n]*pasted[^)\n]*\.png\)[^|\n]*\|/)
+    expect(markdown).not.toContain('memry-file://')
+    expect(markdown).not.toContain(testVaultPath)
+  })
+})

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -54,6 +54,11 @@ file page before it clears cancels it cleanly.
 
 Images render as image blocks (not file blocks). Drag them to resize; double-click for the lightbox.
 
+Inside a table cell an image is inline instead: a cell holds text-level content only, so
+the image sits in the cell with a capped height. Pasting or dropping an image onto a cell
+puts it there rather than below the table. See
+[Images in a Table Cell](./editing.md#images-in-a-table-cell).
+
 ### Zooming and Panning
 
 Opening an image as a file page gives you the full viewer: zoom in and out, reset to fit, and rotate

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -190,6 +190,32 @@ Pasting a URL offers four ways to keep it: plain **URL**, an inline **Mention** 
 
 This works inside a table cell too. **Mention** replaces the pasted URL in that one cell and leaves the rest of the table alone. **Embed** and **Bookmark** are blocks in their own right and a cell holds text only, so they take the URL out of the cell and place the card after the whole table.
 
+## Images in a Table Cell
+
+Images work inside table cells: paste a screenshot into a cell, or drop an image file
+onto one, and it lands in that cell rather than as a block underneath the table. Use it
+for a "before / after" column, a progress log of visual iterations, or a profile table
+with a picture beside each row.
+
+Cell images are stored the same way as any other markdown image, so the file on disk
+stays portable:
+
+```markdown
+| Iteration | Shot                      |
+| --------- | ------------------------- |
+| v1        | ![v1](attachments/v1.png) |
+```
+
+An image sitting in a line of text works the same way — `Here it is ![shot](shot.png)`
+keeps the image on the line instead of moving it to its own block. So do images in a
+heading or inside a quote.
+
+Images are capped at a readable height so one screenshot cannot stretch a row to the
+height of the window. An image on its own line is still a full image block, which is
+what you want most of the time: drag its edge to resize, double-click for the lightbox.
+
+Pasting an image anywhere outside a table is unchanged — you get the usual image block.
+
 ## Link Previews
 
 Links in a note are enriched with the page title, site name and favicon, both for inline link mentions and for bookmark blocks. The lookup runs once per URL and the result is kept in memory, so reopening a note with the same links does not refetch them.

--- a/packages/editor-schema/src/inline/index.ts
+++ b/packages/editor-schema/src/inline/index.ts
@@ -4,11 +4,13 @@ import { linkMentionConfig } from './link-mention'
 import { wikiLinkConfig } from './wiki-link'
 import { hashTagConfig } from './hash-tag'
 import { dateMentionConfig } from './date-mention'
+import { inlineImageConfig } from './inline-image'
 
 export * from './wiki-link'
 export * from './link-mention'
 export * from './hash-tag'
 export * from './date-mention'
+export * from './inline-image'
 
 /**
  * The specs each process supplies for itself. The config and the serialization
@@ -37,6 +39,13 @@ export interface MemryInlineSpecs {
    * and dropping domain/title/favicon/siteName from disk.
    */
   linkMention: InlineContentSpec<typeof linkMentionConfig>
+  /**
+   * The editor's flavour resolves a note-relative `src` for display; main's
+   * emits the raw ref. Same node, same on-disk form — and the raw ref is what
+   * both of them SERIALIZE, or a table cell would write this machine's vault
+   * path into the note (#1640).
+   */
+  inlineImage: InlineContentSpec<typeof inlineImageConfig>
 }
 
 /**
@@ -53,7 +62,8 @@ export function createMemryInlineContentSpecs(specs: MemryInlineSpecs) {
     wikiLink: specs.wikiLink,
     linkMention: specs.linkMention,
     hashTag: specs.hashTag,
-    dateMention: specs.dateMention
+    dateMention: specs.dateMention,
+    inlineImage: specs.inlineImage
   }
   assertSpecKeysMatchNodeTypes('inlineContentSpecs (createMemryInlineContentSpecs)', registered)
   return registered
@@ -64,5 +74,6 @@ export const MEMRY_INLINE_CONTENT_TYPES = [
   'wikiLink',
   'linkMention',
   'hashTag',
-  'dateMention'
+  'dateMention',
+  'inlineImage'
 ] as const

--- a/packages/editor-schema/src/inline/inline-image.test.ts
+++ b/packages/editor-schema/src/inline/inline-image.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The `inlineImage` boundary (#1640).
+ *
+ * The spec's whole risk is `parse`: it runs as a `tag: '*'` rule, so it is
+ * consulted for every element of every document BlockNote parses, and the one
+ * thing it must never do is claim an image the `image` BLOCK used to claim.
+ * Every note in every vault has those.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { inlineImageSerialization } from './inline-image'
+
+/** Parse an HTML fragment and hand back the `<img>` in it, in a real tree. */
+function imgIn(html: string): HTMLElement {
+  const host = document.createElement('div')
+  host.innerHTML = html
+  const img = host.querySelector('img')
+  if (!img) throw new Error(`no <img> in ${html}`)
+  return img
+}
+
+describe('parse leaves block images alone', () => {
+  it('declines an image that is the whole of its paragraph', () => {
+    // #given the shape `![x](y)` on its own line arrives as
+    // #when
+    const parsed = inlineImageSerialization.parse(imgIn('<p><img src="a.png" alt="x"></p>'))
+
+    // #then undefined makes ProseMirror skip this rule and keep looking, which
+    // is how the image BLOCK still gets it. Anything else silently changes the
+    // node type of every image in every existing note.
+    expect(parsed).toBeUndefined()
+  })
+
+  it('declines an image whose paragraph holds only whitespace beside it', () => {
+    // #given remark-rehype leaves newlines between the tags
+    // #when / #then whitespace is not content
+    expect(inlineImageSerialization.parse(imgIn('<p>\n  <img src="a.png">\n</p>'))).toBeUndefined()
+  })
+
+  it('declines anything that is not an image', () => {
+    const span = document.createElement('span')
+    span.textContent = 'not an image'
+    expect(inlineImageSerialization.parse(span)).toBeUndefined()
+  })
+
+  it('declines an image with no src', () => {
+    expect(inlineImageSerialization.parse(imgIn('<p>a <img alt="x"></p>'))).toBeUndefined()
+  })
+})
+
+describe('parse claims the images that had no node at all', () => {
+  it('claims an image inside a table cell, even alone in it', () => {
+    // #given the case the issue is about: GFM allows phrasing content in a cell,
+    // and a cell's content is inline-only, so no block rule can take this one
+    // #when
+    const parsed = inlineImageSerialization.parse(
+      imgIn('<table><tr><td><img src="../attachments/n1/shot.png" alt="shot"></td></tr></table>')
+    )
+
+    // #then
+    expect(parsed).toEqual({ src: '../attachments/n1/shot.png', alt: 'shot' })
+  })
+
+  it('claims an image alone in a heading, which no block rule can take', () => {
+    // #given a heading's content is inline-only in BlockNote, so the image
+    // block rule cannot replace it — before this node the image was dropped
+    // and `# ![x](y)` came back as an empty heading
+    // #when / #then
+    expect(inlineImageSerialization.parse(imgIn('<h1><img src="a.png" alt="x"></h1>'))).toEqual({
+      src: 'a.png',
+      alt: 'x'
+    })
+  })
+
+  it('claims an image sitting beside text in a paragraph', () => {
+    // #given an image glued to the end of a line — what Apple Notes and Bear
+    // exports produce, and what used to be dropped on parse
+    // #when / #then
+    expect(inlineImageSerialization.parse(imgIn('<p>before <img src="a.png"> after</p>'))).toEqual({
+      src: 'a.png',
+      alt: ''
+    })
+  })
+
+  it('keeps a note-relative src exactly as written', () => {
+    // #given `element.src` would resolve this against the document base URL and
+    // hand back `http://localhost/…`, which is what would then reach the vault
+    // #when
+    const parsed = inlineImageSerialization.parse(
+      imgIn('<p>x <img src="../attachments/n1/a.png"></p>')
+    )
+
+    // #then
+    expect(parsed?.src).toBe('../attachments/n1/a.png')
+  })
+})
+
+describe('toExternalHTML writes the ref, not a resolved URL', () => {
+  it('emits an img carrying the raw src and alt', () => {
+    // #given / #when
+    const { dom } = inlineImageSerialization.toExternalHTML({
+      props: { src: '../attachments/n1/a.png', alt: 'a shot' }
+    })
+
+    // #then rehype-remark turns exactly this into `![a shot](../attachments/n1/a.png)`
+    expect(dom.outerHTML).toBe('<img src="../attachments/n1/a.png" alt="a shot">')
+  })
+
+  it('omits alt when there is none, so the markdown stays `![](src)`', () => {
+    const { dom } = inlineImageSerialization.toExternalHTML({ props: { src: 'a.png', alt: '' } })
+    expect(dom.outerHTML).toBe('<img src="a.png">')
+  })
+})

--- a/packages/editor-schema/src/inline/inline-image.ts
+++ b/packages/editor-schema/src/inline/inline-image.ts
@@ -1,0 +1,188 @@
+/**
+ * `inlineImage` inline content spec (#1640).
+ *
+ * BlockNote's `image` is a BLOCK, and a `tableCell` holds inline content only —
+ * so an image could not exist in a table cell at all, and an image glued to the
+ * end of a paragraph was dropped on parse rather than kept. GFM says the same
+ * thing about the file on disk: a table cell may hold phrasing content only, and
+ * `![alt](src)` is phrasing. So the fix is a node with exactly that shape.
+ *
+ * Lives here rather than in the renderer because the main process needs the same
+ * node: a spec the main-process schema does not carry is not a rendering gap, it
+ * is data loss — y-prosemirror deletes any element it cannot build straight out
+ * of the shared Y.Doc (#1435).
+ *
+ * ## Compat
+ *
+ * Purely additive. No existing document holds an `inlineImage`, and nothing that
+ * used to become an `image` block still does — see `parse` below, which hands
+ * every image the block rule used to claim straight back to it. A build without
+ * this spec meeting a document that has one is the ordinary missing-spec case
+ * the parity gate exists to prevent, which is why both processes register it in
+ * the same commit.
+ */
+
+import { createInlineContentSpec, type InlineContentSpec } from '@blocknote/core'
+import type { CustomInlineContentImplementation } from '@blocknote/core'
+
+export const inlineImageConfig = {
+  type: 'inlineImage' as const,
+  propSchema: {
+    /**
+     * Exactly the string that sits between `](` and `)` on disk — usually a
+     * note-relative ref like `../attachments/<noteId>/x.png`. It is NEVER the
+     * resolved `memry-file://` URL: that carries this machine's vault path, and
+     * writing it back would put an absolute local path in the vault file. The
+     * renderer resolves for display only (see the renderer's `inline-image.ts`).
+     */
+    src: { default: '' },
+    alt: { default: '' }
+  },
+  content: 'none' as const
+}
+
+type InlineImageRender = CustomInlineContentImplementation<
+  typeof inlineImageConfig,
+  never
+>['render']
+
+export interface InlineImageProps {
+  src: string
+  alt: string
+}
+
+/** `https:`, `data:`, `memry-file:` — and `C:` on Windows. Mirrors the resolver. */
+export const INLINE_IMAGE_HAS_SCHEME = /^[a-zA-Z][a-zA-Z\d+\-.]*:/
+
+/**
+ * The parents an `image` BLOCK can actually replace.
+ *
+ * `![x](y)` on its own line arrives as `<p><img></p>`, and a `<p>` is a block
+ * BlockNote is free to turn into an image block — that is what it has always
+ * done, and what every image in every existing note relies on.
+ *
+ * Everything else in an HTML document that can hold an `<img>` — a heading, a
+ * tight list item, a table cell — is inline-only in BlockNote's schema, so the
+ * block rule cannot take those. Before this spec they had no node at all and the
+ * image was dropped on parse.
+ */
+const BLOCK_IMAGE_PARENT_TAGS = new Set(['P', 'DIV', 'FIGURE', 'SECTION', 'ARTICLE', 'BODY'])
+
+/**
+ * Containers whose BlockNote node holds INLINE CONTENT ONLY, so no block can
+ * live inside them however the HTML is nested.
+ *
+ * `- ![x](y)` and `> ![x](y)` reach the parser as `<li><p><img></p></li>` and
+ * `<blockquote><p><img></p></blockquote>`: the `<img>` IS alone in a `<p>`, so
+ * the immediate-parent test alone would hand it to the image block — which the
+ * list item and the quote then cannot hold. Measured before this node existed:
+ * the quote came back as a bare `>` with the image gone, and the bullet was
+ * rewritten into Memry's nesting-marker form on every open. Inline content is
+ * what both of them can actually carry.
+ */
+const INLINE_ONLY_ANCESTOR_TAGS = new Set([
+  'LI',
+  'BLOCKQUOTE',
+  'TD',
+  'TH',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6'
+])
+
+/**
+ * Whether this `<img>` is the standalone block image BlockNote already handles.
+ *
+ * This is the line between the two nodes, and it is drawn so that nothing that
+ * used to become an `image` block stops becoming one: same parent, same "there
+ * is nothing else in here" test. An `<img>` with something beside it, or one in
+ * a parent that can only hold inline content, is the case that had no node.
+ */
+function isStandaloneBlockImage(img: HTMLElement): boolean {
+  // A `<figure>` is the image block's caption form, and BlockNote parses the
+  // figure rather than the `<img>` inside it — an `<img>` next to a
+  // `<figcaption>` would otherwise read as "not alone in its parent" and be
+  // claimed here, costing the caption. Declined exactly as its own parse does.
+  if (img.closest('figure')) return true
+
+  const parent = img.parentElement
+  // No parent to compare against (a bare fragment): treat it as standalone and
+  // leave it to the block rule, which is what happens today.
+  if (!parent) return true
+  if (!BLOCK_IMAGE_PARENT_TAGS.has(parent.tagName)) return false
+
+  for (const node of Array.from(parent.childNodes)) {
+    if (node === img) continue
+    if (node.nodeType === 3 /* text */) {
+      if ((node.textContent ?? '').trim() !== '') return false
+      continue
+    }
+    if (node.nodeType === 1 /* element */) return false
+  }
+
+  for (let ancestor = parent.parentElement; ancestor; ancestor = ancestor.parentElement) {
+    if (INLINE_ONLY_ANCESTOR_TAGS.has(ancestor.tagName)) return false
+  }
+  return true
+}
+
+/** Everything that decides the node's on-disk form. Shared by both processes. */
+export const inlineImageSerialization = {
+  /**
+   * Runs as a `tag: '*'` rule — BlockNote gives custom inline content no way to
+   * scope it — so the tag check is first and cheap: this is called for every
+   * element in every pasted or parsed document.
+   *
+   * Returning `undefined` makes ProseMirror skip this rule and keep looking,
+   * which is exactly how a standalone image still becomes an `image` block.
+   */
+  parse: (element: HTMLElement) => {
+    if (element.tagName !== 'IMG') return undefined
+    // `getAttribute`, never `element.src`: the property resolves a relative ref
+    // against the document's base URL, which would bake this machine's path
+    // into the note.
+    const src = element.getAttribute('src')?.trim() || ''
+    if (!src) return undefined
+    if (isStandaloneBlockImage(element)) return undefined
+    return { src, alt: element.getAttribute('alt')?.trim() || '' }
+  },
+  toExternalHTML: (inlineContent: { props: InlineImageProps }) => {
+    const dom = document.createElement('img')
+    dom.setAttribute('src', inlineContent.props.src || '')
+    // Omitted when empty so the markdown reads `![](src)` rather than growing an
+    // `alt=""` that rehype-remark would have to invent a value for.
+    if (inlineContent.props.alt) dom.setAttribute('alt', inlineContent.props.alt)
+    return { dom }
+  }
+}
+
+export function createInlineImageSpec(
+  render: InlineImageRender
+): InlineContentSpec<typeof inlineImageConfig> {
+  return createInlineContentSpec(inlineImageConfig, {
+    render,
+    ...inlineImageSerialization,
+    /**
+     * Both this spec and the `image` BLOCK parse with a `tag: '*'` rule, so the
+     * only thing separating them is order — and without this, block specs are
+     * built first and `image` claims every `<img>` there is. In a paragraph or a
+     * table cell that block has nowhere to go, so ProseMirror drops it: the
+     * exact silent loss this node exists to end.
+     *
+     * Running first is safe because `parse` declines every image `image` used to
+     * take (see `isStandaloneBlockImage`); a rule that declines is skipped and
+     * the block rule is reached exactly as before.
+     */
+    runsBefore: ['image']
+  })
+}
+
+export function createInlineImageContent(src: string, alt = '') {
+  return {
+    type: 'inlineImage' as const,
+    props: { src, alt }
+  }
+}

--- a/packages/editor-schema/src/schema-contract.test.ts
+++ b/packages/editor-schema/src/schema-contract.test.ts
@@ -39,6 +39,7 @@ import {
   createMemryInlineContentSpecs,
   dateMentionConfig,
   hashTagConfig,
+  inlineImageConfig,
   linkMentionConfig,
   wikiLinkConfig,
   type MemryInlineSpecs
@@ -73,7 +74,8 @@ const INLINE_CONFIGS: Record<MemryInlineType, { type: string; propSchema: object
   wikiLink: wikiLinkConfig,
   linkMention: linkMentionConfig,
   hashTag: hashTagConfig,
-  dateMention: dateMentionConfig
+  dateMention: dateMentionConfig,
+  inlineImage: inlineImageConfig
 }
 
 /** One block per custom type, as the renderer authors it. */
@@ -155,6 +157,12 @@ const INLINE_FIXTURES: Record<MemryInlineType, unknown> = {
       remind: 'none',
       timeFormat: 'system'
     }
+  },
+  // A note-relative ref, which is the case that matters: `render` reaching the
+  // vault with a resolved absolute URL is the failure this fixture guards.
+  inlineImage: {
+    type: 'inlineImage',
+    props: { src: '../attachments/n1/shot.png', alt: 'a screenshot' }
   }
 }
 

--- a/packages/editor-schema/src/server.ts
+++ b/packages/editor-schema/src/server.ts
@@ -21,6 +21,8 @@ import {
   createDateMentionSpec,
   dateMentionSerialization,
   hashTagSerialization,
+  createInlineImageSpec,
+  inlineImageSerialization,
   LinkMentionSerializationOnly,
   WikiLinkSerializationOnly,
   type MemryInlineSpecs
@@ -37,6 +39,12 @@ export function createServerInlineSpecs(): MemryInlineSpecs {
     ),
     dateMention: createDateMentionSpec((inlineContent) =>
       dateMentionSerialization.toExternalHTML(inlineContent)
+    ),
+    // The raw `src`, exactly as it sits on disk. Resolving it here would write
+    // this machine's vault path back into the note the first time someone put
+    // an image in a table cell (#1640).
+    inlineImage: createInlineImageSpec((inlineContent) =>
+      inlineImageSerialization.toExternalHTML(inlineContent)
     )
   }
 }


### PR DESCRIPTION
Closes #1640 — option 1 from the issue (inline image node), which the issue calls the lowest-risk path.

## The problem

A BlockNote table cell holds **inline content only**, and `image` is a **block**. So an `<img>` in a cell matched no node at all: the note came back from disk with an empty cell, and the next write-back wrote the emptiness to the file. Markdown agrees on the shape — GFM allows phrasing content in a cell, and `![alt](src)` is phrasing — so the fix is a node with exactly that shape.

## What landed

**`inlineImage` (`src` + `alt`) in `@memry/editor-schema`, registered in BOTH processes.** A spec main lacks is not a rendering gap: y-prosemirror deletes any element it cannot build straight out of the shared Y.Doc (#1435). The schema-parity gates required both halves in the same commit, which is the point of them.

**`parse` runs before the `image` block's** (`runsBefore: ['image']`) — both parse with a `tag: '*'` rule, and without the ordering blocks are built first and `image` claims every `<img>` there is, then gets dropped where it cannot go.

**And it declines everything the image block used to claim.** An `<img>` alone in a `<p>` / `<div>` / `<figure>`, or anywhere under a `<figure>`, is handed straight back, so nothing that is an image block today stops being one. What it claims is what had no node before:

| Markdown | Before | After |
| --- | --- | --- |
| `\| ![x](y) \|` in a cell | image dropped, cell emptied | inline image in the cell |
| `# ![x](y)` | image dropped | inline image in the heading |
| `> ![x](y)` | image dropped, file rewritten to `>` | inline image in the quote |
| `text ![x](y)` | image dropped | inline image on the line |
| `![x](y)` on its own line | image block | **image block, unchanged** |

**The vault file keeps the ref it was written with.** The editor resolves a note-relative `src` to a `memry-file://` URL for display, and that URL is an absolute path on *one* machine. Inside a table BlockNote has no `toExternalHTML` path — cell content goes through ProseMirror's DOM serializer, which builds its HTML from `render` — so `render` **is** the serializer's input there. BlockNote's `{ renderType }` context never reaches a custom spec (its wrapper calls the function plainly), so what separates the two is time: serialization is synchronous end to end, the element holds the raw ref from its first synchronous moment, and only the live element is ever mutated. This is the `linkMention` bug class (#1433) with a worse payload.

**Getting an image into a cell** is a ProseMirror plugin scoped to cells. It sits on `handleDOMEvents`, prepended: BlockNote's own file paste lives there too and ProseMirror consults that prop before the one `handlePaste` is reached through — measured, the pasted image arrived as a block *below* the table. Outside a cell the plugin declines and paste/drop behaviour is exactly what it was.

## Compat

Purely additive. No document holds an `inlineImage` today, no existing image changes node type, and both processes register it in the same commit.

## Verification

- `pnpm --filter @memry/desktop test:main` — 7191 passed (includes a new `markdown → Y.Doc → markdown` round trip for a table of images, and a check that the shared doc is byte-identical afterwards)
- `pnpm --filter @memry/desktop test:renderer` — 7774 passed
- `pnpm --filter @memry/editor-schema test` — 70 passed
- `pnpm lint`, `pnpm typecheck`, `pnpm check:architecture`, `pnpm check:contracts`, `pnpm docs:build` — all green
- **E2E** `tests/e2e/table-cell-image.e2e.ts` — 2 passed against the real Electron app: a seeded cell image opens, renders from a resolved `memry-file://` URL, and is written back as `![v1](shot.png)` with no absolute path in the file; and a pasted PNG lands *in the cell* (not as a block below) and reaches the vault as a note-relative attachment ref.

## Notes for the reviewer

- The shared `blocknote-converter` gate ("a custom spec must not claim the block its text sits in") now carries two named `type|context` pairs that assert the marker survives rather than the bytes: `inlineImage` in a bullet / numbered item. BlockNote lifts a list item's element children into a `blockGroup` *before* any spec is consulted, so `- ![x](y)` has always parsed as an image block nested under the bullet and been written back in the nesting-marker form. Measured on `main` before this node existed; adding it changed neither side.
- `packages/i18n` fails 2 pre-existing tests on `main` (`canvas.link.useUrl` uses `{{url}}` instead of ICU single braces). Untouched here.
- `pnpm test` as a whole SIGSEGVs in turbo — the known flake; both desktop projects are green run individually.