### PR TITLE
fix(editor): stop reading the ProseMirror view through TipTap's lying proxy

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-broken.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-broken.test.tsx
@@ -68,6 +68,10 @@ function editorWith(targets: string[]) {
   return {
     _tiptapEditor: {
       view,
+      // Real tiptap sets `editorView` to the same view while mounted and nulls
+      // it on unmount; `view` alone is a Proxy that lies. The hook reads
+      // `editorView` to tell a live view from a torn-down one.
+      editorView: view,
       on: vi.fn(),
       off: vi.fn(),
       // The hook's plugin-registration effect no-ops through these; the plugin

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-broken.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-broken.ts
@@ -24,6 +24,7 @@ import type { EditorView } from '@tiptap/pm/view'
 import { splitWikiTarget } from '@memry/shared/wiki-target'
 import { notesService, onNoteCreated, onNoteDeleted, onNoteRenamed } from '@/services/notes-service'
 import { registerEditorPlugin } from '../register-editor-plugin'
+import { getLiveTiptapView } from '../live-prosemirror-view'
 import {
   collectWikiLinkTargets,
   createWikiLinkBrokenPlugin,
@@ -34,6 +35,7 @@ const REFRESH_DEBOUNCE_MS = 400
 
 interface TiptapLike {
   view?: EditorView
+  editorView?: EditorView
   on?: (event: string, handler: () => void) => void
   off?: (event: string, handler: () => void) => void
 }
@@ -98,7 +100,7 @@ export function useWikiLinkBroken(editor: unknown): void {
         return
       }
       lastBroken = broken
-      const liveView = tiptap.view
+      const liveView = getLiveTiptapView(tiptap)
       if (liveView) setBrokenWikiTargets(liveView, broken)
     }
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/live-prosemirror-view.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/live-prosemirror-view.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { BlockNoteEditor } from '@blocknote/core'
+import { getLiveProseMirrorView, getLiveTiptapView } from './live-prosemirror-view'
+
+// Uses the default BlockNote schema: the custom schema's extra block specs drag
+// react-pdf into jsdom and none of it touches view lifetime.
+
+const tiptapOf = (editor: BlockNoteEditor): any => (editor as any)._tiptapEditor
+
+const mounted: Array<{ editor: BlockNoteEditor; el: HTMLElement }> = []
+
+afterEach(() => {
+  for (const { editor, el } of mounted.splice(0)) {
+    tiptapOf(editor).unmount()
+    el.remove()
+  }
+})
+
+function mountEditor(): BlockNoteEditor {
+  const editor = BlockNoteEditor.create()
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  editor.mount(el)
+  mounted.push({ editor, el })
+  return editor
+}
+
+// The production teardown order: BlockNoteView's ref unmounts the tiptap editor
+// (nulling `editorView`) while the tiptap editor and its listeners stay alive.
+function unmountedEditor(): BlockNoteEditor {
+  const editor = mountEditor()
+  tiptapOf(editor).unmount()
+  return editor
+}
+
+describe('TipTap 3.x view proxy', () => {
+  it('stays truthy and reports isDestroyed false after unmount, then throws on real access', () => {
+    const editor = unmountedEditor()
+
+    expect(tiptapOf(editor).editorView).toBeFalsy()
+    expect(editor.prosemirrorView).toBeTruthy()
+    expect(editor.prosemirrorView.isDestroyed).toBe(false)
+    expect(() => editor.prosemirrorView.domAtPos(0)).toThrow(/editor view is not available/i)
+  })
+})
+
+describe('getLiveProseMirrorView', () => {
+  it('returns undefined for an unmounted editor', () => {
+    expect(getLiveProseMirrorView(unmountedEditor())).toBeUndefined()
+  })
+
+  it('returns the real view for a mounted editor', () => {
+    const editor = mountEditor()
+    expect(getLiveProseMirrorView(editor)).toBe(tiptapOf(editor).editorView)
+  })
+
+  it('returns undefined for a missing editor', () => {
+    expect(getLiveProseMirrorView(null)).toBeUndefined()
+    expect(getLiveProseMirrorView(undefined)).toBeUndefined()
+  })
+})
+
+describe('getLiveTiptapView', () => {
+  it('returns undefined for an unmounted tiptap editor and the real view for a mounted one', () => {
+    expect(getLiveTiptapView(tiptapOf(unmountedEditor()))).toBeUndefined()
+
+    const tiptap = tiptapOf(mountEditor())
+    expect(getLiveTiptapView(tiptap)).toBe(tiptap.editorView)
+  })
+})
+
+// The shape table-border-handles' resolveFocus now uses. Under the old
+// `if (!view || view.isDestroyed)` guard this same body threw.
+describe('resolveFocus guard shape', () => {
+  const resolveFocus = (editor: BlockNoteEditor): Node | null => {
+    const view = getLiveProseMirrorView(editor)
+    if (!view) return null
+    return view.domAtPos(view.state.selection.from).node
+  }
+
+  it('returns null instead of throwing on an unmounted editor', () => {
+    expect(resolveFocus(unmountedEditor())).toBeNull()
+  })
+
+  it('still resolves a node on a mounted editor', () => {
+    expect(resolveFocus(mountEditor())).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/live-prosemirror-view.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/live-prosemirror-view.ts
@@ -1,0 +1,39 @@
+import type { BlockNoteEditor } from '@blocknote/core'
+import type { EditorView } from '@tiptap/pm/view'
+
+type TiptapLike = { view?: EditorView; editorView?: EditorView }
+
+type TiptapHost = {
+  _tiptapEditor?: TiptapLike
+  prosemirrorView?: EditorView
+}
+
+/**
+ * The real ProseMirror view, or `undefined` while there isn't one.
+ *
+ * TipTap 3.x `editor.view` is a Proxy that is ALWAYS truthy. With no mounted
+ * view behind it, it answers `state`, `composing`, `dragging`, `editable` with
+ * stubs, answers `isDestroyed` with `false`, and THROWS on everything else
+ * ("The editor view is not available"). So both halves of the obvious guard,
+ * `if (!view || view.isDestroyed)`, are dead code and the next line crashes.
+ * `BlockNoteEditor.prosemirrorView` forwards to the same Proxy and types itself
+ * non-optional, so TypeScript won't flag it either.
+ *
+ * The hole is open before mount AND after `unmount()`/`destroy()` — teardown
+ * nulls the view while the tiptap editor and its listeners stay alive, so
+ * ResizeObserver and `update`/`selectionUpdate` callbacks still fire (issue
+ * #541). `editorView` is the real, nullable field; it is the only honest check.
+ */
+export function getLiveTiptapView(tiptap: TiptapLike | null | undefined): EditorView | undefined {
+  if (!tiptap?.editorView) return undefined
+  return tiptap.view
+}
+
+export function getLiveProseMirrorView(
+  editor: BlockNoteEditor | null | undefined
+): EditorView | undefined {
+  const host = editor as unknown as TiptapHost | null | undefined
+  const tiptap = host?._tiptapEditor
+  if (tiptap) return getLiveTiptapView(tiptap)
+  return host?.prosemirrorView
+}

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
@@ -1,6 +1,5 @@
 import type { BlockNoteEditor } from '@blocknote/core'
 import type { EditorState } from '@tiptap/pm/state'
-import type { EditorView } from '@tiptap/pm/view'
 import { useEffect, useRef, useState, type MouseEvent, type PointerEvent } from 'react'
 import {
   BasicTextStyleButton,
@@ -20,6 +19,7 @@ import {
 } from '@blocknote/react'
 import { SuggestionMenu } from '@blocknote/core/extensions'
 import { Link2, MessageCircle } from '@/lib/icons'
+import { getLiveProseMirrorView } from './live-prosemirror-view'
 import type { ReviewSelection } from './types'
 import { ListTypeButtons } from './list-type-buttons'
 import { openWikiLinkForSelection } from './wiki-link-edit-plugin'
@@ -446,9 +446,8 @@ export function getEditorSelectionFromState(
 }
 
 type TiptapHost = {
-  _tiptapEditor?: { state?: EditorState; view?: EditorView; editorView?: EditorView }
+  _tiptapEditor?: { state?: EditorState }
   prosemirrorState?: EditorState
-  prosemirrorView?: EditorView
 }
 
 export function getProseMirrorState(editor: BlockNoteEditor): EditorState {
@@ -457,7 +456,7 @@ export function getProseMirrorState(editor: BlockNoteEditor): EditorState {
 }
 
 function getSelectionTop(editor: BlockNoteEditor, from: number): number | undefined {
-  const view = getProseMirrorView(editor)
+  const view = getLiveProseMirrorView(editor)
   const viewDom = getProseMirrorViewDom(editor)
   if (!viewDom || typeof view?.coordsAtPos !== 'function') return undefined
 
@@ -499,20 +498,8 @@ function getDomEditorSelection(editor: BlockNoteEditor): ReviewSelection | null 
   }
 }
 
-function getProseMirrorView(editor: BlockNoteEditor): EditorView | undefined {
-  const host = editor as unknown as TiptapHost
-  const tiptap = host._tiptapEditor
-  // TipTap 3.x `editor.view` returns a Proxy that THROWS on any property access
-  // (e.g. `.dom`) until the ProseMirror view is mounted, so `view?.dom` can't
-  // short-circuit — the Proxy is non-null. `editorView` is the real view and is
-  // only set once mounted; guard on it so reads during the pre-mount render
-  // window get `undefined` instead of crashing the editor (issue #541).
-  if (tiptap && !tiptap.editorView) return undefined
-  return tiptap?.view ?? host.prosemirrorView
-}
-
 function getProseMirrorViewDom(editor: BlockNoteEditor): HTMLElement | undefined {
-  return getProseMirrorView(editor)?.dom
+  return getLiveProseMirrorView(editor)?.dom
 }
 
 function hasMultiBlockDomSelection(editor: BlockNoteEditor): boolean {

--- a/apps/desktop/src/renderer/src/components/note/content-area/table-border-handles.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/table-border-handles.tsx
@@ -24,6 +24,7 @@ import {
 } from '@blocknote/react'
 import { useT } from '@memry/i18n/renderer'
 
+import { getLiveProseMirrorView } from './live-prosemirror-view'
 import { isTableMenuShortcut } from './table-keyboard-menu'
 
 /**
@@ -437,8 +438,8 @@ export const TableBorderHandles: FC<TableBorderHandlesProps> = ({ containerEl })
    * collapsed caret. The selection is the only thing that knows.
    */
   const resolveFocus = useCallback((): void => {
-    const view = editor.prosemirrorView
-    if (!view || view.isDestroyed) {
+    const view = getLiveProseMirrorView(editor)
+    if (!view) {
       focusCellRef.current = null
       setFocusRing(null)
       return


### PR DESCRIPTION
## Summary

Refs #1996. Fixes the `domAtPos` half of it; see "What this does not fix" below for why it is not `Closes`.

TipTap 3.x `Editor.view` is a Proxy that is **always truthy**. With no mounted view behind it, it answers `state`, `composing`, `dragging`, `editable` with stubs, answers `isDestroyed` with `false`, and throws `[tiptap error]: The editor view is not available...` on everything else (`@tiptap/core@3.19.0/dist/index.js:4715-4745`). So the obvious guard is dead code on **both** halves:

```ts
const view = editor.prosemirrorView
if (!view || view.isDestroyed) return   // never taken
view.domAtPos(...)                      // throws
```

`BlockNoteEditor.prosemirrorView` forwards to the same Proxy and declares itself non-optional `EditorView`, so TypeScript never flagged it either.

`resolveFocus` in `table-border-handles.tsx` carried exactly that guard. It runs from a `ResizeObserver` and from the editor's `update` / `selectionUpdate` events, and both outlive the view: `BlockNoteView`'s ref calls `unmount()` (which nulls `editorView`) while the tiptap editor and its listeners stay alive, and `use-editor-teardown` defers `destroy()` past a microtask and an awaited markdown flush. Those two entry points account for every `domAtPos` event in telemetry.

The honest check is `_tiptapEditor.editorView`, the real nullable field. `review-formatting-toolbar.tsx` had already discovered this once (its comment cites #541) but kept it **private and unexported**, so two other call sites re-invented the broken guard. This extracts it as `live-prosemirror-view.ts`, migrates every caller, and keeps the reason in the doc comment — without that sentence the helper reads as redundant and gets deleted, which is how this recurred three times.

Also migrated `use-wiki-link-broken.ts`, where the same dead guard sits on an `await` continuation and then dispatches into the view.

**Validation.** Re-ran the issue's PostHog query (project 412311) before writing any code. `posAtDOM` is live on the newest release `2026.903.2` (last seen 2026-09-03 23:43) and `domAtPos` last fired on `2026.825.1`; 14 events / 4 users across both. Every `domAtPos` stack ends in `Object.get`, which is that Proxy's `get` trap.

### Two sub-failures from #1996 deliberately not fixed here

**`inlineContent.findIndex is not a function` — already fixed, dropped.** Last occurrence anywhere in 120 days is 2026-08-09 on `2026.808.1`, five releases ago. `git log --grep "#1589"` is empty because the fix landed without an issue reference: `12d59c99a` (2026-08-19, first shipped in `v2026-08-21`) deletes that exact `inlineContent.findIndex(` call and replaces it with an `Array.isArray` branch plus a `tableContent` walk. Writing another guard would be redundant.

**React #185 — third-party render loop, documented not fixed**, which acceptance criterion 3 of the issue explicitly allows. The stack is `commitLayoutEffectOnFiber <- ... <- commitHookEffectListMount <- <anonymous> <- measureRect <- dispatchSetState`, and `measureRect` is `useRect` in `@dnd-kit/core@6.3.1` (`core.esm.js:2159`), which calls `setRect` from a `useIsomorphicLayoutEffect`. No application frame appears anywhere in the loop.

### What this does not fix

The `posAtDOM` stack is `HTMLDivElement.<handler> <- getLinkAtElement <- transact <- Object.get`, which runs entirely inside `@blocknote/core`'s `LinkToolbarExtension.getLinkAtElement`. That function reads `editor.prosemirrorView.posAtDOM(element, 0)` with no guard — the identical bug class, upstream. Fixing it means regenerating the existing 130 KB patch over minified dist bundles, and I could not build a reproduction that would let me prove the patch works. Shipping it would be a hypothesis wearing a fix's clothes, so it stays open with frame-level evidence posted on the issue. That is why this is `Refs`, not `Closes`.

**Docs gate:** pushed with `MEMRY_DOCS_IMPACT_SKIP=1`. No user-facing surface changes — no new setting, command, IPC contract, or behaviour a user can observe beyond the editor no longer throwing. Nothing in `apps/docs/src` describes the table focus ring or view-lifetime internals.

## Release note

Fixed a crash that could break the editor when switching or closing a tab while a table was focused.

## Test plan

New `live-prosemirror-view.test.ts` drives a **real** `BlockNoteEditor` (no mock of the Proxy — a mock would prove nothing about the real library). It characterises the bug as a fact about TipTap: after `_tiptapEditor.unmount()`, `editor.prosemirrorView` is truthy, its `isDestroyed` is `false`, and `domAtPos(0)` throws `/editor view is not available/`.

Focused suites, run directly via vitest (a bare filename filter is ignored in this repo):

```
vitest run --project renderer live-prosemirror-view.test.ts use-wiki-link-broken.test.tsx \
  review-formatting-toolbar.test.tsx ContentArea.test.tsx
  Test Files  4 passed (4)
       Tests  71 passed (71)
```

`pnpm --filter @memry/desktop typecheck:web` exit 0. `typecheck:test` exit 0 — the new test file is **not** added to either `exclude` backlog and compiles. Prettier clean, ESLint 0 errors, `git diff --check` clean.

**Mutation checks** (source copied to `/tmp` first and restored from there, never `git checkout`):

1. Drop the `!tiptap?.editorView` guard, 3 of 7 fail, including `resolveFocus guard shape > returns null instead of throwing on an unmounted editor` with `[tiptap error]: The editor view is not available. Cannot access view['domAtPos']...` — verbatim the production crash.
2. Make `getLiveProseMirrorView` return `undefined` unconditionally, 2 of 7 fail: `expected undefined to be EditorView{ …(21) }` and `expected null to be truthy`.

`use-wiki-link-broken.test.tsx`'s fixture supplied `view` but no `editorView`, so it was asserting against a shape the real library never has; corrected with a comment saying why. Not run locally: the full desktop suite, deliberately, since several agents share this machine and parallel full suites cause false failures. CI covers it. The boundary-check job fails on `apps/mobile/.../vault-db-harness.ts -> node:sqlite`, pre-existing on `main` and fixed in #2015.
