### PR TITLE
test(notes): cover the mind-map journey end to end

### DIFF
--- a/apps/desktop/tests/e2e/mind-map.e2e.ts
+++ b/apps/desktop/tests/e2e/mind-map.e2e.ts
@@ -1,0 +1,162 @@
+/**
+ * Note mind map E2E
+ *
+ * The one end-to-end journey the mind-map epic (#1667) asks for: open a note,
+ * press the header toggle, see the note's structure as a map, click a heading
+ * node, and land back in the editor at that heading.
+ *
+ * This journey is only reachable because the map ships a `role="tree"` DOM
+ * projection alongside the drawing. The drawing itself is a bitmap surface —
+ * Playwright cannot see a node inside it, cannot click one, and cannot read a
+ * label off it. The tree layer exists for screen readers, for keyboard users,
+ * and for exactly this file.
+ *
+ * The second test is the undo guarantee. The unit suite asserts it structurally
+ * (the editor instance is the same object across a toggle round trip); here it
+ * is asserted the way a user would notice it — type, look at the map, come back,
+ * undo, and find the typing undone rather than the history gone.
+ */
+
+import { test, expect } from './fixtures'
+import type { Page } from '@playwright/test'
+import {
+  waitForAppReady,
+  waitForVaultReady,
+  seedNote,
+  SELECTORS,
+  SHORTCUTS
+} from './utils/electron-helpers'
+import { waitForNoteById, openNoteByHandle } from './utils/note-sync-helpers'
+
+const NOTE_TITLE = 'Mind Map Journey'
+
+/**
+ * Long on purpose. The point of the last assertion is that the editor SCROLLED
+ * to the clicked heading, so the note has to be taller than the viewport —
+ * otherwise "the heading is on screen" is true before the click as well and the
+ * test passes without the feature working.
+ */
+const FILLER = Array.from(
+  { length: 12 },
+  (_, i) => `Filler paragraph ${i + 1} keeping the sections far apart.`
+).join('\n\n')
+
+const NOTE_BODY = [
+  '# Overview',
+  FILLER,
+  '## Background',
+  FILLER,
+  '# Risks',
+  FILLER,
+  '## Mitigations',
+  FILLER,
+  '# Closing Section',
+  FILLER
+].join('\n\n')
+
+const TOGGLE = '[data-testid="note-mind-map-toggle"]'
+const MAP = '[data-testid="note-mind-map"]'
+const TREE = '[data-testid="mind-map-tree"]'
+const HEADING_NODES = `${TREE} [role="treeitem"][data-mind-map-kind="heading"]`
+
+async function seedAndOpen(page: Page): Promise<void> {
+  const id = await seedNote(page, NOTE_TITLE, NOTE_BODY)
+  const handle = await waitForNoteById(page, id, NOTE_TITLE)
+  await openNoteByHandle(page, handle)
+  await expect(page.locator(SELECTORS.noteTitle).first()).toHaveValue(NOTE_TITLE)
+}
+
+test.describe('Note mind map', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+  })
+
+  test('opens a note as a map and lands back on the heading a node names', async ({ page }) => {
+    await seedAndOpen(page)
+
+    const toggle = page.locator(TOGGLE)
+    await expect(toggle).toBeVisible()
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    // The map replaces the body.
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.locator(MAP)).toBeVisible()
+
+    // The editor is HIDDEN, not unmounted. Both halves matter: `toBeAttached`
+    // is the undo-history guarantee, `not.toBeVisible` is the replacement.
+    const editor = page.locator(SELECTORS.noteEditor).first()
+    await expect(editor).toBeAttached()
+    await expect(editor).not.toBeVisible()
+
+    // The region announces itself as the note's map.
+    await expect(page.locator(`${MAP} [role="img"]`)).toHaveAttribute(
+      'aria-label',
+      new RegExp(NOTE_TITLE)
+    )
+
+    // Every heading in the note reached the tree.
+    const headings = page.locator(HEADING_NODES)
+    await expect(headings).toHaveCount(5)
+    await expect(headings.filter({ hasText: 'Closing Section' })).toHaveCount(1)
+
+    // Take the LAST heading, so landing on it requires a real scroll.
+    const target = headings.filter({ hasText: 'Closing Section' }).first()
+    const blockId = await target.getAttribute('data-mind-map-block')
+    expect(blockId, 'a heading node carries no block anchor').toBeTruthy()
+
+    // Activated from the keyboard, not with a mouse click, and deliberately so.
+    // The tree is `sr-only` — it is the map's accessible projection, sitting at
+    // one pixel underneath the drawing, and a pointer never reaches it in the
+    // real product either. A mouse user clicks the drawn box on the canvas; a
+    // screen-reader or keyboard user walks this tree. Driving it with the
+    // keyboard is what the tree is for, and it doubles as the acceptance check
+    // that keyboard activation does the same thing a click does.
+    await target.press('Enter')
+
+    // The map closed and gave the note back.
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false')
+    await expect(page.locator(MAP)).toHaveCount(0)
+    await expect(editor).toBeVisible()
+
+    // Landed on the clicked heading. `.first()` because a block id appears on
+    // more than one node in the rendered block, which is why the app's own
+    // `scrollToHeadingBlock` scopes its lookup and takes the first match too.
+    const landed = page.locator(`[data-id="${blockId}"]`).first()
+    await expect(landed).toBeInViewport({ timeout: 10000 })
+
+    // ...and genuinely scrolled there rather than sitting at the top, which is
+    // the assertion that fails if the toggle closes without navigating.
+    const firstHeading = page.locator(`${SELECTORS.noteEditor} h1`).first()
+    await expect(firstHeading).not.toBeInViewport()
+  })
+
+  test('keeps undo history across a trip to the map and back', async ({ page }) => {
+    await seedAndOpen(page)
+
+    const editor = page.locator(SELECTORS.noteEditor).first()
+    await editor.click()
+    await page.keyboard.press('End')
+
+    const typed = 'typed before looking at the map'
+    await page.keyboard.type(typed)
+    await expect(editor).toContainText(typed)
+
+    // Look at the map and come back.
+    const toggle = page.locator(TOGGLE)
+    await toggle.click()
+    await expect(page.locator(MAP)).toBeVisible()
+    await toggle.click()
+    await expect(page.locator(MAP)).toHaveCount(0)
+    await expect(editor).toBeVisible()
+
+    // If the map had unmounted the editor, the collaborative undo manager would
+    // have gone with it and this would undo nothing — or worse, everything.
+    await editor.click()
+    await page.keyboard.press(SHORTCUTS.undo)
+
+    await expect(editor).not.toContainText(typed)
+    await expect(editor).toContainText('Overview')
+  })
+})


### PR DESCRIPTION
## Why this exists

Epic #1667's testing decisions ask for exactly one end-to-end journey:

> open a note, toggle, see the map, click a heading node, land back in the editor at the right block.

None of the eight tickets' acceptance criteria claimed it — #1670 left it out deliberately, since its own ACs did not list it — so it was the one thing the epic asked for that nothing owned. This is it.

It matters more than its size suggests. The drawing is a bitmap surface: no unit test can see a node inside it, click one, or read a label off it. Everything below the canvas is proven by the pure entry point and by renderer tests against the accessible tree; this is the only test that proves the whole thing works when it is actually running.

## What it covers

**1. The journey.** Seed a note with five headings and enough filler to make the page taller than the viewport, open it, press the header toggle, and assert:

- the toggle reports `aria-pressed="true"` and the map appears;
- the editor is **attached but not visible** — the two halves are separate assertions on purpose, because "attached" is the undo-history guarantee and "not visible" is the replacement;
- the map region's label names the note;
- all five headings reached the tree;
- activating the **last** heading closes the map, brings the editor back, and lands on that heading — and the note's first `h1` is no longer in the viewport, which is the assertion that fails if the toggle closes without navigating.

The note is long on purpose. In a short note "the heading is on screen" is already true before the click, and the test would pass without the feature working.

**2. The undo guarantee.** The unit suite asserts it structurally — the editor instance is the same object across a toggle round trip. This asserts what that buys: type, look at the map, come back, undo, and find the typing undone rather than the history gone. Had the map unmounted the editor, the collaborative undo manager would have gone with it.

## Keyboard, not pointer — deliberately

The node is activated with `Enter`, not a click. The tree is `sr-only`, one pixel underneath the drawing, and a pointer never reaches it in the product either: a mouse user clicks the drawn box on the canvas, a keyboard or screen-reader user walks this tree. Driving it from the keyboard is what the layer is for, and it doubles as the acceptance check that keyboard activation does the same thing a click does.

Two earlier failures were both the test being wrong, not the feature: driving an `sr-only` layer with a pointer, and a block id that appears on more than one node in a rendered block (the app's own `scrollToHeadingBlock` scopes its lookup and takes the first match for the same reason).

## Verification

Run against a fresh production build — the suite launches `out/` and only rebuilds when `BUILD_BEFORE_TEST` is set, so a stale bundle silently tests old code:

```
MEMRY_ENV=production pnpm exec electron-vite build     exit 0   ✓ built in 13.03s
bash scripts/ensure-native.sh electron                 exit 0

pnpm exec playwright test tests/e2e/mind-map.e2e.ts    exit 0
  ✓ 1 [electron] › Note mind map › opens a note as a map and lands back on the heading a node names (14.0s)
  ✓ 2 [electron] › Note mind map › keeps undo history across a trip to the map and back (13.9s)
  2 passed (28.3s)
```

Repository gates:

```
pnpm lint                                    exit 0   108 problems (0 errors, 108 warnings), all pre-existing
pnpm typecheck                               exit 0   Tasks: 17 successful, 17 total
pnpm --filter @memry/desktop i18n:check      exit 0   ok: i18n check passed
pnpm docs:impact --base origin/main --strict exit 0   no desktop/sync-server docs-relevant changes detected
```

One new test file, no production code touched.

Part of #1667.