### PR TITLE
fix(graph): keep WebGL alive without a GPU and report when it is missing

### DIFF
--- a/apps/desktop/src/main/gpu-crash-guard.test.ts
+++ b/apps/desktop/src/main/gpu-crash-guard.test.ts
@@ -6,7 +6,8 @@ const mocks = vi.hoisted(() => ({
     isPackaged: true,
     disableHardwareAcceleration: vi.fn(),
     getVersion: vi.fn(() => '2026.702.2'),
-    getPath: vi.fn((name: string) => `/userdata/${name}`)
+    getPath: vi.fn((name: string) => `/userdata/${name}`),
+    commandLine: { appendSwitch: vi.fn() }
   }
 }))
 
@@ -24,6 +25,7 @@ vi.mock('./telemetry/diagnostics', () => ({
 import { readFileSync, writeFileSync, rmSync } from 'node:fs'
 import {
   applyGpuCrashGuard,
+  enableSoftwareWebglFallback,
   recordGpuCrash,
   shouldDisableHwAccel,
   shouldRecordGpuCrash
@@ -126,5 +128,13 @@ describe('recordGpuCrash', () => {
     expect(writeFileSync).toHaveBeenCalledTimes(1)
     const [, payload] = vi.mocked(writeFileSync).mock.calls[0]
     expect(JSON.parse(payload as string)).toEqual({ disabledForGpu: true, version: '2026.702.2' })
+  })
+})
+
+describe('enableSoftwareWebglFallback', () => {
+  it('lets Chromium fall back to SwiftShader so a launch without GPU WebGL still gets a context', () => {
+    enableSoftwareWebglFallback()
+
+    expect(mocks.app.commandLine.appendSwitch).toHaveBeenCalledWith('enable-unsafe-swiftshader')
   })
 })

--- a/apps/desktop/src/main/gpu-crash-guard.ts
+++ b/apps/desktop/src/main/gpu-crash-guard.ts
@@ -90,6 +90,17 @@ export function applyGpuCrashGuard(): void {
 }
 
 /**
+ * Chromium no longer falls back to SwiftShader for WebGL on its own. Without
+ * this switch a launch that has no GPU WebGL (hardware acceleration disabled by
+ * the guard above, a blocklisted driver, Remote Desktop, a VM) gets no WebGL
+ * context at all, and every Sigma graph surface renders the "graph isn't
+ * available" fallback. Must run before app 'ready'.
+ */
+export function enableSoftwareWebglFallback(): void {
+  app.commandLine.appendSwitch('enable-unsafe-swiftshader')
+}
+
+/**
  * Pure decision: should a `child-process-gone` event be recorded as a GPU crash?
  * Only the GPU process dying for a real fault qualifies — exclude 'clean-exit'
  * (normal shutdown) and, since Electron 40, 'memory-eviction' (OS memory-pressure

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -145,7 +145,12 @@ import {
   performQuitAndInstall
 } from './updater'
 import { clearPendingInstallMarker, isPendingInstallInFlight } from './updater-install-guard'
-import { applyGpuCrashGuard, recordGpuCrash, shouldRecordGpuCrash } from './gpu-crash-guard'
+import {
+  applyGpuCrashGuard,
+  enableSoftwareWebglFallback,
+  recordGpuCrash,
+  shouldRecordGpuCrash
+} from './gpu-crash-guard'
 import { buildAppMenu, buildEditableTextContextMenu } from './menu'
 import { getMainI18n, setMainI18n } from './lib/main-i18n'
 import {
@@ -290,6 +295,7 @@ migrateLegacyLogDir()
 // blacklisted Windows GPUs paint nothing, leaving an invisible window), fall
 // back to software rendering this launch instead of stranding the user.
 applyGpuCrashGuard()
+enableSoftwareWebglFallback()
 
 // Native crashes (the ones no JS handler ever sees) leave a minidump in
 // app.getPath('crashDumps') for the Path B diagnostic bundle the user submits

--- a/apps/desktop/src/renderer/src/lib/webgl-support.test.ts
+++ b/apps/desktop/src/renderer/src/lib/webgl-support.test.ts
@@ -1,5 +1,9 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { hasWebGLSupport } from './webgl-support'
+
+const mocks = vi.hoisted(() => ({ trackRendererLog: vi.fn() }))
+
+vi.mock('./telemetry-diagnostics', () => ({ trackRendererLog: mocks.trackRendererLog }))
 
 describe('hasWebGLSupport', () => {
   afterEach(() => {
@@ -35,5 +39,36 @@ describe('hasWebGLSupport', () => {
     })
 
     expect(hasWebGLSupport()).toBe(false)
+  })
+})
+
+describe('hasWebGLSupport telemetry', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mocks.trackRendererLog.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reports an unavailable WebGL context once per session', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
+    const { hasWebGLSupport: probe } = await import('./webgl-support')
+
+    expect(probe()).toBe(false)
+    expect(probe()).toBe(false)
+    expect(mocks.trackRendererLog).toHaveBeenCalledTimes(1)
+    expect(mocks.trackRendererLog).toHaveBeenCalledWith('warn', 'webgl_unavailable', 'WebGLSupport')
+  })
+
+  it('stays silent when WebGL works', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      getExtension: () => null
+    } as unknown as RenderingContext)
+    const { hasWebGLSupport: probe } = await import('./webgl-support')
+
+    expect(probe()).toBe(true)
+    expect(mocks.trackRendererLog).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/src/lib/webgl-support.ts
+++ b/apps/desktop/src/renderer/src/lib/webgl-support.ts
@@ -1,3 +1,15 @@
+import { trackRendererLog } from './telemetry-diagnostics'
+
+let unavailabilityReported = false
+
+function reportUnavailable(): false {
+  if (!unavailabilityReported) {
+    unavailabilityReported = true
+    trackRendererLog('warn', 'webgl_unavailable', 'WebGLSupport')
+  }
+  return false
+}
+
 /**
  * Sigma needs at least one WebGL context for every graph surface. Probe the
  * browser boundary once before mounting Sigma so unsupported devices get a
@@ -13,11 +25,11 @@ export function hasWebGLSupport(): boolean {
       canvas.getContext('webgl2') ??
       canvas.getContext('webgl') ??
       canvas.getContext('experimental-webgl')
-    if (!context) return false
+    if (!context) return reportUnavailable()
 
     ;(context as WebGLRenderingContext).getExtension('WEBGL_lose_context')?.loseContext()
     return true
   } catch {
-    return false
+    return reportUnavailable()
   }
 }

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -260,6 +260,19 @@ void trackTelemetry('onboarding_completed', {
 
 The `void` makes the call non-blocking and unfailable from the UI's point of view.
 
+### WebGL Availability
+
+Every Sigma graph surface (`graph-page`, `graph-canvas`, `local-graph-panel`) probes
+`hasWebGLSupport()` (`apps/desktop/src/renderer/src/lib/webgl-support.ts`) before mounting.
+Chromium no longer falls back to SwiftShader for WebGL on its own, so `main/index.ts` appends
+`--enable-unsafe-swiftshader` before `ready` (`enableSoftwareWebglFallback()` in
+`gpu-crash-guard.ts`): a launch without GPU WebGL — hardware acceleration disabled by the crash
+guard, a blocklisted driver, Remote Desktop, a VM — renders the graph in software instead of
+showing the "Graph isn't available on this device" fallback. When even that fails, the probe
+records one `app_log_recorded` `warn` per session (`source: WebGLSupport`,
+`log_action: webgl_unavailable`) so affected installs can be counted in PostHog. The fallback is an
+expected device condition, never an `app_error_seen` exception.
+
 ### Events Before the Runtime Exists
 
 `trackMainEvent` used to no-op while `getTelemetryRuntime()` was still `null`, so anything that

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -243,9 +243,13 @@ Turn the motion off with **Live motion** under the gear icon → **Display** if 
 still graph — the same forces then run once and stop, which is also the lighter option on
 very large vaults.
 
-If the device cannot start WebGL, Memry shows a safe fallback instead of opening the graph.
-Your notes remain available, and **Close** removes the graph tab so it will not be restored on
-the next launch.
+Memry turns on Chromium's software WebGL renderer, so a device without GPU acceleration — a
+remote desktop session, a virtual machine, a blocklisted graphics driver, or a launch where Memry
+disabled hardware acceleration after a GPU crash — still draws the graph, only more slowly.
+
+If even the software renderer cannot start, Memry shows a safe fallback instead of opening the
+graph. Your notes remain available, and **Close** removes the graph tab so it will not be
+restored on the next launch.
 
 ## Renaming a Linked Note
 


### PR DESCRIPTION
## Summary
- Append `--enable-unsafe-swiftshader` before app `ready` (`enableSoftwareWebglFallback()` in `gpu-crash-guard.ts`). Chromium no longer falls back to SwiftShader for WebGL on its own, so a launch without GPU WebGL (hardware acceleration disabled by `gpu-crash-guard` after a GPU crash, a blocklisted driver, Remote Desktop, a VM) had no WebGL context and every graph surface showed the #2088 fallback "Graph isn't available on this device". With the switch those launches render the graph in software.
- `hasWebGLSupport()` now records one `app_log_recorded` warn per session (`source: WebGLSupport`, `log_action: webgl_unavailable`). The fallback screen was silent, so affected installs were invisible in PostHog.
- Docs: `architecture/observability.md` (new "WebGL Availability" section) and the graph fallback paragraph in `user-guide/notes/wiki-links.md`.

Context: Windows user report on 2026-09-10 after `2026.909.1`. Electron 43.1.1 probe (`BrowserWindow` + `canvas.getContext`, `app.getGPUFeatureStatus()`):

```
hw                 webgl=true   renderer=ANGLE Metal
nogpu              webgl=false  gpu.webgl=disabled_off
nogpu+swiftshader  webgl=true   gpu.webgl=unavailable_software (SwiftShader)
```

Does not touch the Windows CRDT preflight crash; that is a separate issue.

## Release note
Graph view now renders on devices without GPU acceleration, using software rendering.

## Test plan
- `pnpm exec vitest run --config config/vitest.config.ts --project main src/main/gpu-crash-guard.test.ts` — 17 passed. The new test failed before the fix with `enableSoftwareWebglFallback is not a function`.
- `pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/lib/webgl-support.test.ts src/renderer/src/components/graph/graph-page.i18n.test.tsx` — 10 passed. The telemetry test failed before the fix with 0 calls.
- `pnpm typecheck:web`, `pnpm typecheck:node`, `pnpm typecheck:test`, eslint on the touched files, `git diff --check`.
- `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build`.
- Not verified on a real Windows machine without GPU WebGL; the reporter should confirm on the next release.
