### PR TITLE
fix(cli): resolve drizzle migrations from the bundle, not a source-tree guess

### DIFF
--- a/apps/cli/src/app-core/bookmarks.test.ts
+++ b/apps/cli/src/app-core/bookmarks.test.ts
@@ -9,12 +9,9 @@ import { createBookmarksService } from '@memry/app-core/bookmarks'
 import type { DataDb } from './database.ts'
 
 // Builds the bookmarks table directly instead of going through
-// openDatabases()/runMigrations(): findWorkspaceRoot() walks up from the
-// current file looking for a directory literally named "memry", which in a
-// git worktree checkout (<repo>/.worktrees/<branch>/...) overshoots the
-// worktree and lands on the outer main-checkout repo root — a pre-existing,
-// unrelated environment issue, not something this fix touches. Building the
-// table in-memory keeps this test independent of that.
+// openDatabases()/runMigrations(): this suite is about bookmark id minting, not
+// about migrations, and an in-memory table keeps it independent of where the
+// drizzle folders resolve from (see migrations-path.test.ts for that).
 function createInMemoryDataDb(): DataDb {
   const sqlite = new Database(':memory:')
   sqlite.exec(`

--- a/apps/cli/src/app-core/database.ts
+++ b/apps/cli/src/app-core/database.ts
@@ -7,7 +7,8 @@ import * as dataSchema from '@memry/db-schema/data-schema'
 import * as indexSchema from '@memry/db-schema/index-schema'
 import { projects, statuses } from '@memry/db-schema/data-schema'
 import { eq } from 'drizzle-orm'
-import { findWorkspaceRoot, getDataDbPath, getIndexDbPath, getMemryDir } from './paths.ts'
+import { resolveMigrationsDir } from './migrations-path.ts'
+import { getDataDbPath, getIndexDbPath, getMemryDir } from './paths.ts'
 
 export type DataDb = BetterSQLite3Database<typeof dataSchema>
 export type IndexDb = BetterSQLite3Database<typeof indexSchema>
@@ -157,19 +158,14 @@ function ensureDefaultTaskProject(db: DataDb): void {
 }
 
 export function openDatabases(vaultPath: string): OpenedDatabases {
-  const workspaceRoot = findWorkspaceRoot()
+  const dataMigrations = resolveMigrationsDir('data')
+  const indexMigrations = resolveMigrationsDir('index')
   const dataDbPath = getDataDbPath(vaultPath)
   const indexDbPath = getIndexDbPath(vaultPath)
 
   withDatabaseInitLock(vaultPath, () => {
-    runMigrations(
-      dataDbPath,
-      path.join(workspaceRoot, 'apps/desktop/src/main/database/drizzle-data')
-    )
-    runMigrations(
-      indexDbPath,
-      path.join(workspaceRoot, 'apps/desktop/src/main/database/drizzle-index')
-    )
+    runMigrations(dataDbPath, dataMigrations)
+    runMigrations(indexDbPath, indexMigrations)
 
     const seedSqlite = new Database(dataDbPath)
     configure(seedSqlite, -dataCacheKiB)

--- a/apps/cli/src/app-core/migrations-path.test.ts
+++ b/apps/cli/src/app-core/migrations-path.test.ts
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { openDatabases } from './database.ts'
+import {
+  isMigrationsDir,
+  migrationsDirCandidates,
+  migrationsDirEnvVar,
+  resolveMigrationsDir,
+  type MigrationsKind
+} from './migrations-path.ts'
+
+// Real directory trees, not a stubbed `exists` predicate: the bug in #1722 was
+// that a path was accepted without anyone checking whether it existed, so a
+// test that mocks existence away cannot catch a regression of it.
+function makeTempRoot(label: string): string {
+  return fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), `memry-${label}-`))
+}
+
+/** A folder drizzle would accept: it has meta/_journal.json. */
+function seedMigrationsFolder(dir: string, kind: MigrationsKind): string {
+  const folder = path.join(dir, `drizzle-${kind}`)
+  fs.mkdirSync(path.join(folder, 'meta'), { recursive: true })
+  fs.writeFileSync(
+    path.join(folder, 'meta', '_journal.json'),
+    JSON.stringify({ version: '7', dialect: 'sqlite', entries: [] })
+  )
+  return folder
+}
+
+/** Lays out `<root>/apps/desktop/src/main/database/drizzle-<kind>` like a checkout. */
+function seedSourceCheckout(root: string, kind: MigrationsKind): string {
+  const parent = path.join(root, 'apps', 'desktop', 'src', 'main', 'database')
+  fs.mkdirSync(parent, { recursive: true })
+  return seedMigrationsFolder(parent, kind)
+}
+
+test('isMigrationsDir accepts a folder only when drizzle journal is present', () => {
+  const root = makeTempRoot('journal')
+  try {
+    const empty = path.join(root, 'drizzle-data')
+    fs.mkdirSync(empty, { recursive: true })
+    assert.equal(isMigrationsDir(empty), false, 'an empty folder is not a migrations folder')
+
+    const seeded = seedMigrationsFolder(root, 'index')
+    assert.equal(isMigrationsDir(seeded), true)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+// Issue #1722: in the packaged Linux build app-core is bundled into
+// app.asar/out/main/index.js and copyMigrations() drops drizzle-data/ and
+// drizzle-index/ right beside it. No ancestor is named "memry" and no source
+// checkout exists on the box, so the old name-matching walk fell through to
+// process.cwd() and handed drizzle a path that was never there.
+test('resolves the folder bundled next to the module (packaged app.asar layout)', () => {
+  const root = makeTempRoot('packaged')
+  try {
+    const outMain = path.join(root, 'app.asar', 'out', 'main')
+    fs.mkdirSync(outMain, { recursive: true })
+    const dataFolder = seedMigrationsFolder(outMain, 'data')
+    const indexFolder = seedMigrationsFolder(outMain, 'index')
+
+    // cwd is wherever the user happened to run the CLI from, and has nothing.
+    const lookup = { moduleDir: outMain, cwd: makeTempRoot('packaged-cwd') }
+
+    assert.equal(resolveMigrationsDir('data', lookup), dataFolder)
+    assert.equal(resolveMigrationsDir('index', lookup), indexFolder)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('resolves a bundle emitted one level down (out/main/chunks/)', () => {
+  const root = makeTempRoot('chunked')
+  try {
+    const outMain = path.join(root, 'out', 'main')
+    const chunks = path.join(outMain, 'chunks')
+    fs.mkdirSync(chunks, { recursive: true })
+    const dataFolder = seedMigrationsFolder(outMain, 'data')
+
+    assert.equal(resolveMigrationsDir('data', { moduleDir: chunks, cwd: root }), dataFolder)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('resolves the checkout folders when running from source', () => {
+  const root = makeTempRoot('checkout')
+  try {
+    const dataFolder = seedSourceCheckout(root, 'data')
+    const moduleDir = path.join(root, 'packages', 'app-core', 'src')
+    fs.mkdirSync(moduleDir, { recursive: true })
+
+    assert.equal(resolveMigrationsDir('data', { moduleDir, cwd: root }), dataFolder)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+// The old walk matched on a directory *name* (endsWith("/memry")), so from a
+// worktree nested under the main checkout it climbed straight past the worktree
+// and ran the outer branch's migrations — silently, with tests still green.
+test('a nested worktree resolves its own migrations, not the outer checkout', () => {
+  const root = makeTempRoot('worktree')
+  try {
+    const outer = path.join(root, 'memry')
+    const worktree = path.join(outer, '.claude', 'worktrees', 'some-branch')
+    fs.mkdirSync(worktree, { recursive: true })
+
+    const outerFolder = seedSourceCheckout(outer, 'data')
+    const worktreeFolder = seedSourceCheckout(worktree, 'data')
+
+    const moduleDir = path.join(worktree, 'packages', 'app-core', 'src')
+    fs.mkdirSync(moduleDir, { recursive: true })
+
+    const resolved = resolveMigrationsDir('data', { moduleDir, cwd: worktree })
+    assert.equal(resolved, worktreeFolder)
+    assert.notEqual(resolved, outerFolder)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+// The old walk only ever matched a directory literally named "memry", so any
+// clone under another name fell through to process.cwd().
+test('a checkout cloned under any folder name still resolves', () => {
+  const root = makeTempRoot('renamed')
+  try {
+    const checkout = path.join(root, 'not-called-memry')
+    const dataFolder = seedSourceCheckout(checkout, 'data')
+    const moduleDir = path.join(checkout, 'packages', 'app-core', 'src')
+    fs.mkdirSync(moduleDir, { recursive: true })
+
+    assert.equal(
+      resolveMigrationsDir('data', { moduleDir, cwd: makeTempRoot('renamed-cwd') }),
+      dataFolder
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('the env override wins over both the bundle and the checkout', () => {
+  const root = makeTempRoot('override')
+  try {
+    const outMain = path.join(root, 'out', 'main')
+    fs.mkdirSync(outMain, { recursive: true })
+    const bundled = seedMigrationsFolder(outMain, 'data')
+
+    const overrideBase = path.join(root, 'override')
+    fs.mkdirSync(overrideBase, { recursive: true })
+    const overridden = seedMigrationsFolder(overrideBase, 'data')
+
+    const resolved = resolveMigrationsDir('data', {
+      moduleDir: outMain,
+      cwd: root,
+      envDir: overrideBase
+    })
+    assert.equal(resolved, overridden)
+    assert.notEqual(resolved, bundled)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('an override pointing at a folder without a journal is skipped, not trusted', () => {
+  const root = makeTempRoot('bad-override')
+  try {
+    const outMain = path.join(root, 'out', 'main')
+    fs.mkdirSync(outMain, { recursive: true })
+    const bundled = seedMigrationsFolder(outMain, 'data')
+
+    const overrideBase = path.join(root, 'empty-override')
+    fs.mkdirSync(path.join(overrideBase, 'drizzle-data'), { recursive: true })
+
+    assert.equal(
+      resolveMigrationsDir('data', { moduleDir: outMain, cwd: root, envDir: overrideBase }),
+      bundled
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('failure names the paths that were tried instead of drizzle’s bare journal error', () => {
+  const root = makeTempRoot('missing')
+  try {
+    const moduleDir = path.join(root, 'out', 'main')
+    fs.mkdirSync(moduleDir, { recursive: true })
+
+    assert.throws(
+      () => resolveMigrationsDir('data', { moduleDir, cwd: root }),
+      (error: Error) => {
+        assert.match(error.message, /Could not find the drizzle-data migrations folder/)
+        assert.match(error.message, new RegExp(migrationsDirEnvVar))
+        assert.ok(
+          error.message.includes(path.join(moduleDir, 'drizzle-data')),
+          'the message lists the concrete candidates that were checked'
+        )
+        assert.doesNotMatch(error.message, /^Can't find meta\/_journal\.json file$/)
+        return true
+      }
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('candidates are ordered, de-duplicated, and never mix the two kinds', () => {
+  const lookup = { moduleDir: '/pkg/out/main', cwd: '/pkg/out/main', envDir: '/opt/migrations' }
+  const candidates = migrationsDirCandidates('index', lookup)
+
+  assert.equal(candidates[0], path.join('/opt/migrations', 'drizzle-index'))
+  assert.equal(candidates[1], path.join('/pkg/out/main', 'drizzle-index'))
+  assert.equal(new Set(candidates).size, candidates.length, 'no duplicate candidates')
+  assert.ok(
+    candidates.every((dir) => dir.endsWith('drizzle-index')),
+    'a data lookup never leaks into an index lookup'
+  )
+})
+
+// End-to-end guard for the reported symptom: opening a vault must not depend on
+// the directory the process was launched from.
+test('openDatabases migrates a fresh vault regardless of process.cwd()', () => {
+  const vaultPath = makeTempRoot('vault')
+  const elsewhere = makeTempRoot('elsewhere')
+  const originalCwd = process.cwd()
+  try {
+    process.chdir(elsewhere)
+    const databases = openDatabases(vaultPath)
+    try {
+      const tables = databases.dataSqlite
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .all() as { name: string }[]
+      assert.ok(
+        tables.some((row) => row.name === 'projects'),
+        'data.db is migrated'
+      )
+      const inbox = databases.dataSqlite
+        .prepare('SELECT id FROM projects WHERE id = ?')
+        .get('inbox')
+      assert.ok(inbox, 'the default task project is seeded')
+    } finally {
+      databases.close()
+    }
+  } finally {
+    process.chdir(originalCwd)
+    fs.rmSync(vaultPath, { recursive: true, force: true })
+    fs.rmSync(elsewhere, { recursive: true, force: true })
+  }
+})

--- a/apps/cli/src/app-core/migrations-path.ts
+++ b/apps/cli/src/app-core/migrations-path.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Which of the two drizzle migration sets to resolve: `data` (notes, tasks,
+ * projects) or `index` (search, graph).
+ */
+export type MigrationsKind = 'data' | 'index'
+
+/** Env override, so a packager or a debug run can point at an explicit folder. */
+export const migrationsDirEnvVar = 'MEMRY_MIGRATIONS_DIR'
+
+/** Where the migrations live inside a source checkout, relative to the repo root. */
+const sourceMigrationsParent = path.join('apps', 'desktop', 'src', 'main', 'database')
+
+export interface MigrationsLookup {
+  /** Directory of the module doing the lookup. */
+  moduleDir: string
+  /** Process working directory, kept as the last-resort search root. */
+  cwd: string
+  /** Raw value of {@link migrationsDirEnvVar}, if set. */
+  envDir?: string
+}
+
+function folderName(kind: MigrationsKind): string {
+  return `drizzle-${kind}`
+}
+
+function ancestors(start: string): string[] {
+  const chain: string[] = []
+  let current = path.resolve(start)
+  for (;;) {
+    chain.push(current)
+    const parent = path.dirname(current)
+    if (parent === current) return chain
+    current = parent
+  }
+}
+
+/**
+ * Every place a migration folder could plausibly be, in the order we trust it.
+ *
+ * Order matters: an explicit override beats the bundle, and the bundle beats a
+ * source checkout, so a packaged binary never wanders into whatever tree the
+ * user happened to launch it from.
+ */
+export function migrationsDirCandidates(kind: MigrationsKind, lookup: MigrationsLookup): string[] {
+  const name = folderName(kind)
+  const candidates: string[] = []
+
+  if (lookup.envDir) candidates.push(path.resolve(lookup.envDir, name))
+
+  // Packaged: app-core is bundled into out/main/index.js and electron.vite's
+  // copyMigrations() plugin drops the folders next to it. The parent is
+  // insurance in case rollup ever emits the bundle into out/main/chunks/.
+  candidates.push(path.join(lookup.moduleDir, name))
+  candidates.push(path.join(path.dirname(lookup.moduleDir), name))
+
+  // Source checkout: the nearest ancestor that actually holds the folders.
+  // Anchored to the module first so a git worktree resolves to itself instead
+  // of the outer main checkout it is nested inside.
+  for (const dir of [...ancestors(lookup.moduleDir), ...ancestors(lookup.cwd)]) {
+    candidates.push(path.join(dir, sourceMigrationsParent, name))
+  }
+
+  return [...new Set(candidates)]
+}
+
+/**
+ * A directory only counts as a migration folder if drizzle's journal is there —
+ * matching on the path alone is what let a packaged build hand drizzle a
+ * directory that does not exist (issue #1722).
+ */
+export function isMigrationsDir(dir: string): boolean {
+  return fs.existsSync(path.join(dir, 'meta', '_journal.json'))
+}
+
+function defaultLookup(): MigrationsLookup {
+  return {
+    moduleDir: fileURLToPath(new URL('.', import.meta.url)),
+    cwd: process.cwd(),
+    envDir: process.env[migrationsDirEnvVar] || undefined
+  }
+}
+
+/**
+ * Resolve the drizzle migration folder for `kind`, or throw naming what was
+ * tried — drizzle's own failure is a bare "Can't find meta/_journal.json file"
+ * with no path in it, which is unactionable from a packaged binary's stderr.
+ */
+export function resolveMigrationsDir(
+  kind: MigrationsKind,
+  lookup: MigrationsLookup = defaultLookup()
+): string {
+  const candidates = migrationsDirCandidates(kind, lookup)
+  const found = candidates.find(isMigrationsDir)
+  if (found) return found
+
+  throw new Error(
+    `Could not find the ${folderName(kind)} migrations folder. Tried:\n` +
+      candidates.map((dir) => `  - ${dir}`).join('\n') +
+      `\nSet ${migrationsDirEnvVar} to the directory containing drizzle-data/ and drizzle-index/ to override.`
+  )
+}

--- a/apps/cli/src/app-core/paths.ts
+++ b/apps/cli/src/app-core/paths.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
 export interface VaultConfig {
   excludePatterns: string[]
@@ -78,13 +77,4 @@ export async function ensureVaultLayout(vaultPath: string): Promise<VaultConfig>
   await writeVaultConfig(vaultPath, config)
 
   return config
-}
-
-export function findWorkspaceRoot(start = fileURLToPath(new URL('.', import.meta.url))): string {
-  let current = start
-  while (current !== path.dirname(current)) {
-    if (current.endsWith(`${path.sep}memry`)) return current
-    current = path.dirname(current)
-  }
-  return process.cwd()
 }

--- a/apps/cli/src/app-core/reminders.test.ts
+++ b/apps/cli/src/app-core/reminders.test.ts
@@ -20,12 +20,9 @@ test('reminder target types: canonical set is exactly the five supported targets
 })
 
 // Builds the reminders table directly instead of going through
-// openDatabases()/runMigrations(): findWorkspaceRoot() walks up from the
-// current file looking for a directory literally named "memry", which in a
-// git worktree checkout (<repo>/.worktrees/<branch>/...) overshoots the
-// worktree and lands on the outer main-checkout repo root — a pre-existing,
-// unrelated environment issue (see bookmarks.test.ts). Building the table
-// in-memory keeps this test independent of that.
+// openDatabases()/runMigrations(): this suite is about reminder hooks, not about
+// migrations, and an in-memory table keeps it independent of where the drizzle
+// folders resolve from (see migrations-path.test.ts for that).
 function createInMemoryDataDb(): DataDb {
   const sqlite = new Database(':memory:')
   sqlite.exec(`

--- a/apps/docs/src/user-guide/cli-reference.md
+++ b/apps/docs/src/user-guide/cli-reference.md
@@ -1765,3 +1765,15 @@ The most common error messages are:
 - `Pass --yes to delete a <thing>` — a destructive command needs the safety flag.
 - `Multiple vaults found. Choose one with memrynote vault use ... or run with --vault <path>.`
 - `No default vault configured. Open memrynote and choose Settings > Command Line > Default vault, or run with --vault <path>.`
+
+---
+
+## Environment variables
+
+| Variable               | Meaning                                                                                                                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MEMRY_MIGRATIONS_DIR` | Directory holding `drizzle-data/` and `drizzle-index/`. An escape hatch — the CLI finds them on its own, both from a packaged install and from a source checkout. Set it only if it ever reports that it could not. |
+
+If a command fails with `Could not find the drizzle-data migrations folder`, the
+error lists every path that was checked; point `MEMRY_MIGRATIONS_DIR` at the
+right one and please open an issue, since finding them should not need help.


### PR DESCRIPTION
Fixes #1722.

## The bug

Every vault-opening command from the packaged headless CLI died with drizzle's `Can't find meta/_journal.json file` — `vault init`, `notes list`, `tasks list`, search, all of it. Nothing was missing from the package; only the lookup was wrong.

`openDatabases()` built its migration paths from `findWorkspaceRoot()`, which walked up from the module looking for a directory *named* `memry` and otherwise fell back to `process.cwd()`, then joined `apps/desktop/src/main/database/drizzle-*`. In the bundle that becomes:

```js
// out/main/index.js — the file that ships as app.asar/out/main/index.js
const workspaceRoot = findWorkspaceRoot();
runMigrations(dataDbPath, path.join(workspaceRoot, "apps/desktop/src/main/database/drizzle-data"));
```

On a Linux install `__filename` is `/opt/MemryNote/resources/app.asar/out/main/index.js`. No ancestor is named `memry`, so the walk fell through to whatever directory the user happened to be standing in, and then appended a source-tree path that exists nowhere on the machine.

The desktop app never hit this because `apps/desktop/src/main/database/migrate.ts` resolves `__dirname/drizzle-data`, which is correct inside the asar. `openDatabases()` is only reached through `createMemryApp()`, whose only caller is the CLI — so the blast radius was exactly the headless binary.

## The fix

`resolveMigrationsDir(kind)` replaces the name-matching walk with an ordered candidate list where **every candidate is validated by the presence of `meta/_journal.json`** before it is used:

1. `MEMRY_MIGRATIONS_DIR` — an explicit escape hatch for packagers and for debugging a bad build;
2. `<dir of the calling module>/drizzle-<kind>` — where `copyMigrations()` already ships them (`out/main/`), plus its parent in case rollup ever emits the bundle into `out/main/chunks/`;
3. the nearest ancestor holding `apps/desktop/src/main/database/drizzle-<kind>` — the source-checkout case, anchored to the module;
4. the same walk from `process.cwd()`, preserving today's last-resort behaviour.

If nothing validates, it throws with every path it tried, instead of letting drizzle surface a message with no path in it.

## Two silent bugs that came with it

Matching on a directory *name* rather than on its contents was also misresolving in ways that never raised an error:

- **A git worktree nested under the main checkout resolved to the outer repo.** From `<repo>/memry/.worktrees/<branch>/…`, the first ancestor ending in `memry` is the outer main checkout — so a branch adding a migration ran *main's* migration set and still reported green. This was known and worked around in-tree: `bookmarks.test.ts` and `reminders.test.ts` both hand-build their tables with a comment explaining they were dodging it. Those comments are now obsolete and updated.
- **A clone under any other folder name never matched at all**, silently degrading to `process.cwd()`, so the CLI's behaviour depended on where you `cd`'d from before running it.

Both are covered by regression tests.

## Verification

Tests are real directory trees, not a stubbed `exists` predicate — the bug was that a path was trusted without anyone checking whether it existed, so a test that mocks existence away cannot catch a regression of it.

`apps/cli/src/app-core/migrations-path.test.ts` — 11 tests covering: packaged `out/main` layout; a bundle one level deeper; source checkout; nested worktree resolving to itself; a clone under a different folder name; env override winning; an override *without* a journal being skipped rather than trusted; the error naming its candidates; candidate ordering/de-duplication; and an end-to-end `openDatabases()` on a fresh vault run from an unrelated `process.cwd()`.

Both halves of the fix were mutation-checked. Removing the bundle-relative candidates fails 5 tests; restoring the old name-matching walk fails the worktree and renamed-clone tests.

Beyond unit tests, the packaged path was exercised with the real Electron binary: `out/` was copied to a directory outside the repo — no ancestor named `memry`, no source tree anywhere above it, i.e. the Linux install's exact shape — and driven through `--cli`. `vault init` wrote `config.json`, `data.db` and `index.db`; `notes list` and `tasks list` returned clean. Hiding the bundled folder there produces the new error listing all eight candidates instead of drizzle's bare one.

Gates: `pnpm typecheck`, `pnpm lint`, `pnpm test:desktop`, `pnpm --filter @memry/cli test`, `pnpm --filter @memry/app-core test`, `pnpm check:architecture`, `pnpm check:contracts`, `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build`.

## Compatibility

No schema change, no migration SQL change, no on-disk format change, no IPC contract change. The desktop app keeps its existing `__dirname` resolution and is untouched. Existing installs migrate exactly as before — the only difference is which directory the migration files are read from in the CLI.

## Follow-up (deliberately not in this PR)

The deeper smell is that shared code reaches into another workspace app's source tree by hardcoded runtime path. The migration folders should be owned by a package both consumers already depend on (`@memry/db-schema`), so desktop and CLI resolve one location. That means moving the folders and retargeting `config/drizzle-*.config.ts`, `copyMigrations()` and ~30 test/script references — worth its own issue, not worth the risk inside a production fix.
