### PR TITLE
perf(launch): add the cold-launch measurement harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ Thumbs.db
 *.tmp
 .eslintcache
 
+# Launch perf harness output (scripts/launch-bench.mjs)
+.perf/
+
 # Cloudflare
 .wrangler
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typecheck:emails": "pnpm --filter @memry/marketing-emails typecheck",
     "test": "pnpm repair:links && node scripts/run-turbo.js run test --filter=@memry/contracts --filter=@memry/sync-client --filter=@memry/app-core --filter=@memry/cli --filter=@memry/desktop --filter=@memry/editor-schema --filter=@memry/sync-server --filter=@memry/landing --filter=@memry/mobile",
     "test:cli": "pnpm --filter @memry/app-core test && pnpm --filter @memry/cli test",
-    "test:release": "node --test scripts/release-utils.test.mjs scripts/release-notes-utils.test.mjs scripts/reddit-release-utils.test.mjs scripts/pre-push-policy.test.mjs scripts/docs-impact.test.mjs scripts/package-scripts.test.mjs scripts/link-env.test.mjs scripts/check-staged-renderer-guards.test.mjs apps/desktop/scripts/build-packaged-app-utils.test.cjs apps/desktop/scripts/check-packaged-runtime-deps-utils.test.cjs",
+    "test:release": "node --test scripts/release-utils.test.mjs scripts/release-notes-utils.test.mjs scripts/reddit-release-utils.test.mjs scripts/pre-push-policy.test.mjs scripts/docs-impact.test.mjs scripts/package-scripts.test.mjs scripts/link-env.test.mjs scripts/check-staged-renderer-guards.test.mjs scripts/launch-bench.test.mjs apps/desktop/scripts/build-packaged-app-utils.test.cjs apps/desktop/scripts/check-packaged-runtime-deps-utils.test.cjs",
     "test:desktop": "pnpm --filter @memry/desktop test",
     "test:sync-server": "pnpm --filter @memry/sync-server test",
     "test:sync-harness": "pnpm --filter @memry/sync-harness build:worker && pnpm --filter @memry/sync-harness test",

--- a/scripts/launch-bench.mjs
+++ b/scripts/launch-bench.mjs
@@ -1,0 +1,640 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { open } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const LOCK_DIR = '/tmp/memry-launch-bench.lock'
+const LOG_PATH = path.join(homedir(), 'Library/Logs/memrynote/main.log')
+const PERF_DIR = fileURLToPath(new URL('../.perf/', import.meta.url))
+const APP_MTIME_STAMP = path.join(PERF_DIR, 'last-app-mtime')
+
+const DEFAULT_RUNS = 5
+const DEFAULT_APP = '/Applications/MemryNote.app'
+const DEFAULT_PORT = 9222
+
+const SETTLE_MS = 2_000
+const QUIT_DEADLINE_MS = 20_000
+const CDP_DEADLINE_MS = 30_000
+const LOG_DEADLINE_MS = 45_000
+const READY_STATE_DEADLINE_MS = 30_000
+const CDP_POLL_MS = 250
+const LOG_POLL_MS = 100
+
+const LOG_TIMESTAMP_PATTERN = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})\.(\d{3})\b/
+const STARTING_LINE_PATTERN = /MemryNote (\S+) starting \((packaged|dev)\)/
+const TIMELINE_FIELD_PATTERN = /^([A-Za-z][A-Za-z0-9]*): (.+?),?$/
+
+export const TIERS = {
+  packaged: { label: 'packaged (tier 3)', wallClockValid: true },
+  dev: { label: 'dev build', wallClockValid: false },
+  unknown: { label: 'unknown', wallClockValid: false }
+}
+
+export const METRICS = [
+  { key: 'click_to_shown_ms', read: (run) => run.clickToShownMs, tier3Only: true },
+  { key: 'app_ready_ms', read: (run) => run.timeline?.appReadyMs, tier3Only: false },
+  { key: 'window_created_ms', read: (run) => run.timeline?.windowCreatedMs, tier3Only: false },
+  { key: 'vault_open_start_ms', read: (run) => run.timeline?.vaultOpenStartMs, tier3Only: false },
+  { key: 'vault_open_ready_ms', read: (run) => run.timeline?.vaultOpenReadyMs, tier3Only: false },
+  { key: 'renderer_loaded_ms', read: (run) => run.timeline?.rendererLoadedMs, tier3Only: false },
+  { key: 'ready_to_show_ms', read: (run) => run.timeline?.readyToShowMs, tier3Only: false },
+  { key: 'shown_ms', read: (run) => run.timeline?.shownMs, tier3Only: false },
+  { key: 'renderer_first_paint_ms', read: (run) => run.renderer?.firstPaintMs, tier3Only: false },
+  { key: 'renderer_fcp_ms', read: (run) => run.renderer?.fcpMs, tier3Only: false },
+  {
+    key: 'renderer_dom_interactive_ms',
+    read: (run) => run.renderer?.domInteractiveMs,
+    tier3Only: false
+  },
+  {
+    key: 'renderer_dom_content_loaded_ms',
+    read: (run) => run.renderer?.domContentLoadedMs,
+    tier3Only: false
+  },
+  { key: 'cdp_attach_offset_ms', read: (run) => run.cdpAttachOffsetMs, tier3Only: false }
+]
+
+const REFUSAL_NOTE = 'refused: not tier 3 (packaged)'
+const REFUSAL_CELL = 'refused (not tier 3)'
+
+export function parseLogTimestamp(line) {
+  const match = LOG_TIMESTAMP_PATTERN.exec(line)
+  if (!match) {
+    return null
+  }
+
+  const [, year, month, day, hour, minute, second, millisecond] = match
+
+  return new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second),
+    Number(millisecond)
+  ).getTime()
+}
+
+function parseTimelineValue(raw) {
+  if (raw.startsWith("'") && raw.endsWith("'")) {
+    return raw.slice(1, -1)
+  }
+  if (raw === 'true') {
+    return true
+  }
+  if (raw === 'false') {
+    return false
+  }
+
+  const numeric = Number(raw)
+  return Number.isNaN(numeric) ? raw : numeric
+}
+
+export function parseLaunchTimeline(slice) {
+  const lines = slice.split('\n')
+  let startIndex = -1
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index].includes('launch timeline {')) {
+      startIndex = index
+    }
+  }
+
+  if (startIndex === -1) {
+    return null
+  }
+
+  const fields = {}
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index].trim()
+    if (line === '}') {
+      return fields
+    }
+
+    const match = TIMELINE_FIELD_PATTERN.exec(line)
+    if (match) {
+      fields[match[1]] = parseTimelineValue(match[2])
+    }
+  }
+
+  return null
+}
+
+export function findWindowShownAt(slice) {
+  const lines = slice.split('\n').filter((line) => line.includes('main window shown'))
+  if (lines.length === 0) {
+    return null
+  }
+
+  return parseLogTimestamp(lines.at(-1))
+}
+
+export function detectTier(slice) {
+  return STARTING_LINE_PATTERN.exec(slice)?.[2] ?? 'unknown'
+}
+
+export function median(numbers) {
+  const sorted = numbers.filter((value) => Number.isFinite(value)).sort((a, b) => a - b)
+  if (sorted.length === 0) {
+    return null
+  }
+
+  const middle = Math.floor(sorted.length / 2)
+  if (sorted.length % 2 === 1) {
+    return sorted[middle]
+  }
+
+  return (sorted[middle - 1] + sorted[middle]) / 2
+}
+
+export function summarize(runs) {
+  const wallClockValid =
+    runs.length > 0 && runs.every((run) => TIERS[run.tier]?.wallClockValid === true)
+
+  return METRICS.map(({ key, read, tier3Only }) => {
+    if (tier3Only && !wallClockValid) {
+      return { key, median: null, unit: 'ms', note: REFUSAL_NOTE }
+    }
+
+    return { key, median: median(runs.map(read)), unit: 'ms', note: null }
+  })
+}
+
+export function formatMedianTable(summary, runs) {
+  const width = Math.max(...summary.map((row) => row.key.length), 'metric'.length)
+  const tiers = runs.map((run) => `#${run.run} ${run.tier}`).join(', ')
+  const lines = [
+    `runs: ${runs.length}${tiers ? ` (${tiers})` : ''}`,
+    '',
+    `${'metric'.padEnd(width)}  median`
+  ]
+
+  for (const row of summary) {
+    const cell = row.note
+      ? REFUSAL_CELL
+      : row.median === null
+        ? '-'
+        : `${Number(row.median.toFixed(3))} ${row.unit}`
+    lines.push(`${row.key.padEnd(width)}  ${cell}`)
+  }
+
+  return lines.join('\n')
+}
+
+function detectAppVersion(slice) {
+  return STARTING_LINE_PATTERN.exec(slice)?.[1] ?? null
+}
+
+function readRequiredValue(argv, index, flag) {
+  const value = argv[index + 1]
+  if (!value) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return value
+}
+
+function readPositiveInteger(raw, flag) {
+  const value = Number(raw)
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${flag} requires a positive integer, got: ${raw}`)
+  }
+  return value
+}
+
+function parseArgs(argv) {
+  const options = { runs: DEFAULT_RUNS, appPath: DEFAULT_APP, port: DEFAULT_PORT }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+
+    if (arg === '--runs') {
+      options.runs = readPositiveInteger(readRequiredValue(argv, index, arg), arg)
+      index += 1
+      continue
+    }
+
+    if (arg === '--app') {
+      options.appPath = path.resolve(readRequiredValue(argv, index, arg))
+      index += 1
+      continue
+    }
+
+    if (arg === '--port') {
+      options.port = readPositiveInteger(readRequiredValue(argv, index, arg), arg)
+      index += 1
+      continue
+    }
+
+    throw new Error(
+      `Unknown argument: ${arg}\nUsage: node scripts/launch-bench.mjs [--runs 5] [--app ${DEFAULT_APP}] [--port ${DEFAULT_PORT}]`
+    )
+  }
+
+  return options
+}
+
+let lockHeld = false
+
+function releaseLock() {
+  if (!lockHeld) {
+    return
+  }
+  lockHeld = false
+  rmSync(LOCK_DIR, { force: true, recursive: true })
+}
+
+function refuseOnHeldLock() {
+  let owner
+  try {
+    owner = readFileSync(path.join(LOCK_DIR, 'owner'), 'utf8').trim()
+  } catch {
+    owner = '(no owner file)'
+  }
+
+  console.error(`launch-bench: ${LOCK_DIR} is held by another run.`)
+  console.error(owner)
+  console.error(`If that pid is dead, remove the lock: rm -rf ${LOCK_DIR}`)
+  process.exit(1)
+}
+
+function acquireLock() {
+  try {
+    mkdirSync(LOCK_DIR)
+  } catch (error) {
+    if (error.code === 'EEXIST') {
+      refuseOnHeldLock()
+    }
+    throw error
+  }
+
+  lockHeld = true
+  writeFileSync(
+    path.join(LOCK_DIR, 'owner'),
+    `pid ${process.pid}\nstarted ${new Date().toISOString()}\n`
+  )
+
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => {
+      releaseLock()
+      process.exit(signal === 'SIGINT' ? 130 : 143)
+    })
+  }
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function readAppMtimeMs(appPath) {
+  const appName = path.basename(appPath, '.app')
+  return statSync(path.join(appPath, 'Contents/MacOS', appName)).mtimeMs
+}
+
+function readStoredAppMtimeMs() {
+  try {
+    const stored = Number(readFileSync(APP_MTIME_STAMP, 'utf8').trim())
+    return Number.isFinite(stored) ? stored : null
+  } catch {
+    return null
+  }
+}
+
+function isAppRunning(appPath) {
+  return spawnSync('pgrep', ['-f', `${appPath}/Contents/MacOS/`]).status === 0
+}
+
+async function quitApp(appPath) {
+  spawnSync('osascript', ['-e', `quit app "${path.basename(appPath, '.app')}"`])
+
+  const deadline = Date.now() + QUIT_DEADLINE_MS
+  while (Date.now() < deadline) {
+    if (!isAppRunning(appPath)) {
+      return
+    }
+    await delay(CDP_POLL_MS)
+  }
+
+  throw new Error(`${appPath} was still running ${QUIT_DEADLINE_MS} ms after the quit request`)
+}
+
+function logSizeOrZero() {
+  try {
+    return statSync(LOG_PATH).size
+  } catch {
+    return 0
+  }
+}
+
+// The log is shared by the packaged app and by any `pnpm dev` in any worktree, so the
+// byte offset taken just before launch is the only thing that makes the slice ours.
+async function readLogSlice(anchorOffset) {
+  let handle
+  try {
+    handle = await open(LOG_PATH, 'r')
+  } catch {
+    return ''
+  }
+
+  try {
+    const stats = await handle.stat()
+    if (stats.size <= anchorOffset) {
+      return ''
+    }
+
+    const buffer = Buffer.alloc(stats.size - anchorOffset)
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, anchorOffset)
+    return buffer.subarray(0, bytesRead).toString('utf8')
+  } finally {
+    await handle.close()
+  }
+}
+
+async function fetchPageTarget(port) {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/json/list`)
+    if (!response.ok) {
+      return null
+    }
+    const targets = await response.json()
+    return targets.find((target) => target.type === 'page') ?? null
+  } catch {
+    return null
+  }
+}
+
+async function waitForPageTarget(port) {
+  const deadline = Date.now() + CDP_DEADLINE_MS
+  while (Date.now() < deadline) {
+    const target = await fetchPageTarget(port)
+    if (target) {
+      return target
+    }
+    await delay(CDP_POLL_MS)
+  }
+
+  throw new Error(`no CDP page target on port ${port} within ${CDP_DEADLINE_MS} ms`)
+}
+
+async function waitForLaunchRecord(anchorOffset) {
+  const deadline = Date.now() + LOG_DEADLINE_MS
+  while (Date.now() < deadline) {
+    const slice = await readLogSlice(anchorOffset)
+    const shownAt = findWindowShownAt(slice)
+    const timeline = parseLaunchTimeline(slice)
+    if (shownAt !== null && timeline) {
+      return { slice, shownAt, timeline }
+    }
+    await delay(LOG_POLL_MS)
+  }
+
+  throw new Error(
+    `log had no "main window shown" line plus a closed launch timeline block within ${LOG_DEADLINE_MS} ms`
+  )
+}
+
+function connectCdp(webSocketDebuggerUrl) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(webSocketDebuggerUrl)
+    const pending = new Map()
+    let nextId = 1
+
+    const failPending = (error) => {
+      for (const entry of pending.values()) {
+        entry.reject(error)
+      }
+      pending.clear()
+    }
+
+    socket.addEventListener('message', (event) => {
+      const message = JSON.parse(event.data)
+      const entry = pending.get(message.id)
+      if (!entry) {
+        return
+      }
+      pending.delete(message.id)
+      if (message.error) {
+        entry.reject(new Error(`CDP ${message.error.message}`))
+      } else {
+        entry.resolve(message.result)
+      }
+    })
+
+    socket.addEventListener('error', () => {
+      const error = new Error(`CDP socket failed: ${webSocketDebuggerUrl}`)
+      failPending(error)
+      reject(error)
+    })
+
+    socket.addEventListener('close', () => {
+      failPending(new Error('CDP socket closed with requests in flight'))
+    })
+
+    socket.addEventListener('open', () => {
+      resolve({
+        send(method, params) {
+          return new Promise((resolveSend, rejectSend) => {
+            const id = nextId
+            nextId += 1
+            pending.set(id, { resolve: resolveSend, reject: rejectSend })
+            socket.send(JSON.stringify({ id, method, params }))
+          })
+        },
+        close() {
+          socket.close()
+        }
+      })
+    })
+  })
+}
+
+const RENDERER_METRICS_EXPRESSION = `(() => {
+  const round = (value) => (typeof value === 'number' ? Math.round(value * 1000) / 1000 : undefined)
+  const navigation = performance.getEntriesByType('navigation')[0]
+  const paints = performance.getEntriesByType('paint')
+  const paintAt = (name) => paints.find((entry) => entry.name === name)?.startTime
+  return {
+    firstPaintMs: round(paintAt('first-paint')),
+    fcpMs: round(paintAt('first-contentful-paint')),
+    domInteractiveMs: round(navigation?.domInteractive),
+    domContentLoadedMs: round(navigation?.domContentLoadedEventEnd),
+    loadEventMs: round(navigation?.loadEventEnd)
+  }
+})()`
+
+async function readRendererMetrics(webSocketDebuggerUrl) {
+  const client = await connectCdp(webSocketDebuggerUrl)
+
+  try {
+    const deadline = Date.now() + READY_STATE_DEADLINE_MS
+    let ready = false
+    while (Date.now() < deadline) {
+      const state = await client.send('Runtime.evaluate', {
+        expression: 'document.readyState',
+        returnByValue: true
+      })
+      if (state.result?.value === 'complete') {
+        ready = true
+        break
+      }
+      await delay(CDP_POLL_MS)
+    }
+
+    if (!ready) {
+      throw new Error(
+        `renderer never reached document.readyState "complete" within ${READY_STATE_DEADLINE_MS} ms`
+      )
+    }
+
+    // Screencast frame timing is not a metric here: attaching CDP perturbs the renderer,
+    // and the epic's exploratory run saw no first frame until +3.88 s. The performance
+    // entries below were recorded before the attach, so reading them after load is safe.
+    const evaluated = await client.send('Runtime.evaluate', {
+      expression: RENDERER_METRICS_EXPRESSION,
+      returnByValue: true
+    })
+
+    return evaluated.result?.value ?? {}
+  } finally {
+    client.close()
+  }
+}
+
+function collectWarnings(record) {
+  const warnings = []
+  if (record.tier !== 'packaged') {
+    warnings.push(`tier is "${record.tier}", wall-clock metrics are not comparable`)
+  }
+  if (record.timeline.rendererLoadedMs === undefined) {
+    warnings.push('launch timeline had no rendererLoadedMs field')
+  }
+  if (record.renderer.fcpMs === undefined) {
+    warnings.push('renderer reported no first-contentful-paint entry')
+  }
+  return warnings
+}
+
+async function measureRun({ run, appPath, port, appMtimeMs, firstRunAfterAppChange }) {
+  await quitApp(appPath)
+  await delay(SETTLE_MS)
+
+  const anchorOffset = logSizeOrZero()
+  const t0 = Date.now()
+  const launch = spawnSync('open', [
+    '-a',
+    appPath,
+    '--args',
+    `--remote-debugging-port=${port}`,
+    '--remote-allow-origins=*'
+  ])
+
+  if (launch.status !== 0) {
+    throw new Error(
+      `open -a ${appPath} exited ${launch.status}: ${String(launch.stderr ?? '').trim()}`
+    )
+  }
+
+  const target = await waitForPageTarget(port)
+  const cdpAttachOffsetMs = Date.now() - t0
+
+  const { slice, shownAt, timeline } = await waitForLaunchRecord(anchorOffset)
+  const renderer = await readRendererMetrics(target.webSocketDebuggerUrl)
+  const tier = detectTier(slice)
+
+  const record = {
+    run,
+    tier,
+    tierLabel: TIERS[tier].label,
+    appMtimeMs,
+    firstRunAfterAppChange,
+    t0Iso: new Date(t0).toISOString(),
+    clickToShownMs: shownAt - t0,
+    cdpAttachOffsetMs,
+    timeline,
+    renderer,
+    warnings: [],
+    appVersion: detectAppVersion(slice)
+  }
+  record.warnings = collectWarnings(record)
+
+  return record
+}
+
+async function runBench(options) {
+  const appMtimeMs = readAppMtimeMs(options.appPath)
+  let firstRunAfterAppChange = readStoredAppMtimeMs() !== appMtimeMs
+
+  const startedAt = new Date().toISOString()
+  const runs = []
+  const failures = []
+
+  for (let run = 1; run <= options.runs; run += 1) {
+    try {
+      const record = await measureRun({
+        run,
+        appPath: options.appPath,
+        port: options.port,
+        appMtimeMs,
+        firstRunAfterAppChange
+      })
+      runs.push(record)
+      console.log(JSON.stringify(record))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      failures.push({ run, message })
+      console.error(`run ${run} failed: ${message}`)
+    }
+
+    if (run === 1) {
+      mkdirSync(PERF_DIR, { recursive: true })
+      writeFileSync(APP_MTIME_STAMP, `${appMtimeMs}\n`)
+      firstRunAfterAppChange = false
+    }
+  }
+
+  const summary = summarize(runs)
+  const appVersion = runs.find((record) => record.appVersion)?.appVersion ?? 'unknown version'
+
+  console.log('')
+  console.log(`${options.appPath} (${appVersion})`)
+  console.log(formatMedianTable(summary, runs))
+
+  mkdirSync(PERF_DIR, { recursive: true })
+  const reportPath = path.join(PERF_DIR, `launch-bench-${startedAt.replaceAll(':', '-')}.json`)
+  writeFileSync(
+    reportPath,
+    `${JSON.stringify({ app: options.appPath, appMtimeMs, startedAt, runs, summary }, null, 2)}\n`
+  )
+  console.log(reportPath)
+
+  if (failures.length > 0) {
+    console.error('')
+    for (const failure of failures) {
+      console.error(`failed run ${failure.run}: ${failure.message}`)
+    }
+    process.exitCode = 1
+  }
+}
+
+async function runCli() {
+  const options = parseArgs(process.argv.slice(2))
+  acquireLock()
+
+  try {
+    await runBench(options)
+  } finally {
+    releaseLock()
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await runCli()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(2)
+  }
+}

--- a/scripts/launch-bench.mjs
+++ b/scripts/launch-bench.mjs
@@ -289,9 +289,15 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-function readAppMtimeMs(appPath) {
-  const appName = path.basename(appPath, '.app')
-  return statSync(path.join(appPath, 'Contents/MacOS', appName)).mtimeMs
+// The bundle directory can be renamed (two builds kept side by side for an A/B), so
+// the executable name comes from Info.plist rather than from the directory name.
+function readBundleExecutable(appPath) {
+  const plist = readFileSync(path.join(appPath, 'Contents/Info.plist'), 'utf8')
+  return /<key>CFBundleExecutable<\/key>\s*<string>([^<]+)<\/string>/.exec(plist)?.[1] ?? null
+}
+
+function readAppMtimeMs(appPath, executableName) {
+  return statSync(path.join(appPath, 'Contents/MacOS', executableName)).mtimeMs
 }
 
 function readStoredAppMtimeMs() {
@@ -307,8 +313,8 @@ function isAppRunning(appPath) {
   return spawnSync('pgrep', ['-f', `${appPath}/Contents/MacOS/`]).status === 0
 }
 
-async function quitApp(appPath) {
-  spawnSync('osascript', ['-e', `quit app "${path.basename(appPath, '.app')}"`])
+async function quitApp(appPath, executableName) {
+  spawnSync('osascript', ['-e', `quit app "${executableName}"`])
 
   const deadline = Date.now() + QUIT_DEADLINE_MS
   while (Date.now() < deadline) {
@@ -516,8 +522,15 @@ function collectWarnings(record) {
   return warnings
 }
 
-async function measureRun({ run, appPath, port, appMtimeMs, firstRunAfterAppChange }) {
-  await quitApp(appPath)
+async function measureRun({
+  run,
+  appPath,
+  executableName,
+  port,
+  appMtimeMs,
+  firstRunAfterAppChange
+}) {
+  await quitApp(appPath, executableName)
   await delay(SETTLE_MS)
 
   const anchorOffset = logSizeOrZero()
@@ -563,7 +576,11 @@ async function measureRun({ run, appPath, port, appMtimeMs, firstRunAfterAppChan
 }
 
 async function runBench(options) {
-  const appMtimeMs = readAppMtimeMs(options.appPath)
+  const executableName = readBundleExecutable(options.appPath)
+  if (!executableName) {
+    throw new Error(`no CFBundleExecutable in ${options.appPath}/Contents/Info.plist`)
+  }
+  const appMtimeMs = readAppMtimeMs(options.appPath, executableName)
   let firstRunAfterAppChange = readStoredAppMtimeMs() !== appMtimeMs
 
   const startedAt = new Date().toISOString()
@@ -575,6 +592,7 @@ async function runBench(options) {
       const record = await measureRun({
         run,
         appPath: options.appPath,
+        executableName,
         port: options.port,
         appMtimeMs,
         firstRunAfterAppChange

--- a/scripts/launch-bench.mjs
+++ b/scripts/launch-bench.mjs
@@ -20,7 +20,7 @@ const SETTLE_MS = 2_000
 const QUIT_DEADLINE_MS = 20_000
 const CDP_DEADLINE_MS = 30_000
 const LOG_DEADLINE_MS = 45_000
-const READY_STATE_DEADLINE_MS = 30_000
+const FCP_DEADLINE_MS = 30_000
 const CDP_POLL_MS = 250
 const LOG_POLL_MS = 100
 
@@ -451,6 +451,10 @@ function connectCdp(webSocketDebuggerUrl) {
   })
 }
 
+const FCP_PRESENT_EXPRESSION = `performance
+  .getEntriesByType('paint')
+  .some((entry) => entry.name === 'first-contentful-paint')`
+
 const RENDERER_METRICS_EXPRESSION = `(() => {
   const round = (value) => (typeof value === 'number' ? Math.round(value * 1000) / 1000 : undefined)
   const navigation = performance.getEntriesByType('navigation')[0]
@@ -469,24 +473,19 @@ async function readRendererMetrics(webSocketDebuggerUrl) {
   const client = await connectCdp(webSocketDebuggerUrl)
 
   try {
-    const deadline = Date.now() + READY_STATE_DEADLINE_MS
-    let ready = false
+    // This app paints its first contentful frame after the load event, so waiting on
+    // document.readyState samples only the runs whose FCP happened to land early and
+    // silently drops the slow ones. Wait for the entry itself.
+    const deadline = Date.now() + FCP_DEADLINE_MS
     while (Date.now() < deadline) {
-      const state = await client.send('Runtime.evaluate', {
-        expression: 'document.readyState',
+      const seen = await client.send('Runtime.evaluate', {
+        expression: FCP_PRESENT_EXPRESSION,
         returnByValue: true
       })
-      if (state.result?.value === 'complete') {
-        ready = true
+      if (seen.result?.value === true) {
         break
       }
       await delay(CDP_POLL_MS)
-    }
-
-    if (!ready) {
-      throw new Error(
-        `renderer never reached document.readyState "complete" within ${READY_STATE_DEADLINE_MS} ms`
-      )
     }
 
     // Screencast frame timing is not a metric here: attaching CDP perturbs the renderer,

--- a/scripts/launch-bench.test.mjs
+++ b/scripts/launch-bench.test.mjs
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  detectTier,
+  findWindowShownAt,
+  formatMedianTable,
+  median,
+  parseLaunchTimeline,
+  parseLogTimestamp,
+  summarize
+} from './launch-bench.mjs'
+
+const STARTING_LINE =
+  '2026-09-04 14:13:53.280 [info]  [ (Main)                         ] MemryNote 2026.903.2 starting (packaged)'
+const SHOWN_LINE =
+  '2026-09-04 14:13:53.758 [info]  [ (Main)                         ] main window shown (ready-to-show)'
+const TIMELINE_BLOCK = `2026-09-04 14:13:53.759 [info]  [ (Startup)                      ] launch timeline {
+  reason: 'ready-to-show',
+  appReadyMs: 703,
+  windowCreatedMs: 797,
+  vaultOpenStartMs: 801,
+  vaultOpenReadyMs: 875,
+  readyToShowMs: 1063,
+  shownMs: 1076,
+  fallback: false,
+  vaultOpenPending: false
+}`
+
+const SLICE = `${STARTING_LINE}\n${SHOWN_LINE}\n${TIMELINE_BLOCK}\n`
+
+function makeRun(run, tier, offset) {
+  return {
+    run,
+    tier,
+    clickToShownMs: 1000 + offset,
+    cdpAttachOffsetMs: 900 + offset,
+    timeline: { appReadyMs: 700 + offset, shownMs: 1076 + offset },
+    renderer: { fcpMs: 756.5 + offset }
+  }
+}
+
+describe('parseLogTimestamp', () => {
+  it('reads a real log line as local time', () => {
+    assert.equal(parseLogTimestamp(SHOWN_LINE), new Date(2026, 8, 4, 14, 13, 53, 758).getTime())
+  })
+
+  it('returns null for a stack-trace continuation line', () => {
+    assert.equal(
+      parseLogTimestamp('    at Object.<anonymous> (/Users/h4yfans/worktrees/a/src/main/index.ts)'),
+      null
+    )
+  })
+})
+
+describe('parseLaunchTimeline', () => {
+  it('reads the multi-line block', () => {
+    assert.deepEqual(parseLaunchTimeline(SLICE), {
+      reason: 'ready-to-show',
+      appReadyMs: 703,
+      windowCreatedMs: 797,
+      vaultOpenStartMs: 801,
+      vaultOpenReadyMs: 875,
+      readyToShowMs: 1063,
+      shownMs: 1076,
+      fallback: false,
+      vaultOpenPending: false
+    })
+  })
+
+  it('returns null when the block is absent', () => {
+    assert.equal(parseLaunchTimeline(`${STARTING_LINE}\n${SHOWN_LINE}\n`), null)
+  })
+
+  it('returns null while the block is still unclosed', () => {
+    const truncated = SLICE.split('\n').slice(0, -2).join('\n')
+    assert.equal(parseLaunchTimeline(truncated), null)
+  })
+})
+
+describe('findWindowShownAt', () => {
+  it('picks the last match, not the first', () => {
+    const later =
+      '2026-09-04 14:20:01.500 [info]  [ (Main)                         ] main window shown (fallback-timeout)'
+    assert.equal(
+      findWindowShownAt(`${SLICE}${later}\n`),
+      new Date(2026, 8, 4, 14, 20, 1, 500).getTime()
+    )
+  })
+
+  it('returns null when no window was shown', () => {
+    assert.equal(findWindowShownAt(STARTING_LINE), null)
+  })
+})
+
+describe('detectTier', () => {
+  it('reads packaged, dev, and unknown', () => {
+    assert.equal(detectTier(SLICE), 'packaged')
+    assert.equal(detectTier(STARTING_LINE.replace('(packaged)', '(dev)')), 'dev')
+    assert.equal(detectTier(SHOWN_LINE), 'unknown')
+  })
+})
+
+describe('median', () => {
+  it('takes the middle value of an odd count', () => {
+    assert.equal(median([3, 1, 2]), 2)
+  })
+
+  it('averages the two middle values of an even count', () => {
+    assert.equal(median([4, 1, 3, 2]), 2.5)
+  })
+
+  it('returns null for an empty list', () => {
+    assert.equal(median([]), null)
+  })
+})
+
+describe('summarize', () => {
+  it('refuses click_to_shown_ms when any run is not packaged, and still reports the rest', () => {
+    const summary = summarize([makeRun(1, 'packaged', 0), makeRun(2, 'dev', 100)])
+    const byKey = Object.fromEntries(summary.map((row) => [row.key, row]))
+
+    assert.equal(byKey.click_to_shown_ms.median, null)
+    assert.equal(byKey.click_to_shown_ms.note, 'refused: not tier 3 (packaged)')
+    assert.equal(byKey.app_ready_ms.median, 750)
+    assert.equal(byKey.app_ready_ms.note, null)
+    assert.equal(byKey.renderer_fcp_ms.median, 806.5)
+    assert.equal(byKey.cdp_attach_offset_ms.median, 950)
+    assert.equal(byKey.renderer_loaded_ms.median, null)
+  })
+
+  it('reports click_to_shown_ms when every run is packaged', () => {
+    const summary = summarize([makeRun(1, 'packaged', 0), makeRun(2, 'packaged', 100)])
+    const clickToShown = summary.find((row) => row.key === 'click_to_shown_ms')
+
+    assert.equal(clickToShown.median, 1050)
+    assert.equal(clickToShown.note, null)
+  })
+
+  it('keeps the metric order stable', () => {
+    assert.deepEqual(
+      summarize([]).map((row) => row.key),
+      [
+        'click_to_shown_ms',
+        'app_ready_ms',
+        'window_created_ms',
+        'vault_open_start_ms',
+        'vault_open_ready_ms',
+        'renderer_loaded_ms',
+        'ready_to_show_ms',
+        'shown_ms',
+        'renderer_first_paint_ms',
+        'renderer_fcp_ms',
+        'renderer_dom_interactive_ms',
+        'renderer_dom_content_loaded_ms',
+        'cdp_attach_offset_ms'
+      ]
+    )
+  })
+})
+
+describe('formatMedianTable', () => {
+  it('prints no measurement on the refused row', () => {
+    const runs = [makeRun(1, 'packaged', 0), makeRun(2, 'dev', 100)]
+    const table = formatMedianTable(summarize(runs), runs)
+    const refusedRow = table.split('\n').find((line) => line.startsWith('click_to_shown_ms'))
+
+    assert.match(refusedRow, /refused \(not tier 3\)/)
+    assert.equal(/\d/.test(refusedRow.replace('tier 3', 'tier')), false)
+  })
+
+  it('renders an absent metric as a dash and names the per-run tiers', () => {
+    const runs = [makeRun(1, 'packaged', 0)]
+    const table = formatMedianTable(summarize(runs), runs)
+
+    assert.match(table, /^runs: 1 \(#1 packaged\)$/m)
+    assert.match(table, /^renderer_loaded_ms\s+-$/m)
+    assert.match(table, /^click_to_shown_ms\s+1000 ms$/m)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `scripts/launch-bench.mjs`, the measurement harness every other child of #2001 reports its before/after against. Until this exists, no PR in that epic can claim a number.

Per run it quits the app, stamps `t0`, launches with `--remote-debugging-port`, waits for the CDP page target, reads the `main window shown` line and the `launch timeline { … }` block out of `~/Library/Logs/memrynote/main.log`, then reads `performance.getEntriesByType('navigation'|'paint')` over CDP. It prints one JSON line per run plus a median table, and writes raw runs to a gitignored `.perf/`.

Three design points worth a reviewer's attention:

- **A machine-global lock at `/tmp/memry-launch-bench.lock`.** Acquired with `mkdir` as the atomic primitive, carries an owner pid, released on `SIGINT`/`SIGTERM`. A number taken while a build or test suite is running is noise, and a noisy number is worse than no number because it gets quoted in a PR.
- **A tier gate.** `click_to_shown_ms` is refused outright unless every run detected `starting (packaged)`. Wall-clock-from-launch means nothing on a dev build, where `applyLoginShellPath` never runs and the renderer comes from a Vite dev server. The other metrics still report, because main-process phases and paint entries are offsets from the process's own origin.
- **The log slice is anchored on a byte offset** taken immediately before `open -a`. That log is shared by the packaged app and by any `pnpm dev` in any worktree; live stack traces from an unrelated worktree were found interleaved with packaged launch records during development.

Screencast frame timing is deliberately not a metric. Attaching CDP perturbs the renderer badly, which is where the epic's `+3.88 s` artifact came from.

Second commit fixes a defect in the ruler itself: the renderer read was gated on `document.readyState === 'complete'`, but this app's load event lands at ~240 ms and FCP at ~350 ms, so the read fired before the paint entry existed. `first-contentful-paint` was `undefined` in 7 of the first 10 runs and the three survivors were the ones that happened to paint early — a median drawn from a sample biased toward fast launches. It now polls for the entry itself, and FCP is present 5 of 5.

## Release note

none

## Test plan

`pnpm lint`, `pnpm typecheck` (19/19), and `pnpm test:release` (100 pass, 0 fail, including 16 new tests for the harness) all exit 0. `pnpm docs:impact --base origin/main --strict` exits 0.

**This PR is the ruler, so it has no before/after of its own. What it produces is the epic's corrected baseline.** Three independent 5-run medians against the shipped `/Applications/MemryNote.app` 2026.903.2:

| metric | run C | run D | independent re-run | epic's claim |
| --- | ---: | ---: | ---: | ---: |
| `click_to_shown_ms` | 1104 | 1065 | 1103 | 1332 |
| `app_ready_ms` | 313 | 298 | 287 | 304 |
| `window_created_ms` | 355 | 340 | 330 | 348 |
| `vault_open_ready_ms` | 444 | 424 | 419 | 446 |
| `ready_to_show_ms` | 594 | 583 | 580 | 624 |
| `renderer_first_paint_ms` | 156 | 152 | 156 | 316 |
| `renderer_fcp_ms` | 348 | 344 | 352 | 756 |

Reproducibility: worst metric drift between two consecutive runs is 4.8%, click-to-shown 3.5%, FCP 1.1%.

**Two corrections to the epic's baseline, both of which change how later children should be budgeted.**

1. **The epic's 1332 ms click-to-shown is a cold-cache number; warm steady state is ~1100 ms.** The one genuinely cold launch measured today was 1310 ms, which does reproduce. Later PRs in the stack must therefore compare warm against warm, not against 1332.
2. **First paint and FCP are both roughly half what the epic recorded**, consistently across 20 launches of the same bundle. The main-process timeline reproduces exactly, so this is not a different machine state. The hypothesis, labelled as one: the epic's paint figures came from the same exploratory session that had `Page.startScreencast` running, which forces continuous compositor frame capture and pushes FCP later — the same mechanism behind the `+3.88 s` artifact the epic already warns about. This harness never starts a screencast and attaches only after the launch record is in the log.

   **Consequence: the "~440 ms of visible empty window" in the epic's problem 2 is about 196 ms today.** #2006 and #2007 have materially less headroom than budgeted, and that is worth re-checking before spending two medium issues on it.

Known limits, stated rather than buried: `--app` is exercised only against `/Applications/MemryNote.app` and is untested against a fresh `build:unpack` output; `--port` is untested at any value other than 9222. Absolute numbers on this machine carry a corporate-agent tax (Malwarebytes at 99% CPU, a Kandji daemon at 25% throughout), so only deltas measured here are meaningful.

Closes #2002
