### PR TITLE
fix(mobile): serialize sync pipelines; first sync resumes past unpullable items

### DIFF
--- a/apps/mobile/src/app/(vault)/_layout.tsx
+++ b/apps/mobile/src/app/(vault)/_layout.tsx
@@ -43,6 +43,8 @@ export default function VaultLayout() {
         log.warn('Initial sync pass failed', {
           error: err instanceof Error ? err.message : String(err)
         })
+        // A dead run must not leave a frozen 0% bar on screen forever.
+        if (!cancelled) setProgress(null)
       } finally {
         if (!cancelled) setSyncing(false)
       }

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -42,15 +42,41 @@ export class MobileSyncEngine {
   private deviceKeys = new Map<string, Uint8Array | null>()
   private deviceKeysFetched = false
   private listeners = new Set<(summary: SyncSummary) => void>()
+  private chain: Promise<unknown> = Promise.resolve()
 
   constructor(readonly vaultId: string) {
     this.http = createMobileHttpClient(syncBaseUrl())
+    // NetInfo emits the CURRENT state immediately on subscribe; syncing on
+    // that first emission raced the windowed first sync (two transactions on
+    // one SQLite connection, and a shared record cursor — the 83-items-stuck
+    // wedge). Only genuine offline→online transitions trigger a pass.
+    let initialEmission = true
     this.http.onOnlineChanged((online) => {
       this.online = online
+      if (initialEmission) {
+        initialEmission = false
+        return
+      }
       if (online) {
         void this.sync().catch(() => {})
       }
     })
+  }
+
+  /**
+   * Every pipeline that touches the vault DB or the record cursor runs
+   * through this queue. sync(), the first-sync phases and on-demand fetches
+   * used to interleave — expo-sqlite shares one connection per DB, so two
+   * concurrent withTransactionAsync calls throw, and two concurrent pulls
+   * race the cursor.
+   */
+  private exclusive<T>(task: () => Promise<T>): Promise<T> {
+    const run = this.chain.then(task, task)
+    this.chain = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
   }
 
   onSynced(listener: (summary: SyncSummary) => void): () => void {
@@ -125,7 +151,7 @@ export class MobileSyncEngine {
   /** Incremental sync pass. Coalesces concurrent callers into one run. */
   sync(): Promise<SyncSummary> {
     if (this.syncing) return this.syncing
-    this.syncing = this.runSync().finally(() => {
+    this.syncing = this.exclusive(() => this.runSync()).finally(() => {
       this.syncing = null
     })
     return this.syncing
@@ -147,7 +173,7 @@ export class MobileSyncEngine {
       return { ok: false, reason: 'error', itemsApplied: 0, bodiesUpdated: 0 }
     }
 
-    const bodies = await this.pullBodiesFor(store, record.changedNoteIds)
+    const bodies = await this.pullBodiesForUnlocked(store, record.changedNoteIds)
     await this.pollStatus(engine)
 
     const summary: SyncSummary = {
@@ -160,7 +186,11 @@ export class MobileSyncEngine {
     return summary
   }
 
-  async pullBodiesFor(store: MobilePullStore, noteIds: string[]): Promise<number> {
+  pullBodiesFor(store: MobilePullStore, noteIds: string[]): Promise<number> {
+    return this.exclusive(() => this.pullBodiesForUnlocked(store, noteIds))
+  }
+
+  private async pullBodiesForUnlocked(store: MobilePullStore, noteIds: string[]): Promise<number> {
     if (noteIds.length === 0 || !this.vaultKeyCache) return 0
     const db = await openVaultDb(this.vaultId)
     const puller = new CrdtBodyPuller({
@@ -180,20 +210,24 @@ export class MobileSyncEngine {
   }
 
   /** Pull specific record blobs (windowed first sync / on-demand). */
-  async pullBlobs(itemIds: string[]): Promise<{ applied: number; changedNoteIds: string[] }> {
-    const prepared = await this.prepare()
-    if (!prepared) return { applied: 0, changedNoteIds: [] }
-    const engine = this.makeEngine(prepared.store)
-    const result = await engine.pullBlobsByIds(itemIds)
-    return { applied: result.applied, changedNoteIds: result.changedNoteIds }
+  pullBlobs(itemIds: string[]): Promise<{ applied: number; changedNoteIds: string[] }> {
+    return this.exclusive(async () => {
+      const prepared = await this.prepare()
+      if (!prepared) return { applied: 0, changedNoteIds: [] }
+      const engine = this.makeEngine(prepared.store)
+      const result = await engine.pullBlobsByIds(itemIds)
+      return { applied: result.applied, changedNoteIds: result.changedNoteIds }
+    })
   }
 
-  async pullRefsToEnd(): Promise<number> {
-    const prepared = await this.prepare()
-    if (!prepared) return 0
-    const engine = this.makeEngine(prepared.store)
-    const { refs } = await engine.pullRefsToEnd()
-    return refs
+  pullRefsToEnd(): Promise<number> {
+    return this.exclusive(async () => {
+      const prepared = await this.prepare()
+      if (!prepared) return 0
+      const engine = this.makeEngine(prepared.store)
+      const { refs } = await engine.pullRefsToEnd()
+      return refs
+    })
   }
 
   async getStore(): Promise<MobilePullStore | null> {

--- a/apps/mobile/src/sync/first-sync.ts
+++ b/apps/mobile/src/sync/first-sync.ts
@@ -49,27 +49,44 @@ export async function runFirstSyncIfNeeded(
   const recentNoteIds = new Set<string>()
   const windowStart = Date.now() - BODY_WINDOW_DAYS * 24 * 60 * 60 * 1000
 
-  // Metadata phase: everything, newest first, in protocol-sized chunks.
+  // Metadata phase: everything, newest first, in protocol-sized chunks. On a
+  // resumed run totalRefs is 0 (cursor already at the end) while rows from
+  // the interrupted attempt still sit metadata-only — count those in.
+  const missingAtStart = await db.getFirstAsync<{ n: number }>(
+    `SELECT COUNT(*) AS n FROM sync_items WHERE payload_state = 'metadata-only' AND deleted_at IS NULL`
+  )
+  const totalToPull = Math.max(totalRefs, missingAtStart?.n ?? 0)
+
+  // Ids the server would not return or that failed decrypt: skipped, never
+  // looped on — an unpullable chunk must not wedge the whole first sync.
+  const unpullable = new Set<string>()
   for (;;) {
-    const ids = await store.listItemIdsMissingPayload(allTypes, BLOB_CHUNK)
+    const candidates = await store.listItemIdsMissingPayload(allTypes, BLOB_CHUNK + unpullable.size)
+    const ids = candidates.filter((id) => !unpullable.has(id)).slice(0, BLOB_CHUNK)
     if (ids.length === 0) break
     const result = await engine.pullBlobs(ids)
-    pulled += ids.length
+    pulled += result.applied
     for (const noteId of result.changedNoteIds) recentNoteIds.add(noteId)
+
+    // Whatever this chunk left metadata-only is unpullable for this run.
+    const placeholders = ids.map(() => '?').join(',')
+    const stillMissing = await db.getAllAsync<{ id: string }>(
+      `SELECT id FROM sync_items WHERE payload_state = 'metadata-only' AND id IN (${placeholders})`,
+      ids
+    )
+    for (const row of stillMissing) unpullable.add(row.id)
+
     onProgress({
       phase: 'metadata',
-      fraction: totalRefs === 0 ? 1 : Math.min(0.8, (pulled / Math.max(totalRefs, 1)) * 0.8),
-      itemsTotal: totalRefs,
+      fraction: Math.min(0.8, (pulled / Math.max(totalToPull, 1)) * 0.8),
+      itemsTotal: totalToPull,
       itemsPulled: pulled
     })
-    if (result.applied === 0) {
-      // Every id in this chunk failed (corrupt/unpullable) — the store rows
-      // still say metadata-only, so looping again would spin forever.
-      log.warn('First sync chunk applied nothing; stopping metadata phase', {
-        chunk: ids.length
-      })
-      break
-    }
+  }
+  if (unpullable.size > 0) {
+    log.warn('First sync finished with unpullable items; on-demand fetch retries them', {
+      count: unpullable.size
+    })
   }
 
   // Recent-bodies phase: only the 30-day window pays the CRDT cost up front.


### PR DESCRIPTION
Root cause of the stuck US1 first sync, diagnosed on the reference device (seam harness: conformance 26/26 PASS; pull round-trip green except 'no note body materialized'; 83 items frozen at metadata-only, progress bar frozen at 0%):

1. **Constructor-time sync race.** NetInfo emits the current state immediately on subscribe, so the engine started an incremental sync the moment it was constructed — concurrently with the windowed first sync. expo-sqlite shares one connection per DB: two concurrent `withTransactionAsync` calls throw, killing the first sync in its refs phase, while the surviving incremental pass advanced the shared record cursor to the end — stranding refs whose blobs nothing would ever fetch again, and never reaching the body phase (hence zero `note_bodies`).
2. **Fix:** one exclusive queue per engine (`sync()", refs, blobs, bodies all serialize); the initial NetInfo emission no longer triggers a pass — only genuine offline→online transitions do.
3. **First sync is now resumable:** leftover metadata-only rows count into the progress total, ids the server won't return are skipped instead of wedging the loop, and a dead run clears the frozen progress bar.

Evidence: mobile typecheck + lint green; behaviour fix verified next on the reference device (re-run of the seam harness + first sync completing).