### PR TITLE
fix(updater): stop reporting four more offline check failures as app errors

### DIFF
--- a/apps/desktop/src/main/updater-error-severity.test.ts
+++ b/apps/desktop/src/main/updater-error-severity.test.ts
@@ -44,6 +44,13 @@ describe('classifyUpdaterError', () => {
     'net::ERR_CONNECTION_RESET',
     'net::ERR_CONNECTION_CLOSED',
     'net::ERR_CONNECTION_REFUSED',
+    // Issue #1994, measured on builds that already carry the #1587 allowlist
+    // (2026.822.1+) — older builds reported everything as an error, so they
+    // cannot evidence a gap in this set.
+    'net::ERR_CONNECTION_ABORTED',
+    'net::ERR_ADDRESS_UNREACHABLE',
+    'net::ERR_ADDRESS_INVALID',
+    'net::ERR_NETWORK_ACCESS_DENIED',
     'net::ERR_NETWORK_IO_SUSPENDED',
     'net::ERR_HTTP2_PROTOCOL_ERROR',
     'net::ERR_HTTP2_SERVER_REFUSED_STREAM'
@@ -112,6 +119,22 @@ describe('classifyUpdaterError', () => {
         name: 'HttpError',
         statusCode: 503
       }),
+      expected: 'error'
+    },
+    {
+      // Issue #1994 proposed demoting an upstream 5xx during a check. Kept loud
+      // deliberately. A 504 on the releases feed is GitHub's edge failing for
+      // everyone at once, so it is the one check-phase shape that means the whole
+      // fleet has stopped receiving updates — the opposite of the per-device
+      // transport codes above, which scale with the number of flaky networks.
+      // Losing it from Error Tracking would hide a delivery outage.
+      name: 'a 504 on the releases feed during a check',
+      error: Object.assign(
+        new Error(
+          '504 \n"method: GET url: https://github.com/memrynote/memry/releases.atom\n\nData:\n<html><body>'
+        ),
+        { name: 'HttpError', code: 'HTTP_ERROR_504', statusCode: 504 }
+      ),
       expected: 'error'
     },
     {
@@ -192,6 +215,11 @@ describe('classifyUpdaterError', () => {
   it.each(otherPhases)('keeps the same failure at error in the %s phase', (phase) => {
     expect(isUpdaterCheckPhase(phase)).toBe(false)
     expect(classifyUpdaterError(netError('net::ERR_INTERNET_DISCONNECTED'), phase)).toBe('error')
+  })
+
+  // The codes added by #1994 inherit that narrowing rather than widening it.
+  it.each(otherPhases)('keeps a newly demoted code at error in the %s phase', (phase) => {
+    expect(classifyUpdaterError(netError('net::ERR_ADDRESS_UNREACHABLE'), phase)).toBe('error')
   })
 })
 

--- a/apps/desktop/src/main/updater-error-severity.ts
+++ b/apps/desktop/src/main/updater-error-severity.ts
@@ -19,6 +19,12 @@ export type UpdaterErrorSeverity = 'warn' | 'error'
  * An allowlist, never a `net::ERR_` prefix test: a prefix match would also
  * swallow `net::ERR_CERT_*` / `net::ERR_SSL_*` (a certificate failure is a
  * security signal) and any future code we have not reasoned about.
+ *
+ * The second block was added from issue #1994's re-validation. Only builds that
+ * already carry the #1587 classification (2026.822.1 and newer) can show an
+ * allowlist gap — an older build reported every code as an error regardless, so
+ * it carries no signal about this set. Cut that way, the check phase still
+ * produced these four at error severity between 2026-08-22 and 2026-09-04.
  */
 const TRANSIENT_NETWORK_ERRORS: ReadonlySet<string> = new Set([
   'net::ERR_NAME_NOT_RESOLVED',
@@ -29,6 +35,17 @@ const TRANSIENT_NETWORK_ERRORS: ReadonlySet<string> = new Set([
   'net::ERR_CONNECTION_RESET',
   'net::ERR_CONNECTION_CLOSED',
   'net::ERR_CONNECTION_REFUSED',
+  // The peer vanished before answering. Same class as the RESET/CLOSED pair
+  // above, and the check never got a response to judge. 3 events / 1 user.
+  'net::ERR_CONNECTION_ABORTED',
+  // No route to the destination, or an address the stack refuses to route at
+  // all — a downed interface or a captive portal handing back a bogus DNS
+  // answer. Both are the device's own network, not our feed. 7 events / 3 users.
+  'net::ERR_ADDRESS_UNREACHABLE',
+  'net::ERR_ADDRESS_INVALID',
+  // A local firewall or MDM policy blocked the socket before it left the
+  // machine. Nothing the app did and nothing a user can act on. 1 event.
+  'net::ERR_NETWORK_ACCESS_DENIED',
   // Laptop sleep: the network stack is suspended mid-request.
   'net::ERR_NETWORK_IO_SUSPENDED',
   'net::ERR_HTTP2_PROTOCOL_ERROR',

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -864,14 +864,22 @@ reason, phase, mode, status, kind, result`, plus numeric metric keys like
   chain** carries only allowlisted Chromium transport codes — `net::ERR_NAME_NOT_RESOLVED`,
   `ERR_INTERNET_DISCONNECTED`, `ERR_NETWORK_CHANGED`, `ERR_TIMED_OUT`, `ERR_CONNECTION_TIMED_OUT`,
   `ERR_CONNECTION_RESET`, `ERR_CONNECTION_CLOSED`, `ERR_CONNECTION_REFUSED`,
-  `ERR_NETWORK_IO_SUSPENDED`, `ERR_HTTP2_PROTOCOL_ERROR`, `ERR_HTTP2_SERVER_REFUSED_STREAM` — ships
+  `ERR_CONNECTION_ABORTED`, `ERR_ADDRESS_UNREACHABLE`, `ERR_ADDRESS_INVALID`,
+  `ERR_NETWORK_ACCESS_DENIED`, `ERR_NETWORK_IO_SUSPENDED`, `ERR_HTTP2_PROTOCOL_ERROR`,
+  `ERR_HTTP2_SERVER_REFUSED_STREAM` — ships
   as an `app_log_recorded` `warn` instead of an `app_error_seen` exception. Being offline is a
   normal state for an offline-first app, and those events were 33.2 % of every exception in the
   product. The cause chain matters because electron-updater's `GitHubProvider` wraps a transport
   failure in a parse-shaped `ERR_UPDATER_INVALID_RELEASE_FEED`; a feed that is genuinely malformed
   has no network cause and stays an exception. The set is an **allowlist, never a `net::ERR_`
   prefix test**: `net::ERR_CERT_*` / `net::ERR_SSL_*` are security signals, and anything
-  unrecognised fails closed to `error`. Everything else is untouched — HTTP 4xx/5xx (including the
+  unrecognised fails closed to `error`. `ERR_CONNECTION_ABORTED`, `ERR_ADDRESS_UNREACHABLE`,
+  `ERR_ADDRESS_INVALID` and `ERR_NETWORK_ACCESS_DENIED` were added by #1994, measured on the only
+  population that can evidence a gap in this set — builds already carrying this classification
+  (`2026.822.1` and newer), since an older build reported every code as an error regardless. An
+  upstream **5xx stays an exception** deliberately: a 504 on the releases feed is GitHub failing for
+  everyone at once, the one check-phase shape meaning the whole fleet has stopped receiving updates,
+  unlike the per-device transport codes above that scale with the number of flaky networks. Everything else is untouched — HTTP 4xx/5xx (including the
   `HTTP_ERROR_618` `jwt:expired` on GitHub's pre-signed asset URLs), signature failures,
   install-phase errnos, `ENOENT … app-update.yml`, and **any** failure in the `download` /
   `downloaded` / `install` phases, where a network drop can leave a half-applied update.


### PR DESCRIPTION
## Summary

Closes #1994.

#1587 demoted transient updater network failures during a check, and it worked — the bulk `net::ERR_*` noise is confined to pre-fix builds and is ageing out. Four Chromium transport codes were still missing from `TRANSIENT_NETWORK_ERRORS`, so a check that never left the user's machine still landed in Error Tracking.

**The measurement basis changed the answer, so it is worth stating.** The issue's snapshot cuts by "newest release", but `2026.903.1`/`2026.903.2` shipped ~1 day before this work with 41 users combined, so their zero check-phase rows are underpowered, not evidence of a fix. The classification module has only ever had two commits — `8eb31ea95` (#1587) and `2b8ef562d` (#1623) — and both first shipped in `v2026-08-22`. So the only population that can evidence a gap is builds carrying that code: `2026.822.1` and newer. A pre-fix build reported every code as an error regardless, which is exactly why `817.1` / `811.1` / `808.2` dominate the raw numbers while saying nothing about this allowlist.

Cut that way, check-phase exceptions on post-fix builds, 2026-08-22 → 2026-09-04:

| code | events | users |
| --- | ---: | ---: |
| `net::ERR_ADDRESS_UNREACHABLE` | 4 | 2 |
| `HTTP 504` (releases.atom) | 3 | 3 |
| `net::ERR_SSL_PROTOCOL_ERROR` | 3 | 1 |
| `net::ERR_CONNECTION_ABORTED` | 3 | 1 |
| `net::ERR_ADDRESS_INVALID` | 3 | 2 |
| `net::ERR_NETWORK_ACCESS_DENIED` | 1 | 1 |
| `net::ERR_INTERNET_DISCONNECTED` | 1 | 1 |

**Demoted** (each justified in a comment at its line): `ERR_ADDRESS_UNREACHABLE` and `ERR_ADDRESS_INVALID` (no route, or an address the stack refuses to route — a downed interface or a captive portal returning a bogus answer), `ERR_CONNECTION_ABORTED` (peer vanished before answering, same class as the already-allowlisted RESET/CLOSED pair), `ERR_NETWORK_ACCESS_DENIED` (local firewall or MDM policy blocked the socket before it left the machine).

Three deviations from the issue as written, all evidence-led:

- **`ERR_CONNECTION_ABORTED` was not in the report.** The re-validation found it.
- **`ERR_SOCKET_NOT_CONNECTED` and `HTTP_ERROR_618` are dropped.** Neither occurs on a post-fix build. Every 618 still visible (most recently 2026-09-03) is on pre-fix `817.1` — that is #1623's retry working as designed, so adding 618 severity handling would be fixing an already-fixed bug.
- **An upstream 5xx stays an exception.** A 504 on the releases feed is GitHub failing for everyone at once, so it is the one check-phase shape meaning the whole fleet has stopped receiving updates — the opposite of per-device transport codes, which scale with the number of flaky networks. It also fails the issue's own criterion of "genuinely the user is offline". `updater-error-severity.test.ts` already pinned `statusCode: 503` → `error` with that reasoning; a new test now pins the production 504 shape alongside it, so this decision is not silently re-litigated later.

`ERR_SSL_PROTOCOL_ERROR` stays an error, as the issue asked: the set is an allowlist precisely so `CERT`/`SSL` codes remain security signals.

One thing that looked like a bug and is not: `ERR_INTERNET_DISCONNECTED` is already allowlisted yet appears above at error severity. `reportUpdaterFailure` (`updater.ts:158`) escalates whenever `stuck` is true regardless of classification — the deliberate stuck-updater escalation. No change made.

The download / install narrowing is untouched, and a new test asserts the four added codes inherit it rather than widen it. The diff is purely additive, so every existing install classifies exactly as before except for these four codes. Scoped to severity classification and its tests to avoid colliding with #2016.

## Release note

none

## Test plan

- `vitest run --project main src/main/updater-error-severity.test.ts` — **55 passed**
- `vitest run --project main src/main/updater.test.ts` — **42 passed**
- `pnpm --filter @memry/desktop typecheck:test` — pass
- `tsc --noEmit -p tsconfig.node.json --composite false` — pass
- `prettier --check` on touched files — pass; `eslint` — 0 errors
- `pnpm docs:impact --base origin/main --strict` — `covered`

Mutation-checked both new assertions, restoring from a `/tmp` copy each time:

1. Removed `net::ERR_ADDRESS_UNREACHABLE` from the allowlist → `1 failed | 54 passed`, failing on `reports 'net::ERR_ADDRESS_UNREACHABLE' as 'warn' in the check phase` (`expected 'error' to be 'warn'`).
2. Applied the 5xx demotion the issue proposed (`status >= 500 && status <= 599 → 'warn'`) → `2 failed | 53 passed`, failing on both the new `a 504 on the releases feed during a check` and the pre-existing `a 5xx that also mentions a transient transport code`. That the proposed change breaks a test written deliberately in #1587 is the clearest argument for keeping 5xx loud.

Not run locally: the full desktop suite. Several agents share this machine and `electron-rebuild` was churning the native module ABI throughout; the touched module is pure classification logic with no native dependency, so its focused suite is unaffected. CI on fresh runners is the full-suite authority.
