### PR TITLE
fix(home): make the Home tab title follow the active board

### DIFF
--- a/apps/desktop/src/renderer/src/App.test.tsx
+++ b/apps/desktop/src/renderer/src/App.test.tsx
@@ -64,6 +64,12 @@ vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({ clear: queryClientClear })
 }))
 
+vi.mock('@/components/tabs/home-tab-title-sync', () => ({
+  // Owns a react-query subscription; `@tanstack/react-query` is fully mocked
+  // here. Its own suite covers it (`home-tab-title-sync.test.tsx`).
+  HomeTabTitleSync: () => null
+}))
+
 vi.mock('next-themes', () => ({
   ThemeProvider: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="theme-provider">{children}</div>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -87,6 +87,7 @@ import { useAgentMcpCanvasWriteResponder } from '@/agent-mcp/canvas-write-handle
 import { AgentFeatureProvider } from '@/agent-chat/agent-feature-provider'
 import { AgentTabTitleSync } from '@/agent-chat/agent-tab-title-sync'
 import { CanvasTabTitleSync } from '@/components/tabs/canvas-tab-title-sync'
+import { HomeTabTitleSync } from '@/components/tabs/home-tab-title-sync'
 
 const log = createLogger('App')
 const startupTheme = getStartupTheme()
@@ -344,6 +345,7 @@ const AppContent = (): React.JSX.Element => {
     <TabDragProvider>
       <AgentTabTitleSync />
       <CanvasTabTitleSync />
+      <HomeTabTitleSync />
       <div className="flex flex-1 overflow-hidden bg-background" id="main-content">
         <SplitViewContainer />
       </div>

--- a/apps/desktop/src/renderer/src/App.workspace-counts.test.tsx
+++ b/apps/desktop/src/renderer/src/App.workspace-counts.test.tsx
@@ -118,6 +118,12 @@ vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({ clear: vi.fn() })
 }))
 
+vi.mock('@/components/tabs/home-tab-title-sync', () => ({
+  // Owns a react-query subscription; `@tanstack/react-query` is fully mocked
+  // here. Its own suite covers it (`home-tab-title-sync.test.tsx`).
+  HomeTabTitleSync: () => null
+}))
+
 vi.mock('next-themes', () => ({
   ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   useTheme: () => ({ setTheme: vi.fn() })

--- a/apps/desktop/src/renderer/src/components/tabs/home-tab-title-sync.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/home-tab-title-sync.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * The seam under test is the real one: a real `TabProvider`, the real reducer,
+ * the real `useHomeBoards` (including the shared active-board store) and the
+ * real `updateTabTitle`. Only `window.api.homePages` and the home-page events —
+ * the IPC boundary the renderer cannot own — are mocks, so an assertion here is
+ * about the tab title a user would read off the tab strip.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TabProvider, useTabs } from '@/contexts/tabs/context'
+import type { Tab, TabGroup, TabSystemState } from '@/contexts/tabs/types'
+import { useHomeBoards } from '@/hooks/use-home-boards'
+import { HomeTabTitleSync } from './home-tab-title-sync'
+
+interface TestBoard {
+  id: string
+  name: string
+  position: number
+  widgets: never[]
+}
+
+const ACTIVE_KEY = 'memry-home-active-board'
+
+/** Mutable so a test can rename a board between refetches. */
+let boards: TestBoard[] = []
+/** Resolves the board list; swapped for a never-resolving one in the loading test. */
+let listBoards: () => Promise<TestBoard[]> = async () => boards
+/** Fires the main-process "a board changed" broadcast the hook refetches on. */
+let emitHomePageUpdated: (() => void) | null = null
+
+const board = (id: string, name: string, position: number): TestBoard => ({
+  id,
+  name,
+  position,
+  widgets: []
+})
+
+const homeTab = (overrides: Partial<Tab> = {}): Tab => ({
+  id: 'tab-home',
+  type: 'home',
+  title: 'Home',
+  icon: 'home',
+  path: '/home',
+  isPinned: false,
+  isModified: false,
+  isPreview: false,
+  isDeleted: false,
+  openedAt: 1,
+  lastAccessedAt: 1,
+  ...overrides
+})
+
+const noteTab = (overrides: Partial<Tab> = {}): Tab => ({
+  id: 'tab-note',
+  type: 'note',
+  title: 'Some note',
+  icon: 'file-text',
+  path: '/note/note-1',
+  entityId: 'note-1',
+  isPinned: false,
+  isModified: false,
+  isPreview: false,
+  isDeleted: false,
+  openedAt: 1,
+  lastAccessedAt: 1,
+  ...overrides
+})
+
+const makeGroup = (id: string, tabs: Tab[], activeTabId?: string): TabGroup => ({
+  id,
+  tabs,
+  activeTabId: activeTabId ?? tabs[0]?.id ?? null,
+  isActive: true,
+  back: [],
+  forward: []
+})
+
+const makeState = (groups: TabGroup[]): TabSystemState => ({
+  tabGroups: Object.fromEntries(groups.map((group) => [group.id, group])),
+  layout: { type: 'leaf', tabGroupId: groups[0].id },
+  activeGroupId: groups[0].id,
+  settings: { restoreSessionOnStart: true, tabCloseButton: 'hover' },
+  recentlyClosed: []
+})
+
+function mount(initialState: TabSystemState) {
+  let latestTabs: ReturnType<typeof useTabs> | null = null
+  let latestBoards: ReturnType<typeof useHomeBoards> | null = null
+
+  const Probe = (): null => {
+    latestTabs = useTabs()
+    latestBoards = useHomeBoards()
+    return null
+  }
+
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+  })
+
+  const view = render(
+    <QueryClientProvider client={client}>
+      <TabProvider initialState={initialState}>
+        <HomeTabTitleSync />
+        <Probe />
+      </TabProvider>
+    </QueryClientProvider>
+  )
+
+  return {
+    ...view,
+    titleOf: (groupId: string, tabId: string): string | undefined =>
+      latestTabs?.state.tabGroups[groupId]?.tabs.find((tab) => tab.id === tabId)?.title,
+    selectBoard: (id: string): void => {
+      latestBoards?.setActiveBoardId(id)
+    },
+    get groups() {
+      return latestTabs?.state.tabGroups
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  emitHomePageUpdated = null
+  boards = [board('b1', 'Home', 0), board('b2', 'Work', 1)]
+  listBoards = async () => boards
+
+  window.api.onSettingsChanged = vi.fn(() => vi.fn())
+  window.api.homePages = {
+    list: vi.fn(() => listBoards()),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    reorder: vi.fn()
+  } as unknown as typeof window.api.homePages
+  window.api.onHomePageCreated = vi.fn(
+    () => () => {}
+  ) as unknown as typeof window.api.onHomePageCreated
+  window.api.onHomePageUpdated = vi.fn((callback: (event: { id: string }) => void) => {
+    emitHomePageUpdated = () => callback({ id: 'b1' })
+    return () => {}
+  }) as unknown as typeof window.api.onHomePageUpdated
+  window.api.onHomePageDeleted = vi.fn(
+    () => () => {}
+  ) as unknown as typeof window.api.onHomePageDeleted
+})
+
+describe('HomeTabTitleSync', () => {
+  it('retitles a restored Home tab to the board it is actually showing', async () => {
+    // The reported bug, and the rehydration case in one: a tab persisted by an
+    // older build carries the stamped literal "Home" with no board id at all.
+    localStorage.setItem(ACTIVE_KEY, 'b2')
+    const view = mount(makeState([makeGroup('main', [homeTab()])]))
+
+    await waitFor(() => expect(view.titleOf('main', 'tab-home')).toBe('Work'))
+  })
+
+  it('keeps "Home" while the untouched default board is the one open', async () => {
+    localStorage.setItem(ACTIVE_KEY, 'b1')
+    const view = mount(makeState([makeGroup('main', [homeTab()])]))
+
+    await waitFor(() => expect(window.api.homePages.list).toHaveBeenCalled())
+    await Promise.resolve()
+
+    expect(view.titleOf('main', 'tab-home')).toBe('Home')
+  })
+
+  it('follows a switch to another board', async () => {
+    localStorage.setItem(ACTIVE_KEY, 'b1')
+    const view = mount(makeState([makeGroup('main', [homeTab()])]))
+    await waitFor(() => expect(view.titleOf('main', 'tab-home')).toBe('Home'))
+
+    act(() => view.selectBoard('b2'))
+
+    await waitFor(() => expect(view.titleOf('main', 'tab-home')).toBe('Work'))
+  })
+
+  it('follows a rename of the board that is open', async () => {
+    localStorage.setItem(ACTIVE_KEY, 'b2')
+    const view = mount(makeState([makeGroup('main', [homeTab()])]))
+    await waitFor(() => expect(view.titleOf('main', 'tab-home')).toBe('Work'))
+
+    boards = [board('b1', 'Home', 0), board('b2', 'Planning', 1)]
+    act(() => emitHomePageUpdated?.())
+
+    await waitFor(() => expect(view.titleOf('main', 'tab-home')).toBe('Planning'))
+  })
+
+  it('retitles a Home tab the user is not looking at', async () => {
+    // The reason this component sits above the tab tree: only the ACTIVE tab is
+    // mounted, so the Home page itself is not rendered in this scenario.
+    localStorage.setItem(ACTIVE_KEY, 'b2')
+    const view = mount(makeState([makeGroup('main', [noteTab(), homeTab()], 'tab-note')]))
+
+    await waitFor(() => expect(view.titleOf('main', 'tab-home')).toBe('Work'))
+    expect(view.titleOf('main', 'tab-note')).toBe('Some note')
+  })
+
+  it('retitles the Home tab in every pane it is open in', async () => {
+    localStorage.setItem(ACTIVE_KEY, 'b2')
+    const view = mount(
+      makeState([
+        makeGroup('main', [homeTab({ id: 'tab-left' })]),
+        makeGroup('side', [homeTab({ id: 'tab-right' })])
+      ])
+    )
+
+    await waitFor(() => expect(view.titleOf('main', 'tab-left')).toBe('Work'))
+    expect(view.titleOf('side', 'tab-right')).toBe('Work')
+  })
+
+  it('follows the selection when the open board is deleted out from under it', async () => {
+    localStorage.setItem(ACTIVE_KEY, 'b2')
+    const view = mount(makeState([makeGroup('main', [homeTab()])]))
+    await waitFor(() => expect(view.titleOf('main', 'tab-home')).toBe('Work'))
+
+    // The stored id survives the delete; `useHomeBoards` resolves it to the
+    // first board that still exists, and the title has to follow that.
+    boards = [board('b1', 'Home', 0)]
+    act(() => emitHomePageUpdated?.())
+
+    await waitFor(() => expect(view.titleOf('main', 'tab-home')).toBe('Home'))
+  })
+
+  it('falls back to "Home" when the vault has no boards at all', async () => {
+    boards = []
+    const view = mount(makeState([makeGroup('main', [homeTab({ title: 'Work' })])]))
+
+    await waitFor(() => expect(view.titleOf('main', 'tab-home')).toBe('Home'))
+  })
+
+  it('falls back to "Home" when a board name is blank', async () => {
+    localStorage.setItem(ACTIVE_KEY, 'b2')
+    boards = [board('b1', 'Home', 0), board('b2', '   ', 1)]
+    const view = mount(makeState([makeGroup('main', [homeTab({ title: 'Work' })])]))
+
+    await waitFor(() => expect(view.titleOf('main', 'tab-home')).toBe('Home'))
+  })
+
+  it('leaves the restored title alone while the board list is still loading', async () => {
+    listBoards = () => new Promise<TestBoard[]>(() => {})
+    const view = mount(makeState([makeGroup('main', [homeTab({ title: 'Work' })])]))
+
+    await waitFor(() => expect(window.api.homePages.list).toHaveBeenCalled())
+
+    expect(view.titleOf('main', 'tab-home')).toBe('Work')
+  })
+
+  it('leaves tab state untouched when a refetch carries the title the tab already has', async () => {
+    // Widget edits invalidate the same query, so this is the common case, not
+    // the edge one: it must not churn state the persistence layer writes.
+    localStorage.setItem(ACTIVE_KEY, 'b2')
+    const view = mount(makeState([makeGroup('main', [homeTab()])]))
+    await waitFor(() => expect(view.titleOf('main', 'tab-home')).toBe('Work'))
+    const before = view.groups
+
+    act(() => emitHomePageUpdated?.())
+    await waitFor(() => expect(window.api.homePages.list).toHaveBeenCalledTimes(2))
+
+    expect(view.groups).toBe(before)
+  })
+
+  it('leaves tabs that are not Home alone', async () => {
+    localStorage.setItem(ACTIVE_KEY, 'b2')
+    const view = mount(makeState([makeGroup('main', [noteTab()])]))
+
+    await waitFor(() => expect(window.api.homePages.list).toHaveBeenCalled())
+
+    expect(view.titleOf('main', 'tab-note')).toBe('Some note')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/tabs/home-tab-title-sync.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/home-tab-title-sync.tsx
@@ -1,0 +1,58 @@
+/**
+ * Keeps the Home tab's title on the name of the board it is showing.
+ *
+ * A tab's title is a SNAPSHOT taken when the tab opens (`createDefaultTab`
+ * stamps the literal `'Home'`), so switching to another board, or renaming the
+ * one already open, left the tab reading `Home` for every board there is.
+ *
+ * It lives here, above the tab tree, rather than in the Home page: only the
+ * ACTIVE tab is mounted, so a page-level effect would go silent the moment the
+ * user looked at anything else — and a board renamed on another device arrives
+ * by sync while the Home tab sits in the background.
+ *
+ * Diffing shape rather than the event-driven one `CanvasTabTitleSync` uses: the
+ * board list is already in memory as a query, so there is nothing to hold a
+ * second copy of, and one derived title covers every route a rename can take
+ * (the board manager, a peer's write, a board being deleted out from under the
+ * selection) without a subscription per route.
+ *
+ * The default board is named `home.board.defaultName` — "Home" — when it is
+ * seeded, so an untouched install keeps reading "Home" and only a real rename
+ * changes it. That same string is the fallback for a session that has no board
+ * at all, which is what a tab persisted by an older build carries anyway.
+ *
+ * @module components/tabs/home-tab-title-sync
+ */
+
+import { useEffect } from 'react'
+
+import { useTabs } from '@/contexts/tabs'
+import { useHomeBoards } from '@/hooks/use-home-boards'
+import { useT } from '@memry/i18n/renderer'
+
+export function HomeTabTitleSync(): null {
+  const { activeBoard, isLoading } = useHomeBoards()
+  const { state, updateTabTitle } = useTabs()
+  const { t } = useT('common')
+  const tabGroups = state?.tabGroups
+
+  useEffect(() => {
+    // Retitling from the empty list the query starts on would overwrite a
+    // restored title with the fallback and then flip it back a tick later.
+    if (isLoading || !tabGroups) return
+    const title = activeBoard?.name?.trim() || t('home.board.defaultName')
+    for (const [groupId, group] of Object.entries(tabGroups)) {
+      for (const tab of group.tabs) {
+        // Skipping a tab that already reads `title` is what keeps a widget
+        // autosave — which invalidates the same query — from re-rendering the
+        // tab tree and re-arming the debounced write of tab state to disk.
+        if (tab.type !== 'home' || tab.title === title) continue
+        updateTabTitle(tab.id, title, groupId)
+      }
+    }
+  }, [activeBoard, isLoading, t, tabGroups, updateTabTitle])
+
+  return null
+}
+
+export default HomeTabTitleSync

--- a/apps/desktop/src/renderer/src/hooks/use-home-boards.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-home-boards.test.tsx
@@ -100,6 +100,23 @@ describe('useHomeBoards', () => {
     await waitFor(() => expect(listMock).toHaveBeenCalled())
   })
 
+  // The tab title is rendered from a second `useHomeBoards()` mounted above the
+  // tab tree, so a switch made on the Home page has to reach it. `localStorage`
+  // alone notifies nobody — a per-instance `useState` would leave the other
+  // consumer on the value it read at mount.
+  it('shares the active board id across hook instances', async () => {
+    const second = { ...board, id: 'b2', name: 'Work' }
+    vi.mocked(window.api.homePages.list).mockResolvedValue([board, second])
+    const { result: page } = renderHook(() => useHomeBoards(), { wrapper })
+    const { result: elsewhere } = renderHook(() => useHomeBoards(), { wrapper })
+    await waitFor(() => expect(elsewhere.current.boards).toHaveLength(2))
+
+    act(() => page.current.setActiveBoardId('b2'))
+
+    expect(elsewhere.current.activeBoardId).toBe('b2')
+    expect(elsewhere.current.activeBoard?.name).toBe('Work')
+  })
+
   it('unsubscribes from all three events on unmount', async () => {
     const { result, unmount } = renderHook(() => useHomeBoards(), { wrapper })
     await waitFor(() => expect(result.current.boards).toHaveLength(1))

--- a/apps/desktop/src/renderer/src/hooks/use-home-boards.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-home-boards.ts
@@ -1,10 +1,41 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useSyncExternalStore } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { HomePage, WidgetInstance } from '@memry/contracts/home-page-api'
 import { trackTelemetry } from '@/lib/telemetry'
 
 const ACTIVE_KEY = 'memry-home-active-board'
 const homeBoardsKey = ['home-boards'] as const
+
+/**
+ * The active board id is shared between hook instances, not private to one.
+ *
+ * `useHomeBoards` is mounted in more than one place — the Home page, and
+ * `HomeTabTitleSync` above the tab tree — and `localStorage` on its own
+ * notifies nobody: a write from one instance would leave every other one on the
+ * value it read into `useState` at mount, so the tab title would never learn
+ * which board the page switched to. A module-level store keeps them on one
+ * value, and also keeps two Home panes in a split from drifting apart.
+ *
+ * `localStorage` stays the source of truth rather than a cached copy: the
+ * snapshot is a string (stable for `useSyncExternalStore` by value), a session
+ * written by an older build is read unchanged, and a test clearing storage
+ * cannot be contradicted by module state that outlives it.
+ */
+const activeBoardListeners = new Set<() => void>()
+
+const subscribeActiveBoardId = (listener: () => void): (() => void) => {
+  activeBoardListeners.add(listener)
+  return () => {
+    activeBoardListeners.delete(listener)
+  }
+}
+
+const getStoredActiveBoardId = (): string | null => localStorage.getItem(ACTIVE_KEY)
+
+const setStoredActiveBoardId = (id: string): void => {
+  localStorage.setItem(ACTIVE_KEY, id)
+  for (const listener of activeBoardListeners) listener()
+}
 
 const trackBoardCustomized = (action: string, widgetCount?: number): void => {
   void trackTelemetry('home_board_customized', {
@@ -21,14 +52,7 @@ export function useHomeBoards() {
     queryFn: () => window.api.homePages.list()
   })
 
-  const [activeBoardId, setActiveBoardIdState] = useState<string | null>(() =>
-    localStorage.getItem(ACTIVE_KEY)
-  )
-
-  const setActiveBoardId = useCallback((id: string) => {
-    localStorage.setItem(ACTIVE_KEY, id)
-    setActiveBoardIdState(id)
-  }, [])
+  const activeBoardId = useSyncExternalStore(subscribeActiveBoardId, getStoredActiveBoardId)
 
   const invalidate = () => qc.invalidateQueries({ queryKey: homeBoardsKey })
 
@@ -93,7 +117,7 @@ export function useHomeBoards() {
     boards,
     activeBoard,
     activeBoardId: resolvedActiveId,
-    setActiveBoardId,
+    setActiveBoardId: setStoredActiveBoardId,
     isLoading,
     createBoard: (name: string): Promise<HomePage> => createMut.mutateAsync(name),
     renameBoard: (id: string, name: string): Promise<void> =>

--- a/apps/desktop/tests/setup-dom.ts
+++ b/apps/desktop/tests/setup-dom.ts
@@ -108,6 +108,15 @@ const createMockApi = () => ({
     deleteFromAccount: vi.fn().mockResolvedValue(undefined)
   },
 
+  // Home boards API (mounted app-wide by HomeTabTitleSync, not only by the Home page)
+  homePages: {
+    list: vi.fn().mockResolvedValue([]),
+    create: vi.fn().mockResolvedValue({ id: 'home-board', name: 'Home', position: 0, widgets: [] }),
+    update: vi.fn().mockResolvedValue({ id: 'home-board', name: 'Home', position: 0, widgets: [] }),
+    delete: vi.fn().mockResolvedValue({ success: true }),
+    reorder: vi.fn().mockResolvedValue({ success: true })
+  },
+
   // Notes API
   notes: {
     create: vi.fn().mockResolvedValue({ success: true, note: null }),
@@ -525,6 +534,9 @@ const createMockApi = () => ({
   onNoteMoved: vi.fn().mockReturnValue(() => {}),
   onNoteExternalChange: vi.fn().mockReturnValue(() => {}),
   onCanvasUpdated: vi.fn().mockReturnValue(() => {}),
+  onHomePageCreated: vi.fn().mockReturnValue(() => {}),
+  onHomePageUpdated: vi.fn().mockReturnValue(() => {}),
+  onHomePageDeleted: vi.fn().mockReturnValue(() => {}),
   onCanvasDeleted: vi.fn().mockReturnValue(() => {}),
   onLargeFileIndex: vi.fn().mockReturnValue(() => {}),
   onLargeFileSearchProgress: vi.fn().mockReturnValue(() => {}),

--- a/apps/docs/src/user-guide/home-dashboard.md
+++ b/apps/docs/src/user-guide/home-dashboard.md
@@ -10,10 +10,10 @@ Opening a board paints it in one pass — no entrance animation on the board or 
 
 A fresh vault auto-seeds a single board named **Home**. You can keep just that one or organize work across several boards.
 
-- **Switch boards** — pick a board from the board switcher in the header.
+- **Switch boards** — pick a board from the board switcher in the header. The Home tab takes the name of whichever board is open, so the tab strip says which one you are on.
 - **Create a board** — use **New board** in the switcher. It arrives named "New board"; rename it from the manager below.
 - **Manage boards** — **Manage boards** in the switcher opens a dialog listing every board:
-  - **Rename** — click a board's name (or the pencil) and type. **Enter** saves, **Esc** discards the edit and leaves the dialog open.
+  - **Rename** — click a board's name (or the pencil) and type. **Enter** saves, **Esc** discards the edit and leaves the dialog open. Renaming the board you are on retitles the Home tab with it.
   - **Reorder** — drag a row by its handle. The switcher and every synced device follow the new order.
   - **Delete** — the trash button removes a board and its widgets. The last remaining board can't be deleted.
 

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -218,6 +218,12 @@ A toast is no use while the window is going away, so memrynote records the failu
 
 A small dot appears on a tab title when there are unsaved changes (rare — memrynote auto-saves). On a compressed tab the dot takes the close button's place, so unsaved work stays visible. Closing a modified tab triggers a flush before close.
 
+## The Home Tab
+
+The Home tab is named after the board it is showing, not after the word "Home". Switch to another board and the tab follows; rename the board you are on and the tab picks the new name up straight away. A rename that arrives from another device counts too, and so does one that lands while Home is sitting in a background tab — the tab is retitled either way.
+
+A fresh vault seeds its first board as **Home**, so an untouched install reads exactly as it always did; the tab only changes once you rename that board or make another one. If the board you were on is deleted, the tab falls back to the first board that is left.
+
 ## Canvases in Tabs
 
 Canvases open as tabs too, so you can keep a board in one pane and a note in the other. Note that a note open in a visible pane is edited there, not on the canvas card — see [Cards & Links](./canvas/cards-and-links.md).


### PR DESCRIPTION
## The report

Beta user Aurelie Kabore, 22 Aug 2026, v2026-08-22:

> "I was able to rename a board. The tab still always says 'Home' even when in a different board."

## Root cause

A tab's title is a **snapshot**, not a derived value. `createDefaultTab` (`contexts/tabs/helpers.ts`) stamps the literal string `'Home'` when the Home tab is created, and nothing ever recomputes it — so no matter which board is active, or what that board was renamed to, the tab keeps reading `Home`. Canvas and agent tabs already have title-sync components above the tab tree for exactly this reason (`CanvasTabTitleSync`, `AgentTabTitleSync`); Home had none.

A second, quieter cause sat underneath it: `useHomeBoards` kept the active board id in a per-instance `useState` seeded from `localStorage`. `localStorage` notifies nobody, so a second consumer of the hook would never learn about a board switch made by the first one — which means a sync component could not have worked even if it existed.

## The fix

- **`components/tabs/home-tab-title-sync.tsx` (new)** — derives the title from the active board and retitles every `type === 'home'` tab, in every pane. It sits in `App.tsx` next to the two existing title syncs rather than inside the Home page, because **only the active tab is mounted**: a page-level effect would go silent the moment the user looked at anything else, and a board renamed on another device arrives by sync while the Home tab sits in the background.
- **`hooks/use-home-boards.ts`** — the active board id becomes a small module-level external store read through `useSyncExternalStore`. `localStorage` stays the source of truth (same key, same format); the store only adds the notification that was missing. This also stops two Home panes in a split view from drifting apart.
- Title when the board is the default one: **still "Home"**, because the seeded board is literally named `home.board.defaultName` ("Home"). It changes only if that board is actually renamed. That same i18n string is the fallback for a vault with no boards, or a board whose name is blank.

## Backward compatibility

No schema, contract, or persisted-format change.

- A tab persisted by an older build carries `title: 'Home'` and no board id at all. It is read unchanged and corrected on the next mount — covered by the first test.
- The `memry-home-active-board` localStorage key keeps its name and its plain-string value, so a session written by an older version is read as-is.
- The new title is written into the existing `Tab.title` field, which `serializeTabState` already persists, so it survives a restart with no migration.
- A vault with zero boards, or an active board id pointing at a board that no longer exists, both fall back rather than blanking the tab.

## Tests

`components/tabs/home-tab-title-sync.test.tsx` (new, 12 cases) drives the real `TabProvider`, the real reducer, and the real `useHomeBoards`; only the `window.api.homePages` IPC boundary is mocked.

- retitles a restored Home tab to the board it is showing (the rehydration / old-persisted-shape case)
- keeps "Home" while the untouched default board is open
- follows a switch to another board
- follows a rename of the board that is open
- retitles a Home tab the user is **not** looking at (the unmounted-page case)
- retitles the Home tab in every pane it is open in
- follows the selection when the open board is deleted out from under it
- falls back to "Home" with no boards, and with a blank board name
- leaves the restored title alone while the board list is still loading
- leaves tab state untouched when a refetch carries the title the tab already has
- leaves tabs that are not Home alone

`hooks/use-home-boards.test.tsx` gains `shares the active board id across hook instances`.

Both were mutation-checked: stubbing the sync effect to a no-op fails 8 of the 12; reverting the store to the old per-instance `useState` fails `follows a switch to another board`.

`App.test.tsx` and `App.workspace-counts.test.tsx` mock `@tanstack/react-query` wholesale, so they now stub `HomeTabTitleSync` (which owns a query subscription). The renderer test setup gained the `homePages` API and the three `onHomePage*` event mocks, since the hook is now mounted app-wide rather than only by the Home page.

## Verification

| Command | Result |
| --- | --- |
| `pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/components/tabs/home-tab-title-sync.test.tsx` | 12 passed |
| `pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/hooks/use-home-boards.test.tsx` | 9 passed |
| `pnpm exec vitest run --config config/vitest.config.ts --project renderer` (full renderer project) | 8242 passed, 2 files failed — `notes-tree-folder-rename-duplicate` / `notes-tree-virtualized-rename`, timeouts under full-suite load; both **pass in isolation** (22 passed) and neither touches boards or tab titles |
| `pnpm typecheck` | 17/17 tasks successful |
| `pnpm lint` | exit 0 (repo-wide pre-existing prettier warnings only; none in the touched files) |
| `pnpm docs:impact --base origin/main --strict` | `covered` |
| `pnpm docs:build` | build complete |

E2E was not run. The existing specs select the Home tab by testid (`nav-home`) or by `/Home/`, and a fresh e2e vault seeds its board as "Home", so the title they match is unchanged.

## Not in scope

With the Home feature flag off, the Home tab is a neutral launcher but would still take the active board's name. Left alone deliberately: gating it would add an untested branch and a second settings fetch at App level for a rare opt-out.
