### PR TITLE
file/image blocks: rename an attachment from the block menu

### DIFF
--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -198,6 +198,7 @@ export interface MainIpcInvokeHandlers {
   "notes:add-status-option": (...args: [{ propertyName: string; categoryKey: "todo" | "in_progress" | "done"; option: { value: string; color: string; }; }]) => Awaited<Promise<{ success: boolean; }>>
   "notes:apply-template": (...args: [{ noteId: string; templateId: string; mode: "full" | "body"; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
   "notes:attachment-open-external": (...args: [{ noteId: string; url: string; }]) => Awaited<Promise<void>>
+  "notes:attachment-rename": (...args: [{ noteId: string; url: string; newName: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/notes-api").AttachmentRenameResult>>
   "notes:attachment-resolve": (...args: [{ noteId: string; url: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/notes-api").AttachmentResolveResult>>
   "notes:attachment-reveal-in-finder": (...args: [{ noteId: string; url: string; }]) => Awaited<Promise<void>>
   "notes:create": (...args: [{ title: string; content?: string | undefined; folder?: string | undefined; tags?: string[] | undefined; template?: string | undefined; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>

--- a/apps/desktop/src/main/ipc/notes-handlers.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.ts
@@ -21,13 +21,15 @@ import {
   ApplyTemplateSchema,
   LargeFileReadLinesSchema,
   LargeFileSearchSchema,
-  AttachmentActionSchema
+  AttachmentActionSchema,
+  AttachmentRenameSchema
 } from '@memry/contracts/notes-api'
 import {
   resolveAttachment,
   revealAttachmentInFinder,
   openAttachmentExternal
 } from '../vault/attachment-actions'
+import { renameAttachment } from '../vault/attachment-rename'
 import {
   openLargeFileSession,
   readLargeFileLines,
@@ -510,6 +512,15 @@ export function registerNotesHandlers(): void {
     createValidatedHandler(AttachmentActionSchema, async (input) => {
       await openAttachmentExternal(input.noteId, input.url)
     })
+  )
+
+  // notes:attachment-rename - Rename an attachment on disk (#1714). The block's
+  // url/name are rewritten by the caller; the body change is what reaches peers.
+  ipcMain.handle(
+    NotesChannels.invoke.ATTACHMENT_RENAME,
+    createValidatedHandler(AttachmentRenameSchema, (input) =>
+      renameAttachment(input.noteId, input.url, input.newName)
+    )
   )
 
   // =========================================================================

--- a/apps/desktop/src/main/ipc/sync-attachment-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/sync-attachment-handlers.test.ts
@@ -118,6 +118,11 @@ vi.mock('../sync/crdt-writeback', () => ({
   markWritebackIgnored: vi.fn()
 }))
 
+const mockApplyDownloadedAttachmentName = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+vi.mock('../vault/attachment-rename', () => ({
+  applyDownloadedAttachmentName: (...args: unknown[]) => mockApplyDownloadedAttachmentName(...args)
+}))
+
 vi.mock('../vault/index', () => ({
   getStatus: vi.fn().mockReturnValue({ path: null })
 }))
@@ -687,6 +692,56 @@ describe('sync-attachment-handlers', () => {
     )
     expect(markWritebackIgnored).toHaveBeenCalledWith('/vault/attachments/file.pdf')
     await vi.waitFor(() => expect(recordDownloadedFileSize).toHaveBeenCalledWith('note-1', 1234))
+  })
+
+  it('renames a downloaded embedded attachment to the name the note body carries', async () => {
+    // #given a device materializing a file whose in-app rename (#1714) already
+    // synced: the manifest still names it as it was at upload
+    vi.mocked(getValidAccessToken).mockResolvedValue('token-1')
+    vi.mocked(isDatabaseInitialized).mockReturnValue(true)
+    mockApplyDownloadedAttachmentName.mockClear()
+    registerAttachmentHandlers()
+
+    const onDownloadNeeded = mockOnDownloadNeeded.mock.calls[0][0] as (event: {
+      noteId: string
+      attachmentId: string
+      diskPath: string
+      intoDir?: boolean
+    }) => void
+    onDownloadNeeded({
+      noteId: 'note-1',
+      attachmentId: 'attachment-1',
+      diskPath: '/vault/attachments/note-1',
+      intoDir: true
+    })
+
+    // #then the file on THIS device ends up under the body's current name
+    await vi.waitFor(() =>
+      expect(mockApplyDownloadedAttachmentName).toHaveBeenCalledWith('note-1', '/tmp/file.pdf')
+    )
+  })
+
+  it('leaves a binary note download out of the attachment rename reconcile', async () => {
+    vi.mocked(getValidAccessToken).mockResolvedValue('token-1')
+    vi.mocked(isDatabaseInitialized).mockReturnValue(true)
+    mockApplyDownloadedAttachmentName.mockClear()
+    registerAttachmentHandlers()
+
+    const onDownloadNeeded = mockOnDownloadNeeded.mock.calls[0][0] as (event: {
+      noteId: string
+      attachmentId: string
+      diskPath: string
+    }) => void
+    onDownloadNeeded({
+      noteId: 'note-1',
+      attachmentId: 'attachment-1',
+      diskPath: '/vault/attachments/file.pdf'
+    })
+
+    // A binary note IS the file — its name comes from the note, not from a
+    // block ref, so the attachments-folder reconcile has no business here.
+    await vi.waitFor(() => expect(recordDownloadedFileSize).toHaveBeenCalled())
+    expect(mockApplyDownloadedAttachmentName).not.toHaveBeenCalled()
   })
 
   it('broadcasts failures from async attachment event callbacks', async () => {

--- a/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
+++ b/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
@@ -43,6 +43,7 @@ import {
   registerOutboxUploader
 } from '../sync/attachment-outbox'
 import { markWritebackIgnored } from '../sync/crdt-writeback'
+import { applyDownloadedAttachmentName } from '../vault/attachment-rename'
 import { getStatus as getVaultStatus } from '../vault/index'
 
 import {
@@ -457,6 +458,13 @@ export function registerAttachmentHandlers(): void {
           ? await service.downloadAttachment(attachmentId, diskPath, { targetIsDir: true })
           : await service.downloadAttachment(attachmentId, diskPath)
         markDownloadSucceeded(isDatabaseInitialized() ? getDatabase() : null, noteId, attachmentId)
+        // The manifest froze this file's name at upload, so a device that
+        // materializes it after an in-app rename (#1714) gets the OLD name.
+        // The note body is the authority — rename to what it asks for before
+        // anything is told the file exists.
+        if (intoDir && isDatabaseInitialized()) {
+          await applyDownloadedAttachmentName(noteId, result.filePath)
+        }
         // The bytes are on disk now, but a note that is already open resolved
         // its attachment URLs when its blocks were built and never asks again.
         // Without this the file is invisible until the app is restarted —

--- a/apps/desktop/src/main/sync/crdt-writeback.test.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.test.ts
@@ -32,6 +32,8 @@ const mocks = vi.hoisted(() => ({
   closeDoc: vi.fn(),
   getDoc: vi.fn(),
   syncNoteDateReminders: vi.fn(),
+  getVaultRoot: vi.fn(),
+  reconcileRenamedAttachments: vi.fn(),
   clearNoteDateReminders: vi.fn(),
   createRemindersService: vi.fn(),
   sent: [] as Array<{ channel: string; payload: unknown }>,
@@ -95,7 +97,12 @@ vi.mock('../vault/frontmatter', () => ({
   generateContentHash: (...args: unknown[]) => mocks.generateContentHash(...args)
 }))
 
+vi.mock('../vault/attachment-rename-reconcile', () => ({
+  reconcileRenamedAttachments: (...args: unknown[]) => mocks.reconcileRenamedAttachments(...args)
+}))
+
 vi.mock('../vault/notes', () => ({
+  getVaultRoot: (...args: unknown[]) => mocks.getVaultRoot(...args),
   getDefaultNoteDir: (...args: unknown[]) => mocks.getDefaultNoteDir(...args),
   toRelativePath: (...args: unknown[]) => mocks.toRelativePath(...args),
   toAbsolutePath: (...args: unknown[]) => mocks.toAbsolutePath(...args),
@@ -213,6 +220,8 @@ describe('crdt writeback', () => {
     // captured — the behaviour every case below except the reopen ones wants.
     mocks.getDoc.mockReturnValue(undefined)
     mocks.maybeCreateSignificantSnapshot.mockReturnValue({ id: 'snap-1' })
+    mocks.getVaultRoot.mockReturnValue('/vault')
+    mocks.reconcileRenamedAttachments.mockReset().mockReturnValue([])
   })
 
   afterEach(() => {
@@ -828,6 +837,47 @@ describe('crdt writeback', () => {
       expect(vaultFile).toBe('paragraph one\n\nparagraph two from another device')
       expect(mocks.atomicWrite).not.toHaveBeenCalled()
     })
+  })
+
+  // ==========================================================================
+  // An attachment rename arriving in the body (#1714)
+  // ==========================================================================
+
+  it('hands the old and new body to the attachment rename reconcile', async () => {
+    // #given a body whose attachment ref changed — the shape a rename made on
+    // another device arrives in, since the blob itself is never re-uploaded
+    mocks.safeRead.mockResolvedValue(
+      '---\ntitle: Existing\n---\n<!-- file:{"url":"../attachments/note-1/k3f9x2-scan.pdf"} -->'
+    )
+    mocks.yDocToMarkdown.mockResolvedValue(
+      '<!-- file:{"url":"../attachments/note-1/k3f9x2-invoice.pdf"} -->'
+    )
+
+    // #when
+    scheduleWriteback('note-1', makeDoc('Existing'))
+    await vi.advanceTimersByTimeAsync(500)
+
+    // #then this device's own copy of the file gets renamed from the body diff
+    expect(mocks.reconcileRenamedAttachments).toHaveBeenCalledWith(
+      'note-1',
+      expect.stringContaining('k3f9x2-scan.pdf'),
+      expect.stringContaining('k3f9x2-invoice.pdf'),
+      '/vault'
+    )
+  })
+
+  it('keeps the write-back successful when the reconcile throws', async () => {
+    mocks.reconcileRenamedAttachments.mockImplementation(() => {
+      throw new Error('attachments folder is read-only')
+    })
+
+    scheduleWriteback('note-1', makeDoc('Existing'))
+    await vi.advanceTimersByTimeAsync(500)
+
+    // The note's bytes are already on disk when the reconcile runs; a folder
+    // that cannot be touched must not make a successful write-back look failed.
+    expect(mocks.atomicWrite).toHaveBeenCalled()
+    expect(mocks.sent.some((s) => s.channel === 'sync:write-back-failed')).toBe(false)
   })
 
   // ==========================================================================

--- a/apps/desktop/src/main/sync/crdt-writeback.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.ts
@@ -25,12 +25,14 @@ import {
 } from '../vault/frontmatter'
 import {
   getDefaultNoteDir,
+  getVaultRoot,
   toRelativePath,
   toAbsolutePath,
   maybeCreateSignificantSnapshot
 } from '../vault/notes'
 import { getJournalPath } from '../vault/journal'
 import { syncNoteToCache, deleteNoteFromCache } from '../vault/note-sync'
+import { reconcileRenamedAttachments } from '../vault/attachment-rename-reconcile'
 import { flushProjectionEvents } from '../projections'
 import { getIndexDatabase, getDatabase } from '../database/client'
 import { getNoteCacheById, getNoteCacheByPath } from '@main/database/queries/notes'
@@ -486,6 +488,25 @@ async function performWriteback(noteId: string, doc: Y.Doc): Promise<void> {
   }
 }
 
+/**
+ * Apply, on this device, the attachment rename a body change carries.
+ *
+ * Isolated from the write-back's own failure path on purpose: the file is
+ * already written when this runs, so a vault lookup or an unreadable
+ * attachments folder must not make a successful write-back look failed.
+ */
+function applyAttachmentRenames(
+  noteId: string,
+  previousContent: string | null,
+  nextContent: string
+): void {
+  try {
+    reconcileRenamedAttachments(noteId, previousContent, nextContent, getVaultRoot())
+  } catch (err) {
+    log.warn('Attachment rename reconcile failed during write-back', { noteId, err })
+  }
+}
+
 async function writebackExisting(
   noteId: string,
   cached: NonNullable<ReturnType<typeof getNoteCacheById>>,
@@ -559,6 +580,13 @@ async function writebackExisting(
 
   rememberIgnoredWrite(absolutePath)
   await atomicWrite(absolutePath, fileContent)
+
+  // An attachment rename that arrived in this body (#1714): the file is still
+  // on this device under its old name — the blob is never re-uploaded, so the
+  // encrypted manifest keeps the name it had at upload. Renaming here is what
+  // makes the rename real on every device rather than only on the one that
+  // performed it. Never throws; the note's own bytes are already written.
+  applyAttachmentRenames(noteId, existingRaw, fileContent)
 
   syncNoteToCache(
     indexDb,
@@ -700,6 +728,9 @@ async function writebackJournal(
 
     rememberIgnoredWrite(absolutePath)
     await atomicWrite(absolutePath, fileContent)
+
+    // Journals hold file/image blocks like any other note — see the note path.
+    applyAttachmentRenames(noteId, existingRaw, fileContent)
 
     syncNoteToCache(
       indexDb,

--- a/apps/desktop/src/main/vault/attachment-rename-reconcile.test.ts
+++ b/apps/desktop/src/main/vault/attachment-rename-reconcile.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for attachment-rename-reconcile.ts (#1714) — the half that makes a
+ * rename real on the OTHER devices. The blob is never re-uploaded, so a peer's
+ * only evidence is the body change; these cover what that evidence licenses and,
+ * just as importantly, what it does not (an external rename is left alone).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+import {
+  extractAttachmentFilenames,
+  planAttachmentRenames,
+  reconcileDownloadedAttachmentName,
+  reconcileRenamedAttachments
+} from './attachment-rename-reconcile'
+
+const NOTE_ID = 'n1'
+
+let vaultPath = ''
+
+function attachmentsDir(): string {
+  return path.join(vaultPath, 'attachments', NOTE_ID)
+}
+
+function writeAttachment(filename: string): string {
+  const dir = attachmentsDir()
+  fs.mkdirSync(dir, { recursive: true })
+  const absolute = path.join(dir, filename)
+  fs.writeFileSync(absolute, 'bytes')
+  return absolute
+}
+
+function body(...filenames: string[]): string {
+  return filenames
+    .map(
+      (f) =>
+        `<!-- file:{"url":"../attachments/${NOTE_ID}/${f}","name":"x","size":1,"mimeType":"application/pdf"} -->`
+    )
+    .join('\n\n')
+}
+
+beforeEach(() => {
+  vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'attachment-reconcile-'))
+})
+
+afterEach(() => {
+  fs.rmSync(vaultPath, { recursive: true, force: true })
+})
+
+describe('extractAttachmentFilenames', () => {
+  it('finds refs in file markers, image links and legacy absolute urls', () => {
+    const markdown = [
+      body('k3f9x2-report.pdf'),
+      `![pic](../attachments/${NOTE_ID}/aaaaaa-photo.png)`,
+      `![old](memry-file://local/Users/someone/Vault/attachments/${NOTE_ID}/bbbbbb-legacy.png)`
+    ].join('\n\n')
+
+    expect(extractAttachmentFilenames(NOTE_ID, markdown)).toEqual(
+      new Set(['k3f9x2-report.pdf', 'aaaaaa-photo.png', 'bbbbbb-legacy.png'])
+    )
+  })
+
+  it('decodes percent-encoded refs', () => {
+    expect(
+      extractAttachmentFilenames(NOTE_ID, `![p](../attachments/${NOTE_ID}/aaaaaa-my%20file.png)`)
+    ).toEqual(new Set(['aaaaaa-my file.png']))
+  })
+
+  it('ignores another note’s attachments', () => {
+    expect(
+      extractAttachmentFilenames(NOTE_ID, `![p](../attachments/other/aaaaaa-photo.png)`)
+    ).toEqual(new Set())
+  })
+})
+
+describe('planAttachmentRenames', () => {
+  it('pairs a ref that left with the one that arrived under the same prefix', () => {
+    expect(
+      planAttachmentRenames(new Set(['k3f9x2-scan.pdf']), new Set(['k3f9x2-invoice.pdf']))
+    ).toEqual([{ from: 'k3f9x2-scan.pdf', to: 'k3f9x2-invoice.pdf' }])
+  })
+
+  it('pairs two renames in the same body change independently', () => {
+    expect(
+      planAttachmentRenames(
+        new Set(['aaaaaa-one.pdf', 'bbbbbb-two.pdf']),
+        new Set(['aaaaaa-first.pdf', 'bbbbbb-second.pdf'])
+      )
+    ).toEqual([
+      { from: 'aaaaaa-one.pdf', to: 'aaaaaa-first.pdf' },
+      { from: 'bbbbbb-two.pdf', to: 'bbbbbb-second.pdf' }
+    ])
+  })
+
+  it('is silent for a deleted block and for a newly added one', () => {
+    expect(planAttachmentRenames(new Set(['k3f9x2-scan.pdf']), new Set())).toEqual([])
+    expect(planAttachmentRenames(new Set(), new Set(['k3f9x2-scan.pdf']))).toEqual([])
+  })
+
+  it('refuses to guess when the same prefix has two candidates', () => {
+    expect(
+      planAttachmentRenames(new Set(['k3f9x2-scan.pdf']), new Set(['k3f9x2-a.pdf', 'k3f9x2-b.pdf']))
+    ).toEqual([])
+  })
+
+  it('ignores prefix-less filenames, which carry no identity to pair on', () => {
+    expect(planAttachmentRenames(new Set(['scan.pdf']), new Set(['invoice.pdf']))).toEqual([])
+  })
+})
+
+describe('reconcileRenamedAttachments', () => {
+  it('renames this device’s file to the name the synced body asks for', () => {
+    writeAttachment('k3f9x2-scan.pdf')
+
+    const applied = reconcileRenamedAttachments(
+      NOTE_ID,
+      body('k3f9x2-scan.pdf'),
+      body('k3f9x2-invoice.pdf'),
+      vaultPath
+    )
+
+    expect(applied).toEqual([{ from: 'k3f9x2-scan.pdf', to: 'k3f9x2-invoice.pdf' }])
+    expect(fs.existsSync(path.join(attachmentsDir(), 'k3f9x2-invoice.pdf'))).toBe(true)
+    expect(fs.existsSync(path.join(attachmentsDir(), 'k3f9x2-scan.pdf'))).toBe(false)
+  })
+
+  it('is a no-op on the device that already renamed the file', () => {
+    writeAttachment('k3f9x2-invoice.pdf')
+
+    expect(
+      reconcileRenamedAttachments(
+        NOTE_ID,
+        body('k3f9x2-scan.pdf'),
+        body('k3f9x2-invoice.pdf'),
+        vaultPath
+      )
+    ).toEqual([])
+    expect(fs.existsSync(path.join(attachmentsDir(), 'k3f9x2-invoice.pdf'))).toBe(true)
+  })
+
+  it('never overwrites a file already holding the target name', () => {
+    writeAttachment('k3f9x2-scan.pdf')
+    fs.writeFileSync(path.join(attachmentsDir(), 'k3f9x2-invoice.pdf'), 'other-bytes')
+
+    expect(
+      reconcileRenamedAttachments(
+        NOTE_ID,
+        body('k3f9x2-scan.pdf'),
+        body('k3f9x2-invoice.pdf'),
+        vaultPath
+      )
+    ).toEqual([])
+    expect(fs.readFileSync(path.join(attachmentsDir(), 'k3f9x2-invoice.pdf'), 'utf8')).toBe(
+      'other-bytes'
+    )
+  })
+
+  it('leaves a file renamed outside the app alone — the body did not change', () => {
+    // #1713's case: this device's disk moved, the note did not. Self-heal serves
+    // it; renaming it back here would undo what the user did in Finder.
+    writeAttachment('k3f9x2-renamed-by-hand.pdf')
+    const unchanged = body('k3f9x2-scan.pdf')
+
+    expect(reconcileRenamedAttachments(NOTE_ID, unchanged, unchanged, vaultPath)).toEqual([])
+    expect(fs.existsSync(path.join(attachmentsDir(), 'k3f9x2-renamed-by-hand.pdf'))).toBe(true)
+  })
+
+  it('does nothing without a previous body (a note written for the first time)', () => {
+    writeAttachment('k3f9x2-scan.pdf')
+    expect(
+      reconcileRenamedAttachments(NOTE_ID, null, body('k3f9x2-invoice.pdf'), vaultPath)
+    ).toEqual([])
+  })
+})
+
+describe('reconcileDownloadedAttachmentName', () => {
+  it('renames a freshly downloaded file to the name the body carries', () => {
+    // The manifest froze the name at upload, so sync lands the OLD one here.
+    const downloaded = writeAttachment('k3f9x2-scan.pdf')
+
+    const result = reconcileDownloadedAttachmentName(
+      NOTE_ID,
+      downloaded,
+      body('k3f9x2-invoice.pdf'),
+      vaultPath
+    )
+
+    expect(result).toBe(path.join(attachmentsDir(), 'k3f9x2-invoice.pdf'))
+    expect(fs.existsSync(path.join(attachmentsDir(), 'k3f9x2-invoice.pdf'))).toBe(true)
+    expect(fs.existsSync(downloaded)).toBe(false)
+  })
+
+  it('leaves a download the body already names alone', () => {
+    const downloaded = writeAttachment('k3f9x2-invoice.pdf')
+
+    expect(
+      reconcileDownloadedAttachmentName(NOTE_ID, downloaded, body('k3f9x2-invoice.pdf'), vaultPath)
+    ).toBe(downloaded)
+  })
+
+  it('leaves a download the body has no unique match for alone', () => {
+    const downloaded = writeAttachment('k3f9x2-scan.pdf')
+
+    expect(
+      reconcileDownloadedAttachmentName(
+        NOTE_ID,
+        downloaded,
+        body('k3f9x2-a.pdf', 'k3f9x2-b.pdf'),
+        vaultPath
+      )
+    ).toBe(downloaded)
+    expect(fs.existsSync(downloaded)).toBe(true)
+  })
+
+  it('refuses a path outside this note’s attachments folder', () => {
+    const outside = path.join(vaultPath, 'attachments', 'other', 'k3f9x2-scan.pdf')
+    fs.mkdirSync(path.dirname(outside), { recursive: true })
+    fs.writeFileSync(outside, 'bytes')
+
+    expect(
+      reconcileDownloadedAttachmentName(NOTE_ID, outside, body('k3f9x2-invoice.pdf'), vaultPath)
+    ).toBeNull()
+    expect(fs.existsSync(outside)).toBe(true)
+  })
+})

--- a/apps/desktop/src/main/vault/attachment-rename-reconcile.ts
+++ b/apps/desktop/src/main/vault/attachment-rename-reconcile.ts
@@ -1,0 +1,181 @@
+/**
+ * Making an attachment rename land on every device's disk (#1714).
+ *
+ * A rename travels as a note body change: the block's `url` names a different
+ * file in the same `attachments/<noteId>/` folder, with the nanoid prefix
+ * unchanged. Nothing is re-uploaded, so a peer receiving that body still holds
+ * the file under the OLD name — self-heal keeps the embed working, but the file
+ * on that device keeps a name the user renamed away from, forever.
+ *
+ * Two narrow, evidence-backed points converge it:
+ *
+ *  - `planAttachmentRenames` diffs the refs of the body a write-back is about
+ *    to replace against the refs it is writing. A ref that disappeared and a
+ *    ref that appeared sharing its nanoid prefix IS the rename that just
+ *    arrived — nothing else produces that pair.
+ *  - `reconcileDownloadedAttachmentName` runs when sync materializes a file:
+ *    the manifest froze the filename at upload, so a file downloaded after the
+ *    rename lands under the old name and is renamed to what the body asks for.
+ *
+ * Deliberately NOT a general "make the folder match the body" pass. A file the
+ * user renamed by hand outside the app (#1713) has no matching body change and
+ * is never touched here — it keeps the name the user gave it and keeps being
+ * served through self-heal.
+ */
+
+import { renameSync, existsSync } from 'fs'
+import path from 'path'
+import { createLogger } from '../lib/logger'
+import { getNoteAttachmentsDir } from './attachments'
+
+const logger = createLogger('AttachmentRenameReconcile')
+
+/** The `{6-char nanoid}-` prefix `generateUniqueFilename` puts on every file. */
+const STORED_PREFIX_RE = /^[0-9a-z]{6}-/
+
+export interface PlannedRename {
+  from: string
+  to: string
+}
+
+/**
+ * Every stored filename a note body references for its own attachments folder.
+ *
+ * Covers all three ref shapes at once — note-relative (`../attachments/<id>/f`),
+ * the `<!-- file:{"url":…} -->` marker's escaped JSON, and legacy absolute
+ * `memry-file://local/…/attachments/<id>/f` — because all three contain the
+ * same `attachments/<noteId>/<filename>` tail.
+ */
+export function extractAttachmentFilenames(noteId: string, markdown: string): Set<string> {
+  const out = new Set<string>()
+  if (!markdown) return out
+
+  // Escape the id: note ids are generated, but this string reaches a regex.
+  const escapedId = noteId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`attachments[/\\\\]${escapedId}[/\\\\]([^)\\s"'<>\\\\]+)`, 'g')
+
+  for (const match of markdown.matchAll(re)) {
+    const raw = match[1]
+    let decoded = raw
+    try {
+      decoded = decodeURIComponent(raw)
+    } catch {
+      // A stray `%` is not an encoding — keep the literal name.
+    }
+    if (decoded) out.add(decoded)
+  }
+  return out
+}
+
+/**
+ * The renames implied by one body replacing another: a ref that left and
+ * exactly one ref that arrived carrying the same nanoid prefix.
+ *
+ * "Exactly one" on both sides is the whole safety story. Two files renamed in
+ * the same write-back still pair up (their prefixes differ); an ambiguous
+ * prefix — two candidates either way — is left alone rather than guessed at.
+ */
+export function planAttachmentRenames(previous: Set<string>, next: Set<string>): PlannedRename[] {
+  const gone = [...previous].filter((name) => !next.has(name) && STORED_PREFIX_RE.test(name))
+  const arrived = [...next].filter((name) => !previous.has(name) && STORED_PREFIX_RE.test(name))
+  if (gone.length === 0 || arrived.length === 0) return []
+
+  const plans: PlannedRename[] = []
+  for (const from of gone) {
+    const prefix = from.slice(0, 7)
+    const candidates = arrived.filter((name) => name.startsWith(prefix))
+    const sources = gone.filter((name) => name.startsWith(prefix))
+    if (candidates.length === 1 && sources.length === 1) {
+      plans.push({ from, to: candidates[0] })
+    }
+  }
+  return plans
+}
+
+/**
+ * Apply the renames a body change implies to this device's attachments folder.
+ *
+ * Never throws: the note's bytes are already written by the time this runs, and
+ * a folder that cannot be touched must not turn a successful write-back into a
+ * failure. Skips anything already in the target state, so it is idempotent and
+ * a no-op on the device that performed the rename in the first place.
+ */
+export function reconcileRenamedAttachments(
+  noteId: string,
+  previousMarkdown: string | null,
+  nextMarkdown: string,
+  vaultPath: string
+): PlannedRename[] {
+  if (!previousMarkdown || !vaultPath) return []
+
+  const plans = planAttachmentRenames(
+    extractAttachmentFilenames(noteId, previousMarkdown),
+    extractAttachmentFilenames(noteId, nextMarkdown)
+  )
+  if (plans.length === 0) return []
+
+  const dir = getNoteAttachmentsDir(vaultPath, noteId)
+  const applied: PlannedRename[] = []
+  for (const plan of plans) {
+    const from = path.join(dir, plan.from)
+    const to = path.join(dir, plan.to)
+    // Source gone: this device renamed it (or never had it). Target taken:
+    // something already holds the name — overwriting it would destroy a file.
+    if (!existsSync(from) || existsSync(to)) continue
+    try {
+      renameSync(from, to)
+      applied.push(plan)
+    } catch (error) {
+      logger.warn('Failed to apply a synced attachment rename', { noteId, error })
+    }
+  }
+  if (applied.length > 0) {
+    logger.info('Applied synced attachment renames', { noteId, count: applied.length })
+  }
+  return applied
+}
+
+/**
+ * Rename a just-downloaded attachment to the name the note body asks for.
+ *
+ * The encrypted manifest froze the filename at upload, so a device that
+ * materializes the file after a rename gets the old name. The body is the
+ * authority here — and the file was created by sync a moment ago, so there is
+ * no user-chosen name to overwrite.
+ *
+ * Returns the file's final path (renamed or not), or null when the input is not
+ * a file in this note's attachments folder.
+ */
+export function reconcileDownloadedAttachmentName(
+  noteId: string,
+  downloadedPath: string,
+  noteMarkdown: string | null,
+  vaultPath: string
+): string | null {
+  if (!noteMarkdown || !vaultPath) return null
+
+  const dir = getNoteAttachmentsDir(vaultPath, noteId)
+  if (path.resolve(path.dirname(downloadedPath)) !== path.resolve(dir)) return null
+
+  const downloaded = path.basename(downloadedPath)
+  if (!STORED_PREFIX_RE.test(downloaded)) return downloadedPath
+
+  const refs = extractAttachmentFilenames(noteId, noteMarkdown)
+  if (refs.has(downloaded)) return downloadedPath
+
+  const prefix = downloaded.slice(0, 7)
+  const candidates = [...refs].filter((name) => name.startsWith(prefix))
+  if (candidates.length !== 1) return downloadedPath
+
+  const target = path.join(dir, candidates[0])
+  if (existsSync(target)) return downloadedPath
+
+  try {
+    renameSync(downloadedPath, target)
+    logger.info('Renamed a downloaded attachment to its synced name', { noteId })
+    return target
+  } catch (error) {
+    logger.warn('Failed to rename a downloaded attachment', { noteId, error })
+    return downloadedPath
+  }
+}

--- a/apps/desktop/src/main/vault/attachment-rename.test.ts
+++ b/apps/desktop/src/main/vault/attachment-rename.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for attachment-rename.ts (#1714). The disk rename is the half of the
+ * feature the note body cannot repair on its own, so the name shaping, the
+ * collision walk and the "this note's folder only" guard are all covered here.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+vi.mock('electron', () => ({
+  shell: { showItemInFolder: vi.fn(), openPath: vi.fn().mockResolvedValue('') }
+}))
+
+const getNoteCacheById = vi.fn()
+vi.mock('@main/database/queries/notes', () => ({
+  getNoteCacheById: (...args: unknown[]) => getNoteCacheById(...args)
+}))
+
+vi.mock('../database', () => ({ getIndexDatabase: () => ({}) }))
+vi.mock('../database/queries/notes/note-crud', () => ({
+  getNoteCacheById: (...args: unknown[]) => getNoteCacheById(...args)
+}))
+
+let vaultPath = ''
+vi.mock('./notes-io', () => ({ getVaultRoot: () => vaultPath }))
+vi.mock('./index', () => ({ getStatus: () => ({ path: vaultPath }) }))
+
+import {
+  buildRenamedFilename,
+  renameAttachment,
+  resolveCollision,
+  sanitizeAttachmentName
+} from './attachment-rename'
+import { NoteError } from '../lib/errors'
+
+const NOTE_ID = 'n1'
+const NOTE_PATH = 'notes/My Note.md'
+
+function writeAttachment(relative: string): string {
+  const absolute = path.join(vaultPath, relative)
+  fs.mkdirSync(path.dirname(absolute), { recursive: true })
+  fs.writeFileSync(absolute, 'pdf-bytes')
+  return absolute
+}
+
+beforeEach(() => {
+  vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'attachment-rename-'))
+  getNoteCacheById.mockImplementation((_db: unknown, id: string) =>
+    id === NOTE_ID ? { path: NOTE_PATH } : undefined
+  )
+})
+
+afterEach(() => {
+  fs.rmSync(vaultPath, { recursive: true, force: true })
+})
+
+describe('buildRenamedFilename', () => {
+  it('keeps the nanoid prefix and the extension', () => {
+    expect(buildRenamedFilename('k3f9x2-scan_0031.pdf', 'Invoice March')).toBe(
+      'k3f9x2-Invoice-March.pdf'
+    )
+  })
+
+  it('does not duplicate an extension the user typed', () => {
+    expect(buildRenamedFilename('k3f9x2-scan.pdf', 'invoice.pdf')).toBe('k3f9x2-invoice.pdf')
+    expect(buildRenamedFilename('k3f9x2-scan.pdf', 'invoice.PDF')).toBe('k3f9x2-invoice.pdf')
+  })
+
+  it('strips what would break a markdown link or the file marker', () => {
+    expect(buildRenamedFilename('k3f9x2-a.png', 'holiday (2) {draft}')).toBe(
+      'k3f9x2-holiday-2-draft.png'
+    )
+  })
+
+  it('never produces an empty middle segment', () => {
+    // sanitizeFilename already answers a name that is nothing but dots.
+    expect(buildRenamedFilename('k3f9x2-a.png', '...')).toBe('k3f9x2-untitled.png')
+    expect(buildRenamedFilename('k3f9x2-a.png', '( )')).toBe('k3f9x2-file.png')
+  })
+
+  it('leaves a prefix-less legacy filename prefix-less', () => {
+    expect(buildRenamedFilename('report.pdf', 'invoice')).toBe('invoice.pdf')
+  })
+
+  it('sanitizes path separators out of the name', () => {
+    expect(sanitizeAttachmentName('../../etc/passwd')).not.toContain('/')
+  })
+})
+
+describe('resolveCollision', () => {
+  it('returns the candidate when nothing holds the name', () => {
+    fs.mkdirSync(path.join(vaultPath, 'attachments', NOTE_ID), { recursive: true })
+    expect(resolveCollision(path.join(vaultPath, 'attachments', NOTE_ID), 'a-b.pdf')).toBe(
+      'a-b.pdf'
+    )
+  })
+
+  it('walks -2, -3 while the name is taken', () => {
+    const dir = path.join(vaultPath, 'attachments', NOTE_ID)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, 'k3f9x2-invoice.pdf'), 'x')
+    fs.writeFileSync(path.join(dir, 'k3f9x2-invoice-2.pdf'), 'x')
+
+    expect(resolveCollision(dir, 'k3f9x2-invoice.pdf')).toBe('k3f9x2-invoice-3.pdf')
+  })
+})
+
+describe('renameAttachment', () => {
+  it('renames the file on disk and returns the new note-relative ref', async () => {
+    writeAttachment(`attachments/${NOTE_ID}/k3f9x2-scan_0031.pdf`)
+
+    const result = await renameAttachment(
+      NOTE_ID,
+      `../attachments/${NOTE_ID}/k3f9x2-scan_0031.pdf`,
+      'Invoice March'
+    )
+
+    expect(result).toEqual({
+      storedFilename: 'k3f9x2-Invoice-March.pdf',
+      url: `../attachments/${NOTE_ID}/k3f9x2-Invoice-March.pdf`,
+      name: 'Invoice March.pdf'
+    })
+    expect(
+      fs.existsSync(path.join(vaultPath, 'attachments', NOTE_ID, 'k3f9x2-Invoice-March.pdf'))
+    ).toBe(true)
+    expect(
+      fs.existsSync(path.join(vaultPath, 'attachments', NOTE_ID, 'k3f9x2-scan_0031.pdf'))
+    ).toBe(false)
+  })
+
+  it('renames the file self-heal found when the block ref is stale', async () => {
+    // The block still names the pre-external-rename file; only the healed one exists.
+    writeAttachment(`attachments/${NOTE_ID}/k3f9x2-renamed-by-hand.pdf`)
+
+    const result = await renameAttachment(
+      NOTE_ID,
+      `../attachments/${NOTE_ID}/k3f9x2-scan.pdf`,
+      'invoice'
+    )
+
+    expect(result.storedFilename).toBe('k3f9x2-invoice.pdf')
+    expect(fs.existsSync(path.join(vaultPath, 'attachments', NOTE_ID, 'k3f9x2-invoice.pdf'))).toBe(
+      true
+    )
+  })
+
+  it('suffixes instead of overwriting an existing file', async () => {
+    // The nanoid prefix normally keeps two attachments apart; prefix-less
+    // legacy files (and a freak prefix collision) are what can actually clash.
+    writeAttachment(`attachments/${NOTE_ID}/one.pdf`)
+    writeAttachment(`attachments/${NOTE_ID}/invoice.pdf`)
+
+    const result = await renameAttachment(NOTE_ID, `../attachments/${NOTE_ID}/one.pdf`, 'invoice')
+
+    expect(result.storedFilename).toBe('invoice-2.pdf')
+    expect(
+      fs.readFileSync(path.join(vaultPath, 'attachments', NOTE_ID, 'invoice.pdf'), 'utf8')
+    ).toBe('pdf-bytes')
+  })
+
+  it('rejects a file outside this note’s attachments folder', async () => {
+    writeAttachment('attachments/other/k3f9x2-report.pdf')
+
+    await expect(
+      renameAttachment(NOTE_ID, '../attachments/other/k3f9x2-report.pdf', 'invoice')
+    ).rejects.toBeInstanceOf(NoteError)
+  })
+
+  it('rejects a file that is not on disk', async () => {
+    fs.mkdirSync(path.join(vaultPath, 'attachments', NOTE_ID), { recursive: true })
+
+    await expect(
+      renameAttachment(NOTE_ID, `../attachments/${NOTE_ID}/k3f9x2-gone.pdf`, 'invoice')
+    ).rejects.toBeInstanceOf(NoteError)
+  })
+
+  it('rejects an empty name before touching the disk', async () => {
+    writeAttachment(`attachments/${NOTE_ID}/k3f9x2-scan.pdf`)
+
+    await expect(
+      renameAttachment(NOTE_ID, `../attachments/${NOTE_ID}/k3f9x2-scan.pdf`, '   ')
+    ).rejects.toBeInstanceOf(NoteError)
+    expect(fs.existsSync(path.join(vaultPath, 'attachments', NOTE_ID, 'k3f9x2-scan.pdf'))).toBe(
+      true
+    )
+  })
+})

--- a/apps/desktop/src/main/vault/attachment-rename.test.ts
+++ b/apps/desktop/src/main/vault/attachment-rename.test.ts
@@ -160,6 +160,22 @@ describe('renameAttachment', () => {
     ).toBe('pdf-bytes')
   })
 
+  it('is a no-op when the submitted name is the one it already has', async () => {
+    writeAttachment(`attachments/${NOTE_ID}/k3f9x2-invoice.pdf`)
+
+    const result = await renameAttachment(
+      NOTE_ID,
+      `../attachments/${NOTE_ID}/k3f9x2-invoice.pdf`,
+      'invoice.pdf'
+    )
+
+    // The file holding that name is this file — suffixing it would be churn.
+    expect(result.storedFilename).toBe('k3f9x2-invoice.pdf')
+    expect(fs.readdirSync(path.join(vaultPath, 'attachments', NOTE_ID))).toEqual([
+      'k3f9x2-invoice.pdf'
+    ])
+  })
+
   it('rejects a file outside this note’s attachments folder', async () => {
     writeAttachment('attachments/other/k3f9x2-report.pdf')
 

--- a/apps/desktop/src/main/vault/attachment-rename.ts
+++ b/apps/desktop/src/main/vault/attachment-rename.ts
@@ -1,0 +1,185 @@
+/**
+ * Renaming an attachment from its block menu (#1714).
+ *
+ * A stored attachment is named `{6-char nanoid}-{sanitized name}{ext}` inside
+ * `attachments/<noteId>/`. A rename keeps the nanoid prefix and the extension
+ * and only replaces the middle: the prefix is what every cross-device repair
+ * path keys on (self-heal in `attachment-heal.ts`, the rename reconcile below),
+ * and a changed extension would make the block's mime type a lie.
+ *
+ * Order of operations is disk first, note body second — the renderer writes the
+ * block's `url`/`name` after this resolves. A crash in that window leaves the
+ * body pointing at the old name, which self-heal already repairs by prefix; the
+ * reverse order would leave the body naming a file that does not exist anywhere.
+ *
+ * Sync semantics: nothing is re-uploaded. The blob and its encrypted manifest
+ * are untouched (the manifest's filename stays frozen at whatever it was at
+ * upload). What travels is the note body — the block's new `url` — through the
+ * ordinary CRDT path, so an older client simply sees a body whose ref differs
+ * from its disk and falls back to self-heal. Peers converge their own disk from
+ * the body: see `attachment-rename-reconcile.ts`.
+ */
+
+import { rename, readFile } from 'fs/promises'
+import { existsSync } from 'fs'
+import path from 'path'
+import type { AttachmentRenameResult } from '@memry/contracts/notes-api'
+import { getNoteCacheById } from '@main/database/queries/notes'
+import { getIndexDatabase } from '../database'
+import { NoteError, NoteErrorCode } from '../lib/errors'
+import { createLogger } from '../lib/logger'
+import { sanitizeFilename } from './file-ops'
+import { resolveAttachment } from './attachment-actions'
+import { reconcileDownloadedAttachmentName } from './attachment-rename-reconcile'
+import { getAttachmentRef, getNoteAttachmentsDir } from './attachments'
+import { getVaultRoot } from './notes-io'
+
+const logger = createLogger('AttachmentRename')
+
+/** The `{6-char nanoid}-` prefix `generateUniqueFilename` puts on every file. */
+const STORED_PREFIX_RE = /^[0-9a-z]{6}-/
+
+/** How many `-2`, `-3`… suffixes a collision may walk before giving up. */
+const MAX_COLLISION_ATTEMPTS = 100
+
+/**
+ * The stored middle segment for a user-typed name.
+ *
+ * Same shaping as `generateUniqueFilename`: spaces, parens and braces are out
+ * (they break markdown image links and terminate the `<!-- file:{…} -->`
+ * marker), and the result can never be empty.
+ */
+export function sanitizeAttachmentName(requested: string): string {
+  return (
+    sanitizeFilename(requested)
+      .replace(/[\s(){}]+/g, '-')
+      .replace(/-{2,}/g, '-')
+      .replace(/^-|-$/g, '') || 'file'
+  )
+}
+
+/**
+ * The stored filename a rename produces, before collision handling.
+ *
+ * `currentStored` keeps its nanoid prefix and its extension; a user who types
+ * an extension gets it stripped when it matches the current one, so
+ * "invoice.pdf" and "invoice" both land on `{prefix}-invoice.pdf`.
+ */
+export function buildRenamedFilename(currentStored: string, requestedName: string): string {
+  const ext = path.extname(currentStored)
+  const prefixMatch = currentStored.match(STORED_PREFIX_RE)
+  const prefix = prefixMatch ? prefixMatch[0] : ''
+
+  let base = requestedName.trim()
+  if (ext && base.toLowerCase().endsWith(ext.toLowerCase())) {
+    base = base.slice(0, base.length - ext.length)
+  }
+
+  return `${prefix}${sanitizeAttachmentName(base)}${ext}`
+}
+
+/**
+ * A free filename in `dir` for `candidate`, appending `-2`, `-3`… before the
+ * extension when the name is taken.
+ *
+ * Refusing the rename on a collision was the other option; suffixing wins
+ * because the two files are genuinely different attachments (different nanoid
+ * prefixes) that the user simply wants to call the same thing, and an error
+ * dialog cannot tell them which existing file is in the way.
+ */
+export function resolveCollision(dir: string, candidate: string): string {
+  if (!existsSync(path.join(dir, candidate))) return candidate
+
+  const ext = path.extname(candidate)
+  const base = candidate.slice(0, candidate.length - ext.length)
+  for (let n = 2; n < MAX_COLLISION_ATTEMPTS; n++) {
+    const next = `${base}-${n}${ext}`
+    if (!existsSync(path.join(dir, next))) return next
+  }
+  throw new NoteError('Could not find a free attachment filename', NoteErrorCode.INVALID_PATH)
+}
+
+/**
+ * Rename an attachment on disk and report the new block `url` / `name`.
+ *
+ * The caller passes the block's raw `props.url`; it is resolved (and self-healed)
+ * against the vault exactly like every other attachment action, so an arbitrary
+ * filesystem path can never be renamed through this.
+ */
+export async function renameAttachment(
+  noteId: string,
+  url: string,
+  newName: string
+): Promise<AttachmentRenameResult> {
+  const trimmed = newName.trim()
+  if (!trimmed) {
+    throw new NoteError('New attachment name is empty', NoteErrorCode.INVALID_PATH, noteId)
+  }
+
+  const resolved = resolveAttachment(noteId, url)
+  if (!resolved.exists) {
+    throw new NoteError('Attachment file not found on disk', NoteErrorCode.NOT_FOUND, noteId)
+  }
+
+  const vaultPath = getVaultRoot()
+  const attachmentsDir = getNoteAttachmentsDir(vaultPath, noteId)
+  if (path.resolve(path.dirname(resolved.absolutePath)) !== path.resolve(attachmentsDir)) {
+    // Only files this note owns are renameable: a shared or out-of-folder file
+    // would have references this note cannot rewrite.
+    throw new NoteError(
+      'Attachment is not stored in this note’s attachments folder',
+      NoteErrorCode.INVALID_PATH,
+      noteId
+    )
+  }
+
+  const currentStored = resolved.storedFilename
+  const target = resolveCollision(attachmentsDir, buildRenamedFilename(currentStored, trimmed))
+
+  if (target !== currentStored) {
+    await rename(resolved.absolutePath, path.join(attachmentsDir, target))
+    logger.info('Attachment renamed', { noteId })
+  }
+
+  const notePath = getNoteCacheById(getIndexDatabase(), noteId)?.path
+  return {
+    storedFilename: target,
+    url: getAttachmentRef(vaultPath, noteId, target, notePath),
+    name: displayNameFor(target, trimmed)
+  }
+}
+
+/**
+ * What the block shows. The stored name is sanitized and prefixed; the display
+ * name keeps what the user typed, with the extension restored when they dropped
+ * it, so a PDF never reads as extension-less in the card.
+ */
+function displayNameFor(storedFilename: string, requested: string): string {
+  const ext = path.extname(storedFilename)
+  const trimmed = requested.trim()
+  if (!ext || trimmed.toLowerCase().endsWith(ext.toLowerCase())) return trimmed
+  return `${trimmed}${ext}`
+}
+
+/**
+ * Rename a file sync just materialized to the name this note's body asks for.
+ *
+ * The one caller is the attachment download handler; the note's markdown is read
+ * here so the reconcile itself stays a pure function of (body, folder). Never
+ * throws: a missing note file or an unreadable folder leaves the download exactly
+ * as it landed, which is what happened before this existed.
+ */
+export async function applyDownloadedAttachmentName(
+  noteId: string,
+  downloadedPath: string
+): Promise<void> {
+  try {
+    const notePath = getNoteCacheById(getIndexDatabase(), noteId)?.path
+    if (!notePath) return
+    const vaultPath = getVaultRoot()
+    const markdown = await readFile(path.join(vaultPath, notePath), 'utf-8')
+    reconcileDownloadedAttachmentName(noteId, downloadedPath, markdown, vaultPath)
+  } catch (error) {
+    logger.warn('Could not reconcile a downloaded attachment name', { noteId, error })
+  }
+}

--- a/apps/desktop/src/main/vault/attachment-rename.ts
+++ b/apps/desktop/src/main/vault/attachment-rename.ts
@@ -134,7 +134,11 @@ export async function renameAttachment(
   }
 
   const currentStored = resolved.storedFilename
-  const target = resolveCollision(attachmentsDir, buildRenamedFilename(currentStored, trimmed))
+  const candidate = buildRenamedFilename(currentStored, trimmed)
+  // Submitting the name it already has must not walk the collision suffix: the
+  // file holding that name IS this file, so `-2` would be pure churn.
+  const target =
+    candidate === currentStored ? candidate : resolveCollision(attachmentsDir, candidate)
 
   if (target !== currentStored) {
     await rename(resolved.absolutePath, path.join(attachmentsDir, target))

--- a/apps/desktop/src/preload/generated-rpc.ts
+++ b/apps/desktop/src/preload/generated-rpc.ts
@@ -95,6 +95,7 @@ export function createGeneratedRpcApi({
       "resolveAttachment": ((noteId, url) => invoke("notes:attachment-resolve", { noteId, url })) as GeneratedRpcApi["notes"]["resolveAttachment"],
       "revealAttachmentInFinder": ((noteId, url) => invoke("notes:attachment-reveal-in-finder", { noteId, url })) as GeneratedRpcApi["notes"]["revealAttachmentInFinder"],
       "openAttachmentExternal": ((noteId, url) => invoke("notes:attachment-open-external", { noteId, url })) as GeneratedRpcApi["notes"]["openAttachmentExternal"],
+      "renameAttachment": ((noteId, url, newName) => invoke("notes:attachment-rename", { noteId, url, newName })) as GeneratedRpcApi["notes"]["renameAttachment"],
       "getPropertyDefinitions": (() => invoke("notes:get-property-definitions")) as GeneratedRpcApi["notes"]["getPropertyDefinitions"],
       "createPropertyDefinition": ((input) => invoke("notes:create-property-definition", input)) as GeneratedRpcApi["notes"]["createPropertyDefinition"],
       "updatePropertyDefinition": ((input) => invoke("notes:update-property-definition", input)) as GeneratedRpcApi["notes"]["updatePropertyDefinition"],

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -1288,7 +1288,7 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
 
   // From a DOM element inside an image block to the block's raw stored props.
   const resolveImageFromElement = useCallback(
-    (element: HTMLElement): { url: string; name: string } | null => {
+    (element: HTMLElement): { url: string; name: string; blockId: string } | null => {
       const blockId = element.closest('[data-id]')?.getAttribute('data-id')
       if (!blockId) return null
 
@@ -1297,8 +1297,20 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
       const { url, name } = block.props as { url?: string; name?: string }
       if (!url) return null
 
-      return { url, name: name || url.split('/').pop() || url }
+      return { url, name: name || url.split('/').pop() || url, blockId }
     },
+    [editor]
+  )
+
+  // An attachment rename (#1714) has already renamed the file on disk; the
+  // block's url has to follow, or the note keeps pointing at the old name.
+  const applyImageRename = useCallback(
+    (blockId: string) =>
+      (next: { url: string; name: string }): void => {
+        const block = editor.getBlock(blockId)
+        if (!block || block.type !== 'image') return
+        editor.updateBlock(block, { props: { url: next.url, name: next.name } })
+      },
     [editor]
   )
 
@@ -1461,12 +1473,14 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
             <ImageAttachmentMenu
               target={imageMenuTarget}
               onClose={() => setImageMenuTarget(null)}
+              onRenamed={applyImageRename(imageMenuTarget.blockId)}
             />
           )}
           {imageHoverTarget && !imageMenuTarget && (
             <ImageHoverMenuButton
               target={imageHoverTarget}
               onOpenChange={handleImageHoverMenuOpenChange}
+              onRenamed={applyImageRename(imageHoverTarget.blockId)}
             />
           )}
           <BlockNoteView

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -21,6 +21,7 @@ import {
   useImageHoverMenu,
   type ImageMenuTarget
 } from './attachment-block-menu'
+import { AttachmentRenameFlow } from './attachment-rename-dialog'
 import { useTheme } from 'next-themes'
 import { AIMenuController, getAISlashMenuItems } from '@blocknote/xl-ai'
 import { CustomAIMenu } from './ai-menu'
@@ -1302,16 +1303,29 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     [editor]
   )
 
+  // The rename dialog for an image lives HERE, not in the menu (#1714). Both
+  // image surfaces are rendered only while their menu is open or the pointer is
+  // over the image, so a dialog parented to them was unmounted by the very
+  // click that opened it — Rename looked like it did nothing at all.
+  const [imageRenameTarget, setImageRenameTarget] = useState<{
+    url: string
+    name: string
+    blockId: string
+  } | null>(null)
+
   // An attachment rename (#1714) has already renamed the file on disk; the
   // block's url has to follow, or the note keeps pointing at the old name.
   const applyImageRename = useCallback(
-    (blockId: string) =>
-      (next: { url: string; name: string }): void => {
-        const block = editor.getBlock(blockId)
-        if (!block || block.type !== 'image') return
+    (next: { url: string; name: string }): void => {
+      const blockId = imageRenameTarget?.blockId
+      if (!blockId) return
+      const block = editor.getBlock(blockId)
+      if (block && block.type === 'image') {
         editor.updateBlock(block, { props: { url: next.url, name: next.name } })
-      },
-    [editor]
+      }
+      setImageRenameTarget(null)
+    },
+    [editor, imageRenameTarget]
   )
 
   const { hoverTarget: imageHoverTarget, handleMenuOpenChange: handleImageHoverMenuOpenChange } =
@@ -1473,14 +1487,26 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
             <ImageAttachmentMenu
               target={imageMenuTarget}
               onClose={() => setImageMenuTarget(null)}
-              onRenamed={applyImageRename(imageMenuTarget.blockId)}
+              onRequestRename={() => {
+                setImageRenameTarget(imageMenuTarget)
+                setImageMenuTarget(null)
+              }}
+            />
+          )}
+          {imageRenameTarget && (
+            <AttachmentRenameFlow
+              url={imageRenameTarget.url}
+              name={imageRenameTarget.name}
+              open
+              onOpenChange={(open) => !open && setImageRenameTarget(null)}
+              onRenamed={applyImageRename}
             />
           )}
           {imageHoverTarget && !imageMenuTarget && (
             <ImageHoverMenuButton
               target={imageHoverTarget}
               onOpenChange={handleImageHoverMenuOpenChange}
-              onRenamed={applyImageRename(imageHoverTarget.blockId)}
+              onRequestRename={() => setImageRenameTarget(imageHoverTarget)}
             />
           )}
           <BlockNoteView

--- a/apps/desktop/src/renderer/src/components/note/content-area/attachment-block-menu.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/attachment-block-menu.test.tsx
@@ -4,7 +4,7 @@
  * Copy path and the original + stored filename for a file block.
  */
 
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { fireEvent } from '@testing-library/react'
@@ -14,9 +14,11 @@ import { NoteFileUrlProvider } from './note-file-url-context'
 import {
   AttachmentBlockContextMenu,
   AttachmentMenuButton,
+  ImageAttachmentMenu,
   ImageHoverMenuButton,
   useImageHoverMenu
 } from './attachment-block-menu'
+import { AttachmentRenameFlow, renameFieldValue } from './attachment-rename-dialog'
 
 // The reveal action's label branches on platform. Pin macOS so these
 // assertions read the Finder wording whatever host the suite runs on.
@@ -184,6 +186,79 @@ describe('renaming from the menu (#1714)', () => {
     await waitFor(() => expect(mocks.renameAttachment).toHaveBeenCalled())
     expect(onRenamed).not.toHaveBeenCalled()
     expect(screen.getByTestId('attachment-rename-dialog')).toBeInTheDocument()
+  })
+})
+
+/**
+ * What the editor does: the image menu lives only while it is open, and the
+ * floating button only while the pointer is on the image. A dialog parented to
+ * either was unmounted by the very click that opened it, so Rename on an image
+ * did nothing at all — the host has to own the dialog.
+ */
+const hostRenamed = vi.fn()
+
+function ImageMenuHostHarness() {
+  const [menuOpen, setMenuOpen] = useState(true)
+  const [renameTarget, setRenameTarget] = useState<{ url: string; name: string } | null>(null)
+
+  return (
+    <>
+      {menuOpen && (
+        <ImageAttachmentMenu
+          target={{ x: 0, y: 0, url: URL, name: 'report.pdf', blockId: 'b1' }}
+          onClose={() => setMenuOpen(false)}
+          onRequestRename={() => {
+            setRenameTarget({ url: URL, name: 'report.pdf' })
+            setMenuOpen(false)
+          }}
+        />
+      )}
+      {renameTarget && (
+        <AttachmentRenameFlow
+          url={renameTarget.url}
+          name={renameTarget.name}
+          open
+          onOpenChange={(open) => !open && setRenameTarget(null)}
+          onRenamed={hostRenamed}
+        />
+      )}
+    </>
+  )
+}
+
+describe('image blocks — host-owned rename (#1714)', () => {
+  it('keeps the dialog when the menu that asked for it unmounts', async () => {
+    hostRenamed.mockClear()
+    const user = userEvent.setup()
+    renderWithProvider(<ImageMenuHostHarness />)
+
+    await user.click(await screen.findByRole('menuitem', { name: 'Rename…' }))
+
+    // The menu is gone, the dialog is not.
+    expect(screen.queryByTestId('attachment-image-menu')).not.toBeInTheDocument()
+    const field = await screen.findByLabelText('Attachment name')
+    expect(field).toHaveValue('report')
+
+    await user.clear(field)
+    await user.type(field, 'invoice')
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+
+    await waitFor(() => {
+      expect(mocks.renameAttachment).toHaveBeenCalledWith(NOTE_ID, URL, 'invoice.pdf')
+    })
+    await waitFor(() => {
+      expect(hostRenamed).toHaveBeenCalledWith({
+        url: '../attachments/note-1/k3f9x2-invoice.pdf',
+        name: 'invoice.pdf'
+      })
+    })
+  })
+
+  it('drops the stored nanoid prefix from the field an image falls back to', () => {
+    // An image block with no name of its own falls back to the stored filename;
+    // main puts the prefix back, so offering it would double it.
+    expect(renameFieldValue('k3f9x2-photo.png')).toBe('photo.png')
+    expect(renameFieldValue('holiday-photo.png')).toBe('holiday-photo.png')
   })
 })
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/attachment-block-menu.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/attachment-block-menu.test.tsx
@@ -40,6 +40,7 @@ const mocks = vi.hoisted(() => ({
   resolveAttachment: vi.fn(),
   revealAttachmentInFinder: vi.fn(),
   openAttachmentExternal: vi.fn(),
+  renameAttachment: vi.fn(),
   clipboardWriteText: vi.fn()
 }))
 
@@ -55,6 +56,11 @@ beforeEach(() => {
   mocks.resolveAttachment.mockReset().mockResolvedValue(RESOLVED)
   mocks.revealAttachmentInFinder.mockReset().mockResolvedValue(undefined)
   mocks.openAttachmentExternal.mockReset().mockResolvedValue(undefined)
+  mocks.renameAttachment.mockReset().mockResolvedValue({
+    storedFilename: 'k3f9x2-invoice.pdf',
+    url: '../attachments/note-1/k3f9x2-invoice.pdf',
+    name: 'invoice.pdf'
+  })
   mocks.clipboardWriteText.mockReset().mockResolvedValue(undefined)
 
   const api = window.api as unknown as Record<string, unknown>
@@ -62,7 +68,8 @@ beforeEach(() => {
     ...((api.notes as Record<string, unknown>) ?? {}),
     resolveAttachment: mocks.resolveAttachment,
     revealAttachmentInFinder: mocks.revealAttachmentInFinder,
-    openAttachmentExternal: mocks.openAttachmentExternal
+    openAttachmentExternal: mocks.openAttachmentExternal,
+    renameAttachment: mocks.renameAttachment
   }
   Object.defineProperty(navigator, 'clipboard', {
     value: { writeText: mocks.clipboardWriteText },
@@ -127,10 +134,63 @@ describe('AttachmentMenuButton', () => {
   })
 })
 
+describe('renaming from the menu (#1714)', () => {
+  it('offers Rename only when the surface can write the result back', async () => {
+    const user = userEvent.setup()
+    renderWithProvider(<AttachmentMenuButton url={URL} name="report.pdf" />)
+
+    await user.click(screen.getByRole('button', { name: 'File actions' }))
+
+    await screen.findByRole('menuitem', { name: 'Reveal in Finder' })
+    expect(screen.queryByRole('menuitem', { name: 'Rename…' })).not.toBeInTheDocument()
+  })
+
+  it('renames the file and hands the new url + name back to the block', async () => {
+    const onRenamed = vi.fn()
+    const user = userEvent.setup()
+    renderWithProvider(<AttachmentMenuButton url={URL} name="report.pdf" onRenamed={onRenamed} />)
+
+    await user.click(screen.getByRole('button', { name: 'File actions' }))
+    await user.click(await screen.findByRole('menuitem', { name: 'Rename…' }))
+
+    const field = await screen.findByLabelText('Attachment name')
+    // The extension is not editable — it is the one part the rename keeps.
+    expect(field).toHaveValue('report')
+    await user.clear(field)
+    await user.type(field, 'invoice')
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+
+    await waitFor(() => {
+      expect(mocks.renameAttachment).toHaveBeenCalledWith(NOTE_ID, URL, 'invoice.pdf')
+    })
+    await waitFor(() => {
+      expect(onRenamed).toHaveBeenCalledWith({
+        url: '../attachments/note-1/k3f9x2-invoice.pdf',
+        name: 'invoice.pdf'
+      })
+    })
+  })
+
+  it('keeps the dialog open and does not touch the block when the rename fails', async () => {
+    mocks.renameAttachment.mockRejectedValue(new Error('nope'))
+    const onRenamed = vi.fn()
+    const user = userEvent.setup()
+    renderWithProvider(<AttachmentMenuButton url={URL} name="report.pdf" onRenamed={onRenamed} />)
+
+    await user.click(screen.getByRole('button', { name: 'File actions' }))
+    await user.click(await screen.findByRole('menuitem', { name: 'Rename…' }))
+    await user.click(await screen.findByRole('button', { name: 'Rename' }))
+
+    await waitFor(() => expect(mocks.renameAttachment).toHaveBeenCalled())
+    expect(onRenamed).not.toHaveBeenCalled()
+    expect(screen.getByTestId('attachment-rename-dialog')).toBeInTheDocument()
+  })
+})
+
 function ImageHoverHarness({
   resolveImage
 }: {
-  resolveImage: (el: HTMLElement) => { url: string; name: string } | null
+  resolveImage: (el: HTMLElement) => { url: string; name: string; blockId: string } | null
 }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const { hoverTarget, handleMenuOpenChange } = useImageHoverMenu(containerRef, resolveImage)
@@ -149,7 +209,7 @@ function ImageHoverHarness({
 }
 
 describe('useImageHoverMenu + ImageHoverMenuButton', () => {
-  const resolveImage = () => ({ url: URL, name: 'report.pdf' })
+  const resolveImage = () => ({ url: URL, name: 'report.pdf', blockId: 'b1' })
 
   it('shows the floating button while hovering an image and opens the menu from it', async () => {
     const user = userEvent.setup()

--- a/apps/desktop/src/renderer/src/components/note/content-area/attachment-block-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/attachment-block-menu.tsx
@@ -35,15 +35,9 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { useAttachmentNoteId } from './note-file-url-context'
-import { AttachmentRenameDialog } from './attachment-rename-dialog'
+import { AttachmentRenameFlow, type AttachmentRenamedHandler } from './attachment-rename-dialog'
 
-/**
- * What a surface does with a completed rename: write the new `url`/`name` back
- * into the block. Without it the menu still renames the file on disk, so the
- * item is hidden rather than offered — a rename the note never records would
- * leave the block pointing at the old name (self-heal territory, not intent).
- */
-export type AttachmentRenamedHandler = (next: { url: string; name: string }) => void
+export type { AttachmentRenamedHandler }
 
 interface AttachmentMenuState {
   info: AttachmentResolveResult | null
@@ -58,17 +52,32 @@ interface AttachmentMenuState {
   renameOpen: boolean
 }
 
+/**
+ * Who owns the rename dialog.
+ *
+ * `onRenamed` — the menu owns it. Only safe where the menu itself stays
+ * mounted (the file block's card).
+ * `onRequestRename` — the HOST owns it, and the menu only asks. The image
+ * surfaces need this: the editor unmounts them as soon as the menu closes or
+ * the pointer leaves the image, which took the dialog down with it before it
+ * ever rendered — clicking Rename appeared to do nothing.
+ */
+interface RenameWiring {
+  onRenamed?: AttachmentRenamedHandler
+  onRequestRename?: () => void
+}
+
 function useAttachmentMenu(
   url: string,
   name: string,
-  onRenamed?: AttachmentRenamedHandler
+  rename: RenameWiring = {}
 ): AttachmentMenuState & { renameDialog: React.ReactNode } {
+  const { onRenamed, onRequestRename } = rename
   const noteId = useAttachmentNoteId()
   const { t } = useT('notes')
   const [info, setInfo] = useState<AttachmentResolveResult | null>(null)
   const [resolveFailed, setResolveFailed] = useState(false)
   const [renameOpen, setRenameOpen] = useState(false)
-  const [renaming, setRenaming] = useState(false)
 
   // Resolved lazily on menu open, not on block mount — a note can hold dozens
   // of attachment blocks and the answer can change when sync lands the file.
@@ -111,36 +120,14 @@ function useAttachmentMenu(
       })
   }, [info, t])
 
-  const submitRename = useCallback(
-    (nextName: string) => {
-      if (!noteId) return
-      setRenaming(true)
-      window.api.notes
-        .renameAttachment(noteId, url, nextName)
-        .then((result) => {
-          // Disk first, block second: main has already renamed the file, so the
-          // block MUST take the result even if the user has moved on — a block
-          // left on the old ref only survives through self-heal.
-          onRenamed?.({ url: result.url, name: result.name })
-          setRenameOpen(false)
-          toast.success(t('editor.attachmentRename.renamed', { name: result.name }))
-        })
-        .catch((err: unknown) => {
-          toast.error(extractErrorMessage(err, t('editor.attachmentRename.failed')))
-        })
-        .finally(() => setRenaming(false))
-    },
-    [noteId, url, onRenamed, t]
-  )
-
   const renameDialog =
     onRenamed && renameOpen ? (
-      <AttachmentRenameDialog
+      <AttachmentRenameFlow
+        url={url}
+        name={info?.storedFilename && !name ? info.storedFilename : name}
         open={renameOpen}
         onOpenChange={setRenameOpen}
-        currentName={info?.storedFilename && !name ? info.storedFilename : name}
-        busy={renaming}
-        onSubmit={submitRename}
+        onRenamed={onRenamed}
       />
     ) : null
 
@@ -152,7 +139,7 @@ function useAttachmentMenu(
     reveal,
     openExternal,
     copyPath,
-    startRename: onRenamed ? () => setRenameOpen(true) : undefined,
+    startRename: onRequestRename ?? (onRenamed ? () => setRenameOpen(true) : undefined),
     renameOpen,
     renameDialog
   }
@@ -251,7 +238,7 @@ export function AttachmentBlockContextMenu({
   onRenamed?: AttachmentRenamedHandler
   children: React.ReactNode
 }) {
-  const state = useAttachmentMenu(url, name, onRenamed)
+  const state = useAttachmentMenu(url, name, { onRenamed })
 
   return (
     <>
@@ -281,7 +268,8 @@ export function AttachmentMenuButton({
   name,
   className,
   onOpenChange,
-  onRenamed
+  onRenamed,
+  onRequestRename
 }: {
   url: string
   name: string
@@ -289,8 +277,10 @@ export function AttachmentMenuButton({
   /** Extra open-state observer, chained after the resolve-on-open handler. */
   onOpenChange?: (open: boolean) => void
   onRenamed?: AttachmentRenamedHandler
+  /** Host-owned rename — see {@link RenameWiring}. */
+  onRequestRename?: () => void
 }) {
-  const state = useAttachmentMenu(url, name, onRenamed)
+  const state = useAttachmentMenu(url, name, { onRenamed, onRequestRename })
   const { t } = useT('notes')
 
   return (
@@ -353,13 +343,17 @@ export interface ImageMenuTarget {
 export function ImageAttachmentMenu({
   target,
   onClose,
-  onRenamed
+  onRequestRename
 }: {
   target: ImageMenuTarget
   onClose: () => void
-  onRenamed?: AttachmentRenamedHandler
+  /**
+   * Host-owned rename. This menu is unmounted by the editor the moment it
+   * closes, so it can only ask for the dialog — never render it.
+   */
+  onRequestRename?: () => void
 }) {
-  const state = useAttachmentMenu(target.url, target.name, onRenamed)
+  const state = useAttachmentMenu(target.url, target.name, { onRequestRename })
   const { handleOpenChange } = state
 
   // Controlled-open: resolve immediately, since there is no opening gesture
@@ -369,26 +363,14 @@ export function ImageAttachmentMenu({
   }, [handleOpenChange])
 
   return (
-    <>
-      <DropdownMenu
-        open={!state.renameOpen}
-        onOpenChange={(open) => !open && !state.renameOpen && onClose()}
-      >
-        <DropdownMenuTrigger asChild>
-          <span style={{ position: 'fixed', top: target.y, left: target.x, width: 0, height: 0 }} />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="start"
-          data-testid="attachment-image-menu"
-          onCloseAutoFocus={(event) => {
-            if (state.renameOpen) event.preventDefault()
-          }}
-        >
-          <AttachmentMenuBody name={target.name} state={state} components={DROPDOWN_COMPONENTS} />
-        </DropdownMenuContent>
-      </DropdownMenu>
-      {state.renameDialog}
-    </>
+    <DropdownMenu open onOpenChange={(open) => !open && onClose()}>
+      <DropdownMenuTrigger asChild>
+        <span style={{ position: 'fixed', top: target.y, left: target.x, width: 0, height: 0 }} />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" data-testid="attachment-image-menu">
+        <AttachmentMenuBody name={target.name} state={state} components={DROPDOWN_COMPONENTS} />
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 
@@ -418,11 +400,12 @@ export interface HoverImageTarget {
 export function ImageHoverMenuButton({
   target,
   onOpenChange,
-  onRenamed
+  onRequestRename
 }: {
   target: HoverImageTarget
   onOpenChange?: (open: boolean) => void
-  onRenamed?: AttachmentRenamedHandler
+  /** Host-owned rename — this button is unmounted as soon as the menu closes. */
+  onRequestRename?: () => void
 }) {
   return (
     <div
@@ -433,7 +416,7 @@ export function ImageHoverMenuButton({
         url={target.url}
         name={target.name}
         onOpenChange={onOpenChange}
-        onRenamed={onRenamed}
+        onRequestRename={onRequestRename}
         className="h-6 w-6 rounded-md border border-border bg-background/90 shadow-sm"
       />
     </div>

--- a/apps/desktop/src/renderer/src/components/note/content-area/attachment-block-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/attachment-block-menu.tsx
@@ -13,7 +13,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import type { AttachmentResolveResult } from '@memry/contracts/notes-api'
-import { Copy, ExternalLink, FolderOpen, MoreHorizontal } from '@/lib/icons'
+import { Copy, ExternalLink, FolderOpen, MoreHorizontal, Pencil } from '@/lib/icons'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
@@ -35,6 +35,15 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { useAttachmentNoteId } from './note-file-url-context'
+import { AttachmentRenameDialog } from './attachment-rename-dialog'
+
+/**
+ * What a surface does with a completed rename: write the new `url`/`name` back
+ * into the block. Without it the menu still renames the file on disk, so the
+ * item is hidden rather than offered — a rename the note never records would
+ * leave the block pointing at the old name (self-heal territory, not intent).
+ */
+export type AttachmentRenamedHandler = (next: { url: string; name: string }) => void
 
 interface AttachmentMenuState {
   info: AttachmentResolveResult | null
@@ -44,13 +53,22 @@ interface AttachmentMenuState {
   reveal: () => void
   openExternal: () => void
   copyPath: () => void
+  /** Absent when the surface cannot write the result back into the block. */
+  startRename?: () => void
+  renameOpen: boolean
 }
 
-function useAttachmentMenu(url: string): AttachmentMenuState {
+function useAttachmentMenu(
+  url: string,
+  name: string,
+  onRenamed?: AttachmentRenamedHandler
+): AttachmentMenuState & { renameDialog: React.ReactNode } {
   const noteId = useAttachmentNoteId()
   const { t } = useT('notes')
   const [info, setInfo] = useState<AttachmentResolveResult | null>(null)
   const [resolveFailed, setResolveFailed] = useState(false)
+  const [renameOpen, setRenameOpen] = useState(false)
+  const [renaming, setRenaming] = useState(false)
 
   // Resolved lazily on menu open, not on block mount — a note can hold dozens
   // of attachment blocks and the answer can change when sync lands the file.
@@ -93,6 +111,39 @@ function useAttachmentMenu(url: string): AttachmentMenuState {
       })
   }, [info, t])
 
+  const submitRename = useCallback(
+    (nextName: string) => {
+      if (!noteId) return
+      setRenaming(true)
+      window.api.notes
+        .renameAttachment(noteId, url, nextName)
+        .then((result) => {
+          // Disk first, block second: main has already renamed the file, so the
+          // block MUST take the result even if the user has moved on — a block
+          // left on the old ref only survives through self-heal.
+          onRenamed?.({ url: result.url, name: result.name })
+          setRenameOpen(false)
+          toast.success(t('editor.attachmentRename.renamed', { name: result.name }))
+        })
+        .catch((err: unknown) => {
+          toast.error(extractErrorMessage(err, t('editor.attachmentRename.failed')))
+        })
+        .finally(() => setRenaming(false))
+    },
+    [noteId, url, onRenamed, t]
+  )
+
+  const renameDialog =
+    onRenamed && renameOpen ? (
+      <AttachmentRenameDialog
+        open={renameOpen}
+        onOpenChange={setRenameOpen}
+        currentName={info?.storedFilename && !name ? info.storedFilename : name}
+        busy={renaming}
+        onSubmit={submitRename}
+      />
+    ) : null
+
   return {
     info,
     resolveFailed,
@@ -100,7 +151,10 @@ function useAttachmentMenu(url: string): AttachmentMenuState {
     handleOpenChange,
     reveal,
     openExternal,
-    copyPath
+    copyPath,
+    startRename: onRenamed ? () => setRenameOpen(true) : undefined,
+    renameOpen,
+    renameDialog
   }
 }
 
@@ -130,7 +184,7 @@ function AttachmentMenuBody({
   const { t } = useT('notes')
   const { Item, Label, Separator } = components
   const fileActions = useFileActionLabels()
-  const { info, actionsDisabled, reveal, openExternal, copyPath } = state
+  const { info, actionsDisabled, reveal, openExternal, copyPath, startRename } = state
 
   return (
     <>
@@ -163,6 +217,12 @@ function AttachmentMenuBody({
         <Copy className="h-4 w-4" />
         {t('editor.toolbar.copyPath')}
       </Item>
+      {startRename && (
+        <Item disabled={actionsDisabled} onClick={startRename}>
+          <Pencil className="h-4 w-4" />
+          {t('editor.attachmentRename.menuItem')}
+        </Item>
+      )}
     </>
   )
 }
@@ -183,21 +243,35 @@ const CONTEXT_COMPONENTS: MenuComponents = {
 export function AttachmentBlockContextMenu({
   url,
   name,
+  onRenamed,
   children
 }: {
   url: string
   name: string
+  onRenamed?: AttachmentRenamedHandler
   children: React.ReactNode
 }) {
-  const state = useAttachmentMenu(url)
+  const state = useAttachmentMenu(url, name, onRenamed)
 
   return (
-    <ContextMenu onOpenChange={state.handleOpenChange}>
-      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-      <ContextMenuContent data-testid="attachment-context-menu">
-        <AttachmentMenuBody name={name} state={state} components={CONTEXT_COMPONENTS} />
-      </ContextMenuContent>
-    </ContextMenu>
+    <>
+      <ContextMenu onOpenChange={state.handleOpenChange}>
+        <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+        <ContextMenuContent
+          data-testid="attachment-context-menu"
+          // The menu unmounts as the dialog mounts, and Radix restores focus to
+          // the trigger on unmount — which pulls it straight back out of the
+          // rename field. Declining the restore while renaming is the same guard
+          // the sidebar's inline rename needs.
+          onCloseAutoFocus={(event) => {
+            if (state.renameOpen) event.preventDefault()
+          }}
+        >
+          <AttachmentMenuBody name={name} state={state} components={CONTEXT_COMPONENTS} />
+        </ContextMenuContent>
+      </ContextMenu>
+      {state.renameDialog}
+    </>
   )
 }
 
@@ -206,44 +280,56 @@ export function AttachmentMenuButton({
   url,
   name,
   className,
-  onOpenChange
+  onOpenChange,
+  onRenamed
 }: {
   url: string
   name: string
   className?: string
   /** Extra open-state observer, chained after the resolve-on-open handler. */
   onOpenChange?: (open: boolean) => void
+  onRenamed?: AttachmentRenamedHandler
 }) {
-  const state = useAttachmentMenu(url)
+  const state = useAttachmentMenu(url, name, onRenamed)
   const { t } = useT('notes')
 
   return (
-    <DropdownMenu
-      onOpenChange={(open) => {
-        state.handleOpenChange(open)
-        onOpenChange?.(open)
-      }}
-    >
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          aria-label={t('editor.attachmentMenu.menuLabel')}
-          data-testid="attachment-menu-button"
-          // Keep the editor from treating the press as a selection change
-          // before the menu opens (same guard as the PDF alignment buttons).
-          onPointerDown={(e) => e.stopPropagation()}
-          className={cn(
-            'flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent/50',
-            className
-          )}
+    <>
+      <DropdownMenu
+        onOpenChange={(open) => {
+          state.handleOpenChange(open)
+          onOpenChange?.(open)
+        }}
+      >
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label={t('editor.attachmentMenu.menuLabel')}
+            data-testid="attachment-menu-button"
+            // Keep the editor from treating the press as a selection change
+            // before the menu opens (same guard as the PDF alignment buttons).
+            onPointerDown={(e) => e.stopPropagation()}
+            className={cn(
+              'flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent/50',
+              className
+            )}
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          sideOffset={8}
+          data-testid="attachment-dropdown-menu"
+          onCloseAutoFocus={(event) => {
+            if (state.renameOpen) event.preventDefault()
+          }}
         >
-          <MoreHorizontal className="h-4 w-4" />
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" sideOffset={8} data-testid="attachment-dropdown-menu">
-        <AttachmentMenuBody name={name} state={state} components={DROPDOWN_COMPONENTS} />
-      </DropdownMenuContent>
-    </DropdownMenu>
+          <AttachmentMenuBody name={name} state={state} components={DROPDOWN_COMPONENTS} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {state.renameDialog}
+    </>
   )
 }
 
@@ -256,6 +342,8 @@ export interface ImageMenuTarget {
   y: number
   url: string
   name: string
+  /** The image block this menu acts on, so a rename can write back to it. */
+  blockId: string
 }
 
 /**
@@ -264,12 +352,14 @@ export interface ImageMenuTarget {
  */
 export function ImageAttachmentMenu({
   target,
-  onClose
+  onClose,
+  onRenamed
 }: {
   target: ImageMenuTarget
   onClose: () => void
+  onRenamed?: AttachmentRenamedHandler
 }) {
-  const state = useAttachmentMenu(target.url)
+  const state = useAttachmentMenu(target.url, target.name, onRenamed)
   const { handleOpenChange } = state
 
   // Controlled-open: resolve immediately, since there is no opening gesture
@@ -279,14 +369,26 @@ export function ImageAttachmentMenu({
   }, [handleOpenChange])
 
   return (
-    <DropdownMenu open onOpenChange={(open) => !open && onClose()}>
-      <DropdownMenuTrigger asChild>
-        <span style={{ position: 'fixed', top: target.y, left: target.x, width: 0, height: 0 }} />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" data-testid="attachment-image-menu">
-        <AttachmentMenuBody name={target.name} state={state} components={DROPDOWN_COMPONENTS} />
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu
+        open={!state.renameOpen}
+        onOpenChange={(open) => !open && !state.renameOpen && onClose()}
+      >
+        <DropdownMenuTrigger asChild>
+          <span style={{ position: 'fixed', top: target.y, left: target.x, width: 0, height: 0 }} />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          data-testid="attachment-image-menu"
+          onCloseAutoFocus={(event) => {
+            if (state.renameOpen) event.preventDefault()
+          }}
+        >
+          <AttachmentMenuBody name={target.name} state={state} components={DROPDOWN_COMPONENTS} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {state.renameDialog}
+    </>
   )
 }
 
@@ -297,6 +399,8 @@ export function ImageAttachmentMenu({
 export interface HoverImageTarget {
   url: string
   name: string
+  /** The image block this menu acts on, so a rename can write back to it. */
+  blockId: string
   /** Viewport coordinates for the button, from the image's bounding rect. */
   x: number
   y: number
@@ -313,10 +417,12 @@ export interface HoverImageTarget {
  */
 export function ImageHoverMenuButton({
   target,
-  onOpenChange
+  onOpenChange,
+  onRenamed
 }: {
   target: HoverImageTarget
   onOpenChange?: (open: boolean) => void
+  onRenamed?: AttachmentRenamedHandler
 }) {
   return (
     <div
@@ -327,6 +433,7 @@ export function ImageHoverMenuButton({
         url={target.url}
         name={target.name}
         onOpenChange={onOpenChange}
+        onRenamed={onRenamed}
         className="h-6 w-6 rounded-md border border-border bg-background/90 shadow-sm"
       />
     </div>
@@ -342,7 +449,7 @@ export function ImageHoverMenuButton({
  */
 export function useImageHoverMenu(
   containerRef: React.RefObject<HTMLElement | null>,
-  resolveImage: (el: HTMLElement) => { url: string; name: string } | null
+  resolveImage: (el: HTMLElement) => { url: string; name: string; blockId: string } | null
 ): {
   hoverTarget: HoverImageTarget | null
   handleMenuOpenChange: (open: boolean) => void

--- a/apps/desktop/src/renderer/src/components/note/content-area/attachment-rename-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/attachment-rename-dialog.tsx
@@ -7,7 +7,9 @@
  * would promise something the rename cannot deliver.
  */
 
-import { useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { extractErrorMessage } from '@/lib/ipc-error'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -19,12 +21,32 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { useT } from '@memry/i18n/renderer'
+import { useAttachmentNoteId } from './note-file-url-context'
+
+/** What a surface does with a completed rename — see `AttachmentRenameFlow`. */
+export type AttachmentRenamedHandler = (next: { url: string; name: string }) => void
 
 /** `report.pdf` → `['report', '.pdf']`; a dotless name keeps an empty suffix. */
 export function splitExtension(name: string): [string, string] {
   const dot = name.lastIndexOf('.')
   if (dot <= 0) return [name, '']
   return [name.slice(0, dot), name.slice(dot)]
+}
+
+/** The `{6-char nanoid}-` prefix every stored attachment filename carries. */
+const STORED_PREFIX_RE = /^[0-9a-z]{6}-/
+
+/**
+ * What the field starts on.
+ *
+ * An image block often has no display name of its own, so the caller falls back
+ * to the STORED filename — which carries the nanoid prefix. Offering that as
+ * the editable text made an untouched Rename produce `k3f9x2-k3f9x2-photo.png`,
+ * since main puts the prefix back on whatever is typed.
+ */
+export function renameFieldValue(name: string): string {
+  const [base, extension] = splitExtension(name)
+  return `${base.replace(STORED_PREFIX_RE, '') || base}${extension}`
 }
 
 export function AttachmentRenameDialog({
@@ -42,7 +64,7 @@ export function AttachmentRenameDialog({
 }) {
   const { t } = useT('notes')
   const { t: tCommon } = useT('common')
-  const [base, extension] = splitExtension(currentName)
+  const [base, extension] = splitExtension(renameFieldValue(currentName))
   // Mounted per open (the menu renders it only while renaming), so the initial
   // state IS the current name — no effect syncing a prop into state, and no
   // draft surviving from the last block whose menu was open.
@@ -87,5 +109,67 @@ export function AttachmentRenameDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  )
+}
+
+/**
+ * The rename itself: the IPC call, its in-flight state, and the dialog.
+ *
+ * Owned by whoever can keep it mounted, which is NOT always the menu. The image
+ * surfaces are rendered by the editor only while their menu is open or the
+ * pointer is over the image, so a dialog parented to them unmounts the instant
+ * the menu closes — the click did nothing at all. Those hosts render this
+ * themselves; the file block, whose menu button lives in a card that stays
+ * mounted, lets the menu render it.
+ */
+export function AttachmentRenameFlow({
+  url,
+  name,
+  open,
+  onOpenChange,
+  onRenamed
+}: {
+  url: string
+  name: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onRenamed: AttachmentRenamedHandler
+}) {
+  const noteId = useAttachmentNoteId()
+  const { t } = useT('notes')
+  const [busy, setBusy] = useState(false)
+
+  const submit = useCallback(
+    (nextName: string) => {
+      if (!noteId) return
+      setBusy(true)
+      window.api.notes
+        .renameAttachment(noteId, url, nextName)
+        .then((result) => {
+          // Disk first, block second: main has already renamed the file, so the
+          // block MUST take the result — a block left on the old ref only
+          // survives through self-heal.
+          onRenamed({ url: result.url, name: result.name })
+          onOpenChange(false)
+          toast.success(t('editor.attachmentRename.renamed', { name: result.name }))
+        })
+        .catch((err: unknown) => {
+          toast.error(extractErrorMessage(err, t('editor.attachmentRename.failed')))
+        })
+        .finally(() => setBusy(false))
+    },
+    [noteId, url, onRenamed, onOpenChange, t]
+  )
+
+  if (!open) return null
+
+  return (
+    <AttachmentRenameDialog
+      open
+      onOpenChange={onOpenChange}
+      currentName={name}
+      busy={busy}
+      onSubmit={submit}
+    />
   )
 }

--- a/apps/desktop/src/renderer/src/components/note/content-area/attachment-rename-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/attachment-rename-dialog.tsx
@@ -1,0 +1,91 @@
+/**
+ * Rename dialog for an attachment block (#1714).
+ *
+ * The field starts on the name without its extension, selected, because the
+ * extension is the one part a rename may not change — main keeps it (and the
+ * stored nanoid prefix) whatever the user types, so offering it for editing
+ * would promise something the rename cannot deliver.
+ */
+
+import { useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { useT } from '@memry/i18n/renderer'
+
+/** `report.pdf` → `['report', '.pdf']`; a dotless name keeps an empty suffix. */
+export function splitExtension(name: string): [string, string] {
+  const dot = name.lastIndexOf('.')
+  if (dot <= 0) return [name, '']
+  return [name.slice(0, dot), name.slice(dot)]
+}
+
+export function AttachmentRenameDialog({
+  open,
+  onOpenChange,
+  currentName,
+  busy,
+  onSubmit
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  currentName: string
+  busy: boolean
+  onSubmit: (nextName: string) => void
+}) {
+  const { t } = useT('notes')
+  const { t: tCommon } = useT('common')
+  const [base, extension] = splitExtension(currentName)
+  // Mounted per open (the menu renders it only while renaming), so the initial
+  // state IS the current name — no effect syncing a prop into state, and no
+  // draft surviving from the last block whose menu was open.
+  const [value, setValue] = useState(base)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const trimmed = value.trim()
+  const submit = (): void => {
+    if (!trimmed || busy) return
+    onSubmit(`${trimmed}${extension}`)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md" data-testid="attachment-rename-dialog">
+        <DialogHeader>
+          <DialogTitle>{t('editor.attachmentRename.title')}</DialogTitle>
+          <DialogDescription>{t('editor.attachmentRename.description')}</DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center gap-2">
+          <Input
+            ref={inputRef}
+            autoFocus
+            value={value}
+            aria-label={t('editor.attachmentRename.fieldLabel')}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key !== 'Enter') return
+              e.preventDefault()
+              submit()
+            }}
+          />
+          {extension && <span className="shrink-0 text-sm text-muted-foreground">{extension}</span>}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            {tCommon('button.cancel')}
+          </Button>
+          <Button onClick={submit} disabled={!trimmed || busy}>
+            {t('editor.attachmentRename.confirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createFileBlock,
@@ -503,5 +504,64 @@ describe('FileBlock missing attachment card (#1713)', () => {
     expect(await screen.findByTestId('pdf-document')).toBeInTheDocument()
     expect(resolveAttachment).toHaveBeenCalled()
     expect(screen.queryByTestId('attachment-missing-card')).not.toBeInTheDocument()
+  })
+})
+
+describe('FileBlock rename (#1714)', () => {
+  // A plain file card rather than a PDF: the menu button is in the card itself,
+  // with no react-pdf load step in the way.
+  const RELATIVE = '../attachments/note1/abc123-manual.txt'
+  let savedNotesApi: unknown
+
+  afterEach(() => {
+    ;(window.api as unknown as Record<string, unknown>).notes = savedNotesApi
+  })
+
+  it('records the renamed url and name on the block', async () => {
+    const api = window.api as unknown as Record<string, unknown>
+    savedNotesApi = api.notes
+    api.notes = {
+      ...((api.notes as Record<string, unknown>) ?? {}),
+      resolveAttachment: vi.fn().mockResolvedValue({
+        absolutePath: '/vault/attachments/note1/abc123-manual.txt',
+        storedFilename: 'abc123-manual.txt',
+        exists: true
+      }),
+      renameAttachment: vi.fn().mockResolvedValue({
+        storedFilename: 'abc123-invoice.txt',
+        url: '../attachments/note1/abc123-invoice.txt',
+        name: 'invoice.txt'
+      })
+    }
+
+    const updateBlock = vi.fn()
+    const block = {
+      props: { url: RELATIVE, name: 'manual.txt', size: 2048, mimeType: 'text/plain' }
+    }
+    const Render = (createFileBlock as any).render
+    render(
+      <NoteFileUrlProvider resolveFileUrl={async (url) => url} noteId="note1">
+        <Render contentRef={vi.fn()} editor={{ updateBlock }} block={block} />
+      </NoteFileUrlProvider>
+    )
+
+    const user = userEvent.setup()
+    const menuButtons = await screen.findAllByTestId('attachment-menu-button')
+    await user.click(menuButtons[0])
+    await user.click(
+      await screen.findByRole('menuitem', { name: 'editor.attachmentRename.menuItem' })
+    )
+    await user.click(screen.getByRole('button', { name: 'editor.attachmentRename.confirm' }))
+
+    // Main renamed the file already; the block recording it is what carries the
+    // rename into the note — and from there to the other devices.
+    await waitFor(() => {
+      expect(updateBlock).toHaveBeenCalledWith(block, {
+        props: expect.objectContaining({
+          url: '../attachments/note1/abc123-invoice.txt',
+          name: 'invoice.txt'
+        })
+      })
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -828,6 +828,17 @@ function FileBlockRender({
     [editor, block]
   )
 
+  // The file on disk is already renamed when this runs (#1714); writing the new
+  // ref into the block is what records the rename in the note — and what carries
+  // it to the other devices, which rename their own copy from the body change.
+  const handleRenamed = useCallback(
+    (next: { url: string; name: string }) => {
+      const fileEditor = editor as FileBlockEditor | undefined
+      fileEditor?.updateBlock(block, { props: { ...block.props, url: next.url, name: next.name } })
+    },
+    [editor, block]
+  )
+
   // Don't render if no URL
   if (!url) {
     return (
@@ -846,13 +857,13 @@ function FileBlockRender({
 
   // The raw stored url goes to the menu, never `resolvedUrl` — main re-resolves
   // and validates it against the vault itself.
-  const menuButton = <AttachmentMenuButton url={url} name={name} />
+  const menuButton = <AttachmentMenuButton url={url} name={name} onRenamed={handleRenamed} />
 
   // The file is gone from disk and self-heal found no unique match: name the
   // expected file so the user can repair the rename by hand (#1713).
   if (presence.missing) {
     return (
-      <AttachmentBlockContextMenu url={url} name={name}>
+      <AttachmentBlockContextMenu url={url} name={name} onRenamed={handleRenamed}>
         <div ref={contentRef} className="file-block my-2" contentEditable={false}>
           <MissingAttachmentCard
             name={name}
@@ -865,7 +876,7 @@ function FileBlockRender({
   }
 
   return (
-    <AttachmentBlockContextMenu url={url} name={name}>
+    <AttachmentBlockContextMenu url={url} name={name} onRenamed={handleRenamed}>
       <div ref={contentRef} className="file-block my-2" contentEditable={false}>
         {isPdf ? (
           <PdfPreview

--- a/apps/desktop/tests/e2e/attachment-block-menu.e2e.ts
+++ b/apps/desktop/tests/e2e/attachment-block-menu.e2e.ts
@@ -13,6 +13,7 @@
  * `src/main/vault/attachment-actions.test.ts`.
  */
 
+import fs from 'fs'
 import path from 'path'
 import type { Page } from '@playwright/test'
 import { test, expect } from './fixtures'
@@ -164,6 +165,57 @@ test.describe('Attachment block menu', () => {
     expect(clipboardText).toBe(
       path.join(testVaultPath, 'attachments', attachmentNoteId, storedFilename)
     )
+  })
+
+  test('rename renames the file on disk and rewrites the block ref in the note', async ({
+    page,
+    testVaultPath
+  }) => {
+    await ready(page)
+    const title = uniqueLabel('Attachment Rename')
+    const { noteId, attachmentNoteId, storedFilename } = await seedNoteWithFileBlock(
+      page,
+      testVaultPath,
+      title
+    )
+
+    const card = page.locator('.file-attachment').first()
+    await card.hover()
+    await card.locator('[data-testid="attachment-menu-button"]').click()
+    await page
+      .locator('[data-testid="attachment-dropdown-menu"]')
+      .getByRole('menuitem', { name: 'Rename…' })
+      .click()
+
+    const dialog = page.locator('[data-testid="attachment-rename-dialog"]')
+    await expect(dialog).toBeVisible()
+    await dialog.getByLabel('Attachment name').fill('quarterly-report')
+    await dialog.getByRole('button', { name: 'Rename', exact: true }).click()
+
+    // The nanoid prefix survives; the middle segment is what changed.
+    const prefix = storedFilename.slice(0, 7)
+    const renamed = `${prefix}quarterly-report.txt`
+    const folder = path.join(testVaultPath, 'attachments', attachmentNoteId)
+    await expect
+      .poll(() => fs.existsSync(path.join(folder, renamed)), { timeout: 10_000 })
+      .toBe(true)
+    expect(fs.existsSync(path.join(folder, storedFilename))).toBe(false)
+
+    // The block shows the new name...
+    await expect(card.getByText('quarterly-report.txt')).toBeVisible()
+
+    // ...and the note's own markdown carries the new ref, which is the only
+    // thing that reaches the other devices — the blob is never re-uploaded.
+    const notePath = await page.evaluate(
+      async (id) => (await window.api.notes.get(id))?.path,
+      noteId
+    )
+    expect(notePath).toBeTruthy()
+    await expect
+      .poll(() => fs.readFileSync(path.join(testVaultPath, notePath as string), 'utf8'), {
+        timeout: 15_000
+      })
+      .toContain(renamed)
   })
 
   test('right-click on the block opens the same menu', async ({ page, testVaultPath }) => {

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -32,12 +32,28 @@ Every attachment block — the file card, the audio player, and the inline PDF p
 - **Reveal in Finder** — show the stored file in your OS file manager. On Windows the item reads **Show in Explorer**, on Linux **Show in file manager**; this guide calls it **Reveal in Finder** throughout.
 - **Open in default app** — hand the file to whatever your OS opens that type with
 - **Copy path** — put the file's absolute on-disk path on the clipboard
+- **Rename…** — give the file a better name, on disk and on your other devices
 
 The menu's header shows the **original filename** and the name the file is **stored as** on disk. Attachments are saved under `<vault>/attachments/<note-id>/` with a short random prefix (`k3f9x2-report.pdf`), so this menu is the way to find or forward the original file without hunting through the vault by hand.
 
 If the file hasn't synced to this device yet, the menu still shows both names, but the actions stay disabled until the download lands.
 
 Image blocks get the same menu too: hovering the image floats the `⋯` button over its top corner, and a right-click on the image opens the menu directly.
+
+### Renaming an Attachment
+
+Files arrive with the name whatever produced them chose — `scan_0031.pdf`, `IMG_4471.png`. **Rename…** in the block menu fixes that for good: type a new name and MemryNote renames the file **on disk**, updates the block, and carries the rename to your other devices.
+
+Two things stay as they are, on purpose:
+
+- **The extension.** A `.pdf` stays a `.pdf`, so the block keeps rendering it as one. The dialog shows the extension next to the field rather than letting you edit it.
+- **The 6-character prefix.** `k3f9x2-scan.pdf` becomes `k3f9x2-invoice.pdf`. That prefix is what keeps two files with the same name apart, and what lets every other device recognise the file it already has as the one that was renamed.
+
+If the name you type is already taken inside that note's attachments folder, the file gets a `-2` (then `-3`, …) rather than overwriting anything.
+
+**Across devices**, nothing is re-uploaded — only the note travels. Each device renames its own copy of the file when the note's change arrives, so the file ends up with the same name everywhere, and the embed keeps working the whole time. A device that has not downloaded the file yet renames it as soon as it does. A device running an older build keeps showing the file correctly through the self-heal described below; it just keeps the old name on its own disk until it updates.
+
+A file renamed **outside** the app is a different case and is left alone — see below.
 
 ### The Attachments Panel
 
@@ -52,6 +68,8 @@ The attachments folder is yours to look at, and files in it sometimes get rename
 Now a missing file **heals at load time**: MemryNote looks for the renamed file inside the same note's attachments folder — a file that kept its 6-character prefix, or kept its name and lost the prefix — and serves it when the match is unambiguous. The note itself is never rewritten, so the repair is safe across synced devices; each device resolves against its own disk.
 
 If there is no safe match (the file is gone, or two candidates look equally likely), the block shows a card naming **the exact filename it expected**, so you can restore the name by hand. Renaming the file back — or to anything that keeps its prefix — fixes the block on the next load.
+
+A rename you make in Finder is never undone by MemryNote: it repairs the link, not your file. Only a **Rename…** from the block menu changes a name on disk, and only that rename travels between devices.
 
 ## PDF Inline Preview
 

--- a/packages/contracts/src/notes-api.ts
+++ b/packages/contracts/src/notes-api.ts
@@ -168,6 +168,23 @@ export const AttachmentActionSchema = z.object({
   url: z.string().min(1)
 })
 
+export const AttachmentRenameSchema = z.object({
+  noteId: z.string(),
+  /** Raw `props.url` from a file/image block — note-relative or legacy `memry-file://local/…` */
+  url: z.string().min(1),
+  /** What the user typed. Sanitized in main; the nanoid prefix and extension are kept. */
+  newName: z.string().min(1).max(200)
+})
+
+export interface AttachmentRenameResult {
+  /** New basename on disk, e.g. `k3f9x2-invoice.pdf` */
+  storedFilename: string
+  /** New note-relative ref for the block's `url` prop */
+  url: string
+  /** New display name for the block's `name` prop */
+  name: string
+}
+
 export interface AttachmentResolveResult {
   /** Absolute on-disk path, remapped to this device's vault for cross-device notes */
   absolutePath: string
@@ -510,5 +527,6 @@ export interface NotesClientAPI {
   resolveAttachment(noteId: string, url: string): Promise<AttachmentResolveResult>
   revealAttachmentInFinder(noteId: string, url: string): Promise<void>
   openAttachmentExternal(noteId: string, url: string): Promise<void>
+  renameAttachment(noteId: string, url: string, newName: string): Promise<AttachmentRenameResult>
   applyTemplate(input: z.infer<typeof ApplyTemplateSchema>): Promise<NoteUpdateResponse>
 }

--- a/packages/contracts/src/notes-channels.ts
+++ b/packages/contracts/src/notes-channels.ts
@@ -83,6 +83,8 @@ export const NotesChannels = {
     ATTACHMENT_REVEAL_IN_FINDER: 'notes:attachment-reveal-in-finder',
     /** Open an attachment with the OS default app */
     ATTACHMENT_OPEN_EXTERNAL: 'notes:attachment-open-external',
+    /** Rename an attachment on disk, keeping its nanoid prefix and extension */
+    ATTACHMENT_RENAME: 'notes:attachment-rename',
     /** Get folder config (template settings) */
     GET_FOLDER_CONFIG: 'notes:get-folder-config',
     /** Set folder config (template settings) */

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -177,6 +177,15 @@
       "missingTitle": "Attachment file missing",
       "missingExpected": "Expected file: {name}"
     },
+    "attachmentRename": {
+      "menuItem": "Rename…",
+      "title": "Rename attachment",
+      "description": "The file is renamed on disk and on your other devices. Its extension stays the same.",
+      "fieldLabel": "Attachment name",
+      "confirm": "Rename",
+      "renamed": "Renamed to {name}",
+      "failed": "Failed to rename attachment"
+    },
     "attachmentsDialog": {
       "title": "Attachments",
       "description": "Files stored with this note",

--- a/packages/rpc/src/notes.ts
+++ b/packages/rpc/src/notes.ts
@@ -5,6 +5,7 @@ import type {
   StatusCategoryKey
 } from '../../contracts/src/property-types.ts'
 import type {
+  AttachmentRenameResult,
   AttachmentResolveResult,
   NoteSizeClass,
   NoteLargeFileInfo,
@@ -550,6 +551,13 @@ export const notesRpc = defineDomain({
       channel: NotesChannels.invoke.ATTACHMENT_OPEN_EXTERNAL,
       params: ['noteId', 'url'],
       invokeArgs: ['{ noteId, url }']
+    }),
+    renameAttachment: defineMethod<
+      (noteId: string, url: string, newName: string) => Promise<AttachmentRenameResult>
+    >({
+      channel: NotesChannels.invoke.ATTACHMENT_RENAME,
+      params: ['noteId', 'url', 'newName'],
+      invokeArgs: ['{ noteId, url, newName }']
     }),
     getPropertyDefinitions: defineMethod<() => Promise<PropertyDefinition[]>>({
       channel: NotesChannels.invoke.GET_PROPERTY_DEFINITIONS


### PR DESCRIPTION
## Summary

Adds **Rename…** to the attachment block menu (file / PDF / audio cards, image blocks, and the right-click context menu), and makes that rename land on every device's disk.

Closes #1714.

**What a rename does**
- Renames the file on disk, keeping the `{6-char nanoid}-` prefix and the extension. The dialog edits only the middle segment; the extension is shown beside the field, not edited.
- Rewrites the block's `url` + `name`, which is what records the rename in the note.
- Collisions inside the note's attachments folder get `-2`, `-3`, … rather than overwriting. Submitting the name the file already has is a no-op.
- Order is **disk first, body second**: a crash in that window leaves the body on the old name, which self-heal (#1713) already repairs by prefix. The reverse order would leave the body naming a file that exists nowhere.

**Sync semantics — nothing is re-uploaded**
The blob and its encrypted manifest are untouched (the manifest's filename stays frozen at whatever it was at upload). Only the note body travels, through the ordinary CRDT path. No new sync item type, no new DB column, no change to the note payload shape — so an older client is unaffected: it sees a body whose ref differs from its disk and falls back to self-heal, exactly as it does today for an externally renamed file.

Peers converge their own disk from two narrow, evidence-backed points:
1. **Write-back diff** (`crdt-writeback.ts`) — when a body replaces another, a ref that disappeared plus a ref that arrived under the same nanoid prefix *is* the rename that just arrived. That device renames its own copy.
2. **Post-download** (`sync-attachment-handlers.ts`) — a file materialized after the rename lands under the manifest's old name, so it is renamed to what the body asks for right after the download.

**Deliberately not a general "make the folder match the body" pass.** A file renamed by hand in Finder (#1713's case) produces no body change and is never touched — it keeps the user's name and keeps being served through self-heal. Only an in-app rename moves a file on disk, and only an in-app rename travels.

## Release note

Attachments can now be renamed from the block menu. The file is renamed on disk — keeping its extension — and the new name reaches your other devices without re-uploading anything.

## Test plan

New tests
- `src/main/vault/attachment-rename.test.ts` (15) — name shaping, extension/prefix retention, collision walk, same-name no-op, "this note's folder only" guard, renaming a self-healed file, empty-name rejection.
- `src/main/vault/attachment-rename-reconcile.test.ts` (17) — ref extraction across file markers / image links / legacy `memry-file://` urls, rename pairing (including two renames in one body change and the ambiguous cases it refuses), the peer-side disk rename, no-op on the originating device, never overwriting an existing target, **and that an external rename with an unchanged body is left alone**, plus the post-download rename.
- `crdt-writeback.test.ts` (+2) — the write-back hands old and new body to the reconcile; a throwing reconcile does not make a successful write-back look failed.
- `sync-attachment-handlers.test.ts` (+2) — an embedded (`intoDir`) download is reconciled; a binary-note download is not.
- `attachment-block-menu.test.tsx` (+3) — Rename is offered only where the result can be written back, the IPC round trip hands the new url/name to the block, a failed rename keeps the dialog open and leaves the block alone.
- `file-block.test.tsx` (+1) — a completed rename is recorded on the block props.
- `attachment-block-menu.e2e.ts` (+1) — rename from the menu → the file is renamed on disk and the note's markdown carries the new ref.

Gates run locally (after rebase onto `main`)
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm --filter @memry/desktop i18n:check` ✅
- `pnpm ipc:check` ✅ (bindings regenerated via `pnpm ipc:generate`)
- `pnpm docs:impact --base origin/main --strict` ✅ · `pnpm docs:build` ✅
- Affected suites: main 91 ✅ (4 files), renderer 25 ✅ (2 files)

Not run locally: the full `pnpm test:desktop` sweep and the new E2E spec — CI covers both.

## Reviewer notes
- `apps/docs/src/user-guide/notes/attachments.md` documents the rename, what stays fixed (extension + prefix), the collision rule, the cross-device behaviour, and explicitly that a Finder rename is never undone.
- The reconcile deliberately refuses to guess: an ambiguous prefix (two candidates on either side of the diff) is left alone, and a prefix-less legacy filename carries no identity to pair on, so it is skipped.
