### PR TITLE
fix(desktop): size custom folder icons to the built-in glyph box

### DIFF
--- a/apps/desktop/src/renderer/src/components/folder-icon-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-icon-button.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { FolderIconButton } from './folder-icon-button'
+
+vi.mock('@/lib/custom-icons-store', () => ({
+  useCustomIcon: (id: string) =>
+    id === 'known'
+      ? {
+          id: 'known',
+          name: 'Rocket',
+          url: 'memry-file:///icons/known.png',
+          createdAt: '2026-01-01T00:00:00.000Z'
+        }
+      : undefined
+}))
+
+describe('FolderIconButton custom icons', () => {
+  it('renders a URL-backed folder icon at the built-in glyph size, not the row text size', () => {
+    const { container } = render(
+      <FolderIconButton icon="custom:known" isExpanded={false} onIconChange={vi.fn()} />
+    )
+
+    const img = container.querySelector('img')
+    expect(img?.className).toContain('size-5')
+    expect(img?.className).toContain('object-contain')
+    expect(img?.getAttribute('alt')).toBe('Rocket')
+    // The picker button is the row's reserved 20px slot; the icon fills it
+    // rather than growing it, which is what keeps the row height put.
+    expect(img?.closest('button')?.className).toContain('h-5 w-5')
+  })
+
+  it('keeps the same 20px slot when the icon is missing from the library', () => {
+    const { container } = render(
+      <FolderIconButton icon="custom:deleted-on-a-peer" isExpanded={false} onIconChange={vi.fn()} />
+    )
+
+    expect(container.querySelector('img')).toBeNull()
+    const placeholder = container.querySelector('button span > span')
+    expect(placeholder?.className).toBe('size-5')
+  })
+
+  it('falls back to the built-in folder glyph when the folder has no icon', () => {
+    const { container } = render(
+      <FolderIconButton icon={null} isExpanded={false} onIconChange={vi.fn()} />
+    )
+
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.querySelector('svg')).not.toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/folder-icon-button.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-icon-button.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { Folder, FolderOpen, ArrowRight } from '@/lib/icons'
-import { NoteIconDisplay } from '@/lib/render-note-icon'
+import { FOLDER_CUSTOM_ICON_CLASS, NoteIconDisplay } from '@/lib/render-note-icon'
 import { IconPickerButton } from '@/components/icon-picker-button'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
@@ -26,7 +26,11 @@ export function FolderIconButton({
   const { t: tPhaseF } = useT('common')
 
   const folderIcon = icon ? (
-    <NoteIconDisplay value={icon} className="text-sm leading-none" />
+    <NoteIconDisplay
+      value={icon}
+      className="text-sm leading-none"
+      customIconClassName={FOLDER_CUSTOM_ICON_CLASS}
+    />
   ) : isExpanded ? (
     <FolderOpen className="h-4 w-4 text-muted-foreground" />
   ) : (

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-emoji-chip.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-emoji-chip.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useCallback, useState } from 'react'
 import { Folder } from '@/lib/icons'
-import { NoteIconDisplay } from '@/lib/render-note-icon'
+import { FOLDER_CUSTOM_ICON_CLASS, NoteIconDisplay } from '@/lib/render-note-icon'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { useT } from '@memry/i18n/renderer'
 
@@ -46,7 +46,11 @@ export function FolderEmojiChip({ icon, onIconChange }: FolderEmojiChipProps): R
           className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[9px] border bg-muted transition-colors hover:bg-accent"
         >
           {icon ? (
-            <NoteIconDisplay value={icon} className="text-[17px] leading-none" />
+            <NoteIconDisplay
+              value={icon}
+              className="text-[17px] leading-none"
+              customIconClassName={FOLDER_CUSTOM_ICON_CLASS}
+            />
           ) : (
             <Folder className="h-4 w-4 text-muted-foreground" />
           )}

--- a/apps/desktop/src/renderer/src/lib/render-note-icon.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/render-note-icon.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { FOLDER_CUSTOM_ICON_CLASS, NoteIconDisplay } from './render-note-icon'
+
+// The library is a module store fed by IPC. Only two cases matter here: an id
+// the vault knows, and one it does not (deleted on a peer while a folder still
+// points at it).
+vi.mock('./custom-icons-store', () => ({
+  useCustomIcon: (id: string) =>
+    id === 'known'
+      ? {
+          id: 'known',
+          name: 'Rocket',
+          url: 'memry-file:///icons/known.png',
+          createdAt: '2026-01-01T00:00:00.000Z'
+        }
+      : undefined
+}))
+
+vi.mock('./hugeicon-renderer', () => ({
+  HugeIconByName: ({ name, className }: { name: string; className?: string }) => (
+    <span data-testid="huge-icon" data-name={name} className={className} />
+  )
+}))
+
+describe('NoteIconDisplay custom icons', () => {
+  it('sizes a custom icon to the caller box instead of the row text size', () => {
+    const { container } = render(
+      <NoteIconDisplay
+        value="custom:known"
+        className="text-sm leading-none"
+        customIconClassName={FOLDER_CUSTOM_ICON_CLASS}
+      />
+    )
+
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+    expect(img?.getAttribute('src')).toBe('memry-file:///icons/known.png')
+    expect(img?.getAttribute('alt')).toBe('Rocket')
+    expect(img?.className).toContain(FOLDER_CUSTOM_ICON_CLASS)
+    expect(img?.className).toContain('object-contain')
+    // The 1em fallback must be gone, not merely joined with the box class.
+    expect(img?.className).not.toContain('h-[1em]')
+  })
+
+  it('reserves the same box while an icon is missing, so nothing shifts later', () => {
+    const { container } = render(
+      <NoteIconDisplay
+        value="custom:deleted-on-a-peer"
+        className="text-sm leading-none"
+        customIconClassName={FOLDER_CUSTOM_ICON_CLASS}
+      />
+    )
+
+    expect(container.querySelector('img')).toBeNull()
+    const placeholder = container.querySelector('span > span')
+    expect(placeholder?.className).toBe(FOLDER_CUSTOM_ICON_CLASS)
+  })
+
+  it('still tracks the surrounding text when no box is requested', () => {
+    const { container } = render(<NoteIconDisplay value="custom:known" className="text-sm" />)
+
+    expect(container.querySelector('img')?.className).toContain('h-[1em] w-[1em]')
+  })
+
+  it('leaves emoji and library icons untouched by the custom-icon box', () => {
+    const emoji = render(
+      <NoteIconDisplay value="📚" customIconClassName={FOLDER_CUSTOM_ICON_CLASS} />
+    )
+    expect(emoji.container.textContent).toBe('📚')
+    expect(emoji.container.innerHTML).not.toContain(FOLDER_CUSTOM_ICON_CLASS)
+
+    const library = render(
+      <NoteIconDisplay
+        value="icon:StarIcon"
+        className="text-sm"
+        customIconClassName={FOLDER_CUSTOM_ICON_CLASS}
+      />
+    )
+    const glyph = library.getByTestId('huge-icon')
+    expect(glyph.getAttribute('data-name')).toBe('StarIcon')
+    expect(glyph.className).toBe('text-sm')
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/render-note-icon.tsx
+++ b/apps/desktop/src/renderer/src/lib/render-note-icon.tsx
@@ -9,14 +9,37 @@ import { useCustomIcon } from './custom-icons-store'
 import { HugeIconByName } from './hugeicon-renderer'
 
 /**
+ * The box a folder's custom icon gets: 20px, the size the built-in folder glyph
+ * already reserves in the sidebar row and the folder-view header. Without it a
+ * URL-backed icon renders at the row's 14px text size and is unreadable.
+ *
+ * Both surfaces put the icon inside a button that is already at least this tall,
+ * so widening the glyph does not move the row height.
+ */
+export const FOLDER_CUSTOM_ICON_CLASS = 'size-5'
+
+/** Default box: track the surrounding text, as emoji and library icons do. */
+const TEXT_SIZED_CUSTOM_ICON_CLASS = 'h-[1em] w-[1em]'
+
+/**
  * A user-uploaded icon, sized to the surrounding text so one component covers
- * a 14px sidebar row and a 28px note title alike.
+ * a 14px sidebar row and a 28px note title alike — or to `customIconClassName`
+ * where the text size is too small to identify the image (folder rows).
  *
  * The library is loaded asynchronously and an icon can also be missing outright
  * (deleted on another device while a folder still points at it), so an unknown
- * id renders nothing rather than a broken-image glyph.
+ * id renders an empty box of the same size rather than a broken-image glyph:
+ * the row is laid out once, whether the icon arrives or never does.
  */
-function CustomIconImage({ id, className }: { id: string; className?: string }): React.JSX.Element {
+function CustomIconImage({
+  id,
+  className,
+  customIconClassName = TEXT_SIZED_CUSTOM_ICON_CLASS
+}: {
+  id: string
+  className?: string
+  customIconClassName?: string
+}): React.JSX.Element {
   const icon = useCustomIcon(id)
 
   return (
@@ -26,10 +49,10 @@ function CustomIconImage({ id, className }: { id: string; className?: string }):
           src={icon.url}
           alt={icon.name}
           draggable={false}
-          className="h-[1em] w-[1em] object-contain"
+          className={cn('object-contain', customIconClassName)}
         />
       ) : (
-        <span className="h-[1em] w-[1em]" />
+        <span className={customIconClassName} />
       )}
     </span>
   )
@@ -37,16 +60,25 @@ function CustomIconImage({ id, className }: { id: string; className?: string }):
 
 export function NoteIconDisplay({
   value,
-  className
+  className,
+  customIconClassName
 }: {
   value: string
   className?: string
+  /** Box for a `custom:` image icon only; emoji and library icons ignore it. */
+  customIconClassName?: string
 }): React.JSX.Element {
   if (isIconValue(value)) {
     return <HugeIconByName name={parseIconName(value)} className={className} />
   }
   if (isCustomIconValue(value)) {
-    return <CustomIconImage id={parseCustomIconId(value)} className={className} />
+    return (
+      <CustomIconImage
+        id={parseCustomIconId(value)}
+        className={className}
+        customIconClassName={customIconClassName}
+      />
+    )
   }
   return (
     <span className={cn('inline-flex items-center justify-center leading-none', className)}>


### PR DESCRIPTION
## Summary

URL-backed folder icons rendered at the row's `1em` text size (~14px in the sidebar), so they were unidentifiable next to the 20px built-in folder glyph.

`NoteIconDisplay` / `CustomIconImage` now take an optional `customIconClassName`, defaulting to the old text-tracking box — note, tag, and tab surfaces are unchanged. Folder surfaces pass `FOLDER_CUSTOM_ICON_CLASS` (`size-5`). The class also lands on the missing-icon placeholder, so an icon that arrives late or never arrives reserves the same slot and the row is laid out once.

Row height does not move: the icon already sat inside a fixed `h-5 w-5` picker button in an `h-7` row. `FolderIconButton` is the single seam behind `TreeFolderIcon`, `virtualized-notes-tree`, and `canvas-folder-row`, so all sidebar folder rows are covered by one call site; `folder-emoji-chip` covers the folder-view header.

No change to the stored `custom:<id>` value, the icons store, or sync.

Closes #2072

## Release note

Custom folder icons added from a URL now render at the same size as the built-in folder icon in the sidebar and folder view, instead of shrinking to the row's text size.

## Test plan

- `pnpm --filter @memry/desktop test:renderer` — new `render-note-icon.test.tsx` (4) and `folder-icon-button.test.tsx` (3): 7/7 pass. Full renderer suite is 37 failed files / 408 failed tests both with and without this change — identical to baseline, no regression.
- `pnpm --filter @memry/desktop typecheck:web` — clean.
- `tsc --noEmit -p tsconfig.test.web.json` — clean; both new test files compile and neither was added to an exclude list.
- `pnpm --filter @memry/desktop i18n:check` — `ok: i18n check passed`.

Not done: the Electron visual/interaction test the issue asks for. The 20px claim rests on `size-5` = 1.25rem plus the unchanged button geometry, not on a screenshot.

`move-to-folder-dialog.tsx` lists folder icons in a 16px slot and is deliberately untouched — `size-5` would overflow it.

## Caveats

Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: this is a pixel-size change to an existing feature with no behavior, contract, or format change, and no page under `apps/docs/src` documents folder or custom icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)