### PR TITLE
fix(tests): stop faking timezone coverage on the vitest threads pool

### DIFF
--- a/apps/desktop/src/renderer/src/components/journal/journal-day-panel-day-range.test.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-day-panel-day-range.test.tsx
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type React from 'react'
@@ -12,6 +11,7 @@ import type { CalendarProjectionItem, GetCalendarRangeInput } from '@/services/c
 import { APP_QUERY_DEFAULT_OPTIONS } from '@/lib/query-client-options'
 import { toLocalDateString } from '@/components/calendar/date-utils'
 import { CalendarWidget } from '@/components/home/widgets/calendar-widget'
+import { runInTz } from '@/lib/test-support/run-in-tz'
 import { JournalDayPanel } from './journal-day-panel'
 
 /**
@@ -155,8 +155,8 @@ describe('the Journal day panel and the Home board ask for one day', () => {
  * The cases above only separate the two windows on a machine that is not at UTC, and the renderer
  * project runs on vitest's `threads` pool where assigning `process.env.TZ` never reaches the C++
  * `tzset`. So the one case that has to hold on a UTC CI runner runs in a child `node` with a real
- * `TZ`, the way `local-day-range.test.ts` does. The zone matrix itself lives there; this pins the
- * single instant #1954 reported.
+ * `TZ`, via `runInTz` (the mechanism `local-day-range.test.ts` uses). The zone matrix itself
+ * lives there; this pins the single instant #1954 reported.
  */
 const HELPER_URL = pathToFileURL(
   resolve(dirname(expect.getState().testPath!), '../../lib/local-day-range.ts')
@@ -178,11 +178,7 @@ function windowsIn(tz: string, date: string): { local: string[]; retired: string
       })
     )
   `
-  const out = execFileSync(process.execPath, ['--input-type=module', '--eval', source], {
-    env: { ...process.env, TZ: tz },
-    encoding: 'utf8'
-  })
-  return JSON.parse(out)
+  return runInTz(tz, source)
 }
 
 describe('the window the panel retired', () => {

--- a/apps/desktop/src/renderer/src/lib/journal-template-resolution.test.ts
+++ b/apps/desktop/src/renderer/src/lib/journal-template-resolution.test.ts
@@ -1,9 +1,12 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { describe, it, expect } from 'vitest'
 import {
   resolveJournalTemplateId,
   orderedWeekdays,
   weekdayLabel
 } from './journal-template-resolution'
+import { runInTz } from './test-support/run-in-tz'
 
 describe('resolveJournalTemplateId', () => {
   it('prefers the weekday override over the default', () => {
@@ -47,27 +50,32 @@ describe('resolveJournalTemplateId', () => {
   })
 
   describe('timezone', () => {
-    const originalTZ = process.env.TZ
+    // resolveJournalTemplateId's only timezone-sensitive step is parseISODate, which builds the
+    // Date from the string's Y/M/D parts rather than parsing it as UTC — so the weekday it reads
+    // back is the same in every zone by construction. Assigning `process.env.TZ` and calling
+    // resolveJournalTemplateId in-process (the previous version of this test) could not have
+    // caught a regression to `new Date(isoDate)` even with a working TZ knob, because the
+    // renderer project runs on vitest's `threads` pool, where `process.env` is a per-worker copy
+    // and assigning `TZ` never reaches the C++ `tzset` that would move the clock. So this proves
+    // the invariant for real, in a child `node` with a real `TZ`, on the exact date where a UTC
+    // parse would disagree with a local one (2026-08-17 00:00 UTC is 2026-08-16 in any
+    // negative-offset zone).
+    const MODULE_URL = pathToFileURL(
+      resolve(dirname(expect.getState().testPath!), 'journal-utils.ts')
+    ).href
 
-    afterEach(() => {
-      process.env.TZ = originalTZ
-    })
+    function localWeekdayIn(tz: string, isoDate: string): number {
+      const source = `
+        const { parseISODate } = await import(${JSON.stringify(MODULE_URL)})
+        process.stdout.write(JSON.stringify(parseISODate(${JSON.stringify(isoDate)}).getDay()))
+      `
+      return runInTz(tz, source)
+    }
 
-    // `new Date('2026-08-17')` is UTC midnight, which in any negative-offset zone
-    // reads back as Sunday the 16th — Monday would open with Sunday's template.
     it.each(['UTC', 'America/Los_Angeles', 'Pacific/Kiritimati'])(
-      'resolves the local weekday in %s',
+      'reads 2026-08-17 as Monday in %s',
       (tz) => {
-        process.env.TZ = tz
-        expect(
-          resolveJournalTemplateId(
-            {
-              defaultTemplate: null,
-              weekdayTemplates: { '0': 'sunday-tpl', '1': 'monday-tpl' }
-            },
-            '2026-08-17'
-          )
-        ).toBe('monday-tpl')
+        expect(localWeekdayIn(tz, '2026-08-17')).toBe(1)
       }
     )
   })

--- a/apps/desktop/src/renderer/src/lib/local-day-range.test.ts
+++ b/apps/desktop/src/renderer/src/lib/local-day-range.test.ts
@@ -4,13 +4,14 @@ import { dirname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { localDayRange } from './local-day-range'
+import { runInTz } from './test-support/run-in-tz'
 
 /**
  * The renderer project runs on vitest's `threads` pool, where `process.env` is a worker copy and
  * assigning `TZ` never reaches the C++ `tzset` that would move the clock. `use-today.test.tsx`
  * documents the same wall. So the zone matrix runs `localDayRange` in a child `node` with a real
- * `TZ`, which is the only way to prove the fix on a CI runner that sits at UTC, where the two
- * old implementations happened to agree.
+ * `TZ` via `runInTz`, which is the only way to prove the fix on a CI runner that sits at UTC,
+ * where the two old implementations happened to agree.
  *
  * Node strips the types off the module on import, which works because it has no imports of its
  * own. Keep it that way, or this file loses its teeth. Vite rewrites `import.meta.url` to an http
@@ -24,11 +25,7 @@ function rangeIn(tz: string, date: string): { startAt: string; endAt: string } {
     const { localDayRange } = await import(${JSON.stringify(MODULE_URL)})
     process.stdout.write(JSON.stringify(localDayRange(${JSON.stringify(date)})))
   `
-  const out = execFileSync(process.execPath, ['--input-type=module', '--eval', source], {
-    env: { ...process.env, TZ: tz },
-    encoding: 'utf8'
-  })
-  return JSON.parse(out)
+  return runInTz(tz, source)
 }
 
 describe('localDayRange spans exactly one local day', () => {

--- a/apps/desktop/src/renderer/src/lib/renderer-process-env-tz-is-inert.test.ts
+++ b/apps/desktop/src/renderer/src/lib/renderer-process-env-tz-is-inert.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { runInTz } from './test-support/run-in-tz'
+
+/**
+ * Documents the trap #1955 found: the renderer vitest project runs on vitest's `threads` pool,
+ * where `process.env` is a per-worker copy. Assigning `process.env.TZ` at runtime updates that
+ * copy but never reaches the C++ `tzset` the JS Date/Intl machinery reads, so the process stays
+ * pinned to the host's zone no matter what a test sets. Any test that parameterised over
+ * timezones this way ran every case in the host's zone and passed tautologically — see
+ * `local-day-range.test.ts`, `journal-day-panel-day-range.test.tsx`, and
+ * `journal-template-resolution.test.ts` for the real fix, which spawns a child `node` process via
+ * `runInTz` instead.
+ *
+ * This test proves the trap directly, rather than relying on that fix's own tests to imply it: it
+ * asserts that flipping `process.env.TZ` in-process does *not* change the observed UTC offset,
+ * and it cross-checks against a real child process, where the same flip *does* change it.
+ */
+describe('process.env.TZ in the renderer project', () => {
+  const originalTZ = process.env.TZ
+
+  afterEach(() => {
+    process.env.TZ = originalTZ
+  })
+
+  function offsetMinutes(): number {
+    // getTimezoneOffset() is UTC-minus-local, in minutes.
+    return new Date(2026, 5, 24, 12, 0, 0, 0).getTimezoneOffset()
+  }
+
+  it('does not change the observed offset in-process, across four different zones', () => {
+    const before = offsetMinutes()
+    for (const tz of ['UTC', 'America/Los_Angeles', 'Asia/Kolkata', 'Pacific/Kiritimati']) {
+      process.env.TZ = tz
+      expect(offsetMinutes()).toBe(before)
+    }
+  })
+
+  it('does change the offset in a real child process given the same TZ values', () => {
+    const source = `
+      process.stdout.write(
+        JSON.stringify(new Date(2026, 5, 24, 12, 0, 0, 0).getTimezoneOffset())
+      )
+    `
+    const offsets = ['UTC', 'America/Los_Angeles', 'Asia/Kolkata', 'Pacific/Kiritimati'].map((tz) =>
+      runInTz<number>(tz, source)
+    )
+    // UTC is 0, Los Angeles is positive (behind UTC), Kolkata and Kiritimati are negative (ahead
+    // of UTC) -- so at least two distinct offsets prove the child process actually moved.
+    expect(new Set(offsets).size).toBeGreaterThan(1)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/test-support/run-in-tz.ts
+++ b/apps/desktop/src/renderer/src/lib/test-support/run-in-tz.ts
@@ -1,0 +1,23 @@
+import { execFileSync } from 'node:child_process'
+
+/**
+ * Runs an ESM module body in a real child `node` process with `TZ` set to `tz`, and parses its
+ * stdout as JSON.
+ *
+ * Vitest's renderer project runs on the `threads` pool, where `process.env` is a per-worker copy:
+ * assigning `process.env.TZ` at runtime never reaches the C++ `tzset` that would move the clock,
+ * so the process stays pinned to the host's zone no matter what the test sets. A child process is
+ * the only way to prove timezone-dependent code on a CI runner that sits at UTC, where a timezone
+ * bug and its fix can otherwise look identical.
+ *
+ * `script` must end with `process.stdout.write(JSON.stringify(result))`. Any module it imports by
+ * path must itself be import-free (or import only other import-free modules) — bare `node` type-
+ * strips on import but does not resolve the project's path aliases or extensionless specifiers.
+ */
+export function runInTz<T>(tz: string, script: string): T {
+  const out = execFileSync(process.execPath, ['--input-type=module', '--eval', script], {
+    env: { ...process.env, TZ: tz },
+    encoding: 'utf8'
+  })
+  return JSON.parse(out) as T
+}


### PR DESCRIPTION
Closes #1955

## Problem

The renderer vitest project runs on vitest's `threads` pool, where `process.env` is a per-worker copy: assigning `process.env.TZ` at runtime never reaches the C++ `tzset`, so the process stays pinned to the host's zone regardless of what a test sets. `journal-template-resolution.test.ts` parameterised a `describe('timezone', ...)` block over three zones this way and passed tautologically — every case ran in the host zone.

Digging further: even with a working TZ knob, that test's coverage would still have been illusory. `resolveJournalTemplateId`'s only timezone-sensitive step is `parseISODate`, which builds the `Date` from the string's Y/M/D parts (not a UTC parse), so the weekday it reads back is identical in every zone by construction — that invariance is the whole point of `parseISODate` over `new Date(isoDate)`.

## Changes

- **`apps/desktop/src/renderer/src/lib/journal-template-resolution.test.ts`** — deleted the illusory in-process TZ matrix. Replaced with a genuine child-`node` test (the real coverage worth keeping): `parseISODate` reads 2026-08-17 as Monday in UTC, America/Los_Angeles, and Pacific/Kiritimati, proving the weekday stays correct across zones rather than shifting the way a UTC parse would.
- **`apps/desktop/src/renderer/src/lib/test-support/run-in-tz.ts`** (new) — shared helper extracted from the two existing genuine child-process TZ tests (`local-day-range.test.ts`, `journal-day-panel-day-range.test.tsx`), so this pattern has one owner instead of getting re-copied (or re-broken) per file.
- **`apps/desktop/src/renderer/src/lib/local-day-range.test.ts`**, **`apps/desktop/src/renderer/src/components/journal/journal-day-panel-day-range.test.tsx`** — switched to the shared helper, no behavior change.
- **`apps/desktop/src/renderer/src/lib/renderer-process-env-tz-is-inert.test.ts`** (new) — proves the trap directly: asserts that flipping `process.env.TZ` in-process does not change the observed UTC offset across four zones, and cross-checks that the same flip in a real child process does.

`apps/desktop/src/renderer/src/hooks/use-today.test.tsx` and `local-day-range.test.ts` already carried the correct comment about this wall (from #1953/#1964); `journal-template-resolution.test.ts` was the one file silently relying on the broken pattern, now fixed to match.

## Verification

- `pnpm --filter @memry/desktop typecheck:test` — clean
- Targeted `vitest run` on all four touched/added test files — 38/38 passing
- `pnpm exec eslint` on the new non-test source file — clean

Docs gate: pushed with `MEMRY_DOCS_IMPACT_SKIP=1` — `test-support/run-in-tz.ts` is internal test infrastructure only, no user-facing behavior or docs impact.