### PR TITLE
fix(scripts): exempt tooling configs from the mobile reachability walk

### DIFF
--- a/scripts/check-architecture-boundaries.js
+++ b/scripts/check-architecture-boundaries.js
@@ -96,6 +96,12 @@ function isTestFile(filePath) {
   return /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(filePath)
 }
 
+// Tooling configs (vitest.config.ts, metro.config.js, ...) run under node by
+// definition; the mobile reachability rule is about the app's RUNTIME graph.
+function isToolingConfigFile(filePath) {
+  return /\.config\.(ts|js|mjs|cjs)$/.test(path.basename(filePath))
+}
+
 function stripSourceExtension(filePath) {
   return filePath.replace(/\.(ts|tsx|js|jsx|mjs|cjs)$/, '')
 }
@@ -391,7 +397,7 @@ async function walkMobileSources(dir) {
     }
 
     const filePath = path.join(dir, entry.name)
-    if (isSourceFile(filePath) && !isTestFile(filePath)) {
+    if (isSourceFile(filePath) && !isTestFile(filePath) && !isToolingConfigFile(filePath)) {
       files.push(filePath)
     }
   }


### PR DESCRIPTION
check:architecture is red on current main:

```
- apps/mobile/vitest.config.ts -> node:url (node builtin reachable from apps/mobile)
```

`pnpm typecheck` runs the check, so every branch cut from main fails it. The mobile reachability rule (spec 001-mobile-app T003) guards the app's runtime import graph; a vitest config runs under node by definition and was only picked up because the walk skips test files but not tool configs. This skips `*.config.{ts,js,mjs,cjs}` in `walkMobileSources`, next to the existing test-file skip.

Verified: `node scripts/check-architecture-boundaries.js` fails on main, passes with this change; no other walk sites touched.