### PR TITLE
Integrate task start dates into Today

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
+import { useToday } from '@/hooks/use-today'
 import { resolveProjectReorderTarget } from '@/components/sidebar/sidebar-drag-types'
 import type { DragEndEvent } from '@dnd-kit/core'
 import { arrayMove } from '@dnd-kit/sortable'
@@ -442,9 +443,10 @@ function App(): React.JSX.Element {
   // Calculate view counts and project task counts in a single pass over the
   // tasks. Both recompute on every task mutation, so re-filtering the whole list
   // once per view and once per project is the wrong shape at this level.
+  const todayKey = useToday()
   const { viewCounts, projectTaskCounts } = useMemo(
-    () => getTaskWorkspaceCounts(tasks, projects, taskViewIds),
-    [tasks, projects]
+    () => getTaskWorkspaceCounts(tasks, projects, taskViewIds, new Date(`${todayKey}T00:00:00`)),
+    [tasks, projects, todayKey]
   )
 
   // Update project task counts

--- a/apps/desktop/src/renderer/src/components/tasks/interactive-due-date-badge.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/interactive-due-date-badge.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useT } from '@memry/i18n/renderer'
 import { Calendar, Repeat } from '@/lib/icons'
 
 import { cn } from '@/lib/utils'
@@ -8,6 +9,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { DatePickerContent } from './date-picker-content'
 
 interface InteractiveDueDateBadgeProps {
+  dateKind?: 'due' | 'start'
   dueDate: Date | null
   dueTime: string | null
   onDateChange: (date: Date | null) => void
@@ -32,6 +34,7 @@ const badgeStyles: Record<string, string> = {
 }
 
 export const InteractiveDueDateBadge = ({
+  dateKind = 'due',
   dueDate,
   dueTime,
   onDateChange,
@@ -41,6 +44,7 @@ export const InteractiveDueDateBadge = ({
   fixedWidth = false,
   className
 }: InteractiveDueDateBadgeProps): React.JSX.Element => {
+  const { t } = useT('tasks')
   const [isOpen, setIsOpen] = React.useState(false)
   const {
     settings: { clockFormat }
@@ -63,7 +67,7 @@ export const InteractiveDueDateBadge = ({
     [onDateChange, onTimeChange]
   )
 
-  const dateStatus = status?.status ?? 'none'
+  const dateStatus = dateKind === 'start' ? 'none' : (status?.status ?? 'none')
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
@@ -77,7 +81,11 @@ export const InteractiveDueDateBadge = ({
             fixedWidth && 'w-[110px] flex justify-end',
             className
           )}
-          aria-label={`Due: ${dateLabel}. Click to change.`}
+          aria-label={
+            dateKind === 'start'
+              ? t('task.changeStartDate', { date: dateLabel })
+              : `Due: ${dateLabel}. Click to change.`
+          }
         >
           {isRepeating && <Repeat className="size-3 shrink-0" />}
           <Calendar size={12} className="shrink-0" />

--- a/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.test.tsx
@@ -149,7 +149,12 @@ const project: Project = {
   name: 'Test Project',
   color: '#6366F1',
   statuses,
-  isArchived: false
+  isArchived: false,
+  description: '',
+  icon: 'folder',
+  isDefault: false,
+  createdAt: new Date(2026, 0, 1),
+  taskCount: 0
 }
 
 const createTask = (overrides: Partial<Task> = {}): Task => ({
@@ -182,7 +187,12 @@ const project2: Project = {
     { id: 'w-todo', name: 'Backlog', color: '#6B7280', type: 'todo', order: 0 },
     { id: 'w-done', name: 'Shipped', color: '#10B981', type: 'done', order: 1 }
   ],
-  isArchived: false
+  isArchived: false,
+  description: '',
+  icon: 'folder',
+  isDefault: false,
+  createdAt: new Date(2026, 0, 1),
+  taskCount: 0
 }
 
 const defaultProps: TaskDetailDrawerProps = {
@@ -290,6 +300,16 @@ describe('TaskDetailDrawer — editable properties', () => {
 
       expect(onUpdateTask).toHaveBeenCalledWith('task-1', { tags: ['work', 'new-tag'] })
     })
+  })
+
+  it('sets a start date through the date picker', async () => {
+    renderWithI18n(<TaskDetailDrawer {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /start:.*click to change/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^Tomorrow/ }))
+    const tomorrow = new Date()
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    tomorrow.setHours(0, 0, 0, 0)
+    expect(defaultProps.onUpdateTask).toHaveBeenCalledWith('task-1', { startDate: tomorrow })
   })
 
   describe('due date editing', () => {
@@ -511,12 +531,15 @@ describe('TaskDetailDrawer — editable properties', () => {
       title: 'My Note',
       emoji: '📝',
       content: '',
-      folderId: null,
-      createdAt: new Date(),
-      modifiedAt: new Date(),
-      isPinned: false,
-      isStarred: false
-    } as ReturnType<typeof notesService.get> extends Promise<infer T> ? T : never
+      path: 'note-1.md',
+      frontmatter: {},
+      created: new Date(),
+      modified: new Date(),
+      tags: [],
+      aliases: [],
+      wordCount: 0,
+      properties: {}
+    } satisfies NonNullable<Awaited<ReturnType<typeof notesService.get>>>
 
     it('shows emoji instead of NoteIcon when note has emoji', async () => {
       vi.mocked(notesService.get).mockResolvedValueOnce(mockNoteData)

--- a/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.tsx
@@ -355,6 +355,13 @@ export const TaskDetailDrawer = memo(function TaskDetailDrawer({
     [task, onUpdateTask]
   )
 
+  const handleStartDateChange = useCallback(
+    (startDate: Date | null) => {
+      if (task) onUpdateTask?.(task.id, { startDate })
+    },
+    [task, onUpdateTask]
+  )
+
   const handleDueDateChange = useCallback(
     (dueDate: Date | null) => {
       if (task) onUpdateTask?.(task.id, { dueDate })
@@ -503,6 +510,18 @@ export const TaskDetailDrawer = memo(function TaskDetailDrawer({
                   priority={task.priority}
                   onPriorityChange={handlePriorityChange}
                   compact
+                />
+              </div>
+
+              <div className="flex items-center py-1.5">
+                <span className="text-[12px] w-[90px] shrink-0 text-text-tertiary leading-4">
+                  {t('task.startDate')}
+                </span>
+                <InteractiveDueDateBadge
+                  dateKind="start"
+                  dueDate={task.startDate ?? null}
+                  dueTime={null}
+                  onDateChange={handleStartDateChange}
                 />
               </div>
 

--- a/apps/desktop/src/renderer/src/data/task-model.ts
+++ b/apps/desktop/src/renderer/src/data/task-model.ts
@@ -53,6 +53,8 @@ export interface Task {
 
   priority: Priority
 
+  startDate?: Date | null
+
   // Due date
   dueDate: Date | null
   dueTime: string | null // "14:30" format, optional even if dueDate set
@@ -192,6 +194,7 @@ export const createDefaultTask = (
   statusId,
   priority: 'none',
   dueDate,
+  startDate: null,
   dueTime: null,
   isRepeating: false,
   repeatConfig: null,

--- a/apps/desktop/src/renderer/src/features/tasks/use-task-queries.test.ts
+++ b/apps/desktop/src/renderer/src/features/tasks/use-task-queries.test.ts
@@ -33,3 +33,13 @@ describe('dbTaskToUiTask tags', () => {
     expect(result.tags).toEqual([])
   })
 })
+
+describe('dbTaskToUiTask start date', () => {
+  it('loads a calendar date at local midnight', () => {
+    const task = dbTaskToUiTask({ ...baseDbTask, startDate: '2026-09-07' })
+    expect(task.startDate).toEqual(new Date(2026, 8, 7))
+  })
+  it('keeps tasks without a start date unscheduled', () => {
+    expect(dbTaskToUiTask(baseDbTask).startDate).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/features/tasks/use-task-queries.test.tsx
+++ b/apps/desktop/src/renderer/src/features/tasks/use-task-queries.test.tsx
@@ -512,6 +512,23 @@ describe('useTaskWorkspaceMutations', () => {
       })
     }
 
+    it('persists and clears start dates without changing the due date', async () => {
+      const { result } = renderMutations()
+      await act(async () => {
+        await result.current.updateTask('task-1', { startDate: new Date(2026, 8, 7) })
+      })
+      expect(lastUpdatePayload().startDate).toBe('2026-09-07')
+      expect(lastUpdatePayload().dueDate).toBeUndefined()
+      await act(async () => {
+        await result.current.updateTask('task-1', { startDate: null })
+      })
+      expect(lastUpdatePayload().startDate).toBeNull()
+      await act(async () => {
+        await result.current.updateTask('task-1', { description: 'unchanged dates' })
+      })
+      expect(lastUpdatePayload().startDate).toBeUndefined()
+    })
+
     it('omits dueDate (does not null it) when updating only the description', async () => {
       const { result } = renderMutations()
 

--- a/apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts
+++ b/apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts
@@ -104,6 +104,7 @@ export function dbTaskToUiTask(dbTask: Task): UiTask {
     projectId: dbTask.projectId,
     statusId: dbTask.statusId ?? '',
     priority: priorityMap[dbTask.priority as number] ?? 'none',
+    startDate: dbTask.startDate ? parseDueDate(dbTask.startDate) : null,
     dueDate: dbTask.dueDate ? parseDueDate(dbTask.dueDate) : null,
     dueTime: dbTask.dueTime,
     isRepeating: !!dbTask.repeatConfig,
@@ -347,6 +348,7 @@ export function useTaskWorkspaceMutations() {
           priority: priorityReverseMap[task.priority] ?? 0,
           statusId: task.statusId || null,
           parentId: task.parentId || null,
+          startDate: task.startDate ? formatDateKey(task.startDate) : null,
           dueDate: task.dueDate ? formatDateKey(task.dueDate) : null,
           dueTime: task.dueTime || null,
           isRepeating: task.isRepeating,
@@ -405,6 +407,12 @@ export function useTaskWorkspaceMutations() {
                     ? formatDateKey(otherUpdates.dueDate)
                     : null
                   : undefined,
+              startDate:
+                'startDate' in otherUpdates
+                  ? otherUpdates.startDate
+                    ? formatDateKey(otherUpdates.startDate)
+                    : null
+                  : undefined,
               dueTime: 'dueTime' in otherUpdates ? otherUpdates.dueTime : undefined,
               isRepeating: otherUpdates.isRepeating,
               repeatConfig: toServiceRepeatConfig(otherUpdates.repeatConfig),
@@ -447,6 +455,12 @@ export function useTaskWorkspaceMutations() {
                     ? formatDateKey(otherUpdates.dueDate)
                     : null
                   : undefined,
+              startDate:
+                'startDate' in otherUpdates
+                  ? otherUpdates.startDate
+                    ? formatDateKey(otherUpdates.startDate)
+                    : null
+                  : undefined,
               dueTime: 'dueTime' in otherUpdates ? otherUpdates.dueTime : undefined,
               isRepeating: otherUpdates.isRepeating,
               repeatConfig: toServiceRepeatConfig(otherUpdates.repeatConfig),
@@ -474,6 +488,12 @@ export function useTaskWorkspaceMutations() {
             'dueDate' in updates
               ? updates.dueDate
                 ? formatDateKey(updates.dueDate)
+                : null
+              : undefined,
+          startDate:
+            'startDate' in updates
+              ? updates.startDate
+                ? formatDateKey(updates.startDate)
                 : null
               : undefined,
           dueTime: 'dueTime' in updates ? updates.dueTime : undefined,

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-view-helpers.ts
@@ -13,6 +13,9 @@ import {
 } from './task-date-utils'
 import { isTaskCompleted } from './task-status-helpers'
 
+const hasStarted = (task: Task, today: Date): boolean =>
+  !!task.startDate && !isAfter(startOfDay(task.startDate), today)
+
 // ============================================================================
 // SUBTASK INCLUSION HELPER
 // ============================================================================
@@ -34,7 +37,8 @@ export const getFilteredTasks = (
   selectedId: string,
   selectedType: 'view' | 'project',
   projects: Project[],
-  _includeCompleted = false
+  _includeCompleted = false,
+  now = new Date()
 ): Task[] => {
   const nonArchivedTasks = tasks.filter((t) => !t.archivedAt)
 
@@ -51,7 +55,7 @@ export const getFilteredTasks = (
   const completedTopLevel = nonArchivedTasks.filter((t) => isComplete(t) && !isSubtask(t))
 
   if (selectedType === 'view') {
-    const today = startOfDay(new Date())
+    const today = startOfDay(now)
     const weekFromNow = addDays(today, 7)
 
     switch (selectedId) {
@@ -60,6 +64,7 @@ export const getFilteredTasks = (
 
       case 'today': {
         const matchingTopLevel = incompleteTopLevel.filter((task) => {
+          if (hasStarted(task, today)) return true
           if (!task.dueDate) return false
           const taskDate = startOfDay(task.dueDate)
           return isSameDay(taskDate, today) || isBefore(taskDate, today)
@@ -141,7 +146,8 @@ export interface TaskWorkspaceCounts {
 export const getTaskWorkspaceCounts = (
   tasks: Task[],
   projects: Project[],
-  viewIds: readonly string[]
+  viewIds: readonly string[],
+  now = new Date()
 ): TaskWorkspaceCounts => {
   const statusTypesByProject = new Map<string, Map<string, StatusType>>()
   for (const project of projects) {
@@ -152,7 +158,7 @@ export const getTaskWorkspaceCounts = (
     statusTypesByProject.set(project.id, statusTypes)
   }
 
-  const today = startOfDay(new Date())
+  const today = startOfDay(now)
   const tomorrow = addDays(today, 1)
   const weekFromNow = addDays(today, 7)
   const weekEnd = endOfWeek(today)
@@ -163,6 +169,7 @@ export const getTaskWorkspaceCounts = (
 
     switch (viewId) {
       case 'today': {
+        if (hasStarted(task, today)) return true
         if (!task.dueDate) return false
         const taskDate = startOfDay(task.dueDate)
         return isSameDay(taskDate, today) || isBefore(taskDate, today)
@@ -347,6 +354,14 @@ export const getTodayTasks = (tasks: Task[], projects: Project[]): TodayViewTask
   tasks.forEach((task) => {
     if (isTaskCompleted(task, projects)) return
     if (task.parentId !== null) return
+    if (task.archivedAt) return
+    if (
+      hasStarted(task, todayStart) &&
+      (!task.dueDate || !isBefore(startOfDay(task.dueDate), todayStart))
+    ) {
+      today.push(task)
+      return
+    }
     if (!task.dueDate) return
 
     const dueDate = startOfDay(task.dueDate)
@@ -390,9 +405,10 @@ const DUE_WINDOW_DAYS: Record<TaskDueWindow, [number, number]> = {
 export const getTasksInDueWindow = (
   tasks: Task[],
   projects: Project[],
-  window: TaskDueWindow
+  window: TaskDueWindow,
+  now = new Date()
 ): Task[] => {
-  const todayStart = startOfDay(new Date())
+  const todayStart = startOfDay(now)
   const [firstDay, lastDay] = DUE_WINDOW_DAYS[window]
   const windowStart = addDays(todayStart, firstDay)
   const windowEnd = endOfDay(addDays(todayStart, lastDay))
@@ -404,6 +420,15 @@ export const getTasksInDueWindow = (
   tasks.forEach((task) => {
     if (isTaskCompleted(task, projects)) return
     if (task.parentId !== null) return
+    if (task.archivedAt) return
+    if (
+      window === 'today' &&
+      hasStarted(task, todayStart) &&
+      (!task.dueDate || !isBefore(startOfDay(task.dueDate), todayStart))
+    ) {
+      inWindow.push(task)
+      return
+    }
     if (!task.dueDate) return
 
     const dueDate = startOfDay(task.dueDate)

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-workspace-counts.test.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-workspace-counts.test.ts
@@ -7,10 +7,10 @@
  * real filter would show, the badge must show. The mutation matrix at the bottom
  * walks every input that has to invalidate the counts.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import type { Task } from '@/data/task-model'
 import type { Project, StatusType } from '@/data/tasks-data'
-import { getFilteredTasks, getTaskWorkspaceCounts } from '.'
+import { getFilteredTasks, getTaskWorkspaceCounts, getTodayTasks, getTasksInDueWindow } from '.'
 import { addDays, startOfDay } from './task-date-utils'
 
 const ALL_VIEW_IDS = [
@@ -373,5 +373,52 @@ describe('getTaskWorkspaceCounts invalidation matrix', () => {
     expect(
       getTaskWorkspaceCounts(baselineTasks(), remaining, ALL_VIEW_IDS).viewCounts
     ).toMatchObject({ all: 11, completed: 2 })
+  })
+})
+
+describe('tasks spanning several days', () => {
+  it('stays in Today from its start through its due date, then becomes overdue', () => {
+    vi.useFakeTimers()
+    try {
+      const task = createTask({
+        id: 'long-task',
+        statusId: 'doing',
+        startDate: new Date(2026, 8, 7),
+        dueDate: new Date(2026, 8, 11)
+      })
+      for (let day = 6; day <= 12; day++) {
+        vi.setSystemTime(new Date(2026, 8, day, 12))
+        const expected = day >= 7 ? [task] : []
+        expect(getFilteredTasks([task], 'today', 'view', projects)).toEqual(expected)
+        expect(getTasksInDueWindow([task], projects, 'today')).toEqual(expected)
+        expect(getTaskWorkspaceCounts([task], projects, ['today']).viewCounts.today).toBe(
+          expected.length
+        )
+        const grouped = getTodayTasks([task], projects)
+        expect(grouped.today).toEqual(day >= 7 && day <= 11 ? [task] : [])
+        expect(grouped.overdue).toEqual(day === 12 ? [task] : [])
+        expect(task.statusId).toBe('doing')
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('handles no deadline, completion, archives, cleared starts, and subtasks', () => {
+    const active = createTask({ id: 'active', startDate: addDays(TODAY, -2) })
+    const child = createTask({ id: 'child', parentId: active.id })
+    const tasks = [
+      active,
+      child,
+      createTask({ id: 'done', startDate: TODAY, statusId: 'done' }),
+      createTask({ id: 'archived', startDate: TODAY, archivedAt: TODAY }),
+      createTask({ id: 'future', startDate: addDays(TODAY, 1) }),
+      createTask({ id: 'cleared', startDate: null }),
+      createTask({ id: 'legacy' })
+    ]
+    expect(getFilteredTasks(tasks, 'today', 'view', projects)).toEqual([active, child])
+    expect(getTasksInDueWindow(tasks, projects, 'today')).toEqual([active, child])
+    expect(getTodayTasks(tasks, projects).today).toEqual([active, child])
+    expect(getTaskWorkspaceCounts(tasks, projects, ['today']).viewCounts.today).toBe(2)
   })
 })

--- a/apps/desktop/src/renderer/src/pages/tasks.tsx
+++ b/apps/desktop/src/renderer/src/pages/tasks.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback, useEffect, useId } from 'react'
+import { useToday } from '@/hooks/use-today'
 import { LayoutGroup, motion, useReducedMotion } from 'motion/react'
 
 import { useT } from '@memry/i18n/renderer'
@@ -132,6 +133,8 @@ export const TasksPage = ({
   selectedTaskIds: externalSelectedIds,
   onSelectedTaskIdsChange
 }: TasksPageProps): React.JSX.Element => {
+  const todayKey = useToday()
+  const currentDay = useMemo(() => new Date(`${todayKey}T00:00:00`), [todayKey])
   const { t } = useT('tasks')
   const { t: tCommon } = useT('common')
 
@@ -400,9 +403,9 @@ export const TasksPage = ({
 
   // Derived: filtered tasks for current selection, scoped by dropdown project
   const baseFilteredTasks = useMemo(() => {
-    const base = getFilteredTasks(tasks, selectedId, selectedType, projects)
+    const base = getFilteredTasks(tasks, selectedId, selectedType, projects, false, currentDay)
     return scopeTasksByProject(base, selectedProjectId)
-  }, [tasks, selectedId, selectedType, projects, selectedProjectId])
+  }, [tasks, selectedId, selectedType, projects, selectedProjectId, currentDay])
 
   // Apply advanced filters and sort to base filtered tasks
   const { filteredTasks, totalCount, filteredCount } = useFilteredAndSortedTasks({
@@ -424,12 +427,12 @@ export const TasksPage = ({
   // Null on the "all" tab, which has no window.
   const windowFilteredTasks = useMemo(() => {
     if (activeInternalTab === 'all') return null
-    return getTasksInDueWindow(filteredTasks, projects, activeInternalTab)
-  }, [activeInternalTab, filteredTasks, projects])
+    return getTasksInDueWindow(filteredTasks, projects, activeInternalTab, currentDay)
+  }, [activeInternalTab, filteredTasks, projects, currentDay])
 
   // Counted off what is actually on screen, so a window empties for the same
   // reason the "all" list does. A filter and a window can contradict each other
-  // outright — "No due date" inside Today can never match — and without this the
+  // outright, and without this the
   // page just goes blank with nothing saying the filters did it.
   const visibleCount = windowFilteredTasks?.length ?? filteredCount
   const showFilterEmptyState = filtersActive && visibleCount === 0 && totalCount > 0
@@ -500,7 +503,9 @@ export const TasksPage = ({
   const tabCounts = useMemo((): TasksTabCounts => {
     const scopedTasks = scopeTasksByProject(tasks, selectedProjectId)
     const countWindow = (window: TaskDueWindow): number =>
-      getTasksInDueWindow(scopedTasks, projects, window).filter((t) => t.parentId === null).length
+      getTasksInDueWindow(scopedTasks, projects, window, currentDay).filter(
+        (t) => t.parentId === null
+      ).length
 
     return {
       all: getFilteredTasks(scopedTasks, 'all', 'view', projects).length,
@@ -508,7 +513,7 @@ export const TasksPage = ({
       tomorrow: countWindow('tomorrow'),
       next7: countWindow('next7')
     }
-  }, [tasks, projects, selectedProjectId])
+  }, [tasks, projects, selectedProjectId, currentDay])
 
   // Done section per scope. "Today" keeps its completed-today rule — that is the
   // day's progress, and it is what the celebration counts. The other windows

--- a/apps/desktop/tsconfig.test.web.json
+++ b/apps/desktop/tsconfig.test.web.json
@@ -83,7 +83,6 @@
     "src/renderer/src/components/tasks/kanban/kanban-column-extra.test.tsx",
     "src/renderer/src/components/tasks/kanban/kanban-columns.test.ts",
     "src/renderer/src/components/tasks/project/virtualized-project-task-list.test.tsx",
-    "src/renderer/src/components/tasks/task-detail-drawer.test.tsx",
     "src/renderer/src/components/tasks/task-row-extra.test.tsx",
     "src/renderer/src/components/tasks/task-section.test.tsx",
     "src/renderer/src/components/tasks/virtualized-all-tasks-view.test.tsx",

--- a/apps/docs/src/user-guide/tasks/capturing.md
+++ b/apps/docs/src/user-guide/tasks/capturing.md
@@ -186,3 +186,15 @@ A task's description is a rich text editor, the same style as notes. In the task
 - [List vs Kanban](/user-guide/tasks/list-vs-kanban) — view options
 - [Filters & Sorting](/user-guide/tasks/filters-sorting)
 - [Subtasks & Recurrence](/user-guide/tasks/subtasks-recurrence)
+
+## Start dates for longer tasks
+
+Open a task's details and select **Start date** to choose when work should begin.
+The **Due Date** remains its deadline. For example, a task starting Monday and due
+Friday appears in **Today** every day from Monday through Friday. Set its status
+to **In progress** when you begin; the start date does not change the status.
+
+An unfinished task stays in Today after its deadline as overdue. A task with a
+start date but no deadline stays in Today until completed. Clear the start date
+to remove this scheduling behavior. Tasks without a start date keep their existing
+due-date behavior.

--- a/packages/i18n/src/locales/en/tasks.json
+++ b/packages/i18n/src/locales/en/tasks.json
@@ -31,6 +31,8 @@
     "status": "Status",
     "priority": "Priority",
     "tags": "Tags",
+    "startDate": "Start date",
+    "changeStartDate": "Start: {date}. Click to change.",
     "dueDate": "Due Date",
     "reminder": "Reminder",
     "project": "Project",

--- a/packages/i18n/src/locales/tr/tasks.json
+++ b/packages/i18n/src/locales/tr/tasks.json
@@ -28,6 +28,8 @@
     "details": "Görev ayrıntıları",
     "status": "Durum",
     "priority": "Öncelik",
+    "startDate": "Başlangıç tarihi",
+    "changeStartDate": "Başlangıç: {date}. Değiştirmek için tıklayın.",
     "dueDate": "Son Tarih",
     "project": "Proje",
     "repeat": "Tekrarla",


### PR DESCRIPTION
## Summary

- expose task start dates in the desktop task model and detail drawer
- keep started tasks in Today through their due date, then show them as overdue
- persist start-date updates without changing due dates and document the behavior

## Release note

Tasks can now have a start date and remain visible in Today while they are active.

## Test plan

- `pnpm --filter @memry/desktop test:renderer`
- `pnpm --filter @memry/desktop typecheck:web`
- `pnpm --filter @memry/desktop typecheck:test`
- `pnpm --filter @memry/desktop i18n:check`
- `pnpm lint`
- `pnpm docs:impact --base origin/main --strict`
- `pnpm docs:build`
- `git diff --check`