### PR TITLE
feat(notes): save the mind map as a canvas (#1675)

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.test.ts
@@ -339,7 +339,7 @@ describe('buildMindMap — elements', () => {
 
   it('mints one box per node and one connector per edge', () => {
     const boxes = map.elements.filter((element) => element.type === 'rectangle')
-    const edges = map.elements.filter((element) => element.type === 'line')
+    const edges = map.elements.filter((element) => element.type === 'arrow')
 
     expect(boxes).toHaveLength(map.nodeCount)
     expect(edges).toHaveLength(map.nodeCount - 1)
@@ -352,7 +352,7 @@ describe('buildMindMap — elements', () => {
 
     const boxIds = new Set(map.nodes.map((node) => node.id))
     for (const element of map.elements) {
-      if (element.type !== 'line') continue
+      if (element.type !== 'arrow') continue
       // A connector is named after the child it lands on, and every child in
       // the map has a box; a dangling connector would draw a line to nowhere.
       expect(boxIds.has(element.id.replace(/-edge$/, ''))).toBe(true)
@@ -361,10 +361,32 @@ describe('buildMindMap — elements', () => {
     }
   })
 
+  it('binds each connector to the two boxes it joins, by their own ids', () => {
+    const byId = new Map(map.nodes.map((node) => [node.id, node]))
+    const boxIds = new Set(map.elements.filter((el) => el.type === 'rectangle').map((el) => el.id))
+    const arrows = map.elements.filter((element) => element.type === 'arrow')
+    expect(arrows.length).toBeGreaterThan(0)
+
+    for (const arrow of arrows) {
+      const child = byId.get(arrow.id.replace(/-edge$/, ''))!
+      // Bindings, not baked coordinates: a node dragged in a saved canvas has
+      // to take its connectors with it, and frozen endpoints do not follow.
+      expect(arrow.start).toEqual({ id: child.parentId })
+      expect(arrow.end).toEqual({ id: child.id })
+      // Both ends must name a box that is actually in the scene, or the
+      // drawing library resolves the binding to nothing.
+      expect(boxIds.has(arrow.start.id)).toBe(true)
+      expect(boxIds.has(arrow.end.id)).toBe(true)
+      // A branch is a rule, not a direction.
+      expect(arrow.startArrowhead).toBeNull()
+      expect(arrow.endArrowhead).toBeNull()
+    }
+  })
+
   it('draws connectors from the parent box to the child box', () => {
     const byId = new Map(map.nodes.map((node) => [node.id, node]))
     for (const element of map.elements) {
-      if (element.type !== 'line') continue
+      if (element.type !== 'arrow') continue
       const child = byId.get(element.id.replace(/-edge$/, ''))!
       const parent = byId.get(child.parentId!)!
       expect(element.x).toBe(parent.x + parent.width)

--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.ts
@@ -27,7 +27,7 @@ export function buildMindMap(
   return {
     tree,
     nodes,
-    elements: mintElements(nodes, direction, options.noteId),
+    elements: mintElements(nodes, direction, { noteId: options.noteId }),
     direction,
     nodeCount: nodes.length,
     reachedNodeCap,

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.tsx
@@ -21,20 +21,10 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Excalidraw, convertToExcalidrawElements } from '@excalidraw/excalidraw'
 import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
-import type { ExcalidrawElementSkeleton } from '@excalidraw/excalidraw/data/transform'
 import '@excalidraw/excalidraw/index.css'
 import { useTheme } from 'next-themes'
-import { copySceneAsImage, copySceneAsVector } from './mind-map-export'
+import { copySceneAsImage, copySceneAsVector, toSkeleton } from './mind-map-export'
 import type { MindMapElement } from './mind-map-types'
-
-/**
- * The map's element descriptors are plain data so the pipeline that mints them
- * stays pure and testable without this chunk. Excalidraw's own skeleton type
- * brands its point tuples, which no plain literal can satisfy, so the handover
- * happens here, once, at the boundary.
- */
-const toSkeleton = (elements: readonly MindMapElement[]): ExcalidrawElementSkeleton[] =>
-  elements as unknown as ExcalidrawElementSkeleton[]
 
 /**
  * What the map's toolbar can do, closed over the live surface.

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
@@ -56,12 +56,52 @@ const MORE_STROKE = '#ff671a'
 const ROUNDNESS = { type: 3 }
 
 /**
+ * Which anchor a box's deep link carries.
+ *
+ * - `block` — the drawn map, handed straight back into the session that minted
+ *   it. Exact, and worthless anywhere else: a block id lives exactly as long as
+ *   the document that minted it.
+ * - `heading` — a map written to a file. Heading TEXT is all a link can carry
+ *   that outlives the document, and it is the house convention already
+ *   (`[[Note#Heading]]`). A node with no heading above it anchors on nothing,
+ *   which reads as "this note, from the top".
+ */
+export type MindMapLinkAnchor = 'block' | 'heading'
+
+export interface MintElementsOptions {
+  /** Given, every box carries a deep link back into this note. */
+  noteId?: string
+  /** Defaults to `block` — the drawn map's anchor. */
+  anchor?: MindMapLinkAnchor
+  /**
+   * An extra badge on the root box, ahead of whatever it already carries. The
+   * saved snapshot puts its generation date here so a canvas found months later
+   * says what it is; the drawn map passes nothing and reads as it always has.
+   *
+   * Ahead of, never instead of: the root's own detail may say how much folded
+   * into it, and replacing that line would drop the one thing telling the
+   * reader the map is not the whole note.
+   */
+  rootDetail?: string
+  /**
+   * Node id → the href that node's box should carry instead of an anchor into
+   * this note. Only read in `heading` mode, and only ever supplied for
+   * wiki-link nodes: their target is a title, and resolving a title to a note
+   * id is a database lookup this pure pipeline cannot do. The save path does
+   * the lookup and hands the answers in.
+   */
+  wikiHrefs?: ReadonlyMap<string, string>
+}
+
+/**
  * The deep link a box carries, or `undefined` when there is no note to point
  * at.
  *
  * Every box needs a link of its OWN, because the link is the only handle a
  * click on a bitmap has: two boxes sharing one would send a click to whichever
- * came first. So:
+ * came first.
+ *
+ * **On screen (`block`)** the link is an address within this session:
  *
  * - a box standing for a block anchors on that block;
  * - the root has no block — it is the note's title — so it carries no anchor,
@@ -77,9 +117,40 @@ const ROUNDNESS = { type: 3 }
  * lookup this pure pipeline cannot do. What a fold marker does is expand, which
  * is not a destination at all. Both are decided in `activateMindMapNode`; this
  * href only has to say WHICH box was clicked.
+ *
+ * **In a file (`heading`)** none of that survives. A node id means nothing to
+ * the device that opens the canvas, and there is no `activateMindMapNode` on
+ * the other side to interpret it — so every box anchors on the heading it sits
+ * under, and a box with no heading above it anchors on nothing and opens the
+ * note at the top. A wiki-link box is the one exception: it points OUT of this
+ * note, so the caller resolves its target and hands the href in through
+ * `wikiHrefs`, and a target that resolves to nothing falls back to the same
+ * heading anchor as everything else — which is at least where the link is
+ * written.
  */
-function nodeLink(node: MindMapPositionedNode, noteId: string | undefined): string | undefined {
+function nodeLink(
+  node: MindMapPositionedNode,
+  { noteId, anchor, wikiHrefs }: MintElementsOptions & { anchor: MindMapLinkAnchor }
+): string | undefined {
+  // Resolved by the caller, because a wiki target is a title and turning one
+  // into an id is a database lookup this pipeline must not grow.
+  if (anchor === 'heading') {
+    const resolved = wikiHrefs?.get(node.id)
+    if (resolved) return resolved
+  }
+
   if (!noteId) return undefined
+
+  if (anchor === 'heading') {
+    return (
+      buildMemryHref({
+        kind: 'note',
+        id: noteId,
+        anchor: node.headingText ? { type: 'heading', text: node.headingText } : null
+      }) ?? undefined
+    )
+  }
+
   const anchorId = node.blockId ?? (node.kind === 'root' ? null : node.id)
   return (
     buildMemryHref({
@@ -91,8 +162,15 @@ function nodeLink(node: MindMapPositionedNode, noteId: string | undefined): stri
 }
 
 /** What the box actually holds: the label, then its badge line when there is one. */
-function boxText(node: MindMapPositionedNode): string {
-  return node.detail === '' ? node.label : `${node.label}\n${node.detail}`
+function boxText(node: MindMapPositionedNode, detail: string): string {
+  return detail === '' ? node.label : `${node.label}\n${detail}`
+}
+
+/** How many wrapped lines a run of text takes inside a box of this width. */
+function linesIn(text: string, width: number): number {
+  if (text === '') return 0
+  const perLine = Math.max(1, Math.floor((width - PADDING_X * 2) / CHAR_WIDTH))
+  return Math.ceil(text.length / perLine)
 }
 
 /**
@@ -133,8 +211,9 @@ function strikeRules(node: MindMapPositionedNode, direction: MindMapDirection): 
 export function mintElements(
   nodes: readonly MindMapPositionedNode[],
   direction: MindMapDirection,
-  noteId?: string
+  options: MintElementsOptions = {}
 ): MindMapElement[] {
+  const { noteId, anchor = 'block', rootDetail, wikiHrefs } = options
   const byId = new Map(nodes.map((node) => [node.id, node]))
   const elements: MindMapElement[] = []
 
@@ -151,8 +230,12 @@ export function mintElements(
     const endX = direction === 'rtl' ? node.x + node.width : node.x
     const endY = node.y + Math.round(node.height / 2)
 
+    // A bound arrow, not a line between two frozen points. The coordinates
+    // above are only where it STARTS life; the binding is what keeps it
+    // attached to both boxes once someone drags one, which is the whole
+    // difference between a picture and a canvas the user can work in.
     elements.push({
-      type: 'line',
+      type: 'arrow',
       id: `${node.id}-edge`,
       x: startX,
       y: startY,
@@ -160,6 +243,11 @@ export function mintElements(
         [0, 0],
         [endX - startX, endY - startY]
       ],
+      start: { id: parent.id },
+      end: { id: node.id },
+      startArrowhead: null,
+      endArrowhead: null,
+      roundness: null,
       strokeColor: EDGE_STROKE,
       strokeWidth: 1,
       roughness: 0
@@ -170,14 +258,24 @@ export function mintElements(
     const isRoot = node.kind === 'root'
     const isLink = node.kind === 'wikiLink'
     const isMore = node.kind === 'more'
+    const detail =
+      isRoot && rootDetail
+        ? [rootDetail, node.detail].filter((part) => part !== '').join(' · ')
+        : node.detail
     elements.push({
       type: 'rectangle',
       id: node.id,
-      link: nodeLink(node, noteId),
+      link: nodeLink(node, { noteId, anchor, wikiHrefs }),
       x: node.x,
       y: node.y,
       width: node.width,
-      height: node.height,
+      // A dated root needs lines the layout did not budget for. Grown here
+      // rather than in the layout, and downwards only: the drawn map's geometry
+      // stays byte-identical to what it has always been, and the root is alone
+      // in its column so nothing sits under it to collide with.
+      height:
+        node.height +
+        (linesIn(detail, node.width) - linesIn(node.detail, node.width)) * LINE_HEIGHT,
       strokeColor: isRoot
         ? ROOT_STROKE
         : isLink
@@ -200,7 +298,7 @@ export function mintElements(
       roundness: ROUNDNESS,
       ...(isLink && { strokeStyle: 'dashed' as const }),
       label: {
-        text: boxText(node),
+        text: boxText(node, detail),
         fontSize: MIND_MAP_FONT_SIZE,
         textAlign: direction === 'rtl' ? 'right' : 'left',
         verticalAlign: 'middle',

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-export.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-export.ts
@@ -1,12 +1,12 @@
 /**
- * Taking the map with you.
+ * Taking the map with you — onto the clipboard, or into a canvas of your own.
  *
  * Part of the lazy drawing chunk: it imports @excalidraw/excalidraw, so it is
- * only ever reached from `mind-map-canvas.tsx` and never from a module the main
+ * only ever reached through a dynamic import and never from a module the main
  * renderer bundle can see.
  *
- * The scene comes from the LIVE surface, never from a fresh `buildMindMap`
- * call. What the user copies has to be what the user is looking at — including
+ * A COPY comes from the LIVE surface, never from a fresh `buildMindMap` call.
+ * What the user copies has to be what the user is looking at — including
  * branches they expanded — and only the surface knows that.
  *
  * Both paths go through `navigator.clipboard`, which is the app's existing
@@ -24,11 +24,36 @@
  * Neither path needs a main-process channel, so no IPC contract is touched.
  */
 
-import { exportToBlob, exportToSvg } from '@excalidraw/excalidraw'
+import { convertToExcalidrawElements, exportToBlob, exportToSvg } from '@excalidraw/excalidraw'
 import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
+import type { ExcalidrawElementSkeleton } from '@excalidraw/excalidraw/data/transform'
+import { mindMapSceneJson } from './mind-map-snapshot'
+import type { MindMapElement } from './mind-map-types'
 
 /** The slice of the live surface an export reads. */
 export type MindMapSceneSource = Pick<ExcalidrawImperativeAPI, 'getSceneElements' | 'getFiles'>
+
+/**
+ * The map's element descriptors are plain data so the pipeline that mints them
+ * stays pure and testable without this chunk. The library's own skeleton type
+ * brands its point tuples, which no plain literal can satisfy, so the handover
+ * happens at the boundary — here and in `mind-map-canvas.tsx`.
+ */
+export const toSkeleton = (elements: readonly MindMapElement[]): ExcalidrawElementSkeleton[] =>
+  elements as unknown as ExcalidrawElementSkeleton[]
+
+/**
+ * Snapshot skeletons → a canvas document the vault can store.
+ *
+ * The conversion is what turns `start`/`end` ids into real arrow bindings, so
+ * a node dragged in the saved canvas keeps its connectors: the library
+ * regenerates every id on the way in and resolves the two by the ids the
+ * skeletons carried. It lives in this chunk because it is the drawing library's
+ * job; the document it goes into is minted purely (see `mind-map-snapshot.ts`).
+ */
+export function toCanvasScene(elements: readonly MindMapElement[]): string {
+  return mindMapSceneJson(convertToExcalidrawElements(toSkeleton(elements)))
+}
 
 /** Breathing room around the drawing, in scene units. */
 const EXPORT_PADDING = 16

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-layout.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-layout.ts
@@ -140,6 +140,7 @@ export function layoutMindMap(
       isDone: item.node.isDone,
       taskId: item.node.taskId,
       wikiTarget: item.node.wikiTarget,
+      headingText: item.node.headingText,
       tags: item.node.tags,
       contents: item.node.contents,
       foldedCount: item.node.foldedCount,

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-projection.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-projection.ts
@@ -187,6 +187,9 @@ export function projectBlocks(
     isDone: false,
     taskId: null,
     wikiTarget: null,
+    // The root is the note itself, so it stands under no heading: a link to it
+    // reads as "this note, from the top".
+    headingText: null,
     tags: [],
     contents: [],
     foldedCount: 0,
@@ -274,6 +277,9 @@ export function projectBlocks(
       // outside this note and it is not a task.
       taskId: null,
       wikiTarget: null,
+      // What it folds away lives under the same heading its parent does, so a
+      // saved canvas can still point at the section the missing rows are in.
+      headingText: parent.headingText,
       tags: [],
       contents: [],
       foldedCount: 0,
@@ -327,6 +333,10 @@ export function projectBlocks(
         isDone: false,
         taskId: null,
         wikiTarget: link.target,
+        // The heading the LINK is written under, in THIS note — not anything
+        // about the note it names. It is the fallback a saved canvas falls back
+        // to when the target cannot be resolved to a real note.
+        headingText: parent.headingText,
         tags: [],
         contents: [],
         foldedCount: 0,
@@ -428,6 +438,18 @@ export function projectBlocks(
         // never set one has none, and the node says so rather than inventing it.
         taskId: kind === 'task' ? stringProp(block.props, 'taskId') : null,
         wikiTarget: null,
+        // A heading anchors on itself; everything else borrows whatever heading
+        // it sits under. `parent` is the open heading when there is one and the
+        // enclosing container otherwise, and a container already carries the
+        // heading IT sits under — so one read walks the whole chain, containers
+        // and their fresh level stacks included.
+        //
+        // `text`, not `label`: `label` has been through `clipLabel`, and an
+        // anchor clipped mid-heading resolves to nothing on the device that
+        // opens the saved canvas. The whole text is also what `extractHeadings`
+        // reads back on the other side — both drop content-less inline specs (a
+        // hash tag among them), so a heading tagged inline still matches.
+        headingText: kind === 'heading' ? text : parent.headingText,
         tags: read.tags,
         contents: [],
         foldedCount: 0,

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-snapshot.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-snapshot.test.ts
@@ -1,0 +1,419 @@
+/**
+ * What a saved mind map actually contains.
+ *
+ * Everything here runs without a DOM and without the drawing library, which is
+ * what makes it cheap to be exhaustive about the three things that decide
+ * whether a canvas found six months from now on another device is any use: the
+ * anchor its links carry, the date on its root, and whether the document is a
+ * canvas at all.
+ *
+ * The one step this cannot cover is `convertToExcalidrawElements`, which turns
+ * these descriptors into real elements — the library's barrel cannot initialize
+ * under jsdom (the same reason every unit suite under `pages/canvas` mocks it).
+ * The stand-in below does what the converter does that matters here: it hands
+ * back elements with identity, leaving the fields this file asserts on
+ * untouched.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { parseMemryHref, tabFromMemryHref } from '@/lib/memry-links'
+import { buildMindMap } from './build-mind-map'
+import { mindMapSceneJson, mintSnapshotElements, uniqueCanvasTitle } from './mind-map-snapshot'
+import type { MindMapBoxElement, MindMapElement, MindMapSourceBlock } from './mind-map-types'
+
+const GENERATED = 'Snapshot · 21 Aug 2026'
+
+function heading(id: string, level: number, text: string): MindMapSourceBlock {
+  return { id, type: 'heading', props: { level }, content: [{ type: 'text', text }] }
+}
+
+function bullet(id: string, text: string, children?: MindMapSourceBlock[]): MindMapSourceBlock {
+  return { id, type: 'bulletListItem', content: [{ type: 'text', text }], children }
+}
+
+/** A paragraph carrying one `[[wiki link]]`, as the editor stores it. */
+function linkPara(id: string, target: string): MindMapSourceBlock {
+  return {
+    id,
+    type: 'paragraph',
+    content: [{ type: 'wikiLink', props: { target, alias: '' } }]
+  }
+}
+
+const BLOCKS: MindMapSourceBlock[] = [
+  bullet('b-intro', 'Before any heading'),
+  heading('b-risks', 1, 'Risks'),
+  bullet('b-lock', 'Vendor lock-in', [bullet('b-deep', 'Exit costs')]),
+  heading('b-cost', 2, 'Cost'),
+  bullet('b-budget', 'Budget'),
+  heading('b-plan', 1, 'Plan')
+]
+
+function snapshot(blocks: readonly MindMapSourceBlock[] = BLOCKS): MindMapElement[] {
+  const map = buildMindMap(blocks, { rootLabel: 'Roadmap', noteId: 'n1' })
+  return mintSnapshotElements(map, { noteId: 'n1', generatedLabel: GENERATED })
+}
+
+function boxes(elements: readonly MindMapElement[]): Map<string, MindMapBoxElement> {
+  return new Map(
+    elements
+      .filter((element): element is MindMapBoxElement => element.type === 'rectangle')
+      .map((box) => [box.id, box] as const)
+  )
+}
+
+describe('mintSnapshotElements — links that outlive the document', () => {
+  it('anchors a heading on its own text, never on a block id', () => {
+    const byId = boxes(snapshot())
+
+    expect(byId.get('mm-b-risks')?.link).toBe('memry://note/n1#Risks')
+    expect(byId.get('mm-b-cost')?.link).toBe('memry://note/n1#Cost')
+  })
+
+  it('anchors a list node on its nearest ancestor heading, however deep', () => {
+    const byId = boxes(snapshot())
+
+    // Directly under `Risks`…
+    expect(byId.get('mm-b-lock')?.link).toBe('memry://note/n1#Risks')
+    // …and nested one level further under the same one.
+    expect(byId.get('mm-b-deep')?.link).toBe('memry://note/n1#Risks')
+    // Under the deeper heading, not the one that opened the section.
+    expect(byId.get('mm-b-budget')?.link).toBe('memry://note/n1#Cost')
+  })
+
+  it('anchors on nothing above the first heading, and at the root', () => {
+    const byId = boxes(snapshot())
+
+    // No heading to borrow: the link opens the note at the top, which is where
+    // a build with no anchors at all would have put the reader anyway.
+    expect(byId.get('mm-b-intro')?.link).toBe('memry://note/n1')
+    expect(byId.get('mm-root')?.link).toBe('memry://note/n1')
+  })
+
+  it('writes no block anchor anywhere in the document, whatever the note holds', () => {
+    // The load-bearing assertion of the whole feature: a block id is minted at
+    // parse time and markdown does not carry it, so every one of these would be
+    // dead the moment the file was opened on another device.
+    //
+    // Deliberately over a note holding every kind that carries no block of its
+    // own — a wiki link and a "+N more" fold marker — because those are exactly
+    // the boxes the DRAWN map anchors on their node id, which is a block anchor
+    // in every way that matters here.
+    const everything = [
+      ...BLOCKS,
+      linkPara('b-link', 'Roadmap'),
+      heading('b-many', 1, 'Many'),
+      ...Array.from({ length: 13 }, (_, i) => bullet(`b-many-${i}`, `Item ${i}`))
+    ]
+    const map = buildMindMap(everything, { rootLabel: 'Roadmap', noteId: 'n1' })
+    // Precondition: the fixture really does contain both.
+    expect(map.nodes.some((node) => node.kind === 'wikiLink')).toBe(true)
+    expect(map.nodes.some((node) => node.kind === 'more')).toBe(true)
+
+    for (const box of boxes(
+      mintSnapshotElements(map, { noteId: 'n1', generatedLabel: GENERATED })
+    ).values()) {
+      expect(box.link).not.toMatch(/#\^/)
+    }
+  })
+
+  it('escapes a heading whose text would otherwise break the link', () => {
+    const byId = boxes(snapshot([heading('b-q', 1, 'Q3 / Q4 plan?')]))
+
+    const href = byId.get('mm-b-q')!.link!
+    expect(href).toBe('memry://note/n1#Q3%20%2F%20Q4%20plan%3F')
+
+    const parsed = parseMemryHref(href)
+    if (parsed?.kind !== 'note') throw new Error('the link no longer names a note')
+    expect(parsed.anchor).toEqual({ type: 'heading', text: 'Q3 / Q4 plan?' })
+  })
+
+  it('round-trips through the parser a canvas will read it with', () => {
+    for (const box of boxes(snapshot()).values()) {
+      const parsed = parseMemryHref(box.link!)
+      // Still resolves to the note itself on a build that has never heard of
+      // anchors: the item comes out of the path, the anchor out of the fragment.
+      expect(parsed).toMatchObject({ kind: 'note', id: 'n1' })
+      expect(tabFromMemryHref(box.link!)).toMatchObject({ type: 'note', path: '/note/n1' })
+      if (parsed?.kind === 'note' && parsed.anchor) {
+        expect(parsed.anchor.type).toBe('heading')
+      }
+    }
+  })
+})
+
+describe('mintSnapshotElements — the document itself', () => {
+  it('dates the root, under the note title', () => {
+    const root = boxes(snapshot()).get('mm-root')!
+
+    // Found months later, the canvas has to say it is a snapshot rather than a
+    // live view of the note.
+    expect(root.label.text).toBe(`Roadmap\n${GENERATED}`)
+  })
+
+  it('grows the root box to hold the line the layout never budgeted for', () => {
+    const map = buildMindMap([heading('b-a', 1, 'A')], { rootLabel: 'Q3', noteId: 'n1' })
+    const drawnRoot = map.elements.find((element) => element.id === 'mm-root')!
+    const savedRoot = boxes(
+      mintSnapshotElements(map, { noteId: 'n1', generatedLabel: GENERATED })
+    ).get('mm-root')!
+
+    expect(savedRoot.height).toBeGreaterThan(drawnRoot.type === 'rectangle' ? drawnRoot.height : 0)
+    // Downwards only: the root is alone in its column, and every other box has
+    // to stay exactly where the drawn map put it.
+    expect(savedRoot.x).toBe(map.nodes[0].x)
+    expect(savedRoot.y).toBe(map.nodes[0].y)
+  })
+
+  it('leaves every other node exactly where the drawn map put it', () => {
+    const map = buildMindMap(BLOCKS, { rootLabel: 'Roadmap', noteId: 'n1' })
+    const drawn = boxes(map.elements)
+    const saved = boxes(mintSnapshotElements(map, { noteId: 'n1', generatedLabel: GENERATED }))
+
+    for (const [id, box] of saved) {
+      if (id === 'mm-root') continue
+      const before = drawn.get(id)!
+      // Same map, re-minted for a file — not a second projection of the note.
+      expect([box.x, box.y, box.width, box.height]).toEqual([
+        before.x,
+        before.y,
+        before.width,
+        before.height
+      ])
+    }
+  })
+
+  it('mints plain shapes carrying links, never live entity cards', () => {
+    for (const element of snapshot()) {
+      // `customData.entityType` is what makes a rectangle a live Memry card
+      // (see `pages/canvas/canvas-cards.ts`). A card is roughly ten times the
+      // size of a map node, and a dozen make the map unreadable.
+      expect(element).not.toHaveProperty('customData')
+      expect(['rectangle', 'arrow', 'line']).toContain(element.type)
+    }
+  })
+
+  it('keeps its connectors bound so a dragged node takes them with it', () => {
+    const arrows = snapshot().filter((element) => element.type === 'arrow')
+    const boxIds = new Set(boxes(snapshot()).keys())
+
+    expect(arrows.length).toBeGreaterThan(0)
+    for (const arrow of arrows) {
+      expect(boxIds.has(arrow.start.id)).toBe(true)
+      expect(boxIds.has(arrow.end.id)).toBe(true)
+    }
+  })
+})
+
+describe('mindMapSceneJson', () => {
+  /** Stands in for the converter, which only adds identity to each element. */
+  const converted = (elements: readonly MindMapElement[]): unknown[] =>
+    elements.map((element, index) => ({ ...element, id: `minted-${index}`, version: 1 }))
+
+  it('produces a document the vault stores as a canvas, unchanged', () => {
+    const json = mindMapSceneJson(converted(snapshot()))
+    const scene = JSON.parse(json) as Record<string, unknown>
+
+    // These keys, in this order, are `canvas/scene-file.ts`'s own — what
+    // `canonicalize` writes back out. Matching it means the store canonicalizes
+    // this document to itself plus its `memry` sidecar, and writes it as-is.
+    expect(Object.keys(scene)).toEqual([
+      'type',
+      'version',
+      'source',
+      'elements',
+      'appState',
+      'files'
+    ])
+    expect(scene.type).toBe('excalidraw')
+    expect(scene.version).toBe(2)
+    expect(scene.source).toBe('memry')
+    expect(scene.appState).toEqual({})
+    expect(scene.files).toEqual({})
+    expect(Array.isArray(scene.elements)).toBe(true)
+    expect(scene.elements).toHaveLength(snapshot().length)
+  })
+
+  it('reads back as the editor loads a scene', () => {
+    // `canvas-editor.tsx` does exactly this on mount.
+    const parsed = JSON.parse(mindMapSceneJson(converted(snapshot()))) as {
+      elements?: unknown[]
+      appState?: unknown
+      files?: unknown
+    }
+    expect(parsed.elements?.length).toBeGreaterThan(0)
+    expect(parsed.appState).toBeDefined()
+    expect(parsed.files).toBeDefined()
+  })
+
+  it('survives a map with nothing in it', () => {
+    const empty = buildMindMap([], { rootLabel: 'Empty', noteId: 'n1' })
+    const scene = JSON.parse(
+      mindMapSceneJson(
+        converted(mintSnapshotElements(empty, { noteId: 'n1', generatedLabel: GENERATED }))
+      )
+    ) as { elements: unknown[] }
+
+    // The root alone, still a valid document.
+    expect(scene.elements).toHaveLength(1)
+  })
+})
+
+describe('uniqueCanvasTitle', () => {
+  it('keeps the note title when nothing at the root has it', () => {
+    expect(uniqueCanvasTitle('Roadmap', ['Sketches', null, ''])).toBe('Roadmap')
+  })
+
+  it('suffixes from 2 upwards, exactly as the vault names the file', () => {
+    expect(uniqueCanvasTitle('Roadmap', ['Roadmap'])).toBe('Roadmap 2')
+    expect(uniqueCanvasTitle('Roadmap', ['Roadmap', 'Roadmap 2'])).toBe('Roadmap 3')
+    // A gap is not filled: the next free number wins, so two saves in a row
+    // never race onto the same name.
+    expect(uniqueCanvasTitle('Roadmap', ['Roadmap', 'Roadmap 3'])).toBe('Roadmap 2')
+  })
+
+  it('collides the way the filesystem does — case-folded and NFC-normalized', () => {
+    // macOS and Windows are case-insensitive, and macOS stores filenames
+    // decomposed, so a comparison that missed either would hand two rows the
+    // same label while their files differ.
+    expect(uniqueCanvasTitle('Roadmap', ['ROADMAP'])).toBe('Roadmap 2')
+    expect(uniqueCanvasTitle('Café', ['Café'])).toBe('Café 2')
+  })
+
+  it('ignores canvases with no title of their own', () => {
+    expect(uniqueCanvasTitle('Roadmap', [null, null])).toBe('Roadmap')
+  })
+})
+
+describe('mintSnapshotElements — a heading longer than the label cap', () => {
+  // 96 characters: comfortably past MIND_MAP_MAX_LABEL_CHARS (72), so the box
+  // label is clipped and the anchor must not be.
+  const LONG =
+    'Everything we learned about vendor lock-in during the third quarter of the migration work'
+
+  const map = buildMindMap([heading('b-long', 1, LONG), bullet('b-kid', 'A detail')], {
+    rootLabel: 'Roadmap',
+    noteId: 'n1'
+  })
+  const byId = boxes(mintSnapshotElements(map, { noteId: 'n1', generatedLabel: GENERATED }))
+
+  it('clips the drawn label, because a box cannot hold it', () => {
+    // Precondition: if the cap ever stops biting here, the assertions below
+    // stop proving anything, so it is asserted rather than assumed.
+    expect(byId.get('mm-b-long')!.label.text.length).toBeLessThan(LONG.length)
+    expect(byId.get('mm-b-long')!.label.text).toMatch(/…$/)
+  })
+
+  it('anchors on the WHOLE heading, not on the clipped label', () => {
+    // The single failure this field exists to prevent: an anchor clipped to
+    // `Everything we learned about vendor lock-in during the thir…` matches no
+    // heading on the device that opens the canvas, so the link silently lands
+    // at the top of the note instead of at the section.
+    const href = `memry://note/n1#${encodeURIComponent(LONG)}`
+    expect(byId.get('mm-b-long')!.link).toBe(href)
+    // And the child borrows the same whole text.
+    expect(byId.get('mm-b-kid')!.link).toBe(href)
+
+    const parsed = parseMemryHref(byId.get('mm-b-long')!.link!)
+    if (parsed?.kind !== 'note') throw new Error('the link no longer names a note')
+    expect(parsed.anchor).toEqual({ type: 'heading', text: LONG })
+  })
+})
+
+describe('mintSnapshotElements — wiki-link nodes', () => {
+  const blocks = [heading('b-h', 1, 'Risks'), linkPara('b-p', 'Roadmap')]
+
+  function linkBox(wikiHrefs?: ReadonlyMap<string, string>): MindMapBoxElement {
+    const map = buildMindMap(blocks, { rootLabel: 'Q3', noteId: 'n1' })
+    const node = map.nodes.find((n) => n.kind === 'wikiLink')!
+    return boxes(
+      mintSnapshotElements(map, { noteId: 'n1', generatedLabel: GENERATED, wikiHrefs })
+    ).get(node.id)!
+  }
+
+  it('carries the resolved target when the caller could resolve it', () => {
+    const map = buildMindMap(blocks, { rootLabel: 'Q3', noteId: 'n1' })
+    const node = map.nodes.find((n) => n.kind === 'wikiLink')!
+    const box = linkBox(new Map([[node.id, 'memry://note/n2#Plan']]))
+
+    // The point of a saved wiki-link node: it opens the note it names, on any
+    // device, rather than a node id only this session understood.
+    expect(box.link).toBe('memry://note/n2#Plan')
+  })
+
+  it('falls back to the heading it is written under when it resolves to nothing', () => {
+    // Never a dead box and never an invented destination: it opens the source
+    // note at the section the link is written in.
+    expect(linkBox().link).toBe('memry://note/n1#Risks')
+  })
+
+  it('never carries the node-id anchor the drawn map gives it', () => {
+    const map = buildMindMap(blocks, { rootLabel: 'Q3', noteId: 'n1' })
+    const node = map.nodes.find((n) => n.kind === 'wikiLink')!
+    const drawn = boxes(map.elements).get(node.id)!
+
+    // On screen the href is only a click handle, and it IS a node-id anchor.
+    expect(drawn.link).toBe(`memry://note/n1#^${node.id}`)
+    // In a file that names a block this device never minted.
+    expect(linkBox().link).not.toMatch(/#\^/)
+  })
+
+  it('keeps the dashed outline that tells it apart from this note', () => {
+    expect(linkBox().strokeStyle).toBe('dashed')
+  })
+})
+
+describe('mintSnapshotElements — fold markers', () => {
+  // Thirteen children under one heading: one past MIND_MAP_MAX_CHILDREN, so the
+  // twelfth slot becomes a "+N more".
+  const map = buildMindMap(
+    [
+      heading('b-h', 1, 'Risks'),
+      ...Array.from({ length: 13 }, (_, i) => bullet(`b-${i}`, `Item ${i}`))
+    ],
+    { rootLabel: 'Q3', noteId: 'n1', formatMore: (count) => `+${count} more` }
+  )
+  const marker = map.nodes.find((node) => node.kind === 'more')!
+  const box = boxes(mintSnapshotElements(map, { noteId: 'n1', generatedLabel: GENERATED })).get(
+    marker.id
+  )!
+
+  it('is minted rather than dropped, so the canvas says how much is missing', () => {
+    // Dropping it would be exactly the silent loss the feature refuses: the
+    // canvas would simply be short two rows with nothing to say so.
+    expect(marker.foldedCount).toBeGreaterThan(0)
+    expect(box.label.text).toBe(`+${marker.foldedCount} more`)
+  })
+
+  it('opens the note at the section the missing rows actually live in', () => {
+    // It cannot expand in a file — there is nothing on the other side to expand
+    // it — so it points at the place the folded content really is.
+    expect(box.link).toBe('memry://note/n1#Risks')
+    expect(box.link).not.toMatch(/#\^/)
+  })
+})
+
+describe("mintSnapshotElements — the date never displaces the root's own badge", () => {
+  it('keeps what the root already had to say, alongside the generation date', () => {
+    // A table before the first heading is counted on the root, so the root has
+    // a badge line of its own — the same line a fold count would land on.
+    const map = buildMindMap([{ id: 'b-t', type: 'table' }, heading('b-h', 1, 'Risks')], {
+      rootLabel: 'Q3',
+      noteId: 'n1',
+      formatContentCount: (kind, count) => `${count} ${kind}`
+    })
+    const rootDetail = map.nodes[0].detail
+    // Precondition: if the root stops carrying a badge, this proves nothing.
+    if (rootDetail === '') throw new Error('the root carries no badge; fixture is wrong')
+
+    const box = boxes(mintSnapshotElements(map, { noteId: 'n1', generatedLabel: GENERATED })).get(
+      'mm-root'
+    )!
+    const [title, badges] = box.label.text.split('\n')
+    expect(title).toBe('Q3')
+    // The date is added AHEAD of that line, never instead of it: replacing it
+    // would drop whatever the root was saying about what is not on the picture
+    // — a fold count above all.
+    expect(badges).toBe(`${GENERATED} · ${rootDetail}`)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-snapshot.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-snapshot.ts
@@ -1,0 +1,136 @@
+/**
+ * The map, turned into a canvas the user owns.
+ *
+ * Pure, and deliberately free of the drawing library: everything here is plain
+ * data, so the whole shape of a saved canvas — its links, its dated root, its
+ * document envelope, its name — is asserted in a unit test with no DOM. The one
+ * step that needs the library (skeletons → real elements) lives in the lazy
+ * chunk, in `mind-map-export.ts`.
+ *
+ * The promise the whole feature rests on: the moment the canvas exists it
+ * DETACHES. Nothing regenerates it, nothing overwrites it, and the note holds
+ * no reference back to it. That is why saving twice makes a second canvas
+ * rather than replacing the first — the first may be an hour of someone's work
+ * by then — and it is why the relationship is one-way: the reverse would need a
+ * database field, a sync handler and a compatibility plan it does not earn.
+ *
+ * Three things the snapshot changes about the map as drawn, all for the same
+ * reason — the file outlives the document that produced it:
+ *
+ * 1. **Links anchor on heading TEXT, never on a block id.** Block ids are
+ *    minted at parse time and markdown does not carry them, so a copied vault,
+ *    a fresh device or a rebuilt document mints new ones. A list node anchors
+ *    to its nearest ancestor heading; a node under no heading anchors on
+ *    nothing and opens the note at the top.
+ * 2. **The root carries the date it was generated**, so a canvas found months
+ *    later announces that it is a snapshot rather than a live view.
+ * 3. **Nodes stay plain shapes carrying deep links, never live entity cards.**
+ *    A card is roughly ten times the size of a map node and a dozen of them
+ *    make the map unreadable. The user can add real cards by hand — it is their
+ *    canvas.
+ *
+ * Two node kinds need saying out loud, because neither is a place in this note:
+ *
+ * - A **wiki-link** node points at another document. On screen its href is only
+ *   a click handle and the real destination is `wikiTarget`, a title — but a
+ *   saved file has no click handler to read that, so the caller resolves the
+ *   target through the same resolver a `[[…]]` in the body goes through and
+ *   hands the answers in as `wikiHrefs`. A target that resolves to nothing
+ *   falls back to the heading anchor every other node gets: the box then opens
+ *   the note at the section the link is written in, which is the only true
+ *   thing left to say about it.
+ * - A **"+N more"** fold marker is a view affordance with nothing to expand in
+ *   a file. It is still minted, and deliberately: it is the line that says how
+ *   much of the note is not on this canvas, and dropping it would be exactly
+ *   the silent loss the whole feature refuses. It anchors on the heading whose
+ *   children are folded, so clicking it opens the note at the place the missing
+ *   rows actually live.
+ */
+
+import { mintElements } from './mind-map-elements'
+import type { MindMap, MindMapElement } from './mind-map-types'
+
+export interface MindMapSnapshotOptions {
+  /** The note the links point back at. */
+  noteId: string
+  /**
+   * The dated badge on the root box, ahead of whatever the root already says.
+   * Translated and formatted by the caller: this module has no translator and
+   * must not grow one, and the text is frozen into the file the moment it is
+   * written.
+   */
+  generatedLabel: string
+  /**
+   * Wiki-link node id → the href its box should carry, resolved by the caller.
+   * Absent entries fall back to a heading anchor into the source note. See the
+   * module note above.
+   */
+  wikiHrefs?: ReadonlyMap<string, string>
+}
+
+/**
+ * The map as currently drawn, re-minted for a file rather than for a session.
+ *
+ * Same nodes, same coordinates — this is the map the user is looking at, not a
+ * second projection of the note — with durable links and a dated root.
+ */
+export function mintSnapshotElements(
+  map: MindMap,
+  { noteId, generatedLabel, wikiHrefs }: MindMapSnapshotOptions
+): MindMapElement[] {
+  return mintElements(map.nodes, map.direction, {
+    noteId,
+    anchor: 'heading',
+    rootDetail: generatedLabel,
+    wikiHrefs
+  })
+}
+
+/**
+ * The canvas document, as the vault stores one.
+ *
+ * The keys and their order are `canvas/scene-file.ts`'s own (`EMPTY_SCENE`,
+ * written back out by `canonicalize`), so the store canonicalizes this to
+ * itself plus its `memry` sidecar and writes it unchanged. `appState` is left
+ * empty on purpose: the camera is the reader's, and a canvas that opens where
+ * the map happened to be scrolled would be a surprise rather than a courtesy.
+ */
+export function mindMapSceneJson(elements: readonly unknown[]): string {
+  return JSON.stringify({
+    type: 'excalidraw',
+    version: 2,
+    source: 'memry',
+    elements,
+    appState: {},
+    files: {}
+  })
+}
+
+/** How the vault compares two names: NFC-folded and case-insensitive. */
+function titleKey(title: string): string {
+  return title.normalize('NFC').toLowerCase()
+}
+
+/**
+ * `Plan`, then `Plan 2`, then `Plan 3` — the same suffix the vault gives a
+ * canvas FILE whose name is already taken (`allocateCanvasPath`), applied to
+ * the stored title as well.
+ *
+ * Both halves are needed or they disagree: the file is uniquified on disk
+ * whatever we ask for, so a row left holding the raw title would show two
+ * identically-named canvases in the sidebar pointing at differently-named
+ * files. `duplicateCanvas` solves the same problem the same way, one layer
+ * down.
+ */
+export function uniqueCanvasTitle(title: string, taken: Iterable<string | null>): string {
+  const claimed = new Set<string>()
+  for (const name of taken) {
+    if (name !== null && name !== '') claimed.add(titleKey(name))
+  }
+
+  if (!claimed.has(titleKey(title))) return title
+
+  let counter = 2
+  while (claimed.has(titleKey(`${title} ${counter}`))) counter += 1
+  return `${title} ${counter}`
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
@@ -116,6 +116,20 @@ export interface MindMapNode {
    * exactly the way the editor does.
    */
   wikiTarget: string | null
+  /**
+   * The text of the nearest heading at or above this node, or `null` when
+   * nothing above it is a heading. User content, never translated.
+   *
+   * It exists because a link that is written to disk can only anchor on heading
+   * TEXT — block ids die with the document that minted them — and a list item
+   * has no heading of its own, so it borrows its nearest ancestor's.
+   *
+   * Computed where the heading's text is still WHOLE, rather than read back off
+   * `label`: `label` is a display string that `clipLabel` shortens past 72
+   * characters, and an anchor clipped to `A very long heading th…` resolves to
+   * nothing on the device that opens the canvas.
+   */
+  headingText: string | null
   /** Inline hash tags found in this node's own text. User content, `#` stripped. */
   tags: string[]
   /** Content sitting under this node that is not drawn, in a stable order. */
@@ -155,6 +169,7 @@ export interface MindMapPositionedNode {
   isDone: boolean
   taskId: string | null
   wikiTarget: string | null
+  headingText: string | null
   tags: string[]
   contents: MindMapContentCount[]
   foldedCount: number
@@ -209,9 +224,41 @@ export interface MindMapBoxElement {
 }
 
 /**
- * A straight rule: the connector from a parent box to one of its children, or
- * the strike-through over a completed item's label. The drawing surface is a
- * bitmap with no text decorations, so "struck through" has to be a real line.
+ * A straight rule with no arrowheads: the connector from a parent box to one of
+ * its children.
+ *
+ * An arrow rather than a line, and bound at both ends rather than drawn between
+ * two baked coordinates. On screen the two look identical — the arrowheads are
+ * off — but a saved canvas is hand-edited, and a connector whose endpoints are
+ * frozen numbers comes loose the first time the user drags a node. `start`/`end`
+ * name the boxes by the ids the boxes carry, which the drawing library resolves
+ * into real bindings even though it regenerates every id on the way in.
+ */
+export interface MindMapArrowElement {
+  type: 'arrow'
+  id: string
+  x: number
+  y: number
+  points: Array<[number, number]>
+  /** The parent box's id. */
+  start: { id: string }
+  /** The child box's id. */
+  end: { id: string }
+  /** Both null: a mind-map branch is a rule, not a direction. */
+  startArrowhead: null
+  endArrowhead: null
+  /** Null so a two-point connector stays a hard straight rule. */
+  roundness: null
+  strokeColor: string
+  strokeWidth: number
+  roughness: number
+}
+
+/**
+ * A straight rule: the strike-through over a completed item's label. The
+ * drawing surface is a bitmap with no text decorations, so "struck through" has
+ * to be a real line — and an unbound one, because it belongs to the box's text
+ * rather than to the space between two boxes.
  */
 export interface MindMapLineElement {
   type: 'line'
@@ -224,7 +271,7 @@ export interface MindMapLineElement {
   roughness: number
 }
 
-export type MindMapElement = MindMapBoxElement | MindMapLineElement
+export type MindMapElement = MindMapBoxElement | MindMapArrowElement | MindMapLineElement
 
 /** Bounding box of every positioned node, so the host can fit the view. */
 export interface MindMapBounds {
@@ -291,7 +338,10 @@ export interface MindMap {
   tree: MindMapNode
   /** Every node with coordinates, in depth-first order starting at the root. */
   nodes: MindMapPositionedNode[]
-  /** Drawing elements: one box per node, one connector per parent→child edge. */
+  /**
+   * Drawing elements: one box per node, one bound connector per parent→child
+   * edge, and a rule per line of a completed item's label.
+   */
   elements: MindMapElement[]
   direction: MindMapDirection
   /** Node total including the root. Never above `MIND_MAP_MAX_NODES`. */

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.test.tsx
@@ -21,10 +21,30 @@ const mocks = vi.hoisted(() => ({
   copyImage: vi.fn(),
   copyVector: vi.fn(),
   /** False to hold the surface back, as a chunk that has not arrived yet. */
-  handsControlsUp: true
+  handsControlsUp: true,
+  toCanvasScene: vi.fn((elements: readonly unknown[]) => JSON.stringify({ elements })),
+  create: vi.fn(),
+  list: vi.fn(),
+  resolveWikiLink: vi.fn()
 }))
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+// The drawing library cannot initialize under jsdom, and this module imports
+// it. What the save action puts INTO a canvas is asserted without any of that,
+// purely, in `mind-map-snapshot.test.ts`; what is asserted here is the wiring —
+// which document, under which name, and what the user is told when it fails.
+vi.mock('./mind-map-export', () => ({ toCanvasScene: mocks.toCanvasScene }))
+
+vi.mock('@/services/canvas-service', () => ({
+  canvasService: { create: mocks.create, list: mocks.list }
+}))
+
+// The real one, standing in for the database behind it: a wiki target is a
+// title, and only a lookup turns one into an id. What matters here is that the
+// save path asks it at all, and asks the same resolver a `[[…]]` in the body
+// asks.
+vi.mock('@/lib/wikilink-resolver', () => ({ resolveWikiLink: mocks.resolveWikiLink }))
 
 vi.mock('./mind-map-canvas', () => ({
   MindMapCanvas: ({
@@ -73,6 +93,12 @@ describe('MindMapView toolbar', () => {
     mocks.handsControlsUp = true
     mocks.copyImage.mockResolvedValue(undefined)
     mocks.copyVector.mockResolvedValue(undefined)
+    mocks.toCanvasScene.mockImplementation((elements: readonly unknown[]) =>
+      JSON.stringify({ elements })
+    )
+    mocks.list.mockResolvedValue({ canvases: [] })
+    mocks.create.mockResolvedValue({ id: 'canvas-1' })
+    mocks.resolveWikiLink.mockResolvedValue({ type: 'not-found', id: '', heading: null })
   })
 
   it('offers fit and both copies, translated, in the map and outside its picture', async () => {
@@ -83,7 +109,7 @@ describe('MindMapView toolbar', () => {
       within(toolbar)
         .getAllByRole('button')
         .map((button) => button.getAttribute('aria-label'))
-    ).toEqual(['Fit to view', 'Copy as image', 'Copy as vector'])
+    ).toEqual(['Fit to view', 'Copy as image', 'Copy as vector', 'Save as canvas'])
     // Every control is also its own tooltip.
     for (const button of within(toolbar).getAllByRole('button')) {
       expect(button).toHaveAttribute('title', button.getAttribute('aria-label'))
@@ -96,12 +122,15 @@ describe('MindMapView toolbar', () => {
     expect(screen.getByRole('img')).not.toContainElement(toolbar)
   })
 
-  it('leaves the controls inert until the drawing surface is live', async () => {
+  it('leaves the surface-bound controls inert until the drawing surface is live', async () => {
     mocks.handsControlsUp = false
     const toolbar = await renderMap()
 
     for (const button of within(toolbar).getAllByRole('button')) {
-      expect(button).toBeDisabled()
+      // Saving is the exception: its document is minted from the map's own
+      // descriptors, so it never waits on a chunk to arrive.
+      const expected = button.getAttribute('aria-label') !== 'Save as canvas'
+      expect(button.hasAttribute('disabled')).toBe(expected)
     }
   })
 
@@ -182,6 +211,133 @@ describe('MindMapView toolbar', () => {
     expect(notice.compareDocumentPosition(screen.getByRole('img'))).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     )
+  })
+
+  it('mints a canvas at the root, named after the note, and says so', async () => {
+    await renderMap()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as canvas' }))
+    await waitFor(() => expect(mocks.create).toHaveBeenCalledTimes(1))
+
+    const input = mocks.create.mock.calls[0][0] as {
+      title: string
+      folder: string | null
+      scene: string
+    }
+    // The canvas ROOT: the note's folder tree is deliberately not mirrored.
+    expect(input.folder).toBeNull()
+    expect(input.title).toBe('Test Note')
+    expect(JSON.parse(input.scene)).toHaveProperty('elements')
+    expect(toast.success).toHaveBeenCalledWith('Saved as the canvas \u201cTest Note\u201d')
+  })
+
+  it('suffixes the title when the canvas root already holds that name', async () => {
+    mocks.list.mockResolvedValue({
+      canvases: [
+        { id: 'c1', title: 'Test Note', folder: null },
+        { id: 'c2', title: 'test note 2', folder: null },
+        // A same-named canvas in a FOLDER is not a collision: only the root is.
+        { id: 'c3', title: 'Test Note 3', folder: 'Work' }
+      ]
+    })
+    await renderMap()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as canvas' }))
+    await waitFor(() => expect(mocks.create).toHaveBeenCalledTimes(1))
+    expect((mocks.create.mock.calls[0][0] as { title: string }).title).toBe('Test Note 3')
+  })
+
+  it('makes a SECOND canvas rather than replacing the first', async () => {
+    await renderMap()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as canvas' }))
+    await waitFor(() => expect(mocks.create).toHaveBeenCalledTimes(1))
+
+    // As the vault looks once the first save has landed.
+    mocks.list.mockResolvedValue({ canvases: [{ id: 'c1', title: 'Test Note', folder: null }] })
+    fireEvent.click(screen.getByRole('button', { name: 'Save as canvas' }))
+    await waitFor(() => expect(mocks.create).toHaveBeenCalledTimes(2))
+
+    // Two creates, two names, and never an update: overwriting would destroy a
+    // canvas the user may have spent an hour editing.
+    expect((mocks.create.mock.calls[1][0] as { title: string }).title).toBe('Test Note 2')
+    expect(
+      mocks.create.mock.calls.every((call) => (call[0] as { id?: string }).id === undefined)
+    ).toBe(true)
+  })
+
+  it('dates the root so the canvas announces that it is a snapshot', async () => {
+    await renderMap()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as canvas' }))
+    await waitFor(() => expect(mocks.toCanvasScene).toHaveBeenCalledTimes(1))
+
+    const elements = mocks.toCanvasScene.mock.calls[0][0] as Array<{
+      type: string
+      id: string
+      label?: { text: string }
+    }>
+    const root = elements.find((element) => element.id === 'mm-root')!
+    expect(root.label?.text.split('\n')[1]).toMatch(/^Snapshot · .+/)
+  })
+
+  it('says a save failed rather than failing quietly', async () => {
+    mocks.create.mockRejectedValue(new Error('Vault is read-only'))
+    await renderMap()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as canvas' }))
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Vault is read-only'))
+    expect(toast.success).not.toHaveBeenCalled()
+
+    // And the control comes back, so a transient failure is not a dead button.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save as canvas' })).not.toBeDisabled()
+    )
+  })
+
+  it('falls back to a translated message when a failed save carries none', async () => {
+    mocks.list.mockRejectedValue(undefined)
+    await renderMap()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as canvas' }))
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Failed to save the map as a canvas')
+    )
+    expect(mocks.create).not.toHaveBeenCalled()
+  })
+
+  it('resolves a wiki-link node to the note it names before writing the file', async () => {
+    mocks.resolveWikiLink.mockResolvedValue({ type: 'note', id: 'n2', heading: 'Plan' })
+    renderView([
+      {
+        id: 'b-h1',
+        type: 'heading',
+        props: { level: 1 },
+        content: [{ type: 'text', text: 'Alpha' }]
+      },
+      {
+        id: 'b-p',
+        type: 'paragraph',
+        content: [{ type: 'wikiLink', props: { target: 'Roadmap' } }]
+      }
+    ])
+    await screen.findByRole('toolbar')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as canvas' }))
+    await waitFor(() => expect(mocks.toCanvasScene).toHaveBeenCalledTimes(1))
+
+    // Asked the same resolver a `[[…]]` in the note body goes through.
+    expect(mocks.resolveWikiLink).toHaveBeenCalledWith('Roadmap')
+
+    const elements = mocks.toCanvasScene.mock.calls[0][0] as Array<{
+      type: string
+      link?: string
+      strokeStyle?: string
+    }>
+    // The saved box opens the note it names, on any device — not a node id only
+    // this session could have understood.
+    expect(elements.some((element) => element.link === 'memry://note/n2#Plan')).toBe(true)
+    expect(elements.every((element) => !element.link?.includes('#^'))).toBe(true)
   })
 
   it('takes its controls back when the drawing surface goes away', async () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
@@ -26,14 +26,18 @@
 import { lazy, Suspense, useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { useT } from '@memry/i18n/renderer'
-import { Focus, Image, PenTool } from '@/lib/icons'
+import { Focus, Image, PenTool, Save } from '@/lib/icons'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { createLogger } from '@/lib/logger'
+import { buildMemryHref } from '@/lib/memry-links'
+import { resolveWikiLink } from '@/lib/wikilink-resolver'
+import { canvasService } from '@/services/canvas-service'
 import { nodeFromMindMapLink, type MindMapNodeActivation } from './mind-map-navigation'
+import { mintSnapshotElements, uniqueCanvasTitle } from './mind-map-snapshot'
 import { MindMapToolbar, type MindMapToolbarAction } from './mind-map-toolbar'
 import { MindMapTree } from './mind-map-tree'
 import type { MindMapControls } from './mind-map-canvas'
-import type { MindMap } from './mind-map-types'
+import type { MindMap, MindMapPositionedNode } from './mind-map-types'
 
 const log = createLogger('NoteMindMap')
 
@@ -44,6 +48,62 @@ const log = createLogger('NoteMindMap')
 const LazyMindMapCanvas = lazy(async () => ({
   default: (await import('./mind-map-canvas')).MindMapCanvas
 }))
+
+/**
+ * Wiki-link nodes, resolved to hrefs that still mean something on another
+ * device.
+ *
+ * On screen a wiki-link box's href is only a click handle — the real
+ * destination is `wikiTarget`, a TITLE, and `activateMindMapNode` turns it into
+ * a tab. A saved canvas has neither: nothing on the other side reads
+ * `wikiTarget`, so the target has to be resolved to a real id here, once, at
+ * the moment the file is written.
+ *
+ * Through `resolveWikiLink`, the same resolver a `[[…]]` in the note body goes
+ * through, so a saved link opens exactly what clicking the link opens — a note
+ * at its heading, or a filed binary in its viewer. Resolved once per distinct
+ * target rather than once per node, because a note that links to `Roadmap` five
+ * times should cost one lookup.
+ *
+ * A target that resolves to nothing gets no entry, and its box falls back to
+ * the heading anchor every other node carries: it opens the source note at the
+ * section the link is written in. Better than a dead box, and it invents no
+ * destination — a `create` resolution means the note does not exist yet, and
+ * freezing "make this note" into a document is not a promise a file can keep.
+ */
+async function resolveWikiHrefs(
+  nodes: readonly MindMapPositionedNode[]
+): Promise<Map<string, string>> {
+  const links = nodes.filter((node) => node.kind === 'wikiLink' && node.wikiTarget !== null)
+  const targets = [...new Set(links.map((node) => node.wikiTarget as string))]
+
+  const byTarget = new Map<string, string>()
+  await Promise.all(
+    targets.map(async (target) => {
+      const resolved = await resolveWikiLink(target).catch(() => null)
+      if (!resolved || (resolved.type !== 'note' && resolved.type !== 'file')) return
+
+      const href = buildMemryHref({
+        kind: resolved.type,
+        id: resolved.id,
+        // A filed binary has no inside to address; a note takes the heading half
+        // of `[[Note#Heading]]` exactly as the editor would.
+        anchor:
+          resolved.type === 'note' && resolved.heading
+            ? { type: 'heading', text: resolved.heading }
+            : null
+      })
+      if (href) byTarget.set(target, href)
+    })
+  )
+
+  const hrefs = new Map<string, string>()
+  for (const node of links) {
+    const href = byTarget.get(node.wikiTarget as string)
+    if (href) hrefs.set(node.id, href)
+  }
+  return hrefs
+}
 
 interface MindMapViewProps {
   map: MindMap
@@ -63,6 +123,7 @@ export function MindMapView({
 }: MindMapViewProps): React.JSX.Element {
   const { t } = useT('notes')
   const [controls, setControls] = useState<MindMapControls | null>(null)
+  const [isSaving, setSaving] = useState(false)
 
   const copy = useCallback(
     (run: () => Promise<void>, success: string): void => {
@@ -76,6 +137,48 @@ export function MindMapView({
     },
     [t]
   )
+
+  /**
+   * Mints a canvas from the map as currently drawn, and lets go of it.
+   *
+   * A NEW canvas every time, at the canvas root, named after the note with the
+   * vault's own collision suffix. Nothing is overwritten and nothing is written
+   * back to the note: from here on the canvas is the user's alone.
+   *
+   * The date is formatted here because this is the layer with a locale, and it
+   * is frozen into the file — a snapshot says when it was taken, not what time
+   * it is now.
+   */
+  const save = useCallback((): void => {
+    setSaving(true)
+    void (async () => {
+      const [{ toCanvasScene }, existing, wikiHrefs] = await Promise.all([
+        import('./mind-map-export'),
+        canvasService.list(),
+        resolveWikiHrefs(map.nodes)
+      ])
+
+      const generatedLabel = t('mindMap.toolbar.snapshotOn', {
+        date: new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date())
+      })
+      const scene = toCanvasScene(mintSnapshotElements(map, { noteId, generatedLabel, wikiHrefs }))
+      // Only the canvas ROOT can collide: that is where this one is filed. The
+      // note's own folder tree is deliberately not mirrored — gluing the two
+      // trees together would make every note rename a canvas move.
+      const title = uniqueCanvasTitle(
+        noteTitle.trim() || t('editor.title.untitled'),
+        existing.canvases.filter((canvas) => canvas.folder === null).map((canvas) => canvas.title)
+      )
+
+      await canvasService.create({ title, scene, folder: null })
+      toast.success(t('mindMap.toolbar.saved', { title }))
+    })()
+      .catch((err: unknown) => {
+        log.warn('Failed to save the mind map as a canvas', err)
+        toast.error(extractErrorMessage(err, t('mindMap.toolbar.saveFailed')))
+      })
+      .finally(() => setSaving(false))
+  }, [map, noteId, noteTitle, t])
 
   const actions = useMemo<MindMapToolbarAction[]>(
     () => [
@@ -103,9 +206,22 @@ export function MindMapView({
         onSelect: () => {
           if (controls) copy(controls.copyVector, t('mindMap.toolbar.vectorCopied'))
         }
+      },
+      {
+        // A fourth entry in the same array, not a new slot: the toolbar takes
+        // its actions as data precisely so this needed no new prop.
+        //
+        // Unlike the three above it does not wait on the drawing surface — the
+        // saved document is minted from the map's own descriptors, not read off
+        // the live scene — so it is only inert while a save is in flight.
+        id: 'save-canvas',
+        label: t('mindMap.toolbar.saveCanvas'),
+        icon: Save,
+        disabled: isSaving,
+        onSelect: save
       }
     ],
-    [controls, copy, t]
+    [controls, copy, isSaving, save, t]
   )
 
   // Empty until the map is actually at its limit — see the region below.

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
@@ -19,6 +19,8 @@ import { act, fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { buildMindMap } from '@/components/note/mind-map'
+import { mintSnapshotElements } from '@/components/note/mind-map/mind-map-snapshot'
 import { CanvasEditor } from './canvas-editor'
 import { clearCardTitleCache } from './canvas-link-target-title'
 
@@ -545,6 +547,63 @@ describe('CanvasEditor link opening', () => {
       expect.objectContaining({ type: 'note', path: '/note/n1', title: 'Roadmap' })
     )
     expect(mocks.windowOpen).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The receiving half of a saved mind map's links.
+   *
+   * The href is not typed out here — it is minted by the real snapshot path, so
+   * this is the actual round trip: what the mind map WRITES into a canvas is
+   * what this editor READS back out of one. Typing the string by hand would let
+   * the two drift apart and still pass.
+   */
+  it('lands a heading-anchored note link at that heading, not at the top', async () => {
+    const map = buildMindMap(
+      [
+        {
+          id: 'b-h',
+          type: 'heading',
+          props: { level: 1 },
+          content: [{ type: 'text', text: 'Risks' }]
+        },
+        {
+          id: 'b-li',
+          type: 'bulletListItem',
+          content: [{ type: 'text', text: 'Vendor lock-in' }]
+        }
+      ],
+      { rootLabel: 'Roadmap', noteId: 'n1' }
+    )
+    const elements = mintSnapshotElements(map, { noteId: 'n1', generatedLabel: 'Snapshot' })
+    const listBox = elements.find(
+      (element) => element.type === 'rectangle' && element.id === 'mm-b-li'
+    )
+    const href = listBox?.type === 'rectangle' ? listBox.link : undefined
+    // A list item borrows the heading above it: heading TEXT is the only anchor
+    // that still means anything on a device that never minted these block ids.
+    expect(href).toBe('memry://note/n1#Risks')
+
+    render(<CanvasEditor canvasId="c1" initialScene="" />)
+    clickLink(href!)
+    await act(async () => {})
+
+    expect(mocks.openTab).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'note',
+        path: '/note/n1',
+        viewState: { headingText: 'Risks' }
+      })
+    )
+  })
+
+  it('opens at the top when the link names a block, which this device never minted', async () => {
+    render(<CanvasEditor canvasId="c1" initialScene="" />)
+
+    clickLink('memry://note/n1#^b-h')
+    await act(async () => {})
+
+    const tab = mocks.openTab.mock.calls[0][0] as { viewState?: unknown }
+    expect(tab.viewState).toBeUndefined()
   })
 
   it('reports a deleted target rather than opening a blank tab', async () => {

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
@@ -554,6 +554,15 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
    * whose entity is gone opens blank with no way back to what went wrong. The
    * singleton views (Tasks, Inbox, Calendar) open regardless of whether their
    * focus target still exists, so they are not worth the round trip.
+   *
+   * A HEADING anchor on the link is consumed here rather than in
+   * `tabFromMemryHref`, which deliberately says only WHICH item to open: where
+   * inside it to land is the opening page's business, and the note page already
+   * takes a heading through `viewState.headingText` (matched by text, trimmed
+   * and case-folded, once its own editor has produced headings). Text is the
+   * only anchor a link written into a canvas can carry — the file outlives the
+   * document that produced it, and block ids do not. A BLOCK anchor is
+   * therefore ignored: it would name a block this device has never minted.
    */
   const openMemryTarget = useCallback(
     async (href: string): Promise<void> => {
@@ -578,7 +587,11 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
         toast.error(t('canvas.link.itemMissing'))
         return
       }
-      openTab(tab)
+
+      const heading =
+        parsed.kind === 'note' && parsed.anchor?.type === 'heading' ? parsed.anchor.text : null
+
+      openTab(heading ? { ...tab, viewState: { ...tab.viewState, headingText: heading } } : tab)
     },
     [openTab, t]
   )

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -1685,7 +1685,12 @@ describe('NotePage', () => {
         within(toolbar)
           .getAllByRole('button')
           .map((b) => b.getAttribute('aria-label'))
-      ).toEqual(['mindMap.toolbar.fit', 'mindMap.toolbar.copyImage', 'mindMap.toolbar.copyVector'])
+      ).toEqual([
+        'mindMap.toolbar.fit',
+        'mindMap.toolbar.copyImage',
+        'mindMap.toolbar.copyVector',
+        'mindMap.toolbar.saveCanvas'
+      ])
 
       // Wired to the live surface, not to a rebuilt copy of the map.
       fireEvent.click(screen.getByTestId('mind-map-toolbar-fit'))

--- a/apps/docs/src/user-guide/notes/mind-map.md
+++ b/apps/docs/src/user-guide/notes/mind-map.md
@@ -151,6 +151,8 @@ same thing.
   a note, a message or a slide.
 - **Copy as vector** puts the map on the clipboard as SVG markup, which design
   tools paste as editable artwork.
+- **Save as canvas** keeps the map: it becomes a real canvas you own. See
+  [Saving the Map as a Canvas](#saving-the-map-as-a-canvas) below.
 
 Both copies contain the map **as you are looking at it**, so anything you have
 opened up in the map is in the copy too. They are exported on a transparent
@@ -160,6 +162,62 @@ tells you rather than failing quietly.
 
 The map's camera is not remembered. Close the map and open it again and it
 frames the whole thing afresh — the same place **Fit to view** takes you.
+
+## Saving the Map as a Canvas
+
+**Save as canvas** turns the map into a canvas document — one you can rearrange,
+extend and build on like any other.
+
+The new canvas appears at the top level of **Canvases** in the sidebar, named
+after the note. If a canvas at that level already has that name, the new one
+gets a number after it (`Roadmap 2`, `Roadmap 3`), exactly the way the vault
+names any other file whose name is taken.
+
+Three things are worth knowing about it.
+
+**It is yours from the moment it exists.** Nothing regenerates it and nothing
+overwrites it. Edit it freely — memrynote will never come back and change it.
+
+**Saving twice gives you two canvases.** The second save never replaces the
+first, because the first might be an hour of your work by then. If you want one
+canvas, delete the one you do not want.
+
+**It says when it was taken.** The root node carries the date the map was
+generated, so a canvas you find months later announces itself as a snapshot of
+the note rather than a live view of it.
+
+Every node in the saved canvas keeps its link back into the note, and those
+links keep working on your other devices: they point at the **heading** a node
+sits under, which is something the note carries everywhere, rather than at an
+internal identifier that only exists on the machine that made the map. A list
+item links to the nearest heading above it. Nodes above the first heading — and
+the root — open the note at the top.
+
+**Wiki-link nodes open the note they name.** A `[[link]]` node in the saved
+canvas is resolved when the canvas is written, so it opens the linked note — at
+its heading, if the link named one — on any of your devices. If the link points
+at a note that does not exist yet, the node opens the source note at the section
+the link is written in instead, so it is never a dead box.
+
+**A "+N more" node stays in the saved canvas**, even though there is nothing for
+it to open in a document. It is what tells you the canvas is not the whole note,
+and how much is missing; clicking it takes you to the section in the note where
+those items actually live. The same is true of the counts on other nodes: if the
+map folded something into a node, the saved canvas still says so.
+
+Nodes are saved as plain shapes with links on them rather than as live memrynote
+cards. A card is around ten times the size of a map node, and a dozen of them
+would make the map unreadable. Add real cards by hand wherever you want them —
+it is your canvas.
+
+The connectors are real bound arrows, so dragging a node around takes its
+branches with it.
+
+The note itself keeps no record of the canvas. The relationship only runs one
+way: the canvas points back at the note, and the note knows nothing about the
+canvas.
+
+If a canvas cannot be created, memrynote tells you rather than failing quietly.
 
 ## Coming Back to the Note
 

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -987,7 +987,11 @@
       "copyVector": "Copy as vector",
       "imageCopied": "Map copied as an image",
       "vectorCopied": "Map copied as vector artwork",
-      "copyFailed": "Failed to copy the map"
+      "copyFailed": "Failed to copy the map",
+      "saveCanvas": "Save as canvas",
+      "saved": "Saved as the canvas \u201c{title}\u201d",
+      "saveFailed": "Failed to save the map as a canvas",
+      "snapshotOn": "Snapshot \u00b7 {date}"
     }
   }
 }


### PR DESCRIPTION
Closes nothing — implements #1675 (part of #1667). Every blocker is merged.

## Rebased onto `db693aac9` (#1673, which sits on `bebbe2173` / #1672)

Head is now `560d5e085`. Five conflicts, all resolved by keeping both intentions; **nothing of #1672's or #1673's behaviour changed to accommodate this PR.**

| File | Conflict | Resolution |
|---|---|---|
| `mind-map-layout.ts` | #1672's `taskId`/`wikiTarget` vs this PR's `headingText` in the positioned-node literal | all three carried through |
| `mind-map-types.ts` | same three fields, twice (`MindMapNode`, `MindMapPositionedNode`) | all three kept; `MindMapArrowElement` and the widened `MindMapElement` union auto-merged beside #1672's `strokeStyle?: 'dashed'` |
| `mind-map-projection.ts` | same three fields, in the root literal and the block-node literal | all three kept |
| `mind-map-elements.ts` | #1672/#1673's four-treatment box styling (wiki blue + dashed, fold-marker accent) vs this PR's `rootDetail` height growth; and #1672's node-id anchor rule vs this PR's anchor mode | `nodeLink` now branches on the mode: `block` keeps #1672's rule verbatim, `heading` is this PR's. The box loop keeps every style branch **and** the grown root. |
| `mind-map-view.test.tsx` | #1673's two cap-notice cases vs this PR's six save cases | purely additive, both blocks kept. One of mine renamed to `…when a failed save carries none` so it no longer shares a name with the copy-path case. |

Auto-merged and then checked by hand: `mind-map-view.tsx` (toolbar → cap notice → `role="img"`, order and sibling-ness intact), `note.test.tsx`, `build-mind-map.ts/.test.ts`, `mind-map.md`, `notes.json`.

**`notes.json` verified programmatically**, not by eye — parsed, then asserted the exact key sets:

```
mindMap top-level keys: ['badge', 'emptyHint', 'linkHint', 'more', 'nodeCapNotice', 'regionLabel', 'toolbar', 'treeLabel']
toolbar keys: ['copyFailed', 'copyImage', 'copyVector', 'fit', 'imageCopied', 'label',
               'saveCanvas', 'saveFailed', 'saved', 'snapshotOn', 'vectorCopied']
OK: exact key sets match — #1672 (linkHint), #1673 (more, nodeCapNotice) and #1675 (four toolbar keys) all intact
```

Brace/paren balance checked on every merged and conflicted file; all zero.

## Three things the new code changed about this PR

### 1. Long headings — the reason `headingText` exists is now real

`clipLabel` shortens a label past 72 characters. `headingText` is computed from the projection's **whole** `text`, never read back off `label`, so a heading of 96 characters still produces a complete anchor. New cases in `mind-map-snapshot.test.ts` assert both halves: that the drawn label really is clipped (precondition), and that the saved anchor is the untruncated heading — for the heading node and for a child borrowing it.

### 2. Wiki-link nodes — resolved at save time

On screen a wiki-link box's href is only a click handle: #1672 anchors it on the node's own id and the real destination is `wikiTarget`, a title. A file has no click handler to read that, so writing that href into a canvas would put a block anchor this device minted into a durable document — exactly what this ticket forbids.

**Decision:** the save path resolves each distinct target through `resolveWikiLink` — the same resolver a `[[…]]` in the note body goes through — and hands the answers to the pure minting step as `wikiHrefs`. A saved wiki-link box therefore opens the note it names (at its heading, if the link named one) or the filed binary it names, on any device. A target that resolves to nothing (`create` / `not-found`) gets no entry and falls back to the heading anchor every other node carries, so it opens the source note at the section the link is written in — never a dead box, and never a frozen "create this note" promise a file cannot keep. The dashed outline is preserved.

### 3. Fold markers — minted, not dropped

**Decision: a "+N more" node stays in the saved canvas.** Dropping it is the silent loss the epic forbids — the canvas would simply be short some rows with nothing to say so. Kept, it is the line that says how much of the note is not on the canvas. It cannot expand in a document, so it anchors on the heading whose children are folded: clicking it opens the note at the place the missing rows actually live.

The same reasoning surfaced a bug this PR had introduced on its own: `rootDetail` **replaced** the root's badge line, which would have discarded the root's own fold count. It now goes **ahead of** it (`Snapshot · 21 Aug 2026 · +15 more`), with a test.

Both are documented in `mind-map.md` so neither is a surprise to a user who finds the canvas later.

I do **not** think either was out of scope: both are cases of "what does a saved canvas do with a node kind", which is squarely #1675's question, and leaving either alone would have shipped a block anchor into a durable file or lost content silently.

## Re-verified

```
$ pnpm lint                                       -> exit 0
✖ 108 problems (0 errors, 108 warnings)           (all pre-existing; none in a file this branch touches)

$ pnpm typecheck                                  -> exit 0
@memry/desktop:typecheck: Generated RPC bindings are up to date
@memry/desktop:typecheck: IPC invoke map is up to date
 Tasks:    17 successful, 17 total
  Time:    32.189s

$ pnpm test                                       -> exit 1  (known turbo flake, named this time)
@memry/desktop:test: [ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command was killed with SIGSEGV (Segmentation fault): vitest run --config config/vitest.config.ts
 Tasks:    8 successful, 9 total
  Time:    1m44.121s
No `Failed Tests` block and no failing spec named — the worker was killed, not a
red assertion. Re-run directly:

$ pnpm test:desktop                               -> exit 0
 Test Files  1379 passed | 3 skipped (1382)
      Tests  17991 passed | 1 expected fail | 13 skipped (18005)
   Duration  127.60s

$ pnpm --filter @memry/desktop i18n:check         -> exit 0
ok: i18n check passed

$ pnpm docs:impact --base db693aac9 --strict      -> exit 0
docs impact: covered against db693aac9
docs impact: docs changed on this branch

$ pnpm docs:build                                 -> exit 0
build complete in 4.92s.

$ pnpm check:architecture                         -> exit 0
architecture boundary check passed

$ pnpm check:contracts                            -> exit 0
contracts boundary check passed
```

### The probe, re-run on the merged code

Against the **real** `@excalidraw/excalidraw` converter (bundled for node, jsdom shell — it cannot initialize under vitest), over a note containing every node kind the three tickets can produce:

```
node kinds present: ["root","heading","bullet","wikiLink","check","more"]
--- ON-SCREEN MAP (buildMindMap) ---
  types: {"arrow":19,"rectangle":20,"line":1,"text":20}
  every arrow bound to two real boxes: true
  every box carries its arrow(s) + its text: true
  arrowheads all null: true
  dashed boxes (wiki links): 1
  block anchors (#^) among links: 19          <- correct: in-session click handles
--- SAVED SNAPSHOT ---
  types: {"arrow":19,"rectangle":20,"line":1,"text":20}
  every arrow bound to two real boxes: true
  every box carries its arrow(s) + its text: true
  arrowheads all null: true
  dashed boxes (wiki links): 1
  block anchors (#^) among links: 0           <- none reach the file
  links: ["memry://note/n1", "memry://note/n1#Risks", "memry://note/n1#Risks",
          "memry://note/n2#Plan",                          <- the wiki link, resolved
          "memry://note/n1#Risks",
          "memry://note/n1#Everything%20we%20learned%20about%20vendor%20lock-in%20during%20the%20third%20quarter%20of%20the%20migration%20work",
          "memry://note/n1#Many", ... x13 ]                <- incl. the "+N more" marker
  long-heading anchor complete: true
--- CANVAS DOCUMENT ---
  keys: ["type","version","source","elements","appState","files"]
  type/version/source: excalidraw 2 memry
  element count: 60  bytes: 39298
--- RTL MAP ---   (same counts, all bindings resolve)
```

`every box carries its arrow(s) + its text: true` is the load-bearing line — a box whose `boundElements` lists its arrows takes them with it when dragged — and it holds for dashed wiki boxes and fold markers exactly as for every other box. The probe is a throwaway and is not committed.

---

# What this PR does

## What this adds

**Save as canvas** — a fourth entry in the map toolbar's `actions` array (no new prop, no new slot). It mints a canvas from the map as currently drawn, files it at the canvas root under the note's name, and then lets go of it completely: nothing regenerates it, nothing overwrites it, and the note holds no reference back.

## Three decisions worth reading

### 1. Connectors are now real bound arrows

#1669 minted connectors as straight `line` elements with baked endpoints and flagged that this ticket had to change that. It does. A connector is now `type: 'arrow'` with `start: { id: <parent> }` / `end: { id: <child> }`, both arrowheads `null` and `roundness: null`, so **on screen it is the same straight grey rule it has always been** while a node dragged in a saved canvas keeps its branches attached.

Element minting is private behind `buildMindMap`, so the public seam did not move. The change is real, though, and was verified against the real `@excalidraw/excalidraw` converter rather than assumed — see *Verification* below.

The strike-through over a completed item stays a `line`: it belongs to the box's text, not to the space between two boxes.

### 2. The saved document is minted purely, and only the last step touches the library

`mind-map-snapshot.ts` is a new private module with no drawing-library import. It re-mints the map's own positioned nodes for a FILE rather than for a session — same nodes, same coordinates, durable links, dated root — and builds the canvas envelope. That is what makes the anchor form, the date, the collision suffix and the document shape all assertable in a unit test with no DOM.

The one step that needs the library (skeletons → real elements, which is what resolves the arrow bindings) is `toCanvasScene` in `mind-map-export.ts`, reached from `mind-map-view.tsx` through a dynamic `import()`. No static drawing-library import entered the main renderer bundle.

Re-minting from `map` rather than re-running `buildMindMap` is deliberate: the saved canvas is the map the user is looking at, so whatever a later ticket puts INTO `map` (expanded branches, #1673) flows into the file for free.

### 3. The receiving half of heading anchors is now wired — #1670 left it deliberately

`canvas-editor.tsx`'s `openMemryTarget` ignored a heading anchor. Nothing minted such a link, and this ticket is what starts minting them, so without this the acceptance criterion would have passed on paper and failed in the product: every link in a saved canvas would open the right note **at the top**.

It is consumed in `openMemryTarget`, not in `tabFromMemryHref` — which #1668 documented as saying only WHICH item to open, leaving where-inside-it to the opening page. The note page already takes a heading through tab view state `headingText` (`pages/note.tsx` → `initialHeadingText` → `scrollToHeadingWhenReady`, which handles a block that has not rendered yet). A BLOCK anchor arriving from a canvas is ignored: it names a block this device has never minted.

## Acceptance criteria

- [x] **A save action in the map toolbar creates a canvas at the canvas root, titled after the note, with a suffix on collision.** `mind-map-view.test.tsx` → *mints a canvas at the root, named after the note, and says so* (asserts `folder: null`, `title: 'Test Note'`) and *suffixes the title when the canvas root already holds that name* (a same-named canvas in a folder is not a collision). Suffix algebra in `mind-map-snapshot.test.ts` → `uniqueCanvasTitle` (4 cases, incl. NFC + case folding, matching `canvasPathKey`).
- [x] **The canvas appears in the sidebar like any other canvas and is fully user-owned; nothing regenerates or overwrites it.** It goes through the existing `canvasService.create` path with no new field, so it is an ordinary canvas row and file. Nothing in this branch ever calls `canvas.update`, and the note stores nothing.
- [x] **Saving a second time creates a second canvas rather than replacing the first.** `mind-map-view.test.tsx` → *makes a SECOND canvas rather than replacing the first*: two clicks, two `create` calls, second one named `Test Note 2`.
- [x] **Nodes that point at vault items are minted as plain shapes carrying deep links, not live entity cards.** `mind-map-snapshot.test.ts` → *mints plain shapes carrying links, never live entity cards* (no `customData`, which is what makes a rectangle a live card in `pages/canvas/canvas-cards.ts`).
- [x] **Links use heading-text anchors so they resolve on another device; a list node anchors to its nearest ancestor heading.** `mind-map-snapshot.test.ts` → six cases: heading anchors on its own text; a list node (and a nested one) on its nearest ancestor heading; a node under a deeper heading on THAT one; nothing above the first heading and at the root; **no `#^` block anchor anywhere in the document**; percent-escaping round-trips through `parseMemryHref`.
- [x] **The round trip actually lands at the heading.** `canvas-editor.test.tsx` → *lands a heading-anchored note link at that heading, not at the top*. The href is not typed by hand — it is minted by the real `buildMindMap` + `mintSnapshotElements`, then clicked through the real `onLinkOpen`, and the tab that comes out carries `viewState: { headingText: 'Risks' }`. Companion case: a block anchor opens with no view state.
- [x] **The root node records the date the map was generated.** `mind-map-snapshot.test.ts` → *dates the root, under the note title*, plus *grows the root box to hold the line the layout never budgeted for* (downwards only; every other node stays byte-identical to the drawn map). `mind-map-view.test.tsx` → *dates the root so the canvas announces that it is a snapshot* (the real translated + locale-formatted string).
- [x] **The note stores no reference to the canvas; the relationship is one-way.** No schema, no contract, no sync handler, no settings field — `pnpm check:contracts` and `pnpm check:architecture` both pass and `pnpm typecheck` reports the IPC invoke map unchanged.
- [x] **A wiki-link node carries a link that still resolves on another device.** `mind-map-snapshot.test.ts` → four cases: the resolved target is what the box carries; a target that resolves to nothing falls back to the heading the link is written under; it never carries the node-id anchor the drawn map gives it; the dashed outline survives. `mind-map-view.test.tsx` → *resolves a wiki-link node to the note it names before writing the file* (asserts the save path asks `resolveWikiLink`, the same resolver the note body uses).
- [x] **A "+N more" fold marker is kept and accounted for rather than dropped.** `mind-map-snapshot.test.ts` → *is minted rather than dropped, so the canvas says how much is missing* and *opens the note at the section the missing rows actually live in*.
- [x] **A heading past the 72-character label cap still anchors on its whole text.** `mind-map-snapshot.test.ts` → *clips the drawn label, because a box cannot hold it* (precondition) and *anchors on the WHOLE heading, not on the clipped label*.
- [x] **The generation date never displaces what the root already had to say.** `mind-map-snapshot.test.ts` → *keeps what the root already had to say, alongside the generation date*.
- [x] **Tests cover collision naming, the anchor form, and that the produced document parses as a valid canvas scene.** `mindMapSceneJson` asserts the document's keys **in the exact order `canvas/scene-file.ts`'s `canonicalize` emits them** (`type`, `version`, `source`, `elements`, `appState`, `files`), so the store canonicalizes it to itself plus its `memry` sidecar and writes it unchanged; plus a case reading it back the way `canvas-editor.tsx` loads a scene, and an empty map.

## Verification

### The bound arrows, against the real converter

See **The probe, re-run on the merged code** at the top of this description — that run is on the rebased head and covers the dashed wiki-link boxes and the fold markers too.

### Gates

See **Re-verified** at the top of this description — those are the current numbers, run on the rebased head.


## Shape

- `mind-map-snapshot.ts` — **new**, private, pure. Snapshot minting, the canvas envelope, the collision suffix.
- `mind-map-elements.ts` — connectors become bound arrows; minting gains an anchor mode and an optional root detail line.
- `mind-map-projection.ts` / `mind-map-layout.ts` / `mind-map-types.ts` — a node now carries `headingText`, the nearest heading at or above it, computed where the heading's text is still whole rather than read back off the display label.
- `mind-map-export.ts` — gains `toCanvasScene`; `toSkeleton` moved here so both callers share one cast.
- `mind-map-view.tsx` — the fourth toolbar action, the strings, the toast, the error surfacing.
- `canvas-editor.tsx` — consumes a heading anchor.

`buildMindMap` remains the one public entry point; nothing private was exported from `index.ts`. The toolbar is still a **sibling** of the `role="img"` region.

## Out of scope, on purpose

- The link bubble in a saved canvas prints the raw `memry://note/<id>#Heading`, because these hrefs carry no `?label=`. That is the drawn map's existing behaviour (#1669 mints label-less links too), and changing it here would make the drawn map and the saved one disagree for no acceptance criterion. Worth a follow-up.
- A heading whose text contains a wiki link or a date mention anchors on text that `extractHeadings` reads differently, so such a link opens the note at the top rather than at the heading. Degrades exactly the way the spec says an unresolvable anchor should, and there is no data loss. An inline hash tag is fine — both sides drop it.
