### PR TITLE
fix(sync-server): retry a rate-limited pack compaction nudge and stop reporting it as a 500

### DIFF
--- a/apps/docs/src/architecture/vault-packs.md
+++ b/apps/docs/src/architecture/vault-packs.md
@@ -82,6 +82,12 @@ Compaction is triggered two ways, both of which converge on the same idempotent 
   request (not per item) onto `PACK_QUEUE` after their own commit has settled, through
   `waitUntil`. A failed enqueue can therefore never fail an already-committed push. The consumer
   runs one message per invocation (`max_batch_size = 1`, `max_concurrency = 1`, `max_retries = 3`).
+- **Queue backpressure.** Queues answers a burst with `Too Many Requests`. The producer retries the
+  send twice with full jitter (`ENQUEUE_RETRY_DELAYS_MS`, 200 ms upper bound), then gives up with a
+  typed `PACK_ENQUEUE_RATE_LIMITED` 429. That is an expected condition, not a defect: the vault's
+  rows still sit above its watermark, so the cron backfill re-drives it. Telemetry records it as a
+  handled warning rather than an unhandled 500, so it stays visible without reading as an outage.
+  Any enqueue failure that is not backpressure still surfaces as a genuine unhandled error.
 - **Cron backfill.** The 6-hourly sweep drains historical backlog at `PACKS_PER_BACKFILL_TICK` = 3
   packs per tick across all vaults, oldest backlog first, with no sleeps inside the invocation —
   Worker CPU is billed wall-CPU, so pacing is expressed as bounded work per tick plus a resumable

--- a/apps/sync-server/src/lib/errors.ts
+++ b/apps/sync-server/src/lib/errors.ts
@@ -85,6 +85,11 @@ export const ErrorCodes = {
   NOT_FOUND: 'NOT_FOUND',
   RATE_LIMITED: 'RATE_LIMITED',
 
+  // Queues answered the compaction nudge with backpressure (#1997). Never
+  // reaches a client: the nudge runs in waitUntil after the response is sent,
+  // so this code exists purely to classify the failure as expected telemetry.
+  PACK_ENQUEUE_RATE_LIMITED: 'PACK_ENQUEUE_RATE_LIMITED',
+
   WS_RATE_LIMITED: 'WS_RATE_LIMITED',
   WS_TOKEN_EXPIRED: 'WS_TOKEN_EXPIRED',
   WS_INVALID_CONNECTION: 'WS_INVALID_CONNECTION'

--- a/apps/sync-server/src/services/analytics.test.ts
+++ b/apps/sync-server/src/services/analytics.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { captureBusinessEvent, captureServerError, captureServerLog } from './analytics'
+import { AppError, ErrorCodes } from '../lib/errors'
+import {
+  captureBusinessEvent,
+  captureServerError,
+  captureServerLog,
+  waitUntilCaptured
+} from './analytics'
 import { hashTelemetryId } from './telemetry'
 
 afterEach(() => {
@@ -275,5 +281,74 @@ describe('captureServerLog → PostHog', () => {
     expect(body.batch[0].properties.environment).toBe('staging')
     expect(body.batch[0].properties.level).toBe('info')
     expect(body.batch[0].properties.status_code).toBe(200)
+  })
+})
+
+/**
+ * Background-task classification (#1997). A rejected waitUntil promise used to
+ * be stamped 500/WAIT_UNTIL_REJECTED/handled:false unconditionally, which
+ * buried expected backpressure in the unhandled-error stream.
+ */
+describe('waitUntilCaptured classification', () => {
+  const contextFor = () => {
+    const scheduled: Promise<unknown>[] = []
+    return {
+      ctx: {
+        env: posthogEnv,
+        req: { method: 'POST', path: '/sync/push' },
+        executionCtx: {
+          waitUntil: (promise: Promise<unknown>) => {
+            scheduled.push(promise)
+          }
+        }
+      },
+      settle: () => Promise.all(scheduled)
+    }
+  }
+
+  const logLineFrom = (fetchSpy: ReturnType<typeof stubFetch>) => {
+    const logCall = fetchSpy.mock.calls.find(([url]) => String(url).endsWith('/v1/logs'))
+    const body = JSON.parse((logCall![1] as RequestInit).body as string)
+    const record = body.resourceLogs[0].scopeLogs[0].logRecords[0]
+    return { severity: record.severityText, line: JSON.parse(record.body.stringValue) }
+  }
+
+  it('records a typed error as expected backpressure, not an unhandled 500', async () => {
+    const fetchSpy = stubFetch()
+    const { ctx, settle } = contextFor()
+    const rateLimited = new AppError(
+      ErrorCodes.PACK_ENQUEUE_RATE_LIMITED,
+      'Pack compaction enqueue rate-limited; deferred to the backfill cron',
+      429
+    )
+
+    waitUntilCaptured(ctx, Promise.reject(rateLimited), {
+      source: 'PackQueue',
+      action: 'pack_enqueue_failed'
+    })
+    await settle()
+
+    const { severity, line } = logLineFrom(fetchSpy)
+    expect(severity).toBe('warn')
+    expect(line.handled).toBe(true)
+    expect(line.status_code).toBe(429)
+    expect(line.error_code).toBe('PACK_ENQUEUE_RATE_LIMITED')
+  })
+
+  it('still records an untyped rejection as an unhandled 500', async () => {
+    const fetchSpy = stubFetch()
+    const { ctx, settle } = contextFor()
+
+    waitUntilCaptured(ctx, Promise.reject(new Error('queue exploded')), {
+      source: 'PackQueue',
+      action: 'pack_enqueue_failed'
+    })
+    await settle()
+
+    const { severity, line } = logLineFrom(fetchSpy)
+    expect(severity).toBe('error')
+    expect(line.handled).toBe(false)
+    expect(line.status_code).toBe(500)
+    expect(line.error_code).toBe('WAIT_UNTIL_REJECTED')
   })
 })

--- a/apps/sync-server/src/services/analytics.ts
+++ b/apps/sync-server/src/services/analytics.ts
@@ -359,6 +359,15 @@ export const safeWaitUntil = (
   }
 }
 
+// An AppError-shaped rejection carries its own code AND status, which means the
+// throwing code already classified itself. Duck-typed rather than
+// `instanceof AppError` because lib/errors.ts imports this module.
+const isClassifiedError = (error: unknown): boolean =>
+  error !== null &&
+  typeof error === 'object' &&
+  typeof (error as { code?: unknown }).code === 'string' &&
+  typeof (error as { statusCode?: unknown }).statusCode === 'number'
+
 export const waitUntilCaptured = (
   c: WaitUntilContext,
   promise: Promise<unknown>,
@@ -372,9 +381,12 @@ export const waitUntilCaptured = (
         path: getRequestPath(c.req),
         source: metadata.source,
         action: metadata.action,
-        errorCode: 'WAIT_UNTIL_REJECTED',
-        statusCode: 500,
-        handled: false
+        // Mirror errorHandler: a typed error is an expected condition, so let
+        // its own code/status through and mark it handled. Only an untyped
+        // rejection is a genuine unhandled defect worth a 500 (#1997).
+        ...(isClassifiedError(error)
+          ? { handled: true }
+          : { errorCode: 'WAIT_UNTIL_REJECTED', statusCode: 500, handled: false })
       })
     )
   )

--- a/apps/sync-server/src/services/pack-compaction.test.ts
+++ b/apps/sync-server/src/services/pack-compaction.test.ts
@@ -1,14 +1,61 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createMemoryR2, createSqliteD1, type SqliteD1 } from '../__tests__/d1-sqlite'
-import { PACKED_KINDS,
+import { AppError } from '../lib/errors'
+import {
+  ENQUEUE_RETRY_DELAYS_MS,
+  PACKED_KINDS,
   PACK_TARGET_BYTES,
   compactOneRange,
+  enqueuePackCompaction,
   insertPackIndexRow,
   packObjectKey,
   selectCandidates
 } from './pack-compaction'
 import { extractEntry, parsePack } from './pack-format'
+
+/**
+ * Producer-side backpressure (#1997). Queues answers a burst with "Too Many
+ * Requests"; that used to drop the nudge on the first try and surface as an
+ * unhandled 500.
+ */
+describe('enqueuePackCompaction under queue backpressure', () => {
+  const scope = { userId: 'user-enqueue', vaultId: 'default' }
+  const tooManyRequests = (): Error => new Error('Queue send failed: Too Many Requests')
+
+  it('retries a rate-limited send instead of dropping the nudge', async () => {
+    const send = vi.fn().mockRejectedValueOnce(tooManyRequests()).mockResolvedValueOnce(undefined)
+
+    await enqueuePackCompaction({ PACK_QUEUE: { send } as unknown as Queue }, scope)
+
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(send).toHaveBeenLastCalledWith(scope)
+  })
+
+  it('gives up as a typed 429 so telemetry reads it as expected, not unhandled', async () => {
+    const send = vi.fn().mockRejectedValue(tooManyRequests())
+
+    const thrown = await enqueuePackCompaction(
+      { PACK_QUEUE: { send } as unknown as Queue },
+      scope
+    ).catch((error: unknown) => error)
+
+    expect(send).toHaveBeenCalledTimes(ENQUEUE_RETRY_DELAYS_MS.length + 1)
+    expect(thrown).toBeInstanceOf(AppError)
+    expect((thrown as AppError).code).toBe('PACK_ENQUEUE_RATE_LIMITED')
+    expect((thrown as AppError).statusCode).toBe(429)
+  })
+
+  it('rethrows a non-backpressure failure unchanged and without retrying', async () => {
+    const boom = new Error('binding exploded')
+    const send = vi.fn().mockRejectedValue(boom)
+
+    await expect(
+      enqueuePackCompaction({ PACK_QUEUE: { send } as unknown as Queue }, scope)
+    ).rejects.toBe(boom)
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+})
 
 /**
  * Compaction core against the REAL migration ledger (0001..0007): selection

--- a/apps/sync-server/src/services/pack-compaction.ts
+++ b/apps/sync-server/src/services/pack-compaction.ts
@@ -1,3 +1,4 @@
+import { AppError, ErrorCodes } from '../lib/errors'
 import { createLogger } from '../lib/logger'
 import { openPack, type PackEntryMeta, type PackEntryPlan, type PackKindName } from './pack-format'
 
@@ -571,6 +572,18 @@ export interface PackCompactionMessageBody {
   vaultId: string
 }
 
+// Backoff caps for a rate-limited send (#1997). Two short retries, upper-bounded
+// at 200ms total: the nudge rides waitUntil after the response is already sent,
+// so it may spend a little time, but never enough to matter to the invocation.
+export const ENQUEUE_RETRY_DELAYS_MS = [50, 150]
+
+// Queues signals per-queue backpressure as "Too Many Requests". Matched on the
+// message because the binding throws a plain Error with no status field.
+const isQueueRateLimited = (error: unknown): boolean =>
+  error instanceof Error && /too many requests|rate limit(ed)?|\b429\b/i.test(error.message)
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
 /**
  * Enqueue a compaction nudge after a successful push/snapshot commit.
  * Best-effort coalescing: one message per request (not per item); Queues
@@ -584,5 +597,31 @@ export const enqueuePackCompaction = async (
   scope: VaultScope
 ): Promise<void> => {
   if (!env.PACK_QUEUE) return
-  await env.PACK_QUEUE.send({ userId: scope.userId, vaultId: scope.vaultId })
+  const body = { userId: scope.userId, vaultId: scope.vaultId }
+
+  for (let attempt = 0; attempt <= ENQUEUE_RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      await env.PACK_QUEUE.send(body)
+      return
+    } catch (error) {
+      // Anything that is not backpressure is a real fault: surface it unchanged
+      // so it keeps reading as an unhandled defect.
+      if (!isQueueRateLimited(error)) throw error
+      if (attempt === ENQUEUE_RETRY_DELAYS_MS.length) {
+        // Retries exhausted. The intent is NOT lost and needs no pending-row of
+        // its own: pack_watermarks already leave this vault's rows above its
+        // watermark, so findBacklogVaults picks it up on the 6-hourly backfill
+        // cron. Typed 429 so waitUntilCaptured records expected backpressure
+        // instead of an unhandled 500.
+        throw new AppError(
+          ErrorCodes.PACK_ENQUEUE_RATE_LIMITED,
+          'Pack compaction enqueue rate-limited; deferred to the backfill cron',
+          429
+        )
+      }
+      // Full jitter — isolates that hit the limit together must not retry in
+      // lockstep and rebuild the very burst that triggered it.
+      await sleep(Math.random() * ENQUEUE_RETRY_DELAYS_MS[attempt])
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Closes #1997

Pack compaction is nudged onto a Cloudflare Queue after a successful push. When Queues answered a burst with `Too Many Requests`, `enqueuePackCompaction` sent exactly once, so the 429 rejected inside `waitUntil` and the nudge was gone. `waitUntilCaptured` then stamped every rejection `500` / `WAIT_UNTIL_REJECTED` / `handled:false`, filing routine backpressure in the unhandled-error stream alongside genuine defects.

Re-validated on the production `server` log stream before touching code: the signature is still live, most recently `2026-09-03T14:45:29Z` on `POST /sync/push`.

Two changes:

- `enqueuePackCompaction` retries a rate-limited send twice with full jitter, upper-bounded at 200 ms total. It rides `waitUntil` after the response is already sent, so it may spend that time. A failure that is not backpressure is rethrown unchanged and still reads as a genuine defect.
- On exhaustion it throws a typed `AppError` (`PACK_ENQUEUE_RATE_LIMITED`, 429). `waitUntilCaptured` now mirrors `errorHandler`: an error carrying its own code and status has classified itself, so it is recorded as handled. `captureServerError` already routes `handled` non-5xx to `warn`, so this becomes observable without being alarming.

**No pending-compaction row, and no D1 migration.** The issue proposed persisting the intent, but the durable fallback already exists: `pack_watermarks` leaves the vault's rows above its watermark, so `findBacklogVaults` re-drives it on the 6-hourly backfill cron. A pending table would duplicate that state and add a migration to a production service for nothing. The issue's "nothing retries it" premise is wrong on this point, and `pack-consumer.ts` already documents the cron as the backstop.

The issue also proposed coalescing one enqueue per vault per window. Not done: that needs new shared state (a Durable Object or KV), and at the observed volume the retry absorbs the burst. Worth revisiting only if `PACK_ENQUEUE_RATE_LIMITED` warns become frequent, which is now measurable because they are labelled.

**Compatibility.** No schema, sync-protocol, or wire-format change. `PACK_ENQUEUE_RATE_LIMITED` never reaches a client: the nudge runs in `waitUntil` after the response is sent, so the code exists only to classify telemetry. Older desktop builds are unaffected. Compaction stays what it already was, an optimization rather than a correctness requirement, and the retried send is idempotent by the pipeline's existing design (at-least-once delivery, deterministic pack key, unique `pack_index` row), so a duplicate nudge is at worst one no-op pass.

## Release note

none

## Test plan

- `npx vitest run` in `apps/sync-server`: **80 files, 1263 tests passed**.
- `npx tsc --noEmit -p tsconfig.json` in `apps/sync-server`: clean.
- `prettier --write` on all five touched files. (`apps/sync-server/**` is ignored by `eslint.config.mjs:40`, so ESLint is a no-op there.)
- Five new tests: three covering enqueue retry / typed-429 exhaustion / non-backpressure passthrough, two covering `waitUntilCaptured` classification.
- Mutation-checked both new assertion groups, restoring from `/tmp` copies rather than `git checkout`:
  - Forcing the classification branch off (`isClassifiedError` → `false`) failed exactly one test: `AssertionError: expected 'error' to be 'warn'`.
  - Removing the retry (give up on first 429) failed exactly the two enqueue tests: `expected "vi.fn()" to be called 3 times, but got 1 times`.
