### PR TITLE
fix(tasks): count the rows a project lists, and let dialogs shrink

### DIFF
--- a/apps/desktop/src/renderer/src/App.workspace-counts.test.tsx
+++ b/apps/desktop/src/renderer/src/App.workspace-counts.test.tsx
@@ -338,9 +338,11 @@ describe('App workspace count computation', () => {
     // today: a-open (overdue) + a-open-sub
     // completed: a-done + b-done
     expect(lastViewCounts).toEqual({ all: 3, today: 2, completed: 2 })
-    // project-a: a-open, a-open-sub | project-b: b-open only — b-archived is
-    // archived, so no view renders it and the badge must not count it (#1323)
-    expect(lastProjectCounts).toEqual({ 'project-a': 2, 'project-b': 1 })
+    // project-a: a-open only — a-open-sub is a subtask, and a project badge
+    // counts rows, not the subtasks nested inside them (#1878).
+    // project-b: b-open only — b-archived is archived, so no view renders it
+    // and the badge must not count it (#1323)
+    expect(lastProjectCounts).toEqual({ 'project-a': 1, 'project-b': 1 })
   })
 
   it('recomputes the counts when a task changes', () => {
@@ -353,7 +355,7 @@ describe('App workspace count computation', () => {
     expect(lastViewCounts).toEqual({ all: 2, today: 2, completed: 2 })
     // project-b is left with b-done and b-archived only, neither of which the
     // project view renders as an open task, so its badge is empty
-    expect(lastProjectCounts).toEqual({ 'project-a': 2, 'project-b': 0 })
+    expect(lastProjectCounts).toEqual({ 'project-a': 1, 'project-b': 0 })
     expect(sidebarRenders).toBeGreaterThan(0)
     expect(belowProviderRenders).toBeGreaterThan(0)
   })

--- a/apps/desktop/src/renderer/src/components/tasks/bulk-actions/bulk-actions.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/bulk-actions/bulk-actions.test.tsx
@@ -278,6 +278,33 @@ describe('bulk action components', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  /**
+   * jsdom does no layout, so this pins the shrink contract instead of the
+   * pixels. A long title used to widen the dialog's single grid track past its
+   * max width; the footer stretched with the track and carried the confirm
+   * button off the dialog, then off the window (#1878). Every box between the
+   * dialog and the title has to be allowed to shrink for `truncate` to work.
+   */
+  it('lets a long task title shrink instead of widening the dialog', () => {
+    const longTitle =
+      'Research into whether Copilot will classify and retrieve documents instead of Docuware (and retention management)'
+
+    render(
+      <BulkDeleteDialog
+        open
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        tasks={[{ ...tasks[0], title: longTitle }]}
+      />
+    )
+
+    expect(screen.getByRole('dialog').className).toContain('grid-cols-[minmax(0,1fr)]')
+
+    const title = screen.getByText(longTitle)
+    expect(title).toHaveClass('truncate', 'min-w-0')
+    expect(title.parentElement).toHaveClass('min-w-0')
+  })
+
   it('selects due dates with optional time and resets after close', () => {
     const onClose = vi.fn()
     const onConfirm = vi.fn()

--- a/apps/desktop/src/renderer/src/components/tasks/bulk-actions/bulk-delete-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/bulk-actions/bulk-delete-dialog.tsx
@@ -65,12 +65,17 @@ export const BulkDeleteDialog = ({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="py-4">
-          <ul className="space-y-1 text-sm">
+        <div className="min-w-0 py-4">
+          <ul className="min-w-0 space-y-1 text-sm">
             {visibleTasks.map((task) => (
-              <li key={task.id} className="flex items-center gap-2">
+              // `min-w-0` on both the row and the title: a flex item refuses to
+              // shrink below its content by default, which is what `truncate`
+              // needs it to do.
+              <li key={task.id} className="flex min-w-0 items-center gap-2">
                 <span className="text-muted-foreground">•</span>
-                <span className="truncate">{task.title}</span>
+                <span className="min-w-0 truncate" title={task.title}>
+                  {task.title}
+                </span>
               </li>
             ))}
             {remainingCount > 0 && (

--- a/apps/desktop/src/renderer/src/components/tasks/projects/project-selector.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/projects/project-selector.tsx
@@ -110,7 +110,10 @@ export const ProjectSelector = ({
   const projectTaskCounts = useMemo(() => {
     const counts: Record<string, number> = {}
     activeProjects.forEach((project) => {
-      const projectTaskList = tasks.filter((t) => t.projectId === project.id && !t.parentId)
+      const projectTaskList = tasks.filter(
+        // Archived tasks are in no list, so they must not be in a badge either.
+        (t) => t.projectId === project.id && !t.parentId && !t.archivedAt
+      )
       const incompleteCount = projectTaskList.filter((t) => {
         const proj = projects.find((p) => p.id === t.projectId)
         if (!proj) return true

--- a/apps/desktop/src/renderer/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/dialog.tsx
@@ -28,6 +28,15 @@ const DialogOverlay = React.forwardRef<
 ))
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
+/**
+ * `grid-cols-[minmax(0,1fr)]` is load-bearing. A grid track sizes to its
+ * content's minimum by default, so one unbreakable string — a long task title,
+ * a URL — widened the single column past `max-w-lg`. Every row then stretched
+ * to that track, and the footer's end-aligned buttons went with it: the
+ * confirm button slid off the dialog, and off the window entirely when the
+ * string was long enough. Clamping the track makes the children shrinkable, so
+ * `truncate` and wrapping do their job instead.
+ */
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
@@ -40,7 +49,7 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          'fixed start-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg rtl:translate-x-[50%]',
+          'fixed start-[50%] top-[50%] z-50 grid grid-cols-[minmax(0,1fr)] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg rtl:translate-x-[50%]',
           className
         )}
         {...props}

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-status-helpers.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-status-helpers.ts
@@ -142,18 +142,30 @@ export interface TaskGroupByStatus {
   tasks: Task[]
 }
 
+/**
+ * Buckets tasks into the project's own statuses, in status order.
+ *
+ * Every task lands in exactly one bucket. A task whose `statusId` is not one of
+ * the project's — a status that was deleted, or one carried over from another
+ * project — matches nothing, and dropping it would leave it in no list at all:
+ * invisible, uneditable, but still counted by everything that counts tasks. The
+ * first status adopts those instead, so the user can see and re-file them.
+ */
 export const groupTasksByStatus = (
   tasks: Task[],
   projectStatuses: Status[],
   preserveOrder: boolean = false
 ): TaskGroupByStatus[] => {
   const sortedStatuses = [...projectStatuses].sort((a, b) => a.order - b.order)
+  const knownStatusIds = new Set(projectStatuses.map((status) => status.id))
+  const unknownStatusTasks = tasks.filter((t) => !knownStatusIds.has(t.statusId))
 
-  return sortedStatuses.map((status) => {
+  return sortedStatuses.map((status, index) => {
     const statusTasks = tasks.filter((t) => t.statusId === status.id)
+    const groupTasks = index === 0 ? [...statusTasks, ...unknownStatusTasks] : statusTasks
     return {
       status,
-      tasks: preserveOrder ? statusTasks : sortTasksByPriorityAndDate(statusTasks)
+      tasks: preserveOrder ? groupTasks : sortTasksByPriorityAndDate(groupTasks)
     }
   })
 }

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-utils.test.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-utils.test.ts
@@ -2133,6 +2133,20 @@ describe('Task Utils', () => {
 
         expect(groups).toEqual([])
       })
+
+      // A dropped task is in no list at all: invisible and uneditable, while
+      // every badge that counts tasks still counts it (#1878).
+      it('should put tasks with an unknown status in the first status', () => {
+        const tasks = [
+          createMockTask({ id: 't1', statusId: 's1' }),
+          createMockTask({ id: 'orphan', statusId: 'status-deleted-long-ago' })
+        ]
+
+        const groups = groupTasksByStatus(tasks, statusList, true)
+
+        expect(groups[0].tasks.map((t: Task) => t.id)).toEqual(['t1', 'orphan'])
+        expect(groups.flatMap((g: { tasks: Task[] }) => g.tasks)).toHaveLength(tasks.length)
+      })
     })
   })
 

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts
@@ -119,9 +119,10 @@ export interface TaskWorkspaceCounts {
   /** Per view id, equal to `getFilteredTasks(tasks, viewId, 'view', projects).length`. */
   viewCounts: Record<string, number>
   /**
-   * Per `task.projectId`, the number of that project's non-archived tasks not in
-   * a `done` status — i.e. the rows `getFilteredTasks(tasks, projectId,
-   * 'project', projects)` renders, minus the completed ones.
+   * Per `task.projectId`, the number of that project's non-archived, top-level
+   * tasks not in a `done` status — i.e. the rows `getFilteredTasks(tasks,
+   * projectId, 'project', projects)` renders as rows, minus the completed ones.
+   * Subtasks are excluded: they render nested under their parent.
    */
   projectTaskCounts: Record<string, number>
 }
@@ -209,13 +210,17 @@ export const getTaskWorkspaceCounts = (
     // badge makes it read higher than the list it opens.
     if (task.archivedAt) continue
 
-    if (isIncomplete) {
-      projectTaskCounts[projectId] = (projectTaskCounts[projectId] ?? 0) + 1
-    }
-
     if (task.parentId !== null) {
       nonArchivedSubtaskParentIds.push(task.parentId)
       continue
+    }
+
+    // A subtask is a row under its parent, never a row of its own, so it must
+    // not lift the project badge past the number of rows the project lists.
+    // Counting them made a project of finished parents read as dozens of open
+    // tasks over an empty To Do section.
+    if (isIncomplete) {
+      projectTaskCounts[projectId] = (projectTaskCounts[projectId] ?? 0) + 1
     }
 
     for (const viewId of viewIds) {

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-workspace-counts.test.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-workspace-counts.test.ts
@@ -109,9 +109,11 @@ const baselineTasks = (): Task[] => [
 ]
 
 /**
- * A project badge has to mean "tasks you will see when you open this project".
+ * A project badge has to mean "rows you will see when you open this project".
  * The project view is `getFilteredTasks(..., 'project', ...)`, which drops
- * archived rows up front, so the badge is that list minus its completed rows.
+ * archived rows up front, so the badge is that list minus its completed rows —
+ * and minus its subtasks, which render nested under a parent rather than as
+ * rows of their own.
  *
  * This replaces the pre-single-pass App.tsx expression, which filtered by
  * project id and status only and therefore counted archived tasks no view can
@@ -122,9 +124,9 @@ const expectedProjectTaskCount = (
   project: Project,
   allProjects: Project[]
 ): number =>
-  getFilteredTasks(tasks, project.id, 'project', allProjects).filter(
-    (t) => project.statuses.find((s) => s.id === t.statusId)?.type !== 'done'
-  ).length
+  getFilteredTasks(tasks, project.id, 'project', allProjects)
+    .filter((t) => t.parentId === null)
+    .filter((t) => project.statuses.find((s) => s.id === t.statusId)?.type !== 'done').length
 
 const expectMatchesFilters = (tasks: Task[], allProjects: Project[] = projects): void => {
   const { viewCounts, projectTaskCounts } = getTaskWorkspaceCounts(tasks, allProjects, ALL_VIEW_IDS)
@@ -167,9 +169,10 @@ describe('getTaskWorkspaceCounts', () => {
     })
 
     expect(projectTaskCounts).toEqual({
-      // project-a incomplete: overdue, overdue-sub, due-today, due-tomorrow,
-      // due-in-3, due-in-20, no-due-date, done-a-sub, ghost-status, orphan-sub
-      'project-a': 10,
+      // project-a incomplete rows: overdue, due-today, due-tomorrow, due-in-3,
+      // due-in-20, no-due-date, ghost-status. overdue-sub, done-a-sub and
+      // orphan-sub are subtasks, so they are not rows and not counted.
+      'project-a': 7,
       // project-b incomplete and renderable: b-open only. b-archived and
       // archived-sub are archived, so the project view never lists them and the
       // badge must not count them either (#1323).
@@ -237,7 +240,7 @@ describe('getTaskWorkspaceCounts invalidation matrix', () => {
     {
       name: 'task created',
       apply: (tasks) => [...tasks, createTask({ id: 'fresh', dueDate: TODAY })],
-      changes: { all: 11, today: 5, 'project-a': 11 }
+      changes: { all: 11, today: 5, 'project-a': 8 }
     },
     {
       name: 'task edited (title only)',
@@ -248,23 +251,23 @@ describe('getTaskWorkspaceCounts invalidation matrix', () => {
       name: 'task completed',
       apply: (tasks) =>
         tasks.map((t) => (t.id === 'overdue' ? { ...t, statusId: 'done', completedAt: TODAY } : t)),
-      changes: { all: 8, today: 2, completed: 5, 'project-a': 9 }
+      changes: { all: 8, today: 2, completed: 5, 'project-a': 6 }
     },
     {
       name: 'task uncompleted',
       apply: (tasks) =>
         tasks.map((t) => (t.id === 'done-a' ? { ...t, statusId: 'todo', completedAt: null } : t)),
-      changes: { all: 12, completed: 1, 'project-a': 11 }
+      changes: { all: 12, completed: 1, 'project-a': 8 }
     },
     {
       name: 'task deleted',
       apply: (tasks) => tasks.filter((t) => t.id !== 'due-today'),
-      changes: { all: 9, today: 3, 'project-a': 9 }
+      changes: { all: 9, today: 3, 'project-a': 6 }
     },
     {
       name: 'parent deleted (its subtask stops riding along)',
       apply: (tasks) => tasks.filter((t) => t.id !== 'overdue'),
-      changes: { all: 8, today: 2, 'project-a': 9 }
+      changes: { all: 8, today: 2, 'project-a': 6 }
     },
     {
       name: 'due date moved out of today',
@@ -283,7 +286,7 @@ describe('getTaskWorkspaceCounts invalidation matrix', () => {
         tasks.map((t) =>
           t.id === 'no-due-date' ? { ...t, projectId: 'project-b', statusId: 'todo' } : t
         ),
-      changes: { 'project-a': 9, 'project-b': 2 }
+      changes: { 'project-a': 6, 'project-b': 2 }
     },
     {
       name: 'status reassigned within the project',
@@ -298,9 +301,9 @@ describe('getTaskWorkspaceCounts invalidation matrix', () => {
     {
       name: 'task archived',
       // The project badge has to fall with the view: archiving removes the row
-      // from the project list, so project-a drops 10 -> 9 (#1323).
+      // from the project list, so project-a drops 7 -> 6 (#1323).
       apply: (tasks) => tasks.map((t) => (t.id === 'due-today' ? { ...t, archivedAt: TODAY } : t)),
-      changes: { all: 9, today: 3, 'project-a': 9 }
+      changes: { all: 9, today: 3, 'project-a': 6 }
     },
     {
       name: 'task unarchived',
@@ -314,12 +317,14 @@ describe('getTaskWorkspaceCounts invalidation matrix', () => {
         ...tasks,
         createTask({ id: 'from-inbox', sourceNoteId: 'note-1', dueDate: addDays(TODAY, 1) })
       ],
-      changes: { all: 11, upcoming: 3, tomorrow: 2, 'project-a': 11 }
+      changes: { all: 11, upcoming: 3, tomorrow: 2, 'project-a': 8 }
     },
     {
       name: 'remote device writes a subtask under an open parent',
+      // The view badges follow it (the subtask rides along under its parent),
+      // the project badge does not: a subtask is not a row of its own.
       apply: (tasks) => [...tasks, createTask({ id: 'remote-sub', parentId: 'due-today' })],
-      changes: { all: 11, today: 5, 'project-a': 11 }
+      changes: { all: 11, today: 5, 'project-a': 7 }
     }
   ]
 

--- a/apps/desktop/src/renderer/src/pages/project/tabs/overview-tab.tsx
+++ b/apps/desktop/src/renderer/src/pages/project/tabs/overview-tab.tsx
@@ -28,9 +28,9 @@ export const OverviewTab = ({ project, hub, handlers }: OverviewTabProps): React
         onViewAll={() => handlers.onGoToTab('tasks')}
         onAdd={handlers.onAddTask}
         emptyLabel={t('projectHub.sections.emptyTasks')}
-        isEmpty={hub.tasks.length === 0}
+        isEmpty={hub.rowTasks.length === 0}
       >
-        {hub.tasks.slice(0, OVERVIEW_PREVIEW_COUNT).map((task) => (
+        {hub.rowTasks.slice(0, OVERVIEW_PREVIEW_COUNT).map((task) => (
           <TaskRow
             key={task.id}
             task={task}

--- a/apps/desktop/src/renderer/src/pages/project/use-project-hub.test.ts
+++ b/apps/desktop/src/renderer/src/pages/project/use-project-hub.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { tasksService } from '@/services/tasks-service'
+import { flattenTasksByStatus } from '@/lib/virtual-list-utils'
 import { deriveProgress, useProjectHub } from './use-project-hub'
 import type { Project, Status } from '@/data/tasks-data'
 import type { Task } from '@/data/task-model'
 
+// The hook reads the whole workspace out of context; tests swap what it sees.
+const workspace = vi.hoisted(() => ({
+  current: { tasks: [] as unknown[], projects: [] as unknown[] }
+}))
+
 vi.mock('@/contexts/tasks', () => ({
-  useTasksContext: () => ({ tasks: [], projects: [] })
+  useTasksContext: () => workspace.current
 }))
 
 vi.mock('@/services/tasks-service', () => ({
@@ -142,6 +148,7 @@ describe('useProjectHub', () => {
   beforeEach(() => {
     vi.mocked(tasksService.listProjectContents).mockReset()
     vi.mocked(tasksService.getProject).mockReset()
+    workspace.current = { tasks: [], projects: [] }
   })
 
   const emptyContents = {
@@ -177,5 +184,43 @@ describe('useProjectHub', () => {
 
     act(() => result.current.setHomeNoteId('note-9'))
     expect(result.current.homeNoteId).toBe('note-9')
+  })
+
+  /**
+   * The Tasks tab badge is a promise about the tab under it. It counted every
+   * task carrying the project id — subtasks nested under a parent row, and
+   * tasks whose status the project no longer has — so a project of finished
+   * work advertised 130 tasks over sections reading 0, 0 and 37 (#1878).
+   */
+  it('counts exactly the rows the Tasks tab lists', async () => {
+    const project = makeProject()
+    const parent = makeTask({ id: 'parent', subtaskIds: ['sub'] })
+    const tasks = [
+      parent,
+      makeTask({ id: 'sub', parentId: 'parent' }),
+      makeTask({ id: 'done', statusId: 'done', completedAt: new Date() }),
+      makeTask({ id: 'ghost-status', statusId: 'status-deleted-long-ago' }),
+      makeTask({ id: 'archived', archivedAt: new Date() })
+    ]
+    workspace.current = { tasks, projects: [project] }
+
+    vi.mocked(tasksService.listProjectContents).mockResolvedValue(emptyContents)
+    vi.mocked(tasksService.getProject).mockResolvedValue(null as never)
+
+    const { result } = renderHook(() => useProjectHub('p1'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const rows = flattenTasksByStatus(
+      result.current.tasks,
+      project,
+      new Set<string>(),
+      result.current.tasks,
+      true
+    ).filter((item) => item.type === 'task' || item.type === 'parent-task')
+
+    // parent, done and ghost-status. The subtask renders under its parent and
+    // the archived task renders nowhere.
+    expect(rows).toHaveLength(3)
+    expect(result.current.counts.tasks).toBe(rows.length)
   })
 })

--- a/apps/desktop/src/renderer/src/pages/project/use-project-hub.ts
+++ b/apps/desktop/src/renderer/src/pages/project/use-project-hub.ts
@@ -37,6 +37,12 @@ export interface ProjectProgress {
 export interface ProjectHubData {
   project: Project | null
   tasks: Task[]
+  /**
+   * The project's tasks that the Tasks tab lists as rows — top-level only.
+   * Subtasks are in `tasks` (the list renders them nested under their parent)
+   * but are not rows, so they must not reach a count or a preview.
+   */
+  rowTasks: Task[]
   notes: ProjectLinkedNote[]
   pinnedNotes: ProjectLinkedNote[]
   files: ProjectLinkedFile[]
@@ -141,6 +147,8 @@ export function useProjectHub(projectId: string | undefined): ProjectHubData {
     return getFilteredTasks(tasks, projectId, 'project', projects)
   }, [tasks, projectId, projects])
 
+  const rowTasks = useMemo(() => projectTasks.filter((t) => t.parentId === null), [projectTasks])
+
   useEffect(() => {
     if (!projectId) return
 
@@ -221,12 +229,16 @@ export function useProjectHub(projectId: string | undefined): ProjectHubData {
   return {
     project,
     tasks: projectTasks,
+    rowTasks,
     notes: contents.notes,
     pinnedNotes,
     files: contents.files,
     events: contents.events,
     counts: {
-      tasks: projectTasks.length,
+      // The rows the Tasks tab shows, so the badge and the status sections under
+      // it add up. Counting subtasks here made the badge read far higher than
+      // any section on the tab it labels.
+      tasks: rowTasks.length,
       notes: contents.counts.notes,
       files: contents.counts.files,
       events: contents.counts.events

--- a/apps/docs/src/user-guide/projects.md
+++ b/apps/docs/src/user-guide/projects.md
@@ -43,7 +43,11 @@ Open the project's **⋯** menu and choose **Edit statuses**. From there you can
 
 The sidebar shows **incomplete** task counts per project — tasks whose status type is not `done`. This keeps the count meaningful even as you complete tasks.
 
-Archived tasks are excluded, so the badge always matches the number of open tasks you see when you open the project.
+Every count is a count of **rows**. Subtasks are not rows of their own: they live under their parent task and show up as its `2/5` progress, so they never appear in a badge. Archived tasks are excluded too, so the badge always matches the number of open tasks you see when you open the project.
+
+The **Tasks** tab in the project hub counts the same rows, but all of them rather than only the open ones — so it equals the To Do, In Progress and Done sections underneath it added together.
+
+If a task points at a status the project no longer has — after the status was deleted, or after the task arrived from a project with a different workflow — it appears in the project's first status so you can see it and re-file it.
 
 ## Default Project
 


### PR DESCRIPTION
Closes #1878

## Summary

Two defects from one user report.

### 1 — a project showed three different task numbers at once

The Inbox project's tab bar read **Tasks 130**, the sidebar read **93**, and the sections under the 130 read TO DO (0), IN PROGRESS (0), DONE (37).

None of the three was the number of rows on screen, because each counted a different set:

| | counted |
|---|---|
| Tasks tab (`useProjectHub`) | every non-archived task with the project id |
| Sidebar (`getTaskWorkspaceCounts`) | the same, minus the done ones |
| The tab itself | top-level tasks bucketed into the project's own statuses |

So both badges counted subtasks, which render nested under a parent rather than as rows of their own, and both counted tasks whose `statusId` is no longer one of the project's statuses.

That second group is the worse half. `groupTasksByStatus` matched them to no bucket and dropped them, so they were invisible and uneditable while every badge kept counting them. 130 − 37 = 93 is not a coincidence: the two badges were reporting on tasks the tab could not show.

Both badges now count top-level tasks — the tab all of them, the sidebar the open ones — so the tab badge equals its own sections added together, and the sidebar badge is that minus the done ones. The first status adopts tasks whose status is gone, so nothing on file is unreachable and nothing counted is unseeable. The project picker in the Tasks toolbar was counting archived tasks; it now excludes them, as the sidebar already did.

### 2 — a long task title carried the bulk-delete confirm button off the window

`DialogContent` is a CSS grid. A grid track sizes to its content's minimum, so one long unbreakable title widened the single column past `max-w-lg`; every row stretched to that track, and the footer's end-aligned buttons rode along with it. `truncate` on the title could not help, because a flex item will not shrink below its content without `min-w-0`.

Clamping the track with `grid-cols-[minmax(0,1fr)]` fixes it for every dialog in the app, not only this one. The bulk-delete row gets the `min-w-0` its `truncate` was always missing.

## Release note

Project task counts now match the list they label: subtasks count under their parent instead of separately, and a task whose status was deleted shows up in the project's first status instead of disappearing. Deleting several tasks at once no longer pushes the confirm button off the window when one of them has a long title.

## Test plan

**Bug 2, measured in a real browser.** jsdom does no layout, so the claim was checked in headless Chromium at 1280px against the exact pre- and post-fix markup, with the title from the report repeated three times:

```
broken { dialogWidth: 512, confirmRight: 2704, insideViewport: false }
fixed  { dialogWidth: 512, confirmRight:  871, insideViewport: true  }
```

The dialog itself never exceeds 512px in either case — it is the track and the footer that escape it, which is why the button leaves the window while the dialog looks fine.

**Bug 1, pinned to the render path.** The new `useProjectHub` test builds a project holding an open parent, its subtask, a done task, a task with a deleted status, and an archived task, then asserts the badge equals the rows `flattenTasksByStatus` actually emits — so the badge cannot drift from the list again without going red.

Both halves of that test were mutation-checked: restoring the old count gives `expected 4 to be 3`, and removing the orphan-status adoption gives `expected [ …(2) ] to have a length of 3 but got 2`.

The badge-vs-filter equivalence matrix in `task-workspace-counts.test.ts` is unchanged in shape; its expectation now states the top-level rule explicitly and every count in it moved accordingly.

```
pnpm exec vitest --project renderer
  Test Files  692 passed (692)
       Tests  8410 passed | 7 skipped (8417)
```

`typecheck:web`, `typecheck:test`, `eslint` on the diff, `git diff --check`, `docs:impact --base origin/main --strict`, `docs:build` all pass. `pnpm typecheck` fails on `origin/main` before this branch exists, in the architecture boundary check (`apps/mobile/vitest.config.ts -> node:url`, arrived with #1863); it needs its own fix.

One note for anyone who sees a red local run: 35 renderer suites fail on Node 26 with `Cannot read properties of undefined (reading 'clear')`, because jsdom leaves `localStorage` undefined there. The repo asks for Node 24 (`engines`), and on Node 24 every one of them passes. Nothing to do with this branch, but it looks alarming.

## Caveats

A subtask whose parent no longer exists in the task list still renders nowhere, and is now no longer counted either. It was unreachable before this change and remains so; making orphaned subtasks recoverable is a separate piece of work.
