### PR TITLE
fix(sync): refresh link references and CriticMarkup on external-edit feed

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -409,12 +409,25 @@ export async function markdownToYFragment(
   return seedFragment(markdown, fragment, notePath, { recordSource: true })
 }
 
-async function seedFragment(
+export interface PreparedFragmentSeed {
+  blocks: Block[]
+  marks: ReturnType<typeof parseCriticMarkup>['marks']
+  definitions: ReturnType<typeof stripLinkReferenceDefinitions>['definitions']
+  usages: ReturnType<typeof stripLinkReferenceDefinitions>['usages']
+  plainText: string
+}
+
+/**
+ * Parse markdown into everything a fragment seed needs to write, without
+ * touching the Y.Doc. Shared by the initial seed (`markdownToYFragment`) and
+ * the external-edit door (`replaceNoteBodyInCrdt`), so both refresh the same
+ * side channels — link references (#1909) and CriticMarkup marks — instead of
+ * only the one that happens to parse the fragment itself.
+ */
+export async function prepareFragmentSeed(
   markdown: string,
-  fragment: Y.XmlFragment,
-  notePath: string | undefined,
-  options: { recordSource: boolean }
-): Promise<boolean> {
+  notePath: string | undefined
+): Promise<PreparedFragmentSeed | null> {
   const parsed = parseCriticMarkup(markdown)
   // Reference definitions ride beside the document in two Y.Arrays: the editor
   // has no block for one, so the definition is dropped and the destination
@@ -424,19 +437,50 @@ async function seedFragment(
   // reference link dead on screen.
   const references = stripLinkReferenceDefinitions(parsed.plainText)
   const blocks = await markdownToBlocks(parsed.plainText, notePath)
-  if (!blocks) return false
+  if (!blocks) return null
   // Upgrade `- [ ] … {task:id}` checkboxes into taskBlock nodes so the renderer
   // binds the custom block on first paint instead of a raw checkbox.
   const normalized = normalizeTaskBlocks(blocks).blocks
-  const ok = blocksToYFragment(normalized, fragment)
+  return {
+    blocks: normalized,
+    marks: parsed.marks,
+    definitions: references.definitions,
+    usages: references.usages,
+    plainText: parsed.plainText
+  }
+}
+
+/**
+ * Synchronous write half of a fragment seed: replaces the fragment's blocks
+ * and both side-channel arrays. Safe to call on an already-empty fragment
+ * (the initial seed) or to wrap in a `doc.transact` alongside clearing an
+ * existing fragment (a replace).
+ */
+export function applyFragmentSeed(
+  prepared: PreparedFragmentSeed,
+  fragment: Y.XmlFragment
+): boolean {
+  const ok = blocksToYFragment(prepared.blocks, fragment)
   if (ok && fragment.doc) {
-    writeCriticMarkupMarksToYDoc(fragment.doc, parsed.marks)
-    writeLinkReferencesToYDoc(fragment.doc, references.definitions, references.usages)
-    if (options.recordSource) {
-      // The source at the layer `yDocToMarkdown` returns: CriticMarkup already
-      // stripped, definitions still where the author put them.
-      await recordMarkdownSourceInYDoc(fragment.doc, parsed.plainText, fragmentNameOf(fragment))
-    }
+    writeCriticMarkupMarksToYDoc(fragment.doc, prepared.marks)
+    writeLinkReferencesToYDoc(fragment.doc, prepared.definitions, prepared.usages)
+  }
+  return ok
+}
+
+async function seedFragment(
+  markdown: string,
+  fragment: Y.XmlFragment,
+  notePath: string | undefined,
+  options: { recordSource: boolean }
+): Promise<boolean> {
+  const prepared = await prepareFragmentSeed(markdown, notePath)
+  if (!prepared) return false
+  const ok = applyFragmentSeed(prepared, fragment)
+  if (ok && fragment.doc && options.recordSource) {
+    // The source at the layer `yDocToMarkdown` returns: CriticMarkup already
+    // stripped, definitions still where the author put them.
+    await recordMarkdownSourceInYDoc(fragment.doc, prepared.plainText, fragmentNameOf(fragment))
   }
   return ok
 }

--- a/apps/desktop/src/main/sync/crdt-feed.seed-refresh.test.ts
+++ b/apps/desktop/src/main/sync/crdt-feed.seed-refresh.test.ts
@@ -1,0 +1,70 @@
+/**
+ * #1959: `replaceNoteBodyInCrdt` must refresh the same side channels the
+ * initial markdown seed does — link-reference definitions/usages (#1909) and
+ * CriticMarkup marks — not just the fragment's blocks. Runs the real
+ * `blocknote-converter` (only `crdt-provider` is stubbed) so the assertions
+ * exercise the actual parse/write path an external edit goes through.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import * as Y from 'yjs'
+import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
+import { readLinkReferencesFromYDoc } from '@memry/shared/link-references'
+import { readCriticMarkupMarksFromYDoc } from '@memry/shared'
+import { writeMarkdownSourceToYDoc } from '@memry/shared/markdown-source'
+import { markdownToYFragment, yDocToMarkdown } from './blocknote-converter'
+
+const getDoc = vi.fn()
+
+vi.mock('../sync/crdt-provider', () => ({
+  getCrdtProvider: () => ({ getDoc }),
+  ORIGIN_LOCAL: 'local'
+}))
+
+import { replaceNoteBodyInCrdt } from './crdt-feed'
+
+async function seed(markdown: string): Promise<Y.Doc> {
+  const doc = new Y.Doc()
+  const ok = await markdownToYFragment(markdown, doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+  expect(ok, 'markdown reached the shared doc').toBe(true)
+  return doc
+}
+
+describe('replaceNoteBodyInCrdt seed-parity (#1959)', () => {
+  it('replaces a stale link-reference definition on an external edit', async () => {
+    const doc = await seed('See [a][d].\n\n[d]: https://one.example')
+    getDoc.mockReturnValue(doc)
+
+    const ok = await replaceNoteBodyInCrdt('n1', 'See [a][d].\n\n[d]: https://two.example')
+    expect(ok).toBe(true)
+
+    const refs = readLinkReferencesFromYDoc(doc)
+    expect(refs.definitions).toHaveLength(1)
+    expect(refs.definitions[0]).toMatchObject({ label: 'd', destination: 'https://two.example' })
+
+    // Clearing the raw-source record forces write-back through the same
+    // canonical (fragment + side-channel array) path an edited region takes,
+    // which is exactly where the stale array used to leak back out.
+    writeMarkdownSourceToYDoc(doc, null)
+    const writtenBack = await yDocToMarkdown(doc)
+    expect(writtenBack).toContain('https://two.example')
+    expect(writtenBack).not.toContain('https://one.example')
+  })
+
+  it('strips CriticMarkup and refreshes the marks array on an external edit', async () => {
+    const doc = await seed('Hello {++brave++} world.')
+    expect(readCriticMarkupMarksFromYDoc(doc)).toHaveLength(1)
+
+    getDoc.mockReturnValue(doc)
+    const ok = await replaceNoteBodyInCrdt('n1', 'Hello plain world.')
+    expect(ok).toBe(true)
+
+    // The new body has no CriticMarkup, so the stale mark must not survive.
+    expect(readCriticMarkupMarksFromYDoc(doc)).toHaveLength(0)
+
+    writeMarkdownSourceToYDoc(doc, null)
+    const writtenBack = await yDocToMarkdown(doc)
+    expect(writtenBack).toContain('Hello plain world.')
+    expect(writtenBack).not.toContain('{++')
+  })
+})

--- a/apps/desktop/src/main/sync/crdt-feed.test.ts
+++ b/apps/desktop/src/main/sync/crdt-feed.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const getDoc = vi.fn()
-const markdownToBlocks = vi.fn()
-const blocksToYFragment = vi.fn()
+const prepareFragmentSeed = vi.fn()
+const applyFragmentSeed = vi.fn()
 const recordMarkdownSourceInYDoc = vi.fn()
 
 vi.mock('../sync/crdt-provider', () => ({
@@ -10,8 +10,8 @@ vi.mock('../sync/crdt-provider', () => ({
   ORIGIN_LOCAL: 'local'
 }))
 vi.mock('../sync/blocknote-converter', () => ({
-  markdownToBlocks: (...a: unknown[]) => markdownToBlocks(...a),
-  blocksToYFragment: (...a: unknown[]) => blocksToYFragment(...a),
+  prepareFragmentSeed: (...a: unknown[]) => prepareFragmentSeed(...a),
+  applyFragmentSeed: (...a: unknown[]) => applyFragmentSeed(...a),
   recordMarkdownSourceInYDoc: (...a: unknown[]) => recordMarkdownSourceInYDoc(...a)
 }))
 
@@ -41,8 +41,8 @@ function makeTagDoc(initialTags: string[] = ['work', 'daily']) {
 
 beforeEach(() => {
   getDoc.mockReset()
-  markdownToBlocks.mockReset()
-  blocksToYFragment.mockReset()
+  prepareFragmentSeed.mockReset()
+  applyFragmentSeed.mockReset()
   recordMarkdownSourceInYDoc.mockReset()
 })
 
@@ -50,12 +50,12 @@ describe('replaceNoteBodyInCrdt', () => {
   it('returns false when no doc is open', async () => {
     getDoc.mockReturnValue(null)
     expect(await replaceNoteBodyInCrdt('n1', '# hi')).toBe(false)
-    expect(markdownToBlocks).not.toHaveBeenCalled()
+    expect(prepareFragmentSeed).not.toHaveBeenCalled()
   })
 
   it('returns false when markdown does not parse', async () => {
     getDoc.mockReturnValue(makeDoc())
-    markdownToBlocks.mockResolvedValue(null)
+    prepareFragmentSeed.mockResolvedValue(null)
     expect(await replaceNoteBodyInCrdt('n1', '')).toBe(false)
   })
 
@@ -72,18 +72,20 @@ describe('replaceNoteBodyInCrdt', () => {
 
     // #then no parse, no transaction, and the live doc is left alone
     expect(await replaceNoteBodyInCrdt('n1', dump)).toBe(false)
-    expect(markdownToBlocks).not.toHaveBeenCalled()
+    expect(prepareFragmentSeed).not.toHaveBeenCalled()
     expect(doc.transact).not.toHaveBeenCalled()
   })
 
   it('clears the fragment then rebuilds it once when a doc is open', async () => {
     const doc = makeDoc()
     getDoc.mockReturnValue(doc)
-    markdownToBlocks.mockResolvedValue([{ type: 'paragraph' }])
+    const prepared = { blocks: [{ type: 'paragraph' }] }
+    prepareFragmentSeed.mockResolvedValue(prepared)
+    applyFragmentSeed.mockReturnValue(true)
     const ok = await replaceNoteBodyInCrdt('n1', '# hi')
     expect(ok).toBe(true)
     expect(doc._fragment.delete).toHaveBeenCalledWith(0, 3)
-    expect(blocksToYFragment).toHaveBeenCalledTimes(1)
+    expect(applyFragmentSeed).toHaveBeenCalledWith(prepared, doc._fragment)
     expect(doc.transact).toHaveBeenCalledTimes(1)
     // The file's new bytes become the source the write-back preserves (#1915).
     expect(recordMarkdownSourceInYDoc).toHaveBeenCalledWith(doc, '# hi', 'prosemirror')

--- a/apps/desktop/src/main/sync/crdt-feed.ts
+++ b/apps/desktop/src/main/sync/crdt-feed.ts
@@ -7,11 +7,10 @@
 
 import { getCrdtProvider, ORIGIN_LOCAL } from './crdt-provider'
 import {
-  markdownToBlocks,
-  blocksToYFragment,
+  prepareFragmentSeed,
+  applyFragmentSeed,
   recordMarkdownSourceInYDoc
 } from './blocknote-converter'
-import { normalizeTaskBlocks } from '@memry/shared/task-block'
 import { classifyMarkdownContent } from '@memry/shared/markdown-class'
 import { getIndexDatabase } from '../database'
 import { getNoteCacheById } from '@main/database/queries/notes'
@@ -59,20 +58,18 @@ export async function replaceNoteBodyInCrdt(noteId: string, markdown: string): P
     return false
   }
 
-  const blocks = await markdownToBlocks(markdown, noteCachePath(noteId))
-  if (!blocks) return false
-
-  // Same upgrade the initial markdown seed does (markdownToYFragment): without
-  // it a `- [ ] … {task:id}` line lands in the fragment as a raw checkbox and
-  // the open note paints a checkbox with the id suffix showing, instead of the
-  // task row. In CRDT mode the renderer trusts the fragment and never
-  // re-normalizes, so this is the only place it can happen.
-  const normalized = normalizeTaskBlocks(blocks).blocks
+  // Shares its parse (task-block upgrade included) and both side-channel
+  // writes with the initial markdown seed (markdownToYFragment), so an
+  // external edit refreshes link-reference definitions/usages (#1909) and
+  // CriticMarkup marks the same way a freshly seeded note does, instead of
+  // leaving the previous body's copies in place (#1959).
+  const prepared = await prepareFragmentSeed(markdown, noteCachePath(noteId))
+  if (!prepared) return false
 
   const fragment = doc.getXmlFragment('prosemirror')
   doc.transact(() => {
     fragment.delete(0, fragment.length)
-    blocksToYFragment(normalized, fragment)
+    applyFragmentSeed(prepared, fragment)
   }, ORIGIN_LOCAL)
 
   // The file's new bytes are the source from here on: whatever the write-back


### PR DESCRIPTION
## What

`replaceNoteBodyInCrdt` (the vault-watcher/template-apply door into a note's live Y.Doc) parsed markdown straight to blocks, skipping the CriticMarkup strip and the link-reference-definition strip that the initial markdown seed (`markdownToYFragment`) does. Two side channels were left holding the previous body's data:

- `linkReferenceDefinitions`/`linkReferenceUsages` (#1918): an external edit that changed, added, or removed a `[label]: url` definition had the old definition/usages re-emitted on the next write-back.
- `criticMarkupMarks`: CriticMarkup was never stripped before parsing, so `{++ins++}` landed in the fragment as literal text while the stale marks array kept reapplying on write-back.

`recordMarkdownSourceInYDoc` (#1915) was already called correctly here and is unaffected.

## Fix

Extracted the shared seed logic in `blocknote-converter.ts` into:
- `prepareFragmentSeed` (async parse: CriticMarkup, link-reference strip, blocks, task-block normalize)
- `applyFragmentSeed` (sync write: blocks + both side-channel arrays)

`markdownToYFragment` and `replaceNoteBodyInCrdt` now both compose these two functions, so an external edit refreshes exactly what a fresh seed refreshes. `replaceNoteBodyInCrdt` still wraps its fragment clear + write in the existing `doc.transact(..., ORIGIN_LOCAL)` for atomicity.

## Verification

- Added `crdt-feed.seed-refresh.test.ts`: seeds a note with a link-reference definition and a CriticMarkup insertion via the real `blocknote-converter`, feeds an edited body through `replaceNoteBodyInCrdt`, and asserts the definitions/marks arrays are refreshed and the canonical write-back path (source record cleared) reflects the new definition and drops the stale CriticMarkup marker — the exact repro from the issue.
- Updated `crdt-feed.test.ts` mocks for the new shared-function shape.
- `pnpm --filter @memry/desktop test:main` — all crdt-feed tests pass (one unrelated pre-existing failure in `crdt-sync-coordinator.test.ts` from an Electron native-install issue in this worktree, not touched by this change).
- `pnpm --filter @memry/desktop typecheck:node` and `typecheck:test` — clean.

Docs gate: pushed with `MEMRY_DOCS_IMPACT_SKIP=1`. This is an internal correctness fix restoring already-intended behavior (link references and CriticMarkup survive an external edit, same as a fresh note seed) — no new feature, contract, or user-facing behavior change to document.

Closes #1959
Part of #1906