### PR TITLE
fix(tasks,notes): stop empty titles reaching tasks:create and notes:rename

### DIFF
--- a/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.test.tsx
@@ -198,6 +198,23 @@ describe('CaptureBar — text entry', () => {
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
+  it('does not submit quick-add input that leaves no title behind', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    renderBar(
+      <CaptureBar {...baseProps} onSubmit={onSubmit} quickAdd={{ projects: mockProjects }} />
+    )
+
+    // Quick-add strips its own tokens, so this is non-empty text that parses to
+    // an empty title. Submitting it is a guaranteed `tasks:create` rejection.
+    await user.type(field(), '#launch')
+
+    expect(screen.getByRole('button', { name: /capture|submit|send/i })).toBeDisabled()
+
+    await user.keyboard('{Enter}')
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
   it('inserts a newline on Shift+Enter instead of submitting', async () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn()

--- a/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.tsx
@@ -168,6 +168,16 @@ export const CaptureBar = ({
   const disabled = isBusy
   const trimmed = value.trim()
 
+  // What actually becomes the task title. Quick-add strips its own tokens, so
+  // token-only text ("!!high", "@today") is non-empty here but parses to an
+  // empty title — which the `tasks:create` contract rejects with a ZodError the
+  // user can do nothing about (#1991). Gate the affordance on this, not on
+  // `trimmed`.
+  const submittableTitle = useMemo(
+    () => (quickAdd ? parseQuickAdd(trimmed, quickAdd.projects).title.trim() : trimmed),
+    [quickAdd, trimmed]
+  )
+
   // Registered for the lifetime of the bar, so `ownsFocusShortcut` can pick a
   // single winner when split view has more than one bar mounted.
   useEffect(() => registerCaptureField(() => fieldRef.current), [])
@@ -339,7 +349,7 @@ export const CaptureBar = ({
   // --------------------------------------------------------------------------
 
   const submit = useCallback(async (): Promise<void> => {
-    if (!trimmed || disabled) return
+    if (!submittableTitle || disabled) return
 
     const result = quickAdd
       ? await (async () => {
@@ -362,7 +372,7 @@ export const CaptureBar = ({
     }
     // Keep focus for rapid entry.
     fieldRef.current?.focus()
-  }, [trimmed, disabled, quickAdd, onSubmit, resolveNoteIds])
+  }, [submittableTitle, trimmed, disabled, quickAdd, onSubmit, resolveNoteIds])
 
   const openDetail = useCallback((): void => {
     if (!onOpenDetail) return
@@ -628,16 +638,16 @@ export const CaptureBar = ({
             <button
               type="button"
               onClick={() => void submit()}
-              disabled={!trimmed || disabled}
+              disabled={!submittableTitle || disabled}
               aria-label={submitLabel?.(value) ?? t('capture.submit')}
               className={cn(
                 'flex size-5 items-center justify-center rounded-md transition-colors duration-200',
                 'disabled:cursor-not-allowed',
-                !trimmed || disabled
+                !submittableTitle || disabled
                   ? 'text-muted-foreground/30'
                   : 'text-background dark:text-black'
               )}
-              style={trimmed && !disabled ? { backgroundColor: accentColor } : undefined}
+              style={submittableTitle && !disabled ? { backgroundColor: accentColor } : undefined}
             >
               {disabled ? (
                 <Loader2 className="size-3 animate-spin" aria-hidden="true" />

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -1186,6 +1186,10 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
           const parsed = title
             ? parseQuickAdd(title, projects)
             : { title: '', priority: 'none', projectId: null, dueDate: null, tags: [] }
+          // A checklist line of nothing but quick-add tokens ("- [ ] #errand")
+          // parses to an empty title, which `tasks:create` rejects. Leave it as
+          // a checkbox rather than surfacing a contract error (#1991).
+          if (!parsed.title.trim()) return
 
           const result = await tasksService.create({
             projectId: projectIdForCreate ?? parsed.projectId ?? defaultProject.id,
@@ -1407,6 +1411,9 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
         const parsed = title
           ? parseQuickAdd(title, projects)
           : { title: '', priority: 'none', projectId: null, dueDate: null }
+        // The draft scan only checks the raw block title, so a token-only draft
+        // reaches here with nothing left to name the task.
+        if (!parsed.title.trim()) return
 
         try {
           const result = await tasksService.create({

--- a/apps/desktop/src/renderer/src/components/note/content-area/task-block/index.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/task-block/index.tsx
@@ -6,7 +6,10 @@ import {
   type TaskBlockEditor,
   type TaskBlockInlineContent
 } from './task-block-renderer'
+import { toast } from 'sonner'
+import { getI18n } from 'react-i18next'
 import { tasksService } from '@/services/tasks-service'
+import { extractErrorMessage } from '@/lib/ipc-error'
 import { parseQuickAdd } from '@/lib/quick-add-parser'
 import { formatDateKey } from '@/lib/task-utils'
 import type { Project } from '@/data/tasks-data'
@@ -50,6 +53,13 @@ export function getTaskSlashMenuItem(editor: unknown, noteId?: string) {
         props: { taskId: '', title: text, checked: false }
       })
 
+      // `/task` on an empty line is the normal way to start one, so there is
+      // nothing to create yet. The block above is now a draft taskBlock with an
+      // empty `taskId`; ContentArea's draft scan picks it up and creates the row
+      // as soon as the user types a title. Calling `tasks:create` with `''` here
+      // only earns a contract rejection the user never asked for (#1991).
+      if (!text) return
+
       const res = await tasksService.listProjects()
       const projects = res.projects ?? []
       const defaultProject =
@@ -59,29 +69,42 @@ export function getTaskSlashMenuItem(editor: unknown, noteId?: string) {
         ) ?? projects[0]
       if (!defaultProject) return
 
-      const parsed = text
-        ? parseQuickAdd(text, projects as unknown as Project[])
-        : { title: '', priority: 'none' as const, projectId: null, dueDate: null }
+      const parsed = parseQuickAdd(text, projects as unknown as Project[])
+      // Quick-add lifts its own tokens off the line, so a line of nothing but
+      // tokens ("#tag", "!!high") leaves no title behind. Same draft handoff as
+      // the empty-line case above.
+      if (!parsed.title.trim()) return
 
-      const result = await tasksService.create({
-        projectId: parsed.projectId ?? defaultProject.id,
-        title: parsed.title,
-        priority: PRIORITY_REVERSE[parsed.priority] ?? 0,
-        dueDate: parsed.dueDate ? formatDateKey(parsed.dueDate) : null,
-        linkedNoteIds: noteId ? [noteId] : []
-      })
-      if (result.success && result.task) {
-        // Re-fetch fresh: the block reference captured before the awaits above
-        // may be stale by now.
-        const freshBlock = taskEditor.getBlock(blockId) ?? currentBlock
-        const currentTitle = freshBlock.props?.title || parsed.title || text
-        taskEditor.updateBlock(freshBlock, {
-          type: 'taskBlock',
-          props: { taskId: result.task.id, title: currentTitle, checked: false }
+      try {
+        const result = await tasksService.create({
+          projectId: parsed.projectId ?? defaultProject.id,
+          title: parsed.title,
+          priority: PRIORITY_REVERSE[parsed.priority] ?? 0,
+          dueDate: parsed.dueDate ? formatDateKey(parsed.dueDate) : null,
+          linkedNoteIds: noteId ? [noteId] : []
         })
-        if (currentTitle && currentTitle !== result.task.title) {
-          void tasksService.update({ id: result.task.id, title: currentTitle })
+        if (result.success && result.task) {
+          // Re-fetch fresh: the block reference captured before the awaits above
+          // may be stale by now.
+          const freshBlock = taskEditor.getBlock(blockId) ?? currentBlock
+          const currentTitle = freshBlock.props?.title || parsed.title || text
+          taskEditor.updateBlock(freshBlock, {
+            type: 'taskBlock',
+            props: { taskId: result.task.id, title: currentTitle, checked: false }
+          })
+          if (currentTitle && currentTitle !== result.task.title) {
+            void tasksService.update({ id: result.task.id, title: currentTitle })
+          }
         }
+      } catch (err) {
+        // Without this the rejection was unhandled and the block sat there
+        // looking like a real task with no row behind it.
+        toast.error(
+          extractErrorMessage(
+            err,
+            getI18n().getFixedT(null, 'notes')('phaseI.errors.failedToCreateTask')
+          )
+        )
       }
     },
     aliases: ['task', 'todo', 'action'],

--- a/apps/desktop/src/renderer/src/components/note/content-area/task-block/task-creation-popover.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/task-block/task-creation-popover.tsx
@@ -86,14 +86,18 @@ const TaskCreationPopoverForm: FC<TaskCreationPopoverFormProps> = ({
   const [error, setError] = useState<string | null>(null)
   const createBtnRef = useRef<HTMLButtonElement>(null)
 
+  // The block's text is the title, and a task block can be empty. Creating from
+  // it would fail the `min(1)` contract with a message the user cannot act on.
+  const trimmedTitle = title.trim()
+
   const handleCreate = useCallback((): void => {
-    if (!projectId || isSubmitting) return
+    if (!projectId || !trimmedTitle || isSubmitting) return
     setIsSubmitting(true)
     setError(null)
 
     const input: TaskCreateInput = {
       projectId,
-      title,
+      title: trimmedTitle,
       priority,
       dueDate: dueDate || null,
       linkedNoteIds: noteId ? [noteId] : []
@@ -118,7 +122,7 @@ const TaskCreationPopoverForm: FC<TaskCreationPopoverFormProps> = ({
         setIsSubmitting(false)
       }
     })()
-  }, [projectId, title, priority, dueDate, noteId, isSubmitting, onCreated])
+  }, [projectId, trimmedTitle, priority, dueDate, noteId, isSubmitting, onCreated])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -210,7 +214,7 @@ const TaskCreationPopoverForm: FC<TaskCreationPopoverFormProps> = ({
           ref={createBtnRef}
           size="sm"
           onClick={handleCreate}
-          disabled={!projectId || isSubmitting}
+          disabled={!projectId || !trimmedTitle || isSubmitting}
           autoFocus
         >
           {isSubmitting ? 'Creating...' : 'Create'}

--- a/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.test.tsx
@@ -330,6 +330,17 @@ describe('TaskDetailDrawer — editable properties', () => {
         expect.objectContaining({ title: expect.any(String) })
       )
     })
+
+    it('drops a blank title edit rather than sending it to tasks:update', async () => {
+      const user = userEvent.setup()
+      const onUpdateTask = vi.fn()
+      renderWithI18n(<TaskDetailDrawer {...defaultProps} onUpdateTask={onUpdateTask} />)
+
+      const titleInput = screen.getByPlaceholderText('Task name')
+      await user.clear(titleInput)
+
+      expect(onUpdateTask).not.toHaveBeenCalled()
+    })
   })
 
   describe('description editing', () => {

--- a/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.tsx
@@ -461,7 +461,13 @@ export const TaskDetailDrawer = memo(function TaskDetailDrawer({
               <input
                 type="text"
                 value={task.title}
-                onChange={(e) => onUpdateTask?.(task.id, { title: e.target.value })}
+                onChange={(e) => {
+                  // Every keystroke is a `tasks:update`, so select-all + delete
+                  // used to send `title: ''` at a `min(1)` contract. A task
+                  // cannot be untitled; drop the empty edit instead (#1991).
+                  if (!e.target.value.trim()) return
+                  onUpdateTask?.(task.id, { title: e.target.value })
+                }}
                 className="flex-1 min-w-0 text-[14px] font-medium text-text-primary bg-transparent outline-none truncate"
                 placeholder={t('task.namePlaceholder')}
                 aria-label={t('task.namePlaceholder')}

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-task-editor.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-task-editor.tsx
@@ -107,7 +107,12 @@ export const CanvasTaskEditor = ({
         data-canvas-task-title
         value={task.title}
         readOnly={!interactive}
-        onChange={(e) => void updateTask(task.id, { title: e.target.value })}
+        onChange={(e) => {
+          // Same per-keystroke `tasks:update` as the task drawer: an empty title
+          // is a contract violation, not an edit worth sending (#1991).
+          if (!e.target.value.trim()) return
+          void updateTask(task.id, { title: e.target.value })
+        }}
         placeholder={t('task.namePlaceholder')}
         aria-label={t('task.namePlaceholder')}
         className="w-full min-w-0 bg-transparent text-[13px] font-medium text-text-primary outline-none"

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -530,9 +530,14 @@ vi.mock('@/components/note/note-title', () => ({
     title: string
     onTitleChange: (title: string) => void
   }) => (
-    <button type="button" onClick={() => onTitleChange('Renamed Note')}>
-      {title}
-    </button>
+    <>
+      <button type="button" onClick={() => onTitleChange('Renamed Note')}>
+        {title}
+      </button>
+      <button type="button" onClick={() => onTitleChange('   ')}>
+        Blank the title
+      </button>
+    </>
   )
 }))
 
@@ -887,6 +892,15 @@ describe('NotePage', () => {
     expect(await screen.findByText('load failed')).toBeInTheDocument()
     fireEvent.click(screen.getByText('button.retry'))
     expect(mocks.refetchNote).toHaveBeenCalled()
+  })
+
+  it('refuses a blank title instead of letting the rename contract reject it', async () => {
+    renderWithProviders(<NotePage noteId="note-1" />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Blank the title' }))
+
+    expect(mocks.renameNote).not.toHaveBeenCalled()
+    expect(toast.error).toHaveBeenCalledWith('page.toast.titleRequired')
   })
 
   it('saves title, tags, properties, backlinks, and linked task navigation', async () => {

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -849,11 +849,20 @@ export function NotePage({ noteId }: NotePageProps) {
         return
       }
 
+      // Clearing the field and blurring used to send `newTitle: ''` straight at
+      // the `min(1)` contract; the rejection was logged and nothing else, so the
+      // title silently snapped back (#1991).
+      if (!newTitle.trim()) {
+        toast.error(t('page.toast.titleRequired'))
+        return
+      }
+
       try {
         await renameNote.mutateAsync({ id: noteId, newTitle })
         // Note will be updated via TanStack Query cache invalidation
       } catch (err) {
         log.error('Failed to rename note:', err)
+        toast.error(extractErrorMessage(err, t('page.toast.renameFailed')))
       }
     },
     [noteId, note, isDeleted, t, renameNote]

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -24,6 +24,7 @@
       "localOnly": "Note set to local only",
       "willSync": "Note will sync to cloud",
       "renameFailed": "Failed to rename note",
+      "titleRequired": "A note needs a title",
       "toggleLocalOnlyFailed": "Failed to toggle local only",
       "toggleFullWidthFailed": "Failed to toggle full width",
       "pathCopied": "Path copied",


### PR DESCRIPTION
## Summary

Closes #1991.

Re-validated on 2026-09-04 before writing any code. The signal is still live on the newest shipped release: on `2026.903.2`, `tasks:create` rejected an empty `title` for 2 win32 and 1 darwin user in the first day, and `2026.903.1` shows `notes:rename` with an empty `newTitle`. Decomposed by `$exception_values` (`too_small` + `path: ["title"]`) and cut by `app_version`, not off the issue list. Every sample carries `minimum: 1` on an empty string; nothing whitespace-only reached the boundary.

Seven renderer paths could send an empty title through a `min(1)` IPC contract, so the user hit a validation rejection they had no way to act on.

The dominant one is `/task` in the note editor. On an empty line it converted the block to a draft task block and then immediately called `tasks:create` with `title: ''`. ContentArea's draft scan already creates that row the moment a title is typed, so the slash command now hands off to it. The same shape covers the token-only cases: quick-add lifts its own tokens off the line, so `#launch` or `!!high` is non-empty text that parses to an empty title.

- `capture-bar` gates submit and the send button on the parsed title rather than the raw text, which closes both the Tasks page and the Project hub through one component
- the `/task` slash command and both `ContentArea` create paths bail when the parsed title is empty
- the task creation popover disables Create on an empty block title
- the task drawer and the canvas task card drop a blank per-keystroke `tasks:update` instead of sending it
- clearing the note title now says so instead of failing silently, and a rename failure surfaces through `extractErrorMessage`
- the `/task` create is wrapped, so its rejection is no longer unhandled

The contract is deliberately unchanged. Issue item 2 asks whether `min(1)` should become a trimmed check; the answer is no. There is no evidence of whitespace-only titles reaching the boundary, and `z.string().trim()` is a transform, not a validation, so it would rewrite the value under the two title inputs that fire `tasks:update` on every keystroke and eat a trailing space as the user types it. The affordance guards reject whitespace instead. No IPC contract change, but `pnpm ipc:check` was run anyway and reports the invoke map and generated bindings up to date.

Backward compatibility: renderer-only, no schema, no channel, no persisted shape. Existing rows are untouched, and an older app version talking to this code is unaffected because nothing on the wire changed.

`MEMRY_DOCS_IMPACT_SKIP=1` on push. The gate flags any desktop change, and `docs:impact` named no target page. This adds no feature and changes no documented workflow. It refuses input that previously produced an error, and the only new string is a toast telling the user a note needs a title.

## Release note

Creating a task with `/task` on an empty line, or with text that is only quick-add tokens, no longer fails with a validation error. Clearing a note's title now tells you a title is required instead of silently reverting.

## Test plan

Focused renderer suites for what was touched, all green:

```
npx vitest run --config config/vitest.config.ts --project renderer \
  src/renderer/src/components/capture-bar/capture-bar.test.tsx \
  src/renderer/src/pages/note.test.tsx \
  src/renderer/src/components/tasks/task-detail-drawer.test.tsx \
  src/renderer/src/components/note/content-area/ContentArea.test.tsx \
  src/renderer/src/components/note/content-area/task-block/task-block-renderer.test.tsx \
  src/renderer/src/pages/tasks.test.tsx
→ Test Files 6 passed (6) | Tests 221 passed (221)
```

Also `pnpm --filter @memry/desktop typecheck:web`, `typecheck:test`, `i18n:check` (ok), `pnpm ipc:check`, and prettier plus eslint on the touched files. The full suite is left to CI.

Three new assertions were mutation-checked. Reverting the capture-bar gate to `trimmed`, deleting the blank-title guard in `note.tsx`, and deleting the drawer's guard each fail exactly their own test and nothing else (3 failed, 151 passed). Sources were restored from `/tmp` copies and the suites re-run green.

`pnpm check:architecture` still fails on the pre-existing `apps/mobile/.../vault-db-harness.ts -> node:sqlite` violation, fixed separately in #2015.
