### PR TITLE
fix(journal): give the day panel and the Home board one day boundary

### DIFF
--- a/apps/desktop/src/renderer/src/components/journal/journal-day-panel-day-range.test.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-day-panel-day-range.test.tsx
@@ -1,0 +1,197 @@
+import { execFileSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nextProvider } from 'react-i18next'
+import type { i18n as I18nInstance } from 'i18next'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRendererI18n } from '@memry/i18n/renderer'
+import type { CalendarProjectionItem, GetCalendarRangeInput } from '@/services/calendar-service'
+import { APP_QUERY_DEFAULT_OPTIONS } from '@/lib/query-client-options'
+import { toLocalDateString } from '@/components/calendar/date-utils'
+import { CalendarWidget } from '@/components/home/widgets/calendar-widget'
+import { JournalDayPanel } from './journal-day-panel'
+
+/**
+ * The Journal day panel and the Home board must be looking at the same day (#1954). The panel
+ * built its own window by pinning local date components to `T00:00:00.000Z`, which is the defect
+ * #1920 removed from the Home board — so once that landed, the two surfaces disagreed with each
+ * other by the host's UTC offset. At UTC-7 a 22:00 local event is 05:00Z the next day: inside the
+ * panel's window for tomorrow, inside Home's window for today.
+ */
+
+const { mockGetRange, requestedRanges, server } = vi.hoisted(() => ({
+  mockGetRange: vi.fn(),
+  requestedRanges: [] as GetCalendarRangeInput[],
+  server: { items: [] as CalendarProjectionItem[] }
+}))
+
+vi.mock('@/services/calendar-service', () => ({
+  calendarService: { getRange: mockGetRange },
+  onCalendarChanged: () => () => {}
+}))
+
+vi.mock('@/hooks/use-general-settings', () => ({
+  useGeneralSettings: () => ({ settings: { clockFormat: '24h' } })
+}))
+
+vi.mock('@/hooks/use-feature-flags', () => ({
+  // Only the calendar section is under test; the panel renders nothing at all without it.
+  useFeatureFlags: () => ({ isEnabled: (flag: string) => flag === 'calendar' })
+}))
+
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: {
+    list: vi.fn(async () => ({ tasks: [] })),
+    getStats: vi.fn(async () => ({ overdue: 0 }))
+  },
+  onTaskCreated: () => () => {},
+  onTaskUpdated: () => () => {},
+  onTaskDeleted: () => () => {},
+  onTaskCompleted: () => () => {}
+}))
+
+vi.mock('@/contexts/tasks', () => ({
+  useTasksContext: () => ({ projects: [] })
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabActions: () => ({ openTab: vi.fn() })
+}))
+
+vi.mock('@/features/tasks/use-task-queries', () => ({
+  useTaskWorkspaceData: () => ({ tasks: [], projects: [] })
+}))
+
+let i18nInstance: I18nInstance
+
+/** An instant at a local wall-clock time on today's local date. */
+function todayLocalAt(hour: number, minute = 0): string {
+  const now = new Date()
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate(), hour, minute).toISOString()
+}
+
+function event(id: string, title: string, startAt: string): CalendarProjectionItem {
+  return {
+    projectionId: id,
+    sourceType: 'calendar_event',
+    sourceId: id,
+    title,
+    descriptionPreview: null,
+    startAt,
+    endAt: new Date(Date.parse(startAt) + 30 * 60_000).toISOString(),
+    isAllDay: false,
+    timezone: 'UTC',
+    visualType: 'event',
+    editability: 'full',
+    source: { provider: null },
+    binding: null,
+    snoozeOffsetMinutes: null
+  } as unknown as CalendarProjectionItem
+}
+
+function renderWith(node: React.JSX.Element): void {
+  const client = new QueryClient({ defaultOptions: APP_QUERY_DEFAULT_OPTIONS })
+  render(
+    <I18nextProvider i18n={i18nInstance}>
+      <QueryClientProvider client={client}>{node}</QueryClientProvider>
+    </I18nextProvider>
+  )
+}
+
+beforeAll(async () => {
+  i18nInstance = await createRendererI18n({ locale: 'en' })
+})
+
+beforeEach(() => {
+  requestedRanges.length = 0
+  server.items = []
+  // Stands in for the main process, which selects on the instants it is handed.
+  mockGetRange.mockImplementation(async (input: GetCalendarRangeInput) => {
+    requestedRanges.push(input)
+    return {
+      items: server.items.filter((i) => i.startAt >= input.startAt && i.startAt < input.endAt)
+    }
+  })
+})
+
+describe('the Journal day panel and the Home board ask for one day', () => {
+  // Each side gets its own QueryClient, or the shared key would dedupe the second fetch away and
+  // leave nothing to compare.
+  it('requests the same window as the Home calendar widget', async () => {
+    renderWith(<JournalDayPanel date={toLocalDateString(new Date())} />)
+    await waitFor(() => expect(requestedRanges).toHaveLength(1))
+    cleanup()
+
+    renderWith(<CalendarWidget config={{}} size="M" />)
+    await waitFor(() => expect(requestedRanges).toHaveLength(2))
+
+    const [panel, widget] = requestedRanges
+    expect(panel).toEqual(widget)
+  })
+
+  it.each([
+    ['a local-evening event', 22, 0],
+    ['a local just-past-midnight event', 0, 30]
+  ])('shows %s that belongs to the day it is displaying', async (_label, hour, minute) => {
+    server.items = [event('e1', 'Investor sync', todayLocalAt(hour, minute))]
+    renderWith(<JournalDayPanel date={toLocalDateString(new Date())} />)
+
+    expect(await screen.findByText('Investor sync')).toBeInTheDocument()
+  })
+
+  it('leaves out an event that belongs to the next local day', async () => {
+    server.items = [event('e1', 'Tomorrow standup', todayLocalAt(24, 30))]
+    renderWith(<JournalDayPanel date={toLocalDateString(new Date())} />)
+
+    await waitFor(() => expect(requestedRanges).toHaveLength(1))
+    expect(screen.queryByText('Tomorrow standup')).not.toBeInTheDocument()
+  })
+})
+
+/**
+ * The cases above only separate the two windows on a machine that is not at UTC, and the renderer
+ * project runs on vitest's `threads` pool where assigning `process.env.TZ` never reaches the C++
+ * `tzset`. So the one case that has to hold on a UTC CI runner runs in a child `node` with a real
+ * `TZ`, the way `local-day-range.test.ts` does. The zone matrix itself lives there; this pins the
+ * single instant #1954 reported.
+ */
+const HELPER_URL = pathToFileURL(
+  resolve(dirname(expect.getState().testPath!), '../../lib/local-day-range.ts')
+).href
+
+function windowsIn(tz: string, date: string): { local: string[]; retired: string[] } {
+  const source = `
+    const { localDayRange } = await import(${JSON.stringify(HELPER_URL)})
+    const date = ${JSON.stringify(date)}
+    const local = localDayRange(date)
+    // The window the panel used to build, kept here only to prove it differs.
+    const start = new Date(date + 'T00:00:00.000Z')
+    const end = new Date(start)
+    end.setUTCDate(end.getUTCDate() + 1)
+    process.stdout.write(
+      JSON.stringify({
+        local: [local.startAt, local.endAt],
+        retired: [start.toISOString(), end.toISOString()]
+      })
+    )
+  `
+  const out = execFileSync(process.execPath, ['--input-type=module', '--eval', source], {
+    env: { ...process.env, TZ: tz },
+    encoding: 'utf8'
+  })
+  return JSON.parse(out)
+}
+
+describe('the window the panel retired', () => {
+  it('put a 22:00 local event at UTC-7 into tomorrow, where Home never looked', () => {
+    const { local, retired } = windowsIn('America/Los_Angeles', '2026-06-24')
+    // 22:00 local on the 24th, the instant the issue reported.
+    const at = '2026-06-25T05:00:00.000Z'
+
+    expect(at >= local[0] && at < local[1]).toBe(true)
+    expect(at >= retired[0] && at < retired[1]).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/journal/journal-day-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-day-panel.test.tsx
@@ -5,6 +5,7 @@ import { I18nextProvider } from 'react-i18next'
 import type { i18n as I18nInstance } from 'i18next'
 import type { ReactElement } from 'react'
 import { createRendererI18n } from '@memry/i18n/renderer'
+import { localDayRange } from '@/lib/local-day-range'
 import { JournalDayPanel } from './journal-day-panel'
 import type { CalendarProjectionItem } from '@/services/calendar-service'
 
@@ -138,10 +139,9 @@ describe('JournalDayPanel', () => {
 
     await waitFor(() =>
       expect(mockUseCalendarRange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          startAt: '2026-04-14T00:00:00.000Z',
-          endAt: '2026-04-15T00:00:00.000Z'
-        })
+        // Through the helper the panel uses, not literal instants: the window is the local
+        // day, so its UTC form moves with the machine's zone (#1954).
+        expect.objectContaining(localDayRange('2026-04-14'))
       )
     )
 

--- a/apps/desktop/src/renderer/src/components/journal/journal-day-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-day-panel.tsx
@@ -24,6 +24,7 @@ import type { Status, Project } from '@/data/tasks-data'
 import { ChevronDown } from '@/lib/icons'
 import { createLogger } from '@/lib/logger'
 import { getEventBaseColor } from '@/lib/event-type-colors'
+import { localDayRange } from '@/lib/local-day-range'
 import { formatTimeOfDay, type ClockFormat } from '@/lib/time-format'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { useFeatureFlags } from '@/hooks/use-feature-flags'
@@ -58,17 +59,6 @@ interface ScheduleEvent {
   title: string
   kind: ScheduleRowKind
   label: string | null
-}
-
-function getDayRange(date: string): { startAt: string; endAt: string } {
-  const start = new Date(`${date}T00:00:00.000Z`)
-  const end = new Date(start)
-  end.setUTCDate(end.getUTCDate() + 1)
-
-  return {
-    startAt: start.toISOString(),
-    endAt: end.toISOString()
-  }
 }
 
 function formatScheduleTimeLabel(
@@ -256,7 +246,7 @@ export function JournalDayPanel({ date, className, onHoverColor }: JournalDayPan
   const queryClient = useQueryClient()
   const { settings } = useGeneralSettings()
   const clockFormat = settings.clockFormat
-  const scheduleRange = useMemo(() => getDayRange(date), [date])
+  const scheduleRange = useMemo(() => localDayRange(date), [date])
   const scheduleQuery = useCalendarRange(scheduleRange)
 
   const projectMap = useMemo(() => {

--- a/apps/desktop/src/renderer/src/components/search/search-components.test.tsx
+++ b/apps/desktop/src/renderer/src/components/search/search-components.test.tsx
@@ -5,6 +5,7 @@ import { SearchFilters } from '@/components/search/search-filters'
 import { SearchResultGroup } from '@/components/search/search-result-group'
 import { SearchResultItem } from '@/components/search/search-result-item'
 import { searchService } from '@/services/search-service'
+import { localDayRange } from '@/lib/local-day-range'
 
 const openTab = vi.fn()
 const setQuery = vi.fn()
@@ -279,6 +280,36 @@ describe('search components coverage', () => {
     expect(onToggleTag).toHaveBeenCalledWith('roadmap')
     expect(onSetDateRange).toHaveBeenCalled()
     expect(onClear).toHaveBeenCalled()
+  })
+
+  // The presets used to name the UTC date and cover the UTC day, so in a westerly zone "Today"
+  // meant tomorrow and excluded the whole local evening (#1954).
+  it('scopes the Today preset to the local day, not the UTC one', () => {
+    const onSetDateRange = vi.fn()
+    render(
+      <SearchFilters
+        activeTypes={[]}
+        activeTags={[]}
+        activeDateRange={null}
+        onToggleType={vi.fn()}
+        onToggleTag={vi.fn()}
+        onSetDateRange={onSetDateRange}
+        onClear={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getAllByRole('button').find((b) => b.textContent === '')!)
+    fireEvent.click(screen.getByRole('button', { name: 'Today' }))
+
+    const now = new Date()
+    const { startAt, endAt } = localDayRange(
+      `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+    )
+    // `search.ts` filters with an inclusive `to`, so the preset stops a millisecond short of the
+    // next local midnight rather than reaching it.
+    expect(onSetDateRange).toHaveBeenCalledWith({
+      from: startAt,
+      to: new Date(Date.parse(endAt) - 1).toISOString()
+    })
   })
 
   it('opens command palette results and recent reasons', async () => {

--- a/apps/desktop/src/renderer/src/components/search/search-filters.tsx
+++ b/apps/desktop/src/renderer/src/components/search/search-filters.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback } from 'react'
 import { FileText, BookOpen, CheckSquare, Inbox, X, Filter, Tag, Calendar } from '@/lib/icons'
 import type { ContentType, DateRange } from '@memry/contracts/search-api'
 import { searchService } from '@/services/search-service'
+import { localDayRange } from '@/lib/local-day-range'
+import { toLocalDateString } from '@/components/calendar/date-utils'
 import { useT } from '@memry/i18n/renderer'
 
 interface SearchFiltersProps {
@@ -32,30 +34,38 @@ const DATE_PRESETS = [
   { label: 'This Month', getValue: () => thisMonthRange() }
 ] as const
 
+/**
+ * The presets used to read the date off `toISOString()` and pin it to `T00:00:00.000Z`, so both
+ * the day they named and the window they covered were UTC's, not the user's (#1954). At UTC-7 a
+ * note edited at 18:00 local landed on tomorrow's date and fell outside "Today" entirely.
+ *
+ * `search.ts` filters `modifiedAt >= from && modifiedAt <= to`, an inclusive end, while
+ * `localDayRange` hands back the half-open `[start, next start)`. One millisecond back off the
+ * end is what reconciles the two without letting the next day's first instant through.
+ */
+function localDaysBetween(fromDate: string, toDate: string): DateRange {
+  return {
+    from: localDayRange(fromDate).startAt,
+    to: new Date(Date.parse(localDayRange(toDate).endAt) - 1).toISOString()
+  }
+}
+
 function todayRange(): DateRange {
-  const now = new Date()
-  const date = now.toISOString().slice(0, 10)
-  return { from: `${date}T00:00:00.000Z`, to: `${date}T23:59:59.999Z` }
+  const today = toLocalDateString(new Date())
+  return localDaysBetween(today, today)
 }
 
 function thisWeekRange(): DateRange {
   const now = new Date()
-  const dayOfWeek = now.getDay()
   const start = new Date(now)
-  start.setDate(now.getDate() - dayOfWeek)
-  return {
-    from: `${start.toISOString().slice(0, 10)}T00:00:00.000Z`,
-    to: `${now.toISOString().slice(0, 10)}T23:59:59.999Z`
-  }
+  start.setDate(now.getDate() - now.getDay())
+  return localDaysBetween(toLocalDateString(start), toLocalDateString(now))
 }
 
 function thisMonthRange(): DateRange {
   const now = new Date()
   const start = new Date(now.getFullYear(), now.getMonth(), 1)
-  return {
-    from: `${start.toISOString().slice(0, 10)}T00:00:00.000Z`,
-    to: `${now.toISOString().slice(0, 10)}T23:59:59.999Z`
-  }
+  return localDaysBetween(toLocalDateString(start), toLocalDateString(now))
 }
 
 export function SearchFilters({

--- a/apps/desktop/src/renderer/src/lib/local-day-range.test.ts
+++ b/apps/desktop/src/renderer/src/lib/local-day-range.test.ts
@@ -107,3 +107,32 @@ describe('localDayRange in the host zone', () => {
 it('local-day-range.ts stays import-free', () => {
   expect(readFileSync(MODULE_PATH, 'utf8')).not.toMatch(/^\s*import\s/m)
 })
+
+// A behavioural test cannot tell the two windows apart on a UTC CI runner, so the rule that keeps
+// the fix from creeping back is structural: no renderer module rebuilds a day window by pinning a
+// date to UTC midnight. `T00:00:00` without the `Z` is a local parse and stays allowed (#1954).
+it('no renderer module pins a day window to UTC midnight', () => {
+  const root = resolve(dirname(expect.getState().testPath!), '..')
+  // `git grep` exits 1 when nothing matches, which is the healthy end state once the comments
+  // that still name the literal stop doing so.
+  let matched = ''
+  try {
+    matched = execFileSync('git', ['grep', '-l', 'T00:00:00\\.000Z', '--', root], {
+      encoding: 'utf8'
+    })
+  } catch {
+    matched = ''
+  }
+  const offenders = matched
+    .split('\n')
+    .filter(Boolean)
+    .filter((file) => !/\.(test|spec)\.tsx?$/.test(file))
+    .filter((file) => {
+      const code = readFileSync(file, 'utf8')
+        .split('\n')
+        .filter((line) => !/^\s*(\*|\/\/|\/\*)/.test(line))
+      return code.some((line) => line.includes('T00:00:00.000Z'))
+    })
+
+  expect(offenders).toEqual([])
+})

--- a/apps/docs/src/user-guide/day-panel.md
+++ b/apps/docs/src/user-guide/day-panel.md
@@ -38,6 +38,8 @@ Click a task to open its detail drawer; right-click for the context menu (status
 
 Calendar events for the focused date plus a preview of that day's journal entry (when applicable).
 
+The day runs midnight to midnight on your own clock, the same boundary the [Home board](/user-guide/home-dashboard) uses. A late-evening event and one just after midnight land on the days you would put them on, and the panel and the board never disagree about which day an event belongs to.
+
 If the [Google Calendar integration](/user-guide/settings#google-calendar) is linked, external events appear here too.
 
 ## Resizing

--- a/apps/docs/src/user-guide/search.md
+++ b/apps/docs/src/user-guide/search.md
@@ -49,6 +49,10 @@ Examples:
 - `#research neural networks` — items tagged `research` containing "neural networks"
 - `#daily 1 review` — notes only, tagged `daily`, containing "review"
 
+## Date Filters
+
+The filter bar's **Today**, **This Week**, and **This Month** presets narrow results to items modified in that stretch. They read your local calendar, so "Today" is your own midnight-to-midnight day rather than UTC's — a note edited late in the evening still counts as today's.
+
 ## Recents
 
 When the palette is empty it shows your recent trail: the items you last opened from search, each with the query that led you to them. It is a way back to a note you found yesterday without remembering how you phrased it.


### PR DESCRIPTION
## Summary

The Journal day panel built its own day window by pinning the local date to `T00:00:00.000Z` — the exact defect #1920 removed from the Home board. Once that PR landed, the two surfaces disagreed with each other by the host's UTC offset: at UTC-7 a 22:00 local event is 05:00Z the next day, so the panel filed it under tomorrow while Home filed it under today. The panel now calls the shared `localDayRange`.

The sweep #1954 asked for turned up a second caller. The search date presets read the day off `toISOString()` and covered the UTC day, so both the day they named and the window they spanned were UTC's: at UTC-7 a note edited at 18:00 local landed on tomorrow's date and fell outside "Today" entirely. They go through the same helper now, backing one millisecond off the end because `search.ts` filters with an inclusive `to`.

The remaining `T00:00:00.000Z` hits (journal streak counting, `app-core/tasks.ts`, `journal-api.ts`) are date-string arithmetic, not wall-clock windows — UTC is deliberate and correct there, so they are untouched.

### The tests needed a structural gate

A behavioural test cannot separate the two windows on a UTC CI runner, which is the one zone where the old window and the correct one agree. Verified by mutation: reinstating either pin leaves every rendering test green under `TZ=UTC`, and the renderer project runs on vitest's `threads` pool where assigning `process.env.TZ` never reaches `tzset`. So alongside the child-`node` case that pins the reported instant in a real zone, `local-day-range.test.ts` now fails if any renderer module rebuilds a day window at UTC midnight. Both mutants die under that gate at UTC.

Closes #1954

## Release note

The Journal day panel and the search date filters now use your local day. A late-evening or just-after-midnight event lands on the day you would put it on, and the day panel no longer disagrees with the Home board about which day an event belongs to.

## Test plan

- `pnpm typecheck` — green
- desktop renderer suite, full: 714 files / 8863 tests passing
- `pnpm lint` — 0 errors
- `pnpm docs:impact --base d1ee526 --strict` — covered; `pnpm docs:build` green
- Mutation: reinstating the UTC pin in `journal-day-panel.tsx` fails the guard at `TZ=UTC`; same for `search-filters.tsx`. Reinstating it in the panel also fails the rendering tests at a non-UTC host zone.
