### PR TITLE
fix(updater): tell macOS users why an app on a read-only volume cannot update

### DIFF
--- a/apps/desktop/src/main/updater-error-severity.test.ts
+++ b/apps/desktop/src/main/updater-error-severity.test.ts
@@ -4,6 +4,7 @@ import type { UpdaterErrorPhase } from './updater'
 import {
   classifyUpdaterError,
   isExpiredSignedAssetError,
+  isReadOnlyVolumeError,
   isUpdaterCheckPhase,
   recordUpdaterCheckFailure,
   recordUpdaterCheckSuccess,
@@ -307,5 +308,39 @@ describe('isExpiredSignedAssetError', () => {
     const expired = signedAssetError(618, 'release-assets.githubusercontent.com', '618 jwt:expired')
     expect(classifyUpdaterError(expired, 'check')).toBe('error')
     expect(classifyUpdaterError(new Error('net::ERR_TIMED_OUT'), 'check')).toBe('warn')
+  })
+})
+
+describe('isReadOnlyVolumeError', () => {
+  // Verbatim Squirrel.Mac copy from the 2026-09-04 PostHog window (issue #1995).
+  const squirrelReadOnlyVolume =
+    'Cannot update while running on a read-only volume. The application is on a ' +
+    "read-only volume. Please move the application and try again. If you're on " +
+    "macOS Sierra or later, you'll need to move the application out of the " +
+    'Downloads directory. See https://github.com/Squirrel/Squirrel.Mac/issues/182 ' +
+    'for more information.'
+
+  it('recognises the Squirrel.Mac read-only volume failure', () => {
+    expect(isReadOnlyVolumeError(new Error(squirrelReadOnlyVolume))).toBe(true)
+  })
+
+  it('reads through a cause chain, the way electron-updater wraps failures', () => {
+    const wrapped = new Error('Cannot install update')
+    ;(wrapped as { cause?: unknown }).cause = new Error(squirrelReadOnlyVolume)
+    expect(isReadOnlyVolumeError(wrapped)).toBe(true)
+  })
+
+  it('leaves every other updater failure alone', () => {
+    expect(isReadOnlyVolumeError(new Error('net::ERR_INTERNET_DISCONNECTED'))).toBe(false)
+    expect(isReadOnlyVolumeError(new Error('ENOSPC: no space left on device'))).toBe(false)
+    // "read-only" without the volume is a file-permission problem, not this one.
+    expect(isReadOnlyVolumeError(new Error('EROFS: read-only file system'))).toBe(false)
+    expect(isReadOnlyVolumeError(undefined)).toBe(false)
+    expect(isReadOnlyVolumeError(squirrelReadOnlyVolume)).toBe(true)
+  })
+
+  it('demotes the failure below error severity in the install phase', () => {
+    expect(classifyUpdaterError(new Error(squirrelReadOnlyVolume), 'downloaded')).toBe('warn')
+    expect(classifyUpdaterError(new Error('ENOSPC: no space left'), 'downloaded')).toBe('error')
   })
 })

--- a/apps/desktop/src/main/updater-error-severity.ts
+++ b/apps/desktop/src/main/updater-error-severity.ts
@@ -79,15 +79,45 @@ const collectNetErrorTokens = (error: unknown, depth = 0): string[] => {
 }
 
 /**
- * `warn` only for a check that failed to reach the network. Fails closed:
- * anything with no recognised transport code, an unknown `net::ERR_*`, an HTTP
- * status (a 404 feed, a 618 `jwt:expired` asset URL), a signature failure or an
- * install-phase errno stays `error`.
+ * Squirrel.Mac's refusal to stage an update from a read-only mount, matched on
+ * the distinctive half of its hardcoded English copy (Squirrel/Squirrel.Mac#182):
+ *
+ *   "Cannot update while running on a read-only volume. The application is on a
+ *    read-only volume. Please move the application and try again. ..."
+ *
+ * The phrase, not `EROFS` or a bare "read-only": the app being on a read-only
+ * *volume* is the whole condition, and it is what tells the two failures apart.
+ * A read-only file inside a writable install is a permissions defect and keeps
+ * error severity.
+ */
+const READ_ONLY_VOLUME = 'read-only volume'
+
+/**
+ * True when the update failed because the app is running from the mounted DMG or
+ * a Gatekeeper-translocated copy in ~/Downloads. A location the user chose, not
+ * a defect: nothing in the app can repair it, only moving the app can.
+ */
+export const isReadOnlyVolumeError = (error: unknown, depth = 0): boolean => {
+  if (!error || depth > MAX_CAUSE_DEPTH) return false
+  if (errorText(error).includes(READ_ONLY_VOLUME)) return true
+  const cause = typeof error === 'object' ? (error as { cause?: unknown }).cause : undefined
+  return isReadOnlyVolumeError(cause, depth + 1)
+}
+
+/**
+ * `warn` for a check that failed to reach the network, and for an app running
+ * from a read-only volume. Fails closed: anything with no recognised transport
+ * code, an unknown `net::ERR_*`, an HTTP status (a 404 feed, a 618 `jwt:expired`
+ * asset URL), a signature failure or an install-phase errno stays `error`.
  */
 export const classifyUpdaterError = (
   error: unknown,
   phase: UpdaterErrorPhase
 ): UpdaterErrorSeverity => {
+  // Phase-independent: this one fires while staging the download, outside every
+  // check phase, and it is an environment state in all of them. The user is told
+  // about it in the UI instead (issue #1995).
+  if (isReadOnlyVolumeError(error)) return 'warn'
   if (!isUpdaterCheckPhase(phase)) return 'error'
   // A response arrived, so this is not a connectivity drop: the server said no.
   const status =

--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -45,7 +45,10 @@ const mocks = vi.hoisted(() => {
     app: Object.assign(new MockEmitter(), {
       isPackaged: true,
       getVersion: vi.fn(() => '1.2.3'),
-      quit: vi.fn()
+      quit: vi.fn(),
+      // macOS-only in Electron. Defaults to a correctly installed app so no
+      // existing test can accidentally take the "move me" path.
+      isInApplicationsFolder: vi.fn(() => true)
     }),
     // Session-end guard listens on BrowserWindow instances, so windows are emitters.
     createWindow: () =>
@@ -158,6 +161,7 @@ describe('updater', () => {
     mocks.windows[0].removeAllListeners()
     mocks.autoUpdater.autoDownload = true
     mocks.autoUpdater.autoInstallOnAppQuit = false
+    mocks.app.isInApplicationsFolder.mockReturnValue(true)
     mocks.autoUpdater.checkForUpdates.mockResolvedValue(undefined)
     mocks.autoUpdater.downloadUpdate.mockResolvedValue(undefined)
     mocks.autoUpdater.quitAndInstall.mockImplementation(() => undefined)
@@ -786,6 +790,58 @@ describe('updater', () => {
 
         expect(trackMainError).toHaveBeenCalledWith('updater', 'download', expired)
         expect(updater.getUpdateState()).toMatchObject({ status: 'error' })
+      })
+    })
+
+    describe('a macOS read-only volume', () => {
+      // Verbatim Squirrel.Mac copy, as it reaches production telemetry.
+      const readOnlyVolume = (): Error =>
+        new Error(
+          'Cannot update while running on a read-only volume. The application is on a ' +
+            "read-only volume. Please move the application and try again. If you're on " +
+            "macOS Sierra or later, you'll need to move the application out of the " +
+            'Downloads directory. See https://github.com/Squirrel/Squirrel.Mac/issues/182 ' +
+            'for more information.'
+        )
+
+      async function failToInstallOnReadOnlyVolume(): Promise<{
+        updater: typeof import('./updater')
+        error: Error
+      }> {
+        const updater = await loadUpdater()
+        updater.initializeUpdater()
+        mocks.autoUpdater.emit('update-downloaded', { version: '1.2.4' })
+        const error = readOnlyVolume()
+        mocks.autoUpdater.emit('error', error)
+        return { updater, error }
+      }
+
+      it('tells the user to move the app instead of relaying the Squirrel copy', async () => {
+        mocks.app.isInApplicationsFolder.mockReturnValue(false)
+
+        const { updater } = await failToInstallOnReadOnlyVolume()
+
+        expect(updater.getUpdateState()).toMatchObject({
+          status: 'error',
+          error: 'system:error.updateReadOnlyVolume'
+        })
+      })
+
+      it('keeps the raw failure when the app already runs from Applications', async () => {
+        mocks.app.isInApplicationsFolder.mockReturnValue(true)
+
+        const { updater } = await failToInstallOnReadOnlyVolume()
+
+        expect(updater.getUpdateState().error).toContain('read-only volume')
+      })
+
+      it('reports the environment state as a warning, not an exception', async () => {
+        mocks.app.isInApplicationsFolder.mockReturnValue(false)
+
+        const { error } = await failToInstallOnReadOnlyVolume()
+
+        expect(trackMainWarning).toHaveBeenCalledWith('updater', 'downloaded', error)
+        expect(trackMainError).not.toHaveBeenCalled()
       })
     })
 

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -14,6 +14,7 @@ import { markUpdateInstallStarted } from './telemetry/update-install-marker'
 import {
   classifyUpdaterError,
   isExpiredSignedAssetError,
+  isReadOnlyVolumeError,
   isUpdaterCheckPhase,
   recordUpdaterCheckFailure,
   recordUpdaterCheckSuccess,
@@ -151,12 +152,17 @@ export function describeUpdaterError(
 /**
  * Route a failure to the telemetry severity it deserves. A background check that
  * could not reach the network is the user being offline, not a defect, so it
- * ships as a `warn` log line — queryable, but out of Error Tracking. Everything
- * else, plus an install whose checks have been failing for a day straight, stays
- * an exception: those users cannot receive a fix. See updater-error-severity.ts.
+ * ships as a `warn` log line — queryable, but out of Error Tracking. So does an
+ * app running from a read-only volume, in any phase. Everything else, plus an
+ * install whose checks have been failing for a day straight, stays an exception:
+ * those users cannot receive a fix. See updater-error-severity.ts.
  */
 function reportUpdaterFailure(error: unknown, phase: UpdaterErrorPhase): void {
   if (!isUpdaterCheckPhase(phase)) {
+    if (classifyUpdaterError(error, phase) === 'warn') {
+      trackMainWarning('updater', phase, error)
+      return
+    }
     trackMainError('updater', phase, error)
     return
   }
@@ -408,12 +414,20 @@ export function initializeUpdater(): void {
     // The local main.log line and the user-facing state stay at error severity:
     // only the telemetry severity is classified.
     logger.error('updater error', error, describeUpdaterError(error, phase))
+    // The app is on the mounted DMG or a translocated ~/Downloads copy, so
+    // Squirrel cannot stage anything and never will from here. Squirrel's own
+    // copy is the only thing the user would otherwise see, in Settings and in
+    // the menu-bar check, and it explains the failure without naming the fix.
+    // The `isInApplicationsFolder()` guard is what keeps this from telling a
+    // correctly installed user to move an app that is already in place; it is
+    // macOS-only, so `?.()` leaves every other platform on the raw message.
+    const readOnlyVolume = isReadOnlyVolumeError(error) && app.isInApplicationsFolder?.() === false
     // Update-pipeline breakage (feed 404s, signature failures, disk-full
     // downloads) must reach error tracking: affected users cannot update to a fix.
     reportUpdaterFailure(error, phase)
     setState({
       status: 'error',
-      error: message
+      error: readOnlyVolume ? getMainI18n().t('system:error.updateReadOnlyVolume') : message
     })
   })
 

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -414,17 +414,16 @@ export function initializeUpdater(): void {
     // The local main.log line and the user-facing state stay at error severity:
     // only the telemetry severity is classified.
     logger.error('updater error', error, describeUpdaterError(error, phase))
-    // The app is on the mounted DMG or a translocated ~/Downloads copy, so
-    // Squirrel cannot stage anything and never will from here. Squirrel's own
-    // copy is the only thing the user would otherwise see, in Settings and in
-    // the menu-bar check, and it explains the failure without naming the fix.
-    // The `isInApplicationsFolder()` guard is what keeps this from telling a
-    // correctly installed user to move an app that is already in place; it is
-    // macOS-only, so `?.()` leaves every other platform on the raw message.
-    const readOnlyVolume = isReadOnlyVolumeError(error) && app.isInApplicationsFolder?.() === false
     // Update-pipeline breakage (feed 404s, signature failures, disk-full
     // downloads) must reach error tracking: affected users cannot update to a fix.
     reportUpdaterFailure(error, phase)
+    // The app is on the mounted DMG or a translocated ~/Downloads copy, so
+    // Squirrel cannot stage anything and never will from here. Its own message
+    // explains that without naming the fix, so say what to do instead. The
+    // `isInApplicationsFolder()` guard is what keeps this from telling a
+    // correctly installed user to move an app that is already in place; it is
+    // macOS-only, so `?.()` leaves every other platform on the raw message.
+    const readOnlyVolume = isReadOnlyVolumeError(error) && app.isInApplicationsFolder?.() === false
     setState({
       status: 'error',
       error: readOnlyVolume ? getMainI18n().t('system:error.updateReadOnlyVolume') : message

--- a/apps/docs/src/guide/install.md
+++ b/apps/docs/src/guide/install.md
@@ -41,6 +41,13 @@ file along with the report:
 - **macOS** — `~/Library/Logs/memrynote/main.log`
 - **Linux** — `~/.config/memrynote/logs/main.log`
 
+On macOS, updates cannot install at all while the app runs from a read-only location —
+the mounted `.dmg` you downloaded, or a copy still sitting in `~/Downloads`, which macOS
+runs from a temporary read-only mount of its own. There is nothing to report here: drag
+memrynote into your **Applications** folder and open it from there, and updates start
+working. **Settings → General → App Updates** says so directly when this is what is
+blocking you.
+
 On Windows, an update can also be blocked by a file in the install folder being held
 open — antivirus and leftover memrynote processes are the usual causes. The installer
 works around this on its own now, and it writes an `install.log` next to the app

--- a/packages/i18n/src/locales/en/system.json
+++ b/packages/i18n/src/locales/en/system.json
@@ -56,7 +56,8 @@
     "reminderTimeMustBeFuture": "Reminder time must be in the future",
     "definitionNotFound": "Definition not found",
     "noteNotFound": "Note not found",
-    "updateFailed": "Update failed"
+    "updateFailed": "Update failed",
+    "updateReadOnlyVolume": "Updates can't be installed while memrynote runs from this location. Move memrynote to your Applications folder and open it again."
   },
   "startup": {
     "installingUpdate": {


### PR DESCRIPTION
## Summary

Closes #1995.

An app running from the mounted `.dmg`, or from `~/Downloads` where macOS
translocates it onto a read-only mount, cannot install updates. Squirrel.Mac
refuses to stage one and raises `Cannot update while running on a read-only
volume. …`. Until now that string was the only thing the user could ever see,
and almost nobody could: `status: 'error'` hides the sidebar update button and
suppresses the in-app prompt, so the message only reaches Settings → General →
App Updates and the menu-bar **Check for Updates…** toast. Squirrel's copy also
explains the failure without naming the fix.

On that one condition the state now carries plain text instead: "Updates can't
be installed while memrynote runs from this location. Move memrynote to your
Applications folder and open it again."

No contract change. It reuses the existing `AppUpdateState.error` field that
both surfaces already render, so nothing in `packages/contracts` moved and there
is no renderer/main version-skew story to manage.

Detection is two conditions, not a message match alone. `isReadOnlyVolumeError()`
matches the phrase `read-only volume` through the error's cause chain — the
phrase, not `EROFS` or a bare "read-only", so a read-only *file* inside a
writable install stays a permissions defect. It is then gated on
`app.isInApplicationsFolder() === false`, which is what stops a correctly
installed user from being told to move an app that is already in place. That
call is macOS-only in Electron, so `?.()` leaves every other platform on the raw
message.

The failure is also demoted from exception to `warn` telemetry, in
`updater-error-severity.ts` alongside the existing transient-network policy. It
is an environment state the user chose, nothing in the app can repair it, and it
is now visible in the UI. This is issue #1995's third acceptance criterion.

Scope note, deliberately narrow. The issue's original body proposed a first-run
"Move to Applications" dialog. Its own correction demoted the issue from a
stranding bug to P2 UX, having confirmed affected installs do eventually update.
Current volume is one install on the newest release. A proactive modal is not
earned by that; explaining the failure where the user already goes to ask about
updates is.

`updater.ts` touches the `autoUpdater.on('error')` handler and
`reportUpdaterFailure()`, so it overlaps the region PR #2016 edits. The changes
are separable: this one adds two lines inside the existing handler and a branch
inside the existing non-check-phase arm.

## Release note

macOS: memrynote now explains that updates cannot install while it is running
from a disk image or your Downloads folder, and tells you to move it to
Applications.

## Test plan

Re-validated the signal before writing code, per the issue's own instruction.
PostHog project 412311, run 2026-09-04:

- 14-day window: `2026.903.1` — 114 events, 1 install, last seen
  `2026-09-04T09:45:27+03:00`, hours before this change. Also `2026.825.1` (4)
  and `2026.817.1` (288). Still live on a current release, so the fix proceeds.
- Exception text confirmed verbatim as the Squirrel.Mac string, type `Error`,
  no `statusCode`, phase `downloaded` — which is why `classifyUpdaterError`
  never saw it (`reportUpdaterFailure` short-circuits every non-check phase to
  `trackMainError`).

Automated, all green:

```
pnpm exec vitest run --config config/vitest.config.ts --project main \
  src/main/updater-error-severity.test.ts src/main/updater.test.ts \
  src/main/ipc/updater-handlers.test.ts
  Test Files  3 passed (3)
       Tests  96 passed (96)

pnpm --filter @memry/desktop typecheck:node   exit 0
pnpm --filter @memry/desktop typecheck:test   exit 0
pnpm --filter @memry/desktop i18n:check       ok: i18n check passed
pnpm exec eslint <touched files>              0 errors
pnpm exec prettier --check <touched files>    clean
git diff --check                              clean
pnpm docs:impact --base origin/main --strict  covered
pnpm docs:build                               build complete in 37.21s
```

Seven new assertions across the two suites. Each was mutation-checked by
breaking the source and confirming the specific test fails, then restoring from
a `/tmp` copy:

1. Removed the read-only branch from `classifyUpdaterError` → 2 failed, 92
   passed. `expected 'error' to be 'warn'`, and `trackMainWarning` not called
   with `['updater', 'downloaded', …]`.
2. Removed the `app.isInApplicationsFolder?.() === false` guard → 1 failed, 44
   passed. `expected 'system:error.updateReadOnlyVolume' to contain 'read-only
   volume'` — the assertion that a correctly installed user keeps the raw
   message.
3. Reverted the message swap → 1 failed, 44 passed, on the "tells the user to
   move the app" assertion.

The full desktop suite was not run locally — several agents share this machine
and are churning the native-module ABI. CI covers it.

Not verified in a packaged macOS build. Reproducing it needs a signed build run
from a mounted DMG, which this environment cannot produce. The Squirrel string
and its phase come from production telemetry rather than a local repro.

`pnpm check:architecture` fails on
`apps/mobile/.../vault-db-harness.ts -> node:sqlite`, pre-existing on `main` and
fixed by PR #2015.

Docs note: the final commit is a comment reorder inside `updater.ts`. Pre-push
resolves its base to the previous pushed commit, so the gate saw a
docs-relevant file with no docs diff and I pushed it with
`MEMRY_DOCS_IMPACT_SKIP=1`. The branch as a whole is `covered` against
`origin/main` — the docs change landed one commit earlier.
