### PR TITLE
fix(updater): open the release-notes tab in the background

### DIFF
--- a/apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-focus.test.tsx
+++ b/apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-focus.test.tsx
@@ -1,0 +1,186 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { type ReactElement } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppUpdateState } from '@memry/contracts/ipc-updater'
+import { TabProvider, useActiveGroupTabs, useActiveTab } from '@/contexts/tabs'
+import type { Tab, TabSystemState } from '@/contexts/tabs'
+import { useTemplateDraft } from '@/hooks/use-template-draft'
+import { UpdateReleaseNotesTabOpener } from './update-release-notes-tab-opener'
+
+const mocks = vi.hoisted(() => ({
+  state: {} as AppUpdateState,
+  updateTemplate: vi.fn()
+}))
+
+vi.mock('@/hooks/use-app-updater', () => ({
+  useAppUpdater: () => ({ state: mocks.state })
+}))
+
+vi.mock('@/hooks/use-templates', () => ({
+  useTemplates: () => ({
+    createTemplate: vi.fn(),
+    updateTemplate: mocks.updateTemplate
+  })
+}))
+
+const quiet: AppUpdateState = {
+  currentVersion: '2026.700.1',
+  status: 'up-to-date',
+  updateSupported: true,
+  availableVersion: null,
+  releaseName: null,
+  releaseDate: null,
+  releaseNotes: null,
+  releaseNotesHtml: null,
+  downloadProgressPercent: null,
+  lastCheckedAt: null,
+  error: null,
+  autoDownloadEnabled: false,
+  autoCheckEnabled: true
+}
+
+/**
+ * A silent auto-download, which is the path the reporting customer was on: an
+ * update surfaces with no prompt to click through.
+ */
+const downloading = (version: string): AppUpdateState => ({
+  ...quiet,
+  status: 'downloading',
+  availableVersion: version,
+  releaseNotes: 'notes',
+  releaseNotesHtml: `<p>${version}</p>`
+})
+
+const templateTab: Tab = {
+  id: 'template-tab',
+  type: 'template-editor',
+  title: 'Weekly Review',
+  icon: 'file-text',
+  path: '/templates/tpl-1',
+  entityId: 'tpl-1',
+  isPinned: false,
+  isModified: false,
+  isPreview: false,
+  isDeleted: false,
+  openedAt: 1,
+  lastAccessedAt: 1
+}
+
+const initialState = (): TabSystemState => ({
+  tabGroups: {
+    g1: {
+      id: 'g1',
+      tabs: [templateTab],
+      activeTabId: templateTab.id,
+      isActive: true,
+      back: [],
+      forward: []
+    }
+  },
+  layout: { type: 'leaf', tabGroupId: 'g1' },
+  activeGroupId: 'g1',
+  settings: { restoreSessionOnStart: true, tabCloseButton: 'hover' },
+  recentlyClosed: []
+})
+
+/**
+ * The real template draft: body edits live in component state behind an 800ms
+ * debounce whose cleanup clears the pending save without flushing it, so an
+ * unmount inside that window discards everything typed since the last write.
+ */
+function TemplateEditorStub(): ReactElement {
+  const { fields, setFields } = useTemplateDraft({
+    templateId: 'tpl-1',
+    initial: { name: 'Weekly Review', icon: null, tags: [], properties: [], content: '' }
+  })
+  return (
+    <textarea
+      aria-label="template body"
+      value={fields.content}
+      onChange={(event) => setFields({ content: event.target.value })}
+    />
+  )
+}
+
+/** Mirrors `TabPane`, which mounts the active tab's content and nothing else. */
+function ActivePane(): ReactElement | null {
+  const activeTab = useActiveTab()
+  return activeTab?.type === 'template-editor' ? <TemplateEditorStub /> : null
+}
+
+function TabStrip(): ReactElement {
+  const tabs = useActiveGroupTabs()
+  const activeTab = useActiveTab()
+  return (
+    <ul>
+      {tabs.map((tab) => (
+        <li key={tab.id} data-testid={`tab-${tab.type}`} aria-current={tab.id === activeTab?.id}>
+          {tab.title}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+describe('release-notes tab focus', () => {
+  let state: TabSystemState
+
+  // A fresh element every time: React bails out of reconciling a re-render whose
+  // element is referentially identical, which would stop the opener from ever
+  // seeing the new updater state.
+  const tree = (): ReactElement => (
+    <TabProvider initialState={state}>
+      <UpdateReleaseNotesTabOpener />
+      <TabStrip />
+      <ActivePane />
+    </TabProvider>
+  )
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    mocks.updateTemplate.mockReset()
+    mocks.updateTemplate.mockResolvedValue({ id: 'tpl-1' })
+    mocks.state = quiet
+    state = initialState()
+    window.api.onSettingsChanged = vi.fn(() => vi.fn())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('leaves the tab the user is working in active when an update surfaces', () => {
+    const { rerender } = render(tree())
+    expect(screen.getByTestId('tab-template-editor')).toHaveAttribute('aria-current', 'true')
+
+    mocks.state = downloading('2026.708.1')
+    rerender(tree())
+
+    expect(screen.getByTestId('tab-virtual-note')).toHaveAttribute('aria-current', 'false')
+    expect(screen.getByTestId('tab-template-editor')).toHaveAttribute('aria-current', 'true')
+  })
+
+  it('lets the debounced template save land instead of unmounting it away', () => {
+    const { rerender } = render(tree())
+    fireEvent.change(screen.getByLabelText('template body'), {
+      target: { value: '## Wins\n## Blockers' }
+    })
+
+    // Mid-debounce: the edit is still only in the mounted component.
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+    expect(mocks.updateTemplate).not.toHaveBeenCalled()
+
+    mocks.state = downloading('2026.708.1')
+    rerender(tree())
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    expect(mocks.updateTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'tpl-1', content: '## Wins\n## Blockers' })
+    )
+    expect(screen.getByLabelText('template body')).toHaveValue('## Wins\n## Blockers')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-opener.test.tsx
+++ b/apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-opener.test.tsx
@@ -53,6 +53,7 @@ describe('UpdateReleaseNotesTabOpener', () => {
       isPreview: false,
       viewState: { content: '<p>2026.708.1</p>', contentType: 'html' }
     })
+    expect(mocks.openTab.mock.calls[0][1]).toMatchObject({ background: true })
   })
 
   it('does not re-open the same version on a re-render', () => {

--- a/apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-opener.tsx
+++ b/apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-opener.tsx
@@ -6,9 +6,10 @@ import { planReleaseNotesTab } from './release-notes-tab'
 /**
  * Part of the update flow: when a new release surfaces — whether the prompt is shown
  * or a silent auto-download begins — open a read-only "release notes" tab rendering
- * the humanized notes (with clickable PR links). The tab is ephemeral (never written
- * to the vault, never synced, excluded from tab persistence); closing removes it, and
- * Cmd/Ctrl+Shift+T reopens it from the in-memory closed-tab stack.
+ * the humanized notes (with clickable PR links) in the BACKGROUND. The tab is
+ * ephemeral (never written to the vault, never synced, excluded from tab
+ * persistence); closing removes it, and Cmd/Ctrl+Shift+T reopens it from the
+ * in-memory closed-tab stack.
  *
  * Opens once per surfaced version so short-interval polling never re-opens it.
  * Renders nothing; must live inside TabProvider.
@@ -23,19 +24,25 @@ export function UpdateReleaseNotesTabOpener(): null {
     if (!plan) return
 
     surfacedVersionRef.current = plan.version
-    openTab({
-      type: 'virtual-note',
-      title: plan.title,
-      icon: 'file-text',
-      // Unique per version so distinct release-notes tabs never collapse into one
-      // another via the no-entityId open/reopen dedup.
-      path: `/virtual/release-notes/${plan.version}`,
-      isPinned: false,
-      isModified: false,
-      isPreview: false,
-      isDeleted: false,
-      viewState: { content: plan.content, contentType: plan.contentType }
-    })
+    openTab(
+      {
+        type: 'virtual-note',
+        title: plan.title,
+        icon: 'file-text',
+        // Unique per version so distinct release-notes tabs never collapse into one
+        // another via the no-entityId open/reopen dedup.
+        path: `/virtual/release-notes/${plan.version}`,
+        isPinned: false,
+        isModified: false,
+        isPreview: false,
+        isDeleted: false,
+        viewState: { content: plan.content, contentType: plan.contentType }
+      },
+      // The user did not ask for this tab; the release poller did. `TabPane` mounts
+      // the active tab alone, so focusing this one would unmount whatever the user
+      // is typing in and discard its not-yet-persisted editor state.
+      { background: true }
+    )
   }, [state, openTab])
 
   return null

--- a/apps/desktop/tests/e2e/update-notice-tab-focus.e2e.ts
+++ b/apps/desktop/tests/e2e/update-notice-tab-focus.e2e.ts
@@ -1,0 +1,84 @@
+import type { ElectronApplication, Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { ready, uniqueLabel } from './utils/desktop-test-helpers'
+import { SELECTORS } from './utils/electron-helpers'
+
+const SURFACED_VERSION = '2026.999.9'
+
+/**
+ * Broadcast a surfaced release from main on the channel the renderer's updater
+ * store already listens to. `downloading` is the silent auto-download phase, which
+ * is deliberately not promptable, so no modal opens over the app and the
+ * release-notes tab is the only thing the update flow puts on screen.
+ */
+async function surfaceUpdate(electronApp: ElectronApplication): Promise<void> {
+  await electronApp.evaluate(({ BrowserWindow }, version) => {
+    BrowserWindow.getAllWindows()[0]?.webContents.send('updater:state-changed', {
+      currentVersion: '2026.700.1',
+      status: 'downloading',
+      updateSupported: true,
+      availableVersion: version,
+      releaseName: `MemryNote ${version}`,
+      releaseDate: null,
+      releaseNotes: 'notes',
+      releaseNotesHtml: `<h2>Fixes</h2><p>Release ${version}</p>`,
+      downloadProgressPercent: 10,
+      lastCheckedAt: null,
+      error: null,
+      autoDownloadEnabled: true,
+      autoCheckEnabled: true
+    })
+  }, SURFACED_VERSION)
+}
+
+/** `templates.get` resolves the template itself, not a `{ template }` envelope. */
+async function persistedBody(page: Page, name: string): Promise<string | null> {
+  return page.evaluate(async (templateName) => {
+    const list = await window.api.templates.list()
+    const match = list.templates.find((template) => template.name === templateName)
+    if (!match) return null
+    const full = await window.api.templates.get(match.id)
+    return full?.content ?? null
+  }, name)
+}
+
+test.describe('Update notice tab focus', () => {
+  test('a surfaced release does not steal focus from, or discard, a template being written', async ({
+    page,
+    electronApp
+  }) => {
+    await ready(page)
+
+    const templateName = uniqueLabel('Weekly Review')
+
+    await page.evaluate(() => {
+      window.api.quickCapture.openSettings('templates')
+    })
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await page.getByRole('button', { name: 'New Template' }).click()
+
+    // The title field only commits on blur, so Enter is what actually sets the
+    // name and enables Create.
+    await page.getByPlaceholder('Template name').fill(templateName)
+    await page.keyboard.press('Enter')
+    await page.getByRole('button', { name: 'Create Template' }).click()
+
+    const editor = page.locator(SELECTORS.noteEditor).first()
+    await editor.waitFor({ state: 'visible', timeout: 10_000 })
+    await editor.click()
+    await page.keyboard.type('Wins and blockers')
+
+    // Surface the release straight after typing, while the body is still inside
+    // the debounce window that the focus steal used to destroy.
+    await surfaceUpdate(electronApp)
+
+    const releaseNotesTab = page.getByRole('tab', { name: `MemryNote ${SURFACED_VERSION}` })
+    await expect(releaseNotesTab).toBeVisible({ timeout: 20_000 })
+    await expect(releaseNotesTab).toHaveAttribute('aria-selected', 'false')
+    await expect(page.locator(SELECTORS.activeTab)).toHaveAttribute('aria-label', templateName)
+
+    // Past the editor's 150ms markdown debounce and the template's 800ms save.
+    await page.waitForTimeout(4_000)
+    expect(await persistedBody(page, templateName)).toContain('Wins and blockers')
+  })
+})

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -78,6 +78,8 @@ When memrynote finds an update it opens an in-app **update prompt** showing the 
 - **Skip This Version** — never prompt automatically for this version again. A manual check clears the skip so the version can surface again.
 - **Automatically download & install updates** — when enabled, future updates download in the background and install on the next quit without prompting.
 
+When a version surfaces, memrynote also opens its **release notes** as a read-only tab. That tab always opens in the background. It never takes focus from the note, template, or canvas you are working in, so an update arriving mid-edit cannot interrupt or discard what you are typing. Click it when you want to read the notes, or close it and reopen it with `Cmd/Ctrl+Shift+T`.
+
 You can also run the same check from the menu bar without opening Settings: **memrynote → Check for Updates…** on macOS, **Help → Check for Updates…** on Windows and Linux. The result is always reported as a toast — up to date, an available or ready-to-install version, or the error — and an available update still opens the update prompt unless automatic downloads are on. In a development build the toast says updates are packaged-release only.
 
 ### Language & Region


### PR DESCRIPTION
## What was broken

A customer on v2026-08-23.2 (Win32) lost a template body: "As I was creating a Template I received an update notice, which resulted in my template being lost because the update note took its place. I was able to get my template tab back, but all my work was gone so it was just the title of the template."

## Root cause

`UpdateReleaseNotesTabOpener` opens the release-notes tab the moment a release surfaces, and it passed no open options. `OPEN_TAB` therefore took the foreground branch and made the new tab active. `TabPane` mounts only the active tab (`tab-pane.tsx:57` renders `activeTab` alone), so the template editor unmounted mid-edit. Its body lives in component state behind an 800ms debounced save whose cleanup is a bare `clearTimeout`, so the pending write was discarded and the template kept only the name written when Create was pressed. That is exactly the title-only row the customer found. Introduced by #817.

## What changed

The opener now passes `{ background: true }`. `openTab` already forwarded that flag and the reducer already honoured it on every branch; the caller simply never set it. An automatic, non-user-initiated tab no longer takes focus. The two other automatic-looking `openTab` callers (`use-reminder-notifications`) are both driven by a real click, so they are untouched.

## Verification

Unit, `apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-focus.test.tsx`, driving the real `TabProvider`, the real reducer and the real `useTemplateDraft` rather than a mocked `useTabs`. Committed failing first, then the fix.

Before the fix, 3 failed / 3 passed:

```
× release-notes tab focus > leaves the tab the user is working in active when an update surfaces
  Expected the element to have attribute: aria-current="false"
  Received: aria-current="true"
× release-notes tab focus > lets the debounced template save land instead of unmounting it away
  expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]
  Number of calls: 0
× UpdateReleaseNotesTabOpener > opens a read-only release-notes tab once when an update surfaces
  expected undefined to match object { background: true }
```

After: `Test Files 5 passed (5) / Tests 27 passed (27)`.

E2E, `apps/desktop/tests/e2e/update-notice-tab-focus.e2e.ts`, on the real path. It creates a template through Settings, types a body, then broadcasts a `downloading` release from the main process on `updater:state-changed` (the silent auto-download phase, which is not promptable, so no modal covers the app). No test-only production code was added.

Without the fix the spec fails on the focus assertion, and a probe on the same build showed the persisted body was `""` while the editor had unmounted:

```
✘ a surfaced release does not steal focus from, or discard, a template being written
  expect(locator).toHaveAttribute(expected) failed
  Expected: "false"   Received: "true"
```

With the fix, `1 passed`, asserting the release-notes tab is present but `aria-selected="false"`, the template tab is still the active tab, and the persisted template body contains the typed text.

Also green: `pnpm lint` (0 errors), `pnpm typecheck` (19/19), `pnpm check:architecture`, `git diff --check`, `pnpm docs:impact --strict` (covered).

`pnpm --filter @memry/desktop test:renderer` reports `notes-tree-folder-rename-duplicate.test.tsx` failing on timeouts; it passes 14/14 in isolation, reproduces on clean `origin/main` in a separate worktree, and is machine load from several worktrees running at once, not this diff.

## Not fixed here

Two latent defects this change does not address, deliberately kept out of scope:

- `use-template-draft.ts:168-178` clears its debounce on unmount without flushing, so up to 800ms of template edits are still lost on any ordinary tab switch.
- `use-editor-teardown.ts:72-91` defers the `beforeDestroy` markdown flush into a `queueMicrotask`, so it runs after the owning component has already unmounted.

Both get their own issues.
