### PR TITLE
fix(scripts): scan class lists, not whole renderer files, for physical Tailwind classes

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -120,6 +120,11 @@ jobs:
       - name: Test docs gate and pre-push policy
         run: node --test scripts/docs-impact.test.mjs scripts/pre-push-policy.test.mjs
 
+      # The renderer guard runs on every commit, so a regression here either blocks
+      # legitimate work or lets physical direction classes into RTL-sensitive code.
+      - name: Test renderer guardrails
+        run: node --test scripts/check-staged-renderer-guards.test.mjs
+
   unit:
     name: Unit & integration tests
     runs-on: ubuntu-latest

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -117,13 +117,12 @@ jobs:
 
       # The pre-push docs block was deleted by an unrelated PR and stayed deleted for
       # weeks because nothing ran these guards. Keep them in CI.
-      - name: Test docs gate and pre-push policy
-        run: node --test scripts/docs-impact.test.mjs scripts/pre-push-policy.test.mjs
-
-      # The renderer guard runs on every commit, so a regression here either blocks
-      # legitimate work or lets physical direction classes into RTL-sensitive code.
-      - name: Test renderer guardrails
-        run: node --test scripts/check-staged-renderer-guards.test.mjs
+      #
+      # Globbed rather than listed by name. A script test nobody remembers to wire up
+      # is the same silent non-coverage. Every scripts/*.test.mjs is node:test and
+      # hermetic, so the next one is covered without anyone knowing this step exists.
+      - name: Test repo scripts
+        run: node --test scripts/*.test.mjs
 
   unit:
     name: Unit & integration tests

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typecheck:emails": "pnpm --filter @memry/marketing-emails typecheck",
     "test": "pnpm repair:links && node scripts/run-turbo.js run test --filter=@memry/contracts --filter=@memry/sync-client --filter=@memry/app-core --filter=@memry/cli --filter=@memry/desktop --filter=@memry/editor-schema --filter=@memry/sync-server --filter=@memry/landing --filter=@memry/mobile",
     "test:cli": "pnpm --filter @memry/app-core test && pnpm --filter @memry/cli test",
-    "test:release": "node --test scripts/release-utils.test.mjs scripts/release-notes-utils.test.mjs scripts/reddit-release-utils.test.mjs scripts/pre-push-policy.test.mjs scripts/docs-impact.test.mjs scripts/package-scripts.test.mjs scripts/link-env.test.mjs apps/desktop/scripts/build-packaged-app-utils.test.cjs apps/desktop/scripts/check-packaged-runtime-deps-utils.test.cjs",
+    "test:release": "node --test scripts/release-utils.test.mjs scripts/release-notes-utils.test.mjs scripts/reddit-release-utils.test.mjs scripts/pre-push-policy.test.mjs scripts/docs-impact.test.mjs scripts/package-scripts.test.mjs scripts/link-env.test.mjs scripts/check-staged-renderer-guards.test.mjs apps/desktop/scripts/build-packaged-app-utils.test.cjs apps/desktop/scripts/check-packaged-runtime-deps-utils.test.cjs",
     "test:desktop": "pnpm --filter @memry/desktop test",
     "test:sync-server": "pnpm --filter @memry/sync-server test",
     "test:sync-harness": "pnpm --filter @memry/sync-harness build:worker && pnpm --filter @memry/sync-harness test",

--- a/scripts/check-staged-renderer-guards.mjs
+++ b/scripts/check-staged-renderer-guards.mjs
@@ -7,6 +7,12 @@ const ignoredTestPattern = /(?:\.test|\.spec)\.[cm]?[jt]sx?$/
 const rawConsolePattern = /\bconsole\.(?:debug|error|info|log|trace|warn)\s*\(/g
 const physicalTailwindPattern =
   /(?:^|[\s"'`])((?:[a-z0-9-]+:)*-?(?:(?:ml|mr|pl|pr|left|right)-[^\s"'`]+|text-(?:left|right)\b|border-(?:l|r)(?:-[^\s"'`]+)?\b|rounded-(?:l|r)(?:-[^\s"'`]+)?\b))/gi
+const classListCallPattern = /\b(?:cn|clsx|cva|twMerge)\s*\(/g
+const classNameAttributePattern = /\bclassName\s*=/g
+
+const CODE = 0
+const COMMENT = 1
+const STRING = 2
 
 function shouldScanPath(filePath) {
   return rendererSourcePattern.test(filePath) && !ignoredTestPattern.test(filePath)
@@ -14,6 +20,201 @@ function shouldScanPath(filePath) {
 
 function lineNumberAt(text, index) {
   return text.slice(0, index).split('\n').length
+}
+
+// Splits a source file into code, comment and string regions without parsing it.
+// `literalEnds` maps each opening quote or backtick to the index just past its
+// closing delimiter, so a caller can take a whole literal including any `${}`.
+function classifySource(text) {
+  const kinds = new Uint8Array(text.length)
+  const stringSpans = []
+  const literalEnds = new Map()
+
+  function fill(start, end, kind) {
+    for (let index = start; index < end && index < text.length; index += 1) {
+      kinds[index] = kind
+    }
+  }
+
+  function scanQuoted(start) {
+    const quote = text[start]
+    let index = start + 1
+
+    while (index < text.length && text[index] !== quote && text[index] !== '\n') {
+      index += text[index] === '\\' ? 2 : 1
+    }
+
+    const contentEnd = Math.min(index, text.length)
+    const end = Math.min(contentEnd + 1, text.length)
+
+    fill(start, end, STRING)
+    stringSpans.push({ start: start + 1, end: contentEnd })
+    literalEnds.set(start, end)
+    return end
+  }
+
+  function scanTemplate(start) {
+    let index = start + 1
+    let chunkStart = index
+
+    while (index < text.length) {
+      if (text[index] === '\\') {
+        index += 2
+        continue
+      }
+
+      if (text[index] === '`') {
+        fill(chunkStart, index, STRING)
+        stringSpans.push({ start: chunkStart, end: index })
+        fill(start, start + 1, STRING)
+        fill(index, index + 1, STRING)
+        literalEnds.set(start, index + 1)
+        return index + 1
+      }
+
+      if (text[index] === '$' && text[index + 1] === '{') {
+        fill(chunkStart, index, STRING)
+        stringSpans.push({ start: chunkStart, end: index })
+        index = scanCode(index + 2, true)
+        chunkStart = index
+        continue
+      }
+
+      index += 1
+    }
+
+    fill(chunkStart, text.length, STRING)
+    stringSpans.push({ start: chunkStart, end: text.length })
+    literalEnds.set(start, text.length)
+    return text.length
+  }
+
+  function scanCode(from, insideInterpolation) {
+    let index = from
+
+    while (index < text.length) {
+      const char = text[index]
+      const nextChar = text[index + 1]
+
+      if (char === '/' && nextChar === '/') {
+        const lineEnd = text.indexOf('\n', index)
+        const end = lineEnd === -1 ? text.length : lineEnd
+        fill(index, end, COMMENT)
+        index = end
+        continue
+      }
+
+      if (char === '/' && nextChar === '*') {
+        const blockEnd = text.indexOf('*/', index + 2)
+        const end = blockEnd === -1 ? text.length : blockEnd + 2
+        fill(index, end, COMMENT)
+        index = end
+        continue
+      }
+
+      if (char === '"' || char === "'") {
+        index = scanQuoted(index)
+        continue
+      }
+
+      if (char === '`') {
+        index = scanTemplate(index)
+        continue
+      }
+
+      if (insideInterpolation) {
+        if (char === '{') {
+          index = scanCode(index + 1, true)
+          continue
+        }
+
+        if (char === '}') {
+          return index + 1
+        }
+      }
+
+      index += 1
+    }
+
+    return index
+  }
+
+  scanCode(0, false)
+  return { kinds, stringSpans, literalEnds }
+}
+
+function findClosingDelimiter(text, kinds, openIndex) {
+  const open = text[openIndex]
+  const close = open === '(' ? ')' : '}'
+  let depth = 0
+
+  for (let index = openIndex; index < text.length; index += 1) {
+    if (kinds[index] !== CODE) {
+      continue
+    }
+
+    if (text[index] === open) {
+      depth += 1
+    } else if (text[index] === close) {
+      depth -= 1
+
+      if (depth === 0) {
+        return index + 1
+      }
+    }
+  }
+
+  return text.length
+}
+
+// A class list is either an argument to cn/clsx/cva/twMerge or the value of a
+// className prop. Everything else in the file is prose as far as this rule cares.
+function findClassListRegions(text, kinds, literalEnds) {
+  const regions = []
+
+  for (const match of text.matchAll(classListCallPattern)) {
+    const start = match.index ?? 0
+
+    if (kinds[start] !== CODE) {
+      continue
+    }
+
+    const parenIndex = start + match[0].length - 1
+    regions.push({ start: parenIndex, end: findClosingDelimiter(text, kinds, parenIndex) })
+  }
+
+  for (const match of text.matchAll(classNameAttributePattern)) {
+    const start = match.index ?? 0
+
+    if (kinds[start] !== CODE) {
+      continue
+    }
+
+    let valueIndex = start + match[0].length
+
+    while (valueIndex < text.length && /\s/.test(text[valueIndex])) {
+      valueIndex += 1
+    }
+
+    const valueChar = text[valueIndex]
+
+    if (valueChar === '{') {
+      regions.push({ start: valueIndex, end: findClosingDelimiter(text, kinds, valueIndex) })
+    } else if (literalEnds.has(valueIndex)) {
+      regions.push({ start: valueIndex, end: literalEnds.get(valueIndex) })
+    }
+  }
+
+  return regions
+}
+
+function findClassListStringSpans(text) {
+  const { kinds, stringSpans, literalEnds } = classifySource(text)
+  const regions = findClassListRegions(text, kinds, literalEnds)
+
+  return stringSpans.filter((span) =>
+    regions.some((region) => span.start >= region.start && span.end <= region.end)
+  )
 }
 
 export function scanRendererText(filePath, text) {
@@ -24,20 +225,22 @@ export function scanRendererText(filePath, text) {
   const findings = []
   const physicalClassLines = new Set()
 
-  for (const match of text.matchAll(physicalTailwindPattern)) {
-    const line = lineNumberAt(text, match.index ?? 0)
+  for (const span of findClassListStringSpans(text)) {
+    for (const match of text.slice(span.start, span.end).matchAll(physicalTailwindPattern)) {
+      const line = lineNumberAt(text, span.start + (match.index ?? 0))
 
-    if (physicalClassLines.has(line)) {
-      continue
+      if (physicalClassLines.has(line)) {
+        continue
+      }
+
+      physicalClassLines.add(line)
+      findings.push({
+        filePath,
+        line,
+        rule: 'physical-tailwind-class',
+        message: match[1]
+      })
     }
-
-    physicalClassLines.add(line)
-    findings.push({
-      filePath,
-      line,
-      rule: 'physical-tailwind-class',
-      message: match[1]
-    })
   }
 
   for (const match of text.matchAll(rawConsolePattern)) {

--- a/scripts/check-staged-renderer-guards.test.mjs
+++ b/scripts/check-staged-renderer-guards.test.mjs
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { scanRendererText } from './check-staged-renderer-guards.mjs'
+
+const rendererPath = 'apps/desktop/src/renderer/src/components/sample.tsx'
+
+const physical = (findings) =>
+  findings.filter((finding) => finding.rule === 'physical-tailwind-class')
+
+describe('physical Tailwind classes in class lists', () => {
+  it('reports the className line and not the adjacent comment', () => {
+    const source = [
+      'export function Sample() {',
+      '  // Open the context menu on right-click.',
+      '  return <div className="absolute right-0" />',
+      '}'
+    ].join('\n')
+
+    const findings = scanRendererText(rendererPath, source)
+
+    assert.deepEqual(findings, [
+      {
+        filePath: rendererPath,
+        line: 3,
+        rule: 'physical-tailwind-class',
+        message: 'right-0'
+      }
+    ])
+  })
+
+  it('reports a class inside cn(), clsx(), cva() and twMerge()', () => {
+    const source = [
+      'const a = cn("flex", isOpen && "ml-2")',
+      'const b = clsx("pr-4")',
+      'const c = cva("base", { variants: { side: { start: "left-0" } } })',
+      'const d = twMerge("border-l-2")'
+    ].join('\n')
+
+    assert.deepEqual(
+      physical(scanRendererText(rendererPath, source)).map((finding) => [
+        finding.line,
+        finding.message
+      ]),
+      [
+        [1, 'ml-2'],
+        [2, 'pr-4'],
+        [3, 'left-0'],
+        [4, 'border-l-2']
+      ]
+    )
+  })
+
+  it('reports a class inside a className template literal and its interpolated class list', () => {
+    const source = [
+      'const e = <div className={`flex ${wide ? "pl-8" : ""} text-left`} />',
+      'const f = <div className={isOpen ? "rounded-r-md" : "rounded-none"} />'
+    ].join('\n')
+
+    assert.deepEqual(
+      physical(scanRendererText(rendererPath, source)).map((finding) => [
+        finding.line,
+        finding.message
+      ]),
+      [
+        [1, 'pl-8'],
+        [2, 'rounded-r-md']
+      ]
+    )
+  })
+
+  it('leaves logical direction classes alone', () => {
+    const source = 'const g = <div className="ms-2 pe-4 start-0 text-end border-s rounded-e-md" />'
+
+    assert.deepEqual(physical(scanRendererText(rendererPath, source)), [])
+  })
+})
+
+describe('text that only looks like a physical Tailwind class', () => {
+  it('ignores prose in line and block comments', () => {
+    const source = [
+      '// Fires on right-click and keeps the text-left reading order.',
+      '/**',
+      ' * Aligns to the left-hand edge, mirroring ml-4 in the legacy sheet.',
+      ' */',
+      'export const noop = () => {}'
+    ].join('\n')
+
+    assert.deepEqual(scanRendererText(rendererPath, source), [])
+  })
+
+  it('ignores a commented-out className', () => {
+    const source = '// return <div className="right-0" />'
+
+    assert.deepEqual(scanRendererText(rendererPath, source), [])
+  })
+
+  it('ignores string literals that are not class lists', () => {
+    const source = [
+      'import { Panel } from "./right-panel"',
+      'const label = t("menu.right-click")',
+      'const hint = "Aligned to the right-hand edge"',
+      'const el = <button data-testid="context-menu-right-click" aria-label="Move left-1 step" />'
+    ].join('\n')
+
+    assert.deepEqual(scanRendererText(rendererPath, source), [])
+  })
+
+  it('ignores a non-class-list call that happens to take direction words', () => {
+    const source = 'const h = describeShortcut("right-click", "text-left")'
+
+    assert.deepEqual(scanRendererText(rendererPath, source), [])
+  })
+})
+
+describe('raw console calls', () => {
+  it('still reports every raw console call with its line', () => {
+    const source = ['const i = 1', 'console.warn("boom")', 'console.log("again")'].join('\n')
+
+    assert.deepEqual(scanRendererText(rendererPath, source), [
+      {
+        filePath: rendererPath,
+        line: 2,
+        rule: 'raw-console',
+        message: 'console.warn('
+      },
+      {
+        filePath: rendererPath,
+        line: 3,
+        rule: 'raw-console',
+        message: 'console.log('
+      }
+    ])
+  })
+})
+
+describe('scanned paths', () => {
+  it('skips files outside the renderer source tree', () => {
+    const source = 'const j = <div className="right-0" />'
+
+    assert.deepEqual(scanRendererText('apps/desktop/src/main/sample.tsx', source), [])
+  })
+
+  it('skips renderer test files', () => {
+    const source = 'const k = <div className="right-0" />'
+
+    assert.deepEqual(
+      scanRendererText('apps/desktop/src/renderer/src/components/sample.test.tsx', source),
+      []
+    )
+  })
+})

--- a/scripts/check-staged-renderer-guards.test.mjs
+++ b/scripts/check-staged-renderer-guards.test.mjs
@@ -69,6 +69,24 @@ describe('physical Tailwind classes in class lists', () => {
     )
   })
 
+  // A lone apostrophe in JSX text or a regex reads as an opening quote. Closing an
+  // unterminated literal at the newline keeps that from swallowing the rest of the file.
+  it('still reports later lines after an apostrophe that is not a string', () => {
+    const source = [
+      "const warning = <p>don't do that</p>",
+      "const contraction = /isn't/",
+      'const g = <div className="ml-2" />'
+    ].join('\n')
+
+    assert.deepEqual(
+      physical(scanRendererText(rendererPath, source)).map((finding) => [
+        finding.line,
+        finding.message
+      ]),
+      [[3, 'ml-2']]
+    )
+  })
+
   it('leaves logical direction classes alone', () => {
     const source = 'const g = <div className="ms-2 pe-4 start-0 text-end border-s rounded-e-md" />'
 

--- a/scripts/check-staged-renderer-guards.test.mjs
+++ b/scripts/check-staged-renderer-guards.test.mjs
@@ -111,6 +111,16 @@ describe('text that only looks like a physical Tailwind class', () => {
 
     assert.deepEqual(scanRendererText(rendererPath, source), [])
   })
+
+  // Known limit of anchoring on className and cn/clsx/cva/twMerge. A class list
+  // parked in a config table reaches className through a variable, and following
+  // that would need a real parser. DENSITY_CONFIG in use-display-density.ts is the
+  // only such site in the renderer tree today.
+  it('does not follow a class list held in a config object', () => {
+    const source = 'const config = { watermarkOffset: "-left-2 lg:-left-4" }'
+
+    assert.deepEqual(scanRendererText(rendererPath, source), [])
+  })
 })
 
 describe('raw console calls', () => {


### PR DESCRIPTION
## Summary

Closes #1924.

`physicalTailwindPattern` in `scripts/check-staged-renderer-guards.mjs` matched raw text anywhere in a renderer source file, so the English word "right-click" in a code comment read as a physical Tailwind class and blocked the commit.

`scanRendererText` now classifies the file into code, comment and string regions, finds the class-list regions, and matches only inside string literals that sit in one. A class list is the value of a `className` prop or an argument to `cn`, `clsx`, `cva` or `twMerge`. The classifier is a lexer over quotes, template interpolation and comments. It is not a parser, and it does not follow a class list through a variable.

Regions rather than a context-aware regex, deliberately. The rule is about Tailwind class lists, so the honest model is to find the class lists. A regex that inspects surrounding characters still cannot tell `// the right-0 rule` from `className="right-0"`, because the distinguishing fact sits arbitrarily far to the left.

`rawConsolePattern` is untouched and still scans raw text.

### The stale half of the issue

The issue also reports that the guard "flags the whole staged file rather than the offending line". That is stale against `origin/main`. `scanRendererText` there already returns a `line`, and the CLI already prints `path:line`. Nothing here changes that; the new test pins the line number so it stays true.

### What the new scanner stops catching, measured

Both scanners were run over all 1952 files under `apps/desktop/src/renderer/src`. The new one drops five findings and adds none.

Three were prose in comments, which is the bug:

```
components/tabs/tab-bar-context-menu.tsx:3  [Right-click]         * Right-click context menu for empty tab bar area
lib/expression-parser.ts:268                [Right-associative]   * Right-associative operators
lib/expression-parser.ts:385                [right-associativity] // Handle right-associativity
```

Two are genuine physical classes that the guard now misses:

```
hooks/use-display-density.ts:79   [-left-2]  watermarkOffset: '-left-2 lg:-left-4 -top-4 lg:-top-6',
hooks/use-display-density.ts:114  [-left-1]  watermarkOffset: '-left-1 lg:-left-2 -top-2 lg:-top-3',
```

They live in the `DENSITY_CONFIG` table and reach `className` through a variable, which needs a parser to follow. A shape heuristic ("does this string look like a class list?") was considered and rejected: prose like `'the right-hand edge'` matches the same token grammar as `'-left-2 lg:-left-4'`, so the heuristic reintroduces exactly the guessing this issue is about. A test pins the limit as documented behavior rather than an accident. That file already carries physical classes and is exempt under the pre-existing-file rule in `CLAUDE.md`.

Two sites in one exempt file, against every comment in the tree that says "right-click", is the trade this PR takes.

### Test wiring

`scripts/check-staged-renderer-guards.test.mjs` is new. Nothing exercised this script's behavior before.

Rather than name it in CI and leave the next author to rediscover the rule, the `Test docs gate and pre-push policy` step in the `static` job becomes `node --test scripts/*.test.mjs`. Five of the ten `scripts/*.test.mjs` files were reachable from no workflow at all: `link-env`, `package-scripts`, `reddit-release-utils`, `release-notes-utils` and `release-utils`. All ten were audited first: every one uses `node:test`, none opens a socket, and none needs a build artifact, keychain entry or native module. `link-env` is the only one touching the filesystem and it does so inside `mkdtempSync` under `tmpdir`. The `static` job runs on `ubuntu-latest` with the default bash shell, so the glob expands in the runner.

`validate-mac-update-manifest.test.mjs` keeps its own step and now runs twice. Folding it in was out of scope.

The file is also added to `pnpm test:release`, which is a local convenience only; no workflow runs that script.

## Release note

none

## Test plan

Repro through the guard CLI on a genuinely staged file, comment on line 1 and `className="absolute right-0 top-0"` on line 3. Before the fix it reported two findings, `:1 physical-tailwind-class - right-click.` and `:3 physical-tailwind-class - right-0`. After the fix it reports only `:3 physical-tailwind-class - right-0`, and the same file with `end-0` in place of `right-0` exits 0.

`node --test scripts/check-staged-renderer-guards.test.mjs`, 13 pass 0 fail. Five of these cases fail on `origin/main`.

`node --test scripts/*.test.mjs`, the exact command CI now runs, under `bash --noprofile --norc -e -o pipefail`: 102 pass 0 fail. Confirmed in this PR's own `Static checks` run, not just locally.

Differential run of the `origin/main` scanner against the new one over all 1952 files under `apps/desktop/src/renderer/src`: 5 removed, 0 added, each one listed above.

`pnpm lint`, `pnpm typecheck` (19/19 tasks), `pnpm check:architecture`, `pnpm check:contracts`, `git diff --check` and `pnpm docs:impact --base origin/main --strict` all pass. `npx react-doctor .` reports only pre-existing findings in `apps/mobile`; this diff touches no React.

Not run: E2E and any Electron rebuild. The change is a Node script under `scripts/` plus a workflow step.
