### PR TITLE
fix(startup): stop the login-shell probe hanging for the whole session

### DIFF
--- a/apps/desktop/src/main/agent/cli/login-shell-path.ts
+++ b/apps/desktop/src/main/agent/cli/login-shell-path.ts
@@ -1,12 +1,10 @@
-import { execFile } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { basename, delimiter } from 'node:path'
-import { promisify } from 'node:util'
 
 import { createLogger } from '../../lib/logger'
 import { trackMainLog } from '../../telemetry/diagnostics'
 
 const logger = createLogger('AgentCli:LoginShellPath')
-const execFileAsync = promisify(execFile)
 
 /**
  * Resolve the user's real login-shell PATH so packaged builds can find CLIs.
@@ -64,10 +62,46 @@ export function mergePaths(
   return merged.join(separator)
 }
 
-const runShellProbe: RunShellProbe = async (shell, args) => {
-  const { stdout } = await execFileAsync(shell, args, { encoding: 'utf8', timeout: 3000 })
-  return stdout
-}
+export const PROBE_TIMEOUT_MS = 3_000
+
+const runShellProbe: RunShellProbe = (shell, args) =>
+  new Promise((resolve, reject) => {
+    // stdin is closed, not piped. An rc chain that reads stdin blocks forever on
+    // an open pipe, and the synchronous probe this replaced handed the shell EOF
+    // for free.
+    const child = spawn(shell, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+
+    let stdout = ''
+    let settled = false
+    const settle = (action: () => void): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      action()
+    }
+
+    const timer = setTimeout(() => {
+      // SIGKILL, not the default SIGTERM: an interactive shell ignores SIGTERM,
+      // so the polite signal leaves this promise pending for the whole session
+      // and every consumer awaiting the PATH gate hangs with it.
+      child.kill('SIGKILL')
+      settle(() => reject(Object.assign(new Error('login shell probe timed out'), { code: null })))
+    }, PROBE_TIMEOUT_MS)
+    timer.unref?.()
+
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk
+    })
+    child.on('error', (error) => settle(() => reject(error)))
+    child.on('close', (code) => {
+      settle(() =>
+        code === 0
+          ? resolve(stdout)
+          : reject(Object.assign(new Error(`login shell exited ${code}`), { code }))
+      )
+    })
+  })
 
 /** Probe the login shell for its PATH; resolves to null on any failure. */
 export async function readLoginShellPath(
@@ -96,11 +130,12 @@ export async function readLoginShellPath(
     }
     return parsed
   } catch (error) {
-    // execFile rejects with a numeric `code` when the shell exited non-zero and
-    // with a string errno when it never started, so the two stay apart the way
-    // the synchronous `result.status` check kept them apart.
+    // A numeric `code` means the shell ran and exited non-zero; a string errno
+    // means it never started; `null` is the timeout kill. That keeps the three
+    // apart the way the synchronous `result.status` check did.
     const code = (error as { code?: unknown } | null)?.code
-    return probeFailed(typeof code === 'number' ? `status_${code}` : 'spawn_error')
+    if (typeof code === 'number') return probeFailed(`status_${code}`)
+    return probeFailed(code === null ? 'status_none' : 'spawn_error')
   }
 }
 

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -1260,3 +1260,23 @@ several vaults can therefore name a note from a vault the app is not opening: th
 speculative chunk prefetch is then wasted, and the mark never fires. Absent is the correct
 reading in that case, not a failure, but it does mean a median over launches must state
 how many runs carried the mark.
+
+## Login-shell PATH probe: failure classes
+
+The probe runs `$SHELL -ilc` once per packaged launch to recover the user's real PATH, and
+reports one of four outcomes through `login_shell_path_probe_failed`:
+
+- `marker_missing` — the shell ran and exited cleanly but printed no marker, usually an rc
+  chain that writes to stdout.
+- `status_<n>` — the shell ran and exited non-zero.
+- `status_none` — the probe hit its 3 s deadline and was killed.
+- `spawn_error` — the shell never started.
+
+Two details are load-bearing and easy to undo by accident. The child's **stdin is closed,
+not piped**: an rc chain that reads stdin blocks forever on an open pipe, and every
+consumer awaiting `whenLoginShellPathApplied()` blocks with it. The deadline kills with
+**SIGKILL**, because an interactive shell ignores SIGTERM, so the polite signal would leave
+the promise pending for the whole session.
+
+The unit suite injects a fake probe and therefore cannot catch either regression. A change
+to how the child process is spawned needs a real shell to verify.


### PR DESCRIPTION
## Summary

**#2052 shipped a hang. This fixes it.**

That PR moved the login-shell PATH probe from `spawnSync` to `execFile`, which changed two things that combine badly:

- **`execFile` keeps the child's stdin pipe open.** `spawnSync` handed the shell EOF for free. An rc chain that reads stdin now blocks on an open pipe.
- **Its timeout sends SIGTERM, which an interactive (`-i`) shell ignores**, then waits for exit. So the timeout does not end it either.

### What a user hits

Anyone on packaged macOS or Linux whose `.zshrc`/`.bashrc` reads stdin:

- `whenLoginShellPathApplied()` never resolves.
- `runBinaryCommand` (`binary-detection.ts:35`) never returns, so `GET_BACKEND_STATUSES` never resolves and `backendStatuses` stays `null`.
- A sent Agent Chat message hangs in `bootstrap.ts:123` **with the turn lock held**.
- Headless `--cli` (`index.ts:379-381`) never prints and never exits.

### The fix

`spawn` with `stdio: ['ignore', 'pipe', 'pipe']` so the shell gets EOF, `SIGKILL` on timeout so an interactive shell cannot ignore it, and a `settled` latch so the promise resolves or rejects exactly once. The timer is `unref`'d so it cannot hold the process alive.

The timeout failure class returns to `status_none`, which is what the synchronous probe reported before #2052 relabelled it `spawn_error`.

## Release note

Fixed a startup hang that could leave Agent Chat unable to detect the Claude and Codex CLIs, on machines whose shell startup files read input.

## Test plan

Reproduced against `/bin/zsh` with a `.zshrc` containing `read x`, using the exact probe command:

| | result |
| --- | --- |
| shipped code (`execFile`, `timeout: 3000`) | **still pending at 10 s**, killed by the harness (exit 124), no output |
| this fix | **resolved in 15 ms**, PATH marker present |

`pnpm lint` 0, `pnpm typecheck` 0, `pnpm --filter @memry/desktop test:main` green at **575 files, 8095 passed, 0 failed**, no ABI errors. The existing `login-shell-path` suite passes unchanged, because it injects a fake probe and does not exercise the real shell — which is exactly why this got through.

Found by an adversarial review of the landed #2001 stack, run on a different model from the one that wrote #2052. The PR body's claim that it "keeps its 3 s timeout" was wrong in both directions: a 6 s rc chain took 6 s before and after, and the new code was unbounded when stdin is read.

Refs #2003
