### PR TITLE
fix(editor): spelling suggestions in the context menu; one menu per secondary click

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -1595,7 +1595,11 @@ describe('main index phase2 exports', () => {
 
     contextMenuHandler({}, editableParams)
 
-    expect(buildEditableTextContextMenuMock).toHaveBeenCalledWith(expect.anything(), editableParams)
+    expect(buildEditableTextContextMenuMock).toHaveBeenCalledWith(
+      expect.anything(),
+      editableParams,
+      mainWindow.webContents
+    )
     expect(editableContextMenuPopupMock).toHaveBeenCalledWith({
       window: mainWindow,
       frame: editableParams.frame

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -841,7 +841,7 @@ function createWindow(): void {
   })
 
   mainWindow.webContents.on('context-menu', (_event, params) => {
-    const menu = buildEditableTextContextMenu(mainI18n, params)
+    const menu = buildEditableTextContextMenu(mainI18n, params, mainWindow.webContents)
     if (!menu) return
 
     menu.popup({

--- a/apps/desktop/src/main/menu.test.ts
+++ b/apps/desktop/src/main/menu.test.ts
@@ -20,11 +20,23 @@ import { buildAppMenu, buildEditableTextContextMenu } from './menu'
 interface TemplateItem {
   label?: string
   role?: string
+  type?: string
+  enabled?: boolean
   accelerator?: string
   registerAccelerator?: boolean
   id?: string
   click?: () => void
   submenu?: TemplateItem[]
+}
+
+function createWebContents() {
+  return {
+    replaceMisspelling: vi.fn(),
+    session: { addWordToSpellCheckerDictionary: vi.fn() }
+  } as unknown as Electron.WebContents & {
+    replaceMisspelling: ReturnType<typeof vi.fn>
+    session: { addWordToSpellCheckerDictionary: ReturnType<typeof vi.fn> }
+  }
 }
 
 /** Find an item by label in the most recently built template. */
@@ -313,17 +325,21 @@ describe('buildAppMenu', () => {
   it('builds a native editable context menu from edit flags', async () => {
     const i18n = await createMainI18n({ locale: 'en' })
 
-    const menu = buildEditableTextContextMenu(i18n, {
-      isEditable: true,
-      editFlags: {
-        canUndo: false,
-        canRedo: true,
-        canCut: false,
-        canCopy: true,
-        canPaste: true,
-        canSelectAll: true
-      }
-    })
+    const menu = buildEditableTextContextMenu(
+      i18n,
+      {
+        isEditable: true,
+        editFlags: {
+          canUndo: false,
+          canRedo: true,
+          canCut: false,
+          canCopy: true,
+          canPaste: true,
+          canSelectAll: true
+        }
+      },
+      createWebContents()
+    )
 
     expect(menu).toEqual({ template: buildFromTemplate.mock.calls[0][0] })
     expect(buildFromTemplate.mock.calls[0][0]).toEqual(
@@ -346,9 +362,73 @@ describe('buildAppMenu', () => {
   it('does not build a text context menu for non-editable targets', async () => {
     const i18n = await createMainI18n({ locale: 'en' })
 
-    const menu = buildEditableTextContextMenu(i18n, { isEditable: false })
+    const menu = buildEditableTextContextMenu(i18n, { isEditable: false }, createWebContents())
 
     expect(menu).toBeNull()
     expect(buildFromTemplate).not.toHaveBeenCalled()
+  })
+
+  it('offers spelling suggestions above the edit items and applies the picked one', async () => {
+    const i18n = await createMainI18n({ locale: 'en' })
+    const webContents = createWebContents()
+
+    buildEditableTextContextMenu(
+      i18n,
+      {
+        isEditable: true,
+        misspelledWord: 'recieve',
+        dictionarySuggestions: ['receive', 'reprieve'],
+        editFlags: { canPaste: true }
+      },
+      webContents
+    )
+
+    const template = buildFromTemplate.mock.calls.at(-1)?.[0] as TemplateItem[]
+    expect(template.slice(0, 5)).toEqual([
+      expect.objectContaining({ label: 'receive' }),
+      expect.objectContaining({ label: 'reprieve' }),
+      { type: 'separator' },
+      expect.objectContaining({ label: 'Add to Dictionary' }),
+      { type: 'separator' }
+    ])
+    expect(template[5]).toMatchObject({ label: 'Undo', role: 'undo' })
+
+    template[1].click?.()
+    expect(webContents.replaceMisspelling).toHaveBeenCalledWith('reprieve')
+
+    template[3].click?.()
+    expect(webContents.session.addWordToSpellCheckerDictionary).toHaveBeenCalledWith('recieve')
+  })
+
+  it('shows a disabled placeholder when the dictionary has no suggestions', async () => {
+    const i18n = await createMainI18n({ locale: 'en' })
+
+    buildEditableTextContextMenu(
+      i18n,
+      { isEditable: true, misspelledWord: 'qwertyu', dictionarySuggestions: [], editFlags: {} },
+      createWebContents()
+    )
+
+    const template = buildFromTemplate.mock.calls.at(-1)?.[0] as TemplateItem[]
+    expect(template.slice(0, 4)).toEqual([
+      { label: 'No Suggestions', enabled: false },
+      { type: 'separator' },
+      expect.objectContaining({ label: 'Add to Dictionary' }),
+      { type: 'separator' }
+    ])
+  })
+
+  it('leaves the context menu untouched when the word is spelled correctly', async () => {
+    const i18n = await createMainI18n({ locale: 'en' })
+
+    buildEditableTextContextMenu(
+      i18n,
+      { isEditable: true, misspelledWord: '', dictionarySuggestions: [], editFlags: {} },
+      createWebContents()
+    )
+
+    const template = buildFromTemplate.mock.calls.at(-1)?.[0] as TemplateItem[]
+    expect(template[0]).toMatchObject({ label: 'Undo', role: 'undo' })
+    expect(template.map((item) => item.label)).not.toContain('Add to Dictionary')
   })
 })

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -1,4 +1,12 @@
-import { app, BrowserWindow, dialog, Menu, shell, type MenuItemConstructorOptions } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  Menu,
+  shell,
+  type MenuItemConstructorOptions,
+  type WebContents
+} from 'electron'
 import { AppChannels } from '@memry/contracts/ipc-channels'
 import type { I18nInstance } from '@memry/i18n/main'
 import { sendAppNavigationDirection } from './app-navigation-command'
@@ -7,6 +15,8 @@ const DOCS_URL = 'https://docs.memrynote.com'
 
 interface EditableContextMenuParams {
   isEditable?: boolean
+  misspelledWord?: string
+  dictionarySuggestions?: string[]
   editFlags?: {
     canUndo?: boolean
     canRedo?: boolean
@@ -289,13 +299,33 @@ export function buildAppMenu(i18n: I18nInstance): Menu {
 
 export function buildEditableTextContextMenu(
   i18n: I18nInstance,
-  params: EditableContextMenuParams
+  params: EditableContextMenuParams,
+  webContents: WebContents
 ): Menu | null {
   if (!params.isEditable) return null
 
   const t = i18n.getFixedT(null, 'menu')
   const flags = params.editFlags ?? {}
+  const misspelledWord = params.misspelledWord
+  const suggestions = params.dictionarySuggestions ?? []
+  const spelling: MenuItemConstructorOptions[] = misspelledWord
+    ? [
+        ...(suggestions.length > 0
+          ? suggestions.map((suggestion) => ({
+              label: suggestion,
+              click: () => webContents.replaceMisspelling(suggestion)
+            }))
+          : [{ label: t('edit.noSuggestions'), enabled: false }]),
+        { type: 'separator' },
+        {
+          label: t('edit.addToDictionary'),
+          click: () => webContents.session.addWordToSpellCheckerDictionary(misspelledWord)
+        },
+        { type: 'separator' }
+      ]
+    : []
   const template: MenuItemConstructorOptions[] = [
+    ...spelling,
     { label: t('edit.undo'), role: 'undo', enabled: Boolean(flags.canUndo) },
     { label: t('edit.redo'), role: 'redo', enabled: Boolean(flags.canRedo) },
     { type: 'separator' },

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
@@ -126,10 +126,63 @@ describe('ReviewFormattingToolbar', () => {
     ]
     toolbarMocks.editor.updateBlock.mockClear()
     ;(toolbarMocks.editor as { _tiptapEditor?: unknown })._tiptapEditor = undefined
+    ;(toolbarMocks.editor as { prosemirrorView?: unknown }).prosemirrorView = undefined
     const selection = toolbarMocks.editor.prosemirrorState.selection as Record<string, unknown>
     delete selection.$from
     delete selection.$to
     vi.mocked(openWikiLinkForSelection).mockClear()
+  })
+
+  describe('native context menu', () => {
+    function mountEditorDom(): HTMLElement {
+      const dom = document.createElement('div')
+      document.body.appendChild(dom)
+      ;(toolbarMocks.editor as { prosemirrorView?: unknown }).prosemirrorView = { dom }
+      return dom
+    }
+
+    it('yields the floating toolbar to the native menu on right-click', () => {
+      const editorDom = mountEditorDom()
+
+      render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+      expect(screen.getByTestId('formatting-toolbar')).toBeInTheDocument()
+
+      fireEvent.contextMenu(editorDom)
+      expect(screen.queryByTestId('formatting-toolbar')).not.toBeInTheDocument()
+
+      // A second right-click keeps it hidden; only an ordinary interaction restores it.
+      fireEvent.pointerDown(editorDom, { button: 2 })
+      expect(screen.queryByTestId('formatting-toolbar')).not.toBeInTheDocument()
+
+      fireEvent.pointerDown(editorDom, { button: 0 })
+      expect(screen.getByTestId('formatting-toolbar')).toBeInTheDocument()
+
+      fireEvent.contextMenu(editorDom)
+      fireEvent.keyDown(editorDom, { key: 'Escape' })
+      expect(screen.getByTestId('formatting-toolbar')).toBeInTheDocument()
+
+      editorDom.remove()
+    })
+
+    it('ignores right-clicks outside the editor', () => {
+      mountEditorDom()
+
+      render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+
+      fireEvent.contextMenu(document.body)
+      expect(screen.getByTestId('formatting-toolbar')).toBeInTheDocument()
+    })
+
+    it('leaves the sticky toolbar alone', () => {
+      const editorDom = mountEditorDom()
+
+      render(<ReviewFormattingToolbar variant="sticky" onAddComment={vi.fn()} />)
+
+      fireEvent.contextMenu(editorDom)
+      expect(screen.getByTestId('formatting-toolbar')).toBeInTheDocument()
+
+      editorDom.remove()
+    })
   })
 
   it('offers Link to note only once a single-block selection exists', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
@@ -1,9 +1,13 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ReviewFormattingToolbar } from './review-formatting-toolbar'
+import {
+  ReviewFormattingToolbar,
+  ReviewFormattingToolbarController
+} from './review-formatting-toolbar'
 import { openWikiLinkForSelection } from './wiki-link-edit-plugin'
 
 const toolbarMocks = vi.hoisted(() => ({
+  remountKey: 0,
   editor: {
     prosemirrorState: {
       selection: { empty: false, from: 2, to: 15 },
@@ -64,11 +68,13 @@ vi.mock('@blocknote/react', () => ({
   FormattingToolbar: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="formatting-toolbar">{children}</div>
   ),
+  // Keyed so a test can force the remount BlockNote performs mid-interaction:
+  // the toolbar below is torn down and rebuilt while the controller stays put.
   FormattingToolbarController: ({
     formattingToolbar
   }: {
     formattingToolbar: (props: Record<string, unknown>) => React.ReactNode
-  }) => <>{formattingToolbar({})}</>,
+  }) => <div key={toolbarMocks.remountKey}>{formattingToolbar({})}</div>,
   BlockTypeSelect: () => <button type="button">block type</button>,
   BasicTextStyleButton: ({ basicTextStyle }: { basicTextStyle: string }) => (
     <button type="button">{basicTextStyle}</button>
@@ -127,6 +133,8 @@ describe('ReviewFormattingToolbar', () => {
     toolbarMocks.editor.updateBlock.mockClear()
     ;(toolbarMocks.editor as { _tiptapEditor?: unknown })._tiptapEditor = undefined
     ;(toolbarMocks.editor as { prosemirrorView?: unknown }).prosemirrorView = undefined
+    toolbarMocks.remountKey = 0
+    fireEvent.pointerDown(document.body, { button: 0 })
     const selection = toolbarMocks.editor.prosemirrorState.selection as Record<string, unknown>
     delete selection.$from
     delete selection.$to
@@ -144,7 +152,7 @@ describe('ReviewFormattingToolbar', () => {
     it('yields the floating toolbar to the native menu on right-click', () => {
       const editorDom = mountEditorDom()
 
-      render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+      render(<ReviewFormattingToolbarController onAddComment={vi.fn()} />)
       expect(screen.getByTestId('formatting-toolbar')).toBeInTheDocument()
 
       fireEvent.contextMenu(editorDom)
@@ -164,10 +172,27 @@ describe('ReviewFormattingToolbar', () => {
       editorDom.remove()
     })
 
+    // The first attempt at this fix held the state inside the toolbar and passed
+    // its unit tests while failing in the real app: BlockNote rebuilds the
+    // toolbar during the right-click, so the state died with the old instance.
+    it('stays suppressed when BlockNote rebuilds the toolbar mid-right-click', () => {
+      const editorDom = mountEditorDom()
+
+      const { rerender } = render(<ReviewFormattingToolbarController onAddComment={vi.fn()} />)
+      fireEvent.contextMenu(editorDom)
+
+      toolbarMocks.remountKey += 1
+      rerender(<ReviewFormattingToolbarController onAddComment={vi.fn()} />)
+
+      expect(screen.queryByTestId('formatting-toolbar')).not.toBeInTheDocument()
+
+      editorDom.remove()
+    })
+
     it('ignores right-clicks outside the editor', () => {
       mountEditorDom()
 
-      render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+      render(<ReviewFormattingToolbarController onAddComment={vi.fn()} />)
 
       fireEvent.contextMenu(document.body)
       expect(screen.getByTestId('formatting-toolbar')).toBeInTheDocument()

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
@@ -31,6 +31,15 @@ interface ReviewFormattingToolbarProps {
 }
 
 export function ReviewFormattingToolbarController(props: ReviewFormattingToolbarProps) {
+  const editor = useBlockNoteEditor()
+  // The gate lives here, not in the toolbar below: BlockNote tears the toolbar
+  // down and mounts a fresh one mid-interaction, so state held there is lost
+  // exactly when it is needed. This component is mounted by ContentArea and
+  // outlives that churn.
+  const isContextMenuOpen = useContextMenuOpen(editor)
+
+  if (isContextMenuOpen) return null
+
   return (
     <FormattingToolbarController
       formattingToolbar={(toolbarProps) => (
@@ -58,7 +67,6 @@ export function ReviewFormattingToolbar({
       return Boolean(selection && !selection.empty && (selection as { node?: unknown }).node)
     }
   })
-  const isContextMenuOpen = useContextMenuOpen(editor)
 
   if (variant === 'sticky') {
     return (
@@ -71,7 +79,7 @@ export function ReviewFormattingToolbar({
     )
   }
 
-  if (isNodeSelection || isContextMenuOpen) return null
+  if (isNodeSelection) return null
 
   return (
     <FormattingToolbar {...toolbarProps}>
@@ -123,6 +131,10 @@ export function ReviewFormattingToolbar({
  * on is platform-dependent, so this suppresses by state instead of racing that
  * listener: hidden until the next ordinary interaction. Capture on `window`
  * runs ahead of anything that might stop propagation.
+ *
+ * Call this from a component BlockNote does not own. Its controller remounts
+ * the toolbar during the very interaction being suppressed, which resets any
+ * state held below it.
  */
 function useContextMenuOpen(editor: BlockNoteEditor): boolean {
   const [isOpen, setIsOpen] = useState(false)

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
@@ -1,7 +1,7 @@
 import type { BlockNoteEditor } from '@blocknote/core'
 import type { EditorState } from '@tiptap/pm/state'
 import type { EditorView } from '@tiptap/pm/view'
-import { useEffect, useRef, type MouseEvent, type PointerEvent } from 'react'
+import { useEffect, useRef, useState, type MouseEvent, type PointerEvent } from 'react'
 import {
   BasicTextStyleButton,
   BlockTypeSelect,
@@ -58,6 +58,7 @@ export function ReviewFormattingToolbar({
       return Boolean(selection && !selection.empty && (selection as { node?: unknown }).node)
     }
   })
+  const isContextMenuOpen = useContextMenuOpen(editor)
 
   if (variant === 'sticky') {
     return (
@@ -70,7 +71,7 @@ export function ReviewFormattingToolbar({
     )
   }
 
-  if (isNodeSelection) return null
+  if (isNodeSelection || isContextMenuOpen) return null
 
   return (
     <FormattingToolbar {...toolbarProps}>
@@ -111,6 +112,46 @@ export function ReviewFormattingToolbar({
       </div>
     </FormattingToolbar>
   )
+}
+
+/**
+ * A secondary click pops the native context menu from the main process, while
+ * BlockNote independently opens this toolbar off the same pointer sequence
+ * (#1850). Two menus, and the toolbar is the one left without focus.
+ *
+ * Whether `contextmenu` arrives before or after the `pointerup` BlockNote opens
+ * on is platform-dependent, so this suppresses by state instead of racing that
+ * listener: hidden until the next ordinary interaction. Capture on `window`
+ * runs ahead of anything that might stop propagation.
+ */
+function useContextMenuOpen(editor: BlockNoteEditor): boolean {
+  const [isOpen, setIsOpen] = useState(false)
+
+  useEffect(() => {
+    const open = (event: Event): void => {
+      const viewDom = getProseMirrorViewDom(editor)
+      const target = event.target
+      if (!viewDom || !(target instanceof Node) || !viewDom.contains(target)) return
+      setIsOpen(true)
+    }
+    const closeOnPointer = (event: Event): void => {
+      if ((event as { button?: number }).button === 2) return
+      setIsOpen(false)
+    }
+    const closeOnKey = (): void => setIsOpen(false)
+
+    window.addEventListener('contextmenu', open, true)
+    window.addEventListener('pointerdown', closeOnPointer, true)
+    window.addEventListener('keydown', closeOnKey, true)
+
+    return () => {
+      window.removeEventListener('contextmenu', open, true)
+      window.removeEventListener('pointerdown', closeOnPointer, true)
+      window.removeEventListener('keydown', closeOnKey, true)
+    }
+  }, [editor])
+
+  return isOpen
 }
 
 /**

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -232,6 +232,10 @@ If enabled in [Settings → Editor](/user-guide/settings#editor), word count app
 
 Off by default. Turn on **Check Spelling** in [Settings → Editor](/user-guide/settings#editor) to underline misspelled words as you write.
 
+Open the context menu on an underlined word to correct it. Suggestions sit at the top of the menu; picking one replaces the word. **Add to Dictionary** teaches the spellchecker the word so it stops being flagged, on this and future runs. Words with no suggestion show a disabled **No Suggestions** entry.
+
+Memry does not pick a spellchecking language of its own. macOS detects the language you are writing in; Windows and Linux use the dictionary for the system locale.
+
 ## Toolbar
 
 The formatting toolbar can be sticky at the top or float above selections — choose in [Settings → Editor](/user-guide/settings#editor).
@@ -239,6 +243,8 @@ The formatting toolbar can be sticky at the top or float above selections — ch
 Both modes offer the same formatting controls: the block type (paragraph, heading, list) plus inline styles, alignment, colour, indent, and links. The block type control is hidden for blocks that have no alternative type, such as tasks, callouts, and files.
 
 The floating toolbar also carries **inline code** (`` `code` ``) next to bold, italic, underline and strikethrough, and ends with a full-width **Comment** button that opens a comment on the selection.
+
+Opening the context menu stands the floating toolbar down, so you get one menu rather than two. It returns on your next click or keystroke.
 
 ### Turning existing lines into a list
 

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -179,7 +179,7 @@ Clicking a row — built-in or custom — opens it in the [template editor](/use
 
 ### Spelling
 
-**Check Spelling** underlines misspelled words in notes and journals. It is **off by default**; turn it on to see squiggles as you write.
+**Check Spelling** underlines misspelled words in notes and journals. It is **off by default**; turn it on to see squiggles as you write. Correcting a flagged word happens from the editor's context menu — see [Spell Check](/user-guide/notes/editing#spell-check).
 
 ---
 

--- a/packages/i18n/src/locales/en/menu.json
+++ b/packages/i18n/src/locales/en/menu.json
@@ -34,7 +34,9 @@
     "pasteAndMatchStyle": "Paste and Match Style",
     "delete": "Delete",
     "startSpeaking": "Start Speaking",
-    "stopSpeaking": "Stop Speaking"
+    "stopSpeaking": "Stop Speaking",
+    "addToDictionary": "Add to Dictionary",
+    "noSuggestions": "No Suggestions"
   },
   "insert": {
     "label": "Insert",


### PR DESCRIPTION
Closes #1850

Two unrelated defects behind one report. Aurelie guessed they might be the same bug; they are not.

## Bug 1 — spelling suggestions were never wired up

Chromium's spellchecker was doing its job. The red squiggle simply led nowhere.

Electron hands `misspelledWord` and `dictionarySuggestions` to the `context-menu` handler in `apps/desktop/src/main/index.ts`, and has done all along. `buildEditableTextContextMenu` never declared either field, so the menu it built went straight to undo/cut/copy/paste. `replaceMisspelling` and `addWordToSpellCheckerDictionary` appeared nowhere in the codebase.

The builder now prepends the suggestions, each applying via `replaceMisspelling`, then a separator, then **Add to Dictionary**, then a separator before the existing edit items. An empty suggestion list shows a disabled **No Suggestions** entry so the feature is visibly present instead of silently absent. All labels go through i18n like the rest of the file.

The builder takes the `WebContents` it acts on as a third argument; both APIs hang off it.

### On `setSpellCheckerLanguages`

Confirmed genuinely unset, and deliberately left that way. Electron's typings state the macOS spellchecker is the OS one and detects the language itself, making the call a no-op there; Windows and Linux fall back to the dictionary for the app locale. The reporter's squiggles are proof that the default already resolves to a working dictionary on her machine.

Wiring it to the app's UI language would actively regress anyone running an English UI while writing in another language. Choosing a writing-language source is a product decision, not a bug fix, so this PR does not invent one.

## Bug 2 — two menus, and the wrong one held focus

The native menu is popped from the main process while the renderer independently opens BlockNote's floating formatting toolbar off the same pointer sequence. Neither knew about the other, so the toolbar appeared without focus and stayed inert until force-clicked.

BlockNote opens that toolbar from a capture-phase `pointerup` listener on the document. Whether `contextmenu` arrives before or after that `pointerup` is platform-dependent, so racing its listener would have meant a platform branch. Instead the toolbar gates on state: a `contextmenu` inside the ProseMirror DOM hides the floating toolbar until the next ordinary interaction (a non-secondary `pointerdown`, or any key). The listener is capture-phase on `window`, which runs ahead of anything that could stop propagation.

**Where that state lives turned out to be the whole problem.** The first attempt put it in `ReviewFormattingToolbar` and passed its unit tests, but failed in the real app. `FormattingToolbarController` tears the toolbar down and mounts a fresh one during the very interaction being suppressed — a `MutationObserver` recorded removed/added twice, at 4ms and 14ms — so the `useState` died with the old instance and the replacement rendered as if nothing had happened. The suppression fired and then undid itself.

The gate now sits in `ReviewFormattingToolbarController`, which ContentArea mounts and BlockNote never touches. When it is open the controller returns null and `FormattingToolbarController` is not rendered at all. The sticky toolbar and the double-click selection path are untouched, which the reporter explicitly asked for.

## Verification

**Bug 1, in a real Electron process.** A probe loaded a spellchecked `contenteditable`, sent a genuine secondary-button `sendInputEvent`, and fed the resulting params through the real `buildEditableTextContextMenu`:

```
PARAMS {"isEditable":true,"misspelledWord":"recieve","dictionarySuggestions":["receive","relieve"]}
MENU   ["receive", "relieve", separator, "Add to Dictionary", separator, "Undo", "Redo", ...]
AFTER_REPLACE  I receive mail
```

Clicking the suggestion replaced the word in the live page. Add-to-dictionary was verified across a full app restart: a second run reported `misspelledWord: ""` for the same word, and `listWordsInSpellCheckerDictionary()` returned `["recieve"]`. The probe word was then removed again, so no dictionary state was left behind.

**Bug 2, in the packaged app under Playwright.** Against a renderer bundle rebuilt from scratch and grepped to confirm it contained this arrangement: a normal double-click still opens the floating toolbar, a right-click leaves none visible, and the next ordinary selection opens it again. Four consecutive passes, no flake. The build carrying the earlier broken arrangement served as the negative control and fails the same assertion, so the test is load-bearing. Guards against a vacuous pass: the selection still reads the clicked word afterwards, the editor keeps focus, and a main-process counter saw exactly one genuine `context-menu` event.

**Unit tests.** Suggestion ordering, the empty-suggestions placeholder, the correctly-spelled no-op, both click handlers, and the toolbar gate. Every new test was mutation-checked: reverting the corresponding fix turns it red. The mocked `FormattingToolbarController` is keyed so one test forces the remount that defeated the first attempt — putting the state back in the inner component fails that test and only that test.

```
Test Files  4 passed (4)
     Tests  125 passed (125)
```

**Gates.** `pnpm lint`, `typecheck:web`, `typecheck:node`, `typecheck:test`, `i18n:check`, `git diff --check`, `docs:impact --strict`, `docs:build` all pass.

## Windows

The reporter is on Windows; I can only run macOS. No platform-specific branch was added anywhere in this change, which is the point of gating bug 2 on state rather than on event order. The one platform-dependent behaviour in play, the spellchecker's language source, is described above and is Electron's own default on both platforms.

One honest gap: the Playwright harness has to neutralise the native menu to run at all, since Playwright cannot see or dismiss an OS menu. So the E2E covers the toolbar half only. The native menu half — that the suggestions actually render in the Windows context menu — is covered by the Electron probe above on macOS and by construction elsewhere, and deserves one manual pass on Windows before release.

## Note on a pre-existing red gate

`pnpm typecheck` and `pnpm build` fail on `origin/main` before this branch exists, in the architecture boundary check:

```
- apps/mobile/vitest.config.ts -> node:url (node builtin reachable from apps/mobile)
```

That file arrived with #1863 and this PR does not touch `apps/mobile`. It needs its own fix.

The final commit pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: it relocates where the gate's state lives and changes no user-visible behaviour beyond what the docs commit on this branch already describes. `docs:impact --base origin/main --strict` reports the branch as covered.
