### PR TITLE
fix(properties): stop dropping and duplicating property options

### DIFF
--- a/apps/desktop/src/main/ipc/notes-handlers.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.ts
@@ -696,20 +696,11 @@ export function registerNotesHandlers(): void {
         option: z.object({ value: z.string().min(1), color: z.string().min(1) })
       }),
       async (input) => {
-        const { PropertyDefinitionsService, DEFAULT_STATUS_DEFINITION } =
-          await import('../vault/property-definitions')
+        const { PropertyDefinitionsService } = await import('../vault/property-definitions')
         const service = PropertyDefinitionsService.get()
-        const existing = service.get(input.propertyName)
-        if (!existing) {
-          const def = {
-            ...DEFAULT_STATUS_DEFINITION,
-            name: input.propertyName
-          }
-          await service.upsert(def)
-          await service.addStatusOption(input.propertyName, input.categoryKey, input.option)
-        } else {
-          await service.addStatusOption(input.propertyName, input.categoryKey, input.option)
-        }
+        // The service materializes a missing status definition itself, so the
+        // pre-upsert this used to do only cost a second write of the same file.
+        await service.addStatusOption(input.propertyName, input.categoryKey, input.option)
         return { success: true }
       }
     )

--- a/apps/desktop/src/main/vault/property-definitions.test.ts
+++ b/apps/desktop/src/main/vault/property-definitions.test.ts
@@ -238,11 +238,10 @@ describe('PropertyDefinitionsService', () => {
     expect(service.getAll()).toEqual([])
   })
 
-  it('mutates select and status options without touching missing definitions', async () => {
+  it('mutates select and status options', async () => {
     const service = PropertyDefinitionsService.init('/vault')
     const newOption: SelectOption = { value: 'Review', color: 'violet' }
 
-    await service.addOption('missing', newOption)
     await service.upsert({
       name: 'Stage',
       type: 'select',
@@ -264,7 +263,6 @@ describe('PropertyDefinitionsService', () => {
     await service.renameOption('Status', 'Backlog', 'Queued')
     await service.updateOptionColor('Status', 'Queued', 'blue')
     await service.removeOption('Status', 'Working')
-    await service.addStatusOption('Status', 'missing', { value: 'Ignored', color: 'red' })
 
     expect(service.get('Status')).toMatchObject({
       categories: {
@@ -386,5 +384,157 @@ describe('PropertyDefinitionsService — showOnCalendar', () => {
     safeReadMock.mockResolvedValueOnce(writtenContent)
     await svc.reload()
     expect(svc.listCalendarEnabledNames()).toEqual(['Published'])
+  })
+})
+
+describe('PropertyDefinitionsService — option writes never vanish', () => {
+  let dataDb: ReturnType<typeof createDbMock>
+  let indexDb: ReturnType<typeof createDbMock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    PropertyDefinitionsService.destroy()
+    dataDb = createDbMock()
+    indexDb = createDbMock()
+    getMemryDirMock.mockReturnValue('/vault/.memry')
+    getDatabaseMock.mockReturnValue(dataDb.db)
+    getIndexDatabaseMock.mockReturnValue(indexDb.db)
+    safeReadMock.mockResolvedValue(null)
+    atomicWriteMock.mockResolvedValue(undefined)
+  })
+
+  // notes:create-property-definition sends exactly this shape for a status
+  // property: no `categories`. js-yaml refuses to dump `undefined`, so the
+  // write threw, the cache kept the unserializable definition, and every later
+  // addStatusOption saw `!def.categories` and returned silently.
+  it('persists a status definition created without categories', async () => {
+    const service = PropertyDefinitionsService.init('/vault')
+
+    await service.upsert({ name: 'Workflow', type: 'status' })
+
+    expect(service.get('Workflow')?.categories).toEqual(DEFAULT_STATUS_DEFINITION.categories)
+    expect(atomicWriteMock).toHaveBeenCalledWith(
+      '/vault/.memry/properties.md',
+      expect.stringContaining('Not started')
+    )
+  })
+
+  it('round-trips a status definition created without categories through properties.md', async () => {
+    const service = PropertyDefinitionsService.init('/vault')
+    await service.upsert({ name: 'Workflow', type: 'status' })
+
+    const written = atomicWriteMock.mock.calls.at(-1)![1] as string
+    safeReadMock.mockResolvedValueOnce(written)
+
+    const reloaded = PropertyDefinitionsService.init('/vault')
+    await reloaded.reload()
+
+    expect(reloaded.get('Workflow')?.categories).toEqual(DEFAULT_STATUS_DEFINITION.categories)
+  })
+
+  it('keeps persisting unrelated definitions after a status property is created', async () => {
+    const service = PropertyDefinitionsService.init('/vault')
+    await service.upsert({
+      name: 'Stage',
+      type: 'select',
+      options: [{ value: 'Idea', color: 'sky' }]
+    })
+    await service.upsert({ name: 'Workflow', type: 'status' })
+
+    await service.upsert({
+      name: 'Area',
+      type: 'select',
+      options: [{ value: 'Ops', color: 'sky' }]
+    })
+
+    expect(atomicWriteMock.mock.calls.at(-1)![1] as string).toContain('Ops')
+  })
+
+  it('serializes a select definition that carries no options', async () => {
+    const service = PropertyDefinitionsService.init('/vault')
+
+    await service.upsert({ name: 'Stage', type: 'select' })
+
+    expect(atomicWriteMock).toHaveBeenCalledWith(
+      '/vault/.memry/properties.md',
+      expect.stringContaining('type: select')
+    )
+  })
+
+  it('adds a status option to a property that has no persisted definition', async () => {
+    const service = PropertyDefinitionsService.init('/vault')
+
+    await service.addStatusOption('Status', 'in_progress', { value: 'Blocked', color: 'amber' })
+
+    expect(service.get('Status')?.categories?.in_progress.options).toEqual([
+      { value: 'In Progress', color: 'amber' },
+      { value: 'Blocked', color: 'amber' }
+    ])
+    expect(atomicWriteMock.mock.calls.at(-1)![1] as string).toContain('Blocked')
+  })
+
+  it('adds a status option to a definition stored without categories', async () => {
+    const service = PropertyDefinitionsService.init('/vault')
+    await service.upsert({ name: 'Workflow', type: 'status' })
+
+    await service.addStatusOption('Workflow', 'todo', { value: 'Blocked', color: 'amber' })
+
+    expect(service.get('Workflow')?.categories?.todo.options).toEqual([
+      { value: 'Not started', color: 'stone', default: true },
+      { value: 'Blocked', color: 'amber' }
+    ])
+  })
+
+  it('keeps one entry when the same status option value is added twice', async () => {
+    const service = PropertyDefinitionsService.init('/vault')
+    await service.upsert({ name: 'Status', type: 'status', categories: statusCategories() })
+
+    await service.addStatusOption('Status', 'in_progress', { value: 'Blocked', color: 'amber' })
+    await service.addStatusOption('Status', 'in_progress', { value: 'Blocked', color: 'rose' })
+
+    expect(service.get('Status')?.categories?.in_progress.options).toEqual([
+      { value: 'Working', color: 'amber' },
+      { value: 'Blocked', color: 'amber' }
+    ])
+  })
+
+  it('keeps one entry when the same select option value is added twice', async () => {
+    const service = PropertyDefinitionsService.init('/vault')
+    await service.upsert({ name: 'Stage', type: 'select', options: [] })
+
+    await service.addOption('Stage', { value: 'Idea', color: 'sky' })
+    await service.addOption('Stage', { value: 'Idea', color: 'rose' })
+
+    expect(service.get('Stage')?.options).toEqual([{ value: 'Idea', color: 'sky' }])
+  })
+
+  it('rejects an option mutation against a definition that does not exist', async () => {
+    const service = PropertyDefinitionsService.init('/vault')
+
+    await expect(
+      service.addOption('missing', { value: 'Review', color: 'violet' })
+    ).rejects.toThrow(/missing/)
+    await expect(service.removeOption('missing', 'Review')).rejects.toThrow(/missing/)
+    await expect(service.renameOption('missing', 'Review', 'Done')).rejects.toThrow(/missing/)
+    await expect(service.updateOptionColor('missing', 'Review', 'sky')).rejects.toThrow(/missing/)
+    expect(atomicWriteMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a status option added to a definition of another type', async () => {
+    const service = PropertyDefinitionsService.init('/vault')
+    await service.upsert({ name: 'Status', type: 'select', options: [] })
+
+    await expect(
+      service.addStatusOption('Status', 'todo', { value: 'Blocked', color: 'amber' })
+    ).rejects.toThrow(/Status/)
+  })
+
+  it('rejects a status option added to an unknown category', async () => {
+    const service = PropertyDefinitionsService.init('/vault')
+    await service.upsert({ name: 'Status', type: 'status', categories: statusCategories() })
+
+    await expect(
+      service.addStatusOption('Status', 'nope', { value: 'Blocked', color: 'amber' })
+    ).rejects.toThrow(/nope/)
   })
 })

--- a/apps/desktop/src/main/vault/property-definitions.ts
+++ b/apps/desktop/src/main/vault/property-definitions.ts
@@ -83,8 +83,9 @@ export class PropertyDefinitionsService {
   }
 
   async upsert(definition: PropertyDefinition): Promise<void> {
+    const normalized = normalizeDefinition(definition)
     await this.enqueueWrite(async () => {
-      this.cache.set(definition.name, definition)
+      this.cache.set(normalized.name, normalized)
       await this.persistToFile()
       this.rebuildDbCache()
     })
@@ -121,24 +122,21 @@ export class PropertyDefinitionsService {
   }
 
   async renameOption(propertyName: string, oldValue: string, newValue: string): Promise<void> {
-    const def = this.cache.get(propertyName)
-    if (!def) return
+    const def = this.requireDefinition(propertyName)
 
     const updated = renameOptionInDefinition(def, oldValue, newValue)
     await this.upsert(updated)
   }
 
   async addOption(propertyName: string, option: SelectOption): Promise<void> {
-    const def = this.cache.get(propertyName)
-    if (!def) return
+    const def = this.requireDefinition(propertyName)
 
     const updated = addOptionToDefinition(def, option)
     await this.upsert(updated)
   }
 
   async removeOption(propertyName: string, optionValue: string): Promise<void> {
-    const def = this.cache.get(propertyName)
-    if (!def) return
+    const def = this.requireDefinition(propertyName)
 
     if (def.type === 'status' && def.categories) {
       const categories = { ...def.categories }
@@ -162,8 +160,7 @@ export class PropertyDefinitionsService {
     optionValue: string,
     newColor: string
   ): Promise<void> {
-    const def = this.cache.get(propertyName)
-    if (!def) return
+    const def = this.requireDefinition(propertyName)
 
     const updateColor = (o: SelectOption) =>
       o.value === optionValue ? { ...o, color: newColor } : o
@@ -191,15 +188,30 @@ export class PropertyDefinitionsService {
     option: SelectOption
   ): Promise<void> {
     const def = this.cache.get(propertyName)
-    if (!def || def.type !== 'status' || !def.categories) return
+    if (def && def.type !== 'status') {
+      throw new Error(`Property "${propertyName}" is not a status property`)
+    }
 
-    const category = def.categories[categoryKey as keyof StatusCategories]
-    if (!category) return
+    // The picker shows DEFAULT_STATUS_DEFINITION's categories for a status
+    // property that has none persisted, so materialize what the user is looking
+    // at instead of dropping the write.
+    const categories = def?.categories ?? DEFAULT_STATUS_DEFINITION.categories
+    const category = categories[categoryKey as keyof StatusCategories]
+    if (!category) {
+      throw new Error(`Unknown status category "${categoryKey}"`)
+    }
+
+    if (category.options.some((o) => o.value === option.value)) {
+      logger.debug('Status option already exists, skipping', propertyName, option.value)
+      return
+    }
 
     const updated: PropertyDefinition = {
+      name: propertyName,
+      type: 'status',
       ...def,
       categories: {
-        ...def.categories,
+        ...categories,
         [categoryKey]: {
           ...category,
           options: [...category.options, option]
@@ -207,6 +219,14 @@ export class PropertyDefinitionsService {
       }
     }
     await this.upsert(updated)
+  }
+
+  private requireDefinition(propertyName: string): PropertyDefinition {
+    const def = this.cache.get(propertyName)
+    if (!def) {
+      throw new Error(`No property definition named "${propertyName}"`)
+    }
+    return def
   }
 
   private applyParsedData(data: PropertyDefinitionsFileData): void {
@@ -228,14 +248,19 @@ export class PropertyDefinitionsService {
     const properties: Record<string, unknown> = {}
 
     for (const [name, def] of this.cache) {
+      // js-yaml refuses to dump `undefined`, and one such value fails the write
+      // for every property in the file, not just its own.
       if (def.type === 'status') {
-        properties[name] = { type: 'status', categories: def.categories }
+        properties[name] = {
+          type: 'status',
+          categories: def.categories ?? DEFAULT_STATUS_DEFINITION.categories
+        }
       } else if (def.type === 'date') {
-        properties[name] = { type: 'date', showOnCalendar: def.showOnCalendar }
+        properties[name] = { type: 'date', showOnCalendar: def.showOnCalendar ?? false }
       } else if (def.type === 'project') {
         properties[name] = { type: 'project' }
       } else {
-        properties[name] = { type: def.type, options: def.options }
+        properties[name] = { type: def.type, options: def.options ?? [] }
       }
     }
 
@@ -329,10 +354,24 @@ function renameOptionInDefinition(
 }
 
 function addOptionToDefinition(def: PropertyDefinition, option: SelectOption): PropertyDefinition {
+  const options = def.options ?? []
+  if (options.some((o) => o.value === option.value)) return def
+
   return {
     ...def,
-    options: [...(def.options ?? []), option]
+    options: [...options, option]
   }
+}
+
+/**
+ * A `status` definition with no categories cannot be serialized, so a write
+ * carrying one threw and left the cache holding a definition that every later
+ * status write skipped. The cache never holds one.
+ */
+function normalizeDefinition(definition: PropertyDefinition): PropertyDefinition {
+  if (definition.type !== 'status' || definition.categories) return definition
+
+  return { ...definition, categories: DEFAULT_STATUS_DEFINITION.categories }
 }
 
 export { DEFAULT_STATUS_DEFINITION }

--- a/apps/desktop/src/main/vault/property-definitions.ts
+++ b/apps/desktop/src/main/vault/property-definitions.ts
@@ -10,6 +10,7 @@ import {
   type PropertyDefinitionsFileData,
   type SelectOption,
   type StatusCategories,
+  DEFAULT_STATUS_CATEGORIES,
   DEFAULT_STATUS_DEFINITION
 } from '@memry/contracts/property-types'
 import { propertyDefinitions as propertyDefinitionsTable } from '@memry/db-schema/schema/notes-cache'
@@ -192,10 +193,10 @@ export class PropertyDefinitionsService {
       throw new Error(`Property "${propertyName}" is not a status property`)
     }
 
-    // The picker shows DEFAULT_STATUS_DEFINITION's categories for a status
-    // property that has none persisted, so materialize what the user is looking
-    // at instead of dropping the write.
-    const categories = def?.categories ?? DEFAULT_STATUS_DEFINITION.categories
+    // The picker shows the default categories for a status property that has
+    // none persisted, so materialize what the user is looking at instead of
+    // dropping the write.
+    const categories = def?.categories ?? DEFAULT_STATUS_CATEGORIES
     const category = categories[categoryKey as keyof StatusCategories]
     if (!category) {
       throw new Error(`Unknown status category "${categoryKey}"`)
@@ -253,7 +254,7 @@ export class PropertyDefinitionsService {
       if (def.type === 'status') {
         properties[name] = {
           type: 'status',
-          categories: def.categories ?? DEFAULT_STATUS_DEFINITION.categories
+          categories: def.categories ?? DEFAULT_STATUS_CATEGORIES
         }
       } else if (def.type === 'date') {
         properties[name] = { type: 'date', showOnCalendar: def.showOnCalendar ?? false }
@@ -371,7 +372,7 @@ function addOptionToDefinition(def: PropertyDefinition, option: SelectOption): P
 function normalizeDefinition(definition: PropertyDefinition): PropertyDefinition {
   if (definition.type !== 'status' || definition.categories) return definition
 
-  return { ...definition, categories: DEFAULT_STATUS_DEFINITION.categories }
+  return { ...definition, categories: DEFAULT_STATUS_CATEGORIES }
 }
 
 export { DEFAULT_STATUS_DEFINITION }

--- a/apps/desktop/src/renderer/src/components/note/info-section/PropertyRow.tsx
+++ b/apps/desktop/src/renderer/src/components/note/info-section/PropertyRow.tsx
@@ -39,6 +39,8 @@ import {
   type StatusCategories,
   type StatusCategoryKey
 } from '@memry/contracts/property-types'
+import { toast } from 'sonner'
+import { extractErrorMessage } from '@/lib/ipc-error'
 import { useT } from '@memry/i18n/renderer'
 import { useCalendarProperties } from '@/hooks/use-calendar-properties'
 import { getEventBaseColor } from '@/lib/event-type-colors'
@@ -160,6 +162,7 @@ function SelectPropertyRenderer({
   onValueChange: (value: unknown) => void
 }) {
   const { getDefinition, refresh } = usePropertyDefinitions()
+  const { t } = useT('settings')
   const definition = getDefinition(property.name)
 
   const options: SelectOption[] = useMemo(() => {
@@ -188,28 +191,40 @@ function SelectPropertyRenderer({
   const handleAddOption = useCallback(
     async (option: SelectOption) => {
       const { notesService } = await import('@/services/notes-service')
-      await notesService.addPropertyOption(property.name, option)
+      try {
+        await notesService.addPropertyOption(property.name, option)
+      } catch (err) {
+        toast.error(extractErrorMessage(err, t('properties.toasts.addFailed')))
+      }
       await refresh()
     },
-    [property.name, refresh]
+    [property.name, refresh, t]
   )
 
   const handleAddStatusOption = useCallback(
     async (categoryKey: StatusCategoryKey, option: SelectOption) => {
       const { notesService } = await import('@/services/notes-service')
-      await notesService.addStatusOption(property.name, categoryKey, option)
+      try {
+        await notesService.addStatusOption(property.name, categoryKey, option)
+      } catch (err) {
+        toast.error(extractErrorMessage(err, t('properties.toasts.addFailed')))
+      }
       await refresh()
     },
-    [property.name, refresh]
+    [property.name, refresh, t]
   )
 
   const handleRemoveOption = useCallback(
     async (optionValue: string) => {
       const { notesService } = await import('@/services/notes-service')
-      await notesService.removePropertyOption(property.name, optionValue)
+      try {
+        await notesService.removePropertyOption(property.name, optionValue)
+      } catch (err) {
+        toast.error(extractErrorMessage(err, t('properties.toasts.removeFailed')))
+      }
       await refresh()
     },
-    [property.name, refresh]
+    [property.name, refresh, t]
   )
 
   if (property.type === 'status' && categories) {

--- a/apps/desktop/tests/e2e/property-status-options.e2e.ts
+++ b/apps/desktop/tests/e2e/property-status-options.e2e.ts
@@ -1,0 +1,133 @@
+/**
+ * Status property option persistence.
+ *
+ * A status option the user types into the picker has to reach
+ * `.memry/properties.md` and come back exactly once. Two regressions this
+ * guards. A status definition created with `categories: undefined` made js-yaml
+ * refuse the dump, so the write threw while the main-process cache kept the
+ * broken definition and every later "add status option" silently did nothing.
+ * And the append had no dedupe on `option.value`, so adding the same name twice
+ * left two entries in the category.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+import type { Locator, Page } from '@playwright/test'
+
+import { test, expect } from './fixtures'
+import { seedNote, waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
+import { openNoteByHandle } from './utils/note-sync-helpers'
+import { waitForStable } from './utils/wait-helpers'
+
+const NEW_OPTION = 'Blocked'
+
+/** Label of the status category the new option is typed into. */
+const CATEGORY = 'In progress'
+
+/** Ships in every status definition, so it identifies the status picker's popover. */
+const DEFAULT_OPTION = 'Not started'
+
+function statusPicker(page: Page): Locator {
+  return page
+    .locator('[data-slot="picker-content"]')
+    .filter({ has: page.getByRole('option', { name: DEFAULT_OPTION, exact: true }) })
+    .first()
+}
+
+function optionsNamed(picker: Locator, value: string): Locator {
+  return picker.getByRole('option', { name: value, exact: true })
+}
+
+async function addStatusPropertyThroughUi(page: Page): Promise<Locator> {
+  await page.locator('.group\\/metadata').first().hover()
+
+  const addPropertyButton = page.getByRole('button', { name: 'Add property' }).first()
+  await expect(addPropertyButton).toBeVisible()
+  await addPropertyButton.click()
+
+  await page.getByRole('option', { name: 'Status', exact: true }).first().click()
+
+  const picker = statusPicker(page)
+  await expect(picker).toBeVisible()
+  return picker
+}
+
+async function reopenStatusPicker(page: Page): Promise<Locator> {
+  const propertyList = page.getByRole('list', { name: 'Properties list' }).first()
+  await expect(propertyList).toBeVisible()
+  await propertyList.locator('[aria-haspopup]').first().click()
+
+  const picker = statusPicker(page)
+  await expect(picker).toBeVisible()
+  return picker
+}
+
+async function typeNewOption(picker: Locator, value: string): Promise<void> {
+  const category = picker.locator('[data-slot="picker-section"]').filter({ hasText: CATEGORY })
+  await category.getByRole('button', { name: 'Add', exact: true }).click()
+
+  const input = picker.getByRole('textbox', { name: 'Option name' })
+  await expect(input).toBeVisible()
+  await input.fill(value)
+  await input.press('Enter')
+}
+
+function readDefinitionsFile(vaultPath: string): string {
+  const file = path.join(vaultPath, '.memry', 'properties.md')
+  return fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : ''
+}
+
+function countOccurrences(text: string, value: string): number {
+  return text.split(value).length - 1
+}
+
+test.describe('Status property options', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+  })
+
+  test('a status option added in the picker survives a reload exactly once', async ({
+    page,
+    testVaultPath
+  }) => {
+    const title = `Status Options ${Date.now()}`
+    const id = await seedNote(page, title)
+    await openNoteByHandle(page, { id, title })
+
+    const picker = await addStatusPropertyThroughUi(page)
+    await typeNewOption(picker, NEW_OPTION)
+    await expect(optionsNamed(picker, NEW_OPTION)).toHaveCount(1)
+
+    await page.reload()
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+    await openNoteByHandle(page, { id, title })
+
+    const reopened = await reopenStatusPicker(page)
+    await expect(optionsNamed(reopened, NEW_OPTION)).toHaveCount(1)
+    expect(countOccurrences(readDefinitionsFile(testVaultPath), NEW_OPTION)).toBe(1)
+  })
+
+  test('adding the same status option twice leaves one entry', async ({ page, testVaultPath }) => {
+    const title = `Status Options Idempotent ${Date.now()}`
+    const id = await seedNote(page, title)
+    await openNoteByHandle(page, { id, title })
+
+    const picker = await addStatusPropertyThroughUi(page)
+    await typeNewOption(picker, NEW_OPTION)
+    await expect(optionsNamed(picker, NEW_OPTION)).toHaveCount(1)
+
+    await typeNewOption(picker, NEW_OPTION)
+
+    // A duplicating append rewrites the file, so settling on unchanged bytes is
+    // what separates "the second add was dropped" from "it has not landed yet".
+    const settled = await waitForStable(async () => readDefinitionsFile(testVaultPath), {
+      stableFor: 2_000,
+      timeout: 20_000
+    })
+    expect(countOccurrences(settled, NEW_OPTION)).toBe(1)
+    await expect(optionsNamed(picker, NEW_OPTION)).toHaveCount(1)
+  })
+})

--- a/apps/docs/src/user-guide/notes/properties-tags.md
+++ b/apps/docs/src/user-guide/notes/properties-tags.md
@@ -96,6 +96,10 @@ Open [Settings → Properties](/user-guide/settings#properties) to create, renam
 
 A property definition is reused across every note that adopts it — adding a `Topics` multi-select once means every note has access to the same vocabulary.
 
+Option names are unique within a property. Adding an option whose name already exists keeps the existing one, including its color, rather than creating a second entry.
+
+A status property you have not customized yet shows the built-in `Todo` / `In progress` / `Done` set. The first option you add to it saves that set alongside your new option, so what the picker shows and what the vault stores stay the same.
+
 ### Adding a Property to a Note
 
 In the property panel, click **Add property** and pick from the list. Set the value inline.

--- a/packages/contracts/src/property-types.ts
+++ b/packages/contracts/src/property-types.ts
@@ -48,26 +48,28 @@ export interface PropertyDefinition {
   showOnCalendar?: boolean
 }
 
+export const DEFAULT_STATUS_CATEGORIES: StatusCategories = {
+  todo: {
+    label: 'To-do',
+    options: [{ value: 'Not started', color: 'stone', default: true }]
+  },
+  in_progress: {
+    label: 'In progress',
+    options: [{ value: 'In Progress', color: 'amber' }]
+  },
+  done: {
+    label: 'Complete',
+    options: [
+      { value: 'Done', color: 'emerald' },
+      { value: 'Abandoned', color: 'rose' }
+    ]
+  }
+}
+
 export const DEFAULT_STATUS_DEFINITION: PropertyDefinition = {
   name: 'status',
   type: PropertyTypes.STATUS,
-  categories: {
-    todo: {
-      label: 'To-do',
-      options: [{ value: 'Not started', color: 'stone', default: true }]
-    },
-    in_progress: {
-      label: 'In progress',
-      options: [{ value: 'In Progress', color: 'amber' }]
-    },
-    done: {
-      label: 'Complete',
-      options: [
-        { value: 'Done', color: 'emerald' },
-        { value: 'Abandoned', color: 'rose' }
-      ]
-    }
-  }
+  categories: DEFAULT_STATUS_CATEGORIES
 }
 
 const SelectOptionSchema = z.object({


### PR DESCRIPTION
Reported 2026-08-30 on v2026-08-25 Win32: properties "are not retaining added statuses but also duplicating them." Two separate defects behind one sentence.

## Statuses vanished

`notes:create-property-definition` sends `{ name, type: 'status' }` with no `categories` for a status property. `persistToFile` handed that straight to `matter.stringify`, and js-yaml refuses to dump `undefined`, so the write threw with `unacceptable kind of an object to dump [object Undefined]`. `upsert` had already mutated the cache, so the cache kept a status definition with no categories. From then on `addStatusOption` hit `!def.categories` and returned silently: every status the user added disappeared with no error, no log, and no toast. The blast radius was the whole vault, not one property, because one unserializable entry in the cache fails `persistToFile` for every property in the file, so no definition reached `.memry/properties.md` again for the rest of the session. Meanwhile `PropertyRow` renders `DEFAULT_STATUS_DEFINITION.categories` when a status property has no stored options, so the picker kept showing a healthy default set the vault never had.

`upsert` now normalizes a status definition to carry categories before anything caches or writes it, and `persistToFile` emits no `undefined` for any type (`options ?? []`, `showOnCalendar ?? false`).

## Duplicates

Both append sites concatenated without checking `option.value`, so adding the same name twice wrote two entries. Combined with the first defect the user loop was: add, see nothing, add again, get two. `addStatusOption` and `addOptionToDefinition` now skip a value that is already in the category or the option list.

## No more silent no-ops

A missing definition was a bare `return` in five methods. `addStatusOption` now materializes the default categories the picker is already showing, so what the user sees and what persists agree, and it throws on a real inconsistency (a non-status definition, an unknown category key). `addOption`, `removeOption`, `renameOption` and `updateOptionColor` throw instead of returning, and `PropertyRow`'s option handlers surface that through the usual `extractErrorMessage` toast rather than an unhandled rejection. The `ADD_STATUS_OPTION` handler's pre-upsert is gone; the service materializes in one write instead of two.

## Compatibility

No migration, and nothing to repair on disk. The persisted shape is unchanged for anything an older build could write. Every entry this newly emits is one whose write previously threw, so no existing file contains one: `PropertyDefinitionSchema` has always required `categories` on a status entry and `options` on a select entry, and a file that failed `safeParse` was discarded wholesale rather than half-read. The one shape drift is a `date` entry that omitted `showOnCalendar` now round-tripping as `showOnCalendar: false`, which `DatePropertySchema` accepts on old builds too (`z.boolean().optional()`) and which `listCalendarEnabledNames` already filters on `=== true`. The poisoned cache state was per-session and never reached disk, so an affected install recovers on the next launch.

## Verification

Main-process tests in `apps/desktop/src/main/vault/property-definitions.test.ts`, committed red before the fix (11 failed, 10 pre-existing passed) and green after (21 passed). New cases: `persists a status definition created without categories`, `round-trips a status definition created without categories through properties.md`, `keeps persisting unrelated definitions after a status property is created`, `serializes a select definition that carries no options`, `adds a status option to a property that has no persisted definition`, `adds a status option to a definition stored without categories`, `keeps one entry when the same status option value is added twice`, `keeps one entry when the same select option value is added twice`, `rejects an option mutation against a definition that does not exist`, `rejects a status option added to a definition of another type`, `rejects a status option added to an unknown category`.

E2E in `apps/desktop/tests/e2e/property-status-options.e2e.ts` drives the real picker: `a status option added in the picker survives a reload exactly once` and `adding the same status option twice leaves one entry`. Both assert on the DOM count and on occurrences in `.memry/properties.md`. Both pass, run as `BUILD_BEFORE_TEST=1 pnpm --filter @memry/desktop test:e2e tests/e2e/property-status-options.e2e.ts` (`Running 2 tests using 1 worker`, `2 passed (1.6m)`). Because the fix was already in the tree, each assertion was proven able to fail by reinstating the bug in the built bundle: dropping the dedupe gives `Expected: 1 / Received: 2` on the file, and reverting the categories materialization gives `Expected: 1 / Received: 0` after the reload while the pre-reload assertion still passes, which is the vanishing-status symptom exactly.

Gates: `pnpm lint` 0 errors, `pnpm typecheck` clean, `pnpm --filter @memry/desktop test:main` 7616 passed, `pnpm --filter @memry/desktop test:renderer` 8522 passed, `pnpm check:architecture` passed, `pnpm ipc:check` up to date, `pnpm docs:impact --strict` and `pnpm docs:build` clean, `git diff --check` clean.

Two failures seen during the gate runs were not from this branch. `src/main/sync/attachments.test.ts` errored on a half-installed Electron binary while another build ran concurrently, and passes 37/37 in isolation. `notes-tree-folder-rename-duplicate.test.tsx` timed out on its above-the-virtualization-threshold cases; clean `origin/main` fails the identical 7 tests with the same timeouts on this machine.
