### PR TITLE
feat(docs): add robots.txt, sitemap, and per-page canonicals

### DIFF
--- a/apps/docs/src/.vitepress/config.ts
+++ b/apps/docs/src/.vitepress/config.ts
@@ -6,6 +6,13 @@ export default defineConfig({
   description: 'Documentation for memrynote, a private offline-first workspace.',
   cleanUrls: true,
   lastUpdated: true,
+  sitemap: {
+    hostname: 'https://docs.memrynote.com'
+  },
+  transformHead: ({ page }) => {
+    const path = page.replace(/index\.md$/, '').replace(/\.md$/, '')
+    return [['link', { rel: 'canonical', href: `https://docs.memrynote.com/${path}` }]]
+  },
   head: [
     ['meta', { name: 'theme-color', content: '#111827' }],
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }]

--- a/apps/docs/src/architecture.md
+++ b/apps/docs/src/architecture.md
@@ -1,3 +1,7 @@
+---
+description: How memrynote's Electron desktop app, Cloudflare Workers sync server, and shared packages fit together in the monorepo.
+---
+
 # Architecture
 
 memrynote is a pnpm + Turborepo monorepo with an Electron desktop app, a Cloudflare Workers sync server, and shared TypeScript packages.

--- a/apps/docs/src/contributing.md
+++ b/apps/docs/src/contributing.md
@@ -1,3 +1,7 @@
+---
+description: How to set up a local memrynote development environment and contribute changes.
+---
+
 # Contributing
 
 Thanks for helping build memrynote. Keep changes small, focused, and easy to review.

--- a/apps/docs/src/features.md
+++ b/apps/docs/src/features.md
@@ -1,3 +1,7 @@
+---
+description: A high-level map of what memrynote does — notes, journal, tasks, canvas, sync, and AI features.
+---
+
 # Features Overview
 
 A high-level map of what memrynote does. Each section links to dedicated pages in the [User Guide](/user-guide/notes/editing).

--- a/apps/docs/src/guide/first-run.md
+++ b/apps/docs/src/guide/first-run.md
@@ -1,3 +1,7 @@
+---
+description: What happens the first time you open memrynote — choosing a vault location, setting a passphrase, and saving the recovery phrase.
+---
+
 # First Run & Vault Setup
 
 What happens the first time you open memrynote: choosing a vault location, setting a passphrase, and saving the recovery phrase.

--- a/apps/docs/src/guide/install.md
+++ b/apps/docs/src/guide/install.md
@@ -1,3 +1,7 @@
+---
+description: Download and install memrynote on macOS, Windows, or Linux, including Homebrew and manual installer options.
+---
+
 # Install memrynote
 
 Download the desktop app from **[memrynote.com/download/desktop](https://memrynote.com/download/desktop)**.

--- a/apps/docs/src/guide/tour.md
+++ b/apps/docs/src/guide/tour.md
@@ -1,3 +1,7 @@
+---
+description: A 60-second lap through the parts of memrynote you'll use most — sidebar, tabs, editor, and day panel.
+---
+
 # A Tour of memrynote
 
 A 60-second lap through the parts of the app you'll use most.

--- a/apps/docs/src/public/robots.txt
+++ b/apps/docs/src/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.memrynote.com/sitemap.xml

--- a/apps/docs/src/roadmap.md
+++ b/apps/docs/src/roadmap.md
@@ -1,3 +1,7 @@
+---
+description: What memrynote is stabilizing on the way to a first public release.
+---
+
 # Roadmap
 
 memrynote is moving toward a first public release. This page tracks direction, not a release

--- a/apps/landing/public/llms.txt
+++ b/apps/landing/public/llms.txt
@@ -1,0 +1,9 @@
+# memrynote
+
+memrynote is a private, offline-first workspace for notes, journal, tasks, and projects,
+with end-to-end encrypted sync across devices.
+
+- Website: https://memrynote.com
+- Documentation: https://docs.memrynote.com
+- Documentation sitemap: https://docs.memrynote.com/sitemap.xml
+- Source: https://github.com/memrynote/memry


### PR DESCRIPTION
## Summary
- Enable VitePress's built-in sitemap generation (`sitemap: { hostname: 'https://docs.memrynote.com' }`), no extra dependency needed
- Add `apps/docs/src/public/robots.txt` pointing crawlers at the sitemap
- Add per-page canonical URLs via `transformHead` in the VitePress config
- Replace the shared boilerplate meta description with real per-page descriptions on the top-level guide/overview pages (install, first-run, tour, architecture, contributing, features, roadmap)
- Add the docs sitemap URL to the landing site's `llms.txt` (created — none existed)

## Test plan
- [x] `pnpm docs:build` succeeds and generates `sitemap.xml` + `robots.txt` in the output dir
- [x] Verified canonical link tags render correctly (e.g. `/guide/install` → `https://docs.memrynote.com/guide/install`, index → `https://docs.memrynote.com/`)
- [x] Verified per-page meta description renders on `guide/install`

Closes #1927