### PR TITLE
perf(renderer): lazy-load InboxPage to keep the editor stack out of the entry chunk

### DIFF
--- a/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
@@ -14,17 +14,19 @@ import type { Tab } from '@/contexts/tabs/types'
 import { TabIdentityProvider } from '@/contexts/tabs/tab-identity'
 import { useTasksOptional } from '@/contexts/tasks'
 import { cn } from '@/lib/utils'
-import { InboxPage } from '@/pages/inbox'
 import { useT } from '@memry/i18n/renderer'
 import { stringifyUnknown } from '@/lib/stringify-unknown'
 import type { ViewScope } from '@memry/contracts/folder-view-api'
 
 // =============================================================================
-// MEMOIZED PAGE COMPONENTS
-// Prevents recreation on every render - crucial for performance
+// LAZY PAGE COMPONENTS
+// Module-level so each type keeps one stable component identity, and so no
+// page's dependency tree lands in the entry chunk.
 // =============================================================================
 
-const MemoizedInboxPage = React.memo(InboxPage)
+const LazyInboxPage = React.lazy(async () => ({
+  default: (await import('@/pages/inbox')).InboxPage
+}))
 const LazyCalendarPage = React.lazy(async () => ({
   default: (await import('@/pages/calendar')).CalendarPage
 }))
@@ -106,7 +108,7 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
         return <LazyHomePage />
 
       case 'inbox':
-        return <MemoizedInboxPage />
+        return <LazyInboxPage />
 
       case 'calendar':
         return <LazyCalendarPage />

--- a/apps/docs/src/architecture.md
+++ b/apps/docs/src/architecture.md
@@ -17,6 +17,20 @@ memrynote is a pnpm + Turborepo monorepo with an Electron desktop app, a Cloudfl
 | `packages/db-schema` | Drizzle ORM schemas.                                      |
 | `packages/shared`    | Shared utilities.                                         |
 
+## Renderer Page Loading
+
+Every page in the tab content switch is loaded through `React.lazy`, so no page's
+dependency tree lands in the entry chunk. The editor stack (`@blocknote`, ProseMirror,
+Yjs) reaches the renderer only through pages that mount an editor, which means it is
+fetched when the user first opens a note or the Inbox rather than parsed on every
+launch.
+
+The trade is deliberate. Keeping those modules out of the entry chunk removes parse
+work from the launch path and moves it onto the first navigation that needs it, off
+local disk. A page added to that switch with a static import silently returns the
+whole tree to the entry chunk, so new pages follow the same lazy shape as their
+siblings.
+
 ## Trust Boundary
 
 The user's device is trusted. The server is not. Everything that leaves the device is encrypted; the server stores ciphertext and serves it back.


### PR DESCRIPTION
## Summary

`tab-content.tsx` lazy-loads seventeen pages and eagerly imported one: `InboxPage`. That single edge dragged the whole `@blocknote`/ProseMirror/Yjs stack into the renderer's entry chunk, so it was parsed on every launch whether or not a note was ever opened.

The chain is nine hops, and the two barrel files are why reading imports misses it:

```
main.tsx → App.tsx:30 → components/split-view/index.ts (barrel)
  → tab-content.tsx:17 → pages/inbox.tsx
  → pages/inbox/inbox-list-view.tsx:16 → components/inbox-detail/index.ts (barrel)
  → content-section.tsx:35 → inbox-content-editor.tsx → @blocknote/react, @blocknote/shadcn
```

`InboxPage` is now `React.lazy` in the same shape as its seventeen siblings. The `Suspense fallback={null}` wrapper was already there. `React.memo(InboxPage)` went with it, redundant since the component takes no props and the `content` `useMemo` already keeps the element stable — which left the `MEMOIZED PAGE COMPONENTS` banner describing a block with no memos in it, so the banner was retitled.

## Release note

none

## Test plan

`pnpm lint` 0, `pnpm typecheck` 0, `pnpm --filter @memry/desktop test:renderer` green at **724 files, 8943 passed**. `pnpm docs:impact --base fix/settings-migration-idempotent --strict` 0, `pnpm docs:build` 0.

### Bundle, measured by building both sides

| | before | after |
| --- | ---: | ---: |
| entry chunk | 13,116,648 B | **9,839,575 B** |

−3,277,073 bytes, **−24.98%**. Total renderer JS moves only 30,519 bytes, so the stack relocated rather than duplicated. `grep -l ReplaceError` still matches exactly one chunk, so ProseMirror stays deduped, and the entry no longer matches `bn-block-content`.

### Launch, measured on tier 3

Both bundles burned in, interleaved A/B across four passes, pooled median of **20 runs per arm**, spread reported as interquartile range.

| metric | base (#2005) | this branch | delta | verdict |
| --- | ---: | ---: | ---: | --- |
| `ready_to_show_ms` | 389.0 | 359.5 | **−29.5** | faster (IQR 53) |
| `shown_ms` | 401.5 | 368.5 | **−33.0** | faster (IQR 54) |
| `renderer_dom_content_loaded_ms` | 237.8 | 207.7 | **−30.1** | faster (IQR 39) |
| `renderer_fcp_ms` | 310.0 | 292.0 | −18.0 | not resolvable (IQR 60) |
| `click_to_shown_ms` | 887.5 | 884.0 | −3.5 | not resolvable (IQR 112) |
| `app_ready_ms` | 108.5 | 108.0 | −0.5 | not resolvable |
| `renderer_first_paint_ms` | 152.0 | 158.0 | +6.0 | not resolvable |

**Roughly 30 ms, consistently, on the three parse-bound metrics.** `app_ready` correctly does not move — it is main-process work upstream of any renderer parse, which is a useful control.

**This is not the epic's largest win, and the epic's ranking should be corrected.** #2001 lists this as "largest absolute; highest risk" and puts #2003 seventh. Measured, #2003 is −152 ms across two files and this is −30 ms across two lines. A 24.98% byte cut buys ~30 ms because V8 compiles function bodies lazily, so bytes were a proxy that was off by roughly 5×.

It is still worth landing: 3.28 MB out of the entry chunk is the precondition for #2008's `manualChunks` and for #2047, and the change is two lines with no behavioural risk found.

### A cost moved, which the issue does not mention

`ContentArea-*.js` is unchanged at ~785 KB, because the editor stack it consumes used to arrive free inside the already-parsed entry chunk. It now comes from `blocknote-react-*` (1,090,837 B) plus `index-CXTvJDgV.js` (1,414,154 B). **Roughly 2.5 MB is deferred onto first note open or first Inbox open**, off local disk. The right trade for launch, but it is a trade, and it is now documented in `apps/docs/src/architecture.md`.

### Inbox-restore risk, lower than the issue assumes

`createDefaultTab()` at `contexts/tabs/helpers.ts:216` returns `type: 'home'`, and `LazyHomePage` is already lazy, so a fresh launch already crosses this exact boundary today. Restore is asynchronous: `contexts/tabs/persistence/hooks.ts:238-250` awaits `storage.load()` before dispatching `RESTORE_SESSION`, so an Inbox tab cannot exist before first paint and the chunk request starts after FCP. `fallback={null}` gives an empty pane rather than a spinner flash — **that last point is unverified**, since it needs a packaged app driven by hand.

### E2E

Not run here (native pre-hook). Full paths for whoever runs them, primary: `apps/desktop/tests/e2e/tabs.e2e.ts`, `inbox.e2e.ts`, `inbox-bulk-actions.e2e.ts`, `inbox-review-reminder.e2e.ts`, `quick-capture.e2e.ts`, `tab-reuse-on-page-click.e2e.ts`. Secondary: `calendar-inbox-snooze-click.e2e.ts`, `sidebar-nav-collapse.e2e.ts`, `search-command-palette.e2e.ts`, `integration.e2e.ts`. The failure shape to watch for is a spec asserting on Inbox content immediately after a click with no `waitFor`.

**The contract flagged as at-risk turned out to be vacuous.** `tabs.e2e.ts:477-490` is titled "default Inbox" and comments that the default tab is Inbox, but it only asserts `tabCount >= 1` and that `activeTitle` is truthy. The comment is also wrong, since `createDefaultTab()` returns Home. It cannot break, and it is worth its own cleanup issue.

Closes #2009
