### PR TITLE
fix(telemetry): stop grouping bare Errors into one Error Tracking issue

### DIFF
--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -476,6 +476,17 @@ Errors additionally become `$exception` events for PostHog Error Tracking (`exce
 `services/posthog-transform.ts`), fingerprinted on our own `errorCode` when one is present so
 grouping follows the app's own error taxonomy rather than PostHog's pattern-hash default.
 
+**Generic constructor names do not group.** `toErrorCode` falls back to the error's constructor
+name, so every bare `new Error('...')` reports `errorCode: 'Error'`. Pinning the fingerprint to
+that merged roughly thirty unrelated production failures — offline network errors, a Squirrel
+read-only-volume update failure, `data.db failed PRAGMA quick_check`, missing agent API keys —
+into one issue titled after whichever stack the first sample happened to carry (#2134). The
+transform therefore omits `$exception_fingerprint` for the built-in constructor names plus the
+`UnknownError` / `StringError` fallbacks (`NON_DISCRIMINATING_ERROR_CODES`), handing those back to
+PostHog's pattern hash so they split into real issues. A generic name still rides along as
+`$exception_list[0].type`; only the grouping key changes. Give a failure a typed code if you want
+it grouped as its own issue.
+
 Three server-side guards keep this stream from flooding the PostHog quota:
 
 - **Warn-level log lines never reach Error Tracking.** The desktop demotes expected failures to

--- a/apps/sync-server/src/services/posthog-transform.test.ts
+++ b/apps/sync-server/src/services/posthog-transform.test.ts
@@ -525,6 +525,46 @@ describe('exceptionEvent', () => {
     expect(result?.properties).not.toHaveProperty('$exception_fingerprint')
   })
 
+  it('omits $exception_fingerprint for a generic constructor-name error code', () => {
+    // `toErrorCode` reports `Error` for every bare `new Error(...)`; pinning the
+    // fingerprint to it merged ~30 unrelated failures into one issue (#2134).
+    const result = exceptionEvent(
+      batchFixture(),
+      eventFixture({ errorCode: 'Error', error: { message: 'net::ERR_TIMED_OUT' } }),
+      ctx
+    )
+    expect(result?.properties).not.toHaveProperty('$exception_fingerprint')
+  })
+
+  it('omits $exception_fingerprint for the UnknownError fallback code', () => {
+    const result = exceptionEvent(
+      batchFixture(),
+      eventFixture({ errorCode: 'UnknownError', error: { message: 'boom' } }),
+      ctx
+    )
+    expect(result?.properties).not.toHaveProperty('$exception_fingerprint')
+  })
+
+  it('still pins $exception_fingerprint for a typed code that happens to end in Error', () => {
+    const result = exceptionEvent(
+      batchFixture(),
+      eventFixture({ errorCode: 'SqliteError', error: { message: 'database is locked' } }),
+      ctx
+    )
+    expect(result?.properties.$exception_fingerprint).toBe('SqliteError')
+  })
+
+  it('keeps the generic code as $exception_list[0].type even when it does not group', () => {
+    const result = exceptionEvent(
+      batchFixture(),
+      eventFixture({ errorCode: 'Error', error: { message: 'net::ERR_TIMED_OUT' } }),
+      ctx
+    )
+    const list = result?.properties.$exception_list as { type: string; value: string }[]
+    expect(list[0].type).toBe('Error')
+    expect(list[0].value).toBe('net::ERR_TIMED_OUT')
+  })
+
   it('still sets $exception_list[0].type to the event name when there is no errorCode', () => {
     const result = exceptionEvent(
       batchFixture(),

--- a/apps/sync-server/src/services/posthog-transform.ts
+++ b/apps/sync-server/src/services/posthog-transform.ts
@@ -321,6 +321,33 @@ export const isLegacyMutationDropNoise = (batch: TelemetryBatch, event: Telemetr
   event.dimensions?.log_action === 'local_mutation_dropped' &&
   isVersionBefore(batch.appVersion, DROP_TRIPWIRE_FIX_VERSION)
 
+// `toErrorCode` falls back to the error's constructor name, so every bare
+// `new Error('...')` in the codebase reports errorCode `Error`. Pinning the
+// fingerprint to that collapsed ~30 unrelated failures — offline network
+// errors, a Squirrel read-only-volume update failure, `data.db failed PRAGMA
+// quick_check`, missing agent API keys — into ONE issue, titled after whichever
+// stack the first sample happened to carry (#2134). A generic constructor name
+// is not a code: it says nothing about what failed, so it must not group.
+//
+// Omitting the fingerprint hands grouping back to PostHog's pattern hash, which
+// reads the type, the message and the stack frames — the failures above split
+// into their own issues instead of one meaningless bucket.
+const NON_DISCRIMINATING_ERROR_CODES = new Set([
+  'Error',
+  'EvalError',
+  'RangeError',
+  'ReferenceError',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+  'AggregateError',
+  'UnknownError',
+  'StringError'
+])
+
+const isGroupableErrorCode = (errorCode: string | undefined): errorCode is string =>
+  Boolean(errorCode) && !NON_DISCRIMINATING_ERROR_CODES.has(errorCode as string)
+
 // Error Tracking requires the event name to be exactly `$exception`; a plain
 // `exception` lands in Events and never reaches the Error Tracking product.
 //
@@ -391,10 +418,12 @@ export const exceptionEvent = (
       // Unlike `type`, the fingerprint must NOT fall back to event.name: that would
       // collapse every distinct error without an errorCode into one Error Tracking
       // issue (all grouped under e.g. "app_error_seen"), defeating the pinning this
-      // comment block exists to justify. Omit the key when there is no errorCode so
-      // PostHog falls back to its own pattern-hash grouping instead. Do not
-      // "simplify" this back to an unconditional assignment.
-      ...(event.errorCode ? { $exception_fingerprint: event.errorCode } : {}),
+      // comment block exists to justify. Omit the key when there is no errorCode,
+      // and equally when the code is only a generic constructor name
+      // (NON_DISCRIMINATING_ERROR_CODES), so PostHog falls back to its own
+      // pattern-hash grouping instead. Do not "simplify" this back to an
+      // unconditional assignment.
+      ...(isGroupableErrorCode(event.errorCode) ? { $exception_fingerprint: event.errorCode } : {}),
       surface: event.surface,
       action: event.action,
       app_version: batch.appVersion,


### PR DESCRIPTION
## What

`exceptionEvent` pinned `$exception_fingerprint` to our own `errorCode`. But `toErrorCode` falls back to the error's constructor name, so every plain `new Error('...')` in the codebase reports `errorCode: 'Error'` — and all of them landed in a single Error Tracking issue.

That issue is #2134, titled "Google OAuth token exchange fails in connectGoogleCalendar": 452 occurrences, 33 users. Its actual contents over the last 14 days:

| message | occ | users |
| --- | --- | --- |
| `net::ERR_NETWORK_CHANGED` | 380 | 4 |
| `net::ERR_INTERNET_DISCONNECTED` | 242 | 4 |
| `net::ERR_TIMED_OUT` | 172 | 3 |
| Squirrel "read-only volume" update failure | 148 | 1 |
| `net::ERR_NAME_NOT_RESOLVED` | 127 | 3 |
| Sigma "Container has no width" | 33 | 23 |
| `data.db failed PRAGMA quick_check` | 11 | 1 |
| … ~25 more, incl. missing agent API keys, tiptap view errors, ditto/codesign update failures | | |

Three occurrences were the calendar OAuth path. The title came from whichever sample's stack the issue page happened to render.

## Why

A generic constructor name is not an error code — it says nothing about what failed, so it must not be the grouping key. Omitting the fingerprint hands those events back to PostHog's pattern hash (type + message + frames), which splits them into real issues.

Typed codes (`SYNC_TIMEOUT`, `SqliteError`, `Utility_crashed_*`) keep pinning exactly as before. The generic name still rides along as `$exception_list[0].type`; only the grouping key changes.

This is server-side, so it applies to every installed desktop version without an app update.

## Verify

- `apps/sync-server` `posthog-transform.test.ts`: 76 passed, incl. four new cases (generic code omits the fingerprint, `UnknownError` omits it, `SqliteError` still pins, type is preserved).
- `pnpm --filter @memry/sync-server typecheck`, `pnpm lint`, `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build` — all green.
- The rest of the sync-server suite fails locally on a `better-sqlite3` NODE_MODULE_VERSION mismatch in this worktree, unrelated to this change.

After deploy: #2134 should stop growing and the failures above should appear as separate issues. Worth re-triaging the calendar OAuth path then, on its real volume.

Closes #2134

🤖 Generated with [Claude Code](https://claude.com/claude-code)