### PR TITLE
feat(notes): cap the mind map and fold what it cannot draw (#1673)

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map-caps.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map-caps.test.ts
@@ -7,10 +7,10 @@
  * saying what it meant; these import the caps and assert the behaviour around
  * them instead.
  *
- * The load-bearing test in this file is the last one. Every other case checks
- * one cap; that one checks the promise the whole ticket rests on — that a block
- * which would have been a node is either DRAWN exactly once or COUNTED exactly
- * once, and never simply gone.
+ * The load-bearing cases are the last describe. Every other case checks one
+ * cap; those check the promise the whole thing rests on — that a block which
+ * would have been a node is either DRAWN exactly once or COUNTED exactly once,
+ * and never simply gone.
  */
 
 import { describe, expect, it } from 'vitest'
@@ -208,6 +208,13 @@ describe('buildMindMap — the label cap', () => {
     const map = buildMindMap([heading('h', 1, 'Short enough')], TRANSLATED)
 
     expect(map.nodes[1].label).toBe('Short enough')
+  })
+
+  it('clips the note title too, which is a label like any other', () => {
+    const map = buildMindMap([], { ...TRANSLATED, rootLabel: long })
+
+    expect(map.tree.label.length).toBeLessThanOrEqual(MIND_MAP_MAX_LABEL_CHARS)
+    expect(map.tree.label.endsWith('…')).toBe(true)
   })
 })
 

--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map-caps.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map-caps.test.ts
@@ -1,0 +1,600 @@
+/**
+ * The caps, and what happens AT a cap — asserted through the one public entry
+ * point, with no DOM anywhere.
+ *
+ * The cap values themselves are never spelled out here. A test that repeats
+ * `12` is a test that has to be edited when the number changes, and it stops
+ * saying what it meant; these import the caps and assert the behaviour around
+ * them instead.
+ *
+ * The load-bearing test in this file is the last one. Every other case checks
+ * one cap; that one checks the promise the whole ticket rests on — that a block
+ * which would have been a node is either DRAWN exactly once or COUNTED exactly
+ * once, and never simply gone.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { buildMindMap } from './build-mind-map'
+import {
+  MIND_MAP_MAX_CHILDREN,
+  MIND_MAP_MAX_DEPTH,
+  MIND_MAP_MAX_LABEL_CHARS,
+  MIND_MAP_MAX_NODES
+} from './mind-map-caps'
+import type { MindMapNode, MindMapOptions, MindMapSourceBlock } from './mind-map-types'
+
+function heading(id: string, level: number, text: string): MindMapSourceBlock {
+  return { id, type: 'heading', props: { level }, content: [{ type: 'text', text }] }
+}
+
+function bullet(id: string, text: string, children?: MindMapSourceBlock[]): MindMapSourceBlock {
+  return { id, type: 'bulletListItem', content: [{ type: 'text', text }], children }
+}
+
+function toggle(id: string, text: string, children: MindMapSourceBlock[]): MindMapSourceBlock {
+  return { id, type: 'toggleListItem', content: [{ type: 'text', text }], children }
+}
+
+/** Stand-ins for the app's translator: deterministic, and never a locale shape. */
+const formatMore = (count: number): string => `+${count} more`
+const formatContentCount = (kind: string, count: number): string => `${count} ${kind}`
+
+/** Everything the app passes, so the wording under test is the wording shipped. */
+const TRANSLATED: MindMapOptions = { rootLabel: 'Note', formatMore, formatContentCount }
+
+function walk(node: MindMapNode): MindMapNode[] {
+  return [node, ...node.children.flatMap(walk)]
+}
+
+function labelled(tree: MindMapNode, label: string): MindMapNode {
+  const found = walk(tree).find((node) => node.label === label)
+  if (!found) throw new Error(`no node labelled ${label}`)
+  return found
+}
+
+function childLabels(node: MindMapNode): string[] {
+  return node.children.map((child) => child.label)
+}
+
+/** How many blocks are in a fixture, at every level of it. */
+function countBlocks(blocks: readonly MindMapSourceBlock[]): number {
+  return blocks.reduce((sum, block) => sum + 1 + countBlocks(block.children ?? []), 0)
+}
+
+/** A block whose content is `[[wiki links]]` and nothing else. */
+function links(id: string, type: string, targets: readonly string[]): MindMapSourceBlock {
+  return {
+    id,
+    type,
+    content: targets.map((target) => ({ type: 'wikiLink', props: { target } }))
+  }
+}
+
+/**
+ * Everything the map owes the user an answer about.
+ *
+ * Not "blocks": a wiki link is a run of inline content that becomes a node of
+ * its own (#1672), so it is a candidate exactly like a block that would be a
+ * node. That is the deliberate widening of the invariant below — counting
+ * blocks alone would silently stop covering links the moment they exist.
+ *
+ * Every fixture here is built from blocks that WOULD each be a node and from
+ * links with distinct targets, so this stays a count rather than a second copy
+ * of the projection's rules.
+ */
+function countCandidates(blocks: readonly MindMapSourceBlock[]): number {
+  return blocks.reduce((sum, block) => {
+    const inline = Array.isArray(block.content) ? block.content : []
+    const linkCount = inline.filter((run) => (run as { type?: unknown }).type === 'wikiLink').length
+    const hasText = inline.some(
+      (run) =>
+        typeof (run as { text?: unknown }).text === 'string' &&
+        (run as { text: string }).text.trim() !== ''
+    )
+    // A paragraph is never a node, and neither is a block with nothing to show
+    // — a list item holding only links IS its links (#1672). Neither is a
+    // candidate; the links inside them still are.
+    const own = block.type !== 'paragraph' && hasText ? 1 : 0
+    return sum + own + linkCount + countCandidates(block.children ?? [])
+  }, 0)
+}
+
+/** A chain of nested bullets, one per level, labelled by the level it sits at. */
+function bulletChain(depth: number, labelAt: (level: number) => string): MindMapSourceBlock {
+  let block = bullet(`c-${depth}`, labelAt(depth))
+  for (let level = depth - 1; level >= 1; level -= 1) {
+    block = bullet(`c-${level}`, labelAt(level), [block])
+  }
+  return block
+}
+
+describe('buildMindMap — the depth cap', () => {
+  const overDeep = bulletChain(MIND_MAP_MAX_DEPTH + 2, (level) => `Level ${level}`)
+
+  it('folds what is past the cap into the deepest node still drawn', () => {
+    const map = buildMindMap([overDeep], TRANSLATED)
+
+    // Everything inside the cap is drawn, and nothing past it is.
+    expect(map.nodes.map((node) => node.label)).toEqual([
+      'Note',
+      ...Array.from({ length: MIND_MAP_MAX_DEPTH }, (_, index) => `Level ${index + 1}`)
+    ])
+    expect(Math.max(...map.nodes.map((node) => node.depth))).toBe(MIND_MAP_MAX_DEPTH)
+
+    // And the deepest node still drawn says how much is behind it, in the
+    // caller's own words. The two folded levels are counted, not dropped.
+    const deepest = labelled(map.tree, `Level ${MIND_MAP_MAX_DEPTH}`)
+    expect(deepest.foldedCount).toBe(2)
+    expect(deepest.detail).toBe('+2 more')
+  })
+
+  it('counts depth in nodes that are DRAWN, so a blank one costs nothing', () => {
+    // The same chain, with one rung that has nothing to show. It draws no box —
+    // #1671's rule — so the rung below it lands where a labelled one would, and
+    // the whole chain still fits inside the cap.
+    const withBlank = bulletChain(MIND_MAP_MAX_DEPTH + 1, (level) =>
+      level === 3 ? '   ' : `Level ${level}`
+    )
+    const map = buildMindMap([withBlank], TRANSLATED)
+
+    expect(map.nodeCount).toBe(MIND_MAP_MAX_DEPTH + 1)
+    expect(labelled(map.tree, `Level ${MIND_MAP_MAX_DEPTH + 1}`).depth).toBe(MIND_MAP_MAX_DEPTH)
+    // Nothing was hidden, so nothing is counted: a blank rung had nothing to
+    // see, and "+1 more" would send the user looking for content that is not
+    // there. An over-deep rung DID have something to show, which is the whole
+    // difference between the two.
+    expect(map.nodes.every((node) => node.foldedCount === 0)).toBe(true)
+    expect(map.nodes.every((node) => node.detail === '')).toBe(true)
+  })
+
+  it('folds a blank heading and an over-deep heading by the very same route', () => {
+    const blankHeading = buildMindMap(
+      [heading('a', 1, 'Alpha'), heading('blank', 2, '   '), heading('c', 3, 'Still visible')],
+      TRANSLATED
+    )
+
+    // Both cases re-parent onto the nearest node that IS drawn; they differ
+    // only in whether there was anything to count.
+    expect(childLabels(labelled(blankHeading.tree, 'Alpha'))).toEqual(['Still visible'])
+    expect(labelled(blankHeading.tree, 'Alpha').foldedCount).toBe(0)
+    expect(labelled(blankHeading.tree, 'Still visible').depth).toBe(2)
+  })
+
+  it('counts depth through a container, so a heading inside a toggle stays inside it', () => {
+    // Three toggles deep, then a heading, then a list under it: the heading does
+    // not hoist out of the toggle it was written in, and the depth it is at is
+    // the depth the cap is applied to.
+    const map = buildMindMap(
+      [
+        toggle('t1', 'One', [
+          toggle('t2', 'Two', [
+            toggle('t3', 'Three', [
+              heading('h', 1, 'Inside heading'),
+              bullet('b1', 'Under the heading', [bullet('b2', 'Deeper', [bullet('b3', 'Deepest')])])
+            ])
+          ])
+        ])
+      ],
+      TRANSLATED
+    )
+
+    expect(labelled(map.tree, 'Inside heading').depth).toBe(4)
+    expect(labelled(map.tree, 'Under the heading').depth).toBe(5)
+    expect(labelled(map.tree, 'Deeper').depth).toBe(MIND_MAP_MAX_DEPTH)
+    // One rung past the cap, and it folds into the node above it rather than
+    // being hoisted somewhere shallower or dropped.
+    expect(map.nodes.some((node) => node.label === 'Deepest')).toBe(false)
+    expect(labelled(map.tree, 'Deeper').foldedCount).toBe(1)
+  })
+})
+
+describe('buildMindMap — the label cap', () => {
+  const long = 'A heading with rather a lot to say for itself, going on and on and on past the cap'
+
+  it('clips an over-long label, marks the clip, and keeps the node navigable', () => {
+    const map = buildMindMap([heading('h', 1, long)], TRANSLATED)
+    const [, node] = map.nodes
+
+    expect(long.length).toBeGreaterThan(MIND_MAP_MAX_LABEL_CHARS)
+    expect(node.label.length).toBeLessThanOrEqual(MIND_MAP_MAX_LABEL_CHARS)
+    // Visible, not silent — and recoverable, because the node still points at
+    // the block that holds every word of it.
+    expect(node.label.endsWith('…')).toBe(true)
+    expect(long.startsWith(node.label.slice(0, -1).trimEnd())).toBe(true)
+    expect(node.blockId).toBe('h')
+  })
+
+  it('leaves a label that fits exactly as the user wrote it', () => {
+    const map = buildMindMap([heading('h', 1, 'Short enough')], TRANSLATED)
+
+    expect(map.nodes[1].label).toBe('Short enough')
+  })
+})
+
+describe('buildMindMap — the children cap', () => {
+  const items = (count: number): MindMapSourceBlock[] =>
+    Array.from({ length: count }, (_, index) => bullet(`b-${index + 1}`, `Item ${index + 1}`))
+
+  it('draws every child of a parent that fits, with no marker at all', () => {
+    const map = buildMindMap(
+      [heading('h', 1, 'Section'), ...items(MIND_MAP_MAX_CHILDREN)],
+      TRANSLATED
+    )
+
+    const section = labelled(map.tree, 'Section')
+    expect(section.children).toHaveLength(MIND_MAP_MAX_CHILDREN)
+    expect(section.children.every((child) => child.kind === 'bullet')).toBe(true)
+  })
+
+  it('stands the overflow behind one marker the user can open', () => {
+    const overflow = 8
+    const map = buildMindMap(
+      [heading('h', 1, 'Section'), ...items(MIND_MAP_MAX_CHILDREN + overflow)],
+      TRANSLATED
+    )
+
+    const section = labelled(map.tree, 'Section')
+    expect(section.children).toHaveLength(MIND_MAP_MAX_CHILDREN + 1)
+    // The children that are drawn are the first ones, in the order they were
+    // written — the map reads top-down, like the note.
+    expect(childLabels(section).slice(0, MIND_MAP_MAX_CHILDREN)).toEqual(
+      items(MIND_MAP_MAX_CHILDREN).map((_, index) => `Item ${index + 1}`)
+    )
+
+    const marker = section.children[MIND_MAP_MAX_CHILDREN]
+    expect(marker.kind).toBe('more')
+    expect(marker.foldedCount).toBe(overflow)
+    expect(marker.label).toBe(`+${overflow} more`)
+    // Derived from its parent, so the same branch opens to the same shape on
+    // every rebuild — that is what lets expansion be a set of ids.
+    expect(marker.id).toBe(`${section.id}-more`)
+    // The count is the label, never also a badge underneath it.
+    expect(marker.detail).toBe('')
+  })
+
+  it('counts the whole branch behind the marker, not only its top row', () => {
+    const map = buildMindMap(
+      [
+        heading('h', 1, 'Section'),
+        ...items(MIND_MAP_MAX_CHILDREN),
+        bullet('hidden', 'Hidden', [bullet('hidden-a', 'Under it'), bullet('hidden-b', 'Also')])
+      ],
+      TRANSLATED
+    )
+
+    // "+3 more" hiding a subtree of three is honest; "+1 more" hiding three
+    // would be exactly the quiet loss this whole ticket exists to prevent.
+    const marker = labelled(map.tree, '+3 more')
+    expect(marker.foldedCount).toBe(3)
+  })
+
+  it('labels a marker with a number even when the caller has no translator', () => {
+    const map = buildMindMap([heading('h', 1, 'Section'), ...items(MIND_MAP_MAX_CHILDREN + 2)], {
+      rootLabel: 'Note'
+    })
+
+    const marker = labelled(map.tree, '+2')
+    expect(marker.kind).toBe('more')
+    // The wording is chrome and can be missing; the count never is.
+    expect(marker.foldedCount).toBe(2)
+  })
+})
+
+describe('buildMindMap — expansion', () => {
+  const blocks = [
+    heading('h', 1, 'Section'),
+    ...Array.from({ length: MIND_MAP_MAX_CHILDREN + 5 }, (_, index) =>
+      bullet(`b-${index + 1}`, `Item ${index + 1}`)
+    )
+  ]
+  const markerId = `mm-h-more`
+
+  it('opens the branch in place, leaving nothing folded', () => {
+    const folded = buildMindMap(blocks, TRANSLATED)
+    expect(labelled(folded.tree, '+5 more').id).toBe(markerId)
+
+    const opened = buildMindMap(blocks, { ...TRANSLATED, expanded: new Set([markerId]) })
+
+    const section = labelled(opened.tree, 'Section')
+    expect(section.children).toHaveLength(MIND_MAP_MAX_CHILDREN + 5)
+    expect(section.children.some((child) => child.kind === 'more')).toBe(false)
+    expect(opened.nodes.every((node) => node.foldedCount === 0)).toBe(true)
+    // In place: the branch opened where it was, under the same parent.
+    expect(childLabels(opened.tree)).toEqual(['Section'])
+  })
+
+  it('opens an expanded branch to identical coordinates every time', () => {
+    const first = buildMindMap(blocks, { ...TRANSLATED, expanded: new Set([markerId]) })
+    const second = buildMindMap(structuredClone(blocks), {
+      ...TRANSLATED,
+      expanded: new Set([markerId])
+    })
+
+    expect(second).toEqual(first)
+    expect(second.nodes.map((node) => [node.id, node.x, node.y])).toEqual(
+      first.nodes.map((node) => [node.id, node.x, node.y])
+    )
+  })
+
+  it('leaves every other branch exactly where it was', () => {
+    const twoSections = [
+      ...blocks,
+      heading('h2', 1, 'Other'),
+      bullet('o-1', 'Untouched'),
+      bullet('o-2', 'Also untouched')
+    ]
+    const folded = buildMindMap(twoSections, TRANSLATED)
+    const opened = buildMindMap(twoSections, { ...TRANSLATED, expanded: new Set([markerId]) })
+
+    // Expansion is not a redraw of the whole note: what was not opened keeps
+    // its shape, so the user's spatial memory of it survives the click.
+    expect(childLabels(labelled(opened.tree, 'Other'))).toEqual(
+      childLabels(labelled(folded.tree, 'Other'))
+    )
+  })
+
+  it('ignores an expansion id that no longer matches anything', () => {
+    // Ids are minted from block ids, which the note re-mints when it is edited.
+    // A stale one has to be inert rather than an error — which is also why the
+    // set is never persisted in the first place.
+    const map = buildMindMap(blocks, { ...TRANSLATED, expanded: new Set(['mm-gone-more']) })
+
+    expect(labelled(map.tree, '+5 more').kind).toBe('more')
+  })
+
+  it('still holds the whole-map cap after an expansion', () => {
+    const huge = [
+      heading('h', 1, 'Section'),
+      ...Array.from({ length: MIND_MAP_MAX_NODES * 2 }, (_, index) =>
+        bullet(`b-${index + 1}`, `Item ${index + 1}`)
+      )
+    ]
+
+    const folded = buildMindMap(huge, TRANSLATED)
+    expect(folded.reachedNodeCap).toBe(false)
+
+    const opened = buildMindMap(huge, { ...TRANSLATED, expanded: new Set([markerId]) })
+
+    // Opening a branch is not a way around the total: the map fills to the cap
+    // and the rest folds onto the section, which says how much.
+    expect(opened.nodeCount).toBe(MIND_MAP_MAX_NODES)
+    expect(opened.reachedNodeCap).toBe(true)
+    // Root and heading aside, every drawn node is an item; the items the budget
+    // did not reach are counted on the heading rather than dropped.
+    const drawnItems = opened.nodes.filter((node) => node.kind === 'bullet').length
+    expect(labelled(opened.tree, 'Section').foldedCount).toBe(countBlocks(huge) - 1 - drawnItems)
+  })
+})
+
+/** Wide AND deep: within every per-parent cap, far past the total. */
+const sprawl: MindMapSourceBlock[] = Array.from({ length: MIND_MAP_MAX_CHILDREN }, (_, top) => [
+  heading(`h1-${top}`, 1, `Section ${top + 1}`),
+  ...Array.from({ length: MIND_MAP_MAX_CHILDREN }, (_, mid) => [
+    heading(`h2-${top}-${mid}`, 2, `Part ${top + 1}.${mid + 1}`),
+    ...Array.from({ length: MIND_MAP_MAX_CHILDREN }, (_, leaf) =>
+      bullet(`b-${top}-${mid}-${leaf}`, `Item ${top + 1}.${mid + 1}.${leaf + 1}`)
+    )
+  ]).flat()
+]).flat()
+
+describe('buildMindMap — wiki links meet the same caps', () => {
+  const targets = (count: number, from = 1): string[] =>
+    Array.from({ length: count }, (_, index) => `Note ${index + from}`)
+
+  it('folds a fan of links behind one marker, like any other children', () => {
+    const overflow = 8
+    const map = buildMindMap(
+      [
+        heading('h', 1, 'Reading'),
+        links('l', 'paragraph', targets(MIND_MAP_MAX_CHILDREN + overflow))
+      ],
+      TRANSLATED
+    )
+
+    // A link is a node the map owes the user an answer about, so it goes
+    // through the very same placement — a section packed with links folds
+    // rather than sprawling past the cap.
+    const section = labelled(map.tree, 'Reading')
+    expect(section.children).toHaveLength(MIND_MAP_MAX_CHILDREN + 1)
+    expect(
+      section.children.slice(0, MIND_MAP_MAX_CHILDREN).every((c) => c.kind === 'wikiLink')
+    ).toBe(true)
+    const marker = section.children[MIND_MAP_MAX_CHILDREN]
+    expect(marker.kind).toBe('more')
+    expect(marker.foldedCount).toBe(overflow)
+  })
+
+  it('opens a folded fan of links in place', () => {
+    const blocks = [
+      heading('h', 1, 'Reading'),
+      links('l', 'paragraph', targets(MIND_MAP_MAX_CHILDREN + 4))
+    ]
+    const opened = buildMindMap(blocks, { ...TRANSLATED, expanded: new Set(['mm-h-more']) })
+
+    const section = labelled(opened.tree, 'Reading')
+    expect(section.children).toHaveLength(MIND_MAP_MAX_CHILDREN + 4)
+    expect(section.children.every((child) => child.kind === 'wikiLink')).toBe(true)
+    expect(opened.nodes.every((node) => node.foldedCount === 0)).toBe(true)
+  })
+
+  it('folds a link written past the depth cap into the deepest node drawn', () => {
+    // A chain exactly at the cap, with one rung too many below it holding both
+    // text and a link.
+    let deepest: MindMapSourceBlock = {
+      id: 'too-deep',
+      type: 'bulletListItem',
+      content: [
+        { type: 'text', text: 'Too deep' },
+        { type: 'wikiLink', props: { target: 'Roadmap' } }
+      ]
+    }
+    for (let level = MIND_MAP_MAX_DEPTH; level >= 1; level -= 1) {
+      deepest = bullet(`d-${level}`, `Rung ${level}`, [deepest])
+    }
+    const map = buildMindMap([deepest], TRANSLATED)
+
+    expect(map.nodes.some((node) => node.kind === 'wikiLink')).toBe(false)
+    // The over-deep bullet AND the link inside it, both counted on the last
+    // node the map drew — never dropped for being past the edge.
+    expect(labelled(map.tree, `Rung ${MIND_MAP_MAX_DEPTH}`).foldedCount).toBe(2)
+  })
+
+  it('counts links written inside a branch that is already folded away', () => {
+    const map = buildMindMap(
+      [
+        heading('h', 1, 'Reading'),
+        ...Array.from({ length: MIND_MAP_MAX_CHILDREN }, (_, index) =>
+          bullet(`b-${index}`, `Item ${index + 1}`)
+        ),
+        // One bullet past the cap, with two links written beneath it. The
+        // bullet folds, and the links arrive with the scope already folded —
+        // all three are behind the marker, and all three are what it says.
+        {
+          id: 'over',
+          type: 'bulletListItem',
+          content: [{ type: 'text', text: 'Spilled' }],
+          children: [links('over-links', 'bulletListItem', ['Roadmap', 'Backlog'])]
+        }
+      ],
+      TRANSLATED
+    )
+
+    expect(labelled(map.tree, '+3 more').foldedCount).toBe(3)
+  })
+
+  it('clips an over-long link label like any other label', () => {
+    const map = buildMindMap(
+      [links('l', 'paragraph', ['R'.repeat(MIND_MAP_MAX_LABEL_CHARS * 2)])],
+      TRANSLATED
+    )
+
+    const link = map.nodes.find((node) => node.kind === 'wikiLink')!
+    expect(link.label.length).toBeLessThanOrEqual(MIND_MAP_MAX_LABEL_CHARS)
+    expect(link.label.endsWith('…')).toBe(true)
+    // Clipped for drawing only — what it OPENS is untouched.
+    expect(link.wikiTarget).toHaveLength(MIND_MAP_MAX_LABEL_CHARS * 2)
+  })
+})
+
+describe('buildMindMap — the whole-map node cap', () => {
+  it('stops at the cap and says that it did', () => {
+    const map = buildMindMap(sprawl, TRANSLATED)
+
+    expect(map.nodeCount).toBe(MIND_MAP_MAX_NODES)
+    expect(map.reachedNodeCap).toBe(true)
+  })
+
+  it('says nothing about a cap a note never reaches', () => {
+    const map = buildMindMap([heading('h', 1, 'Section'), bullet('b', 'Item')], TRANSLATED)
+
+    expect(map.reachedNodeCap).toBe(false)
+    expect(map.nodes.every((node) => node.foldedCount === 0)).toBe(true)
+  })
+
+  it('lands the overflow on nodes that ARE drawn, in the words the caller gave', () => {
+    const map = buildMindMap(sprawl, TRANSLATED)
+
+    const carrying = map.nodes.filter((node) => node.foldedCount > 0)
+    expect(carrying.length).toBeGreaterThan(0)
+    for (const node of carrying) {
+      if (node.kind === 'more') continue
+      expect(node.detail).toContain(`+${node.foldedCount} more`)
+    }
+  })
+})
+
+describe('buildMindMap — nothing disappears silently', () => {
+  /**
+   * The promise the whole ticket rests on, as one assertion.
+   *
+   * Every fixture below is built out of blocks that WOULD each be a node, so
+   * the count of blocks is the count of things the map owes the user an answer
+   * about. Each one has to be drawn exactly once, or counted exactly once on a
+   * node that is drawn. Anything else is a block that vanished.
+   */
+  function expectNothingLost(blocks: readonly MindMapSourceBlock[]): void {
+    const map = buildMindMap(blocks, TRANSLATED)
+
+    // Every cap holds...
+    expect(map.nodeCount).toBeLessThanOrEqual(MIND_MAP_MAX_NODES)
+    for (const node of map.nodes) {
+      expect(node.depth).toBeLessThanOrEqual(MIND_MAP_MAX_DEPTH)
+      expect(node.label.length).toBeLessThanOrEqual(MIND_MAP_MAX_LABEL_CHARS)
+    }
+    for (const node of walk(map.tree)) {
+      const markers = node.children.filter((child) => child.kind === 'more')
+      // At most the cap in real children, and never more than one marker to
+      // stand for whatever did not fit.
+      expect(node.children.length - markers.length).toBeLessThanOrEqual(MIND_MAP_MAX_CHILDREN)
+      expect(markers.length).toBeLessThanOrEqual(1)
+    }
+
+    // ...and nothing was lost keeping them. A wiki-link node counts on both
+    // sides of this: it is a candidate, and it is drawn or folded like any
+    // other node.
+    const drawn = map.nodes.filter((node) => node.kind !== 'root' && node.kind !== 'more').length
+    const counted = map.nodes.reduce((sum, node) => sum + node.foldedCount, 0)
+    expect(drawn + counted).toBe(countCandidates(blocks))
+  }
+
+  const deepChain = bulletChain(MIND_MAP_MAX_DEPTH + 3, (level) => `Rung ${level}`)
+
+  const wideSection: MindMapSourceBlock[] = [
+    heading('wide', 1, 'Wide'),
+    ...Array.from({ length: MIND_MAP_MAX_CHILDREN + 6 }, (_, index) =>
+      bullet(`w-${index}`, `Item ${index}`, [
+        bullet(`w-${index}-a`, 'Under it'),
+        links(`w-${index}-l`, 'bulletListItem', [`Reaches ${index}`])
+      ])
+    )
+  ]
+
+  it('accounts for everything past the depth cap', () => {
+    expectNothingLost([deepChain])
+  })
+
+  it('accounts for everything past the children cap, subtrees included', () => {
+    expectNothingLost(wideSection)
+  })
+
+  it('accounts for everything past the whole-map cap', () => {
+    expectNothingLost(sprawl)
+  })
+
+  it('accounts for wiki links, which are candidates too', () => {
+    // Links past the children cap, links inside a bullet that is itself past
+    // it, and a link written in a paragraph that is no node at all.
+    expectNothingLost([
+      heading('links', 1, 'Reading'),
+      ...Array.from({ length: MIND_MAP_MAX_CHILDREN }, (_, index) =>
+        links(`l-${index}`, 'bulletListItem', [`Note ${index + 1}`])
+      ),
+      links('over', 'bulletListItem', ['Spilled A', 'Spilled B']),
+      links('prose', 'paragraph', ['From prose'])
+    ])
+  })
+
+  it('accounts for everything when all four caps bite at once', () => {
+    // The deep chain and the wide section come FIRST, so they are projected
+    // while there is still budget: that is what puts the depth cap and the
+    // children cap in force here rather than letting the node cap answer for
+    // everything. The over-long heading trips the label cap on the way past.
+    const blocks: MindMapSourceBlock[] = [
+      deepChain,
+      ...wideSection,
+      heading('long', 1, 'x'.repeat(MIND_MAP_MAX_LABEL_CHARS * 2)),
+      links('prose', 'paragraph', ['Reached from prose']),
+      ...sprawl
+    ]
+
+    expectNothingLost(blocks)
+
+    // Not a vacuous pass: every fold route really did fire on this note.
+    const map = buildMindMap(blocks, TRANSLATED)
+    expect(map.reachedNodeCap).toBe(true)
+    expect(labelled(map.tree, `Rung ${MIND_MAP_MAX_DEPTH}`).foldedCount).toBeGreaterThan(0)
+    expect(walk(map.tree).some((node) => node.kind === 'more')).toBe(true)
+    expect(map.nodes.some((node) => node.label.endsWith('…'))).toBe(true)
+    expect(map.nodes.some((node) => node.kind === 'wikiLink')).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.ts
@@ -21,7 +21,7 @@ export function buildMindMap(
   options: MindMapOptions
 ): MindMap {
   const direction = options.direction ?? 'ltr'
-  const tree = projectBlocks(blocks, options)
+  const { tree, reachedNodeCap } = projectBlocks(blocks, options)
   const { nodes, bounds } = layoutMindMap(tree, direction)
 
   return {
@@ -30,6 +30,7 @@ export function buildMindMap(
     elements: mintElements(nodes, direction, options.noteId),
     direction,
     nodeCount: nodes.length,
+    reachedNodeCap,
     isEmpty: tree.children.length === 0,
     bounds
   }

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-caps.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-caps.ts
@@ -1,0 +1,67 @@
+/**
+ * How much the map draws before it starts folding.
+ *
+ * Private to this directory, like every other step behind `buildMindMap`. The
+ * numbers live in one file because they are a single readability budget rather
+ * than four unrelated knobs, and because a test that asserts a cap should name
+ * the cap rather than repeat its value.
+ *
+ * The governing rule that shapes all four: nothing disappears silently. Every
+ * cap here has a visible consequence — a clipped label ends in an ellipsis, an
+ * over-deep or over-budget node is counted on the nearest node still drawn, and
+ * a parent with too many children grows a "+N more" node that opens it again.
+ */
+
+/**
+ * Deepest node the map draws, counted in nodes still drawn below the root.
+ *
+ * Six is the depth a note actually reaches: markdown stops at six heading
+ * levels, and by the time a bullet is six branches from the title the map is
+ * already three thousand pixels wide. Depth is counted in VISIBLE ancestors,
+ * not in source nesting, so a blank heading or an unlabelled bullet — neither
+ * of which draws a box — costs nothing against this.
+ */
+export const MIND_MAP_MAX_DEPTH = 6
+
+/**
+ * Longest label a box holds, the clipping ellipsis included.
+ *
+ * A box caps at 264px wide and holds about 25 characters a line, so this is
+ * three lines: enough to recognise a heading, short enough that one wordy node
+ * cannot dominate the column it sits in. Clipping is not a loss — the ellipsis
+ * says it happened, and the node still navigates to the block with the full
+ * text in it.
+ */
+export const MIND_MAP_MAX_LABEL_CHARS = 72
+
+/**
+ * Most children one parent draws, the "+N more" node included.
+ *
+ * Twelve boxes at roughly 58px apiece is a screenful, which is the point: past
+ * that the user is scrolling a list rather than reading a shape. The overflow
+ * is a fold, not a loss — the "+N more" node opens it in place.
+ */
+export const MIND_MAP_MAX_CHILDREN = 12
+
+/**
+ * Most nodes the whole map draws, the root and every "+N more" node included.
+ *
+ * Past this the picture stops being readable and its accessible twin stops
+ * being walkable. Whatever is over budget is counted on the nearest node still
+ * drawn, and the map says it hit the limit.
+ */
+export const MIND_MAP_MAX_NODES = 200
+
+/** The clipping mark. Punctuation, not language: labels are user content. */
+const ELLIPSIS = '…'
+
+/**
+ * A label as a box can hold it.
+ *
+ * Clips inside the cap rather than past it, so the returned string is never
+ * longer than the cap even once the ellipsis is on the end.
+ */
+export function clipLabel(label: string): string {
+  if (label.length <= MIND_MAP_MAX_LABEL_CHARS) return label
+  return `${label.slice(0, MIND_MAP_MAX_LABEL_CHARS - ELLIPSIS.length).trimEnd()}${ELLIPSIS}`
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
@@ -41,6 +41,17 @@ const LINK_LABEL = '#364fc7'
 const DONE_STROKE = '#ced4da'
 const DONE_FILL = '#f8f9fa'
 const DONE_LABEL = '#adb5bd'
+/**
+ * A fold marker reads as a control rather than as content: the accent outline
+ * is the same one the root carries, on the ordinary white fill, so it is
+ * recognisably ours and unmistakably not a piece of the note.
+ *
+ * Deliberately NOT dashed. A dashed outline is #1672's "this is another
+ * document" signal, and a fold marker is the opposite — it stands for content
+ * of THIS note that is folded away. Two meanings on one outline would make
+ * neither readable.
+ */
+const MORE_STROKE = '#ff671a'
 /** Adaptive corner radius. */
 const ROUNDNESS = { type: 3 }
 
@@ -55,11 +66,17 @@ const ROUNDNESS = { type: 3 }
  * - a box standing for a block anchors on that block;
  * - the root has no block — it is the note's title — so it carries no anchor,
  *   which reads as "this note, from the top";
- * - a wiki-link box has no block either, so it anchors on its own node id,
- *   which is minted from the block that held the link and lives exactly as
- *   long. Where the link actually goes is `wikiTarget` on the node, not this
- *   href: a wiki target is a title, and turning one into a note id is a
- *   database lookup this pure pipeline cannot do.
+ * - every OTHER blockless box anchors on its own node id. Today that is a
+ *   wiki link, whose id is minted from the block that held it, and a "+N more"
+ *   fold marker, whose id is minted from the parent it folds. One rule rather
+ *   than one per kind: the root is the only box that may share the unanchored
+ *   href, and everything else is told apart by its own id.
+ *
+ * Where a wiki-link box actually goes is `wikiTarget` on the node, not this
+ * href: a wiki target is a title, and turning one into a note id is a database
+ * lookup this pure pipeline cannot do. What a fold marker does is expand, which
+ * is not a destination at all. Both are decided in `activateMindMapNode`; this
+ * href only has to say WHICH box was clicked.
  */
 function nodeLink(node: MindMapPositionedNode, noteId: string | undefined): string | undefined {
   if (!noteId) return undefined
@@ -152,6 +169,7 @@ export function mintElements(
   for (const node of nodes) {
     const isRoot = node.kind === 'root'
     const isLink = node.kind === 'wikiLink'
+    const isMore = node.kind === 'more'
     elements.push({
       type: 'rectangle',
       id: node.id,
@@ -164,9 +182,11 @@ export function mintElements(
         ? ROOT_STROKE
         : isLink
           ? LINK_STROKE
-          : node.isDone
-            ? DONE_STROKE
-            : NODE_STROKE,
+          : isMore
+            ? MORE_STROKE
+            : node.isDone
+              ? DONE_STROKE
+              : NODE_STROKE,
       backgroundColor: isRoot
         ? ROOT_FILL
         : isLink

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-layout.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-layout.ts
@@ -142,6 +142,7 @@ export function layoutMindMap(
       wikiTarget: item.node.wikiTarget,
       tags: item.node.tags,
       contents: item.node.contents,
+      foldedCount: item.node.foldedCount,
       detail: item.node.detail,
       parentId: item.parentId,
       // RTL mirrors the whole map about the root's leading edge, so the tree

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.test.ts
@@ -17,12 +17,24 @@ function actions() {
   return {
     navigateToBlock: vi.fn<(blockId: string | null) => void>(),
     openNote: vi.fn<(wikiTarget: string) => void>(),
-    openTask: vi.fn<(taskId: string) => void>()
+    openTask: vi.fn<(taskId: string) => void>(),
+    expandBranch: vi.fn<(nodeId: string) => void>()
   }
 }
 
 const blocks = [heading('b-alpha', 1, 'Alpha'), heading('b-beta', 2, 'Beta')]
 const map = buildMindMap(blocks, { rootLabel: 'Test Note', noteId: 'note-1' })
+
+/**
+ * A note wide enough that its root grows a fold marker, so the one node kind
+ * that is not a place in the note has a real instance to be dispatched.
+ */
+const folded = buildMindMap(
+  Array.from({ length: 40 }, (_, index) => heading(`b-${index + 1}`, 1, `Section ${index + 1}`)),
+  { rootLabel: 'Test Note', noteId: 'note-1' }
+)
+
+const marker = folded.nodes.find((candidate) => candidate.kind === 'more')!
 
 function node(label: string): MindMapPositionedNode {
   const found = map.nodes.find((candidate) => candidate.label === label)
@@ -35,6 +47,23 @@ describe('activateMindMapNode', () => {
     const acted = actions()
     activateMindMapNode(node('Alpha'), acted)
     expect(acted.navigateToBlock).toHaveBeenCalledWith('b-alpha')
+    expect(acted.expandBranch).not.toHaveBeenCalled()
+  })
+
+  it('opens the branch a fold marker stands for, without leaving the map', () => {
+    const acted = actions()
+    activateMindMapNode(marker, acted)
+
+    // Its own id, which is derived from its parent's — that is what the host
+    // holds on to, and it is why expanding is a set of ids rather than a shape.
+    expect(acted.expandBranch).toHaveBeenCalledWith(marker.id)
+    expect(marker.id).toBe('mm-root-more')
+    // A fold marker is not a place in the note, and not a place anywhere else
+    // either: sending it down any of the other three would close the map AND
+    // leave the fold in place.
+    expect(acted.navigateToBlock).not.toHaveBeenCalled()
+    expect(acted.openNote).not.toHaveBeenCalled()
+    expect(acted.openTask).not.toHaveBeenCalled()
   })
 
   it('sends the root node to the top of the note', () => {
@@ -203,6 +232,17 @@ describe('nodeFromMindMapLink', () => {
     // clicked — and no box in this map ever carries one: a wiki-link box points
     // at its own node here, and WHERE that node goes is `wikiTarget` on it.
     expect(nodeFromMindMapLink('memry://note/other#^b-beta', map.nodes, 'note-1')).toBeNull()
+  })
+
+  it('resolves a fold marker, which owns no block of its own', () => {
+    const box = folded.elements.find((element) => element.id === marker.id)!
+    if (box.type !== 'rectangle') throw new Error('the marker drew no box')
+
+    // Without this the drawing would answer a click on "+N more" with the root,
+    // because both are blockless — and the user would be scrolled to the top of
+    // their note instead of having the branch opened.
+    expect(nodeFromMindMapLink(box.link!, folded.nodes, 'note-1')).toBe(marker)
+    expect(box.link).toBe(`memry://note/note-1#^${marker.id}`)
   })
 
   it('refuses a block anchor no node in this map owns', () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.ts
@@ -41,6 +41,16 @@ export interface MindMapNodeActions {
   openNote: (wikiTarget: string) => void
   /** Open a task, through the note page's own task-opening path. */
   openTask: (taskId: string) => void
+  /**
+   * Open the branch a fold marker stands for, in place. Called with the fold
+   * marker's own node id, which is derived from its parent's, so the same
+   * branch opens to the same shape every time the map is rebuilt.
+   *
+   * The host keeps this in memory for as long as the map is open and never
+   * writes it down: these ids are minted from block ids, and a note re-mints
+   * those the moment it is edited or opened somewhere else.
+   */
+  expandBranch: (nodeId: string) => void
 }
 
 /** Called with the node the user activated, however they reached it. */
@@ -79,6 +89,14 @@ export function activateMindMapNode(
       // ever a guard.
       if (node.wikiTarget) actions.openNote(node.wikiTarget)
       return
+    case 'more':
+      // The other node that is not a place in the note: it is the handle on
+      // the branch its parent folded away. Sending it down `navigateToBlock`
+      // would take the user to the top of the note — it has no block — which
+      // is both wrong and unrecoverable, since the map would close and the
+      // fold would still be there when they came back.
+      actions.expandBranch(node.id)
+      return
     default: {
       // Compile-time only. A kind added to the map without a case here fails to
       // assign, so a new node kind cannot ship silently doing nothing.
@@ -96,16 +114,20 @@ export function activateMindMapNode(
  * rather than by string surgery, so the one grammar keeps working — an anchor
  * form this build cannot place resolves to no node instead of the wrong one.
  *
- * A box that stands for a block resolves through its block; one that has no
- * block of its own — a wiki link — resolves through its node id, which is what
- * its href was minted with. Blocks are tried first, so an id that could somehow
- * be both still means what it has always meant.
+ * ONE lookup with one fallback, not one per kind of blockless box. A box that
+ * stands for a block resolves through its block; a box with no block of its own
+ * — a wiki link, or a "+N more" fold marker — resolves through its node id,
+ * which is what its href was minted with. Blocks are tried first, and the
+ * fallback considers ONLY blockless nodes, which is what keeps all three
+ * guarantees at once: a real block's link can never land on one of these
+ * boxes, a fold marker never resolves to the root, and a wiki-link box never
+ * resolves to a place in this note.
  *
- * Null for a link that is not a place in THIS map. A link naming another note
- * is not one of these boxes: a wiki-link box points at its own node here, and
- * WHERE that node goes is `wikiTarget` on it, read by `activateMindMapNode`.
- * Answering an unknown link with this map's root would send the user somewhere
- * they did not click.
+ * Null for a link that is not a box in THIS map. A link naming another note is
+ * not one of them: a wiki-link box points at its own node here, and WHERE that
+ * node goes is `wikiTarget` on it, read by `activateMindMapNode`. Answering an
+ * unknown link with this map's root would send the user somewhere they did not
+ * click.
  */
 export function nodeFromMindMapLink(
   href: string,
@@ -120,7 +142,11 @@ export function nodeFromMindMapLink(
   if (anchor.type !== 'block') return null
   return (
     nodes.find((node) => node.blockId === anchor.id) ??
-    nodes.find((node) => node.id === anchor.id) ??
+    // A wiki link and a fold marker each own no block, so their boxes carry
+    // their own node id in the anchor instead. The `blockId === null` guard is
+    // what makes one fallback safe for both: an anchor naming a real block can
+    // never be answered by a box that only happens to share the string.
+    nodes.find((node) => node.blockId === null && node.id === anchor.id) ??
     null
   )
 }

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-projection.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-projection.ts
@@ -178,7 +178,9 @@ export function projectBlocks(
   const root: MindMapNode = {
     id: MIND_MAP_ROOT_ID,
     blockId: null,
-    label: options.rootLabel,
+    // The title is user content and a long one would draw a box as tall as a
+    // section, so the label cap covers it too. Clipped, never reworded.
+    label: clipLabel(options.rootLabel),
     kind: 'root',
     level: null,
     depth: 0,
@@ -268,6 +270,10 @@ export function projectBlocks(
       level: null,
       depth: parent.depth + 1,
       isDone: false,
+      // A fold marker stands for content, it is not content: it opens nothing
+      // outside this note and it is not a task.
+      taskId: null,
+      wikiTarget: null,
       tags: [],
       contents: [],
       foldedCount: 0,
@@ -490,7 +496,9 @@ function finish(
   // badge underneath it. Without a translator it still says how much, in digits
   // rather than in words — the number is the promise, the wording is chrome.
   if (node.kind === 'more') {
-    node.label = formatMore ? formatMore(node.foldedCount) : `+${node.foldedCount}`
+    // Clipped like any other label: a locale can word this far longer than
+    // English does, and the cap has to mean the same thing in all of them.
+    node.label = clipLabel(formatMore ? formatMore(node.foldedCount) : `+${node.foldedCount}`)
   }
 
   const tagged = node.tags.map((tag) => `#${tag}`).join(' ')

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-projection.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-projection.ts
@@ -26,8 +26,24 @@
  * leaves the label of whatever held it and becomes a leaf of its own, the same
  * way a hash tag leaves the label and becomes a badge — a link points at
  * another document, and that is a branch rather than a word in a sentence.
+ *
+ * The caps are enforced here too, and they obey the same rule. A node this pass
+ * declines to draw — because it is too deep, because its parent already has as
+ * many children as the map draws, or because the whole map is out of budget —
+ * is COUNTED on the nearest node that is drawn, never dropped. One accounting
+ * invariant holds over the whole result and the tests assert it directly: every
+ * CANDIDATE — a block that would be a node, or a wiki link written inside one —
+ * is either drawn exactly once or counted exactly once. A wiki link goes
+ * through the very same placement as a block's node, so a fan of links past the
+ * children cap folds behind a "+N more" like anything else.
  */
 
+import {
+  MIND_MAP_MAX_CHILDREN,
+  MIND_MAP_MAX_DEPTH,
+  MIND_MAP_MAX_NODES,
+  clipLabel
+} from './mind-map-caps'
 import { normalizeLabel, readInline, stringProp, isRecord } from './mind-map-inline'
 import type { InlineWikiLink } from './mind-map-inline'
 import type {
@@ -40,6 +56,9 @@ import type {
 } from './mind-map-types'
 
 export const MIND_MAP_ROOT_ID = 'mm-root'
+
+/** Shared so a build with no expansion allocates nothing per call. */
+const EMPTY_EXPANSION: ReadonlySet<string> = new Set<string>()
 
 const MIN_HEADING_LEVEL = 1
 const MAX_HEADING_LEVEL = 6
@@ -111,6 +130,17 @@ function listStart(props: unknown): number | null {
   return typeof raw === 'number' && Number.isInteger(raw) ? raw : null
 }
 
+/** The id of the fold marker a parent grows when its children overflow. */
+export function moreNodeId(parentId: string): string {
+  return `${parentId}-more`
+}
+
+/** What the projection returns: the tree, plus whether the budget ran out. */
+export interface Projection {
+  tree: MindMapNode
+  reachedNodeCap: boolean
+}
+
 /**
  * Turns a block tree into the logical map.
  *
@@ -123,17 +153,28 @@ function listStart(props: unknown): number | null {
  * - Anything before the first heading belongs to the root.
  * - A block with nothing to show — no text and no tags — draws no box and does
  *   not join the level stack; whatever sits under it folds up to the nearest
- *   ancestor that does have something to show, rather than disappearing.
+ *   ancestor that does have something to show, rather than disappearing. It
+ *   adds nothing to that ancestor's fold count, because nothing was hidden:
+ *   there was nothing to see in the first place. Its links fold up with its
+ *   children and are placed under that ancestor.
  * - A wiki link becomes a leaf under the node its block belongs to, wherever it
  *   was written: a heading, a list item, or a paragraph that is no node itself.
  *   A block whose only content was its links therefore hands them straight to
  *   its own parent, so a bullet list of links is a fan of links and not a fan
  *   of empty boxes each holding one.
+ * - A node past the depth cap, or minted once the whole-map budget is gone,
+ *   folds by exactly the same route — except that it DID have something to
+ *   show, so it is counted on the ancestor it folded into, which then says so.
+ *   A wiki link is placed the same way and folds the same way.
+ * - A parent past the children cap grows one `more` node, and everything
+ *   further under that parent — later children, their whole subtrees, and any
+ *   links written in them — is counted on it, so "+N more" is the true size of
+ *   what is behind the fold rather than only its top row.
  */
 export function projectBlocks(
   blocks: readonly MindMapSourceBlock[],
   options: MindMapOptions
-): MindMapNode {
+): Projection {
   const root: MindMapNode = {
     id: MIND_MAP_ROOT_ID,
     blockId: null,
@@ -146,9 +187,17 @@ export function projectBlocks(
     wikiTarget: null,
     tags: [],
     contents: [],
+    foldedCount: 0,
     detail: '',
     children: []
   }
+
+  const expanded = options.expanded ?? EMPTY_EXPANSION
+  /** The root is already spent, so the budget is what is left after it. */
+  let budget = MIND_MAP_MAX_NODES - 1
+  let reachedNodeCap = false
+  /** The one fold marker a parent ever grows, so a second overflow finds it. */
+  const moreNodes = new Map<MindMapNode, MindMapNode>()
 
   /** Content tallies, kept aside so a node's `contents` is written once, in order. */
   const tallies = new Map<MindMapNode, Map<MindMapContentKind, number>>()
@@ -171,6 +220,65 @@ export function projectBlocks(
     tallies.set(node, counts)
   }
 
+  /** One more thing hidden behind `node`. Returned so callers can chain. */
+  const fold = (node: MindMapNode): MindMapNode => {
+    node.foldedCount += 1
+    return node
+  }
+
+  /**
+   * Where a candidate node ended up: drawn under its parent, or folded into
+   * whichever node now stands for it. The second answer is not a failure — it
+   * is the node that carries the count, and everything under the candidate
+   * folds into the very same place, which is what keeps the accounting exact.
+   */
+  type Placement = { drawn: MindMapNode } | { foldedInto: MindMapNode }
+
+  const placeUnder = (parent: MindMapNode, make: () => MindMapNode): Placement => {
+    // Depth first: a parent already at the limit draws no children at all, so
+    // it never grows a fold marker it would have to draw one level too deep.
+    if (parent.depth + 1 > MIND_MAP_MAX_DEPTH) return { foldedInto: fold(parent) }
+
+    const existing = moreNodes.get(parent)
+    if (existing) return { foldedInto: fold(existing) }
+
+    const isFull =
+      !expanded.has(moreNodeId(parent.id)) && parent.children.length >= MIND_MAP_MAX_CHILDREN
+
+    if (budget <= 0) {
+      // Out of budget for anything, fold marker included: the map says so above
+      // the picture instead, and the count still lands on a node that is drawn.
+      reachedNodeCap = true
+      return { foldedInto: fold(parent) }
+    }
+
+    budget -= 1
+    if (!isFull) {
+      const node = make()
+      parent.children.push(node)
+      return { drawn: node }
+    }
+
+    const more: MindMapNode = {
+      id: moreNodeId(parent.id),
+      blockId: null,
+      // Written in `finish`, from the count it ends up standing for.
+      label: '',
+      kind: 'more',
+      level: null,
+      depth: parent.depth + 1,
+      isDone: false,
+      tags: [],
+      contents: [],
+      foldedCount: 0,
+      detail: '',
+      children: []
+    }
+    moreNodes.set(parent, more)
+    parent.children.push(more)
+    return { foldedInto: fold(more) }
+  }
+
   /**
    * One leaf per wiki link written in a block, under whatever node that block
    * belongs to — the block's own node when it minted one, otherwise the node
@@ -183,17 +291,30 @@ export function projectBlocks(
    * not a block; and `blockId` is what a click navigates TO, so a link sharing
    * its sentence's block id would send a click on the link to the sentence.
    * What the link opens is carried in `wikiTarget` instead.
+   *
+   * Placed through `placeUnder`, exactly like a block's own node: a link is a
+   * node the map owes the user an answer about, so it is subject to every cap
+   * and is counted when a cap holds it back. A heading with thirty links folds
+   * behind one "+N more" rather than drawing thirty boxes, and `folded` — set
+   * when the whole scope is already behind a fold — counts them there instead.
    */
   const addLinks = (
     parent: MindMapNode,
     blockId: string,
-    links: readonly InlineWikiLink[]
+    links: readonly InlineWikiLink[],
+    folded: MindMapNode | null
   ): void => {
     links.forEach((link, index) => {
-      parent.children.push({
+      if (folded) {
+        // Behind a fold. A link had something to show, so it is counted on the
+        // node standing for the fold, the same as any other node would be.
+        fold(folded)
+        return
+      }
+      placeUnder(parent, () => ({
         id: mintId(`${blockId}-link-${index + 1}`),
         blockId: null,
-        label: link.label,
+        label: clipLabel(link.label),
         kind: 'wikiLink',
         level: null,
         depth: parent.depth + 1,
@@ -202,9 +323,10 @@ export function projectBlocks(
         wikiTarget: link.target,
         tags: [],
         contents: [],
+        foldedCount: 0,
         detail: '',
         children: []
-      })
+      }))
     })
   }
 
@@ -212,15 +334,21 @@ export function projectBlocks(
    * One level of containment: the node holding these blocks, and the headings
    * open inside it, shallowest first. A container gets its own stack so its
    * headings cannot escape it; the top level's container is the root.
+   *
+   * `folded` is set when this whole scope is behind a fold. Nothing here draws
+   * then; every node it would have drawn is counted on that one node, which is
+   * how a fold marker ends up naming the true size of what is behind it.
    */
   interface Scope {
     container: MindMapNode
     stack: Array<{ level: number; node: MindMapNode }>
+    folded: MindMapNode | null
   }
 
   /** Whatever a block written here belongs to: the open heading, else the container. */
   const parentIn = (scope: Scope): MindMapNode =>
-    scope.stack.length > 0 ? scope.stack[scope.stack.length - 1].node : scope.container
+    scope.folded ??
+    (scope.stack.length > 0 ? scope.stack[scope.stack.length - 1].node : scope.container)
 
   const visitBlocks = (siblings: readonly MindMapSourceBlock[], scope: Scope): void => {
     // Numbered items count within their own uninterrupted run, exactly as the
@@ -239,7 +367,7 @@ export function projectBlocks(
         // A paragraph is never a node, but a wiki link written in one is still
         // somewhere this note reaches, so it branches off the node the
         // paragraph belongs to rather than being lost with it.
-        addLinks(parentIn(scope), block.id, readInline(block.content).links)
+        addLinks(parentIn(scope), block.id, readInline(block.content).links, scope.folded)
         // Paragraphs, dividers and anything unregistered contribute no node and
         // never re-parent what is inside them.
         visitBlocks(block.children ?? [], scope)
@@ -253,11 +381,22 @@ export function projectBlocks(
           : readInline(block.content)
       const text = normalizeLabel(read.text)
 
-      // Nothing to show: no box, no level-stack entry, and its children fold up
-      // to whatever this block's own parent was. Its links fold up with them —
-      // `- [[Roadmap]]` is a branch to Roadmap, not an empty box holding one.
+      // Nothing to show: no box, no level-stack entry, and no fold count — an
+      // empty block hides nothing, so counting it would send the user looking
+      // for content that was never there. Its children fold up to whatever this
+      // block's own parent was, which is the same route a capped node takes,
+      // and its links fold up with them — `- [[Roadmap]]` is a branch to
+      // Roadmap, not an empty box holding one.
       if (text === '' && read.tags.length === 0) {
-        addLinks(parentIn(scope), block.id, read.links)
+        addLinks(parentIn(scope), block.id, read.links, scope.folded)
+        visitBlocks(block.children ?? [], scope)
+        continue
+      }
+
+      // Already behind a fold: this had something to show, so it is counted,
+      // and everything under it is counted on the very same node.
+      if (scope.folded) {
+        fold(scope.folded)
         visitBlocks(block.children ?? [], scope)
         continue
       }
@@ -270,10 +409,10 @@ export function projectBlocks(
       }
       const parent = parentIn(scope)
 
-      const node: MindMapNode = {
+      const placement = placeUnder(parent, () => ({
         id: mintId(block.id),
         blockId: block.id,
-        label: isNumbered ? `${ordinal}.${text === '' ? '' : ` ${text}`}` : text,
+        label: clipLabel(isNumbered ? `${ordinal}.${text === '' ? '' : ` ${text}`}` : text),
         kind,
         level,
         depth: parent.depth + 1,
@@ -285,26 +424,46 @@ export function projectBlocks(
         wikiTarget: null,
         tags: read.tags,
         contents: [],
+        foldedCount: 0,
         detail: '',
         children: []
-      }
-      parent.children.push(node)
-      if (level !== null) scope.stack.push({ level, node })
+      }))
 
-      // The links written in this block come before the blocks written inside
-      // it, which is the order the note reads in.
-      addLinks(node, block.id, read.links)
-      visitBlocks(block.children ?? [], { container: node, stack: [] })
+      if ('drawn' in placement) {
+        if (level !== null) scope.stack.push({ level, node: placement.drawn })
+        // The links written in this block come before the blocks written inside
+        // it, which is the order the note reads in.
+        addLinks(placement.drawn, block.id, read.links, null)
+        visitBlocks(block.children ?? [], {
+          container: placement.drawn,
+          stack: [],
+          folded: null
+        })
+        continue
+      }
+
+      // Not drawn. A heading that folded never joins the level stack, so what
+      // follows it attaches to the nearest node that IS drawn and folds there
+      // in its turn — exactly what an unlabelled heading has always done. Its
+      // links go with it: they were inside a node the map is not drawing, so
+      // they are counted on the node that stands for it.
+      addLinks(parent, block.id, read.links, placement.foldedInto)
+      visitBlocks(block.children ?? [], {
+        container: parent,
+        stack: [],
+        folded: placement.foldedInto
+      })
     }
   }
 
-  visitBlocks(blocks, { container: root, stack: [] })
-  finish(root, tallies, options.formatContentCount)
-  return root
+  visitBlocks(blocks, { container: root, stack: [], folded: null })
+  finish(root, tallies, options)
+  return { tree: root, reachedNodeCap }
 }
 
 /**
- * Writes every node's `contents` and `detail` once the tallies are complete.
+ * Writes every node's `contents`, `detail` and — for a fold marker — its label,
+ * once the tallies and the fold counts are complete.
  *
  * `detail` is composed here rather than in either projection so the picture and
  * the accessible tree cannot drift into saying different things about the same
@@ -313,7 +472,7 @@ export function projectBlocks(
 function finish(
   node: MindMapNode,
   tallies: Map<MindMapNode, Map<MindMapContentKind, number>>,
-  format: MindMapOptions['formatContentCount']
+  options: MindMapOptions
 ): void {
   const counts = tallies.get(node)
   if (counts) {
@@ -325,11 +484,22 @@ function finish(
     node.contents = contents
   }
 
-  const tagged = node.tags.map((tag) => `#${tag}`).join(' ')
-  const counted = format
-    ? node.contents.map(({ kind, count }) => format(kind, count)).join(' · ')
-    : ''
-  node.detail = [tagged, counted].filter((part) => part !== '').join(' · ')
+  const { formatContentCount, formatMore } = options
 
-  for (const child of node.children) finish(child, tallies, format)
+  // A fold marker IS its count, so the count is its label and never also a
+  // badge underneath it. Without a translator it still says how much, in digits
+  // rather than in words — the number is the promise, the wording is chrome.
+  if (node.kind === 'more') {
+    node.label = formatMore ? formatMore(node.foldedCount) : `+${node.foldedCount}`
+  }
+
+  const tagged = node.tags.map((tag) => `#${tag}`).join(' ')
+  const counted = formatContentCount
+    ? node.contents.map(({ kind, count }) => formatContentCount(kind, count)).join(' · ')
+    : ''
+  const folded =
+    node.kind !== 'more' && node.foldedCount > 0 && formatMore ? formatMore(node.foldedCount) : ''
+  node.detail = [tagged, counted, folded].filter((part) => part !== '').join(' · ')
+
+  for (const child of node.children) finish(child, tallies, options)
 }

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.test.tsx
@@ -57,7 +57,44 @@ function itemFor(items: HTMLElement[], label: string): HTMLElement {
   return item
 }
 
+/** A note wide enough for the root to fold its overflow behind a marker. */
+const foldedMap = buildMindMap(
+  Array.from({ length: 40 }, (_, index) => heading(`b-${index + 1}`, 1, `Section ${index + 1}`)),
+  { rootLabel: 'Test Note', noteId: 'note-1', formatMore: (count) => `+${count} more` }
+)
+
+function renderFoldedTree(): { onActivateNode: ReturnType<typeof vi.fn>; marker: HTMLElement } {
+  const onActivateNode = vi.fn()
+  render(
+    <MindMapTree nodes={foldedMap.nodes} label="Map of Test Note" onActivateNode={onActivateNode} />
+  )
+  const node = foldedMap.nodes.find((candidate) => candidate.kind === 'more')!
+  const marker = within(screen.getByRole('tree'))
+    .getAllByRole('treeitem')
+    .find((item) => item.dataset.mindMapNode === node.id)
+  if (!marker) throw new Error('no tree item for the fold marker')
+  return { onActivateNode, marker }
+}
+
 describe('MindMapTree', () => {
+  it('announces a fold marker as a branch that is shut, and opens it on Enter', () => {
+    const { onActivateNode, marker } = renderFoldedTree()
+
+    // Not a dead label: a treeitem that says it is collapsed is a control a
+    // reader knows to activate, which is the whole point of "+N more".
+    expect(marker).toHaveAttribute('aria-expanded', 'false')
+    expect(marker).toHaveAttribute('data-mind-map-kind', 'more')
+    expect(marker).toHaveTextContent('+28 more')
+    expect(marker).not.toHaveAttribute('data-mind-map-block')
+
+    fireEvent.keyDown(marker, { key: 'Enter' })
+    expect(onActivateNode).toHaveBeenCalledTimes(1)
+    expect(onActivateNode.mock.calls[0][0]).toMatchObject({ kind: 'more', foldedCount: 28 })
+
+    fireEvent.click(marker)
+    expect(onActivateNode).toHaveBeenCalledTimes(2)
+  })
+
   it('activates the node that was clicked, and only that node', () => {
     const { onActivateNode, items } = renderTree()
 

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.test.tsx
@@ -66,7 +66,12 @@ const foldedMap = buildMindMap(
 function renderFoldedTree(): { onActivateNode: ReturnType<typeof vi.fn>; marker: HTMLElement } {
   const onActivateNode = vi.fn()
   render(
-    <MindMapTree nodes={foldedMap.nodes} label="Map of Test Note" onActivateNode={onActivateNode} />
+    <MindMapTree
+      nodes={foldedMap.nodes}
+      label="Map of Test Note"
+      linkHint="link to another page"
+      onActivateNode={onActivateNode}
+    />
   )
   const node = foldedMap.nodes.find((candidate) => candidate.kind === 'more')!
   const marker = within(screen.getByRole('tree'))

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-tree.tsx
@@ -26,6 +26,19 @@ function isTickable(kind: MindMapNodeKind): boolean {
   return kind === 'check' || kind === 'task'
 }
 
+/**
+ * Whether this item announces itself as open, shut, or neither.
+ *
+ * A fold marker has no children of its own but stands for a branch that is
+ * shut, and activating it opens that branch in place. Saying so is the whole
+ * difference between "+3 more" reading as a dead label and reading as the
+ * control it is.
+ */
+function expandedState(branch: Branch): boolean | undefined {
+  if (branch.node.kind === 'more') return false
+  return branch.children.length > 0 ? true : undefined
+}
+
 interface MindMapTreeProps {
   nodes: readonly MindMapPositionedNode[]
   /** Translated; names the note the tree belongs to. */
@@ -90,7 +103,7 @@ function BranchItems({
           aria-level={level}
           aria-posinset={index + 1}
           aria-setsize={branches.length}
-          aria-expanded={branch.children.length > 0 ? true : undefined}
+          aria-expanded={expandedState(branch)}
           // A tickable item announces its tick. This is what "dimmed and struck
           // through" means to a reader who cannot see the drawing, so it is a
           // real ARIA state rather than the `data-` attribute next to it.

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
@@ -61,6 +61,13 @@ export type MindMapNodeKind =
    * is inside the note it names is the graph view's question, not this one's.
    */
   | 'wikiLink'
+  /**
+   * A fold marker: "+N more", standing for the children of its parent that the
+   * children-per-parent cap held back. It is not a place in the note — it is
+   * the handle that opens the branch again — so activating it expands rather
+   * than navigates. `foldedCount` is how many it stands for.
+   */
+  | 'more'
 
 /**
  * Content that is not structure. It never becomes a node; it is counted on the
@@ -114,10 +121,24 @@ export interface MindMapNode {
   /** Content sitting under this node that is not drawn, in a stable order. */
   contents: MindMapContentCount[]
   /**
-   * The second line of the node: its tags and its content counts, already
-   * composed. Tags are user content; the counts come from
-   * `MindMapOptions.formatContentCount`, so this is the one place the two
-   * projections read their badge text from and they cannot disagree.
+   * How many nodes folded INTO this one and are therefore not drawn anywhere:
+   * everything past the depth cap, plus everything the whole-map node cap had
+   * no budget left for. Zero for a node that hides nothing.
+   *
+   * On a `more` node this is not a fold into it but what it stands for — the
+   * children its parent held back — and it is what the node is labelled with.
+   *
+   * It is the number the "nothing disappears silently" promise is kept with, so
+   * it is data rather than only wording: a caller with no translator still sees
+   * exactly how much is not on the picture.
+   */
+  foldedCount: number
+  /**
+   * The second line of the node: its tags, its content counts and how much
+   * folded into it, already composed. Tags are user content; the counts come
+   * from `MindMapOptions.formatContentCount` and `MindMapOptions.formatMore`,
+   * so this is the one place the two projections read their badge text from and
+   * they cannot disagree.
    */
   detail: string
   children: MindMapNode[]
@@ -136,6 +157,7 @@ export interface MindMapPositionedNode {
   wikiTarget: string | null
   tags: string[]
   contents: MindMapContentCount[]
+  foldedCount: number
   detail: string
   parentId: string | null
   x: number
@@ -234,6 +256,30 @@ export interface MindMapOptions {
    * the data never disappears, only its wording.
    */
   formatContentCount?: (kind: MindMapContentKind, count: number) => string
+  /**
+   * Turns "two folded away" into words, for a `more` node's label and for the
+   * fold badge on a node something folded into. Supplied by the caller for the
+   * same reason `formatContentCount` is: a fold marker is app chrome and has to
+   * be translated and pluralised, while this pipeline stays pure.
+   *
+   * Omitting it labels a `more` node `+2` — a number, no language — and leaves
+   * the fold badge out of `detail`. `foldedCount` carries the fact either way.
+   */
+  formatMore?: (count: number) => string
+  /**
+   * Ids of the `more` nodes the user has opened, so their parents draw every
+   * child instead of folding the overflow.
+   *
+   * A set of ids rather than a boolean per branch because a `more` node's id is
+   * derived from its parent's, so the same branch opens to the same shape on
+   * every rebuild — expanding twice lands on identical coordinates.
+   *
+   * Deliberately NOT persisted anywhere: these ids are minted from block ids,
+   * which the note re-mints as soon as it is edited or opened on another
+   * device, so stored expansion would go stale the moment it mattered. It lives
+   * for as long as the map is open and no longer.
+   */
+  expanded?: ReadonlySet<string>
 }
 
 /**
@@ -248,8 +294,14 @@ export interface MindMap {
   /** Drawing elements: one box per node, one connector per parent→child edge. */
   elements: MindMapElement[]
   direction: MindMapDirection
-  /** Node total including the root. */
+  /** Node total including the root. Never above `MIND_MAP_MAX_NODES`. */
   nodeCount: number
+  /**
+   * True when the whole-map node cap is what stopped the map drawing more.
+   * The host says so above the picture: a user who cannot tell a complete map
+   * from a truncated one stops trusting either.
+   */
+  reachedNodeCap: boolean
   /** True when the note contributed nothing to branch from. */
   isEmpty: boolean
   bounds: MindMapBounds

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.test.tsx
@@ -51,10 +51,10 @@ const BLOCKS: MindMapSourceBlock[] = [
 
 const activateNode = vi.fn()
 
-function renderView(): ReturnType<typeof render> {
+function renderView(blocks: MindMapSourceBlock[] = BLOCKS): ReturnType<typeof render> {
   return render(
     <MindMapView
-      map={buildMindMap(BLOCKS, { rootLabel: 'Test Note', noteId: 'note-1' })}
+      map={buildMindMap(blocks, { rootLabel: 'Test Note', noteId: 'note-1' })}
       noteId="note-1"
       noteTitle="Test Note"
       onActivateNode={activateNode}
@@ -139,6 +139,49 @@ describe('MindMapView toolbar', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Copy as vector' }))
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to copy the map'))
+  })
+
+  it('says nothing about a limit the note never reaches', async () => {
+    await renderMap()
+
+    // The region is there — it has to already exist for a screen reader to
+    // announce it later — but it says nothing.
+    expect(screen.getByTestId('note-mind-map-cap-notice')).toBeEmptyDOMElement()
+  })
+
+  it('says the map is at its limit, above the picture and outside it', async () => {
+    // Wide and deep enough that the whole-map budget runs out on it.
+    const section = (id: string, level: number, text: string): MindMapSourceBlock => ({
+      id,
+      type: 'heading',
+      props: { level },
+      content: [{ type: 'text', text }]
+    })
+    const huge: MindMapSourceBlock[] = Array.from({ length: 12 }, (_, top) => [
+      section(`h1-${top}`, 1, `Section ${top}`),
+      ...Array.from({ length: 12 }, (_, mid) => [
+        section(`h2-${top}-${mid}`, 2, `Part ${top}.${mid}`),
+        {
+          id: `b-${top}-${mid}`,
+          type: 'bulletListItem',
+          content: [{ type: 'text', text: `Item ${top}.${mid}` }]
+        }
+      ]).flat()
+    ]).flat()
+    renderView(huge)
+
+    const notice = await screen.findByTestId('note-mind-map-cap-notice')
+    // Translated, and a live region so it also arrives when expanding a branch
+    // is what spent the last of the budget.
+    expect(notice).toHaveTextContent('This map is at its limit of 200 nodes')
+    expect(notice).toHaveAttribute('role', 'status')
+    // Above the drawing and never inside it: an image role makes its contents
+    // presentational, so a notice nested in it would reach nobody.
+    expect(screen.getByTestId('note-mind-map')).toContainElement(notice)
+    expect(screen.getByRole('img')).not.toContainElement(notice)
+    expect(notice.compareDocumentPosition(screen.getByRole('img'))).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
   })
 
   it('takes its controls back when the drawing surface goes away', async () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
@@ -1,6 +1,6 @@
 /**
- * The map surface: its toolbar, the drawing, its accessible twin, and the
- * empty-note hint.
+ * The map surface: its toolbar, the size notice, the drawing, its accessible
+ * twin, and the empty-note hint.
  *
  * Two projections of one layout result sit side by side here — the picture for
  * people who can see it, the tree for everyone and everything else. They are
@@ -108,6 +108,9 @@ export function MindMapView({
     [controls, copy, t]
   )
 
+  // Empty until the map is actually at its limit — see the region below.
+  const capNotice = map.reachedNodeCap ? t('mindMap.nodeCapNotice', { count: map.nodeCount }) : ''
+
   // A click on the drawing arrives as the deep link of the box it landed on;
   // that is the only handle a bitmap surface gives us. Resolving it back to a
   // node here means both projections end in the same activation, rather than
@@ -123,6 +126,23 @@ export function MindMapView({
   return (
     <div className="relative flex h-full w-full flex-col bg-background" data-testid="note-mind-map">
       <MindMapToolbar actions={actions} label={t('mindMap.toolbar.label')} />
+
+      {/* Above the picture and outside it, for the same reason the toolbar is:
+          anything inside an image role is presentational, and this is the one
+          line that tells a reader the map is not the whole note.
+
+          Mounted whether or not it has anything to say, and empty when it does
+          not. A live region that appears with its text already in it is one a
+          screen reader can miss entirely — and the moment this line matters
+          most is the one where opening a branch is what spent the last of the
+          budget, which happens while the reader is already here. */}
+      <p
+        role="status"
+        className={capNotice === '' ? 'sr-only' : 'px-3 pb-2 text-xs text-text-tertiary'}
+        data-testid="note-mind-map-cap-notice"
+      >
+        {capNotice}
+      </p>
 
       <div
         role="img"

--- a/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.test.tsx
@@ -33,6 +33,12 @@ const root = map.nodes.find((node) => node.kind === 'root')!
 const link = map.nodes.find((node) => node.kind === 'wikiLink')!
 const task = map.nodes.find((node) => node.kind === 'task')!
 
+/** A note wide enough that the root folds its overflow behind a marker. */
+const marker = buildMindMap(
+  Array.from({ length: 40 }, (_, index) => heading(`b-${index}`, 1, `Section ${index}`)),
+  { rootLabel: 'Test Note', noteId: 'note-1' }
+).nodes.find((node) => node.kind === 'more')!
+
 let container: HTMLElement
 let top: HTMLElement
 /** Every scroll the run asked for, in order, with what it was aimed at. */
@@ -42,9 +48,11 @@ function setup(options: { smooth?: boolean } = {}) {
   const close = vi.fn()
   const openNote = vi.fn()
   const openTask = vi.fn()
+  const expandBranch = vi.fn()
   const view = renderHook(() =>
     useMindMapNavigation({
       close,
+      expandBranch,
       getContainer: () => container,
       getTopElement: () => top,
       smooth: options.smooth ?? true,
@@ -52,7 +60,7 @@ function setup(options: { smooth?: boolean } = {}) {
       openTask
     })
   )
-  return { close, openNote, openTask, view }
+  return { close, openNote, openTask, expandBranch, view }
 }
 
 /** The block, once whatever gates the editor's render has let it through. */
@@ -123,6 +131,19 @@ describe('useMindMapNavigation', () => {
     renderBlock('b-alpha')
     await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
     for (const entry of scrolled) expect(entry.target).toBe(beta)
+  })
+
+  it('opens a fold marker in place, without closing the map or scrolling', () => {
+    const { close, expandBranch, view } = setup()
+
+    act(() => view.result.current.activateNode(marker))
+
+    expect(expandBranch).toHaveBeenCalledWith(marker.id)
+    // A fold is undone where it is: closing the map here would hide the branch
+    // the user just asked to see. (A wiki link also leaves the map open, but it
+    // leaves the NOTE — this one goes nowhere at all.)
+    expect(close).not.toHaveBeenCalled()
+    expect(scrolled).toHaveLength(0)
   })
 
   it('sends the root node to the top of the note', () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.ts
@@ -31,6 +31,11 @@ import { activateMindMapNode, type MindMapNodeActivation } from './mind-map-navi
 interface UseMindMapNavigationOptions {
   /** Closes the map. A no-op when it is already closed. */
   close: () => void
+  /**
+   * Opens the branch a "+N more" node stands for, in place. The one node kind
+   * that does not close the map: a fold is undone where it is, not by leaving.
+   */
+  expandBranch: (nodeId: string) => void
   /** The pane the block lives in — never the document, which in split view
    * would scroll whichever pane comes first rather than this one. */
   getContainer: () => HTMLElement | null
@@ -61,6 +66,7 @@ export interface UseMindMapNavigationResult {
 
 export function useMindMapNavigation({
   close,
+  expandBranch,
   getContainer,
   getTopElement,
   smooth,
@@ -106,8 +112,8 @@ export function useMindMapNavigation({
   )
 
   const activateNode = useCallback<MindMapNodeActivation>(
-    (node) => activateMindMapNode(node, { navigateToBlock, openNote, openTask }),
-    [navigateToBlock, openNote, openTask]
+    (node) => activateMindMapNode(node, { navigateToBlock, openNote, openTask, expandBranch }),
+    [navigateToBlock, openNote, openTask, expandBranch]
   )
 
   return useMemo(() => ({ navigateToBlock, activateNode }), [navigateToBlock, activateNode])

--- a/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map.ts
@@ -26,6 +26,19 @@ function parseMindMapOpen(raw: unknown): boolean | undefined {
   return typeof raw === 'boolean' ? raw : undefined
 }
 
+/**
+ * No branch opened. A shared, frozen value so closing an already-collapsed map
+ * is a no-op to React rather than a fresh set on every commit.
+ *
+ * Note what is NOT here: a view-state key. Expansion is deliberately kept in
+ * memory only. The ids in it are derived from block ids, which the note re-mints
+ * whenever it is edited, rebuilt or opened on another device, so persisting them
+ * would fill tab state with identifiers that are stale by the time they are read
+ * — and would have to be parsed and kept version-tolerant forever for a state
+ * the user restores with one click.
+ */
+const NO_EXPANSION: ReadonlySet<string> = new Set<string>()
+
 /** The slice of a BlockNote editor the map reads. */
 interface BlockTreeHost {
   document?: unknown
@@ -67,6 +80,11 @@ export interface UseMindMapResult {
   close: () => void
   /** Null until the map is open and has been built. */
   map: MindMap | null
+  /**
+   * Open the branch a "+N more" node stands for. In-memory only: it is dropped
+   * when the map closes, and never written to tab view state.
+   */
+  expandBranch: (nodeId: string) => void
   /** Pass to the content area in place of the callback that was composed in. */
   handleEditorReady: (editor: unknown) => void
   /**
@@ -108,6 +126,12 @@ export function useMindMap({
     []
   )
 
+  /** Same contract, same reason: a fold marker is chrome, so it is translated. */
+  const formatMore = useCallback(
+    (count: number) => translate.current('mindMap.more', { count }),
+    []
+  )
+
   const [storedOpen, setStoredOpen] = useTabViewState<boolean>({
     key: MIND_MAP_VIEW_STATE_KEY,
     defaultValue: false,
@@ -118,6 +142,16 @@ export function useMindMap({
   const editorRef = useRef<BlockTreeHost | null>(null)
   const [editorRevision, setEditorRevision] = useState(0)
   const [map, setMap] = useState<MindMap | null>(null)
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(NO_EXPANSION)
+
+  const expandBranch = useCallback((nodeId: string) => {
+    setExpanded((previous) => {
+      if (previous.has(nodeId)) return previous
+      const next = new Set(previous)
+      next.add(nodeId)
+      return next
+    })
+  }, [])
 
   const handleEditorReady = useCallback(
     (editor: unknown) => {
@@ -134,16 +168,23 @@ export function useMindMap({
         rootLabel: noteTitle,
         direction,
         noteId,
-        formatContentCount
+        formatContentCount,
+        formatMore,
+        expanded
       }),
-    [direction, noteId, noteTitle, formatContentCount]
+    [direction, noteId, noteTitle, formatContentCount, formatMore, expanded]
   )
 
   // Layout, not passive: the note body is hidden in the same commit that flips
   // the toggle, so a map that arrived a frame later would paint a blank gap.
+  //
+  // Closing drops the expansion with the map. Nothing to clean up on the way
+  // out, and nothing to reconcile on the way in: the next open is the note's
+  // shape as the note is now, which is the only shape those ids still fit.
   useLayoutEffect(() => {
     if (!isOpen) {
       setMap(null)
+      setExpanded(NO_EXPANSION)
       return
     }
     setMap(build())
@@ -166,7 +207,7 @@ export function useMindMap({
   }, [storedOpen, setStoredOpen])
 
   return useMemo(
-    () => ({ isAvailable, isOpen, toggle, close, map, handleEditorReady, refresh }),
-    [isAvailable, isOpen, toggle, close, map, handleEditorReady, refresh]
+    () => ({ isAvailable, isOpen, toggle, close, map, expandBranch, handleEditorReady, refresh }),
+    [isAvailable, isOpen, toggle, close, map, expandBranch, handleEditorReady, refresh]
   )
 }

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -1918,5 +1918,111 @@ describe('NotePage', () => {
       )
       expect(screen.getByTestId('note-mind-map')).toBeInTheDocument()
     })
+
+    describe('caps and folding', () => {
+      /** More bullets under one heading than the map draws at once. */
+      const overflowing = (count: number): unknown[] => [
+        {
+          id: 'b-h1',
+          type: 'heading',
+          props: { level: 1 },
+          content: [{ type: 'text', text: 'Alpha' }]
+        },
+        ...Array.from({ length: count }, (_, index) => ({
+          id: `b-item-${index + 1}`,
+          type: 'bulletListItem',
+          content: [{ type: 'text', text: `Item ${index + 1}` }]
+        }))
+      ]
+
+      const treeItems = (): HTMLElement[] =>
+        within(screen.getByRole('tree')).getAllByRole('treeitem')
+
+      const marker = (): HTMLElement | null =>
+        screen.getByRole('tree').querySelector<HTMLElement>('[data-mind-map-kind="more"]')
+
+      it('opens a folded branch in place and never writes down that it did', async () => {
+        mocks.editorBlocks = overflowing(15)
+        renderWithProviders(<NotePage noteId="note-1" />)
+        await openMap()
+
+        // Root, the heading, the children that fit, and one marker for the rest
+        // — translated and pluralised through the app's own layer.
+        expect(treeItems()).toHaveLength(15)
+        expect(marker()).toHaveTextContent('mindMap.more:{"count":3}')
+
+        // Through the drawing, which is where a user actually clicks: the
+        // bitmap hands back the box's deep link and nothing else.
+        fireEvent.click(drawnBoxFor('memry://note/note-1#^mm-b-h1-more'))
+
+        await waitFor(() => expect(marker()).toBeNull())
+        expect(treeItems()).toHaveLength(17)
+        // In place: the map is still open. A fold is undone where it is, and
+        // the one node kind that is not a place in the note does not navigate.
+        expect(screen.getByTestId('note-mind-map')).toBeInTheDocument()
+
+        // Nothing about the expansion reached tab state. Node ids are minted
+        // from block ids, so a stored one is stale the moment the note changes.
+        expect(mocks.tabViewState).toMatchObject({ noteMindMap: true })
+        expect(JSON.stringify(mocks.tabViewState)).not.toContain('mm-')
+        expect(JSON.stringify(mocks.tabViewState)).not.toContain('more')
+      })
+
+      it('forgets an expansion when the map closes', async () => {
+        mocks.editorBlocks = overflowing(15)
+        renderWithProviders(<NotePage noteId="note-1" />)
+        await openMap()
+        fireEvent.click(drawnBoxFor('memry://note/note-1#^mm-b-h1-more'))
+        await waitFor(() => expect(marker()).toBeNull())
+
+        fireEvent.click(screen.getByTestId('note-mind-map-toggle'))
+        await waitFor(() => expect(screen.queryByTestId('note-mind-map')).not.toBeInTheDocument())
+        fireEvent.click(screen.getByTestId('note-mind-map-toggle'))
+        await screen.findByTestId('note-mind-map')
+
+        // Back to the folded shape: expansion lives exactly as long as the map.
+        expect(marker()).toHaveTextContent('mindMap.more:{"count":3}')
+        expect(treeItems()).toHaveLength(15)
+      })
+
+      it('says above the map when it is at its limit, and stays quiet otherwise', async () => {
+        renderWithProviders(<NotePage noteId="note-1" />)
+        await openMap()
+        expect(screen.getByTestId('note-mind-map-cap-notice')).toBeEmptyDOMElement()
+
+        fireEvent.click(screen.getByTestId('note-mind-map-toggle'))
+        await waitFor(() => expect(screen.queryByTestId('note-mind-map')).not.toBeInTheDocument())
+
+        // A note far past the whole-map budget: wide, and three levels deep.
+        mocks.editorBlocks = Array.from({ length: 12 }, (_, top) => [
+          {
+            id: `h1-${top}`,
+            type: 'heading',
+            props: { level: 1 },
+            content: [{ type: 'text', text: `Section ${top}` }]
+          },
+          ...Array.from({ length: 12 }, (_, mid) => [
+            {
+              id: `h2-${top}-${mid}`,
+              type: 'heading',
+              props: { level: 2 },
+              content: [{ type: 'text', text: `Part ${top}.${mid}` }]
+            },
+            {
+              id: `b-${top}-${mid}`,
+              type: 'bulletListItem',
+              content: [{ type: 'text', text: `Item ${top}.${mid}` }]
+            }
+          ]).flat()
+        ]).flat()
+        await openMap()
+
+        const notice = await screen.findByTestId('note-mind-map-cap-notice')
+        expect(notice).toHaveTextContent('mindMap.nodeCapNotice:{"count":200}')
+        // Above the picture and outside it — an image role's contents are
+        // presentational, so a notice inside it would reach nobody.
+        expect(screen.getByRole('img')).not.toContainElement(notice)
+      })
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -1261,6 +1261,7 @@ export function NotePage({ noteId }: NotePageProps) {
   )
   const mindMapNavigation = useMindMapNavigation({
     close: mindMap.close,
+    expandBranch: mindMap.expandBranch,
     getContainer: getEditorContainer,
     getTopElement: getNoteBody,
     smooth: !prefersReducedMotion,

--- a/apps/docs/src/user-guide/notes/mind-map.md
+++ b/apps/docs/src/user-guide/notes/mind-map.md
@@ -98,7 +98,8 @@ omission is visible on the map, and most of them you can open back up.
   deepest node still drawn, and that node carries a `+N more` badge saying how
   much is behind it. Click that node to open the note at that block and read the
   rest there.
-- **Very long labels** are clipped with an ellipsis. The node still opens the
+- **Very long labels** are clipped with an ellipsis — a very long note title
+  included, since the root is a box like any other. The node still opens the
   block, where the full text is.
 - **A very large note.** The map draws at most 200 nodes. When it reaches that,
   a one-line notice appears above the map and whatever is left over is counted

--- a/apps/docs/src/user-guide/notes/mind-map.md
+++ b/apps/docs/src/user-guide/notes/mind-map.md
@@ -83,6 +83,35 @@ dropped:
   a `[[wiki link]]` is the one inline thing that does not, because it points
   somewhere else.
 
+## When a Note Is Big
+
+A map that draws everything stops being readable, so the map has limits. The
+rule that governs all of them is that **nothing disappears quietly**: every
+omission is visible on the map, and most of them you can open back up.
+
+- **Too many items under one heading.** The first dozen are drawn and the rest
+  stand behind a **`+N more`** node. Click it — or select it and press Enter —
+  and that branch opens in place, right where it was. Nothing else on the map
+  moves. Wiki-link nodes count towards this like anything else, so a section
+  packed with links folds the same way rather than sprawling.
+- **Branches nested very deep.** Anything past six levels folds into the
+  deepest node still drawn, and that node carries a `+N more` badge saying how
+  much is behind it. Click that node to open the note at that block and read the
+  rest there.
+- **Very long labels** are clipped with an ellipsis. The node still opens the
+  block, where the full text is.
+- **A very large note.** The map draws at most 200 nodes. When it reaches that,
+  a one-line notice appears above the map and whatever is left over is counted
+  on the nearest node that is drawn, in the same `+N more` badge.
+
+Opening a branch is not a way around the 200-node limit: if opening one fills
+the map, the notice appears and the rest folds onto the node above it.
+
+Branches you open are remembered for as long as the map is open and no longer.
+Close the map and open it again and it is back to its folded shape — the map is
+rebuilt from the note each time, and a note that has been edited would not have
+the same branches to open anyway.
+
 ## Clicking a Node
 
 The map is navigation, not just a picture.
@@ -101,6 +130,8 @@ The map is navigation, not just a picture.
   body does.
 - Opening another note leaves the map where it was. It is a view of _this_ note,
   so the tab you came from is still on the map when you return to it.
+- Click a **`+N more`** node to open that branch in place. This is the other
+  node that does not take you back into the note: a fold is undone where it is.
 - The **outline panel** stays available while the map shows, and clicking a
   heading there does exactly the same thing. One control, one behaviour.
 

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -969,6 +969,8 @@
     "treeLabel": "Mind map outline of {title}",
     "emptyHint": "Add a heading to this note and the map will branch.",
     "linkHint": "link to another page",
+    "more": "{count, plural, one {+# more} other {+# more}}",
+    "nodeCapNotice": "This map is at its limit of {count, plural, one {# node} other {# nodes}}; the rest is folded into the nearest node above it.",
     "badge": {
       "table": "{count, plural, one {# table} other {# tables}}",
       "code": "{count, plural, one {# code block} other {# code blocks}}",


### PR DESCRIPTION
Implements #1673 (part of #1667). Draft — sibling #1675 is still in flight and touches the same files, so a further rebase is expected. Do not merge.

**Rebased onto `bebbe2173` (#1672).** Eleven conflicts, resolved by keeping both intentions. The one that needed real thought is `nodeFromMindMapLink`: #1672 and this branch each added a node-id fallback for a different blockless box, and there is now **one** fallback serving both — blocks match by block id first, and the fallback considers only nodes with `blockId === null`. That guard is what keeps all three guarantees at once: a real block's link can never land on one of these boxes, a fold marker never resolves to the root, and a wiki-link box never resolves to a place in this note. The same collapse happened in `mind-map-elements.ts`, where #1672's `node.blockId ?? (kind === 'root' ? null : node.id)` already subsumes the fold marker, so this branch's separate rule was dropped rather than kept alongside it.

**Wiki links now go through the caps.** #1672 pushed link nodes straight onto their parent; they are placed through `placeUnder` like any other node, so a heading full of links folds behind a `+N more` instead of sprawling, an over-deep link is counted on the deepest node drawn, and links inside an already-folded branch are counted on the marker. Nothing of #1672's behaviour changed for a note inside the caps.

## What changed

Four caps come into force, and the half that matters is what happens at each one: **nothing disappears silently.**

**One accounting invariant governs all of it**, and the tests assert it directly rather than only asserting that caps hold: every **candidate** is either **drawn exactly once** or **counted exactly once** on a node that is drawn.

"Candidate" is deliberately wider than "block" since #1672: a wiki link is a run of inline content that becomes a node of its own, so it is a candidate too, and a block that draws no box (a paragraph, or a list item holding only links) is not one. The test's counter was widened to match — `countCandidates` rather than `countBlocks` — and four fixtures now carry links, including links behind each of the three folding routes.

- **Depth cap — 6 levels below the root.** A node past it is not drawn; it folds into the nearest node still drawn, which then carries a `+N more` badge. Depth is counted in nodes that are *drawn*, so a block with nothing to show costs no depth — which is #1671's blank-heading rule, now sharing one code path with real folding. A blank node still folds the same way, but adds nothing to the count, because it hid nothing.
- **Label cap — 72 characters.** Clipped with an ellipsis. The node still opens the block that holds the full text, so the clip is visible and recoverable.
- **Children cap — 12 per parent.** The overflow stands behind one `+N more` node, clickable on the drawing and in the tree, keyboard-activatable, and it opens that branch **in place**. It counts the whole branch behind it — direct children *and* their subtrees — because `+1 more` hiding forty nodes is exactly the quiet loss this ticket exists to prevent.
- **Total cap — 200 nodes.** Reaching it shows a one-line translated notice above the map. Whatever is over budget is counted on the nearest node still drawn, in the same `+N more` badge.

**Depth accounting respects container nesting**: a heading written inside a toggle or callout stays inside it and is measured at the depth it actually draws at.

## Shapes

```ts
// new kind; the dispatch still ends in `const unhandled: never = node.kind`
type MindMapNodeKind = 'root' | 'heading' | 'bullet' | 'numbered' | 'check'
                     | 'task' | 'toggle' | 'callout' | 'more'

interface MindMapNodeActions {
  navigateToBlock: (blockId: string | null) => void
  expandBranch: (nodeId: string) => void   // the one kind that is not a place in the note
}

// on MindMapNode and MindMapPositionedNode
foldedCount: number       // how much folded into this node; on a `more` node, what it stands for

// on MindMapOptions
formatMore?: (count: number) => string     // same contract as formatContentCount
expanded?: ReadonlySet<string>             // ids of opened `more` nodes

// on MindMap
reachedNodeCap: boolean
```

Cap values live in a new **private** module `mind-map-caps.ts`. It is not re-exported from `index.ts`; `buildMindMap` remains the only public seam.

## Expansion is not persisted

A marker's id is derived from its parent's (`${parentNodeId}-more`), so the same branch opens to the same shape and the same coordinates on every rebuild.

The set lives in `useMindMap` React state and is cleared in the same layout effect that drops the map when the toggle closes. It is never written to tab view state: the ids come from block ids, which the note re-mints whenever it is edited, rebuilt or opened on another device, so a stored one would be stale by the time it was read — and would need a parse function and version tolerance forever, for a state one click restores.

**The total cap still holds after an expansion.** The node budget is applied uniformly during projection, so opening a huge branch fills the map to 200 and folds the rest onto the node above it, with the notice appearing.

## Acceptance criteria

- [x] **Depth, label length, children-per-parent and total node caps are enforced.** `build-mind-map-caps.test.ts`, one describe per cap; `expectNothingLost` re-asserts all four on every fixture.
- [x] **Content past the depth cap folds into its nearest visible ancestor rather than being dropped, and that ancestor carries a `+N more` badge.** "folds what is past the cap into the deepest node still drawn" asserts `foldedCount === 2` **and** `detail === '+2 more'`; "counts depth through a container…" covers the nested case.
- [x] **A `+N more` node is clickable and keyboard-activatable, and expands that branch in place; the overall node cap still holds after expansion.** `mind-map-tree.test.tsx` (Enter and click, `aria-expanded="false"`), `mind-map-navigation.test.ts` (dispatch routes to `expandBranch`, never `navigateToBlock`; the drawn box's link resolves back to the marker), `use-mind-map-navigation.test.tsx` (does not close the map, does not scroll), `note.test.tsx` (click on the drawing, branch opens, map stays open), and "still holds the whole-map cap after an expansion".
- [x] **Expansion state resets when the map closes and is never persisted.** `note.test.tsx` — "forgets an expansion when the map closes", and "never writes down that it did" asserts `JSON.stringify(tabViewState)` contains no node id.
- [x] **Reaching the overall node cap shows a one-line translated notice above the map.** `mind-map-view.test.tsx` and `note.test.tsx` — translated through the i18n layer, `role="status"`, a sibling of the `role="img"` region and before it in document order.
- [x] **Unit tests cover each cap, depth folding, expansion, and assert that no content is silently dropped.** 22 cases in `build-mind-map-caps.test.ts`; the four under `nothing disappears silently` are the direct proof, and two mutations (dropping the depth fold count, dropping the folded-subtree count) were confirmed to turn them red.

## Invariants held

- Editor hidden and inert, never unmounted — untouched; the existing editor-identity assertion still passes.
- One public entry point. `buildMindMap` is still the only seam; no private module is exported.
- Layout deterministic — "lays out identically whether or not the boxes carry links" and "lays the same note out identically on every call" pass unchanged, plus a new "opens an expanded branch to identical coordinates every time".
- No IPC contract, no migration, no sync handler, no settings schema.
- Header overflow menu unchanged in both modes; still gated on `spatialCanvas`.
- Toolbar still a sibling of the `role="img"` region; the notice is a sibling too.

## Judgement calls, flagged rather than buried

1. **A blank node adds nothing to the fold count.** #1671's blank heading and an over-deep node now fold by the identical code path and are measured the same way. They differ in one place only: a blank node hid nothing, so it counts for nothing. Counting it would put `+7 more` on a heading above a run of empty spacer bullets and send the user looking for content that does not exist.
2. **`+N more` counts the whole hidden branch**, not just the hidden siblings. The conventional reading is "N more siblings", but that number would understate what is behind the fold, and completeness is the promise this ticket is built on.
3. **A fold marker's box carries its own node id in the link anchor.** The bitmap hands a click back as a link and nothing else; without this a click on `+N more` would resolve to the root and scroll the user to the top of their note. Only blockless nodes are eligible for id matching, so a real block's link can never resolve to the wrong node.
4. **Depth folding is not expandable.** It is visible (the badge) and recoverable by navigation (click the node, land at the block) — which matches the spec's "every omission is visible and most are recoverable".

## Gates

```
$ pnpm lint                                     EXIT=0
✖ 108 problems (0 errors, 108 warnings)
  (all pre-existing; zero in any changed file)

$ pnpm typecheck                                EXIT=0
 Tasks:    17 successful, 17 total

$ pnpm test                                     EXIT=1  <- known turbo flake
@memry/contracts:test:      Test Files  50 passed (50)
@memry/editor-schema:test:  Test Files  3 passed (3)      Tests  95 passed
@memry/i18n:test:           Test Files  11 passed (11)    Tests  56 passed
@memry/sync-harness:test:   Test Files  5 passed (5)      Tests  32 passed
@memry/sync-server:test:    Test Files  62 passed (62)    Tests  966 passed
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command was killed with SIGSEGV
  (17810 desktop tests had passed with zero failures when the runner segfaulted)

$ pnpm test:desktop                             EXIT=0  <- the re-run
 Test Files  1378 passed | 3 skipped (1381)
      Tests  17954 passed | 1 expected fail | 13 skipped (17968)

$ pnpm --filter @memry/desktop i18n:check       EXIT=0
ok: i18n check passed

$ pnpm docs:impact --base bebbe2173 --strict    EXIT=0
docs impact: covered against bebbe2173
docs impact: docs changed on this branch

$ pnpm docs:build                               EXIT=0
build complete in 5.10s

Merged en/notes.json verified programmatically, not by eye:
  mindMap keys = badge, emptyHint, linkHint, more, nodeCapNotice,
                 regionLabel, toolbar, treeLabel
  vs origin/main: added mindMap.more + mindMap.nodeCapNotice, removed nothing
```
