### PR TITLE
fix(desktop): surface the LevelDB open error in the CRDT preflight child

### DIFF
--- a/apps/desktop/src/main/sync/crdt-preflight-child.test.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight-child.test.ts
@@ -1,4 +1,16 @@
-import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+  type MockInstance
+} from 'vitest'
 import {
   PREFLIGHT_MARK_BINDING_LOADED,
   PREFLIGHT_MARK_STARTED,
@@ -9,7 +21,13 @@ const mockWriteSync = vi.hoisted(() => vi.fn())
 const mockRmSync = vi.hoisted(() => vi.fn())
 const mockRmdirSync = vi.hoisted(() => vi.fn())
 const mockUnlinkSync = vi.hoisted(() => vi.fn())
-const mockRequire = vi.hoisted(() => vi.fn())
+// `require` AND `require.resolve`: the child resolves the level adapter through
+// y-leveldb's own resolution, so both halves of the createRequire result are used.
+const mockRequire = vi.hoisted(() => {
+  const fn = vi.fn() as ReturnType<typeof vi.fn> & { resolve: (id: string) => string }
+  fn.resolve = () => '/fake/node_modules/y-leveldb/dist/y-leveldb.cjs'
+  return fn
+})
 
 // Only the entry points the child actually uses are swapped; everything else
 // stays real so yjs keeps working. The delete-shaped calls are stubbed purely
@@ -54,6 +72,9 @@ interface FakePersistence {
 
 let persistence: FakePersistence
 let constructedWith: string[]
+/** Directories the injected level adapter was actually constructed against. */
+let levelConstructedWith: string[]
+let levelOpen: Mock<() => Promise<void>>
 let loadedDoc: { destroy: ReturnType<typeof vi.fn> }
 let exitSpy: MockInstance<(code?: number) => never>
 let abortSpy: MockInstance<() => never>
@@ -91,13 +112,31 @@ describe('crdt-preflight-child', () => {
   beforeEach(() => {
     persistence = makePersistence()
     constructedWith = []
+    levelConstructedWith = []
+    levelOpen = vi.fn(async () => undefined)
     mockWriteSync.mockReset().mockReturnValue(0)
+    mockRequire.resolve = () => '/fake/node_modules/y-leveldb/dist/y-leveldb.cjs'
     mockRequire.mockReset().mockImplementation((id: string) => {
+      // Stands in for `level`, whose only job here is to be constructed by
+      // y-leveldb and opened by the child.
+      if (id === 'level') {
+        return {
+          Level: class {
+            constructor(dir: string) {
+              levelConstructedWith.push(dir)
+            }
+            open = (): Promise<void> => levelOpen()
+          }
+        }
+      }
       if (id !== 'y-leveldb') throw new Error(`unexpected require: ${id}`)
       return {
         LeveldbPersistence: class {
-          constructor(dir: string) {
+          constructor(dir: string, opts?: { Level?: new (dir: string, o: object) => unknown }) {
             constructedWith.push(dir)
+            // Real y-leveldb constructs the adapter in its own constructor;
+            // the child's diagnostic depends on that, so the fake does too.
+            if (opts?.Level) new opts.Level(dir, {})
           }
           storeUpdate = persistence.storeUpdate
           getYDoc = persistence.getYDoc
@@ -259,6 +298,67 @@ describe('crdt-preflight-child', () => {
       expect(persistence.clearDocument).not.toHaveBeenCalled()
     })
 
+    /**
+     * The field failure this exists for (2026.909.1, Linux): every y-leveldb
+     * call runs inside `_transact`, which catches, warns and resolves `null`,
+     * so a store that could not be opened at all still walked past the write
+     * and read markers and died on `TypeError: Cannot read properties of null
+     * (reading 'destroy')`. The LevelDB error was never printed anywhere.
+     */
+    it('prints the LevelDB open error, root cause first, and stops at the open marker', async () => {
+      levelOpen.mockRejectedValue(
+        Object.assign(new Error('Database is not open'), {
+          code: 'LEVEL_DATABASE_NOT_OPEN',
+          cause: new Error(
+            'IO error: lock /Users/ada/Library/Application Support/memry/crdt-store/LOCK: already held by process'
+          )
+        })
+      )
+
+      const code = await runChild()
+
+      expect(code).toBe(1)
+      expect(levelConstructedWith).toEqual([STORE_DIR])
+      const openLine = marks().find((line) => line.includes('store open failed'))
+      // The wrapper says only "Database is not open"; the cause is the line
+      // that separates a held LOCK from a corrupt store, so it leads.
+      expect(openLine).toContain('IO error: lock')
+      expect(openLine).toContain('already held by process')
+      expect(openLine).toContain('[LEVEL_DATABASE_NOT_OPEN] Database is not open')
+      expect(openLine?.indexOf('IO error')).toBeLessThan(
+        openLine?.indexOf('LEVEL_DATABASE_NOT_OPEN') ?? -1
+      )
+      // Nothing past the open was attempted — the store markers would otherwise
+      // claim a write and a read that never really ran.
+      expect(
+        marks()
+          .filter((line) => line.startsWith('@@'))
+          .at(-1)
+      ).toBe(`${PREFLIGHT_MARK_STORE_OPS.open}\n`)
+      expect(persistence.storeUpdate).not.toHaveBeenCalled()
+    })
+
+    it('opens the store explicitly before the first y-leveldb call', async () => {
+      await runChild()
+
+      expect(levelOpen).toHaveBeenCalledTimes(1)
+      expect(levelOpen.mock.invocationCallOrder[0]).toBeLessThan(
+        persistence.storeUpdate.mock.invocationCallOrder[0]
+      )
+    })
+
+    it('names the swallowed read instead of dereferencing null', async () => {
+      persistence.getYDoc.mockResolvedValue(null)
+
+      const code = await runChild()
+
+      expect(code).toBe(1)
+      const reported = errorSpy.mock.calls[0]?.[0]
+      expect(reported).toBeInstanceOf(Error)
+      expect(reported).not.toBeInstanceOf(TypeError)
+      expect(String(reported)).toContain('store read returned null')
+    })
+
     it('exits non-zero, without loading the binding, when no probe dir is passed', async () => {
       const code = await runChild(null)
 
@@ -266,6 +366,55 @@ describe('crdt-preflight-child', () => {
       expect(mockRequire).not.toHaveBeenCalled()
       expect(errorSpy.mock.calls[0]?.[0]).toBeInstanceOf(Error)
       expect(String(errorSpy.mock.calls[0]?.[0])).toContain('missing probe directory')
+    })
+  })
+
+  /**
+   * The one test that loads the real y-leveldb and the real classic-level
+   * binding. Everything above proves the child's wiring against fakes, which
+   * cannot prove the two things that actually matter in the field: that
+   * y-leveldb honours the injected `Level` adapter at all, and that a store
+   * whose LOCK is held really does reject the explicit open with a message
+   * naming the lock. Needs `pnpm --filter @memry/desktop rebuild:node`.
+   */
+  describe('against a real LevelDB store', () => {
+    it('reports the held LOCK instead of dying on a null dereference', async () => {
+      const { createRequire: realCreateRequire } =
+        await vi.importActual<typeof import('module')>('module')
+      const realRequire = realCreateRequire(import.meta.url)
+      // Mirror the child's own two-step resolution: `level` comes from
+      // y-leveldb's directory, not ours. It matters — the repo carries two
+      // classic-level copies, and LevelDB's lock table lives inside a loaded
+      // native binary, so a holder from the other copy would not conflict.
+      const yLeveldbRequire = realCreateRequire(realRequire.resolve('y-leveldb'))
+      mockRequire.resolve = (id: string) => realRequire.resolve(id)
+      mockRequire.mockImplementation((id: string) =>
+        id === 'level' ? yLeveldbRequire(id) : realRequire(id)
+      )
+
+      // Holding the LOCK here is what the previous app process does to the
+      // next one when it never exits cleanly.
+      const { Level } = yLeveldbRequire('level') as {
+        Level: new (dir: string, opts: object) => { open(): Promise<void>; close(): Promise<void> }
+      }
+      const dir = await mkdtemp(join(tmpdir(), 'memry-preflight-lock-'))
+      const holder = new Level(dir, {})
+      await holder.open()
+
+      try {
+        expect(await runChild(dir)).toBe(1)
+
+        const openLine = marks().find((line) => line.includes('store open failed'))
+        expect(openLine).toBeDefined()
+        expect(openLine).toContain('lock')
+        expect(openLine).toContain('LOCK')
+        // The masked failure: a TypeError from `loaded.destroy()` naming
+        // neither the store nor the cause.
+        expect(String(errorSpy.mock.calls[0]?.[0])).not.toContain('reading')
+      } finally {
+        await holder.close()
+        await rm(dir, { recursive: true, force: true })
+      }
     })
   })
 

--- a/apps/desktop/src/main/sync/crdt-preflight-child.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight-child.ts
@@ -31,6 +31,36 @@ import {
 
 const PROBE_DOC = '__memry_preflight__'
 
+/** The one thing this file needs off a level adapter: an explicit open. */
+interface LevelInstance {
+  open(): Promise<void>
+}
+type LevelAdapter = new (location: string, options: Record<string, unknown>) => LevelInstance
+
+/** How deep a cause chain is worth printing before it is noise. */
+const MAX_CAUSE_DEPTH = 5
+
+/**
+ * The whole error chain on one line, root cause FIRST.
+ *
+ * abstract-level buries the diagnostic: a failed open rejects with
+ * `Database is not open (LEVEL_DATABASE_NOT_OPEN)` and carries the LevelDB
+ * message — the part that separates "another process holds the LOCK" from
+ * "the store is corrupt" — only in `cause`. The parent keeps a bounded prefix
+ * of this line as the failure reason, so the informative end leads.
+ */
+function describeErrorChain(err: unknown): string {
+  const parts: string[] = []
+  let current: unknown = err
+  for (let depth = 0; current instanceof Error && depth < MAX_CAUSE_DEPTH; depth++) {
+    const code = (current as { code?: unknown }).code
+    parts.push(typeof code === 'string' ? `[${code}] ${current.message}` : current.message)
+    current = (current as { cause?: unknown }).cause
+  }
+  if (parts.length === 0) return String(err)
+  return parts.reverse().join(' <- ')
+}
+
 function mark(marker: string): void {
   // writeSync, not process.stderr.write: stderr is a pipe here, so Node's
   // stream write is async and a native abort microseconds later would eat the
@@ -58,10 +88,25 @@ async function main(): Promise<void> {
   // child runtime that never started. `require`, not `import()` — y-leveldb is
   // an external dep resolved relative to this bundle, and CJS require is what
   // works from inside the packaged app.
-  const { LeveldbPersistence } = createRequire(__filename)(
-    'y-leveldb'
-  ) as typeof import('y-leveldb')
+  const childRequire = createRequire(__filename)
+  const { LeveldbPersistence } = childRequire('y-leveldb') as typeof import('y-leveldb')
   mark(PREFLIGHT_MARK_BINDING_LOADED)
+
+  // y-leveldb opens its database lazily and never exposes the instance, so the
+  // only way to see WHY an open failed is to hand it the adapter and keep a
+  // reference. Resolved THROUGH y-leveldb's own resolution: the app's module
+  // graph carries a second, newer classic-level, and probing the store with a
+  // different native binding than the one y-leveldb will use proves nothing.
+  const { Level } = createRequire(childRequire.resolve('y-leveldb'))('level') as {
+    Level: LevelAdapter
+  }
+  const adapters: LevelInstance[] = []
+  class CapturingLevel extends Level {
+    constructor(location: string, options: Record<string, unknown>) {
+      super(location, options)
+      adapters.push(this)
+    }
+  }
 
   // This is the user's real store: round-trip a throwaway probe doc, clear it,
   // and close cleanly (releasing the LevelDB LOCK for main). Never delete the
@@ -71,7 +116,28 @@ async function main(): Promise<void> {
   // unwinds nothing, so the only way to name the failing operation is to have
   // already said which one is starting.
   mark(PREFLIGHT_MARK_STORE_OPS.open)
-  const persistence = new LeveldbPersistence(probeDir)
+  const persistence = new LeveldbPersistence(probeDir, { Level: CapturingLevel })
+  const db = adapters[0]
+  if (!db) {
+    throw new Error('crdt-preflight: y-leveldb ignored the injected Level adapter')
+  }
+  // Open explicitly, before any y-leveldb call. Every y-leveldb method runs
+  // inside `_transact`, which catches, console.warns and resolves `null` — so a
+  // store that cannot be opened at all still walks through write and read
+  // markers and only dies later on a null dereference, with the real error
+  // (`IO error: lock <dir>/LOCK: already held by process`, `Corruption: ...`)
+  // never printed. Observed in the field on 2026.909.1. This is the one call
+  // whose rejection we can read.
+  try {
+    await db.open()
+  } catch (err) {
+    // writeSync for the same reason mark() uses it: this is the line the parent
+    // needs most, and a native abort microseconds later would eat a buffered
+    // stream write.
+    writeSync(2, `crdt-preflight: store open failed: ${describeErrorChain(err)}\n`)
+    throw err
+  }
+
   const doc = new Y.Doc()
   doc.getMap('probe').set('ok', true)
   mark(PREFLIGHT_MARK_STORE_OPS.write)
@@ -80,6 +146,14 @@ async function main(): Promise<void> {
 
   mark(PREFLIGHT_MARK_STORE_OPS.read)
   const loaded = await persistence.getYDoc(PROBE_DOC)
+  // `null`, not a doc, means `_transact` swallowed the real error into a warn
+  // line. Dereferencing it produced `TypeError: Cannot read properties of null`
+  // — a verdict that named neither the store nor the cause.
+  if (!loaded) {
+    throw new Error(
+      'crdt-preflight: store read returned null — y-leveldb swallowed a transaction error, see the lines above'
+    )
+  }
   loaded.destroy()
 
   mark(PREFLIGHT_MARK_STORE_OPS.clear)

--- a/apps/desktop/src/main/sync/crdt-preflight.test.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight.test.ts
@@ -143,6 +143,76 @@ describe('runCrdtPreflight', () => {
     expect(mockFork).toHaveBeenCalledTimes(2)
   })
 
+  /**
+   * `reason` is the only free text that reaches telemetry
+   * (crdt-persistence.ts), and "child exited with code 1" answers nothing. The
+   * child now prints the LevelDB error the y-leveldb transaction wrapper used
+   * to swallow, so the discriminating line has to survive into `reason`.
+   */
+  describe('failure reason', () => {
+    const LOCK_ERROR =
+      'crdt-preflight: store open failed: IO error: lock /home/ada/.config/Memry/crdt-store/LOCK: already held by process <- [LEVEL_DATABASE_NOT_OPEN] Database is not open'
+
+    async function failBothTransportsWith(line: string): Promise<string | undefined> {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.say(PREFLIGHT_MARK_STARTED)
+      child.say(PREFLIGHT_MARK_BINDING_LOADED)
+      child.say(PREFLIGHT_MARK_STORE_OPS.open)
+      child.emit('exit', 1)
+      await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled())
+      nodeChild.say(PREFLIGHT_MARK_STARTED)
+      nodeChild.say(PREFLIGHT_MARK_BINDING_LOADED)
+      nodeChild.say(PREFLIGHT_MARK_STORE_OPS.open)
+      nodeChild.say(line)
+      nodeChild.emit('exit', 1)
+      return (await pending).reason
+    }
+
+    it('carries the child’s LevelDB error alongside the exit code', async () => {
+      const reason = await failBothTransportsWith(LOCK_ERROR)
+
+      expect(reason).toContain('child exited with code 1')
+      expect(reason).toContain('already held by process')
+      expect(reason).toContain('LEVEL_DATABASE_NOT_OPEN')
+    })
+
+    it('strips absolute paths — the message ships, the user’s directory does not', async () => {
+      const reason = await failBothTransportsWith(LOCK_ERROR)
+
+      // The main redactor knows the vault root, not userData, so a store path
+      // in here would leave the device verbatim.
+      expect(reason).not.toContain('/home/ada')
+      expect(reason).not.toContain('crdt-store')
+      expect(reason).toContain('<path>')
+    })
+
+    it('strips Windows paths too', async () => {
+      const reason = await failBothTransportsWith(
+        'IO error: lock C:\\Users\\Ada\\AppData\\Roaming\\memry\\crdt-store\\LOCK: held'
+      )
+
+      expect(reason).not.toContain('C:\\Users')
+      expect(reason).toContain('<path>')
+    })
+
+    it('bounds the detail so a runaway line cannot become the telemetry payload', async () => {
+      const reason = await failBothTransportsWith(`Corruption: ${'x'.repeat(5000)}`)
+
+      expect(reason?.length).toBeLessThan(300)
+    })
+
+    it('ignores stage markers and stack frames when picking the line', async () => {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.say(PREFLIGHT_MARK_STARTED)
+      child.emit('exit', 1)
+      // Only a 'binding' failure so the node retry never runs.
+      const reason = (await pending).reason
+
+      // Markers are the only thing on stderr — nothing to attach.
+      expect(reason).toBe('child exited with code 1 (0x1)')
+    })
+  })
+
   // The child reports how far it got on stderr, because the exit code alone
   // cannot tell "the store aborted the binding" from "this machine cannot
   // start a utility process at all" (Windows 0xFFFF7003, crashpad init).

--- a/apps/desktop/src/main/sync/crdt-preflight.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight.ts
@@ -35,6 +35,31 @@ const PREFLIGHT_TIMEOUT_MS = 10_000
 // The interesting part of a native abort is the first crash banner; keep
 // enough of it to identify the failing subsystem in log aggregation.
 const STDERR_CAPTURE_CHARS = 4096
+// How much of the child's own error line rides along in `reason`. `reason` is
+// shipped as telemetry (crdt-persistence.ts), so it stays short.
+const REASON_DETAIL_CHARS = 200
+// Absolute paths, POSIX and Windows. The child's most useful line names the
+// store — `IO error: lock /home/<user>/.config/.../LOCK: already held by
+// process` — and the main redactor only knows the VAULT root, not userData, so
+// that path would ship verbatim. The message is the signal; the path is not.
+const ABSOLUTE_PATH = /(?:[A-Za-z]:\\|\/)[^\s'"]*[\\/][^\s'"]*/g
+
+/**
+ * The child's first real error line, bounded and path-free.
+ *
+ * Everything the child says is either a stage marker, an error line or a stack
+ * frame. The markers already become `stage`/`storeOp`, and stack frames name
+ * our own bundle, so the first line that is neither is the one carrying the
+ * LevelDB verdict.
+ */
+function firstErrorLine(stderr: string): string | undefined {
+  for (const raw of stderr.split('\n')) {
+    const line = raw.trim()
+    if (!line || line.startsWith('@@memry-preflight:') || line.startsWith('at ')) continue
+    return line.replace(ABSOLUTE_PATH, '<path>').slice(0, REASON_DETAIL_CHARS)
+  }
+  return undefined
+}
 
 export type { CrdtPreflightStage }
 
@@ -166,13 +191,23 @@ async function execPreflight(storeDir: string, transport: Transport): Promise<Cr
       return undefined
     }
 
-    /** A failure verdict, staged and attributed from whatever stderr carried. */
-    const failure = (reason: string): CrdtPreflightResult => ({
-      ok: false,
-      stage: stageFromMarkers(),
-      storeOp: storeOpFromMarkers(),
-      reason
-    })
+    /**
+     * A failure verdict, staged and attributed from whatever stderr carried.
+     *
+     * The exit code alone ("child exited with code 1") says nothing, so the
+     * child's own error line rides along: it is what tells a held LOCK apart
+     * from a corrupt store, and `reason` is the only part of this that reaches
+     * telemetry.
+     */
+    const failure = (reason: string): CrdtPreflightResult => {
+      const detail = firstErrorLine(stderr)
+      return {
+        ok: false,
+        stage: stageFromMarkers(),
+        storeOp: storeOpFromMarkers(),
+        reason: detail ? `${reason}: ${detail}` : reason
+      }
+    }
 
     const settle = (result: CrdtPreflightResult): void => {
       if (settled) return

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -220,6 +220,19 @@ store from a machine that cannot start a child at all:
 - `binding-in-use` — a `store` failure that reproduced against an empty
   directory. Not a marker the child can write; the provider assigns it (below).
 
+The markers name the failing operation, not its cause. y-leveldb opens its
+database lazily and runs every call inside a transaction wrapper that catches,
+warns and resolves `null` — so a store that could not be opened at all used to
+walk past the `write` and `read` markers and die on a null dereference, with the
+LevelDB error never printed anywhere. The child therefore hands y-leveldb its
+own level adapter, opens it **explicitly** right after the `open` marker, and
+prints the whole cause chain root cause first (`IO error: lock <dir>/LOCK:
+already held by process`, `Corruption: …`) — which is what tells a store held
+open by a previous process apart from a store that is genuinely damaged. The
+parent attaches that line to the failure `reason`, bounded and with absolute
+paths stripped, so it reaches the `CRDT_PERSISTENCE_UNAVAILABLE` telemetry event
+too.
+
 A `bootstrap` **or** `store` failure is retried once as a plain node child
 (`ELECTRON_RUN_AS_NODE`), which starts no Chromium and no crash handler. A
 verdict reported with `transport: node` therefore means the Chromium-free


### PR DESCRIPTION
## Summary

Diagnosis only. No change to quarantine, in-memory or control-probe decisions.

A user's `main.log` (2026-09-10, Linux/ChromeOS Crostini, 2026.909.1) logs `CRDT preflight child failed` for the real store on **every** launch, with this child stderr:

```
@@memry-preflight:started@@
@@memry-preflight:binding-loaded@@
@@memry-preflight:store-open@@
@@memry-preflight:store-write@@
Error during y-leveldb transaction ModuleError: Iterator is not open: cannot call nextv() after close()  { code: 'LEVEL_ITERATOR_NOT_OPEN' }
@@memry-preflight:store-read@@
Error during y-leveldb transaction ModuleError: Database is not open  { code: 'LEVEL_DATABASE_NOT_OPEN' }
TypeError: Cannot read properties of null (reading 'destroy')
    at main (.../crdt-preflight-child.js:50:10)
```

y-leveldb opens its database lazily and runs every call inside `_transact`, which catches, `console.warn`s and resolves `null`. So the underlying `db.open()` rejected, the child still walked past the `write` and `read` markers, `getYDoc()` handed back `null`, and the process died on `loaded.destroy()` with a `TypeError` that names neither the store nor the cause. The one line that matters — `IO error: lock <dir>/LOCK: already held by process` vs `Corruption: ...` — is never printed anywhere.

Meanwhile the parent's empty-directory control probe passes on every launch (no "fails on an empty directory too" warning in the log), so the binding is fine and the store gets quarantined every launch, piling up `.broken-<ts>` directories. The leading hypothesis is a LOCK still held by the previous app process, which never exited cleanly (every shutdown in that log ends in `forcing exit`, from an unrelated threadpool hang). This PR is what makes the next log answer that.

### Changes

- **Child** (`crdt-preflight-child.ts`): hand y-leveldb its own level adapter via the documented `{ Level }` option so the child keeps a reference, then `await db.open()` explicitly right after the `open` marker, before `store-write`. On rejection, `writeSync` the whole cause chain **root cause first** and exit non-zero. abstract-level wraps the real failure as `Database is not open (LEVEL_DATABASE_NOT_OPEN)` and puts the LevelDB text only in `cause`, so the informative end has to lead.
  The adapter is resolved *through* y-leveldb's own resolution (`createRequire(require.resolve('y-leveldb'))('level')`) — the repo carries two classic-level copies, and probing with a different native binding than the one y-leveldb will use proves nothing.
- **Child**: a `null` from `getYDoc()` is now a named error ("store read returned null — y-leveldb swallowed a transaction error, see the lines above") instead of a null dereference.
- **Parent** (`crdt-preflight.ts`): the first stderr line that is neither a stage marker nor a stack frame is attached to the failure `reason`, capped at 200 chars, with absolute paths replaced by `<path>`. `reason` is the only free text that reaches telemetry (`CRDT_PERSISTENCE_UNAVAILABLE`), and `getMainRedactOptions()` only knows the *vault* root — not `userData` — so the store path in a LOCK error would otherwise ship verbatim. `stage`/`storeOp` semantics unchanged; the existing `CRDT preflight child failed { ..., stderr }` line is untouched.

### Follow-up (not in this PR)

`settleStoreStageFailure` still quarantines a store whose only problem is a held LOCK: the control probe runs against a fresh empty directory, which opens fine, so the verdict comes back "the data is at fault" and the store is moved aside. If the next log confirms the lock hypothesis, that decision needs a lock-aware branch.

### Unverified

No Crostini repro — the lock-held hypothesis is what this change exists to confirm or refute from the next field log.

## Release note

none

## Test plan

- `pnpm --filter @memry/desktop typecheck:node` — clean
- `pnpm --filter @memry/desktop typecheck:test` — clean (both node and web projects)
- `vitest run --project main src/main/sync/crdt-preflight-child.test.ts src/main/sync/crdt-preflight.test.ts` — **40 passed**, including a new test that opens a real `ClassicLevel` on a temp dir, holds the LOCK, and asserts the child exits 1 with a stderr line naming the lock rather than a `TypeError`. That one loads the real y-leveldb + classic-level (needs `rebuild:node`) because the mocked tests cannot prove y-leveldb honours the injected adapter.
- `vitest run --project main src/main/sync/` — **171 files passed, 3020 tests**
- `eslint` on the four touched files — clean; `git diff --check` — clean
- `pnpm docs:impact --base origin/main --strict` — covered; `pnpm docs:build` — clean
