### PR TITLE
fix(tables): dragging across cells selects cells, not the whole table

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.test.tsx
@@ -293,6 +293,20 @@ describe('useBlockMarqueeSelection', () => {
     trigger.append(line)
     const boldRun = document.createElement('strong')
     line.append(boldRun)
+    // A table cell, spelled the way BlockNote renders one: a bare `<td>` whose
+    // inner paragraph carries no class. Nothing here matches
+    // `.bn-inline-content`, so before the cell rule a drag across cells started
+    // a marquee — and since a table is one block, that marquee swallowed the
+    // whole table. Covered against the real markup in
+    // marquee-hit-test.integration.test.ts.
+    const table = document.createElement('div')
+    table.className = 'bn-block-content'
+    table.setAttribute('data-content-type', 'table')
+    trigger.append(table)
+    const cell = document.createElement('td')
+    table.append(cell)
+    const cellParagraph = document.createElement('p')
+    cell.append(cellParagraph)
 
     const { result, unmount } = renderHook(() =>
       useBlockMarqueeSelection({
@@ -314,7 +328,7 @@ describe('useBlockMarqueeSelection', () => {
       })
     }
 
-    for (const insideText of [line, boldRun]) {
+    for (const insideText of [line, boldRun, cell, cellParagraph]) {
       act(() => {
         insideText.dispatchEvent(mouse('mousedown', { clientX: 0, clientY: 0 }))
         document.dispatchEvent(mouse('mousemove', { clientX: 150, clientY: 70 }))

--- a/apps/desktop/src/renderer/src/components/note/content-area/marquee-hit-test.integration.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/marquee-hit-test.integration.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { BlockNoteEditor } from '@blocknote/core'
+import { hasSelectableTextAt, shouldStartMarquee } from './marquee-hit-test'
+
+/**
+ * The marquee start rule reads BlockNote's own markup, so the fixtures in
+ * `use-block-marquee-selection.test.tsx` are only as true as our reading of it.
+ * These run the predicates against a real mounted editor instead, which is what
+ * turns the TRIPWIRE note in `marquee-hit-test.ts` from a comment into a test:
+ * rename `.bn-inline-content` upstream, or change how a cell renders, and this
+ * file fails rather than text selection quietly dying in the app.
+ *
+ * Uses the default BlockNote schema — it already carries paragraphs and tables,
+ * and the custom schema's extra specs drag react-pdf into jsdom.
+ */
+
+const mounted: Array<{ editor: BlockNoteEditor; el: HTMLElement }> = []
+
+afterEach(() => {
+  for (const { editor, el } of mounted.splice(0)) {
+    editor.unmount()
+    el.remove()
+  }
+})
+
+function mountEditor(): HTMLElement {
+  const editor = BlockNoteEditor.create({
+    initialContent: [
+      { type: 'paragraph', content: 'Intro' },
+      {
+        type: 'table',
+        content: {
+          type: 'tableContent',
+          headerRows: 1,
+          rows: [{ cells: ['Task', 'Owner'] }, { cells: ['Ship it', 'Kaan'] }]
+        }
+      }
+    ] as never
+  })
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  editor.mount(el)
+  mounted.push({ editor, el })
+  return el
+}
+
+function query(root: HTMLElement, selector: string): Element {
+  const found = root.querySelector(selector)
+  if (!found) throw new Error(`the editor rendered no ${selector}`)
+  return found
+}
+
+describe('marquee hit-testing against real BlockNote markup', () => {
+  it('reads a paragraph line as text', () => {
+    const root = mountEditor()
+    const line = query(root, '.bn-block-content[data-content-type="paragraph"] .bn-inline-content')
+
+    expect(line.textContent).toBe('Intro')
+    expect(hasSelectableTextAt(line)).toBe(true)
+  })
+
+  it('reads a table cell as text even though it carries no inline-content class', () => {
+    const root = mountEditor()
+    const cell = query(root, 'td')
+    const cellParagraph = query(root, 'td p')
+
+    // The markup this rule exists for. If either assertion starts failing, the
+    // cell rule in `hasSelectableTextAt` may have become unnecessary — or may
+    // have started missing cells. Check before deleting it.
+    expect(cellParagraph.className).toBe('')
+    expect(cell.querySelector('.bn-inline-content')).toBeNull()
+
+    for (const target of [cell, cellParagraph, query(root, 'th')]) {
+      expect(hasSelectableTextAt(target)).toBe(true)
+    }
+  })
+
+  it('still lets a marquee start beside the table', () => {
+    const root = mountEditor()
+    const table = query(root, '.bn-block-content[data-content-type="table"]')
+
+    // The block box outside any cell — the margin the table is selected from.
+    // A table has to stay marquee-selectable as a whole block.
+    expect(hasSelectableTextAt(table)).toBe(false)
+    expect(shouldStartMarquee(table)).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/marquee-hit-test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/marquee-hit-test.ts
@@ -29,6 +29,13 @@ const BLOCK_CONTENT_SELECTOR = '.bn-block-content'
 const INLINE_CONTENT_SELECTOR = '.bn-inline-content'
 
 /**
+ * A table cell. BlockNote renders one as a bare `<td><p>text</p></td>` — that
+ * inner paragraph carries no class at all, so cells need naming in their own
+ * right rather than being reached through `.bn-inline-content`.
+ */
+const TABLE_CELL_SELECTOR = 'td, th'
+
+/**
  * Is this press outside every block — i.e. in the margin, the gutter, or the
  * empty space below the last block?
  *
@@ -140,8 +147,23 @@ export function shouldStartMarquee(target: EventTarget | null): target is HTMLEl
  * is deliberately the block box, not the line box: reclassifying the tail of a
  * short line would mean measuring line boxes on every mousedown, and users have
  * no reliable sense of where a line ended. The practical consequence, stated so
- * it is not later filed as a bug: the only place to begin a right-side marquee
- * is the gray margin outside the column.
+ * it is not later filed as a bug: the only place to begin a marquee on the
+ * right is the gray margin outside the column.
+ *
+ * ## Why table cells are asked about separately
+ *
+ * The tripwire below is not hypothetical — a table is the case where it already
+ * bites. BlockNote renders a cell as `<td colspan="1" rowspan="1"><p>text</p></td>`,
+ * and that inner `<p>` carries no `.bn-inline-content` class, unlike the one in
+ * a paragraph block. So the check above answers "no text" for every press
+ * inside a table, the text itself included, and a drag across cells started a
+ * marquee instead of selecting cells. Because a table is a single block, that
+ * marquee then selected the whole table: the cells looked selected, but
+ * Backspace deleted the entire table rather than the cells' contents.
+ *
+ * Naming cells here hands every in-table drag to prosemirror-tables, which owns
+ * cell selection. The table can still be marquee-selected as a block from the
+ * margin beside it, where no `td` is under the pointer.
  *
  * TRIPWIRE, read this before upgrading BlockNote. `.bn-inline-content` is a
  * BlockNote-internal class name, not a contract. If an upgrade renames it, this
@@ -152,5 +174,6 @@ export function shouldStartMarquee(target: EventTarget | null): target is HTMLEl
  * derives the name from here.
  */
 export function hasSelectableTextAt(target: Element): boolean {
-  return target.closest(INLINE_CONTENT_SELECTOR) !== null
+  if (target.closest(INLINE_CONTENT_SELECTOR) !== null) return true
+  return target.closest(TABLE_CELL_SELECTOR) !== null
 }

--- a/apps/desktop/tests/e2e/marquee-table-cells.e2e.ts
+++ b/apps/desktop/tests/e2e/marquee-table-cells.e2e.ts
@@ -1,0 +1,158 @@
+/**
+ * Dragging across table cells must select cells, not the table.
+ *
+ * The reported symptom: dragging from one cell to another highlighted the cells
+ * but also ran the block marquee, and because a table is a single block the
+ * marquee took the whole table. Backspace then deleted the table instead of the
+ * cells' contents.
+ *
+ * This lives in E2E because the gesture is the bug. The predicate underneath is
+ * covered in `marquee-hit-test.integration.test.ts`, but only a real drag over
+ * real geometry shows what the two selections do when they compete — jsdom has
+ * no layout, so every `boundingBox()` here would be zero.
+ */
+
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { ready, uniqueLabel } from './utils/desktop-test-helpers'
+import { openNoteByTitle } from './utils/note-sync-helpers'
+import { marqueeGutterX } from './utils/marquee-helpers'
+
+const EDITABLE_SELECTOR = '.bn-container [contenteditable="true"]'
+const HIGHLIGHTED_SELECTOR = '.marquee-block-highlight'
+
+const TABLE_NOTE_BODY = [
+  'Intro',
+  '',
+  '| Task    | Owner  |',
+  '| ------- | ------ |',
+  '| Ship it | Kaan   |',
+  '| Review  | Nobody |',
+  ''
+].join('\n')
+
+async function seedTableNote(page: Page, title: string): Promise<string> {
+  const created = await page.evaluate(
+    async ({ t, c }) => window.api.notes.create({ title: t, content: c }),
+    { t: title, c: TABLE_NOTE_BODY }
+  )
+  const id = created?.note?.id
+  if (!id) throw new Error(`could not seed "${title}"`)
+  return id
+}
+
+/** The table's cells as plain strings, row by row — `null` when it is gone. */
+async function tableCells(page: Page): Promise<string[][] | null> {
+  return page.evaluate(() => {
+    const editor = (window as any).__memryEditor
+    if (!editor) return null
+    const table = editor.document.find((block: any) => block.type === 'table')
+    if (!table) return null
+    return table.content.rows.map((row: any) =>
+      row.cells.map((cell: any) =>
+        (cell.content ?? [])
+          .map((inline: any) => (inline.type === 'text' ? inline.text : `<${inline.type}>`))
+          .join('')
+      )
+    )
+  })
+}
+
+async function openTableNote(page: Page, title: string): Promise<void> {
+  await openNoteByTitle(page, title)
+  await page.locator(EDITABLE_SELECTOR).first().waitFor({ state: 'visible', timeout: 20_000 })
+  await expect
+    .poll(() => tableCells(page), { timeout: 20_000 })
+    .toEqual([
+      ['Task', 'Owner'],
+      ['Ship it', 'Kaan'],
+      ['Review', 'Nobody']
+    ])
+}
+
+function cell(page: Page, text: string) {
+  return page
+    .locator(`${EDITABLE_SELECTOR} td, ${EDITABLE_SELECTOR} th`)
+    .filter({ hasText: text })
+    .first()
+}
+
+/** Centre of the cell whose text reads `text`. */
+async function cellCentre(page: Page, text: string): Promise<{ x: number; y: number }> {
+  const box = await cell(page, text).boundingBox()
+  if (!box) throw new Error(`the "${text}" cell has no bounding box`)
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}
+
+/** A real press-move-release, with enough travel to clear the marquee threshold. */
+async function dragBetween(
+  page: Page,
+  from: { x: number; y: number },
+  to: { x: number; y: number }
+): Promise<void> {
+  await page.mouse.move(from.x, from.y)
+  await page.mouse.down()
+  // Several steps: the marquee promotes on movement, so one jump could skip the
+  // very state this test is about.
+  await page.mouse.move((from.x + to.x) / 2, (from.y + to.y) / 2, { steps: 6 })
+  await page.mouse.move(to.x, to.y, { steps: 6 })
+  await page.mouse.up()
+}
+
+test.describe('Marquee and table cells', () => {
+  test.beforeEach(async ({ page }) => {
+    await ready(page)
+  })
+
+  test('dragging across cells leaves the table alone', async ({ page }) => {
+    const title = uniqueLabel('Marquee Table Cells')
+    await seedTableNote(page, title)
+    await openTableNote(page, title)
+
+    await dragBetween(page, await cellCentre(page, 'Ship it'), await cellCentre(page, 'Kaan'))
+
+    // No block marquee: the table is one block, so any highlight here is the
+    // whole table being selected behind the cell selection.
+    await expect(page.locator(HIGHLIGHTED_SELECTOR)).toHaveCount(0)
+
+    await page.keyboard.press('Backspace')
+
+    // The table survives, and only the dragged-over cells were emptied.
+    await expect
+      .poll(() => tableCells(page), { timeout: 10_000 })
+      .toEqual([
+        ['Task', 'Owner'],
+        ['', ''],
+        ['Review', 'Nobody']
+      ])
+  })
+
+  test('still selects the table as a block from the margin beside it', async ({ page }) => {
+    const title = uniqueLabel('Marquee Table Margin')
+    await seedTableNote(page, title)
+    await openTableNote(page, title)
+
+    // The table is the second block. Starting in the gray margin beside it is
+    // how a whole table is selected, and that has to keep working — the cell
+    // rule must not have made tables unselectable.
+    const gutterX = await marqueeGutterX(page, 1)
+    const tableBox = await page.locator('.bn-block[data-id]').nth(1).boundingBox()
+    if (!tableBox) throw new Error('the table block has no bounding box')
+
+    // The rectangle has to reach into the table, not just run down the margin
+    // beside it — a marquee highlights the blocks it intersects.
+    await dragBetween(
+      page,
+      { x: gutterX, y: tableBox.y - 4 },
+      { x: tableBox.x + tableBox.width / 2, y: tableBox.y + tableBox.height - 4 }
+    )
+
+    await expect(page.locator(HIGHLIGHTED_SELECTOR)).not.toHaveCount(0)
+
+    await page.keyboard.press('Backspace')
+
+    // Selected as a block, Backspace takes the whole table — the behaviour the
+    // cell drag must not trigger.
+    await expect.poll(() => tableCells(page), { timeout: 10_000 }).toBeNull()
+  })
+})

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -134,6 +134,8 @@ A selection box follows the pointer and every block it touches is highlighted, t
 
 A bookmark card is the one exception: its whole surface is a link, so clicking it opens the link and a drag has to begin in the margin beside it instead.
 
+Inside a table, dragging selects **cells**, not blocks — a drag from one cell to another selects the range between them, and <kbd>Backspace</kbd> then clears those cells and leaves the table standing. To select the table itself as a block, begin the drag in the margin beside it, the same as for any other block.
+
 With blocks selected, <kbd>Backspace</kbd> deletes them, <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> indent and outdent them, and <kbd>Esc</kbd> clears the selection.
 
 One consequence worth knowing: the empty space to the right of a short line still counts as that line's text, so the right-hand margin outside the column is the place to begin a right-side block selection.


### PR DESCRIPTION
Reported while testing tables: dragging from one cell to another highlighted the cells, but <kbd>Backspace</kbd> then deleted **the whole table** instead of clearing the selected cells.

## Why

BlockNote renders a table cell as:

```html
<td colspan="1" rowspan="1"><p>Ship it</p></td>
```

That inner `<p>` carries **no class**, unlike a paragraph block's `<p class="bn-inline-content">`. The marquee start rule asks `hasSelectableTextAt`, which looks for exactly `.bn-inline-content` — so it answered "no text here" for every press inside a table, *the text itself included*, not just the cell padding.

So a drag across cells started a block marquee. A table is a single block, so the marquee took the entire table. Both selections were live at once: prosemirror-tables drew its cell selection (what you saw), while the marquee held the table as a selected block (what <kbd>Backspace</kbd> acted on).

The module's own TRIPWIRE note warned that `.bn-inline-content` is a BlockNote internal rather than a contract. A table is where that already bit.

## The change

`hasSelectableTextAt` now names table cells in their own right. Every in-table drag goes to prosemirror-tables, which owns cell selection. A table is still marquee-selectable as a block from the margin beside it, where no cell sits under the pointer — covered by a test so the rule cannot quietly widen.

## Tests

- `marquee-hit-test.integration.test.ts` (new) — runs both predicates against a **real mounted editor**, and asserts the markup itself: the cell's `<p>` has an empty `className` and no `.bn-inline-content` inside. This turns the TRIPWIRE comment into a test — a BlockNote upgrade that changes either class now fails here rather than silently killing text selection in the app.
- `use-block-marquee-selection.test.tsx` — the decision table gains a cell and its inner paragraph, spelled the way BlockNote renders them.
- `marquee-table-cells.e2e.ts` (new) — a real mouse drag across cells: no block highlight, and <kbd>Backspace</kbd> leaves the table standing with only the dragged-over cells emptied. Plus the guard in the other direction: a drag from the margin still selects the table as a block and <kbd>Backspace</kbd> still deletes it.

Mutation-checked both layers. Reverting the fix turns the two renderer tests red, and — after a rebuild — turns the E2E cell drag red (the marquee highlight reappears) while the margin test stays green, which is exactly the reported bug and exactly the behaviour that must not change.

## Verification

- marquee renderer tests — 5 files, 58 tests
- content-area renderer suite — 49 files, 633 tests
- `marquee-table-cells.e2e.ts` + the existing `marquee-selection.e2e.ts` — 21 passed, real Electron
- `pnpm typecheck`, `pnpm build`, eslint, `git diff --check`
- `pnpm docs:impact --base origin/main --strict` — covered; `pnpm docs:build`

## One unrelated line

The renderer guardrail reads `right-side` in a pre-existing comment as a physical Tailwind class, and it scans the whole staged file rather than the diff — so touching this file blocked the commit. Reworded that phrase, nothing else.
