### PR TITLE
fix(desktop): keep the note and folder icon picker on screen

### DIFF
--- a/apps/desktop/src/renderer/src/components/icon-picker-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/icon-picker-button.test.tsx
@@ -34,8 +34,18 @@ vi.mock('@/components/ui/popover', async () => {
           onOpenChange?.(true)
         }
       }),
-    PopoverContent: ({ children, open }: any) =>
-      open ? React.createElement('div', null, children) : null
+    PopoverContent: ({ children, open, collisionPadding, side }: any) =>
+      open
+        ? React.createElement(
+            'div',
+            {
+              'data-testid': 'popover-content',
+              'data-collision-padding': String(collisionPadding),
+              'data-side': side
+            },
+            children
+          )
+        : null
   }
 })
 
@@ -184,5 +194,21 @@ describe('IconPickerButton', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Set icon' }))
     expect(onPickerOpenChange).toHaveBeenCalledWith(true)
+  })
+
+  // Radix runs `shift` before `flip`, so a bottom-placed panel taller than the room
+  // under the trigger is flipped up afterwards with no second clamp and loses its tab
+  // bar off the top edge (#1984). Side placement puts `shift` on the overflowing axis.
+  it('opens to the side, off the viewport edges, so it cannot be clipped', () => {
+    render(
+      <IconPickerButton hasIcon={false} onIconChange={vi.fn()} ariaLabel="Set icon">
+        <span>📝</span>
+      </IconPickerButton>
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Set icon' }))
+
+    const content = screen.getByTestId('popover-content')
+    expect(content.getAttribute('data-collision-padding')).toBe('8')
+    expect(content.getAttribute('data-side')).toBe('right')
   })
 })

--- a/apps/desktop/src/renderer/src/components/icon-picker-button.tsx
+++ b/apps/desktop/src/renderer/src/components/icon-picker-button.tsx
@@ -82,8 +82,10 @@ export function IconPickerButton({
           </button>
         </PopoverTrigger>
         <PopoverContent
+          side="right"
           align="start"
           sideOffset={4}
+          collisionPadding={8}
           className="w-auto border-0 bg-transparent p-0 shadow-none"
           onClick={(e) => e.stopPropagation()}
         >

--- a/apps/desktop/src/renderer/src/components/note/note-title/EmojiPicker.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-title/EmojiPicker.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import type { i18n as I18nInstance } from 'i18next'
+import { createRendererI18n } from '@memry/i18n/renderer'
+import { EmojiPicker } from './EmojiPicker'
+
+// emoji-mart renders a heavy DOM tree that jsdom does not need for layout assertions.
+vi.mock('@emoji-mart/react', () => ({
+  default: () => <div data-testid="emoji-grid" style={{ height: 435 }} />
+}))
+vi.mock('@emoji-mart/data', () => ({ default: {} }))
+
+let i18n: I18nInstance
+
+beforeAll(async () => {
+  i18n = await createRendererI18n({ locale: 'en' })
+})
+
+const renderPicker = (props: Partial<React.ComponentProps<typeof EmojiPicker>> = {}) =>
+  render(
+    <I18nextProvider i18n={i18n}>
+      <EmojiPicker
+        isOpen
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        onRemove={vi.fn()}
+        hasEmoji={false}
+        {...props}
+      />
+    </I18nextProvider>
+  )
+
+describe('EmojiPicker layout', () => {
+  it('caps the embedded panel to the room the popover measured so the tabs stay visible', () => {
+    renderPicker({ embedded: true })
+
+    const panel = screen.getByRole('dialog')
+    expect(panel.className).toContain('max-h-(--radix-popover-content-available-height)')
+    expect(panel.className).toContain('flex-col')
+    expect(panel.className).toContain('overflow-hidden')
+  })
+
+  it('keeps the tab bar from shrinking and lets the grid scroll instead', () => {
+    renderPicker({ embedded: true })
+
+    const tabBar = screen.getByRole('button', { name: 'Emoji' }).parentElement
+    expect(tabBar?.className).toContain('shrink-0')
+
+    const grid = screen.getByTestId('emoji-grid').parentElement
+    expect(grid?.className).toContain('overflow-y-auto')
+    expect(grid?.className).toContain('min-h-0')
+  })
+
+  it('keeps the remove row pinned outside the scroll area', () => {
+    renderPicker({ embedded: true, hasEmoji: true })
+
+    const removeRow = screen.getByRole('button', { name: /remove/i }).parentElement
+    expect(removeRow?.className).toContain('shrink-0')
+  })
+
+  it('does not constrain the free-floating (non-embedded) panel', () => {
+    renderPicker()
+
+    const panel = screen.getByRole('dialog')
+    expect(panel.className).not.toContain('max-h-')
+    expect(panel.className).toContain('absolute')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/note-title/EmojiPicker.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-title/EmojiPicker.tsx
@@ -120,12 +120,18 @@ export function EmojiPicker({
       aria-label={t('menus.emoji.aria')}
       onKeyDown={handleKeyDown}
       className={cn(
-        embedded ? 'relative' : 'absolute start-0 top-full z-50 mt-2',
+        embedded
+          ? // Cap the panel at the room the host Popover measured so a short window
+            // shrinks the scrollable grid instead of pushing the tab bar off the top
+            // edge (#1984). The var is inherited from the Popover content and resolves
+            // to `none` outside one, so the free-floating panel is unaffected.
+            'relative flex max-h-(--radix-popover-content-available-height) flex-col overflow-hidden'
+          : 'absolute start-0 top-full z-50 mt-2',
         'rounded-xl border border-border bg-popover shadow-lg',
         'animate-in fade-in-0 zoom-in-95 duration-150'
       )}
     >
-      <div className="flex border-b border-border">
+      <div className="flex shrink-0 border-b border-border">
         <button
           type="button"
           onClick={() => setActiveTab('emoji')}
@@ -166,6 +172,7 @@ export function EmojiPicker({
 
       <div
         ref={contentRef}
+        className="min-h-0 overflow-y-auto"
         style={
           activeTab !== 'emoji' && contentSize
             ? { width: contentSize.width, height: contentSize.height, overflow: 'hidden' }
@@ -205,7 +212,7 @@ export function EmojiPicker({
       </div>
 
       {hasEmoji && (
-        <div className="border-t border-border p-2">
+        <div className="shrink-0 border-t border-border p-2">
           <button
             type="button"
             onClick={handleRemove}

--- a/apps/desktop/src/renderer/src/components/settings/tag-icon-chip.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/tag-icon-chip.tsx
@@ -59,8 +59,10 @@ export function TagIconChip({ icon, color, onIconChange }: TagIconChipProps): Re
         </button>
       </PopoverTrigger>
       <PopoverContent
+        side="right"
         align="start"
         sideOffset={6}
+        collisionPadding={8}
         className="w-auto border-0 bg-transparent p-0 shadow-none"
         onClick={(e) => e.stopPropagation()}
       >

--- a/apps/desktop/tests/e2e/sidebar-icon-picker-viewport.e2e.ts
+++ b/apps/desktop/tests/e2e/sidebar-icon-picker-viewport.e2e.ts
@@ -1,0 +1,78 @@
+/**
+ * Sidebar icon picker viewport clipping E2E (#1984, reopened from #801).
+ *
+ * #801 moved the note/folder icon picker into a Radix Popover, which fixed the
+ * left/right drift but not the vertical case. Radix runs `shift` BEFORE `flip`,
+ * so a bottom-placed panel that is taller than the room under a low sidebar row
+ * gets flipped above the trigger afterwards with no second clamp — its tab bar,
+ * the only route to the Icons and Custom tabs, ends up above the viewport top.
+ *
+ * The picker now opens to the side, which puts Radix's vertical `shift` on the
+ * axis that overflows, and the panel is capped to the height Radix measured, so
+ * the emoji grid scrolls instead of pushing the tabs off screen. Asserted in a
+ * deliberately short window, which is the reporter's condition.
+ */
+
+import type { ElectronApplication, Page } from '@playwright/test'
+
+import { test, expect } from './fixtures'
+import { ready } from './utils/desktop-test-helpers'
+
+const PICKER = 'Emoji and icon picker' // notes:menus.emoji.aria
+const SHORT_WINDOW = { x: 0, y: 0, width: 1100, height: 400 }
+
+async function resizeWindow(
+  electronApp: ElectronApplication,
+  bounds: typeof SHORT_WINDOW
+): Promise<void> {
+  await electronApp.evaluate(({ BrowserWindow }, next) => {
+    const win = BrowserWindow.getAllWindows()[0]
+    if (win) win.setBounds(next)
+  }, bounds)
+}
+
+async function seedNotes(page: Page, count: number): Promise<void> {
+  await page.evaluate(async (total) => {
+    const api = (window as unknown as { api: Record<string, any> }).api
+    for (let i = 0; i < total; i++) {
+      await api.notes.create({ title: `Picker Viewport ${i}`, content: 'seed' })
+    }
+  }, count)
+}
+
+async function expandCollectionsSection(page: Page): Promise<void> {
+  const trigger = page.locator('button[aria-label^="Collections section, "]').first()
+  await trigger.waitFor({ state: 'visible', timeout: 20_000 })
+  const label = (await trigger.getAttribute('aria-label')) ?? ''
+  if (label.includes('collapsed')) await trigger.click()
+}
+
+test.describe('Sidebar icon picker in a short window', () => {
+  test('stays fully on screen so its tabs are reachable', async ({ page, electronApp }) => {
+    await ready(page)
+    await seedNotes(page, 6)
+    await resizeWindow(electronApp, SHORT_WINDOW)
+    await expandCollectionsSection(page)
+
+    // The lowest row is the worst case: least room below, most upward shift.
+    const trigger = page.getByRole('button', { name: 'Set Icon' }).last()
+    await trigger.waitFor({ state: 'visible', timeout: 20_000 })
+    await trigger.click()
+
+    const picker = page.getByRole('dialog', { name: PICKER })
+    await expect(picker).toBeVisible({ timeout: 10_000 })
+
+    const box = await picker.boundingBox()
+    expect(box).not.toBeNull()
+    const viewportHeight = await page.evaluate(() => window.innerHeight)
+    // The regression: a shifted panel reports a negative top.
+    expect(box!.y).toBeGreaterThanOrEqual(0)
+    expect(box!.y + box!.height).toBeLessThanOrEqual(viewportHeight + 1)
+
+    // The tabs are the thing the reporter could not reach — they must click.
+    const iconsTab = picker.getByRole('button', { name: 'Icons' })
+    await expect(iconsTab).toBeVisible()
+    await iconsTab.click()
+    await expect(picker.locator('button[title]').first()).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/apps/docs/src/user-guide/notes/custom-icons.md
+++ b/apps/docs/src/user-guide/notes/custom-icons.md
@@ -16,6 +16,9 @@ and switch to **Custom**.
 Dragging an image straight out of a browser window works too — it arrives as a link, and is
 handled the same way.
 
+The panel opens beside the icon you clicked, and never off the edge of the window: in a window too
+short to hold it, the tabs and the **Remove** row stay put and the grid below them scrolls.
+
 Each new icon is named after its file, minus the extension; a linked icon is named after the file
 name in the link, or the site it came from. Hover a row and click the pencil to rename it; the name
 is what the search box matches, so name them the way you would look for them later. The trash icon


### PR DESCRIPTION
## Summary

Closes #1984 (reopened from #801).

#801 moved the note/folder icon picker into a Radix Popover, which fixed the horizontal drift but not the vertical case, so the reporter still hit it. Confirmed in the real app before changing anything: in a 400px-tall window the panel's top lands at `y = -158`, so its tab bar — the only way to reach the Icons and Custom tabs — is off the top edge.

Root cause is not the missing `collisionPadding` the issue guessed. Radix's popper runs `shift` **before** `flip` (`@radix-ui/react-popper`): the panel is placed below the row, shifted into view, and only then flipped above the trigger, with no second clamp. A ~470px panel opened from a low sidebar row in a short window therefore settles half above the viewport.

The fix, all in the one shared `IconPickerButton` + the panel it hosts:

- `side="right"` on the popover, so Radix's vertical `shift` runs on the axis that actually overflows and `flip` only swaps left/right.
- `collisionPadding={8}`.
- The embedded panel is capped to `--radix-popover-content-available-height` and laid out as a column: the tab bar and the Remove row are `shrink-0`, the grid scrolls.

Every caller goes through `IconPickerButton` already — notes, folders, canvas rows, project rows, the template editor — so all of them are fixed at once. `TagIconChip` in Settings hosts the same panel and got the same popover props.

Assumptions / notes for review:

- `side="right"` is physical, not logical. In RTL the sidebar is on the right, so Radix's `flip` sends the panel to the left there; `collisionPadding` keeps it on screen either way. Radix has no logical `side`, so this is the available behaviour.
- Capping to the measured height on a *bottom*-placed popover does not work: shrinking the panel makes it fit under the trigger, Radix flips it back, and it collapses to the ~46px of room left there. Side placement is what makes the cap stable. Verified both ways in the app.

## Release note

The note, folder, canvas and tag icon picker no longer opens with its tabs cut off above the top of the window; it opens beside the icon and scrolls when the window is short.

## Test plan

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @memry/desktop test:renderer` — 730 files, 9000 tests green (full `pnpm test:desktop` segfaults locally on the node project because native modules are built for Electron here; the changes are renderer-only)
- `pnpm check:architecture`
- New unit tests: `icon-picker-button.test.tsx` (side + collision padding), `EmojiPicker.test.tsx` (capped, non-shrinking chrome, scrolling grid, free-floating panel untouched)
- New E2E `tests/e2e/sidebar-icon-picker-viewport.e2e.ts` — 400px-tall window, lowest sidebar row: asserts the panel is fully on screen and the Icons tab clicks through. Fails on `main` (`y = -158`), passes here.
- `pnpm exec playwright test tag-icon-picker sidebar-icon-picker-viewport` — 6 passed
- `pnpm docs:impact --base origin/main --strict` + `pnpm docs:build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)