### PR TITLE
feat(editor): Notion-style block side menu

### DIFF
--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -196,6 +196,7 @@ export interface MainIpcInvokeHandlers {
   "locale:set": (...args: [unknown]) => Awaited<Promise<void>>
   "notes:add-property-option": (...args: [{ propertyName: string; option: { value: string; color: string; }; }]) => Awaited<Promise<{ success: boolean; }>>
   "notes:add-status-option": (...args: [{ propertyName: string; categoryKey: "todo" | "in_progress" | "done"; option: { value: string; color: string; }; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:append-blocks": (...args: [{ sourceNoteId: string; targetNoteId: string; markdown: string; }]) => Awaited<Promise<{ targetPath: string; success: true; }> | { success: false; error: string }>
   "notes:apply-template": (...args: [{ noteId: string; templateId: string; mode: "full" | "body"; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
   "notes:attachment-open-external": (...args: [{ noteId: string; url: string; }]) => Awaited<Promise<void>>
   "notes:attachment-rename": (...args: [{ noteId: string; url: string; newName: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/notes-api").AttachmentRenameResult>>

--- a/apps/desktop/src/main/ipc/notes-handlers.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.ts
@@ -21,6 +21,7 @@ import {
   NoteGetPositionsSchema,
   SetLocalOnlySchema,
   ApplyTemplateSchema,
+  NoteAppendBlocksSchema,
   LargeFileReadLinesSchema,
   LargeFileSearchSchema,
   AttachmentActionSchema,
@@ -79,6 +80,7 @@ import {
   setNoteLocalOnlyCommand
 } from '../notes/domain'
 import { applyTemplateToNote } from '../notes/apply-template'
+import { appendBlocksToNote } from '../vault/append-blocks'
 import { getAllSupportedExtensions } from '@memry/shared/file-types'
 import { saveAttachment, deleteAttachment, listNoteAttachments } from '../vault/attachments'
 import { getStatus as getVaultStatus } from '../vault/index'
@@ -386,6 +388,25 @@ export function registerNotesHandlers(): void {
       return { success: true as const, note }
     },
     'errors:note.applyTemplateFailed'
+  )
+
+  // notes:append-blocks - Append markdown to the end of another note's body.
+  // The target half of the block side menu's "Move to"; the renderer removes
+  // the block from the source editor only after this resolves.
+  registerCommand(
+    NotesChannels.invoke.APPEND_BLOCKS,
+    NoteAppendBlocksSchema,
+    async (input) => {
+      const result = await appendBlocksToNote(input)
+      trackMainEvent('note_updated', {
+        surface: 'notes',
+        action: 'blocks_appended',
+        objectType: 'note',
+        result: 'success'
+      })
+      return { success: true as const, ...result }
+    },
+    'errors:note.appendBlocksFailed'
   )
 
   // notes:rename - Rename a note

--- a/apps/desktop/src/main/vault/append-blocks.test.ts
+++ b/apps/desktop/src/main/vault/append-blocks.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for append-blocks.ts — the target half of the block side menu's
+ * "Move to".
+ *
+ * The behaviour worth pinning is the ORDER, not the string concatenation:
+ * `notes:update` and the MCP append path both write the file and skip
+ * `feedExternalEditToCrdt`, which silently loses the appended text when the
+ * target note is open (the next CRDT writeback overwrites it). These assert the
+ * write is marked ignored BEFORE it lands and the CRDT feed runs AFTER, with
+ * the post-append body.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const calls: string[] = []
+const feedCalls: Array<{ noteId: string; content: string }> = []
+const written: Array<{ path: string; content: string }> = []
+const emitted: Array<{ channel: string; event: any }> = []
+
+const noteRows: Record<string, any> = {}
+
+vi.mock('@main/database/queries/notes', () => ({
+  getNoteCacheById: vi.fn((_db: unknown, id: string) => noteRows[id])
+}))
+vi.mock('../database', () => ({ getIndexDatabase: vi.fn(() => ({})) }))
+vi.mock('../sync/crdt-external-feed', () => ({
+  feedExternalEditToCrdt: vi.fn(async (noteId: string, content: string) => {
+    calls.push('feedExternalEditToCrdt')
+    feedCalls.push({ noteId, content })
+  })
+}))
+vi.mock('../sync/crdt-writeback', () => ({
+  markWritebackIgnored: vi.fn(() => calls.push('markWritebackIgnored'))
+}))
+vi.mock('./note-sync', () => ({
+  syncNoteToCache: vi.fn(() => {
+    calls.push('syncNoteToCache')
+    return { wordCount: 3, characterCount: 12, tags: [] }
+  })
+}))
+vi.mock('./file-ops', () => ({
+  safeRead: vi.fn(async (p: string) => written.find((w) => w.path === p)?.content ?? null),
+  atomicWrite: vi.fn(async (p: string, content: string) => {
+    calls.push('atomicWrite')
+    const existing = written.find((w) => w.path === p)
+    if (existing) existing.content = content
+    else written.push({ path: p, content })
+  })
+}))
+vi.mock('./notes-io', () => ({
+  emitNoteEvent: vi.fn((channel: string, event: unknown) => {
+    calls.push('emitNoteEvent')
+    emitted.push({ channel, event })
+  }),
+  toAbsolutePath: vi.fn((p: string) => `/vault/${p}`)
+}))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+import { appendBlocksToNote } from './append-blocks'
+
+function seedNote(id: string, notePath: string, body: string) {
+  noteRows[id] = {
+    id,
+    path: notePath,
+    title: id,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    localOnly: false,
+    emoji: null
+  }
+  written.push({ path: `/vault/${notePath}`, content: body })
+}
+
+beforeEach(() => {
+  calls.length = 0
+  feedCalls.length = 0
+  written.length = 0
+  emitted.length = 0
+  for (const key of Object.keys(noteRows)) delete noteRows[key]
+})
+
+describe('appendBlocksToNote', () => {
+  it('appends to the end of the target body, separated by a blank line', async () => {
+    seedNote('src', 'notes/source.md', 'Source body')
+    seedNote('dst', 'notes/target.md', 'Existing target body')
+
+    await appendBlocksToNote({ sourceNoteId: 'src', targetNoteId: 'dst', markdown: 'Moved block' })
+
+    const target = written.find((w) => w.path === '/vault/notes/target.md')!
+    expect(target.content).toContain('Existing target body\n\nMoved block')
+  })
+
+  it('marks the write ignored before it lands and feeds the CRDT after', async () => {
+    seedNote('src', 'notes/source.md', 'Source body')
+    seedNote('dst', 'notes/target.md', 'Target body')
+
+    await appendBlocksToNote({ sourceNoteId: 'src', targetNoteId: 'dst', markdown: 'Moved block' })
+
+    expect(calls).toEqual([
+      'markWritebackIgnored',
+      'atomicWrite',
+      'syncNoteToCache',
+      'emitNoteEvent',
+      'feedExternalEditToCrdt'
+    ])
+  })
+
+  it('feeds the CRDT the POST-append body, not the original', async () => {
+    seedNote('src', 'notes/source.md', 'Source body')
+    seedNote('dst', 'notes/target.md', 'Target body')
+
+    await appendBlocksToNote({ sourceNoteId: 'src', targetNoteId: 'dst', markdown: 'Moved block' })
+
+    expect(feedCalls).toHaveLength(1)
+    expect(feedCalls[0].noteId).toBe('dst')
+    expect(feedCalls[0].content).toContain('Moved block')
+  })
+
+  it('emits notes:updated as an EXTERNAL edit so an open editor reloads', async () => {
+    seedNote('src', 'notes/source.md', 'Source body')
+    seedNote('dst', 'notes/target.md', 'Target body')
+
+    await appendBlocksToNote({ sourceNoteId: 'src', targetNoteId: 'dst', markdown: 'Moved block' })
+
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0].event.id).toBe('dst')
+    expect(emitted[0].event.source).toBe('external')
+  })
+
+  it('rewrites note-relative attachment refs when the notes are in different folders', async () => {
+    seedNote('src', 'a/source.md', 'Source body')
+    seedNote('dst', 'b/deep/target.md', 'Target body')
+
+    await appendBlocksToNote({
+      sourceNoteId: 'src',
+      targetNoteId: 'dst',
+      markdown: '![shot](../attachments/src/shot.png)'
+    })
+
+    const target = written.find((w) => w.path === '/vault/b/deep/target.md')!
+    expect(target.content).toContain('attachments/src/shot.png')
+    expect(target.content).not.toContain('](../attachments/src/shot.png)')
+  })
+
+  it('writes nothing when the target note is missing', async () => {
+    seedNote('src', 'notes/source.md', 'Source body')
+
+    await expect(
+      appendBlocksToNote({ sourceNoteId: 'src', targetNoteId: 'gone', markdown: 'Moved block' })
+    ).rejects.toThrow(/Target note not found/)
+    expect(calls).toEqual([])
+  })
+
+  it('refuses to move a block into its own note', async () => {
+    seedNote('src', 'notes/source.md', 'Source body')
+
+    await expect(
+      appendBlocksToNote({ sourceNoteId: 'src', targetNoteId: 'src', markdown: 'Moved block' })
+    ).rejects.toThrow(/same/)
+    expect(calls).toEqual([])
+  })
+})

--- a/apps/desktop/src/main/vault/append-blocks.ts
+++ b/apps/desktop/src/main/vault/append-blocks.ts
@@ -1,0 +1,126 @@
+/**
+ * Append markdown to the end of a note that the renderer may not have open —
+ * the target half of the block side menu's "Move to".
+ *
+ * The renderer can only write a note body through a mounted editor (Yjs →
+ * `crdt:apply-update` → debounced writeback). "Move to" needs to write a note
+ * that is usually closed, so the write happens here, in the same order the
+ * watcher lands an out-of-app edit — the order proven by
+ * `rename-link-rewrite.ts` in this folder:
+ *
+ *  1. `markWritebackIgnored` so the watcher does not re-ingest our own write,
+ *  2. `atomicWrite` the file,
+ *  3. `syncNoteToCache` to re-project the index rows,
+ *  4. `notes:updated` with `source: 'external'` for the renderer,
+ *  5. `await feedExternalEditToCrdt` for the note's CRDT body.
+ *
+ * Step 5 is not optional. `notes:update` and the MCP `vault_update_note` append
+ * mode both skip it, and because `syncNoteToCache` refreshes `contentHash`
+ * first, the watcher's dedupe (`vault/watcher.ts`) returns early and never
+ * feeds the CRDT either — so when the target note IS open, its Y.Doc keeps the
+ * pre-append body and the next writeback overwrites the appended text. Awaiting
+ * the feed here is what makes a move into an open note survive.
+ *
+ * @module vault/append-blocks
+ */
+
+import { NotesChannels } from '@memry/contracts/ipc-channels'
+import type { NoteUpdatedEvent } from '@memry/contracts/notes-api'
+import { rewriteNoteRefsForMove } from '@memry/editor-schema/note-refs'
+import { getNoteCacheById } from '@main/database/queries/notes'
+import { getIndexDatabase } from '../database'
+import { feedExternalEditToCrdt } from '../sync/crdt-external-feed'
+import { markWritebackIgnored } from '../sync/crdt-writeback'
+import { parseNote, serializeParsedNote } from './frontmatter'
+import { syncNoteToCache } from './note-sync'
+import { safeRead, atomicWrite } from './file-ops'
+import { emitNoteEvent, toAbsolutePath } from './notes-io'
+import { createLogger } from '../lib/logger'
+
+const log = createLogger('AppendBlocks')
+
+export interface AppendBlocksInput {
+  sourceNoteId: string
+  targetNoteId: string
+  markdown: string
+}
+
+function toIso(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value
+}
+
+/**
+ * Append `markdown` to the end of the target note's body.
+ *
+ * Throws on a missing/unreadable note so the renderer keeps the block in the
+ * source note — a failed move must never lose content.
+ */
+export async function appendBlocksToNote(
+  input: AppendBlocksInput
+): Promise<{ targetPath: string }> {
+  const { sourceNoteId, targetNoteId, markdown } = input
+
+  if (!markdown.trim()) throw new Error('Nothing to append')
+  if (sourceNoteId === targetNoteId) throw new Error('Source and target note are the same')
+
+  const db = getIndexDatabase()
+  const target = getNoteCacheById(db, targetNoteId)
+  if (!target) throw new Error(`Target note not found: ${targetNoteId}`)
+  const source = getNoteCacheById(db, sourceNoteId)
+  if (!source) throw new Error(`Source note not found: ${sourceNoteId}`)
+
+  const absolutePath = toAbsolutePath(target.path)
+  const original = await safeRead(absolutePath)
+  if (original === null) throw new Error(`Target note is unreadable: ${target.path}`)
+
+  // Attachment/image refs in the moved slice are relative to the SOURCE note's
+  // folder. Same folder is a no-op (returns null); across folders this is the
+  // same surgical `../` arithmetic `moveNote` uses.
+  const rewritten = rewriteNoteRefsForMove(markdown, source.path, target.path) ?? markdown
+
+  const parsedOriginal = parseNote(original, target.path)
+  const head = parsedOriginal.content.replace(/\s+$/, '')
+  const nextContent = head ? `${head}\n\n${rewritten.trim()}` : rewritten.trim()
+  // `serializeParsedNote` re-applies the file's dominant EOL and final-newline
+  // presence, and leaves the raw frontmatter block byte-identical.
+  const nextFile = serializeParsedNote(parsedOriginal, nextContent, { frontmatterEdited: false })
+
+  markWritebackIgnored(absolutePath)
+  await atomicWrite(absolutePath, nextFile)
+
+  const now = new Date().toISOString()
+  const parsed = parseNote(nextFile, target.path)
+  const syncResult = syncNoteToCache(
+    db,
+    {
+      id: targetNoteId,
+      path: target.path,
+      fileContent: nextFile,
+      frontmatter: parsed.frontmatter,
+      parsedContent: parsed.content,
+      title: target.title,
+      createdAt: toIso(target.createdAt),
+      modifiedAt: now,
+      localOnly: target.localOnly ?? false,
+      emoji: target.emoji ?? null
+    },
+    { isNew: false }
+  )
+
+  const event: NoteUpdatedEvent = {
+    id: targetNoteId,
+    changes: {
+      content: parsed.content,
+      modified: new Date(now),
+      wordCount: syncResult.wordCount
+    },
+    source: 'external'
+  }
+  emitNoteEvent(NotesChannels.events.UPDATED, event)
+
+  await feedExternalEditToCrdt(targetNoteId, parsed.content)
+
+  log.info('Appended blocks to note', { targetNoteId, sourceNoteId, chars: rewritten.length })
+
+  return { targetPath: target.path }
+}

--- a/apps/desktop/src/preload/generated-rpc.ts
+++ b/apps/desktop/src/preload/generated-rpc.ts
@@ -82,6 +82,7 @@ export function createGeneratedRpcApi({
       "move": ((id, newFolder) => invoke("notes:move", { id, newFolder })) as GeneratedRpcApi["notes"]["move"],
       "delete": ((id) => invoke("notes:delete", id)) as GeneratedRpcApi["notes"]["delete"],
       "applyTemplate": ((input) => invoke("notes:apply-template", input)) as GeneratedRpcApi["notes"]["applyTemplate"],
+      "appendBlocks": ((input) => invoke("notes:append-blocks", input)) as GeneratedRpcApi["notes"]["appendBlocks"],
       "list": ((options) => invoke("notes:list", options ?? {})) as GeneratedRpcApi["notes"]["list"],
       "getTags": (() => invoke("notes:get-tags")) as GeneratedRpcApi["notes"]["getTags"],
       "getLinks": ((id) => invoke("notes:get-links", id)) as GeneratedRpcApi["notes"]["getLinks"],

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -99,6 +99,15 @@ vi.mock('@blocknote/react', () => ({
     }
   })),
   useEditorState: vi.fn(() => ({ hasSelection: false, isMultiBlock: false })),
+  // ContentArea pulls the canonical markdown serializer in for the block side
+  // menu's "Move to", and that module reaches the custom block specs — so the
+  // spec factory has to exist even though no block is rendered here.
+  createReactBlockSpec: vi.fn((config: unknown) => ({ config, implementation: {} })),
+  useExtensionState: vi.fn(() => undefined),
+  SideMenu: () => <div data-testid="side-menu" />,
+  SideMenuController: () => <div data-testid="side-menu-controller" />,
+  BlockColorsItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  RemoveBlockItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SuggestionMenuController: (props: Record<string, unknown>) => {
     contentAreaMocks.suggestionControllers.push(props)
     return <div data-testid={`suggestion-${props.triggerCharacter}`} />

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -80,7 +80,12 @@ import {
   ReviewFormattingToolbarController
 } from './review-formatting-toolbar'
 import { createCriticMarkupDecorationPlugin } from './critic-markup-decorations'
+import { Plugin } from 'prosemirror-state'
+import { isMac } from '@/lib/shortcut-registry'
+import { serializeBlocksPreservingBlanks } from './markdown-utils'
 import { registerEditorPlugin } from './register-editor-plugin'
+import { BlockSideMenuController, duplicateBlock } from './block-side-menu'
+import { MoveBlockDialog } from './move-block-dialog'
 import { createMultiBlockIndentPlugin } from './multi-block-indent-plugin'
 
 import {
@@ -1411,6 +1416,71 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     [editor, noteId, tasksCtx]
   )
 
+  // "Move to" from the block side menu: the picker names a target note, then
+  // the block's markdown is appended there BEFORE it is removed here. Ordering
+  // matters — a failed append must leave the block where it is rather than lose
+  // it, so the removal only runs once the IPC resolves.
+  const [moveBlockId, setMoveBlockId] = useState<string | null>(null)
+
+  const requestBlockMove = useCallback((blockId: string) => {
+    setMoveBlockId(blockId)
+  }, [])
+
+  const moveBlockToNote = useCallback(
+    async (targetNoteId: string): Promise<void> => {
+      const blockId = moveBlockId
+      if (!blockId || !noteId) return
+      const block = editor.getBlock(blockId)
+      if (!block) return
+
+      try {
+        // The canonical renderer serializer, so Memry's block markers (callout,
+        // bookmark, colors) survive the trip instead of being flattened.
+        // `serializeBlocksPreservingBlanks` is typed against BlockNote's default
+        // schema; the note editor's schema is a superset, so widen at the call.
+        const markdown = await serializeBlocksPreservingBlanks(editor, [block] as never)
+        if (!markdown.trim()) return
+
+        const result = await window.api.notes.appendBlocks({
+          sourceNoteId: noteId,
+          targetNoteId,
+          markdown
+        })
+        if (!result?.success) {
+          throw new Error(result?.error ?? 'append failed')
+        }
+
+        editor.removeBlocks([block])
+      } catch (err) {
+        toast.error(extractErrorMessage(err, tRef.current('editor.blockMenu.moveDialog.failed')))
+      } finally {
+        setMoveBlockId(null)
+      }
+    },
+    [editor, moveBlockId, noteId]
+  )
+
+  // ⌘D duplicates the block under the caret, matching the side menu's item.
+  // Registered as a ProseMirror keymap plugin so it only fires inside the
+  // editor and never steals the chord from the rest of the app.
+  useEffect(() => {
+    const plugin = new Plugin({
+      props: {
+        handleKeyDown: (_view, event) => {
+          const mod = isMac ? event.metaKey : event.ctrlKey
+          if (!mod || event.shiftKey || event.altKey || event.key.toLowerCase() !== 'd') {
+            return false
+          }
+          const blockId = editor.getTextCursorPosition?.()?.block?.id
+          if (!blockId) return false
+          event.preventDefault()
+          return duplicateBlock(editor, blockId)
+        }
+      }
+    })
+    return registerEditorPlugin(editor, plugin, (p, plugins) => [p, ...plugins])
+  }, [editor])
+
   // A context-menu click on an image block opens the attachment menu (reveal /
   // open / copy path — issue #1709). The built-in image block has no custom
   // render to mount a trigger in, so the menu is a controlled dropdown anchored
@@ -1625,6 +1695,14 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
               }}
             />
           )}
+          {moveBlockId && noteId && (
+            <MoveBlockDialog
+              open
+              onOpenChange={(open) => !open && setMoveBlockId(null)}
+              currentNoteId={noteId}
+              onSelect={(targetNoteId) => void moveBlockToNote(targetNoteId)}
+            />
+          )}
           {imageRenameTarget && (
             <AttachmentRenameFlow
               url={imageRenameTarget.url}
@@ -1722,6 +1800,10 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
             slashMenu={false}
             emojiPicker={false}
             filePanel={false}
+            // `BlockSideMenuController` below replaces the stock side menu.
+            // Left on, BlockNote renders its own on top and the default
+            // AddBlockButton's icon intercepts clicks meant for our drag handle.
+            sideMenu={false}
             // BlockNote anchors its row/column handles with floating-ui beside
             // the table, never on it. `TableBorderHandles` below draws ours on
             // the cell borders instead and opens the same menus from them.
@@ -1738,6 +1820,13 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
             ) : (
               <ReviewFormattingToolbarController onAddComment={review?.onAddComment} />
             )}
+            {/* Memry's block menu: BlockNote's stock drag-handle menu carries
+              only Delete + Colors. This one keeps both and adds Turn into,
+              Duplicate, Move to and Comment. */}
+            <BlockSideMenuController
+              onAddComment={review?.onAddComment}
+              onRequestMove={requestBlockMove}
+            />
             {aiEnabled && aiReady && <AIMenuController aiMenu={CustomAIMenu} />}
             <FilePanelController filePanel={UploadOnlyFilePanel} />
             <SuggestionMenuController

--- a/apps/desktop/src/renderer/src/components/note/content-area/block-side-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/block-side-menu.tsx
@@ -1,0 +1,366 @@
+/**
+ * Memry's block side menu — the menu behind a block's drag handle.
+ *
+ * BlockNote's stock drag-handle menu carries two items (Delete, Colors). This
+ * one adds the rest of the Notion-shaped set: Turn into, Duplicate, Move to and
+ * Comment. It is built ON TOP of the default items rather than replacing them,
+ * so `RemoveBlockItem` / `BlockColorsItem` keep their behaviour, their markdown
+ * round-trip and their `data-test` hooks.
+ *
+ * Everything acts on the block whose handle was clicked — never on a wider
+ * multi-block selection, because the handle itself names the target.
+ *
+ * @module note/content-area/block-side-menu
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- BlockNote's own default
+   drag-handle items type the editor as `<any, any, any>`; narrowing here would
+   make Memry's heterogeneous block schema unassignable at every call site. */
+
+import { useCallback, useMemo, type FC, type ReactNode } from 'react'
+import {
+  BlockColorsItem,
+  RemoveBlockItem,
+  SideMenu,
+  SideMenuController,
+  useBlockNoteEditor,
+  useComponentsContext,
+  useExtensionState
+} from '@blocknote/react'
+import { SideMenuExtension } from '@blocknote/core/extensions'
+import { TextSelection } from 'prosemirror-state'
+import type { Node as ProseMirrorNode } from 'prosemirror-model'
+import type { BlockNoteEditor } from '@blocknote/core'
+import { ArrowRight, Copy, MessageCircle, Palette, Trash2, Type } from '@/lib/icons'
+import { useT } from '@memry/i18n/renderer'
+import { isMac } from '@/lib/shortcut-registry'
+import { getEditorSelectionFromState, getProseMirrorState } from './review-formatting-toolbar'
+import type { ReviewSelection } from './types'
+
+type AnyBlock = { id: string; type: string; props?: Record<string, unknown>; content?: unknown }
+
+/**
+ * Blocks with no inline text of their own. Turn into and Comment are hidden on
+ * these: converting a file block to a heading is meaningless, and CriticMarkup
+ * wraps TEXT — there is nothing for a comment to anchor to.
+ */
+const NON_TEXT_BLOCK_TYPES = new Set([
+  'file',
+  'image',
+  'video',
+  'audio',
+  'youtubeEmbed',
+  'bookmark',
+  'taskBlock',
+  'table'
+])
+
+/**
+ * Blocks that own an attachment. "Move to" is hidden on these: the bytes live
+ * under `attachments/<owning note id>/` and the target note's
+ * `attachmentReferences` row never gains the id, so the embed would resolve on
+ * this machine and be broken on every other device. Not a door to open by
+ * accident — see the plan's Move to section.
+ */
+const ATTACHMENT_BLOCK_TYPES = new Set(['file', 'image', 'video', 'audio'])
+
+/** Turn-into targets, in menu order. Heading carries its level as a prop. */
+const TURN_INTO_TARGETS: Array<{ key: string; type: string; props?: Record<string, unknown> }> = [
+  { key: 'paragraph', type: 'paragraph' },
+  { key: 'heading1', type: 'heading', props: { level: 1 } },
+  { key: 'heading2', type: 'heading', props: { level: 2 } },
+  { key: 'heading3', type: 'heading', props: { level: 3 } },
+  { key: 'bulletList', type: 'bulletListItem' },
+  { key: 'numberedList', type: 'numberedListItem' },
+  { key: 'checkList', type: 'checkListItem' },
+  { key: 'toggleList', type: 'toggleListItem' },
+  { key: 'quote', type: 'quote' },
+  { key: 'codeBlock', type: 'codeBlock' },
+  { key: 'callout', type: 'callout' }
+]
+
+function useCurrentBlock(): AnyBlock | undefined {
+  const editor = useBlockNoteEditor<any, any, any>()
+  return useExtensionState(SideMenuExtension, {
+    editor,
+    selector: (state) => state?.block
+  }) as AnyBlock | undefined
+}
+
+/** Inline text carried by a block, used to decide if a comment can anchor. */
+function blockText(block: AnyBlock): string {
+  const content = block.content
+  if (!Array.isArray(content)) return ''
+  return content
+    .map((node) => (typeof node === 'object' && node && 'text' in node ? String(node.text) : ''))
+    .join('')
+}
+
+/** True when the block embeds a vault attachment, block-level or inline. */
+function carriesAttachment(block: AnyBlock): boolean {
+  if (ATTACHMENT_BLOCK_TYPES.has(block.type)) return true
+  const content = block.content
+  if (!Array.isArray(content)) return false
+  return content.some(
+    (node) =>
+      typeof node === 'object' &&
+      node !== null &&
+      (node as { type?: string }).type === 'inlineImage'
+  )
+}
+
+/**
+ * ProseMirror range covering a block's inline content.
+ *
+ * A block container node carries the block id; its first textblock descendant
+ * holds the inline content the comment must wrap.
+ */
+function findBlockInlineRange(
+  doc: ProseMirrorNode,
+  blockId: string
+): { from: number; to: number } | null {
+  let found: { from: number; to: number } | null = null
+
+  doc.descendants((node, pos) => {
+    if (found) return false
+    if ((node.attrs as { id?: string } | undefined)?.id !== blockId) return true
+
+    node.descendants((child, childPos) => {
+      if (found || !child.isTextblock) return !found
+      const from = pos + 1 + childPos + 1
+      found = { from, to: from + child.content.size }
+      return false
+    })
+    return false
+  })
+
+  return found
+}
+
+function MenuItem({
+  icon,
+  label,
+  shortcut,
+  onClick
+}: {
+  icon: ReactNode
+  label: string
+  shortcut?: string
+  onClick: () => void
+}) {
+  const Components = useComponentsContext()!
+  return (
+    <Components.Generic.Menu.Item className="bn-menu-item" icon={icon} onClick={onClick}>
+      {label}
+      {shortcut ? (
+        <span className="bn-menu-item-shortcut ms-auto ps-4 opacity-60">{shortcut}</span>
+      ) : null}
+    </Components.Generic.Menu.Item>
+  )
+}
+
+function TurnIntoItem() {
+  const { t } = useT('notes')
+  const Components = useComponentsContext()!
+  const editor = useBlockNoteEditor<any, any, any>()
+  const block = useCurrentBlock()
+
+  if (!block || NON_TEXT_BLOCK_TYPES.has(block.type)) return null
+
+  // Only offer types this editor's schema actually carries — the note body and
+  // the task/inbox editors do not share a schema.
+  const targets = TURN_INTO_TARGETS.filter((target) =>
+    Boolean(editor.schema.blockSchema[target.type])
+  )
+  if (targets.length === 0) return null
+
+  return (
+    <Components.Generic.Menu.Root position="right" sub={true}>
+      <Components.Generic.Menu.Trigger sub={true}>
+        <Components.Generic.Menu.Item
+          className="bn-menu-item"
+          icon={<Type size={16} />}
+          subTrigger={true}
+        >
+          {t('editor.blockMenu.turnInto')}
+        </Components.Generic.Menu.Item>
+      </Components.Generic.Menu.Trigger>
+      <Components.Generic.Menu.Dropdown sub={true} className="bn-menu-dropdown">
+        {targets.map((target) => (
+          <Components.Generic.Menu.Item
+            key={target.key}
+            className="bn-menu-item"
+            onClick={() => {
+              // `updateBlock` keeps `children`, so an indented sub-list survives
+              // the conversion instead of being silently dropped.
+              editor.updateBlock(block, { type: target.type, props: target.props ?? {} })
+            }}
+          >
+            {t(`editor.blockMenu.turnIntoTypes.${target.key}`)}
+          </Components.Generic.Menu.Item>
+        ))}
+      </Components.Generic.Menu.Dropdown>
+    </Components.Generic.Menu.Root>
+  )
+}
+
+function DuplicateItem() {
+  const { t } = useT('notes')
+  const editor = useBlockNoteEditor<any, any, any>()
+  const block = useCurrentBlock()
+
+  const duplicate = useCallback(() => {
+    if (!block) return
+    duplicateBlock(editor, block.id)
+  }, [editor, block])
+
+  if (!block) return null
+
+  return (
+    <MenuItem
+      icon={<Copy size={16} />}
+      label={t('editor.blockMenu.duplicate')}
+      shortcut={duplicateShortcutLabel()}
+      onClick={duplicate}
+    />
+  )
+}
+
+function MoveToItem({ onRequestMove }: { onRequestMove?: (blockId: string) => void }) {
+  const { t } = useT('notes')
+  const block = useCurrentBlock()
+
+  if (!block || !onRequestMove) return null
+  // Moving an attachment-bearing block would break the embed on every other
+  // device; the item is hidden rather than shown failing.
+  if (carriesAttachment(block)) return null
+
+  return (
+    <MenuItem
+      icon={<ArrowRight size={16} />}
+      label={t('editor.blockMenu.moveTo')}
+      onClick={() => onRequestMove(block.id)}
+    />
+  )
+}
+
+function CommentItem({ onAddComment }: { onAddComment?: (selection: ReviewSelection) => void }) {
+  const { t } = useT('notes')
+  const editor = useBlockNoteEditor<any, any, any>()
+  const block = useCurrentBlock()
+
+  const addComment = useCallback(() => {
+    if (!block || !onAddComment) return
+    const typed = editor as unknown as BlockNoteEditor
+    const state = getProseMirrorState(typed)
+    const view = (editor as { prosemirrorView?: { dispatch: (tr: unknown) => void } })
+      .prosemirrorView
+    const range = findBlockInlineRange(state.doc, block.id)
+    if (!range || range.to <= range.from || !view) return
+
+    // The review composer anchors to a ProseMirror range, so select the block's
+    // text first and then read the selection back through the same helper the
+    // formatting toolbar's comment button uses.
+    view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, range.from, range.to)))
+    onAddComment(getEditorSelectionFromState(typed, getProseMirrorState(typed)))
+  }, [editor, block, onAddComment])
+
+  if (!block || !onAddComment) return null
+  if (NON_TEXT_BLOCK_TYPES.has(block.type)) return null
+  if (!blockText(block).trim()) return null
+
+  return (
+    <MenuItem
+      icon={<MessageCircle size={16} />}
+      label={t('editor.blockMenu.comment')}
+      onClick={addComment}
+    />
+  )
+}
+
+/**
+ * Duplicate a block and its subtree, inserting the copy directly below.
+ *
+ * Exported so the ⌘D editor plugin and the menu item share one implementation.
+ */
+export function duplicateBlock(editor: any, blockId: string): boolean {
+  const block = editor.getBlock(blockId)
+  if (!block) return false
+  // `id` is stripped from the copy (and from every descendant) so BlockNote
+  // mints fresh ones; reusing them would collide with the original.
+  const stripIds = (node: any): any => ({
+    ...node,
+    id: undefined,
+    children: Array.isArray(node.children) ? node.children.map(stripIds) : node.children
+  })
+  editor.insertBlocks([stripIds(block)], block, 'after')
+  return true
+}
+
+export function duplicateShortcutLabel(): string {
+  return isMac ? '⌘D' : 'Ctrl+D'
+}
+
+export interface BlockSideMenuProps {
+  /** Opens the review comment composer; omitted where review is not wired. */
+  onAddComment?: (selection: ReviewSelection) => void
+  /** Opens the "move block to another note" picker for the given block. */
+  onRequestMove?: (blockId: string) => void
+}
+
+/**
+ * Mount inside `<BlockNoteView>` to replace the stock side menu.
+ *
+ * `SideMenuController` renders its `sideMenu` component with no props, so the
+ * handlers are closed over here rather than threaded through BlockNote.
+ */
+export function BlockSideMenuController({ onAddComment, onRequestMove }: BlockSideMenuProps) {
+  const { t } = useT('notes')
+
+  const dragHandleMenu = useMemo<FC>(
+    () => () => <MemryDragHandleMenu onAddComment={onAddComment} onRequestMove={onRequestMove} />,
+    [onAddComment, onRequestMove]
+  )
+
+  const sideMenu = useMemo<FC>(
+    () => () => <SideMenu dragHandleMenu={dragHandleMenu} />,
+    [dragHandleMenu]
+  )
+
+  // `t` is read here only so the menu re-renders on a language change; the
+  // labels themselves are resolved inside each item.
+  void t
+
+  return <SideMenuController sideMenu={sideMenu} />
+}
+
+function MemryDragHandleMenu({ onAddComment, onRequestMove }: BlockSideMenuProps) {
+  const { t } = useT('notes')
+  const Components = useComponentsContext()!
+
+  return (
+    <Components.Generic.Menu.Dropdown className="bn-menu-dropdown bn-drag-handle-menu">
+      <TurnIntoItem />
+      {/* Stock item: owns the block colour props, their markdown marker and the
+          `text-color-*` test hooks. The label stays BlockNote's "Colors" so the
+          existing drag-handle E2E keeps matching it. */}
+      <BlockColorsItem>
+        <span className="flex items-center gap-2">
+          <Palette size={16} aria-hidden />
+          {t('editor.blockMenu.colors')}
+        </span>
+      </BlockColorsItem>
+      <Components.Generic.Menu.Divider />
+      <DuplicateItem />
+      <MoveToItem onRequestMove={onRequestMove} />
+      <RemoveBlockItem>
+        <span className="flex items-center gap-2">
+          <Trash2 size={16} aria-hidden />
+          {t('editor.blockMenu.delete')}
+        </span>
+      </RemoveBlockItem>
+      <Components.Generic.Menu.Divider />
+      <CommentItem onAddComment={onAddComment} />
+    </Components.Generic.Menu.Dropdown>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/note/content-area/move-block-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/move-block-dialog.tsx
@@ -1,0 +1,160 @@
+/**
+ * Picker for the block side menu's "Move to": choose the note a block is moved
+ * into. The block is appended to the END of the chosen note's body.
+ *
+ * Deliberately has no "create a new note" row — moving and creating are two
+ * failure points, and a failed create would leave the block in limbo.
+ *
+ * @module note/content-area/move-block-dialog
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { fuzzySearch } from '@/lib/fuzzy-search'
+import { notesService } from '@/services/notes-service'
+import { createLogger } from '@/lib/logger'
+import { useT } from '@memry/i18n/renderer'
+import { cn } from '@/lib/utils'
+
+const log = createLogger('MoveBlockDialog')
+
+interface NoteOption {
+  id: string
+  title: string
+  path: string
+}
+
+export interface MoveBlockDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The note the block is being moved OUT of; never offered as a target. */
+  currentNoteId: string
+  onSelect: (targetNoteId: string) => void
+}
+
+export function MoveBlockDialog({
+  open,
+  onOpenChange,
+  currentNoteId,
+  onSelect
+}: MoveBlockDialogProps) {
+  const { t } = useT('notes')
+  const [notes, setNotes] = useState<NoteOption[]>([])
+  const [query, setQuery] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const result = await notesService.list({ limit: 500, sortBy: 'modified', fields: 'tree' })
+        if (cancelled) return
+        setNotes(
+          (result?.notes ?? [])
+            .filter((note: { id: string }) => note.id !== currentNoteId)
+            .map((note: { id: string; title: string; path: string }) => ({
+              id: note.id,
+              title: note.title,
+              path: note.path
+            }))
+        )
+      } catch (err) {
+        if (!cancelled) log.warn('Failed to load notes for move target picker', { error: err })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [open, currentNoteId])
+
+  const results = useMemo(
+    () => fuzzySearch(notes, query, ['title', 'path']).slice(0, 50),
+    [notes, query]
+  )
+
+  // Clamped during render rather than reset in an effect: a narrowing query can
+  // leave the cursor past the end of the list for one frame otherwise.
+  const selectedIndex = Math.min(activeIndex, Math.max(results.length - 1, 0))
+
+  const commit = useCallback(
+    (index: number) => {
+      const picked = results[index]
+      if (!picked) return
+      onSelect(picked.id)
+      onOpenChange(false)
+    },
+    [results, onSelect, onOpenChange]
+  )
+
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setActiveIndex(Math.min(selectedIndex + 1, results.length - 1))
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setActiveIndex(Math.max(selectedIndex - 1, 0))
+      } else if (event.key === 'Enter') {
+        event.preventDefault()
+        commit(selectedIndex)
+      }
+    },
+    [results.length, selectedIndex, commit]
+  )
+
+  useEffect(() => {
+    const active = listRef.current?.querySelector<HTMLElement>('[data-active="true"]')
+    active?.scrollIntoView({ block: 'nearest' })
+  }, [selectedIndex])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md" data-test="move-block-dialog">
+        <DialogHeader>
+          <DialogTitle>{t('editor.blockMenu.moveDialog.title')}</DialogTitle>
+        </DialogHeader>
+        <Input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={t('editor.blockMenu.moveDialog.searchPlaceholder')}
+          data-test="move-block-search"
+        />
+        <ScrollArea className="max-h-72">
+          <div ref={listRef} className="flex flex-col gap-0.5 pe-2">
+            {results.length === 0 ? (
+              <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+                {t('editor.blockMenu.moveDialog.noResults')}
+              </p>
+            ) : (
+              results.map((note, index) => (
+                <button
+                  key={note.id}
+                  type="button"
+                  data-active={index === selectedIndex}
+                  data-test="move-block-option"
+                  className={cn(
+                    'flex flex-col items-start rounded-md px-2 py-1.5 text-start text-sm',
+                    index === selectedIndex
+                      ? 'bg-accent text-accent-foreground'
+                      : 'hover:bg-accent/50'
+                  )}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => commit(index)}
+                >
+                  <span className="truncate font-medium">{note.title}</span>
+                  <span className="truncate text-xs text-muted-foreground">{note.path}</span>
+                </button>
+              ))
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
@@ -429,7 +429,10 @@ function getEditorSelection(editor: BlockNoteEditor): ReviewSelection {
   return getEditorSelectionFromState(editor, state)
 }
 
-function getEditorSelectionFromState(editor: BlockNoteEditor, state: EditorState): ReviewSelection {
+export function getEditorSelectionFromState(
+  editor: BlockNoteEditor,
+  state: EditorState
+): ReviewSelection {
   const selection = state.selection
   if (selection.empty) return { text: '', isEmpty: true }
 
@@ -448,7 +451,7 @@ type TiptapHost = {
   prosemirrorView?: EditorView
 }
 
-function getProseMirrorState(editor: BlockNoteEditor): EditorState {
+export function getProseMirrorState(editor: BlockNoteEditor): EditorState {
   const host = editor as unknown as TiptapHost
   return (host._tiptapEditor?.state ?? host.prosemirrorState) as EditorState
 }

--- a/apps/desktop/tests/e2e/editor-drag-handle-menu.e2e.ts
+++ b/apps/desktop/tests/e2e/editor-drag-handle-menu.e2e.ts
@@ -87,6 +87,90 @@ test.describe('Drag handle menu E2E', () => {
     await expect(page.locator('.bn-block-content[data-text-color="red"]').first()).toBeVisible()
   })
 
+  test('turns a paragraph into a heading via the menu', async ({ page }) => {
+    await createNote(page, uniqueLabel('Drag Menu Turn Into'))
+    await focusEditor(page)
+    await page.keyboard.type('Promote me to a heading')
+
+    await openDragHandleMenu(page)
+    await page.getByRole('menuitem', { name: 'Turn into' }).first().click()
+    await page.getByRole('menuitem', { name: 'Heading 1' }).first().click()
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() => (window as any).__memryEditor?.document?.[0]?.type as string)
+      )
+      .toBe('heading')
+  })
+
+  test('duplicates a block via the menu, directly below the original', async ({ page }) => {
+    await createNote(page, uniqueLabel('Drag Menu Duplicate'))
+    await focusEditor(page)
+    await page.keyboard.type('Copy me')
+
+    await openDragHandleMenu(page)
+    await page.getByRole('menuitem', { name: 'Duplicate' }).first().click()
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const editor = (window as any).__memryEditor
+          const text = (block: any) =>
+            (block?.content ?? []).map((n: any) => n?.text ?? '').join('')
+          return editor.document.filter((b: any) => text(b) === 'Copy me').length
+        })
+      )
+      .toBe(2)
+  })
+
+  test('moves a block into another note and removes it from the source', async ({ page }) => {
+    const targetTitle = uniqueLabel('Move Target')
+    await createNote(page, targetTitle)
+    await focusEditor(page)
+    await page.keyboard.type('Target note body')
+    // Let the target note's autosave land before it is written to from main.
+    await page.waitForTimeout(1_500)
+
+    const sourceTitle = uniqueLabel('Move Source')
+    await createNote(page, sourceTitle)
+    await focusEditor(page)
+    await page.keyboard.type('Relocate this line')
+    const { id: movedId } = await firstBlock(page)
+
+    await openDragHandleMenu(page)
+    await page.getByRole('menuitem', { name: 'Move to' }).first().click()
+
+    const search = page.locator('[data-test="move-block-search"]')
+    await search.waitFor({ state: 'visible', timeout: 5_000 })
+    await search.fill(targetTitle)
+    await page.locator('[data-test="move-block-option"]').first().click()
+
+    // Source: the block is gone only after the append resolved.
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          (blockId) => (window as any).__memryEditor.document.some((b: any) => b.id === blockId),
+          movedId
+        )
+      )
+      .toBe(false)
+
+    // Target: the line landed at the end of the target note's body on disk.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async (noteTitle) => {
+            const list = await (window as any).api.notes.list({})
+            const note = list.notes.find((n: { title: string }) => n.title === noteTitle)
+            if (!note) return null
+            const full = await (window as any).api.notes.get(note.id)
+            return full?.content ?? null
+          }, targetTitle),
+        { timeout: 10_000 }
+      )
+      .toContain('Relocate this line')
+  })
+
   test('deletes a block via real menu clicks', async ({ page }) => {
     await createNote(page, uniqueLabel('Drag Menu Delete'))
     await focusEditor(page)

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -236,6 +236,30 @@ Hover the gutter on the left to reveal the block handle. Drag a block to:
 - Reorder within the note
 - Move out into a different note (drop on a sidebar item or another open tab)
 
+## Block Menu
+
+Click the block handle in the left gutter to open the block menu. Everything in it
+applies to that one block, no matter what else is selected:
+
+| Action                          | What it does                                                                                                                                                    |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Turn into**                   | Converts the block to another text type — text, heading 1–3, bulleted, numbered or to-do list, toggle list, quote, code, callout. Indented children come along. |
+| **Colors**                      | Sets the block's text and background colour.                                                                                                                    |
+| **Duplicate** (`⌘D` / `Ctrl+D`) | Copies the block and its indented children directly below.                                                                                                      |
+| **Move to…**                    | Search for another note and move the block to the end of it.                                                                                                    |
+| **Delete**                      | Removes the block.                                                                                                                                              |
+| **Comment**                     | Opens a comment on the block, in the same review sidebar as a comment on selected text.                                                                         |
+
+Some entries are hidden when they do not apply. **Turn into** and **Comment** do not
+appear on blocks with no text of their own — files, images, embeds, bookmarks, tasks
+and tables. **Move to…** is hidden on blocks that hold an attachment, because the
+file stays with the note that owns it and the embed would break on your other
+devices.
+
+**Move to…** writes to the target note first and only removes the block here once
+that succeeds, so a failed move leaves the block where it was. Undo restores the
+block in this note; it does not remove the copy in the target note.
+
 ## Selecting Text and Blocks
 
 Dragging that **starts inside a line** always selects text, however far it travels and in whatever direction. Dragging straight down across several paragraphs selects the text between the two points, exactly as dragging diagonally does.

--- a/packages/contracts/src/notes-api.ts
+++ b/packages/contracts/src/notes-api.ts
@@ -228,6 +228,19 @@ export const ApplyTemplateSchema = z.object({
 })
 
 /**
+ * Append a slice of markdown to the end of another note's body.
+ *
+ * The renderer half of "Move to" removes the block from the source editor only
+ * AFTER this resolves, so the source note is named here purely to rewrite
+ * note-relative refs into the target note's folder — never to edit it.
+ */
+export const NoteAppendBlocksSchema = z.object({
+  sourceNoteId: z.string(),
+  targetNoteId: z.string(),
+  markdown: z.string()
+})
+
+/**
  * One window of lines from an open large-file session.
  *
  * `count` is capped because the response is an IPC payload: the viewer only

--- a/packages/contracts/src/notes-channels.ts
+++ b/packages/contracts/src/notes-channels.ts
@@ -129,6 +129,8 @@ export const NotesChannels = {
     GET_LOCAL_ONLY_COUNT: 'notes:get-local-only-count',
     /** Apply a template to an existing note (replaces body; optionally merges metadata) */
     APPLY_TEMPLATE: 'notes:apply-template',
+    /** Append markdown to the end of an existing note's body (block "Move to") */
+    APPEND_BLOCKS: 'notes:append-blocks',
     /** Open a large-file-class file for read-only streaming */
     LARGE_FILE_OPEN: 'notes:large-file-open',
     /** Read one window of lines from an open large-file session */

--- a/packages/i18n/src/locales/en/errors.json
+++ b/packages/i18n/src/locales/en/errors.json
@@ -28,6 +28,7 @@
     "renameFailed": "Failed to rename note",
     "moveFailed": "Failed to move note",
     "applyTemplateFailed": "Failed to apply template",
+    "appendBlocksFailed": "Failed to move the block to that note",
     "exportPdfFailed": "Failed to export PDF",
     "exportHtmlFailed": "Failed to export HTML",
     "restoreVersionFailed": "Failed to restore version",

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -244,6 +244,34 @@
       "refused": "This line carries an id, a dependency or a block link that Obsidian needs at the end of the line. Remove it in Obsidian first, then convert.",
       "createFailed": "Could not create the task for this line.",
       "completeFailed": "The task was created, but its done date could not be applied."
+    },
+    "blockMenu": {
+      "turnInto": "Turn into",
+      "turnIntoTypes": {
+        "paragraph": "Text",
+        "heading1": "Heading 1",
+        "heading2": "Heading 2",
+        "heading3": "Heading 3",
+        "bulletList": "Bulleted list",
+        "numberedList": "Numbered list",
+        "checkList": "To-do list",
+        "toggleList": "Toggle list",
+        "quote": "Quote",
+        "codeBlock": "Code",
+        "callout": "Callout"
+      },
+      "colors": "Colors",
+      "duplicate": "Duplicate",
+      "moveTo": "Move to…",
+      "delete": "Delete",
+      "comment": "Comment",
+      "moveDialog": {
+        "title": "Move block to note",
+        "searchPlaceholder": "Search notes…",
+        "noResults": "No matching notes",
+        "moved": "Block moved to “{title}”",
+        "failed": "Could not move the block"
+      }
     }
   },
   "dateMention": {

--- a/packages/rpc/src/notes.ts
+++ b/packages/rpc/src/notes.ts
@@ -276,6 +276,23 @@ export interface ApplyTemplateInput {
 }
 
 /**
+ * Append a slice of markdown to the end of another note's body — the target
+ * half of the block side menu's "Move to". The source note is named only so
+ * note-relative attachment refs can be rewritten into the target's folder.
+ */
+export interface AppendBlocksInput {
+  sourceNoteId: string
+  targetNoteId: string
+  markdown: string
+}
+
+export interface AppendBlocksResponse {
+  success: boolean
+  targetPath?: string
+  error?: string
+}
+
+/**
  * Which per-note fields `notes.list` should build. Omit for the full shape —
  * `'tree'` drops the sidebar-irrelevant heavy fields (`snippet`, `mimeType`,
  * `fileSize`) from every row.
@@ -491,6 +508,10 @@ export const notesRpc = defineDomain({
     }),
     applyTemplate: defineMethod<(input: ApplyTemplateInput) => Promise<NoteUpdateResponse>>({
       channel: NotesChannels.invoke.APPLY_TEMPLATE,
+      params: ['input']
+    }),
+    appendBlocks: defineMethod<(input: AppendBlocksInput) => Promise<AppendBlocksResponse>>({
+      channel: NotesChannels.invoke.APPEND_BLOCKS,
       params: ['input']
     }),
     list: defineMethod<(options?: NoteListOptions) => Promise<NoteListResponse>>({


### PR DESCRIPTION
## Summary

The block drag-handle menu carried only **Delete** and **Colors**. This adds **Turn into**, **Duplicate**, **Move to** and **Comment**, built on top of BlockNote's default items so the stock behaviour, the colour markdown marker and the existing menu test hooks all survive.

Order, with two dividers: Turn into › · Colors › — Duplicate `⌘D` · Move to… · Delete — Comment.

Hidden where they do not apply: **Turn into** and **Comment** on blocks with no inline text (`file`, `image`, `video`, `audio`, `youtubeEmbed`, `bookmark`, `taskBlock`, `table`); **Move to** on attachment-bearing blocks. The menu always acts on the clicked block, never on a wider selection.

Three things worth a reviewer's attention:

- **`sideMenu={false}` is load-bearing.** Without it BlockNote renders its own side menu alongside ours and the default `AddBlockButton` icon swallows clicks meant for the drag handle — the pre-existing drag-handle E2E goes red.
- **Move to writes through main, in a specific order.** The renderer cannot write a note it has not opened, so the target half runs behind a new `notes:append-blocks` channel following the sequence `rename-link-rewrite.ts` proved: `markWritebackIgnored` → `atomicWrite` → `syncNoteToCache` → `notes:updated(external)` → `await feedExternalEditToCrdt`. Awaiting the CRDT feed is what makes a move into an **open** note survive; `notes:update` and the MCP `vault_update_note` append path both skip it and get silently overwritten by the next writeback. `append-blocks.test.ts` asserts that order directly.
- **Move to is hidden on attachment blocks on purpose.** Attachment bytes live under `attachments/<owning note id>/`, and the target note's `attachmentReferences` row never gains the id — the embed would resolve locally and be broken on every other device. Local-only correctness is the failure mode worth refusing.

Comment reuses the existing CriticMarkup review composer (`openCommentComposer`), so there is no new table, sync type or panel. Colors keeps BlockNote's own item untouched.

Out of scope, deliberately: the search box (5 items do not need one), `Copy link to block` (block anchors do not scroll yet — `wikilink-resolver.ts:101` — so the copied link would go nowhere), Edit icon, Suggest edits, Ask AI, Skills.

Backward compatibility: additive only. New IPC channel, no change to an existing one; no schema or migration; markdown round-trip unchanged.

## Release note

Blocks now have a fuller menu on their drag handle: turn a block into another type, set its colour, duplicate it (⌘D), move it to another note, delete it, or comment on it.

## Test plan

Automated:

- `pnpm ipc:generate && pnpm ipc:check` — pass
- `pnpm typecheck` (node/web/test) — pass
- `pnpm lint` — pass, zero warnings on the new files
- `pnpm --filter @memry/desktop test:renderer` — 716/716 files, 8867 tests
- `apps/desktop/src/main/vault/append-blocks.test.ts` (new) — 7/7, including the write-order assertion
- `pnpm --filter @memry/desktop i18n:check` — pass
- `pnpm docs:build` — pass
- `BUILD_BEFORE_TEST=1 pnpm test:e2e tests/e2e/editor-drag-handle-menu.e2e.ts` — **5/5**, with the two pre-existing colour/delete tests unchanged and green

The new E2E `moves a block into another note and removes it from the source` reads the target note's body back **from disk**, so the closed-note write plus CRDT feed is covered end to end rather than asserted in a mock.

Manual (`pnpm dev`): turn into with an indented toggle (children survive), colour persistence across reopen, ⌘D, comment round-trip into `{>> <<}`, and a move into a note open in another tab — the block appears immediately and is still there after the writeback window.

Note: `pnpm --filter @memry/desktop test:main` failed once on `src/main/sync/attachments.test.ts` with an Electron binary path error in this fresh worktree; run alone it passes 37/37 and the file imports nothing this branch touches.
