### PR TITLE
debug(mobile): full error text in the seam harness crash surface

### DIFF
--- a/apps/mobile/src/app/(dev)/seam-tests.tsx
+++ b/apps/mobile/src/app/(dev)/seam-tests.tsx
@@ -30,7 +30,7 @@ export default function SeamTestsScreen() {
         setRoundTrip(r)
         setStep(null)
       } catch (err) {
-        setCrash(err instanceof Error ? `${err.name}: ${err.message.slice(0, 160)}` : String(err))
+        setCrash(err instanceof Error ? `${err.name}: ${err.message.slice(0, 500)}` : String(err))
       } finally {
         setBusy(false)
       }

--- a/apps/mobile/src/sync/__harness__/us1-seam-harness.ts
+++ b/apps/mobile/src/sync/__harness__/us1-seam-harness.ts
@@ -217,7 +217,15 @@ export async function runPullPipelineRoundTrip(
         )
       }
 
-      const blobResult = await engine.pullBlobs(stuckSample.map((s) => s.id))
+      let blobResult: { applied: number; changedNoteIds: string[] }
+      try {
+        blobResult = await engine.pullBlobs(stuckSample.map((s) => s.id))
+      } catch (err) {
+        result.notes.push(
+          `probe pullBlobs THREW: ${err instanceof Error ? err.message.slice(0, 300) : String(err)}`
+        )
+        blobResult = { applied: -1, changedNoteIds: [] }
+      }
       const after = await db.getFirstAsync<{ n: number }>(
         `SELECT COUNT(*) AS n FROM sync_items WHERE payload_state = 'metadata-only' AND deleted_at IS NULL AND id IN (${stuckSample.map(() => '?').join(',')})`,
         stuckSample.map((s) => s.id)


### PR DESCRIPTION
The round-trip's SQLiteErrorException was truncated at 160 chars right before the interesting part; the crash line now carries 500 chars and the stuck-probe pullBlobs failure is captured into the notes with its own message. Dev harness only.