### PR TITLE
fix(sidebar): persist the open state in localStorage instead of a cookie

### DIFF
--- a/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget-refresh.test.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget-refresh.test.tsx
@@ -31,10 +31,28 @@ const SOURCE_TYPE_BY_VISUAL_TYPE = {
   note: 'note'
 } as const
 
+/**
+ * The instant these tests pretend it is, on today's real local date.
+ *
+ * `use-today` snapshots the local date into module scope at import and re-reads the wall clock
+ * for its first subscriber. A clock faked onto any other date therefore arrives as a midnight
+ * rollover, which moves `todayCalendarRange`, moves the query key with it, and makes the widget
+ * fetch a second day on mount. Only the time of day is pinned, and from local fields rather than
+ * a UTC instant, which far enough from UTC would name a different day.
+ */
+const NOW = new Date()
+NOW.setHours(9, 30, 0, 0)
+
+function todayAtHour(hour: number): string {
+  const at = new Date(NOW)
+  at.setHours(hour, 0, 0, 0)
+  return at.toISOString()
+}
+
 function projectionItem(
   id: string,
   title: string,
-  hourUtc: number,
+  hour: number,
   visualType: keyof typeof SOURCE_TYPE_BY_VISUAL_TYPE
 ): CalendarProjectionItem {
   return {
@@ -43,8 +61,8 @@ function projectionItem(
     sourceId: id,
     title,
     descriptionPreview: null,
-    startAt: `2026-08-31T${String(hourUtc).padStart(2, '0')}:00:00.000Z`,
-    endAt: `2026-08-31T${String(hourUtc + 1).padStart(2, '0')}:00:00.000Z`,
+    startAt: todayAtHour(hour),
+    endAt: todayAtHour(hour + 1),
     isAllDay: false,
     timezone: 'UTC',
     visualType,
@@ -101,7 +119,7 @@ function renderApp(): { showBoard: (visible: boolean) => void } {
 
 describe('home calendar widget stays current', () => {
   beforeEach(() => {
-    vi.setSystemTime(new Date('2026-08-31T09:30:00.000Z'))
+    vi.setSystemTime(NOW)
     listeners.clear()
     server.items = [projectionItem('e1', 'Standup', 10, 'event')]
     mockGetRange.mockReset()

--- a/apps/desktop/src/renderer/src/components/ui/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { isMac } from '@/hooks/use-keyboard-shortcuts-base'
 import { __setShortcutOverridesForTests } from '@/lib/shortcut-bindings'
@@ -29,6 +29,14 @@ import {
   useSidebar
 } from './sidebar'
 
+const mocks = vi.hoisted(() => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => mocks.logger
+}))
+
 function SidebarStateProbe(): React.JSX.Element {
   const { state } = useSidebar()
   return <div data-testid="sidebar-state">{state}</div>
@@ -52,7 +60,6 @@ function setWindowWidth(width: number): void {
 
 describe('SidebarProvider shortcuts', () => {
   beforeEach(() => {
-    document.cookie = 'sidebar_state=; path=/; max-age=0'
     localStorage.clear()
     setWindowWidth(1024)
   })
@@ -217,6 +224,119 @@ describe('SidebarProvider shortcuts', () => {
   it('throws when useSidebar is read outside a provider', () => {
     expect(() => render(<SidebarStateProbe />)).toThrow(
       'useSidebar must be used within a SidebarProvider.'
+    )
+  })
+})
+
+describe('SidebarProvider open-state persistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setWindowWidth(1024)
+    mocks.logger.error.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('restores a collapsed sidebar from localStorage on mount', () => {
+    localStorage.setItem('sidebar_open', 'false')
+
+    render(
+      <SidebarProvider defaultOpen>
+        <SidebarStateProbe />
+      </SidebarProvider>
+    )
+
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('collapsed')
+  })
+
+  it('falls back to defaultOpen when the key was never written', () => {
+    render(
+      <SidebarProvider defaultOpen>
+        <SidebarStateProbe />
+      </SidebarProvider>
+    )
+
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('expanded')
+    expect(localStorage.getItem('sidebar_open')).toBeNull()
+  })
+
+  it('writes the open state to localStorage on toggle', () => {
+    render(
+      <SidebarProvider defaultOpen>
+        <SidebarStateProbe />
+      </SidebarProvider>
+    )
+
+    fireEvent.keyDown(window, { key: 'b', ...sidebarToggleShortcutInit() })
+
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('collapsed')
+    expect(localStorage.getItem('sidebar_open')).toBe('false')
+
+    fireEvent.keyDown(window, { key: 'b', ...sidebarToggleShortcutInit() })
+
+    expect(localStorage.getItem('sidebar_open')).toBe('true')
+  })
+
+  it('stays collapsed across a remount, which is what a vault switch does', () => {
+    // App.tsx keys SidebarProvider by vaultPath, so switching vaults remounts it.
+    const first = render(
+      <SidebarProvider defaultOpen>
+        <SidebarStateProbe />
+      </SidebarProvider>
+    )
+
+    fireEvent.keyDown(window, { key: 'b', ...sidebarToggleShortcutInit() })
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('collapsed')
+
+    first.unmount()
+
+    render(
+      <SidebarProvider defaultOpen>
+        <SidebarStateProbe />
+      </SidebarProvider>
+    )
+
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('collapsed')
+  })
+
+  it('logs and falls back to defaultOpen when the read throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => {
+      if (key === 'sidebar_open') throw new Error('storage blocked')
+      return null
+    })
+
+    render(
+      <SidebarProvider defaultOpen>
+        <SidebarStateProbe />
+      </SidebarProvider>
+    )
+
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('expanded')
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('sidebar open state'),
+      expect.any(Error)
+    )
+  })
+
+  it('logs and keeps toggling when the write throws', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string) => {
+      if (key === 'sidebar_open') throw new Error('storage blocked')
+    })
+
+    render(
+      <SidebarProvider defaultOpen>
+        <SidebarStateProbe />
+      </SidebarProvider>
+    )
+
+    fireEvent.keyDown(window, { key: 'b', ...sidebarToggleShortcutInit() })
+
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('collapsed')
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('sidebar open state'),
+      expect.any(Error)
     )
   })
 })

--- a/apps/desktop/src/renderer/src/components/ui/sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/sidebar.tsx
@@ -21,15 +21,17 @@ import { useKeyboardShortcuts, type KeyboardShortcut } from '@/hooks/use-keyboar
 import { isRichTextFocused } from '@/hooks/use-keyboard-shortcuts'
 import { useShortcutBinding } from '@/lib/shortcut-bindings'
 import { useT } from '@memry/i18n/renderer'
+import { createLogger } from '@/lib/logger'
 
-const SIDEBAR_COOKIE_NAME = 'sidebar_state'
-const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH_MOBILE = '18rem'
 const SIDEBAR_WIDTH_ICON = '3rem'
 const SIDEBAR_WIDTH_DEFAULT_PX = 256
 const SIDEBAR_WIDTH_MIN_PX = 171
 const SIDEBAR_WIDTH_MAX_PX = 480
 const SIDEBAR_STORAGE_KEY = 'sidebar_width'
+const SIDEBAR_OPEN_STORAGE_KEY = 'sidebar_open'
+
+const log = createLogger('Sidebar')
 
 type SidebarContextProps = {
   state: 'expanded' | 'collapsed'
@@ -74,10 +76,10 @@ function SidebarProvider({
 
   const [_open, _setOpen] = React.useState(() => {
     try {
-      const match = document.cookie.match(new RegExp(`${SIDEBAR_COOKIE_NAME}=([^;]+)`))
-      if (match) return match[1] === 'true'
-    } catch {
-      /* cookie unavailable */
+      const stored = localStorage.getItem(SIDEBAR_OPEN_STORAGE_KEY)
+      if (stored !== null) return stored === 'true'
+    } catch (error) {
+      log.error('Failed to read the sidebar open state', error)
     }
     return defaultOpen
   })
@@ -90,7 +92,11 @@ function SidebarProvider({
       } else {
         _setOpen(openState)
       }
-      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+      try {
+        localStorage.setItem(SIDEBAR_OPEN_STORAGE_KEY, String(openState))
+      } catch (error) {
+        log.error('Failed to persist the sidebar open state', error)
+      }
     },
     [setOpenProp, open]
   )

--- a/apps/desktop/tests/e2e/sidebar-open-state.e2e.ts
+++ b/apps/desktop/tests/e2e/sidebar-open-state.e2e.ts
@@ -1,0 +1,98 @@
+/**
+ * Sidebar open-state persistence E2E.
+ *
+ * The packaged renderer is loaded with `loadFile()`, so its origin is `file://`
+ * and Chromium drops every cookie written there. The old cookie-backed open
+ * state therefore never survived anything, while a dev run over
+ * `http://localhost` kept working — which is why the bug shipped. These two
+ * cases run against the built bundle, so they exercise the real `file://`
+ * origin the user has.
+ *
+ * The restart case cannot use `fixtures.ts` (one launch per test, fresh
+ * user-data dir per launch), so it drives `launchElectronWithWindow` directly
+ * twice against one `userDataDir` — localStorage lives in that dir.
+ */
+
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
+import { destroyElectronApp, launchElectronWithWindow } from './utils/electron-lifecycle'
+
+function makeVault(prefix: string): string {
+  const vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  fs.mkdirSync(path.join(vaultPath, '.memry'), { recursive: true })
+  fs.mkdirSync(path.join(vaultPath, 'notes'), { recursive: true })
+  fs.mkdirSync(path.join(vaultPath, 'journal'), { recursive: true })
+  return vaultPath
+}
+
+// Only the desktop branch of `Sidebar` carries data-state; the `collapsible="none"`
+// and mobile Sheet branches share data-slot but emit neither data-state nor data-side.
+function sidebar(page: Page) {
+  return page.locator('[data-slot="sidebar"][data-side="left"]')
+}
+
+async function collapseSidebar(page: Page): Promise<void> {
+  await expect(sidebar(page)).toHaveAttribute('data-state', 'expanded')
+  await page
+    .getByRole('button', { name: /toggle sidebar/i })
+    .first()
+    .click()
+  await expect(sidebar(page)).toHaveAttribute('data-state', 'collapsed')
+}
+
+test('a collapsed sidebar is still collapsed after a restart', async () => {
+  const testVaultPath = makeVault('memry-sidebar-open-state-vault-')
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-sidebar-open-state-userdata-'))
+
+  const first = await launchElectronWithWindow({ testVaultPath, userDataDir })
+  try {
+    await waitForAppReady(first.page)
+    await waitForVaultReady(first.page)
+    await collapseSidebar(first.page)
+  } finally {
+    // Empty dirs list: the user-data dir has to outlive this launch.
+    await destroyElectronApp(first.app, [])
+  }
+
+  const second = await launchElectronWithWindow({ testVaultPath, userDataDir })
+  try {
+    await waitForAppReady(second.page)
+    await waitForVaultReady(second.page)
+
+    await expect(sidebar(second.page)).toHaveAttribute('data-state', 'collapsed')
+  } finally {
+    await destroyElectronApp(second.app, [
+      second.userDataDir,
+      second.resolvedUserDataDir,
+      userDataDir
+    ])
+    fs.rmSync(testVaultPath, { recursive: true, force: true })
+  }
+})
+
+test('a collapsed sidebar is still collapsed after switching vaults', async ({ page }) => {
+  await waitForAppReady(page)
+  await waitForVaultReady(page)
+
+  await collapseSidebar(page)
+
+  // App.tsx renders `<SidebarProvider key={vaultPath}>`, so opening another
+  // vault remounts the provider and re-runs its state initializer.
+  const secondVaultPath = makeVault('memry-sidebar-open-state-second-')
+  try {
+    const created = await page.evaluate(
+      (p) => window.api.vault.create(p, 'Sidebar Second Vault'),
+      secondVaultPath
+    )
+    expect(created.success, created.error).toBe(true)
+    await waitForVaultReady(page)
+
+    await expect(sidebar(page)).toHaveAttribute('data-state', 'collapsed')
+  } finally {
+    fs.rmSync(secondVaultPath, { recursive: true, force: true })
+  }
+})

--- a/apps/desktop/tests/e2e/sidebar-open-state.e2e.ts
+++ b/apps/desktop/tests/e2e/sidebar-open-state.e2e.ts
@@ -8,15 +8,22 @@
  * cases run against the built bundle, so they exercise the real `file://`
  * origin the user has.
  *
- * The restart case cannot use `fixtures.ts` (one launch per test, fresh
- * user-data dir per launch), so it drives `launchElectronWithWindow` directly
- * twice against one `userDataDir` — localStorage lives in that dir.
+ * The restart case cannot use `fixtures.ts`, which launches once per test with
+ * a fresh user-data dir. It launches through the shared helper, then relaunches
+ * with that first process's own `spawnfile` and `spawnargs`, which already
+ * carry the resolved Electron binary, the main entry and `--user-data-dir`.
+ * Reusing them keeps the second launch byte-identical to the first without
+ * editing anything under `utils/`. That matters: Playwright's `--only-changed`
+ * follows the import graph, and every spec reaches `utils/electron-lifecycle.ts`
+ * through `fixtures.ts`, so touching it makes the changed-E2E job run all 593
+ * specs and blow its 35 minute budget.
  */
 
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import { Page } from '@playwright/test'
+import { _electron as electron } from '@playwright/test'
 import { test, expect } from './fixtures'
 import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
 import { destroyElectronApp, launchElectronWithWindow } from './utils/electron-lifecycle'
@@ -46,30 +53,40 @@ async function collapseSidebar(page: Page): Promise<void> {
 
 test('a collapsed sidebar is still collapsed after a restart', async () => {
   const testVaultPath = makeVault('memry-sidebar-open-state-vault-')
-  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-sidebar-open-state-userdata-'))
 
-  const first = await launchElectronWithWindow({ testVaultPath, userDataDir })
+  const first = await launchElectronWithWindow({ testVaultPath })
+  const spawned = first.app.process()
+  const executablePath = spawned.spawnfile
+  const args = spawned.spawnargs.slice(1)
+  const userDataDirs = [first.userDataDir, first.resolvedUserDataDir]
+
   try {
     await waitForAppReady(first.page)
     await waitForVaultReady(first.page)
     await collapseSidebar(first.page)
   } finally {
-    // Empty dirs list: the user-data dir has to outlive this launch.
+    // Empty dirs list: the user-data dir holds the localStorage the relaunch reads.
     await destroyElectronApp(first.app, [])
   }
 
-  const second = await launchElectronWithWindow({ testVaultPath, userDataDir })
-  try {
-    await waitForAppReady(second.page)
-    await waitForVaultReady(second.page)
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    NODE_ENV: 'test',
+    TEST_VAULT_PATH: testVaultPath,
+    MEMRY_TEST_LOG_DIR: path.join(first.userDataDir, 'logs')
+  }
+  delete env.ELECTRON_RUN_AS_NODE
 
-    await expect(sidebar(second.page)).toHaveAttribute('data-state', 'collapsed')
+  const second = await electron.launch({ executablePath, args, env })
+  try {
+    const page = await second.firstWindow({ timeout: 45_000 })
+    await page.waitForLoadState('domcontentloaded')
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+
+    await expect(sidebar(page)).toHaveAttribute('data-state', 'collapsed')
   } finally {
-    await destroyElectronApp(second.app, [
-      second.userDataDir,
-      second.resolvedUserDataDir,
-      userDataDir
-    ])
+    await destroyElectronApp(second, userDataDirs)
     fs.rmSync(testVaultPath, { recursive: true, force: true })
   }
 })

--- a/apps/desktop/tests/e2e/utils/electron-lifecycle.ts
+++ b/apps/desktop/tests/e2e/utils/electron-lifecycle.ts
@@ -34,6 +34,14 @@ export interface LaunchOptions {
   deviceId?: string
   syncServerUrl?: string | null
   extraEnv?: Record<string, string | undefined>
+  /**
+   * Reuse an existing user-data dir instead of minting a fresh one, so a
+   * relaunch sees the renderer state Chromium keeps there (localStorage,
+   * IndexedDB). Pass the same dir to both launches and delete it yourself.
+   * Note this also shares `logDir`, so `waitForMainLog` can match a line the
+   * earlier launch wrote.
+   */
+  userDataDir?: string
 }
 
 export interface LaunchedElectron {
@@ -179,7 +187,7 @@ export async function waitForMainLog(
 
 async function launchOnce(opts: LaunchOptions): Promise<LaunchedElectron> {
   const prefix = opts.deviceId ? `memry-userdata-${opts.deviceId}-` : 'memry-userdata-'
-  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  const userDataDir = opts.userDataDir ?? fs.mkdtempSync(path.join(os.tmpdir(), prefix))
   // Isolate electron-log's file output to this run's fresh dir (see logger.ts) so
   // waitForMainLog reads only lines from this launch, never a prior run's leftovers.
   const logDir = path.join(userDataDir, 'logs')

--- a/apps/desktop/tests/e2e/utils/electron-lifecycle.ts
+++ b/apps/desktop/tests/e2e/utils/electron-lifecycle.ts
@@ -34,14 +34,6 @@ export interface LaunchOptions {
   deviceId?: string
   syncServerUrl?: string | null
   extraEnv?: Record<string, string | undefined>
-  /**
-   * Reuse an existing user-data dir instead of minting a fresh one, so a
-   * relaunch sees the renderer state Chromium keeps there (localStorage,
-   * IndexedDB). Pass the same dir to both launches and delete it yourself.
-   * Note this also shares `logDir`, so `waitForMainLog` can match a line the
-   * earlier launch wrote.
-   */
-  userDataDir?: string
 }
 
 export interface LaunchedElectron {
@@ -187,7 +179,7 @@ export async function waitForMainLog(
 
 async function launchOnce(opts: LaunchOptions): Promise<LaunchedElectron> {
   const prefix = opts.deviceId ? `memry-userdata-${opts.deviceId}-` : 'memry-userdata-'
-  const userDataDir = opts.userDataDir ?? fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
   // Isolate electron-log's file output to this run's fresh dir (see logger.ts) so
   // waitForMainLog reads only lines from this launch, never a prior run's leftovers.
   const logDir = path.join(userDataDir, 'logs')

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -84,6 +84,9 @@ cell on <kbd>Esc</kbd>. See
 > the selection and nothing else, and everywhere else it toggles the sidebar. Rebind
 > **Toggle Sidebar** if you would rather keep the two apart.
 
+Memry remembers whether the sidebar is open. Close it and it stays closed when you
+switch vaults and when you next start the app, until you open it again.
+
 The same shortcut reference opens from the question-mark button in the sidebar footer.
 It groups shortcuts into General, Tabs & Splits, Inbox, Journal, Notes / Editor, Tasks,
 and Settings sections so you can scan by workflow.


### PR DESCRIPTION
## Summary

A sidebar the user closed came back open on the next launch and on every vault switch. `SidebarProvider` in `apps/desktop/src/renderer/src/components/ui/sidebar.tsx` kept the open state in a `sidebar_state` cookie. The packaged renderer is loaded with `loadFile()`, so its origin is `file://`, and Chromium stores no cookie for that origin. The write was a no-op, the read never matched, and the state initializer fell through to `defaultOpen = true` every time. The bare `catch` swallowed the failure, so nothing ever surfaced. A dev run serves the renderer over `http://localhost`, where cookies work, which is why this shipped.

The vault-switch half of the report has the same single cause. `App.tsx:632` renders `<SidebarProvider key={vaultPath}>`, so opening another vault unmounts and remounts the provider and re-runs that same failing read. One fix covers both symptoms.

The open state now persists through `localStorage` under `sidebar_open`. That is the mechanism `sidebarWidth` already uses twenty lines down in the same component, and it works on `file://`. The cookie path is deleted rather than kept alongside, so there is one persistence mechanism in this file instead of two. A failed read or write now logs through `createLogger('Sidebar')`.

Scope is global, not per vault, matching the width. The sidebar is a workspace layout preference rather than vault content, so a user who collapses it once should not have to collapse it again in each vault. The tradeoff is that someone who wants a different layout per vault cannot have one. Nobody can have that today either, and the reporter asked for the opposite.

Migration is nothing. A user who never wrote the key gets `defaultOpen`, exactly as before. No one has a readable `sidebar_state` cookie on `file://`, so there is no old value worth carrying over.

Blast radius is small. `SidebarProvider` is the only reader and writer of the key, and `apps/desktop/src/renderer/src/pages`, `app-sidebar.tsx` and the E2E suite all reach the state through `useSidebar()`. No shared test helper changed. The restart spec relaunches by reusing the first Electron process's own `spawnfile` and `spawnargs`, which already carry the resolved binary, the main entry and `--user-data-dir`, so the second launch is byte-identical to the first. An earlier revision added a `userDataDir` option to `apps/desktop/tests/e2e/utils/electron-lifecycle.ts` instead. That is worth recording. Playwright's `--only-changed` follows the import graph, every spec reaches that util through `fixtures.ts`, and the changed-E2E job therefore selected all 593 specs and hit its 35 minute cap twice.

Carries the test-only main fix from the calendar-widget PR until it lands; rebasing after that drops it.

Closes #1938

## Release note

Memry now remembers a closed sidebar across app restarts and vault switches.

## Test plan

The E2E is the load-bearing check here. It runs the built bundle from `file://`, which is the only surface where this bug exists, so it was proven red before green.

| Check | Outcome |
| --- | --- |
| `pnpm --filter @memry/desktop test:renderer` on `sidebar.test.tsx`, before the fix | 5 failed, 7 passed |
| `pnpm --filter @memry/desktop test:renderer` on `sidebar.test.tsx`, after the fix | 12 passed |
| `pnpm --filter @memry/desktop test:renderer`, whole suite | 8633 passed, 1 pre-existing failure in `calendar-widget-refresh.test.tsx` that reproduces identically on `origin/main` |
| `pnpm test:e2e` on `sidebar-open-state.e2e.ts` with `origin/main`'s `sidebar.tsx` | 2 failed, both `Expected: "collapsed" Received: "expanded"` |
| `pnpm test:e2e` on `sidebar-open-state.e2e.ts` and `sidebar-window-controls.e2e.ts` with the fix | 6 passed |
| `pnpm --filter @memry/desktop typecheck:web` / `typecheck:node` / `typecheck:test` | pass |
| `pnpm lint` | 0 errors, no new warnings |
| `pnpm --filter @memry/desktop i18n:check` | pass |
| `pnpm check:architecture` and `pnpm check:contracts` | pass |
| `pnpm docs:impact --base origin/main --strict` | covered |
| `pnpm docs:build` | pass |
| `git diff --check` | clean |

The new unit tests cover the read on mount, the fallback when the key was never written, the write on toggle, the remount that a vault switch performs, and the logged failure when `localStorage` throws on read and on write. Five mutations of the fix were each killed, including one that keeps the behaviour and only breaks propagation by hoisting the read to module scope, which survives first mount and fails the remount case.
