### PR TITLE
fix(account): free-plan sync upsell + signed-in checkout on /account/sync

### DIFF
--- a/apps/desktop/src/main/billing/paddle-billing.ts
+++ b/apps/desktop/src/main/billing/paddle-billing.ts
@@ -12,7 +12,9 @@ import {
 } from './entitlement-cache'
 
 const log = createLogger('Billing')
-const DEFAULT_CHECKOUT_PAGE_URL = 'https://memrynote.com/checkout'
+// The account-area plan picker; it accepts the desktop-minted checkout token
+// in the hash so the user lands signed-in-like, with no separate web login.
+const DEFAULT_CHECKOUT_PAGE_URL = 'https://memrynote.com/account/sync'
 
 export type BillingPlanId = 'plus' | 'pro' | 'believer'
 export type BillingCadence = 'monthly' | 'annual' | 'lifetime'

--- a/apps/desktop/src/main/ipc/account-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/account-handlers.test.ts
@@ -145,12 +145,12 @@ describe('account-handlers', () => {
 
     await expect(invokeHandler(AccountChannels.invoke.START_CHECKOUT)).resolves.toEqual({
       success: true,
-      checkoutUrl: 'https://memrynote.com/checkout#token=checkout-token-1'
+      checkoutUrl: 'https://memrynote.com/account/sync#token=checkout-token-1'
     })
 
     expect(mocks.postToServer).toHaveBeenCalledWith('/auth/checkout-token', {}, 'token-1')
     expect(mocks.shellOpenExternal).toHaveBeenCalledWith(
-      'https://memrynote.com/checkout#token=checkout-token-1'
+      'https://memrynote.com/account/sync#token=checkout-token-1'
     )
   })
 

--- a/apps/desktop/src/renderer/src/hooks/use-sync-hooks.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-sync-hooks.test.tsx
@@ -116,8 +116,13 @@ describe('sync hooks', () => {
     rerender()
     expect(result.current.label).toBe('account.sync.statuses.offlinePending{"count":5}')
 
-    mocks.syncState.status = 'unknown-status'
+    mocks.syncState.status = 'local_only'
     mocks.syncState.pendingCount = 0
+    rerender()
+    expect(result.current.label).toBe('account.sync.statuses.localOnly')
+    expect(result.current.dotColor).toBe('bg-gray-400')
+
+    mocks.syncState.status = 'unknown-status'
     mocks.syncState.error = 'sync failed'
     mocks.syncState.conflicts = [{ itemId: 'n1', itemType: 'note', detectedAt: 1 }]
     rerender()

--- a/apps/desktop/src/renderer/src/hooks/use-sync-status.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-sync-status.ts
@@ -15,7 +15,7 @@ import { useSync } from '@/contexts/sync-context'
 import { notesService } from '@/services/notes-service'
 import { useT } from '@memry/i18n/renderer'
 
-type SyncStatusType = 'idle' | 'syncing' | 'paused' | 'error' | 'offline' | 'unknown'
+type SyncStatusType = 'idle' | 'syncing' | 'paused' | 'error' | 'offline' | 'local_only' | 'unknown'
 
 interface SyncStatusDisplay {
   label: string
@@ -76,6 +76,14 @@ const STATUS_MAP: Record<string, Omit<SyncStatusDisplay, 'label'> & { labelKey: 
   },
   offline: {
     labelKey: 'account.sync.statuses.offline',
+    dotColor: 'bg-gray-400',
+    IconComponent: CloudOff,
+    isAnimating: false
+  },
+  // Free plan: main gates the sync runtime and reports `local_only`, a status
+  // outside the renderer SyncStatus union (see use-home-seed-gate.ts).
+  local_only: {
+    labelKey: 'account.sync.statuses.localOnly',
     dotColor: 'bg-gray-400',
     IconComponent: CloudOff,
     isAnimating: false

--- a/apps/desktop/src/renderer/src/pages/settings/account-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/account-section.tsx
@@ -266,6 +266,9 @@ export function AccountSettings() {
   const initial = (email ?? 'U').charAt(0).toUpperCase()
   const isSyncActive = syncStatus.status !== 'paused'
   const isToggleDisabled = syncStatus.status === 'syncing' || syncStatus.status === 'offline'
+  // Free plan (or any unpaid account main gated into `local_only`): sync never
+  // connects, so the status row would sit on "Connecting..." forever.
+  const isSyncLocked = billing?.plan === 'free' || syncStatus.status === 'local_only'
   const storageCategoryLabels: Record<string, string> = {
     notes: t('account.storage.categories.notes'),
     attachments: t('account.storage.categories.attachments'),
@@ -312,29 +315,57 @@ export function AccountSettings() {
       </div>
 
       <SettingsGroup label={t('account.groups.sync')}>
-        <div className="flex items-center justify-between h-11 px-4 shrink-0">
-          <div className="flex items-center gap-2">
-            <div
-              className={`size-2 shrink-0 rounded-full ${syncStatus.dotColor} ${
-                syncStatus.isAnimating ? 'motion-safe:animate-pulse' : ''
-              }`}
-            />
-            <div className="flex flex-col gap-px">
-              <span className="font-medium text-[13px]/4 text-foreground">{syncStatus.label}</span>
+        {isSyncLocked ? (
+          <div className="flex items-center justify-between gap-3 px-4 py-3.5">
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <span className="font-medium text-[13px]/4 text-foreground">
+                {t('account.sync.upsell.title')}
+              </span>
               <span className="text-xs/4 text-muted-foreground">
-                {t('account.sync.lastSynced', { time: syncStatus.lastSyncLabel })}
-                {syncStatus.pendingCount > 0 &&
-                  ` · ${t('account.sync.pending', { count: syncStatus.pendingCount })}`}
+                {t('account.sync.upsell.description')}
               </span>
             </div>
+            <Button
+              variant="default"
+              size="sm"
+              onClick={() => void handleStartCheckout()}
+              disabled={isCheckoutStarting}
+              className="h-7 shrink-0 px-3 text-xs/4"
+            >
+              {isCheckoutStarting
+                ? t('account.billing.actions.opening')
+                : t('account.billing.actions.unlockSync')}
+            </Button>
           </div>
-          <Switch
-            checked={isSyncActive}
-            disabled={isToggleDisabled}
-            onCheckedChange={(checked) => void (checked ? syncStatus.resume() : syncStatus.pause())}
-            className={ACCENT_SWITCH}
-          />
-        </div>
+        ) : (
+          <div className="flex items-center justify-between h-11 px-4 shrink-0">
+            <div className="flex items-center gap-2">
+              <div
+                className={`size-2 shrink-0 rounded-full ${syncStatus.dotColor} ${
+                  syncStatus.isAnimating ? 'motion-safe:animate-pulse' : ''
+                }`}
+              />
+              <div className="flex flex-col gap-px">
+                <span className="font-medium text-[13px]/4 text-foreground">
+                  {syncStatus.label}
+                </span>
+                <span className="text-xs/4 text-muted-foreground">
+                  {t('account.sync.lastSynced', { time: syncStatus.lastSyncLabel })}
+                  {syncStatus.pendingCount > 0 &&
+                    ` · ${t('account.sync.pending', { count: syncStatus.pendingCount })}`}
+                </span>
+              </div>
+            </div>
+            <Switch
+              checked={isSyncActive}
+              disabled={isToggleDisabled}
+              onCheckedChange={(checked) =>
+                void (checked ? syncStatus.resume() : syncStatus.pause())
+              }
+              className={ACCENT_SWITCH}
+            />
+          </div>
+        )}
       </SettingsGroup>
 
       <SettingsGroup label={t('account.groups.billing')}>
@@ -464,7 +495,9 @@ export function AccountSettings() {
             >
               {isCheckoutStarting
                 ? t('account.billing.actions.opening')
-                : t('account.billing.actions.upgrade')}
+                : isSyncLocked
+                  ? t('account.billing.actions.unlockSync')
+                  : t('account.billing.actions.upgrade')}
             </Button>
             <Button
               variant="outline"

--- a/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
@@ -526,8 +526,9 @@ describe('settings section coverage', () => {
       'https://github.com/memrynote/memry/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+'
     )
 
-    fireEvent.click(screen.getByRole('switch'))
-    expect(mocks.syncStatus.pause).toHaveBeenCalled()
+    // Free plan: the sync toggle is replaced by the upgrade upsell.
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+    expect(screen.getByText('account.sync.upsell.title')).toBeInTheDocument()
 
     fireEvent.click(screen.getByText('link device'))
     expect(screen.getByText('qr linking')).toBeInTheDocument()
@@ -541,7 +542,8 @@ describe('settings section coverage', () => {
     render(<AccountSettings />)
     expect((await screen.findAllByText('account.billing.plans.free')).length).toBeGreaterThan(0)
 
-    fireEvent.click(screen.getByText('account.billing.actions.upgrade'))
+    // Free plan renders the marketing CTA in both the sync upsell and billing.
+    fireEvent.click(screen.getAllByText('account.billing.actions.unlockSync')[0])
     await waitFor(() => expect(window.api.account.startCheckout).toHaveBeenCalledWith())
 
     fireEvent.click(screen.getByText('account.billing.actions.refresh'))
@@ -552,6 +554,29 @@ describe('settings section coverage', () => {
 
     fireEvent.click(screen.getByText('account.billing.actions.manage'))
     await waitFor(() => expect(window.api.account.openBillingPortal).toHaveBeenCalled())
+  })
+
+  it('shows the sync toggle for a paid plan and pauses sync on toggle', async () => {
+    ;(window.api.account.getBillingStatus as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      plan: 'pro',
+      status: 'active',
+      source: 'paddle',
+      limits: {
+        storageLimit: 10 * 1024 * 1024 * 1024,
+        maxFileSize: 200 * 1024 * 1024,
+        maxVaults: 10,
+        versionHistoryDays: 365
+      },
+      usage: { storageUsed: 1536 },
+      expiresAt: null,
+      canManageBilling: true
+    })
+    render(<AccountSettings />)
+    expect((await screen.findAllByText('account.billing.plans.pro')).length).toBeGreaterThan(0)
+    expect(screen.queryByText('account.sync.upsell.title')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('switch'))
+    expect(mocks.syncStatus.pause).toHaveBeenCalled()
   })
 
   it('renders setup while recovery confirmation is still pending', () => {

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -25,12 +25,17 @@ The signed-in email and current subscription plan. Read-only — sign in or out 
 
 A toggle to enable or pause cloud sync, plus a status indicator and the time of the last successful sync.
 
+On the free plan sync stays local-only, so the status shows **Local only** and this group swaps the
+toggle for an upgrade card with an **Unlock Sync** button that opens the plan picker in your
+browser.
+
 ### Billing
 
 Shows the current sync plan, activation state, storage limit, max file size, synced vault limit, and
-version-history window. **Upgrade** opens the plan page in your browser, where you choose a plan
-(Plus, Pro, or Believer) and billing frequency (monthly or yearly) before continuing to Paddle
-checkout. **Refresh status** asks the sync server to reconcile the latest Paddle transaction, and
+version-history window. **Upgrade** (labelled **Unlock Sync** on the free plan) opens the plan
+picker at `memrynote.com/account/sync` in your browser — no separate web login needed — where you
+choose a plan (Plus, Pro, or Believer) and billing frequency (monthly or yearly) before continuing
+to Paddle checkout. **Refresh status** asks the sync server to reconcile the latest Paddle transaction, and
 **Manage billing** opens Paddle's hosted customer portal when the account has a Paddle customer id.
 
 If checkout succeeds before the webhook finishes, Billing shows **Activation pending**. Use

--- a/apps/docs/src/user-guide/sync/how-sync-works.md
+++ b/apps/docs/src/user-guide/sync/how-sync-works.md
@@ -29,7 +29,8 @@ All record sync, CRDT sync, WebSocket sync notifications, and encrypted blob upl
 the active plan on the sync server. The server still stores only ciphertext.
 
 Start a paid plan from **Settings -> Account -> Billing** or **Upgrade to Pro** in the sidebar
-account menu. memrynote opens checkout on `memrynote.com/pricing`; after Paddle completes payment,
+account menu. memrynote opens the plan picker on `memrynote.com/account/sync`, carrying a checkout
+token so you land there without a separate web login; after Paddle completes payment,
 return to the app from the success page so the desktop can reconcile the transaction and refresh
 sync. If the webhook is still processing, Billing shows **Activation pending** with a refresh button
 and the billing support email.

--- a/apps/landing/src/components/account/RequireAuth.tsx
+++ b/apps/landing/src/components/account/RequireAuth.tsx
@@ -1,10 +1,17 @@
 import type { ReactNode } from 'react'
-import { Navigate } from 'react-router'
+import { Navigate, useLocation } from 'react-router'
 import { useAuth } from '@/contexts/auth-context'
+import { parseCheckoutToken } from '@/lib/checkout-summary'
 
 export function RequireAuth({ children }: { children: ReactNode }) {
   const { ready, isSignedIn } = useAuth()
+  const location = useLocation()
+  // Desktop hands free users a checkout token at /account/sync#token=... so
+  // they can pick a plan without a separate web login; only that route is
+  // reachable this way — the other account tabs still require a session.
+  const hasCheckoutHandoff =
+    location.pathname === '/account/sync' && parseCheckoutToken(location.hash) != null
   if (!ready) return null // avoid SSR/first-paint flash
-  if (!isSignedIn) return <Navigate to="/login" replace />
+  if (!isSignedIn && !hasCheckoutHandoff) return <Navigate to="/login" replace />
   return <>{children}</>
 }

--- a/apps/landing/src/pages/account/SyncSection.tsx
+++ b/apps/landing/src/pages/account/SyncSection.tsx
@@ -1,26 +1,35 @@
 import { useEffect, useState } from 'react'
 import { CheckoutPanel } from '@/components/account/CheckoutPanel'
+import { parseCheckoutToken } from '@/lib/checkout-summary'
 import { useAuth } from '@/contexts/auth-context'
 
 export function SyncSection() {
   const { api } = useAuth()
-  const [token, setToken] = useState<string | null>(null)
+  // Desktop opens /account/sync#token=<checkoutToken>; that token already
+  // scopes the purchase to the account, so no web session (or mint) is needed.
+  const [hashToken] = useState<string | null>(() =>
+    typeof window === 'undefined' ? null : parseCheckoutToken(window.location.hash)
+  )
+  const [mintedToken, setMintedToken] = useState<string | null>(null)
   const [error, setError] = useState(false)
 
   useEffect(() => {
+    if (hashToken) return
     api
       .authedJson<{ checkoutToken: string }>('/auth/checkout-token', { method: 'POST' })
-      .then((r) => setToken(r.checkoutToken))
+      .then((r) => setMintedToken(r.checkoutToken))
       .catch(() => setError(true))
-  }, [api])
+  }, [api, hashToken])
+
+  const token = hashToken ?? mintedToken
 
   return (
     <div className="space-y-6">
       <h1 className="font-editorial text-2xl tracking-[-0.01em]">Sync</h1>
-      {error ? (
-        <p className="text-sm text-red-500">Could not start checkout. Reload to try again.</p>
-      ) : token ? (
+      {token ? (
         <CheckoutPanel token={token} />
+      ) : error ? (
+        <p className="text-sm text-red-500">Could not start checkout. Reload to try again.</p>
       ) : (
         <p className="text-sm text-muted">Loading…</p>
       )}

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -626,12 +626,17 @@
         "syncError": "Sync Error",
         "offline": "Offline",
         "connecting": "Connecting...",
+        "localOnly": "Local only",
         "pushed": "{count, plural, one {# pushed} other {# pushed}}",
         "pulled": "{count, plural, one {# pulled} other {# pulled}}",
         "pushedPulled": "{parts}",
         "changesPending": "{count, plural, one {# change pending} other {# changes pending}}",
         "offlinePending": "Offline ({count, plural, one {# change pending} other {# changes pending}})",
         "never": "Never"
+      },
+      "upsell": {
+        "title": "Your notes live only on this device",
+        "description": "Upgrade to sync across all your devices — end-to-end encrypted, so only you can read them."
       }
     },
     "billing": {
@@ -661,6 +666,7 @@
       "activationPendingPrefix": "Activation pending. Paddle can take a moment to confirm checkout. Refresh status or email",
       "actions": {
         "upgrade": "Upgrade",
+        "unlockSync": "Unlock Sync",
         "opening": "Opening...",
         "refresh": "Refresh status",
         "manage": "Manage billing"


### PR DESCRIPTION
## Problem

Free accounts are gated out of sync in the main process (`local_only`), but the renderer status map didn't know that status, so **Settings → Account** sat on "Connecting…" forever — both the header pill and the Sync group. The upgrade CTA was also a dry "Upgrade" button that dropped users on the generic checkout page.

## Changes

**Desktop**
- `use-sync-status.ts`: map `local_only` → **Local only** (gray dot, CloudOff) instead of falling through to "Connecting…". Fixes the pill everywhere it renders.
- `account-section.tsx`: on the free plan the Sync group swaps the status row + toggle (meaningless without a plan) for an upsell card — *"Your notes live only on this device / Upgrade to sync across all your devices — end-to-end encrypted, so only you can read them."* — with an **Unlock Sync** CTA. The Billing **Upgrade** button also becomes **Unlock Sync** on the free plan.
- `paddle-billing.ts`: default checkout target `memrynote.com/checkout` → `memrynote.com/account/sync` (still `#token=<checkoutToken>`; `CHECKOUT_PAGE_URL` override unchanged).

**Landing**
- `SyncSection`: prefers a `#token=` hash (desktop handoff) over minting one from the web session.
- `RequireAuth`: only `/account/sync` with a checkout token in the hash bypasses the login redirect, so a desktop free user lands straight on the plan picker inside the account shell — no separate web login. Profile/Billing tabs still require a session; tokenless `/account/sync` still redirects to `/login`.

## Verification

- Renderer suites (`settings-sections`, `use-sync-hooks`): 15/15 green, incl. new free-plan upsell + paid-plan toggle tests
- Main suites (`account-handlers`, `paddle-billing.activation`): 9/9 green
- `typecheck:web/node/test`, `i18n:check`, `pnpm lint`, landing `typecheck` + tests (70/70): green
- Browser-verified on landing dev: `/account/sync#token=…` renders the plan picker without login; tokenless visit still bounces to `/login`
- `docs:impact --strict` + `docs:build` green (settings + how-sync-works updated)
