### PR TITLE
fix(editor): keep a blockquote's blank line and its nesting on the way back

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -7,7 +7,10 @@ import {
   FILE_BLOCK_LINE_REGEX,
   parseFileBlockMarker,
   readCalloutRun,
+  readStructuredQuoteRun,
   resolveCalloutRun,
+  resolveQuoteRun,
+  serializeQuoteBlock,
   serializeToggleBlock,
   splitMarkdownByToggles,
   type ToggleBlockSegment
@@ -422,6 +425,27 @@ async function serializeToggle(editor: ServerBlockNoteEditor, block: Block): Pro
   return serializeToggleBlock(summary, body, colorsMarker, isOpen === true)
 }
 
+function isStructuredQuote(block: Block): boolean {
+  return (block.type as string) === 'quote' && ((block.children ?? []) as Block[]).length > 0
+}
+
+/**
+ * A quote block that owns children writes them INSIDE the blockquote, one `> `
+ * per line and a bare `>` per gap — the bytes `readStructuredQuoteRun` reads
+ * back. BlockNote's own serializer puts children AFTER the quote (`> A\n\nB`),
+ * which is how a blank quote line and a nested callout were lost (#1881).
+ *
+ * The quote's own line is serialized as a paragraph, the same trick
+ * `serializeToggle` uses: a `quote` serialized alone already carries the `> `
+ * this function is about to add.
+ */
+async function serializeQuote(editor: ServerBlockNoteEditor, block: Block): Promise<string> {
+  const own = { ...block, type: 'paragraph', props: {}, children: [] } as unknown as Block
+  const children = (block.children ?? []) as Block[]
+  const inner = await blocksToMarkdownPreserving(editor, [own, ...children])
+  return serializeQuoteBlock(inner.trim())
+}
+
 /**
  * Main-process twin of the renderer's embed resolution: same rewrite, but the
  * vault lookup is a direct call instead of an IPC round trip. A closed vault or
@@ -574,6 +598,25 @@ async function parseContentWithColorMarkers(
         i = claimed.end - 1
         continue
       }
+
+      const quoted = atParagraphStart ? await parseQuoteRunAt(editor, lines, i) : null
+      if (quoted) {
+        await flushBuffer()
+        const props = { ...(pendingColors ?? {}) }
+        pendingColors = null
+        pendingTableColors = null
+        blocks.push({
+          type: 'quote',
+          props,
+          content: quoted.content,
+          children: quoted.children
+        } as unknown as Block)
+        for (let consumed = i + 1; consumed < quoted.end; consumed++) {
+          fence.consume(lines[consumed])
+        }
+        i = quoted.end - 1
+        continue
+      }
     }
 
     // Deliberately NOT fence-guarded: this branch predates custom-block parsing
@@ -651,6 +694,38 @@ async function parseCalloutRunAt(
   if (!claimed) return null
 
   return { type: claimed.type, content: claimed.content, end: run.end }
+}
+
+/**
+ * Claim a structured blockquote at `lines[i]`, or null to leave the bytes on
+ * BlockNote's own quote path.
+ *
+ * Only the two shapes BlockNote's flat quote block loses are read (a blank `>`
+ * separator, a `> >` nesting level), and even those only when re-serializing
+ * the parse reproduces the run byte-for-byte — see `resolveQuoteRun`. The
+ * claimed run becomes a quote block that owns its later blocks as children,
+ * which `serializeQuote` writes back inside the blockquote.
+ *
+ * Inner blocks are parsed flat, so a quote nested two levels deep declines and
+ * keeps today's behavior rather than round-tripping through a half-applied
+ * nesting.
+ */
+async function parseQuoteRunAt(
+  editor: ServerBlockNoteEditor,
+  lines: readonly string[],
+  i: number
+): Promise<{ content: unknown; children: Block[]; end: number } | null> {
+  const run = readStructuredQuoteRun(lines, i)
+  if (!run) return null
+
+  const claimed = await resolveQuoteRun(
+    run,
+    async (md) => (await editor.tryParseMarkdownToBlocks(md)) as never[],
+    async (parsed) => serializeBlocks(editor, parsed as PartialBlock[])
+  )
+  if (!claimed) return null
+
+  return { content: claimed.content, children: claimed.children as Block[], end: run.end }
 }
 
 /**
@@ -777,6 +852,14 @@ async function blocksToMarkdownPreserving(
       await flushContentGroup()
       flushGap()
       segments.push({ type: 'content', text: await serializeToggle(editor, block) })
+    } else if (isStructuredQuote(block)) {
+      await flushContentGroup()
+      flushGap()
+      const quoted = await serializeQuote(editor, block)
+      segments.push({
+        type: 'content',
+        text: colorMarkers.length > 0 ? `${colorMarkers.join('\n')}\n${quoted}` : quoted
+      })
     } else if (isEmptyParagraph(block)) {
       if (contentGroup.length > 0) {
         const md = await serializeBlocks(editor, contentGroup as PartialBlock[])

--- a/apps/desktop/src/main/vault/__fixtures__/golden-vault/roundtrip-quotes.md
+++ b/apps/desktop/src/main/vault/__fixtures__/golden-vault/roundtrip-quotes.md
@@ -1,0 +1,31 @@
+---
+title: Blockquote round-trip corpus
+---
+
+> A flat quote stays one block
+
+> One
+>
+> Two
+
+> [!info]
+> One
+>
+> Two
+
+> [!note] Outer callout
+> Outer body text
+>
+> > [!warning] Inner callout
+> > Inner body text
+
+> Intro
+>
+> - one
+> - two
+
+> Intro
+>
+> ```ts
+> const x = 1
+> ```

--- a/apps/desktop/src/renderer/src/components/note/content-area/callout-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/callout-block.tsx
@@ -1,5 +1,11 @@
 import { createReactBlockSpec } from '@blocknote/react'
-import { calloutConfig, readCalloutRun, type CalloutRun } from '@memry/editor-schema/blocks'
+import {
+  calloutConfig,
+  readCalloutRun,
+  readStructuredQuoteRun,
+  type CalloutRun,
+  type QuoteRun
+} from '@memry/editor-schema/blocks'
 import { createFenceTracker } from '@memry/shared/markdown-fences'
 import {
   DropdownMenu,
@@ -186,10 +192,16 @@ export function getCalloutSlashMenuItem(
 export { serializeCalloutBlock } from '@memry/editor-schema/blocks'
 
 export type CalloutSegment = { kind: 'callout'; run: CalloutRun }
+/**
+ * A blockquote run whose inner structure BlockNote's flat quote block loses —
+ * claimed under the same byte-round-trip proof as a callout, and for the same
+ * reason: the bytes belong to whoever wrote the file (#1881).
+ */
+export type QuoteSegment = { kind: 'quote'; run: QuoteRun }
 export type MarkdownSegment = { kind: 'markdown'; text: string }
-export type ContentSegment = CalloutSegment | MarkdownSegment
+export type ContentSegment = CalloutSegment | QuoteSegment | MarkdownSegment
 
-export function splitMarkdownByCallouts(markdown: string): ContentSegment[] {
+export function splitMarkdownByBlockquoteRuns(markdown: string): ContentSegment[] {
   const lines = markdown.split('\n')
   const segments: ContentSegment[] = []
   const fence = createFenceTracker()
@@ -208,13 +220,22 @@ export function splitMarkdownByCallouts(markdown: string): ContentSegment[] {
     const atParagraphStart = i === 0 || lines[i - 1].trim() === ''
     const run = insideFence ? null : readCalloutRun(lines, i, atParagraphStart)
 
-    if (run) {
+    const quoteRun =
+      run || insideFence || !atParagraphStart ? null : readStructuredQuoteRun(lines, i)
+
+    const segment: CalloutSegment | QuoteSegment | null = run
+      ? { kind: 'callout', run }
+      : quoteRun
+        ? { kind: 'quote', run: quoteRun }
+        : null
+
+    if (segment) {
       flushMarkdown()
-      segments.push({ kind: 'callout', run })
-      for (let consumed = i + 1; consumed < run.end; consumed++) {
+      segments.push(segment)
+      for (let consumed = i + 1; consumed < segment.run.end; consumed++) {
         fence.consume(lines[consumed])
       }
-      i = run.end
+      i = segment.run.end
     } else {
       mdLines.push(lines[i])
       i++

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
@@ -34,9 +34,11 @@ import {
   restoreBlockNesting,
   splitMarkdownByBlockNestingMarkers
 } from '@memry/shared/block-nesting'
-import { splitMarkdownByCallouts, serializeCalloutBlock } from './callout-block'
+import { splitMarkdownByBlockquoteRuns, serializeCalloutBlock } from './callout-block'
 import {
   resolveCalloutRun,
+  resolveQuoteRun,
+  serializeQuoteBlock,
   serializeToggleBlock,
   splitMarkdownByToggles,
   type ToggleBlockSegment
@@ -188,6 +190,24 @@ async function serializeToggle(editor: any, block: Block): Promise<string> {
   return serializeToggleBlock(summary, body, colorsMarker, isOpen === true)
 }
 
+function isStructuredQuote(block: Block): boolean {
+  return (block.type as string) === 'quote' && ((block.children ?? []) as Block[]).length > 0
+}
+
+/**
+ * A quote block that owns children writes them INSIDE the blockquote, one `> `
+ * per line and a bare `>` per gap — the bytes `readStructuredQuoteRun` reads
+ * back. BlockNote's own serializer puts children AFTER the quote (`> A\n\nB`),
+ * which is how a blank quote line and a nested callout were lost (#1881).
+ * Byte-identical to the main process's `serializeQuote`.
+ */
+async function serializeQuote(editor: any, block: Block): Promise<string> {
+  const own = { ...block, type: 'paragraph', props: {}, children: [] } as unknown as Block
+  const children = (block.children ?? []) as Block[]
+  const inner = await serializeBlocksPreservingBlanks(editor, [own, ...children])
+  return serializeQuoteBlock(inner.trim())
+}
+
 export function sanitizeBlockIds(blocks: Block[]): Block[] {
   let didChange = false
 
@@ -296,11 +316,30 @@ async function parseToggleSegment(editor: any, segment: ToggleBlockSegment): Pro
 }
 
 async function parseMarkdownWithoutToggles(editor: any, markdown: string): Promise<Block[]> {
-  const calloutSegments = splitMarkdownByCallouts(markdown)
+  const quotedSegments = splitMarkdownByBlockquoteRuns(markdown)
   const blocks: Block[] = []
 
-  for (const cseg of calloutSegments) {
-    if (cseg.kind === 'callout') {
+  for (const cseg of quotedSegments) {
+    if (cseg.kind === 'quote') {
+      const claimed = await resolveQuoteRun(
+        cseg.run,
+        async (md) => editor.tryParseMarkdownToBlocks(md),
+        async (parsed) => serializeBlocks(editor, parsed as Block[])
+      )
+      if (claimed) {
+        blocks.push({
+          type: 'quote' as const,
+          props: {},
+          content: claimed.content,
+          children: claimed.children
+        } as unknown as Block)
+      } else {
+        // Same rule as a declined callout: a run the byte-round-trip guard
+        // refuses is not ours to reshape, so its original lines parse as any
+        // other markdown would.
+        await parseMarkdownSegmentText(editor, cseg.run.raw, blocks)
+      }
+    } else if (cseg.kind === 'callout') {
       const claimed = await resolveCalloutRun(
         cseg.run,
         async (md) => editor.tryParseMarkdownToBlocks(md),
@@ -446,6 +485,14 @@ export async function serializeBlocksPreservingBlanks(
       await flushContent()
       flushGap()
       segments.push({ type: 'content', text: await serializeToggle(editor, block) })
+    } else if (isStructuredQuote(block)) {
+      await flushContent()
+      flushGap()
+      const quoted = await serializeQuote(editor, block)
+      segments.push({
+        type: 'content',
+        text: colorMarkers.length > 0 ? `${colorMarkers.join('\n')}\n${quoted}` : quoted
+      })
     } else if (isEmptyParagraph(block)) {
       await flushContent()
       emptyCount++

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -147,6 +147,27 @@ Common markdown shortcuts work inline:
 | `` `code` `` | `code`        |
 | ` ``` `      | Code block    |
 
+## Quotes
+
+A quote can hold more than one paragraph. A blank quote line separates them, and a quote
+indented inside another one stays nested:
+
+```md
+> [!note] Outer callout
+> Outer body text
+>
+> > [!warning] Inner callout
+> > Inner body text
+```
+
+Both survive a save, byte for byte. A note written in Obsidian with multi-paragraph or
+nested quotes opens here and is written back exactly as its author wrote it, so the two
+apps can edit the same vault without either one reflowing the other's quotes.
+
+One shape is still flattened: a nested quote written without the blank line between the
+levels (`> Outer` directly above `> > Inner`) is read as a single quote and saved that
+way.
+
 ## Title
 
 The title is editable inline at the top of the editor. Renames are live — the title updates in tabs, the sidebar, search, and any inbound wiki links.

--- a/packages/editor-schema/src/blocks/markdown.test.ts
+++ b/packages/editor-schema/src/blocks/markdown.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { serializeToggleBlock, splitMarkdownByToggles } from './markdown'
+import {
+  readStructuredQuoteRun,
+  serializeQuoteBlock,
+  serializeToggleBlock,
+  splitMarkdownByToggles
+} from './markdown'
 
 describe('serializeToggleBlock', () => {
   it('wraps the body in blank lines so renderers format it as markdown', () => {
@@ -209,5 +214,52 @@ describe('splitMarkdownByToggles', () => {
     expect(splitMarkdownByToggles(serializeToggleBlock('Docs', body))).toEqual([
       { kind: 'toggle', summary: 'Docs', body, open: false, colorsMarker: null }
     ])
+  })
+})
+
+describe('readStructuredQuoteRun', () => {
+  const read = (markdown: string): ReturnType<typeof readStructuredQuoteRun> =>
+    readStructuredQuoteRun(markdown.split('\n'), 0)
+
+  it('strips one level off a run separated by a bare `>`', () => {
+    expect(read('> One\n>\n> Two')).toEqual({
+      innerMarkdown: 'One\n\nTwo',
+      raw: '> One\n>\n> Two',
+      end: 3
+    })
+  })
+
+  it('strips one level off a nested run, leaving the inner `>` in place', () => {
+    expect(read('> Outer\n>\n> > Inner')?.innerMarkdown).toBe('Outer\n\n> Inner')
+  })
+
+  it('declines a flat run, which BlockNote already round-trips', () => {
+    expect(read('> One\n> Two')).toBeNull()
+  })
+
+  it('declines a line that is not a quote at all', () => {
+    expect(read('Just text')).toBeNull()
+  })
+
+  it('refuses the whole run on a `>text` line rather than tearing it in two', () => {
+    expect(read('> One\n>\n>Two')).toBeNull()
+  })
+
+  it('stops at the first line outside the quote', () => {
+    expect(read('> One\n>\n> Two\n\nAfter')?.end).toBe(3)
+  })
+})
+
+describe('serializeQuoteBlock', () => {
+  it('inverts the strip, writing a bare `>` for each blank line', () => {
+    expect(serializeQuoteBlock('One\n\nTwo')).toBe('> One\n>\n> Two')
+  })
+
+  it('round-trips every run its reader claims', () => {
+    for (const raw of ['> One\n>\n> Two', '> Outer\n>\n> > Inner', '> A\n>\n> - one\n> - two']) {
+      const run = readStructuredQuoteRun(raw.split('\n'), 0)
+      expect(run).not.toBeNull()
+      expect(serializeQuoteBlock(run!.innerMarkdown)).toBe(raw)
+    }
   })
 })

--- a/packages/editor-schema/src/blocks/markdown.ts
+++ b/packages/editor-schema/src/blocks/markdown.ts
@@ -153,6 +153,103 @@ export async function resolveCalloutRun(
 }
 
 // ---------------------------------------------------------------------------
+// quote — a blockquote run whose inner structure BlockNote's flat `quote` block
+// cannot hold on its own
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-quote inner markdown: one `> ` per line, a bare `>` for each blank line
+ * separating the quote's own blocks. The exact inverse of the one-level strip
+ * `readStructuredQuoteRun` performs.
+ */
+export function serializeQuoteBlock(innerMarkdown: string): string {
+  return innerMarkdown
+    .split('\n')
+    .map((line) => (line === '' ? '>' : `> ${line}`))
+    .join('\n')
+}
+
+export interface QuoteRun {
+  /** The run's lines with one `>` level stripped. */
+  innerMarkdown: string
+  /** The run's original lines, verbatim, for fallback parsing on decline. */
+  raw: string
+  /** Index of the first line after the run. */
+  end: number
+}
+
+/**
+ * Read a blockquote run at `lines[start]` whose inner structure BlockNote
+ * cannot hold flat, or null to leave the bytes on the path they are on today.
+ *
+ * BlockNote parses a whole blockquote into ONE block of inline content, so a
+ * blank `>` separator and a `> >` nesting level are gone before serialization
+ * ever runs: `> A\n>\n> B` comes back as `> A\n> B` and a nested callout comes
+ * back unnested (#1881). Those two are exactly the shapes claimed here. A run
+ * with neither is already flat and stays on the untouched path, so no quote
+ * that round-trips today changes.
+ *
+ * Strict on the prefix: only `>` alone and `> …` are read. A `>text` line —
+ * valid CommonMark, never bytes Memry writes — refuses the whole run rather
+ * than ending it early, which would tear one blockquote into two.
+ */
+export function readStructuredQuoteRun(lines: readonly string[], start: number): QuoteRun | null {
+  if (!lines[start]?.startsWith('>')) return null
+
+  const inner: string[] = []
+  let end = start
+  let structured = false
+
+  while (end < lines.length && lines[end].startsWith('>')) {
+    const line = lines[end]
+    if (line === '>') {
+      inner.push('')
+      structured = true
+    } else if (line.startsWith('> ')) {
+      const stripped = line.slice(2)
+      inner.push(stripped)
+      if (stripped.startsWith('>')) structured = true
+    } else {
+      return null
+    }
+    end++
+  }
+
+  if (!structured) return null
+  return { innerMarkdown: inner.join('\n'), raw: lines.slice(start, end).join('\n'), end }
+}
+
+/**
+ * Decide whether a run may become a quote block that owns children, by proof
+ * rather than by pattern — the same rule `resolveCalloutRun` applies: parse the
+ * stripped inner markdown, and claim only if re-serializing and re-quoting it
+ * reproduces the run byte-for-byte. Anything the schema would normalize
+ * declines and the caller leaves the bytes exactly as they were. A lazily
+ * continued `> A\n> > B` is one such run: its inner blocks only come back
+ * through a blank separator the author never wrote.
+ *
+ * The first inner block becomes the quote's own content and the rest its
+ * children, which is the list `serializeQuoteBlock` is handed on the way out.
+ */
+export async function resolveQuoteRun(
+  run: QuoteRun,
+  parseMarkdown: (markdown: string) => Promise<ParsedBlockShape[]>,
+  serializeBlocks: (blocks: ParsedBlockShape[]) => Promise<string>
+): Promise<{ content: unknown; children: ParsedBlockShape[] } | null> {
+  const parsed = await parseMarkdown(run.innerMarkdown)
+  const [first, ...children] = parsed
+  if (!first || first.type !== 'paragraph' || first.children?.length) return null
+  // No children means a flat quote, which the untouched path already serializes
+  // correctly — claiming it would only route identical bytes through more code.
+  if (children.length === 0) return null
+
+  const roundTripped = (await serializeBlocks(parsed)).trim()
+  if (serializeQuoteBlock(roundTripped) !== run.raw) return null
+
+  return { content: first.content ?? [], children }
+}
+
+// ---------------------------------------------------------------------------
 // youtubeEmbed / bookmark — an image embed whose alt text names the block
 // ---------------------------------------------------------------------------
 

--- a/packages/editor-schema/src/conformance.ts
+++ b/packages/editor-schema/src/conformance.ts
@@ -138,6 +138,29 @@ const calloutCases: RoundtripCase[] = [
     markdown:
       '> [!note] Outer callout\n> Outer body text\n>\n> > [!warning] Inner callout\n> > Inner body text',
     pending: { renderer: 1881, main: 1881 }
+  },
+  {
+    name: 'plain quote with a blank separator line',
+    markdown: '> One\n>\n> Two',
+    pending: { renderer: 1881, main: 1881 }
+  },
+  {
+    name: 'quote with a fenced code block after a blank line',
+    markdown: '> Intro\n>\n> ```ts\n> const x = 1\n> ```',
+    pending: { renderer: 1881, main: 1881 }
+  },
+  {
+    name: 'quote with a list after a blank line',
+    markdown: '> Intro\n>\n> - one\n> - two',
+    pending: { renderer: 1881, main: 1881 }
+  },
+  {
+    // Lazy continuation: the inner blocks only come back through a blank
+    // separator the author never wrote, so the claim declines by proof and the
+    // run stays on BlockNote's flat quote path.
+    name: 'lazily continued nested quote keeps its flat bytes',
+    markdown: '> Outer\n> > Inner',
+    pending: { renderer: 1881, main: 1881 }
   }
 ]
 

--- a/packages/editor-schema/src/conformance.ts
+++ b/packages/editor-schema/src/conformance.ts
@@ -127,32 +127,28 @@ const calloutCases: RoundtripCase[] = [
     markdown: '> [!info] Title here\n> Body'
   },
   {
-    // #1875 declines blank-`>`-line shapes from the callout claim; the quote
-    // path then collapses the blank line — generic blockquote behavior (#1881).
+    // #1875 declines blank-`>`-line shapes from the callout claim, so the run
+    // stays a blockquote; #1881 is what makes that blockquote keep its blank
+    // separator instead of collapsing to `> [!info]\n> One\n> Two`.
     name: 'callout with a multi-paragraph body',
-    markdown: '> [!info]\n> One\n>\n> Two',
-    pending: { renderer: 1881, main: 1881 }
+    markdown: '> [!info]\n> One\n>\n> Two'
   },
   {
     name: 'nested foreign callouts pass through untouched',
     markdown:
-      '> [!note] Outer callout\n> Outer body text\n>\n> > [!warning] Inner callout\n> > Inner body text',
-    pending: { renderer: 1881, main: 1881 }
+      '> [!note] Outer callout\n> Outer body text\n>\n> > [!warning] Inner callout\n> > Inner body text'
   },
   {
     name: 'plain quote with a blank separator line',
-    markdown: '> One\n>\n> Two',
-    pending: { renderer: 1881, main: 1881 }
+    markdown: '> One\n>\n> Two'
   },
   {
     name: 'quote with a fenced code block after a blank line',
-    markdown: '> Intro\n>\n> ```ts\n> const x = 1\n> ```',
-    pending: { renderer: 1881, main: 1881 }
+    markdown: '> Intro\n>\n> ```ts\n> const x = 1\n> ```'
   },
   {
     name: 'quote with a list after a blank line',
-    markdown: '> Intro\n>\n> - one\n> - two',
-    pending: { renderer: 1881, main: 1881 }
+    markdown: '> Intro\n>\n> - one\n> - two'
   },
   {
     // Lazy continuation: the inner blocks only come back through a blank


### PR DESCRIPTION
## Summary

A blockquote's own structure never survived a save. `> A\n>\n> B` came back as `> A\n> B`, and a nested `> > [!warning]` callout came back unnested. On an Obsidian vault that is a rewrite of a file Memry never wrote (#1881, and the byte-compat guarantee #1846 exists to protect). #1875 deliberately declined these shapes from the callout claim, which left them on the generic quote path where the damage happens.

Serialization was never the culprit. BlockNote parses a whole blockquote into ONE block of inline content, so the blank `>` separator and the `> >` level are gone before serialization runs. Measured: `> [!info]\n> One\n>\n> Two` parses to `text: "[!info]\nOne\nTwo\n"`. BlockNote's quote block cannot hold the structure either, since its children serialize *outside* the quote (`> A\n\nB`) and a `\n\n` in content becomes backslash hard breaks. So the fix is at the parse seam, not the serializer.

A blockquote run carrying a blank `>` separator or a `> >` level is now claimed whole. One `>` level comes off, the inside parses as ordinary markdown, and the first block becomes the quote's content with the rest as its children. `serializeQuote` writes that list back inside the blockquote, one `> ` per line and a bare `>` per gap.

The claim is proven, not pattern-matched, the same rule `resolveCalloutRun` already applies: re-serializing the parse must reproduce the run byte-for-byte, or the run is left exactly where it was. A run with neither shape is already flat and never enters this path, so no quote that round-trips today changes.

Reviewer notes:

- **No new node type.** `quote` and `paragraph` only, so a doc written by this build still opens on an older install rather than hitting y-prosemirror's delete-unknown-node repair.
- Both pipelines share the seam. `splitMarkdownByCallouts` is now `splitMarkdownByBlockquoteRuns` and emits quote runs alongside callout runs; the main process claims in its existing line loop.
- **#1881 stays open.** A lazily continued `> Outer\n> > Inner` (no blank line between the levels) only comes back through a separator the author never wrote, so it declines on the byte proof and keeps today's flat behavior. It is pinned as a new pending corpus case rather than left undocumented.
- First commit adds the failing shapes to the corpus as `pending` cases; the second lands the fix and removes the flags. Each commit is green on its own.

## Release note

Quotes with more than one paragraph, and quotes nested inside other quotes, now survive a save instead of being flattened. Notes written in Obsidian with these shapes are written back byte for byte.

## Test plan

- `vitest --project main src/main/sync/blocknote-converter.roundtrip.test.ts` — 59 passed, 3 expected fail (the remaining pending cases: #1881 lazy continuation, #1883, #1877)
- `vitest --project renderer src/renderer/src/components/note/content-area/roundtrip-conformance.test.ts` — 51 passed, 5 expected fail
- New golden fixture `roundtrip-quotes.md` round-trips byte-identical through the converter
- New unit tests for `readStructuredQuoteRun` / `serializeQuoteBlock` covering the decline rules (flat run, `>text` line, non-quote line)
- Full desktop suites: `10206 passed | 4 expected fail` (main + shared), `8524 passed | 5 expected fail` (renderer)
- `tsc --noEmit` on `tsconfig.node.json` and `tsconfig.web.json`, eslint and prettier clean on touched files
- `pnpm docs:impact --base <base> --strict` covered, `pnpm docs:build` passes
- Rebased onto current `main` and re-run against its new `raw-html-roundtrip.probe.test.ts` suite