### PR TITLE
fix(sync): keep callouts intact through the main-path write-back

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -31,6 +31,7 @@ import {
 import { createWikiLinkInlineContent, wikiLinkToText } from '@memry/editor-schema/inline'
 import { createServerBlockSpecs, createServerInlineSpecs } from '@memry/editor-schema/server'
 import { serializeDateMentionToken } from '@memry/shared/date-mention'
+import { serializeBlockColorsMarker } from '@memry/shared/block-colors'
 import { fileBlockCommentData, parseFileBlockMarker } from '@memry/editor-schema/blocks'
 
 describe('blocknote-converter code block language', () => {
@@ -1644,9 +1645,9 @@ describe('registering the custom specs does not rewrite existing markdown', () =
     '- [ ] a task {task:t1}',
     '```ts\nconst x = "[[Roadmap]]"\n```',
     '((date:eyJhbmNob3JJZCI6ImExIn0)) leftover token.',
-    // Callouts stay quote blocks on this path: their marker line carries a type
-    // and an optional title the callout schema cannot hold, so parsing them
-    // would rewrite `> [!note]` as `> [!info]` in every Obsidian vault.
+    // A Memry-shaped callout is claimed as a callout block now, under a
+    // byte-round-trip guard; foreign types and titled markers stay quote
+    // blocks. Either way the bytes must not move (#1846).
     '> [!info]\n> Heads up',
     '> [!note]\n> An Obsidian type this schema has no value for',
     '> [!info] A title on the marker line\n> and a body',
@@ -3033,5 +3034,140 @@ describe('a date pill keeps its exact bytes on the main path', () => {
 
     expect(escaped).toContain('\\')
     expect(await roundTrip(`due ${escaped} ok`)).toBe(`due ((date:${payload})) ok`)
+  })
+})
+
+describe('callouts on the CRDT path (#1846)', () => {
+  // Main used to leave every callout a quote block, so seeding a doc from the
+  // vault file demoted `> [!info]` on reopen and the callout UI never came
+  // back. Now main claims exactly the bytes Memry's own serializer writes —
+  // proven per note by re-serializing the body — and declines everything else,
+  // which is what keeps a foreign `> [!note]` byte-identical.
+  it.each(['info', 'warning', 'error', 'success'] as const)(
+    '`> [!%s]` with a multi-line body claims as a callout and writes identical bytes',
+    async (type) => {
+      // #given the bytes serializeCalloutBlock writes for this type
+      const markdown = serializeCalloutBlock(type, 'line one\nline two')
+      const doc = new Y.Doc()
+      await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+      // #when / #then the doc holds a real callout block again…
+      const blocks = await yFragmentToBlocks(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+      expect(blocks?.[0]?.type).toBe('callout')
+      expect((blocks?.[0]?.props as { type: string }).type).toBe(type)
+      // …and write-back reproduces the file byte-for-byte
+      expect(await yDocToMarkdown(doc)).toBe(markdown)
+    }
+  )
+
+  it('an empty callout claims and round-trips', async () => {
+    const markdown = serializeCalloutBlock('info', '')
+    const doc = new Y.Doc()
+    await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+    const blocks = await yFragmentToBlocks(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(blocks?.[0]?.type).toBe('callout')
+    expect(await yDocToMarkdown(doc)).toBe(markdown)
+  })
+
+  it.each([
+    ['a foreign Obsidian type', '> [!note]\n> body text'],
+    ['another foreign type', '> [!tip]\n> body text'],
+    ['a title after the marker', '> [!info] A title\n> body text']
+  ])('%s stays a quote block and stays byte-identical', async (_name, markdown) => {
+    // #given bytes Memry never writes — an Obsidian vault's, typically
+    const doc = new Y.Doc()
+    await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+    // #when / #then not claimed, not rewritten
+    const blocks = await yFragmentToBlocks(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(blocks?.[0]?.type).toBe('quote')
+    expect(await yDocToMarkdown(doc)).toBe(markdown)
+  })
+
+  it.each([
+    ['a blank `>` line in the body', '> [!info]\n> line one\n>\n> line two'],
+    ['a list in the body', '> [!info]\n> - item one\n> - item two']
+  ])('%s declines the claim and stays a quote block', async (_name, markdown) => {
+    // serializeCalloutBlock never writes these shapes, so claiming them could
+    // not reproduce the bytes; they stay on the quote path exactly as before
+    // this feature. (That path's own normalization of these shapes predates
+    // #1846 and is the conformance suite’s to pin down.)
+    const doc = new Y.Doc()
+    await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+    const blocks = await yFragmentToBlocks(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(blocks?.some((b) => (b.type as string) === 'callout')).toBe(false)
+  })
+
+  it('a colored callout keeps its colors marker through the round trip', async () => {
+    const markdown = `${serializeBlockColorsMarker({
+      textColor: 'red',
+      backgroundColor: 'default'
+    } as never)}\n${serializeCalloutBlock('info', 'colored body')}`
+    const doc = new Y.Doc()
+    await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+    const blocks = await yFragmentToBlocks(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(blocks?.[0]?.type).toBe('callout')
+    expect((blocks?.[0]?.props as { textColor: string }).textColor).toBe('red')
+    expect(await yDocToMarkdown(doc)).toBe(markdown)
+  })
+
+  it('a callout marker inside a code fence is the author’s text', async () => {
+    const markdown = '```md\n> [!info]\n> not a callout\n```'
+    const doc = new Y.Doc()
+    await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+    const blocks = await yFragmentToBlocks(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(blocks?.some((b) => (b.type as string) === 'callout')).toBe(false)
+    expect(await yDocToMarkdown(doc)).toBe(markdown)
+  })
+})
+
+describe('healing callouts already torn bare (#1846)', () => {
+  // The damage this heals: a write path once tore `> [!info]` away from its
+  // `> `-quoted body, leaving the marker as a bare line above plain text. Only
+  // the unambiguous shape heals — marker at a paragraph start, body directly
+  // below. A lone marker, a marker mid-paragraph, or a body the callout schema
+  // could not reproduce stays exactly as the author’s bytes.
+  it('heals a bare marker with its body directly below', async () => {
+    const damaged = '[!info]\nHer text line\nand a second line'
+    const doc = new Y.Doc()
+    await markdownToYFragment(damaged, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+    const blocks = await yFragmentToBlocks(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(blocks?.[0]?.type).toBe('callout')
+    expect(await yDocToMarkdown(doc)).toBe(
+      serializeCalloutBlock('info', 'Her text line\nand a second line')
+    )
+  })
+
+  it.each([
+    ['a lone bare marker', '[!info]'],
+    ['a bare marker with a blank line before its text', '[!info]\n\na separate paragraph'],
+    ['a bare marker mid-paragraph', 'some text\n[!info]\nmore text'],
+    ['a foreign bare marker', '[!note]\nbody text']
+  ])('%s stays byte-identical', async (_name, markdown) => {
+    const doc = new Y.Doc()
+    await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+    const blocks = await yFragmentToBlocks(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(blocks?.some((b) => (b.type as string) === 'callout')).toBe(false)
+    expect(await yDocToMarkdown(doc)).toBe(markdown)
+  })
+
+  it.each([
+    // Byte identity is not asserted for these two: the paragraph/list gap and
+    // the fence-language default are normalizations that predate #1846 and
+    // apply to these shapes with or without the marker line.
+    ['a bare marker whose body is a list', '[!info]\n- item one\n- item two'],
+    ['a bare marker inside a code fence', '```\n[!info]\nsnippet text\n```']
+  ])('%s does not heal into a callout', async (_name, markdown) => {
+    const doc = new Y.Doc()
+    await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+
+    const blocks = await yFragmentToBlocks(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+    expect(blocks?.some((b) => (b.type as string) === 'callout')).toBe(false)
   })
 })

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -6,6 +6,8 @@ import {
   EMBED_LINE_REGEX,
   FILE_BLOCK_LINE_REGEX,
   parseFileBlockMarker,
+  readCalloutRun,
+  resolveCalloutRun,
   serializeToggleBlock,
   splitMarkdownByToggles,
   type ToggleBlockSegment
@@ -531,11 +533,39 @@ async function parseContentWithColorMarkers(
   }
 
   const fence = createFenceTracker()
+  const lines = text.split('\n')
 
-  for (const line of text.split('\n')) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
     const trimmed = line.trim()
     // A marker inside a code fence is the author's text, not a marker.
     const insideFence = fence.consume(line)
+
+    // Callouts are claimed here ONLY in the exact shapes this feature owns —
+    // see parseCalloutRunAt. Everything else `> `-prefixed stays a quote block
+    // and its bytes stay untouched, which is what keeps `> [!note]` in an
+    // Obsidian vault byte-identical through Memry.
+    if (!insideFence) {
+      // A colors marker sits directly above the block it colors, so a claim
+      // right after one is still a paragraph start.
+      const atParagraphStart =
+        i === 0 ||
+        lines[i - 1].trim() === '' ||
+        (buffer.length === 0 && (pendingColors !== null || pendingTableColors !== null))
+      const claimed = await parseCalloutRunAt(editor, lines, i, atParagraphStart)
+      if (claimed) {
+        await flushBuffer()
+        const props = { type: claimed.type, ...(pendingColors ?? {}) }
+        pendingColors = null
+        pendingTableColors = null
+        blocks.push({ type: 'callout', props, content: claimed.content } as unknown as Block)
+        for (let consumed = i + 1; consumed < claimed.end; consumed++) {
+          fence.consume(lines[consumed])
+        }
+        i = claimed.end - 1
+        continue
+      }
+    }
 
     // Deliberately NOT fence-guarded: this branch predates custom-block parsing
     // and guarding it would drop a colour marker that follows a fence this
@@ -579,6 +609,42 @@ async function parseContentWithColorMarkers(
 }
 
 /**
+ * Claim a callout at `lines[i]`, or null to leave the bytes alone.
+ *
+ * The claim is proven, not pattern-matched: `resolveCalloutRun` re-serializes
+ * the body and claims only when `serializeCalloutBlock` would write the run
+ * back byte-for-byte. `> [!note]`, `> [!tip]`, a title after the marker, a
+ * blank `>` line, a list in the body — all decline and stay quote blocks with
+ * their bytes untouched, which is the Obsidian-vault guarantee the old
+ * "never parse callouts" rule existed to protect (#1846). What that rule cost
+ * was every Memry callout on this path: seeding a doc from the vault file
+ * demoted `> [!info]` to a quote block, the editor lost the callout UI, and
+ * the marker eventually tore away from its body as plain text.
+ *
+ * The bare `[!info]`-plus-body shape is the already-torn form of that damage;
+ * `readCalloutRun` heals it only at a paragraph start with the body directly
+ * below, so a lone `[!info]` someone typed as text stays text.
+ */
+async function parseCalloutRunAt(
+  editor: ServerBlockNoteEditor,
+  lines: readonly string[],
+  i: number,
+  atParagraphStart: boolean
+): Promise<{ type: string; content: unknown; end: number } | null> {
+  const run = readCalloutRun(lines, i, atParagraphStart)
+  if (!run) return null
+
+  const claimed = await resolveCalloutRun(
+    run,
+    async (md) => (await editor.tryParseMarkdownToBlocks(md)) as never[],
+    async (block) => serializeBlocks(editor, [block as PartialBlock])
+  )
+  if (!claimed) return null
+
+  return { type: claimed.type, content: claimed.content, end: run.end }
+}
+
+/**
  * The three custom blocks whose on-disk form is a single marker line.
  *
  * Without this, the main process — which is what seeds a note's shared Y.Doc
@@ -591,12 +657,9 @@ async function parseContentWithColorMarkers(
  * markdown-utils.ts); it only ever runs on the non-collaborative path, so this
  * is the same rule applied where the collaborative path actually parses.
  *
- * Callouts deliberately have no case here. Their marker line carries a type and
- * an optional title that this schema cannot hold — `> [!note]` and `> [!tip]`
- * are not among the four values `calloutConfig` allows, and a title after the
- * marker moves onto its own line on the way back out. Parsing them would
- * rewrite `> [!note]` as `> [!info]` in every Obsidian vault; left alone they
- * stay quote blocks and their bytes stay untouched.
+ * Callouts have no case here because their form spans lines; they are claimed
+ * by `parseCalloutRunAt` in the caller's line loop, under the byte-round-trip
+ * guard documented there.
  */
 function parseCustomBlockMarkerLine(line: string): Block | null {
   // Matched exactly the way the renderer matches (markdown-utils.ts): `file` on

--- a/apps/desktop/src/renderer/src/components/note/content-area/callout-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/callout-block.tsx
@@ -1,5 +1,6 @@
 import { createReactBlockSpec } from '@blocknote/react'
-import { calloutConfig, CALLOUT_LINE_REGEX } from '@memry/editor-schema/blocks'
+import { calloutConfig, readCalloutRun, type CalloutRun } from '@memry/editor-schema/blocks'
+import { createFenceTracker } from '@memry/shared/markdown-fences'
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -176,21 +177,22 @@ export function getCalloutSlashMenuItem(
 // Callout Block Serialization (> [!type]\n> content)
 // ============================================================================
 
-// The `> [!type]` form lives in @memry/editor-schema/blocks so the main process
-// writes the same bytes. The splitter below stays here: it is the editor's
-// lenient reader (an unknown type falls back to `info`, a title on the marker
-// line moves into the body), which is fine for a paste but would rewrite every
-// `> [!note]` in an Obsidian vault if the CRDT parser used it.
+// The `> [!type]` form AND the claim rules live in @memry/editor-schema/blocks
+// so both processes read and write the same bytes. The reader is strict on
+// purpose: only the exact shape `serializeCalloutBlock` writes (plus the bare
+// damaged shape #1846 heals) is claimed — `> [!note]` and a title after the
+// marker are someone else's bytes and stay quote blocks, on this path exactly
+// as on the CRDT one.
 export { serializeCalloutBlock } from '@memry/editor-schema/blocks'
 
-export type CalloutSegment = { kind: 'callout'; type: CalloutTypeValue; content: string }
+export type CalloutSegment = { kind: 'callout'; run: CalloutRun }
 export type MarkdownSegment = { kind: 'markdown'; text: string }
 export type ContentSegment = CalloutSegment | MarkdownSegment
 
 export function splitMarkdownByCallouts(markdown: string): ContentSegment[] {
-  const validTypes: readonly string[] = CALLOUT_TYPES.map((t) => t.value)
   const lines = markdown.split('\n')
   const segments: ContentSegment[] = []
+  const fence = createFenceTracker()
 
   let mdLines: string[] = []
   let i = 0
@@ -202,28 +204,17 @@ export function splitMarkdownByCallouts(markdown: string): ContentSegment[] {
   }
 
   while (i < lines.length) {
-    const match = lines[i].match(CALLOUT_LINE_REGEX)
-    if (match) {
+    const insideFence = fence.consume(lines[i])
+    const atParagraphStart = i === 0 || lines[i - 1].trim() === ''
+    const run = insideFence ? null : readCalloutRun(lines, i, atParagraphStart)
+
+    if (run) {
       flushMarkdown()
-
-      const rawType = match[1]
-      const type = validTypes.includes(rawType) ? (rawType as CalloutTypeValue) : 'info'
-      const contentLines: string[] = []
-
-      const titleText = match[2].trim()
-      if (titleText) contentLines.push(titleText)
-
-      i++
-      while (i < lines.length && (lines[i].startsWith('> ') || lines[i] === '>')) {
-        if (lines[i] === '>') {
-          contentLines.push('')
-        } else {
-          contentLines.push(lines[i].slice(2))
-        }
-        i++
+      segments.push({ kind: 'callout', run })
+      for (let consumed = i + 1; consumed < run.end; consumed++) {
+        fence.consume(lines[consumed])
       }
-
-      segments.push({ kind: 'callout', type, content: contentLines.join('\n').trim() })
+      i = run.end
     } else {
       mdLines.push(lines[i])
       i++

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
@@ -60,7 +60,10 @@ describe('parseMarkdownPreservingBlanks', () => {
           content: [{ type: 'text', text: markdown, styles: {} }],
           children: []
         }
-      ])
+      ]),
+      blocksToMarkdownLossy: vi.fn(async (blocks: any[]) =>
+        blocks.map((block) => block.content?.[0]?.text ?? '').join('\n')
+      )
     }
 
     const blocks = await parseMarkdownPreservingBlanks(
@@ -70,7 +73,7 @@ describe('parseMarkdownPreservingBlanks', () => {
         '![embed](https://www.youtube.com/watch?v=dQw4w9WgXcQ)',
         '![embed](https://example.com/not-youtube)',
         '',
-        '> [!warning] Heads up',
+        '> [!warning]',
         '> Body line'
       ].join('\n')
     )
@@ -87,12 +90,66 @@ describe('parseMarkdownPreservingBlanks', () => {
         expect.objectContaining({
           type: 'callout',
           props: { type: 'warning' },
-          content: [{ type: 'text', text: 'Heads up\nBody line', styles: {} }]
+          content: [{ type: 'text', text: 'Body line', styles: {} }]
         })
       ])
     )
     expect(editor.tryParseMarkdownToBlocks).toHaveBeenCalledWith(
       expect.stringContaining('https://example.com/not-youtube')
+    )
+  })
+
+  it('leaves foreign and titled callout markers as markdown instead of claiming them', async () => {
+    // `> [!note]` and `> [!warning] A title` are bytes Memry never writes —
+    // claiming them would rewrite an Obsidian vault on the next save (#1846).
+    const editor = {
+      tryParseMarkdownToBlocks: vi.fn(async (markdown: string) => [
+        {
+          type: 'paragraph',
+          props: {},
+          content: [{ type: 'text', text: markdown, styles: {} }],
+          children: []
+        }
+      ]),
+      blocksToMarkdownLossy: vi.fn(async (blocks: any[]) =>
+        blocks.map((block) => block.content?.[0]?.text ?? '').join('\n')
+      )
+    }
+
+    const blocks = await parseMarkdownPreservingBlanks(
+      editor,
+      ['> [!note]\n> An Obsidian type', '', '> [!warning] A title\n> and a body'].join('\n')
+    )
+
+    expect(blocks.some((b) => (b.type as string) === 'callout')).toBe(false)
+    expect(editor.tryParseMarkdownToBlocks).toHaveBeenCalledWith(expect.stringContaining('[!note]'))
+  })
+
+  it('heals a bare callout marker whose body sits directly below (#1846)', async () => {
+    const editor = {
+      tryParseMarkdownToBlocks: vi.fn(async (markdown: string) => [
+        {
+          type: 'paragraph',
+          props: {},
+          content: [{ type: 'text', text: markdown, styles: {} }],
+          children: []
+        }
+      ]),
+      blocksToMarkdownLossy: vi.fn(async (blocks: any[]) =>
+        blocks.map((block) => block.content?.[0]?.text ?? '').join('\n')
+      )
+    }
+
+    const blocks = await parseMarkdownPreservingBlanks(editor, '[!info]\nHer text line')
+
+    expect(blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'callout',
+          props: { type: 'info' },
+          content: [{ type: 'text', text: 'Her text line', styles: {} }]
+        })
+      ])
     )
   })
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
@@ -36,6 +36,7 @@ import {
 } from '@memry/shared/block-nesting'
 import { splitMarkdownByCallouts, serializeCalloutBlock } from './callout-block'
 import {
+  resolveCalloutRun,
   serializeToggleBlock,
   splitMarkdownByToggles,
   type ToggleBlockSegment
@@ -291,60 +292,73 @@ async function parseMarkdownWithoutToggles(editor: any, markdown: string): Promi
 
   for (const cseg of calloutSegments) {
     if (cseg.kind === 'callout') {
-      const parsed = await editor.tryParseMarkdownToBlocks(cseg.content)
-      const inlineContent = parsed[0]?.content ?? cseg.content
-      blocks.push({
-        type: 'callout' as const,
-        props: { type: cseg.type },
-        content: inlineContent
-      } as unknown as Block)
-    } else {
-      const blankSegments = splitMarkdownPreservingBlanks(separateBlockImages(cseg.text))
-      for (const seg of blankSegments) {
-        if (seg.type === 'content') {
-          const embedParts = splitByEmbedMarkers(seg.text)
-          for (const part of embedParts) {
-            if (part.kind === 'embed') {
-              blocks.push({
-                type: 'youtubeEmbed' as const,
-                props: { videoId: part.videoId, videoUrl: part.url }
-              } as unknown as Block)
-            } else if (part.kind === 'bookmark') {
-              blocks.push({
-                type: 'bookmark' as const,
-                props: { url: part.url, domain: extractDomain(part.url) }
-              } as unknown as Block)
-            } else if (part.kind === 'file') {
-              blocks.push({
-                type: 'file' as const,
-                props: part.props
-              } as unknown as Block)
-            } else {
-              const parsed = await parseMarkdownChunkPreservingNesting(editor, part.text)
-              if (part.colors && parsed[0]) {
-                parsed[0].props = { ...parsed[0].props, ...part.colors }
-              }
-              if (part.tableColors && parsed[0]) {
-                applyTableCellColors(parsed[0].content, part.tableColors)
-              }
-              blocks.push(...parsed)
-            }
-          }
-        } else {
-          for (let i = 0; i < seg.extraLines; i++) {
-            blocks.push({
-              type: 'paragraph',
-              content: [],
-              children: [],
-              props: {}
-            } as unknown as Block)
-          }
-        }
+      const claimed = await resolveCalloutRun(
+        cseg.run,
+        async (md) => editor.tryParseMarkdownToBlocks(md),
+        async (block) => serializeBlocks(editor, [block as Block])
+      )
+      if (claimed) {
+        blocks.push({
+          type: 'callout' as const,
+          props: { type: claimed.type },
+          content: claimed.content
+        } as unknown as Block)
+      } else {
+        // A run the byte-round-trip guard declines is not ours to reshape:
+        // parse its original lines exactly as any other markdown.
+        await parseMarkdownSegmentText(editor, cseg.run.raw, blocks)
       }
+    } else {
+      await parseMarkdownSegmentText(editor, cseg.text, blocks)
     }
   }
 
   return blocks
+}
+
+async function parseMarkdownSegmentText(editor: any, text: string, blocks: Block[]): Promise<void> {
+  const blankSegments = splitMarkdownPreservingBlanks(separateBlockImages(text))
+  for (const seg of blankSegments) {
+    if (seg.type === 'content') {
+      const embedParts = splitByEmbedMarkers(seg.text)
+      for (const part of embedParts) {
+        if (part.kind === 'embed') {
+          blocks.push({
+            type: 'youtubeEmbed' as const,
+            props: { videoId: part.videoId, videoUrl: part.url }
+          } as unknown as Block)
+        } else if (part.kind === 'bookmark') {
+          blocks.push({
+            type: 'bookmark' as const,
+            props: { url: part.url, domain: extractDomain(part.url) }
+          } as unknown as Block)
+        } else if (part.kind === 'file') {
+          blocks.push({
+            type: 'file' as const,
+            props: part.props
+          } as unknown as Block)
+        } else {
+          const parsed = await parseMarkdownChunkPreservingNesting(editor, part.text)
+          if (part.colors && parsed[0]) {
+            parsed[0].props = { ...parsed[0].props, ...part.colors }
+          }
+          if (part.tableColors && parsed[0]) {
+            applyTableCellColors(parsed[0].content, part.tableColors)
+          }
+          blocks.push(...parsed)
+        }
+      }
+    } else {
+      for (let i = 0; i < seg.extraLines; i++) {
+        blocks.push({
+          type: 'paragraph',
+          content: [],
+          children: [],
+          props: {}
+        } as unknown as Block)
+      }
+    }
+  }
 }
 
 export async function serializeBlocksPreservingBlanks(

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -1277,11 +1277,18 @@ recognised there, using the same rules the renderer uses on its own save path. M
 inside a code fence are the author's text and stay text; the fence tracker follows
 CommonMark, so a longer fence quoting a shorter one is not mistaken for a closing one.
 
-Callouts are deliberately **not** parsed back. Their marker carries a type and an optional
-title that the block config cannot hold, and the renderer's parser coerces any unrecognised
-type to `info`. Parsing them on this path would rewrite `> [!note]` as `> [!info]` in every
-Obsidian-authored vault, so a callout read from a file stays a quote block and its bytes stay
-untouched. A callout created in the editor round-trips through the live document normally.
+Callouts are parsed back **only in the exact shape Memry itself writes**: a marker that is
+one of the four supported types with nothing after the `]`, followed by one `> ` per body
+line. The claim is proven per note — the body is re-serialized and must reproduce the file
+byte-for-byte, or the run is declined. Everything else — `> [!note]`, `> [!tip]`, a title
+after the marker, a blank `>` line, a list in the body — stays a quote block and its bytes
+stay untouched, which is what keeps an Obsidian-authored vault byte-identical through Memry.
+Both processes share the claim rules (`readCalloutRun` / `resolveCalloutRun` in
+`@memry/editor-schema/blocks`), so a callout survives create → sync → main-process
+write-back → reopen on the collaborative and non-collaborative paths alike. A note already
+damaged into a bare `[!info]` line with its body directly below heals into a callout on
+parse; a lone marker, a marker mid-paragraph, or a body the schema could not reproduce stays
+the author's text.
 
 ## Files Worth Knowing
 

--- a/packages/editor-schema/src/blocks/markdown.ts
+++ b/packages/editor-schema/src/blocks/markdown.ts
@@ -27,14 +27,129 @@ export const CALLOUT_TYPE_VALUES = ['info', 'warning', 'error', 'success'] as co
 
 export type CalloutTypeValue = (typeof CALLOUT_TYPE_VALUES)[number]
 
-/** Matches a callout's opening line: `> [!type]`, with any trailing title text. */
-export const CALLOUT_LINE_REGEX = /^> \[!(\w+)\](.*)/
+/**
+ * Exactly the marker `serializeCalloutBlock` writes: one of the four Memry
+ * types, nothing after the `]`. `> [!note]` and `> [!info] A title` are NOT
+ * this — those are someone else's bytes (Obsidian's, usually) and claiming
+ * them would rewrite a file Memry never wrote.
+ */
+const MEMRY_CALLOUT_MARKER_REGEX = /^> \[!(info|warning|error|success)\]$/
+
+/**
+ * The damaged form #1846 heals: the marker alone on its line, its `> ` prefix
+ * already lost. Healed only at a paragraph start with the body directly below
+ * — a lone `[!info]` with nothing under it stays the author's text.
+ */
+const BARE_CALLOUT_MARKER_REGEX = /^\[!(info|warning|error|success)\]$/
 
 export function serializeCalloutBlock(type: string, contentMarkdown: string): string {
   const lines = contentMarkdown.split('\n').filter((l) => l.length > 0)
   if (lines.length === 0) return `> [!${type}]`
   const quoted = lines.map((line) => `> ${line}`).join('\n')
   return `> [!${type}]\n${quoted}`
+}
+
+export interface CalloutRun {
+  type: CalloutTypeValue
+  /** Body lines with the `> ` prefix stripped; verbatim for a bare run. */
+  contentLines: string[]
+  /** The run's original lines, verbatim, for fallback parsing on decline. */
+  raw: string
+  /** Index of the first line after the run. */
+  end: number
+}
+
+/**
+ * Read one callout run starting at `lines[start]`, or null.
+ *
+ * Accepts only the two shapes this feature owns: the exact bytes
+ * `serializeCalloutBlock` writes (strict marker + one `> ` per body line), and
+ * the bare damaged shape (marker line without its `> `, body directly below).
+ * Both require a paragraph start — a marker halfway through a paragraph or a
+ * quote is part of that paragraph's bytes, not a callout.
+ *
+ * A run that abuts more quote lines (`>` on its own, `>text`) is refused
+ * whole: `serializeCalloutBlock` never writes those, so the region is a quote
+ * block that merely starts like a callout, and splitting it would tear the
+ * quote in two.
+ */
+export function readCalloutRun(
+  lines: readonly string[],
+  start: number,
+  atParagraphStart: boolean
+): CalloutRun | null {
+  if (!atParagraphStart) return null
+
+  const quoted = lines[start].match(MEMRY_CALLOUT_MARKER_REGEX)
+  if (quoted) {
+    const contentLines: string[] = []
+    let end = start + 1
+    while (end < lines.length) {
+      const body = lines[end].match(/^> (.+)$/)
+      if (!body) break
+      contentLines.push(body[1])
+      end++
+    }
+    if (end < lines.length && lines[end].startsWith('>')) return null
+    return {
+      type: quoted[1] as CalloutTypeValue,
+      contentLines,
+      raw: lines.slice(start, end).join('\n'),
+      end
+    }
+  }
+
+  const bare = lines[start].match(BARE_CALLOUT_MARKER_REGEX)
+  if (bare) {
+    const contentLines: string[] = []
+    let end = start + 1
+    while (end < lines.length && lines[end].trim() !== '') {
+      contentLines.push(lines[end])
+      end++
+    }
+    if (contentLines.length === 0) return null
+    return {
+      type: bare[1] as CalloutTypeValue,
+      contentLines,
+      raw: lines.slice(start, end).join('\n'),
+      end
+    }
+  }
+
+  return null
+}
+
+interface ParsedBlockShape {
+  type?: unknown
+  content?: unknown
+  children?: unknown[]
+}
+
+/**
+ * Decide whether a run may become a callout block, by proof rather than by
+ * pattern: parse the body, and claim only if serializing it back reproduces
+ * the body byte-for-byte (so `serializeCalloutBlock` reproduces the whole run
+ * on the way out). Anything the schema would normalize — a list in the body, a
+ * nested quote, a second paragraph — declines, and the caller leaves the bytes
+ * exactly as they were.
+ */
+export async function resolveCalloutRun(
+  run: CalloutRun,
+  parseMarkdown: (markdown: string) => Promise<ParsedBlockShape[]>,
+  serializeBlock: (block: ParsedBlockShape) => Promise<string>
+): Promise<{ type: CalloutTypeValue; content: unknown } | null> {
+  const content = run.contentLines.join('\n')
+  if (content === '') return { type: run.type, content: [] }
+
+  const parsed = await parseMarkdown(content)
+  if (parsed.length !== 1) return null
+  const block = parsed[0]
+  if (block.type !== 'paragraph' || block.children?.length) return null
+
+  const roundTripped = (await serializeBlock(block)).trim()
+  if (roundTripped !== content) return null
+
+  return { type: run.type, content: block.content ?? [] }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1846

## Root cause, with the failing bytes

Main's parser deliberately never claimed callouts, so any time a note's Y.Doc is seeded from the vault file (new device, external edit, re-seed), the callout block is demoted to a quote block and the callout UI never comes back:

```
IN:     "> [!info]\n> Heads up"
BLOCKS: [{"type":"quote","content":[{"type":"text","text":"[!info]\nHeads up"}]}]
```

From there the marker is literal text inside a quote, one edit away from the reported end state — a bare `[!info]` line above unquoted content, which `CALLOUT_LINE_REGEX` can never claim again. The renderer's reader meanwhile was lenient (it claimed `> [!note]` as `info` and folded a title into the body), so the two paths could not produce the same bytes for the same file.

## Design

Both paths now share one strict, **proven** claim (`readCalloutRun` / `resolveCalloutRun` in `@memry/editor-schema/blocks`):

- A run is claimed only in the exact shape `serializeCalloutBlock` writes: `> [!info|warning|error|success]` with nothing after the `]`, one `> ` per body line, at a paragraph start.
- The claim must prove itself: the body is parsed and re-serialized, and unless that reproduces the run byte-for-byte, the claim is declined and the bytes stay exactly as written.
- Main claims in `parseContentWithColorMarkers` (collaborative path); the renderer's `splitMarkdownByCallouts` is rewritten on the same rules (non-collaborative path), replacing its lenient reader.

**Rejected alternative**: widening the schema so main can hold foreign types and titles verbatim. That is a schema/vault-format change needing its own migration and sync-compat plan, and it still could not byte-preserve arbitrary quote bodies (blank `>` lines, nested `> >`) without a verbatim block type. The guarded claim closes the reported loss with no schema change; anything it cannot reproduce is simply left alone.

## Obsidian compat (non-negotiable)

`> [!note]`, `> [!tip]`, and `> [!info] A title` are never claimed and round-trip byte-identical through main — asserted in `callouts on the CRDT path (#1846)` and in the existing `round-trips %j unchanged` table. The guard makes this hold by construction: a claim that cannot reproduce the bytes does not happen.

Pre-existing and out of scope: the **quote path itself** already rewrites two shapes today (a blank `>` line inside a quoted callout body is dropped, and nested `> > [!warning]` is flattened on the markdown → doc → markdown round trip). This predates this PR and reproduces on `origin/main`; it belongs to the #1848 conformance suite. Left un-claimed here so this PR does not make it worse.

## Healing rule

A note already damaged into the bare shape heals on parse, only when unambiguous: a line that is exactly `[!info]` / `[!warning]` / `[!error]` / `[!success]`, at a paragraph start, with a non-empty body directly below — and only if the body passes the same byte guard. A lone marker, a marker mid-paragraph, a marker with a blank line before its text, a foreign type, or a body the schema would normalize (a list, a fence) stays the author's bytes untouched.

## Verification

- Repro first: the demotion above and the byte matrix were captured from `yDocToMarkdown` before the fix; the new tests fail on the parent commit and pass after.
- `blocknote-converter.test.ts`: 251 passed — claim for all four types (single/multi-line/empty bodies), foreign/titled/blank-`>`/list-body declines, fence guard, colors-marker stability, heal + heal-decline matrix.
- `markdown-utils.test.ts` (renderer): 24 passed — strict claim, foreign/titled decline, heal.
- `@memry/editor-schema` tests 137 passed; desktop `typecheck:web/node/test` green; lint green; `docs:impact --strict` + `docs:build` green (`apps/docs/src/architecture/crdt.md` updated).
- Full `--project main` suite: 7498 passed; only pre-existing failures in `scripts/check-cert-hashes-config.test.ts`, which fail identically on an untouched `origin/main` worktree.
