### PR TITLE
Tables: row and column actions from the keyboard

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -3892,6 +3892,24 @@ del.bn-inline-content {
 }
 
 /*
+ * The anchor the keyboard menu hangs from: a box over the caret's cell, with no
+ * paint and no pointer of its own.
+ *
+ * It exists only while that menu is open. Radix positions the dropdown against
+ * its trigger and returns focus to it on `Escape`, so the trigger has to be a
+ * real element in the table's own coordinates — but the cell underneath it is
+ * still being typed in, so it must never take a click or show a cursor.
+ */
+.memry-table-keyboard-anchor {
+  position: absolute;
+  z-index: 8;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  pointer-events: none;
+}
+
+/*
  * The focused cell's inline-end border carries our cell nub AND
  * prosemirror-tables' column-resize grab zone. The resize cursor and drag win
  * the pointer, which makes the nub hard to hit, so while a cell holds the

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -132,7 +132,11 @@ vi.mock('@blocknote/react', () => ({
     Provider: ({ children }: { children: React.ReactNode }) => children
   },
   TableCellMenu: () => <div data-testid="table-cell-menu" />,
-  TableHandleMenu: () => <div data-testid="table-handle-menu" />
+  TableHandleMenu: () => <div data-testid="table-handle-menu" />,
+  // The keyboard menu's items, for the same reason: it only renders once the
+  // caret is measured inside a cell, which needs layout jsdom does not have.
+  AddButton: () => <div data-testid="table-add-button" />,
+  DeleteButton: () => <div data-testid="table-delete-button" />
 }))
 
 vi.mock('sonner', () => ({

--- a/apps/desktop/src/renderer/src/components/note/content-area/table-border-handles.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/table-border-handles.tsx
@@ -11,7 +11,9 @@ import {
 import { createPortal } from 'react-dom'
 import { TableHandlesExtension } from '@blocknote/core/extensions'
 import {
+  AddButton,
   ComponentsContext,
+  DeleteButton,
   TableCellMenu,
   TableHandleMenu,
   useBlockNoteEditor,
@@ -20,6 +22,9 @@ import {
   useEditorSelectionChange,
   useExtension
 } from '@blocknote/react'
+import { useT } from '@memry/i18n/renderer'
+
+import { isTableMenuShortcut } from './table-keyboard-menu'
 
 /**
  * Table row/column/cell handles that sit ON the table's own border lines.
@@ -66,7 +71,10 @@ import {
  *
  * Separately from all of this, and driven by the caret rather than the pointer,
  * the cell holding the selection is ringed in the user's accent — see
- * `measureFocus`.
+ * `measureFocus`, and gets the row and column actions on a keyboard shortcut —
+ * see `openKeyboardMenu`. Hover is not a gesture every user has: without that
+ * shortcut, adding a row or deleting a column is unreachable by keyboard and by
+ * touch alike.
  */
 
 /**
@@ -126,6 +134,9 @@ const SHIELD_ATTR = 'data-memry-table-resize-shield'
 
 /** Marks a menu that was moved out of the wrapper, for its layer in base.css. */
 const MENU_CLASS = 'memry-table-menu'
+
+/** The `openBarRef` pin for the keyboard's menu, which belongs to no bar. */
+const KEYBOARD_MENU_KEY = 'keyboard'
 
 const CELL_SELECTOR = '[data-content-type="table"] td, [data-content-type="table"] th'
 
@@ -350,6 +361,7 @@ export const TableBorderHandles: FC<TableBorderHandlesProps> = ({ containerEl })
   const components = useComponentsContext()
   const tableHandles = useExtension(TableHandlesExtension)
 
+  const { t } = useT('notes')
   const hoveredCellRef = useRef<HTMLTableCellElement | null>(null)
   /**
    * The cell the caret is in — the one the resize shield covers.
@@ -361,6 +373,9 @@ export const TableBorderHandles: FC<TableBorderHandlesProps> = ({ containerEl })
   const focusCellRef = useRef<HTMLTableCellElement | null>(null)
   const [geometry, setGeometry] = useState<Geometry | null>(null)
   const [focusRing, setFocusRing] = useState<FocusRing | null>(null)
+  const keyboardTriggerRef = useRef<HTMLButtonElement | null>(null)
+  /** Whether the keyboard menu is up, for the anchor's own focus handler. */
+  const keyboardMenuOpenRef = useRef(false)
   /**
    * The bar whose menu is open, or null. While a menu is open the bars are
    * pinned to the cell it was opened from: the pointer is over the menu, which
@@ -473,6 +488,94 @@ export const TableBorderHandles: FC<TableBorderHandlesProps> = ({ containerEl })
     [editor, tableHandles]
   )
 
+  /**
+   * Open the row/column menu on the caret's cell, from the keyboard.
+   *
+   * The nubs are raised by hover and are not in the tab order, so without this
+   * every row and column action is mouse-only — a keyboard-only user cannot add
+   * a row or delete a column at all (#1661), and neither can a touch user, who
+   * has no hover either.
+   *
+   * Aiming is the same as the mouse path's: replay a `mousemove` on the cell so
+   * `TableHandlesExtension`'s own plugin view names it, then freeze while the
+   * menu is up. The menu's items read their row and column indices from that
+   * state, not from a prop.
+   *
+   * Opening it is a `pointerdown` on the anchor, not a synthetic `Enter` on it,
+   * even though Radix opens on either: the anchor lives inside the table, so a
+   * bubbling `Enter` reaches ProseMirror's own keydown handler on the way out
+   * and splits the block under the caret. `pointerdown` is inert for
+   * ProseMirror, and `fakeEvent` is the flag `@blocknote/shadcn`'s trigger
+   * wrapper looks for to let one through to Radix.
+   */
+  const openKeyboardMenu = useCallback((): boolean => {
+    const cell = focusCellRef.current
+    const trigger = keyboardTriggerRef.current
+    if (!cell?.isConnected || !trigger) return false
+
+    pointExtensionAtCell(cell)
+    tableHandles.freezeHandles()
+    const press = new PointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 0 })
+    ;(press as PointerEvent & { fakeEvent?: boolean }).fakeEvent = true
+    trigger.dispatchEvent(press)
+    return true
+  }, [tableHandles])
+
+  const handleKeyboardOpenChange = useCallback(
+    (open: boolean): void => {
+      keyboardMenuOpenRef.current = open
+      if (open) {
+        // Same pin as a nub's menu: hover bookkeeping must not tear anything
+        // down while this menu, portalled outside the editor, holds the pointer.
+        openBarRef.current = KEYBOARD_MENU_KEY
+        return
+      }
+
+      tableHandles.unfreezeHandles()
+      openBarRef.current = null
+      // Focus is handed back by `handleAnchorFocus`, not from here: Radix
+      // restores it to the trigger on its own schedule, and a `focus()` racing
+      // that lands nowhere.
+    },
+    [tableHandles]
+  )
+
+  /**
+   * Hand focus on from the anchor to the editor.
+   *
+   * Radix focuses the trigger when the menu closes, however it was closed —
+   * `Escape`, an item, or a click outside. The trigger is a box over a cell, not
+   * a place a caret can live, so it passes focus straight on: the ProseMirror
+   * selection never moved, so the caret lands back in the cell the menu was
+   * opened from, which is what `Escape` has to do.
+   *
+   * Only while the menu is CLOSED. Radix's focus scope pulls focus back into an
+   * open menu, so bouncing it out from here turns every arrow key into a fight:
+   * focus leaves for the editor, the scope hauls it back to the menu's own box,
+   * and the highlight starts again from the first item.
+   */
+  const handleAnchorFocus = useCallback((): void => {
+    if (keyboardMenuOpenRef.current) return
+    editor.focus()
+  }, [editor])
+
+  useEffect(() => {
+    if (!containerEl) return
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (openBarRef.current) return
+      if (!isTableMenuShortcut(event)) return
+      if (!openKeyboardMenu()) return
+      // Capture phase, so this lands before ProseMirror's own handler on
+      // `view.dom` — `Mod+Shift+Enter` must not also split the cell.
+      event.preventDefault()
+      event.stopPropagation()
+    }
+
+    containerEl.addEventListener('keydown', handleKeyDown, true)
+    return () => containerEl.removeEventListener('keydown', handleKeyDown, true)
+  }, [containerEl, openKeyboardMenu])
+
   useEffect(() => {
     if (!containerEl) return
 
@@ -545,9 +648,10 @@ export const TableBorderHandles: FC<TableBorderHandlesProps> = ({ containerEl })
           className="memry-table-handles"
           contentEditable={false}
           suppressContentEditableWarning
-          // Pointer-only, by design: the bars are raised by hover and are not in
-          // the tab order, so announcing them would offer a control no keyboard
-          // can reach. Reaching these menus from the keyboard is #1661.
+          // Pointer-only, by design: the bars are raised by hover and are not
+          // in the tab order, so announcing them would offer a control no
+          // keyboard can reach. The keyboard has its own way to the same
+          // actions — see `keyboardMenu` below.
           aria-hidden="true"
         >
           {geometry.bars.map((bar) => (
@@ -607,6 +711,70 @@ export const TableBorderHandles: FC<TableBorderHandlesProps> = ({ containerEl })
     )
   }
 
+  /**
+   * The keyboard's way into the row and column actions.
+   *
+   * One menu rather than the pointer's two, because a keyboard has no cell to
+   * point at: the caret's cell names both a row and a column at once, so both
+   * sets of actions belong in the menu that cell opens. The items are
+   * BlockNote's own `AddButton` / `DeleteButton`, so the edits and their labels
+   * are the same ones the nubs perform.
+   *
+   * Mounted for as long as the caret is in a cell, not raised by the shortcut:
+   * Radix opens a dropdown from an event on its trigger, so the trigger has to
+   * already be there when the key is pressed. It is a box over that cell which
+   * takes no pointer events and paints nothing — the cell under it is still
+   * being typed in.
+   */
+  let keyboardMenu: ReactNode = null
+  if (focusRing && menuComponents) {
+    const { Root, Trigger, Dropdown, Divider, Label } = menuComponents.Generic.Menu
+    // 1-based: the row and column a person counts, not the array index.
+    const position = { row: focusRing.rowIndex + 1, column: focusRing.colIndex + 1 }
+    keyboardMenu = createPortal(
+      <ComponentsContext.Provider value={menuComponents}>
+        <Root onOpenChange={handleKeyboardOpenChange}>
+          <Trigger>
+            <button
+              ref={keyboardTriggerRef}
+              type="button"
+              tabIndex={-1}
+              className="memry-table-keyboard-anchor"
+              data-memry-table-keyboard-anchor=""
+              data-row-index={focusRing.rowIndex}
+              data-col-index={focusRing.colIndex}
+              contentEditable={false}
+              suppressContentEditableWarning
+              onFocus={handleAnchorFocus}
+              // Radix names the dropdown after its trigger, so the row and
+              // column reach a screen reader as the menu's own name.
+              aria-label={t('editor.table.keyboardMenuAria', position)}
+              style={{
+                insetInlineStart: `${focusRing.inlineStart}px`,
+                insetBlockStart: `${focusRing.blockStart}px`,
+                inlineSize: `${focusRing.inlineSize}px`,
+                blockSize: `${focusRing.blockSize}px`
+              }}
+            />
+          </Trigger>
+          {/* `@blocknote/shadcn`'s dropdown forwards className and nothing
+            else, so the class is also what names this menu in the E2E. */}
+          <Dropdown className="bn-table-handle-menu memry-table-keyboard-menu">
+            <Label>{t('editor.table.keyboardMenuTitle', position)}</Label>
+            <DeleteButton orientation="row" />
+            <AddButton orientation="row" side="above" />
+            <AddButton orientation="row" side="below" />
+            <Divider />
+            <DeleteButton orientation="column" />
+            <AddButton orientation="column" side="left" />
+            <AddButton orientation="column" side="right" />
+          </Dropdown>
+        </Root>
+      </ComponentsContext.Provider>,
+      focusRing.wrapper
+    )
+  }
+
   return (
     <>
       {focusRing &&
@@ -649,6 +817,7 @@ export const TableBorderHandles: FC<TableBorderHandlesProps> = ({ containerEl })
           focusRing.wrapper
         )}
       {handles}
+      {keyboardMenu}
     </>
   )
 }

--- a/apps/desktop/src/renderer/src/components/note/content-area/table-keyboard-menu.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/table-keyboard-menu.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+
+import { isTableMenuShortcut } from './table-keyboard-menu'
+
+/**
+ * The predicate is asserted on its own because the thing it guards is a
+ * capture-phase listener inside a live editor: a combination that also reaches
+ * ProseMirror splits the cell under the caret, and a combination that is never
+ * matched leaves the row and column actions mouse-only (#1661).
+ */
+const press = (init: Partial<KeyboardEventInit> & { key: string }): KeyboardEvent =>
+  new KeyboardEvent('keydown', init)
+
+describe('isTableMenuShortcut', () => {
+  it('takes the three keys that open a context menu', () => {
+    expect(isTableMenuShortcut(press({ key: 'ContextMenu' }))).toBe(true)
+    expect(isTableMenuShortcut(press({ key: 'F10', shiftKey: true }))).toBe(true)
+    // The one a MacBook can actually send: its F10 is a media key.
+    expect(isTableMenuShortcut(press({ key: 'Enter', shiftKey: true, metaKey: true }))).toBe(true)
+    expect(isTableMenuShortcut(press({ key: 'Enter', shiftKey: true, ctrlKey: true }))).toBe(true)
+  })
+
+  it('leaves the keys the editor itself owns alone', () => {
+    // A plain Enter in a cell, and Shift+Enter, are ProseMirror's.
+    expect(isTableMenuShortcut(press({ key: 'Enter' }))).toBe(false)
+    expect(isTableMenuShortcut(press({ key: 'Enter', shiftKey: true }))).toBe(false)
+    // Mod+Enter is BlockNote's, and Mod+Enter without Shift must stay so.
+    expect(isTableMenuShortcut(press({ key: 'Enter', metaKey: true }))).toBe(false)
+    expect(isTableMenuShortcut(press({ key: 'F10' }))).toBe(false)
+    expect(isTableMenuShortcut(press({ key: 'a', shiftKey: true, metaKey: true }))).toBe(false)
+  })
+
+  it('ignores anything carrying Alt, which is a different keystroke', () => {
+    expect(
+      isTableMenuShortcut(press({ key: 'Enter', shiftKey: true, metaKey: true, altKey: true }))
+    ).toBe(false)
+    expect(isTableMenuShortcut(press({ key: 'F10', shiftKey: true, altKey: true }))).toBe(false)
+    expect(isTableMenuShortcut(press({ key: 'ContextMenu', altKey: true }))).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/table-keyboard-menu.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/table-keyboard-menu.ts
@@ -1,0 +1,28 @@
+/**
+ * Which keypress opens the table's row/column menu from the caret's cell.
+ *
+ * A pure predicate rather than a branch inside the overlay so the combination
+ * can be asserted without a live editor — see `table-keyboard-menu.test.ts`.
+ *
+ * Three keys, because no single one reaches every keyboard:
+ *   - `ContextMenu`, the dedicated key on a full PC keyboard
+ *   - `Shift+F10`, the same request on a keyboard without that key. On a Mac
+ *     with the default function-key setting this is a media key and never
+ *     reaches the renderer, which is why it is not the only binding
+ *   - `Mod+Shift+Enter`, the one that works on every keyboard including a
+ *     MacBook's. `Mod-Shift-Enter` is unbound in BlockNote 0.47 (its own
+ *     `Mod-Shift-*` keys are the list types, 6 through 9) and in
+ *     prosemirror-tables
+ *
+ * All three are only read while the caret is inside a table cell; anywhere else
+ * the event is left alone.
+ */
+export function isTableMenuShortcut(event: KeyboardEvent): boolean {
+  if (event.altKey) return false
+
+  if (event.key === 'ContextMenu') return !event.metaKey && !event.ctrlKey
+
+  if (event.key === 'F10') return event.shiftKey && !event.metaKey && !event.ctrlKey
+
+  return event.key === 'Enter' && event.shiftKey && (event.metaKey || event.ctrlKey)
+}

--- a/apps/desktop/tests/e2e/table-border-handles.e2e.ts
+++ b/apps/desktop/tests/e2e/table-border-handles.e2e.ts
@@ -666,4 +666,177 @@ test.describe('Table border handles', () => {
         ['B1', 'B3']
       ])
   })
+
+  test('a keyboard alone can add a row and delete a column', async ({ page }) => {
+    // #given a note holding a 3x3 table whose every cell is separately named,
+    // so acting on the neighbouring row or column shows up as the wrong name
+    // surviving rather than as a count that happens to match
+    const note = await createNote(page, `Table Keyboard Menu ${Date.now()}`)
+    await openNoteByHandle(page, note)
+    await setDocument(page, GRID_DOC)
+
+    const editor = page.locator(SELECTORS.noteEditor).first()
+    const rows = editor.locator('table tr')
+    await expect(rows).toHaveCount(3, { timeout: 15_000 })
+
+    /**
+     * The caret has to start somewhere, and the editor is only reachable by
+     * clicking into it. Everything after this first click is keys: the cell the
+     * menu acts on is reached with arrows, so a menu that read the CLICKED cell
+     * instead of the caret's would act on H1 and be caught.
+     */
+    await rows.nth(0).locator('th, td').nth(0).click({ position: IN_CELL })
+
+    const anchor = page.locator('[data-memry-table-keyboard-anchor]')
+    const menu = page.locator('.memry-table-keyboard-menu')
+
+    /**
+     * The label of the menu item that currently holds the focus, or '' while
+     * the focus is still on the menu's own box.
+     */
+    const focusedItem = (): Promise<string> =>
+      page.evaluate(() => {
+        const active = document.activeElement
+        if (active?.getAttribute('data-slot') !== 'dropdown-menu-item') return ''
+        return (active.textContent ?? '').trim()
+      })
+
+    /**
+     * Walk the menu with ArrowDown until `label` holds the focus, then run it.
+     *
+     * Each press waits for the highlight to actually move: Radix moves the
+     * focus a frame after the key, and pressing again before it lands leaves
+     * the walk stuck on the first item.
+     */
+    const runByKeyboard = async (label: string): Promise<void> => {
+      const trail: string[] = []
+      for (let step = 0; step < 12; step += 1) {
+        const here = await focusedItem()
+        if (here === label) {
+          await page.keyboard.press('Enter')
+          return
+        }
+        trail.push(here || '(menu)')
+        await page.keyboard.press('ArrowDown')
+        await expect.poll(focusedItem, { timeout: 5_000 }).not.toBe(here)
+      }
+      throw new Error(`${label} never took the focus. Walked: ${trail.join(' -> ')}`)
+    }
+
+    // #when the caret is walked to A2 — row 1, column 1 — with the keys that
+    // move between cells. ArrowRight would walk the text inside a cell first;
+    // Tab is the one that crosses a cell boundary in one press.
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('Tab')
+    await expect(anchor).toHaveAttribute('data-row-index', '1', { timeout: 10_000 })
+    await expect(anchor).toHaveAttribute('data-col-index', '1')
+
+    // #and the table menu is asked for with the keyboard
+    await page.keyboard.press('ControlOrMeta+Shift+Enter')
+    await expect(menu).toBeVisible({ timeout: 10_000 })
+
+    // #then the menu names the cell it will act on, counted the way a person
+    // counts, and Radix hands that name to the dropdown as its own
+    await expect(menu).toContainText('Row 2 · Column 2')
+    await expect(menu).toHaveAttribute('aria-labelledby', /.+/)
+    const menuName = await menu.evaluate((element) => {
+      const id = element.getAttribute('aria-labelledby')
+      return id ? (document.getElementById(id)?.getAttribute('aria-label') ?? '') : ''
+    })
+    expect(menuName).toBe('Table actions for row 2, column 2')
+
+    // #and the caret's own Enter never reached the editor: the cell still holds
+    // the one line it started with
+    expect(textGrid(await tableShape(page))[1][1]).toBe('A2')
+
+    // #when "Add row below" is reached with arrows and run with Enter
+    await runByKeyboard('Add row below')
+
+    // #then the new row is under A, not under the header and not at the end
+    await expect
+      .poll(async () => textGrid(await tableShape(page)))
+      .toEqual([
+        ['H1', 'H2', 'H3'],
+        ['A1', 'A2', 'A3'],
+        ['', '', ''],
+        ['B1', 'B2', 'B3']
+      ])
+
+    // #when the same is done for the middle COLUMN, from a fresh table
+    await setDocument(page, GRID_DOC)
+    await expect(rows).toHaveCount(3, { timeout: 15_000 })
+    await rows.nth(0).locator('th, td').nth(0).click({ position: IN_CELL })
+    // Replacing the document drops the caret, and with it the anchor; wait for
+    // the click to put both back before the keys start.
+    await expect(anchor).toHaveCount(1, { timeout: 10_000 })
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('Tab')
+    await expect(anchor).toHaveAttribute('data-col-index', '1', { timeout: 10_000 })
+    await page.keyboard.press('ControlOrMeta+Shift+Enter')
+    await expect(menu).toBeVisible({ timeout: 10_000 })
+    await runByKeyboard('Delete column')
+
+    // #then column 1 is the column that went, in every row
+    await expect
+      .poll(async () => textGrid(await tableShape(page)))
+      .toEqual([
+        ['H1', 'H3'],
+        ['A1', 'A3'],
+        ['B1', 'B3']
+      ])
+  })
+
+  test('Escape closes the keyboard menu and hands the caret back to its cell', async ({ page }) => {
+    // #given a note holding a 3x3 table, with the caret walked into A2
+    const note = await createNote(page, `Table Keyboard Escape ${Date.now()}`)
+    await openNoteByHandle(page, note)
+    await setDocument(page, GRID_DOC)
+
+    const editor = page.locator(SELECTORS.noteEditor).first()
+    const rows = editor.locator('table tr')
+    await expect(rows).toHaveCount(3, { timeout: 15_000 })
+    await rows.nth(0).locator('th, td').nth(0).click({ position: IN_CELL })
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('Tab')
+    // `Tab` crosses into the next cell with that cell's text SELECTED — that is
+    // prosemirror-tables' own `goToNextCell`. Collapse it to a caret at the end,
+    // so what lands after `Escape` is an insertion and not a replacement.
+    await page.keyboard.press('ArrowRight')
+
+    const menu = page.locator('.memry-table-keyboard-menu')
+
+    // #when the menu is opened and then dismissed with Escape
+    await page.keyboard.press('ControlOrMeta+Shift+Enter')
+    await expect(menu).toBeVisible({ timeout: 10_000 })
+    await page.keyboard.press('Escape')
+    await expect(menu).toHaveCount(0, { timeout: 10_000 })
+
+    // #then the table is untouched, and typing lands back in the cell the menu
+    // was opened from — a caret left on the closed menu's trigger would put
+    // these characters nowhere
+    // #and the focus is back inside the editor itself, not left on the box the
+    // menu hung from
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const active = document.activeElement
+            if (!active) return 'none'
+            if (active.hasAttribute('data-memry-table-keyboard-anchor')) return 'anchor'
+            return active.closest('.bn-editor') ? 'editor' : 'elsewhere'
+          }),
+        { timeout: 10_000 }
+      )
+      .toBe('editor')
+
+    await page.keyboard.type('zz')
+    await expect
+      .poll(async () => textGrid(await tableShape(page))[1][1], { timeout: 10_000 })
+      .toBe('A2zz')
+    expect(textGrid(await tableShape(page))).toEqual([
+      ['H1', 'H2', 'H3'],
+      ['A1', 'A2zz', 'A3'],
+      ['B1', 'B2', 'B3']
+    ])
+  })
 })

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -61,6 +61,18 @@ A chord indicator briefly flashes when the prefix is active.
 | Open block menu  | Type `/`                               |
 | Find in page     | <kbd>⌘</kbd>+<kbd>F</kbd>              |
 
+With the cursor inside a table cell:
+
+| Action                 | Shortcut                                                                                 |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| Next / previous cell   | <kbd>Tab</kbd> / <kbd>⇧</kbd>+<kbd>Tab</kbd>                                             |
+| Row and column actions | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>Enter</kbd>, <kbd>⇧</kbd>+<kbd>F10</kbd>, or Context Menu |
+
+The menu holds Delete row, Add row above / below, Delete column and Add column
+left / right, is named after the cell it acts on, and returns the cursor to that
+cell on <kbd>Esc</kbd>. See
+[Editing notes](./notes/editing.md#row-and-column-actions-from-the-keyboard).
+
 ## View
 
 | Action                         | Shortcut                                  |

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -87,6 +87,23 @@ Backspace clears what is inside them and leaves the table standing. To select
 the table itself as a block — to move it or delete it whole — start the drag in
 the margin beside it rather than inside a cell.
 
+### Row and column actions from the keyboard
+
+The marks are raised by hover, which a keyboard and a touch screen do not have.
+With the cursor in a cell, press **Ctrl/Cmd + Shift + Enter** — or **Shift + F10**,
+or the **Context Menu** key — to open one menu holding both sets of actions:
+
+- Delete row, Add row above, Add row below
+- Delete column, Add column left, Add column right
+
+The menu is titled with the cell it will act on (`Row 2 · Column 2`, counting
+from one and counting the header row), and a screen reader announces the same
+row and column as the menu's name. Move through it with the arrow keys, run an
+item with Enter, and press **Escape** to close it — the cursor returns to the
+cell it was opened from.
+
+Cell colours and splitting or merging stay on the cell mark for now.
+
 ### Cell colour and formatting
 
 Open a cell's right-hand mark and choose **Colors** to set that cell's text or

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -129,6 +129,10 @@
       "listPlaceholder": "List item",
       "todoPlaceholder": "To-do item"
     },
+    "table": {
+      "keyboardMenuAria": "Table actions for row {row}, column {column}",
+      "keyboardMenuTitle": "Row {row} · Column {column}"
+    },
     "list": {
       "bulleted": "Bulleted list",
       "numbered": "Numbered list",


### PR DESCRIPTION
Closes #1661

## Problem

A table's row and column actions — Delete row, Add row above/below, Delete column, Add column left/right — lived only on the hover nubs. No hover, no actions: a keyboard-only user could not add a row or delete a column at all, and neither could a touch user. `PRODUCT.md` commits to WCAG AA, and this was a function with no keyboard path whatsoever.

## What this does

The caret's cell now carries an anchor of its own — a box over that cell with no paint and no pointer events — and three keys open one menu on it:

- <kbd>Mod</kbd>+<kbd>Shift</kbd>+<kbd>Enter</kbd> — the one every keyboard can send (a MacBook's F10 is a media key)
- <kbd>Shift</kbd>+<kbd>F10</kbd> and the <kbd>Context Menu</kbd> key — the OS convention for "menu for the focused thing"

One menu, not the pointer's two: a keyboard has no cell to point at, and the caret's cell names a row and a column at once, so both axes' actions belong together. The items are BlockNote's own `AddButton` / `DeleteButton`, so the edits and the labels are exactly the ones the nubs already perform.

- The menu is titled `Row 2 · Column 2` and Radix names the dropdown after its trigger, so a screen reader announces the same row and column as the menu's name.
- Arrow keys walk it, Enter runs an item, <kbd>Esc</kbd> closes it and hands the caret back to the cell it was opened from.
- Cell colours and split/merge stay on the cell nub — out of scope here, which is row and column actions.

## Decisions worth reviewing

- **Opening is a synthetic `pointerdown`, not a synthetic `Enter`.** The anchor lives inside the table, so a bubbling `Enter` reaches ProseMirror's keydown handler on the way out and splits the block under the caret. `pointerdown` is inert for ProseMirror, and `fakeEvent` is the flag `@blocknote/shadcn`'s trigger wrapper looks for.
- **The anchor is mounted for as long as the caret is in a cell**, not raised by the shortcut: Radix opens a dropdown from an event on a trigger that already exists.
- **The anchor bounces focus to the editor only while the menu is closed.** Radix's focus scope pulls focus back into an open menu, so bouncing it out unconditionally turned every arrow key into a fight and left the highlight stuck on the first item.
- The shortcut listener is capture-phase on the editor container, so `Mod+Shift+Enter` never also reaches ProseMirror.

## Verification

- `pnpm --filter @memry/desktop test:renderer` — green (new `table-keyboard-menu.test.ts` covers the shortcut predicate, including the combinations the editor itself owns)
- `pnpm typecheck`, `pnpm lint`, `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build` — green
- E2E: three keyboard-only journeys in `table-border-handles.e2e.ts` (add a row, delete a column, Escape returns the caret) — running; the PR stays draft until they are green.