### PR TITLE
perf(startup): run the updater after the window is on screen

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -833,7 +833,6 @@ describe('main index phase2 exports', () => {
         show: false
       })
     )
-    expect(initializeUpdaterMock).toHaveBeenCalled()
     expect(autoOpenLastVaultMock).toHaveBeenCalled()
 
     const createdWindow = browserWindows[0]
@@ -1379,6 +1378,24 @@ describe('main index phase2 exports', () => {
       info: ReturnType<typeof vi.fn>
     }
     expect(scoped.info).toHaveBeenCalledWith('MemryNote 1.0.0 starting (dev)')
+  })
+
+  it('starts the updater only once the window has been revealed', async () => {
+    vi.useFakeTimers()
+    whenReadyMock.mockResolvedValue(undefined)
+
+    await importMainModule()
+    await flushReadyWork()
+
+    const { POST_REVEAL_DELAY_MS } = await import('./post-reveal')
+    expect(initializeUpdaterMock).not.toHaveBeenCalled()
+
+    const createdWindow = browserWindows[0]
+    createdWindow.emitTestEvent('ready-to-show')
+    expect(initializeUpdaterMock).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(POST_REVEAL_DELAY_MS)
+    expect(initializeUpdaterMock).toHaveBeenCalledTimes(1)
   })
 
   it('reveals the main window via fallback timeout when ready-to-show never fires', async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -82,6 +82,7 @@ import {
   stopActiveHeartbeat
 } from './telemetry/diagnostics'
 import { recordLaunchPhase, reportLaunchTimeline } from './launch-timeline'
+import { onceWindowShown, schedulePostRevealTasks } from './post-reveal'
 import { toErrorCode } from '@memry/contracts/telemetry-api'
 import { drainEarlyMainEvents, trackMainEvent } from './telemetry/track'
 import {
@@ -800,6 +801,7 @@ function createWindow(): void {
     // Reveal is the moment the user stops staring at nothing, so it is where
     // the launch timeline is complete enough to attribute a slow start (#843).
     reportLaunchTimeline(reason)
+    schedulePostRevealTasks()
   }
 
   const fallbackShowTimer = setTimeout(() => {
@@ -1708,7 +1710,10 @@ const appReady = app.whenReady().then(async () => {
   }
 
   createWindow()
-  initializeUpdater()
+  // The updater touches disk (install-health reconcile, prefs, app-update.yml)
+  // and fires its first GitHub check straight away. None of that is on the way
+  // to the first frame, and all of it landed between window creation and reveal.
+  onceWindowShown('updater', initializeUpdater)
 
   // Open the last vault and start schedulers concurrently with renderer load.
   // The renderer subscribes to vault status events and updates automatically.

--- a/apps/desktop/src/main/post-reveal.test.ts
+++ b/apps/desktop/src/main/post-reveal.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const scopedLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+}
+const isAppShuttingDownMock = vi.fn(() => false)
+
+vi.mock('./lib/logger', () => ({
+  createLogger: vi.fn(() => scopedLogger)
+}))
+
+vi.mock('./app-shutdown', () => ({
+  isAppShuttingDown: isAppShuttingDownMock
+}))
+
+// The queue and its latches are module state, so each test gets a fresh copy.
+async function importPostReveal(): Promise<typeof import('./post-reveal')> {
+  vi.resetModules()
+  return import('./post-reveal')
+}
+
+describe('post-reveal queue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    scopedLogger.warn.mockClear()
+    isAppShuttingDownMock.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('holds registered work until the delay after the reveal has elapsed', async () => {
+    const { onceWindowShown, schedulePostRevealTasks, POST_REVEAL_DELAY_MS } =
+      await importPostReveal()
+    const task = vi.fn()
+
+    onceWindowShown('updater', task)
+    schedulePostRevealTasks()
+    expect(task).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(POST_REVEAL_DELAY_MS)
+    expect(task).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs each name at most once across repeated reveals', async () => {
+    const { onceWindowShown, schedulePostRevealTasks, POST_REVEAL_DELAY_MS } =
+      await importPostReveal()
+    const task = vi.fn()
+
+    onceWindowShown('updater', task)
+    schedulePostRevealTasks()
+    await vi.advanceTimersByTimeAsync(POST_REVEAL_DELAY_MS)
+
+    // A macOS dock reopen re-creates and re-reveals the window.
+    onceWindowShown('updater', task)
+    schedulePostRevealTasks()
+    await vi.advanceTimersByTimeAsync(POST_REVEAL_DELAY_MS)
+
+    expect(task).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs work registered after the drain immediately', async () => {
+    const { onceWindowShown, schedulePostRevealTasks, POST_REVEAL_DELAY_MS } =
+      await importPostReveal()
+    const task = vi.fn()
+
+    schedulePostRevealTasks()
+    await vi.advanceTimersByTimeAsync(POST_REVEAL_DELAY_MS)
+
+    onceWindowShown('late', task)
+    expect(task).toHaveBeenCalledTimes(1)
+  })
+
+  it('starts nothing when the app is quitting inside the delay', async () => {
+    const { onceWindowShown, schedulePostRevealTasks, POST_REVEAL_DELAY_MS } =
+      await importPostReveal()
+    const task = vi.fn()
+    const later = vi.fn()
+
+    onceWindowShown('updater', task)
+    schedulePostRevealTasks()
+    isAppShuttingDownMock.mockReturnValue(true)
+    await vi.advanceTimersByTimeAsync(POST_REVEAL_DELAY_MS)
+
+    onceWindowShown('late', later)
+    expect(task).not.toHaveBeenCalled()
+    expect(later).not.toHaveBeenCalled()
+  })
+
+  it('keeps later tasks running when one throws', async () => {
+    const { onceWindowShown, schedulePostRevealTasks, POST_REVEAL_DELAY_MS } =
+      await importPostReveal()
+    const survivor = vi.fn()
+
+    onceWindowShown('boom', () => {
+      throw new Error('nope')
+    })
+    onceWindowShown('survivor', survivor)
+    schedulePostRevealTasks()
+    await vi.advanceTimersByTimeAsync(POST_REVEAL_DELAY_MS)
+
+    expect(survivor).toHaveBeenCalledTimes(1)
+    expect(scopedLogger.warn).toHaveBeenCalledWith(
+      'deferred startup task failed: boom',
+      expect.any(Error)
+    )
+  })
+
+  it('reports a rejected async task without an unhandled rejection', async () => {
+    const { onceWindowShown, schedulePostRevealTasks, POST_REVEAL_DELAY_MS } =
+      await importPostReveal()
+
+    onceWindowShown('async-boom', async () => {
+      throw new Error('nope')
+    })
+    schedulePostRevealTasks()
+    await vi.advanceTimersByTimeAsync(POST_REVEAL_DELAY_MS)
+
+    expect(scopedLogger.warn).toHaveBeenCalledWith(
+      'deferred startup task failed: async-boom',
+      expect.any(Error)
+    )
+  })
+})

--- a/apps/desktop/src/main/post-reveal.ts
+++ b/apps/desktop/src/main/post-reveal.ts
@@ -1,0 +1,69 @@
+// Post-reveal startup queue.
+//
+// Work registered here is startup work the first frame does not depend on. It
+// runs after the main window is on screen, so it can no longer sit between
+// `createWindow()` and the reveal and push out the moment the user stops
+// staring at nothing (#2001).
+import { isAppShuttingDown } from './app-shutdown'
+import { createLogger } from './lib/logger'
+
+const postRevealLog = createLogger('Startup')
+
+// The reveal fires on 'ready-to-show', which means the renderer can paint, not
+// that it has finished booting: its own IPC round-trips keep the main thread
+// busy for a few hundred milliseconds afterwards. Draining on the next tick
+// would move the contention rather than remove it, so wait out that window.
+export const POST_REVEAL_DELAY_MS = 1_000
+
+type PostRevealTask = () => void | Promise<void>
+
+const queue = new Map<string, PostRevealTask>()
+const started = new Set<string>()
+let scheduled = false
+let drained = false
+
+const runTask = (name: string, task: PostRevealTask): void => {
+  if (started.has(name)) return
+  started.add(name)
+  try {
+    const result = task()
+    if (result instanceof Promise) {
+      void result.catch((error) => {
+        postRevealLog.warn(`deferred startup task failed: ${name}`, error)
+      })
+    }
+  } catch (error) {
+    postRevealLog.warn(`deferred startup task failed: ${name}`, error)
+  }
+}
+
+/**
+ * Register startup work to run once the main window is visible. `name` is the
+ * at-most-once key: a macOS dock reopen re-enters window creation and reveal, so
+ * a caller on that path registering again must not start a second copy.
+ */
+export const onceWindowShown = (name: string, task: PostRevealTask): void => {
+  if (started.has(name)) return
+  if (drained) {
+    runTask(name, task)
+    return
+  }
+  queue.set(name, task)
+}
+
+/** Arm the drain. Called from the reveal; repeat reveals are no-ops. */
+export const schedulePostRevealTasks = (): void => {
+  if (scheduled) return
+  scheduled = true
+  const timer = setTimeout(() => {
+    // A quit inside the delay has already torn down the services these tasks
+    // would arm; starting them now is the mid-shutdown re-arm app-shutdown
+    // exists to prevent. Stay undrained so nothing registered later starts either.
+    if (isAppShuttingDown()) return
+    drained = true
+    const pending = [...queue]
+    queue.clear()
+    for (const [name, task] of pending) runTask(name, task)
+  }, POST_REVEAL_DELAY_MS)
+  timer.unref?.()
+}

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -98,6 +98,25 @@ The line is logged at `warn` when the reveal came from the fallback or took ≥5
 `error` records reach the diagnostic log sink — and at `info` otherwise, so healthy launches stay
 local instead of flooding the sink.
 
+### Post-Reveal Startup Queue
+
+`src/main/post-reveal.ts` holds startup work the first frame does not depend on, so it cannot sit
+between window creation and the reveal and inflate `shownMs`. Register with
+`onceWindowShown(name, task)`; the reveal calls `schedulePostRevealTasks()`, which drains the queue
+one second later. The delay is deliberate: `ready-to-show` means the renderer can paint, not that it
+has finished booting, and draining on the next tick would move main-thread contention rather than
+remove it.
+
+`name` is the at-most-once key. A macOS dock reopen re-creates and re-reveals the main window, so a
+caller on that path registering again must not start a second copy. Work registered after the drain
+runs immediately. A task that throws or rejects is logged under the `Startup` scope and never stops
+the others. If the app begins quitting inside the delay the queue is left undrained, so a deferred
+task cannot re-arm a service the shutdown sequence has already torn down.
+
+The updater is the first tenant: `initializeUpdater()` reconciles install health, reads its prefs,
+resolves `app-update.yml` and fires the `startup-check` update check, none of which is on the way to
+the first frame.
+
 ## Telemetry
 
 Telemetry is enabled by default in production builds and off by default in development builds.


### PR DESCRIPTION
## Summary

Adds `apps/desktop/src/main/post-reveal.ts`, a small post-reveal startup queue, and moves `initializeUpdater()` onto it.

`onceWindowShown(name, task)` registers startup work the first frame does not depend on; `schedulePostRevealTasks()` arms the drain from `revealMainWindow`. Three properties matter:

- **At-most-once, keyed by name.** A macOS dock reopen re-enters window creation and reveal, so a caller on that path registering again must not start a second copy.
- **`isAppShuttingDown()` is checked inside the drain**, not at each call site, so every future tenant inherits the guard rather than having to remember it.
- **It drains 1000 ms after reveal, not on the next tick.** `ready-to-show` means the renderer *can* paint, not that it has finished booting; its own IPC round-trips keep the main thread busy for a few hundred milliseconds afterwards. Draining immediately would relocate the contention rather than remove it.

`schedulePostRevealTasks()` is called after `reportLaunchTimeline`, so the `'launch timeline'` string and `reason: 'fallback-timeout'` pinned by `packages/contracts/src/redact.test.ts:123-143` are untouched.

#2003 and #2012 both need this seam, which is the main reason it exists.

### Two claims in #2004 that turned out to be wrong

Re-derived from the code rather than taken from the issue:

- **`startChatServer` is not on the boot path.** One non-test call site, `apps/desktop/src/main/ipc/ai-inline-handlers.ts:86`, inside an IPC handler. Main never starts it at boot, so no reordering can move it.
- **The Agent MCP server is not in `main/index.ts`.** It is `apps/desktop/src/main/vault/index.ts:943-948`, already behind vault open and already idempotent via `if (agentHandle) return` plus a shared `agentStartupPromise` — the exact dock-reopen hazard the issue describes as unhandled.

`initializeUpdater()` at `main/index.ts:1711` was the only real candidate, and the issue does not name it.

## Release note

none

## Test plan

`pnpm lint` and `pnpm typecheck` (19 tasks) exit 0. `pnpm --filter @memry/desktop test:main` is green: **574 files, 8052 tests passed, 0 failed**. `pnpm docs:impact --base perf/launch-bench-harness --strict` exits 0.

### Measured: no win, and that is the result

Tier 3, `electron-builder --dir`, unsigned, two bundles kept side by side and benchmarked A/B/A/B to cancel machine drift. Pooled median of **10 runs per arm**, from settled passes only.

| metric | base | this branch | delta | verdict |
| --- | ---: | ---: | ---: | --- |
| `click_to_shown_ms` | 1090 | 1092 | +2 | noise |
| `app_ready_ms` | 273 | 284 | +10 | noise |
| `window_created_ms` | 328 | 328 | 0 | noise |
| `vault_open_ready_ms` | 415 | 400 | −15 | noise |
| `ready_to_show_ms` | 580 | 582 | +1 | noise |
| `shown_ms` | 592 | 592 | 0 | noise |
| `renderer_fcp_ms` | 352 | 344 | −8 | noise |

**The prediction was 10 to 40 ms off `ready_to_show_ms` and `shown_ms`. Observed: +1 and 0.** So `initializeUpdater()`'s pre-reveal cost was already negligible, and this PR buys no measurable launch time. It is scaffolding, and it is worth landing only because #2003 and #2012 need the seam.

Deferring the updater past reveal is still correct on its own terms — it touches disk (install-health reconcile, prefs, `app-update.yml`) and fires a GitHub check, none of which the first frame depends on — but nobody should quote a number for it.

### How the measurement was made, because the naive version is wrong

A null-hypothesis run against two **byte-identical** copies of the same build:

| pass | copy A click→shown | copy B click→shown |
| --- | ---: | ---: |
| 1 | 1374 | 2619 |
| 2 | 1152 | 1169 |

Identical builds differed by **1245 ms** on first encounter and by **17 ms** once settled. macOS charges a large one-time cost for a bundle it has never seen (Spotlight indexing plus Gatekeeper/XProtect scanning ~700 MB), and it is not a single slow launch that a median of 5 rejects — it poisons most of a batch. Any number taken from a freshly built bundle is unusable. Both arms here were burned in first, and every delta above is inside the ~1.5% settled noise floor.

`initializeUpdater()` also returns early on `!app.isPackaged` (`apps/desktop/src/main/updater.ts:330`), so this change is invisible in dev and in every E2E run. Only a packaged benchmark can observe it.

### Landmines for whoever takes #2003 or #2012

- The 1000 ms delay is shared by the whole queue. When #2003 moves the MCP server onto it, the server comes up at reveal + 1 s, which on the fallback path is 11 s against the 30 s `firstWindow` budget in `apps/desktop/tests/e2e/tests/agent-mcp-external-client.e2e.ts:23-31`. Margin is 19 s; any further increase needs that test re-checked.
- The ready-time startup test in `apps/desktop/src/main/index.phase2.test.ts` no longer asserts the updater ran. Four issues in this epic touch that file; nobody should re-add `expect(initializeUpdaterMock).toHaveBeenCalled()`.
- The largest remaining cost inside the reveal window is `autoOpenLastVault()`, finishing at 415 ms against a 580 ms reveal. Deferring it would show the window at picker size and then resize it via the handler at `main/index.ts:761`, making it a UX change rather than a scheduling one. Left alone deliberately.

Closes #2004
