### PR TITLE
fix(desktop): actually rebuild classic-level for Electron

### DIFF
--- a/apps/desktop/scripts/check-packaged-runtime-deps.js
+++ b/apps/desktop/scripts/check-packaged-runtime-deps.js
@@ -151,28 +151,39 @@ const database = new Database(':memory:')
 database.close()
 require(packagedRequire.resolve('keytar'))
 
-// classic-level backs the CRDT store (y-leveldb). A binary built for the
-// wrong ABI does not fail at require() — it fails at open() with
-// napi_create_reference errors thrown out-of-band, or hangs its callbacks
-// (shipped broken in 2026.705.1: first keystroke crashed the editor). Probe a
-// real open/put/get/close so a bad binary fails the build, not the user.
-const { ClassicLevel } = require(packagedRequire.resolve('classic-level'))
-const levelDbPath = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-classic-level-smoke-'))
+// classic-level backs the CRDT store. A binary built for the wrong ABI does
+// not fail at require() — it fails at open() with napi_create_reference errors
+// thrown out-of-band, hangs its callbacks (shipped broken in 2026.705.1: first
+// keystroke crashed the editor), or access-violates on the first write (#1988,
+// win32). Probe through y-leveldb, not classic-level directly: the CRDT store
+// loads its own copy through level, which is a different resolution than a bare
+// require('classic-level') and was the copy left unrebuilt in #1988.
+const Y = require(packagedRequire.resolve('yjs'))
+const { LeveldbPersistence } = require(packagedRequire.resolve('y-leveldb'))
+const levelDbPath = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-crdt-store-smoke-'))
+const PROBE_DOC = '__memry_packaged_smoke__'
 
 const timer = setTimeout(() => {
-  console.error('classic-level smoke timed out — native binding hangs under packaged Electron')
+  console.error('CRDT store smoke timed out — native binding hangs under packaged Electron')
   process.exit(1)
 }, 30000)
 
 ;(async () => {
-  const db = new ClassicLevel(levelDbPath)
-  await db.open()
-  await db.put('probe', 'ok')
-  const value = await db.get('probe')
-  if (value !== 'ok') {
-    throw new Error(\`classic-level probe read mismatch: \${value}\`)
+  const persistence = new LeveldbPersistence(levelDbPath)
+  const doc = new Y.Doc()
+  doc.getMap('probe').set('ok', true)
+  await persistence.storeUpdate(PROBE_DOC, Y.encodeStateAsUpdate(doc))
+  doc.destroy()
+
+  const loaded = await persistence.getYDoc(PROBE_DOC)
+  const value = loaded.getMap('probe').get('ok')
+  loaded.destroy()
+  if (value !== true) {
+    throw new Error(\`CRDT store probe read mismatch: \${value}\`)
   }
-  await db.close()
+
+  await persistence.clearDocument(PROBE_DOC)
+  await persistence.destroy()
   clearTimeout(timer)
   fs.rmSync(levelDbPath, { force: true, recursive: true })
   console.log(\`Electron native runtime ABI \${process.versions.modules}\`)
@@ -240,6 +251,49 @@ function assertNativeModuleArch(moduleName, resolvedPath, expectedArch) {
   }
 }
 
+/**
+ * The CRDT store's classic-level must be compiled for Electron, not the upstream
+ * Node prebuild.
+ *
+ * @electron/rebuild silently leaves it as a prebuild under pnpm: its walker never
+ * descends into y-leveldb's sibling `level` -> `classic-level` copy, and
+ * `Prebuildify.findPrebuiltModule` short-circuits the compile whenever a
+ * `node.napi.node` is present. v2026.903.2 shipped to Windows that way and every
+ * install access-violated on the first store write (#1988). A `build/Release`
+ * binary is the only observable proof the rebuild actually ran, so assert it here
+ * rather than trusting the rebuild step's exit code.
+ *
+ * Resolved through y-leveldb, because that is the chain the main process uses; a
+ * bare require('classic-level') can land on a different copy.
+ */
+function assertCrdtClassicLevelBuiltFromSource(yLeveldbEntry) {
+  let classicLevelRoot
+  try {
+    const yLeveldbRoot = findPackageRoot(yLeveldbEntry, 'y-leveldb')
+    const levelEntry = createRequire(path.join(yLeveldbRoot, 'package.json')).resolve('level')
+    const levelRoot = findPackageRoot(levelEntry, 'level')
+    const classicLevelEntry = createRequire(path.join(levelRoot, 'package.json')).resolve(
+      'classic-level'
+    )
+    classicLevelRoot = findPackageRoot(classicLevelEntry, 'classic-level')
+  } catch (error) {
+    fail(`Cannot resolve the CRDT store's classic-level from y-leveldb: ${error.message}`)
+    return
+  }
+
+  const releaseDir = path.join(classicLevelRoot, 'build', 'Release')
+  const builtBinaries = fs.existsSync(releaseDir)
+    ? fs.readdirSync(releaseDir).filter((entry) => entry.endsWith('.node'))
+    : []
+
+  if (builtBinaries.length === 0) {
+    fail(
+      `Packaged classic-level was never rebuilt for Electron: no build/Release binary in ${classicLevelRoot}. ` +
+        'Run apps/desktop/scripts/ensure-native.sh electron before packaging.'
+    )
+  }
+}
+
 function checkResources(resourcesPath, expectedArch) {
   const appAsarPath = path.join(resourcesPath, 'app.asar')
   const externalNodeModulesPath = path.join(resourcesPath, 'node_modules')
@@ -286,6 +340,8 @@ function checkResources(resourcesPath, expectedArch) {
   if (!fs.existsSync(betterSqliteBinary)) {
     fail(`Missing packaged better-sqlite3 binary: ${betterSqliteBinary}`)
   }
+
+  assertCrdtClassicLevelBuiltFromSource(resolvedModules.get('y-leveldb'))
 
   const directElectronPath = path.join(externalNodeModulesPath, 'electron')
   if (fs.existsSync(directElectronPath)) {

--- a/apps/desktop/scripts/ensure-native.sh
+++ b/apps/desktop/scripts/ensure-native.sh
@@ -98,6 +98,29 @@ if [ "$TARGET" = "electron" ]; then
     process.stdout.write(path.join(main.slice(0, i + marker.length), 'lib', 'cli.js'))
   ")"
   node "$ELECTRON_REBUILD_CLI" -f -o "$MODULES"
+
+  # That call leaves classic-level as the upstream Node prebuild, for two
+  # independent reasons. v2026.903.2 shipped to Windows that way: better-sqlite3
+  # and keytar had build/Release binaries in the package, classic-level had none,
+  # so the CRDT store ran on prebuilds/win32-x64/node.napi.node.
+  #
+  # 1. @electron/rebuild's module walker only descends into `<module>/node_modules`.
+  #    Under pnpm, y-leveldb's level -> classic-level@1.4.x sits in a sibling
+  #    directory inside .pnpm, so the copy the CRDT store actually loads is never
+  #    visited. The only walkable classic-level is the dev-only 3.x, which
+  #    electron-builder then prunes out of the package.
+  # 2. Even when visited, Prebuildify.findPrebuiltModule accepts an existing
+  #    node.napi.node and short-circuits the compile. `-f` does not override that;
+  #    only --build-from-source does.
+  #
+  # So drive each copy in the store directly: --module-dir is always a rebuild
+  # candidate regardless of the walk, and --build-from-source skips the prebuild
+  # short-circuit. Same reasoning as the node branch below.
+  for classic_dir in "$REPO_ROOT"/node_modules/.pnpm/classic-level@*/node_modules/classic-level; do
+    [ -d "$classic_dir" ] || continue
+    echo "[native] force-building ${classic_dir#"$REPO_ROOT/"} for Electron"
+    node "$ELECTRON_REBUILD_CLI" -f --build-from-source --only classic-level --module-dir "$classic_dir"
+  done
 else
   echo "[native] rebuilding $MODULES for Node $(node -v)..."
   for mod in ${MODULES//,/ }; do

--- a/apps/docs/src/contribute/gotchas.md
+++ b/apps/docs/src/contribute/gotchas.md
@@ -15,6 +15,17 @@ Two fix paths depending on the target:
 
 > Using the Node fix for Electron leaves `autoOpenLastVault` silently failing with `ERR_DLOPEN_FAILED`. The app never opens the test vault, and E2E waits for workspace surfaces time out.
 
+## `electron-rebuild -o classic-level` is a silent no-op
+
+Symptom: no `ERR_DLOPEN_FAILED`. The native binding loads, the LevelDB store opens, and the **first write** access-violates (`0xC0000005` on win32) or hangs its callbacks. Windows shipped this way from v2026.705.1 through v2026.903.2 (#1583, #1988): every packaged build carried `build/Release/better_sqlite3.node` and `build/Release/keytar.node`, and no `build/Release` for classic-level at all.
+
+`@electron/rebuild` skips classic-level for two independent reasons:
+
+- Its module walker only descends into `<module>/node_modules`. Under pnpm, y-leveldb's `level` -> `classic-level@1.4.x` sits in a sibling directory inside `.pnpm`, so the copy the CRDT store actually loads is never visited. The only walkable `classic-level` is the dev-only 3.x, which electron-builder then prunes out of the package.
+- Even when visited, `Prebuildify.findPrebuiltModule` accepts an existing `prebuilds/<platform>/node.napi.node` and short-circuits the compile. `--force` does not override that; only `--build-from-source` does.
+
+`apps/desktop/scripts/ensure-native.sh` handles both targets by driving each `.pnpm/classic-level@*` copy directly. Never treat the plain `-o ...,classic-level` flag as proof the rebuild happened. The only proof is a `build/Release/*.node` inside the classic-level package, which `check-packaged-runtime-deps.js` asserts on every packaged build.
+
 ## Electron binary re-downloads on every worktree
 
 `bash apps/desktop/scripts/ensure-native.sh electron` (and the E2E fixtures, when


### PR DESCRIPTION
## Summary

The shipped Windows package never contained an Electron-built `classic-level`. Unzipping `MemryNote-2026.903.2-win.zip` shows `build/Release/better_sqlite3.node` and `build/Release/keytar.node`, and **no** `build/Release` for `classic-level` anywhere. The CRDT store therefore ran on the upstream Node prebuild, `prebuilds/win32-x64/node.napi.node`.

`electron-rebuild -o better-sqlite3,classic-level,keytar` is a silent no-op for `classic-level`, for two independent reasons:

1. `@electron/rebuild`'s module walker only descends into `<module>/node_modules`. Under pnpm, `y-leveldb` → `level@8` → `classic-level@1.4.1` lives in a sibling directory inside `.pnpm`, so the copy the CRDT store actually loads is never visited. The only walkable `classic-level` is the dev-only `3.x` pulled in by the stray `level@^10` devDependency, which electron-builder then prunes out of the package.
2. Even when visited, `Prebuildify.findPrebuiltModule` accepts an existing `node.napi.node` and short-circuits the compile. `-f` does not override that; only `--build-from-source` does.

The node branch of `ensure-native.sh` already works around (1) with its own loop over `.pnpm/classic-level@*`. The electron branch never got the same treatment. This adds it, plus `--build-from-source` for (2).

The packaged gate could not have caught this. It probed `classic-level` through a bare `require`, which is a different resolution than the one the main process uses, and it asserted nothing about how the binary was produced. It now probes `y-leveldb`'s `LeveldbPersistence` — the exact calls `crdt-preflight-child.ts` makes — and fails the build when the CRDT store's `classic-level` has no `build/Release` binary.

Refs #1988, #1583. This does **not** claim to close #1988: whether removing the Node/Electron binary divergence clears the `0xC0000005` on the first store write is measured on the next release. Follow-ups tracked in #2046.

## Release note

none

## Test plan

macOS, `apps/desktop/scripts/ensure-native.sh electron`:

- Before: `classic-level@1.4.1` had no Electron build; the walker reported `Building modules: better-sqlite3, keytar, classic-level` and still short-circuited on the prebuild.
- After: both store copies compile. `build/Release/.forge-meta` reads `arm64--148` for `classic-level@1.4.1` and `classic-level@3.0.0` (Electron 43.1.1 ABI 148).

New smoke probe run under the Electron binary with `ELECTRON_RUN_AS_NODE=1`, resolving through `y-leveldb`:

```
SMOKE OK — electron=43.1.1 ABI=148
```

Resolution chain used by the new assertion verified to land on the copy the CRDT store loads:

```
chain ok -> node_modules/.pnpm/classic-level@1.4.1/node_modules/classic-level
build/Release: [ 'classic_level.node' ]
```

Negative path: with `build/Release` moved aside, the assertion's binary list is empty and the gate fails the build.

Also run: `pnpm lint` (exit 0), `node --test apps/desktop/scripts/check-packaged-runtime-deps-utils.test.cjs` (3/3), `bash -n ensure-native.sh`, `pnpm docs:impact --base bd66a7dd9 --strict` (covered), `pnpm docs:build` (exit 0).

Not run: a full packaged Windows build. The Windows path is exercised by the release workflow's own `Check packaged runtime dependencies` step, which now carries the assertion.
