### PR TITLE
feat(notes): show the mind map's link affordance on hover, and name the destination

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map-wiki-links.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map-wiki-links.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, expect, it } from 'vitest'
 import { buildMindMap } from './build-mind-map'
+import { mindMapHrefOf } from './mind-map-hover'
 import type {
   MindMapBoxElement,
   MindMapNode,
@@ -253,17 +254,18 @@ describe('buildMindMap — wiki links are drawn apart from the note', () => {
     const link = boxFor(map, 'Roadmap')
     const sentence = boxFor(map, 'Read')
 
-    // In view mode the whole box is the link's hit area, so two boxes sharing
-    // one href would send a click to whichever came first.
-    expect(link.link).not.toBe(sentence.link)
-    expect(sentence.link).toBe('memry://note/note-1#^b')
-    expect(link.link).toBe(`memry://note/note-1#^${positioned(map, 'Roadmap').id}`)
+    // The whole box is the hit area — the map's own hit test keeps what view
+    // mode used to give it — so two boxes sharing one href would send a click
+    // to whichever came first.
+    expect(mindMapHrefOf(link)).not.toBe(mindMapHrefOf(sentence))
+    expect(mindMapHrefOf(sentence)).toBe('memry://note/note-1#^b')
+    expect(mindMapHrefOf(link)).toBe(`memry://note/note-1#^${positioned(map, 'Roadmap').id}`)
   })
 
   it('keeps the href of every box unique', () => {
     const hrefs = map.elements
       .filter((element): element is MindMapBoxElement => element.type === 'rectangle')
-      .map((box) => box.link)
+      .map((box) => mindMapHrefOf(box))
 
     expect(new Set(hrefs).size).toBe(hrefs.length)
   })

--- a/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/build-mind-map.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, expect, it } from 'vitest'
 import { buildMindMap } from './build-mind-map'
+import { mindMapHrefOf } from './mind-map-hover'
 import type {
   MindMapBoxElement,
   MindMapNode,
@@ -403,17 +404,25 @@ describe('buildMindMap — elements', () => {
 describe('buildMindMap — deep links', () => {
   const blocks = [heading('a', 1, 'Alpha'), heading('a1', 2, 'Alpha one')]
 
-  function boxes(map: ReturnType<typeof buildMindMap>): Map<string, { link?: string }> {
+  /**
+   * The deep link each box carries, keyed by node id.
+   *
+   * Read out of `customData`, which is where the DRAWN map keeps its hrefs.
+   * `element.link` is the field the drawing library paints its permanent link
+   * glyph from, and on a map every single box is linked — so the map keeps its
+   * addresses somewhere the renderer will not decorate them.
+   */
+  function hrefs(map: ReturnType<typeof buildMindMap>): Map<string, string | null> {
     return new Map(
       map.elements
         .filter((element) => element.type === 'rectangle')
-        .map((box) => [box.id, box] as const)
+        .map((box) => [box.id, mindMapHrefOf(box)] as const)
     )
   }
 
   it('draws no links at all without a note to point at', () => {
     const map = buildMindMap(blocks, { rootLabel: 'Note' })
-    for (const box of boxes(map).values()) expect(box.link).toBeUndefined()
+    for (const href of hrefs(map).values()) expect(href).toBeNull()
   })
 
   it('anchors a heading box at its own block', () => {
@@ -421,7 +430,7 @@ describe('buildMindMap — deep links', () => {
     const alpha = map.nodes.find((node) => node.label === 'Alpha')!
 
     // A block anchor: exact, and meaningful only in the session that minted it.
-    expect(boxes(map).get(alpha.id)?.link).toBe('memry://note/note-1#^a')
+    expect(hrefs(map).get(alpha.id)).toBe('memry://note/note-1#^a')
   })
 
   it('anchors the root at nothing, because the title is not a block', () => {
@@ -429,15 +438,37 @@ describe('buildMindMap — deep links', () => {
     const root = map.nodes.find((node) => node.kind === 'root')!
 
     // No fragment — which reads as "this note, from the top".
-    expect(boxes(map).get(root.id)?.link).toBe('memry://note/note-1')
+    expect(hrefs(map).get(root.id)).toBe('memry://note/note-1')
   })
 
   it('links every box and no connector', () => {
     const map = buildMindMap(blocks, { rootLabel: 'Note', noteId: 'note-1' })
     for (const element of map.elements) {
-      if (element.type === 'rectangle') expect(element.link).toMatch(/^memry:\/\/note\/note-1/)
-      else expect(element).not.toHaveProperty('link')
+      if (element.type === 'rectangle') {
+        expect(mindMapHrefOf(element)).toMatch(/^memry:\/\/note\/note-1/)
+      } else {
+        expect(element).not.toHaveProperty('customData')
+      }
     }
+  })
+
+  it('puts no `link` on any drawn element, so no glyph is ever painted', () => {
+    const map = buildMindMap(blocks, { rootLabel: 'Note', noteId: 'note-1' })
+
+    // The whole of problem 1 in #1688: the library's glyph condition is
+    // `element.link && !selected`, with no hover gate and no prop, appState
+    // field or CSS surface that suppresses it. The only way the map does not
+    // wear a wall of identical blue squares is to carry no `link` at all.
+    for (const element of map.elements) expect(element).not.toHaveProperty('link')
+  })
+
+  it('carries no display label on a drawn href, which nothing on screen reads', () => {
+    const map = buildMindMap(blocks, { rootLabel: 'Note', noteId: 'note-1' })
+
+    // The map renders its own affordance from the node it hit, so an on-screen
+    // href never has to describe itself. Only a FILE needs a `?label=`, because
+    // only a file is read by code that is not ours.
+    for (const href of hrefs(map).values()) expect(href).not.toContain('label=')
   })
 
   it('lays out identically whether or not the boxes carry links', () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.css
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.css
@@ -1,0 +1,17 @@
+/**
+ * The one thing `element.link` bought that a DOM overlay cannot re-create.
+ *
+ * The drawing library sets its cursor as an inline style on the interactive
+ * canvas, and re-sets it on pointer moves — in view mode it is `grab`, and it
+ * used to become `pointer` over a linked element for us. Only a rule marked
+ * important outranks an inline style, so the pointer cursor is declared here
+ * and switched on by the data attribute the surface sets while a node is under
+ * the cursor.
+ *
+ * Deliberately keyed on `canvas` and on our own attribute, not on any class the
+ * library owns: the two canvases inside this wrapper are the library's, but the
+ * selector says nothing about how it names them.
+ */
+.mind-map-surface[data-node-hover='true'] canvas {
+  cursor: pointer !important;
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.test.tsx
@@ -1,37 +1,65 @@
 /**
- * What the toolbar's actions actually do to the drawing.
+ * What the surface actually does: the toolbar's actions, and the link
+ * affordance the map draws for itself.
  *
  * The drawing library stands in for itself here: jsdom has no canvas to
  * rasterise to and no system clipboard to write to, so the real
  * `exportToBlob`/`exportToSvg` could not run and the real `navigator.clipboard`
- * does not exist. What these tests can prove is the part that has been wrong
- * before in this kind of code: that an export reads the LIVE scene rather than
- * the elements the map was built from, that the export settings are pinned
- * rather than inherited from the app's theme or the user's camera, and that a
- * failure travels up to the caller instead of being swallowed here.
+ * does not exist. The stand-in is faithful in the two places that matter — it
+ * hands up a live scene the exports read, and it converts viewport points to
+ * scene points the same way the library does — so what these tests prove is the
+ * wiring, which is where this kind of code has gone wrong before: that an
+ * export reads the LIVE scene rather than the elements the map was built from,
+ * that the export settings are pinned rather than inherited from the app's
+ * theme or the user's camera, that a failure travels up to the caller, and that
+ * the hover and the click land on the box the pointer is actually over.
  *
- * They deliberately do not prove that the resulting bytes are a valid PNG or
- * that a real clipboard accepts them — only a real browser can say that.
+ * They deliberately do not prove that the resulting bytes are a valid PNG, that
+ * a real clipboard accepts them, or that a real Excalidraw canvas puts its
+ * pixels where this arithmetic says it does — only a real browser can say that.
  */
 
 import { useEffect } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { act, render } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { exportToBlob, exportToSvg } from '@excalidraw/excalidraw'
-import { MindMapCanvas, type MindMapControls } from './mind-map-canvas'
+import { MindMapCanvas, type MindMapControls, type MindMapHoverLabel } from './mind-map-canvas'
 import type { MindMapElement } from './mind-map-types'
 
 /**
  * The scene the surface is showing — deliberately NOT the elements the map was
  * built from, so a test can tell the two apart. A branch the user expanded
  * lives here and nowhere else.
+ *
+ * Real geometry and real `customData`, because the hit test reads both off this
+ * same live scene: the library regenerates every id on the way in, so
+ * `customData` is the only field a box's address can survive in.
  */
-const LIVE_ELEMENTS = [{ id: 'live-1' }, { id: 'live-2' }]
+const ROOT_HREF = 'memry://note/n1'
+const ITEM_HREF = 'memry://note/n1#^b-item'
+const WIKI_HREF = 'memry://note/n1#^mm-b-item-link-1'
+
+const LIVE_ELEMENTS = [
+  { id: 'live-1', x: 0, y: 0, width: 100, height: 40, customData: { memryHref: ROOT_HREF } },
+  { id: 'live-2', x: 200, y: 0, width: 160, height: 40, customData: { memryHref: ITEM_HREF } },
+  { id: 'live-3', x: 200, y: 100, width: 160, height: 40, customData: { memryHref: WIKI_HREF } },
+  /** A connector: no address, so the hit test must never answer with it. */
+  { id: 'live-edge', x: 0, y: 0, width: 400, height: 400 }
+]
 const LIVE_FILES = { 'file-1': { id: 'file-1' } }
+
+const HOVER_LABELS: ReadonlyMap<string, MindMapHoverLabel> = new Map([
+  [ROOT_HREF, { chain: 'Test Note', hint: null }],
+  [ITEM_HREF, { chain: '\u2026 \u2192 Q3 Risks \u2192 Hire a designer', hint: null }],
+  [WIKI_HREF, { chain: 'Roadmap \u2192 Q3', hint: 'link to another page' }]
+])
 
 const mocks = vi.hoisted(() => ({
   scrollToContent: vi.fn(),
-  updateScene: vi.fn()
+  updateScene: vi.fn(),
+  onChange: vi.fn(() => () => {}),
+  /** The camera, as a test can move it. */
+  appState: { scrollX: 0, scrollY: 0, zoom: { value: 1 }, offsetLeft: 0, offsetTop: 0 }
 }))
 
 vi.mock('@excalidraw/excalidraw', () => ({
@@ -40,6 +68,8 @@ vi.mock('@excalidraw/excalidraw', () => ({
       excalidrawAPI({
         getSceneElements: () => LIVE_ELEMENTS,
         getFiles: () => LIVE_FILES,
+        getAppState: () => mocks.appState,
+        onChange: mocks.onChange,
         updateScene: mocks.updateScene,
         scrollToContent: mocks.scrollToContent
       })
@@ -47,6 +77,15 @@ vi.mock('@excalidraw/excalidraw', () => ({
     return <div data-testid="excalidraw" />
   },
   convertToExcalidrawElements: (elements: unknown[]) => elements,
+  // The library's own arithmetic, kept honest rather than stubbed: the hit test
+  // is only as right as this conversion.
+  viewportCoordsToSceneCoords: (
+    point: { clientX: number; clientY: number },
+    appState: { scrollX: number; scrollY: number; zoom: { value: number } }
+  ) => ({
+    x: point.clientX / appState.zoom.value - appState.scrollX,
+    y: point.clientY / appState.zoom.value - appState.scrollY
+  }),
   exportToBlob: vi.fn(),
   exportToSvg: vi.fn()
 }))
@@ -70,6 +109,7 @@ function mountSurface(): { controls: () => MindMapControls; unmount: () => void 
   const view = render(
     <MindMapCanvas
       elements={BUILT_ELEMENTS}
+      hoverLabels={HOVER_LABELS}
       onOpenLink={openLink}
       onControlsChange={(next) => {
         latest = next
@@ -85,9 +125,29 @@ function mountSurface(): { controls: () => MindMapControls; unmount: () => void 
   }
 }
 
+/** The drawing itself, which is what a pointer event on the canvas reaches. */
+function drawing(): HTMLElement {
+  return screen.getByTestId('excalidraw')
+}
+
+function pointAt(x: number, y: number): void {
+  fireEvent.pointerMove(drawing(), { clientX: x, clientY: y })
+}
+
+function clickAt(x: number, y: number): void {
+  fireEvent.pointerDown(drawing(), { clientX: x, clientY: y })
+  fireEvent.click(drawing(), { clientX: x, clientY: y })
+}
+
+function card(): HTMLElement | null {
+  return screen.queryByTestId('mind-map-hover-card')
+}
+
 describe('MindMapCanvas controls', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.onChange.mockImplementation(() => () => {})
+    mocks.appState = { scrollX: 0, scrollY: 0, zoom: { value: 1 }, offsetLeft: 0, offsetTop: 0 }
     vi.stubGlobal('ClipboardItem', FakeClipboardItem)
     Object.defineProperty(globalThis.navigator, 'clipboard', {
       value: clipboard,
@@ -105,6 +165,7 @@ describe('MindMapCanvas controls', () => {
     const view = render(
       <MindMapCanvas
         elements={BUILT_ELEMENTS}
+        hoverLabels={HOVER_LABELS}
         onOpenLink={openLink}
         onControlsChange={(next) => {
           latest = next
@@ -191,5 +252,166 @@ describe('MindMapCanvas controls', () => {
 
     await expect(surface.controls().copyImage()).rejects.toThrow('Rasterising failed')
     expect(clipboard.write).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * The affordance the map draws for itself, now that its boxes carry no `link`
+ * for the library to decorate.
+ *
+ * What is asserted is the wiring and the arithmetic — which box a point lands
+ * on, what is said about it, and that a click reaches the same box. What jsdom
+ * cannot say is whether the card lands over the right pixels on a real canvas;
+ * the numbers are checked here, the picture is not.
+ */
+describe('MindMapCanvas link affordance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.onChange.mockImplementation(() => () => {})
+    mocks.appState = { scrollX: 0, scrollY: 0, zoom: { value: 1 }, offsetLeft: 0, offsetTop: 0 }
+  })
+
+  it('says nothing until the pointer is over a node', () => {
+    mountSurface()
+    expect(card()).toBeNull()
+
+    // Inside the connector's bounds but on no box: an element with no address
+    // is not a node, however large it is.
+    pointAt(150, 60)
+    expect(card()).toBeNull()
+  })
+
+  it('names the node under the cursor, and only that node', () => {
+    mountSurface()
+
+    pointAt(240, 20)
+    expect(card()).toHaveTextContent('\u2026 \u2192 Q3 Risks \u2192 Hire a designer')
+    expect(card()).not.toHaveTextContent('Test Note')
+
+    pointAt(50, 20)
+    expect(card()).toHaveTextContent('Test Note')
+    expect(card()).not.toHaveTextContent('Q3 Risks')
+  })
+
+  it('answers for the whole box, not for a glyph in the corner of it', () => {
+    mountSurface()
+
+    // Every corner and the middle of live-2 (200,0 → 360,40). This is the
+    // property view mode's own link hit test gave us and the one thing a
+    // re-implementation could quietly take away.
+    for (const [x, y] of [
+      [200, 0],
+      [360, 0],
+      [200, 40],
+      [360, 40],
+      [280, 20]
+    ]) {
+      pointAt(x, y)
+      expect(card()).toHaveTextContent('Hire a designer')
+    }
+
+    // One pixel past the edge is not the box.
+    pointAt(361, 20)
+    expect(card()).toBeNull()
+  })
+
+  it('says when the link leaves this note, in the tree\u2019s own words', () => {
+    mountSurface()
+
+    pointAt(280, 120)
+    expect(card()).toHaveTextContent('Roadmap \u2192 Q3')
+    expect(card()).toHaveTextContent('link to another page')
+  })
+
+  it('is decoration on the picture rather than a second thing to read', () => {
+    mountSurface()
+    pointAt(280, 20)
+
+    // The accessible tree beside the map already carries this in words; a
+    // second copy would be read out twice. It is also never a pointer target —
+    // every event has to reach the drawing underneath it.
+    const layer = card()!.parentElement!
+    expect(layer).toHaveAttribute('aria-hidden', 'true')
+    expect(layer.className).toContain('pointer-events-none')
+  })
+
+  it('turns the cursor into a pointer only while a node is under it', () => {
+    const { container } = render(
+      <MindMapCanvas elements={BUILT_ELEMENTS} hoverLabels={HOVER_LABELS} onOpenLink={openLink} />
+    )
+    const wrapper = container.querySelector('.mind-map-surface')!
+    expect(wrapper).not.toHaveAttribute('data-node-hover')
+
+    pointAt(280, 20)
+    // The rule itself lives in CSS, because only a rule marked important
+    // outranks the inline cursor the library sets on its own canvas.
+    expect(wrapper).toHaveAttribute('data-node-hover', 'true')
+
+    pointAt(500, 500)
+    expect(wrapper).not.toHaveAttribute('data-node-hover')
+  })
+
+  it('follows the camera, so a pan does not leave the answer behind', () => {
+    mountSurface()
+
+    pointAt(240, 20)
+    expect(card()).toHaveTextContent('Hire a designer')
+
+    // The pointer has not moved; the drawing has. The same screen point is now
+    // over the root's box.
+    mocks.appState = { ...mocks.appState, scrollX: 200 }
+    pointAt(240, 20)
+    expect(card()).toHaveTextContent('Test Note')
+  })
+
+  it('opens what the box under the click points at, from anywhere in the box', () => {
+    mountSurface()
+
+    clickAt(205, 38)
+    expect(openLink).toHaveBeenCalledWith(ITEM_HREF)
+
+    clickAt(20, 20)
+    expect(openLink).toHaveBeenLastCalledWith(ROOT_HREF)
+
+    // A wiki-link box is handed back exactly like any other: WHERE it goes is
+    // decided downstream, from the node its href resolves to.
+    clickAt(280, 120)
+    expect(openLink).toHaveBeenLastCalledWith(WIKI_HREF)
+  })
+
+  it('opens nothing when the click lands on no box', () => {
+    mountSurface()
+
+    clickAt(150, 60)
+    expect(openLink).not.toHaveBeenCalled()
+  })
+
+  it('treats a press that travelled as a pan rather than as a click', () => {
+    mountSurface()
+
+    // In view mode a drag anywhere moves the camera, and finishing a pan over
+    // a node must not open it.
+    fireEvent.pointerDown(drawing(), { clientX: 210, clientY: 20 })
+    fireEvent.click(drawing(), { clientX: 300, clientY: 20 })
+    expect(openLink).not.toHaveBeenCalled()
+  })
+
+  it('forgets what was under the cursor when the map is rebuilt', () => {
+    const view = render(
+      <MindMapCanvas elements={BUILT_ELEMENTS} hoverLabels={HOVER_LABELS} onOpenLink={openLink} />
+    )
+    pointAt(240, 20)
+    expect(card()).not.toBeNull()
+
+    // A rebuilt map is a different drawing; whatever was under the cursor
+    // belonged to the old one.
+    view.rerender(
+      <MindMapCanvas
+        elements={[{ type: 'rectangle', id: 'built-2' }] as unknown as readonly MindMapElement[]}
+        hoverLabels={HOVER_LABELS}
+        onOpenLink={openLink}
+      />
+    )
+    expect(card()).toBeNull()
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.tsx
@@ -16,15 +16,34 @@
  * map's image region. (Anything inside an `img` role is presentational, so a
  * toolbar nested in it would be invisible to exactly the readers the accessible
  * projection exists for.)
+ *
+ * This chunk also owns the map's LINK AFFORDANCE, which used to be the drawing
+ * library's job. A box carrying `element.link` gets a permanent blue glyph and
+ * a hover bubble printing the raw href; on a canvas where a few shapes are
+ * linked that marks something, and on a map where every box is it marks
+ * nothing and buries the shape the picture exists to show. There is no
+ * hover-gate for the glyph and no supported way to ask what is under the
+ * cursor, so the map keeps its href out of `link` (see `mintElements`) and
+ * re-implements the three things that field was buying: the pointer cursor
+ * (`mind-map-canvas.css`), the hover affordance below, and click-to-open. The
+ * hit test is the whole bounding box, which is what view mode gave us and why
+ * clicking anywhere on a node has always worked.
  */
 
-import { useCallback, useEffect, useMemo, useRef } from 'react'
-import { Excalidraw, convertToExcalidrawElements } from '@excalidraw/excalidraw'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Excalidraw,
+  convertToExcalidrawElements,
+  viewportCoordsToSceneCoords
+} from '@excalidraw/excalidraw'
 import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
 import '@excalidraw/excalidraw/index.css'
 import { useTheme } from 'next-themes'
+import { ExternalLink, Link } from '@/lib/icons'
 import { copySceneAsImage, copySceneAsVector, toSkeleton } from './mind-map-export'
+import { hitMindMapBox, mindMapHoverAnchor, type MindMapHitElement } from './mind-map-hover'
 import type { MindMapElement } from './mind-map-types'
+import './mind-map-canvas.css'
 
 /**
  * What the map's toolbar can do, closed over the live surface.
@@ -39,8 +58,49 @@ export interface MindMapControls {
   copyVector: () => Promise<void>
 }
 
+/** What the affordance says about one node, composed by the host. */
+export interface MindMapHoverLabel {
+  /**
+   * Where the click goes, as a short chain — `… → Q3 Risks → Hire a designer`.
+   * Node labels, note titles and headings are user content; only the separator
+   * between them is translated.
+   */
+  chain: string
+  /**
+   * Translated, and set only when the link leaves this note. It is the same
+   * sentence the accessible tree gives a wiki-link node, so the picture and the
+   * tree cannot say different things — and it is what tells a reader that
+   * `Roadmap` is another page rather than a section of this one.
+   */
+  hint: string | null
+}
+
+/** How far the pointer may travel between press and release and still be a click. */
+const CLICK_SLOP = 4
+
+interface MindMapHoverState {
+  /**
+   * The drawing this answer was computed against, held only to be compared by
+   * identity. A rebuilt map is a different drawing at different coordinates, so
+   * an answer from the old one is discarded on sight rather than cleared by an
+   * effect — the surface refits on a rebuild, and an affordance left pinned to
+   * where a box used to be is worse than none.
+   */
+  drawing: readonly MindMapElement[]
+  href: string
+  /** Pixels from the drawing surface's own origin. See `mindMapHoverAnchor`. */
+  x: number
+  y: number
+}
+
 interface MindMapCanvasProps {
   elements: readonly MindMapElement[]
+  /**
+   * Deep link → what to say about the node carrying it. Keyed by href because
+   * that is what a box carries and what a hit test hands back; every box has
+   * one of its own, so the keys cannot collide.
+   */
+  hoverLabels: ReadonlyMap<string, MindMapHoverLabel>
   /** The deep link of the box that was clicked. See `handleMindMapLinkOpen`. */
   onOpenLink: (href: string) => void
   /**
@@ -50,13 +110,37 @@ interface MindMapCanvasProps {
   onControlsChange?: (controls: MindMapControls | null) => void
 }
 
+/** The pointer position, in the two fields both the library and we read. */
+type PointerPosition = Pick<React.PointerEvent, 'clientX' | 'clientY'>
+
 export function MindMapCanvas({
   elements,
+  hoverLabels,
   onOpenLink,
   onControlsChange
 }: MindMapCanvasProps): React.JSX.Element {
   const { resolvedTheme } = useTheme()
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null)
+  // The same instance as a piece of state, purely so an effect can subscribe to
+  // it once it exists: a ref assignment does not re-run one.
+  const [api, setApi] = useState<ExcalidrawImperativeAPI | null>(null)
+  const [hovered, setHovered] = useState<MindMapHoverState | null>(null)
+  /** Last seen pointer, so a pan or a zoom can re-answer without a mouse move. */
+  const pointerRef = useRef<PointerPosition | null>(null)
+  /** Where the press started, so a drag to pan is not read as a click. */
+  const pressRef = useRef<PointerPosition | null>(null)
+  const frameRef = useRef<number | null>(null)
+
+  /**
+   * Stable, and it has to be: the surface hands its instance back through this,
+   * and taking the instance into state means every call re-renders. An inline
+   * arrow would be a new prop each time, and a surface that re-announced itself
+   * on a prop change would then announce itself forever.
+   */
+  const handleApi = useCallback((instance: ExcalidrawImperativeAPI): void => {
+    apiRef.current = instance
+    setApi(instance)
+  }, [])
 
   // Re-feeding the scene rather than remounting keeps the camera and the
   // library's own warm-up across a rebuild of the same note.
@@ -66,6 +150,113 @@ export function MindMapCanvas({
     api.updateScene({ elements: convertToExcalidrawElements(toSkeleton(elements)) })
     api.scrollToContent(undefined, { fitToContent: true, animate: false })
   }, [elements])
+
+  /**
+   * The box under a viewport point, read from the LIVE scene.
+   *
+   * The live scene rather than the elements this was built from, because the
+   * library regenerates every id on the way in — which is exactly why the href
+   * travels in `customData`, the one field that survives the conversion.
+   */
+  const hitAt = useCallback((point: PointerPosition) => {
+    const api = apiRef.current
+    if (!api) return null
+    const scene = viewportCoordsToSceneCoords(point, api.getAppState())
+    return hitMindMapBox(api.getSceneElements() as unknown as readonly MindMapHitElement[], scene)
+  }, [])
+
+  const syncHover = useCallback((): void => {
+    const api = apiRef.current
+    const pointer = pointerRef.current
+    if (!api || !pointer) {
+      setHovered(null)
+      return
+    }
+
+    const hit = hitAt(pointer)
+    if (!hit || !hoverLabels.has(hit.href)) {
+      setHovered(null)
+      return
+    }
+
+    const anchor = mindMapHoverAnchor(hit, api.getAppState())
+    // Same box, same place — hand back the very same object so React does not
+    // re-render. The affordance is pinned to the BOX, so moving the pointer
+    // inside one node costs nothing at all.
+    setHovered((current) =>
+      current &&
+      current.drawing === elements &&
+      current.href === hit.href &&
+      current.x === anchor.x &&
+      current.y === anchor.y
+        ? current
+        : { drawing: elements, href: hit.href, x: anchor.x, y: anchor.y }
+    )
+  }, [elements, hitAt, hoverLabels])
+
+  /**
+   * A pan or a zoom moves the drawing under a pointer that never moved, so the
+   * answer has to be recomputed from a change rather than from a mouse event.
+   * Coalesced onto a frame because the library reports every committed state
+   * change, a pan tick included, and each answer costs a scene read.
+   */
+  useEffect(() => {
+    if (!api) return
+    const unsubscribe = api.onChange(() => {
+      if (frameRef.current !== null) return
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null
+        syncHover()
+      })
+    })
+    return () => {
+      unsubscribe()
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current)
+      frameRef.current = null
+    }
+  }, [api, syncHover])
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent): void => {
+      pointerRef.current = { clientX: event.clientX, clientY: event.clientY }
+      syncHover()
+    },
+    [syncHover]
+  )
+
+  const handlePointerLeave = useCallback((): void => {
+    pointerRef.current = null
+    setHovered(null)
+  }, [])
+
+  const handlePointerDown = useCallback((event: React.PointerEvent): void => {
+    pressRef.current = { clientX: event.clientX, clientY: event.clientY }
+  }, [])
+
+  /**
+   * Click-to-open, re-implemented.
+   *
+   * Hit-tested again at the release point rather than trusting the hovered
+   * state, so a click always opens the box it landed on. A press that travelled
+   * is a pan, not a click — in view mode a drag anywhere moves the camera, and
+   * finishing a pan over a node must not open it.
+   */
+  const handleClick = useCallback(
+    (event: React.MouseEvent): void => {
+      const press = pressRef.current
+      pressRef.current = null
+      if (
+        press &&
+        Math.hypot(event.clientX - press.clientX, event.clientY - press.clientY) > CLICK_SLOP
+      ) {
+        return
+      }
+
+      const hit = hitAt(event)
+      if (hit) onOpenLink(hit.href)
+    },
+    [hitAt, onOpenLink]
+  )
 
   const fit = useCallback((): void => {
     apiRef.current?.scrollToContent(undefined, { fitToContent: true, animate: true })
@@ -96,40 +287,75 @@ export function MindMapCanvas({
     return () => onControlsChange?.(null)
   }, [controls, onControlsChange])
 
+  // Discarded rather than cleared: see `MindMapHoverState.drawing`.
+  const hover = hovered && hovered.drawing === elements ? hovered : null
+  const label = hover ? (hoverLabels.get(hover.href) ?? null) : null
+  // A link out of the note is drawn differently on the map; the affordance says
+  // the same thing with its icon.
+  const HoverIcon = label?.hint === null ? Link : ExternalLink
+
   return (
-    <Excalidraw
-      excalidrawAPI={(instance) => {
-        apiRef.current = instance
-      }}
-      initialData={{
-        elements: convertToExcalidrawElements(toSkeleton(elements)),
-        appState: { viewBackgroundColor: 'transparent' },
-        scrollToContent: true
-      }}
-      // In view mode the whole box is the link's hit area, so this fires for a
-      // click anywhere on a node — which is what makes the drawing navigable at
-      // all. The default must be prevented: Excalidraw's fallback ends in
-      // `window.open`, which under Electron either does nothing or reloads the
-      // entire app (see `canvas-editor.tsx`, same trap).
-      onLinkOpen={(element, event) => {
-        event.preventDefault()
-        if (element.link) onOpenLink(element.link)
-      }}
-      viewModeEnabled
-      zenModeEnabled
-      UIOptions={{
-        canvasActions: {
-          export: false,
-          loadScene: false,
-          saveToActiveFile: false,
-          changeViewBackgroundColor: false,
-          clearCanvas: false,
-          toggleTheme: false
-        }
-      }}
-      // Three Memry themes exist (light/dark/white); anything not dark maps to
-      // Excalidraw's light theme.
-      theme={resolvedTheme === 'dark' ? 'dark' : 'light'}
-    />
+    <div
+      // The class is what the pointer-cursor rule hangs off; the attribute is
+      // what switches it on.
+      className="mind-map-surface relative h-full w-full"
+      data-node-hover={hover ? 'true' : undefined}
+      // Capture phase: these have to answer whatever the drawing surface does
+      // with the event afterwards.
+      onPointerDownCapture={handlePointerDown}
+      onPointerMoveCapture={handlePointerMove}
+      onClickCapture={handleClick}
+      onPointerLeave={handlePointerLeave}
+    >
+      <Excalidraw
+        excalidrawAPI={handleApi}
+        initialData={{
+          elements: convertToExcalidrawElements(toSkeleton(elements)),
+          appState: { viewBackgroundColor: 'transparent' },
+          scrollToContent: true
+        }}
+        viewModeEnabled
+        zenModeEnabled
+        UIOptions={{
+          canvasActions: {
+            export: false,
+            loadScene: false,
+            saveToActiveFile: false,
+            changeViewBackgroundColor: false,
+            clearCanvas: false,
+            toggleTheme: false
+          }
+        }}
+        // Three Memry themes exist (light/dark/white); anything not dark maps to
+        // Excalidraw's light theme.
+        theme={resolvedTheme === 'dark' ? 'dark' : 'light'}
+      />
+
+      {label && hover && (
+        /* Decoration on the picture, and deliberately so: it is a mouse-only
+           affordance whose content the accessible tree beside the map already
+           carries in words. Hidden from assistive technology rather than
+           duplicated into it, and never a pointer target — every event has to
+           reach the surface underneath. Clipped to the map so it can never
+           spill over the toolbar or the note around it. */
+        <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
+          <div
+            data-testid="mind-map-hover-card"
+            className="absolute z-10 flex max-w-[min(20rem,90%)] -translate-x-1/2 translate-y-2 items-center gap-1.5 rounded-md border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md"
+            // Pixels on the drawing surface's own axes, whose origin is the
+            // same corner in either reading direction — geometry, not layout,
+            // so a logical inset here would put the card on the wrong side of
+            // an RTL map.
+            style={{ left: hover.x, top: hover.y }}
+          >
+            <HoverIcon className="size-3.5 shrink-0 text-text-tertiary" />
+            <span className="truncate">{label.chain}</span>
+            {label.hint !== null && (
+              <span className="shrink-0 text-text-tertiary">{label.hint}</span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
   )
 }

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-destination.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-destination.test.ts
@@ -1,0 +1,246 @@
+/**
+ * What a node says it opens.
+ *
+ * Driven through `buildMindMap` wherever the case allows it, so the nodes under
+ * test are the ones the map really draws rather than a hand-made idea of them.
+ * The one exception is called out where it appears.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { buildMindMap } from './build-mind-map'
+import { mindMapDestination, mindMapDestinations } from './mind-map-destination'
+import type { MindMapPositionedNode, MindMapSourceBlock } from './mind-map-types'
+
+const SEP = { separator: '→' }
+
+function heading(id: string, level: number, text: string): MindMapSourceBlock {
+  return { id, type: 'heading', props: { level }, content: [{ type: 'text', text }] }
+}
+
+function bullet(id: string, text: string): MindMapSourceBlock {
+  return { id, type: 'bulletListItem', content: [{ type: 'text', text }] }
+}
+
+function chainOf(map: ReturnType<typeof buildMindMap>, label: string): string {
+  const byId = new Map(map.nodes.map((node) => [node.id, node]))
+  const node = map.nodes.find((candidate) => candidate.label === label)
+  if (!node) throw new Error(`no node labelled ${label}`)
+  return mindMapDestination(node, byId, SEP)
+}
+
+describe('mindMapDestination — a place in this note', () => {
+  const map = buildMindMap([heading('b-h', 1, 'Q3 Risks'), bullet('b-i', 'Hire a designer')], {
+    rootLabel: 'Planning',
+    noteId: 'n1'
+  })
+
+  it('names the note, and nothing else, for the root', () => {
+    expect(chainOf(map, 'Planning')).toBe('Planning')
+  })
+
+  it('names the path down to a heading', () => {
+    expect(chainOf(map, 'Q3 Risks')).toBe('Planning → Q3 Risks')
+  })
+
+  it('keeps the last two steps and says that there were more', () => {
+    // The question a hover answers is "where will I land"; the nearest ancestor
+    // and the target answer it, and a six-level path overflows the line.
+    expect(chainOf(map, 'Hire a designer')).toBe('… → Q3 Risks → Hire a designer')
+  })
+
+  it('keeps a numbered item’s number, which is part of what the user wrote', () => {
+    const numbered = buildMindMap(
+      [
+        heading('b-h', 1, 'Steps'),
+        { id: 'b-1', type: 'numberedListItem', content: [{ type: 'text', text: 'Prepare' }] },
+        { id: 'b-2', type: 'numberedListItem', content: [{ type: 'text', text: 'Ship' }] }
+      ],
+      { rootLabel: 'Planning', noteId: 'n1' }
+    )
+    expect(chainOf(numbered, '2. Ship')).toBe('… → Steps → 2. Ship')
+  })
+
+  it('steps over a blank heading rather than drawing a gap for it', () => {
+    // A blank heading mints no box and never joins the level stack, so its
+    // children legitimately have one step fewer.
+    const blank = buildMindMap(
+      [heading('b-h', 1, 'Q3 Risks'), heading('b-blank', 2, ''), bullet('b-i', 'Hire')],
+      { rootLabel: 'Planning', noteId: 'n1' }
+    )
+    expect(chainOf(blank, 'Hire')).toBe('… → Q3 Risks → Hire')
+  })
+
+  it('translates only the separator, never the words around it', () => {
+    // The names are the user's own; the arrow between them is chrome, and an
+    // RTL locale hands one that points the way that locale reads.
+    expect(chainOf(map, 'Hire a designer')).toContain('Q3 Risks')
+    const rtl = buildMindMap([heading('b-h', 1, 'Q3 Risks'), bullet('b-i', 'Hire a designer')], {
+      rootLabel: 'Planning',
+      noteId: 'n1'
+    })
+    const byId = new Map(rtl.nodes.map((node) => [node.id, node]))
+    const node = rtl.nodes.find((candidate) => candidate.label === 'Hire a designer')!
+    expect(mindMapDestination(node, byId, { separator: '←' })).toBe(
+      '… ← Q3 Risks ← Hire a designer'
+    )
+  })
+
+  it('never runs past the link bubble’s own budget', () => {
+    const long = buildMindMap([heading('b-h', 1, 'A'.repeat(40)), bullet('b-i', 'B'.repeat(40))], {
+      rootLabel: 'Planning',
+      noteId: 'n1'
+    })
+    // 48 characters, the same clip `linkBubbleLabel`'s bubble is written for —
+    // shared as a function rather than copied as a number.
+    expect(chainOf(long, 'B'.repeat(40)).length).toBeLessThanOrEqual(48)
+  })
+})
+
+describe('mindMapDestination — heading segments come from the unclipped text', () => {
+  it('is a real trap: the pipeline clips a long heading’s label', () => {
+    const map = buildMindMap([heading('b-h', 1, 'H'.repeat(90))], {
+      rootLabel: 'Planning',
+      noteId: 'n1'
+    })
+    const node = map.nodes.find((candidate) => candidate.kind === 'heading')!
+
+    // `label` is a display string and has been shortened; `headingText` is kept
+    // whole precisely so an anchor — and now a name — is built from the truth.
+    expect(node.label.endsWith('…')).toBe(true)
+    expect(node.headingText).toBe('H'.repeat(90))
+  })
+
+  it('reads `headingText` rather than `label`', () => {
+    // Hand-built on purpose, and the only place in this file that is. Under the
+    // 48-character budget the two strings can only diverge past the point where
+    // both are already clipped, so the rule is asserted where it is visible:
+    // directly, on a node whose two fields disagree.
+    const node: MindMapPositionedNode = {
+      id: 'mm-h',
+      blockId: 'b-h',
+      label: 'Clipped…',
+      kind: 'heading',
+      level: 1,
+      depth: 1,
+      isDone: false,
+      taskId: null,
+      wikiTarget: null,
+      headingText: 'The whole heading',
+      tags: [],
+      contents: [],
+      foldedCount: 0,
+      detail: '',
+      parentId: null,
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10
+    }
+
+    expect(mindMapDestination(node, new Map([[node.id, node]]), SEP)).toBe('The whole heading')
+  })
+})
+
+describe('mindMapDestination — nodes that are not a place in this note', () => {
+  const map = buildMindMap(
+    [
+      heading('b-h', 1, 'Q3 Risks'),
+      {
+        id: 'b-i',
+        type: 'bulletListItem',
+        content: [
+          { type: 'text', text: 'Read ' },
+          { type: 'wikiLink', props: { target: 'Roadmap#Q3' } }
+        ]
+      }
+    ],
+    { rootLabel: 'Planning', noteId: 'n1' }
+  )
+
+  function wikiChain(target: string): string {
+    const linked = buildMindMap(
+      [
+        heading('b-h', 1, 'Q3 Risks'),
+        {
+          id: 'b-i',
+          type: 'bulletListItem',
+          content: [
+            { type: 'text', text: 'Read ' },
+            { type: 'wikiLink', props: { target } }
+          ]
+        }
+      ],
+      { rootLabel: 'Planning', noteId: 'n1' }
+    )
+    const byId = new Map(linked.nodes.map((node) => [node.id, node]))
+    const node = linked.nodes.find((candidate) => candidate.kind === 'wikiLink')!
+    return mindMapDestination(node, byId, SEP)
+  }
+
+  it('names the note a wiki link points AT, never the note the map is of', () => {
+    // Naming this note here would be zero information: the reader is in it. It
+    // is also the case a user hits most often, because a wiki node is the one
+    // worth hovering.
+    const chain = mindMapDestinations(map.nodes, SEP).get(
+      map.nodes.find((node) => node.kind === 'wikiLink')!.id
+    )
+    expect(chain).toBe('Roadmap → Q3')
+    expect(chain).not.toContain('Planning')
+  })
+
+  it('names just the note when the link carries no heading', () => {
+    expect(wikiChain('Roadmap')).toBe('Roadmap')
+  })
+
+  it('drops a block reference, which is the machine identifier this replaces', () => {
+    expect(wikiChain('Roadmap#^b3')).toBe('Roadmap')
+  })
+
+  it('keeps a note whose title really contains a hash', () => {
+    // `Sprint #4` is a note somebody may really have, so the raw target is the
+    // fallback when splitting leaves nothing to name.
+    expect(wikiChain('#')).toBe('#')
+  })
+
+  it('names the branch a fold marker stands for, not the marker', () => {
+    const folded = buildMindMap(
+      [
+        heading('b-h', 1, 'Q3 Risks'),
+        ...Array.from({ length: 13 }, (_, index) => bullet(`b-${index}`, `Item ${index}`))
+      ],
+      { rootLabel: 'Planning', noteId: 'n1', formatMore: (count) => `+${count} more` }
+    )
+    const byId = new Map(folded.nodes.map((node) => [node.id, node]))
+    const marker = folded.nodes.find((node) => node.kind === 'more')!
+
+    // Activating it opens the branch; in a saved canvas its link opens the note
+    // at the section the missing rows live in. Both are "under Q3 Risks", and
+    // neither is "+2 more".
+    expect(mindMapDestination(marker, byId, SEP)).toBe('Planning → Q3 Risks')
+  })
+
+  it('names a task node by the path down to it', () => {
+    const tasks = buildMindMap(
+      [
+        heading('b-h', 1, 'Q3 Risks'),
+        { id: 'b-t', type: 'taskBlock', props: { taskId: 't-7', title: 'Cut the build' } }
+      ],
+      { rootLabel: 'Planning', noteId: 'n1' }
+    )
+    // The last segment IS the task's name, which is what a click on it opens.
+    expect(chainOf(tasks, 'Cut the build')).toBe('… → Q3 Risks → Cut the build')
+  })
+})
+
+describe('mindMapDestinations', () => {
+  it('answers for every node the map drew', () => {
+    const map = buildMindMap([heading('b-h', 1, 'Q3 Risks'), bullet('b-i', 'Hire')], {
+      rootLabel: 'Planning',
+      noteId: 'n1'
+    })
+    const all = mindMapDestinations(map.nodes, SEP)
+
+    expect(all.size).toBe(map.nodes.length)
+    for (const chain of all.values()) expect(chain).not.toBe('')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-destination.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-destination.ts
@@ -1,0 +1,170 @@
+/**
+ * Naming where a node's link goes, instead of printing the link.
+ *
+ * Both surfaces used to hand the user a raw href —
+ * `memry://note/skfe4c9o0z15#^mm-d5f2a543-…-link-1` — because that is all
+ * either of them had to show. For a wiki-link box the anchor is a synthetic
+ * node id minted by the projection (#1672 anchors wiki boxes on their own id,
+ * since resolving a wiki target to a note id is a database lookup the pure
+ * pipeline cannot do), so it is a machine identifier that will never mean
+ * anything to a person — and wiki boxes are exactly the ones worth hovering.
+ *
+ * What is shown instead is the DESTINATION, said as a short chain:
+ * `… → Q3 Risks → Hire a designer`.
+ *
+ * "Destination" is the whole point, and it is not the same as "where the node
+ * sits in the picture":
+ *
+ * - a heading, list, toggle, callout or task node names the path down to it;
+ * - a **wiki-link** node names the note it points AT. Naming the note the map
+ *   is of would be zero information — the reader is already in it;
+ * - a **fold marker** names the node whose children are folded, because that is
+ *   where the rows it stands for actually live (and, in a saved canvas, where
+ *   its heading anchor lands);
+ * - the **root** is just the note's name.
+ *
+ * Pure, and with no translator of its own: the one piece of chrome in the
+ * string — the separator between segments — is passed in, exactly as
+ * `formatContentCount` and `formatMore` are passed into the pipeline. Node
+ * labels, note titles and heading text are user content and are never
+ * translated.
+ */
+
+import { isBlockReference, splitWikiTarget } from '@memry/shared/wiki-target'
+import { truncateLabel } from '@/pages/canvas/canvas-link-label'
+import type { MindMapPositionedNode } from './mind-map-types'
+
+/**
+ * How many segments of the path survive.
+ *
+ * The question a hover answers is "where will I land", and the nearest ancestor
+ * plus the target answer it. A full six-level path overflows the line, and in a
+ * saved canvas it overflows the link bubble, which is a single row of text.
+ */
+const CHAIN_SEGMENTS = 2
+
+/** Stands in for the ancestors that did not fit. */
+const ELLIPSIS = '…'
+
+/** Used when the caller has no translator to hand — tests, mostly. */
+const DEFAULT_SEPARATOR = '→'
+
+export interface MindMapDestinationOptions {
+  /**
+   * Between segments. Translated chrome: an RTL locale supplies an arrow that
+   * points the way that locale reads.
+   */
+  separator?: string
+}
+
+/**
+ * The text one node contributes.
+ *
+ * A heading contributes its `headingText`, never its `label`. `label` is a
+ * display string that `clipLabel` shortens past 72 characters, so a long
+ * heading would arrive here already ending in an ellipsis and be clipped a
+ * second time; `headingText` is kept whole for exactly this reason. Everything
+ * else has only its label — which for a numbered item still carries its `3. `,
+ * and should: the number is part of what the user wrote.
+ */
+function segmentOf(node: MindMapPositionedNode): string {
+  const text = node.kind === 'heading' && node.headingText ? node.headingText : node.label
+  return text.trim()
+}
+
+/**
+ * The path from the root down to this node, nearest-last.
+ *
+ * `parentId` lives on the positioned node rather than the logical one, which is
+ * why this takes the map both surfaces already build. Blank segments are
+ * dropped rather than drawn as gaps — a blank heading mints no box and never
+ * joins the level stack, so its descendants legitimately have one fewer step.
+ *
+ * The `seen` set is a cycle guard, not a real case: the layout emits a tree.
+ * It costs one Set and turns a hypothetical hang into a short chain.
+ */
+function ancestry(
+  node: MindMapPositionedNode,
+  byId: ReadonlyMap<string, MindMapPositionedNode>
+): string[] {
+  const segments: string[] = []
+  const seen = new Set<string>()
+
+  let current: MindMapPositionedNode | undefined = node
+  while (current && !seen.has(current.id)) {
+    seen.add(current.id)
+    const segment = segmentOf(current)
+    if (segment !== '') segments.unshift(segment)
+    current = current.parentId === null ? undefined : byId.get(current.parentId)
+  }
+  return segments
+}
+
+/**
+ * What a wiki link names, read the way the rest of the app reads it.
+ *
+ * `[[Roadmap#Q3]]` is a note and a place inside it, so it says both. A block
+ * reference (`[[Roadmap#^b3]]`) says only the note: `^b3` is the same kind of
+ * machine identifier this whole change exists to stop showing.
+ */
+function wikiSegments(target: string): string[] {
+  const { note, heading } = splitWikiTarget(target)
+  const segments = [note]
+  if (heading && !isBlockReference(heading)) segments.push(heading)
+
+  const named = segments.map((segment) => segment.trim()).filter((segment) => segment !== '')
+  // `[[#Heading]]` addresses this note, so the note half is empty and the
+  // heading is all there is to say. A target that is nothing but `#` leaves
+  // nothing at all, and the raw target is then the only honest answer.
+  return named.length > 0 ? named : [target.trim()]
+}
+
+function destinationSegments(
+  node: MindMapPositionedNode,
+  byId: ReadonlyMap<string, MindMapPositionedNode>
+): string[] {
+  if (node.kind === 'wikiLink' && node.wikiTarget !== null && node.wikiTarget.trim() !== '') {
+    return wikiSegments(node.wikiTarget)
+  }
+
+  if (node.kind === 'more') {
+    const parent = node.parentId === null ? undefined : byId.get(node.parentId)
+    return parent ? ancestry(parent, byId) : []
+  }
+
+  return ancestry(node, byId)
+}
+
+/**
+ * The destination of one node, as a line of text.
+ *
+ * Clipped with the link bubble's own `truncateLabel`, because the saved canvas
+ * renders this string in that bubble and the bubble applies no budget of its
+ * own to a `memry://` label. Sharing the function rather than the number is
+ * what keeps the two from drifting apart.
+ *
+ * The empty string when there is nothing to say, which the callers read as
+ * "write no label" rather than as an empty one.
+ */
+export function mindMapDestination(
+  node: MindMapPositionedNode,
+  byId: ReadonlyMap<string, MindMapPositionedNode>,
+  { separator }: MindMapDestinationOptions = {}
+): string {
+  const joiner = separator?.trim() || DEFAULT_SEPARATOR
+  const segments = destinationSegments(node, byId)
+  if (segments.length === 0) return ''
+
+  const kept = segments.slice(-CHAIN_SEGMENTS)
+  const parts = segments.length > kept.length ? [ELLIPSIS, ...kept] : kept
+  return truncateLabel(parts.join(` ${joiner} `))
+}
+
+/** Every node's destination, keyed by node id. */
+export function mindMapDestinations(
+  nodes: readonly MindMapPositionedNode[],
+  options: MindMapDestinationOptions = {}
+): Map<string, string> {
+  const byId = new Map(nodes.map((node) => [node.id, node]))
+  return new Map(nodes.map((node) => [node.id, mindMapDestination(node, byId, options)]))
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
@@ -91,6 +91,22 @@ export interface MintElementsOptions {
    * the lookup and hands the answers in.
    */
   wikiHrefs?: ReadonlyMap<string, string>
+  /**
+   * Node id → the name to carry on that node's href as a `?label=` hint.
+   *
+   * Only read in `heading` mode, because only a file needs it. The drawn map
+   * renders its own affordance from the node it hit, so an on-screen href never
+   * has to describe itself — and leaving the hint off keeps those hrefs exactly
+   * the strings they have always been.
+   *
+   * A saved canvas has no such affordance: the drawing library prints
+   * `element.link` verbatim in its bubble, and the only hook into that text is
+   * the label the href carries (`canvas-link-label.ts` reads it, `CanvasEditor`
+   * swaps it in). Composed by the caller, because the name is a destination
+   * chain whose separator is translated chrome and this module has no
+   * translator.
+   */
+  labels?: ReadonlyMap<string, string>
 }
 
 /**
@@ -100,6 +116,14 @@ export interface MintElementsOptions {
  * Every box needs a link of its OWN, because the link is the only handle a
  * click on a bitmap has: two boxes sharing one would send a click to whichever
  * came first.
+ *
+ * WHERE the box carries it differs by mode, and that is not cosmetic. In a file
+ * it goes in `element.link`, which is what makes the box clickable in an
+ * ordinary canvas at all. On the drawn map it goes in `customData` instead:
+ * `element.link` also paints a permanent blue glyph, one per linked element,
+ * and on a map where EVERY box is linked that marks nothing and buries the one
+ * thing the picture is for — its shape. The map renders its own hover
+ * affordance from this href instead (see `mind-map-hover.ts`).
  *
  * **On screen (`block`)** the link is an address within this session:
  *
@@ -130,10 +154,11 @@ export interface MintElementsOptions {
  */
 function nodeLink(
   node: MindMapPositionedNode,
-  { noteId, anchor, wikiHrefs }: MintElementsOptions & { anchor: MindMapLinkAnchor }
+  { noteId, anchor, wikiHrefs, labels }: MintElementsOptions & { anchor: MindMapLinkAnchor }
 ): string | undefined {
   // Resolved by the caller, because a wiki target is a title and turning one
-  // into an id is a database lookup this pipeline must not grow.
+  // into an id is a database lookup this pipeline must not grow. Its label is
+  // the caller's too, for the same reason.
   if (anchor === 'heading') {
     const resolved = wikiHrefs?.get(node.id)
     if (resolved) return resolved
@@ -146,6 +171,11 @@ function nodeLink(
       buildMemryHref({
         kind: 'note',
         id: noteId,
+        // Additive, and additive is the whole compatibility story: `label` sits
+        // in the query, which the parser has always read, and a build that has
+        // never heard of it drops it and opens the same note at the same
+        // heading. It cannot disturb the anchor, which lives in the fragment.
+        label: labels?.get(node.id) ?? null,
         anchor: node.headingText ? { type: 'heading', text: node.headingText } : null
       }) ?? undefined
     )
@@ -213,7 +243,7 @@ export function mintElements(
   direction: MindMapDirection,
   options: MintElementsOptions = {}
 ): MindMapElement[] {
-  const { noteId, anchor = 'block', rootDetail, wikiHrefs } = options
+  const { noteId, anchor = 'block', rootDetail, wikiHrefs, labels } = options
   const byId = new Map(nodes.map((node) => [node.id, node]))
   const elements: MindMapElement[] = []
 
@@ -262,10 +292,20 @@ export function mintElements(
       isRoot && rootDetail
         ? [rootDetail, node.detail].filter((part) => part !== '').join(' · ')
         : node.detail
+    const href = nodeLink(node, { noteId, anchor, wikiHrefs, labels })
+    // One href, two homes. See `nodeLink` for why the drawn map keeps its out
+    // of `link`: that field is what paints the glyph, and a map is nothing but
+    // linked boxes.
+    const address =
+      href === undefined
+        ? {}
+        : anchor === 'heading'
+          ? { link: href }
+          : { customData: { memryHref: href } }
     elements.push({
       type: 'rectangle',
       id: node.id,
-      link: nodeLink(node, { noteId, anchor, wikiHrefs }),
+      ...address,
       x: node.x,
       y: node.y,
       width: node.width,

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-hover.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-hover.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The hit test that replaced the drawing library's own.
+ *
+ * Pure arithmetic over plain data, which is the point: jsdom has no canvas, so
+ * the only way to be sure a click lands on the box the user aimed at is to
+ * check the geometry somewhere a canvas is not needed.
+ *
+ * The elements here are minted by the real pipeline wherever the case allows
+ * it, so the `customData` this reads is the `customData` `mintElements` writes
+ * — the one coupling between the two files that a rename could break silently.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { buildMindMap } from './build-mind-map'
+import { hitMindMapBox, mindMapHoverAnchor, mindMapHrefOf } from './mind-map-hover'
+import type { MindMapHitElement } from './mind-map-hover'
+
+const BOX: MindMapHitElement = {
+  x: 100,
+  y: 50,
+  width: 200,
+  height: 40,
+  customData: { memryHref: 'memry://note/n1#^b' }
+}
+
+describe('mindMapHrefOf', () => {
+  it('reads the address a drawn box was minted with', () => {
+    const map = buildMindMap(
+      [{ id: 'b-h', type: 'heading', props: { level: 1 }, content: [{ type: 'text', text: 'A' }] }],
+      { rootLabel: 'Note', noteId: 'n1' }
+    )
+    const boxes = map.elements.filter((element) => element.type === 'rectangle')
+
+    // The round trip that a rename of the key would break, asserted across the
+    // two files that share it rather than inside either one.
+    expect(boxes.length).toBeGreaterThan(0)
+    for (const box of boxes) expect(mindMapHrefOf(box)).toMatch(/^memry:\/\/note\/n1/)
+  })
+
+  it('answers for nothing else on the drawing', () => {
+    expect(mindMapHrefOf({ x: 0, y: 0, width: 1, height: 1 })).toBeNull()
+    expect(mindMapHrefOf({ x: 0, y: 0, width: 1, height: 1, customData: null })).toBeNull()
+    expect(
+      mindMapHrefOf({ x: 0, y: 0, width: 1, height: 1, customData: { entityType: 'note' } })
+    ).toBeNull()
+    expect(
+      mindMapHrefOf({ x: 0, y: 0, width: 1, height: 1, customData: { memryHref: '' } })
+    ).toBeNull()
+  })
+})
+
+describe('hitMindMapBox', () => {
+  it('answers for the whole bounding box, edges included', () => {
+    // This is what view mode's own link hit test was doing for us, and it is
+    // why a click anywhere on a node has always opened it.
+    for (const [x, y] of [
+      [100, 50],
+      [300, 50],
+      [100, 90],
+      [300, 90],
+      [200, 70]
+    ]) {
+      expect(hitMindMapBox([BOX], { x, y })?.href).toBe('memry://note/n1#^b')
+    }
+  })
+
+  it('answers for nothing outside it', () => {
+    expect(hitMindMapBox([BOX], { x: 99, y: 70 })).toBeNull()
+    expect(hitMindMapBox([BOX], { x: 301, y: 70 })).toBeNull()
+    expect(hitMindMapBox([BOX], { x: 200, y: 49 })).toBeNull()
+    expect(hitMindMapBox([BOX], { x: 200, y: 91 })).toBeNull()
+  })
+
+  it('ignores an element with no address, however large', () => {
+    const connector: MindMapHitElement = { x: 0, y: 0, width: 1000, height: 1000 }
+    expect(hitMindMapBox([connector], { x: 200, y: 70 })).toBeNull()
+    // And never answers with it in place of a real box underneath the pointer.
+    expect(hitMindMapBox([connector, BOX], { x: 200, y: 70 })?.href).toBe('memry://note/n1#^b')
+  })
+
+  it('ignores a deleted element', () => {
+    expect(hitMindMapBox([{ ...BOX, isDeleted: true }], { x: 200, y: 70 })).toBeNull()
+  })
+
+  it('answers with the box drawn last where two overlap', () => {
+    const over: MindMapHitElement = { ...BOX, customData: { memryHref: 'memry://note/n1#^c' } }
+    expect(hitMindMapBox([BOX, over], { x: 200, y: 70 })?.href).toBe('memry://note/n1#^c')
+  })
+
+  it('hands back the rectangle, so the affordance can be pinned to the box', () => {
+    expect(hitMindMapBox([BOX], { x: 200, y: 70 })).toEqual({
+      href: 'memry://note/n1#^b',
+      x: 100,
+      y: 50,
+      width: 200,
+      height: 40
+    })
+  })
+})
+
+describe('mindMapHoverAnchor', () => {
+  const hit = { href: 'h', x: 100, y: 50, width: 200, height: 40 }
+
+  it('sits under the box and centred on it', () => {
+    // Centred rather than aligned to one end: the map mirrors in RTL, and a
+    // tooltip anchored to a fixed side would then hang off the wrong end of
+    // every node.
+    expect(mindMapHoverAnchor(hit, { scrollX: 0, scrollY: 0, zoom: { value: 1 } })).toEqual({
+      x: 200,
+      y: 90
+    })
+  })
+
+  it('follows the camera', () => {
+    expect(mindMapHoverAnchor(hit, { scrollX: -100, scrollY: -50, zoom: { value: 1 } })).toEqual({
+      x: 100,
+      y: 40
+    })
+    expect(mindMapHoverAnchor(hit, { scrollX: 0, scrollY: 0, zoom: { value: 2 } })).toEqual({
+      x: 400,
+      y: 180
+    })
+  })
+
+  it('survives a zoom of zero rather than placing the card at NaN', () => {
+    expect(mindMapHoverAnchor(hit, { scrollX: 0, scrollY: 0, zoom: { value: 0 } })).toEqual({
+      x: 200,
+      y: 90
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-hover.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-hover.ts
@@ -1,0 +1,122 @@
+/**
+ * Finding the node under the cursor, and where to pin the affordance for it.
+ *
+ * The drawing library gives us neither. Its own link affordance is driven by
+ * `element.link`, which paints a permanent glyph on every element that has one
+ * — useful on a real canvas where a handful of shapes are linked, pure noise on
+ * a map where every single box is. There is no prop, `appState` field or CSS
+ * surface that hover-gates that glyph, and no supported way to ask which
+ * element is under the pointer either: `onPointerUpdate` hands over raw
+ * coordinates with no hit-test result, `appState.hoveredElementIds` is only
+ * populated while the element-link picker is open, and the real hit test
+ * (`isPointHittingLink`) is not exported — the package's type map resolves it,
+ * so importing it type-checks and then fails at bundle time.
+ *
+ * So the map carries its href in `customData` instead, where nothing paints it,
+ * and answers "what is under the cursor" here.
+ *
+ * Pure and library-free on purpose: the shapes below are the narrow slice of a
+ * scene element and of the camera that this reads, so the whole hit test unit
+ * tests without a canvas — which jsdom does not have.
+ */
+
+/** Where a box's deep link is carried on the drawn map. See `mintElements`. */
+export const MIND_MAP_HREF_KEY = 'memryHref'
+
+/** The slice of a scene element the hit test reads. */
+export interface MindMapHitElement {
+  x: number
+  y: number
+  width: number
+  height: number
+  isDeleted?: boolean
+  customData?: Record<string, unknown> | null
+}
+
+/** The box that was hit: its href, and its rectangle in scene units. */
+export interface MindMapHit {
+  href: string
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/** The slice of the camera the anchor math reads. */
+export interface MindMapCamera {
+  scrollX: number
+  scrollY: number
+  zoom: { value: number }
+}
+
+/** A point in scene units. */
+export interface MindMapScenePoint {
+  x: number
+  y: number
+}
+
+/**
+ * The deep link a drawn box carries, or null when this element is not one of
+ * ours (a connector, a strike rule, the text bound into a box).
+ */
+export function mindMapHrefOf(element: MindMapHitElement): string | null {
+  const href = element.customData?.[MIND_MAP_HREF_KEY]
+  return typeof href === 'string' && href !== '' ? href : null
+}
+
+/**
+ * The box under a point, or null.
+ *
+ * The WHOLE bounding box is the hit area, deliberately. That is what view mode
+ * was doing for us — `isPointHittingLink` widens to the element's bounding box
+ * in view mode on desktop — and it is why a click anywhere on a node has always
+ * opened it. A hit test that only answered for the 14px glyph would technically
+ * restore "click to open" and in practice take the feature away.
+ *
+ * Walked from the end, so the box drawn last wins where two overlap. A tidy
+ * tree never overlaps its own boxes, but the rule costs nothing and means the
+ * answer never depends on that staying true.
+ */
+export function hitMindMapBox(
+  elements: readonly MindMapHitElement[],
+  point: MindMapScenePoint
+): MindMapHit | null {
+  for (let index = elements.length - 1; index >= 0; index -= 1) {
+    const element = elements[index]
+    if (!element || element.isDeleted) continue
+
+    const href = mindMapHrefOf(element)
+    if (href === null) continue
+
+    if (point.x < element.x || point.x > element.x + element.width) continue
+    if (point.y < element.y || point.y > element.y + element.height) continue
+
+    return { href, x: element.x, y: element.y, width: element.width, height: element.height }
+  }
+  return null
+}
+
+/**
+ * Where the affordance sits, in pixels from the drawing surface's own origin.
+ *
+ * Under the box and centred on it. Centred rather than aligned to one end
+ * because the map mirrors in RTL and a tooltip anchored to a fixed side would
+ * then hang off the wrong end of every node; the midpoint reads the same in
+ * both directions.
+ *
+ * The axes here are the canvas viewport's, not the page's layout: the origin is
+ * the surface's top corner in either reading direction, so this is geometry
+ * rather than a direction-sensitive position. It is the inverse of the
+ * transform the drawing applies to the scene (`(scene + scroll) * zoom`), which
+ * is the same arithmetic `CanvasCardLayer` uses to lay its cards over a scene.
+ */
+export function mindMapHoverAnchor(
+  hit: MindMapHit,
+  camera: MindMapCamera
+): { x: number; y: number } {
+  const zoom = camera.zoom.value || 1
+  return {
+    x: (hit.x + hit.width / 2 + camera.scrollX) * zoom,
+    y: (hit.y + hit.height + camera.scrollY) * zoom
+  }
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-library-contract.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-library-contract.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The upgrade tripwire for the drawing library's part of the map's links.
+ *
+ * Three things the map now leans on are library internals with no stability
+ * contract, and none of them fails loudly when it changes — the map would
+ * simply stop being clickable, or grow back the wall of glyphs this replaced:
+ *
+ * 1. **`customData` survives the conversion into a scene.** It is the whole
+ *    reason a drawn box can carry an address: the library regenerates every
+ *    element id on the way in, so an id is no handle and `customData` is.
+ * 2. **`viewportCoordsToSceneCoords` is exported at RUNTIME.** The package's
+ *    type map resolves modules it does not ship — `isPointHittingLink` and
+ *    `hitElementBoundingBox` type-check and then fail at bundle time — so a
+ *    type-level check proves nothing about what actually loads.
+ * 3. **The pointer cursor is declared important.** The library sets its cursor
+ *    inline on its own canvas and re-sets it as the pointer moves, so only an
+ *    important rule outranks it.
+ *
+ * What this file can honestly do about 1 and 2 is read the shipped artifact.
+ * The library cannot be imported for real in this suite — the module touches a
+ * canvas at import time and jsdom has none, which is why every other test here
+ * stands it in — so these are string assertions over the bundle rather than a
+ * live call. They will not catch a subtle behaviour change; they WILL catch the
+ * field or the export disappearing, which is what an upgrade does. Failing here
+ * is the signal to recheck the map's hit test by hand and then move the pin.
+ *
+ * `assets/excalidraw-context-menu-css.test.ts` is the same shape of guard, for
+ * the same reason.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/** Vitest's cwd is apps/desktop; jsdom has no file: `import.meta.url`. */
+const PACKAGE_JSON = join(process.cwd(), 'package.json')
+const CURSOR_CSS = join(
+  process.cwd(),
+  'src/renderer/src/components/note/mind-map/mind-map-canvas.css'
+)
+/** What electron-vite bundles: the package's `production` export condition. */
+const RUNTIME_BUNDLE_DIR = join(
+  process.cwd(),
+  '../../node_modules/@excalidraw/excalidraw/dist/prod'
+)
+const VERIFIED_VERSION = '0.18.1'
+
+function installedVersion(): string | undefined {
+  const pkg = JSON.parse(readFileSync(PACKAGE_JSON, 'utf8')) as {
+    dependencies?: Record<string, string>
+    devDependencies?: Record<string, string>
+  }
+  // Bundled into the renderer by electron-vite, so it lives in devDependencies.
+  return (
+    pkg.dependencies?.['@excalidraw/excalidraw'] ?? pkg.devDependencies?.['@excalidraw/excalidraw']
+  )
+}
+
+function bundleText(file: string): string {
+  return readFileSync(join(RUNTIME_BUNDLE_DIR, file), 'utf8')
+}
+
+describe('@excalidraw/excalidraw, where the mind map depends on its internals', () => {
+  it('pins the version the map’s link handling was verified against', () => {
+    expect(
+      installedVersion(),
+      '@excalidraw/excalidraw is no longer a desktop dependency'
+    ).toBeDefined()
+    expect(installedVersion()).toContain(VERIFIED_VERSION)
+  })
+
+  it('still exports the viewport-to-scene helper the hit test is built on', () => {
+    // Without this there is no way to turn a pointer position into a place on
+    // the drawing, and the map's boxes stop being clickable at all.
+    expect(bundleText('index.js')).toContain('viewportCoordsToSceneCoords')
+  })
+
+  it('still copies `customData` onto the elements it constructs', () => {
+    // `_newElementBase` ends with `customData: rest.customData`; minified that
+    // reads as `customData:X.customData`. The constructors live in a chunk
+    // rather than the entry and the chunk names change every release, so every
+    // one of them is searched.
+    const chunks = readdirSync(RUNTIME_BUNDLE_DIR).filter((name) => name.endsWith('.js'))
+    expect(chunks.length).toBeGreaterThan(0)
+
+    const forwards = chunks.some((name) =>
+      /customData\s*:\s*[A-Za-z_$][\w$]*\.customData/.test(bundleText(name))
+    )
+    expect(forwards, 'the element constructor no longer forwards customData').toBe(true)
+  })
+})
+
+describe('the pointer cursor the map draws for itself', () => {
+  it('is declared, scoped to the map, and marked important', () => {
+    // jsdom has no cascade and never renders the library, so a source-level
+    // assertion is the only honest guard against the rule being deleted or
+    // stripped of the one thing that makes it work.
+    const css = readFileSync(CURSOR_CSS, 'utf8')
+    const rule = css.match(/\.mind-map-surface\[data-node-hover='true'\][^{]*\{([^}]*)\}/)
+
+    expect(rule, 'no hover-cursor rule in mind-map-canvas.css').not.toBeNull()
+    expect(rule?.[1]).toMatch(/cursor:\s*pointer\s*!important/)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-navigation.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, it, vi } from 'vitest'
 import { buildMindMap } from './build-mind-map'
+import { mindMapHrefOf } from './mind-map-hover'
 import { activateMindMapNode, nodeFromMindMapLink } from './mind-map-navigation'
 import type { MindMapBoxElement, MindMapPositionedNode, MindMapSourceBlock } from './mind-map-types'
 
@@ -171,7 +172,7 @@ describe('activateMindMapNode', () => {
     const fromTree = actions()
     const fromDrawing = actions()
     activateMindMapNode(beta, fromTree)
-    activateMindMapNode(nodeFromMindMapLink(box.link!, map.nodes, 'note-1')!, fromDrawing)
+    activateMindMapNode(nodeFromMindMapLink(mindMapHrefOf(box)!, map.nodes, 'note-1')!, fromDrawing)
 
     // Two projections of one layout, one activation: the picture cannot grow a
     // navigation behaviour the tree does not have.
@@ -194,8 +195,9 @@ describe('nodeFromMindMapLink', () => {
     // The round trip that matters: what the pipeline drew is what a click on it
     // resolves back to.
     for (const element of map.elements) {
-      if (element.type !== 'rectangle' || !element.link) continue
-      expect(nodeFromMindMapLink(element.link, map.nodes, 'note-1')?.id).toBe(element.id)
+      const href = element.type === 'rectangle' ? mindMapHrefOf(element) : null
+      if (href === null) continue
+      expect(nodeFromMindMapLink(href, map.nodes, 'note-1')?.id).toBe(element.id)
     }
   })
 
@@ -221,7 +223,7 @@ describe('nodeFromMindMapLink', () => {
 
     // Its sentence's box and its own carry different hrefs, so a click on the
     // link cannot resolve to the sentence that holds it.
-    expect(nodeFromMindMapLink(box.link!, linked.nodes, 'note-1')).toBe(link)
+    expect(nodeFromMindMapLink(mindMapHrefOf(box)!, linked.nodes, 'note-1')).toBe(link)
     expect(nodeFromMindMapLink('memry://note/note-1#^b-item', linked.nodes, 'note-1')?.kind).toBe(
       'bullet'
     )
@@ -241,8 +243,8 @@ describe('nodeFromMindMapLink', () => {
     // Without this the drawing would answer a click on "+N more" with the root,
     // because both are blockless — and the user would be scrolled to the top of
     // their note instead of having the branch opened.
-    expect(nodeFromMindMapLink(box.link!, folded.nodes, 'note-1')).toBe(marker)
-    expect(box.link).toBe(`memry://note/note-1#^${marker.id}`)
+    expect(nodeFromMindMapLink(mindMapHrefOf(box)!, folded.nodes, 'note-1')).toBe(marker)
+    expect(mindMapHrefOf(box)).toBe(`memry://note/note-1#^${marker.id}`)
   })
 
   it('refuses a block anchor no node in this map owns', () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-snapshot.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-snapshot.test.ts
@@ -18,6 +18,7 @@
 import { describe, expect, it } from 'vitest'
 import { parseMemryHref, tabFromMemryHref } from '@/lib/memry-links'
 import { buildMindMap } from './build-mind-map'
+import { mindMapHrefOf } from './mind-map-hover'
 import { mindMapSceneJson, mintSnapshotElements, uniqueCanvasTitle } from './mind-map-snapshot'
 import type { MindMapBoxElement, MindMapElement, MindMapSourceBlock } from './mind-map-types'
 
@@ -352,8 +353,10 @@ describe('mintSnapshotElements — wiki-link nodes', () => {
     const node = map.nodes.find((n) => n.kind === 'wikiLink')!
     const drawn = boxes(map.elements).get(node.id)!
 
-    // On screen the href is only a click handle, and it IS a node-id anchor.
-    expect(drawn.link).toBe(`memry://note/n1#^${node.id}`)
+    // On screen the href is only a click handle, it IS a node-id anchor, and it
+    // is carried in `customData` so no link glyph is painted over the map.
+    expect(mindMapHrefOf(drawn)).toBe(`memry://note/n1#^${node.id}`)
+    expect(drawn).not.toHaveProperty('link')
     // In a file that names a block this device never minted.
     expect(linkBox().link).not.toMatch(/#\^/)
   })

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-snapshot.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-snapshot.ts
@@ -14,8 +14,9 @@
  * by then — and it is why the relationship is one-way: the reverse would need a
  * database field, a sync handler and a compatibility plan it does not earn.
  *
- * Three things the snapshot changes about the map as drawn, all for the same
- * reason — the file outlives the document that produced it:
+ * Four things the snapshot changes about the map as drawn, all for the same
+ * reason — the file outlives the document that produced it, and nothing of ours
+ * is watching when it is opened:
  *
  * 1. **Links anchor on heading TEXT, never on a block id.** Block ids are
  *    minted at parse time and markdown does not carry them, so a copied vault,
@@ -28,6 +29,17 @@
  *    A card is roughly ten times the size of a map node and a dozen of them
  *    make the map unreadable. The user can add real cards by hand — it is their
  *    canvas.
+ * 4. **Every link carries the name of what it opens**, as a `?label=` hint, so
+ *    the canvas' own hover bubble reads `… → Q3 Risks` rather than a
+ *    `memry://` URL. It is a hint and never an identity — the id is what
+ *    resolves — and it is additive: a build that never heard of labels drops it
+ *    and opens the same note at the same heading.
+ *
+ * Their links stay exactly where an ordinary canvas expects them, in
+ * `element.link`. The DRAWN map moved its own out of that field (the glyph it
+ * paints is noise on a map), but a saved canvas is not ours to render — it is
+ * opened by `CanvasEditor` like any other, and stripping its links would take
+ * away the one thing that makes it more than a picture.
  *
  * Two node kinds need saying out loud, because neither is a place in this note:
  *
@@ -66,6 +78,22 @@ export interface MindMapSnapshotOptions {
    * module note above.
    */
   wikiHrefs?: ReadonlyMap<string, string>
+  /**
+   * Node id → the name its link should announce, as a `?label=` hint on the
+   * href.
+   *
+   * The fourth thing the snapshot changes about the map as drawn, and the one
+   * that only a file needs. The drawing library prints `element.link` verbatim
+   * in its hover bubble, so without this a saved canvas hovers as
+   * `memry://note/skfe4c9o0z15#Q3%20Risks`. `CanvasEditor` already watches for
+   * that bubble and swaps in whatever `linkBubbleLabel` reads off the href — it
+   * has simply had nothing to read, because the map wrote no label. So the
+   * readable name is bought with a label rather than with rendering code.
+   *
+   * Composed by the caller: it is a destination chain whose separator is
+   * translated chrome, and this module has no translator.
+   */
+  labels?: ReadonlyMap<string, string>
 }
 
 /**
@@ -76,13 +104,14 @@ export interface MindMapSnapshotOptions {
  */
 export function mintSnapshotElements(
   map: MindMap,
-  { noteId, generatedLabel, wikiHrefs }: MindMapSnapshotOptions
+  { noteId, generatedLabel, wikiHrefs, labels }: MindMapSnapshotOptions
 ): MindMapElement[] {
   return mintElements(map.nodes, map.direction, {
     noteId,
     anchor: 'heading',
     rootDetail: generatedLabel,
-    wikiHrefs
+    wikiHrefs,
+    labels
   })
 }
 

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
@@ -210,17 +210,34 @@ export interface MindMapBoxElement {
     strokeColor: string
   }
   /**
-   * A `memry://` deep link back into the note, present only when the build was
-   * given a note id. It is what makes a drawn box clickable at all: the drawing
-   * surface is a bitmap with no DOM, and its link hit test — the whole bounding
-   * box, in view mode — is the only handle a click has on a node.
+   * A `memry://` deep link back into the note, on a box destined for a FILE.
+   *
+   * It is what makes a box in a saved canvas clickable: an ordinary canvas has
+   * no code of ours watching it, so the link has to be something the drawing
+   * library itself acts on. A saved canvas outlives the document that produced
+   * it, so the anchor here is heading TEXT — never a block id, which dies with
+   * that document.
+   *
+   * Absent on the DRAWN map, and deliberately: `element.link` also paints a
+   * permanent glyph, and a map where every box is linked is a wall of identical
+   * blue squares over a picture whose whole point is shape. The drawn map
+   * carries its href in `customData` instead.
+   */
+  link?: string
+  /**
+   * The same `memry://` deep link, on a box drawn on SCREEN, kept where the
+   * renderer will not paint anything for it.
+   *
+   * It is still the only handle a click on a bitmap has — the map hit-tests it
+   * itself (`mind-map-hover.ts`) and resolves it back to a node through
+   * `nodeFromMindMapLink`, preserving what view mode's own link hit test gave
+   * us: the whole bounding box, not a glyph.
    *
    * A block anchor is right HERE and only here: these elements are drawn for
    * the session that minted them, and a block id lives exactly as long as the
-   * document that minted it. A saved canvas outlives that, so the file's links
-   * will carry heading text instead.
+   * document that minted it.
    */
-  link?: string
+  customData?: { memryHref: string }
 }
 
 /**

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.test.tsx
@@ -25,7 +25,11 @@ const mocks = vi.hoisted(() => ({
   toCanvasScene: vi.fn((elements: readonly unknown[]) => JSON.stringify({ elements })),
   create: vi.fn(),
   list: vi.fn(),
-  resolveWikiLink: vi.fn()
+  resolveWikiLink: vi.fn(),
+  hoverLabels: new Map<string, { chain: string; hint: string | null }>() as ReadonlyMap<
+    string,
+    { chain: string; hint: string | null }
+  >
 }))
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
@@ -48,10 +52,14 @@ vi.mock('@/lib/wikilink-resolver', () => ({ resolveWikiLink: mocks.resolveWikiLi
 
 vi.mock('./mind-map-canvas', () => ({
   MindMapCanvas: ({
+    hoverLabels,
     onControlsChange
   }: {
+    hoverLabels: ReadonlyMap<string, { chain: string; hint: string | null }>
     onControlsChange?: (controls: Record<string, unknown> | null) => void
   }) => {
+    // What the surface was handed, so a test can read it without a canvas.
+    mocks.hoverLabels = hoverLabels
     useEffect(() => {
       if (!mocks.handsControlsUp) return
       onControlsChange?.({
@@ -335,9 +343,89 @@ describe('MindMapView toolbar', () => {
       strokeStyle?: string
     }>
     // The saved box opens the note it names, on any device — not a node id only
-    // this session could have understood.
-    expect(elements.some((element) => element.link === 'memry://note/n2#Plan')).toBe(true)
+    // this session could have understood — and it says so in words, because the
+    // canvas' own bubble prints the href verbatim unless the href names itself.
+    expect(elements.some((element) => element.link === 'memry://note/n2?label=Roadmap#Plan')).toBe(
+      true
+    )
     expect(elements.every((element) => !element.link?.includes('#^'))).toBe(true)
+  })
+
+  it('names every saved link, so a canvas hovers as words rather than as a URL', async () => {
+    renderView([
+      {
+        id: 'b-h1',
+        type: 'heading',
+        props: { level: 1 },
+        content: [{ type: 'text', text: 'Q3 Risks' }]
+      },
+      {
+        id: 'b-item',
+        type: 'bulletListItem',
+        content: [{ type: 'text', text: 'Hire a designer' }]
+      }
+    ])
+    await screen.findByRole('toolbar')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as canvas' }))
+    await waitFor(() => expect(mocks.toCanvasScene).toHaveBeenCalledTimes(1))
+
+    const boxes = (
+      mocks.toCanvasScene.mock.calls[0][0] as Array<{ type: string; id: string; link?: string }>
+    ).filter((element) => element.type === 'rectangle')
+
+    // Every one of them, not just the interesting ones: a canvas with one URL
+    // left in it still hovers as a URL.
+    expect(boxes.length).toBeGreaterThan(0)
+    for (const box of boxes) {
+      expect(new URL(box.link!).searchParams.get('label')).toBeTruthy()
+    }
+
+    const item = boxes.find((box) => box.id.endsWith('b-item'))!
+    // The destination, as a chain: the section it lands in, then the row. The
+    // separator is the only translated part.
+    expect(new URL(item.link!).searchParams.get('label')).toBe(
+      '\u2026 \u2192 Q3 Risks \u2192 Hire a designer'
+    )
+    // And the label never disturbs the anchor, which is what actually resolves.
+    expect(item.link).toContain('#Q3%20Risks')
+  })
+
+  it('hands the drawing a name for every box it drew, keyed the way a click arrives', async () => {
+    renderView([
+      {
+        id: 'b-h1',
+        type: 'heading',
+        props: { level: 1 },
+        content: [{ type: 'text', text: 'Q3 Risks' }]
+      },
+      {
+        id: 'b-p',
+        type: 'paragraph',
+        content: [{ type: 'wikiLink', props: { target: 'Roadmap' } }]
+      }
+    ])
+    await screen.findByTestId('mind-map-canvas')
+
+    // Keyed by href because that is what a box carries and what the hit test
+    // hands back — the drawing has no node ids to give, the library having
+    // regenerated every one of them.
+    expect(
+      [...mocks.hoverLabels.keys()].every((href) => href.startsWith('memry://note/note-1'))
+    ).toBe(true)
+    expect(mocks.hoverLabels.get('memry://note/note-1')).toEqual({
+      chain: 'Test Note',
+      hint: null
+    })
+    expect(mocks.hoverLabels.get('memry://note/note-1#^b-h1')).toEqual({
+      chain: 'Test Note \u2192 Q3 Risks',
+      hint: null
+    })
+
+    // A wiki node names the note it points AT, and says in words that it leaves
+    // this one — the same sentence the accessible tree gives it.
+    const wiki = [...mocks.hoverLabels.values()].find((label) => label.hint !== null)
+    expect(wiki).toEqual({ chain: 'Roadmap', hint: 'link to another page' })
   })
 
   it('takes its controls back when the drawing surface goes away', async () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
@@ -32,11 +32,13 @@ import { createLogger } from '@/lib/logger'
 import { buildMemryHref } from '@/lib/memry-links'
 import { resolveWikiLink } from '@/lib/wikilink-resolver'
 import { canvasService } from '@/services/canvas-service'
+import { mindMapDestinations } from './mind-map-destination'
+import { mindMapHrefOf } from './mind-map-hover'
 import { nodeFromMindMapLink, type MindMapNodeActivation } from './mind-map-navigation'
 import { mintSnapshotElements, uniqueCanvasTitle } from './mind-map-snapshot'
 import { MindMapToolbar, type MindMapToolbarAction } from './mind-map-toolbar'
 import { MindMapTree } from './mind-map-tree'
-import type { MindMapControls } from './mind-map-canvas'
+import type { MindMapControls, MindMapHoverLabel } from './mind-map-canvas'
 import type { MindMap, MindMapPositionedNode } from './mind-map-types'
 
 const log = createLogger('NoteMindMap')
@@ -72,10 +74,19 @@ const LazyMindMapCanvas = lazy(async () => ({
  * freezing "make this note" into a document is not a promise a file can keep.
  */
 async function resolveWikiHrefs(
-  nodes: readonly MindMapPositionedNode[]
+  nodes: readonly MindMapPositionedNode[],
+  labels: ReadonlyMap<string, string>
 ): Promise<Map<string, string>> {
   const links = nodes.filter((node) => node.kind === 'wikiLink' && node.wikiTarget !== null)
   const targets = [...new Set(links.map((node) => node.wikiTarget as string))]
+
+  // A wiki node's name comes from its target alone, so every node sharing a
+  // target shares a name and the label can be resolved once per target too.
+  const labelByTarget = new Map<string, string>()
+  for (const node of links) {
+    const target = node.wikiTarget as string
+    if (!labelByTarget.has(target)) labelByTarget.set(target, labels.get(node.id) ?? '')
+  }
 
   const byTarget = new Map<string, string>()
   await Promise.all(
@@ -86,6 +97,10 @@ async function resolveWikiHrefs(
       const href = buildMemryHref({
         kind: resolved.type,
         id: resolved.id,
+        // So the canvas' link bubble says the page this box opens rather than
+        // its address. A hint, never an identity — the id is what resolves, and
+        // the opening path reads the item's real title before it names a tab.
+        label: labelByTarget.get(target) || null,
         // A filed binary has no inside to address; a note takes the heading half
         // of `[[Note#Heading]]` exactly as the editor would.
         anchor:
@@ -125,6 +140,48 @@ export function MindMapView({
   const [controls, setControls] = useState<MindMapControls | null>(null)
   const [isSaving, setSaving] = useState(false)
 
+  /**
+   * What each node's link opens, said as a name.
+   *
+   * Composed here because this is the layer with a translator: the separator
+   * between segments is chrome and has to follow the reading direction, while
+   * the names it joins — headings, list items, note titles — are the user's own
+   * words and are never translated.
+   *
+   * One derivation feeds both surfaces. The drawn map renders it on hover; the
+   * saved canvas freezes it into each href as a `?label=`, which is the only
+   * hook the drawing library's own bubble has.
+   */
+  const destinations = useMemo(
+    () => mindMapDestinations(map.nodes, { separator: t('mindMap.chain.separator') }),
+    [map.nodes, t]
+  )
+
+  /**
+   * The same names, keyed the way a click and a hover arrive: by the href the
+   * box carries.
+   *
+   * Read off the minted elements rather than re-derived, so the affordance can
+   * only ever describe a box that was actually drawn.
+   */
+  const hoverLabels = useMemo(() => {
+    const byId = new Map(map.nodes.map((node) => [node.id, node]))
+    const linkHint = t('mindMap.linkHint')
+    const labels = new Map<string, MindMapHoverLabel>()
+
+    for (const element of map.elements) {
+      if (element.type !== 'rectangle') continue
+      const href = mindMapHrefOf(element)
+      const node = byId.get(element.id)
+      if (href === null || !node) continue
+      labels.set(href, {
+        chain: destinations.get(node.id) ?? '',
+        hint: node.kind === 'wikiLink' ? linkHint : null
+      })
+    }
+    return labels
+  }, [destinations, map.elements, map.nodes, t])
+
   const copy = useCallback(
     (run: () => Promise<void>, success: string): void => {
       void run()
@@ -155,13 +212,15 @@ export function MindMapView({
       const [{ toCanvasScene }, existing, wikiHrefs] = await Promise.all([
         import('./mind-map-export'),
         canvasService.list(),
-        resolveWikiHrefs(map.nodes)
+        resolveWikiHrefs(map.nodes, destinations)
       ])
 
       const generatedLabel = t('mindMap.toolbar.snapshotOn', {
         date: new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date())
       })
-      const scene = toCanvasScene(mintSnapshotElements(map, { noteId, generatedLabel, wikiHrefs }))
+      const scene = toCanvasScene(
+        mintSnapshotElements(map, { noteId, generatedLabel, wikiHrefs, labels: destinations })
+      )
       // Only the canvas ROOT can collide: that is where this one is filed. The
       // note's own folder tree is deliberately not mirrored — gluing the two
       // trees together would make every note rename a canvas move.
@@ -178,7 +237,7 @@ export function MindMapView({
         toast.error(extractErrorMessage(err, t('mindMap.toolbar.saveFailed')))
       })
       .finally(() => setSaving(false))
-  }, [map, noteId, noteTitle, t])
+  }, [destinations, map, noteId, noteTitle, t])
 
   const actions = useMemo<MindMapToolbarAction[]>(
     () => [
@@ -268,6 +327,7 @@ export function MindMapView({
         <Suspense fallback={<div className="h-full w-full" aria-hidden="true" />}>
           <LazyMindMapCanvas
             elements={map.elements}
+            hoverLabels={hoverLabels}
             onOpenLink={handleOpenLink}
             onControlsChange={setControls}
           />

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -272,7 +272,7 @@ vi.mock('@/components/note/mind-map/mind-map-canvas', () => ({
     onOpenLink,
     onControlsChange
   }: {
-    elements: Array<{ id: string; link?: string }>
+    elements: Array<{ id: string; customData?: { memryHref: string } }>
     onOpenLink: (href: string) => void
     onControlsChange?: (controls: Record<string, unknown> | null) => void
   }) => {
@@ -288,19 +288,22 @@ vi.mock('@/components/note/mind-map/mind-map-canvas', () => ({
     }, [onControlsChange])
     return (
       <div data-testid="mind-map-canvas" data-element-count={elements.length}>
-        {/* Excalidraw hands a click back as the link of the box it landed on —
-            in view mode the whole box is the hit area. Standing in for that is
-            all this needs to do; everything downstream of it is the real path. */}
+        {/* The real surface hit-tests the box under the cursor and hands its
+            deep link back — the whole bounding box, as view mode's own link hit
+            test used to do for us. The href lives in `customData` rather than
+            `link` so the library paints no glyph over the map. Standing in for
+            that is all this needs to do; everything downstream is the real
+            path. */}
         {elements
-          .filter((element) => Boolean(element.link))
+          .filter((element) => Boolean(element.customData?.memryHref))
           .map((element) => (
             <button
               key={element.id}
               type="button"
               data-testid={`mind-map-box-${element.id}`}
-              onClick={() => onOpenLink(element.link!)}
+              onClick={() => onOpenLink(element.customData!.memryHref)}
             >
-              {element.link}
+              {element.customData!.memryHref}
             </button>
           ))}
       </div>

--- a/apps/docs/src/user-guide/notes/mind-map.md
+++ b/apps/docs/src/user-guide/notes/mind-map.md
@@ -140,6 +140,18 @@ Nodes work from the keyboard too. Tab into the map, move between nodes with the
 up and down arrows (Home and End jump to the ends), and press Enter or Space to
 open the one you are on.
 
+### Where a Node Goes
+
+Point at a node and a small card appears under it naming what the click opens:
+the last two steps of the path, such as `… → Q3 Risks → Hire a designer`. A
+wiki-link node names **the note it points at** rather than the one you are in,
+and says that it leaves the note. A `+N more` node names the branch it stands
+for.
+
+Nothing marks a node the rest of the time, and deliberately. Every node on a map
+is a link, so a marker on each of them would mark nothing and bury the shape the
+map is for. The whole node is the target either way — click anywhere on the box.
+
 ## The Map's Own Toolbar
 
 A small toolbar sits at the top of the map, and only there — the note's overflow
@@ -198,6 +210,10 @@ canvas is resolved when the canvas is written, so it opens the linked note — a
 its heading, if the link named one — on any of your devices. If the link points
 at a note that does not exist yet, the node opens the source note at the section
 the link is written in instead, so it is never a dead box.
+
+Each link carries the name of what it opens, so hovering a node in the saved
+canvas shows `… → Q3 Risks` rather than the address behind it — including on a
+device that has never opened the note the map was made from.
 
 **A "+N more" node stays in the saved canvas**, even though there is nothing for
 it to open in a document. It is what tells you the canvas is not the whole note,

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -981,6 +981,9 @@
     "treeLabel": "Mind map outline of {title}",
     "emptyHint": "Add a heading to this note and the map will branch.",
     "linkHint": "link to another page",
+    "chain": {
+      "separator": "\u2192"
+    },
     "more": "{count, plural, one {+# more} other {+# more}}",
     "nodeCapNotice": "This map is at its limit of {count, plural, one {# node} other {# nodes}}; the rest is folded into the nearest node above it.",
     "badge": {


### PR DESCRIPTION
Follow-up work for #1688. The issue stays open for review.

## What this does

Two presentation problems with the note mind map's links, solved differently on the two surfaces because the two surfaces are different.

### The drawn map renders its own affordance

Every node on a map is linked, so the drawing library's permanent blue glyph marks nothing and buries the one thing the picture exists to show. Its condition is `element.link && !selected` — not hover-gated, with no prop, `appState` field or CSS surface that suppresses it — so the map now keeps its href in `customData`, where nothing paints it, and renders the affordance itself:

- a **hover card** under the hovered node naming where the click goes;
- the **pointer cursor**, as a CSS rule marked important (the library sets its cursor inline on its own canvas and re-sets it on pointer moves, so only an important rule outranks it);
- **click-to-open**, hit-tested at the release point, with a press that travelled treated as a pan.

The hit test is the **whole bounding box**. That is what view mode's own `isPointHittingLink` was giving us and why clicking anywhere on a node has always worked; a replacement that only answered for a 14px glyph would restore "click to open" on paper and take the feature away in practice.

### The saved canvas keeps its links and gains a name

A saved canvas is opened by `CanvasEditor` like any other, with nothing of ours watching it, so its links stay exactly where they are — they are the point of #1675. They now carry a `?label=`. `CanvasEditor` already runs a `MutationObserver` that swaps the bubble text for whatever `linkBubbleLabel` reads off the href; it has simply had nothing to read. **Zero new rendering code on that side.**

The label is additive: it sits in the query, the anchor stays in the fragment, and a build that has never heard of labels drops the one and still resolves the other. Heading-text anchors are untouched.

### The name

One derivation for both surfaces: the destination as a short chain, last two segments with a leading ellipsis — `… → Q3 Risks → Hire a designer`, clipped with the link bubble's own `truncateLabel` (48 chars, shared as a function rather than copied as a number).

It says where the click **goes**, not where the node sits: a wiki-link node names the note it points at (never this one), a fold marker names the branch it stands for, the root is just the note. Heading segments come from the unclipped `headingText`, never the display `label`. Only the separator is translated (`mindMap.chain.separator`), so an RTL locale supplies an arrow that points the way it reads; the wiki-link hint reuses the existing `mindMap.linkHint` the accessible tree already says.

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| Permanent link glyph gone from every node | met | `build-mind-map.test.ts` "puts no `link` on any drawn element, so no glyph is ever painted" asserts every drawn element; `mind-map-snapshot.test.ts` asserts the drawn box carries `customData` and no `link` |
| Hover shows the affordance and the chain for that node only | met | `mind-map-canvas.test.tsx` "names the node under the cursor, and only that node", "says nothing until the pointer is over a node", "says when the link leaves this note" |
| Clicking anywhere on a node still opens what it points at, for every node kind | met | `mind-map-canvas.test.tsx` "answers for the whole box, not for a glyph in the corner of it" + "opens what the box under the click points at, from anywhere in the box"; the href → node → activation path is unchanged, covered by `mind-map-navigation.test.ts` and `note.test.tsx`'s four mind-map navigation tests (heading, root, wiki link, fold marker) |
| Keyboard activation through `role="tree"` unchanged, and the tree still announces what a node points at | met | `mind-map-tree.tsx` untouched; `mind-map-tree.test.tsx` unchanged and green; the E2E journey drives the tree with `press('Enter')` and is untouched |
| A saved canvas shows a readable name instead of a raw `memry://` URL, on a device that has never seen the note | met | `mind-map-view.test.tsx` "names every saved link, so a canvas hovers as words rather than as a URL" asserts a `label` on **every** saved box; `linkBubbleLabel` + `CanvasEditor`'s existing observer render it, with no change on that side |
| Saved links still carry heading-text anchors and still resolve; the label is additive and an older build ignores it | met | `mind-map-snapshot.test.ts` (unchanged assertions on `#Heading` anchors and `parseMemryHref`/`tabFromMemryHref` round trips) still green; the new view test asserts `#Q3%20Risks` survives alongside the label. `label` lives in the query, which `parseMemryHref` has always read and always tolerated |
| Copy as image and copy as vector unaffected | met | `renderLinkIcon` is behind `if (!isExporting)`, so exports never contained the glyph; the export path reads the live scene and is untouched — `mind-map-canvas.test.tsx`'s four export tests unchanged and green |
| Chain translated where it is chrome, never where it is user content | met | `mind-map-destination.test.ts` "translates only the separator, never the words around it"; the pure builder takes the separator as a parameter and has no translator, exactly as `formatContentCount`/`formatMore` do |
| Tests cover: no `link` on screen; hover names only the hovered node; the click path reaches each node kind; saved hrefs carry a label; the chain is built from unclipped heading text | met | see rows above, plus `mind-map-destination.test.ts` "is a real trap: the pipeline clips a long heading's label" / "reads `headingText` rather than `label`" |

## Gates

```
$ pnpm lint
✖ 108 problems (0 errors, 108 warnings)
  0 errors and 65 warnings potentially fixable with the `--fix` option.
LINT_EXIT=0
```

108 warnings are the pre-existing baseline; this branch adds none — no `mind-map` file appears in the output.

```
$ pnpm typecheck
 Tasks:    17 successful, 17 total
Cached:    16 cached, 17 total
  Time:    38.722s
TYPECHECK_EXIT=0
```

Includes `check:contracts`, `check:architecture`, `ipc:check`, and `typecheck:test:node` + `typecheck:test:web`.

```
$ pnpm test
@memry/contracts:test:      Test Files  50 passed (50)
@memry/contracts:test:           Tests  1666 passed (1666)
@memry/editor-schema:test:  Test Files  3 passed (3)
@memry/editor-schema:test:       Tests  95 passed (95)
@memry/i18n:test:           Test Files  11 passed (11)
@memry/i18n:test:                Tests  56 passed (56)
@memry/sync-server:test:    Test Files  62 passed (62)
@memry/sync-server:test:         Tests  966 passed (966)
@memry/sync-harness:test:   Test Files  5 passed (5)
@memry/sync-harness:test:        Tests  32 passed (32)
@memry/desktop:test:        Test Files  1382 passed | 3 skipped (1385)
@memry/desktop:test:             Tests  18044 passed | 1 expected fail | 13 skipped (18058)

 Tasks:    9 successful, 9 total
  Time:    3m27.167s
TEST_EXIT=0
```

```
$ pnpm --filter @memry/desktop i18n:check
warn: 381 keys missing in zh-TW/* (will fall back to en)
warn: 265 English keys not referenced by scanned source
ok: i18n check passed
I18N_EXIT=0
```

```
$ pnpm docs:impact --base 05f9c6738 --strict
docs impact: covered against 05f9c6738
docs impact: docs changed on this branch
DOCS_IMPACT_EXIT=0

$ pnpm docs:build
✓ rendering pages...
build complete in 3.23s.
DOCS_BUILD_EXIT=0
```

## What the tests prove, and what they cannot

jsdom has no canvas, so nothing here proves pixels. The hit test, the anchor arithmetic and the hover/click wiring are asserted as numbers and DOM against a faithful stand-in for the library — its `viewportCoordsToSceneCoords` arithmetic is reimplemented in the mock rather than stubbed away, and the live scene the hit test reads is deliberately not the elements the map was built from. What no test here can say is whether a real Excalidraw canvas puts its pixels where that arithmetic says, or whether the pointer cursor actually wins the cascade.

For the two library internals this now rests on, `mind-map-library-contract.test.ts` is an upgrade tripwire rather than a behavioural test: the library cannot be imported for real in this suite (it touches a canvas at import time), so it reads the shipped `dist/prod` bundle for the `customData` forward and the `viewportCoordsToSceneCoords` export, and pins the verified version. It will not catch a subtle behaviour change; it will catch the field or the export disappearing.

Verified out of band against the installed 0.18.1 bundle: `_newElementBase` ends in `customData: rest.customData` and the restore path carries it too (`dist/dev/chunk-4FTI6OG3.js:15084` and `:20484`), which is the assumption the whole on-screen half rests on. The shipped precedent is `CanvasCardLayer`, which has round-tripped `customData` through `convertToExcalidrawElements` in production since the spatial canvas shipped.

**Not run:** the app itself, and Playwright. The mind-map E2E journey drives the `sr-only` tree with `press('Enter')` and never touches the drawing, so it is unaffected by this change and was left untouched.

## Compatibility

No IPC contract, no migration, no sync handler, no settings schema. `buildMindMap` is still the only pipeline export. The map still gates on `spatialCanvas`. The toolbar is still a sibling of the `role="img"` region; the hover card sits **inside** it and is `aria-hidden` + `pointer-events-none`, because it is a mouse-only affordance whose content the accessible tree already carries in words.
