### PR TITLE
feat(notes): make a mind map node take you back into the note (#1670)

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.test.ts
@@ -337,3 +337,53 @@ describe('buildMindMap — elements', () => {
     expect(boxes.map((box) => box.label.text)).toEqual(map.nodes.map((node) => node.label))
   })
 })
+
+describe('buildMindMap — deep links', () => {
+  const blocks = [heading('a', 1, 'Alpha'), heading('a1', 2, 'Alpha one')]
+
+  function boxes(map: ReturnType<typeof buildMindMap>): Map<string, { link?: string }> {
+    return new Map(
+      map.elements
+        .filter((element) => element.type === 'rectangle')
+        .map((box) => [box.id, box] as const)
+    )
+  }
+
+  it('draws no links at all without a note to point at', () => {
+    const map = buildMindMap(blocks, { rootLabel: 'Note' })
+    for (const box of boxes(map).values()) expect(box.link).toBeUndefined()
+  })
+
+  it('anchors a heading box at its own block', () => {
+    const map = buildMindMap(blocks, { rootLabel: 'Note', noteId: 'note-1' })
+    const alpha = map.nodes.find((node) => node.label === 'Alpha')!
+
+    // A block anchor: exact, and meaningful only in the session that minted it.
+    expect(boxes(map).get(alpha.id)?.link).toBe('memry://note/note-1#^a')
+  })
+
+  it('anchors the root at nothing, because the title is not a block', () => {
+    const map = buildMindMap(blocks, { rootLabel: 'Note', noteId: 'note-1' })
+    const root = map.nodes.find((node) => node.kind === 'root')!
+
+    // No fragment — which reads as "this note, from the top".
+    expect(boxes(map).get(root.id)?.link).toBe('memry://note/note-1')
+  })
+
+  it('links every box and no connector', () => {
+    const map = buildMindMap(blocks, { rootLabel: 'Note', noteId: 'note-1' })
+    for (const element of map.elements) {
+      if (element.type === 'rectangle') expect(element.link).toMatch(/^memry:\/\/note\/note-1/)
+      else expect(element).not.toHaveProperty('link')
+    }
+  })
+
+  it('lays out identically whether or not the boxes carry links', () => {
+    const withoutLinks = buildMindMap(blocks, { rootLabel: 'Note' })
+    const withLinks = buildMindMap(blocks, { rootLabel: 'Note', noteId: 'note-1' })
+
+    // A link is an attribute of a box, never an input to where it sits.
+    expect(withLinks.nodes).toEqual(withoutLinks.nodes)
+    expect(withLinks.bounds).toEqual(withoutLinks.bounds)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.ts
@@ -27,7 +27,7 @@ export function buildMindMap(
   return {
     tree,
     nodes,
-    elements: mintElements(nodes, direction),
+    elements: mintElements(nodes, direction, options.noteId),
     direction,
     nodeCount: nodes.length,
     isEmpty: tree.children.length === 0,

--- a/apps/desktop/src/renderer/src/components/note/mind-map/index.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/index.ts
@@ -6,9 +6,13 @@
  */
 
 export { buildMindMap } from './build-mind-map'
+export { activateMindMapNode, nodeFromMindMapLink } from './mind-map-navigation'
+export type { MindMapNodeActions, MindMapNodeActivation } from './mind-map-navigation'
 export { MindMapView } from './mind-map-view'
 export { MIND_MAP_VIEW_STATE_KEY, useMindMap } from './use-mind-map'
 export type { UseMindMapResult } from './use-mind-map'
+export { useMindMapNavigation } from './use-mind-map-navigation'
+export type { UseMindMapNavigationResult } from './use-mind-map-navigation'
 export type {
   MindMap,
   MindMapBounds,

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.tsx
@@ -30,9 +30,11 @@ const toSkeleton = (elements: readonly MindMapElement[]): ExcalidrawElementSkele
 
 interface MindMapCanvasProps {
   elements: readonly MindMapElement[]
+  /** The deep link of the box that was clicked. See `handleMindMapLinkOpen`. */
+  onOpenLink: (href: string) => void
 }
 
-export function MindMapCanvas({ elements }: MindMapCanvasProps): React.JSX.Element {
+export function MindMapCanvas({ elements, onOpenLink }: MindMapCanvasProps): React.JSX.Element {
   const { resolvedTheme } = useTheme()
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null)
 
@@ -54,6 +56,15 @@ export function MindMapCanvas({ elements }: MindMapCanvasProps): React.JSX.Eleme
         elements: convertToExcalidrawElements(toSkeleton(elements)),
         appState: { viewBackgroundColor: 'transparent' },
         scrollToContent: true
+      }}
+      // In view mode the whole box is the link's hit area, so this fires for a
+      // click anywhere on a node — which is what makes the drawing navigable at
+      // all. The default must be prevented: Excalidraw's fallback ends in
+      // `window.open`, which under Electron either does nothing or reloads the
+      // entire app (see `canvas-editor.tsx`, same trap).
+      onLinkOpen={(element, event) => {
+        event.preventDefault()
+        if (element.link) onOpenLink(element.link)
       }}
       viewModeEnabled
       zenModeEnabled

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
@@ -7,6 +7,7 @@
  * renderers would make "save as canvas" a WYSIWYG lie.
  */
 
+import { buildMemryHref } from '@/lib/memry-links'
 import { MIND_MAP_FONT_SIZE } from './mind-map-layout'
 import type { MindMapDirection, MindMapElement, MindMapPositionedNode } from './mind-map-types'
 
@@ -23,9 +24,26 @@ const EDGE_STROKE = '#adb5bd'
 /** Adaptive corner radius. */
 const ROUNDNESS = { type: 3 }
 
+/**
+ * The deep link a box carries, or `undefined` when there is no note to point
+ * at. The root has no block of its own — it is the note's title — so its link
+ * carries no anchor, which reads as "this note, from the top".
+ */
+function nodeLink(node: MindMapPositionedNode, noteId: string | undefined): string | undefined {
+  if (!noteId) return undefined
+  return (
+    buildMemryHref({
+      kind: 'note',
+      id: noteId,
+      anchor: node.blockId ? { type: 'block', id: node.blockId } : null
+    }) ?? undefined
+  )
+}
+
 export function mintElements(
   nodes: readonly MindMapPositionedNode[],
-  direction: MindMapDirection
+  direction: MindMapDirection,
+  noteId?: string
 ): MindMapElement[] {
   const byId = new Map(nodes.map((node) => [node.id, node]))
   const elements: MindMapElement[] = []
@@ -63,6 +81,7 @@ export function mintElements(
     elements.push({
       type: 'rectangle',
       id: node.id,
+      link: nodeLink(node, noteId),
       x: node.x,
       y: node.y,
       width: node.width,

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Where a node activation goes, and how a drawn box's deep link finds its node.
+ * Both are pure, so every case here runs without a DOM.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { buildMindMap } from './build-mind-map'
+import { activateMindMapNode, nodeFromMindMapLink } from './mind-map-navigation'
+import type { MindMapPositionedNode, MindMapSourceBlock } from './mind-map-types'
+
+function heading(id: string, level: number, text: string): MindMapSourceBlock {
+  return { id, type: 'heading', props: { level }, content: [{ type: 'text', text }] }
+}
+
+const blocks = [heading('b-alpha', 1, 'Alpha'), heading('b-beta', 2, 'Beta')]
+const map = buildMindMap(blocks, { rootLabel: 'Test Note', noteId: 'note-1' })
+
+function node(label: string): MindMapPositionedNode {
+  const found = map.nodes.find((candidate) => candidate.label === label)
+  if (!found) throw new Error(`no node labelled ${label}`)
+  return found
+}
+
+describe('activateMindMapNode', () => {
+  it('sends a heading node to its own block', () => {
+    const navigateToBlock = vi.fn()
+    activateMindMapNode(node('Alpha'), { navigateToBlock })
+    expect(navigateToBlock).toHaveBeenCalledWith('b-alpha')
+  })
+
+  it('sends the root node to the top of the note', () => {
+    const navigateToBlock = vi.fn()
+    activateMindMapNode(node('Test Note'), { navigateToBlock })
+    // Null, not a block id: the root stands for the title, which is not a block.
+    expect(navigateToBlock).toHaveBeenCalledWith(null)
+  })
+
+  it('lands a drawn box and its tree twin on the very same call', () => {
+    const beta = node('Beta')
+    const box = map.elements
+      .filter((element) => element.type === 'rectangle')
+      .find((element) => element.id === beta.id)!
+
+    const fromTree = vi.fn()
+    const fromDrawing = vi.fn()
+    activateMindMapNode(beta, { navigateToBlock: fromTree })
+    activateMindMapNode(nodeFromMindMapLink(box.link!, map.nodes, 'note-1')!, {
+      navigateToBlock: fromDrawing
+    })
+
+    // Two projections of one layout, one activation: the picture cannot grow a
+    // navigation behaviour the tree does not have.
+    expect(fromDrawing.mock.calls).toEqual(fromTree.mock.calls)
+  })
+})
+
+describe('nodeFromMindMapLink', () => {
+  it('resolves a block anchor to the node that owns the block', () => {
+    expect(nodeFromMindMapLink('memry://note/note-1#^b-beta', map.nodes, 'note-1')).toBe(
+      node('Beta')
+    )
+  })
+
+  it('resolves an unanchored link to the root', () => {
+    expect(nodeFromMindMapLink('memry://note/note-1', map.nodes, 'note-1')).toBe(node('Test Note'))
+  })
+
+  it('resolves the link a box was actually minted with', () => {
+    // The round trip that matters: what the pipeline drew is what a click on it
+    // resolves back to.
+    for (const element of map.elements) {
+      if (element.type !== 'rectangle' || !element.link) continue
+      expect(nodeFromMindMapLink(element.link, map.nodes, 'note-1')?.id).toBe(element.id)
+    }
+  })
+
+  it('refuses a link into another note', () => {
+    // Answering with this map's root would send the user somewhere they never
+    // clicked. Opening the other note is a later ticket's job, not this one's.
+    expect(nodeFromMindMapLink('memry://note/other#^b-beta', map.nodes, 'note-1')).toBeNull()
+  })
+
+  it('refuses a block anchor no node in this map owns', () => {
+    expect(nodeFromMindMapLink('memry://note/note-1#^gone', map.nodes, 'note-1')).toBeNull()
+  })
+
+  it('refuses an anchor form that is not a block, and anything not a note', () => {
+    // A heading-text anchor is what a SAVED canvas carries; in-session clicks
+    // address the block directly, so one arriving here is not this map's node.
+    expect(nodeFromMindMapLink('memry://note/note-1#Alpha', map.nodes, 'note-1')).toBeNull()
+    expect(nodeFromMindMapLink('memry://task/t1', map.nodes, 'note-1')).toBeNull()
+    expect(nodeFromMindMapLink('https://example.com', map.nodes, 'note-1')).toBeNull()
+    expect(nodeFromMindMapLink('', map.nodes, 'note-1')).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.ts
@@ -1,0 +1,77 @@
+/**
+ * What happens when a map node is activated.
+ *
+ * One dispatch for every surface: the tree projection calls it with the node it
+ * was clicked on, the drawing calls it with the node its deep link resolves to,
+ * and the outline panel calls the same underlying action directly. One control
+ * never gets two behaviours because there is only ever one place that decides.
+ *
+ * Pure: no DOM, no React. The host supplies the actions; this file only routes.
+ * Adding a node kind makes the switch non-exhaustive, so a new kind cannot be
+ * drawn without someone deciding what activating it does.
+ */
+
+import { parseMemryHref } from '@/lib/memry-links'
+import type { MindMapPositionedNode } from './mind-map-types'
+
+/**
+ * Everything a node can ask the note page to do. It has one member today
+ * because the map draws two kinds of node, both of which are places in this
+ * note; opening another note and opening a task join it with their own kinds.
+ */
+export interface MindMapNodeActions {
+  /**
+   * Close the map and land at this block in the note. `null` is the top of the
+   * note — the root node stands for the title, which is not a block.
+   */
+  navigateToBlock: (blockId: string | null) => void
+}
+
+/** Called with the node the user activated, however they reached it. */
+export type MindMapNodeActivation = (node: MindMapPositionedNode) => void
+
+export function activateMindMapNode(
+  node: MindMapPositionedNode,
+  actions: MindMapNodeActions
+): void {
+  switch (node.kind) {
+    case 'root':
+    case 'heading':
+      // The root's `blockId` is null, which is already "the top of the note" —
+      // one branch, not two, because a node's block is what it navigates to.
+      actions.navigateToBlock(node.blockId)
+      return
+    default: {
+      // Compile-time only. A kind added to the map without a case here fails to
+      // assign, so a new node kind cannot ship silently doing nothing.
+      const unhandled: never = node.kind
+      void unhandled
+    }
+  }
+}
+
+/**
+ * The node a drawn box's deep link stands for.
+ *
+ * The drawing is a bitmap: a click reaches us as the link on the element it
+ * landed on, and nothing else. The link is read with the vault's own parser
+ * rather than by string surgery, so the one grammar keeps working — an anchor
+ * form this build cannot place resolves to no node instead of the wrong one.
+ *
+ * Null for a link that is not a place in THIS note. A link to another note is
+ * not this map's business, and answering it with this map's root would send the
+ * user somewhere they did not click.
+ */
+export function nodeFromMindMapLink(
+  href: string,
+  nodes: readonly MindMapPositionedNode[],
+  noteId: string
+): MindMapPositionedNode | null {
+  const parsed = parseMemryHref(href)
+  if (!parsed || parsed.kind !== 'note' || parsed.id !== noteId) return null
+
+  const anchor = parsed.anchor
+  if (!anchor) return nodes.find((node) => node.kind === 'root') ?? null
+  if (anchor.type !== 'block') return null
+  return nodes.find((node) => node.blockId === anchor.id) ?? null
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * The map's accessible twin, driven the way a person drives it.
+ *
+ * This layer exists so the map is reachable without sight and without a mouse;
+ * these assertions are what make that claim true rather than aspirational. They
+ * are also the only way any harness can reach a node, since the picture beside
+ * this tree is a bitmap.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { buildMindMap } from './build-mind-map'
+import { MindMapTree } from './mind-map-tree'
+import type { MindMapSourceBlock } from './mind-map-types'
+
+function heading(id: string, level: number, text: string): MindMapSourceBlock {
+  return { id, type: 'heading', props: { level }, content: [{ type: 'text', text }] }
+}
+
+const map = buildMindMap(
+  [heading('b-alpha', 1, 'Alpha'), heading('b-beta', 2, 'Beta'), heading('b-gamma', 1, 'Gamma')],
+  { rootLabel: 'Test Note', noteId: 'note-1' }
+)
+
+function renderTree(): { onActivateNode: ReturnType<typeof vi.fn>; items: HTMLElement[] } {
+  const onActivateNode = vi.fn()
+  render(<MindMapTree nodes={map.nodes} label="Map of Test Note" onActivateNode={onActivateNode} />)
+  const items = within(screen.getByRole('tree')).getAllByRole('treeitem')
+  return { onActivateNode, items }
+}
+
+/** The item standing for a node, by the node id it carries. */
+function itemFor(items: HTMLElement[], label: string): HTMLElement {
+  const node = map.nodes.find((candidate) => candidate.label === label)!
+  const item = items.find((candidate) => candidate.dataset.mindMapNode === node.id)
+  if (!item) throw new Error(`no tree item for ${label}`)
+  return item
+}
+
+describe('MindMapTree', () => {
+  it('activates the node that was clicked, and only that node', () => {
+    const { onActivateNode, items } = renderTree()
+
+    fireEvent.click(itemFor(items, 'Beta'))
+
+    // Items nest, so without stopping the event a click on a leaf would also
+    // activate every ancestor it happens to sit inside.
+    expect(onActivateNode).toHaveBeenCalledTimes(1)
+    expect(onActivateNode.mock.calls[0][0]).toMatchObject({ blockId: 'b-beta', kind: 'heading' })
+  })
+
+  it('activates the root, which stands for the note itself', () => {
+    const { onActivateNode, items } = renderTree()
+
+    fireEvent.click(itemFor(items, 'Test Note'))
+
+    expect(onActivateNode).toHaveBeenCalledTimes(1)
+    expect(onActivateNode.mock.calls[0][0]).toMatchObject({ blockId: null, kind: 'root' })
+  })
+
+  it('activates from the keyboard exactly as a click does', () => {
+    const { onActivateNode, items } = renderTree()
+    const beta = itemFor(items, 'Beta')
+
+    fireEvent.keyDown(beta, { key: 'Enter' })
+    fireEvent.keyDown(beta, { key: ' ' })
+    fireEvent.click(beta)
+
+    expect(onActivateNode).toHaveBeenCalledTimes(3)
+    const [enter, space, click] = onActivateNode.mock.calls
+    expect(enter).toEqual(click)
+    expect(space).toEqual(click)
+  })
+
+  it('keeps one tab stop and moves focus with the arrows', () => {
+    const { items } = renderTree()
+
+    // A note with fifty headings must not become fifty invisible tab stops.
+    expect(items.filter((item) => item.tabIndex === 0)).toHaveLength(1)
+    expect(itemFor(items, 'Test Note').tabIndex).toBe(0)
+
+    const root = itemFor(items, 'Test Note')
+    root.focus()
+    fireEvent.keyDown(root, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(itemFor(items, 'Alpha'))
+
+    fireEvent.keyDown(document.activeElement!, { key: 'End' })
+    expect(document.activeElement).toBe(itemFor(items, 'Gamma'))
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' })
+    expect(document.activeElement).toBe(itemFor(items, 'Beta'))
+
+    fireEvent.keyDown(document.activeElement!, { key: 'Home' })
+    expect(document.activeElement).toBe(root)
+  })
+
+  it('moves the tab stop to wherever focus landed', () => {
+    const { items } = renderTree()
+    const root = itemFor(items, 'Test Note')
+
+    root.focus()
+    fireEvent.keyDown(root, { key: 'ArrowDown' })
+
+    // Tabbing away and back returns the user to where they were, not to the top.
+    expect(itemFor(items, 'Alpha').tabIndex).toBe(0)
+    expect(root.tabIndex).toBe(-1)
+  })
+
+  it('does not activate anything on an arrow key', () => {
+    const { onActivateNode, items } = renderTree()
+    const root = itemFor(items, 'Test Note')
+
+    root.focus()
+    fireEvent.keyDown(root, { key: 'ArrowDown' })
+
+    expect(onActivateNode).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.tsx
@@ -10,14 +10,23 @@
  *
  * Visually hidden rather than absent: the picture is the visual presentation,
  * this is the same content for everyone else.
+ *
+ * It is also the map's keyboard surface. Focus moves with the arrow keys and
+ * only one item is ever in the tab order, which is the tree pattern and is also
+ * what keeps a note with fifty headings from becoming fifty invisible tab
+ * stops. Enter and Space activate, and land in the same place a click does.
  */
 
+import { useCallback, useMemo, useRef, useState } from 'react'
+import type { MindMapNodeActivation } from './mind-map-navigation'
 import type { MindMapPositionedNode } from './mind-map-types'
 
 interface MindMapTreeProps {
   nodes: readonly MindMapPositionedNode[]
   /** Translated; names the note the tree belongs to. */
   label: string
+  /** Called with the node the user clicked or pressed Enter/Space on. */
+  onActivateNode: MindMapNodeActivation
 }
 
 interface Branch {
@@ -46,10 +55,18 @@ function toBranches(nodes: readonly MindMapPositionedNode[]): Branch[] {
 
 function BranchItems({
   branches,
-  level
+  level,
+  activeId,
+  onActivate,
+  onFocusNode,
+  onNavigate
 }: {
   branches: Branch[]
   level: number
+  activeId: string | null
+  onActivate: MindMapNodeActivation
+  onFocusNode: (nodeId: string) => void
+  onNavigate: (key: string, nodeId: string) => void
 }): React.JSX.Element {
   return (
     <>
@@ -63,11 +80,43 @@ function BranchItems({
           aria-expanded={branch.children.length > 0 ? true : undefined}
           data-mind-map-node={branch.node.id}
           data-mind-map-block={branch.node.blockId ?? undefined}
+          // Roving: exactly one item is reachable with Tab, the arrows do the
+          // rest. Items nest, so every handler stops here — otherwise a click
+          // on a child would also activate every ancestor it sits inside.
+          tabIndex={branch.node.id === activeId ? 0 : -1}
+          onFocus={(event) => {
+            event.stopPropagation()
+            onFocusNode(branch.node.id)
+          }}
+          onClick={(event) => {
+            event.stopPropagation()
+            onActivate(branch.node)
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault()
+              event.stopPropagation()
+              onActivate(branch.node)
+              return
+            }
+            if (['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
+              event.preventDefault()
+              event.stopPropagation()
+              onNavigate(event.key, branch.node.id)
+            }
+          }}
         >
           <span>{branch.node.label}</span>
           {branch.children.length > 0 && (
             <ul role="group">
-              <BranchItems branches={branch.children} level={level + 1} />
+              <BranchItems
+                branches={branch.children}
+                level={level + 1}
+                activeId={activeId}
+                onActivate={onActivate}
+                onFocusNode={onFocusNode}
+                onNavigate={onNavigate}
+              />
             </ul>
           )}
         </li>
@@ -76,10 +125,55 @@ function BranchItems({
   )
 }
 
-export function MindMapTree({ nodes, label }: MindMapTreeProps): React.JSX.Element {
+export function MindMapTree({ nodes, label, onActivateNode }: MindMapTreeProps): React.JSX.Element {
+  const treeRef = useRef<HTMLUListElement>(null)
+  // Which item holds the single tab stop. It follows focus, so tabbing away and
+  // back returns to where the user was rather than to the top. Seeded with the
+  // first node, which the layout always emits as the root.
+  const [focusedId, setFocusedId] = useState<string | null>(null)
+  const activeId = focusedId ?? nodes[0]?.id ?? null
+
+  const branches = useMemo(() => toBranches(nodes), [nodes])
+
+  const onFocusNode = useCallback((nodeId: string) => {
+    setFocusedId(nodeId)
+  }, [])
+
+  // Flat document order is what the arrows walk: it is what the reader hears,
+  // and it is the order the nodes were laid out in.
+  const onNavigate = useCallback((key: string, nodeId: string) => {
+    const items = Array.from(
+      treeRef.current?.querySelectorAll<HTMLElement>('[role="treeitem"]') ?? []
+    )
+    if (items.length === 0) return
+    const index = items.findIndex((item) => item.dataset.mindMapNode === nodeId)
+    const next =
+      key === 'Home'
+        ? items[0]
+        : key === 'End'
+          ? items[items.length - 1]
+          : key === 'ArrowDown'
+            ? items[Math.min(index + 1, items.length - 1)]
+            : items[Math.max(index - 1, 0)]
+    next?.focus()
+  }, [])
+
   return (
-    <ul role="tree" aria-label={label} className="sr-only" data-testid="mind-map-tree">
-      <BranchItems branches={toBranches(nodes)} level={1} />
+    <ul
+      ref={treeRef}
+      role="tree"
+      aria-label={label}
+      className="sr-only"
+      data-testid="mind-map-tree"
+    >
+      <BranchItems
+        branches={branches}
+        level={1}
+        activeId={activeId}
+        onActivate={onActivateNode}
+        onFocusNode={onFocusNode}
+        onNavigate={onNavigate}
+      />
     </ul>
   )
 }

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
@@ -86,6 +86,18 @@ export interface MindMapBoxElement {
     verticalAlign: 'middle'
     strokeColor: string
   }
+  /**
+   * A `memry://` deep link back into the note, present only when the build was
+   * given a note id. It is what makes a drawn box clickable at all: the drawing
+   * surface is a bitmap with no DOM, and its link hit test — the whole bounding
+   * box, in view mode — is the only handle a click has on a node.
+   *
+   * A block anchor is right HERE and only here: these elements are drawn for
+   * the session that minted them, and a block id lives exactly as long as the
+   * document that minted it. A saved canvas outlives that, so the file's links
+   * will carry heading text instead.
+   */
+  link?: string
 }
 
 /** The connector from a parent box to one of its children. */
@@ -116,6 +128,13 @@ export interface MindMapOptions {
   /** Defaults to `'ltr'`. In `'rtl'` the tree mirrors so it grows with the
    * reading direction rather than against it. */
   direction?: MindMapDirection
+  /**
+   * The note the map is of. Given it, every box is minted with a `memry://`
+   * deep link back to its own block, which is how a click on the drawing finds
+   * out which node it landed on. Left out, the map draws exactly as before and
+   * only the tree projection is clickable.
+   */
+  noteId?: string
 }
 
 /**

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
@@ -8,8 +8,9 @@
  * for.
  */
 
-import { lazy, Suspense } from 'react'
+import { lazy, Suspense, useCallback } from 'react'
 import { useT } from '@memry/i18n/renderer'
+import { nodeFromMindMapLink, type MindMapNodeActivation } from './mind-map-navigation'
 import { MindMapTree } from './mind-map-tree'
 import type { MindMap } from './mind-map-types'
 
@@ -23,12 +24,33 @@ const LazyMindMapCanvas = lazy(async () => ({
 
 interface MindMapViewProps {
   map: MindMap
+  /** The note the map is of, so a drawn box's deep link resolves to a node. */
+  noteId: string
   /** The note title. User content; never translated. */
   noteTitle: string
+  /** One handler for both projections — the picture and the tree agree. */
+  onActivateNode: MindMapNodeActivation
 }
 
-export function MindMapView({ map, noteTitle }: MindMapViewProps): React.JSX.Element {
+export function MindMapView({
+  map,
+  noteId,
+  noteTitle,
+  onActivateNode
+}: MindMapViewProps): React.JSX.Element {
   const { t } = useT('notes')
+
+  // A click on the drawing arrives as the deep link of the box it landed on;
+  // that is the only handle a bitmap surface gives us. Resolving it back to a
+  // node here means both projections end in the same activation, rather than
+  // the picture growing a navigation path of its own.
+  const handleOpenLink = useCallback(
+    (href: string) => {
+      const node = nodeFromMindMapLink(href, map.nodes, noteId)
+      if (node) onActivateNode(node)
+    },
+    [map.nodes, noteId, onActivateNode]
+  )
 
   return (
     <div className="relative flex h-full w-full flex-col bg-background" data-testid="note-mind-map">
@@ -38,7 +60,7 @@ export function MindMapView({ map, noteTitle }: MindMapViewProps): React.JSX.Ele
         className="relative min-h-0 flex-1"
       >
         <Suspense fallback={<div className="h-full w-full" aria-hidden="true" />}>
-          <LazyMindMapCanvas elements={map.elements} />
+          <LazyMindMapCanvas elements={map.elements} onOpenLink={handleOpenLink} />
         </Suspense>
       </div>
 
@@ -51,7 +73,11 @@ export function MindMapView({ map, noteTitle }: MindMapViewProps): React.JSX.Ele
         </p>
       )}
 
-      <MindMapTree nodes={map.nodes} label={t('mindMap.treeLabel', { title: noteTitle })} />
+      <MindMapTree
+        nodes={map.nodes}
+        label={t('mindMap.treeLabel', { title: noteTitle })}
+        onActivateNode={onActivateNode}
+      />
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Landing back in the note: the map closes, and then the block is scrolled to —
+ * including when it is not in the document at the moment of the click.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { buildMindMap } from './build-mind-map'
+import { useMindMapNavigation } from './use-mind-map-navigation'
+import type { MindMapSourceBlock } from './mind-map-types'
+
+function heading(id: string, level: number, text: string): MindMapSourceBlock {
+  return { id, type: 'heading', props: { level }, content: [{ type: 'text', text }] }
+}
+
+const map = buildMindMap([heading('b-alpha', 1, 'Alpha')], {
+  rootLabel: 'Test Note',
+  noteId: 'note-1'
+})
+const alpha = map.nodes.find((node) => node.label === 'Alpha')!
+const root = map.nodes.find((node) => node.kind === 'root')!
+
+let container: HTMLElement
+let top: HTMLElement
+/** Every scroll the run asked for, in order, with what it was aimed at. */
+let scrolled: Array<{ target: Element; options: boolean | ScrollIntoViewOptions | undefined }>
+
+function setup(options: { smooth?: boolean } = {}) {
+  const close = vi.fn()
+  const view = renderHook(() =>
+    useMindMapNavigation({
+      close,
+      getContainer: () => container,
+      getTopElement: () => top,
+      smooth: options.smooth ?? true
+    })
+  )
+  return { close, view }
+}
+
+/** The block, once whatever gates the editor's render has let it through. */
+function renderBlock(id: string): HTMLElement {
+  const block = document.createElement('div')
+  block.setAttribute('data-id', id)
+  container.append(block)
+  return block
+}
+
+beforeEach(() => {
+  scrolled = []
+  // Recording the element as well as the options: which one was scrolled is
+  // the whole assertion, and jsdom implements none of this.
+  Element.prototype.scrollIntoView = function scrollIntoViewStub(
+    this: Element,
+    options?: boolean | ScrollIntoViewOptions
+  ): void {
+    scrolled.push({ target: this, options })
+  }
+  container = document.createElement('div')
+  top = document.createElement('div')
+  document.body.append(container, top)
+})
+
+afterEach(() => {
+  container.remove()
+  top.remove()
+})
+
+describe('useMindMapNavigation', () => {
+  it('closes the map before scrolling, because nothing hidden can be scrolled into view', () => {
+    const { close, view } = setup()
+    const block = renderBlock('b-alpha')
+
+    act(() => view.result.current.navigateToBlock('b-alpha'))
+
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(scrolled).toEqual([{ target: block, options: { behavior: 'smooth', block: 'start' } }])
+  })
+
+  it('waits for a block the content area has not rendered yet', async () => {
+    const { view } = setup()
+
+    // The window the note page's own heading anchor was written for: the map
+    // named a target, and the editor's render is still behind its placeholder.
+    act(() => view.result.current.navigateToBlock('b-alpha'))
+    expect(scrolled).toHaveLength(0)
+
+    const block = renderBlock('b-alpha')
+    await waitFor(() => expect(scrolled.length).toBeGreaterThan(0))
+    expect(scrolled[0].target).toBe(block)
+    // Never smooth from here: there is no starting position for an animation to
+    // be relative to when the content has not arrived.
+    expect(scrolled[0].options).toEqual({ behavior: 'auto', block: 'start' })
+  })
+
+  it('calls a pending wait off when a second navigation starts', async () => {
+    const { view } = setup()
+
+    act(() => view.result.current.navigateToBlock('b-alpha'))
+    act(() => view.result.current.navigateToBlock('b-beta'))
+
+    const beta = renderBlock('b-beta')
+    await waitFor(() => expect(scrolled.length).toBeGreaterThan(0))
+
+    // Two waits racing would fight over the offset for the whole deadline.
+    renderBlock('b-alpha')
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+    for (const entry of scrolled) expect(entry.target).toBe(beta)
+  })
+
+  it('sends the root node to the top of the note', () => {
+    const { close, view } = setup()
+
+    act(() => view.result.current.activateNode(root))
+
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(scrolled[0].target).toBe(top)
+  })
+
+  it('sends a heading node to its own block, through the same call the outline makes', () => {
+    const { view } = setup()
+    const block = renderBlock('b-alpha')
+
+    act(() => view.result.current.activateNode(alpha))
+    const fromMap = [...scrolled]
+    scrolled = []
+
+    // What the outline panel is handed, called with the same heading.
+    act(() => view.result.current.navigateToBlock('b-alpha'))
+
+    expect(fromMap).toEqual([{ target: block, options: { behavior: 'smooth', block: 'start' } }])
+    expect(scrolled).toEqual(fromMap)
+  })
+
+  it('honours a request for less motion', () => {
+    const { view } = setup({ smooth: false })
+    renderBlock('b-alpha')
+
+    act(() => view.result.current.navigateToBlock('b-alpha'))
+
+    expect(scrolled[0].options).toEqual({ behavior: 'auto', block: 'start' })
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.ts
@@ -1,0 +1,98 @@
+/**
+ * Landing the user back in the note.
+ *
+ * Two steps, and both are load-bearing. The map does not sit beside the note,
+ * it sits on top of it: the body is hidden (kept mounted, so the editor and its
+ * undo history survive) and nothing inside a hidden body can be scrolled into
+ * the user's view. So the map closes first. And the block may not be in the
+ * document yet — `ContentArea` holds its render behind a placeholder until the
+ * CRDT binding settles — which is why a miss falls through to the waiting form
+ * rather than giving up.
+ *
+ * The immediate lookup is tried first on purpose. Coming from the map the block
+ * is almost always already there, having been rendered behind the picture the
+ * whole time, and a single call is what keeps the outline panel's smooth jump
+ * exactly as smooth as it was before this existed.
+ *
+ * The same `navigateToBlock` is what the outline panel is handed, so a heading
+ * click has one behaviour whether or not the map is open.
+ */
+
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { RESTORE_MAX_MS } from '@/hooks/use-tab-scroll-restore'
+import { scrollToHeadingBlock, scrollToHeadingWhenReady } from '@/lib/scroll-to-heading'
+import { activateMindMapNode, type MindMapNodeActivation } from './mind-map-navigation'
+
+interface UseMindMapNavigationOptions {
+  /** Closes the map. A no-op when it is already closed. */
+  close: () => void
+  /** The pane the block lives in — never the document, which in split view
+   * would scroll whichever pane comes first rather than this one. */
+  getContainer: () => HTMLElement | null
+  /** The top of the note: where the root node, which is the title, lands. */
+  getTopElement: () => HTMLElement | null
+  /** False when the user asked for less motion. */
+  smooth: boolean
+}
+
+export interface UseMindMapNavigationResult {
+  /**
+   * Close the map and land at this block. `null` is the top of the note.
+   * Handed to the outline panel as-is — one function, one behaviour.
+   */
+  navigateToBlock: (blockId: string | null) => void
+  /** What a node activation on either projection ends in. */
+  activateNode: MindMapNodeActivation
+}
+
+export function useMindMapNavigation({
+  close,
+  getContainer,
+  getTopElement,
+  smooth
+}: UseMindMapNavigationOptions): UseMindMapNavigationResult {
+  // A wait outlives the click that started it, so a second click — or leaving
+  // the note — has to call the first one off, or two of them fight over the
+  // scroll offset for as long as the deadline lasts.
+  const cancelPendingRef = useRef<(() => void) | null>(null)
+  const cancelPending = useCallback(() => {
+    cancelPendingRef.current?.()
+    cancelPendingRef.current = null
+  }, [])
+
+  useEffect(() => cancelPending, [cancelPending])
+
+  const navigateToBlock = useCallback(
+    (blockId: string | null) => {
+      cancelPending()
+      close()
+
+      if (blockId === null) {
+        getTopElement()?.scrollIntoView?.({ behavior: smooth ? 'smooth' : 'auto', block: 'start' })
+        return
+      }
+
+      if (scrollToHeadingBlock(getContainer(), blockId, { smooth })) return
+
+      // Not rendered yet. Never smooth from here: there is no starting position
+      // for an animation to be relative to when the content has not arrived.
+      cancelPendingRef.current = scrollToHeadingWhenReady({
+        getContainer,
+        getHeadingId: () => blockId,
+        smooth: false,
+        timeoutMs: RESTORE_MAX_MS,
+        onSettled: () => {
+          cancelPendingRef.current = null
+        }
+      })
+    },
+    [cancelPending, close, getContainer, getTopElement, smooth]
+  )
+
+  const activateNode = useCallback<MindMapNodeActivation>(
+    (node) => activateMindMapNode(node, { navigateToBlock }),
+    [navigateToBlock]
+  )
+
+  return useMemo(() => ({ navigateToBlock, activateNode }), [navigateToBlock, activateNode])
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map.ts
@@ -44,6 +44,8 @@ function readBlocks(host: BlockTreeHost | null): MindMapSourceBlock[] {
 }
 
 interface UseMindMapOptions {
+  /** The note the map is of, so its boxes carry deep links back into it. */
+  noteId: string
   /** Root label. User content; never translated. */
   noteTitle: string
   /**
@@ -59,6 +61,10 @@ export interface UseMindMapResult {
   /** True while the map replaces the note body. */
   isOpen: boolean
   toggle: () => void
+  /** Gives the note back. A no-op when the map is already closed, so the
+   * outline panel can call it on every heading click without writing tab
+   * state each time. */
+  close: () => void
   /** Null until the map is open and has been built. */
   map: MindMap | null
   /** Pass to the content area in place of the callback that was composed in. */
@@ -71,7 +77,11 @@ export interface UseMindMapResult {
   refresh: () => void
 }
 
-export function useMindMap({ noteTitle, onEditorReady }: UseMindMapOptions): UseMindMapResult {
+export function useMindMap({
+  noteId,
+  noteTitle,
+  onEditorReady
+}: UseMindMapOptions): UseMindMapResult {
   const { isEnabled } = useFeatureFlags()
   const isAvailable = isEnabled('spatialCanvas')
   const direction = useDirection()
@@ -97,8 +107,8 @@ export function useMindMap({ noteTitle, onEditorReady }: UseMindMapOptions): Use
   )
 
   const build = useCallback(
-    () => buildMindMap(readBlocks(editorRef.current), { rootLabel: noteTitle, direction }),
-    [direction, noteTitle]
+    () => buildMindMap(readBlocks(editorRef.current), { rootLabel: noteTitle, direction, noteId }),
+    [direction, noteId, noteTitle]
   )
 
   // Layout, not passive: the note body is hidden in the same commit that flips
@@ -120,8 +130,15 @@ export function useMindMap({ noteTitle, onEditorReady }: UseMindMapOptions): Use
     setStoredOpen((previous) => !previous)
   }, [setStoredOpen])
 
+  const close = useCallback(() => {
+    // Guarded: the setter always dispatches, and the outline panel calls this on
+    // every heading click, map or no map.
+    if (!storedOpen) return
+    setStoredOpen(false)
+  }, [storedOpen, setStoredOpen])
+
   return useMemo(
-    () => ({ isAvailable, isOpen, toggle, map, handleEditorReady, refresh }),
-    [isAvailable, isOpen, toggle, map, handleEditorReady, refresh]
+    () => ({ isAvailable, isOpen, toggle, close, map, handleEditorReady, refresh }),
+    [isAvailable, isOpen, toggle, close, map, handleEditorReady, refresh]
   )
 }

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { renderWithProviders } from '@tests/utils/render'
 import { NotePage } from './note'
@@ -263,8 +263,30 @@ vi.mock('@/hooks/use-feature-flags', () => ({
 // The map's drawing chunk imports Excalidraw; the accessible tree beside it is
 // what these tests read, and what an end-to-end run reads too.
 vi.mock('@/components/note/mind-map/mind-map-canvas', () => ({
-  MindMapCanvas: ({ elements }: { elements: unknown[] }) => (
-    <div data-testid="mind-map-canvas" data-element-count={elements.length} />
+  MindMapCanvas: ({
+    elements,
+    onOpenLink
+  }: {
+    elements: Array<{ id: string; link?: string }>
+    onOpenLink: (href: string) => void
+  }) => (
+    <div data-testid="mind-map-canvas" data-element-count={elements.length}>
+      {/* Excalidraw hands a click back as the link of the box it landed on —
+          in view mode the whole box is the hit area. Standing in for that is
+          all this needs to do; everything downstream of it is the real path. */}
+      {elements
+        .filter((element) => Boolean(element.link))
+        .map((element) => (
+          <button
+            key={element.id}
+            type="button"
+            data-testid={`mind-map-box-${element.id}`}
+            onClick={() => onOpenLink(element.link!)}
+          >
+            {element.link}
+          </button>
+        ))}
+    </div>
   )
 }))
 
@@ -340,6 +362,11 @@ vi.mock('@/components/note', () => ({
       <button type="button" onClick={() => onHeadingClick('heading-1')}>
         Jump heading
       </button>
+      {/* The outline panel stays visible in map mode, so it is reachable here
+          in both modes — which is the point of the assertions that use it. */}
+      <button type="button" onClick={() => onHeadingClick('b-h1')}>
+        Jump Alpha
+      </button>
       {topBar}
       {breadcrumb}
       {actions}
@@ -404,6 +431,11 @@ vi.mock('@/components/note', () => ({
           {String(externalContentRevision ?? 'none')}
         </div>
         <div data-id="heading-1" />
+        {/* One `[data-id]` per block, exactly as the real editor renders — this
+            is what a jump to a block finds, or fails to find. */}
+        {(mocks.editorBlocks as Array<{ id: string }>).map((block) => (
+          <div key={block.id} data-id={block.id} />
+        ))}
         <button type="button" onClick={() => onMarkdownChange('# Changed')}>
           Change markdown
         </button>
@@ -1601,6 +1633,97 @@ describe('NotePage', () => {
       expect(screen.getByTestId('note-mind-map-empty-hint')).toHaveTextContent('mindMap.emptyHint')
       // A disabled control explains nothing; the hint does.
       expect(screen.getByTestId('note-mind-map-toggle')).not.toBeDisabled()
+    })
+
+    /** The tree item standing for a block, which is what a reader activates. */
+    const treeItemFor = (blockId: string): HTMLElement => {
+      const item = screen
+        .getByRole('tree')
+        .querySelector<HTMLElement>(`[data-mind-map-block="${blockId}"]`)
+      if (!item) throw new Error(`no tree item for ${blockId}`)
+      return item
+    }
+
+    /** The drawn box standing for a block: Excalidraw gives back its link. */
+    const drawnBoxFor = (href: string): HTMLElement => screen.getByText(href)
+
+    const blockElement = (blockId: string): Element => {
+      const element = document.querySelector(`[data-id="${blockId}"]`)
+      if (!element) throw new Error(`no block ${blockId}`)
+      return element
+    }
+
+    const expectLandedOnAlpha = async (scrolls: MockInstance): Promise<void> => {
+      // Both halves: the map has to go, or the body it hid cannot be seen, and
+      // the block has to be scrolled to, or the user is merely back at the top.
+      await waitFor(() => expect(screen.queryByTestId('note-mind-map')).not.toBeInTheDocument())
+      expect(scrolls).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' })
+    }
+
+    it('lands on the heading a map node names, and gives the note back', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+      const scrolls = vi.spyOn(blockElement('b-h1'), 'scrollIntoView')
+
+      fireEvent.click(treeItemFor('b-h1'))
+
+      await expectLandedOnAlpha(scrolls)
+    })
+
+    it('activates a node from the keyboard exactly as a click does', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+      const scrolls = vi.spyOn(blockElement('b-h1'), 'scrollIntoView')
+
+      fireEvent.keyDown(treeItemFor('b-h1'), { key: 'Enter' })
+
+      await expectLandedOnAlpha(scrolls)
+    })
+
+    it('lands on the same heading from the drawing', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+      const scrolls = vi.spyOn(blockElement('b-h1'), 'scrollIntoView')
+
+      // A block anchor, minted for this session: the drawing's only handle on
+      // which node a click landed on is the deep link the box carries.
+      fireEvent.click(drawnBoxFor('memry://note/note-1#^b-h1'))
+
+      await expectLandedOnAlpha(scrolls)
+    })
+
+    it('returns to the top of the note from the root node', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+      const scrolls = vi.spyOn(screen.getByTestId('note-body'), 'scrollIntoView')
+
+      // The root is the title, which is not a block — so its link has no anchor.
+      fireEvent.click(drawnBoxFor('memry://note/note-1'))
+
+      await waitFor(() => expect(screen.queryByTestId('note-mind-map')).not.toBeInTheDocument())
+      expect(scrolls).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' })
+    })
+
+    it('takes the identical path from the outline panel while the map is showing', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+
+      await openMap()
+      // One spy for both runs: the block is the same node throughout, because
+      // the body was hidden rather than unmounted.
+      const scrolls = vi.spyOn(blockElement('b-h1'), 'scrollIntoView')
+      fireEvent.click(treeItemFor('b-h1'))
+      await expectLandedOnAlpha(scrolls)
+      const mapCalls = [...scrolls.mock.calls]
+      scrolls.mockClear()
+
+      fireEvent.click(screen.getByTestId('note-mind-map-toggle'))
+      await screen.findByTestId('note-mind-map')
+      fireEvent.click(screen.getByRole('button', { name: 'Jump Alpha' }))
+
+      // One control, one behaviour: the outline panel is handed the very
+      // function the map's nodes end in, so this cannot drift from the above.
+      await expectLandedOnAlpha(scrolls)
+      expect(scrolls.mock.calls).toEqual(mapCalls)
     })
   })
 })

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -32,7 +32,7 @@ import {
   Block
 } from '@/components/note'
 import { isOutsideAllBlocks } from '@/components/note/content-area/marquee-hit-test'
-import { MindMapView, useMindMap } from '@/components/note/mind-map'
+import { MindMapView, useMindMap, useMindMapNavigation } from '@/components/note/mind-map'
 import { NoteTitle } from '@/components/note/note-title'
 import { TagsRow, Tag } from '@/components/note/tags-row'
 import { InfoSection, type NewProperty } from '@/components/note/info-section'
@@ -357,6 +357,9 @@ export function NotePage({ noteId }: NotePageProps) {
 
   // Find in page (Cmd+F)
   const editorContainerRef = useRef<HTMLDivElement>(null)
+  // Title, properties, tags and body together — the top of the note, which is
+  // where the mind map's root node lands.
+  const noteBodyRef = useRef<HTMLDivElement>(null)
   const [marqueeZoneEl, setMarqueeZoneEl] = useState<HTMLDivElement | null>(null)
 
   // Click anywhere in the marquee zone (full scroll area, minus title/metadata
@@ -656,19 +659,6 @@ export function NotePage({ noteId }: NotePageProps) {
   // Handlers
   // ============================================================================
 
-  const handleHeadingClick = useCallback(
-    (headingId: string) => {
-      // Scoped to this pane. `document.querySelector` returns whichever pane is
-      // first in the DOM, so in split view the outline scrolled the pane the
-      // user was not looking at. Smooth is right here — the jump happens inside
-      // content already on screen — unless the user asked for less motion.
-      scrollToHeadingBlock(editorContainerRef.current, headingId, {
-        smooth: !prefersReducedMotion
-      })
-    },
-    [prefersReducedMotion]
-  )
-
   /**
    * Scrolls to a heading by TEXT, which is all `[[Note#Heading]]` carries — a
    * block id is minted per document and means nothing to the note that wrote
@@ -799,10 +789,22 @@ export function NotePage({ noteId }: NotePageProps) {
   // the live block tree off the editor that stays mounted behind it, with no
   // new prop on the content area.
   const mindMap = useMindMap({
+    noteId: noteId ?? '',
     noteTitle: note?.title ?? '',
     onEditorReady: review.handleEditorReady
   })
   const { refresh: refreshMindMap } = mindMap
+  // One handler for the outline panel and for both projections of the map, so
+  // a heading click cannot mean two different things depending on what else is
+  // on screen. The map closes first; see the hook for why that is not optional.
+  const getEditorContainer = useCallback(() => editorContainerRef.current, [])
+  const getNoteBody = useCallback(() => noteBodyRef.current, [])
+  const mindMapNavigation = useMindMapNavigation({
+    close: mindMap.close,
+    getContainer: getEditorContainer,
+    getTopElement: getNoteBody,
+    smooth: !prefersReducedMotion
+  })
   // The map is built when it opens, but a restored tab reopens it before the
   // body has finished loading. The heading set arriving is the signal that the
   // block tree behind the map is real.
@@ -1488,14 +1490,19 @@ export function NotePage({ noteId }: NotePageProps) {
     <NoteLayout
       suppressScrollRestore={Boolean(initialHeadingText)}
       headings={headings}
-      onHeadingClick={handleHeadingClick}
+      onHeadingClick={mindMapNavigation.navigateToBlock}
       actions={actionIcons}
       fullWidth={isFullWidth}
       contentWidth={noteContentWidth ?? undefined}
       sideRail={hasReviewContent ? <ReviewRail review={review} targetId={noteId} /> : undefined}
       overlay={
         mindMap.isOpen && mindMap.map ? (
-          <MindMapView map={mindMap.map} noteTitle={note.title} />
+          <MindMapView
+            map={mindMap.map}
+            noteId={noteId ?? ''}
+            noteTitle={note.title}
+            onActivateNode={mindMapNavigation.activateNode}
+          />
         ) : undefined
       }
       onRailHiddenChange={setReviewRailHidden}
@@ -1520,6 +1527,7 @@ export function NotePage({ noteId }: NotePageProps) {
           reduced motion); critically damped spring, no overshoot */}
       <motion.div
         key={noteId}
+        ref={noteBodyRef}
         initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ type: 'spring', bounce: 0, duration: 0.35 }}

--- a/apps/docs/src/user-guide/notes/mind-map.md
+++ b/apps/docs/src/user-guide/notes/mind-map.md
@@ -31,6 +31,20 @@ edited, and the note is untouched by opening it.
 A note with no headings opens on the root alone, with a hint that adding a
 heading will branch it.
 
+## Clicking a Node
+
+The map is navigation, not just a picture.
+
+- Click a **heading node** and the map closes and the note reopens at that
+  heading.
+- Click the **root** — the note's title — to come back to the top of the note.
+- The **outline panel** stays available while the map shows, and clicking a
+  heading there does exactly the same thing. One control, one behaviour.
+
+Nodes work from the keyboard too. Tab into the map, move between nodes with the
+up and down arrows (Home and End jump to the ends), and press Enter or Space to
+open the one you are on.
+
 ## Coming Back to the Note
 
 Your work is exactly where you left it. The editor is only hidden while the map
@@ -52,8 +66,10 @@ than against it.
 ## Accessibility
 
 The drawing sits beside a real tree in the page, so every node is announced by a
-screen reader with its nesting level. The map region itself is labelled with the
-note's name and how many nodes it holds.
+screen reader with its nesting level, and every node can be reached and opened
+with the keyboard. The map takes a single tab stop: arrow keys move between
+nodes from there. The map region itself is labelled with the note's name and how
+many nodes it holds.
 
 ## Turning It Off
 


### PR DESCRIPTION
Closes nothing on its own — implements #1670 (part of #1667). Blockers #1668 and #1669 are merged; this branch is cut from `d297035f3`.

## What this does

The map becomes navigation. Clicking a node closes the map and lands the user at that place in the note.

Both steps are load-bearing and neither is optional. The note body is hidden (never unmounted) while the map shows, so nothing inside it can be scrolled into the user's view; and `ContentArea` gates its own render behind a placeholder until the CRDT binding settles, so the target block may not be in the document yet. So: close first, then try the immediate lookup, and fall through to the existing `scrollToHeadingWhenReady` wait when the block is not there.

## The node-activation dispatch

One dispatch stands behind every surface, so #1671 (list and task nodes) and #1672 (wiki-link nodes) extend it rather than growing paths of their own:

```ts
// components/note/mind-map/mind-map-navigation.ts
export interface MindMapNodeActions {
  navigateToBlock: (blockId: string | null) => void  // null = top of the note
}
export type MindMapNodeActivation = (node: MindMapPositionedNode) => void
export function activateMindMapNode(node, actions): void   // switch on node.kind
export function nodeFromMindMapLink(href, nodes, noteId): MindMapPositionedNode | null
```

`activateMindMapNode` switches on `node.kind` with a `never` default, so adding a kind to `MindMapNodeKind` fails to compile until someone decides what activating it does. A new kind adds a member to `MindMapNodeActions` (`openNote`, `openTask`) and a case.

**How the drawing gets a click.** Excalidraw draws to a bitmap and gives no DOM. Boxes are therefore minted with a `memry://` deep link, and in view mode Excalidraw's link hit test is the whole bounding box — so a click anywhere on a node arrives as `onLinkOpen(element, event)`. The link is read back with `parseMemryHref(href).anchor` (the anchor grammar #1668 landed) and resolved to the node it names. Boxes carry a **block** anchor: exact, and alive exactly as long as the document that minted it, which is right for a click handed straight back into the same session. A saved canvas outlives that document and will need heading text instead — that is #1676's decision, and element minting stays private behind `buildMindMap`, so it can make it.

`buildMindMap` gains one optional option, `noteId`. Without it the map draws exactly as before and only the tree projection is clickable. Layout is byte-identical with and without links (asserted).

## Acceptance criteria

- [x] **Clicking a heading node closes the map and lands at that heading, including when the target block has not been rendered yet.** `note.test.tsx` "lands on the heading a map node names, and gives the note back"; the not-yet-rendered case in `use-mind-map-navigation.test.tsx` "waits for a block the content area has not rendered yet".
- [x] **Activating a node from the keyboard does the same thing as clicking it.** `mind-map-tree.test.tsx` "activates from the keyboard exactly as a click does" asserts Enter, Space and click produce the identical call; `note.test.tsx` "activates a node from the keyboard exactly as a click does" runs it through the whole page.
- [x] **Clicking the root node returns to the top of the note.** `note.test.tsx` "returns to the top of the note from the root node"; `use-mind-map-navigation.test.tsx` "sends the root node to the top of the note".
- [x] **Clicking a heading in the outline panel while the map is showing takes the identical path as clicking the corresponding map node.** `note.test.tsx` "takes the identical path from the outline panel while the map is showing" drives both and asserts the recorded scroll calls are equal. The outline panel is handed `mindMapNavigation.navigateToBlock` — the very function `activateNode` ends in.
- [x] **Navigation works both from the tree-role projection and from the drawn map.** Tree: the tests above. Drawing: `note.test.tsx` "lands on the same heading from the drawing" clicks through the link the box was actually minted with.
- [x] **Tests cover each path and assert that the outline and the map call the same handler.** Above, plus `mind-map-navigation.test.ts` "lands a drawn box and its tree twin on the very same call" and "resolves the link a box was actually minted with".

## Invariants held

- The editor is hidden and inert, never unmounted; `invisible` (not `hidden`) is untouched — #1669's assertions still pass unchanged.
- One public entry point: `buildMindMap`. Projection, layout and element minting stay private.
- Layout stays deterministic — no clock, no randomness; the new option only attaches a string to a box.
- No IPC contract, no migration, no sync handler, no settings schema.
- Still gated on the existing `spatialCanvas` key.
- The note header overflow menu is untouched in both modes.
- No new user-visible strings: node labels are user content. `i18n:check` is green with no additions.
- Logical Tailwind classes only (the tree adds no physical ones).

## Keyboard and accessibility

The tree keeps a **single tab stop**: arrow keys move between items, Home/End jump to the ends, Enter/Space activate. All-items-tabbable would have turned a note with fifty headings into fifty invisible tab stops, so this follows the ARIA tree pattern instead.

## Gates

```
$ pnpm lint
✖ 109 problems (0 errors, 109 warnings)      # exit 0 — all pre-existing
$ pnpm typecheck
Tasks:    17 successful, 17 total            # exit 0
$ pnpm test                                  # exit 0
@memry/desktop   Test Files  1374 passed | 3 skipped (1377)
@memry/desktop        Tests  17854 passed | 1 expected fail | 13 skipped (17868)
@memry/sync-server  Test Files  62 passed (62)
@memry/sync-server       Tests  966 passed (966)
Tasks:    9 successful, 9 total

# First run of the same suite hit a fresh-worktree environment flake,
# recorded for honesty: two main SUITES failed to load, running no test —
#   FAIL main src/main/sync/engine/crdt-sync-coordinator.test.ts
#   FAIL main src/main/sync/engine/full-sync-runner.test.ts
#   Error: Electron failed to install correctly. …
#     ❯ getElectronPath node_modules/electron/index.js:43:13
# Nothing in src/main is touched here; both pass on their own and the
# clean re-run above is green.
$ pnpm --filter @memry/desktop i18n:check
ok: i18n check passed                        # exit 0
$ pnpm docs:impact --base d297035f3 --strict
docs impact: covered against d297035f3
docs impact: docs changed on this branch     # exit 0
```
