### PR TITLE
fix(sync-client): move the conformance suite out of __tests__ so Metro can bundle it

### DIFF
--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -7,7 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./adapters": "./src/adapters/index.ts",
-    "./adapters/conformance": "./src/adapters/__tests__/conformance.ts",
+    "./adapters/conformance": "./src/adapters/conformance.ts",
     "./vector-clock": "./src/vector-clock.ts",
     "./pull": "./src/pull/index.ts",
     "./*": "./src/*.ts"

--- a/packages/sync-client/src/adapters/conformance.ts
+++ b/packages/sync-client/src/adapters/conformance.ts
@@ -3,7 +3,7 @@ import {
   type CrdtTransport,
   type SyncAdapterSeam,
   type SyncPlatformAdapters
-} from '../index.ts'
+} from './index.ts'
 
 /**
  * One shared conformance suite, run against every adapter implementation:


### PR DESCRIPTION
Expo's Metro file map excludes `__tests__` directories, so the on-device seam harness could not resolve `@memry/sync-client/adapters/conformance` even though the file exists — the US1 device build failed to bundle. The suite is a shipped cross-shell API (it runs on device against the real mobile adapters), so it moves to `src/adapters/conformance.ts` and the exports map follows.

Only the package specifier ever referenced the old path. Evidence: sync-client 19 files / 179 tests green; desktop's conformance run 22/22 green; mobile typecheck green.