### PR TITLE
perf(renderer): resolve the startup locale in the preload instead of awaiting IPC

### DIFF
--- a/apps/desktop/src/main/ipc/locale-handler.test.ts
+++ b/apps/desktop/src/main/ipc/locale-handler.test.ts
@@ -14,7 +14,7 @@ const hoisted = vi.hoisted(() => ({
 }))
 
 vi.mock('electron', () => ({
-  ipcMain: { handle: vi.fn() },
+  ipcMain: { handle: vi.fn(), on: vi.fn() },
   BrowserWindow: { getAllWindows: vi.fn(() => hoisted.windows) }
 }))
 
@@ -60,6 +60,19 @@ describe('locale handler', () => {
     expect(ipcMain.handle).toHaveBeenCalledWith('locale:get', expect.any(Function))
     expect(ipcMain.handle).toHaveBeenCalledWith('locale:set', expect.any(Function))
     expect(ipcMain.handle).toHaveBeenCalledWith('locale:list', expect.any(Function))
+  })
+
+  it('answers the startup sync channel with the active locale', () => {
+    const mockI18n = { changeLanguage: vi.fn(), language: 'tr' } as any
+    registerLocaleHandlers(mockI18n, () => {})
+
+    const listener = (ipcMain.on as any).mock.calls.find(
+      ([channel]: [string]) => channel === 'locale:getStartupSync'
+    )[1]
+    const event = { returnValue: undefined as unknown }
+    listener(event)
+
+    expect(event.returnValue).toBe('tr')
   })
 
   it('rejects an invalid locale string', async () => {

--- a/apps/desktop/src/main/ipc/locale-handler.ts
+++ b/apps/desktop/src/main/ipc/locale-handler.ts
@@ -121,6 +121,13 @@ export function registerLocaleHandlers(i18n: I18nInstance, rebuildMenu: RebuildM
 
   ipcMain.handle(LocaleChannels.Get, () => activeLocale)
 
+  // Registered here rather than lazily: the preload calls this synchronously
+  // during window load, which happens after registerAllHandlers() but while the
+  // rest of the whenReady chain (vault open) is still running.
+  ipcMain.on(LocaleChannels.GetStartupSync, (event) => {
+    event.returnValue = activeLocale
+  })
+
   ipcMain.handle(LocaleChannels.List, () => SUPPORTED_LOCALES)
 
   ipcMain.handle(LocaleChannels.Set, async (_event, candidate: unknown): Promise<void> => {

--- a/apps/desktop/src/main/sync/item-handlers/settings-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/settings-handler.test.ts
@@ -68,7 +68,7 @@ vi.mock('electron', () => ({
   },
   // locale-handler registers its IPC channels on import-time registration; the
   // real apply path is exercised through it, so ipcMain has to exist.
-  ipcMain: { handle: vi.fn() }
+  ipcMain: { handle: vi.fn(), on: vi.fn() }
 }))
 
 vi.mock('../../database', () => ({

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -10,6 +10,12 @@ import type { Locale, LocaleApi } from '@memry/contracts/locale-api'
 import { createLogger } from './lib/logger'
 import { invoke, invokeSync, send, subscribe } from './lib/ipc'
 import { applyStartupTheme, getStartupThemeSync, THEME_STORAGE_KEY } from './lib/startup-theme'
+import {
+  applyStartupLocale,
+  cacheStartupLocale,
+  getStartupLocaleSync,
+  refreshStartupLocaleCache
+} from './lib/startup-locale'
 import { applyZoomFactor, getStartupZoomFactor } from './lib/startup-zoom'
 import { createGeneratedRpcApi } from './generated-rpc'
 import { windowApi, getFileDropPaths, contextMenuApi, quickCaptureApi, flushApi } from './api/core'
@@ -65,6 +71,16 @@ if (typeof globalThis.window !== 'undefined') {
   // There is deliberately no synchronous-IPC fallback like the theme's — a
   // first launch with nothing cached is 100%, which is the right answer.
   applyZoomFactor(getStartupZoomFactor())
+
+  // Owned here, not in the renderer: `dir`/`lang` set after the entry chunk has
+  // parsed would let an RTL user's document sit LTR for the whole parse.
+  applyStartupLocale(getStartupLocaleSync())
+
+  // The cache is written only here, so the renderer never has to remember to
+  // keep it in step. Every locale change reaches every window through this
+  // broadcast, whether it came from settings, onboarding, or a peer device.
+  subscribe<Locale>(LocaleChannels.Changed, cacheStartupLocale)
+  refreshStartupLocaleCache()
 }
 
 const generatedRpcApi = createGeneratedRpcApi({
@@ -76,7 +92,8 @@ const generatedRpcApi = createGeneratedRpcApi({
 const localeApi: LocaleApi = {
   get: () => invoke(LocaleChannels.Get),
   set: (locale: Locale) => invoke(LocaleChannels.Set, locale),
-  list: () => invoke(LocaleChannels.List)
+  list: () => invoke(LocaleChannels.List),
+  getStartupSync: getStartupLocaleSync
 }
 
 export const api = {

--- a/apps/desktop/src/preload/lib/startup-locale.test.ts
+++ b/apps/desktop/src/preload/lib/startup-locale.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  sendSync: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcRenderer: {
+    invoke: mocks.invoke,
+    sendSync: mocks.sendSync
+  }
+}))
+
+import {
+  LOCALE_STORAGE_KEY,
+  applyStartupLocale,
+  cacheStartupLocale,
+  getStartupLocaleSync,
+  refreshStartupLocaleCache
+} from './startup-locale'
+
+function createStorage(): Storage {
+  const entries = new Map<string, string>()
+  return {
+    get length() {
+      return entries.size
+    },
+    clear: () => entries.clear(),
+    getItem: (key: string) => entries.get(key) ?? null,
+    key: (index: number) => [...entries.keys()][index] ?? null,
+    removeItem: (key: string) => void entries.delete(key),
+    setItem: (key: string, value: string) => void entries.set(key, value)
+  }
+}
+
+const documentElement = { attrs: new Map<string, string>() }
+const fakeDocument = {
+  get documentElement() {
+    return {
+      setAttribute: (name: string, value: string) => documentElement.attrs.set(name, value)
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  documentElement.attrs.clear()
+  // The preload suite runs on `environment: 'node'`, and renderer suites never
+  // clear localStorage between files. A fresh store per test keeps a cached
+  // locale from leaking either way.
+  vi.stubGlobal('window', { localStorage: createStorage(), addEventListener: vi.fn() })
+  vi.stubGlobal('document', fakeDocument)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('getStartupLocaleSync', () => {
+  it('returns a cached locale without touching IPC', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'tr')
+
+    expect(getStartupLocaleSync()).toBe('tr')
+    expect(mocks.sendSync).not.toHaveBeenCalled()
+  })
+
+  it('falls back to synchronous IPC and caches the answer when nothing is cached', () => {
+    mocks.sendSync.mockReturnValue('ar')
+
+    expect(getStartupLocaleSync()).toBe('ar')
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('ar')
+  })
+
+  it('ignores a cached value that is not a supported locale', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, '[object Object]')
+    mocks.sendSync.mockReturnValue('de')
+
+    expect(getStartupLocaleSync()).toBe('de')
+  })
+
+  it('falls back to English when neither the cache nor IPC answers', () => {
+    mocks.sendSync.mockReturnValue(undefined)
+
+    expect(getStartupLocaleSync()).toBe('en')
+  })
+
+  it('falls back to English when the sync channel throws', () => {
+    mocks.sendSync.mockImplementation(() => {
+      throw new Error('no handler registered')
+    })
+
+    expect(getStartupLocaleSync()).toBe('en')
+  })
+})
+
+describe('cacheStartupLocale', () => {
+  it('survives storage that refuses writes', () => {
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error('quota exceeded')
+        }
+      }
+    })
+
+    expect(() => cacheStartupLocale('fr')).not.toThrow()
+  })
+})
+
+describe('refreshStartupLocaleCache', () => {
+  it('rewrites a stale cache from the authoritative locale', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'en')
+    mocks.invoke.mockResolvedValue('he')
+
+    refreshStartupLocaleCache()
+    await vi.waitFor(() => expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('he'))
+  })
+
+  it('leaves the cache alone when the authority cannot be read', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'tr')
+    mocks.invoke.mockRejectedValue(new Error('offline'))
+
+    refreshStartupLocaleCache()
+    await vi.waitFor(() => expect(mocks.invoke).toHaveBeenCalled())
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('tr')
+  })
+})
+
+describe('applyStartupLocale', () => {
+  it('sets rtl for Arabic', () => {
+    applyStartupLocale('ar')
+
+    expect(documentElement.attrs.get('lang')).toBe('ar')
+    expect(documentElement.attrs.get('dir')).toBe('rtl')
+  })
+
+  it('sets ltr for Turkish', () => {
+    applyStartupLocale('tr')
+
+    expect(documentElement.attrs.get('lang')).toBe('tr')
+    expect(documentElement.attrs.get('dir')).toBe('ltr')
+  })
+})

--- a/apps/desktop/src/preload/lib/startup-locale.ts
+++ b/apps/desktop/src/preload/lib/startup-locale.ts
@@ -1,0 +1,97 @@
+import { ipcRenderer } from 'electron'
+import { LocaleChannels } from '@memry/contracts/ipc-channels'
+import { LocaleSchema, FALLBACK_LOCALE, type Locale } from '@memry/contracts/locale-api'
+import { localeDirection } from '@memry/i18n/shared/direction'
+
+export const LOCALE_STORAGE_KEY = 'memry-locale'
+
+function parseLocale(value: unknown): Locale | null {
+  const result = LocaleSchema.safeParse(value)
+  return result.success ? result.data : null
+}
+
+export function cacheStartupLocale(locale: Locale): void {
+  try {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, locale)
+  } catch {
+    // localStorage may be unavailable in some test or restricted environments
+  }
+}
+
+/**
+ * The locale to boot with, with no await anywhere on the path.
+ *
+ * The renderer used to open with `await window.api.locale.get()`, so the i18n
+ * bundle load could not even start until an IPC round-trip came back — and that
+ * round-trip races vault open on the main process. The cache makes the common
+ * launch free; `sendSync` covers the launch that has no cache yet (first run,
+ * first launch after upgrading to this build, cleared storage) and is
+ * authoritative, so a missing cache can never produce a wrong-language frame.
+ */
+export function getStartupLocaleSync(): Locale {
+  try {
+    const cached = parseLocale(window.localStorage.getItem(LOCALE_STORAGE_KEY))
+    if (cached) return cached
+  } catch {
+    // localStorage may be unavailable; fall through to IPC
+  }
+
+  try {
+    const locale = parseLocale(ipcRenderer.sendSync(LocaleChannels.GetStartupSync))
+    if (locale) {
+      cacheStartupLocale(locale)
+      return locale
+    }
+  } catch {
+    // fall through
+  }
+
+  return FALLBACK_LOCALE
+}
+
+/**
+ * Re-reads the authoritative locale and rewrites the cache. Fire-and-forget and
+ * off the boot path — nothing waits on it. Without this a cache that somehow
+ * went stale would stay stale, and the renderer would correct the same
+ * mismatch on every launch forever instead of once.
+ */
+export function refreshStartupLocaleCache(): void {
+  void ipcRenderer
+    .invoke(LocaleChannels.Get)
+    .then((value: unknown) => {
+      const locale = parseLocale(value)
+      if (locale) cacheStartupLocale(locale)
+    })
+    .catch(() => {
+      // A locale we cannot re-read is a locale we leave cached as-is
+    })
+}
+
+/**
+ * Sets `<html lang>` and `<html dir>` before any renderer script evaluates, so
+ * an RTL user's document is never LTR while the entry chunk is still parsing.
+ * Mirrors applyStartupTheme's DOMContentLoaded guard: the preload can run
+ * before documentElement exists.
+ */
+export function applyStartupLocale(locale: Locale): void {
+  const direction = localeDirection(locale)
+
+  const applyToRoot = (): boolean => {
+    const root = document.documentElement
+    if (!root) return false
+
+    root.setAttribute('lang', locale)
+    root.setAttribute('dir', direction)
+    return true
+  }
+
+  if (!applyToRoot()) {
+    window.addEventListener(
+      'DOMContentLoaded',
+      () => {
+        applyToRoot()
+      },
+      { once: true }
+    )
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/startup-locale.test.ts
+++ b/apps/desktop/src/renderer/src/lib/startup-locale.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { getStartupLocale } from './startup-locale'
+
+// `tests/setup-dom.ts` defines window.api as writable but not configurable, so
+// this assigns over it and puts the shared mock back rather than deleting.
+const windowTarget = window as unknown as { api?: unknown }
+const originalApi = windowTarget.api
+
+afterEach(() => {
+  windowTarget.api = originalApi
+})
+
+describe('getStartupLocale', () => {
+  it('returns what the preload resolved', () => {
+    windowTarget.api = { locale: { getStartupSync: () => 'tr' } }
+
+    expect(getStartupLocale()).toBe('tr')
+  })
+
+  it('falls back to English when the preload bridge is missing', () => {
+    windowTarget.api = undefined
+
+    expect(getStartupLocale()).toBe('en')
+  })
+
+  it('falls back to English when the bridge answers with an unsupported locale', () => {
+    windowTarget.api = { locale: { getStartupSync: () => 'klingon' } }
+
+    expect(getStartupLocale()).toBe('en')
+  })
+
+  it('falls back to English when the bridge has no locale API at all', () => {
+    windowTarget.api = {}
+
+    expect(getStartupLocale()).toBe('en')
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/startup-locale.ts
+++ b/apps/desktop/src/renderer/src/lib/startup-locale.ts
@@ -1,0 +1,12 @@
+import { FALLBACK_LOCALE, LocaleSchema, type Locale } from '@memry/contracts/locale-api'
+
+/**
+ * The locale to build the i18n instance with, available before the first
+ * `await`. The preload resolves it from its cache or synchronous IPC; a
+ * renderer running without that bridge (unit tests, a stale preload) gets the
+ * fallback and the post-render reconcile corrects it.
+ */
+export function getStartupLocale(): Locale {
+  const result = LocaleSchema.safeParse(window.api?.locale?.getStartupSync?.())
+  return result.success ? result.data : FALLBACK_LOCALE
+}

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -19,7 +19,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from 'next-themes'
-import { createRendererI18n, I18nProvider, applyLocaleToDocument } from '@memry/i18n/renderer'
+import {
+  createRendererI18n,
+  I18nProvider,
+  applyLocaleToDocument,
+  type I18nInstance
+} from '@memry/i18n/renderer'
 import { type Locale } from '@memry/i18n/shared'
 import App from './App'
 import { setActiveLocale } from './lib/active-locale'
@@ -29,6 +34,7 @@ import { AuthProvider } from './contexts/auth-context'
 import { SyncProvider } from './contexts/sync-context'
 import { AISettingsProvider } from './contexts/ai-settings-context'
 import { getStartupTheme, THEME_STORAGE_KEY } from './lib/startup-theme'
+import { getStartupLocale } from './lib/startup-locale'
 import { APP_QUERY_DEFAULT_OPTIONS } from './lib/query-client-options'
 import { createLogger } from './lib/logger'
 import {
@@ -69,16 +75,36 @@ try {
 const isQuickCaptureWindow =
   window.location.hash === '#/quick-capture' || window.location.hash === '#quick-capture'
 const startupTheme = getStartupTheme()
+const startupLocale = getStartupLocale()
+
+// Started at module scope rather than inside boot(): the locale is already
+// known, so there is nothing left for the 11 locale namespace chunks to wait
+// for. This used to sit behind `await window.api.locale.get()`, an IPC
+// round-trip that races vault open on the main process.
+const i18nReady = createRendererI18n({ locale: startupLocale })
+
+// `locale.get()` stays the authority. It is consulted after the first render,
+// and only ever disagrees when the preload's cache went stale, in which case
+// the session switches through the same path a settings change takes.
+async function reconcileStartupLocale(i18n: I18nInstance): Promise<void> {
+  const actual = await window.api.locale.get()
+  if (actual === startupLocale) return
+
+  log.warn('Startup locale disagreed with the main process', {
+    assumed: startupLocale,
+    actual
+  })
+  await i18n.changeLanguage(actual)
+  applyLocaleToDocument(actual)
+}
 
 async function boot(): Promise<void> {
-  const initialLocale = await window.api.locale.get()
-  const i18n = await createRendererI18n({ locale: initialLocale })
-  applyLocaleToDocument(initialLocale)
+  const i18n = await i18nReady
 
   // Keep the module-scoped locale that pure Intl helpers read in sync. Hooked to
   // i18next itself rather than to each caller, so every changeLanguage path
   // (settings, onboarding, sync from another device) is covered.
-  setActiveLocale(initialLocale)
+  setActiveLocale(startupLocale)
   i18n.on('languageChanged', (locale) => {
     setActiveLocale(locale as Locale)
   })
@@ -126,6 +152,10 @@ async function boot(): Promise<void> {
 
   createRoot(document.getElementById('root')!).render(rootComponent)
   trackRendererReady(performance.now() - rendererStartedAt)
+
+  void reconcileStartupLocale(i18n).catch((error) => {
+    log.error('Startup locale reconcile failed', error)
+  })
 }
 
 void boot().catch((error) => {

--- a/apps/docs/src/architecture.md
+++ b/apps/docs/src/architecture.md
@@ -47,6 +47,27 @@ Adding an icon to `icon-map.ts` means rerunning the generator; `--check` mode gu
 in the test suite. A static import of the package barrel anywhere in the renderer
 silently pulls all ~5,000 glyphs back into the entry chunk.
 
+## Startup Bootstrap
+
+Theme, zoom factor and locale are resolved in the preload, before any renderer script
+evaluates. Each reads a `localStorage` cache first and falls back to a synchronous IPC
+channel (`settings:getStartupThemeSync`, `locale:getStartupSync`) only when there is no
+usable cached value, which in practice means first run, first launch after an upgrade
+that introduced the cache, or cleared storage. The synchronous channel is the authority,
+so a missing cache can never produce a wrong first frame; the cache only removes the IPC
+call from the common launch.
+
+The renderer must not re-apply any of them. Setting the theme class, the zoom factor or
+`<html dir>` a second time after the entry chunk has parsed is the visible flash this
+arrangement exists to prevent. The renderer's job is to consume the resolved value:
+`main.tsx` builds its i18n instance from `getStartupLocale()` at module scope, so the
+locale namespace chunks start loading with no `await` in front of them, and reconciles
+against `window.api.locale.get()` after the first render.
+
+Every locale change broadcasts on `locale:changed`, and the preload is the only writer of
+the locale cache, so a language switch from settings, onboarding, or a peer device keeps
+the next launch correct without the renderer participating.
+
 ## Trust Boundary
 
 The user's device is trusted. The server is not. Everything that leaves the device is encrypted; the server stores ciphertext and serves it back.

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -961,6 +961,13 @@ export type GraphInvokeChannel = (typeof GraphChannels.invoke)[keyof typeof Grap
 
 export const LocaleChannels = {
   Get: 'locale:get',
+  /**
+   * Synchronous startup read, for first-paint bootstrap in the preload. Same
+   * shape as SettingsChannels.sync.GET_STARTUP_THEME: a `sendSync` the preload
+   * only reaches on a launch with no cached locale, so the renderer never has
+   * to await an IPC round-trip before it knows which language to load.
+   */
+  GetStartupSync: 'locale:getStartupSync',
   Set: 'locale:set',
   List: 'locale:list',
   Changed: 'locale:changed'

--- a/packages/contracts/src/locale-api.ts
+++ b/packages/contracts/src/locale-api.ts
@@ -49,4 +49,10 @@ export interface LocaleApi {
   get: () => Promise<Locale>
   set: (locale: Locale) => Promise<void>
   list: () => Promise<readonly Locale[]>
+  /**
+   * The locale to boot with, resolved without awaiting anything. Reads the
+   * preload's localStorage cache first and only falls back to synchronous IPC
+   * when there is no usable cached value. `get()` stays the authority.
+   */
+  getStartupSync: () => Locale
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -8,6 +8,7 @@
     "./main": "./src/main/index.ts",
     "./renderer": "./src/renderer/index.ts",
     "./shared": "./src/shared/index.ts",
+    "./shared/direction": "./src/shared/direction.ts",
     "./locales": "./src/locales/index.ts",
     "./locales/en-errors": "./src/locales/en-errors.ts",
     "./locales/en-bundle": "./src/locales/en-bundle.ts"


### PR DESCRIPTION
## Summary

`boot()` opened with `await window.api.locale.get()`, so the eleven locale namespace chunks could not begin loading until an IPC round-trip returned, and `createRoot` waited behind both.

The preload now resolves the locale synchronously, in the same shape the shipped startup-theme path already uses: a `localStorage` cache in front of a new `locale:getStartupSync` channel. `main.tsx` builds i18n at module scope from that value and reconciles against the authoritative `locale.get()` after the first render. `<html lang>` and `<html dir>` moved to the preload.

`packages/i18n/src/shared/direction.ts` is exported as a subpath rather than copied, because it carries V8-version-specific `getTextInfo()` handling that must not fork.

### What this does not do, stated plainly

**React's first commit is still a spinner, and a user perceives nothing different.**

`App.tsx:583-589` returns a bare `Loader2` on `bg-background` whenever `vaultLoading` is true, and `hooks/use-vault.ts` starts `isLoading` at `useState(true)`, clearing it only inside a `useEffect` that awaits two IPC round-trips. Effects run after commit, so no first painted frame can skip it.

The half that would actually change what the user sees is a synchronous **initial vault status**, and it is blocked here by ordering, not by effort: `createWindow()` is at `main/index.ts:1722` and the `autoOpenLastVault()` block runs after it, so at preload time `getStatus()` (`vault/index.ts:767`) truthfully reports the vault as closed on every launch that has one. A sync channel would route a returning user to `VaultOnboarding` (`App.tsx:594`) instead of the shell. Painting the shell first needs a cached last-known snapshot, which is what **#2013** already specifies. That half belongs there, not here.

For the record, #2007's body says to apply `dir` "in the shell from #2006". #2006 was closed without code, so that dependency does not exist; `dir` is in the preload instead, which runs earlier than the shell would have.

## Release note

none

## Test plan

All exit 0: `pnpm lint`, `pnpm typecheck`, `pnpm --filter @memry/desktop test:renderer` (**726 files, 8949 passed**), `pnpm --filter @memry/desktop test:main` (**574 files, 8061 passed**), `pnpm --filter @memry/desktop i18n:check`, `pnpm ipc:generate` (no churn) then `pnpm ipc:check`, `pnpm docs:impact --base perf/hugeicons-tree-shake --strict`, `git diff --check`.

### Measured: no change

Tier 3, both bundles burned in, interleaved A/B across nine passes. Pooled median of **43 and 44 runs per arm**:

| metric | base (#2047) | this branch | delta | verdict |
| --- | ---: | ---: | ---: | --- |
| `click_to_shown_ms` | 832.0 | 839.5 | +7.5 | noise (IQR 34) |
| `app_ready_ms` | 104.0 | 103.0 | −1.0 | noise (IQR 12) |
| `ready_to_show_ms` | 326.0 | 331.0 | +5.0 | noise (IQR 21) |
| `shown_ms` | 334.0 | 338.0 | +4.0 | noise (IQR 20) |
| `renderer_first_paint_ms` | 148.0 | 152.0 | +4.0 | noise (IQR 16) |
| `renderer_fcp_ms` | 256.0 | 252.0 | −4.0 | noise (IQR 60) |
| `renderer_dom_content_loaded_ms` | 174.9 | 180.1 | +5.2 | noise (IQR 17) |

Restricted to the quietest 24 runs per arm, it is flatter still: `click_to_shown` −0.5, `shown` 0.0, `renderer_fcp_ms` 0.0.

**The falsification condition set before measuring was "if pooled FCP moves less than the ~20 ms settled IQR, the perf claim is dead". It moved 4 ms. The perf claim is dead, and this PR does not make one.**

An earlier batch showed `click_to_shown` +39.5 ms and flagged as a regression. That did not survive: its IQRs were 50 and 80 against 14 and 20 in a clean batch, and `EndpointAgentDaemon` (Malwarebytes) was measured at 99.6% CPU during it. Re-running to 43 runs per arm collapsed the effect to +7.5 ms, inside noise. Recorded because a false regression deserves the same correction as a false win.

### Why land it anyway

Two reasons that are not performance:

1. **RTL correctness improves.** `dir` and `lang` are now set before any renderer script evaluates, rather than after an IPC round-trip resolved. The cache is never the sole source of truth, so there is no "render English now, correct later" path — which is what the issue body actually suggested, and which was deliberately declined.
2. **One IPC round-trip leaves the critical path.** On this idle machine that is ~1 ms and unmeasurable. On a machine where the main process is busy during boot it is unbounded, and the main process is demonstrably busy there — that is what #2003 and #2004 were about.

If neither reason is worth the added channel to you, this is a reasonable PR to drop. It is the honest framing.

### Backward compatibility

The new channel is renderer-to-main only, registered at `main/index.ts:1545`, before `createWindow()` at `:1722`. The new `localStorage['memry-locale']` is validated through `LocaleSchema.safeParse`, so a corrupt value falls through to the authoritative sync call rather than producing a wrong frame — the same class of bug as the `[object Object]` theme value that used to white-screen the renderer. An older build ignores the key. Stale values heal twice, in the preload and in the session reconcile. No DB, sync protocol, vault format or settings shape is touched.

One tradeoff: `sendSync` blocks the renderer on a cache miss, which is exactly one launch per install, and is the same tradeoff the existing theme channel already makes.

### E2E

**`apps/desktop/tests/e2e/i18n.e2e.ts` must be run before landing.** Its `:52-53` pin `html[dir=rtl]` and `lang=ar`, and those attributes now come from a different process. Full path required; a bare filename runs all 605 tests. RTL was checked for `ar` → `rtl` and `tr` → `ltr` in unit tests.

Not verified: the `sendSync` path against a real Electron main (unit-tested against a mocked `ipcRenderer` only), that `dir` survives to first paint on the packaged `file://` origin, and the quick-capture window, whose preload runs the same bootstrap.

Closes #2007
