### PR TITLE
fix(tasks): refuse a due or start date the calendar does not have

### DIFF
--- a/apps/desktop/src/main/agent/mcp/tools/__tests__/schemas.test.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/__tests__/schemas.test.ts
@@ -168,4 +168,28 @@ describe('Vault MCP tool schemas', () => {
       }).success
     ).toBe(false)
   })
+  // The agent's task writes reach the tasks domain through handles-adapter, not
+  // through the IPC handler, so TaskCreateSchema never sees them and this schema
+  // is the only place an impossible date can be stopped.
+  it('refuses a task date the calendar does not have', () => {
+    const create = (patch: Record<string, unknown>) =>
+      TOOL_SCHEMAS.vault_create_task.input.safeParse({ title: 'Task', ...patch }).success
+
+    for (const date of ['2026-02-30', '2025-02-29', '2026-13-01']) {
+      expect(create({ due_date: date })).toBe(false)
+      expect(create({ start_date: date })).toBe(false)
+      expect(create({ due: date })).toBe(false)
+      expect(
+        TOOL_SCHEMAS.vault_update_task.input.safeParse({ id: 'task-1', due_date: date }).success
+      ).toBe(false)
+    }
+
+    expect(create({ due_date: '2024-02-29', start_date: '2024-02-29', due: '2024-02-29' })).toBe(
+      true
+    )
+    expect(
+      TOOL_SCHEMAS.vault_update_task.input.safeParse({ id: 'task-1', due_date: '2024-02-29' })
+        .success
+    ).toBe(true)
+  })
 })

--- a/apps/desktop/src/main/agent/mcp/tools/schemas.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/schemas.ts
@@ -9,6 +9,7 @@ import {
   MAX_DRAW_ELEMENTS,
   MAX_EDIT_ELEMENTS
 } from '@memry/contracts/canvas-draw'
+import { CalendarDateSchema } from '@memry/contracts/calendar-date'
 import { NoteFileTypeEnum } from '@memry/contracts/search-api'
 
 const idSchema = z.string().min(1)
@@ -39,10 +40,14 @@ const taskPatchSchema = z.object({
   status_id: idSchema.nullish(),
   project_id: idSchema.nullish(),
   parent_id: idSchema.nullish(),
-  due: isoDateSchema.nullish(),
-  due_date: isoDateSchema.nullish(),
+  // `handles.tasks.create` and `handles.tasks.update` call the tasks domain
+  // straight, so this schema is the only gate on the agent's write path — the
+  // IPC handler's TaskCreateSchema never sees it. The shape regex the other
+  // date arguments carry would let 2026-02-30 through to the row.
+  due: CalendarDateSchema.nullish(),
+  due_date: CalendarDateSchema.nullish(),
   due_time: isoTimeSchema.nullish(),
-  start_date: isoDateSchema.nullish(),
+  start_date: CalendarDateSchema.nullish(),
   priority: z.number().int().min(0).max(4).optional(),
   notes: z.string().max(10000).nullish(),
   description: z.string().max(10000).nullish(),

--- a/apps/desktop/src/main/database/queries/tasks.test.ts
+++ b/apps/desktop/src/main/database/queries/tasks.test.ts
@@ -435,4 +435,27 @@ describe('tasks queries', () => {
     createTask('task-58', { parentId: parent.id, position: 2 })
     expect(getNextTaskPosition(db, projectId, parent.id)).toBe(3)
   })
+  // A row written before dueDate and startDate were validated is still sitting
+  // in a beta user's database. Validation lands on the next write; every read
+  // over the row it already holds has to keep working.
+  it('reads back a row holding dates the calendar does not have', () => {
+    const legacy = createTask('task-legacy', { dueDate: '2026-02-30', startDate: '2025-02-29' })
+    createTask('task-real', { dueDate: '2026-02-28' })
+
+    const fetched = getTaskById(db, legacy.id)
+    expect(fetched?.dueDate).toBe('2026-02-30')
+    expect(fetched?.startDate).toBe('2025-02-29')
+
+    expect(listTasks(db).map((task) => task.id)).toContain('task-legacy')
+    expect(listTasks(db, { sortBy: 'dueDate', sortOrder: 'asc' }).map((task) => task.id)).toEqual([
+      'task-real',
+      'task-legacy'
+    ])
+    expect(getTasksByDueDate(db, '2026-02-30').map((task) => task.id)).toEqual(['task-legacy'])
+    expect(() => getOverdueTasks(db)).not.toThrow()
+    expect(getTaskStats(db).total).toBe(2)
+
+    const copy = duplicateTask(db, legacy.id, 'task-legacy-copy')
+    expect(copy?.dueDate).toBe('2026-02-30')
+  })
 })

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-date-utils.test.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-date-utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { formatDateKey, parseDateKey, parseDueDate } from './task-date-utils'
+
+// The write path refuses a date the calendar does not have, but a row stored
+// before it did is still in a beta user's database and still has to render.
+// These cases pin what the renderer does with one: it rolls the value onto a
+// real day and hands back a usable Date, never `Invalid Date` and never a throw.
+describe('parseDueDate over a stored date the calendar does not have', () => {
+  it.each([
+    ['2026-02-30', '2026-03-02'],
+    ['2025-02-29', '2025-03-01'],
+    ['2026-13-01', '2027-01-01'],
+    ['2026-00-10', '2025-12-10']
+  ])('rolls %s onto %s instead of throwing', (stored, rolled) => {
+    const parsed = parseDueDate(stored)
+    expect(Number.isNaN(parsed.getTime())).toBe(false)
+    expect(formatDateKey(parsed)).toBe(rolled)
+  })
+
+  it('leaves a date the calendar does have alone', () => {
+    expect(formatDateKey(parseDueDate('2024-02-29'))).toBe('2024-02-29')
+    expect(formatDateKey(parseDateKey('2026-01-15'))).toBe('2026-01-15')
+  })
+})

--- a/apps/docs/src/user-guide/tasks/import-obsidian.md
+++ b/apps/docs/src/user-guide/tasks/import-obsidian.md
@@ -60,6 +60,14 @@ That matters because the checkbox in the file is what Memry reads back. A comple
 
 A done date the calendar does not have, `✅ 2026-02-30`, is not a completion time. The task imports as it is written otherwise, and the date survives on the description with the rest of the line.
 
+## A due or start date the calendar does not have
+
+The plugin's date grammar accepts any four digits, two digits and two digits, so `📅 2026-02-30`, `📅 2025-02-29` and `📅 2026-13-01` are all things you can type into a note. None of them is a day, and Memry will not store a due date that never arrives.
+
+The import stops rather than guessing which day you meant. The checkbox stays an ordinary checkbox, your line is left exactly as you wrote it, and a message names the date that was refused. Correct the date and the line imports on the next tick.
+
+February the twenty-ninth in a leap year is a real day and imports normally.
+
 ## Tag limits
 
 A Memry task takes up to twenty tags, each up to fifty characters. The Obsidian tag grammar is looser than that, so a longer or a twenty-first tag does not become a Memry tag.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -12,6 +12,7 @@
     "./bookmark-types": "./src/bookmark-types.ts",
     "./bookmarks-api": "./src/bookmarks-api.ts",
     "./calendar-api": "./src/calendar-api.ts",
+    "./calendar-date": "./src/calendar-date.ts",
     "./canvas-api": "./src/canvas-api.ts",
     "./canvas-draw": "./src/canvas-draw.ts",
     "./canvas-folder-api": "./src/canvas-folder-api.ts",

--- a/packages/contracts/src/calendar-date.test.ts
+++ b/packages/contracts/src/calendar-date.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { CalendarDateSchema, isCalendarDate } from './calendar-date'
+
+const originalTimeZone = process.env.TZ
+
+afterEach(() => {
+  if (originalTimeZone === undefined) delete process.env.TZ
+  else process.env.TZ = originalTimeZone
+})
+
+describe('isCalendarDate', () => {
+  it.each(['2026-01-15', '2024-02-29', '2026-12-31', '2026-01-01', '0100-01-01'])(
+    'accepts %s',
+    (value) => {
+      expect(isCalendarDate(value)).toBe(true)
+    }
+  )
+
+  // `new Date(year, ...)` maps a year of 0 through 99 onto 1900 through 1999,
+  // so the round trip reads 1901 back for year 1 and refuses it. Years below
+  // 0100 are not reachable as a task due date, and widening the predicate to
+  // serve them would buy nothing, so the limit is recorded rather than fixed.
+  it('refuses a year below 0100, which the Date constructor remaps', () => {
+    expect(isCalendarDate('0001-01-01')).toBe(false)
+  })
+
+  it.each([
+    '2026-02-30',
+    '2025-02-29',
+    '2026-13-01',
+    '2026-00-10',
+    '2026-04-31',
+    '2026-11-31',
+    '2026-01-00',
+    '2026-01-32'
+  ])('refuses %s', (value) => {
+    expect(isCalendarDate(value)).toBe(false)
+  })
+
+  it.each(['01-15-2026', '2026-1-15', '2026-01-15T10:00:00Z', '2026-01-15 ', '', 'tomorrow'])(
+    'refuses %s, which is not the date-only shape at all',
+    (value) => {
+      expect(isCalendarDate(value)).toBe(false)
+    }
+  )
+
+  // The naive check is `new Date(value)` plus the local getters. That parse is
+  // UTC, so in any zone west of UTC the first of January reads back as the
+  // thirty-first of December and a real date is refused. Building the date from
+  // its parts keeps both ends of the comparison in one zone.
+  it.each(['Pacific/Pago_Pago', 'Pacific/Kiritimati', 'UTC', 'Asia/Kolkata'])(
+    'accepts the year boundary and the leap day in %s',
+    (timeZone) => {
+      process.env.TZ = timeZone
+      expect(isCalendarDate('2026-01-01')).toBe(true)
+      expect(isCalendarDate('2026-12-31')).toBe(true)
+      expect(isCalendarDate('2024-02-29')).toBe(true)
+      expect(isCalendarDate('2025-02-29')).toBe(false)
+    }
+  )
+
+  // America/Santiago and America/Havana move the clock forward at midnight, so
+  // the day has no 00:00 and `new Date(y, m - 1, d)` lands on 01:00. The
+  // calendar day is unchanged, which is all this predicate reads.
+  it.each(['America/Santiago', 'America/Havana'])(
+    'accepts a day whose local midnight does not exist in %s',
+    (timeZone) => {
+      process.env.TZ = timeZone
+      expect(isCalendarDate('2019-09-08')).toBe(true)
+      expect(isCalendarDate('2018-03-11')).toBe(true)
+    }
+  )
+})
+
+describe('CalendarDateSchema', () => {
+  it('carries a message a user can act on', () => {
+    const result = CalendarDateSchema.safeParse('2026-02-30')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        'Date must be a real calendar date in YYYY-MM-DD form'
+      )
+    }
+  })
+
+  it('returns the input unchanged for a date that exists', () => {
+    expect(CalendarDateSchema.parse('2024-02-29')).toBe('2024-02-29')
+  })
+})

--- a/packages/contracts/src/calendar-date.ts
+++ b/packages/contracts/src/calendar-date.ts
@@ -1,0 +1,36 @@
+/**
+ * A `YYYY-MM-DD` string the calendar actually has.
+ *
+ * The shape regex alone accepts `2026-02-30`, `2025-02-29` and `2026-13-01`,
+ * so a date a user typed by hand or an importer read out of someone else's
+ * markdown lands in the database and is rendered from there. `completedAt` is
+ * a `z.string().datetime()` and zod already refuses the impossible instant,
+ * which is the asymmetry this closes.
+ *
+ * The round trip goes through the LOCAL constructor and the local getters, the
+ * same pair `localMidnight` uses in the Obsidian import. `new Date('2026-01-01')`
+ * parses as UTC midnight, so reading `getDate()` off it answers 31 December in
+ * any zone west of UTC and a perfectly real date is refused. Building the date
+ * from its parts keeps the comparison inside one zone, and a zone whose clocks
+ * skip local midnight still lands on the same calendar day.
+ */
+
+import { z } from 'zod'
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/
+
+export function isCalendarDate(value: string): boolean {
+  if (!DATE_ONLY.test(value)) return false
+  const [year, month, day] = value.split('-').map(Number)
+  const at = new Date(year, month - 1, day)
+  return at.getFullYear() === year && at.getMonth() === month - 1 && at.getDate() === day
+}
+
+/**
+ * Said on every field that stores a written calendar date. The message reaches
+ * the user through the IPC error envelope and `extractErrorMessage`, so it
+ * names the two ways the value can be wrong rather than echoing the input.
+ */
+export const CalendarDateSchema = z
+  .string()
+  .refine(isCalendarDate, 'Date must be a real calendar date in YYYY-MM-DD form')

--- a/packages/contracts/src/sync-payloads.test.ts
+++ b/packages/contracts/src/sync-payloads.test.ts
@@ -78,6 +78,19 @@ describe('TaskSyncPayloadSchema', () => {
     expect(TaskSyncPayloadSchema.safeParse({}).success).toBe(true)
   })
 
+  // A peer running an older build may hold a task whose dueDate the calendar
+  // does not have. TaskCreateSchema refuses that date on a fresh write, but the
+  // sync payload has to stay loose: a strict date here would make the receiving
+  // device reject the item forever, and the user cannot see the row to fix it.
+  it('accepts a stored date the calendar does not have, so an old row still syncs', () => {
+    const result = TaskSyncPayloadSchema.safeParse({
+      title: 'Written before the date was validated',
+      dueDate: '2026-02-30',
+      startDate: '2025-02-29'
+    })
+    expect(result.success).toBe(true)
+  })
+
   it('accepts full payload with clock + fieldClocks (Phase 8 regression)', () => {
     const result = TaskSyncPayloadSchema.safeParse({
       title: 'Write tests',

--- a/packages/contracts/src/tasks-api.test.ts
+++ b/packages/contracts/src/tasks-api.test.ts
@@ -319,6 +319,38 @@ describe('TaskCreateSchema', () => {
     expect(result.success).toBe(true)
   })
 
+  it.each(['2026-02-30', '2025-02-29', '2026-13-01', '2026-04-31', '2026-00-10'])(
+    'should reject dueDate %s, which the calendar does not have',
+    (dueDate) => {
+      const result = TaskCreateSchema.safeParse({ projectId: 'proj-1', title: 'Test', dueDate })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].path).toContain('dueDate')
+      }
+    }
+  )
+
+  it.each(['2026-02-30', '2025-02-29', '2026-13-01'])(
+    'should reject startDate %s, which the calendar does not have',
+    (startDate) => {
+      const result = TaskCreateSchema.safeParse({ projectId: 'proj-1', title: 'Test', startDate })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].path).toContain('startDate')
+      }
+    }
+  )
+
+  it('should accept 2024-02-29, which a leap year does have', () => {
+    const result = TaskCreateSchema.safeParse({
+      projectId: 'proj-1',
+      title: 'Test',
+      dueDate: '2024-02-29',
+      startDate: '2024-02-29'
+    })
+    expect(result.success).toBe(true)
+  })
+
   it('should reject invalid dueTime format', () => {
     const result = TaskCreateSchema.safeParse({
       projectId: 'proj-1',
@@ -447,6 +479,37 @@ describe('TaskUpdateSchema', () => {
       parentId: null,
       dueDate: null,
       dueTime: null
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it.each(['2026-02-30', '2025-02-29', '2026-13-01'])(
+    'should reject dueDate %s, which the calendar does not have',
+    (dueDate) => {
+      const result = TaskUpdateSchema.safeParse({ id: 'task-1', dueDate })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].path).toContain('dueDate')
+      }
+    }
+  )
+
+  it.each(['2026-02-30', '2025-02-29', '2026-13-01'])(
+    'should reject startDate %s, which the calendar does not have',
+    (startDate) => {
+      const result = TaskUpdateSchema.safeParse({ id: 'task-1', startDate })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].path).toContain('startDate')
+      }
+    }
+  )
+
+  it('should accept 2024-02-29, which a leap year does have', () => {
+    const result = TaskUpdateSchema.safeParse({
+      id: 'task-1',
+      dueDate: '2024-02-29',
+      startDate: '2024-02-29'
     })
     expect(result.success).toBe(true)
   })

--- a/packages/contracts/src/tasks-api.ts
+++ b/packages/contracts/src/tasks-api.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod'
+import { CalendarDateSchema } from './calendar-date.ts'
 import type { ProjectWithStats, Task, TaskListItem } from '@memry/domain-tasks'
 export type {
   RepeatConfig,
@@ -53,18 +54,12 @@ export const TaskCreateSchema = z.object({
   priority: z.number().int().min(0).max(4).default(0),
   statusId: z.string().nullish(),
   parentId: z.string().nullish(),
-  dueDate: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .nullish(),
+  dueDate: CalendarDateSchema.nullish(),
   dueTime: z
     .string()
     .regex(/^\d{2}:\d{2}$/)
     .nullish(),
-  startDate: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .nullish(),
+  startDate: CalendarDateSchema.nullish(),
   isRepeating: z.boolean().default(false),
   repeatConfig: RepeatConfigSchema.nullish(),
   repeatFrom: z.enum(['due', 'completion']).nullish(),
@@ -83,18 +78,12 @@ export const TaskUpdateSchema = z.object({
   projectId: z.string().optional(),
   statusId: z.string().nullish(),
   parentId: z.string().nullish(),
-  dueDate: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .nullish(),
+  dueDate: CalendarDateSchema.nullish(),
   dueTime: z
     .string()
     .regex(/^\d{2}:\d{2}$/)
     .nullish(),
-  startDate: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .nullish(),
+  startDate: CalendarDateSchema.nullish(),
   isRepeating: z.boolean().optional(),
   repeatConfig: RepeatConfigSchema.nullish(),
   repeatFrom: z.enum(['due', 'completion']).nullish(),


### PR DESCRIPTION
## Summary

Closes #1923.

`dueDate` and `startDate` were validated by a bare `/^\d{4}-\d{2}-\d{2}$/`, so `2026-02-30`, `2025-02-29` and `2026-13-01` parsed clean and landed in the `tasks` row. `completedAt` is a `z.string().datetime()` and zod already refused the impossible instant, which is the asymmetry the issue names.

`packages/contracts/src/calendar-date.ts` holds one `CalendarDateSchema`. It keeps the regex as a first pass, then rebuilds the date from its parts and checks the parts survive. `TaskCreateSchema` and `TaskUpdateSchema` use it on both fields. The round trip goes through the local constructor and the local getters, the same pair `localMidnight` uses for the done date in #1922; `new Date('2026-01-01')` parses as UTC, so reading `getDate()` off it answers 31 December anywhere west of UTC and refuses a real date.

`taskPatchSchema` in the Vault MCP tool schemas gets the same schema on `due`, `due_date` and `start_date`. The agent's writes run `handles.tasks.create` into `createDesktopTasksDomain`, which never touches `TaskCreateSchema`, so that tool schema is the only gate on the path. The `isoDateSchema` the journal and calendar read tools share is left alone.

**Validate on write, tolerate on read.** Nothing parses a task row on the way out: the IPC responses, the RPC `Task` and the calendar projection items are plain interfaces, and the query layer compares `dueDate` as a SQLite string. `TaskSyncPayloadSchema` stays deliberately loose, because a strict date there would make a receiving device reject a peer's older row forever, on a value the user cannot see to fix.

## Release note

An Obsidian task line carrying a date the calendar does not have, such as `📅 2026-02-30` or `📅 2025-02-29`, no longer imports as a task with a due date that never arrives. The line is left exactly as written and a message names the refused date.

## Test plan

- `vitest --project shared packages/contracts/src/` — 52 files, 1724 tests pass. `tasks-api.test.ts` covers `2026-02-30`, `2025-02-29`, `2026-13-01` and `2024-02-29` on create and update; `calendar-date.test.ts` pins the year boundary and the leap day in `Pacific/Pago_Pago`, `Pacific/Kiritimati`, `UTC` and `Asia/Kolkata`, and a day whose local midnight does not exist in `America/Santiago` and `America/Havana`; `sync-payloads.test.ts` pins that a peer's stored impossible date still parses.
- Fourteen of those cases fail on the first commit of this branch, which lands the tests before the fix.
- `vitest --project main src/main/agent/mcp` — 15 files, 124 tests pass. Reverting `schemas.ts` to `origin/main` and rerunning turns the new case red with `expected true to be false`, so the MCP guard is load-bearing rather than duplicated.
- `vitest --project main src/main/database/queries/tasks.test.ts` — a seeded row holding `dueDate: '2026-02-30'` and `startDate: '2025-02-29'` reads back verbatim through `getTaskById`, appears in `listTasks`, sorts correctly under `sortBy: 'dueDate'`, is found by `getTasksByDueDate`, counts in `getTaskStats`, survives `duplicateTask`, and does not throw from `getOverdueTasks`.
- `vitest --project renderer src/renderer/src/lib/task-utils` — 4 files, 423 tests pass, including new cases pinning that `parseDueDate` rolls a stored impossible date onto a real day instead of throwing or returning `Invalid Date`.
- `pnpm lint`, `pnpm typecheck`, `pnpm --filter @memry/desktop typecheck:test`, `pnpm check:architecture`, `pnpm check:contracts`, `pnpm ipc:generate && pnpm ipc:check`, `pnpm --filter @memry/desktop i18n:check`, `git diff --check` all pass.
- `pnpm docs:impact --base origin/main --strict` and `pnpm docs:build` pass.
- `npx react-doctor` reports only pre-existing findings under `apps/mobile`, none in files this branch touches.
- No E2E was run from this worktree. `apps/desktop/tests/e2e/obsidian-tasks-import.e2e.ts` needed no edit; it uses no impossible dates.
