### PR TITLE
fix(updater): tell the user when an update keeps failing to install

### DIFF
--- a/apps/desktop/src/main/updater-install-health.test.ts
+++ b/apps/desktop/src/main/updater-install-health.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { mockApp } from '@tests/utils/mock-electron'
+
+vi.mock('electron', () => ({
+  app: mockApp
+}))
+
+vi.mock('./lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+import {
+  UPDATE_INSTALL_HEALTH_FILENAME,
+  reconcileUpdateInstallHealth,
+  recordUpdateInstallFailure
+} from './updater-install-health'
+
+// The verbatim production shapes from #1999: the build two installs sat on for
+// four releases, and the target whose Squirrel.Mac staging kept failing.
+const STUCK_BUILD = 'v2026-08-17.1'
+const TARGET = 'v2026-09-03.2'
+
+describe('update install health', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-update-install-health-'))
+    mockApp.getPath.mockImplementation((name: string) =>
+      name === 'userData' ? tempDir : `/mock/${name}`
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  const healthFile = (): string => path.join(tempDir, UPDATE_INSTALL_HEALTH_FILENAME)
+  const writeRaw = (contents: string): void => fs.writeFileSync(healthFile(), contents, 'utf-8')
+
+  it('escalates on the third failed install of the same update, and only once', () => {
+    // #given two launches whose install of the same target already failed
+    expect(recordUpdateInstallFailure(STUCK_BUILD, TARGET)).toEqual({
+      consecutiveFailures: 1,
+      stuck: false
+    })
+    expect(recordUpdateInstallFailure(STUCK_BUILD, TARGET)).toEqual({
+      consecutiveFailures: 2,
+      stuck: false
+    })
+
+    // #when a third launch fails the same way
+    // #then the streak escalates exactly once, and stays latched afterwards
+    expect(recordUpdateInstallFailure(STUCK_BUILD, TARGET)).toEqual({
+      consecutiveFailures: 3,
+      stuck: true
+    })
+    expect(recordUpdateInstallFailure(STUCK_BUILD, TARGET)).toEqual({
+      consecutiveFailures: 4,
+      stuck: false
+    })
+  })
+
+  it('keeps the streak across launches, which is the whole point of the file', () => {
+    // #given a streak written by earlier sessions
+    recordUpdateInstallFailure(STUCK_BUILD, TARGET)
+    recordUpdateInstallFailure(STUCK_BUILD, TARGET)
+
+    // #when a fresh launch reconciles and then fails again
+    expect(reconcileUpdateInstallHealth(STUCK_BUILD)).toBeNull()
+
+    // #then the count continued rather than restarting at one
+    expect(recordUpdateInstallFailure(STUCK_BUILD, TARGET)).toEqual({
+      consecutiveFailures: 3,
+      stuck: true
+    })
+  })
+
+  it('restarts the streak when a NEW update is the one failing', () => {
+    // #given an escalated streak against one target
+    recordUpdateInstallFailure(STUCK_BUILD, TARGET)
+    recordUpdateInstallFailure(STUCK_BUILD, TARGET)
+    recordUpdateInstallFailure(STUCK_BUILD, TARGET)
+
+    // #when a different update fails its first install
+    // #then one failure of a different update is not a stranded install
+    expect(recordUpdateInstallFailure(STUCK_BUILD, 'v2026-09-10.1')).toEqual({
+      consecutiveFailures: 1,
+      stuck: false
+    })
+    expect(reconcileUpdateInstallHealth(STUCK_BUILD)).toBeNull()
+  })
+
+  it('re-surfaces an escalated streak on every launch the app is still stuck', () => {
+    // #given three failed installs on this build
+    recordUpdateInstallFailure(STUCK_BUILD, TARGET)
+    recordUpdateInstallFailure(STUCK_BUILD, TARGET)
+    recordUpdateInstallFailure(STUCK_BUILD, TARGET)
+
+    // #when the app boots again as the same old build
+    // #then the user is told which update to install by hand, again
+    expect(reconcileUpdateInstallHealth(STUCK_BUILD)).toBe(TARGET)
+    expect(reconcileUpdateInstallHealth(STUCK_BUILD)).toBe(TARGET)
+  })
+
+  it('clears everything once the app boots as a different build', () => {
+    // #given an escalated streak
+    recordUpdateInstallFailure(STUCK_BUILD, TARGET)
+    recordUpdateInstallFailure(STUCK_BUILD, TARGET)
+    recordUpdateInstallFailure(STUCK_BUILD, TARGET)
+
+    // #when the app boots as the version it was trying to install
+    expect(reconcileUpdateInstallHealth(TARGET)).toBeNull()
+
+    // #then the file is gone and a later failure starts from scratch
+    expect(fs.existsSync(healthFile())).toBe(false)
+    expect(recordUpdateInstallFailure(TARGET, 'v2026-09-10.1')).toEqual({
+      consecutiveFailures: 1,
+      stuck: false
+    })
+  })
+
+  it('behaves exactly like a fresh install when no state file exists', () => {
+    // #given no file on disk, which is every install shipped before this change
+    // #when the app boots
+    expect(reconcileUpdateInstallHealth(STUCK_BUILD)).toBeNull()
+
+    // #then the first failure is the first failure
+    expect(recordUpdateInstallFailure(STUCK_BUILD, TARGET)).toEqual({
+      consecutiveFailures: 1,
+      stuck: false
+    })
+  })
+
+  it('degrades to no streak on a torn or corrupt file', () => {
+    // #given a half-written file, the shape a crash mid-write leaves behind
+    writeRaw('{"fromVersion":"v2026-08-17.1","targetVer')
+
+    // #when the updater reads it
+    // #then nothing is surfaced and the streak restarts rather than throwing
+    expect(reconcileUpdateInstallHealth(STUCK_BUILD)).toBeNull()
+    expect(recordUpdateInstallFailure(STUCK_BUILD, TARGET)).toEqual({
+      consecutiveFailures: 1,
+      stuck: false
+    })
+  })
+
+  it('rejects a hostile target version instead of substituting characters out of it', () => {
+    // #given a file whose target version is a path, not a version
+    writeRaw(
+      JSON.stringify({
+        fromVersion: STUCK_BUILD,
+        targetVersion: '/Users/kaan/x',
+        consecutiveFailures: 3,
+        escalated: true
+      })
+    )
+
+    // #when the app boots as the stuck build
+    // #then the record is refused whole: no sanitised version reaches the dialog
+    expect(reconcileUpdateInstallHealth(STUCK_BUILD)).toBeNull()
+  })
+
+  it('rejects an out-of-range failure count instead of trusting it', () => {
+    // #given a count that no honest run could have written
+    writeRaw(
+      JSON.stringify({
+        fromVersion: STUCK_BUILD,
+        targetVersion: TARGET,
+        consecutiveFailures: Number.MAX_SAFE_INTEGER,
+        escalated: false
+      })
+    )
+
+    // #when the next install fails
+    // #then the streak starts over rather than escalating off a bogus number
+    expect(recordUpdateInstallFailure(STUCK_BUILD, TARGET)).toEqual({
+      consecutiveFailures: 1,
+      stuck: false
+    })
+  })
+
+  it('rejects a non-boolean escalation latch', () => {
+    // #given a latch that is not a boolean
+    writeRaw(
+      JSON.stringify({
+        fromVersion: STUCK_BUILD,
+        targetVersion: TARGET,
+        consecutiveFailures: 3,
+        escalated: 'yes'
+      })
+    )
+
+    // #when the app boots as the stuck build
+    // #then the record is refused whole rather than read as escalated
+    expect(reconcileUpdateInstallHealth(STUCK_BUILD)).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/updater-install-health.ts
+++ b/apps/desktop/src/main/updater-install-health.ts
@@ -1,0 +1,166 @@
+// Cross-launch install-failure streak. macOS Squirrel.Mac stages a downloaded
+// update into its own ShipIt copy, and when that copy fails (`ditto: Could not
+// lstat …`, `No space left on device`) electron-updater's `error` event fires in
+// a session that then quits normally. Nothing about the failure survives the
+// quit, so the next launch re-serves the same cached zip to Squirrel and fails
+// the same way — two production installs sat on 2026.817.1 through four releases
+// with no user-facing signal at all (#1999). The shipped artifact was fine; only
+// the local staging copy failed.
+//
+// The check-phase streak in updater-error-severity.ts can live in memory because
+// its escalation window is one session. This one cannot: staging is re-attempted
+// on every auto-check while an update sits downloaded (electron-updater serves
+// the cached, already-validated zip via `done(false)` in AppUpdater, which
+// re-dispatches `update-downloaded`), but a user who quits after one or two
+// failures starts from zero on the next launch and never reaches the threshold.
+// Only a file on disk carries the streak across that quit. Same conventions as
+// telemetry/update-install-marker.ts and telemetry/crash-marker.ts:
+// synchronous, never throws, and a corrupt or half-written file degrades to "no
+// streak" rather than breaking the updater.
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { app } from 'electron'
+
+import { createLogger } from './lib/logger'
+
+const logger = createLogger('UpdateInstallHealth')
+
+export const UPDATE_INSTALL_HEALTH_FILENAME = 'update-install-health.json'
+
+/**
+ * Failed install attempts before the user is offered the manual installer.
+ * Attempts, not launches: staging is retried on every auto-check, so a
+ * persistently stuck install reaches this within ~30 minutes rather than over
+ * three days. Three because a single failure is the disk that was momentarily
+ * full, while a higher bar only extends the silent loop this exists to break.
+ */
+const STUCK_INSTALL_FAILURES = 3
+
+/**
+ * Guards the version strings read back off disk before they are handed to the
+ * updater state and rendered. Deliberately not `toSafeToken`: that substitutes
+ * illegal characters, which would turn a hand-edited or torn-write path into a
+ * plausible-looking version (`_Users_kaan_x`) instead of rejecting it.
+ */
+const VERSION_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/
+
+/** A streak this long is already far past the threshold; the cap only stops a
+ * garbage value from being written back and growing without bound. */
+const MAX_RECORDED_FAILURES = 999
+
+interface UpdateInstallHealth {
+  /**
+   * Display version of the build that keeps failing to update. The one value
+   * that says the streak is still live: booting as anything else means the app
+   * moved on, whether via this update, a later one, or a manual install.
+   */
+  fromVersion: string
+  /** Display version being installed. The streak is per target: a different
+   * update failing once is not a stranded install. */
+  targetVersion: string
+  consecutiveFailures: number
+  /** Latched once the streak escalated, so the user-facing dialog fires once per
+   * streak instead of on every subsequent failure. */
+  escalated: boolean
+}
+
+const healthPath = (): string => path.join(app.getPath('userData'), UPDATE_INSTALL_HEALTH_FILENAME)
+
+const parseHealth = (raw: string): UpdateInstallHealth | null => {
+  try {
+    const parsed = JSON.parse(raw) as Partial<UpdateInstallHealth>
+    if (!parsed || typeof parsed !== 'object') return null
+    const { fromVersion, targetVersion, consecutiveFailures, escalated } = parsed
+    if (typeof fromVersion !== 'string' || !VERSION_TOKEN.test(fromVersion)) return null
+    if (typeof targetVersion !== 'string' || !VERSION_TOKEN.test(targetVersion)) return null
+    if (
+      typeof consecutiveFailures !== 'number' ||
+      !Number.isInteger(consecutiveFailures) ||
+      consecutiveFailures < 1 ||
+      consecutiveFailures > MAX_RECORDED_FAILURES
+    ) {
+      return null
+    }
+    if (typeof escalated !== 'boolean') return null
+    return { fromVersion, targetVersion, consecutiveFailures, escalated }
+  } catch {
+    return null
+  }
+}
+
+const readHealth = (): UpdateInstallHealth | null => {
+  try {
+    return parseHealth(fs.readFileSync(healthPath(), 'utf-8'))
+  } catch {
+    return null // no file: no streak, which is every install that has never failed
+  }
+}
+
+const writeHealth = (health: UpdateInstallHealth): void => {
+  try {
+    fs.writeFileSync(healthPath(), JSON.stringify(health), 'utf-8')
+  } catch (error) {
+    logger.warn('Failed to persist the update-install streak; it restarts next launch', { error })
+  }
+}
+
+const clearHealth = (): void => {
+  try {
+    fs.rmSync(healthPath(), { force: true })
+  } catch (error) {
+    logger.warn('Failed to clear the update-install streak', { error })
+  }
+}
+
+/**
+ * Count one failed install attempt for `targetVersion` and report whether this
+ * is the attempt that crosses the threshold. `stuck` is true exactly once per
+ * streak, matching recordUpdaterCheckFailure's latch.
+ *
+ * The streak resets whenever either version changes: a new target means a
+ * different update, and a new `fromVersion` means an install did apply.
+ */
+export const recordUpdateInstallFailure = (
+  fromVersion: string,
+  targetVersion: string
+): { consecutiveFailures: number; stuck: boolean } => {
+  const existing = readHealth()
+  const previous =
+    existing && existing.fromVersion === fromVersion && existing.targetVersion === targetVersion
+      ? existing
+      : null
+  const consecutiveFailures = Math.min(
+    previous ? previous.consecutiveFailures + 1 : 1,
+    MAX_RECORDED_FAILURES
+  )
+  const stuck = !previous?.escalated && consecutiveFailures >= STUCK_INSTALL_FAILURES
+  writeHealth({
+    fromVersion,
+    targetVersion,
+    consecutiveFailures,
+    escalated: (previous?.escalated ?? false) || stuck
+  })
+  return { consecutiveFailures, stuck }
+}
+
+/**
+ * Reconcile the persisted streak against the build that is actually running.
+ * Call once per launch, before any install attempt.
+ *
+ * Returns the target version the user is still stranded on when the streak has
+ * already escalated, so the manual-installer dialog comes back on every launch
+ * the loop is still live — the escalation latch stops repeat *failures* from
+ * re-firing it, not repeat launches. Returns null in every other case, and
+ * clears the file once the app boots as a different build, which is the only
+ * honest evidence that an install applied.
+ */
+export const reconcileUpdateInstallHealth = (currentVersion: string): string | null => {
+  const health = readHealth()
+  if (!health) return null
+  if (health.fromVersion !== currentVersion) {
+    clearHealth()
+    return null
+  }
+  return health.escalated ? health.targetVersion : null
+}

--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -68,6 +68,10 @@ const mocks = vi.hoisted(() => {
     dialog: {
       showMessageBox: vi.fn()
     },
+    installHealth: {
+      recordUpdateInstallFailure: vi.fn(),
+      reconcileUpdateInstallHealth: vi.fn()
+    },
     // Stable across createLogger() calls so tests can assert on the enriched
     // updater-failure payloads (issue #842).
     logger: {
@@ -136,6 +140,12 @@ vi.mock('./telemetry/track', () => ({
 vi.mock('./telemetry/update-install-marker', () => ({
   markUpdateInstallStarted: vi.fn()
 }))
+// Reads and writes a JSON file under userData; the streak logic itself is
+// covered in updater-install-health.test.ts.
+vi.mock('./updater-install-health', () => ({
+  recordUpdateInstallFailure: mocks.installHealth.recordUpdateInstallFailure,
+  reconcileUpdateInstallHealth: mocks.installHealth.reconcileUpdateInstallHealth
+}))
 
 import { markUpdateInstallStarted } from './telemetry/update-install-marker'
 import { trackMainError, trackMainWarning } from './telemetry/diagnostics'
@@ -166,6 +176,11 @@ describe('updater', () => {
     mocks.app.getVersion.mockReturnValue('1.2.3')
     mocks.app.quit.mockClear()
     mocks.windows[0].webContents.send.mockClear()
+    mocks.installHealth.recordUpdateInstallFailure.mockReturnValue({
+      consecutiveFailures: 1,
+      stuck: false
+    })
+    mocks.installHealth.reconcileUpdateInstallHealth.mockReturnValue(null)
   })
 
   it('keeps updater unavailable outside packaged builds', async () => {
@@ -820,6 +835,61 @@ describe('updater', () => {
       expect(trackMainWarning).toHaveBeenLastCalledWith('updater', 'check', expect.any(Error), {
         retryCount: 1
       })
+    })
+  })
+
+  // macOS Squirrel.Mac fails to stage the update AFTER electron-updater has
+  // dispatched update-downloaded, so the error lands in the 'downloaded' phase
+  // and the next launch repeats it forever unless the streak is persisted.
+  describe('repeated background install failures (#1999)', () => {
+    it('counts a failure that arrives once the update is downloaded', async () => {
+      const updater = await loadUpdater()
+      updater.initializeUpdater()
+
+      mocks.autoUpdater.emit('update-downloaded', { version: '1.2.7' })
+      mocks.autoUpdater.emit('error', new Error('ditto: Could not lstat'))
+
+      expect(mocks.installHealth.recordUpdateInstallFailure).toHaveBeenCalledWith(
+        'v1.2.3',
+        'v1.2.7'
+      )
+      expect(updater.getUpdateState().installFailed).toBeNull()
+    })
+
+    it('offers the manual installer once the streak escalates', async () => {
+      mocks.installHealth.recordUpdateInstallFailure.mockReturnValue({
+        consecutiveFailures: 3,
+        stuck: true
+      })
+      const updater = await loadUpdater()
+      updater.initializeUpdater()
+
+      mocks.autoUpdater.emit('update-downloaded', { version: '1.2.7' })
+      mocks.autoUpdater.emit('error', new Error('ditto: Could not lstat'))
+
+      expect(updater.getUpdateState().installFailed).toEqual({ version: 'v1.2.7' })
+    })
+
+    it('leaves check and download failures to their own streak', async () => {
+      const updater = await loadUpdater()
+      updater.initializeUpdater()
+
+      mocks.autoUpdater.emit('checking-for-update')
+      mocks.autoUpdater.emit('error', new Error('net::ERR_NAME_NOT_RESOLVED'))
+      void updater.downloadUpdate()
+      mocks.autoUpdater.emit('error', new Error('disk full'))
+
+      expect(mocks.installHealth.recordUpdateInstallFailure).not.toHaveBeenCalled()
+    })
+
+    it('re-surfaces a streak that escalated in an earlier launch', async () => {
+      mocks.installHealth.reconcileUpdateInstallHealth.mockReturnValue('v2026-09-03.2')
+      const updater = await loadUpdater()
+
+      updater.initializeUpdater()
+
+      expect(mocks.installHealth.reconcileUpdateInstallHealth).toHaveBeenCalledWith('v1.2.3')
+      expect(updater.getUpdateState().installFailed).toEqual({ version: 'v2026-09-03.2' })
     })
   })
 

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -19,6 +19,7 @@ import {
   recordUpdaterCheckSuccess,
   resetUpdaterCheckHealth
 } from './updater-error-severity'
+import { recordUpdateInstallFailure, reconcileUpdateInstallHealth } from './updater-install-health'
 
 const logger = createLogger('Updater')
 
@@ -188,6 +189,42 @@ function currentErrorPhase(): UpdaterErrorPhase {
 }
 
 /**
+ * Count a failure that belongs to the install half of the pipeline, and surface
+ * the manual-installer path once the same update has failed to install enough
+ * times in a row (#1999).
+ *
+ * The phase is the whole gate, deliberately. `downloaded` is set only by the
+ * update-downloaded handler, and electron-updater's MacUpdater hands the file to
+ * Squirrel.Mac for staging in the same tick it dispatches that event — so an
+ * error arriving in this state is a failed install attempt for
+ * `state.availableVersion`, which is what the macOS ShipIt `ditto` failures are.
+ * `install` is the explicit Restart-to-install path.
+ *
+ * `idle` is NOT counted even though the same failure can land there once the
+ * status has moved on: it is also the phase for every error that arrives while
+ * no operation is running, and padding the streak with unrelated failures would
+ * hand a user the "download it manually" dialog for an update that is fine.
+ * Under-counting only delays the escalation by a launch.
+ */
+function noteInstallAttemptFailure(phase: UpdaterErrorPhase): void {
+  if (phase !== 'downloaded' && phase !== 'install') {
+    return
+  }
+  const targetVersion = state.availableVersion
+  if (!targetVersion) {
+    return
+  }
+  const { consecutiveFailures, stuck } = recordUpdateInstallFailure(
+    getCurrentDisplayVersion(),
+    targetVersion
+  )
+  logger.warn('update install attempt failed', { targetVersion, consecutiveFailures })
+  if (stuck) {
+    noteFailedUpdateInstall(targetVersion)
+  }
+}
+
+/**
  * Extra attempts for a check that died on an expired GitHub signed-asset URL,
  * and the pause before each. A check is three small GETs, so asking again is
  * cheap; the delay is there because the expiry is a timing race, not a state we
@@ -290,6 +327,13 @@ export function initializeUpdater(): void {
 
   initialized = true
   resetUpdaterCheckHealth()
+  // A streak that already escalated is re-surfaced on every launch it is still
+  // live: the user stays stuck on the old build until they install manually, and
+  // the escalation latch only stops repeat failures from re-firing the dialog.
+  const strandedInstallVersion = reconcileUpdateInstallHealth(getCurrentDisplayVersion())
+  if (strandedInstallVersion) {
+    noteFailedUpdateInstall(strandedInstallVersion)
+  }
   autoUpdater.logger = updaterLibraryLogger
   const prefs = getUpdaterPrefs()
   const autoDownloadEnabled = prefs.autoDownload ?? false
@@ -415,6 +459,7 @@ export function initializeUpdater(): void {
       status: 'error',
       error: message
     })
+    noteInstallAttemptFailure(phase)
   })
 
   if (autoCheckEnabled) {

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -880,6 +880,21 @@ reason, phase, mode, status, kind, result`, plus numeric metric keys like
   separate one laptop on a train from many installs failing in a row. An install that has not
   completed a single check in 24 hours _and_ has failed at least 6 checks in that time raises one
   exception (latched until the next successful check), so a genuinely stuck updater is still loud.
+- **Repeated install failures**: a failed _check_ is loud in telemetry, but a failed _install_ was
+  silent to the user. On macOS, Squirrel.Mac stages a downloaded update into its own ShipIt copy,
+  and when that copy fails (`ditto: Could not lstat …`, `No space left on device`) the error lands
+  in a session that then quits normally. Nothing survived the quit, so the next launch re-served the
+  same cached zip and failed the same way — two production installs sat on `2026.817.1` through four
+  releases with no signal of any kind (#1999). `apps/desktop/src/main/updater-install-health.ts`
+  persists the streak in `update-install-health.json` under `userData`, keyed on the pair
+  (running version, target version), and after three consecutive failed attempts sets
+  `installFailed` so the existing manual-download dialog appears. It counts _attempts_, not
+  launches: electron-updater re-serves an already-validated cached zip on every auto-check, so a
+  genuinely stuck install surfaces within ~30 minutes. The streak clears the moment the app boots as
+  a different build, which is the only honest evidence an install applied — display versions cannot
+  be ordered, so "newer than the failing one" is not a test that can be written. Every field is
+  re-validated on read and a corrupt file degrades to "no streak"; an install that has never failed
+  has no file and behaves exactly as before.
 - **Expired GitHub signed asset URLs**: GitHub serves a release asset by redirecting to a
   short-lived signed `release-assets.githubusercontent.com` URL. When the follow-up GET lands after
   that token expires, GitHub answers with the non-standard status **618 `jwt:expired`**, and

--- a/scripts/check-architecture-boundaries.js
+++ b/scripts/check-architecture-boundaries.js
@@ -92,8 +92,15 @@ function isSourceFile(filePath) {
   return /\.(ts|tsx|js|jsx|mjs|cjs)$/.test(filePath)
 }
 
+// Test-only code, by either convention this repo uses: a `.test.`/`.spec.` suffix
+// or any file under a `__tests__` / `__mocks__` directory. Both are excluded from
+// every boundary walk below, because the rules are about what SHIPS. A shared
+// test harness under `__tests__` is not shipped, and `apps/mobile`'s notes
+// harness reaches for `node:sqlite` on purpose — running the shipping SQL against
+// real SQLite is the entire point of it.
 function isTestFile(filePath) {
-  return /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(filePath)
+  if (/\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(filePath)) return true
+  return filePath.split(path.sep).some((segment) => segment === '__tests__' || segment === '__mocks__')
 }
 
 function stripSourceExtension(filePath) {
@@ -405,6 +412,21 @@ async function walkMobileSources(dir) {
   return files
 }
 
+// Test-only modules are skipped as walk SEEDS, so excluding them here would be a
+// hole rather than a skip: shipping code that imports one would escape the walk
+// entirely, and the node builtin it reaches would go unreported. Only shipping
+// files are ever walked, so anything resolving to a test file got there from
+// shipping code, which is itself the violation.
+function enqueueReachable(filePath, specifier, resolved, queue, blockingViolations) {
+  if (!isTestFile(resolved)) {
+    queue.push(resolved)
+    return
+  }
+  blockingViolations.add(
+    formatViolation(filePath, specifier, 'test-only module reachable from shipping code')
+  )
+}
+
 // Mobile reachability rule (spec 001-mobile-app T003 / Constitution I): nothing
 // reachable from apps/mobile — including transitively through workspace
 // packages — may import a node builtin or electron. Walks the real import
@@ -450,15 +472,15 @@ async function checkMobileReachability(blockingViolations) {
 
       if (specifier.startsWith('.')) {
         const resolved = resolveSourceFile(path.resolve(path.dirname(filePath), specifier))
-        if (resolved && isSourceFile(resolved) && !isTestFile(resolved)) {
-          queue.push(resolved)
+        if (resolved && isSourceFile(resolved)) {
+          enqueueReachable(filePath, specifier, resolved, queue, blockingViolations)
         }
         continue
       }
 
       const workspaceResolved = resolveWorkspaceImport(specifier, workspacePackages)
-      if (workspaceResolved && isSourceFile(workspaceResolved) && !isTestFile(workspaceResolved)) {
-        queue.push(workspaceResolved)
+      if (workspaceResolved && isSourceFile(workspaceResolved)) {
+        enqueueReachable(filePath, specifier, workspaceResolved, queue, blockingViolations)
       }
     }
   }


### PR DESCRIPTION
## Summary

Stacked on #2015 (the CI boundary fix), so this branch can go green. Rebase onto `main` once that lands.

macOS Squirrel.Mac stages a downloaded update into its own ShipIt copy. When that copy fails (`ditto: Could not lstat …`, `No space left on device`) the error arrives in a session that then quits normally, and nothing about it survives the quit. The next launch re-serves the same cached zip and fails identically, forever, with no signal to the user. Two production installs sat on `2026.817.1` through four releases. Re-validated 2026-09-04: still firing on `2026.903.1` as of 07:30 today.

**The build is not at fault.** I downloaded the published `MemryNote-2026.903.2-arm64.zip` and extracted it with `ditto -x -k`, the same tool ShipIt uses. It extracted cleanly: 396 symlinks, **0 dangling**, and all four failing paths from the issue resolve. The `ditto` message names the *source* path in the user's staging dir, and `lstat` succeeds on a dangling symlink — so the entry is absent entirely and the staged copy is incomplete. The issue's second premise is wrong too: `jsdom` is a declared production dependency, imported by four main-process importers. Full evidence in the [issue comment](https://github.com/memrynote/memry/issues/1999#issuecomment-5536188279).

**The gap this closes.** The user-facing half already existed — `installFailed` on the updater state and the manual-download dialog behind it. Nothing ever set it for this path. `detectFailedUpdateInstall` only fires when the marker was written by an explicit Restart-to-install, so background staging failures were never detected at all: `UPDATE_INSTALL_DID_NOT_APPLY` produced 5 events in 45 days, once per user, while the `ditto` failures repeated daily.

`updater-install-health.ts` persists the streak keyed on the pair (running version, target version) and sets `installFailed` after three consecutive failures.

Three decisions worth reviewing:

- **Attempts, not launches.** electron-updater re-serves an already-validated cached zip via `done(false)` (`AppUpdater.js:603`), which re-dispatches `update-downloaded` on every 10-minute auto-check. So a stuck install surfaces in ~30 minutes rather than over three days.
- **Cleared by booting a different build**, not by comparing versions. Memry display versions cannot be ordered — `v2026-09-10.1` sorts below `v2026-09-03.2` — so "newer than the failing one" is not a test that can be written. Booting as any other build is the only honest evidence an install applied, and it is the same comparison `update-install-marker.ts` already makes.
- **Re-surfaced on every launch** while the streak is live. The escalation latch stops repeat *failures* from re-firing the dialog, not repeat launches; latching per streak would show it once and drop the user back into the silent loop.

Every field is re-validated on read and rejected rather than repaired — `toSafeToken` substitutes, so a torn write would become a plausible-looking version. An install that has never failed has no file and behaves exactly as before. No IPC contract shape changed.

Closes #1999. Part of #1987.

## Release note
Memry now tells you when an update has repeatedly failed to install, and offers a manual download, instead of silently retrying forever.

## Test plan
- Full desktop suite: **1452 files, 19837 passed, 0 failed.**
- `updater-install-health.test.ts` (10 cases) + 4 wiring cases in `updater.test.ts`: escalation at 3 and only once, cross-launch persistence, a new target restarting the streak, re-surfacing while stuck, clearing on a successful install, missing file, torn file, and three hostile-value rejections.
- Mutation-checked rather than trusted green: threshold → 99 fails 3 of 10; removing the `VERSION_TOKEN` guard fails exactly the hostile-path test; removing the failure-count bound fails exactly the out-of-range test.
- `typecheck:node`, `typecheck:test`, `check:architecture`, `check:contracts`, `docs:impact --strict`, prettier and eslint all clean.
- Not verified on a packaged macOS build against real Squirrel staging — I cannot force a failing ShipIt copy locally. The mechanism was established by reading the shipped `electron-updater@6.7.3` source rather than assumed.
