### PR TITLE
feat(mobile): add note reminders with iOS local notification delivery

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -32,6 +32,7 @@
     "expo-image-picker": "~57.0.14",
     "expo-linking": "~57.0.7",
     "expo-local-authentication": "~57.0.2",
+    "expo-notifications": "~57.0.17",
     "expo-print": "~57.0.1",
     "expo-router": "~57.0.15",
     "expo-secure-store": "~57.0.1",

--- a/apps/mobile/src/app/(vault)/(tabs)/notes/[id].tsx
+++ b/apps/mobile/src/app/(vault)/(tabs)/notes/[id].tsx
@@ -38,9 +38,16 @@ import { readBookmarkKeys, toggleBookmark } from '@/features/notes/bookmarks'
 import { NoteFooter } from '@/features/notes/chrome/note-footer'
 import { readBacklinks } from '@/features/notes/backlinks'
 import { NoteMoreSheet } from '@/features/notes/chrome/note-more-sheet'
+import { ReminderSheet } from '@/features/notes/chrome/reminder-sheet'
 import { QuickOpenModal } from '@/features/notes/chrome/quick-open-modal'
 import { editGate } from '@/features/notes/edit-gate'
 import { MoveSheet } from '@/features/notes/move-sheet'
+import {
+  describeReminder,
+  readNoteReminder,
+  reminderPermission,
+  type NoteReminder
+} from '@/features/notes/reminders'
 import {
   addTag,
   clearPendingSeed,
@@ -128,6 +135,7 @@ type NoteOverlay =
   | { kind: 'none' }
   | { kind: 'quick-open' }
   | { kind: 'more' }
+  | { kind: 'reminder' }
   | { kind: 'rename' }
   | { kind: 'move'; snapshot: NotesSnapshot }
 
@@ -161,6 +169,15 @@ export default function NoteScreen() {
   const [keyboardVisible, setKeyboardVisible] = useState<boolean | null>(null)
   const [editorPanelOpen, setEditorPanelOpen] = useState(false)
   const [bookmarked, setBookmarked] = useState(false)
+  const [reminder, setReminder] = useState<NoteReminder | null>(null)
+  /**
+   * Whether this device can ring at all.
+   *
+   * Read when the sheet opens rather than stored: the user can turn
+   * notifications off in Settings at any time, and a flag written when the
+   * reminder was set would keep promising a banner that can no longer appear.
+   */
+  const [notificationsOff, setNotificationsOff] = useState(false)
   const [backlinkCount, setBacklinkCount] = useState(0)
   const [addingTag, setAddingTag] = useState(false)
   const [addingProperty, setAddingProperty] = useState(false)
@@ -209,6 +226,11 @@ export default function NoteScreen() {
     let cancelled = false
     void readBookmarkKeys(session.db).then((keys) => {
       if (!cancelled) setBookmarked(keys.has(`note:${id}`))
+    })
+    // A reminder set on the desktop arrives through a pull, not through this
+    // screen, so the sync subscription below refreshes it too.
+    void readNoteReminder(session.db, id).then((next) => {
+      if (!cancelled) setReminder(next)
     })
     return () => {
       cancelled = true
@@ -310,6 +332,7 @@ export default function NoteScreen() {
         }
         const refreshed = await readNoteRecord(session.db, id)
         if (refreshed) applyRecord(refreshed)
+        setReminder(await readNoteReminder(session.db, id))
       })()
     })
   }, [applyRecord, id, session])
@@ -370,6 +393,15 @@ export default function NoteScreen() {
           }
         : null,
     [session]
+  )
+
+  /**
+   * The bell row, derived from the row and the clock — never a second boolean
+   * to keep in step with the reminder itself.
+   */
+  const reminderBadge = useMemo(
+    () => describeReminder(reminder, new Date(), notificationsOff),
+    [notificationsOff, reminder]
   )
 
   const cfg: BridgeCfg = useMemo(
@@ -558,6 +590,8 @@ export default function NoteScreen() {
   const openMore = useCallback(async () => {
     setOverlay({ kind: 'more' })
     if (!session || !id) return
+    setReminder(await readNoteReminder(session.db, id))
+    setNotificationsOff((await reminderPermission()) === 'denied')
     const { totalReferences } = await readBacklinks(session.db, id)
     setBacklinkCount(totalReferences)
   }, [id, session])
@@ -964,7 +998,9 @@ export default function NoteScreen() {
         readOnly={!writable}
         onClose={() => setOverlay({ kind: 'none' })}
         backlinkCount={backlinkCount}
+        reminder={reminderBadge}
         onToggleBookmark={() => void runBookmark()}
+        onReminder={() => setOverlay({ kind: 'reminder' })}
         onBacklinks={() => router.push(`/notes/backlinks?id=${encodeURIComponent(id)}`)}
         onRename={() => setOverlay({ kind: 'rename' })}
         onMove={() => void openMove()}
@@ -990,6 +1026,18 @@ export default function NoteScreen() {
             })
         }}
       />
+
+      {overlay.kind === 'reminder' ? (
+        <ReminderSheet
+          visible
+          ctx={writable ? ctx : null}
+          noteId={id}
+          noteTitle={title}
+          reminder={reminder}
+          onClose={() => setOverlay({ kind: 'none' })}
+          onChanged={setReminder}
+        />
+      ) : null}
 
       {overlay.kind === 'move' ? (
         <MoveSheet

--- a/apps/mobile/src/app/(vault)/_layout.tsx
+++ b/apps/mobile/src/app/(vault)/_layout.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { Stack } from 'expo-router'
+import { router, Stack } from 'expo-router'
+import { openVaultDb } from '@/db/index'
+import { onReminderTap, reconcileReminders } from '@/features/notes/reminders'
 import { FirstSyncScreen } from '@/features/sync/first-sync-screen'
 import { FirstSyncProgressBar } from '@/features/sync/progress'
 import { SyncErrorScreen } from '@/features/sync/sync-error-screen'
@@ -49,6 +51,9 @@ export default function VaultLayout() {
 
   useEffect(() => {
     let cancelled = false
+    // Filled inside the async body below, torn down by the cleanup that cannot
+    // await it.
+    const teardown: (() => void)[] = []
     void (async () => {
       const vaultId = await loadCurrentVaultId()
       if (!vaultId || cancelled) return
@@ -56,6 +61,18 @@ export default function VaultLayout() {
       wireForegroundSync()
       void registerBackgroundSync()
       startSyncSocket(vaultId)
+
+      // Reminders: two of the three edges. Relaunch is this call; a pull is the
+      // subscription; the foreground edge lives in `sync/background.ts`, on the
+      // AppState listener that already owns that transition. The pass is
+      // idempotent, so overlapping calls cost nothing.
+      const reminderCtx = { db: await openVaultDb(vaultId), vaultId }
+      if (cancelled) return
+      void reconcileReminders(reminderCtx)
+      teardown.push(
+        getSyncEngine(vaultId).onSynced(() => void reconcileReminders(reminderCtx)),
+        onReminderTap(({ noteId }) => router.push(`/notes/${noteId}`))
+      )
 
       try {
         setSyncing(true)
@@ -86,6 +103,7 @@ export default function VaultLayout() {
     })()
     return () => {
       cancelled = true
+      for (const off of teardown) off()
       // Three things already leak here (two NetInfo subscriptions and the
       // engine registry, none of which have a removal path), so the socket
       // gets an explicit stop rather than becoming a fourth. Clearing the

--- a/apps/mobile/src/components/ui/icon.tsx
+++ b/apps/mobile/src/components/ui/icon.tsx
@@ -2,6 +2,7 @@ import {
   ArrowDownWideNarrow,
   ArrowLeft,
   Bell,
+  BellRing,
   Bookmark,
   BookmarkX,
   BookOpen,
@@ -106,6 +107,8 @@ const glyphs = {
   check: Check,
   trash: Trash2,
   bell: Bell,
+  // The active state, mirroring desktop's Bell/BellRing swap.
+  'bell-ring': BellRing,
   share: Share2,
   // A page with an arrow leaving it. `share` is the system share sheet; this is
   // the note becoming a file, which is a different promise to the reader.

--- a/apps/mobile/src/features/notes/__tests__/reminders.test.ts
+++ b/apps/mobile/src/features/notes/__tests__/reminders.test.ts
@@ -1,0 +1,527 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  clearNoteReminder,
+  describeReminder,
+  readNoteReminder,
+  reconcileReminders,
+  reminderPresets,
+  setNoteReminder,
+  type ReminderPermission,
+  type ReminderScheduler,
+  type ScheduledReminder,
+  type ScheduleRequest
+} from '@/features/notes/reminders'
+
+import { openTestVault, seedNote, type TestVault } from './vault-db-harness'
+
+/**
+ * A stand-in for the iOS pending-notification list.
+ *
+ * Keyed by identifier and REPLACING on a second schedule, because that is the
+ * property the whole reconciler rests on — a fake that appended instead would
+ * make every idempotency assertion here vacuous.
+ */
+function fakeScheduler(
+  entries: ScheduledReminder[] = [],
+  permission: ReminderPermission = 'granted'
+) {
+  const held = new Map(entries.map((entry) => [entry.reminderId, entry]))
+  const scheduled: ScheduleRequest[] = []
+  const cancelled: string[] = []
+  const scheduler: ReminderScheduler = {
+    permission: () => Promise.resolve(permission),
+    request: () => Promise.resolve(permission),
+    list: () => Promise.resolve([...held.values()]),
+    schedule: (request) => {
+      scheduled.push(request)
+      held.set(request.reminderId, {
+        reminderId: request.reminderId,
+        noteId: request.noteId,
+        at: request.at
+      })
+      return Promise.resolve('ok')
+    },
+    cancel: (reminderId) => {
+      cancelled.push(reminderId)
+      held.delete(reminderId)
+      return Promise.resolve()
+    }
+  }
+  return { scheduler, scheduled, cancelled, held }
+}
+
+/** Insert a reminder the way a pull would: full payload, no queue row. */
+function seedReminder(
+  vault: TestVault,
+  input: {
+    id: string
+    targetId: string
+    remindAt: string
+    targetType?: string
+    status?: string
+    snoozedUntil?: string
+    triggeredAt?: string
+    deleted?: boolean
+  }
+): void {
+  const payload: Record<string, unknown> = {
+    targetType: input.targetType ?? 'note',
+    targetId: input.targetId,
+    remindAt: input.remindAt,
+    status: input.status ?? 'pending',
+    clock: { 'device-remote': 1 },
+    createdAt: '2026-01-01T00:00:00.000Z'
+  }
+  if (input.snoozedUntil) payload.snoozedUntil = input.snoozedUntil
+  if (input.triggeredAt) payload.triggeredAt = input.triggeredAt
+  void vault.db.runAsync(
+    `INSERT INTO sync_items (id, type, vault_id, updated_at, deleted_at, payload_state, payload)
+     VALUES (?, 'reminder', 'vault-1', ?, ?, 'full', ?)`,
+    [input.id, 1_700_000_000_000, input.deleted ? 1_700_000_000_000 : null, JSON.stringify(payload)]
+  )
+}
+
+/**
+ * LOCAL wall-clock instants, not UTC literals.
+ *
+ * `describeReminder` renders in the device's timezone, so a UTC literal makes
+ * "Today 18:00" a fact about the CI box rather than about the code — the exact
+ * shape of vacuous timezone test this repo has been bitten by before.
+ * Tue 10 March 2026, so `next-week` lands on the following Monday.
+ */
+const NOW = new Date(2026, 2, 10, 12, 0, 0, 0)
+const SOON = new Date(2026, 2, 10, 18, 0, 0, 0)
+const LATER = new Date(2026, 2, 11, 9, 0, 0, 0)
+const YESTERDAY = new Date(2026, 2, 9, 9, 0, 0, 0)
+const TWO_DAYS_ON = new Date(2026, 2, 12, 12, 0, 0, 0)
+
+function writtenPayloads(vault: TestVault): Record<string, unknown>[] {
+  return vault.outboxRows().map((row) => row.payload as Record<string, unknown>)
+}
+
+describe('reminders — writing', () => {
+  let vault: TestVault
+
+  beforeEach(() => {
+    vault = openTestVault()
+  })
+  afterEach(() => vault.close())
+
+  it('derives the id from the note so two offline devices mint one row', async () => {
+    const os = fakeScheduler()
+    await setNoteReminder(vault.ctx, 'n1', SOON, { scheduler: os.scheduler, now: NOW })
+
+    const rows = vault.outboxRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].itemId).toBe('rem_note_n1')
+    expect(rows[0].itemType).toBe('reminder:update')
+    expect(rows[0].payload).toMatchObject({
+      targetType: 'note',
+      targetId: 'n1',
+      remindAt: SOON.toISOString(),
+      status: 'pending'
+    })
+  })
+
+  it('a second pick replaces in place: same id, climbing clock', async () => {
+    const os = fakeScheduler()
+    await setNoteReminder(vault.ctx, 'n1', SOON, { scheduler: os.scheduler, now: NOW })
+    await setNoteReminder(vault.ctx, 'n1', LATER, { scheduler: os.scheduler, now: NOW })
+
+    const rows = vault.outboxRows()
+    // One row, not two: `enqueueRecord` supersedes this device's earlier pending
+    // rows for the same id.
+    expect(rows).toHaveLength(1)
+    expect(rows[0].itemId).toBe('rem_note_n1')
+    expect((rows[0].payload as { clock: Record<string, number> }).clock['device-a']).toBe(2)
+    expect((rows[0].payload as { remindAt: string }).remindAt).toBe(LATER.toISOString())
+  })
+
+  it('re-adding after a removal keeps the clock climbing', async () => {
+    const os = fakeScheduler()
+    await setNoteReminder(vault.ctx, 'n1', SOON, { scheduler: os.scheduler, now: NOW })
+    await clearNoteReminder(vault.ctx, 'n1', { scheduler: os.scheduler, now: NOW })
+    await setNoteReminder(vault.ctx, 'n1', LATER, { scheduler: os.scheduler, now: NOW })
+
+    const rows = vault.outboxRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].itemType).toBe('reminder:update')
+    // A fresh `{device-a: 1}` on the re-add would read as OLDER than the delete
+    // on every peer, and the reminder would simply never come back.
+    expect((rows[0].payload as { clock: Record<string, number> }).clock['device-a']).toBe(3)
+    expect(await readNoteReminder(vault.ctx.db, 'n1', NOW)).not.toBeNull()
+  })
+
+  it('removing tombstones the row rather than deleting it', async () => {
+    const os = fakeScheduler()
+    await setNoteReminder(vault.ctx, 'n1', SOON, { scheduler: os.scheduler, now: NOW })
+    await clearNoteReminder(vault.ctx, 'n1', { scheduler: os.scheduler, now: NOW })
+
+    const row = await vault.db.getFirstAsync<{ deleted_at: number | null }>(
+      `SELECT deleted_at FROM sync_items WHERE id = 'rem_note_n1'`
+    )
+    // A hard delete makes the next pull treat the server's copy as new and the
+    // reminder comes back.
+    expect(row?.deleted_at).not.toBeNull()
+    expect(vault.outboxRows().at(-1)?.itemType).toBe('reminder:delete')
+    expect(await readNoteReminder(vault.ctx.db, 'n1', NOW)).toBeNull()
+  })
+
+  it('supersedes a desktop-minted random-id reminder on the same note', async () => {
+    seedReminder(vault, { id: 'rem_abc123', targetId: 'n1', remindAt: LATER.toISOString() })
+    const os = fakeScheduler()
+    await setNoteReminder(vault.ctx, 'n1', SOON, { scheduler: os.scheduler, now: NOW })
+
+    const rows = vault.outboxRows()
+    expect(rows.map((row) => `${row.itemId}:${row.op}`).sort()).toEqual([
+      'rem_abc123:delete',
+      'rem_note_n1:upsert'
+    ])
+    const live = await readNoteReminder(vault.ctx.db, 'n1', NOW)
+    expect(live?.id).toBe('rem_note_n1')
+  })
+
+  it('never writes triggeredAt or a triggered status, even when it read one', async () => {
+    seedReminder(vault, {
+      id: 'rem_note_n1',
+      targetId: 'n1',
+      remindAt: LATER.toISOString(),
+      status: 'triggered',
+      triggeredAt: '2026-03-09T09:00:00.000Z'
+    })
+    seedReminder(vault, {
+      id: 'rem_legacy',
+      targetId: 'n1',
+      remindAt: LATER.toISOString(),
+      status: 'triggered',
+      triggeredAt: '2026-03-09T09:00:00.000Z'
+    })
+    const os = fakeScheduler()
+    await setNoteReminder(vault.ctx, 'n1', SOON, { scheduler: os.scheduler, now: NOW })
+    await clearNoteReminder(vault.ctx, 'n1', { scheduler: os.scheduler, now: NOW })
+
+    const payloads = writtenPayloads(vault)
+    expect(payloads.length).toBeGreaterThan(0)
+    for (const payload of payloads) {
+      expect(payload).not.toHaveProperty('triggeredAt')
+      expect(payload.status).not.toBe('triggered')
+    }
+  })
+
+  it('leaves note_date rows completely alone', async () => {
+    seedReminder(vault, {
+      id: 'rem_nd_n1_anchor',
+      targetId: 'n1',
+      remindAt: LATER.toISOString(),
+      targetType: 'note_date'
+    })
+    const os = fakeScheduler()
+    await setNoteReminder(vault.ctx, 'n1', SOON, { scheduler: os.scheduler, now: NOW })
+    await clearNoteReminder(vault.ctx, 'n1', { scheduler: os.scheduler, now: NOW })
+
+    const touched = vault.outboxRows().map((row) => row.itemId)
+    expect(touched).not.toContain('rem_nd_n1_anchor')
+    const row = await vault.db.getFirstAsync<{ deleted_at: number | null }>(
+      `SELECT deleted_at FROM sync_items WHERE id = 'rem_nd_n1_anchor'`
+    )
+    expect(row?.deleted_at).toBeNull()
+    // And it is never scheduled either: the reconciler reads the same filter.
+    expect(os.scheduled.map((request) => request.reminderId)).not.toContain('rem_nd_n1_anchor')
+  })
+
+  it('keeps unknown fields a newer desktop wrote', async () => {
+    void vault.db.runAsync(
+      `INSERT INTO sync_items (id, type, vault_id, updated_at, payload_state, payload)
+       VALUES ('rem_note_n1', 'reminder', 'vault-1', 1, 'full', ?)`,
+      [
+        JSON.stringify({
+          targetType: 'note',
+          targetId: 'n1',
+          remindAt: LATER.toISOString(),
+          status: 'pending',
+          repeatRule: 'weekly'
+        })
+      ]
+    )
+    const os = fakeScheduler()
+    await setNoteReminder(vault.ctx, 'n1', SOON, { scheduler: os.scheduler, now: NOW })
+    expect(vault.outboxRows()[0].payload).toMatchObject({ repeatRule: 'weekly' })
+  })
+
+  it('reports a save the OS refused to ring as saved, not failed', async () => {
+    const os = fakeScheduler([], 'denied')
+    const result = await setNoteReminder(vault.ctx, 'n1', SOON, {
+      scheduler: os.scheduler,
+      now: NOW
+    })
+    expect(result.delivery).toBe('permission-denied')
+    expect(result.reminder.remindAt).toEqual(SOON)
+    expect(await readNoteReminder(vault.ctx.db, 'n1', NOW)).not.toBeNull()
+  })
+
+  it('a time already past is saved and reported as such', async () => {
+    const os = fakeScheduler()
+    const result = await setNoteReminder(vault.ctx, 'n1', YESTERDAY, {
+      scheduler: os.scheduler,
+      now: NOW
+    })
+    expect(result.delivery).toBe('in-the-past')
+    expect(os.scheduled).toHaveLength(0)
+  })
+})
+
+describe('reminders — the reconciler', () => {
+  let vault: TestVault
+
+  beforeEach(() => {
+    vault = openTestVault()
+  })
+  afterEach(() => vault.close())
+
+  it('schedules a reminder created on another device', async () => {
+    seedNote(vault, { id: 'n1', title: 'Aurelie' })
+    seedReminder(vault, { id: 'rem_note_n1', targetId: 'n1', remindAt: SOON.toISOString() })
+    const os = fakeScheduler()
+
+    const report = await reconcileReminders(vault.ctx, os.scheduler, NOW)
+
+    expect(report.scheduled).toBe(1)
+    expect(os.scheduled[0]).toMatchObject({
+      reminderId: 'rem_note_n1',
+      noteId: 'n1',
+      vaultId: 'vault-1',
+      at: SOON,
+      // The note's own title, not a generic string: the banner has to say which
+      // note it is about.
+      title: 'Aurelie'
+    })
+  })
+
+  it('cancels one deleted on another device', async () => {
+    seedReminder(vault, {
+      id: 'rem_note_n1',
+      targetId: 'n1',
+      remindAt: SOON.toISOString(),
+      deleted: true
+    })
+    const os = fakeScheduler([{ reminderId: 'rem_note_n1', noteId: 'n1', at: SOON }])
+
+    const report = await reconcileReminders(vault.ctx, os.scheduler, NOW)
+
+    expect(report.cancelled).toBe(1)
+    expect(os.cancelled).toEqual(['rem_note_n1'])
+    expect(os.scheduled).toHaveLength(0)
+  })
+
+  it('catches a same-id entry holding a stale time', async () => {
+    seedReminder(vault, { id: 'rem_note_n1', targetId: 'n1', remindAt: LATER.toISOString() })
+    // The identifier still matches, so a "schedule if missing" reconciler would
+    // leave this standing at the OLD time.
+    const os = fakeScheduler([{ reminderId: 'rem_note_n1', noteId: 'n1', at: SOON }])
+
+    const report = await reconcileReminders(vault.ctx, os.scheduler, NOW)
+
+    expect(os.cancelled).toEqual(['rem_note_n1'])
+    expect(report.scheduled).toBe(1)
+    expect(os.scheduled[0].at).toEqual(LATER)
+  })
+
+  it('leaves an entry that already agrees exactly alone', async () => {
+    seedReminder(vault, { id: 'rem_note_n1', targetId: 'n1', remindAt: SOON.toISOString() })
+    const os = fakeScheduler([{ reminderId: 'rem_note_n1', noteId: 'n1', at: SOON }])
+
+    const report = await reconcileReminders(vault.ctx, os.scheduler, NOW)
+
+    expect(report).toMatchObject({ scheduled: 0, cancelled: 0, deferred: 0 })
+  })
+
+  it('repairs a crash between the row write and the schedule', async () => {
+    seedReminder(vault, { id: 'rem_note_n1', targetId: 'n1', remindAt: SOON.toISOString() })
+    const os = fakeScheduler()
+
+    expect((await reconcileReminders(vault.ctx, os.scheduler, NOW)).scheduled).toBe(1)
+  })
+
+  it('cancels a notification whose row never landed', async () => {
+    const os = fakeScheduler([{ reminderId: 'rem_note_ghost', noteId: 'ghost', at: SOON }])
+
+    const report = await reconcileReminders(vault.ctx, os.scheduler, NOW)
+
+    expect(report.cancelled).toBe(1)
+    expect(os.held.size).toBe(0)
+  })
+
+  it('does not back-fire a reminder that came due while the app was closed', async () => {
+    seedReminder(vault, {
+      id: 'rem_note_n1',
+      targetId: 'n1',
+      remindAt: YESTERDAY.toISOString()
+    })
+    const os = fakeScheduler()
+
+    const report = await reconcileReminders(vault.ctx, os.scheduler, NOW)
+
+    expect(report.scheduled).toBe(0)
+    // It is not lost — the row reads as overdue and the More sheet says so.
+    const reminder = await readNoteReminder(vault.ctx.db, 'n1', NOW)
+    expect(reminder?.state.kind).toBe('overdue')
+  })
+
+  it('honours a snooze issued on another device', async () => {
+    seedReminder(vault, {
+      id: 'rem_note_n1',
+      targetId: 'n1',
+      remindAt: SOON.toISOString(),
+      status: 'snoozed',
+      snoozedUntil: LATER.toISOString()
+    })
+    const os = fakeScheduler()
+
+    await reconcileReminders(vault.ctx, os.scheduler, NOW)
+
+    // Scheduling `remindAt` would ring the phone at the time the user already
+    // pushed away.
+    expect(os.scheduled[0].at).toEqual(LATER)
+  })
+
+  it('schedules nothing for a reminder dismissed on another device', async () => {
+    seedReminder(vault, {
+      id: 'rem_note_n1',
+      targetId: 'n1',
+      remindAt: SOON.toISOString(),
+      status: 'dismissed'
+    })
+    const os = fakeScheduler([{ reminderId: 'rem_note_n1', noteId: 'n1', at: SOON }])
+
+    const report = await reconcileReminders(vault.ctx, os.scheduler, NOW)
+
+    expect(report.scheduled).toBe(0)
+    expect(os.cancelled).toEqual(['rem_note_n1'])
+  })
+
+  it('caps the device at its budget and defers the rest, soonest first', async () => {
+    for (let i = 0; i < 60; i += 1) {
+      seedReminder(vault, {
+        id: `rem_note_n${i}`,
+        targetId: `n${i}`,
+        // One per hour, ascending, so the cut is unambiguous.
+        remindAt: new Date(NOW.getTime() + (i + 1) * 3_600_000).toISOString()
+      })
+    }
+    const os = fakeScheduler()
+
+    const report = await reconcileReminders(vault.ctx, os.scheduler, NOW)
+
+    expect(report.scheduled).toBe(56)
+    expect(report.deferred).toBe(4)
+    expect(report.deferredIds).toEqual([
+      'rem_note_n56',
+      'rem_note_n57',
+      'rem_note_n58',
+      'rem_note_n59'
+    ])
+  })
+
+  it('touches nothing when the permission is denied', async () => {
+    seedReminder(vault, { id: 'rem_note_n1', targetId: 'n1', remindAt: SOON.toISOString() })
+    const os = fakeScheduler([{ reminderId: 'rem_note_n1', noteId: 'n1', at: SOON }], 'denied')
+
+    const report = await reconcileReminders(vault.ctx, os.scheduler, NOW)
+
+    expect(report).toMatchObject({ scheduled: 0, cancelled: 0, permission: 'denied' })
+    expect(os.cancelled).toHaveLength(0)
+  })
+
+  it('reports rather than throws when the OS call fails', async () => {
+    seedReminder(vault, { id: 'rem_note_n1', targetId: 'n1', remindAt: SOON.toISOString() })
+    const os = fakeScheduler()
+    const broken: ReminderScheduler = {
+      ...os.scheduler,
+      list: () => Promise.reject(new Error('no notification module'))
+    }
+
+    // It runs from AppState listeners, where a rejection is an unhandled one.
+    await expect(reconcileReminders(vault.ctx, broken, NOW)).resolves.toMatchObject({
+      scheduled: 0,
+      permission: 'unavailable'
+    })
+  })
+})
+
+describe('reminders — presentation', () => {
+  it('is amber only while the reminder is still ahead', async () => {
+    const vault = openTestVault()
+    try {
+      seedReminder(vault, { id: 'rem_note_n1', targetId: 'n1', remindAt: SOON.toISOString() })
+      const ahead = await readNoteReminder(vault.db, 'n1', NOW)
+      expect(describeReminder(ahead, NOW)).toEqual({
+        label: 'Reminder',
+        trailing: 'Today 18:00',
+        amber: true
+      })
+      const behind = await readNoteReminder(vault.db, 'n1', TWO_DAYS_ON)
+      expect(describeReminder(behind, TWO_DAYS_ON)).toMatchObject({
+        label: 'Reminder — was due',
+        amber: false
+      })
+    } finally {
+      vault.close()
+    }
+  })
+
+  it('says notifications are off instead of a time this device will not honour', async () => {
+    const vault = openTestVault()
+    try {
+      seedReminder(vault, { id: 'rem_note_n1', targetId: 'n1', remindAt: SOON.toISOString() })
+      const reminder = await readNoteReminder(vault.db, 'n1', NOW)
+      expect(describeReminder(reminder, NOW, true).trailing).toBe('Notifications off')
+    } finally {
+      vault.close()
+    }
+  })
+
+  it('offers no reminder at all as the invitation to set one', () => {
+    expect(describeReminder(null, NOW)).toEqual({
+      label: 'Remind me…',
+      trailing: null,
+      amber: false
+    })
+  })
+
+  it('drops a preset whose time has already gone', () => {
+    // 22:00 local: neither "later today" nor "this evening" can still happen.
+    const lateNight = new Date(2026, 2, 10, 22, 0, 0, 0)
+    expect(reminderPresets(lateNight).map((preset) => preset.key)).toEqual([
+      'tomorrow',
+      'next-week'
+    ])
+  })
+
+  it('lists presets in the order they happen, not the order they are declared', () => {
+    // At 19:00 "Later today" (23:00) is LATER than "This evening" (20:00).
+    const evening = new Date(2026, 2, 10, 19, 0, 0, 0)
+    expect(reminderPresets(evening).map((preset) => preset.key)).toEqual([
+      'this-evening',
+      'later-today',
+      'tomorrow',
+      'next-week'
+    ])
+  })
+
+  it('every preset it does offer is in the future', () => {
+    const morning = new Date(2026, 2, 10, 8, 0, 0, 0)
+    const presets = reminderPresets(morning)
+    expect(presets.map((preset) => preset.key)).toEqual([
+      'later-today',
+      'this-evening',
+      'tomorrow',
+      'next-week'
+    ])
+    for (const preset of presets) {
+      expect(preset.at.getTime()).toBeGreaterThan(morning.getTime())
+    }
+    // Next week is the next Monday; 10 March 2026 is a Tuesday.
+    expect(presets[3].at.getDay()).toBe(1)
+  })
+})

--- a/apps/mobile/src/features/notes/chrome/note-more-sheet.tsx
+++ b/apps/mobile/src/features/notes/chrome/note-more-sheet.tsx
@@ -5,6 +5,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { AppText } from '@/components/ui/app-text'
 import { BottomSheet } from '@/components/ui/bottom-sheet'
 import { Icon, type IconName } from '@/components/ui/icon'
+import type { Color } from '@/theme/colors'
+import type { ReminderBadge } from '@/features/notes/reminders'
 import { space } from '@/theme/primitives'
 import { useColors } from '@/theme/use-colors'
 
@@ -14,8 +16,11 @@ export interface NoteMoreSheetProps {
   bookmarked: boolean
   readOnly: boolean
   backlinkCount: number
+  /** Already derived by `describeReminder`; this sheet never reads the clock. */
+  reminder: ReminderBadge
   onClose: () => void
   onToggleBookmark: () => void
+  onReminder: () => void
   onBacklinks: () => void
   onRename: () => void
   onMove: () => void
@@ -26,11 +31,22 @@ export interface NoteMoreSheetProps {
 }
 
 interface MoreAction {
-  key: 'bookmark' | 'backlinks' | 'rename' | 'move' | 'duplicate' | 'share' | 'export' | 'delete'
+  key:
+    | 'bookmark'
+    | 'reminder'
+    | 'backlinks'
+    | 'rename'
+    | 'move'
+    | 'duplicate'
+    | 'share'
+    | 'export'
+    | 'delete'
   label: string
   icon: IconName
   trailing?: string
   destructive?: boolean
+  /** Only the reminder row uses this today, for its active state. */
+  iconColor?: Color
   onPress: () => void
 }
 
@@ -41,8 +57,10 @@ export function NoteMoreSheet({
   bookmarked,
   readOnly,
   backlinkCount,
+  reminder,
   onClose,
   onToggleBookmark,
+  onReminder,
   onBacklinks,
   onRename,
   onMove,
@@ -65,6 +83,16 @@ export function NoteMoreSheet({
       label: bookmarked ? 'Remove bookmark' : 'Bookmark note',
       icon: bookmarked ? 'bookmark-off' : 'bookmark',
       onPress: onToggleBookmark
+    },
+    {
+      key: 'reminder',
+      label: reminder.label,
+      // The ringing bell plus the AA text step of the accent, which is the only
+      // tinted colour small enough glyphs are allowed to use.
+      icon: reminder.amber ? 'bell-ring' : 'bell',
+      ...(reminder.trailing ? { trailing: reminder.trailing } : {}),
+      ...(reminder.amber ? { iconColor: c.tint.text } : {}),
+      onPress: onReminder
     },
     {
       key: 'backlinks',
@@ -131,7 +159,7 @@ export function NoteMoreSheet({
               ]}
             >
               <View style={styles.iconSlot}>
-                <Icon name={action.icon} size={22} color={color} />
+                <Icon name={action.icon} size={22} color={action.iconColor ?? color} />
               </View>
               <AppText color={color} style={styles.actionLabel}>
                 {action.label}

--- a/apps/mobile/src/features/notes/chrome/reminder-sheet.tsx
+++ b/apps/mobile/src/features/notes/chrome/reminder-sheet.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useMemo, useState } from 'react'
+import { Alert, Linking, Pressable, StyleSheet, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { DatePicker, Host } from '@expo/ui/swift-ui'
+
+import { AppText } from '@/components/ui/app-text'
+import { BottomSheet } from '@/components/ui/bottom-sheet'
+import { Icon } from '@/components/ui/icon'
+import { extractErrorMessage } from '@/lib/errors'
+import { createLogger } from '@/lib/logger'
+import type { NoteOpsContext } from '@/features/notes/note-ops'
+import {
+  clearNoteReminder,
+  formatReminderTime,
+  reminderPresets,
+  setNoteReminder,
+  type NoteReminder
+} from '@/features/notes/reminders'
+import { fontFamilies } from '@/theme/fonts'
+import { radius, sizes, space } from '@/theme/primitives'
+import { useColors } from '@/theme/use-colors'
+
+const log = createLogger('ReminderSheet')
+
+// The same 52pt row `sort-sheet.tsx` uses; one more sheet does not earn a step
+// on the size scale.
+const ROW_HEIGHT = 52
+const PICKER_HEIGHT = 220
+
+export interface ReminderSheetProps {
+  visible: boolean
+  ctx: NoteOpsContext | null
+  noteId: string
+  noteTitle: string
+  reminder: NoteReminder | null
+  onClose: () => void
+  onChanged: (reminder: NoteReminder | null) => void
+}
+
+/**
+ * `setNoteReminder` saves and syncs whatever happens with the OS, so every
+ * branch below is about DELIVERY — what this device will or will not show —
+ * never about whether the reminder exists.
+ */
+export function ReminderSheet({
+  visible,
+  ctx,
+  noteId,
+  noteTitle,
+  reminder,
+  onClose,
+  onChanged
+}: ReminderSheetProps) {
+  const c = useColors()
+  const insets = useSafeAreaInsets()
+  const [custom, setCustom] = useState<Date | null>(null)
+
+  // Anchored to the mount. The note screen mounts this sheet only while it is
+  // open, so "the moment the sheet opened" and "the moment it mounted" are the
+  // same instant, and presets cannot move under the user's finger mid-render.
+  const now = useMemo(() => new Date(), [])
+  const presets = useMemo(() => reminderPresets(now), [now])
+
+  const pick = useCallback(
+    async (at: Date) => {
+      if (!ctx) return
+      onClose()
+      try {
+        // No `title`: that field is the user's own reminder text on the
+        // desktop, and the banner already falls back to the note's title. This
+        // sheet has no text input, so writing one would be inventing data.
+        const result = await setNoteReminder(ctx, noteId, at)
+        onChanged(result.reminder)
+        switch (result.delivery) {
+          case 'scheduled':
+            return
+          case 'permission-denied':
+            return Alert.alert(
+              'Reminder saved, notifications are off',
+              'Memry can’t show a notification on this device until you allow them in Settings. The reminder still syncs to your other devices.',
+              [
+                { text: 'Not now', style: 'cancel' },
+                { text: 'Open Settings', onPress: () => void Linking.openSettings() }
+              ]
+            )
+          case 'in-the-past':
+            return Alert.alert(
+              'Reminder saved',
+              'That time has already passed, so no notification will be shown.'
+            )
+          case 'device-limit':
+            return Alert.alert(
+              'Reminder saved',
+              'This device is already holding its maximum number of scheduled reminders. This one is scheduled as earlier reminders pass.'
+            )
+          case 'unavailable':
+            // Simulator, a stale dev client, or a build without the module.
+            // Saved and syncing; saying nothing beats a dialog about a
+            // capability the user did not ask for.
+            return
+        }
+      } catch (error) {
+        const message = extractErrorMessage(error, 'That reminder could not be saved.')
+        log.error('Setting a reminder failed', { noteId, error: message })
+        Alert.alert('Reminder failed', message)
+      }
+    },
+    [ctx, noteId, onChanged, onClose]
+  )
+
+  const remove = useCallback(async () => {
+    if (!ctx) return
+    onClose()
+    try {
+      await clearNoteReminder(ctx, noteId)
+      onChanged(null)
+    } catch (error) {
+      const message = extractErrorMessage(error, 'That reminder could not be removed.')
+      log.error('Clearing a reminder failed', { noteId, error: message })
+      Alert.alert('Reminder failed', message)
+    }
+  }, [ctx, noteId, onChanged, onClose])
+
+  return (
+    <BottomSheet
+      visible={visible}
+      onClose={onClose}
+      accessibilityLabel={`Remind me about ${noteTitle}`}
+      style={{ paddingBottom: insets.bottom }}
+    >
+      <View style={styles.header}>
+        <AppText style={styles.headerTitle}>Remind me</AppText>
+        {reminder && reminder.state.kind !== 'dismissed' ? (
+          <AppText variant="footnote" color={c.text.secondary}>
+            {formatReminderTime(reminder.state.at, now)}
+          </AppText>
+        ) : null}
+      </View>
+
+      {presets.map((preset) => (
+        <Pressable
+          key={preset.key}
+          accessibilityRole="button"
+          accessibilityLabel={`${preset.label}, ${formatReminderTime(preset.at, now)}`}
+          onPress={() => void pick(preset.at)}
+          style={[styles.row, { borderTopColor: c.line.border }]}
+        >
+          <View style={styles.iconSlot}>
+            <Icon name="bell" size={18} color={c.text.secondary} />
+          </View>
+          <AppText style={styles.rowLabel}>{preset.label}</AppText>
+          <AppText variant="footnote" color={c.text.tertiary}>
+            {formatReminderTime(preset.at, now)}
+          </AppText>
+        </Pressable>
+      ))}
+
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Pick a date and time"
+        accessibilityState={{ expanded: custom !== null }}
+        // Opens in place rather than as a second sheet: a picker stacked on a
+        // modal is the arrangement `properties.tsx` already declined.
+        onPress={() => setCustom((open) => (open ? null : defaultCustom(now)))}
+        style={[styles.row, { borderTopColor: c.line.border }]}
+      >
+        <View style={styles.iconSlot}>
+          <Icon name="calendar" size={18} color={c.text.secondary} />
+        </View>
+        <AppText style={styles.rowLabel}>Pick date &amp; time…</AppText>
+      </Pressable>
+
+      {custom ? (
+        <View style={[styles.picker, { borderTopColor: c.line.border }]}>
+          <Host matchContents style={styles.pickerHost}>
+            <DatePicker
+              selection={custom}
+              displayedComponents={['date', 'hourAndMinute']}
+              onDateChange={setCustom}
+            />
+          </Host>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Set reminder"
+            onPress={() => void pick(custom)}
+            style={[styles.confirm, { backgroundColor: c.tint.base }]}
+          >
+            <AppText color={c.tint.foreground}>Set reminder</AppText>
+          </Pressable>
+        </View>
+      ) : null}
+
+      {reminder ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Remove reminder"
+          onPress={() => void remove()}
+          style={[styles.row, { borderTopColor: c.line.border }]}
+        >
+          <View style={styles.iconSlot}>
+            <Icon name="trash" size={18} color={c.ui.destructiveText} />
+          </View>
+          <AppText color={c.ui.destructiveText} style={styles.rowLabel}>
+            Remove reminder
+          </AppText>
+        </Pressable>
+      ) : null}
+    </BottomSheet>
+  )
+}
+
+/** The picker opens on the next whole hour, not on `now` to the second. */
+function defaultCustom(now: Date): Date {
+  const at = new Date(now)
+  at.setMinutes(0, 0, 0)
+  at.setHours(at.getHours() + 1)
+  return at
+}
+
+const styles = StyleSheet.create({
+  header: {
+    height: ROW_HEIGHT,
+    paddingHorizontal: sizes.gutter,
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  headerTitle: { flex: 1, fontFamily: fontFamilies.sansSemiBold, letterSpacing: -0.17 },
+  row: {
+    height: ROW_HEIGHT,
+    paddingHorizontal: sizes.gutter,
+    gap: space.s12,
+    borderTopWidth: 1,
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  iconSlot: { width: 24, alignItems: 'center', justifyContent: 'center' },
+  rowLabel: { flex: 1, minWidth: 0 },
+  picker: {
+    borderTopWidth: 1,
+    paddingHorizontal: sizes.gutter,
+    paddingVertical: space.s12,
+    gap: space.s12
+  },
+  pickerHost: { minHeight: PICKER_HEIGHT },
+  confirm: {
+    height: sizes.tapTarget,
+    borderRadius: radius.md,
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+})

--- a/apps/mobile/src/features/notes/reminder-notifications.ts
+++ b/apps/mobile/src/features/notes/reminder-notifications.ts
@@ -1,0 +1,210 @@
+import * as Notifications from 'expo-notifications'
+
+import { createLogger } from '@/lib/logger'
+import type {
+  ReminderPermission,
+  ReminderScheduler,
+  ScheduledReminder,
+  ScheduleRequest
+} from '@/features/notes/reminders'
+
+const log = createLogger('ReminderNotifications')
+
+/**
+ * The ONLY file that imports `expo-notifications`.
+ *
+ * Everything crossing this boundary is a domain value: an expo `Notification`,
+ * `NotificationRequest` or permission object never escapes, so `reminders.ts`
+ * can be driven by a fake in a test and the app has exactly one place to look
+ * when the OS behaves differently from the docs.
+ *
+ * **The identifier of a scheduled reminder IS the reminder id.** That is the
+ * load-bearing choice of the whole delivery design:
+ *
+ * - cancel is O(1) and needs no lookup table;
+ * - scheduling twice REPLACES rather than duplicates, so every path is
+ *   idempotent by construction and there is no "did I already schedule this"
+ *   bookkeeping to get out of step;
+ * - the OS list is therefore a complete, crash-proof record of what this device
+ *   holds — exactly the local table we would otherwise have to add and migrate.
+ *
+ * iOS honours a caller-supplied identifier, which is what this rests on. This
+ * feature is iOS-only for v1.
+ */
+
+const MARKER = 'reminder'
+
+/**
+ * A reminder banner is worth interrupting for while the app is open — the whole
+ * point is that the user asked to be told at this moment.
+ */
+Notifications.setNotificationHandler({
+  handleNotification: () =>
+    Promise.resolve({
+      shouldPlaySound: true,
+      shouldSetBadge: false,
+      shouldShowBanner: true,
+      shouldShowList: true
+    })
+})
+
+export interface ReminderRef {
+  reminderId: string
+  noteId: string
+}
+
+/** Validate the OS payload here so no unchecked `any` reaches the domain. */
+function toRef(data: unknown): ReminderRef | null {
+  if (typeof data !== 'object' || data === null) return null
+  const record = data as Record<string, unknown>
+  if (record.memry !== MARKER) return null
+  const { reminderId, noteId } = record
+  if (typeof reminderId !== 'string' || typeof noteId !== 'string') return null
+  return { reminderId, noteId }
+}
+
+function toScheduled(request: Notifications.NotificationRequest): ScheduledReminder | null {
+  const ref = toRef(request.content.data)
+  if (!ref) return null
+  // The time is read out of OUR data, not out of the trigger: the trigger's
+  // shape differs by platform and by trigger type, and this comparison is what
+  // lets the reconciler spot an entry that still has the right id at the wrong
+  // time.
+  const raw = (request.content.data as Record<string, unknown>).at
+  const ms = typeof raw === 'string' ? Date.parse(raw) : NaN
+  if (!Number.isFinite(ms)) return null
+  return { reminderId: ref.reminderId, noteId: ref.noteId, at: new Date(ms) }
+}
+
+function toPermission(status: Notifications.NotificationPermissionsStatus): ReminderPermission {
+  // iOS's granular states matter here: PROVISIONAL and EPHEMERAL both deliver,
+  // and `granted` already folds them in.
+  return status.granted ? 'granted' : 'denied'
+}
+
+async function permission(): Promise<ReminderPermission> {
+  try {
+    return toPermission(await Notifications.getPermissionsAsync())
+  } catch (err) {
+    log.warn('Reading the notification permission failed', {
+      error: err instanceof Error ? err.message : String(err)
+    })
+    return 'unavailable'
+  }
+}
+
+async function request(): Promise<ReminderPermission> {
+  try {
+    const current = await Notifications.getPermissionsAsync()
+    if (current.granted) return 'granted'
+    // Asking again once iOS has recorded a denial does nothing — the prompt
+    // never appears and the call resolves denied. The user has to go to
+    // Settings, which is what the sheet offers them.
+    if (!current.canAskAgain) return 'denied'
+    return toPermission(
+      await Notifications.requestPermissionsAsync({
+        ios: { allowAlert: true, allowBadge: false, allowSound: true }
+      })
+    )
+  } catch (err) {
+    log.warn('Requesting the notification permission failed', {
+      error: err instanceof Error ? err.message : String(err)
+    })
+    return 'unavailable'
+  }
+}
+
+async function list(): Promise<ScheduledReminder[]> {
+  const requests = await Notifications.getAllScheduledNotificationsAsync()
+  const entries: ScheduledReminder[] = []
+  for (const item of requests) {
+    const entry = toScheduled(item)
+    // Anything that is not one of ours is left alone. This app schedules
+    // nothing else today, but cancelling a stranger's notification because it
+    // was not in `want` is the kind of bug that only shows up later.
+    if (entry) entries.push(entry)
+  }
+  return entries
+}
+
+async function schedule(input: ScheduleRequest): Promise<'ok' | 'denied' | 'unavailable'> {
+  try {
+    await Notifications.scheduleNotificationAsync({
+      identifier: input.reminderId,
+      content: {
+        title: input.title,
+        body: input.body,
+        data: {
+          memry: MARKER,
+          reminderId: input.reminderId,
+          noteId: input.noteId,
+          vaultId: input.vaultId,
+          at: input.at.toISOString()
+        }
+      },
+      trigger: { type: Notifications.SchedulableTriggerInputTypes.DATE, date: input.at }
+    })
+    return 'ok'
+  } catch (err) {
+    log.warn('Scheduling a reminder notification failed', {
+      reminderId: input.reminderId,
+      error: err instanceof Error ? err.message : String(err)
+    })
+    return 'unavailable'
+  }
+}
+
+async function cancel(reminderId: string): Promise<void> {
+  try {
+    await Notifications.cancelScheduledNotificationAsync(reminderId)
+  } catch (err) {
+    log.warn('Cancelling a reminder notification failed', {
+      reminderId,
+      error: err instanceof Error ? err.message : String(err)
+    })
+  }
+}
+
+export const notificationScheduler: ReminderScheduler = {
+  permission,
+  request,
+  list,
+  schedule,
+  cancel
+}
+
+/**
+ * Route a tapped banner back to its note. Returns an unsubscribe.
+ *
+ * The cold-start response is checked too: a tap that LAUNCHED the app has
+ * already been delivered by the time any listener attaches, so a listener alone
+ * would open the app on the notes list and lose the tap.
+ */
+export function onReminderTap(handler: (ref: ReminderRef) => void): () => void {
+  let live = true
+  void Notifications.getLastNotificationResponseAsync()
+    .then((response) => {
+      if (!live || !response) return
+      const ref = toRef(response.notification.request.content.data)
+      if (!ref) return
+      // Without this the same launch tap is replayed on every later cold start
+      // that happens to have no newer response.
+      Notifications.clearLastNotificationResponse()
+      handler(ref)
+    })
+    .catch((err: unknown) => {
+      log.warn('Reading the launch notification response failed', {
+        error: err instanceof Error ? err.message : String(err)
+      })
+    })
+
+  const subscription = Notifications.addNotificationResponseReceivedListener((response) => {
+    const ref = toRef(response.notification.request.content.data)
+    if (ref) handler(ref)
+  })
+
+  return () => {
+    live = false
+    subscription.remove()
+  }
+}

--- a/apps/mobile/src/features/notes/reminders.ts
+++ b/apps/mobile/src/features/notes/reminders.ts
@@ -1,0 +1,821 @@
+import { noteReminderSyncId } from '@memry/contracts/reminder-types'
+import { toOutboundReminderPayload } from '@memry/sync-client/reminder-outbound'
+
+import type { VaultDb } from '@/db/index'
+import { withVaultTransaction } from '@/db/tx'
+import { createLogger } from '@/lib/logger'
+import type { NoteOpsContext } from '@/features/notes/note-ops'
+import { bumpClock } from '@/sync/outbox'
+
+const log = createLogger('Reminders')
+
+/**
+ * Note reminders (issue #2111), the mobile half of a record desktop already
+ * owns.
+ *
+ * Two rules shape everything here.
+ *
+ * 1. **The stored payload is synced truth ONLY.** Desktop keeps `triggeredAt`
+ *    and `status: 'triggered'` in the same row it syncs and strips them on the
+ *    way out, which works there because desktop merges an incoming payload
+ *    field by field. Mobile has no per-type handler: `applyRecordItems`
+ *    overwrites `sync_items.payload` VERBATIM with whatever arrived, so a
+ *    device-local field parked inside the payload is destroyed by the next pull
+ *    touching that reminder — silently, because the cursor advances anyway.
+ *    Mobile therefore never writes one, and needs no strip step because there
+ *    is nothing to strip.
+ *
+ * 2. **The OS pending-notification list is the only device-local store.**
+ *    Schedules are keyed by `identifier === reminder.id`, so the list is a
+ *    complete, crash-proof record of what this device holds — exactly the local
+ *    table we would otherwise have had to add, migrate and keep in step with
+ *    both the OS and the database. `reconcileReminders` is the ONE function
+ *    that schedules or cancels anything.
+ *
+ * `targetType: 'note_date'` rows are never read, replaced or deleted here. They
+ * are owned by desktop's note-content reconciler, their `remindAt` is derived
+ * per device from a date pill, and mobile touching one would sync a value that
+ * makes two desktops contend and reset each other's dismissals
+ * (`reminder-outbound.ts`).
+ */
+
+// ---------------------------------------------------------------------------
+// Instants
+// ---------------------------------------------------------------------------
+
+declare const instantBrand: unique symbol
+
+/**
+ * An ISO-8601 UTC instant, produced from a local `Date` via `.toISOString()`.
+ *
+ * Branded because the reminder wire format is a STRING and this app has already
+ * been burned once by writing epoch ms where the desktop schema declared a
+ * string (`NotePayload.createdAt`): every phone-edited note failed `safeParse`
+ * on the desktop and was skipped without retry. The brand makes that class of
+ * bug a compile error — the only way to obtain one is `toInstant`.
+ */
+export type Instant = string & { readonly [instantBrand]: true }
+
+export function toInstant(date: Date): Instant {
+  return date.toISOString() as Instant
+}
+
+/** Parse at the boundary. `null` on anything that is not a readable instant. */
+export function fromInstant(value: unknown): Date | null {
+  if (typeof value !== 'string') return null
+  const ms = Date.parse(value)
+  return Number.isFinite(ms) ? new Date(ms) : null
+}
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+export type ReminderTarget = 'note' | 'journal'
+
+/**
+ * The four states a reminder can be in from this device's point of view.
+ *
+ * A union rather than a status string plus a pile of booleans: "amber", "was
+ * due" and "should the OS hold a notification for this" are all one question,
+ * and a boolean pair can express states that cannot exist.
+ *
+ * `at` is the EFFECTIVE instant — `snoozedUntil ?? remindAt`. A snooze issued on
+ * the desktop syncs, so reading `remindAt` alone would ring this phone at the
+ * original time the user already pushed away.
+ *
+ * INVARIANT: `kind === 'scheduled' | 'snoozed'` ⟺ the reconciler wants an OS
+ * notification for this row. That equivalence is the whole scheduling rule;
+ * there is no second predicate anywhere.
+ */
+export type ReminderState =
+  | { kind: 'scheduled'; at: Date }
+  | { kind: 'snoozed'; at: Date }
+  | { kind: 'overdue'; at: Date }
+  | { kind: 'dismissed'; at: Date }
+
+/**
+ * A note reminder as this app understands it — the DOMAIN type.
+ *
+ * Deliberately not the wire shape: `remindAt` is a `Date`, `state` is derived,
+ * and the desktop-only highlight columns are absent. The stored payload keeps
+ * every one of those fields untouched; they just do not belong on the surface
+ * handed to a React component.
+ */
+export interface NoteReminder {
+  readonly id: string
+  readonly noteId: string
+  readonly targetType: ReminderTarget
+  readonly remindAt: Date
+  readonly snoozedUntil: Date | null
+  readonly title: string | null
+  readonly note: string | null
+  /** Derived on read from `status` + the effective instant vs. now. Never stored. */
+  readonly state: ReminderState
+}
+
+/** `NoteReminder | null` flattened into exactly what a row or sheet renders. */
+export interface ReminderBadge {
+  readonly label: string
+  readonly trailing: string | null
+  /** SINGLE derivation of the desktop amber-bell rule. */
+  readonly amber: boolean
+}
+
+export type ReminderDelivery =
+  /** The OS is holding a dated notification for this reminder. */
+  | 'scheduled'
+  /** Saved and syncing; this device will show nothing. */
+  | 'permission-denied'
+  /** Saved; the time has already passed, so there is nothing to schedule. */
+  | 'in-the-past'
+  /** Saved; the device's pending-notification budget is full right now. */
+  | 'device-limit'
+  /** Saved; no notification module (simulator, test, stale dev client). */
+  | 'unavailable'
+
+/**
+ * Every branch carries the saved reminder.
+ *
+ * Permission is a DELIVERY outcome, not a save outcome — the type makes it
+ * impossible to write a call site that discards the reminder because the OS
+ * said no.
+ */
+export interface SetReminderResult {
+  readonly reminder: NoteReminder
+  readonly delivery: ReminderDelivery
+}
+
+export type ReminderPermission = 'granted' | 'denied' | 'unavailable'
+
+/** One entry the OS is holding, parsed into domain values at the boundary. */
+export interface ScheduledReminder {
+  readonly reminderId: string
+  readonly noteId: string
+  readonly at: Date
+}
+
+/** What the reconciler asks the OS to hold. Content is built here, not there. */
+export interface ScheduleRequest {
+  readonly reminderId: string
+  readonly noteId: string
+  readonly vaultId: string
+  readonly at: Date
+  readonly title: string
+  readonly body: string
+}
+
+/**
+ * The OS scheduler, as an interface.
+ *
+ * Named so the reconciler can be driven by a fake in a unit test — the cases
+ * that matter (a stale entry at the wrong time, an entry for a reminder that no
+ * longer exists) are invisible in a database and obvious in a call log. The
+ * real implementation is `reminder-notifications.ts`, the only file in the app
+ * that imports `expo-notifications`.
+ */
+export interface ReminderScheduler {
+  /** Never prompts. Prompting is a user-initiated act; see `setNoteReminder`. */
+  permission(): Promise<ReminderPermission>
+  /** Prompts only when the user has not been asked yet. */
+  request(): Promise<ReminderPermission>
+  list(): Promise<ScheduledReminder[]>
+  schedule(request: ScheduleRequest): Promise<'ok' | 'denied' | 'unavailable'>
+  cancel(reminderId: string): Promise<void>
+}
+
+export interface ReconcileReport {
+  readonly scheduled: number
+  readonly cancelled: number
+  /** Wanted, but over the device budget. */
+  readonly deferred: number
+  /**
+   * WHICH ones were deferred, not just how many.
+   *
+   * `setNoteReminder` has to tell the user "saved, but this device is full"
+   * about the reminder they just picked, and the count alone cannot answer
+   * that. The alternative is a second round trip to the OS list right after the
+   * reconciler already read it.
+   */
+  readonly deferredIds: readonly string[]
+  readonly permission: ReminderPermission
+}
+
+export interface ReminderPreset {
+  readonly key: 'later-today' | 'this-evening' | 'tomorrow' | 'next-week'
+  readonly label: string
+  readonly at: Date
+}
+
+/** The reconciler needs no outbox: it only reads rows and talks to the OS. */
+export type ReminderContext = Pick<NoteOpsContext, 'db' | 'vaultId'>
+
+// ---------------------------------------------------------------------------
+// Wire type
+// ---------------------------------------------------------------------------
+
+/**
+ * The stored `sync_items.payload` for a `reminder`, exactly as desktop writes
+ * it (`ReminderSyncPayloadSchema`).
+ *
+ * Index signature per the mobile payload rule: read verbatim, mutate only our
+ * own fields, write the whole object back, so a newer desktop's unknown fields
+ * survive a mobile edit untouched.
+ *
+ * `status` omits `'triggered'` while the wire schema allows it, and
+ * `triggeredAt` is absent entirely. Deliberate asymmetry: mobile must READ a
+ * `'triggered'` leaked by an older desktop build tolerantly, and must never
+ * WRITE one. The narrowed type enforces that at compile time instead of at a
+ * runtime strip anyone could forget to call.
+ */
+interface ReminderPayload {
+  targetType?: string
+  targetId?: string
+  remindAt?: string
+  anchorId?: string | null
+  highlightText?: string | null
+  highlightStart?: number | null
+  highlightEnd?: number | null
+  title?: string | null
+  note?: string | null
+  status?: 'pending' | 'dismissed' | 'snoozed'
+  dismissedAt?: string | null
+  snoozedUntil?: string | null
+  clock?: Record<string, number>
+  createdAt?: string
+  modifiedAt?: string
+  [unknownFieldsFromNewerClients: string]: unknown
+}
+
+// ---------------------------------------------------------------------------
+// Reading
+// ---------------------------------------------------------------------------
+
+function asTarget(value: unknown): ReminderTarget | null {
+  return value === 'note' || value === 'journal' ? value : null
+}
+
+/**
+ * A stored payload as a domain reminder, or `null` if this module does not own
+ * it.
+ *
+ * `note_date`, `highlight` and `task` rows fall out here, which is what makes
+ * "this module never touches a `note_date` row" a property of the type rather
+ * than of a comment: there is no code path that produces any other value.
+ */
+function toReminder(id: string, payload: ReminderPayload, now: Date): NoteReminder | null {
+  const targetType = asTarget(payload.targetType)
+  const noteId = payload.targetId
+  const remindAt = fromInstant(payload.remindAt)
+  if (!targetType || typeof noteId !== 'string' || !remindAt) return null
+
+  return {
+    id,
+    noteId,
+    targetType,
+    remindAt,
+    snoozedUntil: fromInstant(payload.snoozedUntil),
+    title: typeof payload.title === 'string' ? payload.title : null,
+    note: typeof payload.note === 'string' ? payload.note : null,
+    state: deriveState(remindAt, fromInstant(payload.snoozedUntil), payload.status, now)
+  }
+}
+
+/**
+ * The only place a reminder's state is decided.
+ *
+ * A `'triggered'` status from an older desktop build is read as time like any
+ * other — it only ever meant "some device's scheduler fired", which says
+ * nothing about this one — and is never written back.
+ */
+function deriveState(
+  remindAt: Date,
+  snoozedUntil: Date | null,
+  status: unknown,
+  now: Date
+): ReminderState {
+  const at = snoozedUntil ?? remindAt
+  if (status === 'dismissed') return { kind: 'dismissed', at }
+  if (at.getTime() <= now.getTime()) return { kind: 'overdue', at }
+  if (status === 'snoozed' && snoozedUntil) return { kind: 'snoozed', at }
+  return { kind: 'scheduled', at }
+}
+
+function parsePayload(raw: string | null): ReminderPayload | null {
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as ReminderPayload
+  } catch {
+    log.warn('Reminder payload is not JSON; skipping')
+    return null
+  }
+}
+
+/** Every live note/journal reminder in the vault, oldest effective time first. */
+export async function readLiveReminders(db: VaultDb, now: Date): Promise<NoteReminder[]> {
+  const rows = await db.getAllAsync<{ id: string; payload: string | null }>(
+    `SELECT id, payload FROM sync_items WHERE type = 'reminder' AND deleted_at IS NULL`
+  )
+  const reminders: NoteReminder[] = []
+  for (const row of rows) {
+    const payload = parsePayload(row.payload)
+    if (!payload) continue
+    const reminder = toReminder(row.id, payload, now)
+    if (reminder) reminders.push(reminder)
+  }
+  return reminders.sort((a, b) => a.state.at.getTime() - b.state.at.getTime())
+}
+
+/**
+ * The one live reminder on a note, or null. Reads `sync_items`; no network, no
+ * OS.
+ *
+ * A dismissed reminder reads as no reminder — the user silenced it on some
+ * device and the bell should say so. An active one wins over an overdue one;
+ * with the deterministic id there is normally exactly one row anyway.
+ */
+export async function readNoteReminder(
+  db: VaultDb,
+  noteId: string,
+  now: Date = new Date()
+): Promise<NoteReminder | null> {
+  const mine = (await readLiveReminders(db, now)).filter((r) => r.noteId === noteId)
+  return (
+    mine.find((r) => r.state.kind === 'scheduled' || r.state.kind === 'snoozed') ??
+    mine.filter((r) => r.state.kind === 'overdue').at(-1) ??
+    null
+  )
+}
+
+async function readStoredPayload(db: VaultDb, id: string): Promise<ReminderPayload | null> {
+  // No `deleted_at IS NULL`: a tombstoned row's payload — and its CLOCK — is
+  // exactly what a re-add has to reuse.
+  const row = await db.getFirstAsync<{ payload: string | null }>(
+    'SELECT payload FROM sync_items WHERE id = ?',
+    [id]
+  )
+  return parsePayload(row?.payload ?? null)
+}
+
+// ---------------------------------------------------------------------------
+// Presentation (pure: no db, no OS, no clock of its own)
+// ---------------------------------------------------------------------------
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+function timeOfDay(at: Date): string {
+  return `${pad(at.getHours())}:${pad(at.getMinutes())}`
+}
+
+function sameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  )
+}
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec'
+] as const
+
+/** "Today 09:00" · "Tomorrow 09:00" · "Mon 09:00" · "12 Mar 09:00". */
+export function formatReminderTime(at: Date, now: Date): string {
+  const tomorrow = new Date(now)
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  if (sameDay(at, now)) return `Today ${timeOfDay(at)}`
+  if (sameDay(at, tomorrow)) return `Tomorrow ${timeOfDay(at)}`
+  const days = (at.getTime() - now.getTime()) / 86_400_000
+  if (days > 0 && days < 7) return `${WEEKDAYS[at.getDay()]} ${timeOfDay(at)}`
+  return `${at.getDate()} ${MONTHS[at.getMonth()]} ${timeOfDay(at)}`
+}
+
+/** "just now" · "3 hours ago" · "2 days ago". */
+export function formatTimeAgo(at: Date, now: Date): string {
+  const minutes = Math.floor((now.getTime() - at.getTime()) / 60_000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  const days = Math.floor(hours / 24)
+  return `${days} day${days === 1 ? '' : 's'} ago`
+}
+
+/**
+ * The More-sheet row, derived from the row and the clock.
+ *
+ * Takes `now` rather than reading the clock so the derivation is pure and a
+ * timezone test can drive it. The cost is that an open screen can hold an amber
+ * bell a minute after it should have gone plain, which is not worth a ticking
+ * timer on the note screen.
+ */
+export function describeReminder(
+  reminder: NoteReminder | null,
+  now: Date,
+  notificationsOff = false
+): ReminderBadge {
+  if (!reminder || reminder.state.kind === 'dismissed') {
+    return { label: 'Remind me…', trailing: null, amber: false }
+  }
+  if (reminder.state.kind === 'overdue') {
+    return {
+      label: 'Reminder — was due',
+      trailing: formatTimeAgo(reminder.state.at, now),
+      amber: false
+    }
+  }
+  return {
+    label: 'Reminder',
+    // Said at the moment it matters, and kept being said: a reminder this
+    // device can never ring is otherwise indistinguishable from one that will.
+    trailing: notificationsOff ? 'Notifications off' : formatReminderTime(reminder.state.at, now),
+    amber: true
+  }
+}
+
+function at(now: Date, dayOffset: number, hour: number): Date {
+  const date = new Date(now)
+  date.setDate(date.getDate() + dayOffset)
+  date.setHours(hour, 0, 0, 0)
+  return date
+}
+
+/**
+ * The four quick picks, as a pure function of `now`.
+ *
+ * A preset whose time has already passed is dropped rather than silently
+ * rolled forward — "This evening" that means tomorrow evening is a lie the row
+ * cannot tell the user.
+ */
+export function reminderPresets(now: Date): readonly ReminderPreset[] {
+  const laterToday = new Date(now)
+  laterToday.setMinutes(0, 0, 0)
+  laterToday.setHours(laterToday.getHours() + 4)
+
+  const presets: ReminderPreset[] = []
+  if (sameDay(laterToday, now)) {
+    presets.push({ key: 'later-today', label: 'Later today', at: laterToday })
+  }
+  const evening = at(now, 0, 20)
+  if (evening.getTime() > now.getTime()) {
+    presets.push({ key: 'this-evening', label: 'This evening', at: evening })
+  }
+  presets.push({ key: 'tomorrow', label: 'Tomorrow', at: at(now, 1, 9) })
+  // Next Monday, 09:00. `getDay()` is 0 for Sunday.
+  const day = now.getDay()
+  const untilMonday = day === 0 ? 1 : 8 - day
+  presets.push({ key: 'next-week', label: 'Next week', at: at(now, untilMonday, 9) })
+  // Chronological, not declaration order: after 16:00 "Later today" is LATER
+  // than "This evening", and a list that reads out of order looks broken.
+  return presets.sort((x, y) => x.at.getTime() - y.at.getTime())
+}
+
+// ---------------------------------------------------------------------------
+// Writing
+// ---------------------------------------------------------------------------
+
+/**
+ * Last step before `JSON.stringify`, always.
+ *
+ * On a payload this module built it is the identity function — nothing here
+ * ever writes `triggeredAt` or `status: 'triggered'`. It runs anyway so that a
+ * PULLED payload carrying one from an older desktop build is normalized when
+ * mobile next edits it, and so that a device-local field desktop adds later is
+ * inherited for free instead of drifting.
+ */
+function serialize(payload: ReminderPayload): string {
+  return JSON.stringify(toOutboundReminderPayload(payload))
+}
+
+async function upsertRow(
+  ctx: NoteOpsContext,
+  id: string,
+  payload: ReminderPayload,
+  now: number
+): Promise<void> {
+  bumpClock(payload as Record<string, unknown>, ctx.deviceId)
+  const serialized = serialize(payload)
+  await ctx.db.runAsync(
+    `INSERT INTO sync_items (id, type, vault_id, updated_at, deleted_at, payload_state, payload)
+     VALUES (?, 'reminder', ?, ?, NULL, 'full', ?)
+     ON CONFLICT(id) DO UPDATE SET
+       updated_at = excluded.updated_at,
+       deleted_at = NULL,
+       payload_state = 'full',
+       payload = excluded.payload`,
+    [id, ctx.vaultId, now, serialized]
+  )
+  await ctx.outbox.enqueueRecord('reminder', id, 'update', serialized)
+}
+
+async function tombstoneRow(ctx: NoteOpsContext, id: string, now: number): Promise<void> {
+  const stored = await readStoredPayload(ctx.db, id)
+  if (!stored) return
+  bumpClock(stored as Record<string, unknown>, ctx.deviceId)
+  const serialized = serialize(stored)
+  // A tombstone, never a hard delete — same rule as a bookmark: deleting the
+  // row locally makes the next pull treat the server's copy as new and the
+  // reminder comes back.
+  await ctx.db.runAsync(
+    'UPDATE sync_items SET deleted_at = ?, updated_at = ?, payload = ? WHERE id = ?',
+    [now, now, serialized, id]
+  )
+  await ctx.outbox.enqueueRecord('reminder', id, 'delete', serialized)
+}
+
+export interface SetReminderOptions {
+  title?: string | null
+  note?: string | null
+  targetType?: ReminderTarget
+  /** Injected in tests; production callers take the real OS scheduler. */
+  scheduler?: ReminderScheduler
+  now?: Date
+}
+
+/**
+ * Set or replace the reminder on a note. Mirrors desktop's
+ * `useSetOrReplaceReminder`: one reminder per note, a new pick replaces the old.
+ *
+ * The row and the queued push land FIRST, then the OS scheduler is reconciled.
+ * A saved reminder with no notification is repaired by the next reconcile pass;
+ * a notification with no row would be a ghost banner for a reminder the user
+ * does not have.
+ */
+export async function setNoteReminder(
+  ctx: NoteOpsContext,
+  noteId: string,
+  remindAt: Date,
+  opts: SetReminderOptions = {}
+): Promise<SetReminderResult> {
+  const now = opts.now ?? new Date()
+  const id = noteReminderSyncId(noteId)
+  const stamp = now.getTime()
+
+  // A desktop-created random-id reminder on this note is SUPERSEDED, not left
+  // beside the new one — desktop resolves one-per-note the same way.
+  const superseded = (await readLiveReminders(ctx.db, now))
+    .filter((r) => r.noteId === noteId && r.id !== id)
+    .map((r) => r.id)
+
+  const payload: ReminderPayload = (await readStoredPayload(ctx.db, id)) ?? {
+    createdAt: toInstant(now)
+  }
+  const targetType = opts.targetType ?? asTarget(payload.targetType) ?? 'note'
+  payload.targetType = targetType
+  payload.targetId = noteId
+  payload.remindAt = toInstant(remindAt)
+  payload.status = 'pending'
+  payload.dismissedAt = null
+  // A new time undoes a snooze: the user just said when they want this.
+  payload.snoozedUntil = null
+  if (opts.title !== undefined) payload.title = opts.title
+  if (opts.note !== undefined) payload.note = opts.note
+  payload.modifiedAt = toInstant(now)
+
+  await withVaultTransaction(ctx.db, async () => {
+    for (const staleId of superseded) await tombstoneRow(ctx, staleId, stamp)
+    await upsertRow(ctx, id, payload, stamp)
+  })
+
+  // Built from what was just written rather than read back: the row is the
+  // authority for every OTHER device, but this call already knows what it put
+  // there, and a re-read would only introduce a way for the result to be null.
+  const reminder: NoteReminder = {
+    id,
+    noteId,
+    targetType,
+    remindAt,
+    snoozedUntil: null,
+    title: payload.title ?? null,
+    note: payload.note ?? null,
+    state: deriveState(remindAt, null, 'pending', now)
+  }
+
+  // Asked HERE, at the moment the user confirmed a time — never at app start,
+  // which is the most reliable way to earn a permanent denial.
+  const scheduler = opts.scheduler ?? (await loadScheduler()) ?? undefined
+  if (scheduler) await scheduler.request()
+  const report = await reconcileReminders(ctx, scheduler, now)
+
+  return { reminder, delivery: deliveryFor(reminder, report, now) }
+}
+
+function deliveryFor(reminder: NoteReminder, report: ReconcileReport, now: Date): ReminderDelivery {
+  if (report.permission === 'unavailable') return 'unavailable'
+  if (reminder.state.at.getTime() <= now.getTime()) return 'in-the-past'
+  if (report.permission === 'denied') return 'permission-denied'
+  if (report.deferredIds.includes(reminder.id)) return 'device-limit'
+  return 'scheduled'
+}
+
+/**
+ * Remove the reminder on a note: tombstone every row this module owns for it,
+ * enqueue the deletes, cancel the notification.
+ *
+ * A delete, not a dismiss. Desktop models those separately and mobile ships the
+ * one the More sheet offers; `status: 'dismissed'` is a status write away when
+ * a surface needs it.
+ */
+export async function clearNoteReminder(
+  ctx: NoteOpsContext,
+  noteId: string,
+  opts: { scheduler?: ReminderScheduler; now?: Date } = {}
+): Promise<void> {
+  const now = opts.now ?? new Date()
+  const stamp = now.getTime()
+  const ids = (await readLiveReminders(ctx.db, now))
+    .filter((r) => r.noteId === noteId)
+    .map((r) => r.id)
+  if (ids.length === 0) return
+
+  await withVaultTransaction(ctx.db, async () => {
+    for (const id of ids) await tombstoneRow(ctx, id, stamp)
+  })
+
+  await reconcileReminders(ctx, opts.scheduler)
+}
+
+// ---------------------------------------------------------------------------
+// The reconciler
+// ---------------------------------------------------------------------------
+
+/**
+ * iOS holds at most 64 pending local notifications per app and SILENTLY drops
+ * the rest. Silently is the hazard, so the cut is made here, with headroom for
+ * anything else the app ever schedules. Reminders past the cut are deferred,
+ * not lost: every pass re-cuts the list, so far reminders move into the budget
+ * as near ones fire.
+ */
+export const DEVICE_BUDGET = 56
+
+/** iOS truncates a long banner anyway; the DB field is never touched. */
+const BODY_LIMIT = 200
+
+/** Loaded lazily so this module has no static `expo-notifications` dependency. */
+async function loadScheduler(): Promise<ReminderScheduler | null> {
+  try {
+    return (await import('./reminder-notifications')).notificationScheduler
+  } catch (err) {
+    log.warn('The notification module is unavailable', {
+      error: err instanceof Error ? err.message : String(err)
+    })
+    return null
+  }
+}
+
+/** Note titles for the reminders about to be scheduled, in one query per 100. */
+async function readTitles(db: VaultDb, ids: string[]): Promise<Map<string, string>> {
+  const titles = new Map<string, string>()
+  for (let i = 0; i < ids.length; i += 100) {
+    const chunk = ids.slice(i, i + 100)
+    const rows = await db.getAllAsync<{ id: string; payload: string | null }>(
+      `SELECT id, payload FROM sync_items
+       WHERE type IN ('note', 'journal') AND id IN (${chunk.map(() => '?').join(',')})`,
+      chunk
+    )
+    for (const row of rows) {
+      if (!row.payload) continue
+      try {
+        const title = (JSON.parse(row.payload) as { title?: unknown }).title
+        if (typeof title === 'string' && title.length > 0) titles.set(row.id, title)
+      } catch {
+        // A note whose payload will not parse still deserves a banner; it just
+        // gets the fallback title.
+      }
+    }
+  }
+  return titles
+}
+
+/**
+ * Make the OS scheduler agree with the database. THE only function in the app
+ * that schedules or cancels a notification.
+ *
+ * Idempotent and safe to call concurrently: schedules are keyed by
+ * `identifier === reminder.id`, so re-scheduling replaces a reminder's single
+ * OS entry rather than adding a second one.
+ *
+ * Never throws. It runs from `AppState` listeners and sync callbacks, where a
+ * rejection is an unhandled rejection nobody reads.
+ */
+export async function reconcileReminders(
+  ctx: ReminderContext,
+  scheduler?: ReminderScheduler,
+  now: Date = new Date()
+): Promise<ReconcileReport> {
+  const idle = { scheduled: 0, cancelled: 0, deferred: 0, deferredIds: [] as string[] }
+  try {
+    const os = scheduler ?? (await loadScheduler())
+    if (!os) return { ...idle, permission: 'unavailable' }
+
+    const permission = await os.permission()
+    if (permission !== 'granted') {
+      // Cancel nothing: a denied permission means the list is already empty, and
+      // if permission was revoked while banners were pending iOS has dropped
+      // them itself. The rows are untouched and keep syncing.
+      return { ...idle, permission }
+    }
+
+    const active = (await readLiveReminders(ctx.db, now)).filter(
+      (r) => r.state.kind === 'scheduled' || r.state.kind === 'snoozed'
+    )
+    const want = active.slice(0, DEVICE_BUDGET)
+    const deferredIds = active.slice(DEVICE_BUDGET).map((r) => r.id)
+    const wanted = new Map(want.map((r) => [r.id, r]))
+
+    const have = await os.list()
+    const standing = new Set<string>()
+    let cancelled = 0
+    for (const entry of have) {
+      const match = wanted.get(entry.reminderId)
+      // (b) is the case a naive "schedule if missing" reconciler gets wrong: the
+      // identifier still matches, so the entry LOOKS correct while holding a
+      // stale time. The comparison is on the instant, not on identity.
+      if (match && match.state.at.getTime() === entry.at.getTime()) {
+        standing.add(entry.reminderId)
+        continue
+      }
+      await os.cancel(entry.reminderId)
+      cancelled += 1
+    }
+
+    const missing = want.filter((r) => !standing.has(r.id))
+    const titles = await readTitles(
+      ctx.db,
+      missing.map((r) => r.noteId)
+    )
+    let scheduledCount = 0
+    for (const reminder of missing) {
+      const outcome = await os.schedule({
+        reminderId: reminder.id,
+        noteId: reminder.noteId,
+        vaultId: ctx.vaultId,
+        at: reminder.state.at,
+        title: reminder.title ?? titles.get(reminder.noteId) ?? 'Memry',
+        body: (reminder.note ?? 'Reminder').slice(0, BODY_LIMIT)
+      })
+      if (outcome === 'ok') scheduledCount += 1
+    }
+
+    return {
+      scheduled: scheduledCount,
+      cancelled,
+      deferred: deferredIds.length,
+      deferredIds,
+      permission
+    }
+  } catch (err) {
+    log.warn('Reconciling reminders failed', {
+      error: err instanceof Error ? err.message : String(err)
+    })
+    return { ...idle, permission: 'unavailable' }
+  }
+}
+
+/** Read the OS permission without prompting. `unavailable` off-device. */
+export async function reminderPermission(): Promise<ReminderPermission> {
+  const os = await loadScheduler()
+  return os ? os.permission() : 'unavailable'
+}
+
+/**
+ * Route a tapped banner back to its note. Returns an unsubscribe.
+ *
+ * Wrapped here so the shell has one module to import for everything reminders,
+ * and so the `expo-notifications` import stays dynamic — a Node test that pulls
+ * in this file never reaches it.
+ */
+export function onReminderTap(
+  handler: (ref: { reminderId: string; noteId: string }) => void
+): () => void {
+  let live = true
+  let off: (() => void) | null = null
+  void import('./reminder-notifications')
+    .then((mod) => {
+      if (!live) return
+      off = mod.onReminderTap(handler)
+    })
+    .catch((err: unknown) => {
+      log.warn('Reminder tap routing is unavailable', {
+        error: err instanceof Error ? err.message : String(err)
+      })
+    })
+  return () => {
+    live = false
+    off?.()
+  }
+}

--- a/apps/mobile/src/sync/background.ts
+++ b/apps/mobile/src/sync/background.ts
@@ -1,6 +1,8 @@
 import * as BackgroundTask from 'expo-background-task'
 import * as TaskManager from 'expo-task-manager'
 import { AppState } from 'react-native'
+import { openVaultDb } from '../db/index'
+import { reconcileReminders } from '../features/notes/reminders'
 import { createLogger } from '../lib/logger'
 import { createMobileHttpClient } from '../adapters/http-client'
 import { syncBaseUrl } from './server-config'
@@ -52,6 +54,24 @@ export async function registerBackgroundSync(minIntervalMinutes = 15): Promise<v
   }
 }
 
+/**
+ * Reconcile without a caller-supplied context.
+ *
+ * The DB handle is memoized per vault by `openVaultDb`, so this is a map lookup
+ * on every pass but the first. Failures are swallowed by `reconcileReminders`
+ * itself; the `catch` is for the open.
+ */
+async function reconcileVaultReminders(vaultId: string): Promise<void> {
+  try {
+    const db = await openVaultDb(vaultId)
+    await reconcileReminders({ db, vaultId })
+  } catch (err) {
+    log.warn('Reminder reconcile on foreground failed', {
+      error: err instanceof Error ? err.message : String(err)
+    })
+  }
+}
+
 let foregroundWired = false
 
 /**
@@ -77,6 +97,11 @@ export function wireForegroundSync(): void {
     if (next === 'active' && previous !== 'active') {
       startSyncSocket(vaultId)
       void requestVaultSync(vaultId, 'app-foreground')
+      // The reminder reconciler's third edge, on the listener that already owns
+      // this transition rather than on a second one of its own. iOS can drop
+      // pending notifications while the app is away — a revoked permission, the
+      // per-app cap — and this is where the database gets to put them back.
+      void reconcileVaultReminders(vaultId)
     } else if (next !== 'active' && previous === 'active') {
       stopSyncSocket()
       void requestVaultSync(vaultId, 'app-background')

--- a/packages/contracts/src/reminder-types.ts
+++ b/packages/contracts/src/reminder-types.ts
@@ -35,3 +35,20 @@ export type ReminderStatus = (typeof reminderStatus)[keyof typeof reminderStatus
 export function noteDateReminderId(noteId: string, anchorId: string): string {
   return `rem_nd_${noteId}_${anchorId}`
 }
+
+/**
+ * Deterministic id for the ONE user-set reminder on a note or journal.
+ *
+ * Desktop mints a random `rem_<nanoid>` and resolves "one reminder per note" by
+ * deleting the rows it can currently see. Two devices offline cannot see each
+ * other's, so random ids give a note TWO reminders after the merge. Deriving
+ * the id from the target makes those the same row and lets the vector clock
+ * decide the time — the same reasoning `bookmarkSyncId` and
+ * `noteDateReminderId` already encode.
+ *
+ * Distinct prefix from `rem_nd_`: `note_date` rows are owned by desktop's
+ * note-content reconciler and must never collide with a user-set reminder.
+ */
+export function noteReminderSyncId(noteId: string): string {
+  return `rem_note_${noteId}`
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1057,6 +1057,9 @@ importers:
       expo-local-authentication:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.15)
+      expo-notifications:
+        specifier: ~57.0.17
+        version: 57.0.17(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       expo-print:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))
@@ -2890,6 +2893,10 @@ packages:
     resolution: {integrity: sha512-28pqaEqwnmLduZ00Pq9HkSzE5wbj1MTwp5/n8nm8rD8MCjR9eUnVOwmNksPI3Be2ReAPO/DbPn1puy0mvoocsQ==}
     engines: {node: '>=20.12.0'}
 
+  '@expo/env@2.4.3':
+    resolution: {integrity: sha512-M1NXeZCA1mkMkYOyIe7PlyRX0/jqFtMoJgyblnlq/vpCRfmueFT7RnGSQG8uEFDF5WHOFGijAQ3fogPh3/n5Ng==}
+    engines: {node: '>=20.12.0'}
+
   '@expo/expo-modules-macros-plugin@0.6.1':
     resolution: {integrity: sha512-cpsLZE4rqkc1Y3eZTkxB98jrqY1YXgetmtxFt8q89jBRmk3quRuk1BZo+VcnCSObZardjg99r1k5xijEMONFGA==}
 
@@ -2899,6 +2906,9 @@ packages:
 
   '@expo/image-utils@0.11.4':
     resolution: {integrity: sha512-pn/4770DIEOcYZr484uazuwg20FX/qaDkeMRF6J+oxejynDmEmO8wLsCudaNShFE0BhyKGQTYrs2rsRhqrqESw==}
+
+  '@expo/image-utils@0.11.5':
+    resolution: {integrity: sha512-KPQBTpmpAfy/Vu9y4wPW808/qtZxjYmyJg8cm2QCPAupp+qEWA3b5zmk0ulOwQ9OgeHxuCPgUqWgkwHFo7UsrQ==}
 
   '@expo/inline-modules@0.1.6':
     resolution: {integrity: sha512-5f6EiOIKsFj9zlrCBet4ZIQRPEa9dBUdQgTzpjYwdZ8Z/M8W5lqMVL9dEs4HYKvEmDnqv0dQuDkFLyRSwu/DAQ==}
@@ -7539,6 +7549,9 @@ packages:
       expo-widgets:
         optional: true
 
+  badgin@1.2.3:
+    resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -9268,6 +9281,11 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  expo-application@57.0.2:
+    resolution: {integrity: sha512-q31YwcXyymviAmdrtDfAg3Dld4VMxLCNAfgMHip7vZpPX4lzF/AfwsywqBJUAjQnJknzaNAkzqvMVjO5XmKYDA==}
+    peerDependencies:
+      expo: '*'
+
   expo-asset@57.0.13:
     resolution: {integrity: sha512-RPjMcmPXRMb6UbQdTIkmSDEnQL5LKGTu7ZXatq3U67V6ldlSdQeQ9pQV7zlmk0DrbnaMEh3HYiEh2YxWLNyCzA==}
     peerDependencies:
@@ -9287,6 +9305,12 @@ packages:
 
   expo-constants@57.0.13:
     resolution: {integrity: sha512-eB5AHp7kKxsVIBjTetUgj5WQSw8joI2ekzgTlcUv+Hc0x2t0jZU6IiL4DpyOT2yZQ71n0WJZCkmOKLgxlajIzg==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+
+  expo-constants@57.0.17:
+    resolution: {integrity: sha512-cPWYBKN1SEbg2lXg2f8VkePJqGZrJPLvVdQDCTfbFu9sQHO1M31Y1zILReUuGnmt/VKeUz40ze579vR00xGu/A==}
     peerDependencies:
       expo: '*'
       react-native: '*'
@@ -9406,6 +9430,13 @@ packages:
   expo-modules-jsi@57.0.5:
     resolution: {integrity: sha512-NQF7MUF0j3rQHV8KJqETYA1SrJr3USvQ/AWEhODo+unMRFBDP9BKpn8+aNGGmx6fa2XLnqC2qulVw4DT6Gp13Q==}
     peerDependencies:
+      react-native: '*'
+
+  expo-notifications@57.0.17:
+    resolution: {integrity: sha512-P/9ZqBOlFBVCZK3T5bhqORtWJhtVBcXQXe/MY1YWuKaxWgKvoGeEvD9ItWuo87jg2nD+eloVmFYqwdhhVCxPlA==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
       react-native: '*'
 
   expo-print@57.0.1:
@@ -17117,6 +17148,85 @@ snapshots:
 
   '@expo-google-fonts/space-grotesk@0.4.1': {}
 
+  '@expo/cli@57.0.17(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-constants@57.0.13(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8)))(expo-font@57.0.1)(expo-router@57.0.15)(expo@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)':
+    dependencies:
+      '@expo/code-signing-certificates': 0.0.6
+      '@expo/config': 57.0.8(typescript@5.9.3)
+      '@expo/config-plugins': 57.0.8(typescript@5.9.3)
+      '@expo/devcert': 1.2.1
+      '@expo/env': 2.4.2
+      '@expo/image-utils': 0.11.4(typescript@5.9.3)
+      '@expo/inline-modules': 0.1.6(typescript@5.9.3)
+      '@expo/json-file': 11.0.1
+      '@expo/log-box': 57.0.3(@expo/dom-webview@57.0.1)(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)
+      '@expo/metro': 56.0.0
+      '@expo/metro-config': 57.0.9(expo@57.0.15)(typescript@5.9.3)
+      '@expo/metro-file-map': 57.0.1
+      '@expo/osascript': 2.7.1
+      '@expo/package-manager': 1.13.1
+      '@expo/plist': 0.8.1
+      '@expo/prebuild-config': 57.0.13(typescript@5.9.3)
+      '@expo/require-utils': 57.0.4(typescript@5.9.3)
+      '@expo/router-server': 57.0.7(@expo/metro-runtime@57.0.12)(expo-constants@57.0.13(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8)))(expo-font@57.0.1)(expo-router@57.0.15)(expo-server@57.0.3)(expo@57.0.15)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@expo/schema-utils': 57.0.2
+      '@expo/spawn-async': 1.8.0
+      '@expo/ws-tunnel': 2.0.0(ws@8.21.3)
+      '@expo/xcpretty': 4.4.4
+      '@react-native/dev-middleware': 0.86.2
+      accepts: 1.3.8
+      agent-cli-detector: 0.1.6
+      arg: 5.0.2
+      bplist-creator: 0.1.0
+      bplist-parser: 0.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      compression: 1.8.1
+      connect: 3.7.0
+      debug: 4.4.3
+      dnssd-advertise: 1.1.6
+      expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-webview@14.0.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo-server: 57.0.3
+      fetch-nodeshim: 0.4.10
+      getenv: 2.0.0
+      glob: 13.0.6
+      lan-network: 0.2.1
+      multitars: 1.0.2
+      node-forge: 1.4.0
+      npm-package-arg: 11.0.3
+      ora: 3.4.0
+      picomatch: 4.0.4
+      pretty-format: 29.7.0
+      progress: 2.0.3
+      prompts: 2.4.2
+      resolve-from: 5.0.0
+      sandbox-cli-detector: 0.2.0
+      semver: 7.8.4
+      send: 0.19.2
+      slugify: 1.6.9
+      stacktrace-parser: 0.1.11
+      structured-headers: 0.4.1
+      terminal-link: 2.1.1
+      toqr: 0.1.1
+      wrap-ansi: 7.0.0
+      ws: 8.21.3
+      zod: 3.25.76
+    optionalDependencies:
+      expo-router: 57.0.15(15e845b980d0e5c1bc6e68c6c412716b)
+      react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8)
+    transitivePeerDependencies:
+      - '@expo/dom-webview'
+      - '@expo/metro-runtime'
+      - bufferutil
+      - expo-constants
+      - expo-font
+      - react
+      - react-dom
+      - react-server-dom-webpack
+      - supports-color
+      - typescript
+      - utf-8-validate
+    optional: true
+
   '@expo/cli@57.0.17(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-constants@57.0.13)(expo-font@57.0.1)(expo-router@57.0.15)(expo@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
@@ -17194,85 +17304,6 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
-
-  '@expo/cli@57.0.17(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-constants@57.0.13)(expo-font@57.0.1)(expo-router@57.0.15)(expo@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)':
-    dependencies:
-      '@expo/code-signing-certificates': 0.0.6
-      '@expo/config': 57.0.8(typescript@5.9.3)
-      '@expo/config-plugins': 57.0.8(typescript@5.9.3)
-      '@expo/devcert': 1.2.1
-      '@expo/env': 2.4.2
-      '@expo/image-utils': 0.11.4(typescript@5.9.3)
-      '@expo/inline-modules': 0.1.6(typescript@5.9.3)
-      '@expo/json-file': 11.0.1
-      '@expo/log-box': 57.0.3(@expo/dom-webview@57.0.1)(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)
-      '@expo/metro': 56.0.0
-      '@expo/metro-config': 57.0.9(expo@57.0.15)(typescript@5.9.3)
-      '@expo/metro-file-map': 57.0.1
-      '@expo/osascript': 2.7.1
-      '@expo/package-manager': 1.13.1
-      '@expo/plist': 0.8.1
-      '@expo/prebuild-config': 57.0.13(typescript@5.9.3)
-      '@expo/require-utils': 57.0.4(typescript@5.9.3)
-      '@expo/router-server': 57.0.7(@expo/metro-runtime@57.0.12)(expo-constants@57.0.13)(expo-font@57.0.1)(expo-router@57.0.15)(expo-server@57.0.3)(expo@57.0.15)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@expo/schema-utils': 57.0.2
-      '@expo/spawn-async': 1.8.0
-      '@expo/ws-tunnel': 2.0.0(ws@8.21.3)
-      '@expo/xcpretty': 4.4.4
-      '@react-native/dev-middleware': 0.86.2
-      accepts: 1.3.8
-      agent-cli-detector: 0.1.6
-      arg: 5.0.2
-      bplist-creator: 0.1.0
-      bplist-parser: 0.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      compression: 1.8.1
-      connect: 3.7.0
-      debug: 4.4.3
-      dnssd-advertise: 1.1.6
-      expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-webview@14.0.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
-      expo-server: 57.0.3
-      fetch-nodeshim: 0.4.10
-      getenv: 2.0.0
-      glob: 13.0.6
-      lan-network: 0.2.1
-      multitars: 1.0.2
-      node-forge: 1.4.0
-      npm-package-arg: 11.0.3
-      ora: 3.4.0
-      picomatch: 4.0.4
-      pretty-format: 29.7.0
-      progress: 2.0.3
-      prompts: 2.4.2
-      resolve-from: 5.0.0
-      sandbox-cli-detector: 0.2.0
-      semver: 7.8.4
-      send: 0.19.2
-      slugify: 1.6.9
-      stacktrace-parser: 0.1.11
-      structured-headers: 0.4.1
-      terminal-link: 2.1.1
-      toqr: 0.1.1
-      wrap-ansi: 7.0.0
-      ws: 8.21.3
-      zod: 3.25.76
-    optionalDependencies:
-      expo-router: 57.0.15(6e15545ddca8408f93677db6b57cd9aa)
-      react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8)
-    transitivePeerDependencies:
-      - '@expo/dom-webview'
-      - '@expo/metro-runtime'
-      - bufferutil
-      - expo-constants
-      - expo-font
-      - react
-      - react-dom
-      - react-server-dom-webpack
-      - supports-color
-      - typescript
-      - utf-8-validate
-    optional: true
 
   '@expo/code-signing-certificates@0.0.6':
     dependencies:
@@ -17414,6 +17445,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/env@2.4.3':
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/expo-modules-macros-plugin@0.6.1': {}
 
   '@expo/fingerprint@0.20.9':
@@ -17449,6 +17488,19 @@ snapshots:
   '@expo/image-utils@0.11.4(typescript@6.0.3)':
     dependencies:
       '@expo/require-utils': 57.0.4(typescript@6.0.3)
+      '@expo/spawn-async': 1.8.0
+      chalk: 4.1.2
+      getenv: 2.0.0
+      jimp-compact: 0.16.1
+      parse-png: 2.1.0
+      semver: 7.8.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@expo/image-utils@0.11.5(typescript@6.0.3)':
+    dependencies:
+      '@expo/require-utils': 57.0.5(typescript@6.0.3)
       '@expo/spawn-async': 1.8.0
       chalk: 4.1.2
       getenv: 2.0.0
@@ -17724,6 +17776,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/router-server@57.0.7(@expo/metro-runtime@57.0.12)(expo-constants@57.0.13(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8)))(expo-font@57.0.1)(expo-router@57.0.15)(expo-server@57.0.3)(expo@57.0.15)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      debug: 4.4.3
+      expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-webview@14.0.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo-constants: 57.0.13(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))
+      expo-font: 57.0.1(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)
+      expo-server: 57.0.3
+      react: 19.2.8
+    optionalDependencies:
+      '@expo/metro-runtime': 57.0.12(@expo/log-box@57.0.3)(expo@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)
+      expo-router: 57.0.15(15e845b980d0e5c1bc6e68c6c412716b)
+      react-dom: 19.2.8(react@19.2.8)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@expo/router-server@57.0.7(@expo/metro-runtime@57.0.12)(expo-constants@57.0.13)(expo-font@57.0.1)(expo-router@57.0.15)(expo-server@57.0.3)(expo@57.0.15)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       debug: 4.4.3
@@ -17738,22 +17806,6 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
-
-  '@expo/router-server@57.0.7(@expo/metro-runtime@57.0.12)(expo-constants@57.0.13)(expo-font@57.0.1)(expo-router@57.0.15)(expo-server@57.0.3)(expo@57.0.15)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      debug: 4.4.3
-      expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-webview@14.0.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
-      expo-constants: 57.0.13(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))
-      expo-font: 57.0.1(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)
-      expo-server: 57.0.3
-      react: 19.2.8
-    optionalDependencies:
-      '@expo/metro-runtime': 57.0.12(@expo/log-box@57.0.3)(expo@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)
-      expo-router: 57.0.15(6e15545ddca8408f93677db6b57cd9aa)
-      react-dom: 19.2.8(react@19.2.8)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@expo/schema-utils@57.0.2': {}
 
@@ -21950,7 +22002,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@2.2.0))(msw@2.12.9(@types/node@25.9.5)(typescript@6.0.3))(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@2.3.0))(msw@2.12.9(@types/node@25.9.5)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@3.2.7':
     dependencies:
@@ -22043,7 +22095,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@2.2.0))(msw@2.12.9(@types/node@25.9.5)(typescript@6.0.3))(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@2.3.0))(msw@2.12.9(@types/node@25.9.5)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/utils@3.2.7':
     dependencies:
@@ -22663,10 +22715,12 @@ snapshots:
       react-refresh: 0.14.2
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-webview@14.0.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+
+  badgin@1.2.3: {}
 
   bail@2.0.2: {}
 
@@ -24606,6 +24660,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  expo-application@57.0.2(expo@57.0.15):
+    dependencies:
+      expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+
   expo-asset@57.0.13(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
     dependencies:
       '@expo/image-utils': 0.11.4(typescript@6.0.3)
@@ -24654,6 +24712,23 @@ snapshots:
   expo-constants@57.0.13(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8)):
     dependencies:
       '@expo/env': 2.4.2
+      expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-webview@14.0.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  expo-constants@57.0.17(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3)):
+    dependencies:
+      '@expo/env': 2.4.3
+      expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-constants@57.0.17(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8)):
+    dependencies:
+      '@expo/env': 2.4.3
       expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-webview@14.0.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8)
     transitivePeerDependencies:
@@ -24850,12 +24925,26 @@ snapshots:
       react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8)
     optional: true
 
+  expo-notifications@57.0.17(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
+    dependencies:
+      '@expo/image-utils': 0.11.5(typescript@6.0.3)
+      abort-controller: 3.0.0
+      badgin: 1.2.3
+      expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo-application: 57.0.2(expo@57.0.15)
+      expo-constants: 57.0.17(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   expo-print@57.0.1(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3)):
     dependencies:
       expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.3)
 
-  expo-router@57.0.15(6e15545ddca8408f93677db6b57cd9aa):
+  expo-router@57.0.15(15e845b980d0e5c1bc6e68c6c412716b):
     dependencies:
       '@expo/log-box': 57.0.3(@expo/dom-webview@57.0.1)(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)
       '@expo/metro-runtime': 57.0.12(@expo/log-box@57.0.3)(expo@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)
@@ -24869,7 +24958,7 @@ snapshots:
       debug: 4.4.3
       escape-string-regexp: 4.0.0
       expo: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-webview@14.0.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
-      expo-constants: 57.0.13(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))
+      expo-constants: 57.0.17(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))
       expo-glass-effect: 57.0.1(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)
       expo-linking: 57.0.7(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)
       expo-server: 57.0.3
@@ -25092,7 +25181,7 @@ snapshots:
   expo@57.0.15(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-webview@14.0.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.7
-      '@expo/cli': 57.0.17(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-constants@57.0.13)(expo-font@57.0.1)(expo-router@57.0.15)(expo@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      '@expo/cli': 57.0.17(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-constants@57.0.13(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8)))(expo-font@57.0.1)(expo-router@57.0.15)(expo@57.0.15)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       '@expo/config': 57.0.8(typescript@5.9.3)
       '@expo/config-plugins': 57.0.8(typescript@5.9.3)
       '@expo/devtools': 57.0.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.13)(react@19.2.8))(react@19.2.8)


### PR DESCRIPTION
## Summary

Mobile had no reminder UI; desktop already syncs a `reminder` row per note (`apps/desktop/src/renderer/src/components/reminder/`). Adds set / edit / remove reminder to the note More sheet, storing the same sync payload shape desktop writes, and delivers via a real iOS local notification scheduled at pick time (mobile has no background process to poll the way desktop's minute-tick does).

The stored payload carries synced truth only. Mobile's pull applies incoming `sync_items` rows wholesale with no per-type field merge, so a device-local status like desktop's `triggered` would be silently destroyed by the next sync touching that row. The iOS pending-notification list, keyed by reminder id, is the sole device-local record of what this device will show; `reconcileReminders` is the one function that schedules or cancels a notification, and it runs on relaunch, on every sync, and on foreground (hooked into the existing `AppState` listener in `sync/background.ts`).

Permission denial never blocks saving: the reminder is stored and synced regardless, and the picker surfaces the actual delivery outcome (scheduled, denied with an Open Settings link, in the past, or over the device's pending-notification budget) instead of failing silently, per the issue's ask to state that behaviour.

Journal reminders are supported by the data layer (`targetType: 'journal'`) but have no UI entry point yet — the journal screen has no More sheet. Ships note-only.

Docs: `packages/contracts/src/reminder-types.ts` trips the docs-relevant pattern for one new helper, `noteReminderSyncId`. It only derives a deterministic id for the new mobile module; desktop's behavior (random ids, one-per-note resolved in the renderer) is unchanged, and mobile has no released user-guide surface yet. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`.

Closes #2111

## Release note

none

## Test plan

- `pnpm --filter @memry/mobile typecheck` — clean
- `pnpm --filter @memry/mobile test` — 463/463 passing, including 28 new tests covering replace/tombstone semantics, the reconciler's relaunch/cross-device/crash table, and that no write ever contains `triggeredAt` or `status: 'triggered'`
- `pnpm --filter @memry/mobile lint` — clean (only pre-existing warnings in untouched files)
- `pnpm check:architecture`, `pnpm check:contracts` — passing
- Not yet verified: on-device notification delivery. Needs `pnpm --filter @memry/mobile ios:staging` (native rebuild, new native module) and a manual pass — set a reminder, background the app, confirm the banner fires and tapping it opens the note, then delete on desktop and confirm the banner doesn't fire on the phone.