### PR TITLE
feat(links): let a memry:// link address a place inside a note (#1668)

### DIFF
--- a/apps/desktop/src/renderer/src/lib/memry-links.test.ts
+++ b/apps/desktop/src/renderer/src/lib/memry-links.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { isBlockReference, splitWikiTarget } from '@memry/shared/wiki-target'
 import { buildMemryHref, parseMemryHref, tabFromMemryHref } from './memry-links'
 
 /**
@@ -47,6 +48,114 @@ describe('parseMemryHref', () => {
     ['a calendar event with no id', 'memry://calendar/event/']
   ])('rejects %s', (_label, href) => {
     expect(parseMemryHref(href)).toBeNull()
+  })
+})
+
+/**
+ * A link can address a place inside a note. Two forms, because the two consumers
+ * outlive each other by different amounts: a click inside the running app can
+ * name a block id, while a link written into a saved canvas cannot — block ids
+ * are minted per document and die with it — so it names a heading by text.
+ */
+describe('parseMemryHref anchors', () => {
+  it('reads a block anchor, for a target that only has to survive this session', () => {
+    expect(parseMemryHref('memry://note/n1#^blk-1')).toEqual({
+      kind: 'note',
+      id: 'n1',
+      label: null,
+      anchor: { type: 'block', id: 'blk-1' }
+    })
+  })
+
+  it('reads a heading anchor by its text, which is what survives being written down', () => {
+    expect(parseMemryHref('memry://note/n1#Getting%20Started')).toEqual({
+      kind: 'note',
+      id: 'n1',
+      label: null,
+      anchor: { type: 'heading', text: 'Getting Started' }
+    })
+  })
+
+  it('reads the fragment exactly as a wiki link reads its heading half', () => {
+    // The convention is `splitWikiTarget` + `isBlockReference`, not a second
+    // grammar that happens to look similar: `#A#B` names `B` in both, and `^`
+    // marks a block in both.
+    expect(isBlockReference(splitWikiTarget('Note#^blk-1').heading ?? '')).toBe(true)
+    expect(parseMemryHref('memry://note/n1#A#B')).toEqual({
+      kind: 'note',
+      id: 'n1',
+      label: null,
+      anchor: { type: 'heading', text: splitWikiTarget('Note#A#B').heading }
+    })
+  })
+
+  it('keeps a heading that really starts with a caret out of the block form', () => {
+    // The marker is read before the fragment is decoded, so an encoded caret is
+    // text and a literal one is the marker.
+    expect(parseMemryHref('memry://note/n1#%5Ecaret')).toEqual({
+      kind: 'note',
+      id: 'n1',
+      label: null,
+      anchor: { type: 'heading', text: '^caret' }
+    })
+  })
+
+  it('carries the heading verbatim, leaving case-folding to whoever matches it', () => {
+    expect(parseMemryHref('memry://note/n1#Getting%20STARTED')).toEqual({
+      kind: 'note',
+      id: 'n1',
+      label: null,
+      anchor: { type: 'heading', text: 'Getting STARTED' }
+    })
+  })
+
+  it('resolves the same note whether or not the link carries an anchor', () => {
+    expect(parseMemryHref('memry://note/n1?label=Roadmap')).toEqual({
+      kind: 'note',
+      id: 'n1',
+      label: 'Roadmap'
+    })
+    expect(parseMemryHref('memry://note/n1?label=Roadmap#^blk-1')).toEqual({
+      kind: 'note',
+      id: 'n1',
+      label: 'Roadmap',
+      anchor: { type: 'block', id: 'blk-1' }
+    })
+  })
+
+  it('parses an unanchored link to the object it has always parsed to', () => {
+    // Not `anchor: null` — absent. Every existing caller destructures this
+    // result, and a link with no anchor must be indistinguishable from one
+    // written before anchors existed.
+    const parsed = parseMemryHref('memry://note/n1')
+    expect(parsed).toEqual({ kind: 'note', id: 'n1', label: null })
+    expect(Object.keys(parsed ?? {}).sort()).toEqual(['id', 'kind', 'label'])
+  })
+
+  it.each([
+    ['an empty fragment', 'memry://note/n1#'],
+    ['a block marker with no id', 'memry://note/n1#^'],
+    ['a fragment that will not decode', 'memry://note/n1#%zz'],
+    ['a fragment that is only whitespace', 'memry://note/n1#%20']
+  ])('drops %s and still resolves the note', (_label, href) => {
+    expect(parseMemryHref(href)).toEqual({ kind: 'note', id: 'n1', label: null })
+  })
+
+  it.each([
+    ['a task', 'memry://task/t1#^blk-1', { kind: 'task', id: 't1', label: null }],
+    ['an inbox item', 'memry://inbox/i1#Heading', { kind: 'inbox', id: 'i1', label: null }],
+    [
+      'a folder',
+      'memry://folder/Work%2FNotes#Heading',
+      { kind: 'folder', id: 'Work/Notes', label: null }
+    ],
+    [
+      'a calendar event',
+      'memry://calendar/event/e1?date=2026-08-17#Heading',
+      { kind: 'calendar_event', id: 'e1', date: '2026-08-17', label: null }
+    ]
+  ])('drops an anchor on %s, which has no inside to point at', (_label, href, expected) => {
+    expect(parseMemryHref(href)).toEqual(expected)
   })
 })
 
@@ -115,6 +224,88 @@ describe('buildMemryHref', () => {
   it('omits the label entirely when there is none, so old links stay byte-identical', () => {
     expect(buildMemryHref({ kind: 'note', id: 'n1' })).toBe('memry://note/n1')
     expect(buildMemryHref({ kind: 'note', id: 'n1', label: '' })).toBe('memry://note/n1')
+  })
+
+  it('round-trips a block anchor', () => {
+    const href = buildMemryHref({ kind: 'note', id: 'n1', anchor: { type: 'block', id: 'blk-1' } })
+    expect(href).toBe('memry://note/n1#^blk-1')
+    expect(parseMemryHref(href as string)).toEqual({
+      kind: 'note',
+      id: 'n1',
+      label: null,
+      anchor: { type: 'block', id: 'blk-1' }
+    })
+  })
+
+  it('round-trips a heading anchor, punctuation and all', () => {
+    for (const text of ['Getting Started', 'Q3 #4 & 50% done', 'Überschrift', '^caret', 'a?b']) {
+      const href = buildMemryHref({ kind: 'note', id: 'n1', anchor: { type: 'heading', text } })
+      expect(href).not.toBeNull()
+      expect(parseMemryHref(href as string)).toEqual({
+        kind: 'note',
+        id: 'n1',
+        label: null,
+        anchor: { type: 'heading', text }
+      })
+    }
+  })
+
+  it('keeps the label and the anchor side by side, query first', () => {
+    const href = buildMemryHref({
+      kind: 'note',
+      id: 'n1',
+      label: 'Roadmap',
+      anchor: { type: 'heading', text: 'Getting Started' }
+    })
+    expect(href).toBe('memry://note/n1?label=Roadmap#Getting%20Started')
+    expect(parseMemryHref(href as string)).toEqual({
+      kind: 'note',
+      id: 'n1',
+      label: 'Roadmap',
+      anchor: { type: 'heading', text: 'Getting Started' }
+    })
+  })
+
+  it('keeps an anchor out of the path and the query, which is all an older build reads', () => {
+    // The whole cross-version story. An older build resolves an item from the
+    // path and the query and never looks at the fragment, so it must be able to
+    // read an anchored link as the unanchored one, byte for byte.
+    const anchored = new URL(
+      buildMemryHref({
+        kind: 'note',
+        id: 'n1',
+        label: 'Roadmap',
+        anchor: { type: 'heading', text: 'Getting Started' }
+      }) as string
+    )
+    const plain = new URL(buildMemryHref({ kind: 'note', id: 'n1', label: 'Roadmap' }) as string)
+    expect(anchored.pathname).toBe(plain.pathname)
+    expect(anchored.search).toBe(plain.search)
+    expect(anchored.hash).not.toBe('')
+  })
+
+  it('writes no fragment at all when there is no anchor', () => {
+    expect(buildMemryHref({ kind: 'note', id: 'n1', anchor: null })).toBe('memry://note/n1')
+    expect(
+      buildMemryHref({ kind: 'note', id: 'n1', anchor: { type: 'heading', text: '  ' } })
+    ).toBe('memry://note/n1')
+    expect(buildMemryHref({ kind: 'note', id: 'n1', anchor: { type: 'block', id: '' } })).toBe(
+      'memry://note/n1'
+    )
+  })
+
+  it('ignores an anchor on a kind with no inside, rather than writing a dead one', () => {
+    expect(buildMemryHref({ kind: 'task', id: 't1', anchor: { type: 'block', id: 'blk-1' } })).toBe(
+      'memry://task/t1'
+    )
+    expect(
+      buildMemryHref({
+        kind: 'calendar_event',
+        id: 'e1',
+        date: '2026-08-17',
+        anchor: { type: 'heading', text: 'Agenda' }
+      })
+    ).toBe('memry://calendar/event/e1?date=2026-08-17')
   })
 })
 
@@ -202,6 +393,17 @@ describe('tabFromMemryHref', () => {
 
   it('returns null for anything the grammar rejects', () => {
     expect(tabFromMemryHref('https://example.com')).toBeNull()
+  })
+
+  it('opens an anchored note in exactly the tab the unanchored link opens', () => {
+    // A tab says WHICH item to open. Where inside it to land is the note page's
+    // business, read from `parseMemryHref(...).anchor` by whoever navigates.
+    expect(tabFromMemryHref('memry://note/n1#^blk-1', { title: 'Roadmap' })).toEqual(
+      tabFromMemryHref('memry://note/n1', { title: 'Roadmap' })
+    )
+    expect(tabFromMemryHref('memry://note/n1#Getting%20Started')).toEqual(
+      tabFromMemryHref('memry://note/n1')
+    )
   })
 
   it('never marks an opened tab as pinned, modified, preview or deleted', () => {

--- a/apps/desktop/src/renderer/src/lib/memry-links.ts
+++ b/apps/desktop/src/renderer/src/lib/memry-links.ts
@@ -10,8 +10,16 @@
  * Pure on purpose: `now` is a parameter rather than a `Date.now()` call so the
  * builder unit-tests without faking the clock, and so a caller that re-fires a
  * focus can control the token it stamps.
+ *
+ * A link can also address a place INSIDE a note, in the URL fragment. The
+ * fragment is deliberate: the parser resolves an item from the path and the
+ * query alone, so a build that has never heard of anchors — every build shipped
+ * before this one — reads the same note out of an anchored link and ignores the
+ * rest. That is the whole of the cross-version story, and it is why an anchor
+ * must never move into the query.
  */
 
+import { isBlockReference, splitWikiTarget } from '@memry/shared/wiki-target'
 import type { Tab } from '@/contexts/tabs/types'
 
 /** A tab descriptor as `openTab` accepts it — ids and timestamps are its job. */
@@ -26,14 +34,38 @@ export type MemryLinkKind =
   'note' | 'file' | 'task' | 'inbox' | 'journal' | 'project' | 'folder' | 'calendar_event'
 
 /**
+ * Where inside a note a link lands, in the two forms the two consumers need.
+ *
+ * A `block` anchor names a block by its id. Block ids are minted when a document
+ * is parsed and markdown does not carry them, so they live exactly as long as
+ * the collaborative document that minted them — a fresh device, a copied vault
+ * or a rebuild mints new ones. A block anchor is therefore only ever right for a
+ * click handed straight back into the same session.
+ *
+ * A `heading` anchor names a heading by its TEXT, which is all a link can carry
+ * that outlives the document: it is what survives being written into a canvas
+ * file, synced, and opened on another device months later. It is also already
+ * the house convention — `[[Note#Heading]]` names a heading by text, and the
+ * note page matches it with `normalizeHeading`, trimmed and case-folded, first
+ * match wins. Nothing here matches; this is the reading of the link.
+ */
+export type MemryAnchor = { type: 'block'; id: string } | { type: 'heading'; text: string }
+
+/**
  * `label` is the item's title as it read when the link was written. It exists so
  * a surface that can only render the link string — Excalidraw's link bubble
  * shows `element.link` verbatim, with no hook to change it — can still show a
  * name instead of an id, without a lookup and without being online. It is a
  * cached display hint, never an identity: the id is what resolves.
+ *
+ * `anchor` is present only when the link carries one this build can use, and
+ * only on `note`: a note is the only kind with an inside to address. It is
+ * absent — not null — when there is none, so an unanchored link parses to the
+ * object it has always parsed to.
  */
 export type ParsedMemryHref = { label: string | null } & (
-  | { kind: Exclude<MemryLinkKind, 'calendar_event'>; id: string }
+  | { kind: 'note'; id: string; anchor?: MemryAnchor }
+  | { kind: Exclude<MemryLinkKind, 'calendar_event' | 'note'>; id: string }
   | { kind: 'calendar_event'; id: string; date: string | null }
 )
 
@@ -44,6 +76,52 @@ type SimpleHost = (typeof SIMPLE_HOSTS)[number]
 
 function isSimpleHost(value: string): value is SimpleHost {
   return (SIMPLE_HOSTS as readonly string[]).includes(value)
+}
+
+/** Percent-decodes one half of an anchor, or null when it says nothing. */
+function decodeAnchorPart(value: string): string | null {
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(value)
+  } catch {
+    // A malformed percent escape. The note came out of the path and is already
+    // resolved, so the anchor is what gets dropped, never the link.
+    return null
+  }
+  return decoded.trim() || null
+}
+
+/**
+ * The fragment, read as the heading half of a wiki-link target.
+ *
+ * `memry://note/n1#Heading` is `[[Note#Heading]]` and `memry://note/n1#^b3` is
+ * `[[Note#^b3]]`, on purpose: one convention for "an item, then a place inside
+ * it" rather than a second one that reads differently. `splitWikiTarget` is
+ * what splits it, so `#A#B` names `B` here exactly as it does there, and
+ * `isBlockReference` is what tells the two forms apart.
+ *
+ * The `^` marker is tested BEFORE decoding, which is what keeps a heading whose
+ * text really begins with a caret — written `%5E…` — from being read as a block.
+ *
+ * Null for every anchor this build cannot turn into a place: no fragment, a
+ * block marker with no id, a fragment that will not decode. An anchor FORM a
+ * later build invents is not null but is equally harmless — it reads as heading
+ * text that matches no heading, and the reader lands at the top of the note,
+ * which is where a build with no anchors at all would have put them.
+ */
+function parseAnchor(hash: string): MemryAnchor | null {
+  // `url.hash` keeps its leading `#`, which is the separator `splitWikiTarget`
+  // looks for — an empty fragment is the empty string and splits to no heading.
+  const { heading } = splitWikiTarget(hash)
+  if (!heading) return null
+
+  if (isBlockReference(heading)) {
+    const id = decodeAnchorPart(heading.slice(1))
+    return id ? { type: 'block', id } : null
+  }
+
+  const text = decodeAnchorPart(heading)
+  return text ? { type: 'heading', text } : null
 }
 
 export function parseMemryHref(href: string): ParsedMemryHref | null {
@@ -60,12 +138,19 @@ export function parseMemryHref(href: string): ParsedMemryHref | null {
   if (!id) return null
 
   const label = url.searchParams.get('label')
+  const host = url.hostname
 
-  if (isSimpleHost(url.hostname)) {
-    return { kind: url.hostname, id, label }
+  if (isSimpleHost(host)) {
+    if (host === 'note') {
+      const anchor = parseAnchor(url.hash)
+      return anchor ? { kind: 'note', id, label, anchor } : { kind: 'note', id, label }
+    }
+    // Every other kind is a whole item, with no inside to point at, so an
+    // anchor on one is dropped and the item still opens.
+    return { kind: host, id, label }
   }
 
-  if (url.hostname === 'calendar') {
+  if (host === 'calendar') {
     const parts = url.pathname.split('/').filter(Boolean)
     if (parts[0] !== 'event' || !parts[1]) return null
     return {
@@ -86,14 +171,38 @@ export interface MemryHrefInput {
   date?: string | null
   /** The item's title, carried along as a display hint. See `ParsedMemryHref`. */
   label?: string | null
+  /**
+   * Where inside the note to land. Ignored by every other kind, which has no
+   * inside — a link to a task opens the task, anchor or no anchor.
+   *
+   * A link that will be written to disk must use a `heading` anchor: block ids
+   * die with the document that minted them. See `MemryAnchor`.
+   */
+  anchor?: MemryAnchor | null
+}
+
+/** The fragment for an anchor, `#` included, or '' when there is nothing to say. */
+function buildAnchorFragment(anchor: MemryAnchor | null | undefined): string {
+  if (!anchor) return ''
+  if (anchor.type === 'block') {
+    const id = anchor.id.trim()
+    // The `^` stays literal — it is the marker the parser reads before it
+    // decodes, and encoding it would make the anchor a heading called `^id`.
+    return id ? `#^${encodeURIComponent(id)}` : ''
+  }
+  const text = anchor.text.trim()
+  return text ? `#${encodeURIComponent(text)}` : ''
 }
 
 /**
  * The inverse of `parseMemryHref`. Returns null when the input cannot produce a
  * link that resolves — a calendar event with no date has no day to focus, so a
  * link to it would parse and then refuse to open.
+ *
+ * An anchor that says nothing is left off rather than refused: the note is what
+ * the link is for, and it opens either way.
  */
-export function buildMemryHref({ kind, id, date, label }: MemryHrefInput): string | null {
+export function buildMemryHref({ kind, id, date, label, anchor }: MemryHrefInput): string | null {
   if (!id) return null
 
   const params = new URLSearchParams()
@@ -108,7 +217,8 @@ export function buildMemryHref({ kind, id, date, label }: MemryHrefInput): strin
       ? `memry://calendar/event/${encodeURIComponent(id)}`
       : `memry://${kind}/${encodeURIComponent(id)}`
   const query = params.toString()
-  return query ? `${path}?${query}` : path
+  const fragment = kind === 'note' ? buildAnchorFragment(anchor) : ''
+  return `${path}${query ? `?${query}` : ''}${fragment}`
 }
 
 export interface TabFromHrefOptions {
@@ -131,6 +241,10 @@ const BASE = {
 /**
  * Builds the tab that opens a `memry://` href "as if the item were clicked in
  * its home view". Returns null for anything this grammar cannot resolve.
+ *
+ * An anchor the href carries is deliberately not read here. A tab says WHICH
+ * item to open; where inside it to land is the page's own business, and the
+ * caller that wants it reads `parseMemryHref(...).anchor`.
  */
 export function tabFromMemryHref(
   href: string,


### PR DESCRIPTION
Closes #1668. Part of #1667.

## What changed

The `memry://` grammar could only name an item. It now also carries an **anchor** naming a place inside a **note**, in two forms — because the two consumers outlive each other by different amounts.

| Form | Written as | For |
| --- | --- | --- |
| `{ type: 'block', id }` | `memry://note/n1#^blk-1` | a click handed straight back into the same session |
| `{ type: 'heading', text }` | `memry://note/n1#Getting%20Started` | a link written into a saved canvas, which outlives the document |

Block ids are minted when a document is parsed and markdown does not carry them, so they live exactly as long as the collaborative document that minted them — a fresh device, a copied vault or a rebuild mints new ones. Anything durable must name a heading by its text.

**One convention, not two.** The fragment is read as the heading half of a wiki-link target, through `splitWikiTarget` and `isBlockReference` from `@memry/shared/wiki-target`: `#A#B` names `B` here exactly as `[[Note#A#B]]` does, and `^` marks a block in both. No new sigil was invented.

**The anchor lives in the URL fragment**, and that placement is the whole cross-version story: `parseMemryHref` resolves an item from the path and the query alone, so every build shipped before this one reads the same note out of an anchored link and ignores the rest. A test asserts the fragment never leaks into `pathname` or `search`, so a later change that moves the anchor into a query parameter goes red.

**Nothing disappears silently.** An anchor is dropped — never the link — when it names nothing this build can use (no fragment, a `^` with no id, a fragment that will not percent-decode) or when the kind has no inside to point at (task, inbox, folder, calendar event).

**Groundwork only, no user-visible change.** No caller writes an anchor yet, and `tabFromMemryHref` deliberately does not read one — a tab says *which* item to open; *where inside it* to land is the page's business. Navigation wiring is a follow-up ticket. A link with no anchor parses and builds byte-identically to before: `anchor` is *absent*, not null, so the parsed object is the object every existing caller already destructures.

Touches no IPC contract, no migration, no sync handler and no settings schema.

## Acceptance criteria

- [x] **The grammar can carry a block anchor and a heading-text anchor, and both round-trip through building and parsing.** `buildMemryHref` gains `anchor`; `parseMemryHref` returns it on `note`. Tests: `round-trips a block anchor`, `round-trips a heading anchor, punctuation and all` (spaces, `#`, `&`, `%`, non-ASCII, `?`, a literal leading caret).
- [x] **Heading-text anchors resolve by the same split-first, text-matching convention already used for wiki links that name a heading.** The fragment goes through `splitWikiTarget` + `isBlockReference`. Test `reads the fragment exactly as a wiki link reads its heading half` pins the equivalence against those functions directly. The anchor text is carried verbatim so `normalizeHeading` at the consumer does the case-folding, exactly as the `[[Note#Heading]]` path does.
- [x] **Parsing a link whose anchor is unrecognised still resolves the note and drops the anchor.** Four cases for an unusable anchor (`#`, `#^`, `#%zz`, `#%20`) and four for a kind with no inside (task, inbox, folder, calendar event) all assert the item still resolves with no anchor. The placement test above locks in the older-build guarantee itself.
- [x] **Links with no anchor behave exactly as they do today.** `parses an unanchored link to the object it has always parsed to` asserts the key set is exactly `id, kind, label` — not `anchor: undefined`. `writes no fragment at all when there is no anchor` keeps the built string byte-identical. `opens an anchored note in exactly the tab the unanchored link opens` covers `tabFromMemryHref`. Every pre-existing test in the file is unchanged and still green.
- [x] **Unit tests cover round-tripping both anchor forms, unknown-anchor tolerance, and a no-anchor regression.** 59 tests in `memry-links.test.ts`, up from 32.

Mutation-tested rather than eyeballed — three deliberate breakages, each caught:

| Mutation | Killed by |
| --- | --- |
| anchor written into the query instead of the fragment | 4 tests, including the placement guard |
| fragment decoded *before* the `^` marker is tested | 2 tests (a heading really starting with a caret) |
| `anchor` key always present, `undefined` when empty | 1 test (the no-anchor regression) |

## Gates

```
pnpm lint            → exit 0   (105 warnings, 0 errors — all pre-existing style warnings on main)
pnpm typecheck       → exit 0
pnpm test:desktop    → exit 0   Test Files 1370 passed | 3 skipped (1373)
                                Tests 17793 passed | 1 expected fail | 13 skipped (17807)
pnpm --filter @memry/desktop i18n:check → exit 0   "ok: i18n check passed"
```

Full-repo `pnpm test` is red for two reasons, neither of them this branch:

1. **`@memry/i18n` is red on `origin/main`.** `src/locales/icu-brace-style.test.ts` fails on `en/common.json → canvas.link.useUrl: Link to {{url}}` and `phaseF.componentsAppSidebar.sortLabel: Sort {{section}}: {{mode}}`. Both strings are committed at `origin/main` (`git show origin/main:packages/i18n/src/locales/en/common.json` lines 322 and 416) and this branch touches no locale file. Flagged separately.
2. **`@memry/desktop` SIGSEGV'd once under turbo** — the known turbo flake. Run standalone it is fully green, as above.

`pnpm docs:impact --base 0e52164 --strict` reports `missing-docs` for `memry-links.ts`, waived with `MEMRY_DOCS_IMPACT_SKIP=1`. Reason: there is no user-facing behaviour to document. `apps/docs/src` has no page mentioning `memry://` or deep links at all, no caller writes an anchor, and no navigation reads one. The user-facing documentation belongs with the feature that ships the anchors.

## Files

- `apps/desktop/src/renderer/src/lib/memry-links.ts`
- `apps/desktop/src/renderer/src/lib/memry-links.test.ts`
