### PR TITLE
feat(canvas): give a saved mind map the same link affordance as the drawn one

### DIFF
--- a/apps/desktop/src/main/canvas/elements.test.ts
+++ b/apps/desktop/src/main/canvas/elements.test.ts
@@ -72,6 +72,46 @@ describe('readSceneElements', () => {
     expect(result.elements[0]).toMatchObject({ entityType: 'note', entityId: 'note-1' })
   })
 
+  it('reports a saved mind map\u2019s href, which the box keeps out of `link`', () => {
+    // A map box carries its deep link in `customData` so the drawing library
+    // paints no glyph for it. Where it is stored is a rendering concern; a
+    // reader asking what the box points at gets the same answer either way.
+    const result = readSceneElements(
+      scene([
+        {
+          id: 'mm-b1',
+          type: 'rectangle',
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+          customData: { memryHref: 'memry://note/n1#Risks' }
+        }
+      ])
+    )
+
+    expect(result.elements[0]?.link).toBe('memry://note/n1#Risks')
+  })
+
+  it('prefers a real `link` over the one a map box carries', () => {
+    const result = readSceneElements(
+      scene([
+        {
+          id: 'r1',
+          type: 'rectangle',
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+          link: 'https://example.com',
+          customData: { memryHref: 'memry://note/n1' }
+        }
+      ])
+    )
+
+    expect(result.elements[0]?.link).toBe('https://example.com')
+  })
+
   it('ignores customData that is not a real entity ref', () => {
     const result = readSceneElements(
       scene([

--- a/apps/desktop/src/main/canvas/elements.ts
+++ b/apps/desktop/src/main/canvas/elements.ts
@@ -57,6 +57,12 @@ function num(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0
 }
 
+/** The deep link a saved mind-map box carries. See `mind-map-hover.ts`. */
+function mindMapHref(customData: unknown): string | undefined {
+  if (typeof customData !== 'object' || customData === null) return undefined
+  return str((customData as { memryHref?: unknown }).memryHref)
+}
+
 function bindingId(value: unknown): string | undefined {
   if (!value || typeof value !== 'object') return undefined
   return str((value as { elementId?: unknown }).elementId)
@@ -137,7 +143,13 @@ export function readSceneElements(scene: string): CanvasSceneElements {
     if (strokeColor) view.strokeColor = strokeColor
     const backgroundColor = str(element.backgroundColor)
     if (backgroundColor) view.backgroundColor = backgroundColor
-    const link = str(element.link)
+    // A box saved from a note's mind map keeps its `memry://` href in
+    // `customData` rather than in `link` — the drawing library paints a
+    // permanent glyph for the latter, and a map is nothing but linked boxes
+    // (see `mind-map-snapshot.ts`). Where it is stored is a rendering concern;
+    // a reader asking what this element points at wants the same answer either
+    // way.
+    const link = str(element.link) ?? mindMapHref(element.customData)
     if (link) view.link = link
     const startElementId = bindingId(element.startBinding)
     if (startElementId) view.startElementId = startElementId

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-elements.ts
@@ -117,13 +117,14 @@ export interface MintElementsOptions {
  * click on a bitmap has: two boxes sharing one would send a click to whichever
  * came first.
  *
- * WHERE the box carries it differs by mode, and that is not cosmetic. In a file
- * it goes in `element.link`, which is what makes the box clickable in an
- * ordinary canvas at all. On the drawn map it goes in `customData` instead:
- * `element.link` also paints a permanent blue glyph, one per linked element,
- * and on a map where EVERY box is linked that marks nothing and buries the one
- * thing the picture is for — its shape. The map renders its own hover
- * affordance from this href instead (see `mind-map-hover.ts`).
+ * WHERE the box carries it is the same in both modes, and that is not
+ * cosmetic: it goes in `customData`, never in `element.link`. `element.link`
+ * paints a permanent blue glyph, one per linked element, and on a map where
+ * EVERY box is linked that marks nothing and buries the one thing the picture
+ * is for — its shape. Both surfaces render their own hover affordance from
+ * this href instead: the drawn map in `mind-map-canvas.tsx`, a saved canvas in
+ * `canvas-node-link-overlay.tsx`, off the same key and the same hit test
+ * (`mind-map-hover.ts`).
  *
  * **On screen (`block`)** the link is an address within this session:
  *
@@ -293,15 +294,9 @@ export function mintElements(
         ? [rootDetail, node.detail].filter((part) => part !== '').join(' · ')
         : node.detail
     const href = nodeLink(node, { noteId, anchor, wikiHrefs, labels })
-    // One href, two homes. See `nodeLink` for why the drawn map keeps its out
-    // of `link`: that field is what paints the glyph, and a map is nothing but
-    // linked boxes.
-    const address =
-      href === undefined
-        ? {}
-        : anchor === 'heading'
-          ? { link: href }
-          : { customData: { memryHref: href } }
+    // One href, one home. See `nodeLink` for why it stays out of `link`: that
+    // field is what paints the glyph, and a map is nothing but linked boxes.
+    const address = href === undefined ? {} : { customData: { memryHref: href } }
     elements.push({
       type: 'rectangle',
       id: node.id,

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-snapshot.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-snapshot.test.ts
@@ -55,6 +55,18 @@ function snapshot(blocks: readonly MindMapSourceBlock[] = BLOCKS): MindMapElemen
   return mintSnapshotElements(map, { noteId: 'n1', generatedLabel: GENERATED })
 }
 
+/**
+ * Where a box carries its deep link.
+ *
+ * `customData`, never `element.link` — the drawing library paints a permanent
+ * glyph for the latter, and a map is nothing but linked boxes. Read through one
+ * helper so the assertions below say what the link IS rather than where it
+ * happens to live.
+ */
+function hrefOf(box: MindMapBoxElement | undefined): string | undefined {
+  return box?.customData?.memryHref
+}
+
 function boxes(elements: readonly MindMapElement[]): Map<string, MindMapBoxElement> {
   return new Map(
     elements
@@ -67,19 +79,19 @@ describe('mintSnapshotElements — links that outlive the document', () => {
   it('anchors a heading on its own text, never on a block id', () => {
     const byId = boxes(snapshot())
 
-    expect(byId.get('mm-b-risks')?.link).toBe('memry://note/n1#Risks')
-    expect(byId.get('mm-b-cost')?.link).toBe('memry://note/n1#Cost')
+    expect(hrefOf(byId.get('mm-b-risks'))).toBe('memry://note/n1#Risks')
+    expect(hrefOf(byId.get('mm-b-cost'))).toBe('memry://note/n1#Cost')
   })
 
   it('anchors a list node on its nearest ancestor heading, however deep', () => {
     const byId = boxes(snapshot())
 
     // Directly under `Risks`…
-    expect(byId.get('mm-b-lock')?.link).toBe('memry://note/n1#Risks')
+    expect(hrefOf(byId.get('mm-b-lock'))).toBe('memry://note/n1#Risks')
     // …and nested one level further under the same one.
-    expect(byId.get('mm-b-deep')?.link).toBe('memry://note/n1#Risks')
+    expect(hrefOf(byId.get('mm-b-deep'))).toBe('memry://note/n1#Risks')
     // Under the deeper heading, not the one that opened the section.
-    expect(byId.get('mm-b-budget')?.link).toBe('memry://note/n1#Cost')
+    expect(hrefOf(byId.get('mm-b-budget'))).toBe('memry://note/n1#Cost')
   })
 
   it('anchors on nothing above the first heading, and at the root', () => {
@@ -87,8 +99,8 @@ describe('mintSnapshotElements — links that outlive the document', () => {
 
     // No heading to borrow: the link opens the note at the top, which is where
     // a build with no anchors at all would have put the reader anyway.
-    expect(byId.get('mm-b-intro')?.link).toBe('memry://note/n1')
-    expect(byId.get('mm-root')?.link).toBe('memry://note/n1')
+    expect(hrefOf(byId.get('mm-b-intro'))).toBe('memry://note/n1')
+    expect(hrefOf(byId.get('mm-root'))).toBe('memry://note/n1')
   })
 
   it('writes no block anchor anywhere in the document, whatever the note holds', () => {
@@ -114,14 +126,14 @@ describe('mintSnapshotElements — links that outlive the document', () => {
     for (const box of boxes(
       mintSnapshotElements(map, { noteId: 'n1', generatedLabel: GENERATED })
     ).values()) {
-      expect(box.link).not.toMatch(/#\^/)
+      expect(hrefOf(box)).not.toMatch(/#\^/)
     }
   })
 
   it('escapes a heading whose text would otherwise break the link', () => {
     const byId = boxes(snapshot([heading('b-q', 1, 'Q3 / Q4 plan?')]))
 
-    const href = byId.get('mm-b-q')!.link!
+    const href = hrefOf(byId.get('mm-b-q'))!
     expect(href).toBe('memry://note/n1#Q3%20%2F%20Q4%20plan%3F')
 
     const parsed = parseMemryHref(href)
@@ -131,11 +143,11 @@ describe('mintSnapshotElements — links that outlive the document', () => {
 
   it('round-trips through the parser a canvas will read it with', () => {
     for (const box of boxes(snapshot()).values()) {
-      const parsed = parseMemryHref(box.link!)
+      const parsed = parseMemryHref(hrefOf(box)!)
       // Still resolves to the note itself on a build that has never heard of
       // anchors: the item comes out of the path, the anchor out of the fragment.
       expect(parsed).toMatchObject({ kind: 'note', id: 'n1' })
-      expect(tabFromMemryHref(box.link!)).toMatchObject({ type: 'note', path: '/note/n1' })
+      expect(tabFromMemryHref(hrefOf(box)!)).toMatchObject({ type: 'note', path: '/note/n1' })
       if (parsed?.kind === 'note' && parsed.anchor) {
         expect(parsed.anchor.type).toBe('heading')
       }
@@ -188,8 +200,11 @@ describe('mintSnapshotElements — the document itself', () => {
     for (const element of snapshot()) {
       // `customData.entityType` is what makes a rectangle a live Memry card
       // (see `pages/canvas/canvas-cards.ts`). A card is roughly ten times the
-      // size of a map node, and a dozen make the map unreadable.
-      expect(element).not.toHaveProperty('customData')
+      // size of a map node, and a dozen make the map unreadable. The boxes DO
+      // carry `customData` — it is where their href lives — so what is asserted
+      // is the absence of the card keys, not of the field.
+      expect(element).not.toHaveProperty('customData.entityType')
+      expect(element).not.toHaveProperty('customData.entityId')
       expect(['rectangle', 'arrow', 'line']).toContain(element.type)
     }
   })
@@ -311,11 +326,11 @@ describe('mintSnapshotElements — a heading longer than the label cap', () => {
     // heading on the device that opens the canvas, so the link silently lands
     // at the top of the note instead of at the section.
     const href = `memry://note/n1#${encodeURIComponent(LONG)}`
-    expect(byId.get('mm-b-long')!.link).toBe(href)
+    expect(hrefOf(byId.get('mm-b-long'))).toBe(href)
     // And the child borrows the same whole text.
-    expect(byId.get('mm-b-kid')!.link).toBe(href)
+    expect(hrefOf(byId.get('mm-b-kid'))).toBe(href)
 
-    const parsed = parseMemryHref(byId.get('mm-b-long')!.link!)
+    const parsed = parseMemryHref(hrefOf(byId.get('mm-b-long'))!)
     if (parsed?.kind !== 'note') throw new Error('the link no longer names a note')
     expect(parsed.anchor).toEqual({ type: 'heading', text: LONG })
   })
@@ -339,13 +354,13 @@ describe('mintSnapshotElements — wiki-link nodes', () => {
 
     // The point of a saved wiki-link node: it opens the note it names, on any
     // device, rather than a node id only this session understood.
-    expect(box.link).toBe('memry://note/n2#Plan')
+    expect(hrefOf(box)).toBe('memry://note/n2#Plan')
   })
 
   it('falls back to the heading it is written under when it resolves to nothing', () => {
     // Never a dead box and never an invented destination: it opens the source
     // note at the section the link is written in.
-    expect(linkBox().link).toBe('memry://note/n1#Risks')
+    expect(hrefOf(linkBox())).toBe('memry://note/n1#Risks')
   })
 
   it('never carries the node-id anchor the drawn map gives it', () => {
@@ -358,7 +373,7 @@ describe('mintSnapshotElements — wiki-link nodes', () => {
     expect(mindMapHrefOf(drawn)).toBe(`memry://note/n1#^${node.id}`)
     expect(drawn).not.toHaveProperty('link')
     // In a file that names a block this device never minted.
-    expect(linkBox().link).not.toMatch(/#\^/)
+    expect(hrefOf(linkBox())).not.toMatch(/#\^/)
   })
 
   it('keeps the dashed outline that tells it apart from this note', () => {
@@ -391,8 +406,8 @@ describe('mintSnapshotElements — fold markers', () => {
   it('opens the note at the section the missing rows actually live in', () => {
     // It cannot expand in a file — there is nothing on the other side to expand
     // it — so it points at the place the folded content really is.
-    expect(box.link).toBe('memry://note/n1#Risks')
-    expect(box.link).not.toMatch(/#\^/)
+    expect(hrefOf(box)).toBe('memry://note/n1#Risks')
+    expect(hrefOf(box)).not.toMatch(/#\^/)
   })
 })
 

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-snapshot.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-snapshot.ts
@@ -30,16 +30,24 @@
  *    make the map unreadable. The user can add real cards by hand — it is their
  *    canvas.
  * 4. **Every link carries the name of what it opens**, as a `?label=` hint, so
- *    the canvas' own hover bubble reads `… → Q3 Risks` rather than a
- *    `memry://` URL. It is a hint and never an identity — the id is what
- *    resolves — and it is additive: a build that never heard of labels drops it
- *    and opens the same note at the same heading.
+ *    the affordance reads `… → Q3 Risks` rather than a `memry://` URL. It is a
+ *    hint and never an identity — the id is what resolves — and it is
+ *    additive: a build that never heard of labels drops it and opens the same
+ *    note at the same heading.
  *
- * Their links stay exactly where an ordinary canvas expects them, in
- * `element.link`. The DRAWN map moved its own out of that field (the glyph it
- * paints is noise on a map), but a saved canvas is not ours to render — it is
- * opened by `CanvasEditor` like any other, and stripping its links would take
- * away the one thing that makes it more than a picture.
+ * What does NOT change is where a box keeps its href: `customData`, exactly as
+ * the drawn map does, never `element.link`. That field paints a permanent glyph
+ * per linked element, and a map is nothing but linked boxes — so a saved map
+ * would wear a blue square on every card the drawn one does not. `CanvasEditor`
+ * renders the same hover affordance for these boxes instead
+ * (`canvas-node-link-overlay.tsx`), which is what makes a saved map read like
+ * the map it was saved from.
+ *
+ * The cost is stated rather than hidden: a build that predates that overlay
+ * opens one of these canvases and sees boxes it cannot click. Nothing is lost
+ * and nothing is corrupted — the href is right there in the file, and the
+ * build that wrote it is the build that reads it — but a downgrade is a
+ * picture until it upgrades again.
  *
  * Two node kinds need saying out loud, because neither is a place in this note:
  *
@@ -83,12 +91,12 @@ export interface MindMapSnapshotOptions {
    * href.
    *
    * The fourth thing the snapshot changes about the map as drawn, and the one
-   * that only a file needs. The drawing library prints `element.link` verbatim
-   * in its hover bubble, so without this a saved canvas hovers as
-   * `memry://note/skfe4c9o0z15#Q3%20Risks`. `CanvasEditor` already watches for
-   * that bubble and swaps in whatever `linkBubbleLabel` reads off the href — it
-   * has simply had nothing to read, because the map wrote no label. So the
-   * readable name is bought with a label rather than with rendering code.
+   * that only a file needs. The drawn map is rendered beside the note it was
+   * built from, so its affordance can be handed the names directly; a file has
+   * nothing beside it, and the only thing that travels with a box is its href.
+   * So the name is frozen into the query as `?label=`, and `linkBubbleLabel`
+   * reads it back out — the same reader the canvas' own link bubble uses, so a
+   * hand-made link and a saved map's link are named by one rule.
    *
    * Composed by the caller: it is a destination chain whose separator is
    * translated chrome, and this module has no translator.

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-types.ts
@@ -210,32 +210,23 @@ export interface MindMapBoxElement {
     strokeColor: string
   }
   /**
-   * A `memry://` deep link back into the note, on a box destined for a FILE.
+   * A `memry://` deep link, kept where the renderer will not paint anything
+   * for it — never in `element.link`.
    *
-   * It is what makes a box in a saved canvas clickable: an ordinary canvas has
-   * no code of ours watching it, so the link has to be something the drawing
-   * library itself acts on. A saved canvas outlives the document that produced
-   * it, so the anchor here is heading TEXT — never a block id, which dies with
-   * that document.
+   * `element.link` is what the drawing library acts on, and what it paints a
+   * permanent blue glyph for. One glyph marks something on a canvas where a
+   * few shapes are linked; on a map, where EVERY box is, it is a wall of
+   * identical blue squares over a picture whose whole point is shape. So the
+   * href lives here on BOTH surfaces, and both render their own hover
+   * affordance from it: the drawn map in `mind-map-canvas.tsx`, a saved canvas
+   * in `canvas-node-link-overlay.tsx`. Same key, same hit test — the whole
+   * bounding box, which is what view mode's own link hit test gave us — so a
+   * map reads the same way after it is saved as it did while it was drawn.
    *
-   * Absent on the DRAWN map, and deliberately: `element.link` also paints a
-   * permanent glyph, and a map where every box is linked is a wall of identical
-   * blue squares over a picture whose whole point is shape. The drawn map
-   * carries its href in `customData` instead.
-   */
-  link?: string
-  /**
-   * The same `memry://` deep link, on a box drawn on SCREEN, kept where the
-   * renderer will not paint anything for it.
-   *
-   * It is still the only handle a click on a bitmap has — the map hit-tests it
-   * itself (`mind-map-hover.ts`) and resolves it back to a node through
-   * `nodeFromMindMapLink`, preserving what view mode's own link hit test gave
-   * us: the whole bounding box, not a glyph.
-   *
-   * A block anchor is right HERE and only here: these elements are drawn for
-   * the session that minted them, and a block id lives exactly as long as the
-   * document that minted it.
+   * Which anchor it carries still differs, and has to. On screen it may name a
+   * BLOCK, because these elements are drawn for the session that minted them
+   * and a block id lives exactly as long as that document. A saved canvas
+   * outlives it, so a file's boxes anchor on heading TEXT instead.
    */
   customData?: { memryHref: string }
 }

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.test.tsx
@@ -73,6 +73,25 @@ vi.mock('./mind-map-canvas', () => ({
   }
 }))
 
+/** The slice of a saved element these assertions read. */
+interface SavedElement {
+  type: string
+  id: string
+  link?: string
+  strokeStyle?: string
+  customData?: { memryHref?: string }
+}
+
+/**
+ * Where a saved box carries its deep link.
+ *
+ * `customData`, never `element.link`: that field is what the drawing library
+ * paints its permanent glyph from, and a map is nothing but linked boxes.
+ */
+function hrefOf(element: SavedElement): string | undefined {
+  return element.customData?.memryHref
+}
+
 const BLOCKS: MindMapSourceBlock[] = [
   { id: 'b-h1', type: 'heading', props: { level: 1 }, content: [{ type: 'text', text: 'Alpha' }] }
 ]
@@ -337,18 +356,14 @@ describe('MindMapView toolbar', () => {
     // Asked the same resolver a `[[…]]` in the note body goes through.
     expect(mocks.resolveWikiLink).toHaveBeenCalledWith('Roadmap')
 
-    const elements = mocks.toCanvasScene.mock.calls[0][0] as Array<{
-      type: string
-      link?: string
-      strokeStyle?: string
-    }>
+    const elements = mocks.toCanvasScene.mock.calls[0][0] as SavedElement[]
     // The saved box opens the note it names, on any device — not a node id only
     // this session could have understood — and it says so in words, because the
-    // canvas' own bubble prints the href verbatim unless the href names itself.
-    expect(elements.some((element) => element.link === 'memry://note/n2?label=Roadmap#Plan')).toBe(
-      true
-    )
-    expect(elements.every((element) => !element.link?.includes('#^'))).toBe(true)
+    // affordance a canvas renders for it has nothing but the href to read.
+    expect(
+      elements.some((element) => hrefOf(element) === 'memry://note/n2?label=Roadmap#Plan')
+    ).toBe(true)
+    expect(elements.every((element) => !hrefOf(element)?.includes('#^'))).toBe(true)
   })
 
   it('names every saved link, so a canvas hovers as words rather than as a URL', async () => {
@@ -370,25 +385,47 @@ describe('MindMapView toolbar', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save as canvas' }))
     await waitFor(() => expect(mocks.toCanvasScene).toHaveBeenCalledTimes(1))
 
-    const boxes = (
-      mocks.toCanvasScene.mock.calls[0][0] as Array<{ type: string; id: string; link?: string }>
-    ).filter((element) => element.type === 'rectangle')
+    const boxes = (mocks.toCanvasScene.mock.calls[0][0] as SavedElement[]).filter(
+      (element) => element.type === 'rectangle'
+    )
 
     // Every one of them, not just the interesting ones: a canvas with one URL
     // left in it still hovers as a URL.
     expect(boxes.length).toBeGreaterThan(0)
     for (const box of boxes) {
-      expect(new URL(box.link!).searchParams.get('label')).toBeTruthy()
+      expect(new URL(hrefOf(box)!).searchParams.get('label')).toBeTruthy()
     }
 
     const item = boxes.find((box) => box.id.endsWith('b-item'))!
     // The destination, as a chain: the section it lands in, then the row. The
     // separator is the only translated part.
-    expect(new URL(item.link!).searchParams.get('label')).toBe(
+    expect(new URL(hrefOf(item)!).searchParams.get('label')).toBe(
       '\u2026 \u2192 Q3 Risks \u2192 Hire a designer'
     )
     // And the label never disturbs the anchor, which is what actually resolves.
-    expect(item.link).toContain('#Q3%20Risks')
+    expect(hrefOf(item)).toContain('#Q3%20Risks')
+  })
+
+  it('leaves `element.link` empty, so no saved box wears the library glyph', async () => {
+    renderView([
+      {
+        id: 'b-h1',
+        type: 'heading',
+        props: { level: 1 },
+        content: [{ type: 'text', text: 'Q3 Risks' }]
+      }
+    ])
+    await screen.findByRole('toolbar')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as canvas' }))
+    await waitFor(() => expect(mocks.toCanvasScene).toHaveBeenCalledTimes(1))
+
+    // The glyph's only condition is `element.link`, hover-gated by nothing. A
+    // saved map keeps its href in `customData` for exactly that reason, and
+    // `CanvasEditor` renders the same hover affordance the drawn map does.
+    const elements = mocks.toCanvasScene.mock.calls[0][0] as SavedElement[]
+    expect(elements.some((element) => hrefOf(element) !== undefined)).toBe(true)
+    expect(elements.every((element) => element.link === undefined)).toBe(true)
   })
 
   it('hands the drawing a name for every box it drew, keyed the way a click arrives', async () => {

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
@@ -15,18 +15,21 @@
  *    save-to-disk file dialog.
  */
 
-import { act, fireEvent, render } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { buildMindMap } from '@/components/note/mind-map'
+import { mindMapDestinations } from '@/components/note/mind-map/mind-map-destination'
 import { mintSnapshotElements } from '@/components/note/mind-map/mind-map-snapshot'
+import type { MindMapBoxElement, MindMapElement } from '@/components/note/mind-map/mind-map-types'
 import { CanvasEditor } from './canvas-editor'
 import { clearCardTitleCache } from './canvas-link-target-title'
 
 interface FakeApi {
   getSceneElements: () => unknown[]
-  getAppState: () => { isLoading: boolean; selectedElementIds: Record<string, boolean> }
+  getAppState: () => Record<string, unknown>
+  onChange: (listener: () => void) => () => void
   getFiles: () => Record<string, unknown>
   scrollToContent: (...args: unknown[]) => void
   updateScene: (...args: unknown[]) => void
@@ -115,8 +118,22 @@ vi.mock('@excalidraw/excalidraw', () => ({
         getSceneElements: () => mocks.api.elements,
         getAppState: () => ({
           isLoading: mocks.api.isLoading,
-          selectedElementIds: mocks.api.selectedElementIds
+          selectedElementIds: mocks.api.selectedElementIds,
+          // The camera and the tool, which the node-link overlay reads before
+          // it will answer a hover. Identity camera: a client point is a scene
+          // point, so a test can aim at an element's own coordinates.
+          activeTool: { type: 'selection' },
+          selectedElementsAreBeingDragged: false,
+          resizingElement: null,
+          offsetLeft: 0,
+          offsetTop: 0,
+          scrollX: 0,
+          scrollY: 0,
+          zoom: { value: 1 }
         }),
+        // The overlay re-answers its hover on every committed change; nothing
+        // in these suites drives one, so the subscription only has to exist.
+        onChange: () => () => {},
         getFiles: () => ({}),
         scrollToContent: (...args: unknown[]) => mocks.scrollToContent(...args),
         updateScene: (...args: unknown[]) => mocks.updateScene(...args)
@@ -127,6 +144,12 @@ vi.mock('@excalidraw/excalidraw', () => ({
   },
   serializeAsJSON: (elements: unknown[], ...rest: unknown[]) =>
     mocks.serializeAsJSON(elements, ...rest),
+  // The identity camera the fake appState describes, so the overlay's hit test
+  // can be aimed with plain element coordinates.
+  viewportCoordsToSceneCoords: (point: { clientX: number; clientY: number }) => ({
+    x: point.clientX,
+    y: point.clientY
+  }),
   languages: [],
   defaultLang: { code: 'en' },
   // Library persistence is covered by the adapter's own tests; here it only
@@ -552,12 +575,13 @@ describe('CanvasEditor link opening', () => {
   /**
    * The receiving half of a saved mind map's links.
    *
-   * The href is not typed out here — it is minted by the real snapshot path, so
-   * this is the actual round trip: what the mind map WRITES into a canvas is
-   * what this editor READS back out of one. Typing the string by hand would let
-   * the two drift apart and still pass.
+   * Nothing here is typed out by hand — the scene is minted by the real
+   * snapshot path and the click goes through the real overlay, so this is the
+   * actual round trip: what the mind map WRITES into a canvas is what this
+   * editor READS back out of one. A hand-written href would let the two drift
+   * apart and still pass.
    */
-  it('lands a heading-anchored note link at that heading, not at the top', async () => {
+  function savedMindMap(): { elements: MindMapElement[]; listBox: MindMapBoxElement } {
     const map = buildMindMap(
       [
         {
@@ -576,15 +600,44 @@ describe('CanvasEditor link opening', () => {
     )
     const elements = mintSnapshotElements(map, { noteId: 'n1', generatedLabel: 'Snapshot' })
     const listBox = elements.find(
-      (element) => element.type === 'rectangle' && element.id === 'mm-b-li'
+      (element): element is MindMapBoxElement =>
+        element.type === 'rectangle' && element.id === 'mm-b-li'
     )
-    const href = listBox?.type === 'rectangle' ? listBox.link : undefined
+    if (!listBox) throw new Error('the saved map no longer draws a box for the list item')
+    return { elements, listBox }
+  }
+
+  /** Moves the pointer onto a box, which is what summons the overlay's card. */
+  function hover(box: MindMapBoxElement): void {
+    fireEvent.pointerMove(screen.getByTestId('excalidraw'), {
+      clientX: box.x + box.width / 2,
+      clientY: box.y + box.height / 2
+    })
+  }
+
+  /**
+   * The load-bearing half of "a saved map reads like the map it was saved
+   * from": the drawing library paints its permanent glyph off `element.link`,
+   * so a saved map must not put its href there.
+   */
+  it('leaves `element.link` empty on a saved map, so no box wears a glyph', () => {
+    const { elements } = savedMindMap()
+
+    for (const element of elements) {
+      expect(element).not.toHaveProperty('link')
+    }
+  })
+
+  it('lands a heading-anchored note link at that heading, not at the top', async () => {
+    const { elements, listBox } = savedMindMap()
     // A list item borrows the heading above it: heading TEXT is the only anchor
     // that still means anything on a device that never minted these block ids.
-    expect(href).toBe('memry://note/n1#Risks')
+    expect(listBox.customData?.memryHref).toBe('memry://note/n1#Risks')
+    mocks.api.elements = elements
 
     render(<CanvasEditor canvasId="c1" initialScene="" />)
-    clickLink(href!)
+    hover(listBox)
+    fireEvent.click(screen.getByTestId('canvas-node-link-card'))
     await act(async () => {})
 
     expect(mocks.openTab).toHaveBeenCalledWith(
@@ -594,6 +647,46 @@ describe('CanvasEditor link opening', () => {
         viewState: { headingText: 'Risks' }
       })
     )
+  })
+
+  it('names the destination on hover instead of printing the href', () => {
+    const map = buildMindMap(
+      [
+        {
+          id: 'b-h',
+          type: 'heading',
+          props: { level: 1 },
+          content: [{ type: 'text', text: 'Risks' }]
+        }
+      ],
+      { rootLabel: 'Roadmap', noteId: 'n1' }
+    )
+    const elements = mintSnapshotElements(map, {
+      noteId: 'n1',
+      generatedLabel: 'Snapshot',
+      labels: mindMapDestinations(map.nodes)
+    })
+    const headingBox = elements.find(
+      (element): element is MindMapBoxElement =>
+        element.type === 'rectangle' && element.id === 'mm-b-h'
+    )!
+    mocks.api.elements = elements
+
+    render(<CanvasEditor canvasId="c1" initialScene="" />)
+    hover(headingBox)
+
+    // The name the save froze into the href, read back out of it — never
+    // `memry://note/n1#Risks`.
+    expect(screen.getByTestId('canvas-node-link-card')).toHaveTextContent('Roadmap → Risks')
+  })
+
+  it('shows nothing over a shape that carries no map link', () => {
+    mocks.api.elements = [{ id: 'plain', type: 'rectangle', x: 0, y: 0, width: 50, height: 50 }]
+
+    render(<CanvasEditor canvasId="c1" initialScene="" />)
+    fireEvent.pointerMove(screen.getByTestId('excalidraw'), { clientX: 10, clientY: 10 })
+
+    expect(screen.queryByTestId('canvas-node-link-card')).toBeNull()
   })
 
   it('opens at the top when the link names a block, which this device never minted', async () => {

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
@@ -46,6 +46,7 @@ import { computeSceneSignature, createScenePersister } from './canvas-persistenc
 import { externalizeSceneAssets, retryCanvasAssetUploads } from './canvas-externalize'
 import { pickExcalidrawLangCode } from './excalidraw-lang'
 import { CanvasCardLayer } from './canvas-card-overlay'
+import { CanvasNodeLinkLayer } from './canvas-node-link-overlay'
 import { createVaultLibraryAdapter } from './canvas-library-adapter'
 import { extractEntityRefs, type CardElement } from './canvas-cards'
 import {
@@ -624,12 +625,9 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
    * links, when `isLocalLink` matches — assigns `window.location` and reloads
    * the entire app. Preventing the event's default is what disables both.
    */
-  const handleLinkOpen = useCallback<
-    NonNullable<React.ComponentProps<typeof Excalidraw>['onLinkOpen']>
-  >(
-    (element, event) => {
-      event.preventDefault()
-      const action = resolveCanvasLink(element.link, window.location.href)
+  const openHref = useCallback(
+    (href: string | null | undefined): void => {
+      const action = resolveCanvasLink(href, window.location.href)
 
       switch (action.kind) {
         case 'memry':
@@ -660,6 +658,16 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
       }
     },
     [openMemryTarget, t]
+  )
+
+  const handleLinkOpen = useCallback<
+    NonNullable<React.ComponentProps<typeof Excalidraw>['onLinkOpen']>
+  >(
+    (element, event) => {
+      event.preventDefault()
+      openHref(element.link)
+    },
+    [openHref]
   )
 
   /**
@@ -848,11 +856,17 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
         langCode={langCode}
       />
       {api ? (
-        <CanvasCardLayer
-          excalidrawAPI={api}
-          wrapperRef={wrapperRef}
-          onSceneMutated={() => persisterRef.current?.notifyChange()}
-        />
+        <>
+          <CanvasCardLayer
+            excalidrawAPI={api}
+            wrapperRef={wrapperRef}
+            onSceneMutated={() => persisterRef.current?.notifyChange()}
+          />
+          {/* A saved mind map's boxes keep their href out of `element.link`,
+              where the library would paint a glyph on every one of them; this
+              is the affordance they carry instead. */}
+          <CanvasNodeLinkLayer excalidrawAPI={api} wrapperRef={wrapperRef} onOpen={openHref} />
+        </>
       ) : null}
       <CanvasLinkDialog
         open={linkPickerOpen}

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-node-link-overlay.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-node-link-overlay.tsx
@@ -1,0 +1,188 @@
+/**
+ * The link affordance for a saved mind map's boxes.
+ *
+ * A canvas minted from a note's mind map (`mind-map-snapshot.ts`) carries each
+ * box's `memry://` href in `customData`, not in `element.link`. That is not a
+ * detail of the file format, it is the whole reason this file exists: the
+ * drawing library paints a permanent blue glyph on every element that has a
+ * `link`, hover-gated by nothing and suppressible by no prop, appState field or
+ * CSS surface. On a canvas where a handful of shapes are linked that glyph
+ * marks something. On a map, where every single box is, it marks nothing and
+ * buries the one thing the picture is for — its shape.
+ *
+ * So a saved map keeps its href where nothing paints it, and this layer renders
+ * what that field was buying: a hover card naming the destination, and a way to
+ * open it. Same hit test and same anchor math as the drawn map
+ * (`mind-map-hover.ts`), so a map reads the same way after it is saved as it
+ * did while it was drawn — which is the entire point.
+ *
+ * One thing is deliberately NOT the same. The drawn map is read-only, so the
+ * whole box is a click target there; here a box is a shape the user can select,
+ * drag, restyle and delete, and stealing its clicks would take the canvas away
+ * from them. The CARD is the control instead: hovering names the destination,
+ * clicking the card opens it.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { viewportCoordsToSceneCoords } from '@excalidraw/excalidraw'
+import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
+import { useT } from '@memry/i18n/renderer'
+import { Link } from '@/lib/icons'
+import {
+  hitMindMapBox,
+  mindMapHoverAnchor,
+  type MindMapHitElement
+} from '@/components/note/mind-map/mind-map-hover'
+import { linkBubbleLabel, truncateLabel } from './canvas-link-label'
+
+interface HoverState {
+  href: string
+  /** Pixels from the drawing surface's own origin. See `mindMapHoverAnchor`. */
+  x: number
+  y: number
+}
+
+/** The slice of a scene element this layer reads on top of the hit test's own. */
+type SceneElement = MindMapHitElement & { link?: string | null }
+
+interface CanvasNodeLinkLayerProps {
+  excalidrawAPI: ExcalidrawImperativeAPI
+  /** Wrapper element hosting the canvas — the pointer listeners attach here. */
+  wrapperRef: React.RefObject<HTMLDivElement | null>
+  /** Opens the href, through the editor's own link handling. */
+  onOpen: (href: string) => void
+}
+
+export const CanvasNodeLinkLayer = ({
+  excalidrawAPI,
+  wrapperRef,
+  onOpen
+}: CanvasNodeLinkLayerProps): React.JSX.Element | null => {
+  const { t } = useT('common')
+  const [hovered, setHovered] = useState<HoverState | null>(null)
+  /** Last seen pointer, so a pan or a zoom can re-answer without a mouse move. */
+  const pointerRef = useRef<{ clientX: number; clientY: number } | null>(null)
+  /** The card's own element, so a pointer that moved ONTO it is not a miss. */
+  const cardRef = useRef<HTMLButtonElement | null>(null)
+  const frameRef = useRef<number | null>(null)
+
+  /**
+   * The box under the last known pointer, or null.
+   *
+   * Read from the LIVE scene, and answered only while the canvas is idle: a
+   * pointer that is drawing, dragging or resizing is doing something to the
+   * document, and a card that appeared under it would be an invitation to
+   * misclick. An element that carries a real `element.link` as well is left to
+   * the library — that one has a glyph, and two affordances for one link is
+   * worse than either.
+   */
+  const hitAtPointer = useCallback((): HoverState | null => {
+    const pointer = pointerRef.current
+    if (!pointer) return null
+
+    const appState = excalidrawAPI.getAppState()
+    if (appState.activeTool.type !== 'selection') return null
+    if (appState.selectedElementsAreBeingDragged || appState.resizingElement) return null
+
+    const elements = excalidrawAPI.getSceneElements() as unknown as readonly SceneElement[]
+    const scene = viewportCoordsToSceneCoords(pointer, appState)
+    const hit = hitMindMapBox(
+      elements.filter((element) => !element.link),
+      scene
+    )
+    if (!hit) return null
+
+    const anchor = mindMapHoverAnchor(hit, appState)
+    return { href: hit.href, x: anchor.x, y: anchor.y }
+  }, [excalidrawAPI])
+
+  const syncHover = useCallback((): void => {
+    const next = hitAtPointer()
+    // Same box, same place — hand back the very same object so React does not
+    // re-render. Moving the pointer inside one node then costs nothing at all.
+    setHovered((current) =>
+      current && next && current.href === next.href && current.x === next.x && current.y === next.y
+        ? current
+        : next
+    )
+  }, [hitAtPointer])
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current
+    if (!wrapper) return
+
+    const onPointerMove = (event: PointerEvent): void => {
+      // The card sits over the surface, so a pointer on it reaches this
+      // listener too — and hit-testing there would answer "nothing", clearing
+      // the very card the pointer is travelling to.
+      if (event.target instanceof Node && cardRef.current?.contains(event.target)) return
+      pointerRef.current = { clientX: event.clientX, clientY: event.clientY }
+      syncHover()
+    }
+    const onPointerLeave = (): void => {
+      pointerRef.current = null
+      setHovered(null)
+    }
+
+    // Capture phase: these have to answer whatever the drawing surface does
+    // with the event afterwards.
+    wrapper.addEventListener('pointermove', onPointerMove, true)
+    wrapper.addEventListener('pointerleave', onPointerLeave)
+    return () => {
+      wrapper.removeEventListener('pointermove', onPointerMove, true)
+      wrapper.removeEventListener('pointerleave', onPointerLeave)
+    }
+  }, [syncHover, wrapperRef])
+
+  /**
+   * A pan, a zoom or a drag moves the drawing under a pointer that never moved,
+   * so the answer has to be recomputed from a change rather than from a mouse
+   * event. Coalesced onto a frame because the library reports every committed
+   * state change, a pan tick included, and each answer costs a scene read.
+   */
+  useEffect(() => {
+    const unsubscribe = excalidrawAPI.onChange(() => {
+      if (frameRef.current !== null) return
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null
+        syncHover()
+      })
+    })
+    return () => {
+      unsubscribe()
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current)
+      frameRef.current = null
+    }
+  }, [excalidrawAPI, syncHover])
+
+  if (!hovered) return null
+
+  // The label the href froze into itself when the map was saved. A box written
+  // before labels existed falls back to the href, which is the honest answer:
+  // it is all that box has ever carried.
+  const name = linkBubbleLabel(hovered.href) ?? truncateLabel(hovered.href)
+
+  return (
+    /* Clipped to the canvas so the card can never spill over the surrounding
+       chrome, and transparent to the pointer everywhere except on the card —
+       every other event has to reach the drawing surface underneath. */
+    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+      <button
+        ref={cardRef}
+        type="button"
+        data-testid="canvas-node-link-card"
+        aria-label={t('canvas.link.openTarget', { name })}
+        className="pointer-events-auto absolute z-10 flex max-w-[min(20rem,90%)] -translate-x-1/2 translate-y-2 cursor-pointer items-center gap-1.5 rounded-md border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md"
+        // Pixels on the drawing surface's own axes, whose origin is the same
+        // corner in either reading direction — geometry, not layout, so a
+        // logical inset here would put the card on the wrong side of an RTL
+        // canvas.
+        style={{ left: hovered.x, top: hovered.y }}
+        onClick={() => onOpen(hovered.href)}
+      >
+        <Link className="size-3.5 shrink-0 text-text-tertiary" />
+        <span className="truncate">{name}</span>
+      </button>
+    </div>
+  )
+}

--- a/apps/docs/src/user-guide/notes/mind-map.md
+++ b/apps/docs/src/user-guide/notes/mind-map.md
@@ -211,9 +211,12 @@ its heading, if the link named one — on any of your devices. If the link point
 at a note that does not exist yet, the node opens the source note at the section
 the link is written in instead, so it is never a dead box.
 
-Each link carries the name of what it opens, so hovering a node in the saved
-canvas shows `… → Q3 Risks` rather than the address behind it — including on a
-device that has never opened the note the map was made from.
+**The saved canvas reads like the map it came from.** Nothing marks a node until
+you point at one, and then the same small card appears under it naming what the
+click opens — `… → Q3 Risks` rather than the address behind it, including on a
+device that has never opened the note the map was made from. Click the card to
+go there. (On a canvas, unlike on the map, the box itself stays yours to select,
+drag and restyle; only the card opens the link.)
 
 **A "+N more" node stays in the saved canvas**, even though there is nothing for
 it to open in a document. It is what tells you the canvas is not the whole note,

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -320,6 +320,7 @@
       "groupProjects": "Projects",
       "groupFolders": "Folders",
       "useUrl": "Link to {url}",
+      "openTarget": "Open {name}",
       "shapeTarget": "A shape on this canvas",
       "missingTarget": "No longer on this canvas"
     },


### PR DESCRIPTION
## Summary

A map saved as a canvas wore the drawing library's permanent blue glyph on every single box — the very noise #1689 took off the drawn map, reintroduced the moment the map was saved. The two surfaces were meant to read the same; they did not.

**Before / after:** every card carried a blue link square in its top-right corner, visible without hovering → nothing marks a node until you point at one, and then the same hover card the drawn map shows appears under it, naming the destination.

### What changed

- **The snapshot keeps its href where the drawn map keeps its** — `customData.memryHref`, never `element.link`. That field is the glyph's only condition (`element.link && !selected`): hover-gated by nothing, suppressible by no prop, `appState` field or CSS surface. A map is nothing but linked boxes, so one glyph per box marks nothing and buries the shape the picture is for.
- **`CanvasEditor` renders the affordance instead** — new `canvas-node-link-overlay.tsx`, off the same key, the same hit test and the same anchor math the drawn map uses (`mind-map-hover.ts`). The name comes from the `?label=` the href already carries (#1689), read back through `linkBubbleLabel` — the same reader the canvas' own link bubble uses, so a hand-made link and a saved map's link are named by one rule.
- **One thing is deliberately NOT the same.** The drawn map is read-only, so the whole box is a click target there. In a canvas a box is a shape the user can select, drag, restyle and delete, and stealing its clicks would take the document away from them — so the **card** is the control: hover names the destination, clicking the card opens it. The card yields to a real `element.link` and stays down while a tool is active or something is being dragged or resized.
- **The agent-facing read follows the href, not the field.** `readSceneElements` reports `customData.memryHref` as the element's `link` when there is no `link`, so an MCP reader still learns what a box points at. A real `link` still wins.

### Compatibility

Stated rather than hidden:

- **Canvases saved BEFORE this change are untouched.** They keep their `element.link`, their glyph and their bubble. Rewriting a document the user owns is not ours to do — to get the new presentation on an existing map, save it again.
- **A build that predates this overlay** opens one of these canvases and sees boxes it cannot click. Nothing is lost and nothing is corrupted — the href is right there in the file, and the build that wrote it is the build that reads it — but a downgrade is a picture until it upgrades again.

No IPC contract, no migration, no sync handler, no settings change.

## Release note

A mind map saved as a canvas now reads like the map it came from: no permanent link marker on every card, and pointing at a node names where the click goes.

## Test plan

- `pnpm --filter @memry/desktop typecheck` (node + web + test)
- `pnpm lint` — 0 errors
- `pnpm --filter @memry/desktop i18n:check`
- `pnpm check:architecture`
- renderer suites for `components/note/mind-map` + `pages/canvas` — 642 passed
- main suites for `main/canvas` — 338 passed
- `pnpm docs:impact --base 8ad65dec8 --strict`, `pnpm docs:build`

New coverage:

- the saved scene carries a href on its boxes and `element.link` on none of them (both the minting side and the editor side, minted by the real snapshot path rather than hand-written)
- hovering a saved box names the destination instead of printing the href
- clicking the card lands a heading-anchored link at that heading
- nothing appears over a shape carrying no map link
- `readSceneElements` reports a map box's href, and prefers a real `link` over it
