### PR TITLE
fix(properties): stop the property row eating the space bar

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/info-section/PropertyRow.space-input.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/info-section/PropertyRow.space-input.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * "Properties do not allow spaces anymore": typing `movie series` into a
+ * property field produced `movieseries`.
+ *
+ * Unlike PropertyRow.test.tsx these render the real editors. The bug lived in
+ * the row's own `role="button"` value wrapper, so any test that stubs the
+ * editors out cannot see it.
+ */
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { PropertyRow } from './PropertyRow'
+import type { Property } from './types'
+
+const mocks = vi.hoisted(() => ({
+  refresh: vi.fn(),
+  addPropertyOption: vi.fn(),
+  addStatusOption: vi.fn(),
+  removePropertyOption: vi.fn(),
+  isEnabled: vi.fn(() => false),
+  setEnabled: vi.fn()
+}))
+
+vi.mock('@/hooks/use-calendar-properties', () => ({
+  useCalendarProperties: () => ({
+    isEnabled: mocks.isEnabled,
+    setEnabled: mocks.setEnabled
+  })
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false
+  })
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: () => '' } }
+}))
+
+vi.mock('@/hooks/use-projects-list', () => ({
+  useProjectsList: () => ({ projects: [], isLoading: false })
+}))
+
+vi.mock('@/hooks/use-property-definitions', () => ({
+  usePropertyDefinitions: () => ({
+    refresh: mocks.refresh,
+    getDefinition: () => ({ options: JSON.stringify([]) })
+  })
+}))
+
+vi.mock('@/services/notes-service', () => ({
+  notesService: {
+    addPropertyOption: mocks.addPropertyOption,
+    addStatusOption: mocks.addStatusOption,
+    removePropertyOption: mocks.removePropertyOption
+  }
+}))
+
+const TWO_WORDS = 'movie series'
+
+const property = (overrides: Partial<Property> = {}): Property => ({
+  id: 'prop-1',
+  name: 'Genre',
+  type: 'text',
+  value: '',
+  isCustom: true,
+  ...overrides
+})
+
+describe('PropertyRow space handling', () => {
+  it('keeps the space when typing into a text property value', async () => {
+    const user = userEvent.setup()
+
+    render(<PropertyRow property={property()} onValueChange={vi.fn()} autoFocus />)
+
+    const input = screen.getByRole('textbox', { name: 'Empty' })
+    await user.type(input, TWO_WORDS)
+
+    expect(input).toHaveValue(TWO_WORDS)
+  })
+
+  // The picker is portalled onto document.body, but React still routes its
+  // keydown through the row's value wrapper, so this input shares the bug.
+  it('keeps the space when naming a new select option', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <PropertyRow
+        property={property({ type: 'select', value: null })}
+        onValueChange={vi.fn()}
+        autoFocus
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'New option' }))
+
+    const input = screen.getByRole('textbox', { name: 'Option name' })
+    await user.type(input, TWO_WORDS)
+
+    expect(input).toHaveValue(TWO_WORDS)
+  })
+
+  it('still starts editing when Enter or Space lands on the value wrapper itself', async () => {
+    const user = userEvent.setup()
+
+    render(<PropertyRow property={property({ value: 'Drama' })} onValueChange={vi.fn()} />)
+
+    const wrapper = screen.getByRole('button', { name: 'Drama' })
+    wrapper.focus()
+    await user.keyboard(' ')
+
+    expect(screen.getByRole('textbox', { name: 'Empty' })).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/info-section/PropertyRow.tsx
+++ b/apps/desktop/src/renderer/src/components/note/info-section/PropertyRow.tsx
@@ -526,7 +526,13 @@ export function PropertyRow({
         role="button"
         tabIndex={0}
         onClick={handleStartEdit}
+        // Only this wrapper's own keystrokes activate it. React routes synthetic
+        // events up the component tree, including out of the Radix portal the
+        // select/status pickers render into, so every editor below feeds its
+        // keydowns through here. Without the target check, `preventDefault()`
+        // deleted the space bar in every property field.
         onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault()
             handleStartEdit()

--- a/apps/desktop/tests/e2e/property-space-input.e2e.ts
+++ b/apps/desktop/tests/e2e/property-space-input.e2e.ts
@@ -1,0 +1,101 @@
+/**
+ * Property inputs must accept the space character.
+ *
+ * Reported as "Properties do not allow spaces anymore": typing `movie series`
+ * into a property field drops the space and leaves `movieseries`.
+ *
+ * These drive real key events (`keyboard.type`), never `fill()` — `fill()` sets
+ * the value directly and would pass even while every keystroke is being
+ * swallowed.
+ */
+
+import { test, expect } from './fixtures'
+import type { Page } from '@playwright/test'
+import { waitForAppReady, waitForVaultReady, seedNote } from './utils/electron-helpers'
+import { openNoteByHandle } from './utils/note-sync-helpers'
+
+const TWO_WORDS = 'movie series'
+
+async function openSeededNote(page: Page, title: string): Promise<string> {
+  const id = await seedNote(page, title)
+  await openNoteByHandle(page, { id, title })
+  return id
+}
+
+async function openAddPropertyPopup(page: Page): Promise<void> {
+  await page.locator('.group\\/metadata').first().hover()
+  const addPropertyButton = page.getByRole('button', { name: 'Add property' }).first()
+  await expect(addPropertyButton).toBeVisible()
+  await addPropertyButton.click()
+}
+
+async function addProperty(page: Page, type: 'Text' | 'Select'): Promise<void> {
+  await openAddPropertyPopup(page)
+  const typeOption = page.getByRole('option', { name: type, exact: true }).first()
+  await expect(typeOption).toBeVisible()
+  await typeOption.click()
+}
+
+test.describe('Property fields accept spaces', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+  })
+
+  test('the add-property name field keeps the space in "movie series"', async ({ page }) => {
+    await openSeededNote(page, `Prop space name ${Date.now()}`)
+    await openAddPropertyPopup(page)
+
+    const nameInput = page.getByRole('textbox', { name: 'Property name' })
+    await expect(nameInput).toBeVisible()
+    await nameInput.click()
+    await page.keyboard.type(TWO_WORDS, { delay: 25 })
+
+    await expect(nameInput).toHaveValue(TWO_WORDS)
+  })
+
+  test('a text property value keeps the space in "movie series"', async ({ page }) => {
+    await openSeededNote(page, `Prop space value ${Date.now()}`)
+    await addProperty(page, 'Text')
+
+    const valueInput = page.getByRole('textbox', { name: 'Empty' }).first()
+    await expect(valueInput).toBeFocused()
+    await page.keyboard.type(TWO_WORDS, { delay: 25 })
+
+    await expect(valueInput).toHaveValue(TWO_WORDS)
+  })
+
+  // The picker lives in a Radix portal, so its keydowns leave the row in the DOM
+  // but still climb the React tree through the row's value wrapper.
+  test('a new select option name keeps the space in "movie series"', async ({ page }) => {
+    await openSeededNote(page, `Prop space option ${Date.now()}`)
+    await addProperty(page, 'Select')
+
+    const newOption = page.getByRole('button', { name: 'New option' })
+    await expect(newOption).toBeVisible()
+    await newOption.click()
+
+    const optionInput = page.getByRole('textbox', { name: 'Option name' })
+    await expect(optionInput).toBeFocused()
+    await page.keyboard.type(TWO_WORDS, { delay: 25 })
+
+    await expect(optionInput).toHaveValue(TWO_WORDS)
+  })
+
+  test('renaming a property keeps the space in "movie series"', async ({ page }) => {
+    await openSeededNote(page, `Prop space rename ${Date.now()}`)
+    await addProperty(page, 'Text')
+
+    const propertyList = page.getByRole('list', { name: 'Properties list' }).first()
+    const nameLabel = propertyList.getByRole('button', { name: 'Text', exact: true }).first()
+    await expect(nameLabel).toBeVisible()
+    await nameLabel.click()
+
+    const renameInput = page.getByRole('textbox', { name: 'Edit property name' })
+    await expect(renameInput).toBeFocused()
+    await page.keyboard.press('ControlOrMeta+a')
+    await page.keyboard.type(TWO_WORDS, { delay: 25 })
+
+    await expect(renameInput).toHaveValue(TWO_WORDS)
+  })
+})


### PR DESCRIPTION
## Summary

Typing `movie series` into a property field produced `movieseries`. Reported by a customer on
v2026-08-25 as "Properties do not allow spaces anymore".

**Root cause: `apps/desktop/src/renderer/src/components/note/info-section/PropertyRow.tsx:514`.**
A property row's value slot is a `role="button"` div that starts editing on Enter or Space, and it
called `preventDefault()` for those keys on every keydown it saw:

```tsx
onKeyDown={(e) => {
  if (e.key === 'Enter' || e.key === ' ') {
    e.preventDefault()
    handleStartEdit()
  }
}}
```

React routes synthetic events up the *component* tree, so every editor rendered under
`PropertyValueRenderer` fed its keydowns through that handler. The space was cancelled before the
browser could insert it. This reaches further than it looks: the select, status and multiselect
pickers render into a Radix portal, whose DOM node sits on `document.body` but whose React parent is
still this div, so their option-name and search inputs were hit too.

Affected inputs, all under that one wrapper: text, number, URL and long-text property **values**,
plus the option-name and search fields of select, status, multiselect, relation and project
properties.

The fix is one line — activate only on the wrapper's own keystrokes. A keydown that started in a
descendant belongs to that descendant.

### Not affected

Two nearby fields were checked and are fine, and the E2E covers both so they stay that way:

- The **add-property name field** (`AddPropertyPopup.tsx`) is not under this wrapper. This is the
  field the bug was first attributed to; it always accepted spaces.
- **Renaming** a property (`PropertyRow.tsx:465`) is a sibling of the value slot, not a child.

### Same shape elsewhere, left alone

`folder-table-view.tsx:998` and `grouped-table.tsx:980` do the same unguarded `case ' ': preventDefault()`
on a `role="grid"` container. They are safe today only because every editable cell shields itself with
`onKeyDown={stopPropagation}` (`folder-view/property-cell.tsx:406,440`). Not touched here — no evidence
of a live bug, and widening the diff into a second surface is not what this fix needs.

## Release note

Fixed: you can type spaces in note property values again, and in select, status and multiselect
option names.

## Test plan

New E2E `apps/desktop/tests/e2e/property-space-input.e2e.ts`, driving real key events
(`keyboard.type`, never `fill()` — `fill()` sets the value directly and passes even while every
keystroke is being swallowed). Committed before the fix so the history shows it failing.

Before the fix:

```
✓ 1 the add-property name field keeps the space in "movie series" (19.1s)
✘ 2 a text property value keeps the space in "movie series" (30.4s)
✘ 3 a new select option name keeps the space in "movie series" (29.5s)
✓ 4 renaming a property keeps the space in "movie series" (17.7s)
  Expected: "movie series"
  Received: "movieseries"
2 failed, 2 passed
```

After:

```
✓ 1 the add-property name field keeps the space in "movie series" (17.4s)
✓ 2 a text property value keeps the space in "movie series" (17.5s)
✓ 3 a new select option name keeps the space in "movie series" (16.6s)
✓ 4 renaming a property keeps the space in "movie series" (17.3s)
4 passed (6.0m)
```

New renderer test `PropertyRow.space-input.test.tsx` renders the **real** editors — the existing
`PropertyRow.test.tsx` stubs them all out, which is why it never saw this. Covers the direct child
input, the portalled select option name, and that a genuine Space on the wrapper still opens the
editor. 2 failed / 1 passed before, 3 passed after.

Gates, all green:

- `pnpm lint` — 0 errors, 109 pre-existing warnings
- `pnpm typecheck` — exit 0
- `pnpm --filter @memry/desktop test:renderer` — 700 files, 8527 passed
- `pnpm test:e2e -- property-space-input.e2e.ts` — 4 passed
- `pnpm check:architecture` — passed
- `git diff --check` — clean

`docs:impact` flagged `missing-docs` and was waived with `MEMRY_DOCS_IMPACT_SKIP=1`. This restores
behaviour the docs already assume — `apps/docs/src/user-guide/notes/properties-tags.md` describes
setting property values inline and never suggested spaces were special. Documenting "spaces work" would
only describe the bug.
