### PR TITLE
feat(mind-map): navigate the map from the outline, and open on the current section

### DIFF
--- a/apps/desktop/src/renderer/src/components/note-sidebar-surfaces.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note-sidebar-surfaces.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -231,6 +231,30 @@ describe('note and sidebar cold surfaces', () => {
     expect(screen.getByText('Top bar')).toBeInTheDocument()
     expect(screen.getByText('Note body')).toBeInTheDocument()
     expect(marqueeRef).toHaveBeenCalled()
+  })
+
+  it('reports the heading the reader is on, so the mind map knows where to open', async () => {
+    const onActiveHeadingChange = vi.fn()
+    const headings = [
+      { id: 'intro', level: 2, text: 'Intro', position: 0 },
+      { id: 'details', level: 3, text: 'Details', position: 40 }
+    ]
+
+    render(
+      <NoteLayout headings={headings} onActiveHeadingChange={onActiveHeadingChange}>
+        <article>
+          <h2 data-id="intro">Intro</h2>
+          <h3 data-id="details">Details</h3>
+        </article>
+      </NoteLayout>
+    )
+
+    // Reported rather than lifted: nothing above this layout re-renders when
+    // the reader scrolls past a heading, but the note page still has to know
+    // which one they were on when they ask for the map.
+    await waitFor(() => expect(onActiveHeadingChange).toHaveBeenCalled())
+    const reported = onActiveHeadingChange.mock.calls.at(-1)?.[0]
+    expect(headings.map((heading) => heading.id)).toContain(reported)
   })
 
   it('hangs the comment rail off the centered content column', () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.css
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.css
@@ -15,3 +15,46 @@
 .mind-map-surface[data-node-hover='true'] canvas {
   cursor: pointer !important;
 }
+
+/**
+ * The ring that marks the box an outline click sent the camera to.
+ *
+ * Hold, then fade. The hold covers the camera's flight (`FOCUS_CAMERA_MS`) plus
+ * a beat after it lands, so the mark is still there when the map settles —
+ * a ring that faded on the way would answer "where did I just go?" with nothing.
+ * The element is unmounted when the flash ends, so the animation never repeats.
+ *
+ * No transform and no scale: the ring is positioned in viewport pixels that are
+ * recomputed against the live camera every frame, and animating its geometry
+ * here would fight that arithmetic.
+ *
+ * The DURATION is set inline from `FOCUS_FLASH_MS`, which is also what unmounts
+ * the ring — one number, so the fade can neither outlive the element nor finish
+ * while it is still on screen.
+ */
+@keyframes mind-map-focus-flash {
+  0%,
+  75% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.mind-map-focus-ring {
+  animation-name: mind-map-focus-flash;
+  animation-timing-function: ease-out;
+  animation-fill-mode: forwards;
+}
+
+/**
+ * A reader who asked for less motion still gets the mark — it is what tells
+ * them where the click went — just without the fade.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .mind-map-focus-ring {
+    animation-name: none;
+    opacity: 1;
+  }
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.test.tsx
@@ -57,7 +57,8 @@ const HOVER_LABELS: ReadonlyMap<string, MindMapHoverLabel> = new Map([
 const mocks = vi.hoisted(() => ({
   scrollToContent: vi.fn(),
   updateScene: vi.fn(),
-  onChange: vi.fn(() => () => {}),
+  /** Takes the handler, so a test can drive a camera change by calling it. */
+  onChange: vi.fn((_handler: () => void) => () => {}),
   /** The camera, as a test can move it. */
   appState: { scrollX: 0, scrollY: 0, zoom: { value: 1 }, offsetLeft: 0, offsetTop: 0 }
 }))
@@ -104,13 +105,16 @@ const BUILT_ELEMENTS = [
   { type: 'rectangle', id: 'built-1' }
 ] as unknown as readonly MindMapElement[]
 
-function mountSurface(): { controls: () => MindMapControls; unmount: () => void } {
+function mountSurface(
+  initialFocusHref: string | null = null
+): { controls: () => MindMapControls; unmount: () => void } {
   let latest: MindMapControls | null = null
   const view = render(
     <MindMapCanvas
       elements={BUILT_ELEMENTS}
       hoverLabels={HOVER_LABELS}
       onOpenLink={openLink}
+      initialFocusHref={initialFocusHref}
       onControlsChange={(next) => {
         latest = next
       }}
@@ -174,12 +178,157 @@ describe('MindMapCanvas controls', () => {
     )
     expect(latest).toEqual({
       fit: expect.any(Function),
+      focus: expect.any(Function),
       copyImage: expect.any(Function),
       copyVector: expect.any(Function)
     })
 
     view.unmount()
     expect(latest).toBeNull()
+  })
+
+  it('opens framed whole when the reader had nowhere in particular to be', () => {
+    mountSurface(null)
+
+    expect(mocks.scrollToContent).toHaveBeenCalledTimes(1)
+    expect(mocks.scrollToContent).toHaveBeenCalledWith(undefined, {
+      fitToContent: true,
+      animate: false
+    })
+  })
+
+  it('opens on the section the reader was in, in the same frame as the fit', () => {
+    mountSurface(ITEM_HREF)
+
+    // The fit is what decides the ZOOM — there is no other source for a
+    // sensible one — and the centring lands on top of it before anything is
+    // painted, so the whole-map view is never something the user sees go past.
+    expect(mocks.scrollToContent.mock.calls).toEqual([
+      [undefined, { fitToContent: true, animate: false }],
+      [LIVE_ELEMENTS[1], { animate: false }]
+    ])
+  })
+
+  it('falls back to the whole drawing when the block it was aimed at was not drawn', () => {
+    // A heading folded behind a "+N more", or dropped at the node cap: the map
+    // is still worth showing, just not from there.
+    mountSurface('memry://note/n1#^b-never-drawn')
+
+    expect(mocks.scrollToContent).toHaveBeenCalledTimes(1)
+    expect(mocks.scrollToContent).toHaveBeenCalledWith(undefined, {
+      fitToContent: true,
+      animate: false
+    })
+  })
+
+  it('centres on one box on focus, and leaves the zoom exactly where it was', () => {
+    const surface = mountSurface()
+    mocks.scrollToContent.mockClear()
+
+    expect(surface.controls().focus(WIKI_HREF)).toBe(true)
+
+    // NEITHER fit option is passed, and that is the whole point: with one, the
+    // library would rescale the picture and take away the reading distance the
+    // user chose from the outline panel they clicked in.
+    // The flight is pinned rather than left to the library's default, because
+    // the ring that marks the arrival has to outlast it.
+    expect(mocks.scrollToContent).toHaveBeenCalledWith(LIVE_ELEMENTS[2], {
+      animate: true,
+      duration: 250
+    })
+  })
+
+  it('rings the box it focused, so the reader can see what the click landed on', () => {
+    const surface = mountSurface()
+
+    act(() => {
+      surface.controls().focus(WIKI_HREF)
+    })
+
+    // The box's own rectangle, through the camera: `(scene + scroll) * zoom`,
+    // which at rest is the scene rectangle itself.
+    const ring = screen.getByTestId('mind-map-focus-ring')
+    expect(ring).toHaveStyle({ left: '200px', top: '100px', width: '160px', height: '40px' })
+    // Decoration on the picture: the outline entry the reader pressed already
+    // named this node in words.
+    expect(ring.parentElement).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('keeps the ring glued to its box while the camera is still flying', async () => {
+    // The camera reports every committed change, a pan tick included, which is
+    // what the ring rides: measured once at the click it would sit where the
+    // box used to be for the whole flight.
+    let notify: (() => void) | undefined
+    mocks.onChange.mockImplementation((handler: () => void) => {
+      notify = handler
+      return () => {}
+    })
+    const surface = mountSurface()
+
+    act(() => {
+      surface.controls().focus(WIKI_HREF)
+    })
+    expect(screen.getByTestId('mind-map-focus-ring')).toHaveStyle({ left: '200px' })
+
+    mocks.appState = { scrollX: -100, scrollY: 0, zoom: { value: 2 }, offsetLeft: 0, offsetTop: 0 }
+    await act(async () => {
+      notify?.()
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+    })
+
+    // `(200 - 100) * 2`, the same transform the affordance anchor uses.
+    expect(screen.getByTestId('mind-map-focus-ring')).toHaveStyle({
+      left: '200px',
+      top: '200px',
+      width: '320px',
+      height: '80px'
+    })
+  })
+
+  it('drops the ring once the flash is over', async () => {
+    vi.useFakeTimers()
+    try {
+      const surface = mountSurface()
+      act(() => {
+        surface.controls().focus(WIKI_HREF)
+      })
+      expect(screen.getByTestId('mind-map-focus-ring')).toBeInTheDocument()
+
+      act(() => {
+        vi.advanceTimersByTime(600)
+      })
+
+      // Unmounted rather than left at zero opacity, so the next focus animates
+      // from the start instead of showing a ring that never fades.
+      expect(screen.queryByTestId('mind-map-focus-ring')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('moves the ring to the second box when a second heading is clicked', () => {
+    const surface = mountSurface()
+
+    act(() => {
+      surface.controls().focus(WIKI_HREF)
+    })
+    act(() => {
+      surface.controls().focus(ITEM_HREF)
+    })
+
+    // One ring, on the box the reader asked for last.
+    expect(screen.getAllByTestId('mind-map-focus-ring')).toHaveLength(1)
+    expect(screen.getByTestId('mind-map-focus-ring')).toHaveStyle({ top: '0px' })
+  })
+
+  it('answers false for a box that is not on the live scene, and moves nothing', () => {
+    const surface = mountSurface()
+    mocks.scrollToContent.mockClear()
+
+    // False is what lets the outline panel fall back to opening the note at
+    // that heading rather than swallowing the click.
+    expect(surface.controls().focus('memry://note/n1#^b-never-drawn')).toBe(false)
+    expect(mocks.scrollToContent).not.toHaveBeenCalled()
   })
 
   it('frames the whole drawing on fit, wherever the user panned to', () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-canvas.tsx
@@ -30,7 +30,7 @@
  * clicking anywhere on a node has always worked.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import {
   Excalidraw,
   convertToExcalidrawElements,
@@ -38,10 +38,17 @@ import {
 } from '@excalidraw/excalidraw'
 import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
 import '@excalidraw/excalidraw/index.css'
+import { useReducedMotion } from 'motion/react'
 import { useTheme } from 'next-themes'
 import { ExternalLink, Link } from '@/lib/icons'
 import { copySceneAsImage, copySceneAsVector, toSkeleton } from './mind-map-export'
-import { hitMindMapBox, mindMapHoverAnchor, type MindMapHitElement } from './mind-map-hover'
+import {
+  hitMindMapBox,
+  mindMapBoxRect,
+  mindMapHoverAnchor,
+  mindMapHrefOf,
+  type MindMapHitElement
+} from './mind-map-hover'
 import type { MindMapElement } from './mind-map-types'
 import './mind-map-canvas.css'
 
@@ -54,6 +61,17 @@ import './mind-map-canvas.css'
 export interface MindMapControls {
   /** Frame the whole drawing again, whatever the user panned or zoomed to. */
   fit: () => void
+  /**
+   * Centre the camera on one box, named by the href it carries, and leave the
+   * zoom alone.
+   *
+   * The zoom is deliberately untouched: this is how the outline panel navigates
+   * a map that is already open, and a jump that also rescaled the picture would
+   * take away the reading distance the user chose. False when no box on the
+   * live scene carries that href, which is the caller's signal to do something
+   * else entirely rather than to leave the click doing nothing.
+   */
+  focus: (href: string) => boolean
   copyImage: () => Promise<void>
   copyVector: () => Promise<void>
 }
@@ -77,6 +95,25 @@ export interface MindMapHoverLabel {
 
 /** How far the pointer may travel between press and release and still be a click. */
 const CLICK_SLOP = 4
+
+/**
+ * How long the camera takes to fly to a focused box.
+ *
+ * Pinned rather than left to the library's own default, because the flash below
+ * has to outlast the flight: a ring that finished while the map was still
+ * moving would mark the arrival of nothing. An upgrade that changed the default
+ * would silently break that relationship.
+ */
+const FOCUS_CAMERA_MS = 250
+
+/**
+ * How long the ring stays on the box, flight included.
+ *
+ * The `mind-map-focus-flash` keyframes hold it solid over the flight and the
+ * beat after it, then fade — so the eye is led to the box rather than shown a
+ * marker that was already gone by the time the map settled.
+ */
+const FOCUS_FLASH_MS = 600
 
 interface MindMapHoverState {
   /**
@@ -104,6 +141,16 @@ interface MindMapCanvasProps {
   /** The deep link of the box that was clicked. See `handleMindMapLinkOpen`. */
   onOpenLink: (href: string) => void
   /**
+   * The box to open on, rather than the whole drawing — the section the user was
+   * reading when they asked for the map.
+   *
+   * Read at the moment the scene is fed, never watched: a value that moved the
+   * camera every time it changed would fight the user for it. Null, or an href
+   * no box carries, leaves the map framed whole, which is the only honest answer
+   * for a note with nothing above the fold to focus on.
+   */
+  initialFocusHref?: string | null
+  /**
    * Called with the controls once the surface is live, and with `null` when it
    * goes away, so the toolbar is never wired to a surface that is not there.
    */
@@ -117,14 +164,25 @@ export function MindMapCanvas({
   elements,
   hoverLabels,
   onOpenLink,
+  initialFocusHref = null,
   onControlsChange
 }: MindMapCanvasProps): React.JSX.Element {
   const { resolvedTheme } = useTheme()
+  const prefersReducedMotion = useReducedMotion()
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null)
   // The same instance as a piece of state, purely so an effect can subscribe to
   // it once it exists: a ref assignment does not re-run one.
   const [api, setApi] = useState<ExcalidrawImperativeAPI | null>(null)
   const [hovered, setHovered] = useState<MindMapHoverState | null>(null)
+  /** The box the outline panel last sent the camera to, while its ring lasts. */
+  const [focusedHref, setFocusedHref] = useState<string | null>(null)
+  const [focusRect, setFocusRect] = useState<{
+    left: number
+    top: number
+    width: number
+    height: number
+  } | null>(null)
+  const flashRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   /** Last seen pointer, so a pan or a zoom can re-answer without a mouse move. */
   const pointerRef = useRef<PointerPosition | null>(null)
   /** Where the press started, so a drag to pan is not read as a click. */
@@ -142,14 +200,53 @@ export function MindMapCanvas({
     setApi(instance)
   }, [])
 
+  /**
+   * Latest focus target, kept where the scene effect can read it without
+   * depending on it. A layout effect rather than an assignment during render,
+   * and it runs before the passive effect below on the very first commit too.
+   */
+  const focusRef = useRef(initialFocusHref)
+  useLayoutEffect(() => {
+    focusRef.current = initialFocusHref
+  }, [initialFocusHref])
+
+  /**
+   * The live element carrying this href, or null.
+   *
+   * The LIVE scene, for the same reason the hit test reads it: the library
+   * regenerates every id on import, so the elements this was built from cannot
+   * be handed to the camera. `customData` is what survives.
+   */
+  const elementForHref = useCallback((href: string) => {
+    const api = apiRef.current
+    if (!api) return null
+    return (
+      api
+        .getSceneElements()
+        .find(
+          (element) =>
+            !element.isDeleted && mindMapHrefOf(element as unknown as MindMapHitElement) === href
+        ) ?? null
+    )
+  }, [])
+
   // Re-feeding the scene rather than remounting keeps the camera and the
   // library's own warm-up across a rebuild of the same note.
+  //
+  // Framed whole first, then centred on the focus target. The fit is what
+  // decides the ZOOM — there is no other source for a sensible one, and the
+  // centring step deliberately does not change it — and both land in the same
+  // frame, so the whole-map view is never a thing the user sees on the way past.
   useEffect(() => {
     const api = apiRef.current
     if (!api) return
     api.updateScene({ elements: convertToExcalidrawElements(toSkeleton(elements)) })
     api.scrollToContent(undefined, { fitToContent: true, animate: false })
-  }, [elements])
+
+    const href = focusRef.current
+    const target = href === null ? null : elementForHref(href)
+    if (target) api.scrollToContent(target, { animate: false })
+  }, [elements, elementForHref])
 
   /**
    * The box under a viewport point, read from the LIVE scene.
@@ -195,6 +292,41 @@ export function MindMapCanvas({
   }, [elements, hitAt, hoverLabels])
 
   /**
+   * Where the ring goes, against the camera as it is right now.
+   *
+   * Recomputed on every committed change for the same reason the affordance is,
+   * and then some: the camera is still flying when the ring appears, so a
+   * rectangle measured once at the click would sit where the box USED to be for
+   * the whole flight.
+   */
+  const syncFocus = useCallback((): void => {
+    const api = apiRef.current
+    if (!api || focusedHref === null) {
+      setFocusRect(null)
+      return
+    }
+
+    const target = elementForHref(focusedHref)
+    if (!target) {
+      setFocusRect(null)
+      return
+    }
+
+    const rect = mindMapBoxRect(target, api.getAppState())
+    // Same box, same place: hand back the very same object so a pan that does
+    // not move this node does not re-render the ring.
+    setFocusRect((current) =>
+      current &&
+      current.left === rect.left &&
+      current.top === rect.top &&
+      current.width === rect.width &&
+      current.height === rect.height
+        ? current
+        : rect
+    )
+  }, [elementForHref, focusedHref])
+
+  /**
    * A pan or a zoom moves the drawing under a pointer that never moved, so the
    * answer has to be recomputed from a change rather than from a mouse event.
    * Coalesced onto a frame because the library reports every committed state
@@ -207,6 +339,7 @@ export function MindMapCanvas({
       frameRef.current = requestAnimationFrame(() => {
         frameRef.current = null
         syncHover()
+        syncFocus()
       })
     })
     return () => {
@@ -214,7 +347,7 @@ export function MindMapCanvas({
       if (frameRef.current !== null) cancelAnimationFrame(frameRef.current)
       frameRef.current = null
     }
-  }, [api, syncHover])
+  }, [api, syncHover, syncFocus])
 
   const handlePointerMove = useCallback(
     (event: React.PointerEvent): void => {
@@ -262,6 +395,49 @@ export function MindMapCanvas({
     apiRef.current?.scrollToContent(undefined, { fitToContent: true, animate: true })
   }, [])
 
+  /**
+   * Neither `fitToContent` nor `fitToViewport` is passed, and that is the whole
+   * point: with no fit option the library only moves the camera, so the box
+   * arrives in the middle of the view at exactly the scale the user left it at.
+   */
+  const focus = useCallback(
+    (href: string): boolean => {
+      const api = apiRef.current
+      const target = api ? elementForHref(href) : null
+      if (!api || !target) return false
+
+      api.scrollToContent(target, {
+        animate: !prefersReducedMotion,
+        duration: FOCUS_CAMERA_MS
+      })
+
+      // Restarted rather than queued: clicking a second heading while the first
+      // ring is still up marks the second box, not both.
+      if (flashRef.current !== null) clearTimeout(flashRef.current)
+      setFocusedHref(href)
+      flashRef.current = setTimeout(() => {
+        flashRef.current = null
+        setFocusedHref(null)
+      }, FOCUS_FLASH_MS)
+      return true
+    },
+    [elementForHref, prefersReducedMotion]
+  )
+
+  // The ring appears at the click rather than on the next committed change: the
+  // camera reports its flight, but a focus that did not move it at all — the
+  // box was already centred — reports nothing to hang the first frame off.
+  useLayoutEffect(() => {
+    syncFocus()
+  }, [syncFocus])
+
+  useEffect(
+    () => () => {
+      if (flashRef.current !== null) clearTimeout(flashRef.current)
+    },
+    []
+  )
+
   // Read through the ref at call time, never captured at build time: the point
   // of exporting from the live surface is that it holds whatever the map shows
   // right now, expanded branches included.
@@ -278,8 +454,8 @@ export function MindMapCanvas({
   }, [])
 
   const controls = useMemo<MindMapControls>(
-    () => ({ fit, copyImage, copyVector }),
-    [fit, copyImage, copyVector]
+    () => ({ fit, focus, copyImage, copyVector }),
+    [fit, focus, copyImage, copyVector]
   )
 
   useEffect(() => {
@@ -330,6 +506,32 @@ export function MindMapCanvas({
         // Excalidraw's light theme.
         theme={resolvedTheme === 'dark' ? 'dark' : 'light'}
       />
+
+      {focusRect && (
+        /* What the click landed on, said in the one language a bitmap surface
+           has. Decoration, like the hover card: the outline entry the user just
+           pressed already named this node in words, so repeating it to assistive
+           technology would announce the same thing twice. Never a pointer
+           target, and clipped to the map so a ring on a node at the edge cannot
+           spill over the toolbar. */
+        <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
+          <div
+            data-testid="mind-map-focus-ring"
+            className="mind-map-focus-ring absolute rounded-md ring-2 ring-accent-orange"
+            // Geometry on the drawing surface's own axes, not layout: a logical
+            // inset here would put the ring on the wrong side of an RTL map.
+            style={{
+              left: focusRect.left,
+              top: focusRect.top,
+              width: focusRect.width,
+              height: focusRect.height,
+              // Driven from the constant that also decides when the ring is
+              // unmounted, so the fade cannot outlive the element or end early.
+              animationDuration: `${FOCUS_FLASH_MS}ms`
+            }}
+          />
+        </div>
+      )}
 
       {label && hover && (
         /* Decoration on the picture, and deliberately so: it is a mouse-only

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-focus.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-focus.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Naming a drawn box from an outline entry.
+ *
+ * Built through `buildMindMap` rather than from hand-written nodes, because the
+ * claim under test is that the outline's block ids and the map's boxes line up
+ * on a real map — a fixture that agreed with itself would prove nothing.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { buildMindMap } from './build-mind-map'
+import { mindMapHrefForBlock } from './mind-map-focus'
+import { mindMapHrefOf } from './mind-map-hover'
+import type { MindMapBoxElement, MindMapSourceBlock } from './mind-map-types'
+
+function heading(id: string, level: number, text: string): MindMapSourceBlock {
+  return { id, type: 'heading', props: { level }, content: [{ type: 'text', text }] }
+}
+
+const map = buildMindMap(
+  [
+    heading('b-alpha', 1, 'Alpha'),
+    { id: 'b-item', type: 'bulletListItem', content: [{ type: 'text', text: 'a point' }] },
+    { id: 'b-tail', type: 'paragraph', content: [{ type: 'text', text: 'a line' }] }
+  ],
+  { rootLabel: 'Test Note', noteId: 'note-1' }
+)
+
+describe('mindMapHrefForBlock', () => {
+  it('answers with the href the box for that block actually carries', () => {
+    const node = map.nodes.find((candidate) => candidate.blockId === 'b-alpha')!
+    const element = map.elements.find(
+      (candidate): candidate is MindMapBoxElement =>
+        candidate.id === node.id && candidate.type === 'rectangle'
+    )!
+
+    // The same string the hit test hands back on a click, which is what makes
+    // it a usable handle on the live scene after the library remints every id.
+    expect(mindMapHrefForBlock(map, 'b-alpha')).toBe(mindMapHrefOf(element))
+    expect(mindMapHrefForBlock(map, 'b-alpha')).toContain('note-1')
+  })
+
+  it('answers for any drawn block, not only headings', () => {
+    expect(mindMapHrefForBlock(map, 'b-item')).not.toBeNull()
+  })
+
+  it('answers null for a block this map did not draw', () => {
+    // What a heading folded behind a "+N more", or dropped at the node cap,
+    // looks like from here — and the signal the caller falls back on.
+    expect(mindMapHrefForBlock(map, 'b-missing')).toBeNull()
+  })
+
+  it('answers null for a note with no map to speak of', () => {
+    const empty = buildMindMap([], { rootLabel: 'Empty', noteId: 'note-1' })
+    expect(mindMapHrefForBlock(empty, 'b-alpha')).toBeNull()
+  })
+
+  it('never answers with the root, which stands for the title and no block', () => {
+    const root = map.nodes.find((node) => node.kind === 'root')!
+    expect(root.blockId).toBeNull()
+    // A root href would send the camera to the middle of the map for a block
+    // that is nowhere on it.
+    expect(mindMapHrefForBlock(map, '')).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-focus.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-focus.ts
@@ -1,0 +1,44 @@
+/**
+ * Finding the drawn box that stands for a block.
+ *
+ * The outline panel and the map are keyed by the same thing without ever having
+ * agreed to be: an outline entry's `id` IS the BlockNote block id, and that is
+ * exactly what a node carries in `blockId`. So a heading click can name a box on
+ * the map with no new identifier and no lookup table to keep in sync.
+ *
+ * The answer is an HREF rather than an element or an index, because the drawing
+ * library regenerates every element id on the way in — the same reason the map's
+ * deep link travels in `customData` (see `MindMapBoxElement.customData`). The
+ * href is the one handle that survives the conversion, and it is already what
+ * the canvas' hit test hands back and what `hoverLabels` is keyed by.
+ *
+ * Null is a real answer, not a failure: a heading folded away behind a "+N more"
+ * marker, or dropped at the node cap, has no box to move the camera to. The
+ * caller reads that as "this one cannot be shown on the map" and falls back to
+ * opening the note at it.
+ *
+ * Pure: no DOM, no React, no library.
+ */
+
+import { mindMapHrefOf } from './mind-map-hover'
+import type { MindMap } from './mind-map-types'
+
+/**
+ * The deep link of the box drawn for this block, or null when the block has no
+ * box on this map.
+ *
+ * Matched through the node rather than by scanning hrefs, because a box's href
+ * is minted from its node and reading it back out by string surgery would be a
+ * second grammar to keep in step with `nodeLink`.
+ */
+export function mindMapHrefForBlock(map: MindMap, blockId: string): string | null {
+  const node = map.nodes.find((candidate) => candidate.blockId === blockId)
+  if (!node) return null
+
+  // Elements carry the NODE id, which is stable within one build. (The library
+  // replaces it on import; nothing here reads the live scene.)
+  const element = map.elements.find((candidate) => candidate.id === node.id)
+  if (!element || element.type !== 'rectangle') return null
+
+  return mindMapHrefOf(element)
+}

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-hover.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-hover.ts
@@ -110,6 +110,28 @@ export function hitMindMapBox(
  * transform the drawing applies to the scene (`(scene + scroll) * zoom`), which
  * is the same arithmetic `CanvasCardLayer` uses to lay its cards over a scene.
  */
+/**
+ * A box's rectangle in pixels on the drawing surface's own axes.
+ *
+ * The same transform the affordance anchor uses — `(scene + scroll) * zoom` —
+ * applied to the whole box rather than to one point on it, because a ring drawn
+ * around a node has to sit exactly on it at any zoom. Recomputed against the
+ * live camera on every committed change, so it stays glued to the box while the
+ * camera is still flying towards it.
+ */
+export function mindMapBoxRect(
+  box: { x: number; y: number; width: number; height: number },
+  camera: MindMapCamera
+): { left: number; top: number; width: number; height: number } {
+  const zoom = camera.zoom.value || 1
+  return {
+    left: (box.x + camera.scrollX) * zoom,
+    top: (box.y + camera.scrollY) * zoom,
+    width: box.width * zoom,
+    height: box.height * zoom
+  }
+}
+
 export function mindMapHoverAnchor(
   hit: MindMapHit,
   camera: MindMapCamera

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
@@ -14,16 +14,22 @@
  *
  * Mount lifetime, decided here because this is where viewport state arrives:
  * the drawing surface is mounted on toggle and unmounted on close, and the
- * camera is NOT persisted. Every open frames the whole map. The map is a
- * derived view rebuilt from the note each time it opens, so a restored camera
- * could point at coordinates the new drawing no longer uses — the same reason
- * the map's expansion state is not persisted either. And the loss costs
- * nothing: reopening the map puts the camera exactly where "Fit to view" puts
- * it, so the state is one click from recovery rather than something to store,
- * parse and keep compatible across versions.
+ * camera is NOT persisted. The map is a derived view rebuilt from the note each
+ * time it opens, so a restored camera could point at coordinates the new drawing
+ * no longer uses — the same reason the map's expansion state is not persisted
+ * either. And the loss costs nothing: reopening the map puts the camera on the
+ * section the reader was in, and "Fit to view" is one click away.
+ *
+ * Where a fresh camera POINTS is decided here too. Framing the whole map is the
+ * right answer only for a reader who has nowhere in particular to be; anyone who
+ * scrolled to a section and then asked for the picture asked for the picture OF
+ * THAT SECTION, so the block they were reading is resolved to a box and handed
+ * down as the opening target. It is resolved here rather than below because this
+ * is the layer holding the map, and only the map knows whether a given block was
+ * drawn at all.
  */
 
-import { lazy, Suspense, useCallback, useMemo, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { useT } from '@memry/i18n/renderer'
 import { Focus, Image, PenTool, Save } from '@/lib/icons'
@@ -33,6 +39,7 @@ import { buildMemryHref } from '@/lib/memry-links'
 import { resolveWikiLink } from '@/lib/wikilink-resolver'
 import { canvasService } from '@/services/canvas-service'
 import { mindMapDestinations } from './mind-map-destination'
+import { mindMapHrefForBlock } from './mind-map-focus'
 import { mindMapHrefOf } from './mind-map-hover'
 import { nodeFromMindMapLink, type MindMapNodeActivation } from './mind-map-navigation'
 import { mintSnapshotElements, uniqueCanvasTitle } from './mind-map-snapshot'
@@ -128,13 +135,32 @@ interface MindMapViewProps {
   noteTitle: string
   /** One handler for both projections — the picture and the tree agree. */
   onActivateNode: MindMapNodeActivation
+  /**
+   * The block the reader was on when they opened the map, so it opens on that
+   * section instead of on the whole picture. Null when there is nothing to aim
+   * at — an untitled top-of-note, or a note with no headings.
+   */
+  initialFocusBlockId?: string | null
+  /**
+   * Handed a way to move the open map's camera to a block, and `null` the moment
+   * there is no live surface to move.
+   *
+   * A block id rather than an href, because that is what the outline panel has,
+   * and resolving one to the other is this layer's job. `false` back means the
+   * block was not drawn — folded behind a "+N more", or dropped at the node cap
+   * — which is what lets the caller fall back to opening the note at it rather
+   * than swallowing the click.
+   */
+  onFocusChange?: (focusBlock: ((blockId: string) => boolean) | null) => void
 }
 
 export function MindMapView({
   map,
   noteId,
   noteTitle,
-  onActivateNode
+  onActivateNode,
+  initialFocusBlockId = null,
+  onFocusChange
 }: MindMapViewProps): React.JSX.Element {
   const { t } = useT('notes')
   const [controls, setControls] = useState<MindMapControls | null>(null)
@@ -298,6 +324,33 @@ export function MindMapView({
     [map.nodes, noteId, onActivateNode]
   )
 
+  const initialFocusHref = useMemo(
+    () => (initialFocusBlockId === null ? null : mindMapHrefForBlock(map, initialFocusBlockId)),
+    [initialFocusBlockId, map]
+  )
+
+  const focusBlock = useMemo(() => {
+    if (controls === null) return null
+    return (blockId: string): boolean => {
+      const href = mindMapHrefForBlock(map, blockId)
+      return href === null ? false : controls.focus(href)
+    }
+  }, [controls, map])
+
+  // The same handshake `onControlsChange` makes one layer down, one layer up:
+  // the surface announces itself when it is live and takes the announcement
+  // back when it is not, so nothing is ever wired to a camera that is gone.
+  //
+  // The rule's advice — lift the state to the parent — is the wrong shape here.
+  // What the parent is being handed is a way to CALL the drawing surface, and
+  // the surface is mounted below this component precisely so that Excalidraw
+  // stays out of the main bundle. Lifting it would move the lazy boundary.
+  useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-live-state-to-parent
+    onFocusChange?.(focusBlock)
+    return () => onFocusChange?.(null)
+  }, [focusBlock, onFocusChange])
+
   return (
     <div className="relative flex h-full w-full flex-col bg-background" data-testid="note-mind-map">
       <MindMapToolbar actions={actions} label={t('mindMap.toolbar.label')} />
@@ -329,6 +382,7 @@ export function MindMapView({
             elements={map.elements}
             hoverLabels={hoverLabels}
             onOpenLink={handleOpenLink}
+            initialFocusHref={initialFocusHref}
             onControlsChange={setControls}
           />
         </Suspense>

--- a/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.test.tsx
@@ -44,11 +44,16 @@ let top: HTMLElement
 /** Every scroll the run asked for, in order, with what it was aimed at. */
 let scrolled: Array<{ target: Element; options: boolean | ScrollIntoViewOptions | undefined }>
 
-function setup(options: { smooth?: boolean } = {}) {
+function setup(options: { smooth?: boolean; canFocus?: boolean } = {}) {
   const close = vi.fn()
   const openNote = vi.fn()
   const openTask = vi.fn()
   const expandBranch = vi.fn()
+  // What a live map answers: true once it has moved its camera onto the block.
+  // False is every other state — closed, not mounted, or asked for a block it
+  // never drew — and is the default here because most of this file is about
+  // the path taken when the map cannot answer.
+  const focusBlock = vi.fn(() => options.canFocus ?? false)
   const view = renderHook(() =>
     useMindMapNavigation({
       close,
@@ -57,10 +62,11 @@ function setup(options: { smooth?: boolean } = {}) {
       getTopElement: () => top,
       smooth: options.smooth ?? true,
       openNote,
-      openTask
+      openTask,
+      focusBlock
     })
   )
-  return { close, openNote, openTask, expandBranch, view }
+  return { close, openNote, openTask, expandBranch, focusBlock, view }
 }
 
 /** The block, once whatever gates the editor's render has let it through. */
@@ -155,7 +161,7 @@ describe('useMindMapNavigation', () => {
     expect(scrolled[0].target).toBe(top)
   })
 
-  it('sends a heading node to its own block, through the same call the outline makes', () => {
+  it('sends a heading node to its own block, and the outline lands in the same place', () => {
     const { view } = setup()
     const block = renderBlock('b-alpha')
 
@@ -163,11 +169,53 @@ describe('useMindMapNavigation', () => {
     const fromMap = [...scrolled]
     scrolled = []
 
-    // What the outline panel is handed, called with the same heading.
-    act(() => view.result.current.navigateToBlock('b-alpha'))
+    // The outline's own entry point, called with the same heading. It only
+    // diverges while a map is showing that block; with none, the two agree.
+    act(() => view.result.current.navigateFromOutline('b-alpha'))
 
     expect(fromMap).toEqual([{ target: block, options: { behavior: 'smooth', block: 'start' } }])
     expect(scrolled).toEqual(fromMap)
+  })
+
+  it('moves the open map\'s camera on an outline click, and leaves the map open', () => {
+    const { close, focusBlock, view } = setup({ canFocus: true })
+    renderBlock('b-alpha')
+
+    act(() => view.result.current.navigateFromOutline('b-alpha'))
+
+    expect(focusBlock).toHaveBeenCalledWith('b-alpha')
+    // The panel sits over the picture on purpose: on a map too big to see at
+    // once it is the only way to reach a far branch, so the click has to be a
+    // move rather than an exit.
+    expect(close).not.toHaveBeenCalled()
+    expect(scrolled).toEqual([])
+  })
+
+  it('falls back to opening the note when the map did not draw that block', () => {
+    const { close, focusBlock, view } = setup({ canFocus: false })
+    const block = renderBlock('b-alpha')
+
+    act(() => view.result.current.navigateFromOutline('b-alpha'))
+
+    // A heading folded behind a "+N more", or dropped at the node cap, has no
+    // box to move to. The click still has to go somewhere.
+    expect(focusBlock).toHaveBeenCalledWith('b-alpha')
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(scrolled).toEqual([{ target: block, options: { behavior: 'smooth', block: 'start' } }])
+  })
+
+  it('still closes the map when a node on it is clicked, even though the map can focus', () => {
+    const { close, focusBlock, view } = setup({ canFocus: true })
+    const block = renderBlock('b-alpha')
+
+    act(() => view.result.current.activateNode(alpha))
+
+    // The regression this split exists to prevent: a box on the map is a place
+    // in the NOTE, so clicking it has to leave the map rather than re-centre on
+    // the thing the user just clicked.
+    expect(focusBlock).not.toHaveBeenCalled()
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(scrolled).toEqual([{ target: block, options: { behavior: 'smooth', block: 'start' } }])
   })
 
   it('hands a wiki-link node to the page, leaving the map where it was', () => {

--- a/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.ts
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/use-mind-map-navigation.ts
@@ -14,8 +14,19 @@
  * whole time, and a single call is what keeps the outline panel's smooth jump
  * exactly as smooth as it was before this existed.
  *
- * The same `navigateToBlock` is what the outline panel is handed, so a heading
- * click has one behaviour whether or not the map is open.
+ * The outline panel gets its OWN entry point rather than this one, and the split
+ * is the point. A box on the map is a place in the note — clicking it means "take
+ * me there", so it closes the map. An entry in the outline, while the map is
+ * open, is a place on the MAP — the panel sits above the picture on purpose, and
+ * on a map too big to see at once it is the only way to reach a far branch. So
+ * that click moves the camera and leaves the map open. Same destination, two
+ * different intents, and widening one function to serve both would have made
+ * clicking a node stop navigating.
+ *
+ * The outline falls back to this one whenever the map cannot answer: closed, not
+ * yet mounted, or asked for a block it did not draw (folded behind a "+N more",
+ * or dropped at the node cap). That fallback IS the old behaviour, so a heading
+ * click never does nothing.
  *
  * Two node kinds do not land in this note at all — a wiki link opens the note
  * it names, a task opens its task — and neither closes the map. They are handed
@@ -52,14 +63,25 @@ interface UseMindMapNavigationOptions {
   openNote: (wikiTarget: string) => void
   /** The note page's own task handler. */
   openTask: (taskId: string) => void
+  /**
+   * Moves the open map's camera onto a block, and answers whether it could.
+   * False for a closed map, a surface that has not mounted yet, and a block the
+   * map did not draw.
+   */
+  focusBlock: (blockId: string) => boolean
 }
 
 export interface UseMindMapNavigationResult {
   /**
    * Close the map and land at this block. `null` is the top of the note.
-   * Handed to the outline panel as-is — one function, one behaviour.
+   * What a map node's activation ends in.
    */
   navigateToBlock: (blockId: string | null) => void
+  /**
+   * A heading click in the outline panel. Moves the camera when the map is
+   * showing that block, and otherwise behaves exactly like `navigateToBlock`.
+   */
+  navigateFromOutline: (blockId: string) => void
   /** What a node activation on either projection ends in. */
   activateNode: MindMapNodeActivation
 }
@@ -71,7 +93,8 @@ export function useMindMapNavigation({
   getTopElement,
   smooth,
   openNote,
-  openTask
+  openTask,
+  focusBlock
 }: UseMindMapNavigationOptions): UseMindMapNavigationResult {
   // A wait outlives the click that started it, so a second click — or leaving
   // the note — has to call the first one off, or two of them fight over the
@@ -111,10 +134,24 @@ export function useMindMapNavigation({
     [cancelPending, close, getContainer, getTopElement, smooth]
   )
 
+  const navigateFromOutline = useCallback(
+    (blockId: string) => {
+      // Nothing to call off and nothing to close on this path: the camera move
+      // is instantaneous and leaves the note exactly where it was, so a pending
+      // scroll from an earlier click is not something this one invalidates.
+      if (focusBlock(blockId)) return
+      navigateToBlock(blockId)
+    },
+    [focusBlock, navigateToBlock]
+  )
+
   const activateNode = useCallback<MindMapNodeActivation>(
     (node) => activateMindMapNode(node, { navigateToBlock, openNote, openTask, expandBranch }),
     [navigateToBlock, openNote, openTask, expandBranch]
   )
 
-  return useMemo(() => ({ navigateToBlock, activateNode }), [navigateToBlock, activateNode])
+  return useMemo(
+    () => ({ navigateToBlock, navigateFromOutline, activateNode }),
+    [navigateToBlock, navigateFromOutline, activateNode]
+  )
 }

--- a/apps/desktop/src/renderer/src/components/note/note-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-layout.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useEffect,
   useRef,
   useState,
   type CSSProperties,
@@ -40,6 +41,15 @@ interface NoteLayoutProps {
   marqueeZoneRef?: (el: HTMLDivElement | null) => void
   onRailHiddenChange?: (hidden: boolean) => void
   /**
+   * The heading the reader is currently on, as scroll tracking sees it.
+   *
+   * Reported rather than lifted because the outline panel is this layout's own
+   * furniture and nothing above it needs to re-render when the reader scrolls
+   * past a heading. The note page keeps the value in a ref and reads it once,
+   * when the mind map opens, to decide where the map's camera should land.
+   */
+  onActiveHeadingChange?: (headingId: string | null) => void
+  /**
    * Set while the page has a heading to jump to (`[[Note#Heading]]`). Scroll
    * restore keeps saving, but does not re-apply the saved offset on this mount:
    * the user named a destination, which is the fresher intent.
@@ -64,6 +74,7 @@ export function NoteLayout({
   contentWidth,
   marqueeZoneRef,
   onRailHiddenChange,
+  onActiveHeadingChange,
   suppressScrollRestore = false
 }: NoteLayoutProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -81,6 +92,15 @@ export function NoteLayout({
     offset: 120,
     scrollContainerRef: scrollRef
   })
+
+  // Lifting this, as the rule suggests, would re-render the whole note page on
+  // every scroll tick to serve one read that happens when the mind map opens.
+  // The plugin also traces `activeHeadingId` back to `scrollRef` and calls it a
+  // ref handed to a parent; it is not — what leaves here is a heading id.
+  useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-data-to-parent, react-you-might-not-need-an-effect/no-pass-ref-to-parent
+    onActiveHeadingChange?.(activeHeadingId)
+  }, [activeHeadingId, onActiveHeadingChange])
 
   const handleHeadingClick = useCallback(
     (headingId: string) => {

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -64,6 +64,11 @@ const mocks = vi.hoisted(() => ({
   editorInstances: [] as unknown[],
   /** The controls the map surface hands up to its toolbar. */
   mindMapFit: vi.fn(),
+  /**
+   * The live map's camera. True by default — a map that is showing the block is
+   * the interesting case, and the fallback path sets it false explicitly.
+   */
+  mindMapFocus: vi.fn(() => true),
   mindMapCopyImage: vi.fn(),
   mindMapCopyVector: vi.fn(),
   onDeleted: vi.fn(),
@@ -291,6 +296,7 @@ vi.mock('@/components/note/mind-map/mind-map-canvas', () => ({
     useEffect(() => {
       onControlsChange?.({
         fit: mocks.mindMapFit,
+        focus: mocks.mindMapFocus,
         copyImage: mocks.mindMapCopyImage,
         copyVector: mocks.mindMapCopyVector
       })
@@ -817,6 +823,9 @@ describe('NotePage', () => {
     mocks.noteState.note = note
     mocks.noteState.isLoading = false
     mocks.noteState.error = null
+    // `clearAllMocks` keeps a return value set by a test, so the default that
+    // stands for a live map is re-asserted here rather than assumed.
+    mocks.mindMapFocus.mockReturnValue(true)
     mocks.updateNote.mockResolvedValue({ success: true })
     mocks.renameNote.mockResolvedValue({ success: true })
     mocks.deleteNote.mockResolvedValue({ success: true })
@@ -1813,7 +1822,25 @@ describe('NotePage', () => {
       expect(scrolls).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' })
     })
 
-    it('takes the identical path from the outline panel while the map is showing', async () => {
+    it('moves the map camera from the outline panel rather than leaving the map', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+
+      await openMap()
+      const scrolls = vi.spyOn(blockElement('b-h1'), 'scrollIntoView')
+
+      fireEvent.click(screen.getByRole('button', { name: 'Jump Alpha' }))
+
+      // The panel sits over the picture on purpose, and on a map too big to see
+      // at once it is the only way to reach a far branch. So this click is a
+      // camera move: the map stays, and the note underneath is not scrolled.
+      expect(mocks.mindMapFocus).toHaveBeenCalledWith('memry://note/note-1#^b-h1')
+      expect(screen.getByTestId('note-mind-map')).toBeInTheDocument()
+      expect(scrolls).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the note when the map is not showing that block', async () => {
+      // A heading folded behind a "+N more", or dropped at the node cap.
+      mocks.mindMapFocus.mockReturnValue(false)
       renderWithProviders(<NotePage noteId="note-1" />)
 
       await openMap()
@@ -1829,8 +1856,8 @@ describe('NotePage', () => {
       await screen.findByTestId('note-mind-map')
       fireEvent.click(screen.getByRole('button', { name: 'Jump Alpha' }))
 
-      // One control, one behaviour: the outline panel is handed the very
-      // function the map's nodes end in, so this cannot drift from the above.
+      // The fallback IS the old behaviour, unchanged, so a heading click never
+      // does nothing.
       await expectLandedOnAlpha(scrolls)
       expect(scrolls.mock.calls).toEqual(mapCalls)
     })

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -1310,6 +1310,29 @@ export function NotePage({ noteId }: NotePageProps) {
     (wikiTarget: string) => void handleInternalLinkClick(wikiTarget),
     [handleInternalLinkClick]
   )
+  // Both of these are refs rather than state, and for the same reason: they are
+  // read at the instant of a click or a mount and never rendered, so putting
+  // either in state would re-render this page on every scroll tick or every
+  // remount of the drawing surface for nothing.
+  //
+  // `activeHeadingRef` is where the map's camera lands when it opens;
+  // `mindMapFocusRef` is how an outline click moves it while it is open, and it
+  // is null exactly when there is no live map to move.
+  const activeHeadingRef = useRef<string | null>(null)
+  const handleActiveHeadingChange = useCallback((headingId: string | null) => {
+    activeHeadingRef.current = headingId
+  }, [])
+  const mindMapFocusRef = useRef<((blockId: string) => boolean) | null>(null)
+  const handleMindMapFocusChange = useCallback(
+    (focusBlock: ((blockId: string) => boolean) | null) => {
+      mindMapFocusRef.current = focusBlock
+    },
+    []
+  )
+  const focusMindMapBlock = useCallback(
+    (blockId: string) => mindMapFocusRef.current?.(blockId) === true,
+    []
+  )
   const mindMapNavigation = useMindMapNavigation({
     close: mindMap.close,
     expandBranch: mindMap.expandBranch,
@@ -1317,7 +1340,8 @@ export function NotePage({ noteId }: NotePageProps) {
     getTopElement: getNoteBody,
     smooth: !prefersReducedMotion,
     openNote: openLinkedNote,
-    openTask: handleLinkedTaskClick
+    openTask: handleLinkedTaskClick,
+    focusBlock: focusMindMapBlock
   })
 
   // ============================================================================
@@ -1568,7 +1592,8 @@ export function NotePage({ noteId }: NotePageProps) {
     <NoteLayout
       suppressScrollRestore={Boolean(initialHeadingText)}
       headings={headings}
-      onHeadingClick={mindMapNavigation.navigateToBlock}
+      onHeadingClick={mindMapNavigation.navigateFromOutline}
+      onActiveHeadingChange={handleActiveHeadingChange}
       actions={actionIcons}
       fullWidth={isFullWidth}
       contentWidth={noteContentWidth ?? undefined}
@@ -1580,6 +1605,8 @@ export function NotePage({ noteId }: NotePageProps) {
             noteId={noteId ?? ''}
             noteTitle={note.title}
             onActivateNode={mindMapNavigation.activateNode}
+            initialFocusBlockId={activeHeadingRef.current}
+            onFocusChange={handleMindMapFocusChange}
           />
         ) : undefined
       }

--- a/apps/docs/src/user-guide/notes/mind-map.md
+++ b/apps/docs/src/user-guide/notes/mind-map.md
@@ -13,6 +13,11 @@ actions. The title, properties, tags and body are replaced by the map. The
 header, the breadcrumb, the note's overflow menu and the outline panel all stay
 where they were.
 
+The map **opens on the section you were reading**. Scroll to a heading halfway
+down a long note, press the icon, and the map is already looking at that part of
+the tree rather than at the whole picture from a distance. If you were at the
+top, or the note has no headings, it frames the whole map instead.
+
 Press the same icon again to return to the note.
 
 The map is a **view of the note, not a document**. Nothing is saved, nothing is
@@ -133,8 +138,13 @@ The map is navigation, not just a picture.
   so the tab you came from is still on the map when you return to it.
 - Click a **`+N more`** node to open that branch in place. This is the other
   node that does not take you back into the note: a fold is undone where it is.
-- The **outline panel** stays available while the map shows, and clicking a
-  heading there does exactly the same thing. One control, one behaviour.
+- The **outline panel** stays available while the map shows, and while the map
+  is open it steers the map rather than leaving it. Click a heading there and
+  the map slides to that heading's node, at whatever zoom you are on, with a
+  brief ring around the node it landed on so you can see where you arrived. On
+  a map too big to see at once, this is how you reach a far branch. If the
+  heading is not drawn — it is behind a `+N more`, or past the 200-node limit —
+  the click opens the note at it, the way it does when the map is closed.
 
 Nodes work from the keyboard too. Tab into the map, move between nodes with the
 up and down arrows (Home and End jump to the ends), and press Enter or Space to
@@ -172,8 +182,9 @@ background and always in the map's light colours, so the same note copies the
 same way whichever app theme you are in. If a copy cannot be made, memrynote
 tells you rather than failing quietly.
 
-The map's camera is not remembered. Close the map and open it again and it
-frames the whole thing afresh — the same place **Fit to view** takes you.
+The map's camera is not remembered. Close the map and open it again and it is
+back on the section you are reading, and **Fit to view** frames the whole thing
+from there.
 
 ## Saving the Map as a Canvas
 


### PR DESCRIPTION
## Summary

The outline panel sits above the mind map on purpose — `NoteLayout` renders it at `z-40` over a `z-20` overlay — but clicking a heading there closed the map and scrolled the note behind it. On a map too big to see at once, that made the one control positioned to reach a far branch an exit instead.

Two changes, both about where the camera points.

**An outline click steers the open map.** It now moves the camera onto that heading's box and leaves the map open, at whatever zoom the reader is on (`scrollToContent` is called with no fit option on purpose, so the reading distance they chose survives the jump). A short ring marks the box it landed on — held over the flight and the beat after it, then faded — so the jump answers "where did I just go?". When the map did not draw that block (folded behind a `+N more`, or dropped at the 200-node cap) the click falls back to the old behaviour and opens the note at it, so a heading click never does nothing.

**The map opens on the section you were reading.** The fit still runs, because it is what decides the zoom, and the centring lands in the same frame — so the whole-map view is never something the user sees go past.

Clicking a box **on** the map is untouched: that is a place in the note, so it still closes the map and scrolls there. The outline gets its own entry point (`navigateFromOutline`) rather than a widened `navigateToBlock` — widening the one function would have made clicking a node stop navigating, and there is a regression test pinning that.

### How the two surfaces line up

No new identifier: an outline entry's `id` already **is** the BlockNote block id, which is what a map node carries in `blockId`. The new pure helper `mindMapHrefForBlock` resolves one to the box's `memry://` href, and the canvas finds the live element by `customData.memryHref` — Excalidraw remints every element id on import, so that is the only handle that survives.

### Notes

- Camera flight is pinned at 250 ms rather than left to the library's default, because the ring has to outlast it; an upgrade changing that default would silently break the relationship.
- The ring is a DOM overlay measured against the live camera every committed change, not a scene mutation — the map stays read-only by construction.
- `prefers-reduced-motion`: the camera jumps instead of flying and the ring does not fade, but it still appears. It is what says where the click went.
- Three `react-you-might-not-need-an-effect` disables were added with reasons. Lifting the active heading would re-render the whole note page on every scroll tick to serve one read; lifting the focus handle would move the lazy Excalidraw boundary.

## Release note

Clicking a heading in the outline panel while the mind map is open now moves the map to that heading instead of closing the map, and the map opens on the section you were reading rather than framing the whole picture.

## Test plan

- `pnpm --filter @memry/desktop test:renderer` — 721 files, 8924 tests pass. (The run exits 1 on an unhandled error in `App.test.tsx` / `use-keyboard-shortcuts-base.ts`; that file is untouched here and reproduces on `main`.)
- `pnpm --filter @memry/desktop typecheck:web`, `typecheck:test` — clean.
- `pnpm lint` — 0 errors, 0 warnings.
- `pnpm docs:impact --base origin/main --strict` — docs changed on this branch. `pnpm docs:build` — clean.
- New tests: `mind-map-focus.test.ts` (block → box href, including the folded/capped `null`); canvas camera and ring tests (fit-then-centre ordering, fallback to fit-all, zoom untouched on focus, ring glued to its box while the camera flies, ring dropped when the flash ends, second click moves the one ring); `use-mind-map-navigation` (outline click focuses and does not close, falls back when it cannot, and **a map node click still closes** — the regression this split exists to prevent); `note-layout` active-heading reporting.
- Not covered by tests, needs eyes on the real app: Excalidraw's camera cannot be exercised in jsdom, so the actual motion, the ring's colour/weight, and the reduced-motion path want a look in `pnpm dev`.
