### PR TITLE
fix(telemetry): stop PostHog quota flooding + silent auto-update flow

### DIFF
--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -414,6 +414,24 @@ Errors additionally become `$exception` events for PostHog Error Tracking (`exce
 `services/posthog-transform.ts`), fingerprinted on our own `errorCode` when one is present so
 grouping follows the app's own error taxonomy rather than PostHog's pattern-hash default.
 
+Three server-side guards keep this stream from flooding the PostHog quota:
+
+- **Warn-level log lines never reach Error Tracking.** The desktop demotes expected failures to
+  warn-level `app_log_recorded` lines precisely so they stay out of Error Tracking (#1587);
+  `exceptionEvent` promotes an `app_log_recorded` event only when its `action` is `error`.
+  Warn-level lines stay fully queryable as events and log records.
+- **Legacy drop-tripwire noise is dropped at ingestion.** Desktop versions before 2026.821 ship
+  the `local_mutation_dropped` tripwire once per polled row with no throttle or eligibility gate
+  (#1579) — at peak 45% of the project's entire event volume, triple-billed as product event,
+  `$exception` and log line. `isLegacyMutationDropNoise` drops those events before all three
+  sinks; fixed clients still forward their throttled diagnostic trickle.
+- **Per-install hourly exception budget.** `claimExceptionBudget`
+  (`services/exception-budget.ts`) caps `$exception` forwards at 60 per install per hour, reusing
+  the `rate_limits` table. Only the `$exception` stream is trimmed — the product events and log
+  lines for the same failures still forward, so a capped install stays diagnosable. The claim
+  fails open on D1 errors: a flaky database costs extra PostHog events, never a swallowed crash
+  report.
+
 #### Stack frames
 
 Error Tracking renders code locations **only** from `$exception_list[].stacktrace` — it never

--- a/apps/sync-server/src/routes/telemetry.test.ts
+++ b/apps/sync-server/src/routes/telemetry.test.ts
@@ -322,4 +322,54 @@ describe('POST /telemetry/batch → PostHog', () => {
     const body = JSON.parse((captureCall?.[1] as RequestInit).body as string)
     expect(body.batch.map((e: { event: string }) => e.event)).toContain('note_created')
   })
+
+  // The pre-fix drop tripwire (#1579) was triple-billed: product event,
+  // $exception AND log line. It must vanish from every sink, not get demoted.
+  it('drops the legacy local_mutation_dropped tripwire from every sink', async () => {
+    // #given a pre-fix desktop batch with one tripwire event and one real event
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+    const { env } = createEnv({
+      POSTHOG_KEY: 'phc_test',
+      POSTHOG_HOST: 'https://us.i.posthog.com'
+    })
+    const request = new Request('http://localhost/telemetry/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...sampleBatch,
+        appVersion: '2026.817.1',
+        events: [
+          {
+            id: '550e8400-e29b-41d4-a716-446655440010',
+            name: 'app_log_recorded',
+            occurredAt: VALID_TIMESTAMP,
+            surface: 'app',
+            action: 'warn',
+            result: 'failed',
+            errorCode: 'calendar_source',
+            dimensions: { log_action: 'local_mutation_dropped' }
+          },
+          sampleEvent
+        ]
+      })
+    })
+
+    // #when posting through the app
+    const response = await app.request(request, {}, env)
+
+    // #then the 202 still reports the raw count so old clients keep flushing
+    expect(response.status).toBe(202)
+    expect(((await response.json()) as { accepted: number }).accepted).toBe(2)
+    // #then the capture batch has the real event but no tripwire, no $exception
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled())
+    const captureCall = fetchSpy.mock.calls.find(([url]) => String(url).endsWith('/batch/'))
+    const body = JSON.parse((captureCall?.[1] as RequestInit).body as string)
+    const names = body.batch.map((e: { event: string }) => e.event)
+    expect(names).toContain('app_started')
+    expect(names).not.toContain('app_log_recorded')
+    expect(names).not.toContain('$exception')
+    // #then no log line was pushed for it either
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).endsWith('/i/v1/logs'))).toBe(false)
+  })
 })

--- a/apps/sync-server/src/routes/telemetry.ts
+++ b/apps/sync-server/src/routes/telemetry.ts
@@ -7,11 +7,13 @@ import { AppError, ErrorCodes } from '../lib/errors'
 import { createLogger } from '../lib/logger'
 import { createRateLimiter } from '../middleware/rate-limit'
 import { safeWaitUntil } from '../services/analytics'
+import { claimExceptionBudget } from '../services/exception-budget'
 import { capturePostHogEvents } from '../services/posthog'
 import { desktopErrorRecord, desktopLogRecord, pushPostHogLogs } from '../services/posthog-logs'
 import {
   exceptionEvent,
   identifyEvent,
+  isLegacyMutationDropNoise,
   productEvent,
   resolveDistinctId
 } from '../services/posthog-transform'
@@ -63,10 +65,23 @@ telemetry.post('/batch', async (c) => {
   }
   const distinctId = resolveDistinctId(ctx)
 
-  const events = batch.events.map((event) => productEvent(batch, event, ctx))
-  const exceptions = batch.events
+  // Pre-fix desktops (< 2026.821) ship the per-mutation drop tripwire
+  // unthrottled; those events are dropped before ALL THREE sinks below, not
+  // demoted — see isLegacyMutationDropNoise. The 202 still reports the raw
+  // count so old clients keep flushing normally.
+  const forwardable = batch.events.filter((event) => !isLegacyMutationDropNoise(batch, event))
+
+  const events = forwardable.map((event) => productEvent(batch, event, ctx))
+  let exceptions = forwardable
     .map((event) => exceptionEvent(batch, event, ctx))
     .filter((event): event is NonNullable<typeof event> => event !== null)
+  if (exceptions.length > 0) {
+    // Per-install hourly cap on the `$exception` stream only — the product
+    // events and log lines for the same failures still forward, so a capped
+    // install stays diagnosable while Error Tracking stays affordable.
+    const granted = await claimExceptionBudget(c.env.DB, installHash, exceptions.length)
+    if (granted < exceptions.length) exceptions = exceptions.slice(0, granted)
+  }
 
   // $identify merges the anonymous install person into the account person
   // PERMANENTLY, and the desktop flushes roughly every 30s. claimIdentifySession
@@ -86,7 +101,7 @@ telemetry.post('/batch', async (c) => {
 
   // Desktop error events also become PostHog log lines (redacted stack frames
   // only — see TelemetryErrorDetailSchema) so they are searchable in the Logs tab.
-  const errorEvents = batch.events.filter((event) => event.errorCode || event.error)
+  const errorEvents = forwardable.filter((event) => event.errorCode || event.error)
   if (errorEvents.length > 0) {
     safeWaitUntil(
       c,

--- a/apps/sync-server/src/services/exception-budget.test.ts
+++ b/apps/sync-server/src/services/exception-budget.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { claimExceptionBudget, EXCEPTION_BUDGET_PER_HOUR } from './exception-budget'
+
+// Minimal D1 stand-in: `batch` resolves with a canned SELECT result carrying
+// the post-upsert count, mirroring the [upsert, select] pair the claim issues.
+const dbWithCount = (count: number | undefined): D1Database => {
+  const statement = { bind: vi.fn().mockReturnThis() }
+  return {
+    prepare: vi.fn(() => statement),
+    batch: vi
+      .fn()
+      .mockResolvedValue([{ results: [] }, { results: count === undefined ? [] : [{ count }] }])
+  } as unknown as D1Database
+}
+
+describe('claimExceptionBudget', () => {
+  it('grants the full request while the window has room', async () => {
+    expect(await claimExceptionBudget(dbWithCount(5), 'hash', 5)).toBe(5)
+  })
+
+  it('grants exactly up to the cap when the request straddles it', async () => {
+    // 55 already used before this batch of 10 → only 5 slots remain.
+    expect(await claimExceptionBudget(dbWithCount(65), 'hash', 10)).toBe(5)
+  })
+
+  it('grants nothing once the window is exhausted', async () => {
+    expect(
+      await claimExceptionBudget(dbWithCount(EXCEPTION_BUDGET_PER_HOUR + 20), 'hash', 10)
+    ).toBe(0)
+  })
+
+  it('short-circuits a zero-size request without touching the database', async () => {
+    const db = dbWithCount(0)
+    expect(await claimExceptionBudget(db, 'hash', 0)).toBe(0)
+    expect((db as unknown as { batch: ReturnType<typeof vi.fn> }).batch).not.toHaveBeenCalled()
+  })
+
+  // A flaky database must cost extra PostHog events, never a swallowed crash.
+  it('fails open when D1 errors', async () => {
+    const db = {
+      prepare: vi.fn(() => ({ bind: vi.fn().mockReturnThis() })),
+      batch: vi.fn().mockRejectedValue(new Error('D1 down'))
+    } as unknown as D1Database
+    expect(await claimExceptionBudget(db, 'hash', 7)).toBe(7)
+  })
+
+  it('fails open when the select comes back empty', async () => {
+    expect(await claimExceptionBudget(dbWithCount(undefined), 'hash', 4)).toBe(4)
+  })
+})

--- a/apps/sync-server/src/services/exception-budget.ts
+++ b/apps/sync-server/src/services/exception-budget.ts
@@ -1,0 +1,60 @@
+import { createLogger } from '../lib/logger'
+
+const logger = createLogger('ExceptionBudget')
+
+// Hard hourly ceiling on `$exception` forwards per install. A healthy install
+// emits a handful per hour; a runaway one (a crash loop, an old client's
+// per-mutation tripwire) once produced 45% of the project's entire PostHog
+// event volume (#1579). 60/hour still samples a genuine crash storm generously
+// while capping the worst case at ~1.4k/day instead of tens of thousands.
+export const EXCEPTION_BUDGET_PER_HOUR = 60
+export const EXCEPTION_BUDGET_WINDOW_SECONDS = 60 * 60
+
+/**
+ * Claims `requested` slots from the install's hourly `$exception` budget and
+ * returns how many were granted. Shares the `rate_limits` table (same
+ * fixed-window upsert as the middleware) under its own key prefix, so it needs
+ * no new migration. Trims only the `$exception` stream: the product event and
+ * the PostHog log line for the same failure still forward, so the diagnostic
+ * record survives the cap.
+ *
+ * Fails OPEN: a D1 error grants the full request — a flaky database must cost
+ * extra PostHog events, never silently swallow a real crash report.
+ */
+export const claimExceptionBudget = async (
+  db: D1Database,
+  installHash: string,
+  requested: number
+): Promise<number> => {
+  if (requested <= 0) return 0
+  const key = `telemetry-exc:${installHash}`
+  const now = Math.floor(Date.now() / 1000)
+  const windowStart = now - EXCEPTION_BUDGET_WINDOW_SECONDS
+  try {
+    const result = await db.batch([
+      db
+        .prepare(
+          `INSERT INTO rate_limits (key, count, window_start)
+           VALUES (?, ?, ?)
+           ON CONFLICT (key) DO UPDATE SET
+             count = CASE WHEN window_start < ? THEN ? ELSE count + ? END,
+             window_start = CASE WHEN window_start < ? THEN ? ELSE window_start END`
+        )
+        .bind(key, requested, now, windowStart, requested, requested, windowStart, now),
+      db.prepare('SELECT count FROM rate_limits WHERE key = ?').bind(key)
+    ])
+    const row = (result[1] as D1Result).results?.[0] as { count: number } | undefined
+    const used = row?.count ?? requested
+    // `used` already includes this batch; grant the part of it that still fits.
+    const granted = Math.min(requested, Math.max(0, EXCEPTION_BUDGET_PER_HOUR - (used - requested)))
+    if (granted < requested) {
+      logger.warn('Exception budget exhausted, trimming batch', { requested, granted, used })
+    }
+    return granted
+  } catch (error) {
+    logger.warn('Exception budget claim failed, forwarding untrimmed', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return requested
+  }
+}

--- a/apps/sync-server/src/services/posthog-transform.test.ts
+++ b/apps/sync-server/src/services/posthog-transform.test.ts
@@ -9,6 +9,7 @@ import type {
 import {
   exceptionEvent,
   identifyEvent,
+  isLegacyMutationDropNoise,
   personProperties,
   productEvent,
   resolveDistinctId
@@ -393,6 +394,38 @@ describe('exceptionEvent', () => {
     expect(exceptionEvent(batchFixture(), eventFixture(), ctx)).toBeNull()
   })
 
+  // The desktop demotes expected failures to warn-level app_log_recorded lines
+  // so they stay OUT of Error Tracking (#1587). Promoting them back is how the
+  // local_mutation_dropped tripwire became the stackless `calendar_source`
+  // issue that at peak was 45% of the project's PostHog volume.
+  it('never promotes a warn-level log line into Error Tracking', () => {
+    expect(
+      exceptionEvent(
+        batchFixture(),
+        eventFixture({
+          name: 'app_log_recorded',
+          action: 'warn',
+          errorCode: 'calendar_source'
+        }),
+        ctx
+      )
+    ).toBeNull()
+  })
+
+  it('still promotes an error-level log line', () => {
+    const result = exceptionEvent(
+      batchFixture(),
+      eventFixture({
+        name: 'app_log_recorded',
+        action: 'error',
+        errorCode: 'Utility_crashed_CrdtPreflight'
+      }),
+      ctx
+    )
+    expect(result?.event).toBe('$exception')
+    expect(result?.properties.$exception_fingerprint).toBe('Utility_crashed_CrdtPreflight')
+  })
+
   it('builds a $exception with the error code as type and fingerprint', () => {
     const result = exceptionEvent(
       batchFixture(),
@@ -654,5 +687,40 @@ describe('exceptionEvent', () => {
       ctx
     )
     expect(result?.properties.$exception_fingerprint).toBe('SYNC_TIMEOUT')
+  })
+})
+
+describe('isLegacyMutationDropNoise', () => {
+  const dropEvent = (overrides = {}) =>
+    eventFixture({
+      name: 'app_log_recorded',
+      action: 'warn',
+      errorCode: 'calendar_source',
+      dimensions: { log_action: 'local_mutation_dropped' },
+      ...overrides
+    })
+
+  it('flags the tripwire from a pre-fix desktop version', () => {
+    expect(isLegacyMutationDropNoise(batchFixture({ appVersion: '2026.817.1' }), dropEvent())).toBe(
+      true
+    )
+  })
+
+  it('lets the throttled tripwire from a fixed version through', () => {
+    for (const appVersion of ['2026.821.1', '2026.823.2', '2027.101.1']) {
+      expect(isLegacyMutationDropNoise(batchFixture({ appVersion }), dropEvent())).toBe(false)
+    }
+  })
+
+  it('ignores other log actions and other event names on old versions', () => {
+    const batch = batchFixture({ appVersion: '2026.817.1' })
+    expect(
+      isLegacyMutationDropNoise(batch, dropEvent({ dimensions: { log_action: 'other' } }))
+    ).toBe(false)
+    expect(isLegacyMutationDropNoise(batch, dropEvent({ name: 'app_error_seen' }))).toBe(false)
+  })
+
+  it('fails open on an unparseable version', () => {
+    expect(isLegacyMutationDropNoise(batchFixture({ appVersion: 'dev' }), dropEvent())).toBe(false)
   })
 })

--- a/apps/sync-server/src/services/posthog-transform.ts
+++ b/apps/sync-server/src/services/posthog-transform.ts
@@ -255,6 +255,44 @@ export const parseStackFrames = (stack: string): RawFrame[] => {
   return frames.slice(0, MAX_FRAMES).reverse()
 }
 
+// Desktop versions are calendar-shaped ("2026.821.2"). Numeric segment compare;
+// an unparseable version is treated as current so a future format change fails
+// open (forward the event) rather than silently dropping telemetry.
+const parseVersion = (value: string): number[] | null => {
+  const parts = value.split('.').map((part) => Number(part))
+  if (parts.length === 0 || parts.some((part) => !Number.isFinite(part) || part < 0)) return null
+  return parts
+}
+
+const isVersionBefore = (value: string, reference: readonly number[]): boolean => {
+  const parts = parseVersion(value)
+  if (!parts) return false
+  for (let i = 0; i < reference.length; i += 1) {
+    const own = parts[i] ?? 0
+    if (own !== reference[i]) return own < reference[i]
+  }
+  return false
+}
+
+// First desktop release carrying the #1579 tripwire fix (`4e58ba112`): the
+// eligibility gate plus the 30-minute per-type throttle on
+// `local_mutation_dropped`.
+const DROP_TRIPWIRE_FIX_VERSION = [2026, 821, 0] as const
+
+/**
+ * The pre-fix desktop shipped the `local_mutation_dropped` tripwire once per
+ * polled row with no throttle and no eligibility gate — at peak 45% of the
+ * project's ENTIRE PostHog event volume, triple-billed as product event +
+ * `$exception` + log line (#1579). Those installs exist until their users
+ * update; this server-side filter is the only place they can be silenced.
+ * Fixed clients throttle the same signal to a diagnostic trickle, which is why
+ * the gate is version-scoped rather than dropping the signal outright.
+ */
+export const isLegacyMutationDropNoise = (batch: TelemetryBatch, event: TelemetryEvent): boolean =>
+  event.name === 'app_log_recorded' &&
+  event.dimensions?.log_action === 'local_mutation_dropped' &&
+  isVersionBefore(batch.appVersion, DROP_TRIPWIRE_FIX_VERSION)
+
 // Error Tracking requires the event name to be exactly `$exception`; a plain
 // `exception` lands in Events and never reaches the Error Tracking product.
 //
@@ -267,6 +305,14 @@ export const exceptionEvent = (
   ctx: TransformContext
 ): PostHogEvent | null => {
   if (!event.errorCode && !event.error) return null
+
+  // The desktop demotes expected failures to warn-level `app_log_recorded`
+  // lines precisely so they stay OUT of Error Tracking (#1587) — but this
+  // transform used to promote any errorCode back into a `$exception`, which is
+  // how log-derived tripwires (`local_mutation_dropped` → fingerprint
+  // `calendar_source`) became stackless Error Tracking issues. Only error-level
+  // log lines carry a defect; the rest stay queryable as events and logs.
+  if (event.name === 'app_log_recorded' && event.action !== 'error') return null
 
   // type only needs a label, so falling back to the event name is harmless here.
   const type = event.errorCode ?? event.name


### PR DESCRIPTION
## Part 1 — PostHog quota flooding (sync-server)

The Error Tracking issue fingerprinted `calendar_source` is not an exception — it is the `local_mutation_dropped` tripwire from desktops older than 2026.821, shipped once per polled calendar row with no throttle (#1579). Over 30 days this class was **45.5% of the project's entire PostHog event volume** (73.5k of 161k), triple-billed as product event + `$exception` + log line. The desktop fix (v2026-08-21) works — zero events from fixed versions — but old clients only stop server-side.

- **Warn-level `app_log_recorded` lines never become `$exception`** — completes #1587; only `action: 'error'` log lines are promoted. Warns stay queryable as events/logs.
- **Legacy drop-tripwire noise dropped at ingestion** — `isLegacyMutationDropNoise` drops `local_mutation_dropped` from app versions < 2026.821 before all three sinks. Fixed clients still forward their throttled trickle.
- **Per-install hourly `$exception` budget (60/h)** — `claimExceptionBudget` reuses `rate_limits` (no migration), trims only the `$exception` stream, fails open on D1 errors.

## Part 2 — silent auto-update + post-restart what's-new (desktop)

Root cause of the noisy install: it sat on 2026.817.1 for days because updates waited for a click behind the 'available' prompt. New flow:

- **Updates always download silently.** No download prompt, no opt-in — `autoUpdater.autoDownload` is forced on; the Settings toggle and the available-phase dialog (Download / Remind Me Later / Skip This Version) are removed, with `skipVersion`/`setAutoDownload` IPC removed as orphans. Legacy store keys stay read-tolerated.
- **The user only sees the restart phase.** Once downloaded: the restart dialog (Restart Now / Later) + the sidebar Restart button. 'Later' still installs on the next natural quit (`autoInstallOnAppQuit`).
- **Release notes open AFTER the restart.** Notes are persisted at download time (`store.pendingWhatsNew`) and consumed exactly once on the first launch of the installed version via the new `updater:consume-whats-new` IPC — the background download stays invisible; 'what changed' arrives when the change is actually running.

## Verification

- sync-server: 63 files / 980 tests green; typecheck green.
- desktop: `typecheck:web` + `typecheck:node` + `typecheck:test` green; full main suite 561 files / 7328 tests green; full renderer suite 688 files / 8358 tests green; `ipc:generate` + `ipc:check` + `rpc:check` green; `i18n:check` green.
- docs: `docs:impact --strict` + `docs:build` green (observability, settings, menu-bar pages updated).
