### PR TITLE
test(sync): probe what the write-back round-trip does to raw HTML

### DIFF
--- a/apps/desktop/src/main/sync/raw-html-roundtrip.probe.test.ts
+++ b/apps/desktop/src/main/sync/raw-html-roundtrip.probe.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Probe: what markdown → Y.Doc → markdown does to raw HTML (#1883, and the
+ * wider hole behind it).
+ *
+ * The pair below is exactly what the app runs — `markdownToYFragment` seeds the
+ * doc on note open, `yDocToMarkdown` re-serializes the WHOLE doc on the first
+ * write-back after that. So `pass1` is the bytes that land in the user's file
+ * the first time anything touches a note written by hand or by Obsidian, and
+ * `pass2` is what a second open of that file produces.
+ *
+ * `pass1`/`pass2` record CURRENT behavior, not desired behavior. This file is
+ * an instrument: it goes red when the behavior moves, which is the point. A
+ * `null` means "byte-identical to the input".
+ */
+
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
+import { serializeToggleBlock } from '@memry/editor-schema/blocks'
+import { markdownToYFragment, yDocToMarkdown } from './blocknote-converter'
+
+async function onePass(markdown: string): Promise<string> {
+  const doc = new Y.Doc()
+  const ok = await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+  expect(ok, 'markdown reached the doc').toBe(true)
+  const out = await yDocToMarkdown(doc)
+  expect(out, 'the doc serialized back at all').not.toBeNull()
+  return out as string
+}
+
+interface Probe {
+  name: string
+  markdown: string
+  /** Output of the first round-trip; `null` means identical to the input. */
+  pass1: string | null
+  /** Output of a second round-trip over `pass1`; `null` means identical to it. */
+  pass2?: string
+}
+
+/**
+ * A note whose body is ONLY an HTML block loses everything. Pass 1 leaves three
+ * newlines where the block was, pass 2 turns those into the empty string, and
+ * `yDocToMarkdown`'s empty-conversion guard never fires because the fragment
+ * really does hold the (empty) paragraphs it converted.
+ */
+const HTML_ONLY_BODY: Probe[] = [
+  { name: '<div> on one line', markdown: '<div class="x">Body</div>', pass1: '\n\n\n', pass2: '' },
+  { name: '<p> paragraph', markdown: '<p>Body</p>', pass1: '\n\n\n', pass2: '' },
+  { name: '<center> block', markdown: '<center>Body</center>', pass1: '\n\n\n', pass2: '' },
+  {
+    name: '<figure> with a caption',
+    markdown: '<figure>\n<img src="a.png">\n<figcaption>Cap</figcaption>\n</figure>',
+    pass1: '\n\n\n',
+    pass2: ''
+  },
+  {
+    name: 'raw HTML table',
+    markdown: '<table>\n<tr><td>a</td></tr>\n</table>',
+    pass1: '\n\n\n',
+    pass2: ''
+  },
+  {
+    name: '<iframe> embed',
+    markdown: '<iframe src="https://example.com"></iframe>',
+    pass1: '\n\n\n',
+    pass2: ''
+  },
+  {
+    name: '<video> embed',
+    markdown: '<video src="a.mp4" controls></video>',
+    pass1: '\n\n\n',
+    pass2: ''
+  },
+  { name: 'raw <img>', markdown: '<img src="a.png" alt="A">', pass1: '\n\n\n', pass2: '' },
+  { name: '<hr /> self-closing', markdown: '<hr />', pass1: '\n\n\n', pass2: '' },
+  { name: '<br> alone on a line', markdown: '<br>', pass1: '\n\n\n', pass2: '' },
+  { name: 'a plain HTML comment', markdown: '<!-- a note to self -->', pass1: '\n\n\n', pass2: '' },
+  { name: '<script> block', markdown: '<script>alert(1)</script>', pass1: '\n\n\n', pass2: '' }
+]
+
+/** With markdown around it, the tags go and the inner text stays. */
+const BLOCK_LEVEL_IN_CONTEXT: Probe[] = [
+  {
+    name: 'bare <details> written by hand',
+    markdown: '<details>\n<summary>Foreign</summary>\n\nBody\n\n</details>',
+    pass1: 'Body'
+  },
+  {
+    name: 'bare <details> holding a markdown list',
+    markdown: '<details>\n<summary>S</summary>\n\n- one\n- two\n\n</details>',
+    pass1: '- one\n- two'
+  },
+  {
+    name: '<div> wrapper around a blank-line-separated body',
+    markdown: '<div class="x">\n\nBody\n\n</div>',
+    pass1: 'Body'
+  },
+  {
+    name: 'html block between two paragraphs',
+    markdown: 'Before\n\n<div class="x">Body</div>\n\nAfter',
+    pass1: 'Before\n\nAfter'
+  },
+  {
+    name: 'blockquote whose only content is html',
+    markdown: '> <div>Body</div>',
+    pass1: '>'
+  },
+  {
+    name: 'bare <details> nested in a Memry toggle body',
+    markdown: serializeToggleBlock(
+      'Summary',
+      '<details>\n<summary>In</summary>\n\nX\n\n</details>'
+    ),
+    pass1: serializeToggleBlock('Summary', 'X')
+  }
+]
+
+/** Inline tags lose the markup and keep the text, so `<a href>` loses its link. */
+const INLINE_LEVEL: Probe[] = [
+  { name: '<kbd>', markdown: 'Press <kbd>Cmd</kbd> now.', pass1: 'Press Cmd now.' },
+  { name: '<sup>', markdown: 'Text<sup>1</sup> here.', pass1: 'Text1 here.' },
+  { name: '<u>', markdown: 'An <u>underlined</u> word.', pass1: 'An underlined word.' },
+  { name: '<mark>', markdown: 'A <mark>marked</mark> word.', pass1: 'A marked word.' },
+  {
+    name: '<abbr title>',
+    markdown: 'Use <abbr title="HyperText">HTML</abbr>.',
+    pass1: 'Use HTML.'
+  },
+  {
+    name: '<a href> loses the destination',
+    markdown: 'See <a href="https://example.com">this</a>.',
+    pass1: 'See this.'
+  },
+  { name: '<br> mid-paragraph', markdown: 'One<br>Two', pass1: 'OneTwo' },
+  { name: 'in a list item', markdown: '- <kbd>A</kbd> item', pass1: '- A item' },
+  { name: 'in a heading', markdown: '# Title <sup>x</sup>', pass1: '# Title x' },
+  { name: 'an HTML entity is decoded', markdown: 'A &amp; B', pass1: 'A & B' }
+]
+
+const SURVIVORS: Probe[] = [
+  {
+    name: 'raw HTML inside a fenced code block',
+    markdown: '```html\n<div class="x">Body</div>\n```',
+    pass1: null
+  },
+  { name: 'raw HTML inside inline code', markdown: 'Use `<div>` here.', pass1: null },
+  {
+    name: "Memry's own toggle, terminated",
+    markdown: serializeToggleBlock('Summary', 'Body'),
+    pass1: null
+  },
+  {
+    name: "Memry's own file-block marker",
+    markdown:
+      '<!-- file:{"url":"memry-file://v/a.pdf","name":"a.pdf","size":12,"mimeType":"application/pdf"} -->',
+    pass1: null
+  },
+  {
+    name: "Memry's own colors marker",
+    markdown: '<!-- colors:{"backgroundColor":"blue"} -->\nBody',
+    pass1: null
+  },
+  {
+    name: 'an inline color span in the exact bytes Memry writes',
+    markdown: 'A <span style="color:#ff0000">red</span> word.',
+    pass1: null
+  },
+  {
+    name: 'a hand-written color span is re-spaced, not dropped',
+    markdown: 'A <span style="color: #ff0000">red</span> word.',
+    pass1: 'A <span style="color:#ff0000">red</span> word.'
+  }
+]
+
+const PENDING_1883: Probe[] = [
+  {
+    name: 'unterminated Memry toggle',
+    markdown: '<details data-memry-toggle>\n<summary>Unterminated</summary>\n\nBody',
+    pass1: 'Body'
+  }
+]
+
+function run(title: string, probes: Probe[]): void {
+  describe(title, () => {
+    it.each(probes)('$name', async ({ markdown, pass1, pass2 }) => {
+      const once = await onePass(markdown)
+      expect(once, 'first round-trip').toBe(pass1 ?? markdown)
+      expect(await onePass(once), 'second round-trip').toBe(pass2 ?? once)
+    })
+  })
+}
+
+describe('raw HTML through the write-back round-trip', () => {
+  run('an HTML-only body is emptied outright', HTML_ONLY_BODY)
+  run('a block-level tag is dropped, its inner text kept', BLOCK_LEVEL_IN_CONTEXT)
+  run('an inline tag is dropped, its text kept', INLINE_LEVEL)
+  run('what survives', SURVIVORS)
+  run('the narrow shape #1883 tracks', PENDING_1883)
+})


### PR DESCRIPTION
## Summary

A probe test pinning what `markdown → Y.Doc → markdown` actually does to raw HTML. No production code changes.

The pair it drives is the one the app runs: `markdownToYFragment` seeds the doc on note open, and `yDocToMarkdown` re-serializes the whole doc on the first write-back after that. So pass 1 is the bytes that land in the user's file the first time anything touches a note written by hand or by Obsidian.

The loss is app-wide, not the bare-`<details>` case #1883 tracks. Measured across 36 cases:

- **A body that is only HTML is emptied outright.** `<div>`, `<p>`, `<figure>`, `<table>`, `<iframe>`, `<video>`, `<img>`, `<hr/>`, `<br>`, `<script>`, and a plain `<!-- comment -->` each serialize to `"\n\n\n"` on pass 1 and to `""` on pass 2. `yDocToMarkdown`'s empty-conversion guard never fires, because the fragment genuinely holds the empty paragraphs it converted.
- **A block tag with markdown around it loses the tag and keeps the inner text.** `> <div>Body</div>` becomes `>`. A bare `<details>` nested in a Memry toggle body is dropped, summary and all.
- **An inline tag loses its markup too**, so `<a href="…">this</a>` keeps `this` and loses the destination, and `One<br>Two` becomes `OneTwo`.
- **What survives**: code fences, inline code, Memry's own toggle / `file:` / `colors:` markers, and an inline color span in the exact bytes Memry writes. A hand-written `color: #ff0000` is re-spaced to `color:#ff0000`.

Root cause is one line up from #1883. Every path that is not a code fence, a Memry marker line, or a terminated Memry toggle ends at `editor.tryParseMarkdownToBlocks`, and BlockNote's schema has no node for raw HTML, so remark's `html` nodes are dropped. `splitMarkdownByToggles` declining a region is correct and irrelevant; the declined lines still reach that parser.

This contradicts a stated guarantee in `packages/editor-schema/src/blocks/markdown.ts` (~line 289), which says a bare `<details>` written by hand in Obsidian "is left as the author wrote it". That holds at the split layer and is false end to end.

## Trigger

The loss enters the Y.Doc at seed time (`crdt-provider.ts:1075`) and is persisted immediately. It reaches the file on the first write-back, which fires only for IPC or network origins (`crdt-provider.ts:1219`). One keystroke anywhere in the note rewrites the whole body, and on a second device an inbound update does it with nobody typing. `maybeCreateSignificantSnapshot` is not a safety net, since stripping tags is a near-zero word diff.

## What this PR does not do

It does not fix the behavior. The recorded `pass1`/`pass2` values are current behavior, so the file goes red the moment the behavior moves, and the fix flips them to the input.

## Reviewer notes on the fix that should follow

One probe collapsed the design space. A paragraph whose text content is `<div class="x">Body</div>` serializes back verbatim and unescaped, and a single paragraph with soft-break runs reproduces `<details>\n<summary>Foreign</summary>\n\nBody\n\n</details>` byte for byte. So preserving raw HTML needs **no new schema node**, no serializer change, and no new node name in the CRDT fragment. The whole fix is parse-side: recognize the HTML run and hand it to a plain paragraph instead of to BlockNote's parser, which is the `parseCustomBlockMarkerLine` shape already in `parseContentWithColorMarkers`.

Byte-compat, since write-back byte-compares:

- Notes with no raw HTML parse and serialize identically today and after, so `fileContent === existingRaw` still short-circuits. No churn, no sync traffic, no snapshot.
- Affected notes churn once, toward the original bytes. Their on-disk body today is already the damaged form, so the first write-back after a fix is a repair.
- No CRDT format change, so no `findUnrepresentableNodes` refusal, and old and new builds interoperate in both directions. That is what makes it shippable to a live beta.
- Notes already destroyed are not recoverable from the doc.
- Both serializers must move together. The renderer twin in `markdown-utils.ts` runs the same parse, and the #1848 conformance corpus pins main and renderer to the same bytes.

Toggle fold behavior is untouched here (#1847).

## Release note
none

## Test plan

```
pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/sync/raw-html-roundtrip.probe.test.ts
```

36 passed. `pnpm --filter @memry/desktop typecheck:test:node` clean.
