### PR TITLE
fix(agent-chat): surface Claude/Codex CLI providers when undetected

### DIFF
--- a/apps/desktop/src/main/ipc/agent-handlers.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.ts
@@ -38,7 +38,7 @@ import { broadcastAgentEvent, setAgentStreamTarget } from '../agent/runtime/even
 import { broadcastToAllWindows } from '../lib/window-broadcast'
 import { createLogger } from '../lib/logger'
 import { getMainI18n } from '../lib/main-i18n'
-import { trackMainError } from '../telemetry/diagnostics'
+import { trackMainError, trackMainLog } from '../telemetry/diagnostics'
 import { trackMainEvent } from '../telemetry/track'
 
 const logger = createLogger('IPC:Agent')
@@ -424,12 +424,26 @@ async function backendModelFromOptions(
   return settings.model || null
 }
 
+// A missed CLI probe is otherwise invisible in telemetry: the status quietly
+// drives the UI and nothing is logged, so "the Codex option never appeared for
+// me" reports cannot be corroborated. One shipped line per backend per session.
+const reportedUndetectedClis = new Set<string>()
+
 async function getBackendStatuses(deps: AgentHandlerDeps): Promise<BackendStatusesResponse> {
   const [claude, codex, local] = await Promise.all([
     deps.backends.get('claude_cli').getStatus(),
     deps.backends.get('codex_cli').getStatus(),
     deps.backends.get('local_openai_compatible').getStatus()
   ])
+  for (const status of [claude, codex]) {
+    if (!status.available && !reportedUndetectedClis.has(status.backend)) {
+      reportedUndetectedClis.add(status.backend)
+      trackMainLog('warn', {
+        scope: 'AgentBackendStatus',
+        action: `${status.backend}_undetected`
+      })
+    }
+  }
   return {
     claude_cli: claude,
     codex_cli: codex,

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/composer.test.tsx
@@ -150,7 +150,10 @@ describe('Composer', () => {
       format: 'wav',
       waveform: []
     })
-    vi.mocked(window.api.settings.getVoiceRecordingReadiness).mockResolvedValue({ ready: true })
+    vi.mocked(window.api.settings.getVoiceRecordingReadiness).mockResolvedValue({
+      ready: true,
+      provider: 'local'
+    })
     vi.mocked(window.api.inbox.transcribeAudio).mockReset()
     mockSendTurn.mockReset()
     mockCancelTurn.mockReset()
@@ -498,7 +501,7 @@ describe('Composer', () => {
     })
   })
 
-  it('hides the section of an unavailable CLI provider', async () => {
+  it('shows a setup row instead of models for an unavailable CLI provider', async () => {
     mockUseAgentOptional.mockReturnValue({
       state: {
         inFlight: {},
@@ -522,7 +525,10 @@ describe('Composer', () => {
     await openModelSubmenu()
 
     expect(await screen.findByRole('menuitem', { name: 'Sonnet' })).toBeInTheDocument()
-    expect(screen.queryByText('Codex')).not.toBeInTheDocument()
+    expect(screen.getByText('Codex')).toBeInTheDocument()
+    expect(
+      screen.getByRole('menuitem', { name: 'Not detected — set up in Settings…' })
+    ).toBeInTheDocument()
     expect(screen.queryByRole('menuitem', { name: 'GPT-5.5' })).not.toBeInTheDocument()
   })
 

--- a/apps/desktop/src/renderer/src/agent-chat/composer-settings-menu.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/composer-settings-menu.tsx
@@ -321,6 +321,19 @@ export function ComposerSettingsMenu(props: ComposerSettingsMenuProps): React.JS
                 ))}
               </>
             )}
+            {!props.claudeAvailable && normalizedQuery.length === 0 && (
+              <>
+                <DropdownMenuLabel className={sectionLabelClass}>
+                  {t('agentChat.composer.providers.claude')}
+                </DropdownMenuLabel>
+                <DropdownMenuItem
+                  onSelect={props.onOpenProviderSettings}
+                  className="text-muted-foreground/70"
+                >
+                  <span>{t('agentChat.composer.models.cliSetup')}</span>
+                </DropdownMenuItem>
+              </>
+            )}
             {props.codexAvailable && codexModels.length > 0 && (
               <>
                 <DropdownMenuLabel className={sectionLabelClass}>
@@ -337,6 +350,19 @@ export function ComposerSettingsMenu(props: ComposerSettingsMenuProps): React.JS
                       selectedCheck}
                   </DropdownMenuItem>
                 ))}
+              </>
+            )}
+            {!props.codexAvailable && normalizedQuery.length === 0 && (
+              <>
+                <DropdownMenuLabel className={sectionLabelClass}>
+                  {t('agentChat.composer.providers.codex')}
+                </DropdownMenuLabel>
+                <DropdownMenuItem
+                  onSelect={props.onOpenProviderSettings}
+                  className="text-muted-foreground/70"
+                >
+                  <span>{t('agentChat.composer.models.cliSetup')}</span>
+                </DropdownMenuItem>
               </>
             )}
             {showCustomModelRow && customModelBackend && (

--- a/apps/desktop/src/renderer/src/pages/settings/agent-providers-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/agent-providers-section.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type {
   AgentAccessMode,
+  AgentBackendStatus,
   AgentLocalProviderPreset,
   AgentLocalProviderProbeResult,
   AgentLocalProviderSettings,
   AgentPreferences,
-  AgentToolApprovalMode
+  AgentToolApprovalMode,
+  BackendStatusesResponse
 } from '@memry/contracts/ipc-agent'
 import { useT } from '@memry/i18n/renderer'
 
@@ -42,6 +44,7 @@ export function AgentProvidersSection({
   const { t } = useT('settings')
   const [settings, setSettings] = useState<AgentLocalProviderSettings | null>(null)
   const [preferences, setPreferences] = useState<AgentPreferences | null>(null)
+  const [backendStatuses, setBackendStatuses] = useState<BackendStatusesResponse | null>(null)
   const [apiKey, setApiKey] = useState('')
   const [models, setModels] = useState<string[]>([])
   const [status, setStatus] = useState<AgentLocalProviderProbeResult | null>(null)
@@ -57,6 +60,9 @@ export function AgentProvidersSection({
       if (cancelled) return
       setSettings(nextSettings)
       setPreferences(nextPreferences)
+    })
+    void window.api.agent.getBackendStatuses().then((statuses) => {
+      if (!cancelled) setBackendStatuses(statuses)
     })
     return () => {
       cancelled = true
@@ -164,6 +170,22 @@ export function AgentProvidersSection({
   const connectionError =
     status && (!status.connected || !status.modelAvailable) ? status.detail : null
 
+  const cliStatusText = (cli: AgentBackendStatus | undefined): string => {
+    if (!cli) return t('agentProviders.cliAgents.status.notDetected')
+    if (cli.available) {
+      return cli.version
+        ? t('agentProviders.cliAgents.status.detected', { version: cli.version })
+        : t('agentProviders.cliAgents.status.detectedNoVersion')
+    }
+    if (cli.version && cli.minimumRequired) {
+      return t('agentProviders.cliAgents.status.belowMinimum', {
+        version: cli.version,
+        minimum: cli.minimumRequired
+      })
+    }
+    return t('agentProviders.cliAgents.status.notDetected')
+  }
+
   if (!settings || !preferences) return null
 
   return (
@@ -217,6 +239,37 @@ export function AgentProvidersSection({
               </SelectItem>
             </SelectContent>
           </Select>
+        </SettingRow>
+      </SettingsGroup>
+
+      <SettingsGroup label={t('agentProviders.groups.cliAgents')}>
+        <SettingRow
+          label={t('agentProviders.cliAgents.claude.label')}
+          description={t('agentProviders.cliAgents.claude.description')}
+        >
+          <span
+            className={
+              backendStatuses?.claude_cli.available
+                ? 'text-xs/4 text-green-600'
+                : 'text-xs/4 text-muted-foreground'
+            }
+          >
+            {cliStatusText(backendStatuses?.claude_cli)}
+          </span>
+        </SettingRow>
+        <SettingRow
+          label={t('agentProviders.cliAgents.codex.label')}
+          description={t('agentProviders.cliAgents.codex.description')}
+        >
+          <span
+            className={
+              backendStatuses?.codex_cli.available
+                ? 'text-xs/4 text-green-600'
+                : 'text-xs/4 text-muted-foreground'
+            }
+          >
+            {cliStatusText(backendStatuses?.codex_cli)}
+          </span>
         </SettingRow>
       </SettingsGroup>
 

--- a/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
@@ -297,6 +297,18 @@ function installWindowApi() {
         allowNonLoopback: false
       }),
       getPreferences: vi.fn().mockResolvedValue(agentPreferences),
+      getBackendStatuses: vi.fn().mockResolvedValue({
+        claude_cli: { backend: 'claude_cli', available: true, version: '2.3.0' },
+        codex_cli: {
+          backend: 'codex_cli',
+          available: false,
+          reason: 'missing_binary',
+          detail: 'Install Codex CLI.',
+          version: null,
+          minimumRequired: '0.130.0'
+        },
+        local_openai_compatible: { backend: 'local_openai_compatible', available: true }
+      }),
       setPreferences: vi.fn(async (input) => ({ ...agentPreferences, ...input })),
       setLocalProviderSettings: vi.fn(async (input) => ({
         preset: input.preset,
@@ -324,14 +336,14 @@ function installWindowApi() {
         toolsEnabled: true,
         detail: null
       })
-    },
+    } as unknown as typeof window.api.agent,
     syncOps: {
       getStorageBreakdown: vi.fn().mockResolvedValue({
         used: 1536,
         limit: 4096,
         breakdown: { notes: 1024, attachments: 256, crdt: 128, other: 128 }
       })
-    },
+    } as unknown as typeof window.api.syncOps,
     account: {
       getBillingStatus: vi.fn().mockResolvedValue({
         plan: 'free',
@@ -366,7 +378,7 @@ function installWindowApi() {
         success: true,
         portalUrl: 'https://paddle.test/portal'
       })
-    },
+    } as unknown as typeof window.api.account,
     settings: {
       ...window.api.settings,
       getTerminalCommandStatus: vi.fn().mockResolvedValue({
@@ -723,6 +735,14 @@ describe('settings section coverage', () => {
     expect(window.api.agent.getPreferences).toHaveBeenCalled()
 
     expect(await screen.findByText('agentProviders.permissions.group')).toBeInTheDocument()
+
+    // CLI agent detection status: Claude detected with a version, Codex missing.
+    expect(await screen.findByText('agentProviders.cliAgents.claude.label')).toBeInTheDocument()
+    expect(
+      await screen.findByText('agentProviders.cliAgents.status.detected {"version":"2.3.0"}')
+    ).toBeInTheDocument()
+    expect(screen.getByText('agentProviders.cliAgents.codex.label')).toBeInTheDocument()
+    expect(screen.getByText('agentProviders.cliAgents.status.notDetected')).toBeInTheDocument()
 
     fireEvent.click(screen.getByText('agentProviders.permissions.access.computerAccess'))
     await waitFor(() =>

--- a/apps/desktop/tsconfig.test.web.json
+++ b/apps/desktop/tsconfig.test.web.json
@@ -19,7 +19,6 @@
   "exclude": [
     "src/renderer/src/App.test.tsx",
     "src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx",
-    "src/renderer/src/agent-chat/__tests__/composer.test.tsx",
     "src/renderer/src/agent-chat/__tests__/message-stream.test.tsx",
     "src/renderer/src/agent-mcp/canvas-write-handler.test.tsx",
     "src/renderer/src/agent-mcp/current-note-handler.test.tsx",
@@ -149,7 +148,6 @@
     "src/renderer/src/pages/settings/ai-section.test.tsx",
     "src/renderer/src/pages/settings/general-section.i18n.test.tsx",
     "src/renderer/src/pages/settings/properties-section.test.tsx",
-    "src/renderer/src/pages/settings/settings-sections.test.tsx",
     "src/renderer/src/pages/settings/setup-wizard.test.tsx",
     "src/renderer/src/pages/settings/shortcuts-section.test.tsx",
     "src/renderer/src/pages/tags-hub.test.tsx",

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -48,6 +48,11 @@ message or provider check picks it up without a restart. If the CLI is removed, 
 its executable bit between that check and the moment a turn actually starts, the turn ends right
 away with a `Claude CLI failed to start: ...` (or `Codex CLI failed to start: ...`) error naming the
 reason, and the conversation is free to accept a new message as soon as the CLI is back.
+A CLI that is not detected is not hidden: the composer's model picker still lists the Claude and
+Codex sections with a muted "Not detected — set up in Settings…" row that opens
+[Settings -> AI Assistant -> Agent Permissions](/user-guide/settings#agent-permissions), where a
+CLI agents group shows the live detection status of each CLI (version when found) alongside install
+and sign-in instructions (`claude login` / `codex login`).
 For local models, configure a compatible server in
 [Settings -> AI Assistant -> Agent Permissions](/user-guide/settings#agent-permissions) first.
 If the global AI switch is off in [Settings -> AI](/user-guide/settings#ai), the Agent tab and Agent

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -214,7 +214,8 @@
         "search": "Search models…",
         "useCustom": "Use \"{query}\"",
         "localEmpty": "No models found — check Settings",
-        "localSetup": "Set up in Settings…"
+        "localSetup": "Set up in Settings…",
+        "cliSetup": "Not detected — set up in Settings…"
       },
       "settings": {
         "reasoning": "Reasoning",

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -1569,8 +1569,25 @@
       "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
+      "cliAgents": "CLI agents",
       "local": "Local OpenAI-compatible provider",
       "actions": "Connection checks"
+    },
+    "cliAgents": {
+      "claude": {
+        "label": "Claude Code CLI",
+        "description": "Install Claude Code from claude.ai/code, then run `claude login`. MemryNote picks it up automatically."
+      },
+      "codex": {
+        "label": "Codex CLI",
+        "description": "Install with `npm install -g @openai/codex`, then run `codex login` to sign in to your OpenAI account. MemryNote picks it up automatically."
+      },
+      "status": {
+        "detected": "Detected · v{version}",
+        "detectedNoVersion": "Detected",
+        "belowMinimum": "v{version} installed — needs {minimum} or newer",
+        "notDetected": "Not detected"
+      }
     },
     "permissions": {
       "group": "Agent permissions",


### PR DESCRIPTION
## Problem

Beta feedback (2026-08-22): a user tried to hook Codex CLI into Agent Chat and could not find the option anywhere.

Root cause: the composer's model picker rendered a CLI provider's section only when the binary was already detected (`available && models.length > 0`), so a missing or below-minimum Codex CLI erased every trace of Codex from the UI. The Settings AI panel only covered local OpenAI-compatible providers — Codex appeared nowhere unless it was already working.

## Fix

- **Composer model menu**: undetected Claude/Codex providers now render their section label with a muted "Not detected — set up in Settings…" row that opens Settings → AI Assistant → Agent Permissions.
- **Settings → Agent Permissions**: new **CLI agents** group showing live detection status per CLI — `Detected · v2.3.0`, `v0.9.0 installed — needs 0.130.0 or newer`, or `Not detected` — with install + `claude login` / `codex login` instructions. Detection re-probes on panel open (misses are never cached).
- **Telemetry**: one warn log per session per undetected CLI (`AgentBackendStatus` / `<backend>_undetected`) via the log-ship pipeline, so future "the option never appeared" reports can be corroborated and we get how many installs lack each CLI.
- **Docs**: `agent-mcp.md` documents the discoverability behavior.
- **Test debt**: removed `composer.test.tsx` and `settings-sections.test.tsx` from the `tsconfig.test.web.json` exclude backlog (309 → 307) and fixed their 4 compile errors.

## Verification

- `composer.test.tsx` 37/37, `settings-sections.test.tsx` 11/11, `agent-handlers` + `agent-lazy-handlers` 24/24
- `typecheck:web`, `typecheck:node`, `tsconfig.test.web` all green
- `i18n:check` green, i18n package tests 56/56
- `docs:build` green