### PR TITLE
fix(desktop): recover unsupported graph renderer

### DIFF
--- a/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
@@ -234,6 +234,12 @@ describe('GraphCanvas', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.clearAllMocks()
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      () =>
+        ({
+          getExtension: vi.fn()
+        }) as unknown as RenderingContext
+    )
     graphCanvasMocks.sigmaContainerProps = null
     graphCanvasMocks.sigma.getGraph = () => graphCanvasMocks.sigmaContainerProps?.graph
     graphCanvasMocks.createNote.mockResolvedValue({
@@ -247,6 +253,23 @@ describe('GraphCanvas', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('renders a safe fallback when WebGL is unavailable', () => {
+    vi.mocked(HTMLCanvasElement.prototype.getContext).mockReturnValue(null)
+
+    render(
+      <GraphCanvas
+        data={data}
+        filterState={filters}
+        graphSettings={settings}
+        onFocusNode={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("Graph isn't available on this device")).toBeInTheDocument()
+    expect(screen.queryByTestId('sigma')).not.toBeInTheDocument()
   })
 
   it('builds sigma settings, applies reducers, and handles hover/context menu actions', async () => {

--- a/apps/desktop/src/renderer/src/components/graph/graph-canvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-canvas.tsx
@@ -12,6 +12,7 @@ import {
   type BuildGraphOptions
 } from '@/lib/graph-builder'
 import { refreshSigmaIfMeasurable } from '@/lib/sigma-refresh'
+import { hasWebGLSupport } from '@/lib/webgl-support'
 import { LivePhysics, SettledPhysics, type PhysicsHandle } from './physics-layout'
 import type { GraphFilterState } from '@/hooks/use-graph-filters'
 import type { GraphSettings } from '@memry/contracts/graph-api'
@@ -21,6 +22,7 @@ import { useT } from '@memry/i18n/renderer'
 import { GraphEvents } from './graph-events'
 import { GraphTooltip } from './graph-tooltip'
 import { GraphContextMenu, type ContextMenuState } from './graph-context-menu'
+import { GraphRenderUnavailable } from './graph-render-unavailable'
 
 const ENTITY_TYPE_VISIBILITY: Record<string, keyof GraphFilterState> = {
   note: 'showNotes',
@@ -65,15 +67,18 @@ interface GraphCanvasProps {
   filterState: GraphFilterState
   graphSettings: GraphSettings
   onFocusNode: (nodeId: string) => void
+  onClose?: () => void
 }
 
 export function GraphCanvas({
   data,
   filterState,
   graphSettings,
-  onFocusNode
+  onFocusNode,
+  onClose
 }: GraphCanvasProps): React.JSX.Element {
   const { resolvedTheme } = useTheme()
+  const [webglAvailable] = useState(() => hasWebGLSupport())
   const [hoveredNode, setHoveredNode] = useState<string | null>(null)
   const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null)
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
@@ -252,6 +257,8 @@ export function GraphCanvas({
   )
 
   const handleCloseContextMenu = useCallback(() => setContextMenu(null), [])
+
+  if (!webglAvailable) return <GraphRenderUnavailable onClose={onClose} />
 
   return (
     <div className="relative h-full w-full">

--- a/apps/desktop/src/renderer/src/components/graph/graph-page.i18n.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-page.i18n.test.tsx
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { I18nextProvider } from 'react-i18next'
 import type { i18n as I18nInstance } from 'i18next'
 import { createRendererI18n } from '@memry/i18n/renderer'
@@ -15,6 +15,8 @@ const graphHookMocks = vi.hoisted(() => ({
   useGraphSettings: vi.fn()
 }))
 
+const renderingMocks = vi.hoisted(() => ({ webglAvailable: true }))
+
 vi.mock('@/hooks/use-graph-data', () => ({
   useGraphData: graphHookMocks.useGraphData,
   useGraphReactivity: graphHookMocks.useGraphReactivity
@@ -26,6 +28,10 @@ vi.mock('@/hooks/use-graph-filters', () => ({
 
 vi.mock('@/hooks/use-graph-settings', () => ({
   useGraphSettings: graphHookMocks.useGraphSettings
+}))
+
+vi.mock('@/lib/webgl-support', () => ({
+  hasWebGLSupport: () => renderingMocks.webglAvailable
 }))
 
 vi.mock('./graph-canvas', () => ({
@@ -56,6 +62,7 @@ beforeAll(async () => {
 })
 
 beforeEach(() => {
+  renderingMocks.webglAvailable = true
   graphHookMocks.useGraphData.mockReturnValue({
     data: null,
     isLoading: false,
@@ -86,6 +93,22 @@ function graphData(data: GraphDataResponse): GraphDataResponse {
 }
 
 describe('GraphPage i18n', () => {
+  it('offers a close action when the device cannot render WebGL', () => {
+    renderingMocks.webglAvailable = false
+    const onClose = vi.fn()
+
+    render(
+      <I18nextProvider i18n={i18nEn}>
+        <GraphPage onClose={onClose} />
+      </I18nextProvider>
+    )
+
+    expect(screen.getByText("Graph isn't available on this device")).toBeInTheDocument()
+    expect(screen.queryByTestId('graph-control-panel')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it('renders loading state copy', () => {
     graphHookMocks.useGraphData.mockReturnValue({
       data: null,

--- a/apps/desktop/src/renderer/src/components/graph/graph-page.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-page.tsx
@@ -1,14 +1,16 @@
-import { useMemo, useCallback, useEffect } from 'react'
+import { useMemo, useCallback, useEffect, useState } from 'react'
 import { Loader2, AlertCircle, Network, Link2, Lightbulb } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
 import { trackTelemetry } from '@/lib/telemetry'
 import { trackRendererError } from '@/lib/telemetry-diagnostics'
+import { hasWebGLSupport } from '@/lib/webgl-support'
 import { useGraphData, useGraphReactivity } from '@/hooks/use-graph-data'
 import { useGraphFilters } from '@/hooks/use-graph-filters'
 import { useGraphSettings } from '@/hooks/use-graph-settings'
 import { useT } from '@memry/i18n/renderer'
 import { GraphCanvas } from './graph-canvas'
 import { GraphControlPanel } from './graph-control-panel'
+import { GraphRenderUnavailable } from './graph-render-unavailable'
 
 const ENTITY_LABEL_KEYS = {
   note: { one: 'entity.note', other: 'entity.notes' },
@@ -19,7 +21,15 @@ const ENTITY_LABEL_KEYS = {
   orphan: { one: 'entity.orphan', other: 'entity.orphans' }
 } as const
 
-export function GraphPage(): React.JSX.Element {
+export function GraphPage({ onClose }: { onClose?: () => void } = {}): React.JSX.Element {
+  const [webglAvailable] = useState(() => hasWebGLSupport())
+
+  if (!webglAvailable) return <GraphRenderUnavailable onClose={onClose} />
+
+  return <GraphPageContent onClose={onClose} />
+}
+
+function GraphPageContent({ onClose }: { onClose?: () => void }): React.JSX.Element {
   const { t } = useT('graph')
   useEffect(() => {
     void trackTelemetry('graph_opened', { surface: 'graph', action: 'opened' })
@@ -107,6 +117,7 @@ export function GraphPage(): React.JSX.Element {
           filterState={filterState}
           graphSettings={graphSettings}
           onFocusNode={handleFocusNode}
+          onClose={onClose}
         />
         {/* Visually-hidden node list for screen readers */}
         <ul className="sr-only" aria-label={t('page.nodes-list-label')}>

--- a/apps/desktop/src/renderer/src/components/graph/graph-render-unavailable.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-render-unavailable.tsx
@@ -1,0 +1,38 @@
+import { AlertCircle } from '@/lib/icons'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { useT } from '@memry/i18n/renderer'
+
+export function GraphRenderUnavailable({
+  className,
+  onClose
+}: {
+  className?: string
+  onClose?: () => void
+}): React.JSX.Element {
+  const { t } = useT('graph')
+  const { t: tCommon } = useT('common')
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        'flex h-full flex-col items-center justify-center gap-3 p-8 text-center',
+        className
+      )}
+    >
+      <AlertCircle className="size-8 text-destructive/60" />
+      <div className="space-y-1">
+        <p className="text-sm text-destructive/80 font-serif">{t('page.render-failed')}</p>
+        <p className="max-w-md text-sm text-muted-foreground">
+          {t('page.render-failed-description')}
+        </p>
+      </div>
+      {onClose && (
+        <Button variant="outline" size="sm" onClick={onClose}>
+          {tCommon('button.close')}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel-sigma-lifecycle.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel-sigma-lifecycle.test.tsx
@@ -162,6 +162,12 @@ describe('LocalGraphPanel Sigma lifecycle', () => {
   beforeEach(() => {
     mocks.instances.length = 0
     mocks.localGraph = { data: baseData, isLoading: false }
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      () =>
+        ({
+          getExtension: vi.fn()
+        }) as unknown as RenderingContext
+    )
     frames = new Map()
     nextFrameHandle = 0
     document.documentElement.style.setProperty('--graph-dimmed-node', '#dddddd')

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel-zero-width.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel-zero-width.test.tsx
@@ -116,6 +116,12 @@ describe('LocalGraphPanel on a container with no width', () => {
     mocks.refreshCount = 0
     frames = new Map()
     nextFrameHandle = 0
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      () =>
+        ({
+          getExtension: vi.fn()
+        }) as unknown as RenderingContext
+    )
     offsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth')
     Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
       configurable: true,

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel.test.tsx
@@ -135,6 +135,12 @@ describe('LocalGraphPanel', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.clearAllMocks()
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      () =>
+        ({
+          getExtension: vi.fn()
+        }) as unknown as RenderingContext
+    )
     mocks.localGraph = { data: graphData, isLoading: false }
     mocks.sigmaContainerProps = null
     document.documentElement.style.setProperty('--graph-dimmed-node', '#dddddd')
@@ -215,6 +221,17 @@ describe('LocalGraphPanel', () => {
       vi.runOnlyPendingTimers()
     })
     unmount()
+  })
+
+  it('renders a safe fallback with the local panel close control when WebGL is unavailable', () => {
+    vi.mocked(HTMLCanvasElement.prototype.getContext).mockReturnValue(null)
+    const onClose = vi.fn()
+
+    render(<LocalGraphPanel noteId="note-a" onClose={onClose} />)
+
+    expect(screen.getByText('page.render-failed')).toBeInTheDocument()
+    fireEvent.click(screen.getByTitle('local-panel.close'))
+    expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('runs a live simulation and stops it on unmount', () => {

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel.tsx
@@ -10,10 +10,12 @@ import { Button } from '@/components/ui/button'
 import { useLocalGraphData } from '@/hooks/use-graph-data'
 import { buildGraphologyGraph } from '@/lib/graph-builder'
 import { refreshSigmaIfMeasurable } from '@/lib/sigma-refresh'
+import { hasWebGLSupport } from '@/lib/webgl-support'
 import type { GraphPhysicsOptions } from '@/lib/graph-physics'
 import { useT } from '@memry/i18n/renderer'
 import { GraphEvents } from './graph-events'
 import { GraphTooltip } from './graph-tooltip'
+import { GraphRenderUnavailable } from './graph-render-unavailable'
 import { LivePhysics, type PhysicsHandle } from './physics-layout'
 
 const CENTER_HIGHLIGHT_COLOR = '#f59e0b'
@@ -47,6 +49,7 @@ export function LocalGraphPanel({
 }: LocalGraphPanelProps): React.JSX.Element {
   const { t } = useT('graph')
   const { resolvedTheme } = useTheme()
+  const [webglAvailable] = useState(() => hasWebGLSupport())
   const { data, isLoading } = useLocalGraphData(noteId)
 
   const [hoveredNode, setHoveredNode] = useState<string | null>(null)
@@ -172,6 +175,15 @@ export function LocalGraphPanel({
         <div className="flex h-full items-center justify-center">
           <span className="text-xs text-muted-foreground">{t('local-panel.empty')}</span>
         </div>
+        <PanelHeader onClose={onClose} />
+      </div>
+    )
+  }
+
+  if (!webglAvailable) {
+    return (
+      <div className="relative h-[250px] rounded-md border border-border bg-muted/30 overflow-hidden">
+        <GraphRenderUnavailable className="p-4" />
         <PanelHeader onClose={onClose} />
       </div>
     )

--- a/apps/desktop/src/renderer/src/components/split-view/tab-content.test.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-content.test.tsx
@@ -8,14 +8,15 @@
  * its persister saves that scene under the new canvas id.
  */
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TabContent } from './tab-content'
 import type { Tab } from '@/contexts/tabs/types'
 
 const mocks = vi.hoisted(() => ({
-  canvasMounts: [] as string[]
+  canvasMounts: [] as string[],
+  closeTab: vi.fn()
 }))
 
 vi.mock('@memry/i18n/renderer', () => ({
@@ -23,7 +24,11 @@ vi.mock('@memry/i18n/renderer', () => ({
 }))
 
 vi.mock('@/contexts/tabs', () => ({
-  useTabActions: () => ({ dispatch: vi.fn() })
+  useTabActions: () => ({ dispatch: vi.fn(), closeTab: mocks.closeTab })
+}))
+
+vi.mock('@/components/diagnostics/incident-report-provider', () => ({
+  useReportIncident: () => vi.fn()
 }))
 
 vi.mock('@/contexts/tasks', () => ({
@@ -49,6 +54,12 @@ vi.mock('@/pages/canvas', async () => {
   }
 })
 
+vi.mock('@/components/graph/graph-page', () => ({
+  GraphPage: () => {
+    throw new Error('graph renderer failed')
+  }
+}))
+
 const makeCanvasTab = (id: string, entityId: string): Tab => ({
   id,
   type: 'canvas',
@@ -64,9 +75,18 @@ const makeCanvasTab = (id: string, entityId: string): Tab => ({
   lastAccessedAt: 1
 })
 
+const makeGraphTab = (id: string): Tab => ({
+  ...makeCanvasTab(id, 'graph'),
+  type: 'graph',
+  title: 'Graph',
+  icon: 'network',
+  path: '/graph'
+})
+
 describe('TabContent canvas tabs', () => {
   beforeEach(() => {
     mocks.canvasMounts = []
+    mocks.closeTab.mockClear()
   })
 
   it('remounts the canvas page when the active canvas tab changes', async () => {
@@ -86,5 +106,20 @@ describe('TabContent canvas tabs', () => {
     // A second MOUNT proves the key swapped the component instance; prop-only
     // reuse would leave one mount and (in the real page) the old scene.
     expect(mocks.canvasMounts).toEqual(['istanbul', 'launch'])
+  })
+
+  it('closes a tab when its renderer fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const tab = makeGraphTab('broken-graph')
+
+    render(<TabContent tab={tab} groupId="main" />)
+
+    expect(
+      await screen.findByText('phaseF.componentsTabsTabErrorBoundary.somethingWentWrong')
+    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'button.close' }))
+
+    expect(mocks.closeTab).toHaveBeenCalledWith('broken-graph', 'main')
+    consoleError.mockRestore()
   })
 })

--- a/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
@@ -9,10 +9,12 @@
  * 3. useMemo with tab.id key ensures content is cached per tab instance
  */
 
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import type { Tab } from '@/contexts/tabs/types'
 import { TabIdentityProvider } from '@/contexts/tabs/tab-identity'
+import { useTabActions } from '@/contexts/tabs'
 import { useTasksOptional } from '@/contexts/tasks'
+import { TabErrorBoundary } from '@/components/tabs/tab-error-boundary'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
 import { stringifyUnknown } from '@/lib/stringify-unknown'
@@ -90,7 +92,12 @@ interface TabContentProps {
  */
 export const TabContent = ({ tab, groupId, className }: TabContentProps): React.JSX.Element => {
   const { t: tPhaseF } = useT('common')
+  const { closeTab } = useTabActions()
   const tasksContext = useTasksOptional()
+
+  const handleCloseTab = useCallback((): void => {
+    closeTab(tab.id, groupId)
+  }, [closeTab, groupId, tab.id])
 
   // FolderViewPage's `useFolderView` keys its live-refresh subscriptions off
   // scope identity — memoized here (independent of the broader `content`
@@ -182,7 +189,7 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
         return <LazyTemplateEditorPage templateId={tab.entityId} tabId={tab.id} />
 
       case 'graph':
-        return <LazyGraphPage />
+        return <LazyGraphPage onClose={handleCloseTab} />
 
       case 'tags':
         return <LazyTagsHubPage />
@@ -242,7 +249,8 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
     tab.viewState?.query,
     tasksContext,
     folderScope,
-    tagScope
+    tagScope,
+    handleCloseTab
   ])
 
   return (
@@ -254,7 +262,12 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
       data-tab-content={tab.id}
     >
       <TabIdentityProvider tabId={tab.id} groupId={groupId} entityId={tab.entityId}>
-        <React.Suspense fallback={null}>{content}</React.Suspense>
+        <TabErrorBoundary
+          key={`${tab.id}:${tab.type}:${tab.entityId ?? ''}`}
+          onCloseTab={handleCloseTab}
+        >
+          <React.Suspense fallback={null}>{content}</React.Suspense>
+        </TabErrorBoundary>
       </TabIdentityProvider>
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/tabs/tab-error-boundary.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-error-boundary.tsx
@@ -18,6 +18,8 @@ interface TabErrorBoundaryProps {
   children: ReactNode
   /** Fallback callback when error occurs */
   onError?: (error: Error, errorInfo: ErrorInfo) => void
+  /** Remove the tab that cannot render, so a persisted failure cannot strand the app. */
+  onCloseTab?: () => void
 }
 
 interface TabErrorBoundaryImplProps extends TabErrorBoundaryProps {
@@ -30,6 +32,7 @@ interface TabErrorBoundaryLabels {
   errorOccurred: string
   tryAgain: string
   sendReport: string
+  closeTab: string
 }
 
 interface TabErrorBoundaryState {
@@ -82,11 +85,20 @@ class TabErrorBoundaryImpl extends Component<
                 {this.state.error.message}
               </code>
             )}
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              {this.props.onCloseTab && (
+                <button
+                  type="button"
+                  onClick={this.props.onCloseTab}
+                  className="flex items-center gap-2 px-4 py-2 bg-tint text-tint-foreground rounded-md hover:bg-tint-hover transition-colors"
+                >
+                  {labels.closeTab}
+                </button>
+              )}
               <button
                 type="button"
                 onClick={this.handleRetry}
-                className="flex items-center gap-2 px-4 py-2 bg-tint text-tint-foreground rounded-md hover:bg-tint-hover transition-colors"
+                className="flex items-center gap-2 px-4 py-2 border border-border rounded-md hover:bg-muted transition-colors"
               >
                 <RefreshCw className="w-4 h-4" />
                 {labels.tryAgain}
@@ -123,7 +135,8 @@ export function TabErrorBoundary(props: TabErrorBoundaryProps): ReactNode {
           'phaseF.componentsTabsTabErrorBoundary.anErrorOccurredWhileRenderingThisTabContent'
         ),
         tryAgain: t('phaseF.componentsTabsTabErrorBoundary.tryAgain'),
-        sendReport: t('phaseF.componentsTabsTabErrorBoundary.sendReport')
+        sendReport: t('phaseF.componentsTabsTabErrorBoundary.sendReport'),
+        closeTab: t('button.close')
       }}
     />
   )

--- a/apps/desktop/src/renderer/src/lib/webgl-support.test.ts
+++ b/apps/desktop/src/renderer/src/lib/webgl-support.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { hasWebGLSupport } from './webgl-support'
+
+describe('hasWebGLSupport', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reports false when the browser cannot create any supported context', () => {
+    const getContext = vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
+
+    expect(hasWebGLSupport()).toBe(false)
+    expect(getContext.mock.calls.map(([kind]) => kind)).toEqual([
+      'webgl2',
+      'webgl',
+      'experimental-webgl'
+    ])
+  })
+
+  it('releases the probe context after confirming support', () => {
+    const loseContext = vi.fn()
+    const getExtension = vi.fn(() => ({ loseContext }))
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      getExtension
+    } as unknown as RenderingContext)
+
+    expect(hasWebGLSupport()).toBe(true)
+    expect(getExtension).toHaveBeenCalledWith('WEBGL_lose_context')
+    expect(loseContext).toHaveBeenCalledOnce()
+  })
+
+  it('reports false when context creation throws', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => {
+      throw new Error('WebGL disabled')
+    })
+
+    expect(hasWebGLSupport()).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/webgl-support.ts
+++ b/apps/desktop/src/renderer/src/lib/webgl-support.ts
@@ -1,0 +1,23 @@
+/**
+ * Sigma needs at least one WebGL context for every graph surface. Probe the
+ * browser boundary once before mounting Sigma so unsupported devices get a
+ * rendered fallback instead of an exception from Sigma's constructor.
+ */
+export function hasWebGLSupport(): boolean {
+  if (typeof document === 'undefined') return false
+
+  const canvas = document.createElement('canvas')
+
+  try {
+    const context =
+      canvas.getContext('webgl2') ??
+      canvas.getContext('webgl') ??
+      canvas.getContext('experimental-webgl')
+    if (!context) return false
+
+    ;(context as WebGLRenderingContext).getExtension('WEBGL_lose_context')?.loseContext()
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -243,6 +243,10 @@ Turn the motion off with **Live motion** under the gear icon → **Display** if 
 still graph — the same forces then run once and stop, which is also the lighter option on
 very large vaults.
 
+If the device cannot start WebGL, Memry shows a safe fallback instead of opening the graph.
+Your notes remain available, and **Close** removes the graph tab so it will not be restored on
+the next launch.
+
 ## Renaming a Linked Note
 
 Renaming a note updates every wiki link that points at it, across the whole vault: each

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -18,6 +18,9 @@ Tabs share the width of the bar evenly. Widen the window and they grow, up to a 
 
 There is no limit on how many tabs you can have open: use the tab context menu (**Close others**, **Close to the right**) when the bar gets long.
 
+If a tab's content cannot render, its error state keeps the tab bar available and offers **Close**.
+Closing the broken tab removes it from the saved session. If it was the only tab, Memry opens Home.
+
 The one thing that closes a tab without being asked is deleting what it shows. Delete a canvas — from the sidebar, or on another device — and its tab closes everywhere it was open, in both panes of a split view. Deleted notes keep their tab and show the title struck through instead, because the text is still there to read.
 
 ### Tab Context Menu

--- a/packages/i18n/src/locales/en/graph.json
+++ b/packages/i18n/src/locales/en/graph.json
@@ -2,6 +2,8 @@
   "page": {
     "loading": "Loading graph...",
     "load-failed": "Failed to load graph data",
+    "render-failed": "Graph isn't available on this device",
+    "render-failed-description": "This device could not start the graphics renderer. Your notes are safe.",
     "try-again": "Try again",
     "aria-label": "Knowledge graph with {nodeCount, plural, one {# node} other {# nodes}} and {edgeCount, plural, one {# connection} other {# connections}}{summary, select, none {.} other {: {summary}.}}",
     "nodes-list-label": "Graph nodes",

--- a/packages/i18n/src/locales/tr/graph.json
+++ b/packages/i18n/src/locales/tr/graph.json
@@ -2,6 +2,8 @@
   "page": {
     "loading": "Grafik yükleniyor...",
     "load-failed": "Grafik verileri yüklenemedi",
+    "render-failed": "Grafik bu cihazda kullanılamıyor",
+    "render-failed-description": "Bu cihaz grafik motorunu başlatamadı. Notlarınız güvende.",
     "try-again": "Tekrar dene",
     "aria-label": "Bilgi grafiği: {nodeCount, plural, one {# düğüm} other {# düğüm}} ve {edgeCount, plural, one {# bağlantı} other {# bağlantı}}{summary, select, none {.} other {: {summary}.}}",
     "nodes-list-label": "Grafik düğümleri",


### PR DESCRIPTION
## Summary

Guard graph rendering when the device cannot create a WebGL context. Keep renderer failures inside the affected tab and let the user close the failed tab.

## Why

Sigma 3.0.3 calls `blendFunc` after all WebGL context attempts return null. The existing app-level boundary leaves a persisted graph tab able to lock the user into the same screen after every restart.

## Scope

- Add a WebGL capability probe and safe graph fallback for full and local graph views.
- Add tab-scoped error recovery with a localized Close action.
- Document graph and tab recovery behavior.

## Blast Radius

Devices without WebGL no longer mount Sigma. Existing vault and note data remain unchanged. Closing the failed tab removes only its saved tab state; the existing reducer opens Home when it was the only tab.

## Verification

- 50 focused renderer tests passed.
- Desktop web and test typechecks passed.
- Staged secret and renderer guard checks passed.
- Docs impact strict and docs build passed.
- Production desktop build passed.
- Autoreview passed with no accepted or actionable findings.

## Release note

Graph view now shows a safe recovery state on devices without WebGL.

## Test plan

See Verification above. Manual Electron UI smoke was not run because the session has no Orca desktop driver.