### PR TITLE
fix(editor): indent every block of a multi-block selection on Tab

### DIFF
--- a/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget-refresh.test.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget-refresh.test.tsx
@@ -31,10 +31,28 @@ const SOURCE_TYPE_BY_VISUAL_TYPE = {
   note: 'note'
 } as const
 
+/**
+ * The instant these tests pretend it is, on today's real local date.
+ *
+ * `use-today` snapshots the local date into module scope at import and re-reads the wall clock
+ * for its first subscriber. A clock faked onto any other date therefore arrives as a midnight
+ * rollover, which moves `todayCalendarRange`, moves the query key with it, and makes the widget
+ * fetch a second day on mount. Only the time of day is pinned, and from local fields rather than
+ * a UTC instant, which far enough from UTC would name a different day.
+ */
+const NOW = new Date()
+NOW.setHours(9, 30, 0, 0)
+
+function todayAtHour(hour: number): string {
+  const at = new Date(NOW)
+  at.setHours(hour, 0, 0, 0)
+  return at.toISOString()
+}
+
 function projectionItem(
   id: string,
   title: string,
-  hourUtc: number,
+  hour: number,
   visualType: keyof typeof SOURCE_TYPE_BY_VISUAL_TYPE
 ): CalendarProjectionItem {
   return {
@@ -43,8 +61,8 @@ function projectionItem(
     sourceId: id,
     title,
     descriptionPreview: null,
-    startAt: `2026-08-31T${String(hourUtc).padStart(2, '0')}:00:00.000Z`,
-    endAt: `2026-08-31T${String(hourUtc + 1).padStart(2, '0')}:00:00.000Z`,
+    startAt: todayAtHour(hour),
+    endAt: todayAtHour(hour + 1),
     isAllDay: false,
     timezone: 'UTC',
     visualType,
@@ -101,7 +119,7 @@ function renderApp(): { showBoard: (visible: boolean) => void } {
 
 describe('home calendar widget stays current', () => {
   beforeEach(() => {
-    vi.setSystemTime(new Date('2026-08-31T09:30:00.000Z'))
+    vi.setSystemTime(NOW)
     listeners.clear()
     server.items = [projectionItem('e1', 'Standup', 10, 'event')]
     mockGetRange.mockReset()

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -81,6 +81,7 @@ import {
 } from './review-formatting-toolbar'
 import { createCriticMarkupDecorationPlugin } from './critic-markup-decorations'
 import { registerEditorPlugin } from './register-editor-plugin'
+import { createMultiBlockIndentPlugin } from './multi-block-indent-plugin'
 
 import {
   useBlockNoteSetup,
@@ -892,6 +893,16 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     },
     [editor, insertDatePill]
   )
+
+  // Tab / Shift+Tab over a selection spanning two or more blocks. Prepended
+  // because BlockNote's own keymap hands Tab back to the browser while any
+  // non-empty selection is live, so nothing indents without this. It registers
+  // before the date ghost below on purpose: each prepend goes to the front, so
+  // the ghost ends up ahead of it and keeps Tab while a date is being typed.
+  useEffect(() => {
+    const plugin = createMultiBlockIndentPlugin(editor)
+    return registerEditorPlugin(editor, plugin, (p, plugins) => [p, ...plugins])
+  }, [editor])
 
   // Inline `@`-date ghost text + Tab completion. Prepend the plugin so its Tab
   // handler wins over block-indent keymaps while a date mention is active.

--- a/apps/desktop/src/renderer/src/components/note/content-area/multi-block-indent-plugin.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/multi-block-indent-plugin.test.ts
@@ -1,0 +1,447 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createElement } from 'react'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { BlockNoteEditor } from '@blocknote/core'
+import { NodeSelection } from '@tiptap/pm/state'
+
+vi.mock('react-pdf', () => ({
+  Document: () => null,
+  Page: () => null,
+  pdfjs: { GlobalWorkerOptions: { workerSrc: '' } }
+}))
+
+vi.mock('@/lib/url-metadata', () => ({
+  fetchLinkPreview: vi.fn().mockResolvedValue({ domain: '', title: '', favicon: '' }),
+  extractDomain: (url: string) => url
+}))
+
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: { update: vi.fn(), listProjects: vi.fn(), create: vi.fn() }
+}))
+
+vi.mock('@/services/notes-service', () => ({
+  notesService: { getTags: vi.fn() }
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() })
+}))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key.split('.').at(-1) ?? key })
+}))
+
+import { tasksService } from '@/services/tasks-service'
+import { notesService } from '@/services/notes-service'
+import { editorSchema } from './editor-schema'
+import { registerEditorPlugin } from './register-editor-plugin'
+import { createDateMentionGhostPlugin } from './date-mention-ghost-plugin'
+import { analyzeTaskIntents } from './scan-task-intents'
+import { indentTaskBlock, outdentTaskBlock } from './hooks/task-block-marquee-indent'
+import { MentionMenu, type MentionSuggestionItem } from './mention-menu'
+import { TagSuggestionPopover } from './tag-suggestion-popover'
+import {
+  createMultiBlockIndentPlugin,
+  indentBlocks,
+  outdentBlocks,
+  selectedBlockIds
+} from './multi-block-indent-plugin'
+
+const mounted: Array<{ editor: BlockNoteEditor; el: HTMLElement }> = []
+
+afterEach(() => {
+  vi.useRealTimers()
+  cleanup()
+  for (const { editor, el } of mounted.splice(0)) {
+    ;(editor as any).mount(undefined)
+    el.remove()
+  }
+})
+
+beforeEach(() => {
+  vi.mocked(tasksService.update).mockReset()
+  vi.mocked(tasksService.update).mockResolvedValue({ success: true } as never)
+  vi.mocked(notesService.getTags).mockResolvedValue([
+    { tag: 'work', color: 'blue', count: 4 }
+  ] as never)
+})
+
+function mountEditor(blocks: unknown[], useAppSchema = false): BlockNoteEditor {
+  const editor = useAppSchema
+    ? (BlockNoteEditor.create({ schema: editorSchema } as never) as unknown as BlockNoteEditor)
+    : BlockNoteEditor.create()
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  editor.mount(el)
+  mounted.push({ editor, el })
+  editor.replaceBlocks(editor.document, blocks as never)
+  return editor
+}
+
+function paragraphs(labels: string[]): unknown[] {
+  return labels.map((label) => ({ id: label, type: 'paragraph', content: label }))
+}
+
+function tiptap(editor: BlockNoteEditor): any {
+  return (editor as any)._tiptapEditor
+}
+
+function containerPos(doc: any, id: string): number {
+  let found = -1
+  doc.descendants((node: any, pos: number) => {
+    if (found !== -1) return false
+    if (node.type.name === 'blockContainer' && node.attrs?.id === id) {
+      found = pos
+      return false
+    }
+    return true
+  })
+  if (found === -1) throw new Error(`no block container for ${id}`)
+  return found
+}
+
+function outline(blocks: any[]): string[] {
+  return blocks.map((block) => {
+    const label =
+      block.type === 'taskBlock'
+        ? `#${block.props.taskId}`
+        : (block.content ?? []).map((c: any) => c.text ?? '').join('')
+    const children = outline(block.children ?? [])
+    return children.length > 0 ? `${label}(${children.join(' ')})` : label
+  })
+}
+
+/** The document without the empty paragraph BlockNote keeps after the last block. */
+function topBlocks(editor: BlockNoteEditor): any[] {
+  const blocks = [...(editor.document as any[])]
+  const last = blocks.at(-1)
+  if (blocks.length > 1 && last?.type === 'paragraph' && (last.content ?? []).length === 0) {
+    blocks.pop()
+  }
+  return blocks
+}
+
+function topOutline(editor: BlockNoteEditor): string[] {
+  return outline(topBlocks(editor))
+}
+
+function shapeOf(blocks: any[]): unknown[] {
+  return blocks.map((block) => ({
+    id: block.id,
+    type: block.type,
+    parentTaskId: block.props?.parentTaskId,
+    children: shapeOf(block.children ?? [])
+  }))
+}
+
+function registerPlugin(editor: BlockNoteEditor): void {
+  registerEditorPlugin(editor, createMultiBlockIndentPlugin(editor), (p, plugins) => [
+    p,
+    ...plugins
+  ])
+}
+
+function selectAcross(editor: BlockNoteEditor, fromId: string, toId: string): void {
+  const tt = tiptap(editor)
+  tt.commands.setTextSelection({
+    from: containerPos(tt.state.doc, fromId) + 3,
+    to: containerPos(tt.state.doc, toId) + 3
+  })
+}
+
+// A real keydown on the view, the path the app takes. tiptap's
+// `keyboardShortcut` command replays captured steps onto its own transaction
+// and loses every sink after the first.
+function pressTab(editor: BlockNoteEditor, shift = false): KeyboardEvent {
+  const event = tabEvent({ shiftKey: shift })
+  tiptap(editor).view.dom.dispatchEvent(event)
+  return event
+}
+
+function countTransactions(editor: BlockNoteEditor): () => number {
+  let count = 0
+  tiptap(editor).on('transaction', () => {
+    count += 1
+  })
+  return () => count
+}
+
+function pluginOf(editor: BlockNoteEditor): any {
+  return createMultiBlockIndentPlugin(editor)
+}
+
+function tabEvent(init: KeyboardEventInit = {}): KeyboardEvent {
+  return new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true, ...init })
+}
+
+describe('Tab over a multi-block selection', () => {
+  it('nests every selected block, unnests them again, in one undoable transaction', () => {
+    const editor = mountEditor(paragraphs(['A', 'B', 'C', 'D']))
+    registerPlugin(editor)
+    expect(topOutline(editor)).toEqual(['A', 'B', 'C', 'D'])
+
+    selectAcross(editor, 'B', 'C')
+    expect(selectedBlockIds(editor)).toEqual(['B', 'C'])
+
+    const transactions = countTransactions(editor)
+    const tab = pressTab(editor)
+
+    expect(topOutline(editor)).toEqual(['A(B C)', 'D'])
+    expect(transactions()).toBe(1)
+    expect(tab.defaultPrevented).toBe(true)
+    expect(selectedBlockIds(editor)).toEqual(['B', 'C'])
+
+    editor.undo()
+    expect(topOutline(editor)).toEqual(['A', 'B', 'C', 'D'])
+
+    selectAcross(editor, 'B', 'C')
+    pressTab(editor)
+    expect(topOutline(editor)).toEqual(['A(B C)', 'D'])
+
+    // History groups edits closer than its group delay into one undo step.
+    // Move the clock so the outdent below gets its own step.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(Date.now() + 5_000)
+    const before = transactions()
+    pressTab(editor, true)
+
+    expect(topOutline(editor)).toEqual(['A', 'B', 'C', 'D'])
+    expect(transactions() - before).toBe(1)
+
+    editor.undo()
+    expect(topOutline(editor)).toEqual(['A(B C)', 'D'])
+  })
+
+  it('skips a block that cannot nest and keeps going', () => {
+    const editor = mountEditor(paragraphs(['A', 'B', 'C']))
+    registerPlugin(editor)
+
+    selectAcross(editor, 'A', 'B')
+    expect(() => pressTab(editor)).not.toThrow()
+
+    expect(topOutline(editor)).toEqual(['A(B)', 'C'])
+  })
+
+  it('leaves a single-block selection to BlockNote', () => {
+    const editor = mountEditor(paragraphs(['A', 'B']))
+    const plugin = pluginOf(editor)
+    registerPlugin(editor)
+
+    const tt = tiptap(editor)
+    tt.commands.setTextSelection(containerPos(tt.state.doc, 'B') + 3)
+    expect(selectedBlockIds(editor)).toEqual([])
+    expect(plugin.props.handleKeyDown(tt.view, tabEvent())).toBe(false)
+
+    pressTab(editor)
+    expect(topOutline(editor)).toEqual(['A(B)'])
+  })
+
+  it('ignores Tab with a modifier held', () => {
+    const editor = mountEditor(paragraphs(['A', 'B', 'C']))
+    const plugin = pluginOf(editor)
+    registerPlugin(editor)
+    selectAcross(editor, 'B', 'C')
+
+    const tt = tiptap(editor)
+    for (const modifier of ['metaKey', 'ctrlKey', 'altKey'] as const) {
+      expect(plugin.props.handleKeyDown(tt.view, tabEvent({ [modifier]: true }))).toBe(false)
+    }
+
+    expect(topOutline(editor)).toEqual(['A', 'B', 'C'])
+  })
+})
+
+describe('mixed paragraph and task blocks', () => {
+  const blocks = (): unknown[] => [
+    { id: 'T0', type: 'taskBlock', props: { taskId: 't0', title: 'Parent' } },
+    { id: 'P', type: 'paragraph', content: 'P' },
+    { id: 'T1', type: 'taskBlock', props: { taskId: 't1', title: 'One' } },
+    { id: 'T2', type: 'taskBlock', props: { taskId: 't2', title: 'Two' } }
+  ]
+
+  function byHand(editor: BlockNoteEditor, ids: string[], direction: 'indent' | 'outdent'): void {
+    for (const id of direction === 'indent' ? ids : [...ids].reverse()) {
+      if ((editor as any).getBlock(id)?.type === 'taskBlock') {
+        if (direction === 'indent') indentTaskBlock(editor, id)
+        else outdentTaskBlock(editor, id)
+        continue
+      }
+      const tt = tiptap(editor)
+      const pos = containerPos(tt.state.doc, id)
+      tt.view.dispatch(tt.state.tr.setSelection(NodeSelection.create(tt.state.doc, pos)))
+      if (direction === 'indent') {
+        if ((editor as any).canNestBlock()) (editor as any).nestBlock()
+      } else if ((editor as any).canUnnestBlock()) {
+        ;(editor as any).unnestBlock()
+      }
+    }
+  }
+
+  it('indents the paragraph and re-parents every task in one batch', () => {
+    const editor = mountEditor(blocks(), true)
+    indentBlocks(editor, ['P', 'T1', 'T2'])
+
+    expect(topOutline(editor)).toEqual(['#t0(P #t1 #t2)'])
+    const nested = (editor.document[0] as any).children
+    expect(nested[1].props.parentTaskId).toBe('t0')
+    expect(nested[2].props.parentTaskId).toBe('t0')
+    expect(vi.mocked(tasksService.update).mock.calls.map(([arg]) => arg)).toEqual([
+      { id: 't1', parentId: 't0' },
+      { id: 't2', parentId: 't0' }
+    ])
+
+    const hand = mountEditor(blocks(), true)
+    byHand(hand, ['P', 'T1', 'T2'], 'indent')
+    expect(shapeOf(topBlocks(editor))).toEqual(shapeOf(topBlocks(hand)))
+    expect(analyzeTaskIntents(topBlocks(editor) as never, new Set())).toEqual(
+      analyzeTaskIntents(topBlocks(hand) as never, new Set())
+    )
+  })
+
+  it('skips a task block that cannot nest and still moves the rest', () => {
+    const editor = mountEditor(
+      [
+        { id: 'A', type: 'paragraph', content: 'A' },
+        { id: 'T0', type: 'taskBlock', props: { taskId: 't0', title: 'Parent' } },
+        { id: 'B', type: 'paragraph', content: 'B' }
+      ],
+      true
+    )
+    registerPlugin(editor)
+    selectAcross(editor, 'A', 'B')
+    expect(selectedBlockIds(editor)).toEqual(['A', 'T0', 'B'])
+
+    pressTab(editor)
+
+    // A is first, T0 has no task block above it, B nests under T0 as by hand.
+    expect(topOutline(editor)).toEqual(['A', '#t0(B)'])
+    expect((editor as any).getBlock('T0').props.parentTaskId).toBe('')
+    expect(tasksService.update).not.toHaveBeenCalled()
+  })
+
+  it('outdents the same batch back to where it started', () => {
+    const editor = mountEditor(blocks(), true)
+    indentBlocks(editor, ['P', 'T1', 'T2'])
+    vi.mocked(tasksService.update).mockClear()
+
+    outdentBlocks(editor, ['P', 'T1', 'T2'])
+
+    expect(topOutline(editor)).toEqual(['#t0', 'P', '#t1', '#t2'])
+    expect(vi.mocked(tasksService.update).mock.calls.map(([arg]) => arg)).toEqual([
+      { id: 't2', parentId: null },
+      { id: 't1', parentId: null }
+    ])
+
+    const hand = mountEditor(blocks(), true)
+    indentBlocks(hand, ['P', 'T1', 'T2'])
+    byHand(hand, ['P', 'T1', 'T2'], 'outdent')
+    expect(shapeOf(topBlocks(editor))).toEqual(shapeOf(topBlocks(hand)))
+    expect(analyzeTaskIntents(topBlocks(editor) as never, new Set())).toEqual(
+      analyzeTaskIntents(topBlocks(hand) as never, new Set())
+    )
+  })
+})
+
+describe('menus that own Tab keep it', () => {
+  it('lets the tag suggestion popover confirm its highlighted tag', async () => {
+    const editor = mountEditor(paragraphs(['A', 'B', 'C']))
+    registerPlugin(editor)
+    selectAcross(editor, 'B', 'C')
+    const before = topOutline(editor)
+
+    const container = document.createElement('div')
+    const pill = document.createElement('span')
+    pill.className = 'inline-hash-tag'
+    pill.dataset.hashTag = 'wo'
+    pill.getBoundingClientRect = vi.fn(() => ({ top: 20, bottom: 40, left: 60 }) as DOMRect)
+    container.getBoundingClientRect = vi.fn(() => ({ top: 10, left: 20 }) as DOMRect)
+    container.append(pill)
+
+    const handlers = new Map<string, () => void>()
+    const onSelect = vi.fn()
+    const fakeEditor = {
+      _tiptapEditor: {
+        state: {
+          selection: {
+            $from: {
+              parentOffset: 2,
+              pos: 10,
+              nodeBefore: { type: { name: 'hashTag' }, attrs: { tag: 'wo' }, nodeSize: 4 }
+            },
+            from: 10,
+            to: 10
+          }
+        },
+        on: (event: string, handler: () => void) => handlers.set(event, handler),
+        off: (event: string) => handlers.delete(event)
+      }
+    }
+
+    render(
+      createElement(TagSuggestionPopover as any, {
+        editor: fakeEditor,
+        editorContainerRef: { current: container },
+        onSelect
+      })
+    )
+    act(() => {
+      handlers.get('selectionUpdate')?.()
+    })
+    expect(await screen.findByText('#work')).toBeInTheDocument()
+    // The keydown listener is a passive effect behind a promise-driven render.
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    tiptap(editor).view.dom.dispatchEvent(tabEvent())
+
+    expect(onSelect).toHaveBeenCalledWith('work', 'blue', 6)
+    expect(topOutline(editor)).toEqual(before)
+  })
+
+  it('lets the mention menu confirm its highlighted row', () => {
+    const editor = mountEditor(paragraphs(['A', 'B', 'C']))
+    registerPlugin(editor)
+    selectAcross(editor, 'B', 'C')
+    const before = topOutline(editor)
+
+    const items: MentionSuggestionItem[] = [
+      { kind: 'note', id: 'n1', title: 'Q3 Roadmap' },
+      { kind: 'note', id: 'n2', title: 'Meeting prep' }
+    ]
+    const onItemClick = vi.fn()
+    render(
+      createElement(MentionMenu as any, {
+        items,
+        loadingState: 'loaded',
+        selectedIndex: 0,
+        onItemClick,
+        hasMore: false,
+        onShowMore: vi.fn()
+      })
+    )
+
+    tiptap(editor).view.dom.dispatchEvent(tabEvent())
+
+    expect(onItemClick).toHaveBeenCalledWith(items[0])
+    expect(topOutline(editor)).toEqual(before)
+  })
+
+  it('leaves the inline date ghost to fill its own text', () => {
+    const editor = mountEditor([{ id: 'A', type: 'paragraph', content: '@to' }])
+    registerPlugin(editor)
+    registerEditorPlugin(
+      editor,
+      createDateMentionGhostPlugin({ onAcceptPill: vi.fn() }),
+      (p, plugins) => [p, ...plugins]
+    )
+
+    const tt = tiptap(editor)
+    tt.commands.setTextSelection(containerPos(tt.state.doc, 'A') + 5)
+    pressTab(editor)
+
+    expect(topOutline(editor)).toEqual(['@Today'])
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/multi-block-indent-plugin.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/multi-block-indent-plugin.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Tab / Shift+Tab over a selection that spans more than one block.
+ *
+ * BlockNote 0.47.1's `KeyboardShortcutsExtension` gives Tab back to the browser
+ * whenever the formatting toolbar store holds a selection, which it does for any
+ * non-empty selection even though this app never renders that toolbar. So the
+ * multi-block case reached no indent handler at all, while a caret still nested
+ * through BlockNote's own path. This plugin owns only the multi-block case and
+ * leaves the caret alone.
+ */
+
+import { NodeSelection, Plugin, PluginKey } from '@tiptap/pm/state'
+import type { Transaction } from '@tiptap/pm/state'
+import { liftListItem } from '@tiptap/pm/schema-list'
+import type { EditorView } from '@tiptap/pm/view'
+import { indentTaskBlock, outdentTaskBlock } from './hooks/task-block-marquee-indent'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('MultiBlockIndent')
+
+export const multiBlockIndentPluginKey = new PluginKey('multiBlockIndent')
+
+type IndentDirection = 'indent' | 'outdent'
+
+export function selectedBlockIds(editor: any): string[] {
+  try {
+    return (editor?.getSelection()?.blocks ?? []).map((block: any) => block.id)
+  } catch {
+    // BlockNote throws rather than returning undefined on some selections.
+    return []
+  }
+}
+
+function containerPos(doc: any, id: string): number | null {
+  let found: number | null = null
+  doc.descendants((node: any, pos: number) => {
+    if (found !== null) return false
+    if (node.type.name === 'blockContainer' && node.attrs?.id === id) {
+      found = pos
+      return false
+    }
+    return true
+  })
+  return found
+}
+
+function moveOne(editor: any, tr: Transaction, id: string, direction: IndentDirection): boolean {
+  const pos = containerPos(tr.doc, id)
+  if (pos === null) return false
+
+  if (editor.getBlock(id)?.type === 'taskBlock') {
+    const outcome =
+      direction === 'indent' ? indentTaskBlock(editor, id) : outdentTaskBlock(editor, id)
+    if (outcome.kind === 'skipped') {
+      log.debug('task block not moved', id, direction, outcome.reason)
+      return false
+    }
+    return true
+  }
+
+  tr.setSelection(NodeSelection.create(tr.doc, pos))
+
+  if (direction === 'indent') {
+    if (!editor.canNestBlock()) return false
+    editor.nestBlock()
+    return true
+  }
+
+  if (!editor.canUnnestBlock()) return false
+  // Not `editor.unnestBlock()`: that dispatches its own tiptap command
+  // transaction, which cannot join the one in flight. `liftListItem` reads only
+  // `selection` and `tr` and dispatches the same `tr` back.
+  const schema = tr.doc.type.schema
+  return liftListItem(schema.nodes.blockContainer)({ selection: tr.selection, tr } as any, () => {})
+}
+
+function moveBlocks(editor: any, ids: readonly string[], direction: IndentDirection): boolean {
+  if (ids.length === 0) return false
+
+  let moved = 0
+  editor.transact((tr: Transaction) => {
+    const original = tr.selection
+    const ordered = direction === 'indent' ? ids : [...ids].reverse()
+    for (const id of ordered) {
+      if (moveOne(editor, tr, id, direction)) moved += 1
+    }
+    tr.setSelection(original.map(tr.doc, tr.mapping))
+  })
+  return moved > 0
+}
+
+export function indentBlocks(editor: any, ids: readonly string[]): boolean {
+  return moveBlocks(editor, ids, 'indent')
+}
+
+export function outdentBlocks(editor: any, ids: readonly string[]): boolean {
+  return moveBlocks(editor, ids, 'outdent')
+}
+
+export function createMultiBlockIndentPlugin(editor: any): Plugin {
+  return new Plugin({
+    key: multiBlockIndentPluginKey,
+    props: {
+      handleKeyDown(_view: EditorView, event: KeyboardEvent): boolean {
+        if (event.key !== 'Tab') return false
+        if (event.metaKey || event.ctrlKey || event.altKey) return false
+
+        const ids = selectedBlockIds(editor)
+        if (ids.length < 2) return false
+
+        if (event.shiftKey) outdentBlocks(editor, ids)
+        else indentBlocks(editor, ids)
+        // Consumed even when nothing moved, or the browser moves focus out.
+        return true
+      }
+    }
+  })
+}

--- a/apps/desktop/tests/e2e/editor-multi-block-indent.e2e.ts
+++ b/apps/desktop/tests/e2e/editor-multi-block-indent.e2e.ts
@@ -1,0 +1,183 @@
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { ready, uniqueLabel } from './utils/desktop-test-helpers'
+import { SELECTORS, SHORTCUTS } from './utils/electron-helpers'
+import { createNoteWithBody } from './utils/note-sync-helpers'
+
+const NESTED_MARKER = 'memry:block-nesting-level=1'
+const TAG_MENU = '[role="listbox"]'
+
+interface BlockShape {
+  text: string
+  children: BlockShape[]
+}
+
+async function focusEditor(page: Page): Promise<void> {
+  const editor = page.locator(SELECTORS.noteEditor).first()
+  await editor.waitFor({ state: 'visible', timeout: 10_000 })
+  await editor.click()
+}
+
+async function selectBlocks(page: Page, fromIndex: number, toIndex: number): Promise<void> {
+  await focusEditor(page)
+  await page.evaluate(
+    ({ from, to }) => {
+      const editor = (window as unknown as { __memryEditor?: any }).__memryEditor
+      if (!editor) throw new Error('window.__memryEditor not exposed')
+      const doc = editor.document as Array<{ id: string }>
+      editor.focus()
+      editor.setSelection(doc[from].id, doc[to].id)
+    },
+    { from: fromIndex, to: toIndex }
+  )
+}
+
+async function placeCaretAtEnd(page: Page, blockIndex: number): Promise<void> {
+  await focusEditor(page)
+  await page.evaluate((index) => {
+    const editor = (window as unknown as { __memryEditor?: any }).__memryEditor
+    if (!editor) throw new Error('window.__memryEditor not exposed')
+    const doc = editor.document as Array<{ id: string }>
+    editor.focus()
+    editor.setTextCursorPosition(doc[index].id, 'end')
+  }, blockIndex)
+}
+
+async function documentShape(page: Page): Promise<BlockShape[]> {
+  return page.evaluate(() => {
+    const editor = (window as unknown as { __memryEditor?: any }).__memryEditor
+    if (!editor) throw new Error('window.__memryEditor not exposed')
+    const text = (content: unknown): string =>
+      Array.isArray(content)
+        ? content
+            .map((item) =>
+              typeof item?.text === 'string'
+                ? item.text
+                : typeof item?.attrs?.tag === 'string'
+                  ? `#${item.attrs.tag}`
+                  : typeof item?.props?.tag === 'string'
+                    ? `#${item.props.tag}`
+                    : ''
+            )
+            .join('')
+        : ''
+    const walk = (blocks: any[]): BlockShape[] =>
+      blocks.map((block) => ({ text: text(block.content), children: walk(block.children ?? []) }))
+    const shape = walk(editor.document as any[])
+    // BlockNote keeps an empty trailing paragraph after the last real block.
+    while (shape.length > 1 && shape.at(-1)?.text === '' && shape.at(-1)?.children.length === 0) {
+      shape.pop()
+    }
+    return shape
+  })
+}
+
+async function storedContent(page: Page, noteId: string): Promise<string> {
+  return page.evaluate(async (id) => {
+    const note = await window.api.notes.get(id)
+    return note?.content ?? ''
+  }, noteId)
+}
+
+async function seedTag(page: Page, tag: string): Promise<void> {
+  await page.evaluate(
+    async ({ title, body }) => {
+      const result = await window.api.notes.create({ title, content: body })
+      if (!result.success) throw new Error(result.error || 'tag seed note failed')
+    },
+    { title: uniqueLabel('Tag seed'), body: `Seeded with #${tag}` }
+  )
+  await expect
+    .poll(
+      () =>
+        page.evaluate(async () => {
+          const tags = await window.api.notes.getTags()
+          return tags.map((entry: { tag: string }) => entry.tag)
+        }),
+      { timeout: 15_000 }
+    )
+    .toContain(tag)
+}
+
+const flat = (...lines: string[]): BlockShape[] => lines.map((text) => ({ text, children: [] }))
+
+test.describe('Multi-block Tab indent', () => {
+  test.beforeEach(async ({ page }) => {
+    await ready(page)
+  })
+
+  test('Tab indents every selected block and Shift+Tab brings them all back', async ({ page }) => {
+    const note = await createNoteWithBody(
+      page,
+      uniqueLabel('Multi indent'),
+      'Anchor\nFirst\nSecond'
+    )
+    await expect.poll(() => documentShape(page)).toEqual(flat('Anchor', 'First', 'Second'))
+
+    await selectBlocks(page, 1, 2)
+    await page.keyboard.press('Tab')
+
+    await expect
+      .poll(() => documentShape(page))
+      .toEqual([{ text: 'Anchor', children: flat('First', 'Second') }])
+    await expect
+      .poll(() => storedContent(page, note.id), { timeout: 10_000 })
+      .toContain(NESTED_MARKER)
+
+    await page.keyboard.press('Shift+Tab')
+
+    await expect.poll(() => documentShape(page)).toEqual(flat('Anchor', 'First', 'Second'))
+    await expect
+      .poll(() => storedContent(page, note.id), { timeout: 10_000 })
+      .not.toContain(NESTED_MARKER)
+  })
+
+  test('one undo reverts the whole multi-block indent', async ({ page }) => {
+    await createNoteWithBody(page, uniqueLabel('Multi indent undo'), 'Anchor\nFirst\nSecond')
+    await expect.poll(() => documentShape(page)).toEqual(flat('Anchor', 'First', 'Second'))
+
+    await selectBlocks(page, 1, 2)
+    await page.keyboard.press('Tab')
+    await expect
+      .poll(() => documentShape(page))
+      .toEqual([{ text: 'Anchor', children: flat('First', 'Second') }])
+
+    // Past y-prosemirror's capture window, so the undo below cannot merge with
+    // anything that follows it.
+    await page.waitForTimeout(700)
+    await page.keyboard.press(SHORTCUTS.undo)
+    await expect.poll(() => documentShape(page)).toEqual(flat('Anchor', 'First', 'Second'))
+  })
+
+  test('a block that cannot nest is skipped and the rest still indent', async ({ page }) => {
+    await createNoteWithBody(page, uniqueLabel('Multi indent skip'), 'First\nSecond')
+    await expect.poll(() => documentShape(page)).toEqual(flat('First', 'Second'))
+
+    await selectBlocks(page, 0, 1)
+    await page.keyboard.press('Tab')
+
+    await expect
+      .poll(() => documentShape(page))
+      .toEqual([{ text: 'First', children: flat('Second') }])
+  })
+
+  test('Tab completes the open tag suggestion instead of indenting', async ({ page }) => {
+    // Typed two characters short below, so the menu has exactly one match.
+    const tag = `mbi${Math.random().toString(36).slice(2, 8)}`
+    await seedTag(page, tag)
+
+    await createNoteWithBody(page, uniqueLabel('Tag menu Tab'), 'Anchor\nSecond')
+    await expect.poll(() => documentShape(page)).toEqual(flat('Anchor', 'Second'))
+
+    await placeCaretAtEnd(page, 1)
+    await page.keyboard.type(` #${tag.slice(0, -2)}`)
+    await expect(page.locator(TAG_MENU)).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator(TAG_MENU)).toContainText(tag)
+
+    await page.keyboard.press('Tab')
+
+    await expect(page.locator(`.inline-hash-tag[data-hash-tag="${tag}"]`)).toBeVisible()
+    await expect(page.locator(TAG_MENU)).toBeHidden()
+    await expect.poll(() => documentShape(page)).toEqual(flat('Anchor', `Second #${tag}`))
+  })
+})

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -59,7 +59,11 @@ A chord indicator briefly flashes when the prefix is active.
 | Underline        | <kbd>⌘</kbd>+<kbd>U</kbd>              |
 | Insert wiki link | Type `[[`                              |
 | Open block menu  | Type `/`                               |
+| Indent block     | <kbd>Tab</kbd>                         |
+| Outdent block    | <kbd>⇧</kbd>+<kbd>Tab</kbd>            |
 | Find in page     | <kbd>⌘</kbd>+<kbd>F</kbd>              |
+
+<kbd>Tab</kbd> and <kbd>⇧</kbd>+<kbd>Tab</kbd> act on every block in the selection, not only the one holding the cursor.
 
 With the cursor inside a table cell:
 

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -251,6 +251,8 @@ Inside a table, dragging selects **cells**, not blocks — a drag from one cell 
 
 With blocks selected, <kbd>Backspace</kbd> deletes them, <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> indent and outdent them, and <kbd>Esc</kbd> clears the selection.
 
+Text selected across several blocks works the same way: <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> indent and outdent every block the selection touches, and a single undo reverts the whole step. A block that is already as far left as it can go is left where it is; the rest still move.
+
 One consequence worth knowing: the empty space to the right of a short line still counts as that line's text, so the right-hand margin outside the column is the place to begin a right-side block selection.
 
 ## Saving


### PR DESCRIPTION
## Summary

Select two lines and press Tab. Only the block under the caret ever moved, and with a selection that spans two blocks not even that: the key did nothing and focus left the editor (#1940).

Nothing in the app owned Tab for indentation. BlockNote's `KeyboardShortcutsExtension` handles it and returns false for both Tab and Shift+Tab whenever `FormattingToolbarExtension.store.state` is truthy. That store flips to true on any non-empty selection, even though the view renders `formattingToolbar={false}`, so a text selection across blocks never reached `nestBlock`. With a caret the store is false and `nestBlock` sinks the caret block. A headless BlockNote probe proved both halves before any code was written.

`multi-block-indent-plugin.ts` adds a ProseMirror plugin whose `handleKeyDown` acts only when `editor.getSelection()` spans two or more blocks. For each selected block, in document order, it places a `NodeSelection` on the block container and calls `editor.canNestBlock()` then `editor.nestBlock()`. Shift+Tab walks the ids in reverse and lifts each with prosemirror-schema-list's `liftListItem` on the same transaction, because BlockNote's `unnestBlock` dispatches its own tiptap command transaction and cannot join one in flight. A task block goes through `indentTaskBlock` and `outdentTaskBlock` from `hooks/task-block-marquee-indent.ts`, the helpers that mirror the inline Tab handler of the task title input in `task-block-renderer.tsx`. They move the block and set `parentTaskId` inside the transaction, and each fires a `tasksService.update` IPC for the DB row that is not awaited and not part of the transaction or its undo, the same pre-existing behaviour the marquee path has. A block that cannot move is skipped and the loop continues. Everything runs inside one `editor.transact`, the original selection is mapped back at the end, and one undo reverts the whole step. A caret or a selection inside one block returns false, so BlockNote's default keymap keeps that case. When the selection spans two or more blocks the key is consumed even if nothing could move, so Tab stays in the editor instead of moving focus out, which matches what a caret does today.

No throw is reachable inside the transaction for ids read from the current document: `canNestBlock` and `canUnnestBlock` gate the ProseMirror steps, the block position is looked up fresh in the transaction's doc before each step, and the task helpers already catch their `replaceBlocks`. If something did throw, `editor.transact` dispatches nothing, so the document stays as it was rather than half moved, and the error surfaces from the keydown handler. No per-block guard was added.

`ContentArea.tsx` registers the plugin prepended and before the date ghost effect. Prepending is a robustness choice. Today BlockNote's keymap declines a range, so even an appended handler receives the key, but that is BlockNote's bail path and not a contract. The menus that consume Tab keep winning by construction. `tag-suggestion-popover.tsx` and `mention-menu.tsx` listen on `document` in the capture phase and stop propagation, so the key never reaches the view. `date-mention-ghost-plugin.ts` acts only on an empty selection and this plugin only on two or more blocks. `comment-composer.tsx` is a separate DOM tree.

Tradeoffs. `tabBehavior: 'prefer-indent'` on the editor is a one-line change that makes BlockNote sink the whole range as one group. Rejected: a range whose first block cannot nest then does nothing for every block, and task blocks would get `parentTaskId` from the onChange reconciliation in a second transaction, which splits undo. The marquee hook keeps its own per-block loops in `use-block-marquee-selection.ts`. Migrating it to this module is a follow-up, since its unit tests assert on the old mechanism and three marquee E2E specs would join the change.

Blast radius. The note editor on every surface that mounts `ContentArea` (notes, journal, canvas cards, project home). Only Tab and Shift+Tab with a selection spanning two or more blocks change behaviour. Stored markdown keeps its format: nested blocks serialize with the existing `memry:block-nesting-level` markers.

Carries the test-only main fix from the calendar-widget PR (#1945) until it lands; rebasing after that drops it.

Closes #1940

## Release note

Tab and Shift+Tab now indent and outdent every block in a selection that spans several lines, and one undo reverts the whole step.

## Test plan

Root cause and mechanism were settled first with a headless BlockNote probe in jsdom (formatting toolbar store true on a range, `keyboardShortcut('Tab')` leaves the doc unchanged, direct `nestBlock()` sinks the range; per-block `NodeSelection` sink inside one `transact` dispatches one transaction and undoes in one step; `liftListItem` shim lifts in the same transaction).

- `vitest --project renderer multi-block-indent-plugin.test.ts`: red against the stub handler (3 failed, `A(B)` instead of `A(B C)`, task blocks not re-parented), then 10 passed. Covers two paragraphs nested and unnested in one transaction with one undo, selection still spanning both blocks and the keydown consumed, a first block that cannot nest, a caret left to BlockNote, modifier keys ignored, a mixed paragraph and task range compared block by block against `indentTaskBlock` and `outdentTaskBlock` by hand and through `analyzeTaskIntents`, a real Tab over a range holding a task block with no task above it (skipped, `parentTaskId` untouched, no `tasksService.update`, the paragraph after it still nests), and the tag popover, mention menu and date ghost keeping Tab.
- Mutation check on the committed module, each run against that file and restored from HEAD afterwards: first block only, inverted `canNestBlock` gate, one transaction per block, no selection restore, key not consumed, Shift handling swapped. 6 of 6 killed.
- Neighbouring renderer suites (tag popover, mention menu, date ghost, marquee hook, task-block marquee indent, scan-task-intents, register-editor-plugin, ContentArea): 8 files, 134 passed.
- Electron E2E `editor-multi-block-indent.e2e.ts`, red with `ContentArea.tsx` checked out from origin/main and the fix committed: 3 failed (received flat `children: []`, expected nested), 1 passed (the tag-menu case is a regression guard). Green with HEAD in the same lock window together with `inline-date-ghost.e2e.ts`, `inline-subtasks.e2e.ts` and `editor-undo.e2e.ts`: 35 passed. The spec selects two paragraphs with `editor.setSelection`, presses Tab, asserts both are nested in the editor document and that `notes.get` content carries the level-1 nesting marker, presses Shift+Tab and asserts both are back, checks one undo reverts the whole indent, checks the first block is skipped when it cannot nest, and checks Tab completes an open tag suggestion instead of indenting.
- `pnpm --filter @memry/desktop test:renderer`: 706 files, 8637 passed, 2 expected fail, 7 skipped. An earlier full run failed the tag popover case once under load; the test now flushes passive effects through `act` before the key press, as the popover's own test does, and passed three isolated reruns and the full suite after that.
- `pnpm --filter @memry/desktop typecheck:web`, `typecheck:test`: pass.
- `pnpm lint`: 0 errors (108 pre-existing warnings, none in changed files).
- `pnpm --filter @memry/desktop i18n:check`: pass.
- `pnpm check:architecture`, `pnpm check:contracts`, `git diff --check`: pass.
- `pnpm docs:impact --base origin/main --strict`: covered (`notes/editing.md`, `keyboard-shortcuts.md`). `pnpm docs:build`: build complete.
- Not run: `test:main` and `ipc:check`. No main-process code, contract or IPC handler changed.
