### PR TITLE
fix(sync): stamp a first clock on frozen clock-less push payloads

### DIFF
--- a/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
@@ -595,8 +595,10 @@ describe('PushCoordinator', () => {
       expect(postToServerMock).toHaveBeenCalledTimes(2)
       const first = postToServerMock.mock.calls[0][1] as PushBody
       const second = postToServerMock.mock.calls[1][1] as PushBody
-      expect(first.items[0].encryptedData).toBe(v1)
-      expect(second.items[0].encryptedData).toBe(v2)
+      // The wire payload additionally carries the first clock the coordinator
+      // stamps on a clock-less payload of a clock-required type.
+      expect(JSON.parse(first.items[0].encryptedData)).toMatchObject({ title: 'first' })
+      expect(JSON.parse(second.items[0].encryptedData)).toMatchObject({ title: 'second' })
 
       expect(queue.getSize()).toBe(0)
     })
@@ -625,7 +627,7 @@ describe('PushCoordinator', () => {
       expect(postToServerMock).toHaveBeenCalledTimes(1)
       const body = postToServerMock.mock.calls[0][1] as PushBody
       expect(body.items).toHaveLength(1)
-      expect(body.items[0].encryptedData).toBe(v2)
+      expect(JSON.parse(body.items[0].encryptedData)).toMatchObject({ title: 'second' })
       expect(queue.getSize()).toBe(0)
     })
 
@@ -684,8 +686,95 @@ describe('PushCoordinator', () => {
       const body = postToServerMock.mock.calls[0][1] as PushBody
       expect(body.items).toHaveLength(1)
       expect(body.items[0].operation).toBe('create')
-      expect(body.items[0].encryptedData).toBe(v2)
+      expect(JSON.parse(body.items[0].encryptedData)).toMatchObject({ title: 'second' })
       expect(queue.getSize()).toBe(0)
+    })
+  })
+
+  // A frozen queue payload written by a pre-#1223 build has no clock, and the
+  // handlers' buildPushPayload repair never reaches a delete, an orphaned row,
+  // or a handler throw — those all push the frozen payload verbatim. The server
+  // requires a clock on every item of a clock-required type and one clock-less
+  // item fails the whole batch, so a single such row blocks the queue forever.
+  describe('#given a clock-less frozen payload of a clock-required type', () => {
+    it('#then a delete is stamped with a first clock before it is pushed', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      acceptAll()
+
+      queue.enqueue({
+        type: 'calendar_external_event',
+        itemId: 'cal-ev-1',
+        operation: 'delete',
+        payload: JSON.stringify({ id: 'cal-ev-1', title: 'Standup' })
+      })
+
+      await coordinator.push()
+
+      const body = postToServerMock.mock.calls[0][1] as PushBody
+      expect(body.items).toHaveLength(1)
+      expect(JSON.parse(body.items[0].encryptedData)).toMatchObject({
+        id: 'cal-ev-1',
+        clock: { 'device-1': 1 }
+      })
+      expect(queue.getSize()).toBe(0)
+    })
+
+    it('#then an orphaned update falls back to the frozen payload with a clock stamped', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      acceptAll()
+      // Row no longer exists locally, so the handler cannot rebuild it.
+      getHandlerMock.mockReturnValue({ buildPushPayload: () => null, markPushSynced: vi.fn() })
+
+      queue.enqueue({
+        type: 'calendar_external_event',
+        itemId: 'cal-ev-2',
+        operation: 'update',
+        payload: JSON.stringify({ id: 'cal-ev-2', title: 'Retro' })
+      })
+
+      await coordinator.push()
+
+      const body = postToServerMock.mock.calls[0][1] as PushBody
+      expect(JSON.parse(body.items[0].encryptedData)).toMatchObject({
+        id: 'cal-ev-2',
+        clock: { 'device-1': 1 }
+      })
+    })
+
+    it('#then a payload that already carries a clock is left untouched', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      acceptAll()
+
+      const payload = JSON.stringify({ id: 'cal-ev-3', clock: { 'device-9': 4 } })
+      queue.enqueue({
+        type: 'calendar_external_event',
+        itemId: 'cal-ev-3',
+        operation: 'delete',
+        payload
+      })
+
+      await coordinator.push()
+
+      const body = postToServerMock.mock.calls[0][1] as PushBody
+      expect(body.items[0].encryptedData).toBe(payload)
+    })
+
+    it('#then a type without the clock requirement is never stamped', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      acceptAll()
+
+      const payload = JSON.stringify({ general: { theme: 'dark' } })
+      queue.enqueue({
+        type: 'settings',
+        itemId: 'synced_settings',
+        operation: 'update',
+        payload
+      })
+
+      await coordinator.push()
+
+      const body = postToServerMock.mock.calls[0][1] as PushBody
+      expect(body.items[0].encryptedData).toBe(payload)
     })
   })
 

--- a/apps/desktop/src/main/sync/engine/push-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.ts
@@ -2,6 +2,7 @@ import { createLogger } from '../../lib/logger'
 import { EVENT_CHANNELS } from '@memry/contracts/ipc-events'
 import type { QueueClearedEvent, SyncStatusChangedEvent } from '@memry/contracts/ipc-events'
 import type { PushResponse, SyncItemType } from '@memry/contracts/sync-api'
+import { RECORD_CLOCK_REQUIRED_ITEM_TYPES } from '@memry/contracts/sync-api'
 import { secureCleanup } from '../../crypto/index'
 import { encryptPushBatch } from '../sync-crypto-batch'
 import { getHandler, getRemoteSyncAdapter } from '../item-handlers'
@@ -27,6 +28,8 @@ import {
 } from './sync-context'
 
 const log = createLogger('PushCoordinator')
+
+const RECORD_CLOCK_REQUIRED_TYPE_SET = new Set<string>(RECORD_CLOCK_REQUIRED_ITEM_TYPES)
 
 export class PushCoordinator {
   private ctx: SyncContext
@@ -523,7 +526,7 @@ export class PushCoordinator {
     deviceId: string,
     vaultKey: Uint8Array
   ): string {
-    if (item.operation === 'delete') return item.payload
+    if (item.operation === 'delete') return this.ensureRequiredClock(item, item.payload, deviceId)
 
     try {
       const adapter =
@@ -549,17 +552,51 @@ export class PushCoordinator {
           itemId: item.itemId.slice(0, 8),
           type: item.type
         })
-        return item.payload
+        return this.ensureRequiredClock(item, item.payload, deviceId)
       }
 
-      return fresh
+      return this.ensureRequiredClock(item, fresh, deviceId)
     } catch (err) {
       log.warn('Push: failed to build fresh payload, using frozen', {
         itemId: item.itemId.slice(0, 8),
         type: item.type,
         error: err
       })
-      return item.payload
+      return this.ensureRequiredClock(item, item.payload, deviceId)
+    }
+  }
+
+  /**
+   * Last-resort clock repair before a payload leaves the device. The handlers'
+   * `buildPushPayload` repair (#1215/#1223) only reaches a create/update whose
+   * row still exists locally — a delete, an orphaned row, or a handler throw
+   * falls back to the FROZEN queue payload, and a frozen payload written by a
+   * pre-#1223 build has no clock. The server requires a clock on every item of
+   * a clock-required type and one clock-less item fails the whole batch, so a
+   * single such row blocks the queue forever (Jerry's 601-pending Fedora
+   * install). Stamping only when the clock is absent keeps handler-built clocks
+   * untouched; the invented first clock is not persisted (deletes and orphans
+   * have no row to persist to), which matches buildDeletePayload's own
+   * `{ id, clock: increment({}, deviceId) }` fallback.
+   */
+  private ensureRequiredClock(
+    item: { itemId: string; type: string },
+    payload: string,
+    deviceId: string
+  ): string {
+    if (!RECORD_CLOCK_REQUIRED_TYPE_SET.has(item.type)) return payload
+    try {
+      const parsed = JSON.parse(payload) as Record<string, unknown> | null
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return payload
+      const clock = parsed.clock
+      if (clock && typeof clock === 'object' && !Array.isArray(clock)) return payload
+      log.info('Push: stamped missing clock on outgoing payload', {
+        itemId: item.itemId.slice(0, 8),
+        type: item.type
+      })
+      return JSON.stringify({ ...parsed, clock: { [deviceId]: 1 } })
+    } catch {
+      return payload
     }
   }
 }

--- a/apps/docs/src/architecture/sync-handlers.md
+++ b/apps/docs/src/architecture/sync-handlers.md
@@ -333,6 +333,17 @@ queued by older builds, so a stuck queue drains on the next push instead of wait
 sync. Stamping without persisting is not enough: the next local edit would tick from `{}` to the same
 clock the server already acked, and the update would be dropped as a replay.
 
+A handler's `buildPushPayload` repair only reaches a create or update whose local row still exists.
+Three cases skip it and fall back to the **frozen** queue payload: a `delete`, a row the handler can
+no longer read, and a handler that throws. A frozen payload written by a build that predates the
+stamping rule carries no clock, and one such row fails every batch forever. So `PushCoordinator`
+makes a last-resort check on the way out: for a type in `RECORD_CLOCK_REQUIRED_ITEM_TYPES`, a payload
+that parses to an object with no `clock` object leaves with `{ [deviceId]: 1 }` stamped on it. A
+payload that already has a clock — handler-built or frozen — is untouched, and an unparseable payload
+is sent as-is. This stamp is **not** persisted, because the cases that reach it have no local row to
+persist to; it matches the `{ id, clock: increment({}, deviceId) }` fallback `buildDeletePayload`
+already uses. It is a queue-unblocking backstop, not a substitute for stamping at write time.
+
 Handlers that persist locally encrypted fields must receive the vault key from the sync engine during
 pull apply and push payload encoding. Agent conversation and message handlers use that key to decrypt
 their SQLite envelopes and re-encode sync payloads without exposing plaintext to the server.

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -264,7 +264,10 @@ rejects any push whose clock has no entry greater than the one it already holds.
 the delete is answered `SYNC_REPLAY_DETECTED`, the queue row is cleared as already applied, the next
 pull serves the same orphan again, and the repair runs again — the loop it exists to end, running
 forever. A normal delete never hits this: it is built from a local row by the domain layer, which
-stamps the clock on the way out, and the push path sends `delete` payloads verbatim by design. An
+stamps the clock on the way out, and the push path sends `delete` payloads verbatim apart from the
+last-resort clock stamp described in
+[Initial seeding](/architecture/sync-handlers#initial-seeding), which only fires when the payload has
+no clock at all and so cannot lift a server clock past itself. An
 orphan has no local row, which is what makes it an orphan, so nothing else can stamp it. Without
 signing keys the stamp is impossible, and the orphan is left for the next pull rather than spending a
 push that would only be refused again.


### PR DESCRIPTION
## Problem

A live install (reported by a beta user, diagnostic incident `MEMRY-TKSJLTEU`) is stuck at **601 pending changes** with every push failing:

```
VALIDATION_ERROR: Invalid push request: Record sync item type "calendar_external_event" requires clock metadata
```

The install is on 2026.822.1, which already contains the #1223 repair — yet the queue never drains.

## Root cause

The #1223 repair lives in the handlers' `buildPushPayload` and only reaches a **create/update whose local row still exists**. `resolvePushPayload` falls back to the frozen queue payload in three cases:

1. `operation === 'delete'` — repair is skipped entirely
2. the row no longer exists locally (`buildPushPayload` returns `null`)
3. the handler throws

A frozen payload written by a pre-#1223 build has no clock. The server requires clock metadata on every item of a clock-required type, and one clock-less item fails the **whole batch**, so a single such row blocks all sync forever — the pending count only grows as other changes queue behind it.

## Fix

`resolvePushPayload` now routes every outgoing payload through `ensureRequiredClock`: for a type in `RECORD_CLOCK_REQUIRED_ITEM_TYPES`, a payload with no `clock` object is stamped `{ [deviceId]: 1 }` — deletes and frozen fallbacks included. Payloads that already carry a clock are untouched, so handler-built clocks never double-tick. The stamp is not persisted (the cases that reach it have no local row), matching `buildDeletePayload`'s existing `{ id, clock: increment({}, deviceId) }` fallback.

## Verification

- 4 new tests: clock-less delete stamped, orphaned update stamped, existing clock untouched, non-clock-required type untouched
- 3 existing tests updated (they asserted byte-identical clock-less `task` payloads on the wire; `task` is clock-required, so the wire payload now legitimately carries the stamp)
- `test:main` 560 files green, `typecheck:node`/`typecheck:test` green, docs impact + docs build green

Docs updated: `sync-handlers.md` (Initial seeding) and `sync-protocol.md` (delete-verbatim claim).