### PR TITLE
fix(installer): never let a failed Windows update destroy the existing install

### DIFF
--- a/apps/desktop/build/installer.nsh
+++ b/apps/desktop/build/installer.nsh
@@ -22,24 +22,189 @@
 # report from Windows users.
 #
 # customRemoveFiles replaces that whole block (see the !ifmacrodef in
-# uninstaller.nsh), so this macro owns both paths. It keeps the atomic rename as
-# the happy path — it is the safest way to remove files, and on success nothing
-# changes — but a busy file now falls back to the same tolerant sweep a manual
-# uninstall would have done instead of making the update impossible.
+# uninstaller.nsh), so this macro owns both paths.
+#
+# ── The self-destruct problem (#1851) ────────────────────────────────────────
+#
+# Both the stock template and the first version of this macro DELETE the old
+# install before the new one exists: the uninstaller's staging area is
+# $PLUGINSDIR, which NSIS wipes the moment the uninstaller process exits — long
+# before the installer extracts a single new file. The window between "old
+# install removed" and "new install written" is therefore unprotected. An
+# extraction failure, a declined elevation, AV quarantining the freshly written
+# exe — or, worst of all, Windows killing the silent installer that
+# autoInstallOnAppQuit spawned during an OS shutdown — leaves the user with an
+# install directory holding only the uninstaller and a Start menu shortcut that
+# points at nothing. Recovery required a manual uninstall + reinstall.
+#
+# The fix is to make the removal recoverable at every step:
+#
+#   1. The update-path removal MOVES the old install into a sibling directory
+#      ("$INSTDIR.update-backup" — same volume, so it is pure Rename, no copy,
+#      no extra disk) instead of deleting it. Every file is always in exactly
+#      one of the two directories, so an interruption at ANY point loses
+#      nothing.
+#   2. Before touching anything, the uninstaller arms a HKCU RunOnce entry: at
+#      the next logon, if "$INSTDIR\<exe>" is missing, robocopy moves the
+#      backup back; once the exe exists the leftover backup is deleted. This
+#      is the only mechanism that survives the installer being KILLED (OS
+#      shutdown mid-update) — no NSIS callback runs in that case.
+#   3. .onInstFailed restores the backup in-process for the failures that DO
+#      reach a callback (assisted-UI cancel, extraction failure).
+#   4. customInstall — which only runs after the new files are on disk —
+#      disarms the RunOnce entry and deletes the backup.
+#
+# A busy file (AV handle, stray process) no longer aborts the update either:
+# the move falls back to restore + CopyFiles (a copy can read a mapped file),
+# then the same tolerant sweep a manual uninstall would have done.
 #
 # The last obstacle is the app binary itself. It cannot be DELETED while a
 # process still has it mapped — but Windows will happily RENAME it, because the
-# loader opens an image with FILE_SHARE_DELETE. That asymmetry is the whole
-# reason electron-builder's happy path is rename-based, and it is the escape
-# hatch here too: move the live binary aside and the installer has a clean
-# $INSTDIR to extract into, with the running process still pointing at the
-# renamed inode until it exits.
-#
-# Aborting instead — as this macro used to, and as stock still does — is what
-# strands a user forever: the failure is not transient, so every future update
-# hits the same wall and the only way out is uninstall-then-reinstall. Renaming
-# is strictly better; we abort only if even the rename fails, which is the same
-# outcome as before, so this can never be worse than what it replaces.
+# loader opens an image with FILE_SHARE_DELETE. That asymmetry is why the happy
+# path is rename-based, and it is the escape hatch at the end too: move the
+# live binary aside and the installer has a clean $INSTDIR to extract into,
+# with the running process still pointing at the renamed inode until it exits.
+
+# These mirror common.nsh's APP_EXECUTABLE_FILENAME / UNINSTALL_FILENAME. They
+# must be re-derived here because this include is compiled BEFORE common.nsh
+# (electron-builder prepends the custom include to the script), so the
+# template's defines do not exist yet at this point. PRODUCT_FILENAME and
+# APP_ID arrive via makensis -D flags and are always available.
+!define MEMRY_APP_EXE "${PRODUCT_FILENAME}.exe"
+!define MEMRY_UNINSTALL_EXE "Uninstall ${PRODUCT_FILENAME}.exe"
+!define MEMRY_RUNONCE_KEY "Software\Microsoft\Windows\CurrentVersion\RunOnce"
+!define MEMRY_RUNONCE_NAME "${APP_ID}.update-restore"
+
+!ifdef BUILD_UNINSTALLER
+  Var updateBackupDir
+
+  # Recursive move of $INSTDIR into $updateBackupDir — the same walk as the
+  # template's un.atomicRMDir, but renaming into a directory that SURVIVES the
+  # uninstaller's exit instead of into $PLUGINSDIR. Plain NSIS only (no
+  # LogicLib) because this compiles before the template's includes.
+  # Push "" (subpath) before calling; returns 0 on success or the path of the
+  # first file that could not be renamed.
+  Function un.moveToUpdateBackup
+    Exch $R0
+    Push $R1
+    Push $R2
+    Push $R3
+
+    StrCpy $R3 "$INSTDIR$R0\*.*"
+    FindFirst $R1 $R2 $R3
+
+    loop:
+      StrCmp $R2 "" break
+
+      StrCmp $R2 "." continue
+      StrCmp $R2 ".." continue
+
+      IfFileExists "$INSTDIR$R0\$R2\*.*" isDir isNotDir
+
+      isDir:
+        CreateDirectory "$updateBackupDir$R0\$R2"
+
+        Push "$R0\$R2"
+        Call un.moveToUpdateBackup
+        Pop $R3
+
+        StrCmp $R3 "0" continue done
+
+      isNotDir:
+        ClearErrors
+        Rename "$INSTDIR$R0\$R2" "$updateBackupDir$R0\$R2"
+
+        # Ignore errors when renaming the uninstaller itself (it may be held
+        # by the copy the installer is ExecWait'ing).
+        StrCmp "$R0\$R2" "\${MEMRY_UNINSTALL_EXE}" 0 +2
+        ClearErrors
+
+        IfErrors 0 continue
+        StrCpy $R3 "$INSTDIR$R0\$R2"
+        Goto done
+
+      continue:
+        FindNext $R1 $R2
+        Goto loop
+
+    break:
+      StrCpy $R3 0
+
+    done:
+      FindClose $R1
+
+      StrCpy $R0 $R3
+
+      Pop $R3
+      Pop $R2
+      Pop $R1
+      Exch $R0
+  FunctionEnd
+
+  # Inverse walk: move everything in $updateBackupDir back into $INSTDIR.
+  # Used when the rename pass hit a busy file and the removal falls back to
+  # copy-then-sweep, so the copy sees one complete tree.
+  Function un.restoreFromUpdateBackup
+    Exch $R0
+    Push $R1
+    Push $R2
+    Push $R3
+
+    StrCpy $R3 "$updateBackupDir$R0\*.*"
+    FindFirst $R1 $R2 $R3
+
+    loop:
+      StrCmp $R2 "" break
+
+      StrCmp $R2 "." continue
+      StrCmp $R2 ".." continue
+
+      IfFileExists "$updateBackupDir$R0\$R2\*.*" isDir isNotDir
+
+      isDir:
+        CreateDirectory "$INSTDIR$R0\$R2"
+
+        Push "$R0\$R2"
+        Call un.restoreFromUpdateBackup
+        Pop $R3
+
+        Goto continue
+
+      isNotDir:
+        ClearErrors
+        Rename "$updateBackupDir$R0\$R2" "$INSTDIR$R0\$R2"
+
+      continue:
+        FindNext $R1 $R2
+        Goto loop
+
+    break:
+      StrCpy $R0 0
+      FindClose $R1
+
+      Pop $R3
+      Pop $R2
+      Pop $R1
+      Exch $R0
+  FunctionEnd
+!endif
+
+!ifndef BUILD_UNINSTALLER
+  # Restore the moved-aside install when the installer aborts AFTER the old
+  # version was removed (assisted-UI cancel, extraction failure, silent-mode
+  # auto-abort). Copy, not move: the RunOnce entry stays armed and cleans the
+  # backup up at the next logon, and a half-copied restore here must not eat
+  # the backup. A killed installer (OS shutdown) never reaches this callback —
+  # that case is covered by the RunOnce entry alone.
+  Function .onInstFailed
+    IfFileExists "$INSTDIR\${MEMRY_APP_EXE}" restoreDone
+    IfFileExists "$INSTDIR.update-backup\*.*" 0 restoreDone
+    ClearErrors
+    CopyFiles /SILENT "$INSTDIR.update-backup\*.*" "$INSTDIR"
+    restoreDone:
+  FunctionEnd
+!endif
+
 # Why customInstall exists — the Start menu entry must survive every path.
 #
 # electron-builder's keep-shortcuts handshake preserves shortcuts (and thus
@@ -68,6 +233,13 @@
 # itself cannot be restored programmatically (Windows offers no API), but
 # with the link and AUMID back the user can re-pin — and with in-place
 # updates fixed, the keep path preserves that pin from then on.
+#
+# It is also the update's commit point: it only runs after the new files are
+# on disk, so this is where the removal's safety net is disarmed — first the
+# RunOnce entry (so a kill between the two deletes can at worst leave a stale
+# backup, never resurrect one), then the backup itself. Both are no-ops for a
+# fresh install, and they also clean up leftovers when a manual reinstall
+# repairs a previously failed update.
 !macro customInstall
   ${ifNot} ${FileExists} "$newStartMenuLink"
     CreateShortCut "$newStartMenuLink" "$appExe" "" "$appExe" 0 "" "" "${APP_DESCRIPTION}"
@@ -76,31 +248,55 @@
     # refresh the shell so Start search picks the entry up immediately
     System::Call 'Shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'
   ${endIf}
+
+  DeleteRegValue HKCU "${MEMRY_RUNONCE_KEY}" "${MEMRY_RUNONCE_NAME}"
+  RMDir /r "$INSTDIR.update-backup"
 !macroend
 
 !macro customRemoveFiles
   ${if} ${isUpdated}
-    CreateDirectory "$PLUGINSDIR\old-install"
+    StrCpy $updateBackupDir "$INSTDIR.update-backup"
+
+    # A leftover backup from an earlier failed update whose RunOnce never got
+    # a chance to run. The current install is the state to preserve now.
+    RMDir /r "$updateBackupDir"
+
+    # Arm the safety net BEFORE touching any file, so even a kill inside the
+    # move below is recoverable at the next logon. The command restores the
+    # backup only while the exe is missing, and removes the backup only once
+    # the exe exists — so a partially failed robocopy keeps the backup for
+    # the next attempt instead of deleting the only copy.
+    WriteRegStr HKCU "${MEMRY_RUNONCE_KEY}" "${MEMRY_RUNONCE_NAME}" 'cmd.exe /c if not exist "$INSTDIR\${MEMRY_APP_EXE}" robocopy "$updateBackupDir" "$INSTDIR" /E /MOVE >nul 2>&1 & if exist "$INSTDIR\${MEMRY_APP_EXE}" rmdir /s /q "$updateBackupDir"'
+
+    CreateDirectory "$updateBackupDir"
 
     Push ""
-    Call un.atomicRMDir
+    Call un.moveToUpdateBackup
     Pop $R0
 
     ${if} $R0 != 0
       DetailPrint "File is busy: $R0"
-      DetailPrint "Atomic removal failed; falling back to in-place removal."
+      DetailPrint "Atomic move failed; falling back to copy + in-place removal."
 
-      # Move back whatever was already relocated, so the sweep below deletes
-      # from one place instead of leaving half the old install in $PLUGINSDIR.
+      # Reassemble the original tree so the copy below sees every file in one
+      # place, then COPY it into the backup — CopyFiles can read a file whose
+      # image is mapped by a running process, which Rename could not move.
       Push ""
-      Call un.restoreFiles
+      Call un.restoreFromUpdateBackup
       Pop $R9
+
+      ClearErrors
+      CreateDirectory "$updateBackupDir"
+      CopyFiles /SILENT "$INSTDIR\*.*" "$updateBackupDir"
+      ClearErrors
     ${endif}
   ${endif}
 
-  # Move out of $INSTDIR so it can be removed. Tolerant by design: RMDir /r
-  # deletes what it can and skips what it cannot, leaving only genuinely locked
-  # files behind for the installer to overwrite.
+  # Move out of $INSTDIR so it can be removed. After a clean move this only
+  # clears the leftover empty directory skeleton; on the busy-file fallback it
+  # is the same tolerant sweep a manual uninstall would have done — it deletes
+  # what it can and skips what it cannot, leaving only genuinely locked files
+  # behind for the installer to overwrite.
   SetOutPath $TEMP
   RMDir /r $INSTDIR
 

--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => {
   class MockEmitter {
@@ -42,19 +42,28 @@ const mocks = vi.hoisted(() => {
         storeState.prefs = { ...storeState.prefs, autoCheck: enabled }
       })
     },
-    app: {
+    app: Object.assign(new MockEmitter(), {
       isPackaged: true,
       getVersion: vi.fn(() => '1.2.3'),
       quit: vi.fn()
-    },
-    windows: [
-      {
+    }),
+    // Session-end guard listens on BrowserWindow instances, so windows are emitters.
+    createWindow: () =>
+      Object.assign(new MockEmitter(), {
         isDestroyed: () => false,
         webContents: {
           isDestroyed: () => false,
           send: vi.fn()
         }
-      }
+      }),
+    windows: [
+      Object.assign(new MockEmitter(), {
+        isDestroyed: () => false,
+        webContents: {
+          isDestroyed: () => false,
+          send: vi.fn()
+        }
+      })
     ],
     dialog: {
       showMessageBox: vi.fn()
@@ -145,6 +154,8 @@ describe('updater', () => {
     vi.clearAllMocks()
     mocks.storeState.prefs = {}
     mocks.autoUpdater.removeAllListeners()
+    mocks.app.removeAllListeners()
+    mocks.windows[0].removeAllListeners()
     mocks.autoUpdater.autoDownload = true
     mocks.autoUpdater.autoInstallOnAppQuit = false
     mocks.autoUpdater.checkForUpdates.mockResolvedValue(undefined)
@@ -887,5 +898,60 @@ describe('updater', () => {
     expect(mocks.autoUpdater.logger).toBeDefined()
     mocks.autoUpdater.logger.info('Cannot run installer: error code: EACCES')
     expect(mocks.logger.info).toHaveBeenCalledWith('Cannot run installer: error code: EACCES')
+  })
+})
+
+describe('session-end install guard (#1851)', () => {
+  const realPlatform = process.platform
+
+  function setPlatform(value: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', { value, configurable: true })
+  }
+
+  beforeEach(() => {
+    mocks.app.removeAllListeners()
+    mocks.windows[0].removeAllListeners()
+    mocks.autoUpdater.removeAllListeners()
+    mocks.autoUpdater.autoInstallOnAppQuit = false
+    mocks.autoUpdater.checkForUpdates.mockResolvedValue(undefined)
+    mocks.storeState.prefs = {}
+    mocks.app.isPackaged = true
+  })
+
+  afterEach(() => {
+    setPlatform(realPlatform)
+  })
+
+  it('skips install-on-quit when the OS session ends on Windows', async () => {
+    setPlatform('win32')
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+    expect(mocks.autoUpdater.autoInstallOnAppQuit).toBe(true)
+
+    mocks.windows[0].emit('query-session-end')
+
+    expect(mocks.autoUpdater.autoInstallOnAppQuit).toBe(false)
+  })
+
+  it('guards windows created after updater init', async () => {
+    setPlatform('win32')
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+
+    const lateWindow = mocks.createWindow()
+    mocks.app.emit('browser-window-created', {}, lateWindow)
+    lateWindow.emit('session-end')
+
+    expect(mocks.autoUpdater.autoInstallOnAppQuit).toBe(false)
+  })
+
+  it('does not touch install-on-quit off Windows', async () => {
+    setPlatform('darwin')
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+
+    mocks.windows[0].emit('query-session-end')
+
+    expect(mocks.autoUpdater.autoInstallOnAppQuit).toBe(true)
   })
 })

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,4 +1,4 @@
-import { app } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import { autoUpdater, type UpdateInfo } from 'electron-updater'
 import type { AppUpdateState } from '@memry/contracts/ipc-updater'
 import { UpdaterChannels } from '@memry/contracts/ipc-updater'
@@ -243,6 +243,44 @@ export function noteFailedUpdateInstall(version: string | null): void {
   setState({ installFailed: { version } })
 }
 
+/**
+ * Windows kills the detached NSIS installer that autoInstallOnAppQuit spawns
+ * when the quit is part of an OS shutdown/restart/log-off — after the old
+ * install has already been removed. That is how a user ends up with an install
+ * directory holding only the uninstaller and a dead Start menu shortcut
+ * (#1851). When the OS session is ending, skip the install-on-quit entirely:
+ * the downloaded update applies on the next user-initiated quit or via the
+ * in-app Restart prompt instead. `query-session-end` can fire for a shutdown
+ * that another app then cancels — the cost of that false positive is one
+ * skipped silent install, which the next quit picks up.
+ */
+function disableInstallOnSessionEnd(): void {
+  if (!autoUpdater.autoInstallOnAppQuit) {
+    return
+  }
+  logger.warn(
+    'OS session ending — skipping install-on-quit so a killed installer cannot remove the existing install'
+  )
+  autoUpdater.autoInstallOnAppQuit = false
+}
+
+function watchWindowForSessionEnd(window: BrowserWindow): void {
+  window.on('query-session-end', disableInstallOnSessionEnd)
+  window.on('session-end', disableInstallOnSessionEnd)
+}
+
+function registerSessionEndInstallGuard(): void {
+  if (process.platform !== 'win32') {
+    return
+  }
+  for (const window of BrowserWindow.getAllWindows()) {
+    watchWindowForSessionEnd(window)
+  }
+  app.on('browser-window-created', (_event, window) => {
+    watchWindowForSessionEnd(window)
+  })
+}
+
 export function initializeUpdater(): void {
   if (initialized || !app.isPackaged) {
     return
@@ -256,6 +294,7 @@ export function initializeUpdater(): void {
   const autoCheckEnabled = prefs.autoCheck ?? true
   autoUpdater.autoDownload = autoDownloadEnabled
   autoUpdater.autoInstallOnAppQuit = true
+  registerSessionEndInstallGuard()
   setState({ autoDownloadEnabled, autoCheckEnabled })
 
   autoUpdater.on('checking-for-update', () => {

--- a/apps/docs/src/guide/install.md
+++ b/apps/docs/src/guide/install.md
@@ -43,6 +43,13 @@ works around this on its own now, and it writes an `install.log` next to the app
 (typically `%LOCALAPPDATA%\Programs\memrynote`) that names the file it could not move.
 That log is the most useful thing you can send us if an update still fails.
 
+A failed Windows update can no longer remove the app. The installer keeps the old
+version in a backup folder next to the install folder until the new files are fully in
+place, and restores it automatically — at the next Windows sign-in at the latest — if
+anything interrupts the install, including shutting the PC down mid-update. For the same
+reason, an update is no longer installed while Windows itself is shutting down; it
+simply applies the next time you quit the app.
+
 One caveat if you are already affected. On Windows the step that removes the old files
 is run by the version you currently have installed, not by the one being installed — so
 these workarounds only take effect on updates _away from_ a build that contains them. If


### PR DESCRIPTION
## Summary

Fixes #1851 — a failed silent Windows update (extraction failure, AV quarantine, or Windows killing the installer during an OS shutdown) removed the old install before the new one existed, leaving the user with only the uninstaller and a dead shortcut. Recovery required a manual uninstall + reinstall.

Three layers now guarantee a launchable app survives every failure mode:

- **NSIS removal is recoverable** (`installer.nsh`): the update path renames the old install into a sibling `<install-dir>.update-backup` (same volume — pure rename, no copy, no extra disk) instead of deleting it via the `$PLUGINSDIR` staging area that dies with the uninstaller process. Every file is always in exactly one of the two directories, so a kill at any point loses nothing. A busy file no longer aborts the update either: restore + `CopyFiles` fallback (a copy can read a mapped image), then the same tolerant sweep as a manual uninstall.
- **RunOnce safety net**: armed before any file is touched. At the next sign-in, if the exe is missing, `robocopy /E /MOVE` restores the backup; the backup is only deleted once the exe exists. This is the sole mechanism that survives the installer being killed mid-update (the reported case — shutdown at night, app gone in the morning). `.onInstFailed` additionally restores in-process for failures that do reach a callback, and `customInstall` — which only runs after the new files are on disk — disarms the RunOnce entry and drops the backup.
- **Updater guard** (`updater.ts`): on Windows `query-session-end`/`session-end`, install-on-quit is disabled — the detached installer spawned during an OS shutdown is doomed to be killed mid-update. The downloaded update applies on the next user-initiated quit or via the in-app Restart prompt.

Side effect: with the app launchable again after a failed update, the existing `UPDATE_INSTALL_DID_NOT_APPLY` marker telemetry starts reporting exactly the failures that previously reported nothing (the app could not launch).

Known limits: the RunOnce entry is per-user (HKCU) — for an elevated per-machine install into e.g. Program Files the next-logon restore may lack write access; `.onInstFailed` (which runs elevated) still covers the non-kill failures there. Default per-user installs (the reported case) are fully covered. The uninstaller half only takes effect on updates _away from_ a build containing it, same as the previous installer fixes.

## Release note

Windows: a failed or interrupted update can no longer remove the app. The old version is kept next to the install folder until the new one is fully in place and is restored automatically — at the latest at your next Windows sign-in. Updates are also no longer installed while Windows is shutting down; they apply on the next app quit instead.

## Test plan

- `vitest --project main src/main/updater.test.ts` — 42/42 green, including 3 new session-end guard tests (win32 skips install-on-quit, late-created windows are guarded, non-Windows untouched).
- `pnpm typecheck:node`, `pnpm typecheck:test`, `eslint` on touched files — clean.
- Both NSIS build passes (installer and `-DBUILD_UNINSTALLER`) compiled with electron-builder's bundled `makensis` 3.0.4 against the real template includes and flag predicates — exit 0, no warnings.
- `pnpm docs:impact --base origin/main --strict` and `pnpm docs:build` — green (docs updated in `guide/install.md`).
- Not runtime-tested on Windows hardware: the kill-during-shutdown and AV-quarantine scenarios from #1851's investigation checklist still need a Win10/Win11 pass before release.
