### PR TITLE
fix(desktop): let a wiki link name a canvas

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-broken.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-broken.test.tsx
@@ -13,6 +13,7 @@ import { WIKI_LINK_BROKEN_PLUGIN_KEY, createWikiLinkBrokenPlugin } from '../wiki
 
 const mocks = vi.hoisted(() => ({
   resolveTitles: vi.fn<(titles: string[]) => Promise<Record<string, unknown>>>(),
+  listCanvases: vi.fn<() => Promise<{ canvases: Array<{ id: string; title: string | null }> }>>(),
   createdCallbacks: [] as Array<() => void>,
   renamedCallbacks: [] as Array<() => void>,
   deletedCallbacks: [] as Array<() => void>
@@ -34,6 +35,16 @@ vi.mock('@/services/notes-service', () => ({
   }
 }))
 
+vi.mock('@/services/canvas-service', () => ({
+  canvasService: { list: () => mocks.listCanvases() },
+  onCanvasCreated: () => () => {},
+  onCanvasUpdated: () => () => {},
+  onCanvasDeleted: () => () => {}
+}))
+
+vi.mock('@/lib/logger', () => ({ createLogger: () => ({ error: vi.fn(), warn: vi.fn() }) }))
+
+import { clearCanvasLookupCache } from '@/lib/canvas-lookup'
 import { useWikiLinkBroken } from './use-wiki-link-broken'
 
 const schema = new Schema({
@@ -99,6 +110,9 @@ describe('useWikiLinkBroken', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     mocks.resolveTitles.mockReset()
+    mocks.listCanvases.mockReset()
+    mocks.listCanvases.mockResolvedValue({ canvases: [] })
+    clearCanvasLookupCache()
     mocks.createdCallbacks.length = 0
     mocks.renamedCallbacks.length = 0
     mocks.deletedCallbacks.length = 0
@@ -152,5 +166,18 @@ describe('useWikiLinkBroken', () => {
 
     expect(mocks.resolveTitles).toHaveBeenCalledTimes(2)
     expect(brokenTargetsOf(editor._tiptapEditor.view.state)).toEqual([])
+  })
+
+  it('does not paint a canvas link broken (#1983)', async () => {
+    mocks.resolveTitles.mockResolvedValue({ 'Sprint Board': null, Ghost: null })
+    mocks.listCanvases.mockResolvedValue({
+      canvases: [{ id: 'canvas-1', title: 'Sprint Board' }]
+    })
+    const editor = editorWith(['Sprint Board', 'Ghost'])
+
+    renderHook(() => useWikiLinkBroken(editor))
+    await flushResolve()
+
+    expect(brokenTargetsOf(editor._tiptapEditor.view.state)).toEqual(['Ghost'])
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-broken.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-broken.ts
@@ -7,6 +7,9 @@
  * Targets that resolve to nothing become the plugin's broken set, painted as
  * `.wiki-link-broken` (see `wiki-link-broken-plugin.ts`).
  *
+ * A target no note claims is asked of the canvas list before it is called
+ * broken, because a canvas is a link target too (#1983).
+ *
  * Resolution order per target matches the click path: the note half of
  * `[[Note#Heading]]` first, the raw string second — so a note literally named
  * `Sprint #4` is not marked broken. `[[#Heading]]` addresses the note it is
@@ -23,6 +26,8 @@ import { useEffect } from 'react'
 import type { EditorView } from '@tiptap/pm/view'
 import { splitWikiTarget } from '@memry/shared/wiki-target'
 import { notesService, onNoteCreated, onNoteDeleted, onNoteRenamed } from '@/services/notes-service'
+import { clearCanvasLookupCache, resolveCanvasByTitle } from '@/lib/canvas-lookup'
+import { onCanvasCreated, onCanvasDeleted, onCanvasUpdated } from '@/services/canvas-service'
 import { registerEditorPlugin } from '../register-editor-plugin'
 import { getLiveTiptapView } from '../live-prosemirror-view'
 import {
@@ -87,6 +92,17 @@ export function useWikiLinkBroken(editor: unknown): void {
           return
         }
         if (cancelled) return
+
+        // A canvas is a link target too (#1983), and the note index has never
+        // heard of one — without this pass every working `[[My Canvas]]` would
+        // be painted broken. Asked only about titles no note claimed, so the
+        // common case costs nothing.
+        for (const title of unknown) {
+          if (resolvedCache.get(title.toLowerCase()) === true) continue
+          const canvas = await resolveCanvasByTitle(title)
+          if (canvas) resolvedCache.set(title.toLowerCase(), true)
+        }
+        if (cancelled) return
       }
 
       const broken = new Set<string>()
@@ -111,6 +127,7 @@ export function useWikiLinkBroken(editor: unknown): void {
 
     const forceRefresh = (): void => {
       resolvedCache.clear()
+      clearCanvasLookupCache()
       scheduleRefresh()
     }
 
@@ -119,7 +136,10 @@ export function useWikiLinkBroken(editor: unknown): void {
     const unsubscribes = [
       onNoteCreated(forceRefresh),
       onNoteRenamed(forceRefresh),
-      onNoteDeleted(forceRefresh)
+      onNoteDeleted(forceRefresh),
+      onCanvasCreated(forceRefresh),
+      onCanvasUpdated(forceRefresh),
+      onCanvasDeleted(forceRefresh)
     ]
 
     return () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.test.tsx
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   listNotes: vi.fn(),
   getFile: vi.fn(),
   getByPath: vi.fn(),
+  listCanvases: vi.fn(),
   logger: {
     error: vi.fn()
   }
@@ -19,15 +20,23 @@ vi.mock('@/services/notes-service', () => ({
   }
 }))
 
+vi.mock('@/services/canvas-service', () => ({
+  canvasService: { list: (...args: unknown[]) => mocks.listCanvases(...args) }
+}))
+
 vi.mock('@/lib/logger', () => ({
   createLogger: () => mocks.logger
 }))
 
+import { clearCanvasLookupCache } from '@/lib/canvas-lookup'
+
 describe('useWikiLinkSuggestions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    clearCanvasLookupCache()
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-10T12:00:00.000Z'))
+    mocks.listCanvases.mockResolvedValue({ canvases: [] })
     mocks.listNotes.mockResolvedValue({
       notes: [
         {
@@ -401,6 +410,53 @@ describe('useWikiLinkSuggestions', () => {
         [{ type: 'wikiLink', props: { target: 'Daily Note#Kararlar alındı', alias: 'dün' } }],
         { updateSelection: true }
       )
+    })
+  })
+
+  describe('canvases (#1983)', () => {
+    it('offers canvases below notes and drops the create row on an exact canvas', async () => {
+      mocks.listCanvases.mockResolvedValue({
+        canvases: [
+          { id: 'canvas-1', title: 'Roadmap Board' },
+          { id: 'canvas-2', title: null }
+        ]
+      })
+      const editor = { insertInlineContent: vi.fn() }
+      const { result } = renderHook(() => useWikiLinkSuggestions(editor))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Roadmap')
+      })
+
+      // The note keeps the top of the list; the canvas is a row of its own, and
+      // the untitled canvas has no target so it is never offered.
+      expect(items.map((item) => [item.type, item.target])).toEqual([
+        ['note', 'Roadmap'],
+        ['canvas', 'Roadmap Board']
+      ])
+
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Roadmap Board')
+      })
+      expect(items.map((item) => item.type)).toEqual(['canvas'])
+    })
+
+    it('commits an alias against an exact canvas name', async () => {
+      mocks.listCanvases.mockResolvedValue({
+        canvases: [{ id: 'canvas-1', title: 'Sprint Board' }]
+      })
+      const editor = { insertInlineContent: vi.fn() }
+      const { result } = renderHook(() => useWikiLinkSuggestions(editor))
+
+      let items = [] as Awaited<ReturnType<typeof result.current.getWikiLinkItems>>
+      await act(async () => {
+        items = await result.current.getWikiLinkItems('Sprint Board | the board')
+      })
+
+      expect(items).toEqual([
+        expect.objectContaining({ type: 'alias', target: 'Sprint Board', alias: 'the board' })
+      ])
     })
   })
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.ts
@@ -6,6 +6,7 @@ import { isBlockReference } from '@memry/shared/wiki-target'
 import { fuzzySearch } from '@/lib/fuzzy-search'
 import { toMemryFileUrl } from '@/lib/memry-file-url'
 import { notesService } from '@/services/notes-service'
+import { listTitledCanvases } from '@/lib/canvas-lookup'
 import { createWikiLinkInlineContent } from '../wiki-link'
 import { parseWikiLinkQuery, pickAlias } from '../wiki-link-utils'
 import { activeRunWikiLink, replaceActiveRunWithWikiLink } from '../wiki-link-edit-plugin'
@@ -175,14 +176,31 @@ export function useWikiLinkSuggestions(editor: any) {
 
       const filtered = search ? fuzzySearch(notes, search, ['title']) : notes
 
+      // Canvases are vault items the same way notes are, and the menu is the
+      // only place a writer discovers one while writing (#1983). Untitled ones
+      // are left out: they have no target a link could carry.
+      const canvases = await listTitledCanvases()
+      const filteredCanvases = search ? fuzzySearch(canvases, search, ['title']) : canvases
+
       const exactNote = search
         ? filtered.find((note) => note.title.toLowerCase() === search.toLowerCase())
+        : undefined
+      const exactCanvas = search
+        ? filteredCanvases.find((canvas) => canvas.title.toLowerCase() === search.toLowerCase())
         : undefined
       if (alias && exactNote) {
         return [aliasRow(exactNote.title, alias)]
       }
+      if (alias && exactCanvas) {
+        return [aliasRow(exactCanvas.title, alias)]
+      }
 
-      const sorted = filtered.slice(0, 10)
+      // Notes keep the top of the list — they are what the grammar has always
+      // been for, and the resolver reads them first too. A few slots are held
+      // back for canvases, so a vault whose notes fill the menu on their own
+      // does not hide every canvas the query matched.
+      const canvasSlots = Math.min(filteredCanvases.length, 3)
+      const sorted = filtered.slice(0, 10 - canvasSlots)
 
       const suggestions: WikiLinkSuggestionItem[] = sorted.map((note) => ({
         id: note.id,
@@ -197,7 +215,18 @@ export function useWikiLinkSuggestions(editor: any) {
         ...(note.fileSize != null ? { fileSize: note.fileSize } : {})
       }))
 
-      const hasExactMatch = search ? Boolean(exactNote) : true
+      for (const canvas of filteredCanvases.slice(0, Math.max(0, 10 - suggestions.length))) {
+        suggestions.push({
+          id: canvas.id,
+          title: canvas.title,
+          target: canvas.title,
+          alias,
+          exists: true,
+          type: 'canvas'
+        })
+      }
+
+      const hasExactMatch = search ? Boolean(exactNote ?? exactCanvas) : true
 
       if (search && !hasExactMatch) {
         // The row names the note that will actually be created, which is the

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.tsx
@@ -3,7 +3,7 @@
  */
 
 import type { SuggestionMenuProps } from '@blocknote/react'
-import { FileAudio, FileText, Hash, Plus, Type } from '@/lib/icons'
+import { FileAudio, FileText, Hash, PenTool, Plus, Type } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
 
@@ -23,8 +23,10 @@ export type WikiLinkSuggestionItem = {
    * over the `#`, and it carries no target, so picking it does nothing.
    * `alias` is the whole menu once both halves of `[[target|alias]]` are
    * settled: one row that commits the display name.
+   * `canvas` is a spatial canvas — a vault item with no headings and no
+   * embed form, so it is a plain row with the canvas icon (#1983).
    */
-  type: 'note' | 'create' | 'heading' | 'headingEmpty' | 'alias'
+  type: 'note' | 'canvas' | 'create' | 'heading' | 'headingEmpty' | 'alias'
   lastEdited?: string
   fileType?: WikiLinkFileType
   mimeType?: string | null
@@ -208,6 +210,9 @@ export function WikiLinkMenu({
             aria-selected={isSelected}
           >
             {item.type === 'create' ? <Plus className="mt-0.5 h-4 w-4 shrink-0" /> : null}
+            {item.type === 'canvas' ? (
+              <PenTool className="h-4 w-4 shrink-0 opacity-70" aria-hidden />
+            ) : null}
             <div className="flex min-w-0 flex-1 flex-col gap-0.5 text-start">
               {item.type === 'create' ? (
                 <>

--- a/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
+++ b/apps/desktop/src/renderer/src/components/note/mind-map/mind-map-view.tsx
@@ -99,7 +99,12 @@ async function resolveWikiHrefs(
   await Promise.all(
     targets.map(async (target) => {
       const resolved = await resolveWikiLink(target).catch(() => null)
-      if (!resolved || (resolved.type !== 'note' && resolved.type !== 'file')) return
+      if (
+        !resolved ||
+        (resolved.type !== 'note' && resolved.type !== 'file' && resolved.type !== 'canvas')
+      ) {
+        return
+      }
 
       const href = buildMemryHref({
         kind: resolved.type,

--- a/apps/desktop/src/renderer/src/components/sidebar/canvas-tree/canvas-row.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/canvas-tree/canvas-row.tsx
@@ -25,6 +25,7 @@ import {
   ExternalLink,
   FolderInput,
   FolderOpen,
+  Link,
   PenTool,
   Pencil,
   Smile,
@@ -106,6 +107,8 @@ export function CanvasRow({
   const menus = useRowMenuState()
 
   const title = canvas.title || t('canvas.untitled')
+  /** What `[[…]]` would carry for this canvas; empty when it has no title. */
+  const linkTarget = canvas.title?.trim() ?? ''
   const unreadable = canvas.unreadable === true
 
   const revealEntry: CanvasMenuEntry = {
@@ -164,6 +167,23 @@ export function CanvasRow({
           icon: Copy,
           onSelect: () => onDuplicate(canvas)
         },
+        // The wiki link itself, not the file path: a path resolves to nothing in
+        // the editor, and what the writer wants is something they can paste into
+        // a note and click (#1983). Left out for an untitled canvas, which has no
+        // target a link could carry.
+        ...(linkTarget
+          ? [
+              {
+                kind: 'item' as const,
+                id: 'copy-link',
+                label: t('canvas.actions.copyLink'),
+                icon: Link,
+                onSelect: () => {
+                  void navigator.clipboard.writeText(`[[${linkTarget}]]`)
+                }
+              }
+            ]
+          : []),
         { kind: 'separator', id: 'sep-icon' },
         {
           kind: 'item',

--- a/apps/desktop/src/renderer/src/lib/canvas-lookup.test.ts
+++ b/apps/desktop/src/renderer/src/lib/canvas-lookup.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The canvas half of the editor's link grammar (#1983): one cached list, an
+ * untitled canvas that no link can name, and a case-insensitive title match.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  error: vi.fn()
+}))
+
+vi.mock('@/services/canvas-service', () => ({
+  canvasService: { list: (...args: unknown[]) => mocks.list(...args) }
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: mocks.error })
+}))
+
+import { clearCanvasLookupCache, listTitledCanvases, resolveCanvasByTitle } from './canvas-lookup'
+
+describe('canvas-lookup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearCanvasLookupCache()
+    mocks.list.mockResolvedValue({
+      canvases: [
+        { id: 'canvas-1', title: 'Sprint Board' },
+        { id: 'canvas-2', title: '  ' },
+        { id: 'canvas-3', title: null }
+      ]
+    })
+  })
+
+  it('lists only canvases a link could name', async () => {
+    expect(await listTitledCanvases()).toEqual([{ id: 'canvas-1', title: 'Sprint Board' }])
+  })
+
+  it('asks once and serves the rest of the window from the cache', async () => {
+    await listTitledCanvases()
+    await resolveCanvasByTitle('Sprint Board')
+
+    expect(mocks.list).toHaveBeenCalledTimes(1)
+  })
+
+  it('matches a title case- and whitespace-insensitively', async () => {
+    expect(await resolveCanvasByTitle('  sprint BOARD ')).toEqual({
+      id: 'canvas-1',
+      title: 'Sprint Board'
+    })
+    expect(await resolveCanvasByTitle('No Such Board')).toBeNull()
+    expect(await resolveCanvasByTitle('   ')).toBeNull()
+  })
+
+  it('answers "no canvas" rather than throwing when the list call fails', async () => {
+    clearCanvasLookupCache()
+    mocks.list.mockRejectedValue(new Error('ipc down'))
+
+    expect(await resolveCanvasByTitle('Sprint Board')).toBeNull()
+    expect(mocks.error).toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/canvas-lookup.ts
+++ b/apps/desktop/src/renderer/src/lib/canvas-lookup.ts
@@ -1,0 +1,84 @@
+/**
+ * Canvas titles, as the editor's link grammar needs them (#1983).
+ *
+ * A canvas is a first-class vault item in the sidebar, the Related picker and
+ * the mind map, but the editor's `[[…]]` grammar only ever knew about notes:
+ * typing `[[` never offered one, and a hand-typed `[[My Canvas]]` resolved to
+ * nothing and was painted broken. Three surfaces need the same answer — the
+ * resolver, the suggestion menu and the broken-link pass — so the lookup lives
+ * here once rather than three times.
+ *
+ * Canvases have no title index and no `resolve-by-title` channel; the whole
+ * list is one cheap IPC call (metadata rows, no scenes), so it is fetched and
+ * cached for the same short window the wiki-link suggestion cache uses. A
+ * canvas created or renamed a moment ago therefore becomes linkable within
+ * seconds rather than instantly, which is the same freshness the note-side
+ * suggestion list has always had.
+ *
+ * @module lib/canvas-lookup
+ */
+
+import { canvasService, type CanvasSummary } from '@/services/canvas-service'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('Lib:CanvasLookup')
+
+const CACHE_TTL_MS = 5000
+
+let cache: { canvases: CanvasSummary[]; fetchedAt: number } | null = null
+
+/** Drops the cached list, so the next lookup asks again. Tests and events. */
+export function clearCanvasLookupCache(): void {
+  cache = null
+}
+
+/** Every live canvas, cached briefly. Empty when the call fails — never throws. */
+export async function listCanvasesCached(): Promise<CanvasSummary[]> {
+  const now = Date.now()
+  if (cache && now - cache.fetchedAt <= CACHE_TTL_MS) return cache.canvases
+
+  try {
+    const result = await canvasService.list()
+    cache = { canvases: result.canvases, fetchedAt: now }
+  } catch (error) {
+    log.error('Failed to list canvases for link resolution', error)
+    cache = { canvases: [], fetchedAt: now }
+  }
+  return cache.canvases
+}
+
+/** A canvas that has a title, which is the only kind a link can name. */
+export interface TitledCanvas {
+  id: string
+  title: string
+}
+
+/**
+ * Every canvas a link could name — the titled ones. An untitled canvas has
+ * nothing for `[[…]]` to carry, so it is neither offered nor matched.
+ */
+export async function listTitledCanvases(): Promise<TitledCanvas[]> {
+  const canvases = await listCanvasesCached()
+  const titled: TitledCanvas[] = []
+  for (const canvas of canvases) {
+    const title = canvas.title?.trim()
+    if (title) titled.push({ id: canvas.id, title })
+  }
+  return titled
+}
+
+/**
+ * The canvas a wiki-link target names, matched on title.
+ *
+ * Case-insensitive, exact match, first row wins — the same reading
+ * `resolveNoteByTitle` gives a note title, so `[[my canvas]]` and
+ * `[[My Canvas]]` reach the same canvas. An untitled canvas has nothing to
+ * name it, so it never matches.
+ */
+export async function resolveCanvasByTitle(title: string): Promise<TitledCanvas | null> {
+  const wanted = title.trim().toLowerCase()
+  if (!wanted) return null
+
+  const canvases = await listTitledCanvases()
+  return canvases.find((canvas) => canvas.title.toLowerCase() === wanted) ?? null
+}

--- a/apps/desktop/src/renderer/src/lib/memry-links.test.ts
+++ b/apps/desktop/src/renderer/src/lib/memry-links.test.ts
@@ -406,6 +406,30 @@ describe('tabFromMemryHref', () => {
     )
   })
 
+  it('opens a canvas link in the canvas tab (#1983)', () => {
+    const href = buildMemryHref({ kind: 'canvas', id: 'canvas-1', label: 'Sprint Board' })
+    expect(href).toBe('memry://canvas/canvas-1?label=Sprint+Board')
+    expect(parseMemryHref(href as string)).toEqual({
+      kind: 'canvas',
+      id: 'canvas-1',
+      label: 'Sprint Board'
+    })
+    expect(tabFromMemryHref(href as string)).toMatchObject({
+      type: 'canvas',
+      title: 'Sprint Board',
+      path: '/canvas/canvas-1',
+      entityId: 'canvas-1'
+    })
+  })
+
+  it('drops an anchor on a canvas, which has no inside to address', () => {
+    expect(parseMemryHref('memry://canvas/canvas-1#Ideas')).toEqual({
+      kind: 'canvas',
+      id: 'canvas-1',
+      label: null
+    })
+  })
+
   it('never marks an opened tab as pinned, modified, preview or deleted', () => {
     expect(tabFromMemryHref('memry://note/n1')).toMatchObject({
       isPinned: false,

--- a/apps/desktop/src/renderer/src/lib/memry-links.ts
+++ b/apps/desktop/src/renderer/src/lib/memry-links.ts
@@ -31,7 +31,15 @@ export type OpenableTab = Omit<Tab, 'id' | 'openedAt' | 'lastAccessedAt'>
  * they must open in the file viewer, never the markdown editor (#800).
  */
 export type MemryLinkKind =
-  'note' | 'file' | 'task' | 'inbox' | 'journal' | 'project' | 'folder' | 'calendar_event'
+  | 'note'
+  | 'file'
+  | 'task'
+  | 'inbox'
+  | 'journal'
+  | 'project'
+  | 'folder'
+  | 'canvas'
+  | 'calendar_event'
 
 /**
  * Where inside a note a link lands, in the two forms the two consumers need.
@@ -70,7 +78,16 @@ export type ParsedMemryHref = { label: string | null } & (
 )
 
 /** Hostnames whose whole path is the item id. */
-const SIMPLE_HOSTS = ['note', 'file', 'task', 'inbox', 'journal', 'project', 'folder'] as const
+const SIMPLE_HOSTS = [
+  'note',
+  'file',
+  'task',
+  'inbox',
+  'journal',
+  'project',
+  'folder',
+  'canvas'
+] as const
 
 type SimpleHost = (typeof SIMPLE_HOSTS)[number]
 
@@ -318,6 +335,15 @@ export function tabFromMemryHref(
         title: title ?? parsed.label ?? parsed.id,
         icon: 'folder',
         path: `/folder/${encodeURIComponent(parsed.id)}`,
+        entityId: parsed.id
+      }
+    case 'canvas':
+      return {
+        ...BASE,
+        type: 'canvas',
+        title: title ?? parsed.label ?? 'Canvas',
+        icon: 'pen-tool',
+        path: `/canvas/${parsed.id}`,
         entityId: parsed.id
       }
     case 'calendar_event': {

--- a/apps/desktop/src/renderer/src/lib/wikilink-resolver.test.ts
+++ b/apps/desktop/src/renderer/src/lib/wikilink-resolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { notesService } from '@/services/notes-service'
+import { resolveCanvasByTitle } from '@/lib/canvas-lookup'
 import { resolveWikiLink, hasFileExtension } from './wikilink-resolver'
 
 vi.mock('@/services/notes-service', () => ({
@@ -8,11 +9,18 @@ vi.mock('@/services/notes-service', () => ({
   }
 }))
 
+vi.mock('@/lib/canvas-lookup', () => ({
+  resolveCanvasByTitle: vi.fn()
+}))
+
 describe('wikilink-resolver', () => {
   const resolveByTitle = vi.mocked(notesService.resolveByTitle)
+  const resolveCanvas = vi.mocked(resolveCanvasByTitle)
 
   beforeEach(() => {
     resolveByTitle.mockReset()
+    resolveCanvas.mockReset()
+    resolveCanvas.mockResolvedValue(null)
   })
 
   describe('resolveWikiLink', () => {
@@ -222,6 +230,63 @@ describe('wikilink-resolver', () => {
       expect(resolveByTitle).not.toHaveBeenCalled()
       expect(result.type).toBe('not-found')
       expect(result.heading).toBe('Decisions')
+    })
+  })
+
+  describe('canvases (#1983)', () => {
+    it('resolves a target no note claims to the canvas of that name', async () => {
+      resolveByTitle.mockResolvedValue(null)
+      resolveCanvas.mockImplementation(async (title) =>
+        title.toLowerCase() === 'sprint board' ? { id: 'canvas-1', title: 'Sprint Board' } : null
+      )
+
+      const result = await resolveWikiLink('sprint board')
+
+      expect(result).toEqual({
+        type: 'canvas',
+        id: 'canvas-1',
+        title: 'Sprint Board',
+        fileType: 'markdown',
+        icon: 'pen-tool',
+        heading: null
+      })
+    })
+
+    it('keeps notes ahead of canvases, so an existing link never changes meaning', async () => {
+      resolveByTitle.mockResolvedValue({
+        id: 'note-1',
+        path: 'Notes/Sprint Board.md',
+        title: 'Sprint Board',
+        fileType: 'markdown'
+      })
+      resolveCanvas.mockResolvedValue({ id: 'canvas-1', title: 'Sprint Board' })
+
+      const result = await resolveWikiLink('Sprint Board')
+
+      expect(result.type).toBe('note')
+      expect(result.id).toBe('note-1')
+      expect(resolveCanvas).not.toHaveBeenCalled()
+    })
+
+    it('opens the canvas named before a `#`, carrying no heading', async () => {
+      resolveByTitle.mockResolvedValue(null)
+      resolveCanvas.mockImplementation(async (title) =>
+        title === 'Sprint Board' ? { id: 'canvas-1', title: 'Sprint Board' } : null
+      )
+
+      const result = await resolveWikiLink('Sprint Board#Ideas')
+
+      expect(result.type).toBe('canvas')
+      expect(result.id).toBe('canvas-1')
+      expect(result.heading).toBeNull()
+    })
+
+    it('still offers to create a note when nothing answers the target', async () => {
+      resolveByTitle.mockResolvedValue(null)
+
+      const result = await resolveWikiLink('Nothing Here')
+
+      expect(result.type).toBe('create')
     })
   })
 

--- a/apps/desktop/src/renderer/src/lib/wikilink-resolver.ts
+++ b/apps/desktop/src/renderer/src/lib/wikilink-resolver.ts
@@ -8,6 +8,7 @@
  */
 
 import { notesService } from '@/services/notes-service'
+import { resolveCanvasByTitle } from '@/lib/canvas-lookup'
 import { getFileType, getExtension, isSupported } from '@memry/shared/file-types'
 import { splitWikiTarget, isBlockReference, resolveWikiTarget } from '@memry/shared/wiki-target'
 
@@ -15,7 +16,7 @@ import { splitWikiTarget, isBlockReference, resolveWikiTarget } from '@memry/sha
 // Types
 // ============================================================================
 
-export type ResolutionType = 'note' | 'file' | 'create' | 'not-found'
+export type ResolutionType = 'note' | 'file' | 'canvas' | 'create' | 'not-found'
 
 export interface ResolvedWikiLink {
   type: ResolutionType
@@ -123,6 +124,24 @@ export async function resolveWikiLink(target: string): Promise<ResolvedWikiLink>
     notesService.resolveByTitle(title)
   )
   if (resolved) return resolvedRecord(resolved.match, resolved.heading)
+
+  // Notes first, canvases second, and that order is the compatibility story:
+  // every link that resolved to a note before this change still does, so a
+  // canvas can only ever claim a target nothing else answered (#1983). A canvas
+  // has no headings, so the heading half of `[[Canvas#Anything]]` is dropped —
+  // the canvas still opens, which is what the note-side block-reference branch
+  // already does.
+  const canvas = await resolveWikiTarget(trimmedTarget, (title) => resolveCanvasByTitle(title))
+  if (canvas) {
+    return {
+      type: 'canvas',
+      id: canvas.match.id,
+      title: canvas.match.title,
+      fileType: 'markdown',
+      icon: 'pen-tool',
+      heading: null
+    }
+  }
 
   // Not found in database
   if (hasKnownExtension) {

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -713,6 +713,20 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
               ...(resolution.heading && { viewState: { headingText: resolution.heading } })
             })
             break
+          case 'canvas':
+            // No editor to land inside, so no heading to carry (#1983).
+            openTab({
+              type: 'canvas',
+              title: resolution.title,
+              icon: 'pen-tool',
+              path: `/canvas/${resolution.id}`,
+              entityId: resolution.id,
+              isPinned: false,
+              isModified: false,
+              isPreview: false,
+              isDeleted: false
+            })
+            break
           case 'create':
             // Same confirm dialog as the note editor (#1716) instead of the
             // old dead-end "not found" toast.

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -504,6 +504,9 @@ vi.mock('@/components/note', () => ({
         <button type="button" onClick={() => onInternalLinkClick('Missing.png')}>
           Internal missing file
         </button>
+        <button type="button" onClick={() => onInternalLinkClick('Sprint Board')}>
+          Internal canvas link
+        </button>
         {/* What opening the note reports: the tags the body already carried. */}
         <button type="button" onClick={() => onInlineTagsChange(['work'], 'load')}>
           Load inline tags
@@ -874,8 +877,28 @@ describe('NotePage', () => {
       if (target === 'Diagram.pdf')
         return Promise.resolve({ type: 'file', id: 'file-1', title: 'Diagram.pdf', icon: 'file' })
       if (target === 'New Note') return Promise.resolve({ type: 'create', title: 'New Note' })
+      if (target === 'Sprint Board')
+        return Promise.resolve({ type: 'canvas', id: 'canvas-1', title: 'Sprint Board' })
       return Promise.resolve({ type: 'not-found' })
     })
+  })
+
+  it('opens a canvas a wiki link names (#1983)', async () => {
+    renderWithProviders(<NotePage noteId="note-1" />)
+
+    fireEvent.click(await screen.findByText('Internal canvas link'))
+
+    await waitFor(() =>
+      expect(mocks.openTab).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'canvas',
+          title: 'Sprint Board',
+          path: '/canvas/canvas-1',
+          entityId: 'canvas-1'
+        }),
+        expect.anything()
+      )
+    )
   })
 
   it('renders empty, loading, and error states', async () => {

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -1210,6 +1210,22 @@ export function NotePage({ noteId }: NotePageProps) {
             })
             break
 
+          case 'canvas':
+            // A canvas has no editor to land inside, so there is no heading to
+            // carry: the link opens the board itself (#1983).
+            openLinked({
+              type: 'canvas',
+              title: resolution.title,
+              icon: 'pen-tool',
+              path: `/canvas/${resolution.id}`,
+              entityId: resolution.id,
+              isPinned: false,
+              isModified: false,
+              isPreview: false,
+              isDeleted: false
+            })
+            break
+
           case 'create':
             // Ask before creating — a stale `[[Old Title]]` used to silently
             // mint a duplicate note here (#1716). The dialog carries the

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -19,6 +19,24 @@ write the words you want in the sentence — `[[Continent#North America|North of
 Once both halves are settled the dropdown becomes a single **Display as** row that commits
 it. The link still points at the note; only the visible text changes.
 
+## Linking a Canvas
+
+Canvases sit in the same dropdown as notes, below them, with the canvas icon. Pick one and
+the link is written as `[[Sprint Board]]` — the canvas title, exactly the way a note link
+carries a note title. Clicking it opens the canvas.
+
+A canvas has no headings, so `#` does nothing for one: `[[Sprint Board#Ideas]]` opens the
+board itself.
+
+Notes are matched first. A note and a canvas that share a name both keep working — the link
+opens the note, as it always has — so rename one of them if you need to reach the other.
+
+From the sidebar, a canvas's row menu has **Copy link**, which puts `[[Sprint Board]]` on the
+clipboard ready to paste into a note.
+
+Untitled canvases are not offered: there is no title for the link to carry, so give the
+canvas a name first.
+
 ## Linking Selected Text
 
 Select a word or a sentence and press **Link to note** in the selection toolbar (next to the

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -363,6 +363,7 @@
     "actions": {
       "rename": "Rename",
       "duplicate": "Duplicate",
+      "copyLink": "Copy link",
       "setIcon": "Set icon",
       "removeIcon": "Remove icon",
       "moveToFolder": "Move to folder",


### PR DESCRIPTION
## Summary

Closes #1983.

A canvas is a first-class vault item in the sidebar, the Related picker and the mind map, but the editor's link grammar had never heard of one: typing `[[` offered only notes, a hand-typed `[[My Canvas]]` resolved to nothing and was painted as a broken link, and nothing a user could copy from a canvas resolved as a link.

- `resolveWikiLink` falls back to a canvas title when no note claims the target, and the note and journal pages open the canvas it names. **Notes are still resolved first**, so no link that resolves today changes meaning.
- The `[[` menu lists canvases below the notes with the canvas icon; an exact canvas name suppresses the "create note" row and can take a `|alias`. A few menu slots are reserved for canvases so a note-heavy match cannot hide them all.
- The broken-link pass asks the canvas list about targets no note claimed, so a working canvas link is no longer painted broken. It re-resolves on canvas created/updated/deleted.
- The `memry://` grammar gains a `canvas` kind (`memry://canvas/<id>`), and the mind map now builds a deep link for a wiki link that names a canvas.
- The canvas sidebar row gains **Copy link**, which copies `[[Title]]` — the thing that actually resolves. Copying a file path would not; that is what the report ran into.

### Assumptions / judgment calls

- **Match on title, not path.** Notes resolve by title (`resolveNoteByTitle`), so canvases do too — one convention, and it is what the `[[` menu writes.
- **No new IPC.** Canvas titles come from the existing `canvas:list` call, cached in the renderer for 5s (the same window the wiki-link suggestion cache already uses). No contract, sync-protocol or schema change, so there is nothing to migrate and older builds are unaffected — a `[[Canvas]]` written by this build simply reads as an unresolved link on an older one, exactly as it does today.
- **Untitled canvases are never offered or matched**: there is no target a link could carry.
- **A canvas takes no heading anchor.** `[[Board#Ideas]]` opens the board, mirroring how a block reference already opens the note.

### Deliberately left out

- No E2E spec: the canvas + editor E2E path would need a canvas fixture and a live suggestion menu for what is fully covered by renderer unit tests. Say the word if you want one.
- Non-English locales get the English `Copy link` through the existing fallback, as with every other recently added key.

## Release note

Wiki links can now name a canvas: type `[[` to pick one, click it to open the board, or copy a canvas's link from its sidebar menu.

## Test plan

- `pnpm lint`
- `pnpm --filter @memry/desktop typecheck:web` / `typecheck:node` / `typecheck:test.web` (the repo-wide `pnpm typecheck` fails locally on an unrelated Node 26 flag in `rpc:check`; `check:contracts`, `check:architecture` and `pnpm ipc:check` all pass on Node 24)
- `pnpm test:desktop` — 1470 files, 20065 tests passing
- `pnpm check:architecture`, `pnpm ipc:check`, `pnpm --filter @memry/desktop i18n:check`
- `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build`

New tests: `canvas-lookup.test.ts`, canvas cases in `wikilink-resolver.test.ts`, `memry-links.test.ts`, `use-wiki-link-suggestions.test.tsx`, `use-wiki-link-broken.test.tsx`, and a canvas-open case in `note.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)