### PR TITLE
feat(notes): branch lists, tasks and containers in the note mind map (#1671)

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.test.ts
@@ -6,7 +6,12 @@
 
 import { describe, expect, it } from 'vitest'
 import { buildMindMap } from './build-mind-map'
-import type { MindMapNode, MindMapSourceBlock } from './mind-map-types'
+import type {
+  MindMapBoxElement,
+  MindMapNode,
+  MindMapPositionedNode,
+  MindMapSourceBlock
+} from './mind-map-types'
 
 function heading(id: string, level: number, text: string): MindMapSourceBlock {
   return { id, type: 'heading', props: { level }, content: [{ type: 'text', text }] }
@@ -14,6 +19,35 @@ function heading(id: string, level: number, text: string): MindMapSourceBlock {
 
 function paragraph(id: string, text: string): MindMapSourceBlock {
   return { id, type: 'paragraph', content: [{ type: 'text', text }] }
+}
+
+/** Every block type below is a registered `config.type`, not a guess. */
+function listItem(
+  type: 'bulletListItem' | 'numberedListItem' | 'checkListItem' | 'toggleListItem' | 'callout',
+  id: string,
+  text: string,
+  extra: { props?: Record<string, unknown>; children?: MindMapSourceBlock[] } = {}
+): MindMapSourceBlock {
+  return {
+    id,
+    type,
+    props: extra.props,
+    content: [{ type: 'text', text }],
+    children: extra.children
+  }
+}
+
+function bullet(id: string, text: string, children?: MindMapSourceBlock[]): MindMapSourceBlock {
+  return listItem('bulletListItem', id, text, { children })
+}
+
+function taskBlock(id: string, title: string, checked = false): MindMapSourceBlock {
+  return { id, type: 'taskBlock', props: { taskId: `t-${id}`, title, checked } }
+}
+
+/** A translator stand-in: deterministic, and never the shape a locale file has. */
+function formatContentCount(kind: string, count: number): string {
+  return `${count} ${kind}`
 }
 
 /** Labels of a node's children, in order. */
@@ -101,7 +135,10 @@ describe('buildMindMap — projection', () => {
     expect(labelled(map.tree, 'First section').depth).toBe(1)
   })
 
-  it('finds headings nested inside container blocks', () => {
+  it('keeps a heading written inside a container inside it', () => {
+    // The toggle is a node of its own now, so the heading it holds stays where
+    // it was written rather than being hoisted out and leaving its own
+    // contents behind under a container it no longer belongs to.
     const map = buildMindMap(
       [
         heading('a', 1, 'Alpha'),
@@ -109,13 +146,15 @@ describe('buildMindMap — projection', () => {
           id: 'toggle',
           type: 'toggleListItem',
           content: [{ type: 'text', text: 'Collapsed' }],
-          children: [heading('b', 2, 'Hidden section')]
+          children: [heading('b', 2, 'Hidden section'), bullet('b1', 'Inside the section')]
         }
       ],
       { rootLabel: 'Note' }
     )
 
-    expect(childLabels(labelled(map.tree, 'Alpha'))).toEqual(['Hidden section'])
+    expect(childLabels(labelled(map.tree, 'Alpha'))).toEqual(['Collapsed'])
+    expect(childLabels(labelled(map.tree, 'Collapsed'))).toEqual(['Hidden section'])
+    expect(childLabels(labelled(map.tree, 'Hidden section'))).toEqual(['Inside the section'])
   })
 
   it('folds a blank heading into the nearest labelled ancestor instead of drawing an empty box', () => {
@@ -385,5 +424,352 @@ describe('buildMindMap — deep links', () => {
     // A link is an attribute of a box, never an input to where it sits.
     expect(withLinks.nodes).toEqual(withoutLinks.nodes)
     expect(withLinks.bounds).toEqual(withoutLinks.bounds)
+  })
+})
+
+describe('buildMindMap — lists, tasks and containers', () => {
+  it('branches bullet, numbered and checklist items off the heading above them', () => {
+    const map = buildMindMap(
+      [
+        heading('h', 1, 'Today'),
+        bullet('b', 'A loose thought'),
+        listItem('numberedListItem', 'n', 'A step'),
+        listItem('checkListItem', 'c', 'A box to tick')
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    expect(childLabels(labelled(map.tree, 'Today'))).toEqual([
+      'A loose thought',
+      '1. A step',
+      'A box to tick'
+    ])
+    expect(labelled(map.tree, 'Today').children.map((child) => child.kind)).toEqual([
+      'bullet',
+      'numbered',
+      'check'
+    ])
+  })
+
+  it('numbers a run of items and starts a new run when something interrupts it', () => {
+    const map = buildMindMap(
+      [
+        heading('h', 1, 'Steps'),
+        listItem('numberedListItem', 'n1', 'First'),
+        listItem('numberedListItem', 'n2', 'Second'),
+        paragraph('p', 'An aside, which ends the list.'),
+        listItem('numberedListItem', 'n3', 'First again')
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    expect(childLabels(labelled(map.tree, 'Steps'))).toEqual([
+      '1. First',
+      '2. Second',
+      '1. First again'
+    ])
+  })
+
+  it('starts a numbered run where the user moved it to', () => {
+    const map = buildMindMap(
+      [
+        listItem('numberedListItem', 'n1', 'Five', { props: { start: 5 } }),
+        listItem('numberedListItem', 'n2', 'Six')
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    expect(childLabels(map.tree)).toEqual(['5. Five', '6. Six'])
+  })
+
+  it('branches a nested list item off its parent item, not off the heading', () => {
+    const map = buildMindMap(
+      [
+        heading('h', 1, 'Section'),
+        bullet('b1', 'Parent', [bullet('b2', 'Child', [bullet('b3', 'Grandchild')])]),
+        bullet('b4', 'Sibling')
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    expect(childLabels(labelled(map.tree, 'Section'))).toEqual(['Parent', 'Sibling'])
+    expect(childLabels(labelled(map.tree, 'Parent'))).toEqual(['Child'])
+    expect(childLabels(labelled(map.tree, 'Child'))).toEqual(['Grandchild'])
+    expect(labelled(map.tree, 'Grandchild').depth).toBe(4)
+  })
+
+  it('draws a task block from its title and follows its tick', () => {
+    const map = buildMindMap(
+      [
+        heading('h', 1, 'Commitments'),
+        taskBlock('t1', 'Write the spec'),
+        taskBlock('t2', 'Ship it', true)
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    const tasks = labelled(map.tree, 'Commitments').children
+    expect(tasks.map((task) => [task.kind, task.label, task.isDone])).toEqual([
+      ['task', 'Write the spec', false],
+      ['task', 'Ship it', true]
+    ])
+  })
+
+  it('branches a toggle and a callout into their children rather than flattening them', () => {
+    const map = buildMindMap(
+      [
+        listItem('toggleListItem', 'tg', 'Collapsed in the editor', {
+          children: [bullet('tb', 'Still discoverable here')]
+        }),
+        listItem('callout', 'co', 'Watch out', {
+          props: { type: 'warning' },
+          children: [
+            listItem('checkListItem', 'cc', 'A checklist inside it', { props: { checked: true } })
+          ]
+        })
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    expect(childLabels(map.tree)).toEqual(['Collapsed in the editor', 'Watch out'])
+    expect(labelled(map.tree, 'Collapsed in the editor').kind).toBe('toggle')
+    expect(childLabels(labelled(map.tree, 'Collapsed in the editor'))).toEqual([
+      'Still discoverable here'
+    ])
+    expect(labelled(map.tree, 'Watch out').kind).toBe('callout')
+    expect(childLabels(labelled(map.tree, 'Watch out'))).toEqual(['A checklist inside it'])
+    expect(labelled(map.tree, 'A checklist inside it').isDone).toBe(true)
+  })
+
+  it('carries the source block on every node, which is what navigation lands on', () => {
+    const map = buildMindMap(
+      [
+        heading('h', 1, 'Section'),
+        bullet('b', 'A bullet'),
+        taskBlock('t', 'A task'),
+        listItem('toggleListItem', 'tg', 'A toggle')
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    expect(map.nodes.map((positioned) => positioned.blockId)).toEqual([null, 'h', 'b', 't', 'tg'])
+  })
+
+  it('folds an item with nothing to show and keeps what was under it', () => {
+    const map = buildMindMap(
+      [heading('h', 1, 'Section'), bullet('blank', '   ', [bullet('kept', 'Still here')])],
+      { rootLabel: 'Note' }
+    )
+
+    expect(childLabels(labelled(map.tree, 'Section'))).toEqual(['Still here'])
+  })
+})
+
+describe('buildMindMap — tags and content badges', () => {
+  it('turns an inline tag into a badge on its node rather than a node of its own', () => {
+    const map = buildMindMap(
+      [
+        {
+          id: 'h',
+          type: 'heading',
+          props: { level: 1 },
+          content: [
+            { type: 'text', text: 'Plan ' },
+            { type: 'hashTag', props: { tag: 'q3', color: 'red', icon: '' } },
+            { type: 'text', text: ' review ' },
+            { type: 'hashTag', props: { tag: 'ops' } },
+            { type: 'hashTag', props: { tag: 'q3' } }
+          ]
+        }
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    const section = labelled(map.tree, 'Plan review')
+    expect(map.nodeCount).toBe(2)
+    // Out of the label, onto the node — and a tag written twice reads once.
+    expect(section.tags).toEqual(['q3', 'ops'])
+    expect(section.detail).toBe('#q3 #ops')
+  })
+
+  it('counts content on the node above it instead of drawing a node for it', () => {
+    const map = buildMindMap(
+      [
+        heading('h', 1, 'Section'),
+        { id: 'tbl', type: 'table', content: { type: 'tableContent', rows: [] } },
+        { id: 'code1', type: 'codeBlock', content: [{ type: 'text', text: 'const a = 1' }] },
+        { id: 'code2', type: 'codeBlock', content: [{ type: 'text', text: 'const b = 2' }] },
+        { id: 'img', type: 'image', props: { url: 'a.png' } },
+        { id: 'q', type: 'quote', content: [{ type: 'text', text: 'A quotation.' }] },
+        { id: 'yt', type: 'youtubeEmbed', props: { videoId: 'abc' } },
+        { id: 'vid', type: 'video', props: { url: 'a.mp4' } },
+        { id: 'aud', type: 'audio', props: { url: 'a.mp3' } },
+        { id: 'bk', type: 'bookmark', props: { url: 'https://memry.test' } },
+        { id: 'fl', type: 'file', props: { url: 'a.pdf', name: 'a.pdf' } }
+      ],
+      { rootLabel: 'Note', formatContentCount }
+    )
+
+    // Root plus the heading. Nothing above became a node of its own.
+    expect(map.nodeCount).toBe(2)
+    const section = labelled(map.tree, 'Section')
+    expect(section.contents).toEqual([
+      { kind: 'table', count: 1 },
+      { kind: 'code', count: 2 },
+      { kind: 'image', count: 1 },
+      { kind: 'quote', count: 1 },
+      // youtubeEmbed, video and audio all read as an embed.
+      { kind: 'embed', count: 3 },
+      { kind: 'bookmark', count: 1 },
+      { kind: 'file', count: 1 }
+    ])
+    expect(section.detail).toBe(
+      '1 table · 2 code · 1 image · 1 quote · 3 embed · 1 bookmark · 1 file'
+    )
+    // On the box the reader can see, not only in the data behind it.
+    const box = map.elements.find(
+      (element) => element.type === 'rectangle' && element.id === section.id
+    )
+    expect(box?.type === 'rectangle' && box.label.text).toBe(`Section\n${section.detail}`)
+  })
+
+  it('counts content against the container holding it, and the root before any heading', () => {
+    const map = buildMindMap(
+      [
+        { id: 'img', type: 'image', props: { url: 'a.png' } },
+        heading('h', 1, 'Section'),
+        listItem('toggleListItem', 'tg', 'A toggle', {
+          children: [{ id: 'code', type: 'codeBlock', content: [{ type: 'text', text: 'x' }] }]
+        })
+      ],
+      { rootLabel: 'Note', formatContentCount }
+    )
+
+    expect(map.tree.detail).toBe('1 image')
+    expect(labelled(map.tree, 'Section').detail).toBe('')
+    expect(labelled(map.tree, 'A toggle').detail).toBe('1 code')
+  })
+
+  it('keeps the counts and loses only their wording when no formatter is supplied', () => {
+    const map = buildMindMap(
+      [heading('h', 1, 'Section'), { id: 'tbl', type: 'table', content: { rows: [] } }],
+      { rootLabel: 'Note' }
+    )
+
+    const section = labelled(map.tree, 'Section')
+    expect(section.contents).toEqual([{ kind: 'table', count: 1 }])
+    expect(section.detail).toBe('')
+  })
+
+  it('keeps date mentions, link mentions and inline images as plain label text', () => {
+    const map = buildMindMap(
+      [
+        {
+          id: 'h',
+          type: 'heading',
+          props: { level: 1 },
+          content: [
+            { type: 'text', text: 'Due ' },
+            { type: 'dateMention', props: { dateISO: '2026-08-21', hasTime: false } },
+            { type: 'text', text: ' per ' },
+            {
+              type: 'linkMention',
+              props: { url: 'https://memry.test/x', domain: 'memry.test', title: 'the brief' }
+            },
+            { type: 'text', text: ' see ' },
+            { type: 'inlineImage', props: { src: 'chart.png', alt: 'the chart', width: 0 } }
+          ]
+        },
+        paragraph('p', 'A paragraph never becomes a node.')
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    expect(map.nodeCount).toBe(2)
+    expect(childLabels(map.tree)).toEqual(['Due 2026-08-21 per the brief see the chart'])
+  })
+
+  it('lets the badge line widen and heighten the box that carries it', () => {
+    const plain = buildMindMap([heading('h', 1, 'Section')], { rootLabel: 'Note' })
+    const badged = buildMindMap(
+      [heading('h', 1, 'Section'), { id: 'tbl', type: 'table', content: { rows: [] } }],
+      { rootLabel: 'Note', formatContentCount: () => 'a considerably longer badge line' }
+    )
+
+    expect(badged.nodes[1].height).toBeGreaterThan(plain.nodes[1].height)
+    expect(badged.nodes[1].width).toBeGreaterThan(plain.nodes[1].width)
+  })
+})
+
+describe('buildMindMap — completed items', () => {
+  const map = buildMindMap(
+    [
+      heading('h', 1, 'Commitments'),
+      taskBlock('open', 'Still to do'),
+      taskBlock('done', 'Already done', true),
+      listItem('checkListItem', 'ticked', 'Ticked off', { props: { checked: true } })
+    ],
+    { rootLabel: 'Note' }
+  )
+
+  function boxOf(label: string): {
+    positioned: MindMapPositionedNode
+    box: MindMapBoxElement
+  } {
+    const positioned = map.nodes.find((candidate) => candidate.label === label)
+    if (!positioned) throw new Error(`no node labelled ${label}`)
+    const box = map.elements.find(
+      (element) => element.type === 'rectangle' && element.id === positioned.id
+    )
+    if (box?.type !== 'rectangle') throw new Error(`no box for ${label}`)
+    return { positioned, box }
+  }
+
+  it('dims a completed item and leaves an open one alone', () => {
+    const open = boxOf('Still to do')
+    const done = boxOf('Already done')
+
+    expect(done.box.label.strokeColor).not.toBe(open.box.label.strokeColor)
+    expect(done.box.strokeColor).not.toBe(open.box.strokeColor)
+    expect(done.box.backgroundColor).not.toBe(open.box.backgroundColor)
+  })
+
+  it('rules a completed label through, because the surface has no text decorations', () => {
+    const open = boxOf('Still to do')
+    const strikes = map.elements.filter((element) => element.id.includes('-strike-'))
+
+    expect(strikes.map((strike) => strike.id).sort()).toEqual([
+      'mm-done-strike-1',
+      'mm-ticked-strike-1'
+    ])
+    expect(
+      map.elements.some((element) => element.id.startsWith(`${open.positioned.id}-strike`))
+    ).toBe(false)
+
+    // Horizontal, over the label, inside the box it belongs to.
+    for (const label of ['Already done', 'Ticked off']) {
+      const { positioned } = boxOf(label)
+      const strike = strikes.find((candidate) => candidate.id.startsWith(`${positioned.id}-`))
+      if (strike?.type !== 'line') throw new Error(`no rule over ${label}`)
+      expect(strike.points[1][1]).toBe(0)
+      expect(strike.x).toBeGreaterThan(positioned.x)
+      expect(strike.y).toBeGreaterThan(positioned.y)
+      expect(strike.y).toBeLessThan(positioned.y + positioned.height)
+      expect(strike.x + strike.points[1][0]).toBeLessThanOrEqual(positioned.x + positioned.width)
+    }
+  })
+
+  it('mirrors the rule with the reading direction', () => {
+    const rtl = buildMindMap([taskBlock('done', 'Already done', true)], {
+      rootLabel: 'Note',
+      direction: 'rtl'
+    })
+
+    const positioned = rtl.nodes.find((candidate) => candidate.label === 'Already done')
+    const strike = rtl.elements.find((element) => element.id === 'mm-done-strike-1')
+    if (!positioned || strike?.type !== 'line') throw new Error('no rule in the RTL map')
+    // Hard against the trailing padding edge, which in RTL is where the text starts.
+    expect(strike.x).toBeGreaterThanOrEqual(positioned.x)
+    expect(strike.x + strike.points[1][0]).toBeLessThanOrEqual(positioned.x + positioned.width)
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.ts
@@ -21,7 +21,7 @@ export function buildMindMap(
   options: MindMapOptions
 ): MindMap {
   const direction = options.direction ?? 'ltr'
-  const tree = projectBlocks(blocks, options.rootLabel)
+  const tree = projectBlocks(blocks, options)
   const { nodes, bounds } = layoutMindMap(tree, direction)
 
   return {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/index.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/index.ts
@@ -16,6 +16,8 @@ export type { UseMindMapNavigationResult } from './use-mind-map-navigation'
 export type {
   MindMap,
   MindMapBounds,
+  MindMapContentCount,
+  MindMapContentKind,
   MindMapDirection,
   MindMapElement,
   MindMapNode,

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
@@ -8,12 +8,20 @@
  */
 
 import { buildMemryHref } from '@/lib/memry-links'
-import { MIND_MAP_FONT_SIZE } from './mind-map-layout'
+import {
+  CHAR_WIDTH,
+  LINE_HEIGHT,
+  MIND_MAP_FONT_SIZE,
+  PADDING_X,
+  lineCount
+} from './mind-map-layout'
 import type { MindMapDirection, MindMapElement, MindMapPositionedNode } from './mind-map-types'
 
 /**
  * Authored for the light theme; the drawing library derives the dark one. Calm
- * and restrained on purpose — the map is a reading surface, not a chart.
+ * and restrained on purpose — the map is a reading surface, not a chart. Three
+ * treatments, not one per node kind: the title, the structure, and what is
+ * already done.
  */
 const ROOT_STROKE = '#ff671a'
 const ROOT_FILL = '#fff1e8'
@@ -21,6 +29,10 @@ const NODE_STROKE = '#868e96'
 const NODE_FILL = '#ffffff'
 const LABEL_COLOR = '#1e1e1e'
 const EDGE_STROKE = '#adb5bd'
+/** Ticked items stay on the map and step back from it. */
+const DONE_STROKE = '#ced4da'
+const DONE_FILL = '#f8f9fa'
+const DONE_LABEL = '#adb5bd'
 /** Adaptive corner radius. */
 const ROUNDNESS = { type: 3 }
 
@@ -38,6 +50,46 @@ function nodeLink(node: MindMapPositionedNode, noteId: string | undefined): stri
       anchor: node.blockId ? { type: 'block', id: node.blockId } : null
     }) ?? undefined
   )
+}
+
+/** What the box actually holds: the label, then its badge line when there is one. */
+function boxText(node: MindMapPositionedNode): string {
+  return node.detail === '' ? node.label : `${node.label}\n${node.detail}`
+}
+
+/**
+ * The rules that strike a completed item's label out.
+ *
+ * The surface is a bitmap with no text decorations, so this is drawn: one rule
+ * per wrapped line of the label, over the text and not over the badges. The
+ * geometry mirrors the box's own — the label block is centred vertically, and
+ * the text hangs off whichever side the reading direction starts on.
+ */
+function strikeRules(node: MindMapPositionedNode, direction: MindMapDirection): MindMapElement[] {
+  const labelLines = Math.max(1, lineCount(node.label))
+  const totalLines = labelLines + lineCount(node.detail)
+  const textTop = node.y + Math.round((node.height - totalLines * LINE_HEIGHT) / 2)
+  const perLine = Math.ceil(node.label.length / labelLines)
+
+  return Array.from({ length: labelLines }, (_, line) => {
+    const chars = Math.min(perLine, node.label.length - line * perLine)
+    const length = Math.max(CHAR_WIDTH, chars * CHAR_WIDTH)
+    const startX =
+      direction === 'rtl' ? node.x + node.width - PADDING_X - length : node.x + PADDING_X
+    return {
+      type: 'line' as const,
+      id: `${node.id}-strike-${line + 1}`,
+      x: startX,
+      y: textTop + line * LINE_HEIGHT + Math.round(LINE_HEIGHT / 2),
+      points: [
+        [0, 0],
+        [length, 0]
+      ] as Array<[number, number]>,
+      strokeColor: DONE_LABEL,
+      strokeWidth: 1,
+      roughness: 0
+    }
+  })
 }
 
 export function mintElements(
@@ -86,20 +138,25 @@ export function mintElements(
       y: node.y,
       width: node.width,
       height: node.height,
-      strokeColor: isRoot ? ROOT_STROKE : NODE_STROKE,
-      backgroundColor: isRoot ? ROOT_FILL : NODE_FILL,
+      strokeColor: isRoot ? ROOT_STROKE : node.isDone ? DONE_STROKE : NODE_STROKE,
+      backgroundColor: isRoot ? ROOT_FILL : node.isDone ? DONE_FILL : NODE_FILL,
       fillStyle: 'solid',
       strokeWidth: 1,
       roughness: 0,
       roundness: ROUNDNESS,
       label: {
-        text: node.label,
+        text: boxText(node),
         fontSize: MIND_MAP_FONT_SIZE,
         textAlign: direction === 'rtl' ? 'right' : 'left',
         verticalAlign: 'middle',
-        strokeColor: LABEL_COLOR
+        strokeColor: node.isDone ? DONE_LABEL : LABEL_COLOR
       }
     })
+  }
+
+  // Last, so a rule is never painted under the box it belongs to.
+  for (const node of nodes) {
+    if (node.isDone) elements.push(...strikeRules(node, direction))
   }
 
   return elements

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-inline.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-inline.ts
@@ -1,0 +1,83 @@
+/**
+ * Private helper — a block's inline content becomes a label and its tags.
+ *
+ * Not exported outside this directory. Two things come out of one walk because
+ * they are decided by the same pass: a hash tag becomes a badge on the node, so
+ * it must leave the label at exactly the point it is collected, or the tag
+ * would be shown twice.
+ *
+ * Every inline spec Memry registers is content-less (`content: 'none'`) and
+ * keeps its visible text in props, so the reader below is prop-driven rather
+ * than a switch over node types: it works the same for a spec added later.
+ */
+
+/**
+ * Where a content-less inline spec keeps its text, best first.
+ *
+ * - `wikiLink` → `alias`, else `target`
+ * - `linkMention` → `title`, else `domain`, else `url`
+ * - `inlineImage` → `alt` (a picture with no alt text contributes nothing)
+ * - `dateMention` → `dateISO`, the only date form available without the
+ *   renderer's clock and week-start settings
+ *
+ * `hashTag`'s `tag` is deliberately absent: a tag is a badge, not label text.
+ */
+const INLINE_LABEL_PROPS = ['alias', 'target', 'title', 'alt', 'domain', 'url', 'dateISO'] as const
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/** A prop read as a non-empty trimmed string, or `null`. */
+export function stringProp(props: unknown, key: string): string | null {
+  if (!isRecord(props)) return null
+  const value = props[key]
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+export interface InlineRead {
+  text: string
+  /** In document order, first occurrence wins, `#` already stripped. */
+  tags: string[]
+}
+
+/** Total: any inline shape in, a label and its tags out. */
+export function readInline(value: unknown): InlineRead {
+  const tags: string[] = []
+  const seen = new Set<string>()
+
+  const walk = (node: unknown): string => {
+    if (typeof node === 'string') return node
+    if (Array.isArray(node)) return node.map(walk).join('')
+    if (!isRecord(node)) return ''
+
+    // A tag leaves the label here and reappears as a badge on the node. The
+    // stored prop has no `#`; the badge adds one back so it reads as written.
+    if (node.type === 'hashTag') {
+      const tag = stringProp(node.props, 'tag')
+      if (tag !== null && !seen.has(tag)) {
+        seen.add(tag)
+        tags.push(tag)
+      }
+      return ''
+    }
+
+    if (typeof node.text === 'string') return node.text
+    if (node.content !== undefined) return walk(node.content)
+
+    for (const key of INLINE_LABEL_PROPS) {
+      const candidate = stringProp(node.props, key)
+      if (candidate !== null) return candidate
+    }
+    return ''
+  }
+
+  return { text: walk(value), tags }
+}
+
+/** Collapses runs of whitespace so a wrapped label measures predictably. */
+export function normalizeLabel(raw: string): string {
+  return raw.replace(/\s+/g, ' ').trim()
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-layout.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-layout.ts
@@ -18,10 +18,10 @@ import type {
 
 /** Box metrics. Kept generous so the drawing library never has to grow a box. */
 export const MIND_MAP_FONT_SIZE = 16
-const CHAR_WIDTH = 9
-const PADDING_X = 16
+export const CHAR_WIDTH = 9
+export const PADDING_X = 16
 const PADDING_Y = 10
-const LINE_HEIGHT = 22
+export const LINE_HEIGHT = 22
 const MIN_WIDTH = 96
 const MAX_WIDTH = 264
 const MIN_HEIGHT = 42
@@ -30,17 +30,29 @@ const COLUMN_GAP = 72
 /** Vertical room between two boxes that share a column. */
 const SIBLING_GAP = 16
 
-const MAX_CHARS_PER_LINE = Math.floor((MAX_WIDTH - PADDING_X * 2) / CHAR_WIDTH)
+export const MAX_CHARS_PER_LINE = Math.floor((MAX_WIDTH - PADDING_X * 2) / CHAR_WIDTH)
 
-function boxWidth(label: string): number {
-  const ideal = PADDING_X * 2 + label.length * CHAR_WIDTH
+/** How many wrapped lines a run of text needs inside a box. */
+export function lineCount(text: string): number {
+  return text === '' ? 0 : Math.ceil(text.length / MAX_CHARS_PER_LINE)
+}
+
+/**
+ * A node's text as the box has to hold it: the label, then its badge line when
+ * there is one. Both are one text run to the drawing library, so both are
+ * measured the same way — a box the library has to grow is the one failure
+ * worth avoiding here.
+ */
+function boxWidth(node: MindMapNode): number {
+  const chars = Math.max(node.label.length, node.detail.length)
+  const ideal = PADDING_X * 2 + chars * CHAR_WIDTH
   if (ideal < MIN_WIDTH) return MIN_WIDTH
   if (ideal > MAX_WIDTH) return MAX_WIDTH
   return ideal
 }
 
-function boxHeight(label: string): number {
-  const lines = Math.max(1, Math.ceil(label.length / MAX_CHARS_PER_LINE))
+function boxHeight(node: MindMapNode): number {
+  const lines = Math.max(1, lineCount(node.label)) + lineCount(node.detail)
   return Math.max(MIN_HEIGHT, lines * LINE_HEIGHT + PADDING_Y * 2)
 }
 
@@ -56,8 +68,8 @@ function measure(node: MindMapNode, parentId: string | null): Measured {
   return {
     node,
     parentId,
-    width: boxWidth(node.label),
-    height: boxHeight(node.label),
+    width: boxWidth(node),
+    height: boxHeight(node),
     children: node.children.map((child) => measure(child, node.id))
   }
 }
@@ -125,6 +137,10 @@ export function layoutMindMap(
       kind: item.node.kind,
       level: item.node.level,
       depth: item.node.depth,
+      isDone: item.node.isDone,
+      tags: item.node.tags,
+      contents: item.node.contents,
+      detail: item.node.detail,
       parentId: item.parentId,
       // RTL mirrors the whole map about the root's leading edge, so the tree
       // grows with the reading direction instead of against it.

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.test.ts
@@ -35,6 +35,42 @@ describe('activateMindMapNode', () => {
     expect(navigateToBlock).toHaveBeenCalledWith(null)
   })
 
+  it('sends every other node kind to its own block, the way a heading goes', () => {
+    // The dispatch switches against a `never`, so this is the assertion that a
+    // kind added to the map was actually given a behaviour rather than a case
+    // that silently does nothing.
+    const structured = buildMindMap(
+      [
+        { id: 'b-bullet', type: 'bulletListItem', content: [{ type: 'text', text: 'Bullet' }] },
+        { id: 'b-number', type: 'numberedListItem', content: [{ type: 'text', text: 'Numbered' }] },
+        { id: 'b-check', type: 'checkListItem', content: [{ type: 'text', text: 'Check' }] },
+        { id: 'b-task', type: 'taskBlock', props: { taskId: 't-1', title: 'Task' } },
+        { id: 'b-toggle', type: 'toggleListItem', content: [{ type: 'text', text: 'Toggle' }] },
+        { id: 'b-callout', type: 'callout', content: [{ type: 'text', text: 'Callout' }] }
+      ],
+      { rootLabel: 'Test Note', noteId: 'note-1' }
+    )
+
+    const landed = structured.nodes
+      .filter((candidate) => candidate.kind !== 'root')
+      .map((candidate) => {
+        const navigateToBlock = vi.fn()
+        activateMindMapNode(candidate, { navigateToBlock })
+        return [candidate.kind, navigateToBlock.mock.calls]
+      })
+
+    expect(landed).toEqual([
+      ['bullet', [['b-bullet']]],
+      ['numbered', [['b-number']]],
+      ['check', [['b-check']]],
+      // A task lands on its block until it carries a task id (#1672); it must
+      // not silently do nothing in the meantime.
+      ['task', [['b-task']]],
+      ['toggle', [['b-toggle']]],
+      ['callout', [['b-callout']]]
+    ])
+  })
+
   it('lands a drawn box and its tree twin on the very same call', () => {
     const beta = node('Beta')
     const box = map.elements

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.ts
@@ -16,8 +16,8 @@ import type { MindMapPositionedNode } from './mind-map-types'
 
 /**
  * Everything a node can ask the note page to do. It has one member today
- * because the map draws two kinds of node, both of which are places in this
- * note; opening another note and opening a task join it with their own kinds.
+ * because every kind the map draws is a place in THIS note; opening another
+ * note (a wiki-link node) and opening a task join it with their own kinds.
  */
 export interface MindMapNodeActions {
   /**
@@ -37,8 +37,19 @@ export function activateMindMapNode(
   switch (node.kind) {
     case 'root':
     case 'heading':
-      // The root's `blockId` is null, which is already "the top of the note" —
-      // one branch, not two, because a node's block is what it navigates to.
+    case 'bullet':
+    case 'numbered':
+    case 'check':
+    case 'task':
+    case 'toggle':
+    case 'callout':
+      // Every kind the map draws is a place in this note, so they all land the
+      // same way: the granularity the user sees is the granularity they get
+      // back. The root's `blockId` is null, which already reads as "the top of
+      // the note" — one branch, not two, because a node's block IS what it
+      // navigates to. A task will open its task instead once it carries a task
+      // id (#1672); until it does, its block is the honest answer and doing
+      // nothing is not.
       actions.navigateToBlock(node.blockId)
       return
     default: {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-projection.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-projection.ts
@@ -2,15 +2,36 @@
  * Private step 1 — an editor block tree becomes a logical mind-map tree.
  *
  * Not exported outside this directory: `buildMindMap` is the only seam, so this
- * file is free to change shape as later tickets add lists, tasks and links.
+ * file is free to change shape as later tickets add wiki links and caps.
  *
- * Headings are the one hierarchy mechanism handled here, and they are flat
- * siblings in the block tree whose nesting lives in a `level` prop — so this is
- * a level stack, not a recursive descent. (Recursive descent is still needed to
- * *find* headings, because a heading can sit inside a toggle or a callout.)
+ * Two hierarchy mechanisms are merged in one pass, and they work nothing alike:
+ *
+ * - **Headings are flat siblings** whose nesting lives in a `level` prop, so
+ *   they need a level stack.
+ * - **List items, toggles and callouts are genuinely nested** as `children`, so
+ *   they need recursive descent and attach to whatever block contains them.
+ *
+ * Where the two meet, containment wins and the level stack is scoped to it: a
+ * container opens a fresh stack for what is inside it, so a heading written
+ * inside a toggle nests under that toggle and takes its own contents with it,
+ * rather than being hoisted out and leaving its bullets behind. Within any one
+ * scope a heading still governs what follows it, container or not.
+ *
+ * The governing rule for what appears at all: containers branch, content does
+ * not — but content is never silently invisible. A toggle really holds
+ * children, so flattening it would destroy something the user wrote; a table is
+ * content, so it is counted on the nearest node instead of being drawn.
  */
 
-import type { MindMapNode, MindMapSourceBlock } from './mind-map-types'
+import { normalizeLabel, readInline, stringProp, isRecord } from './mind-map-inline'
+import type {
+  MindMapContentCount,
+  MindMapContentKind,
+  MindMapNode,
+  MindMapNodeKind,
+  MindMapOptions,
+  MindMapSourceBlock
+} from './mind-map-types'
 
 export const MIND_MAP_ROOT_ID = 'mm-root'
 
@@ -18,50 +39,70 @@ const MIN_HEADING_LEVEL = 1
 const MAX_HEADING_LEVEL = 6
 
 /**
- * Content-less inline specs (wiki links, hash tags, date mentions) carry their
- * visible text in props. Read in this order, first non-empty wins.
+ * Block type → node kind, for everything that really holds structure.
  *
- * An interim rule: these kinds get their own treatment when links, tags and
- * dates become nodes and badges of their own.
+ * Every string here is a registered `config.type`: the four list kinds and
+ * `toggleListItem` are BlockNote defaults, `taskBlock` and `callout` are
+ * Memry's own (see `packages/editor-schema/src/blocks/configs.ts`).
  */
-const INLINE_LABEL_PROPS = ['alias', 'target', 'tag', 'dateISO'] as const
+const NODE_KINDS = new Map<string, MindMapNodeKind>([
+  ['heading', 'heading'],
+  ['bulletListItem', 'bullet'],
+  ['numberedListItem', 'numbered'],
+  ['checkListItem', 'check'],
+  ['taskBlock', 'task'],
+  ['toggleListItem', 'toggle'],
+  ['callout', 'callout']
+])
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
-}
+/**
+ * Block type → content kind, for everything that is content rather than
+ * structure. These never become nodes; they are counted on the node above.
+ *
+ * `video` and `audio` join `youtubeEmbed` under `embed`: all three are a piece
+ * of media the map cannot draw, and leaving them out entirely would break the
+ * promise that nothing disappears silently.
+ */
+const CONTENT_KINDS = new Map<string, MindMapContentKind>([
+  ['table', 'table'],
+  ['codeBlock', 'code'],
+  ['image', 'image'],
+  ['quote', 'quote'],
+  ['youtubeEmbed', 'embed'],
+  ['video', 'embed'],
+  ['audio', 'embed'],
+  ['bookmark', 'bookmark'],
+  ['file', 'file']
+])
 
-/** Total: any inline shape in, a plain string out. */
-function inlineText(value: unknown): string {
-  if (typeof value === 'string') return value
-  if (Array.isArray(value)) return value.map(inlineText).join('')
-  if (!isRecord(value)) return ''
+/** Badge order, so the same note always reads the same way. */
+const CONTENT_ORDER: readonly MindMapContentKind[] = [
+  'table',
+  'code',
+  'image',
+  'quote',
+  'embed',
+  'bookmark',
+  'file'
+]
 
-  if (typeof value.text === 'string') return value.text
-  if (value.content !== undefined) return inlineText(value.content)
-
-  const props = value.props
-  if (isRecord(props)) {
-    for (const key of INLINE_LABEL_PROPS) {
-      const candidate = props[key]
-      if (typeof candidate === 'string' && candidate.trim() !== '') return candidate
-    }
-  }
-  return ''
-}
-
-/** Collapses runs of whitespace so a wrapped heading measures predictably. */
-function normalizeLabel(raw: string): string {
-  return raw.replace(/\s+/g, ' ').trim()
-}
-
-function headingLevel(block: MindMapSourceBlock): number | null {
-  if (block.type !== 'heading') return null
-  const props = block.props
+function headingLevel(props: unknown): number {
   const raw = isRecord(props) ? props.level : undefined
   if (typeof raw !== 'number' || !Number.isInteger(raw)) return MIN_HEADING_LEVEL
   if (raw < MIN_HEADING_LEVEL) return MIN_HEADING_LEVEL
   if (raw > MAX_HEADING_LEVEL) return MAX_HEADING_LEVEL
   return raw
+}
+
+/** A checklist item's or a task's tick. Anything but `true` reads as not done. */
+function isChecked(props: unknown): boolean {
+  return isRecord(props) && props.checked === true
+}
+
+/** Where a run of numbered items starts, when the user moved it off 1. */
+function listStart(props: unknown): number | null {
+  const raw = isRecord(props) ? props.start : undefined
+  return typeof raw === 'number' && Number.isInteger(raw) ? raw : null
 }
 
 /**
@@ -73,28 +114,31 @@ function headingLevel(block: MindMapSourceBlock): number | null {
  *   nests one step deeper than its nearest shallower ancestor.
  * - A note whose first heading is a deep level attaches it straight to the
  *   root: relative depth is what matters, not the absolute number.
- * - Anything that is not a heading — including everything before the first
- *   heading — contributes no node, and never re-parents the headings around it.
- * - A blank heading has nothing to show, so it draws no box and does not join
- *   the level stack; its sub-headings fold up to the nearest labelled ancestor
- *   rather than disappearing.
+ * - Anything before the first heading belongs to the root.
+ * - A block with nothing to show — no text and no tags — draws no box and does
+ *   not join the level stack; whatever sits under it folds up to the nearest
+ *   ancestor that does have something to show, rather than disappearing.
  */
 export function projectBlocks(
   blocks: readonly MindMapSourceBlock[],
-  rootLabel: string
+  options: MindMapOptions
 ): MindMapNode {
   const root: MindMapNode = {
     id: MIND_MAP_ROOT_ID,
     blockId: null,
-    label: rootLabel,
+    label: options.rootLabel,
     kind: 'root',
     level: null,
     depth: 0,
+    isDone: false,
+    tags: [],
+    contents: [],
+    detail: '',
     children: []
   }
 
-  /** Open headings, shallowest first. The root is the implicit floor. */
-  const stack: Array<{ level: number; node: MindMapNode }> = []
+  /** Content tallies, kept aside so a node's `contents` is written once, in order. */
+  const tallies = new Map<MindMapNode, Map<MindMapContentKind, number>>()
   /**
    * Block ids should be unique, but a node id collision would mint two drawing
    * elements with one id, so the suffix keeps them apart deterministically.
@@ -108,30 +152,120 @@ export function projectBlocks(
     return seen === 0 ? base : `${base}-${seen + 1}`
   }
 
-  const visit = (block: MindMapSourceBlock): void => {
-    const level = headingLevel(block)
-    if (level !== null) {
-      const label = normalizeLabel(inlineText(block.content))
-      if (label !== '') {
-        while (stack.length > 0 && stack[stack.length - 1].level >= level) stack.pop()
-        const parent = stack.length > 0 ? stack[stack.length - 1].node : root
-        const node: MindMapNode = {
-          id: mintId(block.id),
-          blockId: block.id,
-          label,
-          kind: 'heading',
-          level,
-          depth: parent.depth + 1,
-          children: []
-        }
-        parent.children.push(node)
-        stack.push({ level, node })
-      }
-    }
-
-    for (const child of block.children ?? []) visit(child)
+  const tally = (node: MindMapNode, kind: MindMapContentKind): void => {
+    const counts = tallies.get(node) ?? new Map<MindMapContentKind, number>()
+    counts.set(kind, (counts.get(kind) ?? 0) + 1)
+    tallies.set(node, counts)
   }
 
-  for (const block of blocks) visit(block)
+  /**
+   * One level of containment: the node holding these blocks, and the headings
+   * open inside it, shallowest first. A container gets its own stack so its
+   * headings cannot escape it; the top level's container is the root.
+   */
+  interface Scope {
+    container: MindMapNode
+    stack: Array<{ level: number; node: MindMapNode }>
+  }
+
+  /** Whatever a block written here belongs to: the open heading, else the container. */
+  const parentIn = (scope: Scope): MindMapNode =>
+    scope.stack.length > 0 ? scope.stack[scope.stack.length - 1].node : scope.container
+
+  const visitBlocks = (siblings: readonly MindMapSourceBlock[], scope: Scope): void => {
+    // Numbered items count within their own uninterrupted run, exactly as the
+    // editor renders them: any other block between two of them starts a new list.
+    let ordinal = 0
+
+    for (const block of siblings) {
+      const kind = NODE_KINDS.get(block.type)
+      const isNumbered = kind === 'numbered'
+      if (isNumbered) ordinal = ordinal === 0 ? (listStart(block.props) ?? 1) : ordinal + 1
+      else ordinal = 0
+
+      if (kind === undefined) {
+        const contentKind = CONTENT_KINDS.get(block.type)
+        if (contentKind !== undefined) tally(parentIn(scope), contentKind)
+        // Paragraphs, dividers and anything unregistered contribute no node and
+        // never re-parent what is inside them.
+        visitBlocks(block.children ?? [], scope)
+        continue
+      }
+
+      // A `taskBlock` has no inline content; its text is a prop.
+      const read =
+        kind === 'task'
+          ? { text: stringProp(block.props, 'title') ?? '', tags: [] }
+          : readInline(block.content)
+      const text = normalizeLabel(read.text)
+
+      // Nothing to show: no box, no level-stack entry, and its children fold up
+      // to whatever this block's own parent was.
+      if (text === '' && read.tags.length === 0) {
+        visitBlocks(block.children ?? [], scope)
+        continue
+      }
+
+      const level = kind === 'heading' ? headingLevel(block.props) : null
+      if (level !== null) {
+        while (scope.stack.length > 0 && scope.stack[scope.stack.length - 1].level >= level) {
+          scope.stack.pop()
+        }
+      }
+      const parent = parentIn(scope)
+
+      const node: MindMapNode = {
+        id: mintId(block.id),
+        blockId: block.id,
+        label: isNumbered ? `${ordinal}.${text === '' ? '' : ` ${text}`}` : text,
+        kind,
+        level,
+        depth: parent.depth + 1,
+        isDone: (kind === 'check' || kind === 'task') && isChecked(block.props),
+        tags: read.tags,
+        contents: [],
+        detail: '',
+        children: []
+      }
+      parent.children.push(node)
+      if (level !== null) scope.stack.push({ level, node })
+
+      visitBlocks(block.children ?? [], { container: node, stack: [] })
+    }
+  }
+
+  visitBlocks(blocks, { container: root, stack: [] })
+  finish(root, tallies, options.formatContentCount)
   return root
+}
+
+/**
+ * Writes every node's `contents` and `detail` once the tallies are complete.
+ *
+ * `detail` is composed here rather than in either projection so the picture and
+ * the accessible tree cannot drift into saying different things about the same
+ * node.
+ */
+function finish(
+  node: MindMapNode,
+  tallies: Map<MindMapNode, Map<MindMapContentKind, number>>,
+  format: MindMapOptions['formatContentCount']
+): void {
+  const counts = tallies.get(node)
+  if (counts) {
+    const contents: MindMapContentCount[] = []
+    for (const kind of CONTENT_ORDER) {
+      const count = counts.get(kind)
+      if (count !== undefined) contents.push({ kind, count })
+    }
+    node.contents = contents
+  }
+
+  const tagged = node.tags.map((tag) => `#${tag}`).join(' ')
+  const counted = format
+    ? node.contents.map(({ kind, count }) => format(kind, count)).join(' · ')
+    : ''
+  node.detail = [tagged, counted].filter((part) => part !== '').join(' · ')
+
+  for (const child of node.children) finish(child, tallies, format)
 }

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.tsx
@@ -19,7 +19,12 @@
 
 import { useCallback, useMemo, useRef, useState } from 'react'
 import type { MindMapNodeActivation } from './mind-map-navigation'
-import type { MindMapPositionedNode } from './mind-map-types'
+import type { MindMapNodeKind, MindMapPositionedNode } from './mind-map-types'
+
+/** Kinds that carry a tick, and so have a checked state worth announcing. */
+function isTickable(kind: MindMapNodeKind): boolean {
+  return kind === 'check' || kind === 'task'
+}
 
 interface MindMapTreeProps {
   nodes: readonly MindMapPositionedNode[]
@@ -78,8 +83,14 @@ function BranchItems({
           aria-posinset={index + 1}
           aria-setsize={branches.length}
           aria-expanded={branch.children.length > 0 ? true : undefined}
+          // A tickable item announces its tick. This is what "dimmed and struck
+          // through" means to a reader who cannot see the drawing, so it is a
+          // real ARIA state rather than the `data-` attribute next to it.
+          aria-checked={isTickable(branch.node.kind) ? branch.node.isDone : undefined}
           data-mind-map-node={branch.node.id}
           data-mind-map-block={branch.node.blockId ?? undefined}
+          data-mind-map-kind={branch.node.kind}
+          data-mind-map-done={branch.node.isDone ? 'true' : undefined}
           // Roving: exactly one item is reachable with Tab, the arrows do the
           // rest. Items nest, so every handler stops here — otherwise a click
           // on a child would also activate every ancestor it sits inside.
@@ -107,6 +118,9 @@ function BranchItems({
           }}
         >
           <span>{branch.node.label}</span>
+          {/* The same composed badge line the picture draws — one string, two
+              projections, so they cannot say different things. */}
+          {branch.node.detail !== '' && <span> {branch.node.detail}</span>}
           {branch.children.length > 0 && (
             <ul role="group">
               <BranchItems

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
@@ -29,10 +29,47 @@ export interface MindMapSourceBlock {
 }
 
 /**
- * What a node stands for. Only the note title and its headings are drawn today;
- * lists, tasks and wiki links join this union in later work.
+ * What a node stands for.
+ *
+ * The governing rule is that containers branch and content does not: every kind
+ * here is something that really holds structure, so flattening it would destroy
+ * something the user wrote. Content — tables, code, images, quotes, embeds,
+ * bookmarks, files — is counted on its parent instead (see
+ * `MindMapContentKind`) rather than drawn, and is never silently dropped.
+ *
+ * Wiki links become their own kind in later work.
  */
-export type MindMapNodeKind = 'root' | 'heading'
+export type MindMapNodeKind =
+  | 'root'
+  | 'heading'
+  /** `bulletListItem`. */
+  | 'bullet'
+  /** `numberedListItem`; its number is kept at the front of the label. */
+  | 'numbered'
+  /** `checkListItem`; `isDone` follows its checkbox. */
+  | 'check'
+  /** Memry's `taskBlock`; `isDone` follows its checkbox. */
+  | 'task'
+  /** `toggleListItem` — branches into its children rather than hiding them. */
+  | 'toggle'
+  /** Memry's `callout` — branches into its children. */
+  | 'callout'
+
+/**
+ * Content that is not structure. It never becomes a node; it is counted on the
+ * nearest node above it, which then carries a badge naming what is there.
+ *
+ * `embed` covers `youtubeEmbed`, `video` and `audio`: all three are a piece of
+ * media the map cannot draw and would otherwise lose.
+ */
+export type MindMapContentKind =
+  'table' | 'code' | 'image' | 'quote' | 'embed' | 'bookmark' | 'file'
+
+/** How much of one content kind sits under a node. Never zero. */
+export interface MindMapContentCount {
+  kind: MindMapContentKind
+  count: number
+}
 
 /** A node in the logical tree, before any coordinates exist. */
 export interface MindMapNode {
@@ -43,10 +80,23 @@ export interface MindMapNode {
   /** User content. Never translated. */
   label: string
   kind: MindMapNodeKind
-  /** Heading level as written (1–6); `null` for the root. */
+  /** Heading level as written (1–6); `null` for everything else. */
   level: number | null
   /** Distance from the root. The root is 0. */
   depth: number
+  /** A ticked checklist item or task. Always false for other kinds. */
+  isDone: boolean
+  /** Inline hash tags found in this node's own text. User content, `#` stripped. */
+  tags: string[]
+  /** Content sitting under this node that is not drawn, in a stable order. */
+  contents: MindMapContentCount[]
+  /**
+   * The second line of the node: its tags and its content counts, already
+   * composed. Tags are user content; the counts come from
+   * `MindMapOptions.formatContentCount`, so this is the one place the two
+   * projections read their badge text from and they cannot disagree.
+   */
+  detail: string
   children: MindMapNode[]
 }
 
@@ -58,6 +108,10 @@ export interface MindMapPositionedNode {
   kind: MindMapNodeKind
   level: number | null
   depth: number
+  isDone: boolean
+  tags: string[]
+  contents: MindMapContentCount[]
+  detail: string
   parentId: string | null
   x: number
   y: number
@@ -100,8 +154,12 @@ export interface MindMapBoxElement {
   link?: string
 }
 
-/** The connector from a parent box to one of its children. */
-export interface MindMapEdgeElement {
+/**
+ * A straight rule: the connector from a parent box to one of its children, or
+ * the strike-through over a completed item's label. The drawing surface is a
+ * bitmap with no text decorations, so "struck through" has to be a real line.
+ */
+export interface MindMapLineElement {
   type: 'line'
   id: string
   x: number
@@ -112,7 +170,7 @@ export interface MindMapEdgeElement {
   roughness: number
 }
 
-export type MindMapElement = MindMapBoxElement | MindMapEdgeElement
+export type MindMapElement = MindMapBoxElement | MindMapLineElement
 
 /** Bounding box of every positioned node, so the host can fit the view. */
 export interface MindMapBounds {
@@ -135,6 +193,15 @@ export interface MindMapOptions {
    * only the tree projection is clickable.
    */
   noteId?: string
+  /**
+   * Turns "three tables" into words. Supplied by the caller because a counter
+   * badge is app chrome and has to be translated and pluralised, while this
+   * pipeline stays pure — it has no translator and must not grow one.
+   *
+   * Omitting it keeps the counts in `contents` and leaves them out of `detail`:
+   * the data never disappears, only its wording.
+   */
+  formatContentCount?: (kind: MindMapContentKind, count: number) => string
 }
 
 /**

--- a/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map.ts
@@ -7,12 +7,12 @@
  * type and look at the map at the same time.
  */
 
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { useDirection } from '@memry/i18n/renderer'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useDirection, useT } from '@memry/i18n/renderer'
 import { useFeatureFlags } from '@/hooks/use-feature-flags'
 import { useTabViewState } from '@/hooks/use-tab-view-state'
 import { buildMindMap } from './build-mind-map'
-import type { MindMap, MindMapSourceBlock } from './mind-map-types'
+import type { MindMap, MindMapContentKind, MindMapSourceBlock } from './mind-map-types'
 
 /**
  * Tab view state key. Tab-scoped on purpose: the map is a property of a
@@ -85,6 +85,28 @@ export function useMindMap({
   const { isEnabled } = useFeatureFlags()
   const isAvailable = isEnabled('spatialCanvas')
   const direction = useDirection()
+  const { t } = useT('notes')
+
+  /**
+   * Counter badges are app chrome, so they are translated and pluralised here
+   * and handed to the pure pipeline, which has no translator of its own.
+   *
+   * Read through a ref, and the callback below never changes identity. That is
+   * not tidiness: this feeds the rebuild effect, so a formatter that churned
+   * per render would set state on every commit and the note page would never
+   * settle. The cost is that a language switch does not re-word the badges of
+   * an already-open map until it is toggled — the map is built on open anyway.
+   */
+  const translate = useRef(t)
+  useEffect(() => {
+    translate.current = t
+  }, [t])
+
+  const formatContentCount = useCallback(
+    (kind: MindMapContentKind, count: number) =>
+      translate.current(`mindMap.badge.${kind}`, { count }),
+    []
+  )
 
   const [storedOpen, setStoredOpen] = useTabViewState<boolean>({
     key: MIND_MAP_VIEW_STATE_KEY,
@@ -107,8 +129,14 @@ export function useMindMap({
   )
 
   const build = useCallback(
-    () => buildMindMap(readBlocks(editorRef.current), { rootLabel: noteTitle, direction, noteId }),
-    [direction, noteId, noteTitle]
+    () =>
+      buildMindMap(readBlocks(editorRef.current), {
+        rootLabel: noteTitle,
+        direction,
+        noteId,
+        formatContentCount
+      }),
+    [direction, noteId, noteTitle, formatContentCount]
   )
 
   // Layout, not passive: the note body is hidden in the same commit that flips

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -1613,6 +1613,36 @@ describe('NotePage', () => {
       expect(screen.getByTestId('mind-map-canvas')).toBeInTheDocument()
     })
 
+    it('announces a ticked item and the content its heading only counts', async () => {
+      mocks.editorBlocks = [
+        {
+          id: 'h-1',
+          type: 'heading',
+          props: { level: 1 },
+          content: [{ type: 'text', text: 'Ship' }]
+        },
+        { id: 'tbl-1', type: 'table', content: { rows: [] } },
+        {
+          id: 'task-1',
+          type: 'taskBlock',
+          props: { taskId: 't1', title: 'Cut the build', checked: true }
+        }
+      ]
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+
+      const tree = await screen.findByRole('tree')
+      const [, section, task] = within(tree).getAllByRole('treeitem')
+      // The table is not a node; it is a translated, pluralised badge on the
+      // heading above it — through the translation layer, not hard-coded here.
+      expect(section).toHaveTextContent('mindMap.badge.table:{"count":1}')
+      expect(section).not.toHaveAttribute('aria-checked')
+      // "Struck through" for a reader who cannot see the drawing.
+      expect(task).toHaveAttribute('aria-checked', 'true')
+      expect(task).toHaveAttribute('data-mind-map-kind', 'task')
+      expect(task).toHaveAttribute('data-mind-map-block', 'task-1')
+    })
+
     it('labels the map region with the note and its node count', async () => {
       renderWithProviders(<NotePage noteId="note-1" />)
       await openMap()

--- a/apps/docs/src/user-guide/notes/mind-map.md
+++ b/apps/docs/src/user-guide/notes/mind-map.md
@@ -1,7 +1,8 @@
 # Mind Map
 
 See the shape of a note instead of scrolling through it. The mind map draws the
-note's title as the root and branches through its headings.
+note's title as the root and branches through its headings, lists, tasks and
+containers.
 
 <!-- screenshot: a note's headings drawn as a mind map -->
 
@@ -25,18 +26,48 @@ edited, and the note is untouched by opening it.
   heading in between; the H3 simply nests one step deeper.
 - A note whose first heading is a deep level attaches that heading straight to
   the root. Relative depth is what places a heading, not the number you wrote.
-- Paragraphs and other blocks are not drawn yet. Content before the first
-  heading belongs to the root.
+- **Bullet, numbered and checklist items** branch off the heading they sit
+  under. Numbered items keep their numbers, and a list that restarts in the
+  editor restarts in the map.
+- **Nested list items** branch off their parent item, so the indentation you
+  already wrote is what you see.
+- **Tasks** are nodes of their own, so commitments are part of the note's shape
+  instead of being buried in it.
+- **Toggles and callouts** open into their children. Content you collapsed in
+  the editor is still discoverable in the map, and a callout holding a checklist
+  is not reduced to one node.
+- Content before the first heading belongs to the root.
 
 A note with no headings opens on the root alone, with a hint that adding a
 heading will branch it.
+
+### Ticked Items
+
+A checklist item or a task you have already completed is drawn dimmed, with a
+rule through its label. The map shows what is written, not what should have
+been.
+
+### Tags and Counter Badges
+
+Some things are content rather than structure, and drawing a node for each of
+them would bury the shape of the note under it. They are counted instead, never
+dropped:
+
+- **Tags** written inside a heading or a list item become a small badge on that
+  node rather than nodes of their own, so a heavily tagged note does not drown
+  the map.
+- **Tables, code blocks, images, quotes, embeds, bookmarks and file blocks**
+  are not drawn. The node above them — usually the heading they sit under —
+  carries a badge saying what is there, such as `2 tables · 1 code block`.
+- **Paragraphs** are never nodes. **Date mentions, link mentions and inline
+  pictures** stay as plain text inside the label of the node that holds them.
 
 ## Clicking a Node
 
 The map is navigation, not just a picture.
 
-- Click a **heading node** and the map closes and the note reopens at that
-  heading.
+- Click a **heading, list, task, toggle or callout node** and the map closes and
+  the note reopens at that block.
 - Click the **root** — the note's title — to come back to the top of the note.
 - The **outline panel** stays available while the map shows, and clicking a
   heading there does exactly the same thing. One control, one behaviour.
@@ -66,10 +97,11 @@ than against it.
 ## Accessibility
 
 The drawing sits beside a real tree in the page, so every node is announced by a
-screen reader with its nesting level, and every node can be reached and opened
-with the keyboard. The map takes a single tab stop: arrow keys move between
-nodes from there. The map region itself is labelled with the note's name and how
-many nodes it holds.
+screen reader with its nesting level, its badges, and — for a checklist item or
+a task — whether it is ticked, and every node can be reached and opened with the
+keyboard. The map takes a single tab stop: arrow keys move between nodes from
+there. The map region itself is labelled with the note's name and how many nodes
+it holds.
 
 ## Turning It Off
 

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -967,6 +967,15 @@
   "mindMap": {
     "regionLabel": "Mind map of {title}, {count, plural, one {# node} other {# nodes}}",
     "treeLabel": "Mind map outline of {title}",
-    "emptyHint": "Add a heading to this note and the map will branch."
+    "emptyHint": "Add a heading to this note and the map will branch.",
+    "badge": {
+      "table": "{count, plural, one {# table} other {# tables}}",
+      "code": "{count, plural, one {# code block} other {# code blocks}}",
+      "image": "{count, plural, one {# image} other {# images}}",
+      "quote": "{count, plural, one {# quote} other {# quotes}}",
+      "embed": "{count, plural, one {# embed} other {# embeds}}",
+      "bookmark": "{count, plural, one {# bookmark} other {# bookmarks}}",
+      "file": "{count, plural, one {# file} other {# files}}"
+    }
   }
 }


### PR DESCRIPTION
Closes nothing on its own — implements #1670 (part of #1667). Blockers #1668 and #1669 are merged; this branch is cut from `d297035f3`.

## What this does

The map becomes navigation. Clicking a node closes the map and lands the user at that place in the note.

Both steps are load-bearing and neither is optional. The note body is hidden (never unmounted) while the map shows, so nothing inside it can be scrolled into the user's view; and `ContentArea` gates its own render behind a placeholder until the CRDT binding settles, so the target block may not be in the document yet. So: close first, then try the immediate lookup, and fall through to the existing `scrollToHeadingWhenReady` wait when the block is not there.

## The node-activation dispatch

One dispatch stands behind every surface, so #1671 (list and task nodes) and #1672 (wiki-link nodes) extend it rather than growing paths of their own:

```ts
// components/note/mind-map/mind-map-navigation.ts
export interface MindMapNodeActions {
  navigateToBlock: (blockId: string | null) => void  // null = top of the note
}
export type MindMapNodeActivation = (node: MindMapPositionedNode) => void
export function activateMindMapNode(node, actions): void   // switch on node.kind
export function nodeFromMindMapLink(href, nodes, noteId): MindMapPositionedNode | null
```

`activateMindMapNode` switches on `node.kind` with a `never` default, so adding a kind to `MindMapNodeKind` fails to compile until someone decides what activating it does. A new kind adds a member to `MindMapNodeActions` (`openNote`, `openTask`) and a case.

**How the drawing gets a click.** Excalidraw draws to a bitmap and gives no DOM. Boxes are therefore minted with a `memry://` deep link, and in view mode Excalidraw's link hit test is the whole bounding box — so a click anywhere on a node arrives as `onLinkOpen(element, event)`. The link is read back with `parseMemryHref(href).anchor` (the anchor grammar #1668 landed) and resolved to the node it names. Boxes carry a **block** anchor: exact, and alive exactly as long as the document that minted it, which is right for a click handed straight back into the same session. A saved canvas outlives that document and will need heading text instead — that is #1676's decision, and element minting stays private behind `buildMindMap`, so it can make it.

`buildMindMap` gains one optional option, `noteId`. Without it the map draws exactly as before and only the tree projection is clickable. Layout is byte-identical with and without links (asserted).

## Acceptance criteria

- [x] **Clicking a heading node closes the map and lands at that heading, including when the target block has not been rendered yet.** `note.test.tsx` "lands on the heading a map node names, and gives the note back"; the not-yet-rendered case in `use-mind-map-navigation.test.tsx` "waits for a block the content area has not rendered yet".
- [x] **Activating a node from the keyboard does the same thing as clicking it.** `mind-map-tree.test.tsx` "activates from the keyboard exactly as a click does" asserts Enter, Space and click produce the identical call; `note.test.tsx` "activates a node from the keyboard exactly as a click does" runs it through the whole page.
- [x] **Clicking the root node returns to the top of the note.** `note.test.tsx` "returns to the top of the note from the root node"; `use-mind-map-navigation.test.tsx` "sends the root node to the top of the note".
- [x] **Clicking a heading in the outline panel while the map is showing takes the identical path as clicking the corresponding map node.** `note.test.tsx` "takes the identical path from the outline panel while the map is showing" drives both and asserts the recorded scroll calls are equal. The outline panel is handed `mindMapNavigation.navigateToBlock` — the very function `activateNode` ends in.
- [x] **Navigation works both from the tree-role projection and from the drawn map.** Tree: the tests above. Drawing: `note.test.tsx` "lands on the same heading from the drawing" clicks through the link the box was actually minted with.
- [x] **Tests cover each path and assert that the outline and the map call the same handler.** Above, plus `mind-map-navigation.test.ts` "lands a drawn box and its tree twin on the very same call" and "resolves the link a box was actually minted with".

## Invariants held

- The editor is hidden and inert, never unmounted; `invisible` (not `hidden`) is untouched — #1669's assertions still pass unchanged.
- One public entry point: `buildMindMap`. Projection, layout and element minting stay private.
- Layout stays deterministic — no clock, no randomness; the new option only attaches a string to a box.
- No IPC contract, no migration, no sync handler, no settings schema.
- Still gated on the existing `spatialCanvas` key.
- The note header overflow menu is untouched in both modes.
- No new user-visible strings: node labels are user content. `i18n:check` is green with no additions.
- Logical Tailwind classes only (the tree adds no physical ones).

## Keyboard and accessibility

The tree keeps a **single tab stop**: arrow keys move between items, Home/End jump to the ends, Enter/Space activate. All-items-tabbable would have turned a note with fifty headings into fifty invisible tab stops, so this follows the ARIA tree pattern instead.

## Gates

```
$ pnpm lint
✖ 109 problems (0 errors, 109 warnings)      # exit 0 — all pre-existing
$ pnpm typecheck
Tasks:    17 successful, 17 total            # exit 0
$ pnpm test                                  # exit 0
@memry/desktop   Test Files  1374 passed | 3 skipped (1377)
@memry/desktop        Tests  17854 passed | 1 expected fail | 13 skipped (17868)
@memry/sync-server  Test Files  62 passed (62)
@memry/sync-server       Tests  966 passed (966)
Tasks:    9 successful, 9 total

# First run of the same suite hit a fresh-worktree environment flake,
# recorded for honesty: two main SUITES failed to load, running no test —
#   FAIL main src/main/sync/engine/crdt-sync-coordinator.test.ts
#   FAIL main src/main/sync/engine/full-sync-runner.test.ts
#   Error: Electron failed to install correctly. …
#     ❯ getElectronPath node_modules/electron/index.js:43:13
# Nothing in src/main is touched here; both pass on their own and the
# clean re-run above is green.
$ pnpm --filter @memry/desktop i18n:check
ok: i18n check passed                        # exit 0
$ pnpm docs:impact --base d297035f3 --strict
docs impact: covered against d297035f3
docs impact: docs changed on this branch     # exit 0
```
