### PR TITLE
debug(mobile): live step + crash surface in the seam harness

### DIFF
--- a/apps/mobile/src/app/(dev)/seam-tests.tsx
+++ b/apps/mobile/src/app/(dev)/seam-tests.tsx
@@ -15,15 +15,22 @@ export default function SeamTestsScreen() {
   const [conformance, setConformance] = useState<HarnessResult | null>(null)
   const [roundTrip, setRoundTrip] = useState<HarnessResult | null>(null)
   const [busy, setBusy] = useState(false)
+  const [step, setStep] = useState<string | null>(null)
+  const [crash, setCrash] = useState<string | null>(null)
 
   const runAll = useCallback(() => {
     setBusy(true)
     setTimeout(async () => {
       try {
+        setCrash(null)
+        setStep('conformance')
         const c = await runMobileConformance()
         setConformance(c)
-        const r = await runPullPipelineRoundTrip()
+        const r = await runPullPipelineRoundTrip((s) => setStep(s))
         setRoundTrip(r)
+        setStep(null)
+      } catch (err) {
+        setCrash(err instanceof Error ? `${err.name}: ${err.message.slice(0, 160)}` : String(err))
       } finally {
         setBusy(false)
       }
@@ -65,6 +72,8 @@ export default function SeamTestsScreen() {
               {busy ? 'Running…' : 'Run conformance + pull round-trip'}
             </ThemedText>
           </Pressable>
+          {step ? <ThemedText type="small">⏳ {step}</ThemedText> : null}
+          {crash ? <ThemedText type="smallBold">💥 round-trip threw: {crash}</ThemedText> : null}
           {render('Conformance', conformance)}
           {render('Pull round-trip', roundTrip)}
         </ScrollView>

--- a/apps/mobile/src/sync/__harness__/us1-seam-harness.ts
+++ b/apps/mobile/src/sync/__harness__/us1-seam-harness.ts
@@ -117,7 +117,10 @@ export async function runMobileConformance(): Promise<HarnessResult> {
  * into the real vault DB, then a NoteContentStore round-trip on the same DB.
  * Requires a signed-in session and an unlocked vault.
  */
-export async function runPullPipelineRoundTrip(): Promise<HarnessResult> {
+export async function runPullPipelineRoundTrip(
+  onStep?: (step: string) => void
+): Promise<HarnessResult> {
+  const step = (label: string) => onStep?.(label)
   const result: HarnessResult = { passed: 0, failed: 0, failures: [] }
   const check = (name: string, ok: boolean, detail?: string) => {
     if (ok) result.passed++
@@ -127,16 +130,19 @@ export async function runPullPipelineRoundTrip(): Promise<HarnessResult> {
     }
   }
 
+  step('loading vault id')
   const vaultId = await loadCurrentVaultId()
   if (!vaultId) {
     check('session', false, 'no current vault — sign in and unlock first')
     return result
   }
 
+  step('engine.sync()')
   const engine = getSyncEngine(vaultId)
   const summary = await engine.sync()
   check('pull ran without refusal', summary.ok, summary.reason ?? undefined)
 
+  step('db counts')
   const db = await openVaultDb(vaultId)
   const itemCount = await db.getFirstAsync<{ n: number }>('SELECT COUNT(*) AS n FROM sync_items')
   check('sync_items has rows', (itemCount?.n ?? 0) > 0)
@@ -146,6 +152,7 @@ export async function runPullPipelineRoundTrip(): Promise<HarnessResult> {
   )
   check('at least one note body materialized', noteWithBody !== null)
 
+  step('note content store round-trip')
   const store = createMobileNoteContentStore(db, { vaultId, journalFolder: 'Journal' })
   const probePath = `__harness__/roundtrip-${Date.now().toString(36)}.md`
   const probeContent = '# seam probe\n\nround-trip body\n'
@@ -175,6 +182,7 @@ export async function runPullPipelineRoundTrip(): Promise<HarnessResult> {
     ...corrupt.map((row) => `${row.key.slice(8, 20)}…: ${row.value.slice(0, 80)}`)
   ]
 
+  step('stuck probe')
   // Stuck-item deep probe: which types are stuck, and does the SERVER return
   // them when asked directly? Decides server-omission vs client-not-asking.
   const stuckByType = await db.getAllAsync<{ type: string; n: number }>(
@@ -218,6 +226,7 @@ export async function runPullPipelineRoundTrip(): Promise<HarnessResult> {
         `engine.pullBlobs on those ids → applied ${blobResult.applied}, still stuck ${after?.n ?? '?'} (types: ${stuckSample.map((s) => s.type).join(', ')})`
       )
 
+      step('size ladder')
       // Size ladder: small pulls work, the first-sync 100-id chunks do not.
       // Find the breaking size and surface the thrown error verbatim.
       for (const size of [10, 50, 100]) {


### PR DESCRIPTION
A throw between conformance and the round-trip result was swallowed by the dev runner, rendering as an eternal 'pending'. The screen now shows the current step live (⏳) and prints any thrown error verbatim (💥). Dev harness only; mobile tsc green.