### PR TITLE
fix(reminders): replace a journal or note reminder instead of adding a second

### DIFF
--- a/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget-refresh.test.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget-refresh.test.tsx
@@ -31,10 +31,28 @@ const SOURCE_TYPE_BY_VISUAL_TYPE = {
   note: 'note'
 } as const
 
+/**
+ * The instant these tests pretend it is, on today's real local date.
+ *
+ * `use-today` snapshots the local date into module scope at import and re-reads the wall clock
+ * for its first subscriber. A clock faked onto any other date therefore arrives as a midnight
+ * rollover, which moves `todayCalendarRange`, moves the query key with it, and makes the widget
+ * fetch a second day on mount. Only the time of day is pinned, and from local fields rather than
+ * a UTC instant, which far enough from UTC would name a different day.
+ */
+const NOW = new Date()
+NOW.setHours(9, 30, 0, 0)
+
+function todayAtHour(hour: number): string {
+  const at = new Date(NOW)
+  at.setHours(hour, 0, 0, 0)
+  return at.toISOString()
+}
+
 function projectionItem(
   id: string,
   title: string,
-  hourUtc: number,
+  hour: number,
   visualType: keyof typeof SOURCE_TYPE_BY_VISUAL_TYPE
 ): CalendarProjectionItem {
   return {
@@ -43,8 +61,8 @@ function projectionItem(
     sourceId: id,
     title,
     descriptionPreview: null,
-    startAt: `2026-08-31T${String(hourUtc).padStart(2, '0')}:00:00.000Z`,
-    endAt: `2026-08-31T${String(hourUtc + 1).padStart(2, '0')}:00:00.000Z`,
+    startAt: todayAtHour(hour),
+    endAt: todayAtHour(hour + 1),
     isAllDay: false,
     timezone: 'UTC',
     visualType,
@@ -101,7 +119,7 @@ function renderApp(): { showBoard: (visible: boolean) => void } {
 
 describe('home calendar widget stays current', () => {
   beforeEach(() => {
-    vi.setSystemTime(new Date('2026-08-31T09:30:00.000Z'))
+    vi.setSystemTime(NOW)
     listeners.clear()
     server.items = [projectionItem('e1', 'Standup', 10, 'event')]
     mockGetRange.mockReset()

--- a/apps/desktop/src/renderer/src/components/journal/journal-reminder-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-reminder-button.test.tsx
@@ -39,14 +39,45 @@ vi.mock('@/components/ui/picker', async () => {
   return createPickerStub()
 })
 
+function reminderApi(): Record<string, ReturnType<typeof vi.fn>> {
+  return (getMockApi() as unknown as { reminders: Record<string, ReturnType<typeof vi.fn>> })
+    .reminders
+}
+
+/**
+ * `useNoteReminders` asks for both the note's own reminders and its highlight
+ * reminders, so the seed has to answer per target type. Returning the same row
+ * to both queries would list it twice and make the remove button ambiguous.
+ */
+function seedActiveReminder(targetType: 'journal' | 'note', targetId: string): void {
+  reminderApi().getForTarget.mockImplementation((input: { targetType: string }) =>
+    Promise.resolve(
+      input.targetType === targetType
+        ? [
+            {
+              id: `rem-${targetType}-1`,
+              targetType,
+              targetId,
+              remindAt: '2026-05-17T09:00:00.000Z',
+              status: 'pending',
+              note: null
+            }
+          ]
+        : []
+    )
+  )
+}
+
 describe('JournalReminderButton', () => {
   beforeEach(() => {
-    const api = getMockApi() as unknown as {
-      reminders: Record<string, ReturnType<typeof vi.fn>>
-    }
-    api.reminders.getForTarget = vi.fn().mockResolvedValue([])
-    api.reminders.create.mockClear()
-    api.reminders.create.mockResolvedValue({ success: true })
+    const api = reminderApi()
+    api.getForTarget = vi.fn().mockResolvedValue([])
+    api.create.mockClear()
+    api.create.mockResolvedValue({ success: true })
+    api.update.mockClear()
+    api.update.mockResolvedValue({ success: true, reminder: null })
+    api.delete.mockClear()
+    api.delete.mockResolvedValue({ success: true })
   })
 
   it('sends the note typed in the picker to reminders.create', async () => {
@@ -70,6 +101,40 @@ describe('JournalReminderButton', () => {
           note: 'revisit after the offsite'
         })
       )
+    })
+  })
+
+  it('moves the reminder the entry already has instead of creating a second', async () => {
+    const user = userEvent.setup()
+    seedActiveReminder('journal', '2026-05-10')
+    renderWithProviders(<JournalReminderButton journalDate="2026-05-10" />)
+
+    await screen.findByRole('button', {
+      name: /phaseF.componentsReminderReminderPicker.deleteReminder/
+    })
+    await user.click(screen.getByTestId('preset-in-one-week'))
+
+    await waitFor(() => {
+      expect(reminderApi().update).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'rem-journal-1' })
+      )
+    })
+    expect(reminderApi().create).not.toHaveBeenCalled()
+  })
+
+  it('removes the reminder from the picker list', async () => {
+    const user = userEvent.setup()
+    seedActiveReminder('journal', '2026-05-10')
+    renderWithProviders(<JournalReminderButton journalDate="2026-05-10" />)
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: /phaseF.componentsReminderReminderPicker.deleteReminder/
+      })
+    )
+
+    await waitFor(() => {
+      expect(reminderApi().delete).toHaveBeenCalledWith('rem-journal-1')
     })
   })
 })

--- a/apps/desktop/src/renderer/src/components/journal/journal-reminder-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-reminder-button.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders, getMockApi, userEvent } from '@tests/utils/render'
 import { JournalReminderButton } from './journal-reminder-button'
 
@@ -136,5 +136,29 @@ describe('JournalReminderButton', () => {
     await waitFor(() => {
       expect(reminderApi().delete).toHaveBeenCalledWith('rem-journal-1')
     })
+  })
+
+  it('changes the time on the reminder already set', async () => {
+    const user = userEvent.setup()
+    seedActiveReminder('journal', '2026-05-10')
+    renderWithProviders(<JournalReminderButton journalDate="2026-05-10" />)
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: /phaseF.componentsReminderReminderPicker.editReminder/
+      })
+    )
+    fireEvent.change(screen.getByLabelText(/phaseF.componentsReminderReminderPicker.time/), {
+      target: { value: '07:15' }
+    })
+    await user.click(
+      screen.getByRole('button', { name: 'phaseF.componentsReminderReminderPicker.save' })
+    )
+
+    await waitFor(() => expect(reminderApi().update).toHaveBeenCalledTimes(1))
+    const [payload] = reminderApi().update.mock.calls[0] as [{ id: string; remindAt: string }]
+    expect(payload.id).toBe('rem-journal-1')
+    const moved = new Date(payload.remindAt)
+    expect([moved.getHours(), moved.getMinutes()]).toEqual([7, 15])
   })
 })

--- a/apps/desktop/src/renderer/src/components/journal/journal-reminder-button.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-reminder-button.tsx
@@ -43,7 +43,7 @@ export function JournalReminderButton({
   const {
     settings: { clockFormat }
   } = useGeneralSettings()
-  const { hasActiveReminder, nextReminder, activeReminderCount, actions } =
+  const { activeReminders, hasActiveReminder, nextReminder, activeReminderCount, actions } =
     useJournalReminders(journalDate)
 
   const handleSetReminder = async (date: Date, note?: string): Promise<void> => {
@@ -74,6 +74,9 @@ export function JournalReminderButton({
             telemetrySurface="journal"
             showNote
             disabled={disabled}
+            reminders={activeReminders}
+            onEdit={(id, date, note) => void actions.editReminder(id, date, note)}
+            onDelete={(id) => void actions.deleteReminder(id)}
             trigger={
               <Button
                 variant="ghost"

--- a/apps/desktop/src/renderer/src/components/journal/journal-small-components.test.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-small-components.test.tsx
@@ -28,8 +28,13 @@ vi.mock('@/hooks/use-general-settings', () => ({
 
 vi.mock('@/hooks/use-journal-reminders', () => ({
   useJournalReminders: () => ({
+    activeReminders: [],
     ...mocks.reminderState,
-    actions: { setReminder: mocks.setReminder }
+    actions: {
+      setReminder: mocks.setReminder,
+      editReminder: vi.fn(),
+      deleteReminder: vi.fn()
+    }
   })
 }))
 

--- a/apps/desktop/src/renderer/src/components/note/note-reminder-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-reminder-button.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders, getMockApi, userEvent } from '@tests/utils/render'
 import { NoteReminderButton } from './note-reminder-button'
 
@@ -136,5 +136,29 @@ describe('NoteReminderButton', () => {
     await waitFor(() => {
       expect(reminderApi().delete).toHaveBeenCalledWith('rem-note-1')
     })
+  })
+
+  it('changes the time on the reminder already set', async () => {
+    const user = userEvent.setup()
+    seedActiveReminder('note', 'note-1')
+    renderWithProviders(<NoteReminderButton noteId="note-1" />)
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: /phaseF.componentsReminderReminderPicker.editReminder/
+      })
+    )
+    fireEvent.change(screen.getByLabelText(/phaseF.componentsReminderReminderPicker.time/), {
+      target: { value: '07:15' }
+    })
+    await user.click(
+      screen.getByRole('button', { name: 'phaseF.componentsReminderReminderPicker.save' })
+    )
+
+    await waitFor(() => expect(reminderApi().update).toHaveBeenCalledTimes(1))
+    const [payload] = reminderApi().update.mock.calls[0] as [{ id: string; remindAt: string }]
+    expect(payload.id).toBe('rem-note-1')
+    const moved = new Date(payload.remindAt)
+    expect([moved.getHours(), moved.getMinutes()]).toEqual([7, 15])
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/note-reminder-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-reminder-button.test.tsx
@@ -39,14 +39,45 @@ vi.mock('@/components/ui/picker', async () => {
   return createPickerStub()
 })
 
+function reminderApi(): Record<string, ReturnType<typeof vi.fn>> {
+  return (getMockApi() as unknown as { reminders: Record<string, ReturnType<typeof vi.fn>> })
+    .reminders
+}
+
+/**
+ * `useNoteReminders` asks for both the note's own reminders and its highlight
+ * reminders, so the seed has to answer per target type. Returning the same row
+ * to both queries would list it twice and make the remove button ambiguous.
+ */
+function seedActiveReminder(targetType: 'journal' | 'note', targetId: string): void {
+  reminderApi().getForTarget.mockImplementation((input: { targetType: string }) =>
+    Promise.resolve(
+      input.targetType === targetType
+        ? [
+            {
+              id: `rem-${targetType}-1`,
+              targetType,
+              targetId,
+              remindAt: '2026-05-17T09:00:00.000Z',
+              status: 'pending',
+              note: null
+            }
+          ]
+        : []
+    )
+  )
+}
+
 describe('NoteReminderButton', () => {
   beforeEach(() => {
-    const api = getMockApi() as unknown as {
-      reminders: Record<string, ReturnType<typeof vi.fn>>
-    }
-    api.reminders.getForTarget = vi.fn().mockResolvedValue([])
-    api.reminders.create.mockClear()
-    api.reminders.create.mockResolvedValue({ success: true })
+    const api = reminderApi()
+    api.getForTarget = vi.fn().mockResolvedValue([])
+    api.create.mockClear()
+    api.create.mockResolvedValue({ success: true })
+    api.update.mockClear()
+    api.update.mockResolvedValue({ success: true, reminder: null })
+    api.delete.mockClear()
+    api.delete.mockResolvedValue({ success: true })
   })
 
   it('sends the note typed in the picker to reminders.create', async () => {
@@ -70,6 +101,40 @@ describe('NoteReminderButton', () => {
           note: 'check the contract clause'
         })
       )
+    })
+  })
+
+  it('moves the reminder the note already has instead of creating a second', async () => {
+    const user = userEvent.setup()
+    seedActiveReminder('note', 'note-1')
+    renderWithProviders(<NoteReminderButton noteId="note-1" />)
+
+    await screen.findByRole('button', {
+      name: /phaseF.componentsReminderReminderPicker.deleteReminder/
+    })
+    await user.click(screen.getByTestId('preset-tomorrow'))
+
+    await waitFor(() => {
+      expect(reminderApi().update).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'rem-note-1' })
+      )
+    })
+    expect(reminderApi().create).not.toHaveBeenCalled()
+  })
+
+  it('removes the reminder from the picker list', async () => {
+    const user = userEvent.setup()
+    seedActiveReminder('note', 'note-1')
+    renderWithProviders(<NoteReminderButton noteId="note-1" />)
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: /phaseF.componentsReminderReminderPicker.deleteReminder/
+      })
+    )
+
+    await waitFor(() => {
+      expect(reminderApi().delete).toHaveBeenCalledWith('rem-note-1')
     })
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/note-reminder-button.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-reminder-button.tsx
@@ -41,7 +41,8 @@ export function NoteReminderButton({
   const {
     settings: { clockFormat }
   } = useGeneralSettings()
-  const { hasActiveReminder, nextReminder, activeReminderCount, actions } = useNoteReminders(noteId)
+  const { activeReminders, hasActiveReminder, nextReminder, activeReminderCount, actions } =
+    useNoteReminders(noteId)
 
   const handleSetReminder = async (date: Date, note?: string): Promise<void> => {
     await actions.setReminder(date, note)
@@ -71,6 +72,9 @@ export function NoteReminderButton({
             telemetrySurface="notes"
             showNote
             disabled={disabled}
+            reminders={activeReminders}
+            onEdit={(id, date, note) => void actions.editReminder(id, date, note)}
+            onDelete={(id) => void actions.deleteReminder(id)}
             trigger={
               <Button
                 variant="ghost"

--- a/apps/desktop/src/renderer/src/components/zero-renderer-surfaces-extra.test.tsx
+++ b/apps/desktop/src/renderer/src/components/zero-renderer-surfaces-extra.test.tsx
@@ -72,10 +72,15 @@ vi.mock('@/hooks/use-general-settings', () => ({
 
 vi.mock('@/hooks/use-note-reminders', () => ({
   useNoteReminders: () => ({
+    activeReminders: [],
     hasActiveReminder: true,
     nextReminder: { remindAt: '2026-05-10T10:00:00.000Z' },
     activeReminderCount: 12,
-    actions: { setReminder: mocks.setReminder }
+    actions: {
+      setReminder: mocks.setReminder,
+      editReminder: vi.fn(),
+      deleteReminder: vi.fn()
+    }
   })
 }))
 

--- a/apps/desktop/src/renderer/src/hooks/use-journal-reminders.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-journal-reminders.test.tsx
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   reminders: [] as Array<{ id: string; status: string; remindAt: string }>,
   isLoading: false,
   create: vi.fn(),
+  update: vi.fn(),
   delete: vi.fn(),
   dismiss: vi.fn(),
   snooze: vi.fn(),
@@ -36,6 +37,7 @@ vi.mock('./use-reminders', () => ({
     hasReminders: mocks.reminders.length > 0
   })),
   useCreateReminder: () => ({ mutateAsync: mocks.create }),
+  useUpdateReminder: () => ({ mutateAsync: mocks.update }),
   useDeleteReminder: () => ({ mutateAsync: mocks.delete }),
   useDismissReminder: () => ({ mutateAsync: mocks.dismiss }),
   useSnoozeReminder: () => ({ mutateAsync: mocks.snooze })
@@ -51,6 +53,7 @@ describe('useJournalReminders', () => {
       { id: 'next', status: 'pending', remindAt: '2026-05-10T10:00:00.000Z' }
     ]
     mocks.create.mockResolvedValue({ success: true })
+    mocks.update.mockResolvedValue({ success: true })
     mocks.delete.mockResolvedValue({ success: true })
     mocks.dismiss.mockResolvedValue({ success: true })
     mocks.snooze.mockResolvedValue({ success: true })
@@ -65,7 +68,7 @@ describe('useJournalReminders', () => {
     expect(result.current.isLoading).toBe(false)
   })
 
-  it('creates, deletes, dismisses, and snoozes journal reminders', async () => {
+  it('deletes, dismisses, and snoozes journal reminders', async () => {
     const { result } = renderHook(() => useJournalReminders('2026-05-10'))
 
     await act(async () => {
@@ -79,12 +82,6 @@ describe('useJournalReminders', () => {
       ).resolves.toBe(true)
     })
 
-    expect(mocks.create).toHaveBeenCalledWith({
-      targetType: 'journal',
-      targetId: '2026-05-10',
-      remindAt: '2026-05-10T12:00:00.000Z',
-      note: 'Read'
-    })
     expect(mocks.delete).toHaveBeenCalledWith('next')
     expect(mocks.dismiss).toHaveBeenCalledWith('next')
     expect(mocks.snooze).toHaveBeenCalledWith({
@@ -95,7 +92,7 @@ describe('useJournalReminders', () => {
   })
 
   it('returns false and reports mutation failures', async () => {
-    mocks.create.mockResolvedValueOnce({ success: false, error: 'Nope' })
+    mocks.update.mockResolvedValueOnce({ success: false, error: 'Nope' })
     mocks.delete.mockRejectedValueOnce(new Error('offline'))
     const { result } = renderHook(() => useJournalReminders('2026-05-10'))
 
@@ -109,6 +106,106 @@ describe('useJournalReminders', () => {
     expect(mocks.toastError).toHaveBeenCalledWith('Nope')
     expect(mocks.toastError).toHaveBeenCalledWith('reminder.error.delete')
     expect(mocks.logError).toHaveBeenCalledWith('Failed to delete reminder:', expect.any(Error))
+  })
+
+  it('moves the active reminder instead of adding a second one', async () => {
+    const { result } = renderHook(() => useJournalReminders('2026-05-10'))
+
+    await act(async () => {
+      await expect(
+        result.current.actions.setReminder(new Date('2026-05-10T18:30:00.000Z'), 'Read')
+      ).resolves.toBe(true)
+    })
+
+    expect(mocks.create).not.toHaveBeenCalled()
+    expect(mocks.update).toHaveBeenCalledTimes(1)
+    expect(mocks.update).toHaveBeenCalledWith({
+      id: 'next',
+      remindAt: '2026-05-10T18:30:00.000Z',
+      note: 'Read'
+    })
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('reminder.success.updated')
+  })
+
+  it('clears the note the replaced reminder carried when the picker sends none', async () => {
+    const { result } = renderHook(() => useJournalReminders('2026-05-10'))
+
+    await act(async () => {
+      await result.current.actions.setReminder(new Date('2026-05-10T18:30:00.000Z'))
+    })
+
+    expect(mocks.update).toHaveBeenCalledWith({
+      id: 'next',
+      remindAt: '2026-05-10T18:30:00.000Z',
+      note: null
+    })
+  })
+
+  it('creates the first reminder when the entry has no active one', async () => {
+    mocks.reminders = [{ id: 'done', status: 'dismissed', remindAt: '2026-05-12T09:00:00.000Z' }]
+    const { result } = renderHook(() => useJournalReminders('2026-05-10'))
+
+    await act(async () => {
+      await expect(
+        result.current.actions.setReminder(new Date('2026-05-10T18:30:00.000Z'), 'Read')
+      ).resolves.toBe(true)
+    })
+
+    expect(mocks.update).not.toHaveBeenCalled()
+    expect(mocks.create).toHaveBeenCalledWith({
+      targetType: 'journal',
+      targetId: '2026-05-10',
+      remindAt: '2026-05-10T18:30:00.000Z',
+      note: 'Read'
+    })
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('reminder.success.set')
+  })
+
+  it('exposes the active reminders the picker manages and edits one by id', async () => {
+    const { result } = renderHook(() => useJournalReminders('2026-05-10'))
+
+    expect(result.current.activeReminders.map((reminder) => reminder.id)).toEqual(['next', 'later'])
+
+    await act(async () => {
+      await expect(
+        result.current.actions.editReminder('later', new Date('2026-05-11T18:30:00.000Z'), 'moved')
+      ).resolves.toBe(true)
+    })
+
+    expect(mocks.update).toHaveBeenCalledWith({
+      id: 'later',
+      remindAt: '2026-05-11T18:30:00.000Z',
+      note: 'moved'
+    })
+  })
+
+  it('reports a failed replace against the update wording', async () => {
+    mocks.update.mockResolvedValueOnce({ success: false })
+    const { result } = renderHook(() => useJournalReminders('2026-05-10'))
+
+    await act(async () => {
+      await expect(
+        result.current.actions.setReminder(new Date('2026-05-10T18:30:00.000Z'))
+      ).resolves.toBe(false)
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith('reminder.error.update')
+  })
+
+  it('drops the active indicator once the last reminder is gone', () => {
+    mocks.reminders = [{ id: 'next', status: 'pending', remindAt: '2026-05-10T10:00:00.000Z' }]
+    const { result, rerender } = renderHook(() => useJournalReminders('2026-05-10'))
+
+    expect(result.current.hasActiveReminder).toBe(true)
+    expect(result.current.activeReminderCount).toBe(1)
+
+    mocks.reminders = []
+    rerender()
+
+    expect(result.current.hasActiveReminder).toBe(false)
+    expect(result.current.activeReminderCount).toBe(0)
+    expect(result.current.activeReminders).toEqual([])
+    expect(result.current.nextReminder).toBeNull()
   })
 
   it('does not create a reminder without a journal date', async () => {

--- a/apps/desktop/src/renderer/src/hooks/use-journal-reminders.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-journal-reminders.test.tsx
@@ -208,6 +208,41 @@ describe('useJournalReminders', () => {
     expect(result.current.nextReminder).toBeNull()
   })
 
+  it('surfaces edit failures and thrown errors against the update wording', async () => {
+    const { result } = renderHook(() => useJournalReminders('2026-05-10'))
+
+    mocks.update.mockResolvedValueOnce({ success: false, error: 'server said no' })
+    await act(async () => {
+      await expect(
+        result.current.actions.editReminder('later', new Date('2026-05-11T18:30:00.000Z'))
+      ).resolves.toBe(false)
+    })
+    expect(mocks.toastError).toHaveBeenCalledWith('server said no')
+
+    mocks.update.mockRejectedValueOnce(new Error('offline'))
+    await act(async () => {
+      await expect(
+        result.current.actions.editReminder('later', new Date('2026-05-11T18:30:00.000Z'))
+      ).resolves.toBe(false)
+    })
+    expect(mocks.toastError).toHaveBeenCalledWith('reminder.error.update')
+    expect(mocks.logError).toHaveBeenCalledWith(
+      'Failed to edit journal reminder:',
+      expect.any(Error)
+    )
+
+    mocks.update.mockRejectedValueOnce(new Error('offline'))
+    await act(async () => {
+      await expect(
+        result.current.actions.setReminder(new Date('2026-05-10T18:30:00.000Z'))
+      ).resolves.toBe(false)
+    })
+    expect(mocks.logError).toHaveBeenCalledWith(
+      'Failed to set journal reminder:',
+      expect.any(Error)
+    )
+  })
+
   it('does not create a reminder without a journal date', async () => {
     const { result } = renderHook(() => useJournalReminders(null))
 

--- a/apps/desktop/src/renderer/src/hooks/use-journal-reminders.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-journal-reminders.ts
@@ -11,11 +11,12 @@ import { useMemo, useCallback } from 'react'
 import { createLogger } from '@/lib/logger'
 import {
   useRemindersForTarget,
-  useCreateReminder,
+  useUpdateReminder,
   useDeleteReminder,
   useDismissReminder,
   useSnoozeReminder
 } from './use-reminders'
+import { useSetOrReplaceReminder } from './use-set-or-replace-reminder'
 import { toast } from 'sonner'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { useT } from '@memry/i18n/renderer'
@@ -27,8 +28,10 @@ const log = createLogger('Hook:JournalReminders')
 // ============================================================================
 
 export interface JournalReminderActions {
-  /** Create a reminder for the journal entry */
+  /** Set the entry's reminder, moving the active one when it already has it */
   setReminder: (remindAt: Date, note?: string) => Promise<boolean>
+  /** Edit an existing reminder's time and/or note */
+  editReminder: (reminderId: string, remindAt: Date, note?: string) => Promise<boolean>
   /** Delete a reminder */
   deleteReminder: (reminderId: string) => Promise<boolean>
   /** Dismiss a reminder */
@@ -40,6 +43,8 @@ export interface JournalReminderActions {
 export interface UseJournalRemindersResult {
   /** All reminders for this journal entry */
   reminders: ReturnType<typeof useRemindersForTarget>['reminders']
+  /** Active (pending/snoozed) reminders, sorted by remindAt */
+  activeReminders: ReturnType<typeof useRemindersForTarget>['reminders']
   /** Whether there are any active (pending/snoozed) reminders */
   hasActiveReminder: boolean
   /** The next upcoming reminder (if any) */
@@ -69,23 +74,24 @@ export function useJournalReminders(journalDate: string | null): UseJournalRemin
     hasReminders: _hasReminders
   } = useRemindersForTarget('journal', journalDate ?? '')
 
-  // Filter for active reminders (pending or snoozed)
-  const activeReminders = useMemo(() => {
-    return reminders.filter((r) => r.status === 'pending' || r.status === 'snoozed')
-  }, [reminders])
+  const allReminders = useMemo(
+    () =>
+      [...reminders].sort(
+        (a, b) => new Date(a.remindAt).getTime() - new Date(b.remindAt).getTime()
+      ),
+    [reminders]
+  )
 
-  // Get next upcoming reminder
-  const nextReminder = useMemo(() => {
-    if (activeReminders.length === 0) return null
-    // Sort by remindAt and get the first one
-    const sorted = [...activeReminders].sort(
-      (a, b) => new Date(a.remindAt).getTime() - new Date(b.remindAt).getTime()
-    )
-    return sorted[0]
-  }, [activeReminders])
+  const activeReminders = useMemo(
+    () => allReminders.filter((r) => r.status === 'pending' || r.status === 'snoozed'),
+    [allReminders]
+  )
+
+  const nextReminder = activeReminders[0] ?? null
 
   // Mutations
-  const createReminderMutation = useCreateReminder()
+  const setOrReplaceReminder = useSetOrReplaceReminder()
+  const updateReminderMutation = useUpdateReminder()
   const deleteReminderMutation = useDeleteReminder()
   const dismissReminderMutation = useDismissReminder()
   const snoozeReminderMutation = useSnoozeReminder()
@@ -95,28 +101,60 @@ export function useJournalReminders(journalDate: string | null): UseJournalRemin
     async (remindAt: Date, note?: string): Promise<boolean> => {
       if (!journalDate) return false
 
+      const replacingId = nextReminder?.id ?? null
+      const success = replacingId ? t('reminder.success.updated') : t('reminder.success.set')
+      const failure = replacingId ? t('reminder.error.update') : t('reminder.error.set')
+
       try {
-        const result = await createReminderMutation.mutateAsync({
-          targetType: 'journal',
-          targetId: journalDate,
+        const result = await setOrReplaceReminder(
+          {
+            targetType: 'journal',
+            targetId: journalDate,
+            remindAt: remindAt.toISOString(),
+            note
+          },
+          replacingId
+        )
+
+        if (result.success) {
+          toast.success(success)
+          return true
+        } else {
+          toast.error(extractErrorMessage(result.error, failure))
+          return false
+        }
+      } catch (err) {
+        log.error('Failed to set journal reminder:', err)
+        toast.error(failure)
+        return false
+      }
+    },
+    [journalDate, nextReminder, setOrReplaceReminder, t]
+  )
+
+  const editReminderAction = useCallback(
+    async (reminderId: string, remindAt: Date, note?: string): Promise<boolean> => {
+      try {
+        const result = await updateReminderMutation.mutateAsync({
+          id: reminderId,
           remindAt: remindAt.toISOString(),
           note
         })
 
         if (result.success) {
-          toast.success(t('reminder.success.set'))
+          toast.success(t('reminder.success.updated'))
           return true
         } else {
-          toast.error(extractErrorMessage(result.error, t('reminder.error.set')))
+          toast.error(extractErrorMessage(result.error, t('reminder.error.update')))
           return false
         }
       } catch (err) {
-        log.error('Failed to set journal reminder:', err)
-        toast.error(t('reminder.error.set'))
+        log.error('Failed to edit journal reminder:', err)
+        toast.error(t('reminder.error.update'))
         return false
       }
     },
-    [journalDate, createReminderMutation, t]
+    [updateReminderMutation, t]
   )
 
   const deleteReminderAction = useCallback(
@@ -188,15 +226,23 @@ export function useJournalReminders(journalDate: string | null): UseJournalRemin
   const actions: JournalReminderActions = useMemo(
     () => ({
       setReminder,
+      editReminder: editReminderAction,
       deleteReminder: deleteReminderAction,
       dismissReminder: dismissReminderAction,
       snoozeReminder: snoozeReminderAction
     }),
-    [setReminder, deleteReminderAction, dismissReminderAction, snoozeReminderAction]
+    [
+      setReminder,
+      editReminderAction,
+      deleteReminderAction,
+      dismissReminderAction,
+      snoozeReminderAction
+    ]
   )
 
   return {
-    reminders,
+    reminders: allReminders,
+    activeReminders,
     hasActiveReminder: activeReminders.length > 0,
     nextReminder,
     activeReminderCount: activeReminders.length,

--- a/apps/desktop/src/renderer/src/hooks/use-note-reminders.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-note-reminders.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   noteLoading: false,
   highlightLoading: false,
   createReminder: vi.fn(),
+  updateReminder: vi.fn(),
   deleteReminder: vi.fn(),
   dismissReminder: vi.fn(),
   snoozeReminder: vi.fn(),
@@ -42,6 +43,7 @@ vi.mock('./use-reminders', () => ({
     isLoading: targetType === 'note' ? mocks.noteLoading : mocks.highlightLoading
   }),
   useCreateReminder: () => ({ mutateAsync: mocks.createReminder }),
+  useUpdateReminder: () => ({ mutateAsync: mocks.updateReminder }),
   useDeleteReminder: () => ({ mutateAsync: mocks.deleteReminder }),
   useDismissReminder: () => ({ mutateAsync: mocks.dismissReminder }),
   useSnoozeReminder: () => ({ mutateAsync: mocks.snoozeReminder })
@@ -60,6 +62,7 @@ describe('useNoteReminders', () => {
     mocks.noteLoading = false
     mocks.highlightLoading = false
     mocks.createReminder.mockResolvedValue({ success: true })
+    mocks.updateReminder.mockResolvedValue({ success: true })
     mocks.deleteReminder.mockResolvedValue({ success: true })
     mocks.dismissReminder.mockResolvedValue({ success: true })
     mocks.snoozeReminder.mockResolvedValue({ success: true })
@@ -88,17 +91,93 @@ describe('useNoteReminders', () => {
       ).toBe(true)
     })
 
-    expect(mocks.createReminder).toHaveBeenCalledWith(
-      expect.objectContaining({ targetType: 'note', targetId: 'note-1', note: 'note' })
-    )
     expect(mocks.deleteReminder).toHaveBeenCalledWith('later')
     expect(mocks.dismissReminder).toHaveBeenCalledWith('soon')
     expect(mocks.snoozeReminder).toHaveBeenCalledWith({
       id: 'soon',
       snoozeUntil: '2026-05-15T00:00:00.000Z'
     })
-    expect(mocks.toastSuccess).toHaveBeenCalledWith('reminders.toast.set')
     expect(mocks.toastSuccess).toHaveBeenCalledWith('phaseI.toasts.reminderSnoozed')
+  })
+
+  it("moves the note's own reminder instead of adding a second one", async () => {
+    const { result } = renderHook(() => useNoteReminders('note-1'))
+
+    await act(async () => {
+      expect(
+        await result.current.actions.setReminder(new Date('2026-05-13T00:00:00Z'), 'note')
+      ).toBe(true)
+    })
+
+    expect(mocks.createReminder).not.toHaveBeenCalled()
+    expect(mocks.updateReminder).toHaveBeenCalledTimes(1)
+    expect(mocks.updateReminder).toHaveBeenCalledWith({
+      id: 'later',
+      remindAt: '2026-05-13T00:00:00.000Z',
+      note: 'note'
+    })
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('reminders.toast.updated')
+  })
+
+  it('never moves a highlight reminder, even when it is the next one due', async () => {
+    mocks.noteReminders = []
+    const { result } = renderHook(() => useNoteReminders('note-1'))
+
+    expect(result.current.nextReminder?.id).toBe('soon')
+
+    await act(async () => {
+      await result.current.actions.setReminder(new Date('2026-05-13T00:00:00Z'))
+    })
+
+    expect(mocks.updateReminder).not.toHaveBeenCalled()
+    expect(mocks.createReminder).toHaveBeenCalledWith(
+      expect.objectContaining({ targetType: 'note', targetId: 'note-1' })
+    )
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('reminders.toast.set')
+  })
+
+  it('lists every active reminder for the picker and edits one by id', async () => {
+    const { result } = renderHook(() => useNoteReminders('note-1'))
+
+    expect(result.current.activeReminders.map((reminder) => reminder.id)).toEqual(['soon', 'later'])
+
+    await act(async () => {
+      expect(
+        await result.current.actions.editReminder('soon', new Date('2026-05-15T00:00:00Z'), 'moved')
+      ).toBe(true)
+    })
+
+    expect(mocks.updateReminder).toHaveBeenCalledWith({
+      id: 'soon',
+      remindAt: '2026-05-15T00:00:00.000Z',
+      note: 'moved'
+    })
+  })
+
+  it('drops the active indicator once the last reminder is gone', () => {
+    mocks.highlightReminders = []
+    const { result, rerender } = renderHook(() => useNoteReminders('note-1'))
+
+    expect(result.current.hasActiveReminder).toBe(true)
+
+    mocks.noteReminders = []
+    rerender()
+
+    expect(result.current.hasActiveReminder).toBe(false)
+    expect(result.current.activeReminderCount).toBe(0)
+    expect(result.current.activeReminders).toEqual([])
+    expect(result.current.nextReminder).toBeNull()
+  })
+
+  it('reports a failed replace against the update wording', async () => {
+    mocks.updateReminder.mockResolvedValueOnce({ success: false })
+    const { result } = renderHook(() => useNoteReminders('note-1'))
+
+    await act(async () => {
+      expect(await result.current.actions.setReminder(new Date('2026-05-13T00:00:00Z'))).toBe(false)
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith('reminders.toast.updateFailed')
   })
 
   it('returns false for missing note ids, mutation failures, thrown errors, and loading states', async () => {
@@ -114,7 +193,7 @@ describe('useNoteReminders', () => {
     expect(mocks.createReminder).not.toHaveBeenCalled()
 
     rerender({ noteId: 'note-1' })
-    mocks.createReminder.mockResolvedValueOnce({ success: false, error: 'nope' })
+    mocks.updateReminder.mockResolvedValueOnce({ success: false, error: 'nope' })
     mocks.deleteReminder.mockResolvedValueOnce({ success: false, error: 'delete nope' })
     mocks.dismissReminder.mockRejectedValueOnce(new Error('dismiss boom'))
     mocks.snoozeReminder.mockResolvedValueOnce({ success: false, error: 'snooze nope' })

--- a/apps/desktop/src/renderer/src/hooks/use-note-reminders.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-note-reminders.test.tsx
@@ -169,6 +169,33 @@ describe('useNoteReminders', () => {
     expect(result.current.nextReminder).toBeNull()
   })
 
+  it('surfaces edit failures and thrown errors against the update wording', async () => {
+    const { result } = renderHook(() => useNoteReminders('note-1'))
+
+    mocks.updateReminder.mockResolvedValueOnce({ success: false, error: 'server said no' })
+    await act(async () => {
+      expect(
+        await result.current.actions.editReminder('soon', new Date('2026-05-15T00:00:00Z'))
+      ).toBe(false)
+    })
+    expect(mocks.toastError).toHaveBeenCalledWith('server said no')
+
+    mocks.updateReminder.mockRejectedValueOnce(new Error('offline'))
+    await act(async () => {
+      expect(
+        await result.current.actions.editReminder('soon', new Date('2026-05-15T00:00:00Z'))
+      ).toBe(false)
+    })
+    expect(mocks.toastError).toHaveBeenCalledWith('reminders.toast.updateFailed')
+    expect(mocks.logError).toHaveBeenCalledWith('Failed to edit reminder:', expect.any(Error))
+
+    mocks.updateReminder.mockRejectedValueOnce(new Error('offline'))
+    await act(async () => {
+      expect(await result.current.actions.setReminder(new Date('2026-05-13T00:00:00Z'))).toBe(false)
+    })
+    expect(mocks.logError).toHaveBeenCalledWith('Failed to set reminder:', expect.any(Error))
+  })
+
   it('reports a failed replace against the update wording', async () => {
     mocks.updateReminder.mockResolvedValueOnce({ success: false })
     const { result } = renderHook(() => useNoteReminders('note-1'))

--- a/apps/desktop/src/renderer/src/hooks/use-note-reminders.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-note-reminders.ts
@@ -12,11 +12,12 @@ import { useMemo, useCallback } from 'react'
 import { createLogger } from '@/lib/logger'
 import {
   useRemindersForTarget,
-  useCreateReminder,
+  useUpdateReminder,
   useDeleteReminder,
   useDismissReminder,
   useSnoozeReminder
 } from './use-reminders'
+import { useSetOrReplaceReminder } from './use-set-or-replace-reminder'
 import { toast } from 'sonner'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { useT } from '@memry/i18n/renderer'
@@ -28,8 +29,10 @@ const log = createLogger('Hook:NoteReminders')
 // ============================================================================
 
 export interface NoteReminderActions {
-  /** Create a reminder for the note */
+  /** Set the note's reminder, moving the active one when it already has it */
   setReminder: (remindAt: Date, note?: string) => Promise<boolean>
+  /** Edit an existing reminder's time and/or note */
+  editReminder: (reminderId: string, remindAt: Date, note?: string) => Promise<boolean>
   /** Delete a reminder */
   deleteReminder: (reminderId: string) => Promise<boolean>
   /** Dismiss a reminder */
@@ -41,6 +44,8 @@ export interface NoteReminderActions {
 export interface UseNoteRemindersResult {
   /** All reminders for this note (including highlight reminders) */
   reminders: ReturnType<typeof useRemindersForTarget>['reminders']
+  /** Active (pending/snoozed) reminders, sorted by remindAt */
+  activeReminders: ReturnType<typeof useRemindersForTarget>['reminders']
   /** Whether there are any active (pending/snoozed) reminders */
   hasActiveReminder: boolean
   /** The next upcoming reminder (if any) */
@@ -87,8 +92,23 @@ export function useNoteReminders(noteId: string | null): UseNoteRemindersResult 
     return activeReminders[0] // Already sorted by remindAt
   }, [activeReminders])
 
+  /**
+   * The bell sets a reminder on the note itself, so only a reminder on the note
+   * is replaced by a new time. A highlight reminder is anchored to a passage:
+   * it is listed and removable here, but moving it from the note toolbar would
+   * silently reschedule something the user never opened.
+   */
+  const replaceableReminder = useMemo(() => {
+    const active = noteReminders.filter((r) => r.status === 'pending' || r.status === 'snoozed')
+    const sorted = [...active].sort(
+      (a, b) => new Date(a.remindAt).getTime() - new Date(b.remindAt).getTime()
+    )
+    return sorted[0] ?? null
+  }, [noteReminders])
+
   // Mutations
-  const createReminderMutation = useCreateReminder()
+  const setOrReplaceReminder = useSetOrReplaceReminder()
+  const updateReminderMutation = useUpdateReminder()
   const deleteReminderMutation = useDeleteReminder()
   const dismissReminderMutation = useDismissReminder()
   const snoozeReminderMutation = useSnoozeReminder()
@@ -98,28 +118,62 @@ export function useNoteReminders(noteId: string | null): UseNoteRemindersResult 
     async (remindAt: Date, note?: string): Promise<boolean> => {
       if (!noteId) return false
 
+      const replacingId = replaceableReminder?.id ?? null
+      const success = replacingId ? t('reminders.toast.updated') : t('reminders.toast.set')
+      const failure = replacingId
+        ? t('reminders.toast.updateFailed')
+        : t('reminders.toast.setFailed')
+
       try {
-        const result = await createReminderMutation.mutateAsync({
-          targetType: 'note',
-          targetId: noteId,
+        const result = await setOrReplaceReminder(
+          {
+            targetType: 'note',
+            targetId: noteId,
+            remindAt: remindAt.toISOString(),
+            note
+          },
+          replacingId
+        )
+
+        if (result.success) {
+          toast.success(success)
+          return true
+        } else {
+          toast.error(extractErrorMessage(result.error, failure))
+          return false
+        }
+      } catch (err) {
+        log.error('Failed to set reminder:', err)
+        toast.error(failure)
+        return false
+      }
+    },
+    [noteId, replaceableReminder, setOrReplaceReminder, t]
+  )
+
+  const editReminderAction = useCallback(
+    async (reminderId: string, remindAt: Date, note?: string): Promise<boolean> => {
+      try {
+        const result = await updateReminderMutation.mutateAsync({
+          id: reminderId,
           remindAt: remindAt.toISOString(),
           note
         })
 
         if (result.success) {
-          toast.success(t('reminders.toast.set'))
+          toast.success(t('reminders.toast.updated'))
           return true
         } else {
-          toast.error(extractErrorMessage(result.error, t('reminders.toast.setFailed')))
+          toast.error(extractErrorMessage(result.error, t('reminders.toast.updateFailed')))
           return false
         }
       } catch (err) {
-        log.error('Failed to set reminder:', err)
-        toast.error(t('reminders.toast.setFailed'))
+        log.error('Failed to edit reminder:', err)
+        toast.error(t('reminders.toast.updateFailed'))
         return false
       }
     },
-    [noteId, createReminderMutation, t]
+    [updateReminderMutation, t]
   )
 
   const deleteReminderAction = useCallback(
@@ -196,15 +250,23 @@ export function useNoteReminders(noteId: string | null): UseNoteRemindersResult 
   const actions: NoteReminderActions = useMemo(
     () => ({
       setReminder,
+      editReminder: editReminderAction,
       deleteReminder: deleteReminderAction,
       dismissReminder: dismissReminderAction,
       snoozeReminder: snoozeReminderAction
     }),
-    [setReminder, deleteReminderAction, dismissReminderAction, snoozeReminderAction]
+    [
+      setReminder,
+      editReminderAction,
+      deleteReminderAction,
+      dismissReminderAction,
+      snoozeReminderAction
+    ]
   )
 
   return {
     reminders: allReminders,
+    activeReminders,
     hasActiveReminder: activeReminders.length > 0,
     nextReminder,
     activeReminderCount: activeReminders.length,

--- a/apps/desktop/src/renderer/src/hooks/use-set-or-replace-reminder.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-set-or-replace-reminder.ts
@@ -1,0 +1,47 @@
+/**
+ * Set-or-replace Reminder Hook
+ *
+ * A journal entry and a note each carry one reminder. Picking a time while one
+ * is already active moves that reminder instead of appending a second row, so a
+ * custom time chosen after a preset replaces the preset rather than firing
+ * twice. Both surfaces share this so the rule cannot drift between them.
+ *
+ * @module hooks/use-set-or-replace-reminder
+ */
+
+import { useCallback } from 'react'
+import type { CreateReminderInput } from '@/services/reminder-service'
+import { useCreateReminder, useUpdateReminder } from './use-reminders'
+
+export interface SetOrReplaceReminderResult {
+  success: boolean
+  error?: string
+}
+
+export type SetOrReplaceReminder = (
+  input: CreateReminderInput,
+  replacingId: string | null
+) => Promise<SetOrReplaceReminderResult>
+
+/**
+ * @returns A function taking the reminder to write and the id of the active
+ *   reminder it replaces, or `null` when the target has none.
+ */
+export function useSetOrReplaceReminder(): SetOrReplaceReminder {
+  const createReminder = useCreateReminder()
+  const updateReminder = useUpdateReminder()
+
+  return useCallback(
+    (input, replacingId) =>
+      replacingId === null
+        ? createReminder.mutateAsync(input)
+        : updateReminder.mutateAsync({
+            id: replacingId,
+            remindAt: input.remindAt,
+            // Written through as null so replacing also clears a note the
+            // previous reminder carried and the picker came back without.
+            note: input.note ?? null
+          }),
+    [createReminder, updateReminder]
+  )
+}

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -327,8 +327,13 @@ vi.mock('@/hooks/use-sidebar-navigation', () => ({
 
 vi.mock('@/hooks/use-note-reminders', () => ({
   useNoteReminders: () => ({
+    activeReminders: [],
     hasActiveReminder: false,
-    actions: { setReminder: mocks.setReminder }
+    actions: {
+      setReminder: mocks.setReminder,
+      editReminder: vi.fn(),
+      deleteReminder: vi.fn()
+    }
   })
 }))
 

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -345,7 +345,11 @@ export function NotePage({ noteId }: NotePageProps) {
   const { isBookmarked, toggle: toggleBookmark } = useIsBookmarked('note', noteId ?? '')
 
   // Reminder state
-  const { hasActiveReminder, actions: reminderActions } = useNoteReminders(noteId ?? null)
+  const {
+    activeReminders,
+    hasActiveReminder,
+    actions: reminderActions
+  } = useNoteReminders(noteId ?? null)
   const handleSetReminder = useCallback(
     async (date: Date, reminderNote?: string): Promise<void> => {
       await reminderActions.setReminder(date, reminderNote)
@@ -1343,6 +1347,11 @@ export function NotePage({ noteId }: NotePageProps) {
         telemetrySurface="notes"
         showNote
         disabled={isDeleted}
+        reminders={activeReminders}
+        onEdit={(id, date, reminderNote) =>
+          void reminderActions.editReminder(id, date, reminderNote)
+        }
+        onDelete={(id) => void reminderActions.deleteReminder(id)}
         trigger={
           <Button
             variant="ghost"

--- a/apps/desktop/tests/e2e/journal-reminder-edit.e2e.ts
+++ b/apps/desktop/tests/e2e/journal-reminder-edit.e2e.ts
@@ -1,0 +1,117 @@
+/**
+ * A journal entry carries one reminder. Picking a custom time after a preset
+ * used to append a second row (#1939), and nothing in the journal picker could
+ * remove either one. This drives the real picker: preset, then custom time,
+ * then remove, reading the reminder rows back over the same IPC surface the app
+ * uses so the count is the app's own answer and not a rendering artifact.
+ */
+
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { ready } from './utils/desktop-test-helpers'
+import { navigateTo } from './utils/electron-helpers'
+
+interface JournalReminderRow {
+  id: string
+  targetId: string
+  remindAt: string
+  status: string
+}
+
+async function journalReminders(page: Page): Promise<JournalReminderRow[]> {
+  return page.evaluate(async () => {
+    const result = await window.api.reminders.list({ targetType: 'journal' })
+    return result.reminders.map((reminder) => ({
+      id: reminder.id,
+      targetId: reminder.targetId,
+      remindAt: reminder.remindAt,
+      status: reminder.status
+    }))
+  })
+}
+
+/** Local parts of an ISO instant, read in the renderer so the zone matches. */
+async function localParts(
+  page: Page,
+  iso: string
+): Promise<{ year: number; month: number; day: number; hours: number; minutes: number }> {
+  return page.evaluate((value) => {
+    const date = new Date(value)
+    return {
+      year: date.getFullYear(),
+      month: date.getMonth(),
+      day: date.getDate(),
+      hours: date.getHours(),
+      minutes: date.getMinutes()
+    }
+  }, iso)
+}
+
+test.describe('journal reminder edit and remove', () => {
+  test('a custom time replaces the preset reminder, and removing it clears the bell', async ({
+    page
+  }) => {
+    await ready(page)
+    await navigateTo(page, 'journal')
+
+    const editor = page.locator('.bn-container [contenteditable="true"]').first()
+    await editor.waitFor({ state: 'visible', timeout: 15_000 })
+    await editor.click()
+    await page.keyboard.type('Reminder replacement check.')
+
+    const unsetBell = page.getByRole('button', { name: 'Set reminder to revisit' })
+    await expect(unsetBell).toBeVisible({ timeout: 15_000 })
+    await unsetBell.click()
+
+    const picker = page.locator('[data-slot="picker-content"]')
+    await expect(picker).toBeVisible()
+    await picker.getByRole('option', { name: /In 1 Week/i }).click()
+
+    await expect.poll(async () => (await journalReminders(page)).length).toBe(1)
+    const [preset] = await journalReminders(page)
+    expect(preset.status).toBe('pending')
+
+    const setBell = page.getByRole('button', { name: /^Reminder:/ })
+    await expect(setBell).toBeVisible()
+    await setBell.click()
+    await expect(picker).toBeVisible()
+
+    // The entry already has a reminder, so the picker lists it with its own
+    // remove button rather than only offering to set another.
+    await expect(picker.getByRole('button', { name: 'Delete reminder' })).toHaveCount(1)
+
+    await picker.getByRole('option', { name: /Pick date/i }).click()
+    await picker.getByRole('button', { name: 'Next month' }).click()
+    // The 15th of next month is always in the future and appears once in the
+    // grid; the surrounding out-of-month days are only ever month edges.
+    await picker.getByRole('button', { name: / 15$/ }).click()
+    await picker.locator('#reminder-time').fill('18:45')
+    await picker.getByRole('button', { name: 'Set reminder' }).click()
+
+    await expect
+      .poll(async () => (await journalReminders(page)).map((row) => row.remindAt))
+      .toHaveLength(1)
+
+    const [replaced] = await journalReminders(page)
+    expect(replaced.id).toBe(preset.id)
+    expect(replaced.targetId).toBe(preset.targetId)
+    expect(replaced.remindAt).not.toBe(preset.remindAt)
+
+    const moved = await localParts(page, replaced.remindAt)
+    const expected = await page.evaluate(() => {
+      const now = new Date()
+      const next = new Date(now.getFullYear(), now.getMonth() + 1, 15)
+      return { year: next.getFullYear(), month: next.getMonth(), day: 15 }
+    })
+    expect(moved).toMatchObject({ ...expected, hours: 18, minutes: 45 })
+
+    await page.getByRole('button', { name: /^Reminder:/ }).click()
+    await expect(picker).toBeVisible()
+    await picker.getByRole('button', { name: 'Delete reminder' }).click()
+
+    await expect.poll(async () => (await journalReminders(page)).length).toBe(0)
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('button', { name: 'Set reminder to revisit' })).toBeVisible()
+    await expect(page.getByRole('button', { name: /^Reminder:/ })).toHaveCount(0)
+  })
+})

--- a/apps/docs/src/user-guide/notes/bookmarks-reminders.md
+++ b/apps/docs/src/user-guide/notes/bookmarks-reminders.md
@@ -32,6 +32,13 @@ list of the ones already set, each with its own edit and delete button. All of i
 when the panel is taller than the room the picker has, so the reminders at the end of the list stay
 editable however low in the window you opened it from.
 
+A note or a journal entry carries one reminder. Picking a relative button or a custom time while one
+is already set moves that reminder to the new time instead of adding a second one, so changing the
+hour on a reminder you set last week leaves you with one reminder rather than two firing on the same
+entry. Use the delete button next to a reminder to remove it; removing the last one clears the bell
+on the toolbar. Entries that collected duplicate reminders under an earlier version keep them, and
+each duplicate is listed with its own delete button.
+
 The optional note is available on both paths: type it before you press a relative button and it is
 saved with that reminder too. It is kept everywhere the picker appears — notes, journal entries,
 tasks and inbox items.

--- a/apps/docs/src/user-guide/snooze-reminders.md
+++ b/apps/docs/src/user-guide/snooze-reminders.md
@@ -48,12 +48,15 @@ Reminders fire as **in-app toasts** at a specified date and time.
 
 ### Setting a Reminder
 
-| Where     | How                            |
-| --------- | ------------------------------ |
-| On a note | Note toolbar → reminder picker |
-| On a task | Task detail → reminder picker  |
+| Where              | How                               |
+| ------------------ | --------------------------------- |
+| On a note          | Note toolbar → reminder picker    |
+| On a task          | Task detail → reminder picker     |
+| On a journal entry | Journal toolbar → reminder picker |
 
 The picker offers relative options ("in 1 hour", "tomorrow morning") plus a full date/time picker.
+On a note or a journal entry it also lists the reminder already set, with buttons to change its time
+or remove it. Picking a new time there replaces that reminder instead of adding a second one.
 
 ### When the Reminder Fires
 

--- a/packages/i18n/src/locales/en/journal.json
+++ b/packages/i18n/src/locales/en/journal.json
@@ -196,13 +196,15 @@
       "set": "Reminder set for this journal entry",
       "deleted": "Reminder deleted",
       "dismissed": "Reminder dismissed",
-      "snoozed": "Reminder snoozed"
+      "snoozed": "Reminder snoozed",
+      "updated": "Reminder updated"
     },
     "error": {
       "set": "Failed to set reminder",
       "delete": "Failed to delete reminder",
       "dismiss": "Failed to dismiss reminder",
-      "snooze": "Failed to snooze reminder"
+      "snooze": "Failed to snooze reminder",
+      "update": "Failed to update reminder"
     }
   },
   "toast": {

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -538,7 +538,9 @@
       "deleted": "Reminder deleted",
       "deleteFailed": "Failed to delete reminder",
       "dismissed": "Reminder dismissed",
-      "dismissFailed": "Failed to dismiss reminder"
+      "dismissFailed": "Failed to dismiss reminder",
+      "updated": "Reminder updated",
+      "updateFailed": "Failed to update reminder"
     }
   },
   "linkedTasks": {


### PR DESCRIPTION
## Summary

A reader set a reminder on a journal entry with the "in one week" preset, then wanted a different hour. There was no way to change or remove it, so he opened the picker again and chose a custom time, expecting it to override. It did not. He ended up with two reminders on one entry, both firing.

Two defects sat behind that. `use-journal-reminders.ts` called `useCreateReminder` unconditionally, so every pick appended a row. `journal-reminder-button.tsx` wired only `onSelect` into `ReminderPicker`, even though the picker has taken `reminders`, `onEdit` and `onDelete` since the task surface shipped, and even though the journal hook already exposed `deleteReminder`. The tooltip could already count the extras (`reminder.tooltipMore`) while offering no way to remove one. `note-reminder-button.tsx` and the note page's own toolbar picker had the identical gap, so both are fixed here.

A journal entry or a note now carries one reminder. `useSetOrReplaceReminder` in `hooks/use-set-or-replace-reminder.ts` holds that rule once for both surfaces: given the id of the active reminder it updates that row, and with `null` it creates. It reuses the existing `reminders.update` channel, so nothing in `packages/contracts` or `main/ipc/reminder-handlers.ts` changed. Updating in place rather than deleting and recreating keeps the row id, which means sync sees an update and the calendar projection follows the same row; `remindersService.updateReminder` already resets `status` to pending and clears `triggeredAt`/`snoozedUntil` when `remindAt` moves, so replacing a snoozed reminder re-arms it. The note carried by the new pick is written through as `null` when the picker comes back without one, so replacing clears a stale note instead of stranding it.

The note surface merges the note's own reminders with its highlight reminders. Only the note's own next active reminder is replaceable there: moving a passage reminder from the note toolbar would silently reschedule something the user never opened. Highlight reminders stay in the list with their own remove button.

There is no migration. Entries that already collected duplicates keep every row, they still fire, and the picker now lists each one with its own remove button, which is how a user gets rid of them. Task reminders are deliberately untouched: that surface already had edit and remove, and its `+N` affordance treats several reminders on one task as intentional.

Blast radius is the two reminder buttons, the note page's toolbar picker, the two hooks and two English locale files. `ReminderPicker` itself is unchanged; it already rendered the management list when handed the props. Four test files that partially mock these hooks were extended with the new `activeReminders` and `editReminder` members.

Carries the test-only main fix from the calendar-widget PR until it lands; rebasing after that drops it.

Closes #1939

## Release note

Changing the time on a journal or note reminder now moves the reminder you already had instead of adding a second one, and the picker lets you remove it.

## Test plan

| Check | Outcome |
| --- | --- |
| `vitest --project renderer` on the 4 touched specs, against origin/main source | 15 failed, 8 passed (red first) |
| same 4 specs with the fix | 23 passed |
| `pnpm --filter @memry/desktop test:renderer` | 704/705 files passed. The one failure, `home/widgets/calendar-widget-refresh.test.tsx`, failed identically with every source file of this branch reverted to origin/main, so it predates this work. The carried commit fixes it: that spec is now 6 passed |
| `pnpm --filter @memry/desktop test:main` | 566 files, 7735 tests pass |
| `pnpm --filter @memry/desktop typecheck:web` | pass |
| `pnpm --filter @memry/desktop typecheck:node` | pass |
| `pnpm --filter @memry/desktop typecheck:test` | pass |
| `pnpm lint` | pass, 0 errors |
| `pnpm --filter @memry/desktop i18n:check` | pass |
| `pnpm check:architecture` | pass |
| `pnpm check:contracts` | pass |
| `pnpm docs:impact --base origin/main --strict` | covered |
| `pnpm docs:build` | pass |
| `git diff --check` | clean |

`pnpm ipc:generate && pnpm ipc:check` was not run: no contract, preload, main IPC handler or generated binding changed. The replace path reuses the existing `reminder:update` channel.

E2E, `tests/e2e/journal-reminder-edit.e2e.ts`. It navigates to the journal, sets the "In 1 Week" preset through the real picker, reopens it, picks a custom day and 18:45 from the date and time pane, and reads the rows back over `window.api.reminders.list`. It asserts exactly one row remains, that its id is the preset's id, that its time moved, and that the local parts are the picked day at 18:45. Then it removes the reminder from the picker and asserts the row count is zero and the bell's accessible name is back to "Set reminder to revisit".

Green with the fix, `1 passed (25.3s)`. Red with the seven changed source files checked out from origin/main:

```
Error: expect(locator).toHaveCount(expected) failed
Locator: locator('[data-slot="picker-content"]').getByRole('button', { name: 'Delete reminder' })
Expected: 1
Received: 0
> 81 |     await expect(picker.getByRole('button', { name: 'Delete reminder' })).toHaveCount(1)
1 failed
```

That is the dead end from the report: an entry with a reminder, and the picker offering no way to remove it. The duplicate half of the bug is pinned by the renderer specs, where reverting the fix turns 10 of them red.

Five mutations were run against the staged fix and each was killed: always create rather than replace (10 tests), dropping the note write-through on replace (1), removing `onDelete` from the journal picker (2), replacing from the merged note and highlight list rather than the note's own (2), and replacing the raw first row instead of the next active one (3). The baseline returned 23 passed.

I grepped `apps/desktop/tests/e2e/` for specs asserting the picker layout. Only `integration.e2e.ts` mentions reminders, and its selectors (`add-reminder`, `reminder-picker`, `reminder-1hour`) exist nowhere in the renderer; every assertion is behind an `isVisible()` guard and the tests end in `expect(true).toBe(true)`. It cannot be affected by this change. `property-status-options.e2e.ts` matches `[data-slot="picker-content"]` but drives the status picker, and no `Picker` primitive changed.
