### PR TITLE
ci(sync-server): add a manual dispatch trigger to the staging deploy

### DIFF
--- a/.github/workflows/sync-server-deploy-staging.yml
+++ b/.github/workflows/sync-server-deploy-staging.yml
@@ -1,6 +1,11 @@
 name: Deploy sync-server (staging)
 
 on:
+  # Manual escape hatch. The push trigger below is the normal path, but a
+  # dropped workflow run leaves staging silently on older code than main —
+  # with no way to re-deploy short of pushing another sync-server commit.
+  # Mirrors the production workflow, which is dispatch-only.
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## What

Adds `workflow_dispatch` to `Deploy sync-server (staging)`. The `push` trigger stays exactly as it was.

## Why

The push trigger on `main` (`apps/sync-server/**`, `packages/contracts/**`, ...) has been the *only* way to reach staging. When GitHub drops a workflow run, staging silently stays on older code than `main` and there is no way to re-deploy short of pushing another sync-server commit.

That happened today. The bootstrap epic merge `b9da51797` landed on `main` at 15:09Z changing 38 sync-server files. The runs created for that commit were:

```
15:09:12Z  CodeQL         (dynamic)
15:10:37Z  Security CI    (push)
15:12:47Z  React Doctor   (push)  -> startup_failure
```

No staging deploy, no Desktop CI, no Release Drafter. The next sync-server commit (`8505382fc`, 15:21Z) did not produce one either. Staging's last successful deploy is `3ffbc82c2` from 2026-08-24 — two days and the whole bootstrap epic behind `main`.

The visible symptom was a 1000-note vault taking 8m09s to push to staging, with `POST /sync/push` spending ~37.7s per 100-item batch — measured against server code that predates the push batch rewrite.

## Notes

- Production is already `workflow_dispatch`-only, so this makes the two deploy workflows consistent.
- `github.ref` under a dispatch on `main` is `refs/heads/main`, identical to the push event, so the concurrency group is unchanged.
- Nothing else in the workflow reads push-specific context.

## Verification

- `yaml.safe_load` parses the file; triggers resolve to `['workflow_dispatch', 'push']`.
- Grepped the workflow for `github.event` / `head_commit` — no push-only context beyond the concurrency group noted above.