### PR TITLE
fix(embeddings): dispose the pipeline instead of aborting on idle shutdown

### DIFF
--- a/apps/desktop/src/main/lib/embedding-worker.test.ts
+++ b/apps/desktop/src/main/lib/embedding-worker.test.ts
@@ -105,4 +105,74 @@ describe('embedding worker', () => {
       normalize: true
     })
   })
+
+  describe('shutdown', () => {
+    const loadWorker = async (
+      port: MockParentPort,
+      dispose: () => Promise<unknown>
+    ): Promise<void> => {
+      Object.defineProperty(process, 'parentPort', {
+        configurable: true,
+        writable: true,
+        value: port
+      })
+      const extractor = Object.assign(
+        vi.fn().mockResolvedValue({ data: new Float32Array(EMBEDDING_DIMENSION) }),
+        { dispose }
+      )
+      mockPipeline.mockResolvedValue(extractor)
+
+      await import('./embedding-worker')
+      port.emit('message', { data: { type: 'load-model', requestId: 'load-1' } })
+      await vi.waitFor(() => {
+        expect(port.postMessage).toHaveBeenCalledWith({
+          type: 'load-model-result',
+          requestId: 'load-1'
+        })
+      })
+    }
+
+    // `process.exit()` under a loaded onnxruntime skips JS cleanup and runs the
+    // native static destructors with sessions still live, which aborts with
+    // SIGABRT after the worker's own clean exit 0 (#1990).
+    it('disposes the pipeline and lets the loop drain instead of exiting hard', async () => {
+      const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+      const dispose = vi.fn().mockResolvedValue(undefined)
+      const port = new MockParentPort()
+      await loadWorker(port, dispose)
+
+      port.emit('message', { data: { type: 'shutdown' } })
+
+      await vi.waitFor(() => {
+        expect(dispose).toHaveBeenCalledTimes(1)
+      })
+      expect(exit).not.toHaveBeenCalled()
+      // Electron's ParentPort pauses itself once the last 'message' listener is
+      // gone, releasing the handle that keeps this process alive.
+      expect(port.listenerCount('message')).toBe(0)
+      exit.mockRestore()
+    })
+
+    // The main process force-kills at 3s, and a kill mid-teardown is exactly the
+    // death this fix exists to avoid, so the worker has to give up first.
+    it('falls back to exiting when disposal never settles', async () => {
+      const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+      const dispose = vi.fn().mockReturnValue(new Promise<void>(() => {}))
+      const port = new MockParentPort()
+      await loadWorker(port, dispose)
+
+      vi.useFakeTimers()
+      try {
+        port.emit('message', { data: { type: 'shutdown' } })
+        await vi.advanceTimersByTimeAsync(1_499)
+        expect(exit).not.toHaveBeenCalled()
+
+        await vi.advanceTimersByTimeAsync(1)
+        expect(exit).toHaveBeenCalledWith(0)
+      } finally {
+        vi.useRealTimers()
+        exit.mockRestore()
+      }
+    })
+  })
 })

--- a/apps/desktop/src/main/lib/embedding-worker.ts
+++ b/apps/desktop/src/main/lib/embedding-worker.ts
@@ -15,6 +15,13 @@ const logger = createLogger('Embeddings:Worker')
 
 const MAX_CONTENT_LENGTH = 2000
 
+/**
+ * Ceiling on the orderly teardown below. Comfortably under the main process's
+ * SHUTDOWN_TIMEOUT_MS (3s, embeddings.ts), so a wedged disposal still exits on
+ * its own terms rather than being force-killed and reported as a teardown death.
+ */
+const SHUTDOWN_TIMEOUT_MS = 1_500
+
 interface ModelProgress {
   status: string
   progress?: number
@@ -153,7 +160,50 @@ async function handleEmbed(
   }
 }
 
-parentPort.on('message', (event) => {
+let shuttingDown = false
+
+/**
+ * Free the onnxruntime sessions BEFORE this process unwinds.
+ *
+ * A bare `process.exit(0)` here skipped JS cleanup and ran onnxruntime's native
+ * static destructors with sessions still live, which aborts (SIGABRT, exit 6).
+ * The worker's own exit was clean, so the bridge recorded `graceful_stop` and
+ * Electron then reported a SEPARATE `child-process-gone` for the abort — the
+ * shape behind 70% of macOS installs on #1990.
+ *
+ * Dropping the last 'message' listener is what lets this process end on its own:
+ * Electron's ParentPort pauses itself on `removeListener`, releasing the handle
+ * that keeps the loop alive. The timer bounds that — unref'd so it cannot itself
+ * hold the loop open, and left armed after disposal because a native runtime
+ * with lingering threads is exactly the case it exists for.
+ */
+async function handleShutdown(): Promise<void> {
+  if (shuttingDown) return
+  shuttingDown = true
+
+  const fallback = setTimeout(() => {
+    logger.warn('Embedding worker did not drain after disposal; exiting')
+    process.exit(0)
+  }, SHUTDOWN_TIMEOUT_MS)
+  if (typeof fallback.unref === 'function') {
+    fallback.unref()
+  }
+
+  parentPort.off('message', onMessage)
+
+  const disposable = extractor
+  extractor = null
+
+  try {
+    await disposable?.dispose?.()
+  } catch (error) {
+    logger.error('Failed to dispose embedding pipeline', {
+      message: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+function onMessage(event: { data: unknown }): void {
   const message = event.data as EmbeddingMainToWorkerMessage
 
   switch (message.type) {
@@ -164,9 +214,11 @@ parentPort.on('message', (event) => {
       void handleEmbed(message)
       break
     case 'shutdown':
-      process.exit(0)
+      void handleShutdown()
   }
-})
+}
+
+parentPort.on('message', onMessage)
 
 process.on('uncaughtException', (error) => {
   logger.error('Uncaught embedding worker error', {

--- a/apps/desktop/src/main/telemetry/diagnostics.test.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.test.ts
@@ -189,6 +189,90 @@ describe('telemetry diagnostics', () => {
       )
     })
 
+    // The worker exited 0 on its own; `graceful_stop` is only recorded on an
+    // observed clean exit. The abort Electron reports afterwards is the native
+    // runtime unwinding after the process was already gone, so it must stay
+    // queryable without filing an exception per idle shutdown (#1990).
+    it('demotes a post-exit teardown abort to warn without losing any payload', () => {
+      trackChildProcessGone({
+        type: 'Utility',
+        reason: 'crashed',
+        name: 'Embeddings',
+        exitCode: 6,
+        phase: 'idle_shutdown',
+        context: {
+          pid: 771,
+          uptimeMs: 30_540,
+          release: 'graceful_stop',
+          modelCache: 'present',
+          modelCacheBytes: 90_387_606,
+          load: 'first',
+          crashCount: 1
+        }
+      })
+
+      expect(trackMainEventMock).toHaveBeenCalledWith(
+        'app_log_recorded',
+        expect.objectContaining({
+          // `warn` keeps it out of Error Tracking; everything else is unchanged,
+          // including the fingerprint, so the existing issue's history stands.
+          action: 'warn',
+          result: 'failed',
+          errorCode: 'Utility:crashed:Embeddings',
+          dimensions: { log_action: 'child_process_gone_idle_shutdown' },
+          error: {
+            message:
+              'Embeddings utility process crashed (exit 6, idle_shutdown) ' +
+              '[reason=crashed pid=771 uptime=30540ms release=graceful_stop ' +
+              'cache=present cache_bytes=90387606 load=first crashes=1]'
+          },
+          metrics: { value: 6, durationMs: 30_540, retryCount: 1, byteCount: 90_387_606 }
+        })
+      )
+    })
+
+    // The demotion is justified by the observed exit 0 behind `graceful_stop`
+    // and nothing else. A worker abandoned while still running never produced
+    // one, so its abort is a real fault and has to keep filing an exception.
+    it.each(['live', 'teardown', 'start_timeout', 'fatal_error', 'exit'])(
+      'still reports an exception when the worker was released as %s',
+      (release) => {
+        trackChildProcessGone({
+          type: 'Utility',
+          reason: 'crashed',
+          name: 'Embeddings',
+          exitCode: 6,
+          phase: 'idle_shutdown',
+          context: { release, uptimeMs: 30_540, modelCache: 'present', load: 'first' }
+        })
+
+        expect(trackMainEventMock).toHaveBeenCalledWith(
+          'app_log_recorded',
+          expect.objectContaining({ action: 'error' })
+        )
+      }
+    )
+
+    // The `graceful_stop` release only exists on the embeddings bridge, but the
+    // guard must not widen by accident: another worker's crash with no context
+    // resolved is still an exception.
+    it('keeps a crash from another worker family at error', () => {
+      trackChildProcessGone({
+        type: 'Utility',
+        reason: 'crashed',
+        name: 'VoiceTranscription',
+        exitCode: 6
+      })
+
+      expect(trackMainEventMock).toHaveBeenCalledWith(
+        'app_log_recorded',
+        expect.objectContaining({
+          action: 'error',
+          errorCode: 'Utility:crashed:VoiceTranscription'
+        })
+      )
+    })
+
     it('reports exactly as before when no phase is available', () => {
       trackChildProcessGone({
         type: 'Utility',

--- a/apps/desktop/src/main/telemetry/diagnostics.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.ts
@@ -109,6 +109,25 @@ const contextSummary = (
   return `[${parts.join(' ')}]`
 }
 
+/**
+ * A report for a worker the owning module released as `graceful_stop` is, by
+ * construction, an abort AFTER that worker's own clean exit: the release is only
+ * recorded on an observed `code === 0` (see the 'exit' handler in embeddings.ts).
+ * The work had already drained and the process is already gone, so the report is
+ * post-exit residue from the native runtime unwinding, not a defect the user
+ * felt (#1990).
+ *
+ * It stays fully queryable as an `app_log_recorded` `warn` — same errorCode,
+ * message, stderr tail and metrics — and only leaves Error Tracking, the same
+ * demotion trackMainWarning performs for expected failures (#1587).
+ *
+ * Keyed on the recorded release alone, never the phase: `idle_shutdown` is also
+ * reachable from a force-kill, where the exit code was never observed. Any other
+ * release, and any report carrying no context at all, stays an exception.
+ */
+const isPostExitTeardownAbort = (details: ChildProcessGoneDetails): boolean =>
+  details.context?.release === 'graceful_stop'
+
 // Reports a `child-process-gone` fault as an error log event, or nothing at all
 // for a clean idle-worker exit. Kept here (not inline in index.ts) so the
 // skip decision is unit-tested rather than living in the untested bootstrap.
@@ -155,7 +174,7 @@ export const trackChildProcessGone = (details: ChildProcessGoneDetails): void =>
   if (details.context?.stderrTail) error.stack = details.context.stderrTail.slice(0, 4000)
   // errorCode stays stable (no exit code baked in) so the issue grouping counts
   // crashes per worker; the exit status rides along as a metric instead.
-  trackMainLog('error', {
+  trackMainLog(isPostExitTeardownAbort(details) ? 'warn' : 'error', {
     scope: 'Electron',
     action: details.phase ? `child_process_gone_${details.phase}` : 'child_process_gone',
     errorCode,

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -880,6 +880,21 @@ reason, phase, mode, status, kind, result`, plus numeric metric keys like
   separate one laptop on a train from many installs failing in a row. An install that has not
   completed a single check in 24 hours _and_ has failed at least 6 checks in that time raises one
   exception (latched until the next successful check), so a genuinely stuck updater is still loud.
+- **Post-exit teardown aborts**: a `child-process-gone` report for a worker the owning module
+  released as `graceful_stop` is demoted to `warn`. That release is only ever recorded on an
+  observed `code === 0`, so the pairing is proof the worker already exited cleanly and the report is
+  the native runtime aborting while unwinding afterwards — not a failure the user felt. This was 70%
+  of macOS installs (#1990): the embeddings worker handled its shutdown message with a bare
+  `process.exit(0)`, which skips JS cleanup and runs onnxruntime's static destructors with sessions
+  still live, aborting with SIGABRT. Node reported 0 and Electron reported 6 for the same process,
+  which is why both codes appear. The worker now disposes the pipeline and drops its last `message`
+  listener — Electron's `ParentPort` pauses itself on `removeListener`, releasing the handle that
+  holds the loop open, and there is no `close()` to call — with an unref'd fallback that must stay
+  below `SHUTDOWN_TIMEOUT_MS` in `embeddings.ts` so a wedged disposal is never force-killed into the
+  very teardown death this removes. The demotion keys on the recorded release **alone**, never the
+  phase: `idle_shutdown` is also reachable from a force-kill, where no exit code was ever observed.
+  Demoted reports keep their error code, message, stderr tail and metrics and stay queryable as
+  `app_log_recorded`; they only leave Error Tracking.
 - **Expired GitHub signed asset URLs**: GitHub serves a release asset by redirecting to a
   short-lived signed `release-assets.githubusercontent.com` URL. When the follow-up GET lands after
   that token expires, GitHub answers with the non-standard status **618 `jwt:expired`**, and

--- a/scripts/check-architecture-boundaries.js
+++ b/scripts/check-architecture-boundaries.js
@@ -92,8 +92,15 @@ function isSourceFile(filePath) {
   return /\.(ts|tsx|js|jsx|mjs|cjs)$/.test(filePath)
 }
 
+// Test-only code, by either convention this repo uses: a `.test.`/`.spec.` suffix
+// or any file under a `__tests__` / `__mocks__` directory. Both are excluded from
+// every boundary walk below, because the rules are about what SHIPS. A shared
+// test harness under `__tests__` is not shipped, and `apps/mobile`'s notes
+// harness reaches for `node:sqlite` on purpose — running the shipping SQL against
+// real SQLite is the entire point of it.
 function isTestFile(filePath) {
-  return /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(filePath)
+  if (/\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(filePath)) return true
+  return filePath.split(path.sep).some((segment) => segment === '__tests__' || segment === '__mocks__')
 }
 
 function stripSourceExtension(filePath) {
@@ -405,6 +412,21 @@ async function walkMobileSources(dir) {
   return files
 }
 
+// Test-only modules are skipped as walk SEEDS, so excluding them here would be a
+// hole rather than a skip: shipping code that imports one would escape the walk
+// entirely, and the node builtin it reaches would go unreported. Only shipping
+// files are ever walked, so anything resolving to a test file got there from
+// shipping code, which is itself the violation.
+function enqueueReachable(filePath, specifier, resolved, queue, blockingViolations) {
+  if (!isTestFile(resolved)) {
+    queue.push(resolved)
+    return
+  }
+  blockingViolations.add(
+    formatViolation(filePath, specifier, 'test-only module reachable from shipping code')
+  )
+}
+
 // Mobile reachability rule (spec 001-mobile-app T003 / Constitution I): nothing
 // reachable from apps/mobile — including transitively through workspace
 // packages — may import a node builtin or electron. Walks the real import
@@ -450,15 +472,15 @@ async function checkMobileReachability(blockingViolations) {
 
       if (specifier.startsWith('.')) {
         const resolved = resolveSourceFile(path.resolve(path.dirname(filePath), specifier))
-        if (resolved && isSourceFile(resolved) && !isTestFile(resolved)) {
-          queue.push(resolved)
+        if (resolved && isSourceFile(resolved)) {
+          enqueueReachable(filePath, specifier, resolved, queue, blockingViolations)
         }
         continue
       }
 
       const workspaceResolved = resolveWorkspaceImport(specifier, workspacePackages)
-      if (workspaceResolved && isSourceFile(workspaceResolved) && !isTestFile(workspaceResolved)) {
-        queue.push(workspaceResolved)
+      if (workspaceResolved && isSourceFile(workspaceResolved)) {
+        enqueueReachable(filePath, specifier, workspaceResolved, queue, blockingViolations)
       }
     }
   }


### PR DESCRIPTION
## Summary

Stacked on #2015 (the CI boundary fix) so this branch can go green. Rebase onto `main` once that lands.

The Embeddings worker dies with exit 6 (SIGABRT) on 70% of macOS installs. Re-validated 2026-09-04: still live on `2026.903.2` as of 06:55 today, with one install at `crashes=37`. #1582 closed this by improving the report, not the crash.

**Both hypotheses on the issue were wrong**, and the decision is recorded on the issue as its acceptance criteria required: https://github.com/memrynote/memry/issues/1990#issuecomment-5536706626

Every production sample carries `release=graceful_stop` with `phase=idle_shutdown`. That pair is reachable from exactly one branch in the bridge's `exit` handler — the one gated on `code === 0` — because `releaseWorker('graceful_stop')` passes no phase and `currentPhase()` still reads `shuttingDown === true`. So it is not a description of what happened. It is a **proof that the worker exited 0**, and Electron then reported a separate `child-process-gone` for the same process. Node said 0, Electron said 6.

- **H1 (torn down mid-inference) is refuted.** The idle timer only fires after 30s with nothing queued, and `uptime` clusters at 30540–30847 ms — the timer to the millisecond. `currentPhase()` would have returned `in_flight` had anything been pending. No embedding is lost.
- **H2 (misclassified normal exit) is refuted.** Two different exit codes for one process are two events, not one event described twice. Something really aborts.

## The fix, in the order the issue asked for

**1. Dispose before exiting.** The worker handled `'shutdown'` with a bare `process.exit(0)`, which skips JS cleanup and runs onnxruntime's native static destructors with sessions still live. It now `await`s `pipeline.dispose()` — verified to exist in the installed `@huggingface/transformers@3.8.1`, forwarding to `PreTrainedModel.dispose()` → `session.handler.dispose()` — then drops its last `'message'` listener so the loop ends on its own.

That last part is not incidental: Electron's `ParentPort` registers `port.on('removeListener', …)` and calls `pause()` when the last `'message'` listener goes, releasing the handle that holds the loop open. It exposes only `start`, `pause` and `postMessage` — there is **no `close()`**, so dropping the listener is the equivalent. An unref'd 1500 ms fallback bounds a wedged disposal, deliberately held below `SHUTDOWN_TIMEOUT_MS` (3s) in `embeddings.ts` so a force-kill can never land mid-disposal and reintroduce the exact teardown death this removes. Both constants now name each other in comments.

**2. Demote the residue precisely.** Keyed on the recorded `release === 'graceful_stop'` **alone**, never the phase — `idle_shutdown` is also reachable from a force-kill where no exit code was ever observed. Scoping is narrow by construction: `context` is only populated by the embeddings worker's crash context, so `VoiceTranscription` and every other worker are untouched, and there is a test pinning that.

Verified end to end: `trackMainLog('warn', …)` emits `action: 'warn'`, and the sync-server transform drops non-`error` `app_log_recorded` lines from Error Tracking (#1587) while they stay fully queryable. Error code, message, stderr tail and all four metrics survive.

Order matters. Demoting alone is effectively what #1582 did, and the crash outlived it.

### One deviation from the brief, deliberate
I asked for the demotion to route through `trackMainWarning`. It does not, and the reasoning is right: `trackMainWarning(source, action, error)` rederives the code via `toErrorCode(error)`, which would yield a bare `Error` instead of `Utility:crashed:Embeddings` and drop the composite message, the stderr tail and three of four metrics. `trackMainWarning` is itself just `trackMainLog('warn', …)`, so flipping the level argument is the same mechanism with none of the payload loss.

Closes #1990. Part of #1987.

## Release note
The embeddings worker on macOS now shuts down cleanly instead of aborting, which also stops a recurring crash report.

## Test plan
- Full desktop suite: **1451 files passed, 19832 tests passed**, 3 expected-fail, 13 skipped, exit 0.
- Targeted: 3 files, 83 tests passed. New coverage — dispose called once and `process.exit` never called on shutdown; the `'message'` listener count dropping to zero; the fallback asserted at **1499 ms (nothing) and 1500 ms (exit)**, so it pins the bound rather than observing an eventual exit; the `graceful_stop` demotion carrying a real production payload (`uptime=30540ms`, `cache_bytes=90387606`, exit 6); an `it.each` over `live`/`teardown`/`start_timeout`/`fatal_error`/`exit` proving each still emits `error`; and a `VoiceTranscription` case proving the guard did not widen.
- Three mutations, each restored from `/tmp` copies rather than `git checkout`: forcing the level to `'error'` fails only the demotion test; restoring `process.exit(0)` fails both new worker tests; deleting the fallback timer fails only the fallback test.
- `typecheck:test`, `tsc --noEmit -p tsconfig.node.json`, prettier, eslint, `docs:impact --strict` all clean. No IPC contract change.
