### PR TITLE
fix(desktop): resolve base.css from import.meta.url, not process.cwd()

### DIFF
--- a/apps/desktop/src/renderer/src/assets/blocknote-text-color-css.test.ts
+++ b/apps/desktop/src/renderer/src/assets/blocknote-text-color-css.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import {
   AA_SMALL_TEXT,
@@ -9,9 +10,7 @@ import {
   type ThemeSelector
 } from '@tests/utils/contrast'
 
-// The renderer suite runs in jsdom, where `import.meta.url` is not a file: URL.
-// Vitest's cwd is apps/desktop.
-const BASE_CSS = join(process.cwd(), 'src/renderer/src/assets/base.css')
+const BASE_CSS = join(dirname(fileURLToPath(import.meta.url)), 'base.css')
 
 const SWATCHES = ['gray', 'brown', 'red', 'orange', 'yellow', 'green', 'blue', 'purple', 'pink']
 

--- a/apps/desktop/src/renderer/src/assets/excalidraw-context-menu-css.test.ts
+++ b/apps/desktop/src/renderer/src/assets/excalidraw-context-menu-css.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-// The renderer suite runs in jsdom, where `import.meta.url` is not a file: URL.
-// Vitest's cwd is apps/desktop.
-const BASE_CSS = join(process.cwd(), 'src/renderer/src/assets/base.css')
-const PACKAGE_JSON = join(process.cwd(), 'package.json')
+const TEST_DIR = dirname(fileURLToPath(import.meta.url))
+const BASE_CSS = join(TEST_DIR, 'base.css')
+const PACKAGE_JSON = join(TEST_DIR, '../../../../package.json')
 
 const OVERRIDE_SELECTOR = '.excalidraw .context-menu'
 

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-library-contract.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-library-contract.test.ts
@@ -29,20 +29,16 @@
  */
 
 import { readdirSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
-/** Vitest's cwd is apps/desktop; jsdom has no file: `import.meta.url`. */
-const PACKAGE_JSON = join(process.cwd(), 'package.json')
-const CURSOR_CSS = join(
-  process.cwd(),
-  'src/renderer/src/components/note/mind-map/mind-map-canvas.css'
-)
+const TEST_DIR = dirname(fileURLToPath(import.meta.url))
+const DESKTOP_ROOT = join(TEST_DIR, '../../../../../..')
+const PACKAGE_JSON = join(DESKTOP_ROOT, 'package.json')
+const CURSOR_CSS = join(TEST_DIR, 'mind-map-canvas.css')
 /** What electron-vite bundles: the package's `production` export condition. */
-const RUNTIME_BUNDLE_DIR = join(
-  process.cwd(),
-  '../../node_modules/@excalidraw/excalidraw/dist/prod'
-)
+const RUNTIME_BUNDLE_DIR = join(DESKTOP_ROOT, '../../node_modules/@excalidraw/excalidraw/dist/prod')
 const VERIFIED_VERSION = '0.18.1'
 
 function installedVersion(): string | undefined {

--- a/apps/desktop/src/renderer/src/components/note/review/review-ui.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/review-ui.test.tsx
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { act, fireEvent, render, renderHook, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -80,7 +81,10 @@ function nextFrame(): Promise<void> {
 
 describe('review UI', () => {
   it('moves rail cards left on hover with a theme-owned background token', () => {
-    const css = readFileSync(resolve(process.cwd(), 'src/renderer/src/assets/base.css'), 'utf8')
+    const css = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), '../../../assets/base.css'),
+      'utf8'
+    )
     const cardBlock = css.match(/\.critic-review-card\s*\{(?<body>[^}]*)\}/)?.groups?.body
     const hoverBlock = css.match(
       /\.critic-review-card\[data-hovered='true'\],\s*\.critic-review-card:hover\s*\{(?<body>[^}]*)\}/

--- a/apps/desktop/src/renderer/src/pages/project/theme-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/pages/project/theme-tokens.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-// The renderer suite runs in jsdom, where `import.meta.url` is not a file: URL.
-// Vitest's cwd is apps/desktop.
-const HUB_DIR = join(process.cwd(), 'src/renderer/src/pages/project')
-const BASE_CSS = join(process.cwd(), 'src/renderer/src/assets/base.css')
+// jsdom gives `import.meta.url` a real file: URL even though it lacks other
+// Node file APIs, so resolving from it (rather than `process.cwd()`) works
+// regardless of which directory vitest was invoked from.
+const HUB_DIR = dirname(fileURLToPath(import.meta.url))
+const BASE_CSS = join(HUB_DIR, '../../assets/base.css')
 
 /**
  * Tailwind silently drops a class whose token does not exist — `bg-surface-hover`

--- a/apps/desktop/tests/utils/contrast.ts
+++ b/apps/desktop/tests/utils/contrast.ts
@@ -6,7 +6,8 @@
  * blocks straight from source and do the arithmetic themselves.
  */
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 /** WCAG AA floor for small text (under 18.66px, or 14px bold). */
 export const AA_SMALL_TEXT = 4.5
@@ -15,8 +16,10 @@ export const AA_SMALL_TEXT = 4.5
 export const THEMES = [':root', '.white', '.dark'] as const
 export type ThemeSelector = (typeof THEMES)[number]
 
-// Vitest's cwd is apps/desktop.
-const BASE_CSS = join(process.cwd(), 'src/renderer/src/assets/base.css')
+const BASE_CSS = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../src/renderer/src/assets/base.css'
+)
 
 /**
  * One custom-property map per theme. base.css declares each theme across


### PR DESCRIPTION
## Summary
- `theme-tokens.test.ts` located `base.css` relative to `process.cwd()`, which is `apps/desktop` when vitest runs there but the repo root when invoked with an explicit `--config` path from the root — the documented way to run a targeted test in a fresh worktree. That threw ENOENT for a reason unrelated to the test's subject.
- Fixed by resolving from `import.meta.url` instead, which jsdom gives a real `file:` URL regardless of invocation cwd.
- Grepped `process.cwd()` under `apps/desktop` and found the same cwd-dependent file-resolution bug in five more places: `blocknote-text-color-css.test.ts`, `excalidraw-context-menu-css.test.ts`, `mind-map-library-contract.test.ts`, `review-ui.test.tsx`, and the shared helper `tests/utils/contrast.ts` (outside `src`, so it wasn't in the issue's stated grep scope but hits the same bug). All fixed the same way.
- Left the remaining `process.cwd()` hits alone: `tailwind-arbitrary-css-vars.test.ts` already falls back between both cwds, `terminal-command.test.ts` and `paths.test.ts` use cwd for synthetic/output paths rather than resolving a fixed source file, and `check-cert-hashes.ts` is a script that defaults an arg, not a test.

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts --project renderer <paths>` from `apps/desktop` — 5 files, 81 tests passed
- [x] `./node_modules/.bin/vitest run --config apps/desktop/config/vitest.config.ts --project renderer <paths>` from the repo root — 5 files, 81 tests passed

Closes #1957