### PR TITLE
test(home): pin the calendar widget fixture clock to today's real date

### DIFF
--- a/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget-refresh.test.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget-refresh.test.tsx
@@ -31,10 +31,28 @@ const SOURCE_TYPE_BY_VISUAL_TYPE = {
   note: 'note'
 } as const
 
+/**
+ * The instant these tests pretend it is, on today's real local date.
+ *
+ * `use-today` snapshots the local date into module scope at import and re-reads the wall clock
+ * for its first subscriber. A clock faked onto any other date therefore arrives as a midnight
+ * rollover, which moves `todayCalendarRange`, moves the query key with it, and makes the widget
+ * fetch a second day on mount. Only the time of day is pinned, and from local fields rather than
+ * a UTC instant, which far enough from UTC would name a different day.
+ */
+const NOW = new Date()
+NOW.setHours(9, 30, 0, 0)
+
+function todayAtHour(hour: number): string {
+  const at = new Date(NOW)
+  at.setHours(hour, 0, 0, 0)
+  return at.toISOString()
+}
+
 function projectionItem(
   id: string,
   title: string,
-  hourUtc: number,
+  hour: number,
   visualType: keyof typeof SOURCE_TYPE_BY_VISUAL_TYPE
 ): CalendarProjectionItem {
   return {
@@ -43,8 +61,8 @@ function projectionItem(
     sourceId: id,
     title,
     descriptionPreview: null,
-    startAt: `2026-08-31T${String(hourUtc).padStart(2, '0')}:00:00.000Z`,
-    endAt: `2026-08-31T${String(hourUtc + 1).padStart(2, '0')}:00:00.000Z`,
+    startAt: todayAtHour(hour),
+    endAt: todayAtHour(hour + 1),
     isAllDay: false,
     timezone: 'UTC',
     visualType,
@@ -101,7 +119,7 @@ function renderApp(): { showBoard: (visible: boolean) => void } {
 
 describe('home calendar widget stays current', () => {
   beforeEach(() => {
-    vi.setSystemTime(new Date('2026-08-31T09:30:00.000Z'))
+    vi.setSystemTime(NOW)
     listeners.clear()
     server.items = [projectionItem('e1', 'Standup', 10, 'event')]
     mockGetRange.mockReset()


### PR DESCRIPTION
## Summary

`Unit & integration tests` has been failing on `main` itself, and therefore on every open PR, at
`calendar-widget-refresh.test.tsx > shows an event created elsewhere while the board is open`
with `expected "vi.fn()" to be called 1 times, but got 2 times`. This unblocks the six other
open PRs in the #1934 batch, which all inherit the failure.

The second `getRange` call is real, but the test manufactures it. `beforeEach` faked the clock
onto `2026-08-31T09:30:00.000Z`, the day the suite was written. `use-today` snapshots the local
date into module scope when it is imported and re-reads the wall clock for its first subscriber,
so on any later day that fake clock arrives as a midnight rollover. `useToday` changes value
during mount, `todayCalendarRange` moves with it, the `useCalendarRange` query key moves with
that, and react-query fetches the second day. A probe against the mock confirms the shape rather
than inferring it. The two calls carry different ranges, `2026-09-01` then `2026-08-31`, the
first from the module snapshot and the second from the fake clock. The suite was green on
exactly one calendar day and has been red every day since.

So this is a test-hygiene bug, not a product double-fetch, and the fix is a test-only change.
The product behaviour under a day rollover is correct and wanted: when the local day changes the
widget must query the new day. Nothing in the assertion is loosened. `NOW` is now derived from
the real clock with only the time of day pinned, and `projectionItem` hangs its event hours off
that same instant, so the mount no longer straddles a day boundary and the count is genuinely 1.
The clock is pinned from local date fields rather than a UTC instant because far enough from UTC
the two name different days, which would reintroduce the rollover from the other direction. The
sibling `calendar-widget.test.tsx` already used local fields, so this matches the convention.

Blast radius is one test file. No product code changes, so `home-calendar-widget-refresh.e2e.ts`
exercises unchanged behaviour and was not run. `useCalendarChangeEvents`, `useCalendarRange` and
`CalendarWidget` are untouched.

## Release note

none

## Test plan

- `vitest run --project renderer calendar-widget-refresh.test.tsx` before the fix: 1 failed, 5 passed. After: 6 passed.
- Red then green from the index. `git checkout origin/main -- <file>` fails and `git checkout HEAD -- <file>` passes, under `Europe/Istanbul`, `Pacific/Kiritimati` (UTC+14) and `Pacific/Midway` (UTC-11), whose local dates differ from each other.
- Timezone sweep of the file, 6 passed in `UTC`, `Pacific/Kiritimati`, `Pacific/Midway`, `Asia/Kathmandu`, `America/Los_Angeles`, `Europe/Istanbul`. An earlier sweep passing two spec paths at once ran zero tests and still exited 0, so every run is now guarded on a nonzero test count.
- Green again on 2026-09-02, the day after the run that proved it red. The old fixture had never survived a date change.
- Mutation check, 4 applied and 4 killed. Restoring the hardcoded `2026-08-31` clock. Building `NOW` from a UTC instant instead of local fields, killed under `Pacific/Kiritimati`. Dropping the `onCalendarChanged` subscription in `useCalendarChangeEvents`, 4 failed, which shows the suite still catches the bug #1916 fixed. Changing its settings key guard to `calendars`, 2 failed.
- `pnpm --filter @memry/desktop test:renderer`: 705 files, 8628 passed, 2 expected fail, 7 skipped.
- `typecheck:web`, `typecheck:node`, `typecheck:test`, `pnpm lint` (0 errors), `i18n:check`, `check:architecture`, `check:contracts`, `git diff --check`: all pass. The file is not in the `typecheck:test` exclude backlog, so it really compiles.
- Not run, with reasons. `ipc:check`, no contract, preload or IPC handler touched. `test:main`, no main-process code touched. E2E, no product code touched. The docs gate needed no skip flag, `docs-impact --strict` reports no docs-relevant changes for a test-only diff.
