### PR TITLE
feat(tabs): apply the open-in-new-tab preference to every surface (#1644)

### DIFF
--- a/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
@@ -238,7 +238,9 @@ vi.mock('@/contexts/selected-folder-context', () => ({
 }))
 
 vi.mock('@/hooks/use-general-settings', () => ({
-  useGeneralSettings: () => ({ settings: { createInSelectedFolder: true } })
+  useGeneralSettings: () => ({
+    settings: { createInSelectedFolder: true, openPagesInNewTab: true }
+  })
 }))
 
 vi.mock('@/hooks/use-sidebar-navigation', () => ({

--- a/apps/desktop/src/renderer/src/components/app-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.tsx
@@ -50,11 +50,11 @@ import { NewItemMenuItems } from '@/components/tabs/new-item-menu-items'
 import { useSelectedFolder } from '@/contexts/selected-folder-context'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
+import { useOpenPage } from '@/hooks/use-open-target'
 import type { OpenSidebarItemOptions } from '@/hooks/use-sidebar-navigation'
 import { useFeatureFlags } from '@/hooks/use-feature-flags'
 import { useKeyboardShortcuts, type KeyboardShortcut } from '@/hooks/use-keyboard-shortcuts-base'
 import { useModifierHeld } from '@/hooks/use-modifier-held'
-import { useTabActions } from '@/contexts/tabs'
 import { newItemViewState } from '@/contexts/tabs/helpers'
 import { useSettingsModal } from '@/contexts/settings-modal-context'
 import { notesService } from '@/services/notes-service'
@@ -178,13 +178,15 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
 
   // Tab navigation hook
   const { openSidebarItem, isActiveItem } = useSidebarNavigation()
+  // Plain opens/creations honour the "clicking a page opens a new tab"
+  // preference (#1644); openSidebarItem carries it internally for its rows.
+  const { openPage } = useOpenPage()
   const { isEnabled } = useFeatureFlags()
 
   // First-launch interactive tour (runs once per install)
   useFirstRunTour()
 
   // Tab actions for opening new notes (stable reference, won't cause re-renders)
-  const { openTab } = useTabActions()
 
   const { settings: generalSettings } = useGeneralSettings()
 
@@ -200,7 +202,7 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
       })
 
       if (result.success && result.note) {
-        openTab({
+        openPage({
           type: 'note',
           title: result.note.title || 'Untitled Note',
           icon: 'file-text',
@@ -224,7 +226,7 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
         )
       )
     }
-  }, [openTab, generalSettings.createInSelectedFolder])
+  }, [openPage, generalSettings.createInSelectedFolder])
 
   // Open a top-level section as a tab. Shared by sidebar clicks and the
   // ⌘/Ctrl+number shortcuts so both land the user in exactly the same state.
@@ -271,9 +273,9 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
   const handleNavClick = (page: AppPage) => (e: React.MouseEvent) => {
     e.preventDefault()
     // ⌘/Ctrl-click asks for a second tab, +Shift asks for it without focus.
-    // Nav pages are singletons, so openSidebarItem declines to duplicate them and
-    // focuses the one that exists — the modifiers still matter for the pages that
-    // are not singletons, and the gesture stays consistent across the sidebar.
+    // Since #1644 that holds for the singleton nav pages too: an explicit
+    // gesture mints a real second Home/Inbox/… instead of being downgraded to
+    // "focus the one that exists".
     const inNewTab = e.metaKey || e.ctrlKey
     navigateToPage(page, { inNewTab, inBackground: e.shiftKey && inNewTab })
   }
@@ -319,7 +321,7 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
     (bookmark: BookmarkWithItem) => {
       // Folders open as a folder-view tab; tags open the tag tab.
       if (bookmark.itemType === BookmarkItemTypes.FOLDER) {
-        openTab({
+        openPage({
           type: 'folder',
           title: bookmark.itemTitle || 'Folder',
           icon: 'folder',
@@ -362,13 +364,13 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
       }
       openSidebarItem(item)
     },
-    [openSidebarItem, openTab]
+    [openSidebarItem, openPage]
   )
 
   // Open a canvas in a tab (entityId dedupe keeps it to one tab per canvas)
   const handleCanvasOpen = useCallback(
     (canvas: Pick<CanvasSummary, 'id' | 'title'>) => {
-      openTab({
+      openPage({
         type: 'canvas',
         title: canvas.title || tPhaseF('canvas.untitled'),
         icon: 'pen-tool',
@@ -380,7 +382,7 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
         isDeleted: false
       })
     },
-    [openTab, tPhaseF]
+    [openPage, tPhaseF]
   )
 
   // The canvas tree reports where the user is looking; the section header's `+`

--- a/apps/desktop/src/renderer/src/components/note-sidebar-surfaces.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note-sidebar-surfaces.test.tsx
@@ -31,6 +31,13 @@ const mocks = vi.hoisted(() => ({
   }
 }))
 
+// The row-level middle-click / preference hooks reach useTabActions, which
+// these renders have no TabProvider for — stub the whole open-target module.
+vi.mock('@/hooks/use-open-target', () => ({
+  useOpenTarget: () => ({ openInNewTab: vi.fn(), openToTheSide: vi.fn() }),
+  useOpenPage: () => ({ openPage: vi.fn(), reuseActiveTab: false })
+}))
+
 vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({
     t: (key: string) => key

--- a/apps/desktop/src/renderer/src/components/notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree.tsx
@@ -65,6 +65,7 @@ import { ContextMenuItem, ContextMenuSeparator } from '@/components/ui/context-m
 import { BookmarkMenuItem } from '@/components/sidebar/bookmark-menu-item'
 import { OpenTargetMenuItems } from '@/components/sidebar/open-target-menu-items'
 import { noteTabData, folderTabData } from '@/lib/sidebar-tab-data'
+import { useOpenTarget } from '@/hooks/use-open-target'
 import { shouldVirtualize } from '@/lib/virtualized-tree-utils'
 import {
   VirtualizedNotesTree,
@@ -109,6 +110,18 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
   const treeActionsRef = useRef<TreeActionsHandle | null>(null)
   const virtualTreeActionsRef = useRef<VirtualizedTreeActions | null>(null)
   const isTreeFocusedRef = useRef(false)
+
+  // Middle-click opens rows in a background tab — read on mousedown because a
+  // middle click never produces `click`. Always a genuinely new tab.
+  const { openInNewTab } = useOpenTarget()
+  const middleClickOpen = useCallback(
+    (tab: Parameters<typeof openInNewTab>[0]) => (e: React.MouseEvent) => {
+      if (e.button !== 1) return
+      e.preventDefault()
+      openInNewTab(tab, { background: true })
+    },
+    [openInNewTab]
+  )
 
   const renameCallbackRef = useCallback((el: HTMLInputElement | null) => {
     if (el) {
@@ -325,6 +338,7 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
         <TreeNodeTrigger
           // A file dropped on a note belongs in the folder that note lives in.
           {...{ [FILE_DROP_FOLDER_ATTR]: extractFolderFromPath(note.path) }}
+          onMouseDown={middleClickOpen(noteTabData(note))}
           contextMenuContent={
             <>
               {!isPartOfSelection && (
@@ -449,6 +463,7 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
       >
         <TreeNodeTrigger
           {...{ [FILE_DROP_FOLDER_ATTR]: folder.path }}
+          onMouseDown={middleClickOpen(folderTabData(folder.path, folder.icon))}
           className={cn(
             fileDropFolder === folder.path &&
               'border-2 border-dashed border-primary bg-primary/10 hover:bg-primary/10'

--- a/apps/desktop/src/renderer/src/components/sidebar/canvas-tree/canvas-row.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/canvas-tree/canvas-row.tsx
@@ -47,6 +47,7 @@ import {
 } from './canvas-row-menu'
 import { CanvasRowNameInput, type CanvasRowEdit } from './canvas-row-name-input'
 import { canvasTabData } from '@/lib/sidebar-tab-data'
+import { useOpenTarget } from '@/hooks/use-open-target'
 
 const CANVAS_ICON_SPACER = <div className="h-4 w-4" />
 
@@ -129,6 +130,17 @@ export function CanvasRow({
     kind: 'open-target',
     id: 'open-target',
     tab: canvasTabData(canvas, t('canvas.untitled'))
+  }
+
+  // Middle-click = the row's "Open in New Tab" as a gesture, opening in the
+  // background. Guarded like the plain click: an unreadable canvas cannot open,
+  // and a row being renamed keeps the pointer for its text field. Read on
+  // mousedown because a middle click never produces `click`.
+  const { openInNewTab } = useOpenTarget()
+  const handleMiddleClick = (event: React.MouseEvent): void => {
+    if (event.button !== 1 || unreadable || edit) return
+    event.preventDefault()
+    openInNewTab(canvasTabData(canvas, t('canvas.untitled')), { background: true })
   }
 
   const entries: CanvasMenuEntry[] = unreadable
@@ -246,6 +258,7 @@ export function CanvasRow({
           className="flex items-center gap-1"
           style={{ paddingInlineStart: `${depth * CANVAS_ROW_INDENT_PX}px` }}
           onClick={() => onOpen(canvas)}
+          onMouseDown={handleMiddleClick}
           onKeyDown={handleKeyDown}
           // A row that cannot open must say why before it is clicked, not after.
           title={unreadable ? t('canvas.unreadable') : undefined}

--- a/apps/desktop/src/renderer/src/components/sidebar/canvas-tree/canvas-tree-dnd.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/canvas-tree/canvas-tree-dnd.test.tsx
@@ -39,6 +39,13 @@ const mocks = vi.hoisted(() => ({
   toastError: vi.fn()
 }))
 
+// The row-level middle-click / preference hooks reach useTabActions, which
+// these renders have no TabProvider for — stub the whole open-target module.
+vi.mock('@/hooks/use-open-target', () => ({
+  useOpenTarget: () => ({ openInNewTab: vi.fn(), openToTheSide: vi.fn() }),
+  useOpenPage: () => ({ openPage: vi.fn(), reuseActiveTab: false })
+}))
+
 vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({
     t: (key: string, params?: Record<string, unknown>) => {

--- a/apps/desktop/src/renderer/src/components/sidebar/canvas-tree/canvas-tree.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/canvas-tree/canvas-tree.test.tsx
@@ -35,6 +35,13 @@ const mocks = vi.hoisted(() => ({
 
 // `t` returns the key's last segment so assertions read like the label, and
 // appends the interpolated count so a count-bearing string stays observable.
+// The row-level middle-click / preference hooks reach useTabActions, which
+// these renders have no TabProvider for — stub the whole open-target module.
+vi.mock('@/hooks/use-open-target', () => ({
+  useOpenTarget: () => ({ openInNewTab: vi.fn(), openToTheSide: vi.fn() }),
+  useOpenPage: () => ({ openPage: vi.fn(), reuseActiveTab: false })
+}))
+
 vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({
     t: (key: string, params?: Record<string, unknown>) => {

--- a/apps/desktop/src/renderer/src/components/sidebar/open-target-menu-items.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/open-target-menu-items.tsx
@@ -12,7 +12,7 @@
 
 import { ArrowUpRight, Columns2 } from '@/lib/icons'
 import { ContextMenuItem } from '@/components/ui/context-menu'
-import { useOpenTarget, canOpenInNewTab } from '@/hooks/use-open-target'
+import { useOpenTarget } from '@/hooks/use-open-target'
 import type { OpenTargetTab } from '@/hooks/use-open-target'
 import { useT } from '@memry/i18n/renderer'
 
@@ -42,15 +42,13 @@ export function OpenTargetMenuItems({
 
   return (
     <>
-      {/* Singletons (Home, Inbox, Calendar, …) cannot exist twice, so the row is
-          absent rather than present-and-inert. "Open to the Side" still works:
-          a second pane showing the same singleton is a layout, not a duplicate. */}
-      {canOpenInNewTab(tab.type) && (
-        <Item onClick={() => openInNewTab(tab)}>
-          <ArrowUpRight className="me-2 h-4 w-4" />
-          {t('tree.actions.openInNewTab')}
-        </Item>
-      )}
+      {/* Singletons (Home, Inbox, Calendar, …) used to hide this row; since
+          #1644 an explicit "Open in New Tab" mints a genuine second copy for
+          them too — the command is never inert, so it is never hidden. */}
+      <Item onClick={() => openInNewTab(tab)}>
+        <ArrowUpRight className="me-2 h-4 w-4" />
+        {t('tree.actions.openInNewTab')}
+      </Item>
       <Item onClick={() => openToTheSide(tab)}>
         <Columns2 className="me-2 h-4 w-4" />
         {t('tree.actions.openToTheSide')}

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar-bookmark-list.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar-bookmark-list.tsx
@@ -37,6 +37,7 @@ import { SortableBookmarkItem } from '@/components/sidebar/sortable-bookmark-ite
 import { BOOKMARK_SORT_DRAG_TYPE } from '@/components/sidebar/sidebar-drag-types'
 import { compareListItems, isReorderable } from '@/components/sidebar/sidebar-list-sort'
 import { OpenTargetMenuItems } from '@/components/sidebar/open-target-menu-items'
+import { useOpenTarget } from '@/hooks/use-open-target'
 import { createTabFromSidebarItem } from '@/contexts/tabs/helpers'
 import { useBookmarks, type BookmarkWithItem } from '@/hooks/use-bookmarks'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
@@ -148,6 +149,16 @@ export function SidebarBookmarkList({
     onBookmarkClick?.(bookmark)
   }
 
+  // Middle-click opens the bookmarked item in a background tab — the same tab
+  // the row's "Open in New Tab" menu command builds. Read on mousedown because
+  // a middle click never produces `click`.
+  const { openInNewTab } = useOpenTarget()
+  const handleBookmarkMiddleClick = (item: SidebarItem) => (e: React.MouseEvent) => {
+    if (e.button !== 1) return
+    e.preventDefault()
+    openInNewTab(createTabFromSidebarItem(item), { background: true })
+  }
+
   const handleRemoveBookmark = (bookmark: BookmarkWithItem) => async (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
@@ -213,6 +224,7 @@ export function SidebarBookmarkList({
                   <SidebarMenuButton
                     tooltip={title}
                     onClick={handleBookmarkClick(bookmark)}
+                    onMouseDown={handleBookmarkMiddleClick(sidebarItem)}
                     isActive={isActiveItem(sidebarItem)}
                     className="group pe-8"
                   >

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar-tag-list.contrast.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar-tag-list.contrast.test.tsx
@@ -9,6 +9,13 @@ import { assertSmallTextContrast } from '@tests/utils/contrast'
 // holds to 4.5:1. jsdom has no cascade and no layout, so the ratios come from
 // the literal hex in base.css — see tests/utils/contrast.ts.
 
+// The row-level middle-click / preference hooks reach useTabActions, which
+// these renders have no TabProvider for — stub the whole open-target module.
+vi.mock('@/hooks/use-open-target', () => ({
+  useOpenTarget: () => ({ openInNewTab: vi.fn(), openToTheSide: vi.fn() }),
+  useOpenPage: () => ({ openPage: vi.fn(), reuseActiveTab: false })
+}))
+
 vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({
     t: (key: string, params?: Record<string, unknown>) =>

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar-tag-list.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar-tag-list.test.tsx
@@ -43,6 +43,13 @@ const mocks = vi.hoisted(() => ({
   openSidebarItem: vi.fn()
 }))
 
+// The row-level middle-click / preference hooks reach useTabActions, which
+// these renders have no TabProvider for — stub the whole open-target module.
+vi.mock('@/hooks/use-open-target', () => ({
+  useOpenTarget: () => ({ openInNewTab: vi.fn(), openToTheSide: vi.fn() }),
+  useOpenPage: () => ({ openPage: vi.fn(), reuseActiveTab: false })
+}))
+
 vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({
     t: (key: string, params?: Record<string, unknown>) =>

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar-tag-list.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar-tag-list.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/ui/context-menu'
 import { BookmarkMenuItem } from '@/components/sidebar/bookmark-menu-item'
 import { OpenTargetMenuItems } from '@/components/sidebar/open-target-menu-items'
+import { useOpenTarget } from '@/hooks/use-open-target'
 import { createTabFromSidebarItem } from '@/contexts/tabs/helpers'
 import { useT } from '@memry/i18n/renderer'
 import { SIDEBAR_SORT_DEFAULTS, type SidebarSortMode } from '@memry/contracts/sidebar-sort'
@@ -219,6 +220,24 @@ function TagTreeItem({
     onTagClick(node.fullPath, node.color ?? '')
   }
 
+  // Middle-click opens the tag in a background tab — the row's "Open in New
+  // Tab" as a gesture (mousedown: middle never produces `click`).
+  const { openInNewTab } = useOpenTarget()
+  const handleTagMiddleClick = (e: React.MouseEvent): void => {
+    if (e.button !== 1) return
+    e.preventDefault()
+    openInNewTab(
+      createTabFromSidebarItem({
+        type: 'tag',
+        title: node.name,
+        path: '/tags/' + node.fullPath,
+        entityId: node.fullPath,
+        color: node.color ?? ''
+      }),
+      { background: true }
+    )
+  }
+
   return (
     <>
       <div
@@ -247,6 +266,7 @@ function TagTreeItem({
             <button
               type="button"
               onClick={handleTagClick}
+              onMouseDown={handleTagMiddleClick}
               title={`${node.fullPath} (${node.totalCount})`}
               className={cn(
                 'flex items-center gap-1.5 rounded-sm py-0.5 px-1.5 text-[11px] font-medium leading-3.5 min-w-0',

--- a/apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.test.tsx
@@ -14,6 +14,13 @@ const mocks = vi.hoisted(() => ({
   toastError: vi.fn()
 }))
 
+// The row-level middle-click / preference hooks reach useTabActions, which
+// these renders have no TabProvider for — stub the whole open-target module.
+vi.mock('@/hooks/use-open-target', () => ({
+  useOpenTarget: () => ({ openInNewTab: vi.fn(), openToTheSide: vi.fn() }),
+  useOpenPage: () => ({ openPage: vi.fn(), reuseActiveTab: false })
+}))
+
 vi.mock('sonner', () => ({ toast: { success: mocks.toastSuccess, error: mocks.toastError } }))
 vi.mock('@/services/notes-service', () => ({ notesService: { getFile: mocks.getFile } }))
 vi.mock('@/services/tasks-service', () => ({

--- a/apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.tsx
@@ -16,6 +16,7 @@ import {
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from '@/components/ui/context-menu'
 import { OpenTargetMenuItems } from '@/components/sidebar/open-target-menu-items'
 import { createTabFromSidebarItem } from '@/contexts/tabs/helpers'
+import { useOpenTarget } from '@/hooks/use-open-target'
 import { useOptionalDragContext } from '@/contexts/drag-context'
 import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
 import { extractErrorMessage } from '@/lib/ipc-error'
@@ -147,6 +148,23 @@ export const SortableProjectItem = ({
     [project.id, project.name, tTasks]
   )
 
+  // The same tab the context menu's "Open in New Tab" builds — middle-click is
+  // that command as a gesture, opening in the background (mousedown: middle
+  // never produces `click`).
+  const { openInNewTab } = useOpenTarget()
+  const projectTab = createTabFromSidebarItem({
+    type: 'project',
+    title: project.name,
+    icon: 'folder',
+    path: `/project/${project.id}`,
+    entityId: project.id
+  })
+  const handleMiddleClick = (e: React.MouseEvent): void => {
+    if (e.button !== 1) return
+    e.preventDefault()
+    openInNewTab(projectTab, { background: true })
+  }
+
   return (
     <SidebarMenuItem
       ref={setRefs}
@@ -180,6 +198,7 @@ export const SortableProjectItem = ({
             tooltip={project.name}
             isActive={isActive}
             onClick={onClick}
+            onMouseDown={handleMiddleClick}
             className="h-7 gap-1.5 rounded-[5px] py-0 ps-1"
           >
             {/* Leading block mirrors the tree: expander slot + icon slot */}
@@ -199,15 +218,7 @@ export const SortableProjectItem = ({
           </SidebarMenuButton>
         </ContextMenuTrigger>
         <ContextMenuContent className="w-48">
-          <OpenTargetMenuItems
-            tab={createTabFromSidebarItem({
-              type: 'project',
-              title: project.name,
-              icon: 'folder',
-              path: `/project/${project.id}`,
-              entityId: project.id
-            })}
-          />
+          <OpenTargetMenuItems tab={projectTab} />
         </ContextMenuContent>
       </ContextMenu>
 

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.test.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.test.tsx
@@ -260,8 +260,7 @@ describe('VirtualizedNotesTree', () => {
         entityId: 'note-work',
         isPreview: false,
         type: 'note'
-      }),
-      { reuseActiveTab: false }
+      })
     )
 
     fireEvent.doubleClick(screen.getByText('Alpha'))
@@ -270,8 +269,7 @@ describe('VirtualizedNotesTree', () => {
         entityId: 'note-work',
         isPreview: false,
         type: 'note'
-      }),
-      { reuseActiveTab: false }
+      })
     )
 
     await user.click(screen.getByText('Root'))
@@ -280,8 +278,7 @@ describe('VirtualizedNotesTree', () => {
         entityId: 'note-root',
         isPreview: false,
         type: 'file'
-      }),
-      { reuseActiveTab: false }
+      })
     )
   })
 
@@ -302,6 +299,25 @@ describe('VirtualizedNotesTree', () => {
     expect(mocks.openTab).toHaveBeenLastCalledWith(
       expect.objectContaining({ type: 'folder', entityId: 'Work' }),
       { reuseActiveTab: true }
+    )
+  })
+
+  // Middle-click is an explicit gesture: always a new background tab, even
+  // with the preference set to reuse.
+  it('middle-click opens rows in a background tab regardless of the preference', () => {
+    mocks.openPagesInNewTab = false
+    renderTree()
+
+    fireEvent.mouseDown(screen.getByText('Alpha'), { button: 1 })
+    expect(mocks.openTab).toHaveBeenLastCalledWith(
+      expect.objectContaining({ entityId: 'note-work', type: 'note' }),
+      { forceNew: true, background: true }
+    )
+
+    fireEvent.mouseDown(screen.getByText('Work'), { button: 1 })
+    expect(mocks.openTab).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: 'folder', entityId: 'Work' }),
+      { forceNew: true, background: true }
     )
   })
 
@@ -333,8 +349,7 @@ describe('VirtualizedNotesTree', () => {
       expect.objectContaining({
         type: 'folder',
         entityId: 'Work'
-      }),
-      { reuseActiveTab: false }
+      })
     )
 
     await user.click(screen.getByRole('button', { name: 'folder icon' }))
@@ -440,8 +455,7 @@ describe('VirtualizedNotesTree', () => {
       expect.objectContaining({
         entityId: 'note-work',
         isPreview: false
-      }),
-      { reuseActiveTab: false }
+      })
     )
 
     await user.click(screen.getByRole('button', { name: 'New Note' }))

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
@@ -33,7 +33,6 @@ import {
 import { cn } from '@/lib/utils'
 import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
 import { CANVAS_ITEM_DRAG_MIME, canvasDragPayload } from '@/pages/canvas/canvas-cards'
-import { useTabActions } from '@/contexts/tabs'
 import type { NoteListItem } from '@/hooks/use-notes-query'
 import {
   flattenTree,
@@ -62,7 +61,7 @@ import { FILE_DROP_FOLDER_ATTR } from '@/hooks/use-file-drop'
 import { BookmarkMenuItem } from '@/components/sidebar/bookmark-menu-item'
 import { OpenTargetMenuItems } from '@/components/sidebar/open-target-menu-items'
 import { noteTabData, folderTabData } from '@/lib/sidebar-tab-data'
-import { useGeneralSettings } from '@/hooks/use-general-settings'
+import { useOpenPage, useOpenTarget } from '@/hooks/use-open-target'
 import { resolveDropPosition, type DropPosition } from '@/lib/tree-drop-position'
 import { useT } from '@memry/i18n/renderer'
 
@@ -341,6 +340,7 @@ function FolderRow({
 }: FolderRowProps) {
   const { t } = useT('notes')
   const { t: tCommon } = useT('common')
+  const { openInNewTab } = useOpenTarget()
   const rowRef = useRef<HTMLDivElement>(null)
   const showBulkActions = isSelected && selectedCount > 1
   const showSelectionBadge = showBulkActions && isLastSelected
@@ -356,6 +356,17 @@ function FolderRow({
       onSelect(item.id, e)
     },
     [isBeingRenamed, item.id, onSelect, onToggleExpand]
+  )
+
+  // Middle-click opens the folder view in a background tab — same gesture the
+  // note rows get, read on mousedown because middle never produces `click`.
+  const handleMiddleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button !== 1 || isBeingRenamed) return
+      e.preventDefault()
+      openInNewTab(folderTabData(item.folder.path, item.folder.icon), { background: true })
+    },
+    [isBeingRenamed, item.folder.path, item.folder.icon, openInNewTab]
   )
 
   const _handleExpandClick = useCallback(
@@ -421,6 +432,7 @@ function FolderRow({
           )}
           style={{ paddingLeft: `${item.level * 16 + 8}px` }}
           onClick={handleClick}
+          onMouseDown={handleMiddleClick}
           onKeyDown={handleKeyDown}
           onDragStart={handleDragStart}
           onDragEnd={onDragEnd}
@@ -662,6 +674,7 @@ function NoteRow({
 }: NoteRowProps) {
   const { t } = useT('notes')
   const { t: tCommon } = useT('common')
+  const { openInNewTab } = useOpenTarget()
   const rowRef = useRef<HTMLDivElement>(null)
   const showBulkActions = isSelected && selectedCount > 1
   const showSelectionBadge = showBulkActions && isLastSelected
@@ -675,6 +688,17 @@ function NoteRow({
       onSelect(item.id, e)
     },
     [isBeingRenamed, item.id, onSelect]
+  )
+
+  // Read on mousedown: a middle click never produces a `click` event. Opens in
+  // the background, browser-style, and always as a genuinely new tab.
+  const handleMiddleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button !== 1 || isBeingRenamed) return
+      e.preventDefault()
+      openInNewTab(noteTabData(item.note), { background: true })
+    },
+    [isBeingRenamed, item.note, openInNewTab]
   )
 
   const handleDoubleClick = useCallback(() => {
@@ -726,6 +750,7 @@ function NoteRow({
           )}
           style={{ paddingLeft: `${item.level * 16 + 8}px` }} // Icon button's leading slot replaces the expander gap
           onClick={handleClick}
+          onMouseDown={handleMiddleClick}
           onDoubleClick={handleDoubleClick}
           onKeyDown={handleKeyDown}
           onDragStart={handleDragStart}
@@ -907,11 +932,9 @@ export function VirtualizedNotesTree({
   scrollContainerRef
 }: VirtualizedNotesTreeProps) {
   const { t } = useT('notes')
-  const { openTab } = useTabActions()
   // Same preference the non-virtualized tree honours through useNoteTreeActions'
   // openPage — this tree opens tabs itself, so it has to read it too (#1644).
-  const { settings: generalSettings } = useGeneralSettings()
-  const reuseActiveTab = !generalSettings.openPagesInNewTab
+  const { openPage } = useOpenPage()
   const parentRef = useRef<HTMLDivElement>(null)
   const [scrollMargin, setScrollMargin] = useState(0)
   const usesExternalScroll = !!scrollContainerRef
@@ -1127,28 +1150,28 @@ export function VirtualizedNotesTree({
         if (!isFolder(itemId)) {
           const note = noteMap.get(itemId)
           if (note) {
-            openTab(noteTabData(note), { reuseActiveTab })
+            openPage(noteTabData(note))
           }
         }
       }
     },
-    [selectedIds, onSelectionChange, flatItems, noteMap, openTab, anchorId, reuseActiveTab]
+    [selectedIds, onSelectionChange, flatItems, noteMap, openPage, anchorId]
   )
 
   // Handle note double-click
   const handleNoteDoubleClick = useCallback(
     (note: NoteListItem) => {
-      openTab(noteTabData(note), { reuseActiveTab })
+      openPage(noteTabData(note))
     },
-    [openTab, reuseActiveTab]
+    [openPage]
   )
 
   // Handle opening folder view from hover icon
   const handleOpenFolderView = useCallback(
     (folderPath: string, icon?: string | null) => {
-      openTab(folderTabData(folderPath, icon), { reuseActiveTab })
+      openPage(folderTabData(folderPath, icon))
     },
-    [openTab, reuseActiveTab]
+    [openPage]
   )
 
   // Drag event handlers

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.test.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.test.ts
@@ -120,8 +120,11 @@ describe('tabCrudReducer', () => {
         }
       })
     )
-    expect(replaced.tabGroups.g1.activeTabId).toBe('generated-1')
-    expect(replaced.tabGroups.g1.tabs.map((t) => t.id)).toEqual(['pin', 'generated-1', 'tasks'])
+    // The replaced tab keeps its id — in-place content change, not close+open,
+    // so the strip plays no exit/enter and history entries stay valid.
+    expect(replaced.tabGroups.g1.activeTabId).toBe('note-a')
+    expect(replaced.tabGroups.g1.tabs.map((t) => t.id)).toEqual(['pin', 'note-a', 'tasks'])
+    expect(replaced.tabGroups.g1.tabs[1].entityId).toBe('replacement')
 
     const sameGroupSingleton = tabCrudReducer(
       state,
@@ -226,11 +229,11 @@ describe('tabCrudReducer', () => {
     )
     expect(inserted.tabGroups.g1.tabs.map((t) => t.id)).toEqual([
       'pin',
-      'generated-2',
+      'generated-1',
       'note-a',
       'tasks'
     ])
-    expect(inserted.tabGroups.g1.activeTabId).toBe('generated-2')
+    expect(inserted.tabGroups.g1.activeTabId).toBe('generated-1')
   })
 
   it('normalizes preview opens into permanent tabs without replacing legacy preview tabs', () => {
@@ -581,9 +584,10 @@ describe('tabCrudReducer', () => {
         openAction({ reuseActiveTab: true, tab: newNote })
       )
 
-      // 'note-a' was the active tab; it is gone, replaced in place.
-      expect(next.tabGroups.g1.tabs.map((t) => t.id)).toEqual(['pin', 'generated-1', 'tasks'])
-      expect(next.tabGroups.g1.activeTabId).toBe('generated-1')
+      // 'note-a' was the active tab; its content is replaced in place and the
+      // id survives, so the strip plays no exit/enter for a reuse.
+      expect(next.tabGroups.g1.tabs.map((t) => t.id)).toEqual(['pin', 'note-a', 'tasks'])
+      expect(next.tabGroups.g1.activeTabId).toBe('note-a')
       expect(next.tabGroups.g1.tabs[1].entityId).toBe('fresh')
     })
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
@@ -126,22 +126,26 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
         if (activeTabIndex !== -1) {
           const activeTab = targetGroup.tabs[activeTabIndex]
           if (!activeTab.isPinned) {
+            // KEEPS the active tab's id: this is the same tab changing content,
+            // not a close-plus-open. A fresh id would put the old id through the
+            // strip's exit animation beside the new one entering — two tabs (and
+            // two aria-selected) on screen for the duration — and would strand
+            // the history entries pointing at the old id.
             const newTab: Tab = {
               ...tab,
               isPreview: false,
-              id: generateId(),
+              id: activeTab.id,
               openedAt: Date.now(),
               lastAccessedAt: Date.now()
             }
             const newTabs = [...targetGroup.tabs]
             newTabs[activeTabIndex] = newTab
 
-            const pruned = pruneHistory(targetGroup, new Set([activeTab.id]))
             return {
               ...state,
               tabGroups: {
                 ...state.tabGroups,
-                [groupId]: { ...pruned, tabs: newTabs, activeTabId: newTab.id }
+                [groupId]: { ...targetGroup, tabs: newTabs, activeTabId: newTab.id }
               }
             }
           }
@@ -289,15 +293,17 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
         const activeIndex = targetGroup.tabs.findIndex((t) => t.id === targetGroup.activeTabId)
         const activeTab = activeIndex === -1 ? undefined : targetGroup.tabs[activeIndex]
         if (activeTab && !activeTab.isPinned) {
+          // Same id-preservation as replaceActive above: reuse is this tab
+          // changing content, so the strip must not play a close-plus-open.
+          const reusedTab: Tab = { ...newTab, id: activeTab.id }
           const reusedTabs = [...targetGroup.tabs]
-          reusedTabs[activeIndex] = newTab
+          reusedTabs[activeIndex] = reusedTab
 
-          const pruned = pruneHistory(targetGroup, new Set([activeTab.id]))
           return {
             ...state,
             tabGroups: {
               ...state.tabGroups,
-              [groupId]: { ...pruned, tabs: reusedTabs, activeTabId: newTab.id }
+              [groupId]: { ...targetGroup, tabs: reusedTabs, activeTabId: reusedTab.id }
             },
             activeGroupId: groupId
           }

--- a/apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx
@@ -253,7 +253,7 @@ describe('more major hooks coverage', () => {
     // the reducer free to focus a tab this item already has.
     expect(mocks.openTab).toHaveBeenCalledWith(
       expect.objectContaining({ entityId: 'note-b', isPreview: false }),
-      { background: undefined, forceNew: false }
+      { background: undefined, forceNew: false, reuseActiveTab: false }
     )
 
     result.current.openSidebarItem(
@@ -264,7 +264,7 @@ describe('more major hooks coverage', () => {
     // what makes it skip entity dedup and mint a genuinely new tab.
     expect(mocks.openTab).toHaveBeenCalledWith(
       expect.objectContaining({ entityId: 'note-c', isPreview: false }),
-      { background: true, forceNew: true }
+      { background: true, forceNew: true, reuseActiveTab: false }
     )
 
     result.current.openSidebarItem(

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.test.tsx
@@ -191,8 +191,7 @@ describe('useNoteTreeActions', () => {
         title: 'A',
         path: '/notes/work-a',
         entityId: 'work-a'
-      }),
-      { reuseActiveTab: false }
+      })
     )
 
     act(() => result.current.handleSelectionChange(['other']))
@@ -202,14 +201,12 @@ describe('useNoteTreeActions', () => {
         title: 'C',
         path: '/file/other',
         entityId: 'other'
-      }),
-      { reuseActiveTab: false }
+      })
     )
 
     act(() => result.current.handleOpenFolderView('Work/Nested'))
     expect(mocks.openTab).toHaveBeenLastCalledWith(
-      expect.objectContaining({ type: 'folder', title: 'Nested', path: '/folder/Work%2FNested' }),
-      { reuseActiveTab: false }
+      expect.objectContaining({ type: 'folder', title: 'Nested', path: '/folder/Work%2FNested' })
     )
 
     await act(async () => {

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.ts
@@ -14,6 +14,7 @@ import { revealNoteInSidebar } from '@/lib/reveal-in-sidebar'
 import { toast } from 'sonner'
 import { createLogger } from '@/lib/logger'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
+import { useOpenPage } from '@/hooks/use-open-target'
 import { getTabIconForFileType, type FileType } from '@memry/shared/file-types'
 import {
   getDisplayName,
@@ -53,19 +54,10 @@ export interface NoteTreeActionsDeps {
 
 export function useNoteTreeActions(deps: NoteTreeActionsDeps) {
   const { settings: generalSettings } = useGeneralSettings()
-  const { openTab, closeTab, updateTabTitleByEntityId } = useTabActions()
-
-  // Every plain sidebar open goes through here so the "clicking a page opens a
-  // new tab" preference has one place to live. The explicit gestures — Open in
-  // New Tab, Open to the Side, Cmd-click — go through useOpenTarget and stay
-  // untouched: stated intent always wins over the preference.
-  const openPagesInNewTab = generalSettings.openPagesInNewTab
-  const openPage = useCallback(
-    (tab: Parameters<typeof openTab>[0]) => {
-      openTab(tab, { reuseActiveTab: !openPagesInNewTab })
-    },
-    [openTab, openPagesInNewTab]
-  )
+  const { closeTab, updateTabTitleByEntityId } = useTabActions()
+  // Plain opens and note creation go through openPage so the "clicking a page
+  // opens a new tab" preference applies; explicit gestures keep useOpenTarget.
+  const { openPage } = useOpenPage()
   const queryClient = useQueryClient()
   const originalRenameTitle = useRef<string>('')
 

--- a/apps/desktop/src/renderer/src/hooks/use-open-target.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-open-target.ts
@@ -14,9 +14,9 @@
 
 import { useCallback, useEffect, useRef } from 'react'
 import { useTabActions, useTabs } from '@/contexts/tabs'
-import { SINGLETON_TAB_TYPES } from '@/contexts/tabs/types'
-import type { Tab } from '@/contexts/tabs/types'
+import type { OpenTabOptions, Tab } from '@/contexts/tabs/types'
 import { getSiblingGroupId } from '@/components/split-view/layout-helpers'
+import { useGeneralSettings } from '@/hooks/use-general-settings'
 
 /** Tab data as the callers build it, before the reducer stamps id/timestamps. */
 export type OpenTargetTab = Omit<Tab, 'id' | 'openedAt' | 'lastAccessedAt'>
@@ -27,12 +27,35 @@ export interface OpenTargetOptions {
 }
 
 /**
- * True when this tab type can meaningfully exist twice. Home, Inbox, Calendar,
- * Tasks, Journal, Graph and Tags are declared single-instance, so "Open in New
- * Tab" is a no-op for them — surfaces hide the menu row rather than offer a
- * command that silently does nothing.
+ * The "clicking a page opens a new tab" preference (#1644), as open options.
+ *
+ * `openPage` is what a plain click/activation calls: with the preference on it
+ * behaves exactly like `openTab`; with it off it asks the reducer to reuse the
+ * active tab. The reducer runs that request only after every dedup branch, so a
+ * page that is already open still just gets focused, and it never touches a
+ * pinned tab. Explicit gestures — "Open in New Tab", "Open to the Side",
+ * middle-click — do not go through here: stated intent beats the preference.
  */
-export const canOpenInNewTab = (type: Tab['type']): boolean => !SINGLETON_TAB_TYPES.includes(type)
+export const useOpenPage = () => {
+  const { openTab } = useTabActions()
+  const { settings } = useGeneralSettings()
+  const reuseActiveTab = !settings.openPagesInNewTab
+
+  const openPage = useCallback(
+    (tab: OpenTargetTab, options?: OpenTabOptions) => {
+      // With the preference on and nothing else to say, openPage IS openTab —
+      // no options object, so call sites and their tests read identically.
+      if (!reuseActiveTab && !options) {
+        openTab(tab)
+        return
+      }
+      openTab(tab, { reuseActiveTab, ...options })
+    },
+    [openTab, reuseActiveTab]
+  )
+
+  return { openPage, reuseActiveTab }
+}
 
 export const useOpenTarget = () => {
   const { openTab, splitView } = useTabActions()
@@ -50,11 +73,12 @@ export const useOpenTarget = () => {
    *
    * `forceNew` is what makes this differ from a plain click: without it, OPEN_TAB
    * finds the entity already open — in this pane or another — and just focuses
-   * it. Singletons keep the focus behaviour; they cannot exist twice.
+   * it. That includes singletons: a second Home or Inbox in the same pane is a
+   * deliberate duplicate (#1644), no longer declined.
    */
   const openInNewTab = useCallback(
     (tab: OpenTargetTab, options: OpenTargetOptions = {}) => {
-      openTab(tab, { forceNew: canOpenInNewTab(tab.type), background: options.background })
+      openTab(tab, { forceNew: true, background: options.background })
     },
     [openTab]
   )

--- a/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.reuse.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.reuse.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * #1644 — openSidebarItem under the "clicking a page opens a new tab"
+ * preference, and the singleton un-gating that shipped with it.
+ *
+ * Real reducer + real TabProvider, like the split tests beside this file: the
+ * behaviour under test is which tab the OPEN_TAB action ends up touching, which
+ * stubbed `openTab` mocks cannot see.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { TabProvider, useTabs } from '@/contexts/tabs'
+import type { SidebarItem } from '@/contexts/tabs/types'
+import { SettingsModalProvider } from '@/contexts/settings-modal-context'
+import { FEATURES_SETTINGS_DEFAULTS } from '@memry/contracts/settings-schemas'
+import { renderWithProviders, userEvent } from '@tests/utils/render'
+import { useSidebarNavigation } from './use-sidebar-navigation'
+
+vi.mock('./use-feature-flags', () => ({
+  useFeatureFlags: () => ({ flags: FEATURES_SETTINGS_DEFAULTS })
+}))
+
+const settingsMock = vi.hoisted(() => ({ openPagesInNewTab: true }))
+vi.mock('./use-general-settings', () => ({
+  useGeneralSettings: () => ({
+    settings: { openPagesInNewTab: settingsMock.openPagesInNewTab }
+  })
+}))
+
+const noteItem = (id: string): SidebarItem => ({
+  type: 'note',
+  title: id,
+  path: `/notes/${id}`,
+  entityId: id
+})
+
+const INBOX_ITEM: SidebarItem = { type: 'inbox', title: 'Inbox', path: '/inbox' }
+
+function Probe(): React.JSX.Element {
+  const { openSidebarItem } = useSidebarNavigation()
+  const { state } = useTabs()
+
+  const group = state.tabGroups[state.activeGroupId]
+  const activeTab = group.tabs.find((t) => t.id === group.activeTabId)
+
+  return (
+    <div>
+      <span data-testid="tab-count">{group.tabs.length}</span>
+      <span data-testid="inbox-count">{group.tabs.filter((t) => t.type === 'inbox').length}</span>
+      <span data-testid="active-entity">{activeTab?.entityId ?? activeTab?.type ?? 'none'}</span>
+      <button type="button" onClick={() => openSidebarItem(noteItem('note-a'))}>
+        open-a
+      </button>
+      <button type="button" onClick={() => openSidebarItem(noteItem('note-b'))}>
+        open-b
+      </button>
+      <button type="button" onClick={() => openSidebarItem(INBOX_ITEM)}>
+        open-inbox
+      </button>
+      <button type="button" onClick={() => openSidebarItem(INBOX_ITEM, { inNewTab: true })}>
+        open-inbox-new-tab
+      </button>
+      <button
+        type="button"
+        onClick={() => openSidebarItem(INBOX_ITEM, { inNewTab: true, inBackground: true })}
+      >
+        open-inbox-middle-click
+      </button>
+    </div>
+  )
+}
+
+const renderProbe = (): void => {
+  renderWithProviders(
+    <SettingsModalProvider>
+      <TabProvider>
+        <Probe />
+      </TabProvider>
+    </SettingsModalProvider>
+  )
+}
+
+describe('openSidebarItem under openPagesInNewTab (#1644)', () => {
+  it('reuses the active tab for plain opens when the preference is off', async () => {
+    settingsMock.openPagesInNewTab = false
+    const user = userEvent.setup()
+    renderProbe()
+
+    const startCount = Number(screen.getByTestId('tab-count').textContent)
+
+    await user.click(screen.getByText('open-a'))
+    expect(screen.getByTestId('active-entity').textContent).toBe('note-a')
+    expect(Number(screen.getByTestId('tab-count').textContent)).toBe(startCount)
+
+    // Browsing on replaces in place rather than accumulating.
+    await user.click(screen.getByText('open-b'))
+    expect(screen.getByTestId('active-entity').textContent).toBe('note-b')
+    expect(Number(screen.getByTestId('tab-count').textContent)).toBe(startCount)
+
+    // Reopening a page that is already open focuses it — dedup runs before
+    // reuse, so no tab is destroyed to show a copy of itself.
+    await user.click(screen.getByText('open-b'))
+    expect(Number(screen.getByTestId('tab-count').textContent)).toBe(startCount)
+  })
+
+  it('keeps opening new tabs for plain opens when the preference is on', async () => {
+    settingsMock.openPagesInNewTab = true
+    const user = userEvent.setup()
+    renderProbe()
+
+    const startCount = Number(screen.getByTestId('tab-count').textContent)
+    await user.click(screen.getByText('open-a'))
+    await user.click(screen.getByText('open-b'))
+    expect(Number(screen.getByTestId('tab-count').textContent)).toBe(startCount + 2)
+  })
+
+  it('mints a genuine second copy of a singleton on an explicit new-tab gesture', async () => {
+    settingsMock.openPagesInNewTab = true
+    const user = userEvent.setup()
+    renderProbe()
+
+    await user.click(screen.getByText('open-inbox'))
+    expect(screen.getByTestId('inbox-count').textContent).toBe('1')
+
+    // Plain re-click focuses the existing one — the singleton dedup still holds
+    // for plain clicks.
+    await user.click(screen.getByText('open-inbox'))
+    expect(screen.getByTestId('inbox-count').textContent).toBe('1')
+
+    // The explicit gesture is no longer downgraded to "focus what exists".
+    await user.click(screen.getByText('open-inbox-new-tab'))
+    expect(screen.getByTestId('inbox-count').textContent).toBe('2')
+  })
+
+  it('middle-click opens a background copy without stealing focus', async () => {
+    settingsMock.openPagesInNewTab = true
+    const user = userEvent.setup()
+    renderProbe()
+
+    await user.click(screen.getByText('open-a'))
+    expect(screen.getByTestId('active-entity').textContent).toBe('note-a')
+
+    await user.click(screen.getByText('open-inbox-middle-click'))
+    expect(screen.getByTestId('inbox-count').textContent).toBe('1')
+    // Focus stayed where it was.
+    expect(screen.getByTestId('active-entity').textContent).toBe('note-a')
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.ts
@@ -19,6 +19,7 @@ import { SINGLETON_TAB_TYPES } from '@/contexts/tabs/types'
 import type { Tab, TabSystemState, SidebarItem } from '@/contexts/tabs/types'
 import { useIsItemActive } from './use-is-item-active'
 import { useOpenTarget } from './use-open-target'
+import { useGeneralSettings } from './use-general-settings'
 import { useFeatureFlags } from './use-feature-flags'
 import { useSettingsModal } from '@/contexts/settings-modal-context'
 import { featureForTabType } from '@memry/contracts/feature-flags'
@@ -151,6 +152,13 @@ export const useSidebarNavigation = () => {
   const { flags } = useFeatureFlags()
   const { open: openSettings } = useSettingsModal()
 
+  // "Clicking a page opens a new tab" (#1644). Read through a ref so the
+  // preference never destabilises openSidebarItem — the callback stability is
+  // what this hook exists for (see the PERFORMANCE notes above).
+  const { settings: generalSettings } = useGeneralSettings()
+  const reuseActiveTabRef = useRef(!generalSettings.openPagesInNewTab)
+  reuseActiveTabRef.current = !generalSettings.openPagesInNewTab
+
   // Use refs for state to avoid recreating callbacks
   const stateRef = useRef(state)
   useEffect(() => {
@@ -171,12 +179,11 @@ export const useSidebarNavigation = () => {
       const { inNewTab, inBackground, toTheSide } = options
       const currentState = stateRef.current
 
-      // "Open in New Tab" / Cmd-click / middle-click earn a genuinely new tab —
-      // but only for items that can meaningfully exist twice. SINGLETON_TAB_TYPES
-      // (Home, Inbox, Calendar, Tasks, Journal, Graph, Tags) are declared
-      // single-instance and stay that way; a second identical Inbox is not what
-      // the gesture is for, so those keep focusing the tab that already exists.
-      const forceNewTab = inNewTab === true && !SINGLETON_TAB_TYPES.includes(item.type)
+      // "Open in New Tab" / Cmd-click / middle-click earn a genuinely new tab.
+      // Since #1644 that includes the singletons (Home, Inbox, Calendar, …):
+      // an explicit gesture mints a real second copy rather than being quietly
+      // downgraded to "focus the one that exists".
+      const forceNewTab = inNewTab === true
 
       // Check for existing tab
       const existingTab = findExistingTabForItem(currentState, item)
@@ -211,7 +218,13 @@ export const useSidebarNavigation = () => {
         // and tag rows get identical behaviour without repeating them.
         openToTheSide(tabData, { background: inBackground })
       } else {
-        openTab(tabData, { background: inBackground, forceNew: forceNewTab })
+        // reuseActiveTab is a no-op beside forceNew/background — the reducer
+        // only honours it for a plain, focused open (#1644).
+        openTab(tabData, {
+          background: inBackground,
+          forceNew: forceNewTab,
+          reuseActiveTab: reuseActiveTabRef.current
+        })
       }
     },
     [openTab, setActiveTab, openToTheSide, flags, openSettings]

--- a/apps/desktop/src/renderer/src/pages/folder-view.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/folder-view.test.tsx
@@ -63,6 +63,8 @@ vi.mock('@/contexts/tabs', () => ({
     closeTab: mocks.closeTab,
     getActiveTab: mocks.getActiveTab
   }),
+  // useOpenPage (open-preference plumbing) reads openTab from here.
+  useTabActions: () => ({ openTab: mocks.openTab }),
   useActiveTab: () => mocks.activeTab,
   // The page's view name and search now live in the tab; outside a tab provider
   // the hook degrades to plain local state, which is what these tests exercise.

--- a/apps/desktop/src/renderer/src/pages/folder-view.tsx
+++ b/apps/desktop/src/renderer/src/pages/folder-view.tsx
@@ -26,6 +26,7 @@ import {
   AlertDialogTitle
 } from '@/components/ui/alert-dialog'
 import { useTabs, useActiveTab } from '@/contexts/tabs'
+import { useOpenPage } from '@/hooks/use-open-target'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
 import { FolderTableView } from '@/components/folder-view/folder-table-view'
 import { GroupedTable } from '@/components/folder-view/grouped-table'
@@ -87,6 +88,8 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
   const { t } = useT('notes')
   const { t: tCommon } = useT('common')
   const { openTab, closeTab, getActiveTab } = useTabs()
+  // Plain opens honour the "clicking a page opens a new tab" preference (#1644).
+  const { openPage } = useOpenPage()
   const { openSidebarItem } = useSidebarNavigation()
   const { tags: allTags } = useNoteTagsQuery()
   const { folders, setFolderIcon } = useNoteFoldersQuery()
@@ -353,7 +356,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
   const handleNoteOpen = (noteId: string): void => {
     const note = notes.find((n) => n.id === noteId)
     if (note) {
-      openTab({
+      openPage({
         type: 'note',
         title: note.title,
         icon: 'file-text',
@@ -431,7 +434,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
     const fullPath = folderPath ? `${folderPath}${subfolderPath}` : subfolderPath.slice(1)
     const folderName = subfolderPath.split('/').pop() || 'Folder'
 
-    openTab({
+    openPage({
       type: 'folder',
       title: folderName,
       icon: 'folder',
@@ -631,23 +634,28 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
     [deleteView, storedViewName, setStoredViewName]
   )
 
-  // Handle opening note in new tab (for context menu)
+  // Handle opening note in new tab (for context menu). `forceNew` makes the
+  // command do what its label says — without it the open dedups by entityId and
+  // merely focuses a copy that is already open somewhere.
   const handleOpenInNewTab = useCallback(
     (noteId: string): void => {
       const note = notes.find((n) => n.id === noteId)
       if (note) {
-        openTab({
-          type: 'note',
-          title: note.title,
-          icon: 'file-text',
-          emoji: note.emoji,
-          path: `/notes/${note.id}`,
-          entityId: note.id,
-          isPinned: false,
-          isModified: false,
-          isPreview: false,
-          isDeleted: false
-        })
+        openTab(
+          {
+            type: 'note',
+            title: note.title,
+            icon: 'file-text',
+            emoji: note.emoji,
+            path: `/notes/${note.id}`,
+            entityId: note.id,
+            isPinned: false,
+            isModified: false,
+            isPreview: false,
+            isDeleted: false
+          },
+          { forceNew: true }
+        )
       }
     },
     [notes, openTab]
@@ -762,7 +770,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
   // Navigate to a breadcrumb ancestor folder
   const handleBreadcrumbNav = useCallback(
     (path: string, label: string): void => {
-      openTab({
+      openPage({
         type: 'folder',
         title: label,
         icon: 'folder',
@@ -774,7 +782,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
         isDeleted: false
       })
     },
-    [openTab]
+    [openPage]
   )
 
   // ============================================================================
@@ -797,7 +805,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
       )
 
       if (result.success && result.note) {
-        openTab({
+        openPage({
           type: 'note',
           title: result.note.title || 'Untitled',
           icon: 'file-text',
@@ -813,7 +821,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
     } catch (err) {
       log.error('Failed to create note:', err)
     }
-  }, [createNote, scope, openTab])
+  }, [createNote, scope, openPage])
 
   /**
    * Handle clearing all search and filters.

--- a/apps/desktop/src/renderer/src/pages/home.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/home.test.tsx
@@ -5,9 +5,10 @@ import HomePage from './home'
 // Stub the widgets barrel (Task 9 fills this)
 vi.mock('@/components/home/widgets', () => ({}))
 
-// HomePage reads openTab from the tabs context; no TabProvider in this test
+// HomePage opens tabs through useOpenPage; no TabProvider in this test
 vi.mock('@/contexts/tabs', () => ({
-  useTabs: () => ({ openTab: vi.fn() })
+  useTabs: () => ({ openTab: vi.fn() }),
+  useTabActions: () => ({ openTab: vi.fn() })
 }))
 
 // Stub child components to avoid dnd-kit / WIDGET_REGISTRY / react-query deps

--- a/apps/desktop/src/renderer/src/pages/home.tsx
+++ b/apps/desktop/src/renderer/src/pages/home.tsx
@@ -13,7 +13,7 @@ import { createWidget as makeWidget } from '@/lib/home/widget-registry'
 import type { HomePage, WidgetType } from '@/lib/home/types'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useT } from '@memry/i18n/renderer'
-import { useTabs } from '@/contexts/tabs'
+import { useOpenPage } from '@/hooks/use-open-target'
 import { notesService } from '@/services/notes-service'
 import { createLogger } from '@/lib/logger'
 
@@ -36,13 +36,15 @@ function asLocalPage(page: {
 export default function HomePage(): React.JSX.Element {
   const { t } = useT('common')
   const { flags } = useFeatureFlags()
-  const { openTab } = useTabs()
+  // New-note creation honours the "clicking a page opens a new tab" preference
+  // (#1644): with it off, the note takes over this Home tab.
+  const { openPage } = useOpenPage()
 
   const handleCreateNote = useCallback(async () => {
     try {
       const result = await notesService.create({ title: 'Untitled', content: '' })
       if (result.success && result.note) {
-        openTab({
+        openPage({
           type: 'note',
           title: result.note.title || 'Untitled',
           icon: 'file-text',
@@ -57,7 +59,7 @@ export default function HomePage(): React.JSX.Element {
     } catch (error) {
       log.error('Failed to create new note:', error)
     }
-  }, [openTab])
+  }, [openPage])
 
   const [galleryOpen, setGalleryOpen] = useState(false)
   const [managerOpen, setManagerOpen] = useState(false)

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -216,6 +216,8 @@ vi.mock('@/contexts/tabs', () => ({
     setTabDeleted: mocks.setTabDeleted,
     updateTabTitleByEntityId: mocks.updateTabTitleByEntityId
   }),
+  // useOpenPage (wiki/backlink navigation preference) reads openTab from here.
+  useTabActions: () => ({ openTab: mocks.openTab }),
   useActiveTab: () => ({
     id: '/notes/note-1',
     entityId: 'note-1',

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -54,6 +54,7 @@ import { scrollToHeadingBlock, scrollToHeadingWhenReady } from '@/lib/scroll-to-
 import { RESTORE_MAX_MS } from '@/hooks/use-tab-scroll-restore'
 import { splitWikiTarget, normalizeHeading } from '@memry/shared/wiki-target'
 import { useTabs, useActiveTab } from '@/contexts/tabs'
+import { useOpenPage } from '@/hooks/use-open-target'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
 import { ReminderPicker } from '@/components/reminder'
 import { useNoteReminders } from '@/hooks/use-note-reminders'
@@ -1072,6 +1073,29 @@ export function NotePage({ noteId }: NotePageProps) {
     window.open(href, '_blank', 'noopener,noreferrer')
   }, [])
 
+  // "Clicking a page opens a new tab" (#1644) covers in-note navigation too:
+  // with it off, following a wiki link or a backlink navigates this tab in
+  // place. Guarded on this note being the active tab — reuse replaces the
+  // active tab of the active group, so a link clicked in a background pane
+  // must not clobber an unrelated tab (same guard as the file conversion
+  // above). Dedup still runs first: a target already open just gets focused.
+  const { reuseActiveTab: reusePreferred } = useOpenPage()
+  const openLinked = useCallback(
+    (tab: Parameters<typeof openTab>[0]) => {
+      if (
+        reusePreferred &&
+        activeTab != null &&
+        activeTab.entityId === noteId &&
+        !activeTab.isPinned
+      ) {
+        openTab(tab, { reuseActiveTab: true })
+      } else {
+        openTab(tab)
+      }
+    },
+    [openTab, reusePreferred, activeTab?.entityId, activeTab?.isPinned, noteId]
+  )
+
   const handleInternalLinkClick = useCallback(
     async (linkedNoteIdOrTitle: string) => {
       const target = linkedNoteIdOrTitle?.trim()
@@ -1092,7 +1116,7 @@ export function NotePage({ noteId }: NotePageProps) {
         switch (resolution.type) {
           case 'file':
             // Open file in appropriate viewer (image, video, PDF, audio)
-            openTab({
+            openLinked({
               type: 'file',
               title: resolution.title,
               icon: resolution.icon,
@@ -1109,7 +1133,7 @@ export function NotePage({ noteId }: NotePageProps) {
             // Open note in editor, carrying the heading the link named. The
             // target page consumes it once its own editor has produced headings
             // — text is all we have, and block ids only exist over there.
-            openTab({
+            openLinked({
               type: 'note',
               title: resolution.title,
               icon: 'file-text',
@@ -1133,7 +1157,7 @@ export function NotePage({ noteId }: NotePageProps) {
               toast.error(t('page.toast.createLinkedFailed'))
               return
             }
-            openTab({
+            openLinked({
               type: 'note',
               title: result.note.title,
               icon: 'file-text',
@@ -1157,7 +1181,7 @@ export function NotePage({ noteId }: NotePageProps) {
         toast.error(t('page.toast.openLinkedFailed'))
       }
     },
-    [openTab, createNote, t, scrollToHeadingText, prefersReducedMotion]
+    [openLinked, createNote, t, scrollToHeadingText, prefersReducedMotion]
   )
 
   const handleBacklinkClick = useCallback(
@@ -1171,7 +1195,7 @@ export function NotePage({ noteId }: NotePageProps) {
           }
         : undefined
 
-      openTab({
+      openLinked({
         type: 'note',
         title: noteTitle,
         icon: 'file-text',
@@ -1184,7 +1208,7 @@ export function NotePage({ noteId }: NotePageProps) {
         ...(viewState && { viewState })
       })
     },
-    [openTab, backlinks]
+    [openLinked, backlinks]
   )
 
   // Handle clicking on a linked task

--- a/apps/desktop/tests/e2e/tab-reuse-on-page-click.e2e.ts
+++ b/apps/desktop/tests/e2e/tab-reuse-on-page-click.e2e.ts
@@ -186,4 +186,66 @@ test.describe('Clicking a page reuses the current tab (#1644)', () => {
     expect(await tabs(page).count()).toBe(before + 1)
     await expect(page.locator(`${SELECTORS.tab}:has-text("${titles[0]}")`)).toHaveCount(1)
   })
+
+  test('off: sidebar section click reuses; middle-click still opens a background tab', async ({
+    page
+  }) => {
+    const titles = ['Nav Reuse Anchor']
+    const ids = await seedNotes(page, titles)
+
+    await setOpenPagesInNewTab(page, false)
+
+    await clickNoteRow(page, ids[0], titles[0])
+    const count = await tabs(page).count()
+
+    // A singleton section (Tasks) with no tab open yet: the plain click obeys
+    // the preference and takes over the current tab.
+    const tasksNav = page.locator('[data-tour="nav-tasks"]')
+    await tasksNav.click()
+    await expect(page.locator(SELECTORS.activeTab)).toContainText('Tasks', { timeout: 10_000 })
+    expect(await tabs(page).count()).toBe(count)
+
+    // Middle-click is an explicit gesture: a genuinely new background copy,
+    // preference notwithstanding.
+    await tasksNav.click({ button: 'middle' })
+    await expect.poll(async () => tabs(page).count(), { timeout: 10_000 }).toBe(count + 1)
+    // Focus stayed on the tab we were on.
+    await expect(page.locator(SELECTORS.activeTab)).toContainText('Tasks')
+  })
+
+  test('singletons duplicate through "Open in New Tab" in the nav context menu', async ({
+    page
+  }) => {
+    await setOpenPagesInNewTab(page, true)
+
+    const inboxNav = page.locator('[data-tour="nav-inbox"]')
+    await inboxNav.click()
+    const inboxTabs = page.locator(`${SELECTORS.tab}:has-text("Inbox")`)
+    await expect(inboxTabs).toHaveCount(1)
+
+    // Plain re-click keeps focusing the existing copy.
+    await inboxNav.click()
+    await expect(inboxTabs).toHaveCount(1)
+
+    // The context-menu command mints a real second copy (#1644 un-gated it).
+    await inboxNav.click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Open in New Tab' }).click()
+    await expect(inboxTabs).toHaveCount(2)
+  })
+
+  test('off: middle-click on a note row opens a background tab', async ({ page }) => {
+    const titles = ['Middle Anchor', 'Middle Target']
+    const ids = await seedNotes(page, titles)
+
+    await setOpenPagesInNewTab(page, false)
+
+    await clickNoteRow(page, ids[0], titles[0])
+    const count = await tabs(page).count()
+
+    await treeRow(page, ids[1]).click({ button: 'middle' })
+    await expect.poll(async () => tabs(page).count(), { timeout: 10_000 }).toBe(count + 1)
+    // The anchor keeps focus; the target arrived in the background.
+    await expect(page.locator(SELECTORS.activeTab)).toContainText(titles[0])
+    await expect(page.locator(`${SELECTORS.tab}:has-text("${titles[1]}")`)).toHaveCount(1)
+  })
 })

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -101,7 +101,7 @@ locale has finished loading.
 
 ### Tab Behavior
 
-- **Open Pages in a New Tab** — on by default. Turn it off and clicking a page in the sidebar reuses the current tab instead of adding one, so browsing (or creating) a run of pages leaves a single tab behind. A pinned tab is never replaced — the page opens beside it — and **Open in New Tab** / **Open to the Side** from a row's context menu always open a new tab whatever this is set to. The setting syncs across your devices.
+- **Open Pages in a New Tab** — on by default. Turn it off and opening a page reuses the current tab instead of adding one, so browsing (or creating) a run of pages leaves a single tab behind. It covers every sidebar row — notes, folders, projects, canvases, tags, bookmarks, and the top-level sections — plus new-note/new-canvas creation and following wiki links or backlinks inside a note. A pinned tab is never replaced — the page opens beside it — and explicit gestures always open a new tab whatever this is set to: **Open in New Tab** / **Open to the Side** from a row's context menu, middle-click (opens in the background), and ⌘/Ctrl-click on a section. Since the same release, **Open in New Tab** also works on the singleton sections (Home, Inbox, Journal, Calendar, Tasks, Graph): it opens a genuine second copy. The setting syncs across your devices.
 - **Restore Session** — reopen the previous session's tabs on launch
 - **Tab Close Button** — always visible, hover only, or active tab only
 

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -154,7 +154,7 @@
     "tabs": {
       "openPagesInNewTab": {
         "label": "Open Pages in a New Tab",
-        "description": "Clicking a page in the sidebar opens it in a new tab. When off, it reuses the current tab \u2014 pinned tabs are never replaced. \"Open in New Tab\" and \"Open to the Side\" always open a new tab."
+        "description": "Clicking or creating a page \u2014 notes, folders, projects, canvases, tags, bookmarks \u2014 opens it in a new tab. When off, the current tab is reused, including when following links inside a note; pinned tabs are never replaced. \"Open in New Tab\", \"Open to the Side\" and middle-click always open a new tab."
       },
       "restoreSession": {
         "label": "Restore Session on Start",

--- a/packages/i18n/src/locales/tr/settings.json
+++ b/packages/i18n/src/locales/tr/settings.json
@@ -107,7 +107,7 @@
     "tabs": {
       "openPagesInNewTab": {
         "label": "Sayfalar\u0131 Yeni Sekmede A\u00e7",
-        "description": "Kenar \u00e7ubu\u011funda bir sayfaya t\u0131klamak onu yeni bir sekmede a\u00e7ar. Kapal\u0131yken mevcut sekme yeniden kullan\u0131l\u0131r \u2014 sabitlenmi\u015f sekmeler asla de\u011fi\u015ftirilmez. \"Yeni Sekmede A\u00e7\" ve \"Yan Tarafta A\u00e7\" her zaman yeni sekme a\u00e7ar."
+        "description": "Bir sayfaya t\u0131klamak ya da yeni sayfa olu\u015fturmak \u2014 notlar, klas\u00f6rler, projeler, canvas\u0027lar, etiketler, yer imleri \u2014 onu yeni bir sekmede a\u00e7ar. Kapal\u0131yken mevcut sekme yeniden kullan\u0131l\u0131r; not i\u00e7indeki ba\u011flant\u0131lar\u0131 takip etmek de dahil. Sabitlenmi\u015f sekmeler asla de\u011fi\u015ftirilmez. \"Yeni Sekmede A\u00e7\", \"Yan Tarafta A\u00e7\" ve orta t\u0131k her zaman yeni sekme a\u00e7ar."
       },
       "restoreSession": {
         "label": "Başlangıçta Oturumu Geri Yükle",


### PR DESCRIPTION
Stacked on #1650 (merge that first; this diff reads clean once it lands). Follow-up scope agreed for #1644 / epic #1625.

## What

`general.openPagesInNewTab` now governs every surface that opens a tab, not just the notes tree:

**Preference-aware plain opens.** A shared `useOpenPage` hook carries the preference; converted call sites: both notes trees (incl. creation), app-sidebar note/canvas creation, bookmark folder opens, canvas rows, folder-view rows/subfolders/breadcrumb/new-note, Home's new note. `openSidebarItem` threads it internally (via a ref, keeping its stable-callback guarantee) — that covers projects, tags, the tags hub, bookmarks, and the top-level nav sections.

**In-note navigation.** Wiki links and backlinks obey the preference too — with it off, following a link navigates in place, Obsidian-style. Guarded on the source note being the active tab, so a link clicked in a background pane can never clobber an unrelated tab. Dedup still runs first: an already-open target is focused, never cloned.

**Singletons un-gated.** "Open in New Tab" now renders for Home/Inbox/Journal/Calendar/Tasks/Graph and mints a genuine second copy (`forceNew`); the quiet downgrade in `useSidebarNavigation` is gone. Plain clicks keep dedup-and-focus.

**Middle-click everywhere in the sidebar.** Notes, folders, projects, bookmarks, canvases, tags, and nav sections open a background copy on middle-click (mousedown — middle never produces `click`). Explicit gestures always beat the preference.

**Bug fix in passing:** folder-view's context-menu "Open in New Tab" never passed `forceNew`, so it dedup-focused instead of opening a new tab. Now it does what its label says.

## Verification

- New real-provider suite `use-sidebar-navigation.reuse.test.tsx` (4 specs): reuse on plain opens, dedup-before-reuse, singleton duplication on explicit gesture, background middle-click keeping focus.
- Virtualized-tree middle-click component coverage; existing suites updated where render trees gained the hooks (partial-mock fallout: 10 files, all green again).
- E2E now **7/7**: the original four plus nav-section reuse + nav middle-click, singleton duplication through the context menu, and note-row middle-click.
- `pnpm typecheck` · `pnpm lint` (0 errors) · renderer **654 files / 7811 tests** · `i18n:check` · docs updated (`user-guide/settings.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)