### PR TITLE
fix(notes): note rename rewrites inbound wiki-links vault-wide

### DIFF
--- a/apps/desktop/src/main/database/queries/notes/index.ts
+++ b/apps/desktop/src/main/database/queries/notes/index.ts
@@ -53,7 +53,7 @@ export {
   deleteLinksToNote,
   resolveNoteByTitle,
   resolveNotesByTitles,
-  updateLinkTargets,
+  getInboundLinkSourceIds,
   type IncomingReference
 } from './link-queries'
 

--- a/apps/desktop/src/main/database/queries/notes/link-queries.ts
+++ b/apps/desktop/src/main/database/queries/notes/link-queries.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql } from 'drizzle-orm'
+import { eq, and, isNull, or, sql } from 'drizzle-orm'
 import {
   noteCache,
   noteLinks,
@@ -121,18 +121,34 @@ export function resolveNotesByTitles(
   return resultMap
 }
 
-export function updateLinkTargets(db: IndexDb, sourceId: string): void {
-  const links = getOutgoingLinks(db, sourceId)
-
-  for (const link of links) {
-    if (!link.targetId) {
-      const target = resolveNoteByTitle(db, link.targetTitle)
-      if (target) {
-        db.update(noteLinks)
-          .set({ targetId: target.id })
-          .where(and(eq(noteLinks.sourceId, sourceId), eq(noteLinks.targetTitle, link.targetTitle)))
-          .run()
-      }
-    }
-  }
+/**
+ * Distinct sources whose wiki-links reach a note about to be renamed.
+ *
+ * Resolved rows are matched by target id. Unresolved rows (`target_id` null)
+ * are matched by the indexed title — the SPLIT note-half a link was stored
+ * under (`extractWikiLinks`), so pass `splitWikiTarget(oldTitle).note`, not
+ * the raw title — because a link written before its target was re-indexed
+ * still deserves the rename-time rewrite. The rewrite itself re-checks every
+ * occurrence, so an over-broad candidate here costs a file read, never a
+ * wrong edit.
+ */
+export function getInboundLinkSourceIds(
+  db: IndexDb,
+  targetId: string,
+  indexedTitle: string
+): string[] {
+  return db
+    .selectDistinct({ sourceId: noteLinks.sourceId })
+    .from(noteLinks)
+    .where(
+      or(
+        eq(noteLinks.targetId, targetId),
+        and(
+          isNull(noteLinks.targetId),
+          sql`lower(${noteLinks.targetTitle}) = lower(${indexedTitle})`
+        )
+      )
+    )
+    .all()
+    .map((row) => row.sourceId)
 }

--- a/apps/desktop/src/main/database/queries/notes/notes.test.ts
+++ b/apps/desktop/src/main/database/queries/notes/notes.test.ts
@@ -31,7 +31,7 @@ import {
   getIncomingLinks,
   deleteLinksToNote,
   resolveNoteByTitle,
-  updateLinkTargets,
+  getInboundLinkSourceIds,
   bulkInsertNotes,
   clearNoteCache,
   setNoteProperties,
@@ -354,11 +354,10 @@ describe('notes cache queries', () => {
 
     expect(resolveNoteByTitle(db, 'Target')?.id).toBe('note-17')
 
-    updateLinkTargets(db, 'note-16')
-    const updated = db.get<{ target_id: string | null }>(sql`
-      SELECT target_id FROM note_links WHERE target_title = 'Unresolved'
-    `)
-    expect(updated?.target_id).toBeNull()
+    // Resolved rows match by id; unresolved rows match by title, case-insensitively.
+    expect(getInboundLinkSourceIds(db, 'note-17', 'anything')).toEqual(['note-16'])
+    expect(getInboundLinkSourceIds(db, 'no-such-note', 'UNRESOLVED')).toEqual(['note-16'])
+    expect(getInboundLinkSourceIds(db, 'no-such-note', 'Target')).toEqual([])
 
     deleteLinksToNote(db, 'note-17')
     expect(getIncomingLinks(db, 'note-17')).toHaveLength(0)

--- a/apps/desktop/src/main/sync/crdt-external-feed.ts
+++ b/apps/desktop/src/main/sync/crdt-external-feed.ts
@@ -1,0 +1,62 @@
+/**
+ * Feed a main-originated markdown edit into a note's CRDT body — including a
+ * note whose doc is NOT currently open.
+ *
+ * `replaceNoteBodyInCrdt` alone is only half the job for a closed note: the
+ * Y.Doc persisted when the note was last closed still carries the OLD body,
+ * `seedFromMarkdown` seeds an EMPTY fragment only, and nothing re-reads the
+ * file afterwards — reopening the note would show the body from before the
+ * edit while the vault file on disk holds the new one, and that stale body is
+ * what syncs to every other device. So when no editor holds the note, the
+ * persisted doc is opened (`skipSeed`, because an empty fragment means the
+ * note has no CRDT body at all and its next open will seed from the file —
+ * minting a doc for it now would push a body nothing asked for), fed, and
+ * closed again.
+ *
+ * Used by the vault watcher for out-of-app edits and by the rename-time
+ * wiki-link rewrite (`vault/rename-link-rewrite.ts`); both are main-originated
+ * edits to a file the renderer may or may not have open. Lives apart from
+ * `crdt-feed.ts` so `replaceNoteBodyInCrdt` stays a cross-module call the
+ * watcher tests can observe.
+ *
+ * @module sync/crdt-external-feed
+ */
+
+import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
+import { getCrdtProvider } from './crdt-provider'
+import { replaceNoteBodyInCrdt } from './crdt-feed'
+import { wasRecentNetworkUpdate } from './crdt-writeback'
+import { broadcastToAllWindows } from '../lib/window-broadcast'
+
+// Full fragment replace: lossy re Yjs history, but these edits round-trip
+// through markdown, which destroys that history anyway.
+export async function feedExternalEditToCrdt(
+  noteId: string,
+  markdownContent: string
+): Promise<void> {
+  const provider = getCrdtProvider()
+
+  const feed = async (): Promise<void> => {
+    if (wasRecentNetworkUpdate(noteId)) {
+      broadcastToAllWindows('sync:concurrent-edit', { noteId })
+    }
+
+    await replaceNoteBodyInCrdt(noteId, markdownContent)
+  }
+
+  if (provider.getDoc(noteId)) {
+    await feed()
+    return
+  }
+
+  const doc = await provider.open(noteId, undefined, { skipSeed: true })
+  try {
+    if (doc.getXmlFragment(CRDT_FRAGMENT_NAME).length === 0) return
+
+    await feed()
+  } finally {
+    // Only if it is still editor-less: the renderer may have opened the note
+    // while the replace was in flight, and that doc belongs to the editor now.
+    await provider.closeIfInactive(noteId)
+  }
+}

--- a/apps/desktop/src/main/vault/notes-rename.ts
+++ b/apps/desktop/src/main/vault/notes-rename.ts
@@ -23,6 +23,7 @@ import {
   atomicWrite
 } from './file-ops'
 import { rewriteNoteRefsForMove } from './rewrite-note-refs'
+import { rewriteInboundWikiLinksForRename } from './rename-link-rewrite'
 import { replaceNoteBodyInCrdt } from '../sync/crdt-feed'
 import { markWritebackIgnored } from '../sync/crdt-writeback'
 import { getNoteCacheById } from '@main/database/queries/notes'
@@ -108,6 +109,18 @@ export async function renameNote(id: string, newTitle: string): Promise<Note> {
   // note" would otherwise drop the row this note was just given and send it
   // back to the bottom of a hand-ordered folder (#1646).
   carryPositionToPath(getDatabase(), existing.path, newRelativePath)
+
+  // Wiki-links address this note by its old title; every inbound `[[Old]]` in
+  // the vault is re-pointed now, or it rots into a duplicate-creating link
+  // (#1711). Applies to binary vault items too — `[[some-pdf]]` is title-based
+  // the same way. Runs after the cache sync above so the rewrite reads this
+  // note's new identity.
+  await rewriteInboundWikiLinksForRename({
+    noteId: id,
+    oldTitle: existing.title,
+    newTitle,
+    newPath: newRelativePath
+  })
 
   const note: Note = {
     ...existing,

--- a/apps/desktop/src/main/vault/notes.test.ts
+++ b/apps/desktop/src/main/vault/notes.test.ts
@@ -717,6 +717,41 @@ describe('notes operations', () => {
       expect(retrieved!.path).toContain('Renamed Title')
     })
 
+    it('rewrites inbound wiki-links vault-wide (#1711)', async () => {
+      const target = await notes.createNote({
+        title: 'Link Target',
+        content: 'Target body.'
+      })
+      const source = await notes.createNote({
+        title: 'Link Source',
+        content:
+          'Plain [[Link Target]], heading [[Link Target#Notes]], alias [[Link Target|the label]], other [[Unrelated]].'
+      })
+      const selfLinker = await notes.createNote({
+        title: 'Self Rename',
+        content: 'I mention [[Self Rename]] and [[Link Target]].'
+      })
+
+      // The rewrite finds sources through note_links; settle the projector
+      // the way a live vault has long since settled it before a rename.
+      await projections.flushProjectionEvents()
+      flushProjectionEventsSpy.mockClear()
+
+      await notes.renameNote(target.id, 'Renamed Target')
+
+      const sourceNote = await notes.getNoteById(source.id)
+      expect(sourceNote!.content.trimEnd()).toBe(
+        'Plain [[Renamed Target]], heading [[Renamed Target#Notes]], alias [[Renamed Target|the label]], other [[Unrelated]].'
+      )
+
+      // A note that links to itself is rewritten from its post-rename path.
+      await projections.flushProjectionEvents()
+      flushProjectionEventsSpy.mockClear()
+      await notes.renameNote(selfLinker.id, 'Self Renamed')
+      const selfNote = await notes.getNoteById(selfLinker.id)
+      expect(selfNote!.content.trimEnd()).toBe('I mention [[Self Renamed]] and [[Renamed Target]].')
+    })
+
     it('T364: generates unique path on collision', async () => {
       await notes.createNote({
         title: 'Existing Name',

--- a/apps/desktop/src/main/vault/rename-link-rewrite.ts
+++ b/apps/desktop/src/main/vault/rename-link-rewrite.ts
@@ -1,0 +1,203 @@
+/**
+ * Rename-time vault-wide wiki-link rewrite (#1711).
+ *
+ * Wiki-links address notes by TITLE, so renaming a note silently disconnects
+ * every inbound `[[Old Title]]` in the vault — the next click on one creates a
+ * duplicate note. This module is the persistence half of the Obsidian-model
+ * fix: `rewrite-wiki-links.ts` decides which occurrences to rewrite; this one
+ * finds the source notes through the `note_links` index and lands the rewrite
+ * everywhere a note body lives, in the same order the watcher lands an
+ * out-of-app edit:
+ *
+ *  1. the vault file (`markWritebackIgnored` first, so the watcher does not
+ *     re-ingest our own write),
+ *  2. the index/canonical rows via `syncNoteToCache` — the re-projection is
+ *     what refreshes `note_links.target_title`, so backlinks and the graph
+ *     survive without a rebuild,
+ *  3. the renderer, via the same `notes:updated` event an external edit emits,
+ *  4. the note's CRDT body via `feedExternalEditToCrdt`, which reaches an open
+ *     doc, a closed-but-persisted doc, and correctly leaves a note with no
+ *     CRDT body alone. This is also what carries the rewrite to other devices.
+ *
+ * A source that fails is logged and skipped: the rename itself already
+ * happened, and repairing nine of ten links beats unwinding a filesystem
+ * rename over one unreadable file.
+ *
+ * @module vault/rename-link-rewrite
+ */
+
+import { splitWikiTarget } from '@memry/shared/wiki-target'
+import { isBinaryFileType } from '@memry/shared/file-types'
+import { NotesChannels, JournalChannels } from '@memry/contracts/ipc-channels'
+import type { NoteUpdatedEvent } from '@memry/contracts/notes-api'
+import {
+  getInboundLinkSourceIds,
+  getNoteCacheById,
+  resolveNoteByTitle,
+  isJournalEntry,
+  extractDateFromPath
+} from '@main/database/queries/notes'
+import { getIndexDatabase, type IndexDb } from '../database'
+import { feedExternalEditToCrdt } from '../sync/crdt-external-feed'
+import { markWritebackIgnored } from '../sync/crdt-writeback'
+import { rewriteWikiLinksForRename } from './rewrite-wiki-links'
+import { parseNote } from './frontmatter'
+import { syncNoteToCache } from './note-sync'
+import { safeRead, atomicWrite } from './file-ops'
+import { emitNoteEvent, toAbsolutePath } from './notes-io'
+import { createLogger } from '../lib/logger'
+
+const log = createLogger('RenameLinkRewrite')
+
+function toIso(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value
+}
+
+export interface InboundLinkRewriteInput {
+  noteId: string
+  oldTitle: string
+  newTitle: string
+  /**
+   * The renamed note's post-rename vault-relative path. Projection is async,
+   * so its own cache row may still hold the pre-rename path when this runs —
+   * and a note that links to itself is one of the sources being rewritten.
+   */
+  newPath: string
+}
+
+/**
+ * Rewrite every inbound `[[oldTitle]]` in the vault to `[[newTitle]]`.
+ *
+ * Never throws — the filesystem rename this follows has already happened, and
+ * a broken link repair must not unwind it. Deliberately never flushes
+ * projections inline (rename is a hot path; projector runs async on its own
+ * schedule): the pre-rename `note_links` rows are exactly the sources that
+ * need repairing, and the per-source `syncNoteToCache` re-projection is what
+ * refreshes their `target_title` rows.
+ */
+export async function rewriteInboundWikiLinksForRename(
+  input: InboundLinkRewriteInput
+): Promise<void> {
+  try {
+    await doRewriteInboundLinks(input)
+  } catch (err) {
+    log.warn('Inbound wiki-link rewrite failed after rename', {
+      renamedNoteId: input.noteId,
+      error: err
+    })
+  }
+}
+
+async function doRewriteInboundLinks(input: InboundLinkRewriteInput): Promise<void> {
+  const { noteId, oldTitle, newTitle } = input
+  if (!oldTitle.trim() || oldTitle === newTitle) return
+
+  const db = getIndexDatabase()
+
+  // Links are indexed under their SPLIT note-half (`extractWikiLinks`), so a
+  // `[[Sprint #4]]` inbound row is stored as `Sprint`.
+  const indexedTitle = splitWikiTarget(oldTitle).note || oldTitle
+  const sourceIds = getInboundLinkSourceIds(db, noteId, indexedTitle)
+  if (sourceIds.length === 0) return
+
+  // "Split resolution would have won": a note OTHER than the renamed one
+  // currently claiming this title. See `rewriteWikiLinksForRename`.
+  const otherNoteWithTitleExists = (title: string): boolean => {
+    const match = resolveNoteByTitle(db, title)
+    return match !== undefined && match.id !== noteId
+  }
+
+  for (const sourceId of sourceIds) {
+    try {
+      await rewriteSource(db, sourceId, input, otherNoteWithTitleExists)
+    } catch (err) {
+      log.warn('Failed to rewrite inbound wiki-links in a source note', {
+        sourceId,
+        renamedNoteId: noteId,
+        error: err
+      })
+    }
+  }
+}
+
+async function rewriteSource(
+  db: IndexDb,
+  sourceId: string,
+  input: InboundLinkRewriteInput,
+  otherNoteWithTitleExists: (title: string) => boolean
+): Promise<void> {
+  const { noteId, oldTitle, newTitle } = input
+
+  const cached = getNoteCacheById(db, sourceId)
+  if (!cached) return
+  if (cached.fileType && isBinaryFileType(cached.fileType)) return
+
+  // The renamed note linking to itself: its cache row lags the rename (the
+  // projector is async), so its file lives at the caller-supplied new path.
+  const sourcePath = sourceId === noteId ? input.newPath : cached.path
+  const absolutePath = toAbsolutePath(sourcePath)
+  const original = await safeRead(absolutePath)
+  if (!original) return
+
+  const rewritten = rewriteWikiLinksForRename(
+    original,
+    oldTitle,
+    newTitle,
+    otherNoteWithTitleExists
+  )
+  if (rewritten === null) return
+
+  // Same guard the sync note handler and `moveNote` use before touching a file
+  // the watcher is also watching: this write is already being reconciled here.
+  markWritebackIgnored(absolutePath)
+  await atomicWrite(absolutePath, rewritten)
+
+  const now = new Date().toISOString()
+  const parsed = parseNote(rewritten, sourcePath)
+  const syncResult = syncNoteToCache(
+    db,
+    {
+      id: sourceId,
+      path: sourcePath,
+      fileContent: rewritten,
+      frontmatter: parsed.frontmatter,
+      parsedContent: parsed.content,
+      title: sourceId === noteId ? newTitle : cached.title,
+      createdAt: toIso(cached.createdAt),
+      modifiedAt: now,
+      localOnly: cached.localOnly ?? false,
+      emoji: cached.emoji ?? null
+    },
+    { isNew: false }
+  )
+
+  const event: NoteUpdatedEvent = {
+    id: sourceId,
+    changes: {
+      content: parsed.content,
+      modified: new Date(now),
+      wordCount: syncResult.wordCount
+    },
+    source: 'external'
+  }
+  emitNoteEvent(NotesChannels.events.UPDATED, event)
+
+  await feedExternalEditToCrdt(sourceId, parsed.content)
+
+  if (isJournalEntry(sourcePath)) {
+    const journalDate = extractDateFromPath(sourcePath) ?? ''
+    emitNoteEvent(JournalChannels.events.ENTRY_UPDATED, {
+      date: journalDate,
+      entry: {
+        date: journalDate,
+        content: parsed.content,
+        tags: syncResult.tags,
+        wordCount: syncResult.wordCount,
+        characterCount: syncResult.characterCount,
+        modified: new Date(now),
+        created: new Date(toIso(cached.createdAt))
+      },
+      source: 'external'
+    })
+  }
+}

--- a/apps/desktop/src/main/vault/rewrite-wiki-links.test.ts
+++ b/apps/desktop/src/main/vault/rewrite-wiki-links.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { rewriteWikiLinksForRename } from './rewrite-wiki-links'
+
+const noOther = () => false
+
+describe('rewriteWikiLinksForRename', () => {
+  it('rewrites a plain link and leaves other links alone', () => {
+    expect(
+      rewriteWikiLinksForRename(
+        'See [[Old Title]] and [[Other Note]].',
+        'Old Title',
+        'New Title',
+        noOther
+      )
+    ).toBe('See [[New Title]] and [[Other Note]].')
+  })
+
+  it('returns null when nothing matches', () => {
+    expect(
+      rewriteWikiLinksForRename('See [[Other Note]].', 'Old Title', 'New Title', noOther)
+    ).toBeNull()
+    expect(rewriteWikiLinksForRename('no links here', 'Old Title', 'New Title', noOther)).toBeNull()
+    expect(rewriteWikiLinksForRename('', 'Old Title', 'New Title', noOther)).toBeNull()
+  })
+
+  it('returns null when old and new titles are identical', () => {
+    expect(rewriteWikiLinksForRename('[[Same]]', 'Same', 'Same', noOther)).toBeNull()
+  })
+
+  it('matches titles case-insensitively, same as resolveNoteByTitle', () => {
+    expect(
+      rewriteWikiLinksForRename('[[old title]] and [[OLD TITLE]]', 'Old Title', 'New', noOther)
+    ).toBe('[[New]] and [[New]]')
+  })
+
+  it('rewrites a case-only rename', () => {
+    expect(rewriteWikiLinksForRename('[[old title]]', 'old title', 'Old Title', noOther)).toBe(
+      '[[Old Title]]'
+    )
+  })
+
+  it('keeps the alias untouched', () => {
+    expect(rewriteWikiLinksForRename('[[Old|my label]]', 'Old', 'New', noOther)).toBe(
+      '[[New|my label]]'
+    )
+  })
+
+  it('keeps the heading half, nested segments included', () => {
+    expect(rewriteWikiLinksForRename('[[Old#Heading]]', 'Old', 'New', noOther)).toBe(
+      '[[New#Heading]]'
+    )
+    expect(rewriteWikiLinksForRename('[[Old#H1#H2]]', 'Old', 'New', noOther)).toBe('[[New#H1#H2]]')
+    expect(rewriteWikiLinksForRename('[[Old#Heading|label]]', 'Old', 'New', noOther)).toBe(
+      '[[New#Heading|label]]'
+    )
+  })
+
+  it('never touches a same-note heading link', () => {
+    expect(rewriteWikiLinksForRename('[[#Heading]]', '#Heading', 'New', noOther)).toBeNull()
+  })
+
+  it('rewrites a title containing # when no other note claims the split half', () => {
+    expect(rewriteWikiLinksForRename('[[Sprint #4]]', 'Sprint #4', 'Sprint Four', noOther)).toBe(
+      '[[Sprint Four]]'
+    )
+  })
+
+  it('leaves a title containing # alone when split resolution wins', () => {
+    // A note titled `Sprint` exists, so `[[Sprint #4]]` always resolved to it,
+    // never to the note named `Sprint #4` — the link is not ours to rewrite.
+    const sprintExists = (title: string) => title === 'Sprint'
+    expect(
+      rewriteWikiLinksForRename('[[Sprint #4]]', 'Sprint #4', 'Sprint Four', sprintExists)
+    ).toBeNull()
+  })
+
+  it('rewrites the note half of a heading link even when the raw string matches another rename', () => {
+    // `[[Old#Notes]]` splits first: the note half is what carries the title.
+    expect(rewriteWikiLinksForRename('[[Old#Notes]] and [[Old]]', 'Old', 'New', noOther)).toBe(
+      '[[New#Notes]] and [[New]]'
+    )
+  })
+
+  it('trims the target before matching', () => {
+    expect(rewriteWikiLinksForRename('[[ Old ]]', 'Old', 'New', noOther)).toBe('[[New]]')
+  })
+})

--- a/apps/desktop/src/main/vault/rewrite-wiki-links.ts
+++ b/apps/desktop/src/main/vault/rewrite-wiki-links.ts
@@ -1,0 +1,87 @@
+/**
+ * Rewrite `[[…]]` targets in a note body when the note they address is renamed.
+ *
+ * Wiki-links carry the target's TITLE, nothing else — no id anywhere in the
+ * on-disk format — so a rename silently disconnects every inbound link and the
+ * next click on `[[Old Title]]` creates a duplicate note (#1711). The fix is
+ * the Obsidian model: at rename time, rewrite the stale title inside every
+ * source that links to the renamed note. This module is the pure string half
+ * of that; `rename-link-rewrite.ts` finds the sources and persists the result.
+ *
+ * Which occurrences are rewritten mirrors `resolveWikiTarget`'s split-first
+ * order exactly, because a rewrite must only touch links that RESOLVED to the
+ * renamed note:
+ *
+ *  - `[[Old]]`            → `[[New]]`
+ *  - `[[Old#Heading]]`    → `[[New#Heading]]` — the heading half (everything
+ *    after the first `#`, nested segments included) is kept byte-for-byte.
+ *  - `[[Old|alias]]`      → `[[New|alias]]` — the alias is the label the user
+ *    chose and is never touched, so the visible text does not change.
+ *  - A title that itself contains `#` (`[[Sprint #4]]`) is matched against the
+ *    raw target, but only when no OTHER note claims the split half: split
+ *    resolution wins over the raw fallback, so if a note titled `Sprint`
+ *    exists, `[[Sprint #4]]` was never a link to `Sprint #4` and is left alone.
+ *  - `[[#Heading]]` addresses the note it sits in and is never rewritten.
+ *
+ * Titles match case-insensitively, same as `resolveNoteByTitle`. Returns null
+ * when nothing changed so the caller can skip the write entirely — same
+ * contract as `rewriteNoteRefsForMove`.
+ */
+
+import { splitWikiTarget } from '@memry/shared/wiki-target'
+
+/** `[[target]]` / `[[target|alias]]`; the alias group keeps its `|` prefix. */
+const WIKI_LINK_RUN = /\[\[([^\]|]+)(\|[^\]]+)?\]\]/g
+
+function sameTitle(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase()
+}
+
+/**
+ * The body with every wiki-link to `oldTitle` re-pointed at `newTitle`, or
+ * null when no link matched.
+ *
+ * @param otherNoteWithTitleExists Whether a note OTHER than the renamed one
+ *   currently holds this title — the raw-fallback guard described above.
+ */
+export function rewriteWikiLinksForRename(
+  body: string,
+  oldTitle: string,
+  newTitle: string,
+  otherNoteWithTitleExists: (title: string) => boolean
+): string | null {
+  const from = oldTitle.trim()
+  if (!body || !from || from === newTitle) return null
+
+  let changed = false
+
+  const rewritten = body.replace(
+    WIKI_LINK_RUN,
+    (run, target: string, aliasWithPipe: string | undefined) => {
+      const raw = target.trim()
+      if (!raw) return run
+
+      const { note, heading } = splitWikiTarget(raw)
+      // `[[#Heading]]` — a same-note link; there is no title to go stale.
+      if (!note) return run
+
+      let next: string | null = null
+      if (heading !== null) {
+        if (sameTitle(note, from)) {
+          // Split-first: keep everything from the first `#` on, verbatim.
+          next = newTitle + raw.slice(raw.indexOf('#'))
+        } else if (sameTitle(raw, from) && !otherNoteWithTitleExists(note)) {
+          next = newTitle
+        }
+      } else if (sameTitle(raw, from)) {
+        next = newTitle
+      }
+
+      if (next === null) return run
+      changed = true
+      return `[[${next}${aliasWithPipe ?? ''}]]`
+    }
+  )
+
+  return changed ? rewritten : null
+}

--- a/apps/desktop/src/main/vault/watcher.ts
+++ b/apps/desktop/src/main/vault/watcher.ts
@@ -40,7 +40,6 @@ import {
 } from '@main/database/queries/notes'
 import { getDatabase, getIndexDatabase } from '../database'
 import { NotesChannels, JournalChannels } from '@memry/contracts/ipc-channels'
-import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 import {
   trackPendingDelete,
   checkForRename,
@@ -52,11 +51,10 @@ import {
 import { isSupportedPath, getFileType, getMimeType, getExtension } from '@memry/shared/file-types'
 import { createLogger } from '../lib/logger'
 import { trackMainError } from '../telemetry/diagnostics'
-import { isWritebackIgnored, wasRecentNetworkUpdate } from '../sync/crdt-writeback'
+import { isWritebackIgnored } from '../sync/crdt-writeback'
 import { attachmentEvents } from '../sync/attachment-events'
 import { flushProjectionEvents } from '../projections'
-import { getCrdtProvider } from '../sync/crdt-provider'
-import { replaceNoteBodyInCrdt } from '../sync/crdt-feed'
+import { feedExternalEditToCrdt } from '../sync/crdt-external-feed'
 import { reconcileTaskCheckboxesFromMarkdown } from '../tasks/reconcile-markdown-tasks'
 import { enqueueJournalDelete } from '../journal/runtime-effects'
 import { syncNoteCreate, syncNoteDelete, syncNoteUpdate } from '../notes/runtime-effects'
@@ -150,49 +148,6 @@ function extractJournalDate(relativePath: string): string {
 function toIsoOrNull(value: string | Date | null | undefined): string | null {
   if (!value) return null
   return value instanceof Date ? value.toISOString() : value
-}
-
-// Full fragment replace on external edits: lossy but acceptable since
-// out-of-app edits are infrequent and round-trip through MD destroys Yjs history anyway
-async function feedExternalEditToCrdt(noteId: string, markdownContent: string): Promise<void> {
-  const provider = getCrdtProvider()
-
-  const feed = async (): Promise<void> => {
-    if (wasRecentNetworkUpdate(noteId)) {
-      emitEvent('sync:concurrent-edit', { noteId })
-    }
-
-    await replaceNoteBodyInCrdt(noteId, markdownContent)
-  }
-
-  if (provider.getDoc(noteId)) {
-    await feed()
-    return
-  }
-
-  // No editor holds the note, so there is no doc in memory to feed — and simply
-  // returning here loses the edit for good. The Y.Doc persisted when the note
-  // was last closed still carries the OLD body, `seedFromMarkdown` seeds an
-  // EMPTY fragment only, and nothing re-reads the file afterwards: reopening the
-  // note shows the body from before the edit while the vault file on disk holds
-  // the new one, and that stale body is what syncs to every other device.
-  // Switching to another note before editing the file outside Memry is the whole
-  // setup — the doc is closed the moment its editor unmounts.
-  //
-  // `skipSeed`, because an empty fragment here means something different and
-  // must be left alone: the note has no persisted CRDT body at all, its next
-  // open will seed from this very file, and minting a doc for it now would push
-  // a body nothing asked for.
-  const doc = await provider.open(noteId, undefined, { skipSeed: true })
-  try {
-    if (doc.getXmlFragment(CRDT_FRAGMENT_NAME).length === 0) return
-
-    await feed()
-  } finally {
-    // Only if it is still editor-less: the renderer may have opened the note
-    // while the replace was in flight, and that doc belongs to the editor now.
-    await provider.closeIfInactive(noteId)
-  }
 }
 
 // ============================================================================

--- a/apps/desktop/tests/e2e/graph-links.e2e.ts
+++ b/apps/desktop/tests/e2e/graph-links.e2e.ts
@@ -116,6 +116,9 @@ test.describe('Graph links E2E', () => {
     )
     expect(renameResult.success).toBe(true)
 
+    // The rename rewrites the source's `[[Old]]` to `[[New]]` vault-wide
+    // (#1711), so the backlink survives on the CONTENT level, not just as a
+    // lingering `target_id` in the index.
     await expect
       .poll(
         () =>
@@ -142,9 +145,16 @@ test.describe('Graph links E2E', () => {
       )
       .toMatchObject({
         targetTitle: renamedTitle,
-        sourceContent: expect.stringContaining(seeded.oldWikilink),
+        sourceContent: expect.stringContaining(`[[${renamedTitle}]]`),
         outgoingTargetIds: expect.arrayContaining([seeded.targetId]),
-        incomingSourceIds: expect.arrayContaining([seeded.sourceId])
+        incomingSourceIds: expect.arrayContaining([seeded.sourceId]),
+        outgoingTargetTitles: expect.arrayContaining([renamedTitle])
       })
+
+    const sourceAfterRename = await page.evaluate(
+      ({ sourceId }) => window.api.notes.get(sourceId).then((note) => note?.content ?? ''),
+      seeded
+    )
+    expect(sourceAfterRename).not.toContain(seeded.oldWikilink)
   })
 })

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -243,9 +243,25 @@ Turn the motion off with **Live motion** under the gear icon → **Display** if 
 still graph — the same forces then run once and stop, which is also the lighter option on
 very large vaults.
 
+## Renaming a Linked Note
+
+Renaming a note updates every wiki link that points at it, across the whole vault: each
+inbound `[[Old Title]]` becomes `[[New Title]]` in the source note itself, so the link
+keeps opening the same note and backlinks, mention counts, and the graph carry on
+unchanged. This covers every link form — `[[Old Title#Heading]]` keeps its heading,
+`[[Old Title|label]]` keeps its label (the visible text you chose never changes) — and it
+applies to attached files too: rename a PDF inside Memry and notes linking to it by name
+follow along.
+
+The rewrite is an ordinary edit to each source note, so it appears in open editors right
+away and syncs to your other devices like any other change. Links written in another app
+before the rename (or renames done outside Memry, in Finder or Explorer) are not covered —
+those show up as broken links below.
+
 ## Broken Links
 
-A wiki link whose target does not exist — a typo, a renamed note, or a deleted one — is
+A wiki link whose target does not exist — a typo, a note renamed outside Memry, or a
+deleted one — is
 shown with a **dashed underline and a muted tint** instead of the usual link colour, in
 both the note editor and the journal. Hovering it shows a small card reading
 **"Not found — click to create"** instead of the usual preview.


### PR DESCRIPTION
Fixes #1711 (part of #1708).

## Problem

Wiki-links store the target's **title**, nothing else. Renaming a note (or a PDF/binary vault item) left every inbound `[[Old Title]]` pointing at nothing — the backlink card dropped to 0 mentions, the graph edge went ghost, and clicking the stale link minted a duplicate note.

## Fix — Obsidian model, no on-disk format change

At rename time, every inbound link in the vault is rewritten `[[Old]]` → `[[New]]`:

- **`vault/rewrite-wiki-links.ts`** (pure): mirrors `resolveWikiTarget`'s split-first order so only links that actually *resolved* to the renamed note are touched. `[[Old#Heading]]` keeps its heading verbatim, `[[Old|alias]]` keeps its alias, matching is case-insensitive, and a title containing `#` (`[[Sprint #4]]`) is only rewritten when no other note claims the split half.
- **`vault/rename-link-rewrite.ts`**: finds sources via `note_links` (resolved rows by `target_id`, unresolved rows by the indexed title half), then lands each rewrite the same way the watcher lands an external edit: `markWritebackIgnored` + atomic file write → `syncNoteToCache` re-projection (refreshes `target_title`, so backlinks/graph/snippets survive without an index rebuild) → `notes:updated` to the renderer → CRDT feed. Never throws (the fs rename already happened) and never flushes projections inline (existing rename invariant).
- **`sync/crdt-external-feed.ts`**: the watcher's `feedExternalEditToCrdt` extracted for reuse — reaches an open Y.Doc, a closed-but-persisted one (open `skipSeed` → feed → `closeIfInactive`), and leaves notes with no CRDT body alone. This is also what carries the rewrite to other devices.
- Dead `updateLinkTargets` removed; `getInboundLinkSourceIds` added.
- Works for the binary rename branch too (renaming a PDF fixes `[[some-pdf]]` links).

## Tests

- 12 unit tests for the pure rewrite (alias/heading/case/`Sprint #4` fallback/self-heading links).
- Integration test in `vault/notes.test.ts`: vault-wide rewrite incl. a self-linking note renamed from its post-rename path.
- `graph-links.e2e.ts` flipped from asserting the stale `[[Old Title]]` to asserting the rewritten content + updated `target_title` (2/2 green locally, fresh build).
- Full `test:main`: 562 files / 7344 tests green. `typecheck` web+node+test green, lint green, `docs:impact` + `docs:build` green.

## Docs

`user-guide/notes/wiki-links.md`: new “Renaming a Linked Note” section; broken-links section now scopes rename-rot to renames done *outside* Memry.