### PR TITLE
fix(tags): make the tag hub's New tag actually create a tag

### DIFF
--- a/apps/desktop/src/main/database/queries/tag-definitions.ts
+++ b/apps/desktop/src/main/database/queries/tag-definitions.ts
@@ -71,7 +71,16 @@ export function getOrCreateTag(
   const tagCount = db.select({ count: count() }).from(tagDefinitions).get()?.count ?? 0
   const color = TAG_COLOR_PALETTE[tagCount % TAG_COLOR_PALETTE.length]
 
-  db.insert(tagDefinitions).values({ name: normalizedName, color, colorAuthored: false }).run()
+  // Stored with the caller's casing, matched without it. `name` is the primary
+  // key under COLLATE NOCASE (see nocase.ts), so `Reading` and `reading` are
+  // still the same row and every `eq(name, lowercased)` lookup keeps working;
+  // the row just remembers how the tag was first written. For a tag that no
+  // note uses yet — one created from the tag hub — this row is the only place
+  // the display name exists, since `getAllTagsWithCounts` otherwise takes it
+  // from usage. Only inserts are affected: an existing row's casing is never
+  // rewritten, so nothing re-emits to sync.
+  const displayName = name.trim()
+  db.insert(tagDefinitions).values({ name: displayName, color, colorAuthored: false }).run()
 
   // Insert branch only — the get branch above returns without emitting.
   trackMainEvent('tag_created', {
@@ -81,12 +90,13 @@ export function getOrCreateTag(
     result: 'success'
   })
 
-  return { name: normalizedName, color, icon: null, categoryId: null, sortOrder: 0 }
+  return { name: displayName, color, icon: null, categoryId: null, sortOrder: 0 }
 }
 
 export function getAllTagDefinitions(db: DataDb): {
   name: string
   color: string
+  colorAuthored: boolean
   icon: string | null
   categoryId: string | null
   sortOrder: number
@@ -95,6 +105,7 @@ export function getAllTagDefinitions(db: DataDb): {
     .select({
       name: tagDefinitions.name,
       color: tagDefinitions.color,
+      colorAuthored: tagDefinitions.colorAuthored,
       icon: tagDefinitions.icon,
       categoryId: tagDefinitions.categoryId,
       sortOrder: tagDefinitions.sortOrder

--- a/apps/desktop/src/main/database/queries/tags.test.ts
+++ b/apps/desktop/src/main/database/queries/tags.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { TestDatabaseResult, TestDb } from '@tests/utils/test-db'
 import { createTestDataDb, createTestIndexDb, sql } from '@tests/utils/test-db'
 import { getAllTagsWithCounts, mergeTagInNotes, mergeTagInTasks } from './tags'
+import { getOrCreateTag, setTagCategory, updateTagColor } from './tag-definitions'
 
 // ============================================================================
 // Helpers
@@ -559,5 +560,125 @@ describe('mergeTagInTasks', () => {
 
     // #then: t2's tags are untouched
     expect(readTaskTags(dataDb, 't2')).toEqual(['other'])
+  })
+})
+
+// ============================================================================
+// getAllTagsWithCounts — tags created from the tag hub, before any note uses them
+// ============================================================================
+
+describe('getAllTagsWithCounts and tags created from the hub', () => {
+  let indexResult: TestDatabaseResult
+  let dataResult: TestDatabaseResult
+  let indexDb: TestDb
+  let dataDb: TestDb
+
+  beforeEach(() => {
+    indexResult = createTestIndexDb()
+    dataResult = createTestDataDb()
+    indexDb = indexResult.db
+    dataDb = dataResult.db
+  })
+
+  afterEach(() => {
+    indexResult.close()
+    dataResult.close()
+  })
+
+  function readDefinitionNames(db: TestDb): string[] {
+    return db
+      .all<{ name: string }>(sql`SELECT name FROM tag_definitions ORDER BY name`)
+      .map((r) => r.name)
+  }
+
+  it('keeps a tag the hub created, before any note or task uses it', () => {
+    // #given: the hub's create path — getOrCreateTag then updateTagColor
+    getOrCreateTag(dataDb, 'reading')
+    updateTagColor(dataDb, 'reading', 'emerald')
+
+    // #when
+    const result = getAllTagsWithCounts(indexDb, dataDb)
+
+    // #then: it is listed, at zero, and its definition survives the read
+    const reading = result.find((t) => t.name.toLowerCase() === 'reading')
+    expect(reading).toBeDefined()
+    expect(reading?.count).toBe(0)
+    expect(reading?.color).toBe('emerald')
+    expect(readDefinitionNames(dataDb)).toContain('reading')
+  })
+
+  it('keeps the casing the user typed', () => {
+    // #given
+    getOrCreateTag(dataDb, 'Reading')
+    updateTagColor(dataDb, 'Reading', 'emerald')
+
+    // #when
+    const result = getAllTagsWithCounts(indexDb, dataDb)
+
+    // #then
+    const names = result.map((t) => t.name)
+    expect(names).toContain('Reading')
+  })
+
+  it('collides `reading` into `Reading` under nocase instead of making a second tag', () => {
+    // #given
+    getOrCreateTag(dataDb, 'Reading')
+    updateTagColor(dataDb, 'Reading', 'emerald')
+
+    // #when: the same tag typed in a different case
+    getOrCreateTag(dataDb, 'reading')
+    updateTagColor(dataDb, 'reading', 'violet')
+
+    // #then: one tag, still spelled the way it was first created
+    const result = getAllTagsWithCounts(indexDb, dataDb)
+    const matches = result.filter((t) => t.name.toLowerCase() === 'reading')
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.name).toBe('Reading')
+    expect(matches[0]?.color).toBe('violet')
+    expect(readDefinitionNames(dataDb)).toEqual(['Reading'])
+  })
+
+  it('carries the category the hub assigned', () => {
+    // #given
+    getOrCreateTag(dataDb, 'Reading')
+    updateTagColor(dataDb, 'Reading', 'emerald')
+    dataDb.run(sql`
+      INSERT INTO tag_categories (id, name, sort_order, created_at)
+      VALUES ('cat-1', 'Hobbies', 0, '2026-01-01T00:00:00.000Z')
+    `)
+    setTagCategory(dataDb, 'Reading', 'cat-1')
+
+    // #when
+    const result = getAllTagsWithCounts(indexDb, dataDb)
+
+    // #then
+    const reading = result.find((t) => t.name === 'Reading')
+    expect(reading?.categoryId).toBe('cat-1')
+  })
+
+  it('still collects a bare definition left behind when a note drops its tag', () => {
+    // #given: an auto-minted definition nobody shaped, with no usage left
+    getOrCreateTag(dataDb, 'stale')
+
+    // #when
+    const result = getAllTagsWithCounts(indexDb, dataDb)
+
+    // #then
+    expect(result.find((t) => t.name === 'stale')).toBeUndefined()
+    expect(readDefinitionNames(dataDb)).not.toContain('stale')
+  })
+
+  it('sorts used tags ahead of an unused one', () => {
+    // #given
+    insertNote(indexDb, 'n1')
+    insertNoteTag(indexDb, 'n1', 'work')
+    getOrCreateTag(dataDb, 'Reading')
+    updateTagColor(dataDb, 'Reading', 'emerald')
+
+    // #when
+    const result = getAllTagsWithCounts(indexDb, dataDb)
+
+    // #then
+    expect(result.map((t) => t.name)).toEqual(['work', 'Reading'])
   })
 })

--- a/apps/desktop/src/main/database/queries/tags.ts
+++ b/apps/desktop/src/main/database/queries/tags.ts
@@ -8,6 +8,24 @@ import { getAllTaskTags } from './tasks'
 type IndexDb = Parameters<typeof getAllTags>[0]
 type DataDb = Parameters<typeof getAllTaskTags>[0]
 
+/**
+ * Whether a definition row records a decision someone made about the tag, as
+ * opposed to one `getOrCreateTag` minted on the way past.
+ *
+ * Only three surfaces set `colorAuthored` — the two colour pickers and the tag
+ * hub's create affordance (`tags:update-color`) — so it, an icon, and a
+ * category assignment are between them every deliberate mark a user can leave
+ * on a tag. A tag created in the hub carries an authored colour from the
+ * moment it exists, which is what keeps it alive before any note uses it.
+ */
+function isAuthored(definition: {
+  colorAuthored: boolean
+  icon: string | null
+  categoryId: string | null
+}): boolean {
+  return definition.colorAuthored || definition.icon !== null || definition.categoryId !== null
+}
+
 export function getAllTagsWithCounts(indexDb: IndexDb, dataDb: DataDb): TagWithCount[] {
   const noteCounts = getAllTags(indexDb)
   const taskCounts = getAllTaskTags(dataDb)
@@ -64,13 +82,32 @@ export function getAllTagsWithCounts(indexDb: IndexDb, dataDb: DataDb): TagWithC
     }
   }
 
+  // A definition with no usage behind it is either a tag someone made and has
+  // not filed anywhere yet — the tag hub's "New tag" — or the leftovers of one
+  // whose last note dropped it, in which case collecting it is what stops
+  // renaming `#foo` to `#bar` inside a note leaving `foo` behind forever. The
+  // authored ones are listed at zero; the rest are still collected.
+  const registered: TagWithCount[] = []
   for (const def of definitions) {
-    if (!merged.has(def.name.toLowerCase())) {
+    if (merged.has(def.name.toLowerCase())) continue
+    if (!isAuthored(def)) {
       deleteTagDefinition(dataDb, def.name)
+      continue
     }
+    registered.push({
+      name: def.name,
+      count: 0,
+      color: def.color,
+      icon: def.icon,
+      categoryId: def.categoryId,
+      sortOrder: def.sortOrder
+    })
   }
 
-  return [...merged.values()].filter((tag) => tag.count > 0).sort((a, b) => b.count - a.count)
+  return [
+    ...[...merged.values()].filter((tag) => tag.count > 0).sort((a, b) => b.count - a.count),
+    ...registered.sort((a, b) => a.name.localeCompare(b.name))
+  ]
 }
 
 export function mergeTagInNotes(

--- a/apps/desktop/src/main/vault/notes-queries.test.ts
+++ b/apps/desktop/src/main/vault/notes-queries.test.ts
@@ -1,0 +1,84 @@
+/**
+ * notes:get-tags feeds the editor's `#` autocomplete and the tag pickers.
+ * These tests pin that it shares the hub query's sweep predicate: a tag
+ * created from the hub is offered before anything uses it, while a bare
+ * auto-minted definition is still collected.
+ *
+ * @module vault/notes-queries.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  asClientDb,
+  createTestDataDb,
+  createTestIndexDb,
+  sql,
+  type TestDatabaseResult
+} from '@tests/utils/test-db'
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: vi.fn(() => []) }
+}))
+
+const dbs = vi.hoisted(() => ({
+  data: undefined as unknown,
+  index: undefined as unknown
+}))
+
+vi.mock('../database', () => ({
+  getDatabase: () => dbs.data,
+  getIndexDatabase: () => dbs.index
+}))
+
+import { getOrCreateTag, updateTagColor } from '../database/queries/tag-definitions'
+import { getTagsWithCounts } from './notes-queries'
+
+describe('getTagsWithCounts (notes:get-tags)', () => {
+  let dataResult: TestDatabaseResult
+  let indexResult: TestDatabaseResult
+
+  beforeEach(() => {
+    dataResult = createTestDataDb()
+    indexResult = createTestIndexDb()
+    dbs.data = dataResult.db
+    dbs.index = indexResult.db
+  })
+
+  afterEach(() => {
+    dataResult.close()
+    indexResult.close()
+  })
+
+  function readDefinitionNames(): string[] {
+    return dataResult.db
+      .all<{ name: string }>(sql`SELECT name FROM tag_definitions ORDER BY name`)
+      .map((row) => row.name)
+  }
+
+  it('offers a tag the hub created at count 0 instead of collecting it', () => {
+    // #given: the hub's create path — getOrCreateTag then updateTagColor
+    getOrCreateTag(asClientDb(dataResult.db), 'Reading')
+    updateTagColor(asClientDb(dataResult.db), 'Reading', 'emerald')
+
+    // #when: the `#` autocomplete or a picker loads the list
+    const tags = getTagsWithCounts()
+
+    // #then: offered at zero, and the definition survives the read
+    const reading = tags.find((tag) => tag.tag === 'Reading')
+    expect(reading).toMatchObject({ tag: 'Reading', count: 0, color: 'emerald' })
+    expect(readDefinitionNames()).toContain('Reading')
+    expect(getTagsWithCounts().find((tag) => tag.tag === 'Reading')).toBeDefined()
+  })
+
+  it('still collects a bare auto-minted definition with no usage', () => {
+    // #given: a definition nobody shaped and nothing uses
+    getOrCreateTag(asClientDb(dataResult.db), 'stale')
+
+    // #when
+    const tags = getTagsWithCounts()
+
+    // #then
+    expect(tags.find((tag) => tag.tag === 'stale')).toBeUndefined()
+    expect(readDefinitionNames()).not.toContain('stale')
+  })
+})

--- a/apps/desktop/src/main/vault/notes-queries.ts
+++ b/apps/desktop/src/main/vault/notes-queries.ts
@@ -13,17 +13,13 @@ import {
   listNotesFromCache,
   countNotes,
   getTagsForNotes,
-  getAllTags,
-  getAllTagDefinitions,
-  getOrCreateTag,
-  deleteTagDefinition,
   getPropertiesForNotes,
   getOutgoingLinks,
   getIncomingReferences,
   type NoteTreeCacheRow
 } from '@main/database/queries/notes'
 import type { NoteCache } from '@memry/db-schema/schema/notes-cache'
-import { getAllTaskTags } from '@main/database/queries/tasks'
+import { getAllTagsWithCounts } from '@main/database/queries/tags'
 import { getDatabase, getIndexDatabase } from '../database'
 import { toAbsolutePath } from './notes-io'
 import type {
@@ -115,46 +111,21 @@ export function noteToListItem(note: Note): NoteListItem {
 // Tags & Links
 // ============================================================================
 
+// This endpoint (notes:get-tags) feeds the editor's `#` autocomplete and the
+// tag pickers. It used to carry its own copy of the orphan-definition sweep,
+// which deleted any zero-usage row unconditionally — so a tag created in the
+// hub survived `tags:get-all` only until the first picker opened. Delegating
+// keeps one sweep with one predicate. It also merges counts case-insensitively,
+// which the old copy's exact-case maps did not.
 export function getTagsWithCounts(): { tag: string; color: string; count: number }[] {
   const indexDb = getIndexDatabase()
   const dataDb = getDatabase()
 
-  const definitions = getAllTagDefinitions(dataDb)
-  const noteUsage = getAllTags(indexDb)
-  const taskUsage = getAllTaskTags(dataDb)
-
-  const noteCountMap = new Map(noteUsage.map((u) => [u.tag, u.count]))
-  const taskCountMap = new Map(taskUsage.map((u) => [u.tag, u.count]))
-  const defMap = new Map(definitions.map((d) => [d.name, d.color]))
-
-  const results: { tag: string; color: string; count: number }[] = []
-
-  for (const def of definitions) {
-    const totalCount = (noteCountMap.get(def.name) ?? 0) + (taskCountMap.get(def.name) ?? 0)
-    if (totalCount > 0) {
-      results.push({ tag: def.name, color: def.color, count: totalCount })
-    } else {
-      deleteTagDefinition(dataDb, def.name)
-    }
-  }
-
-  for (const usage of noteUsage) {
-    if (!defMap.has(usage.tag)) {
-      const { color } = getOrCreateTag(dataDb, usage.tag)
-      defMap.set(usage.tag, color)
-      const totalCount = usage.count + (taskCountMap.get(usage.tag) ?? 0)
-      results.push({ tag: usage.tag, color, count: totalCount })
-    }
-  }
-
-  for (const usage of taskUsage) {
-    if (!defMap.has(usage.tag) && !noteCountMap.has(usage.tag)) {
-      const { color } = getOrCreateTag(dataDb, usage.tag)
-      results.push({ tag: usage.tag, color, count: usage.count })
-    }
-  }
-
-  return results.sort((a, b) => b.count - a.count)
+  return getAllTagsWithCounts(indexDb, dataDb).map((tag) => ({
+    tag: tag.name,
+    color: tag.color ?? '',
+    count: tag.count
+  }))
 }
 
 interface LinkContext {

--- a/apps/desktop/src/renderer/src/components/tags-hub/inline-create-row.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tags-hub/inline-create-row.test.tsx
@@ -97,4 +97,14 @@ describe('InlineCreateRow', () => {
 
     expect(onCreateTag).toHaveBeenCalledWith('draft', expect.any(String), 'cat-1')
   })
+
+  it('hands the tag name over with the casing the user typed', async () => {
+    const onCreateTag = vi.fn().mockResolvedValue(undefined)
+    render(<InlineCreateRow onCreateCategory={vi.fn()} onCreateTag={onCreateTag} />)
+
+    await userEvent.click(screen.getByRole('button', { name: /new tag/i }))
+    await userEvent.type(screen.getByRole('textbox'), 'Reading{Enter}')
+
+    expect(onCreateTag).toHaveBeenCalledWith('Reading', expect.any(String), null)
+  })
 })

--- a/apps/desktop/src/renderer/src/hooks/use-tag-categories.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tag-categories.test.ts
@@ -123,4 +123,33 @@ describe('useTagCategories', () => {
       expect(listCategories.mock.calls.length).toBeGreaterThan(listCategoriesCallsBefore)
     )
   })
+
+  it('creates a tag from the hub with the casing the user typed, and refetches so it lands without a restart', async () => {
+    updateTagColor.mockResolvedValue({ success: true })
+    reorder.mockResolvedValue({ success: true })
+
+    const { result } = renderHook(() => useTagCategories())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await result.current.createTag('Reading', 'emerald', null)
+
+    expect(updateTagColor).toHaveBeenCalledWith({ tag: 'Reading', color: 'emerald' })
+    expect(reorder).toHaveBeenCalledWith({
+      tags: [{ tag: 'Reading', categoryId: null, sortOrder: 0 }]
+    })
+    await waitFor(() => expect(refetchNoteTags).toHaveBeenCalled())
+    expect(result.current.error).toBeNull()
+  })
+
+  it('surfaces a failed tag create instead of swallowing it', async () => {
+    updateTagColor.mockResolvedValue({ success: false, error: 'disk is full' })
+
+    const { result } = renderHook(() => useTagCategories())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await result.current.createTag('Reading', 'emerald', null)
+
+    await waitFor(() => expect(result.current.error).toBe('disk is full'))
+    expect(reorder).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/tests/e2e/tag-creation-entry-point.e2e.ts
+++ b/apps/desktop/tests/e2e/tag-creation-entry-point.e2e.ts
@@ -1,0 +1,104 @@
+/**
+ * "New tag" in the tag hub, issue #1910.
+ *
+ * The reported bug is that the hub's create affordance offers both "New
+ * category" and "New tag", and only the category half does anything. The tag
+ * half wrote a `tag_definitions` row and the very next read
+ * (`getAllTagsWithCounts`) deleted it again as an unused orphan, so the tag
+ * never reached the list and no restart would have helped.
+ *
+ * A unit test on the query proves the row survives; only the app can say
+ * whether the button in front of the user reaches it. Both halves of the
+ * affordance are exercised here so a future change that revives the orphan
+ * sweep breaks this rather than shipping quietly.
+ */
+
+import { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { ready } from './utils/desktop-test-helpers'
+
+const UNIQUE = Date.now().toString(36)
+const TAG = `Reading${UNIQUE}`
+
+async function openTagHub(page: Page): Promise<void> {
+  await page.locator('button[aria-label="Open tag hub"]').click()
+  await page.getByRole('button', { name: /new tag/i }).waitFor({ state: 'visible', timeout: 10000 })
+}
+
+async function createTag(page: Page, name: string): Promise<void> {
+  await page.getByRole('button', { name: /new tag/i }).click()
+  await page.getByRole('textbox', { name: 'Tag name' }).fill(name)
+  await page.keyboard.press('Enter')
+}
+
+/** The chip's `title` is `${tag} (${count})`, so it carries both fields. */
+function chip(page: Page, name: string, count: number) {
+  return page.locator(`button[title="${name} (${count})"]`)
+}
+
+/** Every chip whose tag name matches `name` ignoring case. */
+function chipsIgnoringCase(page: Page, name: string) {
+  return page.locator(`button[title^="${name} (" i]`)
+}
+
+async function listedTags(page: Page): Promise<{ name: string; count: number }[]> {
+  return page.evaluate(async () => {
+    const { tags } = await window.api.tags.getAllWithCounts()
+    return tags.map((t) => ({ name: t.name, count: t.count }))
+  })
+}
+
+test.describe('Tag hub create affordance', () => {
+  test.beforeEach(async ({ page }) => {
+    await ready(page)
+  })
+
+  test('a tag created from the hub appears in the list without a restart', async ({ page }) => {
+    await openTagHub(page)
+    await createTag(page, TAG)
+
+    await expect(chip(page, TAG, 0)).toBeVisible({ timeout: 10000 })
+
+    const listed = await listedTags(page)
+    const match = listed.filter((t) => t.name.toLowerCase() === TAG.toLowerCase())
+    expect(match).toHaveLength(1)
+    expect(match[0].name).toBe(TAG)
+    expect(match[0].count).toBe(0)
+  })
+
+  test('the tag keeps the casing the user typed', async ({ page }) => {
+    const name = `Journal${UNIQUE}`
+
+    await openTagHub(page)
+    await createTag(page, name)
+
+    await expect(chip(page, name, 0)).toBeVisible({ timeout: 10000 })
+    await expect(chip(page, name.toLowerCase(), 0)).toHaveCount(0)
+
+    const listed = await listedTags(page)
+    expect(listed.map((t) => t.name)).toContain(name)
+  })
+
+  test('creating the same name in another case collides instead of making a second tag', async ({
+    page
+  }) => {
+    const name = `Errand${UNIQUE}`
+
+    await openTagHub(page)
+    await createTag(page, name)
+    await expect(chip(page, name, 0)).toBeVisible({ timeout: 10000 })
+
+    await createTag(page, name.toLowerCase())
+
+    // `tag_definitions.name` is a COLLATE NOCASE primary key, so the second
+    // create resolves to the row the first one made rather than adding a
+    // sibling, and the original casing stands.
+    await expect(chipsIgnoringCase(page, name)).toHaveCount(1)
+    await expect(chip(page, name, 0)).toBeVisible()
+
+    const listed = await listedTags(page)
+    const match = listed.filter((t) => t.name.toLowerCase() === name.toLowerCase())
+    expect(match).toHaveLength(1)
+    expect(match[0].name).toBe(name)
+  })
+})

--- a/apps/docs/src/user-guide/notes/properties-tags.md
+++ b/apps/docs/src/user-guide/notes/properties-tags.md
@@ -57,7 +57,13 @@ beside the sidebar's **New** button, and the **+** on the tab bar).
 - **New category** — click **New category**, name it, press Enter.
 - **New tag** — click **New tag** in the hub, name it, and pick a starting color. (You can
   still create a tag the usual way, by typing `#tag` on a note or in the tags row — this is
-  just a second entry point that lets you place it in a category up front.)
+  just a second entry point that lets you place it in a category up front.) The tag appears
+  in the hub straight away with a count of 0 and stays there until you use it, so you can lay
+  out a set of tags before writing anything. It keeps the capitalisation you typed —
+  `Reading` stays `Reading` — and because tag names ignore case, typing `reading` afterwards
+  reopens the same tag rather than making a second one. Until a note or task uses it, an
+  empty tag shows in the hub and in tag pickers but not in the sidebar's Tags section, which
+  lists the tags actually in use.
 - **Rename or delete a category** — hover its heading for the pencil and trash icons.
   Deleting a category does not delete its tags; they fall back to **Uncategorized**.
 - **Reorder** — drag a category to reorder categories, or drag a tag chip between or within

--- a/apps/docs/src/user-guide/notes/properties-tags.md
+++ b/apps/docs/src/user-guide/notes/properties-tags.md
@@ -62,8 +62,8 @@ beside the sidebar's **New** button, and the **+** on the tab bar).
   out a set of tags before writing anything. It keeps the capitalisation you typed —
   `Reading` stays `Reading` — and because tag names ignore case, typing `reading` afterwards
   reopens the same tag rather than making a second one. Until a note or task uses it, an
-  empty tag shows in the hub and in tag pickers but not in the sidebar's Tags section, which
-  lists the tags actually in use.
+  empty tag shows in the hub, in tag pickers, and in the editor's `#` autocomplete, but not in
+  the sidebar's Tags section, which lists the tags actually in use.
 - **Rename or delete a category** — hover its heading for the pencil and trash icons.
   Deleting a category does not delete its tags; they fall back to **Uncategorized**.
 - **Reorder** — drag a category to reorder categories, or drag a tag chip between or within


### PR DESCRIPTION
## What changed

The tag hub's create affordance offers **New category** and **New tag**. Only the category half has ever done anything. The tag half wrote a `tag_definitions` row, and the very next read deleted it again.

`getAllTagsWithCounts` — the query behind the hub, the sidebar and every tag picker — treated any definition row with no note or task behind it as garbage and deleted it, then filtered what survived to `count > 0`. The hub's create path writes exactly such a row and then refetches, so the row was collected before the refetch that was meant to show it. Not a swallowed error and not a missing call: the write happened, and the read destroyed it. No restart would have helped.

The rule predates the hub. It comes from the settings-era tag manager (#98, #111), when a tag existed only because a note used it. The hub arrived in #901 with an affordance for creating one that nothing uses yet, and the two models were never reconciled.

Two changes:

- A definition survives the sweep when it carries a deliberate mark — an authored colour, an icon, or a category — and is then listed at count 0. The hub's create path sets an authored colour as it creates, so a new tag is present on the refetch that follows. Bare auto-minted rows are still collected, so editing `#foo` to `#bar` inside a note still does not leave `foo` behind forever.
- `getOrCreateTag` stops lowercasing the name it inserts, so a tag no note uses yet has somewhere to keep its display name. The list otherwise takes display casing from usage, which an unused tag has none of.

I fixed the branch rather than removing the control. The control was deliberately designed, the docs already promise it works, and the reporter's underlying ask — build a taxonomy before writing the notes — is reasonable. Removing it would have confirmed the limitation instead of fixing it.

## Backward compatibility

No schema change, no migration, no contract change. `name` is already the primary key under `COLLATE NOCASE`, so `Reading` and `reading` stay one row and every existing `eq(name, lowercased)` lookup keeps matching.

- **Existing vaults are unaffected retroactively.** The sweep has run on every read since forever, so no vault has orphan definitions waiting to reappear.
- **Casing.** Only inserts change. An existing row's casing is never rewritten, so nothing re-emits to sync and there is no case ping-pong between devices. A row a device receives from sync is matched under NOCASE as before.
- **Older clients.** A tag definition created here syncs as an ordinary definition row. An older client applies it and, on its own read, sweeps it away if the tag reaches that client unused. Degraded, not broken, and it self-heals once the tag is used or the client updates.
- **Forward behaviour change.** A tag that was coloured, iconed or filed and then fell out of use now lingers at count 0 instead of vanishing, keeping the user's colour and category for when the tag comes back.

## Blast radius

The sidebar tree filters `count > 0` itself, so empty tags stay out of the navigation tree. Tag pickers, autocomplete and the capture bar now offer a freshly created tag, which is the point of creating one ahead of use.

`colorAuthored` is doing slightly more work than its name suggests — it now stands for "a human acted on this tag" rather than strictly "a human picked this colour". It is accurate today, since only the two colour pickers and the hub's create path set it, but a follow-up that gives `tag_definitions` an explicit "user created this" flag would model it honestly. That needs a migration and a sync-payload field, which is out of scope here.

## Verification

Node 24.16.0, from the worktree root.

- `pnpm --filter @memry/desktop test:main` — 564 files passed, 7702 passed, 1 expected fail, 6 skipped, exit 0.
- `pnpm --filter @memry/desktop test:renderer` — 3 failures, all pre-existing load flakes in `notes-tree-folder-rename-duplicate.test.tsx` (two 30s+ timeouts) and `agent-chat/__tests__/composer.test.tsx`. Rerun in isolation: 2 files, 51 passed, exit 0. Neither suite imports the changed modules.
- `pnpm lint` — exit 0, 0 errors, 108 pre-existing warnings, none in a changed file.
- `pnpm typecheck` — exit 0. `pnpm --filter @memry/desktop typecheck:test` — exit 0.
- `git diff --check` — clean.
- `pnpm docs:impact --strict` — covered. `pnpm docs:build` — exit 0.

The tests were written first and run red on `origin/main` before the fix:

```
× keeps a tag the hub created, before any note or task uses it
  → expected undefined to be defined
× keeps the casing the user typed
  → expected [] to include 'Reading'
× collides `reading` into `Reading` under nocase instead of making a second tag
  → expected [] to have a length of 1 but got +0
× carries the category the hub assigned
  → expected undefined to be 'cat-1'
× sorts used tags ahead of an unused one
  → expected [ 'work' ] to deeply equal [ 'work', 'Reading' ]
```

## Tests added

- `apps/desktop/src/main/database/queries/tags.test.ts` — 6 cases against a real SQLite pair. The tag survives the read; casing is kept; `reading` after `Reading` collides under `nocase` to one row; the assigned category carries; a bare unused definition is still collected; used tags sort ahead of unused ones.
- `apps/desktop/src/renderer/src/hooks/use-tag-categories.test.ts` — 2 cases. Create from the hub passes the typed casing through and refetches so the tag lands without a restart; a failed create surfaces through `extractErrorMessage` rather than being swallowed.
- `apps/desktop/src/renderer/src/components/tags-hub/inline-create-row.test.tsx` — 1 case. The control hands the name over with the casing the user typed.
- `apps/desktop/tests/e2e/tag-creation-entry-point.e2e.ts` — 3 tests through the real app. The tag appears in the list without a restart; the casing is kept; the same name in another case collides instead of making a second tag.

**E2E has not been run locally** — the coordinator runs the suite serially because it needs an Electron native rebuild.

Closes #1910
