### PR TITLE
fix(cli): run the generated Linux launcher on Ozone's headless platform

### DIFF
--- a/apps/desktop/src/main/cli/terminal-command.test.ts
+++ b/apps/desktop/src/main/cli/terminal-command.test.ts
@@ -38,6 +38,74 @@ describe('terminal command setup', () => {
       inPath: true
     })
     expect(readFileSync(status.shimPath, 'utf8')).toContain(`exec "${executablePath}" --cli "$@"`)
+    expect(readFileSync(status.shimPath, 'utf8')).not.toContain('--ozone-platform')
+  })
+
+  it('installs a Linux shim that runs headless so a displayless host still works', async () => {
+    const root = tempRoot()
+    const binDir = join(root, 'bin')
+    const executablePath = join(root, 'opt', 'MemryNote', 'memrynote')
+
+    const status = await installTerminalCommand({
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      executablePath,
+      pathEnv: binDir,
+      preferredBinDirs: [binDir]
+    })
+
+    expect(status.installed).toBe(true)
+    expect(readFileSync(status.shimPath, 'utf8')).toContain(
+      `exec "${executablePath}" --ozone-platform=headless --disable-gpu --cli "$@"`
+    )
+  })
+
+  it('keeps the app path before the headless switches on Linux', async () => {
+    const root = tempRoot()
+    const binDir = join(root, 'bin')
+    const executablePath = join(root, 'node_modules', 'electron', 'dist', 'electron')
+    const appPath = join(root, 'memry', 'apps', 'desktop')
+
+    const status = await installTerminalCommand({
+      platform: 'linux',
+      homeDir: join(root, 'home'),
+      executablePath,
+      appPath,
+      pathEnv: binDir,
+      preferredBinDirs: [binDir]
+    })
+
+    expect(readFileSync(status.shimPath, 'utf8')).toContain(
+      `exec "${executablePath}" "${appPath}" --ozone-platform=headless --disable-gpu --cli "$@"`
+    )
+  })
+
+  it('treats a pre-headless Linux shim as stale and replaces it', async () => {
+    const root = tempRoot()
+    const binDir = join(root, 'bin')
+    const executablePath = join(root, 'opt', 'MemryNote', 'memrynote')
+    const options = {
+      platform: 'linux' as const,
+      homeDir: join(root, 'home'),
+      executablePath,
+      pathEnv: binDir,
+      preferredBinDirs: [binDir]
+    }
+
+    const initial = await installTerminalCommand(options)
+    writeFileSync(
+      initial.shimPath,
+      `#!/bin/sh\n# Memry terminal command shim\nexec "${executablePath}" --cli "$@"\n`
+    )
+
+    expect((await getTerminalCommandStatus(options)).installed).toBe(false)
+
+    const reinstalled = await installTerminalCommand(options)
+
+    expect(reinstalled.installed).toBe(true)
+    expect(readFileSync(reinstalled.shimPath, 'utf8')).toContain(
+      `exec "${executablePath}" --ozone-platform=headless --disable-gpu --cli "$@"`
+    )
   })
 
   it('installs a Unix shim with the app path when running from unpackaged Electron', async () => {
@@ -108,6 +176,7 @@ describe('terminal command setup', () => {
       inPath: true
     })
     expect(readFileSync(status.shimPath, 'utf8')).toContain(`"${executablePath}" --cli %*`)
+    expect(readFileSync(status.shimPath, 'utf8')).not.toContain('--ozone-platform')
   })
 
   it('installs a Windows cmd shim with the app path when running from unpackaged Electron', async () => {

--- a/apps/desktop/src/main/cli/terminal-command.ts
+++ b/apps/desktop/src/main/cli/terminal-command.ts
@@ -44,6 +44,17 @@ const COMMAND_NAME = 'memrynote'
 const SHIM_MARKER = 'Memry terminal command shim'
 const SHIM_MODE = 0o755
 
+// Ozone initializes before the `--cli` route gets to run, so on a Linux host
+// with neither X11 nor Wayland the launcher dies on display init
+// ("Missing X server or $DISPLAY") even though the CLI never opens a window.
+// Selecting Ozone's headless backend skips that initialization, which is what
+// makes the generated launcher usable on a displayless server without
+// installing Xvfb. Chromium's `--headless` is a chrome/-layer switch that
+// Electron does not implement, so it would be silently ignored here. The
+// switches must precede `--cli`, since everything after it is forwarded to the
+// CLI parser. macOS and Windows have no equivalent failure and stay untouched.
+const LINUX_HEADLESS_SWITCHES = '--ozone-platform=headless --disable-gpu'
+
 function resolvePlatform(platform: NodeJS.Platform = process.platform): TerminalCommandPlatform {
   if (platform === 'darwin' || platform === 'linux' || platform === 'win32') return platform
   return 'linux'
@@ -158,10 +169,11 @@ function renderShim(
   }
 
   const appPathArg = appPath ? ` "${escapeDoubleQuoted(appPath)}"` : ''
+  const headlessArgs = platform === 'linux' ? ` ${LINUX_HEADLESS_SWITCHES}` : ''
   return [
     '#!/bin/sh',
     `# ${SHIM_MARKER}`,
-    `exec "${escapeDoubleQuoted(executablePath)}"${appPathArg} --cli "$@"`,
+    `exec "${escapeDoubleQuoted(executablePath)}"${appPathArg}${headlessArgs} --cli "$@"`,
     ''
   ].join('\n')
 }

--- a/apps/docs/src/user-guide/cli.md
+++ b/apps/docs/src/user-guide/cli.md
@@ -36,6 +36,22 @@ settings switch can replace them with the current launcher. It only replaces lau
 memrynote; if another `memrynote` command already exists in that location, setup stops instead of
 overwriting it.
 
+## Linux servers without a display
+
+On Linux the generated launcher runs memrynote with `--ozone-platform=headless --disable-gpu`, so
+it works on a host that has neither `DISPLAY` nor `WAYLAND_DISPLAY`. You do not need Xvfb.
+
+If you call the packaged binary directly instead of using the launcher, pass those switches
+yourself, before `--cli`:
+
+```bash
+/opt/MemryNote/memrynote --ozone-platform=headless --disable-gpu --cli --json vault status
+```
+
+Without them the binary tries to initialize a display and never reaches the CLI. Launchers
+installed by an older app version lack the switches — reinstall the command from
+**Settings → Command Line** to pick them up.
+
 ## Vault
 
 ```bash


### PR DESCRIPTION
## Summary

The generated Linux `memrynote` launcher exec'd the packaged binary with only `--cli`. On a host with neither `DISPLAY` nor `WAYLAND_DISPLAY`, Ozone still selects X11 and dies on display init (`Missing X server or $DISPLAY`) — or hangs — before the `--cli` route can answer, even though the CLI exits before `app.whenReady()` ever opens a window. `renderShim()` now emits `--ozone-platform=headless --disable-gpu` ahead of `--cli` on Linux only; macOS and Windows shims are byte-identical to before.

Two notes on the switch choice:

- The issue suggested Chromium's `--headless`. That is a `chrome/`-layer switch (`headless_mode_util`) that Electron does not build, so it is a silent no-op — the Electron 43.1.1 Linux dist contains no `chrome/browser/headless/*` symbols. `--disable-gpu` alone is what likely made the reporter's invocation succeed.
- Ozone's headless backend *is* compiled into that dist (`ui/ozone/platform/headless/*`), so `--ozone-platform=headless` is the switch that actually skips display init.

Switches must precede `--cli`, since `getHeadlessCliArgs()` forwards everything after it to the CLI parser.

Compat: shim detection is a byte-exact content compare, so existing Linux launchers already report `installed: false` and get replaced when the user re-runs setup from **Settings → Command Line** — no separate migration. Docs say so explicitly.

## Release note

The `memrynote` terminal command now works on Linux hosts with no display (no Xvfb needed). Linux users should reinstall the command from Settings → Command Line to pick it up.

## Test plan

- `pnpm exec vitest run --config config/vitest.config.ts --project main src/main/cli/terminal-command.test.ts` — 11/11 pass. New cases: Linux shim carries the headless switches; app path stays ahead of them for unpackaged Electron; a pre-headless Linux shim is reported stale and replaced on reinstall; darwin/win32 shims assert `not.toContain('--ozone-platform')`.
- `pnpm lint`, `pnpm --filter @memry/desktop typecheck:node`, `pnpm --filter @memry/desktop typecheck:test`, `pnpm docs:build`, `pnpm docs:impact --base origin/main --strict` — clean.
- Verified against the shipped binary rather than assumption: `strings` on `electron-v43.1.1-linux-x64` confirms the Ozone headless platform is present and the chrome headless-mode layer is not.

Not verified: an end-to-end run on a real displayless Linux host — no Linux machine or container runtime available here, and CI's Linux e2e job runs under `xvfb-run`, so this path is uncovered there too. Worth one smoke test on the reporter's Ubuntu 24.04 host (`env -u DISPLAY -u WAYLAND_DISPLAY /opt/MemryNote/memrynote --ozone-platform=headless --disable-gpu --cli --json vault status`) before this ships.

Closes #1884