### PR TITLE
fix(desktop): keep the sidebar icon picker open while the list scrolls

### DIFF
--- a/apps/desktop/src/renderer/src/components/icon-picker-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/icon-picker-button.test.tsx
@@ -34,14 +34,15 @@ vi.mock('@/components/ui/popover', async () => {
           onOpenChange?.(true)
         }
       }),
-    PopoverContent: ({ children, open, collisionPadding, side }: any) =>
+    PopoverContent: ({ children, open, collisionPadding, side, sticky }: any) =>
       open
         ? React.createElement(
             'div',
             {
               'data-testid': 'popover-content',
               'data-collision-padding': String(collisionPadding),
-              'data-side': side
+              'data-side': side,
+              'data-sticky': sticky
             },
             children
           )
@@ -210,5 +211,20 @@ describe('IconPickerButton', () => {
     const content = screen.getByTestId('popover-content')
     expect(content.getAttribute('data-collision-padding')).toBe('8')
     expect(content.getAttribute('data-side')).toBe('right')
+  })
+
+  // Radix's default shift limiter keeps the panel glued to its row, which on a
+  // short window left the bottom of the panel below the window edge instead of
+  // clamping it — intermittently, depending on how tall the lazy panel was when
+  // Radix first placed it (#1986).
+  it('drops the shift limiter so the panel is always clamped into view', () => {
+    render(
+      <IconPickerButton hasIcon={false} onIconChange={vi.fn()} ariaLabel="Set icon">
+        <span>📝</span>
+      </IconPickerButton>
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Set icon' }))
+
+    expect(screen.getByTestId('popover-content').getAttribute('data-sticky')).toBe('always')
   })
 })

--- a/apps/desktop/src/renderer/src/components/icon-picker-button.tsx
+++ b/apps/desktop/src/renderer/src/components/icon-picker-button.tsx
@@ -86,6 +86,11 @@ export function IconPickerButton({
           align="start"
           sideOffset={4}
           collisionPadding={8}
+          // Radix's default shift limiter keeps the panel glued to its row, which
+          // on a short window intermittently left the bottom of the panel below
+          // the window edge instead of clamping it. 'always' drops the limiter,
+          // so the panel is shifted fully back into view every time.
+          sticky="always"
           className="w-auto border-0 bg-transparent p-0 shadow-none"
           onClick={(e) => e.stopPropagation()}
         >

--- a/apps/desktop/src/renderer/src/components/settings/tag-icon-chip.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/tag-icon-chip.tsx
@@ -63,6 +63,8 @@ export function TagIconChip({ icon, color, onIconChange }: TagIconChipProps): Re
         align="start"
         sideOffset={6}
         collisionPadding={8}
+        // Same shift limiter as the sidebar picker (#1986).
+        sticky="always"
         className="w-auto border-0 bg-transparent p-0 shadow-none"
         onClick={(e) => e.stopPropagation()}
       >

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.test.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.test.tsx
@@ -25,7 +25,12 @@ Object.defineProperty(navigator, 'platform', {
 const mocks = vi.hoisted(() => ({
   openTab: vi.fn(),
   scrollToIndex: vi.fn(),
-  openPagesInNewTab: true
+  openPagesInNewTab: true,
+  // Last options the tree handed the virtualizer, so a test can drive the
+  // rangeExtractor the real virtualizer would call.
+  virtualizerOptions: null as {
+    rangeExtractor?: (range: { startIndex: number; endIndex: number }) => number[]
+  } | null
 }))
 
 vi.mock('@/hooks/use-general-settings', () => ({
@@ -46,17 +51,25 @@ vi.mock('@/contexts/tabs', () => ({
 }))
 
 vi.mock('@tanstack/react-virtual', () => ({
-  useVirtualizer: ({ count }: { count: number }) => ({
-    getVirtualItems: () =>
-      Array.from({ length: count }, (_, index) => ({
-        index,
-        key: index,
-        start: index * 28,
-        size: 28
-      })),
-    getTotalSize: () => count * 28,
-    scrollToIndex: mocks.scrollToIndex
-  })
+  defaultRangeExtractor: ({ startIndex, endIndex }: { startIndex: number; endIndex: number }) =>
+    Array.from({ length: endIndex - startIndex + 1 }, (_, offset) => startIndex + offset),
+  useVirtualizer: (options: {
+    count: number
+    rangeExtractor?: (range: { startIndex: number; endIndex: number }) => number[]
+  }) => {
+    mocks.virtualizerOptions = options
+    return {
+      getVirtualItems: () =>
+        Array.from({ length: options.count }, (_, index) => ({
+          index,
+          key: index,
+          start: index * 28,
+          size: 28
+        })),
+      getTotalSize: () => options.count * 28,
+      scrollToIndex: mocks.scrollToIndex
+    }
+  }
 }))
 
 vi.mock('@/components/ui/context-menu', () => ({
@@ -102,23 +115,35 @@ vi.mock('@/components/icon-picker-button', () => ({
     children,
     hasIcon,
     onIconChange,
+    onPickerOpenChange,
     ariaLabel
   }: {
     children: React.ReactNode
     hasIcon: boolean
     onIconChange: (icon: string | null) => void
+    onPickerOpenChange?: (open: boolean) => void
     ariaLabel: string
   }) => (
-    <button
-      type="button"
-      aria-label={ariaLabel}
-      onClick={(event) => {
-        event.stopPropagation()
-        onIconChange(hasIcon ? null : 'icon:Star')
-      }}
-    >
-      {children}
-    </button>
+    <>
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        onClick={(event) => {
+          event.stopPropagation()
+          onIconChange(hasIcon ? null : 'icon:Star')
+        }}
+      >
+        {children}
+      </button>
+      <button
+        type="button"
+        aria-label={`open ${ariaLabel}`}
+        onClick={(event) => {
+          event.stopPropagation()
+          onPickerOpenChange?.(true)
+        }}
+      />
+    </>
   )
 }))
 
@@ -513,6 +538,21 @@ describe('VirtualizedNotesTree', () => {
     // workNote has an emoji, so the icon button reports hasIcon and clears it on click
     await user.click(within(noteRow).getByRole('button', { name: 'Set Icon' }))
     expect(props.onSetNoteIcon).toHaveBeenCalledWith('note-work', null)
+  })
+
+  // A row the virtualizer drops takes the open picker popover with it, so the
+  // panel vanished mid-pick whenever the sidebar scrolled (#1986).
+  it('pins the row whose icon picker is open into the virtual range', async () => {
+    const user = userEvent.setup()
+    renderTree()
+
+    const rangeOffTheRow = { startIndex: 40, endIndex: 42 }
+    expect(mocks.virtualizerOptions?.rangeExtractor?.(rangeOffTheRow)).toEqual([40, 41, 42])
+
+    // Rows are: 0 the "Work" folder, 1 the note inside it, 2 the root note.
+    await user.click(screen.getAllByLabelText('open Set Icon')[0])
+
+    expect(mocks.virtualizerOptions?.rangeExtractor?.(rangeOffTheRow)).toEqual([1, 40, 41, 42])
   })
 
   it('handles storage failures and disabled drag without moving items', () => {

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
@@ -17,7 +17,7 @@ import {
   useLayoutEffect,
   useImperativeHandle
 } from 'react'
-import { useVirtualizer } from '@tanstack/react-virtual'
+import { defaultRangeExtractor, useVirtualizer } from '@tanstack/react-virtual'
 import {
   FolderOpen,
   LayoutGrid,
@@ -38,6 +38,7 @@ import {
   flattenTree,
   getAllFolderIds,
   TREE_ROW_HEIGHT,
+  withPinnedIndex,
   type TreeStructure,
   type FolderVirtualItem,
   type NoteVirtualItem
@@ -1028,13 +1029,39 @@ export function VirtualizedNotesTree({
     }
   }, [scrollContainerRef])
 
+  /**
+   * Index of the row whose icon picker is open, or -1.
+   *
+   * The picker is a Radix Popover living inside the row, so a row the
+   * virtualizer drops unmounts the popover with it and the panel vanishes
+   * mid-pick — the open state survives at this level, which is why it comes
+   * back when the row scrolls in again (#1986). Scrolling the sidebar at all,
+   * even by a stray trackpad nudge, is enough on rows near the edge of the
+   * virtual window.
+   */
+  const pinnedRowIndex = useMemo(() => {
+    const pinnedId = iconPickerFolderPath ? `folder-${iconPickerFolderPath}` : iconPickerNoteId
+    if (!pinnedId) return -1
+    return flatItems.findIndex((item) => item.id === pinnedId)
+  }, [flatItems, iconPickerFolderPath, iconPickerNoteId])
+
+  // Keep that row rendered wherever the scroll goes, so the popover stays mounted
+  // and Radix just re-anchors it instead of the picker disappearing.
+  const rangeExtractor = useCallback(
+    (range: Parameters<typeof defaultRangeExtractor>[0]) => {
+      return withPinnedIndex(defaultRangeExtractor(range), pinnedRowIndex)
+    },
+    [pinnedRowIndex]
+  )
+
   // Virtual list setup
   const virtualizer = useVirtualizer({
     count: flatItems.length,
     getScrollElement: () => scrollContainerRef?.current ?? parentRef.current,
     estimateSize: () => TREE_ROW_HEIGHT,
     overscan: 10, // Render 10 extra items above/below viewport
-    scrollMargin: usesExternalScroll ? scrollMargin : 0
+    scrollMargin: usesExternalScroll ? scrollMargin : 0,
+    rangeExtractor
   })
 
   /**

--- a/apps/desktop/src/renderer/src/lib/virtualized-tree-pinned-row.test.ts
+++ b/apps/desktop/src/renderer/src/lib/virtualized-tree-pinned-row.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Pinned virtual row (#1986).
+ *
+ * The sidebar icon picker is a popover rendered inside its row, so a row the
+ * virtualizer drops while scrolling takes the open panel down with it and the
+ * picker looks like it closed itself. The virtualizer's `rangeExtractor` runs
+ * this to keep that one row rendered wherever the list is scrolled.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { withPinnedIndex } from './virtualized-tree-utils'
+
+describe('withPinnedIndex', () => {
+  it('adds the pinned row when the virtual window scrolled past it', () => {
+    expect(withPinnedIndex([40, 41, 42], 5)).toEqual([5, 40, 41, 42])
+  })
+
+  it('keeps the result ascending when the pinned row is below the window', () => {
+    expect(withPinnedIndex([10, 11, 12], 99)).toEqual([10, 11, 12, 99])
+  })
+
+  it('returns the window untouched while the pinned row is still in it', () => {
+    const indexes = [4, 5, 6]
+    expect(withPinnedIndex(indexes, 5)).toBe(indexes)
+  })
+
+  // -1 is "no picker open" — the common case, and it must not add a row.
+  it('returns the window untouched when nothing is pinned', () => {
+    const indexes = [4, 5, 6]
+    expect(withPinnedIndex(indexes, -1)).toBe(indexes)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/virtualized-tree-utils.ts
+++ b/apps/desktop/src/renderer/src/lib/virtualized-tree-utils.ts
@@ -246,3 +246,16 @@ export function dropGapStartIndex(
 
   return dropPosition === 'before' ? index : index + 1
 }
+
+/**
+ * The virtual window plus the row that must stay mounted, in ascending order.
+ *
+ * The sidebar icon picker is a popover rendered inside its row, so a row the
+ * virtualizer drops takes the open panel with it and the picker looks like it
+ * closed itself mid-pick (#1986). Feeding this through the virtualizer's
+ * `rangeExtractor` keeps that one row rendered wherever the list is scrolled.
+ */
+export function withPinnedIndex(indexes: number[], pinnedIndex: number): number[] {
+  if (pinnedIndex < 0 || indexes.includes(pinnedIndex)) return indexes
+  return [...indexes, pinnedIndex].sort((a, b) => a - b)
+}

--- a/apps/desktop/tests/e2e/sidebar-icon-picker-scroll.e2e.ts
+++ b/apps/desktop/tests/e2e/sidebar-icon-picker-scroll.e2e.ts
@@ -1,0 +1,70 @@
+/**
+ * Sidebar icon picker survives a sidebar scroll (#1986).
+ *
+ * Past 100 tree items the sidebar swaps to the virtualized tree, which mounts
+ * only the visible rows plus a small overscan. The icon picker is a Radix
+ * Popover rendered *inside* its row, so any scroll that pushed that row out of
+ * the virtual window unmounted the popover with it and the panel vanished
+ * before anything was picked — intermittent, and dependent on how close the row
+ * sat to the edge of the window, which is exactly what the reporter described.
+ *
+ * The row whose picker is open is now pinned into the virtual range, so the
+ * panel stays mounted and Radix just re-anchors it.
+ */
+
+import type { Page } from '@playwright/test'
+
+import { test, expect } from './fixtures'
+import { ready } from './utils/desktop-test-helpers'
+
+const PICKER = 'Emoji and icon picker' // notes:menus.emoji.aria
+// The virtualized tree takes over at 100 items (VIRTUALIZATION_THRESHOLD).
+const SEEDED_NOTES = 130
+
+async function seedNotes(page: Page, count: number): Promise<void> {
+  await page.evaluate(async (total) => {
+    const api = (window as unknown as { api: Record<string, any> }).api
+    for (let i = 0; i < total; i++) {
+      await api.notes.create({
+        title: `Picker Scroll ${String(i).padStart(3, '0')}`,
+        content: 'seed'
+      })
+    }
+  }, count)
+}
+
+async function expandCollectionsSection(page: Page): Promise<void> {
+  const trigger = page.locator('button[aria-label^="Collections section, "]').first()
+  await trigger.waitFor({ state: 'visible', timeout: 20_000 })
+  const label = (await trigger.getAttribute('aria-label')) ?? ''
+  if (label.includes('collapsed')) await trigger.click()
+}
+
+test.describe('Sidebar icon picker in the virtualized tree', () => {
+  test('stays open when the sidebar scrolls under it', async ({ page }) => {
+    await ready(page)
+    await seedNotes(page, SEEDED_NOTES)
+    await page.reload()
+    await ready(page)
+    await expandCollectionsSection(page)
+
+    const triggers = page.getByRole('button', { name: 'Set Icon' })
+    await triggers.first().waitFor({ state: 'visible', timeout: 30_000 })
+
+    const trigger = triggers.nth(5)
+    await trigger.click()
+
+    const picker = page.getByRole('dialog', { name: PICKER })
+    await expect(picker).toBeVisible({ timeout: 10_000 })
+
+    // Scroll over the sidebar, not over the panel — a stray trackpad nudge.
+    const box = await trigger.boundingBox()
+    expect(box).not.toBeNull()
+    await page.mouse.move(box!.x + 5, box!.y + 5)
+    await page.mouse.wheel(0, 800)
+
+    // The regression: the row left the virtual window and took the panel with it.
+    await expect(picker).toBeVisible()
+    await expect(picker.getByRole('button', { name: 'Icons' })).toBeVisible()
+  })
+})

--- a/apps/docs/src/user-guide/notes/custom-icons.md
+++ b/apps/docs/src/user-guide/notes/custom-icons.md
@@ -21,7 +21,8 @@ Dragging an image straight out of a browser window works too — it arrives as a
 handled the same way.
 
 The panel opens beside the icon you clicked, and never off the edge of the window: in a window too
-short to hold it, the tabs and the **Remove** row stay put and the grid below them scrolls.
+short to hold it, the tabs and the **Remove** row stay put and the grid below them scrolls. It also
+stays open if the sidebar scrolls underneath it — it follows the row it belongs to.
 
 Each new icon is named after its file, minus the extension; a linked icon is named after the file
 name in the link, or the site it came from. Hover a row and click the pencil to rename it; the name


### PR DESCRIPTION
## Summary

Closes #1986.

The reporter could not pin the trigger — the sidebar icon picker "closes on its own before anything is chosen", for some notes and not others, and she suspected the row's position in the list. Reproduced in the real app before changing anything, and it is neither a Radix dismissal nor #1984's clipping:

Past 100 tree items the sidebar swaps to `VirtualizedNotesTree`, which mounts only the visible rows plus 10 rows of overscan. The icon picker is a Radix Popover rendered **inside** its row, so any scroll that pushes that row out of the virtual window unmounts the popover with it and the panel disappears mid-pick. The open state lives on the tree, not the row, which is the tell: scroll back and the panel is there again. A stray trackpad nudge over the sidebar is enough, and how much scroll it takes depends on how close the row sits to the edge of the virtual window — "some notes and not others".

The fix:

- Pin the row whose picker is open into the virtual range through the virtualizer's `rangeExtractor` (`withPinnedIndex`), so the popover stays mounted and Radix simply re-anchors it as the row moves. Covers both the note and folder pickers.
- `sticky="always"` on the picker popover. Radix's default shift limiter keeps the panel glued to its row, so on a short window it intermittently settled with its bottom below the window edge instead of being clamped — leftover from #1984, and the reason its E2E spec (`sidebar-icon-picker-viewport`) is flaky on `main` today (2 of 3 local repeats failed on a clean `origin/main`; panel `y=120, height=384` in a 400px window). `TagIconChip` hosts the same panel and gets the same prop.

Assumptions / notes for review:

- The pinned row stays absolutely positioned at its real offset, so if the list is scrolled a long way the panel follows the row off the sidebar viewport; `collisionPadding` + `sticky="always"` keep it on screen. Chosen over hiding it, which is the behaviour being reported as a bug.
- Only the virtualized tree needed pinning; the plain `NotesTree` mounts every row.
- No schema, contract, IPC or sync surface touched. Renderer-only, no migration or compat concern.

## Release note

The note and folder icon picker in the sidebar no longer disappears when the note list scrolls underneath it, and no longer settles with its bottom edge below the window.

## Test plan

- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm --filter @memry/desktop test:renderer` — 731 files, 9008 tests green (full `pnpm test:desktop` segfaults locally on the node project because native modules are built for Electron here; the change is renderer-only)
- New unit test `virtualized-tree-pinned-row.test.ts` for `withPinnedIndex`, and a new case in `icon-picker-button.test.tsx` for `sticky="always"`
- New E2E `tests/e2e/sidebar-icon-picker-scroll.e2e.ts` — 130 notes (past the virtualization threshold), open the picker on a row near the top, wheel the sidebar 800px with the pointer off the panel: the panel is gone on `main`, stays open and usable here
- `pnpm exec playwright test --workers=1 --repeat-each=3 sidebar-icon-picker-viewport sidebar-icon-picker-scroll tag-icon-picker` — 21 passed, including the spec that was flaky before this change
- `pnpm docs:impact --base <base> --strict` + `pnpm docs:build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)