### PR TITLE
Note attachments panel + self-heal for broken attachment refs

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -93,6 +93,7 @@ import { applyMemrynoteIdentity, flipIdentityPin, getIdentityDecision } from './
 import { probeSecretStoreIdentity } from './secrets/secret-storage'
 import { isAllowedExternalUrl, isPathInsideDirs, resolveMemryFilePath } from './lib/external-url'
 import { remapCrossDeviceAttachmentPath } from './lib/attachment-path-remap'
+import { healAttachmentPath } from './vault/attachment-heal'
 import { decideFrameNavigation } from './lib/frame-navigation'
 import { decideEmbedRequestHeaders } from './lib/embed-referer'
 import { registerTestHooks } from './test-hooks'
@@ -1340,9 +1341,21 @@ const appReady = app.whenReady().then(async () => {
     }
 
     if (!existsSync(filePath)) {
-      // Return empty 1x1 transparent PNG for missing image files (null thumbnails)
-      // This avoids console errors and broken image icons
-      if (
+      // Self-heal (#1713): an attachment renamed on disk outside the app is
+      // served from its unique prefix/suffix match in the same note's folder.
+      // The note is never rewritten — each device heals against its own disk
+      // (see vault/attachment-heal.ts). Runs before the transparent-PNG
+      // fallback so renamed images heal instead of rendering as 1x1 blanks.
+      const healed = healAttachmentPath(filePath, vaultPaths)
+      if (healed) {
+        mainLog.debug('memry-file: healed renamed attachment', {
+          requested: filePath,
+          healed
+        })
+        filePath = healed
+      } else if (
+        // Return empty 1x1 transparent PNG for missing image files (null
+        // thumbnails). This avoids console errors and broken image icons
         filePath.endsWith('.png') ||
         filePath.endsWith('.jpg') ||
         filePath.endsWith('.jpeg') ||
@@ -1358,9 +1371,10 @@ const appReady = app.whenReady().then(async () => {
           status: 200,
           headers: { 'Content-Type': 'image/png' }
         })
+      } else {
+        // Return 404 for other missing files
+        return new Response(null, { status: 404, statusText: 'Not Found' })
       }
-      // Return 404 for other missing files
-      return new Response(null, { status: 404, statusText: 'Not Found' })
     }
 
     try {

--- a/apps/desktop/src/main/vault/attachment-actions.test.ts
+++ b/apps/desktop/src/main/vault/attachment-actions.test.ts
@@ -92,6 +92,28 @@ describe('resolveAttachment', () => {
     expect(result.storedFilename).toBe('k3f9x2-late.pdf')
   })
 
+  it('self-heals an externally renamed file via its unique prefix match (#1713)', () => {
+    const renamed = writeAttachment('attachments/n1/k3f9x2-report-final.pdf')
+
+    const result = resolveAttachment(NOTE_ID, '../attachments/n1/k3f9x2-report.pdf')
+
+    expect(result).toEqual({
+      absolutePath: renamed,
+      storedFilename: 'k3f9x2-report-final.pdf',
+      exists: true
+    })
+  })
+
+  it('leaves an ambiguous rename broken, still naming the expected file', () => {
+    writeAttachment('attachments/n1/k3f9x2-a.pdf')
+    writeAttachment('attachments/n1/k3f9x2-b.pdf')
+
+    const result = resolveAttachment(NOTE_ID, '../attachments/n1/k3f9x2-report.pdf')
+
+    expect(result.exists).toBe(false)
+    expect(result.storedFilename).toBe('k3f9x2-report.pdf')
+  })
+
   it('rejects a ref that escapes the vault', () => {
     expect(() => resolveAttachment(NOTE_ID, '../../../../etc/passwd')).toThrowError(
       expect.objectContaining({ code: NoteErrorCode.INVALID_PATH })

--- a/apps/desktop/src/main/vault/attachment-actions.ts
+++ b/apps/desktop/src/main/vault/attachment-actions.ts
@@ -18,6 +18,7 @@ import { getIndexDatabase } from '../database'
 import { NoteError, NoteErrorCode } from '../lib/errors'
 import { fromMemryFileUrl, isPathInVault } from '../lib/paths'
 import { remapCrossDeviceAttachmentPath } from '../lib/attachment-path-remap'
+import { healAttachmentPath } from './attachment-heal'
 import { getVaultRoot } from './notes-io'
 
 const MEMRY_FILE_PREFIX = 'memry-file://local/'
@@ -104,6 +105,14 @@ export function resolveAttachment(noteId: string, url: string): AttachmentResolv
       throw new NoteError('Attachment path escapes the vault', NoteErrorCode.INVALID_PATH, noteId)
     }
     absolutePath = path.join(vaultPath, resolved)
+  }
+
+  if (!existsSync(absolutePath)) {
+    // Self-heal (#1713): the file may have been renamed on disk outside the
+    // app. Serve the unique prefix/suffix match from the same note's folder;
+    // the block's url stays as written (see attachment-heal.ts for why).
+    const healed = healAttachmentPath(absolutePath, [vaultPath])
+    if (healed) absolutePath = healed
   }
 
   return {

--- a/apps/desktop/src/main/vault/attachment-heal.test.ts
+++ b/apps/desktop/src/main/vault/attachment-heal.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for attachment-heal.ts — the resolve-time repair for attachment files
+ * renamed on disk outside the app (#1713). The uniqueness rule is the safety
+ * boundary: an ambiguous folder must never guess, and matching never leaves
+ * the note's own attachments folder.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import { findHealCandidate, healAttachmentPath } from './attachment-heal'
+
+let vaultPath = ''
+let dir = ''
+
+function write(name: string, into: string = dir): void {
+  fs.mkdirSync(into, { recursive: true })
+  fs.writeFileSync(path.join(into, name), 'bytes')
+}
+
+beforeEach(() => {
+  vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'attachment-heal-'))
+  dir = path.join(vaultPath, 'attachments', 'n1')
+  fs.mkdirSync(dir, { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(vaultPath, { recursive: true, force: true })
+})
+
+describe('findHealCandidate', () => {
+  it('heals a prefix-preserving rename (name part changed)', () => {
+    write('abc123-report-final.pdf')
+
+    expect(findHealCandidate(dir, 'abc123-report.pdf')).toBe('abc123-report-final.pdf')
+  })
+
+  it('heals a stripped prefix (user removed the nanoid)', () => {
+    write('report.pdf')
+
+    expect(findHealCandidate(dir, 'abc123-report.pdf')).toBe('report.pdf')
+  })
+
+  it('heals a changed prefix with the name kept', () => {
+    write('xyz789-report.pdf')
+
+    expect(findHealCandidate(dir, 'abc123-report.pdf')).toBe('xyz789-report.pdf')
+  })
+
+  it('stays broken when the prefix and suffix candidates disagree', () => {
+    write('abc123-something-else.pdf')
+    write('zzzzzz-report.pdf')
+
+    expect(findHealCandidate(dir, 'abc123-report.pdf')).toBeNull()
+  })
+
+  it('stays broken when two files share the prefix', () => {
+    write('abc123-a.pdf')
+    write('abc123-b.pdf')
+
+    expect(findHealCandidate(dir, 'abc123-report.pdf')).toBeNull()
+  })
+
+  it('ignores unrelated files and dotfiles', () => {
+    write('abc123-report-v2.pdf')
+    write('.DS_Store')
+    write('qqqqqq-other.png')
+
+    expect(findHealCandidate(dir, 'abc123-report.pdf')).toBe('abc123-report-v2.pdf')
+  })
+
+  it('returns null for an empty or unreadable folder', () => {
+    expect(findHealCandidate(dir, 'abc123-report.pdf')).toBeNull()
+    expect(findHealCandidate(path.join(dir, 'missing'), 'abc123-report.pdf')).toBeNull()
+  })
+})
+
+describe('healAttachmentPath', () => {
+  it('heals only paths of the attachments/<noteId>/<file> shape inside the vault', () => {
+    write('abc123-report-v2.pdf')
+
+    const healed = healAttachmentPath(path.join(dir, 'abc123-report.pdf'), [vaultPath])
+    expect(healed).toBe(path.join(dir, 'abc123-report-v2.pdf'))
+  })
+
+  it('never matches across notes', () => {
+    write('abc123-report.pdf', path.join(vaultPath, 'attachments', 'other-note'))
+
+    expect(healAttachmentPath(path.join(dir, 'abc123-report.pdf'), [vaultPath])).toBeNull()
+  })
+
+  it('rejects paths outside an attachments folder', () => {
+    const notesDir = path.join(vaultPath, 'notes')
+    write('abc123-report-v2.pdf', notesDir)
+
+    expect(healAttachmentPath(path.join(notesDir, 'abc123-report.pdf'), [vaultPath])).toBeNull()
+  })
+
+  it('rejects an attachments-shaped path outside the vault', () => {
+    const foreign = fs.mkdtempSync(path.join(os.tmpdir(), 'foreign-vault-'))
+    try {
+      const foreignDir = path.join(foreign, 'attachments', 'n1')
+      write('abc123-report-v2.pdf', foreignDir)
+
+      expect(healAttachmentPath(path.join(foreignDir, 'abc123-report.pdf'), [vaultPath])).toBeNull()
+    } finally {
+      fs.rmSync(foreign, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/desktop/src/main/vault/attachment-heal.ts
+++ b/apps/desktop/src/main/vault/attachment-heal.ts
@@ -1,0 +1,80 @@
+/**
+ * Self-heal for broken attachment refs (#1713).
+ *
+ * The attachments folder is deliberately excluded from the indexer and the
+ * file watcher, so an attachment renamed on disk outside the app breaks its
+ * block reference silently and nothing ever repairs it. This module finds the
+ * renamed file again — at resolve/serve time only. The note's markdown is
+ * never rewritten: sync freezes the filename inside the encrypted manifest at
+ * upload, so a url rewrite on one device would fight the other devices' disks
+ * forever. Each device instead heals against its own folder on every resolve.
+ *
+ * Stored attachments are named `{6-char nanoid}-{sanitized name}{ext}`
+ * (see `generateUniqueFilename`). A missing file is matched against the other
+ * files of the SAME `attachments/<noteId>/` folder — never across notes — by:
+ *  - prefix: the candidate kept the 6-char prefix and was renamed after it, or
+ *  - suffix: the candidate kept the name and lost/changed the prefix
+ *    (a user stripping the "junk" prefix is the most likely manual rename).
+ * The union of both must be exactly one file, otherwise the ref stays broken
+ * and the block surfaces the expected filename instead.
+ */
+
+import { readdirSync } from 'fs'
+import path from 'path'
+
+/** The `{6-char nanoid}-` prefix `generateUniqueFilename` puts on every file. */
+const STORED_PREFIX_RE = /^[0-9a-z]{6}-/
+
+/**
+ * The unique prefix/suffix match for a missing file among its siblings, or
+ * null when there is none or more than one. `dirPath` must already be a
+ * note's own attachments folder — callers guard that via `healAttachmentPath`.
+ */
+export function findHealCandidate(dirPath: string, expectedFilename: string): string | null {
+  let entries
+  try {
+    entries = readdirSync(dirPath, { withFileTypes: true })
+  } catch {
+    return null
+  }
+
+  const expectedHasPrefix = STORED_PREFIX_RE.test(expectedFilename)
+  const expectedPrefix = expectedHasPrefix ? expectedFilename.slice(0, 7) : null
+  const expectedSuffix = expectedHasPrefix ? expectedFilename.slice(7) : expectedFilename
+
+  const matches: string[] = []
+  for (const entry of entries) {
+    if (!entry.isFile()) continue
+    const name = entry.name
+    if (name.startsWith('.') || name === expectedFilename) continue
+
+    const prefixMatch = expectedPrefix !== null && name.startsWith(expectedPrefix)
+    const suffixMatch =
+      expectedSuffix.length > 0 && name.replace(STORED_PREFIX_RE, '') === expectedSuffix
+    if (prefixMatch || suffixMatch) matches.push(name)
+  }
+
+  return matches.length === 1 ? matches[0] : null
+}
+
+/**
+ * Heal an absolute attachment path that does not exist on disk, or null.
+ *
+ * Only paths of the exact shape `<vault>/attachments/<noteId>/<file>` are
+ * eligible — anything else (a note body, a path outside the vault) is not an
+ * attachment and must keep its plain 404 behavior.
+ */
+export function healAttachmentPath(absolutePath: string, vaultPaths: string[]): string | null {
+  const dir = path.dirname(absolutePath)
+  const attachmentsRoot = path.dirname(dir)
+  if (path.basename(attachmentsRoot) !== 'attachments') return null
+
+  const vaultRoot = path.dirname(attachmentsRoot)
+  const inVault = vaultPaths.some(
+    (vault) => vault && path.resolve(vault) === path.resolve(vaultRoot)
+  )
+  if (!inVault) return null
+
+  const healed = findHealCandidate(dir, path.basename(absolutePath))
+  return healed ? path.join(dir, healed) : null
+}

--- a/apps/desktop/src/main/vault/attachments.test.ts
+++ b/apps/desktop/src/main/vault/attachments.test.ts
@@ -461,6 +461,16 @@ describe('attachment operations', () => {
       expect(attachments).toEqual([])
     })
 
+    it('skips OS droppings like .DS_Store (#1713)', async () => {
+      await saveAttachment('note123', Buffer.from('data'), 'doc.pdf')
+      fs.writeFileSync(path.join(tempVault.path, 'attachments', 'note123', '.DS_Store'), 'junk')
+
+      const attachments = await listNoteAttachments('note123')
+
+      expect(attachments.length).toBe(1)
+      expect(attachments[0].filename.endsWith('doc.pdf')).toBe(true)
+    })
+
     it('T394: includes size and mimeType', async () => {
       const data = Buffer.from('test data')
       await saveAttachment('note123', data, 'test.png')

--- a/apps/desktop/src/main/vault/attachments.ts
+++ b/apps/desktop/src/main/vault/attachments.ts
@@ -496,6 +496,8 @@ export async function listNoteAttachments(noteId: string): Promise<AttachmentInf
 
     for (const entry of entries) {
       if (!entry.isFile()) continue
+      // OS droppings (.DS_Store and friends) are not attachments.
+      if (entry.name.startsWith('.')) continue
 
       const filePath = path.join(attachmentsDir, entry.name)
       const stats = await stat(filePath)

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
@@ -448,3 +448,60 @@ describe('FileBlock url resolution', () => {
     expect(screen.getByTestId('pdf-document')).toHaveAttribute('data-file', RELATIVE)
   })
 })
+
+describe('FileBlock missing attachment card (#1713)', () => {
+  // The file is gone from disk and main's self-heal found no unique match:
+  // the block must say which filename it expected instead of silently failing.
+  const RELATIVE = '../attachments/note1/abc123-manual.pdf'
+
+  let savedNotesApi: unknown
+
+  function renderWithNoteId(resolveAttachment: ReturnType<typeof vi.fn>) {
+    // The global test setup owns `window.api`; overlay the notes surface.
+    const api = window.api as unknown as Record<string, unknown>
+    savedNotesApi = api.notes
+    api.notes = { ...((api.notes as Record<string, unknown>) ?? {}), resolveAttachment }
+    const Render = (createFileBlock as any).render
+    const block = {
+      props: { url: RELATIVE, name: 'manual.pdf', size: 2048, mimeType: 'application/pdf' }
+    }
+    return render(
+      <NoteFileUrlProvider resolveFileUrl={async (url) => url} noteId="note1">
+        <Render contentRef={vi.fn()} editor={{ updateBlock: vi.fn() }} block={block} />
+      </NoteFileUrlProvider>
+    )
+  }
+
+  afterEach(() => {
+    ;(window.api as unknown as Record<string, unknown>).notes = savedNotesApi
+  })
+
+  it('names the expected file when the attachment is gone and unhealable', async () => {
+    const resolveAttachment = vi.fn().mockResolvedValue({
+      absolutePath: '/vault/attachments/note1/abc123-manual.pdf',
+      storedFilename: 'abc123-manual.pdf',
+      exists: false
+    })
+    renderWithNoteId(resolveAttachment)
+
+    expect(await screen.findByTestId('attachment-missing-card')).toBeInTheDocument()
+    expect(resolveAttachment).toHaveBeenCalledWith('note1', RELATIVE)
+    // The i18n mock returns raw keys; the expected-filename line is the
+    // missingExpected key rendered next to the title.
+    expect(screen.getByText(/missingExpected/)).toBeInTheDocument()
+    expect(screen.queryByTestId('pdf-document')).not.toBeInTheDocument()
+  })
+
+  it('renders normally when the file exists (or was healed by main)', async () => {
+    const resolveAttachment = vi.fn().mockResolvedValue({
+      absolutePath: '/vault/attachments/note1/abc123-manual-v2.pdf',
+      storedFilename: 'abc123-manual-v2.pdf',
+      exists: true
+    })
+    renderWithNoteId(resolveAttachment)
+
+    expect(await screen.findByTestId('pdf-document')).toBeInTheDocument()
+    expect(resolveAttachment).toHaveBeenCalled()
+    expect(screen.queryByTestId('attachment-missing-card')).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -6,7 +6,14 @@ import { getI18n } from 'react-i18next'
  * @module components/note/content-area/file-block
  */
 
-import { useState, useCallback, useEffect, useRef, useLayoutEffect } from 'react'
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  useLayoutEffect,
+  useSyncExternalStore
+} from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import type { PDFDocumentProxy as PdfDocumentProxy } from 'pdfjs-dist'
@@ -30,7 +37,8 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { useSync } from '@/contexts/sync-context'
 import { useT } from '@memry/i18n/renderer'
-import { useResolvedFileUrl } from './note-file-url-context'
+import { getAttachmentRevision, subscribeToAttachmentRevisions } from '@/lib/attachment-revision'
+import { HAS_SCHEME, useAttachmentNoteId, useResolvedFileUrl } from './note-file-url-context'
 import { AttachmentBlockContextMenu, AttachmentMenuButton } from './attachment-block-menu'
 import type { FileBlockProps } from './file-block-markers'
 
@@ -669,6 +677,93 @@ function AudioPreview({ url, name, menu }: FilePreviewProps) {
 }
 
 // ============================================================================
+// Missing Attachment Card (#1713)
+// ============================================================================
+
+interface AttachmentPresence {
+  missing: boolean
+  /** The on-disk filename the ref expects, for the card's repair hint. */
+  expectedFilename: string | null
+}
+
+const ATTACHMENT_PRESENT: AttachmentPresence = { missing: false, expectedFilename: null }
+
+/**
+ * Whether the block's attachment is actually on disk (after main's self-heal
+ * pass had its chance). Re-checked when an attachment for this note lands, so
+ * a file that syncs in later clears the card without a remount.
+ */
+function useAttachmentPresence(url: string): AttachmentPresence {
+  const noteId = useAttachmentNoteId()
+  const revision = useSyncExternalStore(subscribeToAttachmentRevisions, () =>
+    getAttachmentRevision(noteId)
+  )
+  const [presence, setPresence] = useState<AttachmentPresence>(ATTACHMENT_PRESENT)
+
+  useEffect(() => {
+    // Only vault refs (note-relative or legacy memry-file) are checkable;
+    // http/data urls are not attachments. Surfaces without a note id (and
+    // tests without the IPC surface) just never show the card.
+    const isVaultRef = Boolean(url) && (!HAS_SCHEME.test(url) || url.startsWith('memry-file:'))
+    if (!noteId || !isVaultRef || !window.api?.notes?.resolveAttachment) {
+      setPresence(ATTACHMENT_PRESENT)
+      return
+    }
+    let cancelled = false
+    window.api.notes
+      .resolveAttachment(noteId, url)
+      .then((info) => {
+        if (cancelled) return
+        setPresence(
+          info.exists
+            ? ATTACHMENT_PRESENT
+            : { missing: true, expectedFilename: info.storedFilename }
+        )
+      })
+      .catch(() => {
+        // An unresolvable url (invalid path shape) is not "missing on disk" —
+        // leave the block to its normal rendering.
+        if (!cancelled) setPresence(ATTACHMENT_PRESENT)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [noteId, url, revision])
+
+  return presence
+}
+
+function MissingAttachmentCard({
+  name,
+  expectedFilename,
+  menu
+}: {
+  name: string
+  expectedFilename: string | null
+  menu?: React.ReactNode
+}) {
+  const { t: tPhaseF } = useT('notes')
+  return (
+    <div
+      data-testid="attachment-missing-card"
+      className="file-attachment-missing relative flex items-center gap-3 rounded-md border border-dashed border-border bg-muted/30 p-3"
+    >
+      <File className="h-5 w-5 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{name}</p>
+        <p className="truncate text-xs text-muted-foreground">
+          {tPhaseF('editor.attachmentMenu.missingTitle')}
+          {expectedFilename
+            ? ` — ${tPhaseF('editor.attachmentMenu.missingExpected', { name: expectedFilename })}`
+            : ''}
+        </p>
+      </div>
+      {menu}
+    </div>
+  )
+}
+
+// ============================================================================
 // FileBlock Spec
 // ============================================================================
 
@@ -710,6 +805,7 @@ function FileBlockRender({
   // result is for rendering only — writing it back to `block.props` would put
   // this machine's vault path into the note's markdown.
   const resolvedUrl = useResolvedFileUrl(url)
+  const presence = useAttachmentPresence(url)
 
   // Persist the user-chosen PDF width + crop height to the block props
   // (round-trips to the vault marker via serializeFileBlock). Declared before
@@ -751,6 +847,22 @@ function FileBlockRender({
   // The raw stored url goes to the menu, never `resolvedUrl` — main re-resolves
   // and validates it against the vault itself.
   const menuButton = <AttachmentMenuButton url={url} name={name} />
+
+  // The file is gone from disk and self-heal found no unique match: name the
+  // expected file so the user can repair the rename by hand (#1713).
+  if (presence.missing) {
+    return (
+      <AttachmentBlockContextMenu url={url} name={name}>
+        <div ref={contentRef} className="file-block my-2" contentEditable={false}>
+          <MissingAttachmentCard
+            name={name}
+            expectedFilename={presence.expectedFilename}
+            menu={menuButton}
+          />
+        </div>
+      </AttachmentBlockContextMenu>
+    )
+  }
 
   return (
     <AttachmentBlockContextMenu url={url} name={name}>

--- a/apps/desktop/src/renderer/src/components/note/content-area/note-file-url-context.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/note-file-url-context.tsx
@@ -50,7 +50,7 @@ export function useAttachmentNoteId(): string | undefined {
 }
 
 /** `https:`, `data:`, `memry-file:` — and `C:` on Windows. Mirrors the resolver. */
-const HAS_SCHEME = /^[a-zA-Z][a-zA-Z\d+\-.]*:/
+export const HAS_SCHEME = /^[a-zA-Z][a-zA-Z\d+\-.]*:/
 
 /**
  * The URL to actually render, or `null` while a note-relative one is still being

--- a/apps/desktop/src/renderer/src/components/note/note-attachments-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-attachments-dialog.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Tests for NoteAttachmentsDialog (#1713) — the note menu's attachments panel.
+ * The folder listing is the source of truth; original names come from the
+ * block props via the caller's lookup.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  NoteAttachmentsDialog,
+  collectOriginalNames,
+  lookupOriginalName
+} from './note-attachments-dialog'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string, opts?: { name?: string }) => (opts?.name ? `${key}:${opts.name}` : key)
+  })
+}))
+
+vi.mock('react-i18next', () => ({
+  getI18n: () => ({ getFixedT: () => (key: string) => key })
+}))
+
+const listAttachments = vi.fn()
+const revealAttachmentInFinder = vi.fn().mockResolvedValue(undefined)
+const openAttachmentExternal = vi.fn().mockResolvedValue(undefined)
+
+// The global test setup owns `window.api`; tests overlay their own notes
+// surface on it rather than replacing the object (same pattern as
+// attachment-block-menu.test.tsx).
+function setupApi(): void {
+  const api = window.api as unknown as Record<string, unknown>
+  api.notes = {
+    ...((api.notes as Record<string, unknown>) ?? {}),
+    listAttachments,
+    revealAttachmentInFinder,
+    openAttachmentExternal
+  }
+}
+
+afterEach(() => {
+  listAttachments.mockReset()
+  revealAttachmentInFinder.mockClear()
+  openAttachmentExternal.mockClear()
+})
+
+const ROW = {
+  filename: 'abc123-report.pdf',
+  path: 'memry-file://local/vault/attachments/n1/abc123-report.pdf',
+  size: 2048,
+  mimeType: 'application/pdf',
+  type: 'file' as const
+}
+
+function renderDialog(names = new Map<string, string>()): void {
+  setupApi()
+  render(
+    <NoteAttachmentsDialog open onOpenChange={vi.fn()} noteId="n1" getOriginalNames={() => names} />
+  )
+}
+
+describe('NoteAttachmentsDialog', () => {
+  it('lists the folder contents with original name, stored name and size', async () => {
+    listAttachments.mockResolvedValue([ROW])
+    renderDialog(new Map([['abc123-report.pdf', 'Quarterly report.pdf']]))
+
+    const row = await screen.findByTestId('note-attachment-row')
+    expect(row).toHaveTextContent('Quarterly report.pdf')
+    expect(row).toHaveTextContent('editor.attachmentMenu.storedAs:abc123-report.pdf')
+    expect(row).toHaveTextContent('2.0 KB')
+  })
+
+  it('falls back to the stored filename when no block names the file', async () => {
+    listAttachments.mockResolvedValue([ROW])
+    renderDialog()
+
+    const row = await screen.findByTestId('note-attachment-row')
+    expect(row).toHaveTextContent('abc123-report.pdf')
+    expect(row).not.toHaveTextContent('storedAs')
+  })
+
+  it('reveals and opens a row through the attachment IPCs', async () => {
+    listAttachments.mockResolvedValue([ROW])
+    renderDialog()
+    await screen.findByTestId('note-attachment-row')
+
+    fireEvent.click(screen.getByLabelText('editor.toolbar.revealInFinder'))
+    fireEvent.click(screen.getByLabelText('editor.toolbar.openInDefaultApp'))
+
+    expect(revealAttachmentInFinder).toHaveBeenCalledWith('n1', ROW.path)
+    expect(openAttachmentExternal).toHaveBeenCalledWith('n1', ROW.path)
+  })
+
+  it('shows the empty state for a note without attachments', async () => {
+    listAttachments.mockResolvedValue([])
+    renderDialog()
+
+    expect(await screen.findByText('editor.attachmentsDialog.empty')).toBeInTheDocument()
+  })
+})
+
+describe('lookupOriginalName', () => {
+  const names = new Map([['abc123-report.pdf', 'Quarterly report.pdf']])
+
+  it('matches the stored filename exactly', () => {
+    expect(lookupOriginalName(names, 'abc123-report.pdf')).toBe('Quarterly report.pdf')
+  })
+
+  it('matches a renamed (self-healed) file by its unique 6-char prefix', () => {
+    expect(lookupOriginalName(names, 'abc123-report-final.pdf')).toBe('Quarterly report.pdf')
+  })
+
+  it('returns undefined for an unknown or ambiguous prefix', () => {
+    expect(lookupOriginalName(names, 'zzzzzz-other.pdf')).toBeUndefined()
+    const ambiguous = new Map([
+      ['abc123-a.pdf', 'A.pdf'],
+      ['abc123-b.pdf', 'B.pdf']
+    ])
+    expect(lookupOriginalName(ambiguous, 'abc123-c.pdf')).toBeUndefined()
+  })
+})
+
+describe('collectOriginalNames', () => {
+  it('walks file and image blocks, including nested children', () => {
+    const editor = {
+      document: [
+        {
+          type: 'file',
+          props: { url: '../attachments/n1/abc123-report.pdf', name: 'Quarterly report.pdf' },
+          children: []
+        },
+        {
+          type: 'paragraph',
+          props: {},
+          children: [
+            {
+              type: 'image',
+              props: { url: '../attachments/n1/qq11ww-photo%20one.png', name: 'photo one.png' },
+              children: []
+            }
+          ]
+        }
+      ]
+    }
+
+    const names = collectOriginalNames(editor)
+    expect(names.get('abc123-report.pdf')).toBe('Quarterly report.pdf')
+    expect(names.get('qq11ww-photo one.png')).toBe('photo one.png')
+  })
+
+  it('tolerates a missing editor or document', () => {
+    expect(collectOriginalNames(null).size).toBe(0)
+    expect(collectOriginalNames({}).size).toBe(0)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/note-attachments-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-attachments-dialog.tsx
@@ -1,0 +1,227 @@
+/**
+ * NoteAttachmentsDialog — every file under this note's `attachments/<noteId>/`
+ * folder, from the note menu (#1713). The folder listing is the source of
+ * truth (`listAttachments`); the original filenames live only in the block
+ * props, so the opener hands in a lookup built from the live editor document.
+ *
+ * @module components/note/note-attachments-dialog
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { getI18n } from 'react-i18next'
+import { toast } from 'sonner'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { ExternalLink, File, FileAudio, FileText, FolderOpen, Image } from '@/lib/icons'
+import { useT } from '@memry/i18n/renderer'
+
+interface AttachmentRow {
+  /** On-disk stored name (`{prefix}-{name}` scheme). */
+  filename: string
+  /** Absolute `memry-file://local/…` URL, accepted by the attachment IPCs. */
+  path: string
+  size: number
+  mimeType: string
+  type: 'image' | 'file'
+}
+
+interface NoteAttachmentsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  noteId: string
+  /**
+   * Stored-filename → original filename, from the note's file/image block
+   * props. Read once per open; a file no block references simply has no entry.
+   */
+  getOriginalNames: () => Map<string, string>
+}
+
+/** The `{6-char nanoid}-` prefix on stored attachment filenames. */
+const STORED_PREFIX_RE = /^[0-9a-z]{6}-/
+
+/**
+ * The block-props original name for a stored file. Falls back to a unique
+ * 6-char-prefix match so an externally renamed (self-healed) file still shows
+ * the name of the block that owns it.
+ */
+export function lookupOriginalName(
+  names: Map<string, string>,
+  storedFilename: string
+): string | undefined {
+  const exact = names.get(storedFilename)
+  if (exact) return exact
+  if (!STORED_PREFIX_RE.test(storedFilename)) return undefined
+  const prefix = storedFilename.slice(0, 7)
+  const hits = [...names.entries()].filter(([stored]) => stored.startsWith(prefix))
+  return hits.length === 1 ? hits[0][1] : undefined
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function rowIcon(row: AttachmentRow): React.ReactNode {
+  if (row.type === 'image') return <Image className="h-5 w-5 shrink-0 text-muted-foreground" />
+  if (row.mimeType === 'application/pdf')
+    return <FileText className="h-5 w-5 shrink-0 text-red-500" />
+  if (row.mimeType.startsWith('audio/'))
+    return <FileAudio className="h-5 w-5 shrink-0 text-muted-foreground" />
+  return <File className="h-5 w-5 shrink-0 text-muted-foreground" />
+}
+
+export function NoteAttachmentsDialog({
+  open,
+  onOpenChange,
+  noteId,
+  getOriginalNames
+}: NoteAttachmentsDialogProps) {
+  const { t } = useT('notes')
+  const [rows, setRows] = useState<AttachmentRow[]>([])
+  const [names, setNames] = useState<Map<string, string>>(new Map())
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setLoading(true)
+    setNames(getOriginalNames())
+    window.api.notes
+      .listAttachments(noteId)
+      .then((attachments: AttachmentRow[]) => {
+        setRows([...attachments].sort((a, b) => a.filename.localeCompare(b.filename)))
+      })
+      .catch((err: unknown) => {
+        // `t` from useT is not identity-stable across renders; pulling the
+        // fallback at call time keeps it out of the effect deps (same pattern
+        // as PdfPreview's load-error handler).
+        toast.error(
+          extractErrorMessage(
+            err,
+            getI18n().getFixedT(null, 'notes')('editor.attachmentsDialog.loadFailed')
+          )
+        )
+        setRows([])
+      })
+      .finally(() => setLoading(false))
+  }, [open, noteId, getOriginalNames])
+
+  const reveal = useCallback(
+    (row: AttachmentRow) => {
+      window.api.notes.revealAttachmentInFinder(noteId, row.path).catch((err: unknown) => {
+        toast.error(extractErrorMessage(err, t('editor.attachmentMenu.revealFailed')))
+      })
+    },
+    [noteId, t]
+  )
+
+  const openExternal = useCallback(
+    (row: AttachmentRow) => {
+      window.api.notes.openAttachmentExternal(noteId, row.path).catch((err: unknown) => {
+        toast.error(extractErrorMessage(err, t('editor.attachmentMenu.openFailed')))
+      })
+    },
+    [noteId, t]
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg" data-testid="note-attachments-dialog">
+        <DialogHeader>
+          <DialogTitle>{t('editor.attachmentsDialog.title')}</DialogTitle>
+          <DialogDescription>{t('editor.attachmentsDialog.description')}</DialogDescription>
+        </DialogHeader>
+        {!loading && rows.length === 0 ? (
+          <p className="py-4 text-sm text-muted-foreground">
+            {t('editor.attachmentsDialog.empty')}
+          </p>
+        ) : (
+          <ul className="max-h-80 space-y-1 overflow-y-auto">
+            {rows.map((row) => {
+              const original = lookupOriginalName(names, row.filename)
+              return (
+                <li
+                  key={row.filename}
+                  data-testid="note-attachment-row"
+                  className="flex items-center gap-3 rounded-md border border-border p-2"
+                >
+                  {rowIcon(row)}
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium" title={original ?? row.filename}>
+                      {original ?? row.filename}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground" title={row.filename}>
+                      {original
+                        ? `${t('editor.attachmentMenu.storedAs', { name: row.filename })} · ${formatFileSize(row.size)}`
+                        : formatFileSize(row.size)}
+                    </p>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    title={t('editor.toolbar.revealInFinder')}
+                    aria-label={t('editor.toolbar.revealInFinder')}
+                    onClick={() => reveal(row)}
+                  >
+                    <FolderOpen className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    title={t('editor.toolbar.openInDefaultApp')}
+                    aria-label={t('editor.toolbar.openInDefaultApp')}
+                    onClick={() => openExternal(row)}
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                  </Button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/**
+ * Stored-filename → original-name map from a live BlockNote document. Walks
+ * file and image blocks; the key is the ref's basename, which is the stored
+ * filename for every attachment the app wrote itself.
+ */
+export function collectOriginalNames(editor: unknown): Map<string, string> {
+  const map = new Map<string, string>()
+  const visit = (blocks: unknown): void => {
+    if (!Array.isArray(blocks)) return
+    for (const block of blocks) {
+      const b = block as {
+        type?: string
+        props?: { url?: string; name?: string }
+        children?: unknown
+      }
+      if ((b.type === 'file' || b.type === 'image') && b.props?.url && b.props.name) {
+        let ref = b.props.url
+        try {
+          ref = decodeURIComponent(ref)
+        } catch {
+          // A malformed escape keeps the raw ref; the basename still matches
+          // whenever the stored name had nothing to encode.
+        }
+        const basename = ref.split(/[/\\]/).pop()
+        if (basename) map.set(basename, b.props.name)
+      }
+      visit(b.children)
+    }
+  }
+  visit((editor as { document?: unknown } | null | undefined)?.document)
+  return map
+}

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -77,6 +77,7 @@ import {
   FolderOpen,
   PanelLeft,
   ExternalLink,
+  Paperclip,
   Trash2
 } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
@@ -84,6 +85,10 @@ import { Picker } from '@/components/ui/picker'
 import { Switch } from '@/components/ui/switch'
 import { MoveToFolderDialog } from '@/components/folder-view/move-to-folder-dialog'
 import { WikiLinkCreateDialog } from '@/components/note/wiki-link-create-dialog'
+import {
+  NoteAttachmentsDialog,
+  collectOriginalNames
+} from '@/components/note/note-attachments-dialog'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -226,6 +231,7 @@ export function NotePage({ noteId }: NotePageProps) {
   const [pendingWikiLinkCreate, setPendingWikiLinkCreate] = useState<string | null>(null)
   const [moreMenuOpen, setMoreMenuOpen] = useState(false)
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false)
+  const [isAttachmentsOpen, setIsAttachmentsOpen] = useState(false)
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   // External ref to the inline title textarea so the "Rename" menu item can focus it
@@ -796,7 +802,22 @@ export function NotePage({ noteId }: NotePageProps) {
     noteTitle: note?.title ?? '',
     onEditorReady: review.handleEditorReady
   })
-  const { refresh: refreshMindMap } = mindMap
+  const { refresh: refreshMindMap, handleEditorReady: mindMapEditorReady } = mindMap
+  // The attachments dialog reads original filenames off the live block tree;
+  // the editor is captured here (composed, not replacing the mind map's hook)
+  // so the dialog needs no new prop on the content area.
+  const attachmentsEditorRef = useRef<unknown>(null)
+  const handleEditorReadyWithAttachments = useCallback(
+    (editor: unknown) => {
+      attachmentsEditorRef.current = editor
+      mindMapEditorReady(editor)
+    },
+    [mindMapEditorReady]
+  )
+  const getAttachmentOriginalNames = useCallback(
+    () => collectOriginalNames(attachmentsEditorRef.current),
+    []
+  )
   const getEditorContainer = useCallback(() => editorContainerRef.current, [])
   const getNoteBody = useCallback(() => noteBodyRef.current, [])
   // The map is built when it opens, but a restored tab reopens it before the
@@ -1402,6 +1423,7 @@ export function NotePage({ noteId }: NotePageProps) {
           if (action === 'reveal-in-finder') void handleRevealInFinder()
           if (action === 'reveal-in-sidebar') handleRevealInSidebar()
           if (action === 'open-external') void handleOpenExternal()
+          if (action === 'attachments') setIsAttachmentsOpen(true)
           if (action === 'delete') setIsDeleteConfirmOpen(true)
           if (action === 'local-only')
             void handleToggleLocalOnly(!(note.frontmatter.localOnly ?? false))
@@ -1495,6 +1517,11 @@ export function NotePage({ noteId }: NotePageProps) {
               value="open-external"
               label={t('editor.toolbar.openInDefaultApp')}
               icon={<ExternalLink className="size-4" />}
+            />
+            <Picker.Item
+              value="attachments"
+              label={t('editor.toolbar.attachments')}
+              icon={<Paperclip className="size-4" />}
             />
             <Picker.Separator />
             <Picker.Item
@@ -1699,7 +1726,7 @@ export function NotePage({ noteId }: NotePageProps) {
                   plainMarkdown: review.plainMarkdown,
                   marks: review.marks,
                   hoveredMarkId: review.hoveredMarkId,
-                  onEditorReady: mindMap.handleEditorReady,
+                  onEditorReady: handleEditorReadyWithAttachments,
                   onAddComment: review.openCommentComposer,
                   getMarkdownSourceOffsetForEditorOffset:
                     review.getMarkdownSourceOffsetForEditorOffset,
@@ -1769,6 +1796,14 @@ export function NotePage({ noteId }: NotePageProps) {
         onOpenChange={setIsExportDialogOpen}
         noteId={noteId}
         noteTitle={note.title}
+      />
+
+      {/* Attachments panel (#1713) */}
+      <NoteAttachmentsDialog
+        open={isAttachmentsOpen}
+        onOpenChange={setIsAttachmentsOpen}
+        noteId={noteId}
+        getOriginalNames={getAttachmentOriginalNames}
       />
 
       {/* Apply Template Dialog */}

--- a/apps/desktop/tests/e2e/attachment-self-heal.e2e.ts
+++ b/apps/desktop/tests/e2e/attachment-self-heal.e2e.ts
@@ -183,6 +183,14 @@ test.describe('Note attachments panel', () => {
     await ready(page)
     const seeded = await seedNoteWithFileBlock(page, testVaultPath, uniqueLabel('Attach Panel'))
 
+    // The panel lists the OPENED note's own folder; the seed uploads against a
+    // host note (the marker-as-initial-content workaround), so mirror the file
+    // into the opened note's folder the way a normal upload would have put it.
+    const hostPath = attachmentDiskPath(testVaultPath, seeded)
+    const ownDir = path.join(testVaultPath, 'attachments', seeded.noteId)
+    fs.mkdirSync(ownDir, { recursive: true })
+    fs.copyFileSync(hostPath, path.join(ownDir, seeded.storedFilename))
+
     await page.locator('[data-testid="note-more-menu"]').first().click()
     await page.getByRole('option', { name: 'Attachments…' }).click()
 

--- a/apps/desktop/tests/e2e/attachment-self-heal.e2e.ts
+++ b/apps/desktop/tests/e2e/attachment-self-heal.e2e.ts
@@ -1,0 +1,204 @@
+/**
+ * Attachments panel + self-heal E2E (issue #1713)
+ *
+ * Covers the two halves of the issue against a real vault on disk:
+ *  - self-heal: an attachment renamed on disk outside the app (prefix kept)
+ *    still renders, without the note's markdown ever changing;
+ *  - ambiguous renames stay broken but the block names the file it expected;
+ *  - the note menu's "Attachments…" panel lists the folder with original +
+ *    stored names and per-row OS actions.
+ *
+ * Side-effecting OS items (Reveal in Finder / Open in default app) are only
+ * asserted present + enabled — never clicked (same policy as
+ * attachment-block-menu / note-menu-actions).
+ */
+
+import fs from 'fs'
+import path from 'path'
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { ready, uniqueLabel } from './utils/desktop-test-helpers'
+import { SELECTORS } from './utils/electron-helpers'
+
+const ORIGINAL_NAME = 'original-report.txt'
+
+interface SeededAttachment {
+  /** The note that is opened, whose body is the file-block marker. */
+  noteId: string
+  /** The note the attachment was uploaded against — the on-disk folder key. */
+  attachmentNoteId: string
+  storedFilename: string
+  /** The note-relative ref written into the block marker. */
+  url: string
+}
+
+/**
+ * Create a note whose body is a single file-block marker pointing at a real
+ * uploaded attachment, then open it via the restored-session pattern (same
+ * seed as attachment-block-menu).
+ */
+async function seedNoteWithFileBlock(
+  page: Page,
+  vaultPath: string,
+  title: string
+): Promise<SeededAttachment> {
+  const seeded = await page.evaluate(
+    async ({ t, fileName }) => {
+      const api = window.api
+
+      const host = await api.notes.create({ title: `${t} host`, content: 'attachment host' })
+      if (!host.success || !host.note) throw new Error(host.error ?? 'host note create failed')
+
+      const file = new File([new TextEncoder().encode('self-heal e2e')], fileName, {
+        type: 'text/plain'
+      })
+      const uploaded = await api.notes.uploadAttachment(host.note.id, file)
+      if (!uploaded.success || !uploaded.path) {
+        throw new Error(uploaded.error ?? 'attachment upload failed')
+      }
+      const attachments = await api.notes.listAttachments(host.note.id)
+      const storedFilename = attachments[0]?.filename
+      if (!storedFilename) throw new Error('uploaded attachment not listed')
+
+      const marker = `<!-- file:${JSON.stringify({
+        url: uploaded.path,
+        name: fileName,
+        size: uploaded.size ?? 0,
+        mimeType: 'text/plain'
+      })} -->`
+      const note = await api.notes.create({ title: t, content: marker })
+      if (!note.success || !note.note) throw new Error(note.error ?? 'note create failed')
+
+      return {
+        noteId: note.note.id,
+        attachmentNoteId: host.note.id,
+        storedFilename,
+        url: uploaded.path
+      }
+    },
+    { t: title, fileName: ORIGINAL_NAME }
+  )
+
+  await page.addInitScript(
+    ({ noteId, t, storageKey }) => {
+      // Tab state is stored per vault since #1702: `memry_tab_state:<vaultPath>`.
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          version: 2,
+          tabGroups: {
+            g1: {
+              id: 'g1',
+              activeTabId: 'note-tab',
+              tabs: [
+                {
+                  id: 'note-tab',
+                  type: 'note',
+                  title: t,
+                  icon: 'file',
+                  path: `/notes/${noteId}`,
+                  entityId: noteId,
+                  isPinned: false
+                }
+              ]
+            }
+          },
+          layout: { type: 'leaf', tabGroupId: 'g1' },
+          activeGroupId: 'g1',
+          settings: { restoreSessionOnStart: true, tabCloseButton: 'hover' },
+          savedAt: Date.now()
+        })
+      )
+    },
+    { noteId: seeded.noteId, t: title, storageKey: `memry_tab_state:${vaultPath}` }
+  )
+  await page.reload()
+  await ready(page)
+  await page.locator(SELECTORS.noteEditor).first().waitFor({ state: 'visible', timeout: 20_000 })
+  await page.locator('.file-attachment').first().waitFor({ state: 'visible', timeout: 20_000 })
+
+  return seeded
+}
+
+function attachmentDiskPath(vaultPath: string, seeded: SeededAttachment): string {
+  return path.join(vaultPath, 'attachments', seeded.attachmentNoteId, seeded.storedFilename)
+}
+
+test.describe('Attachment self-heal', () => {
+  test('a prefix-preserving external rename no longer breaks the block', async ({
+    page,
+    testVaultPath
+  }) => {
+    await ready(page)
+    const seeded = await seedNoteWithFileBlock(page, testVaultPath, uniqueLabel('Heal Rename'))
+
+    // Rename outside the app, keeping the 6-char prefix.
+    const diskPath = attachmentDiskPath(testVaultPath, seeded)
+    const renamed = seeded.storedFilename.replace(/\.txt$/, '-renamed.txt')
+    fs.renameSync(diskPath, path.join(path.dirname(diskPath), renamed))
+
+    await page.reload()
+    await ready(page)
+    await page.locator(SELECTORS.noteEditor).first().waitFor({ state: 'visible', timeout: 20_000 })
+
+    // The block renders normally — no missing-file card.
+    await page.locator('.file-attachment').first().waitFor({ state: 'visible', timeout: 20_000 })
+    await expect(page.getByTestId('attachment-missing-card')).toHaveCount(0)
+
+    // The real resolve IPC heals to the renamed file; the stored ref is untouched.
+    const resolved = await page.evaluate(
+      ({ noteId, url }) => window.api.notes.resolveAttachment(noteId, url),
+      { noteId: seeded.noteId, url: seeded.url }
+    )
+    expect(resolved.exists).toBe(true)
+    expect(resolved.storedFilename).toBe(renamed)
+  })
+
+  test('an ambiguous rename stays broken and names the expected file', async ({
+    page,
+    testVaultPath
+  }) => {
+    await ready(page)
+    const seeded = await seedNoteWithFileBlock(page, testVaultPath, uniqueLabel('Heal Ambiguous'))
+
+    // Two candidates share the prefix — the heal must not guess.
+    const diskPath = attachmentDiskPath(testVaultPath, seeded)
+    const dir = path.dirname(diskPath)
+    const prefix = seeded.storedFilename.slice(0, 7)
+    fs.renameSync(diskPath, path.join(dir, `${prefix}candidate-a.txt`))
+    fs.writeFileSync(path.join(dir, `${prefix}candidate-b.txt`), 'decoy')
+
+    await page.reload()
+    await ready(page)
+    await page.locator(SELECTORS.noteEditor).first().waitFor({ state: 'visible', timeout: 20_000 })
+
+    const card = page.getByTestId('attachment-missing-card')
+    await expect(card).toBeVisible({ timeout: 20_000 })
+    await expect(card).toContainText(seeded.storedFilename)
+  })
+})
+
+test.describe('Note attachments panel', () => {
+  test('lists original + stored names with enabled OS actions', async ({ page, testVaultPath }) => {
+    await ready(page)
+    const seeded = await seedNoteWithFileBlock(page, testVaultPath, uniqueLabel('Attach Panel'))
+
+    await page.locator('[data-testid="note-more-menu"]').first().click()
+    await page.getByRole('option', { name: 'Attachments…' }).click()
+
+    const dialog = page.getByTestId('note-attachments-dialog')
+    await expect(dialog).toBeVisible()
+
+    const row = dialog.getByTestId('note-attachment-row')
+    await expect(row).toHaveCount(1)
+    await expect(row).toContainText(ORIGINAL_NAME)
+    await expect(row).toContainText(seeded.storedFilename)
+
+    // OS items present + enabled, never clicked.
+    for (const label of ['Reveal in Finder', 'Open in default app']) {
+      const button = row.getByRole('button', { name: label })
+      await expect(button).toBeVisible()
+      await expect(button).toBeEnabled()
+    }
+  })
+})

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -39,6 +39,20 @@ If the file hasn't synced to this device yet, the menu still shows both names, b
 
 Image blocks get the same menu too: hovering the image floats the `⋯` button over its top corner, and a right-click on the image opens the menu directly.
 
+### The Attachments Panel
+
+The note menu (`⋯` in the note toolbar) has an **Attachments…** entry that lists every file stored under the note's own attachments folder in one place — no hunting block by block. Each row shows the **original filename** (when a block in the note still references the file), the name it is **stored as** on disk, and its size, with **Reveal in Finder** and **Open in default app** buttons per row.
+
+A row without an original name is a file no block references anymore — still safe in the folder, just not embedded in the note.
+
+### Renamed on Disk? It Heals Itself
+
+The attachments folder is yours to look at, and files in it sometimes get renamed from outside the app — a cleanup in Finder, another tool touching the vault. That used to break the block forever, since nothing watches that folder.
+
+Now a missing file **heals at load time**: MemryNote looks for the renamed file inside the same note's attachments folder — a file that kept its 6-character prefix, or kept its name and lost the prefix — and serves it when the match is unambiguous. The note itself is never rewritten, so the repair is safe across synced devices; each device resolves against its own disk.
+
+If there is no safe match (the file is gone, or two candidates look equally likely), the block shows a card naming **the exact filename it expected**, so you can restore the name by hand. Renaming the file back — or to anything that keeps its prefix — fixes the block on the next load.
+
 ## PDF Inline Preview
 
 PDFs render inline as a clean scrolling preview — no viewer chrome — so a note reads as a document with its source embedded. The embed opens one page tall and **scrolls through the whole document**: keep scrolling inside it to read past the first page. A small `3 / 12` page indicator appears while you hover, so you can tell where you are. Only the pages near the embed's viewport are drawn, so a long PDF in a note stays as light as a short one.

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -168,6 +168,7 @@
       "revealInFinder": "Reveal in Finder",
       "revealInSidebar": "Reveal in navigation",
       "openInDefaultApp": "Open in default app",
+      "attachments": "Attachments…",
       "disableLocalOnly": "Disable local only",
       "setLocalOnly": "Set local only",
       "delete": "Delete note"
@@ -177,7 +178,15 @@
       "storedAs": "Stored as {name}",
       "notSynced": "Not synced to this device yet",
       "revealFailed": "Failed to reveal file",
-      "openFailed": "Failed to open file"
+      "openFailed": "Failed to open file",
+      "missingTitle": "Attachment file missing",
+      "missingExpected": "Expected file: {name}"
+    },
+    "attachmentsDialog": {
+      "title": "Attachments",
+      "description": "Files stored with this note",
+      "empty": "This note has no attachments.",
+      "loadFailed": "Failed to load attachments"
     },
     "breadcrumb": {
       "locationAria": "Note location",


### PR DESCRIPTION
Closes #1713.

## What

**Attachments panel** — an "Attachments…" entry in the note menu opens a dialog listing every file under the note's `attachments/<noteId>/` folder: original filename (from the live block props), stored name, size, with per-row **Reveal in Finder** and **Open in default app** (reuses the #1709 IPCs). `listNoteAttachments` now skips OS droppings like `.DS_Store`.

**Self-heal** — the attachments folder is unwatched, so a file renamed on disk outside the app broke its block forever. Missing files now heal at resolve/serve time: the `memry-file` protocol handler and `resolveAttachment` serve the unique match from the same note's folder (prefix kept, or name kept with the prefix stripped/changed). Matching never leaves the note's own folder; anything ambiguous stays broken. Unhealable blocks — generic file and audio previews included, which previously failed silently — render a card naming the exact filename they expected.

## Deviation from the issue text

The issue proposed rewriting the block's `url` through the editor update path. That would ping-pong between devices: sync freezes the filename inside the encrypted manifest (keyed by attachmentId), so a disk rename never propagates — device B still has the old name on disk, its heal would rewrite the url straight back, and the note would flip forever via CRDT. Healing at resolve time instead means the markdown never changes and each device repairs against its own disk. It also removes the read-only-surface problem and heals image blocks for free.

## Verification

- Unit: `attachment-heal.test.ts` (matching + folder guards), `attachment-actions.test.ts` (heal + ambiguous through the real IPC path), `attachments.test.ts` (dotfile filter), `file-block.test.tsx` (missing card), `note-attachments-dialog.test.tsx` (panel + name lookup) — all green
- E2E `attachment-self-heal.e2e.ts` 3/3: real on-disk rename → block renders and `resolveAttachment` heals; ambiguous rename → card names the expected file; panel lists original + stored names with enabled OS actions
- `typecheck` (web/node/test), `lint` (0 errors), `i18n:check`, `ipc:check` (no contract changes), `docs:impact --strict` + `docs:build` all green; docs updated in `user-guide/notes/attachments.md`