### PR TITLE
feat(release-notes): add release notes for version 2026.903.1

### DIFF
--- a/release-notes/2026.903.1.md
+++ b/release-notes/2026.903.1.md
@@ -1,0 +1,42 @@
+## New Features
+
+- 🧱 Block side menu — the drag handle now opens a fuller menu to change a block's type or colour, duplicate it with ⌘D, move it to another note, delete it, or leave a comment.
+- 🪟 Minimize to tray — turn on Window Behavior in Settings → General and closing the window keeps Memry running in the system tray.
+- ✅ Obsidian task import — checklist lines written with the Obsidian Tasks plugin now come in as real Memry tasks.
+- 🔤 System font picker — the Font Family setting lists every font installed on your computer, each shown in its own typeface with a search box, replacing the old custom font field.
+- 🎨 Canvas links in Related — you can now link canvases from a task's Related picker.
+- 📐 Collapsible sidebar navigation — the top navigation block in the sidebar can be folded away.
+
+## Improvements
+
+- 🚀 Much faster new-device setup — your vault opens in seconds instead of minutes while notes and attachments download in the background.
+- 🔡 Font size slider — interface font size is now a pixel slider you drag instead of three fixed sizes, and your current size carries over.
+- ⚡ Faster first sync — seeding a vault no longer pays a round trip per note.
+- 🔔 Quieter updates — release notes now open in a background tab instead of stealing focus.
+
+## Fixes
+
+- 🛡️ Windows updates can't destroy your install — a failed or interrupted update now restores the previous version automatically, and updates no longer apply while Windows is shutting down.
+- 📄 Your markdown stays yours — notes written in another app are no longer rewritten, keeping bullets, emphasis, headings, rules, line breaks, reference links, and code fences exactly as their author wrote them.
+- 🔄 Sync no longer stalls on big backlogs — when the server refuses a large batch the client retries with smaller ones until it drains.
+- 💬 Quotes survive saving — multi-paragraph and nested blockquotes are written back intact instead of being flattened.
+- 🗂️ Toggles keep their shape — blank lines around a collapsible section are preserved, hand-written `<details>` blocks are left alone, and fold state is remembered.
+- 📅 One day boundary everywhere — the Journal day panel, search date filters, the Home board and the calendar widget now agree on which day an event belongs to, using your local time.
+- 🕐 Live calendar widget — the Home calendar stays current in a background tab and counts only the items it actually shows.
+- 🖼️ Images in exports — exported PDFs show embedded images and exported HTML keeps them after you move or send the file.
+- ↔️ Alignment sticks — centre, right and justified text stays put when you leave a note and restart the app.
+- ⌨️ Multi-block indenting — Tab and Shift+Tab indent or outdent every block in a selection, and one undo reverts the whole step.
+- 📊 Table columns remember their width — a dragged column width now survives reopening the note, and inline content inside table cells stays intact.
+- 🚫 Invalid task dates refused — an imported line with a date the calendar does not have is left as written and a message names the refused date.
+- ☑️ Honest checkboxes — an imported checklist line with no matching task stays a plain checkbox instead of pretending to be an uneditable task.
+- 🔢 Correct project task counts — subtasks count under their parent, tasks with a deleted status appear in the project's first status, and delete dialogs no longer push the confirm button off screen.
+- 🏷️ Property fixes — you can type spaces in property values again, and options stop being dropped or duplicated.
+- ⏰ Reminders replace, not pile up — changing a journal or note reminder's time moves the one you had, and the picker lets you remove it.
+- 📁 Leave a project from its chips — remove a file from a project via the chips under its title, without deleting either.
+- 🧩 Sidebar remembers itself — a closed sidebar stays closed across restarts and vault switches.
+- 🔖 Tag hub creates tags — the New tag button now actually makes one.
+- 🔗 Links and mentions survive reload — inline mentions, link references, date pills, callouts and CriticMarkup stay intact through external edits and reopening.
+- ✍️ Spell-check in context — spelling suggestions appear in the right-click menu, with one menu per secondary click.
+- 💠 Nested quotes keep their level — a lazily nested quote is no longer deleted on save.
+- 🎛️ Task drawer closes cleanly — the task detail drawer now unmounts when dismissed.
+- 🎨 Styles load reliably — the app resolves its base stylesheet correctly regardless of where it was launched from.


### PR DESCRIPTION
## Summary

Release notes for **v2026-09-03**, which shipped from `e7d8e73d2` (`fix(editor): keep the block side menu on the text line for every block type`).

Scope check against the tag: the file covers the block side menu (#1974) and everything before it, and correctly omits `feat(editor): fold a bullet's children` (#1975) and `fix(calendar): stop ticking Google calendars that are never fetched` (#1977) — both landed after the tag was cut and belong to the next release.

## Release note

none

## Test plan

- Content only; no code paths touched.
- `pnpm docs:impact --base origin/main --strict` — no docs-relevant files in the diff.