### PR TITLE
fix(canvas): give the canvas editor stable Excalidraw prop identities

### DIFF
--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
@@ -1199,3 +1199,54 @@ describe('CanvasEditor viewport restore', () => {
     expect(cameraWrites()).toHaveLength(0)
   })
 })
+
+/**
+ * Prop identity across the Excalidraw boundary.
+ *
+ * Excalidraw memoizes itself and shallow-compares most of the props it is
+ * handed — `excalidrawAPI` and `onChange` among them. An inline arrow for
+ * either is a fresh identity on every render of this editor, so the surface
+ * re-renders on every render of the editor, and `onChange` writes state back
+ * into the editor: a circuit that stays open only for as long as nothing
+ * happens to close it. The mind map was handed the same shape and took a
+ * vitest worker to 4 GB with it, so this pins the identities down.
+ */
+describe('CanvasEditor Excalidraw prop identity', () => {
+  beforeEach(() => {
+    mocks.excalidrawProps = {}
+    mocks.linkDialogProps = {}
+    mocks.toastError.mockReset()
+    mocks.api.elements = [{ id: 'shape-1', type: 'rectangle' }]
+    mocks.api.selectedElementIds = { 'shape-1': true }
+    mocks.api.isLoading = false
+    mocks.api.showHyperlinkPopup = false
+    installWindowApi()
+  })
+
+  it('hands the surface the same excalidrawAPI and onChange across a re-render', () => {
+    const { rerender } = render(<CanvasEditor canvasId="c1" initialScene="" />)
+    const first = { ...mocks.excalidrawProps }
+
+    rerender(<CanvasEditor canvasId="c1" initialScene="" />)
+
+    expect(mocks.excalidrawProps.excalidrawAPI).toBe(first.excalidrawAPI)
+    expect(mocks.excalidrawProps.onChange).toBe(first.onChange)
+  })
+
+  it('keeps them stable when the editor re-renders on its own state', () => {
+    const { container } = render(<CanvasEditor canvasId="c1" initialScene="" />)
+    const first = { ...mocks.excalidrawProps }
+
+    // Opening the link picker is a real setState in the editor — the same kind
+    // of write onChange performs, and the one that would feed the loop.
+    fireEvent.keyDown(container.querySelector('[data-canvas-editor]') as Element, {
+      key: 'K',
+      metaKey: true,
+      shiftKey: true
+    })
+
+    expect(mocks.linkDialogProps.open).toBe(true)
+    expect(mocks.excalidrawProps.excalidrawAPI).toBe(first.excalidrawAPI)
+    expect(mocks.excalidrawProps.onChange).toBe(first.onChange)
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
@@ -116,6 +116,26 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
   /** Card titles already resolved for the link bubble, so relabels are stable. */
   const cardTitles = useRef(new Map<string, string>())
 
+  /**
+   * Hands the imperative API out to BOTH sinks, from one stable identity.
+   *
+   * Stable because `excalidrawAPI` is one of the props Excalidraw's own memo
+   * comparator shallow-compares: an inline arrow is a fresh identity on every
+   * render of this component, so it fails that comparison every time and
+   * re-renders the whole surface — which fires `onChange`, which sets state
+   * here, which renders again. A `useCallback` breaks that circuit before it
+   * can close. (The same shape did close, and OOM'd, in the mind map.)
+   *
+   * Both sinks are load-bearing. The ref is what every callback below reads at
+   * call time, so it always describes the surface as it is right now; the state
+   * is what render-time consumers need — `useHandleLibrary` and the gate that
+   * mounts `CanvasCardLayer` — and a ref cannot drive either.
+   */
+  const handleApi = useCallback((instance: ExcalidrawImperativeAPI): void => {
+    apiRef.current = instance
+    setApi(instance)
+  }, [])
+
   // Parse the stored scene up front only to decide whether it is loadable —
   // and deliberately throw the parsed graph away. Retaining it (as a useMemo
   // did) kept a second full copy of the scene, inline image data URLs and all,
@@ -733,6 +753,29 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
     [openLinkPicker]
   )
 
+  /**
+   * The change work, mirrored so `handleChange` can close over nothing.
+   *
+   * A dependency list would not do: `interceptLinkEditor` depends on
+   * `openLinkPicker`, which depends on `t`, whose identity react-i18next only
+   * holds across ordinary renders — one unstable link is enough to churn the
+   * prop, and this is the prop that must never churn.
+   */
+  const changeHandlersRef = useRef({ recordViewport, interceptLinkEditor })
+  useLayoutEffect(() => {
+    changeHandlersRef.current = { recordViewport, interceptLinkEditor }
+  }, [recordViewport, interceptLinkEditor])
+
+  // Stable for the same reason `handleApi` is: `onChange` is shallow-compared
+  // by Excalidraw's memo, and it is the half of the loop that writes state.
+  const handleChange = useCallback<
+    NonNullable<React.ComponentProps<typeof Excalidraw>['onChange']>
+  >((_elements, appState) => {
+    persisterRef.current?.notifyChange()
+    changeHandlersRef.current.recordViewport(appState)
+    changeHandlersRef.current.interceptLinkEditor(appState)
+  }, [])
+
   // Excalidraw's own toolbar/menu i18n comes from its bundled translations via
   // langCode — independent of Memry's i18n and i18n:check; we do not translate
   // Excalidraw's internal UI ourselves.
@@ -785,10 +828,7 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
       onKeyDownCapture={handleKeyDownCapture}
     >
       <Excalidraw
-        excalidrawAPI={(instance) => {
-          apiRef.current = instance
-          setApi(instance)
-        }}
+        excalidrawAPI={handleApi}
         initialData={loadInitialData}
         // The vault is the only store: hide Excalidraw's own file actions
         // (open .excalidraw, save to disk) so they can't bypass — or, via
@@ -800,11 +840,7 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
             saveToActiveFile: false
           }
         }}
-        onChange={(_elements, appState) => {
-          persisterRef.current?.notifyChange()
-          recordViewport(appState)
-          interceptLinkEditor(appState)
-        }}
+        onChange={handleChange}
         onLinkOpen={handleLinkOpen}
         // Three Memry themes exist (light/dark/white); anything not dark maps
         // to Excalidraw's light theme.


### PR DESCRIPTION
## What

`CanvasEditor` handed Excalidraw two inline arrows — `excalidrawAPI` and `onChange`. Both are now `useCallback`-stable.

## Why

Excalidraw memoizes itself and its comparator shallow-compares most props (`areEqual` in `@excalidraw/excalidraw` 0.18.1). An inline arrow is a fresh identity on every render of the editor, so the comparison failed every time, the whole surface re-rendered on every render, and `onChange` writes state straight back into the editor. That circuit stayed open only because nothing happened to close it.

The mind map was handed the same shape while building its hover layer and closed it — the vitest worker OOM'd at 4 GB, and the symptom pointed nowhere near the cause.

## The `onChange` half needs a ref, not a dependency list

`[recordViewport, interceptLinkEditor]` is not enough: `interceptLinkEditor` → `openLinkPicker` → `t`, and react-i18next only holds `t`'s identity across ordinary renders. One unstable link churns the prop. `handleChange` therefore closes over nothing and reads its work through a ref, the same idiom the file already uses for `setStoredViewportRef`.

## Answers to the two questions asked

- **Are `apiRef` and `setApi` both still necessary?** Yes, both. The ref is what every callback reads at call time, so it always describes the surface as it is now; the state is what render-time consumers need — `useHandleLibrary` and the gate that mounts `CanvasCardLayer` — and a ref drives neither.
- **Any other Excalidraw prop with the same problem?** No. `initialData` is destructured out of the comparator entirely, and `UIOptions` is deep-compared key by key, so the inline object literal there is fine. `onLinkOpen`, `theme`, and `langCode` were already stable.

## Tests

New `CanvasEditor Excalidraw prop identity` suite, two cases: identity held across a plain re-render, and across a re-render driven by the editor's own state (opening the link picker — the same kind of write `onChange` performs).

Mutation-checked: restoring either inline arrow turns both new tests red, and nothing else.

## Gates

- `pnpm lint` — 0 errors
- `pnpm typecheck` — 17/17 tasks
- `pnpm test` — 9/9 tasks; 18,000 desktop tests pass
- `pnpm docs:impact --base 60cc66a7e --strict` — waived with `MEMRY_DOCS_IMPACT_SKIP=1`. This is an internal render-identity fix with no user-facing surface: no behavior, UI, setting, or workflow changes, so there is nothing in `apps/docs/src` to update.