### PR TITLE
fix(projects): let an item leave a project from its project chips

### DIFF
--- a/apps/desktop/src/main/tasks/project-item-links.test.ts
+++ b/apps/desktop/src/main/tasks/project-item-links.test.ts
@@ -81,6 +81,37 @@ describe('project item link reroute', () => {
     expect(setEntityProperties).toHaveBeenCalledWith('n1', { project: ['Beta'] })
   })
 
+  // The chips on the file page are the only unassign surface a binary file
+  // has. It owns no frontmatter, so the row in `project_links` is the whole of
+  // its membership and this branch is the entire write.
+  it('deletes the link row for a file on unlink, writing no frontmatter', async () => {
+    isMarkdownNote.mockReturnValue(false)
+    domainUnlink.mockResolvedValue({ success: true })
+
+    const result = await unlinkProjectItem({} as never, domain as never, {
+      projectId: 'p1',
+      itemType: 'file',
+      itemId: 'f1'
+    })
+
+    expect(result).toEqual({ success: true })
+    expect(domainUnlink).toHaveBeenCalledWith({ projectId: 'p1', itemType: 'file', itemId: 'f1' })
+    expect(setEntityProperties).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed file unlink instead of claiming success', async () => {
+    isMarkdownNote.mockReturnValue(false)
+    domainUnlink.mockResolvedValue({ success: false })
+
+    expect(
+      await unlinkProjectItem({} as never, domain as never, {
+        projectId: 'p1',
+        itemType: 'file',
+        itemId: 'f1'
+      })
+    ).toEqual({ success: false, error: 'Failed to unlink item' })
+  })
+
   it('errors when the project does not exist', async () => {
     isMarkdownNote.mockReturnValue(true)
     getProjectById.mockReturnValue(undefined)

--- a/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget-refresh.test.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget-refresh.test.tsx
@@ -31,10 +31,28 @@ const SOURCE_TYPE_BY_VISUAL_TYPE = {
   note: 'note'
 } as const
 
+/**
+ * The instant these tests pretend it is, on today's real local date.
+ *
+ * `use-today` snapshots the local date into module scope at import and re-reads the wall clock
+ * for its first subscriber. A clock faked onto any other date therefore arrives as a midnight
+ * rollover, which moves `todayCalendarRange`, moves the query key with it, and makes the widget
+ * fetch a second day on mount. Only the time of day is pinned, and from local fields rather than
+ * a UTC instant, which far enough from UTC would name a different day.
+ */
+const NOW = new Date()
+NOW.setHours(9, 30, 0, 0)
+
+function todayAtHour(hour: number): string {
+  const at = new Date(NOW)
+  at.setHours(hour, 0, 0, 0)
+  return at.toISOString()
+}
+
 function projectionItem(
   id: string,
   title: string,
-  hourUtc: number,
+  hour: number,
   visualType: keyof typeof SOURCE_TYPE_BY_VISUAL_TYPE
 ): CalendarProjectionItem {
   return {
@@ -43,8 +61,8 @@ function projectionItem(
     sourceId: id,
     title,
     descriptionPreview: null,
-    startAt: `2026-08-31T${String(hourUtc).padStart(2, '0')}:00:00.000Z`,
-    endAt: `2026-08-31T${String(hourUtc + 1).padStart(2, '0')}:00:00.000Z`,
+    startAt: todayAtHour(hour),
+    endAt: todayAtHour(hour + 1),
     isAllDay: false,
     timezone: 'UTC',
     visualType,
@@ -101,7 +119,7 @@ function renderApp(): { showBoard: (visible: boolean) => void } {
 
 describe('home calendar widget stays current', () => {
   beforeEach(() => {
-    vi.setSystemTime(new Date('2026-08-31T09:30:00.000Z'))
+    vi.setSystemTime(NOW)
     listeners.clear()
     server.items = [projectionItem('e1', 'Standup', 10, 'event')]
     mockGetRange.mockReset()

--- a/apps/desktop/src/renderer/src/components/tasks/projects/item-project-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/projects/item-project-chips.test.tsx
@@ -5,7 +5,9 @@ import { ItemProjectChips } from './item-project-chips'
 const { mockListForItem, mockOnProjectUpdated, mockUnlinkProjectItem, mockToastError } = vi.hoisted(
   () => ({
     mockListForItem: vi.fn(),
-    mockOnProjectUpdated: vi.fn(() => () => {}),
+    // Declares the subscriber parameter the component actually passes, so
+    // the mockImplementation below that captures it still typechecks.
+    mockOnProjectUpdated: vi.fn((_callback: () => void) => () => {}),
     mockUnlinkProjectItem: vi.fn(),
     mockToastError: vi.fn()
   })

--- a/apps/desktop/src/renderer/src/components/tasks/projects/item-project-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/projects/item-project-chips.test.tsx
@@ -2,22 +2,30 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { ItemProjectChips } from './item-project-chips'
 
-const { mockListForItem, mockOnProjectUpdated } = vi.hoisted(() => ({
-  mockListForItem: vi.fn(),
-  mockOnProjectUpdated: vi.fn(() => () => {})
-}))
+const { mockListForItem, mockOnProjectUpdated, mockUnlinkProjectItem, mockToastError } = vi.hoisted(
+  () => ({
+    mockListForItem: vi.fn(),
+    mockOnProjectUpdated: vi.fn(() => () => {}),
+    mockUnlinkProjectItem: vi.fn(),
+    mockToastError: vi.fn()
+  })
+)
 
 vi.mock('@/services/tasks-service', () => ({
   tasksService: {
-    listForItem: mockListForItem
+    listForItem: mockListForItem,
+    unlinkProjectItem: mockUnlinkProjectItem
   },
   onProjectUpdated: mockOnProjectUpdated
 }))
+
+vi.mock('sonner', () => ({ toast: { error: mockToastError } }))
 
 describe('ItemProjectChips', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockOnProjectUpdated.mockReturnValue(() => {})
+    mockUnlinkProjectItem.mockResolvedValue({ success: true })
   })
 
   it('renders a chip per linked project', async () => {
@@ -78,5 +86,70 @@ describe('ItemProjectChips', () => {
 
     expect(await screen.findByText('Launch')).toBeInTheDocument()
     expect(mockListForItem).toHaveBeenCalledTimes(2)
+  })
+
+  // A binary file has no frontmatter, so these chips are the whole of its
+  // project membership UI. Without a remove control on them the only exits
+  // from a project are destructive (issue #1941).
+  it('unlinks the item when a chip remove control is used', async () => {
+    mockListForItem
+      .mockResolvedValueOnce([{ id: 'p1', name: 'Launch', color: '#f00', icon: null }])
+      .mockResolvedValue([])
+
+    render(<ItemProjectChips itemType="file" itemId="f1" />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /remove from launch/i }))
+
+    await waitFor(() =>
+      expect(mockUnlinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'file',
+        itemId: 'f1'
+      })
+    )
+    await waitFor(() => expect(screen.queryByText('Launch')).not.toBeInTheDocument())
+  })
+
+  it('gives each chip its own remove control, naming the project it drops', async () => {
+    mockListForItem.mockResolvedValue([
+      { id: 'p1', name: 'Launch', color: '#f00', icon: null },
+      { id: 'p2', name: 'Finance', color: '#0f0', icon: null }
+    ])
+
+    render(<ItemProjectChips itemType="file" itemId="f1" />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /remove from finance/i }))
+
+    await waitFor(() =>
+      expect(mockUnlinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p2',
+        itemType: 'file',
+        itemId: 'f1'
+      })
+    )
+  })
+
+  it('renders the name as plain text where there is nowhere to navigate', async () => {
+    mockListForItem.mockResolvedValue([{ id: 'p1', name: 'Launch', color: '#f00', icon: null }])
+
+    render(<ItemProjectChips itemType="file" itemId="f1" />)
+
+    expect(await screen.findByText('Launch')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /open project launch/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /remove from launch/i })).toBeInTheDocument()
+  })
+
+  // The main side answers a failed unlink with an envelope rather than a
+  // rejection, so a bare await would read it as success and blank the chip.
+  it('keeps the chip and reports a rejected unlink', async () => {
+    mockListForItem.mockResolvedValue([{ id: 'p1', name: 'Launch', color: '#f00', icon: null }])
+    mockUnlinkProjectItem.mockResolvedValue({ success: false, error: 'link is gone' })
+
+    render(<ItemProjectChips itemType="file" itemId="f1" />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /remove from launch/i }))
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith('link is gone'))
+    expect(screen.getByText('Launch')).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/src/components/tasks/projects/item-project-chips.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/projects/item-project-chips.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { X } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import {
   tasksService,
@@ -11,6 +13,19 @@ import { createLogger } from '@/lib/logger'
 import { useT } from '@memry/i18n/renderer'
 
 const log = createLogger('ItemProjectChips')
+
+function ProjectChipLabel({ project }: { project: ProjectRef }): React.JSX.Element {
+  return (
+    <>
+      <span
+        className="size-2 shrink-0 rounded-full"
+        style={{ backgroundColor: project.color }}
+        aria-hidden="true"
+      />
+      <span className="max-w-32 truncate">{project.name}</span>
+    </>
+  )
+}
 
 interface ItemProjectChipsProps {
   itemType: ProjectItemType
@@ -26,9 +41,16 @@ interface ItemProjectChipsProps {
 }
 
 /**
- * Small pill row showing the projects an item (note/calendar event) belongs
- * to, via `project_links`. Shared between the note view and the calendar
- * event popover.
+ * Small pill row showing the projects an item belongs to, via `project_links`,
+ * with a remove control per chip.
+ *
+ * The remove control is not optional. This row is the only place a binary
+ * file's project membership is ever shown — a file has no frontmatter, so it
+ * has no `project` property row to edit the way a markdown note does — and
+ * three separate surfaces can add one (sidebar drag, the file page's "Add to
+ * project", the project hub's paperclip import). Without it the membership is
+ * a one-way door out of which the only exits are deleting the project or the
+ * file.
  */
 export const ItemProjectChips = ({
   itemType,
@@ -63,6 +85,20 @@ export const ItemProjectChips = ({
 
   useEffect(() => onProjectUpdated(() => void load()), [load])
 
+  // The main side answers a failed unlink with an error envelope rather than a
+  // rejection, so the envelope has to be checked before the reload; and the
+  // reload runs either way so the row shows what the DB actually holds.
+  const handleRemove = async (projectId: string): Promise<void> => {
+    try {
+      const result = await tasksService.unlinkProjectItem({ projectId, itemType, itemId })
+      if (!result.success) throw new Error(result.error)
+    } catch (error) {
+      log.error('Failed to remove item from project', extractErrorMessage(error))
+      toast.error(extractErrorMessage(error, t('itemProjects.removeFailed')))
+    }
+    await load()
+  }
+
   if (!isLoading && projects.length === 0) return null
 
   const visible = maxVisible === undefined ? projects : projects.slice(0, maxVisible)
@@ -71,23 +107,37 @@ export const ItemProjectChips = ({
   return (
     <div className={cn('flex flex-wrap items-center gap-1.5', className)}>
       {visible.map((project) => (
-        <button
+        <span
           key={project.id}
-          type="button"
-          aria-label={t('itemProjects.openProject', { name: project.name })}
-          onClick={() => onProjectClick?.(project.id)}
-          className={cn(
-            'inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs',
-            'transition-colors hover:bg-muted/70'
-          )}
+          className="inline-flex items-center rounded-full border border-border bg-muted/40 text-xs"
         >
-          <span
-            className="size-2 shrink-0 rounded-full"
-            style={{ backgroundColor: project.color }}
-            aria-hidden="true"
-          />
-          <span className="max-w-32 truncate">{project.name}</span>
-        </button>
+          {/* The name is a control only where it leads somewhere. The file page
+              mounts this row without `onProjectClick`, and a second tab stop
+              that does nothing beside the real remove control is worse than
+              plain text. */}
+          {onProjectClick ? (
+            <button
+              type="button"
+              aria-label={t('itemProjects.openProject', { name: project.name })}
+              onClick={() => onProjectClick(project.id)}
+              className="inline-flex items-center gap-1.5 rounded-full ps-2 pe-1 py-0.5 transition-colors hover:bg-muted/70"
+            >
+              <ProjectChipLabel project={project} />
+            </button>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 ps-2 pe-1 py-0.5">
+              <ProjectChipLabel project={project} />
+            </span>
+          )}
+          <button
+            type="button"
+            aria-label={t('itemProjects.removeFromProject', { name: project.name })}
+            onClick={() => void handleRemove(project.id)}
+            className="rounded-full ps-0.5 pe-1.5 py-0.5 text-muted-foreground transition-colors hover:text-destructive"
+          >
+            <X className="size-3" />
+          </button>
+        </span>
       ))}
       {hiddenCount > 0 && (
         <span

--- a/apps/desktop/tests/e2e/project-unassign.e2e.ts
+++ b/apps/desktop/tests/e2e/project-unassign.e2e.ts
@@ -1,0 +1,244 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import type { Page } from '@playwright/test'
+
+import { test, expect } from './fixtures'
+import { PNG_BYTES, ready, uniqueLabel } from './utils/desktop-test-helpers'
+import { seedNote, tabSessionStorageKey } from './utils/electron-helpers'
+
+/**
+ * Issue #1941: a file assigned to a project could not be unassigned without
+ * deleting the project or the file.
+ *
+ * The two item kinds reach `project_links` by different routes, so both are
+ * proved here. A markdown note carries its membership in frontmatter and the
+ * projector derives the row, which is why the note block asserts on the raw
+ * file bytes as well as on the link. A binary file has no frontmatter, so its
+ * row in `project_links` is the whole of its membership and the chips on the
+ * file page are the only place it is ever shown.
+ *
+ * Inbox is covered alongside a user-created project because the report named
+ * it, and because `listProjects` does not treat it differently — a regression
+ * that special-cased it would only show up here.
+ */
+
+interface SeededProjects {
+  inboxId: string
+  inboxName: string
+  projectId: string
+}
+
+async function seedProjects(page: Page, projectName: string): Promise<SeededProjects> {
+  return page.evaluate(async (name) => {
+    const created = await window.api.tasks.createProject({ name, color: '#6366f1' })
+    if (!created.success || !created.project) {
+      throw new Error(created.error ?? 'project create failed')
+    }
+
+    const { projects } = await window.api.tasks.listProjects()
+    const inbox = projects.find((project) => project.isInbox)
+    if (!inbox) throw new Error('inbox project missing')
+
+    return { inboxId: inbox.id, inboxName: inbox.name, projectId: created.project.id }
+  }, projectName)
+}
+
+async function linkedItemIds(page: Page, projectId: string): Promise<string[]> {
+  return page.evaluate(async (id) => {
+    const links = await window.api.tasks.listProjectLinks(id)
+    return Array.isArray(links) ? links.map((link) => link.itemId) : []
+  }, projectId)
+}
+
+test.describe('Unassigning from a project', () => {
+  test('a note leaves both a user project and Inbox from its project property', async ({
+    page,
+    testVaultPath
+  }) => {
+    await ready(page)
+
+    const projectName = uniqueLabel('Unassign Project')
+    const { inboxId, inboxName, projectId } = await seedProjects(page, projectName)
+    const noteId = await seedNote(page, uniqueLabel('Unassign Note'), 'Body')
+
+    await page.evaluate(
+      async ({ noteId, projectId, inboxId }) => {
+        for (const id of [projectId, inboxId]) {
+          const linked = await window.api.tasks.linkProjectItem({
+            projectId: id,
+            itemType: 'note',
+            itemId: noteId
+          })
+          if (!linked.success) throw new Error(linked.error ?? 'link failed')
+        }
+      },
+      { noteId, projectId, inboxId }
+    )
+
+    await expect.poll(() => linkedItemIds(page, projectId)).toContain(noteId)
+    await expect.poll(() => linkedItemIds(page, inboxId)).toContain(noteId)
+
+    const notePath = await page.evaluate(async (id) => {
+      const note = await window.api.notes.get(id)
+      return note?.path ?? null
+    }, noteId)
+    expect(notePath).toBeTruthy()
+    expect(fs.readFileSync(path.join(testVaultPath, notePath!), 'utf8')).toContain(projectName)
+
+    await openNoteTab(page, noteId)
+
+    const properties = page.getByRole('list', { name: 'Properties list' }).first()
+    await expect(properties).toBeVisible()
+
+    for (const name of [projectName, inboxName]) {
+      // Exact: the property row's own wrapper is a role="button" whose
+      // accessible name concatenates the chip label with this one, so a
+      // substring match would resolve to two elements.
+      const remove = properties.getByRole('button', { name: `Remove from ${name}`, exact: true })
+      await expect(remove).toBeVisible()
+      await remove.click()
+      await expect(remove).toHaveCount(0)
+    }
+
+    await expect.poll(() => linkedItemIds(page, projectId)).not.toContain(noteId)
+    await expect.poll(() => linkedItemIds(page, inboxId)).not.toContain(noteId)
+
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+
+    await expect.poll(() => linkedItemIds(page, projectId)).not.toContain(noteId)
+    await expect.poll(() => linkedItemIds(page, inboxId)).not.toContain(noteId)
+
+    // The file is the sync payload and the reindex source, so the link has to
+    // be gone from the bytes, not only from the index. `Note.content` is the
+    // body with the frontmatter stripped, so the property is read off
+    // `frontmatter` and confirmed against the file on disk.
+    const stored = await page.evaluate(async (id) => {
+      const note = await window.api.notes.get(id)
+      return note ? JSON.stringify(note.frontmatter) : null
+    }, noteId)
+    expect(stored).not.toContain(projectName)
+    expect(fs.readFileSync(path.join(testVaultPath, notePath!), 'utf8')).not.toContain(projectName)
+  })
+
+  test('a file leaves both a user project and Inbox from its project chips', async ({ page }) => {
+    await ready(page)
+
+    const projectName = uniqueLabel('Unassign File Project')
+    const { inboxId, inboxName, projectId } = await seedProjects(page, projectName)
+
+    const importDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-e2e-unassign-'))
+    const fileName = `unassign-${Date.now()}.png`
+    fs.writeFileSync(path.join(importDir, fileName), Buffer.from(PNG_BYTES))
+    const fileTitle = path.basename(fileName, path.extname(fileName))
+
+    try {
+      const imported = await page.evaluate(
+        async (sourcePath) => window.api.notes.importFiles([sourcePath], ''),
+        path.join(importDir, fileName)
+      )
+      expect(imported.success).toBe(true)
+
+      const findFileId = async (): Promise<string | null> =>
+        page.evaluate(async (title) => {
+          const list = await window.api.notes.list({ limit: 200 })
+          return list.notes.find((note) => note.title === title)?.id ?? null
+        }, fileTitle)
+
+      // The import writes the file; the indexer gives it an id a moment later.
+      await expect.poll(findFileId, { timeout: 20_000 }).not.toBeNull()
+      const fileId = await findFileId()
+      expect(fileId).toBeTruthy()
+
+      await page.evaluate(
+        async ({ fileId, projectId, inboxId }) => {
+          for (const id of [projectId, inboxId]) {
+            const linked = await window.api.tasks.linkProjectItem({
+              projectId: id,
+              itemType: 'file',
+              itemId: fileId
+            })
+            if (!linked.success) throw new Error(linked.error ?? 'link failed')
+          }
+        },
+        { fileId: fileId!, projectId, inboxId }
+      )
+
+      await expect.poll(() => linkedItemIds(page, projectId)).toContain(fileId)
+      await expect.poll(() => linkedItemIds(page, inboxId)).toContain(fileId)
+
+      await openFileTab(page, fileId!, fileTitle)
+
+      for (const name of [projectName, inboxName]) {
+        const remove = page.getByRole('button', { name: `Remove from ${name}`, exact: true })
+        await expect(remove).toBeVisible()
+        await remove.click()
+        await expect(remove).toHaveCount(0)
+      }
+
+      await expect.poll(() => linkedItemIds(page, projectId)).not.toContain(fileId)
+      await expect.poll(() => linkedItemIds(page, inboxId)).not.toContain(fileId)
+
+      await page.reload()
+      await page.waitForLoadState('domcontentloaded')
+
+      await expect.poll(() => linkedItemIds(page, projectId)).not.toContain(fileId)
+      await expect.poll(() => linkedItemIds(page, inboxId)).not.toContain(fileId)
+    } finally {
+      fs.rmSync(importDir, { recursive: true, force: true })
+    }
+  })
+})
+
+async function openNoteTab(page: Page, noteId: string): Promise<void> {
+  await seedTab(page, { type: 'note', id: noteId, title: 'Unassign Note', path: `/note/${noteId}` })
+  await expect(page.getByRole('list', { name: 'Properties list' }).first()).toBeVisible()
+}
+
+async function openFileTab(page: Page, fileId: string, title: string): Promise<void> {
+  await seedTab(page, { type: 'file', id: fileId, title, path: `/file/${fileId}` })
+  await expect(page.getByRole('heading', { name: title })).toBeVisible()
+}
+
+async function seedTab(
+  page: Page,
+  tab: { type: string; id: string; title: string; path: string }
+): Promise<void> {
+  const storageKey = await tabSessionStorageKey(page)
+  await page.addInitScript(
+    ({ tab, storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          version: 2,
+          tabGroups: {
+            g1: {
+              id: 'g1',
+              activeTabId: 'seeded-tab',
+              tabs: [
+                {
+                  id: 'seeded-tab',
+                  type: tab.type,
+                  title: tab.title,
+                  icon: tab.type,
+                  path: tab.path,
+                  entityId: tab.id,
+                  isPinned: false
+                }
+              ]
+            }
+          },
+          layout: { type: 'leaf', tabGroupId: 'g1' },
+          activeGroupId: 'g1',
+          settings: { restoreSessionOnStart: true, tabCloseButton: 'hover' },
+          savedAt: Date.now()
+        })
+      )
+    },
+    { tab, storageKey }
+  )
+  await page.reload()
+  await page.waitForLoadState('domcontentloaded')
+}

--- a/apps/desktop/tsconfig.test.web.json
+++ b/apps/desktop/tsconfig.test.web.json
@@ -83,7 +83,6 @@
     "src/renderer/src/components/tasks/kanban/kanban-column-extra.test.tsx",
     "src/renderer/src/components/tasks/kanban/kanban-columns.test.ts",
     "src/renderer/src/components/tasks/project/virtualized-project-task-list.test.tsx",
-    "src/renderer/src/components/tasks/projects/item-project-chips.test.tsx",
     "src/renderer/src/components/tasks/task-detail-drawer.test.tsx",
     "src/renderer/src/components/tasks/task-row-extra.test.tsx",
     "src/renderer/src/components/tasks/task-section.test.tsx",

--- a/apps/docs/src/user-guide/projects.md
+++ b/apps/docs/src/user-guide/projects.md
@@ -102,7 +102,11 @@ Notes, events, and files join a project as **links** (many-to-many): the same no
 - **Add an event** — right-click a calendar event and choose **Add to project**
 - Dragging any note or file from the sidebar onto a project links it in one step — memrynote tells notes and files apart automatically, so the same drag works for either
 
-Files and calendar events, which have no frontmatter, show small **project chips** under their title — click a chip to jump to that project's hub. A note or journal entry shows its projects in the `project` property row instead.
+Files and calendar events, which have no frontmatter, show small **project chips** under their title. A note or journal entry shows its projects in the `project` property row instead.
+
+### Removing from a project
+
+Nothing has to be deleted to undo a link. A note or journal entry leaves a project from the same `project` property row that put it there: every project is a chip with an **×**. A file leaves the same way, from the project chips under its title, which carry that **×** too. Removing the last one leaves the item in your vault with no project at all, exactly as it was before you linked it. A note's membership lives in its frontmatter, so the removal travels to your other devices with the file itself.
 
 ## Deleting a Project
 

--- a/apps/docs/src/user-guide/projects.md
+++ b/apps/docs/src/user-guide/projects.md
@@ -108,6 +108,8 @@ Files and calendar events, which have no frontmatter, show small **project chips
 
 Nothing has to be deleted to undo a link. A note or journal entry leaves a project from the same `project` property row that put it there: every project is a chip with an **×**. A file leaves the same way, from the project chips under its title, which carry that **×** too. Removing the last one leaves the item in your vault with no project at all, exactly as it was before you linked it. A note's membership lives in its frontmatter, so the removal travels to your other devices with the file itself.
 
+A calendar event leaves from the **Project** field in its own form, either by choosing **No project** or with the **×** on any extra project chip beside it.
+
 ## Deleting a Project
 
 Open the project in the edit modal and use **Delete Project** in the footer. A confirmation dialog names the project, tells you how many tasks go with it, and states that the action cannot be undone. Cancel leaves everything untouched; confirming deletes the project and closes the modal.

--- a/packages/i18n/src/locales/en/tasks.json
+++ b/packages/i18n/src/locales/en/tasks.json
@@ -826,7 +826,9 @@
     }
   },
   "itemProjects": {
-    "openProject": "Open project {name}"
+    "openProject": "Open project {name}",
+    "removeFromProject": "Remove from {name}",
+    "removeFailed": "Could not remove this item from the project"
   },
   "projectHub": {
     "header": {


### PR DESCRIPTION
## Summary

A file assigned to a project could not be unassigned. The only exits were deleting the project or deleting the file, which is what the reporter hit on both the built-in Inbox project and one they had made themselves.

The gap is one-sided UI, not a broken write. Three surfaces add a file to a project: a drag onto a sidebar project row (`sortable-project-item.tsx:139`), the file page's **Add to project** dialog (`add-file-to-project-dialog.tsx:44`), and the project hub's paperclip import (`project-capture-input.tsx:84`). The file page then shows that membership as chips rendered by `ItemProjectChips` (`pages/file.tsx:217` and `:238`), and those chips were plain buttons with no remove control. The `tasks:project-unlink-item` IPC has existed and worked the whole time; outside the calendar's `event-project-field.tsx` nothing in the renderer ever called it. A markdown note has an escape hatch a file does not, its `project` frontmatter property and the chip remove control in `ProjectEditor`, which is why the report is about files.

Every chip in `ItemProjectChips` now carries a remove control that calls `tasksService.unlinkProjectItem`. Behind it the two item kinds already diverge correctly and neither needed changing. For a binary file `unlinkProjectItem` takes the table-native branch and deletes the `project_links` row, which is the whole of that file's membership, and `note-project-links-projector` only reconciles `kind === 'markdown'`, so no reindex can put the row back. For a markdown note the same call rewrites the name out of frontmatter through `setEntityProperties`, so the file stays the payload and sync carries the removal to a second device without a protocol change. No schema change, no migration, nothing an older client cannot read.

One adjacent change rides along. `pages/file.tsx` mounts the row without `onProjectClick`, so the chip's "Open project X" button has always done nothing there. Putting a real control next to a dead one would leave the file page with two adjacent tab stops where only one acts, so the project name now renders as plain text wherever no navigation handler is supplied and stays a button where one is.

Blast radius is the file page plus any future caller of `ItemProjectChips`. `pages/file.tsx` is its only production caller today, `pages/file.test.tsx` stubs the component, and no E2E spec asserted on its markup. The calendar's project field is a separate component and is untouched.

Two things the reviewer should know, because both contradict the issue's "Where to look". It asked whether a chip in `ProjectEditor` has a remove affordance at all: it does, at `ProjectEditor.tsx:94`, and `ProjectEditor.test.tsx` already asserted that removing the last chip emits `[]`. It also suggested copying a clear path from `project-picker.tsx` or `task-detail-drawer.tsx`; there is none to copy, because `tasks.project_id` is `NOT NULL` and `TaskUpdateSchema.projectId` is `.optional()` rather than `.nullish()`, so a task can only move between projects, never leave one. The shape copied instead is the calendar's removable chip at `event-project-field.tsx:265`.

`item-project-chips.test.tsx` sat in the `tsconfig.test.web.json` exclude backlog, so `typecheck:test` compiled none of it. That line is gone, which surfaced one real error: the hoisted `onProjectUpdated` mock declared no parameters, so the pre-existing subscribe-capture case could not implement it. The backlog only ever shrinks.

Carries the test-only main fix from the calendar-widget PR until it lands; rebasing after that drops it.

Closes #1941

## Release note

Files can now be removed from a project from the chips under the file's title, without deleting the file or the project.

## Test plan

| Command | Outcome |
| --- | --- |
| `vitest --project renderer item-project-chips.test.tsx` | 9 passed |
| `vitest --project renderer item-project-chips.test.tsx` on origin/main source | 4 failed, 5 passed (all four new cases) |
| `vitest --project main project-item-links / project-links-domain / note-project-links-projector` | 30 passed |
| `run-e2e.sh tests/e2e/project-unassign.e2e.ts` | 2 passed (28.7s) |
| `run-e2e.sh tests/e2e/project-unassign.e2e.ts` on origin/main source | 1 failed, 1 passed: the file case cannot find the remove control, the note case passes because that surface already worked |
| `pnpm --filter @memry/desktop typecheck:web` | clean |
| `pnpm --filter @memry/desktop typecheck:node` | clean |
| `pnpm --filter @memry/desktop typecheck:test` | clean, and `--listFiles` now shows `item-project-chips.test.tsx` in the program |
| `pnpm --filter @memry/desktop test:renderer` | 8631 passed, 1 failure in `calendar-widget-refresh.test.tsx` that reproduces on origin/main and is fixed by the carried commit; that file alone is 6 passed on this head |
| `pnpm --filter @memry/desktop test:main` | 7737 passed, 566 files |
| `pnpm lint` | 0 errors, 108 warnings, none in a changed file |
| `pnpm --filter @memry/desktop i18n:check` | passed |
| `pnpm check:architecture && pnpm check:contracts` | both passed |
| `git diff --check origin/main..HEAD` | clean |
| `pnpm docs:impact --base origin/main --strict` | covered |
| `pnpm docs:build` | build complete |

`pnpm ipc:check` was not run: no contract, preload, or main IPC handler changed.

No second-device E2E. The diff is a button; it calls `tasks:project-unlink-item`, whose sync publication already existed and is already covered. `project-links-domain.test.ts` asserts that unlink re-enqueues `publisher.projectUpdated` with `changedFields: ['links']`, and a project's payload is what carries its links, so a file's removal reaches a second device the same way its addition always has. For a markdown note the frontmatter write is the sync payload, and the E2E asserts the name is gone from the bytes on disk. A sync spec here would exercise none of the changed lines while holding the shared machine lock.

The issue's "a note that was never assigned is unaffected" holds by construction: `ItemProjectChips` renders nothing when the item has no links (covered by its existing `renders nothing when there are no linked projects` case), so there is no control to press and no write to make.
