### PR TITLE
fix(sidebar): keep the inline rename field open when its menu closes

### DIFF
--- a/apps/desktop/src/renderer/src/components/notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree.tsx
@@ -45,6 +45,7 @@ import {
   type FolderNode
 } from '@/components/notes-tree-utils'
 import { FILE_DROP_FOLDER_ATTR } from '@/hooks/use-file-drop'
+import { handleInlineRenameBlur } from '@/lib/inline-rename-focus'
 import { cn } from '@/lib/utils'
 import { IconPickerButton } from '@/components/icon-picker-button'
 import type { NoteListItem } from '@/hooks/use-notes-query'
@@ -413,7 +414,9 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
                 }
                 e.stopPropagation()
               }}
-              onBlur={() => void actions.handleRenameSubmit(note.id, note.path)}
+              onBlur={(e) =>
+                handleInlineRenameBlur(e, () => void actions.handleRenameSubmit(note.id, note.path))
+              }
               onClick={(e) => e.stopPropagation()}
               disabled={actions.isRenaming}
               className="flex-1 h-5 px-1 text-sm bg-background border border-input rounded focus:outline-none"
@@ -534,7 +537,9 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
                 }
                 e.stopPropagation()
               }}
-              onBlur={() => void actions.handleFolderRenameSubmit(folder.path)}
+              onBlur={(e) =>
+                handleInlineRenameBlur(e, () => void actions.handleFolderRenameSubmit(folder.path))
+              }
               onClick={(e) => e.stopPropagation()}
               disabled={actions.isFolderRenaming}
               className="flex-1 h-5 px-1 text-sm bg-background border border-input rounded focus:outline-none"

--- a/apps/desktop/src/renderer/src/components/ui/context-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/context-menu.tsx
@@ -73,6 +73,15 @@ function ContextMenuSubContent({
   )
 }
 
+/**
+ * A closing menu is a corpse: `Presence` keeps it mounted for its exit
+ * animation, and Radix answers pointer events that whole time — a pointer
+ * leaving an item runs `onItemLeave`, which focuses the menu content again.
+ * When the item just opened an inline rename field, that focus lands ~150ms
+ * after the field did and blurs it, and a blur is a commit for those fields.
+ * `pointer-events-none` while closed makes the corpse inert; the matching
+ * `onCloseAutoFocus` guard below covers the separate unmount-restore path.
+ */
 function ContextMenuContent({
   className,
   onCloseAutoFocus,
@@ -87,7 +96,7 @@ function ContextMenuContent({
           onCloseAutoFocus?.(e)
         }}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-[var(--shadow-card-hover)]',
+          'bg-popover text-popover-foreground data-[state=closed]:pointer-events-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-[var(--shadow-card-hover)]',
           'floating-content-motion',
           className
         )}

--- a/apps/desktop/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -67,6 +67,10 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         'z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-card-hover)]',
+        // Inert while it animates out, for the same reason as ContextMenuContent:
+        // a pointer leaving an item makes Radix focus the content again, which
+        // blurs an inline rename field the item opened a moment earlier.
+        'data-[state=closed]:pointer-events-none',
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-dropdown-menu-content-transform-origin)',
         'floating-content-motion',
         className

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
@@ -64,6 +64,7 @@ import { OpenTargetMenuItems } from '@/components/sidebar/open-target-menu-items
 import { noteTabData, folderTabData } from '@/lib/sidebar-tab-data'
 import { resolveDropPosition, type DropPosition } from '@/lib/tree-drop-position'
 import { useT } from '@memry/i18n/renderer'
+import { handleInlineRenameBlur } from '@/lib/inline-rename-focus'
 
 // ============================================================================
 // Types
@@ -487,7 +488,9 @@ function FolderRow({
                 }
                 e.stopPropagation()
               }}
-              onBlur={() => onFolderRenameSubmit?.(item.folder.path)}
+              onBlur={(e) =>
+                handleInlineRenameBlur(e, () => onFolderRenameSubmit?.(item.folder.path))
+              }
               onClick={(e) => e.stopPropagation()}
               disabled={isFolderRenaming}
               className={RENAME_INPUT_CLASS}
@@ -778,7 +781,9 @@ function NoteRow({
                 }
                 e.stopPropagation()
               }}
-              onBlur={() => onRenameSubmit?.(item.note.id, item.note.path)}
+              onBlur={(e) =>
+                handleInlineRenameBlur(e, () => onRenameSubmit?.(item.note.id, item.note.path))
+              }
               onClick={(e) => e.stopPropagation()}
               disabled={isRenaming}
               className={RENAME_INPUT_CLASS}

--- a/apps/desktop/src/renderer/src/lib/inline-rename-focus.test.ts
+++ b/apps/desktop/src/renderer/src/lib/inline-rename-focus.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import type { FocusEvent } from 'react'
+
+import { isMenuFocusSteal } from './inline-rename-focus'
+
+/** A blur event carrying `relatedTarget`, which is all the helper reads. */
+function blurTo(relatedTarget: EventTarget | null): FocusEvent<HTMLElement> {
+  return { relatedTarget } as unknown as FocusEvent<HTMLElement>
+}
+
+function menuItemInside(state: 'open' | 'closed'): HTMLElement {
+  const content = document.createElement('div')
+  content.setAttribute('role', 'menu')
+  content.dataset.state = state
+  const item = document.createElement('div')
+  item.setAttribute('role', 'menuitem')
+  content.appendChild(item)
+  document.body.appendChild(content)
+  return item
+}
+
+describe('isMenuFocusSteal', () => {
+  it('claims a blur handed to an item of a menu that is animating out', () => {
+    expect(isMenuFocusSteal(blurTo(menuItemInside('closed')))).toBe(true)
+  })
+
+  it('claims a blur handed to the closing menu content itself', () => {
+    const item = menuItemInside('closed')
+    expect(isMenuFocusSteal(blurTo(item.parentElement))).toBe(true)
+  })
+
+  it('leaves a menu the user is deliberately opening alone', () => {
+    // Taking focus back here would fight the open menu's own focus trap.
+    expect(isMenuFocusSteal(blurTo(menuItemInside('open')))).toBe(false)
+  })
+
+  it('leaves an ordinary blur alone, so it still commits', () => {
+    const row = document.createElement('div')
+    document.body.appendChild(row)
+    expect(isMenuFocusSteal(blurTo(row))).toBe(false)
+  })
+
+  it('treats a blur with no related target as an ordinary commit', () => {
+    expect(isMenuFocusSteal(blurTo(null))).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/inline-rename-focus.ts
+++ b/apps/desktop/src/renderer/src/lib/inline-rename-focus.ts
@@ -1,0 +1,40 @@
+import type { FocusEvent } from 'react'
+
+/**
+ * A Radix menu that is animating out is still mounted and still answering
+ * pointer events: a pointer leaving an item runs `onItemLeave`, which focuses
+ * the menu content again, and a pointer moving over an item focuses the item.
+ * When the item just opened an inline rename field, that focus lands a beat
+ * after the field did and blurs it — and in the sidebar trees a blur commits
+ * and closes the field, so the rename dies before a key is ever pressed.
+ *
+ * The menus are made pointer-inert while closing (see `ui/context-menu.tsx`),
+ * which leaves exactly one boundary event to absorb: the one the browser fires
+ * when hit-testing changes. Treat that blur as noise and take focus back.
+ *
+ * @returns true when the blur came from a menu stealing focus, not the user.
+ */
+export function isMenuFocusSteal(event: FocusEvent<HTMLElement>): boolean {
+  const next = event.relatedTarget
+  if (!(next instanceof HTMLElement)) return false
+  const menu = next.closest<HTMLElement>('[role="menu"],[data-radix-menu-content]')
+  // Only a menu on its way out. A menu the user is deliberately OPENING over
+  // an active field still owns focus — taking it back there would fight the
+  // menu's own focus trap, and the two would trade focus until one gives up.
+  return menu?.dataset.state === 'closed'
+}
+
+/**
+ * `onBlur` for an inline rename field: keep the field when a closing menu is
+ * pulling focus away, otherwise let the caller commit.
+ */
+export function handleInlineRenameBlur(
+  event: FocusEvent<HTMLInputElement>,
+  commit: () => void
+): void {
+  if (isMenuFocusSteal(event)) {
+    event.currentTarget.focus()
+    return
+  }
+  commit()
+}

--- a/apps/desktop/tests/e2e/sidebar-folder-rename.e2e.ts
+++ b/apps/desktop/tests/e2e/sidebar-folder-rename.e2e.ts
@@ -1,0 +1,243 @@
+// @ts-nocheck - E2E tests in development, follow canvas-folder-rename.e2e.ts convention
+/**
+ * Renaming a NOTES folder (Collections section) from the row's context menu.
+ *
+ * Companion to canvas-folder-rename.e2e.ts. The field opens while a Radix
+ * context menu is still animating out, and every part of that race runs on
+ * timers and CSS animations jsdom does not have, so the renderer suite cannot
+ * see it. Reported symptom: the field flashes and vanishes ~200ms later, and
+ * the folder keeps its old name.
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { test, expect, type Page } from './fixtures'
+import { ready } from './utils/desktop-test-helpers'
+
+async function openVault(page: Page): Promise<void> {
+  await page
+    .locator('aside, [data-testid="sidebar"], [class*="sidebar"], nav')
+    .first()
+    .waitFor({ state: 'visible', timeout: 90_000 })
+  await ready(page)
+}
+
+function sectionHeader(page: Page) {
+  return page.getByRole('button', { name: /Collections section/ })
+}
+
+async function expandCollections(page: Page): Promise<void> {
+  const header = sectionHeader(page)
+  await expect(header).toBeVisible({ timeout: 30_000 })
+  if ((await header.getAttribute('aria-expanded')) !== 'true') {
+    await header.click()
+  }
+  await expect(header).toHaveAttribute('aria-expanded', 'true')
+}
+
+/** Records every focus() call and every focusout, with a JS stack for the thief. */
+async function instrumentFocus(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const w = window as unknown as { __focusLog: unknown[] }
+    w.__focusLog = []
+    const describe = (el: Element | null): string =>
+      el
+        ? `${el.tagName}${el.getAttribute('aria-label') ? `[${el.getAttribute('aria-label')}]` : ''}${
+            el.getAttribute('data-tree-node-id') ? `{${el.getAttribute('data-tree-node-id')}}` : ''
+          }.${(el.className || '').toString().slice(0, 50)}`
+        : 'null'
+    const origFocus = HTMLElement.prototype.focus
+    HTMLElement.prototype.focus = function (...args) {
+      w.__focusLog.push({
+        t: Math.round(performance.now()),
+        kind: 'focus()',
+        on: describe(this),
+        stack: (new Error().stack || '').split('\n').slice(2, 8).join(' <- ')
+      })
+      return origFocus.apply(this, args)
+    }
+    document.addEventListener(
+      'focusout',
+      (e) => {
+        w.__focusLog.push({
+          t: Math.round(performance.now()),
+          kind: 'focusout',
+          on: describe(e.target as Element),
+          related: describe(e.relatedTarget as Element)
+        })
+      },
+      true
+    )
+  })
+}
+
+async function dumpFocusLog(page: Page, label: string): Promise<void> {
+  const log = await page.evaluate(() => (window as unknown as { __focusLog: unknown[] }).__focusLog)
+  console.log(`\n===== FOCUS LOG (${label}) =====\n${JSON.stringify(log, null, 1)}\n`)
+  await page.evaluate(() => {
+    ;(window as unknown as { __focusLog: unknown[] }).__focusLog = []
+  })
+}
+
+/**
+ * Clicks a row-menu item and then nudges the pointer, the way a hand does.
+ *
+ * The nudge is the whole point: the menu is still mounted and still handling
+ * pointer events through its exit animation, and Radix's `onItemLeave` answers
+ * a pointer leaving an item by focusing the menu content again. A field the
+ * item just opened is blurred by that, and a blur is a commit here.
+ */
+async function clickMenuItemAndMoveOn(page: Page, label: string): Promise<void> {
+  const item = page.getByRole('menuitem', { name: label, exact: true })
+  await expect(item).toBeVisible()
+  const box = await item.boundingBox()
+  await item.click()
+  if (!box) return
+  for (let dy = 6; dy <= 48; dy += 6) {
+    await page.mouse.move(box.x + box.width / 2, box.y + dy)
+    await page.waitForTimeout(20)
+  }
+}
+
+const renameField = (page: Page) => page.getByLabel('Rename', { exact: true })
+
+function folderRow(page: Page, name: string) {
+  return page.locator('[data-tree-node-id^="folder-"]').filter({ hasText: name }).first()
+}
+
+test.describe('Sidebar folder rename (Collections)', () => {
+  test.describe.configure({ timeout: 180_000 })
+
+  test('the rename field stays open and focused', async ({ page }) => {
+    await openVault(page)
+    await expandCollections(page)
+    await instrumentFocus(page)
+
+    // --- Create a folder: it drops straight into rename mode ---
+    await page.getByRole('button', { name: 'New folder', exact: true }).first().click()
+
+    const created = renameField(page)
+    await expect(created).toBeVisible({ timeout: 15_000 })
+    await page.waitForTimeout(600)
+    await dumpFocusLog(page, 'after create')
+    await expect(created, 'create-mode field vanished').toBeVisible()
+    await expect(created, 'create-mode field lost focus').toBeFocused()
+    await created.fill('Work')
+    await created.press('Enter')
+
+    const row = folderRow(page, 'Work')
+    await expect(row).toBeVisible({ timeout: 15_000 })
+    await page.waitForTimeout(500)
+
+    // --- Rename it from the row's context menu (the reported flow) ---
+    await instrumentFocus(page)
+    await row.click({ button: 'right' })
+    await clickMenuItemAndMoveOn(page, 'Rename')
+
+    const field = renameField(page)
+    await expect(field).toBeVisible({ timeout: 10_000 })
+    await page.waitForTimeout(600)
+    await dumpFocusLog(page, 'after context-menu rename')
+
+    await expect(field, 'rename field vanished after opening').toBeVisible()
+    await expect(field, 'rename field lost focus after opening').toBeFocused()
+
+    await field.fill('Studio')
+    await field.press('Enter')
+    await expect(folderRow(page, 'Studio')).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('the rename field stays open past the virtualization threshold', async ({
+    page,
+    testVaultPath
+  }) => {
+    // 150 notes puts the tree over VIRTUALIZATION_THRESHOLD (100), which is the
+    // renderer real users with a real vault get.
+    for (let i = 0; i < 150; i++) {
+      fs.writeFileSync(
+        path.join(testVaultPath, 'notes', `bulk-${String(i).padStart(3, '0')}.md`),
+        `---\ntitle: Bulk ${i}\n---\n\nfiller\n`
+      )
+    }
+    fs.mkdirSync(path.join(testVaultPath, 'notes', 'Work'), { recursive: true })
+    fs.writeFileSync(
+      path.join(testVaultPath, 'notes', 'Work', 'inside.md'),
+      '---\ntitle: Inside\n---\n\nfiller\n'
+    )
+
+    await openVault(page)
+    await page.reload()
+    await openVault(page)
+    await expandCollections(page)
+    await instrumentFocus(page)
+
+    // Seeded notes live under notes/, which the tree draws as its own folder.
+    const notesFolder = page.locator('[data-tree-node-id="folder-notes"]')
+    await expect(notesFolder).toBeVisible({ timeout: 30_000 })
+    await notesFolder.click()
+
+    const row = page.locator('[data-tree-node-id="folder-notes/Work"]')
+    await expect(row).toBeVisible({ timeout: 30_000 })
+    await row.scrollIntoViewIfNeeded()
+    await row.click({ button: 'right' })
+    await clickMenuItemAndMoveOn(page, 'Rename')
+
+    const field = renameField(page)
+    await expect(field).toBeVisible({ timeout: 10_000 })
+    await page.waitForTimeout(600)
+    await dumpFocusLog(page, 'virtualized context-menu rename')
+
+    await expect(field, 'virtualized rename field vanished').toBeVisible()
+    await expect(field, 'virtualized rename field lost focus').toBeFocused()
+
+    await field.fill('Studio')
+    await field.press('Enter')
+    await expect(page.locator('[data-tree-node-id="folder-notes/Studio"]')).toBeVisible({
+      timeout: 15_000
+    })
+  })
+
+  test('the rename field survives a vault change landing while it is open', async ({
+    page,
+    testVaultPath
+  }) => {
+    await openVault(page)
+    await expandCollections(page)
+
+    await page.getByRole('button', { name: 'New folder', exact: true }).first().click()
+    const created = renameField(page)
+    await expect(created).toBeVisible({ timeout: 15_000 })
+    await created.fill('Work')
+    await created.press('Enter')
+
+    const row = folderRow(page, 'Work')
+    await expect(row).toBeVisible({ timeout: 15_000 })
+    await page.waitForTimeout(500)
+
+    await instrumentFocus(page)
+    await row.click({ button: 'right' })
+    await clickMenuItemAndMoveOn(page, 'Rename')
+
+    const field = renameField(page)
+    await expect(field).toBeVisible({ timeout: 10_000 })
+    await expect(field).toBeFocused()
+
+    // The thing a sync push, another device, or the file watcher does while the
+    // user is mid-rename: the notes list and the folder list both change.
+    fs.writeFileSync(
+      path.join(testVaultPath, 'notes', 'arrived-from-sync.md'),
+      '---\ntitle: Arrived\n---\n\nfiller\n'
+    )
+    fs.mkdirSync(path.join(testVaultPath, 'notes', 'ArrivedFolder'), { recursive: true })
+
+    await page.waitForTimeout(1500)
+    await dumpFocusLog(page, 'after a vault change landed')
+
+    await expect(field, 'field vanished when the vault changed under it').toBeVisible()
+    await expect(field, 'field lost focus when the vault changed under it').toBeFocused()
+
+    await field.fill('Studio')
+    await field.press('Enter')
+    await expect(folderRow(page, 'Studio')).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/apps/docs/src/contribute/gotchas.md
+++ b/apps/docs/src/contribute/gotchas.md
@@ -170,6 +170,23 @@ if (
 
 This mirrors `shouldStartMarquee` in `components/note/content-area/marquee-hit-test.ts`. Regression coverage: `tests/e2e/editor-drag-handle-menu.e2e.ts`.
 
+## A Closing Menu Still Steals Focus from the Field It Just Opened
+
+A Radix menu is not gone when it closes. `Presence` keeps it mounted for its exit animation — roughly 150ms — and it keeps answering pointer events for that whole window. A pointer leaving an item runs the menu's `onItemLeave`, which focuses the menu content; a pointer moving over an item focuses the item. Both are normal menu behaviour, and both are fatal to a "Rename" item that opens an inline field on the row underneath: the field focuses itself a frame after the click, the menu takes focus back a beat later, and because a blur commits and closes these fields, the rename ends before a key is pressed. Nothing throws, so no telemetry fires.
+
+It reads as random because it only happens when the pointer moves during the fade. Hold the mouse perfectly still and the rename works.
+
+Two guards are needed, and neither holds alone:
+
+1. `data-[state=closed]:pointer-events-none` on `ContextMenuContent` and `DropdownMenuContent` (`components/ui/*.tsx`), so a menu on its way out is no longer hit-testable and the pointermove storm stops.
+2. `handleInlineRenameBlur` (`lib/inline-rename-focus.ts`) on the field itself: a blur whose `relatedTarget` sits inside a menu already marked `data-state="closed"` is focus theft, not the user leaving, so take focus back instead of committing. This absorbs the single boundary event the browser fires when guard 1 flips hit-testing.
+
+Guard 2 deliberately ignores menus that are still open: a menu the user opens over an active field owns focus, and taking it back there fights the menu's own focus trap forever.
+
+The separate `onCloseAutoFocus` → `preventDefault()` in `components/ui/context-menu.tsx` covers a _different_ path — the focus restore Radix runs when the content unmounts. Do not mistake one for the other.
+
+**Testing this needs a moving pointer.** `page.click()` parks the mouse where it clicked, so a spec that clicks a menu item and then asserts is blind to this whole class. `tests/e2e/sidebar-folder-rename.e2e.ts` nudges the pointer in 6px steps for ~150ms after the click (`clickMenuItemAndMoveOn`); all three of its cases fail without the guards above. jsdom cannot see it at all — it runs no exit animation, so the menu unmounts in the same commit.
+
 ## Global Keydown Listeners Must Not Depend on Render State
 
 `useKeyboardShortcuts` (`hooks/use-keyboard-shortcuts-base.ts`), `useChordShortcuts` and `useInboxKeyboard` each bind exactly one `window` `keydown` listener per mount. The handler reads the shortcut list — and the tab/inbox state it acts on — from a ref refreshed after every render, so it always sees fresh values without re-registering.


### PR DESCRIPTION
## Summary

Renaming a note or folder from a sidebar row's context menu opened the inline field and then lost it again a beat later, leaving the old name in place. It read as random — reported as "10-15 tries before it lets me" — because it only happens when the pointer moves.

A closing Radix menu is not gone. `Presence` keeps it mounted for its exit animation (~150ms) and it answers pointer events that whole time: a pointer leaving an item runs `onItemLeave`, which focuses the menu content, and a pointer moving over an item focuses the item. Either blurs the field the menu item just opened, and a blur commits and closes these fields — so the rename died before a key was pressed. Nothing threw, so no telemetry fired.

Two halves, because neither holds alone:

- `data-[state=closed]:pointer-events-none` on `ContextMenuContent` and `DropdownMenuContent`, so a menu on its way out stops being hit-testable and the pointermove storm ends.
- `handleInlineRenameBlur` (`lib/inline-rename-focus.ts`), wired to all four sidebar rename inputs (note + folder, in both the plain and virtualized trees): a blur whose `relatedTarget` sits inside a menu already marked `data-state="closed"` is focus theft, not the user leaving, so take focus back instead of committing. This absorbs the single boundary event the first change itself produces when hit-testing flips — verified by testing that change on its own, which stayed red.

The guard deliberately ignores menus that are still open: a menu the user opens over an active field owns focus, and fighting its focus trap there would trade focus forever.

This is a different path from the existing `onCloseAutoFocus` → `preventDefault()` in the same file, which covers the focus restore Radix runs at unmount. That guard was already in place and was never what broke here.

The `DropdownMenuContent` line is preventive: the canvas tree's row menu opens an inline name field the same way, and its spec is blind to this for the same reason ours was.

## Release note

Renaming a note or folder from the sidebar menu no longer loses the name field a moment after it opens.

## Test plan

New `apps/desktop/tests/e2e/sidebar-folder-rename.e2e.ts` — plain tree, virtualized tree past the 100-item threshold, and a vault change landing mid-rename. The spec nudges the pointer in 6px steps for ~150ms after clicking the menu item: `page.click()` parks the mouse where it clicked, which is exactly why no existing spec (including the canvas one) could see this class of bug.

- `pnpm exec playwright test sidebar-folder-rename` — **3 failed** without this change, **3 passed** with it
- `pnpm exec vitest run --project renderer src/renderer/src/lib/inline-rename-focus.test.ts` — 5 passed
- `pnpm typecheck:web`, `pnpm typecheck:test` — clean
- `pnpm exec eslint` on the touched files — 0 errors (3 pre-existing warnings in `notes-tree.tsx`)
- `pnpm docs:impact --base 0cf8b839d --strict`, `pnpm docs:build` — clean

Root cause was pinned by patching `HTMLElement.prototype.focus` in the running app to log a stack per call plus capture-phase `focusout`; the theft shows up as `focus() DIV.bg-popover ← Object.onItemLeave` 10ms after the field focused itself.
