### PR TITLE
fix(mobile): note_bodies.path is not unique — a title collision no longer kills the apply batch

### DIFF
--- a/apps/mobile/src/db/migrations/0002_note_body_path_nonunique.sql
+++ b/apps/mobile/src/db/migrations/0002_note_body_path_nonunique.sql
@@ -1,0 +1,7 @@
+-- The derived note path is informational (title collisions are real data:
+-- journals without titles all derive "Untitled.md"), so it cannot be UNIQUE —
+-- the constraint made one colliding note kill its whole apply batch
+-- (SQLite error 19 inside the transaction).
+
+DROP INDEX IF EXISTS idx_note_bodies_path;
+CREATE INDEX idx_note_bodies_path ON note_bodies(path);

--- a/apps/mobile/src/db/migrations/index.ts
+++ b/apps/mobile/src/db/migrations/index.ts
@@ -112,6 +112,16 @@ CREATE TABLE attachments (
 ) WITHOUT ROWID;
 `
 
+export const PATH_NONUNIQUE_SQL = `-- The derived note path is informational (title collisions are real data:
+-- journals without titles all derive "Untitled.md"), so it cannot be UNIQUE —
+-- the constraint made one colliding note kill its whole apply batch
+-- (SQLite error 19 inside the transaction).
+
+DROP INDEX IF EXISTS idx_note_bodies_path;
+CREATE INDEX idx_note_bodies_path ON note_bodies(path);
+`
+
 export const MOBILE_MIGRATIONS: MobileMigration[] = [
-  { version: 1, name: '0001_baseline', sql: BASELINE_SQL }
+  { version: 1, name: '0001_baseline', sql: BASELINE_SQL },
+  { version: 2, name: '0002_note_body_path_nonunique', sql: PATH_NONUNIQUE_SQL }
 ]

--- a/apps/mobile/src/db/pull-store.ts
+++ b/apps/mobile/src/db/pull-store.ts
@@ -163,11 +163,20 @@ export class MobilePullStore implements PullStore, CrdtPullStore {
           ])
 
           if ((item.type === 'note' || item.type === 'journal') && item.payloadJson) {
-            await this.projectNoteWithStatements(item, existingBodies, seenFolders, {
-              folderStmt,
-              bodyUpsertStmt,
-              bodyPathStmt
-            })
+            try {
+              await this.projectNoteWithStatements(item, existingBodies, seenFolders, {
+                folderStmt,
+                bodyUpsertStmt,
+                bodyPathStmt
+              })
+            } catch (err) {
+              // A projection is rebuildable; it must never kill the batch —
+              // the sync_items row is already applied and stays the truth.
+              log.warn('Note projection failed; item applied without projection', {
+                itemId: item.id,
+                error: err instanceof Error ? err.message : String(err)
+              })
+            }
           }
         }
       } finally {


### PR DESCRIPTION
Full culprit surfaced on the device screen: `SQLiteErrorException: Error code 19: UNIQUE constraint failed: note_bodies.path`. The derived vault path is informational and collisions are real data — journals without titles all derive `Untitled.md` — so the unique partial index made one colliding note kill its entire 100-item apply transaction. This (stacked with the earlier finalizeAsync teardown crash) was the stuck-items wedge.

- Mobile ledger `0002_note_body_path_nonunique`: drop the unique index, plain index instead (mobile ledger has no released users; additive file per ledger discipline).
- A failed note projection now logs and continues — the `sync_items` row is already applied and remains the truth; projections are rebuildable.

Migration parity test 2/2, mobile tsc green. Verifying on simulator next (expect stuck → 0).