### PR TITLE
fix(tasks): unmount the task detail drawer when it is closed

### DIFF
--- a/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer-open-state.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer-open-state.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * The drawer's open/closed contract, which the E2E specs address it by.
+ *
+ * Before #1931 the closed drawer stayed mounted behind `inert`, `aria-hidden`
+ * and `width: 0`. A 1px border still gave it a box, so Playwright reported it
+ * visible in both states and every `state: 'visible'` / `state: 'hidden'` wait
+ * on it passed without proving anything. jsdom computes no layout, so these
+ * tests assert the thing Playwright's visibility check was standing in for:
+ * whether the element the specs select is in the document at all, and whether
+ * it names itself open.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { i18n as I18nInstance } from 'i18next'
+import type { ReactElement, ReactNode } from 'react'
+import { createRendererI18n } from '@memry/i18n/renderer'
+import { TaskDetailDrawer, type TaskDetailDrawerProps } from './task-detail-drawer'
+import type { Task } from '@/data/task-model'
+import type { Project, Status } from '@/data/tasks-data'
+
+vi.mock('@/services/notes-service', () => ({
+  notesService: {
+    get: vi.fn().mockResolvedValue(null),
+    getFile: vi.fn().mockResolvedValue(null),
+    list: vi.fn().mockResolvedValue({ notes: [] })
+  }
+}))
+
+// Pulls in the whole tag-sync chain (use-all-tags -> window.api listeners),
+// none of which the open/closed contract depends on.
+vi.mock('@/components/filing/tag-autocomplete', () => ({
+  TagAutocomplete: () => null
+}))
+
+vi.mock('@/services/canvas-service', () => ({
+  canvasService: { list: vi.fn().mockResolvedValue({ canvases: [] }) }
+}))
+
+vi.mock('@/services/search-service', () => ({
+  searchService: {
+    query: vi.fn().mockResolvedValue({ groups: [], totalCount: 0, queryTimeMs: 0 })
+  }
+}))
+
+const statuses: Status[] = [
+  { id: 'todo', name: 'To Do', color: '#6B7280', type: 'todo', order: 0 },
+  { id: 'done', name: 'Done', color: '#10B981', type: 'done', order: 1 }
+]
+
+const project: Project = {
+  id: 'project-1',
+  name: 'Test Project',
+  description: '',
+  icon: 'Folder',
+  color: '#6366F1',
+  statuses,
+  isDefault: false,
+  isArchived: false,
+  createdAt: new Date('2026-01-01'),
+  taskCount: 1
+}
+
+const task: Task = {
+  id: 'task-1',
+  title: 'Test Task',
+  description: '',
+  projectId: 'project-1',
+  statusId: 'todo',
+  priority: 'medium',
+  dueDate: new Date('2026-04-15'),
+  dueTime: null,
+  isRepeating: false,
+  repeatConfig: null,
+  linkedNoteIds: [],
+  sourceNoteId: null,
+  tags: [],
+  parentId: null,
+  subtaskIds: [],
+  createdAt: new Date('2026-01-01'),
+  completedAt: null,
+  archivedAt: null
+}
+
+const props: TaskDetailDrawerProps = {
+  task,
+  isOpen: true,
+  onClose: vi.fn(),
+  tasks: [task],
+  projects: [project]
+}
+
+let i18nEn: I18nInstance
+
+function renderWithI18n(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } }
+  })
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <I18nextProvider i18n={i18nEn}>{children}</I18nextProvider>
+    </QueryClientProvider>
+  )
+  return render(ui, { wrapper: Wrapper })
+}
+
+beforeAll(async () => {
+  i18nEn = await createRendererI18n({ locale: 'en' })
+})
+
+/** What `openTaskDrawer` in tests/e2e/utils/task-drawer-helpers.ts selects. */
+const OPEN_DRAWER = 'aside[aria-label="Task details"][data-state="open"]'
+
+describe('TaskDetailDrawer — open state', () => {
+  it('names itself open, so the E2E locator matches exactly one element', () => {
+    const { container } = renderWithI18n(<TaskDetailDrawer {...props} />)
+
+    expect(container.querySelectorAll(OPEN_DRAWER)).toHaveLength(1)
+    expect(screen.getByRole('complementary', { name: 'Task details' })).toHaveAttribute(
+      'data-state',
+      'open'
+    )
+  })
+
+  it('leaves the DOM entirely when closed', () => {
+    const { container } = renderWithI18n(<TaskDetailDrawer {...props} isOpen={false} />)
+
+    expect(container.querySelectorAll(OPEN_DRAWER)).toHaveLength(0)
+    expect(screen.queryByRole('complementary', { name: 'Task details' })).toBeNull()
+    expect(container.querySelector('aside')).toBeNull()
+  })
+
+  it('does not leave a closed drawer behind when it reopens on another task', () => {
+    const other: Task = { ...task, id: 'task-2', title: 'Other Task' }
+    const { container, rerender } = renderWithI18n(<TaskDetailDrawer {...props} />)
+
+    rerender(<TaskDetailDrawer {...props} isOpen={false} />)
+    expect(container.querySelectorAll(OPEN_DRAWER)).toHaveLength(0)
+
+    rerender(<TaskDetailDrawer {...props} task={other} />)
+    expect(container.querySelectorAll(OPEN_DRAWER)).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.tsx
@@ -173,7 +173,7 @@ export const TaskDetailDrawer = memo(function TaskDetailDrawer({
   onNoteClick,
   onCanvasClick,
   onDeleteTask
-}: TaskDetailDrawerProps): React.JSX.Element {
+}: TaskDetailDrawerProps): React.JSX.Element | null {
   const { t, i18n } = useT('tasks')
   const { t: tCommon } = useT('common')
   const prefersReducedMotion = useReducedMotion()
@@ -426,27 +426,29 @@ export const TaskDetailDrawer = memo(function TaskDetailDrawer({
   // every open and task switch: a subtle materialize from the end edge.
   const entranceX = i18n.dir() === 'rtl' ? -16 : 16
 
+  // Closed, the drawer leaves the DOM. It used to stay mounted behind `inert`,
+  // `aria-hidden` and `width: 0`, but a 1px border still gave it a box, so
+  // Playwright reported it visible in both states and every `state: 'visible'`
+  // or `state: 'hidden'` wait on it passed without proving anything. Nothing is
+  // lost by unmounting: `task` is null while closed, the `key` in tasks.tsx
+  // already forced a remount on every open, and the width lives in
+  // localStorage. `data-state="open"` is the selector specs address it by, so
+  // the open drawer is named positively and closed means "no such element".
+  if (!isOpen) return null
+
   return (
     <motion.aside
       aria-label={t('task.details')}
-      aria-hidden={!isOpen}
-      inert={!isOpen || undefined}
-      initial={
-        isOpen ? (prefersReducedMotion ? { opacity: 0 } : { opacity: 0, x: entranceX }) : false
-      }
-      animate={{ opacity: isOpen ? 1 : 0, x: 0 }}
+      data-state="open"
+      initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, x: entranceX }}
+      animate={{ opacity: 1, x: 0 }}
       transition={
         prefersReducedMotion ? { duration: 0.2 } : { type: 'spring', bounce: 0, duration: 0.3 }
       }
-      className={cn(
-        // ponytail: absolute (not fixed) so the drawer stays inside its own pane in split view
-        // top-[38px] clears the toolbar chrome so the drawer header stays visible
-        'absolute top-[38px] bottom-0 end-0 z-10 border-s bg-surface overflow-hidden',
-        isOpen ? 'border-border' : 'border-transparent pointer-events-none'
-      )}
-      style={{
-        width: isOpen ? `${width}px` : 0
-      }}
+      // ponytail: absolute (not fixed) so the drawer stays inside its own pane in split view
+      // top-[38px] clears the toolbar chrome so the drawer header stays visible
+      className="absolute top-[38px] bottom-0 end-0 z-10 border-s border-border bg-surface overflow-hidden"
+      style={{ width: `${width}px` }}
     >
       <div
         style={{ width: `${width}px` }}
@@ -844,17 +846,15 @@ export const TaskDetailDrawer = memo(function TaskDetailDrawer({
           </>
         )}
       </div>
-      {isOpen && (
-        <PanelResizeRail
-          width={width}
-          setWidth={setWidth}
-          setIsResizing={setIsResizing}
-          minPx={TASK_DETAIL_WIDTH_MIN_PX}
-          maxPx={TASK_DETAIL_WIDTH_MAX_PX}
-          defaultPx={TASK_DETAIL_WIDTH_DEFAULT_PX}
-          ariaLabel={t('drawer.resize')}
-        />
-      )}
+      <PanelResizeRail
+        width={width}
+        setWidth={setWidth}
+        setIsResizing={setIsResizing}
+        minPx={TASK_DETAIL_WIDTH_MIN_PX}
+        maxPx={TASK_DETAIL_WIDTH_MAX_PX}
+        defaultPx={TASK_DETAIL_WIDTH_DEFAULT_PX}
+        ariaLabel={t('drawer.resize')}
+      />
     </motion.aside>
   )
 })

--- a/apps/desktop/tests/e2e/obsidian-tasks-import.e2e.ts
+++ b/apps/desktop/tests/e2e/obsidian-tasks-import.e2e.ts
@@ -31,9 +31,10 @@
 
 import * as fs from 'fs'
 import * as path from 'path'
-import type { Locator, Page } from '@playwright/test'
+import type { Page } from '@playwright/test'
 import { test, expect } from './fixtures'
 import { getNoteHandleByTitle, openNoteByTitle } from './utils/note-sync-helpers'
+import { closeTaskDrawer, openTaskDrawer, taskRow } from './utils/task-drawer-helpers'
 import {
   navigateTo,
   showAllTasksScope,
@@ -46,13 +47,6 @@ import {
 const DATAVIEW_LINE = '- [ ] Pay rent  [due:: 2026-09-15]  [priority:: high]'
 const DECLINED_LINE = '- [ ] Do first 🆔 dcf64c'
 const BODY = ['- [ ] Buy milk 📅 2026-09-01 ⏫ #errand', DATAVIEW_LINE, DECLINED_LINE].join('\n')
-
-/**
- * `task-detail-drawer.tsx` never unmounts. Closed, it keeps a 1px transparent
- * border, so Playwright calls it visible either way and `state: 'visible'` /
- * `state: 'hidden'` prove nothing. `aria-hidden` is the state the app publishes.
- */
-const TASK_DRAWER = '[aria-label="Task details"]'
 
 type DateParts = { year: number; month: number; day: number }
 
@@ -123,25 +117,6 @@ async function goToTasksPage(page: Page): Promise<void> {
   // only proof the click landed on Tasks and not wherever the app already was.
   await expect(page.getByRole('combobox', { name: 'Task views' })).toBeVisible({ timeout: 20_000 })
   await showAllTasksScope(page)
-}
-
-/** By substring: a past-due row carries extra text after the title. */
-function taskRow(page: Page, titleFragment: string): Locator {
-  return page
-    .locator(`[role="button"][aria-label*="Task:"][aria-label*="${titleFragment}"]`)
-    .first()
-}
-
-/**
- * The drawer, which every property edit is scoped to. `today-task-row.tsx`
- * renders the same interactive due-date and project badges inside list rows, so
- * an unscoped `Due: …` or `Project: …` locator can match several buttons.
- */
-async function openTaskDrawer(page: Page, titleFragment: string): Promise<Locator> {
-  await taskRow(page, titleFragment).click()
-  const drawer = page.locator(TASK_DRAWER).first()
-  await expect(drawer).toHaveAttribute('aria-hidden', 'false', { timeout: 15_000 })
-  return drawer
 }
 
 async function listTasks(page: Page): Promise<Array<{ id: string; title: string }>> {
@@ -330,8 +305,7 @@ test.describe('Obsidian Tasks import', () => {
       .poll(async () => (await readTask(page, buyMilkId))?.due, { timeout: 20_000 })
       .toEqual(today)
 
-    await page.getByRole('button', { name: 'Close task details' }).click()
-    await expect(drawer).toHaveAttribute('aria-hidden', 'true', { timeout: 10_000 })
+    await closeTaskDrawer(page)
 
     // #when the other imported task is deleted from its drawer
     const rentDrawer = await openTaskDrawer(page, 'Pay rent')

--- a/apps/desktop/tests/e2e/utils/task-drawer-helpers.ts
+++ b/apps/desktop/tests/e2e/utils/task-drawer-helpers.ts
@@ -1,0 +1,47 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+
+/**
+ * The open task detail drawer, and nothing else.
+ *
+ * The drawer used to stay mounted when closed, behind `inert`, `aria-hidden`
+ * and `width: 0`. A 1px border kept its box non-empty, so Playwright reported
+ * it visible in both states and every `state: 'visible'` / `state: 'hidden'`
+ * wait on it passed without proving anything (#1931). It now unmounts on close
+ * and names its open state outright, so "closed" is a count of zero.
+ *
+ * Go through these helpers rather than rebuilding the locator in a spec. A bare
+ * `[aria-label="Task details"]` invites the visibility wait straight back.
+ */
+const OPEN_TASK_DRAWER = 'aside[aria-label="Task details"][data-state="open"]'
+
+/** By substring: a past-due row carries extra text after the title. */
+export function taskRow(page: Page, titleFragment: string): Locator {
+  return page
+    .locator(`[role="button"][aria-label*="Task:"][aria-label*="${titleFragment}"]`)
+    .first()
+}
+
+/**
+ * Opens the row's drawer and returns it, scoped. `today-task-row.tsx` renders
+ * the same interactive due-date and project badges inside list rows, so an
+ * unscoped `Due: …` or `Project: …` locator can match several buttons.
+ */
+export async function openTaskDrawer(
+  page: Page,
+  titleFragment: string,
+  timeout = 15_000
+): Promise<Locator> {
+  await taskRow(page, titleFragment).click()
+  const drawer = page.locator(OPEN_TASK_DRAWER).first()
+  await expect(drawer).toBeAttached({ timeout })
+  return drawer
+}
+
+export async function expectTaskDrawerClosed(page: Page, timeout = 10_000): Promise<void> {
+  await expect(page.locator(OPEN_TASK_DRAWER)).toHaveCount(0, { timeout })
+}
+
+export async function closeTaskDrawer(page: Page, timeout = 10_000): Promise<void> {
+  await page.getByRole('button', { name: 'Close task details' }).click()
+  await expectTaskDrawerClosed(page, timeout)
+}


### PR DESCRIPTION
## Summary

Closes #1931.

The task detail drawer stayed mounted when closed, behind `inert`,
`aria-hidden="true"` and `width: 0`. A 1px border kept its box non-empty, so
Playwright reported it visible in both states. Any spec that waited on it with
`state: 'visible'` or `state: 'hidden'` passed without testing anything, which
reads like coverage and is worse than no wait.

The drawer now returns `null` when closed. Unmounting is safe here and is the
root fix rather than a new assertion to remember: `task` is already `null` while
the drawer is closed, the `key` in `tasks.tsx` already forced a remount on every
open, the width lives in `localStorage`, and the close was already instant
because `width` snaps to `0` with no transition and no exit animation. The
sibling `inbox-detail-panel.tsx` is the case that genuinely must stay mounted,
because it animates `x` off the pane edge over 300ms on close; the task drawer
only inherited that structure without the animation. With the element gone,
`toBeVisible`, `toBeHidden` and `toHaveCount` all become truthful, so the
habitual Playwright idiom stops lying even for a spec author who does not know
about this issue.

The open drawer additionally carries `data-state="open"`, matching the
convention already used by `inbox-detail-panel.tsx` and `review-badge-layer.tsx`.
That is the selector the E2E helpers address it by, so the open drawer is named
positively and "closed" is a count of zero rather than an absence of some
attribute value.

`apps/desktop/tests/e2e/utils/task-drawer-helpers.ts` is new and owns the
locator plus the wait. `openTaskDrawer`, `closeTaskDrawer` and
`expectTaskDrawerClosed` are exported; the raw selector is not. The one spec that
drove the drawer, `obsidian-tasks-import.e2e.ts` from #1922, previously had a
local `openTaskDrawer` asserting `aria-hidden`, which was correct but private to
that file. It now goes through the shared helpers, so a spec author cannot
reintroduce the visibility wait by rebuilding `[aria-label="Task details"]` by
hand.

The three commits are ordered so the failing test lands before the fix.

No docs change: the drawer's user-visible behavior is identical, the close was
and remains instant, and nothing in `apps/docs/src` describes whether the
collapsed panel stays in the DOM. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`.

## Release note

none

## Test plan

`apps/desktop/src/renderer/src/components/tasks/task-detail-drawer-open-state.test.tsx`
is the load-bearing test. Against the pre-fix component (commit `a140ab56b`
alone) all three cases fail:

```
× names itself open, so the E2E locator matches exactly one element
  → expected  to have a length of 1 but got +0
× leaves the DOM entirely when closed
  → expected <aside …(5)>…(1)</aside> to be null
× does not leave a closed drawer behind when it reopens on another task
  → expected  to have a length of 1 but got +0
Tests  3 failed (3)
```

With the fix:

```
./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer \
  apps/desktop/src/renderer/src/components/tasks/task-detail-drawer-open-state.test.tsx \
  apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.test.tsx \
  apps/desktop/src/renderer/src/pages/tasks.test.tsx
Test Files  3 passed (3)
     Tests  54 passed (54)
```

Gates, all exit 0: `pnpm lint`, `pnpm typecheck`,
`pnpm --filter @memry/desktop typecheck:test`, `pnpm check:architecture`,
`pnpm check:contracts`, `git diff --check`. `npx react-doctor@latest .` reports
six findings in `task-detail-drawer.tsx`, all on lines outside this diff and all
pre-existing (`require-safety-comment-for-type-assertion`,
`no-unknown-parameters`, `no-high-complexity-react-function`, `no-transition-all`
×2, `html-no-nested-interactive`); the diff removes four `isOpen` ternaries and
one conditional subtree and adds one early return, so control-flow complexity in
that component goes down, not up.

E2E not run here, and needs to run serially:
`apps/desktop/tests/e2e/obsidian-tasks-import.e2e.ts`. A pass is the
`Obsidian Tasks import` describe green, which exercises `openTaskDrawer` twice
(`Buy milk`, `Pay rent`) and `closeTaskDrawer` once. The meaningful signal is
that `openTaskDrawer` now waits on `toBeAttached` against
`aside[aria-label="Task details"][data-state="open"]`, so a drawer that never
opens fails the wait instead of passing it.
