### PR TITLE
fix(editor): restore inline date pills on the collaborative open path; legible fired reminders

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -2965,6 +2965,10 @@ describe('a date pill keeps its exact bytes on the main path', () => {
   const legacyEncode = (obj: unknown): string =>
     btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
 
+  /** A base64url run as a markdown escaper would have left it. */
+  const markdownEscaped = (run: string): string =>
+    [...run].map((c) => (c === '_' || c === '-' ? `\\${c}` : c)).join('')
+
   async function roundTrip(markdown: string): Promise<string | null> {
     const doc = new Y.Doc()
     await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
@@ -3025,7 +3029,7 @@ describe('a date pill keeps its exact bytes on the main path', () => {
     // bytes — and the wider token class means the renderer would have promoted
     // the pill either way.
     const payload = legacyEncode({ ...props, anchorId: 'dm_0?x' })
-    const escaped = `((date:${payload.replace(/_/g, '\\_')}))`
+    const escaped = `((date:${markdownEscaped(payload)}))`
 
     expect(escaped).toContain('\\')
     expect(await roundTrip(`due ${escaped} ok`)).toBe(`due ((date:${payload})) ok`)

--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -2941,3 +2941,93 @@ describe('blocknote-converter table cell checkboxes', () => {
     expect(await yDocToMarkdown(doc)).toBe('- [x] a task')
   })
 })
+
+/**
+ * #1845: what main writes for a date pill is exactly what the renderer's
+ * collaborative promoter reads back (`date-mention-collab-promotion.test.ts`).
+ * Main has no promoter of its own — a token it parses out of a vault file stays
+ * plain text in the Y.Doc — so these are the two halves of the loop: the bytes
+ * a node becomes, and the bytes an un-promoted token keeps.
+ *
+ * Asserted as exact strings, never `toContain`: write-back byte-compares, so a
+ * character of drift rewrites every note holding a date pill in every vault.
+ */
+describe('a date pill keeps its exact bytes on the main path', () => {
+  const props = {
+    anchorId: 'dm_5a0b9c1e-2d3f-4a5b-8c7d-9e0f1a2b3c4d',
+    dateISO: '2026-06-20T09:00:00.000Z',
+    hasTime: true,
+    dateFormat: 'full' as const,
+    remind: '1h' as const,
+    timeFormat: '24h' as const
+  }
+
+  const legacyEncode = (obj: unknown): string =>
+    btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+  async function roundTrip(markdown: string): Promise<string | null> {
+    const doc = new Y.Doc()
+    await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    return await yDocToMarkdown(doc)
+  }
+
+  it('serializes the node to the token the renderer promoted it from', async () => {
+    const doc = new Y.Doc()
+    blocksToYFragment(
+      [
+        {
+          id: 'b1',
+          type: 'paragraph',
+          props: {},
+          children: [],
+          content: [{ type: 'dateMention', props }]
+        }
+      ] as unknown as Parameters<typeof blocksToYFragment>[0],
+      doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+
+    expect(await yDocToMarkdown(doc)).toBe(serializeDateMentionToken(props))
+  })
+
+  it('emits only characters no markdown writer escapes', async () => {
+    const doc = new Y.Doc()
+    blocksToYFragment(
+      [
+        {
+          id: 'b1',
+          type: 'paragraph',
+          props: {},
+          children: [],
+          // `?` is what drives base64 onto the symbols base64url spells `-`/`_`,
+          // and `_` is escaped unconditionally in phrasing content.
+          content: [{ type: 'dateMention', props: { ...props, anchorId: 'dm_0?x' } }]
+        }
+      ] as unknown as Parameters<typeof blocksToYFragment>[0],
+      doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    )
+
+    expect(await yDocToMarkdown(doc)).toMatch(/^\(\(date:[A-Za-z0-9,;]+\)\)$/)
+  })
+
+  it('leaves a token it cannot promote byte-identical', async () => {
+    // Both shapes a vault can already hold: today's, and the base64url one
+    // written before the alphabet closed. Main must hand them back untouched.
+    const current = serializeDateMentionToken(props)
+    const legacy = `((date:${legacyEncode({ ...props, anchorId: 'dm_0?x' })}))`
+
+    expect(await roundTrip(`due ${current} ok`)).toBe(`due ${current} ok`)
+    expect(await roundTrip(`due ${legacy} ok`)).toBe(`due ${legacy} ok`)
+  })
+
+  it('drops a stray escape from a token rather than carrying it', async () => {
+    // A `\` inside the run is the shape the report describes. remark-parse reads
+    // it as an escape and does not put it back, so the round trip heals the
+    // bytes — and the wider token class means the renderer would have promoted
+    // the pill either way.
+    const payload = legacyEncode({ ...props, anchorId: 'dm_0?x' })
+    const escaped = `((date:${payload.replace(/_/g, '\\_')}))`
+
+    expect(escaped).toContain('\\')
+    expect(await roundTrip(`due ${escaped} ok`)).toBe(`due ((date:${payload})) ok`)
+  })
+})

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -2941,13 +2941,24 @@ del.bn-inline-content {
   --date-mention-color: #60a5fa;
 }
 
-/* Fired (triggered) reminder pill → red until the pill is edited. Set by
-   useTriggeredDatePills via data-fired; overrides the blue affordance above
-   (same specificity, later in source). One color for both themes. */
+/* Fired (triggered) reminder pill → a spent chip: the reminder is in the past,
+   which is a record, not a fault. Set by useTriggeredDatePills via data-fired;
+   overrides the blue affordance above (same specificity, later in source).
+   Muted text at full opacity keeps the date and time readable — this is the one
+   place a user goes back to ask what they had scheduled — while the settled
+   background and the dimmed alarm say "already happened". Distinct from an
+   armed pill (blue, no fill) and from a date-only pill (muted, no fill, no
+   alarm); red is left to mean broken. Theme-aware through the muted token. */
 .bn-shadcn .bn-editor .date-mention[data-fired='true'],
 .dark .bn-editor .date-mention[data-fired='true'],
 .date-mention[data-fired='true'] {
-  --date-mention-color: #e56458;
+  --date-mention-color: var(--muted-foreground);
+  background: color-mix(in srgb, var(--muted-foreground) 10%, transparent);
+}
+
+.bn-shadcn .bn-editor .date-mention[data-fired='true'] .date-mention-icon,
+.date-mention[data-fired='true'] .date-mention-icon {
+  opacity: 0.6;
 }
 
 .bn-shadcn .bn-editor .date-mention:hover,

--- a/apps/desktop/src/renderer/src/components/note/content-area/date-mention-collab-promotion.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/date-mention-collab-promotion.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Opening a COLLABORATIVE note turns `((date:…))` back into a date pill (#1845).
+ *
+ * The same gap `wiki-link-collab-promotion.test.ts` and
+ * `inline-checkbox-collab-promotion.test.ts` cover, for the node where it costs
+ * the user the most. `useEditorSync`'s load effect returns early once a Y.Doc
+ * fragment is bound, so `normalizeNoteBlocks` runs on the markdown path only —
+ * and a date token carries no readable fallback, so a note whose CRDT doc was
+ * rebuilt from disk opened showing a base64 run where the date had been.
+ *
+ * Nothing is faked between the editor and the CRDT: a REAL `BlockNoteEditor` on
+ * the REAL `editorSchema`, mounted, with REAL Yjs collaboration against a REAL
+ * `Y.Doc`, and the REAL hook whose load effect does the promoting. Only main's
+ * `markdownToYFragment` is stood in for — the fragment is seeded with the shape
+ * that parser produces (one plain text run), because importing `src/main` here
+ * would drag `node:crypto`, `electron-log` and both databases into jsdom.
+ */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BlockNoteEditor, type Block } from '@blocknote/core'
+import * as Y from 'yjs'
+import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
+import { serializeDateMentionToken, type DateMentionData } from '@memry/shared/date-mention'
+
+vi.mock('react-pdf', () => ({
+  Document: () => null,
+  Page: () => null,
+  pdfjs: { GlobalWorkerOptions: { workerSrc: '' } }
+}))
+
+vi.mock('@/lib/url-metadata', () => ({
+  fetchLinkPreview: vi.fn().mockResolvedValue({ domain: '', title: '', favicon: '' })
+}))
+
+import { editorSchema } from './editor-schema'
+import { useEditorSync } from './hooks/use-editor-sync'
+
+const reminder: DateMentionData = {
+  anchorId: 'dm_5a0b9c1e-2d3f-4a5b-8c7d-9e0f1a2b3c4d',
+  dateISO: '2026-06-20T09:00:00.000Z',
+  hasTime: true,
+  dateFormat: 'full',
+  remind: '1h',
+  timeFormat: '24h'
+}
+
+const legacyEncode = (obj: unknown): string =>
+  btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+const mounted: Array<{ editor: BlockNoteEditor; el: HTMLElement; doc: Y.Doc }> = []
+
+afterEach(() => {
+  for (const { editor, el, doc } of mounted.splice(0)) {
+    ;(editor as unknown as { mount: (element?: HTMLElement) => void }).mount()
+    el.remove()
+    doc.destroy()
+  }
+})
+
+function createCollaborativeEditor(): { editor: BlockNoteEditor; fragment: Y.XmlFragment } {
+  const doc = new Y.Doc()
+  const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+
+  const editor = BlockNoteEditor.create({
+    schema: editorSchema,
+    collaboration: { fragment, user: { name: 'Local User', color: '#3b82f6' } }
+  } as never) as unknown as BlockNoteEditor
+
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  editor.mount(el)
+  mounted.push({ editor, el, doc })
+
+  return { editor, fragment }
+}
+
+/** Seed the shared doc the way main's parser leaves it: the token as text. */
+function seedParagraph(editor: BlockNoteEditor, text: string): void {
+  editor.replaceBlocks(editor.document, [
+    { type: 'paragraph', content: [{ type: 'text', text, styles: {} }] } as never
+  ])
+}
+
+function nodeNames(fragment: Y.XmlFragment): string[] {
+  const names: string[] = []
+  const visit = (node: Y.XmlFragment | Y.XmlElement): void => {
+    for (const child of node.toArray()) {
+      const element = child as Y.XmlElement
+      if (typeof element.nodeName !== 'string') continue
+      names.push(element.nodeName)
+      visit(element)
+    }
+  }
+  visit(fragment)
+  return names
+}
+
+function runs(editor: BlockNoteEditor): Array<Record<string, unknown>> {
+  return (editor.document[0] as Block).content as unknown as Array<Record<string, unknown>>
+}
+
+function openNote(editor: BlockNoteEditor, fragment: Y.XmlFragment): void {
+  renderHook(() => useEditorSync({ editor, noteId: 'date-collab-note', yjsFragment: fragment }))
+}
+
+describe('opening a collaborative note promotes its date pills', () => {
+  it('turns a token back into a pill in the shared Y.Doc', () => {
+    // #given the shared doc as main leaves it: the reminder is text, and its
+    // text is base64 — the reported "I have no idea what the date was"
+    const { editor, fragment } = createCollaborativeEditor()
+    seedParagraph(editor, `Ship it ${serializeDateMentionToken(reminder)} please`)
+    expect(nodeNames(fragment)).not.toContain('dateMention')
+
+    // #when the note is opened and nothing else happens — no keystroke
+    openNote(editor, fragment)
+
+    // #then the promotion reached the CRDT, not just the local editor state
+    expect(nodeNames(fragment)).toContain('dateMention')
+    expect(runs(editor)).toEqual([
+      { type: 'text', text: 'Ship it ', styles: {} },
+      { type: 'dateMention', props: reminder },
+      { type: 'text', text: ' please', styles: {} }
+    ])
+  })
+
+  it('promotes a token written by the old base64url writer', () => {
+    // #given the bytes a vault written before the alphabet closed still holds
+    const { editor, fragment } = createCollaborativeEditor()
+    const legacy = { ...reminder, anchorId: 'dm_0?x' }
+    seedParagraph(editor, `((date:${legacyEncode(legacy)}))`)
+
+    openNote(editor, fragment)
+
+    expect(runs(editor)).toEqual([{ type: 'dateMention', props: legacy }])
+  })
+
+  it('promotes a token a markdown escaper backslashed', () => {
+    const { editor, fragment } = createCollaborativeEditor()
+    const legacy = { ...reminder, anchorId: 'dm_0?x' }
+    const escaped = legacyEncode(legacy).replace(/_/g, '\\_').replace(/-/g, '\\-')
+    seedParagraph(editor, `((date:${escaped}))`)
+
+    openNote(editor, fragment)
+
+    expect(runs(editor)).toEqual([{ type: 'dateMention', props: legacy }])
+  })
+
+  it('degrades a token the parser refuses to a readable date', () => {
+    // #given a pre-`remind`-enum token: it arms nothing and never has, but the
+    // date it was scheduled for is still in there
+    const { editor, fragment } = createCollaborativeEditor()
+    const preEnum = {
+      anchorId: 'dm_old',
+      dateISO: '2026-06-20T09:00:00.000Z',
+      hasTime: true,
+      dateFormat: 'full',
+      remind: true,
+      lead: '1h'
+    }
+    seedParagraph(editor, `((date:${legacyEncode(preEnum)}))`)
+
+    openNote(editor, fragment)
+
+    // #then a plain date pill, not two hundred characters of base64
+    expect(runs(editor)).toEqual([
+      {
+        type: 'dateMention',
+        props: {
+          anchorId: 'dm_old',
+          dateISO: '2026-06-20T09:00:00.000Z',
+          hasTime: true,
+          dateFormat: 'full',
+          remind: 'none',
+          timeFormat: 'system'
+        }
+      }
+    ])
+  })
+
+  it('leaves a token with no recoverable date exactly as the user has it', () => {
+    // #given bytes nothing can be made of. Destroying them would be worse than
+    // showing them, so the pass declines.
+    const { editor, fragment } = createCollaborativeEditor()
+    seedParagraph(editor, '((date:notavalidpayload))')
+
+    openNote(editor, fragment)
+
+    expect(nodeNames(fragment)).not.toContain('dateMention')
+    expect(runs(editor)).toEqual([{ type: 'text', text: '((date:notavalidpayload))', styles: {} }])
+  })
+
+  it('promotes once and writes nothing on a second open', () => {
+    // #given a note opened once already — the shared doc now holds the node
+    const { editor, fragment } = createCollaborativeEditor()
+    seedParagraph(editor, serializeDateMentionToken(reminder))
+    openNote(editor, fragment)
+    expect(nodeNames(fragment)).toContain('dateMention')
+
+    // #when it is opened again. "Opening a note must not rewrite it" (#1434):
+    // a promoted node leaves no `((date:` text behind, so the pass finds nothing.
+    const updates: Uint8Array[] = []
+    const doc = fragment.doc as Y.Doc
+    doc.on('update', (update: Uint8Array) => updates.push(update))
+    openNote(editor, fragment)
+
+    // #then no CRDT update at all — not a no-op update, none
+    expect(updates).toEqual([])
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/date-mention-collab-promotion.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/date-mention-collab-promotion.test.ts
@@ -48,6 +48,10 @@ const reminder: DateMentionData = {
 const legacyEncode = (obj: unknown): string =>
   btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
 
+/** A base64url run as a markdown escaper would have left it. */
+const markdownEscaped = (run: string): string =>
+  [...run].map((c) => (c === '_' || c === '-' ? `\\${c}` : c)).join('')
+
 const mounted: Array<{ editor: BlockNoteEditor; el: HTMLElement; doc: Y.Doc }> = []
 
 afterEach(() => {
@@ -138,7 +142,7 @@ describe('opening a collaborative note promotes its date pills', () => {
   it('promotes a token a markdown escaper backslashed', () => {
     const { editor, fragment } = createCollaborativeEditor()
     const legacy = { ...reminder, anchorId: 'dm_0?x' }
-    const escaped = legacyEncode(legacy).replace(/_/g, '\\_').replace(/-/g, '\\-')
+    const escaped = markdownEscaped(legacyEncode(legacy))
     seedParagraph(editor, `((date:${escaped}))`)
 
     openNote(editor, fragment)

--- a/apps/desktop/src/renderer/src/components/note/content-area/date-mention-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/date-mention-utils.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { Block } from '@blocknote/core'
-import { DATE_MENTION_TOKEN_REGEX, parseDateMentionToken } from '@memry/shared/date-mention'
+import {
+  DATE_MENTION_TOKEN_REGEX,
+  parseDateMentionToken,
+  salvageDateMentionToken
+} from '@memry/shared/date-mention'
 import { createDateMentionContent } from './date-mention'
 
 type InlineNode = { type: string; text?: string; styles?: unknown; props?: unknown }
@@ -14,7 +18,7 @@ function splitTextNode(node: InlineNode): InlineNode[] {
   let last = 0
   let m: RegExpExecArray | null
   while ((m = regex.exec(text)) !== null) {
-    const data = parseDateMentionToken(m[1])
+    const data = parseDateMentionToken(m[1]) ?? salvageDateMentionToken(m[1])
     if (!data) continue
     if (m.index > last) {
       out.push({ type: 'text', text: text.slice(last, m.index), styles: node.styles })

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
@@ -12,6 +12,7 @@ import {
 import { normalizeHashTags, extractInlineTags } from '../hash-tag'
 import { normalizeNoteBlocks } from '../normalize-note-blocks'
 import { normalizeInlineCheckboxes } from '../inline-checkbox-utils'
+import { normalizeDateMentions } from '../date-mention-utils'
 import {
   parseMarkdownPreservingBlanks,
   sanitizeBlockIds,
@@ -94,9 +95,9 @@ function replaceInitialBlocksWithoutHistory(editor: any, blocks: Block[]): void 
  * Idempotent by construction: a promoted `wikiLink` node carries its target in
  * props, so `[[` never reappears and `normalizeWikiLinks` stops matching. A
  * second open writes no CRDT update at all, which is what keeps "opening a note
- * must not rewrite it" (#1434) true. Only wiki links promote here — hash tags
- * and date mentions have no promoter on the collaborative path and must stay
- * the bytes they were opened with.
+ * must not rewrite it" (#1434) true. Hash tags still have no promoter here:
+ * they need the note's tag list and colour map, so they must stay the bytes
+ * they were opened with.
  */
 function promoteWikiLinksInSharedDoc(editor: any): void {
   const normalized = normalizeWikiLinks(editor.document as Block[], {
@@ -133,6 +134,33 @@ function promoteWikiLinksInSharedDoc(editor: any): void {
  */
 function promoteInlineCheckboxesInSharedDoc(editor: any): void {
   const normalized = normalizeInlineCheckboxes(editor.document as Block[])
+  if (!normalized.didChange) return
+
+  editor.replaceBlocks(editor.document, normalized.blocks)
+}
+
+/**
+ * Promote the raw `((date:…))` text a collaborative document opens with (#1845).
+ *
+ * The third instance of the gap above, and the one a user cannot read past.
+ * Main parses the vault file into the shared Y.Doc with a `dateMention` spec
+ * whose `parse` claims a `data-date-mention` element — markdown has none — so
+ * the token reaches the doc as plain TEXT, and the renderer is the only thing
+ * that can turn it back into a pill. The load effect returns before
+ * `normalizeNoteBlocks` on this path, so nothing did: a note whose CRDT doc is
+ * rebuilt from disk (a restart, a vault switch, a new device) opened showing a
+ * two-hundred-character base64 run where the date had been. A reminder pill is
+ * worse off than any other node here, because its text carries no readable
+ * fallback at all.
+ *
+ * Byte-neutral for a well-formed token: the promoted node re-serializes to the
+ * bytes it was promoted from, so a second open writes no CRDT update and
+ * "opening a note must not rewrite it" (#1434) still holds. A token the parser
+ * refuses is salvaged to a plain date instead, which does change the bytes —
+ * once, on a note that was already unreadable.
+ */
+function promoteDateMentionsInSharedDoc(editor: any): void {
+  const normalized = normalizeDateMentions(editor.document as Block[])
   if (!normalized.didChange) return
 
   editor.replaceBlocks(editor.document, normalized.blocks)
@@ -334,6 +362,7 @@ export function useEditorSync({
       // push that to every device.
       promoteWikiLinksInSharedDoc(editor)
       promoteInlineCheckboxesInSharedDoc(editor)
+      promoteDateMentionsInSharedDoc(editor)
       clearYjsUndoHistory(editor)
       isContentReadyRef.current = true
       if (onHeadingsChange) {

--- a/apps/docs/src/user-guide/notes/bookmarks-reminders.md
+++ b/apps/docs/src/user-guide/notes/bookmarks-reminders.md
@@ -54,6 +54,25 @@ When the reminder fires, memrynote shows an in-app toast with:
 | Open          | Open the note in a tab           |
 | Dismiss       | Mark as handled; don't reappear  |
 
+## Inline Date Pills
+
+Typing `@` in note text offers a date. Accepting one drops a pill into the sentence, and the pill can
+carry its own reminder — useful when the reminder belongs to a paragraph rather than to the note as a
+whole. Click the pill to change the date, the clock format or the reminder lead time.
+
+A pill reads as one of three things:
+
+| Appearance                             | Meaning                                   |
+| -------------------------------------- | ----------------------------------------- |
+| Muted text, no alarm icon              | A date, with no reminder attached         |
+| Blue text with an alarm icon           | A reminder is armed and has not fired yet |
+| Muted text on a soft fill, faded alarm | The reminder already fired                |
+
+A fired pill keeps its date and time on the page. It is a record of what you scheduled, so you can
+still read it back long after the reminder has passed. Fired styling is per-device: it comes from
+this device's reminder history and is never written into the note file, so the note reads the same on
+a machine where the reminder has not fired yet.
+
 ## Reminder Badge
 
 Notes with upcoming reminders show a small bell badge in the sidebar and tab bar. Hover for the time.

--- a/packages/shared/src/date-mention.test.ts
+++ b/packages/shared/src/date-mention.test.ts
@@ -27,6 +27,10 @@ const encode = (obj: unknown): string =>
 
 const payload = (token: string): string => token.replace(/^\(\(date:|\)\)$/g, '')
 
+/** A base64url run as a markdown escaper would have left it. */
+const markdownEscaped = (run: string): string =>
+  [...run].map((c) => (c === '_' || c === '-' ? `\\${c}` : c)).join('')
+
 describe('date-mention token', () => {
   it('round-trips through serialize/parse', () => {
     const token = serializeDateMentionToken(base)
@@ -166,13 +170,13 @@ describe('tolerating tokens already on disk', () => {
   it('heals a token a markdown escaper backslashed', () => {
     // What the issue reports: `\` lands inside the run, the strict class stops
     // matching, and the pill is left on the page as literal text.
-    const escaped = encode(legacy).replace(/_/g, '\\_').replace(/-/g, '\\-')
+    const escaped = markdownEscaped(encode(legacy))
     expect(escaped).toContain('\\')
     expect(parseDateMentionToken(escaped)).toEqual(legacy)
   })
 
   it('matches escaped and legacy shapes with the token regex', () => {
-    const escaped = `((date:${encode(legacy).replace(/_/g, '\\_')}))`
+    const escaped = `((date:${markdownEscaped(encode(legacy))}))`
     const matches = [...`due ${escaped} today`.matchAll(DATE_MENTION_TOKEN_REGEX)]
     expect(matches).toHaveLength(1)
     expect(parseDateMentionToken(matches[0][1])?.anchorId).toBe('dm_0?x')

--- a/packages/shared/src/date-mention.test.ts
+++ b/packages/shared/src/date-mention.test.ts
@@ -3,6 +3,7 @@ import {
   DATE_MENTION_TOKEN_REGEX,
   serializeDateMentionToken,
   parseDateMentionToken,
+  salvageDateMentionToken,
   computeRemindAt,
   type DateMentionData
 } from './date-mention'
@@ -16,8 +17,15 @@ const base: DateMentionData = {
   timeFormat: '24h'
 }
 
+/**
+ * The writer that shipped before the alphabet closed: plain base64url, `-` and
+ * `_` included. Every token in a real vault was written by this, so it doubles
+ * as the compatibility fixture and as the byte-identity oracle below.
+ */
 const encode = (obj: unknown): string =>
   btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+const payload = (token: string): string => token.replace(/^\(\(date:|\)\)$/g, '')
 
 describe('date-mention token', () => {
   it('round-trips through serialize/parse', () => {
@@ -105,6 +113,101 @@ describe('date-mention token', () => {
     const token = serializeDateMentionToken(bare)
     const [m] = [...token.matchAll(DATE_MENTION_TOKEN_REGEX)]
     expect(parseDateMentionToken(m[1])).toEqual(bare)
+  })
+})
+
+describe('the on-disk alphabet is closed and markdown-inert', () => {
+  // `?` is the shortest input that drives base64 onto its 63rd symbol, which is
+  // where base64url puts `_` — the one character remark-stringify escapes
+  // unconditionally in phrasing content. Nothing in a real payload reaches it,
+  // which is exactly why the alphabet has to be closed by construction rather
+  // than left to what the fields happen to contain.
+  const forced: DateMentionData = { ...base, anchorId: 'dm_0?x' }
+
+  it('never emits a character a markdown writer would escape', () => {
+    expect(encode(forced)).toMatch(/_/)
+    expect(payload(serializeDateMentionToken(forced))).toMatch(/^[A-Za-z0-9,;]+$/)
+  })
+
+  it('round-trips a payload that forced the odd base64 symbols', () => {
+    const token = serializeDateMentionToken(forced)
+    const [m] = [...token.matchAll(DATE_MENTION_TOKEN_REGEX)]
+    expect(parseDateMentionToken(m[1])).toEqual(forced)
+  })
+
+  it('writes the bytes the old writer wrote, for every payload a note can hold', () => {
+    // Byte identity is the compatibility contract: the vault write-back compares
+    // bytes, so a token that re-serialized differently would rewrite every note
+    // holding a date pill. `anchorId` is the only free field and it is
+    // `dm_<uuid>`, so no payload reaches `+`/`/` and both writers agree.
+    for (let i = 0; i < 200; i++) {
+      const data: DateMentionData = {
+        anchorId: `dm_${crypto.randomUUID()}`,
+        dateISO: new Date(Date.UTC(2026, i % 12, (i % 27) + 1, i % 24, i % 60)).toISOString(),
+        hasTime: i % 2 === 0,
+        dateFormat: i % 3 === 0 ? 'full' : 'relative',
+        remind: (['none', 'at', '5m', '30m', '1h', '2h', '1d', '2d', '1w'] as const)[i % 9],
+        timeFormat: (['system', '12h', '24h'] as const)[i % 3]
+      }
+      expect(serializeDateMentionToken(data)).toBe(`((date:${encode(data)}))`)
+    }
+  })
+})
+
+describe('tolerating tokens already on disk', () => {
+  const legacy: DateMentionData = { ...base, anchorId: 'dm_0?x' }
+
+  it('parses a base64url token written before the alphabet closed', () => {
+    const written = encode(legacy)
+    expect(written).toMatch(/[-_]/)
+    expect(parseDateMentionToken(written)).toEqual(legacy)
+  })
+
+  it('heals a token a markdown escaper backslashed', () => {
+    // What the issue reports: `\` lands inside the run, the strict class stops
+    // matching, and the pill is left on the page as literal text.
+    const escaped = encode(legacy).replace(/_/g, '\\_').replace(/-/g, '\\-')
+    expect(escaped).toContain('\\')
+    expect(parseDateMentionToken(escaped)).toEqual(legacy)
+  })
+
+  it('matches escaped and legacy shapes with the token regex', () => {
+    const escaped = `((date:${encode(legacy).replace(/_/g, '\\_')}))`
+    const matches = [...`due ${escaped} today`.matchAll(DATE_MENTION_TOKEN_REGEX)]
+    expect(matches).toHaveLength(1)
+    expect(parseDateMentionToken(matches[0][1])?.anchorId).toBe('dm_0?x')
+  })
+})
+
+describe('salvageDateMentionToken', () => {
+  const preEnum = {
+    anchorId: 'dm_old',
+    dateISO: '2026-06-20T09:00:00.000Z',
+    hasTime: true,
+    dateFormat: 'full',
+    remind: true,
+    lead: '1h'
+  }
+
+  it('recovers the date from a token the parser refuses', () => {
+    // The parser's graceful null is unchanged — the salvage sits beside it, so
+    // a pre-enum token shows the date it was rather than its own base64.
+    expect(parseDateMentionToken(encode(preEnum))).toBeNull()
+    expect(salvageDateMentionToken(encode(preEnum))).toEqual({
+      anchorId: 'dm_old',
+      dateISO: '2026-06-20T09:00:00.000Z',
+      hasTime: true,
+      dateFormat: 'full',
+      remind: 'none',
+      timeFormat: 'system'
+    })
+  })
+
+  it('returns null when no date survives', () => {
+    expect(salvageDateMentionToken('not-json')).toBeNull()
+    expect(salvageDateMentionToken(encode({ anchorId: 'dm_x' }))).toBeNull()
+    expect(salvageDateMentionToken(encode({ anchorId: 'dm_x', dateISO: 'whenever' }))).toBeNull()
+    expect(salvageDateMentionToken(encode({ dateISO: base.dateISO }))).toBeNull()
   })
 })
 

--- a/packages/shared/src/date-mention.ts
+++ b/packages/shared/src/date-mention.ts
@@ -1,23 +1,13 @@
 /**
  * Durable token for inline date mentions. The renderer pill serializes its
- * props to `((date:<base64url-json>))` so the date survives the markdown
+ * props to `((date:<base64-json>))` so the date survives the markdown
  * round-trip as a single text node, and the main process derives reminder
  * rows by parsing the same token out of the note's raw markdown. This module
  * is the single source of truth for the format — imported by both sides.
  */
 
 export type RemindOffset =
-  | 'none'
-  | 'at'
-  | '5m'
-  | '10m'
-  | '15m'
-  | '30m'
-  | '1h'
-  | '2h'
-  | '1d'
-  | '2d'
-  | '1w'
+  'none' | 'at' | '5m' | '10m' | '15m' | '30m' | '1h' | '2h' | '1d' | '2d' | '1w'
 
 export type DateMentionDateFormat = 'relative' | 'full'
 
@@ -34,7 +24,12 @@ export interface DateMentionData {
   timeFormat: DateMentionTimeFormat
 }
 
-export const DATE_MENTION_TOKEN_REGEX = /\(\(date:([A-Za-z0-9_-]+)\)\)/g
+/**
+ * What a token may contain on disk. Writers emit the closed alphabet below;
+ * the class is wider so a token that already picked up base64url's `-`/`_` — or
+ * a stray `\` from a markdown escaper — still matches and is healed on read.
+ */
+export const DATE_MENTION_TOKEN_REGEX = /\(\(date:([A-Za-z0-9,;_\\-]+)\)\)/g
 
 const REMIND_OFFSETS: ReadonlyArray<RemindOffset> = [
   'none',
@@ -68,50 +63,106 @@ const DAY_OFFSET: Record<string, number> = {
   '1w': 7
 }
 
-function toBase64Url(s: string): string {
+/**
+ * base64 over a closed, markdown-inert alphabet: `A-Za-z0-9` plus `,` and `;`
+ * in place of base64url's `-` and `_`.
+ *
+ * The two odd base64 symbols are the only characters an encoder can emit, so
+ * they are the only ones a markdown writer could ever get hold of — and `_`
+ * opens emphasis, which puts it on remark-stringify's unconditional escape list
+ * for phrasing content. `,` and `;` appear on no escape list and start no
+ * markdown construct, so a token is inert by construction rather than by luck.
+ *
+ * Existing vault bytes are untouched: the payload is printable-ASCII JSON, and
+ * base64 only reaches `+`/`/` for input containing `>`, `?` or `~`. No field can
+ * hold one (`dm_<uuid>` anchors, ISO dates, closed enums), so every token
+ * written before this change re-encodes to the same bytes and no note is
+ * rewritten by the write-back byte compare.
+ */
+function encodeTokenPayload(s: string): string {
   // btoa/atob exist in both renderer (browser) and Electron main (Node 20+).
-  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  return btoa(s).replace(/\+/g, ',').replace(/\//g, ';').replace(/=+$/, '')
 }
 
-function fromBase64Url(s: string): string {
-  const padded = s.replace(/-/g, '+').replace(/_/g, '/')
-  return atob(padded)
+function decodeTokenPayload(s: string): string {
+  // `\` can only be an escaper's, never an encoder's. Both alphabets decode:
+  // `-`/`,` were `+`, `_`/`;` were `/`.
+  const base64 = s.replace(/\\/g, '').replace(/[-,]/g, '+').replace(/[_;]/g, '/')
+  return atob(base64)
+}
+
+function decodeTokenObject(encoded: string): Record<string, unknown> | null {
+  try {
+    const obj = JSON.parse(decodeTokenPayload(encoded)) as unknown
+    return obj && typeof obj === 'object' ? (obj as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
 }
 
 export function serializeDateMentionToken(data: DateMentionData): string {
-  return `((date:${toBase64Url(JSON.stringify(data))}))`
+  return `((date:${encodeTokenPayload(JSON.stringify(data))}))`
 }
 
 export function parseDateMentionToken(encoded: string): DateMentionData | null {
-  try {
-    const obj = JSON.parse(fromBase64Url(encoded)) as Record<string, unknown>
-    // Strict on the load-bearing fields; old tokens carried boolean `remind`
-    // + `lead`, both of which fail the enum/string checks below → null (a
-    // graceful drop; callers already skip null).
-    if (
-      typeof obj.anchorId !== 'string' ||
-      typeof obj.dateISO !== 'string' ||
-      typeof obj.hasTime !== 'boolean' ||
-      typeof obj.remind !== 'string' ||
-      !REMIND_OFFSETS.includes(obj.remind as RemindOffset)
-    ) {
-      return null
-    }
-    // Default the cosmetic fields so slightly-old or hand-authored tokens still
-    // render. timeFormat falls back to 'system' (inherit general settings).
-    const dateFormat: DateMentionDateFormat = obj.dateFormat === 'full' ? 'full' : 'relative'
-    const timeFormat: DateMentionTimeFormat =
-      obj.timeFormat === '12h' || obj.timeFormat === '24h' ? obj.timeFormat : 'system'
-    return {
-      anchorId: obj.anchorId,
-      dateISO: obj.dateISO,
-      hasTime: obj.hasTime,
-      dateFormat,
-      remind: obj.remind as RemindOffset,
-      timeFormat
-    }
-  } catch {
+  const obj = decodeTokenObject(encoded)
+  if (!obj) return null
+
+  // Strict on the load-bearing fields; old tokens carried boolean `remind`
+  // + `lead`, both of which fail the enum/string checks below → null (a
+  // graceful drop; callers already skip null).
+  if (
+    typeof obj.anchorId !== 'string' ||
+    typeof obj.dateISO !== 'string' ||
+    typeof obj.hasTime !== 'boolean' ||
+    typeof obj.remind !== 'string' ||
+    !REMIND_OFFSETS.includes(obj.remind as RemindOffset)
+  ) {
     return null
+  }
+  // Default the cosmetic fields so slightly-old or hand-authored tokens still
+  // render. timeFormat falls back to 'system' (inherit general settings).
+  const dateFormat: DateMentionDateFormat = obj.dateFormat === 'full' ? 'full' : 'relative'
+  const timeFormat: DateMentionTimeFormat =
+    obj.timeFormat === '12h' || obj.timeFormat === '24h' ? obj.timeFormat : 'system'
+  return {
+    anchorId: obj.anchorId,
+    dateISO: obj.dateISO,
+    hasTime: obj.hasTime,
+    dateFormat,
+    remind: obj.remind as RemindOffset,
+    timeFormat
+  }
+}
+
+/**
+ * Best-effort recovery from a token `parseDateMentionToken` refused.
+ *
+ * A pre-`remind`-enum token fails that check on `remind` alone, and until now
+ * it stayed on the page as its own base64 — a dense, unreadable run where a
+ * date used to be, which is the half of #1845 the reporter could not work
+ * around. The date itself is right there in the payload, so the pill degrades
+ * to a plain, readable date rather than a blob. The reminder is not restored:
+ * those tokens have armed nothing since the enum landed, so `none` is what they
+ * already meant.
+ *
+ * Returns null when the payload carries no usable date. Those bytes are left
+ * exactly as the user's disk has them — an unreadable token beats a destroyed
+ * one.
+ */
+export function salvageDateMentionToken(encoded: string): DateMentionData | null {
+  const obj = decodeTokenObject(encoded)
+  if (!obj) return null
+  if (typeof obj.anchorId !== 'string' || !obj.anchorId) return null
+  if (typeof obj.dateISO !== 'string' || Number.isNaN(Date.parse(obj.dateISO))) return null
+
+  return {
+    anchorId: obj.anchorId,
+    dateISO: obj.dateISO,
+    hasTime: obj.hasTime === true,
+    dateFormat: obj.dateFormat === 'full' ? 'full' : 'relative',
+    remind: 'none',
+    timeFormat: obj.timeFormat === '12h' || obj.timeFormat === '24h' ? obj.timeFormat : 'system'
   }
 }
 


### PR DESCRIPTION
## What changes for the user

An inline reminder pill written into note body text survives a restart, a vault switch or a rebuild on a new device. Before this, the pill came back as a two-hundred-character base64 run — the date it stood for was unreadable, which is what the reporter hit.

A fired reminder pill now reads as a spent chip: muted text at full opacity, a settled background, a dimmed alarm icon. It keeps its date and time on the page as a record of what was scheduled, and is visually distinct from an armed pill (blue, alarm) and from a date-only pill (muted, no fill, no alarm). Red is left to mean broken.

A date token the parser refuses now degrades to a plain, readable date instead of staying an opaque blob.

## Root cause

Not the escape the issue proposed. Two probes against the real converter say so: a realistic payload never reaches the base64 symbols base64url spells `-`/`_` (the JSON is printable ASCII, and only `>`, `?` or `~` can drive base64 onto them — no field can hold one), and when a token is forced to contain `_`, this serialization path emits it bare rather than escaped.

The actual break is the collaborative open path. Main parses the vault file into the shared Y.Doc with a `dateMention` spec whose `parse` claims a `data-date-mention` element, and markdown has none, so the token reaches the doc as plain text. `useEditorSync`'s load effect returns early once a Y.Doc fragment is bound, so `normalizeNoteBlocks` — and every promoter in it — runs on the markdown path only. Nothing turned the token back into a pill. Wiki links (#1642) and inline checkboxes already close this exact gap; a date token is worse off than either, because its text carries no readable fallback at all.

`promoteDateMentionsInSharedDoc` closes it the same way.

## Compat plan

- **Token bytes are unchanged.** The alphabet is closed at the same time — the encoder spells the two odd base64 symbols `,` and `;` rather than base64url's `-` and `_`, because `_` opens emphasis and sits on remark-stringify's unconditional escape list for phrasing content. No realistic payload reaches those symbols, so every token already on disk re-encodes to identical bytes. `date-mention.test.ts` asserts byte-for-byte equality against the old writer over 200 generated payloads. The write-back byte compare therefore rewrites nothing.
- **Both alphabets parse**, and a stray `\` inside the run is stripped, so any token already written with an escape is healed on read.
- **Graceful null is preserved.** `parseDateMentionToken` still returns null for pre-`remind`-enum tokens. The degrade is a separate `salvageDateMentionToken`, and it restores `remind: 'none'` only — those tokens have armed nothing since the enum landed, so nothing is resurrected.
- **Bytes with no recoverable date are left exactly as they are.** An unreadable token beats a destroyed one.
- **Promotion is byte-neutral.** A promoted node re-serializes to the token it came from, so a second open writes no CRDT update and "opening a note must not rewrite it" (#1434) holds. A salvaged token does change the bytes, once, on a note that was already unreadable.
- **Fired state stays per-device and presentational.** It is still applied as a `data-fired` DOM attribute by `use-triggered-date-pills.ts` and is never written into pill props or markdown.

## Verification

- `pnpm lint` clean. `typecheck:node` / `typecheck:web` / `typecheck:test` clean. `pnpm typecheck` fails only on a pre-existing architecture-boundary violation in `apps/mobile/vitest.config.ts`, which this branch does not touch.
- `packages/shared/src/date-mention.test.ts` — 22 passed. Covers the closed alphabet, byte identity against the old writer, a legacy base64url token with `_`/`-` runs, a backslash-escaped token, and the salvage.
- `apps/desktop/src/main/sync/blocknote-converter.test.ts` — 247 passed with `src/main/notes/note-date-reminders.test.ts`. New: a `dateMention` node serializes to exactly the token the renderer's promoter reads, emits only `[A-Za-z0-9,;]`, hands an un-promotable token back byte-identical, and drops a stray escape rather than carrying it.
- `date-mention-collab-promotion.test.ts` — 6 passed. Real `BlockNoteEditor` on the real schema, real Yjs collaboration, the real hook. Covers the current token, the legacy one, the escaped one, the degrade, the untouched-bytes case, and "promotes once, writes nothing on a second open".
- Full renderer content-area suite — 792 passed, 6 skipped, 62 files.
- `pnpm docs:impact --base origin/main --strict` green, `pnpm docs:build` green, `git diff --check` clean.

The full conformance suite is #1848's; the link-mention half is #1844's, and `link-mention.ts` is untouched here.

Closes #1845
