### PR TITLE
fix(sync-client): validate pull items one by one — a malformed item no longer poisons its page

### DIFF
--- a/apps/mobile/src/app/(dev)/seam-tests.tsx
+++ b/apps/mobile/src/app/(dev)/seam-tests.tsx
@@ -41,6 +41,11 @@ export default function SeamTestsScreen() {
             ✗ {f}
           </ThemedText>
         ))}
+        {(r.notes ?? []).map((n) => (
+          <ThemedText key={n} type="small">
+            ℹ {n}
+          </ThemedText>
+        ))}
       </>
     )
 

--- a/apps/mobile/src/sync/__harness__/us1-seam-harness.ts
+++ b/apps/mobile/src/sync/__harness__/us1-seam-harness.ts
@@ -21,6 +21,8 @@ export interface HarnessResult {
   passed: number
   failed: number
   failures: string[]
+  /** Informational lines (not failures) — e.g. corrupt-item reasons. */
+  notes?: string[]
 }
 
 interface Frame {
@@ -152,6 +154,22 @@ export async function runPullPipelineRoundTrip(): Promise<HarnessResult> {
   const pullStore = new MobilePullStore(db, vaultId)
   const cursor = await pullStore.getRecordCursor()
   check('record cursor advanced', cursor !== null && cursor !== '0')
+
+  // Surface WHY items are stuck, on screen — release builds have no console.
+  const corrupt = await db.getAllAsync<{ key: string; value: string }>(
+    "SELECT key, value FROM meta WHERE key LIKE 'corrupt.%' LIMIT 6"
+  )
+  const corruptCount = await db.getFirstAsync<{ n: number }>(
+    "SELECT COUNT(*) AS n FROM meta WHERE key LIKE 'corrupt.%'"
+  )
+  const missing = await db.getFirstAsync<{ n: number }>(
+    "SELECT COUNT(*) AS n FROM sync_items WHERE payload_state = 'metadata-only' AND deleted_at IS NULL"
+  )
+  result.notes = [
+    `metadata-only items: ${missing?.n ?? 0}`,
+    `corrupt-marked items: ${corruptCount?.n ?? 0}`,
+    ...corrupt.map((row) => `${row.key.slice(8, 20)}…: ${row.value.slice(0, 80)}`)
+  ]
 
   log.info('Pull round-trip finished', { passed: result.passed, failed: result.failed })
   return result

--- a/packages/sync-client/src/pull/engine.test.ts
+++ b/packages/sync-client/src/pull/engine.test.ts
@@ -203,7 +203,52 @@ describe('RecordPullEngine.pullIncremental', () => {
     expect(result.itemsApplied).toBe(3)
   })
 
-  it('drops a page whose /sync/pull response fails validation but still advances the cursor', async () => {
+  it('skips a malformed item without poisoning its page-mates', async () => {
+    const store = memoryStore()
+    const http = fakeHttp([
+      devicesRoute,
+      {
+        match: (req) => req.path.startsWith('/sync/changes'),
+        respond: (req) =>
+          req.path.includes('cursor=5')
+            ? { json: { items: [], deleted: [], hasMore: false, nextCursor: 5 } }
+            : {
+                json: {
+                  items: [
+                    { id: 'bad1', type: 'note', version: 1, modifiedAt: 1, size: 1 },
+                    { id: 'ok1', type: 'note', version: 1, modifiedAt: 2, size: 1 }
+                  ],
+                  deleted: [],
+                  hasMore: true,
+                  nextCursor: 5
+                }
+              }
+      },
+      {
+        match: (req) => req.path === '/sync/pull',
+        respond: () => ({
+          json: {
+            items: [
+              { id: 'bad1', nonsense: true },
+              pullItem('ok1', 'note', { title: 'survives', fileType: 'markdown' })
+            ]
+          }
+        })
+      }
+    ])
+
+    const engine = makeEngine(http, store)
+    const result = await engine.pullIncremental()
+
+    expect(result.ok).toBe(true)
+    expect(store.applied.flat().map((i) => i.id)).toEqual(['ok1'])
+    expect(store.corrupt).toHaveLength(1)
+    expect(store.corrupt[0].id).toBe('bad1')
+    expect(store.corrupt[0].reason).toContain('schema')
+    expect(store.cursor).toBe('5')
+  })
+
+  it('drops a page whose response is not a pull envelope but still advances the cursor', async () => {
     const store = memoryStore()
     const http = fakeHttp([
       devicesRoute,
@@ -223,7 +268,7 @@ describe('RecordPullEngine.pullIncremental', () => {
       },
       {
         match: (req) => req.path === '/sync/pull',
-        respond: () => ({ json: { items: [{ nonsense: true }] } })
+        respond: () => ({ json: { error: 'not an envelope' } })
       }
     ])
 

--- a/packages/sync-client/src/pull/engine.ts
+++ b/packages/sync-client/src/pull/engine.ts
@@ -1,6 +1,6 @@
 import {
   RecordChangesResponseSchema,
-  RecordPullResponseSchema,
+  RecordPullItemResponseSchema,
   DeviceKeysResponseSchema,
   SyncStatusSchema,
   type RecordChangesResponse,
@@ -170,9 +170,12 @@ export class RecordPullEngine {
   }
 
   /**
-   * Pull one page's blobs, decrypt, verify, decode. Returns null when the
-   * whole /sync/pull response failed schema validation — the caller drops the
-   * page (cursor still advances; desktop pull_page_dropped semantics).
+   * Pull one page's blobs, decrypt, verify, decode. Items are validated ONE
+   * BY ONE — a single malformed item is recorded corrupt and skipped, never
+   * allowed to poison its 99 page-mates (desktop's whole-page safeParse drops
+   * the page; on a first sync that wedges every item sharing a chunk with one
+   * bad row). Returns null only when the envelope itself is not a pull
+   * response (the caller drops the page; pull_page_dropped semantics).
    */
   private async pullAndDecode(
     itemIds: string[],
@@ -193,16 +196,36 @@ export class RecordPullEngine {
         this.retryOpts()
       ).then((r) => r.value)
 
-      const parsed = RecordPullResponseSchema.safeParse(raw)
-      if (!parsed.success) {
-        this.deps.log.error('Pull page failed schema validation; page dropped', {
-          itemCount: chunk.length,
-          issue: parsed.error.issues[0]?.message
+      const envelope = raw as { items?: unknown[] }
+      if (!envelope || !Array.isArray(envelope.items)) {
+        this.deps.log.error('Pull response is not a pull envelope; page dropped', {
+          itemCount: chunk.length
         })
         return null
       }
 
-      for (const item of parsed.data.items) {
+      const validItems = []
+      for (const [index, rawItem] of envelope.items.entries()) {
+        const itemParse = RecordPullItemResponseSchema.safeParse(rawItem)
+        if (itemParse.success) {
+          validItems.push(itemParse.data)
+          continue
+        }
+        counters.corrupt++
+        const issue = itemParse.error.issues[0]
+        const reason = `schema: ${issue?.path.join('.') ?? '?'} ${issue?.message ?? 'invalid'}`
+        const rawId = (rawItem as { id?: unknown } | null)?.id
+        if (typeof rawId === 'string' && rawId.length > 0) {
+          await this.deps.store.markItemCorrupt(rawId, reason)
+        }
+        this.deps.log.warn('Pull item failed schema validation; item skipped', {
+          index,
+          itemId: typeof rawId === 'string' ? rawId : 'unknown',
+          reason
+        })
+      }
+
+      for (const item of validItems) {
         const itemOp = item.deletedAt !== undefined ? 'delete' : item.operation
         if (itemOp === 'delete') {
           // Tombstone bodies are never decoded (desktop apply-item.ts rule).


### PR DESCRIPTION
On-device evidence: single-id tap-to-fetch pulls and renders fine while bulk first-sync chunks leave the same 83 notes metadata-only — the signature of the whole-page `RecordPullResponseSchema.safeParse` dropping a 100-item response over one bad row (desktop's `pull_page_dropped` mode; fatal on a first sync because every page-mate gets wedged with it).

Items now validate individually with `RecordPullItemResponseSchema`: a malformed item is recorded corrupt (zod issue path+message as the reason) and skipped; the other 99 apply. Whole-page drop remains only for a response that is not a pull envelope at all. The on-device harness additionally lists metadata-only/corrupt counts and the first corrupt reasons on screen, so the exact bad rows are identifiable from the phone.

Evidence: sync-client 12/12 pull tests (new: salvage + envelope-drop cases), package tsc green, mobile tsc green.