### PR TITLE
test(editor): golden round-trip conformance suite across both serializers

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.roundtrip.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.roundtrip.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Main-pipeline half of the round-trip conformance suite (#1848). The corpus
+ * and the reasoning live in `@memry/editor-schema/conformance`; the renderer
+ * half runs the same corpus in
+ * `src/renderer/src/components/note/content-area/roundtrip-conformance.test.ts`.
+ * Both halves assert the same canonical bytes, so the two serializers agreeing
+ * with the corpus is the same fact as them agreeing with each other.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync } from 'fs'
+import path from 'path'
+import * as Y from 'yjs'
+import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
+import {
+  FUZZ_FAMILIES,
+  ROUNDTRIP_CASES,
+  createSeededRandom
+} from '@memry/editor-schema/conformance'
+import { markdownToYFragment, yDocToMarkdown } from './blocknote-converter'
+import { parseNote } from '../vault/frontmatter'
+
+async function roundTrip(markdown: string): Promise<string> {
+  const doc = new Y.Doc()
+  const ok = await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+  expect(ok, 'markdown reached the shared doc').toBe(true)
+  const out = await yDocToMarkdown(doc)
+  expect(out, 'the doc serialized back at all').not.toBeNull()
+  return out as string
+}
+
+describe('round-trip conformance corpus, main pipeline', () => {
+  const cases = ROUNDTRIP_CASES.map((c) => ({ ...c, pendingIssue: c.pending?.main }))
+
+  it.each(cases.filter((c) => !c.pendingIssue))('$name', async ({ markdown }) => {
+    const once = await roundTrip(markdown)
+    expect(once, 'round-trip is identity').toBe(markdown)
+    expect(await roundTrip(once), 'second round-trip changes nothing').toBe(once)
+  })
+
+  // Broken on current main; fixed by the named sibling of epic #1843. `it.fails`
+  // inverts the expectation, so the sibling landing turns these red and forces
+  // the pending flag off — the case then asserts the fixed behavior forever.
+  it.fails.each(cases.filter((c) => c.pendingIssue))(
+    '$name (pending #$pendingIssue)',
+    async ({ markdown }) => {
+      const once = await roundTrip(markdown)
+      expect(once, 'round-trip is identity').toBe(markdown)
+      expect(await roundTrip(once), 'second round-trip changes nothing').toBe(once)
+    }
+  )
+})
+
+describe('round-trip fuzz, main pipeline', () => {
+  const families = FUZZ_FAMILIES.map((f) => ({ ...f, pendingIssue: f.pending?.main }))
+
+  async function assertFamily(generate: (random: () => number) => string): Promise<void> {
+    const random = createSeededRandom(0x1848)
+    for (let i = 0; i < 48; i++) {
+      const markdown = generate(random)
+      const once = await roundTrip(markdown)
+      expect(once, `round-trip is identity for ${JSON.stringify(markdown)}`).toBe(markdown)
+      expect(
+        await roundTrip(once),
+        `second round-trip changes nothing for ${JSON.stringify(markdown)}`
+      ).toBe(once)
+    }
+  }
+
+  it.each(families.filter((f) => !f.pendingIssue))(
+    '$name stay byte-identical across 48 seeded cases',
+    async ({ generate }) => assertFamily(generate)
+  )
+
+  it.fails.each(families.filter((f) => f.pendingIssue))(
+    '$name stay byte-identical across 48 seeded cases (pending #$pendingIssue)',
+    async ({ generate }) => assertFamily(generate)
+  )
+})
+
+describe('golden vault round-trip fixtures, main pipeline', () => {
+  // The frontmatter-level byte-preservation of these files is asserted in
+  // src/main/vault/byte-preservation.golden.test.ts over the same directory;
+  // this suite additionally pushes their bodies through the CRDT converter.
+  const fixturesDir = path.join(__dirname, '..', 'vault', '__fixtures__', 'golden-vault')
+  const fixtures = readdirSync(fixturesDir).filter((f) => f.startsWith('roundtrip-'))
+
+  it('the token fixtures exist', () => {
+    expect(fixtures.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it.each(fixtures)('%s body survives the converter round-trip byte-identical', async (name) => {
+    const filePath = path.join(fixturesDir, name)
+    const raw = readFileSync(filePath, 'utf-8')
+    const markdown = parseNote(raw, filePath).content.replace(/^\n+/, '').replace(/\n$/, '')
+    const once = await roundTrip(markdown)
+    expect(once, 'round-trip is identity').toBe(markdown)
+    expect(await roundTrip(once), 'second round-trip changes nothing').toBe(once)
+  })
+})

--- a/apps/desktop/src/main/sync/blocknote-converter.roundtrip.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.roundtrip.test.ts
@@ -31,6 +31,7 @@ async function roundTrip(markdown: string): Promise<string> {
 
 describe('round-trip conformance corpus, main pipeline', () => {
   const cases = ROUNDTRIP_CASES.map((c) => ({ ...c, pendingIssue: c.pending?.main }))
+  const pendingCases = cases.filter((c) => c.pendingIssue)
 
   it.each(cases.filter((c) => !c.pendingIssue))('$name', async ({ markdown }) => {
     const once = await roundTrip(markdown)
@@ -41,14 +42,13 @@ describe('round-trip conformance corpus, main pipeline', () => {
   // Broken on current main; fixed by the named sibling of epic #1843. `it.fails`
   // inverts the expectation, so the sibling landing turns these red and forces
   // the pending flag off — the case then asserts the fixed behavior forever.
-  it.fails.each(cases.filter((c) => c.pendingIssue))(
-    '$name (pending #$pendingIssue)',
-    async ({ markdown }) => {
+  if (pendingCases.length > 0) {
+    it.fails.each(pendingCases)('$name (pending #$pendingIssue)', async ({ markdown }) => {
       const once = await roundTrip(markdown)
       expect(once, 'round-trip is identity').toBe(markdown)
       expect(await roundTrip(once), 'second round-trip changes nothing').toBe(once)
-    }
-  )
+    })
+  }
 })
 
 describe('round-trip fuzz, main pipeline', () => {
@@ -67,15 +67,19 @@ describe('round-trip fuzz, main pipeline', () => {
     }
   }
 
+  const pendingFamilies = families.filter((f) => f.pendingIssue)
+
   it.each(families.filter((f) => !f.pendingIssue))(
     '$name stay byte-identical across 48 seeded cases',
     async ({ generate }) => assertFamily(generate)
   )
 
-  it.fails.each(families.filter((f) => f.pendingIssue))(
-    '$name stay byte-identical across 48 seeded cases (pending #$pendingIssue)',
-    async ({ generate }) => assertFamily(generate)
-  )
+  if (pendingFamilies.length > 0) {
+    it.fails.each(pendingFamilies)(
+      '$name stay byte-identical across 48 seeded cases (pending #$pendingIssue)',
+      async ({ generate }) => assertFamily(generate)
+    )
+  }
 })
 
 describe('golden vault round-trip fixtures, main pipeline', () => {

--- a/apps/desktop/src/main/vault/__fixtures__/golden-vault/roundtrip-callouts.md
+++ b/apps/desktop/src/main/vault/__fixtures__/golden-vault/roundtrip-callouts.md
@@ -1,0 +1,21 @@
+---
+title: Callout round-trip corpus
+---
+
+> [!info]
+> Heads up
+
+> [!warning]
+> Careful now
+
+> [!error]
+> Something broke
+
+> [!success]
+> All done
+
+> [!note]
+> A foreign Obsidian type stays byte-identical
+
+> [!tip]
+> So does this one

--- a/apps/desktop/src/main/vault/__fixtures__/golden-vault/roundtrip-containers.md
+++ b/apps/desktop/src/main/vault/__fixtures__/golden-vault/roundtrip-containers.md
@@ -1,0 +1,14 @@
+---
+title: Tokens inside containers round-trip corpus
+---
+
+- ((mention:https%3A%2F%2Fexample.com%2Fa_b_c))
+- ((date:eyJhbmNob3JJZCI6ImExIiwiZGF0ZUlTTyI6IjIwMjYtMDgtMTRUMDk6MDA6MDAuMDAwWiIsImhhc1RpbWUiOnRydWUsImRhdGVGb3JtYXQiOiJyZWxhdGl2ZSIsInJlbWluZCI6Im5vbmUiLCJ0aW1lRm9ybWF0Ijoic3lzdGVtIn0))
+- [[Roadmap|the plan]]
+
+<details data-memry-toggle>
+<summary>Tokens in a toggle body</summary>
+
+((mention:https%3A%2F%2Fexample.com%2Fa_b_c)) and ((date:eyJhbmNob3JJZCI6ImExIiwiZGF0ZUlTTyI6IjIwMjYtMDgtMTRUMDk6MDA6MDAuMDAwWiIsImhhc1RpbWUiOnRydWUsImRhdGVGb3JtYXQiOiJyZWxhdGl2ZSIsInJlbWluZCI6Im5vbmUiLCJ0aW1lRm9ybWF0Ijoic3lzdGVtIn0))
+
+</details>

--- a/apps/desktop/src/main/vault/__fixtures__/golden-vault/roundtrip-inline-tokens.md
+++ b/apps/desktop/src/main/vault/__fixtures__/golden-vault/roundtrip-inline-tokens.md
@@ -1,0 +1,15 @@
+---
+title: Inline token round-trip corpus
+---
+
+Intro ((mention:https%3A%2F%2Fexample.com%2Fa_b_c)) outro.
+
+A parenthesised article ((mention:https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FRust_%28programming_language%29)) survives.
+
+Query strings ((mention:https%3A%2F%2Fexample.com%2F%3Fa%3D1%26b%3D2%26c%3Dx_y)) and spaces ((mention:https%3A%2F%2Fexample.com%2Fa%20b)) too.
+
+Non-ASCII ((mention:https%3A%2F%2Fexample.com%2F%E6%97%A5%E6%9C%AC%E8%AA%9E)) as well.
+
+Before ((date:eyJhbmNob3JJZCI6ImExIiwiZGF0ZUlTTyI6IjIwMjYtMDgtMTRUMDk6MDA6MDAuMDAwWiIsImhhc1RpbWUiOnRydWUsImRhdGVGb3JtYXQiOiJyZWxhdGl2ZSIsInJlbWluZCI6Im5vbmUiLCJ0aW1lRm9ybWF0Ijoic3lzdGVtIn0)) after.
+
+See [[Roadmap]] and [[Roadmap|the plan]] and #tag inline with ((date:eyJhbmNob3JJZCI6ImZpeHR1cmUtYW5jaG9yIiwiZGF0ZUlTTyI6IjIwMjYtMDgtMTRUMDk6MDA6MDAuMDAwWiIsImhhc1RpbWUiOnRydWUsImRhdGVGb3JtYXQiOiJyZWxhdGl2ZSIsInJlbWluZCI6Im5vbmUiLCJ0aW1lRm9ybWF0Ijoic3lzdGVtIn0)).

--- a/apps/desktop/src/main/vault/__fixtures__/golden-vault/roundtrip-toggles.md
+++ b/apps/desktop/src/main/vault/__fixtures__/golden-vault/roundtrip-toggles.md
@@ -1,0 +1,35 @@
+---
+title: Toggle round-trip corpus
+---
+
+<details data-memry-toggle>
+<summary>Empty toggle</summary>
+</details>
+
+<details data-memry-toggle>
+<summary>Toggle with a body</summary>
+
+Body line
+
+</details>
+
+<details data-memry-toggle>
+<summary>Outer</summary>
+
+<details data-memry-toggle>
+<summary>Inner</summary>
+
+Deep body
+
+</details>
+
+</details>
+
+<details data-memry-toggle>
+<summary>Code fence body</summary>
+
+```ts
+const x = 1
+```
+
+</details>

--- a/apps/desktop/src/main/vault/__fixtures__/golden-vault/roundtrip-toggles.md
+++ b/apps/desktop/src/main/vault/__fixtures__/golden-vault/roundtrip-toggles.md
@@ -33,3 +33,10 @@ const x = 1
 ```
 
 </details>
+
+<details data-memry-toggle open>
+<summary>Left expanded</summary>
+
+Visible body
+
+</details>

--- a/apps/desktop/src/renderer/src/components/note/content-area/normalize-note-blocks.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/normalize-note-blocks.ts
@@ -20,6 +20,7 @@ import { normalizeLinkMentions } from './link-mention-utils'
 import { normalizeDateMentions } from './date-mention-utils'
 import { normalizeInlineCheckboxes } from './inline-checkbox-utils'
 import { normalizeTaskBlocks } from './task-block/task-block-utils'
+import { reportUnclaimedTokens } from './unclaimed-token-telemetry'
 
 export function normalizeNoteBlocks(blocks: Block[]): Block[] {
   let normalized = normalizeWikiLinks(blocks).blocks
@@ -31,5 +32,9 @@ export function normalizeNoteBlocks(blocks: Block[]): Block[] {
   // cell whose token is followed by a wiki link or a mention has already had
   // that half promoted, so this only ever looks at the leading text run.
   normalized = normalizeInlineCheckboxes(normalized).blocks
-  return normalizeTaskBlocks(normalized as any[]).blocks as Block[]
+  const result = normalizeTaskBlocks(normalized as any[]).blocks as Block[]
+  // Anything still literal after the chain is a token the note will render
+  // broken. Counted, never surfaced — see unclaimed-token-telemetry.ts (#1848).
+  reportUnclaimedTokens(result)
+  return result
 }

--- a/apps/desktop/src/renderer/src/components/note/content-area/roundtrip-conformance.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/roundtrip-conformance.test.ts
@@ -40,6 +40,7 @@ async function roundTrip(markdown: string): Promise<string> {
 
 describe('round-trip conformance corpus, renderer pipeline', () => {
   const cases = ROUNDTRIP_CASES.map((c) => ({ ...c, pendingIssue: c.pending?.renderer }))
+  const pendingCases = cases.filter((c) => c.pendingIssue)
 
   it.each(cases.filter((c) => !c.pendingIssue))('$name', async ({ markdown }) => {
     const once = await roundTrip(markdown)
@@ -50,14 +51,13 @@ describe('round-trip conformance corpus, renderer pipeline', () => {
   // Broken on current main; fixed by the named sibling of epic #1843. `it.fails`
   // inverts the expectation, so the sibling landing turns these red and forces
   // the pending flag off — the case then asserts the fixed behavior forever.
-  it.fails.each(cases.filter((c) => c.pendingIssue))(
-    '$name (pending #$pendingIssue)',
-    async ({ markdown }) => {
+  if (pendingCases.length > 0) {
+    it.fails.each(pendingCases)('$name (pending #$pendingIssue)', async ({ markdown }) => {
       const once = await roundTrip(markdown)
       expect(once, 'round-trip is identity').toBe(markdown)
       expect(await roundTrip(once), 'second round-trip changes nothing').toBe(once)
-    }
-  )
+    })
+  }
 })
 
 describe('round-trip fuzz, renderer pipeline', () => {
@@ -76,13 +76,17 @@ describe('round-trip fuzz, renderer pipeline', () => {
     }
   }
 
+  const pendingFamilies = families.filter((f) => f.pendingIssue)
+
   it.each(families.filter((f) => !f.pendingIssue))(
     '$name stay byte-identical across 48 seeded cases',
     async ({ generate }) => assertFamily(generate)
   )
 
-  it.fails.each(families.filter((f) => f.pendingIssue))(
-    '$name stay byte-identical across 48 seeded cases (pending #$pendingIssue)',
-    async ({ generate }) => assertFamily(generate)
-  )
+  if (pendingFamilies.length > 0) {
+    it.fails.each(pendingFamilies)(
+      '$name stay byte-identical across 48 seeded cases (pending #$pendingIssue)',
+      async ({ generate }) => assertFamily(generate)
+    )
+  }
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/roundtrip-conformance.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/roundtrip-conformance.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Renderer-pipeline half of the round-trip conformance suite (#1848), against
+ * the REAL editor schema and the real remark serialization — a mocked editor
+ * would pass regardless of what reaches the vault file. The corpus and its
+ * reasoning live in `@memry/editor-schema/conformance`; the main half runs the
+ * same corpus in `src/main/sync/blocknote-converter.roundtrip.test.ts`. Both
+ * halves assert the same canonical bytes, so the two serializers agreeing with
+ * the corpus is the same fact as them agreeing with each other.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { BlockNoteEditor, type Block } from '@blocknote/core'
+import {
+  FUZZ_FAMILIES,
+  ROUNDTRIP_CASES,
+  createSeededRandom
+} from '@memry/editor-schema/conformance'
+
+// The file block's PDF preview pulls pdf.js, which touches `DOMMatrix` at
+// import time and jsdom has none. Nothing else is stubbed.
+vi.mock('react-pdf', () => ({
+  Document: () => null,
+  Page: () => null,
+  pdfjs: { GlobalWorkerOptions: { workerSrc: '' } }
+}))
+
+import { editorSchema } from './editor-schema'
+import { parseMarkdownPreservingBlanks, serializeBlocksPreservingBlanks } from './markdown-utils'
+import { normalizeNoteBlocks } from './normalize-note-blocks'
+
+const editor = BlockNoteEditor.create({ schema: editorSchema, _headless: true } as never)
+
+// The real open→save cycle: parse, promote tokens to inline nodes exactly as
+// every note surface does, serialize back.
+async function roundTrip(markdown: string): Promise<string> {
+  const parsed = await parseMarkdownPreservingBlanks(editor, markdown)
+  const normalized = normalizeNoteBlocks(parsed as Block[])
+  return await serializeBlocksPreservingBlanks(editor, normalized as Block[])
+}
+
+describe('round-trip conformance corpus, renderer pipeline', () => {
+  const cases = ROUNDTRIP_CASES.map((c) => ({ ...c, pendingIssue: c.pending?.renderer }))
+
+  it.each(cases.filter((c) => !c.pendingIssue))('$name', async ({ markdown }) => {
+    const once = await roundTrip(markdown)
+    expect(once, 'round-trip is identity').toBe(markdown)
+    expect(await roundTrip(once), 'second round-trip changes nothing').toBe(once)
+  })
+
+  // Broken on current main; fixed by the named sibling of epic #1843. `it.fails`
+  // inverts the expectation, so the sibling landing turns these red and forces
+  // the pending flag off — the case then asserts the fixed behavior forever.
+  it.fails.each(cases.filter((c) => c.pendingIssue))(
+    '$name (pending #$pendingIssue)',
+    async ({ markdown }) => {
+      const once = await roundTrip(markdown)
+      expect(once, 'round-trip is identity').toBe(markdown)
+      expect(await roundTrip(once), 'second round-trip changes nothing').toBe(once)
+    }
+  )
+})
+
+describe('round-trip fuzz, renderer pipeline', () => {
+  const families = FUZZ_FAMILIES.map((f) => ({ ...f, pendingIssue: f.pending?.renderer }))
+
+  async function assertFamily(generate: (random: () => number) => string): Promise<void> {
+    const random = createSeededRandom(0x1848)
+    for (let i = 0; i < 48; i++) {
+      const markdown = generate(random)
+      const once = await roundTrip(markdown)
+      expect(once, `round-trip is identity for ${JSON.stringify(markdown)}`).toBe(markdown)
+      expect(
+        await roundTrip(once),
+        `second round-trip changes nothing for ${JSON.stringify(markdown)}`
+      ).toBe(once)
+    }
+  }
+
+  it.each(families.filter((f) => !f.pendingIssue))(
+    '$name stay byte-identical across 48 seeded cases',
+    async ({ generate }) => assertFamily(generate)
+  )
+
+  it.fails.each(families.filter((f) => f.pendingIssue))(
+    '$name stay byte-identical across 48 seeded cases (pending #$pendingIssue)',
+    async ({ generate }) => assertFamily(generate)
+  )
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/unclaimed-token-telemetry.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/unclaimed-token-telemetry.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  countUnclaimedTokens,
+  reportUnclaimedTokens,
+  resetUnclaimedTokenTelemetryForTests
+} from './unclaimed-token-telemetry'
+import { trackTelemetry } from '@/lib/telemetry'
+
+vi.mock('@/lib/telemetry', () => ({ trackTelemetry: vi.fn(async () => {}) }))
+
+const track = vi.mocked(trackTelemetry)
+
+function paragraph(text: string): unknown {
+  return { type: 'paragraph', content: [{ type: 'text', text, styles: {} }], children: [] }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  resetUnclaimedTokenTelemetryForTests()
+  track.mockClear()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('countUnclaimedTokens', () => {
+  it('counts literal mention and date tokens left in text runs', () => {
+    const blocks = [
+      paragraph('still literal ((mention:https%3A%2F%2Fx.com )) here'),
+      paragraph('and ((date:broken\\_payload)) plus ((date:another)) here')
+    ]
+
+    expect(countUnclaimedTokens(blocks)).toEqual({ mention: 1, date: 2 })
+  })
+
+  it('counts an orphaned callout marker only at the head of a paragraph', () => {
+    const blocks = [
+      paragraph('[!info]'),
+      paragraph('mid-sentence [!info] is prose, not a lost marker'),
+      { type: 'heading', content: [{ type: 'text', text: '[!info]', styles: {} }], children: [] }
+    ]
+
+    expect(countUnclaimedTokens(blocks)).toEqual({ callout_marker: 1 })
+  })
+
+  it('counts tokens inside table cells and nested children', () => {
+    const blocks = [
+      {
+        type: 'table',
+        content: {
+          type: 'tableContent',
+          rows: [
+            {
+              cells: [
+                {
+                  type: 'tableCell',
+                  content: [{ type: 'text', text: '((mention:x y))', styles: {} }]
+                }
+              ]
+            }
+          ]
+        },
+        children: []
+      },
+      {
+        type: 'bulletListItem',
+        content: [{ type: 'text', text: 'parent', styles: {} }],
+        children: [paragraph('((date:child))')]
+      }
+    ]
+
+    expect(countUnclaimedTokens(blocks)).toEqual({ mention: 1, date: 1 })
+  })
+
+  it('ignores tokens inside code blocks and promoted inline nodes', () => {
+    const blocks = [
+      { type: 'codeBlock', content: [{ type: 'text', text: '((mention:x))', styles: {} }] },
+      {
+        type: 'paragraph',
+        content: [{ type: 'linkMention', props: { url: 'https://x.com' } }],
+        children: []
+      }
+    ]
+
+    expect(countUnclaimedTokens(blocks)).toEqual({})
+  })
+})
+
+describe('reportUnclaimedTokens', () => {
+  it('emits immediately on first sight, once per kind, with the count as a metric', () => {
+    reportUnclaimedTokens([paragraph('((mention:a)) and ((mention:b)) and ((date:c))')])
+
+    expect(track).toHaveBeenCalledTimes(2)
+    expect(track).toHaveBeenCalledWith(
+      'app_error_seen',
+      expect.objectContaining({
+        action: 'editor_unclaimed_token',
+        errorCode: 'unclaimed_mention',
+        result: 'failed',
+        metrics: { itemCount: 2 }
+      })
+    )
+    expect(track).toHaveBeenCalledWith(
+      'app_error_seen',
+      expect.objectContaining({ errorCode: 'unclaimed_date', metrics: { itemCount: 1 } })
+    )
+  })
+
+  it('aggregates a burst into one trailing event per kind instead of spamming', () => {
+    reportUnclaimedTokens([paragraph('((mention:a))')])
+    track.mockClear()
+
+    for (let i = 0; i < 5; i++) {
+      reportUnclaimedTokens([paragraph('((mention:a))')])
+    }
+    expect(track).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(60_000)
+    expect(track).toHaveBeenCalledTimes(1)
+    expect(track).toHaveBeenCalledWith(
+      'app_error_seen',
+      expect.objectContaining({ errorCode: 'unclaimed_mention', metrics: { itemCount: 5 } })
+    )
+  })
+
+  it('emits nothing when every token was claimed', () => {
+    reportUnclaimedTokens([paragraph('a healthy note')])
+
+    expect(track).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/unclaimed-token-telemetry.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/unclaimed-token-telemetry.test.ts
@@ -44,6 +44,15 @@ describe('countUnclaimedTokens', () => {
     expect(countUnclaimedTokens(blocks)).toEqual({ callout_marker: 1 })
   })
 
+  it('counts tokens in string-shaped content, at both the block and the run level', () => {
+    const blocks = [
+      { type: 'paragraph', content: '[!info] plus ((mention:x))', children: [] },
+      { type: 'paragraph', content: ['((date:y))', { type: 'text', text: 'tail', styles: {} }] }
+    ]
+
+    expect(countUnclaimedTokens(blocks)).toEqual({ mention: 1, date: 1, callout_marker: 1 })
+  })
+
   it('counts tokens inside table cells and nested children', () => {
     const blocks = [
       {

--- a/apps/desktop/src/renderer/src/components/note/content-area/unclaimed-token-telemetry.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/unclaimed-token-telemetry.ts
@@ -1,0 +1,163 @@
+/**
+ * Counts persistence tokens that failed to parse back into their blocks — the
+ * silent half of #1848. A mention or date token the normalize chain left as
+ * literal text, or a callout marker that lost its `> ` prefix, used to be
+ * invisible until a user emailed a screenshot; this reports it through the
+ * existing `app_error_seen` channel the day it ships. Metric only: the user
+ * gets no toast, no dialog.
+ *
+ * Emission is throttled per kind — one event per minute, counts aggregated in
+ * between — because the normalize chain runs on every note open and every
+ * remote update, and the main-process telemetry path is itself rate-limited.
+ */
+
+import { trackTelemetry } from '@/lib/telemetry'
+
+export type UnclaimedTokenKind = 'mention' | 'date' | 'callout_marker'
+
+export type UnclaimedTokenCounts = Partial<Record<UnclaimedTokenKind, number>>
+
+const ORPHANED_CALLOUT_MARKER_REGEX = /^\[!\w+\]/
+
+interface InlineNode {
+  type?: string
+  text?: string
+  content?: unknown
+}
+
+function countText(text: string, counts: Required<UnclaimedTokenCounts>): void {
+  counts.mention += text.split('((mention:').length - 1
+  counts.date += text.split('((date:').length - 1
+}
+
+function visitInlineContent(
+  content: unknown,
+  counts: Required<UnclaimedTokenCounts>,
+  isBlockLeadingParagraphRun: boolean
+): void {
+  if (typeof content === 'string') {
+    countText(content, counts)
+    if (isBlockLeadingParagraphRun && ORPHANED_CALLOUT_MARKER_REGEX.test(content)) {
+      counts.callout_marker += 1
+    }
+    return
+  }
+  if (!Array.isArray(content)) return
+
+  content.forEach((item: InlineNode | string, index) => {
+    if (typeof item === 'string') {
+      visitInlineContent(item, counts, isBlockLeadingParagraphRun && index === 0)
+      return
+    }
+    if (item?.type === 'text' && typeof item.text === 'string') {
+      countText(item.text, counts)
+      if (
+        isBlockLeadingParagraphRun &&
+        index === 0 &&
+        ORPHANED_CALLOUT_MARKER_REGEX.test(item.text)
+      ) {
+        counts.callout_marker += 1
+      }
+      return
+    }
+    if (item?.content) visitInlineContent(item.content, counts, false)
+  })
+}
+
+interface WalkableBlock {
+  type?: string
+  content?: unknown
+  children?: unknown
+}
+
+function visitBlocks(
+  blocks: readonly WalkableBlock[],
+  counts: Required<UnclaimedTokenCounts>
+): void {
+  for (const block of blocks) {
+    // A token inside a code block is the author's text, exactly as the
+    // normalize passes treat it.
+    if (block.type === 'codeBlock') continue
+
+    const content = block.content as { type?: string; rows?: Array<{ cells: unknown[] }> } | unknown
+    if (
+      content &&
+      typeof content === 'object' &&
+      !Array.isArray(content) &&
+      (content as { type?: string }).type === 'tableContent'
+    ) {
+      for (const row of (content as { rows?: Array<{ cells: unknown[] }> }).rows ?? []) {
+        for (const cell of row.cells ?? []) {
+          const cellContent =
+            cell && typeof cell === 'object' && 'content' in (cell as object)
+              ? (cell as { content: unknown }).content
+              : cell
+          visitInlineContent(cellContent, counts, false)
+        }
+      }
+    } else {
+      visitInlineContent(content, counts, block.type === 'paragraph')
+    }
+
+    if (Array.isArray(block.children) && block.children.length > 0) {
+      visitBlocks(block.children as WalkableBlock[], counts)
+    }
+  }
+}
+
+export function countUnclaimedTokens(blocks: readonly unknown[]): UnclaimedTokenCounts {
+  const counts: Required<UnclaimedTokenCounts> = { mention: 0, date: 0, callout_marker: 0 }
+  visitBlocks(blocks as WalkableBlock[], counts)
+  const found: UnclaimedTokenCounts = {}
+  for (const kind of ['mention', 'date', 'callout_marker'] as const) {
+    if (counts[kind] > 0) found[kind] = counts[kind]
+  }
+  return found
+}
+
+const FLUSH_INTERVAL_MS = 60_000
+
+const pending = new Map<UnclaimedTokenKind, number>()
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+let lastFlushAt = -Infinity
+
+function flush(): void {
+  flushTimer = null
+  lastFlushAt = Date.now()
+  for (const [kind, count] of pending) {
+    void trackTelemetry('app_error_seen', {
+      surface: 'app',
+      action: 'editor_unclaimed_token',
+      objectType: 'note',
+      source: 'renderer',
+      result: 'failed',
+      errorCode: `unclaimed_${kind}`,
+      metrics: { itemCount: count }
+    })
+  }
+  pending.clear()
+}
+
+export function reportUnclaimedTokens(blocks: readonly unknown[]): void {
+  const counts = countUnclaimedTokens(blocks)
+  const kinds = Object.keys(counts) as UnclaimedTokenKind[]
+  if (kinds.length === 0) return
+
+  for (const kind of kinds) {
+    pending.set(kind, (pending.get(kind) ?? 0) + (counts[kind] ?? 0))
+  }
+
+  const elapsed = Date.now() - lastFlushAt
+  if (elapsed >= FLUSH_INTERVAL_MS) {
+    flush()
+  } else if (!flushTimer) {
+    flushTimer = setTimeout(flush, FLUSH_INTERVAL_MS - elapsed)
+  }
+}
+
+export function resetUnclaimedTokenTelemetryForTests(): void {
+  if (flushTimer) clearTimeout(flushTimer)
+  flushTimer = null
+  lastFlushAt = -Infinity
+  pending.clear()
+}

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -968,6 +968,17 @@ load=… crashes=…]` block appended only when a context was resolved, so every
 - **Vault watcher**: chokidar `onError` can burst per file (a permission-denied subtree), so
   watcher faults are sampled to one `app_error_seen` per minute (`main/vault/watcher.ts`). Every
   error still reaches the local log.
+- **Unclaimed persistence tokens**: a `((mention:…))` / `((date:…))` token the note-open
+  normalize chain left as literal text, or a callout marker orphaned of its `> ` prefix, is a
+  block that will render broken with no error anywhere — the failure mode behind the #1843
+  round-trip epic, previously detectable only by a user emailing a screenshot. The renderer
+  counts them after every normalize pass
+  (`renderer/…/content-area/unclaimed-token-telemetry.ts`) and reports through `app_error_seen`
+  as `action: editor_unclaimed_token` with `errorCode: unclaimed_mention` / `unclaimed_date` /
+  `unclaimed_callout_marker` and the occurrence count in `metrics.itemCount`. First sighting
+  emits immediately; after that, counts aggregate into at most one event per kind per minute,
+  since the chain re-runs on every note open and remote update. Metric only — the user sees no
+  toast or dialog, and no token content ever ships.
 - **User-visible failures that previously left no trail**: a renderer `did-fail-load` (the user is
   staring at a blank window) reports as `DidFailLoad:<chromiumErrorCode>` — the URL never leaves
   the process; a `memry-file:` protocol serve failure (a silently broken image/PDF/video embed)

--- a/packages/editor-schema/package.json
+++ b/packages/editor-schema/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./inline": "./src/inline/index.ts",
     "./blocks": "./src/blocks/index.ts",
+    "./conformance": "./src/conformance.ts",
     "./note-refs": "./src/blocks/rewrite-note-refs.ts",
     "./server": "./src/server.ts"
   },

--- a/packages/editor-schema/src/conformance.ts
+++ b/packages/editor-schema/src/conformance.ts
@@ -55,22 +55,21 @@ function dateMentionData(overrides: Partial<DateMentionData> = {}): DateMentionD
 }
 
 /**
- * An anchor id whose token demonstrably exercises base64url's `_` and `-`
- * runs — the markdown-emphasis characters #1845 is about. Base64 output
- * depends on byte alignment of the whole JSON payload, so the crafted bytes
- * (0xFF runs → `_`, 0xFB 0xEF 0xBE → `-`) are tried at each of the three
- * alignments rather than hardcoded at one; a change to the JSON field order
- * that shifts them all fails loudly instead of silently weakening the corpus.
+ * An anchor id whose bytes (0xFF runs, 0xFB 0xEF 0xBE) forced base64url `__`
+ * and `--` emphasis runs into the token under the pre-#1845 alphabet — the
+ * exact characters remark escaped into unparseable tokens. #1866 closed the
+ * alphabet (the two odd base64 symbols are now `,` and `;`), so the same
+ * hostile bytes must yield a token with no emphasis character at all;
+ * asserted here so a future encoder change that reopens the alphabet fails
+ * the corpus loudly instead of silently reviving the bug.
  */
 function anchorIdWithEmphasisRuns(): string {
-  const underscoreBytes = 'ÿ'.repeat(4)
-  const dashBytes = 'ûï¾'.repeat(3)
-  for (let pad = 0; pad < 3; pad++) {
-    const anchorId = 'x'.repeat(pad) + underscoreBytes + dashBytes
-    const token = serializeDateMentionToken(dateMentionData({ anchorId }))
-    if (token.includes('__') && token.includes('--')) return anchorId
+  const anchorId = 'x' + 'ÿ'.repeat(4) + 'ûï¾'.repeat(3)
+  const token = serializeDateMentionToken(dateMentionData({ anchorId }))
+  if (token.includes('_') || token.includes('-')) {
+    throw new Error('the date token alphabet emits markdown emphasis characters again')
   }
-  throw new Error('no alignment produced both a `__` and a `--` run')
+  return anchorId
 }
 
 const mention = (url: string): string => serializeLinkMentionToken(url)
@@ -93,7 +92,7 @@ const mentionCases: RoundtripCase[] = [
 const dateCases: RoundtripCase[] = [
   { name: 'date pill in body text', markdown: `Before ${date(dateMentionData())} after.` },
   {
-    name: 'date pill with base64url emphasis runs',
+    name: 'date pill whose payload forced emphasis runs pre-#1845',
     markdown: `Before ${date(dateMentionData({ anchorId: anchorIdWithEmphasisRuns() }))} after.`
   },
   {

--- a/packages/editor-schema/src/conformance.ts
+++ b/packages/editor-schema/src/conformance.ts
@@ -1,0 +1,367 @@
+/**
+ * The shared round-trip conformance corpus (#1848).
+ *
+ * One table, asserted against BOTH serializers: the renderer pipeline
+ * (markdown-utils.ts + normalize-note-blocks.ts, in the renderer suite) and the
+ * main/CRDT pipeline (blocknote-converter.ts, in the main suite). Each case's
+ * `markdown` is the canonical on-disk bytes; both suites assert their own
+ * round-trip returns exactly those bytes, which is what makes cross-serializer
+ * agreement a byte-equality fact rather than an assumption — two pipelines that
+ * each reproduce the same constant necessarily agree with each other.
+ *
+ * `pending` marks a case that FAILS against current main because the fix it
+ * asserts ships in a sibling of epic #1843. The suites run those with
+ * `it.fails`, so the moment the sibling lands the inverted expectation turns
+ * red and forces the flag's removal. Remove the flag, never the case.
+ */
+
+import { serializeLinkMentionToken } from './inline/link-mention'
+import { serializeCalloutBlock, serializeToggleBlock } from './blocks/markdown'
+import { serializeDateMentionToken, type DateMentionData } from '@memry/shared/date-mention'
+
+export interface RoundtripCase {
+  name: string
+  /** Canonical on-disk bytes: round-tripping them must be identity. */
+  markdown: string
+  /** Sibling issue that must land before the marked pipeline can pass. */
+  pending?: { renderer?: number; main?: number }
+}
+
+export const MENTION_URLS = [
+  'https://example.com/a_b_c',
+  'https://example.com/a*b*c',
+  'https://example.com/a!b',
+  'https://example.com/~user',
+  "https://example.com/it's",
+  'https://en.wikipedia.org/wiki/Rust_(programming_language)',
+  'https://example.com/100%25',
+  'https://example.com/?a=1&b=2&c=x_y',
+  'https://example.com/page#section',
+  'https://example.com/a b',
+  'https://example.com/日本語/ünïcode',
+  "https://example.com/x_(y)*z!~'&=#%20 end)"
+] as const
+
+export function dateMentionData(overrides: Partial<DateMentionData> = {}): DateMentionData {
+  return {
+    anchorId: 'a1',
+    dateISO: '2026-08-14T09:00:00.000Z',
+    hasTime: true,
+    dateFormat: 'relative',
+    remind: 'none',
+    timeFormat: 'system',
+    ...overrides
+  }
+}
+
+/**
+ * An anchor id whose token demonstrably exercises base64url's `_` and `-`
+ * runs — the markdown-emphasis characters #1845 is about. Base64 output
+ * depends on byte alignment of the whole JSON payload, so the crafted bytes
+ * (0xFF runs → `_`, 0xFB 0xEF 0xBE → `-`) are tried at each of the three
+ * alignments rather than hardcoded at one; a change to the JSON field order
+ * that shifts them all fails loudly instead of silently weakening the corpus.
+ */
+export function anchorIdWithEmphasisRuns(): string {
+  const underscoreBytes = 'ÿ'.repeat(4)
+  const dashBytes = 'ûï¾'.repeat(3)
+  for (let pad = 0; pad < 3; pad++) {
+    const anchorId = 'x'.repeat(pad) + underscoreBytes + dashBytes
+    const token = serializeDateMentionToken(dateMentionData({ anchorId }))
+    if (token.includes('__') && token.includes('--')) return anchorId
+  }
+  throw new Error('no alignment produced both a `__` and a `--` run')
+}
+
+const mention = (url: string): string => serializeLinkMentionToken(url)
+const date = (data: DateMentionData): string => serializeDateMentionToken(data)
+
+const mentionCases: RoundtripCase[] = [
+  ...MENTION_URLS.map((url) => ({
+    name: `link mention url ${url}`,
+    markdown: `Intro ${mention(url)} outro.`
+  })),
+  {
+    // encodeURIComponent leaves `!` and `_` raw, and `_` next to punctuation is
+    // exactly where remark-stringify escapes it into the token.
+    name: 'link mention url with underscore next to punctuation',
+    markdown: `Intro ${mention('https://example.com/!_bang/x.y_~z')} outro.`,
+    pending: { renderer: 1844, main: 1844 }
+  }
+]
+
+const dateCases: RoundtripCase[] = [
+  { name: 'date pill in body text', markdown: `Before ${date(dateMentionData())} after.` },
+  {
+    name: 'date pill with base64url emphasis runs',
+    markdown: `Before ${date(dateMentionData({ anchorId: anchorIdWithEmphasisRuns() }))} after.`
+  },
+  {
+    name: 'date pill with a reminder, whole paragraph',
+    markdown: date(dateMentionData({ remind: '1d', hasTime: false, dateFormat: 'full' }))
+  },
+  {
+    name: 'two date pills in one line',
+    markdown: `${date(dateMentionData())} and ${date(dateMentionData({ anchorId: 'b2' }))}`
+  }
+]
+
+const calloutCases: RoundtripCase[] = [
+  ...(['info', 'warning', 'error', 'success'] as const).map((type) => ({
+    name: `${type} callout`,
+    markdown: serializeCalloutBlock(type, 'Heads up')
+  })),
+  {
+    name: 'callout with a multi-line body',
+    markdown: serializeCalloutBlock('info', 'One\nTwo')
+  },
+  {
+    name: 'foreign > [!note] callout passes through untouched',
+    markdown: '> [!note]\n> An Obsidian note callout',
+    pending: { renderer: 1846 }
+  },
+  {
+    name: 'foreign > [!tip] callout passes through untouched',
+    markdown: '> [!tip]\n> An Obsidian tip callout',
+    pending: { renderer: 1846 }
+  },
+  {
+    name: 'callout with a title after the marker',
+    markdown: '> [!info] Title here\n> Body',
+    pending: { renderer: 1846 }
+  },
+  {
+    name: 'callout with a multi-paragraph body',
+    markdown: '> [!info]\n> One\n>\n> Two',
+    pending: { renderer: 1846, main: 1846 }
+  },
+  {
+    name: 'nested foreign callouts pass through untouched',
+    markdown:
+      '> [!note] Outer callout\n> Outer body text\n>\n> > [!warning] Inner callout\n> > Inner body text',
+    pending: { renderer: 1846, main: 1846 }
+  }
+]
+
+const toggleCases: RoundtripCase[] = [
+  { name: 'empty toggle', markdown: serializeToggleBlock('Summary', '') },
+  { name: 'toggle with a body', markdown: serializeToggleBlock('Summary', 'Body line') },
+  {
+    name: 'nested toggles',
+    markdown: serializeToggleBlock('Outer', serializeToggleBlock('Inner', 'Deep body'))
+  },
+  {
+    name: 'toggle body with blank lines',
+    markdown: serializeToggleBlock('Summary', 'One\n\nTwo')
+  },
+  {
+    name: 'toggle body with a code fence',
+    markdown: serializeToggleBlock('Summary', '```ts\nconst x = 1\n```')
+  },
+  {
+    name: 'toggle body with an image',
+    markdown: serializeToggleBlock(
+      'Summary',
+      '![pic.png](memry-file://local/v/attachments/n/pic.png)'
+    )
+  },
+  {
+    name: 'unterminated toggle stays literal markdown',
+    markdown: '<details data-memry-toggle>\n<summary>Unterminated</summary>\n\nBody',
+    pending: { renderer: 1847, main: 1847 }
+  }
+]
+
+/**
+ * Table bytes are the form the serializers emit — remark pads every cell to the
+ * column width, so the canonical form of a table is the padded one.
+ */
+function tableOf(header: [string, string], row: [string, string]): string {
+  const width = (i: 0 | 1): number => Math.max(header[i].length, row[i].length, 3)
+  const pad = (text: string, i: 0 | 1): string => text.padEnd(width(i))
+  return [
+    `| ${pad(header[0], 0)} | ${pad(header[1], 1)} |`,
+    `| ${'-'.repeat(width(0))} | ${'-'.repeat(width(1))} |`,
+    `| ${pad(row[0], 0)} | ${pad(row[1], 1)} |`
+  ].join('\n')
+}
+
+const containerCases: RoundtripCase[] = [
+  {
+    name: 'mention and date tokens in table cells',
+    markdown: tableOf(['a', 'b'], [mention('https://example.com/plain'), date(dateMentionData())]),
+    pending: { renderer: 1844 }
+  },
+  {
+    // The renderer's rich wikiLink render is what a table cell serializes
+    // through, and it emits display text — the marker never comes back (#1865).
+    name: 'wiki link and hash tag in table cells',
+    markdown: tableOf(['a', 'b'], ['[[Roadmap]]', '#work']),
+    pending: { renderer: 1865 }
+  },
+  {
+    name: 'mention and date tokens in list items',
+    markdown: `- ${mention('https://example.com/plain')}\n- ${date(dateMentionData())}`
+  },
+  {
+    name: 'mention and date tokens in a toggle body',
+    markdown: serializeToggleBlock(
+      'Summary',
+      `${mention('https://example.com/plain')} and ${date(dateMentionData())}`
+    )
+  },
+  {
+    name: 'wiki link, hash tag and mention in a sentence',
+    markdown: `See [[Roadmap]] and #tag and ${mention('https://x.com')} inline.`
+  },
+  {
+    name: 'callout inside a toggle body',
+    markdown: serializeToggleBlock('Summary', serializeCalloutBlock('warning', 'Inside'))
+  }
+]
+
+const blockMarkerCases: RoundtripCase[] = [
+  {
+    name: 'youtube embed marker',
+    markdown: '![embed](https://www.youtube.com/watch?v=dQw4w9WgXcQ)'
+  },
+  { name: 'bookmark marker', markdown: '![bookmark](https://example.com/a)' },
+  {
+    name: 'file marker',
+    markdown:
+      '<!-- file:{"url":"memry-file://local/v/a/x.pdf","name":"x.pdf","size":1234,"mimeType":"application/pdf"} -->'
+  },
+  { name: 'task block line', markdown: '- [ ] a task {task:t1}' }
+]
+
+export const ROUNDTRIP_CASES: readonly RoundtripCase[] = [
+  ...mentionCases,
+  ...dateCases,
+  ...calloutCases,
+  ...toggleCases,
+  ...containerCases,
+  ...blockMarkerCases
+]
+
+// ---------------------------------------------------------------------------
+// Deterministic fuzz layer — no property-testing dependency in the workspace,
+// so a seeded mulberry32 keeps every CI run byte-reproducible.
+// ---------------------------------------------------------------------------
+
+export function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = state
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function pick<T>(random: () => number, values: readonly T[]): T {
+  return values[Math.floor(random() * values.length)]
+}
+
+function stringFrom(random: () => number, alphabet: readonly string[], length: number): string {
+  return Array.from({ length }, () => pick(random, alphabet)).join('')
+}
+
+/** Every character class the issue names as a breaker, plus plain filler. */
+const URL_ALPHABET = [
+  ...'abcz019',
+  '_',
+  '*',
+  '!',
+  '~',
+  "'",
+  '(',
+  ')',
+  '%',
+  '&',
+  '=',
+  '#',
+  ' ',
+  'é',
+  '日'
+] as const
+
+const ANCHOR_ALPHABET = [...'abcz019', '-', '_', '?', '~', '>', '<', '&', 'ÿ', 'û'] as const
+
+/**
+ * Free text remark-stringify reproduces verbatim. Emphasis pairs (`_x_`,
+ * `*x*`), backticks and link brackets are deliberately absent: remark
+ * canonicalizes those in ANY paragraph, callout or not — an app-wide behavior
+ * outside this suite's contract. The token alphabets above are where the
+ * markdown-significant characters belong, because inside a token nothing may
+ * be rewritten, ever.
+ */
+const INERT_TEXT_ALPHABET = [...'abcz019 .,:;?!', 'é', '日'] as const
+
+function inertLine(random: () => number): string {
+  // Runs of spaces collapse in any paragraph — accepted remark behavior, same
+  // rationale as the emphasis exclusions above.
+  return (
+    stringFrom(random, INERT_TEXT_ALPHABET, 1 + Math.floor(random() * 20))
+      .replace(/\s+/g, ' ')
+      .trim() || 'x'
+  )
+}
+
+export function fuzzMentionMarkdown(random: () => number): string {
+  const path = stringFrom(random, URL_ALPHABET, 1 + Math.floor(random() * 24))
+  const url = `https://fuzz.example/${path}`
+  return `Fuzz ${serializeLinkMentionToken(url)} tail.`
+}
+
+export function fuzzDateMarkdown(random: () => number): string {
+  const remindValues = ['none', 'at', '5m', '1h', '1d', '1w'] as const
+  const data = dateMentionData({
+    anchorId: stringFrom(random, ANCHOR_ALPHABET, 1 + Math.floor(random() * 16)),
+    hasTime: random() > 0.5,
+    dateFormat: random() > 0.5 ? 'full' : 'relative',
+    remind: pick(random, remindValues)
+  })
+  return `Fuzz ${serializeDateMentionToken(data)} tail.`
+}
+
+export function fuzzCalloutMarkdown(random: () => number): string {
+  const types = ['info', 'warning', 'error', 'success'] as const
+  const lines = 1 + Math.floor(random() * 3)
+  const body = Array.from({ length: lines }, () => inertLine(random)).join('\n')
+  return serializeCalloutBlock(pick(random, types), body)
+}
+
+export function fuzzToggleMarkdown(random: () => number, depth = 0): string {
+  const roll = random()
+  const body =
+    roll < 0.2
+      ? ''
+      : roll < 0.4
+        ? `${inertLine(random)}\n\n${inertLine(random)}`
+        : roll < 0.6
+          ? `\`\`\`ts\nconst x = ${Math.floor(random() * 100)}\n\`\`\``
+          : roll < 0.8 && depth === 0
+            ? fuzzToggleMarkdown(random, depth + 1)
+            : inertLine(random)
+  return serializeToggleBlock(inertLine(random), body)
+}
+
+export interface FuzzFamily {
+  name: string
+  generate: (random: () => number) => string
+  pending?: { renderer?: number; main?: number }
+}
+
+export const FUZZ_FAMILIES: readonly FuzzFamily[] = [
+  {
+    name: 'link mention urls',
+    generate: fuzzMentionMarkdown,
+    // The alphabet includes `_` next to punctuation, which remark escapes into
+    // the token on current main — the exact class #1844 closes.
+    pending: { renderer: 1844, main: 1844 }
+  },
+  { name: 'date pill payloads', generate: fuzzDateMarkdown },
+  { name: 'callout bodies', generate: fuzzCalloutMarkdown },
+  { name: 'toggle summaries and bodies', generate: (random) => fuzzToggleMarkdown(random) }
+]

--- a/packages/editor-schema/src/conformance.ts
+++ b/packages/editor-schema/src/conformance.ts
@@ -81,11 +81,11 @@ const mentionCases: RoundtripCase[] = [
     markdown: `Intro ${mention(url)} outro.`
   })),
   {
-    // encodeURIComponent leaves `!` and `_` raw, and `_` next to punctuation is
-    // exactly where remark-stringify escapes it into the token.
+    // encodeURIComponent left `!` and `_` raw, and `_` next to punctuation is
+    // exactly where remark-stringify escaped it into the token before #1867
+    // closed the alphabet.
     name: 'link mention url with underscore next to punctuation',
-    markdown: `Intro ${mention('https://example.com/!_bang/x.y_~z')} outro.`,
-    pending: { renderer: 1844, main: 1844 }
+    markdown: `Intro ${mention('https://example.com/!_bang/x.y_~z')} outro.`
   }
 ]
 
@@ -203,9 +203,12 @@ function tableOf(header: [string, string], row: [string, string]): string {
 
 const containerCases: RoundtripCase[] = [
   {
+    // The rich linkMention render is what a renderer-side cell serializes
+    // through, rewriting the token as a markdown link — #1865's class, second
+    // instance (the wiki-link case below is the first).
     name: 'mention and date tokens in table cells',
     markdown: tableOf(['a', 'b'], [mention('https://example.com/plain'), date(dateMentionData())]),
-    pending: { renderer: 1844 }
+    pending: { renderer: 1865 }
   },
   {
     // The renderer's rich wikiLink render is what a table cell serializes
@@ -413,13 +416,7 @@ export interface FuzzFamily {
 }
 
 export const FUZZ_FAMILIES: readonly FuzzFamily[] = [
-  {
-    name: 'link mention urls',
-    generate: fuzzMentionMarkdown,
-    // The alphabet includes `_` next to punctuation, which remark escapes into
-    // the token on current main — the exact class #1844 closes.
-    pending: { renderer: 1844, main: 1844 }
-  },
+  { name: 'link mention urls', generate: fuzzMentionMarkdown },
   { name: 'date pill payloads', generate: fuzzDateMarkdown },
   { name: 'callout bodies', generate: fuzzCalloutMarkdown },
   { name: 'toggle summaries and bodies', generate: (random) => fuzzToggleMarkdown(random) },

--- a/packages/editor-schema/src/conformance.ts
+++ b/packages/editor-schema/src/conformance.ts
@@ -27,7 +27,7 @@ export interface RoundtripCase {
   pending?: { renderer?: number; main?: number }
 }
 
-export const MENTION_URLS = [
+const MENTION_URLS = [
   'https://example.com/a_b_c',
   'https://example.com/a*b*c',
   'https://example.com/a!b',
@@ -42,7 +42,7 @@ export const MENTION_URLS = [
   "https://example.com/x_(y)*z!~'&=#%20 end)"
 ] as const
 
-export function dateMentionData(overrides: Partial<DateMentionData> = {}): DateMentionData {
+function dateMentionData(overrides: Partial<DateMentionData> = {}): DateMentionData {
   return {
     anchorId: 'a1',
     dateISO: '2026-08-14T09:00:00.000Z',
@@ -62,7 +62,7 @@ export function dateMentionData(overrides: Partial<DateMentionData> = {}): DateM
  * alignments rather than hardcoded at one; a change to the JSON field order
  * that shifts them all fails loudly instead of silently weakening the corpus.
  */
-export function anchorIdWithEmphasisRuns(): string {
+function anchorIdWithEmphasisRuns(): string {
   const underscoreBytes = 'ÿ'.repeat(4)
   const dashBytes = 'ûï¾'.repeat(3)
   for (let pad = 0; pad < 3; pad++) {
@@ -308,13 +308,13 @@ function inertLine(random: () => number): string {
   )
 }
 
-export function fuzzMentionMarkdown(random: () => number): string {
+function fuzzMentionMarkdown(random: () => number): string {
   const path = stringFrom(random, URL_ALPHABET, 1 + Math.floor(random() * 24))
   const url = `https://fuzz.example/${path}`
   return `Fuzz ${serializeLinkMentionToken(url)} tail.`
 }
 
-export function fuzzDateMarkdown(random: () => number): string {
+function fuzzDateMarkdown(random: () => number): string {
   const remindValues = ['none', 'at', '5m', '1h', '1d', '1w'] as const
   const data = dateMentionData({
     anchorId: stringFrom(random, ANCHOR_ALPHABET, 1 + Math.floor(random() * 16)),
@@ -325,14 +325,14 @@ export function fuzzDateMarkdown(random: () => number): string {
   return `Fuzz ${serializeDateMentionToken(data)} tail.`
 }
 
-export function fuzzCalloutMarkdown(random: () => number): string {
+function fuzzCalloutMarkdown(random: () => number): string {
   const types = ['info', 'warning', 'error', 'success'] as const
   const lines = 1 + Math.floor(random() * 3)
   const body = Array.from({ length: lines }, () => inertLine(random)).join('\n')
   return serializeCalloutBlock(pick(random, types), body)
 }
 
-export function fuzzToggleMarkdown(random: () => number, depth = 0): string {
+function fuzzToggleMarkdown(random: () => number, depth = 0): string {
   const roll = random()
   const body =
     roll < 0.2

--- a/packages/editor-schema/src/conformance.ts
+++ b/packages/editor-schema/src/conformance.ts
@@ -164,9 +164,19 @@ const toggleCases: RoundtripCase[] = [
     )
   },
   {
+    // splitMarkdownByToggles declines the region, but the leftover raw-HTML
+    // lines then hit BlockNote's parser, which drops them (#1883).
     name: 'unterminated toggle stays literal markdown',
     markdown: '<details data-memry-toggle>\n<summary>Unterminated</summary>\n\nBody',
-    pending: { renderer: 1847, main: 1847 }
+    pending: { renderer: 1883, main: 1883 }
+  },
+  {
+    name: 'expanded toggle keeps its open attribute',
+    markdown: serializeToggleBlock('Summary', 'Body line', null, true)
+  },
+  {
+    name: 'expanded toggle nested in a collapsed one',
+    markdown: serializeToggleBlock('Outer', serializeToggleBlock('Inner', 'Deep body', null, true))
   },
   {
     // splitMarkdownByToggles trims the gap out of its markdown segments before
@@ -349,7 +359,7 @@ function fuzzToggleMarkdown(random: () => number, depth = 0): string {
           : roll < 0.8 && depth === 0
             ? fuzzToggleMarkdown(random, depth + 1)
             : inertLine(random)
-  return serializeToggleBlock(inertLine(random), body)
+  return serializeToggleBlock(inertLine(random), body, null, random() < 0.5)
 }
 
 /**

--- a/packages/editor-schema/src/conformance.ts
+++ b/packages/editor-schema/src/conformance.ts
@@ -169,6 +169,13 @@ const toggleCases: RoundtripCase[] = [
     name: 'unterminated toggle stays literal markdown',
     markdown: '<details data-memry-toggle>\n<summary>Unterminated</summary>\n\nBody',
     pending: { renderer: 1847, main: 1847 }
+  },
+  {
+    // splitMarkdownByToggles trims the gap out of its markdown segments before
+    // the blank-line scanner runs, so the user's spacing collapses on save.
+    name: 'extra blank line next to a toggle survives',
+    markdown: `Before\n\n\n${serializeToggleBlock('Summary', 'Body line')}\n\n\nAfter`,
+    pending: { renderer: 1877, main: 1877 }
   }
 ]
 
@@ -347,6 +354,50 @@ function fuzzToggleMarkdown(random: () => number, depth = 0): string {
   return serializeToggleBlock(inertLine(random), body)
 }
 
+/**
+ * URL characters whose encoded form is markdown-inert on current main, so the
+ * mixed-document family stays green while the mention family above carries the
+ * hostile alphabet (and its pending flag) alone.
+ */
+const SAFE_URL_ALPHABET = [...'abcz019', ' ', '(', ')', 'é', '日'] as const
+
+function safeMentionSentence(random: () => number): string {
+  const path = stringFrom(random, SAFE_URL_ALPHABET, 1 + Math.floor(random() * 12))
+  return `${inertLine(random)} ${serializeLinkMentionToken(`https://fuzz.example/${path}`)} ${inertLine(random)}`
+}
+
+/**
+ * Whole notes mixing every token family with paragraphs, lists and blank-line
+ * gaps — the shape a real vault file has, where a bug in one block's region
+ * scanner shreds its NEIGHBOR (a toggle body swallowing the callout after it,
+ * a gap growing by one line per save).
+ */
+function fuzzMixedDocumentMarkdown(random: () => number): string {
+  let previousWasList = false
+  const nextPart = (): string => {
+    const roll = random()
+    // Two lists across one blank line are ONE list to CommonMark, so the gap
+    // fuses on the way back — accepted canonicalization, not token damage;
+    // the generator never produces the shape.
+    if (roll < 0.15 && !previousWasList) {
+      previousWasList = true
+      return `- ${inertLine(random)}\n- ${inertLine(random)}`
+    }
+    previousWasList = false
+    if (roll < 0.35) return safeMentionSentence(random)
+    if (roll < 0.55)
+      return `${inertLine(random)} ${serializeDateMentionToken(dateMentionData({ anchorId: stringFrom(random, ANCHOR_ALPHABET, 6) }))}`
+    if (roll < 0.7) return fuzzCalloutMarkdown(random)
+    if (roll < 0.85) return fuzzToggleMarkdown(random, 1)
+    return inertLine(random)
+  }
+  const parts = Array.from({ length: 2 + Math.floor(random() * 4) }, nextPart)
+  // A '\n\n\n' join would trip #1877 (gaps adjacent to toggles collapse);
+  // the static corpus case pins that bug, so this family stays green to keep
+  // catching everything else.
+  return parts.join('\n\n')
+}
+
 export interface FuzzFamily {
   name: string
   generate: (random: () => number) => string
@@ -363,5 +414,6 @@ export const FUZZ_FAMILIES: readonly FuzzFamily[] = [
   },
   { name: 'date pill payloads', generate: fuzzDateMarkdown },
   { name: 'callout bodies', generate: fuzzCalloutMarkdown },
-  { name: 'toggle summaries and bodies', generate: (random) => fuzzToggleMarkdown(random) }
+  { name: 'toggle summaries and bodies', generate: (random) => fuzzToggleMarkdown(random) },
+  { name: 'mixed documents', generate: fuzzMixedDocumentMarkdown }
 ]

--- a/packages/editor-schema/src/conformance.ts
+++ b/packages/editor-schema/src/conformance.ts
@@ -116,29 +116,28 @@ const calloutCases: RoundtripCase[] = [
   },
   {
     name: 'foreign > [!note] callout passes through untouched',
-    markdown: '> [!note]\n> An Obsidian note callout',
-    pending: { renderer: 1846 }
+    markdown: '> [!note]\n> An Obsidian note callout'
   },
   {
     name: 'foreign > [!tip] callout passes through untouched',
-    markdown: '> [!tip]\n> An Obsidian tip callout',
-    pending: { renderer: 1846 }
+    markdown: '> [!tip]\n> An Obsidian tip callout'
   },
   {
     name: 'callout with a title after the marker',
-    markdown: '> [!info] Title here\n> Body',
-    pending: { renderer: 1846 }
+    markdown: '> [!info] Title here\n> Body'
   },
   {
+    // #1875 declines blank-`>`-line shapes from the callout claim; the quote
+    // path then collapses the blank line — generic blockquote behavior (#1881).
     name: 'callout with a multi-paragraph body',
     markdown: '> [!info]\n> One\n>\n> Two',
-    pending: { renderer: 1846, main: 1846 }
+    pending: { renderer: 1881, main: 1881 }
   },
   {
     name: 'nested foreign callouts pass through untouched',
     markdown:
       '> [!note] Outer callout\n> Outer body text\n>\n> > [!warning] Inner callout\n> > Inner body text',
-    pending: { renderer: 1846, main: 1846 }
+    pending: { renderer: 1881, main: 1881 }
   }
 ]
 


### PR DESCRIPTION
Closes #1848. Part of epic #1843 — this is the suite that makes the whole token class fail in CI instead of in a user's inbox.

## Shape

One corpus, `@memry/editor-schema/conformance`, asserted byte-for-byte by both pipelines:

- **Renderer half** — `roundtrip-conformance.test.ts` (renderer suite): a REAL `BlockNoteEditor` on the real editor schema, through `parseMarkdownPreservingBlanks` → `normalizeNoteBlocks` → `serializeBlocksPreservingBlanks` — the actual open→save cycle, real remark escaping included. First unmocked renderer round-trip coverage.
- **Main half** — `blocknote-converter.roundtrip.test.ts` (main suite): `markdownToYFragment` → `yDocToMarkdown`, extending the assertions already in `blocknote-converter.test.ts`.

Each case asserts (1) round-trip identity against canonical bytes, (2) second-pass idempotence (write-back never rewrites what it just wrote). Both halves target the SAME canonical bytes, so cross-serializer byte equality is a tested equality, not an assumption.

## Coverage

| Family | Cases |
|---|---|
| Link mention URLs | `_ * ! ~ ' ( ) % & = #`, spaces, non-ASCII, trailing `)`, kitchen-sink, underscore-next-to-punctuation |
| Date pills | body text, crafted base64url `__`/`--` emphasis runs, reminder variants, two-in-a-line |
| Callouts | all four types, multi-line body, foreign `> [!note]`/`> [!tip]` passthrough, title-after-marker, multi-paragraph body, nested foreign |
| Toggles | empty, body, nested, blank lines, code fence, image, unterminated |
| Containers | mention+date in table cells / list items / toggle bodies, wiki link + hash tag in cells and sentences, callout in toggle |
| Block markers | youtube embed, bookmark, file marker, task line |
| Golden vault | four new `roundtrip-*.md` fixtures, byte-gated by the existing frontmatter suite AND pushed through the converter |

## Fuzz

No property-testing dep in the workspace and `pnpm add` is off-limits, so a seeded mulberry32 drives 48 deterministic cases per family (mention URL alphabet, date payload alphabet incl. bytes that force base64url `_`/`-`, callout bodies, structured toggle bodies incl. nesting and fences). Same bytes every CI run. Free-text alphabets exclude emphasis pairs/backticks deliberately: remark canonicalizes those in ANY paragraph — accepted app-wide behavior, not this bug class. Inside a token nothing may be rewritten, so the token alphabets keep every hostile character.

## Expected failures (the two-phase contract)

Cases broken on current main run as `it.fails` tagged with the sibling that fixes them — when that sibling lands, the inverted expectation turns red and forces the flag off, converting the case into a permanent assertion of the fixed behavior:

- **#1844** (link mentions): underscore-next-to-punctuation URL (both pipelines), mention-in-table-cell (renderer — rich `render` rewrites the token as a markdown link), mention URL fuzz family (both).
- **#1846** (callouts): foreign `[!note]`/`[!tip]` rewritten to `[!info]` (renderer), title-after-marker split (renderer), multi-paragraph body collapse (both), nested foreign callouts (both).
- **#1847** (toggles): unterminated `<details data-memry-toggle>` currently DROPS its open/summary lines on both pipelines.
- **#1865** (new, found by this suite): a `[[wiki link]]` in a table cell serializes as bare display text on the renderer path.

#1845 (date pills): every enumerated and fuzzed payload already round-trips on both pipelines — the suite locks that in as plain green assertions.

## Telemetry

`unclaimed-token-telemetry.ts`, wired at the end of `normalizeNoteBlocks` (every note surface runs that chain): counts `((mention:` / `((date:` still literal after promotion and paragraph-leading orphaned `[!type]` markers, skipping code blocks. Reports through the existing `app_error_seen` channel as `action: editor_unclaimed_token`, `errorCode: unclaimed_{mention,date,callout_marker}`, count in `metrics.itemCount`. Leading emit on first sighting, then at most one aggregated event per kind per minute — the chain re-runs per note open/remote update and the main-side error path is itself per-minute throttled, so the counter aggregates instead of spamming. Metric only, no toast. Documented in `architecture/observability.md`.

## CI note

`check:architecture` (inside `pnpm typecheck`) is red on current main for every branch (`apps/mobile/vitest.config.ts -> node:url`); fix is #1868. This branch stays pure of that fix and goes green once #1868 merges and it rebases.

## Verification

- main suite: 48 passed, 5 expected-fail · renderer suite: 38 passed, 10 expected-fail · telemetry: 7 passed
- `pnpm lint` 0 errors; `typecheck:node/web/test` green (new test files compile, exclude backlog untouched); `docs:impact --strict` covered; `docs:build` green; full main project: only the pre-existing `check-cert-hashes-config` local-env failures (identical on untouched main); full renderer project: failures identical to the pre-existing set on main (baseline diff run to confirm).