### PR TITLE
fix(canvas): warn once per canvas that it is too large to sync, not once per visit

### DIFF
--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
@@ -25,6 +25,7 @@ import { mintSnapshotElements } from '@/components/note/mind-map/mind-map-snapsh
 import type { MindMapBoxElement, MindMapElement } from '@/components/note/mind-map/mind-map-types'
 import { CanvasEditor } from './canvas-editor'
 import { clearCardTitleCache } from './canvas-link-target-title'
+import { resetTooLargeNotices } from './canvas-too-large-notice'
 
 interface FakeApi {
   getSceneElements: () => unknown[]
@@ -441,6 +442,9 @@ describe('CanvasEditor too-large-to-sync notice', () => {
     mocks.api.showHyperlinkPopup = false
     mocks.onChange = null
     mocks.tooLargeListeners.clear()
+    // The notice is remembered for the whole app session, so each test starts
+    // from a fresh one.
+    resetTooLargeNotices()
     mocks.liveOpened.mockReset().mockResolvedValue({ ok: true })
     mocks.liveClosed.mockReset().mockResolvedValue({ ok: true })
     installWindowApi()
@@ -510,6 +514,88 @@ describe('CanvasEditor too-large-to-sync notice', () => {
     mocks.update.mockResolvedValue({ id: 'c1', tooLarge: false })
     await saveOnce([{ id: 'a' }])
     emitTooLarge('c1')
+
+    expect(mocks.toastError).toHaveBeenCalledTimes(2)
+  })
+
+  /**
+   * #1643: only the active tab is mounted, so leaving the canvas destroys the
+   * editor and coming back builds a new one. The notice must not start over
+   * with it — the user meets the same warning again on every tab switch.
+   */
+  it('stays quiet when the canvas is left and reopened in the same session', async () => {
+    const first = render(<CanvasEditor canvasId="c1" initialScene="" />)
+    await saveOnce([{ id: 'a' }])
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+
+    first.unmount()
+
+    render(<CanvasEditor canvasId="c1" initialScene="" />)
+    await saveOnce([{ id: 'a' }, { id: 'b' }])
+
+    expect(mocks.update).toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * What makes the remount visible without the user touching anything: a canvas
+   * with externalized images is stored with a top-level `memryAssets` sidecar
+   * that serializeAsJSON never writes back, so the loaded scene and the
+   * serialized scene always differ and the first autosave after mount always
+   * runs — oversized, on arrival.
+   */
+  it('announces once for an image scene that saves on mount, not once per visit', async () => {
+    const storedScene = JSON.stringify({
+      elements: [{ id: 'img-1' }],
+      files: { 'file-1': { dataURL: 'memry-file://local/canvas-assets/abc.png' } },
+      memryAssets: [{ fileId: 'file-1', contentHash: 'abc', extension: 'png' }]
+    })
+    // No edit anywhere below: the scene Excalidraw reports is exactly the one
+    // that was stored, and the save happens because the sidecar cannot be
+    // serialized back.
+    const openCanvas = async (): Promise<{ unmount: () => void }> => {
+      const view = render(<CanvasEditor canvasId="c1" initialScene={storedScene} />)
+      await saveOnce([{ id: 'img-1' }])
+      return view
+    }
+
+    const first = await openCanvas()
+    expect(mocks.update).toHaveBeenCalledTimes(1)
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+    first.unmount()
+
+    const second = await openCanvas()
+    second.unmount()
+
+    expect(mocks.update.mock.calls.length).toBeGreaterThan(1)
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+  })
+
+  it('still warns for a different canvas opened in the same session', async () => {
+    const first = render(<CanvasEditor canvasId="c1" initialScene="" />)
+    await saveOnce([{ id: 'a' }])
+    first.unmount()
+
+    mocks.update.mockResolvedValue({ id: 'c2', tooLarge: true })
+    render(<CanvasEditor canvasId="c2" initialScene="" />)
+    await saveOnce([{ id: 'a' }, { id: 'b' }])
+
+    expect(mocks.toastError).toHaveBeenCalledTimes(2)
+    expect(mocks.toastError).toHaveBeenLastCalledWith('canvas.tooLargeToSync', {
+      id: 'canvas-too-large-c2'
+    })
+  })
+
+  it('warns again after the canvas shrinks under the ceiling and grows past it', async () => {
+    const first = render(<CanvasEditor canvasId="c1" initialScene="" />)
+    await saveOnce([{ id: 'a' }])
+    mocks.update.mockResolvedValue({ id: 'c1', tooLarge: false })
+    await saveOnce([{ id: 'a' }, { id: 'b' }])
+    first.unmount()
+
+    mocks.update.mockResolvedValue({ id: 'c1', tooLarge: true })
+    render(<CanvasEditor canvasId="c1" initialScene="" />)
+    await saveOnce([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
 
     expect(mocks.toastError).toHaveBeenCalledTimes(2)
   })

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
@@ -33,6 +33,7 @@ import { registerPendingSave, unregisterPendingSave } from '@/lib/save-registry'
 import { createLogger } from '@/lib/logger'
 import { trackRendererError } from '@/lib/telemetry-diagnostics'
 import { CanvasLinkDialog } from './canvas-link-dialog'
+import { claimTooLargeNotice, rearmTooLargeNotice } from './canvas-too-large-notice'
 import {
   elementLinkTarget,
   truncateLabel,
@@ -279,17 +280,23 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
   // canvas stops syncing, re-armed only after a save syncs again. The stable
   // toast id is the second line of defence — sonner replaces rather than
   // stacks, so even a repeat announcement can never pile up.
-  const tooLargeAnnouncedRef = useRef(false)
+  //
+  // That edge is remembered OUTSIDE this component (#1643): only the active tab
+  // is mounted, so leaving the canvas destroys this editor and returning builds
+  // a fresh one — a per-instance ref re-armed itself on every tab switch, and
+  // the first save after mount is not the user's doing (a stored scene with
+  // externalized images carries a `memryAssets` sidecar that serializeAsJSON
+  // never writes back, so it always differs from what is on disk and always
+  // saves). See canvas-too-large-notice for the exact scope.
   const announceSyncability = useCallback(
     (tooLarge: boolean): void => {
       if (!tooLarge) {
-        tooLargeAnnouncedRef.current = false
+        rearmTooLargeNotice(canvasId)
         return
       }
-      if (tooLargeAnnouncedRef.current) {
+      if (!claimTooLargeNotice(canvasId)) {
         return
       }
-      tooLargeAnnouncedRef.current = true
       toast.error(t('canvas.tooLargeToSync'), { id: `canvas-too-large-${canvasId}` })
     },
     [canvasId, t]

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-too-large-notice.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-too-large-notice.ts
@@ -1,0 +1,50 @@
+/**
+ * Session-scoped record of which canvases have already announced that they are
+ * too large to sync (§5.6).
+ *
+ * The notice is edge-triggered (#1626): announced when a canvas stops syncing,
+ * re-armed once one of its saves syncs again. That edge was tracked in a ref
+ * inside CanvasEditor — but only the active tab is mounted, so switching away
+ * from a canvas destroys the editor and coming back builds a fresh one with the
+ * ref cleared. Every return to the tab therefore re-announced (#1643), and it
+ * did so without the user touching anything: the stored scene of a canvas that
+ * has externalized images carries a top-level `memryAssets` sidecar that the
+ * renderer's serializer never reproduces, so the first autosave after mount
+ * always differs from the loaded scene and always runs.
+ *
+ * The edge therefore lives here, outside React, so it survives unmount:
+ * - announced at most once per canvas per app session,
+ * - re-armed for that canvas when one of its saves syncs again, so shrinking a
+ *   canvas back under the ceiling and growing it past it again warns anew,
+ * - kept per canvas id, so a different canvas still gets its own notice,
+ * - never persisted: a restart re-announces, so the divergence is never
+ *   silenced, only de-duplicated.
+ *
+ * Keyed by canvas id alone — ids are minted per canvas, not per vault, so two
+ * vaults cannot collide here. Same shape (and same lifetime) as the failed
+ * upload registry in canvas-externalize.
+ */
+
+const announcedCanvasIds = new Set<string>()
+
+/**
+ * Claims the one notice this canvas gets. True exactly once per canvas until
+ * something re-arms it — the caller shows the toast only when it wins the claim.
+ */
+export function claimTooLargeNotice(canvasId: string): boolean {
+  if (announcedCanvasIds.has(canvasId)) {
+    return false
+  }
+  announcedCanvasIds.add(canvasId)
+  return true
+}
+
+/** A save that synced re-arms this canvas's notice for the next time it stops. */
+export function rearmTooLargeNotice(canvasId: string): void {
+  announcedCanvasIds.delete(canvasId)
+}
+
+/** Test seam: forget every announcement, as a fresh app session would. */
+export function resetTooLargeNotices(): void {
+  announcedCanvasIds.clear()
+}

--- a/apps/docs/src/user-guide/canvas/sync-and-limits.md
+++ b/apps/docs/src/user-guide/canvas/sync-and-limits.md
@@ -54,9 +54,10 @@ rather than failing silently. Splitting a very large board into several
 canvases is the usual fix.
 
 The warning appears once, when the board crosses the limit — not again on every
-edit while you keep working. It comes back when there is something new to say:
-after you reopen the board and it is still too large, or after a save that
-synced is followed by one that is too large again.
+edit while you keep working, and not again each time you switch to another tab
+and come back. It comes back when there is something new to say: after a save
+that synced is followed by one that is too large again, or the next time you
+start memrynote and the board is still too large.
 
 ## Known limitations
 


### PR DESCRIPTION
## The report

Aurelie Kabore, 22 Aug 2026, v2026-08-22:

> "I don't think the 'this canvas is too large to sync...' toast is fixed for me though. And I think its a bit more than what I explained or not well explained. Because it will show up sometimes while I am switching tab and as I come back to the canvas the toast will reappear. So I don't think it is at every move of an item anymore, but I am not [sure] how frequent or exact moments for me to put in words, but it still happens for me. I am on v2026-08-22 by the way. I wonder if it is because of images? I do have some images on the canvas."

## Root cause

Two things compose, and both of her observations are literally correct.

1. **The dedupe died on unmount.** #1626 made the notice edge-triggered, but the edge lived in `tooLargeAnnouncedRef`, a ref inside `CanvasEditor`. Only the active tab is mounted, so switching away from the canvas destroys the editor and coming back builds a fresh one with the flag cleared. Every visit got its own first announcement.

2. **Returning to the canvas saves by itself — and images are why.** `canvas:update` injects a top-level `memryAssets` sidecar into the persisted scene, and `serializeAsJSON` in the renderer never writes that key back. So the stored scene (`lastSavedScene`) and the serialized scene always differ, and the persister's first run after mount always saves. That save is oversized, so main emits `canvas:too-large` — before the user has touched anything. The sidecar exists because her canvas has externalized images, which is also what pushed the board past the ceiling in the first place. Her image hypothesis is confirmed: not as a size-check bug, but as the reason a save happens on arrival.

Together: toast on the way out (the unmount flush save), toast again on the way back (the mount save), with no edit in between.

## Dedupe semantics chosen

The edge moves out of React into `canvas-too-large-notice.ts`, a module-level `Set` of canvas ids:

- **once per canvas per app session** — surviving unmount/remount is the whole point;
- **re-armed when one of that canvas's saves syncs again** (`tooLarge: false`), so shrinking back under the ceiling and growing past it again warns anew — the same edge #1626 defined, just at the right scope;
- **per canvas id**, so a different canvas gets its own notice (ids are `nanoid()`, globally unique, so this cannot leak across vaults);
- **never persisted**, so a restart re-announces. The warning is de-duplicated, not silenced — the size limit is real and the user still learns about it.

## Tests

`canvas-editor.test.tsx`, in the existing too-large suite (which now resets the session registry per test):

- `stays quiet when the canvas is left and reopened in the same session` — mount, oversized save, unmount, remount, oversized save: one toast. **Failed before the fix (2 toasts).**
- `announces once for an image scene that saves on mount, not once per visit` — stored scene carries `memryAssets` + a `memry-file://` image, no edit anywhere; asserts the save really does run on each visit and that only the first one announces. **Failed before the fix (2 toasts).**
- `still warns for a different canvas opened in the same session`
- `warns again after the canvas shrinks under the ceiling and grows past it`

## Verification

| Command | Result |
| --- | --- |
| `pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/pages/canvas/canvas-editor.test.tsx` (before fix) | 2 failed, 6 passed — the two remount tests |
| `pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/pages/canvas/canvas-editor.test.tsx` | 57 passed |
| `pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/pages/canvas` | 32 files, 427 passed |
| `pnpm typecheck` | 17/17 successful |
| `pnpm exec eslint` (changed files) | 0 errors |
| `pnpm docs:impact --base origin/main --strict` | covered |
| `pnpm docs:build` | build complete |

No Excalidraw props changed, so the stable `excalidrawAPI` / `onChange` identities from #1690 are untouched; the canvas suites run without the OOM that a re-render loop would cause.

## Known, not fixed here

The redundant save on every canvas mount (item 2 above) is still there: each visit rewrites the scene file and pushes a sync update for a canvas nobody edited. Worth fixing on its own — it is churn, not a correctness bug, and narrowing the persister's dedupe deserves its own change.
