### PR TITLE
fix(calendar): stop ticking Google calendars that are never fetched (#1976)

### DIFF
--- a/apps/desktop/src/main/ipc/calendar-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/calendar-handlers.test.ts
@@ -657,6 +657,62 @@ describe('calendar-handlers', () => {
     })
   })
 
+  it('fetches a calendar as soon as it is switched on', async () => {
+    registerCalendarHandlers()
+
+    db.run(sql`
+      INSERT INTO calendar_sources (
+        id, provider, kind, account_id, remote_id, title, timezone,
+        is_selected, sync_status, created_at, modified_at
+      )
+      VALUES (
+        ${'google-calendar-secondary'}, ${'google'}, ${'calendar'}, ${'google-account-1'},
+        ${'remote-calendar-secondary'}, ${'Personal'}, ${'Europe/Istanbul'}, ${0}, ${'idle'},
+        ${'2026-04-12T08:01:00.000Z'}, ${'2026-04-12T08:01:00.000Z'}
+      )
+    `)
+
+    await invokeHandler(CalendarChannels.invoke.UPDATE_SOURCE_SELECTION, {
+      id: 'google-calendar-secondary',
+      isSelected: true
+    })
+
+    // Switching one OFF purges its events immediately. Switching one on used to
+    // change nothing until the next runner pass, so the toggle read as dead in
+    // exactly the direction the user notices.
+    expect(mockSyncGoogleCalendarSource).toHaveBeenCalledWith(
+      expect.anything(),
+      'google-calendar-secondary'
+    )
+  })
+
+  it('does not re-fetch a calendar that was already on, nor one switched off', async () => {
+    registerCalendarHandlers()
+
+    db.run(sql`
+      INSERT INTO calendar_sources (
+        id, provider, kind, account_id, remote_id, title, timezone,
+        is_selected, sync_status, created_at, modified_at
+      )
+      VALUES (
+        ${'google-calendar-on'}, ${'google'}, ${'calendar'}, ${'google-account-1'},
+        ${'remote-calendar-on'}, ${'Work'}, ${'Europe/Istanbul'}, ${1}, ${'ok'},
+        ${'2026-04-12T08:01:00.000Z'}, ${'2026-04-12T08:01:00.000Z'}
+      )
+    `)
+
+    await invokeHandler(CalendarChannels.invoke.UPDATE_SOURCE_SELECTION, {
+      id: 'google-calendar-on',
+      isSelected: true
+    })
+    await invokeHandler(CalendarChannels.invoke.UPDATE_SOURCE_SELECTION, {
+      id: 'google-calendar-on',
+      isSelected: false
+    })
+
+    expect(mockSyncGoogleCalendarSource).not.toHaveBeenCalled()
+  })
+
   it('brings every calendar on the account into the picker when connecting', async () => {
     registerCalendarHandlers()
     mockConnectGoogleCalendar.mockResolvedValue({

--- a/apps/desktop/src/main/ipc/calendar-handlers.ts
+++ b/apps/desktop/src/main/ipc/calendar-handlers.ts
@@ -646,6 +646,17 @@ export function registerCalendarHandlers(): void {
               calendarId: updated.remoteId
             })
           }
+
+          // The mirror image of the purge above. Turning a calendar on used to
+          // change nothing the user could see until the next runner pass, so
+          // the toggle read as broken in exactly the way turning one off does
+          // not. Fire and forget: the toggle must not wait on the network, and
+          // the sync emits its own change events when the events land.
+          if (input.isSelected && !existing.isSelected) {
+            void syncGoogleCalendarSource(db, updated.id).catch((err) => {
+              log.warn('Immediate sync after enabling a Google calendar failed', err)
+            })
+          }
         }
 
         return { success: true, source: updated }

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
@@ -269,10 +269,19 @@ export function CalendarShell({
               {importedSources.map((source) => (
                 <label
                   key={source.id}
+                  data-testid={`calendar-filter-source-${source.id}`}
                   className="flex items-center justify-between gap-3 text-sm text-foreground"
                 >
-                  <span>{source.title}</span>
+                  <span className="flex min-w-0 flex-col">
+                    <span className="truncate">{source.title}</span>
+                    {!source.isSelected && (
+                      <span className="text-xs text-muted-foreground">
+                        {t('filter.not-syncing')}
+                      </span>
+                    )}
+                  </span>
                   <Checkbox
+                    className="shrink-0"
                     aria-label={source.title}
                     checked={selectedImportedSourceIds.includes(source.id)}
                     disabled={!showImportedCalendars}

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-sidebar.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { CalendarSidebar } from './calendar-sidebar'
+import type { CalendarSourceRecord } from '@/services/calendar-service'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key })
+}))
+
+function source(overrides: Partial<CalendarSourceRecord>): CalendarSourceRecord {
+  return {
+    id: 'google-calendar:primary',
+    provider: 'google',
+    kind: 'calendar',
+    accountId: 'work@example.com',
+    remoteId: 'work@example.com',
+    title: 'Work',
+    timezone: 'Europe/Istanbul',
+    color: '#0ea5e9',
+    isPrimary: true,
+    isSelected: true,
+    isMemryManaged: false,
+    syncCursor: null,
+    syncStatus: 'ok',
+    lastSyncedAt: null,
+    lastError: null,
+    metadata: null,
+    archivedAt: null,
+    syncedAt: null,
+    createdAt: '2026-08-29T08:00:00.000Z',
+    modifiedAt: '2026-08-29T08:00:00.000Z',
+    ...overrides
+  }
+}
+
+const PRIMARY = source({})
+const SECONDARY = source({
+  id: 'google-calendar:personal',
+  remoteId: 'personal@example.com',
+  title: 'Personal',
+  isPrimary: false,
+  isSelected: false
+})
+
+function renderSidebar(props: Partial<React.ComponentProps<typeof CalendarSidebar>> = {}) {
+  const onToggleImportedSource = vi.fn()
+  render(
+    <CalendarSidebar
+      showMemryItems
+      showImportedCalendars
+      importedSources={[PRIMARY, SECONDARY]}
+      selectedImportedSourceIds={[PRIMARY.id]}
+      onToggleMemryItems={vi.fn()}
+      onToggleImportedCalendars={vi.fn()}
+      onToggleImportedSource={onToggleImportedSource}
+      {...props}
+    />
+  )
+  return { onToggleImportedSource }
+}
+
+describe('CalendarSidebar', () => {
+  it('does not tick a calendar nothing is fetching', () => {
+    // The reported bug: discovery only pre-selects the primary calendar, so
+    // every other one was listed with a tick beside it and never produced a
+    // single event.
+    renderSidebar()
+
+    expect(screen.getByRole('checkbox', { name: 'Work' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Personal' })).not.toBeChecked()
+  })
+
+  it('says why an unticked calendar is empty', () => {
+    renderSidebar()
+
+    const secondaryRow = screen.getByTestId(`calendar-filter-source-${SECONDARY.id}`)
+    expect(secondaryRow).toHaveTextContent('filter.not-syncing')
+
+    const primaryRow = screen.getByTestId(`calendar-filter-source-${PRIMARY.id}`)
+    expect(primaryRow).not.toHaveTextContent('filter.not-syncing')
+  })
+
+  it('reports the toggle so the page can subscribe the calendar', async () => {
+    const user = userEvent.setup()
+    const { onToggleImportedSource } = renderSidebar()
+
+    await user.click(screen.getByRole('checkbox', { name: 'Personal' }))
+
+    expect(onToggleImportedSource).toHaveBeenCalledWith(SECONDARY.id)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-sidebar.tsx
@@ -24,7 +24,7 @@ export function CalendarSidebar({
   const { t } = useT('calendar')
 
   return (
-    <aside className="w-full shrink-0 border-b border-border/70 bg-muted/20 px-6 py-5 xl:w-72 xl:border-b-0 xl:border-r">
+    <aside className="w-full shrink-0 border-b border-border/70 bg-muted/20 px-6 py-5 xl:w-72 xl:border-b-0 xl:border-e">
       <div className="space-y-6">
         <div className="space-y-3">
           <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
@@ -61,10 +61,20 @@ export function CalendarSidebar({
             importedSources.map((source) => (
               <label
                 key={source.id}
+                data-testid={`calendar-filter-source-${source.id}`}
                 className="flex items-center justify-between gap-3 rounded-xl border border-border/70 bg-card/70 px-3 py-2 text-sm text-foreground"
               >
-                <span>{source.title}</span>
+                <span className="flex min-w-0 flex-col">
+                  <span className="truncate">{source.title}</span>
+                  {/* Discovery only pre-selects the primary calendar, so this
+                      row is normal, not an error. Without the caption an empty
+                      calendar is indistinguishable from one with no events. */}
+                  {!source.isSelected && (
+                    <span className="text-xs text-muted-foreground">{t('filter.not-syncing')}</span>
+                  )}
+                </span>
                 <Checkbox
+                  className="shrink-0"
                   aria-label={source.title}
                   checked={selectedImportedSourceIds.includes(source.id)}
                   disabled={!showImportedCalendars}

--- a/apps/desktop/src/renderer/src/pages/calendar-callbacks.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-callbacks.test.tsx
@@ -87,13 +87,15 @@ const mocks = vi.hoisted(() => ({
   }),
   closeForDayView: vi.fn(),
   snooze: vi.fn(),
+  sourceMutate: vi.fn(),
   unsnooze: vi.fn(),
   updateEvent: vi.fn()
 }))
 
 vi.mock('@tanstack/react-query', () => ({
   useQuery: () => ({ data: { sources: mocks.calendarSources }, isLoading: false }),
-  useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries })
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+  useMutation: () => ({ mutate: mocks.sourceMutate })
 }))
 
 vi.mock('@/components/calendar', () => ({
@@ -517,6 +519,35 @@ describe('CalendarPage callback coverage', () => {
     await waitFor(() =>
       expect(mocks.lastShellProps?.selectedImportedSourceIds).toEqual(['google-work'])
     )
+  })
+
+  it('leaves a calendar nothing polls unticked, and subscribes it when ticked', async () => {
+    // Discovery only pre-selects the primary calendar. Every other one used to
+    // be handed to the shell as selected, so the calendar page showed a tick
+    // beside a calendar that never produced a single event.
+    mocks.calendarSources = [
+      source('google-work', 'Work'),
+      { ...source('google-home', 'Home'), isSelected: false }
+    ]
+    renderPage()
+
+    await waitFor(() =>
+      expect(mocks.lastShellProps?.selectedImportedSourceIds).toEqual(['google-work'])
+    )
+
+    mocks.lastShellProps?.onToggleImportedSource('google-home')
+
+    expect(mocks.sourceMutate).toHaveBeenCalledWith('google-home')
+  })
+
+  it('does not re-subscribe a calendar that is already syncing', async () => {
+    renderPage()
+
+    await waitFor(() => expect(mocks.lastShellProps).not.toBeNull())
+    mocks.lastShellProps?.onToggleImportedSource('google-home')
+    mocks.lastShellProps?.onToggleImportedSource('google-home')
+
+    expect(mocks.sourceMutate).not.toHaveBeenCalled()
   })
 
   it('creates, updates, quick-saves, promotes, and dismisses popovers', async () => {

--- a/apps/desktop/src/renderer/src/pages/calendar-view-state.test.ts
+++ b/apps/desktop/src/renderer/src/pages/calendar-view-state.test.ts
@@ -9,7 +9,8 @@ import {
   parseImportedSourceIds,
   parseVisualTypes,
   resolveAnchorSync,
-  resolveSelectedSourceIds
+  resolveSelectedSourceIds,
+  resolveSourceToggle
 } from './calendar-view-state'
 
 describe('calendar view-state keys', () => {
@@ -92,22 +93,75 @@ describe('parseImportedSourceIds', () => {
 })
 
 describe('resolveSelectedSourceIds', () => {
-  it('shows every source until the user picks a subset', () => {
-    expect(resolveSelectedSourceIds(null, ['a', 'b'])).toEqual(['a', 'b'])
+  const synced = (id: string) => ({ id, isSelected: true })
+  const unsynced = (id: string) => ({ id, isSelected: false })
+
+  it('shows every synced source until the user picks a subset', () => {
+    expect(resolveSelectedSourceIds(null, [synced('a'), synced('b')])).toEqual(['a', 'b'])
   })
 
   it('honours "chose nothing" rather than falling back to everything', () => {
-    expect(resolveSelectedSourceIds([], ['a', 'b'])).toEqual([])
+    expect(resolveSelectedSourceIds([], [synced('a'), synced('b')])).toEqual([])
   })
 
   it('drops a source that has since disappeared', () => {
-    expect(resolveSelectedSourceIds(['a', 'gone'], ['a', 'b'])).toEqual(['a'])
+    expect(resolveSelectedSourceIds(['a', 'gone'], [synced('a'), synced('b')])).toEqual(['a'])
   })
 
   it('does not add a source connected after the user chose', () => {
     // Deriving "all" only applies to a tab that never chose. Once there is a
     // choice, a newly connected calendar stays off until it is switched on.
-    expect(resolveSelectedSourceIds(['a'], ['a', 'b'])).toEqual(['a'])
+    expect(resolveSelectedSourceIds(['a'], [synced('a'), synced('b')])).toEqual(['a'])
+  })
+
+  it('never pre-selects a source nothing polls', () => {
+    // Discovery only pre-selects the primary calendar. Every other calendar on
+    // the account arrives unselected, and used to be handed back here as if it
+    // were on — the tick the user saw next to a calendar that never produced a
+    // single event.
+    expect(resolveSelectedSourceIds(null, [synced('a'), unsynced('b')])).toEqual(['a'])
+  })
+
+  it('drops a stored source that has since been switched off', () => {
+    expect(resolveSelectedSourceIds(['a', 'b'], [synced('a'), unsynced('b')])).toEqual(['a'])
+  })
+})
+
+describe('resolveSourceToggle', () => {
+  const synced = { id: 'primary', isSelected: true }
+  const unsynced = { id: 'personal', isSelected: false }
+  const sources = [synced, unsynced]
+
+  it('subscribes a source the sweep never polls', () => {
+    // The reported bug: ticking here only filtered events that were never
+    // fetched, so the calendar stayed empty and the tick looked broken.
+    expect(resolveSourceToggle('personal', ['primary'], sources)).toEqual({
+      nextSelectedIds: ['primary', 'personal'],
+      subscribeSourceId: 'personal'
+    })
+  })
+
+  it('does not re-subscribe a source that is already syncing', () => {
+    expect(resolveSourceToggle('primary', [], sources)).toEqual({
+      nextSelectedIds: ['primary'],
+      subscribeSourceId: null
+    })
+  })
+
+  it('switching one off is a view filter, never an unsubscribe', () => {
+    // Unsubscribing purges the mirrored events. That belongs to the Settings
+    // picker, not to a checkbox that reads as "show this on the calendar".
+    expect(resolveSourceToggle('primary', ['primary', 'personal'], sources)).toEqual({
+      nextSelectedIds: ['personal'],
+      subscribeSourceId: null
+    })
+  })
+
+  it('does not subscribe a source that is no longer listed', () => {
+    expect(resolveSourceToggle('gone', ['primary'], sources)).toEqual({
+      nextSelectedIds: ['primary', 'gone'],
+      subscribeSourceId: null
+    })
   })
 })
 

--- a/apps/desktop/src/renderer/src/pages/calendar-view-state.ts
+++ b/apps/desktop/src/renderer/src/pages/calendar-view-state.ts
@@ -121,19 +121,65 @@ export const parseVisualTypes = (raw: unknown): CalendarProjectionVisualType[] |
     : undefined
 
 /**
- * The sources actually shown: every available source until the user picks a
- * subset, then their pick, minus anything that has since disappeared.
+ * The sources actually shown: every synced source until the user picks a
+ * subset, then their pick, minus anything that has since disappeared or been
+ * switched off.
  *
  * Derived rather than stored so there is no first-load seeding effect to fight,
  * and so a newly connected calendar cannot be quietly added to a selection the
  * user made by hand.
+ *
+ * A source with `isSelected: false` is never polled, so it has no events to
+ * show and no tick may claim otherwise. Discovery only pre-selects the primary
+ * calendar, so on a multi-calendar account most rows arrive in that state; this
+ * used to hand back every id regardless and draw them all ticked.
  */
 export function resolveSelectedSourceIds(
   stored: string[] | null,
-  availableIds: string[]
+  sources: readonly { id: string; isSelected: boolean }[]
 ): string[] {
-  if (stored === null) return availableIds
-  return stored.filter((id) => availableIds.includes(id))
+  const syncedIds = sources.filter((source) => source.isSelected).map((source) => source.id)
+  if (stored === null) return syncedIds
+  return stored.filter((id) => syncedIds.includes(id))
+}
+
+export interface SourceToggleDecision {
+  /** The tab's new explicit selection. */
+  nextSelectedIds: string[]
+  /**
+   * The source to subscribe through `calendar:update-source-selection`, or
+   * `null` when the toggle is purely a view filter.
+   */
+  subscribeSourceId: string | null
+}
+
+/**
+ * What a tick on the calendar page's source list means.
+ *
+ * Ticking a source the sweep never polls has to subscribe it — filtering a set
+ * of events that were never fetched is what made this checkbox look dead.
+ * Unticking only hides it here: the source keeps syncing, so turning it back on
+ * is instant and nothing already mirrored is thrown away. That asymmetry is
+ * deliberate. The Settings picker owns the destructive half, where unticking
+ * purges the mirrored events.
+ */
+export function resolveSourceToggle(
+  sourceId: string,
+  selectedIds: readonly string[],
+  sources: readonly { id: string; isSelected: boolean }[]
+): SourceToggleDecision {
+  if (selectedIds.includes(sourceId)) {
+    return {
+      nextSelectedIds: selectedIds.filter((id) => id !== sourceId),
+      subscribeSourceId: null
+    }
+  }
+
+  const source = sources.find((candidate) => candidate.id === sourceId)
+  return {
+    nextSelectedIds: [...selectedIds, sourceId],
+    subscribeSourceId: source && !source.isSelected ? sourceId : null
+  }
 }
 
 export interface AnchorSyncInput {

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import {
   CalendarShell,
@@ -31,6 +31,7 @@ import { useUndoTracker } from '@/hooks/use-undo'
 import {
   calendarService,
   promoteExternalCalendarEvent,
+  updateGoogleCalendarSourceSelection,
   type CalendarProjectionItem,
   type CalendarProjectionVisualType
 } from '@/services/calendar-service'
@@ -53,6 +54,7 @@ import {
   readGlobalCalendarView,
   resolveAnchorSync,
   resolveSelectedSourceIds,
+  resolveSourceToggle,
   writeGlobalCalendarView
 } from './calendar-view-state'
 import { DeleteCalendarEventDialog } from '@/components/calendar/delete-calendar-event-dialog'
@@ -366,26 +368,46 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
   )
 
   const selectedImportedSourceIds = useMemo(
-    () =>
-      resolveSelectedSourceIds(
-        chosenImportedSourceIds,
-        importedSources.map((source) => source.id)
-      ),
+    () => resolveSelectedSourceIds(chosenImportedSourceIds, importedSources),
     [chosenImportedSourceIds, importedSources]
   )
 
+  // Ticking a calendar the sweep never polls has to subscribe it. Filtering a
+  // set of events that were never fetched is what made this checkbox look dead.
+  const enableSourceMutation = useMutation({
+    mutationFn: (sourceId: string) =>
+      updateGoogleCalendarSourceSelection({ id: sourceId, isSelected: true }),
+    onSuccess: async (result) => {
+      const tCalendar = getI18n().getFixedT(null, 'calendar')
+      if (!result.success) {
+        toast.error(result.error ?? tCalendar('filter.enable-source-failed'))
+        return
+      }
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['calendar', 'sources'] }),
+        queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
+      ])
+    },
+    onError: (err) => {
+      log.error('Failed to enable calendar source', err)
+      const tCalendar = getI18n().getFixedT(null, 'calendar')
+      toast.error(extractErrorMessage(err, tCalendar('filter.enable-source-failed')))
+    }
+  })
+
   // Toggling records an EXPLICIT selection: the first toggle turns the derived
-  // "all sources" into a real list minus the one just switched off.
+  // "every synced source" into a real list minus the one just switched off.
   const handleToggleImportedSource = useCallback(
     (sourceId: string) => {
-      const current = selectedImportedSourceIds
-      setChosenImportedSourceIds(
-        current.includes(sourceId)
-          ? current.filter((id) => id !== sourceId)
-          : [...current, sourceId]
+      const { nextSelectedIds, subscribeSourceId } = resolveSourceToggle(
+        sourceId,
+        selectedImportedSourceIds,
+        importedSources
       )
+      if (subscribeSourceId) enableSourceMutation.mutate(subscribeSourceId)
+      setChosenImportedSourceIds(nextSelectedIds)
     },
-    [selectedImportedSourceIds, setChosenImportedSourceIds]
+    [selectedImportedSourceIds, setChosenImportedSourceIds, importedSources, enableSourceMutation]
   )
 
   const filteredItems = useMemo(

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -155,7 +155,13 @@ You can link more than one Google account. In [Settings → Calendar](/user-guid
 
 Each linked account gets its own group listing every calendar on that account — shared calendars, team calendars, holiday calendars, all of them — with a checkbox each. Tick a calendar to bring its events into memrynote; untick it to take them out. Only your primary calendar is ticked when an account is first linked, so nothing else arrives until you ask for it.
 
-**Unticking a calendar deletes its events from memrynote.** Nothing refreshes a calendar you have turned off, so its events are removed rather than left behind to go stale, and the removal reaches your other devices. Tick it again and the events are fetched fresh. Events you [promoted to your vault](#promote-external-events) are your own copy and are not affected.
+**Unticking a calendar deletes its events from memrynote.** Nothing refreshes a calendar you have turned off, so its events are removed rather than left behind to go stale, and the removal reaches your other devices. Tick it again and the events are fetched fresh — straight away, not on the next sync. Events you [promoted to your vault](#promote-external-events) are your own copy and are not affected.
+
+### Turning a Calendar On from the Calendar Page
+
+The calendar page lists the same calendars under **GOOGLE CALENDARS** — in the sidebar on a wide window, in the filter popover on a narrow one. That list shows which calendars are actually being fetched: a calendar you have not turned on is shown unticked and marked **Not syncing**, rather than looking like an empty calendar.
+
+Tick one there and memrynote turns it on for you and fetches its events immediately, exactly as ticking it in Settings does. Unticking it here only hides it from this calendar tab — the calendar keeps syncing and nothing is deleted, so ticking it back on is instant. To stop syncing a calendar and remove its events, untick it in [Settings → Calendar](/user-guide/settings#google-calendar).
 
 The calendar list refreshes on every sync, so a calendar you create in Google later shows up on its own. If you linked an account before this existed, your other calendars appear after the next sync — no need to reconnect.
 

--- a/packages/i18n/src/locales/en/calendar.json
+++ b/packages/i18n/src/locales/en/calendar.json
@@ -30,7 +30,9 @@
     "imported-calendars": "Imported calendars",
     "event-types": "Event types",
     "google-calendars": "Google calendars",
-    "refresh-google-calendars": "Refresh Google calendars"
+    "refresh-google-calendars": "Refresh Google calendars",
+    "not-syncing": "Not syncing · tick to turn on",
+    "enable-source-failed": "Could not turn that calendar on."
   },
   "visual-type": {
     "event": "Event",


### PR DESCRIPTION
Closes #1976

## Summary

The calendar page listed every Google calendar with a tick beside it while only the ones actually subscribed were ever fetched. A user who linked an account owning three calendars saw three ticks and events from one.

Two things were conflated. Discovery only pre-selects the primary calendar (`sync-service.ts`: `isSelected: existing ? existing.isSelected : remote.isPrimary`) and the sweep polls `selectedOnly: true`. But the calendar page's source list never read `isSelected` — `resolveSelectedSourceIds(null, ids)` handed back every listed source. The checkbox was renderer-local, so ticking it filtered a set of events that had never been fetched. The control that does something lives in Settings → Calendar, with nothing on screen to say so.

- `resolveSelectedSourceIds` now derives from `isSelected` in both branches, so a source nothing polls is never ticked. This drives both the sidebar and the narrow-window filter popover.
- Ticking a source on the calendar page subscribes it through the same `calendar:update-source-selection` IPC the Settings picker uses. Unticking stays a view filter — the source keeps syncing, nothing mirrored is purged, turning it back on is instant. The destructive half stays in Settings, where it is labelled.
- Unticked rows carry a **Not syncing · tick to turn on** caption, so an unsubscribed calendar is not mistaken for one with no events.
- `UPDATE_SOURCE_SELECTION` now fetches the calendar immediately when it is switched on, mirroring the purge that already ran when switching one off. Previously the toggle changed nothing visible until the next runner pass, on either screen — the second-order half of the report.

The discovery default is deliberately unchanged: linking an account that owns five calendars still pre-selects only the primary. That is defensible for a noisy shared account, and it is now visible and one click to change, which is what the issue asked for.

## Release note

The calendar page no longer shows a tick beside Google calendars it isn't fetching. Calendars you haven't turned on are listed unticked and marked "Not syncing" — tick one there to turn it on, and its events arrive right away instead of on the next sync.

## Test plan

- `pnpm --filter @memry/desktop test:renderer` — 717 files, 8870 passing. New: `calendar-sidebar.test.tsx` (unsynced row unticked + captioned), `calendar-view-state.test.ts` (`resolveSelectedSourceIds` never pre-selects an unpolled source; `resolveSourceToggle` subscribes on the way on, filters on the way off), `calendar-callbacks.test.tsx` (page hands the shell only synced ids, and fires the mutation when an unsynced one is ticked).
- `pnpm --filter @memry/desktop exec vitest run --project main src/main/ipc/calendar-handlers.test.ts` — 21 passing, incl. immediate fetch on turn-on and no re-fetch when already on or being switched off.
- `pnpm lint`, `pnpm --filter @memry/desktop typecheck`, `pnpm --filter @memry/desktop i18n:check`, `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build` — all green.
- `@memry/mobile` typecheck is red on `origin/main` (expo-router generated route types); untouched here.