### PR TITLE
feat(notes): branch wiki links off the mind map and open what they name (#1672)

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map-wiki-links.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map-wiki-links.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Wiki links as branches of their own, asserted through the single public entry
+ * point — a sibling of `build-mind-map.test.ts` rather than more of it, because
+ * that file is already at the size where nobody reads to the end.
+ *
+ * The rule under test throughout: a wiki link is not part of this note. It
+ * leaves the label that held it and becomes a leaf, exactly the way a hash tag
+ * leaves the label and becomes a badge.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { buildMindMap } from './build-mind-map'
+import type {
+  MindMapBoxElement,
+  MindMapNode,
+  MindMapPositionedNode,
+  MindMapSourceBlock
+} from './mind-map-types'
+
+/** The inline shape a `[[…]]` really has: content-less, text in props. */
+function wikiLink(target: string, alias?: string): Record<string, unknown> {
+  return { type: 'wikiLink', props: { target, alias: alias ?? '' } }
+}
+
+function text(value: string): Record<string, unknown> {
+  return { type: 'text', text: value }
+}
+
+function heading(id: string, level: number, content: unknown[]): MindMapSourceBlock {
+  return { id, type: 'heading', props: { level }, content }
+}
+
+function bullet(
+  id: string,
+  content: unknown[],
+  children?: MindMapSourceBlock[]
+): MindMapSourceBlock {
+  return { id, type: 'bulletListItem', content, children }
+}
+
+function paragraph(id: string, content: unknown[]): MindMapSourceBlock {
+  return { id, type: 'paragraph', content }
+}
+
+function childLabels(node: MindMapNode): string[] {
+  return node.children.map((child) => child.label)
+}
+
+function labelled(tree: MindMapNode, label: string): MindMapNode {
+  const found = [
+    tree,
+    ...tree.children.flatMap(function walk(node): MindMapNode[] {
+      return [node, ...node.children.flatMap(walk)]
+    })
+  ].find((node) => node.label === label)
+  if (!found) throw new Error(`no node labelled ${label}`)
+  return found
+}
+
+function positioned(map: ReturnType<typeof buildMindMap>, label: string): MindMapPositionedNode {
+  const found = map.nodes.find((node) => node.label === label)
+  if (!found) throw new Error(`no node labelled ${label}`)
+  return found
+}
+
+function boxFor(map: ReturnType<typeof buildMindMap>, label: string): MindMapBoxElement {
+  const id = positioned(map, label).id
+  const box = map.elements.find(
+    (element): element is MindMapBoxElement => element.type === 'rectangle' && element.id === id
+  )
+  if (!box) throw new Error(`no box for ${label}`)
+  return box
+}
+
+describe('buildMindMap — wiki links become nodes', () => {
+  it('branches a link written in a heading off that heading', () => {
+    const map = buildMindMap([heading('h', 1, [text('See '), wikiLink('Roadmap')])], {
+      rootLabel: 'Note'
+    })
+
+    // The words around it stay; the link itself is no longer part of them.
+    expect(childLabels(map.tree)).toEqual(['See'])
+    const section = labelled(map.tree, 'See')
+    expect(childLabels(section)).toEqual(['Roadmap'])
+    expect(section.children[0].kind).toBe('wikiLink')
+  })
+
+  it('branches a link written in a list item off that item', () => {
+    const map = buildMindMap(
+      [heading('h', 1, [text('Section')]), bullet('b', [text('Ask '), wikiLink('Priya')])],
+      { rootLabel: 'Note' }
+    )
+
+    const item = labelled(map.tree, 'Ask')
+    expect(item.kind).toBe('bullet')
+    expect(childLabels(item)).toEqual(['Priya'])
+    expect(item.children[0].kind).toBe('wikiLink')
+  })
+
+  it('branches a link written in a paragraph off the node the paragraph belongs to', () => {
+    const map = buildMindMap(
+      [
+        heading('h', 1, [text('Background')]),
+        paragraph('p', [text('Grew out of '), wikiLink('Old plan'), text(' last spring.')])
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    // The paragraph is still no node — but what it reaches is not lost with it.
+    expect(childLabels(labelled(map.tree, 'Background'))).toEqual(['Old plan'])
+    expect(map.nodeCount).toBe(3)
+  })
+
+  it('turns an item that is nothing but a link into the link itself', () => {
+    const map = buildMindMap(
+      [
+        heading('h', 1, [text('Projects')]),
+        bullet('b1', [wikiLink('Alpha')]),
+        bullet('b2', [wikiLink('Beta')])
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    // A list of links is a fan of links, never a fan of empty boxes each
+    // holding one.
+    const projects = labelled(map.tree, 'Projects')
+    expect(childLabels(projects)).toEqual(['Alpha', 'Beta'])
+    expect(projects.children.map((child) => child.kind)).toEqual(['wikiLink', 'wikiLink'])
+    expect(map.nodeCount).toBe(4)
+  })
+
+  it('shows the alias and opens the target', () => {
+    const map = buildMindMap([bullet('b', [wikiLink('2026-Q3-roadmap', 'the roadmap')])], {
+      rootLabel: 'Note'
+    })
+
+    const link = map.tree.children[0]
+    // What the note shows is what the map draws; what it opens is what was
+    // written, heading half and all.
+    expect(link.label).toBe('the roadmap')
+    expect(link.wikiTarget).toBe('2026-Q3-roadmap')
+  })
+
+  it('keeps the heading half of a target, which is where a link lands', () => {
+    const map = buildMindMap([bullet('b', [wikiLink('Roadmap#Q3')])], { rootLabel: 'Note' })
+
+    expect(map.tree.children[0].wikiTarget).toBe('Roadmap#Q3')
+  })
+
+  it('draws one node for a link repeated in the same block, and two for two readings of it', () => {
+    const repeated = buildMindMap([bullet('b', [wikiLink('Alpha'), wikiLink('Alpha')])], {
+      rootLabel: 'Note'
+    })
+    const aliased = buildMindMap(
+      [bullet('b', [wikiLink('Alpha', 'first'), wikiLink('Alpha', 'second')])],
+      { rootLabel: 'Note' }
+    )
+
+    expect(childLabels(repeated.tree)).toEqual(['Alpha'])
+    // Two different words for the same note are two things the note says.
+    expect(childLabels(aliased.tree)).toEqual(['first', 'second'])
+  })
+
+  it('is always a leaf, and never a place in this note', () => {
+    const map = buildMindMap(
+      [bullet('b', [text('Read '), wikiLink('Roadmap')], [bullet('b-kid', [text('Then this')])])],
+      { rootLabel: 'Note' }
+    )
+
+    const link = labelled(map.tree, 'Roadmap')
+    expect(link.children).toEqual([])
+    // Null on purpose: `blockId` is what a click navigates to, so a link
+    // carrying its sentence's block id would scroll to the sentence.
+    expect(link.blockId).toBeNull()
+    expect(link.level).toBeNull()
+    expect(link.isDone).toBe(false)
+    expect(link.taskId).toBeNull()
+  })
+
+  it('leaves every other node kind with no wiki target of its own', () => {
+    const map = buildMindMap(
+      [heading('h', 1, [text('Section')]), bullet('b', [text('Item '), wikiLink('Elsewhere')])],
+      { rootLabel: 'Note' }
+    )
+
+    for (const node of map.nodes) {
+      expect(node.wikiTarget).toBe(node.kind === 'wikiLink' ? 'Elsewhere' : null)
+    }
+  })
+
+  it('hands a link up when the heading that held it draws no box', () => {
+    const map = buildMindMap(
+      [
+        heading('a', 1, [text('Alpha')]),
+        heading('link-only', 2, [wikiLink('Roadmap')]),
+        heading('c', 2, [text('Gamma')])
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    // The heading had nothing of its own to say, so it folds the way a blank
+    // one does — but what it reached out to is still on the map.
+    const alpha = labelled(map.tree, 'Alpha')
+    expect(childLabels(alpha)).toEqual(['Roadmap', 'Gamma'])
+  })
+
+  it('reads a link inside a container against that container, not the note', () => {
+    const map = buildMindMap(
+      [
+        heading('h', 1, [text('Section')]),
+        {
+          id: 'cal',
+          type: 'callout',
+          content: [text('Watch out')],
+          children: [paragraph('p', [wikiLink('Incident log')])]
+        }
+      ],
+      { rootLabel: 'Note' }
+    )
+
+    expect(childLabels(labelled(map.tree, 'Watch out'))).toEqual(['Incident log'])
+  })
+
+  it('mints a link in document order, before the blocks written under it', () => {
+    const map = buildMindMap(
+      [bullet('b', [text('Ship '), wikiLink('v2')], [bullet('b-kid', [text('Sub-item')])])],
+      { rootLabel: 'Note' }
+    )
+
+    expect(childLabels(labelled(map.tree, 'Ship'))).toEqual(['v2', 'Sub-item'])
+  })
+})
+
+describe('buildMindMap — wiki links are drawn apart from the note', () => {
+  const map = buildMindMap(
+    [heading('h', 1, [text('Section')]), bullet('b', [text('Read '), wikiLink('Roadmap')])],
+    { rootLabel: 'Note', noteId: 'note-1' }
+  )
+
+  it('draws a link in its own colour and with a dashed outline', () => {
+    const link = boxFor(map, 'Roadmap')
+    const structure = boxFor(map, 'Section')
+
+    expect(link.strokeColor).not.toBe(structure.strokeColor)
+    expect(link.backgroundColor).not.toBe(structure.backgroundColor)
+    expect(link.label.strokeColor).not.toBe(structure.label.strokeColor)
+    // A second difference that survives colour blindness and a grey printout.
+    expect(link.strokeStyle).toBe('dashed')
+    expect(structure.strokeStyle).toBeUndefined()
+  })
+
+  it('gives a link box a handle of its own, never the one its sentence carries', () => {
+    const link = boxFor(map, 'Roadmap')
+    const sentence = boxFor(map, 'Read')
+
+    // In view mode the whole box is the link's hit area, so two boxes sharing
+    // one href would send a click to whichever came first.
+    expect(link.link).not.toBe(sentence.link)
+    expect(sentence.link).toBe('memry://note/note-1#^b')
+    expect(link.link).toBe(`memry://note/note-1#^${positioned(map, 'Roadmap').id}`)
+  })
+
+  it('keeps the href of every box unique', () => {
+    const hrefs = map.elements
+      .filter((element): element is MindMapBoxElement => element.type === 'rectangle')
+      .map((box) => box.link)
+
+    expect(new Set(hrefs).size).toBe(hrefs.length)
+  })
+})
+
+describe('buildMindMap — task nodes carry their task', () => {
+  it('carries the id a task block was written with', () => {
+    const map = buildMindMap(
+      [{ id: 'tb', type: 'taskBlock', props: { taskId: 't-7', title: 'Cut the build' } }],
+      { rootLabel: 'Note' }
+    )
+
+    const task = labelled(map.tree, 'Cut the build')
+    expect(task.kind).toBe('task')
+    expect(task.taskId).toBe('t-7')
+    // The block is still known: a task with no id has to land somewhere.
+    expect(task.blockId).toBe('tb')
+  })
+
+  it('says so rather than inventing one when the block carries none', () => {
+    const map = buildMindMap(
+      [{ id: 'tb', type: 'taskBlock', props: { taskId: '', title: 'Older build' } }],
+      { rootLabel: 'Note' }
+    )
+
+    expect(labelled(map.tree, 'Older build').taskId).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.test.ts
@@ -177,15 +177,16 @@ describe('buildMindMap — projection', () => {
           content: [
             { type: 'text', text: 'Ship ' },
             { type: 'link', href: 'https://memry.test', content: [{ type: 'text', text: 'v2' }] },
-            { type: 'text', text: ' with ' },
-            { type: 'wikiLink', props: { target: 'Roadmap', alias: 'the roadmap' } }
+            { type: 'text', text: ' with care' }
           ]
         }
       ],
       { rootLabel: 'Note' }
     )
 
-    expect(childLabels(map.tree)).toEqual(['Ship v2 with the roadmap'])
+    // A plain hyperlink is styling around text and stays in the label. A
+    // `[[wiki link]]` does not — see `build-mind-map-wiki-links.test.ts`.
+    expect(childLabels(map.tree)).toEqual(['Ship v2 with care'])
   })
 
   it('collapses whitespace but never translates or rewrites the label', () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
@@ -19,9 +19,13 @@ import type { MindMapDirection, MindMapElement, MindMapPositionedNode } from './
 
 /**
  * Authored for the light theme; the drawing library derives the dark one. Calm
- * and restrained on purpose — the map is a reading surface, not a chart. Three
- * treatments, not one per node kind: the title, the structure, and what is
- * already done.
+ * and restrained on purpose — the map is a reading surface, not a chart. Four
+ * treatments, not one per node kind: the title, the structure, what is already
+ * done, and what is not this note at all.
+ *
+ * A wiki link is drawn in a different colour AND with a dashed outline, so "a
+ * piece of this note" and "another document" stay distinguishable without
+ * colour vision.
  */
 const ROOT_STROKE = '#ff671a'
 const ROOT_FILL = '#fff1e8'
@@ -29,6 +33,10 @@ const NODE_STROKE = '#868e96'
 const NODE_FILL = '#ffffff'
 const LABEL_COLOR = '#1e1e1e'
 const EDGE_STROKE = '#adb5bd'
+/** A link out of the note. Blue is what a link has always been. */
+const LINK_STROKE = '#4c6ef5'
+const LINK_FILL = '#edf2ff'
+const LINK_LABEL = '#364fc7'
 /** Ticked items stay on the map and step back from it. */
 const DONE_STROKE = '#ced4da'
 const DONE_FILL = '#f8f9fa'
@@ -38,16 +46,29 @@ const ROUNDNESS = { type: 3 }
 
 /**
  * The deep link a box carries, or `undefined` when there is no note to point
- * at. The root has no block of its own — it is the note's title — so its link
- * carries no anchor, which reads as "this note, from the top".
+ * at.
+ *
+ * Every box needs a link of its OWN, because the link is the only handle a
+ * click on a bitmap has: two boxes sharing one would send a click to whichever
+ * came first. So:
+ *
+ * - a box standing for a block anchors on that block;
+ * - the root has no block — it is the note's title — so it carries no anchor,
+ *   which reads as "this note, from the top";
+ * - a wiki-link box has no block either, so it anchors on its own node id,
+ *   which is minted from the block that held the link and lives exactly as
+ *   long. Where the link actually goes is `wikiTarget` on the node, not this
+ *   href: a wiki target is a title, and turning one into a note id is a
+ *   database lookup this pure pipeline cannot do.
  */
 function nodeLink(node: MindMapPositionedNode, noteId: string | undefined): string | undefined {
   if (!noteId) return undefined
+  const anchorId = node.blockId ?? (node.kind === 'root' ? null : node.id)
   return (
     buildMemryHref({
       kind: 'note',
       id: noteId,
-      anchor: node.blockId ? { type: 'block', id: node.blockId } : null
+      anchor: anchorId ? { type: 'block', id: anchorId } : null
     }) ?? undefined
   )
 }
@@ -130,6 +151,7 @@ export function mintElements(
 
   for (const node of nodes) {
     const isRoot = node.kind === 'root'
+    const isLink = node.kind === 'wikiLink'
     elements.push({
       type: 'rectangle',
       id: node.id,
@@ -138,18 +160,31 @@ export function mintElements(
       y: node.y,
       width: node.width,
       height: node.height,
-      strokeColor: isRoot ? ROOT_STROKE : node.isDone ? DONE_STROKE : NODE_STROKE,
-      backgroundColor: isRoot ? ROOT_FILL : node.isDone ? DONE_FILL : NODE_FILL,
+      strokeColor: isRoot
+        ? ROOT_STROKE
+        : isLink
+          ? LINK_STROKE
+          : node.isDone
+            ? DONE_STROKE
+            : NODE_STROKE,
+      backgroundColor: isRoot
+        ? ROOT_FILL
+        : isLink
+          ? LINK_FILL
+          : node.isDone
+            ? DONE_FILL
+            : NODE_FILL,
       fillStyle: 'solid',
       strokeWidth: 1,
       roughness: 0,
       roundness: ROUNDNESS,
+      ...(isLink && { strokeStyle: 'dashed' as const }),
       label: {
         text: boxText(node),
         fontSize: MIND_MAP_FONT_SIZE,
         textAlign: direction === 'rtl' ? 'right' : 'left',
         verticalAlign: 'middle',
-        strokeColor: node.isDone ? DONE_LABEL : LABEL_COLOR
+        strokeColor: isLink ? LINK_LABEL : node.isDone ? DONE_LABEL : LABEL_COLOR
       }
     })
   }

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-inline.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-inline.ts
@@ -1,10 +1,11 @@
 /**
- * Private helper — a block's inline content becomes a label and its tags.
+ * Private helper — a block's inline content becomes a label, its tags and the
+ * wiki links written inside it.
  *
- * Not exported outside this directory. Two things come out of one walk because
- * they are decided by the same pass: a hash tag becomes a badge on the node, so
- * it must leave the label at exactly the point it is collected, or the tag
- * would be shown twice.
+ * Not exported outside this directory. Three things come out of one walk
+ * because they are decided by the same pass: a hash tag becomes a badge and a
+ * wiki link becomes a node of its own, so both must leave the label at exactly
+ * the point they are collected, or each would be shown twice.
  *
  * Every inline spec Memry registers is content-less (`content: 'none'`) and
  * keeps its visible text in props, so the reader below is prop-driven rather
@@ -14,15 +15,15 @@
 /**
  * Where a content-less inline spec keeps its text, best first.
  *
- * - `wikiLink` → `alias`, else `target`
  * - `linkMention` → `title`, else `domain`, else `url`
  * - `inlineImage` → `alt` (a picture with no alt text contributes nothing)
  * - `dateMention` → `dateISO`, the only date form available without the
  *   renderer's clock and week-start settings
  *
- * `hashTag`'s `tag` is deliberately absent: a tag is a badge, not label text.
+ * `hashTag`'s `tag` and `wikiLink`'s `target`/`alias` are deliberately absent:
+ * a tag is a badge and a wiki link is a branch, neither is label text.
  */
-const INLINE_LABEL_PROPS = ['alias', 'target', 'title', 'alt', 'domain', 'url', 'dateISO'] as const
+const INLINE_LABEL_PROPS = ['title', 'alt', 'domain', 'url', 'dateISO'] as const
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
@@ -37,16 +38,28 @@ export function stringProp(props: unknown, key: string): string | null {
   return trimmed === '' ? null : trimmed
 }
 
+/** One `[[wiki link]]`, as the map needs to draw it and to open it. */
+export interface InlineWikiLink {
+  /** The target exactly as written — `Roadmap`, `Roadmap#Q3`, `diagram.pdf`. */
+  target: string
+  /** What the note shows for it: its alias when it has one, else the target. */
+  label: string
+}
+
 export interface InlineRead {
   text: string
   /** In document order, first occurrence wins, `#` already stripped. */
   tags: string[]
+  /** In document order, first occurrence of each target-and-label pair wins. */
+  links: InlineWikiLink[]
 }
 
-/** Total: any inline shape in, a label and its tags out. */
+/** Total: any inline shape in, a label, its tags and its wiki links out. */
 export function readInline(value: unknown): InlineRead {
   const tags: string[] = []
   const seen = new Set<string>()
+  const links: InlineWikiLink[] = []
+  const seenLinks = new Set<string>()
 
   const walk = (node: unknown): string => {
     if (typeof node === 'string') return node
@@ -64,6 +77,24 @@ export function readInline(value: unknown): InlineRead {
       return ''
     }
 
+    // A wiki link leaves the label here and reappears as a node of its own. The
+    // pair is what dedupes, not the target alone: `[[A|first]]` and
+    // `[[A|second]]` in one sentence are two things the note says.
+    if (node.type === 'wikiLink') {
+      const target = stringProp(node.props, 'target')
+      if (target !== null) {
+        const label = stringProp(node.props, 'alias') ?? target
+        // A separator no target or alias can contain, so `[[A B|C]]` and
+        // `[[A|B C]]` stay two distinct links rather than one.
+        const signature = `${target}\u0000${label}`
+        if (!seenLinks.has(signature)) {
+          seenLinks.add(signature)
+          links.push({ target, label })
+        }
+      }
+      return ''
+    }
+
     if (typeof node.text === 'string') return node.text
     if (node.content !== undefined) return walk(node.content)
 
@@ -74,7 +105,7 @@ export function readInline(value: unknown): InlineRead {
     return ''
   }
 
-  return { text: walk(value), tags }
+  return { text: walk(value), tags, links }
 }
 
 /** Collapses runs of whitespace so a wrapped label measures predictably. */

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-layout.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-layout.ts
@@ -138,6 +138,8 @@ export function layoutMindMap(
       level: item.node.level,
       depth: item.node.depth,
       isDone: item.node.isDone,
+      taskId: item.node.taskId,
+      wikiTarget: item.node.wikiTarget,
       tags: item.node.tags,
       contents: item.node.contents,
       detail: item.node.detail,

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.test.ts
@@ -6,10 +6,19 @@
 import { describe, expect, it, vi } from 'vitest'
 import { buildMindMap } from './build-mind-map'
 import { activateMindMapNode, nodeFromMindMapLink } from './mind-map-navigation'
-import type { MindMapPositionedNode, MindMapSourceBlock } from './mind-map-types'
+import type { MindMapBoxElement, MindMapPositionedNode, MindMapSourceBlock } from './mind-map-types'
 
 function heading(id: string, level: number, text: string): MindMapSourceBlock {
   return { id, type: 'heading', props: { level }, content: [{ type: 'text', text }] }
+}
+
+/** Every action a node can ask for, so a test asserts what was NOT called too. */
+function actions() {
+  return {
+    navigateToBlock: vi.fn<(blockId: string | null) => void>(),
+    openNote: vi.fn<(wikiTarget: string) => void>(),
+    openTask: vi.fn<(taskId: string) => void>()
+  }
 }
 
 const blocks = [heading('b-alpha', 1, 'Alpha'), heading('b-beta', 2, 'Beta')]
@@ -23,19 +32,19 @@ function node(label: string): MindMapPositionedNode {
 
 describe('activateMindMapNode', () => {
   it('sends a heading node to its own block', () => {
-    const navigateToBlock = vi.fn()
-    activateMindMapNode(node('Alpha'), { navigateToBlock })
-    expect(navigateToBlock).toHaveBeenCalledWith('b-alpha')
+    const acted = actions()
+    activateMindMapNode(node('Alpha'), acted)
+    expect(acted.navigateToBlock).toHaveBeenCalledWith('b-alpha')
   })
 
   it('sends the root node to the top of the note', () => {
-    const navigateToBlock = vi.fn()
-    activateMindMapNode(node('Test Note'), { navigateToBlock })
+    const acted = actions()
+    activateMindMapNode(node('Test Note'), acted)
     // Null, not a block id: the root stands for the title, which is not a block.
-    expect(navigateToBlock).toHaveBeenCalledWith(null)
+    expect(acted.navigateToBlock).toHaveBeenCalledWith(null)
   })
 
-  it('sends every other node kind to its own block, the way a heading goes', () => {
+  it('sends every structural node kind to its own block, the way a heading goes', () => {
     // The dispatch switches against a `never`, so this is the assertion that a
     // kind added to the map was actually given a behaviour rather than a case
     // that silently does nothing.
@@ -44,7 +53,6 @@ describe('activateMindMapNode', () => {
         { id: 'b-bullet', type: 'bulletListItem', content: [{ type: 'text', text: 'Bullet' }] },
         { id: 'b-number', type: 'numberedListItem', content: [{ type: 'text', text: 'Numbered' }] },
         { id: 'b-check', type: 'checkListItem', content: [{ type: 'text', text: 'Check' }] },
-        { id: 'b-task', type: 'taskBlock', props: { taskId: 't-1', title: 'Task' } },
         { id: 'b-toggle', type: 'toggleListItem', content: [{ type: 'text', text: 'Toggle' }] },
         { id: 'b-callout', type: 'callout', content: [{ type: 'text', text: 'Callout' }] }
       ],
@@ -54,21 +62,75 @@ describe('activateMindMapNode', () => {
     const landed = structured.nodes
       .filter((candidate) => candidate.kind !== 'root')
       .map((candidate) => {
-        const navigateToBlock = vi.fn()
-        activateMindMapNode(candidate, { navigateToBlock })
-        return [candidate.kind, navigateToBlock.mock.calls]
+        const acted = actions()
+        activateMindMapNode(candidate, acted)
+        return [candidate.kind, acted.navigateToBlock.mock.calls]
       })
 
     expect(landed).toEqual([
       ['bullet', [['b-bullet']]],
       ['numbered', [['b-number']]],
       ['check', [['b-check']]],
-      // A task lands on its block until it carries a task id (#1672); it must
-      // not silently do nothing in the meantime.
-      ['task', [['b-task']]],
       ['toggle', [['b-toggle']]],
       ['callout', [['b-callout']]]
     ])
+  })
+
+  it('opens the task a task node stands for, rather than the block that mentions it', () => {
+    const tasks = buildMindMap(
+      [{ id: 'b-task', type: 'taskBlock', props: { taskId: 't-1', title: 'Task' } }],
+      { rootLabel: 'Test Note', noteId: 'note-1' }
+    )
+    const acted = actions()
+
+    activateMindMapNode(
+      tasks.nodes.find((candidate) => candidate.kind === 'task')!,
+      acted
+    )
+
+    expect(acted.openTask).toHaveBeenCalledWith('t-1')
+    expect(acted.navigateToBlock).not.toHaveBeenCalled()
+  })
+
+  it('lands a task block written before task ids on its own block instead', () => {
+    const tasks = buildMindMap(
+      [{ id: 'b-task', type: 'taskBlock', props: { taskId: '', title: 'Task' } }],
+      { rootLabel: 'Test Note', noteId: 'note-1' }
+    )
+    const acted = actions()
+
+    activateMindMapNode(
+      tasks.nodes.find((candidate) => candidate.kind === 'task')!,
+      acted
+    )
+
+    // Doing nothing is not an option: a node that draws has to go somewhere.
+    expect(acted.navigateToBlock).toHaveBeenCalledWith('b-task')
+    expect(acted.openTask).not.toHaveBeenCalled()
+  })
+
+  it('opens the note a wiki-link node names, and scrolls nowhere', () => {
+    const linked = buildMindMap(
+      [
+        {
+          id: 'b-item',
+          type: 'bulletListItem',
+          content: [{ type: 'wikiLink', props: { target: 'Roadmap#Q3', alias: 'the plan' } }]
+        }
+      ],
+      { rootLabel: 'Test Note', noteId: 'note-1' }
+    )
+    const acted = actions()
+
+    activateMindMapNode(
+      linked.nodes.find((candidate) => candidate.kind === 'wikiLink')!,
+      acted
+    )
+
+    // The target as written, heading half and all: the note page's own
+    // wiki-link handler is what reads it, exactly as it reads one in the body.
+    expect(acted.openNote).toHaveBeenCalledWith('Roadmap#Q3')
+    expect(acted.navigateToBlock).not.toHaveBeenCalled()
   })
 
   it('lands a drawn box and its tree twin on the very same call', () => {
@@ -77,16 +139,14 @@ describe('activateMindMapNode', () => {
       .filter((element) => element.type === 'rectangle')
       .find((element) => element.id === beta.id)!
 
-    const fromTree = vi.fn()
-    const fromDrawing = vi.fn()
-    activateMindMapNode(beta, { navigateToBlock: fromTree })
-    activateMindMapNode(nodeFromMindMapLink(box.link!, map.nodes, 'note-1')!, {
-      navigateToBlock: fromDrawing
-    })
+    const fromTree = actions()
+    const fromDrawing = actions()
+    activateMindMapNode(beta, fromTree)
+    activateMindMapNode(nodeFromMindMapLink(box.link!, map.nodes, 'note-1')!, fromDrawing)
 
     // Two projections of one layout, one activation: the picture cannot grow a
     // navigation behaviour the tree does not have.
-    expect(fromDrawing.mock.calls).toEqual(fromTree.mock.calls)
+    expect(fromDrawing.navigateToBlock.mock.calls).toEqual(fromTree.navigateToBlock.mock.calls)
   })
 })
 
@@ -110,9 +170,38 @@ describe('nodeFromMindMapLink', () => {
     }
   })
 
+  it('resolves a wiki-link box through the node id its href was minted with', () => {
+    const linked = buildMindMap(
+      [
+        {
+          id: 'b-item',
+          type: 'bulletListItem',
+          content: [
+            { type: 'text', text: 'Read ' },
+            { type: 'wikiLink', props: { target: 'R' } }
+          ]
+        }
+      ],
+      { rootLabel: 'Test Note', noteId: 'note-1' }
+    )
+    const link = linked.nodes.find((candidate) => candidate.kind === 'wikiLink')!
+    const box = linked.elements.find(
+      (element): element is MindMapBoxElement =>
+        element.type === 'rectangle' && element.id === link.id
+    )!
+
+    // Its sentence's box and its own carry different hrefs, so a click on the
+    // link cannot resolve to the sentence that holds it.
+    expect(nodeFromMindMapLink(box.link!, linked.nodes, 'note-1')).toBe(link)
+    expect(nodeFromMindMapLink('memry://note/note-1#^b-item', linked.nodes, 'note-1')?.kind).toBe(
+      'bullet'
+    )
+  })
+
   it('refuses a link into another note', () => {
     // Answering with this map's root would send the user somewhere they never
-    // clicked. Opening the other note is a later ticket's job, not this one's.
+    // clicked — and no box in this map ever carries one: a wiki-link box points
+    // at its own node here, and WHERE that node goes is `wikiTarget` on it.
     expect(nodeFromMindMapLink('memry://note/other#^b-beta', map.nodes, 'note-1')).toBeNull()
   })
 

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.ts
@@ -15,9 +15,12 @@ import { parseMemryHref } from '@/lib/memry-links'
 import type { MindMapPositionedNode } from './mind-map-types'
 
 /**
- * Everything a node can ask the note page to do. It has one member today
- * because every kind the map draws is a place in THIS note; opening another
- * note (a wiki-link node) and opening a task join it with their own kinds.
+ * Everything a node can ask the note page to do.
+ *
+ * Three members rather than one widened one: a node kind that opens something
+ * else is not a block navigation with a different argument, and collapsing
+ * them would let a caller wire the wrong destination without the compiler
+ * noticing.
  */
 export interface MindMapNodeActions {
   /**
@@ -25,6 +28,19 @@ export interface MindMapNodeActions {
    * note — the root node stands for the title, which is not a block.
    */
   navigateToBlock: (blockId: string | null) => void
+  /**
+   * Open the note (or file) a `[[wiki link]]` names, given the target exactly
+   * as it was written.
+   *
+   * A target, not an id, because that is what the note page's own wiki-link
+   * handler takes: the map is deliberately routed through it so a link opens
+   * the way it does everywhere else, honouring the open-in-new-tab preference
+   * the user already set. A surface that opens notes differently from every
+   * other surface becomes a bug report months later.
+   */
+  openNote: (wikiTarget: string) => void
+  /** Open a task, through the note page's own task-opening path. */
+  openTask: (taskId: string) => void
 }
 
 /** Called with the node the user activated, however they reached it. */
@@ -40,17 +56,28 @@ export function activateMindMapNode(
     case 'bullet':
     case 'numbered':
     case 'check':
-    case 'task':
     case 'toggle':
     case 'callout':
-      // Every kind the map draws is a place in this note, so they all land the
-      // same way: the granularity the user sees is the granularity they get
-      // back. The root's `blockId` is null, which already reads as "the top of
-      // the note" — one branch, not two, because a node's block IS what it
-      // navigates to. A task will open its task instead once it carries a task
-      // id (#1672); until it does, its block is the honest answer and doing
-      // nothing is not.
+      // Every kind here is a place in this note, so they all land the same way:
+      // the granularity the user sees is the granularity they get back. The
+      // root's `blockId` is null, which already reads as "the top of the note"
+      // — one branch, not two, because a node's block IS what it navigates to.
       actions.navigateToBlock(node.blockId)
+      return
+    case 'task':
+      // A task node opens its task (#1667). #1671 shipped it landing on its
+      // block instead, naming this ticket as the one that changes it: that
+      // wording was about sharing one activation mechanism, not about the
+      // destination. A task block written before task ids existed still has
+      // none, and for that one its block is the honest answer.
+      if (node.taskId) actions.openTask(node.taskId)
+      else actions.navigateToBlock(node.blockId)
+      return
+    case 'wikiLink':
+      // Not a place in this note at all, so it never touches the map's
+      // scrolling path. An empty target mints no node, so the guard is only
+      // ever a guard.
+      if (node.wikiTarget) actions.openNote(node.wikiTarget)
       return
     default: {
       // Compile-time only. A kind added to the map without a case here fails to
@@ -69,9 +96,16 @@ export function activateMindMapNode(
  * rather than by string surgery, so the one grammar keeps working — an anchor
  * form this build cannot place resolves to no node instead of the wrong one.
  *
- * Null for a link that is not a place in THIS note. A link to another note is
- * not this map's business, and answering it with this map's root would send the
- * user somewhere they did not click.
+ * A box that stands for a block resolves through its block; one that has no
+ * block of its own — a wiki link — resolves through its node id, which is what
+ * its href was minted with. Blocks are tried first, so an id that could somehow
+ * be both still means what it has always meant.
+ *
+ * Null for a link that is not a place in THIS map. A link naming another note
+ * is not one of these boxes: a wiki-link box points at its own node here, and
+ * WHERE that node goes is `wikiTarget` on it, read by `activateMindMapNode`.
+ * Answering an unknown link with this map's root would send the user somewhere
+ * they did not click.
  */
 export function nodeFromMindMapLink(
   href: string,
@@ -84,5 +118,9 @@ export function nodeFromMindMapLink(
   const anchor = parsed.anchor
   if (!anchor) return nodes.find((node) => node.kind === 'root') ?? null
   if (anchor.type !== 'block') return null
-  return nodes.find((node) => node.blockId === anchor.id) ?? null
+  return (
+    nodes.find((node) => node.blockId === anchor.id) ??
+    nodes.find((node) => node.id === anchor.id) ??
+    null
+  )
 }

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-projection.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-projection.ts
@@ -2,7 +2,7 @@
  * Private step 1 — an editor block tree becomes a logical mind-map tree.
  *
  * Not exported outside this directory: `buildMindMap` is the only seam, so this
- * file is free to change shape as later tickets add wiki links and caps.
+ * file is free to change shape as later tickets add caps.
  *
  * Two hierarchy mechanisms are merged in one pass, and they work nothing alike:
  *
@@ -21,9 +21,15 @@
  * not — but content is never silently invisible. A toggle really holds
  * children, so flattening it would destroy something the user wrote; a table is
  * content, so it is counted on the nearest node instead of being drawn.
+ *
+ * A wiki link is the one thing here that is not part of this note at all. It
+ * leaves the label of whatever held it and becomes a leaf of its own, the same
+ * way a hash tag leaves the label and becomes a badge — a link points at
+ * another document, and that is a branch rather than a word in a sentence.
  */
 
 import { normalizeLabel, readInline, stringProp, isRecord } from './mind-map-inline'
+import type { InlineWikiLink } from './mind-map-inline'
 import type {
   MindMapContentCount,
   MindMapContentKind,
@@ -118,6 +124,11 @@ function listStart(props: unknown): number | null {
  * - A block with nothing to show — no text and no tags — draws no box and does
  *   not join the level stack; whatever sits under it folds up to the nearest
  *   ancestor that does have something to show, rather than disappearing.
+ * - A wiki link becomes a leaf under the node its block belongs to, wherever it
+ *   was written: a heading, a list item, or a paragraph that is no node itself.
+ *   A block whose only content was its links therefore hands them straight to
+ *   its own parent, so a bullet list of links is a fan of links and not a fan
+ *   of empty boxes each holding one.
  */
 export function projectBlocks(
   blocks: readonly MindMapSourceBlock[],
@@ -131,6 +142,8 @@ export function projectBlocks(
     level: null,
     depth: 0,
     isDone: false,
+    taskId: null,
+    wikiTarget: null,
     tags: [],
     contents: [],
     detail: '',
@@ -156,6 +169,43 @@ export function projectBlocks(
     const counts = tallies.get(node) ?? new Map<MindMapContentKind, number>()
     counts.set(kind, (counts.get(kind) ?? 0) + 1)
     tallies.set(node, counts)
+  }
+
+  /**
+   * One leaf per wiki link written in a block, under whatever node that block
+   * belongs to — the block's own node when it minted one, otherwise the node
+   * the block itself would have hung from.
+   *
+   * Always a leaf: what is inside the note a link names is the graph view's
+   * question, not this one's.
+   *
+   * `blockId` is null on purpose. A wiki link is a run of inline content and
+   * not a block; and `blockId` is what a click navigates TO, so a link sharing
+   * its sentence's block id would send a click on the link to the sentence.
+   * What the link opens is carried in `wikiTarget` instead.
+   */
+  const addLinks = (
+    parent: MindMapNode,
+    blockId: string,
+    links: readonly InlineWikiLink[]
+  ): void => {
+    links.forEach((link, index) => {
+      parent.children.push({
+        id: mintId(`${blockId}-link-${index + 1}`),
+        blockId: null,
+        label: link.label,
+        kind: 'wikiLink',
+        level: null,
+        depth: parent.depth + 1,
+        isDone: false,
+        taskId: null,
+        wikiTarget: link.target,
+        tags: [],
+        contents: [],
+        detail: '',
+        children: []
+      })
+    })
   }
 
   /**
@@ -186,6 +236,10 @@ export function projectBlocks(
       if (kind === undefined) {
         const contentKind = CONTENT_KINDS.get(block.type)
         if (contentKind !== undefined) tally(parentIn(scope), contentKind)
+        // A paragraph is never a node, but a wiki link written in one is still
+        // somewhere this note reaches, so it branches off the node the
+        // paragraph belongs to rather than being lost with it.
+        addLinks(parentIn(scope), block.id, readInline(block.content).links)
         // Paragraphs, dividers and anything unregistered contribute no node and
         // never re-parent what is inside them.
         visitBlocks(block.children ?? [], scope)
@@ -195,13 +249,15 @@ export function projectBlocks(
       // A `taskBlock` has no inline content; its text is a prop.
       const read =
         kind === 'task'
-          ? { text: stringProp(block.props, 'title') ?? '', tags: [] }
+          ? { text: stringProp(block.props, 'title') ?? '', tags: [], links: [] }
           : readInline(block.content)
       const text = normalizeLabel(read.text)
 
       // Nothing to show: no box, no level-stack entry, and its children fold up
-      // to whatever this block's own parent was.
+      // to whatever this block's own parent was. Its links fold up with them —
+      // `- [[Roadmap]]` is a branch to Roadmap, not an empty box holding one.
       if (text === '' && read.tags.length === 0) {
+        addLinks(parentIn(scope), block.id, read.links)
         visitBlocks(block.children ?? [], scope)
         continue
       }
@@ -222,6 +278,11 @@ export function projectBlocks(
         level,
         depth: parent.depth + 1,
         isDone: (kind === 'check' || kind === 'task') && isChecked(block.props),
+        // Carried so activating a task node opens the task rather than the
+        // block that mentions it (#1667). A task block written by a build that
+        // never set one has none, and the node says so rather than inventing it.
+        taskId: kind === 'task' ? stringProp(block.props, 'taskId') : null,
+        wikiTarget: null,
         tags: read.tags,
         contents: [],
         detail: '',
@@ -230,6 +291,9 @@ export function projectBlocks(
       parent.children.push(node)
       if (level !== null) scope.stack.push({ level, node })
 
+      // The links written in this block come before the blocks written inside
+      // it, which is the order the note reads in.
+      addLinks(node, block.id, read.links)
       visitBlocks(block.children ?? [], { container: node, stack: [] })
     }
   }

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.test.tsx
@@ -22,9 +22,29 @@ const map = buildMindMap(
   { rootLabel: 'Test Note', noteId: 'note-1' }
 )
 
+/** Kept apart so the arrow-key walk above stays the shape it was written for. */
+const linkedMap = buildMindMap(
+  [
+    heading('b-alpha', 1, 'Alpha'),
+    {
+      id: 'b-item',
+      type: 'bulletListItem',
+      content: [{ type: 'wikiLink', props: { target: 'Roadmap#Q3', alias: 'the plan' } }]
+    }
+  ],
+  { rootLabel: 'Test Note', noteId: 'note-1' }
+)
+
 function renderTree(): { onActivateNode: ReturnType<typeof vi.fn>; items: HTMLElement[] } {
   const onActivateNode = vi.fn()
-  render(<MindMapTree nodes={map.nodes} label="Map of Test Note" onActivateNode={onActivateNode} />)
+  render(
+    <MindMapTree
+      nodes={map.nodes}
+      label="Map of Test Note"
+      linkHint="link to another page"
+      onActivateNode={onActivateNode}
+    />
+  )
   const items = within(screen.getByRole('tree')).getAllByRole('treeitem')
   return { onActivateNode, items }
 }
@@ -104,6 +124,41 @@ describe('MindMapTree', () => {
     // Tabbing away and back returns the user to where they were, not to the top.
     expect(itemFor(items, 'Alpha').tabIndex).toBe(0)
     expect(root.tabIndex).toBe(-1)
+  })
+
+  it('says a wiki-link node leaves the note, and activates it like any other', () => {
+    const onActivateNode = vi.fn()
+    render(
+      <MindMapTree
+        nodes={linkedMap.nodes}
+        label="Map of Test Note"
+        linkHint="link to another page"
+        onActivateNode={onActivateNode}
+      />
+    )
+    const node = linkedMap.nodes.find((candidate) => candidate.kind === 'wikiLink')!
+    const item = screen
+      .getByRole('tree')
+      .querySelector<HTMLElement>(`[data-mind-map-node="${node.id}"]`)!
+
+    // The picture says this with a colour and a dashed outline; a reader of
+    // this tree cannot see either, so it is said in words.
+    expect(item).toHaveTextContent('the plan link to another page')
+    expect(item).toHaveAttribute('data-mind-map-kind', 'wikiLink')
+    // A leaf: no group, and nothing to expand.
+    expect(item).not.toHaveAttribute('aria-expanded')
+    expect(item).not.toHaveAttribute('aria-checked')
+
+    fireEvent.keyDown(item, { key: 'Enter' })
+    fireEvent.click(item)
+
+    expect(onActivateNode).toHaveBeenCalledTimes(2)
+    expect(onActivateNode.mock.calls[0]).toEqual(onActivateNode.mock.calls[1])
+    expect(onActivateNode.mock.calls[0][0]).toMatchObject({
+      kind: 'wikiLink',
+      wikiTarget: 'Roadmap#Q3',
+      blockId: null
+    })
   })
 
   it('does not activate anything on an arrow key', () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.tsx
@@ -30,6 +30,12 @@ interface MindMapTreeProps {
   nodes: readonly MindMapPositionedNode[]
   /** Translated; names the note the tree belongs to. */
   label: string
+  /**
+   * Translated; says that a wiki-link node leaves this note. The drawing says
+   * it with a colour and a dashed outline, which a reader of this tree cannot
+   * see, so it is said in words here instead.
+   */
+  linkHint: string
   /** Called with the node the user clicked or pressed Enter/Space on. */
   onActivateNode: MindMapNodeActivation
 }
@@ -62,6 +68,7 @@ function BranchItems({
   branches,
   level,
   activeId,
+  linkHint,
   onActivate,
   onFocusNode,
   onNavigate
@@ -69,6 +76,7 @@ function BranchItems({
   branches: Branch[]
   level: number
   activeId: string | null
+  linkHint: string
   onActivate: MindMapNodeActivation
   onFocusNode: (nodeId: string) => void
   onNavigate: (key: string, nodeId: string) => void
@@ -118,6 +126,8 @@ function BranchItems({
           }}
         >
           <span>{branch.node.label}</span>
+          {/* What the dashed blue box says to everyone who can see it. */}
+          {branch.node.kind === 'wikiLink' && <span> {linkHint}</span>}
           {/* The same composed badge line the picture draws — one string, two
               projections, so they cannot say different things. */}
           {branch.node.detail !== '' && <span> {branch.node.detail}</span>}
@@ -127,6 +137,7 @@ function BranchItems({
                 branches={branch.children}
                 level={level + 1}
                 activeId={activeId}
+                linkHint={linkHint}
                 onActivate={onActivate}
                 onFocusNode={onFocusNode}
                 onNavigate={onNavigate}
@@ -139,7 +150,12 @@ function BranchItems({
   )
 }
 
-export function MindMapTree({ nodes, label, onActivateNode }: MindMapTreeProps): React.JSX.Element {
+export function MindMapTree({
+  nodes,
+  label,
+  linkHint,
+  onActivateNode
+}: MindMapTreeProps): React.JSX.Element {
   const treeRef = useRef<HTMLUListElement>(null)
   // Which item holds the single tab stop. It follows focus, so tabbing away and
   // back returns to where the user was rather than to the top. Seeded with the
@@ -184,6 +200,7 @@ export function MindMapTree({ nodes, label, onActivateNode }: MindMapTreeProps):
         branches={branches}
         level={1}
         activeId={activeId}
+        linkHint={linkHint}
         onActivate={onActivateNode}
         onFocusNode={onFocusNode}
         onNavigate={onNavigate}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
@@ -37,7 +37,9 @@ export interface MindMapSourceBlock {
  * bookmarks, files — is counted on its parent instead (see
  * `MindMapContentKind`) rather than drawn, and is never silently dropped.
  *
- * Wiki links become their own kind in later work.
+ * A wiki link is the one kind that is not a piece of THIS note: it points at
+ * another document, which is a real branch rather than decoration on the label
+ * that happened to contain it.
  */
 export type MindMapNodeKind =
   | 'root'
@@ -54,6 +56,11 @@ export type MindMapNodeKind =
   | 'toggle'
   /** Memry's `callout` — branches into its children. */
   | 'callout'
+  /**
+   * A `[[wiki link]]` lifted out of the text that held it. Always a leaf: what
+   * is inside the note it names is the graph view's question, not this one's.
+   */
+  | 'wikiLink'
 
 /**
  * Content that is not structure. It never becomes a node; it is counted on the
@@ -86,6 +93,22 @@ export interface MindMapNode {
   depth: number
   /** A ticked checklist item or task. Always false for other kinds. */
   isDone: boolean
+  /**
+   * The task a `task` node stands for, so activating it can open the task
+   * rather than the block that mentions it. Null for every other kind, and for
+   * a task block that carries no id yet.
+   */
+  taskId: string | null
+  /**
+   * What a `wikiLink` node points at, exactly as the link was written —
+   * `Roadmap`, `Roadmap#Q3`, `diagram.pdf`. Null for every other kind.
+   *
+   * The target rather than a resolved id, because resolving a wiki target is a
+   * database lookup and this pipeline is pure. The note page hands it to the
+   * same resolver a `[[…]]` in the body goes through, so the map opens a link
+   * exactly the way the editor does.
+   */
+  wikiTarget: string | null
   /** Inline hash tags found in this node's own text. User content, `#` stripped. */
   tags: string[]
   /** Content sitting under this node that is not drawn, in a stable order. */
@@ -109,6 +132,8 @@ export interface MindMapPositionedNode {
   level: number | null
   depth: number
   isDone: boolean
+  taskId: string | null
+  wikiTarget: string | null
   tags: string[]
   contents: MindMapContentCount[]
   detail: string
@@ -133,6 +158,13 @@ export interface MindMapBoxElement {
   strokeWidth: number
   roughness: number
   roundness: { type: number }
+  /**
+   * Absent — the drawing library's own default, a solid outline — for every box
+   * that stands for a piece of this note. A wiki-link box is dashed, so "part
+   * of this note" and "another document" differ by outline as well as by
+   * colour, and are still told apart without colour vision.
+   */
+  strokeStyle?: 'dashed'
   label: {
     text: string
     fontSize: number

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
@@ -150,6 +150,7 @@ export function MindMapView({
       <MindMapTree
         nodes={map.nodes}
         label={t('mindMap.treeLabel', { title: noteTitle })}
+        linkHint={t('mindMap.linkHint')}
         onActivateNode={onActivateNode}
       />
     </div>

--- a/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.test.tsx
@@ -13,12 +13,25 @@ function heading(id: string, level: number, text: string): MindMapSourceBlock {
   return { id, type: 'heading', props: { level }, content: [{ type: 'text', text }] }
 }
 
-const map = buildMindMap([heading('b-alpha', 1, 'Alpha')], {
-  rootLabel: 'Test Note',
-  noteId: 'note-1'
-})
+const map = buildMindMap(
+  [
+    heading('b-alpha', 1, 'Alpha'),
+    {
+      id: 'b-item',
+      type: 'bulletListItem',
+      content: [{ type: 'wikiLink', props: { target: 'Roadmap', alias: 'the plan' } }]
+    },
+    { id: 'b-task', type: 'taskBlock', props: { taskId: 't-1', title: 'Cut the build' } }
+  ],
+  {
+    rootLabel: 'Test Note',
+    noteId: 'note-1'
+  }
+)
 const alpha = map.nodes.find((node) => node.label === 'Alpha')!
 const root = map.nodes.find((node) => node.kind === 'root')!
+const link = map.nodes.find((node) => node.kind === 'wikiLink')!
+const task = map.nodes.find((node) => node.kind === 'task')!
 
 let container: HTMLElement
 let top: HTMLElement
@@ -27,15 +40,19 @@ let scrolled: Array<{ target: Element; options: boolean | ScrollIntoViewOptions 
 
 function setup(options: { smooth?: boolean } = {}) {
   const close = vi.fn()
+  const openNote = vi.fn()
+  const openTask = vi.fn()
   const view = renderHook(() =>
     useMindMapNavigation({
       close,
       getContainer: () => container,
       getTopElement: () => top,
-      smooth: options.smooth ?? true
+      smooth: options.smooth ?? true,
+      openNote,
+      openTask
     })
   )
-  return { close, view }
+  return { close, openNote, openTask, view }
 }
 
 /** The block, once whatever gates the editor's render has let it through. */
@@ -130,6 +147,32 @@ describe('useMindMapNavigation', () => {
 
     expect(fromMap).toEqual([{ target: block, options: { behavior: 'smooth', block: 'start' } }])
     expect(scrolled).toEqual(fromMap)
+  })
+
+  it('hands a wiki-link node to the page, leaving the map where it was', () => {
+    const { close, openNote, openTask, view } = setup()
+
+    act(() => view.result.current.activateNode(link))
+
+    // The target as written — the page's own wiki-link handler resolves it, so
+    // the map inherits the open-in-new-tab preference instead of inventing one.
+    expect(openNote).toHaveBeenCalledWith('Roadmap')
+    expect(openTask).not.toHaveBeenCalled()
+    // Nothing in THIS note was asked for, so nothing here closes or scrolls:
+    // the linked note arrives in whichever tab the preference says.
+    expect(close).not.toHaveBeenCalled()
+    expect(scrolled).toEqual([])
+  })
+
+  it('hands a task node to the page, leaving the map where it was', () => {
+    const { close, openNote, openTask, view } = setup()
+
+    act(() => view.result.current.activateNode(task))
+
+    expect(openTask).toHaveBeenCalledWith('t-1')
+    expect(openNote).not.toHaveBeenCalled()
+    expect(close).not.toHaveBeenCalled()
+    expect(scrolled).toEqual([])
   })
 
   it('honours a request for less motion', () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.ts
@@ -16,6 +16,11 @@
  *
  * The same `navigateToBlock` is what the outline panel is handed, so a heading
  * click has one behaviour whether or not the map is open.
+ *
+ * Two node kinds do not land in this note at all — a wiki link opens the note
+ * it names, a task opens its task — and neither closes the map. They are handed
+ * straight to the note page's own handlers for those things, so the map has no
+ * opening behaviour of its own to drift from the rest of the app.
  */
 
 import { useCallback, useEffect, useMemo, useRef } from 'react'
@@ -33,6 +38,15 @@ interface UseMindMapNavigationOptions {
   getTopElement: () => HTMLElement | null
   /** False when the user asked for less motion. */
   smooth: boolean
+  /**
+   * The note page's own wiki-link handler, taking the target as written. Passed
+   * in rather than rebuilt so the map opens a link through the one path that
+   * already resolves it, creates it when it is missing, and honours the
+   * open-in-new-tab preference.
+   */
+  openNote: (wikiTarget: string) => void
+  /** The note page's own task handler. */
+  openTask: (taskId: string) => void
 }
 
 export interface UseMindMapNavigationResult {
@@ -49,7 +63,9 @@ export function useMindMapNavigation({
   close,
   getContainer,
   getTopElement,
-  smooth
+  smooth,
+  openNote,
+  openTask
 }: UseMindMapNavigationOptions): UseMindMapNavigationResult {
   // A wait outlives the click that started it, so a second click — or leaving
   // the note — has to call the first one off, or two of them fight over the
@@ -90,8 +106,8 @@ export function useMindMapNavigation({
   )
 
   const activateNode = useCallback<MindMapNodeActivation>(
-    (node) => activateMindMapNode(node, { navigateToBlock }),
-    [navigateToBlock]
+    (node) => activateMindMapNode(node, { navigateToBlock, openNote, openTask }),
+    [navigateToBlock, openNote, openTask]
   )
 
   return useMemo(() => ({ navigateToBlock, activateNode }), [navigateToBlock, activateNode])

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -1803,5 +1803,120 @@ describe('NotePage', () => {
       await expectLandedOnAlpha(scrolls)
       expect(scrolls.mock.calls).toEqual(mapCalls)
     })
+
+    /** Blocks holding a link inside a heading and a link inside a list item. */
+    const linkedBlocks = [
+      {
+        id: 'b-h1',
+        type: 'heading',
+        props: { level: 1 },
+        content: [
+          { type: 'text', text: 'Reading' },
+          { type: 'wikiLink', props: { target: 'Existing Note', alias: '' } }
+        ]
+      },
+      {
+        id: 'b-item',
+        type: 'bulletListItem',
+        content: [{ type: 'wikiLink', props: { target: 'Diagram.pdf', alias: '' } }]
+      }
+    ]
+
+    const linkItems = (): HTMLElement[] =>
+      Array.from(
+        screen.getByRole('tree').querySelectorAll<HTMLElement>('[data-mind-map-kind="wikiLink"]')
+      )
+
+    it('draws a wiki link written in a heading and one written in a list item', async () => {
+      mocks.editorBlocks = linkedBlocks
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+
+      // Both positions produce a node, and neither is left decorating the label
+      // that happened to contain it.
+      expect(linkItems().map((item) => item.textContent)).toEqual([
+        'Existing Note mindMap.linkHint',
+        'Diagram.pdf mindMap.linkHint'
+      ])
+      expect(screen.getByRole('tree').textContent).toContain('Reading')
+    })
+
+    it('opens the linked note from a wiki-link node, the way every other surface does', async () => {
+      mocks.editorBlocks = linkedBlocks
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+
+      fireEvent.click(linkItems()[0])
+
+      // Straight through the page's own wiki-link path — the same resolver, the
+      // same tab call, and so the same open-in-new-tab preference the user set.
+      // No map-specific tab rule exists to drift from it.
+      await waitFor(() =>
+        expect(mocks.openTab).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'note', entityId: 'existing-note' }),
+          { reuseActiveTab: true }
+        )
+      )
+      expect(mocks.resolveWikiLink).toHaveBeenCalledWith('Existing Note')
+      // The map is a view of THIS note; opening another one is not a reason to
+      // put it away.
+      expect(screen.getByTestId('note-mind-map')).toBeInTheDocument()
+    })
+
+    it('opens a linked file from the keyboard exactly as from a click', async () => {
+      mocks.editorBlocks = linkedBlocks
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+
+      fireEvent.keyDown(linkItems()[1], { key: 'Enter' })
+
+      await waitFor(() =>
+        expect(mocks.openTab).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'file', entityId: 'file-1' }),
+          { reuseActiveTab: true }
+        )
+      )
+    })
+
+    it('opens the linked note from the drawing too', async () => {
+      mocks.editorBlocks = linkedBlocks
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+
+      // A link box carries a handle of its OWN, never the one on the heading
+      // that held it, or a click here would scroll to that heading instead.
+      const nodeId = linkItems()[0].dataset.mindMapNode
+      fireEvent.click(drawnBoxFor(`memry://note/note-1#^${nodeId}`))
+
+      await waitFor(() =>
+        expect(mocks.openTab).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'note', entityId: 'existing-note' }),
+          { reuseActiveTab: true }
+        )
+      )
+    })
+
+    it('opens the task a task node stands for, not the block that mentions it', async () => {
+      mocks.editorBlocks = [
+        { id: 'b-task', type: 'taskBlock', props: { taskId: 'task-1', title: 'Linked task' } }
+      ]
+      renderWithProviders(<NotePage noteId="note-1" />)
+      await openMap()
+
+      fireEvent.click(treeItemFor('b-task'))
+
+      // The linked-tasks panel's own handler, which is why the project comes
+      // along: one task-opening path, not a second one owned by the map.
+      expect(mocks.openTab).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'tasks',
+          viewState: expect.objectContaining({
+            openTaskId: 'task-1',
+            selectedProjectId: 'project-1'
+          })
+        })
+      )
+      expect(screen.getByTestId('note-mind-map')).toBeInTheDocument()
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -794,17 +794,8 @@ export function NotePage({ noteId }: NotePageProps) {
     onEditorReady: review.handleEditorReady
   })
   const { refresh: refreshMindMap } = mindMap
-  // One handler for the outline panel and for both projections of the map, so
-  // a heading click cannot mean two different things depending on what else is
-  // on screen. The map closes first; see the hook for why that is not optional.
   const getEditorContainer = useCallback(() => editorContainerRef.current, [])
   const getNoteBody = useCallback(() => noteBodyRef.current, [])
-  const mindMapNavigation = useMindMapNavigation({
-    close: mindMap.close,
-    getContainer: getEditorContainer,
-    getTopElement: getNoteBody,
-    smooth: !prefersReducedMotion
-  })
   // The map is built when it opens, but a restored tab reopens it before the
   // body has finished loading. The heading set arriving is the signal that the
   // block tree behind the map is real.
@@ -1252,6 +1243,30 @@ export function NotePage({ noteId }: NotePageProps) {
     },
     [openTab, linkedTasks]
   )
+
+  // One handler for the outline panel and for both projections of the map, so
+  // a heading click cannot mean two different things depending on what else is
+  // on screen. The map closes first; see the hook for why that is not optional.
+  //
+  // The two kinds that leave this note are handed the page's OWN handlers —
+  // the same `handleInternalLinkClick` a `[[…]]` in the body goes through, and
+  // the same `handleLinkedTaskClick` the linked-tasks panel goes through — so
+  // the map invents no tab behaviour of its own and inherits the
+  // open-in-new-tab preference the user already set. Declared here rather than
+  // beside the map's own state because both of those handlers are defined
+  // above it.
+  const openLinkedNote = useCallback(
+    (wikiTarget: string) => void handleInternalLinkClick(wikiTarget),
+    [handleInternalLinkClick]
+  )
+  const mindMapNavigation = useMindMapNavigation({
+    close: mindMap.close,
+    getContainer: getEditorContainer,
+    getTopElement: getNoteBody,
+    smooth: !prefersReducedMotion,
+    openNote: openLinkedNote,
+    openTask: handleLinkedTaskClick
+  })
 
   // ============================================================================
   // Render

--- a/apps/docs/src/user-guide/notes/mind-map.md
+++ b/apps/docs/src/user-guide/notes/mind-map.md
@@ -36,6 +36,7 @@ edited, and the note is untouched by opening it.
 - **Toggles and callouts** open into their children. Content you collapsed in
   the editor is still discoverable in the map, and a callout holding a checklist
   is not reduced to one node.
+- **Wiki links** become nodes of their own — see below.
 - Content before the first heading belongs to the root.
 
 A note with no headings opens on the root alone, with a hint that adding a
@@ -46,6 +47,24 @@ heading will branch it.
 A checklist item or a task you have already completed is drawn dimmed, with a
 rule through its label. The map shows what is written, not what should have
 been.
+
+### Wiki Links
+
+A `[[wiki link]]` points at another document, which is a real branch rather than
+a word in a sentence — so the map draws it as its own node, in blue and with a
+dashed outline, hanging off whatever held it.
+
+- A link written **in a heading** or **in a list item** branches off that node.
+- A link written **in a paragraph** branches off the node the paragraph belongs
+  to, usually the heading above it. Paragraphs are still never nodes, but what
+  they reach out to is not lost with them.
+- A list item that is **nothing but a link** becomes the link itself, so a list
+  of links is a fan of links rather than a row of empty boxes each holding one.
+- A link node shows what the note shows: its **alias** when it has one, the
+  target otherwise. Clicking it opens what the whole target names, heading and
+  all.
+- Link nodes are always leaves. What is inside the note a link names is the
+  graph view's question, not the map's.
 
 ### Tags and Counter Badges
 
@@ -60,15 +79,28 @@ dropped:
   are not drawn. The node above them — usually the heading they sit under —
   carries a badge saying what is there, such as `2 tables · 1 code block`.
 - **Paragraphs** are never nodes. **Date mentions, link mentions and inline
-  pictures** stay as plain text inside the label of the node that holds them.
+  pictures** stay as plain text inside the label of the node that holds them —
+  a `[[wiki link]]` is the one inline thing that does not, because it points
+  somewhere else.
 
 ## Clicking a Node
 
 The map is navigation, not just a picture.
 
-- Click a **heading, list, task, toggle or callout node** and the map closes and
-  the note reopens at that block.
+- Click a **heading, list, toggle or callout node** and the map closes and the
+  note reopens at that block.
 - Click the **root** — the note's title — to come back to the top of the note.
+- Click a **task node** and the task opens, so you can act on it rather than
+  merely find where it was written. A task block written before memrynote gave
+  tasks their own identity has none to open, and lands at its block instead.
+- Click a **wiki-link node** and the linked note — or file — opens, in a new tab
+  or this one according to **Settings → General → Open Pages in a New Tab**, the
+  preference you have already set. The map invents no tab behaviour of its own:
+  it goes through the same path as clicking that link in the note body, so it
+  also creates a missing note and reports a missing file exactly the way the
+  body does.
+- Opening another note leaves the map where it was. It is a view of _this_ note,
+  so the tab you came from is still on the map when you return to it.
 - The **outline panel** stays available while the map shows, and clicking a
   heading there does exactly the same thing. One control, one behaviour.
 
@@ -120,9 +152,10 @@ than against it.
 The drawing sits beside a real tree in the page, so every node is announced by a
 screen reader with its nesting level, its badges, and — for a checklist item or
 a task — whether it is ticked, and every node can be reached and opened with the
-keyboard. The map takes a single tab stop: arrow keys move between nodes from
-there. The map region itself is labelled with the note's name and how many nodes
-it holds.
+keyboard. A wiki-link node says in words that it leaves the note, because the
+blue dashed outline that says so in the picture cannot be heard. The map takes a
+single tab stop: arrow keys move between nodes from there. The map region itself
+is labelled with the note's name and how many nodes it holds.
 
 ## Turning It Off
 

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -968,6 +968,7 @@
     "regionLabel": "Mind map of {title}, {count, plural, one {# node} other {# nodes}}",
     "treeLabel": "Mind map outline of {title}",
     "emptyHint": "Add a heading to this note and the map will branch.",
+    "linkHint": "link to another page",
     "badge": {
       "table": "{count, plural, one {# table} other {# tables}}",
       "code": "{count, plural, one {# code block} other {# code blocks}}",


### PR DESCRIPTION
Closes #1672 (part of #1667). Do not merge yet — siblings #1673 and #1675 are in flight and a rebase is expected.

## What changed

**Wiki links are branches now.** A `[[wiki link]]` points at another document, so it leaves the label that held it and becomes a leaf of its own — exactly the way a hash tag leaves the label and becomes a badge. It is drawn in blue **and** with a dashed outline, so "a piece of this note" and "another document" stay distinguishable without colour vision, and the accessible tree says the same thing in words.

Where a link is written decides where it hangs:

- in a heading or a list item → off that node;
- in a paragraph → off the node the paragraph belongs to (paragraphs are still never nodes, but what they reach is not lost with them);
- a block whose only content was its links hands them straight to its own parent, so a bullet list of links is a fan of links and not a row of empty boxes each holding one.

**Clicking one goes through the note page's own wiki-link handler** — `handleInternalLinkClick`, the same one a `[[…]]` in the body goes through. So the map inherits the open-in-new-tab preference from #1644, creates a missing note and reports a missing file exactly as the body does, and invents no tab rule of its own.

**Task nodes now open their task**, per #1667. #1671 shipped the block landing and named this ticket as the one that changes it. Task nodes carry `taskId` through the projection, and activation routes to the linked-tasks panel's own `handleLinkedTaskClick` — one task-opening path, not a second one owned by the map. A task block written before task ids existed carries none and lands at its block instead of doing nothing.

## Shapes

```ts
interface MindMapNodeActions {
  navigateToBlock: (blockId: string | null) => void
  openNote: (wikiTarget: string) => void   // target as written, not an id
  openTask: (taskId: string) => void
}

type MindMapNodeKind = 'root' | 'heading' | 'bullet' | 'numbered' | 'check'
                     | 'task' | 'toggle' | 'callout' | 'wikiLink'

// on MindMapNode and MindMapPositionedNode
taskId: string | null       // 'task' nodes only
wikiTarget: string | null   // 'wikiLink' nodes only
```

Three actions rather than one widened one: a kind that opens something else is not a block navigation with a different argument. The dispatch still ends in `const unhandled: never = node.kind`, so a kind added later still cannot ship without someone deciding what activating it does.

## Acceptance criteria

- [x] **Wiki links become their own leaf nodes, visually distinct from structure nodes.** `build-mind-map-wiki-links.test.ts` — "is always a leaf, and never a place in this note", "draws a link in its own colour and with a dashed outline".
- [x] **Clicking a wiki-link node opens the linked note, honouring the existing open-in-new-tab preference.** `note.test.tsx` — "opens the linked note from a wiki-link node, the way every other surface does" asserts `openTab(..., { reuseActiveTab: true })` and that `resolveWikiLink` was called with the target; "opens the linked note from the drawing too" covers the bitmap path.
- [x] **Keyboard activation does the same.** `note.test.tsx` — "opens a linked file from the keyboard exactly as from a click"; `mind-map-tree.test.tsx` — "says a wiki-link node leaves the note, and activates it like any other" asserts Enter and click produce identical calls.
- [x] **A wiki link inside a heading and one inside a list item both produce nodes.** `note.test.tsx` — "draws a wiki link written in a heading and one written in a list item"; plus the two projection cases in `build-mind-map-wiki-links.test.ts`, and a third for a link in a paragraph.
- [x] **No surface-specific tab behaviour is introduced.** The map calls the page's existing handlers and nothing else; the note page diff adds one `useCallback` that forwards to `handleInternalLinkClick`, and passes `handleLinkedTaskClick` through unchanged.
- [x] **Tests cover node creation from both positions and the opening path.** 19 new cases across four files; the whole mind-map directory is 121 tests, note page 55.

## Invariants held

- Editor still hidden with `invisible` + `inert`, never unmounted.
- `buildMindMap` is still the only entry point; no private module exported.
- Layout is still deterministic — "lays out identically whether or not the boxes carry links" still passes untouched, and the pure path still has no clock and no randomness.
- No IPC contract, no migration, no sync handler, no settings schema.
- Nothing disappears: a block that draws no box still hands its links up.
- Header overflow menu untouched in both modes; still gated on `spatialCanvas`.
- Toolbar is still a sibling of the `role="img"` region.

## One deviation from the ticket, deliberately

The ticket asked that `nodeFromMindMapLink` stop returning `null` for a link naming a foreign note and hand the parsed href to the note-opening action. That presumes a wiki box carries a link to the *target* note — which needs the target's note id, and resolving a wiki target to an id is a database lookup the pure pipeline cannot do (the target is a title, and it may not even exist yet).

So instead: a wiki box carries a link anchored on **its own node id** under this note (`memry://note/<this note>#^<node id>`), which is unique, honest, and harmless to any other consumer — an older build opens the note at the top. `nodeFromMindMapLink` resolves block ids first and falls back to node ids, and *where* the node goes is `wikiTarget` on the node, read by `activateMindMapNode`. Minting `memry://note/<title>` instead would have put a fabricated note id into a link string the drawing surface shows verbatim and a user can copy out. The "refuses a link into another note" case therefore stays, with its comment rewritten to say why no box ever carries one.

Two smaller judgement calls, flagged for review rather than buried:

1. **The link leaves the parent's label.** #1667 enumerates exactly which inline specs stay as label text — date mentions, link mentions, inline images — and handles wiki links under "Nodes" instead; the ticket says "rather than decoration on the node containing them". Keeping the text as well would draw `## [[Roadmap]]` as a heading "Roadmap" with a child "Roadmap".
2. **A link in a paragraph produces a node.** The ACs name only headings and list items, but user story 11 is "see which other notes this one reaches", and a note that links in prose would otherwise show nothing.

## Out of scope

Caps on the number of link nodes (#1673's business), and what a saved canvas mints for a wiki node (#1675 — it can resolve the target asynchronously at save time, which is the right place for it).

## Gates

```
pnpm lint                                  ✖ 108 problems (0 errors, 108 warnings)   EXIT=0
                                           (all pre-existing; 0 in the changed files)
pnpm typecheck                             Tasks: 17 successful, 17 total            EXIT=0
pnpm test                                  Test Files 1377 passed | 3 skipped (1380)
                                           Tests 17916 passed | 1 expected fail | 13 skipped (17930)
                                                                                     EXIT=0
pnpm --filter @memry/desktop i18n:check    ok: i18n check passed                      EXIT=0
pnpm docs:impact --base 9340bf182 --strict docs impact: covered / docs changed on this branch
                                                                                     EXIT=0
pnpm docs:build                            build complete in 11.67s                   EXIT=0
```

The first `pnpm test` run failed two main suites at LOAD with "Electron failed to install correctly" — the known fresh-worktree hazard, fixed by running `apps/desktop/scripts/install-electron-binary.cjs` and unrelated to this change.
