### PR TITLE
fix(graph): stop repainting Sigma into a container that has no width

### DIFF
--- a/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
@@ -80,6 +80,15 @@ vi.mock('./graph-events', () => ({
       >
         hover note
       </button>
+      <button
+        type="button"
+        onClick={() => {
+          onHoverNode(null)
+          onTooltipMove(null)
+        }}
+      >
+        unhover note
+      </button>
       <button type="button" onClick={() => onFocusNode('note-b')}>
         focus note
       </button>
@@ -775,6 +784,61 @@ describe('GraphCanvas', () => {
       expect(afterFirstFrame).not.toBe(settledX)
       // Without the reheat the loop parks itself again after that single tick.
       expect(graph.getNodeAttribute('note-a', 'x')).not.toBe(afterFirstFrame)
+    })
+
+    it('re-settles and repaints a static forceatlas2 layout when a node appears', () => {
+      const staticPhysics: GraphSettings = {
+        ...settings,
+        layout: 'forceatlas2',
+        animateLayout: false
+      }
+      const { rerender } = renderWith(data, staticPhysics)
+      const graph = liveGraph()
+      const settledX = graph.getNodeAttribute('note-a', 'x')
+      graphCanvasMocks.sigma.refresh.mockClear()
+
+      rerender({
+        nodes: [...data.nodes, noteC],
+        edges: [
+          ...data.edges,
+          { id: 'edge-a-c', source: 'note-a', target: 'note-c', type: 'wikilink', weight: 1 }
+        ]
+      })
+
+      expect(graph.hasNode('note-c')).toBe(true)
+      expect(graph.getNodeAttribute('note-a', 'x')).not.toBe(settledX)
+      expect(graphCanvasMocks.sigma.refresh).toHaveBeenCalled()
+    })
+  })
+
+  describe('hover fade', () => {
+    function renderCanvas(): void {
+      render(
+        <GraphCanvas
+          data={data}
+          filterState={filters}
+          graphSettings={settings}
+          onFocusNode={vi.fn()}
+        />
+      )
+    }
+
+    it('repaints through the fade-out and then parks', () => {
+      renderCanvas()
+      fireEvent.click(screen.getByText('hover note'))
+      for (let i = 0; i < 40; i++) vi.advanceTimersToNextFrame()
+
+      fireEvent.click(screen.getByText('unhover note'))
+      graphCanvasMocks.sigma.refresh.mockClear()
+      for (let i = 0; i < 40; i++) vi.advanceTimersToNextFrame()
+
+      expect(graphCanvasMocks.sigma.refresh).toHaveBeenCalled()
+
+      // A finished fade schedules no further frame, so the graph stops repainting.
+      graphCanvasMocks.sigma.refresh.mockClear()
+      for (let i = 0; i < 5; i++) vi.advanceTimersToNextFrame()
+
+      expect(graphCanvasMocks.sigma.refresh).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
@@ -10,6 +10,10 @@ const graphCanvasMocks = vi.hoisted(() => ({
     // Sigma retains its graph reference even after kill(). The live instance is
     // the one holding the graph the container was rendered with; a stale
     // instance returns something else. Overridden per-test to model the race.
+    // jsdom does no layout, so a real element measures 0 and the refresh guard
+    // would skip every repaint. Hand it one that measures.
+    getContainer: (): HTMLElement =>
+      Object.defineProperty(document.createElement('div'), 'offsetWidth', { value: 800 }),
     getGraph: (): unknown => graphCanvasMocks.sigmaContainerProps?.graph
   },
   sigmaContainerProps: null as null | Record<string, any>,

--- a/apps/desktop/src/renderer/src/components/graph/graph-canvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-canvas.tsx
@@ -11,6 +11,7 @@ import {
   syncGraphologyGraph,
   type BuildGraphOptions
 } from '@/lib/graph-builder'
+import { refreshSigmaIfMeasurable } from '@/lib/sigma-refresh'
 import { LivePhysics, SettledPhysics, type PhysicsHandle } from './physics-layout'
 import type { GraphFilterState } from '@/hooks/use-graph-filters'
 import type { GraphSettings } from '@memry/contracts/graph-api'
@@ -447,7 +448,7 @@ function HoverFadeAnimator({
     const startFade = fadeRef.current
 
     if (startFade === goal) {
-      sigma.refresh()
+      refreshSigmaIfMeasurable(sigma)
       return
     }
 
@@ -457,7 +458,7 @@ function HoverFadeAnimator({
     const tick = (now: number): void => {
       const t = Math.min((now - startTime) / duration, 1)
       fadeRef.current = startFade + (goal - startFade) * easeOutQuad(t)
-      sigma.refresh()
+      refreshSigmaIfMeasurable(sigma)
 
       if (t < 1) {
         animRef.current = requestAnimationFrame(tick)
@@ -465,7 +466,7 @@ function HoverFadeAnimator({
         animRef.current = null
         if (!hoveredNode) {
           hoverTargetRef.current = null
-          sigma.refresh()
+          refreshSigmaIfMeasurable(sigma)
         }
       }
     }

--- a/apps/desktop/src/renderer/src/components/graph/graph-events.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-events.test.tsx
@@ -25,6 +25,10 @@ vi.mock('@react-sigma/core', () => ({
   },
   useSigma: () => ({
     getGraph: () => mocks.liveGraph ?? mocks.graph,
+    // jsdom does no layout, so a real element measures 0 and the refresh guard
+    // would skip every repaint. Hand it one that measures.
+    getContainer: (): HTMLElement =>
+      Object.defineProperty(document.createElement('div'), 'offsetWidth', { value: 800 }),
     viewportToGraph: mocks.viewportToGraph,
     refresh: mocks.refresh
   })

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel-sigma-lifecycle.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel-sigma-lifecycle.test.tsx
@@ -52,6 +52,12 @@ vi.mock('sigma', () => {
       return this.graph
     }
 
+    // jsdom does no layout, so the real container measures 0 and the refresh
+    // guard would skip every repaint. Hand it one that measures.
+    getContainer(): HTMLElement {
+      return Object.defineProperty(document.createElement('div'), 'offsetWidth', { value: 800 })
+    }
+
     getCamera(): FakeSigma['camera'] {
       return this.camera
     }

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel-zero-width.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel-zero-width.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * A frame that lands after the graph's container is gone must not repaint.
+ *
+ * jsdom does no layout, so `offsetWidth` is stubbed to model the one rule that
+ * matters here: an attached element measures, a detached one reads 0 — exactly
+ * what the browser reports between React's mutation phase and the passive
+ * cleanup that cancels the physics loop's animation frame. The fake Sigma
+ * reproduces the real `resize()` contract from sigma 3.0.3, which throws on a
+ * 0-width container instead of rendering.
+ */
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GraphDataResponse } from '@memry/contracts/graph-api'
+
+const ZERO_WIDTH_ERROR =
+  'Sigma: Container has no width. You can set the allowInvalidContainer setting to true to stop seeing this error.'
+
+const mocks = vi.hoisted(() => ({
+  localGraph: { data: null as GraphDataResponse | null, isLoading: false },
+  refreshCount: 0
+}))
+
+vi.mock('sigma', () => {
+  class FakeSigma {
+    private readonly camera = {
+      getState: () => ({ x: 0, y: 0, ratio: 1, angle: 0 }),
+      setState: () => {}
+    }
+
+    constructor(
+      public graph: unknown,
+      public container: HTMLElement,
+      public settings: Record<string, unknown>
+    ) {}
+
+    getGraph(): unknown {
+      return this.graph
+    }
+
+    getContainer(): HTMLElement {
+      return this.container
+    }
+
+    getCamera(): FakeSigma['camera'] {
+      return this.camera
+    }
+
+    setSetting(key: string, value: unknown): void {
+      this.settings = { ...this.settings, [key]: value }
+    }
+
+    refresh(): void {
+      if (this.container.offsetWidth === 0) throw new Error(ZERO_WIDTH_ERROR)
+      mocks.refreshCount += 1
+    }
+
+    kill(): void {}
+  }
+
+  return { Sigma: FakeSigma, default: FakeSigma }
+})
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' })
+}))
+
+vi.mock('@/hooks/use-graph-data', () => ({
+  useLocalGraphData: () => mocks.localGraph
+}))
+
+vi.mock('./graph-events', () => ({
+  GraphEvents: () => null
+}))
+
+const { LocalGraphPanel } = await import('./local-graph-panel')
+
+const baseData: GraphDataResponse = {
+  nodes: ['note-a', 'note-b'].map((id) => ({
+    id,
+    type: 'note' as const,
+    label: id,
+    tags: [],
+    wordCount: 5,
+    connectionCount: 1,
+    emoji: null,
+    color: '#888888',
+    isOrphan: false,
+    isUnresolved: false
+  })),
+  edges: [{ id: 'note-a-note-b', source: 'note-a', target: 'note-b', type: 'wikilink', weight: 1 }]
+}
+
+let frames = new Map<number, FrameRequestCallback>()
+let nextFrameHandle = 0
+
+function runFrames(count: number): void {
+  act(() => {
+    for (let i = 0; i < count; i++) {
+      const next = frames.entries().next()
+      if (next.done) return
+      frames.delete(next.value[0])
+      next.value[1](16 * (i + 1))
+    }
+  })
+}
+
+describe('LocalGraphPanel on a container with no width', () => {
+  let offsetWidth: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    mocks.localGraph = { data: baseData, isLoading: false }
+    mocks.refreshCount = 0
+    frames = new Map()
+    nextFrameHandle = 0
+    offsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth')
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.isConnected ? 800 : 0
+      }
+    })
+    let seed = 0.13
+    vi.spyOn(Math, 'random').mockImplementation(() => {
+      seed = (seed * 9301 + 0.49297) % 1
+      return seed
+    })
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      nextFrameHandle += 1
+      frames.set(nextFrameHandle, callback)
+      return nextFrameHandle
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((handle) => {
+      frames.delete(handle)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (offsetWidth) Object.defineProperty(HTMLElement.prototype, 'offsetWidth', offsetWidth)
+    else Reflect.deleteProperty(HTMLElement.prototype, 'offsetWidth')
+  })
+
+  function renderPanel(): HTMLElement {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    render(<LocalGraphPanel noteId="note-a" onClose={vi.fn()} />, { container: host })
+    return host
+  }
+
+  it('repaints while the container is attached', () => {
+    renderPanel()
+    runFrames(3)
+
+    expect(mocks.refreshCount).toBeGreaterThan(0)
+  })
+
+  it('does not throw when a queued frame lands after the container is detached', () => {
+    const host = renderPanel()
+    runFrames(1)
+    const beforeDetach = mocks.refreshCount
+
+    host.remove()
+
+    expect(() => runFrames(3)).not.toThrow()
+    expect(mocks.refreshCount).toBe(beforeDetach)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel.test.tsx
@@ -16,6 +16,10 @@ const mocks = vi.hoisted(() => ({
     setSetting: vi.fn(),
     // The live simulation refreshes only the instance that owns the graph it is
     // stepping, so the mock has to model getGraph like the real Sigma does.
+    // jsdom does no layout, so a real element measures 0 and the refresh guard
+    // would skip every repaint. Hand it one that measures.
+    getContainer: (): HTMLElement =>
+      Object.defineProperty(document.createElement('div'), 'offsetWidth', { value: 800 }),
     getGraph: (): unknown => mocks.sigmaContainerProps?.graph
   },
   sigmaContainerProps: null as null | Record<string, any>

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel.tsx
@@ -9,6 +9,7 @@ import type { GraphDataResponse } from '@memry/contracts/graph-api'
 import { Button } from '@/components/ui/button'
 import { useLocalGraphData } from '@/hooks/use-graph-data'
 import { buildGraphologyGraph } from '@/lib/graph-builder'
+import { refreshSigmaIfMeasurable } from '@/lib/sigma-refresh'
 import type { GraphPhysicsOptions } from '@/lib/graph-physics'
 import { useT } from '@memry/i18n/renderer'
 import { GraphEvents } from './graph-events'
@@ -385,7 +386,7 @@ function LocalHoverFadeAnimator({
     const startFade = fadeRef.current
 
     if (startFade === goal) {
-      sigma.refresh()
+      refreshSigmaIfMeasurable(sigma)
       return
     }
 
@@ -395,7 +396,7 @@ function LocalHoverFadeAnimator({
     const tick = (now: number): void => {
       const t = Math.min((now - startTime) / duration, 1)
       fadeRef.current = startFade + (goal - startFade) * easeOutQuad(t)
-      sigma.refresh()
+      refreshSigmaIfMeasurable(sigma)
 
       if (t < 1) {
         animRef.current = requestAnimationFrame(tick)
@@ -403,7 +404,7 @@ function LocalHoverFadeAnimator({
         animRef.current = null
         if (!hoveredNode) {
           hoverTargetRef.current = null
-          sigma.refresh()
+          refreshSigmaIfMeasurable(sigma)
         }
       }
     }

--- a/apps/desktop/src/renderer/src/components/graph/physics-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/physics-layout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 import { useSigma } from '@react-sigma/core'
 import type Graph from 'graphology'
 import { GraphPhysics, type GraphPhysicsOptions } from '@/lib/graph-physics'
+import { refreshSigmaIfMeasurable } from '@/lib/sigma-refresh'
 
 /** Upper bound on the synchronous pre-settle, so a huge vault cannot lock the frame forever. */
 const SETTLE_TICK_LIMIT = 400
@@ -58,7 +59,7 @@ export function LivePhysics({
       // SigmaContainer recreates Sigma when `graph` changes and React may hand us
       // the old, killed instance; refreshing that one throws. Same guard as
       // SigmaSettingsSync.
-      if (sigma.getGraph() === graph) sigma.refresh(REPAINT_MOVEMENT_ONLY)
+      if (sigma.getGraph() === graph) refreshSigmaIfMeasurable(sigma, REPAINT_MOVEMENT_ONLY)
       frame = physics.isSettled ? null : requestAnimationFrame(step)
     }
 
@@ -127,7 +128,7 @@ export function SettledPhysics({
     const physics = new GraphPhysics(graph, options)
     physicsRef.current = physics
     settle(physics)
-    if (sigma.getGraph() === graph) sigma.refresh()
+    if (sigma.getGraph() === graph) refreshSigmaIfMeasurable(sigma)
 
     return () => {
       physicsRef.current = null
@@ -143,7 +144,7 @@ export function SettledPhysics({
     if (!physics?.sync()) return
     physics.reheat()
     settle(physics)
-    if (sigma.getGraph() === graph) sigma.refresh()
+    if (sigma.getGraph() === graph) refreshSigmaIfMeasurable(sigma)
   }, [revision, graph, sigma])
 
   return null

--- a/apps/desktop/src/renderer/src/lib/sigma-refresh.ts
+++ b/apps/desktop/src/renderer/src/lib/sigma-refresh.ts
@@ -1,0 +1,25 @@
+import type { Sigma } from 'sigma'
+
+type SigmaRefreshOptions = Parameters<Sigma['refresh']>[0]
+
+/**
+ * Every `sigma.refresh()` renders, and `render()` starts by re-measuring the
+ * container — which throws outright when the container is 0px wide:
+ * "Sigma: Container has no width."
+ *
+ * The graph refreshes from animation frames (physics stepping, hover fades).
+ * React cancels those frames in a passive-effect cleanup, which runs *after*
+ * the mutation phase has already detached the container, so a frame queued
+ * before a teardown still lands on a detached — and therefore 0-width — node
+ * and the throw escapes to `window.onerror`. Skipping the paint is the whole
+ * fix: a container with no width has nothing to show, and one that regains a
+ * width gets repainted by the next frame.
+ *
+ * `allowInvalidContainer` is deliberately not used — it silences the message
+ * and leaves the renderer sized 1×0.
+ */
+export function refreshSigmaIfMeasurable(sigma: Sigma, opts?: SigmaRefreshOptions): boolean {
+  if (sigma.getContainer().offsetWidth === 0) return false
+  sigma.refresh(opts)
+  return true
+}


### PR DESCRIPTION
## Summary

`Sigma: Container has no width` is the largest real failure inside the mixed `Error` fingerprint bucket. 34 users / 43 events over 30 days, and still live on the newest shipped release (`2026.903.2`: 4 events / 3 users, most recent 2026-09-04 02:22 +03:00, win32 and darwin both affected).

Root cause. Sigma's `render()` re-measures the container before drawing and throws outright when it measures 0px wide (`sigma@3.0.3`, `resize()`). The graph repaints from animation frames — the physics simulation in `physics-layout.tsx`, the hover fades in `graph-canvas.tsx` and `local-graph-panel.tsx`. React cancels those frames in a passive-effect cleanup, which runs *after* the mutation phase has already detached the container, so a frame queued before the user leaves the graph lands on a detached (and therefore 0-width) node and the throw escapes to `window.onerror`.

The telemetry matches the mechanism exactly. Every occurrence in the last 10 days fires 2-31 ms after the `$pageview` of the tab the user switched to, and every one is preceded by a `graph_opened` 0.3-11 s earlier:

```
sigma_at                 | preceding pageview                  | delta
2026-09-04T02:22:03.749  | notes    @ 02:22:03.742             |   7 ms
2026-09-04T01:45:37.788  | canvas   @ 01:45:37.766             |  22 ms
2026-09-03T22:13:45.721  | journal  @ 22:13:45.697             |  24 ms
2026-09-03T20:32:10.114  | projects @ 20:32:10.083             |  31 ms
2026-09-03T13:55:11.581  | calendar @ 13:55:11.556             |  25 ms
2026-09-03T00:41:22.032  | tasks    @ 00:41:22.029             |   3 ms
2026-09-03T00:33:50.943  | journal  @ 00:33:50.941             |   2 ms
```

No occurrence sits near a graph mount, so construction at zero width is ruled out — this is a teardown race, not a mount race. Only the active tab is mounted (`tab-pane.tsx`), which is why leaving the graph tears the renderer down while its frames are still queued.

Fix. `refreshSigmaIfMeasurable` skips the paint when the container does not measure, and every refresh in the three graph components routes through it. `allowInvalidContainer` is deliberately not used: it silences the message and leaves the renderer sized 1×0, which is the blank graph the issue complains about.

The four existing graph suites stub Sigma with fakes that had no `getContainer`; each now hands the guard a container that measures, because jsdom does no layout and would otherwise skip every repaint.

No docs change (pushed with `MEMRY_DOCS_IMPACT_SKIP=1`): no feature, setting, UI, or user-visible behaviour changes — this removes an uncaught renderer error and a wasted repaint on teardown.

Closes #1992

## Release note

Fixed an error the graph view could raise when you switched away from it.

## Test plan

New regression test `local-graph-panel-zero-width.test.tsx` models the browser rule that matters: an attached element measures, a detached one reads 0. It drives the real `SigmaContainer` with a fake Sigma that reproduces sigma 3.0.3's `resize()` contract, renders the panel into an attached host, detaches the host, and flushes the queued animation frames.

```
pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/components/graph
 Test Files  8 passed (8)
      Tests  65 passed (65)
```

Mutation-checked, restoring each source from a `/tmp` copy:

- Reverting the guard in `physics-layout.tsx` to a bare `sigma.refresh(...)` fails the detach test with the exact production string: `expected [Function] to not throw an error but 'Error: Sigma: Container has no width.…' was thrown`.
- Making the guard skip unconditionally fails the attached test: `expected 0 to be greater than 0`.

Also green: `pnpm --filter @memry/desktop typecheck:web`, `typecheck:test`, prettier and eslint on every touched file.
