### PR TITLE
feat(landing): link all comparison pages from a sitewide footer block

### DIFF
--- a/apps/landing/src/components/layout/Footer.tsx
+++ b/apps/landing/src/components/layout/Footer.tsx
@@ -4,12 +4,24 @@ import { Container } from './Container'
 import { AskAi } from '@/components/site/AskAi'
 import { FOOTER_LINKS, TWITTER_DEV_URL } from '@/lib/constants'
 import { trackLandingEvent } from '@/lib/analytics'
+import { ALTERNATIVES } from '@/lib/alternatives'
+import { PAGE_META } from '@/lib/seo'
 
 const FOOTER_COLUMNS = [
   { title: 'Product', links: FOOTER_LINKS.product },
   { title: 'Compare', links: FOOTER_LINKS.compare },
   { title: 'Resources', links: FOOTER_LINKS.resources },
   { title: 'Connect', links: FOOTER_LINKS.social }
+] as const
+
+// Every comparison page plus /use-cases, so each one gets a sitewide inbound link
+// instead of relying solely on the /compare hub grid. See issue #1928.
+const ALL_ALTERNATIVES_LINKS = [
+  ...ALTERNATIVES.map((alt) => ({
+    label: `vs ${alt.competitor}`,
+    href: PAGE_META[alt.pageKey].path
+  })),
+  { label: 'Use cases', href: PAGE_META.useCases.path }
 ] as const
 
 const TRUST_LINE = ['End-to-end encrypted', 'Open source', 'Local-first'] as const
@@ -106,6 +118,19 @@ export function Footer() {
               </ul>
             </div>
           ))}
+        </div>
+
+        <div className="mb-16 border-t border-white/10 pt-10">
+          <h4 className="mb-5 font-mono-accent text-[11px] uppercase tracking-[0.18em] text-ink-inverted/60">
+            All alternatives
+          </h4>
+          <ul className="flex flex-wrap gap-x-6 gap-y-3">
+            {ALL_ALTERNATIVES_LINKS.map((link) => (
+              <li key={link.href}>
+                <FooterLink href={footerHref(link.href, pathname)}>{link.label}</FooterLink>
+              </li>
+            ))}
+          </ul>
         </div>
 
         <div className="flex flex-col items-center justify-between gap-4 border-t border-white/10 pt-8 md:flex-row">


### PR DESCRIPTION
## Summary
- 13 of 17 "alternative to X" comparison pages plus /use-cases had only one inbound internal link (from the /compare hub grid), leaving them with little link equity.
- Add a compact "All alternatives" links row to the shared `Footer` component, so all 17 comparison pages and /use-cases get a link from every page on the site.

## Test plan
- [x] `pnpm --filter @memry/landing typecheck` passes
- [x] `eslint apps/landing/src/components/layout/Footer.tsx` clean (one pre-existing unrelated warning)
- [x] `pnpm dev:landing`, checked footer renders on the home page and an alternative page (e.g. /obsidian-alternative)
- [x] `pnpm docs:impact --base origin/main --strict` — no docs gate triggered

Closes #1928