### PR TITLE
fix(telemetry): ship a redacted message with every error report

### DIFF
--- a/apps/desktop/src/main/sync/crdt-persistence.test.ts
+++ b/apps/desktop/src/main/sync/crdt-persistence.test.ts
@@ -213,7 +213,39 @@ describe('openCrdtPersistence telemetry', () => {
     expect(message).toContain('CRDT persistence unavailable at binding-in-use')
     expect(message).toContain('transport=node')
     expect(message).toContain('0xC0000005')
-    expect(message.length).toBeLessThanOrEqual(512)
+  })
+
+  // This event is ~100% win32, where the store path is C:\\Users\\<name>\\... and
+  // is masked by a DIFFERENT regex than the darwin case above. Pinning only the
+  // darwin branch would leave the branch that always fires unguarded.
+  it('redacts a Windows store path out of the reason', async () => {
+    mockPreflight.mockResolvedValue({
+      ok: false,
+      stage: 'binding-in-use',
+      transport: 'node',
+      reason: 'access violation at C:\\Users\\Kaan\\AppData\\Roaming\\Memry\\crdt-store'
+    })
+
+    expect(await openCrdtPersistence(STORE)).toBeNull()
+
+    const event = reportedEvent()
+    expect(JSON.stringify(event)).not.toContain('Kaan')
+  })
+
+  // A reason is a native error string and has no length contract. Over 512 chars
+  // the sync-server 400s the whole batch and the client drops it permanently.
+  it('caps the message so an oversized reason cannot 400 the batch', async () => {
+    mockPreflight.mockResolvedValue({
+      ok: false,
+      stage: 'binding-in-use',
+      transport: 'node',
+      reason: 'access violation reading location '.repeat(120)
+    })
+
+    expect(await openCrdtPersistence(STORE)).toBeNull()
+
+    const { message } = reportedEvent().error as { message: string }
+    expect(message).toHaveLength(512)
   })
 
   it('leaves the store alone when the control directory cannot be cleared', async () => {

--- a/apps/desktop/src/main/sync/crdt-persistence.test.ts
+++ b/apps/desktop/src/main/sync/crdt-persistence.test.ts
@@ -24,6 +24,13 @@ vi.mock('fs', () => ({
   rmSync: (...args: unknown[]) => mockRmSync(...args)
 }))
 
+// The real module reaches into the electron store for the vault root. Mask mode
+// is what an install with no vault open gets anyway, and it is what makes the
+// redacted message assertion below deterministic.
+vi.mock('../telemetry/redact-options', () => ({
+  getMainRedactOptions: () => ({})
+}))
+
 vi.mock('../lib/logger', () => ({
   createLogger: () => ({
     debug: vi.fn(),
@@ -101,16 +108,23 @@ describe('openCrdtPersistence telemetry', () => {
     })
   })
 
-  it('never ships the reason string, which can carry the store path', async () => {
-    mockPreflight.mockResolvedValue(failed('store', 'node'))
+  // The reason ships now (#1989) but only through redactText, and never in a
+  // dimension: SafeDimensionValueSchema is a blocklist, not a guarantee.
+  it('redacts the store path out of the reason it ships', async () => {
+    mockPreflight.mockResolvedValue({
+      ok: false,
+      stage: 'store',
+      transport: 'node',
+      reason: 'LevelDB lock held at /Users/kaan/Library/Application Support/Memry/crdt-store'
+    })
 
     expect(await openCrdtPersistence(STORE)).toBeNull()
 
-    // One dimension is the hard schema limit, and a path would be dropped by
-    // the sanitizer anyway — but the assertion that matters is that no field
-    // carries the reason at all.
-    expect(JSON.stringify(reportedEvent())).not.toContain(STORE)
-    expect(JSON.stringify(reportedEvent())).not.toContain('0xC0000005')
+    const event = reportedEvent()
+    const { message } = event.error as { message: string }
+    expect(message).toContain('~/Library/Application Support/Memry/crdt-store')
+    expect(JSON.stringify(event)).not.toContain('/Users/kaan')
+    expect(event.dimensions).toEqual({ transport: 'node' })
   })
 
   it('attributes a post-preflight failure to the probe, not to the preflight', async () => {
@@ -182,6 +196,24 @@ describe('openCrdtPersistence telemetry', () => {
       errorCode: 'CRDT_PERSISTENCE_UNAVAILABLE:binding-in-use',
       dimensions: { transport: 'node' }
     })
+  })
+
+  // #1989: this event used to ship a stage and a transport and nothing else, so
+  // its Error Tracking issue was titled `CRDT_PERSISTENCE_UNAVAILABLE:binding-in-use`
+  // and held no reason, no exit code and no OS. It was the top win32 issue.
+  it('ships the redacted preflight reason so the issue is debuggable', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockPreflight
+      .mockResolvedValueOnce(failed('store', 'utility'))
+      .mockResolvedValueOnce(failed('store', 'node'))
+
+    expect(await openCrdtPersistence(STORE)).toBeNull()
+
+    const { message } = reportedEvent().error as { message: string }
+    expect(message).toContain('CRDT persistence unavailable at binding-in-use')
+    expect(message).toContain('transport=node')
+    expect(message).toContain('0xC0000005')
+    expect(message.length).toBeLessThanOrEqual(512)
   })
 
   it('leaves the store alone when the control directory cannot be cleared', async () => {

--- a/apps/desktop/src/main/sync/crdt-persistence.ts
+++ b/apps/desktop/src/main/sync/crdt-persistence.ts
@@ -6,6 +6,8 @@ import { createLogger } from '../lib/logger'
 import { runCrdtPreflight, type CrdtPreflightResult } from './crdt-preflight'
 import { moveStoreDir } from './crdt-store-move'
 import { trackMainEvent } from '../telemetry/track'
+import { getMainRedactOptions } from '../telemetry/redact-options'
+import { redactText } from '@memry/contracts/redact'
 
 // Same scope as crdt-provider on purpose: every line below was emitted under
 // 'CrdtProvider' before this module was split out of it, and production log
@@ -49,12 +51,22 @@ type FailurePoint = CrdtPreflightResult['stage'] | 'probe'
  * were therefore indistinguishable, and "how many users are running in-memory"
  * had no answer. This event is the answer; the preflight crash is not.
  *
- * Everything shipped is a bounded token: the stage and transport enums and the
- * event name. The reason string is deliberately NOT sent — it can carry a
- * store path, and `SafeDimensionValueSchema` is a blocklist, not a guarantee.
+ * The stage and transport ride as bounded tokens. The reason string ships too,
+ * but only through `redactText` with the main-process vault root and salted
+ * hasher — the same path every other error message takes. It stays out of
+ * `dimensions`, where `SafeDimensionValueSchema` is a blocklist rather than a
+ * guarantee; the redacted `error.message` field is the one built for free text.
+ * Without it this event's Error Tracking issue was titled after its own error
+ * code and carried nothing else at all (#1989).
  */
 function reportPersistenceUnavailable(preflight: CrdtPreflightResult | null): void {
   const at: FailurePoint = preflight && !preflight.ok ? (preflight.stage ?? 'bootstrap') : 'probe'
+  const message = [
+    `CRDT persistence unavailable at ${at}`,
+    `transport=${preflight?.transport ?? 'none'}`,
+    `os=${os.platform()} ${os.release()}`,
+    `reason=${preflight?.reason ?? 'unknown'}`
+  ].join(' ')
   trackMainEvent('app_error_seen', {
     surface: 'app',
     action: 'init',
@@ -64,6 +76,7 @@ function reportPersistenceUnavailable(preflight: CrdtPreflightResult | null): vo
     // Same `CODE:detail` shape as the other main-process error codes, so the
     // stage is groupable in error tracking without spending the one dimension.
     errorCode: `CRDT_PERSISTENCE_UNAVAILABLE:${at}`,
+    error: { message: redactText(message, getMainRedactOptions()).slice(0, 512) },
     // At most one dimension is allowed to leave the device, and this is the
     // one worth having: a 'node' verdict means the Chromium-free fallback
     // failed too, i.e. the binding is broken on this machine rather than the

--- a/apps/desktop/src/main/telemetry/crash-marker.test.ts
+++ b/apps/desktop/src/main/telemetry/crash-marker.test.ts
@@ -105,6 +105,28 @@ describe('crash marker', () => {
     )
   })
 
+  // The marker is a file on disk. An over-512 message fails the schema at the
+  // sync-server, which 400s the whole batch and the client then drops it for
+  // good — so a torn write must not cost 100 unrelated events.
+  it('bounds a corrupt marker field instead of shipping it', () => {
+    fs.writeFileSync(
+      markerFile(),
+      JSON.stringify({
+        sessionId: 'prior',
+        startedAt: new Date('2026-08-06T10:00:00.000Z').toISOString(),
+        lastAliveAt: new Date('2026-08-06T10:00:01.000Z').toISOString(),
+        shutdownFailure: `/Users/kaan/${'x'.repeat(600)}.md`
+      })
+    )
+
+    detectUncleanShutdown()
+
+    const [, options] = vi.mocked(trackMainEvent).mock.calls[0]
+    expect(options.error?.message).toBe(
+      'Unclean shutdown [failure=none] [step=unknown] [prior_version=unknown] [uptime_ms=1000] [marker=parsed]'
+    )
+  })
+
   it('still emits app_crashed when the marker is unparseable — presence IS the signal', () => {
     // #given a corrupt marker
     fs.writeFileSync(markerFile(), 'not json at all')

--- a/apps/desktop/src/main/telemetry/crash-marker.test.ts
+++ b/apps/desktop/src/main/telemetry/crash-marker.test.ts
@@ -75,6 +75,36 @@ describe('crash marker', () => {
     )
   })
 
+  // #1989: UNCLEAN_SHUTDOWN was an Error Tracking issue titled after its own
+  // error code, with nothing in it. The message is what #1993 has to read.
+  it('names the shutdown phase, prior version and uptime in the message', () => {
+    const startedAt = new Date('2026-08-06T10:00:00.000Z').toISOString()
+    const lastAliveAt = new Date('2026-08-06T10:01:30.000Z').toISOString()
+    fs.writeFileSync(
+      markerFile(),
+      JSON.stringify({
+        sessionId: 'prior',
+        startedAt,
+        lastAliveAt,
+        appVersion: '1.2.3',
+        shutdownFailure: 'timeout',
+        shutdownStep: 'crdt-flush'
+      })
+    )
+
+    detectUncleanShutdown()
+
+    expect(trackMainEvent).toHaveBeenCalledWith(
+      'app_crashed',
+      expect.objectContaining({
+        error: {
+          message:
+            'Unclean shutdown [failure=timeout] [step=crdt-flush] [prior_version=1.2.3] [uptime_ms=90000] [marker=parsed]'
+        }
+      })
+    )
+  })
+
   it('still emits app_crashed when the marker is unparseable — presence IS the signal', () => {
     // #given a corrupt marker
     fs.writeFileSync(markerFile(), 'not json at all')

--- a/apps/desktop/src/main/telemetry/crash-marker.ts
+++ b/apps/desktop/src/main/telemetry/crash-marker.ts
@@ -10,6 +10,8 @@ import path from 'node:path'
 import { app } from 'electron'
 
 import { createLogger } from '../lib/logger'
+import { toSafeToken } from '@memry/contracts/telemetry-api'
+
 import { trackMainEvent } from './track'
 
 const logger = createLogger('CrashMarker')
@@ -98,12 +100,25 @@ export const detectUncleanShutdown = (): void => {
       : marker?.shutdownFailure === 'cleanup_error'
         ? 'SHUTDOWN_CLEANUP_FAILED'
         : 'UNCLEAN_SHUTDOWN'
+  // The errorCode alone is the whole Error Tracking issue title, so an
+  // UNCLEAN_SHUTDOWN row said nothing about which session died or where (#1989).
+  // Every field here is already bounded — an enum, a step token, a version, a
+  // duration — so the message is assembled rather than redacted.
+  const message = [
+    `Unclean shutdown [failure=${marker?.shutdownFailure ?? 'none'}]`,
+    `[step=${toSafeToken(marker?.shutdownStep, 'unknown')}]`,
+    `[prior_version=${toSafeToken(marker?.appVersion, 'unknown')}]`,
+    `[uptime_ms=${durationMs ?? 'unknown'}]`,
+    `[marker=${marker ? 'parsed' : 'unreadable'}]`
+  ].join(' ')
+
   trackMainEvent('app_crashed', {
     surface: 'app',
     action: 'unclean_shutdown',
     source: 'main_process',
     result: 'failed',
     errorCode,
+    error: { message },
     metrics: durationMs === undefined ? undefined : { durationMs },
     dimensions: marker?.appVersion ? { prior_app_version: marker.appVersion } : undefined
   })

--- a/apps/desktop/src/main/telemetry/crash-marker.ts
+++ b/apps/desktop/src/main/telemetry/crash-marker.ts
@@ -10,8 +10,6 @@ import path from 'node:path'
 import { app } from 'electron'
 
 import { createLogger } from '../lib/logger'
-import { toSafeToken } from '@memry/contracts/telemetry-api'
-
 import { trackMainEvent } from './track'
 
 const logger = createLogger('CrashMarker')
@@ -42,6 +40,15 @@ interface SessionMarker {
 // but the marker is a file on disk: anything that survived a hand edit or a torn
 // write must degrade to the plain code rather than ship as a dimension value.
 const SHUTDOWN_STEP_TOKEN = /^[a-z][a-z0-9-]{0,39}$/
+
+// The marker's string fields, as they may appear in a shipped message. This
+// REJECTS rather than substitutes: `toSafeToken` would turn a stray
+// /Users/kaan/secret.md into _Users_kaan_secret_md, which still leaks its
+// structure — the same reasoning TYPED_ERROR_CODE is built on.
+const MARKER_FIELD_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,39}$/
+
+const markerField = (value: string | undefined, fallback: string): string =>
+  value && MARKER_FIELD_TOKEN.test(value) ? value : fallback
 
 const shutdownTimeoutCode = (step: string | undefined): string =>
   step && SHUTDOWN_STEP_TOKEN.test(step)
@@ -102,15 +109,23 @@ export const detectUncleanShutdown = (): void => {
         : 'UNCLEAN_SHUTDOWN'
   // The errorCode alone is the whole Error Tracking issue title, so an
   // UNCLEAN_SHUTDOWN row said nothing about which session died or where (#1989).
-  // Every field here is already bounded — an enum, a step token, a version, a
-  // duration — so the message is assembled rather than redacted.
+  //
+  // Every interpolated field is bounded before it lands here, and the join is
+  // capped, for the same reason SHUTDOWN_STEP_TOKEN exists: the marker is a file
+  // on disk, and a hand edit or a torn write can put anything in these fields.
+  // An over-512 message fails TelemetryErrorDetailSchema at the sync-server,
+  // which 400s the WHOLE batch — and the client classifies 4xx as permanently
+  // rejected, so up to 100 unrelated events would be dropped every launch until
+  // the marker cleared.
   const message = [
-    `Unclean shutdown [failure=${marker?.shutdownFailure ?? 'none'}]`,
-    `[step=${toSafeToken(marker?.shutdownStep, 'unknown')}]`,
-    `[prior_version=${toSafeToken(marker?.appVersion, 'unknown')}]`,
+    `Unclean shutdown [failure=${markerField(marker?.shutdownFailure, 'none')}]`,
+    `[step=${markerField(marker?.shutdownStep, 'unknown')}]`,
+    `[prior_version=${markerField(marker?.appVersion, 'unknown')}]`,
     `[uptime_ms=${durationMs ?? 'unknown'}]`,
     `[marker=${marker ? 'parsed' : 'unreadable'}]`
-  ].join(' ')
+  ]
+    .join(' ')
+    .slice(0, 512)
 
   trackMainEvent('app_crashed', {
     surface: 'app',

--- a/apps/desktop/src/main/telemetry/diagnostics.test.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.test.ts
@@ -245,10 +245,10 @@ describe('telemetry diagnostics', () => {
           error: expect.objectContaining({ stack: expect.stringContaining('at ') })
         })
       )
-      // #and the reason's value never ships
-      const serialized = JSON.stringify(trackMainEventMock.mock.calls[0])
-      expect(serialized).not.toContain('blew up')
-      expect(serialized).not.toContain('@memrynote.com')
+      // #and the reason's text ships redacted rather than dropped (#1989): the
+      // e-mail is masked, the rest is what makes the issue readable
+      const [, options] = trackMainEventMock.mock.calls[0]
+      expect(options.error.message).toBe('vault sync for <email> blew up')
     })
 
     it('adopts the frames of a cross-realm error that fails instanceof Error', () => {
@@ -269,6 +269,10 @@ describe('telemetry diagnostics', () => {
           error: expect.objectContaining({ stack: expect.stringContaining('at loadVault') })
         })
       )
+      // The message rides along, with the home path collapsed and the note
+      // basename hashed away.
+      const [, options] = trackMainEventMock.mock.calls[0]
+      expect(options.error.message).toBe('opening ~/[name].md failed')
       expect(JSON.stringify(trackMainEventMock.mock.calls[0])).not.toContain('private.md')
     })
 

--- a/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.test.ts
+++ b/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.test.ts
@@ -88,10 +88,10 @@ describe('renderer telemetry diagnostics', () => {
         error: expect.objectContaining({ stack: expect.stringContaining('at ') })
       })
     )
-    // #and the reason's value never ships
-    const serialized = JSON.stringify(trackTelemetryMock.mock.calls[0])
-    expect(serialized).not.toContain('secret.md')
-    expect(serialized).not.toContain('boom')
+    // #and the reason's text ships redacted rather than dropped (#1989): the
+    // home path collapses and the note basename is masked
+    const [, options] = trackTelemetryMock.mock.calls[0]
+    expect(options.error.message).toBe('boom at ~/[name].md')
   })
 
   it('captures the error class and source location of a window error with no error object', () => {
@@ -121,10 +121,11 @@ describe('renderer telemetry diagnostics', () => {
         })
       })
     )
-    // #and neither the message text nor the username ships
-    const serialized = JSON.stringify(trackTelemetryMock.mock.calls[0])
-    expect(serialized).not.toContain('focus')
-    expect(serialized).not.toContain('/Users/kaan')
+    // #and the message ships so the issue has a title (#1989), while the
+    // username in the filename stays masked
+    const [, options] = trackTelemetryMock.mock.calls[0]
+    expect(options.error.message).toBe('Uncaught TypeError: n.focus is not a function')
+    expect(JSON.stringify(trackTelemetryMock.mock.calls[0])).not.toContain('/Users/kaan')
   })
 
   it('emits structured renderer logs', () => {

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -466,6 +466,19 @@ Four rules that are load-bearing:
 A React component stack is promoted to frames when there is no JS stack, and always ships intact as
 `$exception_component_stack`.
 
+When there is no message the transform falls back to the error code, which makes the issue title
+identical to the code and tells an engineer nothing new. That fallback sets
+**`exception_message_missing: true`** on the event, so a message-less reporting site is countable
+on a dashboard instead of looking healthy:
+
+```sql
+SELECT properties.$exception_fingerprint AS fp, count() c, uniq(distinct_id) u
+FROM events
+WHERE event = '$exception' AND properties.exception_message_missing
+  AND timestamp > now() - INTERVAL 7 DAY
+GROUP BY fp ORDER BY u DESC
+```
+
 Errors that carry no JS stack by construction — `child-process-gone` for a crashed utility worker,
 where the process that died is not the one reporting — instead carry a synthesized message naming
 the worker, reason and exit status, so their issue page is not blank.
@@ -686,8 +699,11 @@ cross-realm `Error` that fails `instanceof Error` — and those carry no stack, 
 landed in Loki as an unactionable bare `Error` with an empty stack. Reasons are normalized before
 reporting: a real `Error` passes through, a cross-realm error's own frames are adopted, and
 anything else gets a stack synthesized at the handler plus a code naming the reason's type
-(`Rejection_string`, `Rejection_Object`, `Rejection_undefined`). The reason's message or value is
-never copied — only its shape. A reason that crossed a structured-clone or IPC boundary keeps its
+(`Rejection_string`, `Rejection_Object`, `Rejection_undefined`). The reason's message rides along
+**redacted**, not dropped: it goes through the same `redactText` pass as any other error message
+before it leaves the device. Omitting it made every `Rejection_*` row in Error Tracking an issue
+titled after its own error code, with nothing inside to triage. A reason that crossed a
+structured-clone or IPC boundary keeps its
 `.name` but loses both its stack and its constructor; that name is preferred over the constructor
 name, so it reports `Rejection_TypeError` rather than collapsing to `Rejection_Error`. When the
 code is a `Rejection_*` name the stack is the handler's own frames, not the fault's — the code is
@@ -698,7 +714,8 @@ failure paths report only a message and a source location, which previously land
 with an empty stack and nothing to triage. The error class is recovered from the message's leading
 token (`Uncaught TypeError: …` → `TypeError`, subject to the same enum-token rule) and the
 `filename`/`lineno`/`colno` are rebuilt into a stack frame, so the code location survives the same
-frame filter and redaction as a real stack. The message text itself is still never shipped.
+frame filter and redaction as a real stack. The message text ships too, redacted on the device by
+the same pass — without it a cross-origin failure was a `WindowError` issue titled `WindowError`.
 
 Because a rejection reason or `event.error` can be **any** value — including a `Proxy` whose traps
 throw or an object with throwing getters — every property read in this path (including `instanceof`,

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -314,6 +314,16 @@ at most one dimension and that slot already carries `prior_app_version`. The `SH
 prefix is preserved so a query written against the old code still matches. Only a bounded
 kebab-case token is accepted from the marker; anything else degrades to the plain code.
 
+`app_crashed` also carries an assembled **message** naming the shutdown failure, the overrunning
+step, the prior version, the observed uptime and whether the marker parsed — without it the Error
+Tracking issue was titled `UNCLEAN_SHUTDOWN` and held nothing else. The marker is a file on disk, so
+every string field is **rejected outright** unless it matches an enum-ish token (a
+character-substituted path still leaks its structure), and the assembled message is capped at 512
+characters. That cap is not cosmetic: an over-length message fails `TelemetryErrorDetailSchema` at
+the sync-server, which rejects the **whole batch** with a 400, and the desktop client treats a 4xx
+as permanent — one corrupt marker field would otherwise discard up to 100 unrelated events on every
+launch until the marker cleared.
+
 ### Shutdown Budget
 
 `before-quit` runs its cleanup as an ordered list of named steps under **one shared deadline**

--- a/apps/sync-server/src/services/posthog-transform.test.ts
+++ b/apps/sync-server/src/services/posthog-transform.test.ts
@@ -500,6 +500,22 @@ describe('exceptionEvent', () => {
     expect(list[0].value).toBe('NO_DETAIL')
   })
 
+  // #1989: an issue titled after its own error code is indistinguishable from a
+  // healthy one until you open it. The flag is what a dashboard counts.
+  it('flags the fallback so message-less reports are countable', () => {
+    const result = exceptionEvent(batchFixture(), eventFixture({ errorCode: 'NO_DETAIL' }), ctx)
+    expect(result?.properties.exception_message_missing).toBe(true)
+  })
+
+  it('does not flag an exception that carries a message', () => {
+    const result = exceptionEvent(
+      batchFixture(),
+      eventFixture({ errorCode: 'DB_LOCKED', error: { message: 'database is locked' } }),
+      ctx
+    )
+    expect(result?.properties).not.toHaveProperty('exception_message_missing')
+  })
+
   it('omits $exception_fingerprint entirely when there is no errorCode', () => {
     const result = exceptionEvent(
       batchFixture(),

--- a/apps/sync-server/src/services/posthog-transform.ts
+++ b/apps/sync-server/src/services/posthog-transform.ts
@@ -378,6 +378,12 @@ export const exceptionEvent = (
         }
       ],
       $exception_level: 'error',
+      // The `value || type` fallback above is silent by design, which made a
+      // reporting site that ships no message look identical to a failure that
+      // genuinely has none — four of the top ten issues were titled after their
+      // own error code and nobody could tell why (#1989). This flag is what a
+      // dashboard counts to catch the next instrumentation hole.
+      ...(message ? {} : { exception_message_missing: true }),
       // Kept raw alongside the frames: for a React error the component tree is
       // the fastest read during triage, and flattening it into frames would lose
       // the nesting.

--- a/packages/contracts/src/telemetry-api.test.ts
+++ b/packages/contracts/src/telemetry-api.test.ts
@@ -739,9 +739,38 @@ describe('normalizeRejectionReason', () => {
     expect(normalized).toBeInstanceOf(Error)
     expect(normalized.name).toBe('Rejection_string')
     expect(buildErrorDetail(normalized)?.stack).toContain('at ')
-    // #and the reason's value is never shipped
-    expect(normalized.message).toBe('')
-    expect(JSON.stringify(buildErrorDetail(normalized))).not.toContain('on fire')
+    // #and the reason's own text rides along, which is the only thing that makes
+    // the Rejection_string issue readable at all (#1989)
+    expect(buildErrorDetail(normalized)?.message).toBe('everything is on fire')
+  })
+
+  // #1989: the reason's message used to be dropped outright, so every
+  // Rejection_* issue in Error Tracking was titled after its own error code.
+  // Redaction, not omission, is the privacy control.
+  it.each([
+    ['a home path', 'could not open /Users/kaan/Vault/notes', '/Users/kaan'],
+    ['an e-mail', 'sync rejected for kaan@example.com', 'kaan@example.com'],
+    ['a note title', 'failed to parse Quarterly Review.md', 'Quarterly Review'],
+    ['a bearer token', 'Authorization: Bearer abc.def.ghi expired', 'abc.def.ghi']
+  ])('redacts %s carried in a rejection message', (_label, raw, secret) => {
+    const detail = buildErrorDetail(normalizeRejectionReason(raw))
+
+    expect(detail?.message).toBeTruthy()
+    expect(detail?.message).not.toContain(secret)
+  })
+
+  it('carries the message of a cross-realm error, redacted', () => {
+    // #given an error from another realm whose message names a vault note
+    const crossRealm = {
+      name: 'Error',
+      message: 'private note /Users/kaan/secret.md failed',
+      stack: 'Error: boom\n    at doThing (/app/out/main.js:1:1)'
+    }
+
+    const detail = buildErrorDetail(normalizeRejectionReason(crossRealm))
+
+    // #then the message survives with the path and the title both masked
+    expect(detail?.message).toBe('private note ~/[name].md failed')
   })
 
   it('ships the error message, redacted, so the issue title says what broke', () => {
@@ -915,8 +944,9 @@ describe('normalizeWindowError', () => {
     const detail = buildErrorDetail(normalized)
     expect(detail?.stack).toContain('at ')
     expect(detail?.stack).toContain('index-VP6Jd1Vs.js:121718:22')
-    // #and neither the message text nor the username rides along
-    expect(JSON.stringify(detail)).not.toContain('focus')
+    // #and the message rides along so the issue is readable (#1989), while the
+    // username in the filename is still masked
+    expect(detail?.message).toBe('Uncaught TypeError: n.focus is not a function')
     expect(JSON.stringify(detail)).not.toContain('/Users/kaan')
   })
 
@@ -924,9 +954,21 @@ describe('normalizeWindowError', () => {
     // #given the opaque cross-origin case: "Script error." and no location
     const normalized = normalizeWindowError({ error: null, message: 'Script error.' })
 
-    // #then a stable, non-leaking code is reported
+    // #then a stable, non-leaking code is reported, and the message says which
+    // of the several message-less window failures this one was
     expect(toErrorCode(normalized)).toBe('WindowError')
-    expect(normalized.message).toBe('')
+    expect(buildErrorDetail(normalized)?.message).toBe('Script error.')
+  })
+
+  it('redacts a path carried in a window error message', () => {
+    const normalized = normalizeWindowError({
+      error: null,
+      message: '/Users/kaan/secret.md: failed to load'
+    })
+
+    // #then the code stays a bounded token and the message ships masked
+    expect(normalized.name).toBe('WindowError')
+    expect(buildErrorDetail(normalized)?.message).toBe('~/[name].md: failed to load')
   })
 
   it('does not adopt a message-derived name that is not an enum-ish token', () => {

--- a/packages/contracts/src/telemetry-api.ts
+++ b/packages/contracts/src/telemetry-api.ts
@@ -509,6 +509,19 @@ const enumishName = (value: unknown): string | undefined => {
   return typeof name === 'string' && TYPED_ERROR_CODE.test(name) ? name : undefined
 }
 
+// The reason's own text, read defensively: a rejection can be a hostile Proxy,
+// and `readProp` swallows a throwing getter. Capped here so a megabyte-long
+// reason cannot reach `redactText`; buildErrorDetail caps again at 512 after
+// redaction.
+const MAX_RAW_MESSAGE = 2048
+
+const reasonMessage = (reason: unknown): string | undefined => {
+  const message = readProp(reason, 'message')
+  if (typeof message === 'string' && message) return message.slice(0, MAX_RAW_MESSAGE)
+  if (typeof reason === 'string' && reason) return reason.slice(0, MAX_RAW_MESSAGE)
+  return undefined
+}
+
 const rejectionTypeName = (reason: unknown): string => {
   if (reason === null) return 'Rejection_null'
   if (reason === undefined) return 'Rejection_undefined'
@@ -530,14 +543,19 @@ const rejectionTypeName = (reason: unknown): string => {
  *
  * Real Errors pass through; a cross-realm error's own frames are adopted;
  * anything else gets a stack synthesized at the handler plus a name describing
- * the reason's type/constructor. Privacy: the reason's message/value is NEVER
- * copied — only its shape. buildErrorDetail still strips the stack header.
+ * the reason's type/constructor.
+ *
+ * Privacy: the reason's message is carried, then redacted by `buildErrorDetail`
+ * on the device — redaction is the control, not omission (#1989). Dropping it
+ * made `Rejection_Error` an Error Tracking issue whose title was its own code
+ * and whose body held nothing an engineer could act on. `buildErrorDetail`
+ * still strips the stack header, so the message only ships once, redacted.
  */
 export const normalizeRejectionReason = (reason: unknown): Error => {
   const frames = ownStackFrames(reason)
   if (isError(reason) && frames) return reason
 
-  const normalized = new Error()
+  const normalized = new Error(reasonMessage(reason))
   normalized.name = toSafeToken(rejectionTypeName(reason), 'Rejection_unknown')
   if (frames) {
     normalized.stack = frames
@@ -584,15 +602,22 @@ const sourceFrame = (report: WindowErrorReport): string | undefined => {
  * Chromium failure paths, and passing the bare `event.message` string on landed
  * in telemetry as `StringError` with no stack — nothing to triage at all.
  *
- * Privacy: the message is only pattern-matched for its leading error class; its
- * text is never copied. The filename rides along as a stack frame, so it goes
- * through the same redaction as any other frame.
+ * Privacy: the message is carried and redacted by `buildErrorDetail` on the
+ * device (#1989) — without it every cross-origin failure landed as a
+ * `WindowError` issue titled `WindowError`. Only its leading error class is
+ * pattern-matched for the code, which stays a bounded token. The filename rides
+ * along as a stack frame, so it goes through the same redaction as any frame.
  */
 export const normalizeWindowError = (report: WindowErrorReport): Error => {
   const frames = ownStackFrames(report.error)
   if (isError(report.error) && frames) return report.error
 
-  const normalized = new Error()
+  const normalized = new Error(
+    reasonMessage(report.error) ??
+      (typeof report.message === 'string' && report.message
+        ? report.message.slice(0, MAX_RAW_MESSAGE)
+        : undefined)
+  )
   const messageClass =
     typeof report.message === 'string' ? MESSAGE_ERROR_CLASS.exec(report.message)?.[1] : undefined
   normalized.name = toSafeToken(enumishName(report.error) ?? messageClass, 'WindowError')


### PR DESCRIPTION
## Summary

Four of the top ten PostHog Error Tracking issues had no message, no stack and no context — their title was literally their own error code (`CRDT_PERSISTENCE_UNAVAILABLE:binding-in-use`, `Rejection_Error`, `UNCLEAN_SHUTDOWN`, `WindowError`), across 72 users. Re-validated on 2026-09-04: still live on `2026.903.2`, 13 users on the CRDT one alone.

Two causes.

`normalizeRejectionReason` and `normalizeWindowError` discarded the message on purpose, because a rejection reason can embed a note title or a path. But `redactText` already runs on every message `buildErrorDetail` produces, so the real choice was redact or drop, and drop was picked. Both now carry the message and let the existing on-device redaction handle it; the sync-server still re-runs it in mask mode as a backstop.

`CRDT_PERSISTENCE_UNAVAILABLE:*` and `UNCLEAN_SHUTDOWN` passed no `error` object at all. The CRDT site now ships the stage, transport, OS and preflight reason through `redactText` with the main-process vault root and salted hasher — the same path every other error message takes, and out of `dimensions`, where `SafeDimensionValueSchema` is a blocklist rather than a guarantee. The crash marker ships its shutdown phase, step, prior version and uptime, all bounded by construction.

`exceptionEvent`'s `value = message || type` fallback stays, but now sets `exception_message_missing: true`, so the next instrumentation hole is countable on a dashboard instead of looking healthy.

Fingerprints are unchanged: `toErrorCode` never reads the message, so no existing issue forks.

Blocks #1993, which cannot be diagnosed until reports carry a message. Part of #1987.

Closes #1989

## Release note
none

## Test plan
- `pnpm exec vitest run --root packages/contracts src/telemetry-api.test.ts` — 89 passed. Redaction pinned for a home path, an e-mail, a note title, a bearer token and a cross-realm error.
- `apps/sync-server`: `pnpm exec vitest run` — 80 files, 1260 passed.
- `apps/desktop` main project: `crdt-persistence.test.ts` 9 passed, `crash-marker.test.ts` 10 passed.
- `pnpm typecheck`, `pnpm check:contracts`, `pnpm docs:impact --base 4812eda03 --strict`, `pnpm docs:build` — all green.
- `pnpm check:architecture` fails on `apps/mobile/src/features/notes/__tests__/vault-db-harness.ts -> node:sqlite`. Pre-existing on `origin/main`, untouched by this branch.
