### PR TITLE
fix(export): keep embedded images in exported PDF and HTML

### DIFF
--- a/apps/desktop/src/main/ipc/notes-handlers-extra.test.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers-extra.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => {
   }
   const windowInstance = {
     loadURL: vi.fn().mockResolvedValue(undefined),
+    loadFile: vi.fn().mockResolvedValue(undefined),
     webContents,
     destroy: vi.fn(),
     isDestroyed: vi.fn(() => false)
@@ -37,6 +38,8 @@ const mocks = vi.hoisted(() => {
     windowInstance,
     webContents,
     fsWriteFile: vi.fn(),
+    fsRm: vi.fn(),
+    appGetPath: vi.fn(() => '/tmp'),
     resolveNoteByTitle: vi.fn(),
     resolveNotesByTitles: vi.fn(),
     getNoteTags: vi.fn(),
@@ -89,12 +92,14 @@ vi.mock('electron', () => ({
     removeHandler: mocks.removeHandler
   },
   dialog: mocks.dialog,
-  BrowserWindow: mocks.BrowserWindow
+  BrowserWindow: mocks.BrowserWindow,
+  app: { getPath: mocks.appGetPath }
 }))
 
 vi.mock('fs/promises', async (importOriginal) => ({
   ...(await importOriginal<typeof import('fs/promises')>()),
-  writeFile: mocks.fsWriteFile
+  writeFile: mocks.fsWriteFile,
+  rm: mocks.fsRm
 }))
 
 vi.mock('../database', () => ({
@@ -227,7 +232,6 @@ const successful = (result: unknown): unknown => {
   return result
 }
 
-const DATA_HTML_PREFIX = 'data:text/html;charset=utf-8,'
 const PNG_BYTES = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
   'base64'
@@ -245,8 +249,11 @@ describe('notes-handlers extra coverage', () => {
     mocks.handlers.clear()
     mocks.webContents.printToPDF.mockResolvedValue(Buffer.from('pdf'))
     mocks.windowInstance.loadURL.mockResolvedValue(undefined)
+    mocks.windowInstance.loadFile.mockResolvedValue(undefined)
     mocks.windowInstance.isDestroyed.mockReturnValue(false)
     mocks.fsWriteFile.mockResolvedValue(undefined)
+    mocks.fsRm.mockResolvedValue(undefined)
+    mocks.appGetPath.mockReturnValue('/tmp')
     mocks.service.get.mockReturnValue(null)
     mocks.getVaultStatus.mockReturnValue({ path: null })
     mocks.renderNoteAsHtml.mockReturnValue('<html><body>note</body></html>')
@@ -590,13 +597,16 @@ describe('notes-handlers extra coverage', () => {
     )
     expect(mocks.fsWriteFile).toHaveBeenCalledWith('/tmp/Daily_note.pdf', Buffer.from('pdf'))
 
-    // The PDF window loads a `data:` URL, which has no base to resolve a
-    // relative ref against, so the bytes have to travel in the document.
-    const loaded = mocks.windowInstance.loadURL.mock.calls.at(-1)?.[0] as string
-    expect(loaded.startsWith(DATA_HTML_PREFIX)).toBe(true)
-    expect(decodeURIComponent(loaded.slice(DATA_HTML_PREFIX.length))).toBe(
-      `<html><body><img src="data:image/png;base64,${PNG_BASE64}"></body></html>`
+    // Staged to a real file rather than a `data:` URL, which Chromium rejects
+    // past its length ceiling once an image is inlined.
+    const staged = mocks.windowInstance.loadFile.mock.calls.at(-1)?.[0] as string
+    expect(staged).toMatch(/^\/tmp\/memry-export-.+\.html$/)
+    expect(mocks.fsWriteFile).toHaveBeenCalledWith(
+      staged,
+      `<html><body><img src="data:image/png;base64,${PNG_BASE64}"></body></html>`,
+      'utf-8'
     )
+    expect(mocks.fsRm).toHaveBeenCalledWith(staged, { force: true })
 
     mocks.dialog.showSaveDialog.mockResolvedValueOnce({ canceled: true })
     await expect(
@@ -677,10 +687,13 @@ describe('notes-handlers extra coverage', () => {
       })
     ).toEqual({ success: false, error: 'printToPDF crashed' })
     expect(mocks.windowInstance.destroy).toHaveBeenCalledTimes(1)
-    expect(mocks.fsWriteFile).not.toHaveBeenCalled()
+    expect(mocks.fsWriteFile).not.toHaveBeenCalledWith('/tmp/Daily_note.pdf', expect.anything())
+    // The staged HTML is removed even when the print fails.
+    const staged = mocks.windowInstance.loadFile.mock.calls.at(-1)?.[0] as string
+    expect(mocks.fsRm).toHaveBeenCalledWith(staged, { force: true })
 
     mocks.windowInstance.destroy.mockClear()
-    mocks.windowInstance.loadURL.mockRejectedValueOnce(new Error('loadURL crashed'))
+    mocks.windowInstance.loadFile.mockRejectedValueOnce(new Error('loadFile crashed'))
     expect(
       await invoke(NotesChannels.invoke.EXPORT_PDF, {
         noteId: 'note-a',
@@ -688,7 +701,7 @@ describe('notes-handlers extra coverage', () => {
         includeMetadata: false,
         pageSize: 'A4'
       })
-    ).toEqual({ success: false, error: 'loadURL crashed' })
+    ).toEqual({ success: false, error: 'loadFile crashed' })
     expect(mocks.windowInstance.destroy).toHaveBeenCalledTimes(1)
 
     // An already-destroyed window is never destroyed twice.

--- a/apps/desktop/src/main/ipc/notes-handlers-extra.test.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers-extra.test.ts
@@ -665,6 +665,29 @@ describe('notes-handlers extra coverage', () => {
     )
   })
 
+  it('still exports when the staged HTML cannot be removed', async () => {
+    mocks.getNoteById.mockResolvedValue({
+      id: 'note-a',
+      path: 'Note.md',
+      title: 'Daily note',
+      content: '# Today',
+      emoji: null,
+      tags: [],
+      created: new Date('2026-05-10T00:00:00.000Z'),
+      modified: new Date('2026-05-10T00:00:00.000Z')
+    })
+    mocks.fsRm.mockRejectedValueOnce(new Error('EBUSY'))
+
+    await expect(
+      invoke(NotesChannels.invoke.EXPORT_PDF, {
+        noteId: 'note-a',
+        outputPath: '/tmp/Daily_note.pdf',
+        includeMetadata: false,
+        pageSize: 'A4'
+      })
+    ).resolves.toEqual({ success: true, path: '/tmp/Daily_note.pdf' })
+  })
+
   it('destroys the hidden PDF window when rendering fails', async () => {
     const note = {
       id: 'note-a',

--- a/apps/desktop/src/main/ipc/notes-handlers-extra.test.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers-extra.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 import { NotesChannels } from '@memry/contracts/notes-api'
 import { PropertyTypes } from '@memry/contracts/property-types'
@@ -63,6 +66,8 @@ const mocks = vi.hoisted(() => {
     countLocalOnlyNoteMetadata: vi.fn(),
     listPropertyDefinitions: vi.fn(),
     emitNoteAttachmentSaved: vi.fn(),
+    getVaultStatus: vi.fn(() => ({ path: null }) as { path: string | null }),
+    renderNoteAsHtml: vi.fn(() => '<html><body>note</body></html>'),
     service: {
       get: vi.fn(),
       upsert: vi.fn(),
@@ -173,8 +178,13 @@ vi.mock('../vault/property-definitions', () => ({
 }))
 
 vi.mock('../lib/export-utils', () => ({
-  renderNoteAsHtml: vi.fn(() => '<html><body>note</body></html>'),
+  renderNoteAsHtml: mocks.renderNoteAsHtml,
   sanitizeFilename: vi.fn((value: string) => value.replace(/\W+/g, '_'))
+}))
+
+vi.mock('../vault/index', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../vault/index')>()),
+  getStatus: mocks.getVaultStatus
 }))
 
 vi.mock('../lib/main-i18n', () => ({
@@ -197,7 +207,8 @@ vi.mock('@memry/storage-data', () => ({
   listPropertyDefinitions: mocks.listPropertyDefinitions
 }))
 
-vi.mock('@memry/shared/file-types', () => ({
+vi.mock('@memry/shared/file-types', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@memry/shared/file-types')>()),
   getAllSupportedExtensions: vi.fn(() => ['md', 'pdf', 'png'])
 }))
 
@@ -216,8 +227,20 @@ const successful = (result: unknown): unknown => {
   return result
 }
 
+const DATA_HTML_PREFIX = 'data:text/html;charset=utf-8,'
+const PNG_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+  'base64'
+)
+const PNG_BASE64 = PNG_BYTES.toString('base64')
+
 describe('notes-handlers extra coverage', () => {
+  let vaultPath: string
+
   beforeEach(() => {
+    vaultPath = mkdtempSync(path.join(tmpdir(), 'memry-export-handler-'))
+    mkdirSync(path.join(vaultPath, 'attachments', 'note-a'), { recursive: true })
+    writeFileSync(path.join(vaultPath, 'attachments', 'note-a', 'photo.png'), PNG_BYTES)
     vi.clearAllMocks()
     mocks.handlers.clear()
     mocks.webContents.printToPDF.mockResolvedValue(Buffer.from('pdf'))
@@ -225,12 +248,15 @@ describe('notes-handlers extra coverage', () => {
     mocks.windowInstance.isDestroyed.mockReturnValue(false)
     mocks.fsWriteFile.mockResolvedValue(undefined)
     mocks.service.get.mockReturnValue(null)
+    mocks.getVaultStatus.mockReturnValue({ path: null })
+    mocks.renderNoteAsHtml.mockReturnValue('<html><body>note</body></html>')
     registerNotesHandlers()
   })
 
   afterEach(() => {
     unregisterNotesHandlers()
     mocks.handlers.clear()
+    rmSync(vaultPath, { recursive: true, force: true })
   })
 
   it('resolves a batch of titles into a plain record over one channel', async () => {
@@ -531,6 +557,7 @@ describe('notes-handlers extra coverage', () => {
 
     const note = {
       id: 'note-a',
+      path: 'Note.md',
       title: 'Daily note',
       content: '# Today',
       emoji: null,
@@ -539,6 +566,10 @@ describe('notes-handlers extra coverage', () => {
       modified: new Date('2026-05-10T00:00:00.000Z')
     }
     mocks.getNoteById.mockResolvedValue(note)
+    mocks.getVaultStatus.mockReturnValue({ path: vaultPath })
+    mocks.renderNoteAsHtml.mockReturnValue(
+      '<html><body><img src="attachments/note-a/photo.png"></body></html>'
+    )
     mocks.dialog.showSaveDialog.mockResolvedValueOnce({
       canceled: false,
       filePath: '/tmp/Daily_note.pdf'
@@ -558,6 +589,14 @@ describe('notes-handlers extra coverage', () => {
       expect.objectContaining({ pageSize: 'Letter', printBackground: true })
     )
     expect(mocks.fsWriteFile).toHaveBeenCalledWith('/tmp/Daily_note.pdf', Buffer.from('pdf'))
+
+    // The PDF window loads a `data:` URL, which has no base to resolve a
+    // relative ref against, so the bytes have to travel in the document.
+    const loaded = mocks.windowInstance.loadURL.mock.calls.at(-1)?.[0] as string
+    expect(loaded.startsWith(DATA_HTML_PREFIX)).toBe(true)
+    expect(decodeURIComponent(loaded.slice(DATA_HTML_PREFIX.length))).toBe(
+      `<html><body><img src="data:image/png;base64,${PNG_BASE64}"></body></html>`
+    )
 
     mocks.dialog.showSaveDialog.mockResolvedValueOnce({ canceled: true })
     await expect(
@@ -579,9 +618,39 @@ describe('notes-handlers extra coverage', () => {
         pageSize: 'A4'
       })
     ).resolves.toEqual({ success: true, path: '/tmp/Daily_note.html' })
+    // Self-contained, so the file keeps its images once the user moves it.
     expect(mocks.fsWriteFile).toHaveBeenCalledWith(
       '/tmp/Daily_note.html',
-      '<html><body>note</body></html>',
+      `<html><body><img src="data:image/png;base64,${PNG_BASE64}"></body></html>`,
+      'utf-8'
+    )
+  })
+
+  it('leaves an image it cannot read as written', async () => {
+    mocks.getNoteById.mockResolvedValue({
+      id: 'note-a',
+      path: 'Note.md',
+      title: 'Daily note',
+      content: '# Today',
+      emoji: null,
+      tags: [],
+      created: new Date('2026-05-10T00:00:00.000Z'),
+      modified: new Date('2026-05-10T00:00:00.000Z')
+    })
+    mocks.getVaultStatus.mockReturnValue({ path: vaultPath })
+    mocks.renderNoteAsHtml.mockReturnValue('<img src="attachments/note-a/missing.png">')
+
+    await expect(
+      invoke(NotesChannels.invoke.EXPORT_HTML, {
+        noteId: 'note-a',
+        outputPath: '/tmp/Daily_note.html',
+        includeMetadata: false,
+        pageSize: 'A4'
+      })
+    ).resolves.toEqual({ success: true, path: '/tmp/Daily_note.html' })
+    expect(mocks.fsWriteFile).toHaveBeenCalledWith(
+      '/tmp/Daily_note.html',
+      '<img src="attachments/note-a/missing.png">',
       'utf-8'
     )
   })

--- a/apps/desktop/src/main/ipc/notes-handlers.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.ts
@@ -46,6 +46,7 @@ import {
   withErrorHandler
 } from './validate'
 import { registerCommand } from './lib/register-command'
+import type { Note } from '../vault/notes'
 import {
   getNoteById,
   getNoteByPath,
@@ -78,6 +79,8 @@ import {
 import { applyTemplateToNote } from '../notes/apply-template'
 import { getAllSupportedExtensions } from '@memry/shared/file-types'
 import { saveAttachment, deleteAttachment, listNoteAttachments } from '../vault/attachments'
+import { getStatus as getVaultStatus } from '../vault/index'
+import { inlineExportImages } from '../lib/export-image-inliner'
 import { readFolderConfig, writeFolderConfig, getFolderTemplate } from '../vault/folders'
 import {
   syncFolderConfigSet,
@@ -192,6 +195,29 @@ const ExportNoteSchema = z.object({
   // Headless export target — when provided, skip the save dialog (Agent MCP).
   outputPath: z.string().min(1).optional()
 })
+
+/**
+ * Render a note for export with its images carried inside the document.
+ *
+ * Both export paths go through here so the two stay in step: the PDF path has
+ * no base URL to resolve a relative `<img src>` against, and an exported
+ * `.html` only kept its images while it sat next to the attachments (#1935).
+ */
+async function renderNoteForExport(note: Note, includeMetadata: boolean): Promise<string> {
+  const html = renderNoteAsHtml(
+    {
+      id: note.id,
+      title: note.title,
+      content: note.content,
+      emoji: note.emoji,
+      tags: note.tags,
+      created: note.created,
+      modified: note.modified
+    },
+    { includeMetadata }
+  )
+  return inlineExportImages(html, { notePath: note.path, vaultPath: getVaultStatus().path })
+}
 
 /**
  * Register all note-related IPC handlers.
@@ -893,18 +919,7 @@ export function registerNotesHandlers(): void {
         targetPath = result.filePath
       }
 
-      const html = renderNoteAsHtml(
-        {
-          id: note.id,
-          title: note.title,
-          content: note.content,
-          emoji: note.emoji,
-          tags: note.tags,
-          created: note.created,
-          modified: note.modified
-        },
-        { includeMetadata: input.includeMetadata }
-      )
+      const html = await renderNoteForExport(note, input.includeMetadata)
 
       const win = new BrowserWindow({
         show: false,
@@ -982,18 +997,7 @@ export function registerNotesHandlers(): void {
         targetPath = result.filePath
       }
 
-      const html = renderNoteAsHtml(
-        {
-          id: note.id,
-          title: note.title,
-          content: note.content,
-          emoji: note.emoji,
-          tags: note.tags,
-          created: note.created,
-          modified: note.modified
-        },
-        { includeMetadata: input.includeMetadata }
-      )
+      const html = await renderNoteForExport(note, input.includeMetadata)
 
       await fs.writeFile(targetPath, html, 'utf-8')
 

--- a/apps/desktop/src/main/ipc/notes-handlers.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.ts
@@ -5,8 +5,10 @@
  * @module ipc/notes-handlers
  */
 
-import { ipcMain, dialog, BrowserWindow } from 'electron'
+import { ipcMain, dialog, BrowserWindow, app } from 'electron'
 import * as fs from 'fs/promises'
+import * as path from 'path'
+import { randomUUID } from 'crypto'
 import { z } from 'zod'
 import {
   NotesChannels,
@@ -930,9 +932,16 @@ export function registerNotesHandlers(): void {
         }
       })
 
+      // A `data:` URL would be simpler, but Chromium rejects one past its URL
+      // length ceiling with ERR_INVALID_URL, and a note holding one phone
+      // photograph clears that ceiling once its images are inlined. A real file
+      // has no such limit.
+      const stagedHtmlPath = path.join(app.getPath('temp'), `memry-export-${randomUUID()}.html`)
+
       let pdfData: Buffer
       try {
-        await win.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`)
+        await fs.writeFile(stagedHtmlPath, html, 'utf-8')
+        await win.loadFile(stagedHtmlPath)
         await new Promise((resolve) => setTimeout(resolve, 100))
 
         const pageSizeMap: Record<string, Electron.PrintToPDFOptions['pageSize']> = {
@@ -953,6 +962,9 @@ export function registerNotesHandlers(): void {
         })
       } finally {
         if (!win.isDestroyed()) win.destroy()
+        await fs.rm(stagedHtmlPath, { force: true }).catch((error) => {
+          logger.warn('Failed to remove the staged export HTML', { stagedHtmlPath, error })
+        })
       }
 
       await fs.writeFile(targetPath, pdfData)

--- a/apps/desktop/src/main/ipc/notes-handlers.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.ts
@@ -199,7 +199,7 @@ const ExportNoteSchema = z.object({
 /**
  * Render a note for export with its images carried inside the document.
  *
- * Both export paths go through here so the two stay in step: the PDF path has
+ * Both export paths go through here so the two stay in step. The PDF path has
  * no base URL to resolve a relative `<img src>` against, and an exported
  * `.html` only kept its images while it sat next to the attachments (#1935).
  */

--- a/apps/desktop/src/main/lib/export-image-inliner.test.ts
+++ b/apps/desktop/src/main/lib/export-image-inliner.test.ts
@@ -123,23 +123,61 @@ describe('inlineExportImages', () => {
   })
 
   it('leaves a ref that climbs above the vault root untouched', async () => {
-    // The file the climb would land on if `..` were collapsed instead of
-    // rejected: without the guard this would be inlined from the vault root.
+    // The file the climb lands on when `..` is collapsed instead of rejected.
+    // Without the guard this would be inlined from the vault root.
     writeFileSync(path.join(vaultPath, 'escape.png'), PNG_BYTES)
     const source = '<img src="../../escape.png">'
 
     expect(await inlineExportImages(source, { notePath: 'Folder/Note.md', vaultPath })).toBe(source)
   })
 
-  it('falls back to application/octet-stream for an unknown extension', async () => {
+  it('leaves a readable file whose extension is not a known image type', async () => {
     writeFileSync(path.join(vaultPath, 'attachments', 'note-a', 'photo.heic'), PNG_BYTES)
+    const source = '<img src="attachments/note-a/photo.heic">'
 
-    const html = await inlineExportImages('<img src="attachments/note-a/photo.heic">', {
-      notePath: 'Note.md',
-      vaultPath
-    })
+    expect(await inlineExportImages(source, { notePath: 'Note.md', vaultPath })).toBe(source)
+    expect(mocks.warn).toHaveBeenCalledWith(
+      'Export skipped a reference that is not a known image type',
+      expect.objectContaining({ src: 'attachments/note-a/photo.heic' })
+    )
+  })
 
-    expect(html).toBe(`<img src="data:application/octet-stream;base64,${PNG_BASE64}">`)
+  it('never embeds a non-image file the note points at by absolute path', async () => {
+    const secret = path.join(outsidePath, 'id_rsa')
+    writeFileSync(secret, 'PRIVATE KEY BYTES')
+
+    for (const src of [secret, pathToFileURL(secret).href, toMemryFileUrl(secret)]) {
+      const source = `<img src="${src}">`
+      const html = await inlineExportImages(source, { notePath: 'Folder/Note.md', vaultPath })
+
+      expect(html).toBe(source)
+      expect(html).not.toContain('PRIVATE KEY BYTES')
+      expect(html).not.toContain(Buffer.from('PRIVATE KEY BYTES').toString('base64'))
+    }
+  })
+
+  it('inlines every extension on the image allowlist', async () => {
+    const cases: Array<[string, string]> = [
+      ['a.png', 'image/png'],
+      ['a.jpg', 'image/jpeg'],
+      ['a.jpeg', 'image/jpeg'],
+      ['a.gif', 'image/gif'],
+      ['a.webp', 'image/webp'],
+      ['a.svg', 'image/svg+xml'],
+      ['a.bmp', 'image/bmp'],
+      ['a.avif', 'image/avif'],
+      ['a.ico', 'image/x-icon']
+    ]
+
+    for (const [filename, mime] of cases) {
+      writeFileSync(path.join(vaultPath, 'attachments', 'note-a', filename), PNG_BYTES)
+      const html = await inlineExportImages(`<img src="attachments/note-a/${filename}">`, {
+        notePath: 'Note.md',
+        vaultPath
+      })
+
+      expect(html).toBe(`<img src="data:${mime};base64,${PNG_BASE64}">`)
+    }
   })
 
   it('rewrites every occurrence of a repeated image and keeps the original quoting', async () => {

--- a/apps/desktop/src/main/lib/export-image-inliner.test.ts
+++ b/apps/desktop/src/main/lib/export-image-inliner.test.ts
@@ -1,0 +1,165 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { pathToFileURL } from 'url'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ warn: vi.fn() }))
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({ warn: mocks.warn, error: vi.fn(), info: vi.fn(), debug: vi.fn() })
+}))
+
+import { toMemryFileUrl } from './paths'
+import { inlineExportImages } from './export-image-inliner'
+
+const PNG_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+  'base64'
+)
+const PNG_BASE64 = PNG_BYTES.toString('base64')
+
+let vaultPath: string
+let outsidePath: string
+
+beforeEach(() => {
+  mocks.warn.mockClear()
+  vaultPath = mkdtempSync(path.join(tmpdir(), 'memry-export-vault-'))
+  outsidePath = mkdtempSync(path.join(tmpdir(), 'memry-export-outside-'))
+  mkdirSync(path.join(vaultPath, 'attachments', 'note-a'), { recursive: true })
+  mkdirSync(path.join(vaultPath, 'Folder'), { recursive: true })
+  writeFileSync(path.join(vaultPath, 'attachments', 'note-a', 'photo.png'), PNG_BYTES)
+})
+
+afterEach(() => {
+  rmSync(vaultPath, { recursive: true, force: true })
+  rmSync(outsidePath, { recursive: true, force: true })
+})
+
+describe('inlineExportImages', () => {
+  it('inlines a note-relative image as a data URI carrying the file bytes', async () => {
+    const html = await inlineExportImages(
+      '<p><img src="../attachments/note-a/photo.png" alt="pic"></p>',
+      { notePath: 'Folder/Note.md', vaultPath }
+    )
+
+    expect(html).toBe(`<p><img src="data:image/png;base64,${PNG_BASE64}" alt="pic"></p>`)
+  })
+
+  it('resolves a relative ref for a note that sits at the vault root', async () => {
+    const html = await inlineExportImages('<img src="attachments/note-a/photo.png">', {
+      notePath: 'Note.md',
+      vaultPath
+    })
+
+    expect(html).toBe(`<img src="data:image/png;base64,${PNG_BASE64}">`)
+  })
+
+  it('percent-decodes a relative ref before reading it off disk', async () => {
+    writeFileSync(path.join(vaultPath, 'attachments', 'note-a', 'my photo.png'), PNG_BYTES)
+
+    const html = await inlineExportImages('<img src="attachments/note-a/my%20photo.png">', {
+      notePath: 'Note.md',
+      vaultPath
+    })
+
+    expect(html).toBe(`<img src="data:image/png;base64,${PNG_BASE64}">`)
+  })
+
+  it('inlines an image that lives outside the vault', async () => {
+    const outside = path.join(outsidePath, 'outside.png')
+    writeFileSync(outside, PNG_BYTES)
+
+    const html = await inlineExportImages(`<img src="${outside}">`, {
+      notePath: 'Folder/Note.md',
+      vaultPath
+    })
+
+    expect(html).toBe(`<img src="data:image/png;base64,${PNG_BASE64}">`)
+  })
+
+  it('inlines an outside-the-vault image referenced by file:// URL', async () => {
+    const outside = path.join(outsidePath, 'outside.png')
+    writeFileSync(outside, PNG_BYTES)
+
+    const html = await inlineExportImages(`<img src="${pathToFileURL(outside).href}">`, {
+      notePath: 'Folder/Note.md',
+      vaultPath
+    })
+
+    expect(html).toBe(`<img src="data:image/png;base64,${PNG_BASE64}">`)
+  })
+
+  it('inlines a legacy memry-file:// ref', async () => {
+    const outside = path.join(outsidePath, 'my photo.png')
+    writeFileSync(outside, PNG_BYTES)
+
+    const html = await inlineExportImages(`<img src="${toMemryFileUrl(outside)}">`, {
+      notePath: 'Folder/Note.md',
+      vaultPath
+    })
+
+    expect(html).toBe(`<img src="data:image/png;base64,${PNG_BASE64}">`)
+  })
+
+  it('leaves an unreadable path untouched and logs it', async () => {
+    const source = '<img src="attachments/note-a/missing.png">'
+
+    const html = await inlineExportImages(source, { notePath: 'Note.md', vaultPath })
+
+    expect(html).toBe(source)
+    expect(mocks.warn).toHaveBeenCalledWith(
+      'Export could not inline an image, leaving the reference as written',
+      expect.objectContaining({ src: 'attachments/note-a/missing.png' })
+    )
+  })
+
+  it('leaves data:, http: and https: sources alone without reading disk', async () => {
+    const source =
+      '<img src="data:image/gif;base64,R0lGOD"><img src="https://example.com/a.png"><img src="http://example.com/b.png">'
+
+    expect(await inlineExportImages(source, { notePath: 'Note.md', vaultPath })).toBe(source)
+    expect(mocks.warn).not.toHaveBeenCalled()
+  })
+
+  it('leaves a ref that climbs above the vault root untouched', async () => {
+    const source = '<img src="../../escape.png">'
+
+    expect(await inlineExportImages(source, { notePath: 'Folder/Note.md', vaultPath })).toBe(source)
+  })
+
+  it('falls back to application/octet-stream for an unknown extension', async () => {
+    writeFileSync(path.join(vaultPath, 'attachments', 'note-a', 'photo.heic'), PNG_BYTES)
+
+    const html = await inlineExportImages('<img src="attachments/note-a/photo.heic">', {
+      notePath: 'Note.md',
+      vaultPath
+    })
+
+    expect(html).toBe(`<img src="data:application/octet-stream;base64,${PNG_BASE64}">`)
+  })
+
+  it('rewrites every occurrence of a repeated image and keeps the original quoting', async () => {
+    const html = await inlineExportImages(
+      '<img src="attachments/note-a/photo.png"><img src=\'attachments/note-a/photo.png\'>',
+      { notePath: 'Note.md', vaultPath }
+    )
+
+    expect(html).toBe(
+      `<img src="data:image/png;base64,${PNG_BASE64}"><img src='data:image/png;base64,${PNG_BASE64}'>`
+    )
+  })
+
+  it('leaves the html alone when the note path or the vault path is unknown', async () => {
+    const source = '<img src="attachments/note-a/photo.png">'
+
+    expect(await inlineExportImages(source, { notePath: undefined, vaultPath })).toBe(source)
+    expect(await inlineExportImages(source, { notePath: 'Note.md', vaultPath: null })).toBe(source)
+  })
+
+  it('does not touch a src attribute that is not on an img tag', async () => {
+    const source = '<script src="attachments/note-a/photo.png"></script>'
+
+    expect(await inlineExportImages(source, { notePath: 'Note.md', vaultPath })).toBe(source)
+  })
+})

--- a/apps/desktop/src/main/lib/export-image-inliner.test.ts
+++ b/apps/desktop/src/main/lib/export-image-inliner.test.ts
@@ -180,6 +180,25 @@ describe('inlineExportImages', () => {
     }
   })
 
+  it('falls back to the raw ref when the percent-encoding is malformed', async () => {
+    writeFileSync(path.join(vaultPath, 'attachments', 'note-a', '%E0%A4%A.png'), PNG_BYTES)
+
+    const html = await inlineExportImages('<img src="attachments/note-a/%E0%A4%A.png">', {
+      notePath: 'Note.md',
+      vaultPath
+    })
+
+    expect(html).toBe(`<img src="data:image/png;base64,${PNG_BASE64}">`)
+  })
+
+  it('leaves a malformed file: or memry-file: URL untouched instead of throwing', async () => {
+    for (const src of ['file://host/photo.png', 'memry-file://local/%E0%A4%A.png']) {
+      const source = `<img src="${src}">`
+
+      expect(await inlineExportImages(source, { notePath: 'Note.md', vaultPath })).toBe(source)
+    }
+  })
+
   it('rewrites every occurrence of a repeated image and keeps the original quoting', async () => {
     const html = await inlineExportImages(
       '<img src="attachments/note-a/photo.png"><img src=\'attachments/note-a/photo.png\'>',

--- a/apps/desktop/src/main/lib/export-image-inliner.test.ts
+++ b/apps/desktop/src/main/lib/export-image-inliner.test.ts
@@ -123,6 +123,9 @@ describe('inlineExportImages', () => {
   })
 
   it('leaves a ref that climbs above the vault root untouched', async () => {
+    // The file the climb would land on if `..` were collapsed instead of
+    // rejected: without the guard this would be inlined from the vault root.
+    writeFileSync(path.join(vaultPath, 'escape.png'), PNG_BYTES)
     const source = '<img src="../../escape.png">'
 
     expect(await inlineExportImages(source, { notePath: 'Folder/Note.md', vaultPath })).toBe(source)

--- a/apps/desktop/src/main/lib/export-image-inliner.ts
+++ b/apps/desktop/src/main/lib/export-image-inliner.ts
@@ -9,8 +9,15 @@
  *
  * Inlining the bytes fixes both paths with one rule. It needs no base URL and
  * no script, so it works with `webPreferences.javascript: false`, and it makes
- * an exported `.html` self-contained. The cost is document size: every image is
- * carried as base64, about a third larger than the file on disk.
+ * an exported `.html` self-contained. The cost is document size, since base64
+ * runs about a third larger than the file on disk.
+ *
+ * Only the image extensions below are inlined. A note is data, and a synced or
+ * imported one can name any path its author liked, so without the allowlist an
+ * `<img src="file:///…/id_rsa">` would put those bytes into a document the user
+ * then emails. `memry-file:` has the protocol handler's vault and userData
+ * check behind it; every other scheme here has nothing, so the extension is the
+ * gate.
  *
  * @module lib/export-image-inliner
  */
@@ -18,7 +25,7 @@
 import { readFile } from 'fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { getExtension, getMimeType } from '@memry/shared/file-types'
+import { getExtension } from '@memry/shared/file-types'
 import { createLogger } from './logger'
 
 const logger = createLogger('ExportImageInliner')
@@ -30,10 +37,22 @@ export interface ExportImageSource {
   vaultPath?: string | null
 }
 
+const IMAGE_MIME: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  bmp: 'image/bmp',
+  avif: 'image/avif',
+  ico: 'image/x-icon'
+}
+
 const IMG_TAG = /<img\b[^>]*>/gi
 const SRC_ATTR = /(\ssrc\s*=\s*)(["'])([^"']*)\2/i
 
-/** `https:`, `data:`, `memry-file:` — and `C:` on Windows, ruled out first. */
+/** Matches `https:`, `data:`, `memry-file:`, and `C:` on Windows. */
 const HAS_SCHEME = /^[a-zA-Z][a-zA-Z\d+\-.]*:/
 const WINDOWS_DRIVE = /^[a-zA-Z]:[/\\]/
 const SEPARATOR = /[/\\]/
@@ -43,9 +62,9 @@ const SEPARATOR = /[/\\]/
  * and `..`. Returns null when the ref climbs above the vault root.
  *
  * Restated from the renderer's `resolve-note-relative-url.ts` rather than
- * imported: the renderer is not importable here, and both sides have to agree
- * on what a note-relative ref means or the export resolves images the editor
- * does not.
+ * imported, because the renderer is not importable here. Both sides have to
+ * agree on what a note-relative ref means, or the export resolves images the
+ * editor does not.
  */
 function joinWithinVault(dir: string, ref: string): string[] | null {
   const out: string[] = []
@@ -132,9 +151,15 @@ export async function inlineExportImages(html: string, source: ExportImageSource
     [...refs].map(async (src) => {
       const filePath = resolveLocalPath(src, source)
       if (!filePath) return
+
+      const mime = IMAGE_MIME[getExtension(filePath)]
+      if (!mime) {
+        logger.warn('Export skipped a reference that is not a known image type', { src, filePath })
+        return
+      }
+
       try {
         const bytes = await readFile(filePath)
-        const mime = getMimeType(getExtension(filePath)) ?? 'application/octet-stream'
         inlined.set(src, `data:${mime};base64,${bytes.toString('base64')}`)
       } catch (error) {
         logger.warn('Export could not inline an image, leaving the reference as written', {

--- a/apps/desktop/src/main/lib/export-image-inliner.ts
+++ b/apps/desktop/src/main/lib/export-image-inliner.ts
@@ -1,0 +1,156 @@
+/**
+ * Carry an exported note's images inside the exported document.
+ *
+ * PDF export loads the rendered HTML through a `data:text/html` URL, which has
+ * an opaque origin and no base URL, so a relative `<img src="attachments/…">`
+ * has nothing to resolve against and `printToPDF` bakes in a broken image
+ * (#1935). HTML export only looked right because the file happened to land next
+ * to the attachments; move the `.html` and it breaks the same way.
+ *
+ * Inlining the bytes fixes both paths with one rule. It needs no base URL and
+ * no script, so it works with `webPreferences.javascript: false`, and it makes
+ * an exported `.html` self-contained. The cost is document size: every image is
+ * carried as base64, about a third larger than the file on disk.
+ *
+ * @module lib/export-image-inliner
+ */
+
+import { readFile } from 'fs/promises'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { getExtension, getMimeType } from '@memry/shared/file-types'
+import { createLogger } from './logger'
+
+const logger = createLogger('ExportImageInliner')
+
+export interface ExportImageSource {
+  /** The exported note's vault-relative path, e.g. `Folder/Note.md`. */
+  notePath?: string
+  /** Absolute path of the open vault. */
+  vaultPath?: string | null
+}
+
+const IMG_TAG = /<img\b[^>]*>/gi
+const SRC_ATTR = /(\ssrc\s*=\s*)(["'])([^"']*)\2/i
+
+/** `https:`, `data:`, `memry-file:` — and `C:` on Windows, ruled out first. */
+const HAS_SCHEME = /^[a-zA-Z][a-zA-Z\d+\-.]*:/
+const WINDOWS_DRIVE = /^[a-zA-Z]:[/\\]/
+const SEPARATOR = /[/\\]/
+
+/**
+ * Join the note's vault-relative directory with a relative ref, collapsing `.`
+ * and `..`. Returns null when the ref climbs above the vault root.
+ *
+ * Restated from the renderer's `resolve-note-relative-url.ts` rather than
+ * imported: the renderer is not importable here, and both sides have to agree
+ * on what a note-relative ref means or the export resolves images the editor
+ * does not.
+ */
+function joinWithinVault(dir: string, ref: string): string[] | null {
+  const out: string[] = []
+  for (const segment of [...dir.split(SEPARATOR), ...ref.split(SEPARATOR)]) {
+    if (!segment || segment === '.') continue
+    if (segment === '..') {
+      if (out.length === 0) return null
+      out.pop()
+      continue
+    }
+    out.push(segment)
+  }
+  return out.length > 0 ? out : null
+}
+
+function memryFileUrlToPath(url: string): string | null {
+  try {
+    const decoded = decodeURIComponent(new URL(url).pathname)
+    if (process.platform === 'win32') {
+      return decoded.startsWith('/') ? decoded.slice(1) : decoded
+    }
+    return decoded.startsWith('/') ? decoded : `/${decoded}`
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The on-disk file an `<img src>` names, or null when the src is not a local
+ * file we should read: a remote or already-inlined URL, an unknown scheme, or a
+ * relative ref that escapes the vault.
+ */
+function resolveLocalPath(src: string, source: ExportImageSource): string | null {
+  const ref = src.trim()
+  if (!ref) return null
+  if (WINDOWS_DRIVE.test(ref)) return ref
+
+  if (HAS_SCHEME.test(ref)) {
+    const scheme = ref.slice(0, ref.indexOf(':')).toLowerCase()
+    if (scheme === 'file') {
+      try {
+        return fileURLToPath(ref)
+      } catch {
+        return null
+      }
+    }
+    if (scheme === 'memry-file') return memryFileUrlToPath(ref)
+    return null
+  }
+
+  if (ref.startsWith('/') || ref.startsWith('\\')) return ref
+
+  const { notePath, vaultPath } = source
+  if (!notePath || !vaultPath) return null
+
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(ref)
+  } catch {
+    decoded = ref
+  }
+
+  const noteDir = notePath.split(SEPARATOR).slice(0, -1).join('/')
+  const segments = joinWithinVault(noteDir, decoded)
+  if (!segments) return null
+
+  return path.join(vaultPath, ...segments)
+}
+
+/**
+ * Rewrite every `<img src>` in a rendered note to a `data:` URI holding the
+ * file's bytes. A src that names no readable local file is left as written.
+ */
+export async function inlineExportImages(html: string, source: ExportImageSource): Promise<string> {
+  const refs = new Set<string>()
+  for (const tag of html.match(IMG_TAG) ?? []) {
+    const src = SRC_ATTR.exec(tag)?.[3]
+    if (src) refs.add(src)
+  }
+  if (refs.size === 0) return html
+
+  const inlined = new Map<string, string>()
+  await Promise.all(
+    [...refs].map(async (src) => {
+      const filePath = resolveLocalPath(src, source)
+      if (!filePath) return
+      try {
+        const bytes = await readFile(filePath)
+        const mime = getMimeType(getExtension(filePath)) ?? 'application/octet-stream'
+        inlined.set(src, `data:${mime};base64,${bytes.toString('base64')}`)
+      } catch (error) {
+        logger.warn('Export could not inline an image, leaving the reference as written', {
+          src,
+          filePath,
+          error
+        })
+      }
+    })
+  )
+  if (inlined.size === 0) return html
+
+  return html.replace(IMG_TAG, (tag) =>
+    tag.replace(SRC_ATTR, (attribute: string, prefix: string, quote: string, src: string) => {
+      const dataUri = inlined.get(src)
+      return dataUri ? `${prefix}${quote}${dataUri}${quote}` : attribute
+    })
+  )
+}

--- a/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget-refresh.test.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget-refresh.test.tsx
@@ -31,10 +31,28 @@ const SOURCE_TYPE_BY_VISUAL_TYPE = {
   note: 'note'
 } as const
 
+/**
+ * The instant these tests pretend it is, on today's real local date.
+ *
+ * `use-today` snapshots the local date into module scope at import and re-reads the wall clock
+ * for its first subscriber. A clock faked onto any other date therefore arrives as a midnight
+ * rollover, which moves `todayCalendarRange`, moves the query key with it, and makes the widget
+ * fetch a second day on mount. Only the time of day is pinned, and from local fields rather than
+ * a UTC instant, which far enough from UTC would name a different day.
+ */
+const NOW = new Date()
+NOW.setHours(9, 30, 0, 0)
+
+function todayAtHour(hour: number): string {
+  const at = new Date(NOW)
+  at.setHours(hour, 0, 0, 0)
+  return at.toISOString()
+}
+
 function projectionItem(
   id: string,
   title: string,
-  hourUtc: number,
+  hour: number,
   visualType: keyof typeof SOURCE_TYPE_BY_VISUAL_TYPE
 ): CalendarProjectionItem {
   return {
@@ -43,8 +61,8 @@ function projectionItem(
     sourceId: id,
     title,
     descriptionPreview: null,
-    startAt: `2026-08-31T${String(hourUtc).padStart(2, '0')}:00:00.000Z`,
-    endAt: `2026-08-31T${String(hourUtc + 1).padStart(2, '0')}:00:00.000Z`,
+    startAt: todayAtHour(hour),
+    endAt: todayAtHour(hour + 1),
     isAllDay: false,
     timezone: 'UTC',
     visualType,
@@ -101,7 +119,7 @@ function renderApp(): { showBoard: (visible: boolean) => void } {
 
 describe('home calendar widget stays current', () => {
   beforeEach(() => {
-    vi.setSystemTime(new Date('2026-08-31T09:30:00.000Z'))
+    vi.setSystemTime(NOW)
     listeners.clear()
     server.items = [projectionItem('e1', 'Standup', 10, 'event')]
     mockGetRange.mockReset()

--- a/apps/desktop/tests/e2e/note-export-images.e2e.ts
+++ b/apps/desktop/tests/e2e/note-export-images.e2e.ts
@@ -15,14 +15,48 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import zlib from 'zlib'
 import type { Page } from '@playwright/test'
 import { test, expect } from './fixtures'
 import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
 
-/** A 16x16 solid PNG: large enough that Chromium emits a real image object. */
+/** A 16x16 solid PNG, large enough that Chromium emits a real image object. */
 const PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR42mO4Y2NEEmIY1TCqYfhqAAAatkoQSZYreAAAAABJRU5ErkJggg=='
 const PNG_BYTES = Buffer.from(PNG_BASE64, 'base64')
+
+/**
+ * A `size`x`size` PNG stored uncompressed, so the file really is megabytes.
+ * Exists to push the inlined document past Chromium's 2 MB URL ceiling, which a
+ * phone photograph in a real note would do on its own.
+ */
+function makeLargePng(size: number): Buffer {
+  const stride = size * 3 + 1
+  const raw = Buffer.alloc(size * stride)
+  for (let i = 0; i < raw.length; i++) raw[i] = i % 251
+  for (let y = 0; y < size; y++) raw[y * stride] = 0
+
+  const chunk = (type: string, data: Buffer): Buffer => {
+    const body = Buffer.concat([Buffer.from(type, 'latin1'), data])
+    const length = Buffer.alloc(4)
+    length.writeUInt32BE(data.length)
+    const crc = Buffer.alloc(4)
+    crc.writeUInt32BE(zlib.crc32(body))
+    return Buffer.concat([length, body, crc])
+  }
+
+  const ihdr = Buffer.alloc(13)
+  ihdr.writeUInt32BE(size, 0)
+  ihdr.writeUInt32BE(size, 4)
+  ihdr[8] = 8
+  ihdr[9] = 2
+  return Buffer.concat([
+    Buffer.from('89504e470d0a1a0a', 'hex'),
+    chunk('IHDR', ihdr),
+    chunk('IDAT', zlib.deflateSync(raw, { level: 0 })),
+    chunk('IEND', Buffer.alloc(0))
+  ])
+}
 
 interface SeededNote {
   noteId: string
@@ -34,18 +68,28 @@ interface SeededNote {
  * A note whose body embeds a real uploaded attachment.
  *
  * The attachment is uploaded against a host note created first, then the
- * exported note is created WITH the markdown embed as its initial content: a
- * post-create update loses to the CRDT body.
+ * exported note is created WITH the markdown embed as its initial content,
+ * because a post-create update loses to the CRDT body.
  */
-async function seedNoteWithImage(page: Page, title: string): Promise<SeededNote> {
+async function seedNoteWithImage(
+  page: Page,
+  title: string,
+  png: Buffer = PNG_BYTES
+): Promise<SeededNote> {
   return page.evaluate(
-    async ({ t, bytes }) => {
+    async ({ t, base64 }) => {
       const api = window.api
 
       const host = await api.notes.create({ title: `${t} host`, content: 'attachment host' })
       if (!host.success || !host.note) throw new Error(host.error ?? 'host note create failed')
 
-      const file = new File([new Uint8Array(bytes)], 'export-pic.png', { type: 'image/png' })
+      // base64 rather than a number array, so a multi-megabyte image serialises
+      // into the page in a fraction of the time.
+      const binary = atob(base64)
+      const bytes = new Uint8Array(binary.length)
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+
+      const file = new File([bytes], 'export-pic.png', { type: 'image/png' })
       const uploaded = await api.notes.uploadAttachment(host.note.id, file)
       if (!uploaded.success || !uploaded.path) {
         throw new Error(uploaded.error ?? 'attachment upload failed')
@@ -56,7 +100,7 @@ async function seedNoteWithImage(page: Page, title: string): Promise<SeededNote>
 
       return { noteId: note.note.id, ref: uploaded.path }
     },
-    { t: title, bytes: [...PNG_BYTES] }
+    { t: title, base64: png.toString('base64') }
   )
 }
 
@@ -119,6 +163,29 @@ test.describe('Note export keeps embedded images', () => {
     expect(pdf.byteLength).toBeGreaterThan(2000)
     // Skia writes the XObject dictionary uncompressed, so a rendered bitmap is
     // visible in the raw bytes. A broken image leaves no image object at all.
+    expect(pdf.toString('latin1')).toContain('/Image')
+  })
+
+  test('exported PDF embeds an image far larger than the URL length ceiling', async ({ page }) => {
+    const png = makeLargePng(900)
+    expect(png.byteLength).toBeGreaterThan(2 * 1024 * 1024)
+    const seeded = await seedNoteWithImage(page, 'Export big pdf images', png)
+
+    const outputPath = path.join(exportDir, 'big.pdf')
+    const result = await page.evaluate(
+      async ({ noteId, out }) =>
+        window.api.notes.exportPdf({
+          noteId,
+          includeMetadata: false,
+          pageSize: 'A4',
+          outputPath: out
+        }),
+      { noteId: seeded.noteId, out: outputPath }
+    )
+    expect(result.success, result.error ?? 'export failed').toBe(true)
+
+    const pdf = fs.readFileSync(outputPath)
+    expect(pdf.subarray(0, 5).toString('latin1')).toBe('%PDF-')
     expect(pdf.toString('latin1')).toContain('/Image')
   })
 })

--- a/apps/desktop/tests/e2e/note-export-images.e2e.ts
+++ b/apps/desktop/tests/e2e/note-export-images.e2e.ts
@@ -20,17 +20,12 @@ import type { Page } from '@playwright/test'
 import { test, expect } from './fixtures'
 import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
 
-/** A 16x16 solid PNG, large enough that Chromium emits a real image object. */
-const PNG_BASE64 =
-  'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR42mO4Y2NEEmIY1TCqYfhqAAAatkoQSZYreAAAAABJRU5ErkJggg=='
-const PNG_BYTES = Buffer.from(PNG_BASE64, 'base64')
-
 /**
- * A `size`x`size` PNG stored uncompressed, so the file really is megabytes.
- * Exists to push the inlined document past Chromium's 2 MB URL ceiling, which a
- * phone photograph in a real note would do on its own.
+ * A `size`x`size` RGB PNG. `level` 0 stores the pixels uncompressed, which is
+ * how the large case reaches the megabytes needed to clear Chromium's URL
+ * length ceiling, the ceiling a phone photograph clears on its own.
  */
-function makeLargePng(size: number): Buffer {
+function makePng(size: number, level: number): Buffer {
   const stride = size * 3 + 1
   const raw = Buffer.alloc(size * stride)
   for (let i = 0; i < raw.length; i++) raw[i] = i % 251
@@ -53,9 +48,24 @@ function makeLargePng(size: number): Buffer {
   return Buffer.concat([
     Buffer.from('89504e470d0a1a0a', 'hex'),
     chunk('IHDR', ihdr),
-    chunk('IDAT', zlib.deflateSync(raw, { level: 0 })),
+    chunk('IDAT', zlib.deflateSync(raw, { level })),
     chunk('IEND', Buffer.alloc(0))
   ])
+}
+
+/** The image the exported note embeds, wide enough to tell from a broken-image icon. */
+const IMAGE_WIDTH = 613
+const PNG_BYTES = makePng(IMAGE_WIDTH, 9)
+const PNG_BASE64 = PNG_BYTES.toString('base64')
+
+/**
+ * The widest image object in a PDF. Chromium always writes some image, so the
+ * presence of one proves nothing. A broken reference leaves only the tiny
+ * broken-image icon, while a resolved one embeds the note's own bitmap.
+ */
+function widestEmbeddedImage(pdf: Buffer): number {
+  const widths = [...pdf.toString('latin1').matchAll(/\/Width\s+(\d+)/g)].map((m) => Number(m[1]))
+  return widths.length > 0 ? Math.max(...widths) : 0
 }
 
 interface SeededNote {
@@ -160,14 +170,13 @@ test.describe('Note export keeps embedded images', () => {
 
     const pdf = fs.readFileSync(outputPath)
     expect(pdf.subarray(0, 5).toString('latin1')).toBe('%PDF-')
-    expect(pdf.byteLength).toBeGreaterThan(2000)
-    // Skia writes the XObject dictionary uncompressed, so a rendered bitmap is
-    // visible in the raw bytes. A broken image leaves no image object at all.
     expect(pdf.toString('latin1')).toContain('/Image')
+    const widest = widestEmbeddedImage(pdf)
+    expect(widest, `widest embedded image was ${widest}px`).toBeGreaterThan(64)
   })
 
   test('exported PDF embeds an image far larger than the URL length ceiling', async ({ page }) => {
-    const png = makeLargePng(900)
+    const png = makePng(900, 0)
     expect(png.byteLength).toBeGreaterThan(2 * 1024 * 1024)
     const seeded = await seedNoteWithImage(page, 'Export big pdf images', png)
 
@@ -186,6 +195,7 @@ test.describe('Note export keeps embedded images', () => {
 
     const pdf = fs.readFileSync(outputPath)
     expect(pdf.subarray(0, 5).toString('latin1')).toBe('%PDF-')
-    expect(pdf.toString('latin1')).toContain('/Image')
+    const widest = widestEmbeddedImage(pdf)
+    expect(widest, `widest embedded image was ${widest}px`).toBeGreaterThan(64)
   })
 })

--- a/apps/desktop/tests/e2e/note-export-images.e2e.ts
+++ b/apps/desktop/tests/e2e/note-export-images.e2e.ts
@@ -1,0 +1,124 @@
+/**
+ * Note export image embedding E2E (issue #1935)
+ *
+ * A note that embeds an attachment must keep that image in both export
+ * formats. PDF export loads the rendered HTML through a `data:` URL, which has
+ * no base URL, so a relative `<img src="attachments/…">` used to arrive at
+ * `printToPDF` broken. HTML export only looked right while the file sat next to
+ * the attachments folder.
+ *
+ * Export is driven through `window.api.notes.export*` with an explicit
+ * `outputPath`. That is the same handler the note menu invokes; the menu path
+ * itself opens a native save dialog, which Playwright cannot answer.
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
+
+/** A 16x16 solid PNG: large enough that Chromium emits a real image object. */
+const PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR42mO4Y2NEEmIY1TCqYfhqAAAatkoQSZYreAAAAABJRU5ErkJggg=='
+const PNG_BYTES = Buffer.from(PNG_BASE64, 'base64')
+
+interface SeededNote {
+  noteId: string
+  /** The note-relative ref the markdown carries, e.g. `../attachments/<id>/x.png`. */
+  ref: string
+}
+
+/**
+ * A note whose body embeds a real uploaded attachment.
+ *
+ * The attachment is uploaded against a host note created first, then the
+ * exported note is created WITH the markdown embed as its initial content: a
+ * post-create update loses to the CRDT body.
+ */
+async function seedNoteWithImage(page: Page, title: string): Promise<SeededNote> {
+  return page.evaluate(
+    async ({ t, bytes }) => {
+      const api = window.api
+
+      const host = await api.notes.create({ title: `${t} host`, content: 'attachment host' })
+      if (!host.success || !host.note) throw new Error(host.error ?? 'host note create failed')
+
+      const file = new File([new Uint8Array(bytes)], 'export-pic.png', { type: 'image/png' })
+      const uploaded = await api.notes.uploadAttachment(host.note.id, file)
+      if (!uploaded.success || !uploaded.path) {
+        throw new Error(uploaded.error ?? 'attachment upload failed')
+      }
+
+      const note = await api.notes.create({ title: t, content: `![pic](${uploaded.path})` })
+      if (!note.success || !note.note) throw new Error(note.error ?? 'note create failed')
+
+      return { noteId: note.note.id, ref: uploaded.path }
+    },
+    { t: title, bytes: [...PNG_BYTES] }
+  )
+}
+
+test.describe('Note export keeps embedded images', () => {
+  let exportDir: string
+  let movedDir: string
+
+  test.beforeEach(async ({ page }) => {
+    exportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-export-'))
+    movedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-export-moved-'))
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+  })
+
+  test.afterEach(() => {
+    fs.rmSync(exportDir, { recursive: true, force: true })
+    fs.rmSync(movedDir, { recursive: true, force: true })
+  })
+
+  test('exported HTML carries the image after the file is moved', async ({ page }) => {
+    const seeded = await seedNoteWithImage(page, 'Export html images')
+    expect(seeded.ref).toContain('attachments/')
+
+    const outputPath = path.join(exportDir, 'note.html')
+    const result = await page.evaluate(
+      async ({ noteId, out }) =>
+        window.api.notes.exportHtml({ noteId, includeMetadata: false, outputPath: out }),
+      { noteId: seeded.noteId, out: outputPath }
+    )
+    expect(result.success, result.error ?? 'export failed').toBe(true)
+
+    const movedPath = path.join(movedDir, 'note.html')
+    fs.renameSync(outputPath, movedPath)
+    const html = fs.readFileSync(movedPath, 'utf-8')
+
+    const src = /<img[^>]*\ssrc="([^"]*)"/.exec(html)?.[1]
+    expect(src, 'exported html has no <img>').toBeTruthy()
+    expect(src).toBe(`data:image/png;base64,${PNG_BASE64}`)
+    expect(html).not.toContain('attachments/')
+  })
+
+  test('exported PDF embeds the image rather than a broken reference', async ({ page }) => {
+    const seeded = await seedNoteWithImage(page, 'Export pdf images')
+
+    const outputPath = path.join(exportDir, 'note.pdf')
+    const result = await page.evaluate(
+      async ({ noteId, out }) =>
+        window.api.notes.exportPdf({
+          noteId,
+          includeMetadata: false,
+          pageSize: 'A4',
+          outputPath: out
+        }),
+      { noteId: seeded.noteId, out: outputPath }
+    )
+    expect(result.success, result.error ?? 'export failed').toBe(true)
+
+    const pdf = fs.readFileSync(outputPath)
+    expect(pdf.subarray(0, 5).toString('latin1')).toBe('%PDF-')
+    expect(pdf.byteLength).toBeGreaterThan(2000)
+    // Skia writes the XObject dictionary uncompressed, so a rendered bitmap is
+    // visible in the raw bytes. A broken image leaves no image object at all.
+    expect(pdf.toString('latin1')).toContain('/Image')
+  })
+})

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -205,7 +205,7 @@ The **⋯ button** in the top-right of a note (the _More actions_ menu) collects
 - **Local graph** — show or hide the note's local link graph
 - **Find…** — open in-note search (also <kbd>⌘</kbd>+<kbd>F</kbd>)
 - **Version history** — browse and restore past versions
-- **Export** — export the note to PDF or HTML
+- **Export** — export the note to PDF or HTML. Both formats embed the note's images in the exported file itself, so the PDF prints them and an exported `.html` keeps them after you move or send it
 - **Apply template** — insert a template into the note
 - **Full width** — toggle the wide editor layout
 


### PR DESCRIPTION
## Summary

A note that embeds an image exported to PDF with the image broken, while the same note exported to HTML looked fine. `EXPORT_PDF` in `apps/desktop/src/main/ipc/notes-handlers.ts` rendered the note through `renderNoteAsHtml` and handed the result to a hidden `BrowserWindow` as `data:text/html;charset=utf-8,…`. A `data:` URL has an opaque origin and no base URL, so the relative `<img src="attachments/…/photo.png">` that `markdownToHtml` emits had nothing to resolve against. Chromium drew a broken image and `printToPDF` baked it in. `EXPORT_HTML` wrote the same markup to a real file, so the relative path resolved against wherever the user happened to save it. That was luck rather than correctness. Move the `.html` out of the vault and its images break the same way.

The new `apps/desktop/src/main/lib/export-image-inliner.ts` carries the bytes inside the document instead. `inlineExportImages` collects every `<img src>` in the rendered note, resolves each one to a file on disk, and rewrites it to a `data:` URI. Both handlers render through one `renderNoteForExport` helper, so the PDF and HTML paths cannot drift apart again.

Resolution follows the rule the editor already uses. A `data:`, `http:` or `https:` src is left alone. A `file:` URL, a `memry-file:` URL, an absolute path or a Windows drive path is read directly, which is what makes an image outside the vault work. Anything else is a note-relative ref resolved against the note's own directory inside the vault, mirroring the renderer's `resolveNoteRelativeUrl`, including its refusal to follow a ref that climbs above the vault root. Only the nine extensions on an explicit image allowlist are inlined, because a note is data and a synced or imported one can name any path its author liked; without the gate an `<img src="file:///…/id_rsa">` would put those bytes into a document the user then emails. Anything the allowlist rejects, and anything unreadable, is left exactly as written and logged through `createLogger`.

The PDF window now loads a file staged under `app.getPath('temp')` rather than a `data:` URL, removed in the same `finally` block that destroys the window. This is not cosmetic. Inlining grows the document, and the E2E showed Chromium rejecting the URL with `ERR_INVALID_URL (-300)` once a 2.4 MB image was embedded, which a single phone photograph clears. Without this the fix would have traded a broken image for a failed export. The note's HTML touches the OS temp directory for the length of one print, which is the same disk the vault's own plaintext markdown already sits on.

The tradeoff is document size. Base64 runs about a third larger than the file on disk, so a note with several photographs produces a bigger PDF and a much bigger `.html` than before. In exchange the PDF renders and the `.html` survives being moved or emailed. `webPreferences.javascript` stays `false`; nothing here needs a script or a base URL.

Blast radius is the main process and those two export handlers. No IPC contract, database schema, settings shape or sync payload changes, and `pnpm ipc:check` reports the invoke map unchanged. Notes written by older versions export identically, because resolution reads the markdown as it stands and never rewrites the vault.

Carries the test-only main fix from the calendar-widget PR until it lands; rebasing after that drops it.

Closes #1935

## Release note

Exported PDFs now show a note's embedded images, and an exported HTML file keeps its images after you move or send it.

## Test plan

- `pnpm --filter @memry/desktop test:main`. 567 files, 7751 passed, 3 files and 6 tests skipped, 1 expected fail.
- `pnpm --filter @memry/desktop test:renderer`. 705 files, 8628 passed, 2 expected fail, 7 skipped.
- `apps/desktop/src/main/lib/export-image-inliner.test.ts`. 15 passed. Pins the exact `data:image/png;base64,…` payload for a note-relative ref, a percent-encoded ref, a ref from a note in a subfolder, an image outside the vault by absolute path, by `file:` URL and by `memry-file:` URL, and every extension on the allowlist with its MIME type. Pins the untouched cases too: `data:`, `http:`, `https:`, a ref escaping the vault root, an unreadable path, a `src` on a non-`img` tag, a readable file whose extension is not an image, and an `id_rsa` named by absolute path, `file:` URL and `memry-file:` URL, which asserts its bytes appear nowhere in the output.
- `apps/desktop/src/main/ipc/notes-handlers-extra.test.ts`. 10 passed. The export test now asserts the exact inlined `<img src>` in the HTML staged for the PDF window and in the HTML written to disk, and that the staged file is removed. It previously asserted only `success: true`, which is what let this bug ship. Red against `origin/main`'s handler: `expected '<html><body><img src="attachments/not…' to be '<html><body><img src="data:image/png;…'`.
- `apps/desktop/tests/e2e/note-export-images.e2e.ts`. 3 passed. Seeds a note embedding a real uploaded 613px PNG, exports HTML to a temp directory, moves the file to a second directory, and asserts the `<img src>` there is the image's data URI with no `attachments/` reference left. Exports the same note to PDF, and a second note holding a 2.4 MB image, asserting in each case that the widest image object in the PDF is the note's own bitmap. Red against `origin/main`'s handler, all three, with `Error: widest embedded image was 14px`, which is Chromium's broken-image icon. Asserting only the presence of an `/Image` object did not discriminate, because Chromium writes that icon as an image too.
- Mutation check: six mutations of the fix, all killed. Dropping the rewrite, dropping the percent-decode, dropping the image-extension gate, changing the MIME fallback, hoisting the vault-path read to module scope, and collapsing `..` instead of rejecting it. The last one initially survived, because the escaping ref pointed at a file that did not exist; the test now writes that file at the vault root so the guard itself is pinned.
- `pnpm --filter @memry/desktop typecheck:node`, `typecheck:web`, `typecheck:test`, `pnpm lint` (0 errors), `pnpm --filter @memry/desktop i18n:check`, `pnpm check:architecture`, `pnpm check:contracts`, `pnpm ipc:generate && pnpm ipc:check`, `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build`, `git diff --check`. All clean.
