### PR TITLE
fix(mobile): shim lib0's isomorphic-webcrypto require so the yjs bundle resolves

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -26,4 +26,19 @@ config.resolver.nodeModulesPaths = [
 // Raw-TS workspace exports depend on package-exports resolution (R3).
 config.resolver.unstable_enablePackageExports = true
 
+// yjs → lib0 resolves `lib0/webcrypto` to its react-native build, which
+// requires the unmaintained `isomorphic-webcrypto` (native deps, prebuild
+// churn). The surface lib0 uses is three members, served by the app's
+// libsodium-backed crypto polyfill instead (src/lib/isomorphic-webcrypto-shim.js).
+const defaultResolveRequest = config.resolver.resolveRequest
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === 'isomorphic-webcrypto/src/react-native') {
+    return {
+      type: 'sourceFile',
+      filePath: path.resolve(projectRoot, 'src/lib/isomorphic-webcrypto-shim.js')
+    }
+  }
+  return (defaultResolveRequest ?? context.resolveRequest)(context, moduleName, platform)
+}
+
 module.exports = config

--- a/apps/mobile/src/lib/isomorphic-webcrypto-shim.js
+++ b/apps/mobile/src/lib/isomorphic-webcrypto-shim.js
@@ -1,0 +1,20 @@
+// Shim for `isomorphic-webcrypto/src/react-native`, which lib0 (a yjs dep)
+// requires under Metro's react-native export condition. That package is
+// unmaintained and drags in its own native modules; everything lib0 actually
+// touches (`default.ensureSecure()`, `default.subtle`,
+// `default.getRandomValues`) is served here from the app's libsodium-backed
+// crypto polyfill (src/lib/crypto-polyfill.ts, the root layout's first
+// import). Wired up via `resolveRequest` in metro.config.js.
+//
+// Properties read lazily so this module never races the polyfill's install.
+module.exports = {
+  ensureSecure() {},
+  get subtle() {
+    // Hermes has no SubtleCrypto; yjs never touches it. Anything that does
+    // should fail loudly rather than get a broken stub.
+    return globalThis.crypto ? globalThis.crypto.subtle : undefined
+  },
+  getRandomValues(array) {
+    return globalThis.crypto.getRandomValues(array)
+  }
+}


### PR DESCRIPTION
The US1 device build failed at Metro: yjs → lib0 resolves `lib0/webcrypto` to its react-native build, which requires `isomorphic-webcrypto/src/react-native` — an unmaintained package with its own native deps we don't want in the prebuild. lib0 only touches `default.ensureSecure()`, `default.subtle` and `default.getRandomValues`, so a Metro `resolveRequest` redirect serves those from the app's libsodium-backed crypto polyfill (lazy property reads, so it never races the polyfill install).

Evidence: `expo export --platform ios` bundles clean (Hermes bytecode emitted); mobile lint green.