### PR TITLE
fix(installer): heal the missing Windows Start menu shortcut on every install

### DIFF
--- a/apps/desktop/build/installer.nsh
+++ b/apps/desktop/build/installer.nsh
@@ -40,6 +40,44 @@
 # hits the same wall and the only way out is uninstall-then-reinstall. Renaming
 # is strictly better; we abort only if even the rename fails, which is the same
 # outcome as before, so this can never be worse than what it replaces.
+# Why customInstall exists — the Start menu entry must survive every path.
+#
+# electron-builder's keep-shortcuts handshake preserves shortcuts (and thus
+# Start/taskbar pins) across silent auto-updates, but it has two holes that
+# real Windows users fell into:
+#
+#   1. templates/nsis/include/installer.nsh's addStartMenuLink, on the
+#      keepShortcuts=true path, only RENAMES an existing link — a MISSING
+#      Start menu link is never recreated ("the user deleted it" is assumed).
+#      Any one-time loss becomes permanent: every later update keeps the
+#      shortcut missing, the app vanishes from Start search, and pinning
+#      looks broken to the user.
+#   2. include/installUtil.nsh's setIsTryToKeepShortcuts disables the keep
+#      mechanism entirely when allowToChangeInstallationDirectory is defined
+#      and the run is not an auto-update (--updated). Manually running a
+#      downloaded setup.exe over an existing install — the exact workaround
+#      users learned while in-place updates were broken (see
+#      customRemoveFiles below) — therefore wipes shortcuts and unregisters
+#      the AppUserModelID, killing Start menu and taskbar pins.
+#
+# Both holes end in the same state: no "$SMPROGRAMS\MemryNote.lnk". This
+# macro runs at the end of every install (fresh, auto-update, manual rerun)
+# and recreates the Start menu link only when it is missing, with the AUMID
+# stamped so Windows groups/pins it as com.memrynote.memry. When the link
+# exists it is left untouched, so a live pin is never disturbed. The pin
+# itself cannot be restored programmatically (Windows offers no API), but
+# with the link and AUMID back the user can re-pin — and with in-place
+# updates fixed, the keep path preserves that pin from then on.
+!macro customInstall
+  ${ifNot} ${FileExists} "$newStartMenuLink"
+    CreateShortCut "$newStartMenuLink" "$appExe" "" "$appExe" 0 "" "" "${APP_DESCRIPTION}"
+    ClearErrors
+    WinShell::SetLnkAUMI "$newStartMenuLink" "${APP_ID}"
+    # refresh the shell so Start search picks the entry up immediately
+    System::Call 'Shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'
+  ${endIf}
+!macroend
+
 !macro customRemoveFiles
   ${if} ${isUpdated}
     CreateDirectory "$PLUGINSDIR\old-install"


### PR DESCRIPTION
## Problem

User report (Asad): the pinned MemryNote tile on the Windows Start menu is deleted after every update, and after the latest update the app no longer appears in the Start menu at all — it cannot be re-pinned even from the exe location.

## Root cause — a three-link chain

1. **Until v2026-08-17, in-place Windows updates aborted on a single busy file** (documented in `build/installer.nsh`, fixed by #1222 and the rename-aside follow-up). The only way out was uninstall + reinstall — and a full uninstall runs `WinShell::UninstAppUserModelId` and deletes the shortcuts, killing the Start pin on every cycle.
2. **`nsis.allowToChangeInstallationDirectory: true` (added in #709) disables electron-builder's keep-shortcuts handshake** for any installer run without `--updated`. Manually running a downloaded setup.exe over an existing install — the exact workaround users learned while updates were broken — wipes the shortcuts and unregisters the AppUserModelID.
3. **electron-builder's `addStartMenuLink` never recreates a *missing* Start menu link on the `keepShortcuts=true` path** (it assumes the user deleted it). Once links 1 or 2 removed the shortcut, every later silent auto-update preserved its absence: the app vanished from Start search permanently, which reads as "cannot pin".

## Fix

Add a `customInstall` macro to `apps/desktop/build/installer.nsh` that runs at the end of every install (fresh, auto-update, manual rerun) and recreates `$SMPROGRAMS\MemryNote.lnk` **only when it is missing**, with the `com.memrynote.memry` AUMID stamped so Windows groups and pins it correctly. An existing link is left untouched, so a live pin is never disturbed.

The pin itself cannot be restored programmatically (Windows offers no API), but with the link and AUMID back the user can re-pin — and with in-place updates fixed, the keep-shortcuts path preserves that pin from then on. Every affected user is healed on their next update.

## Verification

- Both custom macros (`customInstall`, `customRemoveFiles`) compile clean against electron-builder's own cached `makensis` 3.0.4.1 + the `nsis-resources` WinShell plugin (the exact toolchain release builds use), producing a working installer binary with no errors.
- All constructs are copied verbatim from electron-builder's stock `addStartMenuLink`/`addDesktopLink` macros that ship in every existing build.
- `pnpm docs:impact --base origin/main --strict`: no docs-relevant changes.
- Behavioral verification on a real Windows update cycle happens with the next release build; a compile error would fail the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)