### PR TITLE
feat(notes): give the mind map its own toolbar for fitting and copying it (#1674)

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * What the toolbar's actions actually do to the drawing.
+ *
+ * The drawing library stands in for itself here: jsdom has no canvas to
+ * rasterise to and no system clipboard to write to, so the real
+ * `exportToBlob`/`exportToSvg` could not run and the real `navigator.clipboard`
+ * does not exist. What these tests can prove is the part that has been wrong
+ * before in this kind of code: that an export reads the LIVE scene rather than
+ * the elements the map was built from, that the export settings are pinned
+ * rather than inherited from the app's theme or the user's camera, and that a
+ * failure travels up to the caller instead of being swallowed here.
+ *
+ * They deliberately do not prove that the resulting bytes are a valid PNG or
+ * that a real clipboard accepts them — only a real browser can say that.
+ */
+
+import { useEffect } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render } from '@testing-library/react'
+import { exportToBlob, exportToSvg } from '@excalidraw/excalidraw'
+import { MindMapCanvas, type MindMapControls } from './mind-map-canvas'
+import type { MindMapElement } from './mind-map-types'
+
+/**
+ * The scene the surface is showing — deliberately NOT the elements the map was
+ * built from, so a test can tell the two apart. A branch the user expanded
+ * lives here and nowhere else.
+ */
+const LIVE_ELEMENTS = [{ id: 'live-1' }, { id: 'live-2' }]
+const LIVE_FILES = { 'file-1': { id: 'file-1' } }
+
+const mocks = vi.hoisted(() => ({
+  scrollToContent: vi.fn(),
+  updateScene: vi.fn()
+}))
+
+vi.mock('@excalidraw/excalidraw', () => ({
+  Excalidraw: ({ excalidrawAPI }: { excalidrawAPI: (api: Record<string, unknown>) => void }) => {
+    useEffect(() => {
+      excalidrawAPI({
+        getSceneElements: () => LIVE_ELEMENTS,
+        getFiles: () => LIVE_FILES,
+        updateScene: mocks.updateScene,
+        scrollToContent: mocks.scrollToContent
+      })
+    }, [excalidrawAPI])
+    return <div data-testid="excalidraw" />
+  },
+  convertToExcalidrawElements: (elements: unknown[]) => elements,
+  exportToBlob: vi.fn(),
+  exportToSvg: vi.fn()
+}))
+
+class FakeClipboardItem {
+  constructor(readonly items: Record<string, Blob>) {}
+}
+
+const clipboard = { write: vi.fn(), writeText: vi.fn() }
+
+/** #1670's link forwarding; irrelevant to an export, but the surface takes it. */
+const openLink = vi.fn()
+
+/** The elements the map was built from; a copy must not reach for these. */
+const BUILT_ELEMENTS = [
+  { type: 'rectangle', id: 'built-1' }
+] as unknown as readonly MindMapElement[]
+
+function mountSurface(): { controls: () => MindMapControls; unmount: () => void } {
+  let latest: MindMapControls | null = null
+  const view = render(
+    <MindMapCanvas
+      elements={BUILT_ELEMENTS}
+      onOpenLink={openLink}
+      onControlsChange={(next) => {
+        latest = next
+      }}
+    />
+  )
+  return {
+    controls: () => {
+      if (!latest) throw new Error('the drawing surface handed no controls up')
+      return latest
+    },
+    unmount: view.unmount
+  }
+}
+
+describe('MindMapCanvas controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('ClipboardItem', FakeClipboardItem)
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      value: clipboard,
+      configurable: true,
+      writable: true
+    })
+    vi.mocked(exportToBlob).mockResolvedValue(new Blob(['png-bytes'], { type: 'image/png' }))
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    svg.setAttribute('data-map', 'yes')
+    vi.mocked(exportToSvg).mockResolvedValue(svg)
+  })
+
+  it('hands its controls up while it is live and takes them back when it is not', () => {
+    let latest: MindMapControls | null | undefined
+    const view = render(
+      <MindMapCanvas
+        elements={BUILT_ELEMENTS}
+        onOpenLink={openLink}
+        onControlsChange={(next) => {
+          latest = next
+        }}
+      />
+    )
+    expect(latest).toEqual({
+      fit: expect.any(Function),
+      copyImage: expect.any(Function),
+      copyVector: expect.any(Function)
+    })
+
+    view.unmount()
+    expect(latest).toBeNull()
+  })
+
+  it('frames the whole drawing on fit, wherever the user panned to', () => {
+    const surface = mountSurface()
+    mocks.scrollToContent.mockClear()
+
+    act(() => surface.controls().fit())
+
+    expect(mocks.scrollToContent).toHaveBeenCalledWith(undefined, {
+      fitToContent: true,
+      animate: true
+    })
+  })
+
+  it('copies the live scene as an image, not the elements the map was built from', async () => {
+    const surface = mountSurface()
+
+    await act(async () => await surface.controls().copyImage())
+
+    expect(vi.mocked(exportToBlob).mock.calls[0][0]).toMatchObject({
+      elements: LIVE_ELEMENTS,
+      files: LIVE_FILES,
+      mimeType: 'image/png'
+    })
+    expect(vi.mocked(exportToBlob).mock.calls[0][0].elements).not.toBe(BUILT_ELEMENTS)
+
+    const [items] = clipboard.write.mock.calls[0] as [FakeClipboardItem[]]
+    expect(items[0]).toBeInstanceOf(FakeClipboardItem)
+    expect(items[0].items['image/png']).toBeInstanceOf(Blob)
+  })
+
+  it('copies the live scene as SVG markup, which the sanitized clipboard carries as text', async () => {
+    const surface = mountSurface()
+
+    await act(async () => await surface.controls().copyVector())
+
+    expect(vi.mocked(exportToSvg).mock.calls[0][0]).toMatchObject({
+      elements: LIVE_ELEMENTS,
+      files: LIVE_FILES
+    })
+    expect(clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('data-map="yes"'))
+    expect(clipboard.write).not.toHaveBeenCalled()
+  })
+
+  it('pins the export settings instead of inheriting the theme or the camera', async () => {
+    const surface = mountSurface()
+
+    await act(async () => await surface.controls().copyImage())
+    await act(async () => await surface.controls().copyVector())
+
+    // The map's colours are authored light, so the same note copies the same
+    // way whichever theme the app is in, and drops onto any background.
+    for (const call of [
+      vi.mocked(exportToBlob).mock.calls[0][0],
+      vi.mocked(exportToSvg).mock.calls[0][0]
+    ]) {
+      expect(call.appState).toMatchObject({
+        exportBackground: false,
+        exportWithDarkMode: false,
+        exportEmbedScene: false
+      })
+      expect(call.appState).not.toHaveProperty('scrollX')
+      expect(call.appState).not.toHaveProperty('zoom')
+    }
+  })
+
+  it('lets a failed copy travel up, so the host can say something about it', async () => {
+    vi.mocked(exportToBlob).mockRejectedValue(new Error('Rasterising failed'))
+    const surface = mountSurface()
+
+    await expect(surface.controls().copyImage()).rejects.toThrow('Rasterising failed')
+    expect(clipboard.write).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.tsx
@@ -9,14 +9,22 @@
  *
  * Read-only by construction: the map is a derived view of the note, never a
  * document, so the surface is mounted in view mode and nothing here writes.
+ *
+ * The toolbar's actions are handed UP from here rather than reaching down,
+ * because everything they need — the live scene and the export functions — is
+ * inside this chunk, while the toolbar itself must render as a sibling of the
+ * map's image region. (Anything inside an `img` role is presentational, so a
+ * toolbar nested in it would be invisible to exactly the readers the accessible
+ * projection exists for.)
  */
 
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Excalidraw, convertToExcalidrawElements } from '@excalidraw/excalidraw'
 import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
 import type { ExcalidrawElementSkeleton } from '@excalidraw/excalidraw/data/transform'
 import '@excalidraw/excalidraw/index.css'
 import { useTheme } from 'next-themes'
+import { copySceneAsImage, copySceneAsVector } from './mind-map-export'
 import type { MindMapElement } from './mind-map-types'
 
 /**
@@ -28,13 +36,35 @@ import type { MindMapElement } from './mind-map-types'
 const toSkeleton = (elements: readonly MindMapElement[]): ExcalidrawElementSkeleton[] =>
   elements as unknown as ExcalidrawElementSkeleton[]
 
+/**
+ * What the map's toolbar can do, closed over the live surface.
+ *
+ * Each copy rejects on failure rather than swallowing it — the host turns that
+ * into something the user can read, so a failed export is never silent.
+ */
+export interface MindMapControls {
+  /** Frame the whole drawing again, whatever the user panned or zoomed to. */
+  fit: () => void
+  copyImage: () => Promise<void>
+  copyVector: () => Promise<void>
+}
+
 interface MindMapCanvasProps {
   elements: readonly MindMapElement[]
   /** The deep link of the box that was clicked. See `handleMindMapLinkOpen`. */
   onOpenLink: (href: string) => void
+  /**
+   * Called with the controls once the surface is live, and with `null` when it
+   * goes away, so the toolbar is never wired to a surface that is not there.
+   */
+  onControlsChange?: (controls: MindMapControls | null) => void
 }
 
-export function MindMapCanvas({ elements, onOpenLink }: MindMapCanvasProps): React.JSX.Element {
+export function MindMapCanvas({
+  elements,
+  onOpenLink,
+  onControlsChange
+}: MindMapCanvasProps): React.JSX.Element {
   const { resolvedTheme } = useTheme()
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null)
 
@@ -46,6 +76,35 @@ export function MindMapCanvas({ elements, onOpenLink }: MindMapCanvasProps): Rea
     api.updateScene({ elements: convertToExcalidrawElements(toSkeleton(elements)) })
     api.scrollToContent(undefined, { fitToContent: true, animate: false })
   }, [elements])
+
+  const fit = useCallback((): void => {
+    apiRef.current?.scrollToContent(undefined, { fitToContent: true, animate: true })
+  }, [])
+
+  // Read through the ref at call time, never captured at build time: the point
+  // of exporting from the live surface is that it holds whatever the map shows
+  // right now, expanded branches included.
+  const copyImage = useCallback(async (): Promise<void> => {
+    const api = apiRef.current
+    if (!api) return
+    await copySceneAsImage(api)
+  }, [])
+
+  const copyVector = useCallback(async (): Promise<void> => {
+    const api = apiRef.current
+    if (!api) return
+    await copySceneAsVector(api)
+  }, [])
+
+  const controls = useMemo<MindMapControls>(
+    () => ({ fit, copyImage, copyVector }),
+    [fit, copyImage, copyVector]
+  )
+
+  useEffect(() => {
+    onControlsChange?.(controls)
+    return () => onControlsChange?.(null)
+  }, [controls, onControlsChange])
 
   return (
     <Excalidraw

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-export.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-export.ts
@@ -1,0 +1,79 @@
+/**
+ * Taking the map with you.
+ *
+ * Part of the lazy drawing chunk: it imports @excalidraw/excalidraw, so it is
+ * only ever reached from `mind-map-canvas.tsx` and never from a module the main
+ * renderer bundle can see.
+ *
+ * The scene comes from the LIVE surface, never from a fresh `buildMindMap`
+ * call. What the user copies has to be what the user is looking at — including
+ * branches they expanded — and only the surface knows that.
+ *
+ * Both paths go through `navigator.clipboard`, which is the app's existing
+ * clipboard convention, and both stay inside the `clipboard-sanitized-write`
+ * permission the session already grants (see `main/session-permissions.ts`):
+ *
+ * - The image is a PNG `ClipboardItem`. PNG is one of the clipboard's
+ *   well-known sanitized types, so no unsanitized-write permission is needed.
+ * - The vector is the SVG *markup*, written as text. `image/svg+xml` is not a
+ *   sanitized clipboard type, and asking for raw clipboard access to carry it
+ *   would mean widening a deny-by-default permission set for one button. Design
+ *   tools read pasted SVG markup, and the drawing library's own "copy as SVG"
+ *   does exactly this.
+ *
+ * Neither path needs a main-process channel, so no IPC contract is touched.
+ */
+
+import { exportToBlob, exportToSvg } from '@excalidraw/excalidraw'
+import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
+
+/** The slice of the live surface an export reads. */
+export type MindMapSceneSource = Pick<ExcalidrawImperativeAPI, 'getSceneElements' | 'getFiles'>
+
+/** Breathing room around the drawing, in scene units. */
+const EXPORT_PADDING = 16
+
+/**
+ * The export settings, pinned rather than inherited from the live surface.
+ *
+ * The map's colours are authored for a light surface (see
+ * `mind-map-elements.ts`), so exporting in dark mode would hand the user an
+ * image that does not match what any other reader sees. A transparent
+ * background lets the result drop into a note, a message or a slide without
+ * carrying a rectangle of the app's own background colour with it. Two pixels
+ * per scene unit keeps a pasted map crisp on a high-density display.
+ *
+ * Nothing here reads the camera, so panning or zooming the map does not change
+ * what a copy contains: the export is the whole drawing, every time.
+ */
+const EXPORT_APP_STATE = {
+  exportBackground: false,
+  exportWithDarkMode: false,
+  exportEmbedScene: false,
+  exportScale: 2
+} as const
+
+/** The map as currently drawn, on the clipboard as a PNG. */
+export async function copySceneAsImage(source: MindMapSceneSource): Promise<void> {
+  const blob = await exportToBlob({
+    elements: source.getSceneElements(),
+    appState: EXPORT_APP_STATE,
+    files: source.getFiles(),
+    exportPadding: EXPORT_PADDING,
+    mimeType: 'image/png'
+  })
+
+  await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
+}
+
+/** The map as currently drawn, on the clipboard as SVG markup. */
+export async function copySceneAsVector(source: MindMapSceneSource): Promise<void> {
+  const svg = await exportToSvg({
+    elements: source.getSceneElements(),
+    appState: EXPORT_APP_STATE,
+    files: source.getFiles(),
+    exportPadding: EXPORT_PADDING
+  })
+
+  await navigator.clipboard.writeText(svg.outerHTML)
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-toolbar.tsx
@@ -1,0 +1,67 @@
+/**
+ * The map's own controls.
+ *
+ * Deliberately NOT the note's overflow menu: that menu stays the note's menu in
+ * both modes, because the same button in the same place doing different work
+ * depending on the mode is exactly how someone deletes a note by accident. The
+ * map's actions live in the map.
+ *
+ * Presentational only — it takes a list of actions and draws them. It imports
+ * nothing from the drawing library, so it stays in the main renderer bundle and
+ * renders in a plain test without pulling a canvas chunk in. The list is data
+ * rather than fixed props so a later action (saving the map as a canvas) is one
+ * more entry, not a new prop and a new slot.
+ *
+ * A flex row above the drawing rather than a corner overlay: the drawing
+ * library pins its own islands to the physical corners and does not mirror them
+ * for an RTL app, so a pinned control cluster would collide with them in one
+ * reading direction or the other. A row lets `justify-end` follow the reading
+ * direction on its own, with nothing to overlap.
+ */
+
+import { Button } from '@/components/ui/button'
+import type { AppIcon } from '@/lib/icons'
+
+export interface MindMapToolbarAction {
+  /** Stable within the toolbar; also the control's test id suffix. */
+  id: string
+  /** Translated. Used as both the tooltip and the accessible name. */
+  label: string
+  icon: AppIcon
+  onSelect: () => void
+  /** True while the drawing surface has not handed its controls up yet. */
+  disabled?: boolean
+}
+
+interface MindMapToolbarProps {
+  actions: readonly MindMapToolbarAction[]
+  /** Translated; names the group for a screen reader. */
+  label: string
+}
+
+export function MindMapToolbar({ actions, label }: MindMapToolbarProps): React.JSX.Element {
+  return (
+    <div
+      role="toolbar"
+      aria-label={label}
+      aria-orientation="horizontal"
+      data-testid="mind-map-toolbar"
+      className="flex flex-none items-center justify-end gap-0.5 px-3 py-2"
+    >
+      {actions.map((action) => (
+        <Button
+          key={action.id}
+          variant="ghost"
+          size="icon-sm"
+          onClick={action.onSelect}
+          disabled={action.disabled}
+          title={action.label}
+          aria-label={action.label}
+          data-testid={`mind-map-toolbar-${action.id}`}
+        >
+          <action.icon className="h-3.5 w-3.5 text-muted-foreground" />
+        </Button>
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * The map's controls, as a reader and a user meet them.
+ *
+ * A real render of the real toolbar against the real English strings — the only
+ * thing standing in for something else here is the drawing surface itself,
+ * which imports a library that cannot draw in jsdom. That stub hands its
+ * controls up exactly as the real chunk does, so what is asserted is the wiring
+ * between the toolbar and whatever surface is live.
+ */
+
+import { useEffect } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { toast } from 'sonner'
+import { buildMindMap } from './build-mind-map'
+import { MindMapView } from './mind-map-view'
+import type { MindMapSourceBlock } from './mind-map-types'
+
+const mocks = vi.hoisted(() => ({
+  fit: vi.fn(),
+  copyImage: vi.fn(),
+  copyVector: vi.fn(),
+  /** False to hold the surface back, as a chunk that has not arrived yet. */
+  handsControlsUp: true
+}))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+vi.mock('./mind-map-canvas', () => ({
+  MindMapCanvas: ({
+    onControlsChange
+  }: {
+    onControlsChange?: (controls: Record<string, unknown> | null) => void
+  }) => {
+    useEffect(() => {
+      if (!mocks.handsControlsUp) return
+      onControlsChange?.({
+        fit: mocks.fit,
+        copyImage: mocks.copyImage,
+        copyVector: mocks.copyVector
+      })
+      return () => onControlsChange?.(null)
+    }, [onControlsChange])
+    return <div data-testid="mind-map-canvas" />
+  }
+}))
+
+const BLOCKS: MindMapSourceBlock[] = [
+  { id: 'b-h1', type: 'heading', props: { level: 1 }, content: [{ type: 'text', text: 'Alpha' }] }
+]
+
+const activateNode = vi.fn()
+
+function renderView(): ReturnType<typeof render> {
+  return render(
+    <MindMapView
+      map={buildMindMap(BLOCKS, { rootLabel: 'Test Note', noteId: 'note-1' })}
+      noteId="note-1"
+      noteTitle="Test Note"
+      onActivateNode={activateNode}
+    />
+  )
+}
+
+async function renderMap(): Promise<HTMLElement> {
+  renderView()
+  return await screen.findByRole('toolbar')
+}
+
+describe('MindMapView toolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.handsControlsUp = true
+    mocks.copyImage.mockResolvedValue(undefined)
+    mocks.copyVector.mockResolvedValue(undefined)
+  })
+
+  it('offers fit and both copies, translated, in the map and outside its picture', async () => {
+    const toolbar = await renderMap()
+
+    expect(toolbar).toHaveAccessibleName('Mind map actions')
+    expect(
+      within(toolbar)
+        .getAllByRole('button')
+        .map((button) => button.getAttribute('aria-label'))
+    ).toEqual(['Fit to view', 'Copy as image', 'Copy as vector'])
+    // Every control is also its own tooltip.
+    for (const button of within(toolbar).getAllByRole('button')) {
+      expect(button).toHaveAttribute('title', button.getAttribute('aria-label'))
+    }
+
+    // Inside the map, but NOT inside the drawing's image role: an image role
+    // makes its contents presentational, which would hide these controls from
+    // the readers the accessible projection beside them exists for.
+    expect(screen.getByTestId('note-mind-map')).toContainElement(toolbar)
+    expect(screen.getByRole('img')).not.toContainElement(toolbar)
+  })
+
+  it('leaves the controls inert until the drawing surface is live', async () => {
+    mocks.handsControlsUp = false
+    const toolbar = await renderMap()
+
+    for (const button of within(toolbar).getAllByRole('button')) {
+      expect(button).toBeDisabled()
+    }
+  })
+
+  it('frames the live drawing again on fit', async () => {
+    await renderMap()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fit to view' }))
+    expect(mocks.fit).toHaveBeenCalledTimes(1)
+  })
+
+  it('copies through the live surface and says so', async () => {
+    await renderMap()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy as image' }))
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Map copied as an image'))
+    expect(mocks.copyImage).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy as vector' }))
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Map copied as vector artwork'))
+    expect(mocks.copyVector).toHaveBeenCalledTimes(1)
+  })
+
+  it('says a copy failed rather than failing quietly', async () => {
+    mocks.copyImage.mockRejectedValue(new Error('Clipboard blocked'))
+    await renderMap()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy as image' }))
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Clipboard blocked'))
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a translated message when the failure carries none', async () => {
+    mocks.copyVector.mockRejectedValue(undefined)
+    await renderMap()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy as vector' }))
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to copy the map'))
+  })
+
+  it('takes its controls back when the drawing surface goes away', async () => {
+    const view = renderView()
+    await screen.findByTestId('mind-map-canvas')
+
+    view.unmount()
+    expect(screen.queryByRole('toolbar')).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
@@ -1,18 +1,41 @@
 /**
- * The map surface: the drawing, its accessible twin, and the empty-note hint.
+ * The map surface: its toolbar, the drawing, its accessible twin, and the
+ * empty-note hint.
  *
  * Two projections of one layout result sit side by side here — the picture for
  * people who can see it, the tree for everyone and everything else. They are
  * siblings rather than nested because an image role makes its contents
  * presentational, which would hide the tree from exactly the readers it exists
- * for.
+ * for. The toolbar is a sibling for the same reason.
+ *
+ * The map's controls live here and nowhere else. The note header's overflow
+ * menu is untouched in both modes: one control in one place doing two different
+ * things depending on the mode is how a note gets deleted by accident.
+ *
+ * Mount lifetime, decided here because this is where viewport state arrives:
+ * the drawing surface is mounted on toggle and unmounted on close, and the
+ * camera is NOT persisted. Every open frames the whole map. The map is a
+ * derived view rebuilt from the note each time it opens, so a restored camera
+ * could point at coordinates the new drawing no longer uses — the same reason
+ * the map's expansion state is not persisted either. And the loss costs
+ * nothing: reopening the map puts the camera exactly where "Fit to view" puts
+ * it, so the state is one click from recovery rather than something to store,
+ * parse and keep compatible across versions.
  */
 
-import { lazy, Suspense, useCallback } from 'react'
+import { lazy, Suspense, useCallback, useMemo, useState } from 'react'
+import { toast } from 'sonner'
 import { useT } from '@memry/i18n/renderer'
+import { Focus, Image, PenTool } from '@/lib/icons'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { createLogger } from '@/lib/logger'
 import { nodeFromMindMapLink, type MindMapNodeActivation } from './mind-map-navigation'
+import { MindMapToolbar, type MindMapToolbarAction } from './mind-map-toolbar'
 import { MindMapTree } from './mind-map-tree'
+import type { MindMapControls } from './mind-map-canvas'
 import type { MindMap } from './mind-map-types'
+
+const log = createLogger('NoteMindMap')
 
 /**
  * Lazy for the same reason the canvas page is: @excalidraw/excalidraw and its
@@ -39,6 +62,51 @@ export function MindMapView({
   onActivateNode
 }: MindMapViewProps): React.JSX.Element {
   const { t } = useT('notes')
+  const [controls, setControls] = useState<MindMapControls | null>(null)
+
+  const copy = useCallback(
+    (run: () => Promise<void>, success: string): void => {
+      void run()
+        .then(() => toast.success(success))
+        .catch((err: unknown) => {
+          // Nothing disappears quietly: a copy that failed says so.
+          log.warn('Failed to copy the mind map', err)
+          toast.error(extractErrorMessage(err, t('mindMap.toolbar.copyFailed')))
+        })
+    },
+    [t]
+  )
+
+  const actions = useMemo<MindMapToolbarAction[]>(
+    () => [
+      {
+        id: 'fit',
+        label: t('mindMap.toolbar.fit'),
+        icon: Focus,
+        disabled: controls === null,
+        onSelect: () => controls?.fit()
+      },
+      {
+        id: 'copy-image',
+        label: t('mindMap.toolbar.copyImage'),
+        icon: Image,
+        disabled: controls === null,
+        onSelect: () => {
+          if (controls) copy(controls.copyImage, t('mindMap.toolbar.imageCopied'))
+        }
+      },
+      {
+        id: 'copy-vector',
+        label: t('mindMap.toolbar.copyVector'),
+        icon: PenTool,
+        disabled: controls === null,
+        onSelect: () => {
+          if (controls) copy(controls.copyVector, t('mindMap.toolbar.vectorCopied'))
+        }
+      }
+    ],
+    [controls, copy, t]
+  )
 
   // A click on the drawing arrives as the deep link of the box it landed on;
   // that is the only handle a bitmap surface gives us. Resolving it back to a
@@ -54,13 +122,19 @@ export function MindMapView({
 
   return (
     <div className="relative flex h-full w-full flex-col bg-background" data-testid="note-mind-map">
+      <MindMapToolbar actions={actions} label={t('mindMap.toolbar.label')} />
+
       <div
         role="img"
         aria-label={t('mindMap.regionLabel', { title: noteTitle, count: map.nodeCount })}
         className="relative min-h-0 flex-1"
       >
         <Suspense fallback={<div className="h-full w-full" aria-hidden="true" />}>
-          <LazyMindMapCanvas elements={map.elements} onOpenLink={handleOpenLink} />
+          <LazyMindMapCanvas
+            elements={map.elements}
+            onOpenLink={handleOpenLink}
+            onControlsChange={setControls}
+          />
         </Suspense>
       </div>
 

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -52,6 +52,10 @@ const mocks = vi.hoisted(() => ({
   editorBlocks: [] as unknown[],
   /** One entry per editor the mocked content area built. */
   editorInstances: [] as unknown[],
+  /** The controls the map surface hands up to its toolbar. */
+  mindMapFit: vi.fn(),
+  mindMapCopyImage: vi.fn(),
+  mindMapCopyVector: vi.fn(),
   onDeleted: vi.fn(),
   onUpdated: vi.fn(),
   onRenamed: vi.fn(),
@@ -265,29 +269,43 @@ vi.mock('@/hooks/use-feature-flags', () => ({
 vi.mock('@/components/note/mind-map/mind-map-canvas', () => ({
   MindMapCanvas: ({
     elements,
-    onOpenLink
+    onOpenLink,
+    onControlsChange
   }: {
     elements: Array<{ id: string; link?: string }>
     onOpenLink: (href: string) => void
-  }) => (
-    <div data-testid="mind-map-canvas" data-element-count={elements.length}>
-      {/* Excalidraw hands a click back as the link of the box it landed on —
-          in view mode the whole box is the hit area. Standing in for that is
-          all this needs to do; everything downstream of it is the real path. */}
-      {elements
-        .filter((element) => Boolean(element.link))
-        .map((element) => (
-          <button
-            key={element.id}
-            type="button"
-            data-testid={`mind-map-box-${element.id}`}
-            onClick={() => onOpenLink(element.link!)}
-          >
-            {element.link}
-          </button>
-        ))}
-    </div>
-  )
+    onControlsChange?: (controls: Record<string, unknown> | null) => void
+  }) => {
+    // The real surface hands its controls up once it is live and takes them
+    // back when it goes away; the toolbar is wired to nothing until it does.
+    useEffect(() => {
+      onControlsChange?.({
+        fit: mocks.mindMapFit,
+        copyImage: mocks.mindMapCopyImage,
+        copyVector: mocks.mindMapCopyVector
+      })
+      return () => onControlsChange?.(null)
+    }, [onControlsChange])
+    return (
+      <div data-testid="mind-map-canvas" data-element-count={elements.length}>
+        {/* Excalidraw hands a click back as the link of the box it landed on —
+            in view mode the whole box is the hit area. Standing in for that is
+            all this needs to do; everything downstream of it is the real path. */}
+        {elements
+          .filter((element) => Boolean(element.link))
+          .map((element) => (
+            <button
+              key={element.id}
+              type="button"
+              data-testid={`mind-map-box-${element.id}`}
+              onClick={() => onOpenLink(element.link!)}
+            >
+              {element.link}
+            </button>
+          ))}
+      </div>
+    )
+  }
 }))
 
 vi.mock('@/hooks/use-sidebar-navigation', () => ({
@@ -800,6 +818,8 @@ describe('NotePage', () => {
     mocks.spatialCanvasEnabled = true
     mocks.direction = 'ltr'
     mocks.editorInstances = []
+    mocks.mindMapCopyImage.mockResolvedValue(undefined)
+    mocks.mindMapCopyVector.mockResolvedValue(undefined)
     mocks.editorBlocks = [
       { id: 'b-intro', type: 'paragraph', content: [{ type: 'text', text: 'Preamble' }] },
       {
@@ -1649,6 +1669,34 @@ describe('NotePage', () => {
 
       const region = screen.getByRole('img')
       expect(region).toHaveAccessibleName('mindMap.regionLabel:{"title":"Test Note","count":3}')
+    })
+
+    it('keeps the map toolbar inside the map, and only while the map shows', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await screen.findByTestId('editor-content')
+      // Note mode: the map has no controls anywhere, because there is no map.
+      expect(screen.queryByTestId('mind-map-toolbar')).not.toBeInTheDocument()
+
+      const map = await openMap()
+      const toolbar = await screen.findByRole('toolbar', { name: 'mindMap.toolbar.label' })
+      // Inside the map area — never a second meaning for the note's own menu.
+      expect(map).toContainElement(toolbar)
+      expect(
+        within(toolbar)
+          .getAllByRole('button')
+          .map((b) => b.getAttribute('aria-label'))
+      ).toEqual(['mindMap.toolbar.fit', 'mindMap.toolbar.copyImage', 'mindMap.toolbar.copyVector'])
+
+      // Wired to the live surface, not to a rebuilt copy of the map.
+      fireEvent.click(screen.getByTestId('mind-map-toolbar-fit'))
+      expect(mocks.mindMapFit).toHaveBeenCalledTimes(1)
+      fireEvent.click(screen.getByTestId('mind-map-toolbar-copy-image'))
+      expect(mocks.mindMapCopyImage).toHaveBeenCalledTimes(1)
+      fireEvent.click(screen.getByTestId('mind-map-toolbar-copy-vector'))
+      expect(mocks.mindMapCopyVector).toHaveBeenCalledTimes(1)
+
+      fireEvent.click(screen.getByTestId('note-mind-map-toggle'))
+      await waitFor(() => expect(screen.queryByTestId('mind-map-toolbar')).not.toBeInTheDocument())
     })
 
     it('opens a note with no headings on the root alone, and keeps the toggle live', async () => {

--- a/apps/docs/src/user-guide/notes/mind-map.md
+++ b/apps/docs/src/user-guide/notes/mind-map.md
@@ -76,6 +76,27 @@ Nodes work from the keyboard too. Tab into the map, move between nodes with the
 up and down arrows (Home and End jump to the ends), and press Enter or Space to
 open the one you are on.
 
+## The Map's Own Toolbar
+
+A small toolbar sits at the top of the map, and only there — the note's overflow
+menu is never repurposed, so the same button in the same place always does the
+same thing.
+
+- **Fit to view** frames the whole map again after you have panned or zoomed.
+- **Copy as image** puts the map on the clipboard as a PNG, ready to paste into
+  a note, a message or a slide.
+- **Copy as vector** puts the map on the clipboard as SVG markup, which design
+  tools paste as editable artwork.
+
+Both copies contain the map **as you are looking at it**, so anything you have
+opened up in the map is in the copy too. They are exported on a transparent
+background and always in the map's light colours, so the same note copies the
+same way whichever app theme you are in. If a copy cannot be made, memrynote
+tells you rather than failing quietly.
+
+The map's camera is not remembered. Close the map and open it again and it
+frames the whole thing afresh — the same place **Fit to view** takes you.
+
 ## Coming Back to the Note
 
 Your work is exactly where you left it. The editor is only hidden while the map

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -976,6 +976,15 @@
       "embed": "{count, plural, one {# embed} other {# embeds}}",
       "bookmark": "{count, plural, one {# bookmark} other {# bookmarks}}",
       "file": "{count, plural, one {# file} other {# files}}"
+    },
+    "toolbar": {
+      "label": "Mind map actions",
+      "fit": "Fit to view",
+      "copyImage": "Copy as image",
+      "copyVector": "Copy as vector",
+      "imageCopied": "Map copied as an image",
+      "vectorCopied": "Map copied as vector artwork",
+      "copyFailed": "Failed to copy the map"
     }
   }
 }


### PR DESCRIPTION
Closes nothing — implements #1674 (part of #1667). Blocker #1669 is merged.

**Rebased onto `6abfaa5e0` (#1671), which itself sits on `a0b0feba2` (#1670).**

Onto #1670 — four conflicts, all resolved by keeping both intentions:

- `mind-map-canvas.tsx` — the surface now both forwards link opens (`onOpenLink`) **and** hands its controls up (`onControlsChange`). Neither prop replaced the other.
- `mind-map-view.tsx` — navigation wiring and the toolbar `actions` array both survive; `LazyMindMapCanvas` receives both props. The toolbar is still a **sibling** of the `role="img"` region, asserted by a test.
- `note.test.tsx` — the mocked surface stands in for both mechanisms: a button per linked element (#1670's click path) plus the control spies handed up in an effect (this PR's toolbar path).
- `mind-map.md` — both sections kept, "Clicking a Node" before "The Map's Own Toolbar".

Onto #1671 — one conflict:

- `packages/i18n/src/locales/en/notes.json` — `mindMap.badge.*` (#1671's content-counter strings) and `mindMap.toolbar.*` both land under `mindMap`. Resolved by hand and verified by parsing the file and asserting the exact key sets of both blocks, since this is the shape of merge that silently eats a brace. `note.test.tsx` and `mind-map.md` auto-merged and were checked by hand afterwards: the docs read "What Gets Drawn" → "Ticked Items" → "Tags and Counter Badges" → "Clicking a Node" → "The Map's Own Toolbar".

**Nothing of #1670's or #1671's changed to accommodate this PR.** #1671 renamed `MindMapEdgeElement` to `MindMapLineElement`, but that type is only named inside `mind-map-types.ts` and `mind-map-elements.ts`, neither of which this PR touches, so nothing here needed updating.

## What this adds

A small toolbar inside the map area with three controls: **Fit to view**, **Copy as image**, **Copy as vector**. It shows only while the map is showing. The note header's overflow menu is deliberately untouched and stays the note's menu in both modes.

## Two decisions worth reading

### 1. Canvas mount lifetime and viewport persistence — kept, not persisted

#1669 deviated from the spec by unmounting the drawing chunk on close, and flagged that this ticket had to decide the question once fit-to-view existed. **Decision: keep #1669's lifecycle, and do not persist the camera.** Reopening the map always frames the whole drawing.

- The map is a **derived view rebuilt from the note on every open**. A camera restored onto a redrawn map can point at coordinates the new drawing no longer uses. That is precisely the reasoning the spec used to refuse persisting the map's *expansion* state, and it applies unchanged here.
- The canvas page persists its viewport (`CANVAS_VIEWPORT_KEY`, `parseCanvasViewport`, `viewportFromAppState`) because a canvas is a durable document whose content is stable between visits. A mind map is not.
- Fit-to-view is a **recovery** action, not a preference. Every open already starts fitted, so reopening the map lands the camera exactly where Fit to view lands it. The state is one click from recovery, which does not justify a new `Tab.viewState` key with its own total parse and old-version tolerance.

Within one open session, panning and zooming survive normally — the surface is not remounted.

### 2. Clipboard formats — no new permission, no new IPC

The repo had no existing image-clipboard path (every `navigator.clipboard` call today is `writeText`). Both new paths stay inside the `clipboard-sanitized-write` permission `main/session-permissions.ts` already grants:

- **Copy as image** → `exportToBlob` → `navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])`. PNG is a well-known sanitized clipboard type.
- **Copy as vector** → `exportToSvg` → `navigator.clipboard.writeText(svg.outerHTML)`. `image/svg+xml` is not a sanitized type, and carrying it would mean widening a deny-by-default permission set for one button. Design tools paste SVG markup, and Excalidraw's own "copy as SVG" does exactly this.

No main-process channel was needed, so no IPC contract, migration, sync handler or settings schema is touched.

## Shape

- `mind-map-toolbar.tsx` — presentational, takes `actions: MindMapToolbarAction[]`. No drawing-library import, so it stays in the main bundle and renders in a plain test. **#1675 adds its save control as a fourth entry in that array** (built in `mind-map-view.tsx`), not as a new prop or slot.
- `mind-map-export.ts` — new, inside the lazy chunk; holds the two clipboard paths.
- `mind-map-canvas.tsx` — hands its controls up via `onControlsChange`, because everything they need is inside the lazy chunk while the toolbar must render as a **sibling** of the map's `role="img"` region (contents of an image role are presentational, so a toolbar nested there would be invisible to screen readers).
- `mind-map-view.tsx` — owns the strings, the toolbar placement and the error surfacing.

The toolbar is a flex row above the drawing rather than a pinned corner overlay: the drawing library pins its own islands to physical corners and does not mirror them for an RTL app, so a pinned cluster would collide in one reading direction or the other. `justify-end` follows the reading direction on its own.

Exports read the **live** scene (`getSceneElements()`), never a fresh `buildMindMap` call, so a copy contains branches #1673 will let the user expand. Export settings are pinned (transparent background, light mode, 2× scale) so the same note copies identically whatever the app theme is.

`buildMindMap` remains the one public entry point; nothing private was exported.

## Acceptance criteria

- [x] A toolbar inside the map area offers fit-to-view, copy as image, and copy as vector.
- [x] The toolbar appears only while the map is showing.
- [x] The header overflow menu is unchanged and remains the note's menu in both modes — #1669's `outerHTML` comparison across a toggle still passes, and no header file was touched.
- [x] Exports contain the map as currently drawn, including any expanded branches — asserted by giving the live surface a scene deliberately different from the elements the map was built from.
- [x] All toolbar labels and tooltips are translated (`notes:mindMap.toolbar.*`, ICU single braces). `i18n:check` green.
- [x] Tests assert the toolbar renders only in map mode and that export handlers receive the live drawing.

## What the tests prove, and what they cannot

`mind-map-view.test.tsx` is a real render of the real toolbar against the real English strings; only the drawing surface is stubbed. It proves the wiring, the translated labels and tooltips, the disabled state before the surface is live, that the toolbar is inside the map but outside its `role="img"`, and that a failed copy surfaces through `extractErrorMessage` rather than disappearing.

`mind-map-canvas.test.tsx` stubs the drawing library, which cannot rasterise or reach a clipboard under jsdom. It proves that an export reads the live scene rather than the built elements, that the export settings are pinned rather than inherited, and that a failure travels up to the host. **It cannot prove** that the bytes are a valid PNG or that a real clipboard accepts them — only a real browser can.

`note.test.tsx` proves through the whole note page that the toolbar is absent in note mode, present and wired in map mode, and gone again after toggling back.

## Gates

```
pnpm lint                → exit 0 · 108 problems (0 errors, 108 warnings), none in changed files
pnpm typecheck           → exit 0 · Tasks: 17 successful, 17 total
pnpm test                → exit 0 · no SIGSEGV, no fts-corruption flake
                             contracts      50 files / 1666 tests passed
                             editor-schema   3 files /   95 tests passed
                             i18n           11 files /   56 tests passed
                             sync-server    62 files /  966 tests passed
                             sync-harness    5 files /   32 tests passed
                             desktop      1376 files passed | 3 skipped (1379)
                                         17887 tests passed | 1 expected fail | 13 skipped (17901)
pnpm --filter @memry/desktop i18n:check
                         → exit 0 · "ok: i18n check passed"
pnpm docs:impact --base 6abfaa5e0 --strict
                         → exit 0 · "docs impact: covered" / "docs changed on this branch"
```

Bundle split re-verified against a real production renderer build of the rebased tree: the entry chunk `index-DxtWHd6J.js` (the one `index.html` loads) contains **zero** occurrences of `excalidraw`, while `copySceneAsImage`, `copySceneAsVector` and #1670's `onLinkOpen` all land together in the async `mind-map-canvas-BAMG1bxZ.js`.

Both post-rebase `pnpm test` runs were green first time.

## Deliberately out of scope

- Save as canvas (#1675) — the toolbar takes an action list so that lands as a fourth entry.
- Expanding branches (#1673) — exports already read the live scene, so they will pick it up with no change here.
- The drawing library's own menu island, still visible in the map. Removing it is a separate call about the read-only surface.


