### PR TITLE
perf(startup): probe the login shell alongside boot instead of before it

### DIFF
--- a/apps/desktop/src/main/agent/cli/__tests__/binary-detection.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/binary-detection.test.ts
@@ -166,3 +166,36 @@ describe('cacheBinaryDetection', () => {
     expect(probe).toHaveBeenCalledTimes(2)
   })
 })
+
+describe('runBinaryCommand and the login-shell PATH', () => {
+  it('waits for the augmentation instead of racing it', async () => {
+    vi.resetModules()
+    const loginShellPath = await import('../login-shell-path')
+    const detection = await import('../binary-detection')
+
+    let release: (path: string) => void = () => {}
+    loginShellPath.startLoginShellPathAugmentation({
+      packaged: true,
+      platform: 'darwin',
+      env: { PATH: '/usr/bin' },
+      resolve: () =>
+        new Promise<string>((resolve) => {
+          release = resolve
+        })
+    })
+
+    let finished = false
+    const pending = detection
+      .runBinaryCommand(process.execPath, ['-e', 'process.stdout.write("ok")'])
+      .then((result) => {
+        finished = true
+        return result
+      })
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(finished).toBe(false)
+
+    release('/opt/homebrew/bin')
+    await expect(pending).resolves.toMatchObject({ stdout: 'ok' })
+  })
+})

--- a/apps/desktop/src/main/agent/cli/__tests__/login-shell-path.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/login-shell-path.test.ts
@@ -1,12 +1,35 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ trackMainLog: vi.fn() }))
+
+vi.mock('../../../telemetry/diagnostics', () => ({ trackMainLog: mocks.trackMainLog }))
 
 import {
   PATH_MARKER,
+  type RunShellProbe,
   applyLoginShellPath,
   mergePaths,
   parseShellPath,
   readLoginShellPath
 } from '../login-shell-path'
+
+const probeOk =
+  (path: string): RunShellProbe =>
+  async () =>
+    `${PATH_MARKER}${path}\n`
+
+const probeThrows =
+  (error: unknown): RunShellProbe =>
+  async () => {
+    throw error
+  }
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+const freshModule = async (): Promise<typeof import('../login-shell-path')> => {
+  vi.resetModules()
+  return import('../login-shell-path')
+}
 
 describe('parseShellPath', () => {
   it('extracts PATH from the marker line', () => {
@@ -56,80 +79,163 @@ describe('mergePaths', () => {
 })
 
 describe('readLoginShellPath', () => {
-  const spawnOk = (path: string) =>
-    vi.fn().mockReturnValue({ status: 0, stdout: `${PATH_MARKER}${path}\n`, stderr: '' })
-
-  it('returns the login-shell PATH on a successful probe', () => {
-    const spawn = spawnOk('/opt/homebrew/bin:/usr/bin')
-    expect(readLoginShellPath(spawn as never)).toBe('/opt/homebrew/bin:/usr/bin')
+  beforeEach(() => {
+    mocks.trackMainLog.mockClear()
   })
 
-  it('invokes an interactive login shell', () => {
-    const spawn = spawnOk('/usr/bin')
-    readLoginShellPath(spawn as never)
-    const args = spawn.mock.calls[0][1] as string[]
-    expect(args[0]).toBe('-ilc')
+  it('returns the login-shell PATH on a successful probe', async () => {
+    await expect(readLoginShellPath(probeOk('/opt/homebrew/bin:/usr/bin'))).resolves.toBe(
+      '/opt/homebrew/bin:/usr/bin'
+    )
   })
 
-  it('returns null when the probe exits non-zero', () => {
-    const spawn = vi.fn().mockReturnValue({ status: 1, stdout: '', stderr: 'boom' })
-    expect(readLoginShellPath(spawn as never)).toBeNull()
+  it('invokes an interactive login shell', async () => {
+    const run = vi.fn(probeOk('/usr/bin'))
+    await readLoginShellPath(run)
+    expect(run.mock.calls[0][1][0]).toBe('-ilc')
   })
 
-  it('returns null when the probe throws', () => {
-    const spawn = vi.fn().mockImplementation(() => {
-      throw new Error('spawn failed')
-    })
-    expect(readLoginShellPath(spawn as never)).toBeNull()
+  it('reports a non-zero exit as its status', async () => {
+    const error = Object.assign(new Error('boom'), { code: 1 })
+    await expect(readLoginShellPath(probeThrows(error))).resolves.toBeNull()
+    expect(mocks.trackMainLog).toHaveBeenCalledWith(
+      'warn',
+      expect.objectContaining({ action: 'login_shell_path_probe_failed', errorCode: 'status_1' })
+    )
+  })
+
+  it('reports a shell that never started as a spawn error', async () => {
+    const error = Object.assign(new Error('nope'), { code: 'ENOENT' })
+    await expect(readLoginShellPath(probeThrows(error))).resolves.toBeNull()
+    expect(mocks.trackMainLog).toHaveBeenCalledWith(
+      'warn',
+      expect.objectContaining({ action: 'login_shell_path_probe_failed', errorCode: 'spawn_error' })
+    )
+  })
+
+  it('reports stdout without the marker', async () => {
+    const run: RunShellProbe = async () => 'rc banner only\n'
+    await expect(readLoginShellPath(run)).resolves.toBeNull()
+    expect(mocks.trackMainLog).toHaveBeenCalledWith(
+      'warn',
+      expect.objectContaining({ errorCode: 'marker_missing' })
+    )
   })
 })
 
 describe('applyLoginShellPath', () => {
-  it('augments env.PATH when packaged on a non-Windows platform', () => {
+  it('augments env.PATH when packaged on a non-Windows platform', async () => {
     const env = { PATH: '/usr/bin:/bin' }
-    const applied = applyLoginShellPath({
+    const applied = await applyLoginShellPath({
       packaged: true,
       platform: 'darwin',
       env,
-      resolve: () => '/opt/homebrew/bin:/usr/bin'
+      resolve: async () => '/opt/homebrew/bin:/usr/bin'
     })
     expect(applied).toBe(true)
     expect(env.PATH).toBe('/opt/homebrew/bin:/usr/bin:/bin')
   })
 
-  it('is a no-op when the app is not packaged (terminal already has full PATH)', () => {
+  it('is a no-op when the app is not packaged (terminal already has full PATH)', async () => {
     const env = { PATH: '/usr/bin:/bin' }
-    const applied = applyLoginShellPath({
+    const resolve = vi.fn(async () => '/opt/homebrew/bin')
+    const applied = await applyLoginShellPath({
       packaged: false,
       platform: 'darwin',
       env,
-      resolve: () => '/opt/homebrew/bin'
+      resolve
     })
     expect(applied).toBe(false)
     expect(env.PATH).toBe('/usr/bin:/bin')
+    expect(resolve).not.toHaveBeenCalled()
   })
 
-  it('is a no-op on Windows (GUI apps inherit the system PATH)', () => {
+  it('is a no-op on Windows (GUI apps inherit the system PATH)', async () => {
     const env = { PATH: 'C:\\Windows' }
-    const applied = applyLoginShellPath({
+    const applied = await applyLoginShellPath({
       packaged: true,
       platform: 'win32',
       env,
-      resolve: () => 'C:\\tools'
+      resolve: async () => 'C:\\tools'
     })
     expect(applied).toBe(false)
     expect(env.PATH).toBe('C:\\Windows')
   })
 
-  it('is a no-op when the login-shell PATH cannot be resolved', () => {
+  it('is a no-op when the login-shell PATH cannot be resolved', async () => {
     const env = { PATH: '/usr/bin:/bin' }
-    const applied = applyLoginShellPath({
+    const applied = await applyLoginShellPath({
       packaged: true,
       platform: 'darwin',
       env,
-      resolve: () => null
+      resolve: async () => null
     })
     expect(applied).toBe(false)
     expect(env.PATH).toBe('/usr/bin:/bin')
+  })
+})
+
+describe('startLoginShellPathAugmentation', () => {
+  it('runs one probe however many callers start it', async () => {
+    const module = await freshModule()
+    const env = { PATH: '/usr/bin' }
+    const resolve = vi.fn(async () => '/opt/homebrew/bin')
+    const options = { packaged: true, platform: 'darwin' as const, env, resolve }
+
+    const first = module.startLoginShellPathAugmentation(options)
+    const second = module.startLoginShellPathAugmentation(options)
+
+    expect(second).toBe(first)
+    await expect(first).resolves.toBe(true)
+    expect(resolve).toHaveBeenCalledTimes(1)
+    expect(env.PATH).toBe('/opt/homebrew/bin:/usr/bin')
+  })
+
+  it('holds whenLoginShellPathApplied open until the probe settles', async () => {
+    const module = await freshModule()
+    const env = { PATH: '/usr/bin' }
+    let release: (path: string) => void = () => {}
+
+    module.startLoginShellPathAugmentation({
+      packaged: true,
+      platform: 'darwin',
+      env,
+      resolve: () =>
+        new Promise<string>((resolve) => {
+          release = resolve
+        })
+    })
+
+    let settled = false
+    const waiter = module.whenLoginShellPathApplied().then(() => {
+      settled = true
+    })
+
+    await flush()
+    expect(settled).toBe(false)
+    expect(env.PATH).toBe('/usr/bin')
+
+    release('/opt/homebrew/bin')
+    await waiter
+    expect(env.PATH).toBe('/opt/homebrew/bin:/usr/bin')
+  })
+
+  it('survives a probe that rejects outright', async () => {
+    const module = await freshModule()
+    const applied = module.startLoginShellPathAugmentation({
+      packaged: true,
+      platform: 'darwin',
+      env: { PATH: '/usr/bin' },
+      resolve: async () => {
+        throw new Error('shell exploded')
+      }
+    })
+    await expect(applied).resolves.toBe(false)
+    await expect(module.whenLoginShellPathApplied()).resolves.toBeUndefined()
+  })
+
+  it('resolves whenLoginShellPathApplied when no augmentation was started', async () => {
+    const module = await freshModule()
+    await expect(module.whenLoginShellPathApplied()).resolves.toBeUndefined()
   })
 })

--- a/apps/desktop/src/main/agent/cli/binary-detection.ts
+++ b/apps/desktop/src/main/agent/cli/binary-detection.ts
@@ -5,6 +5,8 @@ import { promisify } from 'node:util'
 
 import type { BinaryStatus } from '@memry/contracts/ipc-agent'
 
+import { whenLoginShellPathApplied } from './login-shell-path'
+
 const execFileAsync = promisify(execFile)
 
 /**
@@ -27,6 +29,10 @@ export async function runBinaryCommand(
   command: string,
   args: string[]
 ): Promise<{ stdout: string; stderr: string } | null> {
+  // A packaged launch starts with the minimal Finder PATH and augments it from
+  // the login shell in the background (#2003). Probing inside that window would
+  // report an installed CLI as missing, so wait the augmentation out first.
+  await whenLoginShellPathApplied()
   try {
     const { stdout, stderr } = await execFileAsync(command, args, { encoding: 'utf8' })
     return { stdout, stderr }

--- a/apps/desktop/src/main/agent/cli/login-shell-path.ts
+++ b/apps/desktop/src/main/agent/cli/login-shell-path.ts
@@ -1,10 +1,12 @@
-import { spawnSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { basename, delimiter } from 'node:path'
+import { promisify } from 'node:util'
 
 import { createLogger } from '../../lib/logger'
 import { trackMainLog } from '../../telemetry/diagnostics'
 
 const logger = createLogger('AgentCli:LoginShellPath')
+const execFileAsync = promisify(execFile)
 
 /**
  * Resolve the user's real login-shell PATH so packaged builds can find CLIs.
@@ -17,12 +19,20 @@ const logger = createLogger('AgentCli:LoginShellPath')
  * the user sees in their terminal, so spawned probes and the CLIs' own `env node`
  * shebangs resolve correctly. `pnpm dev` is launched from a terminal and already
  * has the full PATH, so this is a packaged-only concern.
+ *
+ * The probe sources the user's whole rc chain, which measured 182 ms on the
+ * owner's machine and over a second on a heavier one (#2003). It therefore runs
+ * concurrently with boot rather than in front of it: `startLoginShellPathAugmentation`
+ * fires it and returns, and every consumer that resolves a binary through PATH
+ * awaits `whenLoginShellPathApplied` first so none of them can race the window
+ * where PATH is still the minimal one.
  */
 
 /** Unique token prefixed to the printed PATH so we can extract it past rc noise. */
 export const PATH_MARKER = '__MEMRY_LOGIN_PATH__'
 
-type SpawnSync = typeof spawnSync
+/** Run the shell probe and hand back its stdout; rejects like `execFile` does. */
+export type RunShellProbe = (shell: string, args: string[]) => Promise<string>
 
 /** Pull the PATH out of the shell probe's stdout. */
 export function parseShellPath(stdout: string, marker: string = PATH_MARKER): string | null {
@@ -54,8 +64,15 @@ export function mergePaths(
   return merged.join(separator)
 }
 
-/** Probe the login shell for its PATH; returns null on any failure. */
-export function readLoginShellPath(spawn: SpawnSync = spawnSync): string | null {
+const runShellProbe: RunShellProbe = async (shell, args) => {
+  const { stdout } = await execFileAsync(shell, args, { encoding: 'utf8', timeout: 3000 })
+  return stdout
+}
+
+/** Probe the login shell for its PATH; resolves to null on any failure. */
+export async function readLoginShellPath(
+  run: RunShellProbe = runShellProbe
+): Promise<string | null> {
   const shell = process.env.SHELL || '/bin/bash'
   // A silent null here is precisely the failure that greys out Claude/Codex
   // providers in packaged builds — leave a breadcrumb per failure class.
@@ -72,25 +89,23 @@ export function readLoginShellPath(spawn: SpawnSync = spawnSync): string | null 
   try {
     // `-i` (interactive) so zsh's ~/.zshrc / bash's ~/.bashrc run — that's where
     // PATH is usually set; `-l` (login) so profile files run too.
-    const result = spawn(shell, ['-ilc', `printf '%s\\n' "${PATH_MARKER}$PATH"`], {
-      encoding: 'utf8',
-      timeout: 3000
-    })
-    if (!result || result.status !== 0 || typeof result.stdout !== 'string') {
-      return probeFailed(`status_${result?.status ?? 'none'}`)
-    }
-    const parsed = parseShellPath(result.stdout)
+    const stdout = await run(shell, ['-ilc', `printf '%s\\n' "${PATH_MARKER}$PATH"`])
+    const parsed = parseShellPath(stdout)
     if (parsed === null) {
       return probeFailed('marker_missing')
     }
     return parsed
-  } catch {
-    return probeFailed('spawn_error')
+  } catch (error) {
+    // execFile rejects with a numeric `code` when the shell exited non-zero and
+    // with a string errno when it never started, so the two stay apart the way
+    // the synchronous `result.status` check kept them apart.
+    const code = (error as { code?: unknown } | null)?.code
+    return probeFailed(typeof code === 'number' ? `status_${code}` : 'spawn_error')
   }
 }
 
 interface ApplyOptions {
-  resolve?: () => string | null
+  resolve?: () => Promise<string | null>
   platform?: NodeJS.Platform
   packaged?: boolean
   env?: NodeJS.ProcessEnv
@@ -98,20 +113,20 @@ interface ApplyOptions {
 
 /**
  * Augment `env.PATH` with the login-shell PATH. No-op unless the app is packaged
- * on a non-Windows platform and the probe succeeds. Returns whether PATH changed.
+ * on a non-Windows platform and the probe succeeds. Resolves to whether PATH changed.
  */
-export function applyLoginShellPath({
+export async function applyLoginShellPath({
   resolve = readLoginShellPath,
   platform = process.platform,
   packaged = false,
   env = process.env
-}: ApplyOptions = {}): boolean {
+}: ApplyOptions = {}): Promise<boolean> {
   // Windows GUI apps already inherit the system PATH; dev is launched from a
   // terminal with the full PATH, so only packaged macOS/Linux builds need this.
   if (platform === 'win32' || !packaged) {
     return false
   }
-  const resolved = resolve()
+  const resolved = await resolve()
   if (!resolved) {
     return false
   }
@@ -122,4 +137,29 @@ export function applyLoginShellPath({
   }
   env.PATH = merged
   return true
+}
+
+let augmentation: Promise<boolean> | null = null
+
+/**
+ * Start the probe and leave it running. Boot calls this and moves on; repeat
+ * calls join the first one rather than spawning a second shell.
+ */
+export function startLoginShellPathAugmentation(options: ApplyOptions = {}): Promise<boolean> {
+  augmentation ??= applyLoginShellPath(options).catch((error: unknown) => {
+    logger.warn('Login shell PATH augmentation failed', error)
+    return false
+  })
+  return augmentation
+}
+
+/**
+ * Settle the augmentation before resolving anything through PATH. A probe that
+ * lands inside the window where PATH is still the minimal Finder one reports an
+ * installed CLI as missing, which is the greyed-out-provider bug this file exists
+ * to prevent. Resolves immediately once the augmentation has finished, and on a
+ * build that never started one.
+ */
+export async function whenLoginShellPathApplied(): Promise<void> {
+  await augmentation
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -159,7 +159,10 @@ import { reconcileBillingAndSync, startBillingCheckout } from './billing/paddle-
 import { openPairingWindow } from './capture/pairing'
 import { startCaptureServer, stopCaptureServer } from './capture/server'
 import { stopChatServer } from './ai-inline/ai-chat-server'
-import { applyLoginShellPath } from './agent/cli/login-shell-path'
+import {
+  startLoginShellPathAugmentation,
+  whenLoginShellPathApplied
+} from './agent/cli/login-shell-path'
 import { setAccountKeyChecker } from './crypto'
 import { checkLocalKeyAgainstAccount } from './sync/key-verification'
 
@@ -350,11 +353,14 @@ app.on('web-contents-created', (_event, contents) => {
 
 // A Finder/Dock-launched packaged app inherits only the minimal system PATH, so
 // user-installed CLIs (claude/codex) are invisible to `which` and Agent Chat
-// greys out those providers. Recover the login-shell PATH before anything spawns
-// a probe or the CLIs themselves. No-op in dev (terminal already has full PATH).
-if (applyLoginShellPath({ packaged: app.isPackaged })) {
-  mainLog.info('Augmented PATH from login shell for packaged launch')
-}
+// greys out those providers. Sourcing the user's rc chain to recover the real
+// PATH costs ~180 ms and nothing on the way to the first frame needs it, so the
+// probe runs alongside boot and the CLI probes await it. No-op in dev.
+void startLoginShellPathAugmentation({ packaged: app.isPackaged }).then((applied) => {
+  if (applied) {
+    mainLog.info('Augmented PATH from login shell for packaged launch')
+  }
+})
 
 // A vault folder moved between machines (git, iCloud Drive, Dropbox) arrives
 // carrying the verifier of whichever machine wrote it, while the master key that
@@ -369,10 +375,14 @@ let mainI18n: I18nInstance
 
 if (headlessCliArgs) {
   disableConsoleTransport()
-  void runHeadlessCli(headlessCliArgs).catch((error) => {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
-    app.exit(1)
-  })
+  // Headless has no first frame to protect and shells out to the agent CLIs
+  // immediately, so unlike the GUI path it waits for the augmented PATH.
+  void whenLoginShellPathApplied()
+    .then(() => runHeadlessCli(headlessCliArgs))
+    .catch((error: unknown) => {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+      app.exit(1)
+    })
 }
 
 /**

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -117,6 +117,26 @@ The updater is the first tenant: `initializeUpdater()` reconciles install health
 resolves `app-update.yml` and fires the `startup-check` update check, none of which is on the way to
 the first frame.
 
+### Login-Shell PATH Gate
+
+A packaged app launched from Finder or the Dock inherits only the minimal system PATH, so
+`which claude` and `which codex` fail and Agent Chat greys out providers the user has installed.
+`src/main/agent/cli/login-shell-path.ts` recovers the real PATH by running the login shell, which
+sources the user's whole rc chain and costs anywhere from 180 ms to over a second.
+
+That probe is not on the boot path. `startLoginShellPathAugmentation()` fires it at module scope
+and returns immediately; `whenLoginShellPathApplied()` settles once `process.env.PATH` has been
+merged. Anything that resolves an executable by name must await that gate rather than read PATH and
+hope. `runBinaryCommand()` in `src/main/agent/cli/binary-detection.ts` is where the agent CLIs do
+it, which covers `which`, the `--version` reads and, transitively, the per-turn spawns that run
+after detection. Headless `--cli` awaits it too, because it shells out before any window exists.
+
+The probe still logs `Augmented PATH from login shell for packaged launch` when it changed PATH, and
+still reports `login_shell_path_probe_failed` with a failure class per breakage: `status_<n>` for a
+shell that exited non-zero, `spawn_error` for one that never started, `marker_missing` for output
+the parser could not read. A silent failure here is indistinguishable from an uninstalled CLI, so
+the breadcrumb is the only way to tell the two apart from a user's logs.
+
 ## Telemetry
 
 Telemetry is enabled by default in production builds and off by default in development builds.


### PR DESCRIPTION
## Summary

`applyLoginShellPath` ran `spawnSync($SHELL -ilc …)` before `app.whenReady()`, so every packaged launch paid for sourcing the user's entire rc chain before Electron did anything. The probe now runs *alongside* boot instead of in front of it.

`startLoginShellPathAugmentation()` fires the probe once and memoises the in-flight promise. `whenLoginShellPathApplied()` settles when `process.env.PATH` has actually been merged, and resolves immediately on a build that never started one. `spawnSync` becomes a promisified `execFile`; the 3 s timeout, the `mergePaths` ordering and both telemetry failure classes survive (`execFile` rejects with a numeric `code` for a non-zero exit and a string errno when the shell never starts, which is the distinction `result.status` used to draw).

**The gate sits at one place: `runBinaryCommand` in `binary-detection.ts`**, the single point where PATH is consumed to resolve a binary by name. Scattering `await`s across call sites would have left the next `which` lookup to rediscover the bug. Headless `--cli` also awaits it, because it shells out to the agent CLIs immediately and has no first frame to protect — that restores the ordering the synchronous `spawnSync` used to give it for free.

### Why not defer it to `onceWindowShown` (#2004's queue)

That was the obvious option and it is worse. `onceWindowShown` drains 1000 ms after reveal, and `agent-feature-provider.tsx:33` makes Agent Chat active on first render when the restored tab is `agent-chat` or the persisted sidebar tab is `agent`. So `GET_BACKEND_STATUSES` fires from `agent-context.tsx:397` *inside* that delay for any user who quit with the panel open. Deferring would put the probe behind its most timing-sensitive consumer.

Caching the resolved PATH on disk was also rejected: it accepts greyed-out providers on the first launch after install — the exact failure this file exists to prevent — and adds persisted state needing a migration and corruption story while still requiring the async refresh underneath.

### Consumers audited

`locateBinary` and the `--version` reads are the real exposure and are now gated; a late PATH there returns `detected: false`, and the main-process cache does not save you, because `cacheBinaryDetection` never memoises a miss but the renderer holds the answer in `agent-context.reducer.ts` until the panel remounts. `spawn.ts:99` and `codex-spawn.ts:80` are covered transitively, since `bootstrap.ts:123`/`:180` always detect first. `pgrep` in `updater-install-guard.ts:89` is safe because `/usr/bin` is in the minimal PATH and every failure swallows to `false`. The `utilityProcess.fork` and `crdt-preflight` sites use `process.execPath` or `__dirname`. Nothing captures PATH at import time.

**One residual risk, deliberately not fixed here.** `image-processing/operations.ts:172` memoises a missing ffmpeg forever, in a worker that snapshots PATH at fork time, so a worker forked before the augmentation loses video thumbnails for its lifetime. Gating it broke 8 tests in `bridge.test.ts` that assert the fork happens synchronously. The window is narrow (the worker cannot fork before `autoOpenLastVault()`, and both `window_created` and `vault_open_ready` now sit after the augmentation), and the damage is bounded by the worker's idle shutdown. The real defect is that `findFfmpeg` caches a miss forever — the exact mistake `cacheBinaryDetection` documents avoiding — so it wants its own issue rather than a rushed rewrite of an unrelated test file.

## Release note

Agent CLI detection and app startup no longer wait for your shell profile to load, so the window appears sooner after a Dock click.

## Test plan

`pnpm lint` 0, `pnpm typecheck` 0 (19/19), `pnpm --filter @memry/desktop test:main` green at **574 files, 8058 passed, 1 expected fail, 0 failed**, `pnpm docs:impact --base perf/defer-post-reveal-services --strict` 0, `pnpm docs:build` 0.

### Measured

Tier 3, `electron-builder --dir`, unsigned. Both bundles burned in first, then interleaved A/B/A/B. Pooled median of **10 measured runs per arm** (10 further burn-in launches per arm discarded).

| metric | base (#2004) | this branch | delta | | spread |
| --- | ---: | ---: | ---: | ---: | ---: |
| `click_to_shown_ms` | 1090 | **938** | −152 | −13.9% | 106 |
| `app_ready_ms` | 273 | **114** | −159 | −58.2% | 46 |
| `window_created_ms` | 316 | 158 | −158 | −50.2% | 44 |
| `vault_open_ready_ms` | 396 | 250 | −146 | −36.7% | 50 |
| `ready_to_show_ms` | 562 | 410 | −152 | −27.0% | 55 |
| `shown_ms` | 574 | 422 | −153 | −26.6% | 52 |
| `renderer_first_paint_ms` | 158 | 162 | +4 | +2.5% | 44 |
| `renderer_fcp_ms` | 316 | 326 | +10 | +3.2% | 112 |

Every main-process delta is roughly three times the run-to-run spread. The renderer paint metrics are unchanged, as expected — they are measured from renderer start, not from the click.

The prediction written before measuring was `app_ready` 273 → 90-125 and `click_to_shown` 1090 → 900-940, with the falsification condition *"if `app_ready` does not drop by more than 20 ms, this change did not do what I think"*. Measured 114 and 938.

**Click-to-shown is now 938 ms against the epic's ≤ 800 ms target, from 1090.**

### Measurement method

Numbers taken from a freshly built bundle are unusable: two byte-identical builds measured 1374 ms and 2619 ms on first encounter, and 1152 ms vs 1169 ms once settled. macOS charges a large one-time cost for a bundle it has never seen, and it poisons most of a batch rather than one run a median would reject. Both arms here were burned in before any measured run.

### Note for whoever measures #2012

Its phase table was captured on `2026.903.2` and every entry shifts down once this lands, so measuring against the old numbers would credit this PR's win to that change. Anything it adds that resolves an executable by name must `await whenLoginShellPathApplied()` first. `bootstrap.ts:134`/`:191` pass bare binary names, so anything that reorders or parallelises the detect-then-spawn pair breaks the transitive gate silently.

The `Augmented PATH` log line now lands *after* `starting (packaged)` and usually before `main window shown`, which is the good outcome — the issue's "no `Augmented PATH` before `main window shown`" criterion was a proxy for "no synchronous spawn on the boot path". The criterion that matters is the `AppIdentity` → `starting (packaged)` gap collapsing. `scripts/launch-bench.mjs` does not read that line, so the harness is unaffected.

Not verified: that a running packaged app still detects both CLIs on the tab-restore path. The unit test proves `runBinaryCommand` waits on the promise, not that the packaged app resolves the binaries.

Closes #2003
