### PR TITLE
fix(editor): close the link-mention token alphabet so mentions survive reload

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -3365,13 +3365,15 @@ describe('a link mention through the main serializer', () => {
 
     // #then the exact bytes, and nothing outside the token's closed alphabet
     expect(markdown).toBe(`See ${serializeLinkMentionToken(url)} here.`)
-    expect(markdown).toMatch(/\(\(mention:[A-Za-z0-9.%-]+\)\)/)
+    expect(markdown).toMatch(/^See \(\(mention:[A-Za-z0-9.%-]+\)\) here\.$/)
   })
 
   it('leaves a token it reads out of a vault file byte-identical', async () => {
     // #given main has no promoter — the token stays plain text through the
-    // seed, which is exactly why it must not be rewritten in passing.
-    const markdown = `See ${serializeLinkMentionToken("https://x.test/a*b_c'd")} here.`
+    // seed, which is exactly why it must not be rewritten in passing. Two `*`
+    // URLs on one line is the shape that used to pair up into an emphasis run
+    // and rewrite the whole paragraph.
+    const markdown = `See ${serializeLinkMentionToken("https://x.test/a*b_c'd")} and ${serializeLinkMentionToken('https://x.test/e*f~g')} here.`
     const doc = new Y.Doc()
     await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
 

--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -3322,3 +3322,63 @@ describe('healing callouts already torn bare (#1846)', () => {
     expect(blocks?.some((b) => (b.type as string) === 'callout')).toBe(false)
   })
 })
+
+/**
+ * The main serializer's half of the mention token (#1844). The renderer writes
+ * the vault file when the note is open; main writes it from the shared Y.Doc
+ * when it is not. A URL whose bytes differ between the two would rewrite the
+ * file on every handoff, so what main puts on disk has to be exactly what
+ * `serializeLinkMentionToken` says.
+ */
+describe('a link mention through the main serializer', () => {
+  const mentionBlock = (url: string): unknown => ({
+    id: 'm1',
+    type: 'paragraph',
+    props: {},
+    children: [],
+    content: [
+      { type: 'text', text: 'See ', styles: {} },
+      {
+        type: 'linkMention',
+        props: { url, domain: 'x.test', title: '', favicon: '', siteName: '' }
+      },
+      { type: 'text', text: ' here.', styles: {} }
+    ]
+  })
+
+  it.each([
+    'https://x.test/foo_bar',
+    'https://x.test/a*b',
+    'https://x.test/a~b',
+    "https://x.test/it's",
+    'https://x.test/a!b',
+    'https://x.test/a(b)c',
+    'https://x.test/s?q=a+b&page=2#frag',
+    'https://eksisozluk.com/başlık/şeker'
+  ])('writes the same token the renderer would for %s', async (url) => {
+    // #given
+    const doc = new Y.Doc()
+    blocksToYFragment([mentionBlock(url) as never], doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+    // #when
+    const markdown = await yDocToMarkdown(doc)
+
+    // #then the exact bytes, and nothing outside the token's closed alphabet
+    expect(markdown).toBe(`See ${serializeLinkMentionToken(url)} here.`)
+    expect(markdown).toMatch(/\(\(mention:[A-Za-z0-9.%-]+\)\)/)
+  })
+
+  it('leaves a token it reads out of a vault file byte-identical', async () => {
+    // #given main has no promoter — the token stays plain text through the
+    // seed, which is exactly why it must not be rewritten in passing.
+    const markdown = `See ${serializeLinkMentionToken("https://x.test/a*b_c'd")} here.`
+    const doc = new Y.Doc()
+    await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+    // #when
+    const result = await yDocToMarkdown(doc)
+
+    // #then
+    expect(result).toBe(markdown)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
@@ -175,21 +175,24 @@ function promoteDateMentionsInSharedDoc(editor: any): void {
  * main seeds the shared doc straight from the vault file, where a mention is
  * plain text, and this path returns before `normalizeNoteBlocks` ever runs.
  *
- * Idempotent for the same reason wiki links are — a promoted `linkMention`
- * serializes back to the token it was built from, so `((mention:` is gone from
- * the document and the second open matches nothing and writes no update.
+ * Idempotent from the first open onwards — a promoted `linkMention` serializes
+ * back to the token it was built from, so `((mention:` is gone from the
+ * document and the second open matches nothing and writes no update. The one
+ * exception is a token whose URL holds `_ * ! ~ '`, which older builds wrote
+ * with those characters raw: promoting it rewrites the token in the closed
+ * alphabet once, and every open after that is a no-op.
  *
- * Reports whether it promoted, because only then is the metadata fetch worth
- * it: the token carries the URL and nothing else, so a chip promoted here has
- * no title or favicon until `hydrateLinkMentionFavicons` refills them, exactly
- * as it does on the markdown path.
+ * No favicon hydration here, deliberately. `hydrateLinkMentionFavicons` writes
+ * back a content array it captured before its fetch, which on a shared document
+ * would push a stale block to every device, and it resolves after
+ * `clearYjsUndoHistory` has run, leaving the open undoable. A chip promoted
+ * here renders its domain, which is what the token carries.
  */
-function promoteLinkMentionsInSharedDoc(editor: any): boolean {
+function promoteLinkMentionsInSharedDoc(editor: any): void {
   const normalized = normalizeLinkMentions(editor.document as Block[])
-  if (!normalized.didChange) return false
+  if (!normalized.didChange) return
 
   editor.replaceBlocks(editor.document, normalized.blocks)
-  return true
 }
 
 function clearYjsUndoHistory(editor: any): void {
@@ -387,7 +390,7 @@ export function useEditorSync({
       // undoable step: Cmd+Z here would turn the chips back into raw text and
       // push that to every device.
       promoteWikiLinksInSharedDoc(editor)
-      if (promoteLinkMentionsInSharedDoc(editor)) hydrateLinkMentionFavicons(editor)
+      promoteLinkMentionsInSharedDoc(editor)
       promoteInlineCheckboxesInSharedDoc(editor)
       promoteDateMentionsInSharedDoc(editor)
       clearYjsUndoHistory(editor)

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
@@ -19,6 +19,7 @@ import {
   serializeBlocksPreservingBlanks
 } from '../markdown-utils'
 import { createLinkMentionContent } from '../link-mention'
+import { normalizeLinkMentions } from '../link-mention-utils'
 import { fetchLinkPreview } from '@/lib/url-metadata'
 import type { HeadingInfo, InlineTagsOrigin } from '../types'
 import { createLogger } from '@/lib/logger'
@@ -164,6 +165,31 @@ function promoteDateMentionsInSharedDoc(editor: any): void {
   if (!normalized.didChange) return
 
   editor.replaceBlocks(editor.document, normalized.blocks)
+}
+
+/**
+ * Promote the `((mention:…))` tokens a collaborative document opens with.
+ *
+ * The same gap the two promoters above close, and the one that made a saved
+ * mention come back as literal text after a restart or a vault switch (#1844):
+ * main seeds the shared doc straight from the vault file, where a mention is
+ * plain text, and this path returns before `normalizeNoteBlocks` ever runs.
+ *
+ * Idempotent for the same reason wiki links are — a promoted `linkMention`
+ * serializes back to the token it was built from, so `((mention:` is gone from
+ * the document and the second open matches nothing and writes no update.
+ *
+ * Reports whether it promoted, because only then is the metadata fetch worth
+ * it: the token carries the URL and nothing else, so a chip promoted here has
+ * no title or favicon until `hydrateLinkMentionFavicons` refills them, exactly
+ * as it does on the markdown path.
+ */
+function promoteLinkMentionsInSharedDoc(editor: any): boolean {
+  const normalized = normalizeLinkMentions(editor.document as Block[])
+  if (!normalized.didChange) return false
+
+  editor.replaceBlocks(editor.document, normalized.blocks)
+  return true
 }
 
 function clearYjsUndoHistory(editor: any): void {
@@ -361,6 +387,7 @@ export function useEditorSync({
       // undoable step: Cmd+Z here would turn the chips back into raw text and
       // push that to every device.
       promoteWikiLinksInSharedDoc(editor)
+      if (promoteLinkMentionsInSharedDoc(editor)) hydrateLinkMentionFavicons(editor)
       promoteInlineCheckboxesInSharedDoc(editor)
       promoteDateMentionsInSharedDoc(editor)
       clearYjsUndoHistory(editor)

--- a/apps/desktop/src/renderer/src/components/note/content-area/link-mention-collab-promotion.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/link-mention-collab-promotion.test.ts
@@ -1,0 +1,193 @@
+/**
+ * The other half of #1844, and the one that made the mention vanish outright.
+ *
+ * Main seeds the shared Y.Doc straight from the vault file, and the mention
+ * spec has no text `parse` rule, so `((mention:…))` reaches the doc as plain
+ * TEXT. The collaborative branch of `useEditorSync` returns before
+ * `normalizeNoteBlocks` ever runs, so nothing on either side turned that text
+ * back into a chip: a mention survived until the Y.Doc was thrown away, and
+ * came back as literal `((mention:…))` after a restart or a vault switch.
+ *
+ * Built the same way `wiki-link-collab-promotion.test.ts` is, with nothing
+ * faked between the editor and the CRDT: a REAL `BlockNoteEditor` on the REAL
+ * `editorSchema`, REAL Yjs collaboration, the REAL `useEditorSync` hook. Only
+ * main's `markdownToYFragment` is stood in for — the fragment is seeded with
+ * the one plain text run that parser produces.
+ */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BlockNoteEditor, type Block } from '@blocknote/core'
+import * as Y from 'yjs'
+import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
+import { serializeLinkMentionToken } from '@memry/editor-schema/inline'
+
+vi.mock('react-pdf', () => ({
+  Document: () => null,
+  Page: () => null,
+  pdfjs: { GlobalWorkerOptions: { workerSrc: '' } }
+}))
+
+const fetchLinkPreview = vi.fn().mockResolvedValue({ domain: '', title: '', favicon: '' })
+vi.mock('@/lib/url-metadata', () => ({
+  fetchLinkPreview: (url: string) => fetchLinkPreview(url),
+  extractDomain: (url: string) => {
+    try {
+      return new URL(url).hostname.replace('www.', '')
+    } catch {
+      return url
+    }
+  }
+}))
+
+import { editorSchema } from './editor-schema'
+import { useEditorSync } from './hooks/use-editor-sync'
+
+const mounted: Array<{ editor: BlockNoteEditor; el: HTMLElement; doc: Y.Doc }> = []
+
+afterEach(() => {
+  for (const { editor, el, doc } of mounted.splice(0)) {
+    ;(editor as unknown as { mount: (element?: HTMLElement) => void }).mount()
+    el.remove()
+    doc.destroy()
+  }
+  fetchLinkPreview.mockClear()
+})
+
+function createCollaborativeEditor(): {
+  editor: BlockNoteEditor
+  doc: Y.Doc
+  fragment: Y.XmlFragment
+} {
+  const doc = new Y.Doc()
+  const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+  const editor = BlockNoteEditor.create({
+    schema: editorSchema,
+    collaboration: { fragment, user: { name: 'Local User', color: '#3b82f6' } }
+  } as never) as unknown as BlockNoteEditor
+
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  editor.mount(el)
+  mounted.push({ editor, el, doc })
+
+  return { editor, doc, fragment }
+}
+
+/** Seed the shared doc the way main's parser leaves it: the token as plain text. */
+function seedWithPlainText(editor: BlockNoteEditor, text: string): void {
+  editor.replaceBlocks(editor.document, [
+    { type: 'paragraph', content: [{ type: 'text', text, styles: {} }] } as never
+  ])
+}
+
+function nodeNames(fragment: Y.XmlFragment): string[] {
+  const names: string[] = []
+  const visit = (node: Y.XmlFragment | Y.XmlElement): void => {
+    for (const child of node.toArray()) {
+      const element = child as Y.XmlElement
+      if (typeof element.nodeName !== 'string') continue
+      names.push(element.nodeName)
+      visit(element)
+    }
+  }
+  visit(fragment)
+  return names
+}
+
+/** Rendering the hook IS opening the note: its load effect is the subject. */
+function openNote(editor: BlockNoteEditor, fragment: Y.XmlFragment): void {
+  renderHook(() =>
+    useEditorSync({ editor, noteId: 'link-mention-promotion-note', yjsFragment: fragment })
+  )
+}
+
+const URL_ = 'https://eksisozluk.com/entry/184233570?debe=true'
+
+describe('the renderer promotes ((mention:…)) inside a collaborative document', () => {
+  it('writes a linkMention node into the shared Y.Doc on open', () => {
+    // #given a shared doc holding what main's parser produces for a saved mention
+    const { editor, fragment } = createCollaborativeEditor()
+    seedWithPlainText(editor, `See ${serializeLinkMentionToken(URL_)} for details.`)
+    expect(nodeNames(fragment)).not.toContain('linkMention')
+
+    // #when the note is opened — no edit, no change event
+    openNote(editor, fragment)
+
+    // #then the promotion reached the CRDT, not just the local editor state
+    expect(nodeNames(fragment)).toContain('linkMention')
+    const content = (editor.document[0] as Block).content as Array<{
+      type: string
+      props?: { url?: string; domain?: string }
+    }>
+    expect(content.map((run) => run.type)).toEqual(['text', 'linkMention', 'text'])
+    expect(content[1].props?.url).toBe(URL_)
+    expect(content[1].props?.domain).toBe('eksisozluk.com')
+  })
+
+  it('promotes once and then stops — a second open writes nothing', () => {
+    // #given a note opened once
+    const { editor, doc, fragment } = createCollaborativeEditor()
+    seedWithPlainText(editor, `See ${serializeLinkMentionToken(URL_)} for details.`)
+    openNote(editor, fragment)
+
+    // #when it is opened again against the already-promoted document
+    const updates: Uint8Array[] = []
+    doc.on('update', (update: Uint8Array) => updates.push(update))
+    openNote(editor, fragment)
+    openNote(editor, fragment)
+
+    // #then nothing more is written. A promoted `linkMention` carries its URL
+    // in props, so `((mention:` is gone from the document and the normalizer
+    // stops matching — which is what keeps "opening a note must not rewrite
+    // it" (#1434) true.
+    expect(updates).toEqual([])
+    expect(nodeNames(fragment).filter((name) => name === 'linkMention')).toHaveLength(1)
+  })
+
+  it('heals a token a previous build mangled', () => {
+    // #given the shape sitting in real vaults: a stray space before the `))`
+    const { editor, fragment } = createCollaborativeEditor()
+    seedWithPlainText(editor, '((mention:https%3A%2F%2Fx.test%2Fpage ))')
+
+    // #when
+    openNote(editor, fragment)
+
+    // #then
+    const content = (editor.document[0] as Block).content as Array<{
+      type: string
+      props?: { url?: string }
+    }>
+    expect(content[0].type).toBe('linkMention')
+    expect(content[0].props?.url).toBe('https://x.test/page')
+  })
+
+  it('fetches the site metadata the promoted chip renders', () => {
+    // #given
+    const { editor, fragment } = createCollaborativeEditor()
+    seedWithPlainText(editor, serializeLinkMentionToken(URL_))
+
+    // #when
+    openNote(editor, fragment)
+
+    // #then the collaborative path hydrates like the markdown path does, so a
+    // mention does not render as a bare domain on one surface and a full chip
+    // on the other.
+    expect(fetchLinkPreview).toHaveBeenCalledWith(URL_)
+  })
+
+  it('leaves a note without a mention untouched', () => {
+    // #given
+    const { editor, doc, fragment } = createCollaborativeEditor()
+    seedWithPlainText(editor, 'Nothing to promote here.')
+
+    // #when
+    const updates: Uint8Array[] = []
+    doc.on('update', (update: Uint8Array) => updates.push(update))
+    openNote(editor, fragment)
+
+    // #then no CRDT write, and no needless metadata fetch
+    expect(updates).toEqual([])
+    expect(fetchLinkPreview).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/link-mention-collab-promotion.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/link-mention-collab-promotion.test.ts
@@ -125,17 +125,19 @@ describe('the renderer promotes ((mention:…)) inside a collaborative document'
     expect(content[1].props?.domain).toBe('eksisozluk.com')
   })
 
-  it('promotes once and then stops — a second open writes nothing', () => {
+  it('promotes once and then stops — a second open writes nothing', async () => {
     // #given a note opened once
     const { editor, doc, fragment } = createCollaborativeEditor()
     seedWithPlainText(editor, `See ${serializeLinkMentionToken(URL_)} for details.`)
     openNote(editor, fragment)
 
-    // #when it is opened again against the already-promoted document
+    // #when it is opened again against the already-promoted document. Awaited
+    // so any queued microtask lands inside the window being asserted on.
     const updates: Uint8Array[] = []
     doc.on('update', (update: Uint8Array) => updates.push(update))
     openNote(editor, fragment)
     openNote(editor, fragment)
+    await Promise.resolve()
 
     // #then nothing more is written. A promoted `linkMention` carries its URL
     // in props, so `((mention:` is gone from the document and the normalizer
@@ -162,18 +164,21 @@ describe('the renderer promotes ((mention:…)) inside a collaborative document'
     expect(content[0].props?.url).toBe('https://x.test/page')
   })
 
-  it('fetches the site metadata the promoted chip renders', () => {
+  it('does not fetch site metadata on this path', async () => {
     // #given
     const { editor, fragment } = createCollaborativeEditor()
     seedWithPlainText(editor, serializeLinkMentionToken(URL_))
 
     // #when
     openNote(editor, fragment)
+    await Promise.resolve()
 
-    // #then the collaborative path hydrates like the markdown path does, so a
-    // mention does not render as a bare domain on one surface and a full chip
-    // on the other.
-    expect(fetchLinkPreview).toHaveBeenCalledWith(URL_)
+    // #then `hydrateLinkMentionFavicons` writes back a content array captured
+    // before its fetch and resolves after the undo history is cleared. On a
+    // shared document that is a stale block pushed to every device and an
+    // undoable step on open, so the collaborative path leaves the chip with the
+    // domain the token carries.
+    expect(fetchLinkPreview).not.toHaveBeenCalled()
   })
 
   it('leaves a note without a mention untouched', () => {
@@ -186,8 +191,7 @@ describe('the renderer promotes ((mention:…)) inside a collaborative document'
     doc.on('update', (update: Uint8Array) => updates.push(update))
     openNote(editor, fragment)
 
-    // #then no CRDT write, and no needless metadata fetch
+    // #then
     expect(updates).toEqual([])
-    expect(fetchLinkPreview).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/link-mention-roundtrip.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/link-mention-roundtrip.test.ts
@@ -1,0 +1,157 @@
+/**
+ * A mention's real round trip: node → markdown → disk → markdown → node, with
+ * the REAL editor schema and the REAL save/load serializers on both ends.
+ *
+ * `link-mention.test.ts` in `@memry/editor-schema` pins the token's own bytes.
+ * This drives the pipeline those bytes travel through, because the failure in
+ * #1844 lived between them: remark-stringify writes `*` and `~` into the token
+ * unescaped, and remark-parse then reads the run between two tokens as an
+ * emphasis or strikethrough span, shredding both mentions into literal text.
+ * Neither half is wrong in isolation, so only the round trip catches it.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { BlockNoteEditor, type Block } from '@blocknote/core'
+
+// pdf.js touches `DOMMatrix` at import time, which jsdom has none of. The rest
+// of the schema is real.
+vi.mock('react-pdf', () => ({
+  Document: () => null,
+  Page: () => null,
+  pdfjs: { GlobalWorkerOptions: { workerSrc: '' } }
+}))
+
+import { editorSchema } from './editor-schema'
+import { serializeBlocksPreservingBlanks } from './markdown-utils'
+import { normalizeLinkMentions } from './link-mention-utils'
+
+function createEditor(): BlockNoteEditor {
+  const editor = BlockNoteEditor.create({
+    schema: editorSchema
+  } as never) as unknown as BlockNoteEditor
+  const element = document.createElement('div')
+  document.body.appendChild(element)
+  editor.mount(element)
+  return editor
+}
+
+function mention(url: string): unknown {
+  return {
+    type: 'linkMention',
+    props: { url, domain: 'x.test', title: '', favicon: '', siteName: '' }
+  }
+}
+
+function paragraph(content: unknown[]): Block[] {
+  return [{ id: 'b1', type: 'paragraph', props: {}, children: [], content }] as unknown as Block[]
+}
+
+/** Save the blocks, load them back, and report the mention URLs that survived. */
+async function survivingUrls(editor: BlockNoteEditor, blocks: Block[]): Promise<string[]> {
+  const markdown = await serializeBlocksPreservingBlanks(editor, blocks)
+  const reparsed = await editor.tryParseMarkdownToBlocks(markdown)
+  const { blocks: normalized } = normalizeLinkMentions(reparsed as Block[])
+
+  const urls: string[] = []
+  const walk = (items: unknown[]): void => {
+    for (const item of items as Array<Record<string, any>>) {
+      if (item?.type === 'linkMention') urls.push(item.props.url)
+      if (Array.isArray(item?.content)) walk(item.content)
+      if (Array.isArray(item?.children)) walk(item.children)
+    }
+  }
+  walk(normalized)
+  return urls
+}
+
+describe('a link mention survives the markdown round trip', () => {
+  it.each([
+    ['underscore', 'https://x.test/foo_bar_baz'],
+    ['asterisk', 'https://x.test/a*b'],
+    ['bang', 'https://x.test/a!b'],
+    ['tilde', 'https://x.test/a~b'],
+    ['apostrophe', "https://x.test/it's"],
+    ['parens', 'https://x.test/a(b)c'],
+    ['percent', 'https://x.test/100%25'],
+    ['query string', 'https://x.test/s?q=a+b&page=2#frag'],
+    ['space', 'https://x.test/a b'],
+    ['non-ascii', 'https://eksisozluk.com/başlık/şeker'],
+    ['every offender at once', "https://x.test/_*!~'()%?a=b&c=d#e"]
+  ])('with %s in the URL', async (_name, url) => {
+    const editor = createEditor()
+    expect(await survivingUrls(editor, paragraph([mention(url)]))).toEqual([url])
+  })
+
+  it.each([
+    ['asterisk', 'https://x.test/a*b', 'https://x.test/c*d'],
+    ['tilde', 'https://x.test/a~b', 'https://x.test/c~d'],
+    ['underscore', 'https://x.test/a_b', 'https://x.test/c_d']
+  ])('with two mentions on one line, both holding a %s', async (_name, first, second) => {
+    // The reported shape. Before the token alphabet was closed, the `*` and
+    // `~` runs paired up ACROSS the gap between the two tokens and both
+    // mentions came back as literal `((mention:…))` text.
+    const editor = createEditor()
+    const blocks = paragraph([
+      mention(first),
+      { type: 'text', text: ' and ', styles: {} },
+      mention(second)
+    ])
+    expect(await survivingUrls(editor, blocks)).toEqual([first, second])
+  })
+
+  it('keeps a mention next to styled text', async () => {
+    const editor = createEditor()
+    const blocks = paragraph([
+      mention('https://x.test/a*b'),
+      { type: 'text', text: 'x', styles: { bold: true } }
+    ])
+    expect(await survivingUrls(editor, blocks)).toEqual(['https://x.test/a*b'])
+  })
+
+  it('writes bytes a second save reproduces exactly', async () => {
+    // Opening a note must not rewrite it (#1434): the token has to be a fixed
+    // point, or every open dirties the file and syncs a no-op change.
+    const editor = createEditor()
+    const url = "https://x.test/_*!~'()?a=b"
+    const first = await serializeBlocksPreservingBlanks(editor, paragraph([mention(url)]))
+    const reparsed = await editor.tryParseMarkdownToBlocks(first)
+    const { blocks } = normalizeLinkMentions(reparsed as Block[])
+    const second = await serializeBlocksPreservingBlanks(editor, blocks)
+    expect(second).toBe(first)
+  })
+})
+
+describe('a mangled token already on disk heals on open', () => {
+  it.each([
+    [
+      'a stray space before the delimiter',
+      '((mention:https%3A%2F%2Fx.test%2Fpage ))',
+      'https://x.test/page'
+    ],
+    [
+      'a stray escape inside the payload',
+      '((mention:https%3A%2F%2Fx.test%2Fpage\\_1))',
+      'https://x.test/page_1'
+    ],
+    ['both at once', '((mention:https%3A%2F%2Fx.test%2Fpage\\_1 ))', 'https://x.test/page_1']
+  ])('recovers a mention from %s', (_name, text, expected) => {
+    // Straight to the normalizer, not through `tryParseMarkdownToBlocks`:
+    // remark unescapes `\_` while parsing, so the block text is the only place
+    // a stray backslash can actually be observed.
+    const { blocks, didChange } = normalizeLinkMentions(
+      paragraph([{ type: 'text', text, styles: {} }])
+    )
+
+    expect(didChange).toBe(true)
+    const content = (blocks[0] as Block).content as Array<Record<string, any>>
+    expect(content[0].type).toBe('linkMention')
+    expect(content[0].props.url).toBe(expected)
+  })
+
+  it('leaves prose that merely looks like a token alone', () => {
+    const text = '((mention: see the note below))'
+    expect(normalizeLinkMentions(paragraph([{ type: 'text', text, styles: {} }])).didChange).toBe(
+      false
+    )
+  })
+})

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -1277,6 +1277,22 @@ recognised there, using the same rules the renderer uses on its own save path. M
 inside a code fence are the author's text and stay text; the fence tracker follows
 CommonMark, so a longer fence quoting a shorter one is not mistaken for a closing one.
 
+Some inline nodes have no `parse` rule that could recognise their markdown form, because
+that form is ordinary text: `[[wiki link]]`, a table cell's `[ ]`, and a link mention's
+`((mention:…))` all reach the shared doc as plain text runs. The renderer promotes those
+back into nodes when the note opens (`use-editor-sync.ts`), which is the only thing that
+turns a saved mention back into a chip — without it a mention lives only as long as its
+Y.Doc and comes back as literal text after a restart or a vault switch. Every promoter has
+to be idempotent: the promoted node serialises back to the exact token it was built from,
+so `((mention:` is gone from the document and the second open writes no CRDT update at all.
+
+That in turn constrains the token: its payload alphabet is closed to `[A-Za-z0-9.%-]`, so
+nothing in it can be reinterpreted as markdown. `encodeURIComponent` alone is not enough —
+it leaves `_ ! ~ * ' ( )` raw, and two mentions on one line whose URLs each hold a `*` are
+read back as a single emphasis run spanning both tokens, destroying both. The parser is
+correspondingly tolerant: a token written by an older build can carry a stray space or
+escape, and it is repaired on open rather than left broken.
+
 Callouts are parsed back **only in the exact shape Memry itself writes**: a marker that is
 one of the four supported types with nothing after the `]`, followed by one `> ` per body
 line. The claim is proven per note — the body is re-serialized and must reproduce the file

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -1278,8 +1278,10 @@ inside a code fence are the author's text and stay text; the fence tracker follo
 CommonMark, so a longer fence quoting a shorter one is not mistaken for a closing one.
 
 Some inline nodes have no `parse` rule that could recognise their markdown form, because
-that form is ordinary text: `[[wiki link]]`, a table cell's `[ ]`, and a link mention's
-`((mention:…))` all reach the shared doc as plain text runs. The renderer promotes those
+that form is ordinary text: `[[wiki link]]`, a table cell's `[ ]`, a link mention's
+`((mention:…))` and a date pill's `((date:…))` all reach the shared doc as plain text runs.
+Hash tags are the exception that stays text, because they need the note's tag list and
+colour map, which only the editor has. The renderer promotes the rest
 back into nodes when the note opens (`use-editor-sync.ts`), which is the only thing that
 turns a saved mention back into a chip — without it a mention lives only as long as its
 Y.Doc and comes back as literal text after a restart or a vault switch. Every promoter has

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -320,6 +320,8 @@ A cell whose text genuinely begins `[ ] ` becomes a checkbox too. The characters
 
 Links in a note are enriched with the page title, site name and favicon, both for inline link mentions and for bookmark blocks. The lookup runs once per URL and the result is kept in memory, so reopening a note with the same links does not refetch them.
 
+Only the URL is written to the note file, so a mention that has been through a restart or a vault switch comes back showing its site's domain. Its title and favicon return the next time that note's links are looked up.
+
 That in-memory cache holds the 200 most recently used links and evicts the least recently used entry beyond that, which keeps a long session with many link-heavy notes from growing without a limit. Evicted links are simply fetched again the next time they are shown.
 
 ## Comments

--- a/packages/editor-schema/src/inline/link-mention.test.ts
+++ b/packages/editor-schema/src/inline/link-mention.test.ts
@@ -64,7 +64,7 @@ describe('serializeLinkMentionToken', () => {
 })
 
 describe('MENTION_TOKEN_REGEX', () => {
-  it('accepts every payload the strict pattern accepted', () => {
+  it('captures a legacy token exactly as the strict pattern did', () => {
     const legacyStrict = /\(\(mention:([^)\s]+)\)\)/
     for (const url of ['https://x.test/a', 'https://x.test/foo_bar', 'https://x.test/a*b']) {
       // The legacy serializer left `_ * ! ~ '` raw, so build its output by hand.
@@ -73,6 +73,17 @@ describe('MENTION_TOKEN_REGEX', () => {
         new RegExp(MENTION_TOKEN_REGEX.source).exec(legacyToken)?.[1]
       )
     }
+  })
+
+  it('does not let a broken token upstream swallow a working one', () => {
+    // A note damaged by this very bug holds literal `((mention:` fragments. A
+    // payload class that stops only at `)` runs straight through the fragment
+    // and captures it together with the next real token, so widening the
+    // pattern would have broken mentions that work today.
+    const line = 'x ((mention:foo ((mention:https%3A%2F%2Fx.test)) y'
+    const matches = [...line.matchAll(MENTION_TOKEN_REGEX)]
+
+    expect(matches.map((m) => parseLinkMentionToken(m[1]))).toEqual(['https://x.test'])
   })
 
   it('matches a token a space or an escape has crept into', () => {
@@ -129,9 +140,14 @@ describe('parseLinkMentionToken', () => {
 
   it('refuses to turn prose into a mention', () => {
     // The pattern now admits whitespace, so the repair path is the only thing
-    // standing between `((mention: see below))` and a chip.
+    // standing between `((mention: see below))` and a chip. Stripping the
+    // spaces out of prose can hand it something `new URL` accepts —
+    // `see http://x.com` becomes `seehttp://x.com` — so the alphabet check has
+    // to run as well.
     expect(parseLinkMentionToken(' see below')).toBeNull()
     expect(parseLinkMentionToken('not a url ')).toBeNull()
+    expect(parseLinkMentionToken(' see http://x.com')).toBeNull()
+    expect(parseLinkMentionToken(' javascript:alert(1)')).toBeNull()
     expect(parseLinkMentionToken('  ')).toBeNull()
   })
 })

--- a/packages/editor-schema/src/inline/link-mention.test.ts
+++ b/packages/editor-schema/src/inline/link-mention.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The mention token's contract with the markdown file it lives in (#1844).
+ *
+ * A mention persists as literal text inside a paragraph, so remark-stringify
+ * gets a vote on its bytes. Anything markdown-significant left raw in the
+ * payload comes back escaped, and the escape was landing inside the URL. These
+ * tests pin the alphabet closed and pin the two shapes already sitting in real
+ * vaults as recoverable.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  MENTION_TOKEN_REGEX,
+  serializeLinkMentionToken,
+  parseLinkMentionToken
+} from './link-mention'
+
+function roundTrip(url: string): string | null {
+  const token = serializeLinkMentionToken(url)
+  const match = new RegExp(MENTION_TOKEN_REGEX.source).exec(token)
+  if (!match) return null
+  return parseLinkMentionToken(match[1])
+}
+
+describe('serializeLinkMentionToken', () => {
+  it.each([
+    ['emphasis underscore', 'https://x.test/foo_bar_baz'],
+    ['emphasis asterisk', 'https://x.test/a*b'],
+    ['image bang', 'https://x.test/a!b'],
+    ['strikethrough tilde', 'https://x.test/a~b'],
+    ['apostrophe', "https://x.test/it's"],
+    ['parens', 'https://x.test/a(b)c'],
+    ['percent', 'https://x.test/100%25'],
+    ['query string', 'https://x.test/s?q=a+b&page=2#frag'],
+    ['space', 'https://x.test/a b'],
+    ['non-ascii', 'https://eksisozluk.com/başlık/şeker'],
+    ['every offender at once', "https://x.test/_*!~'()%?a=b&c=d#e"]
+  ])('round-trips a URL with %s', (_name, url) => {
+    expect(roundTrip(url)).toBe(url)
+  })
+
+  it.each([
+    'https://x.test/foo_bar',
+    'https://x.test/a*b',
+    'https://x.test/a!b',
+    'https://x.test/a~b',
+    "https://x.test/it's",
+    'https://x.test/a(b)c',
+    'https://eksisozluk.com/başlık'
+  ])('emits nothing outside the closed alphabet for %s', (url) => {
+    expect(serializeLinkMentionToken(url)).toMatch(/^\(\(mention:[A-Za-z0-9.%-]+\)\)$/)
+  })
+
+  it('leaves the bytes of an already-safe token untouched', () => {
+    // Byte identity, not a round-trip: write-back byte-compares, so a change
+    // here rewrites every note holding a mention in every vault on next open.
+    expect(serializeLinkMentionToken('https://eksisozluk.com/entry/184233570?debe=true')).toBe(
+      '((mention:https%3A%2F%2Feksisozluk.com%2Fentry%2F184233570%3Fdebe%3Dtrue))'
+    )
+    expect(serializeLinkMentionToken('https://x.test/a(b)c')).toBe(
+      '((mention:https%3A%2F%2Fx.test%2Fa%28b%29c))'
+    )
+  })
+})
+
+describe('MENTION_TOKEN_REGEX', () => {
+  it('accepts every payload the strict pattern accepted', () => {
+    const legacyStrict = /\(\(mention:([^)\s]+)\)\)/
+    for (const url of ['https://x.test/a', 'https://x.test/foo_bar', 'https://x.test/a*b']) {
+      // The legacy serializer left `_ * ! ~ '` raw, so build its output by hand.
+      const legacyToken = `((mention:${encodeURIComponent(url).replace(/\(/g, '%28').replace(/\)/g, '%29')}))`
+      expect(legacyStrict.exec(legacyToken)?.[1]).toBe(
+        new RegExp(MENTION_TOKEN_REGEX.source).exec(legacyToken)?.[1]
+      )
+    }
+  })
+
+  it('matches a token a space or an escape has crept into', () => {
+    const pattern = new RegExp(MENTION_TOKEN_REGEX.source)
+    expect(pattern.exec('((mention:https%3A%2F%2Fx.test ))')?.[1]).toBe('https%3A%2F%2Fx.test ')
+    expect(pattern.exec('((mention:https%3A%2F%2Fx.test%2Ffoo\\_bar))')?.[1]).toBe(
+      'https%3A%2F%2Fx.test%2Ffoo\\_bar'
+    )
+  })
+
+  it('stops at the first closing delimiter with two tokens on one line', () => {
+    const matches = [
+      ...'a ((mention:https%3A%2F%2Fa.test)) b ((mention:https%3A%2F%2Fb.test)) c'.matchAll(
+        MENTION_TOKEN_REGEX
+      )
+    ]
+    expect(matches.map((m) => parseLinkMentionToken(m[1]))).toEqual([
+      'https://a.test',
+      'https://b.test'
+    ])
+  })
+})
+
+describe('parseLinkMentionToken', () => {
+  it('reads a legacy token that left markdown characters raw', () => {
+    expect(parseLinkMentionToken('https%3A%2F%2Fx.test%2Ffoo_bar')).toBe('https://x.test/foo_bar')
+    expect(parseLinkMentionToken("https%3A%2F%2Fx.test%2Fit's")).toBe("https://x.test/it's")
+  })
+
+  it('returns null for a malformed percent escape', () => {
+    expect(parseLinkMentionToken('%E0%A4%A')).toBeNull()
+    expect(parseLinkMentionToken('')).toBeNull()
+  })
+
+  it.each([
+    ['a trailing space', 'https%3A%2F%2Fthe-actual-website-url '],
+    ['a leading space', ' https%3A%2F%2Fthe-actual-website-url'],
+    ['a space mid-URL', 'https%3A%2F%2Fthe-actual- website-url']
+  ])('heals %s', (_name, payload) => {
+    expect(parseLinkMentionToken(payload)).toBe('https://the-actual-website-url')
+  })
+
+  it('heals a remark escape left inside the payload', () => {
+    expect(parseLinkMentionToken('https%3A%2F%2Fx.test%2Ffoo\\_bar\\*baz')).toBe(
+      'https://x.test/foo_bar*baz'
+    )
+  })
+
+  it('heals a payload carrying both an escape and a stray space', () => {
+    expect(parseLinkMentionToken('https%3A%2F%2Fx.test%2Ffoo\\_bar ')).toBe(
+      'https://x.test/foo_bar'
+    )
+  })
+
+  it('refuses to turn prose into a mention', () => {
+    // The pattern now admits whitespace, so the repair path is the only thing
+    // standing between `((mention: see below))` and a chip.
+    expect(parseLinkMentionToken(' see below')).toBeNull()
+    expect(parseLinkMentionToken('not a url ')).toBeNull()
+    expect(parseLinkMentionToken('  ')).toBeNull()
+  })
+})

--- a/packages/editor-schema/src/inline/link-mention.ts
+++ b/packages/editor-schema/src/inline/link-mention.ts
@@ -12,20 +12,81 @@ import { createInlineContentSpec, type InlineContentSpec } from '@blocknote/core
  * markdown round-trip as a single text node (a raw URL would be GFM
  * auto-linkified and fragmented; an <a> would be claimed by BlockNote's
  * built-in link mark). Reconstructed on load by normalizeLinkMentions.
+ *
+ * The pattern is deliberately wider than the alphabet the serializer emits. A
+ * token written by an older build can hold a stray space or a remark escape
+ * (see `parseLinkMentionToken`), and the previous `[^)\s]+` refused both — the
+ * token then never matched and stayed literal `((mention:…))` text for good.
+ * Every payload that pattern accepted, this one accepts identically.
  */
-export const MENTION_TOKEN_REGEX = /\(\(mention:([^)\s]+)\)\)/g
+export const MENTION_TOKEN_REGEX = /\(\(mention:([^)\n\r]+)\)\)/g
+
+/**
+ * `encodeURIComponent` leaves `- _ . ! ~ * ' ( )` raw. `(` and `)` break the
+ * `))` delimiter. The rest are markdown-significant, and remark-stringify does
+ * NOT escape them inside the token — so two mentions on one line whose URLs
+ * both hold a `*` (or both a `~`) come back as one emphasis run spanning from
+ * the first token into the second, and both mentions are destroyed (#1844).
+ *
+ * Encoding all seven closes the alphabet to `[A-Za-z0-9.%-]`, so the property
+ * is structural rather than a bet on remark's flanking rules staying put.
+ * `.` and `-` stay raw: both are inert unless they open a line, and a token
+ * never does.
+ */
+const TOKEN_UNSAFE = /[!'()*~_]/g
+const TOKEN_UNSAFE_ENCODED: Record<string, string> = {
+  '!': '%21',
+  "'": '%27',
+  '(': '%28',
+  ')': '%29',
+  '*': '%2A',
+  '~': '%7E',
+  _: '%5F'
+}
 
 export function serializeLinkMentionToken(url: string): string {
-  // encodeURIComponent leaves `(` and `)` raw, which would break the `))`
-  // delimiter for URLs containing parens — escape them explicitly.
-  const encoded = encodeURIComponent(url).replace(/\(/g, '%28').replace(/\)/g, '%29')
+  const encoded = encodeURIComponent(url).replace(
+    TOKEN_UNSAFE,
+    (char) => TOKEN_UNSAFE_ENCODED[char]
+  )
   return `((mention:${encoded}))`
 }
 
-export function parseLinkMentionToken(encoded: string): string | null {
+/**
+ * Any payload with no whitespace and no backslash: everything this serializer
+ * emits, and every older token that reached disk intact. Those keep the
+ * original code path so their bytes and their failure modes are unchanged.
+ */
+const WELL_FORMED_PAYLOAD = /^[^\s\\]+$/
+
+function isAbsoluteUrl(value: string): boolean {
   try {
-    const url = decodeURIComponent(encoded)
-    return url || null
+    new URL(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function parseLinkMentionToken(encoded: string): string | null {
+  if (WELL_FORMED_PAYLOAD.test(encoded)) {
+    try {
+      return decodeURIComponent(encoded) || null
+    } catch {
+      return null
+    }
+  }
+
+  // Vaults hold tokens from builds that left `_ * ! ~ '` raw, so remark's
+  // escapes and stray whitespace are already on disk. Neither a backslash nor
+  // whitespace is legal in the token alphabet, so stripping them is an
+  // unambiguous repair rather than a guess; requiring a parseable URL after the
+  // repair stops the widened pattern from claiming ordinary prose.
+  const repaired = encoded.replace(/[\s\\]/g, '')
+  if (!repaired) return null
+  try {
+    const url = decodeURIComponent(repaired)
+    return isAbsoluteUrl(url) ? url : null
   } catch {
     return null
   }

--- a/packages/editor-schema/src/inline/link-mention.ts
+++ b/packages/editor-schema/src/inline/link-mention.ts
@@ -13,13 +13,15 @@ import { createInlineContentSpec, type InlineContentSpec } from '@blocknote/core
  * auto-linkified and fragmented; an <a> would be claimed by BlockNote's
  * built-in link mark). Reconstructed on load by normalizeLinkMentions.
  *
- * The pattern is deliberately wider than the alphabet the serializer emits. A
+ * The payload class admits whitespace, which the previous `[^)\s]+` refused: a
  * token written by an older build can hold a stray space or a remark escape
- * (see `parseLinkMentionToken`), and the previous `[^)\s]+` refused both — the
- * token then never matched and stayed literal `((mention:…))` text for good.
- * Every payload that pattern accepted, this one accepts identically.
+ * (see `parseLinkMentionToken`), and refusing those left the token as literal
+ * `((mention:…))` text for good. It must still stop at `(`, or an unterminated
+ * `((mention:` earlier on the line swallows the next real token whole and turns
+ * a working mention into text. No serializer has ever emitted a raw paren in a
+ * payload, so nothing is lost by excluding it.
  */
-export const MENTION_TOKEN_REGEX = /\(\(mention:([^)\n\r]+)\)\)/g
+export const MENTION_TOKEN_REGEX = /\(\(mention:([^()\n\r]+)\)\)/g
 
 /**
  * `encodeURIComponent` leaves `- _ . ! ~ * ' ( )` raw. `(` and `)` break the
@@ -59,7 +61,10 @@ export function serializeLinkMentionToken(url: string): string {
  */
 const WELL_FORMED_PAYLOAD = /^[^\s\\]+$/
 
-function isAbsoluteUrl(value: string): boolean {
+/** Every alphabet any build of the serializer has emitted, unioned. */
+const ANY_TOKEN_ALPHABET = /^[A-Za-z0-9.%!'*~_-]+$/
+
+function isUrl(value: string): boolean {
   try {
     new URL(value)
     return true
@@ -77,16 +82,18 @@ export function parseLinkMentionToken(encoded: string): string | null {
     }
   }
 
-  // Vaults hold tokens from builds that left `_ * ! ~ '` raw, so remark's
-  // escapes and stray whitespace are already on disk. Neither a backslash nor
-  // whitespace is legal in the token alphabet, so stripping them is an
-  // unambiguous repair rather than a guess; requiring a parseable URL after the
-  // repair stops the widened pattern from claiming ordinary prose.
+  // Vaults hold tokens from builds that left `_ * ! ~ '` raw, so remark escapes
+  // and stray whitespace are already on disk. Neither is legal in any version
+  // of the alphabet, so stripping them is an unambiguous repair rather than a
+  // guess. The pattern above admits whitespace, though, so what is left has to
+  // earn the chip twice over: it must be spellable as a token, and it must
+  // decode to a URL. `((mention: see http://x.com))` fails the first check and
+  // `((mention: see below))` fails the second.
   const repaired = encoded.replace(/[\s\\]/g, '')
-  if (!repaired) return null
+  if (!ANY_TOKEN_ALPHABET.test(repaired)) return null
   try {
     const url = decodeURIComponent(repaired)
-    return isAbsoluteUrl(url) ? url : null
+    return isUrl(url) ? url : null
   } catch {
     return null
   }


### PR DESCRIPTION
Closes #1844

## What changes for the user

A link mention pasted with the **Mention** option now survives closing the tab, switching vaults and restarting the app. Mentions already sitting broken in a vault are repaired the next time the note is opened, without the user doing anything.

## Root cause

Two independent holes, both confirmed by driving the real serializers rather than by reading the code.

**1. The collaborative load path never rebuilt the chip.** Main seeds the shared Y.Doc straight from the vault file (`markdownToYFragment`), where a mention is plain text, and the Yjs branch of `useEditorSync` returns before `normalizeNoteBlocks` ever runs. Wiki links and inline checkboxes each have a promoter on that path; mentions had none. So a mention lived only as long as its Y.Doc, and came back as literal `((mention:…))` after a restart or a vault switch. This is the reported symptom.

Evidence, from a scratch probe against the real main-process converter: seeding `See ((mention:https%3A%2F%2Fx.test%2Ffoo_bar)) here.` and reading the blocks back yields one plain `text` run, no `linkMention` node.

**2. The token alphabet was open, and the damage happens on re-parse, not on write.** `encodeURIComponent` leaves `- _ . ! ~ * ' ( )` raw. The original comment assumed remark-stringify would escape them; measured against both serializers, it does not. The real failure is that remark-*parse* then reinterprets them. Two mentions on one line whose URLs each hold a `*` (or each a `~`) are read as one emphasis or strikethrough run spanning from the first token into the second, and both mentions are destroyed:

```
in : ((mention:https%3A%2F%2Fx.test%2Fa*b)) and ((mention:https%3A%2F%2Fx.test%2Fc*d))
out: no linkMention nodes at all
```

`_`, `!` and `'` survived every shape tried, including punctuation-flanked ones. They are encoded anyway so the alphabet is closed by construction rather than by a bet on remark's flanking rules holding across a dependency bump.

That is the one judgement call here, and it has a cost worth naming. A mention whose URL contains `_ ! '` works today and will have its token rewritten once — a converging, one-time migration, not a loop. Old builds decode `%5F` correctly, so nothing breaks during a staged rollout; a note edited on an old build after that does get its token written back in the raw form until a new build touches it again. Narrowing the set to `*` and `~` — the two with a reproduction behind them — would avoid that churn entirely and still fix the bug. Easy to change if you would rather have it that way.

## The fix

`packages/editor-schema/src/inline/link-mention.ts`

- `serializeLinkMentionToken` percent-encodes `! ' ( ) * ~ _` on top of `encodeURIComponent`, closing the payload to `[A-Za-z0-9.%-]`. `.` and `-` stay raw; both are inert unless they open a line, and a token never does.
- `MENTION_TOKEN_REGEX` widens from `[^)\s]+` to `[^()\n\r]+`, so a stray space no longer kills the match. It still stops at `(`: a note damaged by this bug holds literal `((mention:` fragments, and a class that stops only at `)` runs through the fragment and captures it together with the next real token, turning a working mention into text.
- `parseLinkMentionToken` keeps its original code path verbatim for any payload with no whitespace and no backslash, and adds a repair path for the rest: strip whitespace and backslashes, then require the result to be spellable in the token alphabet *and* to decode to a parseable URL. Both gates are load-bearing — with spaces stripped, `((mention: see http://x.com))` parses as a URL, and `((mention: see below))` is spellable.

`apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts`

- New `promoteLinkMentionsInSharedDoc`, called in the collaborative branch alongside the wiki-link and inline-checkbox promoters.

Favicon hydration is deliberately **not** wired up on that path. `hydrateLinkMentionFavicons` writes back a content array it captured before its fetch, which on a shared document pushes a stale block to every device, and it resolves after `clearYjsUndoHistory` has run, so opening a note would leave an undoable step — the invariant the surrounding code exists to hold. A chip promoted here renders the domain the token carries; hydrating a shared document safely is its own change.

## Compatibility

Backward compatibility is the constraint that shaped the whole change.

- **Byte identity.** A URL containing none of `! ' ( ) * ~ _` serialises to exactly the bytes it does today — asserted on literal strings, not round-trips, in `link-mention.test.ts`. Tokens whose URL contains one of those seven change bytes once, on the next save, which is also what heals them.
- **The regex is a strict superset.** `[^)\n\r]+` accepts everything `[^)\s]+` accepted, with identical captures; both stop at the first `)`. Asserted directly against the old pattern.
- **The strict parse path is untouched.** Any payload without whitespace or a backslash takes the original `decodeURIComponent` path, including legacy tokens that left `_ * ! ~ '` raw. Only payloads the old regex could never match at all reach the repair path, so no existing behaviour changes.
- **The repair cannot invent mentions.** The widened pattern admits whitespace, so the repair path gates on both the token alphabet and URL parseability. `((mention: see the note below))` and `((mention: see http://x.com))` both stay prose.

- **Already-shredded mentions are not recoverable.** When remark reads a `*`-to-`*` run as emphasis it consumes those characters as markup and splits the token across sibling inline nodes; the bytes are gone. The serializer change stops this happening again. The repair path covers the stray-space and stray-escape shapes only.
- **The promoter is idempotent.** A promoted `linkMention` serialises back to the token it was built from, so `((mention:` is gone from the document and a second open writes no CRDT update — asserted by watching the `Y.Doc`'s `update` events across three opens. This keeps "opening a note must not rewrite it" (#1434) true.

## Verification

Failing first, on the current code:

- `link-mention-roundtrip.test.ts` — 4 failed / 16 passed. The two `*` and `~` pair cases and both space-healing cases.
- `link-mention-collab-promotion.test.ts` — 4 failed / 1 passed. Everything that needs the promoter.

Green after:

- `packages/editor-schema` — 167 passed (30 of them new, in `src/inline/link-mention.test.ts`).
- `apps/desktop` renderer `content-area` — 63 files, 811 passed / 6 skipped.
- `apps/desktop` main `src/main/sync` — 166 files, 2606 passed (241 in `blocknote-converter.test.ts`, including the new cross-path agreement block).
- `pnpm lint` — 0 errors (107 pre-existing warnings, none in the touched files).
- `pnpm typecheck:web` / `:node` / `:test` — clean.
- `pnpm docs:impact --base origin/main --strict` — covered. `pnpm docs:build` — clean.

`pnpm typecheck` as a whole fails on `apps/mobile/vitest.config.ts -> node:url` in the architecture boundary check. That is pre-existing on `origin/main` and unrelated to this branch.

New coverage is deliberately targeted, not the conformance suite in #1848: the token's own bytes in `@memry/editor-schema`, the full node → markdown → node round trip through the real renderer serializer, main/renderer agreement on the same URLs, and the CRDT promotion path driven with a real `BlockNoteEditor`, real Yjs and the real `useEditorSync` hook.

## Note for #1845

The date pill has the same shape of problem: `DATE_MENTION_TOKEN_REGEX` is `[A-Za-z0-9_-]+`, and base64url payloads contain `_`. It also has no promoter on the collaborative path, which the existing `wiki-link-collab-promotion.test.ts` asserts as intended behaviour.
