### PR TITLE
fix(vault): keep properties at frontmatter root

### DIFF
--- a/apps/desktop/src/main/sync/content-sync-services.test.ts
+++ b/apps/desktop/src/main/sync/content-sync-services.test.ts
@@ -157,6 +157,8 @@ vi.mock('../vault/frontmatter', () => ({
 }))
 
 vi.mock('../vault/journal', () => ({
+  extractJournalProperties: (frontmatter: { properties?: Record<string, unknown> }) =>
+    frontmatter.properties,
   getJournalPath: (date: string) => `/vault/journals/${date}.md`,
   parseJournalEntry: (...args: unknown[]) => mocks.parseJournalEntry(...args)
 }))

--- a/apps/desktop/src/main/sync/item-handlers/journal-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/journal-handler.test.ts
@@ -51,6 +51,7 @@ vi.mock('@memry/domain-notes', () => ({
 
 vi.mock('../../vault/journal', () => ({
   deleteJournalEntryFile: (...args: unknown[]) => mockDeleteJournalEntryFile(...args),
+  extractJournalProperties: vi.fn(() => ({ Mood: 'focused' })),
   getJournalPath: vi.fn(() => journalFilePath),
   getJournalRelativePath: vi.fn((date: string) => `journals/${date}.md`),
   parseJournalEntry: vi.fn((_raw: string, date: string) => ({

--- a/apps/desktop/src/main/sync/item-handlers/journal-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/journal-handler.ts
@@ -12,6 +12,7 @@ import { getNoteMetadataById, updateNoteMetadata } from '@memry/storage-data'
 import { saveCanonicalNote } from '@memry/domain-notes'
 import {
   deleteJournalEntryFile,
+  extractJournalProperties,
   getJournalPath,
   getJournalRelativePath,
   parseJournalEntry,
@@ -206,9 +207,7 @@ class JournalHandler extends BaseItemHandler<JournalSyncPayload> {
       const parsed = parseJournalEntry(raw, cached.journalDate)
       content = operation === 'create' ? parsed.content : null
       tags = parsed.frontmatter.tags ?? []
-      if (parsed.frontmatter.properties) {
-        properties = parsed.frontmatter.properties as Record<string, unknown>
-      }
+      properties = extractJournalProperties(parsed.frontmatter) ?? null
     } catch {
       log.warn('Could not read journal file for push payload', {
         noteId: cached.id,

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.test.ts
@@ -35,7 +35,12 @@ vi.mock('../../vault/frontmatter', () => ({
       definitionType: string | undefined,
       inferFn: (name: string, value: unknown) => string
     ) => (name === 'project' ? 'project' : (definitionType ?? inferFn(name, value)))
-  )
+  ),
+  replacePropertiesOnRoot: vi.fn((frontmatter, properties) => {
+    const next = { ...frontmatter }
+    delete next.properties
+    return { ...next, ...properties }
+  })
 }))
 
 vi.mock('../../vault/note-sync', () => ({

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.ts
@@ -40,6 +40,7 @@ import {
   extractInlineTagsFromMarkdown,
   inferPropertyType,
   resolvePropertyType,
+  replacePropertiesOnRoot,
   type NoteFrontmatter
 } from '../../vault/frontmatter'
 import { isPersistableDefinitionType, type PropertyType } from '@memry/contracts/property-types'
@@ -360,11 +361,7 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
               }
             }
             if (propertiesPresent) {
-              if (Object.keys(remoteProperties).length > 0) {
-                parsed.frontmatter.properties = remoteProperties
-              } else {
-                delete parsed.frontmatter.properties
-              }
+              parsed.frontmatter = replacePropertiesOnRoot(parsed.frontmatter, remoteProperties)
             }
             const updatedContent = serializeParsedNote(parsed, parsed.content, {
               frontmatterEdited: true
@@ -414,11 +411,7 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
             }
           }
           if (propertiesPresent) {
-            if (Object.keys(remoteProperties).length > 0) {
-              parsed.frontmatter.properties = remoteProperties
-            } else {
-              delete parsed.frontmatter.properties
-            }
+            parsed.frontmatter = replacePropertiesOnRoot(parsed.frontmatter, remoteProperties)
           }
           const updatedContent = serializeParsedNote(parsed, parsed.content, {
             frontmatterEdited: true

--- a/apps/desktop/src/main/sync/journal-sync.test.ts
+++ b/apps/desktop/src/main/sync/journal-sync.test.ts
@@ -38,6 +38,8 @@ vi.mock('../database/client', () => ({
 vi.mock('../vault/journal', async () => {
   const matter = (await import('gray-matter')).default
   return {
+    extractJournalProperties: (frontmatter: { properties?: Record<string, unknown> }) =>
+      frontmatter.properties,
     getJournalPath: (date: string) => path.join(h.journalDir, `${date}.md`),
     parseJournalEntry: (raw: string, date: string) => {
       const parsed = matter(raw)

--- a/apps/desktop/src/main/sync/journal-sync.ts
+++ b/apps/desktop/src/main/sync/journal-sync.ts
@@ -4,7 +4,7 @@ import type { JournalSyncPayload } from '@memry/contracts/sync-payloads'
 import type { NoteMetadata } from '@memry/db-schema/data-schema'
 import { ContentSyncService, type ContentSyncDeps } from './content-sync-base'
 import { createLogger } from '../lib/logger'
-import { getJournalPath, parseJournalEntry } from '../vault/journal'
+import { extractJournalProperties, getJournalPath, parseJournalEntry } from '../vault/journal'
 
 const log = createLogger('JournalSync')
 
@@ -74,9 +74,7 @@ export class JournalSyncService extends ContentSyncService<JournalSyncPayload, [
       const parsed = parseJournalEntry(raw, date)
       content = operation === 'create' ? parsed.content : null
       tags = parsed.frontmatter.tags ?? []
-      if (parsed.frontmatter.properties) {
-        properties = parsed.frontmatter.properties as Record<string, unknown>
-      }
+      properties = extractJournalProperties(parsed.frontmatter) ?? null
     } catch {
       log.warn('Could not read journal file for sync snapshot', { noteId: cached.id, date })
     }

--- a/apps/desktop/src/main/vault/frontmatter.test.ts
+++ b/apps/desktop/src/main/vault/frontmatter.test.ts
@@ -13,6 +13,9 @@ import {
   calculateWordCount,
   generateContentHash,
   extractProperties,
+  normalizePropertiesToRoot,
+  replacePropertiesOnRoot,
+  writePropertiesToRoot,
   resolvePropertyType,
   inferPropertyType,
   serializePropertyValue,
@@ -140,6 +143,17 @@ describe('frontmatter serialization', () => {
     expect(serializeNote({}, 'Body text\n')).toBe('Body text\n')
     expect(serializeNote({ skipped: undefined }, 'Body text')).toBe('Body text\n')
   })
+
+  it('serializes legacy nested properties at the root', () => {
+    const output = serializeNote(
+      { status: 'active', properties: { status: 'idea', owner: 'Kaan' } },
+      'Body text'
+    )
+
+    expect(output).toMatch(/^status: active$/m)
+    expect(output).toMatch(/^owner: Kaan$/m)
+    expect(output).not.toMatch(/^properties:/m)
+  })
 })
 
 describe('frontmatter utilities', () => {
@@ -219,15 +233,65 @@ Another line with words.
 })
 
 describe('properties helpers', () => {
-  it('extractProperties prefers explicit properties object', () => {
+  it('merges nested properties with root properties, keeping root conflicts', () => {
     const frontmatter: NoteFrontmatter = {
-      id: 'abc123def456',
-      created: FIXED_ISO,
-      modified: FIXED_ISO,
-      properties: { rating: 5, owner: 'alex' }
+      status: 'active',
+      properties: { rating: 5, owner: 'alex', status: 'idea' }
     }
 
-    expect(extractProperties(frontmatter)).toEqual({ rating: 5, owner: 'alex' })
+    expect(extractProperties(frontmatter)).toEqual({
+      rating: 5,
+      owner: 'alex',
+      status: 'active'
+    })
+  })
+
+  it('normalizes nested properties into root keys without losing root values', () => {
+    const result = normalizePropertiesToRoot({
+      tags: ['mobile'],
+      status: 'active',
+      properties: { status: 'idea', owner: 'Kaan' }
+    })
+
+    expect(result).toEqual({
+      frontmatter: { tags: ['mobile'], status: 'active', owner: 'Kaan' },
+      changed: true,
+      conflicts: ['status']
+    })
+  })
+
+  it('does not promote reserved nested keys into user properties', () => {
+    const result = normalizePropertiesToRoot({
+      properties: { tags: ['legacy-tag'], aliases: ['legacy-alias'], owner: 'Kaan' }
+    })
+
+    expect(result.frontmatter).toEqual({ owner: 'Kaan' })
+    expect(extractProperties({ properties: { tags: ['legacy-tag'], owner: 'Kaan' } })).toEqual({
+      owner: 'Kaan'
+    })
+  })
+
+  it('writes a property record at the root and preserves metadata keys', () => {
+    expect(
+      writePropertiesToRoot(
+        { tags: ['mobile'], aliases: ['Launch'] },
+        { status: 'active', owner: 'Kaan' }
+      )
+    ).toEqual({
+      tags: ['mobile'],
+      aliases: ['Launch'],
+      status: 'active',
+      owner: 'Kaan'
+    })
+  })
+
+  it('replaces root properties without bringing back the nested envelope', () => {
+    expect(
+      replacePropertiesOnRoot(
+        { tags: ['mobile'], status: 'old', properties: { owner: 'old' } },
+        { status: 'active' }
+      )
+    ).toEqual({ tags: ['mobile'], status: 'active' })
   })
 
   it('extractProperties falls back to non-reserved keys', () => {

--- a/apps/desktop/src/main/vault/frontmatter.ts
+++ b/apps/desktop/src/main/vault/frontmatter.ts
@@ -174,7 +174,7 @@ export function extractTitleFromPath(filePath: string): string {
  * @returns Complete markdown file content
  */
 export function serializeNote(frontmatter: NoteFrontmatter, content: string): string {
-  return writeMarkdownNote(frontmatter, content)
+  return writeMarkdownNote(normalizePropertiesToRoot(frontmatter).frontmatter, content)
 }
 
 export interface SerializeParsedNoteOptions {
@@ -361,28 +361,98 @@ export function generateContentHash(content: string): string {
 import { PROJECT_PROPERTY_KEY, type PropertyType } from '@memry/contracts/property-types'
 
 /**
- * Reserved frontmatter keys that are NOT properties — only the two keys with
- * Obsidian-defined semantics that Memry reads. Legacy Memry keys (id, title,
- * created, modified, emoji, localOnly) are plain user properties.
+ * Reserved frontmatter keys that are not user properties. `properties` is kept
+ * here as the legacy nested-property envelope while it is migrated away.
+ * Legacy Memry keys (id, title, created, modified, emoji, localOnly) are plain
+ * user properties.
  */
-const RESERVED_FRONTMATTER_KEYS = new Set(['tags', 'aliases'])
+const RESERVED_FRONTMATTER_KEYS = new Set(['tags', 'aliases', 'properties'])
+
+export interface NormalizedPropertiesResult {
+  frontmatter: NoteFrontmatter
+  changed: boolean
+  /** Property names present in both locations. The root value wins. */
+  conflicts: string[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+/**
+ * Move the legacy nested property envelope into top-level frontmatter keys.
+ * Existing root values win when both locations contain the same property.
+ */
+export function normalizePropertiesToRoot(
+  frontmatter: NoteFrontmatter
+): NormalizedPropertiesResult {
+  if (!isRecord(frontmatter.properties)) {
+    return { frontmatter, changed: false, conflicts: [] }
+  }
+
+  const normalized = { ...frontmatter }
+  delete normalized.properties
+
+  const conflicts: string[] = []
+  for (const [name, value] of Object.entries(frontmatter.properties)) {
+    if (RESERVED_FRONTMATTER_KEYS.has(name)) continue
+    if (Object.prototype.hasOwnProperty.call(normalized, name)) {
+      conflicts.push(name)
+      continue
+    }
+    normalized[name] = value
+  }
+
+  return { frontmatter: normalized, changed: true, conflicts }
+}
+
+/** Write a property record as top-level user frontmatter keys. */
+export function writePropertiesToRoot(
+  frontmatter: NoteFrontmatter,
+  properties: Record<string, unknown>
+): NoteFrontmatter {
+  const next = { ...frontmatter }
+  for (const [name, value] of Object.entries(properties)) {
+    if (RESERVED_FRONTMATTER_KEYS.has(name)) continue
+    if (value === undefined) delete next[name]
+    else next[name] = value
+  }
+  return next
+}
+
+/** Replace the current property record while keeping tags and aliases. */
+export function replacePropertiesOnRoot(
+  frontmatter: NoteFrontmatter,
+  properties: Record<string, unknown>
+): NoteFrontmatter {
+  const normalized = { ...normalizePropertiesToRoot(frontmatter).frontmatter }
+  for (const name of Object.keys(extractProperties(normalized))) {
+    delete normalized[name]
+  }
+  return writePropertiesToRoot(normalized, properties)
+}
 
 /**
  * Extract custom properties from frontmatter.
- * T007: Properties are stored under the `properties` key or as top-level keys
- * (excluding reserved keys like id, title, created, modified, tags, aliases).
+ * T007: Properties may still be read from the legacy `properties` key, but
+ * top-level keys are canonical and win on conflicts.
  *
  * @param frontmatter - Parsed frontmatter object
  * @returns Record of property names to values
  */
 export function extractProperties(frontmatter: NoteFrontmatter): Record<string, unknown> {
-  // Check for explicit `properties` object first
-  if (frontmatter.properties && typeof frontmatter.properties === 'object') {
-    return frontmatter.properties as Record<string, unknown>
+  const properties: Record<string, unknown> = {}
+
+  // Nested properties are a legacy format. Read them for compatibility, then
+  // overlay top-level keys so an Obsidian edit wins a stale nested value.
+  if (isRecord(frontmatter.properties)) {
+    for (const [key, value] of Object.entries(frontmatter.properties)) {
+      if (!RESERVED_FRONTMATTER_KEYS.has(key) && value !== undefined) properties[key] = value
+    }
   }
 
-  // Fall back to extracting non-reserved top-level keys
-  const properties: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(frontmatter)) {
     if (!RESERVED_FRONTMATTER_KEYS.has(key) && value !== undefined) {
       properties[key] = value

--- a/apps/desktop/src/main/vault/index.test.ts
+++ b/apps/desktop/src/main/vault/index.test.ts
@@ -46,6 +46,9 @@ const mocks = vi.hoisted(() => ({
   flipOpenPagesInNewTabDefault: vi.fn(),
   reloadPropertyDefinitions: vi.fn(),
   destroyPropertyDefinitions: vi.fn(),
+  getSetting: vi.fn(),
+  setSetting: vi.fn(),
+  migrateNestedPropertiesToRoot: vi.fn(),
   migrateSettingsToConfig: vi.fn(),
   snapshotProjectFrontmatterBackfill: vi.fn(),
   applyProjectFrontmatterBackfill: vi.fn(),
@@ -154,6 +157,11 @@ vi.mock('../database/defaults', () => ({
   ensureDefaultTaskProject: (...args: unknown[]) => mocks.ensureDefaultTaskProject(...args)
 }))
 
+vi.mock('../database/queries/settings', () => ({
+  getSetting: (...args: unknown[]) => mocks.getSetting(...args),
+  setSetting: (...args: unknown[]) => mocks.setSetting(...args)
+}))
+
 vi.mock('./watcher', () => ({
   startWatcher: (...args: unknown[]) => mocks.startWatcher(...args),
   stopWatcher: (...args: unknown[]) => mocks.stopWatcher(...args)
@@ -258,6 +266,13 @@ vi.mock('./backfill-project-frontmatter', () => ({
     mocks.applyProjectFrontmatterBackfill(...args)
 }))
 
+vi.mock('./root-properties-migration', () => ({
+  migrateNestedPropertiesToRoot: (...args: unknown[]) =>
+    mocks.migrateNestedPropertiesToRoot(...args),
+  ROOT_PROPERTIES_MIGRATION_DONE: 'done',
+  ROOT_PROPERTIES_MIGRATION_KEY: 'frontmatterPropertiesRootV1'
+}))
+
 vi.mock('./templates-migration', () => ({
   migrateTemplateFilesToDb: (...args: unknown[]) => mocks.migrateTemplateFilesToDb(...args)
 }))
@@ -325,6 +340,16 @@ describe('vault lifecycle', () => {
     mocks.startWatcher.mockResolvedValue(undefined)
     mocks.stopWatcher.mockResolvedValue(undefined)
     mocks.reloadPropertyDefinitions.mockResolvedValue(undefined)
+    mocks.getSetting.mockReturnValue('done')
+    mocks.migrateNestedPropertiesToRoot.mockResolvedValue({
+      scanned: 0,
+      migrated: 0,
+      migratedPaths: [],
+      skipped: 0,
+      deferred: 0,
+      failed: 0,
+      conflicts: []
+    })
     mocks.startSyncRuntime.mockResolvedValue(undefined)
     mocks.stopSyncRuntime.mockResolvedValue(undefined)
     mocks.initCrdtPersistence.mockResolvedValue(undefined)
@@ -461,6 +486,39 @@ describe('vault lifecycle', () => {
     await vi.waitFor(() => expect(mocks.applyProjectFrontmatterBackfill).toHaveBeenCalled())
     expect(mocks.applyProjectFrontmatterBackfill.mock.invocationCallOrder[0]).toBeGreaterThan(
       mocks.indexVault.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('migrates legacy nested properties before starting the watcher', async () => {
+    mocks.getSetting.mockReturnValue(null)
+    mocks.migrateNestedPropertiesToRoot.mockResolvedValue({
+      scanned: 4,
+      migrated: 2,
+      migratedPaths: ['notes/Mobile.md', 'notes/Other.md'],
+      skipped: 2,
+      deferred: 0,
+      failed: 0,
+      conflicts: ['status']
+    })
+
+    await selectVault({ path: '/vault/work' })
+
+    expect(mocks.migrateNestedPropertiesToRoot).toHaveBeenCalledWith('/vault/work', {
+      excludePatterns: ['.git']
+    })
+    expect(mocks.setSetting).toHaveBeenCalledWith(
+      { kind: 'data-db' },
+      'frontmatterPropertiesRootV1',
+      'done'
+    )
+    expect(mocks.migrateNestedPropertiesToRoot.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.startWatcher.mock.invocationCallOrder[0]
+    )
+    await vi.waitFor(() =>
+      expect(mocks.indexVault).toHaveBeenCalledWith('/vault/work', {
+        shouldStop: expect.any(Function),
+        forcePaths: ['notes/Mobile.md', 'notes/Other.md']
+      })
     )
   })
 

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -72,11 +72,17 @@ import { createEmbeddingProjector } from '../projections/projectors/embedding-pr
 import { createInboxStatsProjector } from '../projections/projectors/inbox-stats-projector'
 import { createNoteProjectLinksProjector } from '../projections/projectors/note-project-links-projector'
 import { PropertyDefinitionsService } from './property-definitions'
+import { getSetting, setSetting } from '../database/queries/settings'
 import { migrateSettingsToConfig } from './settings-cache'
 import {
   applyProjectFrontmatterBackfill,
   snapshotProjectFrontmatterBackfill
 } from './backfill-project-frontmatter'
+import {
+  migrateNestedPropertiesToRoot,
+  ROOT_PROPERTIES_MIGRATION_DONE,
+  ROOT_PROPERTIES_MIGRATION_KEY
+} from './root-properties-migration'
 import { promoteSpatialCanvas } from '../settings/promote-spatial-canvas'
 import { flipOpenPagesInNewTabDefault } from '../settings/flip-open-pages-in-new-tab'
 import { migrateTemplateFilesToDb } from './templates-migration'
@@ -414,6 +420,7 @@ interface BackgroundIndexBuildInput {
   vaultPath: string
   dataDb: ReturnType<typeof getDatabase>
   indexHealth: IndexHealth
+  forcePaths: string[]
   /** Non-null when openVault reset the index DB and a recovery event is owed. */
   recoveredReason: IndexHealth | 'migration_failed' | null
 }
@@ -435,7 +442,7 @@ interface BackgroundIndexBuildInput {
  * paths already cached.
  */
 async function runBackgroundIndexBuild(input: BackgroundIndexBuildInput): Promise<void> {
-  const { vaultPath, dataDb, indexHealth, recoveredReason } = input
+  const { vaultPath, dataDb, indexHealth, recoveredReason, forcePaths } = input
   const startedAt = Date.now()
   // currentStatus.path stays vaultPath for the whole build: closeVault() nulls
   // it only after awaiting this promise, and a vault switch closes first.
@@ -445,8 +452,15 @@ async function runBackgroundIndexBuild(input: BackgroundIndexBuildInput): Promis
   try {
     // Indexes every new/missing note; skips files already in cache, so this is
     // fast for subsequent opens of an up-to-date vault.
-    const result = await indexVault(vaultPath, { shouldStop: isStale })
+    const result = await indexVault(vaultPath, {
+      shouldStop: isStale,
+      ...(forcePaths.length > 0 ? { forcePaths } : {})
+    })
     if (result.cancelled || isStale()) return
+
+    if (forcePaths.length > 0 && result.errors === 0) {
+      setSetting(dataDb, ROOT_PROPERTIES_MIGRATION_KEY, ROOT_PROPERTIES_MIGRATION_DONE)
+    }
 
     if (recoveredReason) {
       // Notify renderer about recovery
@@ -609,6 +623,7 @@ async function openVault(vaultPath: string): Promise<void> {
   // whatever index exists; runBackgroundIndexBuild() repopulates it after
   // isOpen, with progress on the existing index-progress plumbing.
   let recoveredReason: IndexHealth | 'migration_failed' | null = null
+  let migratedRootPropertyPaths: string[] = []
   try {
     if (needsFullIndexRebuild) {
       // Index is corrupt or missing — reset the DB file now so every consumer
@@ -634,6 +649,36 @@ async function openVault(vaultPath: string): Promise<void> {
     // Reload property definitions into DB cache before indexing
     // so getPropertyType() finds correct types during note sync
     await propDefService.reload()
+
+    const migrationState = getSetting(dataDb, ROOT_PROPERTIES_MIGRATION_KEY)
+    if (migrationState !== ROOT_PROPERTIES_MIGRATION_DONE) {
+      const pendingPaths = pendingRootPropertyPaths(migrationState)
+      const migration = await migrateNestedPropertiesToRoot(vaultPath, {
+        excludePatterns: readVaultConfig(vaultPath).excludePatterns
+      })
+      migratedRootPropertyPaths = [
+        ...new Set([...pendingPaths, ...(migration.migratedPaths ?? [])])
+      ]
+      if (migration.deferred === 0 && migration.failed === 0) {
+        setSetting(
+          dataDb,
+          ROOT_PROPERTIES_MIGRATION_KEY,
+          migratedRootPropertyPaths.length > 0
+            ? JSON.stringify({ paths: migratedRootPropertyPaths })
+            : ROOT_PROPERTIES_MIGRATION_DONE
+        )
+      } else if (migratedRootPropertyPaths.length > 0) {
+        // Preserve paths already written before a partial pass failed. The
+        // next open will retry both the write and the cache refresh.
+        setSetting(
+          dataDb,
+          ROOT_PROPERTIES_MIGRATION_KEY,
+          JSON.stringify({ paths: migratedRootPropertyPaths })
+        )
+      } else {
+        logger.warn('Root property migration will retry on the next vault open', migration)
+      }
+    }
   } catch (error) {
     logger.error('Index database init failed:', error)
     trackMainError('vault', 'index_on_open', error)
@@ -674,7 +719,8 @@ async function openVault(vaultPath: string): Promise<void> {
     vaultPath,
     dataDb,
     indexHealth,
-    recoveredReason
+    recoveredReason,
+    forcePaths: migratedRootPropertyPaths
   })
 
   // Register the agent IPC handlers before the sync runtime starts: agent chat
@@ -701,6 +747,18 @@ async function openVault(vaultPath: string): Promise<void> {
     logger.error('Sync runtime start failed after vault open:', error)
     trackMainError('vault', 'sync_runtime_start', error)
   })
+}
+
+function pendingRootPropertyPaths(value: string | null): string[] {
+  if (!value || value === ROOT_PROPERTIES_MIGRATION_DONE) return []
+  try {
+    const parsed = JSON.parse(value) as { paths?: unknown }
+    return Array.isArray(parsed.paths)
+      ? parsed.paths.filter((path): path is string => typeof path === 'string')
+      : []
+  } catch {
+    return []
+  }
 }
 
 /**

--- a/apps/desktop/src/main/vault/indexer.test.ts
+++ b/apps/desktop/src/main/vault/indexer.test.ts
@@ -19,6 +19,7 @@ import { createTestDataDb, createTestIndexDb, type TestDatabaseResult } from '@t
 import type { VaultConfig } from '@memry/contracts/vault-api'
 import { noteMetadata } from '@memry/db-schema/data-schema'
 import { noteCache, noteTags, noteLinks } from '@memry/db-schema/schema/notes-cache'
+import { getNoteProperties } from '../database/queries/notes/property-queries'
 import { createNoteDerivedStateProjector } from '../projections/projectors/note-derived-state-projector'
 import { startProjectionRuntime, stopProjectionRuntime } from '../projections'
 
@@ -258,6 +259,36 @@ describe('indexer', () => {
       expect(second.indexed).toBe(0)
       // ...and no file was read or parsed to decide that.
       expect(vi.mocked(readFile).mock.calls).toHaveLength(0)
+    })
+
+    it('reindexes cached files listed in forcePaths', async () => {
+      const notePath = createTestNote(tempVault, {
+        title: 'Migrated Note',
+        content: 'Content',
+        properties: { status: 'idea' }
+      })
+      const relativePath = path.relative(tempVault.path, notePath).replace(/\\/g, '/')
+
+      await indexer.indexVault(tempVault.path)
+      const cached = testDb.db.select().from(noteCache).get()
+      expect(cached).toBeDefined()
+      expect(getNoteProperties(testDb.db, cached!.id).find((p) => p.name === 'status')?.value).toBe(
+        'idea'
+      )
+
+      fs.writeFileSync(
+        notePath,
+        '---\nid: copied-id\ntitle: Migrated Note\nstatus: active\n---\n\nContent',
+        'utf8'
+      )
+
+      const result = await indexer.indexVault(tempVault.path, { forcePaths: [relativePath] })
+
+      expect(result.indexed).toBe(1)
+      expect(result.skipped).toBe(0)
+      expect(getNoteProperties(testDb.db, cached!.id).find((p) => p.name === 'status')?.value).toBe(
+        'active'
+      )
     })
 
     it('T374: emits progress events', async () => {

--- a/apps/desktop/src/main/vault/indexer.ts
+++ b/apps/desktop/src/main/vault/indexer.ts
@@ -60,6 +60,8 @@ export interface IndexVaultOptions {
    * cache and indexes the rest.
    */
   shouldStop?: () => boolean
+  /** Paths whose frontmatter changed before this pass and must be re-read. */
+  forcePaths?: readonly string[]
 }
 
 // ============================================================================
@@ -123,7 +125,8 @@ async function findVaultFiles(
  */
 async function indexFile(
   vaultPath: string,
-  relativePath: string
+  relativePath: string,
+  forcePaths: ReadonlySet<string>
 ): Promise<'indexed' | 'skipped' | 'error'> {
   const absolutePath = path.join(vaultPath, relativePath)
   const fileType = getFileType(getExtension(absolutePath))
@@ -138,7 +141,7 @@ async function indexFile(
 
     // Check if already in cache by path
     const existingByPath = getNoteCacheByPath(db, relativePath)
-    if (existingByPath) {
+    if (existingByPath && !forcePaths.has(relativePath)) {
       return 'skipped'
     }
 
@@ -335,6 +338,7 @@ export async function indexVault(
   logger.debug('Starting vault indexing:', vaultPath)
 
   const shouldStop = options.shouldStop ?? ((): boolean => false)
+  const forcePaths = new Set(options.forcePaths ?? [])
   const config = getConfig()
   const excludePatterns = config.excludePatterns ?? []
   const result: IndexResult = {
@@ -382,7 +386,7 @@ export async function indexVault(
       return { i, status: 'cancelled' as const }
     }
 
-    const status = await indexFile(vaultPath, file)
+    const status = await indexFile(vaultPath, file, forcePaths)
     completed++
 
     // Emit progress every 10 completions to reduce IPC overhead. Suppressed once

--- a/apps/desktop/src/main/vault/journal.test.ts
+++ b/apps/desktop/src/main/vault/journal.test.ts
@@ -254,6 +254,19 @@ describe('extractJournalProperties', () => {
     })
   })
 
+  it('merges nested and top-level properties, keeping the root value on conflict', () => {
+    const frontmatter = {
+      date: '2026-01-15',
+      status: 'active',
+      properties: { status: 'idea', mood: 'focused' }
+    }
+
+    expect(extractJournalProperties(frontmatter)).toEqual({
+      status: 'active',
+      mood: 'focused'
+    })
+  })
+
   it('ignores reserved frontmatter keys', () => {
     const frontmatter = {
       id: 'j2026-01-15',
@@ -438,6 +451,19 @@ Today I worked on tests.`
       // Verify file was written
       const filePath = path.join(tempVault.path, 'journal', '2026-01-15.md')
       expect(fs.existsSync(filePath)).toBe(true)
+    })
+
+    it('writes journal properties as top-level frontmatter keys', async () => {
+      await writeJournalEntry('2026-01-15', 'New journal entry', undefined, {
+        status: 'active',
+        owner: 'Kaan'
+      })
+
+      const filePath = path.join(tempVault.path, 'journal', '2026-01-15.md')
+      const raw = fs.readFileSync(filePath, 'utf8')
+      expect(raw).toMatch(/^status: active$/m)
+      expect(raw).toMatch(/^owner: Kaan$/m)
+      expect(raw).not.toMatch(/^properties:/m)
     })
 
     it('T381: updates existing journal entry', async () => {

--- a/apps/desktop/src/main/vault/journal.ts
+++ b/apps/desktop/src/main/vault/journal.ts
@@ -13,6 +13,7 @@ import matter from 'gray-matter'
 import { createNoteContentStore } from '@memry/storage-vault'
 import { replaceWikiLinks } from '@memry/shared/wiki-target'
 import { getStatus, getConfig } from './index'
+import { normalizePropertiesToRoot, writePropertiesToRoot } from './frontmatter'
 import { ensureDirectory } from './file-ops'
 import { VaultError, VaultErrorCode } from '../lib/errors'
 import {
@@ -29,7 +30,7 @@ import {
 
 /**
  * Journal entry frontmatter fields. Every key is a plain user property;
- * Memry writes only `date` (and `tags`/`properties` on explicit edit).
+ * Memry writes only `date`, `tags`, and top-level user properties.
  * Legacy Memry keys (id, created, modified) are plain user properties.
  */
 export interface JournalFrontmatter {
@@ -146,7 +147,8 @@ export function parseJournalEntry(rawContent: string, date: string): ParsedJourn
  * @returns Complete markdown file content
  */
 export function serializeJournalEntry(frontmatter: JournalFrontmatter, content: string): string {
-  const clean = Object.fromEntries(Object.entries(frontmatter).filter(([, v]) => v !== undefined))
+  const normalized = normalizePropertiesToRoot(frontmatter).frontmatter
+  const clean = Object.fromEntries(Object.entries(normalized).filter(([, v]) => v !== undefined))
 
   if (Object.keys(clean).length === 0) {
     return content.trim()
@@ -185,10 +187,16 @@ const RESERVED_JOURNAL_KEYS = new Set([
   'emoji'
 ])
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
 /**
  * Extract custom properties from journal frontmatter.
- * Properties can be stored under the `properties` key or as top-level keys
- * (excluding reserved keys like id, date, created, modified, tags).
+ * Legacy entries may store properties under `properties`; top-level keys are
+ * canonical and win on conflicts.
  *
  * @param frontmatter - Parsed frontmatter object
  * @returns Record of property names to values, or undefined if no properties
@@ -196,14 +204,16 @@ const RESERVED_JOURNAL_KEYS = new Set([
 export function extractJournalProperties(
   frontmatter: JournalFrontmatter
 ): Record<string, unknown> | undefined {
-  // Check for explicit `properties` object first
-  if (frontmatter.properties && typeof frontmatter.properties === 'object') {
-    const props = frontmatter.properties as Record<string, unknown>
-    return Object.keys(props).length > 0 ? props : undefined
+  const properties: Record<string, unknown> = {}
+
+  // Nested properties are a legacy format. Read them for compatibility, then
+  // overlay top-level keys so a root edit wins a stale nested value.
+  if (isRecord(frontmatter.properties)) {
+    for (const [key, value] of Object.entries(frontmatter.properties)) {
+      if (key !== 'properties' && value !== undefined) properties[key] = value
+    }
   }
 
-  // Fall back to extracting non-reserved top-level keys
-  const properties: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(frontmatter)) {
     if (!RESERVED_JOURNAL_KEYS.has(key) && value !== undefined) {
       properties[key] = value
@@ -291,7 +301,7 @@ export async function writeJournalEntryWithContent(
     if (properties !== undefined) {
       // Explicitly provided properties (can be empty object to clear)
       if (Object.keys(properties).length > 0) {
-        frontmatter.properties = properties
+        frontmatter = writePropertiesToRoot(frontmatter, properties)
       }
       // If properties is empty object, don't add to frontmatter (effectively clearing)
     } else if (existing.properties && Object.keys(existing.properties).length > 0) {
@@ -304,7 +314,7 @@ export async function writeJournalEntryWithContent(
 
     // Add properties for new entry if provided
     if (properties && Object.keys(properties).length > 0) {
-      frontmatter.properties = properties
+      frontmatter = writePropertiesToRoot(frontmatter, properties)
     }
   }
 

--- a/apps/desktop/src/main/vault/notes-crud.ts
+++ b/apps/desktop/src/main/vault/notes-crud.ts
@@ -16,6 +16,10 @@ import {
   serializeNote,
   serializeParsedNote,
   extractInlineTagsFromMarkdown,
+  normalizePropertiesToRoot,
+  replacePropertiesOnRoot,
+  writePropertiesToRoot,
+  extractProperties,
   type NoteFrontmatter
 } from './frontmatter'
 import { syncNoteToCache, deleteNoteFromCache } from './note-sync'
@@ -291,8 +295,7 @@ export async function createNote(input: NoteCreateInput): Promise<Note> {
 
   const properties = { ...templateProperties, ...(input.properties ?? {}) }
   if (Object.keys(properties).length > 0) {
-    ;(frontmatter as NoteFrontmatter & { properties: Record<string, unknown> }).properties =
-      properties
+    Object.assign(frontmatter, writePropertiesToRoot(frontmatter, properties))
   }
 
   const content = input.content && input.content.trim() ? input.content : templateContent
@@ -626,7 +629,6 @@ export async function updateNote(input: NoteUpdateInput): Promise<Note> {
       }
     }
   }
-  const newProperties = input.properties ?? existing.properties
   const newEmoji = input.emoji !== undefined ? input.emoji : existing.emoji
 
   if (input.content !== undefined && input.content !== existing.content) {
@@ -654,9 +656,16 @@ export async function updateNote(input: NoteUpdateInput): Promise<Note> {
   }
 
   // User keys only — Memry state (title, dates, emoji, localOnly) lives in the DBs
-  const newFrontmatter: NoteFrontmatter & { properties?: Record<string, unknown> } = {
+  const mergedFrontmatter: NoteFrontmatter = {
     ...existing.frontmatter,
     ...input.frontmatter
+  }
+  let newFrontmatter = normalizePropertiesToRoot(mergedFrontmatter).frontmatter
+
+  const newProperties = input.properties ?? extractProperties(newFrontmatter)
+
+  if (input.properties !== undefined) {
+    newFrontmatter = replacePropertiesOnRoot(newFrontmatter, newProperties)
   }
 
   if (newTags.length > 0) {
@@ -665,19 +674,13 @@ export async function updateNote(input: NoteUpdateInput): Promise<Note> {
     delete newFrontmatter.tags
   }
 
-  if (Object.keys(newProperties).length > 0) {
-    newFrontmatter.properties = newProperties
-  } else {
-    delete newFrontmatter.properties
-  }
-
   const tagsChanged =
     newTags.length !== existing.tags.length || newTags.some((t) => !existing.tags.includes(t))
 
-  // Honest edit flag: the frontmatter block is re-stringified only when the
-  // caller actually changed something that lives in it; otherwise the raw
-  // block is re-emitted verbatim (byte preservation).
+  // Re-stringify when a caller changed frontmatter or when normalizing a
+  // legacy nested property block. Otherwise the raw block stays byte-identical.
   const frontmatterEdited =
+    !isDeepStrictEqual(newFrontmatter, existing.frontmatter) ||
     tagsChanged ||
     (input.properties !== undefined && !isDeepStrictEqual(input.properties, existing.properties)) ||
     (input.frontmatter !== undefined &&

--- a/apps/desktop/src/main/vault/notes.test.ts
+++ b/apps/desktop/src/main/vault/notes.test.ts
@@ -201,6 +201,11 @@ describe('notes operations', () => {
         status: 'draft',
         priority: 3
       })
+
+      const raw = fs.readFileSync(path.join(tempVault.path, result.path), 'utf8')
+      expect(raw).toMatch(/^status: draft$/m)
+      expect(raw).toMatch(/^priority: 3$/m)
+      expect(raw).not.toMatch(/^properties:/m)
     })
 
     it('preserves explicit created/modified timestamps', async () => {

--- a/apps/desktop/src/main/vault/property-definitions.test.ts
+++ b/apps/desktop/src/main/vault/property-definitions.test.ts
@@ -208,6 +208,54 @@ describe('PropertyDefinitionsService', () => {
     expect(indexDb.rows).toHaveLength(2)
   })
 
+  it('reloads primitive definitions without dropping status options', async () => {
+    safeReadMock.mockResolvedValue(
+      propertiesFile(`
+  Status:
+    type: status
+    categories:
+      todo:
+        label: To-do
+        options:
+          - value: Idea
+            color: violet
+      in_progress:
+        label: In progress
+        options:
+          - value: Active
+            color: amber
+      done:
+        label: Complete
+        options:
+          - value: Done
+            color: emerald
+  Author:
+    type: text
+    options: []
+  Rating:
+    type: number
+    options: []
+  Shared:
+    type: checkbox
+    options: []
+  Link:
+    type: url
+    options: []
+`)
+    )
+
+    const service = PropertyDefinitionsService.init('/vault')
+    await service.reload()
+
+    expect(service.get('Status')?.categories?.in_progress.options).toEqual([
+      { value: 'Active', color: 'amber' }
+    ])
+    expect(service.get('Author')).toEqual({ name: 'Author', type: 'text', options: [] })
+    expect(service.get('Rating')).toEqual({ name: 'Rating', type: 'number', options: [] })
+    expect(service.get('Shared')).toEqual({ name: 'Shared', type: 'checkbox', options: [] })
+    expect(service.get('Link')).toEqual({ name: 'Link', type: 'url', options: [] })
+  })
+
   it('carries a definition clock across the rebuild a reload triggers', async () => {
     safeReadMock.mockResolvedValue(
       propertiesFile(`  Stage:

--- a/apps/desktop/src/main/vault/root-properties-migration.test.ts
+++ b/apps/desktop/src/main/vault/root-properties-migration.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import path from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -37,7 +37,6 @@ describe('migrateNestedPropertiesToRoot', () => {
       ].join('\n')
     )
 
-    const originalMtime = statSync(notePath).mtimeMs
     await expect(migrateNestedPropertiesToRoot(vaultPath)).resolves.toEqual({
       scanned: 1,
       migrated: 1,
@@ -57,7 +56,6 @@ describe('migrateNestedPropertiesToRoot', () => {
     })
     expect(parsed.content).toBe('\nBody stays byte-for-byte.\n')
     expect(firstPass).not.toMatch(/^properties:/m)
-    expect(statSync(notePath).mtimeMs).toBeCloseTo(originalMtime, 0)
 
     await expect(migrateNestedPropertiesToRoot(vaultPath)).resolves.toEqual({
       scanned: 1,

--- a/apps/desktop/src/main/vault/root-properties-migration.test.ts
+++ b/apps/desktop/src/main/vault/root-properties-migration.test.ts
@@ -1,0 +1,91 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { parseNote } from './frontmatter'
+import { migrateNestedPropertiesToRoot } from './root-properties-migration'
+
+const tempVaults: string[] = []
+
+afterEach(() => {
+  for (const vaultPath of tempVaults.splice(0)) {
+    rmSync(vaultPath, { recursive: true, force: true })
+  }
+})
+
+describe('migrateNestedPropertiesToRoot', () => {
+  it('moves nested properties to root, keeps root conflicts, and converges on rerun', async () => {
+    const vaultPath = mkdtempSync(path.join('/tmp', 'memry-root-properties-'))
+    tempVaults.push(vaultPath)
+    mkdirSync(path.join(vaultPath, 'notes'), { recursive: true })
+
+    const notePath = path.join(vaultPath, 'notes', 'Mobile.md')
+    writeFileSync(
+      notePath,
+      [
+        '---',
+        'tags:',
+        '  - mobile',
+        'status: active',
+        'properties:',
+        '  status: idea',
+        '  owner: Kaan',
+        '---',
+        '',
+        'Body stays byte-for-byte.',
+        ''
+      ].join('\n')
+    )
+
+    const originalMtime = statSync(notePath).mtimeMs
+    await expect(migrateNestedPropertiesToRoot(vaultPath)).resolves.toEqual({
+      scanned: 1,
+      migrated: 1,
+      migratedPaths: ['notes/Mobile.md'],
+      skipped: 0,
+      deferred: 0,
+      failed: 0,
+      conflicts: ['status']
+    })
+
+    const firstPass = readFileSync(notePath, 'utf8')
+    const parsed = parseNote(firstPass, notePath)
+    expect(parsed.frontmatter).toEqual({
+      tags: ['mobile'],
+      status: 'active',
+      owner: 'Kaan'
+    })
+    expect(parsed.content).toBe('\nBody stays byte-for-byte.\n')
+    expect(firstPass).not.toMatch(/^properties:/m)
+    expect(statSync(notePath).mtimeMs).toBeCloseTo(originalMtime, 0)
+
+    await expect(migrateNestedPropertiesToRoot(vaultPath)).resolves.toEqual({
+      scanned: 1,
+      migrated: 0,
+      migratedPaths: [],
+      skipped: 1,
+      deferred: 0,
+      failed: 0,
+      conflicts: []
+    })
+    expect(readFileSync(notePath, 'utf8')).toBe(firstPass)
+  })
+
+  it('defers malformed frontmatter without touching the file', async () => {
+    const vaultPath = mkdtempSync(path.join('/tmp', 'memry-root-properties-'))
+    tempVaults.push(vaultPath)
+    mkdirSync(path.join(vaultPath, 'notes'), { recursive: true })
+
+    const notePath = path.join(vaultPath, 'notes', 'Broken.md')
+    const original = '---\nproperties:\n  status: [idea\n---\n\nBody\n'
+    writeFileSync(notePath, original)
+
+    await expect(migrateNestedPropertiesToRoot(vaultPath)).resolves.toMatchObject({
+      scanned: 1,
+      migrated: 0,
+      deferred: 1,
+      failed: 0
+    })
+    expect(readFileSync(notePath, 'utf8')).toBe(original)
+  })
+})

--- a/apps/desktop/src/main/vault/root-properties-migration.ts
+++ b/apps/desktop/src/main/vault/root-properties-migration.ts
@@ -1,0 +1,145 @@
+import { readdir, readFile, stat, utimes } from 'fs/promises'
+import path from 'path'
+
+import { createLogger } from '../lib/logger'
+import { atomicWrite } from './file-ops'
+import { normalizePropertiesToRoot, parseNote, serializeParsedNote } from './frontmatter'
+
+const logger = createLogger('RootPropertiesMigration')
+
+export const ROOT_PROPERTIES_MIGRATION_KEY = 'frontmatterPropertiesRootV1'
+export const ROOT_PROPERTIES_MIGRATION_DONE = 'done'
+
+export interface RootPropertiesMigrationResult {
+  scanned: number
+  migrated: number
+  migratedPaths: string[]
+  skipped: number
+  deferred: number
+  failed: number
+  conflicts: string[]
+}
+
+interface MigrationOptions {
+  excludePatterns?: string[]
+}
+
+const DEFAULT_EXCLUDES = ['.git', 'node_modules', '.trash', '.obsidian', '.memry']
+
+/**
+ * Migrate legacy `frontmatter.properties` maps into top-level user keys.
+ *
+ * This function deliberately has no completion marker. The vault lifecycle
+ * owns that marker and writes it only after this pass completes. A process
+ * crash after any individual file write therefore makes the next pass resume
+ * safely: already-migrated files are skipped and the remaining files converge.
+ */
+export async function migrateNestedPropertiesToRoot(
+  vaultPath: string,
+  options: MigrationOptions = {}
+): Promise<RootPropertiesMigrationResult> {
+  const result: RootPropertiesMigrationResult = {
+    scanned: 0,
+    migrated: 0,
+    migratedPaths: [],
+    skipped: 0,
+    deferred: 0,
+    failed: 0,
+    conflicts: []
+  }
+
+  let files: string[]
+  try {
+    files = await findMarkdownFiles(vaultPath, options.excludePatterns ?? DEFAULT_EXCLUDES)
+  } catch (error) {
+    logger.error('Could not scan vault for root property migration', { vaultPath, error })
+    result.failed++
+    return result
+  }
+
+  for (const filePath of files) {
+    let raw: string
+    try {
+      raw = await readFile(filePath, 'utf8')
+    } catch (error) {
+      result.failed++
+      logger.warn('Could not read note during root property migration', { filePath, error })
+      continue
+    }
+
+    result.scanned++
+    const originalStats = await stat(filePath).catch(() => null)
+    const parsed = parseNote(raw, filePath)
+    if (parsed.frontmatterError) {
+      result.deferred++
+      logger.warn('Deferring root property migration for unparseable note', {
+        filePath,
+        error: parsed.frontmatterError
+      })
+      continue
+    }
+
+    const normalized = normalizePropertiesToRoot(parsed.frontmatter)
+    if (!normalized.changed) {
+      result.skipped++
+      continue
+    }
+
+    const updated = serializeParsedNote(
+      { ...parsed, frontmatter: normalized.frontmatter },
+      parsed.content,
+      { frontmatterEdited: true }
+    )
+
+    try {
+      await atomicWrite(filePath, updated)
+      if (originalStats) {
+        await utimes(filePath, originalStats.atime, originalStats.mtime)
+      }
+      result.migrated++
+      result.migratedPaths.push(toVaultRelativePath(vaultPath, filePath))
+      result.conflicts.push(...normalized.conflicts)
+    } catch (error) {
+      result.failed++
+      logger.warn('Could not write note during root property migration', { filePath, error })
+    }
+  }
+
+  logger.info('Root property migration complete', {
+    vaultPath,
+    scanned: result.scanned,
+    migrated: result.migrated,
+    skipped: result.skipped,
+    deferred: result.deferred,
+    failed: result.failed,
+    conflicts: result.conflicts.length
+  })
+
+  return result
+}
+
+function toVaultRelativePath(vaultPath: string, filePath: string): string {
+  return path.relative(vaultPath, filePath).split(path.sep).join('/')
+}
+
+async function findMarkdownFiles(dirPath: string, excludePatterns: string[]): Promise<string[]> {
+  const entries = await readdir(dirPath, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue
+    if (excludePatterns.some((pattern) => entry.name === pattern)) continue
+
+    const entryPath = path.join(dirPath, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await findMarkdownFiles(entryPath, excludePatterns)))
+      continue
+    }
+
+    if (entry.isFile() && path.extname(entry.name).toLowerCase() === '.md') {
+      files.push(entryPath)
+    }
+  }
+
+  return files.sort()
+}

--- a/apps/desktop/src/main/vault/root-properties-migration.ts
+++ b/apps/desktop/src/main/vault/root-properties-migration.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, stat, utimes } from 'fs/promises'
+import { readdir, readFile } from 'fs/promises'
 import path from 'path'
 
 import { createLogger } from '../lib/logger'
@@ -68,7 +68,6 @@ export async function migrateNestedPropertiesToRoot(
     }
 
     result.scanned++
-    const originalStats = await stat(filePath).catch(() => null)
     const parsed = parseNote(raw, filePath)
     if (parsed.frontmatterError) {
       result.deferred++
@@ -93,9 +92,6 @@ export async function migrateNestedPropertiesToRoot(
 
     try {
       await atomicWrite(filePath, updated)
-      if (originalStats) {
-        await utimes(filePath, originalStats.atime, originalStats.mtime)
-      }
       result.migrated++
       result.migratedPaths.push(toVaultRelativePath(vaultPath, filePath))
       result.conflicts.push(...normalized.conflicts)

--- a/apps/docs/src/user-guide/notes/properties-tags.md
+++ b/apps/docs/src/user-guide/notes/properties-tags.md
@@ -135,17 +135,16 @@ A note or journal entry joins a project through its **`project` property**, not 
 
 - **Value** — a list of project names, picked from a dropdown. Each choice shows the project's color and icon; archived projects still resolve to their real appearance there, they just don't appear in the picker for new links. A name that matches no project (a typo, or a project deleted on another device before this note synced) still renders, muted, rather than being silently dropped.
 - **Remove** — click the `×` on a chip.
-- **Storage** — the value lives in the note's **frontmatter** as a plain list of project names, so it's visible and editable in a plain markdown editor and travels with the file. memrynote writes it alongside the note's other properties, under the `properties:` key:
+- **Storage** — the value lives in the note's **frontmatter** as a plain list of project names, so it's visible and editable in a plain markdown editor and travels with the file. memrynote writes it as a top-level property:
 
   ```yaml
   ---
-  properties:
-    project:
-      - Website Redesign
+  project:
+    - Website Redesign
   ---
   ```
 
-  A `project:` list written at the top level by another editor is read as well, as long as that note has no `properties:` block of its own. Frontmatter is the source of truth; the [project hub](/user-guide/projects#project-hub) reflects it, not the other way around.
+  Existing notes with a nested `properties:` block are migrated to top-level keys when the vault opens. If both locations contain a key, the top-level value wins. Frontmatter is the source of truth; the [project hub](/user-guide/projects#project-hub) reflects it, not the other way around.
 
 - **Renaming or deleting a project** rewrites the `project` value in every linked note's frontmatter — a rename updates the name in place, a delete removes it from the list.
 - Dragging a note or journal entry onto a project in the sidebar sets this same property.

--- a/packages/contracts/src/property-types.test.ts
+++ b/packages/contracts/src/property-types.test.ts
@@ -98,8 +98,15 @@ describe('PropertyDefinitionSchema (discriminated union)', () => {
     expect(result.success).toBe(false)
   })
 
+  it('accepts primitive variants written to properties.md', () => {
+    for (const type of ['text', 'number', 'checkbox', 'url'] as const) {
+      const result = PropertyDefinitionSchema.safeParse({ type, options: [] })
+      expect(result.success).toBe(true)
+    }
+  })
+
   it('rejects unknown variant type', () => {
-    const result = PropertyDefinitionSchema.safeParse({ type: 'text', options: [] })
+    const result = PropertyDefinitionSchema.safeParse({ type: 'bogus', options: [] })
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.issues[0].path).toContain('type')

--- a/packages/contracts/src/property-types.ts
+++ b/packages/contracts/src/property-types.ts
@@ -102,6 +102,26 @@ const MultiselectPropertySchema = z.object({
   options: z.array(SelectOptionSchema)
 })
 
+const TextPropertySchema = z.object({
+  type: z.literal('text'),
+  options: z.array(SelectOptionSchema).optional()
+})
+
+const NumberPropertySchema = z.object({
+  type: z.literal('number'),
+  options: z.array(SelectOptionSchema).optional()
+})
+
+const CheckboxPropertySchema = z.object({
+  type: z.literal('checkbox'),
+  options: z.array(SelectOptionSchema).optional()
+})
+
+const UrlPropertySchema = z.object({
+  type: z.literal('url'),
+  options: z.array(SelectOptionSchema).optional()
+})
+
 const DatePropertySchema = z.object({
   type: z.literal('date'),
   showOnCalendar: z.boolean().optional()
@@ -125,6 +145,10 @@ export const PropertyDefinitionSchema = z.discriminatedUnion('type', [
   StatusPropertySchema,
   SelectPropertySchema,
   MultiselectPropertySchema,
+  TextPropertySchema,
+  NumberPropertySchema,
+  CheckboxPropertySchema,
+  UrlPropertySchema,
   DatePropertySchema,
   ProjectPropertySchema
 ])


### PR DESCRIPTION
## Summary
- Accept primitive property definition types so properties.md remains parseable and status colors survive reloads.
- Migrate legacy nested note and journal properties to root frontmatter keys, with root values winning conflicts.
- Keep future note, journal, and sync writes root-only and force-reindex migrated files.

## Release note
- 🐛 Fix note properties and status options disappearing after app reload.

## Test plan
- pnpm --filter @memry/contracts test — 55 files, 1773 tests passed
- Focused vault/frontmatter/property-definition tests — 5 files, 168 tests passed
- Forced-path indexer regression test — 1 test passed
- pnpm --filter @memry/desktop lint
- pnpm typecheck
- pnpm docs:impact --base 76e2b22a2e0f037376957acd4d867654adb9648a --strict
- pnpm docs:build
- The broader main suite is locally limited by better-sqlite3 Node/Electron ABI switching; unrelated native-backed tests fail before exercising this change.