### PR TITLE
docs(renderer): record why the renderer build sets no manualChunks

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -151,6 +151,15 @@ export default defineConfig({
     plugins: [devCsp(), react(), tailwindcss()],
     build: {
       rollupOptions: {
+        // No `manualChunks` here, unlike main above. The renderer emits 908 chunks and
+        // exactly one is reachable from the entry without an `import()`, so chunking can
+        // only move startup bytes around, never off the startup path. It can add to it:
+        // `manualChunks` claims a module even when the module was reachable only lazily,
+        // so a vendor rule matching one eager module drags its whole bucket into launch.
+        // A measured react/Radix/motion/rest-of-node_modules split took the eager total
+        // from 4,789,586 to 45,050,500 bytes by pulling in Shiki, Excalidraw, and Mermaid.
+        // See apps/docs/src/architecture.md, "Renderer Chunking".
+
         // Every per-icon module in @hugeicons/core-free-icons tags its array literal
         // with /*#__PURE__*/, which rollup only reads on calls. Left alone it emits one
         // notice per icon and buries the warnings worth acting on.

--- a/apps/docs/src/architecture.md
+++ b/apps/docs/src/architecture.md
@@ -31,6 +31,30 @@ local disk. A page added to that switch with a static import silently returns th
 whole tree to the entry chunk, so new pages follow the same lazy shape as their
 siblings.
 
+## Renderer Chunking
+
+The renderer build sets no `manualChunks`. The main process build sets one, and the two
+are not comparable. Main is CJS over a small fixed graph, where package-per-chunk stops
+rollup splitting a circular package across chunks that then load in the wrong order. The
+renderer is ESM over a large graph whose lazy boundaries rollup already derives from the
+`import()` calls in the page switch.
+
+A production renderer build emits 908 chunks, and exactly one is reachable from the entry
+without an `import()`. Launch parses that single 4,485,640 byte file. `manualChunks`
+cannot shrink it, because it moves modules between chunks rather than off the startup
+path, and V8 compiles function bodies lazily either way.
+
+It can grow it. `manualChunks` assigns a module to its named chunk whether or not the
+module was reachable only through `import()`, so one eagerly imported module in a bucket
+drags the whole bucket onto the startup path. A vendor split over react, Radix, motion,
+and the rest of `node_modules` was measured at 5 eager chunks totalling 45,050,500 bytes,
+against 4,789,586 today. It pulled Shiki's grammars, Excalidraw, Mermaid, and hls.js into
+launch. The narrowest rule that could help, react and react-dom and scheduler alone,
+leaves the eager total byte-identical and only spreads it over two files.
+
+Reducing launch parse work therefore means cutting a lazy boundary so bytes stop being
+reachable from the entry, the shape used for pages above and for icons below.
+
 ## Icon Loading
 
 `@hugeicons/core-free-icons` ships ~5,000 glyphs in one module. The icon picker lets a


### PR DESCRIPTION
## Summary

**This PR adds no `manualChunks`. It records why the renderer must not have one**, in the config next to where someone would add it and in `apps/docs/src/architecture.md`. The silence in the config is what caused #2008 to be filed; the silence is now gone.

## Release note

none

## Test plan

`pnpm lint` 0, `pnpm typecheck` 0, `pnpm --filter @memry/desktop test:renderer` green at **726 files, 8949 passed**, `node scripts/check-worker-bundles.mjs` 0 across all five workers, `pnpm docs:impact --strict` 0.

### The measurement that decides it

A production renderer build emits **908 chunks, and exactly one is reachable from the entry without an `import()`**. Launch parses that single 4,485,640-byte file, and 88.7% of the renderer's module bytes are already lazy after #2009 and #2047. So `manualChunks` has nothing to move *off* the startup path. It can only shuffle bytes between files that all still load.

### It does not merely fail to help. It actively hurts.

`manualChunks` assigns a module to its named chunk **whether or not that module was reachable only through `import()`**. So a single eagerly imported module in a bucket promotes the whole bucket to a static import of the entry.

Measured, not reasoned. A vendor split over react, Radix, motion and the rest of `node_modules`:

| | today | with vendor split |
| --- | ---: | ---: |
| eager bytes | 4,789,586 | **45,050,500** |
| total chunks | 908 | 422 |
| entry file itself | 4,485,640 | **2,072,069** |

It dragged Shiki's grammars, Excalidraw, Mermaid and hls.js onto the launch path — a **9.4×** regression in bytes parsed at startup.

**Note the trap in the last row.** The entry file got *smaller*. Anyone scoring this change by entry-chunk size — which is how #2008 and most of this epic framed bundle work — would have recorded a 54% win while making launch nine times worse.

The narrowest rule that could conceivably help, `react` + `react-dom` + `scheduler` alone, is a clean no-op: byte-identical eager total, just spread over two files.

### The caching argument does not survive `app.asar` either

`config/electron-builder.yml:26` packs the renderer inside `app.asar`, with only `resources/**` unpacked. Squirrel verifies loose files, so 908 versus 5 renderer chunks is invisible to #1999's restart cost, and macOS ships a full zip, so a stable vendor chunk caches nothing. Windows NSIS blockmap deltas could in principle benefit, but chunk names are content-hashed and the entry's specifiers churn with them — labelled unverified rather than claimed.

### ProseMirror dedup

Checked in all three builds: exactly one chunk matches `ReplaceError` every time. In the baseline that chunk is `index-BXPBbYrI.js`, a **lazy** one, not the entry.

### Falsification

Bench a react-only `manualChunks` arm at 20+ runs per side. If `click_to_shown` beats the 34 ms IQR, then splitting eager bytes helps independently of removing them, and this closure is wrong.

### The one real lever, kept out of this PR

`components/settings-modal.tsx:3` statically imports `SettingsPage`, but renders it only inside a Radix `Dialog` with no `forceMount`, so it unmounts when closed. A throwaway `React.lazy` cut at that single boundary removed **492,751 eager bytes, 10.29%**, pulling `qrcode.react` and `components/sync/**` with it. That is a lazy-boundary change, not a chunking change, so it is filed separately rather than smuggled in here. Smaller siblings: `driver.js` at 26,383 bytes for the first-run tour, and `packages/i18n/src/locales/load.ts` as a single 49,002-byte eager module.

Calibrated against this epic's measured data points it is worth roughly 5-15 ms, under the 34 ms IQR, so it should be batched with other cuts into one measurable arm rather than benched alone.

Closes #2008
