### PR TITLE
feat(notes): show a note's headings as a mind map behind a header toggle

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Every projection and layout rule of the mind map, asserted through the single
+ * public entry point and nothing else. No DOM is involved, which is what makes
+ * this coverage cheap enough to be exhaustive.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { buildMindMap } from './build-mind-map'
+import type { MindMapNode, MindMapSourceBlock } from './mind-map-types'
+
+function heading(id: string, level: number, text: string): MindMapSourceBlock {
+  return { id, type: 'heading', props: { level }, content: [{ type: 'text', text }] }
+}
+
+function paragraph(id: string, text: string): MindMapSourceBlock {
+  return { id, type: 'paragraph', content: [{ type: 'text', text }] }
+}
+
+/** Labels of a node's children, in order. */
+function childLabels(node: MindMapNode): string[] {
+  return node.children.map((child) => child.label)
+}
+
+function labelled(tree: MindMapNode, label: string): MindMapNode {
+  const found = [
+    tree,
+    ...tree.children.flatMap(function walk(node): MindMapNode[] {
+      return [node, ...node.children.flatMap(walk)]
+    })
+  ].find((node) => node.label === label)
+  if (!found) throw new Error(`no node labelled ${label}`)
+  return found
+}
+
+describe('buildMindMap — projection', () => {
+  it('roots the map at the note title, never at the first heading', () => {
+    const map = buildMindMap([heading('h1', 1, 'Overview')], { rootLabel: 'Quarterly plan' })
+
+    expect(map.tree.kind).toBe('root')
+    expect(map.tree.label).toBe('Quarterly plan')
+    expect(map.tree.blockId).toBeNull()
+    expect(childLabels(map.tree)).toEqual(['Overview'])
+  })
+
+  it('branches sub-headings off their parent heading', () => {
+    const map = buildMindMap(
+      [
+        heading('a', 1, 'Alpha'),
+        heading('b', 2, 'Alpha one'),
+        heading('c', 2, 'Alpha two'),
+        heading('d', 1, 'Beta')
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    expect(childLabels(map.tree)).toEqual(['Alpha', 'Beta'])
+    expect(childLabels(labelled(map.tree, 'Alpha'))).toEqual(['Alpha one', 'Alpha two'])
+    expect(childLabels(labelled(map.tree, 'Beta'))).toEqual([])
+  })
+
+  it('mints no phantom node for a skipped heading level', () => {
+    // H1 then H3: the H3 goes one step deeper, and no H2 is invented to sit
+    // between them.
+    const map = buildMindMap([heading('a', 1, 'Alpha'), heading('b', 3, 'Deep')], {
+      rootLabel: 'Note'
+    })
+
+    expect(map.nodeCount).toBe(3)
+    expect(childLabels(map.tree)).toEqual(['Alpha'])
+    const deep = labelled(map.tree, 'Deep')
+    expect(childLabels(labelled(map.tree, 'Alpha'))).toEqual(['Deep'])
+    // Relative depth is what places it; the level it was written at is kept.
+    expect(deep.depth).toBe(2)
+    expect(deep.level).toBe(3)
+  })
+
+  it('attaches a deep first heading straight to the root', () => {
+    const map = buildMindMap([heading('a', 4, 'Details'), heading('b', 5, 'Finer')], {
+      rootLabel: 'Note'
+    })
+
+    const details = labelled(map.tree, 'Details')
+    expect(childLabels(map.tree)).toEqual(['Details'])
+    expect(details.depth).toBe(1)
+    expect(details.level).toBe(4)
+    expect(childLabels(details)).toEqual(['Finer'])
+  })
+
+  it('lets content before the first heading attach to the root without minting nodes', () => {
+    const map = buildMindMap(
+      [
+        paragraph('p1', 'A preamble the map does not draw.'),
+        paragraph('p2', 'Nor this one.'),
+        heading('a', 2, 'First section')
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    expect(map.nodeCount).toBe(2)
+    expect(childLabels(map.tree)).toEqual(['First section'])
+    expect(labelled(map.tree, 'First section').depth).toBe(1)
+  })
+
+  it('finds headings nested inside container blocks', () => {
+    const map = buildMindMap(
+      [
+        heading('a', 1, 'Alpha'),
+        {
+          id: 'toggle',
+          type: 'toggleListItem',
+          content: [{ type: 'text', text: 'Collapsed' }],
+          children: [heading('b', 2, 'Hidden section')]
+        }
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    expect(childLabels(labelled(map.tree, 'Alpha'))).toEqual(['Hidden section'])
+  })
+
+  it('folds a blank heading into the nearest labelled ancestor instead of drawing an empty box', () => {
+    const map = buildMindMap(
+      [heading('a', 1, 'Alpha'), heading('blank', 2, '   '), heading('c', 3, 'Still visible')],
+      { rootLabel: 'Note' }
+    )
+
+    expect(map.nodeCount).toBe(3)
+    expect(childLabels(labelled(map.tree, 'Alpha'))).toEqual(['Still visible'])
+  })
+
+  it('reads a label out of styled, linked and content-less inline shapes', () => {
+    const map = buildMindMap(
+      [
+        {
+          id: 'h',
+          type: 'heading',
+          props: { level: 1 },
+          content: [
+            { type: 'text', text: 'Ship ' },
+            { type: 'link', href: 'https://memry.test', content: [{ type: 'text', text: 'v2' }] },
+            { type: 'text', text: ' with ' },
+            { type: 'wikiLink', props: { target: 'Roadmap', alias: 'the roadmap' } }
+          ]
+        }
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    expect(childLabels(map.tree)).toEqual(['Ship v2 with the roadmap'])
+  })
+
+  it('collapses whitespace but never translates or rewrites the label', () => {
+    const map = buildMindMap([heading('a', 1, '  Björk\n  &  Co  ')], { rootLabel: '  My note ' })
+
+    expect(map.tree.label).toBe('  My note ')
+    expect(childLabels(map.tree)).toEqual(['Björk & Co'])
+  })
+
+  it('opens an empty note with the root alone', () => {
+    const map = buildMindMap([], { rootLabel: 'Empty' })
+
+    expect(map.isEmpty).toBe(true)
+    expect(map.nodeCount).toBe(1)
+    expect(map.tree.children).toEqual([])
+    expect(map.nodes).toHaveLength(1)
+    // Still a drawable map: the root box exists and no connector dangles.
+    expect(map.elements).toHaveLength(1)
+    expect(map.elements[0]).toMatchObject({ type: 'rectangle', id: map.tree.id })
+  })
+
+  it('is not empty as soon as one heading exists', () => {
+    const map = buildMindMap([heading('a', 1, 'One')], { rootLabel: 'Note' })
+    expect(map.isEmpty).toBe(false)
+  })
+})
+
+describe('buildMindMap — layout', () => {
+  const twoChildren = [heading('a', 1, 'A'), heading('b', 1, 'B')]
+
+  it('places the root on the leading side with its children in the next column', () => {
+    const map = buildMindMap(twoChildren, { rootLabel: 'Note' })
+
+    expect(map.nodes.map((node) => [node.label, node.x, node.y, node.width, node.height])).toEqual([
+      ['Note', 0, 29, 96, 42],
+      ['A', 168, 0, 96, 42],
+      ['B', 168, 58, 96, 42]
+    ])
+    expect(map.bounds).toEqual({ minX: 0, minY: 0, maxX: 264, maxY: 100 })
+  })
+
+  it('mirrors the whole map in an RTL locale', () => {
+    const map = buildMindMap(twoChildren, { rootLabel: 'Note', direction: 'rtl' })
+
+    expect(map.direction).toBe('rtl')
+    expect(map.nodes.map((node) => [node.label, node.x, node.y])).toEqual([
+      ['Note', -96, 29],
+      ['A', -264, 0],
+      ['B', -264, 58]
+    ])
+    // Same shape, opposite side: children sit before the root in reading order.
+    const root = map.nodes[0]
+    for (const child of map.nodes.slice(1)) expect(child.x).toBeLessThan(root.x)
+  })
+
+  it('keeps every depth in its own column and never overlaps two boxes in one', () => {
+    const map = buildMindMap(
+      [
+        heading('a', 1, 'Alpha'),
+        heading('a1', 2, 'Alpha one'),
+        heading('a2', 2, 'Alpha two with a considerably longer heading than its sibling'),
+        heading('b', 1, 'Beta'),
+        heading('b1', 2, 'Beta one'),
+        heading('b2', 3, 'Beta one deep')
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    const columns = new Map<number, number[]>()
+    for (const node of map.nodes) {
+      const xs = columns.get(node.depth) ?? []
+      xs.push(node.x)
+      columns.set(node.depth, xs)
+    }
+    // One x per depth.
+    for (const xs of columns.values()) expect(new Set(xs).size).toBe(1)
+    // Columns advance with depth.
+    const xByDepth = [...columns.entries()].sort((l, r) => l[0] - r[0]).map(([, xs]) => xs[0])
+    for (let i = 1; i < xByDepth.length; i += 1)
+      expect(xByDepth[i]).toBeGreaterThan(xByDepth[i - 1])
+
+    for (const [, xs] of columns) {
+      const inColumn = map.nodes.filter((node) => node.x === xs[0]).sort((l, r) => l.y - r.y)
+      for (let i = 1; i < inColumn.length; i += 1) {
+        expect(inColumn[i].y).toBeGreaterThanOrEqual(inColumn[i - 1].y + inColumn[i - 1].height)
+      }
+    }
+  })
+
+  it('centres a parent on the span of its children', () => {
+    const map = buildMindMap(
+      [heading('a', 1, 'Alpha'), heading('a1', 2, 'One'), heading('a2', 2, 'Two')],
+      { rootLabel: 'Note' }
+    )
+
+    const byLabel = new Map(map.nodes.map((node) => [node.label, node]))
+    const parent = byLabel.get('Alpha')!
+    const first = byLabel.get('One')!
+    const last = byLabel.get('Two')!
+    const span = (first.y + first.height / 2 + (last.y + last.height / 2)) / 2
+    expect(parent.y + parent.height / 2).toBeCloseTo(span, 0)
+  })
+
+  it('grows a box taller when its label needs more than one line', () => {
+    const map = buildMindMap(
+      [
+        heading('short', 1, 'Short'),
+        heading('long', 1, 'A heading long enough to wrap onto a second line in the map')
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    const byLabel = new Map(map.nodes.map((node) => [node.label, node]))
+    const short = byLabel.get('Short')!
+    const long = byLabel.get('A heading long enough to wrap onto a second line in the map')!
+    expect(long.height).toBeGreaterThan(short.height)
+    // Wider too, but only up to the box cap — past that the label wraps.
+    expect(long.width).toBeGreaterThan(short.width)
+    expect(long.width).toBe(264)
+  })
+
+  it('lays the same note out identically on every call', () => {
+    const blocks = [
+      heading('a', 1, 'Alpha'),
+      heading('a1', 3, 'Skipped level'),
+      paragraph('p', 'ignored'),
+      heading('b', 1, 'Beta'),
+      heading('b1', 2, 'Beta one')
+    ]
+
+    const first = buildMindMap(blocks, { rootLabel: 'Note' })
+    const second = buildMindMap(blocks, { rootLabel: 'Note' })
+    const third = buildMindMap(structuredClone(blocks), { rootLabel: 'Note' })
+
+    expect(second).toEqual(first)
+    expect(third).toEqual(first)
+    // Spelt out because coordinates drifting is the failure that costs the user
+    // their spatial memory of their own note.
+    expect(second.nodes.map((node) => [node.id, node.x, node.y])).toEqual(
+      first.nodes.map((node) => [node.id, node.x, node.y])
+    )
+  })
+})
+
+describe('buildMindMap — elements', () => {
+  const map = buildMindMap(
+    [heading('a', 1, 'Alpha'), heading('a1', 2, 'Alpha one'), heading('b', 1, 'Beta')],
+    { rootLabel: 'Note' }
+  )
+
+  it('mints one box per node and one connector per edge', () => {
+    const boxes = map.elements.filter((element) => element.type === 'rectangle')
+    const edges = map.elements.filter((element) => element.type === 'line')
+
+    expect(boxes).toHaveLength(map.nodeCount)
+    expect(edges).toHaveLength(map.nodeCount - 1)
+    expect(boxes.map((box) => box.id)).toEqual(map.nodes.map((node) => node.id))
+  })
+
+  it('gives every element a unique id and every connector two real endpoints', () => {
+    const ids = map.elements.map((element) => element.id)
+    expect(new Set(ids).size).toBe(ids.length)
+
+    const boxIds = new Set(map.nodes.map((node) => node.id))
+    for (const element of map.elements) {
+      if (element.type !== 'line') continue
+      // A connector is named after the child it lands on, and every child in
+      // the map has a box; a dangling connector would draw a line to nowhere.
+      expect(boxIds.has(element.id.replace(/-edge$/, ''))).toBe(true)
+      expect(element.points).toHaveLength(2)
+      expect(element.points[0]).toEqual([0, 0])
+    }
+  })
+
+  it('draws connectors from the parent box to the child box', () => {
+    const byId = new Map(map.nodes.map((node) => [node.id, node]))
+    for (const element of map.elements) {
+      if (element.type !== 'line') continue
+      const child = byId.get(element.id.replace(/-edge$/, ''))!
+      const parent = byId.get(child.parentId!)!
+      expect(element.x).toBe(parent.x + parent.width)
+      expect(element.x + element.points[1][0]).toBe(child.x)
+    }
+  })
+
+  it('carries the label as user content, undecorated', () => {
+    const boxes = map.elements.filter((element) => element.type === 'rectangle')
+    expect(boxes.map((box) => box.label.text)).toEqual(map.nodes.map((node) => node.label))
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.ts
@@ -1,0 +1,36 @@
+/**
+ * The one public entry point into the mind map.
+ *
+ * An editor block tree plus options in; the logical tree, the positioned nodes
+ * and the drawing elements out, together. Projection, layout and element
+ * minting are private steps behind this call, so every rule about any of them
+ * is asserted here — at whichever layer of the result suits the assertion — and
+ * the internal decomposition stays free to change without a red suite.
+ *
+ * Pure: no DOM, no clock, no randomness. The same blocks always produce the
+ * same result, coordinates included.
+ */
+
+import { layoutMindMap } from './mind-map-layout'
+import { mintElements } from './mind-map-elements'
+import { projectBlocks } from './mind-map-projection'
+import type { MindMap, MindMapOptions, MindMapSourceBlock } from './mind-map-types'
+
+export function buildMindMap(
+  blocks: readonly MindMapSourceBlock[],
+  options: MindMapOptions
+): MindMap {
+  const direction = options.direction ?? 'ltr'
+  const tree = projectBlocks(blocks, options.rootLabel)
+  const { nodes, bounds } = layoutMindMap(tree, direction)
+
+  return {
+    tree,
+    nodes,
+    elements: mintElements(nodes, direction),
+    direction,
+    nodeCount: nodes.length,
+    isEmpty: tree.children.length === 0,
+    bounds
+  }
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/index.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Note mind map — a derived, read-only view of a note's own structure.
+ *
+ * `buildMindMap` is the single entry point into the pipeline: projection,
+ * layout and element minting live behind it and are not separately seamed.
+ */
+
+export { buildMindMap } from './build-mind-map'
+export { MindMapView } from './mind-map-view'
+export { MIND_MAP_VIEW_STATE_KEY, useMindMap } from './use-mind-map'
+export type { UseMindMapResult } from './use-mind-map'
+export type {
+  MindMap,
+  MindMapBounds,
+  MindMapDirection,
+  MindMapElement,
+  MindMapNode,
+  MindMapNodeKind,
+  MindMapOptions,
+  MindMapPositionedNode,
+  MindMapSourceBlock
+} from './mind-map-types'

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.tsx
@@ -1,0 +1,75 @@
+/**
+ * The Excalidraw-importing chunk of the mind map.
+ *
+ * Loaded lazily from `MindMapView` for the same reason `CanvasEditor` is loaded
+ * lazily from `CanvasPage`: @excalidraw/excalidraw and its CSS stay out of the
+ * main renderer bundle, and are never fetched by a user who never opens a map.
+ * Fonts are self-hosted (see public/excalidraw-asset-path.js) because the CSP
+ * blocks Excalidraw's CDN.
+ *
+ * Read-only by construction: the map is a derived view of the note, never a
+ * document, so the surface is mounted in view mode and nothing here writes.
+ */
+
+import { useEffect, useRef } from 'react'
+import { Excalidraw, convertToExcalidrawElements } from '@excalidraw/excalidraw'
+import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
+import type { ExcalidrawElementSkeleton } from '@excalidraw/excalidraw/data/transform'
+import '@excalidraw/excalidraw/index.css'
+import { useTheme } from 'next-themes'
+import type { MindMapElement } from './mind-map-types'
+
+/**
+ * The map's element descriptors are plain data so the pipeline that mints them
+ * stays pure and testable without this chunk. Excalidraw's own skeleton type
+ * brands its point tuples, which no plain literal can satisfy, so the handover
+ * happens here, once, at the boundary.
+ */
+const toSkeleton = (elements: readonly MindMapElement[]): ExcalidrawElementSkeleton[] =>
+  elements as unknown as ExcalidrawElementSkeleton[]
+
+interface MindMapCanvasProps {
+  elements: readonly MindMapElement[]
+}
+
+export function MindMapCanvas({ elements }: MindMapCanvasProps): React.JSX.Element {
+  const { resolvedTheme } = useTheme()
+  const apiRef = useRef<ExcalidrawImperativeAPI | null>(null)
+
+  // Re-feeding the scene rather than remounting keeps the camera and the
+  // library's own warm-up across a rebuild of the same note.
+  useEffect(() => {
+    const api = apiRef.current
+    if (!api) return
+    api.updateScene({ elements: convertToExcalidrawElements(toSkeleton(elements)) })
+    api.scrollToContent(undefined, { fitToContent: true, animate: false })
+  }, [elements])
+
+  return (
+    <Excalidraw
+      excalidrawAPI={(instance) => {
+        apiRef.current = instance
+      }}
+      initialData={{
+        elements: convertToExcalidrawElements(toSkeleton(elements)),
+        appState: { viewBackgroundColor: 'transparent' },
+        scrollToContent: true
+      }}
+      viewModeEnabled
+      zenModeEnabled
+      UIOptions={{
+        canvasActions: {
+          export: false,
+          loadScene: false,
+          saveToActiveFile: false,
+          changeViewBackgroundColor: false,
+          clearCanvas: false,
+          toggleTheme: false
+        }
+      }}
+      // Three Memry themes exist (light/dark/white); anything not dark maps to
+      // Excalidraw's light theme.
+      theme={resolvedTheme === 'dark' ? 'dark' : 'light'}
+    />
+  )
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
@@ -1,0 +1,87 @@
+/**
+ * Private step 3 — positioned nodes become drawing elements.
+ *
+ * Plain data only: the drawing library turns these into a scene, and the same
+ * descriptors are what a saved canvas will be minted from later. One code path
+ * for both is the reason the map is drawn with the canvas renderer at all — two
+ * renderers would make "save as canvas" a WYSIWYG lie.
+ */
+
+import { MIND_MAP_FONT_SIZE } from './mind-map-layout'
+import type { MindMapDirection, MindMapElement, MindMapPositionedNode } from './mind-map-types'
+
+/**
+ * Authored for the light theme; the drawing library derives the dark one. Calm
+ * and restrained on purpose — the map is a reading surface, not a chart.
+ */
+const ROOT_STROKE = '#ff671a'
+const ROOT_FILL = '#fff1e8'
+const NODE_STROKE = '#868e96'
+const NODE_FILL = '#ffffff'
+const LABEL_COLOR = '#1e1e1e'
+const EDGE_STROKE = '#adb5bd'
+/** Adaptive corner radius. */
+const ROUNDNESS = { type: 3 }
+
+export function mintElements(
+  nodes: readonly MindMapPositionedNode[],
+  direction: MindMapDirection
+): MindMapElement[] {
+  const byId = new Map(nodes.map((node) => [node.id, node]))
+  const elements: MindMapElement[] = []
+
+  // Connectors first so the boxes sit on top of them.
+  for (const node of nodes) {
+    if (node.parentId === null) continue
+    const parent = byId.get(node.parentId)
+    if (!parent) continue
+
+    // The connector leaves the parent's trailing edge and lands on the child's
+    // leading edge — which side that is follows the reading direction.
+    const startX = direction === 'rtl' ? parent.x : parent.x + parent.width
+    const startY = parent.y + Math.round(parent.height / 2)
+    const endX = direction === 'rtl' ? node.x + node.width : node.x
+    const endY = node.y + Math.round(node.height / 2)
+
+    elements.push({
+      type: 'line',
+      id: `${node.id}-edge`,
+      x: startX,
+      y: startY,
+      points: [
+        [0, 0],
+        [endX - startX, endY - startY]
+      ],
+      strokeColor: EDGE_STROKE,
+      strokeWidth: 1,
+      roughness: 0
+    })
+  }
+
+  for (const node of nodes) {
+    const isRoot = node.kind === 'root'
+    elements.push({
+      type: 'rectangle',
+      id: node.id,
+      x: node.x,
+      y: node.y,
+      width: node.width,
+      height: node.height,
+      strokeColor: isRoot ? ROOT_STROKE : NODE_STROKE,
+      backgroundColor: isRoot ? ROOT_FILL : NODE_FILL,
+      fillStyle: 'solid',
+      strokeWidth: 1,
+      roughness: 0,
+      roundness: ROUNDNESS,
+      label: {
+        text: node.label,
+        fontSize: MIND_MAP_FONT_SIZE,
+        textAlign: direction === 'rtl' ? 'right' : 'left',
+        verticalAlign: 'middle',
+        strokeColor: LABEL_COLOR
+      }
+    })
+  }
+
+  return elements
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-layout.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-layout.ts
@@ -1,0 +1,156 @@
+/**
+ * Private step 2 — a logical tree becomes positioned nodes.
+ *
+ * A horizontal tidy tree with variable node heights, root on the leading side.
+ * Every number below is integer arithmetic over the label text and the tree
+ * shape alone: no measurement, no randomness, no clock. That is what makes the
+ * same note lay out identically on every open, which is the whole point — a map
+ * that jumps between toggles costs the user the spatial memory it was meant to
+ * give them.
+ */
+
+import type {
+  MindMapBounds,
+  MindMapDirection,
+  MindMapNode,
+  MindMapPositionedNode
+} from './mind-map-types'
+
+/** Box metrics. Kept generous so the drawing library never has to grow a box. */
+export const MIND_MAP_FONT_SIZE = 16
+const CHAR_WIDTH = 9
+const PADDING_X = 16
+const PADDING_Y = 10
+const LINE_HEIGHT = 22
+const MIN_WIDTH = 96
+const MAX_WIDTH = 264
+const MIN_HEIGHT = 42
+/** Horizontal room between one depth column and the next. */
+const COLUMN_GAP = 72
+/** Vertical room between two boxes that share a column. */
+const SIBLING_GAP = 16
+
+const MAX_CHARS_PER_LINE = Math.floor((MAX_WIDTH - PADDING_X * 2) / CHAR_WIDTH)
+
+function boxWidth(label: string): number {
+  const ideal = PADDING_X * 2 + label.length * CHAR_WIDTH
+  if (ideal < MIN_WIDTH) return MIN_WIDTH
+  if (ideal > MAX_WIDTH) return MAX_WIDTH
+  return ideal
+}
+
+function boxHeight(label: string): number {
+  const lines = Math.max(1, Math.ceil(label.length / MAX_CHARS_PER_LINE))
+  return Math.max(MIN_HEIGHT, lines * LINE_HEIGHT + PADDING_Y * 2)
+}
+
+interface Measured {
+  node: MindMapNode
+  parentId: string | null
+  width: number
+  height: number
+  children: Measured[]
+}
+
+function measure(node: MindMapNode, parentId: string | null): Measured {
+  return {
+    node,
+    parentId,
+    width: boxWidth(node.label),
+    height: boxHeight(node.label),
+    children: node.children.map((child) => measure(child, node.id))
+  }
+}
+
+/** Widest box in each depth column, so columns never overlap. */
+function columnWidths(root: Measured): number[] {
+  const widths: number[] = []
+  const walk = (measured: Measured): void => {
+    const depth = measured.node.depth
+    widths[depth] = Math.max(widths[depth] ?? 0, measured.width)
+    for (const child of measured.children) walk(child)
+  }
+  walk(root)
+  return widths
+}
+
+/** Leading edge of each depth column, measured from the root's leading edge. */
+function columnOffsets(widths: number[]): number[] {
+  const offsets: number[] = []
+  let cursor = 0
+  for (let depth = 0; depth < widths.length; depth += 1) {
+    offsets[depth] = cursor
+    cursor += widths[depth] + COLUMN_GAP
+  }
+  return offsets
+}
+
+/**
+ * Places every node and returns them in depth-first order — the same order the
+ * accessible tree projection walks, so one list serves both surfaces.
+ */
+export function layoutMindMap(
+  tree: MindMapNode,
+  direction: MindMapDirection
+): { nodes: MindMapPositionedNode[]; bounds: MindMapBounds } {
+  const measured = measure(tree, null)
+  const offsets = columnOffsets(columnWidths(measured))
+  const tops = new Map<string, number>()
+
+  // Post-order: a leaf takes the next free slot in its column; a parent centres
+  // itself on the span between its first and last child.
+  let cursor = 0
+  const place = (item: Measured): void => {
+    if (item.children.length === 0) {
+      tops.set(item.node.id, cursor)
+      cursor += item.height + SIBLING_GAP
+      return
+    }
+    for (const child of item.children) place(child)
+    const first = item.children[0]
+    const last = item.children[item.children.length - 1]
+    const firstCentre = (tops.get(first.node.id) ?? 0) + first.height / 2
+    const lastCentre = (tops.get(last.node.id) ?? 0) + last.height / 2
+    tops.set(item.node.id, Math.round((firstCentre + lastCentre) / 2 - item.height / 2))
+  }
+  place(measured)
+
+  const nodes: MindMapPositionedNode[] = []
+  const emit = (item: Measured): void => {
+    const offset = offsets[item.node.depth] ?? 0
+    nodes.push({
+      id: item.node.id,
+      blockId: item.node.blockId,
+      label: item.node.label,
+      kind: item.node.kind,
+      level: item.node.level,
+      depth: item.node.depth,
+      parentId: item.parentId,
+      // RTL mirrors the whole map about the root's leading edge, so the tree
+      // grows with the reading direction instead of against it.
+      x: direction === 'rtl' ? -(offset + item.width) : offset,
+      y: tops.get(item.node.id) ?? 0,
+      width: item.width,
+      height: item.height
+    })
+    for (const child of item.children) emit(child)
+  }
+  emit(measured)
+
+  const bounds = nodes.reduce<MindMapBounds>(
+    (acc, node) => ({
+      minX: Math.min(acc.minX, node.x),
+      minY: Math.min(acc.minY, node.y),
+      maxX: Math.max(acc.maxX, node.x + node.width),
+      maxY: Math.max(acc.maxY, node.y + node.height)
+    }),
+    {
+      minX: Number.POSITIVE_INFINITY,
+      minY: Number.POSITIVE_INFINITY,
+      maxX: Number.NEGATIVE_INFINITY,
+      maxY: Number.NEGATIVE_INFINITY
+    }
+  )
+
+  return { nodes, bounds }
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-projection.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-projection.ts
@@ -1,0 +1,137 @@
+/**
+ * Private step 1 — an editor block tree becomes a logical mind-map tree.
+ *
+ * Not exported outside this directory: `buildMindMap` is the only seam, so this
+ * file is free to change shape as later tickets add lists, tasks and links.
+ *
+ * Headings are the one hierarchy mechanism handled here, and they are flat
+ * siblings in the block tree whose nesting lives in a `level` prop — so this is
+ * a level stack, not a recursive descent. (Recursive descent is still needed to
+ * *find* headings, because a heading can sit inside a toggle or a callout.)
+ */
+
+import type { MindMapNode, MindMapSourceBlock } from './mind-map-types'
+
+export const MIND_MAP_ROOT_ID = 'mm-root'
+
+const MIN_HEADING_LEVEL = 1
+const MAX_HEADING_LEVEL = 6
+
+/**
+ * Content-less inline specs (wiki links, hash tags, date mentions) carry their
+ * visible text in props. Read in this order, first non-empty wins.
+ *
+ * An interim rule: these kinds get their own treatment when links, tags and
+ * dates become nodes and badges of their own.
+ */
+const INLINE_LABEL_PROPS = ['alias', 'target', 'tag', 'dateISO'] as const
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/** Total: any inline shape in, a plain string out. */
+function inlineText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) return value.map(inlineText).join('')
+  if (!isRecord(value)) return ''
+
+  if (typeof value.text === 'string') return value.text
+  if (value.content !== undefined) return inlineText(value.content)
+
+  const props = value.props
+  if (isRecord(props)) {
+    for (const key of INLINE_LABEL_PROPS) {
+      const candidate = props[key]
+      if (typeof candidate === 'string' && candidate.trim() !== '') return candidate
+    }
+  }
+  return ''
+}
+
+/** Collapses runs of whitespace so a wrapped heading measures predictably. */
+function normalizeLabel(raw: string): string {
+  return raw.replace(/\s+/g, ' ').trim()
+}
+
+function headingLevel(block: MindMapSourceBlock): number | null {
+  if (block.type !== 'heading') return null
+  const props = block.props
+  const raw = isRecord(props) ? props.level : undefined
+  if (typeof raw !== 'number' || !Number.isInteger(raw)) return MIN_HEADING_LEVEL
+  if (raw < MIN_HEADING_LEVEL) return MIN_HEADING_LEVEL
+  if (raw > MAX_HEADING_LEVEL) return MAX_HEADING_LEVEL
+  return raw
+}
+
+/**
+ * Turns a block tree into the logical map.
+ *
+ * Rules that matter, all of them observable through `buildMindMap`:
+ * - The root is always the note title, never the first heading.
+ * - A skipped level mints no phantom intermediate node; the heading simply
+ *   nests one step deeper than its nearest shallower ancestor.
+ * - A note whose first heading is a deep level attaches it straight to the
+ *   root: relative depth is what matters, not the absolute number.
+ * - Anything that is not a heading — including everything before the first
+ *   heading — contributes no node, and never re-parents the headings around it.
+ * - A blank heading has nothing to show, so it draws no box and does not join
+ *   the level stack; its sub-headings fold up to the nearest labelled ancestor
+ *   rather than disappearing.
+ */
+export function projectBlocks(
+  blocks: readonly MindMapSourceBlock[],
+  rootLabel: string
+): MindMapNode {
+  const root: MindMapNode = {
+    id: MIND_MAP_ROOT_ID,
+    blockId: null,
+    label: rootLabel,
+    kind: 'root',
+    level: null,
+    depth: 0,
+    children: []
+  }
+
+  /** Open headings, shallowest first. The root is the implicit floor. */
+  const stack: Array<{ level: number; node: MindMapNode }> = []
+  /**
+   * Block ids should be unique, but a node id collision would mint two drawing
+   * elements with one id, so the suffix keeps them apart deterministically.
+   */
+  const usedIds = new Map<string, number>()
+
+  const mintId = (blockId: string): string => {
+    const base = `mm-${blockId}`
+    const seen = usedIds.get(base) ?? 0
+    usedIds.set(base, seen + 1)
+    return seen === 0 ? base : `${base}-${seen + 1}`
+  }
+
+  const visit = (block: MindMapSourceBlock): void => {
+    const level = headingLevel(block)
+    if (level !== null) {
+      const label = normalizeLabel(inlineText(block.content))
+      if (label !== '') {
+        while (stack.length > 0 && stack[stack.length - 1].level >= level) stack.pop()
+        const parent = stack.length > 0 ? stack[stack.length - 1].node : root
+        const node: MindMapNode = {
+          id: mintId(block.id),
+          blockId: block.id,
+          label,
+          kind: 'heading',
+          level,
+          depth: parent.depth + 1,
+          children: []
+        }
+        parent.children.push(node)
+        stack.push({ level, node })
+      }
+    }
+
+    for (const child of block.children ?? []) visit(child)
+  }
+
+  for (const block of blocks) visit(block)
+  return root
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.tsx
@@ -1,0 +1,85 @@
+/**
+ * The map's accessible twin.
+ *
+ * Excalidraw draws to a bitmap: a screen reader sees nothing there, and neither
+ * does a browser automation harness. This renders the *same positioned nodes*
+ * as a real tree in the DOM — not a second source of truth, a second projection
+ * of one layout result. It is what makes the feature usable without a mouse or
+ * without sight, and it is the only way an end-to-end test can see inside the
+ * drawing surface at all.
+ *
+ * Visually hidden rather than absent: the picture is the visual presentation,
+ * this is the same content for everyone else.
+ */
+
+import type { MindMapPositionedNode } from './mind-map-types'
+
+interface MindMapTreeProps {
+  nodes: readonly MindMapPositionedNode[]
+  /** Translated; names the note the tree belongs to. */
+  label: string
+}
+
+interface Branch {
+  node: MindMapPositionedNode
+  children: Branch[]
+}
+
+/**
+ * Rebuilds the nesting from the positioned nodes themselves, so the tree can
+ * never describe a shape the layout did not place.
+ */
+function toBranches(nodes: readonly MindMapPositionedNode[]): Branch[] {
+  const branches = new Map<string, Branch>()
+  for (const node of nodes) branches.set(node.id, { node, children: [] })
+
+  const roots: Branch[] = []
+  for (const node of nodes) {
+    const branch = branches.get(node.id)
+    if (!branch) continue
+    const parent = node.parentId === null ? undefined : branches.get(node.parentId)
+    if (parent) parent.children.push(branch)
+    else roots.push(branch)
+  }
+  return roots
+}
+
+function BranchItems({
+  branches,
+  level
+}: {
+  branches: Branch[]
+  level: number
+}): React.JSX.Element {
+  return (
+    <>
+      {branches.map((branch, index) => (
+        <li
+          key={branch.node.id}
+          role="treeitem"
+          aria-level={level}
+          aria-posinset={index + 1}
+          aria-setsize={branches.length}
+          aria-expanded={branch.children.length > 0 ? true : undefined}
+          data-mind-map-node={branch.node.id}
+          data-mind-map-block={branch.node.blockId ?? undefined}
+        >
+          <span>{branch.node.label}</span>
+          {branch.children.length > 0 && (
+            <ul role="group">
+              <BranchItems branches={branch.children} level={level + 1} />
+            </ul>
+          )}
+        </li>
+      ))}
+    </>
+  )
+}
+
+export function MindMapTree({ nodes, label }: MindMapTreeProps): React.JSX.Element {
+  return (
+    <ul role="tree" aria-label={label} className="sr-only" data-testid="mind-map-tree">
+      <BranchItems branches={toBranches(nodes)} level={1} />
+    </ul>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
@@ -1,0 +1,138 @@
+/**
+ * Public shapes of the note mind map.
+ *
+ * `buildMindMap` (see `build-mind-map.ts`) is the only entry point into this
+ * directory; everything here describes what goes in and what comes back out.
+ * The projection, the layout and the element minting are private steps behind
+ * that one function, so none of their intermediate shapes are exported.
+ *
+ * Nothing in this file imports the drawing library: the element descriptors are
+ * plain data, which is what keeps the whole pipeline testable without a DOM and
+ * without pulling a renderer chunk into a unit test.
+ */
+
+/** Direction the tree grows in — derived from the document direction. */
+export type MindMapDirection = 'ltr' | 'rtl'
+
+/**
+ * The structural subset of a BlockNote block the map reads.
+ *
+ * Deliberately loose: `props` and `content` are `unknown` because a block tree
+ * can carry any registered custom spec, and every read of them here is guarded.
+ */
+export interface MindMapSourceBlock {
+  id: string
+  type: string
+  props?: unknown
+  content?: unknown
+  children?: readonly MindMapSourceBlock[]
+}
+
+/**
+ * What a node stands for. Only the note title and its headings are drawn today;
+ * lists, tasks and wiki links join this union in later work.
+ */
+export type MindMapNodeKind = 'root' | 'heading'
+
+/** A node in the logical tree, before any coordinates exist. */
+export interface MindMapNode {
+  /** Stable within one map. Derived from the source block, never random. */
+  id: string
+  /** The block this node came from; `null` for the root, which is the title. */
+  blockId: string | null
+  /** User content. Never translated. */
+  label: string
+  kind: MindMapNodeKind
+  /** Heading level as written (1–6); `null` for the root. */
+  level: number | null
+  /** Distance from the root. The root is 0. */
+  depth: number
+  children: MindMapNode[]
+}
+
+/** The same node once the layout has placed and sized it. */
+export interface MindMapPositionedNode {
+  id: string
+  blockId: string | null
+  label: string
+  kind: MindMapNodeKind
+  level: number | null
+  depth: number
+  parentId: string | null
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/** A node drawn as a labelled box. */
+export interface MindMapBoxElement {
+  type: 'rectangle'
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+  strokeColor: string
+  backgroundColor: string
+  fillStyle: 'solid'
+  strokeWidth: number
+  roughness: number
+  roundness: { type: number }
+  label: {
+    text: string
+    fontSize: number
+    textAlign: 'left' | 'right'
+    verticalAlign: 'middle'
+    strokeColor: string
+  }
+}
+
+/** The connector from a parent box to one of its children. */
+export interface MindMapEdgeElement {
+  type: 'line'
+  id: string
+  x: number
+  y: number
+  points: Array<[number, number]>
+  strokeColor: string
+  strokeWidth: number
+  roughness: number
+}
+
+export type MindMapElement = MindMapBoxElement | MindMapEdgeElement
+
+/** Bounding box of every positioned node, so the host can fit the view. */
+export interface MindMapBounds {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+export interface MindMapOptions {
+  /** The note title, used as the root label. User content; never translated. */
+  rootLabel: string
+  /** Defaults to `'ltr'`. In `'rtl'` the tree mirrors so it grows with the
+   * reading direction rather than against it. */
+  direction?: MindMapDirection
+}
+
+/**
+ * One result carrying all three layers, so a caller (or a test) can assert at
+ * whichever level suits it without a second seam into the pipeline.
+ */
+export interface MindMap {
+  /** The logical tree, rooted at the note title. */
+  tree: MindMapNode
+  /** Every node with coordinates, in depth-first order starting at the root. */
+  nodes: MindMapPositionedNode[]
+  /** Drawing elements: one box per node, one connector per parent→child edge. */
+  elements: MindMapElement[]
+  direction: MindMapDirection
+  /** Node total including the root. */
+  nodeCount: number
+  /** True when the note contributed nothing to branch from. */
+  isEmpty: boolean
+  bounds: MindMapBounds
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
@@ -1,0 +1,57 @@
+/**
+ * The map surface: the drawing, its accessible twin, and the empty-note hint.
+ *
+ * Two projections of one layout result sit side by side here — the picture for
+ * people who can see it, the tree for everyone and everything else. They are
+ * siblings rather than nested because an image role makes its contents
+ * presentational, which would hide the tree from exactly the readers it exists
+ * for.
+ */
+
+import { lazy, Suspense } from 'react'
+import { useT } from '@memry/i18n/renderer'
+import { MindMapTree } from './mind-map-tree'
+import type { MindMap } from './mind-map-types'
+
+/**
+ * Lazy for the same reason the canvas page is: @excalidraw/excalidraw and its
+ * CSS never enter the main renderer bundle.
+ */
+const LazyMindMapCanvas = lazy(async () => ({
+  default: (await import('./mind-map-canvas')).MindMapCanvas
+}))
+
+interface MindMapViewProps {
+  map: MindMap
+  /** The note title. User content; never translated. */
+  noteTitle: string
+}
+
+export function MindMapView({ map, noteTitle }: MindMapViewProps): React.JSX.Element {
+  const { t } = useT('notes')
+
+  return (
+    <div className="relative flex h-full w-full flex-col bg-background" data-testid="note-mind-map">
+      <div
+        role="img"
+        aria-label={t('mindMap.regionLabel', { title: noteTitle, count: map.nodeCount })}
+        className="relative min-h-0 flex-1"
+      >
+        <Suspense fallback={<div className="h-full w-full" aria-hidden="true" />}>
+          <LazyMindMapCanvas elements={map.elements} />
+        </Suspense>
+      </div>
+
+      {map.isEmpty && (
+        <p
+          className="pointer-events-none absolute inset-x-0 bottom-10 text-center text-sm text-text-tertiary"
+          data-testid="note-mind-map-empty-hint"
+        >
+          {t('mindMap.emptyHint')}
+        </p>
+      )}
+
+      <MindMapTree nodes={map.nodes} label={t('mindMap.treeLabel', { title: noteTitle })} />
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map.ts
@@ -1,0 +1,127 @@
+/**
+ * Wiring for the note mind map: what the note page needs and nothing more.
+ *
+ * The data source is the live editor block tree, read from the editor that is
+ * still mounted behind the map. No main-process read, no index query, no
+ * markdown re-parse — and no diffing machinery either, because the user cannot
+ * type and look at the map at the same time.
+ */
+
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useDirection } from '@memry/i18n/renderer'
+import { useFeatureFlags } from '@/hooks/use-feature-flags'
+import { useTabViewState } from '@/hooks/use-tab-view-state'
+import { buildMindMap } from './build-mind-map'
+import type { MindMap, MindMapSourceBlock } from './mind-map-types'
+
+/**
+ * Tab view state key. Tab-scoped on purpose: the map is a property of a
+ * workspace, not of a note, so the same note opened in another tab starts in
+ * note view. It survives a tab switch and a session restore for free.
+ */
+export const MIND_MAP_VIEW_STATE_KEY = 'noteMindMap'
+
+/** Total, as persisted tab state can have been written by an older build. */
+function parseMindMapOpen(raw: unknown): boolean | undefined {
+  return typeof raw === 'boolean' ? raw : undefined
+}
+
+/** The slice of a BlockNote editor the map reads. */
+interface BlockTreeHost {
+  document?: unknown
+}
+
+function readBlocks(host: BlockTreeHost | null): MindMapSourceBlock[] {
+  const document = host?.document
+  if (!Array.isArray(document)) return []
+  return document.filter(
+    (block): block is MindMapSourceBlock =>
+      typeof block === 'object' &&
+      block !== null &&
+      typeof (block as { id?: unknown }).id === 'string' &&
+      typeof (block as { type?: unknown }).type === 'string'
+  )
+}
+
+interface UseMindMapOptions {
+  /** Root label. User content; never translated. */
+  noteTitle: string
+  /**
+   * The note page's existing editor-ready callback. Composed rather than
+   * replaced so the map needs no new prop on the content area.
+   */
+  onEditorReady: (editor: unknown) => void
+}
+
+export interface UseMindMapResult {
+  /** False when the spatial-canvas feature is off; the toggle is not offered. */
+  isAvailable: boolean
+  /** True while the map replaces the note body. */
+  isOpen: boolean
+  toggle: () => void
+  /** Null until the map is open and has been built. */
+  map: MindMap | null
+  /** Pass to the content area in place of the callback that was composed in. */
+  handleEditorReady: (editor: unknown) => void
+  /**
+   * Rebuild from the live block tree. Called when the note reports a different
+   * set of headings, which is how the map catches up with a note whose content
+   * finished loading after a restored tab reopened the map.
+   */
+  refresh: () => void
+}
+
+export function useMindMap({ noteTitle, onEditorReady }: UseMindMapOptions): UseMindMapResult {
+  const { isEnabled } = useFeatureFlags()
+  const isAvailable = isEnabled('spatialCanvas')
+  const direction = useDirection()
+
+  const [storedOpen, setStoredOpen] = useTabViewState<boolean>({
+    key: MIND_MAP_VIEW_STATE_KEY,
+    defaultValue: false,
+    parse: parseMindMapOpen
+  })
+  const isOpen = isAvailable && storedOpen
+
+  const editorRef = useRef<BlockTreeHost | null>(null)
+  const [editorRevision, setEditorRevision] = useState(0)
+  const [map, setMap] = useState<MindMap | null>(null)
+
+  const handleEditorReady = useCallback(
+    (editor: unknown) => {
+      editorRef.current = (editor as BlockTreeHost | null) ?? null
+      setEditorRevision((previous) => previous + 1)
+      onEditorReady(editor)
+    },
+    [onEditorReady]
+  )
+
+  const build = useCallback(
+    () => buildMindMap(readBlocks(editorRef.current), { rootLabel: noteTitle, direction }),
+    [direction, noteTitle]
+  )
+
+  // Layout, not passive: the note body is hidden in the same commit that flips
+  // the toggle, so a map that arrived a frame later would paint a blank gap.
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setMap(null)
+      return
+    }
+    setMap(build())
+    // `editorRevision` is a rebuild trigger, not a value this reads.
+  }, [isOpen, build, editorRevision])
+
+  const refresh = useCallback(() => {
+    setMap((previous) => (previous === null ? previous : build()))
+  }, [build])
+
+  const toggle = useCallback(() => {
+    setStoredOpen((previous) => !previous)
+  }, [setStoredOpen])
+
+  return useMemo(
+    () => ({ isAvailable, isOpen, toggle, map, handleEditorReady, refresh }),
+    [isAvailable, isOpen, toggle, map, handleEditorReady, refresh]
+  )
+}

--- a/apps/desktop/src/renderer/src/components/note/note-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-layout.tsx
@@ -30,6 +30,12 @@ interface NoteLayoutProps {
   stats?: OutlineInfoPanelProps['stats']
   fullWidth?: boolean
   sideRail?: ReactNode
+  /**
+   * Covers the scrolling content, leaving the chrome and the outline panel
+   * reachable. The children stay mounted underneath — the note mind map relies
+   * on that, because unmounting the editor would destroy its undo history.
+   */
+  overlay?: ReactNode
   contentWidth?: string
   marqueeZoneRef?: (el: HTMLDivElement | null) => void
   onRailHiddenChange?: (hidden: boolean) => void
@@ -54,6 +60,7 @@ export function NoteLayout({
   stats,
   fullWidth = false,
   sideRail,
+  overlay,
   contentWidth,
   marqueeZoneRef,
   onRailHiddenChange,
@@ -176,6 +183,15 @@ export function NoteLayout({
           </div>
         </div>
       </div>
+
+      {overlay && (
+        <div
+          data-note-layout-overlay
+          className="absolute inset-x-0 bottom-0 top-[var(--note-chrome-height)] z-20"
+        >
+          {overlay}
+        </div>
+      )}
 
       <OutlineInfoPanel
         headings={headings}

--- a/apps/desktop/src/renderer/src/lib/icons/icon-map.ts
+++ b/apps/desktop/src/renderer/src/lib/icons/icon-map.ts
@@ -274,7 +274,8 @@ import {
   Progress03Icon,
   Pdf01Icon,
   ArrowTurnBackwardIcon,
-  ChartRelationshipIcon
+  ChartRelationshipIcon,
+  HierarchyIcon
 } from '@hugeicons/core-free-icons'
 import { createIcon } from './create-icon'
 
@@ -367,6 +368,7 @@ export const Download = createIcon(Download01Icon)
 export const Upload = createIcon(Upload01Icon)
 export const Share = createIcon(Share01Icon)
 export const ChartRelationship = createIcon(ChartRelationshipIcon)
+export const Hierarchy = createIcon(HierarchyIcon)
 export const Share2 = createIcon(Share02Icon)
 export const Link = createIcon(Link01Icon)
 export const Link2 = createIcon(Link02Icon)

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { renderWithProviders } from '@tests/utils/render'
 import { NotePage } from './note'
 import { toast } from 'sonner'
@@ -44,6 +44,14 @@ const mocks = vi.hoisted(() => ({
   unregisterPendingSave: vi.fn(),
   pickerOnValueChange: null as ((value: string) => void) | null,
   contentAreaMounts: 0,
+  /** What the tab would persist; the mind-map toggle lives in here. */
+  tabViewState: {} as Record<string, unknown>,
+  spatialCanvasEnabled: true,
+  direction: 'ltr' as 'ltr' | 'rtl',
+  /** Blocks the mocked editor reports as its live document. */
+  editorBlocks: [] as unknown[],
+  /** One entry per editor the mocked content area built. */
+  editorInstances: [] as unknown[],
   onDeleted: vi.fn(),
   onUpdated: vi.fn(),
   onRenamed: vi.fn(),
@@ -72,7 +80,8 @@ vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({
     t: (key: string, values?: Record<string, unknown>) =>
       values ? `${key}:${JSON.stringify(values)}` : key
-  })
+  }),
+  useDirection: () => mocks.direction
 }))
 
 vi.mock('react-i18next', () => ({
@@ -209,20 +218,54 @@ vi.mock('@/lib/wikilink-resolver', () => ({
   resolveWikiLink: mocks.resolveWikiLink
 }))
 
-vi.mock('@/contexts/tabs', () => ({
-  useTabs: () => ({
-    openTab: mocks.openTab,
-    closeTab: mocks.closeTab,
-    setTabDeleted: mocks.setTabDeleted,
-    updateTabTitleByEntityId: mocks.updateTabTitleByEntityId
-  }),
-  // useOpenPage (wiki/backlink navigation preference) reads openTab from here.
-  useTabActions: () => ({ openTab: mocks.openTab }),
-  useActiveTab: () => ({
-    id: '/notes/note-1',
-    entityId: 'note-1',
-    viewState: { highlightText: 'Important', highlightStart: 1, highlightEnd: 10 }
+vi.mock('@/contexts/tabs', () => {
+  // Stable across renders: `useTabViewState` puts these in hook dependencies.
+  const tabActions = {
+    dispatch: (action: { type: string; payload: { viewState?: Record<string, unknown> } }) => {
+      if (action.type !== 'SAVE_TAB_STATE') return
+      Object.assign(mocks.tabViewState, action.payload.viewState ?? {})
+    },
+    getTab: () => ({ viewState: mocks.tabViewState })
+  }
+  return {
+    useTabs: () => ({
+      openTab: mocks.openTab,
+      closeTab: mocks.closeTab,
+      setTabDeleted: mocks.setTabDeleted,
+      updateTabTitleByEntityId: mocks.updateTabTitleByEntityId
+    }),
+    // useOpenPage (wiki/backlink navigation preference) reads openTab from here.
+    useTabActions: () => ({ openTab: mocks.openTab }),
+    useTabActionsOptional: () => tabActions,
+    useActiveTab: () => ({
+      id: '/notes/note-1',
+      entityId: 'note-1',
+      viewState: { highlightText: 'Important', highlightStart: 1, highlightEnd: 10 }
+    })
+  }
+})
+
+vi.mock('@/contexts/tabs/tab-identity', () => ({
+  useTabIdentity: () => ({ tabId: '/notes/note-1', groupId: 'group-1' })
+}))
+
+vi.mock('@/hooks/use-feature-flags', () => ({
+  useFeatureFlags: () => ({
+    flags: { spatialCanvas: mocks.spatialCanvasEnabled },
+    isLoading: false,
+    error: null,
+    isEnabled: (feature: string) =>
+      feature === 'spatialCanvas' ? mocks.spatialCanvasEnabled : true,
+    setFlag: vi.fn()
   })
+}))
+
+// The map's drawing chunk imports Excalidraw; the accessible tree beside it is
+// what these tests read, and what an end-to-end run reads too.
+vi.mock('@/components/note/mind-map/mind-map-canvas', () => ({
+  MindMapCanvas: ({ elements }: { elements: unknown[] }) => (
+    <div data-testid="mind-map-canvas" data-element-count={elements.length} />
+  )
 }))
 
 vi.mock('@/hooks/use-sidebar-navigation', () => ({
@@ -275,6 +318,7 @@ vi.mock('@/components/note', () => ({
     breadcrumb,
     stats,
     sideRail,
+    overlay,
     marqueeZoneRef,
     onHeadingClick
   }: {
@@ -285,6 +329,7 @@ vi.mock('@/components/note', () => ({
     breadcrumb: React.ReactNode
     stats?: { wordCount?: number }
     sideRail?: React.ReactNode
+    overlay?: React.ReactNode
     marqueeZoneRef: (element: HTMLDivElement | null) => void
     onHeadingClick: (id: string) => void
   }) => (
@@ -300,6 +345,7 @@ vi.mock('@/components/note', () => ({
       {actions}
       {children}
       {sideRail}
+      {overlay}
     </div>
   ),
   ContentArea: ({
@@ -310,7 +356,8 @@ vi.mock('@/components/note', () => ({
     onLinkClick,
     onInternalLinkClick,
     onInlineTagsChange,
-    focusAtEndRef
+    focusAtEndRef,
+    review
   }: {
     initialContent: string
     externalContentRevision?: number
@@ -322,13 +369,30 @@ vi.mock('@/components/note', () => ({
     onInternalLinkClick: (target: string) => void
     onInlineTagsChange: (tags: string[], origin: 'load' | 'edit') => void
     focusAtEndRef: React.MutableRefObject<(() => void) | null>
+    review?: { onEditorReady?: (editor: unknown) => void }
   }) => {
     const [content] = useState(initialContent)
+    // A fresh mount mints a fresh editor, exactly as the real one does — which
+    // is what makes "same instance across a round trip" a real assertion and
+    // not a comment.
+    const [editor] = useState(() => {
+      const instance = {
+        get document() {
+          return mocks.editorBlocks
+        }
+      }
+      mocks.editorInstances.push(instance)
+      return instance
+    })
     focusAtEndRef.current = mocks.refetchNote
     // Counting mounts (not renders) is the point: an update from elsewhere must
     // reach the live editor as a prop, never as a fresh editor instance.
+    const onEditorReady = review?.onEditorReady
     useEffect(() => {
       mocks.contentAreaMounts += 1
+      onEditorReady?.(editor)
+      return () => onEditorReady?.(null)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
     return (
       <div>
@@ -700,6 +764,25 @@ describe('NotePage', () => {
     mocks.pickerOnValueChange = null
     mocks.propertyOnBlocked = null
     mocks.contentAreaMounts = 0
+    mocks.tabViewState = {}
+    mocks.spatialCanvasEnabled = true
+    mocks.direction = 'ltr'
+    mocks.editorInstances = []
+    mocks.editorBlocks = [
+      { id: 'b-intro', type: 'paragraph', content: [{ type: 'text', text: 'Preamble' }] },
+      {
+        id: 'b-h1',
+        type: 'heading',
+        props: { level: 1 },
+        content: [{ type: 'text', text: 'Alpha' }]
+      },
+      {
+        id: 'b-h2',
+        type: 'heading',
+        props: { level: 3 },
+        content: [{ type: 'text', text: 'Alpha detail' }]
+      }
+    ]
     Element.prototype.scrollIntoView = vi.fn()
     mocks.resolveWikiLink.mockImplementation((target: string) => {
       if (target === 'Existing Note')
@@ -1374,6 +1457,150 @@ describe('NotePage', () => {
       expect(mocks.contentAreaMounts).toBe(1)
       // ...and find still walks the editor, which is where the text is
       expect(mocks.findInPageEnabled).toBe(true)
+    })
+  })
+
+  describe('mind map', () => {
+    const openMap = async (): Promise<HTMLElement> => {
+      const toggle = await screen.findByTestId('note-mind-map-toggle')
+      fireEvent.click(toggle)
+      return await screen.findByTestId('note-mind-map')
+    }
+
+    it('offers the toggle alongside the reminder and bookmark actions', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+
+      const toggle = await screen.findByTestId('note-mind-map-toggle')
+      expect(toggle).toHaveAttribute('aria-pressed', 'false')
+      expect(toggle).toHaveAccessibleName('editor.toolbar.showMindMap')
+      expect(toggle).not.toBeDisabled()
+      // The other two note actions are still where they were.
+      expect(screen.getByRole('button', { name: 'Pick reminder' })).toBeInTheDocument()
+      expect(screen.getByTitle('editor.toolbar.addBookmark')).toBeInTheDocument()
+    })
+
+    it('does not offer the map when the spatial-canvas feature is off', async () => {
+      mocks.spatialCanvasEnabled = false
+      renderWithProviders(<NotePage noteId="note-1" />)
+
+      await screen.findByTestId('editor-content')
+      expect(screen.queryByTestId('note-mind-map-toggle')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('note-mind-map')).not.toBeInTheDocument()
+    })
+
+    it('shows the map, then gives the note back, and never touches the overflow menu', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      const menuBefore = (await screen.findByTestId('note-more-menu')).outerHTML
+
+      const map = await openMap()
+      expect(map).toBeInTheDocument()
+      expect(await screen.findByTestId('note-mind-map-toggle')).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      )
+      // Header, breadcrumb and the note's own menu are untouched in both modes:
+      // the same button in the same place doing different work is how people
+      // delete things by accident.
+      expect(screen.getAllByText('Test Note').length).toBeGreaterThan(0)
+      expect(screen.getByTestId('note-more-menu').outerHTML).toBe(menuBefore)
+
+      fireEvent.click(screen.getByTestId('note-mind-map-toggle'))
+      await waitFor(() => expect(screen.queryByTestId('note-mind-map')).not.toBeInTheDocument())
+      expect(screen.getByTestId('note-mind-map-toggle')).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByTestId('note-more-menu').outerHTML).toBe(menuBefore)
+    })
+
+    it('keeps the very same editor instance across a round trip', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await screen.findByTestId('editor-content')
+      expect(mocks.editorInstances).toHaveLength(1)
+      const before = mocks.editorInstances[0]
+
+      await openMap()
+      fireEvent.click(screen.getByTestId('note-mind-map-toggle'))
+      await waitFor(() => expect(screen.queryByTestId('note-mind-map')).not.toBeInTheDocument())
+
+      // The direct guarantee behind undo history, the cursor, the selection and
+      // the CRDT binding: not "it re-rendered", but the identical object.
+      expect(mocks.editorInstances).toHaveLength(1)
+      expect(mocks.editorInstances[0]).toBe(before)
+      expect(mocks.contentAreaMounts).toBe(1)
+    })
+
+    it('hides the body without collapsing it, and takes it out of the tab order', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      const bodyBefore = await screen.findByTestId('note-body')
+      expect(bodyBefore).not.toHaveAttribute('inert')
+
+      await openMap()
+
+      const body = screen.getByTestId('note-body')
+      // Same node — nothing was torn down and rebuilt.
+      expect(body).toBe(bodyBefore)
+      expect(body).toHaveAttribute('inert')
+      expect(body).toHaveAttribute('aria-hidden', 'true')
+      // `invisible` keeps the layout box; `hidden` would collapse the scroll
+      // height and reset the offset the user came back to.
+      expect(body.className).toContain('invisible')
+      expect(body.className).not.toContain('hidden')
+      expect(screen.getByTestId('editor-content')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId('note-mind-map-toggle'))
+      await waitFor(() => expect(screen.getByTestId('note-body')).not.toHaveAttribute('inert'))
+      expect(screen.getByTestId('note-body')).toBe(bodyBefore)
+    })
+
+    it('writes the map into tab view state and reopens there', async () => {
+      const first = renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+      expect(mocks.tabViewState).toMatchObject({ noteMindMap: true })
+      first.unmount()
+
+      // A restored tab lands straight in map view.
+      renderWithProviders(<NotePage noteId="note-1" />)
+      expect(await screen.findByTestId('note-mind-map')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId('note-mind-map-toggle'))
+      await waitFor(() => expect(mocks.tabViewState.noteMindMap).toBe(false))
+    })
+
+    it('projects every node into a real tree beside the drawing', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+
+      const tree = await screen.findByRole('tree')
+      const items = within(tree).getAllByRole('treeitem')
+      // Root, one heading, and the deeper heading under it — the paragraph is
+      // not a node, and the skipped level minted no phantom between them.
+      expect(items.map((item) => item.textContent)).toEqual([
+        'Test NoteAlphaAlpha detail',
+        'AlphaAlpha detail',
+        'Alpha detail'
+      ])
+      expect(items.map((item) => item.getAttribute('aria-level'))).toEqual(['1', '2', '3'])
+      expect(screen.getByTestId('mind-map-canvas')).toBeInTheDocument()
+    })
+
+    it('labels the map region with the note and its node count', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+
+      const region = screen.getByRole('img')
+      expect(region).toHaveAccessibleName('mindMap.regionLabel:{"title":"Test Note","count":3}')
+    })
+
+    it('opens a note with no headings on the root alone, and keeps the toggle live', async () => {
+      mocks.editorBlocks = [
+        { id: 'b-1', type: 'paragraph', content: [{ type: 'text', text: 'Just prose.' }] }
+      ]
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+
+      const tree = await screen.findByRole('tree')
+      expect(within(tree).getAllByRole('treeitem')).toHaveLength(1)
+      expect(screen.getByTestId('note-mind-map-empty-hint')).toHaveTextContent('mindMap.emptyHint')
+      // A disabled control explains nothing; the hint does.
+      expect(screen.getByTestId('note-mind-map-toggle')).not.toBeDisabled()
     })
   })
 })

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -32,6 +32,7 @@ import {
   Block
 } from '@/components/note'
 import { isOutsideAllBlocks } from '@/components/note/content-area/marquee-hit-test'
+import { MindMapView, useMindMap } from '@/components/note/mind-map'
 import { NoteTitle } from '@/components/note/note-title'
 import { TagsRow, Tag } from '@/components/note/tags-row'
 import { InfoSection, type NewProperty } from '@/components/note/info-section'
@@ -67,6 +68,7 @@ import {
   Monitor,
   Maximize,
   ChartRelationship,
+  Hierarchy,
   PenLine,
   Pencil,
   Search,
@@ -793,6 +795,21 @@ export function NotePage({ noteId }: NotePageProps) {
   const hasReviewContent = review.marks.length > 0 || !!review.activeDraft
   const [reviewRailHidden, setReviewRailHidden] = useState(false)
 
+  // Mind map. `onEditorReady` is composed rather than replaced so the map reads
+  // the live block tree off the editor that stays mounted behind it, with no
+  // new prop on the content area.
+  const mindMap = useMindMap({
+    noteTitle: note?.title ?? '',
+    onEditorReady: review.handleEditorReady
+  })
+  const { refresh: refreshMindMap } = mindMap
+  // The map is built when it opens, but a restored tab reopens it before the
+  // body has finished loading. The heading set arriving is the signal that the
+  // block tree behind the map is real.
+  useEffect(() => {
+    refreshMindMap()
+  }, [headings, refreshMindMap])
+
   const handleTitleChange = useCallback(
     async (newTitle: string) => {
       if (!noteId || !note || newTitle === note.title) return
@@ -1304,6 +1321,32 @@ export function NotePage({ noteId }: NotePageProps) {
         />
       </Button>
 
+      {/* Mind map. Its own actions live inside the map, never in the overflow
+          menu above — the same control doing different work per mode is how
+          people delete things by accident. */}
+      {mindMap.isAvailable && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7 hover:bg-surface-active transition-all duration-150 ease-out active:scale-95 active:bg-surface-active/70 disabled:active:scale-100"
+          onClick={mindMap.toggle}
+          disabled={isDeleted}
+          aria-pressed={mindMap.isOpen}
+          data-testid="note-mind-map-toggle"
+          title={mindMap.isOpen ? t('editor.toolbar.hideMindMap') : t('editor.toolbar.showMindMap')}
+          aria-label={
+            mindMap.isOpen ? t('editor.toolbar.hideMindMap') : t('editor.toolbar.showMindMap')
+          }
+        >
+          <Hierarchy
+            className={cn(
+              'h-3.5 w-3.5',
+              mindMap.isOpen ? 'text-accent-orange' : 'text-muted-foreground'
+            )}
+          />
+        </Button>
+      )}
+
       <Picker
         value={null}
         closeOnSelect={false}
@@ -1450,6 +1493,11 @@ export function NotePage({ noteId }: NotePageProps) {
       fullWidth={isFullWidth}
       contentWidth={noteContentWidth ?? undefined}
       sideRail={hasReviewContent ? <ReviewRail review={review} targetId={noteId} /> : undefined}
+      overlay={
+        mindMap.isOpen && mindMap.map ? (
+          <MindMapView map={mindMap.map} noteTitle={note.title} />
+        ) : undefined
+      }
       onRailHiddenChange={setReviewRailHidden}
       marqueeZoneRef={setMarqueeZoneEl}
       topBar={
@@ -1475,7 +1523,18 @@ export function NotePage({ noteId }: NotePageProps) {
         initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ type: 'spring', bounce: 0, duration: 0.35 }}
-        className="flex flex-col flex-1 mx-auto w-full transition-[max-width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]"
+        data-testid="note-body"
+        // Hidden, never unmounted: unmounting destroys the editor instance and
+        // with it the CRDT undo manager, so a look at the map would cost the
+        // user their undo history. `invisible` also keeps the layout box, which
+        // is what leaves the scroll offset — and the cursor, the selection and
+        // the CRDT binding — exactly where they were.
+        inert={mindMap.isOpen || undefined}
+        aria-hidden={mindMap.isOpen || undefined}
+        className={cn(
+          'flex flex-col flex-1 mx-auto w-full transition-[max-width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]',
+          mindMap.isOpen && 'invisible pointer-events-none'
+        )}
         style={{ maxWidth: noteContentWidth ?? '100%' }}
       >
         {/* Title + Metadata zone — ghost affordance appears on hover */}
@@ -1603,7 +1662,7 @@ export function NotePage({ noteId }: NotePageProps) {
                   plainMarkdown: review.plainMarkdown,
                   marks: review.marks,
                   hoveredMarkId: review.hoveredMarkId,
-                  onEditorReady: review.handleEditorReady,
+                  onEditorReady: mindMap.handleEditorReady,
                   onAddComment: review.openCommentComposer,
                   getMarkdownSourceOffsetForEditorOffset:
                     review.getMarkdownSourceOffsetForEditorOffset,

--- a/apps/docs/src/.vitepress/config.ts
+++ b/apps/docs/src/.vitepress/config.ts
@@ -66,6 +66,7 @@ function unifiedSidebar() {
             { text: 'Custom Icons', link: '/user-guide/notes/custom-icons' },
             { text: 'Bookmarks & Reminders', link: '/user-guide/notes/bookmarks-reminders' },
             { text: 'Find in Page', link: '/user-guide/notes/find-in-page' },
+            { text: 'Mind Map', link: '/user-guide/notes/mind-map' },
             { text: 'Version History', link: '/user-guide/notes/version-history' }
           ]
         },

--- a/apps/docs/src/user-guide/notes/mind-map.md
+++ b/apps/docs/src/user-guide/notes/mind-map.md
@@ -1,0 +1,61 @@
+# Mind Map
+
+See the shape of a note instead of scrolling through it. The mind map draws the
+note's title as the root and branches through its headings.
+
+<!-- screenshot: a note's headings drawn as a mind map -->
+
+## Opening the Map
+
+Press the hierarchy icon in the note header, next to the reminder and bookmark
+actions. The title, properties, tags and body are replaced by the map. The
+header, the breadcrumb, the note's overflow menu and the outline panel all stay
+where they were.
+
+Press the same icon again to return to the note.
+
+The map is a **view of the note, not a document**. Nothing is saved, nothing is
+edited, and the note is untouched by opening it.
+
+## What Gets Drawn
+
+- The **note title** is always the root — never the first heading.
+- **Headings** branch by level: an H3 under an H2 under an H1 nests three deep.
+- A **skipped level** (an H1 followed by an H3) does not invent a missing
+  heading in between; the H3 simply nests one step deeper.
+- A note whose first heading is a deep level attaches that heading straight to
+  the root. Relative depth is what places a heading, not the number you wrote.
+- Paragraphs and other blocks are not drawn yet. Content before the first
+  heading belongs to the root.
+
+A note with no headings opens on the root alone, with a hint that adding a
+heading will branch it.
+
+## Coming Back to the Note
+
+Your work is exactly where you left it. The editor is only hidden while the map
+shows, never torn down, so undo history, the cursor, the selection and the
+scroll position all survive the round trip.
+
+## Per Tab, and Across Restarts
+
+The map is remembered **per tab**. Switch to another tab and back and the map is
+still open; quit and reopen memrynote and it is still open. Opening the same
+note in a different tab starts in note view, because the map belongs to the
+place you are working, not to the note.
+
+## Reading Direction
+
+In a right-to-left language the tree grows with your reading direction rather
+than against it.
+
+## Accessibility
+
+The drawing sits beside a real tree in the page, so every node is announced by a
+screen reader with its nesting level. The map region itself is labelled with the
+note's name and how many nodes it holds.
+
+## Turning It Off
+
+The mind map rides on the **Spatial Canvas** feature. Turn that off in
+**Settings → Features** and the toggle disappears from the note header.

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -140,6 +140,8 @@
       "setReminder": "Set reminder",
       "removeBookmark": "Remove bookmark",
       "addBookmark": "Add bookmark",
+      "showMindMap": "Show mind map",
+      "hideMindMap": "Hide mind map",
       "hideLocalGraph": "Hide local graph",
       "showLocalGraph": "Show local graph",
       "moreActions": "More actions",
@@ -961,5 +963,10 @@
     "groupHeader": {
       "noteCount": "{count, plural, one {# note} other {# notes}}"
     }
+  },
+  "mindMap": {
+    "regionLabel": "Mind map of {title}, {count, plural, one {# node} other {# nodes}}",
+    "treeLabel": "Mind map outline of {title}",
+    "emptyHint": "Add a heading to this note and the map will branch."
   }
 }


### PR DESCRIPTION
Implements #1669 — the tracer bullet for the note mind map (#1667).

A toggle beside the reminder and bookmark actions in the note header replaces
the note's title, properties, tags and body with a mind map rooted at the note
title and branching through its headings. Press it again and the note comes
back exactly as it was.

Only headings are drawn here. Lists, tasks, wiki links, badges, caps,
navigation, the map toolbar and canvas saving are #1670–#1675.

## Design notes

**One public entry point.**

```ts
buildMindMap(blocks: readonly MindMapSourceBlock[], options: MindMapOptions): MindMap
// options: { rootLabel: string; direction?: 'ltr' | 'rtl' }
// MindMap:  { tree, nodes, elements, direction, nodeCount, isEmpty, bounds }
```

`tree` is the logical tree, `nodes` the positioned nodes in depth-first order,
`elements` the drawing descriptors — all three from one call. Projection, layout
and element minting are private behind it, so the internal decomposition can
change without a red suite. Wave-2 tickets extend the node union and the options
object; they do not need a second seam.

**The editor is hidden, never unmounted.** Unmounting destroys the editor
instance and with it the CRDT undo manager. Hiding is layout-preserving
(`visibility`, not `display`), which is what leaves the scroll offset, cursor,
selection and CRDT binding untouched. There is a test asserting the editor
instance is the identical object across a round trip, and it fails if the body
is keyed to remount.

**Layout is deterministic.** Our own horizontal tidy tree with variable node
heights, root on the leading side, integer arithmetic over the label text and
the tree shape only — no measurement, no clock, no randomness. Asserted both by
exact coordinates and by two calls being deeply equal.

**The tree-role DOM projection ships here**, not later: it is what makes the map
reachable by a screen reader and the only way a browser harness can see inside a
bitmap drawing surface. It is a second projection of one layout result, rendered
as a sibling of the `role="img"` canvas region (nested, an image role would make
it presentational and hide it from exactly the readers it exists for).

**No IPC contract, migration, sync handler or settings schema.** Renderer-local:
pure functions, one flag in existing tab view state, the canvas renderer in view
mode. Gated on the existing `spatialCanvas` feature key; no new feature key.

## Acceptance criteria

- [x] Toggle in the note header beside reminder and bookmark, translated label,
      pressed state — `note.test.tsx` "offers the toggle alongside the reminder
      and bookmark actions".
- [x] Activating replaces title/properties/tags/body; header, breadcrumb and
      overflow menu stay visible and unchanged — "shows the map, then gives the
      note back, and never touches the overflow menu" compares the overflow
      menu's `outerHTML` before, during and after.
- [x] Note title as root, headings branching by level — `build-mind-map.test.ts`
      "roots the map at the note title" and "branches sub-headings off their
      parent heading".
- [x] Skipped level mints no phantom node; a deep first heading attaches to the
      root; content before the first heading attaches to the root — three
      dedicated pure tests.
- [x] Deactivating returns the note with undo history, cursor, selection and
      scroll offset intact — "keeps the very same editor instance across a round
      trip" (identical object, one mount) plus "hides the body without
      collapsing it" (same DOM node, layout-preserving hide).
- [x] Tab-scoped, survives tab switch and restart, another tab starts in note
      view — "writes the map into tab view state and reopens there"; the key
      rides `useTabViewState`, which is per-tab and already survives switch and
      session restore, with a total `parse`.
- [x] Tree-role projection exposes every node; map region labelled with the note
      and its node count — "projects every node into a real tree beside the
      drawing" and "labels the map region with the note and its node count".
- [x] RTL branches with the reading direction — "mirrors the whole map in an RTL
      locale" asserts the mirrored coordinates.
- [x] Identical layout on every open — "lays the same note out identically on
      every call".
- [x] A note with no headings opens on the root alone with a quiet hint, toggle
      not disabled — "opens a note with no headings on the root alone, and keeps
      the toggle live".
- [x] Gated on the existing spatial-canvas key, no new settings key — "does not
      offer the map when the spatial-canvas feature is off".
- [x] One public entry point returning all three layers, asserted without a DOM
      including determinism and an RTL run — 21 tests in
      `build-mind-map.test.ts`, importing only `buildMindMap`.
- [x] A renderer test asserts the editor instance is the same object across a
      round trip — see above; mutation-checked.
- [x] No IPC contract, migration, sync handler or settings schema changed — the
      diff touches only renderer components, the note page, the icon map, one
      locale file and docs.

## Mutation evidence

Four deliberate mutations, each caught by the test that is supposed to catch it:

| Mutation | Failing test |
| --- | --- |
| body keyed to remount across the toggle | keeps the very same editor instance across a round trip |
| `invisible` → `hidden` on the hidden body | hides the body without collapsing it |
| `depth: parent.depth + 1` → `depth: level` | skipped level / deep first heading / content before first heading |
| `COLUMN_GAP` 72 → 80 | exact-coordinate and RTL layout tests |

## Gates

```
$ pnpm lint
✖ 108 problems (0 errors, 108 warnings)
exit 0        # warnings are the repo's existing baseline

$ pnpm typecheck
 Tasks:    17 successful, 17 total
exit 0        # includes typecheck:test — neither new test file is in the exclude backlog

$ pnpm test:desktop
 Test Files  1371 passed | 3 skipped (1374)
      Tests  17801 passed | 1 expected fail | 13 skipped (17815)
exit 0

$ pnpm --filter @memry/desktop i18n:check
ok: i18n check passed
exit 0

$ pnpm docs:impact --base 6313dc1b4 --strict
docs impact: covered against 6313dc1b4847158ce66c63ba70dd274d040578c6
docs impact: docs changed on this branch
exit 0

$ pnpm docs:build
build complete in 2.79s.
exit 0
```

### `pnpm test` at the root is red, for a reason that predates this branch

```
@memry/i18n:test: FAIL src/locales/icu-brace-style.test.ts
+   "en/common.json → canvas.link.useUrl: MALFORMED_ARGUMENT (Link to {{url}})",
+   "en/common.json → phaseF.componentsAppSidebar.sortLabel: MALFORMED_ARGUMENT (Sort {{section}}: {{mode}})",
      Tests  2 failed | 54 passed (56)
```

Both keys are in `en/common.json` and are unchanged on `main` — they use
`{{double-brace}}` where the ICU formatter wants single braces. Reverting
`en/notes.json` to its `main` content and re-running `@memry/i18n` reproduces
the identical two failures, so this is pre-existing and was only masked by a
turbo cache hit; touching `en/notes.json` busted that cache. `@memry/desktop#test`
depends on `@memry/i18n#test`, which is why the root `pnpm test` never reaches
the desktop suite — hence the direct `pnpm test:desktop` run above. Not fixed
here: the two strings are unrelated to this change and belong in their own PR.

## Deliberately not done

- The canvas chunk is mounted on toggle and unmounted on close rather than kept
  alive for the tab's lifetime. `React.lazy` already caches the module, so the
  chunk is fetched once; keeping a hidden Excalidraw instance mounted alongside
  a hidden editor buys nothing until there is state worth preserving in it
  (viewport, expansion), which is #1673/#1674 work.
- Connectors are straight lines with explicit points rather than bound arrows.
  Binding matters for the saved canvas (#1675) and edge minting is private
  behind `buildMindMap`, so it can change there without touching this seam.
