### PR TITLE
feat(tables): colour a cell, and keep the colour after the save (#1639)

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -2422,3 +2422,130 @@ describe('toggle blocks survive the markdown round-trip (#1643)', () => {
     expect(await rewrite(markdown)).toBe(markdown)
   })
 })
+
+/**
+ * #1639 — a cell's colour is the one colour a note could not keep.
+ *
+ * BlockNote holds it in the cell's own props and GFM has nowhere to put it, so
+ * `blocksToMarkdownLossy` writes `| a | b |` and the colour is gone on the next
+ * open. Enabling the cell colour menu without this would have shipped a control
+ * whose result vanished on save — the #1643 bug class, on a new surface.
+ *
+ * These drive the real ServerBlockNoteEditor through markdown → Y.Doc →
+ * markdown, which is the path that writes the vault file for a synced note.
+ */
+describe('table cell colours survive the markdown round trip (#1639)', () => {
+  const roundTrip = async (md: string): Promise<string | null> => {
+    const doc = new Y.Doc()
+    const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    await markdownToYFragment(md, fragment)
+    return yDocToMarkdown(doc)
+  }
+
+  const blocksToMd = async (blocks: NonNullable<Awaited<ReturnType<typeof markdownToBlocks>>>) => {
+    const doc = new Y.Doc()
+    const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    blocksToYFragment(blocks, fragment)
+    return yDocToMarkdown(doc)
+  }
+
+  const TABLE_MD = ['| Name | Status |', '| --- | --- |', '| Ship | Done |'].join('\n')
+
+  const cellsOf = (block: unknown) =>
+    (block as { content: { rows: Array<{ cells: Array<{ props: Record<string, string> }> }> } })
+      .content.rows
+
+  it('leaves a table nobody has coloured byte-identical', async () => {
+    // #given the tables already in every vault
+    const canonical = await roundTrip(TABLE_MD)
+
+    // #then no marker is written for them…
+    expect(canonical).not.toContain('table-colors')
+    // …and a second pass changes nothing, which is what write-back compares
+    expect(await roundTrip(canonical!)).toBe(canonical)
+  })
+
+  it('writes a coloured cell as a marker and reads it back onto the same cell', async () => {
+    // #given a table whose second-row first cell was coloured from the cell menu
+    const blocks = await markdownToBlocks(TABLE_MD)
+    Object.assign(cellsOf(blocks![0])[1].cells[0].props, {
+      backgroundColor: 'red',
+      textColor: 'blue'
+    })
+
+    // #when it is saved
+    const saved = await blocksToMd(blocks!)
+
+    // #then the colour is on disk, in front of the table it belongs to
+    expect(saved).toContain(
+      '<!-- table-colors:{"1:0":{"textColor":"blue","backgroundColor":"red"}} -->'
+    )
+    expect(saved).toContain('| Ship')
+
+    // #and reading the note back puts it on the cell it came from
+    const reparsed = await markdownToBlocks(saved!)
+    expect(cellsOf(reparsed![0])[1].cells[0].props).toMatchObject({
+      backgroundColor: 'red',
+      textColor: 'blue'
+    })
+    expect(cellsOf(reparsed![0])[0].cells[0].props).toMatchObject({
+      backgroundColor: 'default',
+      textColor: 'default'
+    })
+
+    // #and the second save is byte-identical to the first
+    expect(await blocksToMd(reparsed!)).toBe(saved)
+  })
+
+  it('keeps a table-level colour and its cell colours on separate marker lines', async () => {
+    // #given both colour paths used on one table
+    const blocks = await markdownToBlocks(TABLE_MD)
+    ;(blocks![0].props as Record<string, string>).textColor = 'green'
+    Object.assign(cellsOf(blocks![0])[0].cells[1].props, { backgroundColor: 'yellow' })
+
+    // #when
+    const saved = await blocksToMd(blocks!)
+
+    // #then the block marker comes first, the cell marker second
+    expect(saved!.split('\n').slice(0, 2)).toEqual([
+      '<!-- colors:{"textColor":"green"} -->',
+      '<!-- table-colors:{"0:1":{"backgroundColor":"yellow"}} -->'
+    ])
+
+    // #and both survive the reopen, together
+    const reparsed = await markdownToBlocks(saved!)
+    expect(reparsed![0].props).toMatchObject({ textColor: 'green' })
+    expect(cellsOf(reparsed![0])[0].cells[1].props).toMatchObject({ backgroundColor: 'yellow' })
+    expect(await blocksToMd(reparsed!)).toBe(saved)
+  })
+
+  it('ignores a marker naming a cell the table no longer has', async () => {
+    // #given a note edited by hand in another editor: the row the marker names
+    // was deleted, the marker was not
+    const md = `<!-- table-colors:{"7:3":{"backgroundColor":"red"}} -->\n${TABLE_MD}`
+
+    // #when
+    const blocks = await markdownToBlocks(md)
+
+    // #then the table still parses, and no marker is written back for it
+    expect(blocks![0].type).toBe('table')
+    expect(await blocksToMd(blocks!)).not.toContain('table-colors')
+  })
+
+  // The other half of #1639: the report was "no formatting in tables at all".
+  // Marks inside a cell need no marker — markdown carries them natively — and
+  // this says so, so it is not rediscovered as a bug the next time.
+  it('round-trips bold and italic inside a cell without any marker', async () => {
+    // #given
+    const md = ['| Name | Status |', '| --- | --- |', '| **Ship** | *Done* |'].join('\n')
+
+    // #when
+    const out = await roundTrip(md)
+
+    // #then
+    expect(out).toContain('**Ship**')
+    expect(out).toContain('*Done*')
+    expect(out).not.toContain('table-colors')
+    expect(await roundTrip(out!)).toBe(out)
+  })
+})

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -23,10 +23,16 @@ import {
 } from '@memry/shared/task-block'
 import {
   type BlockColors,
+  type TableCellColors,
+  applyTableCellColors,
+  extractTableCellColors,
   BLOCK_COLORS_LINE_REGEX,
+  TABLE_CELL_COLORS_LINE_REGEX,
   hasNonDefaultColors,
   parseBlockColorsMarker,
-  serializeBlockColorsMarker
+  parseTableCellColorsMarker,
+  serializeBlockColorsMarker,
+  serializeTableCellColorsMarker
 } from '@memry/shared/block-colors'
 import {
   applyInlineColorTokens,
@@ -508,6 +514,7 @@ async function parseContentWithColorMarkers(
   const blocks: Block[] = []
   let buffer: string[] = []
   let pendingColors: BlockColors | null = null
+  let pendingTableColors: TableCellColors | null = null
 
   const flushBuffer = async (): Promise<void> => {
     if (buffer.length === 0) return
@@ -515,7 +522,11 @@ async function parseContentWithColorMarkers(
     if (pendingColors && parsed[0]) {
       parsed[0].props = { ...parsed[0].props, ...pendingColors }
     }
+    if (pendingTableColors && parsed[0]) {
+      applyTableCellColors(parsed[0].content, pendingTableColors)
+    }
     pendingColors = null
+    pendingTableColors = null
     blocks.push(...parsed)
     buffer = []
   }
@@ -540,10 +551,23 @@ async function parseContentWithColorMarkers(
       }
     }
 
+    // Same rule, one level down: the colors of the individual cells of the
+    // table that follows. `flushBuffer` returns early on an empty buffer, so
+    // the two markers can sit on consecutive lines without clearing each other.
+    if (TABLE_CELL_COLORS_LINE_REGEX.test(trimmed)) {
+      const cellColors = parseTableCellColorsMarker(trimmed)
+      if (cellColors) {
+        await flushBuffer()
+        pendingTableColors = cellColors
+        continue
+      }
+    }
+
     const marker = insideFence ? null : parseCustomBlockMarkerLine(line)
     if (marker) {
       await flushBuffer()
       pendingColors = null
+      pendingTableColors = null
       blocks.push(marker)
       continue
     }
@@ -623,6 +647,22 @@ function parseHttpUrl(url: string): URL | null {
   }
 }
 
+/**
+ * The marker lines a block needs in front of it to keep the colors markdown
+ * cannot carry: its own text/background color, and — for a table — the colors
+ * of its individual cells. Empty for everything else, which is what keeps the
+ * bytes of every note without a colored block exactly as they were.
+ */
+function colorMarkerLines(block: Block): string[] {
+  const lines: string[] = []
+  if (hasNonDefaultColors(block.props as BlockColors)) {
+    lines.push(serializeBlockColorsMarker(block.props as BlockColors))
+  }
+  const cellColors = extractTableCellColors(block.content)
+  if (cellColors) lines.push(serializeTableCellColorsMarker(cellColors))
+  return lines
+}
+
 async function blocksToMarkdownPreserving(
   editor: ServerBlockNoteEditor,
   blocks: Block[]
@@ -647,6 +687,8 @@ async function blocksToMarkdownPreserving(
   }
 
   for (const block of blocks) {
+    const colorMarkers = colorMarkerLines(block)
+
     if ((block.type as string) === 'taskBlock') {
       // BlockNote can't serialize a taskBlock (it's content:'none'), so emit the
       // `- [ ] … {task:id}` line ourselves. Subtasks are kept on the immediately
@@ -671,7 +713,7 @@ async function blocksToMarkdownPreserving(
         contentGroup = []
       }
       emptyCount++
-    } else if (hasNonDefaultColors(block.props as BlockColors)) {
+    } else if (colorMarkers.length > 0) {
       if (contentGroup.length > 0) {
         const md = await serializeBlocks(editor, contentGroup as PartialBlock[])
         segments.push({ type: 'content', text: md.trim() })
@@ -684,7 +726,7 @@ async function blocksToMarkdownPreserving(
       const blockMd = await serializeBlocks(editor, [block] as PartialBlock[])
       segments.push({
         type: 'content',
-        text: `${serializeBlockColorsMarker(block.props as BlockColors)}\n${blockMd.trim()}`
+        text: `${colorMarkers.join('\n')}\n${blockMd.trim()}`
       })
     } else if (hasMarkerSerializedChildren(block)) {
       if (contentGroup.length > 0) {

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -554,6 +554,18 @@ describe('ContentArea', () => {
     expect(contentAreaMocks.blockNoteOptions.tables).toMatchObject({ headers: true })
   })
 
+  // Same default, same consequence: BlockNote hides the cell colour menu unless
+  // both flags are on, which left a table the one place in a note where colour
+  // could not be reached (#1639).
+  it('enables the table cell colour menu', () => {
+    render(<ContentArea noteId="note-1" />)
+
+    expect(contentAreaMocks.blockNoteOptions.tables).toMatchObject({
+      cellBackgroundColor: true,
+      cellTextColor: true
+    })
+  })
+
   // The signed-out clobber: with no session the editor was never bound to a
   // Y.Doc, so keystrokes reached markdown alone and the sign-in that rebuilt the
   // doc from the server wrote it back over them. The local doc is the editor's

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -391,10 +391,14 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
   const editor = useCreateBlockNote({
     schema: editorSchema,
     setIdAttribute: true,
-    // Off by default in BlockNote 0.47, which leaves the table handle menu with
-    // no way to make a header row at all — while markdown storage hands every
-    // table one on the way back in.
-    tables: { headers: true },
+    // All off by default in BlockNote 0.47. `headers` leaves the table handle
+    // menu with no way to make a header row at all — while markdown storage
+    // hands every table one on the way back in. The two colour flags are pure
+    // UI gates on the cell menu (nothing in the schema turns on with them), and
+    // without them a table was the one place in a note where colour was
+    // unreachable (#1639). What the cell holds is written back through the
+    // `<!-- table-colors:… -->` marker, so the colour survives the save.
+    tables: { headers: true, cellBackgroundColor: true, cellTextColor: true },
     uploadFile,
     resolveFileUrl,
     placeholders: {

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
@@ -709,3 +709,77 @@ describe('isEmptyParagraph', () => {
     expect(isEmptyParagraph({ type: 'paragraph', content: ['text'] } as any)).toBe(false)
   })
 })
+
+/**
+ * #1639 — the non-collaborative save path's half of the table cell colour
+ * marker. Its twin (`blocknote-converter.ts`) is pinned by round trips through
+ * a real ServerBlockNoteEditor; what is under test here is the plumbing: the
+ * marker goes in front of the table, and comes back onto the same cell.
+ */
+describe('table cell colours (#1639)', () => {
+  const TABLE_MD = ['| Name | Status |', '| --- | --- |', '| Ship | Done |'].join('\n')
+
+  const cell = (text: string, colors: Record<string, string> = {}) => ({
+    type: 'tableCell',
+    content: [{ type: 'text', text, styles: {} }],
+    props: { colspan: 1, rowspan: 1, textAlignment: 'left', ...colors }
+  })
+
+  const table = (colors: Record<string, string> = {}) => ({
+    type: 'table',
+    props: {},
+    content: {
+      type: 'tableContent',
+      columnWidths: [null, null],
+      headerRows: 1,
+      rows: [
+        { cells: [cell('Name'), cell('Status')] },
+        { cells: [cell('Ship', colors), cell('Done')] }
+      ]
+    },
+    children: []
+  })
+
+  /** A table in, GFM out — and back, ignoring the cell text the marker never touches. */
+  const tableEditor = {
+    tryParseMarkdownToBlocks: vi.fn(async (markdown: string) =>
+      markdown.includes('|') ? [table()] : []
+    ),
+    blocksToMarkdownLossy: vi.fn(async () => TABLE_MD)
+  }
+
+  it('writes the marker in front of the table it belongs to', async () => {
+    // #given the cell menu was used on the second row's first cell
+    const blocks = [table({ backgroundColor: 'red', textColor: 'blue' })]
+
+    // #when
+    const markdown = await serializeBlocksPreservingBlanks(tableEditor, blocks as any[])
+
+    // #then
+    expect(markdown).toBe(
+      `<!-- table-colors:{"1:0":{"textColor":"blue","backgroundColor":"red"}} -->\n${TABLE_MD}`
+    )
+  })
+
+  it('writes nothing extra for a table nobody has coloured', async () => {
+    const markdown = await serializeBlocksPreservingBlanks(tableEditor, [table()] as any[])
+
+    expect(markdown).toBe(TABLE_MD)
+  })
+
+  it('reads the marker back onto the cell it names', async () => {
+    // #given the note as it sits on disk
+    const markdown = `<!-- table-colors:{"1:0":{"backgroundColor":"red"}} -->\n${TABLE_MD}`
+
+    // #when
+    const blocks = await parseMarkdownPreservingBlanks(tableEditor, markdown)
+
+    // #then the colour is on the cell, and the marker is not a paragraph of its own
+    expect(blocks).toHaveLength(1)
+    expect((blocks[0] as any).content.rows[1].cells[0].props).toMatchObject({
+      backgroundColor: 'red',
+      colspan: 1
+    })
+    expect((blocks[0] as any).content.rows[0].cells[0].props).not.toHaveProperty('backgroundColor')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
@@ -12,10 +12,16 @@ import {
 } from '@memry/shared/empty-lines'
 import {
   type BlockColors,
+  type TableCellColors,
+  applyTableCellColors,
+  extractTableCellColors,
   BLOCK_COLORS_LINE_REGEX,
+  TABLE_CELL_COLORS_LINE_REGEX,
   hasNonDefaultColors,
   parseBlockColorsMarker,
-  serializeBlockColorsMarker
+  parseTableCellColorsMarker,
+  serializeBlockColorsMarker,
+  serializeTableCellColorsMarker
 } from '@memry/shared/block-colors'
 import {
   applyInlineColorTokens,
@@ -68,6 +74,22 @@ function hasMarkerSerializedChildren(block: Block): boolean {
   return children.some(
     (child) => !canSerializeChildNatively(block, child) || hasMarkerSerializedChildren(child)
   )
+}
+
+/**
+ * The marker lines a block needs in front of it to keep the colors markdown
+ * cannot carry: its own text/background color, and — for a table — the colors
+ * of its individual cells. Empty for everything else, so a note with no colored
+ * block keeps exactly the bytes it had.
+ */
+function colorMarkerLines(block: Block): string[] {
+  const lines: string[] = []
+  if (hasNonDefaultColors(block.props as BlockColors)) {
+    lines.push(serializeBlockColorsMarker(block.props as BlockColors))
+  }
+  const cellColors = extractTableCellColors(block.content)
+  if (cellColors) lines.push(serializeTableCellColorsMarker(cellColors))
+  return lines
 }
 
 async function parseMarkdownChunkPreservingNesting(
@@ -302,6 +324,9 @@ async function parseMarkdownWithoutToggles(editor: any, markdown: string): Promi
               if (part.colors && parsed[0]) {
                 parsed[0].props = { ...parsed[0].props, ...part.colors }
               }
+              if (part.tableColors && parsed[0]) {
+                applyTableCellColors(parsed[0].content, part.tableColors)
+              }
               blocks.push(...parsed)
             }
           }
@@ -347,6 +372,8 @@ export async function serializeBlocksPreservingBlanks(
   }
 
   for (const block of blocks) {
+    const colorMarkers = colorMarkerLines(block)
+
     if ((block.type as string) === 'taskBlock') {
       await flushContent()
       flushGap()
@@ -399,13 +426,13 @@ export async function serializeBlocksPreservingBlanks(
     } else if (isEmptyParagraph(block)) {
       await flushContent()
       emptyCount++
-    } else if (hasNonDefaultColors(block.props as BlockColors)) {
+    } else if (colorMarkers.length > 0) {
       await flushContent()
       flushGap()
       const blockMd = await serializeBlocks(editor, [block])
       segments.push({
         type: 'content',
-        text: `${serializeBlockColorsMarker(block.props as BlockColors)}\n${blockMd.trim()}`
+        text: `${colorMarkers.join('\n')}\n${blockMd.trim()}`
       })
     } else if (hasMarkerSerializedChildren(block)) {
       await flushContent()
@@ -432,7 +459,7 @@ export async function serializeBlocksPreservingBlanks(
 }
 
 type EmbedPart =
-  | { kind: 'text'; text: string; colors?: BlockColors }
+  | { kind: 'text'; text: string; colors?: BlockColors; tableColors?: TableCellColors }
   | { kind: 'embed'; url: string; videoId: string }
   | { kind: 'bookmark'; url: string }
   | { kind: 'file'; props: FileBlockProps }
@@ -446,14 +473,17 @@ function splitByEmbedMarkers(text: string): EmbedPart[] {
   const parts: EmbedPart[] = []
   let buffer: string[] = []
   let pendingColors: BlockColors | null = null
+  let pendingTableColors: TableCellColors | null = null
 
   const flushBuffer = (): void => {
     if (buffer.length === 0) return
     const part: EmbedPart = { kind: 'text', text: buffer.join('\n') }
     if (pendingColors) part.colors = pendingColors
+    if (pendingTableColors) part.tableColors = pendingTableColors
     parts.push(part)
     buffer = []
     pendingColors = null
+    pendingTableColors = null
   }
 
   for (const line of lines) {
@@ -466,12 +496,24 @@ function splitByEmbedMarkers(text: string): EmbedPart[] {
         continue
       }
     }
+    // Same rule, one level down: the colors of the individual cells of the
+    // table that follows. `flushBuffer` returns early on an empty buffer, so
+    // the two markers can sit on consecutive lines without clearing each other.
+    if (TABLE_CELL_COLORS_LINE_REGEX.test(trimmedLine)) {
+      const cellColors = parseTableCellColorsMarker(trimmedLine)
+      if (cellColors) {
+        flushBuffer()
+        pendingTableColors = cellColors
+        continue
+      }
+    }
     const fileProps = FILE_BLOCK_LINE_REGEX.test(trimmedLine)
       ? parseFileBlockMarker(trimmedLine)
       : null
     if (fileProps) {
       flushBuffer()
       pendingColors = null
+      pendingTableColors = null
       parts.push({ kind: 'file', props: fileProps })
       continue
     }

--- a/apps/desktop/tests/e2e/table-cell-colors.e2e.ts
+++ b/apps/desktop/tests/e2e/table-cell-colors.e2e.ts
@@ -1,0 +1,209 @@
+// @ts-nocheck - E2E test; window.api typing lives in the renderer bundle
+/**
+ * A table cell's colour has to still be there after the note is saved (#1639).
+ *
+ * Two things were wrong. BlockNote 0.47 defaults `tables.cellBackgroundColor`
+ * and `tables.cellTextColor` to false, and with both off it renders no cell
+ * handle at all — so a table was the one place in a note where colour could not
+ * be reached. And a GFM row has nowhere to keep a cell's colour, so simply
+ * turning the menu on would have shipped a control whose result vanished on the
+ * next open. The colour is written as a `<!-- table-colors:… -->` marker line
+ * in front of the table, the same way a block's own colour already was.
+ *
+ * These run on the single-app fixture, which is the NON-collaborative save path
+ * (`markdown-utils.ts`). Its twin, the CRDT/sync path
+ * (`blocknote-converter.ts`), is pinned by unit tests that drive a real
+ * ServerBlockNoteEditor through markdown → Y.Doc → markdown.
+ */
+
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { ready } from './utils/desktop-test-helpers'
+import { SELECTORS } from './utils/electron-helpers'
+import { getNoteFileBodyById, openNoteByHandle, openNoteByTitle } from './utils/note-sync-helpers'
+
+const cell = (text: string) => ({
+  type: 'tableCell',
+  content: [{ type: 'text', text, styles: {} }],
+  props: { colspan: 1, rowspan: 1 }
+})
+
+/** A two-column table with one header row — what `/table` inserts. */
+const TABLE_DOC = [
+  {
+    type: 'table',
+    content: {
+      type: 'tableContent',
+      columnWidths: [null, null],
+      headerRows: 1,
+      rows: [{ cells: [cell('Task'), cell('State')] }, { cells: [cell('Shipping'), cell('Open')] }]
+    }
+  }
+]
+
+const TABLE_MD = ['| Task | State |', '| --- | --- |', '| Shipping | Open |'].join('\n')
+
+/**
+ * Where to double-click inside a cell to select its first word.
+ *
+ * Not the centre: a cell is a fixed 120px wide, a short word leaves the middle
+ * empty, and a double-click on empty cell space selects nothing. Not the very
+ * corner either — the block drag handle overhangs the first column there.
+ */
+const WORD_START = { x: 20, y: 20 }
+
+async function createNote(page: Page, title: string, content = '') {
+  return page.evaluate(
+    async ({ noteTitle, noteContent }) => {
+      const result = await window.api.notes.create({ title: noteTitle, content: noteContent })
+      if (!result.success || !result.note) throw new Error(result.error || 'note create failed')
+      return { id: result.note.id, title: result.note.title, emoji: result.note.emoji ?? null }
+    },
+    { noteTitle: title, noteContent: content }
+  )
+}
+
+async function waitForEditor(page: Page) {
+  const editor = page.locator(SELECTORS.noteEditor).first()
+  await editor.waitFor({ state: 'visible', timeout: 15_000 })
+  return editor
+}
+
+async function setDocument(page: Page, blocks: unknown[]): Promise<void> {
+  await waitForEditor(page)
+  await page.evaluate((next) => {
+    const editor = (window as any).__memryEditor
+    if (!editor) throw new Error('window.__memryEditor not exposed')
+    editor.replaceBlocks(editor.document, next)
+  }, blocks)
+}
+
+/** Every cell as {text, textColor, backgroundColor}, row by row. */
+async function tableShape(page: Page): Promise<unknown[]> {
+  await waitForEditor(page)
+  return page.evaluate(() => {
+    const editor = (window as any).__memryEditor
+    if (!editor) throw new Error('window.__memryEditor not exposed')
+    const table = editor.document.find((block: any) => block.type === 'table')
+    if (!table) throw new Error('no table in the document')
+    return table.content.rows.map((row: any) =>
+      row.cells.map((cellValue: any) => ({
+        text: (cellValue.content ?? []).map((part: any) => part.text ?? '').join(''),
+        textColor: cellValue.props?.textColor,
+        backgroundColor: cellValue.props?.backgroundColor
+      }))
+    )
+  })
+}
+
+test.describe('Table cell colours E2E (#1639)', () => {
+  test.beforeEach(async ({ page }) => {
+    await ready(page)
+  })
+
+  test('a cell coloured from the cell menu is still coloured after a reopen', async ({ page }) => {
+    // #given a note holding a table
+    const title = `Table Cell Colour ${Date.now()}`
+    const note = await createNote(page, title)
+    await openNoteByHandle(page, note)
+    await setDocument(page, TABLE_DOC)
+
+    // #when the body cell is coloured through the menu the flags unlock —
+    // with both off BlockNote renders no cell handle at all, so this hover
+    // finding one is itself the assertion that they are on
+    const bodyCell = page.locator(`${SELECTORS.noteEditor} td`).first()
+    await bodyCell.hover()
+    const cellHandle = page.locator('[data-test="tableCellHandle"]').first()
+    await expect(cellHandle).toBeVisible({ timeout: 10_000 })
+    await cellHandle.click()
+    await page.getByText('Colors', { exact: true }).first().click()
+    await page.locator('[data-test="background-color-red"]').first().click()
+
+    // #then the colour reaches the vault file as a marker in front of the table
+    await expect
+      .poll(async () => (await getNoteFileBodyById(page, note.id)) ?? '', { timeout: 20_000 })
+      .toContain('<!-- table-colors:')
+    const saved = await getNoteFileBodyById(page, note.id)
+    expect(saved).toContain('"1:0":{"backgroundColor":"red"}')
+    expect(saved).toContain('| Shipping')
+
+    // #and it is still there when the note is opened cold
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+    await ready(page)
+    await openNoteByTitle(page, title)
+
+    await expect.poll(async () => (await tableShape(page))[1][0].backgroundColor).toBe('red')
+    expect((await tableShape(page))[0][0].backgroundColor).not.toBe('red')
+
+    // #and reopening rewrote nothing: the round trip converged on the first save
+    expect(await getNoteFileBodyById(page, note.id)).toBe(saved)
+  })
+
+  test('a table whose marker was written by hand opens coloured and is not rewritten', async ({
+    page
+  }) => {
+    // #given a note whose bytes the editor never produced — the marker and the
+    // table went into the vault file as text, exactly as another editor would
+    // have left them
+    const title = `Table Colour Marker ${Date.now()}`
+    const body = `<!-- table-colors:{"1:1":{"textColor":"blue"}} -->\n${TABLE_MD}`
+    const note = await createNote(page, title, body)
+    await openNoteByHandle(page, note)
+
+    // #then the colour is on the cell the marker names, and only that one
+    await expect.poll(async () => (await tableShape(page))[1][1].textColor).toBe('blue')
+    const shape = await tableShape(page)
+    expect(shape[1][0].textColor).not.toBe('blue')
+
+    // #and the marker line is not sitting in the note as a paragraph
+    expect(shape[1][1].text).toBe('Open')
+
+    // #and the file is left exactly as it was found
+    expect(await getNoteFileBodyById(page, note.id)).toBe(body)
+  })
+
+  test('bold and italic applied inside a cell reach the file, in both toolbar modes', async ({
+    page
+  }) => {
+    // #given a note holding a table, on the default floating toolbar
+    const title = `Table Cell Marks ${Date.now()}`
+    const note = await createNote(page, title)
+    await openNoteByHandle(page, note)
+    await setDocument(page, TABLE_DOC)
+
+    // #when the word in the body cell is selected and bolded from the toolbar.
+    // The double-click is aimed near the start of the cell rather than its
+    // centre: a cell is a fixed 120px wide and a short word leaves the middle
+    // of it empty, where a double-click selects nothing at all.
+    const bodyCell = page.locator(`${SELECTORS.noteEditor} td`).first()
+    await bodyCell.dblclick({ position: WORD_START })
+    const boldButton = page.locator('[data-test="bold"]').first()
+    await expect(boldButton).toBeVisible({ timeout: 10_000 })
+    await boldButton.click()
+
+    // #then the mark reaches the file — markdown carries it natively, no marker
+    await expect
+      .poll(async () => (await getNoteFileBodyById(page, note.id)) ?? '', { timeout: 20_000 })
+      .toContain('**Shipping**')
+
+    // #when the same is done with the sticky toolbar on, via the keyboard
+    await page.evaluate(async () => {
+      await window.api.settings.setEditorSettings({ toolbarMode: 'sticky' })
+    })
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+    await ready(page)
+    await openNoteByTitle(page, title)
+
+    const stateCell = page.locator(`${SELECTORS.noteEditor} td`).nth(1)
+    await stateCell.dblclick({ position: WORD_START })
+    await page.keyboard.press('ControlOrMeta+i')
+
+    // #then that mark lands too
+    await expect
+      .poll(async () => (await getNoteFileBodyById(page, note.id)) ?? '', { timeout: 20_000 })
+      .toContain('*Open*')
+    expect(await getNoteFileBodyById(page, note.id)).toContain('**Shipping**')
+  })
+})

--- a/apps/desktop/tests/e2e/table-cell-paste.e2e.ts
+++ b/apps/desktop/tests/e2e/table-cell-paste.e2e.ts
@@ -105,6 +105,12 @@ async function placeCursorAtEndOf(page: Page, cellText: string): Promise<void> {
  * BlockNote's copy handler bails out when the DOM selection is collapsed, so a
  * cut fired before the selection lands is silently a no-op. Repeat the gesture
  * until the browser agrees the text is selected.
+ *
+ * The selection is read a beat after the keys, not in the same tick: measured,
+ * `Shift+End` lands in the DOM before ProseMirror has taken it into its own
+ * state, and in that window the DOM selection reads as the whole rest of the
+ * block while the editor still thinks the cursor is collapsed. Both have to
+ * agree before a cut can do anything.
  */
 async function selectCellText(page: Page, cellText: string): Promise<void> {
   await expect
@@ -113,11 +119,19 @@ async function selectCellText(page: Page, cellText: string): Promise<void> {
         await cell(page, cellText).click()
         await page.keyboard.press('Home')
         await page.keyboard.press('Shift+End')
-        return page.evaluate(() => window.getSelection()?.toString() ?? '')
+        await page.waitForTimeout(150)
+        return page.evaluate(() => {
+          const view = (window as any).__memryEditor?.prosemirrorView
+          const { from, to } = view?.state.selection ?? {}
+          return {
+            dom: window.getSelection()?.toString() ?? '',
+            editor: view ? (view.state.doc.textBetween(from, to, ' ') as string) : ''
+          }
+        })
       },
       { message: `DOM selection over "${cellText}"`, timeout: 10_000 }
     )
-    .toBe(cellText)
+    .toEqual({ dom: cellText, editor: cellText })
 }
 
 async function pastePlainText(page: Page, text: string): Promise<void> {

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -51,6 +51,27 @@ Use the row and column handles on the edge of a table to toggle a header row or
 a header column on and off. The same table controls are available in task
 descriptions and in inbox items.
 
+### Cell colour and formatting
+
+Hover a cell and click the handle inside it to open the cell menu, then
+**Colors** to set that cell's text or background colour. Bold, italic,
+underline, links and mentions all work inside a cell exactly as they do in a
+paragraph — select the text and use the toolbar or the usual shortcuts.
+
+A markdown table has no column for a cell colour, so Memry writes it on a
+comment line just above the table, the same way a coloured paragraph is stored:
+
+```text
+<!-- table-colors:{"1:0":{"backgroundColor":"red"}} -->
+| Task | State |
+| --- | --- |
+| Shipping | Open |
+```
+
+The key is the cell's position — `row:column`, counting from zero and counting
+the header row. Other markdown editors ignore the comment and show the table
+normally. Text styles need no such line: markdown carries them itself.
+
 ## Slash Commands
 
 Type `/` anywhere in the editor to insert a block. Filter by typing — `/h2` jumps straight to Heading 2. Press <kbd>Enter</kbd> to confirm.

--- a/packages/shared/src/block-colors.test.ts
+++ b/packages/shared/src/block-colors.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import {
   BLOCK_COLORS_LINE_REGEX,
+  TABLE_CELL_COLORS_LINE_REGEX,
   hasNonDefaultColors,
   serializeBlockColorsMarker,
-  parseBlockColorsMarker
+  parseBlockColorsMarker,
+  extractTableCellColors,
+  serializeTableCellColorsMarker,
+  parseTableCellColorsMarker,
+  applyTableCellColors
 } from './block-colors'
 
 describe('hasNonDefaultColors', () => {
@@ -46,5 +51,109 @@ describe('BLOCK_COLORS_LINE_REGEX', () => {
   it('matches a full marker line only', () => {
     expect(BLOCK_COLORS_LINE_REGEX.test('<!-- colors:{"textColor":"red"} -->')).toBe(true)
     expect(BLOCK_COLORS_LINE_REGEX.test('text <!-- colors:{"textColor":"red"} -->')).toBe(false)
+  })
+})
+
+/** A table's content in the shape BlockNote parses markdown into. */
+const tableContent = (colors: Array<Array<Record<string, string>>>) => ({
+  type: 'tableContent',
+  columnWidths: [null, null],
+  headerRows: 1,
+  rows: colors.map((row) => ({
+    cells: row.map((cellColors) => ({
+      type: 'tableCell',
+      content: [],
+      props: { colspan: 1, rowspan: 1, textAlignment: 'left', ...cellColors }
+    }))
+  }))
+})
+
+describe('extractTableCellColors', () => {
+  it('returns null when nothing in the table is colored', () => {
+    const content = tableContent([
+      [{ textColor: 'default', backgroundColor: 'default' }, {}],
+      [{}, {}]
+    ])
+
+    expect(extractTableCellColors(content)).toBeNull()
+  })
+
+  it('returns null for a block that is not a table', () => {
+    expect(extractTableCellColors([{ type: 'text', text: 'x', styles: {} }])).toBeNull()
+    expect(extractTableCellColors(undefined)).toBeNull()
+  })
+
+  it('keys the colored cells by row and cell index, non-default keys only', () => {
+    const content = tableContent([
+      [{}, {}],
+      [{ backgroundColor: 'red', textColor: 'default' }, { textColor: 'blue' }]
+    ])
+
+    expect(extractTableCellColors(content)).toEqual({
+      '1:0': { backgroundColor: 'red' },
+      '1:1': { textColor: 'blue' }
+    })
+  })
+
+  it('ignores a cell handed back as a bare inline-content array', () => {
+    const content = { type: 'tableContent', rows: [{ cells: [[{ type: 'text', text: 'x' }]] }] }
+
+    expect(extractTableCellColors(content)).toBeNull()
+  })
+})
+
+describe('serializeTableCellColorsMarker / parseTableCellColorsMarker', () => {
+  it('round-trips a cell color map', () => {
+    const colors = { '1:0': { textColor: 'blue', backgroundColor: 'red' } }
+    const marker = serializeTableCellColorsMarker(colors)
+
+    expect(marker).toBe(
+      '<!-- table-colors:{"1:0":{"textColor":"blue","backgroundColor":"red"}} -->'
+    )
+    expect(parseTableCellColorsMarker(marker)).toEqual(colors)
+  })
+
+  it('returns null for non-marker lines, malformed JSON and non-object payloads', () => {
+    expect(parseTableCellColorsMarker('| a | b |')).toBeNull()
+    expect(parseTableCellColorsMarker('<!-- colors:{"textColor":"red"} -->')).toBeNull()
+    expect(parseTableCellColorsMarker('<!-- table-colors:{broken} -->')).toBeNull()
+  })
+})
+
+describe('applyTableCellColors', () => {
+  it('puts the colors back on the cells the keys name', () => {
+    const content = tableContent([
+      [{}, {}],
+      [{}, {}]
+    ])
+
+    applyTableCellColors(content, { '1:1': { backgroundColor: 'red' } })
+
+    expect(content.rows[1].cells[1].props).toMatchObject({
+      backgroundColor: 'red',
+      // the props the cell already carried are kept
+      colspan: 1,
+      textAlignment: 'left'
+    })
+    expect(content.rows[0].cells[0].props).not.toHaveProperty('backgroundColor')
+  })
+
+  it('skips keys naming a cell the table no longer has', () => {
+    const content = tableContent([[{}, {}]])
+
+    expect(() =>
+      applyTableCellColors(content, {
+        '9:9': { backgroundColor: 'red' },
+        nonsense: { textColor: 'blue' }
+      })
+    ).not.toThrow()
+    expect(extractTableCellColors(content)).toBeNull()
+  })
+})
+
+describe('TABLE_CELL_COLORS_LINE_REGEX', () => {
+  it('matches a full marker line only', () => {
+    expect(TABLE_CELL_COLORS_LINE_REGEX.test('<!-- table-colors:{"0:0":{}} -->')).toBe(true)
+    expect(TABLE_CELL_COLORS_LINE_REGEX.test('x <!-- table-colors:{"0:0":{}} -->')).toBe(false)
   })
 })

--- a/packages/shared/src/block-colors.ts
+++ b/packages/shared/src/block-colors.ts
@@ -21,9 +21,12 @@ export function hasNonDefaultColors(props: BlockColors): boolean {
 }
 
 /**
- * Serialize non-default block colors to a markdown marker line
+ * The non-default colors only, in a fixed key order.
+ *
+ * Both marker forms below serialize through this, so a block and a table cell
+ * holding the same colors always produce the same JSON bytes.
  */
-export function serializeBlockColorsMarker(props: BlockColors): string {
+function pickNonDefaultColors(props: BlockColors): BlockColors {
   const colors: BlockColors = {}
   if (props.textColor !== undefined && props.textColor !== 'default') {
     colors.textColor = props.textColor
@@ -31,7 +34,14 @@ export function serializeBlockColorsMarker(props: BlockColors): string {
   if (props.backgroundColor !== undefined && props.backgroundColor !== 'default') {
     colors.backgroundColor = props.backgroundColor
   }
-  return `<!-- colors:${JSON.stringify(colors)} -->`
+  return colors
+}
+
+/**
+ * Serialize non-default block colors to a markdown marker line
+ */
+export function serializeBlockColorsMarker(props: BlockColors): string {
+  return `<!-- colors:${JSON.stringify(pickNonDefaultColors(props))} -->`
 }
 
 /**
@@ -44,5 +54,115 @@ export function parseBlockColorsMarker(line: string): BlockColors | null {
     return JSON.parse(match[1])
   } catch {
     return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// table cell colors — one marker for the whole table, keyed by cell position
+// ---------------------------------------------------------------------------
+
+/**
+ * A table's non-default cell colors, keyed `"<rowIndex>:<cellIndex>"`.
+ *
+ * BlockNote keeps a cell's text/background color in the cell's own props, and a
+ * GFM row has nowhere to put them: `blocksToMarkdownLossy` writes `| a | b |`
+ * and the color is gone on the next open. So a colored table carries a second
+ * marker line, in the same position and the same shape as the block color
+ * marker — immediately before the block it describes.
+ *
+ * Only colored cells appear, so a table nobody has colored emits no marker at
+ * all and its bytes on disk are exactly what they were before this existed.
+ */
+export type TableCellColors = Record<string, BlockColors>
+
+/** A whole line that is nothing but a table cell color marker. */
+export const TABLE_CELL_COLORS_LINE_REGEX = /^<!-- table-colors:(\{.*\}) -->$/
+
+interface TableCellLike {
+  props?: BlockColors
+}
+
+interface TableContentLike {
+  rows?: Array<{ cells?: unknown[] } | undefined>
+}
+
+/**
+ * A cell's props, or null when the cell cannot hold any.
+ *
+ * BlockNote hands back a cell as a bare inline-content array on schemas where
+ * no cell prop is in play, and only as `{ content, props }` otherwise. Both
+ * shapes reach here, and only the second one has somewhere to keep a color.
+ */
+function cellProps(cell: unknown): BlockColors | null {
+  if (!cell || typeof cell !== 'object' || Array.isArray(cell)) return null
+  const props = (cell as TableCellLike).props
+  return props && typeof props === 'object' ? props : null
+}
+
+function tableRows(content: unknown): TableContentLike['rows'] | null {
+  const rows = (content as TableContentLike | undefined)?.rows
+  return Array.isArray(rows) ? rows : null
+}
+
+/**
+ * The colors of every non-default cell in a table's content, or null when the
+ * block is not a table or nothing in it is colored.
+ */
+export function extractTableCellColors(content: unknown): TableCellColors | null {
+  const rows = tableRows(content)
+  if (!rows) return null
+
+  const colors: TableCellColors = {}
+  rows.forEach((row, rowIndex) => {
+    const cells = row?.cells
+    if (!Array.isArray(cells)) return
+    cells.forEach((cell, cellIndex) => {
+      const props = cellProps(cell)
+      if (!props || !hasNonDefaultColors(props)) return
+      colors[`${rowIndex}:${cellIndex}`] = pickNonDefaultColors(props)
+    })
+  })
+
+  return Object.keys(colors).length > 0 ? colors : null
+}
+
+/** Serialize a table's cell colors to a markdown marker line. */
+export function serializeTableCellColorsMarker(colors: TableCellColors): string {
+  return `<!-- table-colors:${JSON.stringify(colors)} -->`
+}
+
+/** Parse a table cell color marker line; null when the line is not a valid marker. */
+export function parseTableCellColorsMarker(line: string): TableCellColors | null {
+  const match = line.match(TABLE_CELL_COLORS_LINE_REGEX)
+  if (!match) return null
+  try {
+    const parsed = JSON.parse(match[1]) as unknown
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as TableCellColors)
+      : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Put parsed cell colors back on a freshly parsed table's cells.
+ *
+ * A key that names a cell the table no longer has is skipped: the marker is a
+ * projection of a document someone may have edited by hand since, and a row
+ * deleted in a text editor must not throw the whole note's parse away.
+ */
+export function applyTableCellColors(content: unknown, colors: TableCellColors): void {
+  const rows = tableRows(content)
+  if (!rows) return
+
+  for (const [key, cellColors] of Object.entries(colors)) {
+    const [rowIndex, cellIndex] = key.split(':').map(Number)
+    if (!Number.isInteger(rowIndex) || !Number.isInteger(cellIndex)) continue
+    const cells = rows[rowIndex]?.cells
+    const cell = Array.isArray(cells) ? cells[cellIndex] : undefined
+    const props = cellProps(cell)
+    if (!props) continue
+    ;(cell as TableCellLike).props = { ...props, ...cellColors }
   }
 }


### PR DESCRIPTION
Closes #1639 · parent epic #1625 (item **G2**)

> "I also haven't been able use any formatting in the tables"

## What was wrong

BlockNote 0.47 defaults `tables.cellBackgroundColor` and `tables.cellTextColor` to `false`, and with both off it renders **no cell handle at all** (`TableCellHandle` returns `null` unless one of `splitCells` / the two colour flags is on). A table was the one place in a note where colour could not be reached — the drag handle colours the whole block, never a cell.

The second half of the report — bold/italic/underline inside a cell — turned out to be fine, in both toolbar modes. That is now asserted rather than assumed, so it is not rediscovered as a bug.

## Why this is more than one line

Turning the flags on by themselves would have shipped a control whose result vanished. BlockNote keeps a cell's colour in the **cell's own props**; a GFM row has nowhere to put them. Measured against a real `ServerBlockNoteEditor`:

```
| a | b |     →  cell.props.backgroundColor = 'red'  →  | a | b |
```

`blocksToMarkdownLossy` writes the row and the colour is gone on the next open. That is exactly the #1643 bug class (toggles degrading to bullets) on a new surface.

## The on-disk form

A coloured table gets a second marker line in front of it, in the same position and the same shape as the block colour marker that already sits there:

```text
<!-- colors:{"textColor":"green"} -->
<!-- table-colors:{"1:0":{"textColor":"blue","backgroundColor":"red"}} -->
| Task | State |
| --- | --- |
| Shipping | Open |
```

The key is the cell's position, `row:column`, counting the header row. **Only coloured cells appear in it**, so every table already in every vault emits no marker and keeps exactly the bytes it has — asserted directly, because write-back byte-compares. An older client treats the line as the HTML comment it is and drops it, the same way it always has for `<!-- colors: -->`.

Both save paths write and read it — the renderer's (`markdown-utils.ts`) and the CRDT one (`blocknote-converter.ts`) — because those two must agree byte for byte or every note with a table gets rewritten on open.

## Compat

Purely additive. No schema change, no migration, no new node type: `tables.*` is a **UI gate only** (`settings.tables` is read by the React menu components and nothing else), so main and renderer schemas stay identical and nothing in an existing document changes type. A marker naming a cell the table no longer has — a row deleted by hand in another editor — is skipped rather than thrown.

## Verification

| gate | result |
| --- | --- |
| `pnpm typecheck` | green |
| `pnpm lint` | green (0 errors) |
| `pnpm --filter @memry/desktop test:main` | 7193 passed |
| `pnpm --filter @memry/desktop test:renderer` | 7823 passed |
| `shared` vitest project | 2567 passed |
| `pnpm check:architecture`, `pnpm check:contracts`, `i18n:check` | green |
| `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build` | green |
| E2E `table-cell-colors.e2e.ts` (new) | 3 passed |
| E2E `table-cell-paste`, `toggle-blocks`, `vault-markdown-fidelity`, `note-open-byte-stability` | passed |

New tests:

- `packages/shared/src/block-colors.test.ts` — extract / serialize / parse / apply, including a cell handed back as a bare inline array and a key naming a cell that is gone
- `apps/desktop/src/main/sync/blocknote-converter.test.ts` — markdown → Y.Doc → markdown through the real editor: an uncoloured table stays byte-identical, a coloured cell round-trips and the second save equals the first, block colour and cell colours land on separate lines, and bold/italic in a cell need no marker
- `.../content-area/markdown-utils.test.ts` — the same marker plumbing on the non-collaborative path
- `ContentArea.test.tsx` — the flags are actually passed
- `apps/desktop/tests/e2e/table-cell-colors.e2e.ts` — the real app: colouring a cell through the cell menu reaches the vault and survives a cold reopen with the file unchanged; a marker written by hand opens coloured; bold from the floating toolbar and italic from the keyboard in sticky mode both reach the file

Each of these was mutation-checked: dropping the serialize half, dropping the parse half, and turning the two flags back off each turn the relevant tests red.

## One existing test had to be hardened

`selectCellText` in `table-cell-paste.e2e.ts` read the DOM selection in the same tick as the `Shift+End` that produced it. A cell now mounts a hover handle of its own, which is enough extra work to lose that race: measured, the DOM selection reads as the whole rest of the block while ProseMirror still holds a collapsed cursor. It now waits for the two to agree — the editor's selection is what a cut actually reads.

The gesture itself was never broken. With human pacing (a click, then the keys a beat later) it converges 6/6 on this branch and behaves identically on `main`; on `main` the same zero-delay loop also fails 6/6 in isolation. Only the poll was tight enough to notice.
