### PR TITLE
perf(launch): measure when the restored note becomes readable, and prefetch its chunk

### DIFF
--- a/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
@@ -24,49 +24,56 @@ import type { ViewScope } from '@memry/contracts/folder-view-api'
 // page's dependency tree lands in the entry chunk.
 // =============================================================================
 
-const LazyInboxPage = React.lazy(async () => ({
-  default: (await import('@/pages/inbox')).InboxPage
-}))
-const LazyCalendarPage = React.lazy(async () => ({
-  default: (await import('@/pages/calendar')).CalendarPage
-}))
-const LazyJournalPage = React.lazy(async () => ({
-  default: (await import('@/pages/journal')).JournalPage
-}))
-const LazyTasksPage = React.lazy(async () => ({
-  default: (await import('@/pages/tasks')).TasksPage
-}))
-const LazyNotePage = React.lazy(async () => ({
-  default: (await import('@/pages/note')).NotePage
-}))
-const LazyFilePage = React.lazy(async () => ({
-  default: (await import('@/pages/file')).FilePage
-}))
-const LazyFolderViewPage = React.lazy(async () => ({
-  default: (await import('@/pages/folder-view')).FolderViewPage
-}))
+const pageLoaders = {
+  home: async () => (await import('@/pages/home')).default,
+  inbox: async () => (await import('@/pages/inbox')).InboxPage,
+  calendar: async () => (await import('@/pages/calendar')).CalendarPage,
+  journal: async () => (await import('@/pages/journal')).JournalPage,
+  tasks: async () => (await import('@/pages/tasks')).TasksPage,
+  note: async () => (await import('@/pages/note')).NotePage,
+  file: async () => (await import('@/pages/file')).FilePage,
+  folderView: async () => (await import('@/pages/folder-view')).FolderViewPage,
+  templateEditor: async () => (await import('@/pages/template-editor')).TemplateEditorPage,
+  graph: async () => (await import('@/components/graph/graph-page')).GraphPage,
+  tagsHub: async () => (await import('@/pages/tags-hub')).TagsHubPage,
+  agentConversation: async () =>
+    (await import('@/agent-chat/agent-conversation-tab')).AgentConversationTab,
+  canvas: async () => (await import('@/pages/canvas')).CanvasPage,
+  virtualNote: async () => (await import('@/pages/virtual-note')).VirtualNotePage,
+  project: async () => (await import('@/pages/project')).ProjectPage
+} satisfies Record<string, () => Promise<unknown>>
+
+/**
+ * Start a page's chunk fetch before React reaches its lazy boundary, so a
+ * restored tab's download overlaps vault open and tab restore instead of
+ * queueing behind them. It resolves through the same module registry
+ * `React.lazy` reads, so the render-time import is a cache hit, not a
+ * second request.
+ */
+export const prefetchPageModule = (key: string): void => {
+  const loader = pageLoaders[key as keyof typeof pageLoaders]
+  if (loader) void loader().catch(() => {})
+}
+
+const LazyInboxPage = React.lazy(async () => ({ default: await pageLoaders.inbox() }))
+const LazyCalendarPage = React.lazy(async () => ({ default: await pageLoaders.calendar() }))
+const LazyJournalPage = React.lazy(async () => ({ default: await pageLoaders.journal() }))
+const LazyTasksPage = React.lazy(async () => ({ default: await pageLoaders.tasks() }))
+const LazyNotePage = React.lazy(async () => ({ default: await pageLoaders.note() }))
+const LazyFilePage = React.lazy(async () => ({ default: await pageLoaders.file() }))
+const LazyFolderViewPage = React.lazy(async () => ({ default: await pageLoaders.folderView() }))
 const LazyTemplateEditorPage = React.lazy(async () => ({
-  default: (await import('@/pages/template-editor')).TemplateEditorPage
+  default: await pageLoaders.templateEditor()
 }))
-const LazyGraphPage = React.lazy(async () => ({
-  default: (await import('@/components/graph/graph-page')).GraphPage
-}))
-const LazyTagsHubPage = React.lazy(async () => ({
-  default: (await import('@/pages/tags-hub')).TagsHubPage
-}))
+const LazyGraphPage = React.lazy(async () => ({ default: await pageLoaders.graph() }))
+const LazyTagsHubPage = React.lazy(async () => ({ default: await pageLoaders.tagsHub() }))
 const LazyAgentConversationTab = React.lazy(async () => ({
-  default: (await import('@/agent-chat/agent-conversation-tab')).AgentConversationTab
+  default: await pageLoaders.agentConversation()
 }))
-const LazyCanvasPage = React.lazy(async () => ({
-  default: (await import('@/pages/canvas')).CanvasPage
-}))
-const LazyVirtualNotePage = React.lazy(async () => ({
-  default: (await import('@/pages/virtual-note')).VirtualNotePage
-}))
-const LazyHomePage = React.lazy(() => import('@/pages/home'))
-const LazyProjectPage = React.lazy(async () => ({
-  default: (await import('@/pages/project')).ProjectPage
-}))
+const LazyCanvasPage = React.lazy(async () => ({ default: await pageLoaders.canvas() }))
+const LazyVirtualNotePage = React.lazy(async () => ({ default: await pageLoaders.virtualNote() }))
+const LazyHomePage = React.lazy(async () => ({ default: await pageLoaders.home() }))
+const LazyProjectPage = React.lazy(async () => ({ default: await pageLoaders.project() }))
 
 interface TabContentProps {
   /** Tab data */

--- a/apps/desktop/src/renderer/src/lib/launch-restore.test.ts
+++ b/apps/desktop/src/renderer/src/lib/launch-restore.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { STORAGE_KEY } from '@/contexts/tabs/persistence'
+import type { PersistedTabState } from '@/contexts/tabs/persistence'
+
+// Renderer tests never clear localStorage between files (no global afterEach
+// does it), so this suite clears it itself in both beforeEach and afterEach —
+// otherwise a fixture written here would leak into whatever runs next.
+
+const { prefetchPageModuleMock, trackNoteReadableMock } = vi.hoisted(() => ({
+  prefetchPageModuleMock: vi.fn(),
+  trackNoteReadableMock: vi.fn()
+}))
+
+vi.mock('@/components/split-view/tab-content', () => ({
+  prefetchPageModule: prefetchPageModuleMock
+}))
+
+vi.mock('./telemetry-diagnostics', () => ({
+  trackNoteReadable: trackNoteReadableMock
+}))
+
+const noteTabState = (overrides: Partial<PersistedTabState> = {}): PersistedTabState => ({
+  version: 2,
+  tabGroups: {
+    'group-1': {
+      id: 'group-1',
+      activeTabId: 'tab-1',
+      tabs: [
+        {
+          id: 'tab-1',
+          type: 'note',
+          title: 'Note',
+          icon: 'file-text',
+          path: '/notes/note-1',
+          entityId: 'note-1',
+          isPinned: false
+        }
+      ]
+    }
+  },
+  layout: { type: 'leaf', tabGroupId: 'group-1' },
+  activeGroupId: 'group-1',
+  settings: {} as PersistedTabState['settings'],
+  savedAt: 1000,
+  ...overrides
+})
+
+// `launch-restore.ts` computes `LAUNCH_NOTE_ID` and reads `restoredTab` as a
+// module-scope side effect at import time, so a scenario that depends on
+// either one needs a fresh module instance loaded after localStorage is
+// seeded — a plain re-import would just return the already-evaluated module.
+const loadModule = async () => {
+  vi.resetModules()
+  return import('./launch-restore')
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  prefetchPageModuleMock.mockClear()
+  trackNoteReadableMock.mockClear()
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+describe('readRestoredActiveTab', () => {
+  it('returns null when storage is empty', async () => {
+    const { readRestoredActiveTab } = await loadModule()
+    expect(readRestoredActiveTab()).toBeNull()
+  })
+
+  it('picks the entry with the largest savedAt across multiple vault-scoped keys', async () => {
+    localStorage.setItem(`${STORAGE_KEY}:vault-a`, JSON.stringify(noteTabState({ savedAt: 100 })))
+    localStorage.setItem(
+      `${STORAGE_KEY}:vault-b`,
+      JSON.stringify(
+        noteTabState({
+          savedAt: 200,
+          tabGroups: {
+            'group-1': {
+              id: 'group-1',
+              activeTabId: 'tab-2',
+              tabs: [
+                {
+                  id: 'tab-2',
+                  type: 'note',
+                  title: 'B',
+                  icon: 'file-text',
+                  path: '/notes/note-2',
+                  entityId: 'note-2',
+                  isPinned: false
+                }
+              ]
+            }
+          }
+        })
+      )
+    )
+
+    const { readRestoredActiveTab } = await loadModule()
+    expect(readRestoredActiveTab()).toEqual({ type: 'note', entityId: 'note-2' })
+  })
+
+  it('falls back to the legacy global key when it is the only entry', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(noteTabState()))
+
+    const { readRestoredActiveTab } = await loadModule()
+    expect(readRestoredActiveTab()).toEqual({ type: 'note', entityId: 'note-1' })
+  })
+
+  it('skips a malformed JSON entry and still finds a valid one', async () => {
+    localStorage.setItem(`${STORAGE_KEY}:broken`, '{not json')
+    localStorage.setItem(`${STORAGE_KEY}:vault-a`, JSON.stringify(noteTabState()))
+
+    const { readRestoredActiveTab } = await loadModule()
+    expect(readRestoredActiveTab()).toEqual({ type: 'note', entityId: 'note-1' })
+  })
+
+  it('returns null when the newest entry has no activeGroupId', async () => {
+    const { activeGroupId: _drop, ...withoutActiveGroupId } = noteTabState()
+    localStorage.setItem(`${STORAGE_KEY}:vault-a`, JSON.stringify(withoutActiveGroupId))
+
+    const { readRestoredActiveTab } = await loadModule()
+    expect(readRestoredActiveTab()).toBeNull()
+  })
+
+  it('returns null when the active group has no active tab id', async () => {
+    localStorage.setItem(
+      `${STORAGE_KEY}:vault-a`,
+      JSON.stringify(
+        noteTabState({
+          tabGroups: { 'group-1': { id: 'group-1', activeTabId: null, tabs: [] } }
+        })
+      )
+    )
+
+    const { readRestoredActiveTab } = await loadModule()
+    expect(readRestoredActiveTab()).toBeNull()
+  })
+
+  it('ignores keys that do not start with the tab-state prefix', async () => {
+    localStorage.setItem('unrelated-key', JSON.stringify(noteTabState()))
+
+    const { readRestoredActiveTab } = await loadModule()
+    expect(readRestoredActiveTab()).toBeNull()
+  })
+})
+
+describe('prefetchRestoredTabPage', () => {
+  it('prefetches the page module keyed by the restored tab type', async () => {
+    localStorage.setItem(`${STORAGE_KEY}:vault-a`, JSON.stringify(noteTabState()))
+    const { prefetchRestoredTabPage } = await loadModule()
+
+    prefetchRestoredTabPage()
+    expect(prefetchPageModuleMock).toHaveBeenCalledExactlyOnceWith('note')
+  })
+
+  it('no-ops when nothing was restored', async () => {
+    const { prefetchRestoredTabPage } = await loadModule()
+
+    prefetchRestoredTabPage()
+    expect(prefetchPageModuleMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('markLaunchNoteReadable', () => {
+  it('marks performance and tracks telemetry once for the note the launch restored', async () => {
+    localStorage.setItem(`${STORAGE_KEY}:vault-a`, JSON.stringify(noteTabState()))
+    const { markLaunchNoteReadable, NOTE_READABLE_MARK, LAUNCH_NOTE_ID } = await loadModule()
+    expect(LAUNCH_NOTE_ID).toBe('note-1')
+
+    const markSpy = vi.spyOn(performance, 'mark')
+
+    markLaunchNoteReadable('note-1')
+
+    expect(markSpy).toHaveBeenCalledExactlyOnceWith(NOTE_READABLE_MARK)
+    expect(trackNoteReadableMock).toHaveBeenCalledTimes(1)
+
+    markSpy.mockRestore()
+  })
+
+  it('is idempotent — a second call for the same note is a no-op', async () => {
+    localStorage.setItem(`${STORAGE_KEY}:vault-a`, JSON.stringify(noteTabState()))
+    const { markLaunchNoteReadable } = await loadModule()
+
+    const markSpy = vi.spyOn(performance, 'mark')
+
+    markLaunchNoteReadable('note-1')
+    markSpy.mockClear()
+    trackNoteReadableMock.mockClear()
+
+    markLaunchNoteReadable('note-1')
+
+    expect(markSpy).not.toHaveBeenCalled()
+    expect(trackNoteReadableMock).not.toHaveBeenCalled()
+
+    markSpy.mockRestore()
+  })
+
+  it('ignores a note id that does not match the launch-restored note', async () => {
+    localStorage.setItem(`${STORAGE_KEY}:vault-a`, JSON.stringify(noteTabState()))
+    const { markLaunchNoteReadable } = await loadModule()
+
+    const markSpy = vi.spyOn(performance, 'mark')
+    markLaunchNoteReadable('some-other-note')
+
+    expect(markSpy).not.toHaveBeenCalled()
+    expect(trackNoteReadableMock).not.toHaveBeenCalled()
+
+    markSpy.mockRestore()
+  })
+
+  it('no-ops when the launch restored no note at all', async () => {
+    const { markLaunchNoteReadable, LAUNCH_NOTE_ID } = await loadModule()
+    expect(LAUNCH_NOTE_ID).toBeNull()
+
+    const markSpy = vi.spyOn(performance, 'mark')
+    markLaunchNoteReadable('note-1')
+
+    expect(markSpy).not.toHaveBeenCalled()
+    expect(trackNoteReadableMock).not.toHaveBeenCalled()
+
+    markSpy.mockRestore()
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/launch-restore.ts
+++ b/apps/desktop/src/renderer/src/lib/launch-restore.ts
@@ -1,0 +1,105 @@
+// The launch's restored active tab, read straight out of localStorage.
+//
+// Read from storage rather than asked over IPC because the vault path is not
+// available synchronously in the renderer, and a synchronous round-trip here
+// would put back the one a sibling issue just removed from this spot. Tab state
+// is written under `memry_tab_state` (legacy, global) and
+// `memry_tab_state:<vaultPath>`, so with no vault path to key on this picks the
+// entry with the largest `savedAt`. Guessing wrong costs one speculative chunk
+// fetch and nothing else.
+import { prefetchPageModule } from '@/components/split-view/tab-content'
+import { STORAGE_KEY } from '@/contexts/tabs/persistence'
+import type { PersistedTabGroup, PersistedTabState } from '@/contexts/tabs/persistence'
+import type { TabType } from '@/contexts/tabs/types'
+import { trackNoteReadable } from './telemetry-diagnostics'
+
+/** Read by `scripts/launch-bench.mjs` over CDP; renaming it breaks that bench. */
+export const NOTE_READABLE_MARK = 'memry:note-readable'
+
+export const readRestoredActiveTab = (): { type: string; entityId?: string } | null => {
+  try {
+    let newest: Partial<PersistedTabState> | null = null
+    let newestSavedAt = Number.NEGATIVE_INFINITY
+
+    for (let index = 0; index < localStorage.length; index += 1) {
+      const key = localStorage.key(index)
+      if (!key?.startsWith(STORAGE_KEY)) continue
+
+      const raw = localStorage.getItem(key)
+      if (!raw) continue
+
+      let parsed: Partial<PersistedTabState>
+      try {
+        parsed = JSON.parse(raw) as Partial<PersistedTabState>
+      } catch {
+        continue
+      }
+
+      const savedAt = parsed?.savedAt
+      if (typeof savedAt !== 'number' || savedAt <= newestSavedAt) continue
+
+      newest = parsed
+      newestSavedAt = savedAt
+    }
+
+    if (!newest?.activeGroupId) return null
+
+    const groups = newest.tabGroups as Record<string, PersistedTabGroup | undefined> | undefined
+    const group = groups?.[newest.activeGroupId]
+    if (!group?.activeTabId) return null
+
+    const tab = group.tabs?.find((candidate) => candidate.id === group.activeTabId)
+    return tab ? { type: tab.type, entityId: tab.entityId } : null
+  } catch {
+    return null
+  }
+}
+
+const restoredTab = readRestoredActiveTab()
+
+export const LAUNCH_NOTE_ID: string | null =
+  restoredTab?.type === 'note' ? (restoredTab.entityId ?? null) : null
+
+const PREFETCH_KEYS: Partial<Record<TabType, string>> = {
+  home: 'home',
+  inbox: 'inbox',
+  calendar: 'calendar',
+  journal: 'journal',
+  tasks: 'tasks',
+  'all-tasks': 'tasks',
+  today: 'tasks',
+  completed: 'tasks',
+  project: 'project',
+  note: 'note',
+  file: 'file',
+  folder: 'folderView',
+  tag: 'folderView',
+  'template-editor': 'templateEditor',
+  graph: 'graph',
+  tags: 'tagsHub',
+  'agent-chat': 'agentConversation',
+  canvas: 'canvas',
+  'virtual-note': 'virtualNote'
+}
+
+export const prefetchRestoredTabPage = (): void => {
+  if (!restoredTab) return
+  const key = PREFETCH_KEYS[restoredTab.type as TabType]
+  if (key) prefetchPageModule(key)
+}
+
+let noteReadableMarked = false
+
+export const markLaunchNoteReadable = (noteId: string | null | undefined): void => {
+  if (noteReadableMarked) return
+  // Only the note this launch restored counts. Without the equality check, a
+  // user who launches to the home tab and opens a note ten minutes later would
+  // stamp that as the launch metric.
+  if (!noteId || noteId !== LAUNCH_NOTE_ID) return
+
+  noteReadableMarked = true
+  if (typeof performance?.mark !== 'function') return
+
+  performance.mark(NOTE_READABLE_MARK)
+  trackNoteReadable(performance.now())
+}

--- a/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.ts
+++ b/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.ts
@@ -55,6 +55,16 @@ export const trackRendererReady = (durationMs: number): void => {
   })
 }
 
+export const trackNoteReadable = (durationMs: number): void => {
+  void trackTelemetry('app_launch_phase_completed', {
+    surface: 'app',
+    action: 'note_readable',
+    source: 'renderer',
+    result: 'success',
+    metrics: { durationMs: Math.max(0, Math.round(durationMs)) }
+  })
+}
+
 export const registerRendererDiagnostics = (): void => {
   window.addEventListener('error', (event) => {
     // `event.error` is absent for cross-origin scripts and some Chromium failure

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -35,6 +35,7 @@ import { SyncProvider } from './contexts/sync-context'
 import { AISettingsProvider } from './contexts/ai-settings-context'
 import { getStartupTheme, THEME_STORAGE_KEY } from './lib/startup-theme'
 import { getStartupLocale } from './lib/startup-locale'
+import { prefetchRestoredTabPage } from './lib/launch-restore'
 import { APP_QUERY_DEFAULT_OPTIONS } from './lib/query-client-options'
 import { createLogger } from './lib/logger'
 import {
@@ -76,6 +77,15 @@ const isQuickCaptureWindow =
   window.location.hash === '#/quick-capture' || window.location.hash === '#quick-capture'
 const startupTheme = getStartupTheme()
 const startupLocale = getStartupLocale()
+
+// Kicked off at module scope, before `boot()` even starts, so the restored
+// tab's chunk download overlaps everything boot() awaits (i18n, vault open,
+// tab restore) instead of queueing behind them. `prefetchRestoredTabPage`
+// already reads localStorage synchronously and no-ops when there is nothing
+// to restore, so a wrong guess costs one speculative chunk fetch. Skipped for
+// the quick-capture window, which never renders a note tab and would just be
+// paying for a chunk it never uses.
+if (!isQuickCaptureWindow) prefetchRestoredTabPage()
 
 // Started at module scope rather than inside boot(): the locale is already
 // known, so there is nothing left for the 11 locale namespace chunks to wait

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -105,6 +105,7 @@ import { useIsBookmarked } from '@/hooks/use-bookmarks'
 import { useEditorSettings, EDITOR_NORMAL_CONTENT_WIDTH } from '@/hooks/use-editor-settings'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { createLogger } from '@/lib/logger'
+import { markLaunchNoteReadable } from '@/lib/launch-restore'
 import { LocalGraphPanel } from '@/components/graph/local-graph-panel'
 import { graphKeys } from '@/hooks/use-graph-data'
 import { NoteBreadcrumb } from '@/components/note/note-breadcrumb'
@@ -817,8 +818,14 @@ export function NotePage({ noteId }: NotePageProps) {
     (editor: unknown) => {
       attachmentsEditorRef.current = editor
       mindMapEditorReady(editor)
+      // `useCreateBlockNote` renders the editor's blocks synchronously, and
+      // this effect runs after that render commits — the same "block tree is
+      // real" signal the mind map and attachments dialog above already trust.
+      // `editor` is null on teardown, so only a genuine mount counts as the
+      // note becoming readable, never a remount tick.
+      if (editor && noteId) markLaunchNoteReadable(noteId)
     },
-    [mindMapEditorReady]
+    [mindMapEditorReady, noteId]
   )
   const getAttachmentOriginalNames = useCallback(
     () => collectOriginalNames(attachmentsEditorRef.current),

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -1240,3 +1240,23 @@ identity comes only from the verified bearer. `/telemetry/batch` is unchanged by
 until after the vault is open so they never delay first paint. On the sync server, PostHog event
 capture and PostHog Logs pushes both run in `waitUntil` so neither can block the
 `/telemetry/batch` response.
+
+## Launch: note-readable mark
+
+`renderer/src/lib/launch-restore.ts` stamps a `performance.mark('memry:note-readable')`
+when the note a launch restored has actually rendered its block tree, hooked to
+BlockNote's `onEditorReady` rather than to component mount, because mount only proves the
+CRDT binding started. `scripts/launch-bench.mjs` reads it over CDP and reports it as
+`renderer_note_readable_ms`.
+
+The mark is deliberately narrow. It fires only for the note the launch restored, only
+once, and never for a note opened later in the session, so the metric cannot be inflated
+by ordinary navigation.
+
+It is absent, rather than zero, whenever the launch restored something that is not a
+note. The restored tab is read from `localStorage` because the vault path is not available
+synchronously in the renderer, and the key with the newest `savedAt` wins. A machine with
+several vaults can therefore name a note from a vault the app is not opening: the
+speculative chunk prefetch is then wasted, and the mark never fires. Absent is the correct
+reading in that case, not a failure, but it does mean a median over launches must state
+how many runs carried the mark.

--- a/scripts/launch-bench.mjs
+++ b/scripts/launch-bench.mjs
@@ -21,6 +21,13 @@ const QUIT_DEADLINE_MS = 20_000
 const CDP_DEADLINE_MS = 30_000
 const LOG_DEADLINE_MS = 45_000
 const FCP_DEADLINE_MS = 30_000
+// The note-readable mark lands well after FCP (vault open, note query, editor
+// mount all sit between them) and is absent entirely on a launch that restored
+// no note (home tab, no prior session). It gets its own bounded wait rather
+// than reusing FCP_DEADLINE_MS: 8s is already 5x the epic's 1.5s target, so
+// waiting longer would only delay the harness, never turn a real hit into
+// more truth. Timing out reports the metric absent, not zero.
+const NOTE_READABLE_DEADLINE_MS = 8_000
 const CDP_POLL_MS = 250
 const LOG_POLL_MS = 100
 
@@ -55,7 +62,12 @@ export const METRICS = [
     read: (run) => run.renderer?.domContentLoadedMs,
     tier3Only: false
   },
-  { key: 'cdp_attach_offset_ms', read: (run) => run.cdpAttachOffsetMs, tier3Only: false }
+  { key: 'cdp_attach_offset_ms', read: (run) => run.cdpAttachOffsetMs, tier3Only: false },
+  {
+    key: 'renderer_note_readable_ms',
+    read: (run) => run.renderer?.noteReadableMs,
+    tier3Only: false
+  }
 ]
 
 const REFUSAL_NOTE = 'refused: not tier 3 (packaged)'
@@ -461,6 +473,22 @@ const FCP_PRESENT_EXPRESSION = `performance
   .getEntriesByType('paint')
   .some((entry) => entry.name === 'first-contentful-paint')`
 
+// Mirrors NOTE_READABLE_MARK in
+// apps/desktop/src/renderer/src/lib/launch-restore.ts. Not importable here —
+// that module resolves through the renderer's `@/` alias and is TypeScript —
+// so the literal is pinned in both places; keep them in sync.
+const NOTE_READABLE_MARK = 'memry:note-readable'
+
+const NOTE_READABLE_PRESENT_EXPRESSION = `performance
+  .getEntriesByName(${JSON.stringify(NOTE_READABLE_MARK)})
+  .length > 0`
+
+const NOTE_READABLE_METRIC_EXPRESSION = `(() => {
+  const round = (value) => (typeof value === 'number' ? Math.round(value * 1000) / 1000 : undefined)
+  const entry = performance.getEntriesByName(${JSON.stringify(NOTE_READABLE_MARK)})[0]
+  return round(entry?.startTime)
+})()`
+
 const RENDERER_METRICS_EXPRESSION = `(() => {
   const round = (value) => (typeof value === 'number' ? Math.round(value * 1000) / 1000 : undefined)
   const navigation = performance.getEntriesByType('navigation')[0]
@@ -474,6 +502,30 @@ const RENDERER_METRICS_EXPRESSION = `(() => {
     loadEventMs: round(navigation?.loadEventEnd)
   }
 })()`
+
+// Bounded poll for a mark that may legitimately never land (no note was
+// restored) or land well after FCP. Times out to `undefined` rather than 0 or
+// hanging — an absent mark must read as absent, not as a fast note.
+async function readNoteReadableMs(client) {
+  const deadline = Date.now() + NOTE_READABLE_DEADLINE_MS
+  while (Date.now() < deadline) {
+    const seen = await client.send('Runtime.evaluate', {
+      expression: NOTE_READABLE_PRESENT_EXPRESSION,
+      returnByValue: true
+    })
+    if (seen.result?.value === true) {
+      break
+    }
+    await delay(CDP_POLL_MS)
+  }
+
+  const evaluated = await client.send('Runtime.evaluate', {
+    expression: NOTE_READABLE_METRIC_EXPRESSION,
+    returnByValue: true
+  })
+
+  return evaluated.result?.value
+}
 
 async function readRendererMetrics(webSocketDebuggerUrl) {
   const client = await connectCdp(webSocketDebuggerUrl)
@@ -502,7 +554,9 @@ async function readRendererMetrics(webSocketDebuggerUrl) {
       returnByValue: true
     })
 
-    return evaluated.result?.value ?? {}
+    const noteReadableMs = await readNoteReadableMs(client)
+
+    return { ...(evaluated.result?.value ?? {}), noteReadableMs }
   } finally {
     client.close()
   }

--- a/scripts/launch-bench.test.mjs
+++ b/scripts/launch-bench.test.mjs
@@ -153,9 +153,27 @@ describe('summarize', () => {
         'renderer_fcp_ms',
         'renderer_dom_interactive_ms',
         'renderer_dom_content_loaded_ms',
-        'cdp_attach_offset_ms'
+        'cdp_attach_offset_ms',
+        'renderer_note_readable_ms'
       ]
     )
+  })
+
+  it('reports renderer_note_readable_ms absent, not zero, when no note was restored', () => {
+    const summary = summarize([makeRun(1, 'packaged', 0), makeRun(2, 'packaged', 100)])
+    const noteReadable = summary.find((row) => row.key === 'renderer_note_readable_ms')
+
+    assert.equal(noteReadable.median, null)
+  })
+
+  it('reports renderer_note_readable_ms when the mark landed', () => {
+    const runs = [makeRun(1, 'packaged', 0), makeRun(2, 'packaged', 100)]
+    runs[0].renderer.noteReadableMs = 900
+    runs[1].renderer.noteReadableMs = 1000
+    const summary = summarize(runs)
+    const noteReadable = summary.find((row) => row.key === 'renderer_note_readable_ms')
+
+    assert.equal(noteReadable.median, 950)
   })
 })
 


### PR DESCRIPTION
## Summary

Two things, and they are separable:

1. **A measurement that did not exist.** `renderer/src/lib/launch-restore.ts` stamps `performance.mark('memry:note-readable')` when the note a launch restored has actually rendered its block tree, and `scripts/launch-bench.mjs` reports it as `renderer_note_readable_ms`. #2001's definition of done asks for "last-active note readable, a number that exists and is <= 1.5 s from the click", and until now there was no trustworthy number at all.
2. **A speculative prefetch.** The 17 inline `React.lazy` imports in `tab-content.tsx` are refactored into one `pageLoaders` registry, which also backs a new `prefetchPageModule(key)`. `main.tsx` calls `prefetchRestoredTabPage()` at module scope, before `boot()` starts awaiting anything, so the restored tab's chunk download overlaps i18n, vault open and tab restore instead of queueing behind them.

### Where the mark is placed, and why it matters

Not on component mount, and not on `ContentArea`'s CRDT-ready gate — that only proves the binding *started*. It hangs off BlockNote's existing `onEditorReady`, the same "the block tree is real" signal the mind map and attachments dialog already trust. It is guarded on `editor` being non-null (so a teardown call does not count) and on the note id equalling `LAUNCH_NOTE_ID`, and it is idempotent. A mark at the wrong moment produces a confident wrong number, which is worse than no number.

## Release note

none

## Test plan

`pnpm lint` 0, `pnpm typecheck` 0, `pnpm --filter @memry/desktop test:renderer` green at **727 files, 8962 passed**, `node --test scripts/launch-bench.test.mjs` 0, `pnpm docs:impact --base perf/renderer-manual-chunks --strict` 0, `pnpm docs:build` 0.

New unit tests cover `readRestoredActiveTab()` across multi-vault keys, malformed JSON, a missing `activeGroupId`, the legacy global key and a missing active tab id; plus `markLaunchNoteReadable` idempotence and its note-id equality guard. `localStorage` is cleared in `beforeEach`/`afterEach`, because renderer tests do not clear it between files.

### The number, and its honest sample size

**`renderer_note_readable_ms` = 646 ms and 666 ms** on the reference machine, tier 3, against a real vault whose restored tab was a note.

Derived click-to-readable, using `(click_to_shown − shown) + window_created + note_readable`: **≈ 1.3 s, inside the 1.5 s target.**

**n=2, not 20**, and that is worth explaining rather than hiding. Partway through benchmarking, the reference vault's restored tab became a canvas. The mark only fires for a restored *note*, so 19 subsequent runs reported it absent — correctly. Inspecting `localStorage` found three vault tab-states:

| vault | savedAt | active tab |
| --- | ---: | --- |
| `…/MemryNote1000` | 1788424981417 | note |
| `…/MemryNote` | **1788538499330** (newest) | **canvas** |
| `…/dotfiles/Kaan` | 1788532594546 | note |

The newest wins, and it is a canvas. The metric was right; the vault simply had no note to restore.

### The prefetch is unproven, and this PR does not claim it

Two builds were made differing by **exactly one function call** — the `prefetchRestoredTabPage()` invocation — both carrying the instrumentation. Interleaved A/B, 20 runs per arm:

| metric | no prefetch | prefetch | delta | verdict |
| --- | ---: | ---: | ---: | --- |
| `click_to_shown_ms` | 844.0 | 835.0 | −9.0 | noise (IQR 61) |
| `shown_ms` | 349.5 | 341.5 | −8.0 | noise (IQR 33) |
| `renderer_fcp_ms` | 272.0 | 272.0 | 0.0 | noise (IQR 60) |
| `renderer_first_paint_ms` | 160.0 | 152.0 | −8.0 | noise (IQR 16) |
| `renderer_note_readable_ms` | absent | absent | — | vault restored a canvas |

**The prefetch could not be isolated on the metric it exists to move**, for the same vault-state reason. On every shared metric it is noise. So the instrumentation is the part that is done; the prefetch is a plausible, cheap, unproven addition.

`ContentArea` still blocks on CRDT-ready regardless of when the chunk arrives, so the prefetch's ceiling is "chunk fetch time minus vault-open-to-CRDT-ready time", likely small on a warm disk. **Falsification:** re-run the same one-call A/B on a vault whose restored tab is a note, 20+ runs per arm. If `renderer_note_readable_ms` does not move by more than ~1.5× its own IQR, drop the prefetch and keep the instrumentation.

### A limitation in the restore heuristic, stated plainly

The restored tab is read from `localStorage`, not asked over IPC, because the vault path is not available synchronously in the renderer — asking would reinstate the round-trip #2007 just removed from that spot. With several vaults, the newest `savedAt` can name a note from a vault the app is not opening. Consequences, both benign: the prefetch fetches one chunk it will not use, and the mark never fires, so the metric reads absent rather than wrong.

Fixing it properly wants the vault path in the preload via a synchronous startup channel, the pattern #2007 established. That is a follow-up, not this PR.

**Any median over launches must therefore state how many runs carried the mark.** That is now documented in `apps/docs/src/architecture/observability.md`.

### Not verified

No E2E run. The prefetch's wrong-guess cost is reasoned and unit-tested, not observed in a packaged app. `rendererLoadedMs` is still absent from the launch timeline in every run, because `window_did_finish_load` is never marked before reveal — untouched here.

Closes #2012
