### PR TITLE
feat(mobile): quiet save and sync status on the note screen

### DIFF
--- a/apps/mobile/src/app/(vault)/(tabs)/notes/[id].tsx
+++ b/apps/mobile/src/app/(vault)/(tabs)/notes/[id].tsx
@@ -22,6 +22,7 @@ import type {
   EditorAttachmentBlockType,
   InlineMenuTrigger
 } from '@memry/contracts/webview-bridge'
+import { createMobileHttpClient } from '@/adapters/http-client'
 import { AppText } from '@/components/ui/app-text'
 import { NavBarInline } from '@/components/ui/nav-bar'
 import { PromptDialog } from '@/components/ui/prompt-dialog'
@@ -41,6 +42,7 @@ import { AddPropertySheet } from '@/features/notes/add-property-sheet'
 import { AddTagSheet } from '@/features/notes/add-tag-sheet'
 import { readBookmarkKeys, toggleBookmark } from '@/features/notes/bookmarks'
 import { NoteFooter } from '@/features/notes/chrome/note-footer'
+import { NoteSaveStatusLabel } from '@/features/notes/chrome/save-status'
 import { readBacklinks } from '@/features/notes/backlinks'
 import { NoteMoreSheet } from '@/features/notes/chrome/note-more-sheet'
 import { ReminderSheet } from '@/features/notes/chrome/reminder-sheet'
@@ -76,6 +78,7 @@ import { calculateWordCount, type NoteStats } from '@/features/notes/note-stats'
 import { readNotesSnapshot, type NotesSnapshot } from '@/features/notes/notes-repo'
 import { NoteProperties } from '@/features/notes/properties'
 import { propertyTypes } from '@/features/notes/property-types'
+import { noteSaveStatus } from '@/features/notes/save-status'
 import { NoteTags } from '@/features/notes/tags'
 import { useWorkspaceTabs } from '@/features/workspace-tabs/provider'
 import { WorkspaceTabsModal } from '@/features/workspace-tabs/workspace-tabs-modal'
@@ -86,6 +89,7 @@ import { loadCurrentVaultId } from '@/sync/auth-client'
 import { ensureNoteBody } from '@/sync/body-fetch'
 import { getSyncEngine } from '@/sync/engine'
 import { getReadOnlyState, subscribeReadOnly } from '@/sync/read-only-mode'
+import { syncBaseUrl } from '@/sync/server-config'
 import { sizes, space } from '@/theme/primitives'
 import { textStyles } from '@/theme/text-styles'
 import { useColors } from '@/theme/use-colors'
@@ -103,6 +107,16 @@ const BODY_GAP = 14
  * that a pause leaves nothing sitting in the WebView.
  */
 const SAVE_SETTLE_MS = 800
+
+/**
+ * How often the status indicator re-reads this note's queue depth.
+ *
+ * Polled rather than pushed because nothing in the outbox emits: rows are
+ * deleted by the drain, in another module, on a pass this screen did not
+ * start. The timer only runs while something is actually outstanding, so the
+ * resting cost of the indicator is zero.
+ */
+const STATUS_POLL_MS = 1_000
 
 function showFailure(action: string, error: unknown): void {
   const message = extractErrorMessage(error, 'That could not be completed.')
@@ -192,6 +206,17 @@ export default function NoteScreen() {
   const [addingTag, setAddingTag] = useState(false)
   const [addingProperty, setAddingProperty] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
+  /**
+   * The three observable halves of the save/sync indicator (#2115).
+   *
+   * `dirty` is the guest→host window, `queued` is this note's rows in the
+   * outbox and `online` is the HTTP adapter's own flag — the same rule the
+   * sync banner follows, so the dev network switch flips both together.
+   */
+  const [dirty, setDirty] = useState(false)
+  const [queued, setQueued] = useState(0)
+  const [pushing, setPushing] = useState(false)
+  const [online, setOnline] = useState(true)
   const [headerHeight, setHeaderHeight] = useState(0)
   /**
    * Where the WebView's document is scrolled to, driven from the guest.
@@ -380,18 +405,84 @@ export default function NoteScreen() {
   useEffect(() => {
     if (!doc || gate !== 'editing') return
     let timer: ReturnType<typeof setTimeout> | undefined
+    let cancelled = false
     const unsubscribe = doc.onLocalUpdate(() => {
       localUpdates.current += 1
       if (timer) clearTimeout(timer)
-      // Saving is silent: the bar carries no status pill, so this only debounces
-      // the flush that hands the guest's pending edits over.
-      timer = setTimeout(() => void controls.current?.flush(), SAVE_SETTLE_MS)
+      // The status indicator's `saving` window opens here and closes when the
+      // flush RESOLVES, which is when everything the guest had is durable.
+      setDirty(true)
+      timer = setTimeout(() => {
+        const run = controls.current?.flush()
+        if (run) {
+          void run.finally(() => {
+            if (!cancelled) setDirty(false)
+          })
+        } else if (!cancelled) {
+          // No controls means no guest to wait for; nothing is in flight.
+          setDirty(false)
+        }
+      }, SAVE_SETTLE_MS)
     })
     return () => {
+      cancelled = true
       if (timer) clearTimeout(timer)
       unsubscribe()
     }
   }, [doc, gate])
+
+  /** The adapter's online rule, dev network switch included. */
+  useEffect(() => createMobileHttpClient(syncBaseUrl()).onOnlineChanged(setOnline), [])
+
+  /** Reads the queue and reports whether anything is still in it. */
+  const readQueueDepth = useCallback(async (): Promise<boolean> => {
+    if (!session || !id) return false
+    try {
+      const depth = await session.outbox.pendingCountForItem(id)
+      setQueued(depth)
+      setPushing(session.drain.isDraining)
+      return depth > 0
+    } catch (err) {
+      // A failed count must never surface as a wrong status, so the previous
+      // reading stands rather than being reset to "synced".
+      log.warn('Reading the note queue depth failed', {
+        error: extractErrorMessage(err, 'unknown error')
+      })
+      return false
+    }
+  }, [id, session])
+
+  /**
+   * A self-stopping poll rather than an interval.
+   *
+   * It always takes one reading — a queue left full by an earlier session is
+   * exactly the case no local edit will announce — and keeps going only while
+   * something is outstanding, so an idle note costs nothing. `dirty` is a
+   * dependency so that the first keystroke restarts the loop.
+   */
+  useEffect(() => {
+    if (!session || !id) return
+    let stopped = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const tick = async (): Promise<void> => {
+      const stillQueued = await readQueueDepth()
+      if (stopped || !(stillQueued || dirty)) return
+      timer = setTimeout(() => void tick(), STATUS_POLL_MS)
+    }
+    timer = setTimeout(() => void tick(), 0)
+    return () => {
+      stopped = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [dirty, id, readQueueDepth, session])
+
+  const saveStatus = noteSaveStatus({
+    dirty,
+    queued,
+    online,
+    pushing,
+    parked: vaultReadOnly
+  })
 
   const ctx: NoteOpsContext | null = useMemo(
     () =>
@@ -902,6 +993,7 @@ export default function NoteScreen() {
         <NavBarInline
           title=""
           back={{ label: backLabel, onPress: () => router.back() }}
+          center={<NoteSaveStatusLabel status={saveStatus} />}
           actions={[{ icon: 'more', label: 'More', onPress: () => void openMore() }]}
         />
       </View>

--- a/apps/mobile/src/features/notes/__tests__/save-status.test.ts
+++ b/apps/mobile/src/features/notes/__tests__/save-status.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import {
+  describeNoteSaveStatus,
+  noteSaveStatus,
+  type NoteSaveInputs,
+  type NoteSaveStatus
+} from '../save-status'
+
+/** The resting state: nothing typed, nothing queued, connected. */
+const settled: NoteSaveInputs = {
+  dirty: false,
+  queued: 0,
+  online: true,
+  pushing: false,
+  parked: false
+}
+
+describe('noteSaveStatus', () => {
+  it('is synced and invisible when the queue for this note is empty', () => {
+    expect(noteSaveStatus(settled)).toBe('synced')
+    expect(describeNoteSaveStatus('synced')).toBeNull()
+  })
+
+  it('reports saving while the guest may still be holding edits', () => {
+    expect(noteSaveStatus({ ...settled, dirty: true })).toBe('saving')
+    // Even offline: the handoff being reported is local, and it works with no
+    // network at all.
+    expect(noteSaveStatus({ ...settled, dirty: true, online: false, queued: 2 })).toBe('saving')
+  })
+
+  it('reports pending once the edit is durable but still queued', () => {
+    expect(noteSaveStatus({ ...settled, queued: 1 })).toBe('pending')
+  })
+
+  it('reports syncing only while a push pass is actually running', () => {
+    expect(noteSaveStatus({ ...settled, queued: 1, pushing: true })).toBe('syncing')
+    expect(noteSaveStatus({ ...settled, queued: 1, pushing: false })).toBe('pending')
+  })
+
+  it('never says syncing offline, even with a pass still in flight', () => {
+    expect(noteSaveStatus({ ...settled, queued: 1, online: false, pushing: true })).toBe('offline')
+  })
+
+  it('never says syncing while writes are parked', () => {
+    // A parked pass reads the read-only policy and returns without sending a
+    // row, so "Syncing…" would be a straight lie.
+    expect(noteSaveStatus({ ...settled, queued: 1, parked: true, pushing: true })).toBe('pending')
+  })
+
+  it('walks one edit from typing to synced', () => {
+    // Typing.
+    let input: NoteSaveInputs = { ...settled, dirty: true }
+    expect(noteSaveStatus(input)).toBe('saving')
+    // The debounced flush resolved: durable here, queued for the server.
+    input = { ...input, dirty: false, queued: 1 }
+    expect(noteSaveStatus(input)).toBe('pending')
+    // A drain picked it up.
+    input = { ...input, pushing: true }
+    expect(noteSaveStatus(input)).toBe('syncing')
+    // The server accepted it, so the row was deleted.
+    input = { ...input, pushing: false, queued: 0 }
+    expect(noteSaveStatus(input)).toBe('synced')
+  })
+
+  it('walks the offline round trip back to synced', () => {
+    let input: NoteSaveInputs = { ...settled, dirty: true, online: false }
+    expect(noteSaveStatus(input)).toBe('saving')
+    input = { ...input, dirty: false, queued: 1 }
+    expect(noteSaveStatus(input)).toBe('offline')
+    // Reconnected; the drain the online edge fires has not started yet.
+    input = { ...input, online: true }
+    expect(noteSaveStatus(input)).toBe('pending')
+    input = { ...input, pushing: true }
+    expect(noteSaveStatus(input)).toBe('syncing')
+    input = { ...input, pushing: false, queued: 0 }
+    expect(noteSaveStatus(input)).toBe('synced')
+  })
+
+  it('says nothing about the server for a state that has not reached it', () => {
+    // The invariant the indicator exists to keep: only an empty queue may read
+    // as synced, and only an empty queue may render nothing.
+    const flags = [false, true]
+    for (const dirty of flags) {
+      for (const online of flags) {
+        for (const pushing of flags) {
+          for (const parked of flags) {
+            for (const queued of [0, 1, 7]) {
+              const status = noteSaveStatus({ dirty, queued, online, pushing, parked })
+              if (status === 'synced') {
+                expect(queued).toBe(0)
+                expect(dirty).toBe(false)
+              }
+              if (describeNoteSaveStatus(status) === null) expect(status).toBe('synced')
+            }
+          }
+        }
+      }
+    }
+  })
+})
+
+describe('describeNoteSaveStatus', () => {
+  it('gives every visible state a distinct word and a fuller spoken sentence', () => {
+    const visible: NoteSaveStatus[] = ['saving', 'syncing', 'pending', 'offline']
+    const seen = new Set<string>()
+    for (const status of visible) {
+      const described = describeNoteSaveStatus(status)
+      expect(described).not.toBeNull()
+      expect(described!.text.length).toBeGreaterThan(0)
+      // The visible word alone under-explains; VoiceOver gets the sentence.
+      expect(described!.accessibilityLabel.length).toBeGreaterThan(described!.text.length)
+      seen.add(described!.text)
+    }
+    expect(seen.size).toBe(visible.length)
+  })
+})

--- a/apps/mobile/src/features/notes/chrome/save-status.tsx
+++ b/apps/mobile/src/features/notes/chrome/save-status.tsx
@@ -1,0 +1,38 @@
+import { AppText } from '@/components/ui/app-text'
+import { describeNoteSaveStatus, type NoteSaveStatus } from '@/features/notes/save-status'
+import { useColors } from '@/theme/use-colors'
+
+/**
+ * The note bar's status readout (#2115).
+ *
+ * It sits in `NavBarInline`'s `center` slot, which is `pointerEvents="none"` —
+ * a readout, never a control — and the slot is free because the note screen's
+ * heading is the display title below the bar, not the bar's own.
+ *
+ * Text, no glyph and no motion. A spinner would be the only animation on this
+ * screen and would need a reduced-motion branch to earn its place; the word
+ * carries the same meaning at rest, which is what DESIGN.md asks for.
+ *
+ * `accessible` merges the group into one element: a bare `View` wrapping
+ * `Text` is not an accessibility element on iOS, so a label on it would never
+ * reach VoiceOver (the sync banner makes the same call).
+ */
+export function NoteSaveStatusLabel({ status }: { status: NoteSaveStatus }) {
+  const c = useColors()
+  const described = describeNoteSaveStatus(status)
+  if (!described) return null
+
+  return (
+    <AppText
+      accessible
+      testID="note-save-status"
+      accessibilityRole="text"
+      accessibilityLabel={described.accessibilityLabel}
+      variant="footnote"
+      color={c.text.secondary}
+      numberOfLines={1}
+    >
+      {described.text}
+    </AppText>
+  )
+}

--- a/apps/mobile/src/features/notes/save-status.ts
+++ b/apps/mobile/src/features/notes/save-status.ts
@@ -1,0 +1,79 @@
+/**
+ * What the note screen may honestly say about a note's edits (#2115).
+ *
+ * Every state here is derived from something the app can actually observe:
+ * the guest→host handoff (`dirty`), this note's rows in the durable outbox
+ * (`queued`), the HTTP adapter's online flag, whether a push pass is in flight
+ * and whether writes are parked. Nothing infers a server round trip that did
+ * not happen — "synced" means the queue for THIS note is empty, which is only
+ * ever true because the server accepted and the rows were deleted.
+ *
+ * `synced` is the resting state and renders nothing. A permanently visible
+ * badge is the thing this indicator is explicitly not (restraint; DESIGN.md).
+ */
+export type NoteSaveStatus = 'synced' | 'saving' | 'syncing' | 'pending' | 'offline'
+
+export interface NoteSaveInputs {
+  /**
+   * Edits the guest may still be holding.
+   *
+   * Set when a local update arrives and cleared when the debounced
+   * `controls.flush()` resolves — i.e. the window in which the WebView's own
+   * outbound batch has not necessarily reached the host yet. What the host HAS
+   * received is already durable before this flag is even read.
+   */
+  dirty: boolean
+  /** This note's rows in the outbox. Non-zero means the server has not taken them. */
+  queued: number
+  online: boolean
+  /** A drain pass is running right now. */
+  pushing: boolean
+  /** Writes are parked — read-only vault or version gate. The queue waits. */
+  parked: boolean
+}
+
+export function noteSaveStatus(input: NoteSaveInputs): NoteSaveStatus {
+  if (input.dirty) return 'saving'
+  if (input.queued === 0) return 'synced'
+  // Offline outranks a running pass: a drain that started before the radio
+  // dropped is not going to land, and "Syncing…" over a dead connection is the
+  // one thing an honest indicator must never say.
+  if (!input.online) return 'offline'
+  // Parked outranks it for the same reason — the pass reads the policy and
+  // returns without sending a row.
+  if (input.parked) return 'pending'
+  if (input.pushing) return 'syncing'
+  return 'pending'
+}
+
+export interface NoteSaveStatusText {
+  /** The visible word. Kept to two or three, and never a count. */
+  text: string
+  /** The full sentence VoiceOver reads; the visible text alone under-explains. */
+  accessibilityLabel: string
+}
+
+export function describeNoteSaveStatus(status: NoteSaveStatus): NoteSaveStatusText | null {
+  switch (status) {
+    case 'synced':
+      return null
+    case 'saving':
+      return { text: 'Saving…', accessibilityLabel: 'Saving your changes on this device.' }
+    case 'syncing':
+      return {
+        text: 'Syncing…',
+        accessibilityLabel: 'Saved on this device. Sending to your other devices.'
+      }
+    case 'offline':
+      return {
+        text: 'Offline · saved here',
+        accessibilityLabel:
+          'Saved on this device. Offline, so it will sync when you are back online.'
+      }
+    case 'pending':
+      return {
+        text: 'Saved on this device',
+        accessibilityLabel: 'Saved on this device. Not sent to your other devices yet.'
+      }
+  }
+}

--- a/apps/mobile/src/sync/__tests__/outbox-drain.test.ts
+++ b/apps/mobile/src/sync/__tests__/outbox-drain.test.ts
@@ -417,3 +417,31 @@ describe('OutboxDrain server rejections', () => {
     expect(failed.flatMap((f) => f.ids)).toContain(20)
   })
 })
+
+describe('OutboxDrain.isDraining', () => {
+  it('is true only while a pass is in flight', async () => {
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const store: OutboxQueue = {
+      claimBatch: async () => {
+        await gate
+        return []
+      },
+      complete: async () => {},
+      fail: async () => {},
+      pendingCount: async () => 0
+    }
+    const worker = drain(store)
+
+    expect(worker.isDraining).toBe(false)
+    const pass = worker.drain()
+    // The note screen may only say "Syncing…" here; before and after this
+    // window a queued row is waiting, not travelling.
+    expect(worker.isDraining).toBe(true)
+    release?.()
+    await pass
+    expect(worker.isDraining).toBe(false)
+  })
+})

--- a/apps/mobile/src/sync/__tests__/outbox-store.test.ts
+++ b/apps/mobile/src/sync/__tests__/outbox-store.test.ts
@@ -36,3 +36,23 @@ describe('OutboxStore enqueue notifications', () => {
     expect(notify).toHaveBeenCalledOnce()
   })
 })
+
+describe('OutboxStore.pendingCountForItem', () => {
+  it('counts only the rows belonging to the note it was asked about', async () => {
+    const getFirstAsync = vi.fn(async () => ({ n: 3 }))
+    const db = { getFirstAsync } as unknown as VaultDb
+    const store = new OutboxStore(db)
+
+    expect(await store.pendingCountForItem('note-1')).toBe(3)
+    const [sql, params] = getFirstAsync.mock.calls[0] as unknown as [string, unknown[]]
+    // Scope is the whole point: the note screen's indicator would report every
+    // other note's backlog as this note's if the filter went missing.
+    expect(sql).toContain('WHERE item_id = ?')
+    expect(params).toEqual(['note-1'])
+  })
+
+  it('reads an empty queue as zero rather than undefined', async () => {
+    const db = { getFirstAsync: vi.fn(async () => null) } as unknown as VaultDb
+    expect(await new OutboxStore(db).pendingCountForItem('note-1')).toBe(0)
+  })
+})

--- a/apps/mobile/src/sync/outbox.ts
+++ b/apps/mobile/src/sync/outbox.ts
@@ -197,6 +197,21 @@ export class OutboxStore {
   }
 
   /**
+   * Rows still queued for one item, body updates and record writes alike.
+   *
+   * The note screen's status indicator asks this: zero is the only honest
+   * basis for saying an edit reached the server, because a row is deleted
+   * from this table exactly when the push that carried it was accepted.
+   */
+  async pendingCountForItem(itemId: string): Promise<number> {
+    const row = await this.db.getFirstAsync<{ n: number }>(
+      'SELECT COUNT(*) AS n FROM outbox WHERE item_id = ?',
+      [itemId]
+    )
+    return row?.n ?? 0
+  }
+
+  /**
    * Drop a note's queued rows. Called when a note is deleted locally: its
    * pending body updates describe a note that no longer exists, and pushing
    * them after the tombstone resurrects content on other devices.
@@ -298,6 +313,17 @@ export class OutboxDrain {
   private trailing: Promise<DrainResult> | null = null
 
   constructor(private readonly deps: OutboxDrainDeps) {}
+
+  /**
+   * Whether a pass is in flight right now.
+   *
+   * Read by the note screen's status indicator, which may only say "syncing"
+   * while a push is genuinely running — the passes are event-driven, so
+   * between them a queued row is waiting, not travelling.
+   */
+  get isDraining(): boolean {
+    return this.running !== null
+  }
 
   /**
    * Drain the queue. Never two passes at once — that would double-send — and


### PR DESCRIPTION
## Summary

The note screen's bar said nothing about where an edit was. This adds a passive status readout in `NavBarInline`'s existing `center` slot (`pointerEvents="none"` — a readout, not a control), driven by a pure seam.

**What changed**

- `apps/mobile/src/features/notes/save-status.ts` — `noteSaveStatus()` over five states (`synced | saving | syncing | pending | offline`) plus `describeNoteSaveStatus()` for the visible word and the fuller VoiceOver sentence.
- `apps/mobile/src/features/notes/chrome/save-status.tsx` — the readout. `synced` renders nothing.
- `apps/mobile/src/sync/outbox.ts` — `OutboxStore.pendingCountForItem(itemId)` and an `OutboxDrain.isDraining` getter, both read-only.
- `apps/mobile/src/app/(vault)/(tabs)/notes/[id].tsx` — wiring: `dirty` opens on `doc.onLocalUpdate` and closes when the debounced `controls.flush()` resolves; a self-stopping 1 s poll reads this note's queue depth and the drain state, and stops when nothing is outstanding; `online` comes from `createMobileHttpClient(...).onOnlineChanged`, the same rule `SyncStatusBanner` uses, so the dev offline switch flips both. The stale "saving is silent: the bar carries no status pill" comment is gone because this change makes it untrue.

**Why**

The resting state renders nothing. A permanently visible "synced" badge was explicitly not the goal, and an indicator that overstates where an edit is would be worse than no indicator at all — so every state below is derived from something the app can actually observe.

## Correcting the issue's premise

The issue says mobile has no live sync loop. That is no longer true:

- `src/sync/socket-controller.ts` runs a WebSocket, started from `(vault)/_layout.tsx` and from the foreground/online edges in `src/sync/background.ts`.
- `src/sync/request-sync.ts`'s `PLANS` table drains and pulls on `socket`, `app-foreground`, `online`, `background-task`, and drains on `app-background`.
- `OutboxStore`'s `onEnqueued` callback fires `scheduleLocalSync`, a 300 ms-debounced foreground drain, so an edit typed with the app open is pushed without waiting for an app-state edge.

So a `syncing` state is real and observable, and the indicator uses it rather than inventing one.

## What each state honestly asserts

- **saving** — the WebView may still hold an unflushed batch. `applyFromGuest` persists and enqueues *before* `onLocalUpdate` fires, so what the host has already received is durable; the window this reports is the one until `controls.flush()` resolves. That caveat is written into the type's doc comment.
- **pending** — this note has rows in the durable outbox and nothing is moving them right now. The edit is on disk, not on the server.
- **syncing** — `OutboxDrain.isDraining` is true while this note still has queued rows. Caveat: a drain pass is queue-wide, not per note, so the strict claim is "a push pass is running that these rows are in line for". Suppressed when offline or when writes are parked, since a parked pass reads the policy and returns without sending anything.
- **synced** — `queued === 0`. An outbox row is deleted exactly when the push carrying it was accepted, so this is the only server claim the app can make, and it is a real one. Renders nothing.
- **offline** — the HTTP adapter's NetInfo + dev-offline rule.

## Compatibility

No schema, contract, sync-protocol or settings change. Two additive read-only methods over the existing `outbox` table; no writes, no migration, no server surface. Older and newer app versions on the same vault are unaffected.

## Deliberate: no motion

A spinner would be the only animation on this screen and would need its own reduced-motion branch. The word carries the same meaning at rest, so the readout is text-only and `useReducedMotion()` is untouched by this change.

## Release note

Mobile note screen shows a quiet save and sync status while an edit is on its way, and nothing once it has landed.

## Test plan

- `pnpm --filter @memry/mobile lint` — pass (exit 0). This is the gate that covers this diff; root `pnpm lint` is `lint:desktop` only. Root lint also pass.
- `pnpm typecheck` — pass (exit 0).
- `pnpm --filter @memry/mobile test` — pass (exit 0), 63 files / 581 tests.
- `pnpm test` (root) — exit 1 with **zero reported test failures**: `@memry/desktop:test` was killed with SIGSEGV. Known local noise; desktop is untouched by this diff. 10/11 turbo tasks successful, mobile and sync-server green.
- `pnpm check:architecture`, `pnpm check:contracts`, `git diff --check` — pass (exit 0).
- Not applicable: `ipc:generate`/`ipc:check` (no contracts, preload or main IPC), docs gate (no desktop or sync-server change), `editor:check` (editor-web untouched).

New tests cover every state, both directions of the transition walk including the offline round trip, the "only an empty queue may read as synced" invariant across the full input matrix, plus `pendingCountForItem` scoping and `isDraining` opening and closing exactly around a pass.

## Open device-verification items

Not run on a simulator or device, so two things want a look before this leaves draft:

1. VoiceOver on the readout. It sits inside `NavBarInline`'s title layer, which is `pointerEvents="none"`. RN's iOS hit-test override should not remove children from the accessibility tree, and the text carries `accessible`, `accessibilityRole="text"` and a full sentence label — but that is worth confirming out loud.
2. The note-level offline text coexisting with the global `SyncStatusBanner`. The app-level band already shows "Offline…" above this screen; the note-level wording is note-scoped ("Offline · saved here") to complement rather than repeat it, and the two are visible at the same time when offline.

Closes #2115
