### PR TITLE
perf(sync): batch CRDT snapshot pushes so seeding stops paying per-note round trips

### DIFF
--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -2445,3 +2445,183 @@ describe('CrdtProvider bootstrap doc-capacity raise', () => {
     expect(new CrdtProvider().inactiveDocCapacity).toBe(32)
   })
 })
+
+/**
+ * Batched snapshot pushes.
+ *
+ * The bookkeeping `pushSnapshotForNote` owns — the three skips, zeroing the
+ * counters before the send, restoring them after a failure, closing a doc
+ * nothing else had open — is now shared with a path that sends 50 notes in one
+ * request. These pin that none of it was left behind in the split.
+ */
+describe('CrdtProvider batched snapshot pushes', () => {
+  let provider: CrdtProvider
+  let queue: { enqueue: ReturnType<typeof vi.fn>; dropNote: ReturnType<typeof vi.fn> }
+  let pushSnapshot: ReturnType<typeof vi.fn<SnapshotPushFn>>
+  let pushBatch: ReturnType<typeof vi.fn>
+  /** noteId -> accepted. Anything absent is accepted, like a healthy server. */
+  let rejected: Set<string>
+
+  const markdownRow = (id: string): Record<string, unknown> => ({
+    id,
+    path: `notes/${id}.md`,
+    title: id,
+    fileType: 'markdown'
+  })
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mocks.sent = []
+    mocks.windows.clear()
+    mocks.persistenceInstances.length = 0
+    mocks.persistenceBehavior.mode = 'ok'
+    mocks.preflightResult = { ok: true }
+    mocks.preflightQueue.length = 0
+    mocks.dataDb = {}
+    mocks.vaultUuid = VAULT_UUID
+    mocks.getNoteCacheById.mockImplementation((_db: unknown, id: string) => markdownRow(id))
+    mocks.toAbsolutePath.mockImplementation((p: string) => `/vault/${p}`)
+    mocks.safeRead.mockResolvedValue('# Note\n\nBody')
+    mocks.parseNote.mockReturnValue({ content: 'Body' })
+    mocks.markdownToYFragment.mockImplementation(
+      async (_content: string, fragment: Y.XmlFragment) => {
+        fragment.insert(0, [new Y.XmlText('Body')])
+        return true
+      }
+    )
+    mocks.compactYDoc.mockReturnValue(null)
+
+    queue = { enqueue: vi.fn(), dropNote: vi.fn() }
+    pushSnapshot = vi.fn<SnapshotPushFn>().mockResolvedValue(undefined)
+    rejected = new Set<string>()
+    pushBatch = vi.fn(async (entries: Array<{ noteId: string }>) => {
+      return new Map(entries.map((e) => [e.noteId, !rejected.has(e.noteId)]))
+    })
+
+    provider = new CrdtProvider()
+    await provider.init(queue as any, pushSnapshot, pushBatch as any)
+  })
+
+  afterEach(() => {
+    resetCrdtProvider()
+  })
+
+  it('splits into requests at the server cap instead of one request per note', async () => {
+    // #given a seeded vault's worth of bodies. One request per note was
+    // ~750ms each, so 100 notes cost 15 seconds.
+    const noteIds = Array.from({ length: 120 }, (_, i) => `note-${i}`)
+
+    // #when
+    const results = await provider.pushSnapshotsForNotes(noteIds, { concurrency: 4 })
+
+    // #then 50 + 50 + 20, and the single-note endpoint is never touched.
+    const sizes = pushBatch.mock.calls.map((call) => (call[0] as unknown[]).length)
+    expect(sizes.reduce((a, b) => a + b, 0)).toBe(120)
+    expect(Math.max(...sizes)).toBeLessThanOrEqual(50)
+    expect(pushBatch).toHaveBeenCalledTimes(3)
+    expect(pushSnapshot).not.toHaveBeenCalled()
+    expect(results.size).toBe(120)
+    expect([...results.values()].every(Boolean)).toBe(true)
+  })
+
+  it('prepares a repeated id once, because the endpoint rejects a duplicated note', async () => {
+    // #given the same note named twice. Preparing it twice would also zero its
+    // counters twice and lose the debt the second restore had nothing to put
+    // back.
+    const results = await provider.pushSnapshotsForNotes(['note-1', 'note-1'])
+
+    const batched = pushBatch.mock.calls[0][0] as Array<{ noteId: string }>
+    expect(batched.map((e) => e.noteId)).toEqual(['note-1'])
+    expect(results.size).toBe(1)
+  })
+
+  it('still refuses binary, local-only and empty notes before they reach the wire', async () => {
+    // #given one of each refusal the single-note path documents
+    mocks.getNoteCacheById.mockImplementation((_db: unknown, id: string) => {
+      if (id === 'pdf-note') return { id, path: 'notes/File.pdf', fileType: 'pdf' }
+      if (id === 'private-note') return { ...markdownRow(id), localOnly: true }
+      return markdownRow(id)
+    })
+    // An empty file seeds nothing, so the doc has no state worth pushing.
+    mocks.safeRead.mockImplementation(async (p: string) =>
+      p === '/vault/notes/empty-note.md' ? '' : '# Note\n\nBody'
+    )
+
+    // #when
+    const results = await provider.pushSnapshotsForNotes([
+      'note-ok',
+      'pdf-note',
+      'private-note',
+      'empty-note'
+    ])
+
+    // #then only the real markdown note is sent, and the other three read as
+    // "not pushed" rather than as silent successes.
+    const batched = pushBatch.mock.calls[0][0] as Array<{ noteId: string }>
+    expect(batched.map((e) => e.noteId)).toEqual(['note-ok'])
+    expect(results.get('pdf-note')).toBe(false)
+    expect(results.get('private-note')).toBe(false)
+    expect(results.get('empty-note')).toBe(false)
+    expect(results.get('note-ok')).toBe(true)
+  })
+
+  it('leaves a note the server rejected inside the batch pending and retryable', async () => {
+    // #given two notes with unpushed local edits, one of which the server will
+    // refuse. A 200 with `accepted: false` is the case that used to have no
+    // representation at all.
+    await provider.open('note-a', 1)
+    await provider.open('note-b', 1)
+    provider.updateMeta('note-a', { title: 'edited a' })
+    provider.updateMeta('note-b', { title: 'edited b' })
+    rejected.add('note-b')
+
+    // #when
+    const results = await provider.pushSnapshotsForNotes(['note-a', 'note-b'])
+
+    // #then
+    expect(results.get('note-a')).toBe(true)
+    expect(results.get('note-b')).toBe(false)
+
+    // #and the debt is the thing that makes it retryable: the accepted note
+    // owes nothing, the rejected one owes exactly what it owed before.
+    const metrics = new Map(
+      provider.getDocSizeMetrics().map((m) => [m.noteId, m.pendingSnapshotBytes])
+    )
+    expect(metrics.get('note-a')).toBe(0)
+    expect(metrics.get('note-b')).toBeGreaterThan(0)
+
+    // #and the existing retry paths pick it up unchanged.
+    await expect(provider.pushAllSnapshots()).resolves.toBe(1)
+    expect(pushSnapshot).toHaveBeenCalledTimes(1)
+    expect(pushSnapshot.mock.calls[0][0]).toBe('note-b')
+  })
+
+  it('closes the docs it opened itself and leaves the ones it did not', async () => {
+    // #given one note already open in an editor and one that is not
+    await provider.open('note-open', 3)
+
+    // #when
+    await provider.pushSnapshotsForNotes(['note-open', 'note-closed'])
+
+    // #then the editor's doc survives the push; the borrowed one does not.
+    expect(provider.getDoc('note-open')).toBeDefined()
+    expect(provider.getDoc('note-closed')).toBeUndefined()
+  })
+
+  it('falls back to one push per note when no batch fn is wired', async () => {
+    // #given a provider with only the single-note push — every caller that
+    // never wires a batch fn, which is most of them.
+    const single = new CrdtProvider()
+    const singlePush = vi.fn<SnapshotPushFn>().mockResolvedValue(undefined)
+    await single.init(queue as any, singlePush)
+
+    // #when
+    const results = await single.pushSnapshotsForNotes(['note-a', 'note-b'], { concurrency: 2 })
+
+    // #then
+    expect(singlePush.mock.calls.map((c) => c[0]).sort()).toEqual(['note-a', 'note-b'])
+    expect(results.get('note-a')).toBe(true)
+    expect(results.get('note-b')).toBe(true)
+    await single.destroy()
+  })
+})

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -8,6 +8,8 @@ import { getIndexDatabase } from '../database/client'
 import { getNoteCacheById } from '@main/database/queries/notes'
 import type { CrdtUpdateQueue } from './crdt-queue'
 import { MicrotaskBatchBroadcaster } from '@memry/sync-client/microtask-batch-broadcaster'
+import { parallelWithLimit } from '@memry/sync-client/concurrency'
+import { MAX_CRDT_SNAPSHOT_BATCH_ENTRIES } from '@memry/sync-client/crdt-payload'
 import {
   scheduleWriteback,
   flushPendingWritebacks,
@@ -47,6 +49,39 @@ const ACCUMULATED_BYTES_RECHECK_THRESHOLD = 512 * 1024
 const DEFAULT_INACTIVE_DOC_LIMIT = 32
 
 export type SnapshotPushFn = (noteId: string, state: Uint8Array) => Promise<void>
+
+/** One note's full document state, ready to be encrypted and sent. */
+export interface SnapshotBatchEntry {
+  noteId: string
+  state: Uint8Array
+}
+
+/**
+ * Send several notes' full states in as few requests as the server allows.
+ *
+ * Total by contract: it never rejects, and the map it returns has an entry for
+ * every noteId it was handed. `false` means "not on the server" — a per-note
+ * rejection, a transport failure, an old server whose fallback also failed —
+ * and the provider treats every one of them exactly as it treats a failed
+ * single-note push: counters restored, note still pending.
+ */
+export type SnapshotBatchPushFn = (entries: SnapshotBatchEntry[]) => Promise<Map<string, boolean>>
+
+/**
+ * A note's snapshot bytes, captured and detached from the push that sends them.
+ *
+ * `pushSnapshotForNote` used to do both in one closure, which is what made
+ * batching impossible: the send was inside the per-note bookkeeping. Producing
+ * one of these performs every skip check and every "reset before push" step the
+ * single-note path documents; `settle` performs the "restore on failure" and
+ * "close a doc that was not already open" halves. Exactly one `settle` call per
+ * prepared snapshot, whatever happened in between.
+ */
+interface PreparedSnapshot {
+  noteId: string
+  state: Uint8Array
+  settle: (pushed: boolean) => Promise<void>
+}
 
 export interface CrdtProviderOptions {
   inactiveDocLimit?: number
@@ -109,6 +144,7 @@ export class CrdtProvider {
   private persistenceInitPromise: Promise<void> | null = null
   private updateQueue: CrdtUpdateQueue | null = null
   private snapshotPushFn: SnapshotPushFn | null = null
+  private snapshotBatchPushFn: SnapshotBatchPushFn | null = null
   /**
    * Notes already written to the durable pending store during the current
    * queue-less stretch — see `recordUnqueuedUpdate`. Purely a write-dedupe: the
@@ -167,11 +203,21 @@ export class CrdtProvider {
     }
   }
 
-  async init(queue?: CrdtUpdateQueue, snapshotPush?: SnapshotPushFn): Promise<void> {
+  async init(
+    queue?: CrdtUpdateQueue,
+    snapshotPush?: SnapshotPushFn,
+    /**
+     * Optional on purpose: every caller that does not wire one keeps the
+     * per-note path exactly as it is, which is what the tests and the
+     * no-session provider rely on.
+     */
+    snapshotBatchPush?: SnapshotBatchPushFn
+  ): Promise<void> {
     await this.initPersistence()
 
     this.updateQueue = queue ?? null
     this.snapshotPushFn = snapshotPush ?? null
+    this.snapshotBatchPushFn = snapshotBatchPush ?? null
     // Start the next queue-less stretch from a clean slate. Whatever was
     // recorded during the previous one is on disk and is the drain's problem
     // now; keeping the ids here would suppress the re-record if this provider
@@ -703,6 +749,7 @@ export class CrdtProvider {
     this.openLocks.clear()
     this.updateQueue = null
     this.snapshotPushFn = null
+    this.snapshotBatchPushFn = null
 
     // Write-back keeps its own module-level per-note maps, keyed by ids and
     // absolute paths belonging to the vault being torn down here.
@@ -762,9 +809,20 @@ export class CrdtProvider {
     return pushed
   }
 
-  async pushSnapshotForNote(noteId: string): Promise<boolean> {
-    if (!this.snapshotPushFn) return false
-
+  /**
+   * Everything `pushSnapshotForNote` does EXCEPT the send.
+   *
+   * `null` means "nothing to push" — and it means it for all three of the
+   * reasons the single-note path refuses: a binary note, a local-only note, and
+   * an empty document. It is also what an open that threw returns, in which
+   * case the counters are already back where they were.
+   *
+   * A prepared snapshot has already had its counters zeroed, so a `close()`
+   * racing the send — the LRU's eviction, an editor closing the tab — will not
+   * fire a second push for the same bytes. `settle` is what puts them back if
+   * the send did not land, and it is the caller's obligation.
+   */
+  private async prepareSnapshotForNote(noteId: string): Promise<PreparedSnapshot | null> {
     const indexDb = getIndexDatabase()
     const cached = getNoteCacheById(indexDb, noteId)
     if (cached?.fileType && isBinaryFileType(cached.fileType)) {
@@ -772,7 +830,7 @@ export class CrdtProvider {
         noteId,
         fileType: cached.fileType
       })
-      return false
+      return null
     }
 
     // The row is already in hand, so the authoritative read costs nothing here
@@ -785,20 +843,19 @@ export class CrdtProvider {
     // — a `true` here would be the provider claiming a push it refused to make.
     if (cached?.localOnly) {
       log.debug('Skipping CRDT snapshot push for a local-only note', { noteId })
-      return false
+      return null
     }
 
     const wasOpen = this.docs.has(noteId)
-    let entry: ActiveDoc | undefined
     let clearedAccumulated = 0
     let clearedPending = 0
     try {
       const doc = await this.open(noteId)
-      entry = this.docs.get(noteId)
+      const entry = this.docs.get(noteId)
       const state = Y.encodeStateAsUpdate(doc)
       if (state.length <= 4) {
         if (!wasOpen) await this.close(noteId)
-        return false
+        return null
       }
 
       // Reset accumulatedBytes BEFORE push so close() won't fire a duplicate push
@@ -809,21 +866,153 @@ export class CrdtProvider {
         entry.pendingSnapshotBytes = 0
       }
 
-      await this.snapshotPushFn(noteId, state)
-      log.info('Pushed snapshot for note', { noteId, size: state.byteLength })
+      return {
+        noteId,
+        state,
+        settle: async (pushed: boolean): Promise<void> => {
+          if (!pushed) {
+            // Restore the pre-push counters (additive: updates may have landed
+            // mid-push) so pushAllSnapshots and close() still retry this note.
+            // Re-read rather than closing over `entry`: a batch holds its
+            // prepared notes across one network round trip, long enough for the
+            // LRU to evict a doc or for doOpen to have put a replacement in the
+            // map, and the debt belongs to whatever entry is live now.
+            const live = this.docs.get(noteId)
+            if (live) {
+              live.accumulatedBytes += clearedAccumulated
+              live.pendingSnapshotBytes += clearedPending
+            }
+          }
+          if (!wasOpen) await this.close(noteId)
+        }
+      }
+    } catch (err) {
+      log.warn('Preparing a CRDT snapshot failed', { noteId, error: err })
+      const live = this.docs.get(noteId)
+      if (live) {
+        live.accumulatedBytes += clearedAccumulated
+        live.pendingSnapshotBytes += clearedPending
+      }
       if (!wasOpen) await this.close(noteId)
+      return null
+    }
+  }
+
+  async pushSnapshotForNote(noteId: string): Promise<boolean> {
+    const push = this.snapshotPushFn
+    if (!push) return false
+
+    const prepared = await this.prepareSnapshotForNote(noteId)
+    if (!prepared) return false
+
+    try {
+      await push(noteId, prepared.state)
+      log.info('Pushed snapshot for note', { noteId, size: prepared.state.byteLength })
+      await prepared.settle(true)
       return true
     } catch (err) {
       log.warn('pushSnapshotForNote failed', { noteId, error: err })
-      // Restore the pre-push counters (additive: updates may have landed
-      // mid-push) so pushAllSnapshots and close() still retry this note.
-      if (entry) {
-        entry.accumulatedBytes += clearedAccumulated
-        entry.pendingSnapshotBytes += clearedPending
-      }
-      if (!wasOpen) await this.close(noteId)
+      await prepared.settle(false)
       return false
     }
+  }
+
+  /**
+   * Push several notes' snapshots, in as few requests as the server allows.
+   *
+   * The whole point of the method: one seeded vault used to cost one
+   * `POST /sync/crdt/snapshot` per note (~750ms each, ~600ms of it server-side),
+   * so 100 bodies took 15 seconds. Every note is still prepared and settled
+   * individually — the skips, the counter reset, the restore-on-failure and the
+   * `close()` of a doc nothing else had open are per note and unchanged — only
+   * the send is shared.
+   *
+   * Returns one entry per DISTINCT id, so a caller can tell which notes reached
+   * the server. Duplicate ids are collapsed rather than prepared twice: the
+   * batch endpoint rejects a request that repeats a noteId, and preparing the
+   * same note twice would zero its counters, hand the second prepare nothing to
+   * restore, and lose the debt.
+   *
+   * With no batch fn wired this is exactly the old behaviour — N single pushes
+   * at the same concurrency — which is what keeps every non-runtime caller and
+   * the sign-out path working unchanged.
+   */
+  async pushSnapshotsForNotes(
+    noteIds: string[],
+    options: { concurrency?: number; signal?: AbortSignal } = {}
+  ): Promise<Map<string, boolean>> {
+    const results = new Map<string, boolean>()
+    const unique = [...new Set(noteIds)]
+    if (unique.length === 0) return results
+
+    const concurrency = Math.max(1, options.concurrency ?? 1)
+    const batchPush = this.snapshotBatchPushFn
+
+    if (!batchPush) {
+      const tasks = unique.map((noteId) => async () => {
+        results.set(noteId, await this.pushSnapshotForNote(noteId))
+      })
+      await parallelWithLimit(tasks, concurrency, options.signal)
+      // A task that threw left no entry; the caller reads a missing id the same
+      // way it reads `false`, but spelling it out keeps the "one entry per id"
+      // contract literally true.
+      for (const noteId of unique) if (!results.has(noteId)) results.set(noteId, false)
+      return results
+    }
+
+    const chunks: string[][] = []
+    for (let i = 0; i < unique.length; i += MAX_CRDT_SNAPSHOT_BATCH_ENTRIES) {
+      chunks.push(unique.slice(i, i + MAX_CRDT_SNAPSHOT_BATCH_ENTRIES))
+    }
+
+    const tasks = chunks.map((chunk) => async () => {
+      await this.pushSnapshotChunk(chunk, batchPush, results)
+    })
+    await parallelWithLimit(tasks, concurrency, options.signal)
+
+    for (const noteId of unique) if (!results.has(noteId)) results.set(noteId, false)
+    return results
+  }
+
+  private async pushSnapshotChunk(
+    noteIds: string[],
+    batchPush: SnapshotBatchPushFn,
+    results: Map<string, boolean>
+  ): Promise<void> {
+    const prepared: PreparedSnapshot[] = []
+    for (const noteId of noteIds) {
+      const entry = await this.prepareSnapshotForNote(noteId)
+      if (!entry) {
+        results.set(noteId, false)
+        continue
+      }
+      prepared.push(entry)
+    }
+    if (prepared.length === 0) return
+
+    let outcome: Map<string, boolean>
+    try {
+      outcome = await batchPush(prepared.map(({ noteId, state }) => ({ noteId, state })))
+    } catch (err) {
+      // SnapshotBatchPushFn is documented as total, so this is a bug rather
+      // than a transport failure — treat it as one anyway: a thrown batch means
+      // nothing landed, and every note has to stay retryable.
+      log.warn('Batched CRDT snapshot push threw', { count: prepared.length, error: err })
+      outcome = new Map()
+    }
+
+    let pushedCount = 0
+    for (const entry of prepared) {
+      const pushed = outcome.get(entry.noteId) === true
+      if (pushed) pushedCount++
+      results.set(entry.noteId, pushed)
+      await entry.settle(pushed)
+    }
+
+    log.info('Pushed snapshots in a batch', {
+      requested: prepared.length,
+      pushed: pushedCount
+    })
   }
 
   private initDocStructure(doc: Y.Doc): void {

--- a/apps/desktop/src/main/sync/crdt-snapshot-batch.test.ts
+++ b/apps/desktop/src/main/sync/crdt-snapshot-batch.test.ts
@@ -1,0 +1,260 @@
+/**
+ * The batched snapshot sender, and the three things it must never get wrong:
+ * an old server (404) must still get every body, an unmerged note must never
+ * ride the destructive endpoint, and a per-note `accepted: false` must come
+ * back as `false` so the provider keeps the note pending.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { pushCrdtSnapshotBatchMock } = vi.hoisted(() => ({
+  pushCrdtSnapshotBatchMock: vi.fn()
+}))
+
+vi.mock('../lib/logger', () => {
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+  return { createLogger: () => logger }
+})
+
+vi.mock('../crypto/index', () => ({ secureCleanup: vi.fn() }))
+
+// Real crypto would pull libsodium in for a test about request shaping. The
+// bytes only have to be traceable back to the note they came from.
+vi.mock('./crdt-encrypt', () => ({
+  encryptCrdtUpdate: (state: Uint8Array, _key: Uint8Array, noteId: string) =>
+    new Uint8Array([state[0] ?? 0, noteId.length])
+}))
+
+// SyncServerError stays real: the 404/413 branches are `instanceof` checks.
+vi.mock('./http-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./http-client')>()
+  return { ...actual, pushCrdtSnapshotBatch: pushCrdtSnapshotBatchMock }
+})
+
+import { createCrdtSnapshotBatchPush, type CrdtSnapshotBatchDeps } from './crdt-snapshot-batch'
+import { SyncServerError } from './http-client'
+import type { SnapshotBatchEntry } from './crdt-provider'
+
+const entry = (noteId: string): SnapshotBatchEntry => ({
+  noteId,
+  state: new Uint8Array([1, 2, 3])
+})
+
+const createDeps = (
+  overrides: Partial<CrdtSnapshotBatchDeps> = {}
+): {
+  deps: CrdtSnapshotBatchDeps
+  pushSingle: ReturnType<typeof vi.fn>
+  onBatchError: ReturnType<typeof vi.fn>
+} => {
+  const pushSingle = vi.fn().mockResolvedValue(undefined)
+  const onBatchError = vi.fn()
+  const deps: CrdtSnapshotBatchDeps = {
+    pushSingle,
+    hasUnmergedRemoteState: () => false,
+    getAccessToken: async () => 'token-1',
+    getVaultKey: async () => new Uint8Array(32),
+    getSigningKey: async () => new Uint8Array(64),
+    authRetryDeps: {
+      refreshAccessToken: async () => false,
+      getAccessToken: async () => 'token-1'
+    },
+    onBatchError,
+    ...overrides
+  }
+  return { deps, pushSingle, onBatchError }
+}
+
+const acceptAll = (): void => {
+  pushCrdtSnapshotBatchMock.mockImplementation(async (snapshots: Array<{ noteId: string }>) => ({
+    results: snapshots.map((s) => ({ noteId: s.noteId, accepted: true, sequenceNum: 1 }))
+  }))
+}
+
+describe('createCrdtSnapshotBatchPush', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sends every note in one request and answers for each of them', async () => {
+    // #given three notes queued behind one seeded vault push
+    acceptAll()
+    const { deps, pushSingle } = createDeps()
+
+    // #when
+    const results = await createCrdtSnapshotBatchPush(deps)([
+      entry('note-a'),
+      entry('note-b'),
+      entry('note-c')
+    ])
+
+    // #then one request, not three — the whole point of the endpoint.
+    expect(pushCrdtSnapshotBatchMock).toHaveBeenCalledTimes(1)
+    expect(pushSingle).not.toHaveBeenCalled()
+    expect([...results.entries()]).toEqual([
+      ['note-a', true],
+      ['note-b', true],
+      ['note-c', true]
+    ])
+  })
+
+  it('splits at the wire cap instead of letting the server 400 the request', async () => {
+    // #given more notes than one request may carry
+    acceptAll()
+    const { deps } = createDeps()
+    const entries = Array.from({ length: 120 }, (_, i) => entry(`note-${i}`))
+
+    // #when
+    const results = await createCrdtSnapshotBatchPush(deps)(entries)
+
+    // #then 50 + 50 + 20, and every note still accounted for.
+    const sizes = pushCrdtSnapshotBatchMock.mock.calls.map((call) => (call[0] as unknown[]).length)
+    expect(sizes).toEqual([50, 50, 20])
+    expect(results.size).toBe(120)
+    expect([...results.values()].every(Boolean)).toBe(true)
+  })
+
+  it('reports a per-note rejection as false so the note stays retryable', async () => {
+    // #given a 200 response in which one entry failed. HTTP-level success is
+    // not per-note success, and reading it as one silently drops a body.
+    pushCrdtSnapshotBatchMock.mockResolvedValue({
+      results: [
+        { noteId: 'note-a', accepted: true, sequenceNum: 4 },
+        { noteId: 'note-b', accepted: false, reason: 'storage_quota_exceeded' }
+      ]
+    })
+    const { deps } = createDeps()
+
+    // #when
+    const results = await createCrdtSnapshotBatchPush(deps)([entry('note-a'), entry('note-b')])
+
+    // #then
+    expect(results.get('note-a')).toBe(true)
+    expect(results.get('note-b')).toBe(false)
+  })
+
+  it('treats a note the response never mentioned as not pushed', async () => {
+    // #given a response missing an entry. Defaulting the other way would mark a
+    // body durable on the strength of silence.
+    pushCrdtSnapshotBatchMock.mockResolvedValue({
+      results: [{ noteId: 'note-a', accepted: true }]
+    })
+    const { deps } = createDeps()
+
+    // #when
+    const results = await createCrdtSnapshotBatchPush(deps)([entry('note-a'), entry('note-b')])
+
+    // #then
+    expect(results.get('note-b')).toBe(false)
+  })
+
+  describe('#given a sync server with no batch endpoint', () => {
+    const notFound = (): SyncServerError => new SyncServerError('Server returned 404', 404)
+
+    it('falls back to the per-note push and remembers the answer for the session', async () => {
+      // #given the endpoint 404s, which is exactly what every server released
+      // before it does.
+      pushCrdtSnapshotBatchMock.mockRejectedValue(notFound())
+      const { deps, pushSingle } = createDeps()
+      const push = createCrdtSnapshotBatchPush(deps)
+
+      // #when two rounds of notes go out
+      const first = await push([entry('note-a'), entry('note-b')])
+      const second = await push([entry('note-c')])
+
+      // #then every body still reached the server the old way...
+      expect(pushSingle.mock.calls.map((c) => c[0])).toEqual(['note-a', 'note-b', 'note-c'])
+      expect(first.get('note-a')).toBe(true)
+      expect(second.get('note-c')).toBe(true)
+      // ...and the 404 was paid exactly once, not once per batch.
+      expect(pushCrdtSnapshotBatchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports a note the fallback could not push either', async () => {
+      // #given an old server AND a note the single push rejects
+      pushCrdtSnapshotBatchMock.mockRejectedValue(notFound())
+      const { deps, pushSingle } = createDeps()
+      pushSingle.mockRejectedValueOnce(new Error('server offline'))
+
+      // #when
+      const results = await createCrdtSnapshotBatchPush(deps)([entry('note-a'), entry('note-b')])
+
+      // #then the failure is a `false`, never a throw: the provider needs the
+      // answer to restore that note's pending-snapshot debt.
+      expect(results.get('note-a')).toBe(false)
+      expect(results.get('note-b')).toBe(true)
+    })
+  })
+
+  it('never lets an unmerged note ride the destructive batch', async () => {
+    // #given one note whose server state this device could not merge. The batch
+    // endpoint prunes every device's crdt_updates rows at or below the new
+    // watermark — including the payload this device skipped (#1503).
+    acceptAll()
+    const { deps, pushSingle } = createDeps({
+      hasUnmergedRemoteState: (noteId) => noteId === 'note-unmerged'
+    })
+
+    // #when
+    const results = await createCrdtSnapshotBatchPush(deps)([
+      entry('note-a'),
+      entry('note-unmerged')
+    ])
+
+    // #then it goes through the single push, which routes it to the
+    // non-pruning endpoint, and the batch never sees it.
+    expect(pushSingle).toHaveBeenCalledTimes(1)
+    expect(pushSingle.mock.calls[0][0]).toBe('note-unmerged')
+    const batched = pushCrdtSnapshotBatchMock.mock.calls[0][0] as Array<{ noteId: string }>
+    expect(batched.map((s) => s.noteId)).toEqual(['note-a'])
+    expect(results.get('note-unmerged')).toBe(true)
+  })
+
+  it('retries a too-large batch one note at a time so the offender can be named', async () => {
+    // #given a 413 on the aggregate body, which says nothing about WHICH note
+    // is too big. Only the per-note path can tell the user.
+    pushCrdtSnapshotBatchMock.mockRejectedValue(new SyncServerError('too large', 413))
+    const { deps, pushSingle } = createDeps()
+    const push = createCrdtSnapshotBatchPush(deps)
+
+    // #when
+    await push([entry('note-a'), entry('note-b')])
+    await push([entry('note-c')])
+
+    // #then it fell back...
+    expect(pushSingle.mock.calls.map((c) => c[0])).toEqual(['note-a', 'note-b', 'note-c'])
+    // ...but did NOT latch: a 413 is about one payload, not about the server.
+    expect(pushCrdtSnapshotBatchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('hands a transport failure to the runtime and keeps every note pending', async () => {
+    // #given a 401 the auth retry could not fix
+    const unauthorized = new SyncServerError('unauthorized', 401)
+    pushCrdtSnapshotBatchMock.mockRejectedValue(unauthorized)
+    const { deps, onBatchError, pushSingle } = createDeps()
+
+    // #when
+    const results = await createCrdtSnapshotBatchPush(deps)([entry('note-a'), entry('note-b')])
+
+    // #then the runtime gets the error (it pauses the CRDT queue on 401) and
+    // both notes read as not pushed. No per-note fallback: a 401 would fail
+    // there too, and re-pushing would only burn the same broken token.
+    expect(onBatchError).toHaveBeenCalledWith(unauthorized)
+    expect(pushSingle).not.toHaveBeenCalled()
+    expect([...results.values()]).toEqual([false, false])
+  })
+
+  it('sends nothing when the credentials went away mid-session', async () => {
+    // #given a token that expired during an outage
+    acceptAll()
+    const { deps, pushSingle } = createDeps({ getAccessToken: async () => null })
+
+    // #when
+    const results = await createCrdtSnapshotBatchPush(deps)([entry('note-a')])
+
+    // #then no request, and the note stays pending rather than being reported
+    // durable.
+    expect(pushCrdtSnapshotBatchMock).not.toHaveBeenCalled()
+    expect(pushSingle).not.toHaveBeenCalled()
+    expect(results.get('note-a')).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/sync/crdt-snapshot-batch.ts
+++ b/apps/desktop/src/main/sync/crdt-snapshot-batch.ts
@@ -1,0 +1,206 @@
+/**
+ * The batched half of the CRDT snapshot push.
+ *
+ * `POST /sync/crdt/snapshot` carries exactly one note, and a seeded vault
+ * pushes one per body: 100 notes measured at ~750ms each (~600ms server-side)
+ * = 15 seconds of serialised round trips. `POST /sync/crdt/snapshot/batch`
+ * carries up to MAX_CRDT_SNAPSHOT_BATCH_ENTRIES of them, so the same work is a
+ * couple of requests.
+ *
+ * Lives outside `runtime.ts` because everything below has to be testable
+ * without standing up a sync runtime — the 404 fallback in particular, which is
+ * the path a user on an older sync server takes forever.
+ */
+import { createLogger } from '../lib/logger'
+import { secureCleanup } from '../crypto/index'
+import { withRetry } from '@memry/sync-client/retry'
+import { MAX_CRDT_SNAPSHOT_BATCH_ENTRIES } from '@memry/sync-client/crdt-payload'
+import { encryptCrdtUpdate } from './crdt-encrypt'
+import { pushCrdtSnapshotBatch, SyncServerError } from './http-client'
+import { withAuthRetry, type AuthRetryDeps } from './auth-retry'
+import type { SnapshotBatchEntry, SnapshotBatchPushFn, SnapshotPushFn } from './crdt-provider'
+
+const log = createLogger('CrdtSnapshotBatch')
+
+export interface CrdtSnapshotBatchDeps {
+  /** The single-note push. Every fallback in here goes through it, so the
+   * endpoint choice, the 401/413 handling and the retry budget stay in one
+   * place. Rejects on failure, exactly as `SnapshotPushFn` documents. */
+  pushSingle: SnapshotPushFn
+  /**
+   * "This device has not merged what the server holds for that note."
+   *
+   * The batch endpoint is the destructive one: like `/sync/crdt/snapshot` it
+   * overwrites the note's blob and prunes every device's `crdt_updates` rows at
+   * or below the new watermark. A note this returns `true` for must therefore
+   * never ride it — same reasoning, same consequence and the same #1503
+   * incident as the single-note path, which routes those to
+   * `/sync/crdt/updates` instead. Batching does not get to skip the check.
+   */
+  hasUnmergedRemoteState: (noteId: string) => boolean
+  getAccessToken: () => Promise<string | null>
+  getVaultKey: () => Promise<Uint8Array | null>
+  getSigningKey: () => Promise<Uint8Array | null>
+  authRetryDeps: AuthRetryDeps
+  /** Called with the raw error for a whole-batch failure, so the runtime can do
+   * what it already does for a single push: pause the queue on 401, surface a
+   * quota error on 413. */
+  onBatchError?: (err: unknown) => void
+}
+
+/**
+ * Build the provider's `SnapshotBatchPushFn`.
+ *
+ * The returned fn is TOTAL: it never rejects and always answers for every note
+ * it was handed. A note that answers `false` is one the provider must keep
+ * pending — that is the only channel by which a per-note `accepted: false`
+ * reaches the retry machinery.
+ *
+ * The old-server capability is latched on this closure, so it is per sync
+ * runtime — the same lifetime and the same mechanism as
+ * `CrdtSyncCoordinator.snapshotMetaUnsupported`. One wasted 404 per session,
+ * then the per-note path with no further probing.
+ */
+export function createCrdtSnapshotBatchPush(deps: CrdtSnapshotBatchDeps): SnapshotBatchPushFn {
+  let batchEndpointUnsupported = false
+
+  const pushOneByOne = async (
+    entries: SnapshotBatchEntry[],
+    results: Map<string, boolean>
+  ): Promise<void> => {
+    for (const entry of entries) {
+      try {
+        await deps.pushSingle(entry.noteId, entry.state)
+        results.set(entry.noteId, true)
+      } catch (err) {
+        log.warn('Single-note CRDT snapshot push failed', { noteId: entry.noteId, error: err })
+        results.set(entry.noteId, false)
+      }
+    }
+  }
+
+  return async (entries: SnapshotBatchEntry[]): Promise<Map<string, boolean>> => {
+    const results = new Map<string, boolean>()
+    if (entries.length === 0) return results
+
+    // Split before anything else: an unmerged note is not eligible for the
+    // batch at any point, whether or not the server supports it.
+    const batchable: SnapshotBatchEntry[] = []
+    const unmerged: SnapshotBatchEntry[] = []
+    for (const entry of entries) {
+      if (deps.hasUnmergedRemoteState(entry.noteId)) unmerged.push(entry)
+      else batchable.push(entry)
+    }
+    if (unmerged.length > 0) {
+      log.debug('Routing unmerged notes around the snapshot batch', { count: unmerged.length })
+      await pushOneByOne(unmerged, results)
+    }
+
+    if (batchable.length === 0) return results
+    if (batchEndpointUnsupported) {
+      await pushOneByOne(batchable, results)
+      return results
+    }
+
+    let token = await deps.getAccessToken()
+    const vaultKey = await deps.getVaultKey()
+    const signingSecretKey = await deps.getSigningKey()
+    if (!token || !vaultKey || !signingSecretKey) {
+      log.warn('Missing credentials for the batched CRDT snapshot push', {
+        count: batchable.length,
+        authAvailable: !!token,
+        hasVaultKey: !!vaultKey,
+        hasSigningKey: !!signingSecretKey
+      })
+      if (vaultKey) secureCleanup(vaultKey)
+      if (signingSecretKey) secureCleanup(signingSecretKey)
+      // Not a throw: the notes stay pending because they answer `false`, which
+      // is what the provider needs. Throwing would only skip its bookkeeping.
+      for (const entry of batchable) results.set(entry.noteId, false)
+      return results
+    }
+
+    try {
+      for (let i = 0; i < batchable.length; i += MAX_CRDT_SNAPSHOT_BATCH_ENTRIES) {
+        // The provider already chunks at this size, so in practice there is one
+        // slice. Re-slicing here is what makes the wire cap this module's
+        // problem rather than every caller's.
+        const slice = batchable.slice(i, i + MAX_CRDT_SNAPSHOT_BATCH_ENTRIES)
+
+        if (batchEndpointUnsupported) {
+          await pushOneByOne(slice, results)
+          continue
+        }
+
+        const encrypted = slice.map((entry) => ({
+          noteId: entry.noteId,
+          snapshot: encryptCrdtUpdate(entry.state, vaultKey, entry.noteId, signingSecretKey)
+        }))
+
+        try {
+          const response = await withRetry(
+            () =>
+              withAuthRetry(
+                (authToken) => pushCrdtSnapshotBatch(encrypted, authToken),
+                token!,
+                deps.authRetryDeps,
+                (fresh) => {
+                  token = fresh
+                }
+              ),
+            { maxRetries: 3, baseDelayMs: 2000 }
+          )
+
+          for (const result of response.value.results ?? []) {
+            results.set(result.noteId, result.accepted === true)
+            if (result.accepted !== true) {
+              log.warn('Server rejected a snapshot inside a batch', {
+                noteId: result.noteId,
+                reason: result.reason
+              })
+            }
+          }
+          // A note the response never mentioned did not land. Defaulting to
+          // `false` keeps it pending; defaulting the other way would drop a
+          // body with nothing left to retry it.
+          for (const entry of slice) {
+            if (!results.has(entry.noteId)) results.set(entry.noteId, false)
+          }
+          log.debug('Pushed a CRDT snapshot batch', { count: slice.length })
+        } catch (err) {
+          if (err instanceof SyncServerError && err.statusCode === 404) {
+            // The capability signal. A server that predates the endpoint
+            // answers 404 for it and 200 for the single-note one, so the
+            // fallback is not a degradation — it is what this build did before
+            // the batch existed. Latched for the session so the rest of the
+            // vault does not pay a 404 per batch.
+            batchEndpointUnsupported = true
+            log.info('Sync server has no batched snapshot endpoint; using the per-note path')
+            await pushOneByOne(slice, results)
+            continue
+          }
+
+          if (err instanceof SyncServerError && err.statusCode === 413) {
+            // A body limit hit by the AGGREGATE says nothing about which note is
+            // too large. The per-note path is the thing that can tell — and its
+            // 413 handling is what names the offending note to the user.
+            log.warn('Batched CRDT snapshot push was too large; retrying per note', {
+              count: slice.length
+            })
+            await pushOneByOne(slice, results)
+            continue
+          }
+
+          log.warn('Batched CRDT snapshot push failed', { count: slice.length, error: err })
+          deps.onBatchError?.(err)
+          for (const entry of slice) results.set(entry.noteId, false)
+        }
+      }
+    } finally {
+      secureCleanup(vaultKey)
+      secureCleanup(signingSecretKey)
+    }
+
+    return results
+  }
+}

--- a/apps/desktop/src/main/sync/engine-crdt.test.ts
+++ b/apps/desktop/src/main/sync/engine-crdt.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import type { SyncItemType } from '@memry/contracts/sync-api'
 import { SyncEngine, type SyncEngineDeps } from './engine'
 import { createMockDeps, setupTestDb } from '@tests/utils/engine-mocks'
 
@@ -10,9 +11,9 @@ describe('SyncEngine', () => {
       const callOrder: string[] = []
 
       const mockCrdtProvider = {
-        pushSnapshotForNote: vi.fn().mockImplementation(async () => {
+        pushSnapshotsForNotes: vi.fn().mockImplementation(async (noteIds: string[]) => {
           callOrder.push('pushSnapshot')
-          return true
+          return new Map(noteIds.map((id) => [id, true]))
         })
       }
 
@@ -55,7 +56,10 @@ describe('SyncEngine', () => {
 
       await engine.push()
 
-      expect(mockCrdtProvider.pushSnapshotForNote).toHaveBeenCalledWith('note-1')
+      expect(mockCrdtProvider.pushSnapshotsForNotes).toHaveBeenCalledWith(
+        ['note-1'],
+        expect.anything()
+      )
       expect(callOrder).toEqual(['pushSnapshot', 'postToServer'])
 
       vi.restoreAllMocks()
@@ -63,7 +67,9 @@ describe('SyncEngine', () => {
 
     it('#then pushes CRDT snapshot for journal CREATE items too', async () => {
       const mockCrdtProvider = {
-        pushSnapshotForNote: vi.fn().mockResolvedValue(true)
+        pushSnapshotsForNotes: vi
+          .fn()
+          .mockImplementation(async (noteIds: string[]) => new Map(noteIds.map((id) => [id, true])))
       }
 
       const deps = createMockDeps(getDb(), {
@@ -102,7 +108,10 @@ describe('SyncEngine', () => {
 
       await engine.push()
 
-      expect(mockCrdtProvider.pushSnapshotForNote).toHaveBeenCalledWith('journal-1')
+      expect(mockCrdtProvider.pushSnapshotsForNotes).toHaveBeenCalledWith(
+        ['journal-1'],
+        expect.anything()
+      )
 
       vi.restoreAllMocks()
     })
@@ -111,7 +120,9 @@ describe('SyncEngine', () => {
   describe('#given engine with crdtProvider and UPDATE note queued #when push called', () => {
     it('#then does NOT push CRDT snapshot (only CREATEs trigger snapshot)', async () => {
       const mockCrdtProvider = {
-        pushSnapshotForNote: vi.fn().mockResolvedValue(true)
+        pushSnapshotsForNotes: vi
+          .fn()
+          .mockImplementation(async (noteIds: string[]) => new Map(noteIds.map((id) => [id, true])))
       }
 
       const deps = createMockDeps(getDb(), {
@@ -150,7 +161,7 @@ describe('SyncEngine', () => {
 
       await engine.push()
 
-      expect(mockCrdtProvider.pushSnapshotForNote).not.toHaveBeenCalled()
+      expect(mockCrdtProvider.pushSnapshotsForNotes).not.toHaveBeenCalled()
 
       vi.restoreAllMocks()
     })
@@ -159,7 +170,9 @@ describe('SyncEngine', () => {
   describe('#given engine with crdtProvider and CREATE task queued #when push called', () => {
     it('#then does NOT push CRDT snapshot (only note/journal types trigger snapshot)', async () => {
       const mockCrdtProvider = {
-        pushSnapshotForNote: vi.fn().mockResolvedValue(true)
+        pushSnapshotsForNotes: vi
+          .fn()
+          .mockImplementation(async (noteIds: string[]) => new Map(noteIds.map((id) => [id, true])))
       }
 
       const deps = createMockDeps(getDb(), {
@@ -198,7 +211,7 @@ describe('SyncEngine', () => {
 
       await engine.push()
 
-      expect(mockCrdtProvider.pushSnapshotForNote).not.toHaveBeenCalled()
+      expect(mockCrdtProvider.pushSnapshotsForNotes).not.toHaveBeenCalled()
 
       vi.restoreAllMocks()
     })
@@ -207,7 +220,7 @@ describe('SyncEngine', () => {
   describe('#given engine with crdtProvider where snapshot push fails #when push called', () => {
     it('#then still posts sync items to server (snapshot failure is non-blocking)', async () => {
       const mockCrdtProvider = {
-        pushSnapshotForNote: vi.fn().mockRejectedValue(new Error('network timeout'))
+        pushSnapshotsForNotes: vi.fn().mockRejectedValue(new Error('network timeout'))
       }
 
       const deps = createMockDeps(getDb(), {
@@ -246,7 +259,10 @@ describe('SyncEngine', () => {
 
       await engine.push()
 
-      expect(mockCrdtProvider.pushSnapshotForNote).toHaveBeenCalledWith('note-1')
+      expect(mockCrdtProvider.pushSnapshotsForNotes).toHaveBeenCalledWith(
+        ['note-1'],
+        expect.anything()
+      )
       expect(mockPost).toHaveBeenCalled()
       expect(deps.queue.getPendingCount()).toBe(0)
 
@@ -257,7 +273,9 @@ describe('SyncEngine', () => {
   describe('#given engine with crdtProvider and mixed batch #when push called', () => {
     it('#then only pushes CRDT snapshots for CREATE note/journal items in batch', async () => {
       const mockCrdtProvider = {
-        pushSnapshotForNote: vi.fn().mockResolvedValue(true)
+        pushSnapshotsForNotes: vi
+          .fn()
+          .mockImplementation(async (noteIds: string[]) => new Map(noteIds.map((id) => [id, true])))
       }
 
       const deps = createMockDeps(getDb(), {
@@ -292,13 +310,13 @@ describe('SyncEngine', () => {
 
       let encryptCallCount = 0
       vi.spyOn(await import('./encrypt'), 'encryptItemForPush').mockImplementation(
-        (args: { id: string; type: string; operation: string }) => {
+        (args: { id: string; type: SyncItemType; operation: string }) => {
           encryptCallCount++
           return {
             pushItem: {
               id: args.id,
               type: args.type,
-              operation: args.operation,
+              operation: args.operation as 'create' | 'update' | 'delete',
               encryptedKey: 'ek',
               keyNonce: 'kn',
               encryptedData: 'ed',
@@ -320,9 +338,13 @@ describe('SyncEngine', () => {
 
       await engine.push()
 
-      expect(mockCrdtProvider.pushSnapshotForNote).toHaveBeenCalledTimes(2)
-      expect(mockCrdtProvider.pushSnapshotForNote).toHaveBeenCalledWith('note-1')
-      expect(mockCrdtProvider.pushSnapshotForNote).toHaveBeenCalledWith('journal-1')
+      // One call carrying both eligible ids, not one call per note: the whole
+      // batch is what reaches the server as a single request.
+      expect(mockCrdtProvider.pushSnapshotsForNotes).toHaveBeenCalledTimes(1)
+      expect(mockCrdtProvider.pushSnapshotsForNotes).toHaveBeenCalledWith(
+        ['note-1', 'journal-1'],
+        expect.anything()
+      )
 
       vi.restoreAllMocks()
     })

--- a/apps/desktop/src/main/sync/engine/push-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.ts
@@ -13,7 +13,6 @@ import { postToServer, RateLimitError } from '../http-client'
 import { classifyError } from '../sync-errors'
 import { syncErrorTelemetry } from '../sync-error-telemetry'
 import { isBinaryFileType } from '@memry/shared/file-types'
-import { parallelWithLimit } from '@memry/sync-client/concurrency'
 import { SyncTimer } from '@memry/sync-client/sync-timer'
 import { trackMainEvent } from '../../telemetry/track'
 import type { SyncContext } from './sync-context'
@@ -145,7 +144,7 @@ export class PushCoordinator {
           const payloadAtDequeue = new Map(dedupedItems.map((item) => [item.id, item.payload]))
 
           if (this.ctx.deps.crdtProvider) {
-            const snapshotTasks = dedupedItems
+            const snapshotNoteIds = dedupedItems
               .filter((item) => {
                 if (item.operation !== 'create') return false
                 if (item.type !== 'note' && item.type !== 'journal') return false
@@ -157,16 +156,35 @@ export class PushCoordinator {
                 }
                 return true
               })
-              .map((item) => () => this.ctx.deps.crdtProvider!.pushSnapshotForNote(item.itemId))
-            if (snapshotTasks.length > 0) {
-              const snapshotResults = await parallelWithLimit(
-                snapshotTasks,
-                CRDT_SNAPSHOT_CONCURRENCY,
-                abortSignal
-              )
-              const failedSnapshots = snapshotResults.filter((r) => r.status === 'rejected')
-              if (failedSnapshots.length > 0) {
-                log.warn('Push: some CRDT snapshots failed', { count: failedSnapshots.length })
+              .map((item) => item.itemId)
+            if (snapshotNoteIds.length > 0) {
+              // One call, not one per note: the provider batches these onto
+              // `POST /sync/crdt/snapshot/batch` and only falls back to a
+              // request per note when the server has no such endpoint. A
+              // seeded vault used to spend ~750ms per body here.
+              //
+              // Wrapped because a snapshot failure must never block the record
+              // push — that used to fall out of `parallelWithLimit` swallowing
+              // rejections at this call site, and moving the fan-out into the
+              // provider would otherwise have moved that guarantee with it.
+              try {
+                const snapshotResults = await this.ctx.deps.crdtProvider.pushSnapshotsForNotes(
+                  snapshotNoteIds,
+                  { concurrency: CRDT_SNAPSHOT_CONCURRENCY, signal: abortSignal }
+                )
+                const failedSnapshots = [...snapshotResults.values()].filter((ok) => !ok).length
+                if (failedSnapshots > 0) {
+                  // Not a push failure: the record still goes to /sync/push
+                  // below, and the provider has already restored each failed
+                  // note's pending-snapshot debt so the scheduler, close() and
+                  // the pending-note replay retry it.
+                  log.warn('Push: some CRDT snapshots failed', { count: failedSnapshots })
+                }
+              } catch (err) {
+                log.warn('Push: the CRDT snapshot pass threw', {
+                  count: snapshotNoteIds.length,
+                  error: err
+                })
               }
             }
           }

--- a/apps/desktop/src/main/sync/engine/sync-context.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.ts
@@ -167,7 +167,45 @@ export const STALE_CURSOR_THRESHOLD_MS = 24 * 60 * 60 * 1000
 export const MAX_RATE_LIMIT_BACKOFF_MS = 5 * 60 * 1000
 export const BASE_RATE_LIMIT_BACKOFF_MS = 5_000
 export const YIELD_EVERY_N_ITEMS = 20
-export const CRDT_SNAPSHOT_CONCURRENCY = 5
+/**
+ * Concurrent snapshot-push REQUESTS while a push iteration flushes its creates.
+ *
+ * The unit changed. It used to be concurrent NOTES — `pushSnapshotForNote` per
+ * note, one `POST /sync/crdt/snapshot` each — so at 5 a seeded vault spent one
+ * ~750ms round trip per body and 100 bodies took 15 seconds. A request now
+ * carries up to MAX_CRDT_SNAPSHOT_BATCH_ENTRIES (50) notes, so the old
+ * arithmetic of "concurrency = notes in flight" no longer describes anything.
+ *
+ * What actually bounds the request rate now is the shape of the loop above,
+ * not this number:
+ *
+ *   - `dedupedItems` is at most `pushBatchSize` (100) per iteration, so an
+ *     iteration can produce at most ceil(100 / 50) = 2 snapshot requests;
+ *   - iterations are strictly serial, and each one also waits on its own
+ *     `POST /sync/push` round trip.
+ *
+ * So the ceiling is ~2 `crdt_push` requests per serial iteration. Even at an
+ * implausible one iteration per second that is 120 req/min against the
+ * server's 300/min `crdt_push` bucket (sync.ts, keyed per device) — 40%, inside
+ * the same 50% margin the sweep pacing below is derived against, with the
+ * remainder left for the traffic that still pushes one note at a time: the 30s
+ * snapshot scheduler, `close()`, `pushAllSnapshots`, `compactDoc` and the
+ * pending-note replay.
+ *
+ * 4 is therefore headroom rather than a target — it covers `pushBatchSize`
+ * growing to 200 without this becoming the limiter, and it is deliberately not
+ * larger: every in-flight chunk holds up to 50 Y.Docs open across the request,
+ * and the provider's inactive-doc LRU is 32, so a bigger number only buys more
+ * eviction churn. If `pushBatchSize` or the batch cap moves far enough that
+ * more than 4 chunks can exist at once, re-derive against the 300/min bucket
+ * before raising this.
+ *
+ * It also still bounds the OLD-server path: against a server with no batch
+ * endpoint each chunk falls back to one request per note, sent serially inside
+ * the chunk, which is 4 requests in flight — the same order as the 5 this
+ * replaced.
+ */
+export const CRDT_SNAPSHOT_CONCURRENCY = 4
 // Fallback cadence for the vault-wide CRDT sweep at the end of fullSync, used
 // ONLY when the socket cannot answer whether broadcasts were missed: no sweep
 // recorded against the current engine yet (process start, vault switch, engine

--- a/apps/desktop/src/main/sync/http-client.test.ts
+++ b/apps/desktop/src/main/sync/http-client.test.ts
@@ -40,6 +40,7 @@ import {
   getFromServer,
   deleteFromServer,
   pushCrdtFullUpdate,
+  pushCrdtSnapshotBatch,
   SyncServerError,
   NetworkError,
   RateLimitError,
@@ -357,6 +358,63 @@ describe('http-client', () => {
         'CRDT state too large'
       )
       expect(mockFetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pushCrdtSnapshotBatch', () => {
+    it('sends every note in one request, base64-encoded exactly as the single-note push does', async () => {
+      // #given several notes' encrypted snapshots. The batch endpoint is the
+      // same destructive store-and-prune as /sync/crdt/snapshot, one request
+      // per note collapsed into one request for all of them.
+      mockFetch.mockResolvedValue(
+        createJsonResponse({
+          results: [
+            { noteId: 'note-a', accepted: true, sequenceNum: 7 },
+            { noteId: 'note-b', accepted: false, reason: 'too_large' }
+          ]
+        })
+      )
+
+      // #when
+      const response = await pushCrdtSnapshotBatch(
+        [
+          { noteId: 'note-a', snapshot: new Uint8Array([1, 2, 3]) },
+          { noteId: 'note-b', snapshot: new Uint8Array([4, 5]) }
+        ],
+        'token-1'
+      )
+
+      // #then one request, and a body whose bytes match what pushCrdtSnapshot
+      // would have sent for each note on its own.
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      const [url, init] = mockFetch.mock.calls[0] as [string, { body: string }]
+      expect(url).toContain('/sync/crdt/snapshot/batch')
+      expect(JSON.parse(init.body)).toEqual({
+        snapshots: [
+          { noteId: 'note-a', snapshot: Buffer.from([1, 2, 3]).toString('base64') },
+          { noteId: 'note-b', snapshot: Buffer.from([4, 5]).toString('base64') }
+        ]
+      })
+      // #and the per-note verdicts come back in request order, HTTP 200 even
+      // though one of them failed.
+      expect(response.results.map((r) => r.accepted)).toEqual([true, false])
+    })
+
+    it('surfaces a 404 as a SyncServerError so the caller can detect an old server', async () => {
+      // #given a sync server that predates the endpoint. Hono answers a route
+      // it does not have with a non-JSON 404.
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        headers: new Headers(),
+        json: () => Promise.reject(new Error('not json'))
+      } as unknown as Response)
+
+      // #when / #then the status has to survive: it is the whole capability
+      // signal, and swallowing it would strand every body on old servers.
+      await expect(
+        pushCrdtSnapshotBatch([{ noteId: 'note-a', snapshot: new Uint8Array([1]) }], 'token-1')
+      ).rejects.toMatchObject({ statusCode: 404 })
     })
   })
 

--- a/apps/desktop/src/main/sync/http-client.ts
+++ b/apps/desktop/src/main/sync/http-client.ts
@@ -244,6 +244,50 @@ export async function pushCrdtSnapshot(
   )
 }
 
+/** One note's outcome inside a batched snapshot push. */
+export interface CrdtSnapshotBatchResult {
+  noteId: string
+  accepted: boolean
+  sequenceNum?: number
+  reason?: string
+}
+
+export interface CrdtSnapshotBatchResponse {
+  results: CrdtSnapshotBatchResult[]
+}
+
+/**
+ * Push several notes' snapshots in ONE request.
+ *
+ * Byte-for-byte the same encrypted payload `pushCrdtSnapshot` sends, and with
+ * the same destructive consequence per note (`storeSnapshot` +
+ * `pruneUpdatesBeforeSnapshot`) — so the caller owes every note in `snapshots`
+ * the same "this device contains everything the server has" guarantee that the
+ * single-note path documents. See `crdt-snapshot-batch.ts`, which is the only
+ * thing that should be calling this.
+ *
+ * The response is HTTP 200 even when entries fail: `results` carries one entry
+ * per requested note, in request order, and `accepted: false` is a per-note
+ * failure the caller must keep retryable. A server that predates the endpoint
+ * answers 404, which is the capability signal — this function does not handle
+ * it, the caller latches it.
+ *
+ * The caller must not exceed MAX_CRDT_SNAPSHOT_BATCH_ENTRIES entries, and must
+ * not repeat a noteId within one request; both are 400s.
+ */
+export async function pushCrdtSnapshotBatch(
+  snapshots: Array<{ noteId: string; snapshot: Uint8Array }>,
+  token: string
+): Promise<CrdtSnapshotBatchResponse> {
+  const body = {
+    snapshots: snapshots.map(({ noteId, snapshot }) => ({
+      noteId,
+      snapshot: Buffer.from(snapshot).toString('base64')
+    }))
+  }
+  return postToServer<CrdtSnapshotBatchResponse>('/sync/crdt/snapshot/batch', body, token)
+}
+
 /**
  * Push a full document state to the INCREMENTAL endpoint.
  *

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -93,6 +93,7 @@ import { drainPendingCrdtNotes, recordPendingCrdtNotes } from './crdt-pending-no
 import { recoverDirtyItems } from './dirty-recovery'
 import { markSyncEligible, markSyncIneligible } from '@memry/sync-client/sync-eligibility'
 import { encryptCrdtUpdate } from './crdt-encrypt'
+import { createCrdtSnapshotBatchPush } from './crdt-snapshot-batch'
 import { postToServer, pushCrdtSnapshot, pushCrdtFullUpdate, SyncServerError } from './http-client'
 import { classifyError } from './sync-errors'
 import {
@@ -713,8 +714,39 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
         }
       }
 
+      // One request for up to MAX_CRDT_SNAPSHOT_BATCH_ENTRIES notes instead of
+      // one per note. It reuses `snapshotPushFn` for everything the batch is
+      // not allowed to carry — a note whose server state this device has not
+      // merged, and every note on a server too old to have the endpoint — so
+      // the destructive-endpoint reasoning above still has exactly one owner.
+      const snapshotBatchPushFn = createCrdtSnapshotBatchPush({
+        pushSingle: snapshotPushFn,
+        hasUnmergedRemoteState: (noteId) => engine.hasUnmergedRemoteCrdtState(noteId),
+        getAccessToken: () => getValidAccessToken(),
+        getVaultKey: () => getOptionalRuntimeVaultKey(db, 'crdt snapshot batch push'),
+        getSigningKey: () => retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY),
+        authRetryDeps: crdtAuthRetryDeps,
+        onBatchError: (err) => {
+          // Same two conditions the single push handles, and for the same
+          // reasons — see the comments in snapshotPushFn. A body-limit 413
+          // never reaches here: the batch falls back to the per-note path so
+          // the note that is actually too large can be named.
+          if (err instanceof SyncServerError && err.statusCode === 401) {
+            crdtQueue.pause()
+          }
+          if (
+            err instanceof SyncServerError &&
+            err.statusCode === 413 &&
+            classifyError(err).category === 'storage_quota_exceeded'
+          ) {
+            crdtQueue.pause()
+            emitQuotaExceeded()
+          }
+        }
+      })
+
       const crdtProvider = getCrdtProvider()
-      await crdtProvider.init(crdtQueue, snapshotPushFn)
+      await crdtProvider.init(crdtQueue, snapshotPushFn, snapshotBatchPushFn)
 
       // Created here rather than beside `engine.start()`, where it used to be:
       // the replay below is also triggered by the network monitor, whose

--- a/apps/desktop/tsconfig.test.node.json
+++ b/apps/desktop/tsconfig.test.node.json
@@ -133,7 +133,6 @@
     "src/main/sync/device-registration.test.ts",
     "src/main/sync/dirty-recovery.test.ts",
     "src/main/sync/embed-roundtrip.test.ts",
-    "src/main/sync/engine-crdt.test.ts",
     "src/main/sync/engine-push.test.ts",
     "src/main/sync/engine-retries.test.ts",
     "src/main/sync/engine.test.ts",

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -622,6 +622,7 @@ list.
 | `GET /sync/crdt/updates`               | down      | One note's incremental updates (`note_id`, `since`, `limit` query params)                     |
 | `POST /sync/crdt/updates/batch`        | down      | Incremental updates for up to 100 notes in one request, plus `snapshotMeta`                   |
 | `POST /sync/crdt/snapshot`             | up        | Full Yjs document baseline; prunes the note's stored updates at or below it                   |
+| `POST /sync/crdt/snapshot/batch`       | up        | Up to 50 full baselines in one request; same store-and-prune semantics, reported per note      |
 | `GET /sync/crdt/snapshot/:noteId`      | down      | The note's snapshot baseline and its `revision`, applied before its incrementals              |
 | `GET /sync/vaults`                     | down      | List the account's registered vaults                                                          |
 | `POST /sync/vaults`                    | up        | Register or update a vault's encrypted name                                                   |
@@ -731,6 +732,49 @@ Pushing a snapshot is an assertion, not just a write: once the snapshot is store
 snapshot's sequence number. A snapshot that does not already contain those updates does not merely
 fail to add them — it removes them from the server.
 
+### Batched snapshot uploads
+
+`POST /sync/crdt/snapshot` takes one note per request, and the server spends six serial D1/R2
+round trips on it: the note's current watermark, its existing snapshot row, a storage reservation,
+the R2 put, the upsert, and the prune. That is fine for the editing path, where snapshots trickle
+out behind a 30-second debounce, and expensive for seeding, where a fresh vault pushes a baseline
+for every note it owns. On a 1000-note vault each 100 bodies cost 15 seconds, essentially all of it
+server time.
+
+`POST /sync/crdt/snapshot/batch` carries up to 50 snapshots and pays those costs once per request
+instead of once per note — the metadata reads become one `db.batch` chunked at the bind-param
+ceiling, the reservations become one call for the batch's summed growth, the R2 puts run
+concurrently, and the upserts and prunes become one batch each. Semantics per note are identical to
+the single-note endpoint, including the rule that a note's snapshot watermark stays where it is once
+a snapshot exists.
+
+The response reports each note separately:
+
+```jsonc
+{
+  "results": [
+    { "noteId": "…", "accepted": true, "sequenceNum": 42 },
+    { "noteId": "…", "accepted": false, "reason": "…" }
+  ]
+}
+```
+
+Entries are returned in request order, and one note failing does not fail the others. A storage
+quota that the batch as a whole cannot satisfy still rejects the whole request, exactly as the
+single-note path does — nothing partial lands.
+
+Two notes never ride a batch:
+
+- **A note with unmerged remote state.** The batch endpoint prunes stored updates below the new
+  watermark, so a device that merged around server state it could not verify must not assert "I
+  contain everything up to here". Those notes take the non-pruning `POST /sync/crdt/updates` route,
+  the same way the single-note path already routes them.
+- **Anything pushed to a server that predates this endpoint.** Such a server answers 404 here and
+  200 for the single-note route. The first 404 latches for the session and every later chunk falls
+  back to one request per note, so an old server costs one wasted request rather than one per batch.
+  A 413 also falls back per note but does not latch: the aggregate body being too large says nothing
+  about which note is oversized, and only the per-note path can name it to the user.
+
 ### CRDT update sizing
 
 `POST /sync/crdt/updates` is bounded by two different server limits, and the client
@@ -810,6 +854,12 @@ does not already hold, so a second device on the same account is normal use rath
 Under the default per-user key the two devices split one budget, and a legitimate first sync on
 device B made device A's ordinary syncing start failing with 429s. A request that arrives without a
 deviceId keeps the existing userId → IP fallback, so nothing becomes less strict.
+
+`crdt_push` allows 300 requests per 60 seconds. Batched snapshot uploads changed what that budget
+buys: a push iteration dequeues at most 100 creates and a batch carries 50, so an iteration yields
+at most two snapshot requests, and iterations are serial. Seeding a 1000-note vault therefore costs
+roughly 20 requests rather than 1000, which is why `crdt_push` receives no bootstrap elevation —
+`BOOTSTRAP_ELEVATION_MULTIPLIERS` stays pull-only, and pushes keep their abuse ceilings.
 
 `crdt_pull` allows 600 requests per 60 seconds, which is sized for one device pulling an entire
 vault's bodies after a fresh sign-in. That sweep costs two GETs per note — snapshot plus

--- a/apps/sync-server/src/__tests__/crdt-snapshot-batch.test.ts
+++ b/apps/sync-server/src/__tests__/crdt-snapshot-batch.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createMemoryR2, createSqliteD1, type SqliteD1 } from './d1-sqlite'
+import { ErrorCodes } from '../lib/errors'
+import { generateCrdtKey } from '../services/blob'
+import {
+  getSnapshot,
+  pruneUpdatesBeforeSnapshot,
+  pruneUpdatesBeforeSnapshotBatch,
+  storeSnapshot,
+  storeSnapshotBatch,
+  storeUpdates
+} from '../services/crdt'
+
+/**
+ * The batched snapshot writer (#1857) against the REAL migration ledger.
+ *
+ * The hand-written D1 double in services/crdt.test.ts answers whatever it was
+ * taught, so a wrong column list, a wrong bind order, or an IN(...) past the
+ * bind-parameter ceiling passes there. This file runs the actual SQL against
+ * the actual schema, and — because backward compatibility is the whole point —
+ * asserts the batch writes rows INDISTINGUISHABLE from the ones the single-note
+ * endpoint writes, note for note.
+ */
+
+const USER_ID = 'user-snapshot-batch'
+const VAULT_ID = 'vault-1'
+const DEVICE_ID = 'device-snapshot-batch'
+
+let harness: SqliteD1
+let storage: R2Bucket
+
+const now = (): number => Math.floor(Date.now() / 1000)
+
+const bytes = (value: string): ArrayBuffer => {
+  const encoded = new TextEncoder().encode(value)
+  const copy = new Uint8Array(encoded.byteLength)
+  copy.set(encoded)
+  return copy.buffer
+}
+
+const storageUsed = (): number =>
+  (
+    harness.raw.prepare('SELECT storage_used FROM users WHERE id = ?').get(USER_ID) as {
+      storage_used: number
+    }
+  ).storage_used
+
+const snapshotRow = (
+  noteId: string
+): {
+  id: string
+  blob_key: string
+  sequence_num: number
+  size_bytes: number
+  signer_device_id: string
+  revision: string
+  client_platform: string | null
+  client_version: string | null
+} =>
+  harness.raw
+    .prepare('SELECT * FROM crdt_snapshots WHERE user_id = ? AND vault_id = ? AND note_id = ?')
+    .get(USER_ID, VAULT_ID, noteId) as never
+
+const updateCount = (noteId: string): number =>
+  (
+    harness.raw
+      .prepare(
+        'SELECT COUNT(*) as n FROM crdt_updates WHERE user_id = ? AND vault_id = ? AND note_id = ?'
+      )
+      .get(USER_ID, VAULT_ID, noteId) as { n: number }
+  ).n
+
+beforeEach(() => {
+  harness = createSqliteD1()
+  storage = createMemoryR2()
+
+  harness.raw
+    .prepare(
+      `INSERT INTO users (id, email, email_verified, auth_method, storage_used, storage_limit, created_at, updated_at)
+       VALUES (?, ?, 1, 'otp', 0, 0, ?, ?)`
+    )
+    .run(USER_ID, 'snapshot-batch@example.com', now(), now())
+
+  harness.raw
+    .prepare(
+      `INSERT INTO sync_entitlements (user_id, plan, status, source, storage_limit, max_file_size, max_vaults, version_history_days, updated_at)
+       VALUES (?, 'plus', 'active', 'paddle', ?, ?, NULL, 30, ?)`
+    )
+    .run(USER_ID, 50 * 1024 * 1024 * 1024, 100 * 1024 * 1024, now())
+})
+
+afterEach(() => {
+  harness.close()
+})
+
+describe('storeSnapshotBatch', () => {
+  it('stores every snapshot and answers one result per input, in request order', async () => {
+    // #given three notes the server has never seen
+    const inputs = ['note_c', 'note_a', 'note_b'].map((noteId) => ({
+      noteId,
+      snapshotData: bytes(`body-${noteId}`)
+    }))
+
+    // #when
+    const outcomes = await storeSnapshotBatch(
+      harness.db,
+      storage,
+      USER_ID,
+      VAULT_ID,
+      DEVICE_ID,
+      inputs,
+      { platform: 'desktop', version: '1.2.3' }
+    )
+
+    // #then — order is the request's, not the database's
+    expect(outcomes).toEqual([
+      { noteId: 'note_c', accepted: true, sequenceNum: 0 },
+      { noteId: 'note_a', accepted: true, sequenceNum: 0 },
+      { noteId: 'note_b', accepted: true, sequenceNum: 0 }
+    ])
+
+    for (const { noteId } of inputs) {
+      const row = snapshotRow(noteId)
+      expect(row.blob_key).toBe(generateCrdtKey(USER_ID, noteId, VAULT_ID))
+      expect(row.signer_device_id).toBe(DEVICE_ID)
+      expect(row.client_platform).toBe('desktop')
+      expect(row.client_version).toBe('1.2.3')
+
+      // The bytes are actually in R2 under the row's key.
+      const stored = await getSnapshot(harness.db, storage, USER_ID, VAULT_ID, noteId)
+      expect(new TextDecoder().decode(stored!.snapshotData)).toBe(`body-${noteId}`)
+    }
+  })
+
+  // The single-note path is what every shipped client uses, and it is not going
+  // away. A batch that writes a different row for the same input is a data bug
+  // the wire contract cannot catch.
+  it('writes the same row the single-note path writes for the same input', async () => {
+    // #given the same body pushed both ways, on two notes with identical history
+    for (const noteId of ['note_single', 'note_batch']) {
+      await storeUpdates(harness.db, USER_ID, VAULT_ID, noteId, DEVICE_ID, [bytes('u1')])
+    }
+
+    // #when
+    await storeSnapshot(
+      harness.db,
+      storage,
+      USER_ID,
+      VAULT_ID,
+      'note_single',
+      DEVICE_ID,
+      bytes('same-body')
+    )
+    await storeSnapshotBatch(harness.db, storage, USER_ID, VAULT_ID, DEVICE_ID, [
+      { noteId: 'note_batch', snapshotData: bytes('same-body') }
+    ])
+
+    // #then — everything but the row identity and the revision (both fresh
+    // UUIDs by design) matches column for column
+    const single = snapshotRow('note_single')
+    const batch = snapshotRow('note_batch')
+    expect(batch.sequence_num).toBe(single.sequence_num)
+    expect(batch.size_bytes).toBe(single.size_bytes)
+    expect(batch.signer_device_id).toBe(single.signer_device_id)
+    expect(batch.id).not.toBe(single.id)
+    expect(batch.revision).not.toBe(single.revision)
+  })
+
+  it('leaves the watermark where it was for a note that already has a snapshot', async () => {
+    // #given a note snapshotted at sequence 2, with two newer incrementals
+    await storeUpdates(harness.db, USER_ID, VAULT_ID, 'note_old', DEVICE_ID, [
+      bytes('u1'),
+      bytes('u2')
+    ])
+    await storeSnapshot(
+      harness.db,
+      storage,
+      USER_ID,
+      VAULT_ID,
+      'note_old',
+      DEVICE_ID,
+      bytes('first')
+    )
+    expect(snapshotRow('note_old').sequence_num).toBe(2)
+    await storeUpdates(harness.db, USER_ID, VAULT_ID, 'note_old', DEVICE_ID, [
+      bytes('u3'),
+      bytes('u4')
+    ])
+
+    // #given a sibling in the same batch that has updates but no snapshot yet
+    await storeUpdates(harness.db, USER_ID, VAULT_ID, 'note_new', DEVICE_ID, [
+      bytes('n1'),
+      bytes('n2'),
+      bytes('n3')
+    ])
+
+    // #when both ride in one batch
+    const outcomes = await storeSnapshotBatch(harness.db, storage, USER_ID, VAULT_ID, DEVICE_ID, [
+      { noteId: 'note_old', snapshotData: bytes('second') },
+      { noteId: 'note_new', snapshotData: bytes('fresh') }
+    ])
+
+    // #then — the existing watermark is preserved so updates 3..4 stay pullable,
+    // while the fresh note takes the current max
+    expect(outcomes).toEqual([
+      { noteId: 'note_old', accepted: true, sequenceNum: 2 },
+      { noteId: 'note_new', accepted: true, sequenceNum: 3 }
+    ])
+    expect(snapshotRow('note_old').sequence_num).toBe(2)
+    expect(snapshotRow('note_new').sequence_num).toBe(3)
+  })
+
+  // A revision that fails to move when the blob does leaves a client on a stale
+  // body forever — the one failure this token exists to prevent.
+  it('mints a fresh revision on every write, insert and conflict alike', async () => {
+    // #given a first batch
+    await storeSnapshotBatch(harness.db, storage, USER_ID, VAULT_ID, DEVICE_ID, [
+      { noteId: 'note_r', snapshotData: bytes('v1') }
+    ])
+    const first = snapshotRow('note_r')
+
+    // #when the SAME bytes are pushed again
+    await storeSnapshotBatch(harness.db, storage, USER_ID, VAULT_ID, DEVICE_ID, [
+      { noteId: 'note_r', snapshotData: bytes('v1') }
+    ])
+    const second = snapshotRow('note_r')
+
+    // #then the revision moved, and the row identity did not (ON CONFLICT never
+    // rewrites `id`, which is what makes the legacy-revision fallback stable)
+    expect(second.revision).not.toBe(first.revision)
+    expect(second.id).toBe(first.id)
+    expect(second.revision).not.toBe('')
+  })
+
+  it('charges storage once for the batch and books shrinks per note', async () => {
+    // #given a first batch of two 10-byte bodies
+    await storeSnapshotBatch(harness.db, storage, USER_ID, VAULT_ID, DEVICE_ID, [
+      { noteId: 'note_s1', snapshotData: bytes('0123456789') },
+      { noteId: 'note_s2', snapshotData: bytes('0123456789') }
+    ])
+    expect(storageUsed()).toBe(20)
+
+    // #when one body grows and the other shrinks
+    await storeSnapshotBatch(harness.db, storage, USER_ID, VAULT_ID, DEVICE_ID, [
+      { noteId: 'note_s1', snapshotData: bytes('0123456789abcde') },
+      { noteId: 'note_s2', snapshotData: bytes('012') }
+    ])
+
+    // #then the account reflects both deltas exactly (+5, -7)
+    expect(storageUsed()).toBe(18)
+  })
+
+  it('reports an R2 put failure against its own note and refunds only its bytes', async () => {
+    // #given a bucket that refuses exactly one key
+    const failingKey = generateCrdtKey(USER_ID, 'note_bad', VAULT_ID)
+    const realPut = storage.put.bind(storage) as (
+      key: string,
+      value: ArrayBuffer
+    ) => Promise<R2Object>
+    vi.spyOn(storage, 'put').mockImplementation((async (key: string, value: ArrayBuffer) => {
+      // "access denied" classifies as terminal, so putBlob does not burn its
+      // retry budget on a failure the test means to be permanent.
+      if (key === failingKey) throw new Error('access denied')
+      return realPut(key, value)
+    }) as typeof storage.put)
+
+    // #when it rides in the middle of a healthy batch
+    const outcomes = await storeSnapshotBatch(harness.db, storage, USER_ID, VAULT_ID, DEVICE_ID, [
+      { noteId: 'note_ok1', snapshotData: bytes('0123456789') },
+      { noteId: 'note_bad', snapshotData: bytes('0123456789') },
+      { noteId: 'note_ok2', snapshotData: bytes('0123456789') }
+    ])
+
+    // #then only that note fails, and it fails with a typed reason
+    expect(outcomes).toEqual([
+      { noteId: 'note_ok1', accepted: true, sequenceNum: 0 },
+      { noteId: 'note_bad', accepted: false, reason: ErrorCodes.STORAGE_UNAUTHORIZED },
+      { noteId: 'note_ok2', accepted: true, sequenceNum: 0 }
+    ])
+
+    // #then the failed put left NO row behind, and its reservation came back
+    expect(
+      harness.raw
+        .prepare('SELECT id FROM crdt_snapshots WHERE user_id = ? AND note_id = ?')
+        .get(USER_ID, 'note_bad')
+    ).toBeUndefined()
+    expect(storageUsed()).toBe(20)
+  })
+
+  it('rejects the whole batch with a typed quota error rather than a partial write', async () => {
+    // #given an entitlement with almost no room left
+    harness.raw
+      .prepare('UPDATE sync_entitlements SET storage_limit = ? WHERE user_id = ?')
+      .run(5, USER_ID)
+
+    // #when
+    const push = storeSnapshotBatch(harness.db, storage, USER_ID, VAULT_ID, DEVICE_ID, [
+      { noteId: 'note_q1', snapshotData: bytes('0123456789') },
+      { noteId: 'note_q2', snapshotData: bytes('0123456789') }
+    ])
+
+    // #then the same typed error the single-note push throws, and nothing landed
+    await expect(push).rejects.toMatchObject({ code: ErrorCodes.STORAGE_QUOTA_EXCEEDED })
+    expect(
+      (
+        harness.raw
+          .prepare('SELECT COUNT(*) as n FROM crdt_snapshots WHERE user_id = ?')
+          .get(USER_ID) as { n: number }
+      ).n
+    ).toBe(0)
+    expect(storageUsed()).toBe(0)
+  })
+
+  // D1 rejects any statement past 100 bound parameters with a 500 on the whole
+  // request. A full batch is the case that fills a chunk, and it is exactly the
+  // bulk-seed case the endpoint exists for.
+  it('stays inside the D1 bind-parameter ceiling for a full 50-note batch', async () => {
+    // #given the largest batch the route accepts
+    const inputs = Array.from({ length: 50 }, (_, i) => ({
+      noteId: `note_bulk_${i}`,
+      snapshotData: bytes(`body-${i}`)
+    }))
+
+    // #when
+    const outcomes = await storeSnapshotBatch(
+      harness.db,
+      storage,
+      USER_ID,
+      VAULT_ID,
+      DEVICE_ID,
+      inputs
+    )
+
+    // #then
+    expect(outcomes.every((outcome) => outcome.accepted)).toBe(true)
+    expect(
+      (
+        harness.raw
+          .prepare('SELECT COUNT(*) as n FROM crdt_snapshots WHERE user_id = ?')
+          .get(USER_ID) as { n: number }
+      ).n
+    ).toBe(50)
+  })
+})
+
+describe('pruneUpdatesBeforeSnapshotBatch', () => {
+  it('prunes every note at its own watermark and refunds the freed bytes once', async () => {
+    // #given two notes with updates, snapshotted in one batch
+    await storeUpdates(harness.db, USER_ID, VAULT_ID, 'note_p1', DEVICE_ID, [
+      bytes('aaaa'),
+      bytes('bbbb')
+    ])
+    await storeUpdates(harness.db, USER_ID, VAULT_ID, 'note_p2', DEVICE_ID, [bytes('cccc')])
+    const outcomes = await storeSnapshotBatch(harness.db, storage, USER_ID, VAULT_ID, DEVICE_ID, [
+      { noteId: 'note_p1', snapshotData: bytes('s1') },
+      { noteId: 'note_p2', snapshotData: bytes('s2') }
+    ])
+    // 4 + 4 + 4 update bytes, then 2 + 2 snapshot bytes
+    expect(storageUsed()).toBe(16)
+
+    // #given one update that arrives AFTER the watermark
+    await storeUpdates(harness.db, USER_ID, VAULT_ID, 'note_p1', DEVICE_ID, [bytes('dddd')])
+
+    // #when
+    const changes = await pruneUpdatesBeforeSnapshotBatch(
+      harness.db,
+      USER_ID,
+      VAULT_ID,
+      outcomes
+        .filter((outcome) => outcome.accepted === true)
+        .map((outcome) => ({ noteId: outcome.noteId, sequenceNum: outcome.sequenceNum }))
+    )
+
+    // #then the pre-watermark updates are gone, the newer one survives, and the
+    // 12 freed bytes are credited exactly once
+    expect(changes).toBe(3)
+    expect(updateCount('note_p1')).toBe(1)
+    expect(updateCount('note_p2')).toBe(0)
+    expect(storageUsed()).toBe(8)
+  })
+
+  it('matches the single-note prune note for note', async () => {
+    // #given two notes with identical history
+    for (const noteId of ['note_x', 'note_y']) {
+      await storeUpdates(harness.db, USER_ID, VAULT_ID, noteId, DEVICE_ID, [
+        bytes('aaaa'),
+        bytes('bbbb')
+      ])
+      await storeSnapshot(harness.db, storage, USER_ID, VAULT_ID, noteId, DEVICE_ID, bytes('s'))
+    }
+
+    // #when one is pruned singly and the other in a batch
+    const single = await pruneUpdatesBeforeSnapshot(harness.db, USER_ID, VAULT_ID, 'note_x')
+    const batched = await pruneUpdatesBeforeSnapshotBatch(harness.db, USER_ID, VAULT_ID, [
+      { noteId: 'note_y', sequenceNum: snapshotRow('note_y').sequence_num }
+    ])
+
+    // #then
+    expect(batched).toBe(single)
+    expect(updateCount('note_x')).toBe(0)
+    expect(updateCount('note_y')).toBe(0)
+  })
+
+  it('does nothing and touches no storage for an empty note list', async () => {
+    // #when
+    const changes = await pruneUpdatesBeforeSnapshotBatch(harness.db, USER_ID, VAULT_ID, [])
+
+    // #then
+    expect(changes).toBe(0)
+    expect(storageUsed()).toBe(0)
+  })
+})

--- a/apps/sync-server/src/routes/sync.test.ts
+++ b/apps/sync-server/src/routes/sync.test.ts
@@ -74,8 +74,10 @@ vi.mock('../services/crdt', () => ({
   getUpdates: vi.fn().mockResolvedValue({ updates: [], hasMore: false }),
   getBatchUpdates: vi.fn().mockResolvedValue({}),
   storeSnapshot: vi.fn().mockResolvedValue({ sequenceNum: 0 }),
+  storeSnapshotBatch: vi.fn().mockResolvedValue([]),
   getSnapshot: vi.fn().mockResolvedValue(null),
-  pruneUpdatesBeforeSnapshot: vi.fn().mockResolvedValue(0)
+  pruneUpdatesBeforeSnapshot: vi.fn().mockResolvedValue(0),
+  pruneUpdatesBeforeSnapshotBatch: vi.fn().mockResolvedValue(0)
 }))
 
 vi.mock('../services/device', () => ({
@@ -149,9 +151,12 @@ import {
   getUpdates,
   getBatchUpdates,
   storeSnapshot,
+  storeSnapshotBatch,
   getSnapshot,
-  pruneUpdatesBeforeSnapshot
+  pruneUpdatesBeforeSnapshot,
+  pruneUpdatesBeforeSnapshotBatch
 } from '../services/crdt'
+import { bootstrapRateLimitElevation } from '../services/bootstrap-session'
 import { authMiddleware } from '../middleware/auth'
 import { updateDevice } from '../services/device'
 import { getStorageBreakdown } from '../services/storage'
@@ -1585,6 +1590,231 @@ describe('sync routes', () => {
       expect(point.properties.path).toBe('/sync/crdt/snapshot')
     })
 
+    // ========================================================================
+    // POST /sync/crdt/snapshot/batch (#1857)
+    //
+    // The single-note endpoint stays byte-for-byte what it was; these cover the
+    // batch sibling's wire contract. The writer's own invariants (watermark,
+    // revision, storage accounting, bind ceiling) are proven against the real
+    // schema in __tests__/crdt-snapshot-batch.test.ts.
+    // ========================================================================
+
+    const batchBody = (noteIds: string[]) => ({
+      snapshots: noteIds.map((noteId) => ({ noteId, snapshot: btoa(`body-${noteId}`) }))
+    })
+
+    it('stores a snapshot batch and answers one result per note in request order', async () => {
+      vi.mocked(storeSnapshotBatch).mockResolvedValueOnce([
+        { noteId: 'note_b', accepted: true, sequenceNum: 7 },
+        { noteId: 'note_a', accepted: true, sequenceNum: 0 }
+      ])
+
+      const res = await app.request(
+        'http://localhost/sync/crdt/snapshot/batch',
+        jsonPost('/sync/crdt/snapshot/batch', batchBody(['note_b', 'note_a'])),
+        env,
+        executionCtx
+      )
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({
+        results: [
+          { noteId: 'note_b', accepted: true, sequenceNum: 7 },
+          { noteId: 'note_a', accepted: true, sequenceNum: 0 }
+        ]
+      })
+      expect(storeSnapshotBatch).toHaveBeenCalledWith(
+        env.DB,
+        env.STORAGE,
+        'user-1',
+        'vault-1',
+        'device-1',
+        [
+          { noteId: 'note_b', snapshotData: expect.any(ArrayBuffer) },
+          { noteId: 'note_a', snapshotData: expect.any(ArrayBuffer) }
+        ],
+        null
+      )
+      // One prune round trip for the whole batch, at each note's own watermark.
+      expect(pruneUpdatesBeforeSnapshotBatch).toHaveBeenCalledTimes(1)
+      expect(pruneUpdatesBeforeSnapshotBatch).toHaveBeenCalledWith(env.DB, 'user-1', 'vault-1', [
+        { noteId: 'note_b', sequenceNum: 7 },
+        { noteId: 'note_a', sequenceNum: 0 }
+      ])
+    })
+
+    // A snapshot is the only shape edits made while signed out can leave in, so
+    // an unannounced batch is invisible on every peer until the next sweep.
+    it('broadcasts crdt_updated once per accepted note, and never for a rejected one', async () => {
+      vi.mocked(storeSnapshotBatch).mockResolvedValueOnce([
+        { noteId: 'note_a', accepted: true, sequenceNum: 1 },
+        { noteId: 'note_b', accepted: false, reason: ErrorCodes.STORAGE_UPLOAD_FAILED },
+        { noteId: 'note_c', accepted: true, sequenceNum: 2 }
+      ])
+
+      const res = await app.request(
+        'http://localhost/sync/crdt/snapshot/batch',
+        jsonPost('/sync/crdt/snapshot/batch', batchBody(['note_a', 'note_b', 'note_c'])),
+        env,
+        executionCtx
+      )
+
+      expect(res.status).toBe(200)
+      expect(mockDoStub.fetch).toHaveBeenCalledTimes(2)
+      const broadcasts = await Promise.all(
+        mockDoStub.fetch.mock.calls.map(([request]) => (request as Request).json())
+      )
+      expect(broadcasts).toEqual([
+        { excludeDeviceId: 'device-1', vaultId: 'vault-1', type: 'crdt_updated', noteId: 'note_a' },
+        { excludeDeviceId: 'device-1', vaultId: 'vault-1', type: 'crdt_updated', noteId: 'note_c' }
+      ])
+      expect(pruneUpdatesBeforeSnapshotBatch).toHaveBeenCalledWith(env.DB, 'user-1', 'vault-1', [
+        { noteId: 'note_a', sequenceNum: 1 },
+        { noteId: 'note_c', sequenceNum: 2 }
+      ])
+    })
+
+    // Peers told early can pull while the pre-snapshot updates are still going.
+    it('broadcasts only after the batch is stored and prior updates are pruned', async () => {
+      const order: string[] = []
+      vi.mocked(storeSnapshotBatch).mockImplementationOnce(async () => {
+        order.push('store')
+        return [{ noteId: 'note_a', accepted: true, sequenceNum: 1 }]
+      })
+      vi.mocked(pruneUpdatesBeforeSnapshotBatch).mockImplementationOnce(async () => {
+        order.push('prune')
+        return 0
+      })
+      mockDoStub.fetch.mockImplementationOnce(async () => {
+        order.push('broadcast')
+        return Response.json({ sent: 1 })
+      })
+
+      const res = await app.request(
+        'http://localhost/sync/crdt/snapshot/batch',
+        jsonPost('/sync/crdt/snapshot/batch', batchBody(['note_a'])),
+        env,
+        executionCtx
+      )
+
+      expect(res.status).toBe(200)
+      expect(order).toEqual(['store', 'prune', 'broadcast'])
+    })
+
+    it('reports an undecodable payload against its own note and keeps the batch at 200', async () => {
+      vi.mocked(storeSnapshotBatch).mockResolvedValueOnce([
+        { noteId: 'note_a', accepted: true, sequenceNum: 1 }
+      ])
+
+      const res = await app.request(
+        'http://localhost/sync/crdt/snapshot/batch',
+        jsonPost('/sync/crdt/snapshot/batch', {
+          snapshots: [
+            { noteId: 'note_a', snapshot: btoa('body-a') },
+            { noteId: 'note_bad', snapshot: 'not base64 !!!' }
+          ]
+        }),
+        env,
+        executionCtx
+      )
+
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as { results: Array<Record<string, unknown>> }
+      expect(json.results[0]).toEqual({ noteId: 'note_a', accepted: true, sequenceNum: 1 })
+      expect(json.results[1]).toMatchObject({ noteId: 'note_bad', accepted: false })
+      expect(json.results[1].reason).toBe(ErrorCodes.VALIDATION_ERROR)
+      // The good note still reached the writer, alone.
+      expect(vi.mocked(storeSnapshotBatch).mock.calls[0][5]).toEqual([
+        { noteId: 'note_a', snapshotData: expect.any(ArrayBuffer) }
+      ])
+    })
+
+    it('rejects duplicate note ids in a snapshot batch', async () => {
+      const res = await app.request(
+        'http://localhost/sync/crdt/snapshot/batch',
+        jsonPost('/sync/crdt/snapshot/batch', batchBody(['note_1', 'note_1'])),
+        env,
+        executionCtx
+      )
+
+      expect(res.status).toBe(400)
+      expect(storeSnapshotBatch).not.toHaveBeenCalled()
+    })
+
+    it('caps a snapshot batch at 50 notes', async () => {
+      const overCap = Array.from({ length: 51 }, (_, i) => `note_${i}`)
+
+      let res = await app.request(
+        'http://localhost/sync/crdt/snapshot/batch',
+        jsonPost('/sync/crdt/snapshot/batch', batchBody(overCap)),
+        env,
+        executionCtx
+      )
+      expect(res.status).toBe(400)
+      expect(storeSnapshotBatch).not.toHaveBeenCalled()
+
+      vi.mocked(storeSnapshotBatch).mockResolvedValueOnce(
+        overCap.slice(0, 50).map((noteId) => ({ noteId, accepted: true as const, sequenceNum: 0 }))
+      )
+      res = await app.request(
+        'http://localhost/sync/crdt/snapshot/batch',
+        jsonPost('/sync/crdt/snapshot/batch', batchBody(overCap.slice(0, 50))),
+        env,
+        executionCtx
+      )
+      expect(res.status).toBe(200)
+      expect(storeSnapshotBatch).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects an empty snapshot batch', async () => {
+      const res = await app.request(
+        'http://localhost/sync/crdt/snapshot/batch',
+        jsonPost('/sync/crdt/snapshot/batch', { snapshots: [] }),
+        env,
+        executionCtx
+      )
+
+      expect(res.status).toBe(400)
+      expect(storeSnapshotBatch).not.toHaveBeenCalled()
+    })
+
+    it('returns the quota status for a batch the account cannot afford', async () => {
+      vi.mocked(storeSnapshotBatch).mockRejectedValueOnce(
+        new AppError(ErrorCodes.STORAGE_QUOTA_EXCEEDED, 'Storage quota exceeded', 413)
+      )
+
+      const res = await app.request(
+        'http://localhost/sync/crdt/snapshot/batch',
+        jsonPost('/sync/crdt/snapshot/batch', batchBody(['note_a', 'note_b'])),
+        env,
+        executionCtx
+      )
+
+      expect(res.status).toBe(413)
+      expect(pruneUpdatesBeforeSnapshotBatch).not.toHaveBeenCalled()
+      expect(mockDoStub.fetch).not.toHaveBeenCalled()
+    })
+
+    // Every shipped client posts to /sync/crdt/snapshot. Adding the batch route
+    // must not move that path onto the new writer.
+    it('leaves the single-note snapshot endpoint on the single-note writer', async () => {
+      vi.mocked(storeSnapshot).mockResolvedValueOnce({ sequenceNum: 12 })
+
+      const res = await app.request(
+        'http://localhost/sync/crdt/snapshot',
+        jsonPost('/sync/crdt/snapshot', { noteId: 'note_1', snapshot: btoa('snapshot') }),
+        env,
+        executionCtx
+      )
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ sequenceNum: 12 })
+      expect(storeSnapshotBatch).not.toHaveBeenCalled()
+      expect(pruneUpdatesBeforeSnapshotBatch).not.toHaveBeenCalled()
+      expect(storeSnapshot).toHaveBeenCalledTimes(1)
+      expect(pruneUpdatesBeforeSnapshot).toHaveBeenCalledTimes(1)
+    })
+
     it('logs and returns quota errors for CRDT update and snapshot writes', async () => {
       vi.mocked(storeUpdates).mockRejectedValueOnce(
         new AppError(ErrorCodes.STORAGE_QUOTA_EXCEEDED, 'Storage quota exceeded', 413)
@@ -1755,6 +1985,18 @@ describe('CRDT rate limit wiring', () => {
     for (const keyPrefix of ['crdt_push', 'crdt_pull', 'crdt_batch_pull']) {
       expect(optionsFor(keyPrefix)?.identifier).toBe(deviceIdentifier)
     }
+  })
+
+  it('wires the bootstrap elevation seam into every CRDT bucket, push included', () => {
+    // #then — the seam is uniform across the CRDT buckets. On `crdt_push` it is
+    // inert on purpose: elevation multiplies only for key prefixes registered in
+    // BOOTSTRAP_ELEVATION_MULTIPLIERS, and that map is deliberately pull-only.
+    // Wiring it here is what lets a future policy change be a one-line map edit
+    // instead of a route edit; the ceiling itself must not move.
+    for (const keyPrefix of ['crdt_push', 'crdt_pull', 'crdt_batch_pull']) {
+      expect(optionsFor(keyPrefix)?.getElevatedLimits).toBe(bootstrapRateLimitElevation)
+    }
+    expect(optionsFor('crdt_push')).toMatchObject({ maxRequests: 300, windowSeconds: 60 })
   })
 
   it('gives the CRDT pull budget room for a whole-vault body sweep', () => {

--- a/apps/sync-server/src/routes/sync.ts
+++ b/apps/sync-server/src/routes/sync.ts
@@ -44,8 +44,11 @@ import {
   getUpdates,
   getBatchUpdates,
   storeSnapshot,
+  storeSnapshotBatch,
   getSnapshot,
-  pruneUpdatesBeforeSnapshot
+  pruneUpdatesBeforeSnapshot,
+  pruneUpdatesBeforeSnapshotBatch,
+  type SnapshotBatchOutcome
 } from '../services/crdt'
 import { enqueuePackCompaction } from '../services/pack-compaction'
 import { listPacks } from '../services/pack-list'
@@ -580,7 +583,16 @@ const crdtPushRateLimit = createRateLimiter({
   keyPrefix: 'crdt_push',
   maxRequests: 300,
   windowSeconds: 60,
-  identifier: deviceIdentifier
+  identifier: deviceIdentifier,
+  // P1.2 (#1837) seam, wired for parity with the pull buckets. It is INERT
+  // today by design: elevation multiplies only for buckets listed in
+  // BOOTSTRAP_ELEVATION_MULTIPLIERS, and that map is deliberately pull-only —
+  // "pushes keep their abuse ceilings untouched". A bulk seed does not need it
+  // either: /snapshot/batch carries 50 notes per request, so a 1000-note vault
+  // costs 20 requests against a 300/min budget. Registering a `crdt_push`
+  // multiplier is the only change that would make this widen anything, and
+  // that is an abuse-posture decision, not a wiring one.
+  getElevatedLimits: bootstrapRateLimitElevation
 })
 
 // Sized for one device pulling an entire vault's bodies after a fresh sign-in.
@@ -633,6 +645,32 @@ const CrdtPushSchema = z.object({
 const CrdtSnapshotPushSchema = z.object({
   noteId: NoteIdSchema,
   snapshot: z.string()
+})
+
+/**
+ * #1857. 50 notes per request: a snapshot is up to 5MB decoded (~6.7MB of
+ * base64), so a full batch is the largest request the Worker body limit and the
+ * per-invocation subrequest budget comfortably take, and it already turns a
+ * 1000-note seed from 1000 requests into 20.
+ *
+ * `snapshot` is deliberately unbounded here. An oversized payload is a per-note
+ * failure reported in `results`, not a 400 that throws away the 49 good notes
+ * riding with it — decodeCrdtPayload enforces the 5MB ceiling per entry.
+ */
+const CrdtSnapshotBatchPushSchema = z.object({
+  snapshots: z
+    .array(
+      z.object({
+        noteId: NoteIdSchema,
+        snapshot: z.string()
+      })
+    )
+    .min(1)
+    .max(50)
+    .refine(
+      (arr) => new Set(arr.map((s) => s.noteId)).size === arr.length,
+      'Duplicate noteIds are not allowed'
+    )
 })
 
 const handleCrdtUpdatePush = async (c: Context<AppContext>): Promise<Response> => {
@@ -909,6 +947,149 @@ const handleCrdtSnapshotPush = async (c: Context<AppContext>): Promise<Response>
   return c.json({ sequenceNum: result.sequenceNum })
 }
 
+/**
+ * POST /sync/crdt/snapshot/batch (#1857).
+ *
+ * The amortised sibling of the single-note push: same writes, same invariants,
+ * six serial D1/R2 ops for FIFTY notes instead of for one. Answers 200 with a
+ * per-note `results` array in request order, so one bad payload or one failed R2
+ * put costs its own entry and nothing else. Whole-batch conditions — malformed
+ * request shape, storage quota — still surface as the status codes the
+ * single-note endpoint gives (400 / 413), because they are properties of the
+ * request rather than of any note in it.
+ *
+ * /sync/crdt/snapshot is untouched and stays the path every existing client uses.
+ */
+const handleCrdtSnapshotBatchPush = async (c: Context<AppContext>): Promise<Response> => {
+  const userId = c.get('userId')!
+  const deviceId = c.get('deviceId')!
+  const vaultId = c.get('vaultId')!
+  const endpoint = getRequestPath(c)
+  const startedAt = Date.now()
+  const body = await c.req.json()
+  const parsed = parseTransportRequest(CrdtSnapshotBatchPushSchema, body, {
+    transport: 'crdt',
+    endpoint,
+    label: 'CRDT snapshot batch request'
+  })
+
+  // Decode per note: an unusable payload is that note's result, not the batch's.
+  const results = new Array<SnapshotBatchOutcome | undefined>(parsed.snapshots.length)
+  const decoded: Array<{ index: number; noteId: string; snapshotData: ArrayBuffer }> = []
+  parsed.snapshots.forEach((entry, index) => {
+    try {
+      decoded.push({
+        index,
+        noteId: entry.noteId,
+        snapshotData: decodeCrdtPayload(entry.snapshot, endpoint, 'Snapshot exceeds 5MB limit')
+      })
+    } catch (error) {
+      results[index] = {
+        noteId: entry.noteId,
+        accepted: false,
+        reason: error instanceof AppError ? error.code : ErrorCodes.INTERNAL_ERROR
+      }
+    }
+  })
+
+  const totalBytes = decoded.reduce((sum, entry) => sum + entry.snapshotData.byteLength, 0)
+
+  let outcomes: SnapshotBatchOutcome[] = []
+  if (decoded.length > 0) {
+    try {
+      outcomes = await storeSnapshotBatch(
+        c.env.DB,
+        c.env.STORAGE,
+        userId,
+        vaultId,
+        deviceId,
+        decoded.map(({ noteId, snapshotData }) => ({ noteId, snapshotData })),
+        c.get('client') ?? null
+      )
+    } catch (error) {
+      if (error instanceof AppError && error.code === ErrorCodes.STORAGE_QUOTA_EXCEEDED) {
+        logCrdtTraffic({
+          endpoint,
+          event: 'snapshot_rejected',
+          noteCount: decoded.length,
+          totalBytes,
+          latencyMs: Date.now() - startedAt,
+          reason: error.code
+        })
+      }
+      throw error
+    }
+    decoded.forEach((entry, position) => {
+      results[entry.index] = outcomes[position]
+    })
+  }
+
+  const accepted = outcomes.filter((outcome) => outcome.accepted === true)
+
+  if (accepted.length > 0) {
+    await pruneUpdatesBeforeSnapshotBatch(
+      c.env.DB,
+      userId,
+      vaultId,
+      accepted.map((outcome) => ({ noteId: outcome.noteId, sequenceNum: outcome.sequenceNum }))
+    )
+
+    // One nudge for the whole batch — the queue message is per (user, vault),
+    // so fifty of them would be fifty copies of the same work.
+    waitUntilCaptured(c, enqueuePackCompaction(c.env, { userId, vaultId }), {
+      source: 'PackQueue',
+      action: 'pack_enqueue_failed'
+    })
+
+    // Same reasoning and same ordering as the single-note path: peers are told
+    // only after the stores AND the prune settle, one `crdt_updated` per note so
+    // the message shape older clients parse is unchanged. Best-effort — the
+    // writes are already durable, so a failed broadcast must not ask the client
+    // to push fifty snapshots again.
+    const doId = c.env.USER_SYNC_STATE.idFromName(userId)
+    const stub = c.env.USER_SYNC_STATE.get(doId)
+    waitUntilCaptured(
+      c,
+      Promise.all(
+        accepted.map((outcome) =>
+          stub.fetch(
+            new Request(new URL('/broadcast', c.req.url), {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                excludeDeviceId: deviceId,
+                vaultId,
+                type: 'crdt_updated',
+                noteId: outcome.noteId
+              })
+            })
+          )
+        )
+      ),
+      { source: 'UserSyncState', action: 'crdt_snapshot_broadcast_failed' }
+    )
+  }
+
+  logCrdtTraffic({
+    endpoint,
+    event: 'snapshot_stored',
+    noteCount: accepted.length,
+    totalBytes,
+    latencyMs: Date.now() - startedAt
+  })
+
+  return c.json({
+    results: results.map(
+      (outcome, index) =>
+        outcome ?? {
+          noteId: parsed.snapshots[index].noteId,
+          accepted: false,
+          reason: ErrorCodes.INTERNAL_ERROR
+        }
+    )
+  })
+}
+
 const handleCrdtSnapshotPull = async (c: Context<AppContext>): Promise<Response> => {
   const userId = c.get('userId')!
   const vaultId = c.get('vaultId')!
@@ -959,6 +1140,7 @@ crdtSync.post('/updates', crdtPushRateLimit, handleCrdtUpdatePush)
 crdtSync.get('/updates', crdtPullRateLimit, handleCrdtUpdatePull)
 crdtSync.post('/updates/batch', crdtBatchPullRateLimit, handleCrdtBatchPull)
 crdtSync.post('/snapshot', crdtPushRateLimit, handleCrdtSnapshotPush)
+crdtSync.post('/snapshot/batch', crdtPushRateLimit, handleCrdtSnapshotBatchPush)
 crdtSync.get('/snapshot/:noteId', crdtPullRateLimit, handleCrdtSnapshotPull)
 
 sync.route('/crdt', crdtSync)

--- a/apps/sync-server/src/services/crdt.ts
+++ b/apps/sync-server/src/services/crdt.ts
@@ -1,6 +1,7 @@
 import { generateCrdtKey, getBlob, putBlob } from './blob'
 import { adjustStorageUsed, reserveStorage } from './quota'
 import type { ClientIdentity } from '../lib/client-identity'
+import { AppError, ErrorCodes } from '../lib/errors'
 import { createLogger } from '../lib/logger'
 
 const logger = createLogger('CrdtService')
@@ -16,7 +17,7 @@ const refundReservation = async (
   db: D1Database,
   userId: string,
   reservedBytes: number,
-  context: { operation: string; vaultId: string; noteId: string }
+  context: { operation: string; vaultId: string; noteId?: string; noteCount?: number }
 ): Promise<void> => {
   if (reservedBytes <= 0) return
   try {
@@ -305,6 +306,17 @@ export const getBatchUpdates = async (
   return { notes: noteResults, snapshotMeta }
 }
 
+/**
+ * The one snapshot upsert. Shared by the single-note and batch writers so the
+ * two can never drift on the DO UPDATE SET list: a column missing from that
+ * clause (`revision` above all) is not a compile error, it is a client stuck on
+ * a stale body forever.
+ */
+const SNAPSHOT_UPSERT_SQL = `INSERT INTO crdt_snapshots (id, user_id, vault_id, note_id, blob_key, sequence_num, size_bytes, signer_device_id, created_at, revision, client_platform, client_version)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT (user_id, vault_id, note_id)
+         DO UPDATE SET blob_key = excluded.blob_key, sequence_num = excluded.sequence_num, size_bytes = excluded.size_bytes, signer_device_id = excluded.signer_device_id, created_at = excluded.created_at, revision = excluded.revision, client_platform = excluded.client_platform, client_version = excluded.client_version`
+
 export const storeSnapshot = async (
   db: D1Database,
   storage: R2Bucket,
@@ -348,12 +360,7 @@ export const storeSnapshot = async (
     await putBlob(storage, blobKey, snapshotData, userId)
 
     await db
-      .prepare(
-        `INSERT INTO crdt_snapshots (id, user_id, vault_id, note_id, blob_key, sequence_num, size_bytes, signer_device_id, created_at, revision, client_platform, client_version)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-         ON CONFLICT (user_id, vault_id, note_id)
-         DO UPDATE SET blob_key = excluded.blob_key, sequence_num = excluded.sequence_num, size_bytes = excluded.size_bytes, signer_device_id = excluded.signer_device_id, created_at = excluded.created_at, revision = excluded.revision, client_platform = excluded.client_platform, client_version = excluded.client_version`
-      )
+      .prepare(SNAPSHOT_UPSERT_SQL)
       .bind(
         id,
         userId,
@@ -383,6 +390,274 @@ export const storeSnapshot = async (
   }
 
   return { sequenceNum }
+}
+
+/** One note's snapshot inside a batch push. */
+export interface SnapshotBatchInput {
+  noteId: string
+  snapshotData: ArrayBuffer
+}
+
+/**
+ * Per-note result of a batch push, one entry per input in request order.
+ *
+ * Discriminated so a caller cannot read `sequenceNum` off a rejection: the
+ * accepted branch always carries the watermark, the rejected branch always
+ * carries an ErrorCodes value.
+ */
+export type SnapshotBatchOutcome =
+  | { noteId: string; accepted: true; sequenceNum: number }
+  | { noteId: string; accepted: false; reason: string }
+
+/**
+ * Upper bound on simultaneous R2 writes from one snapshot batch. Same value and
+ * same reasoning as `R2_PUSH_PUT_CONCURRENCY` in services/sync.ts: the window
+ * keeps a full batch streaming through in short waves instead of holding 50 R2
+ * connections open at once, well inside the Workers subrequest budget (≤50
+ * puts + ~4 batched D1 round trips + ≤50 broadcast fetches per invocation).
+ */
+const R2_SNAPSHOT_PUT_CONCURRENCY = 8
+
+interface PreparedSnapshot {
+  index: number
+  noteId: string
+  snapshotData: ArrayBuffer
+  blobKey: string
+  sequenceNum: number
+  deltaBytes: number
+  reservedBytes: number
+}
+
+/**
+ * The batched snapshot writer (#1857).
+ *
+ * Same invariants as `storeSnapshot`, at 4 D1 round trips for the whole batch
+ * instead of 6 per note:
+ *
+ *   - a FRESH `revision` UUID on every write, insert and conflict alike;
+ *   - the watermark rule `existingSnapshot?.sequence_num ?? currentSeq`, so a
+ *     note that already has a snapshot keeps its sequence number and later
+ *     incrementals stay pullable;
+ *   - every putBlob AHEAD of the D1 upsert, so a failed put writes no orphan row;
+ *   - reserved bytes refunded when a write fails past the reservation.
+ *
+ * Error semantics: a per-note failure (R2 put) is that note's outcome and never
+ * costs its neighbours. Whole-batch failures behave like the single-note path —
+ * the metadata read and the storage reservation throw (quota surfaces as the
+ * same typed 413 a single push gives), while a failed commit rejects the whole
+ * wave because the upsert batch is all-or-nothing.
+ */
+export const storeSnapshotBatch = async (
+  db: D1Database,
+  storage: R2Bucket,
+  userId: string,
+  vaultId: string,
+  signerDeviceId: string,
+  snapshots: SnapshotBatchInput[],
+  client: ClientIdentity | null = null
+): Promise<SnapshotBatchOutcome[]> => {
+  if (snapshots.length === 0) return []
+
+  const outcomes = new Array<SnapshotBatchOutcome | undefined>(snapshots.length)
+  const rejectWithError = (index: number, error: unknown): void => {
+    outcomes[index] = {
+      noteId: snapshots[index].noteId,
+      accepted: false,
+      reason: error instanceof AppError ? error.code : ErrorCodes.INTERNAL_ERROR
+    }
+  }
+
+  const noteIds = snapshots.map((entry) => entry.noteId)
+
+  // Stage 1: metadata, one db.batch. Both reads are chunked at the D1
+  // bind-parameter ceiling the way `pullItems` and `getBatchSnapshotMeta` are —
+  // an over-long IN list is a 500 on the whole request, not a partial result.
+  // The existing-snapshot chunk carries user_id + vault_id ahead of the ids; the
+  // watermark chunk binds that triple TWICE (once per UNION arm), so its chunk
+  // is half the size.
+  const existingChunkSize = D1_MAX_BIND_PARAMS - 2
+  const watermarkChunkSize = Math.floor((D1_MAX_BIND_PARAMS - 4) / 2)
+
+  const existingChunks: string[][] = []
+  for (let i = 0; i < noteIds.length; i += existingChunkSize) {
+    existingChunks.push(noteIds.slice(i, i + existingChunkSize))
+  }
+  const watermarkChunks: string[][] = []
+  for (let i = 0; i < noteIds.length; i += watermarkChunkSize) {
+    watermarkChunks.push(noteIds.slice(i, i + watermarkChunkSize))
+  }
+
+  const metaStatements: D1PreparedStatement[] = [
+    ...existingChunks.map((chunk) =>
+      db
+        .prepare(
+          `SELECT note_id, sequence_num, size_bytes FROM crdt_snapshots
+       WHERE user_id = ? AND vault_id = ? AND note_id IN (${chunk.map(() => '?').join(', ')})`
+        )
+        .bind(userId, vaultId, ...chunk)
+    ),
+    // The GROUP BY form of `getMaxSequenceNumber`: one row per note that has any
+    // history at all, absent for a note the server has never seen.
+    ...watermarkChunks.map((chunk) => {
+      const placeholders = chunk.map(() => '?').join(', ')
+      return db
+        .prepare(
+          `SELECT note_id, COALESCE(MAX(sequence_num), 0) as max_seq
+       FROM (
+         SELECT note_id, sequence_num FROM crdt_updates WHERE user_id = ? AND vault_id = ? AND note_id IN (${placeholders})
+         UNION ALL
+         SELECT note_id, sequence_num FROM crdt_snapshots WHERE user_id = ? AND vault_id = ? AND note_id IN (${placeholders})
+       )
+       GROUP BY note_id`
+        )
+        .bind(userId, vaultId, ...chunk, userId, vaultId, ...chunk)
+    })
+  ]
+
+  const metaResults = await db.batch(metaStatements)
+
+  const existingByNote = new Map<string, { sequence_num: number; size_bytes: number }>()
+  for (const result of metaResults.slice(0, existingChunks.length)) {
+    for (const row of (
+      result as D1Result<{
+        note_id: string
+        sequence_num: number
+        size_bytes: number
+      }>
+    ).results ?? []) {
+      existingByNote.set(row.note_id, {
+        sequence_num: row.sequence_num,
+        size_bytes: row.size_bytes
+      })
+    }
+  }
+
+  const watermarkByNote = new Map<string, number>()
+  for (const result of metaResults.slice(existingChunks.length)) {
+    for (const row of (result as D1Result<{ note_id: string; max_seq: number | null }>).results ??
+      []) {
+      watermarkByNote.set(row.note_id, row.max_seq ?? 0)
+    }
+  }
+
+  const prepared: PreparedSnapshot[] = snapshots.map((entry, index) => {
+    const existing = existingByNote.get(entry.noteId)
+    return {
+      index,
+      noteId: entry.noteId,
+      snapshotData: entry.snapshotData,
+      blobKey: generateCrdtKey(userId, entry.noteId, vaultId),
+      // Client-uploaded snapshots carry no causal proof that they already
+      // contain the server's updates above the prior watermark, so the
+      // watermark stays put once a snapshot exists — see storeSnapshot.
+      sequenceNum: existing?.sequence_num ?? watermarkByNote.get(entry.noteId) ?? 0,
+      deltaBytes: entry.snapshotData.byteLength - (existing?.size_bytes ?? 0),
+      reservedBytes: 0
+    }
+  })
+
+  // Stage 2: ONE reservation for the summed growth. A quota failure is a
+  // property of the batch, not of any one note, and throws exactly the typed
+  // error the single-note push throws.
+  const totalGrowth = prepared.reduce((sum, entry) => sum + Math.max(0, entry.deltaBytes), 0)
+  if (totalGrowth > 0) {
+    await reserveStorage(db, userId, totalGrowth)
+    for (const entry of prepared) {
+      entry.reservedBytes = Math.max(0, entry.deltaBytes)
+    }
+  }
+
+  // Bytes reserved for notes that fail past this point, refunded once at the end
+  // rather than one UPDATE per failure.
+  let refundBytes = 0
+
+  // Stage 3: R2 puts, bounded concurrency, all of them ahead of the D1 commit so
+  // a failed put leaves no row pointing at bytes that are not there.
+  for (let i = 0; i < prepared.length; i += R2_SNAPSHOT_PUT_CONCURRENCY) {
+    const window = prepared.slice(i, i + R2_SNAPSHOT_PUT_CONCURRENCY)
+    await Promise.all(
+      window.map(async (entry) => {
+        try {
+          await putBlob(storage, entry.blobKey, entry.snapshotData, userId)
+        } catch (error) {
+          refundBytes += entry.reservedBytes
+          rejectWithError(entry.index, error)
+        }
+      })
+    )
+  }
+  let stored = prepared.filter((entry) => outcomes[entry.index] === undefined)
+
+  // Stage 4: upserts and storage shrinks, one transactional db.batch. All or
+  // nothing per batch — a row never lands without its shrink adjustment, and a
+  // client retries the rejected notes either way.
+  if (stored.length > 0) {
+    const now = Math.floor(Date.now() / 1000)
+    const statements: D1PreparedStatement[] = []
+    for (const entry of stored) {
+      statements.push(
+        db
+          .prepare(SNAPSHOT_UPSERT_SQL)
+          .bind(
+            crypto.randomUUID(),
+            userId,
+            vaultId,
+            entry.noteId,
+            entry.blobKey,
+            entry.sequenceNum,
+            entry.snapshotData.byteLength,
+            signerDeviceId,
+            now,
+            crypto.randomUUID(),
+            client?.platform ?? null,
+            client?.version ?? null
+          )
+      )
+      if (entry.deltaBytes < 0) {
+        statements.push(
+          db
+            .prepare(
+              'UPDATE users SET storage_used = MAX(0, storage_used + ?), updated_at = ? WHERE id = ?'
+            )
+            .bind(entry.deltaBytes, now, userId)
+        )
+      }
+    }
+
+    try {
+      await db.batch(statements)
+      for (const entry of stored) {
+        outcomes[entry.index] = {
+          noteId: entry.noteId,
+          accepted: true,
+          sequenceNum: entry.sequenceNum
+        }
+      }
+    } catch (error) {
+      for (const entry of stored) {
+        refundBytes += entry.reservedBytes
+        rejectWithError(entry.index, error)
+      }
+      stored = []
+    }
+  }
+
+  // The refund must never surface as a note outcome: those notes already carry
+  // the reason they actually failed for.
+  await refundReservation(db, userId, refundBytes, {
+    operation: 'storeSnapshotBatch',
+    vaultId,
+    noteCount: snapshots.length
+  })
+
+  return outcomes.map(
+    (outcome, index) =>
+      outcome ?? {
+        noteId: snapshots[index].noteId,
+        accepted: false,
+        reason: ErrorCodes.INTERNAL_ERROR
+      }
+  )
 }
 
 export const getSnapshot = async (
@@ -422,6 +697,11 @@ export const getSnapshot = async (
   }
 }
 
+const PRUNE_SUM_SQL =
+  'SELECT COALESCE(SUM(length(update_data)), 0) as total_bytes FROM crdt_updates WHERE user_id = ? AND vault_id = ? AND note_id = ? AND sequence_num <= ?'
+const PRUNE_DELETE_SQL =
+  'DELETE FROM crdt_updates WHERE user_id = ? AND vault_id = ? AND note_id = ? AND sequence_num <= ?'
+
 export const pruneUpdatesBeforeSnapshot = async (
   db: D1Database,
   userId: string,
@@ -438,21 +718,63 @@ export const pruneUpdatesBeforeSnapshot = async (
   if (!snapshot) return 0
 
   const bytes = await db
-    .prepare(
-      'SELECT COALESCE(SUM(length(update_data)), 0) as total_bytes FROM crdt_updates WHERE user_id = ? AND vault_id = ? AND note_id = ? AND sequence_num <= ?'
-    )
+    .prepare(PRUNE_SUM_SQL)
     .bind(userId, vaultId, noteId, snapshot.sequence_num)
     .first<{ total_bytes: number }>()
 
   const result = await db
-    .prepare(
-      'DELETE FROM crdt_updates WHERE user_id = ? AND vault_id = ? AND note_id = ? AND sequence_num <= ?'
-    )
+    .prepare(PRUNE_DELETE_SQL)
     .bind(userId, vaultId, noteId, snapshot.sequence_num)
     .run()
 
   const changes = result.meta.changes ?? 0
   const totalBytes = Number(bytes?.total_bytes ?? 0)
+  if (changes > 0 && totalBytes > 0) {
+    await adjustStorageUsed(db, userId, -totalBytes)
+  }
+
+  return changes
+}
+
+/**
+ * `pruneUpdatesBeforeSnapshot` for a whole batch, in ONE db.batch instead of
+ * three round trips per note.
+ *
+ * The snapshot watermark is passed in rather than re-read: the caller has just
+ * written it, and re-reading it per note is exactly the round trip this exists
+ * to remove. Every SUM statement is queued ahead of every DELETE, and D1 runs a
+ * batch sequentially inside one transaction, so each SUM still observes the rows
+ * its DELETE is about to remove.
+ */
+export const pruneUpdatesBeforeSnapshotBatch = async (
+  db: D1Database,
+  userId: string,
+  vaultId: string,
+  notes: Array<{ noteId: string; sequenceNum: number }>
+): Promise<number> => {
+  if (notes.length === 0) return 0
+
+  const statements: D1PreparedStatement[] = [
+    ...notes.map((note) =>
+      db.prepare(PRUNE_SUM_SQL).bind(userId, vaultId, note.noteId, note.sequenceNum)
+    ),
+    ...notes.map((note) =>
+      db.prepare(PRUNE_DELETE_SQL).bind(userId, vaultId, note.noteId, note.sequenceNum)
+    )
+  ]
+
+  const results = await db.batch<{ total_bytes: number }>(statements)
+
+  let changes = 0
+  let totalBytes = 0
+  for (let i = 0; i < notes.length; i++) {
+    const deleted = results[notes.length + i].meta.changes ?? 0
+    changes += deleted
+    if (deleted > 0) {
+      totalBytes += Number((results[i].results ?? [])[0]?.total_bytes ?? 0)
+    }
+  }
+
   if (changes > 0 && totalBytes > 0) {
     await adjustStorageUsed(db, userId, -totalBytes)
   }

--- a/packages/sync-client/src/crdt-payload.ts
+++ b/packages/sync-client/src/crdt-payload.ts
@@ -15,6 +15,17 @@
 export const MAX_CRDT_UPDATE_PAYLOAD_CHARS = 1_200_000
 export const MAX_CRDT_REQUEST_PAYLOAD_CHARS = 6_000_000
 
+/**
+ * The server's cap on `POST /sync/crdt/snapshot/batch`'s `snapshots` array.
+ *
+ * Sending more is a 400, so every producer chunks at this number rather than
+ * discovering the ceiling on the wire. It lives here, next to the other CRDT
+ * wire budgets, because both the provider (which decides how many notes to
+ * prepare in one round) and the HTTP layer need it and neither should import
+ * the other.
+ */
+export const MAX_CRDT_SNAPSHOT_BATCH_ENTRIES = 50
+
 export interface CrdtUpdatePushPlan {
   /** Batches to POST in order. Every batch fits both budgets. */
   requests: string[][]


### PR DESCRIPTION
Closes #1857.

## Why

Seeding a vault pushed note bodies one at a time — one `POST /sync/crdt/snapshot` per note, six serial D1/R2 ops on the server for each. Measured on a 1000-note vault against staging:

| | iteration | `POST /sync/push` (100 records) | snapshot phase (100 bodies) |
|---|---|---|---|
| before the #1842 deploy | 52.7 s | 37.7 s | **15.0 s** |
| after | 21.0 s | 6.0 s | **15.0 s** |

The record push improved 6.2x from #1833's batch rewrite. The snapshot phase did not move — that rewrite never touched this endpoint.

Of the ~750 ms per snapshot request: ~600 ms server, ~150 ms round trip, and **at most 149 ms client CPU** — that last figure is arithmetic, not an estimate. The push sustains 6.7 notes/s on one JS thread, so per-note CPU cannot exceed 1000/6.7 ms without saturating it. Bandwidth is not a factor either: ~11 MB total against a measured 830 KB/s upload to the same edge, so line rate for the whole run would be ~14 s against the observed 207 s.

## Server

`POST /sync/crdt/snapshot/batch` takes up to 50 snapshots and amortises what the single-note path pays per note: one `db.batch` for the metadata reads (chunked at the bind-param ceiling), one `reserveStorage` for the batch's summed growth, R2 puts at concurrency 8, one `db.batch` for the upserts, one for the prune.

`storeSnapshot` keeps every invariant its comments document — a fresh `revision` on every write, the watermark rule, `putBlob` ahead of the D1 upsert, refund on failure. The upsert SQL is now a shared constant so the two writers cannot drift on the `DO UPDATE SET` list. **The single-note endpoint is untouched.**

Per-note outcomes are reported separately (`{ noteId, accepted, sequenceNum? , reason? }`, request order), so one bad note does not fail the batch. A quota the batch as a whole cannot satisfy still rejects the whole request, as the single-note path does — nothing partial lands.

## Client

The provider splits into `prepareSnapshotForNote` / `settle`, so the per-note bookkeeping has exactly one implementation shared by the batched and single paths: binary and `localOnly` skips, the empty-doc skip, zeroing the pending-snapshot debt before the send and restoring it on failure, closing a doc that was not already open. `settle` re-reads the doc entry rather than closing over it, because a batch holds notes across a round trip long enough for the 32-slot LRU to evict one.

Encryption moved to the batch function, which reads credentials once per batch instead of three async fetches (including a keychain read) per note.

## Two things that were not in the issue's plan

**A note with unmerged remote CRDT state never enters a batch.** The batch endpoint prunes updates below the new watermark exactly as the single-note one does, so a device that merged around server state it could not verify must not assert "I contain everything up to here". Those notes are split out first — before the capability check, before credentials are read — and routed to the non-pruning `POST /sync/crdt/updates` path, reusing the existing `hasUnmergedRemoteCrdtState` branch in `runtime.ts` so there is one source of truth. Missing this would have been a silent data-loss regression (#1503/#1489).

**`CRDT_SNAPSHOT_CONCURRENCY` drops 5 → 4 rather than rising.** The unit is now requests, not notes. An iteration dequeues at most `pushBatchSize` (100) creates and the wire cap is 50, so it yields at most 2 chunks, and iterations are serial. The old 5 was already over budget at one round trip per note — roughly 400 req/min against the server's 300/min `crdt_push` bucket.

## Backward compatibility

Old servers answer 404 for the batch route and 200 for the single-note one. The first 404 latches a per-session flag and every later chunk falls back to one request per note, so a vault pays one wasted request rather than one per batch — the same mechanism as the existing `snapshotMetaUnsupported` latch. A 413 falls back per note without latching: the aggregate body being too large says nothing about which note is oversized, and only the per-note path names it to the user.

`crdtPushRateLimit` now asks `bootstrapRateLimitElevation` for a multiplier. None is registered for `crdt_push` and this deliberately changes nothing at runtime — `BOOTSTRAP_ELEVATION_MULTIPLIERS` is documented as pull-only. With 50 notes per request a 1000-note vault needs ~20 requests, so the elevation the issue asked for is no longer necessary.

## Verification

```
pnpm typecheck            19/19 successful
pnpm lint                 0 errors (no warnings in changed files)
pnpm test                 11/11 tasks — desktop 1405 files, sync-server 80 files
pnpm ipc:check            pass
pnpm check:architecture   pass
pnpm check:contracts      pass
pnpm docs:impact --strict pass
pnpm docs:build           pass
git diff --check          clean
```

New tests: 11 service-level cases against the real SQLite/migration harness, 9 route cases, 10 batch-function cases, plus provider/http-client coverage. `engine-crdt.test.ts` came **off** the `tsconfig.test.node.json` exclude backlog — the list shrank by one, nothing was added.

Not measured yet: the end-to-end effect on a real seeding run. That is the next step against staging, using the numbers above as the baseline.