### PR TITLE
fix(secrets): stop a hung OS keychain read from wedging telemetry, reports and file IPC

### DIFF
--- a/apps/desktop/src/main/diagnostics/incident-report.ts
+++ b/apps/desktop/src/main/diagnostics/incident-report.ts
@@ -4,8 +4,8 @@
 // consent. `buildIncidentReport` is pure given its deps — it is what the renderer
 // both previews and sends (the incidentId is generated once by the caller and
 // injected, so preview and send produce byte-identical reports).
+import { boundedNetFetch } from '../telemetry/bounded-net-fetch'
 import { randomBytes } from 'node:crypto'
-import { net } from 'electron'
 
 import { redactText } from '@memry/contracts/redact'
 import type {
@@ -136,7 +136,7 @@ export const sendIncidentReport = async (
   deps: SendIncidentReportDeps
 ): Promise<{ incidentId: string }> => {
   const endpoint = resolveEndpoint(deps.endpoint, report.buildChannel)
-  const fetchFn = deps.fetch ?? ((input, init) => net.fetch(input.toString(), init))
+  const fetchFn = deps.fetch ?? ((input, init) => boundedNetFetch(input, init))
   let bearer: string | null = null
   try {
     bearer = await (deps.getAccessToken ?? getValidAccessToken)()

--- a/apps/desktop/src/main/secrets/secret-storage.test.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.test.ts
@@ -53,6 +53,7 @@ vi.mock('keytar', () => ({
 }))
 
 import {
+  KEYCHAIN_READ_TIMEOUT_MS,
   SECRET_STORE_FILENAME,
   deleteSecret,
   finalizeKeytarMigration,
@@ -619,6 +620,58 @@ describe('secret-storage', () => {
 
       expect(harness.keytarDelete).toHaveBeenCalledWith(SERVICE, ACCOUNT)
       expect(harness.keytarStore.has(`${SERVICE}:${ACCOUNT}`)).toBe(false)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // OS keychain read bound
+  // --------------------------------------------------------------------------
+
+  describe('OS keychain read bound', () => {
+    const hangForever = (): Promise<string | null> => new Promise<string | null>(() => {})
+
+    afterEach(() => {
+      vi.useRealTimers()
+      harness.keytarGet.mockImplementation(
+        async (s: string, a: string) => harness.keytarStore.get(`${s}:${a}`) ?? null
+      )
+    })
+
+    it('gives up on a hung OS keychain read and reports the secret as unreadable', async () => {
+      vi.useFakeTimers()
+      harness.keytarGet.mockImplementation(hangForever)
+
+      const outcome = getSecret(SERVICE, ACCOUNT).then(
+        () => 'resolved',
+        (err: Error) => err.name
+      )
+      await vi.advanceTimersByTimeAsync(KEYCHAIN_READ_TIMEOUT_MS)
+
+      await expect(outcome).resolves.toBe('KeychainUnavailableError')
+    })
+
+    it('stops asking the OS keychain for the rest of the run once a read has timed out', async () => {
+      vi.useFakeTimers()
+      harness.keytarGet.mockImplementation(hangForever)
+      const first = getSecret(SERVICE, ACCOUNT).catch((err: Error) => err.name)
+      await vi.advanceTimersByTimeAsync(KEYCHAIN_READ_TIMEOUT_MS)
+      await expect(first).resolves.toBe('KeychainUnavailableError')
+
+      await expect(getSecret(SERVICE, 'other-account')).rejects.toThrow(/keychain/i)
+
+      expect(harness.keytarGet).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports a latched keychain as absent only for callers that opted in', async () => {
+      vi.useFakeTimers()
+      harness.keytarGet.mockImplementation(hangForever)
+      const first = getSecret(SERVICE, ACCOUNT).catch((err: Error) => err.name)
+      await vi.advanceTimersByTimeAsync(KEYCHAIN_READ_TIMEOUT_MS)
+      await expect(first).resolves.toBe('KeychainUnavailableError')
+
+      await expect(
+        getSecret(SERVICE, ACCOUNT, { treatUnreadableAsAbsent: true })
+      ).resolves.toBeNull()
     })
   })
 })

--- a/apps/desktop/src/main/secrets/secret-storage.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.ts
@@ -59,6 +59,48 @@ const keytarMigrationFinalized = new Set<string>()
 
 let loggedPlaintextBackend = false
 
+// keytar has no timeout of its own. Where the Secret Service is missing or
+// wedged (a ChromeOS Crostini container, a headless session, a locked keyring
+// whose prompt nobody can answer) libsecret blocks for as long as D-Bus waits,
+// and every blocked call holds one of libuv's four threadpool threads. Enough
+// of them and every fs/promises read in the app stalls behind the keychain:
+// journal entries, file pages, project folders. Bound the read, and once it
+// has timed out stop asking for the rest of the run.
+export const KEYCHAIN_READ_TIMEOUT_MS = 5_000
+let keychainTimedOut = false
+
+export class KeychainUnavailableError extends Error {
+  constructor(service: string, account: string, cause: 'timeout' | 'latched') {
+    super(
+      cause === 'timeout'
+        ? `OS keychain did not answer within ${KEYCHAIN_READ_TIMEOUT_MS}ms for ${service}/${account}`
+        : `OS keychain is unavailable for the rest of this run (${service}/${account})`
+    )
+    this.name = 'KeychainUnavailableError'
+  }
+}
+
+async function readLegacySecret(service: string, account: string): Promise<string | null> {
+  if (keychainTimedOut) throw new KeychainUnavailableError(service, account, 'latched')
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      keychainTimedOut = true
+      logger.warn('OS keychain read timed out; skipping the OS keychain for the rest of this run', {
+        service,
+        account,
+        timeoutMs: KEYCHAIN_READ_TIMEOUT_MS
+      })
+      reject(new KeychainUnavailableError(service, account, 'timeout'))
+    }, KEYCHAIN_READ_TIMEOUT_MS)
+  })
+  try {
+    return await Promise.race([keytar.getPassword(service, account), deadline])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 const cleanupKey = (service: string, account: string): string => `${service}\u0000${account}`
 
 /** Test-only: reset per-run module state between test cases. */
@@ -66,6 +108,7 @@ export function resetSecretStorageForTests(): void {
   keytarCleanupAttempted.clear()
   keytarMigrationFinalized.clear()
   loggedPlaintextBackend = false
+  keychainTimedOut = false
 }
 
 // ---------------------------------------------------------------------------
@@ -259,7 +302,19 @@ export async function getSecret(
     }
   }
 
-  const legacy = await keytar.getPassword(service, account)
+  let legacy: string | null
+  try {
+    legacy = await readLegacySecret(service, account)
+  } catch (err) {
+    if (err instanceof KeychainUnavailableError && options?.treatUnreadableAsAbsent) {
+      logger.warn('OS keychain unavailable; caller opted to treat the secret as absent', {
+        service,
+        account
+      })
+      return null
+    }
+    throw err
+  }
   if (legacy !== null) {
     if (filePath !== null) {
       await migrateLegacySecret(
@@ -368,6 +423,7 @@ export async function deleteSecret(service: string, account: string): Promise<vo
  */
 export async function finalizeKeytarMigration(service: string, account: string): Promise<void> {
   if (keytarMigrationFinalized.has(cleanupKey(service, account))) return
+  if (keychainTimedOut) return
   if (!isSafeStorageAvailable()) return
   const filePath = resolveStoreFilePath()
   if (!filePath) return
@@ -376,7 +432,7 @@ export async function finalizeKeytarMigration(service: string, account: string):
     if (ciphertext === null) return
     const value = decryptValue(ciphertext)
     if (value === null) return
-    const legacy = await keytar.getPassword(service, account)
+    const legacy = await readLegacySecret(service, account)
     if (legacy === null) {
       // Nothing left in the OS keychain — this migration is done for this run.
       keytarMigrationFinalized.add(cleanupKey(service, account))
@@ -559,7 +615,7 @@ async function cleanupLegacyKeytarCopy(
   if (keytarCleanupAttempted.has(key)) return
   keytarCleanupAttempted.add(key)
   try {
-    const legacy = await keytar.getPassword(service, account)
+    const legacy = await readLegacySecret(service, account)
     if (legacy !== null && legacy === expected) {
       await keytar.deletePassword(service, account)
       logger.info('Removed migrated secret from OS keychain', { service, account })

--- a/apps/desktop/src/main/telemetry/bounded-net-fetch.test.ts
+++ b/apps/desktop/src/main/telemetry/bounded-net-fetch.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(async (_input: string, _init?: RequestInit) => ({ ok: true, status: 202 }))
+}))
+
+vi.mock('electron', () => ({ net: { fetch: mocks.fetch } }))
+
+import { boundedNetFetch } from './bounded-net-fetch'
+
+describe('boundedNetFetch', () => {
+  it('gives every request an abort deadline', async () => {
+    await boundedNetFetch('https://example.test/telemetry/batch', { method: 'POST' })
+
+    const init = mocks.fetch.mock.calls[0]?.[1]
+    expect(init?.method).toBe('POST')
+    expect(init?.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('keeps a deadline the caller already chose', async () => {
+    const controller = new AbortController()
+    await boundedNetFetch('https://example.test/telemetry/batch', { signal: controller.signal })
+
+    expect(mocks.fetch.mock.calls.at(-1)?.[1]?.signal).toBe(controller.signal)
+  })
+})

--- a/apps/desktop/src/main/telemetry/bounded-net-fetch.ts
+++ b/apps/desktop/src/main/telemetry/bounded-net-fetch.ts
@@ -1,0 +1,16 @@
+import { net } from 'electron'
+
+export const NET_FETCH_TIMEOUT_MS = 30_000
+
+/**
+ * net.fetch with an abort deadline. A request that is in flight when
+ * Chromium's network service dies never settles on its own, and a flush loop
+ * awaiting it stalls for the rest of the run while every later batch queues
+ * behind it.
+ */
+export const boundedNetFetch = (
+  input: string | URL,
+  init?: RequestInit,
+  timeoutMs: number = NET_FETCH_TIMEOUT_MS
+): Promise<Response> =>
+  net.fetch(input.toString(), { ...init, signal: init?.signal ?? AbortSignal.timeout(timeoutMs) })

--- a/apps/desktop/src/main/telemetry/client.test.ts
+++ b/apps/desktop/src/main/telemetry/client.test.ts
@@ -278,6 +278,7 @@ describe('createTelemetryClient', () => {
     it('sends Authorization header when getAccessToken resolves a token', async () => {
       // #given a client with getAccessToken that resolves a JWT
       const { deps, calls } = createDeps({
+        getAuthState: () => 'signed_in',
         getAccessToken: async () => 'jwt-token'
       })
       const client = createTelemetryClient(deps)
@@ -296,6 +297,7 @@ describe('createTelemetryClient', () => {
     it('sends no Authorization header when getAccessToken resolves null', async () => {
       // #given a client with getAccessToken that resolves null
       const { deps, calls } = createDeps({
+        getAuthState: () => 'signed_in',
         getAccessToken: async () => null
       })
       const client = createTelemetryClient(deps)
@@ -312,6 +314,7 @@ describe('createTelemetryClient', () => {
     it('flush still succeeds when getAccessToken throws', async () => {
       // #given a client with getAccessToken that throws
       const { deps, calls } = createDeps({
+        getAuthState: () => 'signed_in',
         getAccessToken: async () => {
           throw new Error('token fetch failed')
         }
@@ -331,6 +334,7 @@ describe('createTelemetryClient', () => {
     it('Authorization header is exactly Bearer <token> with one space', async () => {
       // #given a client with a known token
       const { deps, calls } = createDeps({
+        getAuthState: () => 'signed_in',
         getAccessToken: async () => 'my-access-token'
       })
       const client = createTelemetryClient(deps)
@@ -500,5 +504,33 @@ describe('createTelemetryClient — crash durability', () => {
     // #then nothing is restored and nothing is left on disk
     expect(client.getQueueDepth()).toBe(0)
     expect(fs.existsSync(persistPath)).toBe(false)
+  })
+
+  describe('access token lookup', () => {
+    it('never touches the token store for an install that is not signed in', async () => {
+      const getAccessToken = vi.fn(async () => 'token')
+      const { deps, fetchMock } = createDeps({ getAccessToken, getAuthState: () => 'anonymous' })
+      const client = createTelemetryClient(deps)
+      client.track(buildEvent('11111111-1111-1111-1111-111111111111'))
+
+      await client.flush('manual')
+
+      expect(getAccessToken).not.toHaveBeenCalled()
+      const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined
+      expect(init?.headers).not.toHaveProperty('Authorization')
+    })
+
+    it('attaches the token for a signed-in install', async () => {
+      const getAccessToken = vi.fn(async () => 'token')
+      const { deps, fetchMock } = createDeps({ getAccessToken, getAuthState: () => 'signed_in' })
+      const client = createTelemetryClient(deps)
+      client.track(buildEvent('11111111-1111-1111-1111-111111111111'))
+
+      await client.flush('manual')
+
+      expect(getAccessToken).toHaveBeenCalledTimes(1)
+      const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined
+      expect(init?.headers).toHaveProperty('Authorization', 'Bearer token')
+    })
   })
 })

--- a/apps/desktop/src/main/telemetry/client.ts
+++ b/apps/desktop/src/main/telemetry/client.ts
@@ -151,7 +151,10 @@ export const createTelemetryClient = (deps: TelemetryClientDeps): TelemetryClien
     const batch = buildBatch(events)
 
     let bearerValue: string | null = null
-    if (deps.getAccessToken) {
+    // Only a signed-in install has a token to find. Looking one up anyway
+    // costs an OS keychain round-trip per flush, and on a machine whose
+    // keychain hangs that round-trip wedged the whole pipeline.
+    if (deps.getAccessToken && batch.authState === 'signed_in') {
       try {
         bearerValue = await deps.getAccessToken()
       } catch (error) {

--- a/apps/desktop/src/main/telemetry/log-ship.ts
+++ b/apps/desktop/src/main/telemetry/log-ship.ts
@@ -4,8 +4,8 @@
 // batches+ships redacted lines to /telemetry/logs. Nothing in this module wires
 // itself into the real logger at startup — see the caller for that (installLogShip
 // is invoked once from main startup).
+import { boundedNetFetch } from './bounded-net-fetch'
 import log from 'electron-log'
-import { net } from 'electron'
 
 import { redactLogLine } from '@memry/contracts/redact'
 import type { DiagnosticLogBatch, DiagnosticLogLine } from '@memry/contracts/diagnostics-api'
@@ -103,7 +103,7 @@ const resolveEndpoint = (override: string | undefined, channel: TelemetryBuildCh
 }
 
 const wrapFetch = (custom?: TelemetryFetch): TelemetryFetch =>
-  custom ?? (async (input, init) => net.fetch(input.toString(), init))
+  custom ?? (async (input, init) => boundedNetFetch(input, init))
 
 export const installLogShip = (deps: LogShipDeps): LogShip => {
   if (logShipInstance) return logShipInstance

--- a/apps/desktop/src/main/telemetry/runtime.test.ts
+++ b/apps/desktop/src/main/telemetry/runtime.test.ts
@@ -255,6 +255,7 @@ describe('initializeTelemetryRuntime', () => {
       endpoint: 'https://example.test/telemetry/batch',
       initialEnabled: true,
       flushIntervalMs: null,
+      authStateProvider: () => 'signed_in',
       accessTokenProvider: async () => 'jwt-token'
     })
 

--- a/apps/desktop/src/main/telemetry/runtime.ts
+++ b/apps/desktop/src/main/telemetry/runtime.ts
@@ -1,6 +1,7 @@
+import { boundedNetFetch } from './bounded-net-fetch'
 import { randomUUID } from 'node:crypto'
 
-import { app, net } from 'electron'
+import { app } from 'electron'
 
 import type {
   TelemetryAuthState,
@@ -108,10 +109,7 @@ const computeInitialEnabled = (
 
 const wrapFetch = (custom?: TelemetryFetch): TelemetryFetch => {
   if (custom) return custom
-  return async (input, init) => {
-    const response = await net.fetch(input.toString(), init)
-    return response
-  }
+  return async (input, init) => boundedNetFetch(input, init)
 }
 
 export const initializeTelemetryRuntime = (deps?: TelemetryRuntimeDeps): TelemetryRuntime => {

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -108,6 +108,16 @@ service and account strings the OS keychain used. The retired `keytar` module st
 read-only fallback: every read tries the safeStorage store first and falls back to the OS keychain
 under the identical account.
 
+That fallback is bounded (`readLegacySecret` in `secrets/secret-storage.ts`). An OS keychain read
+that has not answered within 5 s (`KEYCHAIN_READ_TIMEOUT_MS`) is reported as **unreadable**
+(`KeychainUnavailableError`), never as absent — the #772 guard still holds — and the OS keychain is
+skipped for the rest of the run. Only callers that opted into `treatUnreadableAsAbsent` see `null`.
+Without the bound, a machine with no working Secret Service (a ChromeOS Crostini container, a
+headless session, a locked keyring whose prompt nobody can answer) left every `keytar` call blocked
+inside libsecret, and each blocked call held one of libuv's four threadpool threads: with four of
+them stuck, every `fs/promises` read in the app — journal entries, file pages, project folders —
+stalled behind the keychain.
+
 A legacy secret migrates lazily on first read: encrypt, persist, decrypt round-trip verify
 byte-identical against the source, and only then delete the OS keychain copy. Any verification
 failure keeps the OS keychain authoritative. The vault master key goes one step further — its OS

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -634,6 +634,21 @@ that batch, so one malformed event cannot wedge the queue head and replay the sa
 on every flush. Transient failures — `5xx`, `429`, and network errors — leave the batch queued for
 a later retry.
 
+### Token Lookup & Request Deadlines
+
+The batch client asks the token manager for an access token only when the install is
+`signed_in`; an `anonymous` or `signed_out` install ships every batch without touching the secret
+store. Looking the token up regardless cost an OS keychain round-trip per flush, and on a machine
+whose keychain hangs (see [Cryptography](./cryptography.md)) that round-trip wedged the whole
+pipeline: events stopped while the log shipper — which never asks for a token — kept going. That
+"logs but no events" split is the diagnostic signature; the diagnostic report upload
+(`sendIncidentReport`) sat behind the same lookup and showed as `Sending…` forever.
+
+Every `net.fetch` on the telemetry path — event batches, log shipping, incident reports — goes
+through `boundedNetFetch` (`telemetry/bounded-net-fetch.ts`) with a 30 s abort deadline. A request
+still in flight when Chromium's network service dies never settles on its own, and a flush loop
+awaiting it would otherwise stall for the rest of the run with every later batch queued behind it.
+
 ### Autosave Event Throttling
 
 `note_updated` and `journal_updated` events fired by the autosave path are throttled to at most


### PR DESCRIPTION
## Summary
Diagnosis from the 2026-09-10 report (install `4c40bad24708`, Linux / ChromeOS Crostini, anonymous, sync off — not Windows). Since 2026-09-09 08:50 the install shipped log lines but zero telemetry events, "Send diagnostic report" sat on `Sending…` forever, and the journal, file and project pages never loaded while the sidebar and settings kept working.

Root cause in the code: every telemetry flush called `getValidAccessToken()`, which fell through the empty safeStorage store into `keytar.getPassword` with no production timeout (`withTestTimeout` only applies under `NODE_ENV=test`). On that machine there is no working Secret Service (`org.freedesktop.secrets was not provided by any .service files` on 2026-09-08), so libsecret blocks inside D-Bus. keytar runs on the libuv threadpool (4 threads); with four blocked calls every `fs/promises` read in the app stalls — `readJournalEntry`, `getFileById`, project and canvas folders — which is exactly the set of pages that stopped. The report upload waited on the same lookup.

- `secrets/secret-storage.ts`: bound the OS keychain read to 5 s (`KEYCHAIN_READ_TIMEOUT_MS`). A timeout reports the secret as **unreadable** (`KeychainUnavailableError`), never as absent, so the #772 guard holds; only `treatUnreadableAsAbsent` callers see `null`. After one timeout the OS keychain is skipped for the rest of the run, and `finalizeKeytarMigration` (called per CRDT batch) short-circuits with it.
- `telemetry/client.ts`: look the access token up only for a `signed_in` install. `anonymous` / `signed_out` installs never had one to find and now skip the secret store entirely.
- `telemetry/bounded-net-fetch.ts`: every telemetry `net.fetch` (batches, log shipping, incident reports) gets a 30 s abort deadline. A request in flight when Chromium's network service dies never settles; a second Linux install (`c88dc9cf7763`, 909.1) stalled its event pipeline that way after `Utility:killed:Network_Service` while its log shipper kept going.
- Docs: `architecture/cryptography.md` (bounded fallback) and `architecture/observability.md` (new "Token Lookup & Request Deadlines").

Not reproduced on the reporting machine; the threadpool link is inferred from the code and the logs-but-no-events split in PostHog. Same install also fails the CRDT preflight on every 909.1 launch (`y-leveldb … Iterator is not open: cannot call nextv() after close()`, store quarantined each time) — separate issue, not touched here. Graph on that machine is the WebGL case shipped in #2127.

## Release note
Fixed an issue where an unresponsive OS keychain could stop the journal, file and project pages from loading and leave diagnostic reports stuck on "Sending…".

## Test plan
- `pnpm exec vitest run --config config/vitest.config.ts --project main src/main/secrets src/main/telemetry src/main/diagnostics src/main/crypto/keychain.test.ts` — 19 files, 290 passed. New: three `OS keychain read bound` cases (timeout → `KeychainUnavailableError`, run-wide latch with keytar called once, opt-in absence), two `access token lookup` cases, two `boundedNetFetch` cases. Before the fix: `KeychainUnavailableError`/`KEYCHAIN_READ_TIMEOUT_MS` missing, anonymous flush still called `getAccessToken`, `init.signal` undefined.
- Existing token tests (`client.test.ts` `getAccessToken`, `runtime.test.ts` `passes accessTokenProvider through`) now set `signed_in`, since anonymous installs intentionally no longer look up a token.
- `pnpm typecheck:node`, `pnpm typecheck:test`, eslint on touched files, `git diff --check`, `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build`.
- Not verified on a machine without a Secret Service.
