### PR TITLE
fix(settings): stop the vault settings migration re-running on every launch

### DIFF
--- a/apps/desktop/src/main/vault/settings-cache.test.ts
+++ b/apps/desktop/src/main/vault/settings-cache.test.ts
@@ -14,7 +14,7 @@ import {
   migrateSettingsToConfig,
   writeCacheFromPreferences
 } from './settings-cache'
-import { VAULT_PREFERENCES_DEFAULTS, readPreferences } from './vault-preferences'
+import { VAULT_PREFERENCES_DEFAULTS, readPreferences, writePreferences } from './vault-preferences'
 
 const MEMRY_DIR = '.memry'
 
@@ -238,6 +238,56 @@ describe('migrateSettingsToConfig', () => {
     const generalRaw = getSetting(testDb.db as any, 'general')
     const general = JSON.parse(generalRaw!)
     expect(general.theme).toBe(GENERAL_SETTINGS_DEFAULTS.theme)
+  })
+
+  it('#given the migration already ran #then a second launch does not rewrite config.json', () => {
+    vaultPath = createTempVault({ excludePatterns: ['.git'] })
+    const configPath = path.join(vaultPath, MEMRY_DIR, 'config.json')
+
+    // What writeCacheFromPreferences leaves behind on a fresh vault's first
+    // launch. Every value is a default, which is what let the migration read its
+    // own cache back and re-seed config.json on each subsequent launch.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setSetting(testDb.db as any, 'general', JSON.stringify(GENERAL_SETTINGS_DEFAULTS))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    migrateSettingsToConfig(testDb.db as any, vaultPath)
+    // writePreferences renames a fresh temp file over the config, so the inode
+    // changes on every write even when the bytes come out identical.
+    const inodeAfterFirst = fs.statSync(configPath).ino
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    migrateSettingsToConfig(testDb.db as any, vaultPath)
+
+    expect(fs.statSync(configPath).ino).toBe(inodeAfterFirst)
+  })
+
+  it('#given a preference the user changed after migrating #then a later launch keeps their value', () => {
+    vaultPath = createTempVault({ excludePatterns: ['.git'] })
+
+    // Pre-migration SQLite state. `minimizeToTray` is the case that bites: the
+    // old guard only compared theme/fontSize/fontFamily/accentColor/language,
+    // so a vault customised through any other field looked untouched.
+    setSetting(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      testDb.db as any,
+      'general',
+      JSON.stringify({ ...GENERAL_SETTINGS_DEFAULTS, minimizeToTray: true })
+    )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    migrateSettingsToConfig(testDb.db as any, vaultPath)
+    expect(readPreferences(vaultPath).minimizeToTray).toBe(true)
+
+    writePreferences(vaultPath, { minimizeToTray: false })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    migrateSettingsToConfig(testDb.db as any, vaultPath)
+
+    expect(readPreferences(vaultPath).minimizeToTray).toBe(false)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const general = JSON.parse(getSetting(testDb.db as any, 'general')!)
+    expect(general.minimizeToTray).toBe(false)
   })
 })
 

--- a/apps/desktop/src/main/vault/settings-cache.ts
+++ b/apps/desktop/src/main/vault/settings-cache.ts
@@ -8,6 +8,7 @@ import { LocaleSchema } from '@memry/contracts/locale-api'
 import {
   readPreferences,
   writePreferences,
+  hasStoredPreferences,
   VAULT_PREFERENCES_DEFAULTS,
   type VaultPreferences
 } from './vault-preferences'
@@ -21,18 +22,25 @@ export function populateSettingsCacheFromConfig(db: DataDb, vaultPath: string): 
   writeCacheFromPreferences(db, prefs)
 }
 
+/**
+ * Seed config.json from the pre-config.json SQLite settings, once per vault.
+ *
+ * The marker is config.json's own preferences block. Nothing but this function
+ * writes the first one — `writePreferences` and this migration shipped in the
+ * same commit, and vault open runs the migration before any other writer can
+ * reach the file — so its presence is an exact record that the seeding is done.
+ *
+ * That has to be the guard because `writeCacheFromPreferences` below refills the
+ * SQLite rows from config.json on every launch. Reading them back as a migration
+ * source is reading this function's own output, which is why the previous
+ * "is config.json still at its defaults" test re-fired on launch after launch.
+ * It also under-reported: it compared five of the eleven portable fields, so a
+ * vault customised only through, say, `minimizeToTray` looked untouched and the
+ * stale SQLite row overwrote a value the user had chosen.
+ */
 export function migrateSettingsToConfig(db: DataDb, vaultPath: string): void {
-  const prefs = readPreferences(vaultPath)
-
-  const isDefault =
-    prefs.theme === VAULT_PREFERENCES_DEFAULTS.theme &&
-    prefs.fontSize === VAULT_PREFERENCES_DEFAULTS.fontSize &&
-    prefs.fontFamily === VAULT_PREFERENCES_DEFAULTS.fontFamily &&
-    prefs.accentColor === VAULT_PREFERENCES_DEFAULTS.accentColor &&
-    prefs.language === VAULT_PREFERENCES_DEFAULTS.language
-
-  if (!isDefault) {
-    writeCacheFromPreferences(db, prefs)
+  if (hasStoredPreferences(vaultPath)) {
+    writeCacheFromPreferences(db, readPreferences(vaultPath))
     return
   }
 
@@ -40,7 +48,7 @@ export function migrateSettingsToConfig(db: DataDb, vaultPath: string): void {
   const rawEditor = getSetting(db, 'editor')
 
   if (!rawGeneral && !rawEditor) {
-    writeCacheFromPreferences(db, prefs)
+    writeCacheFromPreferences(db, readPreferences(vaultPath))
     return
   }
 

--- a/apps/desktop/src/main/vault/vault-preferences.ts
+++ b/apps/desktop/src/main/vault/vault-preferences.ts
@@ -118,6 +118,24 @@ export function readPreferences(vaultPath: string): VaultPreferences {
   }
 }
 
+/**
+ * Whether config.json already carries a preferences block.
+ *
+ * Deliberately not derived from `readPreferences`, which fills every field from
+ * the defaults and so cannot tell an absent block from one whose values happen
+ * to match. The predicate below is the same one `readPreferences` uses to decide
+ * it has nothing stored to read, so the two can never disagree about whether
+ * this vault's settings have been written to disk yet.
+ */
+export function hasStoredPreferences(vaultPath: string): boolean {
+  try {
+    const raw = JSON.parse(fs.readFileSync(getConfigPath(vaultPath), 'utf-8'))
+    return Boolean(raw.preferences)
+  } catch {
+    return false
+  }
+}
+
 export function writePreferences(
   vaultPath: string,
   updates: DeepPartial<VaultPreferences>

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -113,6 +113,22 @@ The cache is validated against the file itself, not against a list of known writ
 
 The on-disk format is unchanged; the cache is purely a runtime concern.
 
+## Settings Storage
+
+Portable settings — theme, font size and family, accent colour, language, the tab and folder
+behaviours, and the editor preferences — live in the `preferences` block of
+`<vault>/.memry/config.json`. That file is the source of truth, which is what lets the settings
+travel with the vault folder. The `general` and `editor` rows in `data.db` are a cache of it,
+rewritten from `config.json` on every vault open, and are what the rest of the app reads.
+
+Settings predate `config.json`, so vault open also seeds that block from the SQLite rows once per
+vault. The guard is the presence of the `preferences` block itself: the seeding is the only thing
+that writes the first one and it runs before any other writer can reach the file, so a block on
+disk means the seeding is already done. Nothing derives settings from the SQLite rows after that
+point — by then those rows are the seeding's own output, and reading them back would overwrite
+whatever the user has changed since. The rows are left in place; they are the cache, not a
+legacy source.
+
 ## App Config File
 
 App-level state that must be readable before any vault opens lives in a single JSON file,


### PR DESCRIPTION
## Summary

The "one-time" settings migration was reading back its own output.

`writeCacheFromPreferences` (`apps/desktop/src/main/vault/settings-cache.ts:106`) rewrites the `general` and `editor` rows in `data.db` from `config.json` on every path through the migration. So the next launch found those rows, rebuilt a non-empty seed, and rewrote `config.json` again. The only guard was "are `config.json`'s preferences still at their defaults", which a vault sitting at defaults answers *yes* to forever. Hence nine runs out of nine.

**There were two bugs here, and the second one is worse.**

That guard compared 5 of the 11 portable fields. A vault customised only through `minimizeToTray`, `fontSizePx`, `customFontFamily`, `createInSelectedFolder`, `openPagesInNewTab`, or any editor field read as untouched — so the migration fired, and the stale SQLite row overwrote the value the user had actually chosen. **That is silent settings loss on live installs**, and it is what the second new test reproduces: set `minimizeToTray: false` after migrating, relaunch, get `true` back.

### The fix

Guard on the presence of `config.json`'s own `preferences` block, via a new `hasStoredPreferences` in `vault-preferences.ts` that reuses the exact predicate `readPreferences` uses to decide it has nothing stored, so the two cannot disagree.

The issue suggested a separate marker. This is better, and the reason is checkable: `git log --diff-filter=A` shows `vault-preferences.ts` and `settings-cache.ts` were added in the same commit (`8ff66f769`, #115), and vault open runs the migration before any other writer reaches the file. So no shipped version can have written a `preferences` block without having already migrated. **The block is the marker**; a separate one would be redundant state that every install then has to carry forever.

The SQLite rows are not deleted. They are the live cache the renderer reads.

## Release note

Fixed a bug where changing certain settings — minimize to tray, font size, custom font, and several editor options — could silently revert to an older value the next time the app started.

## Test plan

`pnpm lint` 0, `pnpm typecheck` 0, `pnpm --filter @memry/desktop test:main` green at **574 files, 8060 passed, 1 expected fail, 0 failed**. `pnpm docs:impact --base perf/login-shell-path-off-boot --strict` 0, `pnpm docs:build` 0.

Three commits, in order: a failing repro, then the fix, then docs.

### Backward compatibility, four populations

This is a live app and the migration has already run repeatedly on every existing install, so the guard has to be right for all four:

1. **Fresh install.** Migrates exactly once, on the launch where the default-valued cache rows exist, then never again.
2. **Already migrated (every existing user).** Skips on the very first launch of this build, with zero log lines. A SQLite marker row would have cost them one more migration first, which is why the `flipOpenPagesInNewTabDefault` idiom was not reused here.
3. **Migrated, then the user changed a setting by hand.** Now preserved. This is the case that was broken.
4. **Downgrade to a build that does not know about this change.** Trivially safe, because **nothing new is written to disk**: no marker, no new field, no shape change. An older build sees byte-identical state.

No `GeneralSettings` field was added, so the ten-places landmine and the CLI snapshot test do not apply.

### Measured: no change, and none was expected

**This is a correctness fix. It does not buy launch time and this PR does not claim any.**

The migration's per-launch cost was measured directly rather than guessed: 200 samples against the real `writePreferences`/`readPreferences` gave **median 0.210 ms, p95 0.280 ms** — about 0.02% of `click_to_shown`, two orders of magnitude below the measurement noise floor. (Warm cache, no fsync, so treat 0.2 ms as a floor; even 10× keeps it invisible.)

Confirmed on tier 3 anyway, to prove it does not *regress*. Both bundles burned in, interleaved A/B, pooled median of 10 runs per arm:

| metric | base (#2003) | this branch | delta | verdict |
| --- | ---: | ---: | ---: | --- |
| `click_to_shown_ms` | 883 | 900 | +18 | noise (spread 57) |
| `app_ready_ms` | 102 | 104 | +2 | noise (spread 30) |
| `vault_open_ready_ms` | 232 | 226 | −6 | noise (spread 29) |
| `ready_to_show_ms` | 390 | 382 | −8 | noise (spread 22) |
| `shown_ms` | 398 | 390 | −8 | noise (spread 24) |

### A testing trap worth knowing about

The re-run test asserts on `config.json`'s **inode**, not its bytes. `writePreferences` renames a fresh temp file over the target, so a re-run always changes the inode even when the bytes come out identical. The first draft of that test compared bytes, passed against the buggy code, and proved nothing.

### Adjacent dead code, deliberately not touched

`hasPreferencesInConfig` at `settings-cache.ts:154` is unreachable and unconditionally returns `true` — it compares a fresh spread by reference. Left in place rather than swept into this PR, but it is worth a one-line deletion.

The new guard's soundness depends on nothing calling `writePreferences` before `vault/index.ts:547`.

Not verified here: the packaged-app acceptance criterion (launch three times against a real vault and grep the log for a single migration line). The unit tests cover the logic; that check wants a human with a real vault.

Closes #2005
