### PR TITLE
fix(i18n): interpolate two English strings with ICU single braces

### DIFF
--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -319,7 +319,7 @@
       "groupJournals": "Journals",
       "groupProjects": "Projects",
       "groupFolders": "Folders",
-      "useUrl": "Link to {{url}}",
+      "useUrl": "Link to {url}",
       "shapeTarget": "A shape on this canvas",
       "missingTarget": "No longer on this canvas"
     },
@@ -413,7 +413,7 @@
       "updateRestart": "Restart",
       "updateInstallingTitle": "Installing update",
       "updateInstallingSubtitle": "MemryNote will restart automatically.",
-      "sortLabel": "Sort {{section}}: {{mode}}",
+      "sortLabel": "Sort {section}: {mode}",
       "sortModeManual": "Manual",
       "sortModeNameAsc": "Name A → Z",
       "sortModeNameDesc": "Name Z → A",


### PR DESCRIPTION
## What

Two English strings were written with i18next double braces. Memry registers an ICU formatter (`packages/i18n/src/shared/icu-formatter.ts`), which cannot parse `{{` — it catches the parse error and returns the raw template, by design, so the bug is visible. Both strings therefore render **literally** in the UI:

- `canvas.link.useUrl` — the canvas link picker offers "Link to {{url}}" instead of the URL you typed.
- `phaseF.componentsAppSidebar.sortLabel` — every sidebar sort trigger reads "Sort {{section}}: {{mode}}".

Both call sites already pass the right parameters, so only the strings were wrong:

- `apps/desktop/src/renderer/src/pages/canvas/canvas-link-dialog.tsx:178` → `t('canvas.link.useUrl', { url: typedUrl })`
- `apps/desktop/src/renderer/src/components/sidebar/use-sidebar-sort-labels.ts:34` → `t('phaseF.componentsAppSidebar.sortLabel', { section, mode })`

English is the only locale affected — every other locale already carries the single-brace form.

## Why now

`pnpm --filter @memry/i18n test` has been **red on `main`** since `f814ca48a` (17 Aug) on the first string, with the second added by `3e812264c5` (20 Aug). `locales/icu-brace-style.test.ts` compiles every locale string with `IntlMessageFormat` and flags both. That red makes the repo-wide `pnpm test` gate red for every branch, so an unrelated PR cannot show a clean gate.

## Verification

```
pnpm --filter @memry/i18n test        exit 0
   Test Files  11 passed (11)
        Tests  56 passed (56)

pnpm --filter @memry/desktop i18n:check   exit 0
   ok: i18n check passed

pnpm docs:impact --base origin/main --strict   exit 0
   docs impact: no desktop/sync-server docs-relevant changes detected
```

Before the change, on `main` at `0e5216478`:

```
 - []
 + [
 +   "en/common.json → canvas.link.useUrl: MALFORMED_ARGUMENT (Link to {{url}})",
 +   "en/common.json → phaseF.componentsAppSidebar.sortLabel: MALFORMED_ARGUMENT (Sort {{section}}: {{mode}})",
 + ]
   Test Files  1 failed | 10 passed (11)
        Tests  2 failed | 54 passed (56)
```

No schema, contract, migration or sync change — two string values in one locale file.