### PR TITLE
fix(tabs): each vault keeps its own tabs across a switch

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -24,7 +24,7 @@ import { ThemeProvider } from 'next-themes'
 // Tab System imports
 import { TabProvider, useTabs } from '@/contexts/tabs'
 import { useRecordRecentlyOpened } from '@/hooks/use-recently-opened'
-import { useTabSessionPersistence, STORAGE_KEY } from '@/contexts/tabs/persistence'
+import { useTabSessionPersistence } from '@/contexts/tabs/persistence'
 import { TasksProvider } from '@/contexts/tasks'
 import { TabDragProvider, TabErrorBoundary } from '@/components/tabs'
 import { SplitViewContainer } from '@/components/split-view'
@@ -124,11 +124,20 @@ function ThemeSyncManager({ children }: { children: React.ReactNode }): React.JS
  * Component that enables tab session persistence.
  * Must be rendered inside TabProvider.
  */
-function TabPersistenceManager({ children }: { children: React.ReactNode }): React.JSX.Element {
+function TabPersistenceManager({
+  vaultPath,
+  children
+}: {
+  vaultPath: string | null
+  children: React.ReactNode
+}): React.JSX.Element {
   // Restore the stored session on mount, and hold the debounced auto-save until
   // that restore has landed — otherwise the save writes the provider's default
   // Home tab over the session the restore is still on its way to read.
-  useTabSessionPersistence()
+  //
+  // The vault path decides which session that is: each vault keeps its own tabs,
+  // so switching reads the other vault's set instead of destroying either.
+  useTabSessionPersistence({ vaultPath })
 
   return <>{children}</>
 }
@@ -398,9 +407,12 @@ function App(): React.JSX.Element {
     if (!vaultPath) return
     if (prevVaultPathRef.current && prevVaultPathRef.current !== vaultPath) {
       queryClient.clear()
-      localStorage.removeItem(STORAGE_KEY)
+      // Cached rows and expanded folder ids belong to the vault being left and
+      // mean nothing in the one being entered, so they go. Tab state does not:
+      // it is stored per vault and read back on the way in, so deleting it here
+      // was what left every switch on a bare Home tab, in both directions.
       localStorage.removeItem('sidebar-tree-expanded')
-      log.info('Vault switched, cleared query cache and tab state')
+      log.info('Vault switched, cleared query cache')
     }
     prevVaultPathRef.current = vaultPath
   }, [vaultPath, queryClient])
@@ -522,7 +534,7 @@ function App(): React.JSX.Element {
                   <HintModeProvider>
                     <TabProvider>
                       <AgentFeatureProvider>
-                        <TabPersistenceManager>
+                        <TabPersistenceManager vaultPath={vaultPath}>
                           <SettingsModalProvider>
                             <SelectedFolderProvider>
                               <SidebarDrillDownProvider>

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/hooks.ts
@@ -18,6 +18,7 @@ import {
 } from './storage'
 import { serializeTabState, deserializeTabState, extractPinnedTabs } from './serialization'
 import type { TabStorage } from './types'
+import { tabStateStorageKey } from './types'
 import { registerPendingSave, unregisterPendingSave } from '@/lib/save-registry'
 import { createLogger } from '@/lib/logger'
 import { useFeatureFlags } from '@/hooks/use-feature-flags'
@@ -34,6 +35,11 @@ const LAST_SESSION_TOAST_ID = 'tab-state-last-session-not-saved'
 interface UseTabPersistenceOptions {
   /** Storage adapter to use */
   storage?: TabStorage
+  /**
+   * Path of the open vault. Decides which key the tabs are written under, so
+   * one vault's session never lands on another's.
+   */
+  vaultPath?: string | null
   /** Debounce delay in ms (default: 1000) */
   debounceMs?: number
   /** Enable auto-save (default: true) */
@@ -44,7 +50,13 @@ interface UseTabPersistenceOptions {
  * Hook to auto-save tab state changes
  */
 export const useTabPersistence = (options: UseTabPersistenceOptions = {}): void => {
-  const { storage = getDefaultStorage(), debounceMs = 1000, enabled = true } = options
+  const {
+    vaultPath = null,
+    storage = getDefaultStorage(vaultPath),
+    debounceMs = 1000,
+    enabled = true
+  } = options
+  const storageKey = tabStateStorageKey(vaultPath)
   const { state } = useTabs()
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastSavedRef = useRef<string>('')
@@ -62,7 +74,7 @@ export const useTabPersistence = (options: UseTabPersistenceOptions = {}): void 
 
     registerPendingSave(FLUSH_REGISTRY_KEY, () => {
       const serialized = serializeTabState(stateRef.current)
-      const result = saveSync(serialized)
+      const result = saveSync(serialized, storageKey)
       if (!result.ok) {
         // Claiming a flush that never happened is what made this invisible:
         // whoever diagnoses "my tabs came back wrong after quitting" needs the
@@ -74,7 +86,7 @@ export const useTabPersistence = (options: UseTabPersistenceOptions = {}): void 
     })
 
     return () => unregisterPendingSave(FLUSH_REGISTRY_KEY)
-  }, [enabled])
+  }, [enabled, storageKey])
 
   // Debounced save
   useEffect(() => {
@@ -149,7 +161,7 @@ export const useTabPersistence = (options: UseTabPersistenceOptions = {}): void 
 
     const handleBeforeUnload = (): void => {
       const serialized = serializeTabState(stateRef.current)
-      const result = saveSync(serialized)
+      const result = saveSync(serialized, storageKey)
       if (!result.ok) {
         log.error('failed to save tab state on unload', { reason: result.reason })
       }
@@ -157,7 +169,35 @@ export const useTabPersistence = (options: UseTabPersistenceOptions = {}): void 
 
     window.addEventListener('beforeunload', handleBeforeUnload)
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [enabled])
+  }, [enabled, storageKey])
+
+  // Flush what is in hand when this subtree goes away.
+  //
+  // Switching vaults unmounts the whole tab tree, and the pending debounce goes
+  // with it: without this, the tabs opened in the last second before the switch
+  // are simply gone, because the timer that would have written them was cleared
+  // instead of fired.
+  //
+  // `enabled` is the guard that makes this safe. `useTabSessionPersistence`
+  // holds it false until the session restore has settled, so no cleanup is even
+  // registered while a restore is in flight — an unmount that interrupts one
+  // cannot write the provider's default Home tab over the session the restore
+  // had not read yet.
+  useEffect(() => {
+    if (!enabled) return
+
+    return () => {
+      // The next key starts from a clean slate: the fingerprint that just
+      // reached the outgoing key must not suppress the first write to another.
+      lastSavedRef.current = ''
+
+      const serialized = serializeTabState(stateRef.current)
+      const result = saveSync(serialized, storageKey)
+      if (!result.ok) {
+        log.error('failed to flush tab state on teardown', { reason: result.reason })
+      }
+    }
+  }, [enabled, storageKey])
 }
 
 // =============================================================================
@@ -178,6 +218,8 @@ interface UseSessionRestoreResult {
 interface UseSessionRestoreOptions {
   /** Storage adapter to use */
   storage?: TabStorage
+  /** Path of the open vault, deciding whose tabs are read back. */
+  vaultPath?: string | null
   /** Auto-restore on mount (default: true) */
   autoRestore?: boolean
 }
@@ -188,7 +230,7 @@ interface UseSessionRestoreOptions {
 export const useSessionRestore = (
   options: UseSessionRestoreOptions = {}
 ): UseSessionRestoreResult => {
-  const { storage = getDefaultStorage(), autoRestore = true } = options
+  const { vaultPath = null, storage = getDefaultStorage(vaultPath), autoRestore = true } = options
   const { dispatch, state } = useTabs()
   const { flags, isLoading: flagsLoading } = useFeatureFlags()
   const hasRestoredRef = useRef(false)
@@ -343,12 +385,13 @@ interface UseTabSessionPersistenceOptions extends UseTabPersistenceOptions {
 export const useTabSessionPersistence = (
   options: UseTabSessionPersistenceOptions = {}
 ): UseSessionRestoreResult => {
-  const { storage, debounceMs, enabled = true, autoRestore } = options
+  const { storage, vaultPath = null, debounceMs, enabled = true, autoRestore } = options
 
-  const restore = useSessionRestore({ storage, autoRestore })
+  const restore = useSessionRestore({ storage, vaultPath, autoRestore })
 
   useTabPersistence({
     storage,
+    vaultPath,
     debounceMs,
     enabled: enabled && !restore.isRestoring
   })

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/index.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/index.ts
@@ -4,13 +4,19 @@
 
 // Types
 export type { PersistedTabState, PersistedTabGroup, PersistedTab, TabStorage } from './types'
-export { STORAGE_VERSION, STORAGE_KEY } from './types'
+export { STORAGE_VERSION, STORAGE_KEY, tabStateStorageKey } from './types'
 
 // Serialization
 export { serializeTabState, deserializeTabState, extractPinnedTabs } from './serialization'
 
 // Storage adapters
-export { localStorageAdapter, getDefaultStorage, saveSync } from './storage'
+export {
+  localStorageAdapter,
+  createLocalStorageAdapter,
+  clearTabStateForVault,
+  getDefaultStorage,
+  saveSync
+} from './storage'
 export type { SyncSaveFailure, SyncSaveResult } from './storage'
 
 // Migrations

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx
@@ -9,13 +9,14 @@ import {
   useTabSessionPersistence
 } from './hooks'
 import {
+  clearTabStateForVault,
   consumeSyncSaveFailure,
   isQuotaExceededError,
   localStorageAdapter,
   saveSync
 } from './storage'
 import { deserializeTabState, extractPinnedTabs, serializeTabState } from './serialization'
-import { STORAGE_KEY, type PersistedTabState, type TabStorage } from './types'
+import { STORAGE_KEY, tabStateStorageKey, type PersistedTabState, type TabStorage } from './types'
 import type { Tab, TabSystemState } from '@/contexts/tabs/types'
 
 const mocks = vi.hoisted(() => ({
@@ -336,8 +337,16 @@ const startupState = (): TabSystemState =>
   }) as TabSystemState
 
 /** Mounts the pair exactly the way `TabPersistenceManager` does at app start. */
-function StartupProbe({ storage, debounceMs }: { storage: TabStorage; debounceMs: number }) {
-  sessionSnapshot = useTabSessionPersistence({ storage, debounceMs })
+function StartupProbe({
+  storage,
+  vaultPath,
+  debounceMs
+}: {
+  storage?: TabStorage
+  vaultPath?: string | null
+  debounceMs: number
+}) {
+  sessionSnapshot = useTabSessionPersistence({ storage, vaultPath, debounceMs })
   return null
 }
 
@@ -415,7 +424,7 @@ describe('tab persistence serialization and storage', () => {
     const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw new Error('quota')
     })
-    expect(saveSync(persisted())).toMatchObject({ ok: false, reason: 'error' })
+    expect(saveSync(persisted(), STORAGE_KEY)).toMatchObject({ ok: false, reason: 'error' })
     setItem.mockRestore()
     expect(consumeSyncSaveFailure()).toBeNull()
   })
@@ -423,7 +432,11 @@ describe('tab persistence serialization and storage', () => {
   it('reports a refused synchronous save and leaves a marker for the next launch', () => {
     const setItem = refuseWritesTo(STORAGE_KEY, quotaError())
 
-    expect(saveSync(persisted())).toEqual({ ok: false, reason: 'quota', at: expect.any(Number) })
+    expect(saveSync(persisted(), STORAGE_KEY)).toEqual({
+      ok: false,
+      reason: 'quota',
+      at: expect.any(Number)
+    })
     setItem.mockRestore()
 
     // The marker is what the next launch reads; consuming it is one-shot, so a
@@ -434,10 +447,10 @@ describe('tab persistence serialization and storage', () => {
 
   it('clears the failure marker once a synchronous save succeeds', () => {
     const setItem = refuseWritesTo(STORAGE_KEY, quotaError())
-    saveSync(persisted())
+    saveSync(persisted(), STORAGE_KEY)
     setItem.mockRestore()
 
-    expect(saveSync(persisted())).toEqual({ ok: true })
+    expect(saveSync(persisted(), STORAGE_KEY)).toEqual({ ok: true })
     expect(localStorage.getItem(STORAGE_KEY)).toContain('pin-1')
     expect(consumeSyncSaveFailure()).toBeNull()
   })
@@ -723,7 +736,7 @@ describe('tab persistence hooks', () => {
 
   it('tells the user at the next launch that the last session was never saved', async () => {
     const setItem = refuseWritesTo(STORAGE_KEY, quotaError())
-    saveSync(serializeTabState(state()))
+    saveSync(serializeTabState(state()), STORAGE_KEY)
     setItem.mockRestore()
 
     const storage: TabStorage = {
@@ -755,7 +768,7 @@ describe('tab persistence hooks', () => {
 
     // A refusal that is not about space explains itself differently.
     const failAgain = refuseWritesTo(STORAGE_KEY, new Error('storage backend offline'))
-    saveSync(serializeTabState(state()))
+    saveSync(serializeTabState(state()), STORAGE_KEY)
     failAgain.mockRestore()
 
     render(withQueryClient(<SessionRestoreProbe storage={storage} />))
@@ -889,5 +902,238 @@ describe('tab session persistence startup order', () => {
     const written = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as PersistedTabState
     expect(Object.keys(written.tabGroups)).toEqual(['group-1'])
     expect(written.tabGroups['group-1'].tabs.map((item) => item.id)).toEqual(['pin-1', 'note-1'])
+  })
+})
+
+/**
+ * Reported by a beta user on 22 Aug 2026:
+ *
+ *   "Now concerning the tabs opened to remain when app relaunched, they are
+ *    preserved when I relaunch the app. But not if I switched to another vault.
+ *    It left me with the Home tab. I tested, switching back and forth between 2
+ *    vaults, opened many tabs on both, and switched. All gone, only Home tab.
+ *    But they are preserved when closing and reopening the app."
+ *
+ * Switching vaults remounts the whole tab tree, so the state in memory is meant
+ * to go — but the stored session went with it, in both directions, which is why
+ * switching back did not bring the first vault's tabs home either.
+ */
+describe('tab session persistence is scoped per vault', () => {
+  const VAULT_A = '/Users/aurelie/Vaults/Work'
+  const VAULT_B = '/Users/aurelie/Vaults/Personal'
+
+  const keyA = tabStateStorageKey(VAULT_A)
+  const keyB = tabStateStorageKey(VAULT_B)
+
+  const readKey = (key: string): PersistedTabState | null =>
+    JSON.parse(localStorage.getItem(key) ?? 'null') as PersistedTabState | null
+
+  const tabIdsAt = (key: string): string[] | null => {
+    const stored = readKey(key)
+    if (!stored) return null
+    return Object.values(stored.tabGroups).flatMap((group) => group.tabs.map((item) => item.id))
+  }
+
+  /** The session one vault is left holding: a pinned tab and a note tab. */
+  const sessionFor = (noteId: string): PersistedTabState =>
+    persisted({
+      tabGroups: {
+        'group-1': {
+          id: 'group-1',
+          activeTabId: noteId,
+          tabs: [
+            {
+              id: 'pin-1',
+              type: 'inbox',
+              title: 'Inbox',
+              icon: 'inbox',
+              path: '/inbox',
+              isPinned: true
+            },
+            {
+              id: noteId,
+              type: 'note',
+              title: noteId,
+              icon: 'file-text',
+              path: `/note/${noteId}`,
+              entityId: noteId,
+              isPinned: false
+            }
+          ]
+        }
+      }
+    })
+
+  const restorePayload = (): Partial<TabSystemState> | undefined => {
+    const call = mocks.dispatch.mock.calls.find((entry) => entry[0]?.type === 'RESTORE_SESSION')
+    return call?.[0].payload as Partial<TabSystemState> | undefined
+  }
+
+  const newQueryClient = () =>
+    new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+    })
+
+  const probe = (vaultPath: string) => (
+    <QueryClientProvider client={newQueryClient()}>
+      <StartupProbe vaultPath={vaultPath} debounceMs={25} />
+    </QueryClientProvider>
+  )
+
+  /** Swap the provider's state the way the reducer would once tabs are open. */
+  const holdSession = (session: PersistedTabState): void => {
+    mocks.tabsState = {
+      ...(mocks.tabsState as TabSystemState),
+      ...(deserializeTabState(session, mocks.flags) as Partial<TabSystemState>)
+    } as TabSystemState
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    localStorage.clear()
+    mocks.tabsState = startupState()
+    mocks.flagsLoading = false
+    sessionSnapshot = null
+
+    // Stand in for the reducer, the way the startup-order suite does: the real
+    // provider swaps its default state for the restored one.
+    mocks.dispatch.mockImplementation((action: { type: string; payload?: unknown }) => {
+      if (action.type !== 'RESTORE_SESSION') return
+      mocks.tabsState = {
+        ...(mocks.tabsState as TabSystemState),
+        ...(action.payload as Partial<TabSystemState>)
+      } as TabSystemState
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('leaves the other vault tabs alone and hands them back on the way home', async () => {
+    // Vault A already holds a session; vault B has never been opened.
+    localStorage.setItem(keyA, JSON.stringify(sessionFor('note-a')))
+
+    // --- Vault A ------------------------------------------------------------
+    const inVaultA = render(probe(VAULT_A))
+    await waitFor(() => expect(restorePayload()).toBeDefined())
+    expect(restorePayload()?.tabGroups?.['group-1'].tabs.map((item) => item.id)).toEqual([
+      'pin-1',
+      'note-a'
+    ])
+
+    await waitFor(() => expect(sessionSnapshot?.isRestoring).toBe(false))
+    act(() => vi.advanceTimersByTime(100))
+    expect(tabIdsAt(keyA)).toEqual(['pin-1', 'note-a'])
+
+    // --- Switch to vault B --------------------------------------------------
+    // `App` keys its tree by the vault path, so the switch is an unmount and a
+    // remount with the provider's default Home tab.
+    inVaultA.unmount()
+    mocks.dispatch.mockClear()
+    mocks.tabsState = startupState()
+
+    const inVaultB = render(probe(VAULT_B))
+    await waitFor(() => expect(sessionSnapshot?.isRestoring).toBe(false))
+
+    // A vault that has never been opened starts on Home, and says so by not
+    // restoring anything at all.
+    expect(restorePayload()).toBeUndefined()
+
+    // B opens its own tabs and they are written under B's key…
+    holdSession(sessionFor('note-b'))
+    inVaultB.rerender(probe(VAULT_B))
+    act(() => vi.advanceTimersByTime(100))
+    expect(tabIdsAt(keyB)).toEqual(['pin-1', 'note-b'])
+
+    // …while A's session is exactly where A left it. This is the assertion the
+    // report turns on: the switch used to delete this entry, which is why
+    // switching back showed nothing either.
+    expect(tabIdsAt(keyA)).toEqual(['pin-1', 'note-a'])
+
+    // --- Switch back to vault A ---------------------------------------------
+    inVaultB.unmount()
+    mocks.dispatch.mockClear()
+    mocks.tabsState = startupState()
+
+    render(probe(VAULT_A))
+    await waitFor(() => expect(restorePayload()).toBeDefined())
+
+    const restored = restorePayload()?.tabGroups?.['group-1'].tabs
+    expect(restored?.map((item) => item.id)).toEqual(['pin-1', 'note-a'])
+    expect(restored?.find((item) => item.id === 'pin-1')?.isPinned).toBe(true)
+  })
+
+  it('adopts the one pre-vault entry into the vault that opens, and only that one', async () => {
+    // What an install upgrading from a build with a single global key holds.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sessionFor('note-legacy')))
+
+    render(probe(VAULT_A))
+
+    // Nobody loses their tabs to the upgrade: the vault the app reopens is the
+    // vault they were left in, so it takes them over.
+    await waitFor(() => expect(restorePayload()).toBeDefined())
+    expect(restorePayload()?.tabGroups?.['group-1'].tabs.map((item) => item.id)).toEqual([
+      'pin-1',
+      'note-legacy'
+    ])
+    expect(tabIdsAt(keyA)).toEqual(['pin-1', 'note-legacy'])
+
+    // And the legacy entry is gone, so the next vault cannot inherit the same
+    // tabs a second time.
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+
+    mocks.dispatch.mockClear()
+    mocks.tabsState = startupState()
+    render(probe(VAULT_B))
+    await waitFor(() => expect(sessionSnapshot?.isRestoring).toBe(false))
+    expect(restorePayload()).toBeUndefined()
+    expect(localStorage.getItem(keyB)).toBeNull()
+  })
+
+  it('writes the pending debounce out on the way to the other vault', async () => {
+    localStorage.setItem(keyA, JSON.stringify(sessionFor('note-a')))
+
+    const inVaultA = render(probe(VAULT_A))
+    await waitFor(() => expect(sessionSnapshot?.isRestoring).toBe(false))
+    act(() => vi.advanceTimersByTime(100))
+    expect(tabIdsAt(keyA)).toEqual(['pin-1', 'note-a'])
+
+    // One more tab, then the switch, inside the debounce window.
+    holdSession(sessionFor('note-late'))
+    inVaultA.rerender(probe(VAULT_A))
+    act(() => vi.advanceTimersByTime(5))
+    inVaultA.unmount()
+
+    expect(tabIdsAt(keyA)).toEqual(['pin-1', 'note-late'])
+  })
+
+  it('does not write the default Home tab over a session the restore never read', () => {
+    const stored = sessionFor('note-a')
+    localStorage.setItem(keyA, JSON.stringify(stored))
+
+    // The flag IPC never answers, so auto-save stays shut the whole time.
+    mocks.flagsLoading = true
+
+    const inVaultA = render(probe(VAULT_A))
+    act(() => vi.advanceTimersByTime(100))
+
+    // A switch that lands mid-restore takes the Home-only default with it.
+    inVaultA.unmount()
+    mocks.flagsLoading = false
+
+    expect(readKey(keyA)).toEqual(stored)
+  })
+
+  it('forgets a removed vault tab state instead of leaving it on the quota', () => {
+    localStorage.setItem(keyA, JSON.stringify(sessionFor('note-a')))
+    localStorage.setItem(keyB, JSON.stringify(sessionFor('note-b')))
+
+    clearTabStateForVault(VAULT_A)
+
+    expect(localStorage.getItem(keyA)).toBeNull()
+    expect(tabIdsAt(keyB)).toEqual(['pin-1', 'note-b'])
   })
 })

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/storage.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/storage.ts
@@ -4,7 +4,7 @@
  */
 
 import type { TabStorage, PersistedTabState } from './types'
-import { STORAGE_KEY } from './types'
+import { STORAGE_KEY, tabStateStorageKey } from './types'
 import { createLogger } from '@/lib/logger'
 
 const log = createLogger('TabPersistence:Storage')
@@ -29,42 +29,113 @@ export const isQuotaExceededError = (error: unknown): boolean => {
 // =============================================================================
 
 /**
+ * Read one key, returning null for anything that is not a usable tab state.
+ * A key that holds garbage is treated as empty rather than thrown over: the
+ * cost of getting this wrong is the user's whole session.
+ */
+const readStateAt = (storageKey: string): PersistedTabState | null => {
+  try {
+    const json = localStorage.getItem(storageKey)
+    if (!json) return null
+
+    const parsed = JSON.parse(json)
+
+    // Basic validation
+    if (!parsed.version || !parsed.tabGroups || !parsed.layout) {
+      log.warn('Invalid persisted tab state, ignoring')
+      return null
+    }
+
+    return parsed as PersistedTabState
+  } catch (error) {
+    log.error('Failed to load tab state from localStorage:', error)
+    return null
+  }
+}
+
+/**
+ * Hand the one pre-scoping entry to the first vault that asks for its own.
+ *
+ * Upgrading installs have their tabs under the global key. Whichever vault the
+ * app opens on is the vault those tabs were left in — the app reopens the last
+ * vault — so it takes them over, and the legacy entry is dropped in the same
+ * breath so a later switch cannot inherit the same tabs into a second vault.
+ * Failing to clear it is the only way this can go wrong, so a refused write
+ * leaves the legacy entry alone and the vault simply starts empty.
+ */
+const adoptLegacyState = (storageKey: string): PersistedTabState | null => {
+  const legacy = readStateAt(STORAGE_KEY)
+  if (!legacy) return null
+
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(legacy))
+    localStorage.removeItem(STORAGE_KEY)
+  } catch (error) {
+    log.error('Failed to adopt pre-vault tab state:', error)
+    return null
+  }
+
+  log.info('adopted pre-vault tab state into the open vault')
+  return legacy
+}
+
+/**
+ * LocalStorage adapter bound to one vault's key.
+ *
+ * Adapters are cached per key so the identity a caller passes to a React effect
+ * stays stable across renders — a fresh object each render would restart the
+ * auto-save debounce forever and nothing would ever be written.
+ */
+const adapterCache = new Map<string, TabStorage>()
+
+export const createLocalStorageAdapter = (vaultPath: string | null | undefined): TabStorage => {
+  const storageKey = tabStateStorageKey(vaultPath)
+  const cached = adapterCache.get(storageKey)
+  if (cached) return cached
+
+  const adapter: TabStorage = {
+    save: async (state: PersistedTabState): Promise<void> => {
+      try {
+        const json = JSON.stringify(state)
+        localStorage.setItem(storageKey, json)
+      } catch (error) {
+        log.error('Failed to save tab state to localStorage:', error)
+        throw error
+      }
+    },
+
+    load: async (): Promise<PersistedTabState | null> => {
+      const own = readStateAt(storageKey)
+      if (own) return own
+      if (storageKey === STORAGE_KEY) return null
+      return adoptLegacyState(storageKey)
+    },
+
+    clear: async (): Promise<void> => {
+      localStorage.removeItem(storageKey)
+    }
+  }
+
+  adapterCache.set(storageKey, adapter)
+  return adapter
+}
+
+/**
  * LocalStorage adapter for tab persistence
  * Best for simple web apps with small state
  */
-export const localStorageAdapter: TabStorage = {
-  save: async (state: PersistedTabState): Promise<void> => {
-    try {
-      const json = JSON.stringify(state)
-      localStorage.setItem(STORAGE_KEY, json)
-    } catch (error) {
-      log.error('Failed to save tab state to localStorage:', error)
-      throw error
-    }
-  },
+export const localStorageAdapter: TabStorage = createLocalStorageAdapter(null)
 
-  load: async (): Promise<PersistedTabState | null> => {
-    try {
-      const json = localStorage.getItem(STORAGE_KEY)
-      if (!json) return null
-
-      const parsed = JSON.parse(json)
-
-      // Basic validation
-      if (!parsed.version || !parsed.tabGroups || !parsed.layout) {
-        log.warn('Invalid persisted tab state, ignoring')
-        return null
-      }
-
-      return parsed as PersistedTabState
-    } catch (error) {
-      log.error('Failed to load tab state from localStorage:', error)
-      return null
-    }
-  },
-
-  clear: async (): Promise<void> => {
-    localStorage.removeItem(STORAGE_KEY)
+/**
+ * Forget one vault's stored tabs.
+ * Called when a vault is removed from the app, so a vault the user will never
+ * open again does not keep sitting on the origin's quota.
+ */
+export const clearTabStateForVault = (vaultPath: string): void => {
+  try {
+    localStorage.removeItem(tabStateStorageKey(vaultPath))
+  } catch (error) {
+    log.warn('Failed to clear tab state for removed vault:', error)
   }
 }
 
@@ -141,10 +212,10 @@ export const consumeSyncSaveFailure = (): SyncSaveFailure | null => {
  * regression far worse than the failed write. The result is returned instead so
  * they can log the truth rather than claim a flush that did not happen.
  */
-export const saveSync = (state: PersistedTabState): SyncSaveResult => {
+export const saveSync = (state: PersistedTabState, storageKey: string): SyncSaveResult => {
   try {
     const json = JSON.stringify(state)
-    localStorage.setItem(STORAGE_KEY, json)
+    localStorage.setItem(storageKey, json)
     clearSaveFailure()
     return { ok: true }
   } catch (error) {
@@ -171,6 +242,6 @@ export const saveSync = (state: PersistedTabState): SyncSaveResult => {
  * closed without moving off it), the replacement backend needs a migration read
  * from `STORAGE_KEY` and a downgrade story, which is its own change.
  */
-export const getDefaultStorage = (): TabStorage => {
-  return localStorageAdapter
+export const getDefaultStorage = (vaultPath?: string | null): TabStorage => {
+  return createLocalStorageAdapter(vaultPath ?? null)
 }

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/types.ts
@@ -18,8 +18,29 @@ import type {
 /** Current schema version for migrations */
 export const STORAGE_VERSION = 2
 
-/** Storage key for tab state */
+/**
+ * Storage key for tab state written before tabs were scoped per vault.
+ *
+ * Still read: an install upgrading from a build that kept one global entry has
+ * its tabs here, and the first vault to look for its own key adopts them (see
+ * `createLocalStorageAdapter`). Nothing writes it any more.
+ */
 export const STORAGE_KEY = 'memry_tab_state'
+
+/**
+ * Storage key holding one vault's tabs.
+ *
+ * Tabs are per-vault the way the rest of the app's vault state is: a note tab
+ * in one vault means nothing in another, so each vault gets its own entry and
+ * switching between them is a read, never a write to the vault being left.
+ *
+ * The vault path is the identity the renderer already switches on (`App` keys
+ * its whole tree by it), so it is the identity used here too. A vault with no
+ * path — no vault open — falls back to the legacy key, which is inert: the
+ * persistence manager only mounts inside the vault-open branch.
+ */
+export const tabStateStorageKey = (vaultPath: string | null | undefined): string =>
+  vaultPath ? `${STORAGE_KEY}:${vaultPath}` : STORAGE_KEY
 
 // =============================================================================
 // PERSISTED TYPES

--- a/apps/desktop/src/renderer/src/hooks/use-vault.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-vault.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getMockApi } from '@tests/utils/render'
 import { useVault, useVaultList } from './use-vault'
+import { tabStateStorageKey } from '@/contexts/tabs/persistence'
 
 function vaultApi() {
   return getMockApi() as {
@@ -183,9 +184,16 @@ describe('useVaultList', () => {
     })
     expect(result.current.vaults).toEqual([{ path: '/other', name: 'Other' }])
 
+    // A removed vault's tabs go with it: nothing will ever read them again, and
+    // they would sit on the origin's quota beside the vaults still in use.
+    localStorage.setItem(tabStateStorageKey('/other'), '{}')
+    localStorage.setItem(tabStateStorageKey('/vault'), '{}')
+
     await act(async () => {
       await result.current.removeVault('/other')
     })
     expect(api.vault.remove).toHaveBeenCalledWith('/other')
+    expect(localStorage.getItem(tabStateStorageKey('/other'))).toBeNull()
+    expect(localStorage.getItem(tabStateStorageKey('/vault'))).toBe('{}')
   })
 })

--- a/apps/desktop/src/renderer/src/hooks/use-vault.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-vault.ts
@@ -15,6 +15,7 @@ import {
   onVaultIndexRecovered
 } from '../services/vault-service'
 import { getI18n } from 'react-i18next'
+import { clearTabStateForVault } from '@/contexts/tabs/persistence'
 
 /**
  * Hook for vault state management.
@@ -299,6 +300,9 @@ export function useVaultList() {
   const removeVault = useCallback(
     async (path: string) => {
       await vaultService.remove(path)
+      // The removed vault's tabs would otherwise sit on the origin's quota
+      // forever, competing with the tab state of vaults the user still opens.
+      clearTabStateForVault(path)
       await refresh()
     },
     [refresh]

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -149,6 +149,14 @@ If **Restore Session** is on, the entire tab and split layout restores on app la
 
 The layout is written only when one of those things actually changes. Activity that leaves the layout alone — a note picking up and losing its modified dot, moving back and forward inside a tab — no longer triggers a rewrite. Quitting still writes the current layout either way, so nothing is lost by the skipped writes.
 
+### Every vault keeps its own tabs
+
+Tabs belong to the vault they were opened in. Switch vaults and you get that vault's own set back — the tabs you had open in it last time, in their order, with their pinned tabs; a vault you have never opened starts on a single Home tab. Switching back returns the first vault's tabs untouched.
+
+Until now a switch left you on a bare Home tab in either direction: every vault shared one stored layout, and changing vaults cleared it, so the vault you arrived in had nothing to restore and the vault you left had already been wiped on the way out. Closing and reopening the app was unaffected, which is why the tabs looked like they only disappeared when you switched.
+
+Nothing needs to be moved by hand after updating. The tabs stored by earlier versions are adopted by the first vault you open, which is the vault they were left in, and each vault takes on its own set from there. Removing a vault from the app forgets its tabs as well.
+
 ### The restore goes first
 
 Saving is held until the stored session has been read back. Before that, a slow launch could let the first automatic save run while the window was still showing its opening Home tab, which wrote that single tab over the session waiting in storage — the restore then had nothing left to bring back, and you arrived at a Home tab even if you had closed Home before quitting. Pinned tabs went the same way, since they live in the same stored layout.


### PR DESCRIPTION
## The report

Aurelie Kabore, beta feedback, 22 Aug 2026, v2026-08-22:

> "Now concerning the tabs opened to remain when app relaunched, they are preserved when I relaunch the app. But not if I switched to another vault. It left me with the Home tab. I tested, switching back and forth between 2 vaults, opened many tabs on both, and switched. All gone, only Home tab. But they are preserved when closing and reopening the app."

## Root cause

Tab state lived under a single global `localStorage` key, `memry_tab_state`, and the vault-switch effect in `App.tsx` deleted it on every switch:

```ts
if (prevVaultPathRef.current && prevVaultPathRef.current !== vaultPath) {
  queryClient.clear()
  localStorage.removeItem(STORAGE_KEY)      // ← the whole stored session
  localStorage.removeItem('sidebar-tree-expanded')
}
```

`App` also keys its tree by the vault path (`<SidebarProvider key={vaultPath}>`), so a switch remounts `TabProvider` on its default single Home tab and re-runs the session restore. With the key just deleted, the restore had nothing to read — hence the bare Home tab. The same effect ran on the way back, so the second vault's tabs were destroyed too, which is why switching back showed nothing either. Quitting and relaunching never ran the effect, so a plain restart looked fine. The recent restore-ordering fix (#1630) is intact and unrelated.

## The fix

Tabs are stored per vault, under `memry_tab_state:<vaultPath>` — the vault path is the identity the renderer already switches on, so no new notion of vault identity was invented. `createLocalStorageAdapter(vaultPath)` binds one adapter per key (cached, so the identity stays stable across renders and does not restart the auto-save debounce), and `useTabPersistence` / `useSessionRestore` / `useTabSessionPersistence` take a `vaultPath`. `saveSync` now takes the key explicitly rather than defaulting to the global one. The `removeItem(STORAGE_KEY)` in `App.tsx` is gone; `sidebar-tree-expanded` and the query cache are still cleared, since those really do belong to the vault being left.

Two smaller holes closed while in here, both surfaced by the self-review:

- The pending auto-save debounce was cleared, not fired, when the tab tree unmounted, so the last second of tab changes was lost on a switch. It is flushed on teardown now, gated on the same `enabled` flag that holds auto-save shut during a restore — so an unmount that interrupts a restore still cannot write the default Home tab over a stored session.
- Removing a vault from the app now forgets its tabs (`clearTabStateForVault`) instead of leaving them on the origin's quota forever.

## Backward compatibility

Real installs have a session under the old global key right now, and it must not vanish on upgrade.

- `STORAGE_KEY` is still read. The first vault to look for its own entry and not find one adopts the pre-scoping entry, writes it under its own key, and removes the legacy key in the same breath — so a later switch cannot inherit the same tabs into a second vault. The app reopens the last vault on launch, which is the vault those tabs were left in, so the adoption lands on the right vault.
- A refused adoption write leaves the legacy entry alone and the vault simply starts empty; nothing is deleted before the replacement is written.
- Nothing writes the legacy key any more, and `saveSync` no longer defaults to it.
- The E2E specs that seed `memry_tab_state` through `addInitScript` (`tab-reuse-on-page-click`, `file-attachments-viewer`, `note-menu-actions`, `pdf-embed-resize`) keep working through exactly this adoption path — the test vault has no scoped entry, so the seeded legacy one is picked up.
- Downgrading to an older build would leave a user on a Home tab once (the scoped entry is invisible to it); no data is lost and re-upgrading finds the entry again.

## Tests

`apps/desktop/src/renderer/src/contexts/tabs/persistence/persistence.test.tsx`, new suite "tab session persistence is scoped per vault":

- vault A restores its session → switch to B (unmount + remount, as `App` does) → B has never been opened so it restores nothing and stays on Home → B writes its own tabs under B's key → **A's entry is still exactly where A left it** → switch back to A restores A's tabs with pinned state intact. This is the reported round trip, including the overwrite case.
- the pre-vault entry is adopted by the vault that opens, the legacy key is dropped, and the next vault does **not** inherit it.
- the pending debounce is written out on the way to the other vault instead of being dropped.
- an unmount while the restore is still gated on the feature-flag IPC does not write the default Home tab over the stored session.
- a removed vault's tabs are forgotten while other vaults' are untouched.

`apps/desktop/src/renderer/src/hooks/use-vault.test.tsx` — `removeVault` clears the removed vault's tab state and only that one.

Proof the new tests bite: with `hooks.ts` reverted to `main` and everything else in place, 3 of the 5 fail (`expected undefined to be defined`, `expected null to deeply equal [ 'pin-1', 'note-legacy' ]`, `expected [ 'pin-1', 'note-a' ] to deeply equal [ 'pin-1', 'note-late' ]`).

## Verification

| Command | Result |
| --- | --- |
| `pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/contexts/tabs src/renderer/src/hooks/use-vault.test.tsx src/renderer/src/components/vault-switcher.test.tsx` (in `apps/desktop`) | 14 files, 162 tests passed |
| `pnpm typecheck` | 17/17 successful |
| `pnpm exec eslint` on every changed file | 0 errors, 0 warnings |
| `pnpm check:architecture` | passed |
| `pnpm docs:impact --base origin/main --strict` | `covered` |
| `pnpm docs:build` | build complete |

Not run, per the brief: full `pnpm test` and the E2E suite.

## Notes

- No IPC contracts, preload, or main-process handlers were touched, so `ipc:generate` / `ipc:check` do not apply.
- No new user-facing strings, so no i18n additions.
- Pre-existing and untouched: the same vault-switch effect clears `sidebar-tree-expanded` globally rather than per vault — a separate bug for folder expansion, not tabs.
