### PR TITLE
fix(sidebar): keep new and renamed items where they were put (#1646)

### DIFF
--- a/apps/desktop/src/main/database/queries/note-positions.test.ts
+++ b/apps/desktop/src/main/database/queries/note-positions.test.ts
@@ -18,7 +18,11 @@ import {
   deleteNotePosition,
   moveNoteToFolder,
   insertNoteAtPosition,
-  getAllNotePositions
+  getAllNotePositions,
+  placeNewItemAtTop,
+  carryPositionToPath,
+  carryFolderPositions,
+  dropFolderPositions
 } from './note-positions'
 
 describe('note-positions queries', () => {
@@ -424,6 +428,196 @@ describe('note-positions queries', () => {
 
       // Assert
       expect(result).toEqual([])
+    })
+  })
+  // =========================================================================
+  // placeNewItemAtTop — #1646
+  // =========================================================================
+  describe('placeNewItemAtTop', () => {
+    it('puts a new note above every note the user has dragged', () => {
+      // #given a folder the user arranged by hand
+      reorderNotesInFolder(testDb.db, 'work', ['work/a.md', 'work/b.md', 'work/c.md'])
+
+      // #when a note is created in it
+      placeNewItemAtTop(testDb.db, 'work/Untitled.md', 'work')
+
+      // #then it leads the folder instead of sorting below all three as a
+      // row-less MAX_SAFE_INTEGER item would
+      expect(getNotesInFolder(testDb.db, 'work').map((n) => n.path)).toEqual([
+        'work/Untitled.md',
+        'work/a.md',
+        'work/b.md',
+        'work/c.md'
+      ])
+    })
+
+    it('writes nothing in a folder nobody has ordered', () => {
+      // #given a folder still running on the tree's implicit order
+      // #when a note is created in it
+      placeNewItemAtTop(testDb.db, 'work/Untitled.md', 'work')
+
+      // #then no row is written: a row would freeze newest-first ordering for
+      // good, and the new note already leads that order
+      expect(getAllNotePositions(testDb.db)).toEqual([])
+    })
+
+    it('clears the row a deleted item left at the same path', () => {
+      // #given a stale row under a path nothing holds any more, in a folder
+      // with no other manual order
+      setNotePosition(testDb.db, 'work/Untitled.md', 'work', 7)
+
+      // #when a new note takes that path
+      placeNewItemAtTop(testDb.db, 'work/Untitled.md', 'work')
+
+      // #then it does not inherit the stranger's slot
+      expect(getNotePosition(testDb.db, 'work/Untitled.md')).toBeUndefined()
+    })
+
+    it('stacks repeated creations newest-first', () => {
+      reorderNotesInFolder(testDb.db, 'work', ['work/a.md'])
+
+      placeNewItemAtTop(testDb.db, 'work/first.md', 'work')
+      placeNewItemAtTop(testDb.db, 'work/second.md', 'work')
+
+      expect(getNotesInFolder(testDb.db, 'work').map((n) => n.path)).toEqual([
+        'work/second.md',
+        'work/first.md',
+        'work/a.md'
+      ])
+    })
+
+    it('reads only the target folder', () => {
+      reorderNotesInFolder(testDb.db, 'other', ['other/a.md', 'other/b.md'])
+
+      placeNewItemAtTop(testDb.db, 'work/Untitled.md', 'work')
+
+      expect(getNotePosition(testDb.db, 'work/Untitled.md')).toBeUndefined()
+    })
+
+    it('orders new items at the vault root', () => {
+      reorderNotesInFolder(testDb.db, '', ['a.md', 'b.md'])
+
+      placeNewItemAtTop(testDb.db, 'Untitled.md', '')
+
+      expect(getNotesInFolder(testDb.db, '')[0].path).toBe('Untitled.md')
+    })
+  })
+
+  // =========================================================================
+  // carryPositionToPath — #1646
+  // =========================================================================
+  describe('carryPositionToPath', () => {
+    it('keeps the slot when a note is renamed', () => {
+      // #given a new note sitting at the top of a hand-ordered folder
+      reorderNotesInFolder(testDb.db, 'work', ['work/a.md', 'work/b.md'])
+      placeNewItemAtTop(testDb.db, 'work/Untitled.md', 'work')
+
+      // #when the rename input that opened with it is committed
+      carryPositionToPath(testDb.db, 'work/Untitled.md', 'work/Q3 plan.md')
+
+      // #then the row moves with it and the list does not resort
+      expect(getNotesInFolder(testDb.db, 'work').map((n) => n.path)).toEqual([
+        'work/Q3 plan.md',
+        'work/a.md',
+        'work/b.md'
+      ])
+      expect(getNotePosition(testDb.db, 'work/Untitled.md')).toBeUndefined()
+    })
+
+    it('does not invent a position for a note that never had one', () => {
+      carryPositionToPath(testDb.db, 'work/a.md', 'work/b.md')
+
+      expect(getAllNotePositions(testDb.db)).toEqual([])
+    })
+
+    it('is a no-op when the path does not change', () => {
+      setNotePosition(testDb.db, 'work/a.md', 'work', 3)
+
+      carryPositionToPath(testDb.db, 'work/a.md', 'work/a.md')
+
+      expect(getNotePosition(testDb.db, 'work/a.md')?.position).toBe(3)
+    })
+  })
+
+  // =========================================================================
+  // carryFolderPositions — #1646
+  // =========================================================================
+  describe('carryFolderPositions', () => {
+    it('carries the folder and everything under it', () => {
+      // #given an ordered folder holding an ordered note and subfolder
+      setNotePosition(testDb.db, 'Work', '', 0)
+      setNotePosition(testDb.db, 'Work/a.md', 'Work', 0)
+      setNotePosition(testDb.db, 'Work/Sub', 'Work', 1)
+      setNotePosition(testDb.db, 'Work/Sub/deep.md', 'Work/Sub', 0)
+
+      // #when the folder is renamed
+      carryFolderPositions(testDb.db, 'Work', 'Projects')
+
+      // #then every row follows, path and parent alike
+      expect(getNotePosition(testDb.db, 'Projects')).toMatchObject({ folderPath: '', position: 0 })
+      expect(getNotePosition(testDb.db, 'Projects/a.md')).toMatchObject({
+        folderPath: 'Projects',
+        position: 0
+      })
+      expect(getNotePosition(testDb.db, 'Projects/Sub/deep.md')).toMatchObject({
+        folderPath: 'Projects/Sub',
+        position: 0
+      })
+      expect(getNotePosition(testDb.db, 'Work')).toBeUndefined()
+      expect(getNotePosition(testDb.db, 'Work/a.md')).toBeUndefined()
+    })
+
+    it('re-derives the parent when the folder moves to another parent', () => {
+      setNotePosition(testDb.db, 'Work', '', 2)
+
+      carryFolderPositions(testDb.db, 'Work', 'Archive/Work')
+
+      expect(getNotePosition(testDb.db, 'Archive/Work')).toMatchObject({
+        folderPath: 'Archive',
+        position: 2
+      })
+    })
+
+    it('leaves a sibling whose name starts with the same letters alone', () => {
+      // #given `Workspace` next to `Work` — a plain prefix test would sweep it
+      setNotePosition(testDb.db, 'Workspace/a.md', 'Workspace', 0)
+      setNotePosition(testDb.db, 'Work/a.md', 'Work', 0)
+
+      carryFolderPositions(testDb.db, 'Work', 'Projects')
+
+      expect(getNotePosition(testDb.db, 'Workspace/a.md')).toMatchObject({
+        folderPath: 'Workspace'
+      })
+    })
+
+    it('does nothing for a folder with no ordered contents', () => {
+      carryFolderPositions(testDb.db, 'Work', 'Projects')
+
+      expect(getAllNotePositions(testDb.db)).toEqual([])
+    })
+  })
+
+  // =========================================================================
+  // dropFolderPositions — #1646
+  // =========================================================================
+  describe('dropFolderPositions', () => {
+    it('drops the folder row and everything beneath it', () => {
+      setNotePosition(testDb.db, 'Work', '', 0)
+      setNotePosition(testDb.db, 'Work/a.md', 'Work', 0)
+      setNotePosition(testDb.db, 'Work/Sub/deep.md', 'Work/Sub', 0)
+      setNotePosition(testDb.db, 'Other/a.md', 'Other', 0)
+
+      dropFolderPositions(testDb.db, 'Work')
+
+      expect(getAllNotePositions(testDb.db).map((r) => r.path)).toEqual(['Other/a.md'])
+    })
+
+    it('leaves a sibling whose name starts with the same letters alone', () => {
+      setNotePosition(testDb.db, 'Workspace/a.md', 'Workspace', 0)
+
+      dropFolderPositions(testDb.db, 'Work')
+
+      expect(getNotePosition(testDb.db, 'Workspace/a.md')).toBeDefined()
     })
   })
 })

--- a/apps/desktop/src/main/database/queries/note-positions.ts
+++ b/apps/desktop/src/main/database/queries/note-positions.ts
@@ -1,4 +1,4 @@
-import { eq, asc, sql } from 'drizzle-orm'
+import { and, asc, eq, ne, sql } from 'drizzle-orm'
 import { notePositions, type NotePosition } from '@memry/db-schema/schema/note-positions'
 import type { DataDb } from '../types'
 
@@ -86,4 +86,125 @@ export function insertNoteAtPosition(
 
 export function getAllNotePositions(db: DataDb): NotePosition[] {
   return db.select().from(notePositions).all()
+}
+
+// ============================================================================
+// Lifecycle — keeping a manual order attached to the item that earned it
+// ============================================================================
+
+/** Parent folder of a vault-relative path. Root lives under `''`. */
+function parentFolderOf(itemPath: string): string {
+  const cut = itemPath.lastIndexOf('/')
+  return cut === -1 ? '' : itemPath.slice(0, cut)
+}
+
+/**
+ * Give a freshly created note or folder the slot above every positioned sibling.
+ *
+ * The tree reads a missing row as `Number.MAX_SAFE_INTEGER`, so in a folder the
+ * user has arranged by hand a new item sorts under everything ever dragged —
+ * the bottom of the list, every time (#1646). A row of `min - 1` puts it where
+ * the person who just pressed "new note" is looking instead.
+ *
+ * When nothing in `folderPath` carries a position the folder still runs on the
+ * tree's implicit order (notes newest-first, folders A→Z) and this writes
+ * nothing: a row here would freeze that order for good, and the newest note is
+ * already at the top of it. Any row left behind by an earlier item that held
+ * this exact path is cleared, so the new item cannot inherit a dead slot.
+ *
+ * Notes and folders share one position namespace per parent, so "the user
+ * ordered this folder" is judged per parent, not per kind.
+ */
+export function placeNewItemAtTop(db: DataDb, itemPath: string, folderPath: string): void {
+  const result = db
+    .select({ minPosition: sql<number | null>`min(${notePositions.position})` })
+    .from(notePositions)
+    .where(and(eq(notePositions.folderPath, folderPath), ne(notePositions.path, itemPath)))
+    .get()
+
+  const min = result?.minPosition
+  if (min === null || min === undefined) {
+    deleteNotePosition(db, itemPath)
+    return
+  }
+
+  setNotePosition(db, itemPath, folderPath, min - 1)
+}
+
+/**
+ * Carry a manual position across a path change.
+ *
+ * Rows are keyed by path and a rename rewrites the path, so without this the
+ * note the user just named drops its slot and falls to the bottom — which is
+ * the second half of #1646, since every new note opens straight into rename.
+ * No-op when the item never had a position.
+ */
+export function carryPositionToPath(db: DataDb, oldPath: string, newPath: string): void {
+  if (oldPath === newPath) return
+
+  const existing = getNotePosition(db, oldPath)
+  if (!existing) return
+
+  db.transaction(() => {
+    deleteNotePosition(db, oldPath)
+    setNotePosition(db, newPath, existing.folderPath, existing.position)
+  })
+}
+
+/**
+ * Re-key a renamed or moved folder: its own row plus every row beneath it.
+ *
+ * A folder rename rewrites the path of everything inside it, so all of those
+ * rows go stale at once — the folder keeps its slot but its whole contents lose
+ * theirs. `renameFolder` also serves drag-to-another-parent, so the folder's own
+ * `folderPath` is re-derived from the new path rather than carried over.
+ */
+export function carryFolderPositions(db: DataDb, oldPath: string, newPath: string): void {
+  if (oldPath === newPath) return
+
+  const oldPrefix = `${oldPath}/`
+  const newPrefix = `${newPath}/`
+  const descendants = getAllNotePositions(db).filter((row) => row.path.startsWith(oldPrefix))
+  const own = getNotePosition(db, oldPath)
+
+  if (!own && descendants.length === 0) return
+
+  db.transaction(() => {
+    if (own) {
+      deleteNotePosition(db, oldPath)
+      setNotePosition(db, newPath, parentFolderOf(newPath), own.position)
+    }
+
+    for (const row of descendants) {
+      const nextFolder =
+        row.folderPath === oldPath
+          ? newPath
+          : row.folderPath.startsWith(oldPrefix)
+            ? newPrefix + row.folderPath.slice(oldPrefix.length)
+            : row.folderPath
+
+      deleteNotePosition(db, row.path)
+      setNotePosition(db, newPrefix + row.path.slice(oldPrefix.length), nextFolder, row.position)
+    }
+  })
+}
+
+/**
+ * Drop a deleted folder's row and everything beneath it.
+ *
+ * Left behind, those rows are inherited by whatever is created at the same path
+ * later — a new folder of the same name would open holding a stranger's order.
+ */
+export function dropFolderPositions(db: DataDb, folderPath: string): void {
+  const prefix = `${folderPath}/`
+  const stale = getAllNotePositions(db).filter(
+    (row) => row.path === folderPath || row.path.startsWith(prefix)
+  )
+  if (stale.length === 0) return
+
+  db.transaction(() => {
+    for (const row of stale) {
+      deleteNotePosition(db, row.path)
+    }
+  })
 }

--- a/apps/desktop/src/main/vault/notes-crud-positions.test.ts
+++ b/apps/desktop/src/main/vault/notes-crud-positions.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Sidebar order across a note's lifecycle — #1646.
+ *
+ * The vault is mocked away; the data DB is real. What is under test is the
+ * wiring: that `createNote`, `deleteNote` and the folder calls reach the
+ * position table at all. The policy those calls carry out is covered
+ * exhaustively in `database/queries/note-positions.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import type { DataDb } from '@main/database/types'
+import {
+  getAllNotePositions,
+  getNotesInFolder,
+  reorderNotesInFolder,
+  setNotePosition
+} from '@main/database/queries/note-positions'
+
+const mocks = vi.hoisted(() => ({
+  getDatabase: vi.fn(),
+  getNoteCacheById: vi.fn(),
+  rm: vi.fn(),
+  rename: vi.fn()
+}))
+
+vi.mock('fs/promises', () => ({
+  default: { rm: mocks.rm, rename: mocks.rename },
+  rm: mocks.rm,
+  rename: mocks.rename
+}))
+
+vi.mock('@main/database/queries/notes', () => ({
+  getNoteCacheById: mocks.getNoteCacheById,
+  getNoteCacheByPath: vi.fn(),
+  getNoteTags: vi.fn(() => []),
+  ensureTagDefinitions: vi.fn(),
+  getNotePropertiesAsRecord: vi.fn(() => ({})),
+  resolveNoteByTitle: vi.fn()
+}))
+
+vi.mock('./file-ops', () => ({
+  atomicWrite: vi.fn(),
+  safeRead: vi.fn(),
+  deleteFile: vi.fn(),
+  ensureDirectory: vi.fn(),
+  listDirectories: vi.fn(() => []),
+  generateNotePath: (dir: string, title: string, folder?: string) =>
+    folder ? `${dir}/${folder}/${title}.md` : `${dir}/${title}.md`,
+  generateUniquePath: (candidate: string) => candidate
+}))
+
+vi.mock('./notes-io', () => ({
+  emitNoteEvent: vi.fn(),
+  getDefaultNoteDir: vi.fn(() => '/vault'),
+  getVaultRoot: vi.fn(() => '/vault'),
+  toAbsolutePath: (relative: string) => `/vault/${relative}`,
+  toRelativePath: (absolute: string) => absolute.replace('/vault/', '')
+}))
+
+vi.mock('../database', () => ({
+  getDatabase: mocks.getDatabase,
+  getIndexDatabase: vi.fn(() => ({}))
+}))
+vi.mock('./note-sync', () => ({
+  syncNoteToCache: vi.fn(() => ({ wordCount: 0 })),
+  deleteNoteFromCache: vi.fn()
+}))
+vi.mock('./notes-queries', () => ({ noteToListItem: vi.fn(() => ({})) }))
+vi.mock('./notes-versions', () => ({ maybeCreateSignificantSnapshot: vi.fn() }))
+vi.mock('./folders', () => ({ readFolderConfig: vi.fn(), getFolderTemplate: vi.fn(() => null) }))
+vi.mock('./index', () => ({ getStatus: vi.fn(), getConfig: vi.fn(() => ({})) }))
+vi.mock('./templates', () => ({ getTemplate: vi.fn(() => null), applyTemplate: vi.fn() }))
+vi.mock('../telemetry/diagnostics', () => ({ trackMainLog: vi.fn() }))
+vi.mock('../sync/crdt-writeback', () => ({ hasPendingWriteback: vi.fn(() => false) }))
+vi.mock('../tasks/reconcile-markdown-tasks', () => ({
+  reconcileTaskCheckboxesFromMarkdown: vi.fn(async () => undefined)
+}))
+vi.mock('../notes/note-date-reminders', () => ({
+  syncNoteDateReminders: vi.fn(),
+  clearNoteDateReminders: vi.fn()
+}))
+vi.mock('../sync/local-mutations', () => ({
+  enqueueLocalSyncCreate: vi.fn(),
+  enqueueLocalSyncDelete: vi.fn(),
+  enqueueLocalSyncUpdate: vi.fn()
+}))
+
+import { createFolder, createNote, deleteFolder, deleteNote, renameFolder } from './notes-crud'
+
+describe('sidebar order across the note lifecycle (#1646)', () => {
+  let testDb: TestDatabaseResult
+  let db: DataDb
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    testDb = createTestDataDb()
+    db = testDb.db as unknown as DataDb
+    mocks.getDatabase.mockReturnValue(db)
+  })
+
+  afterEach(() => {
+    testDb.close()
+  })
+
+  it('creates a note above everything in a hand-ordered folder', async () => {
+    // #given a folder the user dragged into order
+    reorderNotesInFolder(db, 'Work', ['Work/a.md', 'Work/b.md'])
+
+    // #when a note is created in it
+    await createNote({ title: 'Untitled', folder: 'Work' })
+
+    // #then it leads the folder rather than sinking below both
+    expect(getNotesInFolder(db, 'Work').map((n) => n.path)).toEqual([
+      'Work/Untitled.md',
+      'Work/a.md',
+      'Work/b.md'
+    ])
+  })
+
+  it('leaves an untouched vault with no position rows at all', async () => {
+    // #given a vault nobody has ever reordered
+    // #when notes are created at the root and in a folder
+    await createNote({ title: 'Untitled' })
+    await createNote({ title: 'Second', folder: 'Work' })
+
+    // #then nothing is written: implicit newest-first order still governs, and
+    // freezing it here would be an upgrade that moves somebody's sidebar
+    expect(getAllNotePositions(db)).toEqual([])
+  })
+
+  it('creates a folder above everything in a hand-ordered parent', async () => {
+    reorderNotesInFolder(db, '', ['Alpha', 'Beta'])
+
+    await createFolder('Untitled Folder')
+
+    expect(getNotesInFolder(db, '').map((n) => n.path)).toEqual([
+      'Untitled Folder',
+      'Alpha',
+      'Beta'
+    ])
+  })
+
+  it('drops a deleted note row so the next note at that path cannot inherit it', async () => {
+    reorderNotesInFolder(db, 'Work', ['Work/Untitled.md', 'Work/a.md'])
+    mocks.getNoteCacheById.mockReturnValue({
+      id: 'note-1',
+      path: 'Work/Untitled.md',
+      title: 'Untitled',
+      fileType: 'markdown'
+    })
+
+    await deleteNote('note-1')
+
+    expect(getAllNotePositions(db).map((r) => r.path)).toEqual(['Work/a.md'])
+  })
+
+  it('carries a renamed folder and its contents to the new path', async () => {
+    setNotePosition(db, 'Work', '', 0)
+    setNotePosition(db, 'Work/a.md', 'Work', 0)
+
+    await renameFolder('Work', 'Projects')
+
+    expect(
+      getAllNotePositions(db)
+        .map((r) => r.path)
+        .sort()
+    ).toEqual(['Projects', 'Projects/a.md'])
+  })
+
+  it('drops a deleted folder and everything under it', async () => {
+    setNotePosition(db, 'Work', '', 0)
+    setNotePosition(db, 'Work/a.md', 'Work', 0)
+    setNotePosition(db, 'Other/a.md', 'Other', 0)
+
+    await deleteFolder('Work')
+
+    expect(getAllNotePositions(db).map((r) => r.path)).toEqual(['Other/a.md'])
+  })
+})

--- a/apps/desktop/src/main/vault/notes-crud.ts
+++ b/apps/desktop/src/main/vault/notes-crud.ts
@@ -41,6 +41,12 @@ import {
 } from '@main/database/queries/notes'
 import { folderConfigs } from '@memry/db-schema/schema/folder-configs'
 import { inboxItems } from '@memry/db-schema/schema/inbox'
+import {
+  deleteNotePosition,
+  dropFolderPositions,
+  carryFolderPositions,
+  placeNewItemAtTop
+} from '@main/database/queries/note-positions'
 import { getDatabase, getIndexDatabase } from '../database'
 import { NoteError, NoteErrorCode } from '../lib/errors'
 import { generateNoteId } from '../lib/id'
@@ -311,6 +317,10 @@ export async function createNote(input: NoteCreateInput): Promise<Note> {
   )
 
   ensureTagDefinitions(dataDb, mergedTags)
+
+  // Sidebar order. Derived from the path the note actually landed at, not from
+  // `input.folder`, because an unplaced note lands under `defaultNoteFolder`.
+  placeNewItemAtTop(dataDb, relativePath, path.posix.dirname(relativePath).replace(/^\.$/, ''))
 
   const note: Note = {
     id: noteId,
@@ -787,6 +797,7 @@ export async function deleteNote(id: string): Promise<void> {
   await deleteFile(absolutePath)
 
   deleteNoteFromCache(db, id)
+  deleteNotePosition(getDatabase(), cached.path)
 
   emitNoteEvent(NotesChannels.events.DELETED, {
     id,
@@ -844,6 +855,8 @@ export async function createFolder(folderPath: string): Promise<void> {
   const notesDir = getVaultRoot()
   const absolutePath = path.join(notesDir, folderPath)
   await ensureDirectory(absolutePath)
+
+  placeNewItemAtTop(getDatabase(), folderPath, path.posix.dirname(folderPath).replace(/^\.$/, ''))
 }
 
 export async function renameFolder(oldPath: string, newPath: string): Promise<void> {
@@ -853,6 +866,8 @@ export async function renameFolder(oldPath: string, newPath: string): Promise<vo
 
   const { rename } = await import('fs/promises')
   await rename(oldAbsPath, newAbsPath)
+
+  carryFolderPositions(getDatabase(), oldPath, newPath)
 }
 
 export async function deleteFolder(folderPath: string): Promise<void> {
@@ -861,6 +876,8 @@ export async function deleteFolder(folderPath: string): Promise<void> {
 
   const { rm } = await import('fs/promises')
   await rm(absPath, { recursive: true, force: true })
+
+  dropFolderPositions(getDatabase(), folderPath)
 }
 
 // ============================================================================

--- a/apps/desktop/src/main/vault/notes-rename-positions.test.ts
+++ b/apps/desktop/src/main/vault/notes-rename-positions.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Sidebar order across a rename and a move — #1646.
+ *
+ * Position rows are keyed by path, and both operations rewrite the path. The
+ * rename case is the one users meet constantly: every new note opens with its
+ * rename input focused, so a note that loses its row on rename is a note that
+ * jumps to the bottom seconds after it was placed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import type { DataDb } from '@main/database/types'
+import {
+  getAllNotePositions,
+  getNotePosition,
+  getNotesInFolder,
+  reorderNotesInFolder
+} from '@main/database/queries/note-positions'
+
+const mocks = vi.hoisted(() => ({
+  getDatabase: vi.fn(),
+  getNoteById: vi.fn(),
+  rename: vi.fn()
+}))
+
+vi.mock('fs/promises', () => ({
+  default: { rename: mocks.rename },
+  rename: mocks.rename
+}))
+
+vi.mock('./notes-crud', () => ({ getNoteById: mocks.getNoteById }))
+vi.mock('@main/database/queries/notes', () => ({ getNoteCacheById: vi.fn(() => undefined) }))
+vi.mock('../database', () => ({
+  getDatabase: mocks.getDatabase,
+  getIndexDatabase: vi.fn(() => ({}))
+}))
+vi.mock('./file-ops', () => ({
+  ensureDirectory: vi.fn(),
+  sanitizeFilename: (name: string) => name,
+  generateUniquePath: (candidate: string) => candidate,
+  safeRead: vi.fn(async () => ''),
+  atomicWrite: vi.fn()
+}))
+vi.mock('./notes-io', () => ({
+  emitNoteEvent: vi.fn(),
+  getVaultRoot: vi.fn(() => '/vault'),
+  toAbsolutePath: (relative: string) => `/vault/${relative}`,
+  toRelativePath: (absolute: string) => absolute.replace('/vault/', '')
+}))
+vi.mock('./note-sync', () => ({ syncNoteToCache: vi.fn(), syncFileToCache: vi.fn() }))
+vi.mock('./frontmatter', () => ({
+  parseNote: vi.fn(() => ({ frontmatter: {}, content: '' }))
+}))
+vi.mock('./rewrite-note-refs', () => ({ rewriteNoteRefsForMove: vi.fn(() => null) }))
+vi.mock('../sync/crdt-feed', () => ({ replaceNoteBodyInCrdt: vi.fn() }))
+vi.mock('../sync/crdt-writeback', () => ({ markWritebackIgnored: vi.fn() }))
+vi.mock('@memry/storage-data', () => ({ updateNoteMetadata: vi.fn() }))
+
+import { moveNote, renameNote } from './notes-rename'
+
+const noteAt = (path: string) => ({
+  id: 'note-1',
+  path,
+  title: path.split('/').pop()!.replace(/\.md$/, ''),
+  content: '',
+  frontmatter: {},
+  created: new Date('2026-08-20T00:00:00.000Z'),
+  modified: new Date('2026-08-20T00:00:00.000Z'),
+  tags: [],
+  aliases: [],
+  wordCount: 0,
+  properties: {},
+  emoji: null
+})
+
+describe('sidebar order across rename and move (#1646)', () => {
+  let testDb: TestDatabaseResult
+  let db: DataDb
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    testDb = createTestDataDb()
+    db = testDb.db as unknown as DataDb
+    mocks.getDatabase.mockReturnValue(db)
+  })
+
+  afterEach(() => {
+    testDb.close()
+  })
+
+  it('keeps a renamed note in its slot', async () => {
+    // #given a new note holding the top of a hand-ordered folder
+    reorderNotesInFolder(db, 'Work', ['Work/Untitled.md', 'Work/a.md', 'Work/b.md'])
+    mocks.getNoteById.mockResolvedValue(noteAt('Work/Untitled.md'))
+
+    // #when the rename that opened with it is committed
+    await renameNote('note-1', 'Q3 plan')
+
+    // #then the row followed the path and the row-less fallback never applies
+    expect(getNotesInFolder(db, 'Work').map((n) => n.path)).toEqual([
+      'Work/Q3 plan.md',
+      'Work/a.md',
+      'Work/b.md'
+    ])
+  })
+
+  it('invents no position when renaming inside a folder nobody ordered', async () => {
+    mocks.getNoteById.mockResolvedValue(noteAt('Work/Untitled.md'))
+
+    await renameNote('note-1', 'Q3 plan')
+
+    expect(getAllNotePositions(db)).toEqual([])
+  })
+
+  it('moves a note to the top of its new folder and abandons the old row', async () => {
+    reorderNotesInFolder(db, 'Work', ['Work/a.md'])
+    reorderNotesInFolder(db, 'Archive', ['Archive/x.md', 'Archive/y.md'])
+    mocks.getNoteById.mockResolvedValue(noteAt('Work/a.md'))
+
+    await moveNote('note-1', 'Archive')
+
+    expect(getNotePosition(db, 'Work/a.md')).toBeUndefined()
+    expect(getNotesInFolder(db, 'Archive').map((n) => n.path)).toEqual([
+      'Archive/a.md',
+      'Archive/x.md',
+      'Archive/y.md'
+    ])
+  })
+})

--- a/apps/desktop/src/main/vault/notes-rename.ts
+++ b/apps/desktop/src/main/vault/notes-rename.ts
@@ -26,6 +26,11 @@ import { rewriteNoteRefsForMove } from './rewrite-note-refs'
 import { replaceNoteBodyInCrdt } from '../sync/crdt-feed'
 import { markWritebackIgnored } from '../sync/crdt-writeback'
 import { getNoteCacheById } from '@main/database/queries/notes'
+import {
+  carryPositionToPath,
+  deleteNotePosition,
+  placeNewItemAtTop
+} from '@main/database/queries/note-positions'
 import { getDatabase, getIndexDatabase } from '../database'
 import { NoteError, NoteErrorCode } from '../lib/errors'
 import { NotesChannels } from '@memry/contracts/notes-api'
@@ -98,6 +103,11 @@ export async function renameNote(id: string, newTitle: string): Promise<Note> {
       { isNew: false }
     )
   }
+
+  // Position rows are keyed by path, so the rename that follows every "new
+  // note" would otherwise drop the row this note was just given and send it
+  // back to the bottom of a hand-ordered folder (#1646).
+  carryPositionToPath(getDatabase(), existing.path, newRelativePath)
 
   const note: Note = {
     ...existing,
@@ -208,6 +218,17 @@ export async function moveNote(id: string, newFolder: string): Promise<Note> {
       await replaceNoteBodyInCrdt(id, parsed.content)
     }
   }
+
+  // The old row can never be reached again — it is keyed by a path nothing
+  // holds now — and leaving it would hand its slot to the next note created
+  // there. The note takes the top of its new folder, same as a fresh one.
+  const dataDb = getDatabase()
+  deleteNotePosition(dataDb, existing.path)
+  placeNewItemAtTop(
+    dataDb,
+    newRelativePath,
+    path.posix.dirname(newRelativePath).replace(/^\.$/, '')
+  )
 
   const note: Note = {
     ...existing,

--- a/apps/desktop/src/renderer/src/components/notes-tree-sort.test.ts
+++ b/apps/desktop/src/renderer/src/components/notes-tree-sort.test.ts
@@ -158,3 +158,49 @@ describe('buildTreeFromNotes backward compatibility', () => {
     expect(titles(byName.rootNotes)).toEqual(['Gamma', 'Beta', 'alpha'])
   })
 })
+
+describe('new items in a hand-ordered vault (#1646)', () => {
+  const HAND_ORDERED = { 'Beta.md': 0, 'Gamma.md': 1, 'alpha.md': 2, Zeta: 0, apple: 1, Mango: 2 }
+
+  // The half of the bug that lives in the renderer: a missing row reads as
+  // MAX_SAFE_INTEGER, so anything without one sorts under everything the user
+  // ever dragged. Main answers it by writing a row at creation — this test is
+  // the tripwire for the day someone removes that write.
+  it('sorts an item with no stored position under every positioned sibling', () => {
+    const fresh = note('Untitled.md', '2026-03-01', '2026-03-01')
+    const tree = buildTreeFromNotes(
+      [...NOTES, fresh],
+      [...FOLDERS, { path: 'Untitled Folder' }],
+      HAND_ORDERED
+    )
+
+    expect(titles(tree.rootNotes).at(-1)).toBe('Untitled')
+    expect(names(tree.folders).at(-1)).toBe('Untitled Folder')
+  })
+
+  // What main now writes: `min - 1`, which is negative as soon as a hand-ordered
+  // folder starts at 0. Nothing in the tree may clamp that to zero.
+  it('leads the list once main gives the new item the slot above the top one', () => {
+    const fresh = note('Untitled.md', '2026-03-01', '2026-03-01')
+    const positions = { ...HAND_ORDERED, 'Untitled.md': -1, 'Untitled Folder': -1 }
+    const tree = buildTreeFromNotes(
+      [...NOTES, fresh],
+      [...FOLDERS, { path: 'Untitled Folder' }],
+      positions
+    )
+
+    expect(titles(tree.rootNotes)).toEqual(['Untitled', 'Beta', 'Gamma', 'alpha'])
+    expect(names(tree.folders)).toEqual(['Untitled Folder', 'Zeta', 'apple', 'Mango'])
+  })
+
+  // The rename that opens with every new note renames the row's key too, which
+  // is why main carries the position across the path change. Same slot, new
+  // path: the row must still be the one the tree reads.
+  it('holds the slot when the new note is renamed', () => {
+    const renamed = note('Q3 plan.md', '2026-03-01', '2026-03-01')
+    const positions = { ...HAND_ORDERED, 'Q3 plan.md': -1 }
+    const tree = buildTreeFromNotes([...NOTES, renamed], FOLDERS, positions)
+
+    expect(titles(tree.rootNotes)).toEqual(['Q3 plan', 'Beta', 'Gamma', 'alpha'])
+  })
+})

--- a/apps/docs/src/guide/tour.md
+++ b/apps/docs/src/guide/tour.md
@@ -24,7 +24,7 @@ Sections from top to bottom:
 
 Drag any section item to reorder, or right-click for a context menu.
 
-Inside the **Notes** tree, drag a note or folder to move it. Where you drop on a row decides what happens: the top and bottom edges reorder around that row, while the middle of a folder row drops the item **into** that folder. An empty folder takes a drop the same as a full one, so a folder you just created is ready to receive notes immediately. Notes hold no children, so dropping on a note always reorders. Reordering applies while the section is in **Manual** sort — see below; dropping *into* a folder works whatever the sort.
+Inside the **Notes** tree, drag a note or folder to move it. Where you drop on a row decides what happens: the top and bottom edges reorder around that row, while the middle of a folder row drops the item **into** that folder. An empty folder takes a drop the same as a full one, so a folder you just created is ready to receive notes immediately. Notes hold no children, so dropping on a note always reorders. Reordering applies while the section is in **Manual** sort — see below; dropping _into_ a folder works whatever the sort.
 
 ### Sorting a section
 
@@ -45,10 +45,17 @@ Two things follow from picking a mode:
 
 - **Drag-to-reorder only applies in Manual.** In any other mode the list is
   derived from the items themselves, so a position you dragged would be
-  re-sorted straight over. Dragging an item into a *folder* or *project* still
+  re-sorted straight over. Dragging an item into a _folder_ or _project_ still
   works in every mode — that is a move, not a reorder.
 - **Your manual order is kept.** Switching to Name or Modified and back to
   Manual restores the arrangement you made; it is stored, not recomputed.
+
+In Manual sort, a note or folder you create appears **at the top of the folder
+you created it in**, above everything you have arranged there — not at the
+bottom of the list. Naming it does not move it again, and neither does renaming
+a folder: the whole folder keeps its arrangement, and so does everything inside
+it. A folder you have never dragged is not affected; it keeps ordering itself
+(notes newest first, folders A → Z) until you arrange it yourself.
 
 Sort modes are saved per vault and sync, so another device that opens the same
 vault shows the same order. Each section syncs independently — changing


### PR DESCRIPTION
Closes #1646.

## The bug

Sidebar order lives in the `note_positions` table, keyed by path, and the only thing that ever wrote to it was drag-to-reorder. `notes-tree-sort.ts` reads a missing row as `Number.MAX_SAFE_INTEGER`, so once a folder had been arranged by hand, **every note and folder created in it afterwards sorted below everything the user had ever dragged** — the bottom of the list, every time. That is the report verbatim: "jumps down to the very bottom of the list, so then I'm spending time trying to reorder it several times."

Renaming made it worse, and explains the "several times" part. A rename rewrites the path the row is keyed by, and nothing carried the row across — so a note dropped whatever slot it had the moment it was named. Every new note opens straight into its rename input, so a note placed correctly would still fall to the bottom seconds later. The same held for folders: renaming one orphaned its own row *and* every row beneath it.

`setNotePosition`, `deleteNotePosition`, `moveNoteToFolder`, `insertNoteAtPosition` and `getNextPositionInFolder` all existed for exactly this and had no callers outside their own module.

## The fix

Positions now follow an item through its whole life, in main, at the DB layer:

- **create** — the new note or folder takes `min - 1`, the slot above every positioned sibling.
- **rename** — the row is carried to the new path, same folder, same slot.
- **folder rename** — the folder's own row plus every row beneath it are re-keyed, and the folder's parent is re-derived from the new path so drag-to-another-parent works too.
- **move** — the note takes the top of its destination and the old row is dropped.
- **delete** (note and folder) — rows are dropped.

The last two matter beyond tidiness: a row left under a dead path is inherited by whatever is created at that path next, which is its own way of landing a new note somewhere unexplained.

### What is deliberately left alone

**A folder nobody has ordered gets no row written.** It keeps running on the tree's implicit order — notes newest-first, folders A → Z — where the newest note already leads. Writing a row there would freeze that order permanently, and `notes-tree-sort.ts` exists on the premise that an upgrade moves nobody's list. `leaves an untouched vault with no position rows at all` is the test that holds this.

Notes and folders share one position namespace per parent, so "has this folder been ordered?" is judged per parent, not per kind. Called out in the function comment.

### The one issue checkbox not done

> İki eşitlik bozucuyu tek kurala indir

Not done, and I do not think it should be. The two tiebreaks apply to different entity kinds and only ever to items with no position — after this change, the reported scenario never reaches them. Unifying means one of two things: sorting notes A→Z in Manual mode, which reorders every existing user's sidebar, or sorting folders by time, which is impossible since `FolderInfo` is `{ path, icon }` and carries no timestamp at all. `notes-tree-sort.ts:56-63` already documents the current split as the deliberate price of reproducing the pre-sort-mode tree.

## Tests

- `note-positions.test.ts` — 18 new cases over the four new query functions: placement in an ordered folder, silence in an unordered one, stale-row clearing, repeated creations stacking, rename carry, folder-subtree carry with parent re-derivation, subtree drop, and the `Work` / `Workspace` prefix-sibling guard on both sweeps.
- `notes-crud-positions.test.ts`, `notes-rename-positions.test.ts` — new. Vault mocked, **data DB real**, so these run the real SQL through the real call sites: create, rename, move, delete, folder create/rename/delete.
- `notes-tree-sort.test.ts` — the renderer half: a row-less item still sorts last (the tripwire for anyone removing the write), `min - 1` leads the list and is not clamped at zero, and a renamed note holds its slot.

Mutation-checked, all four caught: `min - 1` → `min + 1` (4 fail), dropping the `carryPositionToPath` call (1 fail), dropping the `placeNewItemAtTop` call (1 fail), and losing the `/` from the folder prefix guard (2 fail).

The issue asks for a run on both sides of the virtualization threshold. Both trees consume the same `tree` prop from one `buildTreeFromNotes` — ordering is shared, not duplicated — so a single sort-level test covers both renderers.

## Verification

- `pnpm typecheck` — clean. Note that `note-positions.test.ts` sits in the `tsconfig.test.*` exclude backlog; the two new test files do **not**, and compile.
- `pnpm lint` — 0 errors, no warnings in touched files.
- `pnpm test:main` — 7212 passed, 554 files.
- `pnpm test:renderer` — 7822 passed, 654 files.
- `pnpm check:architecture`, `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build`, `git diff --check` — all clean.

## Compatibility

No schema change; the existing `note_positions` table is used as designed. Nothing backfills, so an existing vault sees no movement until the user creates or renames something, and an unordered folder never gains a row. `min - 1` goes negative, which the column and the comparator both take.