### PR TITLE
fix(secrets): serialize OS keychain calls so a wedged keyring costs one thread

### DIFF
--- a/apps/desktop/src/main/crypto/keychain.ts
+++ b/apps/desktop/src/main/crypto/keychain.ts
@@ -1,14 +1,16 @@
-import keytar from 'keytar'
 import sodium from 'libsodium-wrappers-sumo'
 
 import { KEYCHAIN_ENTRIES } from '@memry/contracts/crypto'
 import type { KeychainEntry } from '@memry/contracts/crypto'
 
 import {
+  deleteLegacySecret,
   deleteSecret,
   finalizeKeytarMigration,
   getSecret,
-  setSecret
+  readLegacySecret,
+  setSecret,
+  writeLegacySecret
 } from '../secrets/secret-storage'
 import { normalizeDeviceSuffix, resolveKeychainAccount } from './keychain-account'
 
@@ -22,6 +24,8 @@ function resolveAccount(entry: KeychainEntry): string {
 // file — stays per-worktree. Migrating out of keytar there would strand the
 // shared key for every other worktree, so plain `pnpm dev` keeps keytar
 // authoritative. Production (no MEMRY_DEVICE) and explicit devices migrate.
+// It still goes through secret-storage's OS keychain gateway so that it shares
+// the single-flight queue and the run-wide unavailability latch.
 function usesSharedDevKeychain(): boolean {
   return normalizeDeviceSuffix(process.env.MEMRY_DEVICE) === 'dev'
 }
@@ -67,7 +71,7 @@ export const storeKey = async (entry: KeychainEntry, key: Uint8Array): Promise<v
   const account = resolveAccount(entry)
   try {
     if (usesSharedDevKeychain()) {
-      await withTestTimeout(keytar.setPassword(entry.service, account, encoded), undefined)
+      await withTestTimeout(writeLegacySecret(entry.service, account, encoded), undefined)
     } else {
       await withTestTimeout(setSecret(entry.service, account, encoded), undefined)
     }
@@ -84,7 +88,7 @@ export const retrieveKey = async (entry: KeychainEntry): Promise<Uint8Array | nu
   let encoded: string | null
   try {
     if (usesSharedDevKeychain()) {
-      encoded = await withTestTimeout(keytar.getPassword(entry.service, account), null)
+      encoded = await withTestTimeout(readLegacySecret(entry.service, account), null)
     } else {
       // The master key's OS keychain copy is only dropped after the retrieved
       // key has been confirmed against the vault verifier — see
@@ -111,7 +115,7 @@ export const deleteKey = async (entry: KeychainEntry): Promise<void> => {
   const account = resolveAccount(entry)
   try {
     if (usesSharedDevKeychain()) {
-      await keytar.deletePassword(entry.service, account)
+      await deleteLegacySecret(entry.service, account)
     } else {
       await deleteSecret(entry.service, account)
     }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,5 +1,8 @@
-// First import on purpose: wires @memry/sync-client's logger/telemetry
-// facades before any extracted sync module can log.
+// First import on purpose: sizes the libuv threadpool before anything can use
+// it (see uv-threadpool.ts — libuv reads the env var once, on first use).
+import './uv-threadpool'
+// Second on purpose: wires @memry/sync-client's logger/telemetry facades
+// before any extracted sync module can log.
 import './sync/sync-client-runtime'
 import {
   app,

--- a/apps/desktop/src/main/secrets/secret-storage.test.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.test.ts
@@ -55,12 +55,15 @@ vi.mock('keytar', () => ({
 import {
   KEYCHAIN_READ_TIMEOUT_MS,
   SECRET_STORE_FILENAME,
+  deleteLegacySecret,
   deleteSecret,
   finalizeKeytarMigration,
   getSecret,
   isSafeStorageAvailable,
+  readLegacySecret,
   resetSecretStorageForTests,
-  setSecret
+  setSecret,
+  writeLegacySecret
 } from './secret-storage'
 
 const SERVICE = 'com.memry.test-service'
@@ -672,6 +675,120 @@ describe('secret-storage', () => {
       await expect(
         getSecret(SERVICE, ACCOUNT, { treatUnreadableAsAbsent: true })
       ).resolves.toBeNull()
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // OS keychain single flight
+  //
+  // The deadline above frees our promise, never the native thread: a keytar
+  // call wedged in libsecret keeps its libuv threadpool thread for the rest of
+  // the process. Only one call may therefore be in flight at a time, so a dead
+  // Secret Service costs one thread per run instead of the whole pool.
+  // --------------------------------------------------------------------------
+
+  describe('OS keychain single flight', () => {
+    const hangForever = (): Promise<string | null> => new Promise<string | null>(() => {})
+    // Real-timer microtask/macrotask drain: the queue hands control over with
+    // .then, so nothing reaches keytar synchronously.
+    const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+    afterEach(() => {
+      vi.useRealTimers()
+      harness.keytarGet.mockImplementation(
+        async (s: string, a: string) => harness.keytarStore.get(`${s}:${a}`) ?? null
+      )
+    })
+
+    it('shares one native call between concurrent reads of the same entry', async () => {
+      let release: (value: string | null) => void = () => {}
+      harness.keytarGet.mockImplementation(
+        () =>
+          new Promise<string | null>((resolve) => {
+            release = resolve
+          })
+      )
+
+      const first = readLegacySecret(SERVICE, ACCOUNT)
+      const second = readLegacySecret(SERVICE, ACCOUNT)
+      await flush()
+
+      expect(harness.keytarGet).toHaveBeenCalledTimes(1)
+      release('shared')
+      await expect(first).resolves.toBe('shared')
+      await expect(second).resolves.toBe('shared')
+
+      // The dedup entry is dropped once the call settles, so a later read is
+      // a fresh native call rather than a cached value.
+      harness.keytarGet.mockResolvedValueOnce('fresh')
+      await expect(readLegacySecret(SERVICE, ACCOUNT)).resolves.toBe('fresh')
+      expect(harness.keytarGet).toHaveBeenCalledTimes(2)
+    })
+
+    it('serializes reads of different entries', async () => {
+      const started: string[] = []
+      const gates = new Map<string, () => void>()
+      harness.keytarGet.mockImplementation(
+        (_service: string, account: string) =>
+          new Promise<string | null>((resolve) => {
+            started.push(account)
+            gates.set(account, () => resolve(`value:${account}`))
+          })
+      )
+
+      const first = readLegacySecret(SERVICE, 'account-a')
+      const second = readLegacySecret(SERVICE, 'account-b')
+      await flush()
+
+      expect(started).toEqual(['account-a'])
+
+      gates.get('account-a')!()
+      await expect(first).resolves.toBe('value:account-a')
+      await flush()
+
+      expect(started).toEqual(['account-a', 'account-b'])
+      gates.get('account-b')!()
+      await expect(second).resolves.toBe('value:account-b')
+    })
+
+    it('rejects a read queued behind a hung one without a second native call', async () => {
+      vi.useFakeTimers()
+      harness.keytarGet.mockImplementation(hangForever)
+
+      const first = readLegacySecret(SERVICE, ACCOUNT).catch((err: Error) => err.name)
+      const queued = readLegacySecret(SERVICE, 'other-account').catch((err: Error) => err.name)
+
+      await vi.advanceTimersByTimeAsync(KEYCHAIN_READ_TIMEOUT_MS)
+
+      await expect(first).resolves.toBe('KeychainUnavailableError')
+      await expect(queued).resolves.toBe('KeychainUnavailableError')
+      expect(harness.keytarGet).toHaveBeenCalledTimes(1)
+    })
+
+    it('refuses writes and deletes once the keychain has latched', async () => {
+      vi.useFakeTimers()
+      harness.keytarGet.mockImplementation(hangForever)
+      const first = readLegacySecret(SERVICE, ACCOUNT).catch((err: Error) => err.name)
+      await vi.advanceTimersByTimeAsync(KEYCHAIN_READ_TIMEOUT_MS)
+      await expect(first).resolves.toBe('KeychainUnavailableError')
+
+      await expect(writeLegacySecret(SERVICE, ACCOUNT, 'value')).rejects.toThrow(/keychain/i)
+      await expect(deleteLegacySecret(SERVICE, ACCOUNT)).rejects.toThrow(/keychain/i)
+      expect(harness.keytarSet).not.toHaveBeenCalled()
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+    })
+
+    it('still deletes the safeStorage copy when the keychain has latched', async () => {
+      await setSecret(SERVICE, ACCOUNT, 'value')
+
+      vi.useFakeTimers()
+      harness.keytarGet.mockImplementation(hangForever)
+      const first = readLegacySecret(SERVICE, 'probe').catch((err: Error) => err.name)
+      await vi.advanceTimersByTimeAsync(KEYCHAIN_READ_TIMEOUT_MS)
+      await expect(first).resolves.toBe('KeychainUnavailableError')
+
+      await expect(deleteSecret(SERVICE, ACCOUNT)).resolves.toBeUndefined()
+      expect(readStoreJson().entries[SERVICE]?.[ACCOUNT]).toBeUndefined()
     })
   })
 })

--- a/apps/desktop/src/main/secrets/secret-storage.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.ts
@@ -80,13 +80,39 @@ export class KeychainUnavailableError extends Error {
   }
 }
 
-async function readLegacySecret(service: string, account: string): Promise<string | null> {
-  if (keychainTimedOut) throw new KeychainUnavailableError(service, account, 'latched')
+// The deadline above only settles OUR promise. keytar runs on a Napi
+// AsyncWorker, so the native call keeps sitting inside libsecret on a libuv
+// threadpool thread that nothing can reclaim — that thread is gone for the rest
+// of the process. Startup issues several keychain reads at once (the sync
+// runtime's refresh token, the Google Calendar sign-in probe, the telemetry
+// access token), so by the time the first deadline fires and flips the latch,
+// three of the four threads are already burned and the app is one fs read away
+// from the same deadlock.
+//
+// So: at most ONE keytar call is in flight process-wide. Concurrent reads of
+// the same service/account share the in-flight promise; every other call queues
+// behind it and re-checks the latch when its turn comes, rejecting without
+// touching keytar. A wedged Secret Service can therefore cost at most one
+// threadpool thread per run.
+let keytarQueue: Promise<unknown> = Promise.resolve()
+const inFlightKeychainReads = new Map<string, Promise<string | null>>()
+
+function withKeychainDeadline<T>(
+  service: string,
+  account: string,
+  call: () => Promise<T>
+): Promise<T> {
+  // Promise.resolve, not the raw return value: unit tests mock keytar with
+  // plain vi.fn()s that return undefined.
+  const pending = Promise.resolve(call())
+  // We stop waiting; the native call does not. Keep a handler on it so a late
+  // rejection can never surface as an unhandled rejection.
+  void pending.catch(() => {})
   let timer: ReturnType<typeof setTimeout> | undefined
   const deadline = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
       keychainTimedOut = true
-      logger.warn('OS keychain read timed out; skipping the OS keychain for the rest of this run', {
+      logger.warn('OS keychain call timed out; skipping the OS keychain for the rest of this run', {
         service,
         account,
         timeoutMs: KEYCHAIN_READ_TIMEOUT_MS
@@ -94,11 +120,56 @@ async function readLegacySecret(service: string, account: string): Promise<strin
       reject(new KeychainUnavailableError(service, account, 'timeout'))
     }, KEYCHAIN_READ_TIMEOUT_MS)
   })
-  try {
-    return await Promise.race([keytar.getPassword(service, account), deadline])
-  } finally {
-    clearTimeout(timer)
+  return Promise.race([pending, deadline]).finally(() => clearTimeout(timer))
+}
+
+/**
+ * Run one keytar operation, serialized process-wide and bounded by the
+ * deadline. The queue advances when the deadline settles, never when the native
+ * call does — a wedged libsecret call never settles, and waiting on it would
+ * wedge the queue as well.
+ */
+function runKeytarOp<T>(service: string, account: string, op: () => Promise<T>): Promise<T> {
+  if (keychainTimedOut) {
+    return Promise.reject(new KeychainUnavailableError(service, account, 'latched'))
   }
+  const run = keytarQueue.then(() => {
+    // The call ahead of us in the queue may have latched in the meantime.
+    if (keychainTimedOut) throw new KeychainUnavailableError(service, account, 'latched')
+    return withKeychainDeadline(service, account, op)
+  })
+  keytarQueue = run.then(
+    () => undefined,
+    () => undefined
+  )
+  return run
+}
+
+/**
+ * Read the OS keychain. Reads are idempotent, so concurrent callers for the
+ * same entry share one native call instead of queueing behind each other.
+ */
+export function readLegacySecret(service: string, account: string): Promise<string | null> {
+  const key = cleanupKey(service, account)
+  const existing = inFlightKeychainReads.get(key)
+  if (existing) return existing
+  const run = runKeytarOp(service, account, () => keytar.getPassword(service, account))
+  inFlightKeychainReads.set(key, run)
+  const clear = (): void => {
+    if (inFlightKeychainReads.get(key) === run) inFlightKeychainReads.delete(key)
+  }
+  run.then(clear, clear)
+  return run
+}
+
+/** Write to the OS keychain through the shared single-flight queue. */
+export function writeLegacySecret(service: string, account: string, value: string): Promise<void> {
+  return runKeytarOp(service, account, () => keytar.setPassword(service, account, value))
+}
+
+/** Delete from the OS keychain through the shared single-flight queue. */
+export function deleteLegacySecret(service: string, account: string): Promise<boolean> {
+  return runKeytarOp(service, account, () => keytar.deletePassword(service, account))
 }
 
 const cleanupKey = (service: string, account: string): string => `${service}\u0000${account}`
@@ -109,6 +180,8 @@ export function resetSecretStorageForTests(): void {
   keytarMigrationFinalized.clear()
   loggedPlaintextBackend = false
   keychainTimedOut = false
+  keytarQueue = Promise.resolve()
+  inFlightKeychainReads.clear()
 }
 
 // ---------------------------------------------------------------------------
@@ -376,7 +449,7 @@ export async function setSecret(service: string, account: string, value: string)
       // The safeStorage copy is now authoritative; drop any stale OS keychain
       // copy so the read fallback can never resurrect an outdated secret.
       try {
-        await keytar.deletePassword(service, account)
+        await deleteLegacySecret(service, account)
       } catch (err) {
         logger.warn('Could not remove stale OS keychain copy after write', {
           error: err,
@@ -399,7 +472,7 @@ export async function setSecret(service: string, account: string, value: string)
     }
   }
 
-  await keytar.setPassword(service, account, value)
+  await writeLegacySecret(service, account, value)
 }
 
 export async function deleteSecret(service: string, account: string): Promise<void> {
@@ -407,8 +480,18 @@ export async function deleteSecret(service: string, account: string): Promise<vo
   // from scratch, so drop any "migration complete" verdict for it.
   keytarMigrationFinalized.delete(cleanupKey(service, account))
   // Keytar first: it was the pre-migration source of truth and its errors are
-  // what call sites historically surfaced.
-  await keytar.deletePassword(service, account)
+  // what call sites historically surfaced. A keychain that is wedged or already
+  // latched is the one exception — sign-out must not hang or fail on it, and
+  // the safeStorage copy removed below is the authoritative one.
+  try {
+    await deleteLegacySecret(service, account)
+  } catch (err) {
+    if (!(err instanceof KeychainUnavailableError)) throw err
+    logger.warn('OS keychain unavailable; deleting the safeStorage copy only', {
+      service,
+      account
+    })
+  }
   // Store removal only needs the userData path, not encryption availability.
   const filePath = resolveStoreFilePath()
   if (filePath) removeCiphertext(filePath, service, account)
@@ -439,7 +522,7 @@ export async function finalizeKeytarMigration(service: string, account: string):
       return
     }
     if (legacy === value) {
-      await keytar.deletePassword(service, account)
+      await deleteLegacySecret(service, account)
       keytarMigrationFinalized.add(cleanupKey(service, account))
       logger.info('Removed confirmed migrated secret from OS keychain', { service, account })
     }
@@ -519,7 +602,7 @@ async function migrateLegacySecret(
   }
 
   try {
-    await keytar.deletePassword(service, account)
+    await deleteLegacySecret(service, account)
     logger.info('Migrated secret from OS keychain to safeStorage', { service, account })
   } catch (err) {
     // The safeStorage copy is verified; a lingering keytar copy is harmless
@@ -617,7 +700,7 @@ async function cleanupLegacyKeytarCopy(
   try {
     const legacy = await readLegacySecret(service, account)
     if (legacy !== null && legacy === expected) {
-      await keytar.deletePassword(service, account)
+      await deleteLegacySecret(service, account)
       logger.info('Removed migrated secret from OS keychain', { service, account })
     }
   } catch (err) {

--- a/apps/desktop/src/main/uv-threadpool.ts
+++ b/apps/desktop/src/main/uv-threadpool.ts
@@ -1,0 +1,28 @@
+// Must be the FIRST module the main process executes. libuv reads
+// UV_THREADPOOL_SIZE once, when the pool is lazily created on its first use, so
+// setting it after any async fs / zlib / crypto / dns / keytar work has started
+// is a no-op.
+//
+// Why: keytar runs on that pool, and on a machine whose Secret Service is
+// registered on D-Bus but never answers (a ChromeOS Crostini container with a
+// locked gnome-keyring collection and no prompter), a keychain read never
+// returns and its thread is gone for the rest of the process. With the default
+// of 4, a handful of startup keychain reads was enough to starve the pool, and
+// from then on every fs/promises call in the main process — journal entries,
+// file pages, project folders, the shutdown snapshot flush — never resolved.
+// sqlite is synchronous and kept working, so the app looked healthy.
+//
+// The real guard is the single-flight queue plus the unavailability latch in
+// secrets/secret-storage.ts, which caps a wedged keychain at one burned thread
+// per run. This only widens the margin for everything else that shares the
+// pool.
+//
+// Verified under Electron 43 on macOS, measured on the real production main
+// bundle (every vendor require ahead of this statement already executed): 12
+// concurrent ~1 s pbkdf2 calls run ~2.9-3.5 threads wide without it and
+// ~5.7-7.6 threads wide with it.
+if (!process.env.UV_THREADPOOL_SIZE) {
+  process.env.UV_THREADPOOL_SIZE = '16'
+}
+
+export {}

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -118,6 +118,22 @@ inside libsecret, and each blocked call held one of libuv's four threadpool thre
 them stuck, every `fs/promises` read in the app — journal entries, file pages, project folders —
 stalled behind the keychain.
 
+The timeout alone was not enough. It settles our promise; it cannot free the native thread, because
+`keytar` runs on a Napi `AsyncWorker` that stays parked inside libsecret. Startup issues several
+keychain reads at once (the sync runtime's refresh token, the Google Calendar sign-in probe, the
+telemetry access token), so three threads were already burned before the first deadline fired. So
+every OS keychain call — read, write and delete alike, from `secret-storage.ts` and from the shared
+`dev` keychain path in `crypto/keychain.ts` — goes through one process-wide single-flight queue.
+Concurrent reads of the same service/account share the in-flight promise; everything else waits, and
+a queued call re-checks the latch when its turn comes and rejects without touching `keytar`. A dead
+Secret Service therefore costs exactly one threadpool thread per run. Deleting a secret tolerates a
+latched keychain so sign-out cannot hang on it; the authoritative safeStorage copy is still removed.
+
+`main/uv-threadpool.ts`, the first module the main process executes, raises `UV_THREADPOOL_SIZE` to
+16 unless the environment already sets it. libuv reads that variable once, when the pool is created
+on first use, so it has to run before any async fs / zlib / crypto / keytar work. This only widens
+the margin for everything else sharing the pool — the single-flight queue is the actual guard.
+
 A legacy secret migrates lazily on first read: encrypt, persist, decrypt round-trip verify
 byte-identical against the source, and only then delete the OS keychain copy. Any verification
 failure keeps the OS keychain authoritative. The vault master key goes one step further — its OS

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -666,6 +666,12 @@ through `boundedNetFetch` (`telemetry/bounded-net-fetch.ts`) with a 30 s abort d
 still in flight when Chromium's network service dies never settles on its own, and a flush loop
 awaiting it would otherwise stall for the rest of the run with every later batch queued behind it.
 
+The keychain side of that hang is bounded twice over: OS keychain calls are serialized through one
+process-wide single-flight queue with a run-wide unavailability latch, so a wedged Secret Service
+can burn at most one libuv threadpool thread instead of all four, and the main process raises
+`UV_THREADPOOL_SIZE` to 16 before anything can use the pool. See
+[Cryptography](./cryptography.md).
+
 ### Autosave Event Throttling
 
 `note_updated` and `journal_updated` events fired by the autosave path are throttled to at most


### PR DESCRIPTION
## Summary
Follow-up to #2128. That PR bounded the OS keychain read at 5 s and latched the keychain off for the rest of the run after a timeout. The bound was necessary but not sufficient.

### Verified mechanism
Install `4c40bad24708`, Linux / ChromeOS Crostini. gnome-keyring's Secret Service is registered on D-Bus but never answers (locked collection, no prompter), so `keytar.getPassword` blocks indefinitely. keytar runs on a Napi `AsyncWorker`, i.e. the libuv threadpool (4 threads by default). Startup issues keychain reads from several places concurrently: sync runtime start (`retrieveKey('refresh-token')`), the Google Calendar runner (`isMemryUserSignedIn`), the telemetry client's token lookup, later the incident-report token lookup. Within ~1 minute all 4 threads are parked inside libsecret, and from then on every `fs/promises` call in the main process never resolves: `readJournalEntry`, file page reads, project/collection folder reads, `safeRead` in the close-snapshots shutdown step. better-sqlite3 is synchronous and keeps working, so the sidebar and settings look healthy while the journal, file and project pages never load. Telemetry flush and "Send a diagnostic report" hang because they look up the access token first.

Evidence from the user's `main.log`:
- On 903.2, before the update, 10 Sep 09:43: the `close-snapshots` shutdown step, a plain `fs.promises.readFile`, ran out of its 8 s budget. The hang predates the update.
- On 909.1: all 5 shutdowns ran `flush-telemetry` out of budget and ended in `forcing exit`.
- On 8 Sep the same machine had no secret service at all; keytar failed fast within 1.5 s (`org.freedesktop.secrets was not provided`, `Unknown or unsupported transport 'disabled'`) and everything worked. Present-but-unresponsive is worse than absent.

### Why the timeout alone was insufficient
`Promise.race` rejects our promise after 5 s; it cannot free the native thread, which stays parked inside libsecret for the life of the process. Every keytar call issued before the latch flips permanently burns one of the 4 threads. Three go out concurrently at startup, so three threads can be gone before the first timeout fires, leaving the app one fs read away from the same deadlock the timeout was meant to prevent.

### What changed
- **Single-flight keychain queue** (`secrets/secret-storage.ts`): at most one `keytar.*` call in flight process-wide. Concurrent reads of the same service/account share the in-flight promise; everything else queues. A queued call re-checks the latch on its turn and rejects with `KeychainUnavailableError('latched')` without touching keytar. The queue advances on the deadline, never on the native call. Covers `getPassword`, `setPassword`, `deletePassword`; `secret-storage.ts` is now the only module in `apps/desktop/src` that references `keytar.*`.
- **`crypto/keychain.ts`**: the shared-`dev`-keychain path called keytar directly and bypassed both queue and latch. Rerouted through the gateway.
- **`deleteSecret`** tolerates a latched keychain instead of throwing, so sign-out cannot hang or fail on it; the authoritative safeStorage copy is still removed.
- **`main/uv-threadpool.ts`**: raises `UV_THREADPOOL_SIZE` to 16 (respecting an existing value) as the first module the main process executes. libuv reads the variable once, when the pool is created on first use. Second line of defence only; single-flight is the real guard.
- Already on main from #2128: 5 s read timeout + run-wide latch, telemetry token lookup only when `signed_in`, 30 s abort deadline on telemetry `net.fetch`.

### Verification
- `UV_THREADPOOL_SIZE` measured on the real production main bundle prefix under Electron 43 / macOS (all vendor requires already executed). 12 concurrent ~1 s `pbkdf2` calls: 4229 / 2477 / 3450 ms without, 1970 / 1342 / 2111 ms with; effective width 2.9–3.5 → 5.7–7.6 threads.
- `vitest --project main src/main/secrets`: 3 files, 74 tests. 5 new cases: same-key dedup, cross-key serialization, a read queued behind a hung one rejecting with keytar called once, writes/deletes refused after the latch, `deleteSecret` still clearing the safeStorage copy when latched.
- Full `vitest --project main`: 580 files, 8131 tests, 8124 passed / 1 expected fail / 6 skipped.
- `typecheck:node`, `typecheck:test`, eslint on touched files, `git diff --check`, `docs:impact --base origin/main --strict` (covered), `docs:build`, production `electron-vite build`.

### Not verified
- No repro on a machine without a working Secret Service. The mechanism is reasoned from the code, the 10 Sep `main.log` and the threadpool measurements.
- No test can assert that the native thread is or isn't freed; the tests pin the JS-side invariant (at most one keytar call reaches the mock).
- `16` is a judgement call, not a tuned value.
