### PR TITLE
feat(desktop): add Set Icon to the folder tab row context menu

### DIFF
--- a/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.tsx
@@ -135,6 +135,8 @@ interface FolderTableViewProps {
   onTagClick?: (tag: string) => void
   /** Called when a tag is removed */
   onTagRemove?: (noteId: string, tag: string) => void
+  /** Set (or clear, with `null`) a row's icon */
+  onSetIcon?: (noteId: string, icon: string | null) => void
   /** Tag color + icon, keyed by lowercased tag name */
   tagMetaMap?: TagMetaMap
   /** Called when a property value is updated */
@@ -289,6 +291,7 @@ export function FolderTableView({
   onFolderClick,
   onTagClick,
   onTagRemove,
+  onSetIcon,
   tagMetaMap,
   onPropertyUpdate,
   onColumnsChange,
@@ -1234,6 +1237,7 @@ export function FolderTableView({
                   onOpenInNewTab={onOpenInNewTab}
                   onMoveToFolder={onMoveToFolder}
                   onDelete={onDelete}
+                  onSetIcon={onSetIcon}
                 >
                   <tr
                     data-index={virtualRow.index}

--- a/apps/desktop/src/renderer/src/components/folder-view/grouped-table.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/grouped-table.tsx
@@ -148,6 +148,8 @@ interface GroupedTableProps {
   onTagClick?: (tag: string) => void
   /** Called when a tag is removed */
   onTagRemove?: (noteId: string, tag: string) => void
+  /** Set (or clear, with `null`) a row's icon */
+  onSetIcon?: (noteId: string, icon: string | null) => void
   /** Tag color + icon, keyed by lowercased tag name */
   tagMetaMap?: TagMetaMap
   /** Called when a property value is updated */
@@ -318,6 +320,7 @@ export function GroupedTable({
   onFolderClick,
   onTagClick,
   onTagRemove,
+  onSetIcon,
   tagMetaMap,
   onPropertyUpdate,
   onColumnsChange,
@@ -1234,6 +1237,7 @@ export function GroupedTable({
                   onOpenInNewTab={onOpenInNewTab}
                   onMoveToFolder={onMoveToFolder}
                   onDelete={onDelete}
+                  onSetIcon={onSetIcon}
                 >
                   <tr
                     data-index={virtualRow.index}

--- a/apps/desktop/src/renderer/src/components/folder-view/row-context-menu.test.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/row-context-menu.test.tsx
@@ -26,6 +26,38 @@ vi.mock('@/components/ui/context-menu', () => ({
   ContextMenuShortcut: ({ children }: { children: React.ReactNode }) => <span>{children}</span>
 }))
 
+// The picker lives in a Dialog (Radix portal + modal focus trap is noisy in
+// jsdom) and is code-split, so stub both: the dialog renders inline when open,
+// the picker exposes one button per action.
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="icon-dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>
+}))
+
+vi.mock('@/components/note/note-title/EmojiPicker', () => ({
+  EmojiPicker: ({
+    onSelect,
+    onRemove,
+    hasEmoji
+  }: {
+    onSelect: (icon: string) => void
+    onRemove: () => void
+    hasEmoji: boolean
+  }) => (
+    <div data-testid="emoji-picker" data-has-emoji={String(hasEmoji)}>
+      <button type="button" onClick={() => onSelect('🚀')}>
+        pick-rocket
+      </button>
+      <button type="button" onClick={onRemove}>
+        picker-remove
+      </button>
+    </div>
+  )
+}))
+
 const makeNote = (overrides: Partial<NoteWithProperties> = {}): NoteWithProperties =>
   ({
     id: 'note-1',
@@ -195,6 +227,85 @@ describe('RowContextMenu', () => {
 
     fireEvent.click(findButtonWithText('Move 2 Notes to Folder'))
     expect(onMoveToFolder).toHaveBeenCalledWith(['note-1', 'note-2'])
+  })
+
+  it('offers Set Icon and writes the picked icon back through onSetIcon', async () => {
+    const onSetIcon = vi.fn()
+
+    render(
+      <RowContextMenu
+        note={makeNote()}
+        isPartOfSelection={false}
+        selectedCount={1}
+        selectedNoteIds={['note-1']}
+        onSetIcon={onSetIcon}
+      >
+        <div>row</div>
+      </RowContextMenu>
+    )
+
+    // No icon set yet, so Remove Icon must stay hidden.
+    expect(screen.queryByText('removeIcon')).toBeNull()
+    expect(screen.queryByTestId('icon-dialog')).toBeNull()
+
+    fireEvent.click(screen.getByText('setIcon'))
+
+    const picker = await screen.findByTestId('emoji-picker')
+    expect(picker.dataset.hasEmoji).toBe('false')
+
+    fireEvent.click(screen.getByText('pick-rocket'))
+    expect(onSetIcon).toHaveBeenCalledWith('note-1', '🚀')
+  })
+
+  it('offers Remove Icon only when the row already has one, and clears it', () => {
+    const onSetIcon = vi.fn()
+
+    render(
+      <RowContextMenu
+        note={makeNote({ emoji: '📚' })}
+        isPartOfSelection={false}
+        selectedCount={1}
+        selectedNoteIds={['note-1']}
+        onSetIcon={onSetIcon}
+      >
+        <div>row</div>
+      </RowContextMenu>
+    )
+
+    fireEvent.click(screen.getByText('removeIcon'))
+    expect(onSetIcon).toHaveBeenCalledWith('note-1', null)
+  })
+
+  it('hides the icon actions for non-note rows and when no handler is wired', () => {
+    const onSetIcon = vi.fn()
+
+    const { unmount } = render(
+      <RowContextMenu
+        note={makeNote({ id: 'task-1', kind: 'task', emoji: '📚' })}
+        isPartOfSelection={false}
+        selectedCount={1}
+        selectedNoteIds={[]}
+        onSetIcon={onSetIcon}
+      >
+        <div>row</div>
+      </RowContextMenu>
+    )
+    expect(screen.queryByText('setIcon')).toBeNull()
+    expect(screen.queryByText('removeIcon')).toBeNull()
+    unmount()
+
+    render(
+      <RowContextMenu
+        note={makeNote({ emoji: '📚' })}
+        isPartOfSelection={false}
+        selectedCount={1}
+        selectedNoteIds={['note-1']}
+      >
+        <div>row</div>
+      </RowContextMenu>
+    )
+    expect(screen.queryByText('setIcon')).toBeNull()
+    expect(screen.queryByText('removeIcon')).toBeNull()
   })
 
   it('does not offer bulk Delete or Move when the selection holds no notes', () => {

--- a/apps/desktop/src/renderer/src/components/folder-view/row-context-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/row-context-menu.tsx
@@ -25,15 +25,23 @@ import {
   FolderInput,
   PanelLeft,
   Link,
-  Trash2
+  Smile,
+  Trash2,
+  X
 } from '@/lib/icons'
 import type { NoteWithProperties } from '@memry/contracts/folder-view-api'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { notesService } from '@/services/notes-service'
 import { createLogger } from '@/lib/logger'
 import { toast } from 'sonner'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { useT } from '@memry/i18n/renderer'
 import { useFileActionLabels } from '@/hooks/use-file-action-labels'
+import { lazy, Suspense, useState } from 'react'
+
+const LazyEmojiPicker = lazy(async () => ({
+  default: (await import('@/components/note/note-title/EmojiPicker')).EmojiPicker
+}))
 
 const log = createLogger('Component:RowContextMenu')
 
@@ -56,6 +64,8 @@ interface RowContextMenuProps {
   onMoveToFolder?: (noteIds: string[]) => void
   /** Callback when note(s) should be deleted */
   onDelete?: (noteIds: string[]) => void
+  /** Callback to set (or clear, with `null`) the row's icon */
+  onSetIcon?: (noteId: string, icon: string | null) => void
 }
 
 /**
@@ -70,10 +80,16 @@ export function RowContextMenu({
   onNoteOpen,
   onOpenInNewTab,
   onMoveToFolder,
-  onDelete
+  onDelete,
+  onSetIcon
 }: RowContextMenuProps): React.JSX.Element {
   const { t: tPhaseF } = useT('notes')
   const fileActions = useFileActionLabels()
+
+  // The picker is hosted in a centred dialog rather than a popover: a context
+  // menu has no stable element to anchor to (the row spans the whole table),
+  // and a dialog is the one placement that can never land off screen.
+  const [isIconPickerOpen, setIsIconPickerOpen] = useState(false)
 
   // Delete and Move to Folder are notes-only IPCs (notesService.delete /
   // notesService.move). Folder view rows are always notes (kind absent),
@@ -151,6 +167,11 @@ export function RowContextMenu({
     }
   }
 
+  const handleSetIcon = (icon: string | null): void => {
+    if (!isNote) return
+    onSetIcon?.(note.id, icon)
+  }
+
   const handleDelete = (): void => {
     if (!isNote) return
     onDelete?.([note.id])
@@ -172,90 +193,122 @@ export function RowContextMenu({
   }
 
   return (
-    <ContextMenu>
-      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-      <ContextMenuContent className="w-52">
-        {showBulkActions ? (
-          // Bulk actions menu (multi-select)
-          <>
-            <ContextMenuItem onClick={handleBulkMoveToFolder}>
-              <FolderInput className="me-2 h-4 w-4" />
-              Move {selectedNoteCount} Notes to Folder...
-              <ContextMenuShortcut>⇧⌘M</ContextMenuShortcut>
-            </ContextMenuItem>
-            <ContextMenuSeparator />
-            <ContextMenuItem variant="destructive" onClick={handleBulkDelete}>
-              <Trash2 className="me-2 h-4 w-4" />
-              {tPhaseF('phaseF.componentsFolderViewRowContextMenu.delete')}
-              {selectedNoteCount} {tPhaseF('phaseF.componentsFolderViewRowContextMenu.notes')}
-            </ContextMenuItem>
-          </>
-        ) : (
-          // Single note actions menu
-          <>
-            {/* Open actions */}
-            <ContextMenuItem onClick={handleOpen}>
-              <FileText className="me-2 h-4 w-4" />
-
-              {tPhaseF('phaseF.componentsFolderViewRowContextMenu.open')}
-            </ContextMenuItem>
-            <ContextMenuItem onClick={handleOpenInNewTab}>
-              <FileText className="me-2 h-4 w-4" />
-              Open in New Tab
-              <ContextMenuShortcut>⌘↵</ContextMenuShortcut>
-            </ContextMenuItem>
-
-            <ContextMenuSeparator />
-
-            {/* External actions */}
-            <ContextMenuItem onClick={() => void handleOpenExternal()}>
-              <ExternalLink className="me-2 h-4 w-4" />
-
-              {tPhaseF('phaseF.componentsFolderViewRowContextMenu.openInExternalEditor')}
-            </ContextMenuItem>
-            <ContextMenuItem onClick={() => void handleRevealInFinder()}>
-              <FolderOpen className="me-2 h-4 w-4" />
-
-              {fileActions.revealInFolder}
-            </ContextMenuItem>
-            <ContextMenuItem onClick={handleRevealInSidebar}>
-              <PanelLeft className="me-2 h-4 w-4" />
-
-              {tPhaseF('phaseF.componentsFolderViewRowContextMenu.revealInSidebar')}
-            </ContextMenuItem>
-
-            <ContextMenuSeparator />
-
-            {/* Utility actions */}
-            <ContextMenuItem onClick={() => void handleCopyLink()}>
-              <Link className="me-2 h-4 w-4" />
-
-              {tPhaseF('phaseF.componentsFolderViewRowContextMenu.copyLink')}
-            </ContextMenuItem>
-            {isNote && (
-              <ContextMenuItem onClick={handleMoveToFolder}>
+    <>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+        <ContextMenuContent className="w-52">
+          {showBulkActions ? (
+            // Bulk actions menu (multi-select)
+            <>
+              <ContextMenuItem onClick={handleBulkMoveToFolder}>
                 <FolderInput className="me-2 h-4 w-4" />
-                Move to Folder...
+                Move {selectedNoteCount} Notes to Folder...
                 <ContextMenuShortcut>⇧⌘M</ContextMenuShortcut>
               </ContextMenuItem>
-            )}
+              <ContextMenuSeparator />
+              <ContextMenuItem variant="destructive" onClick={handleBulkDelete}>
+                <Trash2 className="me-2 h-4 w-4" />
+                {tPhaseF('phaseF.componentsFolderViewRowContextMenu.delete')}
+                {selectedNoteCount} {tPhaseF('phaseF.componentsFolderViewRowContextMenu.notes')}
+              </ContextMenuItem>
+            </>
+          ) : (
+            // Single note actions menu
+            <>
+              {/* Open actions */}
+              <ContextMenuItem onClick={handleOpen}>
+                <FileText className="me-2 h-4 w-4" />
 
-            {isNote && (
-              <>
-                <ContextMenuSeparator />
+                {tPhaseF('phaseF.componentsFolderViewRowContextMenu.open')}
+              </ContextMenuItem>
+              <ContextMenuItem onClick={handleOpenInNewTab}>
+                <FileText className="me-2 h-4 w-4" />
+                Open in New Tab
+                <ContextMenuShortcut>⌘↵</ContextMenuShortcut>
+              </ContextMenuItem>
 
-                {/* Destructive actions */}
-                <ContextMenuItem variant="destructive" onClick={handleDelete}>
-                  <Trash2 className="me-2 h-4 w-4" />
+              <ContextMenuSeparator />
 
-                  {tPhaseF('phaseF.componentsFolderViewRowContextMenu.delete2')}
+              {/* External actions */}
+              <ContextMenuItem onClick={() => void handleOpenExternal()}>
+                <ExternalLink className="me-2 h-4 w-4" />
+
+                {tPhaseF('phaseF.componentsFolderViewRowContextMenu.openInExternalEditor')}
+              </ContextMenuItem>
+              <ContextMenuItem onClick={() => void handleRevealInFinder()}>
+                <FolderOpen className="me-2 h-4 w-4" />
+
+                {fileActions.revealInFolder}
+              </ContextMenuItem>
+              <ContextMenuItem onClick={handleRevealInSidebar}>
+                <PanelLeft className="me-2 h-4 w-4" />
+
+                {tPhaseF('phaseF.componentsFolderViewRowContextMenu.revealInSidebar')}
+              </ContextMenuItem>
+
+              <ContextMenuSeparator />
+
+              {/* Utility actions */}
+              <ContextMenuItem onClick={() => void handleCopyLink()}>
+                <Link className="me-2 h-4 w-4" />
+
+                {tPhaseF('phaseF.componentsFolderViewRowContextMenu.copyLink')}
+              </ContextMenuItem>
+              {isNote && onSetIcon && (
+                <ContextMenuItem onClick={() => setIsIconPickerOpen(true)}>
+                  <Smile className="me-2 h-4 w-4" />
+                  {tPhaseF('tree.actions.setIcon')}
                 </ContextMenuItem>
-              </>
-            )}
-          </>
-        )}
-      </ContextMenuContent>
-    </ContextMenu>
+              )}
+              {isNote && onSetIcon && note.emoji && (
+                <ContextMenuItem onClick={() => handleSetIcon(null)}>
+                  <X className="me-2 h-4 w-4" />
+                  {tPhaseF('tree.actions.removeIcon')}
+                </ContextMenuItem>
+              )}
+              {isNote && (
+                <ContextMenuItem onClick={handleMoveToFolder}>
+                  <FolderInput className="me-2 h-4 w-4" />
+                  Move to Folder...
+                  <ContextMenuShortcut>⇧⌘M</ContextMenuShortcut>
+                </ContextMenuItem>
+              )}
+
+              {isNote && (
+                <>
+                  <ContextMenuSeparator />
+
+                  {/* Destructive actions */}
+                  <ContextMenuItem variant="destructive" onClick={handleDelete}>
+                    <Trash2 className="me-2 h-4 w-4" />
+
+                    {tPhaseF('phaseF.componentsFolderViewRowContextMenu.delete2')}
+                  </ContextMenuItem>
+                </>
+              )}
+            </>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
+
+      <Dialog open={isIconPickerOpen} onOpenChange={setIsIconPickerOpen}>
+        <DialogContent className="w-auto max-w-none border-0 bg-transparent p-0 shadow-none">
+          <DialogHeader className="sr-only">
+            <DialogTitle>{tPhaseF('tree.actions.setIcon')}</DialogTitle>
+          </DialogHeader>
+          <Suspense fallback={null}>
+            <LazyEmojiPicker
+              isOpen
+              embedded
+              onClose={() => setIsIconPickerOpen(false)}
+              onSelect={(icon) => handleSetIcon(icon)}
+              onRemove={() => handleSetIcon(null)}
+              hasEmoji={!!note.emoji}
+            />
+          </Suspense>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }
 

--- a/apps/desktop/src/renderer/src/hooks/use-folder-view.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-folder-view.test.tsx
@@ -302,12 +302,14 @@ describe('useFolderView', () => {
     await act(async () => {
       await result.current.updateNoteProperty('n1', 'status', 'review')
       await result.current.updateNoteTags('n1', ['new'])
+      await result.current.updateNoteIcon('n1', '🚀')
       result.current.removeNotesOptimistically(['n2'])
       await result.current.refresh()
     })
 
     expect(mocks.propertiesSet).toHaveBeenCalledWith('n1', { status: 'review' })
     expect(mocks.notesUpdate).toHaveBeenCalledWith({ id: 'n1', tags: ['new'] })
+    expect(mocks.notesUpdate).toHaveBeenCalledWith({ id: 'n1', emoji: '🚀' })
     expect(window.api.folderView.getViews).toHaveBeenCalled()
   })
 
@@ -454,6 +456,13 @@ describe('useFolderView', () => {
       await result.current.updateNoteTags('n1', ['bad'])
     })
     expect(toast.error).toHaveBeenCalledWith('phaseI.toasts.failedToUpdateTags')
+
+    mocks.notesUpdate.mockResolvedValueOnce({ success: false, error: 'No icon' })
+    await act(async () => {
+      await result.current.updateNoteIcon('n1', null)
+    })
+    expect(mocks.notesUpdate).toHaveBeenCalledWith({ id: 'n1', emoji: null })
+    expect(toast.error).toHaveBeenCalledWith('phaseI.toasts.failedToUpdateIcon')
     ;(window.api.folderView.getConfig as any).mockRejectedValueOnce(new Error('summary failed'))
     await act(async () => {
       await result.current.updateSummaryConfig('title', { type: 'count' })

--- a/apps/desktop/src/renderer/src/hooks/use-folder-view.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-folder-view.ts
@@ -239,6 +239,8 @@ interface UseFolderViewResult {
   updateNoteProperty: (noteId: string, propertyId: string, value: unknown) => Promise<void>
   /** Update tags on a note */
   updateNoteTags: (noteId: string, tags: string[]) => Promise<void>
+  /** Set (or clear, with `null`) a note's icon */
+  updateNoteIcon: (noteId: string, emoji: string | null) => Promise<void>
   /** Total unfiltered note count (for "showing X of Y") */
   unfilteredCount: number
 }
@@ -940,6 +942,48 @@ export function useFolderView({
   )
 
   /**
+   * Set or clear a note's icon with optimistic cache update.
+   *
+   * `null` removes the icon. The row's title cell reads `note.emoji`, so the
+   * optimistic write is what makes the new glyph appear before the IPC lands.
+   */
+  const updateNoteIcon = useCallback(
+    async (noteId: string, emoji: string | null) => {
+      const previousData = queryClient.getQueryData<InfiniteData<ListWithPropertiesResponse>>(
+        folderViewKeys.notes(scope)
+      )
+
+      queryClient.setQueryData<InfiniteData<ListWithPropertiesResponse>>(
+        folderViewKeys.notes(scope),
+        (old) => {
+          if (!old) return old
+          return {
+            ...old,
+            pages: old.pages.map((page) => ({
+              ...page,
+              notes: page.notes.map((note) => (note.id === noteId ? { ...note, emoji } : note))
+            }))
+          }
+        }
+      )
+
+      try {
+        const result = await notesService.update({ id: noteId, emoji })
+        if (!result.success) {
+          throw new Error(result.error ?? 'Failed to update icon')
+        }
+      } catch (err) {
+        log.error('Failed to update icon:', err)
+        toast.error(getI18n().getFixedT(null, 'notes')('phaseI.toasts.failedToUpdateIcon'))
+        if (previousData) {
+          queryClient.setQueryData(folderViewKeys.notes(scope), previousData)
+        }
+      }
+    },
+    [scope, queryClient]
+  )
+
+  /**
    * Refresh all data by invalidating queries
    */
   const refresh = useCallback(async () => {
@@ -1153,7 +1197,8 @@ export function useFolderView({
     refresh,
     removeNotesOptimistically,
     updateNoteProperty,
-    updateNoteTags
+    updateNoteTags,
+    updateNoteIcon
   }
 }
 

--- a/apps/desktop/src/renderer/src/pages/folder-view.tsx
+++ b/apps/desktop/src/renderer/src/pages/folder-view.tsx
@@ -147,7 +147,8 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
     refresh,
     removeNotesOptimistically,
     updateNoteProperty,
-    updateNoteTags
+    updateNoteTags,
+    updateNoteIcon
   } = useFolderView({ scope, initialViewName: storedViewName ?? undefined })
 
   // Get first note for formula preview in editor
@@ -1223,6 +1224,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
               onFolderClick={handleFolderClick}
               onTagClick={handleTagClick}
               onTagRemove={handleTagRemove}
+              onSetIcon={(...args) => void updateNoteIcon(...args)}
               tagMetaMap={tagMetaMap}
               onPropertyUpdate={(...args) => void updateNoteProperty(...args)}
               onColumnsChange={(...args) => void updateColumns(...args)}
@@ -1258,6 +1260,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
               onFolderClick={handleFolderClick}
               onTagClick={handleTagClick}
               onTagRemove={handleTagRemove}
+              onSetIcon={(...args) => void updateNoteIcon(...args)}
               tagMetaMap={tagMetaMap}
               onPropertyUpdate={(...args) => void updateNoteProperty(...args)}
               onColumnsChange={(...args) => void updateColumns(...args)}

--- a/apps/docs/src/user-guide/notes/custom-icons.md
+++ b/apps/docs/src/user-guide/notes/custom-icons.md
@@ -9,6 +9,10 @@ everywhere.
 Open any icon picker — click a folder's icon in the sidebar, or a note's icon next to its title —
 and switch to **Custom**.
 
+When a folder is open as a tab, you can also right-click any note row there and choose **Set Icon**
+(or **Remove Icon**, when the note already has one). That opens the same picker in a centred
+dialog, which is handy when the note's own icon is not on screen.
+
 - **Drop an image** anywhere on the panel,
 - **Click the upload area** and pick one or more files, or
 - **Paste a link** into the link field and press Enter.

--- a/packages/i18n/src/locales/ar/notes.json
+++ b/packages/i18n/src/locales/ar/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "تم تصدير الملاحظة بنجاح",
       "failedToUpdateProperty": "فشل في تحديث الخاصية",
       "failedToUpdateTags": "فشل تحديث العلامات",
+      "failedToUpdateIcon": "فشل تحديث الأيقونة",
       "reminderSnoozed": "تم تأجيل التذكير",
       "failedToSnoozeReminder": "فشل تأجيل التذكير",
       "defaultTemplateSet": "مجموعة القالب الافتراضية",

--- a/packages/i18n/src/locales/cs/notes.json
+++ b/packages/i18n/src/locales/cs/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Poznámka byla úspěšně exportována",
       "failedToUpdateProperty": "Aktualizace služby se nezdařila",
       "failedToUpdateTags": "Aktualizace značek se nezdařila",
+      "failedToUpdateIcon": "Nepodařilo se aktualizovat ikonu",
       "reminderSnoozed": "Připomenutí odloženo",
       "failedToSnoozeReminder": "Připomenutí se nepodařilo odložit",
       "defaultTemplateSet": "Výchozí sada šablon",

--- a/packages/i18n/src/locales/da/notes.json
+++ b/packages/i18n/src/locales/da/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Noten blev eksporteret",
       "failedToUpdateProperty": "Ejendommen kunne ikke opdateres",
       "failedToUpdateTags": "Kunne ikke opdatere tags",
+      "failedToUpdateIcon": "Kunne ikke opdatere ikonet",
       "reminderSnoozed": "Påmindelsen er udsat",
       "failedToSnoozeReminder": "Kunne ikke udsætte påmindelsen",
       "defaultTemplateSet": "Standard skabelonsæt",

--- a/packages/i18n/src/locales/de/notes.json
+++ b/packages/i18n/src/locales/de/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Notiz erfolgreich exportiert",
       "failedToUpdateProperty": "Die Eigenschaft konnte nicht aktualisiert werden",
       "failedToUpdateTags": "Tags konnten nicht aktualisiert werden",
+      "failedToUpdateIcon": "Symbol konnte nicht aktualisiert werden",
       "reminderSnoozed": "Erinnerung wurde deaktiviert",
       "failedToSnoozeReminder": "Schlummerfunktion der Erinnerung fehlgeschlagen",
       "defaultTemplateSet": "Standardvorlagensatz",

--- a/packages/i18n/src/locales/el/notes.json
+++ b/packages/i18n/src/locales/el/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Η σημείωση εξήχθη με επιτυχία",
       "failedToUpdateProperty": "Η ενημέρωση της ιδιοκτησίας απέτυχε",
       "failedToUpdateTags": "Η ενημέρωση των ετικετών απέτυχε",
+      "failedToUpdateIcon": "Αποτυχία ενημέρωσης εικονιδίου",
       "reminderSnoozed": "Η υπενθύμιση αναβλήθηκε",
       "failedToSnoozeReminder": "Απέτυχε η αναβολή της υπενθύμισης",
       "defaultTemplateSet": "Προεπιλεγμένο σύνολο προτύπων",

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -953,6 +953,7 @@
       "noteExportedSuccessfully": "Note exported successfully",
       "failedToUpdateProperty": "Failed to update property",
       "failedToUpdateTags": "Failed to update tags",
+      "failedToUpdateIcon": "Failed to update icon",
       "reminderSnoozed": "Reminder snoozed",
       "failedToSnoozeReminder": "Failed to snooze reminder",
       "defaultTemplateSet": "Default template set",

--- a/packages/i18n/src/locales/es/notes.json
+++ b/packages/i18n/src/locales/es/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Nota exportada exitosamente",
       "failedToUpdateProperty": "No se pudo actualizar la propiedad",
       "failedToUpdateTags": "No se pudieron actualizar las etiquetas",
+      "failedToUpdateIcon": "No se pudo actualizar el icono",
       "reminderSnoozed": "Recordatorio pospuesto",
       "failedToSnoozeReminder": "No se pudo posponer el recordatorio",
       "defaultTemplateSet": "Conjunto de plantillas predeterminado",

--- a/packages/i18n/src/locales/fi/notes.json
+++ b/packages/i18n/src/locales/fi/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Muistiinpanon vienti onnistui",
       "failedToUpdateProperty": "Omaisuuden päivittäminen epäonnistui",
       "failedToUpdateTags": "Tunnisteiden päivittäminen epäonnistui",
+      "failedToUpdateIcon": "Kuvakkeen päivitys epäonnistui",
       "reminderSnoozed": "Muistutus torkutettu",
       "failedToSnoozeReminder": "Muistutuksen torkkuminen epäonnistui",
       "defaultTemplateSet": "Oletusmalli asetettu",

--- a/packages/i18n/src/locales/fil/notes.json
+++ b/packages/i18n/src/locales/fil/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Matagumpay na na-export ang tala",
       "failedToUpdateProperty": "Nabigong i-update ang property",
       "failedToUpdateTags": "Nabigong i-update ang mga tag",
+      "failedToUpdateIcon": "Nabigong i-update ang icon",
       "reminderSnoozed": "Naka-snooze ang paalala",
       "failedToSnoozeReminder": "Nabigong i-snooze ang paalala",
       "defaultTemplateSet": "Default na set ng template",

--- a/packages/i18n/src/locales/fr/notes.json
+++ b/packages/i18n/src/locales/fr/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Note exportée avec succès",
       "failedToUpdateProperty": "Échec de la mise à jour de la propriété",
       "failedToUpdateTags": "Échec de la mise à jour des balises",
+      "failedToUpdateIcon": "Échec de la mise à jour de l'icône",
       "reminderSnoozed": "Rappel mis en attente",
       "failedToSnoozeReminder": "Échec de la répétition du rappel",
       "defaultTemplateSet": "Ensemble de modèles par défaut",

--- a/packages/i18n/src/locales/he/notes.json
+++ b/packages/i18n/src/locales/he/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "הערה יצאה בהצלחה",
       "failedToUpdateProperty": "עדכון הנכס נכשל",
       "failedToUpdateTags": "עדכון התגים נכשל",
+      "failedToUpdateIcon": "עדכון הסמל נכשל",
       "reminderSnoozed": "התזכורת הושהה",
       "failedToSnoozeReminder": "השהיית התזכורת נכשלה",
       "defaultTemplateSet": "ערכת תבנית ברירת מחדל",

--- a/packages/i18n/src/locales/hr/notes.json
+++ b/packages/i18n/src/locales/hr/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Bilješka je uspješno izvezena",
       "failedToUpdateProperty": "Ažuriranje svojstva nije uspjelo",
       "failedToUpdateTags": "Ažuriranje oznaka nije uspjelo",
+      "failedToUpdateIcon": "Ažuriranje ikone nije uspjelo",
       "reminderSnoozed": "Podsjetnik je odgođen",
       "failedToSnoozeReminder": "Odgoda podsjetnika nije uspjela",
       "defaultTemplateSet": "Zadani skup predložaka",

--- a/packages/i18n/src/locales/hu/notes.json
+++ b/packages/i18n/src/locales/hu/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Jegyzet sikeresen exportálva",
       "failedToUpdateProperty": "Nem sikerült frissíteni a tulajdonságot",
       "failedToUpdateTags": "Nem sikerült frissíteni a címkéket",
+      "failedToUpdateIcon": "Az ikon frissítése sikertelen",
       "reminderSnoozed": "Az emlékeztető elhalasztva",
       "failedToSnoozeReminder": "Nem sikerült elhalasztani az emlékeztetőt",
       "defaultTemplateSet": "Alapértelmezett sablonkészlet",

--- a/packages/i18n/src/locales/id/notes.json
+++ b/packages/i18n/src/locales/id/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Catatan berhasil diekspor",
       "failedToUpdateProperty": "Gagal memperbarui properti",
       "failedToUpdateTags": "Gagal memperbarui tag",
+      "failedToUpdateIcon": "Gagal memperbarui ikon",
       "reminderSnoozed": "Pengingat ditunda",
       "failedToSnoozeReminder": "Gagal menunda pengingat",
       "defaultTemplateSet": "Kumpulan templat bawaan",

--- a/packages/i18n/src/locales/it/notes.json
+++ b/packages/i18n/src/locales/it/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Nota esportata con successo",
       "failedToUpdateProperty": "Impossibile aggiornare la proprietà",
       "failedToUpdateTags": "Impossibile aggiornare i tag",
+      "failedToUpdateIcon": "Aggiornamento dell'icona non riuscito",
       "reminderSnoozed": "Promemoria posticipato",
       "failedToSnoozeReminder": "Impossibile posticipare il promemoria",
       "defaultTemplateSet": "Insieme di modelli predefiniti",

--- a/packages/i18n/src/locales/ja/notes.json
+++ b/packages/i18n/src/locales/ja/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "メモは正常にエクスポートされました",
       "failedToUpdateProperty": "プロパティの更新に失敗しました",
       "failedToUpdateTags": "タグの更新に失敗しました",
+      "failedToUpdateIcon": "アイコンの更新に失敗しました",
       "reminderSnoozed": "リマインダーがスヌーズされました",
       "failedToSnoozeReminder": "リマインダーのスヌーズに失敗しました",
       "defaultTemplateSet": "デフォルトのテンプレートセット",

--- a/packages/i18n/src/locales/ko/notes.json
+++ b/packages/i18n/src/locales/ko/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "메모를 성공적으로 내보냈습니다.",
       "failedToUpdateProperty": "속성을 업데이트하지 못했습니다.",
       "failedToUpdateTags": "태그를 업데이트하지 못했습니다.",
+      "failedToUpdateIcon": "아이콘을 업데이트하지 못했습니다",
       "reminderSnoozed": "알림이 일시중지되었습니다.",
       "failedToSnoozeReminder": "알림을 일시중지하지 못했습니다.",
       "defaultTemplateSet": "기본 템플릿 세트",

--- a/packages/i18n/src/locales/ms/notes.json
+++ b/packages/i18n/src/locales/ms/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Nota berjaya dieksport",
       "failedToUpdateProperty": "Gagal mengemas kini harta benda",
       "failedToUpdateTags": "Gagal mengemas kini teg",
+      "failedToUpdateIcon": "Gagal mengemas kini ikon",
       "reminderSnoozed": "Peringatan ditunda",
       "failedToSnoozeReminder": "Gagal menunda peringatan",
       "defaultTemplateSet": "Set templat lalai",

--- a/packages/i18n/src/locales/nl/notes.json
+++ b/packages/i18n/src/locales/nl/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Opmerking succesvol geëxporteerd",
       "failedToUpdateProperty": "Kan de eigenschap niet updaten",
       "failedToUpdateTags": "Kan tags niet updaten",
+      "failedToUpdateIcon": "Kan pictogram niet bijwerken",
       "reminderSnoozed": "Herinnering gesnoozed",
       "failedToSnoozeReminder": "Kan herinnering niet snoozen",
       "defaultTemplateSet": "Standaardsjabloonset",

--- a/packages/i18n/src/locales/no/notes.json
+++ b/packages/i18n/src/locales/no/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Notatet ble eksportert",
       "failedToUpdateProperty": "Kunne ikke oppdatere egenskapen",
       "failedToUpdateTags": "Kunne ikke oppdatere tagger",
+      "failedToUpdateIcon": "Kunne ikke oppdatere ikonet",
       "reminderSnoozed": "Påminnelsen er slumret",
       "failedToSnoozeReminder": "Kunne ikke slumre påminnelsen",
       "defaultTemplateSet": "Standard malsett",

--- a/packages/i18n/src/locales/pl/notes.json
+++ b/packages/i18n/src/locales/pl/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Notatka została pomyślnie wyeksportowana",
       "failedToUpdateProperty": "Nie udało się zaktualizować właściwości",
       "failedToUpdateTags": "Nie udało się zaktualizować tagów",
+      "failedToUpdateIcon": "Nie udało się zaktualizować ikony",
       "reminderSnoozed": "Przypomnienie zostało odłożone",
       "failedToSnoozeReminder": "Nie udało się odłożyć przypomnienia",
       "defaultTemplateSet": "Domyślny zestaw szablonów",

--- a/packages/i18n/src/locales/pt/notes.json
+++ b/packages/i18n/src/locales/pt/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Nota exportada com sucesso",
       "failedToUpdateProperty": "Falha ao atualizar a propriedade",
       "failedToUpdateTags": "Falha ao atualizar tags",
+      "failedToUpdateIcon": "Falha ao atualizar o ícone",
       "reminderSnoozed": "Lembrete adiado",
       "failedToSnoozeReminder": "Falha ao adiar o lembrete",
       "defaultTemplateSet": "Conjunto de modelos padrão",

--- a/packages/i18n/src/locales/ro/notes.json
+++ b/packages/i18n/src/locales/ro/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Nota exportată cu succes",
       "failedToUpdateProperty": "Nu s-a putut actualiza proprietatea",
       "failedToUpdateTags": "Nu s-au actualizat etichetele",
+      "failedToUpdateIcon": "Actualizarea pictogramei a eșuat",
       "reminderSnoozed": "Memento amânat",
       "failedToSnoozeReminder": "Mementoul nu a fost amânat",
       "defaultTemplateSet": "Set de șabloane implicit",

--- a/packages/i18n/src/locales/ru/notes.json
+++ b/packages/i18n/src/locales/ru/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Заметка успешно экспортирована",
       "failedToUpdateProperty": "Не удалось обновить ресурс.",
       "failedToUpdateTags": "Не удалось обновить теги.",
+      "failedToUpdateIcon": "Не удалось обновить значок",
       "reminderSnoozed": "Напоминание отложено",
       "failedToSnoozeReminder": "Не удалось отложить напоминание.",
       "defaultTemplateSet": "Набор шаблонов по умолчанию",

--- a/packages/i18n/src/locales/sk/notes.json
+++ b/packages/i18n/src/locales/sk/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Poznámka bola úspešne exportovaná",
       "failedToUpdateProperty": "Nepodarilo sa aktualizovať vlastnosť",
       "failedToUpdateTags": "Nepodarilo sa aktualizovať značky",
+      "failedToUpdateIcon": "Nepodarilo sa aktualizovať ikonu",
       "reminderSnoozed": "Pripomienka odložená",
       "failedToSnoozeReminder": "Nepodarilo sa odložiť pripomienku",
       "defaultTemplateSet": "Predvolená šablóna nastavená",

--- a/packages/i18n/src/locales/sv/notes.json
+++ b/packages/i18n/src/locales/sv/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Noten exporterades framgångsrikt",
       "failedToUpdateProperty": "Misslyckades med att uppdatera egenskap",
       "failedToUpdateTags": "Det gick inte att uppdatera taggar",
+      "failedToUpdateIcon": "Det gick inte att uppdatera ikonen",
       "reminderSnoozed": "Påminnelse uppskjuten",
       "failedToSnoozeReminder": "Det gick inte att skjuta upp påminnelse",
       "defaultTemplateSet": "Standardmall inställd",

--- a/packages/i18n/src/locales/th/notes.json
+++ b/packages/i18n/src/locales/th/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "บันทึกโน้ตสำเร็จแล้ว",
       "failedToUpdateProperty": "ล้มเหลวในการอัปเดตทรัพย์สิน",
       "failedToUpdateTags": "ไม่สามารถอัปเดตแท็กได้",
+      "failedToUpdateIcon": "อัปเดตไอคอนไม่สำเร็จ",
       "reminderSnoozed": "เลื่อนการเตือนแล้ว",
       "failedToSnoozeReminder": "ไม่สามารถเลื่อนเตือนความจำได้",
       "defaultTemplateSet": "ตั้งค่าเทมเพลตเริ่มต้นแล้ว",

--- a/packages/i18n/src/locales/tr/notes.json
+++ b/packages/i18n/src/locales/tr/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Not başarıyla dışa aktarıldı",
       "failedToUpdateProperty": "Özellik güncellenemedi",
       "failedToUpdateTags": "Etiketler güncellenemedi",
+      "failedToUpdateIcon": "Simge güncellenemedi",
       "reminderSnoozed": "Hatırlatıcı ertelendi",
       "failedToSnoozeReminder": "Hatırlatıcı ertelenemedi",
       "defaultTemplateSet": "Varsayılan şablon ayarlandı",

--- a/packages/i18n/src/locales/uk/notes.json
+++ b/packages/i18n/src/locales/uk/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Нотатку успішно експортовано",
       "failedToUpdateProperty": "Не вдалося оновити властивість",
       "failedToUpdateTags": "Не вдалося оновити теги",
+      "failedToUpdateIcon": "Не вдалося оновити піктограму",
       "reminderSnoozed": "Нагадування відкладено",
       "failedToSnoozeReminder": "Не вдалося відкласти нагадування",
       "defaultTemplateSet": "Встановлено шаблон за замовчуванням",

--- a/packages/i18n/src/locales/vi/notes.json
+++ b/packages/i18n/src/locales/vi/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "Ghi chú đã xuất thành công",
       "failedToUpdateProperty": "Không cập nhật được thuộc tính",
       "failedToUpdateTags": "Không thể cập nhật thẻ",
+      "failedToUpdateIcon": "Không thể cập nhật biểu tượng",
       "reminderSnoozed": "Nhắc nhở đã được hoãn",
       "failedToSnoozeReminder": "Không thể hoãn nhắc nhở",
       "defaultTemplateSet": "Mẫu mặc định đã được đặt",

--- a/packages/i18n/src/locales/zh-CN/notes.json
+++ b/packages/i18n/src/locales/zh-CN/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "笔记导出成功",
       "failedToUpdateProperty": "更新属性失败",
       "failedToUpdateTags": "更新标签失败",
+      "failedToUpdateIcon": "更新图标失败",
       "reminderSnoozed": "提醒已延迟",
       "failedToSnoozeReminder": "推迟提醒失败",
       "defaultTemplateSet": "已设置默认模板",

--- a/packages/i18n/src/locales/zh-TW/notes.json
+++ b/packages/i18n/src/locales/zh-TW/notes.json
@@ -722,6 +722,7 @@
       "noteExportedSuccessfully": "筆記匯出成功",
       "failedToUpdateProperty": "無法更新屬性",
       "failedToUpdateTags": "無法更新標籤",
+      "failedToUpdateIcon": "更新圖示失敗",
       "reminderSnoozed": "提醒已延遲",
       "failedToSnoozeReminder": "無法延後提醒",
       "defaultTemplateSet": "已設為預設範本",


### PR DESCRIPTION
## Summary

Closes #1985.

Opening a folder as a tab is the one icon path the reporter of #1984 found reliable, but the right-click menu on a note row there had no icon entry, so that path was not reachable from where they reached for it.

- **Set Icon** (and **Remove Icon**, only when the row already has one) in `row-context-menu.tsx`, gated on `isNote` like the other note-only actions, so task and inbox rows under tag scope never offer it.
- New `updateNoteIcon(noteId, emoji)` in `useFolderView`, a direct mirror of the existing `updateNoteTags`: optimistic cache write, `notesService.update`, rollback + toast on failure.
- Threaded as `onSetIcon` through `FolderTableView` and `GroupedTable` — the two views that have a row context menu at all.

Assumptions, for review:

- **The picker is hosted in a centred `Dialog`, not the usual popover.** `IconPickerButton` needs a visible trigger to anchor to; a context menu has none, and the row itself spans the whole table so anchoring to it puts the panel at the far edge. A centred dialog also cannot land off screen, which is the property the reporter asked for. The shared `EmojiPicker` is reused as-is in `embedded` mode — no icon logic is duplicated.
- **No new i18n strings for the menu items.** `notes:tree.actions.setIcon` / `removeIcon` already exist and are translated in all 32 locales; the sidebar tree uses the same two. Only one genuinely new key was needed, `phaseI.toasts.failedToUpdateIcon`, added and translated across all 32.
- List and gallery views are untouched: they have no row context menu at all, so wiring one there is a separate change.

## Release note

Right-click a note row in a folder opened as a tab to set or remove its icon.

## Test plan

- `pnpm lint`
- `pnpm typecheck` (incl. `check:contracts`, `check:architecture`, `ipc:check` — all up to date, no contract changes)
- `pnpm --filter @memry/desktop test:renderer` — 730 files, 9003 tests green
- New unit tests: `row-context-menu.test.tsx` (Set Icon opens the picker and writes the pick back; Remove Icon only when the row has an icon, and clears it; both hidden for non-note rows and when no handler is wired), `use-folder-view.test.tsx` (`updateNoteIcon` hits `notesService.update` with `emoji`, and rolls back with a toast on failure)
- `pnpm --filter @memry/desktop i18n:check`
- `pnpm docs:impact --base origin/main --strict` + `pnpm docs:build`

No E2E: the existing `folder-view.e2e.ts` suite cannot reach a folder tab in this local environment — its `beforeEach` never gets past `navigateTo(page, 'notes')` and `T124` fails identically on `main`. Rather than land a spec I could not actually run, the behavior is covered by unit tests. Worth a separate look at why that suite only works in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)