### PR TITLE
Sidebar notes tree: Finder-style arrow-key navigation

### DIFF
--- a/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.test.tsx
+++ b/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.test.tsx
@@ -242,6 +242,11 @@ describe('TreeProvider and tree primitives', () => {
     fireEvent.keyDown(root, { key: 'ArrowDown' })
     expect(screen.getByTestId('selected')).toHaveTextContent('child-a')
 
+    // A right-click leaves focus where it was, which used to strand the arrows
+    // on the sidebar's scroll container.
+    fireEvent.contextMenu(root)
+    expect(root).toHaveFocus()
+
     fireEvent.keyDown(childA, { key: 'ArrowRight' })
     expect(screen.getByText('Grandchild')).toBeInTheDocument()
 

--- a/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.tsx
+++ b/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.tsx
@@ -855,6 +855,9 @@ export const TreeNodeTrigger = ({
               onClick?.(e)
             }}
             onFocus={() => setFocusedId(nodeId)}
+            // A context-menu click does not focus the row on its own, so
+            // arrow navigation had nothing to start from once the menu closed.
+            onContextMenu={() => triggerRef.current?.focus()}
             onKeyDown={handleKeyDown}
             onDragStartCapture={handleDragStart as unknown as React.DragEventHandler}
             onDragEndCapture={handleDragEnd}

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.test.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.test.tsx
@@ -704,4 +704,92 @@ describe('VirtualizedNotesTree', () => {
     rafSpy.mockRestore()
     cancelSpy.mockRestore()
   })
+  describe('Finder-style arrow navigation', () => {
+    const row = (label: string) =>
+      screen.getByText(label).closest('[role="treeitem"]') as HTMLElement
+
+    it('walks down and up the visible rows, selecting as it goes', () => {
+      const props = renderTree()
+
+      const work = row('Work')
+      work.focus()
+
+      fireEvent.keyDown(work, { key: 'ArrowDown' })
+      expect(props.onSelectionChange).toHaveBeenLastCalledWith(['note-work'])
+      expect(row('Alpha')).toHaveFocus()
+
+      fireEvent.keyDown(row('Alpha'), { key: 'ArrowUp' })
+      expect(props.onSelectionChange).toHaveBeenLastCalledWith(['folder-Work'])
+      expect(row('Work')).toHaveFocus()
+    })
+
+    it('opens a closed folder with Right and closes it with Left', () => {
+      localStorage.setItem('sidebar-tree-expanded', JSON.stringify([]))
+      renderTree()
+
+      expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
+
+      fireEvent.keyDown(row('Work'), { key: 'ArrowRight' })
+      expect(screen.getByText('Alpha')).toBeInTheDocument()
+
+      // Second Right steps into the folder rather than reopening it.
+      fireEvent.keyDown(row('Work'), { key: 'ArrowRight' })
+      expect(row('Alpha')).toHaveFocus()
+
+      fireEvent.keyDown(row('Work'), { key: 'ArrowLeft' })
+      expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
+    })
+
+    it('walks Left out of a child onto its folder', () => {
+      const props = renderTree()
+
+      fireEvent.keyDown(row('Alpha'), { key: 'ArrowLeft' })
+      expect(props.onSelectionChange).toHaveBeenLastCalledWith(['folder-Work'])
+      expect(row('Work')).toHaveFocus()
+    })
+
+    /**
+     * The flow that reported this: right-click a row, dismiss the menu, then
+     * press an arrow. Focus is on the row because the row claims it on
+     * contextmenu — without that the keystroke reached the scroll container and
+     * only scrolled the sidebar.
+     */
+    it('navigates from the row a right-click landed on', () => {
+      const props = renderTree()
+
+      fireEvent.contextMenu(row('Work'))
+      expect(row('Work')).toHaveFocus()
+
+      fireEvent.keyDown(row('Work'), { key: 'ArrowDown' })
+      expect(props.onSelectionChange).toHaveBeenLastCalledWith(['note-work'])
+    })
+
+    it('falls back to the selection when the keystroke misses every row', () => {
+      const props = renderTree({ selectedIds: ['folder-Work'] })
+
+      fireEvent.keyDown(screen.getByRole('tree'), { key: 'ArrowDown' })
+      expect(props.onSelectionChange).toHaveBeenLastCalledWith(['note-work'])
+    })
+
+    it('leaves the arrows to an inline rename input', () => {
+      const props = renderTree({
+        renamingFolderPath: 'Work',
+        folderRenameValue: 'Work'
+      })
+
+      const input = screen.getByDisplayValue('Work')
+      fireEvent.keyDown(input, { key: 'ArrowDown' })
+      expect(props.onSelectionChange).not.toHaveBeenCalled()
+    })
+
+    it('ignores an arrow with no row to move to', () => {
+      const props = renderTree()
+
+      fireEvent.keyDown(row('Work'), { key: 'ArrowUp' })
+      fireEvent.keyDown(row('Root'), { key: 'ArrowDown' })
+      fireEvent.keyDown(row('Root'), { key: 'ArrowRight' })
+      fireEvent.keyDown(row('Root'), { key: 'ArrowLeft' })
+      expect(props.onSelectionChange).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
@@ -63,6 +63,7 @@ import { OpenTargetMenuItems } from '@/components/sidebar/open-target-menu-items
 import { noteTabData, folderTabData } from '@/lib/sidebar-tab-data'
 import { useOpenPage, useOpenTarget } from '@/hooks/use-open-target'
 import { resolveDropPosition, type DropPosition } from '@/lib/tree-drop-position'
+import { isTreeNavKey, resolveTreeNavIntent, type TreeNavRow } from '@/lib/tree-keyboard-nav'
 import { useT } from '@memry/i18n/renderer'
 import { handleInlineRenameBlur } from '@/lib/inline-rename-focus'
 
@@ -388,6 +389,12 @@ function FolderRow({
     [item.id, onToggleExpand]
   )
 
+  // A context-menu click does not focus the row on its own, so the arrows had
+  // nothing to navigate from once the menu closed.
+  const handleContextMenu = useCallback(() => {
+    rowRef.current?.focus()
+  }, [])
+
   const handleOpenFolderViewClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -434,6 +441,7 @@ function FolderRow({
           style={{ paddingLeft: `${item.level * 16 + 8}px` }}
           onClick={handleClick}
           onMouseDown={handleMiddleClick}
+          onContextMenu={handleContextMenu}
           onKeyDown={handleKeyDown}
           onDragStart={handleDragStart}
           onDragEnd={onDragEnd}
@@ -719,6 +727,12 @@ function NoteRow({
     [item.note, onDoubleClick]
   )
 
+  // See the folder row: a context-menu click leaves focus where it was, which
+  // strands arrow navigation.
+  const handleContextMenu = useCallback(() => {
+    rowRef.current?.focus()
+  }, [])
+
   const handleDragStart = useCallback(
     (e: React.DragEvent) => {
       onDragStart(e, item.id)
@@ -754,6 +768,7 @@ function NoteRow({
           style={{ paddingLeft: `${item.level * 16 + 8}px` }} // Icon button's leading slot replaces the expander gap
           onClick={handleClick}
           onMouseDown={handleMiddleClick}
+          onContextMenu={handleContextMenu}
           onDoubleClick={handleDoubleClick}
           onKeyDown={handleKeyDown}
           onDragStart={handleDragStart}
@@ -1257,15 +1272,89 @@ export function VirtualizedNotesTree({
     [dragState, onMove]
   )
 
-  // Keyboard handler for Delete key
+  // Finder-style arrow navigation. Rows only carry their depth, and a parent is
+  // the nearest row above at a shallower depth — which is exactly what the flat
+  // visible list already encodes.
+  const navRows = useMemo<TreeNavRow[]>(
+    () =>
+      flatItems.map((item) => ({
+        id: item.id,
+        level: item.level,
+        // An empty folder is still a folder: Right has to open it so a note can
+        // be dropped in later, even though there is nothing to step into.
+        isExpandable: item.type === 'folder',
+        isExpanded: item.type === 'folder' && item.isExpanded
+      })),
+    [flatItems]
+  )
+
+  /**
+   * Focus a row by id. Only rows near the viewport are mounted, so a row the
+   * arrows just walked onto may not exist yet — scroll the virtualizer to it
+   * and focus one frame later, once it has been rendered.
+   */
+  const focusRow = useCallback(
+    (nodeId: string, index: number) => {
+      const find = (): HTMLElement | null => {
+        const wrappers = parentRef.current?.querySelectorAll('[data-tree-node-id]') ?? []
+        for (const wrapper of wrappers) {
+          if (wrapper.getAttribute('data-tree-node-id') !== nodeId) continue
+          // `data-tree-node-id` sits on the positioned wrapper; the focusable
+          // row is the treeitem inside it.
+          return wrapper.querySelector('[role="treeitem"]')
+        }
+        return null
+      }
+
+      const mounted = find()
+      if (mounted) {
+        mounted.focus()
+        return
+      }
+
+      virtualizer.scrollToIndex(index, { align: 'auto' })
+      requestAnimationFrame(() => find()?.focus())
+    },
+    [virtualizer]
+  )
+
+  // Keyboard handler: Delete, plus arrow navigation
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // An inline rename owns its own arrows — they move the caret, not the
+      // selection.
+      const target = e.target as HTMLElement | null
+      if (target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA') return
+
       if ((e.key === 'Delete' || e.key === 'Backspace') && selectedIds.length > 0) {
         e.preventDefault()
         onBulkDelete?.()
+        return
       }
+
+      if (!isTreeNavKey(e.key) || e.metaKey || e.ctrlKey || e.altKey) return
+
+      // Whichever row the keystroke came from wins; a keystroke on the
+      // container itself — right after a context menu closed, say — falls back
+      // to the current selection so the arrows still have somewhere to start.
+      const fromRow = target?.closest?.('[data-tree-node-id]')?.getAttribute('data-tree-node-id')
+      const currentId = fromRow ?? selectedIds[selectedIds.length - 1] ?? null
+
+      const intent = resolveTreeNavIntent(navRows, currentId, e.key)
+      if (!intent) return
+
+      e.preventDefault()
+
+      if (intent.type === 'expand' || intent.type === 'collapse') {
+        handleToggleExpand(intent.id)
+        return
+      }
+
+      onSelectionChange([intent.id])
+      setAnchorId(intent.id)
+      focusRow(intent.id, intent.index)
     },
-    [selectedIds, onBulkDelete]
+    [selectedIds, onBulkDelete, navRows, handleToggleExpand, onSelectionChange, focusRow]
   )
 
   const virtualItems = virtualizer.getVirtualItems()

--- a/apps/desktop/src/renderer/src/lib/tree-keyboard-nav.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tree-keyboard-nav.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { isTreeNavKey, resolveTreeNavIntent, type TreeNavRow } from './tree-keyboard-nav'
+
+/**
+ * folder-work            (expanded)
+ *   folder-work/specs    (collapsed, has children)
+ *   note-a
+ * folder-empty           (expanded, no children)
+ * note-root
+ */
+const rows: TreeNavRow[] = [
+  { id: 'folder-work', level: 0, isExpandable: true, isExpanded: true },
+  { id: 'folder-work/specs', level: 1, isExpandable: true, isExpanded: false },
+  { id: 'note-a', level: 1, isExpandable: false, isExpanded: false },
+  { id: 'folder-empty', level: 0, isExpandable: true, isExpanded: true },
+  { id: 'note-root', level: 0, isExpandable: false, isExpanded: false }
+]
+
+describe('isTreeNavKey', () => {
+  it('claims the four arrows and nothing else', () => {
+    expect(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].every(isTreeNavKey)).toBe(true)
+    expect(isTreeNavKey('Enter')).toBe(false)
+    expect(isTreeNavKey('a')).toBe(false)
+  })
+})
+
+describe('resolveTreeNavIntent', () => {
+  it('steps down and up the visible rows regardless of depth', () => {
+    expect(resolveTreeNavIntent(rows, 'folder-work', 'ArrowDown')).toEqual({
+      type: 'move',
+      id: 'folder-work/specs',
+      index: 1
+    })
+    expect(resolveTreeNavIntent(rows, 'folder-empty', 'ArrowUp')).toEqual({
+      type: 'move',
+      id: 'note-a',
+      index: 2
+    })
+  })
+
+  it('stops at the ends instead of wrapping', () => {
+    expect(resolveTreeNavIntent(rows, 'folder-work', 'ArrowUp')).toBeNull()
+    expect(resolveTreeNavIntent(rows, 'note-root', 'ArrowDown')).toBeNull()
+  })
+
+  it('enters the list from an empty selection, but only on a vertical arrow', () => {
+    expect(resolveTreeNavIntent(rows, null, 'ArrowDown')).toEqual({
+      type: 'move',
+      id: 'folder-work',
+      index: 0
+    })
+    expect(resolveTreeNavIntent(rows, null, 'ArrowRight')).toBeNull()
+    expect(resolveTreeNavIntent(rows, 'gone', 'ArrowUp')).toEqual({
+      type: 'move',
+      id: 'folder-work',
+      index: 0
+    })
+  })
+
+  it('opens a closed folder with Right, then steps into it', () => {
+    expect(resolveTreeNavIntent(rows, 'folder-work/specs', 'ArrowRight')).toEqual({
+      type: 'expand',
+      id: 'folder-work/specs'
+    })
+    expect(resolveTreeNavIntent(rows, 'folder-work', 'ArrowRight')).toEqual({
+      type: 'move',
+      id: 'folder-work/specs',
+      index: 1
+    })
+  })
+
+  it('leaves Right alone on a note and on an open folder with nothing inside', () => {
+    expect(resolveTreeNavIntent(rows, 'note-a', 'ArrowRight')).toBeNull()
+    expect(resolveTreeNavIntent(rows, 'folder-empty', 'ArrowRight')).toBeNull()
+  })
+
+  it('closes an open folder with Left, then walks out to the parent', () => {
+    expect(resolveTreeNavIntent(rows, 'folder-work', 'ArrowLeft')).toEqual({
+      type: 'collapse',
+      id: 'folder-work'
+    })
+    expect(resolveTreeNavIntent(rows, 'note-a', 'ArrowLeft')).toEqual({
+      type: 'move',
+      id: 'folder-work',
+      index: 0
+    })
+    expect(resolveTreeNavIntent(rows, 'folder-work/specs', 'ArrowLeft')).toEqual({
+      type: 'move',
+      id: 'folder-work',
+      index: 0
+    })
+  })
+
+  it('has nothing to do for Left on a root-level leaf', () => {
+    expect(resolveTreeNavIntent(rows, 'note-root', 'ArrowLeft')).toBeNull()
+  })
+
+  it('does nothing on an empty tree or an unhandled key', () => {
+    expect(resolveTreeNavIntent([], 'note-a', 'ArrowDown')).toBeNull()
+    expect(resolveTreeNavIntent(rows, 'note-a', 'Enter')).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/tree-keyboard-nav.ts
+++ b/apps/desktop/src/renderer/src/lib/tree-keyboard-nav.ts
@@ -1,0 +1,96 @@
+/**
+ * Tree Keyboard Navigation
+ *
+ * Finder-style arrow-key semantics for a flattened, visible tree row list.
+ * Pure: it reads rows and a key, and reports what should happen. Moving
+ * focus, changing selection and toggling expansion stay with the caller.
+ *
+ * @module lib/tree-keyboard-nav
+ */
+
+/** One visible row, in render order. */
+export interface TreeNavRow {
+  id: string
+  /** Depth in the tree; root rows are 0. */
+  level: number
+  /** Folders are expandable even while empty; notes never are. */
+  isExpandable: boolean
+  isExpanded: boolean
+}
+
+export type TreeNavIntent =
+  /** Move focus and selection to `id`. */
+  | { type: 'move'; id: string; index: number }
+  | { type: 'expand'; id: string }
+  | { type: 'collapse'; id: string }
+
+const NAV_KEYS = new Set(['ArrowDown', 'ArrowUp', 'ArrowRight', 'ArrowLeft'])
+
+export function isTreeNavKey(key: string): boolean {
+  return NAV_KEYS.has(key)
+}
+
+/** Index of the row `rows[index]` hangs off, or -1 at the root. */
+function findParentIndex(rows: TreeNavRow[], index: number): number {
+  const level = rows[index].level
+  for (let i = index - 1; i >= 0; i--) {
+    if (rows[i].level < level) return i
+  }
+  return -1
+}
+
+/**
+ * Resolve one keystroke against the visible rows.
+ *
+ * With no current row, Down/Up enter the list at its first row so the tree is
+ * reachable from an empty selection. Returns null when the key does nothing —
+ * Right on a note, Left at the root — and the caller should leave the event
+ * alone so the surrounding scroll container keeps its default behaviour.
+ */
+export function resolveTreeNavIntent(
+  rows: TreeNavRow[],
+  currentId: string | null,
+  key: string
+): TreeNavIntent | null {
+  if (rows.length === 0) return null
+
+  const currentIndex = currentId ? rows.findIndex((row) => row.id === currentId) : -1
+
+  if (currentIndex === -1) {
+    if (key !== 'ArrowDown' && key !== 'ArrowUp') return null
+    return { type: 'move', id: rows[0].id, index: 0 }
+  }
+
+  const current = rows[currentIndex]
+
+  switch (key) {
+    case 'ArrowDown': {
+      const next = currentIndex + 1
+      return next < rows.length ? { type: 'move', id: rows[next].id, index: next } : null
+    }
+    case 'ArrowUp': {
+      const prev = currentIndex - 1
+      return prev >= 0 ? { type: 'move', id: rows[prev].id, index: prev } : null
+    }
+    case 'ArrowRight': {
+      if (!current.isExpandable) return null
+      if (!current.isExpanded) return { type: 'expand', id: current.id }
+      // Already open: step into it. An expanded-but-empty folder has no child
+      // row to step into, so nothing happens.
+      const next = currentIndex + 1
+      if (next >= rows.length || rows[next].level <= current.level) return null
+      return { type: 'move', id: rows[next].id, index: next }
+    }
+    case 'ArrowLeft': {
+      if (current.isExpandable && current.isExpanded) {
+        return { type: 'collapse', id: current.id }
+      }
+      const parentIndex = findParentIndex(rows, currentIndex)
+      return parentIndex === -1
+        ? null
+        : { type: 'move', id: rows[parentIndex].id, index: parentIndex }
+    }
+    default:
+      return null
+  }
+}

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -97,6 +97,28 @@ When the inbox or a card has focus:
 | Open source URL | <kbd>O</kbd>                              |
 | Archive         | <kbd>Delete</kbd> or <kbd>Backspace</kbd> |
 
+## Notes Tree
+
+When a row in the sidebar **Collections** tree has focus — click one, or open a
+row's context menu and dismiss it. The arrow keys then move between rows instead
+of scrolling the sidebar.
+
+| Action                              | Shortcut                                  |
+| ----------------------------------- | ----------------------------------------- |
+| Next / previous row                 | <kbd>↓</kbd> / <kbd>↑</kbd>               |
+| Open a folder, then step inside it  | <kbd>→</kbd>                              |
+| Close a folder, or go to its parent | <kbd>←</kbd>                              |
+| Delete selected (asks first)        | <kbd>Delete</kbd> or <kbd>Backspace</kbd> |
+
+<kbd>↓</kbd> and <kbd>↑</kbd> walk every visible row in order, in and out of open
+folders, and stop at the ends rather than wrapping. <kbd>→</kbd> opens a closed
+folder; press it again to move onto the first item inside. <kbd>←</kbd> closes an
+open folder, and on anything already closed — a note, or a folder you just shut —
+it jumps out to the parent folder. Moving onto a note opens it, the same as
+clicking it.
+
+While a row is renaming, the arrow keys move the text cursor instead.
+
 ## Canvases
 
 When a row in the sidebar **Canvases** tree has focus. Tab reaches the rows and


### PR DESCRIPTION
## Summary

Arrow keys now move between rows in the sidebar's Collections tree instead of scrolling the sidebar.

| Key | Folder | Note |
| --- | --- | --- |
| ↓ / ↑ | next / previous visible row, any depth | same |
| → | open if closed; if already open, step onto the first child | — |
| ← | close if open; otherwise walk out to the parent | walk out to the parent |

No wrapping at the ends. With nothing selected, ↓/↑ enter the list at the first row. Moving onto a note opens it — the same thing a selection change already did in the plain tree.

**Why it was broken.** The sidebar renders two trees: the plain one, and a virtualized one that takes over once a vault passes 100 items. Only the plain tree had arrow navigation. The virtualized tree listened for `Delete` and `Enter` and nothing else, so arrows fell through to the browser and scrolled the whole sidebar past Collections, Projects and the rest. That is why this only reproduced on larger vaults.

Both trees shared a second gap: a context-menu click does not focus the row it lands on, so once the menu closed the arrows had no row to navigate from — the reported flow was "right-click a folder, press →, nothing opens".

**How.**

- New `lib/tree-keyboard-nav.ts`: `resolveTreeNavIntent(rows, currentId, key)` is a pure resolver over the flattened visible rows, returning `move` / `expand` / `collapse` / `null`. A row's parent is the nearest row above it at a shallower level, which the flat visible list already encodes — no path parsing.
- `virtualized-notes-tree.tsx` handles the arrows on its container keydown. Details worth a look:
  - Rows are windowed, so a row the arrows just reached may not be mounted. `focusRow` focuses it directly when it exists and otherwise scrolls the virtualizer and focuses one frame later.
  - `data-tree-node-id` sits on the positioned wrapper, not the focusable row; the lookup steps into the wrapper's `[role="treeitem"]`.
  - An inline rename `<input>` keeps its own arrows for the caret.
  - A keystroke that reaches the container without a row falls back to the current selection, so navigation still has a starting point.
- Both trees focus the row on `contextmenu`.

**Reviewer notes.**

- The plain tree's existing arrow handling is untouched — it already matched these semantics. Only the `contextmenu` focus line was added there.
- Arrowing through notes opens each one as you pass. That is pre-existing behaviour of the selection path (`handleSelectionChange` → `openPage`), kept rather than special-cased for the keyboard.
- Branch renamed off the generated `claude/…` name per the repo's branch-naming rule.

## Release note

Arrow keys move through the sidebar's notes tree the way they do in Finder: ↑ and ↓ step between rows, → opens a folder and then moves inside it, and ← closes a folder or jumps out to its parent. Previously the arrows just scrolled the sidebar on larger vaults.

## Test plan

- `resolveTreeNavIntent`: 9 unit tests. Virtualized tree: 7 behaviour tests including the context-menu flow. Plain tree: 1.
- Mutation-checked: disabling the arrow branch turns 5 tests red; removing the folder row's `contextmenu` focus turns 1 red.
- `pnpm typecheck` green
- `pnpm lint` clean on the touched files
- `pnpm --filter @memry/desktop test:renderer` — **676 files / 8198 tests green** (baseline on this branch's merge-base: 675 / 8182)
- `pnpm docs:impact --base <merge-base> --strict` covered · `pnpm docs:build` green