### PR TITLE
fix(sync): keep mobile edits flowing while the app is open

### DIFF
--- a/apps/desktop/src/main/sync/websocket.ts
+++ b/apps/desktop/src/main/sync/websocket.ts
@@ -1,4 +1,5 @@
 import WebSocket from 'ws'
+import { SYNC_SOCKET_MESSAGE_TYPES } from '@memry/contracts/sync-socket'
 import { SyncEventEmitter } from '@memry/sync-client/emitter'
 import { z } from 'zod'
 import { createLogger } from '../lib/logger'
@@ -23,16 +24,7 @@ const HTTP_UPGRADE_REQUIRED = 426
 const MAX_WEBSOCKET_MANAGER_LISTENERS = 10
 
 const WebSocketMessageSchema = z.object({
-  type: z.enum([
-    'changes_available',
-    'crdt_updated',
-    'calendar_changes_available',
-    'heartbeat',
-    'auth_ok',
-    'error',
-    'linking_request',
-    'linking_approved'
-  ]),
+  type: z.enum(SYNC_SOCKET_MESSAGE_TYPES),
   payload: z.record(z.string(), z.unknown()).optional()
 })
 

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -1443,6 +1443,28 @@ it at start and detaches it at stop. A refresh that lands after a vault switch o
 renews nothing instead of reaching into a torn-down socket and CRDT queue, and the runtime that
 replaces it installs its own hook.
 
+### The message contract, and the mobile client
+
+The socket's message names, the keepalive string, the close codes and a parser live in
+`packages/contracts/src/sync-socket.ts`. Desktop imports the name list; mobile parses against the
+same module. An unrecognised `type` parses successfully and is then ignored rather than failing the
+frame, so a server that starts sending a new message cannot break a client that shipped before it.
+
+Mobile is a second implementation rather than a port, because React Native's WebSocket is not the
+same object as `ws`. It has no `terminate()`, no ping/pong events and no `unexpected-response`, so a
+rejected handshake surfaces as a bare error and a synthetic 1006 close with the HTTP status nowhere
+in reach. The mobile client therefore probes the same URL over plain HTTP after a connect that never
+opened, and reads the real status and error code from there. Headers are the only auth channel; RN's
+third constructor argument carries them, and `X-App-Version` goes on the wire without its `+build`
+suffix, because the server's version comparison parses `2+318` as `NaN` and would pass the gate by
+accident. `X-Memry-Vault-Id` is equally required in practice: the Durable Object filters every
+broadcast by the socket's attached vault, so a socket without it connects and then hears nothing.
+
+Mobile does not pin certificates (see below) and relies on the OS trust store. It connects on the
+foreground and online edges and closes the socket **deliberately** when the app backgrounds, so a
+close the OS delivers while suspending the process cannot arm the reconnect backoff and spend the
+handshake budget, which is 15 per 60 seconds keyed by user and shared across all their devices.
+
 ### Certificate pinning on the socket
 
 A `wss://` socket connects through a pinned `https.Agent`. One agent is shared for the process

--- a/apps/mobile/src/app/(vault)/_layout.tsx
+++ b/apps/mobile/src/app/(vault)/_layout.tsx
@@ -13,6 +13,7 @@ import {
   setBackgroundSyncVault,
   wireForegroundSync
 } from '@/sync/background'
+import { startSyncSocket, stopSyncSocket } from '@/sync/socket-controller'
 import { getEditorSession } from '@/editor/session'
 import { getSyncEngine } from '@/sync/engine'
 import { runFirstSyncIfNeeded, type FirstSyncProgress } from '@/sync/first-sync'
@@ -56,6 +57,7 @@ export default function VaultLayout() {
       setBackgroundSyncVault(vaultId)
       wireForegroundSync()
       void registerBackgroundSync()
+      startSyncSocket(vaultId)
 
       try {
         setSyncing(true)
@@ -86,6 +88,13 @@ export default function VaultLayout() {
     })()
     return () => {
       cancelled = true
+      // Three things already leak here (two NetInfo subscriptions and the
+      // engine registry, none of which have a removal path), so the socket
+      // gets an explicit stop rather than becoming a fourth. Clearing the
+      // background vault with it is what stops the 15-minute task syncing the
+      // last vault forever after a sign-out.
+      stopSyncSocket()
+      setBackgroundSyncVault(null)
     }
   }, [attempt])
 

--- a/apps/mobile/src/app/(vault)/_layout.tsx
+++ b/apps/mobile/src/app/(vault)/_layout.tsx
@@ -13,7 +13,7 @@ import {
   setBackgroundSyncVault,
   wireForegroundSync
 } from '@/sync/background'
-import { startSyncSocket, stopSyncSocket } from '@/sync/socket-controller'
+import { shutdownSyncSocket, startSyncSocket } from '@/sync/socket-controller'
 import { getEditorSession } from '@/editor/session'
 import { getSyncEngine } from '@/sync/engine'
 import { runFirstSyncIfNeeded, type FirstSyncProgress } from '@/sync/first-sync'
@@ -93,7 +93,7 @@ export default function VaultLayout() {
       // gets an explicit stop rather than becoming a fourth. Clearing the
       // background vault with it is what stops the 15-minute task syncing the
       // last vault forever after a sign-out.
-      stopSyncSocket()
+      shutdownSyncSocket()
       setBackgroundSyncVault(null)
     }
   }, [attempt])

--- a/apps/mobile/src/editor/doc-manager.ts
+++ b/apps/mobile/src/editor/doc-manager.ts
@@ -251,6 +251,19 @@ export class EditorDocManager {
     return this.open.has(docId)
   }
 
+  /**
+   * The docs held in memory right now, most-recently-opened last.
+   *
+   * A pull pass needs these: a remote edit to a note the user has open writes
+   * no record row when only the body changed, so the change feed never names
+   * it and the only other way to hear about it is the socket. Reading the map
+   * through an accessor keeps `open` private and the LRU ordering an
+   * implementation detail.
+   */
+  openDocIds(): string[] {
+    return [...this.open.keys()]
+  }
+
   /** Feed newly-pulled server rows into whichever docs are open. */
   async refreshOpenDocs(docIds: string[]): Promise<void> {
     for (const docId of docIds) {

--- a/apps/mobile/src/editor/session.ts
+++ b/apps/mobile/src/editor/session.ts
@@ -194,6 +194,24 @@ export interface EditorSession {
 
 const sessions = new Map<string, Promise<EditorSession>>()
 
+/**
+ * The docs held open right now, or none when this vault has no session yet.
+ *
+ * Deliberately does NOT build one. The caller is the pull pass, and building a
+ * session opens the DB, reads the keychain and constructs the outbox and the
+ * attachment transfer — work a pull has no reason to trigger, on a vault the
+ * user may not even have opened an editor in.
+ */
+export async function openDocIdsFor(vaultId: string): Promise<string[]> {
+  const pending = sessions.get(vaultId)
+  if (!pending) return []
+  try {
+    return (await pending).docs.openDocIds()
+  } catch {
+    return []
+  }
+}
+
 export function getEditorSession(vaultId: string): Promise<EditorSession> {
   let pending = sessions.get(vaultId)
   if (!pending) {

--- a/apps/mobile/src/editor/session.ts
+++ b/apps/mobile/src/editor/session.ts
@@ -212,6 +212,20 @@ export async function openDocIdsFor(vaultId: string): Promise<string[]> {
   }
 }
 
+/**
+ * Feed newly-pulled server rows to the open docs, if this vault has a session.
+ *
+ * Same no-build rule as `openDocIdsFor`. The caller is the socket handler, and
+ * a `crdt_updated` for a vault whose editor was never opened has nothing on
+ * screen to refresh.
+ */
+export async function refreshOpenDocsFor(vaultId: string, docIds: string[]): Promise<void> {
+  const pending = sessions.get(vaultId)
+  if (!pending) return
+  const session = await pending
+  await session.docs.refreshOpenDocs(docIds)
+}
+
 export function getEditorSession(vaultId: string): Promise<EditorSession> {
   let pending = sessions.get(vaultId)
   if (!pending) {

--- a/apps/mobile/src/editor/session.ts
+++ b/apps/mobile/src/editor/session.ts
@@ -25,6 +25,8 @@ import { EditorDocManager, type DocHalves, type DocStore } from './doc-manager'
 const log = createLogger('EditorSession')
 
 const LOCAL_PREFIX = 'local.'
+/** Coalesce local outbox writes before a foreground push. */
+const LOCAL_SYNC_INTERVAL_MS = 300
 
 /**
  * The doc store over the two CRDT namespaces.
@@ -262,7 +264,25 @@ async function build(vaultId: string): Promise<EditorSession> {
     })
   }
 
-  const outbox = new OutboxStore(db)
+  let localSyncTimer: ReturnType<typeof setTimeout> | null = null
+  let flushSession: (() => Promise<void>) | null = null
+
+  const scheduleLocalSync = (): void => {
+    if (flushSession === null || localSyncTimer !== null) return
+    localSyncTimer = setTimeout(() => {
+      localSyncTimer = null
+      const run = flushSession?.()
+      if (run) {
+        void run.catch((err) => {
+          log.warn('Foreground outbox drain failed', {
+            error: err instanceof Error ? err.message : String(err)
+          })
+        })
+      }
+    }, LOCAL_SYNC_INTERVAL_MS)
+  }
+
+  const outbox = new OutboxStore(db, scheduleLocalSync)
   const docs = new EditorDocManager(createVaultDocStore(db), outbox)
 
   const http = createMobileHttpClient(syncBaseUrl())
@@ -338,6 +358,25 @@ async function build(vaultId: string): Promise<EditorSession> {
     isMetered: () => http.isMetered()
   })
 
+  const flush = async (): Promise<void> => {
+    await refreshSecrets()
+    const result = await drain.drain()
+    // One retry after a token refresh: an expired access token is the single
+    // most common reason a first drain of the day fails, and it is fixable
+    // without waiting out a backoff the user would experience as lost work.
+    if (result.failed > 0 && !result.parked) {
+      const fresh = await refreshSession()
+      if (fresh) {
+        accessToken = fresh
+        // Only the rows that just failed: the rest of the queue keeps the
+        // backoff it earned, or one refresh would disable it table-wide.
+        if (result.failedIds.length > 0) await outbox.clearBackoff(result.failedIds)
+        await drain.drain()
+      }
+    }
+  }
+  flushSession = flush
+
   return {
     vaultId,
     db,
@@ -368,25 +407,13 @@ async function build(vaultId: string): Promise<EditorSession> {
       keypair = null
       accessToken = ''
       locked = true
+      flushSession = null
+      if (localSyncTimer) {
+        clearTimeout(localSyncTimer)
+        localSyncTimer = null
+      }
       docs.closeAll()
     },
-
-    async flush() {
-      await refreshSecrets()
-      const result = await drain.drain()
-      // One retry after a token refresh: an expired access token is the single
-      // most common reason a first drain of the day fails, and it is fixable
-      // without waiting out a backoff the user would experience as lost work.
-      if (result.failed > 0 && !result.parked) {
-        const fresh = await refreshSession()
-        if (fresh) {
-          accessToken = fresh
-          // Only the rows that just failed: the rest of the queue keeps the
-          // backoff it earned, or one refresh would disable it table-wide.
-          if (result.failedIds.length > 0) await outbox.clearBackoff(result.failedIds)
-          await drain.drain()
-        }
-      }
-    }
+    flush
   }
 }

--- a/apps/mobile/src/features/notes/note-ops.ts
+++ b/apps/mobile/src/features/notes/note-ops.ts
@@ -30,14 +30,16 @@ export interface NotePayload {
   properties?: Record<string, unknown>
   clock?: Record<string, number>
   /**
-   * Epoch ms from this app, an ISO string from desktop.
+   * An ISO string on the wire; epoch ms still turns up in rows written by
+   * older builds of this app.
    *
-   * `NoteSyncPayloadSchema` declares both of these `z.string()` and desktop's
-   * `buildSnapshotPayload` pushes the ISO form, while `createNote` below writes
-   * `Date.now()`. Both shapes are live in the same table on the same device, so
-   * the union is the truth and narrowing it to `number` only moved the failure
-   * to whoever compared one against a number and got `false` forever. Read them
-   * through `toEpochMs`.
+   * This app used to WRITE `Date.now()` here, which `NoteSyncPayloadSchema`
+   * declared `z.string()`. Every note edited on a phone therefore failed
+   * `safeParse` on the desktop and was skipped without retry — the edit looked
+   * synced here and reached no other device. New writes use the ISO form; the
+   * union stays because the old rows are still on disk and on the server, and
+   * narrowing it would only move the failure to whoever compared one against a
+   * number and got `false` forever. Read them through `toEpochMs`.
    */
   createdAt?: number | string
   modifiedAt?: number | string
@@ -168,7 +170,7 @@ export async function updateNote(
 
   mutate(payload)
   const now = Date.now()
-  payload.modifiedAt = now
+  payload.modifiedAt = new Date(now).toISOString()
   bumpClock(payload as Record<string, unknown>, ctx.deviceId)
   const serialized = JSON.stringify(payload)
 
@@ -222,8 +224,8 @@ export async function createNote(
     tags: [],
     properties: {},
     folderPath: input.folderPath ?? null,
-    createdAt: now,
-    modifiedAt: now
+    createdAt: new Date(now).toISOString(),
+    modifiedAt: new Date(now).toISOString()
   }
   bumpClock(payload as Record<string, unknown>, ctx.deviceId)
 
@@ -348,8 +350,8 @@ export async function duplicateNote(
     folderPath:
       opts.folderPath === undefined ? (source.folderPath ?? null) : opts.folderPath || null,
     content: body?.markdown ?? source.content ?? '',
-    createdAt: now,
-    modifiedAt: now
+    createdAt: new Date(now).toISOString(),
+    modifiedAt: new Date(now).toISOString()
   }
   // The copy is a NEW item: the source's vector clock describes a different
   // id's history, and carrying it over would make the first real edit look

--- a/apps/mobile/src/sync/__tests__/convergence.test.ts
+++ b/apps/mobile/src/sync/__tests__/convergence.test.ts
@@ -8,6 +8,7 @@ import {
   type SyncPushCryptoProvider
 } from '@memry/sync-client/push'
 import { EditorDocManager, type DocHalves, type DocStore } from '../../editor/doc-manager'
+import { bodyPullTargets } from '../body-pull-targets'
 import { bumpClock } from '../outbox'
 import { nodeCryptoProvider, Relay } from './relay'
 
@@ -345,5 +346,74 @@ describe('(c) unknown-field round-trip', () => {
     expect(backOnDesktop.title).toBe('Quarterly plan (edited on the phone)')
     // The clock advanced for the editing device without discarding the other's.
     expect(backOnDesktop.clock).toEqual({ [desktop.id]: 3, [mobile.id]: 1 })
+  })
+})
+
+describe('(d) a peer edits only the body of a note this device has open', () => {
+  it('fetches the body even though the change feed names no note', async () => {
+    const relay = new Relay()
+    const noteId = 'note-open-on-the-phone'
+
+    // Both devices already share the note. The phone has it OPEN, which is the
+    // case that matters: the user is looking at the screen the edit belongs to.
+    const base = seedParagraph('shared opening line')
+    const baseUpdate = Y.encodeStateAsUpdate(base)
+
+    const store = memoryStore()
+    store.server.push(baseUpdate)
+    const manager = new EditorDocManager(store, {
+      enqueueCrdtUpdate: async () => {}
+    })
+    const open = await manager.openDoc(noteId)
+
+    // The desktop types into the BODY and nothing else. No title, no folder,
+    // no tags — so it pushes a CRDT update and NO record row, which is exactly
+    // what the server stores and exactly what makes this invisible to the feed.
+    const desktopDoc = new Y.Doc()
+    Y.applyUpdate(desktopDoc, baseUpdate)
+    const beforeEdit = Y.encodeStateVector(desktopDoc)
+    appendParagraph(desktopDoc, 'typed on the desktop')
+    relay.pushCrdt(
+      noteId,
+      encryptCrdtUpdatePacked(
+        crypto,
+        Y.encodeStateAsUpdate(desktopDoc, beforeEdit),
+        vaultKey,
+        noteId,
+        desktop.keys.privateKey
+      ),
+      desktop.id
+    )
+
+    // --- the mobile pull pass ----------------------------------------------
+    // Phase one, the record feed. `collectChangedNoteIds` derives the changed
+    // notes from record rows, and there are none, so this is empty. Asserted
+    // rather than assumed: it is the precondition the whole bug rests on.
+    const changedNoteIds = relay
+      .changesSince(0)
+      .filter((row) => row.type === 'note')
+      .map((row) => row.id)
+    expect(changedNoteIds).toEqual([])
+
+    // Phase two, the bodies. This is the line under test.
+    const targets = bodyPullTargets(changedNoteIds, manager.openDocIds())
+
+    for (const target of targets) {
+      for (const row of relay.crdtSince(target, 0)) {
+        open.applyFromRemote(
+          await decryptCrdtUpdatePacked(
+            crypto,
+            row.packed,
+            vaultKey,
+            target,
+            desktop.keys.publicKey
+          )
+        )
+      }
+    }
+
+    expect(targets).toEqual([noteId])
+    expect(textOf(open.doc)).toContain('typed on the desktop')
+    expect(textOf(open.doc)).toContain('shared opening line')
   })
 })

--- a/apps/mobile/src/sync/__tests__/engine-body-pull.test.ts
+++ b/apps/mobile/src/sync/__tests__/engine-body-pull.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The `runSync` call site, not the helper it calls.
+ *
+ * `convergence.test.ts` proves `bodyPullTargets` computes the right union and
+ * that a body pulled for an open note decrypts and merges. It cannot prove the
+ * sync pass ASKS for that union, because it calls the helper itself. Replacing
+ * the whole fix with `const targets = [...record.changedNoteIds]` leaves that
+ * file green, which makes it a test of the helper rather than of the bug.
+ *
+ * This drives the real `MobileSyncEngine.runSync`. The mocks are the modules
+ * that reach native — `@react-native-community/netinfo` is imported at module
+ * scope by the http client, expo-sqlite by the db, expo-secure-store by the
+ * keychain — plus the two pull engines, which are the seam the assertion reads.
+ * Everything between the record pull and the body pull is the shipped code.
+ */
+
+const state = vi.hoisted(() => ({
+  changedNoteIds: [] as string[],
+  openDocIds: [] as string[],
+  pullBodiesCalls: [] as string[][]
+}))
+
+vi.mock('@react-native-community/netinfo', () => ({
+  default: {
+    addEventListener: () => () => {},
+    fetch: async () => ({ isConnected: true, isInternetReachable: true })
+  }
+}))
+
+vi.mock('@memry/sync-client/pull', () => ({
+  buildClientHeaderValue: () => 'ios/1.0.0',
+  seamJsonRequest: async () => ({ devices: [] }),
+  RecordPullEngine: class {
+    async pullIncremental() {
+      return { ok: true, itemsApplied: 0, changedNoteIds: state.changedNoteIds }
+    }
+    async fetchStatus() {
+      return null
+    }
+  },
+  CrdtBodyPuller: class {
+    async pullBodies(noteIds: string[]) {
+      state.pullBodiesCalls.push([...noteIds])
+      return { notesUpdated: noteIds.length }
+    }
+  }
+}))
+
+vi.mock('../../adapters/http-client', () => ({
+  createMobileHttpClient: () => ({
+    request: async () => ({ status: 200, headers: {}, body: new Uint8Array() }),
+    onOnlineChanged: () => () => {},
+    isMetered: async () => false
+  })
+}))
+vi.mock('../../adapters/runtime', () => ({ mobileAppVersion: () => '1.0.0' }))
+vi.mock('../../db/index', () => ({ openVaultDb: async () => ({}) }))
+vi.mock('../../db/pull-store', () => ({ MobilePullStore: class {} }))
+vi.mock('../../lib/secure-store', () => ({ getVaultKey: async () => new Uint8Array(32) }))
+vi.mock('../auth-client', () => ({
+  loadSession: async () => ({ accessToken: 'access-token' }),
+  refreshSession: async () => 'access-token'
+}))
+vi.mock('../crypto-provider', () => ({ createMobileCryptoProvider: () => ({}) }))
+vi.mock('../sync-state', () => ({ recordSyncOutcome: async () => {} }))
+vi.mock('../note-materializer', () => ({ materializeNoteBody: async () => {} }))
+
+// The registry lookup is stubbed, not the union. What is under test is whether
+// the pass consults the open docs at all, so the assertion has to be able to
+// see an open note without standing up a whole editor session.
+vi.mock('../../editor/session', () => ({ openDocIdsFor: async () => state.openDocIds }))
+
+const { MobileSyncEngine } = await import('../engine')
+
+beforeEach(() => {
+  state.changedNoteIds = []
+  state.openDocIds = []
+  state.pullBodiesCalls = []
+})
+
+describe('the body-pull set a sync pass asks for', () => {
+  it('includes an open note the record feed never named', async () => {
+    // A peer edited only the body, so the change feed carries no record row for
+    // it. This is the precondition the whole defect rests on.
+    state.changedNoteIds = []
+    state.openDocIds = ['note-open-on-the-phone']
+
+    const summary = await new MobileSyncEngine('vault-1').sync()
+
+    expect(state.pullBodiesCalls).toEqual([['note-open-on-the-phone']])
+    // And it is reported, or the editor showing that note keeps painting the
+    // old text even though the new body is now on disk.
+    expect(summary.changedNoteIds).toEqual(['note-open-on-the-phone'])
+  })
+
+  it('is the union of the feed and the open docs, deduplicated', async () => {
+    state.changedNoteIds = ['note-from-feed', 'note-both']
+    state.openDocIds = ['note-both', 'note-open']
+
+    await new MobileSyncEngine('vault-2').sync()
+
+    expect(state.pullBodiesCalls).toEqual([['note-from-feed', 'note-both', 'note-open']])
+  })
+
+  it('asks for nothing when the feed is empty and no doc is open', async () => {
+    state.changedNoteIds = []
+    state.openDocIds = []
+
+    await new MobileSyncEngine('vault-3').sync()
+
+    // An empty set short-circuits before the puller is constructed, so "no
+    // call" is the correct observation rather than a call with no ids.
+    expect(state.pullBodiesCalls).toEqual([])
+  })
+})

--- a/apps/mobile/src/sync/__tests__/outbox-drain.test.ts
+++ b/apps/mobile/src/sync/__tests__/outbox-drain.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 import sodium from 'libsodium-wrappers-sumo'
 import type { SyncHttpClient } from '@memry/sync-client/adapters'
 import type { SeamHttpContext } from '@memry/sync-client/pull'
@@ -101,7 +101,12 @@ function transport(handler: (path: string, body: unknown) => unknown | FakeRespo
   return { http, seen }
 }
 
-function drain(store: OutboxQueue, http?: SyncHttpClient) {
+interface SecretOverrides {
+  vaultKey?: Uint8Array | null
+  signingSecretKey?: Uint8Array | null
+}
+
+function drain(store: OutboxQueue, http?: SyncHttpClient, secrets: SecretOverrides = {}) {
   const httpCtx = () =>
     ({
       // Cases that settle their rows BEFORE any request pass no transport at
@@ -116,8 +121,9 @@ function drain(store: OutboxQueue, http?: SyncHttpClient) {
     store,
     httpCtx,
     crypto,
-    vaultKey: () => vaultKey,
-    signingSecretKey: () => signingSecretKey,
+    vaultKey: () => (secrets.vaultKey === undefined ? vaultKey : secrets.vaultKey),
+    signingSecretKey: () =>
+      secrets.signingSecretKey === undefined ? signingSecretKey : secrets.signingSecretKey,
     deviceId: () => 'device-a',
     isOnline: () => true
   })
@@ -131,6 +137,45 @@ describe('backoffDelayMs', () => {
     // Capped: an item that has failed twenty times must not schedule itself
     // hours out, because the user is still looking at an unsynced note.
     expect(backoffDelayMs(50)).toBeLessThanOrEqual(5 * 60_000 + 5_000)
+  })
+})
+
+describe('OutboxDrain with a push secret missing', () => {
+  /**
+   * The state this pins is the expensive one: a device that holds the vault key
+   * but not the signing key PULLS perfectly and looks healthy, while never
+   * pushing a single row. The old code returned from here without logging, so
+   * the only way to see it was to query the server and notice the device had
+   * written nothing, ever.
+   */
+  it('says which secret is missing instead of returning silently', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { store, completed, failed } = queue([row()])
+
+    const result = await drain(store, undefined, { signingSecretKey: null }).drain()
+
+    expect(result.pushed).toBe(0)
+    // Queued, not dropped and not failed — the row is still owed a push.
+    expect(completed).toHaveLength(0)
+    expect(failed).toHaveLength(0)
+    expect(result.remaining).toBe(1)
+
+    const [message, context] = warn.mock.calls.at(-1)?.slice(1) ?? []
+    expect(message).toContain('push secret is missing')
+    expect(context).toMatchObject({ hasVaultKey: true, hasSigningKey: false, remaining: 1 })
+    warn.mockRestore()
+  })
+
+  it('stays quiet when there is nothing queued to push', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { store } = queue([])
+
+    await drain(store, undefined, { signingSecretKey: null }).drain()
+
+    // An unlinked device idles here on every tick; warning each time would bury
+    // the case that matters under noise.
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
   })
 })
 

--- a/apps/mobile/src/sync/__tests__/outbox-store.test.ts
+++ b/apps/mobile/src/sync/__tests__/outbox-store.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { VaultDb } from '../../db/index'
+import { OutboxStore } from '../outbox'
+
+function fakeDb() {
+  const events: string[] = []
+  const db = {
+    runAsync: vi.fn(async () => {
+      events.push('write')
+      return { changes: 1, lastInsertRowId: 1 }
+    })
+  } as unknown as VaultDb
+  return { db, events }
+}
+
+describe('OutboxStore enqueue notifications', () => {
+  it('notifies after a record write is queued', async () => {
+    const { db, events } = fakeDb()
+    const notify = vi.fn(() => events.push('notify'))
+    const store = new OutboxStore(db, notify)
+
+    await store.enqueueRecord('note', 'note-1', 'update', '{}')
+
+    expect(events).toEqual(['write', 'write', 'notify'])
+    expect(notify).toHaveBeenCalledOnce()
+  })
+
+  it('notifies after a CRDT write is queued', async () => {
+    const { db, events } = fakeDb()
+    const notify = vi.fn(() => events.push('notify'))
+    const store = new OutboxStore(db, notify)
+
+    await store.enqueueCrdtUpdate('note-1', new Uint8Array([1]))
+
+    expect(events).toEqual(['write', 'notify'])
+    expect(notify).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/mobile/src/sync/__tests__/request-sync.test.ts
+++ b/apps/mobile/src/sync/__tests__/request-sync.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { requestSync, type SyncReason, type SyncTriggerDeps } from '../request-sync'
+
+function trigger(overrides: Partial<SyncTriggerDeps> = {}) {
+  const calls: string[] = []
+  const deps: SyncTriggerDeps = {
+    drain: async () => {
+      calls.push('drain')
+    },
+    sync: async () => {
+      calls.push('sync')
+    },
+    isReadOnly: () => false,
+    ...overrides
+  }
+  return { deps, calls }
+}
+
+describe('requestSync', () => {
+  it('drives BOTH a push and a pull for a socket broadcast', async () => {
+    const t = trigger()
+    await requestSync(t.deps, 'vault-1', 'socket')
+    // The bug this collapses: the app could sit in the foreground with eight
+    // queued rows at attempt_count 0 while nothing pushed and nothing pulled.
+    expect(t.calls).toEqual(['drain', 'sync'])
+  })
+
+  it('pushes before it pulls', async () => {
+    const order: string[] = []
+    const t = trigger({
+      drain: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        order.push('drain')
+      },
+      sync: async () => {
+        order.push('sync')
+      }
+    })
+    await requestSync(t.deps, 'vault-1', 'app-foreground')
+    // An edit made offline should leave the device before a pull can hand the
+    // user a stale-looking screen.
+    expect(order).toEqual(['drain', 'sync'])
+  })
+
+  it('keeps each reason doing what its old call site did', async () => {
+    const expected: Record<SyncReason, string[]> = {
+      'app-foreground': ['drain', 'sync'],
+      'background-task': ['drain', 'sync'],
+      'app-background': ['drain'],
+      online: ['drain'],
+      socket: ['drain', 'sync']
+    }
+    for (const [reason, calls] of Object.entries(expected)) {
+      const t = trigger()
+      await requestSync(t.deps, 'vault-1', reason as SyncReason)
+      expect(t.calls, reason).toEqual(calls)
+    }
+  })
+
+  it('passes the vault id through', async () => {
+    const seen: string[] = []
+    const t = trigger({
+      drain: async (vaultId) => {
+        seen.push(vaultId)
+      },
+      sync: async (vaultId) => {
+        seen.push(vaultId)
+      }
+    })
+    await requestSync(t.deps, 'vault-9', 'socket')
+    expect(seen).toEqual(['vault-9', 'vault-9'])
+  })
+})
+
+describe('read-only mode', () => {
+  it('skips the socket drain while the outbox is parked', async () => {
+    const t = trigger({ isReadOnly: () => true })
+    await requestSync(t.deps, 'vault-1', 'socket')
+    // The drain parks itself and logs one line per pass, which is one line per
+    // broadcast once a socket is driving it.
+    expect(t.calls).toEqual(['sync'])
+  })
+
+  it('still drains on the app-state edges, which are rare', async () => {
+    const t = trigger({ isReadOnly: () => true })
+    await requestSync(t.deps, 'vault-1', 'app-background')
+    expect(t.calls).toEqual(['drain'])
+  })
+})
+
+describe('failures', () => {
+  it('still pulls when the push fails', async () => {
+    const t = trigger({
+      drain: async () => {
+        throw new Error('offline')
+      }
+    })
+    await expect(requestSync(t.deps, 'vault-1', 'socket')).resolves.toBeUndefined()
+    expect(t.calls).toEqual(['sync'])
+  })
+
+  it('swallows a failing pull rather than rejecting into a listener', async () => {
+    const t = trigger({
+      sync: async () => {
+        throw new Error('server down')
+      }
+    })
+    // These run inside AppState listeners and socket handlers, where a
+    // rejection is an unhandled rejection.
+    await expect(requestSync(t.deps, 'vault-1', 'app-foreground')).resolves.toBeUndefined()
+    expect(t.calls).toEqual(['drain'])
+  })
+})

--- a/apps/mobile/src/sync/__tests__/socket.test.ts
+++ b/apps/mobile/src/sync/__tests__/socket.test.ts
@@ -5,7 +5,6 @@ import {
   PING_INTERVAL_MS,
   SOCKET_OPEN,
   WATCHDOG_MS,
-  type HandshakeProbeResult,
   type SocketLike,
   type SyncSocketDeps
 } from '../socket'
@@ -60,14 +59,20 @@ interface Harness {
   events: SyncSocketEvent[]
   opens: number
   refreshes: number
-  probes: string[]
+  fetches: number
 }
 
-function harness(overrides: Partial<SyncSocketDeps> = {}, probe?: HandshakeProbeResult): Harness {
+function harness(overrides: Partial<SyncSocketDeps> = {}): Harness {
   const sockets: FakeSocket[] = []
   const events: SyncSocketEvent[] = []
-  const probes: string[] = []
-  const state = { opens: 0, refreshes: 0 }
+  const state = { opens: 0, refreshes: 0, fetches: 0 }
+  // A rejected handshake must not send anything over HTTP. `/sync/ws` answers
+  // a plain GET with 426 before it reaches the Durable Object, so a probe
+  // would read "version incompatible" off every dropped connection.
+  vi.stubGlobal('fetch', () => {
+    state.fetches++
+    return Promise.reject(new Error('no HTTP calls expected from the socket'))
+  })
 
   const deps: SyncSocketDeps = {
     baseUrl: 'https://sync-staging.memrynote.com',
@@ -89,10 +94,6 @@ function harness(overrides: Partial<SyncSocketDeps> = {}, probe?: HandshakeProbe
       sockets.push(created)
       return created
     },
-    probeHandshake: async (url) => {
-      probes.push(url)
-      return probe ?? null
-    },
     // Jitter out, so a backoff assertion is about the curve and not the dice.
     random: () => 0,
     ...overrides
@@ -103,12 +104,14 @@ function harness(overrides: Partial<SyncSocketDeps> = {}, probe?: HandshakeProbe
     socket,
     sockets,
     events,
-    probes,
     get opens() {
       return state.opens
     },
     get refreshes() {
       return state.refreshes
+    },
+    get fetches() {
+      return state.fetches
     }
   }
 }
@@ -125,7 +128,10 @@ async function connected(h: Harness): Promise<FakeSocket> {
 }
 
 beforeEach(() => vi.useFakeTimers())
-afterEach(() => vi.useRealTimers())
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
 
 describe('handshake', () => {
   it('sends auth, a build-free version and the vault id as headers', async () => {
@@ -338,7 +344,7 @@ describe('close codes', () => {
     expect(h.sockets).toHaveLength(2)
   })
 
-  it('lets the replacement win after 4001 rather than trading places with it', async () => {
+  it('backs off after 4001 rather than immediately replacing the replacement', async () => {
     const h = harness()
     const live = await connected(h)
     live.serverClose(4001, 'Replaced by new connection')
@@ -350,48 +356,73 @@ describe('close codes', () => {
 })
 
 describe('rejected handshake', () => {
-  it('probes over plain HTTP, because RN surfaces no status', async () => {
-    const h = harness({}, { status: 426, code: 'SYNC_VERSION_INCOMPATIBLE' })
-    h.socket.start()
-    await settle()
-    // Never opened, so the 1006 is a rejected handshake wearing a network error.
-    h.sockets[0].serverClose(1006)
-    await settle()
-
-    expect(h.probes).toEqual(['https://sync-staging.memrynote.com/sync/ws'])
-    await vi.advanceTimersByTimeAsync(10 * 60_000)
-    expect(h.sockets).toHaveLength(1)
-  })
-
-  it('does not probe a socket that had opened', async () => {
+  it('backs off and NEVER latches, whatever the reason was', async () => {
     const h = harness()
-    const live = await connected(h)
-    live.serverClose(1006)
-    await settle()
-    expect(h.probes).toEqual([])
-  })
-
-  it('refreshes the token when the probe says 401', async () => {
-    const h = harness({}, { status: 401, code: 'AUTH_INVALID_TOKEN' })
     h.socket.start()
     await settle()
+    // React Native reports a refused handshake as a bare error and a synthetic
+    // 1006 with no HTTP status anywhere in reach.
     h.sockets[0].serverClose(1006)
     await settle()
-    expect(h.refreshes).toBe(1)
+
+    // No HTTP probe. `/sync/ws` answers any request without an
+    // `Upgrade: websocket` header with 426 VALIDATION_ERROR before the Durable
+    // Object ever sees it, so reading that status at face value would latch
+    // real-time sync off for the process on the first flaky network.
+    expect(h.fetches).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(h.sockets).toHaveLength(2)
+    h.sockets[1].serverClose(1006)
+    await settle()
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(h.sockets).toHaveLength(3)
+  })
+
+  it('recovers from a handshake that neither opens nor closes', async () => {
+    const h = harness()
+    h.socket.start()
+    await settle()
+    expect(h.sockets).toHaveLength(1)
+
+    // RN imposes no connect timeout of its own, so without a watchdog armed at
+    // creation the manager parks in 'connecting' with no socket and no timer.
+    await vi.advanceTimersByTimeAsync(WATCHDOG_MS)
     await vi.advanceTimersByTimeAsync(1_000)
     expect(h.sockets).toHaveLength(2)
   })
+})
 
-  it('latches off when the probe says the device is revoked', async () => {
-    // The Durable Object answers 403 before the upgrade, so a revoked device
-    // never reaches the 4004 close at all.
-    const h = harness({}, { status: 403, code: 'AUTH_DEVICE_REVOKED' })
+describe('start while backing off', () => {
+  it('does not jump an armed backoff', async () => {
+    const h = harness()
+    const live = await connected(h)
+    live.serverClose(4008)
+    await settle()
+
+    // A foreground edge and an online transition both call start(). Cancelling
+    // the timer here is how a rate-limited client walks straight back into the
+    // 15-per-60-seconds ceiling it shares with the user's other devices.
+    h.socket.start()
     h.socket.start()
     await settle()
-    h.sockets[0].serverClose(1006)
-    await settle()
-    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    await vi.advanceTimersByTimeAsync(29_999)
     expect(h.sockets).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(h.sockets).toHaveLength(2)
+  })
+
+  it('still connects immediately after a deliberate stop', async () => {
+    const h = harness()
+    const live = await connected(h)
+    live.serverClose(4008)
+    await settle()
+    // stop() clears the timer and the attempt count, so a background/foreground
+    // cycle is not punished for a backoff that belonged to the old socket.
+    h.socket.stop()
+    h.socket.start()
+    await settle()
+    expect(h.sockets).toHaveLength(2)
   })
 })
 

--- a/apps/mobile/src/sync/__tests__/socket.test.ts
+++ b/apps/mobile/src/sync/__tests__/socket.test.ts
@@ -1,0 +1,462 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SyncSocketEvent } from '@memry/contracts/sync-socket'
+import {
+  MobileSyncSocket,
+  PING_INTERVAL_MS,
+  SOCKET_OPEN,
+  WATCHDOG_MS,
+  type HandshakeProbeResult,
+  type SocketLike,
+  type SyncSocketDeps
+} from '../socket'
+
+/**
+ * A fake at the WebSocket seam.
+ *
+ * React Native's WebSocket cannot be constructed under node, and the whole
+ * point of the manager taking `createSocket` is that everything above the
+ * constructor is testable without a device. What is faked is one class; the
+ * frame parsing, the state machine, the cadence and the backoff are shipped
+ * code.
+ */
+class FakeSocket implements SocketLike {
+  readyState = SOCKET_OPEN
+  sent: string[] = []
+  closedWith: { code?: number; reason?: string }[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onerror: ((event: unknown) => void) | null = null
+  onclose: ((event: { code?: number; reason?: string }) => void) | null = null
+
+  constructor(
+    readonly url: string,
+    readonly headers: Record<string, string>
+  ) {}
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closedWith.push({ code, reason })
+  }
+
+  open(): void {
+    this.onopen?.()
+  }
+
+  deliver(payload: unknown): void {
+    this.onmessage?.({ data: typeof payload === 'string' ? payload : JSON.stringify(payload) })
+  }
+
+  serverClose(code?: number, reason?: string): void {
+    this.onclose?.({ code, reason })
+  }
+}
+
+interface Harness {
+  socket: MobileSyncSocket
+  sockets: FakeSocket[]
+  events: SyncSocketEvent[]
+  opens: number
+  refreshes: number
+  probes: string[]
+}
+
+function harness(overrides: Partial<SyncSocketDeps> = {}, probe?: HandshakeProbeResult): Harness {
+  const sockets: FakeSocket[] = []
+  const events: SyncSocketEvent[] = []
+  const probes: string[] = []
+  const state = { opens: 0, refreshes: 0 }
+
+  const deps: SyncSocketDeps = {
+    baseUrl: 'https://sync-staging.memrynote.com',
+    getAccessToken: async () => 'jwt-token',
+    refreshAccessToken: async () => {
+      state.refreshes++
+      return 'fresh-token'
+    },
+    getVaultId: () => 'vault-1',
+    getAppVersion: () => '1.4.2+318',
+    isOnline: () => true,
+    log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    onEvent: (event) => events.push(event),
+    onOpen: () => {
+      state.opens++
+    },
+    createSocket: (url, headers) => {
+      const created = new FakeSocket(url, headers)
+      sockets.push(created)
+      return created
+    },
+    probeHandshake: async (url) => {
+      probes.push(url)
+      return probe ?? null
+    },
+    // Jitter out, so a backoff assertion is about the curve and not the dice.
+    random: () => 0,
+    ...overrides
+  }
+
+  const socket = new MobileSyncSocket(deps)
+  return {
+    socket,
+    sockets,
+    events,
+    probes,
+    get opens() {
+      return state.opens
+    },
+    get refreshes() {
+      return state.refreshes
+    }
+  }
+}
+
+/** Let the token read and any probe settle without moving the clock. */
+const settle = (): Promise<void> => vi.advanceTimersByTimeAsync(0).then(() => undefined)
+
+async function connected(h: Harness): Promise<FakeSocket> {
+  h.socket.start()
+  await settle()
+  const live = h.sockets[h.sockets.length - 1]
+  live.open()
+  return live
+}
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+describe('handshake', () => {
+  it('sends auth, a build-free version and the vault id as headers', async () => {
+    const h = harness()
+    const live = await connected(h)
+
+    expect(live.url).toBe('wss://sync-staging.memrynote.com/sync/ws')
+    expect(live.headers).toEqual({
+      Authorization: 'Bearer jwt-token',
+      // The server runs Number('2+318') -> NaN comparing versions, which makes
+      // the gate pass by accident. The build half never goes on the wire.
+      'X-App-Version': '1.4.2',
+      // Omitting this leaves the socket connected and permanently deaf: the
+      // Durable Object filters broadcasts by the socket's attached vault.
+      'X-Memry-Vault-Id': 'vault-1'
+    })
+  })
+
+  it('waits instead of connecting when offline, with no vault, or with no token', async () => {
+    for (const override of [
+      { isOnline: () => false },
+      { getVaultId: () => null },
+      { getAccessToken: async () => null }
+    ] satisfies Partial<SyncSocketDeps>[]) {
+      const h = harness(override)
+      h.socket.start()
+      await settle()
+      expect(h.sockets).toHaveLength(0)
+      // Armed, not abandoned. Returning bare here is what latches real-time
+      // sync off for a whole session.
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(h.socket.connected).toBe(false)
+    }
+  })
+})
+
+describe('message routing', () => {
+  it('hands the caller the frames it can act on', async () => {
+    const h = harness()
+    const live = await connected(h)
+
+    live.deliver({ type: 'changes_available', payload: { cursor: 7, vaultId: 'vault-1' } })
+    live.deliver({ type: 'crdt_updated', payload: { vaultId: 'vault-1', noteId: 'note-9' } })
+
+    expect(h.events).toEqual([
+      { kind: 'changes_available', cursor: 7, vaultId: 'vault-1' },
+      { kind: 'crdt_updated', vaultId: 'vault-1', noteId: 'note-9' }
+    ])
+  })
+
+  it('drops the keepalive answer, the unhandled types and anything unknown', async () => {
+    const h = harness()
+    const live = await connected(h)
+
+    live.deliver('pong')
+    live.deliver({ type: 'calendar_changes_available', payload: {} })
+    live.deliver({ type: 'linking_request', payload: {} })
+    live.deliver({ type: 'from_a_newer_server', payload: { anything: 1 } })
+    live.deliver('not json at all')
+    live.deliver({ type: 'crdt_updated', payload: {} })
+
+    expect(h.events).toEqual([])
+    expect(h.socket.connected).toBe(true)
+  })
+
+  it('reports every successful open so the caller can catch up', async () => {
+    const h = harness()
+    const live = await connected(h)
+    expect(h.opens).toBe(1)
+
+    live.serverClose(1006)
+    await vi.advanceTimersByTimeAsync(1_000)
+    h.sockets[1].open()
+    // Each reconnect brackets a window of broadcasts nobody heard, so every
+    // open has to trigger a catch-up, not just the first.
+    expect(h.opens).toBe(2)
+  })
+})
+
+describe('keepalive', () => {
+  it('sends exactly the string Cloudflare auto-answers, every 25 s', async () => {
+    const h = harness()
+    const live = await connected(h)
+
+    await vi.advanceTimersByTimeAsync(PING_INTERVAL_MS - 1)
+    expect(live.sent).toEqual([])
+
+    // Cloudflare answers this one payload from the hibernation auto-response
+    // without waking the Durable Object, and that answer is also what keeps
+    // the 31 s watchdog from tearing the socket down between beats.
+    for (let beat = 0; beat < 3; beat++) {
+      await vi.advanceTimersByTimeAsync(beat === 0 ? 1 : PING_INTERVAL_MS)
+      live.deliver('pong')
+    }
+    // Any other payload wakes the Durable Object on every beat and spends the
+    // socket's inbound rate-limit budget.
+    expect(live.sent).toEqual(['ping', 'ping', 'ping'])
+    expect(h.socket.connected).toBe(true)
+  })
+
+  it('never sends on a socket that is not open', async () => {
+    const h = harness()
+    const live = await connected(h)
+    live.readyState = 0
+    await vi.advanceTimersByTimeAsync(PING_INTERVAL_MS)
+    // send() throws INVALID_STATE_ERR while CONNECTING, so the guard is load
+    // bearing rather than defensive.
+    expect(live.sent).toEqual([])
+  })
+
+  it('reconnects when nothing arrives for 31 s, and any frame defers that', async () => {
+    const h = harness()
+    const live = await connected(h)
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_MS - 1_000)
+    live.deliver('pong')
+    await vi.advanceTimersByTimeAsync(WATCHDOG_MS - 1)
+    expect(h.sockets).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(h.socket.connected).toBe(false)
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(h.sockets).toHaveLength(2)
+  })
+})
+
+describe('backoff', () => {
+  it('doubles per attempt and stops at 30 s', async () => {
+    const h = harness()
+    h.socket.start()
+    await settle()
+
+    const delays = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000]
+    for (const [index, delay] of delays.entries()) {
+      h.sockets[index].serverClose(1006)
+      await settle()
+      await vi.advanceTimersByTimeAsync(delay - 1)
+      expect(h.sockets).toHaveLength(index + 1)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(h.sockets).toHaveLength(index + 2)
+    }
+  })
+
+  it('resets to the floor after a successful open', async () => {
+    const h = harness()
+    h.socket.start()
+    await settle()
+    h.sockets[0].serverClose(1006)
+    await settle()
+    await vi.advanceTimersByTimeAsync(1_000)
+    h.sockets[1].serverClose(1006)
+    await settle()
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    h.sockets[2].open()
+    h.sockets[2].serverClose(1006)
+    await settle()
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(h.sockets).toHaveLength(4)
+  })
+
+  it('jumps to the ceiling when the server says rate limited', async () => {
+    const h = harness()
+    const live = await connected(h)
+    // The handshake limit is 15 per 60 s keyed by USER, shared with every
+    // other device that person owns.
+    live.serverClose(4008)
+    await settle()
+    await vi.advanceTimersByTimeAsync(29_999)
+    expect(h.sockets).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(h.sockets).toHaveLength(2)
+  })
+})
+
+describe('close codes', () => {
+  it('never reconnects after 4004 device revoked', async () => {
+    const h = harness()
+    const live = await connected(h)
+    live.serverClose(4004, 'Device revoked')
+    await settle()
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    h.socket.start()
+    await settle()
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    expect(h.sockets).toHaveLength(1)
+  })
+
+  it('never reconnects after 4009 version incompatible', async () => {
+    const h = harness()
+    const live = await connected(h)
+    live.serverClose(4009, 'App update required')
+    await settle()
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    h.socket.start()
+    await settle()
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    expect(h.sockets).toHaveLength(1)
+  })
+
+  it('refreshes the session then reconnects after 4003 token expired', async () => {
+    const h = harness()
+    const live = await connected(h)
+    live.serverClose(4003)
+    await settle()
+    expect(h.refreshes).toBe(1)
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(h.sockets).toHaveLength(2)
+  })
+
+  it('lets the replacement win after 4001 rather than trading places with it', async () => {
+    const h = harness()
+    const live = await connected(h)
+    live.serverClose(4001, 'Replaced by new connection')
+    await settle()
+    expect(h.sockets).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(h.sockets).toHaveLength(2)
+  })
+})
+
+describe('rejected handshake', () => {
+  it('probes over plain HTTP, because RN surfaces no status', async () => {
+    const h = harness({}, { status: 426, code: 'SYNC_VERSION_INCOMPATIBLE' })
+    h.socket.start()
+    await settle()
+    // Never opened, so the 1006 is a rejected handshake wearing a network error.
+    h.sockets[0].serverClose(1006)
+    await settle()
+
+    expect(h.probes).toEqual(['https://sync-staging.memrynote.com/sync/ws'])
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    expect(h.sockets).toHaveLength(1)
+  })
+
+  it('does not probe a socket that had opened', async () => {
+    const h = harness()
+    const live = await connected(h)
+    live.serverClose(1006)
+    await settle()
+    expect(h.probes).toEqual([])
+  })
+
+  it('refreshes the token when the probe says 401', async () => {
+    const h = harness({}, { status: 401, code: 'AUTH_INVALID_TOKEN' })
+    h.socket.start()
+    await settle()
+    h.sockets[0].serverClose(1006)
+    await settle()
+    expect(h.refreshes).toBe(1)
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(h.sockets).toHaveLength(2)
+  })
+
+  it('latches off when the probe says the device is revoked', async () => {
+    // The Durable Object answers 403 before the upgrade, so a revoked device
+    // never reaches the 4004 close at all.
+    const h = harness({}, { status: 403, code: 'AUTH_DEVICE_REVOKED' })
+    h.socket.start()
+    await settle()
+    h.sockets[0].serverClose(1006)
+    await settle()
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    expect(h.sockets).toHaveLength(1)
+  })
+})
+
+describe('stop', () => {
+  it('closes the socket and ignores everything it emits afterwards', async () => {
+    const h = harness()
+    const live = await connected(h)
+    h.socket.stop()
+
+    expect(live.closedWith).toEqual([{ code: 1000, reason: 'client teardown' }])
+    // A dead socket can sit in CLOSING until the OS times out; whatever it
+    // emits from there belongs to a connection nobody is listening to.
+    live.serverClose(1006)
+    live.deliver({ type: 'changes_available', payload: { cursor: 1 } })
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    expect(h.events).toEqual([])
+    expect(h.sockets).toHaveLength(1)
+    expect(h.socket.connected).toBe(false)
+  })
+
+  it('stops the keepalive', async () => {
+    const h = harness()
+    const live = await connected(h)
+    h.socket.stop()
+    await vi.advanceTimersByTimeAsync(PING_INTERVAL_MS * 3)
+    expect(live.sent).toEqual([])
+  })
+
+  it('drops a connect that was in flight when the app backgrounded', async () => {
+    let release: (token: string) => void = () => {}
+    const h = harness({
+      getAccessToken: () => new Promise<string>((resolve) => (release = resolve))
+    })
+    h.socket.start()
+    h.socket.stop()
+    release('jwt-token')
+    await settle()
+    expect(h.sockets).toHaveLength(0)
+  })
+
+  it('reconnects on a later start', async () => {
+    const h = harness()
+    await connected(h)
+    h.socket.stop()
+    h.socket.start()
+    await settle()
+    h.sockets[1].open()
+    expect(h.socket.connected).toBe(true)
+  })
+})
+
+describe('refreshAuth', () => {
+  it('extends the live socket in place', async () => {
+    const h = harness()
+    const live = await connected(h)
+    h.socket.refreshAuth('fresh-token')
+    expect(live.sent.map((raw) => JSON.parse(raw))).toEqual([
+      { type: 'auth', payload: { token: 'fresh-token' } }
+    ])
+  })
+
+  it('is a no-op with no live socket', async () => {
+    const h = harness()
+    h.socket.refreshAuth('fresh-token')
+    await settle()
+    expect(h.sockets).toHaveLength(0)
+  })
+})

--- a/apps/mobile/src/sync/background.ts
+++ b/apps/mobile/src/sync/background.ts
@@ -1,11 +1,11 @@
 import * as BackgroundTask from 'expo-background-task'
 import * as TaskManager from 'expo-task-manager'
 import { AppState } from 'react-native'
-import { getEditorSession } from '../editor/session'
 import { createLogger } from '../lib/logger'
 import { createMobileHttpClient } from '../adapters/http-client'
-import { getSyncEngine } from './engine'
 import { syncBaseUrl } from './server-config'
+import { startSyncSocket, stopSyncSocket } from './socket-controller'
+import { requestVaultSync } from './triggers'
 
 const log = createLogger('BackgroundSync')
 
@@ -17,6 +17,8 @@ export function setBackgroundSyncVault(vaultId: string | null): void {
   activeVaultId = vaultId
 }
 
+export { drainOutbox } from './triggers'
+
 /**
  * T052: foreground sync triggers + BGAppRefreshTask via expo-background-task.
  * The task is resumable and interruptible by construction: each pull page is
@@ -26,15 +28,8 @@ export function setBackgroundSyncVault(vaultId: string | null): void {
 TaskManager.defineTask(TASK_NAME, async () => {
   if (!activeVaultId) return BackgroundTask.BackgroundTaskResult.Success
   try {
-    // Push before pull: the queued edits are the only data that exists nowhere
-    // else, and a background window the OS cuts short should spend itself on
-    // those rather than on refreshing what is already safe on the server.
-    await drainOutbox(activeVaultId)
-    const summary = await getSyncEngine(activeVaultId).sync()
-    log.info('Background sync pass finished', {
-      ok: summary.ok,
-      itemsApplied: summary.itemsApplied
-    })
+    await requestVaultSync(activeVaultId, 'background-task')
+    log.info('Background sync pass finished')
     return BackgroundTask.BackgroundTaskResult.Success
   } catch (err) {
     log.warn('Background sync pass failed', {
@@ -57,31 +52,17 @@ export async function registerBackgroundSync(minIntervalMinutes = 15): Promise<v
   }
 }
 
-/**
- * Drain the write queue (T063/T076). Failures are logged, never thrown: a
- * drain that rejects into an AppState listener is an unhandled rejection, and
- * the rows it could not send are still queued for the next pass.
- */
-export async function drainOutbox(vaultId: string): Promise<void> {
-  try {
-    const session = await getEditorSession(vaultId)
-    await session.flush()
-  } catch (err) {
-    log.warn('Outbox drain failed', {
-      error: err instanceof Error ? err.message : String(err)
-    })
-  }
-}
-
 let foregroundWired = false
 
 /**
- * App-state transitions drive both directions of sync.
+ * App-state transitions drive both directions of sync, and the socket's
+ * lifetime with them.
  *
- * Foreground: drain first, then pull — an edit made offline should leave the
- * device before the pull has a chance to hand the user a stale-looking screen.
- * Background: drain only, and immediately, because iOS may suspend the process
- * at any point after the transition (contract rule 5).
+ * The socket is the live loop; these edges are what start and stop it. It is
+ * closed DELIBERATELY on the way out, because a close the OS delivers when it
+ * suspends the process is indistinguishable from a network failure, and the
+ * manager would arm its backoff and burn handshake attempts against a shared
+ * per-user budget on an app nobody is looking at.
  */
 export function wireForegroundSync(): void {
   if (foregroundWired) return
@@ -94,13 +75,11 @@ export function wireForegroundSync(): void {
       return
     }
     if (next === 'active' && previous !== 'active') {
-      void drainOutbox(vaultId).then(() =>
-        getSyncEngine(vaultId)
-          .sync()
-          .catch(() => {})
-      )
+      startSyncSocket(vaultId)
+      void requestVaultSync(vaultId, 'app-foreground')
     } else if (next !== 'active' && previous === 'active') {
-      void drainOutbox(vaultId)
+      stopSyncSocket()
+      void requestVaultSync(vaultId, 'app-background')
     }
     previous = next
   })
@@ -129,16 +108,14 @@ let onlineDrainWired = false
 function wireOnlineDrain(): void {
   if (onlineDrainWired) return
   onlineDrainWired = true
-  let draining = false
   createMobileHttpClient(syncBaseUrl()).onOnlineChanged((online) => {
     const vaultId = activeVaultId
-    // `draining` is not an optimisation: the switch and NetInfo can both emit
-    // for one transition, and two concurrent drains would send the same rows
-    // twice and race each other's deletes.
-    if (!online || !vaultId || draining) return
-    draining = true
-    void drainOutbox(vaultId).finally(() => {
-      draining = false
-    })
+    if (!online || !vaultId) return
+    // Two concurrent drains would send the same rows twice, and the switch and
+    // NetInfo can both emit for one transition. `OutboxDrain` coalesces them
+    // itself with a running pass plus at most one trailing pass, which is why
+    // the local `draining` flag this used to keep is gone.
+    startSyncSocket(vaultId)
+    void requestVaultSync(vaultId, 'online')
   })
 }

--- a/apps/mobile/src/sync/body-pull-targets.ts
+++ b/apps/mobile/src/sync/body-pull-targets.ts
@@ -1,0 +1,11 @@
+/**
+ * Which note bodies a pull pass has to fetch.
+ *
+ * Note bodies do not travel in the record change feed. The feed carries record
+ * rows, and a body-only edit writes no record row at all, so the pass learns
+ * about it from exactly two places: the `crdt_updated` socket broadcast, and
+ * this set.
+ */
+export function bodyPullTargets(changedNoteIds: readonly string[]): string[] {
+  return [...new Set(changedNoteIds)]
+}

--- a/apps/mobile/src/sync/body-pull-targets.ts
+++ b/apps/mobile/src/sync/body-pull-targets.ts
@@ -2,10 +2,20 @@
  * Which note bodies a pull pass has to fetch.
  *
  * Note bodies do not travel in the record change feed. The feed carries record
- * rows, and a body-only edit writes no record row at all, so the pass learns
- * about it from exactly two places: the `crdt_updated` socket broadcast, and
- * this set.
+ * rows, and a body-only edit writes no record row at all, so `changedNoteIds`
+ * names nothing and the pass used to ask for nothing. A peer typing into a
+ * note this device already has on screen was simply invisible.
+ *
+ * The open docs are the union's second half, and they are the heal path. The
+ * `crdt_updated` socket broadcast is what makes a body-only edit arrive
+ * promptly, but a socket that was down over the edit missed the broadcast for
+ * good. Re-asking for the open notes on every pass makes a dropped
+ * socket a latency problem rather than a correctness one. The set is bounded
+ * by the doc manager's LRU cap, so this is a handful of ids, not the vault.
  */
-export function bodyPullTargets(changedNoteIds: readonly string[]): string[] {
-  return [...new Set(changedNoteIds)]
+export function bodyPullTargets(
+  changedNoteIds: readonly string[],
+  openNoteIds: readonly string[]
+): string[] {
+  return [...new Set([...changedNoteIds, ...openNoteIds])]
 }

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -179,10 +179,8 @@ export class MobileSyncEngine {
       return { ok: false, reason: 'error', itemsApplied: 0, bodiesUpdated: 0, changedNoteIds: [] }
     }
 
-    const bodies = await this.pullBodiesForUnlocked(
-      store,
-      bodyPullTargets(record.changedNoteIds, await openDocIdsFor(this.vaultId))
-    )
+    const targets = bodyPullTargets(record.changedNoteIds, await openDocIdsFor(this.vaultId))
+    const bodies = await this.pullBodiesForUnlocked(store, targets)
     await this.pollStatus(engine)
 
     const summary: SyncSummary = {
@@ -190,7 +188,7 @@ export class MobileSyncEngine {
       reason: record.ok ? null : 'refused',
       itemsApplied: record.itemsApplied,
       bodiesUpdated: bodies,
-      changedNoteIds: record.changedNoteIds
+      changedNoteIds: targets
     }
     await recordSyncOutcome(this.vaultId, { ok: summary.ok, reason: summary.reason })
     for (const listener of this.listeners) listener(summary)
@@ -263,11 +261,18 @@ export interface SyncSummary {
   itemsApplied: number
   bodiesUpdated: number
   /**
-   * Notes whose CRDT state this pass touched.
+   * Notes whose CRDT state this pass asked the server about.
    *
    * Carried out of the engine so an OPEN editor can be fed the new rows; the
    * doc manager caches docs for the process lifetime, so a pull that lands
    * server updates is otherwise invisible until the app restarts.
+   *
+   * This is the same union the pass pulled bodies for, not just the notes the
+   * record feed named. Halving it was the on-screen half of the body-only bug:
+   * the heal path would fetch a peer's edit into SQLite and the editor showing
+   * that very note would keep painting the old text until it was reopened.
+   * Refreshing a doc with no new server rows is a no-op, so the wider set costs
+   * nothing.
    */
   changedNoteIds: string[]
 }

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -12,6 +12,7 @@ import { createMobileHttpClient } from '../adapters/http-client'
 import { bodyPullTargets } from './body-pull-targets'
 import { mobileAppVersion } from '../adapters/runtime'
 import { openVaultDb } from '../db/index'
+import { openDocIdsFor } from '../editor/session'
 import { MobilePullStore } from '../db/pull-store'
 import { fromBase64 } from '../crypto/libsodium'
 import { recordSyncOutcome } from './sync-state'
@@ -178,7 +179,10 @@ export class MobileSyncEngine {
       return { ok: false, reason: 'error', itemsApplied: 0, bodiesUpdated: 0, changedNoteIds: [] }
     }
 
-    const bodies = await this.pullBodiesForUnlocked(store, bodyPullTargets(record.changedNoteIds))
+    const bodies = await this.pullBodiesForUnlocked(
+      store,
+      bodyPullTargets(record.changedNoteIds, await openDocIdsFor(this.vaultId))
+    )
     await this.pollStatus(engine)
 
     const summary: SyncSummary = {

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -195,6 +195,24 @@ export class MobileSyncEngine {
     return summary
   }
 
+  /**
+   * Pull specific note bodies, preparing inside the queue.
+   *
+   * The socket path must use this rather than `getStore()` then
+   * `pullBodiesFor`. `prepare()` assigns `vaultKeyCache` and `accessToken`,
+   * and both are handed to the pullers as LIVE getters, so calling it outside
+   * `exclusive()` can null the vault key under a pass that is already running
+   * -- which `pullBodiesForUnlocked` then reports as zero bodies rather than
+   * an error.
+   */
+  pullBodiesForNotes(noteIds: string[]): Promise<number> {
+    return this.exclusive(async () => {
+      const prepared = await this.prepare()
+      if (!prepared) return 0
+      return this.pullBodiesForUnlocked(prepared.store, noteIds)
+    })
+  }
+
   pullBodiesFor(store: MobilePullStore, noteIds: string[]): Promise<number> {
     return this.exclusive(() => this.pullBodiesForUnlocked(store, noteIds))
   }

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -9,6 +9,7 @@ import {
 import { DeviceKeysResponseSchema } from '@memry/contracts/sync-api'
 import type { SyncHttpClient } from '@memry/sync-client/adapters'
 import { createMobileHttpClient } from '../adapters/http-client'
+import { bodyPullTargets } from './body-pull-targets'
 import { mobileAppVersion } from '../adapters/runtime'
 import { openVaultDb } from '../db/index'
 import { MobilePullStore } from '../db/pull-store'
@@ -177,7 +178,7 @@ export class MobileSyncEngine {
       return { ok: false, reason: 'error', itemsApplied: 0, bodiesUpdated: 0, changedNoteIds: [] }
     }
 
-    const bodies = await this.pullBodiesForUnlocked(store, record.changedNoteIds)
+    const bodies = await this.pullBodiesForUnlocked(store, bodyPullTargets(record.changedNoteIds))
     await this.pollStatus(engine)
 
     const summary: SyncSummary = {

--- a/apps/mobile/src/sync/outbox.ts
+++ b/apps/mobile/src/sync/outbox.ts
@@ -340,7 +340,21 @@ export class OutboxDrain {
     const signingSecretKey = this.deps.signingSecretKey()
     if (!vaultKey || !signingSecretKey) {
       // Locked vault: not an error, just nothing we are allowed to encrypt with.
-      return { ...idle, remaining: await store.pendingCount() }
+      //
+      // It has to SAY so. This was the one branch in this method that returned
+      // without a word, and the two secrets fail differently: a pull only needs
+      // the vault key, so a device missing just the signing key pulls forever,
+      // looks healthy, and silently never pushes a single row. That state cost
+      // an afternoon to find from the server side.
+      const remaining = await store.pendingCount()
+      if (remaining > 0) {
+        log.warn('Outbox cannot drain: a push secret is missing', {
+          remaining,
+          hasVaultKey: vaultKey !== null,
+          hasSigningKey: signingSecretKey !== null
+        })
+      }
+      return { ...idle, remaining }
     }
 
     const rows = await store.claimBatch(CLAIM_LIMIT)

--- a/apps/mobile/src/sync/outbox.ts
+++ b/apps/mobile/src/sync/outbox.ts
@@ -57,7 +57,11 @@ export function backoffDelayMs(attemptCount: number): number {
 const encoder = new TextEncoder()
 
 export class OutboxStore {
-  constructor(private readonly db: VaultDb) {}
+  /** Called after a queued row is durable so the owning session can drain it. */
+  constructor(
+    private readonly db: VaultDb,
+    private readonly onEnqueued: () => void = () => {}
+  ) {}
 
   /**
    * Queue a record write. The payload is the FULL item JSON — mobile reads the
@@ -88,6 +92,7 @@ export class OutboxStore {
         Date.now()
       ]
     )
+    this.onEnqueued()
   }
 
   /**
@@ -100,6 +105,7 @@ export class OutboxStore {
       `INSERT INTO outbox (item_type, item_id, op, payload, enqueued_at) VALUES (?, ?, ?, ?, ?)`,
       ['note:crdt', docId, 'crdt-update', update, Date.now()]
     )
+    this.onEnqueued()
   }
 
   async claimBatch(limit: number): Promise<OutboxRow[]> {

--- a/apps/mobile/src/sync/request-sync.ts
+++ b/apps/mobile/src/sync/request-sync.ts
@@ -1,0 +1,76 @@
+import { getReadOnlyState } from './read-only-mode'
+
+/**
+ * The one place that decides what a sync trigger actually does.
+ *
+ * "Drain then pull" used to be written out at each call site and "drain only"
+ * at two more, so every new trigger was a fresh chance to forget half of it,
+ * and none of them were testable — the drain reaches the http client, which
+ * imports `@react-native-community/netinfo` at module scope.
+ */
+
+export type SyncReason =
+  'app-foreground' | 'app-background' | 'background-task' | 'online' | 'socket'
+
+export interface SyncTriggerDeps {
+  drain: (vaultId: string) => Promise<void>
+  sync: (vaultId: string) => Promise<unknown>
+  /** Defaults to the process-global read-only state. */
+  isReadOnly?: () => boolean
+}
+
+interface TriggerPlan {
+  drain: boolean
+  pull: boolean
+  /**
+   * Whether a parked outbox should skip the drain entirely.
+   *
+   * Only the high-frequency trigger sets this. `OutboxDrain` parks itself and
+   * logs one line per pass, which is right for a handful of app-state edges
+   * and wrong for a socket that can deliver a broadcast a second.
+   */
+  quietWhenParked: boolean
+}
+
+/**
+ * A table rather than a chain of ifs, because the interesting content here is
+ * per-reason data, and the difference between "drains" and "also pulls" is the
+ * thing a reader comes to this file to look up.
+ */
+const PLANS: Record<SyncReason, TriggerPlan> = {
+  // Push first, then pull. An edit made offline should leave the device before
+  // a pull has the chance to hand the user a stale-looking screen.
+  'app-foreground': { drain: true, pull: true, quietWhenParked: false },
+  'background-task': { drain: true, pull: true, quietWhenParked: false },
+  // Drain only, and immediately: iOS may suspend the process at any point
+  // after the transition.
+  'app-background': { drain: true, pull: false, quietWhenParked: false },
+  // The engine's own NetInfo handler already pulls on this edge. What nothing
+  // did was PUSH, so edits made offline sat in the queue with attempt_count
+  // still 0 on a device that never left the foreground.
+  online: { drain: true, pull: false, quietWhenParked: false },
+  socket: { drain: true, pull: true, quietWhenParked: true }
+}
+
+/**
+ * Run one trigger. Never throws: these are called from AppState listeners and
+ * socket handlers, where a rejection is an unhandled rejection and the work it
+ * failed to do is still queued for the next pass.
+ */
+export async function requestSync(
+  deps: SyncTriggerDeps,
+  vaultId: string,
+  reason: SyncReason
+): Promise<void> {
+  const plan = PLANS[reason]
+  if (!plan) return
+
+  const readOnly = (deps.isReadOnly ?? (() => getReadOnlyState().readOnly))()
+
+  if (plan.drain && !(plan.quietWhenParked && readOnly)) {
+    await deps.drain(vaultId).catch(() => undefined)
+  }
+  if (plan.pull) {
+    await deps.sync(vaultId).catch(() => undefined)
+  }
+}

--- a/apps/mobile/src/sync/request-sync.ts
+++ b/apps/mobile/src/sync/request-sync.ts
@@ -68,9 +68,23 @@ export async function requestSync(
   const readOnly = (deps.isReadOnly ?? (() => getReadOnlyState().readOnly))()
 
   if (plan.drain && !(plan.quietWhenParked && readOnly)) {
-    await deps.drain(vaultId).catch(() => undefined)
+    await settle(() => deps.drain(vaultId))
   }
   if (plan.pull) {
-    await deps.sync(vaultId).catch(() => undefined)
+    await settle(() => deps.sync(vaultId))
+  }
+}
+
+/**
+ * `.catch()` alone is not enough. `getSyncEngine(id).sync()` can throw
+ * SYNCHRONOUSLY out of the engine constructor, which subscribes to NetInfo,
+ * and every caller here uses `void requestSync(...)` -- so that throw becomes
+ * exactly the unhandled rejection this function promises not to produce.
+ */
+async function settle(task: () => Promise<unknown>): Promise<void> {
+  try {
+    await task()
+  } catch {
+    // Logged by the drain and the engine themselves; the work is still queued.
   }
 }

--- a/apps/mobile/src/sync/socket-controller.ts
+++ b/apps/mobile/src/sync/socket-controller.ts
@@ -34,8 +34,22 @@ const RNWebSocket = WebSocket as unknown as RNWebSocketConstructor
  * the manager stays testable without NetInfo or the keychain.
  */
 
+/**
+ * How long a burst of broadcasts is gathered before it is acted on.
+ *
+ * The server sends one `crdt_updated` per note per accepted push, so a desktop
+ * pushing fifty notes delivers fifty frames. Acting on each one directly meant
+ * fifty single-note HTTP round trips chained behind each other through the
+ * engine's FIFO queue, which is not a coalescer. Imperceptible as latency,
+ * and it turns a batch into one request.
+ */
+const COALESCE_MS = 250
+
 let socket: MobileSyncSocket | null = null
 let activeVaultId: string | null = null
+const pendingNoteIds = new Set<string>()
+let bodyTimer: ReturnType<typeof setTimeout> | null = null
+let passTimer: ReturnType<typeof setTimeout> | null = null
 
 async function currentAccessToken(): Promise<string | null> {
   const session = await loadSession()
@@ -59,12 +73,10 @@ function build(): MobileSyncSocket {
     log,
     createSocket: (url, headers) => new RNWebSocket(url, null, { headers }),
     onOpen: () => {
-      const vaultId = activeVaultId
-      if (!vaultId) return
       // Every reconnect brackets a window in which broadcasts were missed, and
       // a missed `crdt_updated` is gone for good — the server keeps no
       // vault-wide CRDT cursor to ask for it again.
-      void requestVaultSync(vaultId, 'socket')
+      schedulePass()
     },
     onEvent: (event) => {
       const vaultId = activeVaultId
@@ -75,10 +87,10 @@ function build(): MobileSyncSocket {
 
       switch (event.kind) {
         case 'changes_available':
-          void requestVaultSync(vaultId, 'socket')
+          schedulePass()
           return
         case 'crdt_updated':
-          void pullBody(vaultId, event.noteId)
+          scheduleBodyPull(event.noteId)
           return
         case 'error':
           log.warn('Sync socket server error', {
@@ -94,25 +106,50 @@ function build(): MobileSyncSocket {
 }
 
 /**
- * Fetch one note body, then feed it to the editor if that note is open.
+ * Run one full pass, at most one per window.
  *
- * Goes through the engine rather than `CrdtBodyPuller` directly: both engine
- * methods wrap themselves in `exclusive()`, and reaching past them reopens the
- * first-sync cursor wedge, because `runFirstSyncIfNeeded` shares the
- * `sync_cursors` row with `pullIncremental`.
+ * `sync()` and `OutboxDrain.drain()` each coalesce, but `EditorSession.flush`
+ * re-runs its own token refresh per caller, so N concurrent passes were N
+ * `/auth/refresh` posts. One trailing pass per burst removes that fan-out.
  */
-async function pullBody(vaultId: string, noteId: string): Promise<void> {
+function schedulePass(): void {
+  if (passTimer) return
+  passTimer = setTimeout(() => {
+    passTimer = null
+    const vaultId = activeVaultId
+    if (vaultId) void requestVaultSync(vaultId, 'socket')
+  }, COALESCE_MS)
+}
+
+function scheduleBodyPull(noteId: string): void {
+  pendingNoteIds.add(noteId)
+  if (bodyTimer) return
+  bodyTimer = setTimeout(() => {
+    bodyTimer = null
+    const noteIds = [...pendingNoteIds]
+    pendingNoteIds.clear()
+    const vaultId = activeVaultId
+    if (vaultId && noteIds.length > 0) void pullBodies(vaultId, noteIds)
+  }, COALESCE_MS)
+}
+
+/**
+ * Fetch the bodies, then feed them to the editor for whichever notes are open.
+ *
+ * Goes through `pullBodiesForNotes` rather than `getStore()` plus
+ * `pullBodiesFor`. Both wrap themselves in `exclusive()`, but `getStore()`
+ * calls `prepare()` outside it, and `prepare()` reassigns the vault key the
+ * running pass is still reading through a live getter.
+ */
+async function pullBodies(vaultId: string, noteIds: string[]): Promise<void> {
   try {
-    const engine = getSyncEngine(vaultId)
-    const store = await engine.getStore()
-    if (!store) return
-    await engine.pullBodiesFor(store, [noteId])
+    await getSyncEngine(vaultId).pullBodiesForNotes(noteIds)
     // The doc manager caches docs for the process lifetime, so a pull that
     // lands new server rows is invisible on screen until this runs.
-    await refreshOpenDocsFor(vaultId, [noteId])
+    await refreshOpenDocsFor(vaultId, noteIds)
   } catch (err) {
     log.warn('Socket-driven body pull failed', {
-      noteId,
+      notes: noteIds.length,
       error: err instanceof Error ? err.message : String(err)
     })
   }
@@ -136,5 +173,34 @@ export function startSyncSocket(vaultId: string): void {
  * reconnecting a socket the app is not foregrounded to use.
  */
 export function stopSyncSocket(): void {
+  clearTimers()
   socket?.stop()
+}
+
+/**
+ * Tear the socket down for good, dropping the manager itself.
+ *
+ * The distinction from `stopSyncSocket` is the LATCH. 4004 and 4009 are
+ * verdicts about an install and must survive a background/foreground cycle, so
+ * `stop()` keeps them. They must NOT survive a sign-out, or the next account on
+ * this phone inherits a socket that refuses to connect. The vault shell
+ * unmounting is the one event that means "different session", so it is the one
+ * event that discards the instance.
+ */
+export function shutdownSyncSocket(): void {
+  stopSyncSocket()
+  socket = null
+  activeVaultId = null
+}
+
+function clearTimers(): void {
+  if (bodyTimer) {
+    clearTimeout(bodyTimer)
+    bodyTimer = null
+  }
+  if (passTimer) {
+    clearTimeout(passTimer)
+    passTimer = null
+  }
+  pendingNoteIds.clear()
 }

--- a/apps/mobile/src/sync/socket-controller.ts
+++ b/apps/mobile/src/sync/socket-controller.ts
@@ -1,0 +1,140 @@
+import { createMobileHttpClient } from '../adapters/http-client'
+import { mobileAppVersion } from '../adapters/runtime'
+import { refreshOpenDocsFor } from '../editor/session'
+import { createLogger } from '../lib/logger'
+import { loadSession, refreshSession } from './auth-client'
+import { getSyncEngine } from './engine'
+import { MobileSyncSocket, type SocketLike } from './socket'
+import { syncBaseUrl } from './server-config'
+import { requestVaultSync } from './triggers'
+
+const log = createLogger('SyncSocket')
+
+/**
+ * React Native's WebSocket takes a third `options` argument the DOM lib knows
+ * nothing about, and it is the ONLY way to get headers onto the handshake.
+ * Auth on `/sync/ws` is headers or nothing; there is no query param and no
+ * subprotocol. `Libraries/WebSocket/WebSocket.js` in react-native 0.86.2
+ * destructures `options.headers` and hands it to
+ * `NativeWebSocketModule.connect(url, protocols, {headers}, id)`, and it
+ * normalises a non-array `protocols` to null, so both arguments below are as
+ * the runtime wants them.
+ */
+type RNWebSocketConstructor = new (
+  url: string,
+  protocols: string[] | null,
+  options: { headers: Record<string, string> }
+) => SocketLike
+
+const RNWebSocket = WebSocket as unknown as RNWebSocketConstructor
+
+/**
+ * The app's single sync socket, and the only place module singletons meet
+ * `MobileSyncSocket`. Everything the manager itself needs is injected here so
+ * the manager stays testable without NetInfo or the keychain.
+ */
+
+let socket: MobileSyncSocket | null = null
+let activeVaultId: string | null = null
+
+async function currentAccessToken(): Promise<string | null> {
+  const session = await loadSession()
+  return session?.accessToken ?? null
+}
+
+function build(): MobileSyncSocket {
+  const online = createMobileHttpClient(syncBaseUrl())
+  let isOnline = true
+  online.onOnlineChanged((next) => {
+    isOnline = next
+  })
+
+  return new MobileSyncSocket({
+    baseUrl: syncBaseUrl(),
+    getAccessToken: currentAccessToken,
+    refreshAccessToken: () => refreshSession(),
+    getVaultId: () => activeVaultId,
+    getAppVersion: mobileAppVersion,
+    isOnline: () => isOnline,
+    log,
+    createSocket: (url, headers) => new RNWebSocket(url, null, { headers }),
+    onOpen: () => {
+      const vaultId = activeVaultId
+      if (!vaultId) return
+      // Every reconnect brackets a window in which broadcasts were missed, and
+      // a missed `crdt_updated` is gone for good — the server keeps no
+      // vault-wide CRDT cursor to ask for it again.
+      void requestVaultSync(vaultId, 'socket')
+    },
+    onEvent: (event) => {
+      const vaultId = activeVaultId
+      if (!vaultId) return
+      // The Durable Object already filters by the socket's attached vault, so
+      // this only catches a frame in flight across a vault switch.
+      if ('vaultId' in event && event.vaultId && event.vaultId !== vaultId) return
+
+      switch (event.kind) {
+        case 'changes_available':
+          void requestVaultSync(vaultId, 'socket')
+          return
+        case 'crdt_updated':
+          void pullBody(vaultId, event.noteId)
+          return
+        case 'error':
+          log.warn('Sync socket server error', {
+            code: event.code ?? 'unknown',
+            message: event.message ?? ''
+          })
+          return
+        default:
+          return
+      }
+    }
+  })
+}
+
+/**
+ * Fetch one note body, then feed it to the editor if that note is open.
+ *
+ * Goes through the engine rather than `CrdtBodyPuller` directly: both engine
+ * methods wrap themselves in `exclusive()`, and reaching past them reopens the
+ * first-sync cursor wedge, because `runFirstSyncIfNeeded` shares the
+ * `sync_cursors` row with `pullIncremental`.
+ */
+async function pullBody(vaultId: string, noteId: string): Promise<void> {
+  try {
+    const engine = getSyncEngine(vaultId)
+    const store = await engine.getStore()
+    if (!store) return
+    await engine.pullBodiesFor(store, [noteId])
+    // The doc manager caches docs for the process lifetime, so a pull that
+    // lands new server rows is invisible on screen until this runs.
+    await refreshOpenDocsFor(vaultId, [noteId])
+  } catch (err) {
+    log.warn('Socket-driven body pull failed', {
+      noteId,
+      error: err instanceof Error ? err.message : String(err)
+    })
+  }
+}
+
+/** Connect, or reconnect against a different vault. Safe to call repeatedly. */
+export function startSyncSocket(vaultId: string): void {
+  if (socket && activeVaultId !== vaultId) stopSyncSocket()
+  activeVaultId = vaultId
+  socket ??= build()
+  socket.start()
+}
+
+/**
+ * Disconnect deliberately.
+ *
+ * Called on backgrounding as well as teardown. Letting iOS tear the socket
+ * down instead delivers a close indistinguishable from a network failure,
+ * which arms the backoff and then spends the handshake budget -- 15 per 60
+ * seconds, keyed by USER and shared with every other device they own --
+ * reconnecting a socket the app is not foregrounded to use.
+ */
+export function stopSyncSocket(): void {
+  socket?.stop()
+}

--- a/apps/mobile/src/sync/socket.ts
+++ b/apps/mobile/src/sync/socket.ts
@@ -1,0 +1,464 @@
+import {
+  parseSyncSocketFrame,
+  syncSocketAuthFrame,
+  SYNC_SOCKET_CLOSE,
+  SYNC_SOCKET_PING,
+  type SyncSocketEvent
+} from '@memry/contracts/sync-socket'
+import type { SyncLogger } from '@memry/sync-client/adapters'
+
+/**
+ * The phone's half of `GET /sync/ws`.
+ *
+ * Without it the app had no live sync at all: nothing pushed and nothing
+ * pulled while it sat in the foreground, and a body-only edit from another
+ * device had no route to arrive, because `crdt_updated` is broadcast over this
+ * socket and nowhere else.
+ *
+ * Everything it touches is injected. `@react-native-community/netinfo` is
+ * imported at module scope by the http client, which is why the trigger
+ * surface had no tests at all; this file must stay reachable from a plain
+ * node run.
+ */
+
+export const WATCHDOG_MS = 31_000
+export const PING_INTERVAL_MS = 25_000
+export const BASE_RECONNECT_DELAY_MS = 1_000
+export const MAX_RECONNECT_DELAY_MS = 30_000
+export const RECONNECT_JITTER_MS = 500
+
+/**
+ * The backoff attempt a rate-limited close jumps to.
+ *
+ * The handshake limit is 15 per 60 seconds keyed by USER and shared across all
+ * their devices, so a phone that keeps retrying spends a budget its owner's
+ * laptop also needs. 5 puts the next delay at the 30 s ceiling.
+ */
+export const RATE_LIMITED_ATTEMPT = 5
+
+/** `WebSocket.OPEN`. `send()` throws INVALID_STATE_ERR in any other state. */
+export const SOCKET_OPEN = 1
+
+/**
+ * The slice of React Native's WebSocket this manager uses.
+ *
+ * RN has no `terminate()`, no ping/pong events and no 'unexpected-response';
+ * a rejected handshake surfaces as a bare error and a synthetic 1006 close
+ * with the HTTP status nowhere in reach. Narrowing to what actually exists
+ * keeps the desktop manager's shape from being copied in by habit.
+ */
+export interface SocketLike {
+  readyState: number
+  send(data: string): void
+  close(code?: number, reason?: string): void
+  onopen: (() => void) | null
+  onmessage: ((event: { data: unknown }) => void) | null
+  onerror: ((event: unknown) => void) | null
+  onclose: ((event: { code?: number; reason?: string }) => void) | null
+}
+
+export interface HandshakeProbeResult {
+  status: number
+  code?: string
+}
+
+export interface SyncSocketDeps {
+  /** The https sync base url. The ws url and the probe url derive from it. */
+  baseUrl: string
+  getAccessToken: () => Promise<string | null>
+  refreshAccessToken: () => Promise<string | null>
+  getVaultId: () => string | null
+  /** `<semver>` or `<semver>+<build>`; the build half is stripped for the header. */
+  getAppVersion: () => string
+  isOnline: () => boolean
+  log: SyncLogger
+  onEvent: (event: SyncSocketEvent) => void
+  /** Every successful open brackets a window of broadcasts nobody heard. */
+  onOpen: () => void
+  createSocket: (url: string, headers: Record<string, string>) => SocketLike
+  probeHandshake?: (
+    url: string,
+    headers: Record<string, string>
+  ) => Promise<HandshakeProbeResult | null>
+  random?: () => number
+}
+
+/**
+ * Why the manager will never reconnect again this session.
+ *
+ * Both are server verdicts about this install rather than this attempt, so
+ * retrying cannot change the answer and would only spend the shared handshake
+ * budget. Clearing them takes a new app launch, which is the same thing as a
+ * new token or a new binary.
+ */
+type LatchReason = 'device-revoked' | 'version-incompatible'
+
+/**
+ * One state, not the four booleans the desktop manager grew.
+ *
+ * `shouldBeConnected`, `authFailed`, `versionRejected` and `certPinFailed` can
+ * express combinations that mean nothing, and every guard had to spell all
+ * four out. Here "may I connect" is `kind !== 'stopped' && kind !== 'latched'`.
+ */
+type SocketState =
+  | { kind: 'stopped' }
+  | { kind: 'connecting' }
+  | { kind: 'open' }
+  | { kind: 'waiting' }
+  | { kind: 'latched'; why: LatchReason }
+
+export class MobileSyncSocket {
+  private state: SocketState = { kind: 'stopped' }
+  private socket: SocketLike | null = null
+  private attempt = 0
+  private watchdog: ReturnType<typeof setTimeout> | null = null
+  private pingTimer: ReturnType<typeof setInterval> | null = null
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  /**
+   * Bumped by every `stop()` and every teardown. An in-flight `connect()` is
+   * awaiting a keychain read and a token refresh when the user backgrounds the
+   * app, and without this it would happily create a socket afterwards.
+   */
+  private generation = 0
+  private readonly random: () => number
+
+  constructor(private readonly deps: SyncSocketDeps) {
+    this.random = deps.random ?? Math.random
+  }
+
+  get connected(): boolean {
+    return this.state.kind === 'open'
+  }
+
+  start(): void {
+    if (this.state.kind === 'latched') {
+      this.deps.log.debug?.('Socket start ignored', { latched: this.state.why })
+      return
+    }
+    if (this.state.kind === 'connecting' || this.state.kind === 'open') return
+    this.clearReconnectTimer()
+    void this.connect()
+  }
+
+  /**
+   * Deliberate teardown, and it must be deliberate on backgrounding.
+   *
+   * Letting iOS tear the socket down instead delivers a close we cannot tell
+   * from a network failure, which arms the backoff and then burns handshake
+   * attempts reconnecting a socket the app is not even foregrounded to use.
+   */
+  stop(): void {
+    this.generation++
+    this.teardown()
+    this.clearReconnectTimer()
+    this.attempt = 0
+    if (this.state.kind !== 'latched') this.state = { kind: 'stopped' }
+  }
+
+  /** Extend the live socket's expiry in place after a token refresh. */
+  refreshAuth(token: string): void {
+    if (this.state.kind !== 'open') return
+    this.send(syncSocketAuthFrame(token))
+  }
+
+  private async readAccessToken(): Promise<string | null> {
+    try {
+      return await this.deps.getAccessToken()
+    } catch (err) {
+      this.deps.log.warn('Socket token read failed', { error: message(err) })
+      return null
+    }
+  }
+
+  private async connect(): Promise<void> {
+    const generation = this.generation
+    this.state = { kind: 'connecting' }
+
+    if (!this.deps.isOnline()) return this.scheduleReconnect()
+
+    const vaultId = this.deps.getVaultId()
+    if (!vaultId) return this.scheduleReconnect()
+
+    const credential = await this.readAccessToken()
+    // A token read that came back empty must still arm a retry. Returning bare
+    // latches real-time sync off for the session, and it latches exactly when
+    // it hurts: /auth/refresh lives on the server this device cannot reach.
+    if (!credential) return this.scheduleReconnect()
+    if (generation !== this.generation) return
+
+    const headers = this.headers(credential, vaultId)
+    let socket: SocketLike
+    try {
+      socket = this.deps.createSocket(this.wsUrl(), headers)
+    } catch (err) {
+      this.deps.log.warn('Socket construction failed', { error: message(err) })
+      return this.scheduleReconnect()
+    }
+    this.socket = socket
+
+    let opened = false
+    const mine = (): boolean => this.socket === socket && generation === this.generation
+
+    socket.onopen = () => {
+      if (!mine()) return
+      opened = true
+      this.state = { kind: 'open' }
+      this.attempt = 0
+      this.resetWatchdog()
+      this.startPing()
+      this.deps.log.info('Sync socket connected')
+      this.deps.onOpen()
+    }
+
+    socket.onmessage = (event) => {
+      if (!mine()) return
+      // ANY inbound frame proves the connection is alive, including the
+      // keepalive answer and a message this build does not understand.
+      this.resetWatchdog()
+      if (typeof event.data !== 'string') return
+      const parsed = parseSyncSocketFrame(event.data)
+      if (!parsed) {
+        this.deps.log.warn('Unparseable socket frame')
+        return
+      }
+      if (parsed.kind === 'ignored') return
+      this.deps.onEvent(parsed)
+    }
+
+    socket.onerror = (event) => {
+      if (!mine()) return
+      // RN gives no HTTP status here and no 'unexpected-response' event. The
+      // close that follows owns the decision; this line is for the log only.
+      this.deps.log.debug?.('Sync socket error', { error: errorText(event) })
+    }
+
+    socket.onclose = (event) => {
+      if (!mine()) return
+      this.handleClose(event?.code, event?.reason, opened, headers)
+    }
+  }
+
+  private handleClose(
+    code: number | undefined,
+    reason: string | undefined,
+    opened: boolean,
+    headers: Record<string, string>
+  ): void {
+    this.teardown()
+    this.deps.log.info('Sync socket disconnected', { code, reason })
+
+    switch (code) {
+      case SYNC_SOCKET_CLOSE.deviceRevoked:
+        return this.latch('device-revoked')
+      case SYNC_SOCKET_CLOSE.versionIncompatible:
+        return this.latch('version-incompatible')
+      case SYNC_SOCKET_CLOSE.tokenExpired:
+        void this.deps
+          .refreshAccessToken()
+          .catch(() => null)
+          .finally(() => this.scheduleReconnect())
+        return
+      case SYNC_SOCKET_CLOSE.rateLimited:
+        this.attempt = Math.max(this.attempt, RATE_LIMITED_ATTEMPT)
+        return this.scheduleReconnect()
+      case SYNC_SOCKET_CLOSE.replaced:
+        // Another connection for this device took over. That one is now the
+        // live socket, so reconnecting here just replaces it back and the two
+        // trade places forever. Back off like any other close and let the
+        // loser lose.
+        return this.scheduleReconnect()
+      default:
+        break
+    }
+
+    if (opened) return this.scheduleReconnect()
+
+    // Never opened, so this is a rejected handshake wearing a 1006. The status
+    // is not structurally available and the message is not worth string
+    // matching, so ask the same URL over plain HTTP what it would have said.
+    void this.diagnoseHandshake(headers).finally(() => this.scheduleReconnect())
+  }
+
+  private async diagnoseHandshake(headers: Record<string, string>): Promise<void> {
+    const probe = this.deps.probeHandshake ?? defaultProbe
+    let result: HandshakeProbeResult | null = null
+    try {
+      result = await probe(this.probeUrl(), headers)
+    } catch (err) {
+      this.deps.log.debug?.('Handshake probe failed', { error: message(err) })
+      return
+    }
+    if (!result) return
+    this.deps.log.warn('Sync socket handshake rejected', {
+      status: result.status,
+      code: result.code ?? 'unknown'
+    })
+
+    switch (result.status) {
+      case 401:
+        // The token was stale by the time the handshake ran. Refresh now so
+        // the scheduled reconnect has something usable to present.
+        await this.deps.refreshAccessToken().catch(() => null)
+        return
+      case 403:
+        // The Durable Object answers 403 AUTH_DEVICE_REVOKED before the
+        // upgrade, so this device never reaches the 4004 close at all.
+        if (result.code === 'AUTH_DEVICE_REVOKED') this.latch('device-revoked')
+        return
+      case 426:
+        return this.latch('version-incompatible')
+      case 402:
+      case 429:
+        // Plan gate and rate limit are both "not now" rather than "not ever" —
+        // an upgrade or a cooled window heals within the 30 s ceiling without
+        // needing the app relaunched.
+        this.attempt = Math.max(this.attempt, RATE_LIMITED_ATTEMPT)
+        return
+      default:
+        return
+    }
+  }
+
+  private latch(why: LatchReason): void {
+    this.state = { kind: 'latched', why }
+    this.clearReconnectTimer()
+    this.deps.log.warn('Sync socket latched off for this session', { reason: why })
+  }
+
+  private scheduleReconnect(): void {
+    if (this.state.kind === 'stopped' || this.state.kind === 'latched') return
+    this.clearReconnectTimer()
+    this.state = { kind: 'waiting' }
+
+    const delay = Math.min(
+      BASE_RECONNECT_DELAY_MS * 2 ** this.attempt + this.random() * RECONNECT_JITTER_MS,
+      MAX_RECONNECT_DELAY_MS
+    )
+    this.attempt++
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      if (this.state.kind !== 'waiting') return
+      void this.connect()
+    }, delay)
+  }
+
+  private startPing(): void {
+    this.stopPing()
+    this.pingTimer = setInterval(() => this.send(SYNC_SOCKET_PING), PING_INTERVAL_MS)
+  }
+
+  private send(data: string): void {
+    const socket = this.socket
+    if (!socket || socket.readyState !== SOCKET_OPEN) return
+    try {
+      socket.send(data)
+    } catch (err) {
+      this.deps.log.debug?.('Socket send failed', { error: message(err) })
+    }
+  }
+
+  private resetWatchdog(): void {
+    this.clearWatchdog()
+    this.watchdog = setTimeout(() => {
+      this.watchdog = null
+      this.deps.log.warn('Sync socket went quiet; reconnecting')
+      this.teardown()
+      this.scheduleReconnect()
+    }, WATCHDOG_MS)
+  }
+
+  /**
+   * Drop the socket and every timer it owns.
+   *
+   * The reference is nulled and the handlers detached BEFORE close, because
+   * there is no terminate() on React Native and a dead socket can sit in
+   * CLOSING until the OS gives up on it. Anything it emits after this point
+   * belongs to a connection nobody is listening to.
+   */
+  private teardown(): void {
+    const socket = this.socket
+    this.socket = null
+    this.clearWatchdog()
+    this.stopPing()
+    if (!socket) return
+    socket.onopen = null
+    socket.onmessage = null
+    socket.onerror = null
+    socket.onclose = null
+    try {
+      socket.close(1000, 'client teardown')
+    } catch {
+      // A socket already closing throws on some RN versions; nothing to do.
+    }
+  }
+
+  private headers(token: string, vaultId: string): Record<string, string> {
+    return {
+      Authorization: `Bearer ${token}`,
+      // The build half is stripped deliberately. The server compares with
+      // isVersionBelow, which runs Number('0+1') -> NaN on a `+build` suffix
+      // and lets the version gate pass by accident.
+      'X-App-Version': this.deps.getAppVersion().split('+')[0],
+      // Without this the socket connects and is then permanently deaf: the
+      // Durable Object filters every broadcast by the socket's attached vault.
+      'X-Memry-Vault-Id': vaultId
+    }
+  }
+
+  private wsUrl(): string {
+    return this.deps.baseUrl.replace(/^http/, 'ws') + '/sync/ws'
+  }
+
+  private probeUrl(): string {
+    return this.deps.baseUrl + '/sync/ws'
+  }
+
+  private stopPing(): void {
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer)
+      this.pingTimer = null
+    }
+  }
+
+  private clearWatchdog(): void {
+    if (this.watchdog) {
+      clearTimeout(this.watchdog)
+      this.watchdog = null
+    }
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+  }
+}
+
+async function defaultProbe(
+  url: string,
+  headers: Record<string, string>
+): Promise<HandshakeProbeResult | null> {
+  const response = await fetch(url, { method: 'GET', headers })
+  let code: string | undefined
+  try {
+    const body = (await response.json()) as { error?: { code?: string } }
+    code = body?.error?.code
+  } catch {
+    code = undefined
+  }
+  return { status: response.status, code }
+}
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function errorText(event: unknown): string {
+  if (event instanceof Error) return event.message
+  if (event && typeof event === 'object' && 'message' in event) {
+    return String((event as { message: unknown }).message)
+  }
+  return 'unknown'
+}

--- a/apps/mobile/src/sync/socket.ts
+++ b/apps/mobile/src/sync/socket.ts
@@ -57,13 +57,8 @@ export interface SocketLike {
   onclose: ((event: { code?: number; reason?: string }) => void) | null
 }
 
-export interface HandshakeProbeResult {
-  status: number
-  code?: string
-}
-
 export interface SyncSocketDeps {
-  /** The https sync base url. The ws url and the probe url derive from it. */
+  /** The https sync base url. The ws url derives from it. */
   baseUrl: string
   getAccessToken: () => Promise<string | null>
   refreshAccessToken: () => Promise<string | null>
@@ -76,10 +71,6 @@ export interface SyncSocketDeps {
   /** Every successful open brackets a window of broadcasts nobody heard. */
   onOpen: () => void
   createSocket: (url: string, headers: Record<string, string>) => SocketLike
-  probeHandshake?: (
-    url: string,
-    headers: Record<string, string>
-  ) => Promise<HandshakeProbeResult | null>
   random?: () => number
 }
 
@@ -136,7 +127,13 @@ export class MobileSyncSocket {
       return
     }
     if (this.state.kind === 'connecting' || this.state.kind === 'open') return
-    this.clearReconnectTimer()
+    // An armed backoff is deliberate and a foreground or online edge is not a
+    // reason to jump it. Cancelling it here is how a rate-limited client walks
+    // straight back into the 15-per-60-seconds ceiling it shares with every
+    // other device the same user owns. `stop()` clears the timer and resets
+    // the attempt count, so a genuine background/foreground cycle still
+    // reconnects immediately.
+    if (this.reconnectTimer) return
     void this.connect()
   }
 
@@ -195,13 +192,16 @@ export class MobileSyncSocket {
       return this.scheduleReconnect()
     }
     this.socket = socket
+    // Armed here rather than on open. React Native imposes no connect timeout
+    // of its own, and a handshake that neither opens nor closes would
+    // otherwise park the manager in 'connecting' with no timer and no socket,
+    // where `start()` declines to help and nothing ever recovers.
+    this.resetWatchdog()
 
-    let opened = false
     const mine = (): boolean => this.socket === socket && generation === this.generation
 
     socket.onopen = () => {
       if (!mine()) return
-      opened = true
       this.state = { kind: 'open' }
       this.attempt = 0
       this.resetWatchdog()
@@ -234,16 +234,11 @@ export class MobileSyncSocket {
 
     socket.onclose = (event) => {
       if (!mine()) return
-      this.handleClose(event?.code, event?.reason, opened, headers)
+      this.handleClose(event?.code, event?.reason)
     }
   }
 
-  private handleClose(
-    code: number | undefined,
-    reason: string | undefined,
-    opened: boolean,
-    headers: Record<string, string>
-  ): void {
+  private handleClose(code: number | undefined, reason: string | undefined): void {
     this.teardown()
     this.deps.log.info('Sync socket disconnected', { code, reason })
 
@@ -253,69 +248,31 @@ export class MobileSyncSocket {
       case SYNC_SOCKET_CLOSE.versionIncompatible:
         return this.latch('version-incompatible')
       case SYNC_SOCKET_CLOSE.tokenExpired:
-        void this.deps
-          .refreshAccessToken()
-          .catch(() => null)
-          .finally(() => this.scheduleReconnect())
+        // Armed BEFORE the refresh, not after it. Awaiting first leaves the
+        // manager with no socket and no timer, and `refreshSession` carries no
+        // abort signal, so that window is bounded only by the platform socket
+        // timeout. The refresh runs alongside and the reconnect reads whatever
+        // token has landed by the time it fires.
+        this.scheduleReconnect()
+        void this.deps.refreshAccessToken().catch(() => null)
         return
       case SYNC_SOCKET_CLOSE.rateLimited:
         this.attempt = Math.max(this.attempt, RATE_LIMITED_ATTEMPT)
         return this.scheduleReconnect()
-      case SYNC_SOCKET_CLOSE.replaced:
-        // Another connection for this device took over. That one is now the
-        // live socket, so reconnecting here just replaces it back and the two
-        // trade places forever. Back off like any other close and let the
-        // loser lose.
+      default:
+        // Everything else backs off, including the synthetic 1006 that React
+        // Native reports for a handshake the server refused.
+        //
+        // There is deliberately no HTTP probe here. `/sync/ws` answers any
+        // request without an `Upgrade: websocket` header with 426
+        // VALIDATION_ERROR before it reaches the Durable Object, so a plain GET
+        // learns nothing about why the handshake failed and cannot distinguish
+        // a version gate from a dropped connection. A probe that read that 426
+        // at face value would latch real-time sync off for the process on the
+        // first flaky network, which is worse than every problem it could
+        // solve. A raised version floor still reaches the user: `/sync/status`
+        // carries `clientPolicy` on every pass and drives read-only mode.
         return this.scheduleReconnect()
-      default:
-        break
-    }
-
-    if (opened) return this.scheduleReconnect()
-
-    // Never opened, so this is a rejected handshake wearing a 1006. The status
-    // is not structurally available and the message is not worth string
-    // matching, so ask the same URL over plain HTTP what it would have said.
-    void this.diagnoseHandshake(headers).finally(() => this.scheduleReconnect())
-  }
-
-  private async diagnoseHandshake(headers: Record<string, string>): Promise<void> {
-    const probe = this.deps.probeHandshake ?? defaultProbe
-    let result: HandshakeProbeResult | null = null
-    try {
-      result = await probe(this.probeUrl(), headers)
-    } catch (err) {
-      this.deps.log.debug?.('Handshake probe failed', { error: message(err) })
-      return
-    }
-    if (!result) return
-    this.deps.log.warn('Sync socket handshake rejected', {
-      status: result.status,
-      code: result.code ?? 'unknown'
-    })
-
-    switch (result.status) {
-      case 401:
-        // The token was stale by the time the handshake ran. Refresh now so
-        // the scheduled reconnect has something usable to present.
-        await this.deps.refreshAccessToken().catch(() => null)
-        return
-      case 403:
-        // The Durable Object answers 403 AUTH_DEVICE_REVOKED before the
-        // upgrade, so this device never reaches the 4004 close at all.
-        if (result.code === 'AUTH_DEVICE_REVOKED') this.latch('device-revoked')
-        return
-      case 426:
-        return this.latch('version-incompatible')
-      case 402:
-      case 429:
-        // Plan gate and rate limit are both "not now" rather than "not ever" —
-        // an upgrade or a cooled window heals within the 30 s ceiling without
-        // needing the app relaunched.
-        this.attempt = Math.max(this.attempt, RATE_LIMITED_ATTEMPT)
-        return
-      default:
-        return
     }
   }
 
@@ -410,10 +367,6 @@ export class MobileSyncSocket {
     return this.deps.baseUrl.replace(/^http/, 'ws') + '/sync/ws'
   }
 
-  private probeUrl(): string {
-    return this.deps.baseUrl + '/sync/ws'
-  }
-
   private stopPing(): void {
     if (this.pingTimer) {
       clearInterval(this.pingTimer)
@@ -434,21 +387,6 @@ export class MobileSyncSocket {
       this.reconnectTimer = null
     }
   }
-}
-
-async function defaultProbe(
-  url: string,
-  headers: Record<string, string>
-): Promise<HandshakeProbeResult | null> {
-  const response = await fetch(url, { method: 'GET', headers })
-  let code: string | undefined
-  try {
-    const body = (await response.json()) as { error?: { code?: string } }
-    code = body?.error?.code
-  } catch {
-    code = undefined
-  }
-  return { status: response.status, code }
 }
 
 function message(err: unknown): string {

--- a/apps/mobile/src/sync/triggers.ts
+++ b/apps/mobile/src/sync/triggers.ts
@@ -1,0 +1,34 @@
+import { getEditorSession } from '../editor/session'
+import { createLogger } from '../lib/logger'
+import { getSyncEngine } from './engine'
+import { requestSync, type SyncReason } from './request-sync'
+
+const log = createLogger('SyncTriggers')
+
+/**
+ * Drain the write queue. Failures are logged, never thrown: a drain that
+ * rejects into an AppState listener is an unhandled rejection, and the rows it
+ * could not send are still queued for the next pass.
+ */
+export async function drainOutbox(vaultId: string): Promise<void> {
+  try {
+    const session = await getEditorSession(vaultId)
+    await session.flush()
+  } catch (err) {
+    log.warn('Outbox drain failed', {
+      error: err instanceof Error ? err.message : String(err)
+    })
+  }
+}
+
+/** `requestSync` bound to the real drain and the real engine. */
+export function requestVaultSync(vaultId: string, reason: SyncReason): Promise<void> {
+  return requestSync(
+    {
+      drain: drainOutbox,
+      sync: (id) => getSyncEngine(id).sync()
+    },
+    vaultId,
+    reason
+  )
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -58,6 +58,7 @@
     "./settings-sync": "./src/settings-sync.ts",
     "./sidebar-sort": "./src/sidebar-sort.ts",
     "./sync-api": "./src/sync-api.ts",
+    "./sync-socket": "./src/sync-socket.ts",
     "./sync-payloads": "./src/sync-payloads.ts",
     "./tag-colors": "./src/tag-colors.ts",
     "./tags-api": "./src/tags-api.ts",

--- a/packages/contracts/src/sync-payloads.test.ts
+++ b/packages/contracts/src/sync-payloads.test.ts
@@ -768,3 +768,41 @@ describe('TemplateSyncPayloadSchema', () => {
     expect(result.success).toBe(true)
   })
 })
+
+describe('sync timestamps a phone wrote as epoch ms', () => {
+  /**
+   * The regression: mobile sent `modifiedAt` as a number, this schema demanded
+   * a string, and `ItemApplier` skips a failed parse and advances the cursor
+   * without retrying. The edit was accepted by the server, counted as synced by
+   * the phone, and applied nowhere. Six notes in one vault were stuck like that.
+   */
+  it('accepts epoch ms on a note and normalizes it to ISO', () => {
+    const parsed = NoteSyncPayloadSchema.safeParse({
+      title: 'memrynote Mobile',
+      modifiedAt: 1788535842000,
+      createdAt: 1788535842000
+    })
+
+    expect(parsed.success).toBe(true)
+    expect(parsed.success && parsed.data.modifiedAt).toBe('2026-09-04T15:30:42.000Z')
+    expect(parsed.success && parsed.data.createdAt).toBe('2026-09-04T15:30:42.000Z')
+  })
+
+  it('accepts epoch ms on a journal too, which the same screen edits', () => {
+    const parsed = JournalSyncPayloadSchema.safeParse({
+      date: '2026-09-04',
+      modifiedAt: 1788535842000
+    })
+
+    expect(parsed.success).toBe(true)
+    expect(parsed.success && parsed.data.modifiedAt).toBe('2026-09-04T15:30:42.000Z')
+  })
+
+  it('leaves an ISO string exactly as it was sent', () => {
+    const parsed = NoteSyncPayloadSchema.safeParse({
+      modifiedAt: '2026-09-04T15:30:42.000Z'
+    })
+
+    expect(parsed.success && parsed.data.modifiedAt).toBe('2026-09-04T15:30:42.000Z')
+  })
+})

--- a/packages/contracts/src/sync-payloads.ts
+++ b/packages/contracts/src/sync-payloads.ts
@@ -3,6 +3,25 @@ import { FieldClocksSchema, VectorClockSchema } from './sync-api'
 import { ViewConfigSchema } from './folder-view-api'
 import { TemplatePropertySchema } from './templates-api'
 
+/**
+ * A sync timestamp, accepted in either shape a shipped client has ever sent.
+ *
+ * Mobile writes `Date.now()` — a NUMBER — while this schema declared
+ * `z.string()`. Every note a phone edited therefore failed `safeParse` on the
+ * desktop, and `ItemApplier` skips a failed item and advances the cursor
+ * without ever retrying it: the edit was accepted by the server, counted as
+ * synced by the phone, and silently never applied anywhere else. Six notes in
+ * one staging vault were in that state before it was noticed.
+ *
+ * Fixing the phone alone is not enough. Those payloads are already on the
+ * server, so a client that only accepts strings keeps rejecting them forever,
+ * on every device that ever syncs the vault. Widening here is what heals them,
+ * and it is strictly a widening — a string still parses to itself.
+ */
+const SyncTimestampSchema = z
+  .union([z.string(), z.number()])
+  .transform((value) => (typeof value === 'string' ? value : new Date(value).toISOString()))
+
 export const TaskSyncPayloadSchema = z.object({
   title: z.string().optional(),
   description: z.string().nullable().optional(),
@@ -247,8 +266,8 @@ export const NoteSyncPayloadSchema = z.object({
   attachmentReferences: z.array(z.string()).nullable().optional(),
   folderPath: z.string().nullable().optional(),
   clock: VectorClockSchema.optional(),
-  createdAt: z.string().optional(),
-  modifiedAt: z.string().optional()
+  createdAt: SyncTimestampSchema.optional(),
+  modifiedAt: SyncTimestampSchema.optional()
 })
 
 export const JournalSyncPayloadSchema = z.object({
@@ -264,8 +283,8 @@ export const JournalSyncPayloadSchema = z.object({
   tags: z.array(z.string()).optional(),
   properties: z.record(z.string(), z.unknown()).nullable().optional(),
   clock: VectorClockSchema.optional(),
-  createdAt: z.string().optional(),
-  modifiedAt: z.string().optional()
+  createdAt: SyncTimestampSchema.optional(),
+  modifiedAt: SyncTimestampSchema.optional()
 })
 
 export const TagDefinitionSyncPayloadSchema = z.object({

--- a/packages/contracts/src/sync-socket.test.ts
+++ b/packages/contracts/src/sync-socket.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseSyncSocketFrame,
+  syncSocketAuthFrame,
+  SYNC_SOCKET_CLOSE,
+  SYNC_SOCKET_MESSAGE_TYPES,
+  SYNC_SOCKET_PING,
+  SYNC_SOCKET_PONG
+} from './sync-socket'
+
+const frame = (type: string, payload?: Record<string, unknown>): string =>
+  JSON.stringify(payload === undefined ? { type } : { type, payload })
+
+describe('parseSyncSocketFrame', () => {
+  it('narrows the four types a client acts on', () => {
+    expect(parseSyncSocketFrame(frame('changes_available', { cursor: 42, vaultId: 'v1' }))).toEqual(
+      {
+        kind: 'changes_available',
+        cursor: 42,
+        vaultId: 'v1'
+      }
+    )
+    expect(parseSyncSocketFrame(frame('crdt_updated', { vaultId: 'v1', noteId: 'n1' }))).toEqual({
+      kind: 'crdt_updated',
+      vaultId: 'v1',
+      noteId: 'n1'
+    })
+    expect(parseSyncSocketFrame(frame('auth_ok', { exp: 99 }))).toEqual({
+      kind: 'auth_ok',
+      exp: 99
+    })
+    expect(parseSyncSocketFrame(frame('error', { code: 'X', message: 'y' }))).toEqual({
+      kind: 'error',
+      code: 'X',
+      message: 'y'
+    })
+  })
+
+  it('ignores the types this client has no handler for', () => {
+    for (const type of ['calendar_changes_available', 'linking_request', 'linking_approved']) {
+      expect(parseSyncSocketFrame(frame(type, {}))).toEqual({ kind: 'ignored', type })
+    }
+  })
+
+  it('ignores a type it has never heard of instead of failing the frame', () => {
+    // The compatibility rule the whole schema exists for: a server that starts
+    // sending something new must not break a client that shipped before it.
+    expect(parseSyncSocketFrame(frame('quantum_entangled', { anything: true }))).toEqual({
+      kind: 'ignored',
+      type: 'quantum_entangled'
+    })
+  })
+
+  it('ignores a known type whose payload is missing what it needs', () => {
+    // `crdt_updated` without a note id names no work, so it is nothing to do
+    // rather than an error to report.
+    expect(parseSyncSocketFrame(frame('crdt_updated', { vaultId: 'v1' }))).toEqual({
+      kind: 'ignored',
+      type: 'crdt_updated'
+    })
+  })
+
+  it('tolerates a payload-less frame', () => {
+    expect(parseSyncSocketFrame(frame('changes_available'))).toEqual({ kind: 'changes_available' })
+  })
+
+  it('swallows the keepalive answer', () => {
+    expect(parseSyncSocketFrame(SYNC_SOCKET_PONG)).toEqual({ kind: 'ignored', type: 'pong' })
+  })
+
+  it('returns null only when the frame is not an envelope', () => {
+    expect(parseSyncSocketFrame('not json')).toBeNull()
+    expect(parseSyncSocketFrame('{"payload":{}}')).toBeNull()
+    expect(parseSyncSocketFrame('{"type":""}')).toBeNull()
+    expect(parseSyncSocketFrame('[]')).toBeNull()
+  })
+})
+
+describe('protocol constants', () => {
+  it('keeps the keepalive exactly the string Cloudflare auto-answers', () => {
+    // A different payload wakes the Durable Object on every beat and spends
+    // the socket's inbound rate-limit budget.
+    expect(SYNC_SOCKET_PING).toBe('ping')
+    expect(SYNC_SOCKET_PONG).toBe('pong')
+  })
+
+  it('matches the close codes the Durable Object sends', () => {
+    expect(SYNC_SOCKET_CLOSE).toEqual({
+      replaced: 4001,
+      tokenExpired: 4003,
+      deviceRevoked: 4004,
+      rateLimited: 4008,
+      versionIncompatible: 4009
+    })
+  })
+
+  it('lists every name the server broadcasts', () => {
+    expect(SYNC_SOCKET_MESSAGE_TYPES).toContain('changes_available')
+    expect(SYNC_SOCKET_MESSAGE_TYPES).toContain('crdt_updated')
+  })
+
+  it('builds the in-place re-auth frame', () => {
+    expect(JSON.parse(syncSocketAuthFrame('jwt'))).toEqual({
+      type: 'auth',
+      payload: { token: 'jwt' }
+    })
+  })
+})

--- a/packages/contracts/src/sync-socket.ts
+++ b/packages/contracts/src/sync-socket.ts
@@ -1,0 +1,131 @@
+import { z } from 'zod'
+
+/**
+ * The `GET /sync/ws` protocol, in one place.
+ *
+ * Both shells talk to the same Durable Object, and until now each carried its
+ * own copy of the message names. A name added on the server and typo'd on one
+ * client fails silently, because an unrecognised frame is dropped by design.
+ *
+ * Auth is handshake headers only, never a query param or a subprotocol.
+ * `Authorization: Bearer <accessToken>`, `X-App-Version: <semver>` (mandatory,
+ * the server answers 426 without it) and `X-Memry-Vault-Id: <uuid>` (the
+ * server filters every broadcast by the socket's attached vault, so a socket
+ * without it connects and then hears nothing).
+ */
+
+/** Every message name the server can put on a socket today. */
+export const SYNC_SOCKET_MESSAGE_TYPES = [
+  'changes_available',
+  'crdt_updated',
+  'calendar_changes_available',
+  'heartbeat',
+  'auth_ok',
+  'error',
+  'linking_request',
+  'linking_approved'
+] as const
+
+export type SyncSocketMessageType = (typeof SYNC_SOCKET_MESSAGE_TYPES)[number]
+
+/**
+ * The keepalive frame, and it must be exactly this string.
+ *
+ * The Durable Object registers `new WebSocketRequestResponsePair('ping',
+ * 'pong')`, so Cloudflare answers this one payload without waking the DO or
+ * spending the socket's inbound rate-limit budget. Any other keepalive text is
+ * a real message that costs a wake on every beat.
+ */
+export const SYNC_SOCKET_PING = 'ping'
+export const SYNC_SOCKET_PONG = 'pong'
+
+/** Close codes the server uses. 4004 and 4009 are terminal for the session. */
+export const SYNC_SOCKET_CLOSE = {
+  replaced: 4001,
+  tokenExpired: 4003,
+  deviceRevoked: 4004,
+  rateLimited: 4008,
+  versionIncompatible: 4009
+} as const
+
+const EnvelopeSchema = z.object({
+  // A STRING, not an enum over the names above. A newer server must be able to
+  // add a message type without every older client treating the frame as
+  // corrupt; unknown names parse and are then ignored by the caller.
+  type: z.string().min(1),
+  payload: z.record(z.string(), z.unknown()).optional()
+})
+
+const ChangesAvailableSchema = z.object({
+  cursor: z.number().optional(),
+  vaultId: z.string().optional()
+})
+const CrdtUpdatedSchema = z.object({
+  vaultId: z.string().optional(),
+  noteId: z.string().min(1)
+})
+const AuthOkSchema = z.object({ exp: z.number().optional() })
+const ErrorSchema = z.object({ code: z.string().optional(), message: z.string().optional() })
+
+/**
+ * A frame narrowed to what a client can act on.
+ *
+ * `ignored` is a real outcome rather than an error: it covers the keepalive
+ * answer, the message types this client has no handler for, and a known type
+ * whose payload does not carry what it needs. All three mean "do nothing", and
+ * collapsing them into one variant is what keeps an unrecognised frame from
+ * ever reaching a throw.
+ */
+export type SyncSocketEvent =
+  | { kind: 'changes_available'; vaultId?: string; cursor?: number }
+  | { kind: 'crdt_updated'; vaultId?: string; noteId: string }
+  | { kind: 'auth_ok'; exp?: number }
+  | { kind: 'error'; code?: string; message?: string }
+  | { kind: 'ignored'; type: string }
+
+/** The client→server frame that re-authenticates a live socket in place. */
+export function syncSocketAuthFrame(token: string): string {
+  return JSON.stringify({ type: 'auth', payload: { token } })
+}
+
+/**
+ * Parse one inbound text frame. `null` means it was not a message envelope at
+ * all (bad JSON, or no `type`) — the only case worth logging.
+ */
+export function parseSyncSocketFrame(raw: string): SyncSocketEvent | null {
+  if (raw === SYNC_SOCKET_PONG) return { kind: 'ignored', type: SYNC_SOCKET_PONG }
+
+  let json: unknown
+  try {
+    json = JSON.parse(raw)
+  } catch {
+    return null
+  }
+
+  const envelope = EnvelopeSchema.safeParse(json)
+  if (!envelope.success) return null
+
+  const { type, payload } = envelope.data
+  const ignored = { kind: 'ignored', type } as const
+
+  switch (type) {
+    case 'changes_available': {
+      const parsed = ChangesAvailableSchema.safeParse(payload ?? {})
+      return parsed.success ? { kind: 'changes_available', ...parsed.data } : ignored
+    }
+    case 'crdt_updated': {
+      const parsed = CrdtUpdatedSchema.safeParse(payload ?? {})
+      return parsed.success ? { kind: 'crdt_updated', ...parsed.data } : ignored
+    }
+    case 'auth_ok': {
+      const parsed = AuthOkSchema.safeParse(payload ?? {})
+      return parsed.success ? { kind: 'auth_ok', ...parsed.data } : ignored
+    }
+    case 'error': {
+      const parsed = ErrorSchema.safeParse(payload ?? {})
+      return parsed.success ? { kind: 'error', ...parsed.data } : ignored
+    }
+    default:
+      return ignored
+  }
+}


### PR DESCRIPTION
## Summary

Mobile sync now converges in both directions while the app remains open.

- Adds the mobile sync WebSocket and body-only CRDT pull path.
- Refreshes open note bodies when desktop edits arrive.
- Drains the persisted mobile outbox in the foreground with one coalesced 300 ms session scheduler. Record writes (properties, tags, title/move) and CRDT body updates use the same path; lifecycle flush remains the fallback.
- Preserves the existing server contract and supports legacy mobile note timestamp payloads.

## Verification

- `pnpm --filter @memry/mobile test` — 33 files, 288 passed, 1 expected fail.
- `pnpm --filter @memry/mobile typecheck` — passed.
- `pnpm --filter @memry/mobile lint` — 0 errors; 10 existing warnings.
- `pnpm --filter @memry/contracts test` — 1,772 passed.
- `pnpm --filter @memry/desktop test:main` — 574 files, 8,079 passed, 1 expected fail, 3 skipped.
- `pnpm docs:impact --base origin/main --strict` — covered.
- `pnpm docs:build` — passed.
- `git diff --check` — passed.

The new outbox regression coverage verifies that both record and CRDT enqueue paths notify the session scheduler. Staging device verification of mobile-to-desktop property and body edits remains the final manual check.